### PR TITLE
Fix: worker restart survival + long transcript parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-02-15]
+
+### Fixed
+- **Claude Transcript Parsing**: Removed `bufio.Scanner` token-size limitations when reading JSONL transcripts, preventing stop-time classification from erroring and sessions from flashing/sticking `unknown` due to very long lines.
+- **Worker PTY Restart Survival**: Worker backend recovery now accepts legacy socket-path filenames and restores prior `socket_path_mismatch` quarantine entries when they match supported formats, improving daemon restart resilience.
+- **Worker PTY Recovery Safety**: Socket-path mismatch quarantine no longer unlinks the registry-reported worker socket path, preventing accidental orphaning of live worker sessions.
+- **Worker Lifecycle Monitor CPU Spike**: Reduced CPU usage on monitor timeout paths by fast-pathing timeout checks and handling read-deadline errors.
+- **Source App Daemon Selection**: Source-built apps now prefer `~/.local/bin/attn daemon` (when it is at least as new as the bundled daemon) so `make install` daemon changes take effect without rebuilding the app.
+
 ## [2026-02-11]
 
 ### Changed

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -53,17 +53,19 @@ fn is_daemon_running() -> bool {
 /// Start the daemon process
 /// Uses bundled app daemon by default, with optional local override for development.
 #[tauri::command]
-fn start_daemon(_app: tauri::AppHandle) -> Result<(), String> {
+fn start_daemon(_app: tauri::AppHandle, prefer_local: Option<bool>) -> Result<(), String> {
     use std::thread;
     use std::time::Duration;
 
     let home = dirs::home_dir().ok_or("Cannot find home directory")?;
-    let prefer_local = matches!(
+    let prefer_local_env = matches!(
         env::var("ATTN_PREFER_LOCAL_DAEMON")
             .ok()
             .map(|value| value.trim().to_ascii_lowercase()),
         Some(value) if value == "1" || value == "true" || value == "yes"
     );
+    let prefer_local_hint = prefer_local.unwrap_or(false);
+    let prefer_local = prefer_local_env || prefer_local_hint;
 
     // 1. Local dev daemon (~/.local/bin/attn)
     let local_path = home.join(".local/bin/attn");

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -132,7 +132,7 @@ function App() {
         const isRunning = await invoke<boolean>('is_daemon_running');
         if (!isRunning) {
           console.log('[App] Daemon not running, starting...');
-          await invoke('start_daemon');
+          await invoke('start_daemon', { prefer_local: installChannel === 'source' });
           console.log('[App] Daemon started');
         }
       } catch (err) {

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -513,7 +513,7 @@ export function useDaemonSocket({
       const isRunning = await invoke<boolean>('is_daemon_running');
       if (!isRunning) {
         console.log('[Daemon] Not running during reconnect, starting daemon...');
-        await invoke('start_daemon');
+        await invoke('start_daemon', { prefer_local: import.meta.env.VITE_INSTALL_CHANNEL === 'source' });
       }
     } catch (err) {
       console.error('[Daemon] Failed to ensure daemon is running:', err);


### PR DESCRIPTION
### Problem\n- Sessions could flip to **unknown** due to Claude JSONL transcript lines exceeding bufio.Scanner token limits ("token too long").\n- Daemon restarts could strand live worker PTYs due to socket-path validation/quarantine behavior (including unlinking the socket path).\n- Source-built app installs were still starting the bundled daemon, so go build -o attn ./cmd/attn
cat attn > /Users/victor.arias/.local/bin/attn
chmod +x /Users/victor.arias/.local/bin/attn
pkill -f "attn daemon" 2>/dev/null || true
Installed attn to /Users/victor.arias/.local/bin (daemon restarted: 62165) daemon fixes didn’t take effect without rebuilding the app.\n\n### Changes\n- Read JSONL transcripts without Scanner limits (prevents token-too-long parse errors and resulting unknown state).\n- Worker backend recovery accepts legacy socket filenames, restores prior  quarantine entries when valid, and avoids unlinking the registry-reported socket path on mismatch.\n- Source builds (VITE_INSTALL_CHANNEL=source) start  when present (release installs unchanged).\n\n### Tests\n- /Users/victor.arias/go/bin/gotestsum --format testdox -- ./...
github.com/victorarias/attn/internal/logging:
 ✓ Logger debug enabled (0.00s)
 ✓ Logger errorf (0.00s)
 ✓ Logger infof (0.00s)
 ✓ Logger respects debug level (0.00s)
 ✓ Logger writes to file (0.00s)

github.com/victorarias/attn/internal/hooks:
 ✓ Generate hooks (0.00s)
 ✓ GenerateHooks contains session ID (0.00s)
 ✓ GenerateHooks contains socket path (0.00s)
 ✓ GenerateHooks defaults wrapper to attn (0.00s)
 ✓ GenerateHooks has stop hook (0.00s)
 ✓ GenerateHooks has user prompt submit hook (0.00s)
 ✓ GenerateHooks uses wrapper path (0.00s)

github.com/victorarias/attn/internal/config:
 ✓ DBPath config file overrides default (0.00s)
 ✓ DBPath defaults to attn dir (0.00s)
 ✓ DBPath env var overrides config file (0.00s)
 ✓ DBPath env var overrides default (0.00s)
 ✓ SocketPath config file overrides default (0.00s)
 ✓ SocketPath defaults to attn dir (0.00s)
 ✓ SocketPath env var overrides default (0.00s)

github.com/victorarias/attn/internal/classifier:
 ✓ Build prompt (0.00s)
 ✓ BuildPrompt contains required elements (0.00s)
 ✓ BuildPrompt empty input (0.00s)
 ✓ Classify empty text returns idle immediately (0.00s)
 ✓ ClassifyClaudeMessages prefers structured output over assistant text (0.00s)
 ✓ ClassifyClaudeMessages preserves assistant verdict when later tool call is empty (0.00s)
 ✓ ParseResponse JSON structured (0.00s)
 ✓ ParseResponse JSON structured bulleted rubric line then verdict (0.00s)
 ✓ ParseResponse JSON structured fenced json verdict done (0.00s)
 ✓ ParseResponse JSON structured fenced json verdict waiting (0.00s)
 ✓ ParseResponse JSON structured invalid json no verdict (0.00s)
 ✓ ParseResponse JSON structured json needs input true (0.00s)
 ✓ ParseResponse JSON structured json state done (0.00s)
 ✓ ParseResponse JSON structured json status idle (0.00s)
 ✓ ParseResponse JSON structured json verdict waiting (0.00s)
 ✓ ParseResponse done (0.00s)
 ✓ ParseResponse empty and whitespace (0.00s)
 ✓ ParseResponse mixed case (0.00s)
 ✓ ParseResponse no standalone token (0.00s)
 ✓ ParseResponse surrounding text (0.00s)
 ✓ ParseResponse surrounding text DONE line prefix (0.00s)
 ✓ ParseResponse surrounding text WAITING line prefix (0.00s)
 ✓ ParseResponse surrounding text multi-line waiting with rationale (0.00s)
 ✓ ParseResponse surrounding text multi-line with final verdict (0.00s)
 ✓ ParseResponse surrounding text sentence without explicit verdict prefix (0.00s)
 ✓ ParseResponse surrounding text verdict label with done (0.00s)
 ✓ ParseResponse surrounding text verdict label with waiting (0.00s)
 ✓ ParseResponse waiting (0.00s)
 ✓ ParseVerdictFromResponse explicit verdict required (0.00s)
 ✓ ParseVerdictFromResponse explicit verdict required explicit done verdict (0.00s)
 ✓ ParseVerdictFromResponse explicit verdict required explicit waiting verdict (0.00s)
 ✓ ParseVerdictFromResponse explicit verdict required json verdict (0.00s)
 ✓ ParseVerdictFromResponse explicit verdict required plain sentence no explicit verdict (0.00s)

github.com/victorarias/attn/internal/attention:
 ✓ Aggregator aggregate (0.00s)
 ✓ Aggregator all muted (0.00s)
 ✓ Aggregator empty input (0.00s)
 ✓ PR adapter (0.00s)
 ✓ Result filter by kind (0.00s)
 ✓ Session adapter (0.00s)

github.com/victorarias/attn/internal/github/mockserver:
 ✓ MockServer search and approve (0.00s)

github.com/victorarias/attn/internal/client:
 ✓ Client heartbeat (0.00s)
 ✓ Client not running (0.00s)
 ✓ Client query (0.00s)
 ✓ Client register (0.00s)
 ✓ Client register with agent (0.00s)
 ✓ Client socket path (0.00s)
 ✓ Client unregister (0.00s)
 ✓ Client update state (0.00s)
 ✓ Client update todos (0.00s)

github.com/victorarias/attn/cmd/attn:
 ✓ FindCopilotTranscript falls back to newest mod time (0.00s)
 ✓ FindCopilotTranscript prefers closest start time (0.00s)
 ✓ ResolveCopilotTranscript falls back when resume path missing (0.00s)
 ✓ ResolveCopilotTranscript prefers resume session path (0.00s)

github.com/victorarias/attn/internal/daemon:
 ✓ Assistant dedup window behavior (0.00s)
 ✓ Assistant dedup window behavior different text not deduped (0.00s)
 ✓ Assistant dedup window behavior duplicate outside window not deduped (0.00s)
 ✓ Assistant dedup window behavior duplicate within window deduped (0.00s)
 ✓ Cancel review (0.21s)
 ✓ ClassifySessionState claude concurrent duplicate turn runs once (0.01s)
 ✓ ClassifySessionState claude skips duplicate assistant turn (2.02s)
 ✓ Daemon add warning dedupes by code and message (0.00s)
 ✓ Daemon approve PR via web socket (0.31s)
 ✓ Daemon clear all sessions recovers and terminates known sessions (0.00s)
 ✓ Daemon clear warnings not replayed in initial state (0.00s)
 ✓ Daemon forward PTY stream events closes stream on send failure (0.00s)
 ✓ Daemon handle attach session reattach closes old stream (0.00s)
 ✓ Daemon handle attach session reattach failure keeps existing stream (0.00s)
 ✓ Daemon handle client message clear warnings (0.00s)
 ✓ Daemon health endpoint (0.03s)
 ✓ Daemon initial state includes daemon instance ID (0.00s)
 ✓ Daemon initial state includes repo states (0.30s)
 ✓ Daemon inject test PR (0.02s)
 ✓ Daemon inject test session broadcasts to web socket (0.12s)
 ✓ Daemon multiple sessions (0.02s)
 ✓ Daemon mute PR via web socket (0.30s)
 ✓ Daemon mute repo via web socket (0.31s)
 ✓ Daemon new adds warning when persistence falls back to memory (0.01s)
 ✓ Daemon prunes sessions without live PTY on start (0.08s)
 ✓ Daemon reconcile sessions with worker backend (0.00s)
 ✓ Daemon reconcile sessions with worker backend preserves likely alive sessions (0.00s)
 ✓ Daemon reconcile sessions with worker backend skips idle demotion on incomplete recovery (0.00s)
 ✓ Daemon reconcile sessions with worker backend skips idle demotion on liveness probe error (0.00s)
 ✓ Daemon reconcile sessions with worker backend skips recently updated sessions (0.00s)
 ✓ Daemon recovery barrier blocks PTY commands (0.00s)
 ✓ Daemon recovery barrier blocks clear sessions (0.00s)
 ✓ Daemon recovery barrier defers initial state (0.00s)
 ✓ Daemon register and query (0.13s)
 ✓ Daemon run deferred worker reconciliation broadcasts sessions updated on change (0.00s)
 ✓ Daemon run deferred worker reconciliation forces idle demotion (0.00s)
 ✓ Daemon settings include PTY backend mode (0.00s)
 ✓ Daemon settings validation (0.00s)
 ✓ Daemon settings validation empty claude executable (0.00s)
 ✓ Daemon settings validation empty codex executable (0.00s)
 ✓ Daemon settings validation empty copilot executable (0.00s)
 ✓ Daemon settings validation empty new session agent (0.00s)
 ✓ Daemon settings validation empty projects directory (0.00s)
 ✓ Daemon settings validation invalid claude executable (0.00s)
 ✓ Daemon settings validation invalid key (0.00s)
 ✓ Daemon settings validation invalid new session agent (0.00s)
 ✓ Daemon settings validation relative path (0.00s)
 ✓ Daemon settings validation valid new session agent claude (0.00s)
 ✓ Daemon settings validation valid new session agent codex (0.00s)
 ✓ Daemon settings validation valid new session agent copilot (0.00s)
 ✓ Daemon settings validation valid projects directory (0.00s)
 ✓ Daemon settings with agent availability (0.00s)
 ✓ Daemon socket cleanup (0.02s)
 ✓ Daemon start selects embedded backend when requested (0.01s)
 ✓ Daemon start selects worker backend when requested (0.01s)
 ✓ Daemon start worker probe failure falls back to embedded (0.01s)
 ✓ Daemon state change broadcasts to web socket (0.12s)
 ✓ Daemon state transitions all states (0.12s)
 ✓ Daemon state update (0.02s)
 ✓ Daemon stop command completed todos proceeds to classification (0.01s)
 ✓ Daemon stop command pending todos sets waiting input (0.31s)
 ✓ Daemon unregister (0.02s)
 ✓ DoCreateWorktree resolves main repo from worktree (0.12s)
 ✓ DoCreateWorktreeFromBranch resolves main repo from worktree (0.12s)
 ✓ EnsureDaemonInstanceID concurrent calls stable (0.00s)
 ✓ EnsureDaemonInstanceID persists across calls (0.00s)
 ✓ EnsureDaemonInstanceID rewrites corrupt file (0.00s)
 ✓ Extract event type (0.00s)
 ✓ HandlePTYState claude accepts waiting (0.00s)
 ✓ HandlePTYState codex ignores waiting and idle (0.00s)
 ✓ HandlePTYState copilot keeps pending against working noise (0.00s)
 ✓ Harness broadcast recorder (0.11s)
 ✓ Harness classifier with custom responses (0.00s)
 ✓ Harness claude stop retries transcript read on first turn (0.32s)
 ✓ Harness concurrent operations (0.11s)
 ✓ Harness fake classifier (0.21s)
 ✓ Harness wait for event (0.07s)
 ✓ Has copilot transcript pending approval (0.00s)
 ✓ HasCopilotTranscriptPendingApproval create tool (0.00s)
 ✓ HasCopilotTranscriptPendingApproval grace window (0.00s)
 ✓ HasCopilotTranscriptPendingApproval requires turn open (0.00s)
 ✓ Is transcript watched agent (0.00s)
 ✓ Parse git diff numstat (0.00s)
 ✓ Parse git status porcelain (0.00s)
 ✓ Read transcript delta (0.00s)
 ∅ Real agent harness (0.00s)
 ✓ Session state from recovered info (0.00s)
 ✓ Session state from recovered info codex waiting input normalizes to working (0.00s)
 ✓ Session state from recovered info copilot explicit idle normalizes to working (0.00s)
 ✓ Session state from recovered info default working (0.00s)
 ✓ Session state from recovered info explicit idle (0.00s)
 ✓ Session state from recovered info not running is idle (0.00s)
 ✓ Session state from recovered info pending approval (0.00s)
 ✓ Session state from recovered info waiting input (0.00s)
 ✓ Should promote transcript pending (0.00s)
 ✓ StartReview event sequence (0.22s)

github.com/victorarias/attn/internal/github:
 ✓ Client approve PR (0.00s)
 ✓ Client approve PR error (0.00s)
 ✓ Client do request sets headers (0.00s)
 ✓ Client fetch PR details (0.00s)
 ✓ Client fetch all (0.00s)
 ✓ Client merge PR (0.00s)
 ✓ Client merge PR invalid method (0.00s)
 ✓ Client registry CRUD (0.00s)
 ✓ Client registry fetch all PRs (0.02s)
 ✓ Client registry rate limits (0.00s)
 ✓ Client search authored PRs (0.00s)
 ✓ Client search review requested PRs (0.00s)
 ✓ Compare versions (0.00s)
 ✓ Map host to APIURL (0.00s)
 ✓ NewClient blocks test token with real API (0.00s)
 ✓ NewClient custom base URL (0.00s)
 ✓ NewClient defaults to git hub API (0.00s)
 ✓ NewClient uses provided token (0.00s)
 ✓ Parse GH version output (0.00s)
 ✓ Parse auth status hosts (0.00s)
 ✓ Parse auth status hosts empty (0.00s)

github.com/victorarias/attn/internal/git:
 ✓ Checkout remote branch (0.11s)
 ✓ Commit WIP (0.12s)
 ✓ Create worktree (0.09s)
 ✓ Delete worktree (0.12s)
 ✓ Extract rename path (0.00s)
 ✓ Extract rename path dir {old.go => new.go} (0.00s)
 ✓ Extract rename path file.go (0.00s)
 ✓ Extract rename path old.go => new.go (0.00s)
 ✓ Extract rename path src dir {old.go => new.go} (0.00s)
 ✓ Extract rename path src file.go (0.00s)
 ✓ Extract rename path src old.go => src new.go (0.00s)
 ✓ Extract rename path src {old => new} file.go (0.00s)
 ✓ Extract rename path {old => new} file.go (0.00s)
 ✓ Find attn stash (0.12s)
 ✓ FindAttnStash no stashes (0.07s)
 ✓ Generate worktree path (0.00s)
 ✓ Get default branch (0.08s)
 ✓ GetBranchDiffFiles committed changes (0.13s)
 ✓ GetBranchDiffFiles deleted file (0.13s)
 ✓ GetBranchDiffFiles invalid base ref (0.12s)
 ✓ GetBranchDiffFiles line stats (0.15s)
 ✓ GetBranchDiffFiles mixed changes (0.14s)
 ✓ GetBranchDiffFiles no changes (0.11s)
 ✓ GetBranchDiffFiles uncommitted changes (0.11s)
 ✓ GetBranchDiffFiles untracked file (0.10s)
 ✓ GetBranchInfo detached head (0.08s)
 ✓ GetBranchInfo main repo (0.09s)
 ✓ GetBranchInfo not git repo (0.01s)
 ✓ GetBranchInfo worktree (0.10s)
 ✓ Is dirty (0.12s)
 ✓ List branches with commits (0.23s)
 ✓ List remote branches (0.05s)
 ✓ List worktrees (0.09s)
 ✓ Parse git porcelain status (0.00s)
 ✓ Parse git porcelain status (0.00s)
 ✓ Parse git porcelain status #00 (0.00s)
 ✓ Parse git porcelain status ?? (0.00s)
 ✓ Parse git porcelain status AM (0.00s)
 ✓ Parse git porcelain status MM (0.00s)
 ✓ Parse git porcelain status a (0.00s)
 ✓ Parse git porcelain status a (0.00s)
 ✓ Parse git porcelain status d (0.00s)
 ✓ Parse git porcelain status d (0.00s)
 ✓ Parse git porcelain status m (0.00s)
 ✓ Parse git porcelain status m (0.00s)
 ✓ Parse git porcelain status r (0.00s)
 ✓ Parse git porcelain status r (0.00s)
 ✓ Parse git status (0.00s)
 ✓ Parse git status #00 (0.00s)
 ✓ Parse git status R050 (0.00s)
 ✓ Parse git status R100 (0.00s)
 ✓ Parse git status a (0.00s)
 ✓ Parse git status c (0.00s)
 ✓ Parse git status d (0.00s)
 ✓ Parse git status m (0.00s)
 ✓ Parse git status r (0.00s)
 ✓ Parse git status t (0.00s)
 ✓ Parse git status x (0.00s)
 ✓ ResolveMainRepoPath with main repo (0.05s)
 ✓ ResolveMainRepoPath with worktree (0.08s)
 ✓ Stash (0.12s)
 ✓ Stash pop (0.13s)

github.com/victorarias/attn/internal/pathutil:
 ✓ Ensure GUI path (0.01s)
 ✓ Extract path from shell output (0.00s)
 ✓ Extract path from shell output empty output (0.00s)
 ✓ Extract path from shell output malformed - no PATH (0.00s)
 ✓ Extract path from shell output malformed - no closing quote (0.00s)
 ✓ Extract path from shell output path with homebrew (0.00s)
 ✓ Extract path from shell output standard path helper output (0.00s)
 ✓ Merge paths (0.00s)
 ✓ Merge paths empty paths (0.00s)
 ✓ Merge paths empty segments ignored (0.00s)
 ✓ Merge paths no duplicates (0.00s)
 ✓ Merge paths primary only (0.00s)
 ✓ Merge paths secondary only (0.00s)
 ✓ Merge paths with duplicates (0.00s)

github.com/victorarias/attn/internal/reviewer/mcp:
 ✓ Comment operations (0.13s)
 ✓ Get changed files (0.14s)
 ✓ Get diff (0.28s)

github.com/victorarias/attn/internal/reviewer:
 ✓ BuildPrompt rereview (0.02s)
 ✓ Format transcript for prompt (0.00s)
 ✓ Format transcript for prompt chunk events (0.00s)
 ✓ Format transcript for prompt empty array (0.00s)
 ✓ Format transcript for prompt empty transcript (0.00s)
 ✓ Format transcript for prompt finding events (0.00s)
 ✓ Format transcript for prompt invalid JSON (0.00s)
 ✓ Format transcript for prompt mixed events (0.00s)
 ✓ Format transcript for prompt resolved events (0.00s)
 ✓ Reviewer cancellation (0.32s)
 ✓ Reviewer error handling (0.09s)
 ✓ Reviewer full flow (0.17s)
 ✓ Reviewer prevent concurrent runs (0.14s)

github.com/victorarias/attn/internal/reviewer/transport:
 ✓ FixtureBuilder error mid stream (0.00s)
 ✓ FixtureBuilder simple review sequence (0.00s)
 ✓ FixtureBuilder streaming text sequence (0.04s)
 ✓ MockTransport basic flow (0.00s)
 ✓ MockTransport cancellation (0.26s)
 ✓ MockTransport close (0.01s)
 ✓ MockTransport connect error (0.00s)
 ✓ MockTransport delays (0.05s)
 ✓ MockTransport error injection (0.00s)
 ✓ MockTransport write before connect (0.00s)
 ✓ MockTransport write recording (0.00s)

github.com/victorarias/attn/internal/pty:
 ✓ BuildSpawnEnv sets wrapper path (0.00s)
 ✓ ClassifyState copilot allow directory access is pending approval (0.00s)
 ✓ ClassifyState copilot permission prompt is pending approval (0.00s)
 ✓ ClassifyState numbered list question stays waiting input (0.00s)
 ✓ ClassifyState prompt at end is waiting (0.00s)
 ✓ ClassifyState prompt not last stays working (0.00s)
 ✓ FindSafeBoundary complete ANSI (0.00s)
 ✓ FindSafeBoundary incomplete ANSI (0.00s)
 ✓ FindSafeBoundary incomplete UTF8 (0.00s)
 ✓ FirstExecutablePath picks first valid executable (0.00s)
 ✓ FirstExecutablePath returns false when none valid (0.00s)
 ✓ MergeEnvironment overlay wins (0.00s)
 ✓ Parse null separated env (0.00s)
 ✓ Preferred shell candidates (0.00s)
 ✓ ResolveAttnPath prefers env wrapper path (0.00s)
 ✓ RingBufferSnapshot no wrap (0.00s)
 ✓ RingBufferSnapshot wrap (0.00s)
 ✓ SessionInfo includes screen snapshot when available (0.00s)
 ✓ SessionInfo omits screen snapshot for non codex sessions (0.00s)
 ✓ Should fallback shell (0.00s)
 ✓ Should setpgid for PTY (0.00s)
 ✓ VirtualScreenSnapshot preserves alt screen visible frame (0.00s)
 ✓ VirtualScreenSnapshot preserves foreground color (0.00s)
 ✓ VirtualScreenSnapshot round trip (0.00s)
 ✓ VirtualScreenSnapshot round trip full width parity (0.00s)

github.com/victorarias/attn/internal/ptyworker:
 ✓ ConnCtx next read timeout (0.00s)
 ✓ ConnCtx next read timeout attached stream disables read deadline (0.00s)
 ✓ ConnCtx next read timeout hello deadline before auth (0.00s)
 ✓ ConnCtx next read timeout idle rpc connection uses idle deadline (0.00s)
 ✓ ConnCtx next read timeout watch stream disables read deadline (0.00s)
 ✓ Is compatible version (0.00s)
 ✓ Is compatible version exact current version (0.00s)
 ✓ Is compatible version major mismatch (0.00s)
 ✓ Is compatible version minimum compatible (0.00s)
 ✓ Is compatible version minor above current (0.00s)
 ✓ Is compatible version minor below window (0.00s)
 ✓ Request envelope round trip (0.00s)
 ✓ Response envelope error round trip (0.00s)
 ✓ Runtime exit cleanup waits for connections to close (0.07s)
 ✓ Runtime exited session cleans up after TTL without connections (0.02s)
 ✓ Write and read registry (0.00s)

github.com/victorarias/attn/internal/ptybackend:
 ✓ Append capped pre event (0.00s)
 ✓ EmbeddedStream publish after close does not panic (0.00s)
 ✓ EmbeddedStream publish during concurrent close does not panic (0.00s)
 ✓ Is transient recovery error (0.00s)
 ✓ Validate session ID (0.00s)
 ✓ WorkerBackend force session eviction stops monitor and prunes (0.00s)
 ✓ WorkerBackend get session prunes dead registry entry (0.00s)
 ✓ WorkerBackend probe fails when binary unavailable (0.00s)
 ✓ WorkerBackend recover accepts legacy socket path (0.00s)
 ∅ WorkerBackend recover after backend restart (0.00s)
 ✓ WorkerBackend recover preserves live owner mismatch (0.00s)
 ✓ WorkerBackend recover quarantines ownership mismatch (0.00s)
 ✓ WorkerBackend recover reclaims stale ownership mismatch (0.00s)
 ✓ WorkerBackend recover rejects unexpected socket path (0.00s)
 ✓ WorkerBackend recover restores socket mismatch quarantine (0.00s)
 ✓ WorkerBackend recover second call reuses existing session (0.00s)
 ✓ WorkerBackend remove retains tracked session on transient error (0.00s)
 ✓ WorkerBackend session likely alive malformed registry returns error (0.00s)
 ✓ WorkerBackend session likely alive uses validated registry (0.00s)
 ∅ WorkerBackend spawn attach input resize remove (0.00s)
 ✓ WorkerBackend spawn cleans up unready worker process (1.62s)
 ✓ WorkerBackend stop monitor does not hang when watch response missing (2.00s)
 ✓ WorkerSession note poll failure lifecycle (0.00s)
 ✓ WorkerSession note poll recovery resets unreachable state (0.00s)
 ✓ WorkerStream close bounded when peer stalled (0.25s)
 ✓ WorkerStream publish overflow does not block (0.00s)

github.com/victorarias/attn/internal/protocol:
 ✓ Format PRID (0.00s)
 ✓ Parse PRID (0.00s)
 ✓ Parse PRID errors (0.00s)
 ✓ Parse command (0.00s)
 ✓ Parse command clear warnings message (0.00s)
 ✓ Parse command invalid json (0.00s)
 ✓ Parse command missing cmd (0.00s)
 ✓ Parse command query message (0.00s)
 ✓ Parse command register message (0.00s)
 ✓ Parse command state message (0.00s)
 ✓ Parse command unregister message (0.00s)
 ✓ Parse register (0.00s)
 ✓ QueryMessage marshal (0.00s)
 ✓ RegisterMessage marshal (0.00s)
 ✓ StateMessage marshal (0.00s)

github.com/victorarias/attn/internal/wrapper:
 ✓ Cleanup hooks config (0.00s)
 ✓ Default label (0.00s)
 ✓ Generate session ID (0.00s)
 ✓ Write hooks config (0.00s)

github.com/victorarias/attn/internal/transcript:
 ✓ Extract last assistant message (0.00s)
 ✓ ExtractCopilotToolLifecycle complete (0.00s)
 ✓ ExtractCopilotToolLifecycle ignores non lifecycle (0.00s)
 ✓ ExtractCopilotToolLifecycle start (0.00s)
 ✓ ExtractLastAssistantMessage claude code format (0.00s)
 ✓ ExtractLastAssistantMessage claude code format multiple text blocks (0.00s)
 ✓ ExtractLastAssistantMessage claude code format only thinking (0.00s)
 ✓ ExtractLastAssistantMessage codex event message (0.00s)
 ✓ ExtractLastAssistantMessage codex response item output text (0.00s)
 ✓ ExtractLastAssistantMessage copilot events (0.00s)
 ✓ ExtractLastAssistantMessage message role as assistant (0.00s)
 ✓ ExtractLastAssistantMessage no assistant (0.00s)
 ✓ ExtractLastAssistantMessage truncates (0.00s)
 ✓ ExtractLastAssistantMessageAfterLastUser claude assistant after latest user (0.00s)
 ✓ ExtractLastAssistantMessageAfterLastUser claude no user still returns last assistant (0.00s)
 ✓ ExtractLastAssistantMessageAfterLastUser claude stale assistant ignored (0.00s)
 ✓ ExtractLastAssistantMessageAfterLastUser copilot stale assistant ignored (0.00s)
 ✓ ExtractLastAssistantMessageAfterLastUserSince claude fresh assistant returned (0.00s)
 ✓ ExtractLastAssistantMessageAfterLastUserSince claude stale by timestamp ignored (0.00s)
 ✓ FindClaudeTranscript finds session file (0.00s)
 ✓ FindClaudeTranscript returns empty when missing (0.00s)
 ✓ FindCopilotTranscript falls back to newest mod time (0.00s)
 ✓ FindCopilotTranscript prefers closest start time (0.00s)

github.com/victorarias/attn/internal/store:
 ✓ Get or create review (0.01s)
 ✓ Migration20 idempotent when host column already exists (0.02s)
 ✓ Migration21 idempotent when agent column already exists (0.01s)
 ✓ Migrations applied on new DB (0.01s)
 ✓ Migrations idempotent (0.01s)
 ✓ Migrations migrated columns exist (0.02s)
 ✓ OpenDB creates directory (0.01s)
 ✓ OpenDB creates schema (0.01s)
 ✓ OpenDB reopens existing DB (0.02s)
 ✓ Review comments (0.01s)
 ✓ Reviewer sessions (0.02s)
 ✓ Seed legacy DB (0.01s)
 ✓ Store SQ lite persistence (0.01s)
 ✓ Store add and get (0.00s)
 ✓ Store add and get preserves agent (0.00s)
 ✓ Store author state (0.00s)
 ✓ Store list (0.00s)
 ✓ Store list author states (0.00s)
 ✓ Store list repo states (0.00s)
 ✓ Store remove (0.00s)
 ✓ Store repo state (0.00s)
 ✓ Store set PRs preserves approved by me (0.00s)
 ✓ Store set PRs preserves detail fields (0.00s)
 ✓ Store set PRs preserves muted (0.00s)
 ✓ Store set and list PRs (0.00s)
 ✓ Store toggle mute (0.00s)
 ✓ Store toggle mute PR (0.00s)
 ✓ Store toggle mute non existent (0.00s)
 ✓ Store touch (0.01s)
 ✓ Store update state (0.00s)
 ✓ Store update todos (0.00s)
 ✓ Viewed files (0.01s)
 ✓ Worktree store (0.00s)


=== Skipped
=== SKIP: internal/daemon TestRealAgentHarness (0.00s)
    real_agent_harness_test.go:25: set ATTN_REAL_AGENT_HARNESS=1 to run real-agent harness

=== SKIP: internal/ptybackend TestWorkerBackend_SpawnAttachInputResizeRemove (0.00s)
    worker_integration_test.go:21: set ATTN_RUN_WORKER_INTEGRATION=1 to run worker integration test

=== SKIP: internal/ptybackend TestWorkerBackend_RecoverAfterBackendRestart (0.00s)
    worker_integration_test.go:106: set ATTN_RUN_WORKER_INTEGRATION=1 to run worker integration test

DONE 434 tests, 3 skipped in 0.313s\n- 
> app@0.2.7 test /Users/victor.arias/projects/victor/attn/app
> vitest run


 RUN  v4.0.15 /Users/victor.arias/projects/victor/attn/app

 ✓ src/shortcuts/registry.test.ts (14 tests) 4ms
 ✓ src/types/sessionState.test.ts (9 tests) 6ms
 ✓ src/store/sessions.test.ts (21 tests) 6ms
 ✓ src/components/StateIndicator.test.tsx (10 tests) 25ms
 ✓ src/hooks/usePRsNeedingAttention.test.ts (13 tests) 26ms
 ✓ src/components/Sidebar.test.tsx (2 tests) 17ms
 ✓ src/components/UnifiedDiffEditor.test.ts (33 tests) 7ms
 ✓ src/components/Dashboard.test.tsx (1 test) 26ms
 ✓ src/store/daemonSessions.test.ts (8 tests) 2ms
 ✓ src/utils/agentAvailability.test.ts (4 tests) 4ms
stdout | src/App.worktreeCleanup.test.tsx > worktree cleanup prompt > shows worktree cleanup prompt when closing a worktree session
[App] Daemon not running, starting...

stdout | src/App.worktreeCleanup.test.tsx > worktree cleanup prompt > shows worktree cleanup prompt when closing a worktree session
[App] Daemon started

 ✓ src/App.worktreeCleanup.test.tsx (1 test) 37ms
 ✓ src/utils/installChannel.test.ts (4 tests) 2ms
 ✓ src/components/ReviewPanel.test.tsx (40 tests) 1438ms
       ✓ preserves selected file when branch diff refreshes  310ms
       ✓ does not let stale local diff overwrite refreshed remote diff  358ms

 Test Files  13 passed (13)
      Tests  160 passed (160)
   Start at  20:38:06
   Duration  2.42s (transform 1.70s, setup 1.10s, import 3.24s, tests 1.60s, environment 3.37s)\n