### PR TITLE
Add terminal pane zoom mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-03-14]
 
 ### Changed
+- **Pane Zoom Mode**: Add `Cmd+Shift+Z` as a transient workspace zoom that expands the active pane across nested splits without hiding the surrounding panes, allows you to arm zoom before a split exists, retargets automatically when you move focus to another pane, and lights up the sidebar shortcut hint while zoom is active.
 - **PR Review Provider**: Switch the advisory Hodor GitHub workflow from Vertex Gemini to OpenRouter, now targeting `qwen/qwen3-coder-next` with the `open_router_api_key` secret.
 - **Sidebar Dock Shortcut Hints**: Show the split-pane and pane-navigation shortcuts (`Cmd+D`, `Cmd+Shift+D`, `Cmd+Alt+Arrow`) in the left sidebar’s Dock footer so the new session workspace controls are visible where you browse sessions.
 - **Hodor Review Runtime Budget**: Install `pnpm` and the app dependencies before Hodor runs, remove verbose logging, and lower review reasoning effort to medium so PR reviews spend fewer turns on missing-tooling dead ends.

--- a/app/e2e/keyboard-shortcuts.spec.ts
+++ b/app/e2e/keyboard-shortcuts.spec.ts
@@ -59,6 +59,86 @@ async function createSession(
 }
 
 test.describe('Keyboard Shortcuts', () => {
+  test.describe('Terminal Workspace', () => {
+    test('⌘⇧Z zooms toward the active pane without hiding the others', async ({ page, daemon }) => {
+      await daemon.start();
+      await page.goto('/');
+      await page.waitForSelector('.dashboard');
+
+      await createSession(page, daemon, { id: 's-zoom', label: 'Zoom', state: 'working', cwd: '/tmp/test/zoom' });
+      await expect(page.locator('[data-testid="session-s-zoom"]')).toBeVisible({ timeout: 5000 });
+
+      await page.locator('[data-testid="session-s-zoom"]').click();
+      await expect(page.locator('.terminal-wrapper.active')).toBeVisible({ timeout: 2000 });
+
+      await page.evaluate(() => {
+        window.__TEST_SET_SESSION_WORKSPACE?.('s-zoom', {
+          terminals: [{ id: 'pane-shell-1', ptyId: 'runtime-shell-1', title: 'Shell 1' }],
+          layoutTree: {
+            type: 'split',
+            splitId: 'root',
+            direction: 'vertical',
+            ratio: 0.5,
+            children: [
+              { type: 'pane', paneId: 'main' },
+              { type: 'pane', paneId: 'pane-shell-1' },
+            ],
+          },
+        }, 'pane-shell-1');
+      });
+      await expect(page.locator('[data-pane-session-id="s-zoom"][data-pane-kind="shell"]')).toBeVisible({ timeout: 5000 });
+
+      const workspace = page.locator('[data-session-terminal-workspace="s-zoom"]');
+      const mainPane = page.locator('[data-pane-session-id="s-zoom"][data-pane-id="main"]');
+      const utilityPane = page.locator('[data-pane-session-id="s-zoom"][data-pane-kind="shell"]').first();
+      const rootSplit = page.locator('[data-split-id="root"]');
+      const zoomHint = page.getByText('⌘⇧Z zoom');
+
+      await expect(zoomHint).toHaveAttribute('data-active', 'false');
+
+      const mainBefore = await mainPane.boundingBox();
+      const utilityBefore = await utilityPane.boundingBox();
+      expect(mainBefore?.width).toBeTruthy();
+      expect(utilityBefore?.width).toBeTruthy();
+
+      await utilityPane.click();
+      await page.keyboard.press('Meta+Shift+z');
+      await expect(workspace).toHaveAttribute('data-zoomed-pane-id', 'pane-shell-1', { timeout: 2000 });
+      await expect(rootSplit).toHaveAttribute('data-split-ratio', '0.240', { timeout: 2000 });
+      await expect(zoomHint).toHaveAttribute('data-active', 'true');
+
+      await expect.poll(async () => (await utilityPane.boundingBox())?.width ?? 0, { timeout: 2000 })
+        .toBeGreaterThan(utilityBefore!.width);
+      await expect.poll(async () => (await mainPane.boundingBox())?.width ?? 0, { timeout: 2000 })
+        .toBeLessThan(mainBefore!.width);
+
+      const mainAfterZoom = await mainPane.boundingBox();
+      const utilityAfterZoom = await utilityPane.boundingBox();
+      expect(mainAfterZoom).not.toBeNull();
+      expect(utilityAfterZoom).not.toBeNull();
+      expect(utilityAfterZoom!.width).toBeGreaterThan(utilityBefore!.width);
+      expect(mainAfterZoom!.width).toBeLessThan(mainBefore!.width);
+      await expect(mainPane).toBeVisible();
+      await expect(utilityPane).toBeVisible();
+
+      await mainPane.click();
+      await expect(workspace).toHaveAttribute('data-zoomed-pane-id', 'main', { timeout: 2000 });
+      await expect(rootSplit).toHaveAttribute('data-split-ratio', '0.760', { timeout: 2000 });
+      await expect(zoomHint).toHaveAttribute('data-active', 'true');
+
+      await expect.poll(async () => (await mainPane.boundingBox())?.width ?? 0, { timeout: 2000 })
+        .toBeGreaterThan(mainAfterZoom!.width);
+      await expect.poll(async () => (await utilityPane.boundingBox())?.width ?? 0, { timeout: 2000 })
+        .toBeLessThan(utilityAfterZoom!.width);
+
+      const mainRetargeted = await mainPane.boundingBox();
+      const utilityRetargeted = await utilityPane.boundingBox();
+      expect(mainRetargeted).not.toBeNull();
+      expect(utilityRetargeted).not.toBeNull();
+      expect(mainRetargeted!.width).toBeGreaterThan(mainAfterZoom!.width);
+      expect(utilityRetargeted!.width).toBeLessThan(utilityAfterZoom!.width);
+    });
+  });
 
   test.describe('Attention Drawer', () => {
     test('⌘K toggles attention drawer', async ({ page, daemon }) => {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,7 +3,7 @@ import { onOpenUrl, getCurrent } from '@tauri-apps/plugin-deep-link';
 import { invoke, isTauri } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { openUrl } from '@tauri-apps/plugin-opener';
-import { Sidebar, type SidebarHeaderAction, ReviewLoopIcon, EditorIcon, DiffIcon, PRsIcon } from './components/Sidebar';
+import { Sidebar, type SidebarHeaderAction, type FooterShortcut, ReviewLoopIcon, EditorIcon, DiffIcon, PRsIcon } from './components/Sidebar';
 import { Dashboard } from './components/Dashboard';
 import { AttentionDrawer } from './components/AttentionDrawer';
 import { LocationPicker } from './components/LocationPicker';
@@ -992,6 +992,7 @@ function AppContent({
   // Thumbs (Quick Find) state
   const [thumbsOpen, setThumbsOpen] = useState(false);
   const [thumbsText, setThumbsText] = useState('');
+  const [zoomModeBySessionId, setZoomModeBySessionId] = useState<Record<string, boolean>>({});
   const { message: copyMessage, showToast: showCopyToast, clearToast: clearCopyToast } = useCopyToast();
   const { message: errorMessage, showError, clearError } = useErrorToast();
   const activeReviewLoopState = useMemo(
@@ -1627,11 +1628,18 @@ function AppContent({
     toggleDockPanel,
   ]);
 
-  const sidebarFooterShortcuts = useMemo(() => (
+  const activeSessionZoomed = activeSessionId ? Boolean(zoomModeBySessionId[activeSessionId]) : false;
+
+  const sidebarFooterShortcuts = useMemo<FooterShortcut[]>(() => (
     activeSessionId
-      ? ['⌘D split v', '⌘⇧D split h', '⌘⌥←↑→↓ pane']
+      ? [
+          { label: '⌘D split v' },
+          { label: '⌘⇧D split h' },
+          { label: '⌘⇧Z zoom', active: activeSessionZoomed },
+          { label: '⌘⌥←↑→↓ pane' },
+        ]
       : []
-  ), [activeSessionId]);
+  ), [activeSessionId, activeSessionZoomed]);
 
   const handleStartReviewLoop = useCallback(async (prompt: string, iterationLimit: number, presetId?: string) => {
     if (!activeSessionId) return;
@@ -1816,6 +1824,13 @@ function AppContent({
                   }}
                   onFocusPane={(paneId) => {
                     setActivePane(session.id, paneId);
+                  }}
+                  onZoomModeChange={(zoomed) => {
+                    setZoomModeBySessionId((prev) => (
+                      prev[session.id] === zoomed
+                        ? prev
+                        : { ...prev, [session.id]: zoomed }
+                    ));
                   }}
                   onNavigateOutOfSession={handleNavigateOutOfSession}
                 />

--- a/app/src/components/SessionTerminalWorkspace.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace.test.tsx
@@ -1,9 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { forwardRef, useImperativeHandle } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SessionTerminalWorkspace } from './SessionTerminalWorkspace';
 import type { PaneRuntimeEventRouter } from './SessionTerminalWorkspace/paneRuntimeEventRouter';
-import { MAIN_TERMINAL_PANE_ID, createDefaultWorkspaceState } from '../types/workspace';
+import { MAIN_TERMINAL_PANE_ID, createDefaultWorkspaceState, type TerminalWorkspaceState } from '../types/workspace';
 
 const { registeredShortcuts } = vi.hoisted(() => ({
   registeredShortcuts: new Map<string, () => void>(),
@@ -269,6 +269,194 @@ describe('SessionTerminalWorkspace', () => {
     registeredShortcuts.get('terminal.focusRight')?.();
 
     expect(onNavigateOutOfSession).toHaveBeenCalledWith('right');
+  });
+
+  it('applies stored split ratios in the rendered layout', () => {
+    const { container } = render(
+      <SessionTerminalWorkspace
+        sessionId="session-1"
+        sessionLabel="Session 1"
+        sessionAgent="claude"
+        cwd="/tmp/repo"
+        workspace={{
+          terminals: [{ id: 'pane-shell-1', ptyId: 'runtime-shell-1', title: 'Shell 1' }],
+          layoutTree: {
+            type: 'split',
+            splitId: 'root',
+            direction: 'vertical',
+            ratio: 0.3,
+            children: [
+              { type: 'pane', paneId: MAIN_TERMINAL_PANE_ID },
+              { type: 'pane', paneId: 'pane-shell-1' },
+            ],
+          },
+        }}
+        activePaneId={MAIN_TERMINAL_PANE_ID}
+        fontSize={14}
+        enabled
+        isActiveSession
+        eventRouter={mockEventRouter}
+        getMainPaneSpawnArgs={vi.fn(() => null)}
+        onSplitPane={vi.fn()}
+        onClosePane={vi.fn()}
+        onFocusPane={vi.fn()}
+        onNavigateOutOfSession={vi.fn()}
+      />
+    );
+
+    const split = container.querySelector('[data-split-id="root"]');
+    const firstChild = container.querySelector('[data-split-id="root"] [data-split-child-index="0"]') as HTMLElement | null;
+    const secondChild = container.querySelector('[data-split-id="root"] [data-split-child-index="1"]') as HTMLElement | null;
+
+    expect(split).toHaveAttribute('data-split-ratio', '0.300');
+    expect(firstChild?.style.flexGrow).toBe('0.3');
+    expect(secondChild?.style.flexGrow).toBe('0.7');
+  });
+
+  it('lets zoom arm before splitting and applies once a split exists', () => {
+    const { container, rerender } = render(
+      <SessionTerminalWorkspace
+        sessionId="session-1"
+        sessionLabel="Session 1"
+        sessionAgent="claude"
+        cwd="/tmp/repo"
+        workspace={createDefaultWorkspaceState()}
+        activePaneId={MAIN_TERMINAL_PANE_ID}
+        fontSize={14}
+        enabled
+        isActiveSession
+        eventRouter={mockEventRouter}
+        getMainPaneSpawnArgs={vi.fn(() => null)}
+        onSplitPane={vi.fn()}
+        onClosePane={vi.fn()}
+        onFocusPane={vi.fn()}
+        onNavigateOutOfSession={vi.fn()}
+      />
+    );
+
+    act(() => {
+      registeredShortcuts.get('terminal.toggleZoom')?.();
+    });
+
+    expect(container.querySelector('[data-session-terminal-workspace="session-1"]')).toHaveAttribute('data-zoomed-pane-id', MAIN_TERMINAL_PANE_ID);
+    expect(container.querySelector('[data-split-id="root"]')).toBeNull();
+
+    rerender(
+      <SessionTerminalWorkspace
+        sessionId="session-1"
+        sessionLabel="Session 1"
+        sessionAgent="claude"
+        cwd="/tmp/repo"
+        workspace={{
+          terminals: [{ id: 'pane-shell-1', ptyId: 'runtime-shell-1', title: 'Shell 1' }],
+          layoutTree: {
+            type: 'split',
+            splitId: 'root',
+            direction: 'vertical',
+            ratio: 0.5,
+            children: [
+              { type: 'pane', paneId: MAIN_TERMINAL_PANE_ID },
+              { type: 'pane', paneId: 'pane-shell-1' },
+            ],
+          },
+        }}
+        activePaneId={MAIN_TERMINAL_PANE_ID}
+        fontSize={14}
+        enabled
+        isActiveSession
+        eventRouter={mockEventRouter}
+        getMainPaneSpawnArgs={vi.fn(() => null)}
+        onSplitPane={vi.fn()}
+        onClosePane={vi.fn()}
+        onFocusPane={vi.fn()}
+        onNavigateOutOfSession={vi.fn()}
+      />
+    );
+
+    expect(container.querySelector('[data-split-id="root"]')).toHaveAttribute('data-split-ratio', '0.760');
+  });
+
+  it('zooms the active pane across nested splits and retargets when focus changes', () => {
+    const workspace: TerminalWorkspaceState = {
+      terminals: [
+        { id: 'top-right', ptyId: 'runtime-top-right', title: 'Top Right' },
+        { id: 'bottom-right', ptyId: 'runtime-bottom-right', title: 'Bottom Right' },
+      ],
+      layoutTree: {
+        type: 'split' as const,
+        splitId: 'root',
+        direction: 'vertical' as const,
+        ratio: 0.5,
+        children: [
+          { type: 'pane' as const, paneId: MAIN_TERMINAL_PANE_ID },
+          {
+            type: 'split' as const,
+            splitId: 'right',
+            direction: 'horizontal' as const,
+            ratio: 0.5,
+            children: [
+              { type: 'pane' as const, paneId: 'top-right' },
+              { type: 'pane' as const, paneId: 'bottom-right' },
+            ] as const,
+          },
+        ] as const,
+      },
+    };
+
+    const { container, rerender } = render(
+      <SessionTerminalWorkspace
+        sessionId="session-1"
+        sessionLabel="Session 1"
+        sessionAgent="claude"
+        cwd="/tmp/repo"
+        workspace={workspace}
+        activePaneId="bottom-right"
+        fontSize={14}
+        enabled
+        isActiveSession
+        eventRouter={mockEventRouter}
+        getMainPaneSpawnArgs={vi.fn(() => null)}
+        onSplitPane={vi.fn()}
+        onClosePane={vi.fn()}
+        onFocusPane={vi.fn()}
+        onNavigateOutOfSession={vi.fn()}
+      />
+    );
+
+    expect(container.querySelector('[data-split-id="root"]')).toHaveAttribute('data-split-ratio', '0.500');
+    expect(container.querySelector('[data-split-id="right"]')).toHaveAttribute('data-split-ratio', '0.500');
+
+    act(() => {
+      registeredShortcuts.get('terminal.toggleZoom')?.();
+    });
+
+    expect(container.querySelector('[data-session-terminal-workspace="session-1"]')).toHaveAttribute('data-zoomed-pane-id', 'bottom-right');
+    expect(container.querySelector('[data-split-id="root"]')).toHaveAttribute('data-split-ratio', '0.240');
+    expect(container.querySelector('[data-split-id="right"]')).toHaveAttribute('data-split-ratio', '0.240');
+
+    rerender(
+      <SessionTerminalWorkspace
+        sessionId="session-1"
+        sessionLabel="Session 1"
+        sessionAgent="claude"
+        cwd="/tmp/repo"
+        workspace={workspace}
+        activePaneId={MAIN_TERMINAL_PANE_ID}
+        fontSize={14}
+        enabled
+        isActiveSession
+        eventRouter={mockEventRouter}
+        getMainPaneSpawnArgs={vi.fn(() => null)}
+        onSplitPane={vi.fn()}
+        onClosePane={vi.fn()}
+        onFocusPane={vi.fn()}
+        onNavigateOutOfSession={vi.fn()}
+      />
+    );
+
+    expect(container.querySelector('[data-session-terminal-workspace="session-1"]')).toHaveAttribute('data-zoomed-pane-id', MAIN_TERMINAL_PANE_ID);
+    expect(container.querySelector('[data-split-id="root"]')).toHaveAttribute('data-split-ratio', '0.760');
+    expect(container.querySelector('[data-split-id="right"]')).toHaveAttribute('data-split-ratio', '0.500');
   });
 
   it('re-fits the active pane when the workspace topology changes after closing a split', () => {

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -6,6 +6,10 @@
   background: var(--color-bg-editor);
 }
 
+.session-terminal-workspace.zoom-mode .workspace-pane:not(.active) {
+  opacity: 0.72;
+}
+
 .workspace-focus-bar {
   display: flex;
   align-items: center;
@@ -117,9 +121,19 @@
   flex-direction: column;
 }
 
-.workspace-split > .workspace-pane,
-.workspace-split > .workspace-split {
+.workspace-split-child {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
   flex: 1 1 0;
+  transition: flex-grow 160ms ease;
+}
+
+.workspace-split-child > .workspace-pane,
+.workspace-split-child > .workspace-split {
+  flex: 1 1 0;
+  width: 100%;
+  height: 100%;
 }
 
 .workspace-pane-header {

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -4,6 +4,7 @@ import { Terminal, type ResolvedTheme } from '../Terminal';
 import { useShortcut } from '../../shortcuts';
 import {
   MAIN_TERMINAL_PANE_ID,
+  hasPane,
   findPaneInDirection,
   type TerminalNavigationDirection,
   type TerminalLayoutNode,
@@ -16,6 +17,41 @@ import { usePaneRuntimeBinder } from './usePaneRuntimeBinder';
 import type { PaneRuntimeEventRouter } from './paneRuntimeEventRouter';
 import { activeElementSummary, recordPaneRuntimeDebugEvent } from '../../utils/paneRuntimeDebug';
 import './SessionTerminalWorkspace.css';
+
+const ZOOM_PATH_RATIO = 0.76;
+
+function clampSplitRatio(ratio: number): number {
+  if (ratio > 0 && ratio < 1) {
+    return ratio;
+  }
+  return 0.5;
+}
+
+function zoomLayoutTowardPane(node: TerminalLayoutNode, paneId: string): TerminalLayoutNode {
+  if (node.type === 'pane') {
+    return node;
+  }
+
+  const firstContainsPane = hasPane(node.children[0], paneId);
+  const secondContainsPane = hasPane(node.children[1], paneId);
+  const nextChildren: [TerminalLayoutNode, TerminalLayoutNode] = [
+    zoomLayoutTowardPane(node.children[0], paneId),
+    zoomLayoutTowardPane(node.children[1], paneId),
+  ];
+
+  if (!firstContainsPane && !secondContainsPane) {
+    return {
+      ...node,
+      children: nextChildren,
+    };
+  }
+
+  return {
+    ...node,
+    ratio: firstContainsPane ? ZOOM_PATH_RATIO : 1 - ZOOM_PATH_RATIO,
+    children: nextChildren,
+  };
+}
 
 export interface SessionTerminalWorkspaceHandle {
   fitPane: (paneId: string) => void;
@@ -45,6 +81,7 @@ interface SessionTerminalWorkspaceProps {
   onSplitPane: (targetPaneId: string, direction: TerminalSplitDirection) => void;
   onClosePane: (paneId: string) => void;
   onFocusPane: (paneId: string) => void;
+  onZoomModeChange?: (zoomed: boolean) => void;
   onNavigateOutOfSession: (direction: TerminalNavigationDirection) => void;
 }
 
@@ -66,9 +103,11 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     onSplitPane,
     onClosePane,
     onFocusPane,
+    onZoomModeChange,
     onNavigateOutOfSession,
   }, ref) {
     const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null);
+    const [zoomedPaneId, setZoomedPaneId] = useState<string | null>(null);
     const activePaneIdRef = useRef(activePaneId);
     const isActiveSessionRef = useRef(isActiveSession);
 
@@ -114,10 +153,22 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     const splitLayoutActive = workspace.layoutTree.type === 'split';
     const showMainHeader = paneIds.length > 1;
     const effectivePaneId = maximizedPaneId && paneIds.includes(maximizedPaneId) ? maximizedPaneId : null;
+    const effectiveZoomedPaneId = zoomedPaneId && paneIds.includes(zoomedPaneId) ? zoomedPaneId : null;
+    const renderedLayoutTree = useMemo(() => {
+      if (effectivePaneId) {
+        return { type: 'pane', paneId: effectivePaneId } satisfies TerminalLayoutNode;
+      }
+      if (!effectiveZoomedPaneId) {
+        return workspace.layoutTree;
+      }
+      return zoomLayoutTowardPane(workspace.layoutTree, effectiveZoomedPaneId);
+    }, [effectivePaneId, effectiveZoomedPaneId, workspace.layoutTree]);
     const workspaceTopologyKey = JSON.stringify({
-      layoutTree: workspace.layoutTree,
+      layoutTree: renderedLayoutTree,
       terminalIds: workspace.terminals.map((terminal) => terminal.id),
       activePaneId,
+      effectivePaneId,
+      effectiveZoomedPaneId,
     });
 
     useImperativeHandle(ref, () => ({
@@ -139,6 +190,28 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         setMaximizedPaneId(null);
       }
     }, [maximizedPaneId, paneIds]);
+
+    useEffect(() => {
+      if (!zoomedPaneId) {
+        return;
+      }
+      if (!paneIds.includes(zoomedPaneId)) {
+        setZoomedPaneId(null);
+      }
+    }, [paneIds, zoomedPaneId]);
+
+    useEffect(() => {
+      if (!effectiveZoomedPaneId || effectivePaneId) {
+        return;
+      }
+      if (effectiveZoomedPaneId !== activePaneId) {
+        setZoomedPaneId(activePaneId);
+      }
+    }, [activePaneId, effectivePaneId, effectiveZoomedPaneId]);
+
+    useEffect(() => {
+      onZoomModeChange?.(Boolean(effectiveZoomedPaneId));
+    }, [effectiveZoomedPaneId, onZoomModeChange]);
 
     const focusActivePane = useCallback(() => {
       binder.focusPaneWithRetry(activePaneId, 40);
@@ -201,13 +274,19 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     }, [activePaneId, handleCloseTerminal]);
 
     const toggleMaximizeActivePane = useCallback(() => {
+      setZoomedPaneId(null);
       setMaximizedPaneId((current) => (current ? null : activePaneId));
+    }, [activePaneId]);
+
+    const toggleZoomActivePane = useCallback(() => {
+      setMaximizedPaneId(null);
+      setZoomedPaneId((current) => (current === activePaneId ? null : activePaneId));
     }, [activePaneId]);
 
     const handleMovePane = useCallback((direction: TerminalNavigationDirection) => {
       const visibleLayout: TerminalLayoutNode = effectivePaneId
         ? { type: 'pane', paneId: effectivePaneId }
-        : workspace.layoutTree;
+        : renderedLayoutTree;
       const nextPaneId = findPaneInDirection(visibleLayout, activePaneId, direction);
       if (nextPaneId) {
         recordPaneRuntimeDebugEvent({
@@ -229,7 +308,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         details: { direction },
       });
       onNavigateOutOfSession(direction);
-    }, [activePaneId, binder, effectivePaneId, onFocusPane, onNavigateOutOfSession, sessionId, workspace.layoutTree]);
+    }, [activePaneId, binder, effectivePaneId, onFocusPane, onNavigateOutOfSession, renderedLayoutTree, sessionId]);
 
     const handleMainPaneMouseDown = useCallback(() => {
       recordPaneRuntimeDebugEvent({
@@ -283,6 +362,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     useShortcut('terminal.new', () => { void handleNewTerminal(); }, enabled && isActiveSession);
     useShortcut('terminal.splitVertical', () => { handleSplit('vertical'); }, enabled && isActiveSession);
     useShortcut('terminal.splitHorizontal', () => { handleSplit('horizontal'); }, enabled && isActiveSession);
+    useShortcut('terminal.toggleZoom', toggleZoomActivePane, enabled && isActiveSession);
     useShortcut('terminal.toggleMaximize', toggleMaximizeActivePane, enabled && isActiveSession);
     useShortcut('terminal.close', handleCloseActiveTerminal, enabled && isActiveSession && splitLayoutActive);
     useShortcut('terminal.focusLeft', () => handleMovePane('left'), enabled && isActiveSession);
@@ -292,10 +372,30 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
 
     const renderPane = useCallback((node: TerminalLayoutNode): React.ReactNode => {
       if (node.type === 'split') {
+        const firstRatio = clampSplitRatio(node.ratio);
+        const secondRatio = clampSplitRatio(1 - firstRatio);
         return (
-          <div key={node.splitId} className={`workspace-split split-${node.direction}`}>
-            {renderPane(node.children[0])}
-            {renderPane(node.children[1])}
+          <div
+            key={node.splitId}
+            className={`workspace-split split-${node.direction}`}
+            data-split-id={node.splitId}
+            data-split-direction={node.direction}
+            data-split-ratio={firstRatio.toFixed(3)}
+          >
+            <div
+              className="workspace-split-child"
+              data-split-child-index="0"
+              style={{ flexGrow: firstRatio }}
+            >
+              {renderPane(node.children[0])}
+            </div>
+            <div
+              className="workspace-split-child"
+              data-split-child-index="1"
+              style={{ flexGrow: secondRatio }}
+            >
+              {renderPane(node.children[1])}
+            </div>
           </div>
         );
       }
@@ -399,8 +499,9 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
 
     return (
       <div
-        className={`session-terminal-workspace ${effectivePaneId ? 'focus-mode' : ''}`}
+        className={`session-terminal-workspace ${effectivePaneId ? 'focus-mode' : ''} ${effectiveZoomedPaneId && !effectivePaneId ? 'zoom-mode' : ''}`.trim()}
         data-session-terminal-workspace={sessionId}
+        data-zoomed-pane-id={effectiveZoomedPaneId || ''}
       >
         {effectivePaneId && (
           <div className="workspace-focus-bar">
@@ -419,7 +520,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
           </div>
         )}
         <div className="session-terminal-panes">
-          {renderPane(effectivePaneId ? { type: 'pane', paneId: effectivePaneId } : workspace.layoutTree)}
+          {renderPane(renderedLayoutTree)}
         </div>
       </div>
     );

--- a/app/src/components/SessionTerminalWorkspace/usePaneRuntimeBinder.test.ts
+++ b/app/src/components/SessionTerminalWorkspace/usePaneRuntimeBinder.test.ts
@@ -82,6 +82,17 @@ describe('installTerminalKeyHandler', () => {
     expect(mockTriggerShortcut).not.toHaveBeenCalled();
     expect(sendToPty).not.toHaveBeenCalled();
   });
+
+  it('routes cmd+shift+z to the zoom shortcut', () => {
+    const sendToPty = vi.fn();
+    const handler = installTerminalKeyHandler(sendToPty);
+    const event = new KeyboardEvent('keydown', { key: 'z', metaKey: true, shiftKey: true });
+
+    handler(event);
+
+    expect(mockTriggerShortcut).toHaveBeenCalledWith('terminal.toggleZoom');
+    expect(sendToPty).not.toHaveBeenCalled();
+  });
 });
 
 describe('usePaneRuntimeBinder', () => {

--- a/app/src/components/SessionTerminalWorkspace/usePaneRuntimeBinder.ts
+++ b/app/src/components/SessionTerminalWorkspace/usePaneRuntimeBinder.ts
@@ -101,6 +101,9 @@ export function installTerminalKeyHandler(sendToPty: (data: string) => void) {
       if (ev.shiftKey && ev.key.toLowerCase() === 'd') {
         return !triggerShortcut('terminal.splitHorizontal');
       }
+      if (ev.shiftKey && ev.key.toLowerCase() === 'z') {
+        return !triggerShortcut('terminal.toggleZoom');
+      }
       if (ev.shiftKey && ev.key === 'Enter') {
         return !triggerShortcut('terminal.toggleMaximize');
       }

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -427,6 +427,14 @@
   font-family: 'JetBrains Mono', monospace;
 }
 
+.shortcut-hint.active {
+  color: var(--color-text-primary);
+  background: rgba(255, 107, 53, 0.12);
+  border: 1px solid rgba(255, 107, 53, 0.35);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
 /* Collapse button */
 .collapse-btn {
   background: transparent;

--- a/app/src/components/Sidebar.test.tsx
+++ b/app/src/components/Sidebar.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import { Sidebar } from './Sidebar';
+import { Sidebar, type FooterShortcut } from './Sidebar';
 import { getVisualSessionOrder, groupSessionsByDirectory } from '../utils/sessionGrouping';
 
 interface TestSession {
@@ -28,7 +28,7 @@ const baseProps = {
   selectedId: null,
   collapsed: false,
   headerActions: [],
-  footerShortcuts: undefined,
+  footerShortcuts: undefined as FooterShortcut[] | undefined,
   onSelectSession: () => {},
   onNewSession: () => {},
   onCloseSession: () => {},
@@ -141,7 +141,12 @@ describe('Sidebar', () => {
           onClick: () => {},
           icon: null,
         }]}
-        footerShortcuts={['⌘D split v', '⌘⇧D split h', '⌘⌥←↑→↓ pane']}
+        footerShortcuts={[
+          { label: '⌘D split v' },
+          { label: '⌘⇧D split h' },
+          { label: '⌘⇧Z zoom', active: true },
+          { label: '⌘⌥←↑→↓ pane' },
+        ]}
         {...buildSidebarData([])}
       />
     );
@@ -149,6 +154,8 @@ describe('Sidebar', () => {
     expect(screen.getByText('⌘⇧G diff')).toBeInTheDocument();
     expect(screen.getByText('⌘D split v')).toBeInTheDocument();
     expect(screen.getByText('⌘⇧D split h')).toBeInTheDocument();
+    expect(screen.getByText('⌘⇧Z zoom')).toBeInTheDocument();
+    expect(screen.getByText('⌘⇧Z zoom')).toHaveAttribute('data-active', 'true');
     expect(screen.getByText('⌘⌥←↑→↓ pane')).toBeInTheDocument();
     expect(screen.getByText('⌘⇧B sidebar')).toBeInTheDocument();
   });

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -40,7 +40,7 @@ interface SidebarProps {
   selectedId: string | null;
   collapsed: boolean;
   headerActions: SidebarHeaderAction[];
-  footerShortcuts?: string[];
+  footerShortcuts?: FooterShortcut[];
   onSelectSession: (id: string) => void;
   onNewSession: () => void;
   onCloseSession: (id: string) => void;
@@ -59,6 +59,11 @@ export interface SidebarHeaderAction {
   badge?: string | number;
   shortcutHint?: string;
   onClick: () => void;
+}
+
+export interface FooterShortcut {
+  label: string;
+  active?: boolean;
 }
 
 function HomeIcon() {
@@ -149,12 +154,12 @@ export function Sidebar({
   onToggleCollapse,
 }: SidebarProps) {
   const visualIndexOf = (id: string) => visualIndexBySessionId.get(id) ?? -1;
-  const dockShortcutHints = Array.from(new Set([
+  const dockShortcutHints = Array.from(new Map([
     ...headerActions
       .filter((action) => action.shortcutHint && !action.disabled)
-      .map((action) => action.shortcutHint as string),
-    ...(footerShortcuts ?? []),
-  ]));
+      .map((action) => [action.shortcutHint as string, { label: action.shortcutHint as string, active: false }] as const),
+    ...(footerShortcuts ?? []).map((shortcut) => [shortcut.label, shortcut] as const),
+  ]).values());
 
   if (collapsed) {
     return (
@@ -372,8 +377,14 @@ export function Sidebar({
 
       <div className="sidebar-footer">
         <span className="sidebar-footer-label">Dock</span>
-        {dockShortcutHints.map((shortcutHint) => (
-          <span key={shortcutHint} className="shortcut-hint">{shortcutHint}</span>
+        {dockShortcutHints.map((shortcut) => (
+          <span
+            key={shortcut.label}
+            className={`shortcut-hint ${shortcut.active ? 'active' : ''}`.trim()}
+            data-active={shortcut.active ? 'true' : 'false'}
+          >
+            {shortcut.label}
+          </span>
         ))}
         <span className="shortcut-hint">⌘⇧B sidebar</span>
       </div>

--- a/app/src/shortcuts/registry.test.ts
+++ b/app/src/shortcuts/registry.test.ts
@@ -187,6 +187,7 @@ describe('shortcut registry', () => {
       expect(SHORTCUTS['terminal.new']).toEqual({ key: 't', meta: true });
       expect(SHORTCUTS['terminal.splitVertical']).toEqual({ key: 'd', meta: true });
       expect(SHORTCUTS['terminal.splitHorizontal']).toEqual({ key: 'd', meta: true, shift: true });
+      expect(SHORTCUTS['terminal.toggleZoom']).toEqual({ key: 'z', meta: true, shift: true });
       expect(SHORTCUTS['terminal.toggleMaximize']).toEqual({ key: 'Enter', meta: true, shift: true });
       expect(SHORTCUTS['terminal.close']).toEqual({ key: 'w', meta: true });
       expect(SHORTCUTS['terminal.focusLeft']).toEqual({ key: 'ArrowLeft', meta: true, alt: true });

--- a/app/src/shortcuts/registry.ts
+++ b/app/src/shortcuts/registry.ts
@@ -50,6 +50,7 @@ export const SHORTCUTS = {
   'terminal.new': { key: 't', meta: true },
   'terminal.splitVertical': { key: 'd', meta: true },
   'terminal.splitHorizontal': { key: 'd', meta: true, shift: true },
+  'terminal.toggleZoom': { key: 'z', meta: true, shift: true },
   'terminal.toggleMaximize': { key: 'Enter', meta: true, shift: true },
   'terminal.close': { key: 'w', meta: true },
   'terminal.focusLeft': { key: 'ArrowLeft', meta: true, alt: true },

--- a/app/src/store/sessions.ts
+++ b/app/src/store/sessions.ts
@@ -80,6 +80,7 @@ declare global {
   interface Window {
     __TEST_INJECT_SESSION?: (session: TestSession) => void;
     __TEST_UPDATE_SESSION_STATE?: (id: string, state: UISessionState) => void;
+    __TEST_SET_SESSION_WORKSPACE?: (sessionId: string, workspace: TerminalWorkspaceState, daemonActivePaneId?: string) => void;
   }
 }
 
@@ -355,6 +356,16 @@ if (import.meta.env.DEV) {
     useSessionStore.setState((s) => ({
       sessions: s.sessions.map((session) =>
         session.id === id ? { ...session, state } : session
+      ),
+    }));
+  };
+
+  window.__TEST_SET_SESSION_WORKSPACE = (sessionId: string, workspace: TerminalWorkspaceState, daemonActivePaneId = MAIN_TERMINAL_PANE_ID) => {
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === sessionId
+          ? { ...session, workspace, daemonActivePaneId }
+          : session
       ),
     }));
   };


### PR DESCRIPTION
## Summary
- add `Cmd+Shift+Z` zoom mode for terminal panes without hiding surrounding panes
- let zoom be armed before a split exists and keep the sidebar shortcut hint visibly active while zoom is on
- cover the behavior with workspace/unit tests and a Playwright shortcut test

## Testing
- pnpm exec tsc --noEmit
- pnpm exec vitest run src/components/SessionTerminalWorkspace.test.tsx src/components/SessionTerminalWorkspace/usePaneRuntimeBinder.test.ts src/shortcuts/registry.test.ts src/components/Sidebar.test.tsx
- pnpm exec playwright test e2e/keyboard-shortcuts.spec.ts -g "⌘⇧Z zooms toward the active pane without hiding the others"
- git commit hook: go test ./...