### PR TITLE
fix: stabilize CI test failures and focus trap flakiness

### DIFF
--- a/app/e2e/keyboard-shortcuts.spec.ts
+++ b/app/e2e/keyboard-shortcuts.spec.ts
@@ -295,29 +295,35 @@ test.describe('Keyboard Shortcuts', () => {
       const dialog = page.locator('.worktree-cleanup-prompt .cleanup-content');
       await expect(dialog).toBeVisible({ timeout: 2000 });
 
-      // activeEl bypasses document.hasFocus() which returns false in headless CI
-      // even when an element is nominally active, making toBeFocused() flaky.
+      // In headless CI document.hasFocus() returns false, so two problems arise:
+      // 1. page.keyboard.press() routes via the OS focus chain, which may not
+      //    point at the button — the event never reaches the dialog's onKeyDown.
+      // 2. toBeFocused() requires hasFocus() && activeElement, so it always fails.
+      //
+      // Fix: dispatch each key directly to the currently-focused button via
+      // locator.press() (CDP routes to that element regardless of hasFocus).
+      // Check document.activeElement?.matches() directly to bypass hasFocus().
       const activeEl = (sel: string) =>
         page.evaluate((s) => document.activeElement?.matches(s) ?? false, sel);
 
       await expect.poll(() => activeEl('.cleanup-btn.keep')).toBe(true);
 
-      await page.keyboard.press('ArrowRight');
+      await page.locator('.cleanup-btn.keep').press('ArrowRight');
       await expect.poll(() => activeEl('.cleanup-btn.delete')).toBe(true);
 
-      await page.keyboard.press('ArrowRight');
+      await page.locator('.cleanup-btn.delete').press('ArrowRight');
       await expect.poll(() => activeEl('.cleanup-btn.always')).toBe(true);
 
-      await page.keyboard.press('ArrowLeft');
+      await page.locator('.cleanup-btn.always').press('ArrowLeft');
       await expect.poll(() => activeEl('.cleanup-btn.delete')).toBe(true);
 
-      await page.keyboard.press('Tab');
+      await page.locator('.cleanup-btn.delete').press('Tab');
       await expect.poll(() => activeEl('.cleanup-btn.always')).toBe(true);
 
-      await page.keyboard.press('Tab');
+      await page.locator('.cleanup-btn.always').press('Tab');
       await expect.poll(() => activeEl('.cleanup-btn.keep')).toBe(true);
 
-      await page.keyboard.press('Shift+Tab');
+      await page.locator('.cleanup-btn.keep').press('Shift+Tab');
       await expect.poll(() => activeEl('.cleanup-btn.always')).toBe(true);
     });
   });

--- a/app/e2e/keyboard-shortcuts.spec.ts
+++ b/app/e2e/keyboard-shortcuts.spec.ts
@@ -295,32 +295,30 @@ test.describe('Keyboard Shortcuts', () => {
       const dialog = page.locator('.worktree-cleanup-prompt .cleanup-content');
       await expect(dialog).toBeVisible({ timeout: 2000 });
 
-      const keep = page.locator('.cleanup-btn.keep');
-      const del = page.locator('.cleanup-btn.delete');
-      const always = page.locator('.cleanup-btn.always');
+      // activeEl bypasses document.hasFocus() which returns false in headless CI
+      // even when an element is nominally active, making toBeFocused() flaky.
+      const activeEl = (sel: string) =>
+        page.evaluate((s) => document.activeElement?.matches(s) ?? false, sel);
 
-      await expect(keep).toBeFocused();
-
-      // Use page.keyboard instead of locator.press() — locator.press()
-      // re-focuses the element first, which can cause the document to lose
-      // OS-level focus in CI, making the next toBeFocused() return "inactive".
-      await page.keyboard.press('ArrowRight');
-      await expect(del).toBeFocused();
+      await expect.poll(() => activeEl('.cleanup-btn.keep')).toBe(true);
 
       await page.keyboard.press('ArrowRight');
-      await expect(always).toBeFocused();
+      await expect.poll(() => activeEl('.cleanup-btn.delete')).toBe(true);
+
+      await page.keyboard.press('ArrowRight');
+      await expect.poll(() => activeEl('.cleanup-btn.always')).toBe(true);
 
       await page.keyboard.press('ArrowLeft');
-      await expect(del).toBeFocused();
+      await expect.poll(() => activeEl('.cleanup-btn.delete')).toBe(true);
 
       await page.keyboard.press('Tab');
-      await expect(always).toBeFocused();
+      await expect.poll(() => activeEl('.cleanup-btn.always')).toBe(true);
 
       await page.keyboard.press('Tab');
-      await expect(keep).toBeFocused();
+      await expect.poll(() => activeEl('.cleanup-btn.keep')).toBe(true);
 
       await page.keyboard.press('Shift+Tab');
-      await expect(always).toBeFocused();
+      await expect.poll(() => activeEl('.cleanup-btn.always')).toBe(true);
     });
   });
 

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -344,7 +344,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '52',
+        protocol_version: '53',
         sessions: [],
         workspaces: [{
           session_id: 'sess-remote',
@@ -420,7 +420,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '52',
+        protocol_version: '53',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -499,7 +499,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '52',
+        protocol_version: '53',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -592,7 +592,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '52',
+        protocol_version: '53',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -689,7 +689,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '52',
+        protocol_version: '53',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -772,7 +772,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '52',
+        protocol_version: '53',
         sessions: [],
         workspaces: [{
           session_id: 'sess-remote',
@@ -881,7 +881,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '52',
+        protocol_version: '53',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -939,7 +939,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '52',
+        protocol_version: '53',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',


### PR DESCRIPTION
## Summary

- **Protocol version drift**: 8 `useDaemonSocket` tests were using `protocol_version: '52'` in their `initial_state` fixtures after the version was bumped to `53` in the nativeui branch. The mismatch triggered the version-check handler, closing the WebSocket and breaking every assertion in those tests — consistently, every CI run after that merge.

- **Focus trap flakiness**: replaced `toBeFocused()` with `expect.poll(() => page.evaluate(() => document.activeElement?.matches(sel)))` in the worktree cleanup focus trap E2E test. Playwright's `toBeFocused()` internally requires `document.hasFocus() && el === document.activeElement`; in headless Chromium `document.hasFocus()` returns `false` regardless of actual focus state, making the assertions intermittently fail in CI. The `page.evaluate` approach checks only `document.activeElement` directly, bypassing the unreliable `hasFocus()` gate. `expect.poll()` preserves the retry semantics.

## Test plan

- [ ] CI passes (`Frontend` job: vitest + E2E)
- [ ] `useDaemonSocket` tests: all 14 pass (previously 8 failed)
- [ ] Worktree cleanup focus trap test passes consistently under headless conditions