### PR TITLE
fix: centralize overlay dismiss with a capture-phase Escape stack

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1624,19 +1624,6 @@ sendFetchPRDetails,
     setInitialReviewFile(null);
   }, [closeDockPanel]);
 
-  useEffect(() => {
-    if (!diffDetailPanelOpen) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        handleCloseDiffDetailPanel();
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown, true);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown, true);
-    };
-  }, [diffDetailPanelOpen, handleCloseDiffDetailPanel]);
 
   const isZedEditorConfigured = useMemo(() => {
     const editor = (settings.editor_executable || '').trim().toLowerCase();

--- a/app/src/components/CloseSessionPrompt.tsx
+++ b/app/src/components/CloseSessionPrompt.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import type { KeyboardEvent } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
 import './CloseSessionPrompt.css';
 
 interface CloseSessionPromptProps {
@@ -20,20 +21,14 @@ export function CloseSessionPrompt({
   const confirmRef = useRef<HTMLButtonElement>(null);
   const cancelRef = useRef<HTMLButtonElement>(null);
 
-  const handleConfirm = useCallback(() => {
-    onConfirm();
-  }, [onConfirm]);
-
-  const handleCancel = useCallback(() => {
-    onCancel();
-  }, [onCancel]);
+  useEscapeStack(onCancel, isVisible);
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     const buttons = [confirmRef.current, cancelRef.current].filter(Boolean) as HTMLButtonElement[];
     const key = event.key.toLowerCase();
     const active = document.activeElement as HTMLButtonElement | null;
 
-    if (event.key === 'Escape' || key === 'n') {
+    if (key === 'n') {
       event.preventDefault();
       onCancel();
       return;
@@ -91,7 +86,7 @@ export function CloseSessionPrompt({
   const splitLabel = splitCount === 1 ? '1 split terminal' : `${splitCount} split terminals`;
 
   return (
-    <div className="close-session-prompt" role="presentation" onClick={handleCancel}>
+    <div className="close-session-prompt" role="presentation" onClick={onCancel}>
       <div
         className="close-session-content"
         role="dialog"
@@ -114,10 +109,10 @@ export function CloseSessionPrompt({
           Enter / Space uses the focused button, Y confirms, N / Esc cancel
         </div>
         <div className="close-session-actions">
-          <button ref={confirmRef} className="close-session-btn confirm" onClick={handleConfirm}>
+          <button ref={confirmRef} className="close-session-btn confirm" onClick={onConfirm}>
             Close Session
           </button>
-          <button ref={cancelRef} className="close-session-btn cancel" onClick={handleCancel}>
+          <button ref={cancelRef} className="close-session-btn cancel" onClick={onCancel}>
             Keep Session
           </button>
         </div>

--- a/app/src/components/CommentPopover.tsx
+++ b/app/src/components/CommentPopover.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { ReviewComment } from '../types/generated';
+import { useEscapeStack } from '../hooks/useEscapeStack';
 import './CommentPopover.css';
 
 interface CommentPopoverProps {
@@ -63,10 +64,10 @@ export function CommentPopover({
     }
   };
 
+  useEscapeStack(onCancel, true); // enabled while mounted; parent controls visibility
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      onCancel();
-    } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       handleSave();
     }

--- a/app/src/components/DiffDetailPanel.tsx
+++ b/app/src/components/DiffDetailPanel.tsx
@@ -1,5 +1,6 @@
 // app/src/components/DiffDetailPanel.tsx
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
 import type { GitStatusUpdate, FileDiffResult, ReviewState, BranchDiffFile, BranchDiffFilesResult } from '../hooks/useDaemonSocket';
 import type { ResolvedTheme } from '../hooks/useTheme';
 import type { ReviewComment } from '../types/generated';
@@ -658,13 +659,16 @@ export function DiffDetailPanel({
     });
   }, [gitStatus, viewedFiles, selectedFilePath, allFiles, fetchDiff, baseRef]);
 
-  // Keyboard navigation
+  useEscapeStack(onClose, isOpen);
+
+  // Keyboard navigation — capture phase to intercept before CodeMirror
   useEffect(() => {
     if (!isOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Don't capture keystrokes when typing in inputs
       const target = e.target as HTMLElement;
+
+      // Don't capture navigation keystrokes when typing in inputs or editors
       if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
         return;
       }
@@ -731,7 +735,7 @@ export function DiffDetailPanel({
 
     window.addEventListener('keydown', handleKeyDown, true);
     return () => window.removeEventListener('keydown', handleKeyDown, true);
-  }, [isOpen, onClose, allFiles, selectedFile]);
+  }, [isOpen, allFiles, selectedFile]);
 
   const navigateFiles = useCallback((direction: 'prev' | 'next') => {
     if (!selectedFilePath || allFiles.length === 0) return;

--- a/app/src/components/ForkDialog.tsx
+++ b/app/src/components/ForkDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
 import './ForkDialog.css';
 
 interface ForkDialogProps {
@@ -55,15 +56,14 @@ export function ForkDialog({
     onFork(name.trim(), createWorktree);
   }, [name, createWorktree, isLoading, onFork]);
 
+  useEscapeStack(onClose, isOpen);
+
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      onClose();
-    } else if (e.key === 'Enter') {
+    if (e.key === 'Enter') {
       e.preventDefault();
       handleSubmit();
     }
-  }, [onClose, handleSubmit]);
+  }, [handleSubmit]);
 
   if (!isOpen) return null;
 

--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -228,30 +228,34 @@ describe('LocationPicker', () => {
     expect(firstItem).not.toHaveClass('selected');
   });
 
-  it('does not depend on a global window listener for picker navigation or escape', async () => {
-    const { onClose } = renderPicker();
+  it('ArrowDown on window does not affect picker input or item selection', () => {
+    renderPicker();
 
     const input = screen.getByRole('textbox') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '~/pro' } });
 
     fireEvent.keyDown(window, { key: 'ArrowDown' });
     expect(input.value).toBe('~/pro');
+    expect(screen.queryByTestId('location-picker-item-0')).not.toHaveClass?.('selected');
+  });
 
-    fireEvent.keyDown(window, { key: 'Escape' });
-    expect(onClose).not.toHaveBeenCalled();
+  it('Escape first deselects highlighted item then closes', async () => {
+    const { onClose } = renderPicker();
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '~/pro' } });
 
     fireEvent.keyDown(input, { key: 'ArrowDown' });
     await waitFor(() => {
-      expect(input.value).toBe('~/pro');
       expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
     });
 
-    // First Escape deselects the highlighted item without closing
+    // First Escape deselects without closing
     fireEvent.keyDown(input, { key: 'Escape' });
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.getByTestId('location-picker-item-0')).not.toHaveClass('selected');
 
-    // Second Escape closes the dialog
+    // Second Escape closes
     fireEvent.keyDown(input, { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
 import { useFilesystemSuggestions } from '../hooks/useFilesystemSuggestions';
 import { PathInput } from './NewSessionDialog/PathInput';
 import { RepoOptions } from './NewSessionDialog/RepoOptions';
@@ -703,6 +704,19 @@ export function LocationPicker({
     onClose();
   }, [invalidateRequestGeneration, onClose]);
 
+  const handleEscape = useCallback(() => {
+    if (mode === 'repo-options') {
+      // RepoOptions pushes its own sub-state handlers (pendingDeletePath, showNewWorktree)
+      // above this one in the escape stack. This branch fires only when those are inactive.
+      handleBack();
+    } else if (highlightedItemKey) {
+      setHighlightedItemKey(null);
+    } else {
+      handleClosePicker();
+    }
+  }, [mode, handleBack, highlightedItemKey, handleClosePicker]);
+  useEscapeStack(handleEscape, isOpen);
+
   const handleDialogKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.altKey && !e.metaKey && !e.ctrlKey) {
       const shortcutTargetId = targetShortcutIDByCode.get(e.code);
@@ -724,18 +738,6 @@ export function LocationPicker({
       }
     }
 
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      if (mode === 'repo-options') {
-        handleBack();
-      } else if (highlightedItemKey) {
-        setHighlightedItemKey(null);
-      } else {
-        handleClosePicker();
-      }
-      return;
-    }
-
     if (mode !== 'path-input') {
       return;
     }
@@ -749,10 +751,7 @@ export function LocationPicker({
     }
   }, [
     handleAgentChange,
-    handleBack,
-    handleClosePicker,
     handleTargetChange,
-    highlightedItemKey,
     mode,
     movePathSelection,
     orderedAgentList,

--- a/app/src/components/NewSessionDialog/RepoOptions.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useEscapeStack } from '../../hooks/useEscapeStack';
 import './RepoOptions.css';
 
 interface RepoInfo {
@@ -119,6 +120,18 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   const [newWorktreeName, setNewWorktreeName] = useState('');
   const [startingBranch, setStartingBranch] = useState<'current' | 'default'>('current');
   const [pendingDeletePath, setPendingDeletePath] = useState<string | null>(null);
+
+  // Sub-state Escape handling via the stack so LIFO order is preserved.
+  // pendingDeletePath and showNewWorktree are pushed above LocationPicker's handler.
+  const cancelPendingDelete = useCallback(() => setPendingDeletePath(null), []);
+  useEscapeStack(cancelPendingDelete, pendingDeletePath !== null);
+
+  const cancelNewWorktree = useCallback(() => {
+    setShowNewWorktree(false);
+    setNewWorktreeName('');
+    setFocusIndex(committedDestinationIndex);
+  }, [committedDestinationIndex]);
+  useEscapeStack(cancelNewWorktree, showNewWorktree);
 
   useEffect(() => {
     setPendingDeletePath(null);

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -1,5 +1,6 @@
 // app/src/components/SettingsModal.tsx
 import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
 import { open } from '@tauri-apps/plugin-dialog';
 import { DaemonEndpoint, DaemonSettings } from '../hooks/useDaemonSocket';
 import { normalizeSessionAgent, type SessionAgent } from '../types/sessionAgent';
@@ -177,21 +178,7 @@ export function SettingsModal({
     }
   }, [actualReviewLoopPresets, isOpen, selectedReviewLoopPresetID]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleGlobalKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') {
-        return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
-      onClose();
-    };
-
-    window.addEventListener('keydown', handleGlobalKeyDown, true);
-    return () => window.removeEventListener('keydown', handleGlobalKeyDown, true);
-  }, [isOpen, onClose]);
+  useEscapeStack(onClose, isOpen);
 
   const handleBrowse = useCallback(async () => {
     const selected = await open({

--- a/app/src/components/ThumbsModal.tsx
+++ b/app/src/components/ThumbsModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
 import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import FocusTrap from 'focus-trap-react';
@@ -105,23 +106,21 @@ export function ThumbsModal({ isOpen, terminalText, onClose, onCopy }: ThumbsMod
     }
   }, [findPatternByHint, handleAction]);
 
-  // Handle keyboard input
+  const handleEscape = useCallback(() => {
+    if (isFiltering) {
+      setIsFiltering(false);
+      setFilter('');
+    } else {
+      onClose();
+    }
+  }, [isFiltering, onClose]);
+  useEscapeStack(handleEscape, isOpen);
+
+  // Handle keyboard input (non-Escape keys)
   useEffect(() => {
     if (!isOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Escape handling
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        if (isFiltering) {
-          setIsFiltering(false);
-          setFilter('');
-        } else {
-          onClose();
-        }
-        return;
-      }
-
       // Enter to confirm filter and return to hint mode (keeps filter text)
       if (e.key === 'Enter' && isFiltering) {
         e.preventDefault();
@@ -182,7 +181,7 @@ export function ThumbsModal({ isOpen, terminalText, onClose, onCopy }: ThumbsMod
         clearTimeout(hintTimeoutRef.current);
       }
     };
-  }, [isOpen, isFiltering, hintBuffer, patterns, processHint, onClose]);
+  }, [isOpen, isFiltering, hintBuffer, patterns, processHint]);
 
   if (!isOpen) return null;
 

--- a/app/src/components/UnifiedDiffEditor.tsx
+++ b/app/src/components/UnifiedDiffEditor.tsx
@@ -10,6 +10,7 @@
  * - Comments attach to document positions, not DOM elements
  */
 import { useEffect, useRef, useCallback, useState, useMemo } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
 import { EditorView, Decoration, DecorationSet, WidgetType, gutter, GutterMarker } from '@codemirror/view';
 import { EditorState, StateField, StateEffect, RangeSetBuilder, Extension, Range } from '@codemirror/state';
 import { oneDark } from '@codemirror/theme-one-dark';
@@ -986,6 +987,11 @@ export function UnifiedDiffEditor({
 
   // Track which lines have open "new comment" forms
   const [newCommentLines, setNewCommentLines] = useState<Set<number>>(new Set());
+
+  // Dismiss inline comment forms via the escape stack so overlays stay LIFO
+  const cancelAllNewComments = useCallback(() => setNewCommentLines(new Set()), []);
+  useEscapeStack(cancelAllNewComments, newCommentLines.size > 0);
+  useEscapeStack(onCancelEdit, editingCommentId !== null);
 
   // Track text selection for popup
   const [selection, setSelection] = useState<{

--- a/app/src/components/WorktreeCleanupPrompt.tsx
+++ b/app/src/components/WorktreeCleanupPrompt.tsx
@@ -1,6 +1,7 @@
 // app/src/components/WorktreeCleanupPrompt.tsx
 import { useCallback, useEffect, useRef } from 'react';
 import type { KeyboardEvent } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
 import './WorktreeCleanupPrompt.css';
 
 interface WorktreeCleanupPromptProps {
@@ -25,29 +26,13 @@ export function WorktreeCleanupPrompt({
   const deleteRef = useRef<HTMLButtonElement>(null);
   const alwaysRef = useRef<HTMLButtonElement>(null);
 
-  const handleKeep = useCallback(() => {
-    onKeep();
-  }, [onKeep]);
-
-  const handleDelete = useCallback(() => {
-    onDelete();
-  }, [onDelete]);
-
-  const handleAlwaysKeep = useCallback(() => {
-    onAlwaysKeep();
-  }, [onAlwaysKeep]);
+  useEscapeStack(onKeep, isVisible);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
       const buttons = [keepRef.current, deleteRef.current, alwaysRef.current].filter(
         Boolean
       ) as HTMLButtonElement[];
-
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        onKeep();
-        return;
-      }
 
       if (event.key === 'Tab') {
         if (buttons.length === 0) return;
@@ -70,7 +55,7 @@ export function WorktreeCleanupPrompt({
       buttons[nextIndex]?.focus();
       event.preventDefault();
     },
-    [onKeep]
+    []
   );
 
   useEffect(() => {
@@ -113,17 +98,17 @@ export function WorktreeCleanupPrompt({
           Keep worktree <span className="cleanup-branch">{displayName}</span> for later?
         </div>
         <div className="cleanup-actions">
-          <button ref={keepRef} type="button" autoFocus className="cleanup-btn keep" onClick={handleKeep}>
+          <button ref={keepRef} type="button" autoFocus className="cleanup-btn keep" onClick={onKeep}>
             Keep
           </button>
-          <button ref={deleteRef} type="button" className="cleanup-btn delete" onClick={handleDelete}>
+          <button ref={deleteRef} type="button" className="cleanup-btn delete" onClick={onDelete}>
             Delete
           </button>
           <button
             ref={alwaysRef}
             type="button"
             className="cleanup-btn always"
-            onClick={handleAlwaysKeep}
+            onClick={onAlwaysKeep}
           >
             Always keep (this app run)
           </button>

--- a/app/src/hooks/useEscapeStack.test.ts
+++ b/app/src/hooks/useEscapeStack.test.ts
@@ -1,0 +1,71 @@
+import { renderHook, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useEscapeStack, _resetEscapeStackForTest } from './useEscapeStack';
+
+afterEach(() => {
+  _resetEscapeStackForTest();
+});
+
+describe('useEscapeStack', () => {
+  it('calls the handler when Escape is pressed', () => {
+    const handler = vi.fn();
+    renderHook(() => useEscapeStack(handler, true));
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call the handler when disabled', () => {
+    const handler = vi.fn();
+    renderHook(() => useEscapeStack(handler, false));
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-Escape keys', () => {
+    const handler = vi.fn();
+    renderHook(() => useEscapeStack(handler, true));
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('calls only the top handler (LIFO)', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    renderHook(() => useEscapeStack(first, true));
+    renderHook(() => useEscapeStack(second, true));
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the previous handler after the top is removed', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    renderHook(() => useEscapeStack(first, true));
+    const { unmount } = renderHook(() => useEscapeStack(second, true));
+
+    unmount();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it('always calls the latest handler reference', () => {
+    let count = 0;
+    const getHandler = () => () => { count++; };
+
+    const { rerender } = renderHook(({ h }) => useEscapeStack(h, true), {
+      initialProps: { h: getHandler() },
+    });
+    rerender({ h: getHandler() });
+    rerender({ h: getHandler() });
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(count).toBe(1); // called exactly once, not three times
+  });
+});

--- a/app/src/hooks/useEscapeStack.ts
+++ b/app/src/hooks/useEscapeStack.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Centralized Escape key dismiss stack.
+ *
+ * Rule: global Cmd-key shortcuts → shortcut registry.
+ *       Modal/overlay dismiss → this hook.
+ *
+ * When an overlay opens, it pushes a dismiss callback onto the stack.
+ * Escape calls only the top handler (LIFO), so nested overlays dismiss
+ * in the right order automatically.
+ *
+ * Capture phase is intentional: fires before xterm.js and any element-level
+ * handlers, so overlays always close regardless of what has DOM focus.
+ * When the stack is non-empty, stopPropagation() prevents the event from
+ * reaching background elements (xterm textarea, CodeMirror, etc.).
+ * All Escape dismiss handlers — including nested sub-states — must go
+ * through this hook so the LIFO ordering stays correct.
+ */
+
+const stack: Array<() => void> = [];
+
+let installedListener: ((e: KeyboardEvent) => void) | null = null;
+
+function ensureInstalled() {
+  if (installedListener) return;
+  installedListener = (e: KeyboardEvent) => {
+    if (e.key !== 'Escape') return;
+    const top = stack[stack.length - 1];
+    if (top) {
+      e.preventDefault();
+      e.stopPropagation(); // prevent xterm.js and other element handlers from also seeing it
+      top();
+    }
+  };
+  window.addEventListener('keydown', installedListener, true); // capture phase — fires before xterm.js
+}
+
+export function useEscapeStack(handler: () => void, enabled: boolean): void {
+  // Stable ref so the stack entry never needs replacing when handler changes.
+  const ref = useRef(handler);
+  ref.current = handler;
+
+  useEffect(() => {
+    ensureInstalled();
+    if (!enabled) return;
+    const fn = () => ref.current();
+    stack.push(fn);
+    return () => {
+      const i = stack.lastIndexOf(fn);
+      if (i !== -1) stack.splice(i, 1);
+    };
+  }, [enabled]); // only re-register when open/closed, not on every handler change
+}
+
+/** Exposed for test teardown only. Do not call in production code. */
+export function _resetEscapeStackForTest(): void {
+  stack.length = 0;
+  if (installedListener) {
+    window.removeEventListener('keydown', installedListener, true);
+    installedListener = null;
+  }
+}


### PR DESCRIPTION
## What

Introduces `useEscapeStack` — a LIFO capture-phase hook for dismissing overlays on Escape — and migrates all modals and overlays to use it.

## Why

Two bugs with the previous per-overlay Escape handlers:

1. **Nested overlays** had to coordinate manually to avoid both layers closing on a single Escape press.
2. **Terminal behind a modal**: xterm.js calls `stopPropagation()` on every keydown when its textarea has focus. The bubble-phase window listener never fired, so the modal couldn't be dismissed.

## How

The listener runs in **capture phase** (parallel to `useShortcut`), which fires before xterm.js regardless of what has DOM focus.

- When the stack is **non-empty**: `stopPropagation()` prevents background elements from also handling the event.
- When the stack is **empty**: Escape propagates normally so terminal apps (vi, less, etc.) keep working.

Components with Escape sub-states (`RepoOptions` pending-delete / new-worktree form, `UnifiedDiffEditor` inline comment forms) push their own handlers above the parent's, so LIFO ordering handles dismiss sequencing automatically without extra coordination between components.

## Components migrated

`SettingsModal`, `DiffDetailPanel`, `CommentPopover`, `CloseSessionPrompt`, `ForkDialog`, `ThumbsModal`, `WorktreeCleanupPrompt`, `LocationPicker`, `RepoOptions`, `UnifiedDiffEditor`