### PR TITLE
release: v0.5.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.4.0"
+version = "0.5.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "attn",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "com.attn.manager",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## What changed
- bump the packaged app version from `0.4.0` to `0.5.0`
- refresh the generated lockfiles touched by the release script

## Why
- `main` has accumulated substantial user-visible work since `v0.4.0`, including new remote-daemon, mobile web terminal, release artifact, and packaged-app validation work
- the repo now blocks direct pushes to `main`, so the documented `scripts/release.sh` flow cannot publish the release commit directly; this PR preserves the intended release bump through the protected-branch path

## Impact
- once merged, `main` will carry the `0.5.0` app version in the release-versioned files
- the release tag and Homebrew formula update should be performed after merge from the updated `main`

## Validation
- `go test ./...`
- `cd app && pnpm run build`
- `cd app && pnpm test`
