### PR TITLE
Fix comment form paste, draft persistence, and file-switch behavior

### DIFF
--- a/app/e2e/unified-diff-editor.spec.ts
+++ b/app/e2e/unified-diff-editor.spec.ts
@@ -120,6 +120,94 @@ test.describe('UnifiedDiffEditor', () => {
       expect(calls).toHaveLength(1);
     });
   });
+  test.describe('comment form draft persistence', () => {
+    /**
+     * Regression: paste events were intercepted by CodeMirror because
+     * ignoreEvent() only returned true for mouse events. Fixed by returning
+     * true for all events in both comment widgets.
+     */
+    test('paste works inside comment textarea', async ({ page, context }) => {
+      await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+      await page.locator('.cm-line').first().click();
+      const textarea = page.locator('.unified-comment-textarea');
+      await expect(textarea).toBeFocused();
+
+      // Type some text first
+      await page.keyboard.type('typed ');
+
+      // Set clipboard and paste
+      await page.evaluate(() => navigator.clipboard.writeText('pasted'));
+      const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+      await page.keyboard.press(`${modifier}+v`);
+
+      // Pasted content should appear in the textarea, not be eaten by CodeMirror
+      await expect(textarea).toHaveValue('typed pasted');
+    });
+
+    /**
+     * Regression: when file content changed the EditorView was rebuilt but
+     * the comment widgets effect did not re-run (content was missing from deps),
+     * so the open form was lost. Fixed by adding content to the effect deps.
+     * Draft text also needed to survive via a ref (not state) to avoid per-keystroke
+     * widget DOM recreation.
+     */
+    test('open comment form survives content refresh', async ({ page }) => {
+      await page.locator('.cm-line').first().click();
+      const textarea = page.locator('.unified-comment-textarea');
+      await expect(textarea).toBeFocused();
+
+      await page.keyboard.type('draft text');
+      await expect(textarea).toHaveValue('draft text');
+
+      // Simulate a file content update (e.g. background write)
+      await page.evaluate(() => (window.__HARNESS__ as any).refreshContent());
+
+      // Form should still be visible with the typed draft preserved
+      await expect(textarea).toBeVisible();
+      await expect(textarea).toHaveValue('draft text');
+    });
+
+    /**
+     * Regression: newCommentLines was a single Set shared across files, so
+     * switching files left the form open but pointing at the new file's content.
+     * Fixed by keying open forms per filePath.
+     */
+    test('comment form does not appear on a different file after switch', async ({ page }) => {
+      await page.locator('.cm-line').first().click();
+      await expect(page.locator('.unified-comment-form')).toBeVisible();
+
+      // Switch to a different file
+      await page.evaluate(() => (window.__HARNESS__ as any).switchFile('fileB.ts'));
+
+      // The form should not be visible on the new file
+      await expect(page.locator('.unified-comment-form')).not.toBeVisible();
+    });
+
+    /**
+     * The form and its draft should be restored when switching back to the
+     * original file, so the user doesn't lose in-progress work.
+     */
+    test('open form and draft are restored when switching back', async ({ page }) => {
+      await page.locator('.cm-line').first().click();
+      const textarea = page.locator('.unified-comment-textarea');
+      await expect(textarea).toBeFocused();
+
+      await page.keyboard.type('my draft');
+      await expect(textarea).toHaveValue('my draft');
+
+      // Switch away and back
+      await page.evaluate(() => (window.__HARNESS__ as any).switchFile('fileB.ts'));
+      await expect(page.locator('.unified-comment-form')).not.toBeVisible();
+
+      await page.evaluate(() => (window.__HARNESS__ as any).switchFile('fileA.ts'));
+
+      // Form should reappear with the draft intact
+      await expect(page.locator('.unified-comment-form')).toBeVisible();
+      await expect(page.locator('.unified-comment-textarea')).toHaveValue('my draft');
+    });
+  });
+
   test.describe('scrolling', () => {
     test('scroll position preserved when saving comment', async ({ page }) => {
       const editor = page.locator('.cm-scroller');

--- a/app/e2e/unified-diff-editor.spec.ts
+++ b/app/e2e/unified-diff-editor.spec.ts
@@ -206,6 +206,30 @@ test.describe('UnifiedDiffEditor', () => {
       await expect(page.locator('.unified-comment-form')).toBeVisible();
       await expect(page.locator('.unified-comment-textarea')).toHaveValue('my draft');
     });
+
+    /**
+     * Regression: after multiple round-trips (A→B→A→B→A), the form and draft
+     * should still be intact each time we return to the original file.
+     */
+    test('open form and draft survive multiple file round-trips', async ({ page }) => {
+      await page.locator('.cm-line').first().click();
+      const textarea = page.locator('.unified-comment-textarea');
+      await expect(textarea).toBeFocused();
+
+      await page.keyboard.type('persistent draft');
+      await expect(textarea).toHaveValue('persistent draft');
+
+      // Do three full round-trips A→B→A
+      for (let i = 0; i < 3; i++) {
+        await page.evaluate(() => (window.__HARNESS__ as any).switchFile('fileB.ts'));
+        await expect(page.locator('.unified-comment-form')).not.toBeVisible();
+
+        await page.evaluate(() => (window.__HARNESS__ as any).switchFile('fileA.ts'));
+
+        await expect(page.locator('.unified-comment-form')).toBeVisible();
+        await expect(page.locator('.unified-comment-textarea')).toHaveValue('persistent draft');
+      }
+    });
   });
 
   test.describe('scrolling', () => {

--- a/app/src/components/DiffDetailPanel.tsx
+++ b/app/src/components/DiffDetailPanel.tsx
@@ -1114,7 +1114,7 @@ export function DiffDetailPanel({
               </div>
             </div>
             <div className="diff-content">
-              {loading ? (
+              {loading && !diffContent ? (
                 <div className="diff-loading">Loading diff...</div>
               ) : error ? (
                 <div className="diff-error">{error}</div>

--- a/app/src/components/UnifiedDiffEditor.tsx
+++ b/app/src/components/UnifiedDiffEditor.tsx
@@ -722,13 +722,7 @@ function buildLineDecorations(view: EditorView, lines: DiffLine[]): DecorationSe
 interface CommentWidgetConfig {
   comment: InlineComment;
   isEditing: boolean;
-  onEdit: (id: string) => void;
-  onSaveEdit: (id: string, content: string) => void;
-  onCancelEdit: () => void;
-  onResolve: (id: string, resolved: boolean) => void;
-  onWontFix: (id: string, wontFix: boolean) => void;
-  onDelete: (id: string) => void;
-  onSendToClaude?: () => void;
+  showSendToClaude: boolean;
 }
 
 class CommentWidget extends WidgetType {
@@ -736,15 +730,35 @@ class CommentWidget extends WidgetType {
     super();
   }
 
+  eq(other: CommentWidget) {
+    const a = this.config;
+    const b = other.config;
+    return (
+      a.comment.id === b.comment.id &&
+      a.comment.content === b.comment.content &&
+      a.comment.resolved === b.comment.resolved &&
+      a.comment.wontFix === b.comment.wontFix &&
+      a.comment.resolvedBy === b.comment.resolvedBy &&
+      a.comment.wontFixBy === b.comment.wontFixBy &&
+      a.comment.author === b.comment.author &&
+      a.comment.isOutdated === b.comment.isOutdated &&
+      a.comment.isOrphaned === b.comment.isOrphaned &&
+      a.isEditing === b.isEditing &&
+      a.showSendToClaude === b.showSendToClaude
+    );
+  }
+
   toDOM() {
-    const { comment, isEditing, onEdit, onSaveEdit, onCancelEdit, onResolve, onWontFix, onDelete, onSendToClaude } = this.config;
+    const { comment, isEditing, showSendToClaude } = this.config;
 
     const wrapper = document.createElement('div');
     wrapper.className = `unified-comment ${comment.resolved ? 'resolved' : ''} ${comment.wontFix ? 'wont-fix' : ''}`;
+    wrapper.dataset.widgetType = 'comment';
+    wrapper.dataset.commentId = comment.id;
 
     if (isEditing) {
       // Edit mode
-      wrapper.innerHTML = `<textarea class="unified-comment-textarea">${escapeHtml(comment.content)}</textarea><div class="unified-comment-form-actions"><button class="cancel-btn">Cancel</button><button class="save-btn">Save</button></div>`;
+      wrapper.innerHTML = `<textarea class="unified-comment-textarea">${escapeHtml(comment.content)}</textarea><div class="unified-comment-form-actions"><button class="cancel-btn" data-action="cancel-edit">Cancel</button><button class="save-btn" data-action="save-edit">Save</button></div>`;
 
       const textarea = wrapper.querySelector('textarea')!;
       setTimeout(() => {
@@ -752,33 +766,7 @@ class CommentWidget extends WidgetType {
         textarea.setSelectionRange(textarea.value.length, textarea.value.length);
       }, 0);
 
-      textarea.addEventListener('keydown', (e) => {
-        // Stop all key events from bubbling to CodeMirror
-        e.stopPropagation();
-        if (e.key === 'Escape') {
-          e.preventDefault();
-          onCancelEdit();
-        } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-          e.preventDefault();
-          const content = textarea.value.trim();
-          if (content) {
-            onSaveEdit(comment.id, content);
-          }
-        }
-      });
-
-      wrapper.querySelector('.cancel-btn')?.addEventListener('click', (e) => {
-        e.stopPropagation();
-        onCancelEdit();
-      });
-
-      wrapper.querySelector('.save-btn')?.addEventListener('click', (e) => {
-        e.stopPropagation();
-        const content = textarea.value.trim();
-        if (content) {
-          onSaveEdit(comment.id, content);
-        }
-      });
+      textarea.addEventListener('keydown', (e) => e.stopPropagation());
     } else {
       // Display mode
       const resolvedBadge = comment.resolved
@@ -787,38 +775,13 @@ class CommentWidget extends WidgetType {
       const wontFixBadge = comment.wontFix
         ? `<span class="unified-comment-wontfix">Won't Fix by ${comment.wontFixBy === 'agent' ? 'Claude' : 'you'}</span>`
         : '';
-      const sendToClaudeBtn = onSendToClaude
-        ? `<button class="send-btn">Send to CC</button>`
+      const sendToClaudeBtn = showSendToClaude
+        ? `<button class="send-btn" data-action="send-to-claude">Send to CC</button>`
         : '';
       const wontFixBtn = comment.wontFix
-        ? `<button class="wontfix-btn">Undo Won't Fix</button>`
-        : `<button class="wontfix-btn">Won't Fix</button>`;
-      wrapper.innerHTML = `<div class="unified-comment-header"><div class="unified-comment-left"><span class="unified-comment-author">${comment.author === 'agent' ? 'Claude' : 'You'}</span>${resolvedBadge}${wontFixBadge}</div><div class="unified-comment-actions"><button class="edit-btn">Edit</button>${sendToClaudeBtn}<button class="resolve-btn">${comment.resolved ? 'Unresolve' : 'Resolve'}</button>${wontFixBtn}<button class="delete-btn">Delete</button></div></div><div class="unified-comment-content">${renderMarkdown(comment.content)}</div>`;
-
-      wrapper.querySelector('.edit-btn')?.addEventListener('click', (e) => {
-        e.stopPropagation();
-        onEdit(comment.id);
-      });
-
-      wrapper.querySelector('.send-btn')?.addEventListener('click', (e) => {
-        e.stopPropagation();
-        onSendToClaude?.();
-      });
-
-      wrapper.querySelector('.resolve-btn')?.addEventListener('click', (e) => {
-        e.stopPropagation();
-        onResolve(comment.id, !comment.resolved);
-      });
-
-      wrapper.querySelector('.wontfix-btn')?.addEventListener('click', (e) => {
-        e.stopPropagation();
-        onWontFix(comment.id, !comment.wontFix);
-      });
-
-      wrapper.querySelector('.delete-btn')?.addEventListener('click', (e) => {
-        e.stopPropagation();
-        onDelete(comment.id);
-      });
+        ? `<button class="wontfix-btn" data-action="wontfix">Undo Won't Fix</button>`
+        : `<button class="wontfix-btn" data-action="wontfix">Won't Fix</button>`;
+      wrapper.innerHTML = `<div class="unified-comment-header"><div class="unified-comment-left"><span class="unified-comment-author">${comment.author === 'agent' ? 'Claude' : 'You'}</span>${resolvedBadge}${wontFixBadge}</div><div class="unified-comment-actions"><button class="edit-btn" data-action="edit">Edit</button>${sendToClaudeBtn}<button class="resolve-btn" data-action="resolve">${comment.resolved ? 'Unresolve' : 'Resolve'}</button>${wontFixBtn}<button class="delete-btn" data-action="delete">Delete</button></div></div><div class="unified-comment-content">${renderMarkdown(comment.content)}</div>`;
     }
 
     return wrapper;
@@ -836,9 +799,6 @@ class CommentWidget extends WidgetType {
 interface NewCommentFormConfig {
   docLine: number;
   initialValue: string;
-  onSave: (docLine: number, content: string) => void;
-  onCancel: (docLine: number) => void;
-  onDraftChange: (docLine: number, value: string) => void;
 }
 
 class NewCommentFormWidget extends WidgetType {
@@ -846,46 +806,24 @@ class NewCommentFormWidget extends WidgetType {
     super();
   }
 
+  eq(other: NewCommentFormWidget) {
+    return this.config.docLine === other.config.docLine;
+  }
+
   toDOM() {
-    const { docLine, initialValue, onSave, onCancel, onDraftChange } = this.config;
+    const { docLine, initialValue } = this.config;
 
     const wrapper = document.createElement('div');
     wrapper.className = 'unified-comment-form';
-    wrapper.innerHTML = `<textarea class="unified-comment-textarea" rows="2" placeholder="Add a comment..."></textarea><div class="unified-comment-form-actions"><button class="cancel-btn">Cancel</button><button class="save-btn">Save</button></div>`;
+    wrapper.dataset.widgetType = 'new-comment';
+    wrapper.dataset.docLine = String(docLine);
+    wrapper.innerHTML = `<textarea class="unified-comment-textarea" rows="2" placeholder="Add a comment..."></textarea><div class="unified-comment-form-actions"><button class="cancel-btn" data-action="cancel-new">Cancel</button><button class="save-btn" data-action="save-new">Save</button></div>`;
 
     const textarea = wrapper.querySelector('textarea')!;
     textarea.value = initialValue;
     setTimeout(() => textarea.focus(), 0);
 
-    textarea.addEventListener('input', () => onDraftChange(docLine, textarea.value));
-
-    // Keyboard shortcuts - stop propagation to prevent CodeMirror from handling
-    textarea.addEventListener('keydown', (e) => {
-      e.stopPropagation();
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onCancel(docLine);
-      } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        const content = textarea.value.trim();
-        if (content) {
-          onSave(docLine, content);
-        }
-      }
-    });
-
-    wrapper.querySelector('.cancel-btn')?.addEventListener('click', (e) => {
-      e.stopPropagation();
-      onCancel(docLine);
-    });
-
-    wrapper.querySelector('.save-btn')?.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const content = textarea.value.trim();
-      if (content) {
-        onSave(docLine, content);
-      }
-    });
+    textarea.addEventListener('keydown', (e) => e.stopPropagation());
 
     return wrapper;
   }
@@ -962,6 +900,20 @@ function renderMarkdown(text: string): string {
 // ============================================================================
 // Component
 // ============================================================================
+
+interface CommentActions {
+  onStartEdit: (id: string) => void;
+  onEditComment: (id: string, content: string) => Promise<void>;
+  onCancelEdit: () => void;
+  onResolveComment: (id: string, resolved: boolean) => Promise<void>;
+  onWontFixComment: (id: string, wontFix: boolean) => Promise<void>;
+  onDeleteComment: (id: string) => Promise<void>;
+  onSendToClaude?: (reference: string) => void;
+  handleSaveComment: (docLine: number, content: string) => Promise<void>;
+  handleCancelComment: (docLine: number) => void;
+  handleDraftChange: (docLine: number, value: string) => void;
+  filePath?: string;
+}
 
 export function UnifiedDiffEditor({
   original,
@@ -1128,6 +1080,19 @@ export function UnifiedDiffEditor({
     });
     clearDraft(docLine);
   }, [clearDraft]);
+
+  // Stable refs for event delegation — synced every render so delegated
+  // handlers always call the latest callbacks without being effect deps.
+  const actionsRef = useRef<CommentActions>(null!);
+  const commentsRef = useRef<InlineComment[]>([]);
+
+  actionsRef.current = {
+    onStartEdit, onEditComment, onCancelEdit,
+    onResolveComment, onWontFixComment, onDeleteComment,
+    onSendToClaude, handleSaveComment, handleCancelComment,
+    handleDraftChange, filePath,
+  };
+  commentsRef.current = comments;
 
   // Selection popup handlers
   const handleSendToClaudeFromSelection = useCallback(() => {
@@ -1572,7 +1537,135 @@ export function UnifiedDiffEditor({
     setSelection(null);
   }, [content]);
 
-  // Update comment widgets when comments or newCommentLines change
+  // Delegated event listeners for comment widget interactions.
+  // Mounted once; routes all widget clicks/input/keyboard to the latest
+  // callbacks via actionsRef so widget configs stay data-only.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      const actionEl = target.closest('[data-action]') as HTMLElement | null;
+      if (!actionEl) return;
+
+      const action = actionEl.dataset.action;
+      const commentWidget = target.closest('[data-widget-type="comment"]') as HTMLElement | null;
+      const newCommentWidget = target.closest('[data-widget-type="new-comment"]') as HTMLElement | null;
+
+      if (commentWidget) {
+        const commentId = commentWidget.dataset.commentId!;
+        e.stopPropagation();
+
+        switch (action) {
+          case 'edit':
+            actionsRef.current.onStartEdit(commentId);
+            break;
+          case 'save-edit': {
+            const textarea = commentWidget.querySelector('textarea');
+            const val = textarea?.value.trim();
+            if (val) actionsRef.current.onEditComment(commentId, val);
+            break;
+          }
+          case 'cancel-edit':
+            actionsRef.current.onCancelEdit();
+            break;
+          case 'resolve': {
+            const comment = commentsRef.current.find(c => c.id === commentId);
+            if (comment) actionsRef.current.onResolveComment(commentId, !comment.resolved);
+            break;
+          }
+          case 'wontfix': {
+            const comment = commentsRef.current.find(c => c.id === commentId);
+            if (comment) actionsRef.current.onWontFixComment(commentId, !comment.wontFix);
+            break;
+          }
+          case 'delete':
+            actionsRef.current.onDeleteComment(commentId);
+            break;
+          case 'send-to-claude': {
+            const comment = commentsRef.current.find(c => c.id === commentId);
+            if (comment?.anchor && actionsRef.current.filePath && actionsRef.current.onSendToClaude) {
+              const lineNum = comment.anchor.line;
+              const reference = `@${actionsRef.current.filePath}:L${lineNum}\nComment: ${comment.content}`;
+              actionsRef.current.onSendToClaude(reference);
+            }
+            break;
+          }
+        }
+      } else if (newCommentWidget) {
+        const docLine = Number(newCommentWidget.dataset.docLine);
+        e.stopPropagation();
+
+        switch (action) {
+          case 'save-new': {
+            const textarea = newCommentWidget.querySelector('textarea');
+            const val = textarea?.value.trim();
+            if (val) actionsRef.current.handleSaveComment(docLine, val);
+            break;
+          }
+          case 'cancel-new':
+            actionsRef.current.handleCancelComment(docLine);
+            break;
+        }
+      }
+    };
+
+    const handleInput = (e: Event) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName !== 'TEXTAREA') return;
+
+      const newCommentWidget = target.closest('[data-widget-type="new-comment"]') as HTMLElement | null;
+      if (newCommentWidget) {
+        const docLine = Number(newCommentWidget.dataset.docLine);
+        actionsRef.current.handleDraftChange(docLine, (target as HTMLTextAreaElement).value);
+      }
+    };
+
+    const handleKeydown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName !== 'TEXTAREA') return;
+
+      const commentWidget = target.closest('[data-widget-type="comment"]') as HTMLElement | null;
+      const newCommentWidget = target.closest('[data-widget-type="new-comment"]') as HTMLElement | null;
+
+      if (commentWidget) {
+        const commentId = commentWidget.dataset.commentId!;
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          actionsRef.current.onCancelEdit();
+        } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+          e.preventDefault();
+          const val = (target as HTMLTextAreaElement).value.trim();
+          if (val) actionsRef.current.onEditComment(commentId, val);
+        }
+      } else if (newCommentWidget) {
+        const docLine = Number(newCommentWidget.dataset.docLine);
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          actionsRef.current.handleCancelComment(docLine);
+        } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+          e.preventDefault();
+          const val = (target as HTMLTextAreaElement).value.trim();
+          if (val) actionsRef.current.handleSaveComment(docLine, val);
+        }
+      }
+    };
+
+    container.addEventListener('click', handleClick);
+    container.addEventListener('input', handleInput);
+    container.addEventListener('keydown', handleKeydown, true); // capture phase
+
+    return () => {
+      container.removeEventListener('click', handleClick);
+      container.removeEventListener('input', handleInput);
+      container.removeEventListener('keydown', handleKeydown, true);
+    };
+  }, []);
+
+  // Update comment widgets when comments or newCommentLines change.
+  // Callbacks are accessed via actionsRef (event delegation), so only
+  // data deps remain — avoids tearing down widget DOM on callback changes.
   useEffect(() => {
     const view = editorViewRef.current;
     if (!view) return;
@@ -1584,27 +1677,12 @@ export function UnifiedDiffEditor({
       if (comment.docLine > 0 && comment.docLine <= view.state.doc.lines) {
         const line = view.state.doc.line(comment.docLine);
 
-        // Create send to claude callback for this comment
-        const sendToClaudeForComment = onSendToClaude && filePath && comment.anchor
-          ? () => {
-              const lineNum = comment.anchor!.line;
-              const reference = `@${filePath}:L${lineNum}\nComment: ${comment.content}`;
-              onSendToClaude(reference);
-            }
-          : undefined;
-
         widgets.push({
           pos: line.to,
           widget: new CommentWidget({
             comment,
             isEditing: editingCommentId === comment.id,
-            onEdit: onStartEdit,
-            onSaveEdit: onEditComment,
-            onCancelEdit: onCancelEdit,
-            onResolve: onResolveComment,
-            onWontFix: onWontFixComment,
-            onDelete: onDeleteComment,
-            onSendToClaude: sendToClaudeForComment,
+            showSendToClaude: !!(actionsRef.current.onSendToClaude && filePath && comment.anchor),
           }),
         });
       }
@@ -1619,9 +1697,6 @@ export function UnifiedDiffEditor({
           widget: new NewCommentFormWidget({
             docLine,
             initialValue: draftCommentValuesRef.current[filePath ?? '']?.[docLine] ?? '',
-            onSave: handleSaveComment,
-            onCancel: handleCancelComment,
-            onDraftChange: handleDraftChange,
           }),
         });
       }
@@ -1636,7 +1711,7 @@ export function UnifiedDiffEditor({
     view.dispatch({ effects: setCommentWidgets.of(decorations) });
   // NOTE: fontSize is included because the main editor effect recreates the EditorView when fontSize changes.
   // Without fontSize here, this effect wouldn't re-run and comment widgets would be lost.
-  }, [content, comments, newCommentLines, editingCommentId, handleSaveComment, handleCancelComment, handleDraftChange, onStartEdit, onEditComment, onCancelEdit, onResolveComment, onWontFixComment, onDeleteComment, onSendToClaude, filePath, fontSize]);
+  }, [content, comments, newCommentLines, editingCommentId, filePath, fontSize]);
 
   // Update collapsed region decorations when contextLines or expandedRegions change
   useEffect(() => {

--- a/app/src/components/UnifiedDiffEditor.tsx
+++ b/app/src/components/UnifiedDiffEditor.tsx
@@ -970,8 +970,14 @@ export function UnifiedDiffEditor({
 
   // Dismiss inline comment forms via the escape stack so overlays stay LIFO
   const cancelAllNewComments = useCallback(() => {
-    setNewCommentLines(() => new Set());
-  }, [setNewCommentLines]);
+    setNewCommentLines((prev) => {
+      const key = filePath ?? '';
+      for (const docLine of prev) {
+        delete draftCommentValuesRef.current[key]?.[docLine];
+      }
+      return new Set();
+    });
+  }, [setNewCommentLines, filePath]);
   useEscapeStack(cancelAllNewComments, newCommentLines.size > 0);
   useEscapeStack(onCancelEdit, editingCommentId !== null);
 

--- a/app/src/components/UnifiedDiffEditor.tsx
+++ b/app/src/components/UnifiedDiffEditor.tsx
@@ -824,9 +824,8 @@ class CommentWidget extends WidgetType {
     return wrapper;
   }
 
-  ignoreEvent(event: Event) {
-    // Let the widget handle mouse events
-    return event.type.startsWith('mouse');
+  ignoreEvent() {
+    return true;
   }
 }
 
@@ -836,8 +835,10 @@ class CommentWidget extends WidgetType {
 
 interface NewCommentFormConfig {
   docLine: number;
+  initialValue: string;
   onSave: (docLine: number, content: string) => void;
   onCancel: (docLine: number) => void;
+  onDraftChange: (docLine: number, value: string) => void;
 }
 
 class NewCommentFormWidget extends WidgetType {
@@ -846,14 +847,17 @@ class NewCommentFormWidget extends WidgetType {
   }
 
   toDOM() {
-    const { docLine, onSave, onCancel } = this.config;
+    const { docLine, initialValue, onSave, onCancel, onDraftChange } = this.config;
 
     const wrapper = document.createElement('div');
     wrapper.className = 'unified-comment-form';
     wrapper.innerHTML = `<textarea class="unified-comment-textarea" rows="2" placeholder="Add a comment..."></textarea><div class="unified-comment-form-actions"><button class="cancel-btn">Cancel</button><button class="save-btn">Save</button></div>`;
 
     const textarea = wrapper.querySelector('textarea')!;
+    textarea.value = initialValue;
     setTimeout(() => textarea.focus(), 0);
+
+    textarea.addEventListener('input', () => onDraftChange(docLine, textarea.value));
 
     // Keyboard shortcuts - stop propagation to prevent CodeMirror from handling
     textarea.addEventListener('keydown', (e) => {
@@ -886,8 +890,8 @@ class NewCommentFormWidget extends WidgetType {
     return wrapper;
   }
 
-  ignoreEvent(event: Event) {
-    return event.type.startsWith('mouse');
+  ignoreEvent() {
+    return true;
   }
 }
 
@@ -985,11 +989,37 @@ export function UnifiedDiffEditor({
   const buildDocumentDurationMsRef = useRef(0);
   const collapsedRegionCountRef = useRef(0);
 
-  // Track which lines have open "new comment" forms
-  const [newCommentLines, setNewCommentLines] = useState<Set<number>>(new Set());
+  // Track which lines have open "new comment" forms, keyed by filePath so
+  // forms survive file switches and reappear when switching back.
+  const [newCommentLinesByFile, setNewCommentLinesByFile] = useState<Record<string, Set<number>>>({});
+  const newCommentLines = newCommentLinesByFile[filePath ?? ''] ?? new Set<number>();
+
+  const setNewCommentLines = useCallback((updater: (prev: Set<number>) => Set<number>) => {
+    setNewCommentLinesByFile((prev) => {
+      const key = filePath ?? '';
+      return { ...prev, [key]: updater(prev[key] ?? new Set()) };
+    });
+  }, [filePath]);
+
+  // Persist in-progress textarea content keyed by filePath so it survives
+  // widget/editor rebuilds and file switches without causing re-renders on
+  // every keystroke (ref avoids the state→effect→DOM-recreate cycle).
+  const draftCommentValuesRef = useRef<Record<string, Record<number, string>>>({});
+
+  const handleDraftChange = useCallback((docLine: number, value: string) => {
+    const key = filePath ?? '';
+    if (!draftCommentValuesRef.current[key]) draftCommentValuesRef.current[key] = {};
+    draftCommentValuesRef.current[key][docLine] = value;
+  }, [filePath]);
+
+  const clearDraft = useCallback((docLine: number) => {
+    delete draftCommentValuesRef.current[filePath ?? '']?.[docLine];
+  }, [filePath]);
 
   // Dismiss inline comment forms via the escape stack so overlays stay LIFO
-  const cancelAllNewComments = useCallback(() => setNewCommentLines(new Set()), []);
+  const cancelAllNewComments = useCallback(() => {
+    setNewCommentLines(() => new Set());
+  }, [setNewCommentLines]);
   useEscapeStack(cancelAllNewComments, newCommentLines.size > 0);
   useEscapeStack(onCancelEdit, editingCommentId !== null);
 
@@ -1085,8 +1115,9 @@ export function UnifiedDiffEditor({
         next.delete(docLine);
         return next;
       });
+      clearDraft(docLine);
     },
-    [onAddComment]
+    [onAddComment, clearDraft]
   );
 
   const handleCancelComment = useCallback((docLine: number) => {
@@ -1095,7 +1126,8 @@ export function UnifiedDiffEditor({
       next.delete(docLine);
       return next;
     });
-  }, []);
+    clearDraft(docLine);
+  }, [clearDraft]);
 
   // Selection popup handlers
   const handleSendToClaudeFromSelection = useCallback(() => {
@@ -1586,8 +1618,10 @@ export function UnifiedDiffEditor({
           pos: line.to,
           widget: new NewCommentFormWidget({
             docLine,
+            initialValue: draftCommentValuesRef.current[filePath ?? '']?.[docLine] ?? '',
             onSave: handleSaveComment,
             onCancel: handleCancelComment,
+            onDraftChange: handleDraftChange,
           }),
         });
       }
@@ -1602,7 +1636,7 @@ export function UnifiedDiffEditor({
     view.dispatch({ effects: setCommentWidgets.of(decorations) });
   // NOTE: fontSize is included because the main editor effect recreates the EditorView when fontSize changes.
   // Without fontSize here, this effect wouldn't re-run and comment widgets would be lost.
-  }, [comments, newCommentLines, editingCommentId, handleSaveComment, handleCancelComment, onStartEdit, onEditComment, onCancelEdit, onResolveComment, onWontFixComment, onDeleteComment, onSendToClaude, filePath, fontSize]);
+  }, [content, comments, newCommentLines, editingCommentId, handleSaveComment, handleCancelComment, handleDraftChange, onStartEdit, onEditComment, onCancelEdit, onResolveComment, onWontFixComment, onDeleteComment, onSendToClaude, filePath, fontSize]);
 
   // Update collapsed region decorations when contextLines or expandedRegions change
   useEffect(() => {

--- a/app/test-harness/harnesses/UnifiedDiffEditorHarness.tsx
+++ b/app/test-harness/harnesses/UnifiedDiffEditorHarness.tsx
@@ -24,6 +24,28 @@ const SMALL_MODIFIED = `function example() {
   console.log('line 5');
 }`;
 
+// Second file for file-switch tests
+const FILE_B_ORIGINAL = `class Calculator {
+  add(a: number, b: number) {
+    return a + b;
+  }
+  multiply(a: number, b: number) {
+    return a * b;
+  }
+}`;
+
+const FILE_B_MODIFIED = `class Calculator {
+  add(a: number, b: number) {
+    return a + b;
+  }
+  subtract(a: number, b: number) {
+    return a - b;
+  }
+  multiply(a: number, b: number) {
+    return a * b;
+  }
+}`;
+
 // Larger sample to demonstrate hunks/context mode
 const LARGE_ORIGINAL = `/**
  * User authentication module
@@ -182,8 +204,15 @@ export function UnifiedDiffEditorHarness({ onReady }: HarnessProps) {
   const [contextLines, setContextLines] = useState(0); // 0 = full diff
   const [useLargeDiff, setUseLargeDiff] = useState(false);
 
-  const original = useLargeDiff ? LARGE_ORIGINAL : SMALL_ORIGINAL;
-  const modified = useLargeDiff ? LARGE_MODIFIED : SMALL_MODIFIED;
+  // File switching and content refresh (for tests)
+  const [filePath, setFilePath] = useState<string>('fileA.ts');
+  const [refreshCount, setRefreshCount] = useState(0);
+
+  const baseOriginal = filePath === 'fileB.ts' ? FILE_B_ORIGINAL : (useLargeDiff ? LARGE_ORIGINAL : SMALL_ORIGINAL);
+  const baseModified = filePath === 'fileB.ts' ? FILE_B_MODIFIED : (useLargeDiff ? LARGE_MODIFIED : SMALL_MODIFIED);
+  // Append a marker line on refresh so content reference changes and triggers editor rebuild
+  const original = refreshCount > 0 ? `${baseOriginal}\n// refresh-${refreshCount}` : baseOriginal;
+  const modified = refreshCount > 0 ? `${baseModified}\n// refresh-${refreshCount}` : baseModified;
 
   // Mock addComment
   const addComment = useCallback(async (docLine: number, content: string, anchor: import('../../src/components/UnifiedDiffEditor').CommentAnchor) => {
@@ -261,6 +290,12 @@ export function UnifiedDiffEditorHarness({ onReady }: HarnessProps) {
     const timer = setTimeout(() => onReady(), 300);
     return () => clearTimeout(timer);
   }, [onReady]);
+
+  // Expose programmatic controls for tests
+  useEffect(() => {
+    (window.__HARNESS__ as unknown as Record<string, unknown>).switchFile = (path: string) => setFilePath(path);
+    (window.__HARNESS__ as unknown as Record<string, unknown>).refreshContent = () => setRefreshCount((c) => c + 1);
+  }, []);
 
   const controlsStyle: React.CSSProperties = {
     display: 'flex',
@@ -360,6 +395,7 @@ export function UnifiedDiffEditorHarness({ onReady }: HarnessProps) {
         <UnifiedDiffEditor
           original={original}
           modified={modified}
+          filePath={filePath}
           comments={comments}
           editingCommentId={editingCommentId}
           fontSize={fontSize}


### PR DESCRIPTION
## Summary
- Fix paste not working in comment textareas by returning `true` from `ignoreEvent()` for all event types (not just mouse events), so CodeMirror doesn't intercept clipboard events
- Fix comment form draft text being lost on content refresh by switching from React `useState` to `useRef` for draft values (avoids per-keystroke widget DOM recreation) and adding `content` to the comment widgets effect deps
- Fix comment form "moving" to a wrong file on file switch by keying open forms per `filePath` (`newCommentLinesByFile: Record<string, Set<number>>`) instead of a single shared `Set`
- Restore open forms and draft text when switching back to the original file

## Test plan
- [x] Added 4 new e2e tests covering:
  - Paste works inside comment textarea
  - Open comment form survives content refresh with draft preserved
  - Comment form does not appear on a different file after switch
  - Open form and draft are restored when switching back
- [x] All 14 tests in `unified-diff-editor.spec.ts` pass