### PR TITLE
fix: forward mute command to remote endpoint sessions

### DIFF
--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -894,6 +894,10 @@ func (d *Daemon) tryHandleRemoteWSCommand(client *wsClient, cmd string, msg inte
 
 func remoteCommandSessionID(cmd string, msg interface{}) string {
 	switch cmd {
+	case protocol.CmdMute:
+		if typed, ok := msg.(*protocol.MuteMessage); ok {
+			return typed.ID
+		}
 	case protocol.CmdSessionVisualized:
 		if typed, ok := msg.(*protocol.SessionVisualizedMessage); ok {
 			return typed.ID


### PR DESCRIPTION
`CmdMute` was missing from `remoteCommandSessionID` in `websocket.go`. When muting a remote session, `tryHandleRemoteWSCommand` found no session ID to route on, returned `false`, and the command fell through to the local handler — which called `store.ToggleMute` against an ID that doesn't exist in the local store. Silent no-op.

Fix: add `CmdMute` to the switch so it extracts the session ID and the command gets forwarded to the correct remote endpoint.