### PR TITLE
ci: add automated PR review with shitty-reviewing-agent

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,33 @@
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.VERTEX_AI_SA }}
+
+      - uses: victorarias/shitty-reviewing-agent@v0.2.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOOGLE_CLOUD_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
+          GOOGLE_CLOUD_LOCATION: global
+        with:
+          provider: vertex
+          model: gemini-3-flash-preview


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs [shitty-reviewing-agent](https://github.com/victorarias/shitty-reviewing-agent) on PR open and synchronize events
- Uses Gemini 3 Flash Preview via Vertex AI with service account auth

## Test plan
- [ ] Verify `VERTEX_AI_SA` org secret is accessible to this repo
- [ ] Open a test PR and confirm the review agent comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)