### PR TITLE
Fix Sync button re-showing version mismatch after bootstrap

### DIFF
--- a/internal/hub/bootstrap.go
+++ b/internal/hub/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/victorarias/attn/internal/buildinfo"
 	"github.com/victorarias/attn/internal/config"
 )
 
@@ -339,12 +340,19 @@ func (b *Bootstrapper) buildBinaryFromSource(ctx context.Context, platform Remot
 		return fmt.Errorf("source checkout not available for fallback build")
 	}
 
+	ldflags := "-X github.com/victorarias/attn/internal/buildinfo.Version=" + version
+	if fp := buildinfo.SourceFingerprint; fp != "" && fp != "unknown" {
+		ldflags += " -X github.com/victorarias/attn/internal/buildinfo.SourceFingerprint=" + fp
+	}
+	if gc := buildinfo.GitCommit; gc != "" && gc != "unknown" {
+		ldflags += " -X github.com/victorarias/attn/internal/buildinfo.GitCommit=" + gc
+	}
 	cmd := exec.CommandContext(
 		ctx,
 		"go",
 		"build",
 		"-ldflags",
-		"-X github.com/victorarias/attn/internal/buildinfo.Version="+version,
+		ldflags,
 		"-o",
 		outputPath,
 		"./cmd/attn",


### PR DESCRIPTION
## Summary
- `buildBinaryFromSource` only set `Version` in ldflags, leaving `SourceFingerprint` and `GitCommit` at their defaults (`"unknown"`)
- After Sync installed the new binary and restarted the remote daemon, the local client detected a fingerprint mismatch (local had a real fingerprint, remote had `"unknown"`) and re-displayed the same error banner
- Now propagates the running client's `SourceFingerprint` and `GitCommit` into the cross-compiled binary so they match after Sync

## Test plan
- [ ] `make install`, connect to a remote endpoint, trigger a binary mismatch, click Sync — error should clear
- [ ] `go test ./internal/hub/...` passes