### PR TITLE
fix: restore cmd-click link open in terminal with same-URL dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
-## [2026-04-17]
-
-### Fixed
-- **Remote Endpoint Zombie Leak**: Failed WebSocket dials to remote endpoints over SSH no longer leave `<defunct>` `ssh` children behind. On macOS a slow or flapping remote could accumulate thousands of zombies over a day and exhaust `kern.maxprocperuid`, producing `fork: Resource temporarily unavailable` across the whole user session.
-
 ## [2026-04-18]
 
 ### Fixed
 - **Terminal Link Clicks**: Cmd/Ctrl-clicking a URL in the terminal opens it once, whether the TUI renders the URL as an OSC 8 hyperlink or as plain text. Fixes a regression where cmd-click stopped opening plain-text URLs, and where URLs that matched both renderings could open twice.
+
+## [2026-04-17]
+
+### Fixed
+- **Remote Endpoint Zombie Leak**: Failed WebSocket dials to remote endpoints over SSH no longer leave `<defunct>` `ssh` children behind. On macOS a slow or flapping remote could accumulate thousands of zombies over a day and exhaust `kern.maxprocperuid`, producing `fork: Resource temporarily unavailable` across the whole user session.
 
 ## [2026-04-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-04-18]
 
 ### Fixed
-- **Terminal Link Clicks**: Cmd/Ctrl-clicking a URL in the terminal opens it again, whether the TUI renders it as an OSC 8 hyperlink or as plain text. Both xterm surfaces route through a shared opener that de-duplicates same-URL opens within 1s, so links that render in both surfaces still open exactly once.
+- **Terminal Link Clicks**: Cmd/Ctrl-clicking a URL in the terminal opens it once, whether the TUI renders the URL as an OSC 8 hyperlink or as plain text. Fixes a regression where cmd-click stopped opening plain-text URLs, and where URLs that matched both renderings could open twice.
 
 ## [2026-04-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Fixed
 - **Remote Endpoint Zombie Leak**: Failed WebSocket dials to remote endpoints over SSH no longer leave `<defunct>` `ssh` children behind. On macOS a slow or flapping remote could accumulate thousands of zombies over a day and exhaust `kern.maxprocperuid`, producing `fork: Resource temporarily unavailable` across the whole user session.
 
+## [2026-04-18]
+
+### Fixed
+- **Terminal Link Clicks**: Cmd/Ctrl-clicking a URL in the terminal opens it again, whether the TUI renders it as an OSC 8 hyperlink or as plain text. Both xterm surfaces route through a shared opener that de-duplicates same-URL opens within 1s, so links that render in both surfaces still open exactly once.
+
 ## [2026-04-16]
 
 ### Added

--- a/app/src/components/Terminal.tsx
+++ b/app/src/components/Terminal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useImperativeHandle, forwardRef, useCallback, useSta
 import { Terminal as XTerm } from '@xterm/xterm';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import '@xterm/xterm/css/xterm.css';
 import './Terminal.css';
 import { isSuspiciousTerminalSize, isTerminalDebugEnabled, recordResizeEvent, formatResizeLog, type ResizeDiagnostics } from '../utils/terminalDebug';
@@ -78,10 +79,22 @@ function createEmptyStartupSnapshot(): TerminalPerfStartupSnapshot {
   };
 }
 
-// Link opening is handled by the Tauri opener plugin at the webview level.
-// Our xterm handlers are no-ops — they exist only to suppress xterm's default
-// confirm() dialog for OSC 8 hyperlinks and to enable WebLinksAddon decorations
-// (underline + pointer cursor on hover).
+// Open a URL externally, de-duplicating same-URL opens inside a 1s window.
+// Both xterm surfaces (OSC 8 linkHandler and WebLinksAddon) route through here,
+// so if they both fire for the same click the second call is a no-op.
+const LINK_DEDUP_WINDOW_MS = 1000;
+let lastOpenedUri: { uri: string; at: number } | null = null;
+
+async function openExternalUri(uri: string): Promise<void> {
+  const now = Date.now();
+  if (lastOpenedUri?.uri === uri && now - lastOpenedUri.at < LINK_DEDUP_WINDOW_MS) return;
+  lastOpenedUri = { uri, at: now };
+  try {
+    await openUrl(uri);
+  } catch (err) {
+    console.error('[Terminal] Failed to open external URL:', uri, err);
+  }
+}
 
 export interface TerminalHandle {
   terminal: XTerm | null;
@@ -541,9 +554,14 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
           showTopBorder: true,
         },
         theme: getTerminalTheme(resolvedTheme),
-        // Suppress xterm's default confirm() dialog for OSC 8 hyperlinks.
-        // Actual opening is handled at the webview level.
-        linkHandler: { activate: () => {} },
+        // OSC 8 hyperlinks: Cmd/Ctrl+click to open; suppress xterm's default confirm() dialog.
+        linkHandler: {
+          activate: (event, text) => {
+            if (event.metaKey || event.ctrlKey) {
+              void openExternalUri(text);
+            }
+          },
+        },
       });
       appliedFontSizeRef.current = initialFontSize;
       startupSnapshotRef.current = {
@@ -562,9 +580,12 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
         skippedInitialFontEffect: false,
       };
 
-      // WebLinksAddon decorates URLs (underline + pointer on hover).
-      // No-op handler — actual opening is handled at the webview level.
-      term.loadAddon(new WebLinksAddon(() => {}));
+      // Plain-text URLs: Cmd/Ctrl+click to open (underline + pointer on hover).
+      term.loadAddon(new WebLinksAddon((event, uri) => {
+        if (event.metaKey || event.ctrlKey) {
+          void openExternalUri(uri);
+        }
+      }));
 
       // Enable Unicode 11 for correct emoji/CJK width calculation
       term.loadAddon(new Unicode11Addon());

--- a/app/src/components/Terminal.tsx
+++ b/app/src/components/Terminal.tsx
@@ -79,22 +79,10 @@ function createEmptyStartupSnapshot(): TerminalPerfStartupSnapshot {
   };
 }
 
-// Open a URL externally, de-duplicating same-URL opens inside a 1s window.
-// Both xterm surfaces (OSC 8 linkHandler and WebLinksAddon) route through here,
-// so if they both fire for the same click the second call is a no-op.
+// Window within which a same-URL open is considered a duplicate of the prior
+// click (OSC 8 linkHandler and WebLinksAddon can both fire on a single click
+// when a plain-text URL is also wrapped in an OSC 8 hyperlink).
 const LINK_DEDUP_WINDOW_MS = 1000;
-let lastOpenedUri: { uri: string; at: number } | null = null;
-
-async function openExternalUri(uri: string): Promise<void> {
-  const now = Date.now();
-  if (lastOpenedUri?.uri === uri && now - lastOpenedUri.at < LINK_DEDUP_WINDOW_MS) return;
-  lastOpenedUri = { uri, at: now };
-  try {
-    await openUrl(uri);
-  } catch (err) {
-    console.error('[Terminal] Failed to open external URL:', uri, err);
-  }
-}
 
 export interface TerminalHandle {
   terminal: XTerm | null;
@@ -136,6 +124,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
     const perfRegistryIdRef = useRef(`terminal-${Math.random().toString(16).slice(2)}`);
     const readyFiredRef = useRef(false);
     const appliedFontSizeRef = useRef<number | null>(null);
+    const lastLinkOpenRef = useRef<{ uri: string; at: number } | null>(null);
     const startupSnapshotRef = useRef<TerminalPerfStartupSnapshot>(createEmptyStartupSnapshot());
     const lastResizeSnapshotRef = useRef<{
       at: number;
@@ -521,6 +510,18 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
 
     useEffect(() => {
       if (!containerRef.current) return;
+
+      const openExternalUri = async (uri: string): Promise<void> => {
+        const now = Date.now();
+        const last = lastLinkOpenRef.current;
+        if (last?.uri === uri && now - last.at < LINK_DEDUP_WINDOW_MS) return;
+        lastLinkOpenRef.current = { uri, at: now };
+        try {
+          await openUrl(uri);
+        } catch (err) {
+          console.error('[Terminal] Failed to open external URL:', uri, err);
+        }
+      };
 
       // VS Code: Pre-calculate initial dimensions before creating terminal
       // This prevents xterm from initializing with default 80x24 and then resizing

--- a/app/src/components/Terminal.tsx
+++ b/app/src/components/Terminal.tsx
@@ -79,10 +79,22 @@ function createEmptyStartupSnapshot(): TerminalPerfStartupSnapshot {
   };
 }
 
-// Window within which a same-URL open is considered a duplicate of the prior
-// click (OSC 8 linkHandler and WebLinksAddon can both fire on a single click
-// when a plain-text URL is also wrapped in an OSC 8 hyperlink).
+// Open a URL externally, de-duplicating same-URL opens inside a 1s window.
+// Both xterm surfaces (OSC 8 linkHandler and WebLinksAddon) route through here,
+// so if they both fire for the same click the second call is a no-op.
 const LINK_DEDUP_WINDOW_MS = 1000;
+let lastOpenedUri: { uri: string; at: number } | null = null;
+
+async function openExternalUri(uri: string): Promise<void> {
+  const now = Date.now();
+  if (lastOpenedUri?.uri === uri && now - lastOpenedUri.at < LINK_DEDUP_WINDOW_MS) return;
+  lastOpenedUri = { uri, at: now };
+  try {
+    await openUrl(uri);
+  } catch (err) {
+    console.error('[Terminal] Failed to open external URL:', uri, err);
+  }
+}
 
 export interface TerminalHandle {
   terminal: XTerm | null;
@@ -124,7 +136,6 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
     const perfRegistryIdRef = useRef(`terminal-${Math.random().toString(16).slice(2)}`);
     const readyFiredRef = useRef(false);
     const appliedFontSizeRef = useRef<number | null>(null);
-    const lastLinkOpenRef = useRef<{ uri: string; at: number } | null>(null);
     const startupSnapshotRef = useRef<TerminalPerfStartupSnapshot>(createEmptyStartupSnapshot());
     const lastResizeSnapshotRef = useRef<{
       at: number;
@@ -510,18 +521,6 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
 
     useEffect(() => {
       if (!containerRef.current) return;
-
-      const openExternalUri = async (uri: string): Promise<void> => {
-        const now = Date.now();
-        const last = lastLinkOpenRef.current;
-        if (last?.uri === uri && now - last.at < LINK_DEDUP_WINDOW_MS) return;
-        lastLinkOpenRef.current = { uri, at: now };
-        try {
-          await openUrl(uri);
-        } catch (err) {
-          console.error('[Terminal] Failed to open external URL:', uri, err);
-        }
-      };
 
       // VS Code: Pre-calculate initial dimensions before creating terminal
       // This prevents xterm from initializing with default 80x24 and then resizing


### PR DESCRIPTION
## Summary
- Re-enable cmd/ctrl-click to open URLs in the terminal for both OSC 8 hyperlinks and plain-text URLs.
- Route both xterm surfaces (OSC 8 `linkHandler` and `WebLinksAddon`) through a shared opener; dedupe same-URL opens inside a 1s window so a click that matches both surfaces opens exactly once.
- Update `CHANGELOG.md`.

## Why
A previous fix suppressed xterm's default link activation to avoid double-opens, which broke cmd-click entirely (the "Tauri opener at the webview level" referenced in the old comment was not actually intercepting anything). This restores the behavior while keeping the double-open bug fixed via dedup in a single shared opener.

## Test plan
- [x] `pnpm tsc --noEmit` — no errors
- [x] `pnpm test -- --run` — all tests pass
- [x] Manual: `make install`, cmd-click OSC 8 URL in Claude Code tool result → opens once
- [x] Manual: cmd-click plain-text URL in Claude Code main output → opens once
- [x] Manual: plain click (no cmd) does not open