### PR TITLE
release: v0.9.4

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.9.3",
+  "version": "0.9.4",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.9.3"
+version = "0.9.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "attn",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "identifier": "com.attn.manager",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
Patch release bundling the OSC 52 clipboard-forwarding work from #151.

Changes since v0.9.3:
- `feat: forward OSC 52 clipboard writes from remote terminals` — attn now honors the OSC 52 escape sequence, so Claude Code (and other remote TUIs) can copy text to the Mac clipboard over SSH without xclip or an X server.
- `fix: decode OSC 52 payload as UTF-8` — base64 payloads are decoded as UTF-8 so non-ASCII characters (accents, CJK, emoji) come through correctly.
- Copy-on-select and Cmd+Shift+C now route through `tauri-plugin-clipboard-manager`, fixing a silent WKWebView user-activation rejection.
- README documents Option-drag for bypassing mouse tracking in agent sessions.