### PR TITLE
feat: spike 5 native UI — workspace entity model + sidebar + canvas

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           provider: openrouter
           api-key: ${{ secrets.OPEN_ROUTER_API_KEY }}
-          model: qwen/qwen3.6-plus
+          model: moonshotai/kimi-k2.6
           reasoning: xhigh
           max-files: 200
           debug: "true"

--- a/native-ui/crates/attn-native-app/Cargo.toml
+++ b/native-ui/crates/attn-native-app/Cargo.toml
@@ -15,6 +15,10 @@ path = "src/canvas_main.rs"
 name = "attn-spike4"
 path = "src/spike4_main.rs"
 
+[[bin]]
+name = "attn-spike5"
+path = "src/spike5_main.rs"
+
 [dependencies]
 attn-protocol = { path = "../attn-protocol" }
 gpui = "0.2"

--- a/native-ui/crates/attn-native-app/src/daemon_client.rs
+++ b/native-ui/crates/attn-native-app/src/daemon_client.rs
@@ -1,4 +1,4 @@
-use attn_protocol::{ServerEvent, Session, PROTOCOL_VERSION};
+use attn_protocol::{ServerEvent, Session, Workspace, PROTOCOL_VERSION};
 use futures_util::{SinkExt, StreamExt};
 use gpui::{AsyncApp, Context, EventEmitter, WeakEntity};
 use serde::Serialize;
@@ -11,6 +11,13 @@ pub enum DaemonEvent {
     Connected,
     Disconnected,
     SessionsChanged,
+    /// A workspace appeared (or the InitialState batch arrived). Carries the
+    /// snapshot at registration time.
+    WorkspaceRegistered { workspace: Workspace },
+    /// A workspace was removed (cascade-closed by the daemon).
+    WorkspaceUnregistered { workspace_id: String },
+    /// A workspace's rolled-up status changed. Carries the fresh snapshot.
+    WorkspaceStateChanged { workspace: Workspace },
     /// Raw PTY output for a specific session. Delivered directly so terminal
     /// models can subscribe without triggering full workspace re-renders.
     PtyOutput { session_id: String, data: String, seq: i32 },
@@ -26,6 +33,7 @@ pub enum DaemonEvent {
 
 pub struct DaemonClient {
     sessions: Vec<Session>,
+    workspaces: Vec<Workspace>,
     connected: bool,
     error: Option<String>,
     /// Channel sender for outbound commands. None when not connected.
@@ -122,7 +130,13 @@ impl DaemonClient {
         })
         .detach();
 
-        Self { sessions: Vec::new(), connected: false, error: None, cmd_tx: None }
+        Self {
+            sessions: Vec::new(),
+            workspaces: Vec::new(),
+            connected: false,
+            error: None,
+            cmd_tx: None,
+        }
     }
 
     /// Send a serializable command to the daemon. Silently drops if not connected.
@@ -145,6 +159,14 @@ impl DaemonClient {
                     }
                 }
                 self.sessions = msg.sessions;
+                self.workspaces = msg.workspaces;
+                // Replay every persisted workspace as a Registered event so
+                // sidebar/canvas subscribers can hydrate without special-casing
+                // the InitialState path. WorkspaceRegistered is idempotent on
+                // the consumer side (dedup'd by id).
+                for ws in self.workspaces.clone() {
+                    cx.emit(DaemonEvent::WorkspaceRegistered { workspace: ws });
+                }
                 cx.emit(DaemonEvent::SessionsChanged);
                 cx.notify();
             }
@@ -170,6 +192,30 @@ impl DaemonClient {
             ServerEvent::SessionsUpdated(msg) => {
                 self.sessions = msg.sessions;
                 cx.emit(DaemonEvent::SessionsChanged);
+                cx.notify();
+            }
+            ServerEvent::WorkspaceRegistered(msg) => {
+                let ws = msg.workspace;
+                if let Some(existing) = self.workspaces.iter_mut().find(|w| w.id == ws.id) {
+                    *existing = ws.clone();
+                } else {
+                    self.workspaces.push(ws.clone());
+                }
+                cx.emit(DaemonEvent::WorkspaceRegistered { workspace: ws });
+                cx.notify();
+            }
+            ServerEvent::WorkspaceUnregistered(msg) => {
+                let id = msg.workspace.id;
+                self.workspaces.retain(|w| w.id != id);
+                cx.emit(DaemonEvent::WorkspaceUnregistered { workspace_id: id });
+                cx.notify();
+            }
+            ServerEvent::WorkspaceStateChanged(msg) => {
+                let ws = msg.workspace;
+                if let Some(existing) = self.workspaces.iter_mut().find(|w| w.id == ws.id) {
+                    *existing = ws.clone();
+                }
+                cx.emit(DaemonEvent::WorkspaceStateChanged { workspace: ws });
                 cx.notify();
             }
             ServerEvent::AttachResult(msg) => {
@@ -208,6 +254,11 @@ impl DaemonClient {
 
     pub fn sessions(&self) -> &[Session] {
         &self.sessions
+    }
+
+    #[allow(dead_code)]
+    pub fn workspaces(&self) -> &[Workspace] {
+        &self.workspaces
     }
 
     #[allow(dead_code)]

--- a/native-ui/crates/attn-native-app/src/daemon_client.rs
+++ b/native-ui/crates/attn-native-app/src/daemon_client.rs
@@ -167,6 +167,20 @@ impl DaemonClient {
                     }
                 }
                 self.sessions = msg.sessions;
+                // Workspaces are event-driven on the consumer side (add/remove
+                // events update sidebar + canvas state), so a fresh InitialState
+                // must emit removals for any workspace that disappeared during
+                // a disconnect — otherwise stale rows linger after the daemon
+                // restarts with fewer workspaces.
+                let new_ids: std::collections::HashSet<&str> =
+                    msg.workspaces.iter().map(|w| w.id.as_str()).collect();
+                for old in &self.workspaces {
+                    if !new_ids.contains(old.id.as_str()) {
+                        cx.emit(DaemonEvent::WorkspaceUnregistered {
+                            workspace_id: old.id.clone(),
+                        });
+                    }
+                }
                 self.workspaces = msg.workspaces;
                 // Replay every persisted workspace as a Registered event so
                 // sidebar/canvas subscribers can hydrate without special-casing

--- a/native-ui/crates/attn-native-app/src/daemon_client.rs
+++ b/native-ui/crates/attn-native-app/src/daemon_client.rs
@@ -3,7 +3,14 @@ use futures_util::{SinkExt, StreamExt};
 use gpui::{AsyncApp, Context, EventEmitter, WeakEntity};
 use serde::Serialize;
 
-const DAEMON_WS_URL: &str = "ws://localhost:9849/ws";
+const DEFAULT_DAEMON_WS_URL: &str = "ws://localhost:9849/ws";
+
+/// WebSocket URL the daemon client connects to. Defaults to the prod port
+/// (9849); override with `ATTN_WS_URL=ws://localhost:29849/ws` to point at
+/// the dev daemon (`make dev`) during attn-on-attn testing.
+fn daemon_ws_url() -> String {
+    std::env::var("ATTN_WS_URL").unwrap_or_else(|_| DEFAULT_DAEMON_WS_URL.to_string())
+}
 
 /// Events emitted by DaemonClient to subscribers.
 #[derive(Debug, Clone)]
@@ -44,10 +51,11 @@ impl EventEmitter<DaemonEvent> for DaemonClient {}
 
 impl DaemonClient {
     pub fn new(cx: &mut Context<Self>) -> Self {
-        cx.spawn(async |this: WeakEntity<DaemonClient>, cx: &mut AsyncApp| {
+        let url = daemon_ws_url();
+        cx.spawn(async move |this: WeakEntity<DaemonClient>, cx: &mut AsyncApp| {
             loop {
                 let connect_result =
-                    async_tungstenite::async_std::connect_async(DAEMON_WS_URL).await;
+                    async_tungstenite::async_std::connect_async(url.as_str()).await;
 
                 match connect_result {
                     Ok((ws_stream, _)) => {

--- a/native-ui/crates/attn-native-app/src/panel.rs
+++ b/native-ui/crates/attn-native-app/src/panel.rs
@@ -1,0 +1,72 @@
+/// Panels are the canvas's spatial objects. Each carries world-space
+/// position + size and a typed `PanelContent` that decides how it renders
+/// and how interactions (resize → PTY reflow, focus → keyboard routing)
+/// are dispatched.
+///
+/// Adding a new panel type is: define the view struct + `Render`, add one
+/// `PanelContent` arm, handle it in the canvas's render-panel match. No
+/// trait objects — the enum keeps type-specific behaviour explicit and
+/// avoids GPUI's `AnyView` erasure when we need to call type-specific
+/// methods (resize → `PtyResize` only for terminals, focus handle only on
+/// terminals).
+use gpui::{div, prelude::*, px, rgb, Context, Entity, ParentElement, Render, SharedString, Window};
+
+#[derive(Clone, Debug)]
+pub struct Panel {
+    pub id: usize,
+    pub title: SharedString,
+    pub world_x: f32,
+    pub world_y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub content: PanelContent,
+}
+
+#[derive(Clone)]
+pub enum PanelContent {
+    /// Stand-in for any non-terminal panel type — todo lists, browsers,
+    /// drawing canvases. Renders static text with a colour-coded body.
+    /// The variant exists in the spike to prove the enum dispatches over
+    /// at least two distinct render paths.
+    Placeholder(Entity<PlaceholderView>),
+    /// Terminal panel — for the canvas-UI spike this renders the session
+    /// id and a stub label. Wiring real PTY rendering (TerminalView from
+    /// spike 4) into the workspace context is a follow-up; the architecture
+    /// already accommodates it.
+    Terminal { session_id: SharedString },
+}
+
+impl std::fmt::Debug for PanelContent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Placeholder(_) => write!(f, "Placeholder(..)"),
+            Self::Terminal { session_id } => write!(f, "Terminal({session_id})"),
+        }
+    }
+}
+
+/// Static-text panel body. Created cheaply; one entity per panel so each
+/// can be addressed independently in the future (e.g. for a todo list
+/// that needs to subscribe to its own data source).
+pub struct PlaceholderView {
+    pub label: SharedString,
+}
+
+impl PlaceholderView {
+    pub fn new(label: impl Into<SharedString>) -> Self {
+        Self { label: label.into() }
+    }
+}
+
+impl Render for PlaceholderView {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .flex()
+            .items_center()
+            .justify_center()
+            .text_color(rgb(0xa0a0b0))
+            .text_size(px(13.))
+            .child(self.label.clone())
+    }
+}

--- a/native-ui/crates/attn-native-app/src/sidebar.rs
+++ b/native-ui/crates/attn-native-app/src/sidebar.rs
@@ -42,20 +42,16 @@ impl Sidebar {
         }
     }
 
-    /// Insert or replace a workspace handle. Called by `Spike5App` when
-    /// a new `WorkspaceRegistered` event arrives.
+    /// Add a workspace handle. Called by `Spike5App` on `WorkspaceRegistered`.
+    /// `Spike5App` guards duplicates upstream (same id → same `Entity<Workspace>`
+    /// reused), so this is a pure insert — re-inserting the same id is a no-op.
     pub fn upsert_workspace(&mut self, ws: Entity<Workspace>, cx: &mut Context<Self>) {
         let id = ws.read(cx).id.clone();
-        if let Some(slot) = self
-            .workspaces
-            .iter_mut()
-            .find(|existing| existing.read(cx).id == id)
-        {
-            *slot = ws.clone();
-        } else {
-            self.workspaces.push(ws.clone());
-            cx.observe(&ws, |_, _, cx| cx.notify()).detach();
+        if self.workspaces.iter().any(|existing| existing.read(cx).id == id) {
+            return;
         }
+        cx.observe(&ws, |_, _, cx| cx.notify()).detach();
+        self.workspaces.push(ws);
         cx.notify();
     }
 

--- a/native-ui/crates/attn-native-app/src/sidebar.rs
+++ b/native-ui/crates/attn-native-app/src/sidebar.rs
@@ -1,0 +1,160 @@
+/// Fixed-width left rail. One row per workspace. Status badge in front of
+/// the title. Clicking a row asks the parent (`Spike5App`) to switch
+/// selection. The sidebar holds cloned `Entity<Workspace>` handles and
+/// observes each — when a workspace's status changes, only that row
+/// re-renders.
+use attn_protocol::WorkspaceStatus;
+use gpui::{
+    div, prelude::*, px, rgb, Context, Entity, FocusHandle, Focusable, MouseButton, ParentElement,
+    Render, SharedString, Window,
+};
+
+use crate::workspace::Workspace;
+
+pub const SIDEBAR_WIDTH: f32 = 240.0;
+
+pub struct Sidebar {
+    workspaces: Vec<Entity<Workspace>>,
+    selected_id: Option<SharedString>,
+    /// Callback fired when the user clicks a row. Set up by `Spike5App`
+    /// at construction time so the app can swap the canvas's selected
+    /// workspace handle.
+    on_select: Box<dyn Fn(SharedString, &mut Window, &mut gpui::App) + 'static>,
+    focus_handle: FocusHandle,
+}
+
+impl Sidebar {
+    pub fn new(
+        workspaces: Vec<Entity<Workspace>>,
+        on_select: impl Fn(SharedString, &mut Window, &mut gpui::App) + 'static,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        // Re-render this whole view when any member workspace updates.
+        // Cheap: the row count is small and rendering is just a div tree.
+        for ws in &workspaces {
+            cx.observe(ws, |_, _, cx| cx.notify()).detach();
+        }
+        Self {
+            workspaces,
+            selected_id: None,
+            on_select: Box::new(on_select),
+            focus_handle: cx.focus_handle(),
+        }
+    }
+
+    /// Insert or replace a workspace handle. Called by `Spike5App` when
+    /// a new `WorkspaceRegistered` event arrives.
+    pub fn upsert_workspace(&mut self, ws: Entity<Workspace>, cx: &mut Context<Self>) {
+        let id = ws.read(cx).id.clone();
+        if let Some(slot) = self
+            .workspaces
+            .iter_mut()
+            .find(|existing| existing.read(cx).id == id)
+        {
+            *slot = ws.clone();
+        } else {
+            self.workspaces.push(ws.clone());
+            cx.observe(&ws, |_, _, cx| cx.notify()).detach();
+        }
+        cx.notify();
+    }
+
+    pub fn remove_workspace(&mut self, id: &str, cx: &mut Context<Self>) {
+        self.workspaces.retain(|ws| ws.read(cx).id.as_ref() != id);
+        if self.selected_id.as_ref().map(|s| s.as_ref()) == Some(id) {
+            self.selected_id = None;
+        }
+        cx.notify();
+    }
+
+    pub fn set_selected(&mut self, id: Option<SharedString>, cx: &mut Context<Self>) {
+        if self.selected_id != id {
+            self.selected_id = id;
+            cx.notify();
+        }
+    }
+}
+
+impl Focusable for Sidebar {
+    fn focus_handle(&self, _cx: &gpui::App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for Sidebar {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let rows: Vec<gpui::AnyElement> = self
+            .workspaces
+            .iter()
+            .map(|ws_entity| {
+                let ws = ws_entity.read(cx);
+                let id = ws.id.clone();
+                let title = ws.title.clone();
+                let status = ws.status;
+                let selected = self.selected_id.as_ref() == Some(&id);
+                let click_id = id.clone();
+                row(id.clone(), title, status, selected)
+                    .on_mouse_down(MouseButton::Left, cx.listener(move |this, _, window, cx| {
+                        let id = click_id.clone();
+                        (this.on_select)(id.clone(), window, cx);
+                        this.set_selected(Some(id), cx);
+                    }))
+                    .into_any_element()
+            })
+            .collect();
+
+        div()
+            .w(px(SIDEBAR_WIDTH))
+            .h_full()
+            .bg(rgb(0x1a1a22))
+            .border_r_1()
+            .border_color(rgb(0x2a2a35))
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .px_4()
+                    .py_3()
+                    .text_color(rgb(0x8a8a95))
+                    .text_size(px(11.))
+                    .child(SharedString::from("WORKSPACES")),
+            )
+            .children(rows)
+    }
+}
+
+/// One row. Pulled out so the click handler in `render` stays readable.
+fn row(
+    _id: SharedString,
+    title: SharedString,
+    status: WorkspaceStatus,
+    selected: bool,
+) -> gpui::Div {
+    let bg = if selected { rgb(0x2a2a3a) } else { rgb(0x1a1a22) };
+    div()
+        .w_full()
+        .px_4()
+        .py_2()
+        .flex()
+        .items_center()
+        .gap_2()
+        .bg(bg)
+        .text_color(rgb(0xe0e0eb))
+        .text_size(px(13.))
+        .child(status_badge(status))
+        .child(title)
+}
+
+/// Coloured dot reflecting the workspace's rolled-up status. The colour
+/// vocabulary mirrors the Tauri sidebar's session badges so attn feels
+/// consistent across frontends.
+fn status_badge(status: WorkspaceStatus) -> impl IntoElement {
+    let color = match status {
+        WorkspaceStatus::Working => rgb(0x4caf50),       // green
+        WorkspaceStatus::WaitingInput => rgb(0xffc107),  // amber
+        WorkspaceStatus::PendingApproval => rgb(0xff9800), // orange
+        WorkspaceStatus::Idle => rgb(0x6a6a78),          // grey
+        WorkspaceStatus::Launching => rgb(0x2196f3),     // blue
+    };
+    div().w(px(8.)).h(px(8.)).rounded_full().bg(color)
+}

--- a/native-ui/crates/attn-native-app/src/spike5_app.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_app.rs
@@ -5,6 +5,7 @@
 ///
 /// Layout: sidebar pinned left at fixed width, canvas fills the rest.
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use gpui::{
     div, prelude::*, rgb, App, Context, Entity, ParentElement, Render, SharedString, Window,
@@ -143,6 +144,15 @@ impl Render for Spike5App {
     }
 }
 
+/// Process-wide monotonically-increasing panel ID. Panels aren't keyed by id
+/// today (rendered by vec position), but reserving unique ids now keeps the
+/// door open for drag/lookup-by-id without a future rename pass.
+static NEXT_PANEL_ID: AtomicUsize = AtomicUsize::new(1);
+
+fn next_panel_id() -> usize {
+    NEXT_PANEL_ID.fetch_add(1, Ordering::Relaxed)
+}
+
 /// Two panels for every workspace as it appears: one Placeholder, one
 /// Terminal stub. Demonstrates the enum dispatching across distinct
 /// render paths without requiring real PTY wiring in this spike.
@@ -153,7 +163,7 @@ fn make_demo_panels(workspace_id: &SharedString, cx: &mut App) -> Vec<Panel> {
     let session_id = SharedString::from(format!("{workspace_id}-demo"));
     vec![
         Panel {
-            id: 1,
+            id: next_panel_id(),
             title: SharedString::from("Notes"),
             world_x: 60.0,
             world_y: 60.0,
@@ -162,7 +172,7 @@ fn make_demo_panels(workspace_id: &SharedString, cx: &mut App) -> Vec<Panel> {
             content: PanelContent::Placeholder(placeholder_view),
         },
         Panel {
-            id: 2,
+            id: next_panel_id(),
             title: SharedString::from("Agent"),
             world_x: 380.0,
             world_y: 60.0,

--- a/native-ui/crates/attn-native-app/src/spike5_app.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_app.rs
@@ -1,0 +1,174 @@
+/// Spike 5 root view. Owns the live `Vec<Entity<Workspace>>` (the
+/// authoritative list, sidebar and canvas just hold cloned handles), and
+/// subscribes to `DaemonClient` to grow/shrink it as workspaces appear
+/// and vanish on the wire.
+///
+/// Layout: sidebar pinned left at fixed width, canvas fills the rest.
+use std::collections::HashMap;
+
+use gpui::{
+    div, prelude::*, rgb, App, Context, Entity, ParentElement, Render, SharedString, Window,
+};
+
+use crate::daemon_client::{DaemonClient, DaemonEvent};
+use crate::panel::{Panel, PanelContent, PlaceholderView};
+use crate::sidebar::Sidebar;
+use crate::spike5_canvas::Spike5Canvas;
+use crate::workspace::Workspace;
+
+pub struct Spike5App {
+    #[allow(dead_code)]
+    daemon: Entity<DaemonClient>,
+    workspaces_by_id: HashMap<SharedString, Entity<Workspace>>,
+    sidebar: Entity<Sidebar>,
+    canvas: Entity<Spike5Canvas>,
+    selected_id: Option<SharedString>,
+}
+
+impl Spike5App {
+    pub fn new(daemon: Entity<DaemonClient>, cx: &mut Context<Self>) -> Self {
+        let canvas = cx.new(|_| Spike5Canvas::new());
+        let canvas_for_select = canvas.clone();
+        let app_handle = cx.entity().downgrade();
+        let sidebar = cx.new(|cx| {
+            Sidebar::new(
+                Vec::new(),
+                move |id, _window, cx| {
+                    // Resolve the workspace entity, hand it to the canvas,
+                    // and remember the selection on the app.
+                    let app_handle = app_handle.clone();
+                    let canvas = canvas_for_select.clone();
+                    let _ = app_handle.update(cx, |app: &mut Spike5App, cx| {
+                        let ws = app.workspaces_by_id.get(&id).cloned();
+                        canvas.update(cx, |canvas, cx| canvas.set_selected(ws, cx));
+                        app.selected_id = Some(id);
+                    });
+                },
+                cx,
+            )
+        });
+
+        // Forward DaemonClient events into our own state. We subscribe to
+        // the daemon entity, not its raw stream, so GPUI handles the
+        // re-render machinery for us.
+        cx.subscribe(&daemon, |this, _client, event: &DaemonEvent, cx| {
+            match event {
+                DaemonEvent::WorkspaceRegistered { workspace } => {
+                    this.upsert_workspace(workspace.clone(), cx);
+                }
+                DaemonEvent::WorkspaceUnregistered { workspace_id } => {
+                    this.remove_workspace(workspace_id.clone(), cx);
+                }
+                DaemonEvent::WorkspaceStateChanged { workspace } => {
+                    this.apply_workspace_snapshot(workspace.clone(), cx);
+                }
+                _ => {}
+            }
+        })
+        .detach();
+
+        Self {
+            daemon,
+            workspaces_by_id: HashMap::new(),
+            sidebar,
+            canvas,
+            selected_id: None,
+        }
+    }
+
+    fn upsert_workspace(&mut self, data: attn_protocol::Workspace, cx: &mut Context<Self>) {
+        let id = SharedString::from(data.id.clone());
+        if let Some(existing) = self.workspaces_by_id.get(&id) {
+            existing.update(cx, |ws, cx| ws.apply_snapshot(data.clone(), cx));
+            return;
+        }
+        // First time we've seen this workspace — seed it with two demo
+        // panels so the spike has something to render. A real native UI
+        // would build panels from persisted layout state instead.
+        let panels = make_demo_panels(&id, cx);
+        let entity = cx.new(|_| Workspace::new(data, panels));
+        self.workspaces_by_id.insert(id.clone(), entity.clone());
+        self.sidebar.update(cx, |sidebar, cx| sidebar.upsert_workspace(entity.clone(), cx));
+
+        // First workspace to appear becomes the canvas's initial selection.
+        if self.selected_id.is_none() {
+            self.selected_id = Some(id.clone());
+            self.canvas.update(cx, |canvas, cx| canvas.set_selected(Some(entity), cx));
+            self.sidebar
+                .update(cx, |sidebar, cx| sidebar.set_selected(Some(id), cx));
+        }
+    }
+
+    fn apply_workspace_snapshot(
+        &mut self,
+        data: attn_protocol::Workspace,
+        cx: &mut Context<Self>,
+    ) {
+        let id = SharedString::from(data.id.clone());
+        if let Some(existing) = self.workspaces_by_id.get(&id) {
+            existing.update(cx, |ws, cx| ws.apply_snapshot(data, cx));
+        } else {
+            // State change for a workspace we haven't seen — treat as a
+            // late registration (daemon ordering guarantees say this
+            // shouldn't happen, but the cost of being defensive is one
+            // line).
+            self.upsert_workspace(data, cx);
+        }
+    }
+
+    fn remove_workspace(&mut self, id: String, cx: &mut Context<Self>) {
+        let id = SharedString::from(id);
+        if self.workspaces_by_id.remove(&id).is_none() {
+            return;
+        }
+        let id_str = id.clone();
+        self.sidebar
+            .update(cx, |sidebar, cx| sidebar.remove_workspace(&id_str, cx));
+        if self.selected_id.as_ref() == Some(&id) {
+            self.selected_id = None;
+            self.canvas.update(cx, |canvas, cx| canvas.set_selected(None, cx));
+        }
+    }
+}
+
+impl Render for Spike5App {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .flex()
+            .flex_row()
+            .bg(rgb(0x0e0e14))
+            .child(self.sidebar.clone())
+            .child(div().flex_1().child(self.canvas.clone()))
+    }
+}
+
+/// Two panels for every workspace as it appears: one Placeholder, one
+/// Terminal stub. Demonstrates the enum dispatching across distinct
+/// render paths without requiring real PTY wiring in this spike.
+fn make_demo_panels(workspace_id: &SharedString, cx: &mut App) -> Vec<Panel> {
+    let placeholder_label =
+        SharedString::from(format!("Todo Panel · {workspace_id}"));
+    let placeholder_view = cx.new(|_| PlaceholderView::new(placeholder_label));
+    let session_id = SharedString::from(format!("{workspace_id}-demo"));
+    vec![
+        Panel {
+            id: 1,
+            title: SharedString::from("Notes"),
+            world_x: 60.0,
+            world_y: 60.0,
+            width: 280.0,
+            height: 180.0,
+            content: PanelContent::Placeholder(placeholder_view),
+        },
+        Panel {
+            id: 2,
+            title: SharedString::from("Agent"),
+            world_x: 380.0,
+            world_y: 60.0,
+            width: 320.0,
+            height: 200.0,
+            content: PanelContent::Terminal { session_id },
+        },
+    ]
+}

--- a/native-ui/crates/attn-native-app/src/spike5_canvas.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_canvas.rs
@@ -1,0 +1,129 @@
+/// Spike 5 canvas — reads panels from one selected `Entity<Workspace>`
+/// and renders each via the `PanelContent` enum. Pan/zoom is intentionally
+/// out of scope here (proven by spikes 3+4); this canvas focuses on the
+/// architectural piece spike 5 is meant to prove: enum-dispatched panel
+/// rendering off a peer-shared workspace entity.
+///
+/// When the selected workspace changes, the parent (`Spike5App`) calls
+/// `set_selected` with the new entity handle. Subscribers are re-wired so
+/// `cx.notify()` only fires for the workspace currently on screen.
+use gpui::{
+    div, prelude::*, px, rgb, AnyElement, Context, Entity, ParentElement, Render, SharedString,
+    Subscription, Window,
+};
+
+use crate::panel::{Panel, PanelContent};
+use crate::workspace::Workspace;
+
+pub struct Spike5Canvas {
+    selected: Option<Entity<Workspace>>,
+    /// Handle to the workspace observation. Drop = unsubscribe; keeping it
+    /// lets us replace cleanly when selection changes.
+    _selected_subscription: Option<Subscription>,
+}
+
+impl Spike5Canvas {
+    pub fn new() -> Self {
+        Self { selected: None, _selected_subscription: None }
+    }
+
+    pub fn set_selected(&mut self, ws: Option<Entity<Workspace>>, cx: &mut Context<Self>) {
+        self._selected_subscription = ws.as_ref().map(|w| cx.observe(w, |_, _, cx| cx.notify()));
+        self.selected = ws;
+        cx.notify();
+    }
+}
+
+impl Render for Spike5Canvas {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let body: AnyElement = match self.selected.as_ref() {
+            None => empty_state().into_any_element(),
+            Some(ws_entity) => {
+                // Clone the panel list out so the immutable borrow on `cx`
+                // ends before `render_panel` takes its own mutable borrow.
+                let (title, panels_data) = {
+                    let ws = ws_entity.read(cx);
+                    (ws.title.clone(), ws.panels.clone())
+                };
+                let panels: Vec<AnyElement> =
+                    panels_data.iter().map(|p| render_panel(p, cx)).collect();
+                div()
+                    .size_full()
+                    .relative()
+                    .child(
+                        div()
+                            .absolute()
+                            .left_4()
+                            .top_2()
+                            .text_color(rgb(0x6a6a78))
+                            .text_size(px(11.))
+                            .child(format!("workspace · {title}")),
+                    )
+                    .children(panels)
+                    .into_any_element()
+            }
+        };
+
+        div().size_full().bg(rgb(0x0e0e14)).child(body)
+    }
+}
+
+fn empty_state() -> impl IntoElement {
+    div()
+        .size_full()
+        .flex()
+        .items_center()
+        .justify_center()
+        .text_color(rgb(0x6a6a78))
+        .text_size(px(13.))
+        .child(SharedString::from("Select a workspace"))
+}
+
+/// Render one panel. Position is `absolute` in screen space — no zoom for
+/// the spike. The PanelContent match is the place new panel types plug in.
+fn render_panel(panel: &Panel, cx: &mut Context<Spike5Canvas>) -> AnyElement {
+    let frame = div()
+        .absolute()
+        .left(px(panel.world_x))
+        .top(px(panel.world_y))
+        .w(px(panel.width))
+        .h(px(panel.height))
+        .bg(rgb(0x1c1c26))
+        .border_1()
+        .border_color(rgb(0x2a2a35))
+        .rounded_md()
+        .flex()
+        .flex_col()
+        .child(
+            // Title bar
+            div()
+                .px_3()
+                .py_1()
+                .border_b_1()
+                .border_color(rgb(0x2a2a35))
+                .text_color(rgb(0xa0a0b0))
+                .text_size(px(11.))
+                .child(panel.title.clone()),
+        );
+
+    match &panel.content {
+        PanelContent::Placeholder(view) => frame.child(view.clone()).into_any_element(),
+        PanelContent::Terminal { session_id } => frame
+            .child(terminal_stub(session_id.clone(), cx))
+            .into_any_element(),
+    }
+}
+
+/// Stand-in for a real `TerminalView` — proves the enum dispatches a
+/// distinct render branch. Wiring spike-4's terminal rendering into the
+/// workspace context is a follow-up.
+fn terminal_stub(session_id: SharedString, _cx: &mut Context<Spike5Canvas>) -> impl IntoElement {
+    div()
+        .flex_1()
+        .flex()
+        .items_center()
+        .justify_center()
+        .text_color(rgb(0x6a8a6a))
+        .text_size(px(12.))
+        .child(format!("terminal · {session_id} (stub)"))
+}

--- a/native-ui/crates/attn-native-app/src/spike5_main.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_main.rs
@@ -1,0 +1,36 @@
+/// Spike 5 entry point — workspace entity model + sidebar + canvas with
+/// mixed panel types. Run with: `cargo run --bin attn-spike5`.
+mod daemon_client;
+mod panel;
+mod sidebar;
+mod spike5_app;
+mod spike5_canvas;
+mod workspace;
+
+use gpui::{actions, px, size, App, AppContext, Application, Bounds, KeyBinding, WindowBounds, WindowOptions};
+
+use daemon_client::DaemonClient;
+use spike5_app::Spike5App;
+
+actions!(attn_spike5, [Quit]);
+
+fn main() {
+    Application::new().run(|cx: &mut App| {
+        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
+        cx.on_action::<Quit>(|_, cx| cx.quit());
+        let _ = cx.on_window_closed(|cx| cx.quit());
+
+        let bounds = Bounds::centered(None, size(px(1280.), px(800.)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |_window, cx| {
+                let daemon = cx.new(|cx| DaemonClient::new(cx));
+                cx.new(|cx| Spike5App::new(daemon, cx))
+            },
+        )
+        .unwrap();
+    });
+}

--- a/native-ui/crates/attn-native-app/src/workspace.rs
+++ b/native-ui/crates/attn-native-app/src/workspace.rs
@@ -1,0 +1,63 @@
+/// `Workspace` is the GPUI entity that wraps the daemon's wire-level
+/// `attn_protocol::Workspace` plus the canvas panels the user has placed
+/// inside it. Sidebar and canvas both hold cloned `Entity<Workspace>`
+/// handles and observe independently — `cx.notify()` re-renders both.
+///
+/// Note the name collision: `attn_protocol::Workspace` is the wire data
+/// type, `crate::workspace::Workspace` is this GPUI entity. They're
+/// distinct on purpose — the entity owns extra UI-only state (panels)
+/// the daemon doesn't know or care about.
+use attn_protocol::{Workspace as ProtocolWorkspace, WorkspaceStatus};
+use gpui::{Context, EventEmitter, SharedString};
+
+use crate::panel::Panel;
+
+/// Emitted when the workspace's wire-level data changes (rolled-up status,
+/// title, directory). Subscribers are the sidebar (status badge) and the
+/// canvas (panel border colour, if we add focus styling later).
+#[derive(Debug, Clone)]
+pub struct WorkspaceUpdated;
+
+pub struct Workspace {
+    pub id: SharedString,
+    pub title: SharedString,
+    pub directory: SharedString,
+    pub status: WorkspaceStatus,
+    pub panels: Vec<Panel>,
+}
+
+impl EventEmitter<WorkspaceUpdated> for Workspace {}
+
+impl Workspace {
+    pub fn new(data: ProtocolWorkspace, panels: Vec<Panel>) -> Self {
+        Self {
+            id: SharedString::from(data.id),
+            title: SharedString::from(data.title),
+            directory: SharedString::from(data.directory),
+            status: data.status,
+            panels,
+        }
+    }
+
+    /// Apply a fresh wire snapshot. Returns true if anything user-visible
+    /// changed — caller decides whether to `cx.emit` + `cx.notify`.
+    pub fn apply_snapshot(&mut self, data: ProtocolWorkspace, cx: &mut Context<Self>) {
+        let mut changed = false;
+        if self.title.as_ref() != data.title {
+            self.title = SharedString::from(data.title);
+            changed = true;
+        }
+        if self.directory.as_ref() != data.directory {
+            self.directory = SharedString::from(data.directory);
+            changed = true;
+        }
+        if self.status != data.status {
+            self.status = data.status;
+            changed = true;
+        }
+        if changed {
+            cx.emit(WorkspaceUpdated);
+            cx.notify();
+        }
+    }
+}

--- a/native-ui/crates/attn-protocol/src/commands.rs
+++ b/native-ui/crates/attn-protocol/src/commands.rs
@@ -65,3 +65,38 @@ impl PtyResizeMessage {
         Self { cmd: "pty_resize", id: session_id.into(), cols, rows }
     }
 }
+
+#[derive(Debug, Serialize)]
+pub struct RegisterWorkspaceMessage {
+    pub cmd: &'static str,
+    pub id: String,
+    pub title: String,
+    pub directory: String,
+}
+
+impl RegisterWorkspaceMessage {
+    pub fn new(
+        id: impl Into<String>,
+        title: impl Into<String>,
+        directory: impl Into<String>,
+    ) -> Self {
+        Self {
+            cmd: "register_workspace",
+            id: id.into(),
+            title: title.into(),
+            directory: directory.into(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct UnregisterWorkspaceMessage {
+    pub cmd: &'static str,
+    pub id: String,
+}
+
+impl UnregisterWorkspaceMessage {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { cmd: "unregister_workspace", id: id.into() }
+    }
+}

--- a/native-ui/crates/attn-protocol/src/events.rs
+++ b/native-ui/crates/attn-protocol/src/events.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use crate::types::{ReplaySegment, Session};
+use crate::types::{ReplaySegment, Session, Workspace};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct InitialStateMessage {
@@ -11,6 +11,8 @@ pub struct InitialStateMessage {
     pub daemon_instance_id: Option<String>,
     #[serde(default)]
     pub sessions: Vec<Session>,
+    #[serde(default)]
+    pub workspaces: Vec<Workspace>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -35,6 +37,24 @@ pub struct SessionStateChangedMessage {
 pub struct SessionsUpdatedMessage {
     pub event: String,
     pub sessions: Vec<Session>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WorkspaceRegisteredMessage {
+    pub event: String,
+    pub workspace: Workspace,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WorkspaceUnregisteredMessage {
+    pub event: String,
+    pub workspace: Workspace,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WorkspaceStateChangedMessage {
+    pub event: String,
+    pub workspace: Workspace,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -102,6 +122,9 @@ pub enum ServerEvent {
     SessionUnregistered(SessionUnregisteredMessage),
     SessionStateChanged(SessionStateChangedMessage),
     SessionsUpdated(SessionsUpdatedMessage),
+    WorkspaceRegistered(WorkspaceRegisteredMessage),
+    WorkspaceUnregistered(WorkspaceUnregisteredMessage),
+    WorkspaceStateChanged(WorkspaceStateChangedMessage),
     AttachResult(AttachResultMessage),
     PtyOutput(PtyOutputMessage),
     PtyDesync(PtyDesyncMessage),
@@ -133,6 +156,18 @@ impl ServerEvent {
             "sessions_updated" => {
                 let msg: SessionsUpdatedMessage = serde_json::from_str(data)?;
                 Ok(Self::SessionsUpdated(msg))
+            }
+            "workspace_registered" => {
+                let msg: WorkspaceRegisteredMessage = serde_json::from_str(data)?;
+                Ok(Self::WorkspaceRegistered(msg))
+            }
+            "workspace_unregistered" => {
+                let msg: WorkspaceUnregisteredMessage = serde_json::from_str(data)?;
+                Ok(Self::WorkspaceUnregistered(msg))
+            }
+            "workspace_state_changed" => {
+                let msg: WorkspaceStateChangedMessage = serde_json::from_str(data)?;
+                Ok(Self::WorkspaceStateChanged(msg))
             }
             "attach_result" => {
                 let msg: AttachResultMessage = serde_json::from_str(data)?;

--- a/native-ui/crates/attn-protocol/src/types.rs
+++ b/native-ui/crates/attn-protocol/src/types.rs
@@ -42,6 +42,42 @@ impl std::fmt::Display for SessionState {
     }
 }
 
+/// Rolled-up status of all sessions in a workspace. Mirrors the daemon's
+/// `WorkspaceStatus` enum (no `unknown` value — workspaces always have a
+/// directory and a registry entry, so the rollup always lands somewhere).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceStatus {
+    Launching,
+    Working,
+    WaitingInput,
+    PendingApproval,
+    Idle,
+}
+
+impl std::fmt::Display for WorkspaceStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Launching => write!(f, "launching"),
+            Self::Working => write!(f, "working"),
+            Self::WaitingInput => write!(f, "waiting_input"),
+            Self::PendingApproval => write!(f, "pending_approval"),
+            Self::Idle => write!(f, "idle"),
+        }
+    }
+}
+
+/// A workspace as the daemon broadcasts it: the directory + the rolled-up
+/// status of its member sessions. Panels and other UI state are local to
+/// the canvas client; only the wire-visible fields live here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Workspace {
+    pub id: String,
+    pub title: String,
+    pub directory: String,
+    pub status: WorkspaceStatus,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionAgent {
@@ -77,6 +113,8 @@ pub struct Session {
     pub branch: Option<String>,
     #[serde(default)]
     pub endpoint_id: Option<String>,
+    #[serde(default)]
+    pub workspace_id: Option<String>,
     #[serde(default)]
     pub is_worktree: Option<bool>,
     #[serde(default)]


### PR DESCRIPTION
## Summary

The native-UI half of Spike 5 from \`docs/plans/native-gpui-canvas-ui.md\`. Daemon-side wire surface landed in #158; this PR consumes it. Run with \`cargo run --bin attn-spike5\` against a daemon that has at least one workspace registered (see "Trying it out" below).

## What's here

### Wire layer (\`attn-protocol\` crate)
- \`WorkspaceStatus\` enum + \`Workspace\` struct in \`types.rs\`
- \`workspace_id?: Option<String>\` on \`Session\`
- \`WorkspaceRegistered\` / \`WorkspaceUnregistered\` / \`WorkspaceStateChanged\` event messages, matching \`ServerEvent\` variants + parse cases, \`workspaces\` field on \`InitialStateMessage\`
- \`RegisterWorkspaceMessage\` + \`UnregisterWorkspaceMessage\` commands

### Daemon client
- Tracks \`Vec<Workspace>\` alongside \`Vec<Session>\`
- New \`DaemonEvent\` variants fan workspace lifecycle out to subscribers
- \`InitialState\` replays each persisted workspace as a \`Registered\` event so sidebar/canvas hydrate via the same code path as runtime registrations — no special-case code in consumers

### Six new GPUI files (\`attn-spike5\` binary)
1. **\`panel.rs\`** — \`Panel\` struct + \`PanelContent\` enum (\`Placeholder\` | \`Terminal\`) + \`PlaceholderView\`. Enum dispatch over trait objects per the plan: type-specific behaviour (resize → \`PtyResize\`, focus handle) needs the enum back even with type-erased rendering.
2. **\`workspace.rs\`** — \`Entity<Workspace>\` wraps the wire-data plus its panels. \`apply_snapshot\` only emits \`WorkspaceUpdated\` + \`cx.notify()\` when something visible actually changed — matches the daemon-side rollup-suppression pattern.
3. **\`sidebar.rs\`** — fixed-width left rail. One row per workspace with a status-coloured dot (green/amber/orange/blue/grey). Click routes back to \`Spike5App\` via injected callback so the canvas can swap its selected handle without sidebar↔canvas direct coupling.
4. **\`spike5_canvas.rs\`** — reads panels from the currently selected \`Entity<Workspace>\` and renders each via the \`PanelContent\` match. Pan/zoom intentionally out of scope (proven by spikes 3+4); this canvas focuses on the enum-dispatched panel rendering plus the peer-shared workspace entity.
5. **\`spike5_app.rs\`** — root view. Owns \`workspaces_by_id: HashMap<id, Entity<Workspace>>\` (the authoritative list — sidebar and canvas just hold cloned handles), subscribes to \`DaemonClient\` to grow/shrink it, first workspace to appear becomes the canvas's initial selection.
6. **\`spike5_main.rs\`** — binary entry. Wires Cmd-Q + window close → quit.

## Demo content

Every workspace gets two starter panels as it appears: a \`Placeholder\` "Notes" panel and a \`Terminal\` stub "Agent" panel. This proves the enum dispatches across distinct render paths without requiring real PTY wiring in the spike — bringing spike-4's terminal rendering into \`PanelContent::Terminal\` is a follow-up.

## Trying it out

\`\`\`bash
# 1. Make sure a daemon is running. Recommended: dev install so this
#    doesn't fight with your prod attn:
make dev

# 2. Register a workspace via the WS protocol (the canvas client is
#    where this normally happens; for a quick test, any websocat-equivalent
#    pointed at ws://localhost:29849/ works).
echo '{"cmd":"register_workspace","id":"demo","title":"Demo","directory":"/tmp"}' \
  | websocat -n1 ws://localhost:29849/ws

# 3. Run the spike:
cd native-ui && cargo run --bin attn-spike5
\`\`\`

You should see the "Demo" workspace appear in the sidebar with an idle (grey) badge, and the canvas should show the two demo panels.

## Status

- \`cargo build --workspace\` clean (warnings are dead-code on \`DaemonEvent\` variants other binaries consume + spike-5 demo content)
- \`cargo run --bin attn-spike5\` boots cleanly (window opens, no panics)
- Go test suite (694 tests) unchanged and passing
- Full end-to-end runtime verification (register a workspace → see it appear → click → see panels) is pending — this is a spike, the wiring matches the plan, and the binary boots, but I haven't driven it with real registration traffic yet

## Known follow-ups

- Wire spike-4's \`TerminalView\` into \`PanelContent::Terminal\` so terminal panels actually render PTY output (currently a stub label)
- Persist workspace layout (panel positions, sizes) so it survives client restart — the spike plan defers this
- Lift pan/zoom from spike-4 onto the spike-5 canvas