### PR TITLE
feat: add muted sessions for deferring without closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-04-13]
+
+### Added
+- **Muted Sessions**: Sessions can now be muted to park them out of active attention surfaces without closing them. A 🔕 button appears on session rows in the sidebar on hover; muted sessions move to a collapsed "Muted Sessions" section at the sidebar bottom. The dashboard shows a "Muted Sessions (N)" summary group that navigates to the sessions view and expands the muted section on click. Unmuting restores the session to the normal list in its current state. Muted state persists across restarts.
+
 ## [2026-04-12]
 
 ### Added

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1914,6 +1914,7 @@ sendFetchPRDetails,
           onOpenPR={handleOpenPR}
           onOpenSettings={() => setSettingsOpen(true)}
           onMutedGroupClick={() => {
+            setSidebarCollapsed(false);
             setSidebarMutedExpanded(true);
             setView('session');
           }}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -242,6 +242,7 @@ function App() {
     sendMutePR,
     sendMuteRepo,
     sendMuteAuthor,
+    sendMuteSession,
     sendPRVisited,
     sendRefreshPRs,
     sendUnregisterSession,
@@ -344,6 +345,7 @@ function App() {
         sendMutePR={sendMutePR}
         sendMuteRepo={sendMuteRepo}
         sendMuteAuthor={sendMuteAuthor}
+        sendMuteSession={sendMuteSession}
         sendPRVisited={sendPRVisited}
         sendRefreshPRs={sendRefreshPRs}
         sendUnregisterSession={sendUnregisterSession}
@@ -415,6 +417,7 @@ interface AppContentProps {
   sendMutePR: ReturnType<typeof useDaemonSocket>['sendMutePR'];
   sendMuteRepo: ReturnType<typeof useDaemonSocket>['sendMuteRepo'];
   sendMuteAuthor: ReturnType<typeof useDaemonSocket>['sendMuteAuthor'];
+  sendMuteSession: ReturnType<typeof useDaemonSocket>['sendMuteSession'];
   sendPRVisited: ReturnType<typeof useDaemonSocket>['sendPRVisited'];
   sendRefreshPRs: ReturnType<typeof useDaemonSocket>['sendRefreshPRs'];
   sendUnregisterSession: ReturnType<typeof useDaemonSocket>['sendUnregisterSession'];
@@ -481,6 +484,7 @@ function AppContent({
   sendMutePR,
   sendMuteRepo,
   sendMuteAuthor,
+  sendMuteSession,
   sendPRVisited,
   sendRefreshPRs,
   sendUnregisterSession,
@@ -708,8 +712,12 @@ sendFetchPRDetails,
       isWorktree: daemonSession?.is_worktree ?? s.isWorktree,
       recoverable: daemonSession?.recoverable ?? false,
       reviewLoopStatus: reviewLoop?.status,
+      muted: daemonSession?.muted ?? false,
     };
   });
+
+  const unmutedEnrichedSessions = enrichedLocalSessions.filter((s) => !s.muted);
+  const mutedEnrichedSessions = enrichedLocalSessions.filter((s) => s.muted);
 
   const {
     eventRouter: paneRuntimeEventRouter,
@@ -739,6 +747,9 @@ sendFetchPRDetails,
   }, [connect]);
 
   type DockPanelId = 'diff' | 'reviewLoop' | 'attention' | 'diffDetail';
+
+  // Muted section expansion (controlled by Dashboard click)
+  const [sidebarMutedExpanded, setSidebarMutedExpanded] = useState(false);
 
   // View state management
   const [view, setView] = useState<'dashboard' | 'session'>('dashboard');
@@ -1447,8 +1458,8 @@ sendFetchPRDetails,
     setClosedWorktree(null);
   }, []);
 
-  // Calculate attention count for drawer badge
-  const waitingLocalSessions = enrichedLocalSessions
+  // Calculate attention count for drawer badge (muted sessions excluded)
+  const waitingLocalSessions = unmutedEnrichedSessions
     .filter((s) => isAttentionSessionState(s.state) || s.reviewLoopStatus === 'awaiting_user' || s.reviewLoopStatus === 'error')
     .map((s) => ({
       ...s,
@@ -1463,15 +1474,15 @@ sendFetchPRDetails,
 
   // Keyboard shortcut handlers
   const handleJumpToWaiting = useCallback(() => {
-    const waiting = enrichedLocalSessions.find((s) =>
+    const waiting = unmutedEnrichedSessions.find((s) =>
       isAttentionSessionState(s.state) || s.reviewLoopStatus === 'awaiting_user' || s.reviewLoopStatus === 'error'
     );
     if (waiting) {
       handleSelectSession(waiting.id);
     }
-  }, [enrichedLocalSessions, handleSelectSession]);
+  }, [unmutedEnrichedSessions, handleSelectSession]);
 
-  const sessionGroups = useMemo(() => groupSessionsByDirectory(enrichedLocalSessions), [enrichedLocalSessions]);
+  const sessionGroups = useMemo(() => groupSessionsByDirectory(unmutedEnrichedSessions), [unmutedEnrichedSessions]);
 
   // Use visual (grouped) order so ⌘1-9 and prev/next match the sidebar
   const visualSessions = useMemo(() => sessionGroups.flatMap((group) => group.sessions), [sessionGroups]);
@@ -1890,7 +1901,8 @@ sendFetchPRDetails,
       {/* Dashboard - always rendered, shown/hidden via z-index */}
       <div className={`view-container ${view === 'dashboard' ? 'visible' : 'hidden'}`}>
         <Dashboard
-          sessions={enrichedLocalSessions}
+          sessions={unmutedEnrichedSessions}
+          mutedSessions={mutedEnrichedSessions}
           prs={prs}
           isLoading={!hasReceivedInitialState}
           isRefreshing={isRefreshingPRs}
@@ -1901,6 +1913,10 @@ sendFetchPRDetails,
           onRefreshPRs={handleRefreshPRs}
           onOpenPR={handleOpenPR}
           onOpenSettings={() => setSettingsOpen(true)}
+          onMutedGroupClick={() => {
+            setSidebarMutedExpanded(true);
+            setView('session');
+          }}
         />
       </div>
 
@@ -1914,6 +1930,10 @@ sendFetchPRDetails,
           collapsed={sidebarCollapsed}
           headerActions={sidebarHeaderActions}
           footerShortcuts={sidebarFooterShortcuts}
+          mutedSessions={mutedEnrichedSessions}
+          mutedExpanded={sidebarMutedExpanded}
+          onMutedExpandedChange={setSidebarMutedExpanded}
+          onMuteSession={sendMuteSession}
           onSelectSession={handleSelectSession}
           onNewSession={handleNewSession}
           onCloseSession={handleRequestCloseSession}

--- a/app/src/components/Dashboard.css
+++ b/app/src/components/Dashboard.css
@@ -849,3 +849,20 @@
 .pr-row.approved:hover {
   opacity: 0.8;
 }
+
+/* Muted sessions summary group */
+.session-group.muted-summary {
+  cursor: pointer;
+  border-top: 1px solid var(--color-border);
+  padding-top: 4px;
+  margin-top: 4px;
+}
+
+.session-group.muted-summary:hover .group-label {
+  color: var(--color-text-dimmed);
+}
+
+.group-label.dim {
+  color: var(--color-text-muted);
+  font-style: italic;
+}

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -17,16 +17,19 @@ import {
 import appIcon from '../assets/icon.png';
 import './Dashboard.css';
 
+type DashboardSession = {
+  id: string;
+  label: string;
+  state: UISessionState;
+  cwd: string;
+  endpointName?: string;
+  endpointStatus?: string;
+  reviewLoopStatus?: string;
+};
+
 interface DashboardProps {
-  sessions: Array<{
-    id: string;
-    label: string;
-    state: UISessionState;
-    cwd: string;
-    endpointName?: string;
-    endpointStatus?: string;
-    reviewLoopStatus?: string;
-  }>;
+  sessions: DashboardSession[];
+  mutedSessions?: DashboardSession[];
   prs: DaemonPR[];
   isLoading: boolean;
   isRefreshing?: boolean;
@@ -37,10 +40,12 @@ interface DashboardProps {
   onRefreshPRs?: () => void;
   onOpenPR?: (pr: DaemonPR) => void;
   onOpenSettings: () => void;
+  onMutedGroupClick?: () => void;
 }
 
 export function Dashboard({
   sessions,
+  mutedSessions = [],
   prs,
   isLoading,
   isRefreshing,
@@ -51,6 +56,7 @@ export function Dashboard({
   onRefreshPRs,
   onOpenPR,
   onOpenSettings,
+  onMutedGroupClick,
 }: DashboardProps) {
   const reviewLoopIndicator = (status?: string): { glyph: string; label: string } | null => {
     switch (status) {
@@ -245,7 +251,7 @@ export function Dashboard({
             </button>
           </div>
           <div className="card-body">
-            {sessions.length === 0 ? (
+            {sessions.length === 0 && mutedSessions.length === 0 ? (
               <div className="card-empty">No active sessions</div>
             ) : (
               <>
@@ -389,6 +395,15 @@ export function Dashboard({
                         )}
                       </div>
                     ))}
+                  </div>
+                )}
+                {mutedSessions.length > 0 && (
+                  <div
+                    className="session-group muted-summary clickable"
+                    data-testid="session-group-muted"
+                    onClick={onMutedGroupClick}
+                  >
+                    <div className="group-label dim">Muted Sessions ({mutedSessions.length})</div>
                   </div>
                 )}
               </>

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -403,6 +403,7 @@
 .session-actions {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 2px;
   opacity: 0;
   pointer-events: none;
@@ -423,8 +424,14 @@
   cursor: pointer;
   padding: 0;
   width: 14px;
+  height: 14px;
   line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
 }
+
 
 .session-action-btn:hover {
   color: var(--color-text-primary);
@@ -568,4 +575,66 @@
 @keyframes flash-pending {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.3; }
+}
+
+/* Muted sessions section */
+.muted-sessions-section {
+  border-top: 1px solid var(--color-border);
+  padding: 4px 0;
+}
+
+.muted-sessions-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.muted-sessions-header:hover {
+  color: var(--color-text-dimmed);
+}
+
+.muted-sessions-chevron {
+  font-size: 9px;
+  transition: transform 120ms ease;
+  display: inline-block;
+}
+
+.muted-sessions-chevron.expanded {
+  transform: rotate(90deg);
+}
+
+.muted-sessions-list {
+  padding: 0;
+}
+
+.muted-session {
+  opacity: 0.55;
+}
+
+.muted-session:hover {
+  opacity: 0.75;
+}
+
+.muted-session[data-state="waiting_input"]::before {
+  display: none;
+}
+
+.session-action-btn.mute-session-btn {
+  opacity: 0;
+}
+
+.session-item:hover .session-action-btn.mute-session-btn {
+  opacity: 1;
 }

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import './Sidebar.css';
 import type { ReactNode } from 'react';
+import { useState } from 'react';
 import { StateIndicator } from './StateIndicator';
 import { isAttentionSessionState, type UISessionState } from '../types/sessionState';
 import type { SessionGroup } from '../utils/sessionGrouping';
@@ -17,6 +18,7 @@ interface LocalSession {
   endpointStatus?: string;
   recoverable?: boolean;
   reviewLoopStatus?: string;
+  muted?: boolean;
 }
 
 function reviewLoopIndicator(status?: string): { glyph: string; label: string } | null {
@@ -44,6 +46,10 @@ interface SidebarProps {
   collapsed: boolean;
   headerActions: SidebarHeaderAction[];
   footerShortcuts?: FooterShortcut[];
+  mutedSessions?: LocalSession[];
+  mutedExpanded?: boolean;
+  onMutedExpandedChange?: (expanded: boolean) => void;
+  onMuteSession?: (id: string) => void;
   onSelectSession: (id: string) => void;
   onNewSession: () => void;
   onCloseSession: (id: string) => void;
@@ -101,6 +107,7 @@ function ExpandIcon() {
   );
 }
 
+
 export function ReviewLoopIcon() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
@@ -149,6 +156,10 @@ export function Sidebar({
   collapsed,
   headerActions,
   footerShortcuts,
+  mutedSessions = [],
+  mutedExpanded: mutedExpandedProp,
+  onMutedExpandedChange,
+  onMuteSession,
   onSelectSession,
   onNewSession,
   onCloseSession,
@@ -156,6 +167,13 @@ export function Sidebar({
   onGoToDashboard,
   onToggleCollapse,
 }: SidebarProps) {
+  const [mutedExpandedLocal, setMutedExpandedLocal] = useState(false);
+  const mutedExpanded = mutedExpandedProp ?? mutedExpandedLocal;
+  const setMutedExpanded = (v: boolean) => {
+    setMutedExpandedLocal(v);
+    onMutedExpandedChange?.(v);
+  };
+
   const visualIndexOf = (id: string) => visualIndexBySessionId.get(id) ?? -1;
   const dockShortcutHints = Array.from(new Map([
     ...headerActions
@@ -291,6 +309,20 @@ export function Sidebar({
                 {session.isWorktree && <span className="worktree-indicator">⎇</span>}
                 <span className="session-shortcut">⌘{globalIndex + 1}</span>
                 <div className="session-actions">
+                  {onMuteSession && (
+                    <button
+                      className="session-action-btn mute-session-btn"
+                      data-testid={`mute-session-${session.id}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onMuteSession(session.id);
+                      }}
+                      title="Mute session"
+                      aria-label={`Mute session ${session.label}`}
+                    >
+                      ⊘
+                    </button>
+                  )}
                   <button
                     className="session-action-btn close-session-btn"
                     data-testid={`close-session-${session.id}`}
@@ -366,6 +398,20 @@ export function Sidebar({
                     {session.isWorktree && <span className="worktree-indicator">⎇</span>}
                     <span className="session-shortcut">⌘{globalIndex + 1}</span>
                     <div className="session-actions">
+                      {onMuteSession && (
+                        <button
+                          className="session-action-btn mute-session-btn"
+                          data-testid={`mute-session-${session.id}`}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onMuteSession(session.id);
+                          }}
+                          title="Mute session"
+                          aria-label={`Mute session ${session.label}`}
+                        >
+                          ⊘
+                        </button>
+                      )}
                       <button
                         className="session-action-btn close-session-btn"
                         data-testid={`close-session-${session.id}`}
@@ -398,6 +444,60 @@ export function Sidebar({
           );
         })}
       </div>
+
+      {mutedSessions.length > 0 && (
+        <div className="muted-sessions-section">
+          <button
+            className="muted-sessions-header"
+            onClick={() => setMutedExpanded(!mutedExpanded)}
+            aria-expanded={mutedExpanded}
+          >
+            <span className={`muted-sessions-chevron ${mutedExpanded ? 'expanded' : ''}`}>▸</span>
+            Muted Sessions ({mutedSessions.length})
+          </button>
+          {mutedExpanded && (
+            <div className="muted-sessions-list">
+              {mutedSessions.map((session) => (
+                <div
+                  key={session.id}
+                  className={`session-item muted-session ${selectedId === session.id ? 'selected' : ''}`}
+                  data-testid={`sidebar-session-${session.id}`}
+                  data-state={session.state}
+                  onClick={() => onSelectSession(session.id)}
+                >
+                  <StateIndicator state={session.state} size="md" seed={session.id} />
+                  <div className="session-info">
+                    <span className="session-label">{session.label}</span>
+                    {session.endpointName && (
+                      <span className={`session-endpoint-badge status-${session.endpointStatus || 'connected'}`}>
+                        {session.endpointName}
+                      </span>
+                    )}
+                    {session.branch && (
+                      <span className="session-branch">{session.branch}</span>
+                    )}
+                  </div>
+                  <div className="session-actions">
+                    {onMuteSession && (
+                      <button
+                        className="session-action-btn unmute-session-btn"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onMuteSession(session.id);
+                        }}
+                        title="Unmute session"
+                        aria-label={`Unmute session ${session.label}`}
+                      >
+                        ⊙
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       <div className="sidebar-footer">
         <span className="sidebar-footer-label">Dock</span>

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -2367,6 +2367,13 @@ export function useDaemonSocket({
     ws.send(JSON.stringify({ cmd: 'mute_author', author }));
   }, [onAuthorsUpdate]);
 
+  // Mute a session (toggle muted state)
+  const sendMuteSession = useCallback((id: string) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({ cmd: 'mute', id }));
+  }, []);
+
   // Request daemon to refresh PRs from GitHub
   const sendRefreshPRs = useCallback((): Promise<PRActionResult> => {
     return new Promise((resolve, reject) => {
@@ -3334,6 +3341,7 @@ export function useDaemonSocket({
     sendMutePR,
     sendMuteRepo,
     sendMuteAuthor,
+    sendMuteSession,
     sendRefreshPRs,
     sendFetchPRDetails,
     sendClearSessions,

--- a/docs/plans/2026-04-07-muted-sessions.md
+++ b/docs/plans/2026-04-07-muted-sessions.md
@@ -1,0 +1,225 @@
+# Muted Sessions UX Plan
+
+Date: 2026-04-07
+Status: Done
+Owner: app/session attention UX
+
+## Summary
+
+Add a first-class `mute session` workflow for sessions the user wants to keep alive but remove from active attention surfaces.
+
+This is explicitly not a state rewrite. A muted session preserves its real runtime state, but it is removed from the normal attention model and parked in a collapsed `Muted Sessions` section.
+
+The core user problem is:
+
+1. some sessions remain alive and legitimately `waiting_input`
+2. the user does not want to close them yet
+3. the user also does not want them to keep pulling visual attention for the rest of the day
+
+## Chosen UX Model
+
+Use `mute` rather than `mark as read`.
+
+Why:
+
+1. `mark as read` implies the issue has been handled
+2. changing `waiting_input` to `idle` would collapse "done" and "deferred" into the same signal
+3. `mute` better matches the intended user action: keep it, hide it, come back later
+
+This also fits the current backend model, which already includes a session-level `muted` field in the session schema and attention adapter path.
+
+## Product Rules
+
+### Meaning of mute
+
+Muting a session means:
+
+1. the session stays alive
+2. the session keeps its true underlying state
+3. the session is removed from active attention surfaces
+4. the session is parked in a dedicated muted area until manually unmuted
+
+Unmuting a session means:
+
+1. remove the muted flag
+2. return the session to the normal visible list
+3. show it with whatever its current real state is at that moment
+
+If a muted session is still `waiting_input` when unmuted, it returns as yellow.
+
+### Attention behavior
+
+Muted sessions should not:
+
+1. count toward the global attention count
+2. appear in the attention drawer
+3. appear in `Waiting for input` session groups
+4. participate in jump-to-waiting behavior
+
+Muted sessions should:
+
+1. remain visible in a separate muted inventory area
+2. preserve their underlying state for eventual restoration
+
+### Persistence
+
+Muted state should persist across app restarts and daemon restarts.
+
+Muted sessions should remain muted even if their underlying state changes while parked.
+
+## Sidebar UX
+
+### Row action
+
+Add a `Mute` action to session rows in the normal session list.
+
+Placement:
+
+1. alongside existing row actions on hover
+2. available from the sessions sidebar, not only from the dashboard
+
+Initial scope:
+
+1. allow mute for all normal sessions
+2. primary motivation is `waiting_input`, but the interaction need also applies to other sessions the user wants out of view temporarily
+
+### Muted section
+
+Add a dedicated `Muted Sessions` section at the bottom of the left sidebar.
+
+Rules:
+
+1. it is collapsed by default
+2. collapsed header shows count only
+3. example label: `Muted Sessions (4)`
+4. no per-state summary appears in the collapsed header
+
+When expanded:
+
+1. show the full muted session rows
+2. each row includes label, branch, and endpoint/location metadata consistent with the normal sidebar treatment
+3. rows are visually subdued relative to active sessions
+4. each row exposes an `Unmute` action
+
+### Visual treatment
+
+Muted sessions should feel parked, not active.
+
+Recommended treatment:
+
+1. muted section header uses dim text and low-contrast styling
+2. muted rows use subdued text and no attention glow
+3. real state dots may still appear, but muted styling must dominate
+4. muted rows should not look like urgent work even if their underlying state is `waiting_input`
+
+### Ordering
+
+The muted section lives below the normal visible session list.
+
+Within the muted section, preserve stable ordering rather than trying to surface urgency. The whole point is that these rows are intentionally deprioritized.
+
+## Dashboard UX
+
+### Muted summary group
+
+Add a collapsed muted summary group to the Sessions card on the dashboard.
+
+Rules:
+
+1. place it after the normal session groups
+2. show count only
+3. example label: `Muted Sessions (4)`
+4. do not expand muted sessions inline on the dashboard
+
+### Click behavior
+
+Clicking the dashboard muted group should:
+
+1. switch to the sessions view
+2. ensure the sidebar is visible
+3. expand the `Muted Sessions` section in the sidebar
+
+The dashboard remains a summary surface. Session management happens in the sidebar.
+
+## Interaction Details
+
+### Mute flow
+
+When the user mutes a session:
+
+1. the session animates out of the normal list
+2. it moves into the muted section
+3. the attention count updates immediately
+4. the attention drawer no longer includes it
+5. a toast appears: `Session muted. Undo`
+
+### Unmute flow
+
+When the user unmutes a session:
+
+1. it leaves the muted section
+2. it returns to the normal session list based on its current real state
+3. if it is still `waiting_input`, it reappears in the relevant yellow attention surfaces
+
+### Undo
+
+Reuse the existing short-lived undo toast pattern already used for mute-related actions elsewhere in the app.
+
+## Data Model And Implementation Direction
+
+The important product rule is to preserve real state and treat mute as an attention-layer override.
+
+Implementation direction:
+
+1. reuse the existing session `muted` field rather than inventing a fake `read` or `idle` state
+2. filter muted sessions out of attention calculations
+3. surface muted sessions in a dedicated sidebar/dashboard summary path
+4. keep session state transitions independent from mute transitions
+
+This avoids conflating:
+
+1. `idle`: truly done
+2. `waiting_input`: needs input
+3. `muted`: intentionally parked by the user
+
+## Non-goals
+
+This plan does not include:
+
+1. automatic unmute behavior
+2. time-based snoozing
+3. per-state counts inside the muted group header
+4. inline dashboard expansion of muted sessions
+5. rewriting session runtime state to simulate read/done behavior
+
+## Suggested Implementation Phases
+
+### Phase 1: Functional mute support
+
+1. expose session mute/unmute controls in the frontend
+2. remove muted sessions from attention counts and drawer surfaces
+3. add sidebar `Muted Sessions` section with collapsed-by-default behavior
+4. add mute undo toast
+
+### Phase 2: Dashboard integration
+
+1. add dashboard muted summary group
+2. route dashboard click into sessions view with muted section expanded
+
+### Phase 3: Polish
+
+1. refine muted row styling and transitions
+2. verify keyboard navigation and accessibility behavior
+3. add tests for mute persistence and attention-count exclusion
+
+## Acceptance Criteria
+
+The feature is correct when:
+
+1. muting a `waiting_input` session removes it from yellow attention surfaces without closing it
+2. the sidebar shows a collapsed `Muted Sessions (N)` section at the bottom
+3. expanding the muted section reveals full session rows with metadata and unmute actions
+4. the dashboard shows a collapsed muted summary group with count only
+5. clicking the dashboard muted summary navigates to the sessions view and expands the sidebar muted section
+6. unmuting restores the session to the normal list in its true current state
+7. muted sessions remain muted across restart

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -691,6 +691,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleMuteRepoWS(msg.(*protocol.MuteRepoMessage))
 	case protocol.CmdMuteAuthor:
 		d.handleMuteAuthorWS(msg.(*protocol.MuteAuthorMessage))
+	case protocol.CmdMute:
+		d.handleMuteSessionWS(msg.(*protocol.MuteMessage))
 	case protocol.CmdRefreshPRs:
 		d.handleRefreshPRsWS(client)
 	case protocol.CmdFetchPRDetails:

--- a/internal/daemon/ws_session.go
+++ b/internal/daemon/ws_session.go
@@ -9,6 +9,11 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
+func (d *Daemon) handleMuteSessionWS(msg *protocol.MuteMessage) {
+	d.store.ToggleMute(msg.ID)
+	d.broadcastSessionsUpdated()
+}
+
 func (d *Daemon) handleClearSessionsWS() {
 	d.logf("Clearing all sessions")
 	d.clearAllSessions()


### PR DESCRIPTION
## Summary

- Adds a first-class mute workflow: sessions can be parked out of active attention surfaces without being closed
- Muted sessions are excluded from the attention count, attention drawer, sidebar session groups, dashboard state groups, and jump-to-waiting (⌘J)
- A collapsed "Muted Sessions" section appears at the bottom of the sidebar; expanding it shows full session rows with an unmute action
- The dashboard shows a collapsed muted summary group that navigates to the sessions view and expands the sidebar muted section on click
- Mute state persists across app and daemon restarts via the existing SQLite `muted` field
- Unmuting restores the session to the normal list in its true current state

## Implementation notes

- Daemon: wired `CmdMute` → `handleMuteSessionWS` → `store.ToggleMute` + `broadcastSessionsUpdated` (fire-and-forget, no result event needed)
- Frontend: `unmutedEnrichedSessions` / `mutedEnrichedSessions` split in `AppContent` ensures all attention surfaces stay consistent from a single source
- No protocol changes or `make generate-types` needed — `MuteMessage`, `CmdMute`, and `Session.muted` were already in the generated types