### PR TITLE
feat: native canvas convergence — live terminals on a pannable workspace

### DIFF
--- a/native-ui/crates/attn-native-app/src/panel.rs
+++ b/native-ui/crates/attn-native-app/src/panel.rs
@@ -11,6 +11,8 @@
 /// terminals).
 use gpui::{div, prelude::*, px, rgb, Context, Entity, ParentElement, Render, SharedString, Window};
 
+use crate::terminal_view::TerminalView;
+
 #[derive(Clone, Debug)]
 pub struct Panel {
     pub id: usize,
@@ -25,22 +27,24 @@ pub struct Panel {
 #[derive(Clone)]
 pub enum PanelContent {
     /// Stand-in for any non-terminal panel type — todo lists, browsers,
-    /// drawing canvases. Renders static text with a colour-coded body.
-    /// The variant exists in the spike to prove the enum dispatches over
-    /// at least two distinct render paths.
+    /// drawing canvases. Currently unused; reserved as the seam where
+    /// the next panel type plugs in (one variant, one render-match arm).
+    #[allow(dead_code)]
     Placeholder(Entity<PlaceholderView>),
-    /// Terminal panel — for the canvas-UI spike this renders the session
-    /// id and a stub label. Wiring real PTY rendering (TerminalView from
-    /// spike 4) into the workspace context is a follow-up; the architecture
-    /// already accommodates it.
-    Terminal { session_id: SharedString },
+    /// Terminal panel backed by a live `TerminalView` entity. The same
+    /// entity is reused across canvas re-renders and across workspace
+    /// switches — it owns the terminal model + focus handle.
+    Terminal {
+        session_id: SharedString,
+        view: Entity<TerminalView>,
+    },
 }
 
 impl std::fmt::Debug for PanelContent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Placeholder(_) => write!(f, "Placeholder(..)"),
-            Self::Terminal { session_id } => write!(f, "Terminal({session_id})"),
+            Self::Terminal { session_id, .. } => write!(f, "Terminal({session_id})"),
         }
     }
 }
@@ -53,6 +57,7 @@ pub struct PlaceholderView {
 }
 
 impl PlaceholderView {
+    #[allow(dead_code)]
     pub fn new(label: impl Into<SharedString>) -> Self {
         Self { label: label.into() }
     }

--- a/native-ui/crates/attn-native-app/src/panel.rs
+++ b/native-ui/crates/attn-native-app/src/panel.rs
@@ -13,6 +13,11 @@ use gpui::{div, prelude::*, px, rgb, Context, Entity, ParentElement, Render, Sha
 
 use crate::terminal_view::TerminalView;
 
+/// World-space height of the panel title bar. Used by both the canvas
+/// (for hit testing + title-bar layout) and `Spike5App` (for initial
+/// `content_size` when a panel is created). Single source of truth.
+pub const TITLE_HEIGHT: f32 = 24.0;
+
 #[derive(Clone, Debug)]
 pub struct Panel {
     pub id: usize,

--- a/native-ui/crates/attn-native-app/src/spike5_app.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_app.rs
@@ -132,13 +132,33 @@ impl Spike5App {
         }
     }
 
-    /// Walk current sessions and ensure every session whose
-    /// `workspace_id` matches a known workspace has a corresponding
-    /// Terminal panel. Idempotent — duplicates are skipped by id.
+    /// Reconcile each workspace's Terminal panels with the daemon's
+    /// current session list: spawn panels for new sessions, drop panels
+    /// whose session has gone away. Idempotent.
     fn sync_terminal_panels(&mut self, cx: &mut Context<Self>) {
         // Snapshot sessions out of the daemon read borrow before we
         // start mutating workspaces.
         let sessions: Vec<Session> = self.daemon.read(cx).sessions().to_vec();
+        let live_session_ids: std::collections::HashSet<&str> =
+            sessions.iter().map(|s| s.id.as_str()).collect();
+
+        // Prune Terminal panels whose session is no longer alive on the
+        // daemon. Dropping the panel drops the last handle to its
+        // TerminalView, which detaches subscriptions for free.
+        for ws_entity in self.workspaces_by_id.values().cloned().collect::<Vec<_>>() {
+            ws_entity.update(cx, |ws, cx| {
+                let before = ws.panels.len();
+                ws.panels.retain(|p| match &p.content {
+                    PanelContent::Terminal { session_id, .. } => {
+                        live_session_ids.contains(session_id.as_ref())
+                    }
+                    _ => true,
+                });
+                if ws.panels.len() != before {
+                    cx.notify();
+                }
+            });
+        }
 
         for session in sessions {
             let Some(ws_id) = session.workspace_id.as_deref() else {

--- a/native-ui/crates/attn-native-app/src/spike5_app.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_app.rs
@@ -11,7 +11,7 @@ use attn_protocol::{AttachSessionMessage, Session};
 use gpui::{div, prelude::*, rgb, Context, Entity, ParentElement, Render, SharedString, Window};
 
 use crate::daemon_client::{DaemonClient, DaemonEvent};
-use crate::panel::{Panel, PanelContent};
+use crate::panel::{Panel, PanelContent, TITLE_HEIGHT};
 use crate::sidebar::Sidebar;
 use crate::spike5_canvas::Spike5Canvas;
 use crate::terminal_model::TerminalModel;
@@ -34,7 +34,7 @@ pub struct Spike5App {
 
 impl Spike5App {
     pub fn new(daemon: Entity<DaemonClient>, cx: &mut Context<Self>) -> Self {
-        let canvas = cx.new(|cx| Spike5Canvas::new(daemon.clone(), cx));
+        let canvas = cx.new(|cx| Spike5Canvas::new(cx));
         let canvas_for_select = canvas.clone();
         let app_handle = cx.entity().downgrade();
         let sidebar = cx.new(|cx| {
@@ -64,7 +64,17 @@ impl Spike5App {
             DaemonEvent::WorkspaceStateChanged { workspace } => {
                 this.apply_workspace_snapshot(workspace.clone(), cx);
             }
-            DaemonEvent::SessionsChanged | DaemonEvent::Connected => {
+            DaemonEvent::SessionsChanged => {
+                this.sync_terminal_panels(cx);
+            }
+            DaemonEvent::Connected => {
+                // Daemon tracks PTY attachments per client connection,
+                // so on a fresh socket every existing TerminalView is
+                // detached on the daemon side until we re-issue
+                // AttachSession. Without this, terminals go silent
+                // after a daemon restart and only recover on app
+                // restart.
+                this.reattach_existing_terminals(cx);
                 this.sync_terminal_panels(cx);
             }
             _ => {}
@@ -129,6 +139,21 @@ impl Spike5App {
             self.selected_id = None;
             self.canvas
                 .update(cx, |canvas, cx| canvas.set_selected(None, cx));
+        }
+    }
+
+    /// Walk every workspace's Terminal panels and re-issue
+    /// `AttachSession` for each. Called on `Connected` so existing
+    /// terminals resume receiving PtyOutput after a daemon restart or
+    /// any websocket reconnect.
+    fn reattach_existing_terminals(&self, cx: &mut Context<Self>) {
+        let daemon = self.daemon.read(cx);
+        for ws_entity in self.workspaces_by_id.values() {
+            for panel in ws_entity.read(cx).panels.iter() {
+                if let PanelContent::Terminal { session_id, .. } = &panel.content {
+                    daemon.send_cmd(&AttachSessionMessage::new(session_id.to_string()));
+                }
+            }
         }
     }
 
@@ -251,10 +276,6 @@ static NEXT_PANEL_ID: AtomicUsize = AtomicUsize::new(1);
 fn next_panel_id() -> usize {
     NEXT_PANEL_ID.fetch_add(1, Ordering::Relaxed)
 }
-
-/// Mirror of the canvas's title-bar height. Kept in this file so the
-/// initial content_size matches the canvas's per-frame value.
-const TITLE_HEIGHT: f32 = 24.0;
 
 fn panel_terminal_dims(world_w: f32, world_h: f32) -> (u16, u16) {
     use crate::terminal_view::{CHAR_WIDTH, ROW_HEIGHT};

--- a/native-ui/crates/attn-native-app/src/spike5_app.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_app.rs
@@ -1,24 +1,30 @@
-/// Spike 5 root view. Owns the live `Vec<Entity<Workspace>>` (the
+/// Workspace root view. Owns the live `Vec<Entity<Workspace>>` (the
 /// authoritative list, sidebar and canvas just hold cloned handles), and
-/// subscribes to `DaemonClient` to grow/shrink it as workspaces appear
-/// and vanish on the wire.
+/// subscribes to `DaemonClient` to grow/shrink it as workspaces and
+/// sessions appear and vanish on the wire.
 ///
 /// Layout: sidebar pinned left at fixed width, canvas fills the rest.
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use gpui::{
-    div, prelude::*, rgb, App, Context, Entity, ParentElement, Render, SharedString, Window,
-};
+use attn_protocol::{AttachSessionMessage, Session};
+use gpui::{div, prelude::*, rgb, Context, Entity, ParentElement, Render, SharedString, Window};
 
 use crate::daemon_client::{DaemonClient, DaemonEvent};
-use crate::panel::{Panel, PanelContent, PlaceholderView};
+use crate::panel::{Panel, PanelContent};
 use crate::sidebar::Sidebar;
 use crate::spike5_canvas::Spike5Canvas;
+use crate::terminal_model::TerminalModel;
+use crate::terminal_view::TerminalView;
 use crate::workspace::Workspace;
 
+/// Initial terminal panel size in world-space units. Roughly 380×240
+/// matches the spike-4 default and gives ~48 cols × ~12 rows once the
+/// title bar is subtracted.
+const TERMINAL_W: f32 = 380.0;
+const TERMINAL_H: f32 = 240.0;
+
 pub struct Spike5App {
-    #[allow(dead_code)]
     daemon: Entity<DaemonClient>,
     workspaces_by_id: HashMap<SharedString, Entity<Workspace>>,
     sidebar: Entity<Sidebar>,
@@ -28,15 +34,13 @@ pub struct Spike5App {
 
 impl Spike5App {
     pub fn new(daemon: Entity<DaemonClient>, cx: &mut Context<Self>) -> Self {
-        let canvas = cx.new(|_| Spike5Canvas::new());
+        let canvas = cx.new(|cx| Spike5Canvas::new(daemon.clone(), cx));
         let canvas_for_select = canvas.clone();
         let app_handle = cx.entity().downgrade();
         let sidebar = cx.new(|cx| {
             Sidebar::new(
                 Vec::new(),
                 move |id, _window, cx| {
-                    // Resolve the workspace entity, hand it to the canvas,
-                    // and remember the selection on the app.
                     let app_handle = app_handle.clone();
                     let canvas = canvas_for_select.clone();
                     let _ = app_handle.update(cx, |app: &mut Spike5App, cx| {
@@ -49,22 +53,21 @@ impl Spike5App {
             )
         });
 
-        // Forward DaemonClient events into our own state. We subscribe to
-        // the daemon entity, not its raw stream, so GPUI handles the
-        // re-render machinery for us.
-        cx.subscribe(&daemon, |this, _client, event: &DaemonEvent, cx| {
-            match event {
-                DaemonEvent::WorkspaceRegistered { workspace } => {
-                    this.upsert_workspace(workspace.clone(), cx);
-                }
-                DaemonEvent::WorkspaceUnregistered { workspace_id } => {
-                    this.remove_workspace(workspace_id.clone(), cx);
-                }
-                DaemonEvent::WorkspaceStateChanged { workspace } => {
-                    this.apply_workspace_snapshot(workspace.clone(), cx);
-                }
-                _ => {}
+        cx.subscribe(&daemon, |this, _client, event: &DaemonEvent, cx| match event {
+            DaemonEvent::WorkspaceRegistered { workspace } => {
+                this.upsert_workspace(workspace.clone(), cx);
+                this.sync_terminal_panels(cx);
             }
+            DaemonEvent::WorkspaceUnregistered { workspace_id } => {
+                this.remove_workspace(workspace_id.clone(), cx);
+            }
+            DaemonEvent::WorkspaceStateChanged { workspace } => {
+                this.apply_workspace_snapshot(workspace.clone(), cx);
+            }
+            DaemonEvent::SessionsChanged | DaemonEvent::Connected => {
+                this.sync_terminal_panels(cx);
+            }
+            _ => {}
         })
         .detach();
 
@@ -83,18 +86,16 @@ impl Spike5App {
             existing.update(cx, |ws, cx| ws.apply_snapshot(data.clone(), cx));
             return;
         }
-        // First time we've seen this workspace — seed it with two demo
-        // panels so the spike has something to render. A real native UI
-        // would build panels from persisted layout state instead.
-        let panels = make_demo_panels(&id, cx);
-        let entity = cx.new(|_| Workspace::new(data, panels));
+        let entity = cx.new(|_| Workspace::new(data, Vec::new()));
         self.workspaces_by_id.insert(id.clone(), entity.clone());
-        self.sidebar.update(cx, |sidebar, cx| sidebar.upsert_workspace(entity.clone(), cx));
+        self.sidebar
+            .update(cx, |sidebar, cx| sidebar.upsert_workspace(entity.clone(), cx));
 
         // First workspace to appear becomes the canvas's initial selection.
         if self.selected_id.is_none() {
             self.selected_id = Some(id.clone());
-            self.canvas.update(cx, |canvas, cx| canvas.set_selected(Some(entity), cx));
+            self.canvas
+                .update(cx, |canvas, cx| canvas.set_selected(Some(entity), cx));
             self.sidebar
                 .update(cx, |sidebar, cx| sidebar.set_selected(Some(id), cx));
         }
@@ -110,9 +111,8 @@ impl Spike5App {
             existing.update(cx, |ws, cx| ws.apply_snapshot(data, cx));
         } else {
             // State change for a workspace we haven't seen — treat as a
-            // late registration (daemon ordering guarantees say this
-            // shouldn't happen, but the cost of being defensive is one
-            // line).
+            // late registration. Daemon ordering says this shouldn't
+            // happen, but the cost of being defensive is one line.
             self.upsert_workspace(data, cx);
         }
     }
@@ -127,7 +127,86 @@ impl Spike5App {
             .update(cx, |sidebar, cx| sidebar.remove_workspace(&id_str, cx));
         if self.selected_id.as_ref() == Some(&id) {
             self.selected_id = None;
-            self.canvas.update(cx, |canvas, cx| canvas.set_selected(None, cx));
+            self.canvas
+                .update(cx, |canvas, cx| canvas.set_selected(None, cx));
+        }
+    }
+
+    /// Walk current sessions and ensure every session whose
+    /// `workspace_id` matches a known workspace has a corresponding
+    /// Terminal panel. Idempotent — duplicates are skipped by id.
+    fn sync_terminal_panels(&mut self, cx: &mut Context<Self>) {
+        // Snapshot sessions out of the daemon read borrow before we
+        // start mutating workspaces.
+        let sessions: Vec<Session> = self.daemon.read(cx).sessions().to_vec();
+
+        for session in sessions {
+            let Some(ws_id) = session.workspace_id.as_deref() else {
+                continue;
+            };
+            let key = SharedString::from(ws_id.to_string());
+            let Some(ws_entity) = self.workspaces_by_id.get(&key).cloned() else {
+                continue;
+            };
+
+            let already_present = ws_entity.read(cx).panels.iter().any(|p| matches!(
+                &p.content,
+                PanelContent::Terminal { session_id, .. } if session_id.as_ref() == session.id
+            ));
+            if already_present {
+                continue;
+            }
+
+            // Find a non-overlapping x position by counting existing
+            // terminal panels in this workspace.
+            let existing = ws_entity
+                .read(cx)
+                .panels
+                .iter()
+                .filter(|p| matches!(p.content, PanelContent::Terminal { .. }))
+                .count();
+            let world_x = 30.0 + existing as f32 * (TERMINAL_W + 30.0);
+            let world_y = 50.0;
+
+            let session_id = session.id.clone();
+            let label = session.label.clone();
+
+            // Default cols/rows derived from world-space size; the
+            // canvas re-pushes content_size each frame so these will
+            // be corrected on first render if needed.
+            let (cols, rows) = panel_terminal_dims(TERMINAL_W, TERMINAL_H);
+
+            let daemon = self.daemon.clone();
+            let model = cx.new(|cx| TerminalModel::new(session_id.clone(), cols, rows, &daemon, cx));
+            let view = cx.new(|cx| {
+                let mut tv = TerminalView::new(model, daemon.clone(), cx);
+                tv.set_content_size(TERMINAL_W, (TERMINAL_H - TITLE_HEIGHT).max(0.0));
+                tv
+            });
+
+            // Send attach. The TerminalView's render path will emit the
+            // initial PtyResize once it sees its first content_size.
+            self.daemon
+                .read(cx)
+                .send_cmd(&AttachSessionMessage::new(session_id.clone()));
+
+            let panel = Panel {
+                id: next_panel_id(),
+                title: SharedString::from(label),
+                world_x,
+                world_y,
+                width: TERMINAL_W,
+                height: TERMINAL_H,
+                content: PanelContent::Terminal {
+                    session_id: SharedString::from(session_id),
+                    view,
+                },
+            };
+
+            ws_entity.update(cx, |ws, cx| {
+                ws.panels.push(panel);
+                cx.notify();
+            });
         }
     }
 }
@@ -144,41 +223,22 @@ impl Render for Spike5App {
     }
 }
 
-/// Process-wide monotonically-increasing panel ID. Panels aren't keyed by id
-/// today (rendered by vec position), but reserving unique ids now keeps the
-/// door open for drag/lookup-by-id without a future rename pass.
+/// Process-wide monotonically-increasing panel ID. Panels are keyed by
+/// id for hit testing so collisions across workspaces would mis-target
+/// drag/resize.
 static NEXT_PANEL_ID: AtomicUsize = AtomicUsize::new(1);
 
 fn next_panel_id() -> usize {
     NEXT_PANEL_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-/// Two panels for every workspace as it appears: one Placeholder, one
-/// Terminal stub. Demonstrates the enum dispatching across distinct
-/// render paths without requiring real PTY wiring in this spike.
-fn make_demo_panels(workspace_id: &SharedString, cx: &mut App) -> Vec<Panel> {
-    let placeholder_label =
-        SharedString::from(format!("Todo Panel · {workspace_id}"));
-    let placeholder_view = cx.new(|_| PlaceholderView::new(placeholder_label));
-    let session_id = SharedString::from(format!("{workspace_id}-demo"));
-    vec![
-        Panel {
-            id: next_panel_id(),
-            title: SharedString::from("Notes"),
-            world_x: 60.0,
-            world_y: 60.0,
-            width: 280.0,
-            height: 180.0,
-            content: PanelContent::Placeholder(placeholder_view),
-        },
-        Panel {
-            id: next_panel_id(),
-            title: SharedString::from("Agent"),
-            world_x: 380.0,
-            world_y: 60.0,
-            width: 320.0,
-            height: 200.0,
-            content: PanelContent::Terminal { session_id },
-        },
-    ]
+/// Mirror of the canvas's title-bar height. Kept in this file so the
+/// initial content_size matches the canvas's per-frame value.
+const TITLE_HEIGHT: f32 = 24.0;
+
+fn panel_terminal_dims(world_w: f32, world_h: f32) -> (u16, u16) {
+    use crate::terminal_view::{CHAR_WIDTH, ROW_HEIGHT};
+    let cols = ((world_w / CHAR_WIDTH) as u16).max(1);
+    let rows = (((world_h - TITLE_HEIGHT) / ROW_HEIGHT) as u16).max(1);
+    (cols, rows)
 }

--- a/native-ui/crates/attn-native-app/src/spike5_canvas.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_canvas.rs
@@ -1,129 +1,432 @@
-/// Spike 5 canvas — reads panels from one selected `Entity<Workspace>`
-/// and renders each via the `PanelContent` enum. Pan/zoom is intentionally
-/// out of scope here (proven by spikes 3+4); this canvas focuses on the
-/// architectural piece spike 5 is meant to prove: enum-dispatched panel
-/// rendering off a peer-shared workspace entity.
+/// Workspace canvas — pan/zoom/drag/resize/focus on top of the panels
+/// stored in the selected `Entity<Workspace>`. The mechanics (viewport
+/// transform, hit testing, drag-state machine) are the spike-4 design
+/// lifted onto a peer-shared workspace entity instead of a fixed Vec.
 ///
-/// When the selected workspace changes, the parent (`Spike5App`) calls
-/// `set_selected` with the new entity handle. Subscribers are re-wired so
-/// `cx.notify()` only fires for the workspace currently on screen.
+/// Mutation flow: drag/resize update panel position/size by reaching into
+/// the selected workspace via `update`. Terminal cell sizing and PTY
+/// reflow happen inside `TerminalView` itself — when the panel resizes,
+/// `set_content_size` propagates the new dims and the view emits the
+/// PtyResize on its next render.
 use gpui::{
-    div, prelude::*, px, rgb, AnyElement, Context, Entity, ParentElement, Render, SharedString,
-    Subscription, Window,
+    div, point, prelude::*, px, rgb, AnyElement, App, Context, Entity, FocusHandle, Focusable,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Render,
+    ScrollDelta, ScrollWheelEvent, SharedString, Subscription, Window,
 };
 
+use crate::canvas_view::{pf, GridElement, Viewport};
+use crate::daemon_client::DaemonClient;
 use crate::panel::{Panel, PanelContent};
 use crate::workspace::Workspace;
 
+// ── Layout constants ─────────────────────────────────────────────────────────
+
+const TITLE_HEIGHT: f32 = 24.0; // world-space units
+const HANDLE_SIZE: f32 = 8.0; // screen-space pixels (fixed, not scaled)
+const PANEL_MIN_W: f32 = 120.0; // world-space
+const PANEL_MIN_H: f32 = 80.0; // world-space
+
+// ── Drag/resize state ─────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, Debug)]
+enum ResizeHandle {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+#[derive(Clone, Debug)]
+enum DragState {
+    Idle,
+    PanningCanvas { last_screen: gpui::Point<Pixels> },
+    DraggingPanel { panel_id: usize, last_screen: gpui::Point<Pixels> },
+    ResizingPanel { panel_id: usize, handle: ResizeHandle, last_screen: gpui::Point<Pixels> },
+}
+
+#[derive(Debug)]
+enum HitResult {
+    Canvas,
+    PanelBody(usize),
+    TitleBar(usize),
+    ResizeHandle(usize, ResizeHandle),
+}
+
 pub struct Spike5Canvas {
+    #[allow(dead_code)]
+    daemon: Entity<DaemonClient>,
     selected: Option<Entity<Workspace>>,
-    /// Handle to the workspace observation. Drop = unsubscribe; keeping it
-    /// lets us replace cleanly when selection changes.
+    /// Drop = unsubscribe. Replaced when selection changes so re-renders
+    /// only fire for the workspace currently on screen.
     _selected_subscription: Option<Subscription>,
+    viewport: Viewport,
+    drag_state: DragState,
+    focused_panel: Option<usize>,
+    needs_focus_panel: Option<usize>,
+    focus_handle: FocusHandle,
 }
 
 impl Spike5Canvas {
-    pub fn new() -> Self {
-        Self { selected: None, _selected_subscription: None }
+    pub fn new(daemon: Entity<DaemonClient>, cx: &mut Context<Self>) -> Self {
+        Self {
+            daemon,
+            selected: None,
+            _selected_subscription: None,
+            viewport: Viewport::default(),
+            drag_state: DragState::Idle,
+            focused_panel: None,
+            needs_focus_panel: None,
+            focus_handle: cx.focus_handle(),
+        }
     }
 
     pub fn set_selected(&mut self, ws: Option<Entity<Workspace>>, cx: &mut Context<Self>) {
         self._selected_subscription = ws.as_ref().map(|w| cx.observe(w, |_, _, cx| cx.notify()));
         self.selected = ws;
+        self.drag_state = DragState::Idle;
+        self.focused_panel = None;
+        cx.notify();
+    }
+
+    /// Panel snapshot for hit testing and rendering. Cloning is cheap
+    /// (entity handles + small fields) and decouples the immutable read
+    /// from any mutating update later in the same frame.
+    fn panels_snapshot(&self, cx: &App) -> Vec<Panel> {
+        match self.selected.as_ref() {
+            Some(ws) => ws.read(cx).panels.clone(),
+            None => Vec::new(),
+        }
+    }
+
+    // ── Hit testing ──────────────────────────────────────────────────────────
+
+    fn hit_test(&self, screen_pos: gpui::Point<Pixels>, cx: &App) -> HitResult {
+        let mx = pf(screen_pos.x);
+        let my = pf(screen_pos.y);
+        let zoom = self.viewport.zoom;
+        let panels = self.panels_snapshot(cx);
+
+        // Check panels in reverse so the topmost (last rendered) wins.
+        for panel in panels.iter().rev() {
+            let sp = self.viewport.world_to_screen(point(panel.world_x, panel.world_y));
+            let sx = pf(sp.x);
+            let sy = pf(sp.y);
+            let sw = panel.width * zoom;
+            let sh = panel.height * zoom;
+
+            // Resize corner zones — fixed 8+2px hit area in screen space.
+            let half = HANDLE_SIZE / 2.0 + 2.0;
+            if (mx - sx).abs() <= half && (my - sy).abs() <= half {
+                return HitResult::ResizeHandle(panel.id, ResizeHandle::TopLeft);
+            }
+            if (mx - (sx + sw)).abs() <= half && (my - sy).abs() <= half {
+                return HitResult::ResizeHandle(panel.id, ResizeHandle::TopRight);
+            }
+            if (mx - sx).abs() <= half && (my - (sy + sh)).abs() <= half {
+                return HitResult::ResizeHandle(panel.id, ResizeHandle::BottomLeft);
+            }
+            if (mx - (sx + sw)).abs() <= half && (my - (sy + sh)).abs() <= half {
+                return HitResult::ResizeHandle(panel.id, ResizeHandle::BottomRight);
+            }
+
+            if mx >= sx && mx <= sx + sw && my >= sy && my <= sy + sh {
+                let title_h = TITLE_HEIGHT * zoom;
+                if my <= sy + title_h {
+                    return HitResult::TitleBar(panel.id);
+                }
+                return HitResult::PanelBody(panel.id);
+            }
+        }
+
+        HitResult::Canvas
+    }
+
+    // ── Mouse handlers ────────────────────────────────────────────────────────
+
+    fn on_mouse_down(
+        &mut self,
+        event: &MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let pos = event.position;
+        let hit = self.hit_test(pos, cx);
+        match hit {
+            HitResult::TitleBar(id) => {
+                self.focused_panel = Some(id);
+                self.drag_state = DragState::DraggingPanel { panel_id: id, last_screen: pos };
+            }
+            HitResult::ResizeHandle(id, handle) => {
+                self.drag_state =
+                    DragState::ResizingPanel { panel_id: id, handle, last_screen: pos };
+            }
+            HitResult::PanelBody(id) => {
+                self.focused_panel = Some(id);
+                if let Some(ws) = self.selected.as_ref() {
+                    if let Some(panel) = ws.read(cx).panels.iter().find(|p| p.id == id) {
+                        if let PanelContent::Terminal { view, .. } = &panel.content {
+                            view.read(cx).focus_handle.clone().focus(window);
+                        }
+                    }
+                }
+                self.drag_state = DragState::Idle;
+            }
+            HitResult::Canvas => {
+                self.drag_state = DragState::PanningCanvas { last_screen: pos };
+            }
+        }
+        cx.notify();
+    }
+
+    fn on_mouse_move(
+        &mut self,
+        event: &MouseMoveEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let pos = event.position;
+        match self.drag_state.clone() {
+            DragState::Idle => return,
+
+            DragState::PanningCanvas { last_screen } => {
+                let dx = pf(pos.x) - pf(last_screen.x);
+                let dy = pf(pos.y) - pf(last_screen.y);
+                self.viewport.origin.x -= dx / self.viewport.zoom;
+                self.viewport.origin.y -= dy / self.viewport.zoom;
+                self.drag_state = DragState::PanningCanvas { last_screen: pos };
+            }
+
+            DragState::DraggingPanel { panel_id, last_screen } => {
+                let dx = (pf(pos.x) - pf(last_screen.x)) / self.viewport.zoom;
+                let dy = (pf(pos.y) - pf(last_screen.y)) / self.viewport.zoom;
+                if let Some(ws) = self.selected.as_ref() {
+                    ws.update(cx, |ws, cx| {
+                        if let Some(p) = ws.panels.iter_mut().find(|p| p.id == panel_id) {
+                            p.world_x += dx;
+                            p.world_y += dy;
+                            cx.notify();
+                        }
+                    });
+                }
+                self.drag_state = DragState::DraggingPanel { panel_id, last_screen: pos };
+            }
+
+            DragState::ResizingPanel { panel_id, handle, last_screen } => {
+                // Screen delta → world delta so resize feels zoom-invariant.
+                let dx = (pf(pos.x) - pf(last_screen.x)) / self.viewport.zoom;
+                let dy = (pf(pos.y) - pf(last_screen.y)) / self.viewport.zoom;
+                if let Some(ws) = self.selected.as_ref() {
+                    ws.update(cx, |ws, cx| {
+                        if let Some(p) = ws.panels.iter_mut().find(|p| p.id == panel_id) {
+                            apply_resize(p, handle, dx, dy);
+                            cx.notify();
+                        }
+                    });
+                }
+                self.drag_state =
+                    DragState::ResizingPanel { panel_id, handle, last_screen: pos };
+            }
+        }
+        cx.notify();
+    }
+
+    fn on_mouse_up(
+        &mut self,
+        _event: &MouseUpEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.drag_state = DragState::Idle;
+        cx.notify();
+    }
+
+    fn on_scroll_wheel(
+        &mut self,
+        event: &ScrollWheelEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let (dx, dy) = match event.delta {
+            ScrollDelta::Pixels(p) => (pf(p.x), pf(p.y)),
+            ScrollDelta::Lines(p) => (p.x * 20.0, p.y * 20.0),
+        };
+
+        if event.modifiers.platform {
+            // Cmd+scroll → zoom toward cursor.
+            let factor = if dy > 0.0 { 1.08 } else { 1.0 / 1.08 };
+            self.viewport = self.viewport.zoom_toward(event.position, factor);
+        } else {
+            // Regular scroll → pan.
+            self.viewport.origin.x -= dx / self.viewport.zoom;
+            self.viewport.origin.y -= dy / self.viewport.zoom;
+        }
         cx.notify();
     }
 }
 
-impl Render for Spike5Canvas {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let body: AnyElement = match self.selected.as_ref() {
-            None => empty_state().into_any_element(),
-            Some(ws_entity) => {
-                // Clone the panel list out so the immutable borrow on `cx`
-                // ends before `render_panel` takes its own mutable borrow.
-                let (title, panels_data) = {
-                    let ws = ws_entity.read(cx);
-                    (ws.title.clone(), ws.panels.clone())
-                };
-                let panels: Vec<AnyElement> =
-                    panels_data.iter().map(|p| render_panel(p, cx)).collect();
-                div()
-                    .size_full()
-                    .relative()
-                    .child(
-                        div()
-                            .absolute()
-                            .left_4()
-                            .top_2()
-                            .text_color(rgb(0x6a6a78))
-                            .text_size(px(11.))
-                            .child(format!("workspace · {title}")),
-                    )
-                    .children(panels)
-                    .into_any_element()
-            }
-        };
-
-        div().size_full().bg(rgb(0x0e0e14)).child(body)
+fn apply_resize(p: &mut Panel, handle: ResizeHandle, dx: f32, dy: f32) {
+    match handle {
+        ResizeHandle::TopLeft => {
+            let new_w = (p.width - dx).max(PANEL_MIN_W);
+            let new_h = (p.height - dy).max(PANEL_MIN_H);
+            p.world_x += p.width - new_w;
+            p.world_y += p.height - new_h;
+            p.width = new_w;
+            p.height = new_h;
+        }
+        ResizeHandle::TopRight => {
+            let new_h = (p.height - dy).max(PANEL_MIN_H);
+            p.world_y += p.height - new_h;
+            p.height = new_h;
+            p.width = (p.width + dx).max(PANEL_MIN_W);
+        }
+        ResizeHandle::BottomLeft => {
+            let new_w = (p.width - dx).max(PANEL_MIN_W);
+            p.world_x += p.width - new_w;
+            p.width = new_w;
+            p.height = (p.height + dy).max(PANEL_MIN_H);
+        }
+        ResizeHandle::BottomRight => {
+            p.width = (p.width + dx).max(PANEL_MIN_W);
+            p.height = (p.height + dy).max(PANEL_MIN_H);
+        }
     }
 }
 
-fn empty_state() -> impl IntoElement {
+impl Focusable for Spike5Canvas {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for Spike5Canvas {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let viewport = self.viewport;
+        let window_size = window.viewport_size();
+        let ws_w = pf(window_size.width);
+        let ws_h = pf(window_size.height);
+        let focus_handle = self.focus_handle.clone();
+        let focused_panel = self.focused_panel;
+
+        let mut root = div()
+            .size_full()
+            .bg(rgb(0x0e0e14))
+            .track_focus(&focus_handle)
+            .on_mouse_down(MouseButton::Left, cx.listener(Self::on_mouse_down))
+            .on_mouse_move(cx.listener(Self::on_mouse_move))
+            .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
+            .on_scroll_wheel(cx.listener(Self::on_scroll_wheel))
+            .child(GridElement { viewport });
+
+        let Some(selected) = self.selected.clone() else {
+            return root.child(empty_state(SharedString::from("Select a workspace")));
+        };
+
+        let panels = selected.read(cx).panels.clone();
+        if panels.is_empty() {
+            return root.child(empty_state(SharedString::from("Workspace has no panels yet")));
+        }
+
+        // Apply pending focus request now that we have window access.
+        if let Some(fid) = self.needs_focus_panel.take() {
+            if let Some(panel) = panels.iter().find(|p| p.id == fid) {
+                if let PanelContent::Terminal { view, .. } = &panel.content {
+                    view.read(cx).focus_handle.clone().focus(window);
+                }
+            }
+        }
+
+        // Push content_size + zoom into every TerminalView so their next
+        // render syncs cell dims and emits PtyResize on actual change.
+        let zoom = viewport.zoom;
+        for panel in &panels {
+            if let PanelContent::Terminal { view, .. } = &panel.content {
+                let content_w = panel.width;
+                let content_h = (panel.height - TITLE_HEIGHT).max(0.0);
+                view.update(cx, |tv, inner_cx| {
+                    let size_changed = tv.set_content_size(content_w, content_h);
+                    let zoom_changed = tv.set_zoom(zoom);
+                    if size_changed || zoom_changed {
+                        inner_cx.notify();
+                    }
+                });
+            }
+        }
+
+        for panel in &panels {
+            let sp = viewport.world_to_screen(point(panel.world_x, panel.world_y));
+            let sx = pf(sp.x);
+            let sy = pf(sp.y);
+            let sw = panel.width * viewport.zoom;
+            let sh = panel.height * viewport.zoom;
+            let title_h = TITLE_HEIGHT * viewport.zoom;
+
+            // Viewport culling — skip fully off-screen panels.
+            if sx + sw < 0.0 || sy + sh < 0.0 || sx > ws_w || sy > ws_h {
+                continue;
+            }
+
+            let is_focused = focused_panel == Some(panel.id);
+            let border_color = if is_focused { rgb(0x4a9eff) } else { rgb(0x2a2a35) };
+            let content_h = (sh - title_h).max(0.0);
+            let title = panel.title.clone();
+
+            let body: AnyElement = match &panel.content {
+                PanelContent::Placeholder(view) => view.clone().into_any_element(),
+                PanelContent::Terminal { view, .. } => view.clone().into_any_element(),
+            };
+
+            let panel_div = div()
+                .absolute()
+                .left(px(sx))
+                .top(px(sy))
+                .w(px(sw))
+                .h(px(sh))
+                .bg(rgb(0x1c1c26))
+                .border_1()
+                .border_color(border_color)
+                .child(
+                    div()
+                        .w_full()
+                        .h(px(title_h))
+                        .bg(rgb(0x252535))
+                        .flex()
+                        .items_center()
+                        .pl(px(8.0))
+                        .child(div().text_xs().text_color(rgb(0xa0a0b0)).child(title)),
+                )
+                .child(div().w_full().h(px(content_h)).overflow_hidden().child(body))
+                .child(corner_handle(0.0, 0.0))
+                .child(corner_handle(sw - HANDLE_SIZE, 0.0))
+                .child(corner_handle(0.0, sh - HANDLE_SIZE))
+                .child(corner_handle(sw - HANDLE_SIZE, sh - HANDLE_SIZE));
+
+            root = root.child(panel_div);
+        }
+
+        root
+    }
+}
+
+fn empty_state(label: SharedString) -> impl IntoElement {
     div()
+        .absolute()
         .size_full()
         .flex()
         .items_center()
         .justify_center()
         .text_color(rgb(0x6a6a78))
         .text_size(px(13.))
-        .child(SharedString::from("Select a workspace"))
+        .child(label)
 }
 
-/// Render one panel. Position is `absolute` in screen space — no zoom for
-/// the spike. The PanelContent match is the place new panel types plug in.
-fn render_panel(panel: &Panel, cx: &mut Context<Spike5Canvas>) -> AnyElement {
-    let frame = div()
-        .absolute()
-        .left(px(panel.world_x))
-        .top(px(panel.world_y))
-        .w(px(panel.width))
-        .h(px(panel.height))
-        .bg(rgb(0x1c1c26))
-        .border_1()
-        .border_color(rgb(0x2a2a35))
-        .rounded_md()
-        .flex()
-        .flex_col()
-        .child(
-            // Title bar
-            div()
-                .px_3()
-                .py_1()
-                .border_b_1()
-                .border_color(rgb(0x2a2a35))
-                .text_color(rgb(0xa0a0b0))
-                .text_size(px(11.))
-                .child(panel.title.clone()),
-        );
-
-    match &panel.content {
-        PanelContent::Placeholder(view) => frame.child(view.clone()).into_any_element(),
-        PanelContent::Terminal { session_id } => frame
-            .child(terminal_stub(session_id.clone(), cx))
-            .into_any_element(),
-    }
-}
-
-/// Stand-in for a real `TerminalView` — proves the enum dispatches a
-/// distinct render branch. Wiring spike-4's terminal rendering into the
-/// workspace context is a follow-up.
-fn terminal_stub(session_id: SharedString, _cx: &mut Context<Spike5Canvas>) -> impl IntoElement {
+fn corner_handle(left: f32, top: f32) -> impl IntoElement {
     div()
-        .flex_1()
-        .flex()
-        .items_center()
-        .justify_center()
-        .text_color(rgb(0x6a8a6a))
-        .text_size(px(12.))
-        .child(format!("terminal · {session_id} (stub)"))
+        .absolute()
+        .left(px(left))
+        .top(px(top))
+        .w(px(HANDLE_SIZE))
+        .h(px(HANDLE_SIZE))
+        .bg(rgb(0x5a5a6a))
+        .rounded(px(1.0))
 }

--- a/native-ui/crates/attn-native-app/src/spike5_canvas.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_canvas.rs
@@ -169,8 +169,12 @@ impl Spike5Canvas {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let pos = self.local_pos(event.position);
-        let hit = self.hit_test(pos, cx);
+        // hit_test takes canvas-local coords (panel screen positions are
+        // computed from world*zoom with no canvas offset). DragState's
+        // last_screen stays window-relative so it matches on_mouse_move,
+        // where deltas are computed against event.position.
+        let hit = self.hit_test(self.local_pos(event.position), cx);
+        let pos = event.position;
         match hit {
             HitResult::TitleBar(id) => {
                 self.focused_panel = Some(id);

--- a/native-ui/crates/attn-native-app/src/spike5_canvas.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_canvas.rs
@@ -18,13 +18,11 @@ use gpui::{
 };
 
 use crate::canvas_view::{pf, GridElement, Viewport};
-use crate::daemon_client::DaemonClient;
-use crate::panel::{Panel, PanelContent};
+use crate::panel::{Panel, PanelContent, TITLE_HEIGHT};
 use crate::workspace::Workspace;
 
 // ── Layout constants ─────────────────────────────────────────────────────────
 
-const TITLE_HEIGHT: f32 = 24.0; // world-space units
 const HANDLE_SIZE: f32 = 8.0; // screen-space pixels (fixed, not scaled)
 const PANEL_MIN_W: f32 = 120.0; // world-space
 const PANEL_MIN_H: f32 = 80.0; // world-space
@@ -56,8 +54,6 @@ enum HitResult {
 }
 
 pub struct Spike5Canvas {
-    #[allow(dead_code)]
-    daemon: Entity<DaemonClient>,
     selected: Option<Entity<Workspace>>,
     /// Drop = unsubscribe. Replaced when selection changes so re-renders
     /// only fire for the workspace currently on screen.
@@ -65,7 +61,6 @@ pub struct Spike5Canvas {
     viewport: Viewport,
     drag_state: DragState,
     focused_panel: Option<usize>,
-    needs_focus_panel: Option<usize>,
     focus_handle: FocusHandle,
     /// Window-relative bounds of the canvas's root element, captured each
     /// frame via a `canvas()` prepaint callback. Mouse events arrive with
@@ -76,15 +71,13 @@ pub struct Spike5Canvas {
 }
 
 impl Spike5Canvas {
-    pub fn new(daemon: Entity<DaemonClient>, cx: &mut Context<Self>) -> Self {
+    pub fn new(cx: &mut Context<Self>) -> Self {
         Self {
-            daemon,
             selected: None,
             _selected_subscription: None,
             viewport: Viewport::default(),
             drag_state: DragState::Idle,
             focused_panel: None,
-            needs_focus_panel: None,
             focus_handle: cx.focus_handle(),
             bounds: Rc::new(Cell::new(None)),
         }
@@ -365,15 +358,6 @@ impl Render for Spike5Canvas {
         let panels = selected.read(cx).panels.clone();
         if panels.is_empty() {
             return root.child(empty_state(SharedString::from("Workspace has no panels yet")));
-        }
-
-        // Apply pending focus request now that we have window access.
-        if let Some(fid) = self.needs_focus_panel.take() {
-            if let Some(panel) = panels.iter().find(|p| p.id == fid) {
-                if let PanelContent::Terminal { view, .. } = &panel.content {
-                    view.read(cx).focus_handle.clone().focus(window);
-                }
-            }
         }
 
         // Push content_size + zoom into every TerminalView so their next

--- a/native-ui/crates/attn-native-app/src/spike5_canvas.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_canvas.rs
@@ -8,10 +8,13 @@
 /// reflow happen inside `TerminalView` itself — when the panel resizes,
 /// `set_content_size` propagates the new dims and the view emits the
 /// PtyResize on its next render.
+use std::cell::Cell;
+use std::rc::Rc;
+
 use gpui::{
-    div, point, prelude::*, px, rgb, AnyElement, App, Context, Entity, FocusHandle, Focusable,
-    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Render,
-    ScrollDelta, ScrollWheelEvent, SharedString, Subscription, Window,
+    canvas, div, point, prelude::*, px, rgb, AnyElement, App, Bounds, Context, Entity, FocusHandle,
+    Focusable, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels,
+    Render, ScrollDelta, ScrollWheelEvent, SharedString, Subscription, Window,
 };
 
 use crate::canvas_view::{pf, GridElement, Viewport};
@@ -64,6 +67,12 @@ pub struct Spike5Canvas {
     focused_panel: Option<usize>,
     needs_focus_panel: Option<usize>,
     focus_handle: FocusHandle,
+    /// Window-relative bounds of the canvas's root element, captured each
+    /// frame via a `canvas()` prepaint callback. Mouse events arrive with
+    /// window-relative coordinates, so hit testing and zoom focal points
+    /// must subtract this origin to land in canvas-local space. Without
+    /// this, the sidebar's 240px width breaks every panel hit test.
+    bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
 }
 
 impl Spike5Canvas {
@@ -77,6 +86,17 @@ impl Spike5Canvas {
             focused_panel: None,
             needs_focus_panel: None,
             focus_handle: cx.focus_handle(),
+            bounds: Rc::new(Cell::new(None)),
+        }
+    }
+
+    /// Translate a window-relative position into canvas-local space using
+    /// the most recently captured bounds. Falls back to the input when
+    /// bounds aren't known yet (first frame before paint).
+    fn local_pos(&self, screen: gpui::Point<Pixels>) -> gpui::Point<Pixels> {
+        match self.bounds.get() {
+            Some(b) => point(screen.x - b.origin.x, screen.y - b.origin.y),
+            None => screen,
         }
     }
 
@@ -149,7 +169,7 @@ impl Spike5Canvas {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let pos = event.position;
+        let pos = self.local_pos(event.position);
         let hit = self.hit_test(pos, cx);
         match hit {
             HitResult::TitleBar(id) => {
@@ -184,6 +204,8 @@ impl Spike5Canvas {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Window-relative is fine here — every drag-state arm consumes
+        // deltas, and any constant offset cancels out when subtracting.
         let pos = event.position;
         match self.drag_state.clone() {
             DragState::Idle => return,
@@ -252,9 +274,11 @@ impl Spike5Canvas {
         };
 
         if event.modifiers.platform {
-            // Cmd+scroll → zoom toward cursor.
+            // Cmd+scroll → zoom toward cursor. Translate to canvas-local
+            // space so the focal point lands under the actual cursor and
+            // not 240px to its right.
             let factor = if dy > 0.0 { 1.08 } else { 1.0 / 1.08 };
-            self.viewport = self.viewport.zoom_toward(event.position, factor);
+            self.viewport = self.viewport.zoom_toward(self.local_pos(event.position), factor);
         } else {
             // Regular scroll → pan.
             self.viewport.origin.x -= dx / self.viewport.zoom;
@@ -308,6 +332,7 @@ impl Render for Spike5Canvas {
         let focus_handle = self.focus_handle.clone();
         let focused_panel = self.focused_panel;
 
+        let bounds_capture = self.bounds.clone();
         let mut root = div()
             .size_full()
             .bg(rgb(0x0e0e14))
@@ -316,6 +341,17 @@ impl Render for Spike5Canvas {
             .on_mouse_move(cx.listener(Self::on_mouse_move))
             .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
             .on_scroll_wheel(cx.listener(Self::on_scroll_wheel))
+            // Stamp the canvas's window-relative bounds into a shared
+            // cell so mouse handlers can translate event.position into
+            // canvas-local coords. The paint callback is a no-op.
+            .child(
+                canvas(
+                    move |new_bounds, _, _| bounds_capture.set(Some(new_bounds)),
+                    |_, _, _, _| {},
+                )
+                .absolute()
+                .size_full(),
+            )
             .child(GridElement { viewport });
 
         let Some(selected) = self.selected.clone() else {

--- a/native-ui/crates/attn-native-app/src/spike5_main.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_main.rs
@@ -1,10 +1,13 @@
-/// Spike 5 entry point — workspace entity model + sidebar + canvas with
-/// mixed panel types. Run with: `cargo run --bin attn-spike5`.
+/// Workspace canvas entry point — sidebar + pannable canvas with live
+/// terminal panels driven by the daemon. Run with: `cargo run --bin attn-spike5`.
+mod canvas_view;
 mod daemon_client;
 mod panel;
 mod sidebar;
 mod spike5_app;
 mod spike5_canvas;
+mod terminal_model;
+mod terminal_view;
 mod workspace;
 
 use gpui::{actions, px, size, App, AppContext, Application, Bounds, KeyBinding, WindowBounds, WindowOptions};

--- a/native-ui/crates/attn-native-app/src/terminal_view.rs
+++ b/native-ui/crates/attn-native-app/src/terminal_view.rs
@@ -323,6 +323,11 @@ impl TerminalView {
     }
 
     /// Set the canvas zoom factor used for rendering. Returns true if changed.
+    /// `#[allow(dead_code)]` is a per-binary artifact of the spike's
+    /// multi-bin layout — the method is used by `attn-spike4` and
+    /// `attn-spike5` but not by `attn-native`, and Rust dead-code
+    /// analysis runs per binary. A future lib.rs refactor would let us
+    /// drop this.
     #[allow(dead_code)]
     pub fn set_zoom(&mut self, zoom: f32) -> bool {
         let changed = (self.zoom - zoom).abs() >= 0.001;
@@ -334,6 +339,7 @@ impl TerminalView {
 
     /// Set the content area size (world-space units) used for terminal dimension
     /// computation. Returns true if the value changed by more than half a pixel.
+    /// See note on `set_zoom` re: `#[allow(dead_code)]`.
     #[allow(dead_code)]
     pub fn set_content_size(&mut self, w: f32, h: f32) -> bool {
         let changed = match self.content_size {

--- a/scripts/wsctl/main.go
+++ b/scripts/wsctl/main.go
@@ -203,14 +203,18 @@ func rmSession(args []string) error {
 	if *id == "" {
 		return errors.New("--id is required")
 	}
+	// `unregister` SIGTERMs the agent process AND removes the session
+	// record from the daemon's store. `kill_session` only does the
+	// first half — if the agent is already dead, kill_session is a
+	// no-op and the session lingers as a ghost.
 	msg := map[string]any{
-		"cmd": "kill_session",
+		"cmd": "unregister",
 		"id":  *id,
 	}
 	if err := send(msg); err != nil {
 		return err
 	}
-	fmt.Printf("session killed: id=%s\n", *id)
+	fmt.Printf("session removed: id=%s\n", *id)
 	return nil
 }
 

--- a/scripts/wsctl/main.go
+++ b/scripts/wsctl/main.go
@@ -1,0 +1,348 @@
+// wsctl is a tiny dev helper that drives the daemon's websocket directly.
+//
+// Until a real native UI lands with workspace + spawn affordances, the
+// canvas spike (attn-spike5) has no way to create the workspaces or
+// workspace-bound sessions it consumes. This script fills that gap.
+//
+// Defaults to the dev daemon (ws://localhost:29849/ws). Override with
+// ATTN_WS_URL.
+//
+// Usage:
+//
+//	go run ./scripts/wsctl add-workspace --title T --dir D [--id I]
+//	go run ./scripts/wsctl rm-workspace --id I
+//	go run ./scripts/wsctl add-session --workspace W --cwd D [--agent claude] [--label L] [--id I] [--cols 80] [--rows 24]
+//	go run ./scripts/wsctl rm-session --id I
+//	go run ./scripts/wsctl list
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+const defaultWSURL = "ws://localhost:29849/ws"
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	cmd := os.Args[1]
+	args := os.Args[2:]
+
+	var err error
+	switch cmd {
+	case "add-workspace":
+		err = addWorkspace(args)
+	case "rm-workspace":
+		err = rmWorkspace(args)
+	case "add-session":
+		err = addSession(args)
+	case "rm-session":
+		err = rmSession(args)
+	case "list":
+		err = list(args)
+	case "-h", "--help", "help":
+		usage()
+		return
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", cmd)
+		usage()
+		os.Exit(2)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `wsctl — dev helper for driving the attn daemon over WebSocket.
+
+URL: %s (override with ATTN_WS_URL)
+
+Commands:
+  add-workspace --title T --dir D [--id I]
+  rm-workspace --id I
+  add-session --workspace W --cwd D [--agent claude] [--label L] [--id I] [--cols 80] [--rows 24]
+  rm-session --id I
+  list
+`, wsURL())
+}
+
+func wsURL() string {
+	if u := os.Getenv("ATTN_WS_URL"); u != "" {
+		return u
+	}
+	return defaultWSURL
+}
+
+// ── Subcommands ──────────────────────────────────────────────────────────────
+
+func addWorkspace(args []string) error {
+	fs := flag.NewFlagSet("add-workspace", flag.ExitOnError)
+	title := fs.String("title", "", "workspace title (required)")
+	dir := fs.String("dir", "", "workspace directory (required)")
+	id := fs.String("id", "", "workspace id (defaults to a generated one)")
+	fs.Parse(args)
+
+	if *title == "" || *dir == "" {
+		return errors.New("--title and --dir are required")
+	}
+	wsID := *id
+	if wsID == "" {
+		wsID = newID("ws")
+	}
+	abs, err := filepath.Abs(*dir)
+	if err != nil {
+		return err
+	}
+	msg := map[string]any{
+		"cmd":       "register_workspace",
+		"id":        wsID,
+		"title":     *title,
+		"directory": abs,
+	}
+	if err := send(msg); err != nil {
+		return err
+	}
+	fmt.Printf("workspace registered: id=%s title=%q dir=%s\n", wsID, *title, abs)
+	return nil
+}
+
+func rmWorkspace(args []string) error {
+	fs := flag.NewFlagSet("rm-workspace", flag.ExitOnError)
+	id := fs.String("id", "", "workspace id (required)")
+	fs.Parse(args)
+	if *id == "" {
+		return errors.New("--id is required")
+	}
+	msg := map[string]any{
+		"cmd": "unregister_workspace",
+		"id":  *id,
+	}
+	if err := send(msg); err != nil {
+		return err
+	}
+	fmt.Printf("workspace unregistered: id=%s\n", *id)
+	return nil
+}
+
+func addSession(args []string) error {
+	fs := flag.NewFlagSet("add-session", flag.ExitOnError)
+	workspace := fs.String("workspace", "", "owning workspace id (required)")
+	cwd := fs.String("cwd", "", "session working directory (required)")
+	agent := fs.String("agent", "claude", "agent: claude | codex | copilot | shell")
+	label := fs.String("label", "", "session label (defaults to dir basename)")
+	id := fs.String("id", "", "session id (defaults to a generated one)")
+	cols := fs.Int("cols", 80, "initial PTY cols")
+	rows := fs.Int("rows", 24, "initial PTY rows")
+	fs.Parse(args)
+
+	if *workspace == "" || *cwd == "" {
+		return errors.New("--workspace and --cwd are required")
+	}
+	abs, err := filepath.Abs(*cwd)
+	if err != nil {
+		return err
+	}
+	sessID := *id
+	if sessID == "" {
+		// Claude Code (and likely other agents) reject non-UUID session
+		// ids — the agent CLI uses them directly as its own session
+		// identifier, which must be UUID-shaped.
+		sessID = newUUID()
+	}
+
+	msg := map[string]any{
+		"cmd":          "spawn_session",
+		"id":           sessID,
+		"cwd":          abs,
+		"workspace_id": *workspace,
+		"agent":        *agent,
+		"cols":         *cols,
+		"rows":         *rows,
+	}
+	if *label != "" {
+		msg["label"] = *label
+	}
+
+	// Spawn replies with a SpawnResult — wait briefly for it so we
+	// can surface failures (bad cwd, unknown agent, etc.) instead of
+	// printing "ok" and leaving the user to wonder why nothing
+	// appeared.
+	resp, err := sendAndWait(msg, "spawn_result", sessID, 2*time.Second)
+	if err != nil {
+		return err
+	}
+	if resp != nil {
+		success, _ := resp["success"].(bool)
+		if !success {
+			errMsg, _ := resp["error"].(string)
+			return fmt.Errorf("daemon rejected spawn: %s", errMsg)
+		}
+	}
+	fmt.Printf("session spawned: id=%s workspace=%s agent=%s cwd=%s\n", sessID, *workspace, *agent, abs)
+	return nil
+}
+
+func rmSession(args []string) error {
+	fs := flag.NewFlagSet("rm-session", flag.ExitOnError)
+	id := fs.String("id", "", "session id (required)")
+	fs.Parse(args)
+	if *id == "" {
+		return errors.New("--id is required")
+	}
+	msg := map[string]any{
+		"cmd": "kill_session",
+		"id":  *id,
+	}
+	if err := send(msg); err != nil {
+		return err
+	}
+	fmt.Printf("session killed: id=%s\n", *id)
+	return nil
+}
+
+func list(_ []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, wsURL(), nil)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", wsURL(), err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// First message after connect is initial_state.
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("read initial_state: %w", err)
+	}
+	var event map[string]any
+	if err := json.Unmarshal(data, &event); err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	if ev, _ := event["event"].(string); ev != "initial_state" {
+		return fmt.Errorf("expected initial_state, got %q", ev)
+	}
+	pretty, _ := json.MarshalIndent(map[string]any{
+		"workspaces": event["workspaces"],
+		"sessions":   event["sessions"],
+	}, "", "  ")
+	fmt.Println(string(pretty))
+	return nil
+}
+
+// ── Wire helpers ─────────────────────────────────────────────────────────────
+
+// send opens a connection, drains the initial_state event, sends the
+// payload, and closes. No response read — fire-and-forget.
+func send(payload map[string]any) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, wsURL(), nil)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", wsURL(), err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Daemon sends initial_state on connect; drain it before our write
+	// so the socket buffer doesn't backlog.
+	if _, _, err := conn.Read(ctx); err != nil {
+		return fmt.Errorf("drain initial_state: %w", err)
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if err := conn.Write(ctx, websocket.MessageText, body); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	// Tiny grace window so the daemon has time to enqueue the work
+	// before we hang up. Without this, fast-fire calls can race the
+	// daemon's read loop on connection close.
+	time.Sleep(150 * time.Millisecond)
+	return nil
+}
+
+// sendAndWait sends the payload, then reads frames until it sees an
+// event of the given type (filtered by id when provided) or the
+// timeout elapses. Other frames are silently dropped.
+func sendAndWait(payload map[string]any, expectedEvent, expectedID string, timeout time.Duration) (map[string]any, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout+3*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, wsURL(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", wsURL(), err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	if _, _, err := conn.Read(ctx); err != nil {
+		return nil, fmt.Errorf("drain initial_state: %w", err)
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	if err := conn.Write(ctx, websocket.MessageText, body); err != nil {
+		return nil, fmt.Errorf("write: %w", err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, fmt.Errorf("timed out waiting for %s", expectedEvent)
+		}
+		readCtx, readCancel := context.WithTimeout(ctx, remaining)
+		_, data, err := conn.Read(readCtx)
+		readCancel()
+		if err != nil {
+			return nil, fmt.Errorf("read: %w", err)
+		}
+		var event map[string]any
+		if err := json.Unmarshal(data, &event); err != nil {
+			continue
+		}
+		if event["event"] == expectedEvent {
+			if expectedID == "" {
+				return event, nil
+			}
+			if id, _ := event["id"].(string); id == expectedID {
+				return event, nil
+			}
+		}
+	}
+}
+
+func newID(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+// newUUID returns a random RFC 4122 v4 UUID string. We can't use a
+// timestamp-prefixed id for sessions because the agent CLI we hand the
+// id to (e.g. claude) parses it as a UUID and rejects anything else.
+func newUUID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Fall back to a timestamp-derived id; agent CLI will then
+		// reject the spawn, which is a clearer failure than silently
+		// generating a non-random "uuid".
+		return newID("sess")
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}


### PR DESCRIPTION
## Summary

Converges spike-4's terminal-canvas mechanics with spike-5's workspace entity model and adds a small dev helper so the canvas can actually be exercised end-to-end. The result: a sidebar-driven workspace switcher whose canvas is pannable + zoomable and whose panels are live `TerminalView`s wired straight to the daemon.

### Canvas convergence
- `PanelContent::Terminal` now carries an `Entity<TerminalView>`; the same entity persists across canvas re-renders *and* across workspace switches, so terminals don't lose their PTY model when you flip between sidebar rows.
- `Spike5Canvas` was a deliberate stub before this PR — it just absolute-positioned panels with no pan/zoom. It now lifts spike-4's full `Viewport` / `DragState` / `HitResult` machinery and drives mutations through the selected `Entity<Workspace>`. Drag/resize feels zoom-invariant; corner handles work; click-to-focus routes keyboard input to the right terminal.
- `Spike5App` listens for `Connected` / `SessionsChanged` and reconciles each workspace's Terminal panels with the daemon's session list — spawning a `TerminalModel` + `TerminalView` for every session whose `workspace_id` matches a known workspace, and dropping panels whose session has gone away. Idempotent.
- The demo Notes/Agent placeholder factory is gone; panels now mirror the daemon's session list per workspace.
- `PtyResize` is *not* sent from the canvas. Resizing a panel propagates new `content_size` to the `TerminalView`, which detects the change in its own `render` and emits the resize. One source of truth for PTY geometry, same as in spike-4.

### Coordinate-system fixes (post-merge testing turned these up)
- **Hit-test bounds translation** — spike-4 had no sidebar so window-relative mouse coords already landed in canvas-local space. With a 240px sidebar in spike-5, every panel hit test was off by the sidebar width and clicks fell through to "Canvas → pan." Captured the canvas's window-relative bounds via `gpui::canvas` prepaint into a shared `Rc<Cell<Option<Bounds<Pixels>>>>`; `on_mouse_down` and the zoom focal point now translate `event.position` through that origin.
- **DragState consistency** — first attempt at the above translated coords *into* `DragState.last_screen` while `on_mouse_move` still consumed `event.position` window-relative, producing a sidebar-width jump on the first move after grabbing a panel. Fixed by keeping `last_screen` window-relative (deltas only); only hit-test sees the local translation.

### Dev helper: `scripts/wsctl/main.go`
A short Go script that drives the daemon's WebSocket directly. Until a real native UI lands with workspace + spawn affordances, the canvas spike has no way to *create* the workspaces or workspace-bound sessions it consumes (the Tauri app and CLI never set `workspace_id` on `SpawnSessionMessage`). This fills the gap.

```
go run ./scripts/wsctl list
go run ./scripts/wsctl add-workspace --title T --dir D
go run ./scripts/wsctl rm-workspace  --id WID
go run ./scripts/wsctl add-session   --workspace WID --cwd D [--agent claude]
go run ./scripts/wsctl rm-session    --id SID
```

Two notes from real-world use that drove follow-up fixes:
- Session ids must be UUIDs — the agent CLI (claude) parses the spawn id directly as its own session identifier and rejects anything else (`"Invalid session ID. Must be a valid UUID."`). `add-session` now generates RFC 4122 v4 UUIDs via `crypto/rand`.
- `rm-session` uses `unregister` rather than `kill_session`. `kill_session` only signals the agent process — if the agent already died (e.g. an early UUID-format error caused immediate exit), kill is a no-op and the session record lingers as a ghost, which kept its panel rendered on the canvas. `unregister` both SIGTERMs the process and removes the record, so cleanup is reliable under any state.

## Test plan
- [x] `cargo build --bins` clean across all four binaries
- [x] `attn-spike5` against the dev daemon (port 29849) starts, paints, no panic
- [x] Manual: drag a panel by its title bar; resize from each of the four corners; pan with empty-canvas drag; Cmd+scroll zoom toward cursor
- [x] Manual: click into a terminal body — keyboard input lands in that PTY
- [x] Manual: kill a session via `wsctl rm-session` — its panel disappears from the canvas
- [x] Manual: spawn a second session via `wsctl add-session` — second panel appears alongside the first, both interactive
- [ ] Manual: switch workspaces in the sidebar; canvas swaps cleanly and terminal entities persist (so re-selecting an earlier workspace still shows its sessions)