### PR TITLE
fix: normalize fork worktree naming from worktree cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-02-05]
+
+### Fixed
+- **Fork Worktree Naming**: Creating a fork worktree from inside an existing worktree now resolves to the main repo before generating branch/worktree paths, so custom names like `fun` no longer get appended to an existing generated suffix.
+
+---
+
 ## [2026-02-02]
 
 ### Added

--- a/internal/daemon/branch.go
+++ b/internal/daemon/branch.go
@@ -73,7 +73,7 @@ func (d *Daemon) doCreateBranch(mainRepo, branch string) error {
 
 // doCreateWorktreeFromBranch creates a worktree from an existing branch
 func (d *Daemon) doCreateWorktreeFromBranch(msg *protocol.CreateWorktreeFromBranchMessage) (string, error) {
-	mainRepo := git.ExpandPath(msg.MainRepo)
+	mainRepo := git.ResolveMainRepoPath(msg.MainRepo)
 	branch := msg.Branch
 
 	// For remote branches (origin/xxx), extract local name for path and tracking
@@ -86,7 +86,7 @@ func (d *Daemon) doCreateWorktreeFromBranch(msg *protocol.CreateWorktreeFromBran
 	path := protocol.Deref(msg.Path)
 	if path == "" {
 		// Use local branch name for cleaner worktree path
-		path = git.GenerateWorktreePath(msg.MainRepo, localBranch)
+		path = git.GenerateWorktreePath(mainRepo, localBranch)
 	}
 	path = git.ExpandPath(path)
 

--- a/internal/daemon/worktree.go
+++ b/internal/daemon/worktree.go
@@ -94,17 +94,19 @@ func (d *Daemon) doListWorktrees(mainRepo string) []protocol.Worktree {
 // doCreateWorktree creates a git worktree and registers it in the store.
 // Returns the created worktree path and any error.
 func (d *Daemon) doCreateWorktree(msg *protocol.CreateWorktreeMessage) (string, error) {
+	mainRepo := git.ResolveMainRepoPath(msg.MainRepo)
+
 	path := protocol.Deref(msg.Path)
 	if path == "" {
-		path = git.GenerateWorktreePath(msg.MainRepo, msg.Branch)
+		path = git.GenerateWorktreePath(mainRepo, msg.Branch)
 	}
 
 	startingFrom := protocol.Deref(msg.StartingFrom)
 	var err error
 	if startingFrom != "" {
-		err = git.CreateWorktreeFromPoint(msg.MainRepo, msg.Branch, path, startingFrom)
+		err = git.CreateWorktreeFromPoint(mainRepo, msg.Branch, path, startingFrom)
 	} else {
-		err = git.CreateWorktree(msg.MainRepo, msg.Branch, path)
+		err = git.CreateWorktree(mainRepo, msg.Branch, path)
 	}
 	if err != nil {
 		return "", err
@@ -113,7 +115,7 @@ func (d *Daemon) doCreateWorktree(msg *protocol.CreateWorktreeMessage) (string, 
 	wt := &store.Worktree{
 		Path:      path,
 		Branch:    msg.Branch,
-		MainRepo:  msg.MainRepo,
+		MainRepo:  mainRepo,
 		CreatedAt: time.Now(),
 	}
 	d.store.AddWorktree(wt)

--- a/internal/daemon/worktree_naming_test.go
+++ b/internal/daemon/worktree_naming_test.go
@@ -1,0 +1,106 @@
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestDoCreateWorktree_ResolvesMainRepoFromWorktree(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainDir := filepath.Join(tmpDir, "hurdy-gurdy")
+	if err := os.MkdirAll(mainDir, 0755); err != nil {
+		t.Fatalf("failed to create main repo dir: %v", err)
+	}
+
+	runGitDaemon(t, mainDir, "init")
+	runGitDaemon(t, mainDir, "commit", "--allow-empty", "-m", "init")
+
+	// Simulate a pre-existing worktree with a generated suffix-heavy name.
+	existingWorktree := filepath.Join(tmpDir, "hurdy-gurdy--feat-auto-bump-yt-dlp--fork-hurdy-gurdy")
+	runGitDaemon(t, mainDir, "worktree", "add", "-b", "feat/auto-bump-yt-dlp", existingWorktree)
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	path, err := d.doCreateWorktree(&protocol.CreateWorktreeMessage{
+		MainRepo: existingWorktree,
+		Branch:   "fork/fun",
+	})
+	if err != nil {
+		t.Fatalf("doCreateWorktree failed: %v", err)
+	}
+
+	wantPath := filepath.Join(tmpDir, "hurdy-gurdy--fork-fun")
+	if canonicalPathDaemon(path) != canonicalPathDaemon(wantPath) {
+		t.Fatalf("worktree path = %q, want %q", path, wantPath)
+	}
+
+	created := d.store.GetWorktree(path)
+	if created == nil {
+		t.Fatalf("expected created worktree in store for path %q", path)
+	}
+	if canonicalPathDaemon(created.MainRepo) != canonicalPathDaemon(mainDir) {
+		t.Fatalf("stored main repo = %q, want %q", created.MainRepo, mainDir)
+	}
+}
+
+func TestDoCreateWorktreeFromBranch_ResolvesMainRepoFromWorktree(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainDir := filepath.Join(tmpDir, "hurdy-gurdy")
+	if err := os.MkdirAll(mainDir, 0755); err != nil {
+		t.Fatalf("failed to create main repo dir: %v", err)
+	}
+
+	runGitDaemon(t, mainDir, "init")
+	runGitDaemon(t, mainDir, "commit", "--allow-empty", "-m", "init")
+	runGitDaemon(t, mainDir, "branch", "feature/fun")
+
+	existingWorktree := filepath.Join(tmpDir, "hurdy-gurdy--feat-auto-bump-yt-dlp--fork-hurdy-gurdy")
+	runGitDaemon(t, mainDir, "worktree", "add", "-b", "feat/auto-bump-yt-dlp", existingWorktree)
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	path, err := d.doCreateWorktreeFromBranch(&protocol.CreateWorktreeFromBranchMessage{
+		MainRepo: existingWorktree,
+		Branch:   "feature/fun",
+	})
+	if err != nil {
+		t.Fatalf("doCreateWorktreeFromBranch failed: %v", err)
+	}
+
+	wantPath := filepath.Join(tmpDir, "hurdy-gurdy--feature-fun")
+	if canonicalPathDaemon(path) != canonicalPathDaemon(wantPath) {
+		t.Fatalf("worktree path = %q, want %q", path, wantPath)
+	}
+
+	created := d.store.GetWorktree(path)
+	if created == nil {
+		t.Fatalf("expected created worktree in store for path %q", path)
+	}
+	if canonicalPathDaemon(created.MainRepo) != canonicalPathDaemon(mainDir) {
+		t.Fatalf("stored main repo = %q, want %q", created.MainRepo, mainDir)
+	}
+}
+
+func runGitDaemon(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func canonicalPathDaemon(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(path)
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -185,3 +185,20 @@ func GenerateWorktreePath(mainRepo, branch string) string {
 	safeBranch := strings.ReplaceAll(branch, "/", "-")
 	return filepath.Join(filepath.Dir(mainRepo), repoName+"--"+safeBranch)
 }
+
+// ResolveMainRepoPath returns the canonical main repository path for a repo path.
+// If repoPath points to a worktree, it returns that worktree's main repo path.
+// Otherwise it resolves/normalizes the repo path when possible.
+func ResolveMainRepoPath(repoPath string) string {
+	expanded := ExpandPath(repoPath)
+	if mainRepo := GetMainRepoFromWorktree(expanded); mainRepo != "" {
+		return filepath.Clean(mainRepo)
+	}
+
+	resolved, err := ResolveRepoDir(expanded)
+	if err == nil {
+		return resolved
+	}
+
+	return filepath.Clean(expanded)
+}


### PR DESCRIPTION
## Summary
- resolve the canonical main repo path before generating fork/worktree paths
- prevent custom fork names from being appended to an already generated worktree suffix when forking from a worktree
- add regression tests for daemon worktree creation and git main-repo resolution
- update changelog for 2026-02-05

## Testing
- go test ./internal/git ./internal/daemon