### PR TITLE
fix: reap ssh children on remote endpoint dial failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-04-17]
+
+### Fixed
+- **Remote Endpoint Zombie Leak**: Failed WebSocket dials to remote endpoints over SSH no longer leave `<defunct>` `ssh` children behind. On macOS a slow or flapping remote could accumulate thousands of zombies over a day and exhaust `kern.maxprocperuid`, producing `fork: Resource temporarily unavailable` across the whole user session.
+
 ## [2026-04-16]
 
 ### Added

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -396,9 +396,8 @@ func (m *Manager) stopRuntimeLocked(runtime *endpointRuntime) {
 		_ = runtime.conn.Close(websocket.StatusNormalClosure, "")
 		runtime.conn = nil
 	}
-	if runtime.cmd != nil && runtime.cmd.Process != nil {
-		_ = runtime.cmd.Process.Kill()
-		_, _ = runtime.cmd.Process.Wait()
+	if runtime.cmd != nil {
+		killAndReap(runtime.cmd)
 		runtime.cmd = nil
 	}
 	runtime.sessions = make(map[string]protocol.Session)
@@ -1605,9 +1604,8 @@ func (m *Manager) clearConnection(id string) {
 		_ = runtime.conn.Close(websocket.StatusNormalClosure, "")
 		runtime.conn = nil
 	}
-	if runtime.cmd != nil && runtime.cmd.Process != nil {
-		_ = runtime.cmd.Process.Kill()
-		_, _ = runtime.cmd.Process.Wait()
+	if runtime.cmd != nil {
+		killAndReap(runtime.cmd)
 		runtime.cmd = nil
 	}
 }

--- a/internal/hub/transport.go
+++ b/internal/hub/transport.go
@@ -53,7 +53,7 @@ func connectViaSSHOnce(ctx context.Context, sshTarget, authToken string) (*webso
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		_ = cmd.Process.Kill()
+		killAndReap(cmd)
 		return nil, nil, err
 	}
 
@@ -90,7 +90,7 @@ func connectViaSSHOnce(ctx context.Context, sshTarget, authToken string) (*webso
 	ws, _, err := websocket.Dial(ctx, url, &websocket.DialOptions{HTTPHeader: headers})
 	if err != nil {
 		_ = ln.Close()
-		_ = cmd.Process.Kill()
+		killAndReap(cmd)
 		if acceptErr != nil {
 			return nil, nil, acceptErr
 		}
@@ -98,6 +98,18 @@ func connectViaSSHOnce(ctx context.Context, sshTarget, authToken string) (*webso
 	}
 	ws.SetReadLimit(remoteWSMessageReadLimit)
 	return ws, cmd, nil
+}
+
+// killAndReap terminates cmd and waits for it to exit so the child is not left
+// as a zombie on macOS. cmd.Wait also drains the Std{in,out,err}Pipe goroutines
+// that StdinPipe/StdoutPipe spawned; calling only os.Process.Kill leaks both the
+// OS-level zombie and the pipe goroutines.
+func killAndReap(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
 }
 
 func isRetryableWSRelayDialError(err error) bool {

--- a/internal/hub/transport_zombie_test.go
+++ b/internal/hub/transport_zombie_test.go
@@ -1,0 +1,84 @@
+//go:build !windows
+
+package hub
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestConnectViaSSHOnceReapsChildOnDialFailure exercises the websocket.Dial
+// failure path in connectViaSSHOnce. Before the fix, each failed attempt left
+// the ssh child as a <defunct> zombie because cmd.Process.Kill was called
+// without a matching cmd.Wait. On macOS these accumulate until the per-user
+// process limit is hit.
+func TestConnectViaSSHOnceReapsChildOnDialFailure(t *testing.T) {
+	// Shim "ssh" to a script that runs long enough for websocket.Dial to
+	// time out without producing a valid WebSocket upgrade response. The
+	// Dial error path is the one that leaked zombies in the bug.
+	shimDir := t.TempDir()
+	shim := filepath.Join(shimDir, "ssh")
+	script := "#!/bin/sh\nsleep 10\n"
+	if err := os.WriteFile(shim, []byte(script), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	const iterations = 8
+	for i := 0; i < iterations; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		ws, cmd, err := connectViaSSHOnce(ctx, "fake-target", "")
+		cancel()
+		if err == nil {
+			// Unexpected success — clean up and fail.
+			if ws != nil {
+				_ = ws.CloseNow()
+			}
+			killAndReap(cmd)
+			t.Fatalf("iteration %d: expected dial failure via shim, got success", i)
+		}
+	}
+
+	// Give the OS a moment to update process accounting.
+	time.Sleep(200 * time.Millisecond)
+
+	zombies := zombieChildrenOf(t, os.Getpid())
+	if zombies > 0 {
+		t.Fatalf("after %d failed dials: found %d zombie child ssh processes (expected 0)", iterations, zombies)
+	}
+}
+
+// zombieChildrenOf returns the number of <defunct> processes whose PPID equals
+// parent. Uses `ps -A` because `ps` without -A scopes to the controlling tty
+// and will miss detached children in CI.
+func zombieChildrenOf(t *testing.T, parent int) int {
+	t.Helper()
+	out, err := exec.Command("ps", "-A", "-o", "pid=,ppid=,stat=").Output()
+	if err != nil {
+		t.Fatalf("ps failed: %v", err)
+	}
+	count := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 3 {
+			continue
+		}
+		var pid, ppid int
+		if _, err := fmt.Sscanf(fields[0], "%d", &pid); err != nil {
+			continue
+		}
+		if _, err := fmt.Sscanf(fields[1], "%d", &ppid); err != nil {
+			continue
+		}
+		if ppid == parent && strings.HasPrefix(fields[2], "Z") {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
## Summary

- On macOS, every failed `websocket.Dial` to a remote endpoint (flapping remote, slow handshake, etc.) leaked one `<defunct>` ssh child parented to the daemon. Over ~26h one user accumulated 2212 zombies and hit `kern.maxprocperuid`, producing `fork: Resource temporarily unavailable` across the whole session. macOS has no child-subreaper, so these stayed parented to the daemon until it was killed.
- `connectViaSSHOnce` was calling `cmd.Process.Kill()` on both error paths without ever `cmd.Wait()`ing. New `killAndReap` helper does `Kill` + `cmd.Wait`; also promoted the runtime cleanup paths in `manager.go` (they were calling the lower-level `cmd.Process.Wait`, which reaped the pid but skipped the StdinPipe/StdoutPipe goroutine drain).

## Reproduction

Standalone (copy of `connectViaSSHOnce` + fake `ssh` shim that sleeps):
- Old code, 20 failed dials → **20 zombies**
- Fixed code, 20 failed dials → **0 zombies**

Live daemon snapshot during investigation caught one leaked ssh child at `PID 58408 PPID <daemon> Z <defunct>` after ~3 minutes of uptime.

## Test plan

- [x] `go test ./internal/hub/...` — 24 tests pass
- [x] New `TestConnectViaSSHOnceReapsChildOnDialFailure` passes with fix
- [x] Verified the regression test fails without the fix (8 iterations → 8 zombies reported)
- [x] `go build ./...` clean