### PR TITLE
Warn users when daemon falls back to in-memory persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Fixed
 - **Daemon Socket Detection (Tauri)**: Frontend daemon health/start checks now use `~/.attn/attn.sock` (and `ATTN_SOCKET_PATH` override), matching daemon defaults.
 - **Stale Daemon Socket Recovery**: App startup now verifies the daemon socket is connectable (not just present), removes stale socket files, and waits for a live socket before reporting daemon startup success.
+- **Persistence Degraded Visibility**: When SQLite open/migrations fail and daemon falls back to in-memory state, the app now receives a persistent warning banner that includes the DB path and points to daemon logs for recovery details.
 - **Terminal Output Races**: Buffered PTY output until terminals are ready to prevent dropped initial prompt/scrollback in main and utility terminals.
 - **Reconnect Attach Hygiene**: Exited/unregistered sessions are removed from frontend reattach tracking to avoid repeated failed `attach_session` attempts.
 - **Exited PTY Cleanup**: Daemon now removes exited PTY sessions from the manager to prevent stale in-memory session accumulation.


### PR DESCRIPTION
## Summary
- add a daemon startup warning (`persistence_degraded`) when SQLite open/migration fails and the daemon falls back to in-memory storage
- include user-facing remediation guidance in the warning: durable state unavailable, data will not survive restarts, and `See daemon log in ... for details`
- add daemon coverage for fallback behavior to ensure warning content and fallback-store usability are preserved
- update changelog with persistence degraded visibility fix

## Testing
- go test ./internal/daemon
- go test ./internal/store
