### PR TITLE
release: v0.9.2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.9.1"
+version = "0.9.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "attn",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "identifier": "com.attn.manager",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
Patch release — restores cmd/ctrl-click to open URLs in the terminal (#147).

## Changes
- Cmd/Ctrl-clicking a URL in the terminal opens it once, whether the TUI renders it as an OSC 8 hyperlink or as plain text. Fixes a regression where cmd-click stopped opening plain-text URLs, and where URLs that matched both renderings could open twice.

## Version bumps
- `app/package.json` 0.9.1 → 0.9.2
- `app/src-tauri/tauri.conf.json` 0.9.1 → 0.9.2
- `app/src-tauri/Cargo.toml` / `Cargo.lock` 0.9.1 → 0.9.2