### PR TITLE
Restore worktree cleanup prompt when closing worktree sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Release Banner Dismissal**: Added an explicit dismiss control (`×`) for the GitHub release banner and persist dismissal per release version, so a dismissed banner stays hidden until a newer release is published.
+- **Worktree Close Cleanup Prompt**: Restored the delete/keep prompt when closing worktree sessions even if an old persisted "always keep" preference exists; "always keep" now applies only for the current app run.
 
 ## [2026-02-10]
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -564,10 +564,7 @@ function AppContent({
 
   // Worktree cleanup prompt state
   const [closedWorktree, setClosedWorktree] = useState<{ path: string; branch?: string } | null>(null);
-  const [alwaysKeepWorktrees, setAlwaysKeepWorktrees] = useState(() => {
-    const stored = localStorage.getItem('alwaysKeepWorktrees');
-    return stored === 'true';
-  });
+  const [alwaysKeepWorktrees, setAlwaysKeepWorktrees] = useState(false);
 
   // Review panel state
   const [reviewPanelOpen, setReviewPanelOpen] = useState(false);
@@ -1094,7 +1091,6 @@ function AppContent({
 
   const handleWorktreeAlwaysKeep = useCallback(() => {
     setAlwaysKeepWorktrees(true);
-    localStorage.setItem('alwaysKeepWorktrees', 'true');
     setClosedWorktree(null);
   }, []);
 

--- a/app/src/App.worktreeCleanup.test.tsx
+++ b/app/src/App.worktreeCleanup.test.tsx
@@ -1,0 +1,227 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from './App';
+
+const mockUseSessionStore = vi.fn();
+const mockUseDaemonStore = vi.fn();
+const mockUseDaemonSocket = vi.fn();
+const mockSendUnregisterSession = vi.fn();
+
+vi.mock('@tauri-apps/plugin-deep-link', () => ({
+  onOpenUrl: vi.fn(async () => () => {}),
+  getCurrent: vi.fn(async () => []),
+}));
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: vi.fn(async () => {}),
+}));
+
+vi.mock('./components/Terminal', async () => {
+  const React = await import('react');
+  return {
+    Terminal: React.forwardRef(function MockTerminal() {
+      return null;
+    }),
+  };
+});
+
+vi.mock('./components/Sidebar', () => ({
+  Sidebar: ({ sessions, onCloseSession }: { sessions: Array<{ id: string }>; onCloseSession: (id: string) => void }) => (
+    <button data-testid="close-session" onClick={() => onCloseSession(sessions[0].id)}>
+      Close Session
+    </button>
+  ),
+}));
+
+vi.mock('./components/Dashboard', () => ({ Dashboard: () => null }));
+vi.mock('./components/AttentionDrawer', () => ({ AttentionDrawer: () => null }));
+vi.mock('./components/LocationPicker', () => ({ LocationPicker: () => null }));
+vi.mock('./components/BranchPicker', () => ({ BranchPicker: () => null }));
+vi.mock('./components/UndoToast', () => ({ UndoToast: () => null }));
+vi.mock('./components/ChangesPanel', () => ({ ChangesPanel: () => null }));
+vi.mock('./components/ReviewPanel', () => ({ ReviewPanel: () => null }));
+vi.mock('./components/UtilityTerminalPanel', () => ({ UtilityTerminalPanel: () => null }));
+vi.mock('./components/ThumbsModal', () => ({ ThumbsModal: () => null }));
+vi.mock('./components/ForkDialog', () => ({ ForkDialog: () => null }));
+
+vi.mock('./components/CopyToast', () => ({
+  CopyToast: () => null,
+  useCopyToast: () => ({
+    message: null,
+    showToast: vi.fn(),
+    clearToast: vi.fn(),
+  }),
+}));
+
+vi.mock('./components/ErrorToast', () => ({
+  ErrorToast: () => null,
+  useErrorToast: () => ({
+    message: null,
+    showError: vi.fn(),
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock('./hooks/useKeyboardShortcuts', () => ({
+  useKeyboardShortcuts: vi.fn(),
+}));
+
+vi.mock('./hooks/useUIScale', () => ({
+  useUIScale: () => ({
+    scale: 1,
+    increaseScale: vi.fn(),
+    decreaseScale: vi.fn(),
+    resetScale: vi.fn(),
+  }),
+}));
+
+vi.mock('./hooks/useOpenPR', () => ({
+  useOpenPR: () =>
+    vi.fn(async () => ({
+      success: true,
+      worktreePath: '/tmp/wt',
+      sessionId: 's1',
+    })),
+}));
+
+vi.mock('./hooks/usePRsNeedingAttention', () => ({
+  usePRsNeedingAttention: () => ({ needsAttention: [] }),
+}));
+
+vi.mock('./store/sessions', () => ({
+  useSessionStore: () => mockUseSessionStore(),
+}));
+
+vi.mock('./store/daemonSessions', () => ({
+  useDaemonStore: () => mockUseDaemonStore(),
+}));
+
+vi.mock('./hooks/useDaemonSocket', () => ({
+  useDaemonSocket: (args: unknown) => mockUseDaemonSocket(args),
+}));
+
+describe('worktree cleanup prompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+
+    mockUseSessionStore.mockReturnValue({
+      sessions: [
+        {
+          id: 's1',
+          label: 'worktree-session',
+          state: 'working',
+          terminal: null,
+          cwd: '/tmp/repo/.worktrees/feature-a',
+          agent: 'claude',
+          transcriptMatched: true,
+          branch: 'feature-a',
+          isWorktree: true,
+          terminalPanel: {
+            isOpen: false,
+            height: 200,
+            activeTabId: null,
+            terminals: [],
+            nextTerminalNumber: 1,
+          },
+        },
+      ],
+      activeSessionId: 's1',
+      createSession: vi.fn(async () => 's1'),
+      closeSession: vi.fn(),
+      setActiveSession: vi.fn(),
+      connectTerminal: vi.fn(),
+      resizeSession: vi.fn(),
+      openTerminalPanel: vi.fn(),
+      collapseTerminalPanel: vi.fn(),
+      setTerminalPanelHeight: vi.fn(),
+      addUtilityTerminal: vi.fn(),
+      removeUtilityTerminal: vi.fn(),
+      setActiveUtilityTerminal: vi.fn(),
+      renameUtilityTerminal: vi.fn(),
+      setForkParams: vi.fn(),
+      setResumePicker: vi.fn(),
+      setLauncherConfig: vi.fn(),
+      syncFromDaemonSessions: vi.fn(),
+    });
+
+    mockUseDaemonStore.mockReturnValue({
+      daemonSessions: [
+        {
+          id: 's1',
+          label: 'worktree-session',
+          directory: '/tmp/repo/.worktrees/feature-a',
+          state: 'working',
+          branch: 'feature-a',
+          is_worktree: true,
+        },
+      ],
+      setDaemonSessions: vi.fn(),
+      prs: [],
+      setPRs: vi.fn(),
+      setRepoStates: vi.fn(),
+      setAuthorStates: vi.fn(),
+    });
+
+    const fn = vi.fn();
+    mockUseDaemonSocket.mockReturnValue({
+      sendPRAction: fn,
+      sendMutePR: fn,
+      sendMuteRepo: fn,
+      sendMuteAuthor: fn,
+      sendPRVisited: fn,
+      sendRefreshPRs: vi.fn(async () => ({ success: true })),
+      sendUnregisterSession: mockSendUnregisterSession,
+      sendSetSetting: fn,
+      sendCreateWorktree: vi.fn(async () => ({ success: true, path: '/tmp/new' })),
+      sendDeleteWorktree: vi.fn(async () => ({ success: true })),
+      sendDeleteBranch: fn,
+      sendGetRecentLocations: vi.fn(async () => ({ success: true, locations: [] })),
+      sendListBranches: vi.fn(async () => ({ success: true, branches: [] })),
+      sendSwitchBranch: vi.fn(async () => ({ success: true })),
+      sendCreateWorktreeFromBranch: vi.fn(async () => ({ success: true, path: '/tmp/new' })),
+      sendCheckDirty: vi.fn(async () => ({ success: true, dirty: false })),
+      sendStash: vi.fn(async () => ({ success: true })),
+      sendStashPop: vi.fn(async () => ({ success: true })),
+      sendCheckAttnStash: vi.fn(async () => ({ success: true, has_stash: false })),
+      sendCommitWIP: vi.fn(async () => ({ success: true })),
+      sendGetDefaultBranch: vi.fn(async () => ({ success: true, branch: 'main' })),
+      sendFetchRemotes: vi.fn(async () => ({ success: true })),
+      sendFetchPRDetails: vi.fn(async () => ({ success: true })),
+      sendListRemoteBranches: vi.fn(async () => ({ success: true, branches: [] })),
+      sendEnsureRepo: vi.fn(async () => ({ success: true, path: '/tmp/repo' })),
+      sendSubscribeGitStatus: fn,
+      sendUnsubscribeGitStatus: fn,
+      sendGetFileDiff: vi.fn(async () => ({ success: true, original: '', modified: '' })),
+      sendGetBranchDiffFiles: vi.fn(async () => ({ success: true, base_ref: 'main', files: [] })),
+      getRepoInfo: vi.fn(async () => ({ success: true, is_git_repo: true, branch: 'main' })),
+      getReviewState: vi.fn(async () => ({ success: true })),
+      markFileViewed: vi.fn(async () => ({ success: true })),
+      sendAddComment: vi.fn(async () => ({ success: true })),
+      sendUpdateComment: vi.fn(async () => ({ success: true })),
+      sendResolveComment: vi.fn(async () => ({ success: true })),
+      sendWontFixComment: vi.fn(async () => ({ success: true })),
+      sendDeleteComment: vi.fn(async () => ({ success: true })),
+      sendGetComments: vi.fn(async () => ({ success: true, comments: [] })),
+      sendStartReview: vi.fn(async () => ({ success: true })),
+      sendCancelReview: vi.fn(async () => ({ success: true })),
+      connectionError: null,
+      hasReceivedInitialState: true,
+      rateLimit: null,
+      warnings: [],
+      clearWarnings: fn,
+    });
+  });
+
+  it('shows worktree cleanup prompt when closing a worktree session', async () => {
+    localStorage.setItem('alwaysKeepWorktrees', 'true');
+    render(<App />);
+
+    await userEvent.click(screen.getByTestId('close-session'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+});

--- a/app/src/components/WorktreeCleanupPrompt.tsx
+++ b/app/src/components/WorktreeCleanupPrompt.tsx
@@ -106,7 +106,7 @@ export function WorktreeCleanupPrompt({
             Delete
           </button>
           <button ref={alwaysRef} className="cleanup-btn always" onClick={handleAlwaysKeep}>
-            Always keep
+            Always keep (this app run)
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add an App-level regression test that reproduces missing worktree cleanup prompt when closing worktree sessions
- remove persisted `alwaysKeepWorktrees` localStorage suppression so stale preference no longer hides the prompt forever
- keep "always keep" behavior scoped to current app run and clarify prompt label

## Root cause
- the close-session prompt was gated by a persisted `alwaysKeepWorktrees` flag loaded from localStorage
- once set to `true`, the prompt never appeared again across restarts, with no obvious reset path

## Testing
- pnpm -C app test -- App.worktreeCleanup.test.tsx
- pnpm -C app test
- pnpm -C app build
