### PR TITLE
homebrew: update formula for v0.2.7

### DIFF
--- a/Formula/attn.rb
+++ b/Formula/attn.rb
@@ -1,9 +1,9 @@
 class Attn < Formula
   desc "Desktop orchestrator and CLI wrapper for Claude Code and Codex sessions"
   homepage "https://github.com/victorarias/attn"
-  url "https://github.com/victorarias/attn/archive/refs/tags/v0.2.6.tar.gz"
-  sha256 "25df2a9fc55b936d844d726f4a88c244a3ca9a9a4b65adbe495b60649170ff2e"
-  version "0.2.6"
+  url "https://github.com/victorarias/attn/archive/refs/tags/v0.2.7.tar.gz"
+  sha256 "fee1e655534bd34fa2f8ba9d1932d34dff46f84014d4455436400151c0e3ad69"
+  version "0.2.7"
   license "GPL-3.0-only"
 
   depends_on "go" => :build


### PR DESCRIPTION
## Summary
- update Formula/attn.rb to v0.2.7 source tarball
- refresh SHA256 to match tag archive