### PR TITLE
homebrew: update formula for v0.2.10

### DIFF
--- a/Formula/attn.rb
+++ b/Formula/attn.rb
@@ -1,9 +1,9 @@
 class Attn < Formula
   desc "Desktop orchestrator and CLI wrapper for Claude Code and Codex sessions"
   homepage "https://github.com/victorarias/attn"
-  url "https://github.com/victorarias/attn/archive/refs/tags/v0.2.9.tar.gz"
-  sha256 "9e15befec0568dda6b510fa28b80a901000e36ee74f7de815279cecfc42114c1"
-  version "0.2.9"
+  url "https://github.com/victorarias/attn/archive/refs/tags/v0.2.10.tar.gz"
+  sha256 "83e4ed16b98891c6cbffd74e8f287ed9810d73b5f8902c3a7e74c80649eb9eda"
+  version "0.2.10"
   license "GPL-3.0-only"
 
   depends_on "go" => :build


### PR DESCRIPTION
## Summary
- update `Formula/attn.rb` to `v0.2.10`
- refresh source tarball SHA256 for the new tag

## Notes
- release tag `v0.2.10` is already pushed
- GitHub release workflow is triggered from the tag
