### PR TITLE
fix: make cask installs path-independent and release-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,14 +83,42 @@ jobs:
           prerelease: false
           args: --target aarch64-apple-darwin
 
+      - name: Re-sign app and replace release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          APP_PATH="$(find app/src-tauri/target -type d -name 'attn.app' | head -n1)"
+          if [ -z "$APP_PATH" ]; then
+            echo "No attn.app bundle found in build output"
+            exit 1
+          fi
+
+          VERSION="${RELEASE_TAG#v}"
+          WORK_DIR="$(mktemp -d)"
+          cp -R "$APP_PATH" "$WORK_DIR/attn.app"
+
+          # Ensure app bundle has a coherent signature before distributing via cask.
+          xattr -cr "$WORK_DIR/attn.app" || true
+          codesign --force --deep --sign - "$WORK_DIR/attn.app"
+          codesign --verify --deep --strict --verbose=2 "$WORK_DIR/attn.app"
+
+          DMG_REBUILT="$WORK_DIR/attn_${VERSION}_aarch64.dmg"
+          hdiutil create -volname "attn" -srcfolder "$WORK_DIR/attn.app" -format UDZO "$DMG_REBUILT"
+
+          (cd "$WORK_DIR" && tar -czf "attn_aarch64.app.tar.gz" attn.app)
+          APP_TAR="$WORK_DIR/attn_aarch64.app.tar.gz"
+
+          gh release upload "${RELEASE_TAG}" "$DMG_REBUILT" --clobber
+          gh release upload "${RELEASE_TAG}" "$APP_TAR" --clobber
+          echo "DMG_REBUILT=$DMG_REBUILT" >> "$GITHUB_ENV"
+
       - name: Upload stable DMG alias for Homebrew cask
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          DMG_PATH="$(find app/src-tauri/target -type f -name 'attn_*_aarch64.dmg' | head -n1)"
-          if [ -z "$DMG_PATH" ]; then
-            echo "No aarch64 DMG found"
+          if [ -z "${DMG_REBUILT:-}" ]; then
+            echo "Rebuilt DMG path not available"
             exit 1
           fi
-          cp "$DMG_PATH" /tmp/attn_aarch64.dmg
+          cp "$DMG_REBUILT" /tmp/attn_aarch64.dmg
           gh release upload "${RELEASE_TAG}" /tmp/attn_aarch64.dmg --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Agent Fallback Persistence**: Availability fallback now applies at runtime for session launch/open flows without silently rewriting the saved default agent setting.
 
 ### Fixed
+- **Cask Runtime Wrapper Resolution**: Daemon-managed session spawn and Claude hooks now use an explicit wrapper path (`ATTN_WRAPPER_PATH`) instead of relying on `attn` being in shell `PATH`, so Homebrew cask installs work without separately installing the formula.
+- **Release Artifact macOS Signature Integrity**: Release workflow now re-signs and verifies the built `attn.app`, rebuilds the DMG from the signed app, and replaces uploaded release assets from CI before publishing cask artifacts.
 - **Release CI Reliability**: Release workflow now installs `pnpm` before enabling pnpm cache in `setup-node`, and supports manual `workflow_dispatch` retries for existing tags so failed tagged runs can be rebuilt and published entirely from CI.
 - **Copilot Stop Classification Path**: Add Copilot transcript discovery under `~/.copilot/session-state/*/events.jsonl` (matched by cwd + recent activity) so Copilot sessions classify on stop without hooks.
 - **Copilot Resume Transcript Matching**: When launching Copilot with `--resume <session-id>`, stop-time classification now first checks `~/.copilot/session-state/<session-id>/events.jsonl` before falling back to heuristic cwd/timing discovery.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ brew tap victorarias/attn https://github.com/victorarias/attn
 brew install --cask victorarias/attn/attn
 ```
 
+This installs `attn.app` (with bundled daemon/runtime binary). It does not add `attn` to your shell `PATH`.
+
 ### Homebrew formula (CLI + daemon only)
 
 ```bash
 brew install victorarias/attn/attn
 ```
+
+Install this if you want the `attn` command in terminal.
 
 ### Direct DMG
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -88,6 +88,7 @@ fn start_daemon(_app: tauri::AppHandle) -> Result<(), String> {
     }
 
     Command::new(&bin_path)
+        .env("ATTN_WRAPPER_PATH", &bin_path)
         .arg("daemon")
         .spawn()
         .map_err(|e| format!("Failed to start daemon: {}", e))?;

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -119,6 +119,16 @@ func resolveExecutable(envKey, fallback string) string {
 	return fallback
 }
 
+func resolveWrapperPath() string {
+	if value := strings.TrimSpace(os.Getenv("ATTN_WRAPPER_PATH")); value != "" {
+		return value
+	}
+	if exePath, err := os.Executable(); err == nil && strings.TrimSpace(exePath) != "" {
+		return exePath
+	}
+	return "attn"
+}
+
 // openAppWithDeepLink opens the Tauri app with a deep link to spawn a session
 func openAppWithDeepLink() {
 	cwd, err := os.Getwd()
@@ -619,7 +629,7 @@ func runClaudeDirectly() {
 
 	// Write hooks config
 	socketPath := config.SocketPath()
-	hooksPath, err := wrapper.WriteHooksConfig(os.TempDir(), sessionID, socketPath)
+	hooksPath, err := wrapper.WriteHooksConfig(os.TempDir(), sessionID, socketPath, resolveWrapperPath())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error writing hooks config: %v\n", err)
 		os.Exit(1)

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -10,7 +10,7 @@ func TestGenerateHooks(t *testing.T) {
 	sessionID := "abc123"
 	socketPath := "/home/user/.claude-manager.sock"
 
-	settings := Generate(sessionID, socketPath)
+	settings := Generate(sessionID, socketPath, "/tmp/attn")
 
 	// Verify it's valid JSON
 	var parsed map[string]interface{}
@@ -52,7 +52,7 @@ func TestGenerateHooks_ContainsSessionID(t *testing.T) {
 	sessionID := "unique-session-id-12345"
 	socketPath := "/tmp/test.sock"
 
-	hooks := Generate(sessionID, socketPath)
+	hooks := Generate(sessionID, socketPath, "/tmp/attn")
 
 	if !strings.Contains(hooks, sessionID) {
 		t.Error("generated hooks should contain session ID")
@@ -63,7 +63,7 @@ func TestGenerateHooks_ContainsSocketPath(t *testing.T) {
 	sessionID := "test"
 	socketPath := "/custom/path/to/socket.sock"
 
-	hooks := Generate(sessionID, socketPath)
+	hooks := Generate(sessionID, socketPath, "/tmp/attn")
 
 	if !strings.Contains(hooks, socketPath) {
 		t.Error("generated hooks should contain socket path")
@@ -71,7 +71,7 @@ func TestGenerateHooks_ContainsSocketPath(t *testing.T) {
 }
 
 func TestGenerateHooks_HasStopHook(t *testing.T) {
-	hooks := Generate("test", "/tmp/test.sock")
+	hooks := Generate("test", "/tmp/test.sock", "/tmp/attn")
 
 	if !strings.Contains(hooks, "Stop") {
 		t.Error("hooks should include Stop event for waiting state")
@@ -79,10 +79,26 @@ func TestGenerateHooks_HasStopHook(t *testing.T) {
 }
 
 func TestGenerateHooks_HasUserPromptSubmitHook(t *testing.T) {
-	hooks := Generate("test", "/tmp/test.sock")
+	hooks := Generate("test", "/tmp/test.sock", "/tmp/attn")
 
 	if !strings.Contains(hooks, "UserPromptSubmit") {
 		t.Error("hooks should include UserPromptSubmit event for working state")
+	}
+}
+
+func TestGenerateHooks_UsesWrapperPath(t *testing.T) {
+	hooks := Generate("test", "/tmp/test.sock", "/Applications/attn.app/Contents/MacOS/attn")
+
+	if !strings.Contains(hooks, "'/Applications/attn.app/Contents/MacOS/attn' _hook-stop") {
+		t.Error("hooks should include wrapper path in stop hook command")
+	}
+}
+
+func TestGenerateHooks_DefaultsWrapperToAttn(t *testing.T) {
+	hooks := Generate("test", "/tmp/test.sock", "")
+
+	if !strings.Contains(hooks, "'attn' _hook-stop") {
+		t.Error("hooks should default wrapper path to 'attn'")
 	}
 }
 

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -24,7 +24,7 @@ func DefaultLabel() string {
 
 // WriteHooksConfig writes a temporary hooks configuration file
 // Creates a subdirectory to isolate from other temp files (avoids fs.watch issues)
-func WriteHooksConfig(tmpDir, sessionID, socketPath string) (string, error) {
+func WriteHooksConfig(tmpDir, sessionID, socketPath, wrapperPath string) (string, error) {
 	// Create a subdirectory for this session's hooks
 	// This prevents Claude from trying to watch socket files in the parent temp dir
 	hooksDir := filepath.Join(tmpDir, "attn-hooks-"+sessionID)
@@ -34,7 +34,7 @@ func WriteHooksConfig(tmpDir, sessionID, socketPath string) (string, error) {
 
 	configPath := filepath.Join(hooksDir, "settings.json")
 
-	content := hooks.Generate(sessionID, socketPath)
+	content := hooks.Generate(sessionID, socketPath, wrapperPath)
 
 	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
 		return "", err

--- a/internal/wrapper/wrapper_test.go
+++ b/internal/wrapper/wrapper_test.go
@@ -42,7 +42,7 @@ func TestWriteHooksConfig(t *testing.T) {
 	sessionID := "test-session"
 	socketPath := "/tmp/test.sock"
 
-	configPath, err := WriteHooksConfig(tmpDir, sessionID, socketPath)
+	configPath, err := WriteHooksConfig(tmpDir, sessionID, socketPath, "/tmp/attn")
 	if err != nil {
 		t.Fatalf("WriteHooksConfig error: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestWriteHooksConfig(t *testing.T) {
 func TestCleanupHooksConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	configPath, _ := WriteHooksConfig(tmpDir, "test", "/tmp/test.sock")
+	configPath, _ := WriteHooksConfig(tmpDir, "test", "/tmp/test.sock", "/tmp/attn")
 
 	// Verify file exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {


### PR DESCRIPTION
## Summary\n- stop relying on  being in PATH for daemon-managed spawns and Claude hooks\n- propagate explicit wrapper path () from app -> daemon -> spawned sessions\n- update release workflow to re-sign/verify app bundle and replace DMG/app release assets in CI\n- clarify README install behavior for cask vs formula\n\n## Validation\n- go test ./...\n- cargo check -q (app/src-tauri)\n- reproduced prior DMG signature failure and validated CI fix path