### PR TITLE
Switch PR reviews to Hodor

### DIFF
--- a/.github/hodor/v0.3.4-google-vertex.patch
+++ b/.github/hodor/v0.3.4-google-vertex.patch
@@ -1,0 +1,79 @@
+diff --git a/src/agent.ts b/src/agent.ts
+index 93cccd1..0f64b27 100644
+--- a/src/agent.ts
++++ b/src/agent.ts
+@@ -208,6 +208,7 @@ export async function reviewPr(opts: {
+   const envSnapshot: Record<string, string | undefined> = {
+     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
++    GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+     AWS_REGION: process.env.AWS_REGION,
+   };
+
+@@ -217,6 +218,8 @@ export async function reviewPr(opts: {
+       process.env.ANTHROPIC_API_KEY = apiKey;
+     } else if (parsed.provider === "openai") {
+       process.env.OPENAI_API_KEY = apiKey;
++    } else if (parsed.provider === "google") {
++      process.env.GEMINI_API_KEY = apiKey;
+     }
+   }
+
+diff --git a/src/model.ts b/src/model.ts
+index e0812e1..0100cc1 100644
+--- a/src/model.ts
++++ b/src/model.ts
+@@ -25,6 +25,12 @@ export function parseModelString(model: string): ParsedModel {
+       }
+       return { provider: "amazon-bedrock", modelId };
+     }
++    if (first === "vertex" || first === "google-vertex") {
++      return { provider: "google-vertex", modelId: parts.slice(1).join("/") };
++    }
++    if (first === "google" || first === "gemini") {
++      return { provider: "google", modelId: parts.slice(1).join("/") };
++    }
+     if (["anthropic", "openai"].includes(first)) {
+       return { provider: first, modelId: parts.slice(1).join("/") };
+     }
+@@ -44,6 +50,9 @@ export function parseModelString(model: string): ParsedModel {
+   ) {
+     return { provider: "openai", modelId: trimmed };
+   }
++  if (lower.includes("gemini") || lower.includes("google")) {
++    return { provider: "google", modelId: trimmed };
++  }
+
+   // Default to anthropic for unknown models
+   return { provider: "anthropic", modelId: trimmed };
+@@ -88,11 +97,17 @@ export function getApiKey(model?: string): string | null {
+   // Priority 2: Provider-specific
+   if (model) {
+     const { provider } = parseModelString(model);
+-    if (provider === "amazon-bedrock") return null;
++    if (provider === "amazon-bedrock" || provider === "google-vertex") {
++      return null;
++    }
+     if (provider === "anthropic") {
+       const key = process.env.ANTHROPIC_API_KEY;
+       if (key) return key;
+     }
++    if (provider === "google") {
++      const key = process.env.GEMINI_API_KEY;
++      if (key) return key;
++    }
+     if (provider === "openai") {
+       const key = process.env.OPENAI_API_KEY;
+       if (key) return key;
+@@ -101,9 +116,10 @@ export function getApiKey(model?: string): string | null {
+
+   // Priority 3: Fallback
+   if (process.env.ANTHROPIC_API_KEY) return process.env.ANTHROPIC_API_KEY;
++  if (process.env.GEMINI_API_KEY) return process.env.GEMINI_API_KEY;
+   if (process.env.OPENAI_API_KEY) return process.env.OPENAI_API_KEY;
+
+   throw new Error(
+-    "No LLM API key found. Please set one of: LLM_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY",
++    "No LLM API key found. Please set one of: LLM_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, or OPENAI_API_KEY",
+   );
+ }

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,43 +1,125 @@
-name: PR Review
+name: Hodor PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 concurrency:
-  group: pr-review-${{ github.event.pull_request.number }}
+  group: hodor-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   review:
+    if: ${{ !github.event.pull_request.draft && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       VERTEX_AI_SA: ${{ secrets.VERTEX_AI_SA }}
       GOOGLE_CLOUD_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
+      HODOR_VERSION: v0.3.4
+      HODOR_MODEL: google-vertex/gemini-3-flash-preview
+      GOOGLE_CLOUD_LOCATION: global
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
 
       - name: Authenticate to Google Cloud
-        if: ${{ !github.event.pull_request.head.repo.fork && env.VERTEX_AI_SA != '' && env.GOOGLE_CLOUD_PROJECT != '' }}
+        if: ${{ env.VERTEX_AI_SA != '' && env.GOOGLE_CLOUD_PROJECT != '' }}
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ env.VERTEX_AI_SA }}
+          create_credentials_file: true
+          export_environment_variables: true
 
-      - name: Run automated PR review
-        if: ${{ !github.event.pull_request.head.repo.fork && env.VERTEX_AI_SA != '' && env.GOOGLE_CLOUD_PROJECT != '' }}
-        uses: victorarias/shitty-reviewing-agent@main
+      - name: Validate review configuration
+        if: ${{ env.VERTEX_AI_SA != '' && env.GOOGLE_CLOUD_PROJECT != '' }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GOOGLE_CLOUD_PROJECT:-}" ]]; then
+            echo "GOOGLE_CLOUD_PROJECT secret is required." >&2
+            exit 1
+          fi
+
+          if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+            echo "VERTEX_AI_SA secret is required." >&2
+            exit 1
+          fi
+
+          gh --version
+          echo "Using Hodor ${HODOR_VERSION} with model ${HODOR_MODEL}"
+          echo "Vertex project: ${GOOGLE_CLOUD_PROJECT}"
+          echo "Vertex location: ${GOOGLE_CLOUD_LOCATION}"
+
+      - name: Install patched Hodor
+        if: ${{ env.VERTEX_AI_SA != '' && env.GOOGLE_CLOUD_PROJECT != '' }}
+        run: |
+          set -euo pipefail
+          git clone --depth=1 --branch "${HODOR_VERSION}" https://github.com/mr-karan/hodor /tmp/hodor
+          cd /tmp/hodor
+          git apply "${GITHUB_WORKSPACE}/.github/hodor/v0.3.4-google-vertex.patch"
+          bun install --frozen-lockfile
+          bun run build
+
+      - name: Run Hodor review
+        id: hodor
+        if: ${{ env.VERTEX_AI_SA != '' && env.GOOGLE_CLOUD_PROJECT != '' }}
+        continue-on-error: true
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GOOGLE_CLOUD_PROJECT: ${{ env.GOOGLE_CLOUD_PROJECT }}
-          GOOGLE_CLOUD_LOCATION: global
-        with:
-          provider: vertex
-          model: gemini-3-flash-preview
+        run: |
+          set -euo pipefail
+          PR_URL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          cd /tmp/hodor
+          bun run dist/cli.js "$PR_URL" \
+            --model "${HODOR_MODEL}" \
+            --reasoning-effort high \
+            --post \
+            --verbose | tee /tmp/hodor-review.log
 
-      - name: Skip automated PR review
-        if: ${{ github.event.pull_request.head.repo.fork || env.VERTEX_AI_SA == '' || env.GOOGLE_CLOUD_PROJECT == '' }}
-        run: echo "Skipping PR Review for forked PRs or when Vertex credentials are unavailable."
+      - name: Upload Hodor logs
+        if: ${{ always() && env.VERTEX_AI_SA != '' && env.GOOGLE_CLOUD_PROJECT != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: hodor-review-${{ github.run_id }}
+          path: /tmp/hodor-review.log
+          retention-days: 7
+
+      - name: Skip Hodor review
+        if: ${{ env.VERTEX_AI_SA == '' || env.GOOGLE_CLOUD_PROJECT == '' }}
+        run: echo "Skipping Hodor review because required Vertex secrets are unavailable."
+
+      - name: Summarize Hodor review outcome
+        if: ${{ always() && env.VERTEX_AI_SA != '' && env.GOOGLE_CLOUD_PROJECT != '' }}
+        run: |
+          outcome='${{ steps.hodor.outcome }}'
+          {
+            echo "### Hodor review status: ${outcome}"
+            echo
+            echo "- Model: \`${HODOR_MODEL}\`"
+            echo "- Hodor version: \`${HODOR_VERSION}\`"
+            echo
+            if [[ "$outcome" == "success" ]]; then
+              echo "Hodor completed successfully and posted an advisory review comment to the PR."
+            elif [[ "$outcome" == "failure" ]]; then
+              echo "The Hodor run failed. This workflow remains advisory; inspect the uploaded log artifact for details."
+            elif [[ "$outcome" == "cancelled" ]]; then
+              echo "The Hodor run was cancelled."
+            else
+              echo "Hodor step outcome: $outcome"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.hodor/skills/attn-review/SKILL.md
+++ b/.hodor/skills/attn-review/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: attn-review
+description: Review guidance for attn pull requests. Focus on correctness, protocol safety, generated files, session-state behavior, and cross-daemon/app compatibility.
+---
+
+## Review priorities
+- Prioritize correctness, regressions, state-machine bugs, protocol mismatches, and workflow breakage.
+- Ignore style nits unless they hide a real maintenance or behavior issue.
+- Treat automated review findings as advisory, not merge blockers by default.
+
+## Protocol and compatibility
+- Any protocol change must bump `ProtocolVersion` in `internal/protocol/constants.go`.
+- Watch for app/daemon compatibility regressions, especially daemon background-process upgrade paths.
+- Prefer additive protocol changes when possible.
+
+## Generated files
+- Never hand-edit generated protocol files.
+- If `internal/protocol/schema/main.tsp` changes, expect regenerated outputs and consistency across Go + TypeScript consumers.
+
+## Review-comment and PR features
+- When review-comment data structures change, verify all consumers are updated: store, daemon handlers, frontend hooks/UI, and reviewer/MCP paths.
+- Check GitHub/PR workflows for auth assumptions, fork safety, and advisory-vs-blocking behavior.
+
+## Session and PTY behavior
+- Be extra careful around session state transitions (`launching`, `working`, `pending_approval`, `waiting_input`, `idle`, `unknown`).
+- Watch for reconnect, recovery, classifier races, stale timestamps, and full-screen PTY restore regressions.
+- For terminal or renderer changes, prefer deterministic behavior/harness coverage over brittle snapshot expectations.
+
+## Logging and diagnostics
+- Daemon code should use daemon-wired logging rather than stray stderr logging.
+- Favor actionable diagnostics when a failure can leave the app in a degraded but still-running state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-03-10]
+
+### Changed
+- **GitHub PR Review Automation**: Replaced the `victorarias/shitty-reviewing-agent` PR review workflow with Hodor on Vertex AI using `google-vertex/gemini-3-flash-preview`, while keeping the workflow advisory and fork-safe.
+
+### Added
+- **Hodor Review Guidance**: Added a repository-specific Hodor skill and maintainer docs for the PR review workflow, including the local patch required for Google/Vertex model parsing in upstream Hodor `v0.3.4`.
+
 ## [2026-03-08]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ git clone https://github.com/victorarias/attn.git && cd attn
 | [CLI reference](docs/CLI.md) | Commands and flags |
 | [Configuration](docs/CONFIGURATION.md) | Settings |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | When things go sideways |
+| [PR review automation](docs/PR_REVIEW.md) | Hodor workflow and required GitHub secrets |
 | [Release](docs/RELEASE.md) | Maintainer runbook |
 
 ## Status

--- a/docs/PR_REVIEW.md
+++ b/docs/PR_REVIEW.md
@@ -1,0 +1,40 @@
+# PR Review Automation
+
+This repository uses [Hodor](https://github.com/mr-karan/hodor) for advisory pull-request reviews on GitHub.
+
+## Workflow
+
+`.github/workflows/pr-review.yml`:
+
+- runs on non-draft pull requests
+- skips fork PRs so privileged Google Cloud credentials are not exposed
+- checks out the repository with full history so base-branch diffs are available
+- clones Hodor `v0.3.4`
+- applies `.github/hodor/v0.3.4-google-vertex.patch`
+- authenticates with `VERTEX_AI_SA`
+- runs Hodor on Vertex AI with `google-vertex/gemini-3-flash-preview`
+- posts the review back to the PR as an advisory review comment
+
+## Required GitHub secrets
+
+- `VERTEX_AI_SA`
+- `GOOGLE_CLOUD_PROJECT`
+
+The workflow uses `GOOGLE_CLOUD_LOCATION=global`.
+
+## Why the patch exists
+
+Upstream Hodor `v0.3.4` does not yet parse `google/...` and `google-vertex/...` model strings during preflight setup. The local patch adds the minimal Google/Vertex model handling needed for Vertex-backed Gemini reviews.
+
+## Repository-specific review guidance
+
+Hodor loads review guidance from:
+
+- `.hodor/skills/attn-review/SKILL.md`
+
+That skill tells Hodor to focus on protocol safety, generated files, session-state behavior, review-comment consumers, and daemon/app compatibility risks.
+
+## Notes
+
+- The workflow is advisory.
+- The first PR run after any workflow changes is the real end-to-end validation.


### PR DESCRIPTION
## Summary
- replace the current `shitty-reviewing-agent` PR review workflow with Hodor
- run advisory PR reviews on Vertex AI using `google-vertex/gemini-3-flash-preview`
- keep the existing attn GitHub secret layout (`VERTEX_AI_SA`, `GOOGLE_CLOUD_PROJECT`)
- add repository-specific Hodor review guidance and maintainer docs

## Details
- update `.github/workflows/pr-review.yml`
- add `.github/hodor/v0.3.4-google-vertex.patch` so upstream Hodor `v0.3.4` understands `google/...` and `google-vertex/...` model strings
- add `.hodor/skills/attn-review/SKILL.md`
- add `docs/PR_REVIEW.md`
- update `README.md` and `CHANGELOG.md`

## Behavior
- advisory only
- skips fork PRs so privileged GCP credentials are not exposed
- uses existing `VERTEX_AI_SA` and `GOOGLE_CLOUD_PROJECT` secrets
- uses `fetch-depth: 0` so base-branch diffs are available to Hodor

## Validation
- `git apply --check .github/hodor/v0.3.4-google-vertex.patch` against upstream Hodor `v0.3.4`
- built patched Hodor successfully with Bun
- repo test suite via commit hook:
  - Go tests
  - frontend vitest suite

## Follow-up
- the first PR run in Actions will be the real end-to-end validation of the workflow wiring
