### PR TITLE
fix: add PATH recovery to wrapper for GUI app launches

### DIFF
--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/victorarias/attn/internal/client"
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/daemon"
+	"github.com/victorarias/attn/internal/pathutil"
 	"github.com/victorarias/attn/internal/status"
 	"github.com/victorarias/attn/internal/wrapper"
 )
@@ -351,6 +352,9 @@ func findCodexTranscript(cwd string, startedAt time.Time) string {
 
 // runClaudeDirectly runs claude with hooks (used when inside the app)
 func runClaudeDirectly() {
+	// Ensure PATH includes common tool locations (GUI apps start with minimal PATH)
+	pathutil.EnsureGUIPath()
+
 	// Parse flags
 	fs := flag.NewFlagSet("attn", flag.ContinueOnError)
 	labelFlag := fs.String("s", "", "session label")
@@ -502,6 +506,9 @@ func runClaudeDirectly() {
 
 // runCodexDirectly runs codex (used when inside the app)
 func runCodexDirectly() {
+	// Ensure PATH includes common tool locations (GUI apps start with minimal PATH)
+	pathutil.EnsureGUIPath()
+
 	// Parse flags
 	fs := flag.NewFlagSet("attn", flag.ContinueOnError)
 	labelFlag := fs.String("s", "", "session label")


### PR DESCRIPTION
## Summary

- Add `pathutil.EnsureGUIPath()` to wrapper functions that spawn claude/codex

## Problem

When the Tauri app spawns a session, zsh with `-l -c` only sources login profiles (`~/.zprofile`), not interactive configs (`~/.zshrc`). Most users configure PATH in `~/.zshrc`, so `~/.local/bin` (where claude is typically installed) isn't in PATH.

Fish shell users weren't affected because fish sources `config.fish` for all shells.

## Solution

Call `pathutil.EnsureGUIPath()` at the start of `runClaudeDirectly()` and `runCodexDirectly()` to ensure common paths are available before trying to find executables.

## Test plan

- [x] `make test` passes
- [x] Test on macOS with zsh as login shell and PATH configured in `~/.zshrc`