### PR TITLE
fix: re-fit only moved panes after split close and remove ad-hoc codesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-03-15]
+
+### Removed
+- **Ad-hoc code signing**: Remove `codesign -s -` from `make install` and always strip the bundled sidecar signature in app builds. Quarantine removal (`xattr -d`) is still applied.
+
 ## [2026-03-14]
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,9 @@ install: build
 	@# Use cat to avoid copying extended attributes that trigger Gatekeeper
 	cat $(BINARY_NAME) > $(INSTALL_DIR)/$(BINARY_NAME)
 	chmod +x $(INSTALL_DIR)/$(BINARY_NAME)
-	@# macOS: remove quarantine attribute and ad-hoc sign binary
+	@# macOS: remove quarantine attribute
 	@if [ "$(UNAME_S)" = "Darwin" ]; then \
 		xattr -d com.apple.quarantine $(INSTALL_DIR)/$(BINARY_NAME) 2>/dev/null || true; \
-		codesign -s - -f $(INSTALL_DIR)/$(BINARY_NAME); \
-	else \
-		echo "Skipping macOS quarantine removal and codesign on $(UNAME_S)"; \
 	fi
 	@# Kill running daemon and restart with new local code.
 	-pkill -f "$(BINARY_NAME) daemon" 2>/dev/null || true
@@ -98,11 +95,17 @@ build-app: build
 	@mkdir -p app/src-tauri/binaries
 	cp $(BINARY_NAME) app/src-tauri/binaries/$(BINARY_NAME)-aarch64-apple-darwin
 	cd app && VITE_INSTALL_CHANNEL=source pnpm tauri build --bundles app
+	@if [ "$(UNAME_S)" = "Darwin" ]; then \
+		codesign --remove-signature app/src-tauri/target/release/bundle/macos/attn.app/Contents/MacOS/attn 2>/dev/null || true; \
+	fi
 
 build-app-ui-automation: build
 	@mkdir -p app/src-tauri/binaries
 	cp $(BINARY_NAME) app/src-tauri/binaries/$(BINARY_NAME)-aarch64-apple-darwin
 	cd app && ATTN_UI_AUTOMATION=1 VITE_UI_AUTOMATION=1 VITE_INSTALL_CHANNEL=source pnpm tauri build --bundles app
+	@if [ "$(UNAME_S)" = "Darwin" ]; then \
+		codesign --remove-signature app/src-tauri/target/release/bundle/macos/attn.app/Contents/MacOS/attn 2>/dev/null || true; \
+	fi
 
 # Install Tauri app to /Applications
 install-app: build-app

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -171,6 +171,22 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       effectiveZoomedPaneId,
     });
 
+    // Track each pane's tree path so we can detect which panes moved after a topology change.
+    const panePaths = useMemo(() => {
+      const paths = new Map<string, string>();
+      const walk = (node: TerminalLayoutNode, path: string) => {
+        if (node.type === 'pane') {
+          paths.set(node.paneId, path);
+          return;
+        }
+        walk(node.children[0], path + '/0');
+        walk(node.children[1], path + '/1');
+      };
+      walk(renderedLayoutTree, '');
+      return paths;
+    }, [renderedLayoutTree]);
+    const prevPanePathsRef = useRef(panePaths);
+
     useImperativeHandle(ref, () => ({
       fitPane: binder.fitPane,
       fitActivePane: binder.fitActivePane,
@@ -238,21 +254,37 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
 
     useEffect(() => {
       if (!isActiveSession || !enabled) {
+        prevPanePathsRef.current = panePaths;
         return;
       }
-      // Closing a split can leave the surviving main terminal visually stale until
-      // a later resize. Re-fit after the topology change commits to flush xterm's renderer.
+      // Find panes whose tree position changed — only those need re-fitting
+      // after a topology change (e.g. closing a split sibling).
+      const prev = prevPanePathsRef.current;
+      prevPanePathsRef.current = panePaths;
+      const movedPanes: string[] = [];
+      for (const [paneId, path] of panePaths) {
+        if (prev.get(paneId) !== path) {
+          movedPanes.push(paneId);
+        }
+      }
+      if (movedPanes.length === 0) {
+        return;
+      }
       const fitSoon = window.setTimeout(() => {
-        fitPane(activePaneId);
+        for (const paneId of movedPanes) {
+          fitPane(paneId);
+        }
       }, 0);
       const fitAfterLayoutSettles = window.setTimeout(() => {
-        fitPane(activePaneId);
+        for (const paneId of movedPanes) {
+          fitPane(paneId);
+        }
       }, 75);
       return () => {
         window.clearTimeout(fitSoon);
         window.clearTimeout(fitAfterLayoutSettles);
       };
-    }, [activePaneId, enabled, fitPane, isActiveSession, workspaceTopologyKey]);
+    }, [activePaneId, enabled, fitPane, isActiveSession, panePaths, workspaceTopologyKey]);
 
     const handleSplit = useCallback((direction: TerminalSplitDirection) => {
       onSplitPane(activePaneId, direction);


### PR DESCRIPTION
## Summary
- **Split-close resize fix**: After closing a split pane, TUI apps like vim in surviving terminals didn't notice the viewport change. Now we track each pane's tree path and re-fit only panes whose position changed (e.g. B moves from `/1/0` to `/1` when closing C from `A | B/C`). Unaffected panes (A) are left alone to avoid unnecessary SIGWINCH flicker.
- **Remove ad-hoc code signing**: `make install` no longer runs `codesign -s -` on the daemon binary. App builds always strip the bundled sidecar signature. Quarantine removal (`xattr -d`) is still applied.

## Test plan
- [ ] Open shell pane, run `vim`, split (`Cmd+D`), close split (`Cmd+W`) — vim should resize to full width
- [ ] `A | B/C` layout: close C — B resizes, A does not flicker
- [ ] `make install` succeeds without codesign errors
- [ ] `make install-app` succeeds, app launches