### PR TITLE
fix: fetch remote branch before worktree creation and disable autocorrect on branch input

### DIFF
--- a/app/src/components/NewSessionDialog/RepoOptions.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.tsx
@@ -402,6 +402,9 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
                   value={newWorktreeName}
                   onChange={(e) => setNewWorktreeName(e.target.value)}
                   autoFocus
+                  autoCorrect="off"
+                  autoCapitalize="off"
+                  spellCheck={false}
                 />
               </div>
               <div className="new-worktree-radio-row">

--- a/internal/daemon/worktree.go
+++ b/internal/daemon/worktree.go
@@ -4,6 +4,7 @@ package daemon
 import (
 	"net"
 	"os"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -105,11 +106,15 @@ func (d *Daemon) doCreateWorktree(msg *protocol.CreateWorktreeMessage) (string, 
 	path = git.CanonicalizePath(path)
 
 	startingFrom := protocol.Deref(msg.StartingFrom)
-	// If starting from a remote ref (e.g. "origin/main"), fetch it first so
-	// the worktree is created from the latest upstream commit, not a stale cache.
+	// If starting from a remote tracking ref (e.g. "origin/main"), fetch it
+	// first so the worktree is created from the latest upstream commit.
+	// Guard against local branches that happen to contain "/" (e.g. "feat/x")
+	// by checking that the prefix is an actual configured remote.
 	if remote, branch, ok := strings.Cut(startingFrom, "/"); ok {
-		if ferr := git.FetchRemoteBranch(mainRepo, remote, branch); ferr != nil {
-			d.logf("Warning: could not fetch %s before creating worktree: %v", startingFrom, ferr)
+		if remotes, rerr := git.ListRemotes(mainRepo); rerr == nil && slices.Contains(remotes, remote) {
+			if ferr := git.FetchRemoteBranch(mainRepo, remote, branch); ferr != nil {
+				d.logf("Warning: could not fetch %s before creating worktree: %v", startingFrom, ferr)
+			}
 		}
 	}
 	var err error

--- a/internal/daemon/worktree.go
+++ b/internal/daemon/worktree.go
@@ -4,6 +4,7 @@ package daemon
 import (
 	"net"
 	"os"
+	"strings"
 	"syscall"
 	"time"
 
@@ -104,6 +105,13 @@ func (d *Daemon) doCreateWorktree(msg *protocol.CreateWorktreeMessage) (string, 
 	path = git.CanonicalizePath(path)
 
 	startingFrom := protocol.Deref(msg.StartingFrom)
+	// If starting from a remote ref (e.g. "origin/main"), fetch it first so
+	// the worktree is created from the latest upstream commit, not a stale cache.
+	if remote, branch, ok := strings.Cut(startingFrom, "/"); ok {
+		if ferr := git.FetchRemoteBranch(mainRepo, remote, branch); ferr != nil {
+			d.logf("Warning: could not fetch %s before creating worktree: %v", startingFrom, ferr)
+		}
+	}
 	var err error
 	if startingFrom != "" {
 		err = git.CreateWorktreeFromPoint(mainRepo, msg.Branch, path, startingFrom)

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -184,6 +184,25 @@ func GetCurrentBranch(repoDir string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// FetchRemoteBranch fetches a single branch from a remote.
+// remote should be e.g. "origin", branch should be e.g. "main".
+func FetchRemoteBranch(repoDir, remote, branch string) error {
+	cmd := exec.Command("git", "fetch", remote, branch)
+	resolvedDir, err := ResolveRepoDir(repoDir)
+	if err != nil {
+		return err
+	}
+	cmd.Dir = resolvedDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		outStr := strings.TrimSpace(string(out))
+		if outStr == "" {
+			return fmt.Errorf("git fetch failed: %w", err)
+		}
+		return fmt.Errorf("git fetch failed: %s (%w)", outStr, err)
+	}
+	return nil
+}
+
 // FetchRemotes fetches all remotes with prune.
 func FetchRemotes(repoDir string) error {
 	cmd := exec.Command("git", "fetch", "--all", "--prune")

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -184,6 +184,27 @@ func GetCurrentBranch(repoDir string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// ListRemotes returns the configured remote names for the repository.
+func ListRemotes(repoDir string) ([]string, error) {
+	cmd := exec.Command("git", "remote")
+	resolvedDir, err := ResolveRepoDir(repoDir)
+	if err != nil {
+		return nil, err
+	}
+	cmd.Dir = resolvedDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git remote failed: %w", err)
+	}
+	var remotes []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			remotes = append(remotes, line)
+		}
+	}
+	return remotes, nil
+}
+
 // FetchRemoteBranch fetches a single branch from a remote.
 // remote should be e.g. "origin", branch should be e.g. "main".
 func FetchRemoteBranch(repoDir, remote, branch string) error {


### PR DESCRIPTION
## What

Two small bugs in the worktree creation flow:

**Stale origin/main when creating a worktree**

Selecting "Start from origin/main" passed the remote ref straight to `git worktree add`, which uses whatever the local remote-tracking cache has. If the user hasn't fetched recently, the new branch can be behind the actual remote. Now the daemon does a targeted `git fetch <remote> <branch>` right before creating the worktree so the starting point is always fresh.

**Autocorrect mangling branch names on macOS**

The branch name input had no hints to suppress macOS text services. Typing `feat` could silently become `Feat`. Fixed by adding `autoCorrect="off"`, `autoCapitalize="off"`, and `spellCheck={false}` to the input.

## Changes

- `internal/git/branch.go` — add `FetchRemoteBranch(repoDir, remote, branch)` helper
- `internal/daemon/worktree.go` — fetch remote ref before creating worktree when `startingFrom` contains a `/`
- `app/src/components/NewSessionDialog/RepoOptions.tsx` — disable autocorrect/capitalize/spellcheck on branch name input