### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-04-16]
+
+### Added
+- **Send To Claude From Diff Panel**: Unresolved review comments can again be sent to the active agent session from the diff panel — individually or grouped as "Send unresolved (N)". The panel closes on send so the terminal is visible.
+- **Multi-Line Comment Ranges**: Selecting multiple lines and adding a comment now preserves the full range and includes it in send-to-Claude references (e.g. `L5-L10`).
+- **Dashboard Pane Debug Toggle**: A toggle in the Dashboard footer enables pane runtime debug logging for diagnosing terminal focus and render issues.
+
+### Fixed
+- **Comment Form Focus Theft**: Typing in a diff-panel comment or search form no longer loses focus as the terminal emits output in the background. Overlapping focus-retry chains and an unstable workspace binder were letting terminal focus preempt active form input.
+- **Ghost Click Targets In Closed Dock Panels**: Closed side panels no longer intercept clicks on the diff editor. Descendants with `pointer-events: auto` could override the panel's `pointer-events: none`; closed panels are now fully `inert`.
+- **Duplicate Terminal Link Opens**: Cmd-clicking a link in the terminal no longer opens the URL twice. The in-xterm link handlers were redundant with the Tauri opener plugin.
+- **Orphan Comment Cross-Branch Cleanup**: Switching branches while the diff panel was open could misclassify valid comments on the new branch as orphaned and auto-delete them. Cached diff data is now cleared on branch change so cleanup waits for fresh data before running.
+
+### Removed
+- **Won't Fix**: The "won't fix" review-comment state has been removed end to end — UI, protocol, daemon handlers, and store fields. Migration 33 drops the related columns. Comments are now strictly resolved or unresolved.
+
 ## [2026-04-14]
 
 ### Fixed

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.8.2"
+version = "0.9.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "attn",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "identifier": "com.attn.manager",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
Minor release — diff panel improvements, won't fix removal, focus/ghost-click fixes.

## Changes
- Send to Claude restored in the diff panel (individual + grouped "Send unresolved (N)"), panel closes on send
- Multi-line selection comments preserve full range; send-to-Claude references include `L5-L10`
- Won't fix feature removed end to end (UI, protocol, daemon, store); migration 33 drops the columns
- Focus theft fixed: comment/search forms no longer lose focus to terminal output
- Ghost click targets in closed dock panels fixed via `inert`
- Terminal link double-open fixed (xterm handlers were redundant with Tauri opener)
- Orphan comment cross-branch cleanup race fixed (clear cached diff on branch change)
- Dashboard pane debug toggle for diagnostics