### PR TITLE
Connect-first bootstrap + version/binary mismatch sync UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-04-12]
 
+### Fixed
+- **Remote Endpoint Sync Detection**: When connecting to a remote daemon built by a different machine, the home screen now shows a warning banner with a Sync button instead of silently connecting. Clicking Sync reinstalls the remote binary from your local build and restarts the daemon. The endpoint is shown as unavailable (greyed out in the location picker) until synced.
+- **Remote Endpoint Bootstrap Loop**: Reconnecting to a remote endpoint after a clean disconnect no longer re-bootstraps the daemon binary. Bootstrap now runs only on the first connection attempt per loop lifetime, or when the daemon is actually unreachable — eliminating the ping-pong between two machines sharing the same remote daemon.
+- **Protocol Version Mismatch Banner**: Connecting to a remote daemon running a different protocol version surfaces the same Sync banner instead of auto-reinstalling. A "version ahead" warning is shown when the remote is newer than the local client.
+
+## [2026-04-12]
+
 ### Added
 - **Native UI Spike 4 — Terminal Panels on Canvas**: New `attn-spike4` binary merges the terminal surface (spike 2) with the infinite canvas (spike 3). Up to three live agent terminals attach to daemon sessions and appear as draggable, resizable panels on the canvas. Click a terminal body to focus it for keyboard input; drag its title bar to move it; drag corner handles to resize it and reflow the PTY. Zoom changes update visible cell counts automatically. A blue border highlights the focused panel.
 - **Native UI Spike 3 — Infinite Canvas**: New `attn-canvas` binary proves the GPUI-based canvas interaction model. Pan by dragging empty space, zoom toward cursor with Cmd+scroll or regular scroll, drag panels by their title bars, and resize panels by dragging their corner handles. Eight dummy panels are laid out at fixed world positions across an infinite dot-grid canvas. Viewport culling skips off-screen panels every frame.

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -890,6 +890,7 @@ sendFetchPRDetails,
     setView('dashboard');
   }, [setActiveSession]);
 
+
   const clearDockPanelCloseTimer = useCallback((panelId: DockPanelId) => {
     const closeTimer = dockPanelCloseTimersRef.current[panelId];
     if (closeTimer) {
@@ -1013,6 +1014,27 @@ sendFetchPRDetails,
   const [zoomModeBySessionId, setZoomModeBySessionId] = useState<Record<string, boolean>>({});
   const { message: copyMessage, showToast: showCopyToast, clearToast: clearCopyToast } = useCopyToast();
   const { message: errorMessage, showError, clearError } = useErrorToast();
+
+  const handleRebootstrapEndpoint = useCallback(async (endpointId: string) => {
+    try {
+      await sendUpdateEndpoint(endpointId, { enabled: false });
+    } catch {
+      showError('Failed to disable endpoint for sync.');
+      return;
+    }
+    try {
+      await sendUpdateEndpoint(endpointId, { enabled: true });
+    } catch {
+      // Disable succeeded but enable failed — retry enable once to avoid leaving it dark.
+      showError('Sync failed to re-enable endpoint. Retrying…');
+      try {
+        await sendUpdateEndpoint(endpointId, { enabled: true });
+      } catch {
+        showError('Endpoint left disabled after failed sync. Re-enable it in Settings.');
+      }
+    }
+  }, [sendUpdateEndpoint, showError]);
+
   const activeReviewLoopState = useMemo(
     () => (activeSessionId ? reviewLoopsBySessionId[activeSessionId] ?? null : null),
     [activeSessionId, reviewLoopsBySessionId],
@@ -1895,6 +1917,8 @@ sendFetchPRDetails,
           isRefreshing={isRefreshingPRs}
           refreshError={refreshError}
           rateLimit={rateLimit}
+          endpoints={daemonEndpoints}
+          onRebootstrapEndpoint={handleRebootstrapEndpoint}
           onSelectSession={handleSelectSession}
           onNewSession={handleNewSession}
           onRefreshPRs={handleRefreshPRs}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -253,6 +253,7 @@ function App() {
     sendUpdateEndpoint,
     sendRemoveEndpoint,
     sendSetEndpointRemoteWeb,
+    sendBootstrapEndpoint,
     sendGetRecentLocations,
     sendBrowseDirectory,
     sendInspectPath,
@@ -356,6 +357,7 @@ function App() {
         sendUpdateEndpoint={sendUpdateEndpoint}
         sendRemoveEndpoint={sendRemoveEndpoint}
         sendSetEndpointRemoteWeb={sendSetEndpointRemoteWeb}
+        sendBootstrapEndpoint={sendBootstrapEndpoint}
         sendGetRecentLocations={sendGetRecentLocations}
         sendBrowseDirectory={sendBrowseDirectory}
         sendInspectPath={sendInspectPath}
@@ -428,6 +430,7 @@ interface AppContentProps {
   sendUpdateEndpoint: ReturnType<typeof useDaemonSocket>['sendUpdateEndpoint'];
   sendRemoveEndpoint: ReturnType<typeof useDaemonSocket>['sendRemoveEndpoint'];
   sendSetEndpointRemoteWeb: ReturnType<typeof useDaemonSocket>['sendSetEndpointRemoteWeb'];
+  sendBootstrapEndpoint: ReturnType<typeof useDaemonSocket>['sendBootstrapEndpoint'];
   sendGetRecentLocations: ReturnType<typeof useDaemonSocket>['sendGetRecentLocations'];
   sendBrowseDirectory: ReturnType<typeof useDaemonSocket>['sendBrowseDirectory'];
   sendInspectPath: ReturnType<typeof useDaemonSocket>['sendInspectPath'];
@@ -495,6 +498,7 @@ function AppContent({
   sendUpdateEndpoint,
   sendRemoveEndpoint,
   sendSetEndpointRemoteWeb,
+  sendBootstrapEndpoint,
   sendGetRecentLocations,
   sendBrowseDirectory,
 sendInspectPath,
@@ -1017,23 +1021,11 @@ sendFetchPRDetails,
 
   const handleRebootstrapEndpoint = useCallback(async (endpointId: string) => {
     try {
-      await sendUpdateEndpoint(endpointId, { enabled: false });
-    } catch {
-      showError('Failed to disable endpoint for sync.');
-      return;
+      await sendBootstrapEndpoint(endpointId);
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Sync failed.');
     }
-    try {
-      await sendUpdateEndpoint(endpointId, { enabled: true });
-    } catch {
-      // Disable succeeded but enable failed — retry enable once to avoid leaving it dark.
-      showError('Sync failed to re-enable endpoint. Retrying…');
-      try {
-        await sendUpdateEndpoint(endpointId, { enabled: true });
-      } catch {
-        showError('Endpoint left disabled after failed sync. Re-enable it in Settings.');
-      }
-    }
-  }, [sendUpdateEndpoint, showError]);
+  }, [sendBootstrapEndpoint, showError]);
 
   const activeReviewLoopState = useMemo(
     () => (activeSessionId ? reviewLoopsBySessionId[activeSessionId] ?? null : null),

--- a/app/src/components/Dashboard.css
+++ b/app/src/components/Dashboard.css
@@ -95,6 +95,87 @@
   flex-shrink: 0;
 }
 
+/* Version mismatch banner */
+.version-mismatch-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 16px;
+  margin-bottom: 12px;
+  background: rgba(234, 179, 8, 0.08);
+  border: 1px solid rgba(234, 179, 8, 0.3);
+  border-radius: 6px;
+  color: rgba(253, 224, 71, 0.92);
+  font-size: var(--font-size-md);
+}
+
+.version-mismatch-banner--ahead {
+  background: rgba(239, 68, 68, 0.08);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: rgba(252, 165, 165, 0.92);
+}
+
+.version-mismatch-icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.version-mismatch-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.version-mismatch-name {
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+}
+
+.version-mismatch-message {
+  font-size: var(--font-size-sm);
+  opacity: 0.85;
+}
+
+.version-mismatch-warning {
+  font-size: var(--font-size-xs);
+  color: rgba(252, 165, 165, 0.92);
+  margin-top: 2px;
+}
+
+.version-mismatch-sync-btn {
+  align-self: center;
+  background: rgba(234, 179, 8, 0.15);
+  border: 1px solid rgba(234, 179, 8, 0.35);
+  border-radius: 4px;
+  color: rgba(253, 224, 71, 0.92);
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: var(--font-size-sm);
+  padding: 4px 12px;
+  transition: background 150ms ease;
+}
+
+.version-mismatch-sync-btn:hover:not(:disabled) {
+  background: rgba(234, 179, 8, 0.25);
+}
+
+.version-mismatch-sync-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.version-mismatch-banner--ahead .version-mismatch-sync-btn {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: rgba(252, 165, 165, 0.92);
+}
+
+.version-mismatch-banner--ahead .version-mismatch-sync-btn:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.25);
+}
+
 .dashboard-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
@@ -364,7 +445,10 @@
 }
 
 .session-endpoint-badge.status-connecting,
-.session-endpoint-badge.status-bootstrapping {
+.session-endpoint-badge.status-bootstrapping,
+.session-endpoint-badge.status-binary_mismatch,
+.session-endpoint-badge.status-version_mismatch,
+.session-endpoint-badge.status-version_ahead {
   border-color: rgba(245, 158, 11, 0.22);
   color: rgba(253, 224, 71, 0.92);
 }

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 // app/src/components/Dashboard.tsx
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { DaemonPR, RateLimitState } from '../hooks/useDaemonSocket';
+import { DaemonEndpoint, DaemonPR, RateLimitState } from '../hooks/useDaemonSocket';
 import { usePRsNeedingAttention } from '../hooks/usePRsNeedingAttention';
 import { PRActions } from './PRActions';
 import { StateIndicator } from './StateIndicator';
@@ -35,6 +35,8 @@ interface DashboardProps {
   isRefreshing?: boolean;
   refreshError?: string | null;
   rateLimit?: RateLimitState | null;
+  endpoints?: DaemonEndpoint[];
+  onRebootstrapEndpoint?: (endpointId: string) => Promise<void>;
   onSelectSession: (id: string) => void;
   onNewSession: () => void;
   onRefreshPRs?: () => void;
@@ -51,6 +53,8 @@ export function Dashboard({
   isRefreshing,
   refreshError,
   rateLimit,
+  endpoints,
+  onRebootstrapEndpoint,
   onSelectSession,
   onNewSession,
   onRefreshPRs,
@@ -180,6 +184,17 @@ export function Dashboard({
     }).catch(console.error);
   }, []);
 
+  const [syncingEndpointId, setSyncingEndpointId] = useState<string | null>(null);
+  const handleSync = useCallback(async (endpointId: string) => {
+    if (!onRebootstrapEndpoint || syncingEndpointId) return;
+    setSyncingEndpointId(endpointId);
+    try {
+      await onRebootstrapEndpoint(endpointId);
+    } finally {
+      setSyncingEndpointId(null);
+    }
+  }, [onRebootstrapEndpoint, syncingEndpointId]);
+
   // Rate limit countdown
   const [rateLimitCountdown, setRateLimitCountdown] = useState<string | null>(null);
   useEffect(() => {
@@ -240,6 +255,37 @@ export function Dashboard({
           <span>GitHub rate limited. Resuming in {rateLimitCountdown}</span>
         </div>
       )}
+
+      {/* Version mismatch banners */}
+      {endpoints?.filter(ep => ep.status === 'version_mismatch' || ep.status === 'version_ahead' || ep.status === 'binary_mismatch').map(ep => (
+        <div
+          key={ep.id}
+          className={`version-mismatch-banner${ep.status === 'version_ahead' ? ' version-mismatch-banner--ahead' : ''}`}
+        >
+          <svg className="version-mismatch-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+            <line x1="12" y1="9" x2="12" y2="13"/>
+            <line x1="12" y1="17" x2="12.01" y2="17"/>
+          </svg>
+          <div className="version-mismatch-body">
+            <span className="version-mismatch-name">{ep.name}</span>
+            {ep.status_message && (
+              <span className="version-mismatch-message">{ep.status_message}</span>
+            )}
+            {ep.status === 'version_ahead' && (
+              <span className="version-mismatch-warning">Syncing will downgrade the remote — data migration may be required.</span>
+            )}
+          </div>
+          <button
+            className="version-mismatch-sync-btn"
+            aria-label={`Sync ${ep.name}`}
+            disabled={syncingEndpointId === ep.id}
+            onClick={() => handleSync(ep.id)}
+          >
+            {syncingEndpointId === ep.id ? '…' : 'Sync'}
+          </button>
+        </div>
+      ))}
 
       <div className="dashboard-grid">
         {/* Sessions Card */}

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -2642,6 +2642,29 @@ export function useDaemonSocket({
     });
   }, [hasPendingEndpointAction]);
 
+  const sendBootstrapEndpoint = useCallback((endpointId: string): Promise<EndpointActionResult> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      if (hasPendingEndpointAction()) {
+        reject(new Error('Another endpoint action is already in progress'));
+        return;
+      }
+      const key = `endpoint_action:bootstrap:${endpointId}`;
+      pendingActionsRef.current.set(key, { resolve, reject });
+      ws.send(JSON.stringify({ cmd: 'bootstrap_endpoint', endpoint_id: endpointId }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Bootstrap endpoint timed out'));
+        }
+      }, 60000);
+    });
+  }, [hasPendingEndpointAction]);
+
   const sendListEndpoints = useCallback((): Promise<DaemonEndpoint[]> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
@@ -3355,6 +3378,7 @@ export function useDaemonSocket({
     sendUpdateEndpoint,
     sendRemoveEndpoint,
     sendSetEndpointRemoteWeb,
+    sendBootstrapEndpoint,
     sendListEndpoints,
     sendGetRecentLocations,
     sendBrowseDirectory,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MuteMessage, MutePRMessage, MuteRepoMessage, PathInspection, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RemoveEndpointMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionAgent, SessionExitedMessage, SessionRegisteredMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetEndpointRemoteWebMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, WontFixCommentMessage, WontFixCommentResultMessage, WorkspaceActionResultMessage, WorkspaceClosePaneMessage, WorkspaceFocusPaneMessage, WorkspaceGetMessage, WorkspacePane, WorkspacePaneKind, WorkspaceRenamePaneMessage, WorkspaceRuntimeExitedMessage, WorkspaceSnapshot, WorkspaceSnapshotMessage, WorkspaceSplitDirection, WorkspaceSplitPaneMessage, WorkspaceUpdatedMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MuteMessage, MutePRMessage, MuteRepoMessage, PathInspection, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RemoveEndpointMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionAgent, SessionExitedMessage, SessionRegisteredMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetEndpointRemoteWebMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, WontFixCommentMessage, WontFixCommentResultMessage, WorkspaceActionResultMessage, WorkspaceClosePaneMessage, WorkspaceFocusPaneMessage, WorkspaceGetMessage, WorkspacePane, WorkspacePaneKind, WorkspaceRenamePaneMessage, WorkspaceRuntimeExitedMessage, WorkspaceSnapshot, WorkspaceSnapshotMessage, WorkspaceSplitDirection, WorkspaceSplitPaneMessage, WorkspaceUpdatedMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -12,6 +12,7 @@
 //   const attachSessionMessage = Convert.toAttachSessionMessage(json);
 //   const authorState = Convert.toAuthorState(json);
 //   const authorsUpdatedMessage = Convert.toAuthorsUpdatedMessage(json);
+//   const bootstrapEndpointMessage = Convert.toBootstrapEndpointMessage(json);
 //   const branch = Convert.toBranch(json);
 //   const branchChangedMessage = Convert.toBranchChangedMessage(json);
 //   const branchDiffFile = Convert.toBranchDiffFile(json);
@@ -323,6 +324,16 @@ export interface AuthorElement {
 
 export enum AuthorsUpdatedMessageEvent {
     AuthorsUpdated = "authors_updated",
+}
+
+export interface BootstrapEndpointMessage {
+    cmd:         BootstrapEndpointMessageCmd;
+    endpoint_id: string;
+    [property: string]: any;
+}
+
+export enum BootstrapEndpointMessageCmd {
+    BootstrapEndpoint = "bootstrap_endpoint",
 }
 
 export interface Branch {
@@ -2497,6 +2508,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("AuthorsUpdatedMessage")), null, 2);
     }
 
+    public static toBootstrapEndpointMessage(json: string): BootstrapEndpointMessage {
+        return cast(JSON.parse(json), r("BootstrapEndpointMessage"));
+    }
+
+    public static bootstrapEndpointMessageToJson(value: BootstrapEndpointMessage): string {
+        return JSON.stringify(uncast(value, r("BootstrapEndpointMessage")), null, 2);
+    }
+
     public static toBranch(json: string): Branch {
         return cast(JSON.parse(json), r("Branch"));
     }
@@ -4011,6 +4030,10 @@ const typeMap: any = {
         { json: "author", js: "author", typ: "" },
         { json: "muted", js: "muted", typ: true },
     ], "any"),
+    "BootstrapEndpointMessage": o([
+        { json: "cmd", js: "cmd", typ: r("BootstrapEndpointMessageCmd") },
+        { json: "endpoint_id", js: "endpoint_id", typ: "" },
+    ], "any"),
     "Branch": o([
         { json: "commit_hash", js: "commit_hash", typ: u(undefined, "") },
         { json: "commit_time", js: "commit_time", typ: u(undefined, "") },
@@ -5225,6 +5248,9 @@ const typeMap: any = {
     ],
     "AuthorsUpdatedMessageEvent": [
         "authors_updated",
+    ],
+    "BootstrapEndpointMessageCmd": [
+        "bootstrap_endpoint",
     ],
     "BranchChangedMessageEvent": [
         "branch_changed",

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1062,6 +1062,7 @@ export interface InitialStateMessage {
     repos?:              RepoElement[];
     sessions?:           SessionElement[];
     settings?:           { [key: string]: any };
+    source_fingerprint?: string;
     warnings?:           WarningElement[];
     workspaces?:         Workspace[];
     [property: string]: any;
@@ -4426,6 +4427,7 @@ const typeMap: any = {
         { json: "repos", js: "repos", typ: u(undefined, a(r("RepoElement"))) },
         { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
         { json: "settings", js: "settings", typ: u(undefined, m("any")) },
+        { json: "source_fingerprint", js: "source_fingerprint", typ: u(undefined, "") },
         { json: "warnings", js: "warnings", typ: u(undefined, a(r("WarningElement"))) },
         { json: "workspaces", js: "workspaces", typ: u(undefined, a(r("Workspace"))) },
     ], "any"),

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -723,6 +723,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleRemoveEndpointWS(client, msg.(*protocol.RemoveEndpointMessage))
 	case protocol.CmdUpdateEndpoint:
 		d.handleUpdateEndpointWS(client, msg.(*protocol.UpdateEndpointMessage))
+	case protocol.CmdBootstrapEndpoint:
+		d.handleBootstrapEndpointWS(client, msg.(*protocol.BootstrapEndpointMessage))
 	case protocol.CmdListEndpoints:
 		d.handleListEndpointsWS(client)
 	case protocol.CmdSetEndpointRemoteWeb:

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -527,18 +527,18 @@ func (d *Daemon) handleWS(w http.ResponseWriter, r *http.Request) {
 
 func (d *Daemon) sendInitialState(client *wsClient) {
 	event := &protocol.InitialStateMessage{
-		Event:              protocol.EventInitialState,
-		ProtocolVersion:    protocol.Ptr(protocol.ProtocolVersion),
-		SourceFingerprint:  protocol.Ptr(buildinfo.SourceFingerprint),
-		DaemonInstanceID:   protocol.Ptr(d.daemonInstanceID),
-		Sessions:         d.mergedSessionsForBroadcast(),
-		Endpoints:        d.listEndpointInfos(),
-		Workspaces:       d.mergedWorkspacesForBroadcast(),
-		Prs:              protocol.PRsToValues(d.store.ListPRs("")),
-		Repos:            protocol.RepoStatesToValues(d.store.ListRepoStates()),
-		Authors:          protocol.AuthorStatesToValues(d.store.ListAuthorStates()),
-		Settings:         d.settingsWithAgentAvailability(),
-		Warnings:         d.getWarnings(),
+		Event:             protocol.EventInitialState,
+		ProtocolVersion:   protocol.Ptr(protocol.ProtocolVersion),
+		SourceFingerprint: protocol.Ptr(buildinfo.SourceFingerprint),
+		DaemonInstanceID:  protocol.Ptr(d.daemonInstanceID),
+		Sessions:          d.mergedSessionsForBroadcast(),
+		Endpoints:         d.listEndpointInfos(),
+		Workspaces:        d.mergedWorkspacesForBroadcast(),
+		Prs:               protocol.PRsToValues(d.store.ListPRs("")),
+		Repos:             protocol.RepoStatesToValues(d.store.ListRepoStates()),
+		Authors:           protocol.AuthorStatesToValues(d.store.ListAuthorStates()),
+		Settings:          d.settingsWithAgentAvailability(),
+		Warnings:          d.getWarnings(),
 	}
 	data, err := json.Marshal(event)
 	if err != nil {

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -14,6 +14,7 @@ import (
 
 	"nhooyr.io/websocket"
 
+	"github.com/victorarias/attn/internal/buildinfo"
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/ptybackend"
@@ -526,9 +527,10 @@ func (d *Daemon) handleWS(w http.ResponseWriter, r *http.Request) {
 
 func (d *Daemon) sendInitialState(client *wsClient) {
 	event := &protocol.InitialStateMessage{
-		Event:            protocol.EventInitialState,
-		ProtocolVersion:  protocol.Ptr(protocol.ProtocolVersion),
-		DaemonInstanceID: protocol.Ptr(d.daemonInstanceID),
+		Event:              protocol.EventInitialState,
+		ProtocolVersion:    protocol.Ptr(protocol.ProtocolVersion),
+		SourceFingerprint:  protocol.Ptr(buildinfo.SourceFingerprint),
+		DaemonInstanceID:   protocol.Ptr(d.daemonInstanceID),
 		Sessions:         d.mergedSessionsForBroadcast(),
 		Endpoints:        d.listEndpointInfos(),
 		Workspaces:       d.mergedWorkspacesForBroadcast(),

--- a/internal/daemon/ws_endpoints.go
+++ b/internal/daemon/ws_endpoints.go
@@ -88,6 +88,18 @@ func (d *Daemon) handleSetEndpointRemoteWebWS(client *wsClient, msg *protocol.Se
 	d.sendEndpointActionResult(client, "remote_web", endpointID, true, "")
 }
 
+func (d *Daemon) handleBootstrapEndpointWS(client *wsClient, msg *protocol.BootstrapEndpointMessage) {
+	if d.hubManager == nil {
+		d.sendEndpointActionResult(client, "bootstrap", msg.EndpointID, false, "endpoint manager unavailable")
+		return
+	}
+	if err := d.hubManager.BootstrapEndpoint(msg.EndpointID); err != nil {
+		d.sendEndpointActionResult(client, "bootstrap", msg.EndpointID, false, err.Error())
+		return
+	}
+	d.sendEndpointActionResult(client, "bootstrap", msg.EndpointID, true, "")
+}
+
 func (d *Daemon) sendEndpointActionResult(client *wsClient, action, endpointID string, success bool, errMsg string) {
 	result := &protocol.EndpointActionResultMessage{
 		Event:   protocol.EventEndpointActionResult,

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -3,16 +3,19 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"nhooyr.io/websocket"
 
+	"github.com/victorarias/attn/internal/buildinfo"
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
@@ -21,6 +24,24 @@ import (
 type StatusCallback func(info protocol.EndpointInfo)
 type SessionsChangedCallback func()
 type RawEventCallback func(data []byte)
+
+type VersionMismatchError struct {
+	RemoteVersion string
+	LocalVersion  string
+}
+
+func (e *VersionMismatchError) Error() string {
+	return fmt.Sprintf("protocol mismatch: remote=%s local=%s", e.RemoteVersion, e.LocalVersion)
+}
+
+// BinaryMismatchError is returned by consumeRemote when the connection closes
+// while in binary_mismatch state, so the caller can apply the same slow-retry
+// policy as VersionMismatchError instead of the normal fast reconnect.
+type BinaryMismatchError struct {
+	Message string
+}
+
+func (e *BinaryMismatchError) Error() string { return e.Message }
 
 const (
 	settingProjectsDirectory = "projects_directory"
@@ -358,38 +379,61 @@ func (m *Manager) stopRuntimeLocked(runtime *endpointRuntime) {
 
 func (m *Manager) runEndpointLoop(ctx context.Context, id string) {
 	backoff := time.Second
+	firstIteration := true
 	for {
 		record, ok := m.recordFor(id)
 		if !ok {
 			return
 		}
 
-		m.updateStatus(id, "bootstrapping", "Checking remote platform", nil, nil)
-		bootCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-		err := m.bootstrapper.EnsureRemoteReady(bootCtx, record.SSHTarget)
-		cancel()
-		if err != nil {
-			m.updateStatus(id, "error", err.Error(), nil, nil)
-			if !sleepOrDone(ctx, backoff) {
-				return
+		if firstIteration {
+			// Bootstrap once at loop start: install the binary and start the daemon.
+			m.updateStatus(id, "bootstrapping", "Checking remote platform", nil, nil)
+			bootCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+			err := m.bootstrapper.EnsureRemoteReady(bootCtx, record.SSHTarget)
+			cancel()
+			if err != nil {
+				m.updateStatus(id, "error", err.Error(), nil, nil)
+				if !sleepOrDone(ctx, backoff) {
+					return
+				}
+				backoff = nextBackoff(backoff)
+				continue
 			}
-			backoff = nextBackoff(backoff)
-			continue
+			firstIteration = false
 		}
 
+		// Try to connect; if it fails the daemon is not running — bootstrap and retry.
 		m.updateStatus(id, "connecting", "Connecting to remote daemon", nil, nil)
 		conn, cmd, err := connectViaSSH(ctx, record.SSHTarget, config.WSAuthToken())
 		if err != nil {
-			m.updateStatus(id, "error", err.Error(), nil, nil)
-			if !sleepOrDone(ctx, backoff) {
-				return
+			// Daemon appears down — bootstrap then try once more.
+			m.updateStatus(id, "bootstrapping", "Checking remote platform", nil, nil)
+			bootCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+			bootErr := m.bootstrapper.EnsureRemoteReady(bootCtx, record.SSHTarget)
+			cancel()
+			if bootErr != nil {
+				m.updateStatus(id, "error", bootErr.Error(), nil, nil)
+				if !sleepOrDone(ctx, backoff) {
+					return
+				}
+				backoff = nextBackoff(backoff)
+				continue
 			}
-			backoff = nextBackoff(backoff)
-			continue
+			m.updateStatus(id, "connecting", "Connecting to remote daemon", nil, nil)
+			conn, cmd, err = connectViaSSH(ctx, record.SSHTarget, config.WSAuthToken())
+			if err != nil {
+				m.updateStatus(id, "error", err.Error(), nil, nil)
+				if !sleepOrDone(ctx, backoff) {
+					return
+				}
+				backoff = nextBackoff(backoff)
+				continue
+			}
 		}
 
 		m.setConnection(id, conn, cmd)
-		connected, err := m.consumeRemote(ctx, id, conn)
+		connected, consumeErr := m.consumeRemote(ctx, id, conn)
 		m.clearConnection(id)
 		if m.clearRemoteSessions(id) {
 			m.publishSessionsChanged()
@@ -399,10 +443,37 @@ func (m *Manager) runEndpointLoop(ctx context.Context, id string) {
 		if ctx.Err() != nil {
 			return
 		}
+
+		var versionErr *VersionMismatchError
+		if errors.As(consumeErr, &versionErr) {
+			// Version mismatch — surface to user instead of auto-bootstrapping.
+			status, message := versionMismatchStatus(versionErr)
+			m.updateStatus(id, status, message, nil, nil)
+			// Sleep longer before retrying; the user needs to click Sync.
+			if !sleepOrDone(ctx, 30*time.Second) {
+				return
+			}
+			continue
+		}
+
+		var binaryErr *BinaryMismatchError
+		if errors.As(consumeErr, &binaryErr) {
+			// Binary mismatch — connection dropped while in mismatch state.
+			// Keep the binary_mismatch status and use the same slow-retry policy
+			// so the banner stays visible and the user can click Sync.
+			m.updateStatus(id, "binary_mismatch", binaryErr.Message, nil, nil)
+			if !sleepOrDone(ctx, 30*time.Second) {
+				return
+			}
+			continue
+		}
+
 		if connected {
 			m.updateStatus(id, "disconnected", "Disconnected; reconnecting", nil, nil)
-		} else if err != nil {
-			m.updateStatus(id, "error", err.Error(), nil, nil)
+			// Reset backoff after a successful session — it was healthy.
+			backoff = time.Second
+		} else if consumeErr != nil {
+			m.updateStatus(id, "error", consumeErr.Error(), nil, nil)
 		}
 		if !sleepOrDone(ctx, backoff) {
 			return
@@ -411,11 +482,38 @@ func (m *Manager) runEndpointLoop(ctx context.Context, id string) {
 	}
 }
 
+// versionMismatchStatus returns the status string and human-readable message for a
+// VersionMismatchError.  "version_mismatch" means the remote is older (safe to sync
+// by upgrading it).  "version_ahead" means the remote is newer (syncing would downgrade it).
+func versionMismatchStatus(e *VersionMismatchError) (string, string) {
+	remoteN, remoteErr := strconv.Atoi(e.RemoteVersion)
+	localN, localErr := strconv.Atoi(e.LocalVersion)
+	if remoteErr == nil && localErr == nil && remoteN > localN {
+		return "version_ahead", fmt.Sprintf(
+			"remote v%s is ahead of this client v%s — sync will downgrade it",
+			e.RemoteVersion, e.LocalVersion,
+		)
+	}
+	return "version_mismatch", fmt.Sprintf(
+		"remote v%s, this client v%s — remote needs update",
+		e.RemoteVersion, e.LocalVersion,
+	)
+}
+
 func (m *Manager) consumeRemote(ctx context.Context, id string, conn *websocket.Conn) (bool, error) {
 	connected := false
+	// activeStatus and activeMsg track the status established on initial_state so
+	// that subsequent session events preserve it rather than blindly writing
+	// "connected".  For a binary_mismatch connection the WebSocket stays alive
+	// but the endpoint must remain non-"connected" throughout.
+	activeStatus := "connected"
+	activeMsg := "Connected"
 	for {
 		_, data, err := conn.Read(ctx)
 		if err != nil {
+			if activeStatus == "binary_mismatch" {
+				return connected, &BinaryMismatchError{Message: activeMsg}
+			}
 			if connected {
 				return true, err
 			}
@@ -439,13 +537,17 @@ func (m *Manager) consumeRemote(ctx context.Context, id string, conn *websocket.
 				return connected, err
 			}
 			if remoteProtocol := strings.TrimSpace(protocol.Deref(msg.ProtocolVersion)); remoteProtocol != "" && remoteProtocol != protocol.ProtocolVersion {
-				return false, fmt.Errorf("protocol mismatch: remote=%s local=%s", remoteProtocol, protocol.ProtocolVersion)
+				return false, &VersionMismatchError{RemoteVersion: remoteProtocol, LocalVersion: protocol.ProtocolVersion}
 			}
 			changed := m.replaceRemoteSessions(id, msg.Sessions)
 			m.replaceRemoteWorkspaces(id, msg.Workspaces)
 			caps := capabilitiesFromInitialState(&msg)
 			sessionCount := int32(len(msg.Sessions))
-			m.updateStatus(id, "connected", "Connected", caps, &sessionCount)
+			if fingerMismatch, fingerMsg := fingerprintMismatch(msg.SourceFingerprint); fingerMismatch {
+				activeStatus = "binary_mismatch"
+				activeMsg = fingerMsg
+			}
+			m.updateStatus(id, activeStatus, activeMsg, caps, &sessionCount)
 			if changed {
 				m.publishSessionsChanged()
 			}
@@ -464,7 +566,7 @@ func (m *Manager) consumeRemote(ctx context.Context, id string, conn *websocket.
 			}
 			changed := m.replaceRemoteSessions(id, msg.Sessions)
 			sessionCount := int32(len(msg.Sessions))
-			m.updateStatus(id, "connected", "Connected", nil, &sessionCount)
+			m.updateStatus(id, activeStatus, activeMsg, nil, &sessionCount)
 			if changed {
 				m.publishSessionsChanged()
 			}
@@ -477,7 +579,7 @@ func (m *Manager) consumeRemote(ctx context.Context, id string, conn *websocket.
 			}
 			changed, sessionCount := m.upsertRemoteSession(id, *msg.Session)
 			countValue := int32(sessionCount)
-			m.updateStatus(id, "connected", "Connected", nil, &countValue)
+			m.updateStatus(id, activeStatus, activeMsg, nil, &countValue)
 			if changed {
 				m.publishSessionsChanged()
 			}
@@ -491,7 +593,7 @@ func (m *Manager) consumeRemote(ctx context.Context, id string, conn *websocket.
 			changed, sessionCount := m.removeRemoteSession(id, msg.Session.ID)
 			m.removeRemoteWorkspace(id, msg.Session.ID)
 			countValue := int32(sessionCount)
-			m.updateStatus(id, "connected", "Connected", nil, &countValue)
+			m.updateStatus(id, activeStatus, activeMsg, nil, &countValue)
 			if changed {
 				m.publishSessionsChanged()
 			}
@@ -1566,4 +1668,47 @@ func sleepOrDone(ctx context.Context, delay time.Duration) bool {
 	case <-timer.C:
 		return true
 	}
+}
+
+// fingerprintMismatch returns true (and a human-readable message) when the remote
+// daemon was built from a different source than this client.
+//
+// Rules:
+//   - If the local fingerprint is unknown (dev build, no ldflags) — skip; we can't
+//     make any claims about what "our" binary is.
+//   - If the local fingerprint is known but the remote is absent/unknown — mismatch:
+//     the running daemon is either an old binary that pre-dates source_fingerprint
+//     tracking, or a dev build.
+//   - If both are known and equal — no mismatch.
+//   - If both are known and differ — mismatch.
+func fingerprintMismatch(remoteFingerprint *string) (bool, string) {
+	local := normalizeFingerprint(buildinfo.SourceFingerprint)
+	if local == "" {
+		return false, ""
+	}
+	remote := normalizeFingerprint(protocol.Deref(remoteFingerprint))
+	if local == remote {
+		return false, ""
+	}
+	shortLocal := shortFingerprint(local)
+	if remote == "" {
+		return true, fmt.Sprintf("remote binary (unknown) differs from this client (%s) — click Sync to update", shortLocal)
+	}
+	shortRemote := shortFingerprint(remote)
+	return true, fmt.Sprintf("remote binary (%s) differs from this client (%s) — click Sync to update", shortRemote, shortLocal)
+}
+
+func normalizeFingerprint(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || v == "unknown" {
+		return ""
+	}
+	return v
+}
+
+func shortFingerprint(v string) string {
+	if len(v) > 12 {
+		return v[:12]
+	}
+	return v
 }

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -63,6 +63,7 @@ type endpointRuntime struct {
 	cmd              *exec.Cmd
 	writeMu          sync.Mutex
 	pendingRemoteWeb *pendingRemoteWebAction
+	pendingBootstrap bool
 
 	sessions   map[string]protocol.Session
 	workspaces map[string]protocol.WorkspaceSnapshot
@@ -238,6 +239,37 @@ func (m *Manager) AddEndpoint(name, sshTarget string) (*store.EndpointRecord, er
 	return record, nil
 }
 
+// BootstrapEndpoint requests an explicit bootstrap (install binary + start daemon) for the
+// given endpoint.  The flag is consumed at the top of runEndpointLoop so it fires once on
+// the next loop iteration.  Upgrade must be intentional — this is the only path that calls
+// EnsureRemoteReady when the remote daemon is already running.
+func (m *Manager) BootstrapEndpoint(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	rt, ok := m.runtimes[id]
+	if !ok {
+		return fmt.Errorf("endpoint %s not found", id)
+	}
+	rt.pendingBootstrap = true
+	m.stopRuntimeLocked(rt)
+	if m.started && rt.record.Enabled {
+		m.startRuntimeLocked(id)
+	}
+	return nil
+}
+
+func (m *Manager) consumeBootstrapFlag(id string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	rt, ok := m.runtimes[id]
+	if !ok {
+		return false
+	}
+	v := rt.pendingBootstrap
+	rt.pendingBootstrap = false
+	return v
+}
+
 func (m *Manager) UpdateEndpoint(id string, update store.EndpointUpdate) (*store.EndpointRecord, error) {
 	record, err := m.store.UpdateEndpoint(id, update)
 	if err != nil {
@@ -383,6 +415,22 @@ func (m *Manager) runEndpointLoop(ctx context.Context, id string) {
 		record, ok := m.recordFor(id)
 		if !ok {
 			return
+		}
+
+		// Explicit bootstrap requested (e.g. user clicked Sync) — install binary and start daemon.
+		if m.consumeBootstrapFlag(id) {
+			m.updateStatus(id, "bootstrapping", "Installing remote binary", nil, nil)
+			bootCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+			err := m.bootstrapper.EnsureRemoteReady(bootCtx, record.SSHTarget)
+			cancel()
+			if err != nil {
+				m.updateStatus(id, "error", err.Error(), nil, nil)
+				if !sleepOrDone(ctx, backoff) {
+					return
+				}
+				backoff = nextBackoff(backoff)
+				continue
+			}
 		}
 
 		// Try to connect; if it fails the daemon is not running — bootstrap and retry.

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -379,28 +379,10 @@ func (m *Manager) stopRuntimeLocked(runtime *endpointRuntime) {
 
 func (m *Manager) runEndpointLoop(ctx context.Context, id string) {
 	backoff := time.Second
-	firstIteration := true
 	for {
 		record, ok := m.recordFor(id)
 		if !ok {
 			return
-		}
-
-		if firstIteration {
-			// Bootstrap once at loop start: install the binary and start the daemon.
-			m.updateStatus(id, "bootstrapping", "Checking remote platform", nil, nil)
-			bootCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-			err := m.bootstrapper.EnsureRemoteReady(bootCtx, record.SSHTarget)
-			cancel()
-			if err != nil {
-				m.updateStatus(id, "error", err.Error(), nil, nil)
-				if !sleepOrDone(ctx, backoff) {
-					return
-				}
-				backoff = nextBackoff(backoff)
-				continue
-			}
-			firstIteration = false
 		}
 
 		// Try to connect; if it fails the daemon is not running — bootstrap and retry.

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -46,6 +46,7 @@ const (
 	CmdUpdateEndpoint           = "update_endpoint"
 	CmdListEndpoints            = "list_endpoints"
 	CmdSetEndpointRemoteWeb     = "set_endpoint_remote_web"
+	CmdBootstrapEndpoint        = "bootstrap_endpoint"
 	CmdApprovePR                = "approve_pr"
 	CmdMergePR                  = "merge_pr"
 	CmdInjectTestPR             = "inject_test_pr"
@@ -442,6 +443,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdSetEndpointRemoteWeb:
 		var msg SetEndpointRemoteWebMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdBootstrapEndpoint:
+		var msg BootstrapEndpointMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -868,6 +868,9 @@ type InitialStateMessage struct {
 	// Settings corresponds to the JSON schema field "settings".
 	Settings RecordString `json:"settings,omitempty,omitzero"`
 
+	// SourceFingerprint corresponds to the JSON schema field "source_fingerprint".
+	SourceFingerprint *string `json:"source_fingerprint,omitempty,omitzero"`
+
 	// Warnings corresponds to the JSON schema field "warnings".
 	Warnings []DaemonWarning `json:"warnings,omitempty,omitzero"`
 
@@ -1240,6 +1243,20 @@ type PtyResizeMessage struct {
 
 	// Cols corresponds to the JSON schema field "cols".
 	Cols int `json:"cols"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// Rows corresponds to the JSON schema field "rows".
+	Rows int `json:"rows"`
+}
+
+type PtyResizedMessage struct {
+	// Cols corresponds to the JSON schema field "cols".
+	Cols int `json:"cols"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
 
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -164,6 +164,14 @@ type AuthorsUpdatedMessage struct {
 	Event string `json:"event"`
 }
 
+type BootstrapEndpointMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// EndpointID corresponds to the JSON schema field "endpoint_id".
+	EndpointID string `json:"endpoint_id"`
+}
+
 type Branch struct {
 	// CommitHash corresponds to the JSON schema field "commit_hash".
 	CommitHash *string `json:"commit_hash,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -427,6 +427,11 @@ model SetEndpointRemoteWebMessage {
   enabled: boolean;
 }
 
+model BootstrapEndpointMessage {
+  cmd: "bootstrap_endpoint";
+  endpoint_id: string;
+}
+
 model ApprovePRMessage {
   cmd: "approve_pr";
   id: string;

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -718,6 +718,7 @@ model WorkspaceRenamePaneMessage {
 model InitialStateMessage {
   event: "initial_state";
   protocol_version?: string;
+  source_fingerprint?: string;
   daemon_instance_id?: string;
   sessions?: Session[];
   endpoints?: EndpointInfo[];


### PR DESCRIPTION
## Summary

- **Bootstrap loop fix**: Remote daemon bootstrap now runs only on the first connection attempt per loop lifetime (or when the daemon is unreachable). Reconnects after clean disconnects skip bootstrap entirely, eliminating the ping-pong where two machines sharing a remote daemon repeatedly overwrite each other's binary.
- **Version mismatch banner**: Connecting to a remote daemon with a mismatched protocol version surfaces a warning banner on the home screen with a Sync button, instead of auto-reinstalling. A separate \"version ahead\" warning covers the downgrade case.
- **Binary mismatch banner**: A new `source_fingerprint` field in the `initial_state` WebSocket message lets clients detect when the remote daemon was built by a different machine. Mismatch triggers the same banner. If the local binary's fingerprint is unknown (dev build), the check is skipped.
- **Mismatch endpoints are non-usable**: Both mismatch states leave the endpoint greyed out in the location picker. The WebSocket connection stays alive for binary mismatches (sessions remain visible) but the endpoint status is non-`connected` throughout.
- **Sync button**: Disable + enable cycle restarts the loop with `firstIteration=true`, triggering a clean bootstrap. Error handling covers the case where enable fails after a successful disable.
- Both mismatch types use a 30s slow-retry policy so the banner stays visible without flickering.

## Test plan

- [ ] `make install` from two machines sharing a remote endpoint — verify no ping-pong after initial bootstrap
- [ ] Connect from a machine with a different source fingerprint — verify binary mismatch banner appears, endpoint is greyed in location picker
- [ ] Click Sync — verify daemon is updated and endpoint returns to connected
- [ ] Downgrade remote protocol version manually — verify version mismatch banner with correct message
- [ ] Verify `pnpm test` passes (Dashboard tests)