### PR TITLE
homebrew: update formula for v0.2.3

### DIFF
--- a/Formula/attn.rb
+++ b/Formula/attn.rb
@@ -1,9 +1,9 @@
 class Attn < Formula
   desc "Desktop orchestrator and CLI wrapper for Claude Code and Codex sessions"
   homepage "https://github.com/victorarias/attn"
-  url "https://github.com/victorarias/attn/archive/refs/tags/v0.2.2.tar.gz"
-  sha256 "7562e90417e5fb98352de55b6aab980bd5884f78d2ac7a0e09a5e73451264341"
-  version "0.2.2"
+  url "https://github.com/victorarias/attn/archive/refs/tags/v0.2.3.tar.gz"
+  sha256 "bbd3fcdffa769d90359de8ecaefcd442858fb90ae4e967cc13e7914fd09b3a8f"
+  version "0.2.3"
   license "GPL-3.0-only"
 
   depends_on "go" => :build


### PR DESCRIPTION
## Summary
- Update Homebrew formula URL, SHA256, and version for v0.2.3