### PR TITLE
fix: improve location picker and repo options UX

### DIFF
--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -192,7 +192,7 @@ describe('LocationPicker', () => {
     });
   });
 
-  it('clicking a row highlights it without rewriting the input until Enter', async () => {
+  it('clicking a row selects it immediately', async () => {
     const onInspectPath = vi.fn(async () => ({
       success: true,
       inspection: {
@@ -203,20 +203,15 @@ describe('LocationPicker', () => {
         is_directory: true,
       },
     }));
-    renderPicker({ onInspectPath });
+    const { onSelect } = renderPicker({ onInspectPath });
 
     const input = screen.getByRole('textbox') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '~/pro' } });
     fireEvent.click(screen.getByTestId('location-picker-item-0'));
 
-    expect(input.value).toBe('~/pro');
-    expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
-    expect(onInspectPath).not.toHaveBeenCalled();
-
-    fireEvent.keyDown(input, { key: 'Enter' });
-
     await waitFor(() => {
       expect(onInspectPath).toHaveBeenCalledWith('~/projects', undefined);
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects', 'claude', undefined, false);
     });
   });
 
@@ -251,6 +246,12 @@ describe('LocationPicker', () => {
       expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
     });
 
+    // First Escape deselects the highlighted item without closing
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('location-picker-item-0')).not.toHaveClass('selected');
+
+    // Second Escape closes the dialog
     fireEvent.keyDown(input, { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -690,8 +690,8 @@ export function LocationPicker({
     }
 
     const nextIndex = direction === 'down'
-      ? (highlightedIndex < 0 ? 0 : Math.min(highlightedIndex + 1, totalItems - 1))
-      : (highlightedIndex < 0 ? totalItems - 1 : Math.max(highlightedIndex - 1, 0));
+      ? (highlightedIndex < 0 ? 0 : (highlightedIndex + 1) % totalItems)
+      : (highlightedIndex <= 0 ? totalItems - 1 : highlightedIndex - 1);
     const nextItem = selectableItems[nextIndex];
     if (nextItem) {
       setHighlightedItemKey(nextItem.key);
@@ -728,6 +728,8 @@ export function LocationPicker({
       e.preventDefault();
       if (mode === 'repo-options') {
         handleBack();
+      } else if (highlightedItemKey) {
+        setHighlightedItemKey(null);
       } else {
         handleClosePicker();
       }
@@ -750,6 +752,7 @@ export function LocationPicker({
     handleBack,
     handleClosePicker,
     handleTargetChange,
+    highlightedItemKey,
     mode,
     movePathSelection,
     orderedAgentList,
@@ -765,6 +768,7 @@ export function LocationPicker({
       <div
         className="location-picker"
         data-testid="location-picker"
+        tabIndex={-1}
         onClick={(e) => e.stopPropagation()}
         onKeyDown={handleDialogKeyDown}
       >
@@ -781,6 +785,7 @@ export function LocationPicker({
                     key={candidate}
                     type="button"
                     className={`agent-option ${agent === candidate ? 'active' : ''}`}
+                    onMouseDown={(e) => e.preventDefault()}
                     onClick={() => handleAgentChange(candidate)}
                     role="radio"
                     aria-checked={agent === candidate}
@@ -810,6 +815,7 @@ export function LocationPicker({
                   className={`endpoint-option ${active ? 'active' : ''} ${active && yoloMode ? 'yolo-active' : ''}`}
                   data-testid={target.id === LOCAL_TARGET ? 'location-picker-target-local' : `location-picker-target-${target.id}`}
                   data-endpoint-id={target.endpointId}
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => handleTargetChange(target.id)}
                   role="radio"
                   aria-checked={active}
@@ -877,8 +883,8 @@ export function LocationPicker({
                       data-index={index}
                       data-kind="recent"
                       data-path={loc.selectionPath}
-                      onClick={() => setHighlightedItemKey(`recent:${loc.path}`)}
-                      onDoubleClick={() => void handleSelectPath(loc.selectionPath)}
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => void handleSelectPath(loc.selectionPath)}
                     >
                       <div className="picker-icon">🕐</div>
                       <div className="picker-info">
@@ -903,8 +909,8 @@ export function LocationPicker({
                         data-index={globalIndex}
                         data-kind="directory"
                         data-path={item.path}
-                        onClick={() => setHighlightedItemKey(`directory:${item.path}`)}
-                        onDoubleClick={() => void handleSelectPath(item.path)}
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={() => void handleSelectPath(item.path)}
                       >
                         <div className="picker-icon">📁</div>
                         <div className="picker-info">

--- a/app/src/components/NewSessionDialog/RepoOptions.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.tsx
@@ -42,6 +42,12 @@ const baseName = (path: string) => {
   return parts[parts.length - 1] || path;
 };
 
+const tildify = (path: string): string => {
+  const homeMatch = /^(\/(?:Users|home)\/[^/]+)/.exec(path);
+  if (!homeMatch) return path;
+  return '~' + path.slice(homeMatch[1].length);
+};
+
 type DestinationItem =
   | {
       kind: 'main-repo';
@@ -85,8 +91,8 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
         branch: repoInfo.currentBranch,
         icon: '●',
         iconColor: 'icon-green',
-        name: baseName(repoInfo.repo),
-        detail: `${repoInfo.repo} • ${repoInfo.currentBranch} • ${repoInfo.currentCommitHash.substring(0, 7)} • ${formatTime(repoInfo.currentCommitTime)}`,
+        name: repoInfo.currentBranch,
+        detail: `${tildify(repoInfo.repo)} • ${repoInfo.currentCommitHash.substring(0, 7)} • ${formatTime(repoInfo.currentCommitTime)}`,
       },
       ...repoInfo.worktrees.map((worktree) => ({
         kind: 'worktree' as const,
@@ -94,8 +100,8 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
         branch: worktree.branch,
         icon: '◎',
         iconColor: 'icon-purple',
-        name: baseName(worktree.path),
-        detail: `${worktree.path} • ${worktree.branch}`,
+        name: worktree.branch,
+        detail: tildify(worktree.path),
       })),
     ],
     [repoInfo],


### PR DESCRIPTION
## Changes

**LocationPicker**
- Arrow key navigation wraps around (down at last item → first; up at first → last)
- Clicking a folder/recent item now selects it immediately (was highlight-only; double-click to select)
- First Escape deselects a keyboard-highlighted item; second Escape closes the dialog
- Escape now works regardless of focus: `onMouseDown` on buttons and list items keeps focus in the path input; `tabIndex={-1}` on the picker div catches background clicks

**RepoOptions**
- Left column shows branch name instead of the folder basename (was redundant with the detail column for worktrees)
- Path detail replaces `$HOME` with `~` (`/Users/<name>` and `/home/<name>` prefixes)