### PR TITLE
fix: ensure attn is in PATH for cask-only installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-03-16]
+
+### Fixed
+- **`attn` in PATH for cask-only installs**: Prepend the wrapper binary's directory to PATH when spawning agent sessions so Claude Code skills can find `attn` as a bare command even when installed only via the Homebrew cask.
+
 ## [2026-03-15]
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It's a desktop app that wraps your agent CLIs â€” Claude Code, Codex, Copilot â€
 
 ```bash
 brew tap victorarias/attn https://github.com/victorarias/attn
-brew install --cask --no-quarantine victorarias/attn/attn
+brew install --cask victorarias/attn/attn
 ```
 
 This installs `attn.app` (with bundled daemon/runtime binary). It does not add `attn` to your shell `PATH`.

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -421,6 +421,12 @@ func buildSpawnEnv(loginShell string, opts SpawnOptions, agent, wrapperPath stri
 		})
 		if wrapperPath != "" {
 			env = mergeEnvironment(env, []string{"ATTN_WRAPPER_PATH=" + wrapperPath})
+			// Ensure the directory containing attn is in PATH so that
+			// tools (e.g. Claude Code skills) can find it as a bare command
+			// even when installed only inside the .app bundle.
+			if dir := filepath.Dir(wrapperPath); dir != "" && dir != "." {
+				env = prependPath(env, dir)
+			}
 		}
 
 		executable := configuredExecutableForAgent(opts, agent)
@@ -524,6 +530,24 @@ func mergeEnvironment(base, overlay []string) []string {
 		add(entry)
 	}
 	return merged
+}
+
+// prependPath adds dir to the front of the PATH variable in env,
+// avoiding duplicates.
+func prependPath(env []string, dir string) []string {
+	for i, entry := range env {
+		if strings.HasPrefix(entry, "PATH=") {
+			existing := entry[5:]
+			for _, p := range strings.Split(existing, string(os.PathListSeparator)) {
+				if p == dir {
+					return env // already present
+				}
+			}
+			env[i] = "PATH=" + dir + string(os.PathListSeparator) + existing
+			return env
+		}
+	}
+	return append(env, "PATH="+dir)
 }
 
 func filterEnvKeys(env []string, keys ...string) []string {


### PR DESCRIPTION
## Summary
- **PATH for cask installs**: When `attn` is installed only via the Homebrew cask, the binary lives inside `/Applications/attn.app/Contents/MacOS/` which isn't on PATH. Claude Code skills that invoke `attn` as a bare command fail. Now the wrapper binary's directory is prepended to PATH when spawning agent sessions.
- **README**: Remove deprecated `--no-quarantine` flag from cask install instructions (Homebrew dropped support for it).

## Test plan
- [ ] Install via cask only (no formula), open attn, start a Claude session — verify the attn skill can find the `attn` binary
- [ ] `echo $PATH` in a Claude session should include the attn binary's directory