### PR TITLE
fix: restore previously active session when the current one is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-04-22]
+
+### Fixed
+- **Closing A Session Restores The Previous Selection**: Closing the active session used to leave the UI with nothing selected because the daemon sync cleared `activeSessionId` as soon as the session disappeared and the local removal path fell back to an arbitrary first-in-list. The store now tracks recently-active session IDs as an MRU history; when the active one goes away (either via explicit close or a daemon-driven removal such as a remote session dropping), the UI re-selects the most recent still-existing entry. Ghost IDs are pruned on every removal and filtered again when choosing a fallback, so sessions that were closed without ever being focused can't resurrect themselves.
+
+---
+
 ## [2026-04-21]
 
 ### Fixed

--- a/app/src/store/sessions.ts
+++ b/app/src/store/sessions.ts
@@ -48,6 +48,9 @@ interface LauncherConfig {
 interface SessionStore {
   sessions: Session[];
   activeSessionId: string | null;
+  // Previously-active session IDs, most recent first. Used to restore
+  // selection when the active session disappears.
+  recentSessionIds: string[];
   connected: boolean;
   launcherConfig: LauncherConfig;
 
@@ -88,9 +91,31 @@ declare global {
   }
 }
 
+function pushRecent(recent: string[], id: string | null): string[] {
+  if (!id) return recent;
+  const filtered = recent.filter((entry) => entry !== id);
+  filtered.unshift(id);
+  return filtered;
+}
+
+function pickFallbackActive(
+  removedId: string,
+  remainingSessions: Session[],
+  recent: string[],
+): string | null {
+  const existing = new Set(remainingSessions.map((entry) => entry.id));
+  for (const candidate of recent) {
+    if (candidate !== removedId && existing.has(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 export const useSessionStore = create<SessionStore>((set, get) => ({
   sessions: [],
   activeSessionId: null,
+  recentSessionIds: [],
   connected: false,
   launcherConfig: {
     executables: {},
@@ -142,23 +167,29 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     set((state) => ({
       sessions: [...state.sessions, session],
       activeSessionId: id,
+      recentSessionIds:
+        state.activeSessionId && state.activeSessionId !== id
+          ? pushRecent(state.recentSessionIds, state.activeSessionId)
+          : state.recentSessionIds.filter((entry) => entry !== id),
     }));
 
     return id;
   },
 
   removeSessionLocalState: (id: string) => {
-    const { sessions, activeSessionId } = get();
+    const { sessions, activeSessionId, recentSessionIds } = get();
     const newSessions = sessions.filter((s) => s.id !== id);
+    const newRecent = recentSessionIds.filter((entry) => entry !== id);
     let newActiveId = activeSessionId;
 
     if (activeSessionId === id) {
-      newActiveId = newSessions.length > 0 ? newSessions[0].id : null;
+      newActiveId = pickFallbackActive(id, newSessions, recentSessionIds);
     }
 
     set({
       sessions: newSessions,
       activeSessionId: newActiveId,
+      recentSessionIds: newRecent,
     });
   },
 
@@ -175,7 +206,16 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   },
 
   setActiveSession: (id: string | null) => {
-    set({ activeSessionId: id });
+    set((state) => {
+      if (state.activeSessionId === id) {
+        return state;
+      }
+      const nextRecent = pushRecent(state.recentSessionIds, state.activeSessionId);
+      return {
+        activeSessionId: id,
+        recentSessionIds: id ? nextRecent.filter((entry) => entry !== id) : nextRecent,
+      };
+    });
   },
 
   takeSessionSpawnArgs: (id: string, cols: number, rows: number) => {
@@ -322,14 +362,23 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
         } satisfies Session;
       });
 
+      const syncedIds = new Set(syncedSessions.map((session) => session.id));
+      const prunedRecent = state.recentSessionIds.filter((entry) => syncedIds.has(entry));
+
       let nextActiveSessionID = state.activeSessionId;
-      if (nextActiveSessionID && !syncedSessions.some((session) => session.id === nextActiveSessionID)) {
-        nextActiveSessionID = null;
+      let nextRecent = prunedRecent;
+      if (nextActiveSessionID && !syncedIds.has(nextActiveSessionID)) {
+        const fallback = pickFallbackActive(nextActiveSessionID, syncedSessions, prunedRecent);
+        nextActiveSessionID = fallback;
+        nextRecent = fallback
+          ? prunedRecent.filter((entry) => entry !== fallback)
+          : prunedRecent;
       }
 
       return {
         sessions: syncedSessions,
         activeSessionId: nextActiveSessionID,
+        recentSessionIds: nextRecent,
       };
     });
   },


### PR DESCRIPTION
## Summary
- Closing the active session left the UI empty — the daemon-sync path cleared `activeSessionId` the moment the session was gone, and the local removal path fell back to an arbitrary first-in-list.
- The store now maintains an MRU of recently-active session IDs. When the active session disappears (explicit close or daemon-driven removal such as a remote dropping), we re-select the most recent still-existing entry. If nothing in history is still alive, we fall back to `null` rather than a random session.
- History is pruned whenever a session is removed and filtered again when picking a fallback, so sessions that were closed without ever being focused can't come back as a ghost selection.

## Test plan
- [x] `pnpm test -- --run src/store/sessions.test.ts` (sessions store green; the one unrelated failure is `DiffDetailPanel.test.tsx`)
- [x] `make install` + manual verification: open A, open B (auto-active), close B — A is re-selected.
- [ ] Additional manual check: closing a non-active session from the sidebar does not move focus away from the currently active one.
- [ ] Manual check: a remote session disappearing while active falls back to the previously focused local session.