### PR TITLE
Fix daemon test race conditions in CI

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -817,7 +817,7 @@ func TestDaemon_StateChange_BroadcastsToWebSocket(t *testing.T) {
 		os.Remove(sockPath)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	waitForSocket(t, sockPath, 5*time.Second)
 
 	// Register session via unix socket
 	c := client.New(sockPath)
@@ -899,7 +899,7 @@ func TestDaemon_StateTransitions_AllStates(t *testing.T) {
 		os.Remove(sockPath)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	waitForSocket(t, sockPath, 5*time.Second)
 
 	c := client.New(sockPath)
 	err := c.Register("test-session", "Test", "/tmp/test")
@@ -979,7 +979,7 @@ func TestDaemon_InjectTestSession_BroadcastsToWebSocket(t *testing.T) {
 		os.Remove(sockPath)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	waitForSocket(t, sockPath, 5*time.Second)
 
 	// Connect to WebSocket first
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Replace fixed 200ms sleep with `waitForSocket` helper that actively polls for socket availability
- Fixes flaky tests in CI where the daemon may take longer to start than locally

## Test plan
- [x] All 256 tests pass locally
- [x] CI passes on this PR