### PR TITLE
homebrew: update formula for v0.5.0

### DIFF
--- a/Formula/attn.rb
+++ b/Formula/attn.rb
@@ -1,9 +1,9 @@
 class Attn < Formula
   desc "Desktop orchestrator and CLI wrapper for Claude Code and Codex sessions"
   homepage "https://github.com/victorarias/attn"
-  url "https://github.com/victorarias/attn/archive/refs/tags/v0.4.0.tar.gz"
-  sha256 "5ea144d2c89a94bcbf1325754aadaf9776e489891cbc59705e525f46b45d6e80"
-  version "0.4.0"
+  url "https://github.com/victorarias/attn/archive/refs/tags/v0.5.0.tar.gz"
+  sha256 "450cfa15ee1ed869d9cdac3e0ccd1ba8403f14a8b587a8c9afefc7b18b3fb9dc"
+  version "0.5.0"
   license "GPL-3.0-only"
 
   depends_on "go" => :build

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -34,7 +34,7 @@ class Attn < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(output: bin/"attn", ldflags: "-X main.version=#{version}"), "./cmd/attn"
+    system "go", "build", *std_go_args(output: bin/"attn", ldflags: "-X github.com/victorarias/attn/internal/buildinfo.Version=#{version}"), "./cmd/attn"
   end
 
   test do


### PR DESCRIPTION
## What changed
- update `Formula/attn.rb` to point at the published `v0.5.0` source tarball and SHA
- fix `scripts/update-homebrew-formula.sh` to keep using the current `internal/buildinfo.Version` ldflags target when regenerating the formula

## Why
- the release tag `v0.5.0` is now published and the formula needs to match it
- the helper script had drifted back to the legacy `main.version` ldflags target, while the repository formula had already moved to `internal/buildinfo.Version`

## Impact
- Homebrew source installs will target `v0.5.0`
- future formula refreshes produced by the helper will preserve the current build-info injection path

## Validation
- `./scripts/update-homebrew-formula.sh v0.5.0`
- `ruby -c Formula/attn.rb`
- commit hook: `go test ./...`
