### PR TITLE
docs: fix supported agents table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ It's a desktop app that wraps your agent CLIs â€” Claude Code, Codex, Copilot â€
 
 ## Supported agents
 
-| Agent | How attn reads state | Full support |
+| Agent | State detection | Review & forking |
 |---|---|---|
-| [Claude Code](https://claude.ai/code) | Hooks + classifier | Review, forking, everything |
-| [Codex](https://developers.openai.com/codex) | PTY output heuristics | Sessions + state |
-| [Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line) | PTY output heuristics | Sessions + state |
+| [Claude Code](https://claude.ai/code) | Hooks + classifier | Yes |
+| [Codex](https://developers.openai.com/codex) | PTY heuristics + transcript classifier | No |
+| [Copilot CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line) | PTY heuristics + transcript classifier | No |
 
 ## Install
 


### PR DESCRIPTION
## Summary
- Fix the supported agents table to reflect that Codex and Copilot now use **PTY heuristics + transcript classifier** for state detection, not just PTY heuristics alone
- Clarify the columns: "State detection" (method) and "Review & forking" (Claude-only features)

## Test plan
- [ ] Verify table renders correctly on GitHub