### PR TITLE
release: v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Mute Remote Sessions**: Muting a session on a remote endpoint now works correctly. The mute command was not being forwarded to the remote daemon, causing it to silently no-op.
+- **Sync Button Version Re-Prompt**: After successfully bootstrapping a remote endpoint, the home screen no longer re-shows the version-mismatch banner on the next connection attempt.
+- **Inline Comment Form Stability**: Pasting into a comment textarea now works correctly (keystrokes were being intercepted by the editor). Opening a comment on one file, switching to another file, and switching back now restores the open form and any typed draft. Pressing Escape to dismiss a form now clears the draft so stale text cannot be submitted later.
 
 ## [2026-04-13]
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.8.1"
+version = "0.8.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "attn",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "identifier": "com.attn.manager",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
Patch release — version bump and changelog only.

## Changes
- Sync button no longer re-prompts version mismatch after bootstrap
- Inline comment form: paste fixed, draft persists across file switches, Escape clears draft