### PR TITLE
Fix home dashboard hiding pending-approval sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-02-09]
+
+### Fixed
+- **Dashboard Session Visibility**: Home dashboard now renders `pending_approval` sessions in a dedicated "Pending approval" group, so active sessions waiting on tool/permission approval are no longer hidden.
+
 ## [2026-02-08]
 
 ### Added

--- a/app/src/components/Dashboard.test.tsx
+++ b/app/src/components/Dashboard.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Dashboard } from './Dashboard';
+
+vi.mock('../contexts/DaemonContext', () => ({
+  useDaemonContext: () => ({
+    sendMuteRepo: vi.fn(),
+    sendMuteAuthor: vi.fn(),
+    sendPRVisited: vi.fn(),
+  }),
+}));
+
+vi.mock('../store/daemonSessions', () => ({
+  useDaemonStore: () => ({
+    repoStates: [],
+    authorStates: [],
+  }),
+}));
+
+vi.mock('../hooks/usePRsNeedingAttention', () => ({
+  usePRsNeedingAttention: () => ({
+    activePRs: [],
+    needsAttention: [],
+    reviewRequested: [],
+    yourPRs: [],
+  }),
+}));
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: vi.fn(),
+}));
+
+describe('Dashboard sessions', () => {
+  it('shows pending approval sessions on home screen', () => {
+    render(
+      <Dashboard
+        sessions={[
+          { id: 's1', label: 'conductor-bot', state: 'working', cwd: '/repo/a' },
+          { id: 's2', label: 'review-bot', state: 'pending_approval', cwd: '/repo/b' },
+          { id: 's3', label: 'fix-bot', state: 'pending_approval', cwd: '/repo/c' },
+        ]}
+        prs={[]}
+        isLoading={false}
+        settings={{}}
+        onSelectSession={vi.fn()}
+        onNewSession={vi.fn()}
+        onSetSetting={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('session-group-working')).toBeInTheDocument();
+    expect(screen.getByTestId('session-group-pending')).toBeInTheDocument();
+    expect(screen.getByTestId('session-s1')).toBeInTheDocument();
+    expect(screen.getByTestId('session-s2')).toBeInTheDocument();
+    expect(screen.getByTestId('session-s3')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -47,13 +47,23 @@ export function Dashboard({
   onSetSetting,
 }: DashboardProps) {
   const waitingSessions = sessions.filter((s) => s.state === 'waiting_input');
+  const pendingApprovalSessions = sessions.filter((s) => s.state === 'pending_approval');
   const workingSessions = sessions.filter((s) => s.state === 'working');
   const idleSessions = sessions.filter((s) => s.state === 'idle');
 
   // Debug: log session states
   if (sessions.length > 0) {
     console.log('[Dashboard] sessions:', sessions.map(s => ({ id: s.id, state: s.state })));
-    console.log('[Dashboard] waiting:', waitingSessions.length, 'working:', workingSessions.length, 'idle:', idleSessions.length);
+    console.log(
+      '[Dashboard] waiting:',
+      waitingSessions.length,
+      'pending:',
+      pendingApprovalSessions.length,
+      'working:',
+      workingSessions.length,
+      'idle:',
+      idleSessions.length
+    );
   }
 
   // Group PRs by repo
@@ -226,6 +236,23 @@ export function Dashboard({
                         onClick={() => onSelectSession(s.id)}
                       >
                         <StateIndicator state="waiting_input" size="sm" />
+                        <span className="session-name">{s.label}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {pendingApprovalSessions.length > 0 && (
+                  <div className="session-group" data-testid="session-group-pending">
+                    <div className="group-label">Pending approval</div>
+                    {pendingApprovalSessions.map((s) => (
+                      <div
+                        key={s.id}
+                        className="session-row clickable"
+                        data-testid={`session-${s.id}`}
+                        data-state={s.state}
+                        onClick={() => onSelectSession(s.id)}
+                      >
+                        <StateIndicator state="pending_approval" size="sm" />
                         <span className="session-name">{s.label}</span>
                       </div>
                     ))}


### PR DESCRIPTION
## Summary
- include `pending_approval` sessions in the dashboard session grouping
- render a dedicated **Pending approval** section on the Home screen
- add a regression test that covers mixed working + pending sessions
- record the fix in the changelog

## Verification
- `pnpm test src/components/Dashboard.test.tsx src/components/Sidebar.test.tsx src/components/StateIndicator.test.tsx`
- commit hook suite ran successfully (gofmt, go vet, Go tests)

## Root Cause
Dashboard rendered only `waiting_input`, `working`, and `idle` groups. Sessions in `pending_approval` were filtered out of all displayed groups and appeared missing on Home.
