### PR TITLE
homebrew: update formula for v0.2.12

### DIFF
--- a/Formula/attn.rb
+++ b/Formula/attn.rb
@@ -1,9 +1,9 @@
 class Attn < Formula
   desc "Desktop orchestrator and CLI wrapper for Claude Code and Codex sessions"
   homepage "https://github.com/victorarias/attn"
-  url "https://github.com/victorarias/attn/archive/refs/tags/v0.2.11.tar.gz"
-  sha256 "b51d4633a36db8b2f81d7749bf345b4780837730600c7f969f31718b385f1bd3"
-  version "0.2.11"
+  url "https://github.com/victorarias/attn/archive/refs/tags/v0.2.12.tar.gz"
+  sha256 "e890f9c710bdd053ab3e156051e35c690f89805b053793afba554d8b477f251e"
+  version "0.2.12"
   license "GPL-3.0-only"
 
   depends_on "go" => :build


### PR DESCRIPTION
Updates Homebrew formula source URL and SHA256 for v0.2.12.