### PR TITLE
fix: prevent viewport shift when closing location picker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,40 @@ DEBUG=debug attn -s test
 - do not use `log.Printf()` for daemon logging because stderr is discarded in background mode
 - use prefixed `console.log/warn/error` in frontend code and inspect via Tauri DevTools
 
+### Frontend Instrumentation (disk-based)
+
+For hard-to-reproduce UI bugs (viewport shifts, race conditions, layout glitches), prefer **disk-based instrumentation** over `console.log`. This lets the agent read the log file directly without needing browser DevTools access.
+
+Pattern: use Tauri's `writeTextFile` to append JSONL to `$APPLOCALDATA/debug/<name>.jsonl`. See `app/src/utils/paneRuntimeDebug.ts` and `app/src/utils/terminalRuntimeLog.ts` for the canonical pattern.
+
+Quick approach for temporary investigation:
+
+```typescript
+// app/src/utils/viewportDebug.ts (example)
+import { isTauri } from '@tauri-apps/api/core';
+
+let chain: Promise<void> = Promise.resolve();
+
+export function vpLog(event: string, details?: Record<string, unknown>) {
+  const entry = { at: new Date().toISOString(), event, ...details };
+  chain = chain.catch(() => {}).then(async () => {
+    if (!isTauri()) return;
+    const { mkdir, writeTextFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+    await mkdir('debug', { baseDir: BaseDirectory.AppLocalData, recursive: true });
+    await writeTextFile('debug/<name>.jsonl', JSON.stringify(entry) + '\n', {
+      baseDir: BaseDirectory.AppLocalData, append: true, create: true,
+    });
+  });
+}
+```
+
+Read the log: `cat ~/Library/Application\ Support/com.attn.manager/debug/<name>.jsonl`
+
+Rules:
+- Always write to disk, not just console — agents can't read DevTools
+- Use JSONL format (one JSON object per line) so the file is easy to parse
+- Remove temporary instrumentation files once the bug is resolved
+
 ## Architecture Snapshot
 
 - `cmd/attn`: CLI wrapper that launches agents, registers sessions, and wires hooks/settings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,37 +63,7 @@ DEBUG=debug attn -s test
 
 ### Frontend Instrumentation (disk-based)
 
-For hard-to-reproduce UI bugs (viewport shifts, race conditions, layout glitches), prefer **disk-based instrumentation** over `console.log`. This lets the agent read the log file directly without needing browser DevTools access.
-
-Pattern: use Tauri's `writeTextFile` to append JSONL to `$APPLOCALDATA/debug/<name>.jsonl`. See `app/src/utils/paneRuntimeDebug.ts` and `app/src/utils/terminalRuntimeLog.ts` for the canonical pattern.
-
-Quick approach for temporary investigation:
-
-```typescript
-// app/src/utils/viewportDebug.ts (example)
-import { isTauri } from '@tauri-apps/api/core';
-
-let chain: Promise<void> = Promise.resolve();
-
-export function vpLog(event: string, details?: Record<string, unknown>) {
-  const entry = { at: new Date().toISOString(), event, ...details };
-  chain = chain.catch(() => {}).then(async () => {
-    if (!isTauri()) return;
-    const { mkdir, writeTextFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
-    await mkdir('debug', { baseDir: BaseDirectory.AppLocalData, recursive: true });
-    await writeTextFile('debug/<name>.jsonl', JSON.stringify(entry) + '\n', {
-      baseDir: BaseDirectory.AppLocalData, append: true, create: true,
-    });
-  });
-}
-```
-
-Read the log: `cat ~/Library/Application\ Support/com.attn.manager/debug/<name>.jsonl`
-
-Rules:
-- Always write to disk, not just console — agents can't read DevTools
-- Use JSONL format (one JSON object per line) so the file is easy to parse
-- Remove temporary instrumentation files once the bug is resolved
+For hard-to-reproduce UI bugs, prefer disk-based JSONL logs over `console.log` — agents can read files but not DevTools. Write to `$APPLOCALDATA/debug/<name>.jsonl` using Tauri's `writeTextFile`. See `app/src/utils/paneRuntimeDebug.ts` and `app/src/utils/terminalRuntimeLog.ts` for the pattern. Remove temporary instrumentation once the bug is resolved.
 
 ## Architecture Snapshot
 

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -126,6 +126,7 @@ html, body, #root {
   display: flex;
   background: var(--color-bg-app);
   position: relative;
+  overflow: clip;
 }
 
 /* Custom scrollbar styling */

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -996,8 +996,6 @@ sendFetchPRDetails,
   // Location picker state management
   const [locationPickerOpen, setLocationPickerOpen] = useState(false);
 
-  
-
   // Thumbs (Quick Find) state
   const [thumbsOpen, setThumbsOpen] = useState(false);
   const [thumbsText, setThumbsText] = useState('');


### PR DESCRIPTION
## Summary

- `scrollIntoView({ block: 'nearest' })` calls inside the location picker bubble past the `position:fixed` overlay and scroll `.app` horizontally. The overlay masks this while open; dismissing it reveals the shifted layout.
- `overflow: clip` on `.app` prevents all ancestor scrolling — unlike `overflow: hidden`, WebKit respects `clip` for `scrollIntoView` ancestor walks.
- Documents disk-based frontend instrumentation pattern in AGENTS.md for future hard-to-reproduce UI bug investigations.

## Root cause

The location picker uses `scrollIntoView({ block: 'nearest' })` in `LocationPicker.tsx` and `RepoOptions.tsx` to keep the selected item visible. In WebKit (Tauri's macOS webview), this scrolls all scrollable ancestors — including `.app`, which had no overflow constraint. The `position: fixed` overlay masked the scroll. Pressing Escape removed the overlay, revealing `.app` scrolled 882px to the left.

Diagnosed via disk-based DOM instrumentation (JSONL written to `$APPLOCALDATA/debug/`) that captured element bounding rects at three timestamps after picker close: immediately, +1 frame, and +100ms.

## Test plan

- [ ] Open app → create session → close session → open location picker → press Escape → verify no viewport shift
- [ ] Navigate items in location picker with arrow keys → press Escape → verify no shift
- [ ] Enter repo options view → press Escape → verify no shift
- [ ] Normal location picker usage (select path, create session) still works