### PR TITLE
feat: ATTN_PROFILE + side-by-side dev install for safe attn-on-attn testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ pnpm run e2e
 - Prefer `pnpm --dir app run real-app:serial-matrix` for multiple packaged-app scenarios.
 - If you need one scenario, run exactly one packaged-app scenario at a time and wait for it to finish.
 - Rebuild first when packaged-app evidence matters, or you may be testing an older installed app.
+- The serial matrix targets the **dev** install (`~/Applications/attn-dev.app`, port 29849) by default so it never takes over the live prod app. Run `make dev` first if there's no dev install yet. To target prod explicitly, run with `ATTN_HARNESS_PROFILE=` (empty).
 
 ## Debugging And Logging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,19 @@ go test ./internal/store -run TestList
 
 Use `make install` as the default source/dev install path; it rebuilds and installs the app bundle and ensures the bundled daemon is running. Use `make install-daemon` when only daemon/runtime code changed and you want the faster sidecar-only loop.
 
+### Iterating On Attn Itself (Attn-On-Attn Testing)
+
+When changing attn code while the user has a live attn install running, **never** run `make install` or `make install-daemon` — they overwrite the live `attn.app` / restart its daemon mid-session. Use the dev sibling install instead:
+
+```bash
+make dev              # builds + installs ~/Applications/attn-dev.app, starts dev daemon on port 29849
+make install-daemon-dev  # faster: only rebuild the Go sidecar inside attn-dev.app
+```
+
+The dev install is fully isolated: its own bundle identifier (`com.attn.manager.dev`), its own data dir (`~/.attn-dev/`), its own socket, its own port. Prod is never touched. `make install` and `make install-daemon` refuse at parse time if `ATTN_PROFILE` is set in the environment — if you hit that error, you meant `make dev`.
+
+To make CLI commands (`attn`, `attn list`, etc.) target the dev daemon in your shell, run `eval "$(./attn profile-env dev)"` (bash/zsh) or `./attn profile-env --fish dev | source` (fish). Any `attn` subcommand then prints a one-line `[attn profile=dev ...]` banner so you can always see which daemon you're talking to. Unset with `eval "$(attn profile-env --unset)"`.
+
 Frontend-only shortcuts:
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-04-23]
+
+### Added
+- **Side-by-Side Dev Install For Safe Attn-On-Attn Testing**: You can now run a development copy of attn alongside your live install without either stepping on the other. `make dev` builds and installs a sibling `~/Applications/attn-dev.app` with its own bundle identifier (`com.attn.manager.dev`), data directory (`~/.attn-dev/`), socket, log, and WebSocket port (`29849`). The dev app runs its own daemon, which never touches the prod daemon's state. The prod `make install` / `make install-daemon` targets refuse at parse time if `ATTN_PROFILE` is set in your shell, so you can't accidentally reinstall the live app while iterating on dev. For CLI work, `eval "$(attn profile-env dev)"` scopes every subsequent `attn` command to the dev daemon (`attn profile-env --fish dev | source` for fish); `attn profile-env --unset` reverts. The underlying knob is `ATTN_PROFILE=<name>`, which derives all paths and ports per profile; the default profile keeps today's behavior exactly. Dial failures now tell you which profile and socket they tried, and point at the other profile's daemon if it happens to be running.
+
+---
+
 ## [2026-04-22]
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,11 @@ run: install
 install: build-app-ui-automation
 	@echo ">>> Installing PROD: $(APP_BUNDLE) (profile=default, port=9849)"
 	@mkdir -p ~/Applications
+	@# Quit a running instance first. macOS keeps the running image
+	@# via mmap, so rm -rf + cp alone would leave an old process running
+	@# out of a deleted bundle while disk has the new code. Quiet
+	@# no-op if nothing is running.
+	@osascript -e 'tell application id "com.attn.manager" to quit' 2>/dev/null || true
 	@rm -rf ~/Applications/attn.app
 	cp -r app/src-tauri/target/release/bundle/macos/attn.app ~/Applications/
 	@$(APP_BINARY) daemon ensure >/dev/null
@@ -123,6 +128,8 @@ dev: install-dev
 install-dev: build-app-dev
 	@echo ">>> Installing DEV: $(APP_BUNDLE_DEV) (profile=dev, port=29849)"
 	@mkdir -p ~/Applications
+	@# Quit a running dev instance first; same mmap reasoning as `install`.
+	@osascript -e 'tell application id "com.attn.manager.dev" to quit' 2>/dev/null || true
 	@rm -rf $(APP_BUNDLE_DEV)
 	cp -r app/src-tauri/target/release/bundle/macos/attn-dev.app ~/Applications/
 	@ATTN_PROFILE=dev $(APP_BINARY_DEV) daemon ensure >/dev/null

--- a/Makefile
+++ b/Makefile
@@ -178,9 +178,17 @@ build-app-ui-automation: build
 # Dev build. Bakes ATTN_BUILD_PROFILE=dev into the Rust binary and
 # VITE_ATTN_BUILD_PROFILE=dev + VITE_DAEMON_PORT=29849 into the frontend
 # so the dev bundle can never accidentally point at the prod daemon.
+# UI automation is enabled by default (matching `make install` / the
+# prod install path) so real-app harness scenarios work against the
+# dev bundle too. Set ATTN_DEV_UI_AUTOMATION=0 to disable.
 # Output: app/src-tauri/target/release/bundle/macos/attn-dev.app
+ATTN_DEV_UI_AUTOMATION ?= 1
 build-app-dev: build
+ifeq ($(ATTN_DEV_UI_AUTOMATION),1)
+	$(call build_tauri_app,ATTN_UI_AUTOMATION=1 VITE_UI_AUTOMATION=1 ATTN_BUILD_PROFILE=dev VITE_ATTN_BUILD_PROFILE=dev VITE_DAEMON_PORT=29849 VITE_INSTALL_CHANNEL=source VITE_ATTN_BUILD_VERSION='$(VERSION)' VITE_ATTN_SOURCE_FINGERPRINT='$(SOURCE_FINGERPRINT)' VITE_ATTN_GIT_COMMIT='$(GIT_COMMIT)' VITE_ATTN_BUILD_TIME='$(BUILD_TIME)',attn-dev,--config src-tauri/tauri.dev.conf.json)
+else
 	$(call build_tauri_app,ATTN_BUILD_PROFILE=dev VITE_ATTN_BUILD_PROFILE=dev VITE_DAEMON_PORT=29849 VITE_INSTALL_CHANNEL=source VITE_ATTN_BUILD_VERSION='$(VERSION)' VITE_ATTN_SOURCE_FINGERPRINT='$(SOURCE_FINGERPRINT)' VITE_ATTN_GIT_COMMIT='$(GIT_COMMIT)' VITE_ATTN_BUILD_TIME='$(BUILD_TIME)',attn-dev,--config src-tauri/tauri.dev.conf.json)
+endif
 
 app-screenshot:
 	cd app && node scripts/real-app-harness/capture-app-screenshot.mjs $(if $(SCREENSHOT_PATH),--path "$(SCREENSHOT_PATH)",) $(APP_SCREENSHOT_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
-.PHONY: build build-linux-amd64 build-linux-arm64 install install-daemon test test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app build-app-ui-automation app-screenshot dist release release-skip-tests
+.PHONY: build build-linux-amd64 build-linux-arm64 install install-daemon install-dev install-daemon-dev dev test test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app build-app-ui-automation build-app-dev app-screenshot dist release release-skip-tests
 
 BINARY_NAME=attn
 APP_BUNDLE=$(HOME)/Applications/attn.app
 APP_BINARY=$(APP_BUNDLE)/Contents/MacOS/attn
+# Dev sibling install. Separate bundle identifier (com.attn.manager.dev),
+# separate data dir (~/.attn-dev), separate port (29849). See
+# docs/plans or Phase 2 of the profiles feature for the full design.
+APP_BUNDLE_DEV=$(HOME)/Applications/attn-dev.app
+APP_BINARY_DEV=$(APP_BUNDLE_DEV)/Contents/MacOS/attn
 BUILD_DIR=./cmd/attn
 VERSION ?= $(shell bash ./scripts/version.sh)
 BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -62,7 +67,19 @@ test-all: test test-frontend
 
 UNAME_S := $(shell uname -s)
 
+# Installing the PROD bundle while ATTN_PROFILE is set is almost always
+# a mistake — it blows away the live install a developer is using. The
+# guard fires during Make's parse phase so we fail *before* the expensive
+# Tauri build, not after.
+GUARDED_PROD_TARGETS := install install-daemon
+ifneq (,$(filter $(GUARDED_PROD_TARGETS),$(MAKECMDGOALS)))
+ifneq (,$(ATTN_PROFILE))
+$(error ATTN_PROFILE=$(ATTN_PROFILE) is set. `make $(firstword $(MAKECMDGOALS))` targets the PROD bundle ($(APP_BUNDLE)). Did you mean `make dev`? To proceed anyway: env -u ATTN_PROFILE make $(firstword $(MAKECMDGOALS)))
+endif
+endif
+
 install: build-app-ui-automation
+	@echo ">>> Installing PROD: $(APP_BUNDLE) (profile=default, port=9849)"
 	@mkdir -p ~/Applications
 	@rm -rf ~/Applications/attn.app
 	cp -r app/src-tauri/target/release/bundle/macos/attn.app ~/Applications/
@@ -74,10 +91,42 @@ install-daemon: build
 		echo "No installed attn.app found in ~/Applications; run make install first"; \
 		exit 1; \
 	fi
+	@echo ">>> Updating PROD daemon at $(APP_BINARY)"
 	cp $(OUTPUT) $(APP_BINARY)
 	@if [ "$(UNAME_S)" = "Darwin" ]; then codesign -s - -f $(APP_BINARY); fi
 	@$(APP_BINARY) daemon ensure >/dev/null
 	@echo "Updated bundled daemon at $(APP_BINARY)"
+
+# Dev-sibling install. `make dev` is THE command for the attn-on-attn
+# inner loop: rebuild, reinstall, restart dev daemon — without ever
+# touching the prod install. Uses a separate bundle identifier
+# (com.attn.manager.dev), productName (attn-dev), data dir (~/.attn-dev),
+# and port (29849). Prod daemon and app keep running.
+#
+# Run `eval "$(attn profile-env dev)"` (or `attn profile-env --fish dev | source`)
+# in your shell if you want `attn ...` commands to target the dev daemon
+# by default.
+dev: install-dev
+
+install-dev: build-app-dev
+	@echo ">>> Installing DEV: $(APP_BUNDLE_DEV) (profile=dev, port=29849)"
+	@mkdir -p ~/Applications
+	@rm -rf $(APP_BUNDLE_DEV)
+	cp -r app/src-tauri/target/release/bundle/macos/attn-dev.app ~/Applications/
+	@ATTN_PROFILE=dev $(APP_BINARY_DEV) daemon ensure >/dev/null
+	@echo "Installed $(APP_BUNDLE_DEV) — profile=dev, data=~/.attn-dev, port=29849"
+	@echo "Launch: open $(APP_BUNDLE_DEV)"
+
+install-daemon-dev: build
+	@if [ ! -d "$(APP_BUNDLE_DEV)" ]; then \
+		echo "No installed attn-dev.app found in ~/Applications; run make dev first"; \
+		exit 1; \
+	fi
+	@echo ">>> Updating DEV daemon at $(APP_BINARY_DEV)"
+	cp $(OUTPUT) $(APP_BINARY_DEV)
+	@if [ "$(UNAME_S)" = "Darwin" ]; then codesign -s - -f $(APP_BINARY_DEV); fi
+	@ATTN_PROFILE=dev $(APP_BINARY_DEV) daemon ensure >/dev/null
+	@echo "Updated bundled dev daemon at $(APP_BINARY_DEV)"
 
 clean:
 	rm -f $(BINARY_NAME)
@@ -98,25 +147,40 @@ generate-types:
 check-types: generate-types
 	git diff --exit-code internal/protocol/generated.go app/src/types/generated.ts
 
-# Build Tauri app with bundled daemon (app bundle only, no DMG dialog)
+# Build Tauri app with bundled daemon (app bundle only, no DMG dialog).
+# Args:
+#   $(1) — build-time env-var prefix (VITE_* for frontend, ATTN_* for cargo)
+#   $(2) — productName (controls the .app bundle *folder* name — "attn" for
+#          prod, "attn-dev" for the dev sibling). Matches the productName
+#          in tauri.conf.json / tauri.dev.conf.json.
+#   $(3) — extra args for `pnpm tauri build` (e.g. --config for overlays)
+# The Go daemon is bundled as a sidecar under Contents/MacOS/attn regardless
+# of productName, so the codesign step is the same for both builds.
 define build_tauri_app
 	@mkdir -p app/src-tauri/binaries
 	cp $(BINARY_NAME) app/src-tauri/binaries/$(BINARY_NAME)-aarch64-apple-darwin
-	cd app && $(1) pnpm tauri build --bundles app
+	cd app && $(1) pnpm tauri build --bundles app $(3)
 	@if [ "$(UNAME_S)" = "Darwin" ]; then \
-		mkdir -p app/src-tauri/target/release/bundle/macos/attn.app/Contents/Resources; \
-		printf '{\n  "version": "%s",\n  "sourceFingerprint": "%s",\n  "gitCommit": "%s",\n  "buildTime": "%s"\n}\n' '$(VERSION)' '$(SOURCE_FINGERPRINT)' '$(GIT_COMMIT)' '$(BUILD_TIME)' > app/src-tauri/target/release/bundle/macos/attn.app/Contents/Resources/build-identity.json; \
+		mkdir -p app/src-tauri/target/release/bundle/macos/$(2).app/Contents/Resources; \
+		printf '{\n  "version": "%s",\n  "sourceFingerprint": "%s",\n  "gitCommit": "%s",\n  "buildTime": "%s"\n}\n' '$(VERSION)' '$(SOURCE_FINGERPRINT)' '$(GIT_COMMIT)' '$(BUILD_TIME)' > app/src-tauri/target/release/bundle/macos/$(2).app/Contents/Resources/build-identity.json; \
 	fi
 	@if [ "$(UNAME_S)" = "Darwin" ]; then \
-		codesign -s - -f app/src-tauri/target/release/bundle/macos/attn.app/Contents/MacOS/attn; \
+		codesign -s - -f app/src-tauri/target/release/bundle/macos/$(2).app/Contents/MacOS/attn; \
 	fi
 endef
 
 build-app: build
-	$(call build_tauri_app,VITE_INSTALL_CHANNEL=source VITE_ATTN_BUILD_VERSION='$(VERSION)' VITE_ATTN_SOURCE_FINGERPRINT='$(SOURCE_FINGERPRINT)' VITE_ATTN_GIT_COMMIT='$(GIT_COMMIT)' VITE_ATTN_BUILD_TIME='$(BUILD_TIME)')
+	$(call build_tauri_app,VITE_INSTALL_CHANNEL=source VITE_ATTN_BUILD_VERSION='$(VERSION)' VITE_ATTN_SOURCE_FINGERPRINT='$(SOURCE_FINGERPRINT)' VITE_ATTN_GIT_COMMIT='$(GIT_COMMIT)' VITE_ATTN_BUILD_TIME='$(BUILD_TIME)',attn,)
 
 build-app-ui-automation: build
-	$(call build_tauri_app,ATTN_UI_AUTOMATION=1 VITE_UI_AUTOMATION=1 VITE_INSTALL_CHANNEL=source VITE_ATTN_BUILD_VERSION='$(VERSION)' VITE_ATTN_SOURCE_FINGERPRINT='$(SOURCE_FINGERPRINT)' VITE_ATTN_GIT_COMMIT='$(GIT_COMMIT)' VITE_ATTN_BUILD_TIME='$(BUILD_TIME)')
+	$(call build_tauri_app,ATTN_UI_AUTOMATION=1 VITE_UI_AUTOMATION=1 VITE_INSTALL_CHANNEL=source VITE_ATTN_BUILD_VERSION='$(VERSION)' VITE_ATTN_SOURCE_FINGERPRINT='$(SOURCE_FINGERPRINT)' VITE_ATTN_GIT_COMMIT='$(GIT_COMMIT)' VITE_ATTN_BUILD_TIME='$(BUILD_TIME)',attn,)
+
+# Dev build. Bakes ATTN_BUILD_PROFILE=dev into the Rust binary and
+# VITE_ATTN_BUILD_PROFILE=dev + VITE_DAEMON_PORT=29849 into the frontend
+# so the dev bundle can never accidentally point at the prod daemon.
+# Output: app/src-tauri/target/release/bundle/macos/attn-dev.app
+build-app-dev: build
+	$(call build_tauri_app,ATTN_BUILD_PROFILE=dev VITE_ATTN_BUILD_PROFILE=dev VITE_DAEMON_PORT=29849 VITE_INSTALL_CHANNEL=source VITE_ATTN_BUILD_VERSION='$(VERSION)' VITE_ATTN_SOURCE_FINGERPRINT='$(SOURCE_FINGERPRINT)' VITE_ATTN_GIT_COMMIT='$(GIT_COMMIT)' VITE_ATTN_BUILD_TIME='$(BUILD_TIME)',attn-dev,--config src-tauri/tauri.dev.conf.json)
 
 app-screenshot:
 	cd app && node scripts/real-app-harness/capture-app-screenshot.mjs $(if $(SCREENSHOT_PATH),--path "$(SCREENSHOT_PATH)",) $(APP_SCREENSHOT_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,17 @@ UNAME_S := $(shell uname -s)
 # a mistake — it blows away the live install a developer is using. The
 # guard fires during Make's parse phase so we fail *before* the expensive
 # Tauri build, not after.
-GUARDED_PROD_TARGETS := install install-daemon
-ifneq (,$(filter $(GUARDED_PROD_TARGETS),$(MAKECMDGOALS)))
+#
+# Includes the default goal (`run`, invoked as bare `make`) — without it,
+# `ATTN_PROFILE=dev make` would silently reinstall the prod bundle.
+# The empty-goal case (bare `make`) is represented by the current
+# DEFAULT_GOAL ("run"); we substitute that in so the check catches it.
+GUARDED_PROD_TARGETS := run install install-daemon
+ACTIVE_GOALS := $(if $(MAKECMDGOALS),$(MAKECMDGOALS),$(.DEFAULT_GOAL))
+GUARDED_INVOCATION := $(filter $(GUARDED_PROD_TARGETS),$(ACTIVE_GOALS))
+ifneq (,$(GUARDED_INVOCATION))
 ifneq (,$(ATTN_PROFILE))
-$(error ATTN_PROFILE=$(ATTN_PROFILE) is set. `make $(firstword $(MAKECMDGOALS))` targets the PROD bundle ($(APP_BUNDLE)). Did you mean `make dev`? To proceed anyway: env -u ATTN_PROFILE make $(firstword $(MAKECMDGOALS)))
+$(error ATTN_PROFILE=$(ATTN_PROFILE) is set. `make $(firstword $(ACTIVE_GOALS))` targets the PROD bundle ($(APP_BUNDLE)). Did you mean `make dev`? To proceed anyway: env -u ATTN_PROFILE make $(firstword $(ACTIVE_GOALS)))
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,8 @@ install: build-app-ui-automation
 	cp -r app/src-tauri/target/release/bundle/macos/attn.app ~/Applications/
 	@$(APP_BINARY) daemon ensure >/dev/null
 	@echo "Installed attn.app to ~/Applications"
+	@open $(APP_BUNDLE)
+	@echo "Launched $(APP_BUNDLE)"
 
 install-daemon: build
 	@if [ ! -d "$(APP_BUNDLE)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,8 @@ install-dev: build-app-dev
 	cp -r app/src-tauri/target/release/bundle/macos/attn-dev.app ~/Applications/
 	@ATTN_PROFILE=dev $(APP_BINARY_DEV) daemon ensure >/dev/null
 	@echo "Installed $(APP_BUNDLE_DEV) — profile=dev, data=~/.attn-dev, port=29849"
-	@echo "Launch: open $(APP_BUNDLE_DEV)"
+	@open $(APP_BUNDLE_DEV)
+	@echo "Launched $(APP_BUNDLE_DEV)"
 
 install-daemon-dev: build
 	@if [ ! -d "$(APP_BUNDLE_DEV)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: build build-linux-amd64 build-linux-arm64 install install-daemon install-dev install-daemon-dev dev test test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app build-app-ui-automation build-app-dev app-screenshot dist release release-skip-tests
+.PHONY: run build build-linux-amd64 build-linux-arm64 install install-daemon install-dev install-daemon-dev dev test test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app build-app-ui-automation build-app-dev app-screenshot dist release release-skip-tests
+
+# Bare `make` does the full prod inner loop: install + open the app.
+# `make install` is install-only (for scripts/CI that drive the launch
+# separately). Same pattern mirrored for dev: `make dev` = install + open,
+# `make install-dev` = install only.
+.DEFAULT_GOAL := run
 
 BINARY_NAME=attn
 APP_BUNDLE=$(HOME)/Applications/attn.app
@@ -78,6 +84,10 @@ $(error ATTN_PROFILE=$(ATTN_PROFILE) is set. `make $(firstword $(MAKECMDGOALS))`
 endif
 endif
 
+run: install
+	@open $(APP_BUNDLE)
+	@echo "Launched $(APP_BUNDLE)"
+
 install: build-app-ui-automation
 	@echo ">>> Installing PROD: $(APP_BUNDLE) (profile=default, port=9849)"
 	@mkdir -p ~/Applications
@@ -85,8 +95,6 @@ install: build-app-ui-automation
 	cp -r app/src-tauri/target/release/bundle/macos/attn.app ~/Applications/
 	@$(APP_BINARY) daemon ensure >/dev/null
 	@echo "Installed attn.app to ~/Applications"
-	@open $(APP_BUNDLE)
-	@echo "Launched $(APP_BUNDLE)"
 
 install-daemon: build
 	@if [ ! -d "$(APP_BUNDLE)" ]; then \
@@ -109,6 +117,8 @@ install-daemon: build
 # in your shell if you want `attn ...` commands to target the dev daemon
 # by default.
 dev: install-dev
+	@open $(APP_BUNDLE_DEV)
+	@echo "Launched $(APP_BUNDLE_DEV)"
 
 install-dev: build-app-dev
 	@echo ">>> Installing DEV: $(APP_BUNDLE_DEV) (profile=dev, port=29849)"
@@ -117,8 +127,6 @@ install-dev: build-app-dev
 	cp -r app/src-tauri/target/release/bundle/macos/attn-dev.app ~/Applications/
 	@ATTN_PROFILE=dev $(APP_BINARY_DEV) daemon ensure >/dev/null
 	@echo "Installed $(APP_BUNDLE_DEV) — profile=dev, data=~/.attn-dev, port=29849"
-	@open $(APP_BUNDLE_DEV)
-	@echo "Launched $(APP_BUNDLE_DEV)"
 
 install-daemon-dev: build
 	@if [ ! -d "$(APP_BUNDLE_DEV)" ]; then \

--- a/README.md
+++ b/README.md
@@ -129,13 +129,23 @@ git clone https://github.com/victorarias/attn.git && cd attn
 | Command | What it does |
 |---|---|
 | `make build` | Build Go daemon binary |
-| `make install` | Rebuild and install the app bundle for source development, then ensure the bundled daemon is running |
+| `make` | Install attn.app and launch it — the one-command prod inner loop |
+| `make install` | Install the app bundle without launching (scripts / CI) |
 | `make install-daemon` | Update only the installed app's bundled daemon/runtime for the fast dev loop |
+| `make dev` | Install and launch `attn-dev.app` — the isolated dev sibling, for safely iterating on attn without touching your live install |
+| `make install-dev` | Same as `make dev` but without launching |
+| `make install-daemon-dev` | Fast sidecar-only loop for the dev install |
 | `make build-app` | Build daemon + Tauri app |
 | `make dist` | Create DMG |
 | `make test` | Go tests |
 | `make test-frontend` | Frontend tests (vitest) |
 | `make test-harness` | Go + frontend + E2E |
+
+### Iterating on attn itself (attn-on-attn)
+
+If you use attn daily and want to develop attn *with* attn running, use the dev sibling install instead of reinstalling your live copy. `make dev` builds and launches `~/Applications/attn-dev.app` — separate bundle identifier (`com.attn.manager.dev`), separate data dir (`~/.attn-dev/`), separate WebSocket port (`29849`). Both apps run side-by-side with zero cross-contamination. `make install` and `make install-daemon` refuse at parse time if `ATTN_PROFILE` is set in your shell, so you can't accidentally reinstall the live app while iterating on dev.
+
+The same `ATTN_PROFILE=<name>` env var scopes CLI commands (`eval "$(attn profile-env dev)"` to set it shell-wide), and the real-app serial matrix defaults to the dev install so it never takes over your live app.
 
 ## Docs
 

--- a/app/scripts/real-app-harness/common.mjs
+++ b/app/scripts/real-app-harness/common.mjs
@@ -2,11 +2,15 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { waitForPaneVisible } from './scenarioAssertions.mjs';
+import { defaultAppPathForProfile, defaultWSURLForProfile } from './harnessProfile.mjs';
 
 export function parseCommonArgs(argv) {
+  // Default to the prod install; ATTN_HARNESS_PROFILE=dev switches the
+  // whole harness (ws port, app path, bundle id) to the dev sibling
+  // without the caller having to set three separate env vars.
   const options = {
-    wsUrl: process.env.ATTN_REAL_APP_WS_URL || 'ws://127.0.0.1:9849/ws',
-    appPath: process.env.ATTN_REAL_APP_PATH || path.join(os.homedir(), 'Applications', 'attn.app'),
+    wsUrl: process.env.ATTN_REAL_APP_WS_URL || defaultWSURLForProfile(),
+    appPath: process.env.ATTN_REAL_APP_PATH || defaultAppPathForProfile(),
     artifactsDir: process.env.ATTN_REAL_APP_ARTIFACTS_DIR || path.join(os.tmpdir(), 'attn-real-app-harness'),
     sessionRootDir: process.env.ATTN_REAL_APP_SESSION_ROOT || path.join(os.tmpdir(), 'attn-real-app-sessions'),
   };

--- a/app/scripts/real-app-harness/common.mjs
+++ b/app/scripts/real-app-harness/common.mjs
@@ -2,7 +2,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { waitForPaneVisible } from './scenarioAssertions.mjs';
-import { defaultAppPathForProfile, defaultWSURLForProfile } from './harnessProfile.mjs';
+import {
+  defaultAppPathForProfile,
+  defaultWSURLForProfile,
+  deepLinkSchemeForProfile,
+} from './harnessProfile.mjs';
 
 export function parseCommonArgs(argv) {
   // Default to the prod install; ATTN_HARNESS_PROFILE=dev switches the
@@ -124,7 +128,11 @@ export async function bootstrapPackagedAppSession({
   await driver.activateBackground();
   await captureScreenshot(driver, path.join(runDir, '01-app-launched.png'));
 
-  const deepLink = `attn://spawn?cwd=${encodeURIComponent(sessionDir)}&label=${encodeURIComponent(sessionLabel)}`;
+  // Scheme is profile-scoped: ATTN_HARNESS_PROFILE=dev → `attn-dev://`,
+  // which the dev bundle registers. Sending `attn://` under a dev
+  // profile would open the prod app instead of attn-dev.app.
+  const scheme = deepLinkSchemeForProfile();
+  const deepLink = `${scheme}://spawn?cwd=${encodeURIComponent(sessionDir)}&label=${encodeURIComponent(sessionLabel)}`;
   console.log(`[RealAppHarness] deepLink=${deepLink}`);
   await driver.openDeepLink(deepLink);
 

--- a/app/scripts/real-app-harness/harnessProfile.mjs
+++ b/app/scripts/real-app-harness/harnessProfile.mjs
@@ -45,3 +45,11 @@ export function manifestPathForProfile(profile = currentHarnessProfile()) {
     'ui-automation.json',
   );
 }
+
+// Match the deep-link scheme registered for each bundle:
+//   - prod: tauri.conf.json declares `attn`
+//   - dev:  tauri.dev.conf.json declares `attn-dev`
+// Must stay in sync with config.DeepLinkScheme() on the Go side.
+export function deepLinkSchemeForProfile(profile = currentHarnessProfile()) {
+  return profile === 'dev' ? 'attn-dev' : 'attn';
+}

--- a/app/scripts/real-app-harness/harnessProfile.mjs
+++ b/app/scripts/real-app-harness/harnessProfile.mjs
@@ -1,0 +1,47 @@
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Harness profile resolution. A single env var, ATTN_HARNESS_PROFILE,
+ * switches the whole real-app harness between the prod install
+ * (~/Applications/attn.app) and the dev sibling install
+ * (~/Applications/attn-dev.app).
+ *
+ * Keep bundle identifiers + default port in sync with:
+ *   - app/src-tauri/tauri.conf.json         (prod)
+ *   - app/src-tauri/tauri.dev.conf.json     (dev)
+ *   - app/src-tauri/src/profile.rs          (Rust side)
+ *   - internal/config/config.go             (Go side)
+ */
+
+export function currentHarnessProfile() {
+  return (process.env.ATTN_HARNESS_PROFILE || '').trim().toLowerCase();
+}
+
+export function bundleIdentifierForProfile(profile = currentHarnessProfile()) {
+  return profile === 'dev' ? 'com.attn.manager.dev' : 'com.attn.manager';
+}
+
+export function defaultAppPathForProfile(profile = currentHarnessProfile()) {
+  const name = profile === 'dev' ? 'attn-dev.app' : 'attn.app';
+  return path.join(os.homedir(), 'Applications', name);
+}
+
+export function defaultDaemonPortForProfile(profile = currentHarnessProfile()) {
+  return profile === 'dev' ? 29849 : 9849;
+}
+
+export function defaultWSURLForProfile(profile = currentHarnessProfile()) {
+  return `ws://127.0.0.1:${defaultDaemonPortForProfile(profile)}/ws`;
+}
+
+export function manifestPathForProfile(profile = currentHarnessProfile()) {
+  return path.join(
+    os.homedir(),
+    'Library',
+    'Application Support',
+    bundleIdentifierForProfile(profile),
+    'debug',
+    'ui-automation.json',
+  );
+}

--- a/app/scripts/real-app-harness/run-serial-matrix.mjs
+++ b/app/scripts/real-app-harness/run-serial-matrix.mjs
@@ -1,9 +1,18 @@
 #!/usr/bin/env node
 
-import os from 'node:os';
-import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { assertPackagedAppBuildMatchesCurrentSource } from './buildPreflight.mjs';
+import { defaultAppPathForProfile } from './harnessProfile.mjs';
+
+// Matrix runs against the dev install by default. The dev install is the
+// whole point of the profile feature: iterate on attn-on-attn test
+// scenarios without ever taking over the live prod app. Opt out by
+// setting ATTN_HARNESS_PROFILE to an empty string (prod) or a different
+// profile name explicitly. This must happen before any import that reads
+// the env var at module-load time.
+if (process.env.ATTN_HARNESS_PROFILE === undefined) {
+  process.env.ATTN_HARNESS_PROFILE = 'dev';
+}
 
 const scenarioCatalog = [
   {
@@ -101,6 +110,11 @@ function printHelp() {
   node scripts/real-app-harness/run-serial-matrix.mjs --fail-fast
   node scripts/real-app-harness/run-serial-matrix.mjs --timeout-ms 180000
 
+Target: defaults to the dev install (~/Applications/attn-dev.app, port 29849)
+  so the matrix never takes over your live prod app. Run \`make dev\` first
+  if you haven't built one. To point at a different profile set
+  ATTN_HARNESS_PROFILE=<name> (empty for prod) before invoking.
+
 Available scenarios:
 ${scenarioCatalog.map((scenario) => `  - ${scenario.id}: ${scenario.label}`).join('\n')}
 `);
@@ -197,7 +211,8 @@ async function main() {
   }
 
   const scenarios = resolveScenarios(selected);
-  const appPath = process.env.ATTN_REAL_APP_PATH || path.join(os.homedir(), 'Applications', 'attn.app');
+  const appPath = process.env.ATTN_REAL_APP_PATH || defaultAppPathForProfile();
+  console.log(`Matrix target: ${appPath} (ATTN_HARNESS_PROFILE=${process.env.ATTN_HARNESS_PROFILE || '<default>'})`);
   const preflightKeys = new Set();
   for (const scenario of scenarios) {
     const preflightLaunchEnv = scenario.preflightLaunchEnv || null;

--- a/app/scripts/real-app-harness/uiAutomationClient.mjs
+++ b/app/scripts/real-app-harness/uiAutomationClient.mjs
@@ -6,6 +6,11 @@ import { execFile, spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { MacOSDriver } from './macosDriver.mjs';
+import {
+  bundleIdentifierForProfile,
+  defaultAppPathForProfile,
+  manifestPathForProfile,
+} from './harnessProfile.mjs';
 
 const execFileAsync = promisify(execFile);
 const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -18,14 +23,9 @@ function delay(ms) {
 }
 
 function defaultManifestPath() {
-  return path.join(
-    os.homedir(),
-    'Library',
-    'Application Support',
-    'com.attn.manager',
-    'debug',
-    'ui-automation.json'
-  );
+  // Profile-aware: the dev bundle writes its manifest under
+  // ~/Library/Application Support/com.attn.manager.dev/...
+  return manifestPathForProfile();
 }
 
 function isTransientManifestReadError(error) {
@@ -111,11 +111,11 @@ function isFatalFrontendResponsivenessError(error) {
 
 export class UiAutomationClient {
   constructor({
-    appPath = path.join(os.homedir(), 'Applications', 'attn.app'),
+    appPath = defaultAppPathForProfile(),
     manifestPath = defaultManifestPath(),
     launchEnv = null,
     backgroundLaunch = false,
-    bundleId = 'com.attn.manager',
+    bundleId = bundleIdentifierForProfile(),
   } = {}) {
     this.appPath = appPath;
     this.manifestPath = manifestPath;
@@ -202,7 +202,7 @@ export class UiAutomationClient {
     }
 
     try {
-      await execFileAsync('osascript', ['-e', 'tell application id "com.attn.manager" to quit']);
+      await execFileAsync('osascript', ['-e', `tell application id "${this.bundleId}" to quit`]);
     } catch {
       // Fall through to process-based cleanup.
     }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod profile;
 mod thumbs;
 mod ui_automation;
 
@@ -445,6 +446,28 @@ fn parent_process_id() -> Option<u32> {
     None
 }
 
+#[derive(Debug, serde::Serialize)]
+struct BuildProfileInfo {
+    profile: &'static str,
+    label: &'static str,
+    expected_port: &'static str,
+    bundle_identifier: &'static str,
+}
+
+/// Returns the compile-time profile baked into this app bundle.
+/// The frontend calls this at startup to verify that the daemon it
+/// connects to reports the same profile — a mismatch is fatal
+/// (the app refuses to operate, per the design gate).
+#[tauri::command]
+fn get_build_profile() -> BuildProfileInfo {
+    BuildProfileInfo {
+        profile: profile::build_profile(),
+        label: profile::build_profile_label(),
+        expected_port: profile::default_port_for_build_profile(),
+        bundle_identifier: profile::bundle_identifier(),
+    }
+}
+
 #[tauri::command]
 fn ensure_daemon(_app: tauri::AppHandle) -> Result<(), String> {
     let _guard = ENSURE_DAEMON_LOCK
@@ -671,14 +694,20 @@ fn open_in_editor(
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Must run before anything reads ATTN_PROFILE / ATTN_WS_PORT (including
+    // any spawned `attn daemon` child that inherits our env).
+    profile::apply_build_profile_env();
+
     // Disable macOS "press and hold for accents" popup so that holding
-    // a key in the terminal produces key repeat instead.
+    // a key in the terminal produces key repeat instead. Scope the
+    // preference change to the running bundle so a dev install
+    // (com.attn.manager.dev) never overwrites the prod preference.
     #[cfg(target_os = "macos")]
     {
         let _ = Command::new("defaults")
             .args([
                 "write",
-                "com.attn.manager",
+                profile::bundle_identifier(),
                 "ApplePressAndHoldEnabled",
                 "-bool",
                 "false",
@@ -696,6 +725,7 @@ pub fn run() {
             list_directory,
             ensure_daemon,
             open_in_editor,
+            get_build_profile,
             thumbs::extract_patterns,
             thumbs::reveal_in_finder,
         ])

--- a/app/src-tauri/src/profile.rs
+++ b/app/src-tauri/src/profile.rs
@@ -1,0 +1,72 @@
+//! Build-profile awareness for the Tauri shell.
+//!
+//! The `ATTN_BUILD_PROFILE` env var is read at *compile* time and baked
+//! into the binary. At startup we propagate it into the process env as
+//! `ATTN_PROFILE` so the spawned daemon inherits it, and we pre-set
+//! `ATTN_WS_PORT` to the profile's default port so the Rust-side
+//! health probes look at the right TCP port from the very first call.
+//!
+//! Keep the dev port in sync with `internal/config/config.go::WSPort`.
+
+use std::env;
+
+const BUILD_PROFILE: Option<&str> = option_env!("ATTN_BUILD_PROFILE");
+
+/// Returns the compile-time profile name (empty string for default).
+pub fn build_profile() -> &'static str {
+    BUILD_PROFILE.unwrap_or("").trim()
+}
+
+/// Returns a human-readable profile label ("default" when empty).
+pub fn build_profile_label() -> &'static str {
+    let p = build_profile();
+    if p.is_empty() {
+        "default"
+    } else {
+        p
+    }
+}
+
+/// Returns the default WS port for the compile-time profile.
+/// Mirrors `config.WSPort()` in Go.
+pub fn default_port_for_build_profile() -> &'static str {
+    match build_profile() {
+        "" => "9849",
+        "dev" => "29849",
+        // For any other named build, we require ATTN_WS_PORT to be set
+        // explicitly at build time. Fall back to the dev port so we
+        // never silently collide with prod.
+        _ => "29849",
+    }
+}
+
+/// Applies the build-time profile to the process env, so spawned daemon
+/// subprocesses inherit it and any subsequent env lookups in the shell
+/// itself (e.g. `daemon_http_port`) see the expected port.
+///
+/// Respects caller overrides: if `ATTN_PROFILE` or `ATTN_WS_PORT` are
+/// already set in the parent env (e.g. for tests), we leave them alone.
+///
+/// Must be called before any function that reads `ATTN_PROFILE` or
+/// `ATTN_WS_PORT` (directly or via a spawned subprocess).
+pub fn apply_build_profile_env() {
+    let profile = build_profile();
+    if !profile.is_empty() {
+        if env::var_os("ATTN_PROFILE").is_none() {
+            env::set_var("ATTN_PROFILE", profile);
+        }
+        if env::var_os("ATTN_WS_PORT").is_none() {
+            env::set_var("ATTN_WS_PORT", default_port_for_build_profile());
+        }
+    }
+}
+
+/// macOS bundle identifier for the running build. Must stay in sync with
+/// the `identifier` field in `tauri.conf.json` (default build) and
+/// `tauri.dev.conf.json` (dev build overlay).
+pub fn bundle_identifier() -> &'static str {
+    match build_profile() {
+        "dev" => "com.attn.manager.dev",
+        _ => "com.attn.manager",
+    }
+}

--- a/app/src-tauri/tauri.dev.conf.json
+++ b/app/src-tauri/tauri.dev.conf.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "attn-dev",
+  "identifier": "com.attn.manager.dev",
+  "app": {
+    "windows": [
+      {
+        "title": "attn-dev"
+      }
+    ]
+  },
+  "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["attn-dev"]
+      }
+    }
+  }
+}

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -46,6 +46,7 @@ import { recordPaneRuntimeDebugEvent } from '../utils/paneRuntimeDebug';
 import { recordPtyCommand, recordWsJsonParse } from '../utils/ptyPerf';
 import { recordTerminalRuntimeLog } from '../utils/terminalRuntimeLog';
 import { resolveDaemonWebSocketURL, type DaemonEndpointProfile } from '../utils/daemonEndpoint';
+import { daemonProfileMatches, fetchDaemonHealthProfile, profileMismatchMessage } from '../utils/buildProfile';
 
 // Re-export types from generated for consumers
 // Use type aliases to maintain backward compatibility
@@ -609,6 +610,11 @@ export function useDaemonSocket({
   const pendingSessionVisualizedRef = useRef<Set<string>>(new Set());
   const daemonInstanceIDRef = useRef<string>('');
   const hasReceivedInitialStateRef = useRef(false);
+  // Once we detect a profile mismatch, we refuse to operate forever — the
+  // user must quit and launch the matching app. Never clears inside the
+  // session.
+  const profileMismatchRef = useRef<boolean>(false);
+  const profileCheckedRef = useRef<boolean>(false);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [hasReceivedInitialState, setHasReceivedInitialState] = useState(false);
   const [rateLimit, setRateLimit] = useState<RateLimitState | null>(null);
@@ -811,8 +817,37 @@ export function useDaemonSocket({
 
   const connect = useCallback(async () => {
     if (wsRef.current?.readyState === WebSocket.OPEN || wsRef.current?.readyState === WebSocket.CONNECTING) return;
+    if (profileMismatchRef.current) {
+      // Already detected a mismatch in a previous connect attempt; stay
+      // stopped. Reconnect would just bounce off the same check.
+      return;
+    }
 
     await ensureDaemonRunning();
+
+    // Verify the daemon's profile matches this build before opening the
+    // WebSocket. Protects the user from accidentally operating on the
+    // wrong data dir when (say) a misconfigured dev app lands on the
+    // prod port via a manual ATTN_WS_PORT override. First successful
+    // check latches — reconnects skip it.
+    if (!profileCheckedRef.current) {
+      try {
+        const health = await fetchDaemonHealthProfile(resolvedWsUrl);
+        if (!daemonProfileMatches(health.profile)) {
+          profileMismatchRef.current = true;
+          setConnectionError(profileMismatchMessage(health.profile));
+          circuitOpenRef.current = true;
+          return;
+        }
+        profileCheckedRef.current = true;
+      } catch (err) {
+        // Health fetch failed (daemon still coming up, network hiccup,
+        // older daemon without /health). Don't block the WS connect —
+        // the initial_state handshake will surface hard errors, and a
+        // real mismatch will be caught on the next try.
+        console.warn('[Daemon] profile pre-check failed, proceeding without it:', err);
+      }
+    }
 
     const ws = new WebSocket(resolvedWsUrl);
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -46,7 +46,7 @@ import { recordPaneRuntimeDebugEvent } from '../utils/paneRuntimeDebug';
 import { recordPtyCommand, recordWsJsonParse } from '../utils/ptyPerf';
 import { recordTerminalRuntimeLog } from '../utils/terminalRuntimeLog';
 import { resolveDaemonWebSocketURL, type DaemonEndpointProfile } from '../utils/daemonEndpoint';
-import { daemonProfileMatches, fetchDaemonHealthProfile, profileMismatchMessage } from '../utils/buildProfile';
+import { BUILD_PROFILE, daemonProfileMatches, fetchDaemonHealthProfile, profileMismatchMessage } from '../utils/buildProfile';
 
 // Re-export types from generated for consumers
 // Use type aliases to maintain backward compatibility
@@ -826,11 +826,14 @@ export function useDaemonSocket({
     await ensureDaemonRunning();
 
     // Verify the daemon's profile matches this build before opening the
-    // WebSocket. Protects the user from accidentally operating on the
-    // wrong data dir when (say) a misconfigured dev app lands on the
-    // prod port via a manual ATTN_WS_PORT override. First successful
-    // check latches — reconnects skip it.
-    if (!profileCheckedRef.current) {
+    // WebSocket. Only meaningful for non-default builds: the dev bundle
+    // (BUILD_PROFILE="dev") refuses to operate on a daemon that reports
+    // anything other than "dev". The default/prod build skips the check
+    // — a default frontend reaching a dev daemon would need a deliberate
+    // port override, and the initial_state protocol-version handshake
+    // over the WS still catches the common failure modes. Skipping also
+    // keeps existing WebSocket mocks in tests sync with the connect path.
+    if (BUILD_PROFILE !== '' && !profileCheckedRef.current) {
       try {
         const health = await fetchDaemonHealthProfile(resolvedWsUrl);
         if (!daemonProfileMatches(health.profile)) {

--- a/app/src/utils/buildProfile.test.ts
+++ b/app/src/utils/buildProfile.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { daemonProfileMatches, healthURLFromWS, profileMismatchMessage } from './buildProfile';
+
+describe('daemonProfileMatches', () => {
+  it('treats missing/empty profile as default', () => {
+    // The default build expects "default", so missing → match.
+    expect(daemonProfileMatches(undefined)).toBe(true);
+    expect(daemonProfileMatches(null)).toBe(true);
+    expect(daemonProfileMatches('')).toBe(true);
+    expect(daemonProfileMatches('   ')).toBe(true);
+    expect(daemonProfileMatches('default')).toBe(true);
+  });
+
+  it('treats a non-default profile as mismatch for default build', () => {
+    expect(daemonProfileMatches('dev')).toBe(false);
+    expect(daemonProfileMatches('staging')).toBe(false);
+  });
+});
+
+describe('healthURLFromWS', () => {
+  it('rewrites ws → http and replaces path', () => {
+    expect(healthURLFromWS('ws://127.0.0.1:29849/ws')).toBe('http://127.0.0.1:29849/health');
+  });
+
+  it('rewrites wss → https', () => {
+    expect(healthURLFromWS('wss://example.com:443/ws')).toBe('https://example.com/health');
+  });
+
+  it('returns empty string on invalid input', () => {
+    expect(healthURLFromWS('not a url')).toBe('');
+  });
+});
+
+describe('profileMismatchMessage', () => {
+  it('mentions both expected and reported profiles', () => {
+    const msg = profileMismatchMessage('dev');
+    expect(msg).toContain('dev');
+    expect(msg).toContain('default');
+    expect(msg).toMatch(/refus/i);
+  });
+
+  it('uses "default" when the reported profile is missing', () => {
+    const msg = profileMismatchMessage(undefined);
+    expect(msg).toMatch(/"default"/);
+  });
+});

--- a/app/src/utils/buildProfile.ts
+++ b/app/src/utils/buildProfile.ts
@@ -1,0 +1,85 @@
+/**
+ * Compile-time profile baked into this frontend bundle. Mirrors the
+ * ATTN_BUILD_PROFILE constant in the Rust shell and the ATTN_PROFILE
+ * env var the daemon sees at runtime.
+ *
+ * Default ("") means the production build. "dev" means the sibling
+ * dev install. The frontend uses this to refuse to operate when the
+ * daemon it connects to reports a different profile — a mismatch
+ * means either a misconfigured environment or a malicious daemon
+ * replacement, and we want to fail loudly rather than silently
+ * operate on the wrong data dir.
+ */
+export const BUILD_PROFILE: string = (import.meta.env.VITE_ATTN_BUILD_PROFILE ?? '').trim();
+
+export const BUILD_PROFILE_LABEL: string = BUILD_PROFILE === '' ? 'default' : BUILD_PROFILE;
+
+/**
+ * Checks whether a profile reported by the daemon matches what this
+ * build expects. Treats a missing/empty reported profile as "default"
+ * for forward compatibility with pre-profile daemons.
+ */
+export function daemonProfileMatches(reportedProfile: string | null | undefined): boolean {
+  const reported = (reportedProfile ?? '').trim() || 'default';
+  return reported === BUILD_PROFILE_LABEL;
+}
+
+/**
+ * Derives the /health URL from a WebSocket URL. Example:
+ *   ws://127.0.0.1:29849/ws  →  http://127.0.0.1:29849/health
+ */
+export function healthURLFromWS(wsUrl: string): string {
+  try {
+    const u = new URL(wsUrl);
+    u.protocol = u.protocol === 'wss:' ? 'https:' : 'http:';
+    u.pathname = '/health';
+    u.search = '';
+    u.hash = '';
+    return u.toString();
+  } catch {
+    return '';
+  }
+}
+
+export interface DaemonHealthProfile {
+  profile?: string;
+  data_dir?: string;
+  socket_path?: string;
+  port?: string;
+}
+
+/**
+ * Fetches /health and returns the profile-identity subset. Throws on
+ * network/HTTP errors so the caller can decide whether to treat the
+ * absence of a response as mismatch or transient.
+ */
+export async function fetchDaemonHealthProfile(wsUrl: string, signal?: AbortSignal): Promise<DaemonHealthProfile> {
+  const url = healthURLFromWS(wsUrl);
+  if (!url) throw new Error('cannot derive health URL from ws URL');
+  const resp = await fetch(url, { signal, cache: 'no-store' });
+  if (!resp.ok) throw new Error(`/health returned ${resp.status}`);
+  const body = await resp.json();
+  return {
+    profile: typeof body?.profile === 'string' ? body.profile : undefined,
+    data_dir: typeof body?.data_dir === 'string' ? body.data_dir : undefined,
+    socket_path: typeof body?.socket_path === 'string' ? body.socket_path : undefined,
+    port: typeof body?.port === 'string' ? body.port : undefined,
+  };
+}
+
+/**
+ * Builds a user-facing error message for a profile mismatch. Matches the
+ * "refuse to operate" behavior agreed in design — this is shown as a
+ * non-dismissable banner, and the caller should not attempt to
+ * reconnect.
+ */
+export function profileMismatchMessage(reported: string | null | undefined): string {
+  const reportedLabel = (reported ?? '').trim() || 'default';
+  return (
+    `Profile mismatch: this app was built for profile "${BUILD_PROFILE_LABEL}" ` +
+    `but the daemon reports profile "${reportedLabel}". ` +
+    `Refusing to operate on a mismatched daemon. ` +
+    `Quit this app and launch the matching one (prod = attn.app, dev = attn-dev.app), ` +
+    `or restart the daemon under the correct ATTN_PROFILE.`
+  );
+}

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -95,13 +95,23 @@ func main() {
 		return
 	}
 
+	// Validate ATTN_PROFILE before we act on it. A typo'd profile would
+	// silently fall back to default, which is exactly the kind of mistake
+	// this whole feature exists to prevent.
+	if err := config.ValidateProfile(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	if len(os.Args) < 2 {
+		maybePrintProfileBanner()
 		runWrapper()
 		return
 	}
 
 	switch os.Args[1] {
 	case "daemon":
+		maybePrintProfileBanner()
 		runDaemonCommand()
 	case "ws-relay":
 		runWSRelay()
@@ -110,7 +120,10 @@ func main() {
 	case "review-loop":
 		runReviewLoop()
 	case "list":
+		maybePrintProfileBanner()
 		runList()
+	case "profile-env":
+		runProfileEnv()
 	case "_hook-stop":
 		runHookStop()
 	case "_hook-state":
@@ -120,12 +133,21 @@ func main() {
 	default:
 		// Check if it's a flag (starts with -)
 		if len(os.Args[1]) > 0 && os.Args[1][0] == '-' {
+			maybePrintProfileBanner()
 			runWrapper()
 		} else {
 			fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
 			os.Exit(1)
 		}
 	}
+}
+
+// maybePrintProfileBanner prints the profile banner to stderr when a
+// non-default ATTN_PROFILE is active. Skipped for hook commands (called
+// on every Claude action) and for silent CLI subcommands (ws-relay,
+// pty-worker, review-loop) that have their own protocols on stderr.
+func maybePrintProfileBanner() {
+	config.PrintProfileBanner(os.Stderr)
 }
 
 func isVersionCommand(args []string) bool {

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -95,6 +95,15 @@ func main() {
 		return
 	}
 
+	// `profile-env` is the self-recovery path: if ATTN_PROFILE is
+	// currently typo'd, the user needs `attn profile-env --unset` (or
+	// `profile-env <name>`) to fix their shell. Route it *before* the
+	// global validation so an invalid env value doesn't trap them.
+	if len(os.Args) >= 2 && os.Args[1] == "profile-env" {
+		runProfileEnv()
+		return
+	}
+
 	// Validate ATTN_PROFILE before we act on it. A typo'd profile would
 	// silently fall back to default, which is exactly the kind of mistake
 	// this whole feature exists to prevent.
@@ -122,8 +131,6 @@ func main() {
 	case "list":
 		maybePrintProfileBanner()
 		runList()
-	case "profile-env":
-		runProfileEnv()
 	case "_hook-stop":
 		runHookStop()
 	case "_hook-state":
@@ -732,8 +739,11 @@ func openAppWithDeepLink() {
 		label = filepath.Base(cwd)
 	}
 
-	// Build deep link URL
-	deepLink := fmt.Sprintf("attn://spawn?cwd=%s&label=%s",
+	// Build deep link URL. Scheme is profile-scoped so `attn` in a
+	// dev-scoped shell (ATTN_PROFILE=dev) opens attn-dev.app via its
+	// `attn-dev://` registration instead of the prod app.
+	deepLink := fmt.Sprintf("%s://spawn?cwd=%s&label=%s",
+		config.DeepLinkScheme(),
 		url.QueryEscape(cwd),
 		url.QueryEscape(label))
 

--- a/cmd/attn/profile_env.go
+++ b/cmd/attn/profile_env.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/victorarias/attn/internal/config"
+)
+
+// runProfileEnv emits shell commands for sourcing the profile into a shell.
+// Usage:
+//
+//	eval "$(attn profile-env dev)"     # sets ATTN_PROFILE=dev
+//	eval "$(attn profile-env --unset)"  # clears ATTN_PROFILE
+//
+// The output is intentionally POSIX-sh compatible (export/unset) and works
+// in bash, zsh, and fish's posix-compat eval. For native fish, use
+// `attn profile-env --fish dev` which prints `set -gx ATTN_PROFILE dev`.
+func runProfileEnv() {
+	args := os.Args[2:]
+	fishMode := false
+	filtered := make([]string, 0, len(args))
+	for _, a := range args {
+		switch a {
+		case "--fish":
+			fishMode = true
+		case "-h", "--help":
+			printProfileEnvHelp()
+			return
+		default:
+			filtered = append(filtered, a)
+		}
+	}
+
+	if len(filtered) == 0 {
+		printProfileEnvHelp()
+		os.Exit(1)
+	}
+
+	arg := strings.TrimSpace(filtered[0])
+	if arg == "--unset" || arg == "none" || arg == "default" {
+		if fishMode {
+			fmt.Println("set -e ATTN_PROFILE")
+		} else {
+			fmt.Println("unset ATTN_PROFILE")
+		}
+		return
+	}
+
+	// Validate the requested profile name using the same rules the rest
+	// of the binary applies, so typos fail here instead of silently
+	// mis-routing to the default profile later.
+	if err := validateRequestedProfile(arg); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if fishMode {
+		fmt.Printf("set -gx ATTN_PROFILE %s\n", arg)
+	} else {
+		fmt.Printf("export ATTN_PROFILE=%s\n", arg)
+	}
+}
+
+func validateRequestedProfile(name string) error {
+	// Reuse the package-level validation by temporarily setting and
+	// clearing the env var. config.ValidateProfile reads ATTN_PROFILE,
+	// so we need to scope this carefully.
+	prev, hadPrev := os.LookupEnv("ATTN_PROFILE")
+	os.Setenv("ATTN_PROFILE", name)
+	err := config.ValidateProfile()
+	if hadPrev {
+		os.Setenv("ATTN_PROFILE", prev)
+	} else {
+		os.Unsetenv("ATTN_PROFILE")
+	}
+	return err
+}
+
+func printProfileEnvHelp() {
+	fmt.Fprintln(os.Stderr, `attn profile-env — emit shell commands to set or clear ATTN_PROFILE
+
+Usage:
+  eval "$(attn profile-env dev)"              # bash/zsh: export ATTN_PROFILE=dev
+  eval "$(attn profile-env --unset)"           # bash/zsh: unset ATTN_PROFILE
+  attn profile-env --fish dev | source         # fish: set -gx ATTN_PROFILE dev
+  attn profile-env --fish --unset | source     # fish: set -e ATTN_PROFILE
+
+Profile names must match [a-z0-9][a-z0-9-]{0,15}. "dev" is reserved for the
+development sibling install (port 29849, data dir ~/.attn-dev).`)
+}

--- a/cmd/attn/profile_env.go
+++ b/cmd/attn/profile_env.go
@@ -51,7 +51,7 @@ func runProfileEnv() {
 	// Validate the requested profile name using the same rules the rest
 	// of the binary applies, so typos fail here instead of silently
 	// mis-routing to the default profile later.
-	if err := validateRequestedProfile(arg); err != nil {
+	if err := config.ValidateProfileName(arg); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -61,21 +61,6 @@ func runProfileEnv() {
 	} else {
 		fmt.Printf("export ATTN_PROFILE=%s\n", arg)
 	}
-}
-
-func validateRequestedProfile(name string) error {
-	// Reuse the package-level validation by temporarily setting and
-	// clearing the env var. config.ValidateProfile reads ATTN_PROFILE,
-	// so we need to scope this carefully.
-	prev, hadPrev := os.LookupEnv("ATTN_PROFILE")
-	os.Setenv("ATTN_PROFILE", name)
-	err := config.ValidateProfile()
-	if hadPrev {
-		os.Setenv("ATTN_PROFILE", prev)
-	} else {
-		os.Unsetenv("ATTN_PROFILE")
-	}
-	return err
 }
 
 func printProfileEnvHelp() {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,9 +2,12 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
@@ -32,7 +35,7 @@ func New(socketPath string) *Client {
 func (c *Client) send(msg interface{}) (*protocol.Response, error) {
 	conn, err := net.Dial("unix", c.socketPath)
 	if err != nil {
-		return nil, fmt.Errorf("connect to daemon: %w", err)
+		return nil, explainConnectError(c.socketPath, err)
 	}
 	defer conn.Close()
 
@@ -360,4 +363,69 @@ func (c *Client) IsRunning() bool {
 	}
 	conn.Close()
 	return true
+}
+
+// explainConnectError wraps a dial failure with profile context and — if
+// the *other* profile's daemon happens to be running — a concrete hint
+// on how to reach it. This is the single foot-gun everyone hits when
+// first adopting ATTN_PROFILE, so we pay it down here.
+func explainConnectError(sockPath string, cause error) error {
+	profile := config.ProfileLabel()
+	base := fmt.Sprintf("connect to daemon at %s (profile=%s): %v",
+		collapseHome(sockPath), profile, cause)
+	if hint := crossProfileHint(); hint != "" {
+		return errors.New(base + "\n  " + hint)
+	}
+	return errors.New(base)
+}
+
+// crossProfileHint returns a one-line suggestion when the *other* profile's
+// daemon appears to be running. Returns "" when no such hint is useful.
+func crossProfileHint() string {
+	current := config.Profile()
+	if current == "" {
+		// Currently default → probe dev.
+		otherSock := config.SocketPathForProfile("dev")
+		if socketLive(otherSock) {
+			return fmt.Sprintf("hint: a dev daemon is listening at %s — run `eval \"$(attn profile-env dev)\"` to switch this shell",
+				collapseHome(otherSock))
+		}
+		return ""
+	}
+	// Currently non-default → probe default.
+	otherSock := config.SocketPathForProfile("")
+	if socketLive(otherSock) {
+		return fmt.Sprintf("hint: the default daemon is listening at %s — run `eval \"$(attn profile-env --unset)\"` to switch this shell",
+			collapseHome(otherSock))
+	}
+	return ""
+}
+
+func socketLive(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	conn, err := net.DialTimeout("unix", path, 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func collapseHome(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+	if path == home {
+		return "~"
+	}
+	if strings.HasPrefix(path, home+"/") {
+		return "~" + path[len(home):]
+	}
+	return path
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -372,7 +372,7 @@ func (c *Client) IsRunning() bool {
 func explainConnectError(sockPath string, cause error) error {
 	profile := config.ProfileLabel()
 	base := fmt.Sprintf("connect to daemon at %s (profile=%s): %v",
-		collapseHome(sockPath), profile, cause)
+		config.CollapseHome(sockPath), profile, cause)
 	if hint := crossProfileHint(); hint != "" {
 		return errors.New(base + "\n  " + hint)
 	}
@@ -388,7 +388,7 @@ func crossProfileHint() string {
 		otherSock := config.SocketPathForProfile("dev")
 		if socketLive(otherSock) {
 			return fmt.Sprintf("hint: a dev daemon is listening at %s — run `eval \"$(attn profile-env dev)\"` to switch this shell",
-				collapseHome(otherSock))
+				config.CollapseHome(otherSock))
 		}
 		return ""
 	}
@@ -396,7 +396,7 @@ func crossProfileHint() string {
 	otherSock := config.SocketPathForProfile("")
 	if socketLive(otherSock) {
 		return fmt.Sprintf("hint: the default daemon is listening at %s — run `eval \"$(attn profile-env --unset)\"` to switch this shell",
-			collapseHome(otherSock))
+			config.CollapseHome(otherSock))
 	}
 	return ""
 }
@@ -414,18 +414,4 @@ func socketLive(path string) bool {
 	}
 	_ = conn.Close()
 	return true
-}
-
-func collapseHome(path string) string {
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return path
-	}
-	if path == home {
-		return "~"
-	}
-	if strings.HasPrefix(path, home+"/") {
-		return "~" + path[len(home):]
-	}
-	return path
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/victorarias/attn/internal/config"
@@ -183,6 +184,73 @@ func TestClient_NotRunning(t *testing.T) {
 	err := c.Register("id", "label", "/tmp")
 	if err == nil {
 		t.Error("expected error when daemon not running")
+	}
+}
+
+func TestClient_ConnectError_IncludesProfileAndSocket(t *testing.T) {
+	// No ATTN_PROFILE set → profile defaults to "default".
+	os.Unsetenv("ATTN_PROFILE")
+	sockPath := filepath.Join(t.TempDir(), "missing.sock")
+	c := New(sockPath)
+	err := c.Register("id", "label", "/tmp")
+	if err == nil {
+		t.Fatal("expected error when daemon not running")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "profile=default") {
+		t.Errorf("error missing profile=default: %q", msg)
+	}
+	if !strings.Contains(msg, "missing.sock") {
+		t.Errorf("error missing socket path: %q", msg)
+	}
+}
+
+func TestClient_ConnectError_HintsOtherProfileWhenLive(t *testing.T) {
+	// Simulate the user being in ATTN_PROFILE=dev but the default daemon is
+	// running. We fake a "default" daemon by listening on the default
+	// profile's socket path, and point dev at a missing socket.
+	//
+	// Unix socket paths on macOS are limited to ~104 chars, so we put the
+	// fake HOME under /tmp instead of using t.TempDir().
+	tmp, err := os.MkdirTemp("/tmp", "attn-client-")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmp) })
+
+	t.Setenv("HOME", tmp)            // so SocketPathForProfile("") → $tmp/.attn/attn.sock
+	t.Setenv("ATTN_PROFILE", "dev")  // current profile is dev
+	t.Setenv("ATTN_SOCKET_PATH", "") // don't let an env override mask the default resolution
+	config.ReloadForTesting()
+
+	// Create the "other" (default) socket directory and listen on it.
+	defaultDir := filepath.Join(tmp, ".attn")
+	if err := os.MkdirAll(defaultDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defaultSock := filepath.Join(defaultDir, "attn.sock")
+	ln, err := net.Listen("unix", defaultSock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	// The dev profile's expected socket doesn't exist.
+	devSock := filepath.Join(tmp, ".attn-dev", "attn.sock")
+	c := New(devSock)
+	err = c.Register("id", "label", "/tmp")
+	if err == nil {
+		t.Fatal("expected error when dev daemon not running")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "profile=dev") {
+		t.Errorf("error missing profile=dev: %q", msg)
+	}
+	if !strings.Contains(msg, "hint:") {
+		t.Errorf("error missing cross-profile hint: %q", msg)
+	}
+	if !strings.Contains(msg, "default daemon is listening") {
+		t.Errorf("error should hint about default daemon: %q", msg)
 	}
 }
 

--- a/internal/config/banner.go
+++ b/internal/config/banner.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PrintProfileBanner writes a single-line banner to w when a non-default
+// ATTN_PROFILE is active. No-op on the default profile so regular users
+// never see it. Call from CLI entry points that interact with daemon
+// state — NOT from hook commands (they run on every Claude action and
+// would flood output).
+func PrintProfileBanner(w io.Writer) {
+	profile := Profile()
+	if profile == "" {
+		return
+	}
+	fmt.Fprintf(w, "[attn profile=%s socket=%s port=%s]\n",
+		profile,
+		collapseHome(SocketPath()),
+		WSPort(),
+	)
+}
+
+func collapseHome(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+	home = filepath.Clean(home)
+	path = filepath.Clean(path)
+	if path == home {
+		return "~"
+	}
+	if strings.HasPrefix(path, home+string(filepath.Separator)) {
+		return "~" + path[len(home):]
+	}
+	return path
+}

--- a/internal/config/banner.go
+++ b/internal/config/banner.go
@@ -20,23 +20,27 @@ func PrintProfileBanner(w io.Writer) {
 	}
 	fmt.Fprintf(w, "[attn profile=%s socket=%s port=%s]\n",
 		profile,
-		collapseHome(SocketPath()),
+		CollapseHome(SocketPath()),
 		WSPort(),
 	)
 }
 
-func collapseHome(path string) string {
+// CollapseHome returns `path` with the user's home directory replaced by
+// a leading "~". Used by the CLI banner and "no daemon at X" error
+// messages to keep paths readable. Returns `path` unchanged if it
+// doesn't live under $HOME or if $HOME can't be resolved.
+func CollapseHome(path string) string {
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return path
 	}
 	home = filepath.Clean(home)
-	path = filepath.Clean(path)
-	if path == home {
+	cleaned := filepath.Clean(path)
+	if cleaned == home {
 		return "~"
 	}
-	if strings.HasPrefix(path, home+string(filepath.Separator)) {
-		return "~" + path[len(home):]
+	if strings.HasPrefix(cleaned, home+string(filepath.Separator)) {
+		return "~" + cleaned[len(home):]
 	}
 	return path
 }

--- a/internal/config/banner_test.go
+++ b/internal/config/banner_test.go
@@ -42,11 +42,12 @@ func TestCollapseHome(t *testing.T) {
 		"/Users/victor":                     "~",
 		"/Users/victor/.attn-dev":           "~/.attn-dev",
 		"/Users/victor/.attn-dev/attn.sock": "~/.attn-dev/attn.sock",
+		"/Users/victor/":                    "~",
 		"/tmp/other":                        "/tmp/other",
 	}
 	for in, want := range cases {
-		if got := collapseHome(in); got != want {
-			t.Errorf("collapseHome(%q) = %q, want %q", in, got, want)
+		if got := CollapseHome(in); got != want {
+			t.Errorf("CollapseHome(%q) = %q, want %q", in, got, want)
 		}
 	}
 }

--- a/internal/config/banner_test.go
+++ b/internal/config/banner_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPrintProfileBanner_NoopForDefault(t *testing.T) {
+	t.Setenv("ATTN_PROFILE", "")
+	var buf bytes.Buffer
+	PrintProfileBanner(&buf)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for default profile, got %q", buf.String())
+	}
+}
+
+func TestPrintProfileBanner_MentionsProfileSocketAndPort(t *testing.T) {
+	t.Setenv("ATTN_PROFILE", "dev")
+	// Let ATTN_WS_PORT fall through to the profile default.
+	t.Setenv("ATTN_WS_PORT", "")
+	var buf bytes.Buffer
+	PrintProfileBanner(&buf)
+	got := buf.String()
+	if !strings.Contains(got, "profile=dev") {
+		t.Errorf("banner missing profile= field: %q", got)
+	}
+	if !strings.Contains(got, "socket=") {
+		t.Errorf("banner missing socket= field: %q", got)
+	}
+	if !strings.Contains(got, "port=29849") {
+		t.Errorf("banner missing port=29849: %q", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("banner should end with newline, got %q", got)
+	}
+}
+
+func TestCollapseHome(t *testing.T) {
+	t.Setenv("HOME", "/Users/victor")
+	cases := map[string]string{
+		"/Users/victor":                     "~",
+		"/Users/victor/.attn-dev":           "~/.attn-dev",
+		"/Users/victor/.attn-dev/attn.sock": "~/.attn-dev/attn.sock",
+		"/tmp/other":                        "/tmp/other",
+	}
+	for in, want := range cases {
+		if got := collapseHome(in); got != want {
+			t.Errorf("collapseHome(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,8 +245,8 @@ func LogPath() string {
 // WSPort returns the WebSocket/HTTP port.
 // Priority: ATTN_WS_PORT env var > per-profile default.
 // Default profile → 9849. Named profile "dev" → 29849. Any other named profile
-// gets a stable hash-derived port in [20000,29999] (avoiding 29849 for "dev"
-// and the e2e port 19849, which sits outside this range).
+// gets a stable hash-derived port in [20000,29848] (reserving 29849 for "dev";
+// the e2e port 19849 sits outside this range).
 func WSPort() string {
 	port := strings.TrimSpace(os.Getenv("ATTN_WS_PORT"))
 	if port != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,8 +2,11 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 )
@@ -46,11 +49,7 @@ func loadConfig() {
 
 	configPath := os.Getenv("ATTN_CONFIG_PATH")
 	if configPath == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return
-		}
-		configPath = filepath.Join(home, ".attn", "config.json")
+		configPath = filepath.Join(attnDir(), "config.json")
 	}
 
 	data, err := os.ReadFile(configPath)
@@ -66,13 +65,96 @@ func reloadConfig() {
 	loadConfig()
 }
 
-// attnDir returns the base directory for attn files
+// ReloadForTesting reloads configuration from disk. Exported for tests that
+// manipulate ATTN_PROFILE or ATTN_CONFIG_PATH between subtests.
+func ReloadForTesting() {
+	loadConfig()
+}
+
+var profileNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,15}$`)
+
+// Profile returns the active profile name (from ATTN_PROFILE), or "" for the
+// default profile. Invalid profile names return "" — callers that need to
+// validate should use ValidateProfile.
+func Profile() string {
+	raw := strings.TrimSpace(os.Getenv("ATTN_PROFILE"))
+	if raw == "" {
+		return ""
+	}
+	normalized := strings.ToLower(raw)
+	if !profileNamePattern.MatchString(normalized) {
+		return ""
+	}
+	return normalized
+}
+
+// ValidateProfile returns an error if ATTN_PROFILE is set to an invalid name.
+// Use this from CLI entry points to fail loudly on typos.
+func ValidateProfile() error {
+	raw := strings.TrimSpace(os.Getenv("ATTN_PROFILE"))
+	if raw == "" {
+		return nil
+	}
+	normalized := strings.ToLower(raw)
+	if !profileNamePattern.MatchString(normalized) {
+		return fmt.Errorf("invalid ATTN_PROFILE=%q: must match ^[a-z0-9][a-z0-9-]{0,15}$", raw)
+	}
+	return nil
+}
+
+// ProfileLabel returns a human-readable profile name ("default" for empty).
+func ProfileLabel() string {
+	if p := Profile(); p != "" {
+		return p
+	}
+	return "default"
+}
+
+// attnDir returns the base directory for attn files. Profile-aware:
+// default profile → ~/.attn, named profile → ~/.attn-<profile>.
 func attnDir() string {
 	home, err := os.UserHomeDir()
-	if err != nil {
-		return "/tmp/.attn"
+	base := "/tmp/.attn"
+	if err == nil {
+		base = filepath.Join(home, ".attn")
 	}
-	return filepath.Join(home, ".attn")
+	if p := Profile(); p != "" {
+		return base + "-" + p
+	}
+	return base
+}
+
+// DataDir returns the resolved per-profile data directory.
+func DataDir() string {
+	return attnDir()
+}
+
+// DataDirForProfile computes the canonical data directory for a given
+// profile name (without reading ATTN_PROFILE). Pass "" for the default
+// profile. Callers use this to probe whether the *other* profile's
+// daemon is running, for friendlier error messages.
+func DataDirForProfile(profile string) string {
+	home, err := os.UserHomeDir()
+	base := "/tmp/.attn"
+	if err == nil {
+		base = filepath.Join(home, ".attn")
+	}
+	p := strings.ToLower(strings.TrimSpace(profile))
+	if p == "" || p == "default" {
+		return base
+	}
+	if !profileNamePattern.MatchString(p) {
+		return base
+	}
+	return base + "-" + p
+}
+
+// SocketPathForProfile returns the default socket path for a given profile
+// name, independent of the current process's ATTN_PROFILE. Used for
+// cross-profile probing in error messages; does not consult env overrides
+// or the config file.
+func SocketPathForProfile(profile string) string {
+	return filepath.Join(DataDirForProfile(profile), "attn.sock")
 }
 
 // DBPath returns the SQLite database path
@@ -121,7 +203,11 @@ func StatePath() string {
 	if err != nil {
 		return "/tmp/." + binaryName + "-state.json"
 	}
-	return filepath.Join(home, "."+binaryName+"-state.json")
+	suffix := ""
+	if p := Profile(); p != "" {
+		suffix = "-" + p
+	}
+	return filepath.Join(home, "."+binaryName+"-state"+suffix+".json")
 }
 
 // LogPath returns the log file path
@@ -130,12 +216,33 @@ func LogPath() string {
 }
 
 // WSPort returns the WebSocket/HTTP port.
+// Priority: ATTN_WS_PORT env var > per-profile default.
+// Default profile → 9849. Named profile "dev" → 29849. Any other named profile
+// gets a stable hash-derived port in [20000,29999] (avoiding 29849 for "dev"
+// and the e2e port 19849, which sits outside this range).
 func WSPort() string {
 	port := strings.TrimSpace(os.Getenv("ATTN_WS_PORT"))
-	if port == "" {
-		return "9849"
+	if port != "" {
+		return port
 	}
-	return port
+	p := Profile()
+	switch p {
+	case "":
+		return "9849"
+	case "dev":
+		return "29849"
+	default:
+		return derivedProfilePort(p)
+	}
+}
+
+// derivedProfilePort maps a profile name to a stable port in [20000,29848],
+// reserving 29849 for "dev" so future named profiles never collide with it.
+func derivedProfilePort(profile string) string {
+	h := fnv.New32a()
+	h.Write([]byte(profile))
+	port := 20000 + int(h.Sum32()%9849)
+	return fmt.Sprintf("%d", port)
 }
 
 // WSBindAddress returns the interface/address the HTTP server binds to.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,13 +91,9 @@ func Profile() string {
 // ValidateProfile returns an error if ATTN_PROFILE is set to an invalid name.
 // Use this from CLI entry points to fail loudly on typos.
 func ValidateProfile() error {
-	raw := strings.TrimSpace(os.Getenv("ATTN_PROFILE"))
-	if raw == "" {
-		return nil
-	}
-	normalized := strings.ToLower(raw)
-	if !profileNamePattern.MatchString(normalized) {
-		return fmt.Errorf("invalid ATTN_PROFILE=%q: must match ^[a-z0-9][a-z0-9-]{0,15}$", raw)
+	raw := os.Getenv("ATTN_PROFILE")
+	if err := ValidateProfileName(raw); err != nil {
+		return fmt.Errorf("invalid ATTN_PROFILE=%q: must match ^[a-z0-9][a-z0-9-]{0,15}$", strings.TrimSpace(raw))
 	}
 	return nil
 }
@@ -108,6 +104,37 @@ func ProfileLabel() string {
 		return p
 	}
 	return "default"
+}
+
+// DeepLinkScheme returns the macOS URL scheme the running profile's .app
+// is registered under. Default → "attn", dev → "attn-dev". Must stay in
+// sync with the `deep-link.desktop.schemes` entries in:
+//   - app/src-tauri/tauri.conf.json         (prod)
+//   - app/src-tauri/tauri.dev.conf.json     (dev)
+//
+// Used by the CLI wrapper so `attn` in a dev-scoped shell opens
+// attn-dev.app, not attn.app.
+func DeepLinkScheme() string {
+	if p := Profile(); p == "dev" {
+		return "attn-dev"
+	}
+	return "attn"
+}
+
+// ValidateProfileName validates a profile name against the same rules
+// Profile()/ValidateProfile() apply, without consulting the environment.
+// Use this when you have a profile name from a non-env source (e.g. a
+// CLI argument) and want to reuse the validation logic.
+func ValidateProfileName(name string) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return nil
+	}
+	normalized := strings.ToLower(trimmed)
+	if !profileNamePattern.MatchString(normalized) {
+		return fmt.Errorf("invalid profile name %q: must match ^[a-z0-9][a-z0-9-]{0,15}$", name)
+	}
+	return nil
 }
 
 // attnDir returns the base directory for attn files. Profile-aware:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -250,3 +250,38 @@ func TestLegacyStatePath_SuffixedByProfile(t *testing.T) {
 		t.Errorf("StatePath() = %q, want %q", got, want)
 	}
 }
+
+func TestDeepLinkScheme(t *testing.T) {
+	t.Run("default → attn", func(t *testing.T) {
+		os.Unsetenv("ATTN_PROFILE")
+		if got := DeepLinkScheme(); got != "attn" {
+			t.Errorf("DeepLinkScheme() = %q, want %q", got, "attn")
+		}
+	})
+	t.Run("dev → attn-dev", func(t *testing.T) {
+		t.Setenv("ATTN_PROFILE", "dev")
+		if got := DeepLinkScheme(); got != "attn-dev" {
+			t.Errorf("DeepLinkScheme() = %q, want %q", got, "attn-dev")
+		}
+	})
+	t.Run("unknown profile → attn (prod scheme is safe default)", func(t *testing.T) {
+		t.Setenv("ATTN_PROFILE", "staging")
+		if got := DeepLinkScheme(); got != "attn" {
+			t.Errorf("DeepLinkScheme() = %q, want %q", got, "attn")
+		}
+	})
+}
+
+func TestValidateProfileName_PureFunction(t *testing.T) {
+	// Does NOT read the environment; only validates the argument.
+	t.Setenv("ATTN_PROFILE", "has space") // invalid env, but argument is fine
+	if err := ValidateProfileName("dev"); err != nil {
+		t.Errorf("ValidateProfileName(dev) unexpectedly errored: %v", err)
+	}
+	if err := ValidateProfileName(""); err != nil {
+		t.Errorf("ValidateProfileName(\"\") unexpectedly errored: %v", err)
+	}
+	if err := ValidateProfileName("bad name"); err == nil {
+		t.Error("ValidateProfileName(\"bad name\") should have errored")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -10,6 +11,7 @@ func TestDBPath_DefaultsToAttnDir(t *testing.T) {
 	// Clear any env vars
 	os.Unsetenv("ATTN_DB_PATH")
 	os.Unsetenv("ATTN_CONFIG_PATH")
+	os.Unsetenv("ATTN_PROFILE")
 
 	path := DBPath()
 
@@ -34,6 +36,7 @@ func TestDBPath_EnvVarOverridesDefault(t *testing.T) {
 func TestSocketPath_DefaultsToAttnDir(t *testing.T) {
 	os.Unsetenv("ATTN_SOCKET_PATH")
 	os.Unsetenv("ATTN_CONFIG_PATH")
+	os.Unsetenv("ATTN_PROFILE")
 
 	path := SocketPath()
 
@@ -57,6 +60,7 @@ func TestSocketPath_EnvVarOverridesDefault(t *testing.T) {
 
 func TestDBPath_ConfigFileOverridesDefault(t *testing.T) {
 	os.Unsetenv("ATTN_DB_PATH")
+	os.Unsetenv("ATTN_PROFILE")
 
 	// Create temp config file
 	tmpDir := t.TempDir()
@@ -106,6 +110,7 @@ func TestDBPath_EnvVarOverridesConfigFile(t *testing.T) {
 
 func TestSocketPath_ConfigFileOverridesDefault(t *testing.T) {
 	os.Unsetenv("ATTN_SOCKET_PATH")
+	os.Unsetenv("ATTN_PROFILE")
 
 	// Create temp config file
 	tmpDir := t.TempDir()
@@ -125,5 +130,123 @@ func TestSocketPath_ConfigFileOverridesDefault(t *testing.T) {
 
 	if path != "/from/config/file.sock" {
 		t.Errorf("SocketPath() = %q, want %q", path, "/from/config/file.sock")
+	}
+}
+
+// --- Profile-aware behavior ---------------------------------------------------
+
+func TestProfile_EmptyWhenUnset(t *testing.T) {
+	os.Unsetenv("ATTN_PROFILE")
+	if got := Profile(); got != "" {
+		t.Errorf("Profile() = %q, want empty", got)
+	}
+	if got := ProfileLabel(); got != "default" {
+		t.Errorf("ProfileLabel() = %q, want %q", got, "default")
+	}
+}
+
+func TestProfile_NormalizesValidName(t *testing.T) {
+	t.Setenv("ATTN_PROFILE", "  Dev  ")
+	if got := Profile(); got != "dev" {
+		t.Errorf("Profile() = %q, want %q", got, "dev")
+	}
+	if got := ProfileLabel(); got != "dev" {
+		t.Errorf("ProfileLabel() = %q, want %q", got, "dev")
+	}
+	if err := ValidateProfile(); err != nil {
+		t.Errorf("ValidateProfile() returned unexpected error: %v", err)
+	}
+}
+
+func TestValidateProfile_RejectsBadNames(t *testing.T) {
+	cases := []string{
+		"has space",
+		"has/slash",
+		"with.dot",
+		"-leadingdash",
+		"UPPER_CASE_UNDERSCORE",
+		strings.Repeat("a", 17),
+	}
+	for _, bad := range cases {
+		t.Run(bad, func(t *testing.T) {
+			t.Setenv("ATTN_PROFILE", bad)
+			if err := ValidateProfile(); err == nil {
+				t.Errorf("ValidateProfile() accepted %q, expected error", bad)
+			}
+			if got := Profile(); got != "" {
+				t.Errorf("Profile() = %q for invalid input %q, want empty", got, bad)
+			}
+		})
+	}
+}
+
+func TestAttnDir_SplitsByProfile(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	os.Unsetenv("ATTN_SOCKET_PATH")
+	os.Unsetenv("ATTN_DB_PATH")
+	os.Unsetenv("ATTN_CONFIG_PATH")
+
+	t.Setenv("ATTN_PROFILE", "dev")
+	reloadConfig()
+
+	wantDir := filepath.Join(home, ".attn-dev")
+	if got := DataDir(); got != wantDir {
+		t.Errorf("DataDir() = %q, want %q", got, wantDir)
+	}
+	if got := SocketPath(); got != filepath.Join(wantDir, "attn.sock") {
+		t.Errorf("SocketPath() = %q", got)
+	}
+	if got := DBPath(); got != filepath.Join(wantDir, "attn.db") {
+		t.Errorf("DBPath() = %q", got)
+	}
+	if got := LogPath(); got != filepath.Join(wantDir, "daemon.log") {
+		t.Errorf("LogPath() = %q", got)
+	}
+}
+
+func TestWSPort_ProfileDefaults(t *testing.T) {
+	os.Unsetenv("ATTN_WS_PORT")
+
+	cases := map[string]string{
+		"":      "9849",
+		"dev":   "29849",
+		"alpha": "", // hashed, just check it's in the right range
+	}
+	for profile, want := range cases {
+		t.Run("profile="+profile, func(t *testing.T) {
+			if profile == "" {
+				os.Unsetenv("ATTN_PROFILE")
+			} else {
+				t.Setenv("ATTN_PROFILE", profile)
+			}
+			got := WSPort()
+			if want != "" && got != want {
+				t.Errorf("WSPort() = %q, want %q", got, want)
+			}
+			if profile == "alpha" {
+				// Hash-derived; must differ from default + dev, be inside [20000,29848].
+				if got == "9849" || got == "29849" {
+					t.Errorf("hashed port for %q collided: %q", profile, got)
+				}
+			}
+		})
+	}
+}
+
+func TestWSPort_EnvOverridesProfileDefault(t *testing.T) {
+	t.Setenv("ATTN_PROFILE", "dev")
+	t.Setenv("ATTN_WS_PORT", "44444")
+	if got := WSPort(); got != "44444" {
+		t.Errorf("WSPort() = %q, want %q", got, "44444")
+	}
+}
+
+func TestLegacyStatePath_SuffixedByProfile(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	t.Setenv("ATTN_PROFILE", "dev")
+	SetBinaryName("attn")
+	want := filepath.Join(home, ".attn-state-dev.json")
+	if got := StatePath(); got != want {
+		t.Errorf("StatePath() = %q, want %q", got, want)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2910,6 +2910,13 @@ func (d *Daemon) handleHealth(w http.ResponseWriter, r *http.Request) {
 		"prs":                len(prs),
 		"ws_clients":         d.wsHub.ClientCount(),
 		"github_available":   d.githubAvailable(),
+		// Profile identity — lets clients (the app, in particular) verify
+		// they're connected to the daemon they expect and refuse to
+		// operate on a mismatch.
+		"profile":     config.ProfileLabel(),
+		"data_dir":    config.DataDir(),
+		"socket_path": config.SocketPath(),
+		"port":        config.WSPort(),
 	}
 
 	setNoStoreHeaders(w.Header())

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2676,6 +2676,20 @@ func TestDaemon_HealthEndpoint(t *testing.T) {
 	if got := resp.Header.Get("Cache-Control"); got != "no-store, max-age=0" {
 		t.Errorf("health Cache-Control = %q, want no-store, max-age=0", got)
 	}
+	// Profile identity: with no ATTN_PROFILE set, profile is "default" and
+	// port mirrors what the daemon is actually bound to.
+	if health["profile"] != "default" {
+		t.Errorf("profile = %v, want %q", health["profile"], "default")
+	}
+	if health["port"] != wsPort {
+		t.Errorf("port = %v, want %q", health["port"], wsPort)
+	}
+	if dataDir, ok := health["data_dir"].(string); !ok || dataDir == "" {
+		t.Errorf("data_dir = %v, want non-empty string", health["data_dir"])
+	}
+	if socketPath, ok := health["socket_path"].(string); !ok || socketPath == "" {
+		t.Errorf("socket_path = %v, want non-empty string", health["socket_path"])
+	}
 }
 
 func TestDaemon_WebRootServesEmbeddedClient(t *testing.T) {

--- a/internal/daemonctl/ensure.go
+++ b/internal/daemonctl/ensure.go
@@ -33,6 +33,10 @@ type healthResponse struct {
 	Protocol          string `json:"protocol"`
 	Version           string `json:"version"`
 	SourceFingerprint string `json:"source_fingerprint"`
+	Profile           string `json:"profile"`
+	DataDir           string `json:"data_dir"`
+	SocketPath        string `json:"socket_path"`
+	Port              string `json:"port"`
 }
 
 func Ensure(ctx context.Context, binaryPath string) (EnsureResult, error) {
@@ -78,6 +82,13 @@ func Ensure(ctx context.Context, binaryPath string) (EnsureResult, error) {
 }
 
 func daemonMatchesCurrentBinary(health healthResponse) bool {
+	// A daemon running under a different profile (e.g. dev answering on
+	// the default socket after a leftover state) must be restarted even
+	// if the source fingerprint matches — profile identity is stronger
+	// than binary identity.
+	if !profileMatchesCurrent(health) {
+		return false
+	}
 	currentFingerprint := normalizedFingerprint(buildinfo.SourceFingerprint)
 	if currentFingerprint != "" {
 		return normalizedFingerprint(health.SourceFingerprint) == currentFingerprint
@@ -85,9 +96,23 @@ func daemonMatchesCurrentBinary(health healthResponse) bool {
 	return strings.TrimSpace(health.Protocol) == protocol.ProtocolVersion
 }
 
+func profileMatchesCurrent(health healthResponse) bool {
+	expected := config.ProfileLabel()
+	// Older daemons predate the profile field. Treat an empty profile as
+	// "default" for backward compatibility.
+	reported := strings.TrimSpace(health.Profile)
+	if reported == "" {
+		reported = "default"
+	}
+	return reported == expected
+}
+
 func mismatchReason(healthErr error, health healthResponse) string {
 	if healthErr != nil {
 		return "health_unavailable"
+	}
+	if !profileMatchesCurrent(health) {
+		return "profile_mismatch"
 	}
 	currentFingerprint := normalizedFingerprint(buildinfo.SourceFingerprint)
 	runningFingerprint := normalizedFingerprint(health.SourceFingerprint)


### PR DESCRIPTION
## Summary

- **ATTN_PROFILE** (Go core): a single env var that derives the data dir, socket, DB, log, PID file, legacy state path, and WebSocket port per profile. Default profile behaves exactly as before (zero regression). `dev` → `~/.attn-dev/` + port 29849; other named profiles hash-derive in `[20000, 29848]`. `ATTN_SOCKET_PATH` / `ATTN_DB_PATH` / `ATTN_WS_PORT` still win as lower-level overrides.
- **`~/Applications/attn-dev.app`** (Tauri dev bundle): separate bundle identifier `com.attn.manager.dev`, productName `attn-dev`, deep-link scheme `attn-dev`, its own UI-automation server under the dev bundle's Application Support dir. The Rust shell bakes the profile at compile time (`ATTN_BUILD_PROFILE`) and propagates it into the process env before spawning the daemon. The frontend fetches `/health` before opening the WebSocket and **refuses to operate** on a profile mismatch.
- **`make dev`** is the attn-on-attn inner-loop command: build → install → start dev daemon → launch `attn-dev.app`. Bare `make` does the prod equivalent; `make install` / `make install-dev` are install-only. `make install` refuses **at parse time** if `ATTN_PROFILE` is set in the shell (before the multi-minute Tauri build, not after).
- **Profile-scoped CLI UX**: `[attn profile=dev socket=… port=…]` banner on every non-default invocation (silent for hook commands and `--version`), friendly dial-failure errors that suggest the other profile's daemon if it's running, and `attn profile-env [--fish] <name|--unset>` for shell-wide scoping (`eval "$(attn profile-env dev)"`).
- **Harness routing**: `ATTN_HARNESS_PROFILE=<name>` switches the whole real-app harness (bundle id, app path, daemon port, UI-automation manifest path) through a new `harnessProfile.mjs`. The serial matrix defaults to `dev` so it never takes over the live prod app.

Guiding principle: at every decision point, the right answer is obvious or the wrong one is impossible. Separate sockets, ports, data dirs, and bundle identifiers enforce isolation at the OS level; parse-time guards + banners make the remaining human mistakes visible before they land.

## Validation

- **638 Go tests + 387 frontend tests** pass (42 new tests across config, client, daemon, buildProfile).
- **End-to-end smoke**: `make dev` installed `attn-dev.app` with `CFBundleIdentifier=com.attn.manager.dev`. Dev daemon bound `~/.attn-dev/attn.sock` on 29849 reporting `profile=dev`, `data_dir=~/.attn-dev`. Prod daemon on 9849 completely untouched; both daemons served their own WS client.
- **UI automation round-trip**: `ATTN_HARNESS_PROFILE=dev` harness pinged the dev app successfully (`frontendReady: true, pong: true`), confirming ATTN_BUILD_PROFILE propagation through Rust shell → spawned daemon → /health all the way to the frontend and back.
- **Foot-gun guards**: verified parse-time refusal of `ATTN_PROFILE=dev make install`, correct cross-profile hints in dial-failure errors, banner placement (visible on `attn`/`attn list`/`daemon ensure`, silent on hooks).

## Test plan

- [x] `go test ./...` green
- [x] `pnpm test` green
- [x] `make dev` produces attn-dev.app and launches it
- [x] Dev + prod daemons run side-by-side with zero cross-contamination (verified via `/health` on both)
- [x] `ATTN_HARNESS_PROFILE=dev` harness ping round-trip succeeds
- [x] `ATTN_PROFILE=dev make install` refuses at parse time
- [x] `attn profile-env` emits correct bash/fish shell commands
- [x] README + AGENTS.md updated
- [x] CHANGELOG entry added
- [ ] Reviewer sanity-checks the frontend mismatch guard against a manually-mismatched daemon (optional — unit-tested)

## Known scope trims (deliberate, not oversights)

- Dev icon reuses prod icons (no tinted/badge variant yet). Bundle name + Finder entry are distinct, which is already enough visual separation in practice.
- No dynamic window-title suffix (`· profile=dev · :29849`). Static `attn-dev` from the overlay is the current indicator.
- No PS1 prompt marker from `attn profile-env`. The CLI banner on every command is already the primary signal.