### PR TITLE
Improve Claude PTY working detection and ignore final summary lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-02-19]
+
+### Fixed
+- **Claude Working-State PTY Heartbeats**: Claude sessions now emit `working` pulses from the live animated status line (`✻ ... (Xm Ys · ...)`) so green/running state stays accurate during long turns.
+- **Claude Final Summary Guard**: PTY state detection now excludes terminal final summary lines (`✻ <verb> for ...`) from working animation matching, avoiding false “still running” signals at turn completion.
+
 ## [2026-02-18]
 
 ### Changed

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -194,12 +194,15 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 	onState := m.onState
 	m.mu.Unlock()
 
-	if agent == "codex" || agent == "copilot" {
+	switch agent {
+	case "codex", "copilot":
 		session.detector = newCodexStateDetector()
-		if onState != nil {
-			session.onState = func(state string) {
-				onState(opts.ID, state)
-			}
+	case "claude":
+		session.detector = newClaudeWorkingDetector()
+	}
+	if session.detector != nil && onState != nil {
+		session.onState = func(state string) {
+			onState(opts.ID, state)
 		}
 	}
 

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -19,6 +19,10 @@ type sessionSubscriber struct {
 	onDrop func(reason string)
 }
 
+type stateDetector interface {
+	Observe(chunk []byte) (string, bool)
+}
+
 type Session struct {
 	id    string
 	cwd   string
@@ -40,8 +44,8 @@ type Session struct {
 
 	writeMu sync.Mutex
 
-	// CLI state detection based on PTY output (currently Codex/Copilot).
-	detector *codexStateDetector
+	// CLI state detection based on PTY output.
+	detector stateDetector
 	onState  func(state string)
 
 	exitMu     sync.RWMutex


### PR DESCRIPTION
## Summary
- add a Claude-specific PTY working detector and wire it into session spawn for Claude agents
- emit throttled working heartbeat pulses from animated Claude status frames
- ignore variable final summary lines of the form `✻ <verb> for <duration>` so completion summaries do not keep sessions green
- generalize session detector typing to support multiple detector implementations
- add focused tests for Claude working detection and final-summary exclusion
- update changelog entry for 2026-02-19

## Testing
- go test ./internal/pty
- go test ./internal/daemon -run TestHandlePTYState
