### PR TITLE
docs: add plugin system and pi plugin plans

### DIFF
--- a/docs/plans/2026-04-07-pi-integration.md
+++ b/docs/plans/2026-04-07-pi-integration.md
@@ -1,0 +1,790 @@
+# Pi Coding Agent Integration
+
+**Status**: SUPERSEDED on 2026-04-16 by `docs/plans/2026-04-16-plugin-system.md` and `docs/plans/2026-04-16-pi-plugin.md`.
+
+Pi is no longer an in-tree Go driver. It becomes the first consumer of attn's new plugin system — a TypeScript/Bun plugin living in its own repo, connecting over JSON-RPC on the unix socket.
+
+**The behavioral design in this document is still authoritative** and referenced by the new pi plugin plan:
+
+- State event → attn state mapping (§State flow table)
+- Classifier hint pattern (who runs the classifier, with which model)
+- Session ID tie via `session_start` + `attn.link` custom entry
+- Edge cases: `--no-session`, resume/fork, ephemeral crashes
+- Explicit non-goals: no `pending_approval`, no yolo, no permission gate, no transcript watcher, no PTY state detector
+- extension.ts sketch (§F)
+
+**What changes (obsolete in this document):**
+
+- `internal/agent/pi.go`, `internal/agent/pi_ext/`, `internal/classifier/pi.go` — moved to the plugin repo in TypeScript, do not create in attn core.
+- Pi-specific protocol commands (`pi_session_linked`) — replaced by generic `agent_session_linked` / `session.report_metadata` in the plugin system plan.
+- Pi-specific SQLite columns (`pi_session_file`, `pi_session_id`) — replaced by generic `agent_metadata TEXT` blob.
+- Staging to `~/.attn/pi-ext.ts` via `ensureAttnPiExtensionStaged` — plugin handles its own staging.
+- Go `ClassifierProvider` / `ClassifierProviderWithHint` plumbing — plugin may own classifier end-to-end in TypeScript (open question in new plan).
+
+---
+
+**Original status**: Proposed
+**Date**: 2026-04-07
+**Owner**: daemon/frontend
+
+## Summary
+
+Integrate [`pi`](https://github.com/badlogic/pi-mono) (`npm install -g @mariozechner/pi-coding-agent`) as a first-class agent in attn, alongside claude/codex/copilot. The current `internal/agent/pi.go` is a minimal stub that only spawns the binary and passes args through; everything downstream (protocol enum, settings keys, `LocationPicker`, pty manager, hub manager) is already scaffolded for pi but no state detection or lifecycle features are wired up.
+
+Goal: codex-parity baseline (resume, fork, classifier, session metadata) using a custom attn-owned **pi extension** as the primary state source instead of transcript watching or PTY heuristics. Pi's extension API is richer than Claude Code hooks — it surfaces `session_start`, `input`, `before_agent_start`, `agent_start`/`end`, `turn_start`/`end`, `tool_call` (blockable), `tool_result`, `session_shutdown` — which makes it the cleanest place to hang reliable state detection.
+
+## Why an extension, not transcripts or PTY heuristics
+
+- Pi exposes a full TypeScript extension API auto-loadable via `pi -e <path>`. Extensions run in the pi node process, have access to `ctx.sessionManager`, can `appendCustomEntry` to persist state into the session JSONL, and can use `node:net` to talk directly to attn's unix socket.
+- The event model covers every state transition attn cares about, with no race conditions inherent to tailing a JSONL file or parsing a TUI.
+- If the extension fails to load, pi still runs; attn just falls through to `unknown` for that session. No brittle fallback machinery to maintain.
+
+## Architecture
+
+```
+┌─────────────────┐         ┌───────────────────────┐
+│  attn daemon    │         │  pi process           │
+│                 │         │  (spawned by attn)    │
+│  ~/.attn/       │◄────────┤   loads -e <staged>   │
+│  attn.sock      │ unix    │                       │
+│                 │ socket  │   attn pi extension   │
+│                 │         │   (TypeScript)        │
+└─────────────────┘         └───────────────────────┘
+       │                              │
+       │                              │
+       │                              ▼
+       │                    ~/.pi/agent/sessions/
+       │                    --<cwd>--/<ts>_<uuid>.jsonl
+       │                    (pi-owned, extension appends
+       │                     `attn.link` custom entry for
+       │                     session tie recovery)
+       │
+       ▼
+  When pi stops, daemon runs
+  `pi -p --no-tools --no-extensions --model <hint>`
+  as a classifier subprocess.
+```
+
+**State flow:**
+
+| Pi event                | Extension sends                             | Resulting attn state                             |
+|-------------------------|---------------------------------------------|--------------------------------------------------|
+| `session_start`         | `pi_session_linked` (ties IDs)              | (bookkeeping only; state stays `launching`)      |
+| `input` (user-typed)    | `update_state`, state=`working`             | `working`                                        |
+| `before_agent_start`    | `update_state`, state=`working`             | `working`                                        |
+| `turn_start` / `_end`   | (ignored; noise)                            | —                                                |
+| `agent_end`             | `stop` + last assistant text + `classifier_hint` | classifier runs, resolves to `idle` / `waiting_input` |
+| `session_shutdown`      | `update_state`, state=`idle`                | `idle`                                           |
+| Extension fails to load | (nothing)                                   | `launching` → `unknown` until PTY exits          |
+
+**Classifier path:** the extension does NOT call an LLM itself. It just tells the daemon *which* model to use via `classifier_hint: { provider, model }` on the stop payload. The Go daemon implements `ClassifierProvider.Classify` on the pi driver and shells out to `pi -p --no-tools --no-extensions --no-session --model <hint.model> '<prompt>'`, matching the Codex/Copilot pattern. This keeps classifier orchestration unified across agents and uses pi's own auth/model config.
+
+## Session ID tie
+
+Attn generates `ATTN_SESSION_ID` as today and passes it via env var. The extension's `session_start` handler is the first synchronization point:
+
+```typescript
+pi.on("session_start", async (_event, ctx) => {
+  const attnId = process.env.ATTN_SESSION_ID;
+  if (!attnId) return; // running outside attn — no-op
+
+  const piSessionFile = ctx.sessionManager.getSessionFile();  // path or undefined (--no-session)
+  const piSessionId   = ctx.sessionManager.getSessionId();    // pi's own uuid
+
+  // (a) tell the daemon — first message on the socket
+  send({
+    cmd: "pi_session_linked",
+    id: attnId,
+    pi_session_id: piSessionId,
+    pi_session_file: piSessionFile ?? null,
+  });
+
+  // (b) persist the tie inside pi's own session file
+  if (piSessionFile) {
+    ctx.sessionManager.appendCustomEntry("attn.link", { attnSessionId: attnId });
+  }
+});
+```
+
+The daemon stores `pi_session_file` + `pi_session_id` on the attn session record. The persisted `attn.link` custom entry lets attn rebuild the mapping by scanning `~/.pi/agent/sessions/` after a daemon restart — every attn-owned pi session is self-identifying.
+
+Edge cases:
+- `--no-session`: `getSessionFile()` is `undefined`; daemon knows there's no disk file to read.
+- `/resume` or `/fork`: `session_start` fires again with `reason: "resume" | "fork"` and a new session file; the link is re-sent.
+- Ephemeral / crash before link: attn side just has no `pi_session_file` until (or unless) the extension ever connects.
+
+## Wire protocol
+
+All messages are single-line JSON over `~/.attn/attn.sock`, same envelope the Claude hooks use today (exact field shape cross-checked against `internal/hooks` and `internal/daemon` socket handler as step 0 of Phase 2):
+
+```
+{"cmd":"pi_session_linked","id":"<attn>","pi_session_id":"<pi-uuid>","pi_session_file":"<path>|null"}
+{"cmd":"update_state","id":"<attn>","state":"working","source":"pi_ext"}
+{"cmd":"stop","id":"<attn>","text":"<last assistant text>","classifier_hint":{"provider":"google","model":"gemini-2.5-flash"}}
+{"cmd":"update_state","id":"<attn>","state":"idle","source":"pi_ext"}
+```
+
+New commands on the daemon socket: `pi_session_linked`. Reusing existing: `update_state`, `stop`. The optional `classifier_hint` field on the stop payload may or may not require a struct change — will be determined in Phase 2 step 0.
+
+## Deferred / explicit non-goals
+
+The following are intentionally out of scope and should not be added speculatively:
+
+- **`pending_approval` state for pi.** Pi has no native permission prompt. Building one inside the extension would be speculative UX without a concrete problem.
+- **Permission-gate hook** (`rm -rf` / `sudo` / destructive-write interception). Same reason.
+- **Yolo mode.** If there's nothing to gate, there's nothing to bypass. `HasYolo` stays `false`.
+- **Transcript watcher / real-time JSONL tailing.** The extension is the real-time source; tailing would duplicate work.
+- **PTY state detector.** Explicit non-goal: when the extension fails, we report `unknown` rather than introduce fragile TUI parsing.
+- **Global install of the extension to `~/.pi/agent/extensions/`.** The extension is staged per-daemon into `$TMPDIR` and loaded via `-e <path>`; bare `pi` runs outside attn are unaffected.
+
+If any of these becomes desirable later, each is a standalone follow-up with its own design, not part of the initial integration.
+
+## Implementation Phases
+
+### Phase 1 — Launch plumbing (no state yet)
+
+**Goal:** pi sessions launched by attn gain resume, fork, and `--continue` pass-through. Attn still shows `launching → unknown`, but the session is usable with resume semantics matching codex/copilot.
+
+**Changes:**
+
+- `internal/agent/pi.go`
+  - `BuildCommand`: translate `SpawnOpts.{ResumeSessionID, ResumePicker, ForkSession}` into pi's native flags:
+    - `ResumeSessionID != ""` → `--session <path>` (if we have a full file path) or `--fork <partial-uuid>` for fork-from-id. Verify which is right per pi's semantics before committing.
+    - `ResumePicker` → `--resume`
+    - `ForkSession && ResumeSessionID != ""` → `--fork <path-or-uuid>`
+    - Pass `--continue` for a "continue most recent" UX if attn has an equivalent.
+  - `Capabilities`: `HasResume: true`, `HasFork: true`. Everything else stays `false`.
+- `internal/agent/driver_test.go`
+  - Replace `TestBuiltInPiDriver_MinimalCapabilities` with a resume/fork-aware assertion.
+  - Add `TestPiDriver_BuildCommand_Resume`, `TestPiDriver_BuildCommand_Fork`, `TestPiDriver_BuildCommand_Passthrough`.
+
+**Deliverable:** `attn -s foo` + resume picker + fork work end-to-end. No regressions in attn UI state behavior.
+
+### Phase 2 — Attn pi extension + state reporting
+
+**Goal:** attn knows when pi is working vs done via the extension alone.
+
+**Step 0 — verify hook wire protocol.** Before writing any TypeScript, read `internal/hooks/*.go` and `internal/daemon/` socket handler to lock the exact `cmd` / `state` / `source` field shapes. Confirm that adding a new `pi_session_linked` command and an optional `classifier_hint` field on the stop payload does not require a protocol version bump on the WebSocket side.
+
+**New files:**
+
+- `internal/agent/pi_ext/extension.ts` — the extension source.
+  - Single TypeScript file, no npm deps. Imports `@mariozechner/pi-coding-agent` types (resolved at runtime by pi's bundled jiti). Uses `node:net` for the socket, `process.env` for config.
+  - No-ops cleanly if `ATTN_SESSION_ID` or `ATTN_SOCKET_PATH` is missing, so the file is safe even if accidentally copied to `~/.pi/agent/extensions/`.
+  - Subscribes to: `session_start`, `input`, `before_agent_start`, `agent_start`, `agent_end`, `session_shutdown`. (Skip `turn_start`/`turn_end` — noise, `agent_start`/`agent_end` are sufficient.)
+  - On `agent_end`: walks `ctx.sessionManager.getBranch()` for the last assistant text, reads `ctx.model` / current model info, sends `stop` with `classifier_hint`.
+  - Fire-and-forget writes. Reconnects the socket on disconnect with bounded backoff; drops messages if the socket is unavailable.
+- `internal/agent/pi_ext/embed.go` — `//go:embed extension.ts` + `StageExtension(dir string) (path string, err error)` helper.
+- `internal/agent/pi_ext/extension_test.go` — unit tests for the Go staging helper (idempotent writes, permissions, path stable across daemon lifetime).
+
+**Modified files:**
+
+- `internal/agent/pi.go`
+  - `Capabilities`: no new flags flip yet; the extension mechanism is orthogonal to `HasHooks`.
+  - `BuildEnv`: inject `ATTN_SESSION_ID=<opts.SessionID>` and `ATTN_SOCKET_PATH=<opts.SocketPath>` if the existing env plumbing doesn't already provide them (verify against `internal/pty/manager.go` during Phase 2 step 0).
+  - `BuildCommand`: prepend `-e <staged-extension-path>` to the arg list.
+  - Staging: the daemon writes the extension once on startup to `$TMPDIR/attn-pi-ext-<daemon-pid>.ts` and passes the path to spawn options. The pi driver doesn't need to re-stage per spawn.
+- `internal/daemon/` (socket handler / state update dispatch)
+  - Accept and route the new `pi_session_linked` command.
+  - Store `pi_session_file` + `pi_session_id` on the session record (new optional fields on the in-memory session struct and SQLite schema; no frontend surface yet).
+- `internal/daemon/daemon.go` startup
+  - Call `pi_ext.StageExtension(d.tmpDir)` once at init, stash the path, cleanup on shutdown.
+
+**Tests:**
+
+- Go: `BuildCommand` includes `-e <staged>`, env contains `ATTN_SESSION_ID` + `ATTN_SOCKET_PATH`, staging creates a readable file.
+- Go: daemon handles `pi_session_linked` → session record has `pi_session_file` + `pi_session_id` populated.
+- Smoke e2e: spawn `pi --help` (fast, no LLM call) with the extension loaded via `-e`, assert the extension connects to a test socket and sends a `pi_session_linked` message. This is the highest-value test because it exercises the full jiti load.
+
+**Deliverable:** pi sessions in attn transition through `launching → working → idle` based on real pi lifecycle events.
+
+### Phase 3 — Classifier via pi subprocess
+
+**Goal:** WAITING vs DONE classification at stop time.
+
+**New files:**
+
+- `internal/classifier/pi.go` — `ClassifyWithPi(text, executable, model, timeout)` that shells out to `pi -p --no-tools --no-extensions --no-session --mode text --model <model> '<classification prompt>'`. Cribbed from `ClassifyWithCodexExecutableInDir`. Reuse Codex's classifier system prompt verbatim; iterate only if we observe false positives.
+- `internal/classifier/pi_test.go` — parity with existing classifier tests; fake `pi` executable returning different verdicts.
+
+**Modified files:**
+
+- `internal/agent/pi.go`
+  - Implement `ClassifierProvider.Classify(text, timeout)` delegating to `classifier.ClassifyWithPi`.
+  - Add `ExecutableClassifierProvider.ClassifyWithExecutable` if the daemon's classifier dispatch needs it (check how Codex wires this).
+  - `Capabilities`: `HasClassifier: true`.
+- `internal/daemon/` stop-event handler
+  - Extract `classifier_hint.provider` + `classifier_hint.model` from the stop payload and route them into the classifier call. If the existing struct can't carry extra fields, add a new field and classify via a hint-aware variant.
+
+**Tests:**
+
+- Unit: `Pi.Classify()` with a fake pi stub executable.
+- Extension contract: stop payload includes `classifier_hint`.
+- Daemon: stop message with `classifier_hint` → classifier called with the hinted model.
+
+**Deliverable:** pi sessions land on `idle` vs `waiting_input` after stop, parity with claude/codex.
+
+### Phase 4 — Polish
+
+- `app/src/components/SettingsModal.tsx` / `app/src/utils/agentAvailability.ts`: confirm pi row renders correctly, `pi_executable` override works. Most scaffolding already exists; this is verification + small fixes.
+- `CHANGELOG.md`: one entry per landed phase.
+- `AGENTS.md`: one sentence noting pi support and the extension-based state tracking.
+
+Explicitly not in Phase 4: yolo mode, approval state, permission gates, transcript watcher, PTY state detector. See "Deferred / explicit non-goals" above.
+
+## Open questions (to resolve during implementation)
+
+1. **`ATTN_SOCKET_PATH` plumbing.** Is it already injected for non-claude drivers, or does `Pi.BuildEnv` need to add it? Claude hooks rely on the settings.json rather than env, so it may not be there for codex/copilot either. Resolve by reading `internal/pty/manager.go` env setup at the start of Phase 2.
+2. **Existing stop-event struct.** Can it carry `classifier_hint` as an optional field without a protocol version bump? Resolve by reading `internal/protocol` + `internal/daemon` stop handling in Phase 2 step 0.
+3. **Classifier prompt.** Start with Codex's prompt verbatim. If classification quality suffers, revisit with a pi-specific prompt in a follow-up.
+4. **Resume vs fork argument mapping.** Verify exactly how attn's `SpawnOpts.ResumeSessionID` values look today (full path vs uuid vs partial uuid) and map them onto pi's `--session` / `--fork` / `--resume` semantics. Settle this before writing `BuildCommand` in Phase 1.
+
+## Suggested kick-off order
+
+1. **Phase 1** as a standalone PR. Small, low-risk, immediately unlocks pi usage.
+2. **Phase 2 step 0** — investigate hook protocol before writing any TypeScript. (Partially done already — see the *Wire protocol — concrete mapping* section below.)
+3. **Phase 2 extension + staging** — ship state transitions, verify via smoke e2e.
+4. **Phase 3** as a separate PR.
+5. **Phase 4** polish merged alongside Phase 3 or as a tiny follow-up.
+
+---
+
+## Expanded implementation details
+
+The following sections expand load-bearing details that were too hand-wavy in the phase sketches above. Read these before writing code for the relevant phase.
+
+### A. Attn's spawn architecture — why staging and env live in the wrapper, not the daemon
+
+This affects staging (§B), env injection (§D), and failure modes.
+
+There are **two processes** involved in spawning a pi session:
+
+1. **Daemon (`internal/daemon`)** — runs in the background. When a session is requested, it uses `internal/pty/manager.go` to spawn a login shell that runs `attn -s <label> [--resume ...] [--yolo]` and injects `ATTN_DAEMON_MANAGED=1`, `ATTN_SESSION_ID=<id>`, `ATTN_AGENT=pi`, etc. See `internal/pty/manager.go:378` (`buildSpawnCommand`) and `:417` (`buildSpawnEnv`). The daemon does **not** call `Driver.BuildCommand` or `Driver.PrepareLaunch` directly.
+2. **Wrapper (`cmd/attn/main.go`)** — the `attn` binary re-executed by the daemon as the login-shell child. It parses flags, registers with the daemon (no-op when `ATTN_DAEMON_MANAGED=1`), constructs `agentdriver.SpawnOpts{SocketPath: config.SocketPath(), ...}`, calls `preparer.PrepareLaunch(opts)` at line 546, calls `driver.BuildCommand(opts)` at line 575, and `driver.BuildEnv(opts)` at line 580. See `cmd/attn/main.go:520-600`.
+
+**Implications:**
+- `Pi.PrepareLaunch` runs in the **wrapper** process, per spawn, with access to `opts.SessionID`, `opts.SocketPath`, `opts.CWD`.
+- `Pi.BuildCommand` runs in the wrapper too, same access.
+- `Pi.BuildEnv` output is merged into the child process env via `mergeEnv(os.Environ(), driver.BuildEnv(opts))` at `cmd/attn/main.go:580`.
+- `ATTN_SESSION_ID` is set at `internal/pty/manager.go:447` during the daemon-side spawn *and* re-read by the wrapper at `cmd/attn/main.go:521`. We do not need to add it in `Pi.BuildEnv`; it's already in the wrapper's env by the time `BuildEnv` runs, and Go's child process inherits it via `os.Environ()` in `mergeEnv`.
+- `ATTN_SOCKET_PATH` is **not** currently set in the child env by anyone. Claude hooks don't need it (they bake the path into settings.json via `hooks.Generate`). For pi, `Pi.BuildEnv` must add `ATTN_SOCKET_PATH=` + `opts.SocketPath` explicitly.
+
+### B. Staging strategy — use the claude_skill.go pattern
+
+Previous plan said "stage once per daemon lifetime to `$TMPDIR`." Revised: **stage persistently to `~/.attn/pi-ext.ts` with a content-hash check, called from `Pi.PrepareLaunch` in the wrapper.** Mirrors `internal/agent/claude_skill.go:155` (`ensureAttnClaudeSkillInstalled`).
+
+Why the revision: the daemon doesn't run `PrepareLaunch`; the wrapper does. "Per daemon lifetime" would require adding a new daemon-side staging hook with its own config plumbing. The claude_skill pattern is already established in the codebase, is per-spawn but idempotent via content comparison, and requires zero daemon changes.
+
+**Code sketch (new file `internal/agent/pi_ext.go`):**
+
+```go
+package agent
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+)
+
+// attnPiExtensionContent is the TypeScript extension source that attn ships
+// and loads into pi via `pi -e <path>`. See extension.ts in the tree for the
+// canonical source and docs/plans/2026-04-07-pi-integration.md for shape.
+const attnPiExtensionContent = `<full extension.ts source as a Go raw string>`
+
+func ensureAttnPiExtensionStaged() (string, error) {
+    home, err := os.UserHomeDir()
+    if err != nil {
+        return "", fmt.Errorf("resolve home for pi extension: %w", err)
+    }
+    extDir := filepath.Join(home, ".attn")
+    extPath := filepath.Join(extDir, "pi-ext.ts")
+    if current, err := os.ReadFile(extPath); err == nil {
+        if string(current) == attnPiExtensionContent {
+            return extPath, nil
+        }
+    } else if !os.IsNotExist(err) {
+        return "", fmt.Errorf("read pi extension: %w", err)
+    }
+    if err := os.MkdirAll(extDir, 0o755); err != nil {
+        return "", fmt.Errorf("create ~/.attn dir: %w", err)
+    }
+    if err := os.WriteFile(extPath, []byte(attnPiExtensionContent), 0o644); err != nil {
+        return "", fmt.Errorf("write pi extension: %w", err)
+    }
+    return extPath, nil
+}
+```
+
+**Wiring in `internal/agent/pi.go`:**
+
+```go
+var _ LaunchPreparer = (*Pi)(nil)
+
+func (p *Pi) PrepareLaunch(opts SpawnOpts) error {
+    _, err := ensureAttnPiExtensionStaged()
+    return err
+}
+
+func (p *Pi) BuildCommand(opts SpawnOpts) *exec.Cmd {
+    args := []string{}
+    if path, err := ensureAttnPiExtensionStaged(); err == nil {
+        args = append(args, "-e", path)
+    }
+    // ...resume/fork args (see §C)...
+    args = append(args, opts.AgentArgs...)
+    return exec.Command(opts.Executable, args...)
+}
+
+func (p *Pi) BuildEnv(opts SpawnOpts) []string {
+    env := []string{
+        "ATTN_SOCKET_PATH=" + opts.SocketPath,
+    }
+    if opts.Executable != "" && opts.Executable != p.DefaultExecutable() {
+        env = append(env, p.ExecutableEnvVar()+"="+opts.Executable)
+    }
+    return env
+}
+```
+
+**Why `BuildCommand` also calls `ensureAttnPiExtensionStaged`**: `PrepareLaunch` is optional (the interface is only invoked if implemented), and `BuildCommand` needs the path. Calling it twice is idempotent (content-hash short-circuit). If staging fails in `BuildCommand` we just omit the `-e` flag — pi still runs, attn sees `unknown`, matches the "report unknown on failure" decision.
+
+**No SpawnOpts changes, no daemon changes, no singleton.**
+
+### C. Resume/fork flag mapping — semantic mismatch and Phase 1 scope
+
+Pi's native session flags are fundamentally different from codex/copilot:
+
+| attn intent                   | claude                   | codex                | copilot              | pi                                   |
+|-------------------------------|--------------------------|----------------------|----------------------|--------------------------------------|
+| New session                   | `--session-id <id>`      | (none)               | (none)               | (none)                               |
+| Resume picker (interactive)   | `-r`                     | `resume`             | `--resume`           | `--resume`                           |
+| Resume specific by ID         | `-r <id>`                | `resume <id>`        | `--resume <id>`      | **`--session <path>`** (path, not id)|
+| Fork specific by ID           | `-r <id> --fork-session` | (not supported)      | (not supported)      | `--fork <path-or-partial-uuid>`      |
+
+**The mismatch:** attn's `SpawnOpts.ResumeSessionID` carries whatever the downstream agent's native session identifier is — for codex/copilot/claude that's a UUID. Pi's `--session` wants a filesystem path, not a UUID. Pi's `--fork` accepts either a path or a partial UUID, which is one convenient escape hatch.
+
+Looking at how the wrapper populates `ResumeSessionID`: `cmd/attn/main.go:535` sets it from `parsed.resumeID` which comes from CLI arg parsing (`--resume <id>`). For attn-internal recovery flows, the daemon's `SetResumeSessionID` / `GetResumeSessionID` store methods persist whatever id the driver asked to keep.
+
+**Phase 1 scope (honest):**
+
+| Flow                   | Phase 1 wires up?                                              |
+|------------------------|----------------------------------------------------------------|
+| New pi session         | Yes — no resume flags, default pi behavior                     |
+| `--resume` picker      | Yes — `ResumePicker → --resume`                                |
+| Fork-by-id             | Yes — `ForkSession && ResumeSessionID != "" → --fork <id>` (partial UUID works per pi docs) |
+| Resume-by-id in place  | **No** — requires a file path we don't yet have. Defer to Phase 2b. |
+
+Phase 1's `BuildCommand`:
+
+```go
+func (p *Pi) BuildCommand(opts SpawnOpts) *exec.Cmd {
+    args := []string{}
+    // (extension staging handled in §B)
+
+    switch {
+    case opts.ForkSession && opts.ResumeSessionID != "":
+        // Partial UUID works per pi docs; full path also works.
+        args = append(args, "--fork", opts.ResumeSessionID)
+    case opts.ResumePicker:
+        args = append(args, "--resume")
+    case opts.ResumeSessionID != "":
+        // Phase 1: warn and ignore. Phase 2b lifts this limitation.
+        // (Log via driver warning path; return cmd without --session.)
+    }
+
+    if opts.YoloMode {
+        // Explicit non-goal: HasYolo=false, this branch never fires.
+    }
+
+    args = append(args, opts.AgentArgs...)
+    return exec.Command(opts.Executable, args...)
+}
+```
+
+**Capabilities for Phase 1:** `HasResume: true` (picker works), `HasFork: true` (via partial UUID). Leaving `HasResume: true` is slightly dishonest because resume-by-id doesn't work in place — but the picker is resume UX and it *does* work. If this is uncomfortable, gate the capability on `HasFork` alone and leave `HasResume: false` until Phase 2b.
+
+**Phase 2b — resume-by-id lift (added after Phase 2):**
+
+Once `pi_session_linked` is wired up, the daemon stores `pi_session_file` alongside the session. For resume-by-id, the wrapper needs to resolve an incoming ID to a path. Two layers of resolution:
+
+1. **Store lookup** — if attn has ever seen this session before, `store.GetPiSessionLink(id)` returns the path.
+2. **Filesystem glob fallback** — if not in the store (e.g., first time attn is asked to resume a pi session it didn't originally own), glob `~/.pi/agent/sessions/**/*_<partial-uuid>*.jsonl` across all cwd-dirs. Return the first match (or ambiguous → fail).
+
+New helper in `internal/agent/pi.go`:
+
+```go
+func (p *Pi) resolveSessionFile(cwd, idOrPath string) string {
+    // If idOrPath is already a .jsonl path that exists, use it.
+    if strings.HasSuffix(idOrPath, ".jsonl") {
+        if _, err := os.Stat(idOrPath); err == nil {
+            return idOrPath
+        }
+    }
+    // Otherwise treat as a (partial) UUID and glob.
+    // (Implementation: filepath.Glob across ~/.pi/agent/sessions/**/<ts>_*<id>*.jsonl)
+    return ""
+}
+```
+
+Phase 2b threads a store lookup through the wrapper before calling `BuildCommand`, or exposes a `ResumePolicyProvider`-style hook on the driver so it can self-resolve. TBD at phase 2b kickoff — simplest answer is probably to add a `SpawnOpts.ResumeSessionPath` field set by the wrapper after a store lookup, parallel to the existing `ResumeSessionID`.
+
+### D. Wire protocol — concrete mapping
+
+The daemon reads one JSON message per unix socket connection. See `internal/daemon/daemon.go:1406` (`handleConnection`) — 65536-byte buffer, single `protocol.ParseMessage` call, switch on command, dispatch to handler, close conn. **Each message is one connect/write/close cycle** (matches how Claude hooks use `nc` via `hooks.Generate` in `internal/hooks/hooks.go`).
+
+The pi extension must match this: open a new `node:net` socket per message, `write(JSON + '\n')`, `end()`, handle errors by dropping. Do **not** try to keep a persistent connection — the existing `handleConnection` only reads one message and closes.
+
+**New command: `pi_session_linked`.**
+
+TypeSpec (`internal/protocol/schema/main.tsp`) — add alongside existing messages around line 264:
+
+```tsp
+model PiSessionLinkedMessage {
+  cmd: "pi_session_linked";
+  id: string;              // attn session id
+  pi_session_id: string;   // pi's own UUID (empty if ephemeral)
+  pi_session_file?: string; // null/omitted for --no-session
+}
+```
+
+After `make generate-types`, update `internal/protocol/constants.go`:
+
+```go
+const CmdPiSessionLinked = "pi_session_linked"
+
+// In ParseMessage switch:
+case CmdPiSessionLinked:
+    var msg PiSessionLinkedMessage
+    // ... standard parse ...
+```
+
+Daemon handler in `internal/daemon/daemon.go` near `handleStop`:
+
+```go
+func (d *Daemon) handlePiSessionLinked(conn net.Conn, msg *protocol.PiSessionLinkedMessage) {
+    d.logf("handlePiSessionLinked: session=%s pi_id=%s file=%s",
+        msg.ID, msg.PiSessionID, protocol.Deref(msg.PiSessionFile))
+    d.store.SetPiSessionLink(msg.ID, protocol.Deref(msg.PiSessionFile), msg.PiSessionID)
+    d.sendOK(conn)
+}
+```
+
+Add the case to `handleConnection` switch at `internal/daemon/daemon.go:1422`:
+
+```go
+case protocol.CmdPiSessionLinked:
+    d.handlePiSessionLinked(conn, msg.(*protocol.PiSessionLinkedMessage))
+```
+
+**Reusing existing commands for state / stop.**
+
+| Extension event         | Wire command         | Shape                                                                       |
+|-------------------------|----------------------|-----------------------------------------------------------------------------|
+| `session_start`         | `pi_session_linked`  | above                                                                       |
+| `input` / `before_agent_start` / `agent_start` | `state` | `{cmd:"state", id, state:"working"}` — matches existing `StateMessage`      |
+| `session_shutdown`      | `state`              | `{cmd:"state", id, state:"idle"}`                                           |
+| `agent_end`             | `stop`               | `{cmd:"stop", id, transcript_path, text?, classifier_hint?}` — see below    |
+
+**Extending `StopMessage` with classifier hint and pre-extracted text.**
+
+TypeSpec change to `internal/protocol/schema/main.tsp:270`:
+
+```tsp
+model ClassifierHint {
+  provider: string;
+  model: string;
+}
+
+model StopMessage {
+  cmd: "stop";
+  id: string;
+  transcript_path: string;
+  text?: string;                    // new: pre-extracted last assistant text
+  classifier_hint?: ClassifierHint; // new: model to use for classification
+}
+```
+
+Both new fields are optional → this is an additive change → no protocol version bump required for existing Claude-hook clients.
+
+**Consumer side:** `classifySessionState` in `internal/daemon/daemon.go:1669` currently pulls text via `driver.ExtractLastAssistantForClassification(transcriptPath, ...)`. For pi we want to short-circuit: if `msg.Text != nil && *msg.Text != ""`, skip extraction and use it directly. This is a small branch in `classifyOrDeferAfterStop` / `classifySessionState`.
+
+**Classifier hint plumbing:** the existing `ClassifierProvider.Classify(text, timeout)` has no room for a hint. Options:
+1. Add a new optional interface `ClassifierProviderWithHint` that pi implements; daemon prefers it when the stop message carries a hint.
+2. Add a thread-local / per-call context parameter to Classify (more invasive).
+
+Pick option 1 — narrower blast radius:
+
+```go
+// internal/agent/driver.go
+type ClassifierHint struct {
+    Provider string
+    Model    string
+}
+
+type ClassifierProviderWithHint interface {
+    ClassifyWithHint(text string, hint ClassifierHint, timeout time.Duration) (string, error)
+}
+
+func GetClassifierWithHint(d Driver) (ClassifierProviderWithHint, bool) {
+    if d == nil || !EffectiveCapabilities(d).HasClassifier {
+        return nil, false
+    }
+    cp, ok := d.(ClassifierProviderWithHint)
+    return cp, ok
+}
+```
+
+Daemon dispatch (in the classification path): try `ClassifierProviderWithHint` if a hint is present, fall back to `ClassifierProvider.Classify`.
+
+### E. Session record schema + migration
+
+Decision: mirror the `resume_session_id` pattern. New columns live in SQLite and are accessed via explicit store methods, **not** added to the TypeSpec `Session` model (`internal/protocol/schema/main.tsp:91`) or broadcast to the frontend.
+
+Why: matches existing convention (`resume_session_id` is on the sessions table but not in the protocol), keeps internal metadata out of the frontend bundle, avoids a protocol version bump.
+
+**New SQLite migration in `internal/store/sqlite.go` (next migration number after current max — check existing list before writing, current max was 24+ at time of plan):**
+
+```go
+{N,   "add pi_session_file to sessions", "ALTER TABLE sessions ADD COLUMN pi_session_file TEXT NOT NULL DEFAULT ''"},
+{N+1, "add pi_session_id to sessions",   "ALTER TABLE sessions ADD COLUMN pi_session_id TEXT NOT NULL DEFAULT ''"},
+```
+
+Also update the `columnExists` fallback block at `internal/store/sqlite.go:461` to add idempotent ALTERs for these two columns (mirrors how `resume_session_id` is handled at line 461-470).
+
+**New store methods in `internal/store/store.go` (mirror `SetResumeSessionID` / `GetResumeSessionID` at lines 594-625):**
+
+```go
+func (s *Store) SetPiSessionLink(id, piSessionFile, piSessionID string) {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    if s.db == nil {
+        return
+    }
+    _, err := s.db.Exec(
+        "UPDATE sessions SET pi_session_file = ?, pi_session_id = ? WHERE id = ?",
+        strings.TrimSpace(piSessionFile), strings.TrimSpace(piSessionID), id,
+    )
+    if err != nil {
+        log.Printf("[store] SetPiSessionLink: failed for session %s: %v", id, err)
+    }
+}
+
+func (s *Store) GetPiSessionLink(id string) (piSessionFile, piSessionID string) {
+    s.mu.RLock()
+    defer s.mu.RUnlock()
+    if s.db == nil {
+        return "", ""
+    }
+    var f, pid string
+    if err := s.db.QueryRow(
+        "SELECT pi_session_file, pi_session_id FROM sessions WHERE id = ?", id,
+    ).Scan(&f, &pid); err != nil {
+        return "", ""
+    }
+    return strings.TrimSpace(f), strings.TrimSpace(pid)
+}
+```
+
+**Files touched for the schema/link work:**
+
+| File                                        | Change                                                    |
+|---------------------------------------------|-----------------------------------------------------------|
+| `internal/store/sqlite.go`                  | 2 new migrations + columnExists fallback branches         |
+| `internal/store/store.go`                   | `SetPiSessionLink` / `GetPiSessionLink`                   |
+| `internal/store/store_test.go`              | Tests for the new methods (mirror resume_session_id tests)|
+| `internal/protocol/schema/main.tsp`         | `PiSessionLinkedMessage` + `StopMessage` field additions + `ClassifierHint` |
+| `internal/protocol/generated.go`            | Regenerated via `make generate-types`                     |
+| `app/src/types/generated.ts`                | Regenerated via `make generate-types`                     |
+| `internal/protocol/constants.go`            | `CmdPiSessionLinked` constant + `ParseMessage` case       |
+| `internal/daemon/daemon.go`                 | `handlePiSessionLinked`, dispatch case, stop-path short-circuit when `text` is set, classifier dispatch to `ClassifierProviderWithHint` |
+| `internal/agent/driver.go`                  | `ClassifierHint` struct + `ClassifierProviderWithHint` interface + `GetClassifierWithHint` helper |
+
+**Not touched:** `app/src/**` (no frontend surface for pi_session_file/id). `Session` model in TypeSpec (unchanged).
+
+### F. Extension.ts — full file sketch
+
+File path (pre-staging): `internal/agent/pi_ext_source.ts` in the attn repo, not shipped directly. Its content lives as a Go raw string in `internal/agent/pi_ext.go` (see §B). Keeping the `.ts` file in the tree makes editor tooling work; a `go generate` step (or a tiny Go test) reads it and asserts the Go constant matches.
+
+**Full sketch:**
+
+```typescript
+/**
+ * Attn pi extension
+ *
+ * Loaded via `pi -e <path>` when attn spawns pi. Reports session lifecycle
+ * events to attn's unix socket so attn can track state without PTY heuristics
+ * or transcript tailing.
+ *
+ * No-ops cleanly if ATTN_SESSION_ID or ATTN_SOCKET_PATH is missing, so the
+ * file is safe even if accidentally copied to ~/.pi/agent/extensions/.
+ *
+ * Protocol: one JSON message per socket connection (connect / write / end),
+ * matching the daemon's handleConnection loop.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { createConnection } from "node:net";
+import { appendFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+type AttnMessage =
+  | { cmd: "pi_session_linked"; id: string; pi_session_id: string; pi_session_file: string | null }
+  | { cmd: "state"; id: string; state: "working" | "idle" }
+  | { cmd: "stop"; id: string; transcript_path: string; text?: string;
+      classifier_hint?: { provider: string; model: string } };
+
+const ATTN_ID = process.env.ATTN_SESSION_ID;
+const SOCKET_PATH = process.env.ATTN_SOCKET_PATH;
+const LOG_PATH = join(homedir(), ".attn", "pi-ext.log");
+
+function log(line: string): void {
+  try {
+    appendFileSync(LOG_PATH, `[${new Date().toISOString()}] [${ATTN_ID ?? "-"}] ${line}\n`);
+  } catch {
+    // swallow: logging must never crash the extension
+  }
+}
+
+function send(msg: AttnMessage): void {
+  if (!SOCKET_PATH) return;
+  try {
+    const sock = createConnection(SOCKET_PATH);
+    sock.on("error", (err) => log(`socket error: ${err.message}`));
+    sock.on("connect", () => {
+      sock.write(JSON.stringify(msg));
+      sock.end();
+    });
+  } catch (err) {
+    log(`send failed: ${(err as Error).message}`);
+  }
+}
+
+function lastAssistantText(ctx: ExtensionContext): string {
+  try {
+    const branch = ctx.sessionManager.getBranch();
+    for (let i = branch.length - 1; i >= 0; i--) {
+      const entry = branch[i];
+      if (entry.type !== "message") continue;
+      if (entry.message.role !== "assistant") continue;
+      const content = entry.message.content;
+      if (typeof content === "string") return content;
+      if (!Array.isArray(content)) continue;
+      const text = content
+        .filter((c): c is { type: "text"; text: string } => c.type === "text")
+        .map((c) => c.text)
+        .join("\n")
+        .trim();
+      if (text) return text;
+    }
+  } catch (err) {
+    log(`lastAssistantText error: ${(err as Error).message}`);
+  }
+  return "";
+}
+
+function classifierHint(ctx: ExtensionContext): { provider: string; model: string } | undefined {
+  try {
+    // ctx.model is the currently-active model for this session.
+    const m = ctx.model;
+    if (!m || !m.provider || !m.id) return undefined;
+    return { provider: m.provider, model: m.id };
+  } catch (err) {
+    log(`classifierHint error: ${(err as Error).message}`);
+    return undefined;
+  }
+}
+
+export default function (pi: ExtensionAPI): void {
+  if (!ATTN_ID || !SOCKET_PATH) {
+    // Running outside attn. Do nothing.
+    return;
+  }
+
+  log(`extension loaded: attn_id=${ATTN_ID} socket=${SOCKET_PATH}`);
+
+  pi.on("session_start", async (_event, ctx) => {
+    try {
+      const piSessionFile = ctx.sessionManager.getSessionFile() ?? null;
+      const piSessionId = ctx.sessionManager.getSessionId() ?? "";
+      send({
+        cmd: "pi_session_linked",
+        id: ATTN_ID!,
+        pi_session_id: piSessionId,
+        pi_session_file: piSessionFile,
+      });
+      if (piSessionFile) {
+        try {
+          ctx.sessionManager.appendCustomEntry("attn.link", { attnSessionId: ATTN_ID });
+        } catch (err) {
+          log(`appendCustomEntry failed: ${(err as Error).message}`);
+        }
+      }
+    } catch (err) {
+      log(`session_start handler threw: ${(err as Error).message}`);
+    }
+  });
+
+  const markWorking = async () => {
+    try {
+      send({ cmd: "state", id: ATTN_ID!, state: "working" });
+    } catch (err) {
+      log(`markWorking threw: ${(err as Error).message}`);
+    }
+  };
+
+  pi.on("input", markWorking);
+  pi.on("before_agent_start", markWorking);
+  pi.on("agent_start", markWorking);
+
+  pi.on("agent_end", async (_event, ctx) => {
+    try {
+      const text = lastAssistantText(ctx);
+      const hint = classifierHint(ctx);
+      send({
+        cmd: "stop",
+        id: ATTN_ID!,
+        transcript_path: ctx.sessionManager.getSessionFile() ?? "",
+        text: text || undefined,
+        classifier_hint: hint,
+      });
+    } catch (err) {
+      log(`agent_end handler threw: ${(err as Error).message}`);
+    }
+  });
+
+  pi.on("session_shutdown", async (_event) => {
+    try {
+      send({ cmd: "state", id: ATTN_ID!, state: "idle" });
+    } catch (err) {
+      log(`session_shutdown handler threw: ${(err as Error).message}`);
+    }
+  });
+}
+```
+
+**Design notes on the sketch:**
+
+- **Fire-and-forget**. `send()` does not await; if a write fails (socket gone, file missing) the error is logged and execution continues. State messages are idempotent — missing one doesn't desync pi's actual state from attn.
+- **Per-handler try/catch**. A throw inside any pi event handler could abort pi's lifecycle. Every top-level handler wraps its body in try/catch with logging.
+- **Logging to `~/.attn/pi-ext.log`, not stdout**. Pi owns the TUI; any stdout write corrupts it. Append-only file with best-effort error swallowing.
+- **Connection per message**. Matches the daemon's `handleConnection` which reads exactly one message per conn. No persistent connection, no framing concerns, no reconnect logic. Cost: a Unix socket connect is ~microseconds; we'll fire maybe 10 messages per session.
+- **Text and hint extraction are defensive**. Either can return empty; daemon must handle missing `text` by falling through to transcript extraction (which for pi will likely return empty too, causing classifier to skip and state to land on `unknown`). That's acceptable.
+- **`appendCustomEntry` is best-effort**. If pi's persistence fails (ephemeral session, disk full), we still sent the link over the socket — attn still has the tie for this session's lifetime; recovery after daemon restart would just fail.
+- **No npm dependencies**. Only `node:net`, `node:fs`, `node:path`, `node:os`, plus type-only imports from `@mariozechner/pi-coding-agent`. Type imports are erased at runtime by jiti's TS loader; no runtime require path needed.
+- **Type assertions on `ExtensionContext` / `ExtensionAPI`**. These come from the user's installed pi; jiti resolves them at extension load. If pi's type surface changes version-to-version, the extension breaks at load (not runtime) and attn falls through to `unknown`. That's the correct failure mode.
+
+**What's NOT in the sketch but will need to be sorted during implementation:**
+
+- Exact shape of `ctx.model` at `agent_end` time — docs hint it exists but don't nail the property names. Verify against `@mariozechner/pi-coding-agent/dist/` type definitions when writing the Go test that asserts the extension compiles.
+- Whether `ctx.sessionManager.getBranch()` returns only the current branch or the full path from leaf to root — if it's the full path, the walk is correct; if it's ambiguous, check `getBranch(fromId)` overloads.
+- Log rotation — `~/.attn/pi-ext.log` grows unbounded. Acceptable for v1; add rotation if it becomes a problem.
+
+### G. Testing strategy (brief)
+
+- **Go unit tests**: `Pi.BuildCommand` / `BuildEnv` / `PrepareLaunch` — standard table-driven tests in `internal/agent/pi_test.go`. Staging idempotence test.
+- **Store tests**: `SetPiSessionLink` / `GetPiSessionLink` round-trip in `internal/store/store_test.go`.
+- **Protocol test**: `PiSessionLinkedMessage` round-trip parse in `internal/protocol` tests.
+- **Daemon test**: stop message with `text` and `classifier_hint` bypasses transcript extraction and hits `ClassifierProviderWithHint`. Use a fake Pi driver that records hint/text seen.
+- **Extension integration test (deferred)**: spawn a real `pi --print --no-session --no-tools --model <stub> 'hi'` with `-e <staged>` and a test unix socket server. Assert the expected sequence of JSON messages lands on the server. Skip if pi isn't installed in CI; run locally.
+

--- a/docs/plans/2026-04-16-pi-plugin.md
+++ b/docs/plans/2026-04-16-pi-plugin.md
@@ -1,0 +1,137 @@
+# Pi as the first attn plugin
+
+**Status**: DRAFT — depends on `2026-04-16-plugin-system.md` which is also in draft. Not ready to implement.
+**Date**: 2026-04-16
+**Owner**: victor
+
+## Summary
+
+Rebuild pi integration as the first real attn plugin, rather than as an in-tree Go driver. Plugin lives in its own repo (likely `attn-pi` under the same GitHub owner), written in TypeScript for Bun, consumes attn's plugin JSON-RPC protocol directly — no SDK. The SDK emerges from pi's patterns in a later extraction, per the plugin system plan.
+
+**This plan deliberately avoids repeating what's already in the superseded pi plan.** That document remains authoritative for pi's *behavioral* design. This plan focuses on how pi's behavior moves into a plugin shape.
+
+## Relationship to `docs/plans/2026-04-07-pi-integration.md`
+
+The old plan is marked SUPERSEDED but is NOT obsolete for behavior. Load-bearing sections still authoritative:
+
+- State event → attn state mapping (§State flow table)
+- Classifier hint pattern (hints provider + model)
+- Session ID tie via `session_start` event and `attn.link` custom entry
+- Edge cases: `--no-session`, resume/fork, ephemeral crashes
+- Explicit non-goals: no `pending_approval`, no yolo mode, no permission gate, no transcript watcher, no PTY state detector
+- extension.ts sketch (§F)
+- Open questions 3 and 4 (classifier prompt, resume/fork argument mapping)
+
+What's obsolete in the old plan (do not implement):
+
+- `internal/agent/pi.go`, `internal/agent/pi_ext/`, `internal/classifier/pi.go` — moved to the plugin repo in TypeScript.
+- Pi-specific protocol commands (`pi_session_linked`) — replaced by generic `agent_session_linked` / `session.report_metadata`.
+- Pi-specific store columns (`pi_session_file`, `pi_session_id`) — replaced by generic `agent_metadata` JSON blob.
+- `ensureAttnPiExtensionStaged` style content-hash staging in Go — plugin handles its own staging in TypeScript.
+- `ClassifierProvider` / `ClassifierProviderWithHint` Go plumbing — pi plugin may own classification end-to-end in TypeScript (see Open question below).
+
+## Plugin repo layout (proposal)
+
+```
+attn-pi/
+├── attn-plugin.toml          # manifest
+├── package.json              # bun deps, build scripts
+├── src/
+│   ├── index.ts              # plugin entrypoint, JSON-RPC connection to attn
+│   ├── driver.ts             # driver.register + driver.spawn/resume/fork handlers
+│   ├── state.ts              # map pi extension events → attn state reports
+│   ├── classifier.ts         # shells out to `pi -p` for WAITING vs DONE
+│   ├── resume.ts             # resume/fork flag mapping + session-file path resolution
+│   └── pi-extension.ts       # staged into $TMPDIR, loaded by pi via `-e <path>`
+├── README.md
+└── CHANGELOG.md
+```
+
+## Phases
+
+### Phase 1 — Plugin skeleton + launch plumbing
+
+Plugin:
+- Connects to `~/.attn/attn.sock`, sends `hello` with `roles: ["driver"]`.
+- Registers for agent `pi` with `capabilities: { resume: true, fork: true, yolo: false, classifier: true, state_reporting: true }`.
+- Handles `driver.spawn`, `driver.resume`, `driver.fork`: returns `{ argv, env, cwd }`. Includes `-e <staged-extension-path>` in argv even though the extension is a no-op in this phase.
+
+Resume/fork argument mapping follows the old plan §C. Phase 1 honest scope:
+- New session: works
+- `--resume` picker: works
+- Fork by id: works (pi's `--fork` accepts partial UUIDs)
+- Resume by id in place: deferred to Phase 2b — requires session-file path resolution from `agent_metadata` store lookup
+
+State reporting is not wired up yet. Sessions show `launching` → `unknown` until the PTY exits.
+
+**Deliverable:** `attn -s foo` with agent=pi works, resume picker works, fork works. Plugin installable via `attn plugin install --path ./attn-pi` (or dev mode).
+
+### Phase 2 — Pi extension + state reporting
+
+Plugin stages `pi-extension.ts` (content-hash check per daemon lifetime, or `$TMPDIR/attn-pi-ext-<pid>.ts` cleared on exit) and invokes pi with `-e <path>`. The extension handles:
+
+- `session_start` → plugin calls `session.report_metadata { session_id, metadata: { pi_session_id, pi_session_file } }` and the extension persists `attn.link` custom entry in pi's JSONL
+- `input`, `before_agent_start`, `agent_start` → plugin calls `session.report_state { state: "working" }`
+- `agent_end` → plugin calls `session.report_stop { text, classifier_hint }`
+- `session_shutdown` → plugin calls `session.report_state { state: "idle" }`
+
+**Open question: where does the extension connect?** Two options:
+
+1. **Extension → attn directly.** Extension opens `~/.attn/attn.sock`, speaks the protocol (or a thin version of it). Simpler routing, but two-source-of-truth for pi state.
+2. **Extension → host plugin process.** Plugin exposes a local socket/port; extension writes to that; plugin relays to attn. Cleaner — plugin is single source of truth for pi state. Adds one hop.
+
+Recommendation in the conversation leaned toward option 2 but not confirmed.
+
+**Deliverable:** pi sessions transition through `launching → working → idle` based on real pi lifecycle events.
+
+### Phase 2b — Resume-by-id in place
+
+Once `session.report_metadata` stores `pi_session_file` in attn's `agent_metadata` column, plugin can resolve incoming resume IDs to paths. Two-layer resolution:
+
+1. Store lookup via the actor-role `session.get_metadata { session_id }` call.
+2. Filesystem glob fallback — `~/.pi/agent/sessions/**/*_<partial-uuid>*.jsonl` if the store doesn't have the link (first time attn is asked to resume a session it didn't originally own).
+
+### Phase 3 — Classifier
+
+Plugin receives `agent_end` event. Extracts last assistant text via `ctx.sessionManager.getBranch()` in the extension and forwards to the plugin process. Shells out to `pi -p --no-tools --no-extensions --no-session --mode text --model <hint.model> '<classifier prompt>'` with Codex's classifier prompt verbatim (per old plan §Phase 3).
+
+**Open question — who owns the classifier call?**
+
+- **Plugin owns it.** Plugin does the `pi -p` subprocess itself, reports `session.report_stop { verdict: "idle" | "waiting_input" }` directly. Attn's existing classifier path isn't involved for pi. Cleaner for polyglot plugins.
+- **Daemon owns it.** Plugin reports `session.report_stop { text, classifier_hint: { provider, model } }`, daemon runs the subprocess. Unified orchestration, but requires teaching the daemon about every plugin's classifier runtime.
+
+The old plan picked the second for in-tree uniformity. In the plugin world the first is probably cleaner — **plugins are polyglot, each can own its classifier.** But a daemon-owned path is still useful for observer/actor plugins that want to trigger classification on someone else's stop. Both might be worth keeping; default to plugin-owned, optional daemon-owned fallback.
+
+### Phase 4 — Polish
+
+- Settings/config surfacing in the frontend: agent availability, executable override. Most scaffolding already exists from the pi stub currently in `internal/agent/pi.go` — verify it still works when the driver is external.
+- CHANGELOG entries in both attn and attn-pi.
+- README with "install and try" (likely just `attn plugin install https://github.com/<owner>/attn-pi` once the plugin system lands).
+- attn-pi publishes a tagged release.
+
+## Non-goals
+
+Same as the old plan, restated:
+
+- `pending_approval` state — pi has no native approval prompt.
+- Yolo mode — nothing to gate.
+- Permission-gate hook / destructive-write interception.
+- Transcript watcher — the extension is the real-time source.
+- PTY state detector — fail to `unknown` when extension fails to load.
+- Global install of the extension to `~/.pi/agent/extensions/` — staged per-plugin only.
+
+## Open questions
+
+1. **Extension ↔ plugin ↔ attn routing** (Phase 2) — does the pi extension talk directly to attn's socket, or relay through the host plugin process? Leaning toward relay.
+2. **Classifier ownership** (Phase 3) — plugin-owned vs daemon-owned vs both.
+3. **Resume-by-id lift** — ship Phase 2b together with Phase 2 or as follow-up.
+4. **Repo name** — `attn-pi`? `attn-plugin-pi`? First-party or explicitly third-party-shaped?
+5. **Dev-mode-only for initial iteration?** `attn plugin install` CLI might land after pi's Phase 1 is working in dev mode. Lower risk to iterate pi against `attn plugin dev --path ./attn-pi` first, then add the installer when pi's shape stabilizes.
+6. **Raw protocol ergonomics pressure-test** — since pi is the SDK-extraction source, its code should be honest about what's repetitive. Don't paper over protocol awkwardness; that's the signal for where the SDK earns its keep.
+
+## References
+
+- **Old pi plan (behavioral reference):** `docs/plans/2026-04-07-pi-integration.md` — SUPERSEDED but still authoritative for pi-specific behavior.
+- **Plugin system plan:** `docs/plans/2026-04-16-plugin-system.md`.
+- **Pi extension API docs:** https://github.com/badlogic/pi-mono
+- **Pi sessions directory:** `~/.pi/agent/sessions/`

--- a/docs/plans/2026-04-16-plugin-system.md
+++ b/docs/plans/2026-04-16-plugin-system.md
@@ -1,0 +1,218 @@
+# Attn Plugin System
+
+**Status**: DRAFT — design conversation in progress, not ready to implement. Many decisions are proposals from the current conversation that have not been explicitly confirmed; see §Open Questions.
+**Date**: 2026-04-16
+**Owner**: victor
+
+## Summary
+
+Replace the current pattern of integrating coding agents via in-tree Go drivers (`internal/agent/claude.go`, `codex.go`, `copilot.go`, and the previously proposed `pi.go`) with an out-of-process plugin system.
+
+A third party can write a plugin in TypeScript (Bun runtime), point attn at it via `attn plugin install <git-url>`, and their agent works end-to-end — state reporting, classification, resume/fork, session metadata — without touching attn's Go code.
+
+### Goals
+
+1. **Third-party contribution without forking.** Real unfulfilled demand for gemini-cli, opencode, and others the solo maintainer has no intent to ship in-tree.
+2. **One extension mechanism.** Same system eventually serves: AI assistants that help operate attn, attn-as-agent experiments, external dashboards, user automation scripts. Explicitly avoid building a second mechanism later.
+3. **Spark experimentation.** Writing a plugin should feel like a Saturday afternoon hack, not infrastructure work. "From `git init` to my plugin reacting to attn events in five minutes, in whatever language I felt like using."
+
+### Non-goals for V1
+
+Each earns its own design if pursued later:
+
+- Custom UI extensions
+- In-process scripting runtime (Lua, JS, Yaegi, WASM — all rejected for this phase)
+- Sandboxing / plugin signing / vetting
+- Auto-update
+- Cross-daemon plugin composition (plugins are daemon-local in V1)
+- Attn-as-agent itself (the API enables it; shipping it is separate)
+
+## Design conversation — how we got here
+
+The design evolved across a multi-turn conversation on 2026-04-16. Recording the iteration so the reasoning survives:
+
+1. **Started with declarative-manifest pitch** (YAML describing arg mapping, staging rules, classifier command). Rejected: state reporting is the core value of attn and cannot be expressed in YAML. Every existing integration (claude hooks, pi extension, codex/copilot transcript watchers) invests seriously in real code for this layer.
+2. **Subprocess with shell companion files.** Similar rejection — the split between declarative manifest and arbitrary companion scripts is awkward, and plugin authors end up needing real logic for ID resolution, state machine edge cases, freshness protection, etc.
+3. **In-process options considered**:
+   - Go `plugin` package: broken on Windows, version-lockstep fragility on macOS/Linux, no unload, plugin panic crashes daemon, HashiCorp abandoned the approach years ago for these reasons. Rejected.
+   - Embedded scripting (goja / gopher-lua / starlark-go / Yaegi): for a solo maintainer, "own a runtime + host API forever" is a larger long-term load than "own a JSON schema." Every internal refactor risks breaking plugins depending on exposed Go types. Plugin crashes can take the daemon down without aggressive `recover()` discipline. Rejected.
+   - WASM: language-agnostic but painful ABI for the state-reporting event volume; you still own the host API problem. Rejected.
+4. **Minimum viable ("normalize schema + publish protocol + docs, no installer").** Rejected because the user wants a product that sparks creativity and grows an ecosystem, not infrastructure-for-future-infrastructure.
+
+**Landed:** subprocess plugins in TypeScript (Bun runtime), JSON-RPC 2.0 over the existing unix socket, long-running connection per plugin, one mechanism for drivers / observers / actors, real CLI and dev mode.
+
+## Locked decisions
+
+These have been explicitly confirmed in conversation:
+
+- **Subprocess, not in-process.** Plugins run as their own processes. Crash isolation, language freedom, no runtime to maintain.
+- **One mechanism covers agent drivers AND future non-driver plugins.** Observer/actor roles share the same protocol. No second system for attn-as-agent, assistants, dashboards, etc.
+- **TypeScript with Bun as the canonical runtime.**
+- **Pi is the first plugin, not an in-tree driver.** See companion plan `2026-04-16-pi-plugin.md`.
+- **Trust model: user-installed = user-trusted.** Installing a plugin is equivalent to `curl | bash` from that repo. No sandboxing, no signing, no confirmation prompts, no catalog curation. Document clearly in the plugin-authoring README and move on.
+- **No auth.** Unix socket filesystem permissions gate access. Consistent with existing frontend↔daemon and daemon↔daemon trust model in attn today.
+- **Claude, codex, copilot stay in-tree.** No forcing function to migrate. Long-term they could become plugins but that's zero-pressure.
+- **"Great product" target, not minimal infra.** Single maintainer, but the brief is build-it-well, not build-it-small.
+
+## Open questions
+
+These were proposed in conversation but not explicitly confirmed:
+
+1. **Bun-only vs Bun-preferred SDK.** Proposed: Bun-only. Simpler, cleaner, bets on Bun. Alternative: Bun-preferred with Node fallback.
+2. **Plugin distribution format.** Proposed: plugins ship TypeScript source + `package.json`, `attn plugin install` runs `bun install`, Bun is a prereq on the user's machine. Alternative: plugins ship `bun build --compile` binaries, no runtime dependency.
+3. **Plugin lifecycle.** Proposed: attn spawns installed plugins at daemon startup and reconciles on plugin-dir change. User-managed plugins (dev mode, ad-hoc scripts) spawn themselves and connect. One-per-plugin vs one-per-session not fully decided.
+4. **Remote daemons.** Proposed: plugins are daemon-local. Each daemon has its own plugin set. Install per host (SSH to remote, run `attn plugin install` there). Cross-daemon actor/observer deferred — likely exposes same JSON-RPC over the hub's existing WebSocket later. User raised this as an open question worth capturing; design sketched but not confirmed.
+5. **SDK shape and timing.** User pushed back on designing SDK top-down. **Revised approach: pi plugin is written against raw JSON-RPC first. SDK emerges from patterns pi actually needed, extracted after pi works. No SDK in V1.** The protocol must be ergonomic enough to consume without a wrapper.
+6. **Manifest format.** Probably TOML — minimal, human-readable, Bun ecosystem-neutral. Alternatives: JSON, YAML. Not confirmed.
+7. **Install sources.** `attn plugin install <git-url>` as the headline, `--path <dir>` for local development. Not confirmed.
+8. **API versioning discipline.** Proposed: strict `attn_api_version: 1` refuses to load on mismatch. Additive protocol changes don't bump version. Not confirmed.
+9. **Socket coexistence.** Existing one-message-per-connection hook protocol (claude hooks, whatever remains of the old pi plan's pattern) must keep working. Proposed: detect JSON-RPC handshake by first-message shape and switch the connection's mode. Not confirmed.
+10. **JSON-RPC framing.** Proposed: newline-delimited JSON. Alternative: LSP-style Content-Length headers. Unix socket + JSON makes newline-delimited the simpler choice.
+
+## Architecture overview
+
+```
+┌─────────────────┐          ┌────────────────────────────┐
+│  attn daemon    │          │  plugin (Bun process)      │
+│                 │          │                            │
+│  ~/.attn/       │◄─────────┤  long-running JSON-RPC     │
+│  attn.sock      │ unix     │  connection                │
+│                 │ socket   │                            │
+│                 │          │  ┌──────────────────────┐  │
+│                 │          │  │ user-facing agent    │  │
+│                 │          │  │ (pi, gemini, ...)    │  │
+│                 │          │  └──────────────────────┘  │
+│                 │          │   spawned by plugin via    │
+│                 │          │   driver.spawn response    │
+│                 │          │   (attn puts it in a PTY)  │
+└─────────────────┘          └────────────────────────────┘
+```
+
+### Plugin lifecycle — driver role
+
+1. attn spawns the plugin binary at daemon startup (or user runs it in dev mode).
+2. Plugin connects to `~/.attn/attn.sock`, sends `hello { name, version, attn_api_version, roles }`.
+3. attn replies with accepted capabilities. If `driver` is in roles, plugin sends `driver.register { agent, capabilities }`.
+4. When user runs `attn -s foo` with agent = the registered name, attn calls `driver.spawn { session_id, cwd, agent_args, resume, fork, yolo }` on the plugin.
+5. Plugin responds `{ argv, env, cwd }`. attn spawns that command in a PTY under the session. **Attn owns the PTY. Plugin owns agent-specific semantics.**
+6. Plugin stages companion files (extensions, hooks) however it likes. Plugin monitors the agent however it likes.
+7. Plugin reports state via `session.report_state`, `session.report_stop`, `session.report_metadata`.
+8. Plugin exits when attn shuts down or its own lifecycle ends.
+
+### Observer / actor roles
+
+An observer plugin subscribes to events attn already broadcasts (state changes, stops, reviews, PR updates) — notification-only. An actor plugin invokes the methods the frontend invokes (`session.launch`, `session.send_input`, `pr.action`). A plugin can combine roles.
+
+The attn-as-agent / assistant use case is `roles: ["observer", "actor"]` — no driver surface, just observe and act. Not in V1 scope but the API must not preclude it.
+
+## V1 scope
+
+### 1. Schema normalization (prerequisite)
+
+Remove agent-specific fields from core schema and protocol. Replaces the pi-specific additions from the superseded pi plan.
+
+- Generic `agent_metadata TEXT` column on `sessions` (JSON blob, opaque to core) replacing any proposed `pi_session_file` / `pi_session_id` columns.
+- Rename any pi-specific protocol commands → `agent_session_linked { agent, metadata }`.
+- Lock in `classifier_hint` on `stop` as the standard (already generalizable).
+- Store: `SetAgentMetadata(sessionID, jsonBlob)` / `GetAgentMetadata(sessionID)`.
+
+### 2. Control API over unix socket
+
+Extend the daemon's existing unix socket handler to recognize a JSON-RPC 2.0 handshake and switch the connection into long-running RPC mode. Legacy one-message-per-connection hook traffic keeps working.
+
+**Handshake:**
+```json
+→ {"jsonrpc":"2.0","id":1,"method":"hello","params":{
+    "name":"pi-driver","version":"0.1.0",
+    "attn_api_version":1,"roles":["driver"]}}
+← {"jsonrpc":"2.0","id":1,"result":{"ok":true}}
+```
+
+**Driver-role methods (minimum):**
+
+| Method                        | Direction       | Purpose                                                                 |
+|-------------------------------|-----------------|-------------------------------------------------------------------------|
+| `driver.register`             | plugin → attn   | Declare `{ agent, capabilities }`                                       |
+| `driver.spawn`                | attn → plugin   | Request `{ argv, env, cwd }` for a new session                          |
+| `driver.resume`               | attn → plugin   | Same, for resume                                                         |
+| `driver.fork`                 | attn → plugin   | Same, for fork                                                           |
+| `session.report_state`        | plugin → attn   | `{ session_id, state }`                                                  |
+| `session.report_stop`         | plugin → attn   | `{ session_id, text?, classifier_hint?, verdict? }`                      |
+| `session.report_metadata`     | plugin → attn   | `{ session_id, metadata }` (generic, replaces `pi_session_linked`)       |
+| `pty.request_spawn`           | plugin → attn   | (Optional) ask attn to spawn additional processes under the session    |
+
+**Observer-role:** subscriptions via `subscribe { events }`, attn pushes notifications matching the frontend's existing event set.
+
+**Actor-role:** method access to `session.launch`, `session.send_input`, `pr.action`, etc. — same surface the frontend already uses.
+
+### 3. Plugin CLI + installer + dev mode
+
+Commands:
+
+- `attn plugin install <git-url>` — clone to `~/.attn/plugins/<name>/`, validate manifest, run `bun install`, register, spawn.
+- `attn plugin install --path <dir>` — same, from local directory (development).
+- `attn plugin list` — installed plugins, status, roles.
+- `attn plugin remove <name>` — uninstall + stop.
+- `attn plugin update <name>` — `git pull && bun install`, restart.
+- `attn plugin dev --path <dir>` — run attn with plugin spawned foreground, auto-restart on source change, stderr piped to terminal.
+- `attn plugin inspect <name>` — print live JSON-RPC traffic for a plugin.
+
+Manifest (`attn-plugin.toml` at repo root):
+```toml
+name = "pi-driver"
+version = "0.1.0"
+attn_api_version = 1
+description = "Pi coding agent driver for attn"
+
+[plugin]
+entrypoint = "src/index.ts"
+# bun runs this with: bun run <entrypoint>
+```
+
+## Phases
+
+Rough phasing — to refine:
+
+### Phase 0 — Schema normalization
+
+Prereq. Standalone PR. No user-visible behavior change.
+
+### Phase 1 — Protocol + socket handler
+
+Extend daemon socket handler to accept JSON-RPC handshake. Driver-role operations end-to-end against a throwaway test plugin (e.g. a plugin that registers as a fake agent and reports `working → idle` on a timer). Document the wire protocol.
+
+### Phase 2 — CLI + installer + dev mode
+
+Ship the `attn plugin` command family. Manifest parser. Plugin spawn/reconcile loop in the daemon.
+
+### Phase 3 — Pi as the first real plugin
+
+See companion plan `2026-04-16-pi-plugin.md`. Pi forces any protocol gaps to surface.
+
+### Phase 4 — Observer/actor role completion
+
+The driver role is the tightest V1 requirement. Observer/actor were designed alongside but may ship slightly later. No second mechanism, just fleshing out the same protocol.
+
+### Phase 5 — Documentation + templates
+
+"Write your first plugin" tutorial. `attn plugin new driver <name>` scaffolding. Example plugins repo. README for external plugin authors.
+
+## Deferred — post-V1
+
+In priority order of what might come next:
+
+- **SDK extraction.** `@attn/plugin` on npm, extracted from pi's patterns. Typed connection helper, reconnect logic, typed event handlers. Deferred until pi ships and patterns stabilize.
+- **Cross-daemon control API.** Expose the same JSON-RPC surface over the hub's existing WebSocket at `:9849` so actor/observer plugins can span daemons. Useful for attn-as-agent and dashboards.
+- **Custom UI extensions.** Separate design.
+- **Plugin install over SSH / hub** — `attn --endpoint <server> plugin install <url>`. Nice-to-have, requires proxying through the hub.
+- **Claude / codex / copilot migration** to plugins. Zero pressure; only if there's a reason.
+
+## References
+
+- **Superseded pi plan:** `docs/plans/2026-04-07-pi-integration.md` — behavioral design still load-bearing for pi plugin.
+- **Pi plugin plan:** `docs/plans/2026-04-16-pi-plugin.md`.
+- **Existing agent driver interface:** `internal/agent/driver.go`.
+- **Existing socket handler:** `internal/daemon/daemon.go` (`handleConnection`).
+- **Hub module (cross-daemon context):** `internal/hub/`.
+- **Bun:** https://bun.sh — runtime, bundler, test runner. Direct TS execution, `Bun.connect()` for unix sockets, `bun build --compile` for single-file binaries.
+- **JSON-RPC 2.0 spec:** https://www.jsonrpc.org/specification


### PR DESCRIPTION
## Summary
- Adds the draft plugin-system design (`docs/plans/2026-04-16-plugin-system.md`) — subprocess plugins, TypeScript/Bun, JSON-RPC over the unix socket.
- Adds the pi-as-first-plugin plan (`docs/plans/2026-04-16-pi-plugin.md`) — rebuilds pi integration against the plugin protocol instead of as an in-tree Go driver.
- Marks the original `docs/plans/2026-04-07-pi-integration.md` as SUPERSEDED but preserves its behavioral design, which the new pi-plugin plan references.

## Test plan
- [x] Docs-only change; pre-commit hook passed locally (Go tests, frontend tests, Rust tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)