### PR TITLE
feat: per-endpoint profile for remote daemons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-04-25]
+
+### Added
+- **Per-Endpoint Profile For Remote Daemons**: Remote endpoints now carry a profile (the same knob as local `ATTN_PROFILE`), so a dev-profile attn can drive a dev-profile remote daemon side-by-side with prod. Set per endpoint in Settings (defaults to the calling daemon's own profile); threads through binary install path (`~/.local/bin/attn-<profile>`), data dir (`~/.attn-<profile>/`), socket, log, and WebSocket port on the remote. Existing endpoints stay on the default profile and behave exactly as before.
+
+---
+
 ## [2026-04-23]
 
 ### Added

--- a/app/src/components/SettingsModal.css
+++ b/app/src/components/SettingsModal.css
@@ -219,6 +219,18 @@
   border: 1px solid var(--color-border);
 }
 
+.endpoint-profile-badge {
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-secondary);
+}
+
 .endpoint-status-badge.status-connected {
   color: #1f8f4c;
   background: rgba(31, 143, 76, 0.12);

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -103,7 +103,7 @@ describe('SettingsModal review loop prompts', () => {
     fireEvent.click(screen.getByText('Add Endpoint'));
 
     await waitFor(() => {
-      expect(onAddEndpoint).toHaveBeenCalledWith('gpu-box', 'user@gpu-box');
+      expect(onAddEndpoint).toHaveBeenCalledWith('gpu-box', 'user@gpu-box', '');
     });
   });
 

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -24,6 +24,7 @@ import {
   type ReviewLoopPreset,
   serializeSavedReviewLoopPresets,
 } from '../utils/reviewLoopPresets';
+import { BUILD_PROFILE } from '../utils/buildProfile';
 import './SettingsModal.css';
 
 interface SettingsModalProps {
@@ -36,8 +37,8 @@ interface SettingsModalProps {
   onUnmuteAuthor: (author: string) => void;
   settings: DaemonSettings;
   endpoints: DaemonEndpoint[];
-  onAddEndpoint: (name: string, sshTarget: string) => Promise<{ success: boolean }>;
-  onUpdateEndpoint: (endpointId: string, updates: { name?: string; ssh_target?: string; enabled?: boolean }) => Promise<{ success: boolean }>;
+  onAddEndpoint: (name: string, sshTarget: string, profile?: string) => Promise<{ success: boolean }>;
+  onUpdateEndpoint: (endpointId: string, updates: { name?: string; ssh_target?: string; enabled?: boolean; profile?: string }) => Promise<{ success: boolean }>;
   onRemoveEndpoint: (endpointId: string) => Promise<{ success: boolean }>;
   onSetEndpointRemoteWeb: (endpointId: string, enabled: boolean) => Promise<{ success: boolean }>;
   onSetSetting: (key: string, value: string) => void;
@@ -76,9 +77,11 @@ export function SettingsModal({
   const [reviewerModel, setReviewerModel] = useState(settings.reviewer_model || '');
   const [newEndpointName, setNewEndpointName] = useState('');
   const [newEndpointTarget, setNewEndpointTarget] = useState('');
+  const [newEndpointProfile, setNewEndpointProfile] = useState(BUILD_PROFILE);
   const [editingEndpointID, setEditingEndpointID] = useState<string | null>(null);
   const [editingEndpointName, setEditingEndpointName] = useState('');
   const [editingEndpointTarget, setEditingEndpointTarget] = useState('');
+  const [editingEndpointProfile, setEditingEndpointProfile] = useState('');
   const [endpointError, setEndpointError] = useState<string | null>(null);
   const [endpointActionID, setEndpointActionID] = useState<string | null>(null);
   const agentAvailability = useMemo(() => getAgentAvailability(settings), [settings]);
@@ -323,6 +326,7 @@ export function SettingsModal({
   const handleAddEndpoint = useCallback(async () => {
     const name = newEndpointName.trim();
     const sshTarget = newEndpointTarget.trim();
+    const profile = newEndpointProfile.trim();
     if (!name || !sshTarget) {
       setEndpointError('Endpoint name and SSH target are required.');
       return;
@@ -330,32 +334,36 @@ export function SettingsModal({
     setEndpointError(null);
     setEndpointActionID('new');
     try {
-      await onAddEndpoint(name, sshTarget);
+      await onAddEndpoint(name, sshTarget, profile);
       setNewEndpointName('');
       setNewEndpointTarget('');
+      setNewEndpointProfile(BUILD_PROFILE);
     } catch (error) {
       setEndpointError(error instanceof Error ? error.message : 'Failed to add endpoint');
     } finally {
       setEndpointActionID(null);
     }
-  }, [newEndpointName, newEndpointTarget, onAddEndpoint]);
+  }, [newEndpointName, newEndpointProfile, newEndpointTarget, onAddEndpoint]);
 
   const beginEditEndpoint = useCallback((endpoint: DaemonEndpoint) => {
     setEndpointError(null);
     setEditingEndpointID(endpoint.id);
     setEditingEndpointName(endpoint.name);
     setEditingEndpointTarget(endpoint.ssh_target);
+    setEditingEndpointProfile(endpoint.profile || '');
   }, []);
 
   const cancelEditEndpoint = useCallback(() => {
     setEditingEndpointID(null);
     setEditingEndpointName('');
     setEditingEndpointTarget('');
+    setEditingEndpointProfile('');
   }, []);
 
   const handleSaveEndpoint = useCallback(async (endpointId: string) => {
     const name = editingEndpointName.trim();
     const sshTarget = editingEndpointTarget.trim();
+    const profile = editingEndpointProfile.trim();
     if (!name || !sshTarget) {
       setEndpointError('Endpoint name and SSH target are required.');
       return;
@@ -363,14 +371,14 @@ export function SettingsModal({
     setEndpointError(null);
     setEndpointActionID(endpointId);
     try {
-      await onUpdateEndpoint(endpointId, { name, ssh_target: sshTarget });
+      await onUpdateEndpoint(endpointId, { name, ssh_target: sshTarget, profile });
       cancelEditEndpoint();
     } catch (error) {
       setEndpointError(error instanceof Error ? error.message : 'Failed to update endpoint');
     } finally {
       setEndpointActionID(null);
     }
-  }, [cancelEditEndpoint, editingEndpointName, editingEndpointTarget, onUpdateEndpoint]);
+  }, [cancelEditEndpoint, editingEndpointName, editingEndpointProfile, editingEndpointTarget, onUpdateEndpoint]);
 
   const handleToggleEndpoint = useCallback(async (endpoint: DaemonEndpoint) => {
     setEndpointError(null);
@@ -573,6 +581,19 @@ export function SettingsModal({
                 autoCorrect="off"
                 spellCheck={false}
               />
+              <input
+                type="text"
+                value={newEndpointProfile}
+                onChange={(e) => setNewEndpointProfile(e.target.value)}
+                placeholder="default"
+                pattern="[a-z0-9][a-z0-9-]{0,15}"
+                className="settings-input"
+                aria-label="Profile"
+                disabled={endpointActionInFlight}
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+              />
               <button
                 className="browse-btn"
                 onClick={() => void handleAddEndpoint()}
@@ -602,6 +623,7 @@ export function SettingsModal({
                       <div className="endpoint-card-header">
                         <div className="endpoint-card-title">
                           <span className="endpoint-name">{endpoint.name}</span>
+                          <span className="endpoint-profile-badge">{endpoint.profile || 'default'}</span>
                           <span className={`endpoint-status-badge status-${endpoint.status}`}>
                             {endpoint.status}
                           </span>
@@ -662,6 +684,19 @@ export function SettingsModal({
                             onChange={(e) => setEditingEndpointTarget(e.target.value)}
                             className="settings-input"
                             aria-label="Edit SSH target"
+                            disabled={endpointActionInFlight}
+                            autoCapitalize="none"
+                            autoCorrect="off"
+                            spellCheck={false}
+                          />
+                          <input
+                            type="text"
+                            value={editingEndpointProfile}
+                            onChange={(e) => setEditingEndpointProfile(e.target.value)}
+                            className="settings-input"
+                            aria-label="Edit profile"
+                            placeholder="default"
+                            pattern="[a-z0-9][a-z0-9-]{0,15}"
                             disabled={endpointActionInFlight}
                             autoCapitalize="none"
                             autoCorrect="off"

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -344,7 +344,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '54',
+        protocol_version: '55',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -420,7 +420,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '54',
+        protocol_version: '55',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -499,7 +499,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '54',
+        protocol_version: '55',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -592,7 +592,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '54',
+        protocol_version: '55',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -689,7 +689,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '54',
+        protocol_version: '55',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -772,7 +772,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '54',
+        protocol_version: '55',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -881,7 +881,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '54',
+        protocol_version: '55',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -939,7 +939,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '54',
+        protocol_version: '55',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -141,7 +141,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '54';
+const PROTOCOL_VERSION = '55';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 const INCLUDE_ATTACH_REPLAY_DEBUG_PAYLOAD = import.meta.env.VITE_UI_AUTOMATION === '1';
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -2576,7 +2576,7 @@ export function useDaemonSocket({
     ws.send(JSON.stringify({ cmd: 'set_setting', key, value }));
   }, [onSettingsUpdate]);
 
-  const sendAddEndpoint = useCallback((name: string, sshTarget: string): Promise<EndpointActionResult> => {
+  const sendAddEndpoint = useCallback((name: string, sshTarget: string, profile?: string): Promise<EndpointActionResult> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -2589,7 +2589,12 @@ export function useDaemonSocket({
       }
       const key = 'endpoint_action:add:pending';
       pendingActionsRef.current.set(key, { resolve, reject });
-      ws.send(JSON.stringify({ cmd: 'add_endpoint', name, ssh_target: sshTarget }));
+      const payload: Record<string, unknown> = { cmd: 'add_endpoint', name, ssh_target: sshTarget };
+      const trimmed = (profile ?? '').trim();
+      if (trimmed !== '') {
+        payload.profile = trimmed;
+      }
+      ws.send(JSON.stringify(payload));
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
@@ -2601,7 +2606,7 @@ export function useDaemonSocket({
 
   const sendUpdateEndpoint = useCallback((
     endpointId: string,
-    updates: { name?: string; ssh_target?: string; enabled?: boolean }
+    updates: { name?: string; ssh_target?: string; enabled?: boolean; profile?: string }
   ): Promise<EndpointActionResult> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -218,6 +218,7 @@ export enum AddCommentResultMessageEvent {
 export interface AddEndpointMessage {
     cmd:        AddEndpointMessageCmd;
     name:       string;
+    profile?:   string;
     ssh_target: string;
     [property: string]: any;
 }
@@ -654,6 +655,7 @@ export interface EndpointInfo {
     enabled?:        boolean;
     id:              string;
     name:            string;
+    profile?:        string;
     session_count?:  number;
     ssh_target:      string;
     status:          string;
@@ -687,6 +689,7 @@ export interface Endpoint {
     enabled?:        boolean;
     id:              string;
     name:            string;
+    profile?:        string;
     session_count?:  number;
     ssh_target:      string;
     status:          string;
@@ -2285,6 +2288,7 @@ export interface UpdateEndpointMessage {
     enabled?:    boolean;
     endpoint_id: string;
     name?:       string;
+    profile?:    string;
     ssh_target?: string;
     [property: string]: any;
 }
@@ -3926,6 +3930,7 @@ const typeMap: any = {
     "AddEndpointMessage": o([
         { json: "cmd", js: "cmd", typ: r("AddEndpointMessageCmd") },
         { json: "name", js: "name", typ: "" },
+        { json: "profile", js: "profile", typ: u(undefined, "") },
         { json: "ssh_target", js: "ssh_target", typ: "" },
     ], "any"),
     "AnswerReviewLoopMessage": o([
@@ -4166,6 +4171,7 @@ const typeMap: any = {
         { json: "enabled", js: "enabled", typ: u(undefined, true) },
         { json: "id", js: "id", typ: "" },
         { json: "name", js: "name", typ: "" },
+        { json: "profile", js: "profile", typ: u(undefined, "") },
         { json: "session_count", js: "session_count", typ: u(undefined, 0) },
         { json: "ssh_target", js: "ssh_target", typ: "" },
         { json: "status", js: "status", typ: "" },
@@ -4193,6 +4199,7 @@ const typeMap: any = {
         { json: "enabled", js: "enabled", typ: u(undefined, true) },
         { json: "id", js: "id", typ: "" },
         { json: "name", js: "name", typ: "" },
+        { json: "profile", js: "profile", typ: u(undefined, "") },
         { json: "session_count", js: "session_count", typ: u(undefined, 0) },
         { json: "ssh_target", js: "ssh_target", typ: "" },
         { json: "status", js: "status", typ: "" },
@@ -5076,6 +5083,7 @@ const typeMap: any = {
         { json: "enabled", js: "enabled", typ: u(undefined, true) },
         { json: "endpoint_id", js: "endpoint_id", typ: "" },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "profile", js: "profile", typ: u(undefined, "") },
         { json: "ssh_target", js: "ssh_target", typ: u(undefined, "") },
     ], "any"),
     "WebSocketEvent": o([

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,20 @@ func ValidateProfileName(name string) error {
 	return nil
 }
 
+// NormalizeProfileName validates and returns the canonical profile name
+// (lowercased, trimmed). Empty input is valid and yields "". Use this at
+// every persistence/wire boundary so the value the remote daemon sees in
+// $ATTN_PROFILE matches the value stored in the local DB — Profile() on
+// the remote lowercases, so writing a mixed-case form here would split
+// data dirs (`~/.attn-DEV` referenced in scripts vs `~/.attn-dev` written
+// by the daemon).
+func NormalizeProfileName(name string) (string, error) {
+	if err := ValidateProfileName(name); err != nil {
+		return "", err
+	}
+	return strings.ToLower(strings.TrimSpace(name)), nil
+}
+
 // attnDir returns the base directory for attn files. Profile-aware:
 // default profile → ~/.attn, named profile → ~/.attn-<profile>.
 func attnDir() string {
@@ -252,13 +266,24 @@ func WSPort() string {
 	if port != "" {
 		return port
 	}
-	p := Profile()
+	return WSPortForProfile(Profile())
+}
+
+// WSPortForProfile returns the default WebSocket port for a given profile name,
+// independent of the current process's ATTN_PROFILE / ATTN_WS_PORT. Pass "" for
+// the default profile. Used by the hub to compute the right port to talk to a
+// profile-scoped remote daemon.
+func WSPortForProfile(profile string) string {
+	p := strings.ToLower(strings.TrimSpace(profile))
 	switch p {
-	case "":
+	case "", "default":
 		return "9849"
 	case "dev":
 		return "29849"
 	default:
+		if !profileNamePattern.MatchString(p) {
+			return "9849"
+		}
 		return derivedProfilePort(p)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,18 +137,34 @@ func ValidateProfileName(name string) error {
 	return nil
 }
 
-// NormalizeProfileName validates and returns the canonical profile name
-// (lowercased, trimmed). Empty input is valid and yields "". Use this at
-// every persistence/wire boundary so the value the remote daemon sees in
-// $ATTN_PROFILE matches the value stored in the local DB — Profile() on
-// the remote lowercases, so writing a mixed-case form here would split
-// data dirs (`~/.attn-DEV` referenced in scripts vs `~/.attn-dev` written
-// by the daemon).
+// NormalizeProfileName validates and returns the canonical profile name.
+// Use this at every persistence/wire boundary.
+//
+// Two normalization rules:
+//
+//  1. Lowercase + trim, so the value the remote daemon sees in
+//     $ATTN_PROFILE matches the value stored in the local DB — Profile()
+//     on the remote lowercases, so writing a mixed-case form here would
+//     split data dirs (~/.attn-DEV referenced in scripts vs ~/.attn-dev
+//     written by the daemon).
+//
+//  2. The literal "default" maps to "". WSPortForProfile and
+//     DataDirForProfile already treat "default" as the default profile;
+//     hub helpers (remoteBinaryName, ATTN_PROFILE export, log/data dir
+//     scripts) do not. Letting "default" reach those would build
+//     ~/.local/bin/attn-default and ~/.attn-default/ on the remote while
+//     reusing port 9849 — colliding with any real default-profile daemon
+//     on the same host. Canonicalizing here keeps every downstream code
+//     path on a single representation of "the default profile".
 func NormalizeProfileName(name string) (string, error) {
 	if err := ValidateProfileName(name); err != nil {
 		return "", err
 	}
-	return strings.ToLower(strings.TrimSpace(name)), nil
+	canonical := strings.ToLower(strings.TrimSpace(name))
+	if canonical == "default" {
+		canonical = ""
+	}
+	return canonical, nil
 }
 
 // attnDir returns the base directory for attn files. Profile-aware:

--- a/internal/daemon/ws_endpoints.go
+++ b/internal/daemon/ws_endpoints.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 )
@@ -23,7 +24,16 @@ func (d *Daemon) handleAddEndpointWS(client *wsClient, msg *protocol.AddEndpoint
 		d.sendEndpointActionResult(client, "add", "", false, "endpoint manager unavailable")
 		return
 	}
-	record, err := d.hubManager.AddEndpoint(msg.Name, msg.SshTarget)
+	profile := strings.TrimSpace(protocol.Deref(msg.Profile))
+	if profile == "" {
+		profile = config.Profile()
+	}
+	canonicalProfile, err := config.NormalizeProfileName(profile)
+	if err != nil {
+		d.sendEndpointActionResult(client, "add", "", false, err.Error())
+		return
+	}
+	record, err := d.hubManager.AddEndpoint(msg.Name, msg.SshTarget, canonicalProfile)
 	if err != nil {
 		d.sendEndpointActionResult(client, "add", "", false, err.Error())
 		return
@@ -51,10 +61,17 @@ func (d *Daemon) handleUpdateEndpointWS(client *wsClient, msg *protocol.UpdateEn
 		return
 	}
 
+	if msg.Profile != nil {
+		if err := config.ValidateProfileName(*msg.Profile); err != nil {
+			d.sendEndpointActionResult(client, "update", msg.EndpointID, false, err.Error())
+			return
+		}
+	}
 	update := store.EndpointUpdate{
 		Name:      msg.Name,
 		SSHTarget: msg.SshTarget,
 		Enabled:   msg.Enabled,
+		Profile:   msg.Profile,
 	}
 	record, err := d.hubManager.UpdateEndpoint(msg.EndpointID, update)
 	if err != nil {

--- a/internal/hub/bootstrap.go
+++ b/internal/hub/bootstrap.go
@@ -43,8 +43,8 @@ func NewBootstrapper(logf func(format string, args ...interface{})) *Bootstrappe
 	return &Bootstrapper{logf: logf}
 }
 
-func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget string) error {
-	platform, err := b.detectRemotePlatform(ctx, sshTarget)
+func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget, profile string) error {
+	platform, err := b.detectRemotePlatform(ctx, sshTarget, profile)
 	if err != nil {
 		return fmt.Errorf("detect remote platform for %s: %w", sshTarget, err)
 	}
@@ -54,7 +54,7 @@ func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget string) 
 		return fmt.Errorf("determine local version: %w", err)
 	}
 
-	remoteVersion, err := b.remoteVersion(ctx, sshTarget)
+	remoteVersion, err := b.remoteVersion(ctx, sshTarget, profile)
 	if err != nil {
 		return fmt.Errorf("check remote version on %s: %w", sshTarget, err)
 	}
@@ -75,7 +75,7 @@ func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget string) 
 		if err != nil {
 			return fmt.Errorf("hash local binary for %s: %w", sshTarget, err)
 		}
-		remoteHash, err := b.remoteBinarySHA256(ctx, sshTarget)
+		remoteHash, err := b.remoteBinarySHA256(ctx, sshTarget, profile)
 		if err != nil {
 			return fmt.Errorf("hash remote binary on %s: %w", sshTarget, err)
 		}
@@ -86,13 +86,13 @@ func (b *Bootstrapper) EnsureRemoteReady(ctx context.Context, sshTarget string) 
 	}
 
 	if shouldInstall {
-		if err := b.installRemoteBinary(ctx, sshTarget, localBinary); err != nil {
+		if err := b.installRemoteBinary(ctx, sshTarget, profile, localBinary); err != nil {
 			return fmt.Errorf("install attn on %s: %w", sshTarget, err)
 		}
 		binaryUpdated = true
 	}
 
-	if err := b.ensureRemoteDaemonRunning(ctx, sshTarget, binaryUpdated); err != nil {
+	if err := b.ensureRemoteDaemonRunning(ctx, sshTarget, profile, binaryUpdated); err != nil {
 		return fmt.Errorf("ensure remote daemon on %s: %w", sshTarget, err)
 	}
 	return nil
@@ -108,8 +108,8 @@ func shouldInstallRemoteBinary(localVersion, remoteVersion string, preferSourceB
 	return false
 }
 
-func (b *Bootstrapper) detectRemotePlatform(ctx context.Context, sshTarget string) (RemotePlatform, error) {
-	out, err := runSSH(ctx, sshTarget, "uname -sm")
+func (b *Bootstrapper) detectRemotePlatform(ctx context.Context, sshTarget, profile string) (RemotePlatform, error) {
+	out, err := runSSH(ctx, sshTarget, profile, "uname -sm")
 	if err != nil {
 		return RemotePlatform{}, err
 	}
@@ -131,7 +131,8 @@ func (b *Bootstrapper) detectRemotePlatform(ctx context.Context, sshTarget strin
 	}
 }
 
-func (b *Bootstrapper) remoteVersion(ctx context.Context, sshTarget string) (string, error) {
+func (b *Bootstrapper) remoteVersion(ctx context.Context, sshTarget, profile string) (string, error) {
+	binName := remoteBinaryName(profile)
 	script := fmt.Sprintf(`
 ATTN_BIN="${ATTN_REMOTE_ATTN_BIN:-$HOME/.local/bin/%s}"
 if [ ! -x "$ATTN_BIN" ] && [ -z "${ATTN_REMOTE_ATTN_BIN:-}" ]; then
@@ -142,8 +143,8 @@ if [ -z "$ATTN_BIN" ] || [ ! -x "$ATTN_BIN" ]; then
   exit 0
 fi
 "$ATTN_BIN" --version 2>/dev/null || printf NOT_FOUND
-`, config.BinaryName(), config.BinaryName())
-	out, err := runSSH(ctx, sshTarget, script)
+`, binName, binName)
+	out, err := runSSH(ctx, sshTarget, profile, script)
 	if err != nil {
 		return "", err
 	}
@@ -266,7 +267,8 @@ func fileSHA256(path string) (string, error) {
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
-func (b *Bootstrapper) remoteBinarySHA256(ctx context.Context, sshTarget string) (string, error) {
+func (b *Bootstrapper) remoteBinarySHA256(ctx context.Context, sshTarget, profile string) (string, error) {
+	binName := remoteBinaryName(profile)
 	script := fmt.Sprintf(`
 ATTN_BIN="${ATTN_REMOTE_ATTN_BIN:-$HOME/.local/bin/%s}"
 if [ ! -x "$ATTN_BIN" ] && [ -z "${ATTN_REMOTE_ATTN_BIN:-}" ]; then
@@ -285,8 +287,8 @@ if command -v shasum >/dev/null 2>&1; then
   exit 0
 fi
 printf NO_HASH_TOOL
-`, config.BinaryName(), config.BinaryName())
-	out, err := runSSH(ctx, sshTarget, script)
+`, binName, binName)
+	out, err := runSSH(ctx, sshTarget, profile, script)
 	if err != nil {
 		return "", err
 	}
@@ -387,10 +389,10 @@ func (b *Bootstrapper) buildBinaryFromSource(ctx context.Context, platform Remot
 	return nil
 }
 
-func resolveRemoteInstallPath(remoteHome, override string) string {
+func resolveRemoteInstallPath(remoteHome, override, profile string) string {
 	path := strings.TrimSpace(override)
 	if path == "" {
-		return filepath.Join(remoteHome, ".local", "bin", config.BinaryName())
+		return filepath.Join(remoteHome, ".local", "bin", remoteBinaryName(profile))
 	}
 	if strings.HasPrefix(path, "~/") {
 		return filepath.Join(remoteHome, path[2:])
@@ -398,15 +400,16 @@ func resolveRemoteInstallPath(remoteHome, override string) string {
 	return path
 }
 
-func (b *Bootstrapper) installRemoteBinary(ctx context.Context, sshTarget, localBinary string) error {
-	remoteHome, err := runSSH(ctx, sshTarget, `printf '%s' "$HOME"`)
+func (b *Bootstrapper) installRemoteBinary(ctx context.Context, sshTarget, profile, localBinary string) error {
+	remoteHome, err := runSSH(ctx, sshTarget, profile, `printf '%s' "$HOME"`)
 	if err != nil {
 		return err
 	}
-	remoteInstallPath := resolveRemoteInstallPath(strings.TrimSpace(remoteHome), os.Getenv("ATTN_REMOTE_ATTN_BIN"))
+	remoteInstallPath := resolveRemoteInstallPath(strings.TrimSpace(remoteHome), os.Getenv("ATTN_REMOTE_ATTN_BIN"), profile)
 	remoteInstallDir := filepath.Dir(remoteInstallPath)
 	remoteTmpPath := filepath.Join("/tmp", fmt.Sprintf("%s.%d.%d.tmp", filepath.Base(remoteInstallPath), os.Getpid(), time.Now().UnixNano()))
-	if _, err := runSSH(ctx, sshTarget, fmt.Sprintf("mkdir -p %s ~/.attn", shellQuote(remoteInstallDir))); err != nil {
+	attnDir := remoteAttnDirShell(profile)
+	if _, err := runSSH(ctx, sshTarget, profile, fmt.Sprintf("mkdir -p %s %s", shellQuote(remoteInstallDir), attnDir)); err != nil {
 		return err
 	}
 	file, err := os.Open(localBinary)
@@ -417,7 +420,7 @@ func (b *Bootstrapper) installRemoteBinary(ctx context.Context, sshTarget, local
 	cmd := exec.CommandContext(
 		ctx,
 		"ssh",
-		append(sshBaseArgs(sshTarget), remoteShellCommand(fmt.Sprintf("cat > %s", shellQuote(remoteTmpPath))))...,
+		append(sshBaseArgs(sshTarget), remoteShellCommand(profile, fmt.Sprintf("cat > %s", shellQuote(remoteTmpPath))))...,
 	)
 	cmd.Stdin = file
 	out, err := cmd.CombinedOutput()
@@ -427,6 +430,7 @@ func (b *Bootstrapper) installRemoteBinary(ctx context.Context, sshTarget, local
 	if probe, probeErr := runSSH(
 		ctx,
 		sshTarget,
+		profile,
 		fmt.Sprintf("if [ -f %s ]; then wc -c < %s; else printf MISSING; fi", shellQuote(remoteTmpPath), shellQuote(remoteTmpPath)),
 	); probeErr == nil {
 		b.logf("remote binary upload probe: target=%s tmp=%s result=%s", sshTarget, remoteTmpPath, strings.TrimSpace(probe))
@@ -434,6 +438,7 @@ func (b *Bootstrapper) installRemoteBinary(ctx context.Context, sshTarget, local
 	_, err = runSSH(
 		ctx,
 		sshTarget,
+		profile,
 		fmt.Sprintf(
 			"install -m 755 %s %s && rm -f %s",
 			shellQuote(remoteTmpPath),
@@ -444,15 +449,34 @@ func (b *Bootstrapper) installRemoteBinary(ctx context.Context, sshTarget, local
 	return err
 }
 
+// remoteAttnDirShell returns a shell expression that resolves to the
+// remote attn data dir for the given profile. The script picks the path up
+// from $ATTN_PROFILE (which remoteShellEnvScript exports), so it stays
+// self-contained when fed through `sh -lc`.
+func remoteAttnDirShell(profile string) string {
+	if strings.TrimSpace(profile) == "" {
+		return `"$HOME/.attn"`
+	}
+	// Even when we know the profile here, prefer reading $ATTN_PROFILE in the
+	// remote shell so the script and the env script stay consistent.
+	return `"$HOME/.attn-${ATTN_PROFILE}"`
+}
+
 func remoteSocketConfigScript() string {
 	return `
-config_path="${ATTN_CONFIG_PATH:-$HOME/.attn/config.json}"
+attn_profile="${ATTN_PROFILE:-}"
+if [ -n "$attn_profile" ]; then
+  attn_dir="$HOME/.attn-$attn_profile"
+else
+  attn_dir="$HOME/.attn"
+fi
+config_path="${ATTN_CONFIG_PATH:-$attn_dir/config.json}"
 socket_path="${ATTN_SOCKET_PATH:-}"
 if [ -z "$socket_path" ] && [ -f "$config_path" ]; then
   socket_path="$(sed -n 's/.*"socket_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$config_path" | head -n 1)"
 fi
 if [ -z "$socket_path" ]; then
-  socket_path="$HOME/.attn/attn.sock"
+  socket_path="$attn_dir/attn.sock"
 fi
 case "$socket_path" in
   "~/"*) socket_path="$HOME/${socket_path#~/}" ;;
@@ -482,11 +506,12 @@ type remoteDaemonState struct {
 	PID      string
 }
 
-func (b *Bootstrapper) probeRemoteDaemon(ctx context.Context, sshTarget string) (remoteDaemonState, error) {
-	script := remoteSocketConfigScript() + `
-listener_pid="$(ss -H -ltnp "( sport = :${ATTN_WS_PORT:-9849} )" 2>/dev/null | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' | head -n 1)"
+func (b *Bootstrapper) probeRemoteDaemon(ctx context.Context, sshTarget, profile string) (remoteDaemonState, error) {
+	port := config.WSPortForProfile(profile)
+	script := remoteSocketConfigScript() + fmt.Sprintf(`
+listener_pid="$(ss -H -ltnp "( sport = :${ATTN_WS_PORT:-%s} )" 2>/dev/null | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' | head -n 1)"
 if [ -n "$listener_pid" ]; then
-  printf 'running %s\n' "$listener_pid"
+  printf 'running %%s\n' "$listener_pid"
   exit 0
 fi
 if [ -S "$socket_path" ] && [ -f "$pid_path" ]; then
@@ -499,8 +524,8 @@ if [ -S "$socket_path" ] && [ -f "$pid_path" ]; then
   exit 0
 fi
 printf 'stopped\n'
-`
-	out, err := runSSH(ctx, sshTarget, script)
+`, port)
+	out, err := runSSH(ctx, sshTarget, profile, script)
 	if err != nil {
 		return remoteDaemonState{}, err
 	}
@@ -534,28 +559,28 @@ printf 'stopped\n'
 	}
 }
 
-func (b *Bootstrapper) ensureRemoteDaemonRunning(ctx context.Context, sshTarget string, binaryUpdated bool) error {
-	state, err := b.probeRemoteDaemon(ctx, sshTarget)
+func (b *Bootstrapper) ensureRemoteDaemonRunning(ctx context.Context, sshTarget, profile string, binaryUpdated bool) error {
+	state, err := b.probeRemoteDaemon(ctx, sshTarget, profile)
 	if err != nil {
 		return err
 	}
 
 	if state.Stale {
-		if _, err := runSSH(ctx, sshTarget, remoteSocketConfigScript()+`rm -f "$socket_path" "$pid_path"`); err != nil {
+		if _, err := runSSH(ctx, sshTarget, profile, remoteSocketConfigScript()+`rm -f "$socket_path" "$pid_path"`); err != nil {
 			return err
 		}
 		state = remoteDaemonState{}
 	}
 
 	if (state.Running || state.Starting) && binaryUpdated {
-		if err := b.restartRemoteDaemon(ctx, sshTarget, state.PID); err != nil {
+		if err := b.restartRemoteDaemon(ctx, sshTarget, profile, state.PID); err != nil {
 			return err
 		}
 		state = remoteDaemonState{}
 	}
 
 	if !state.Running && !state.Starting {
-		if err := b.startRemoteDaemon(ctx, sshTarget); err != nil {
+		if err := b.startRemoteDaemon(ctx, sshTarget, profile); err != nil {
 			return err
 		}
 	}
@@ -563,7 +588,7 @@ func (b *Bootstrapper) ensureRemoteDaemonRunning(ctx context.Context, sshTarget 
 	deadline := time.Now().Add(remoteDaemonReadyTimeout)
 	for time.Now().Before(deadline) {
 		probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		current, err := b.probeRemoteDaemon(probeCtx, sshTarget)
+		current, err := b.probeRemoteDaemon(probeCtx, sshTarget, profile)
 		cancel()
 		if err == nil && current.Running {
 			return nil
@@ -573,9 +598,13 @@ func (b *Bootstrapper) ensureRemoteDaemonRunning(ctx context.Context, sshTarget 
 	return fmt.Errorf("daemon did not become ready")
 }
 
-func (b *Bootstrapper) startRemoteDaemon(ctx context.Context, sshTarget string) error {
-	launchScript := fmt.Sprintf(`
-mkdir -p ~/.attn
+// startRemoteDaemonScript returns the shell script that launches the remote
+// daemon for a given profile. Pure string for testability.
+func startRemoteDaemonScript(profile string) string {
+	binName := remoteBinaryName(profile)
+	attnDir := remoteAttnDirShell(profile)
+	return fmt.Sprintf(`
+mkdir -p %s
 ATTN_BIN="${ATTN_REMOTE_ATTN_BIN:-$HOME/.local/bin/%s}"
 if [ ! -x "$ATTN_BIN" ] && [ -z "${ATTN_REMOTE_ATTN_BIN:-}" ]; then
   ATTN_BIN="$(command -v %s 2>/dev/null || true)"
@@ -584,22 +613,26 @@ if [ -z "$ATTN_BIN" ] || [ ! -x "$ATTN_BIN" ]; then
   printf 'missing attn binary\n' >&2
   exit 127
 fi
-nohup setsid "$ATTN_BIN" daemon </dev/null >>~/.attn/daemon.log 2>&1 &
-`, config.BinaryName(), config.BinaryName())
+nohup setsid "$ATTN_BIN" daemon </dev/null >>%s/daemon.log 2>&1 &
+`, attnDir, binName, binName, attnDir)
+}
+
+func (b *Bootstrapper) startRemoteDaemon(ctx context.Context, sshTarget, profile string) error {
 	_, err := runSSH(
 		ctx,
 		sshTarget,
-		launchScript,
+		profile,
+		startRemoteDaemonScript(profile),
 	)
 	return err
 }
 
-func (b *Bootstrapper) StopRemoteDaemon(ctx context.Context, sshTarget string) error {
-	if !remoteHarnessCleanupEnabled() {
-		return nil
-	}
-	stopScript := remoteSocketConfigScript() + `
-listener_pid="$(ss -H -ltnp "( sport = :${ATTN_WS_PORT:-9849} )" 2>/dev/null | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' | head -n 1)"
+// stopRemoteDaemonScript returns the shell script that stops the remote daemon
+// for a given profile.
+func stopRemoteDaemonScript(profile string) string {
+	port := config.WSPortForProfile(profile)
+	return remoteSocketConfigScript() + fmt.Sprintf(`
+listener_pid="$(ss -H -ltnp "( sport = :${ATTN_WS_PORT:-%s} )" 2>/dev/null | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' | head -n 1)"
 pid_file_pid=""
 if [ -f "$pid_path" ]; then
   pid_file_pid="$(cat "$pid_path" 2>/dev/null || true)"
@@ -619,19 +652,25 @@ for pid in $seen_pids; do
   kill -9 "$pid" 2>/dev/null || true
 done
 rm -f "$socket_path" "$pid_path"
-`
-	_, err := runSSH(ctx, sshTarget, stopScript)
+`, port)
+}
+
+func (b *Bootstrapper) StopRemoteDaemon(ctx context.Context, sshTarget, profile string) error {
+	if !remoteHarnessCleanupEnabled() {
+		return nil
+	}
+	_, err := runSSH(ctx, sshTarget, profile, stopRemoteDaemonScript(profile))
 	return err
 }
 
-func (b *Bootstrapper) restartRemoteDaemon(ctx context.Context, sshTarget, pid string) error {
+func (b *Bootstrapper) restartRemoteDaemon(ctx context.Context, sshTarget, profile, pid string) error {
 	if strings.TrimSpace(pid) != "" {
-		_, _ = runSSH(ctx, sshTarget, fmt.Sprintf("kill %s 2>/dev/null || true", shellQuote(pid)))
+		_, _ = runSSH(ctx, sshTarget, profile, fmt.Sprintf("kill %s 2>/dev/null || true", shellQuote(pid)))
 		time.Sleep(500 * time.Millisecond)
-		_, _ = runSSH(ctx, sshTarget, fmt.Sprintf("kill -9 %s 2>/dev/null || true", shellQuote(pid)))
+		_, _ = runSSH(ctx, sshTarget, profile, fmt.Sprintf("kill -9 %s 2>/dev/null || true", shellQuote(pid)))
 	}
-	if _, err := runSSH(ctx, sshTarget, remoteSocketConfigScript()+`rm -f "$socket_path" "$pid_path"`); err != nil {
+	if _, err := runSSH(ctx, sshTarget, profile, remoteSocketConfigScript()+`rm -f "$socket_path" "$pid_path"`); err != nil {
 		return err
 	}
-	return b.startRemoteDaemon(ctx, sshTarget)
+	return b.startRemoteDaemon(ctx, sshTarget, profile)
 }

--- a/internal/hub/bootstrap_test.go
+++ b/internal/hub/bootstrap_test.go
@@ -1,6 +1,9 @@
 package hub
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestShouldInstallRemoteBinary(t *testing.T) {
 	tests := []struct {
@@ -87,5 +90,80 @@ func TestRemoteHarnessCleanupEnabled(t *testing.T) {
 	t.Setenv("ATTN_REMOTE_SOCKET_PATH", "/home/victor/.attn/harness/run-456/attn.sock")
 	if !remoteHarnessCleanupEnabled() {
 		t.Fatal("remoteHarnessCleanupEnabled() = false, want true with harness socket override")
+	}
+}
+
+func TestStartRemoteDaemonScript_DefaultProfile(t *testing.T) {
+	script := startRemoteDaemonScript("")
+	if !strings.Contains(script, `mkdir -p "$HOME/.attn"`) {
+		t.Fatalf("default script missing default attn dir: %s", script)
+	}
+	if !strings.Contains(script, "$HOME/.local/bin/attn") {
+		t.Fatalf("default script missing default binary path: %s", script)
+	}
+	if strings.Contains(script, "$HOME/.local/bin/attn-") {
+		t.Fatalf("default script unexpectedly references named-profile binary: %s", script)
+	}
+	if !strings.Contains(script, `>>"$HOME/.attn"/daemon.log`) {
+		t.Fatalf("default script missing default log path: %s", script)
+	}
+}
+
+func TestStartRemoteDaemonScript_NamedProfile(t *testing.T) {
+	script := startRemoteDaemonScript("dev")
+	if !strings.Contains(script, "$HOME/.local/bin/attn-dev") {
+		t.Fatalf("dev script missing dev binary path: %s", script)
+	}
+	if !strings.Contains(script, `mkdir -p "$HOME/.attn-${ATTN_PROFILE}"`) {
+		t.Fatalf("dev script missing profile-aware data dir: %s", script)
+	}
+	if !strings.Contains(script, `>>"$HOME/.attn-${ATTN_PROFILE}"/daemon.log`) {
+		t.Fatalf("dev script missing profile-aware log path: %s", script)
+	}
+}
+
+func TestStopRemoteDaemonScript_PortByProfile(t *testing.T) {
+	defaultScript := stopRemoteDaemonScript("")
+	if !strings.Contains(defaultScript, "${ATTN_WS_PORT:-9849}") {
+		t.Fatalf("default stop script should fall back to 9849: %s", defaultScript)
+	}
+
+	devScript := stopRemoteDaemonScript("dev")
+	if !strings.Contains(devScript, "${ATTN_WS_PORT:-29849}") {
+		t.Fatalf("dev stop script should fall back to 29849: %s", devScript)
+	}
+}
+
+func TestRemoteSocketConfigScriptHonorsProfileEnv(t *testing.T) {
+	script := remoteSocketConfigScript()
+	if !strings.Contains(script, `attn_profile="${ATTN_PROFILE:-}"`) {
+		t.Fatalf("socket-config script missing ATTN_PROFILE read: %s", script)
+	}
+	if !strings.Contains(script, `attn_dir="$HOME/.attn-$attn_profile"`) {
+		t.Fatalf("socket-config script missing named-profile data dir: %s", script)
+	}
+	if !strings.Contains(script, `attn_dir="$HOME/.attn"`) {
+		t.Fatalf("socket-config script missing default data dir: %s", script)
+	}
+}
+
+func TestResolveRemoteInstallPath(t *testing.T) {
+	cases := []struct {
+		remoteHome string
+		override   string
+		profile    string
+		want       string
+	}{
+		{"/home/v", "", "", "/home/v/.local/bin/attn"},
+		{"/home/v", "", "dev", "/home/v/.local/bin/attn-dev"},
+		{"/home/v", "/opt/bin/attn", "dev", "/opt/bin/attn"},
+		{"/home/v", "~/bin/attn", "", "/home/v/bin/attn"},
+	}
+	for _, c := range cases {
+		got := resolveRemoteInstallPath(c.remoteHome, c.override, c.profile)
+		if got != c.want {
+			t.Fatalf("resolveRemoteInstallPath(%q,%q,%q) = %q, want %q",
+				c.remoteHome, c.override, c.profile, got, c.want)
+		}
 	}
 }

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -133,13 +133,17 @@ func NewManager(
 }
 
 func infoFromRecord(record store.EndpointRecord) protocol.EndpointInfo {
-	return protocol.EndpointInfo{
+	info := protocol.EndpointInfo{
 		ID:        record.ID,
 		Name:      record.Name,
 		SshTarget: record.SSHTarget,
 		Status:    "disconnected",
 		Enabled:   protocol.Ptr(record.Enabled),
 	}
+	if strings.TrimSpace(record.Profile) != "" {
+		info.Profile = protocol.Ptr(record.Profile)
+	}
+	return info
 }
 
 func (m *Manager) Start(parent context.Context) {
@@ -159,7 +163,7 @@ func (m *Manager) Start(parent context.Context) {
 
 func (m *Manager) Stop() {
 	changed := false
-	shutdownTargets := make([]string, 0)
+	shutdownTargets := make([]isolatedShutdownTarget, 0)
 	seenTargets := make(map[string]struct{})
 	m.mu.Lock()
 	if m.cancel != nil {
@@ -167,9 +171,10 @@ func (m *Manager) Stop() {
 	}
 	for _, runtime := range m.runtimes {
 		changed = changed || len(runtime.sessions) > 0
-		if target := isolatedRemoteShutdownTarget(runtime.record); target != "" {
-			if _, exists := seenTargets[target]; !exists {
-				seenTargets[target] = struct{}{}
+		if target := isolatedRemoteShutdownTarget(runtime.record); target.Target != "" {
+			key := target.Target + "|" + target.Profile
+			if _, exists := seenTargets[key]; !exists {
+				seenTargets[key] = struct{}{}
 				shutdownTargets = append(shutdownTargets, target)
 			}
 		}
@@ -196,6 +201,11 @@ func (m *Manager) List() []protocol.EndpointInfo {
 			info.Name = record.Name
 			info.SshTarget = record.SSHTarget
 			info.Enabled = protocol.Ptr(record.Enabled)
+			if strings.TrimSpace(record.Profile) != "" {
+				info.Profile = protocol.Ptr(record.Profile)
+			} else {
+				info.Profile = nil
+			}
 		}
 		out = append(out, info)
 	}
@@ -208,9 +218,10 @@ func (m *Manager) List() []protocol.EndpointInfo {
 	return out
 }
 
-func (m *Manager) AddEndpoint(name, sshTarget string) (*store.EndpointRecord, error) {
+func (m *Manager) AddEndpoint(name, sshTarget, profile string) (*store.EndpointRecord, error) {
 	name = strings.TrimSpace(name)
 	sshTarget = strings.TrimSpace(sshTarget)
+	profile = strings.TrimSpace(profile)
 	if name == "" {
 		return nil, fmt.Errorf("endpoint name is required")
 	}
@@ -218,7 +229,7 @@ func (m *Manager) AddEndpoint(name, sshTarget string) (*store.EndpointRecord, er
 		return nil, fmt.Errorf("ssh target is required")
 	}
 
-	record, err := m.store.AddEndpoint(name, sshTarget)
+	record, err := m.store.AddEndpoint(name, sshTarget, profile)
 	if err != nil {
 		return nil, err
 	}
@@ -292,6 +303,11 @@ func (m *Manager) UpdateEndpoint(id string, update store.EndpointUpdate) (*store
 	info.Name = record.Name
 	info.SshTarget = record.SSHTarget
 	info.Enabled = protocol.Ptr(record.Enabled)
+	if strings.TrimSpace(record.Profile) != "" {
+		info.Profile = protocol.Ptr(record.Profile)
+	} else {
+		info.Profile = nil
+	}
 	if info.Status == "" {
 		info.Status = "disconnected"
 	}
@@ -312,7 +328,7 @@ func (m *Manager) UpdateEndpoint(id string, update store.EndpointUpdate) (*store
 
 func (m *Manager) RemoveEndpoint(id string) error {
 	changed := false
-	shutdownTarget := ""
+	var shutdownTarget isolatedShutdownTarget
 	m.mu.Lock()
 	if runtime, ok := m.runtimes[id]; ok {
 		changed = len(runtime.sessions) > 0
@@ -321,45 +337,44 @@ func (m *Manager) RemoveEndpoint(id string) error {
 		delete(m.runtimes, id)
 	}
 	m.mu.Unlock()
-	m.stopIsolatedRemoteDaemons(nonEmptyStrings(shutdownTarget))
+	if shutdownTarget.Target != "" {
+		m.stopIsolatedRemoteDaemons([]isolatedShutdownTarget{shutdownTarget})
+	}
 	if changed {
 		m.publishSessionsChanged()
 	}
 	return m.store.RemoveEndpoint(id)
 }
 
-func isolatedRemoteShutdownTarget(record store.EndpointRecord) string {
+type isolatedShutdownTarget struct {
+	Target  string
+	Profile string
+}
+
+func isolatedRemoteShutdownTarget(record store.EndpointRecord) isolatedShutdownTarget {
 	if !remoteHarnessCleanupEnabled() {
-		return ""
+		return isolatedShutdownTarget{}
 	}
 	target := strings.TrimSpace(record.SSHTarget)
 	if target == "" {
-		return ""
+		return isolatedShutdownTarget{}
 	}
-	return target
+	return isolatedShutdownTarget{Target: target, Profile: strings.TrimSpace(record.Profile)}
 }
 
-func nonEmptyStrings(values ...string) []string {
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		if strings.TrimSpace(value) == "" {
-			continue
-		}
-		out = append(out, value)
-	}
-	return out
-}
-
-func (m *Manager) stopIsolatedRemoteDaemons(targets []string) {
+func (m *Manager) stopIsolatedRemoteDaemons(targets []isolatedShutdownTarget) {
 	if m == nil || m.bootstrapper == nil || len(targets) == 0 || !remoteHarnessCleanupEnabled() {
 		return
 	}
 	for _, target := range targets {
+		if target.Target == "" {
+			continue
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		err := m.bootstrapper.StopRemoteDaemon(ctx, target)
+		err := m.bootstrapper.StopRemoteDaemon(ctx, target.Target, target.Profile)
 		cancel()
 		if err != nil {
-			m.logf("remote harness daemon cleanup failed for %s: %v", target, err)
+			m.logf("remote harness daemon cleanup failed for %s: %v", target.Target, err)
 		}
 	}
 }
@@ -420,7 +435,7 @@ func (m *Manager) runEndpointLoop(ctx context.Context, id string) {
 		if m.consumeBootstrapFlag(id) {
 			m.updateStatus(id, "bootstrapping", "Installing remote binary", nil, nil)
 			bootCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-			err := m.bootstrapper.EnsureRemoteReady(bootCtx, record.SSHTarget)
+			err := m.bootstrapper.EnsureRemoteReady(bootCtx, record.SSHTarget, record.Profile)
 			cancel()
 			if err != nil {
 				m.updateStatus(id, "error", err.Error(), nil, nil)
@@ -434,12 +449,12 @@ func (m *Manager) runEndpointLoop(ctx context.Context, id string) {
 
 		// Try to connect; if it fails the daemon is not running — bootstrap and retry.
 		m.updateStatus(id, "connecting", "Connecting to remote daemon", nil, nil)
-		conn, cmd, err := connectViaSSH(ctx, record.SSHTarget, config.WSAuthToken())
+		conn, cmd, err := connectViaSSH(ctx, record.SSHTarget, config.WSAuthToken(), record.Profile)
 		if err != nil {
 			// Daemon appears down — bootstrap then try once more.
 			m.updateStatus(id, "bootstrapping", "Checking remote platform", nil, nil)
 			bootCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-			bootErr := m.bootstrapper.EnsureRemoteReady(bootCtx, record.SSHTarget)
+			bootErr := m.bootstrapper.EnsureRemoteReady(bootCtx, record.SSHTarget, record.Profile)
 			cancel()
 			if bootErr != nil {
 				m.updateStatus(id, "error", bootErr.Error(), nil, nil)
@@ -450,7 +465,7 @@ func (m *Manager) runEndpointLoop(ctx context.Context, id string) {
 				continue
 			}
 			m.updateStatus(id, "connecting", "Connecting to remote daemon", nil, nil)
-			conn, cmd, err = connectViaSSH(ctx, record.SSHTarget, config.WSAuthToken())
+			conn, cmd, err = connectViaSSH(ctx, record.SSHTarget, config.WSAuthToken(), record.Profile)
 			if err != nil {
 				m.updateStatus(id, "error", err.Error(), nil, nil)
 				if !sleepOrDone(ctx, backoff) {
@@ -1632,6 +1647,11 @@ func (m *Manager) updateStatus(id, status, message string, caps *protocol.Endpoi
 	info.Name = runtime.record.Name
 	info.SshTarget = runtime.record.SSHTarget
 	info.Enabled = protocol.Ptr(runtime.record.Enabled)
+	if strings.TrimSpace(runtime.record.Profile) != "" {
+		info.Profile = protocol.Ptr(runtime.record.Profile)
+	} else {
+		info.Profile = nil
+	}
 	info.Status = status
 	if message != "" {
 		info.StatusMessage = protocol.Ptr(message)

--- a/internal/hub/manager_test.go
+++ b/internal/hub/manager_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestManagerRemoteSessionsTagAndSeparateEndpoints(t *testing.T) {
 	endpointStore := store.New()
-	first, err := endpointStore.AddEndpoint("gpu-box", "gpu")
+	first, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint(first) error = %v", err)
 	}
-	second, err := endpointStore.AddEndpoint("dev-box", "dev")
+	second, err := endpointStore.AddEndpoint("dev-box", "dev", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint(second) error = %v", err)
 	}
@@ -57,7 +57,7 @@ func TestManagerRemoteSessionsTagAndSeparateEndpoints(t *testing.T) {
 
 func TestManagerRemoteSessionsUpsertAndClear(t *testing.T) {
 	endpointStore := store.New()
-	record, err := endpointStore.AddEndpoint("gpu-box", "gpu")
+	record, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint() error = %v", err)
 	}
@@ -113,11 +113,11 @@ func TestManagerRemoteSessionsUpsertAndClear(t *testing.T) {
 
 func TestManagerRemoteWorkspacesTrackAndClear(t *testing.T) {
 	endpointStore := store.New()
-	first, err := endpointStore.AddEndpoint("gpu-box", "gpu")
+	first, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint(first) error = %v", err)
 	}
-	second, err := endpointStore.AddEndpoint("dev-box", "dev")
+	second, err := endpointStore.AddEndpoint("dev-box", "dev", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint(second) error = %v", err)
 	}
@@ -192,7 +192,7 @@ func TestManagerRemoteWorkspacesTrackAndClear(t *testing.T) {
 
 func TestManagerIgnoresWorkspaceUpdatesForRemovedRemoteSessions(t *testing.T) {
 	endpointStore := store.New()
-	record, err := endpointStore.AddEndpoint("gpu-box", "gpu")
+	record, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint() error = %v", err)
 	}
@@ -229,7 +229,7 @@ func TestManagerIgnoresWorkspaceUpdatesForRemovedRemoteSessions(t *testing.T) {
 
 func TestManagerForgetSessionRemovesRemoteSessionAndWorkspace(t *testing.T) {
 	endpointStore := store.New()
-	record, err := endpointStore.AddEndpoint("gpu-box", "gpu")
+	record, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint() error = %v", err)
 	}
@@ -267,7 +267,7 @@ func TestManagerForgetSessionRemovesRemoteSessionAndWorkspace(t *testing.T) {
 
 func TestManagerPendingSessionRouteReservesSpawnEndpoint(t *testing.T) {
 	endpointStore := store.New()
-	record, err := endpointStore.AddEndpoint("gpu-box", "gpu")
+	record, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint() error = %v", err)
 	}
@@ -299,7 +299,7 @@ func TestManagerPendingSessionRouteReservesSpawnEndpoint(t *testing.T) {
 
 func TestManagerPendingSessionRouteExpires(t *testing.T) {
 	endpointStore := store.New()
-	record, err := endpointStore.AddEndpoint("gpu-box", "gpu")
+	record, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint() error = %v", err)
 	}
@@ -319,7 +319,7 @@ func TestManagerPendingSessionRouteExpires(t *testing.T) {
 
 func TestManagerEndpointIDForPathMatchesSessionDirectoryAndMainRepo(t *testing.T) {
 	endpointStore := store.New()
-	record, err := endpointStore.AddEndpoint("gpu-box", "gpu")
+	record, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint() error = %v", err)
 	}
@@ -381,7 +381,7 @@ func TestCapabilitiesFromInitialStateIncludesRemoteWebFields(t *testing.T) {
 
 func TestManagerHandleRemoteSettingsUpdatedResolvesRemoteWebAction(t *testing.T) {
 	endpointStore := store.New()
-	record, err := endpointStore.AddEndpoint("gpu-box", "gpu")
+	record, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint() error = %v", err)
 	}
@@ -429,7 +429,7 @@ func TestManagerHandleRemoteSettingsUpdatedResolvesRemoteWebAction(t *testing.T)
 
 func TestManagerHandleRemoteSettingsUpdatedIgnoresUnrelatedPendingRemoteWebUpdates(t *testing.T) {
 	endpointStore := store.New()
-	record, err := endpointStore.AddEndpoint("gpu-box", "gpu")
+	record, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint() error = %v", err)
 	}
@@ -484,7 +484,7 @@ func TestForwardsRawEventIncludesPickerResults(t *testing.T) {
 
 func TestManagerObserveRemoteEventCachesReviewCommentAndLoopOwnership(t *testing.T) {
 	endpointStore := store.New()
-	record, err := endpointStore.AddEndpoint("gpu-box", "gpu")
+	record, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint() error = %v", err)
 	}

--- a/internal/hub/ssh.go
+++ b/internal/hub/ssh.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/victorarias/attn/internal/config"
 )
 
 func sshBaseArgs(target string) []string {
@@ -24,8 +22,23 @@ func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
 }
 
-func remoteShellEnvScript() string {
-	assignments := make([]string, 0, 4)
+// remoteBinaryName returns the install-relative binary name for a given
+// profile: the default profile uses "attn", named profiles use "attn-<profile>".
+// Mirrors the local install layout (~/Applications/attn-dev.app vs attn.app)
+// so a remote can host multiple profile-isolated daemons side by side.
+func remoteBinaryName(profile string) string {
+	p := strings.TrimSpace(profile)
+	if p == "" {
+		return "attn"
+	}
+	return "attn-" + p
+}
+
+func remoteShellEnvScript(profile string) string {
+	assignments := make([]string, 0, 5)
+	if p := strings.TrimSpace(profile); p != "" {
+		assignments = append(assignments, "export ATTN_PROFILE="+shellQuote(p))
+	}
 	if value := strings.TrimSpace(os.Getenv("ATTN_REMOTE_ATTN_BIN")); value != "" {
 		assignments = append(assignments, "export ATTN_REMOTE_ATTN_BIN="+shellQuote(value))
 	}
@@ -47,17 +60,18 @@ func remoteShellEnvScript() string {
 	return strings.Join(assignments, "; ") + "; "
 }
 
-func remoteShellCommand(script string) string {
-	if envScript := remoteShellEnvScript(); envScript != "" {
+func remoteShellCommand(profile, script string) string {
+	if envScript := remoteShellEnvScript(profile); envScript != "" {
 		script = envScript + script
 	}
 	return "sh -lc " + shellQuote(script)
 }
 
-func remoteAttnCommand(args ...string) string {
+func remoteAttnCommand(profile string, args ...string) string {
+	binName := remoteBinaryName(profile)
 	bin := fmt.Sprintf(`ATTN_BIN="${ATTN_REMOTE_ATTN_BIN:-$HOME/.local/bin/%s}"; if [ ! -x "$ATTN_BIN" ] && [ -z "${ATTN_REMOTE_ATTN_BIN:-}" ]; then ATTN_BIN="$(command -v %s 2>/dev/null || true)"; fi; if [ -z "$ATTN_BIN" ] || [ ! -x "$ATTN_BIN" ]; then printf 'missing attn binary\n' >&2; exit 127; fi; "$ATTN_BIN"`,
-		config.BinaryName(),
-		config.BinaryName(),
+		binName,
+		binName,
 	)
 	for _, arg := range args {
 		bin += " " + shellQuote(arg)
@@ -65,9 +79,9 @@ func remoteAttnCommand(args ...string) string {
 	return bin
 }
 
-func runSSH(ctx context.Context, target, script string) (string, error) {
+func runSSH(ctx context.Context, target, profile, script string) (string, error) {
 	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "ssh", append(sshBaseArgs(target), remoteShellCommand(script))...)
+	cmd := exec.CommandContext(ctx, "ssh", append(sshBaseArgs(target), remoteShellCommand(profile, script))...)
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/hub/ssh_test.go
+++ b/internal/hub/ssh_test.go
@@ -11,7 +11,7 @@ func TestRemoteShellCommandExportsRemoteOverrideEnv(t *testing.T) {
 	t.Setenv("ATTN_REMOTE_WS_PORT", "19549")
 	t.Setenv("ATTN_REMOTE_DB_PATH", "/tmp/attn-harness/attn.db")
 
-	command := remoteShellCommand("printf ready")
+	command := remoteShellCommand("", "printf ready")
 	for _, fragment := range []string{
 		"ATTN_REMOTE_ATTN_BIN",
 		"ATTN_SOCKET_PATH",
@@ -23,14 +23,57 @@ func TestRemoteShellCommandExportsRemoteOverrideEnv(t *testing.T) {
 			t.Fatalf("remoteShellCommand() missing %q in %q", fragment, command)
 		}
 	}
+	if strings.Contains(command, "ATTN_PROFILE") {
+		t.Fatalf("remoteShellCommand(\"\") leaked ATTN_PROFILE: %q", command)
+	}
+}
+
+func TestRemoteShellCommandExportsProfileWhenSet(t *testing.T) {
+	command := remoteShellCommand("dev", "printf ready")
+	if !strings.Contains(command, "export ATTN_PROFILE=") {
+		t.Fatalf("remoteShellCommand(\"dev\") missing ATTN_PROFILE export: %q", command)
+	}
+	if !strings.Contains(command, "dev") {
+		t.Fatalf("remoteShellCommand(\"dev\") missing profile name: %q", command)
+	}
 }
 
 func TestRemoteAttnCommandHonorsRemoteBinaryOverride(t *testing.T) {
-	command := remoteAttnCommand("daemon")
+	command := remoteAttnCommand("", "daemon")
 	if !strings.Contains(command, "ATTN_REMOTE_ATTN_BIN") {
 		t.Fatalf("remoteAttnCommand() = %q, want ATTN_REMOTE_ATTN_BIN override support", command)
 	}
 	if !strings.Contains(command, `daemon`) {
 		t.Fatalf("remoteAttnCommand() = %q, want daemon arg", command)
+	}
+	if !strings.Contains(command, "$HOME/.local/bin/attn") {
+		t.Fatalf("remoteAttnCommand(\"\") = %q, want default $HOME/.local/bin/attn", command)
+	}
+}
+
+func TestRemoteAttnCommandUsesProfileBinary(t *testing.T) {
+	command := remoteAttnCommand("dev", "ws-relay")
+	if !strings.Contains(command, "$HOME/.local/bin/attn-dev") {
+		t.Fatalf("remoteAttnCommand(\"dev\") = %q, want attn-dev binary path", command)
+	}
+}
+
+func TestRemoteBinaryName(t *testing.T) {
+	cases := []struct {
+		profile string
+		want    string
+	}{
+		{"", "attn"},
+		{"  ", "attn"},
+		{"dev", "attn-dev"},
+		{"foo", "attn-foo"},
+	}
+	for _, c := range cases {
+		t.Run(c.profile, func(t *testing.T) {
+			got := remoteBinaryName(c.profile)
+			if got != c.want {
+				t.Fatalf("remoteBinaryName(%q) = %q, want %q", c.profile, got, c.want)
+			}
+		})
 	}
 }

--- a/internal/hub/transport.go
+++ b/internal/hub/transport.go
@@ -17,10 +17,10 @@ import (
 const remoteWSMessageReadLimit = 8 << 20
 const remoteWSDialRetryDelay = 250 * time.Millisecond
 
-func connectViaSSH(ctx context.Context, sshTarget, authToken string) (*websocket.Conn, *exec.Cmd, error) {
+func connectViaSSH(ctx context.Context, sshTarget, authToken, profile string) (*websocket.Conn, *exec.Cmd, error) {
 	var lastErr error
 	for attempt := 0; attempt < 5; attempt++ {
-		ws, cmd, err := connectViaSSHOnce(ctx, sshTarget, authToken)
+		ws, cmd, err := connectViaSSHOnce(ctx, sshTarget, authToken, profile)
 		if err == nil {
 			return ws, cmd, nil
 		}
@@ -37,8 +37,8 @@ func connectViaSSH(ctx context.Context, sshTarget, authToken string) (*websocket
 	return nil, nil, lastErr
 }
 
-func connectViaSSHOnce(ctx context.Context, sshTarget, authToken string) (*websocket.Conn, *exec.Cmd, error) {
-	cmd := exec.CommandContext(ctx, "ssh", append(sshBaseArgs(sshTarget), remoteShellCommand(remoteAttnCommand("ws-relay")))...)
+func connectViaSSHOnce(ctx context.Context, sshTarget, authToken, profile string) (*websocket.Conn, *exec.Cmd, error) {
+	cmd := exec.CommandContext(ctx, "ssh", append(sshBaseArgs(sshTarget), remoteShellCommand(profile, remoteAttnCommand(profile, "ws-relay")))...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, nil, err

--- a/internal/hub/transport_zombie_test.go
+++ b/internal/hub/transport_zombie_test.go
@@ -33,7 +33,7 @@ func TestConnectViaSSHOnceReapsChildOnDialFailure(t *testing.T) {
 	const iterations = 8
 	for i := 0; i < iterations; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-		ws, cmd, err := connectViaSSHOnce(ctx, "fake-target", "")
+		ws, cmd, err := connectViaSSHOnce(ctx, "fake-target", "", "")
 		cancel()
 		if err == nil {
 			// Unexpected success — clean up and fail.

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "54"
+const ProtocolVersion = "55"
 
 // Commands
 const (

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -24,10 +24,10 @@ type AddCommentMessage struct {
 
 type AddCommentResultMessage struct {
 	// Comment corresponds to the JSON schema field "comment".
-	Comment *ReviewComment `json:"comment,omitempty"`
+	Comment *ReviewComment `json:"comment,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -43,6 +43,9 @@ type AddEndpointMessage struct {
 	// Name corresponds to the JSON schema field "name".
 	Name string `json:"name"`
 
+	// Profile corresponds to the JSON schema field "profile".
+	Profile *string `json:"profile,omitempty,omitzero"`
+
 	// SshTarget corresponds to the JSON schema field "ssh_target".
 	SshTarget string `json:"ssh_target"`
 }
@@ -55,7 +58,7 @@ type AnswerReviewLoopMessage struct {
 	Cmd string `json:"cmd"`
 
 	// InteractionID corresponds to the JSON schema field "interaction_id".
-	InteractionID *string `json:"interaction_id,omitempty"`
+	InteractionID *string `json:"interaction_id,omitempty,omitzero"`
 
 	// LoopID corresponds to the JSON schema field "loop_id".
 	LoopID string `json:"loop_id"`
@@ -77,10 +80,10 @@ const AttachPolicySameAppRemount AttachPolicy = "same_app_remount"
 
 type AttachResultMessage struct {
 	// Cols corresponds to the JSON schema field "cols".
-	Cols *int `json:"cols,omitempty"`
+	Cols *int `json:"cols,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -89,49 +92,49 @@ type AttachResultMessage struct {
 	ID string `json:"id"`
 
 	// LastSeq corresponds to the JSON schema field "last_seq".
-	LastSeq *int `json:"last_seq,omitempty"`
+	LastSeq *int `json:"last_seq,omitempty,omitzero"`
 
 	// Pid corresponds to the JSON schema field "pid".
-	Pid *int `json:"pid,omitempty"`
+	Pid *int `json:"pid,omitempty,omitzero"`
 
 	// ReplaySegments corresponds to the JSON schema field "replay_segments".
-	ReplaySegments []ReplaySegment `json:"replay_segments,omitempty"`
+	ReplaySegments []ReplaySegment `json:"replay_segments,omitempty,omitzero"`
 
 	// Rows corresponds to the JSON schema field "rows".
-	Rows *int `json:"rows,omitempty"`
+	Rows *int `json:"rows,omitempty,omitzero"`
 
 	// Running corresponds to the JSON schema field "running".
-	Running *bool `json:"running,omitempty"`
+	Running *bool `json:"running,omitempty,omitzero"`
 
 	// ScreenCols corresponds to the JSON schema field "screen_cols".
-	ScreenCols *int `json:"screen_cols,omitempty"`
+	ScreenCols *int `json:"screen_cols,omitempty,omitzero"`
 
 	// ScreenCursorVisible corresponds to the JSON schema field
 	// "screen_cursor_visible".
-	ScreenCursorVisible *bool `json:"screen_cursor_visible,omitempty"`
+	ScreenCursorVisible *bool `json:"screen_cursor_visible,omitempty,omitzero"`
 
 	// ScreenCursorX corresponds to the JSON schema field "screen_cursor_x".
-	ScreenCursorX *int `json:"screen_cursor_x,omitempty"`
+	ScreenCursorX *int `json:"screen_cursor_x,omitempty,omitzero"`
 
 	// ScreenCursorY corresponds to the JSON schema field "screen_cursor_y".
-	ScreenCursorY *int `json:"screen_cursor_y,omitempty"`
+	ScreenCursorY *int `json:"screen_cursor_y,omitempty,omitzero"`
 
 	// ScreenRows corresponds to the JSON schema field "screen_rows".
-	ScreenRows *int `json:"screen_rows,omitempty"`
+	ScreenRows *int `json:"screen_rows,omitempty,omitzero"`
 
 	// ScreenSnapshot corresponds to the JSON schema field "screen_snapshot".
-	ScreenSnapshot *string `json:"screen_snapshot,omitempty"`
+	ScreenSnapshot *string `json:"screen_snapshot,omitempty,omitzero"`
 
 	// ScreenSnapshotFresh corresponds to the JSON schema field
 	// "screen_snapshot_fresh".
-	ScreenSnapshotFresh *bool `json:"screen_snapshot_fresh,omitempty"`
+	ScreenSnapshotFresh *bool `json:"screen_snapshot_fresh,omitempty,omitzero"`
 
 	// Scrollback corresponds to the JSON schema field "scrollback".
-	Scrollback *string `json:"scrollback,omitempty"`
+	Scrollback *string `json:"scrollback,omitempty,omitzero"`
 
 	// ScrollbackTruncated corresponds to the JSON schema field
 	// "scrollback_truncated".
-	ScrollbackTruncated *bool `json:"scrollback_truncated,omitempty"`
+	ScrollbackTruncated *bool `json:"scrollback_truncated,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
@@ -139,7 +142,7 @@ type AttachResultMessage struct {
 
 type AttachSessionMessage struct {
 	// AttachPolicy corresponds to the JSON schema field "attach_policy".
-	AttachPolicy *AttachPolicy `json:"attach_policy,omitempty"`
+	AttachPolicy *AttachPolicy `json:"attach_policy,omitempty,omitzero"`
 
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -158,7 +161,7 @@ type AuthorState struct {
 
 type AuthorsUpdatedMessage struct {
 	// Authors corresponds to the JSON schema field "authors".
-	Authors []AuthorState `json:"authors,omitempty"`
+	Authors []AuthorState `json:"authors,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -174,13 +177,13 @@ type BootstrapEndpointMessage struct {
 
 type Branch struct {
 	// CommitHash corresponds to the JSON schema field "commit_hash".
-	CommitHash *string `json:"commit_hash,omitempty"`
+	CommitHash *string `json:"commit_hash,omitempty,omitzero"`
 
 	// CommitTime corresponds to the JSON schema field "commit_time".
-	CommitTime *string `json:"commit_time,omitempty"`
+	CommitTime *string `json:"commit_time,omitempty,omitzero"`
 
 	// IsCurrent corresponds to the JSON schema field "is_current".
-	IsCurrent *bool `json:"is_current,omitempty"`
+	IsCurrent *bool `json:"is_current,omitempty,omitzero"`
 
 	// Name corresponds to the JSON schema field "name".
 	Name string `json:"name"`
@@ -191,21 +194,21 @@ type BranchChangedMessage struct {
 	Event string `json:"event"`
 
 	// Session corresponds to the JSON schema field "session".
-	Session *Session `json:"session,omitempty"`
+	Session *Session `json:"session,omitempty,omitzero"`
 }
 
 type BranchDiffFile struct {
 	// Additions corresponds to the JSON schema field "additions".
-	Additions *int `json:"additions,omitempty"`
+	Additions *int `json:"additions,omitempty,omitzero"`
 
 	// Deletions corresponds to the JSON schema field "deletions".
-	Deletions *int `json:"deletions,omitempty"`
+	Deletions *int `json:"deletions,omitempty,omitzero"`
 
 	// HasUncommitted corresponds to the JSON schema field "has_uncommitted".
-	HasUncommitted *bool `json:"has_uncommitted,omitempty"`
+	HasUncommitted *bool `json:"has_uncommitted,omitempty,omitzero"`
 
 	// OldPath corresponds to the JSON schema field "old_path".
-	OldPath *string `json:"old_path,omitempty"`
+	OldPath *string `json:"old_path,omitempty,omitzero"`
 
 	// Path corresponds to the JSON schema field "path".
 	Path string `json:"path"`
@@ -222,7 +225,7 @@ type BranchDiffFilesResultMessage struct {
 	Directory string `json:"directory"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -239,7 +242,7 @@ type BranchesResultMessage struct {
 	Branches []Branch `json:"branches"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -253,13 +256,13 @@ type BrowseDirectoryMessage struct {
 	Cmd string `json:"cmd"`
 
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// InputPath corresponds to the JSON schema field "input_path".
 	InputPath string `json:"input_path"`
 
 	// RequestID corresponds to the JSON schema field "request_id".
-	RequestID *string `json:"request_id,omitempty"`
+	RequestID *string `json:"request_id,omitempty,omitzero"`
 }
 
 type BrowseDirectoryResultMessage struct {
@@ -267,25 +270,25 @@ type BrowseDirectoryResultMessage struct {
 	Directory string `json:"directory"`
 
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Entries corresponds to the JSON schema field "entries".
 	Entries []DirectoryEntry `json:"entries"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// HomePath corresponds to the JSON schema field "home_path".
-	HomePath *string `json:"home_path,omitempty"`
+	HomePath *string `json:"home_path,omitempty,omitzero"`
 
 	// InputPath corresponds to the JSON schema field "input_path".
 	InputPath string `json:"input_path"`
 
 	// RequestID corresponds to the JSON schema field "request_id".
-	RequestID *string `json:"request_id,omitempty"`
+	RequestID *string `json:"request_id,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
@@ -314,7 +317,7 @@ type CollapseRepoMessage struct {
 
 type CommandErrorMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd *string `json:"cmd,omitempty"`
+	Cmd *string `json:"cmd,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
 	Error string `json:"error"`
@@ -337,7 +340,7 @@ type CreateWorktreeFromBranchMessage struct {
 	MainRepo string `json:"main_repo"`
 
 	// Path corresponds to the JSON schema field "path".
-	Path *string `json:"path,omitempty"`
+	Path *string `json:"path,omitempty,omitzero"`
 }
 
 type CreateWorktreeMessage struct {
@@ -348,30 +351,30 @@ type CreateWorktreeMessage struct {
 	Cmd string `json:"cmd"`
 
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// MainRepo corresponds to the JSON schema field "main_repo".
 	MainRepo string `json:"main_repo"`
 
 	// Path corresponds to the JSON schema field "path".
-	Path *string `json:"path,omitempty"`
+	Path *string `json:"path,omitempty,omitzero"`
 
 	// StartingFrom corresponds to the JSON schema field "starting_from".
-	StartingFrom *string `json:"starting_from,omitempty"`
+	StartingFrom *string `json:"starting_from,omitempty,omitzero"`
 }
 
 type CreateWorktreeResultMessage struct {
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// Path corresponds to the JSON schema field "path".
-	Path *string `json:"path,omitempty"`
+	Path *string `json:"path,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
@@ -395,7 +398,7 @@ type DeleteCommentMessage struct {
 
 type DeleteCommentResultMessage struct {
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -409,7 +412,7 @@ type DeleteWorktreeMessage struct {
 	Cmd string `json:"cmd"`
 
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Path corresponds to the JSON schema field "path".
 	Path string `json:"path"`
@@ -417,10 +420,10 @@ type DeleteWorktreeMessage struct {
 
 type DeleteWorktreeResultMessage struct {
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -453,10 +456,10 @@ type EndpointActionResultMessage struct {
 	Action string `json:"action"`
 
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -470,42 +473,42 @@ type EndpointCapabilities struct {
 	AgentsAvailable []string `json:"agents_available"`
 
 	// DaemonInstanceID corresponds to the JSON schema field "daemon_instance_id".
-	DaemonInstanceID *string `json:"daemon_instance_id,omitempty"`
+	DaemonInstanceID *string `json:"daemon_instance_id,omitempty,omitzero"`
 
 	// ProjectsDirectory corresponds to the JSON schema field "projects_directory".
-	ProjectsDirectory *string `json:"projects_directory,omitempty"`
+	ProjectsDirectory *string `json:"projects_directory,omitempty,omitzero"`
 
 	// ProtocolVersion corresponds to the JSON schema field "protocol_version".
 	ProtocolVersion string `json:"protocol_version"`
 
 	// PtyBackendMode corresponds to the JSON schema field "pty_backend_mode".
-	PtyBackendMode *string `json:"pty_backend_mode,omitempty"`
+	PtyBackendMode *string `json:"pty_backend_mode,omitempty,omitzero"`
 
 	// TailscaleAuthURL corresponds to the JSON schema field "tailscale_auth_url".
-	TailscaleAuthURL *string `json:"tailscale_auth_url,omitempty"`
+	TailscaleAuthURL *string `json:"tailscale_auth_url,omitempty,omitzero"`
 
 	// TailscaleDomain corresponds to the JSON schema field "tailscale_domain".
-	TailscaleDomain *string `json:"tailscale_domain,omitempty"`
+	TailscaleDomain *string `json:"tailscale_domain,omitempty,omitzero"`
 
 	// TailscaleEnabled corresponds to the JSON schema field "tailscale_enabled".
-	TailscaleEnabled *bool `json:"tailscale_enabled,omitempty"`
+	TailscaleEnabled *bool `json:"tailscale_enabled,omitempty,omitzero"`
 
 	// TailscaleError corresponds to the JSON schema field "tailscale_error".
-	TailscaleError *string `json:"tailscale_error,omitempty"`
+	TailscaleError *string `json:"tailscale_error,omitempty,omitzero"`
 
 	// TailscaleStatus corresponds to the JSON schema field "tailscale_status".
-	TailscaleStatus *string `json:"tailscale_status,omitempty"`
+	TailscaleStatus *string `json:"tailscale_status,omitempty,omitzero"`
 
 	// TailscaleURL corresponds to the JSON schema field "tailscale_url".
-	TailscaleURL *string `json:"tailscale_url,omitempty"`
+	TailscaleURL *string `json:"tailscale_url,omitempty,omitzero"`
 }
 
 type EndpointInfo struct {
 	// Capabilities corresponds to the JSON schema field "capabilities".
-	Capabilities *EndpointCapabilities `json:"capabilities,omitempty"`
+	Capabilities *EndpointCapabilities `json:"capabilities,omitempty,omitzero"`
 
 	// Enabled corresponds to the JSON schema field "enabled".
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty,omitzero"`
 
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
@@ -513,8 +516,11 @@ type EndpointInfo struct {
 	// Name corresponds to the JSON schema field "name".
 	Name string `json:"name"`
 
+	// Profile corresponds to the JSON schema field "profile".
+	Profile *string `json:"profile,omitempty,omitzero"`
+
 	// SessionCount corresponds to the JSON schema field "session_count".
-	SessionCount *int `json:"session_count,omitempty"`
+	SessionCount *int `json:"session_count,omitempty,omitzero"`
 
 	// SshTarget corresponds to the JSON schema field "ssh_target".
 	SshTarget string `json:"ssh_target"`
@@ -523,7 +529,7 @@ type EndpointInfo struct {
 	Status string `json:"status"`
 
 	// StatusMessage corresponds to the JSON schema field "status_message".
-	StatusMessage *string `json:"status_message,omitempty"`
+	StatusMessage *string `json:"status_message,omitempty,omitzero"`
 }
 
 type EndpointStatusChangedMessage struct {
@@ -555,19 +561,19 @@ type EnsureRepoMessage struct {
 
 type EnsureRepoResultMessage struct {
 	// Cloned corresponds to the JSON schema field "cloned".
-	Cloned *bool `json:"cloned,omitempty"`
+	Cloned *bool `json:"cloned,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// Success corresponds to the JSON schema field "success".
-	Success *bool `json:"success,omitempty"`
+	Success *bool `json:"success,omitempty,omitzero"`
 
 	// TargetPath corresponds to the JSON schema field "target_path".
-	TargetPath *string `json:"target_path,omitempty"`
+	TargetPath *string `json:"target_path,omitempty,omitzero"`
 }
 
 type FetchPRDetailsMessage struct {
@@ -580,13 +586,13 @@ type FetchPRDetailsMessage struct {
 
 type FetchPRDetailsResultMessage struct {
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// Prs corresponds to the JSON schema field "prs".
-	Prs []PR `json:"prs,omitempty"`
+	Prs []PR `json:"prs,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
@@ -602,7 +608,7 @@ type FetchRemotesMessage struct {
 
 type FetchRemotesResultMessage struct {
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -616,7 +622,7 @@ type FileDiffResultMessage struct {
 	Directory string `json:"directory"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -636,7 +642,7 @@ type FileDiffResultMessage struct {
 
 type GetBranchDiffFilesMessage struct {
 	// BaseRef corresponds to the JSON schema field "base_ref".
-	BaseRef *string `json:"base_ref,omitempty"`
+	BaseRef *string `json:"base_ref,omitempty,omitzero"`
 
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -650,7 +656,7 @@ type GetCommentsMessage struct {
 	Cmd string `json:"cmd"`
 
 	// Filepath corresponds to the JSON schema field "filepath".
-	Filepath *string `json:"filepath,omitempty"`
+	Filepath *string `json:"filepath,omitempty,omitzero"`
 
 	// ReviewID corresponds to the JSON schema field "review_id".
 	ReviewID string `json:"review_id"`
@@ -658,10 +664,10 @@ type GetCommentsMessage struct {
 
 type GetCommentsResultMessage struct {
 	// Comments corresponds to the JSON schema field "comments".
-	Comments []ReviewComment `json:"comments,omitempty"`
+	Comments []ReviewComment `json:"comments,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -683,7 +689,7 @@ type GetDefaultBranchResultMessage struct {
 	Branch string `json:"branch"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -694,7 +700,7 @@ type GetDefaultBranchResultMessage struct {
 
 type GetFileDiffMessage struct {
 	// BaseRef corresponds to the JSON schema field "base_ref".
-	BaseRef *string `json:"base_ref,omitempty"`
+	BaseRef *string `json:"base_ref,omitempty,omitzero"`
 
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -706,7 +712,7 @@ type GetFileDiffMessage struct {
 	Path string `json:"path"`
 
 	// Staged corresponds to the JSON schema field "staged".
-	Staged *bool `json:"staged,omitempty"`
+	Staged *bool `json:"staged,omitempty,omitzero"`
 }
 
 type GetRecentLocationsMessage struct {
@@ -714,13 +720,13 @@ type GetRecentLocationsMessage struct {
 	Cmd string `json:"cmd"`
 
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Limit corresponds to the JSON schema field "limit".
-	Limit *int `json:"limit,omitempty"`
+	Limit *int `json:"limit,omitempty,omitzero"`
 
 	// RequestID corresponds to the JSON schema field "request_id".
-	RequestID *string `json:"request_id,omitempty"`
+	RequestID *string `json:"request_id,omitempty,omitzero"`
 }
 
 type GetRepoInfoMessage struct {
@@ -728,7 +734,7 @@ type GetRepoInfoMessage struct {
 	Cmd string `json:"cmd"`
 
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Repo corresponds to the JSON schema field "repo".
 	Repo string `json:"repo"`
@@ -736,16 +742,16 @@ type GetRepoInfoMessage struct {
 
 type GetRepoInfoResultMessage struct {
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// Info corresponds to the JSON schema field "info".
-	Info *RepoInfo `json:"info,omitempty"`
+	Info *RepoInfo `json:"info,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
@@ -780,13 +786,13 @@ type GetReviewStateMessage struct {
 
 type GetReviewStateResultMessage struct {
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// State corresponds to the JSON schema field "state".
-	State *ReviewState `json:"state,omitempty"`
+	State *ReviewState `json:"state,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
@@ -799,13 +805,13 @@ type GetSettingsMessage struct {
 
 type GitFileChange struct {
 	// Additions corresponds to the JSON schema field "additions".
-	Additions *int `json:"additions,omitempty"`
+	Additions *int `json:"additions,omitempty,omitzero"`
 
 	// Deletions corresponds to the JSON schema field "deletions".
-	Deletions *int `json:"deletions,omitempty"`
+	Deletions *int `json:"deletions,omitempty,omitzero"`
 
 	// OldPath corresponds to the JSON schema field "old_path".
-	OldPath *string `json:"old_path,omitempty"`
+	OldPath *string `json:"old_path,omitempty,omitzero"`
 
 	// Path corresponds to the JSON schema field "path".
 	Path string `json:"path"`
@@ -819,7 +825,7 @@ type GitStatusUpdateMessage struct {
 	Directory string `json:"directory"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -850,40 +856,40 @@ const HeatStateWarm HeatState = "warm"
 
 type InitialStateMessage struct {
 	// Authors corresponds to the JSON schema field "authors".
-	Authors []AuthorState `json:"authors,omitempty"`
+	Authors []AuthorState `json:"authors,omitempty,omitzero"`
 
 	// DaemonInstanceID corresponds to the JSON schema field "daemon_instance_id".
-	DaemonInstanceID *string `json:"daemon_instance_id,omitempty"`
+	DaemonInstanceID *string `json:"daemon_instance_id,omitempty,omitzero"`
 
 	// Endpoints corresponds to the JSON schema field "endpoints".
-	Endpoints []EndpointInfo `json:"endpoints,omitempty"`
+	Endpoints []EndpointInfo `json:"endpoints,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// ProtocolVersion corresponds to the JSON schema field "protocol_version".
-	ProtocolVersion *string `json:"protocol_version,omitempty"`
+	ProtocolVersion *string `json:"protocol_version,omitempty,omitzero"`
 
 	// Prs corresponds to the JSON schema field "prs".
-	Prs []PR `json:"prs,omitempty"`
+	Prs []PR `json:"prs,omitempty,omitzero"`
 
 	// Repos corresponds to the JSON schema field "repos".
-	Repos []RepoState `json:"repos,omitempty"`
+	Repos []RepoState `json:"repos,omitempty,omitzero"`
 
 	// SessionLayouts corresponds to the JSON schema field "session_layouts".
-	SessionLayouts []SessionLayout `json:"session_layouts,omitempty"`
+	SessionLayouts []SessionLayout `json:"session_layouts,omitempty,omitzero"`
 
 	// Sessions corresponds to the JSON schema field "sessions".
-	Sessions []Session `json:"sessions,omitempty"`
+	Sessions []Session `json:"sessions,omitempty,omitzero"`
 
 	// Settings corresponds to the JSON schema field "settings".
-	Settings map[string]interface{} `json:"settings,omitempty"`
+	Settings RecordString `json:"settings,omitempty,omitzero"`
 
 	// SourceFingerprint corresponds to the JSON schema field "source_fingerprint".
-	SourceFingerprint *string `json:"source_fingerprint,omitempty"`
+	SourceFingerprint *string `json:"source_fingerprint,omitempty,omitzero"`
 
 	// Warnings corresponds to the JSON schema field "warnings".
-	Warnings []DaemonWarning `json:"warnings,omitempty"`
+	Warnings []DaemonWarning `json:"warnings,omitempty,omitzero"`
 }
 
 type InjectTestPRMessage struct {
@@ -907,30 +913,30 @@ type InspectPathMessage struct {
 	Cmd string `json:"cmd"`
 
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Path corresponds to the JSON schema field "path".
 	Path string `json:"path"`
 
 	// RequestID corresponds to the JSON schema field "request_id".
-	RequestID *string `json:"request_id,omitempty"`
+	RequestID *string `json:"request_id,omitempty,omitzero"`
 }
 
 type InspectPathResultMessage struct {
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// Inspection corresponds to the JSON schema field "inspection".
-	Inspection *PathInspection `json:"inspection,omitempty"`
+	Inspection *PathInspection `json:"inspection,omitempty,omitzero"`
 
 	// RequestID corresponds to the JSON schema field "request_id".
-	RequestID *string `json:"request_id,omitempty"`
+	RequestID *string `json:"request_id,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
@@ -944,7 +950,7 @@ type KillSessionMessage struct {
 	ID string `json:"id"`
 
 	// Signal corresponds to the JSON schema field "signal".
-	Signal *string `json:"signal,omitempty"`
+	Signal *string `json:"signal,omitempty,omitzero"`
 }
 
 type ListBranchesMessage struct {
@@ -973,7 +979,7 @@ type ListRemoteBranchesResultMessage struct {
 	Branches []Branch `json:"branches"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -1006,7 +1012,7 @@ type MarkFileViewedMessage struct {
 
 type MarkFileViewedResultMessage struct {
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -1075,28 +1081,28 @@ type PR struct {
 	Author string `json:"author"`
 
 	// CIStatus corresponds to the JSON schema field "ci_status".
-	CIStatus *string `json:"ci_status,omitempty"`
+	CIStatus *string `json:"ci_status,omitempty,omitzero"`
 
 	// CommentCount corresponds to the JSON schema field "comment_count".
-	CommentCount *int `json:"comment_count,omitempty"`
+	CommentCount *int `json:"comment_count,omitempty,omitzero"`
 
 	// DetailsFetched corresponds to the JSON schema field "details_fetched".
 	DetailsFetched bool `json:"details_fetched"`
 
 	// DetailsFetchedAt corresponds to the JSON schema field "details_fetched_at".
-	DetailsFetchedAt *string `json:"details_fetched_at,omitempty"`
+	DetailsFetchedAt *string `json:"details_fetched_at,omitempty,omitzero"`
 
 	// HasNewChanges corresponds to the JSON schema field "has_new_changes".
 	HasNewChanges bool `json:"has_new_changes"`
 
 	// HeadBranch corresponds to the JSON schema field "head_branch".
-	HeadBranch *string `json:"head_branch,omitempty"`
+	HeadBranch *string `json:"head_branch,omitempty,omitzero"`
 
 	// HeadSHA corresponds to the JSON schema field "head_sha".
-	HeadSHA *string `json:"head_sha,omitempty"`
+	HeadSHA *string `json:"head_sha,omitempty,omitzero"`
 
 	// HeatState corresponds to the JSON schema field "heat_state".
-	HeatState *HeatState `json:"heat_state,omitempty"`
+	HeatState *HeatState `json:"heat_state,omitempty,omitzero"`
 
 	// Host corresponds to the JSON schema field "host".
 	Host string `json:"host"`
@@ -1106,7 +1112,7 @@ type PR struct {
 
 	// LastHeatActivityAt corresponds to the JSON schema field
 	// "last_heat_activity_at".
-	LastHeatActivityAt *string `json:"last_heat_activity_at,omitempty"`
+	LastHeatActivityAt *string `json:"last_heat_activity_at,omitempty,omitzero"`
 
 	// LastPolled corresponds to the JSON schema field "last_polled".
 	LastPolled string `json:"last_polled"`
@@ -1115,10 +1121,10 @@ type PR struct {
 	LastUpdated string `json:"last_updated"`
 
 	// Mergeable corresponds to the JSON schema field "mergeable".
-	Mergeable *bool `json:"mergeable,omitempty"`
+	Mergeable *bool `json:"mergeable,omitempty,omitzero"`
 
 	// MergeableState corresponds to the JSON schema field "mergeable_state".
-	MergeableState *string `json:"mergeable_state,omitempty"`
+	MergeableState *string `json:"mergeable_state,omitempty,omitzero"`
 
 	// Muted corresponds to the JSON schema field "muted".
 	Muted bool `json:"muted"`
@@ -1133,7 +1139,7 @@ type PR struct {
 	Repo string `json:"repo"`
 
 	// ReviewStatus corresponds to the JSON schema field "review_status".
-	ReviewStatus *string `json:"review_status,omitempty"`
+	ReviewStatus *string `json:"review_status,omitempty,omitzero"`
 
 	// Role corresponds to the JSON schema field "role".
 	Role PRRole `json:"role"`
@@ -1153,7 +1159,7 @@ type PRActionResultMessage struct {
 	Action string `json:"action"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -1183,7 +1189,7 @@ type PRsUpdatedMessage struct {
 	Event string `json:"event"`
 
 	// Prs corresponds to the JSON schema field "prs".
-	Prs []PR `json:"prs,omitempty"`
+	Prs []PR `json:"prs,omitempty,omitzero"`
 }
 
 type PathInspection struct {
@@ -1191,7 +1197,7 @@ type PathInspection struct {
 	Exists bool `json:"exists"`
 
 	// HomePath corresponds to the JSON schema field "home_path".
-	HomePath *string `json:"home_path,omitempty"`
+	HomePath *string `json:"home_path,omitempty,omitzero"`
 
 	// InputPath corresponds to the JSON schema field "input_path".
 	InputPath string `json:"input_path"`
@@ -1200,7 +1206,7 @@ type PathInspection struct {
 	IsDirectory bool `json:"is_directory"`
 
 	// RepoRoot corresponds to the JSON schema field "repo_root".
-	RepoRoot *string `json:"repo_root,omitempty"`
+	RepoRoot *string `json:"repo_root,omitempty,omitzero"`
 
 	// ResolvedPath corresponds to the JSON schema field "resolved_path".
 	ResolvedPath string `json:"resolved_path"`
@@ -1228,7 +1234,7 @@ type PtyInputMessage struct {
 	ID string `json:"id"`
 
 	// Source corresponds to the JSON schema field "source".
-	Source *string `json:"source,omitempty"`
+	Source *string `json:"source,omitempty,omitzero"`
 }
 
 type PtyOutputMessage struct {
@@ -1283,7 +1289,7 @@ type QueryMessage struct {
 	Cmd string `json:"cmd"`
 
 	// Filter corresponds to the JSON schema field "filter".
-	Filter *string `json:"filter,omitempty"`
+	Filter *string `json:"filter,omitempty,omitzero"`
 }
 
 type QueryPRsMessage struct {
@@ -1291,7 +1297,7 @@ type QueryPRsMessage struct {
 	Cmd string `json:"cmd"`
 
 	// Filter corresponds to the JSON schema field "filter".
-	Filter *string `json:"filter,omitempty"`
+	Filter *string `json:"filter,omitempty,omitzero"`
 }
 
 type QueryReposMessage struct {
@@ -1299,7 +1305,7 @@ type QueryReposMessage struct {
 	Cmd string `json:"cmd"`
 
 	// Filter corresponds to the JSON schema field "filter".
-	Filter *string `json:"filter,omitempty"`
+	Filter *string `json:"filter,omitempty,omitzero"`
 }
 
 type RateLimitedMessage struct {
@@ -1329,26 +1335,28 @@ type RecentLocation struct {
 
 type RecentLocationsResultMessage struct {
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// HomePath corresponds to the JSON schema field "home_path".
-	HomePath *string `json:"home_path,omitempty"`
+	HomePath *string `json:"home_path,omitempty,omitzero"`
 
 	// RecentLocations corresponds to the JSON schema field "recent_locations".
 	RecentLocations []RecentLocation `json:"recent_locations"`
 
 	// RequestID corresponds to the JSON schema field "request_id".
-	RequestID *string `json:"request_id,omitempty"`
+	RequestID *string `json:"request_id,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
 }
+
+type RecordString map[string]interface{}
 
 type RefreshPRsMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
@@ -1357,7 +1365,7 @@ type RefreshPRsMessage struct {
 
 type RefreshPRsResultMessage struct {
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -1368,7 +1376,7 @@ type RefreshPRsResultMessage struct {
 
 type RegisterMessage struct {
 	// Agent corresponds to the JSON schema field "agent".
-	Agent *SessionAgent `json:"agent,omitempty"`
+	Agent *SessionAgent `json:"agent,omitempty,omitzero"`
 
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -1380,7 +1388,7 @@ type RegisterMessage struct {
 	ID string `json:"id"`
 
 	// Label corresponds to the JSON schema field "label".
-	Label *string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty,omitzero"`
 }
 
 type RemoveEndpointMessage struct {
@@ -1419,7 +1427,7 @@ type RepoInfo struct {
 	DefaultBranch string `json:"default_branch"`
 
 	// FetchedAt corresponds to the JSON schema field "fetched_at".
-	FetchedAt *string `json:"fetched_at,omitempty"`
+	FetchedAt *string `json:"fetched_at,omitempty,omitzero"`
 
 	// Repo corresponds to the JSON schema field "repo".
 	Repo string `json:"repo"`
@@ -1444,7 +1452,7 @@ type ReposUpdatedMessage struct {
 	Event string `json:"event"`
 
 	// Repos corresponds to the JSON schema field "repos".
-	Repos []RepoState `json:"repos,omitempty"`
+	Repos []RepoState `json:"repos,omitempty,omitzero"`
 }
 
 type ResolveCommentMessage struct {
@@ -1460,7 +1468,7 @@ type ResolveCommentMessage struct {
 
 type ResolveCommentResultMessage struct {
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -1471,28 +1479,28 @@ type ResolveCommentResultMessage struct {
 
 type Response struct {
 	// Authors corresponds to the JSON schema field "authors".
-	Authors []AuthorState `json:"authors,omitempty"`
+	Authors []AuthorState `json:"authors,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Ok corresponds to the JSON schema field "ok".
 	Ok bool `json:"ok"`
 
 	// Prs corresponds to the JSON schema field "prs".
-	Prs []PR `json:"prs,omitempty"`
+	Prs []PR `json:"prs,omitempty,omitzero"`
 
 	// Repos corresponds to the JSON schema field "repos".
-	Repos []RepoState `json:"repos,omitempty"`
+	Repos []RepoState `json:"repos,omitempty,omitzero"`
 
 	// ReviewLoopRun corresponds to the JSON schema field "review_loop_run".
-	ReviewLoopRun *ReviewLoopRun `json:"review_loop_run,omitempty"`
+	ReviewLoopRun *ReviewLoopRun `json:"review_loop_run,omitempty,omitzero"`
 
 	// SessionLayouts corresponds to the JSON schema field "session_layouts".
-	SessionLayouts []SessionLayout `json:"session_layouts,omitempty"`
+	SessionLayouts []SessionLayout `json:"session_layouts,omitempty,omitzero"`
 
 	// Sessions corresponds to the JSON schema field "sessions".
-	Sessions []Session `json:"sessions,omitempty"`
+	Sessions []Session `json:"sessions,omitempty,omitzero"`
 }
 
 type ReviewComment struct {
@@ -1521,10 +1529,10 @@ type ReviewComment struct {
 	Resolved bool `json:"resolved"`
 
 	// ResolvedAt corresponds to the JSON schema field "resolved_at".
-	ResolvedAt *string `json:"resolved_at,omitempty"`
+	ResolvedAt *string `json:"resolved_at,omitempty,omitzero"`
 
 	// ResolvedBy corresponds to the JSON schema field "resolved_by".
-	ResolvedBy *string `json:"resolved_by,omitempty"`
+	ResolvedBy *string `json:"resolved_by,omitempty,omitzero"`
 
 	// ReviewID corresponds to the JSON schema field "review_id".
 	ReviewID string `json:"review_id"`
@@ -1539,13 +1547,13 @@ const ReviewLoopDecisionNeedsUserInput ReviewLoopDecision = "needs_user_input"
 
 type ReviewLoopInteraction struct {
 	// Answer corresponds to the JSON schema field "answer".
-	Answer *string `json:"answer,omitempty"`
+	Answer *string `json:"answer,omitempty,omitzero"`
 
 	// AnsweredAt corresponds to the JSON schema field "answered_at".
-	AnsweredAt *string `json:"answered_at,omitempty"`
+	AnsweredAt *string `json:"answered_at,omitempty,omitzero"`
 
 	// ConsumedAt corresponds to the JSON schema field "consumed_at".
-	ConsumedAt *string `json:"consumed_at,omitempty"`
+	ConsumedAt *string `json:"consumed_at,omitempty,omitzero"`
 
 	// CreatedAt corresponds to the JSON schema field "created_at".
 	CreatedAt string `json:"created_at"`
@@ -1554,7 +1562,7 @@ type ReviewLoopInteraction struct {
 	ID string `json:"id"`
 
 	// IterationID corresponds to the JSON schema field "iteration_id".
-	IterationID *string `json:"iteration_id,omitempty"`
+	IterationID *string `json:"iteration_id,omitempty,omitzero"`
 
 	// Kind corresponds to the JSON schema field "kind".
 	Kind string `json:"kind"`
@@ -1577,28 +1585,28 @@ const ReviewLoopInteractionStatusPending ReviewLoopInteractionStatus = "pending"
 
 type ReviewLoopIteration struct {
 	// AssistantTraceJson corresponds to the JSON schema field "assistant_trace_json".
-	AssistantTraceJson *string `json:"assistant_trace_json,omitempty"`
+	AssistantTraceJson *string `json:"assistant_trace_json,omitempty,omitzero"`
 
 	// BlockingReason corresponds to the JSON schema field "blocking_reason".
-	BlockingReason *string `json:"blocking_reason,omitempty"`
+	BlockingReason *string `json:"blocking_reason,omitempty,omitzero"`
 
 	// ChangeStats corresponds to the JSON schema field "change_stats".
-	ChangeStats []BranchDiffFile `json:"change_stats,omitempty"`
+	ChangeStats []BranchDiffFile `json:"change_stats,omitempty,omitzero"`
 
 	// ChangesMade corresponds to the JSON schema field "changes_made".
-	ChangesMade *bool `json:"changes_made,omitempty"`
+	ChangesMade *bool `json:"changes_made,omitempty,omitzero"`
 
 	// CompletedAt corresponds to the JSON schema field "completed_at".
-	CompletedAt *string `json:"completed_at,omitempty"`
+	CompletedAt *string `json:"completed_at,omitempty,omitzero"`
 
 	// Decision corresponds to the JSON schema field "decision".
-	Decision *ReviewLoopDecision `json:"decision,omitempty"`
+	Decision *ReviewLoopDecision `json:"decision,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// FilesTouched corresponds to the JSON schema field "files_touched".
-	FilesTouched []string `json:"files_touched,omitempty"`
+	FilesTouched []string `json:"files_touched,omitempty,omitzero"`
 
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
@@ -1610,7 +1618,7 @@ type ReviewLoopIteration struct {
 	LoopID string `json:"loop_id"`
 
 	// ResultText corresponds to the JSON schema field "result_text".
-	ResultText *string `json:"result_text,omitempty"`
+	ResultText *string `json:"result_text,omitempty,omitzero"`
 
 	// StartedAt corresponds to the JSON schema field "started_at".
 	StartedAt string `json:"started_at"`
@@ -1620,13 +1628,13 @@ type ReviewLoopIteration struct {
 
 	// StructuredOutputJson corresponds to the JSON schema field
 	// "structured_output_json".
-	StructuredOutputJson *string `json:"structured_output_json,omitempty"`
+	StructuredOutputJson *string `json:"structured_output_json,omitempty,omitzero"`
 
 	// SuggestedNextFocus corresponds to the JSON schema field "suggested_next_focus".
-	SuggestedNextFocus *string `json:"suggested_next_focus,omitempty"`
+	SuggestedNextFocus *string `json:"suggested_next_focus,omitempty,omitzero"`
 
 	// Summary corresponds to the JSON schema field "summary".
-	Summary *string `json:"summary,omitempty"`
+	Summary *string `json:"summary,omitempty,omitzero"`
 }
 
 type ReviewLoopIterationStatus string
@@ -1642,16 +1650,16 @@ type ReviewLoopResultMessage struct {
 	Action string `json:"action"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// LoopID corresponds to the JSON schema field "loop_id".
-	LoopID *string `json:"loop_id,omitempty"`
+	LoopID *string `json:"loop_id,omitempty,omitzero"`
 
 	// ReviewLoopRun corresponds to the JSON schema field "review_loop_run".
-	ReviewLoopRun *ReviewLoopRun `json:"review_loop_run,omitempty"`
+	ReviewLoopRun *ReviewLoopRun `json:"review_loop_run,omitempty,omitzero"`
 
 	// SessionID corresponds to the JSON schema field "session_id".
 	SessionID string `json:"session_id"`
@@ -1662,16 +1670,16 @@ type ReviewLoopResultMessage struct {
 
 type ReviewLoopRun struct {
 	// CompletedAt corresponds to the JSON schema field "completed_at".
-	CompletedAt *string `json:"completed_at,omitempty"`
+	CompletedAt *string `json:"completed_at,omitempty,omitzero"`
 
 	// CreatedAt corresponds to the JSON schema field "created_at".
 	CreatedAt string `json:"created_at"`
 
 	// CustomPrompt corresponds to the JSON schema field "custom_prompt".
-	CustomPrompt *string `json:"custom_prompt,omitempty"`
+	CustomPrompt *string `json:"custom_prompt,omitempty,omitzero"`
 
 	// HandoffPayloadJson corresponds to the JSON schema field "handoff_payload_json".
-	HandoffPayloadJson *string `json:"handoff_payload_json,omitempty"`
+	HandoffPayloadJson *string `json:"handoff_payload_json,omitempty,omitzero"`
 
 	// IterationCount corresponds to the JSON schema field "iteration_count".
 	IterationCount int `json:"iteration_count"`
@@ -1680,32 +1688,32 @@ type ReviewLoopRun struct {
 	IterationLimit int `json:"iteration_limit"`
 
 	// Iterations corresponds to the JSON schema field "iterations".
-	Iterations []ReviewLoopIteration `json:"iterations,omitempty"`
+	Iterations []ReviewLoopIteration `json:"iterations,omitempty,omitzero"`
 
 	// LastDecision corresponds to the JSON schema field "last_decision".
-	LastDecision *ReviewLoopDecision `json:"last_decision,omitempty"`
+	LastDecision *ReviewLoopDecision `json:"last_decision,omitempty,omitzero"`
 
 	// LastError corresponds to the JSON schema field "last_error".
-	LastError *string `json:"last_error,omitempty"`
+	LastError *string `json:"last_error,omitempty,omitzero"`
 
 	// LastResultSummary corresponds to the JSON schema field "last_result_summary".
-	LastResultSummary *string `json:"last_result_summary,omitempty"`
+	LastResultSummary *string `json:"last_result_summary,omitempty,omitzero"`
 
 	// LatestIteration corresponds to the JSON schema field "latest_iteration".
-	LatestIteration *ReviewLoopIteration `json:"latest_iteration,omitempty"`
+	LatestIteration *ReviewLoopIteration `json:"latest_iteration,omitempty,omitzero"`
 
 	// LoopID corresponds to the JSON schema field "loop_id".
 	LoopID string `json:"loop_id"`
 
 	// PendingInteraction corresponds to the JSON schema field "pending_interaction".
-	PendingInteraction *ReviewLoopInteraction `json:"pending_interaction,omitempty"`
+	PendingInteraction *ReviewLoopInteraction `json:"pending_interaction,omitempty,omitzero"`
 
 	// PendingInteractionID corresponds to the JSON schema field
 	// "pending_interaction_id".
-	PendingInteractionID *string `json:"pending_interaction_id,omitempty"`
+	PendingInteractionID *string `json:"pending_interaction_id,omitempty,omitzero"`
 
 	// PresetID corresponds to the JSON schema field "preset_id".
-	PresetID *string `json:"preset_id,omitempty"`
+	PresetID *string `json:"preset_id,omitempty,omitzero"`
 
 	// RepoPath corresponds to the JSON schema field "repo_path".
 	RepoPath string `json:"repo_path"`
@@ -1720,7 +1728,7 @@ type ReviewLoopRun struct {
 	Status ReviewLoopRunStatus `json:"status"`
 
 	// StopReason corresponds to the JSON schema field "stop_reason".
-	StopReason *string `json:"stop_reason,omitempty"`
+	StopReason *string `json:"stop_reason,omitempty,omitzero"`
 
 	// UpdatedAt corresponds to the JSON schema field "updated_at".
 	UpdatedAt string `json:"updated_at"`
@@ -1742,7 +1750,7 @@ type ReviewLoopState struct {
 	CreatedAt string `json:"created_at"`
 
 	// CustomPrompt corresponds to the JSON schema field "custom_prompt".
-	CustomPrompt *string `json:"custom_prompt,omitempty"`
+	CustomPrompt *string `json:"custom_prompt,omitempty,omitzero"`
 
 	// IterationCount corresponds to the JSON schema field "iteration_count".
 	IterationCount int `json:"iteration_count"`
@@ -1751,16 +1759,16 @@ type ReviewLoopState struct {
 	IterationLimit int `json:"iteration_limit"`
 
 	// LastAdvanceAt corresponds to the JSON schema field "last_advance_at".
-	LastAdvanceAt *string `json:"last_advance_at,omitempty"`
+	LastAdvanceAt *string `json:"last_advance_at,omitempty,omitzero"`
 
 	// LastPromptAt corresponds to the JSON schema field "last_prompt_at".
-	LastPromptAt *string `json:"last_prompt_at,omitempty"`
+	LastPromptAt *string `json:"last_prompt_at,omitempty,omitzero"`
 
 	// LastUserInputAt corresponds to the JSON schema field "last_user_input_at".
-	LastUserInputAt *string `json:"last_user_input_at,omitempty"`
+	LastUserInputAt *string `json:"last_user_input_at,omitempty,omitzero"`
 
 	// PresetID corresponds to the JSON schema field "preset_id".
-	PresetID *string `json:"preset_id,omitempty"`
+	PresetID *string `json:"preset_id,omitempty,omitzero"`
 
 	// ResolvedPrompt corresponds to the JSON schema field "resolved_prompt".
 	ResolvedPrompt string `json:"resolved_prompt"`
@@ -1772,7 +1780,7 @@ type ReviewLoopState struct {
 	Status ReviewLoopStatus `json:"status"`
 
 	// StopReason corresponds to the JSON schema field "stop_reason".
-	StopReason *string `json:"stop_reason,omitempty"`
+	StopReason *string `json:"stop_reason,omitempty,omitzero"`
 
 	// StopRequested corresponds to the JSON schema field "stop_requested".
 	StopRequested bool `json:"stop_requested"`
@@ -1795,7 +1803,7 @@ type ReviewLoopUpdatedMessage struct {
 	Event string `json:"event"`
 
 	// ReviewLoopRun corresponds to the JSON schema field "review_loop_run".
-	ReviewLoopRun *ReviewLoopRun `json:"review_loop_run,omitempty"`
+	ReviewLoopRun *ReviewLoopRun `json:"review_loop_run,omitempty,omitzero"`
 
 	// SessionID corresponds to the JSON schema field "session_id".
 	SessionID string `json:"session_id"`
@@ -1820,19 +1828,19 @@ type Session struct {
 	Agent SessionAgent `json:"agent"`
 
 	// Branch corresponds to the JSON schema field "branch".
-	Branch *string `json:"branch,omitempty"`
+	Branch *string `json:"branch,omitempty,omitzero"`
 
 	// Directory corresponds to the JSON schema field "directory".
 	Directory string `json:"directory"`
 
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
 
 	// IsWorktree corresponds to the JSON schema field "is_worktree".
-	IsWorktree *bool `json:"is_worktree,omitempty"`
+	IsWorktree *bool `json:"is_worktree,omitempty,omitzero"`
 
 	// Label corresponds to the JSON schema field "label".
 	Label string `json:"label"`
@@ -1841,17 +1849,17 @@ type Session struct {
 	LastSeen string `json:"last_seen"`
 
 	// MainRepo corresponds to the JSON schema field "main_repo".
-	MainRepo *string `json:"main_repo,omitempty"`
+	MainRepo *string `json:"main_repo,omitempty,omitzero"`
 
 	// Muted corresponds to the JSON schema field "muted".
 	Muted bool `json:"muted"`
 
 	// NeedsReviewAfterLongRun corresponds to the JSON schema field
 	// "needs_review_after_long_run".
-	NeedsReviewAfterLongRun *bool `json:"needs_review_after_long_run,omitempty"`
+	NeedsReviewAfterLongRun *bool `json:"needs_review_after_long_run,omitempty,omitzero"`
 
 	// Recoverable corresponds to the JSON schema field "recoverable".
-	Recoverable *bool `json:"recoverable,omitempty"`
+	Recoverable *bool `json:"recoverable,omitempty,omitzero"`
 
 	// State corresponds to the JSON schema field "state".
 	State SessionState `json:"state"`
@@ -1863,7 +1871,7 @@ type Session struct {
 	StateUpdatedAt string `json:"state_updated_at"`
 
 	// Todos corresponds to the JSON schema field "todos".
-	Todos []string `json:"todos,omitempty"`
+	Todos []string `json:"todos,omitempty,omitzero"`
 }
 
 type SessionAgent string
@@ -1884,7 +1892,7 @@ type SessionExitedMessage struct {
 	ID string `json:"id"`
 
 	// Signal corresponds to the JSON schema field "signal".
-	Signal *string `json:"signal,omitempty"`
+	Signal *string `json:"signal,omitempty,omitzero"`
 }
 
 type SessionLayout struct {
@@ -1901,7 +1909,7 @@ type SessionLayout struct {
 	SessionID string `json:"session_id"`
 
 	// UpdatedAt corresponds to the JSON schema field "updated_at".
-	UpdatedAt *string `json:"updated_at,omitempty"`
+	UpdatedAt *string `json:"updated_at,omitempty,omitzero"`
 }
 
 type SessionLayoutActionResultMessage struct {
@@ -1909,13 +1917,13 @@ type SessionLayoutActionResultMessage struct {
 	Action string `json:"action"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// PaneID corresponds to the JSON schema field "pane_id".
-	PaneID *string `json:"pane_id,omitempty"`
+	PaneID *string `json:"pane_id,omitempty,omitzero"`
 
 	// SessionID corresponds to the JSON schema field "session_id".
 	SessionID string `json:"session_id"`
@@ -1970,7 +1978,7 @@ type SessionLayoutPane struct {
 	PaneID string `json:"pane_id"`
 
 	// RuntimeID corresponds to the JSON schema field "runtime_id".
-	RuntimeID *string `json:"runtime_id,omitempty"`
+	RuntimeID *string `json:"runtime_id,omitempty,omitzero"`
 
 	// Title corresponds to the JSON schema field "title".
 	Title string `json:"title"`
@@ -2012,7 +2020,7 @@ type SessionLayoutRuntimeExitedMessage struct {
 	SessionID string `json:"session_id"`
 
 	// Signal corresponds to the JSON schema field "signal".
-	Signal *string `json:"signal,omitempty"`
+	Signal *string `json:"signal,omitempty,omitzero"`
 }
 
 type SessionLayoutSplitDirection string
@@ -2096,7 +2104,7 @@ type SessionsUpdatedMessage struct {
 	Event string `json:"event"`
 
 	// Sessions corresponds to the JSON schema field "sessions".
-	Sessions []Session `json:"sessions,omitempty"`
+	Sessions []Session `json:"sessions,omitempty,omitzero"`
 }
 
 type SetEndpointRemoteWebMessage struct {
@@ -2145,24 +2153,24 @@ type SetSettingMessage struct {
 
 type SettingsUpdatedMessage struct {
 	// ChangedKey corresponds to the JSON schema field "changed_key".
-	ChangedKey *string `json:"changed_key,omitempty"`
+	ChangedKey *string `json:"changed_key,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// Settings corresponds to the JSON schema field "settings".
-	Settings map[string]interface{} `json:"settings,omitempty"`
+	Settings RecordString `json:"settings,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
-	Success *bool `json:"success,omitempty"`
+	Success *bool `json:"success,omitempty,omitzero"`
 }
 
 type SpawnResultMessage struct {
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -2179,52 +2187,52 @@ type SpawnSessionMessage struct {
 	Agent string `json:"agent"`
 
 	// ClaudeExecutable corresponds to the JSON schema field "claude_executable".
-	ClaudeExecutable *string `json:"claude_executable,omitempty"`
+	ClaudeExecutable *string `json:"claude_executable,omitempty,omitzero"`
 
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
 
 	// CodexExecutable corresponds to the JSON schema field "codex_executable".
-	CodexExecutable *string `json:"codex_executable,omitempty"`
+	CodexExecutable *string `json:"codex_executable,omitempty,omitzero"`
 
 	// Cols corresponds to the JSON schema field "cols".
 	Cols int `json:"cols"`
 
 	// CopilotExecutable corresponds to the JSON schema field "copilot_executable".
-	CopilotExecutable *string `json:"copilot_executable,omitempty"`
+	CopilotExecutable *string `json:"copilot_executable,omitempty,omitzero"`
 
 	// Cwd corresponds to the JSON schema field "cwd".
 	Cwd string `json:"cwd"`
 
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
-	EndpointID *string `json:"endpoint_id,omitempty"`
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
 	// Executable corresponds to the JSON schema field "executable".
-	Executable *string `json:"executable,omitempty"`
+	Executable *string `json:"executable,omitempty,omitzero"`
 
 	// ForkSession corresponds to the JSON schema field "fork_session".
-	ForkSession *bool `json:"fork_session,omitempty"`
+	ForkSession *bool `json:"fork_session,omitempty,omitzero"`
 
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
 
 	// Label corresponds to the JSON schema field "label".
-	Label *string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty,omitzero"`
 
 	// PiExecutable corresponds to the JSON schema field "pi_executable".
-	PiExecutable *string `json:"pi_executable,omitempty"`
+	PiExecutable *string `json:"pi_executable,omitempty,omitzero"`
 
 	// ResumePicker corresponds to the JSON schema field "resume_picker".
-	ResumePicker *bool `json:"resume_picker,omitempty"`
+	ResumePicker *bool `json:"resume_picker,omitempty,omitzero"`
 
 	// ResumeSessionID corresponds to the JSON schema field "resume_session_id".
-	ResumeSessionID *string `json:"resume_session_id,omitempty"`
+	ResumeSessionID *string `json:"resume_session_id,omitempty,omitzero"`
 
 	// Rows corresponds to the JSON schema field "rows".
 	Rows int `json:"rows"`
 
 	// YoloMode corresponds to the JSON schema field "yolo_mode".
-	YoloMode *bool `json:"yolo_mode,omitempty"`
+	YoloMode *bool `json:"yolo_mode,omitempty,omitzero"`
 }
 
 type StartReviewLoopMessage struct {
@@ -2232,13 +2240,13 @@ type StartReviewLoopMessage struct {
 	Cmd string `json:"cmd"`
 
 	// HandoffPayloadJson corresponds to the JSON schema field "handoff_payload_json".
-	HandoffPayloadJson *string `json:"handoff_payload_json,omitempty"`
+	HandoffPayloadJson *string `json:"handoff_payload_json,omitempty,omitzero"`
 
 	// IterationLimit corresponds to the JSON schema field "iteration_limit".
 	IterationLimit int `json:"iteration_limit"`
 
 	// PresetID corresponds to the JSON schema field "preset_id".
-	PresetID *string `json:"preset_id,omitempty"`
+	PresetID *string `json:"preset_id,omitempty,omitzero"`
 
 	// Prompt corresponds to the JSON schema field "prompt".
 	Prompt string `json:"prompt"`
@@ -2322,7 +2330,7 @@ type UpdateCommentMessage struct {
 
 type UpdateCommentResultMessage struct {
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -2336,201 +2344,204 @@ type UpdateEndpointMessage struct {
 	Cmd string `json:"cmd"`
 
 	// Enabled corresponds to the JSON schema field "enabled".
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty,omitzero"`
 
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
 	EndpointID string `json:"endpoint_id"`
 
 	// Name corresponds to the JSON schema field "name".
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty,omitzero"`
+
+	// Profile corresponds to the JSON schema field "profile".
+	Profile *string `json:"profile,omitempty,omitzero"`
 
 	// SshTarget corresponds to the JSON schema field "ssh_target".
-	SshTarget *string `json:"ssh_target,omitempty"`
+	SshTarget *string `json:"ssh_target,omitempty,omitzero"`
 }
 
 type WebSocketEvent struct {
 	// Action corresponds to the JSON schema field "action".
-	Action *string `json:"action,omitempty"`
+	Action *string `json:"action,omitempty,omitzero"`
 
 	// Authors corresponds to the JSON schema field "authors".
-	Authors []AuthorState `json:"authors,omitempty"`
+	Authors []AuthorState `json:"authors,omitempty,omitzero"`
 
 	// BaseRef corresponds to the JSON schema field "base_ref".
-	BaseRef *string `json:"base_ref,omitempty"`
+	BaseRef *string `json:"base_ref,omitempty,omitzero"`
 
 	// Branch corresponds to the JSON schema field "branch".
-	Branch *string `json:"branch,omitempty"`
+	Branch *string `json:"branch,omitempty,omitzero"`
 
 	// Branches corresponds to the JSON schema field "branches".
-	Branches []Branch `json:"branches,omitempty"`
+	Branches []Branch `json:"branches,omitempty,omitzero"`
 
 	// Cloned corresponds to the JSON schema field "cloned".
-	Cloned *bool `json:"cloned,omitempty"`
+	Cloned *bool `json:"cloned,omitempty,omitzero"`
 
 	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd *string `json:"cmd,omitempty"`
+	Cmd *string `json:"cmd,omitempty,omitzero"`
 
 	// Cols corresponds to the JSON schema field "cols".
-	Cols *int `json:"cols,omitempty"`
+	Cols *int `json:"cols,omitempty,omitzero"`
 
 	// Conflict corresponds to the JSON schema field "conflict".
-	Conflict *bool `json:"conflict,omitempty"`
+	Conflict *bool `json:"conflict,omitempty,omitzero"`
 
 	// Data corresponds to the JSON schema field "data".
-	Data *string `json:"data,omitempty"`
+	Data *string `json:"data,omitempty,omitzero"`
 
 	// Directory corresponds to the JSON schema field "directory".
-	Directory *string `json:"directory,omitempty"`
+	Directory *string `json:"directory,omitempty,omitzero"`
 
 	// Dirty corresponds to the JSON schema field "dirty".
-	Dirty *bool `json:"dirty,omitempty"`
+	Dirty *bool `json:"dirty,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty"`
+	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
 	// ExitCode corresponds to the JSON schema field "exit_code".
-	ExitCode *int `json:"exit_code,omitempty"`
+	ExitCode *int `json:"exit_code,omitempty,omitzero"`
 
 	// Files corresponds to the JSON schema field "files".
-	Files []BranchDiffFile `json:"files,omitempty"`
+	Files []BranchDiffFile `json:"files,omitempty,omitzero"`
 
 	// Found corresponds to the JSON schema field "found".
-	Found *bool `json:"found,omitempty"`
+	Found *bool `json:"found,omitempty,omitzero"`
 
 	// ID corresponds to the JSON schema field "id".
-	ID *string `json:"id,omitempty"`
+	ID *string `json:"id,omitempty,omitzero"`
 
 	// LastSeq corresponds to the JSON schema field "last_seq".
-	LastSeq *int `json:"last_seq,omitempty"`
+	LastSeq *int `json:"last_seq,omitempty,omitzero"`
 
 	// Modified corresponds to the JSON schema field "modified".
-	Modified *string `json:"modified,omitempty"`
+	Modified *string `json:"modified,omitempty,omitzero"`
 
 	// Original corresponds to the JSON schema field "original".
-	Original *string `json:"original,omitempty"`
+	Original *string `json:"original,omitempty,omitzero"`
 
 	// PaneID corresponds to the JSON schema field "pane_id".
-	PaneID *string `json:"pane_id,omitempty"`
+	PaneID *string `json:"pane_id,omitempty,omitzero"`
 
 	// Path corresponds to the JSON schema field "path".
-	Path *string `json:"path,omitempty"`
+	Path *string `json:"path,omitempty,omitzero"`
 
 	// Pid corresponds to the JSON schema field "pid".
-	Pid *int `json:"pid,omitempty"`
+	Pid *int `json:"pid,omitempty,omitzero"`
 
 	// ProtocolVersion corresponds to the JSON schema field "protocol_version".
-	ProtocolVersion *string `json:"protocol_version,omitempty"`
+	ProtocolVersion *string `json:"protocol_version,omitempty,omitzero"`
 
 	// Prs corresponds to the JSON schema field "prs".
-	Prs []PR `json:"prs,omitempty"`
+	Prs []PR `json:"prs,omitempty,omitzero"`
 
 	// RateLimitResetAt corresponds to the JSON schema field "rate_limit_reset_at".
-	RateLimitResetAt *string `json:"rate_limit_reset_at,omitempty"`
+	RateLimitResetAt *string `json:"rate_limit_reset_at,omitempty,omitzero"`
 
 	// RateLimitResource corresponds to the JSON schema field "rate_limit_resource".
-	RateLimitResource *string `json:"rate_limit_resource,omitempty"`
+	RateLimitResource *string `json:"rate_limit_resource,omitempty,omitzero"`
 
 	// Reason corresponds to the JSON schema field "reason".
-	Reason *string `json:"reason,omitempty"`
+	Reason *string `json:"reason,omitempty,omitzero"`
 
 	// RecentLocations corresponds to the JSON schema field "recent_locations".
-	RecentLocations []RecentLocation `json:"recent_locations,omitempty"`
+	RecentLocations []RecentLocation `json:"recent_locations,omitempty,omitzero"`
 
 	// Repos corresponds to the JSON schema field "repos".
-	Repos []RepoState `json:"repos,omitempty"`
+	Repos []RepoState `json:"repos,omitempty,omitzero"`
 
 	// ReviewLoopRun corresponds to the JSON schema field "review_loop_run".
-	ReviewLoopRun *ReviewLoopRun `json:"review_loop_run,omitempty"`
+	ReviewLoopRun *ReviewLoopRun `json:"review_loop_run,omitempty,omitzero"`
 
 	// Rows corresponds to the JSON schema field "rows".
-	Rows *int `json:"rows,omitempty"`
+	Rows *int `json:"rows,omitempty,omitzero"`
 
 	// Running corresponds to the JSON schema field "running".
-	Running *bool `json:"running,omitempty"`
+	Running *bool `json:"running,omitempty,omitzero"`
 
 	// RuntimeID corresponds to the JSON schema field "runtime_id".
-	RuntimeID *string `json:"runtime_id,omitempty"`
+	RuntimeID *string `json:"runtime_id,omitempty,omitzero"`
 
 	// ScreenCols corresponds to the JSON schema field "screen_cols".
-	ScreenCols *int `json:"screen_cols,omitempty"`
+	ScreenCols *int `json:"screen_cols,omitempty,omitzero"`
 
 	// ScreenCursorVisible corresponds to the JSON schema field
 	// "screen_cursor_visible".
-	ScreenCursorVisible *bool `json:"screen_cursor_visible,omitempty"`
+	ScreenCursorVisible *bool `json:"screen_cursor_visible,omitempty,omitzero"`
 
 	// ScreenCursorX corresponds to the JSON schema field "screen_cursor_x".
-	ScreenCursorX *int `json:"screen_cursor_x,omitempty"`
+	ScreenCursorX *int `json:"screen_cursor_x,omitempty,omitzero"`
 
 	// ScreenCursorY corresponds to the JSON schema field "screen_cursor_y".
-	ScreenCursorY *int `json:"screen_cursor_y,omitempty"`
+	ScreenCursorY *int `json:"screen_cursor_y,omitempty,omitzero"`
 
 	// ScreenRows corresponds to the JSON schema field "screen_rows".
-	ScreenRows *int `json:"screen_rows,omitempty"`
+	ScreenRows *int `json:"screen_rows,omitempty,omitzero"`
 
 	// ScreenSnapshot corresponds to the JSON schema field "screen_snapshot".
-	ScreenSnapshot *string `json:"screen_snapshot,omitempty"`
+	ScreenSnapshot *string `json:"screen_snapshot,omitempty,omitzero"`
 
 	// ScreenSnapshotFresh corresponds to the JSON schema field
 	// "screen_snapshot_fresh".
-	ScreenSnapshotFresh *bool `json:"screen_snapshot_fresh,omitempty"`
+	ScreenSnapshotFresh *bool `json:"screen_snapshot_fresh,omitempty,omitzero"`
 
 	// Scrollback corresponds to the JSON schema field "scrollback".
-	Scrollback *string `json:"scrollback,omitempty"`
+	Scrollback *string `json:"scrollback,omitempty,omitzero"`
 
 	// ScrollbackTruncated corresponds to the JSON schema field
 	// "scrollback_truncated".
-	ScrollbackTruncated *bool `json:"scrollback_truncated,omitempty"`
+	ScrollbackTruncated *bool `json:"scrollback_truncated,omitempty,omitzero"`
 
 	// Seq corresponds to the JSON schema field "seq".
-	Seq *int `json:"seq,omitempty"`
+	Seq *int `json:"seq,omitempty,omitzero"`
 
 	// Session corresponds to the JSON schema field "session".
-	Session *Session `json:"session,omitempty"`
+	Session *Session `json:"session,omitempty,omitzero"`
 
 	// SessionID corresponds to the JSON schema field "session_id".
-	SessionID *string `json:"session_id,omitempty"`
+	SessionID *string `json:"session_id,omitempty,omitzero"`
 
 	// SessionLayout corresponds to the JSON schema field "session_layout".
-	SessionLayout *SessionLayout `json:"session_layout,omitempty"`
+	SessionLayout *SessionLayout `json:"session_layout,omitempty,omitzero"`
 
 	// SessionLayouts corresponds to the JSON schema field "session_layouts".
-	SessionLayouts []SessionLayout `json:"session_layouts,omitempty"`
+	SessionLayouts []SessionLayout `json:"session_layouts,omitempty,omitzero"`
 
 	// Sessions corresponds to the JSON schema field "sessions".
-	Sessions []Session `json:"sessions,omitempty"`
+	Sessions []Session `json:"sessions,omitempty,omitzero"`
 
 	// Settings corresponds to the JSON schema field "settings".
-	Settings map[string]interface{} `json:"settings,omitempty"`
+	Settings RecordString `json:"settings,omitempty,omitzero"`
 
 	// Signal corresponds to the JSON schema field "signal".
-	Signal *string `json:"signal,omitempty"`
+	Signal *string `json:"signal,omitempty,omitzero"`
 
 	// Staged corresponds to the JSON schema field "staged".
-	Staged []GitFileChange `json:"staged,omitempty"`
+	Staged []GitFileChange `json:"staged,omitempty,omitzero"`
 
 	// StashRef corresponds to the JSON schema field "stash_ref".
-	StashRef *string `json:"stash_ref,omitempty"`
+	StashRef *string `json:"stash_ref,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
-	Success *bool `json:"success,omitempty"`
+	Success *bool `json:"success,omitempty,omitzero"`
 
 	// TargetPath corresponds to the JSON schema field "target_path".
-	TargetPath *string `json:"target_path,omitempty"`
+	TargetPath *string `json:"target_path,omitempty,omitzero"`
 
 	// Unstaged corresponds to the JSON schema field "unstaged".
-	Unstaged []GitFileChange `json:"unstaged,omitempty"`
+	Unstaged []GitFileChange `json:"unstaged,omitempty,omitzero"`
 
 	// Untracked corresponds to the JSON schema field "untracked".
-	Untracked []GitFileChange `json:"untracked,omitempty"`
+	Untracked []GitFileChange `json:"untracked,omitempty,omitzero"`
 
 	// Warnings corresponds to the JSON schema field "warnings".
-	Warnings []DaemonWarning `json:"warnings,omitempty"`
+	Warnings []DaemonWarning `json:"warnings,omitempty,omitzero"`
 
 	// Worktrees corresponds to the JSON schema field "worktrees".
-	Worktrees []Worktree `json:"worktrees,omitempty"`
+	Worktrees []Worktree `json:"worktrees,omitempty,omitzero"`
 }
 
 type Worktree struct {
@@ -2538,7 +2549,7 @@ type Worktree struct {
 	Branch string `json:"branch"`
 
 	// CreatedAt corresponds to the JSON schema field "created_at".
-	CreatedAt *string `json:"created_at,omitempty"`
+	CreatedAt *string `json:"created_at,omitempty,omitzero"`
 
 	// MainRepo corresponds to the JSON schema field "main_repo".
 	MainRepo string `json:"main_repo"`
@@ -2568,5 +2579,5 @@ type WorktreesUpdatedMessage struct {
 	Event string `json:"event"`
 
 	// Worktrees corresponds to the JSON schema field "worktrees".
-	Worktrees []Worktree `json:"worktrees,omitempty"`
+	Worktrees []Worktree `json:"worktrees,omitempty,omitzero"`
 }

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -245,6 +245,7 @@ model EndpointInfo {
   ssh_target: string;
   status: string;
   enabled?: boolean;
+  profile?: string;
   status_message?: string;
   session_count?: int32;
   capabilities?: EndpointCapabilities;
@@ -402,6 +403,7 @@ model AddEndpointMessage {
   cmd: "add_endpoint";
   name: string;
   ssh_target: string;
+  profile?: string;
 }
 
 model RemoveEndpointMessage {
@@ -415,6 +417,7 @@ model UpdateEndpointMessage {
   name?: string;
   ssh_target?: string;
   enabled?: boolean;
+  profile?: string;
 }
 
 model ListEndpointsMessage {

--- a/internal/store/endpoints.go
+++ b/internal/store/endpoints.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -14,6 +15,7 @@ type EndpointRecord struct {
 	Name      string
 	SSHTarget string
 	Enabled   bool
+	Profile   string
 	CreatedAt string
 	UpdatedAt string
 }
@@ -22,9 +24,16 @@ type EndpointUpdate struct {
 	Name      *string
 	SSHTarget *string
 	Enabled   *bool
+	Profile   *string
 }
 
-func (s *Store) AddEndpoint(name, sshTarget string) (*EndpointRecord, error) {
+func (s *Store) AddEndpoint(name, sshTarget, profile string) (*EndpointRecord, error) {
+	canonicalProfile, err := config.NormalizeProfileName(profile)
+	if err != nil {
+		return nil, err
+	}
+	profile = canonicalProfile
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -38,16 +47,18 @@ func (s *Store) AddEndpoint(name, sshTarget string) (*EndpointRecord, error) {
 		Name:      strings.TrimSpace(name),
 		SSHTarget: strings.TrimSpace(sshTarget),
 		Enabled:   true,
+		Profile:   profile,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
 	if _, err := s.db.Exec(`
-		INSERT INTO endpoints (id, name, ssh_target, enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?)`,
+		INSERT INTO endpoints (id, name, ssh_target, enabled, profile, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		record.ID,
 		record.Name,
 		record.SSHTarget,
 		boolToInt(record.Enabled),
+		record.Profile,
 		record.CreatedAt,
 		record.UpdatedAt,
 	); err != nil {
@@ -67,13 +78,14 @@ func (s *Store) GetEndpoint(id string) *EndpointRecord {
 	var record EndpointRecord
 	var enabled int
 	err := s.db.QueryRow(`
-		SELECT id, name, ssh_target, enabled, created_at, updated_at
+		SELECT id, name, ssh_target, enabled, profile, created_at, updated_at
 		FROM endpoints
 		WHERE id = ?`, id).Scan(
 		&record.ID,
 		&record.Name,
 		&record.SSHTarget,
 		&enabled,
+		&record.Profile,
 		&record.CreatedAt,
 		&record.UpdatedAt,
 	)
@@ -93,7 +105,7 @@ func (s *Store) ListEndpoints() []EndpointRecord {
 	}
 
 	rows, err := s.db.Query(`
-		SELECT id, name, ssh_target, enabled, created_at, updated_at
+		SELECT id, name, ssh_target, enabled, profile, created_at, updated_at
 		FROM endpoints
 		ORDER BY created_at ASC`)
 	if err != nil {
@@ -111,6 +123,7 @@ func (s *Store) ListEndpoints() []EndpointRecord {
 			&record.Name,
 			&record.SSHTarget,
 			&enabled,
+			&record.Profile,
 			&record.CreatedAt,
 			&record.UpdatedAt,
 		); err != nil {
@@ -127,6 +140,14 @@ func (s *Store) ListEndpoints() []EndpointRecord {
 }
 
 func (s *Store) UpdateEndpoint(id string, update EndpointUpdate) (*EndpointRecord, error) {
+	if update.Profile != nil {
+		canonical, err := config.NormalizeProfileName(*update.Profile)
+		if err != nil {
+			return nil, err
+		}
+		update.Profile = &canonical
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -137,13 +158,14 @@ func (s *Store) UpdateEndpoint(id string, update EndpointUpdate) (*EndpointRecor
 	var record EndpointRecord
 	var enabled int
 	err := s.db.QueryRow(`
-		SELECT id, name, ssh_target, enabled, created_at, updated_at
+		SELECT id, name, ssh_target, enabled, profile, created_at, updated_at
 		FROM endpoints
 		WHERE id = ?`, id).Scan(
 		&record.ID,
 		&record.Name,
 		&record.SSHTarget,
 		&enabled,
+		&record.Profile,
 		&record.CreatedAt,
 		&record.UpdatedAt,
 	)
@@ -161,15 +183,19 @@ func (s *Store) UpdateEndpoint(id string, update EndpointUpdate) (*EndpointRecor
 	if update.Enabled != nil {
 		record.Enabled = *update.Enabled
 	}
+	if update.Profile != nil {
+		record.Profile = *update.Profile
+	}
 	record.UpdatedAt = string(protocol.TimestampNow())
 
 	if _, err := s.db.Exec(`
 		UPDATE endpoints
-		SET name = ?, ssh_target = ?, enabled = ?, updated_at = ?
+		SET name = ?, ssh_target = ?, enabled = ?, profile = ?, updated_at = ?
 		WHERE id = ?`,
 		record.Name,
 		record.SSHTarget,
 		boolToInt(record.Enabled),
+		record.Profile,
 		record.UpdatedAt,
 		record.ID,
 	); err != nil {

--- a/internal/store/endpoints_test.go
+++ b/internal/store/endpoints_test.go
@@ -1,13 +1,15 @@
 package store
 
 import (
+	"database/sql"
+	"path/filepath"
 	"testing"
 )
 
 func TestStoreEndpointCRUD(t *testing.T) {
 	s := New()
 
-	record, err := s.AddEndpoint("gpu-box", "user@example")
+	record, err := s.AddEndpoint("gpu-box", "user@example", "")
 	if err != nil {
 		t.Fatalf("AddEndpoint() error = %v", err)
 	}
@@ -16,6 +18,9 @@ func TestStoreEndpointCRUD(t *testing.T) {
 	}
 	if !record.Enabled {
 		t.Fatal("AddEndpoint() should default enabled=true")
+	}
+	if record.Profile != "" {
+		t.Fatalf("AddEndpoint() Profile = %q, want empty", record.Profile)
 	}
 
 	got := s.GetEndpoint(record.ID)
@@ -32,10 +37,12 @@ func TestStoreEndpointCRUD(t *testing.T) {
 	name := "gpu-box-2"
 	target := "dev@example"
 	enabled := false
+	profile := "dev"
 	updated, err := s.UpdateEndpoint(record.ID, EndpointUpdate{
 		Name:      &name,
 		SSHTarget: &target,
 		Enabled:   &enabled,
+		Profile:   &profile,
 	})
 	if err != nil {
 		t.Fatalf("UpdateEndpoint() error = %v", err)
@@ -49,6 +56,9 @@ func TestStoreEndpointCRUD(t *testing.T) {
 	if updated.Enabled {
 		t.Fatal("UpdateEndpoint().Enabled = true, want false")
 	}
+	if updated.Profile != profile {
+		t.Fatalf("UpdateEndpoint().Profile = %q, want %q", updated.Profile, profile)
+	}
 
 	list := s.ListEndpoints()
 	if len(list) != 1 {
@@ -57,11 +67,169 @@ func TestStoreEndpointCRUD(t *testing.T) {
 	if list[0].ID != record.ID {
 		t.Fatalf("ListEndpoints()[0].ID = %q, want %q", list[0].ID, record.ID)
 	}
+	if list[0].Profile != profile {
+		t.Fatalf("ListEndpoints()[0].Profile = %q, want %q", list[0].Profile, profile)
+	}
 
 	if err := s.RemoveEndpoint(record.ID); err != nil {
 		t.Fatalf("RemoveEndpoint() error = %v", err)
 	}
 	if got := s.GetEndpoint(record.ID); got != nil {
 		t.Fatalf("GetEndpoint() after remove = %+v, want nil", got)
+	}
+}
+
+func TestAddEndpointWithProfile(t *testing.T) {
+	s := New()
+
+	record, err := s.AddEndpoint("gpu-box", "user@example", "dev")
+	if err != nil {
+		t.Fatalf("AddEndpoint() error = %v", err)
+	}
+	if record.Profile != "dev" {
+		t.Fatalf("AddEndpoint() Profile = %q, want dev", record.Profile)
+	}
+
+	got := s.GetEndpoint(record.ID)
+	if got == nil || got.Profile != "dev" {
+		t.Fatalf("GetEndpoint() Profile = %q, want dev", got.Profile)
+	}
+}
+
+func TestAddEndpointNormalizesProfileCase(t *testing.T) {
+	s := New()
+
+	record, err := s.AddEndpoint("gpu-box", "user@example", "DEV")
+	if err != nil {
+		t.Fatalf("AddEndpoint(\"DEV\") error = %v", err)
+	}
+	if record.Profile != "dev" {
+		t.Fatalf("AddEndpoint(\"DEV\") Profile = %q, want %q (must be lowercased so $ATTN_PROFILE on the remote — which is already lowercased by config.Profile() — produces the same data dir as the install path the hub builds locally)", record.Profile, "dev")
+	}
+}
+
+func TestUpdateEndpointClearsProfileWithEmptyString(t *testing.T) {
+	s := New()
+	record, err := s.AddEndpoint("gpu-box", "user@example", "dev")
+	if err != nil {
+		t.Fatalf("AddEndpoint(): %v", err)
+	}
+	if record.Profile != "dev" {
+		t.Fatalf("setup: profile = %q, want dev", record.Profile)
+	}
+
+	empty := ""
+	updated, err := s.UpdateEndpoint(record.ID, EndpointUpdate{Profile: &empty})
+	if err != nil {
+		t.Fatalf("UpdateEndpoint(profile=\"\") error = %v", err)
+	}
+	if updated.Profile != "" {
+		t.Fatalf("UpdateEndpoint(profile=\"\") Profile = %q, want empty (a non-nil empty pointer must clear the profile back to default)", updated.Profile)
+	}
+
+	got := s.GetEndpoint(record.ID)
+	if got == nil || got.Profile != "" {
+		t.Fatalf("GetEndpoint() Profile = %q, want empty", got.Profile)
+	}
+}
+
+func TestUpdateEndpointNormalizesProfileCase(t *testing.T) {
+	s := New()
+	record, err := s.AddEndpoint("gpu-box", "user@example", "")
+	if err != nil {
+		t.Fatalf("AddEndpoint(): %v", err)
+	}
+
+	upper := "DEV"
+	updated, err := s.UpdateEndpoint(record.ID, EndpointUpdate{Profile: &upper})
+	if err != nil {
+		t.Fatalf("UpdateEndpoint(profile=\"DEV\") error = %v", err)
+	}
+	if updated.Profile != "dev" {
+		t.Fatalf("UpdateEndpoint(profile=\"DEV\") Profile = %q, want \"dev\"", updated.Profile)
+	}
+}
+
+func TestAddEndpointRejectsInvalidProfile(t *testing.T) {
+	s := New()
+
+	cases := []string{
+		"with space",
+		"a-very-long-profile-name-over-limit",
+		"-leading-dash",
+	}
+	for _, profile := range cases {
+		t.Run(profile, func(t *testing.T) {
+			if _, err := s.AddEndpoint("gpu-box", "user@example", profile); err == nil {
+				t.Fatalf("AddEndpoint(%q) succeeded, want validation error", profile)
+			}
+		})
+	}
+}
+
+func TestEndpointMigration34BackfillsBlankProfile(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "legacy.db")
+
+	// Simulate a legacy DB created before migration 34 by opening, dropping the
+	// profile column from baseSchema is not possible in SQLite; instead, reset
+	// the schema_migrations row for 34 and the profile column, mimicking an
+	// upgrade from a pre-34 release.
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE endpoints (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			ssh_target TEXT NOT NULL,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		CREATE TABLE schema_migrations (
+			version INTEGER PRIMARY KEY,
+			applied_at TEXT NOT NULL
+		);
+		INSERT INTO endpoints (id, name, ssh_target, enabled, created_at, updated_at)
+		VALUES ('endpoint-1', 'gpu', 'user@host', 1, '2026-01-01', '2026-01-01');
+	`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Mark all migrations up to 33 as applied so only 34 runs.
+	for v := 1; v <= 33; v++ {
+		if _, err := db.Exec(
+			`INSERT INTO schema_migrations (version, applied_at) VALUES (?, datetime('now'))`,
+			v,
+		); err != nil {
+			t.Fatalf("seed migrations: %v", err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reopen via OpenDB which runs migrations.
+	db2, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer db2.Close()
+
+	var profile string
+	if err := db2.QueryRow(`SELECT profile FROM endpoints WHERE id = 'endpoint-1'`).Scan(&profile); err != nil {
+		t.Fatalf("scan profile: %v", err)
+	}
+	if profile != "" {
+		t.Fatalf("legacy endpoint profile = %q, want empty", profile)
+	}
+
+	version, err := GetSchemaVersion(db2)
+	if err != nil {
+		t.Fatalf("GetSchemaVersion: %v", err)
+	}
+	if version < 34 {
+		t.Fatalf("schema version = %d, want >=34", version)
 	}
 }

--- a/internal/store/endpoints_test.go
+++ b/internal/store/endpoints_test.go
@@ -108,6 +108,27 @@ func TestAddEndpointNormalizesProfileCase(t *testing.T) {
 	}
 }
 
+func TestAddEndpointMapsDefaultProfileToEmpty(t *testing.T) {
+	// "default" is the human label for the empty profile, but downstream
+	// hub helpers (remoteBinaryName, ATTN_PROFILE export, data-dir scripts)
+	// would treat it as a named profile and build attn-default / ~/.attn-default
+	// on the remote while WSPortForProfile still returns 9849, colliding with
+	// any real default-profile daemon already on that port.
+	s := New()
+	for _, input := range []string{"default", "DEFAULT", "  default  "} {
+		t.Run(input, func(t *testing.T) {
+			record, err := s.AddEndpoint("gpu-box", "user@example", input)
+			if err != nil {
+				t.Fatalf("AddEndpoint(%q) error = %v", input, err)
+			}
+			if record.Profile != "" {
+				t.Fatalf("AddEndpoint(%q) Profile = %q, want \"\" (literal \"default\" must canonicalize to empty)", input, record.Profile)
+			}
+			_ = s.RemoveEndpoint(record.ID)
+		})
+	}
+}
+
 func TestUpdateEndpointClearsProfileWithEmptyString(t *testing.T) {
 	s := New()
 	record, err := s.AddEndpoint("gpu-box", "user@example", "dev")

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -75,6 +75,7 @@ CREATE TABLE IF NOT EXISTS endpoints (
 	name TEXT NOT NULL,
 	ssh_target TEXT NOT NULL,
 	enabled INTEGER NOT NULL DEFAULT 1,
+	profile TEXT NOT NULL DEFAULT '',
 	created_at TEXT NOT NULL,
 	updated_at TEXT NOT NULL
 );
@@ -285,6 +286,7 @@ var migrations = []migration{
 		updated_at TEXT NOT NULL
 	)`},
 	{33, "drop unused wont_fix columns from review_comments", ""},
+	{34, "add profile to endpoints", "ALTER TABLE endpoints ADD COLUMN profile TEXT NOT NULL DEFAULT ''"},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -385,6 +387,11 @@ func migrateDB(db *sql.DB) error {
 			}
 		} else if m.version == 33 {
 			if err := applyMigration33(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 34 {
+			if err := applyMigration34(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -531,6 +538,20 @@ func applyMigration33(tx *sql.Tx) error {
 		if _, err := tx.Exec("ALTER TABLE review_comments DROP COLUMN " + col); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func applyMigration34(tx *sql.Tx) error {
+	hasProfile, err := columnExists(tx, "endpoints", "profile")
+	if err != nil {
+		return err
+	}
+	if hasProfile {
+		return nil
+	}
+	if _, err := tx.Exec("ALTER TABLE endpoints ADD COLUMN profile TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Extends the local `ATTN_PROFILE` isolation knob to remote endpoints. Each endpoint now stores a profile; the hub threads it into every SSH invocation so the remote daemon runs profile-aware (different binary path, data dir, log, socket, port). A dev-profile attn can now drive a dev-profile remote daemon side-by-side with prod on the same host.

- **Storage**: migration 34 adds `profile` column. `AddEndpoint` / `UpdateEndpoint` validate via `config.NormalizeProfileName`, which lowercase-normalizes so the stored value matches what `config.Profile()` lowercases on the remote daemon (otherwise `~/.attn-DEV` referenced in scripts would diverge from `~/.attn-dev` written by the daemon).
- **Hub**: new `remoteBinaryName(profile)` (`attn` / `attn-<profile>`). Every SSH-script generator (`probeRemoteDaemon`, `startRemoteDaemon`, `stopRemoteDaemon`, `remoteSocketConfigScript`, `installRemoteBinary`, `connectViaSSH`, …) is profile-aware. New `config.WSPortForProfile(profile)` picks the right default port without consulting env.
- **Daemon WS handler**: defaults profile to `config.Profile()` when the message field is empty (belt-and-suspenders alongside the frontend's `BUILD_PROFILE` pre-fill).
- **Frontend**: `SettingsModal` gets a profile input on add/edit and a badge on the endpoint card; `sendAddEndpoint` / `sendUpdateEndpoint` carry profile through. `App.tsx` is unchanged because props use `ReturnType<typeof useDaemonSocket>`.
- **Protocol**: `ProtocolVersion` bumped `54` → `55` per AGENTS.md (three new optional fields on `EndpointInfo`, `AddEndpointMessage`, `UpdateEndpointMessage`).

## Test plan

- [x] `go test ./...` — 664 passed (new tests cover profile round-trip, uppercase normalization, empty-string clears, migration-34 backfill, `remoteBinaryName`, every SSH script generator for default + named profile)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 387 passed
- [x] Manual smoke against an OrbStack Ubuntu VM (`attn-test@orb`):
  - Default profile → `~/.local/bin/attn`, `~/.attn/`, port `9849`, `/health` reports `profile: "default"`, `protocol: "55"`
  - `dev` profile → `~/.local/bin/attn-dev`, `~/.attn-dev/`, port `29849`, `/health` reports `profile: "dev"`, `protocol: "55"`, daemon process has `ATTN_PROFILE=dev` in its env
  - Both daemons run simultaneously as independent processes, each on its own port and data dir
  - Re-running `EnsureRemoteReady` is idempotent (no PID churn)
  - Teardown cleanly removes both daemons, data dirs, and binaries

## Known follow-up

When a user changes an existing endpoint's profile via `update_endpoint`, the local runtime bounces but the *previous-profile* remote daemon keeps running on its old port. Harmless (different port, different data dir) but undocumented; tracked separately.