### PR TITLE
fix: harden CI release workflow for tag retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to release (for retry/fix), e.g. v0.2.0"
+        required: true
+        type: string
 
 jobs:
   tauri:
@@ -13,7 +19,29 @@ jobs:
     runs-on: macos-14
 
     steps:
+      - name: Resolve release tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RELEASE_TAG="${{ inputs.tag }}"
+          else
+            RELEASE_TAG="${{ github.ref_name }}"
+          fi
+
+          if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: $RELEASE_TAG"
+            exit 1
+          fi
+
+          echo "RELEASE_TAG=$RELEASE_TAG" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -26,11 +54,6 @@ jobs:
           node-version: "20"
           cache: pnpm
           cache-dependency-path: app/pnpm-lock.yaml
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install frontend dependencies
         working-directory: app
@@ -53,8 +76,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: app
-          tagName: ${{ github.ref_name }}
-          releaseName: attn ${{ github.ref_name }}
+          tagName: ${{ env.RELEASE_TAG }}
+          releaseName: attn ${{ env.RELEASE_TAG }}
           releaseBody: See CHANGELOG.md for details.
           releaseDraft: false
           prerelease: false
@@ -70,4 +93,4 @@ jobs:
             exit 1
           fi
           cp "$DMG_PATH" /tmp/attn_aarch64.dmg
-          gh release upload "${GITHUB_REF_NAME}" /tmp/attn_aarch64.dmg --clobber
+          gh release upload "${RELEASE_TAG}" /tmp/attn_aarch64.dmg --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Agent Fallback Persistence**: Availability fallback now applies at runtime for session launch/open flows without silently rewriting the saved default agent setting.
 
 ### Fixed
+- **Release CI Reliability**: Release workflow now installs `pnpm` before enabling pnpm cache in `setup-node`, and supports manual `workflow_dispatch` retries for existing tags so failed tagged runs can be rebuilt and published entirely from CI.
 - **Copilot Stop Classification Path**: Add Copilot transcript discovery under `~/.copilot/session-state/*/events.jsonl` (matched by cwd + recent activity) so Copilot sessions classify on stop without hooks.
 - **Copilot Resume Transcript Matching**: When launching Copilot with `--resume <session-id>`, stop-time classification now first checks `~/.copilot/session-state/<session-id>/events.jsonl` before falling back to heuristic cwd/timing discovery.
 - **Copilot Classifier Safety Isolation**: Copilot classification now disables custom instructions and avoids tool auto-approval, and runs from an isolated temp cwd so classifier sessions do not contaminate cwd-based transcript matching.


### PR DESCRIPTION
Fix release workflow so artifacts are always built/published from CI:\n\n- install pnpm before setup-node cache step\n- add workflow_dispatch with tag input for CI-only retry of existing tags\n- resolve tag once and use it consistently for checkout, release creation, and asset upload\n- document in changelog