### PR TITLE
Improve location picker search with contains matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-02-01]
+
+### Changed
+- **Location Picker Search**: Directory search now uses "contains" matching instead of "starts with", so typing "proxy" matches "metadata-proxy"
+- **Location Picker Sort Order**: Directories starting with the search term appear first, followed by directories that contain it elsewhere
+- **Location Picker Navigation**: Arrow key navigation now scrolls the selected item into view
+
+---
+
 ## [2026-01-19]
 
 ### Added

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -195,6 +195,14 @@ export function LocationPicker({
     setState(prev => ({ ...prev, selectedIndex: -1 }));
   }, [state.inputValue]);
 
+  // Scroll selected item into view
+  useEffect(() => {
+    if (state.selectedIndex >= 0) {
+      const el = document.querySelector(`[data-index="${state.selectedIndex}"]`);
+      el?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [state.selectedIndex]);
+
   const handleSelect = useCallback(
     async (rawPath: string) => {
       // Expand ~ to home path and remove trailing slash


### PR DESCRIPTION
## Summary
  - Directory search now uses "contains" matching instead of "starts with", so typing "proxy" matches
   "metadata-proxy"
  - Directories starting with the search term appear first, followed by directories that contain it
  elsewhere
  - Arrow key navigation scrolls the selected item into view