### PR TITLE
Fix Cmd/Ctrl-click terminal links opening in app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-02-10]
+
+### Fixed
+- **Terminal Cmd+Click Link Open**: Terminal hyperlinks now open directly via Tauri opener for both plain URLs and OSC 8 links, removing the xterm warning prompt and fixing links that previously failed to open after confirmation.
+
 ## [2026-02-09]
 
 ### Fixed


### PR DESCRIPTION
## Summary
- route terminal link opens through Tauri opener for both web-links addon URLs and OSC 8 hyperlinks
- remove xterm default OSC link confirm prompt path in-app by setting a custom xterm link handler
- add changelog entry for the terminal link regression fix

## Root cause
- plain URLs were handled by WebLinksAddon + `openUrl`, but OSC 8 hyperlinks were still using xterm's default handler (`confirm` + `window.open`), which is unreliable in Tauri and could show a warning then no-op

## Testing
- `cd app && pnpm exec tsc --noEmit`
- repository pre-commit checks (gofmt, go vet, go test ./...) ran during commit
