### PR TITLE
release: v0.6.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.5.0"
+version = "0.6.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "attn",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.attn.manager",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
Release v0.6.0

This bumps the app/runtime version from 0.5.0 to 0.6.0 after merging the app-owned daemon lifecycle and install-surface simplification work in #122.

Validation already ran via ./scripts/release.sh v0.6.0 before opening this PR:
- go test ./...
- cd app && pnpm run build
- cd app && pnpm test

After merge, push the local tag v0.6.0 to trigger the Release workflow.