### PR TITLE
Add dismiss control for release update banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-02-11]
+
+### Fixed
+- **Release Banner Dismissal**: Added an explicit dismiss control (`×`) for the GitHub release banner and persist dismissal per release version, so a dismissed banner stays hidden until a newer release is published.
+
 ## [2026-02-10]
 
 ### Fixed

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -250,3 +250,18 @@ html, body, #root {
   cursor: wait;
   opacity: 0.8;
 }
+
+.update-dismiss {
+  background: transparent;
+  border: none;
+  color: white;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+  opacity: 0.8;
+}
+
+.update-dismiss:hover {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- add an `×` dismiss control to the GitHub release update banner
- persist dismissed release version in localStorage so dismissed banners stay hidden for that version
- keep showing banner for newer releases
- document the change in changelog

## Testing
- pnpm -C app test
- pnpm -C app build
- pre-commit go test suite