### PR TITLE
release: v0.9.3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.9.2"
+version = "0.9.3"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "attn",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "identifier": "com.attn.manager",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
Patch release bundling the diff-panel polish landed in #149 plus the previously-merged #148 version bump.

## Changes (since v0.9.1 — the most recent tagged release)
- **Diff panel font scaling, focus on open, `]` advance, `e` toggle, controlled file selection, and new-folder file listing** (#149).
- **Terminal link cmd-click dedup and plain-text URL fix** (#147, originally rolled into v0.9.2 but never tagged).

## Version bumps
- `app/package.json` 0.9.2 → 0.9.3
- `app/src-tauri/tauri.conf.json` 0.9.2 → 0.9.3
- `app/src-tauri/Cargo.toml` / `Cargo.lock` 0.9.2 → 0.9.3