### PR TITLE
feat: native canvas test automation sidecar + client capability handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-04-28]
+
+### Added
+- **Native Canvas UI Test Automation Sidecar**: The native GPUI canvas app (`attn-spike5`) now exposes a TCP automation sidecar matching the Tauri app's bridge format, so external test scripts can drive both apps with the same client. Actions cover liveness (`ping`), full state inspection (`get_state`), session enumeration (`list_sessions`), window geometry (`get_window_geometry`), workspace selection (`select_workspace`), panel manipulation (`move_panel`), PTY input/inspection (`send_pty_input`, `read_pane_text`), and a structured event tap (`tail_events`) for cursor-based polling of in-process events when behavior needs verification beyond what get_state can show. The sidecar writes a discovery manifest at `~/Library/Application Support/com.attn.native[.<profile>]/debug/ui-automation.json` mirroring the Tauri layout but namespaced per profile. A `make scenario-native-canvas` target runs an end-to-end harness scenario that connects to the live binary and exercises the bridge.
+- **Client Capability Handshake**: New `client_hello` daemon command lets clients identify themselves and advertise capabilities at connection time. The native canvas app sends `shell_as_session` (treats shell agents as first-class workspace sessions); the Tauri app sends an empty capability set and continues to filter shell-as-session panels out of its sidebar. Lets the daemon serve different behaviors per client without making one client's mental model leak into the other. Protocol version bumped 56 → 57, which forces the standard daemon/app version-mismatch reconnect on next install.
+
+### Changed
+- **UI Automation Gating Is Now Runtime, Not Build-Time**: Both the Tauri app and the new native sidecar decide whether to run the automation bridge at startup based on `ATTN_AUTOMATION` (explicit `1`/`0`) and `ATTN_PROFILE` (defaults on for `dev`, off for prod). Previously the Tauri side was gated by `ATTN_UI_AUTOMATION` / `VITE_UI_AUTOMATION` baked in at compile time, which meant every `make install` shipped a build with the bridge always-on. The `make build-app-ui-automation` target is gone; both `make install` and `make dev` now build the same binary and the runtime decides. **Breaking**: anyone relying on automation against a prod source install must now launch with `ATTN_AUTOMATION=1` to enable it. The bridge token has also moved from a predictable pid+nanos string to 32 OS-random bytes hex-encoded.
+
+### Fixed
+- **Automation Server Now Echoes Wire ID On Malformed Requests**: When a request fails JSON deserialization the server now best-effort extracts the raw `id` field (string, number, or bool) and echoes it back on the error response. Previously a malformed request was answered with a synthetic `ui-automation-{counter}` id that no client could correlate, so a multiplexing client looking up its own id would never match the response and the request would hang silently until timeout.
+
+---
+
 ## [2026-04-26]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run build build-linux-amd64 build-linux-arm64 install install-daemon install-dev install-daemon-dev dev test test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app build-app-ui-automation build-app-dev app-screenshot dist release release-skip-tests
+.PHONY: run build build-linux-amd64 build-linux-arm64 install install-daemon install-dev install-daemon-dev dev test test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app build-app-dev app-screenshot scenario-native-canvas dist release release-skip-tests
 
 # Bare `make` does the full prod inner loop: install + open the app.
 # `make install` is install-only (for scripts/CI that drive the launch
@@ -95,7 +95,7 @@ run: install
 	@open $(APP_BUNDLE)
 	@echo "Launched $(APP_BUNDLE)"
 
-install: build-app-ui-automation
+install: build-app
 	@echo ">>> Installing PROD: $(APP_BUNDLE) (profile=default, port=9849)"
 	@mkdir -p ~/Applications
 	@# Quit a running instance first. macOS keeps the running image
@@ -197,26 +197,28 @@ endef
 build-app: build
 	$(call build_tauri_app,VITE_INSTALL_CHANNEL=source VITE_ATTN_BUILD_VERSION='$(VERSION)' VITE_ATTN_SOURCE_FINGERPRINT='$(SOURCE_FINGERPRINT)' VITE_ATTN_GIT_COMMIT='$(GIT_COMMIT)' VITE_ATTN_BUILD_TIME='$(BUILD_TIME)',attn,)
 
-build-app-ui-automation: build
-	$(call build_tauri_app,ATTN_UI_AUTOMATION=1 VITE_UI_AUTOMATION=1 VITE_INSTALL_CHANNEL=source VITE_ATTN_BUILD_VERSION='$(VERSION)' VITE_ATTN_SOURCE_FINGERPRINT='$(SOURCE_FINGERPRINT)' VITE_ATTN_GIT_COMMIT='$(GIT_COMMIT)' VITE_ATTN_BUILD_TIME='$(BUILD_TIME)',attn,)
-
 # Dev build. Bakes ATTN_BUILD_PROFILE=dev into the Rust binary and
 # VITE_ATTN_BUILD_PROFILE=dev + VITE_DAEMON_PORT=29849 into the frontend
 # so the dev bundle can never accidentally point at the prod daemon.
-# UI automation is enabled by default (matching `make install` / the
-# prod install path) so real-app harness scenarios work against the
-# dev bundle too. Set ATTN_DEV_UI_AUTOMATION=0 to disable.
+# UI automation is gated at *runtime* now (see profile::automation_enabled
+# in app/src-tauri/src/profile.rs) — dev builds get it on by default
+# because the runtime sees ATTN_PROFILE=dev; prod builds get it off
+# unless the user sets ATTN_AUTOMATION=1.
 # Output: app/src-tauri/target/release/bundle/macos/attn-dev.app
-ATTN_DEV_UI_AUTOMATION ?= 1
 build-app-dev: build
-ifeq ($(ATTN_DEV_UI_AUTOMATION),1)
-	$(call build_tauri_app,ATTN_UI_AUTOMATION=1 VITE_UI_AUTOMATION=1 ATTN_BUILD_PROFILE=dev VITE_ATTN_BUILD_PROFILE=dev VITE_DAEMON_PORT=29849 VITE_INSTALL_CHANNEL=source VITE_ATTN_BUILD_VERSION='$(VERSION)' VITE_ATTN_SOURCE_FINGERPRINT='$(SOURCE_FINGERPRINT)' VITE_ATTN_GIT_COMMIT='$(GIT_COMMIT)' VITE_ATTN_BUILD_TIME='$(BUILD_TIME)',attn-dev,--config src-tauri/tauri.dev.conf.json)
-else
 	$(call build_tauri_app,ATTN_BUILD_PROFILE=dev VITE_ATTN_BUILD_PROFILE=dev VITE_DAEMON_PORT=29849 VITE_INSTALL_CHANNEL=source VITE_ATTN_BUILD_VERSION='$(VERSION)' VITE_ATTN_SOURCE_FINGERPRINT='$(SOURCE_FINGERPRINT)' VITE_ATTN_GIT_COMMIT='$(GIT_COMMIT)' VITE_ATTN_BUILD_TIME='$(BUILD_TIME)',attn-dev,--config src-tauri/tauri.dev.conf.json)
-endif
 
 app-screenshot:
 	cd app && node scripts/real-app-harness/capture-app-screenshot.mjs $(if $(SCREENSHOT_PATH),--path "$(SCREENSHOT_PATH)",) $(APP_SCREENSHOT_FLAGS)
+
+# End-to-end scenario for the native canvas app driven through its UI
+# automation sidecar. Assumes a native binary is already running with
+# automation enabled — typically:
+#   ATTN_PROFILE=dev ATTN_WS_URL=ws://localhost:29849/ws \
+#     cargo run --manifest-path native-ui/Cargo.toml --bin attn-spike5
+# The script reads ATTN_PROFILE itself to find the matching manifest.
+scenario-native-canvas:
+	cd app && node scripts/real-app-harness/scenario-native-canvas.mjs
 
 # Ad-hoc sign the installed app binary so macOS doesn't SIGKILL it
 # when invoked as a CLI subprocess (e.g. Claude Code hooks)

--- a/app/scripts/real-app-harness/nativeHarnessProfile.mjs
+++ b/app/scripts/real-app-harness/nativeHarnessProfile.mjs
@@ -1,0 +1,60 @@
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Native-app sibling of harnessProfile.mjs. The native GPUI app and the
+ * Tauri app are evolving on different timelines and will diverge — this
+ * file owns the native side so the Tauri helper isn't paramaterized by
+ * an `app` argument that hides their growing differences.
+ *
+ * Profile + automation gating must stay in sync with the Rust copy at
+ *   - native-ui/crates/attn-native-app/src/automation/profile.rs
+ * and the Tauri runtime gate at
+ *   - app/src-tauri/src/profile.rs
+ * and the Go regex at
+ *   - internal/config/config.go (profileNamePattern)
+ */
+
+const BASE_BUNDLE_ID = 'com.attn.native';
+const PROFILE_REGEX = /^[a-z0-9][a-z0-9-]{0,15}$/;
+
+export function currentNativeProfile() {
+  const raw = (process.env.ATTN_PROFILE || '').trim().toLowerCase();
+  if (!raw || raw === 'default') return '';
+  return PROFILE_REGEX.test(raw) ? raw : '';
+}
+
+export function bundleIdentifierForNativeProfile(profile = currentNativeProfile()) {
+  return profile ? `${BASE_BUNDLE_ID}.${profile}` : BASE_BUNDLE_ID;
+}
+
+export function manifestPathForNativeProfile(profile = currentNativeProfile()) {
+  return path.join(
+    os.homedir(),
+    'Library',
+    'Application Support',
+    bundleIdentifierForNativeProfile(profile),
+    'debug',
+    'ui-automation.json',
+  );
+}
+
+/**
+ * Mirror of the Rust `automation_enabled()` rule. Used by harness scripts
+ * that need to predict whether the app under test will have automation on
+ * (e.g. before launching, to fail fast with a clear message).
+ *
+ * Rule:
+ *   ATTN_AUTOMATION=1 → on
+ *   ATTN_AUTOMATION=0 → off
+ *   ATTN_PROFILE=dev  → on  (default for dev)
+ *   else              → off
+ */
+export function automationEnabledForNativeProfile() {
+  const automation = (process.env.ATTN_AUTOMATION || '').trim();
+  if (automation === '1') return true;
+  if (automation === '0') return false;
+  // Any other non-empty value → strict off (typo-safety, mirrors Rust).
+  if (automation !== '') return false;
+  return currentNativeProfile() === 'dev';
+}

--- a/app/scripts/real-app-harness/scenario-native-canvas.mjs
+++ b/app/scripts/real-app-harness/scenario-native-canvas.mjs
@@ -1,0 +1,568 @@
+#!/usr/bin/env node
+/**
+ * Behavioral scenario for the native canvas app driven through its UI
+ * automation sidecar. Assumes the native binary is already running with
+ * automation enabled (e.g. `ATTN_PROFILE=dev cargo run --bin attn-spike5`).
+ *
+ * Coverage:
+ *   - wire plumbing: manifest discovery, ping, token rejection, unknown
+ *     actions, get_state shape, list_sessions consistency, window geom
+ *   - mutate spatial state: move_panel + assert post-state
+ *   - mutate selection: select_workspace happy path + bogus id error
+ *   - end-to-end PTY: spawn an `agent=shell` session via the daemon WS,
+ *     wait for it to attach as a canvas panel, send `echo HELLO-<uuid>`,
+ *     poll read_pane_text until the marker appears, unregister the
+ *     session, confirm cleanup
+ *
+ * Tearing down: every resource the scenario creates is unregistered in
+ * `finally` blocks, even on assertion failure.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import net from 'node:net';
+import process from 'node:process';
+import WebSocket from 'ws';
+import {
+  automationEnabledForNativeProfile,
+  bundleIdentifierForNativeProfile,
+  currentNativeProfile,
+  manifestPathForNativeProfile,
+} from './nativeHarnessProfile.mjs';
+
+const PROFILE = currentNativeProfile() || 'default';
+const MANIFEST_PATH = manifestPathForNativeProfile();
+const BUNDLE_ID = bundleIdentifierForNativeProfile();
+const DAEMON_WS_URL =
+  process.env.ATTN_WS_URL ||
+  (PROFILE === 'dev' ? 'ws://localhost:29849/ws' : 'ws://localhost:9849/ws');
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+  process.exit(1);
+}
+
+function info(message) {
+  console.log(message);
+}
+
+function readManifest() {
+  let body;
+  try {
+    body = fs.readFileSync(MANIFEST_PATH, 'utf8');
+  } catch (error) {
+    fail(
+      `manifest not found at ${MANIFEST_PATH} — is the native app running with automation? ` +
+        `Try: ATTN_PROFILE=${PROFILE === 'default' ? 'dev' : PROFILE} cargo run --bin attn-spike5\n` +
+        `(${error.message})`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch (error) {
+    fail(`manifest is not valid JSON: ${error.message}`);
+  }
+  if (!parsed.enabled) fail(`manifest reports enabled=false`);
+  if (typeof parsed.port !== 'number') fail(`manifest.port is not a number: ${parsed.port}`);
+  if (typeof parsed.token !== 'string' || parsed.token.length < 32) {
+    fail(`manifest.token looks wrong (length=${parsed.token?.length})`);
+  }
+  return parsed;
+}
+
+class NativeAutomationConnection {
+  constructor(port, token) {
+    this.port = port;
+    this.token = token;
+    this.socket = null;
+    this.buffer = '';
+    this.pending = []; // [{ resolve, reject }] in FIFO order
+    this.nextId = 1;
+  }
+
+  async connect() {
+    await new Promise((resolve, reject) => {
+      this.socket = net.createConnection({ host: '127.0.0.1', port: this.port }, resolve);
+      this.socket.once('error', reject);
+    });
+    this.socket.setEncoding('utf8');
+    this.socket.on('data', (chunk) => this.onData(chunk));
+    this.socket.on('error', (error) => {
+      const reject = this.pending.shift()?.reject;
+      if (reject) reject(error);
+    });
+    this.socket.on('close', () => {
+      while (this.pending.length > 0) {
+        this.pending.shift().reject(new Error('socket closed'));
+      }
+    });
+  }
+
+  onData(chunk) {
+    this.buffer += chunk;
+    let nl;
+    while ((nl = this.buffer.indexOf('\n')) >= 0) {
+      const line = this.buffer.slice(0, nl).trim();
+      this.buffer = this.buffer.slice(nl + 1);
+      if (!line) continue;
+      const next = this.pending.shift();
+      if (!next) continue;
+      try {
+        next.resolve(JSON.parse(line));
+      } catch (error) {
+        next.reject(new Error(`response is not valid JSON: ${error.message}`));
+      }
+    }
+  }
+
+  async request(action, payload = null) {
+    const id = `scenario-${this.nextId++}`;
+    const body = JSON.stringify({ id, token: this.token, action, payload });
+    return new Promise((resolve, reject) => {
+      this.pending.push({ resolve, reject });
+      this.socket.write(`${body}\n`, 'utf8', (error) => {
+        if (error) reject(error);
+      });
+    });
+  }
+
+  close() {
+    if (this.socket) this.socket.end();
+  }
+}
+
+/**
+ * Tiny daemon WS client for spawn_session / unregister. Kept minimal —
+ * uses raw JSON commands matching what wsctl (Go dev helper) sends.
+ */
+class DaemonWSClient {
+  constructor(url) {
+    this.url = url;
+    this.ws = null;
+    this.eventHandlers = new Set();
+    this.opened = false;
+  }
+
+  async connect() {
+    this.ws = new WebSocket(this.url);
+    await new Promise((resolve, reject) => {
+      this.ws.once('open', () => {
+        this.opened = true;
+        resolve();
+      });
+      this.ws.once('error', reject);
+    });
+    this.ws.on('message', (data) => {
+      let event;
+      try {
+        event = JSON.parse(data.toString());
+      } catch {
+        return;
+      }
+      for (const handler of this.eventHandlers) handler(event);
+    });
+    // Identify as a canvas-style client so the daemon registers shell
+    // sessions we spawn — same hello the native app sends.
+    this.ws.send(JSON.stringify({
+      cmd: 'client_hello',
+      client_kind: 'native-canvas-harness',
+      version: 'scenario-native-canvas',
+      capabilities: ['shell_as_session'],
+    }));
+  }
+
+  onEvent(handler) {
+    this.eventHandlers.add(handler);
+    return () => this.eventHandlers.delete(handler);
+  }
+
+  send(payload) {
+    return new Promise((resolve, reject) => {
+      this.ws.send(JSON.stringify(payload), (error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+
+  async spawnShellSession({ workspaceId, cwd, cols = 80, rows = 24 }) {
+    const id = crypto.randomUUID();
+    const result = new Promise((resolveResult, rejectResult) => {
+      const off = this.onEvent((event) => {
+        if (event.event === 'spawn_result' && event.id === id) {
+          off();
+          if (event.success) resolveResult(id);
+          else rejectResult(new Error(`spawn rejected: ${event.error || 'unknown'}`));
+        }
+      });
+      setTimeout(() => {
+        off();
+        rejectResult(new Error(`spawn_session timed out for ${id}`));
+      }, 5000);
+    });
+    await this.send({
+      cmd: 'spawn_session',
+      id,
+      cwd,
+      workspace_id: workspaceId,
+      agent: 'shell',
+      label: 'scenario-shell',
+      cols,
+      rows,
+    });
+    return result;
+  }
+
+  async unregisterSession(id) {
+    await this.send({ cmd: 'unregister', id });
+  }
+
+  close() {
+    if (this.opened) this.ws.close();
+  }
+}
+
+async function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function pollUntil(predicate, { timeoutMs = 5000, intervalMs = 100, label = 'condition' }) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const value = await predicate();
+      if (value) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(intervalMs);
+  }
+  // Throw rather than process.exit so callers can dump diagnostics
+  // (event tail, last get_state) before the scenario fails.
+  throw new Error(
+    `timed out waiting for ${label}${lastError ? ` (last error: ${lastError.message})` : ''}`,
+  );
+}
+
+/**
+ * Pull the event ring buffer from the native app since `cursor`. Returns
+ * `{ events, next_cursor }`. The cursor is monotonic across the process,
+ * so callers can capture it before an action and replay everything that
+ * happened during it.
+ */
+async function tailEvents(conn, cursor = 0) {
+  const r = await conn.request('tail_events', { since_id: cursor });
+  if (!r.ok) throw new Error(`tail_events failed: ${r.error}`);
+  return r.result;
+}
+
+function formatEvent(e) {
+  return `  +${String(e.id).padStart(5)} ${e.category.padEnd(34)} ${JSON.stringify(e.payload)}`;
+}
+
+async function dumpEventsSince(conn, cursor, label) {
+  try {
+    const tail = await tailEvents(conn, cursor);
+    console.error(`\n--- events since ${label} (cursor=${cursor}) ---`);
+    for (const ev of tail.events) console.error(formatEvent(ev));
+    console.error(`--- end (${tail.events.length} events, next_cursor=${tail.next_cursor}) ---\n`);
+  } catch (error) {
+    console.error(`(failed to fetch events for diagnosis: ${error.message})`);
+  }
+}
+
+function pickFirst(state, key) {
+  const arr = state.result?.[key];
+  if (!Array.isArray(arr) || arr.length === 0) return null;
+  return arr[0];
+}
+
+async function checkPlumbing(conn, manifest) {
+  const pong = await conn.request('ping');
+  if (!pong.ok || pong.result?.pong !== true) fail(`ping failed: ${JSON.stringify(pong)}`);
+  if (pong.result.pid !== manifest.pid) {
+    fail(`pid mismatch: manifest=${manifest.pid} ping=${pong.result.pid}`);
+  }
+  info(`  ping ok (pid=${pong.result.pid})`);
+
+  const badConn = new NativeAutomationConnection(manifest.port, 'wrongtoken');
+  await badConn.connect();
+  const rejected = await badConn.request('ping');
+  if (rejected.ok || rejected.error !== 'invalid token') {
+    fail(`expected token rejection, got: ${JSON.stringify(rejected)}`);
+  }
+  badConn.close();
+  info(`  token enforcement ok`);
+
+  const unknown = await conn.request('definitely-not-an-action');
+  if (unknown.ok || !unknown.error?.includes('unknown action')) {
+    fail(`unknown-action handling: ${JSON.stringify(unknown)}`);
+  }
+  info(`  unknown-action error ok`);
+
+  const geom = await conn.request('get_window_geometry');
+  if (!geom.ok) fail(`get_window_geometry: ${geom.error}`);
+  const b = geom.result.globalBounds;
+  if (!(b.width > 0 && b.height > 0)) fail(`window geom looks wrong: ${JSON.stringify(b)}`);
+  info(`  window geometry ok (${b.width}x${b.height} @ scale=${geom.result.scaleFactor})`);
+
+  const state = await conn.request('get_state');
+  if (!state.ok) fail(`get_state: ${state.error}`);
+  for (const field of ['workspaces', 'sessions', 'canvas', 'daemon', 'selected_workspace_id']) {
+    if (!(field in state.result)) fail(`get_state missing field: ${field}`);
+  }
+  const list = await conn.request('list_sessions');
+  if (!list.ok) fail(`list_sessions: ${list.error}`);
+  if (list.result.length !== state.result.sessions.length) {
+    fail(`list_sessions/get_state.sessions length mismatch`);
+  }
+  info(
+    `  state shape ok (workspaces=${state.result.workspaces.length} sessions=${state.result.sessions.length})`,
+  );
+
+  // tail_events sanity: shape is right and cursor advances. Other tests
+  // depend on this primitive, so a separate plumbing-only check makes
+  // failures easier to diagnose.
+  const tail0 = await tailEvents(conn);
+  if (!Array.isArray(tail0.events) || typeof tail0.next_cursor !== 'number') {
+    fail(`tail_events shape wrong: ${JSON.stringify(tail0)}`);
+  }
+  // Re-tail past the cursor: should be empty unless something just fired.
+  const tail1 = await tailEvents(conn, tail0.next_cursor);
+  if (tail1.next_cursor < tail0.next_cursor) {
+    fail(`tail_events cursor regressed: ${tail1.next_cursor} < ${tail0.next_cursor}`);
+  }
+  info(`  tail_events ok (${tail0.events.length} historic events, cursor=${tail0.next_cursor})`);
+}
+
+async function checkMovePanel(conn) {
+  const state = await conn.request('get_state');
+  if (!state.ok) fail(`get_state: ${state.error}`);
+  const ws = pickFirst(state, 'workspaces');
+  if (!ws) {
+    info(`  skipped — no workspaces in environment`);
+    return;
+  }
+  const panel = ws.panels?.[0];
+  if (!panel) {
+    info(`  skipped — workspace has no panels`);
+    return;
+  }
+
+  const targetX = panel.world_x + 137; // arbitrary, distinguishable
+  const targetY = panel.world_y + 31;
+  const move = await conn.request('move_panel', {
+    workspace_id: ws.id,
+    panel_id: panel.id,
+    world_x: targetX,
+    world_y: targetY,
+  });
+  if (!move.ok) fail(`move_panel: ${move.error}`);
+  if (Math.abs(move.result.panel.world_x - targetX) > 0.001) {
+    fail(`move_panel returned wrong world_x: ${move.result.panel.world_x} vs ${targetX}`);
+  }
+
+  // Cross-verify via get_state — proves the mutation actually landed in
+  // the entity, not just the action's response shape.
+  const after = await conn.request('get_state');
+  const wsAfter = after.result.workspaces.find((w) => w.id === ws.id);
+  const panelAfter = wsAfter.panels.find((p) => p.id === panel.id);
+  if (Math.abs(panelAfter.world_x - targetX) > 0.001) {
+    fail(`get_state didn't reflect move: world_x=${panelAfter.world_x} expected ${targetX}`);
+  }
+  info(`  ok (panel ${panel.id}: x ${panel.world_x.toFixed(1)} → ${targetX.toFixed(1)})`);
+
+  // Move it back so re-runs are idempotent. Best-effort.
+  await conn.request('move_panel', {
+    workspace_id: ws.id,
+    panel_id: panel.id,
+    world_x: panel.world_x,
+    world_y: panel.world_y,
+  });
+}
+
+async function checkSelectWorkspace(conn) {
+  const state = await conn.request('get_state');
+  const workspaces = state.result.workspaces || [];
+  if (workspaces.length === 0) {
+    info(`  skipped — no workspaces`);
+    return;
+  }
+
+  // Bogus id should error.
+  const bogus = await conn.request('select_workspace', { id: 'definitely-not-a-real-id' });
+  if (bogus.ok) fail(`select_workspace accepted bogus id: ${JSON.stringify(bogus)}`);
+  if (!bogus.error?.includes('unknown workspace')) {
+    fail(`select_workspace bogus id error wrong: ${bogus.error}`);
+  }
+
+  if (workspaces.length === 1) {
+    // Re-select current — proves the wire works even without a real
+    // flip target. The full switch behavior is exercised any time
+    // there's >1 workspace in the environment.
+    const current = state.result.selected_workspace_id || workspaces[0].id;
+    const same = await conn.request('select_workspace', { id: current });
+    if (!same.ok) fail(`select_workspace (same id): ${same.error}`);
+    info(`  ok (single-ws env: re-select + bogus id rejected)`);
+    return;
+  }
+
+  // Real switch: pick a non-current workspace, switch, assert.
+  const current = state.result.selected_workspace_id || workspaces[0].id;
+  const target = workspaces.find((w) => w.id !== current);
+  const switched = await conn.request('select_workspace', { id: target.id });
+  if (!switched.ok) fail(`select_workspace: ${switched.error}`);
+  if (switched.result.selected_workspace_id !== target.id) {
+    fail(`select_workspace returned wrong id: ${switched.result.selected_workspace_id}`);
+  }
+  const after = await conn.request('get_state');
+  if (after.result.selected_workspace_id !== target.id) {
+    fail(`selection didn't flip in get_state: ${after.result.selected_workspace_id}`);
+  }
+  info(`  ok (flipped ${current} → ${target.id})`);
+
+  // Restore.
+  await conn.request('select_workspace', { id: current });
+}
+
+async function checkPtyRoundTrip(conn, daemon) {
+  const state = await conn.request('get_state');
+  const ws = pickFirst(state, 'workspaces');
+  if (!ws) {
+    info(`  skipped — no workspaces to host a shell`);
+    return;
+  }
+  const cwd = ws.directory || process.env.HOME || '/tmp';
+  const marker = `MARK-${crypto.randomUUID().slice(0, 8)}`;
+
+  // Capture the event cursor BEFORE spawning so we can prove (or refute)
+  // that every step of the chain — daemon broadcast, app receipt, panel
+  // creation, attach result — happened during this scenario.
+  const cursorBefore = (await tailEvents(conn)).next_cursor;
+
+  const sessionId = await daemon.spawnShellSession({ workspaceId: ws.id, cwd });
+  info(`  spawned shell session ${sessionId.slice(0, 8)}… (cursor=${cursorBefore})`);
+  try {
+    // Wait for the `panel_added` event with our session_id. Events let
+    // us assert on the actual UI transition rather than poll-until-state-
+    // converges; on failure we'll dump every event since spawn so we can
+    // see exactly where the chain stopped (daemon broadcast?
+    // Spike5App SessionsChanged? sync_terminal_panels?).
+    try {
+      await pollUntil(
+        async () => {
+          const tail = await tailEvents(conn, cursorBefore);
+          return tail.events.find(
+            (e) => e.category === 'panel_added' && e.payload.session_id === sessionId,
+          );
+        },
+        {
+          timeoutMs: 15000,
+          intervalMs: 200,
+          label: `panel_added event for ${sessionId.slice(0, 8)}`,
+        },
+      );
+    } catch (error) {
+      await dumpEventsSince(conn, cursorBefore, 'spawn');
+      throw error;
+    }
+    info(`  panel attached`);
+
+    // Capture another cursor so the type-and-echo step gets its own
+    // diagnostic window if it fails.
+    const cursorBeforeType = (await tailEvents(conn)).next_cursor;
+
+    // Type the marker. Newline triggers the shell to execute echo, so
+    // the marker shows up on the screen via shell echo.
+    const sent = await conn.request('send_pty_input', {
+      session_id: sessionId,
+      text: `echo ${marker}\n`,
+    });
+    if (!sent.ok) fail(`send_pty_input: ${sent.error}`);
+
+    // Poll read_pane_text until the marker is present somewhere.
+    try {
+      await pollUntil(
+        async () => {
+          const r = await conn.request('read_pane_text', { session_id: sessionId });
+          if (!r.ok) return false;
+          return r.result.text.includes(marker);
+        },
+        { timeoutMs: 5000, label: `marker ${marker} on screen` },
+      );
+    } catch (error) {
+      await dumpEventsSince(conn, cursorBeforeType, 'send_pty_input');
+      // Also dump the current screen text — the most likely failure mode
+      // is "input arrived but the shell hasn't echoed it back yet".
+      try {
+        const pane = await conn.request('read_pane_text', { session_id: sessionId });
+        if (pane.ok) {
+          console.error(`current screen rows:`);
+          for (const row of pane.result.rows.slice(-10)) {
+            console.error(`  ${JSON.stringify(row)}`);
+          }
+        }
+      } catch (_) {}
+      throw error;
+    }
+    info(`  ok (typed and echoed ${marker})`);
+  } finally {
+    await daemon.unregisterSession(sessionId).catch(() => {});
+    try {
+      await pollUntil(
+        async () => {
+          const s = await conn.request('get_state');
+          const w = s.result.workspaces.find((x) => x.id === ws.id);
+          return !w?.panels?.some((p) => p.session_id === sessionId);
+        },
+        { timeoutMs: 3000, intervalMs: 200, label: 'panel removal after unregister' },
+      );
+      info(`  cleanup ok (panel + session removed)`);
+    } catch (cleanupError) {
+      console.error(`WARNING: ${cleanupError.message}`);
+    }
+  }
+}
+
+async function main() {
+  info(`profile=${PROFILE} bundle=${BUNDLE_ID}`);
+  info(`automationEnabledForProfile=${automationEnabledForNativeProfile()}`);
+  info(`manifest=${MANIFEST_PATH}`);
+  info(`daemon=${DAEMON_WS_URL}`);
+
+  const manifest = readManifest();
+  info(`manifest ok: port=${manifest.port} pid=${manifest.pid}`);
+
+  const conn = new NativeAutomationConnection(manifest.port, manifest.token);
+  await conn.connect();
+  info(`connected to 127.0.0.1:${manifest.port}`);
+
+  const daemon = new DaemonWSClient(DAEMON_WS_URL);
+  await daemon.connect();
+  info(`connected to daemon ws`);
+
+  try {
+    info(`\n[wire plumbing]`);
+    await checkPlumbing(conn, manifest);
+
+    info(`\n[move_panel]`);
+    await checkMovePanel(conn);
+
+    info(`\n[select_workspace]`);
+    await checkSelectWorkspace(conn);
+
+    info(`\n[pty round-trip]`);
+    await checkPtyRoundTrip(conn, daemon);
+
+    info(`\nPASS`);
+  } finally {
+    conn.close();
+    daemon.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "dirs 5.0.1",
+ "getrandom 0.2.17",
  "libc",
  "regex",
  "serde",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ dirs = "5"
 regex = "1"
 libc = "0.2"
 base64 = "0.22"
+getrandom = "0.2"
 
 [dev-dependencies]
 anyhow = "1"

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -715,7 +715,18 @@ pub fn run() {
             .output();
     }
 
+    // Webview-side gate for the UI automation bridge. Injected as an
+    // initialization script so React's `useUiAutomationBridge` sees it
+    // synchronously on first render — no Tauri command roundtrip, no
+    // race with `useEffect`. Reads the same runtime decision as the
+    // Rust-side server so both halves of the bridge agree.
+    let automation_init_script = format!(
+        "window.__ATTN_AUTOMATION_ENABLED = {};",
+        profile::automation_enabled()
+    );
+
     tauri::Builder::default()
+        .append_invoke_initialization_script(automation_init_script)
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())

--- a/app/src-tauri/src/profile.rs
+++ b/app/src-tauri/src/profile.rs
@@ -99,7 +99,11 @@ fn decide_automation_enabled(automation: Option<&str>, profile: Option<&str>) ->
         // automation in CI.
         Some(_) => return false,
     }
-    profile.map(str::trim).map(|p| p.to_ascii_lowercase()).as_deref() == Some("dev")
+    profile
+        .map(str::trim)
+        .map(|p| p.to_ascii_lowercase())
+        .as_deref()
+        == Some("dev")
 }
 
 #[cfg(test)]

--- a/app/src-tauri/src/profile.rs
+++ b/app/src-tauri/src/profile.rs
@@ -70,3 +70,58 @@ pub fn bundle_identifier() -> &'static str {
         _ => "com.attn.manager",
     }
 }
+
+/// Decide whether the UI automation bridge should run this launch. Single
+/// rule shared with the native canvas app — keep it in sync with
+/// `native-ui/crates/attn-native-app/src/automation/profile.rs` and
+/// `app/scripts/real-app-harness/nativeHarnessProfile.mjs`.
+///
+///   - `ATTN_AUTOMATION=1`  → on
+///   - `ATTN_AUTOMATION=0`  → off
+///   - `ATTN_PROFILE=dev`   → on   (default for dev)
+///   - otherwise            → off  (default for prod / unset)
+///
+/// `apply_build_profile_env` must run first so a dev build that didn't
+/// inherit `ATTN_PROFILE=dev` from its parent process still sees the
+/// right profile name when this is consulted.
+pub fn automation_enabled() -> bool {
+    let automation = env::var("ATTN_AUTOMATION").ok();
+    let profile = env::var("ATTN_PROFILE").ok();
+    decide_automation_enabled(automation.as_deref(), profile.as_deref())
+}
+
+fn decide_automation_enabled(automation: Option<&str>, profile: Option<&str>) -> bool {
+    match automation.map(str::trim) {
+        Some("1") => return true,
+        Some("0") => return false,
+        Some("") | None => {}
+        // Strict-off on any other value so typos don't silently disable
+        // automation in CI.
+        Some(_) => return false,
+    }
+    profile.map(str::trim).map(|p| p.to_ascii_lowercase()).as_deref() == Some("dev")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn automation_decision_rules() {
+        assert!(decide_automation_enabled(Some("1"), None));
+        assert!(decide_automation_enabled(Some("1"), Some("dev")));
+        assert!(!decide_automation_enabled(Some("0"), None));
+        assert!(!decide_automation_enabled(Some("0"), Some("dev")));
+        assert!(!decide_automation_enabled(Some("yes"), Some("dev")));
+        assert!(decide_automation_enabled(None, Some("dev")));
+        assert!(!decide_automation_enabled(None, Some("ci")));
+        assert!(!decide_automation_enabled(None, None));
+        assert!(decide_automation_enabled(Some(""), Some("dev")));
+        assert!(decide_automation_enabled(Some("  "), Some("dev")));
+        assert!(!decide_automation_enabled(Some("  "), None));
+        // Profile case-insensitive (Go side accepts only lowercase but
+        // mixed case here would mean the parent env wasn't normalized;
+        // handle defensively).
+        assert!(decide_automation_enabled(None, Some("DEV")));
+    }
+}

--- a/app/src-tauri/src/ui_automation.rs
+++ b/app/src-tauri/src/ui_automation.rs
@@ -12,7 +12,7 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Listener, LogicalPosition, LogicalSize, Manager, Runtime};
 
-pub const UI_AUTOMATION_ENABLED: bool = option_env!("ATTN_UI_AUTOMATION").is_some();
+use crate::profile;
 
 const REQUEST_EVENT: &str = "attn://ui-automation/request";
 const RESPONSE_EVENT: &str = "attn://ui-automation/response";
@@ -107,11 +107,26 @@ struct BridgeResponse {
 }
 
 fn generate_token() -> String {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    format!("{:x}{:x}", std::process::id(), now)
+    // 32 random bytes from the OS RNG, hex-encoded. The previous
+    // pid+nanos scheme was predictable enough that anyone on the box
+    // could guess it and drive the bridge — local-only sockets soften
+    // the threat model, but the cost of doing this right is one dep.
+    let mut buf = [0u8; 32];
+    getrandom::getrandom(&mut buf).expect("OS RNG must be available");
+    let mut hex = String::with_capacity(buf.len() * 2);
+    for byte in buf {
+        hex.push(nibble(byte >> 4));
+        hex.push(nibble(byte & 0x0f));
+    }
+    hex
+}
+
+fn nibble(n: u8) -> char {
+    match n {
+        0..=9 => (b'0' + n) as char,
+        10..=15 => (b'a' + n - 10) as char,
+        _ => unreachable!(),
+    }
 }
 
 fn manifest_path<R: Runtime>(app: &AppHandle<R>) -> Option<PathBuf> {
@@ -558,7 +573,7 @@ fn serve_connection<R: Runtime>(
 }
 
 pub fn maybe_start<R: Runtime>(app: &AppHandle<R>) {
-    if !UI_AUTOMATION_ENABLED {
+    if !profile::automation_enabled() {
         return;
     }
 
@@ -596,10 +611,9 @@ pub fn maybe_start<R: Runtime>(app: &AppHandle<R>) {
     append_log(
         app,
         &format!(
-            "server start pid={} port={} enabled={}",
+            "server start pid={} port={} enabled=true",
             std::process::id(),
             port,
-            UI_AUTOMATION_ENABLED
         ),
     );
 

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -344,7 +344,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '56',
+        protocol_version: '57',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -420,7 +420,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '56',
+        protocol_version: '57',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -499,7 +499,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '56',
+        protocol_version: '57',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -592,7 +592,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '56',
+        protocol_version: '57',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -689,7 +689,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '56',
+        protocol_version: '57',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -772,7 +772,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '56',
+        protocol_version: '57',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -881,7 +881,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '56',
+        protocol_version: '57',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -939,7 +939,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '56',
+        protocol_version: '57',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -141,9 +141,15 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '56';
+const PROTOCOL_VERSION = '57';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
-const INCLUDE_ATTACH_REPLAY_DEBUG_PAYLOAD = import.meta.env.VITE_UI_AUTOMATION === '1';
+// Runtime gate (flipped from VITE_UI_AUTOMATION). The Rust shell
+// injects this global before any page script runs — see
+// `automation_init_script` in `app/src-tauri/src/lib.rs`. Falsy in
+// non-Tauri environments and prod builds without ATTN_AUTOMATION=1.
+const INCLUDE_ATTACH_REPLAY_DEBUG_PAYLOAD =
+  typeof window !== 'undefined' &&
+  (window as { __ATTN_AUTOMATION_ENABLED?: boolean }).__ATTN_AUTOMATION_ENABLED === true;
 
 interface PRActionResult {
   success: boolean;
@@ -383,10 +389,22 @@ interface UseDaemonSocketOptions {
   wsUrl?: string;
 }
 
+/**
+ * Sessions the Tauri sidebar should ignore. Shell-agent sessions exist
+ * on the wire because the native canvas app declares the
+ * `shell_as_session` capability, but in the Tauri app shells are utility
+ * terminals (Cmd+T), never sidebar entries. Filtering here keeps the
+ * Tauri app's behavior identical regardless of who else is connected.
+ */
+function isHiddenSidebarSession(session: DaemonSession): boolean {
+  return session.agent === 'shell';
+}
+
 function dedupeSessionsByID(sessions: DaemonSession[]): DaemonSession[] {
   const deduped: DaemonSession[] = [];
   const indexByID = new Map<string, number>();
   for (const session of sessions) {
+    if (isHiddenSidebarSession(session)) continue;
     const existingIndex = indexByID.get(session.id);
     if (existingIndex === undefined) {
       indexByID.set(session.id, deduped.length);
@@ -399,6 +417,7 @@ function dedupeSessionsByID(sessions: DaemonSession[]): DaemonSession[] {
 }
 
 function upsertSessionByID(sessions: DaemonSession[], session: DaemonSession): DaemonSession[] {
+  if (isHiddenSidebarSession(session)) return sessions;
   const index = sessions.findIndex((entry) => entry.id === session.id);
   if (index === -1) {
     return [...sessions, session];
@@ -865,6 +884,20 @@ export function useDaemonSocket({
         clearTimeout(circuitResetTimeoutRef.current);
         circuitResetTimeoutRef.current = null;
       }
+
+      // Identify ourselves first thing. The Tauri app declares no
+      // capabilities — it relies on the daemon's legacy defaults
+      // (shell PTYs from spawn_session are utility terminals, not
+      // sessions). Sending hello at all is still useful for daemon-side
+      // diagnostics (client kind/version in logs).
+      ws.send(
+        JSON.stringify({
+          cmd: 'client_hello',
+          client_kind: 'tauri-app',
+          version: `protocol-${PROTOCOL_VERSION}`,
+          capabilities: [],
+        }),
+      );
 
       if (gitStatusSubscriptionRef.current) {
         ws.send(JSON.stringify({ cmd: 'subscribe_git_status', directory: gitStatusSubscriptionRef.current }));

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1939,7 +1939,14 @@ export function useUiAutomationBridge({
   handleAutomationRequestRef.current = handleAutomationRequest;
 
   useEffect(() => {
-    if (!isTauri() || import.meta.env.VITE_UI_AUTOMATION !== '1') {
+    // Gate flipped from compile-time `VITE_UI_AUTOMATION` to a runtime
+    // global injected by the Rust shell (`append_invoke_initialization_script`).
+    // The Rust-side decision lives in `app/src-tauri/src/profile.rs::automation_enabled`
+    // and applies the same rule as the native canvas app: explicit
+    // ATTN_AUTOMATION wins, otherwise dev profile defaults on.
+    const automationEnabled =
+      typeof window !== 'undefined' && (window as { __ATTN_AUTOMATION_ENABLED?: boolean }).__ATTN_AUTOMATION_ENABLED === true;
+    if (!isTauri() || !automationEnabled) {
       return;
     }
 

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MuteMessage, MutePRMessage, MuteRepoMessage, PathInspection, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionAgent, SessionExitedMessage, SessionLayout, SessionLayoutActionResultMessage, SessionLayoutClosePaneMessage, SessionLayoutFocusPaneMessage, SessionLayoutGetMessage, SessionLayoutMessage, SessionLayoutPane, SessionLayoutPaneKind, SessionLayoutRenamePaneMessage, SessionLayoutRuntimeExitedMessage, SessionLayoutSplitDirection, SessionLayoutSplitPaneMessage, SessionLayoutUpdatedMessage, SessionRegisteredMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetEndpointRemoteWebMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MuteMessage, MutePRMessage, MuteRepoMessage, PathInspection, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionAgent, SessionExitedMessage, SessionLayout, SessionLayoutActionResultMessage, SessionLayoutClosePaneMessage, SessionLayoutFocusPaneMessage, SessionLayoutGetMessage, SessionLayoutMessage, SessionLayoutPane, SessionLayoutPaneKind, SessionLayoutRenamePaneMessage, SessionLayoutRuntimeExitedMessage, SessionLayoutSplitDirection, SessionLayoutSplitPaneMessage, SessionLayoutUpdatedMessage, SessionRegisteredMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetEndpointRemoteWebMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -22,6 +22,7 @@
 //   const browseDirectoryResultMessage = Convert.toBrowseDirectoryResultMessage(json);
 //   const clearSessionsMessage = Convert.toClearSessionsMessage(json);
 //   const clearWarningsMessage = Convert.toClearWarningsMessage(json);
+//   const clientHelloMessage = Convert.toClientHelloMessage(json);
 //   const collapseRepoMessage = Convert.toCollapseRepoMessage(json);
 //   const commandErrorMessage = Convert.toCommandErrorMessage(json);
 //   const createWorktreeFromBranchMessage = Convert.toCreateWorktreeFromBranchMessage(json);
@@ -499,6 +500,18 @@ export interface ClearWarningsMessage {
 
 export enum ClearWarningsMessageCmd {
     ClearWarnings = "clear_warnings",
+}
+
+export interface ClientHelloMessage {
+    capabilities: string[];
+    client_kind:  string;
+    cmd:          ClientHelloMessageCmd;
+    version:      string;
+    [property: string]: any;
+}
+
+export enum ClientHelloMessageCmd {
+    ClientHello = "client_hello",
 }
 
 export interface CollapseRepoMessage {
@@ -2651,6 +2664,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("ClearWarningsMessage")), null, 2);
     }
 
+    public static toClientHelloMessage(json: string): ClientHelloMessage {
+        return cast(JSON.parse(json), r("ClientHelloMessage"));
+    }
+
+    public static clientHelloMessageToJson(value: ClientHelloMessage): string {
+        return JSON.stringify(uncast(value, r("ClientHelloMessage")), null, 2);
+    }
+
     public static toCollapseRepoMessage(json: string): CollapseRepoMessage {
         return cast(JSON.parse(json), r("CollapseRepoMessage"));
     }
@@ -4227,6 +4248,12 @@ const typeMap: any = {
     "ClearWarningsMessage": o([
         { json: "cmd", js: "cmd", typ: r("ClearWarningsMessageCmd") },
     ], "any"),
+    "ClientHelloMessage": o([
+        { json: "capabilities", js: "capabilities", typ: a("") },
+        { json: "client_kind", js: "client_kind", typ: "" },
+        { json: "cmd", js: "cmd", typ: r("ClientHelloMessageCmd") },
+        { json: "version", js: "version", typ: "" },
+    ], "any"),
     "CollapseRepoMessage": o([
         { json: "cmd", js: "cmd", typ: r("CollapseRepoMessageCmd") },
         { json: "collapsed", js: "collapsed", typ: true },
@@ -5417,6 +5444,9 @@ const typeMap: any = {
     ],
     "ClearWarningsMessageCmd": [
         "clear_warnings",
+    ],
+    "ClientHelloMessageCmd": [
+        "client_hello",
     ],
     "CollapseRepoMessageCmd": [
         "collapse_repo",

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -384,6 +384,7 @@ export enum SessionAgent {
     Codex = "codex",
     Copilot = "copilot",
     Pi = "pi",
+    Shell = "shell",
 }
 
 export enum SessionState {
@@ -5418,6 +5419,7 @@ const typeMap: any = {
         "codex",
         "copilot",
         "pi",
+        "shell",
     ],
     "SessionState": [
         "idle",

--- a/docs/plans/native-gpui-canvas-ui.md
+++ b/docs/plans/native-gpui-canvas-ui.md
@@ -4,8 +4,8 @@
 
 Spike plan. Prototypes to prove feasibility before building the real client.
 
-**Completed:** Spikes 1, 2, 3, 4 (`attn-native`, `attn-native`, `attn-canvas`, `attn-spike4`)
-**Next:** Spike 5 (Workspace Entity Model + Sidebar) — prerequisite: SessionLayout rename commit first
+**Completed:** Spikes 1, 2, 3, 4, 5 + canvas convergence + Spike 6 (UI Test Automation Sidecar)
+**Next:** Layer-2 automation actions (input dispatch, panel-targeted reads) as future spikes need them
 
 ## Why
 
@@ -379,6 +379,30 @@ Layer 3 — **macOS input driver** (reuse as-is):
 **Design decision**: Start with a minimal action set. Each subsequent spike adds the actions it needs for its own tests (e.g. Spike 4 adds `read_pane_text`, `focus_panel`). The automation server grows incrementally with the app.
 
 **Effort**: Small-Medium (1 day). The hard design work is already done in the Tauri app — this is a port of the server side to Rust, reuse of the client side as-is.
+
+#### Implementation notes (landed)
+
+What shipped vs. the plan above:
+
+- **Profiles instead of a separate flag**: Profiles arrived after the original plan was written. Automation is now gated at runtime via `ATTN_AUTOMATION` (explicit `1`/`0`) with a profile-aware default (`ATTN_PROFILE=dev` → on, prod → off). The `--automation` CLI flag from the plan was dropped — environment is the single decision surface for both apps. The same rule lives in three places that all need to agree:
+  - `native-ui/crates/attn-native-app/src/automation/profile.rs`
+  - `app/src-tauri/src/profile.rs::automation_enabled`
+  - `app/scripts/real-app-harness/nativeHarnessProfile.mjs`
+- **Bundle-id namespace**: native side uses `com.attn.native[.<profile>]` (e.g. `com.attn.native.dev`). There is no actual `.app` bundle yet; the namespace is just the manifest directory contract that matches what a future packaged build would use.
+- **Tauri side flipped from build-time to runtime gating**: the old `option_env!("ATTN_UI_AUTOMATION")` const + `VITE_UI_AUTOMATION` Vite env are gone. Rust decides `automation_enabled()` at startup and injects `window.__ATTN_AUTOMATION_ENABLED` via `append_invoke_initialization_script` so `useUiAutomationBridge` reads it synchronously on first render. **Breaking**: prod source installs that relied on automation always-on must now set `ATTN_AUTOMATION=1`.
+- **Token generation**: 32 random bytes from `getrandom` (OS RNG), hex-encoded — replaces the predictable pid+nanos scheme on both sides.
+- **Action set landed**: `ping`, `get_state`, `list_sessions`, `get_window_geometry`. Unknown actions return `{ ok: false, error: "unknown action: <name>" }` so future scripts get useful feedback.
+- **Server architecture**: tokio-style accept loop + per-connection task on GPUI's background executor; channel-bridged dispatcher hands action requests to a foreground pump (`automation::actions::pump_actions`) that runs handlers with `&mut AsyncApp` so they can `read_entity` / `update_window` safely. The per-action snapshot lives next to the data (`Spike5App::automation_snapshot`, `Workspace::automation_snapshot`, `Spike5Canvas::automation_snapshot`) — wire layer doesn't reach into entity internals.
+- **Test layers**: wire protocol + manifest paths + automation rule have unit tests (no GPUI). The integrated path is proven by `make native-automation-smoke`, which connects to a live binary, exercises every action, and asserts shape. No GPUI-runtime unit tests for action handlers — `Spike5App::new` requires a live daemon, mocking that is more plumbing than the spike justifies.
+
+#### Skipped for spike-ness (clearly labeled)
+
+These are not in the landed PR; future spikes can address them:
+
+- **Manifest cleanup on signal exit**: `Drop` on the `Handle` deletes the manifest, but Rust doesn't run `Drop` on SIGTERM/SIGKILL — the manifest stays on disk with stale port + pid until the next launch overwrites it. Same limitation as the Tauri side. Eventually-consistent and harmless because external clients re-read on each connection, but a clean SIGTERM handler would be cheap.
+- **Layer-2 input actions** (`type_pane_via_ui`, `click_pane`, `focus_panel`, `read_pane_text`, etc.): not implemented. The plan calls for adding these incrementally as future spikes need them. Layer 3 (OS-level input via `InputDriver.swift`) works against the native app now via `bundleIdentifierForNativeProfile()`.
+- **Frontend ready signal**: the Tauri side has a `ready` event the bridge waits for before accepting requests. The native side has no equivalent — actions can hit before GPUI has a window. In practice the smoke script just retries; if this becomes a real flake we'll add a ready beacon.
+- **Wired into `attn-native` (spike-1) binary**: only `attn-spike5` boots the sidecar today. The earlier spikes don't have the workspace state worth automating; revisit if any pre-spike-5 surface ever needs scenario coverage.
 
 ---
 

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -37,6 +37,14 @@ type wsClient struct {
 	pendingRemote   map[string]struct{}          // remote runtime IDs awaiting attach_result
 	attachMu        sync.Mutex
 
+	// Identity + capabilities declared via client_hello. Clients that
+	// never send hello have an empty capabilities map and are treated as
+	// the legacy default (matches the Tauri app's pre-hello behavior).
+	clientKind    string
+	clientVersion string
+	capabilities  map[string]struct{}
+	identityMu    sync.RWMutex
+
 	// Git status subscription state
 	gitStatusDir        string
 	gitStatusTicker     *time.Ticker
@@ -44,6 +52,30 @@ type wsClient struct {
 	gitStatusHash       string // hash of last sent status for dedup
 	gitStatusEndpointID string
 	gitStatusMu         sync.Mutex
+}
+
+// HasCapability reports whether the client advertised the given
+// capability via client_hello. False for clients that never sent hello.
+// Capability strings are arbitrary; see protocol.Capability* constants.
+func (c *wsClient) HasCapability(cap string) bool {
+	c.identityMu.RLock()
+	defer c.identityMu.RUnlock()
+	_, ok := c.capabilities[cap]
+	return ok
+}
+
+// setIdentity records the hello payload on the client. Idempotent —
+// later hellos overwrite earlier ones, which is the right behavior if a
+// client ever wants to re-declare (no current case, but cheap).
+func (c *wsClient) setIdentity(kind, version string, caps []string) {
+	c.identityMu.Lock()
+	defer c.identityMu.Unlock()
+	c.clientKind = kind
+	c.clientVersion = version
+	c.capabilities = make(map[string]struct{}, len(caps))
+	for _, cap := range caps {
+		c.capabilities[cap] = struct{}{}
+	}
 }
 
 func (c *wsClient) closeSendChannel() {
@@ -684,6 +716,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 	}
 
 	switch cmd {
+	case protocol.CmdClientHello:
+		d.handleClientHello(client, msg.(*protocol.ClientHelloMessage))
 	case protocol.CmdApprovePR:
 		d.handleApprovePRWS(client, msg.(*protocol.ApprovePRMessage))
 	case protocol.CmdMergePR:

--- a/internal/daemon/ws_hello.go
+++ b/internal/daemon/ws_hello.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// handleClientHello records the client's identity and capabilities so
+// per-client behavior (gated via wsClient.HasCapability) can take effect
+// for the rest of the connection. Idempotent — a client that re-sends
+// hello overwrites its prior identity.
+//
+// We deliberately don't reply: the hello is a fire-and-forget setup
+// message. The next command the client sends is the real signal that
+// the connection is alive and ready.
+func (d *Daemon) handleClientHello(client *wsClient, msg *protocol.ClientHelloMessage) {
+	client.setIdentity(msg.ClientKind, msg.Version, msg.Capabilities)
+	d.logf(
+		"client hello: kind=%q version=%q capabilities=%v",
+		msg.ClientKind,
+		msg.Version,
+		msg.Capabilities,
+	)
+}

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -403,7 +403,13 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		return
 	}
 
-	if !isShell {
+	// Shell PTYs are utility terminals by default (Cmd+T in the Tauri
+	// app — fire-and-forget, not tracked as sessions). The native canvas
+	// app needs them as first-class sessions so the workspace can render
+	// each PTY as a panel; it opts in via the `shell_as_session`
+	// capability declared in client_hello.
+	registerAsSession := !isShell || client.HasCapability(protocol.CapabilityShellAsSession)
+	if registerAsSession {
 		d.clearLongRunTracking(msg.ID)
 		branchInfo, _ := git.GetBranchInfo(cwd)
 		nowStr := string(protocol.TimestampNow())

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,10 +10,11 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "56"
+const ProtocolVersion = "57"
 
 // Commands
 const (
+	CmdClientHello              = "client_hello"
 	CmdRegister                 = "register"
 	CmdUnregister               = "unregister"
 	CmdState                    = "state"
@@ -170,6 +171,18 @@ const (
 	AgentShellValue = "shell"
 )
 
+// Client capabilities advertised in ClientHelloMessage.capabilities.
+// Daemon code checks these via wsClient.HasCapability so behavior can
+// diverge per client without name-keying on client_kind. Unknown
+// capability strings are silently ignored.
+const (
+	// CapabilityShellAsSession: when set, the daemon treats shell PTY
+	// spawns from this client as first-class sessions (store + broadcast)
+	// rather than fire-and-forget utility terminals. Declared by the
+	// native-canvas app; absent from the legacy Tauri app.
+	CapabilityShellAsSession = "shell_as_session"
+)
+
 // PR states (values for PR.State field, distinct from session states)
 const (
 	PRStateWaiting = "waiting" // PR needs attention
@@ -227,6 +240,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	// Parse based on command type
 	switch peek.Cmd {
+	case CmdClientHello:
+		var msg ClientHelloMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
 	case CmdRegister:
 		var msg RegisterMessage
 		if err := json.Unmarshal(data, &msg); err != nil {

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -304,6 +304,20 @@ type ClearWarningsMessage struct {
 	Cmd string `json:"cmd"`
 }
 
+type ClientHelloMessage struct {
+	// Capabilities corresponds to the JSON schema field "capabilities".
+	Capabilities []string `json:"capabilities"`
+
+	// ClientKind corresponds to the JSON schema field "client_kind".
+	ClientKind string `json:"client_kind"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Version corresponds to the JSON schema field "version".
+	Version string `json:"version"`
+}
+
 type CollapseRepoMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1914,6 +1914,7 @@ const SessionAgentClaude SessionAgent = "claude"
 const SessionAgentCodex SessionAgent = "codex"
 const SessionAgentCopilot SessionAgent = "copilot"
 const SessionAgentPi SessionAgent = "pi"
+const SessionAgentShell SessionAgent = "shell"
 
 type SessionExitedMessage struct {
 	// Event corresponds to the JSON schema field "event".

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -28,6 +28,10 @@ enum SessionAgent {
   codex,
   copilot,
   pi,
+  // Shell agents are first-class sessions for clients that advertise the
+  // shell_as_session capability (the native canvas app); the Tauri app
+  // continues to filter them out of its sidebar.
+  shell,
 }
 
 // WorkspaceStatus is the rolled-up status of all sessions in a workspace.

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -280,6 +280,24 @@ model EndpointInfo {
 // Command Messages (Client → Daemon)
 // ============================================================================
 
+// Sent first thing after a WebSocket connect so the daemon can serve
+// per-client behavior gated on capabilities. Clients that don't send a
+// hello are treated as the legacy default (no capabilities) for
+// backwards compatibility.
+//
+// Capabilities are open-ended strings — the daemon checks the ones it
+// recognizes; unknown capabilities are ignored. Currently defined:
+//   - "shell_as_session" — when the client spawns a shell PTY via
+//     spawn_session, the daemon treats it as a first-class session
+//     (added to the store, broadcast as session_registered) instead of
+//     a fire-and-forget utility terminal.
+model ClientHelloMessage {
+  cmd: "client_hello";
+  client_kind: string;          // e.g. "native-canvas", "tauri-app"
+  version: string;              // free-form, used for diagnostics
+  capabilities: string[];       // see capability docstrings above
+}
+
 model RegisterMessage {
   cmd: "register";
   id: string;

--- a/native-ui/Cargo.lock
+++ b/native-ui/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "attn-protocol",
  "base64",
  "futures-util",
+ "getrandom 0.2.17",
  "gpui",
  "serde",
  "serde_json",

--- a/native-ui/Cargo.toml
+++ b/native-ui/Cargo.toml
@@ -9,3 +9,4 @@ members = [
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 futures-util = "0.3"
+getrandom = "0.2"

--- a/native-ui/crates/attn-native-app/Cargo.toml
+++ b/native-ui/crates/attn-native-app/Cargo.toml
@@ -30,3 +30,4 @@ smol = "2"
 alacritty_terminal = "0.26.0"
 base64 = "0.22"
 async-channel = "2"
+getrandom = { workspace = true }

--- a/native-ui/crates/attn-native-app/src/automation/actions.rs
+++ b/native-ui/crates/attn-native-app/src/automation/actions.rs
@@ -1,0 +1,283 @@
+/// GPUI-bound action handlers. The wire-protocol server runs on the GPUI
+/// background executor and can't access entities directly (`AsyncApp` is
+/// !Send across some boundaries, and entity access has to happen on the
+/// foreground thread). We bridge with an async channel: the dispatcher
+/// sends an `ActionRequest`, a foreground-spawned `pump_actions` task
+/// reads each request, runs the handler with `&mut AsyncApp`, and sends
+/// the result back.
+use std::sync::Arc;
+
+use async_channel::{unbounded, Receiver, Sender};
+use attn_protocol::PtyInputMessage;
+use gpui::{prelude::*, AnyView, App, AsyncApp, Entity, SharedString, WeakEntity, Window};
+use serde_json::{json, Value};
+
+use crate::canvas_view::pf;
+use crate::panel::PanelContent;
+use crate::spike5_app::Spike5App;
+use crate::terminal_model::TerminalModel;
+
+use super::events;
+use super::server::Dispatcher;
+
+pub struct ActionRequest {
+    pub action: String,
+    pub payload: Value,
+    pub reply: Sender<Result<Value, String>>,
+}
+
+/// Build a `(Dispatcher, Receiver)` pair. The `Dispatcher` is what the
+/// TCP server uses to fulfill requests; the `Receiver` is consumed by
+/// `pump_actions` on the foreground.
+pub fn make_dispatcher() -> (Dispatcher, Receiver<ActionRequest>) {
+    let (tx, rx) = unbounded::<ActionRequest>();
+    let tx = Arc::new(tx);
+    let dispatcher: Dispatcher = Arc::new(move |action, payload| {
+        let tx = tx.clone();
+        Box::pin(async move {
+            let (reply_tx, reply_rx) = async_channel::bounded(1);
+            tx.send(ActionRequest {
+                action,
+                payload,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|e| format!("dispatcher: action queue closed: {e}"))?;
+            reply_rx
+                .recv()
+                .await
+                .map_err(|e| format!("dispatcher: reply channel closed: {e}"))?
+        })
+    });
+    (dispatcher, rx)
+}
+
+/// Foreground-side pump. Spawn via `cx.spawn` so it has access to
+/// `&mut AsyncApp` across awaits. Returns when the channel is closed
+/// (i.e. when the dispatcher is dropped on app shutdown).
+pub async fn pump_actions(
+    rx: Receiver<ActionRequest>,
+    app: WeakEntity<Spike5App>,
+    mut cx: AsyncApp,
+) {
+    while let Ok(req) = rx.recv().await {
+        let result = handle_action(&req.action, req.payload, &app, &mut cx).await;
+        let _ = req.reply.send(result).await;
+    }
+}
+
+async fn handle_action(
+    action: &str,
+    payload: Value,
+    app: &WeakEntity<Spike5App>,
+    cx: &mut AsyncApp,
+) -> Result<Value, String> {
+    match action {
+        "ping" => Ok(json!({
+            "pong": true,
+            "pid": std::process::id(),
+        })),
+        "get_state" => get_state(app, cx),
+        "list_sessions" => list_sessions(app, cx),
+        "get_window_geometry" => get_window_geometry(cx),
+        "select_workspace" => select_workspace(app, cx, payload),
+        "move_panel" => move_panel(app, cx, payload),
+        "send_pty_input" => send_pty_input(app, cx, payload),
+        "read_pane_text" => read_pane_text(app, cx, payload),
+        "tail_events" => tail_events(payload),
+        _ => Err(format!("unknown action: {action}")),
+    }
+}
+
+fn get_state(app: &WeakEntity<Spike5App>, cx: &mut AsyncApp) -> Result<Value, String> {
+    let entity = app.upgrade().ok_or("Spike5App entity dropped")?;
+    cx.read_entity(&entity, |app: &Spike5App, cx: &App| app.automation_snapshot(cx))
+        .map_err(|e| format!("read entity: {e}"))
+}
+
+fn list_sessions(app: &WeakEntity<Spike5App>, cx: &mut AsyncApp) -> Result<Value, String> {
+    let entity = app.upgrade().ok_or("Spike5App entity dropped")?;
+    cx.read_entity(&entity, |app: &Spike5App, cx: &App| {
+        let sessions = app.daemon().read(cx).sessions();
+        serde_json::to_value(sessions).unwrap_or(Value::Null)
+    })
+    .map_err(|e| format!("read entity: {e}"))
+}
+
+fn select_workspace(
+    app: &WeakEntity<Spike5App>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let id = payload
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or("payload.id (string) is required")?
+        .to_string();
+    let entity = app.upgrade().ok_or("Spike5App entity dropped")?;
+    cx.update_entity(&entity, |app, cx| {
+        if app.workspace(&id).is_none() {
+            return Err(format!("unknown workspace id: {id}"));
+        }
+        app.select_workspace(SharedString::from(id.clone()), cx);
+        Ok(json!({ "selected_workspace_id": id }))
+    })
+    .map_err(|e| format!("update entity: {e}"))?
+}
+
+fn move_panel(
+    app: &WeakEntity<Spike5App>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let workspace_id = payload
+        .get("workspace_id")
+        .and_then(Value::as_str)
+        .ok_or("payload.workspace_id (string) is required")?
+        .to_string();
+    let panel_id = payload
+        .get("panel_id")
+        .and_then(Value::as_u64)
+        .ok_or("payload.panel_id (number) is required")? as usize;
+    let world_x = payload.get("world_x").and_then(Value::as_f64).map(|n| n as f32);
+    let world_y = payload.get("world_y").and_then(Value::as_f64).map(|n| n as f32);
+    let width = payload.get("width").and_then(Value::as_f64).map(|n| n as f32);
+    let height = payload.get("height").and_then(Value::as_f64).map(|n| n as f32);
+
+    let app_entity = app.upgrade().ok_or("Spike5App entity dropped")?;
+    let workspace = cx
+        .read_entity(&app_entity, |app: &Spike5App, _cx: &App| {
+            app.workspace(&workspace_id)
+        })
+        .map_err(|e| format!("read entity: {e}"))?
+        .ok_or_else(|| format!("unknown workspace id: {workspace_id}"))?;
+
+    cx.update_entity(&workspace, |ws, cx| {
+        ws.update_panel(panel_id, world_x, world_y, width, height, cx)
+            .map(|panel| json!({ "panel": panel }))
+            .ok_or_else(|| format!("unknown panel id: {panel_id}"))
+    })
+    .map_err(|e| format!("update entity: {e}"))?
+}
+
+fn send_pty_input(
+    app: &WeakEntity<Spike5App>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .ok_or("payload.session_id (string) is required")?
+        .to_string();
+    let text = payload
+        .get("text")
+        .and_then(Value::as_str)
+        .ok_or("payload.text (string) is required")?
+        .to_string();
+
+    let app_entity = app.upgrade().ok_or("Spike5App entity dropped")?;
+    cx.read_entity(&app_entity, |app: &Spike5App, cx: &App| {
+        if find_terminal_model(app, &session_id, cx).is_none() {
+            return Err(format!("no terminal panel for session: {session_id}"));
+        }
+        // The daemon routes by session id; we just need to send the
+        // message. Passing through TerminalModel would also work but
+        // it's strictly equivalent and adds an indirection.
+        app.daemon()
+            .read(cx)
+            .send_cmd(&PtyInputMessage::new(session_id.clone(), text.clone()));
+        Ok(json!({
+            "session_id": session_id,
+            "bytes_sent": text.len(),
+        }))
+    })
+    .map_err(|e| format!("read entity: {e}"))?
+}
+
+fn read_pane_text(
+    app: &WeakEntity<Spike5App>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .ok_or("payload.session_id (string) is required")?
+        .to_string();
+
+    let app_entity = app.upgrade().ok_or("Spike5App entity dropped")?;
+    let model = cx
+        .read_entity(&app_entity, |app: &Spike5App, cx: &App| {
+            find_terminal_model(app, &session_id, cx)
+        })
+        .map_err(|e| format!("read entity: {e}"))?
+        .ok_or_else(|| format!("no terminal panel for session: {session_id}"))?;
+
+    cx.read_entity(&model, |term: &TerminalModel, _cx: &App| {
+        let rows = term.screen_text();
+        let joined = rows.join("\n");
+        json!({
+            "session_id": term.session_id,
+            "cols": term.cols,
+            "rows": rows,
+            "text": joined,
+        })
+    })
+    .map_err(|e| format!("read terminal model: {e}"))
+}
+
+/// Walks every workspace's panels for a Terminal panel matching
+/// `session_id` and returns its model handle. None when no such panel
+/// exists in any workspace.
+fn find_terminal_model(
+    app: &Spike5App,
+    session_id: &str,
+    cx: &App,
+) -> Option<Entity<TerminalModel>> {
+    for ws in app.workspaces() {
+        for panel in ws.read(cx).panels.iter() {
+            if let PanelContent::Terminal { session_id: sid, view } = &panel.content {
+                if sid.as_ref() == session_id {
+                    return Some(view.read(cx).model().clone());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Drain the in-process event ring buffer past `since_id` (defaults to 0,
+/// meaning "give me everything you still have"). Doesn't need entity
+/// access — the buffer is global — but routes through the action pump
+/// for protocol uniformity.
+fn tail_events(payload: Value) -> Result<Value, String> {
+    let cursor = payload
+        .get("since_id")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    Ok(events::tail_events_response(cursor))
+}
+
+fn get_window_geometry(cx: &mut AsyncApp) -> Result<Value, String> {
+    let window = cx
+        .update(|app: &mut App| app.windows().into_iter().next())
+        .map_err(|e| format!("list windows: {e}"))?
+        .ok_or("no open windows")?;
+    cx.update_window(
+        window,
+        |_view: AnyView, window: &mut Window, _app: &mut App| {
+            let bounds = window.bounds();
+            json!({
+                "scaleFactor": window.scale_factor(),
+                "globalBounds": {
+                    "x": pf(bounds.origin.x),
+                    "y": pf(bounds.origin.y),
+                    "width": pf(bounds.size.width),
+                    "height": pf(bounds.size.height),
+                },
+            })
+        },
+    )
+    .map_err(|e| format!("update window: {e}"))
+}

--- a/native-ui/crates/attn-native-app/src/automation/events.rs
+++ b/native-ui/crates/attn-native-app/src/automation/events.rs
@@ -1,0 +1,189 @@
+//! In-memory ring buffer of structured events for diagnosing UI behavior
+//! end-to-end. Externally observable via the automation `tail_events`
+//! action.
+//!
+//! ## Why this exists
+//!
+//! When something behaves wrong end-to-end (a session spawns but no panel
+//! attaches, a workspace switch doesn't take effect, a typed command
+//! doesn't echo), the only way to figure out where in the chain it broke
+//! is to see what each layer saw and what it did. `eprintln!` would do for
+//! one debugging session but doesn't survive into the real app — we need a
+//! structured stream that test scripts AND production debugging both
+//! consume. This is the same pattern Playwright tracing or Chrome DevTools'
+//! performance log expose.
+//!
+//! ## Design
+//!
+//! - Single global ring buffer (bounded; oldest dropped on overflow).
+//! - Monotonic 64-bit ids; consumers poll with a `since_id` cursor.
+//! - Mutex-protected. Lock contention is fine for our volume — emission
+//!   sites fire at the rate of UI state changes (low hundreds/sec at peak).
+//! - Always-on. The buffer's memory cost is bounded (~150 KB at full
+//!   capacity), and the cost of an emission is one `Mutex` acquire +
+//!   `VecDeque::push_back`.
+//!
+//! ## Categories
+//!
+//! Categories are stable string identifiers — pick from this enumerated
+//! list when adding new emission sites so consumers can switch on them.
+//!
+//! - `daemon_event` — payload `{kind, ...}` for every inbound wire event
+//!   from the daemon. Excludes `pty_output` (would dominate the buffer).
+//! - `sessions_changed_observed` — Spike5App reacted to a SessionsChanged
+//!   emit; carries the post-reaction session count.
+//! - `workspace_registered_observed`, `workspace_unregistered_observed`,
+//!   `workspace_state_changed_observed` — Spike5App processed the matching
+//!   daemon event and updated its workspaces map.
+//! - `workspace_selected` — payload `{id}`. Sidebar click or automation.
+//! - `panel_added` — payload
+//!   `{workspace_id, panel_id, session_id, kind}`. Fired by
+//!   `sync_terminal_panels` when a new Terminal panel is created.
+//! - `panel_pruned` — payload
+//!   `{workspace_id, panel_id, session_id}`. Fired when
+//!   `sync_terminal_panels` drops a panel whose session disappeared.
+//! - `panel_updated` — payload `{workspace_id, panel_id, world_x, world_y,
+//!   width, height}`. Fired by `Workspace::update_panel`.
+//! - `terminal_attach_processed` — payload `{session_id, success,
+//!   has_snapshot, replay_segments}`. Fired when `TerminalModel` finishes
+//!   processing an `AttachResult`.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{LazyLock, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+/// Maximum events kept in the ring buffer. ~2k events covers a long
+/// scenario or several seconds of peak UI activity; older events fall out
+/// the front.
+const CAPACITY: usize = 2048;
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+static LOG: LazyLock<Mutex<VecDeque<Event>>> =
+    LazyLock::new(|| Mutex::new(VecDeque::with_capacity(CAPACITY)));
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Event {
+    /// Monotonic across the process lifetime. Used as the `tail_since`
+    /// cursor.
+    pub id: u64,
+    /// Wall-clock milliseconds since the Unix epoch. Useful for ordering
+    /// against external observers (e.g. the daemon's own log).
+    pub ts_ms: u64,
+    pub category: String,
+    pub payload: Value,
+}
+
+/// Append an event. Drops the oldest record when the buffer is full.
+pub fn record(category: impl Into<String>, payload: Value) {
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let ts_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let event = Event {
+        id,
+        ts_ms,
+        category: category.into(),
+        payload,
+    };
+    if let Ok(mut log) = LOG.lock() {
+        if log.len() >= CAPACITY {
+            log.pop_front();
+        }
+        log.push_back(event);
+    }
+}
+
+/// Pull every event with `id > cursor`, oldest-to-newest.
+pub fn tail_since(cursor: u64) -> Vec<Event> {
+    match LOG.lock() {
+        Ok(log) => log.iter().filter(|e| e.id > cursor).cloned().collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Build the JSON response for the `tail_events` action. Returns the
+/// matching events plus the cursor a caller should send back next time.
+pub fn tail_events_response(cursor: u64) -> Value {
+    let events = tail_since(cursor);
+    let next_cursor = events.last().map(|e| e.id).unwrap_or(cursor);
+    json!({
+        "events": events,
+        "next_cursor": next_cursor,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn current_id() -> u64 {
+        NEXT_ID.load(Ordering::Relaxed)
+    }
+
+    #[test]
+    fn record_then_tail_returns_only_new_events() {
+        let cursor = current_id() - 1;
+        record("test_record_a", json!({"x": 1}));
+        record("test_record_b", json!({"x": 2}));
+        let events = tail_since(cursor);
+        // Filter to our categories — other tests may have emitted too.
+        let ours: Vec<_> = events
+            .into_iter()
+            .filter(|e| e.category == "test_record_a" || e.category == "test_record_b")
+            .collect();
+        assert!(ours.len() >= 2);
+        // Ids must be strictly increasing.
+        for pair in ours.windows(2) {
+            assert!(pair[1].id > pair[0].id);
+        }
+    }
+
+    #[test]
+    fn ring_buffer_is_bounded() {
+        for i in 0..(CAPACITY + 100) {
+            record("test_bounded", json!({"i": i}));
+        }
+        let log_len = LOG.lock().unwrap().len();
+        assert!(
+            log_len <= CAPACITY,
+            "log grew past capacity: {} > {}",
+            log_len,
+            CAPACITY
+        );
+    }
+
+    #[test]
+    fn tail_events_response_advances_cursor() {
+        let before = current_id() - 1;
+        record("test_cursor", json!({}));
+        let response = tail_events_response(before);
+        let events = response["events"].as_array().unwrap();
+        let next_cursor = response["next_cursor"].as_u64().unwrap();
+        assert!(!events.is_empty());
+        assert!(next_cursor > before);
+
+        // Calling again with the new cursor should return no `test_cursor`
+        // events (other tests may still slip in).
+        let again = tail_events_response(next_cursor);
+        let again_events = again["events"].as_array().unwrap();
+        let our_again: Vec<_> = again_events
+            .iter()
+            .filter(|e| e["category"] == "test_cursor")
+            .collect();
+        assert!(our_again.is_empty());
+    }
+
+    #[test]
+    fn empty_tail_keeps_cursor() {
+        let response = tail_events_response(u64::MAX);
+        let events = response["events"].as_array().unwrap();
+        assert!(events.is_empty());
+        assert_eq!(response["next_cursor"].as_u64().unwrap(), u64::MAX);
+    }
+}

--- a/native-ui/crates/attn-native-app/src/automation/manifest.rs
+++ b/native-ui/crates/attn-native-app/src/automation/manifest.rs
@@ -1,0 +1,107 @@
+/// Discovery manifest written to disk on automation server start so external
+/// test scripts can find the live port + token. Mirrors the Tauri side's
+/// shape so `uiAutomationClient.mjs` works against either app.
+use serde::Serialize;
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+
+#[derive(Debug, Serialize)]
+pub struct Manifest {
+    pub enabled: bool,
+    pub port: u16,
+    pub token: String,
+    pub pid: u32,
+    pub started_at: String,
+}
+
+/// Generate a 32-byte random token, hex-encoded. Uses OS randomness via
+/// `getrandom` so the token is not predictable from pid + start time
+/// (the Tauri side's current scheme — see #12).
+pub fn generate_token() -> String {
+    let mut buf = [0u8; 32];
+    getrandom::getrandom(&mut buf).expect("OS RNG must be available");
+    let mut hex = String::with_capacity(buf.len() * 2);
+    for byte in buf {
+        // Hand-rolled hex to avoid pulling in a dep just for this.
+        hex.push(nibble(byte >> 4));
+        hex.push(nibble(byte & 0x0f));
+    }
+    hex
+}
+
+fn nibble(n: u8) -> char {
+    match n {
+        0..=9 => (b'0' + n) as char,
+        10..=15 => (b'a' + n - 10) as char,
+        _ => unreachable!(),
+    }
+}
+
+pub fn write(path: &Path, manifest: &Manifest) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let body = serde_json::to_string_pretty(manifest)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let mut file = fs::File::create(path)?;
+    file.write_all(body.as_bytes())?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+pub fn delete(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_is_64_hex_chars() {
+        let t = generate_token();
+        assert_eq!(t.len(), 64);
+        assert!(t.chars().all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()));
+    }
+
+    #[test]
+    fn tokens_differ() {
+        // Two independent calls should never collide.
+        assert_ne!(generate_token(), generate_token());
+    }
+
+    #[test]
+    fn write_then_read_roundtrips() {
+        let dir = std::env::temp_dir().join(format!(
+            "attn-automation-test-{}",
+            std::process::id()
+        ));
+        let path = dir.join("ui-automation.json");
+        let _ = fs::remove_dir_all(&dir);
+
+        let manifest = Manifest {
+            enabled: true,
+            port: 12345,
+            token: "deadbeef".into(),
+            pid: 9999,
+            started_at: "1234".into(),
+        };
+        write(&path, &manifest).unwrap();
+
+        let body = fs::read_to_string(&path).unwrap();
+        assert!(body.contains("\"port\": 12345"));
+        assert!(body.contains("\"token\": \"deadbeef\""));
+
+        delete(&path).unwrap();
+        assert!(!path.exists());
+        // Second delete is idempotent.
+        delete(&path).unwrap();
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/native-ui/crates/attn-native-app/src/automation/mod.rs
+++ b/native-ui/crates/attn-native-app/src/automation/mod.rs
@@ -1,0 +1,16 @@
+/// UI automation sidecar for the native canvas app. See module docs in
+/// `profile.rs` for the gating rule, and `docs/plans/native-gpui-canvas-ui.md`
+/// (Spike 6) for the broader design.
+///
+/// The sidecar runs an in-process TCP server that external test scripts
+/// connect to. Wire format and manifest layout match the Tauri bridge so
+/// `app/scripts/real-app-harness/uiAutomationClient.mjs` works against
+/// either app with only the manifest path swapped out.
+pub mod actions;
+pub mod events;
+pub mod manifest;
+pub mod profile;
+pub mod protocol;
+pub mod server;
+
+pub use profile::{automation_enabled, manifest_path};

--- a/native-ui/crates/attn-native-app/src/automation/profile.rs
+++ b/native-ui/crates/attn-native-app/src/automation/profile.rs
@@ -1,0 +1,162 @@
+/// Profile resolution + automation gating.
+///
+/// One decision rule is shared across native Rust, Tauri Rust, and the
+/// harness JS side; this is the Rust copy. Keep it in sync with:
+///   - `app/src-tauri/src/profile.rs`            (Tauri runtime gate)
+///   - `app/scripts/real-app-harness/nativeHarnessProfile.mjs`
+///   - `internal/config/config.go`               (profile name regex)
+///
+/// `automation_enabled` rule:
+///   - `ATTN_AUTOMATION=1`  → on
+///   - `ATTN_AUTOMATION=0`  → off
+///   - `ATTN_PROFILE=dev`   → on   (default for dev)
+///   - otherwise            → off  (default for prod / unset)
+use std::path::PathBuf;
+
+const PROFILE_ENV: &str = "ATTN_PROFILE";
+const AUTOMATION_ENV: &str = "ATTN_AUTOMATION";
+const BASE_BUNDLE_ID: &str = "com.attn.native";
+
+/// Resolved profile name (lowercased, validated). `None` for default profile
+/// or for any input that fails validation — this matches the Go side's
+/// permissive read path: bad profile env values silently fall through to
+/// default rather than crashing the app.
+pub fn profile() -> Option<String> {
+    let raw = std::env::var(PROFILE_ENV).ok()?;
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() || normalized == "default" {
+        return None;
+    }
+    if !is_valid_profile(&normalized) {
+        return None;
+    }
+    Some(normalized)
+}
+
+/// Decide whether the automation server should run this launch. Single rule
+/// for both apps. See module doc.
+pub fn automation_enabled() -> bool {
+    decide_automation_enabled(
+        std::env::var(AUTOMATION_ENV).ok().as_deref(),
+        profile().as_deref(),
+    )
+}
+
+/// Pure decision function so the rule itself is testable without touching
+/// process env.
+fn decide_automation_enabled(automation: Option<&str>, profile: Option<&str>) -> bool {
+    match automation.map(str::trim) {
+        Some("1") => return true,
+        Some("0") => return false,
+        Some("") | None => {}
+        // Any other value — be strict here so typos don't silently disable
+        // automation in CI. Treat as "explicit off" for safety.
+        Some(_) => return false,
+    }
+    profile == Some("dev")
+}
+
+/// Bundle identifier for the manifest path. Prod (default profile) lands at
+/// `com.attn.native`; dev/other profiles get a suffix so installs of the
+/// same app for different profiles don't collide on disk. Used internally
+/// by `manifest_path` and exposed to tests.
+fn bundle_identifier_for(profile: Option<&str>) -> String {
+    match profile {
+        Some(p) if !p.is_empty() => format!("{BASE_BUNDLE_ID}.{p}"),
+        _ => BASE_BUNDLE_ID.to_string(),
+    }
+}
+
+/// Manifest path mirroring the Tauri side
+/// (`~/Library/Application Support/<bundle-id>/debug/ui-automation.json`).
+/// Falls back to `/tmp` if the home dir can't be read; the manifest is a
+/// dev affordance, not a hard product requirement, and crashing the app
+/// here would be worse than writing to a less-discoverable path.
+pub fn manifest_path() -> PathBuf {
+    manifest_path_for(profile().as_deref())
+}
+
+pub fn manifest_path_for(profile: Option<&str>) -> PathBuf {
+    let base = dirs_home().unwrap_or_else(|| PathBuf::from("/tmp"));
+    base.join("Library")
+        .join("Application Support")
+        .join(bundle_identifier_for(profile))
+        .join("debug")
+        .join("ui-automation.json")
+}
+
+fn dirs_home() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+fn is_valid_profile(s: &str) -> bool {
+    // Mirror Go's `^[a-z0-9][a-z0-9-]{0,15}$`. Manual validation avoids
+    // pulling in the `regex` crate just for one tiny pattern.
+    let bytes = s.as_bytes();
+    if bytes.is_empty() || bytes.len() > 16 {
+        return false;
+    }
+    if !is_alnum_lower(bytes[0]) {
+        return false;
+    }
+    bytes[1..].iter().all(|&b| is_alnum_lower(b) || b == b'-')
+}
+
+fn is_alnum_lower(b: u8) -> bool {
+    matches!(b, b'a'..=b'z' | b'0'..=b'9')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_validation_matches_go_regex() {
+        for ok in ["dev", "ci", "a", "a-b", "abcdefghijklmnop"] {
+            assert!(is_valid_profile(ok), "expected ok: {ok}");
+        }
+        for bad in [
+            "",
+            "-dev",
+            "Dev",
+            "dev_",
+            "dev space",
+            "abcdefghijklmnopq", // 17 chars
+        ] {
+            assert!(!is_valid_profile(bad), "expected bad: {bad}");
+        }
+    }
+
+    #[test]
+    fn bundle_identifier_namespace() {
+        assert_eq!(bundle_identifier_for(None), "com.attn.native");
+        assert_eq!(bundle_identifier_for(Some("dev")), "com.attn.native.dev");
+        assert_eq!(bundle_identifier_for(Some("ci")), "com.attn.native.ci");
+    }
+
+    #[test]
+    fn manifest_path_includes_bundle_namespace() {
+        let dev = manifest_path_for(Some("dev"));
+        assert!(dev.to_string_lossy().contains("com.attn.native.dev"));
+        assert!(dev.ends_with("debug/ui-automation.json"));
+    }
+
+    #[test]
+    fn automation_decision_rules() {
+        // Explicit env wins over everything.
+        assert!(decide_automation_enabled(Some("1"), None));
+        assert!(decide_automation_enabled(Some("1"), Some("dev")));
+        assert!(!decide_automation_enabled(Some("0"), None));
+        assert!(!decide_automation_enabled(Some("0"), Some("dev")));
+        // Bogus value → strict off.
+        assert!(!decide_automation_enabled(Some("yes"), Some("dev")));
+        // Unset env → profile decides.
+        assert!(decide_automation_enabled(None, Some("dev")));
+        assert!(!decide_automation_enabled(None, Some("ci")));
+        assert!(!decide_automation_enabled(None, None));
+        // Empty / whitespace env value treated as unset → profile decides.
+        assert!(decide_automation_enabled(Some(""), Some("dev")));
+        assert!(decide_automation_enabled(Some("  "), Some("dev")));
+        assert!(!decide_automation_enabled(Some("  "), None));
+    }
+}

--- a/native-ui/crates/attn-native-app/src/automation/protocol.rs
+++ b/native-ui/crates/attn-native-app/src/automation/protocol.rs
@@ -1,0 +1,79 @@
+/// Wire types for the UI automation TCP protocol. Newline-delimited JSON;
+/// one request per line, one response per line. Format must stay compatible
+/// with `app/scripts/real-app-harness/uiAutomationClient.mjs`.
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Deserialize)]
+pub struct Request {
+    /// Optional client-supplied id. If absent the server assigns one and
+    /// echoes it back in the response so callers can correlate.
+    #[serde(default)]
+    pub id: Option<String>,
+    pub token: String,
+    pub action: String,
+    #[serde(default)]
+    pub payload: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Response {
+    pub id: String,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl Response {
+    pub fn ok(id: String, result: Value) -> Self {
+        Self {
+            id,
+            ok: true,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn err(id: String, message: impl Into<String>) -> Self {
+        Self {
+            id,
+            ok: false,
+            result: None,
+            error: Some(message.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_payload_optional() {
+        let parsed: Request = serde_json::from_str(
+            r#"{"id":"a","token":"t","action":"ping"}"#,
+        )
+        .unwrap();
+        assert_eq!(parsed.action, "ping");
+        assert!(parsed.payload.is_none());
+    }
+
+    #[test]
+    fn response_omits_unused_fields() {
+        let body = serde_json::to_string(&Response::ok(
+            "1".into(),
+            serde_json::json!({"pong": true}),
+        ))
+        .unwrap();
+        assert!(body.contains("\"ok\":true"));
+        assert!(body.contains("\"result\""));
+        assert!(!body.contains("\"error\""));
+
+        let body = serde_json::to_string(&Response::err("2".into(), "nope")).unwrap();
+        assert!(body.contains("\"ok\":false"));
+        assert!(body.contains("\"error\":\"nope\""));
+        assert!(!body.contains("\"result\""));
+    }
+}

--- a/native-ui/crates/attn-native-app/src/automation/server.rs
+++ b/native-ui/crates/attn-native-app/src/automation/server.rs
@@ -1,0 +1,419 @@
+/// TCP server that accepts newline-delimited JSON requests from external
+/// test scripts. Mirrors the Tauri bridge's wire format so the existing
+/// `uiAutomationClient.mjs` works against either app.
+///
+/// Lifecycle: `start` binds a random local port, writes the manifest, and
+/// spawns the accept loop. The returned `Handle` deletes the manifest on
+/// drop. The accept loop itself stays alive as long as the GPUI app does;
+/// `Handle::shutdown` would be the place to add an explicit signal if we
+/// ever need it.
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures_util::future::BoxFuture;
+use futures_util::AsyncBufReadExt;
+use futures_util::AsyncReadExt;
+use futures_util::AsyncWriteExt;
+use serde_json::Value;
+use smol::io::BufReader;
+use smol::net::TcpListener;
+use smol::stream::StreamExt;
+
+use super::manifest::{self, Manifest};
+use super::protocol::{Request, Response};
+
+/// Action dispatch surface. The server hands the action name + payload to
+/// this function and awaits the resulting `Value` (or `String` error). The
+/// real implementation in `actions.rs` runs handlers on the GPUI main
+/// thread; tests can plug in a synchronous stub.
+pub type Dispatcher = Arc<
+    dyn Fn(String, Value) -> BoxFuture<'static, Result<Value, String>> + Send + Sync + 'static,
+>;
+
+/// How the server spawns its background tasks. Decouples the wire layer
+/// from a specific executor so production code can use GPUI's
+/// `BackgroundExecutor` while tests use a `smol::Executor`. Tasks must be
+/// `Send` because they will be polled on whatever thread the executor
+/// happens to run them on.
+pub type Spawner = Arc<dyn Fn(BoxFuture<'static, ()>) + Send + Sync + 'static>;
+
+/// Build a `Spawner` from a `smol::Executor`. Convenience for tests.
+#[cfg(test)]
+pub fn spawner_from_smol(executor: Arc<smol::Executor<'static>>) -> Spawner {
+    Arc::new(move |fut| {
+        executor.spawn(fut).detach();
+    })
+}
+
+/// Resources the server owns. Drop deletes the manifest so external
+/// observers can't see a stale port/token after the app exits.
+pub struct Handle {
+    manifest_path: PathBuf,
+}
+
+impl Handle {
+    pub fn manifest_path(&self) -> &std::path::Path {
+        &self.manifest_path
+    }
+}
+
+impl Drop for Handle {
+    fn drop(&mut self) {
+        let _ = manifest::delete(&self.manifest_path);
+    }
+}
+
+/// Bind a localhost TCP listener on a random port. Pulled out so callers
+/// can inspect the bound address before the server is started — useful
+/// in tests and to avoid time-of-check races between `bind` and the
+/// manifest write.
+pub fn bind() -> std::io::Result<TcpListener> {
+    smol::block_on(async { TcpListener::bind("127.0.0.1:0").await })
+}
+
+/// Start the server with an already-bound listener. Returns immediately;
+/// the accept loop is spawned via the provided `Spawner` so the wire
+/// layer doesn't depend on which executor (smol, GPUI background) is in
+/// use.
+pub fn start(
+    listener: TcpListener,
+    manifest_path: PathBuf,
+    dispatcher: Dispatcher,
+    spawner: Spawner,
+) -> std::io::Result<Handle> {
+    let port = listener.local_addr()?.port();
+    let token = manifest::generate_token();
+
+    let manifest_value = Manifest {
+        enabled: true,
+        port,
+        token: token.clone(),
+        pid: std::process::id(),
+        started_at: started_at_unix_secs(),
+    };
+    manifest::write(&manifest_path, &manifest_value)?;
+
+    let spawner_for_loop = spawner.clone();
+    spawner(Box::pin(accept_loop(
+        listener,
+        token,
+        dispatcher,
+        spawner_for_loop,
+    )));
+
+    Ok(Handle { manifest_path })
+}
+
+fn started_at_unix_secs() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default();
+    secs.to_string()
+}
+
+async fn accept_loop(
+    listener: TcpListener,
+    expected_token: String,
+    dispatcher: Dispatcher,
+    spawner: Spawner,
+) {
+    let mut incoming = listener.incoming();
+    while let Some(stream) = incoming.next().await {
+        let stream = match stream {
+            Ok(s) => s,
+            Err(error) => {
+                eprintln!("[automation] accept failed: {error}");
+                continue;
+            }
+        };
+        let token = expected_token.clone();
+        let dispatcher = dispatcher.clone();
+        spawner(Box::pin(async move {
+            if let Err(error) = handle_connection(stream, token, dispatcher).await {
+                eprintln!("[automation] connection ended: {error}");
+            }
+        }));
+    }
+}
+
+async fn handle_connection(
+    stream: smol::net::TcpStream,
+    expected_token: String,
+    dispatcher: Dispatcher,
+) -> std::io::Result<()> {
+    let (read_half, mut write_half) = stream.split();
+    let mut reader = BufReader::new(read_half);
+    let mut request_counter: u64 = 0;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let bytes = reader.read_line(&mut line).await?;
+        if bytes == 0 {
+            // Peer closed.
+            return Ok(());
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        request_counter += 1;
+        let response = process_request(
+            trimmed,
+            &expected_token,
+            request_counter,
+            dispatcher.clone(),
+        )
+        .await;
+
+        let body = match serde_json::to_string(&response) {
+            Ok(s) => s,
+            Err(error) => format!(
+                "{{\"id\":\"{}\",\"ok\":false,\"error\":\"failed to encode response: {}\"}}",
+                response.id, error
+            ),
+        };
+        write_half.write_all(body.as_bytes()).await?;
+        write_half.write_all(b"\n").await?;
+        write_half.flush().await?;
+    }
+}
+
+/// Pulled out for unit-testing without a real socket. Takes the raw line
+/// (already trimmed) plus the expected token; returns a `Response`.
+async fn process_request(
+    line: &str,
+    expected_token: &str,
+    request_counter: u64,
+    dispatcher: Dispatcher,
+) -> Response {
+    let request: Request = match serde_json::from_str(line) {
+        Ok(r) => r,
+        Err(error) => {
+            // Best-effort: pull `id` out of the malformed payload so the
+            // client can still correlate the error to its request. A client
+            // that sent `id: 7` (number) instead of `"7"` would otherwise
+            // get an error tagged with a synthetic id, never resolve its
+            // pending Promise, and hang silently.
+            let echoed_id = serde_json::from_str::<Value>(line)
+                .ok()
+                .and_then(|v| match v.get("id")? {
+                    Value::String(s) => Some(s.clone()),
+                    Value::Number(n) => Some(n.to_string()),
+                    Value::Bool(b) => Some(b.to_string()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| format!("ui-automation-{request_counter}"));
+            return Response::err(echoed_id, format!("invalid request json: {error}"));
+        }
+    };
+    let id = request
+        .id
+        .clone()
+        .unwrap_or_else(|| format!("ui-automation-{request_counter}"));
+
+    if !constant_time_eq(request.token.as_bytes(), expected_token.as_bytes()) {
+        return Response::err(id, "invalid token");
+    }
+
+    let payload = request.payload.unwrap_or(Value::Null);
+    match dispatcher(request.action, payload).await {
+        Ok(result) => Response::ok(id, result),
+        Err(error) => Response::err(id, error),
+    }
+}
+
+/// Constant-time byte comparison so token validation doesn't leak length
+/// information to a slow attacker. Local-only sockets soften the threat
+/// model, but the cost of doing this right is two lines.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Convenience for tests/local code that just want a boxed-future closure
+/// from a sync function.
+#[allow(dead_code)]
+pub fn dispatcher_from_sync<F>(f: F) -> Dispatcher
+where
+    F: Fn(String, Value) -> Result<Value, String> + Send + Sync + 'static,
+{
+    let f = Arc::new(f);
+    Arc::new(move |action, payload| {
+        let f = f.clone();
+        Box::pin(async move { f(action, payload) }) as Pin<Box<_>>
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn echo_dispatcher() -> Dispatcher {
+        dispatcher_from_sync(|action, payload| {
+            Ok(json!({"action": action, "payload": payload}))
+        })
+    }
+
+    #[test]
+    fn rejects_invalid_token() {
+        let response = smol::block_on(process_request(
+            r#"{"id":"a","token":"bad","action":"ping"}"#,
+            "good",
+            1,
+            echo_dispatcher(),
+        ));
+        assert!(!response.ok);
+        assert_eq!(response.error.as_deref(), Some("invalid token"));
+        assert_eq!(response.id, "a");
+    }
+
+    #[test]
+    fn rejects_invalid_json() {
+        let response = smol::block_on(process_request(
+            "not json",
+            "good",
+            42,
+            echo_dispatcher(),
+        ));
+        assert!(!response.ok);
+        // Truly unparseable input has no recoverable id, so we fall back
+        // to the synthetic counter.
+        assert_eq!(response.id, "ui-automation-42");
+        assert!(response
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("invalid request json"));
+    }
+
+    #[test]
+    fn echoes_id_when_type_mismatched() {
+        // Numeric id — schema wants string. We still echo it back so the
+        // client can correlate; without this it would hang waiting for a
+        // response keyed by "1" while the error went to a synthetic id.
+        let response = smol::block_on(process_request(
+            r#"{"id":1,"token":"good","action":"ping"}"#,
+            "good",
+            99,
+            echo_dispatcher(),
+        ));
+        assert!(!response.ok);
+        assert_eq!(response.id, "1");
+        assert!(response
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("invalid request json"));
+    }
+
+    #[test]
+    fn assigns_id_when_missing() {
+        let response = smol::block_on(process_request(
+            r#"{"token":"good","action":"ping"}"#,
+            "good",
+            7,
+            echo_dispatcher(),
+        ));
+        assert!(response.ok);
+        assert_eq!(response.id, "ui-automation-7");
+    }
+
+    #[test]
+    fn dispatcher_runs_for_valid_request() {
+        let response = smol::block_on(process_request(
+            r#"{"id":"x","token":"good","action":"ping","payload":{"hello":"world"}}"#,
+            "good",
+            1,
+            echo_dispatcher(),
+        ));
+        assert!(response.ok);
+        assert_eq!(response.id, "x");
+        assert_eq!(
+            response.result.unwrap(),
+            json!({"action":"ping","payload":{"hello":"world"}})
+        );
+    }
+
+    #[test]
+    fn end_to_end_through_real_socket() {
+        // Bind, start, connect, exchange one request, shut down.
+        let listener = bind().expect("bind");
+        let addr = listener.local_addr().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "attn-automation-server-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        let manifest_path = dir.join("ui-automation.json");
+
+        let executor = Arc::new(smol::Executor::new());
+        let runner = executor.clone();
+        // Drive the executor on a worker thread so the spawned tasks
+        // actually run while the test thread does its synchronous TCP
+        // dance.
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_inner = stop.clone();
+        let runner_thread = std::thread::spawn(move || {
+            smol::block_on(async {
+                while !stop_inner.load(std::sync::atomic::Ordering::Relaxed) {
+                    runner.tick().await;
+                }
+            });
+        });
+
+        let _handle = start(
+            listener,
+            manifest_path.clone(),
+            echo_dispatcher(),
+            spawner_from_smol(executor.clone()),
+        )
+        .expect("start");
+
+        // Read the manifest, fish out the token.
+        let body = std::fs::read_to_string(&manifest_path).expect("manifest");
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let token = parsed["token"].as_str().unwrap().to_string();
+        assert_eq!(parsed["port"].as_u64().unwrap(), addr.port() as u64);
+
+        // Send one request synchronously over a blocking TCP socket.
+        use std::io::{BufRead, BufReader as StdBufReader, Write};
+        let mut stream = std::net::TcpStream::connect(addr).expect("connect");
+        let request = format!(
+            r#"{{"id":"abc","token":"{token}","action":"ping","payload":{{"k":"v"}}}}"#
+        );
+        stream.write_all(request.as_bytes()).unwrap();
+        stream.write_all(b"\n").unwrap();
+        stream.flush().unwrap();
+        let mut reader = StdBufReader::new(stream);
+        let mut response_line = String::new();
+        reader.read_line(&mut response_line).unwrap();
+        let response: serde_json::Value = serde_json::from_str(response_line.trim()).unwrap();
+        assert_eq!(response["ok"], json!(true));
+        assert_eq!(response["id"], json!("abc"));
+        assert_eq!(
+            response["result"],
+            json!({"action":"ping","payload":{"k":"v"}})
+        );
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        // Force the executor to wake up so the thread observes the stop
+        // flag — schedule one trivial task.
+        executor.spawn(async {}).detach();
+        let _ = runner_thread.join();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/native-ui/crates/attn-native-app/src/daemon_client.rs
+++ b/native-ui/crates/attn-native-app/src/daemon_client.rs
@@ -1,7 +1,13 @@
-use attn_protocol::{ServerEvent, Session, Workspace, PROTOCOL_VERSION};
+use attn_protocol::{
+    ClientHelloMessage, ServerEvent, Session, Workspace, CAPABILITY_SHELL_AS_SESSION,
+    PROTOCOL_VERSION,
+};
 use futures_util::{SinkExt, StreamExt};
 use gpui::{AsyncApp, Context, EventEmitter, WeakEntity};
 use serde::Serialize;
+use serde_json::json;
+
+use crate::automation::events;
 
 const DEFAULT_DAEMON_WS_URL: &str = "ws://localhost:9849/ws";
 
@@ -61,6 +67,21 @@ impl DaemonClient {
                     Ok((ws_stream, _)) => {
                         // Create a channel for outbound messages.
                         let (cmd_tx, cmd_rx) = async_channel::unbounded::<String>();
+
+                        // Identify ourselves before any other command. Daemon
+                        // gates per-client behavior on these capabilities;
+                        // shell_as_session is what makes spawned shells appear
+                        // as canvas panels (the Tauri app, which doesn't send
+                        // hello, retains the legacy "shell = utility terminal"
+                        // behavior).
+                        let hello = ClientHelloMessage::new(
+                            "native-canvas",
+                            env!("CARGO_PKG_VERSION"),
+                            vec![CAPABILITY_SHELL_AS_SESSION.to_string()],
+                        );
+                        if let Ok(text) = serde_json::to_string(&hello) {
+                            let _ = cmd_tx.try_send(text);
+                        }
 
                         let update_ok =
                             this.update(cx, |client: &mut DaemonClient, cx: &mut Context<DaemonClient>| {
@@ -155,6 +176,7 @@ impl DaemonClient {
     }
 
     fn handle_event(&mut self, event: ServerEvent, cx: &mut Context<Self>) {
+        record_inbound_event(&event);
         match event {
             ServerEvent::InitialState(msg) => {
                 if let Some(ref v) = msg.protocol_version {
@@ -292,4 +314,78 @@ impl DaemonClient {
     pub fn error(&self) -> Option<&str> {
         self.error.as_deref()
     }
+}
+
+/// Summarize an inbound `ServerEvent` and record it in the global event
+/// log. PtyOutput is excluded — at typical streaming rates it would
+/// dominate the ring buffer and crowd out lower-frequency events that are
+/// far more useful for diagnosing UI-level problems. Specific
+/// PTY-byte-count diagnosis can be added later as a separate higher-level
+/// event (e.g. "first output for session X received") if we need it.
+fn record_inbound_event(event: &ServerEvent) {
+    let payload = match event {
+        ServerEvent::InitialState(m) => json!({
+            "kind": "initial_state",
+            "session_count": m.sessions.len(),
+            "workspace_count": m.workspaces.len(),
+        }),
+        ServerEvent::SessionRegistered(m) => json!({
+            "kind": "session_registered",
+            "session_id": m.session.id.as_str(),
+            "workspace_id": m.session.workspace_id.as_deref(),
+            "agent": format!("{:?}", m.session.agent),
+        }),
+        ServerEvent::SessionUnregistered(m) => json!({
+            "kind": "session_unregistered",
+            "session_id": m.session.id.as_str(),
+        }),
+        ServerEvent::SessionStateChanged(m) => json!({
+            "kind": "session_state_changed",
+            "session_id": m.session.id.as_str(),
+            "state": format!("{:?}", m.session.state),
+        }),
+        ServerEvent::SessionsUpdated(m) => json!({
+            "kind": "sessions_updated",
+            "session_count": m.sessions.len(),
+        }),
+        ServerEvent::WorkspaceRegistered(m) => json!({
+            "kind": "workspace_registered",
+            "workspace_id": m.workspace.id.as_str(),
+            "title": m.workspace.title.as_str(),
+        }),
+        ServerEvent::WorkspaceUnregistered(m) => json!({
+            "kind": "workspace_unregistered",
+            "workspace_id": m.workspace.id.as_str(),
+        }),
+        ServerEvent::WorkspaceStateChanged(m) => json!({
+            "kind": "workspace_state_changed",
+            "workspace_id": m.workspace.id.as_str(),
+        }),
+        ServerEvent::AttachResult(m) => json!({
+            "kind": "attach_result",
+            "session_id": m.id.as_str(),
+            "success": m.success,
+            "has_snapshot": m.screen_snapshot.is_some(),
+            "replay_segments": m.replay_segments.as_ref().map(|s| s.len()).unwrap_or(0),
+            "last_seq": m.last_seq,
+        }),
+        ServerEvent::PtyDesync(m) => json!({
+            "kind": "pty_desync",
+            "session_id": m.id.as_str(),
+        }),
+        ServerEvent::PtyResized(m) => json!({
+            "kind": "pty_resized",
+            "session_id": m.id.as_str(),
+            "cols": m.cols,
+            "rows": m.rows,
+        }),
+        ServerEvent::SessionExited(m) => json!({
+            "kind": "session_exited",
+            "session_id": m.id.as_str(),
+            "exit_code": m.exit_code,
+        }),
+        ServerEvent::PtyOutput(_) => return,
+        ServerEvent::Unknown(name) => json!({"kind": "unknown", "event": name.as_str()}),
+    };
+    events::record("daemon_event", payload);
 }

--- a/native-ui/crates/attn-native-app/src/spike5_app.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_app.rs
@@ -6,10 +6,14 @@
 /// Layout: sidebar pinned left at fixed width, canvas fills the rest.
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use attn_protocol::{AttachSessionMessage, Session};
-use gpui::{div, prelude::*, rgb, Context, Entity, ParentElement, Render, SharedString, Window};
+use gpui::{div, prelude::*, rgb, App, Context, Entity, ParentElement, Render, SharedString, Window};
+use serde_json::{json, Value};
 
+use crate::automation;
+use crate::automation::events;
 use crate::daemon_client::{DaemonClient, DaemonEvent};
 use crate::panel::{Panel, PanelContent, TITLE_HEIGHT};
 use crate::sidebar::Sidebar;
@@ -30,23 +34,24 @@ pub struct Spike5App {
     sidebar: Entity<Sidebar>,
     canvas: Entity<Spike5Canvas>,
     selected_id: Option<SharedString>,
+    /// Live automation server handle. Drop deletes the manifest. `None`
+    /// when automation is disabled for this launch (default in prod) or
+    /// when bind/start failed — in which case we still want the app to
+    /// run, just without the test sidecar.
+    _automation: Option<automation::server::Handle>,
 }
 
 impl Spike5App {
     pub fn new(daemon: Entity<DaemonClient>, cx: &mut Context<Self>) -> Self {
         let canvas = cx.new(|cx| Spike5Canvas::new(cx));
-        let canvas_for_select = canvas.clone();
         let app_handle = cx.entity().downgrade();
         let sidebar = cx.new(|cx| {
             Sidebar::new(
                 Vec::new(),
                 move |id, _window, cx| {
                     let app_handle = app_handle.clone();
-                    let canvas = canvas_for_select.clone();
                     let _ = app_handle.update(cx, |app: &mut Spike5App, cx| {
-                        let ws = app.workspaces_by_id.get(&id).cloned();
-                        canvas.update(cx, |canvas, cx| canvas.set_selected(ws, cx));
-                        app.selected_id = Some(id);
+                        app.select_workspace(id, cx);
                     });
                 },
                 cx,
@@ -55,19 +60,36 @@ impl Spike5App {
 
         cx.subscribe(&daemon, |this, _client, event: &DaemonEvent, cx| match event {
             DaemonEvent::WorkspaceRegistered { workspace } => {
+                events::record(
+                    "workspace_registered_observed",
+                    json!({"workspace_id": workspace.id.as_str()}),
+                );
                 this.upsert_workspace(workspace.clone(), cx);
                 this.sync_terminal_panels(cx);
             }
             DaemonEvent::WorkspaceUnregistered { workspace_id } => {
+                events::record(
+                    "workspace_unregistered_observed",
+                    json!({"workspace_id": workspace_id.as_str()}),
+                );
                 this.remove_workspace(workspace_id.clone(), cx);
             }
             DaemonEvent::WorkspaceStateChanged { workspace } => {
+                events::record(
+                    "workspace_state_changed_observed",
+                    json!({"workspace_id": workspace.id.as_str()}),
+                );
                 this.apply_workspace_snapshot(workspace.clone(), cx);
             }
             DaemonEvent::SessionsChanged => {
+                events::record(
+                    "sessions_changed_observed",
+                    json!({"session_count": this.daemon.read(cx).sessions().len()}),
+                );
                 this.sync_terminal_panels(cx);
             }
             DaemonEvent::Connected => {
+                events::record("daemon_connected", json!({}));
                 // Daemon tracks PTY attachments per client connection,
                 // so on a fresh socket every existing TerminalView is
                 // detached on the daemon side until we re-issue
@@ -81,13 +103,90 @@ impl Spike5App {
         })
         .detach();
 
+        let automation_handle = if automation::automation_enabled() {
+            start_automation(cx)
+        } else {
+            None
+        };
+
         Self {
             daemon,
             workspaces_by_id: HashMap::new(),
             sidebar,
             canvas,
             selected_id: None,
+            _automation: automation_handle,
         }
+    }
+
+    /// Read-only handle to the daemon client, exposed so the automation
+    /// module can serialize wire-level workspace + session state without
+    /// cloning the lists out of `Spike5App`.
+    pub fn daemon(&self) -> &Entity<DaemonClient> {
+        &self.daemon
+    }
+
+    /// Lookup helper used by automation actions to target a specific
+    /// workspace by id without exposing the underlying map.
+    pub fn workspace(&self, id: &str) -> Option<Entity<Workspace>> {
+        self.workspaces_by_id
+            .get(&SharedString::from(id.to_string()))
+            .cloned()
+    }
+
+    /// Iterator over every live workspace handle. Used by automation
+    /// actions that need to scan panels across workspaces (e.g.
+    /// `read_pane_text` finding the terminal model for a given session).
+    pub fn workspaces(&self) -> impl Iterator<Item = &Entity<Workspace>> {
+        self.workspaces_by_id.values()
+    }
+
+    /// Switch the canvas + sidebar to the given workspace id. Shared by
+    /// the sidebar's click callback and the automation `select_workspace`
+    /// action so both paths produce identical state. No-op when `id`
+    /// doesn't match a known workspace.
+    pub fn select_workspace(&mut self, id: SharedString, cx: &mut Context<Self>) {
+        let Some(ws) = self.workspaces_by_id.get(&id).cloned() else {
+            events::record(
+                "workspace_select_missed",
+                json!({"id": id.as_ref(), "reason": "unknown_id"}),
+            );
+            return;
+        };
+        events::record("workspace_selected", json!({"id": id.as_ref()}));
+        let canvas = self.canvas.clone();
+        canvas.update(cx, |canvas, cx| canvas.set_selected(Some(ws), cx));
+        self.selected_id = Some(id.clone());
+        self.sidebar
+            .update(cx, |sidebar, cx| sidebar.set_selected(Some(id), cx));
+    }
+
+    /// Build a JSON snapshot of everything an external test script needs
+    /// to reason about: live wire state, the canvas's local UI state, and
+    /// which workspace is currently selected. Shape is the long-term
+    /// contract; new fields are added as automation needs grow.
+    pub fn automation_snapshot(&self, cx: &App) -> Value {
+        let daemon = self.daemon.read(cx);
+        let sessions = daemon.sessions();
+
+        let workspaces: Vec<Value> = self
+            .workspaces_by_id
+            .values()
+            .map(|ws| ws.read(cx).automation_snapshot())
+            .collect();
+
+        let canvas = self.canvas.read(cx).automation_snapshot();
+
+        json!({
+            "selected_workspace_id": self.selected_id.as_ref().map(|s| s.to_string()),
+            "workspaces": workspaces,
+            "sessions": serde_json::to_value(sessions).unwrap_or(Value::Null),
+            "canvas": canvas,
+            "daemon": {
+                "connected": daemon.connected(),
+                "error": daemon.error(),
+            },
+        })
     }
 
     fn upsert_workspace(&mut self, data: attn_protocol::Workspace, cx: &mut Context<Self>) {
@@ -167,15 +266,35 @@ impl Spike5App {
         let live_session_ids: std::collections::HashSet<&str> =
             sessions.iter().map(|s| s.id.as_str()).collect();
 
+        events::record(
+            "sync_terminal_panels_start",
+            json!({
+                "session_count": sessions.len(),
+                "workspace_count": self.workspaces_by_id.len(),
+            }),
+        );
+
         // Prune Terminal panels whose session is no longer alive on the
         // daemon. Dropping the panel drops the last handle to its
         // TerminalView, which detaches subscriptions for free.
         for ws_entity in self.workspaces_by_id.values().cloned().collect::<Vec<_>>() {
             ws_entity.update(cx, |ws, cx| {
+                let workspace_id = ws.id.to_string();
                 let before = ws.panels.len();
                 ws.panels.retain(|p| match &p.content {
                     PanelContent::Terminal { session_id, .. } => {
-                        live_session_ids.contains(session_id.as_ref())
+                        let alive = live_session_ids.contains(session_id.as_ref());
+                        if !alive {
+                            events::record(
+                                "panel_pruned",
+                                json!({
+                                    "workspace_id": workspace_id.as_str(),
+                                    "panel_id": p.id,
+                                    "session_id": session_id.as_ref(),
+                                }),
+                            );
+                        }
+                        alive
                     }
                     _ => true,
                 });
@@ -243,10 +362,21 @@ impl Spike5App {
                 width: TERMINAL_W,
                 height: TERMINAL_H,
                 content: PanelContent::Terminal {
-                    session_id: SharedString::from(session_id),
+                    session_id: SharedString::from(session_id.clone()),
                     view,
                 },
             };
+
+            let panel_id = panel.id;
+            events::record(
+                "panel_added",
+                json!({
+                    "workspace_id": ws_id,
+                    "panel_id": panel_id,
+                    "session_id": session_id.as_str(),
+                    "kind": "terminal",
+                }),
+            );
 
             ws_entity.update(cx, |ws, cx| {
                 ws.panels.push(panel);
@@ -282,4 +412,52 @@ fn panel_terminal_dims(world_w: f32, world_h: f32) -> (u16, u16) {
     let cols = ((world_w / CHAR_WIDTH) as u16).max(1);
     let rows = (((world_h - TITLE_HEIGHT) / ROW_HEIGHT) as u16).max(1);
     (cols, rows)
+}
+
+/// Bring up the UI automation TCP server + dispatch pump. Errors are
+/// logged but don't bubble up — automation is a dev/test affordance and
+/// shouldn't take down the app if (e.g.) the manifest dir is unwritable.
+fn start_automation(cx: &mut Context<Spike5App>) -> Option<automation::server::Handle> {
+    let listener = match automation::server::bind() {
+        Ok(l) => l,
+        Err(error) => {
+            eprintln!("[automation] bind failed: {error}");
+            return None;
+        }
+    };
+
+    let manifest_path = automation::manifest_path();
+    let (dispatcher, rx) = automation::actions::make_dispatcher();
+
+    // Spawn the wire-protocol layer onto GPUI's background executor. The
+    // executor is multi-threaded and `Send`, so the closure stored in
+    // the `Spawner` can hand futures to it from anywhere.
+    let bg = cx.background_executor().clone();
+    let spawner: automation::server::Spawner = Arc::new(move |fut| {
+        bg.spawn(fut).detach();
+    });
+
+    let handle = match automation::server::start(listener, manifest_path, dispatcher, spawner) {
+        Ok(h) => h,
+        Err(error) => {
+            eprintln!("[automation] start failed: {error}");
+            return None;
+        }
+    };
+
+    // Drive the foreground-side action pump on GPUI's main thread so
+    // handlers can read entity state. Detached: it loops until the
+    // dispatcher's channel closes (which happens when the server handle
+    // is dropped on app shutdown).
+    let app_handle = cx.entity().downgrade();
+    cx.spawn(async move |_, cx| {
+        automation::actions::pump_actions(rx, app_handle, cx.clone()).await;
+    })
+    .detach();
+
+    eprintln!(
+        "[automation] listening — manifest at {}",
+        handle.manifest_path().display()
+    );
+    Some(handle)
 }

--- a/native-ui/crates/attn-native-app/src/spike5_canvas.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_canvas.rs
@@ -17,6 +17,8 @@ use gpui::{
     Render, ScrollDelta, ScrollWheelEvent, SharedString, Subscription, Window,
 };
 
+use serde_json::{json, Value};
+
 use crate::canvas_view::{pf, GridElement, Viewport};
 use crate::panel::{Panel, PanelContent, TITLE_HEIGHT};
 use crate::workspace::Workspace;
@@ -91,6 +93,30 @@ impl Spike5Canvas {
             Some(b) => point(screen.x - b.origin.x, screen.y - b.origin.y),
             None => screen,
         }
+    }
+
+    /// JSON view used by the UI automation server. Captures viewport,
+    /// focus, and the canvas's window-relative bounds so test scripts
+    /// can translate world coordinates into screen pixels for OS-level
+    /// input.
+    pub fn automation_snapshot(&self) -> Value {
+        let bounds = self.bounds.get().map(|b| {
+            json!({
+                "x": pf(b.origin.x),
+                "y": pf(b.origin.y),
+                "width": pf(b.size.width),
+                "height": pf(b.size.height),
+            })
+        });
+        json!({
+            "viewport": {
+                "origin_x": self.viewport.origin.x,
+                "origin_y": self.viewport.origin.y,
+                "zoom": self.viewport.zoom,
+            },
+            "focused_panel_id": self.focused_panel,
+            "bounds": bounds,
+        })
     }
 
     pub fn set_selected(&mut self, ws: Option<Entity<Workspace>>, cx: &mut Context<Self>) {

--- a/native-ui/crates/attn-native-app/src/spike5_main.rs
+++ b/native-ui/crates/attn-native-app/src/spike5_main.rs
@@ -1,5 +1,6 @@
 /// Workspace canvas entry point — sidebar + pannable canvas with live
 /// terminal panels driven by the daemon. Run with: `cargo run --bin attn-spike5`.
+mod automation;
 mod canvas_view;
 mod daemon_client;
 mod panel;

--- a/native-ui/crates/attn-native-app/src/terminal_model.rs
+++ b/native-ui/crates/attn-native-app/src/terminal_model.rs
@@ -8,9 +8,11 @@ use alacritty_terminal::{
 };
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use gpui::{Context, Entity, EventEmitter};
+use serde_json::json;
 
 use attn_protocol::AttachResultMessage;
 
+use crate::automation::events;
 use crate::daemon_client::{DaemonClient, DaemonEvent};
 
 /// Emitted when the terminal screen content changes and needs to be repainted.
@@ -92,6 +94,18 @@ impl TerminalModel {
     }
 
     fn handle_attach_result(&mut self, msg: &AttachResultMessage, cx: &mut Context<Self>) {
+        events::record(
+            "terminal_attach_processed",
+            json!({
+                "session_id": self.session_id.as_str(),
+                "success": msg.success,
+                "has_snapshot": msg.screen_snapshot.is_some(),
+                "replay_segments": msg.replay_segments.as_ref().map(|s| s.len()).unwrap_or(0),
+                "last_seq": msg.last_seq,
+                "cols": msg.cols,
+                "rows": msg.rows,
+            }),
+        );
         if !msg.success {
             return;
         }
@@ -168,6 +182,34 @@ impl TerminalModel {
     pub fn cursor(&self) -> (usize, usize) {
         let point = self.term.grid().cursor.point;
         (point.column.0, point.line.0 as usize)
+    }
+
+    /// Plain-text snapshot of the current screen, one row per Vec entry.
+    /// Used by the automation `read_pane_text` action so scenarios can
+    /// assert that typed input survived the PTY round-trip. Trailing
+    /// space-only rows are kept (callers can trim) so callers see the
+    /// real screen geometry.
+    pub fn screen_text(&self) -> Vec<String> {
+        let grid = self.term.grid();
+        let lines = grid.screen_lines();
+        let cols = grid.columns();
+        let mut out = Vec::with_capacity(lines);
+        for row in 0..lines {
+            let line = Line(row as i32 - grid.display_offset() as i32);
+            let mut s = String::with_capacity(cols);
+            for col in 0..cols {
+                let cell: &Cell = &grid[line][Column(col)];
+                s.push(cell.c);
+            }
+            // Trailing spaces on a row are noise for substring matching;
+            // trim them but keep the row entry so row indices line up
+            // with what the user sees on screen.
+            while s.ends_with(' ') {
+                s.pop();
+            }
+            out.push(s);
+        }
+        out
     }
 
     /// Render a single row as a sequence of (character, fg_color, is_cursor) triples.

--- a/native-ui/crates/attn-native-app/src/terminal_view.rs
+++ b/native-ui/crates/attn-native-app/src/terminal_view.rs
@@ -303,6 +303,13 @@ impl Focusable for TerminalView {
 }
 
 impl TerminalView {
+    /// Read-only handle to the underlying terminal model. Used by the
+    /// automation `read_pane_text` action to dump the visible grid for
+    /// scenario assertions.
+    pub fn model(&self) -> &Entity<TerminalModel> {
+        &self.terminal
+    }
+
     pub fn new(
         terminal: Entity<TerminalModel>,
         daemon: Entity<DaemonClient>,

--- a/native-ui/crates/attn-native-app/src/workspace.rs
+++ b/native-ui/crates/attn-native-app/src/workspace.rs
@@ -9,8 +9,10 @@
 /// the daemon doesn't know or care about.
 use attn_protocol::{Workspace as ProtocolWorkspace, WorkspaceStatus};
 use gpui::{Context, EventEmitter, SharedString};
+use serde_json::{json, Value};
 
-use crate::panel::Panel;
+use crate::automation::events;
+use crate::panel::{Panel, PanelContent};
 
 /// Emitted when the workspace's wire-level data changes (rolled-up status,
 /// title, directory). Subscribers are the sidebar (status badge) and the
@@ -39,6 +41,78 @@ impl Workspace {
         }
     }
 
+    /// JSON view used by the UI automation server. Pulled into the
+    /// workspace itself so the snapshot shape lives next to the data;
+    /// callers (`Spike5App::automation_snapshot`) just stitch them
+    /// together.
+    pub fn automation_snapshot(&self) -> Value {
+        let panels: Vec<Value> = self.panels.iter().map(panel_snapshot).collect();
+        json!({
+            "id": self.id.to_string(),
+            "title": self.title.to_string(),
+            "directory": self.directory.to_string(),
+            "status": self.status.to_string(),
+            "panels": panels,
+        })
+    }
+
+    /// Apply a partial update to a panel by id. Used by the automation
+    /// `move_panel` action. Returns the post-update panel snapshot when
+    /// the panel exists, `None` otherwise. Notifies subscribers when any
+    /// field actually changes so the canvas re-renders.
+    pub fn update_panel(
+        &mut self,
+        panel_id: usize,
+        world_x: Option<f32>,
+        world_y: Option<f32>,
+        width: Option<f32>,
+        height: Option<f32>,
+        cx: &mut Context<Self>,
+    ) -> Option<Value> {
+        let workspace_id = self.id.clone();
+        let panel = self.panels.iter_mut().find(|p| p.id == panel_id)?;
+        let mut changed = false;
+        if let Some(x) = world_x {
+            if (panel.world_x - x).abs() > f32::EPSILON {
+                panel.world_x = x;
+                changed = true;
+            }
+        }
+        if let Some(y) = world_y {
+            if (panel.world_y - y).abs() > f32::EPSILON {
+                panel.world_y = y;
+                changed = true;
+            }
+        }
+        if let Some(w) = width {
+            if (panel.width - w).abs() > f32::EPSILON {
+                panel.width = w;
+                changed = true;
+            }
+        }
+        if let Some(h) = height {
+            if (panel.height - h).abs() > f32::EPSILON {
+                panel.height = h;
+                changed = true;
+            }
+        }
+        if changed {
+            events::record(
+                "panel_updated",
+                json!({
+                    "workspace_id": workspace_id.as_ref(),
+                    "panel_id": panel.id,
+                    "world_x": panel.world_x,
+                    "world_y": panel.world_y,
+                    "width": panel.width,
+                    "height": panel.height,
+                }),
+            );
+            cx.notify();
+        }
+        Some(panel_snapshot(panel))
+    }
+
     /// Apply a fresh wire snapshot. Returns true if anything user-visible
     /// changed — caller decides whether to `cx.emit` + `cx.notify`.
     pub fn apply_snapshot(&mut self, data: ProtocolWorkspace, cx: &mut Context<Self>) {
@@ -60,4 +134,21 @@ impl Workspace {
             cx.notify();
         }
     }
+}
+
+fn panel_snapshot(panel: &Panel) -> Value {
+    let (kind, session_id) = match &panel.content {
+        PanelContent::Terminal { session_id, .. } => ("terminal", Some(session_id.to_string())),
+        PanelContent::Placeholder(_) => ("placeholder", None),
+    };
+    json!({
+        "id": panel.id,
+        "kind": kind,
+        "title": panel.title.to_string(),
+        "session_id": session_id,
+        "world_x": panel.world_x,
+        "world_y": panel.world_y,
+        "width": panel.width,
+        "height": panel.height,
+    })
 }

--- a/native-ui/crates/attn-protocol/src/commands.rs
+++ b/native-ui/crates/attn-protocol/src/commands.rs
@@ -14,6 +14,29 @@ impl QueryMessage {
 }
 
 #[derive(Debug, Serialize)]
+pub struct ClientHelloMessage {
+    pub cmd: &'static str,
+    pub client_kind: String,
+    pub version: String,
+    pub capabilities: Vec<String>,
+}
+
+impl ClientHelloMessage {
+    pub fn new(
+        client_kind: impl Into<String>,
+        version: impl Into<String>,
+        capabilities: Vec<String>,
+    ) -> Self {
+        Self {
+            cmd: "client_hello",
+            client_kind: client_kind.into(),
+            version: version.into(),
+            capabilities,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
 pub struct AttachSessionMessage {
     pub cmd: &'static str,
     pub id: String,

--- a/native-ui/crates/attn-protocol/src/lib.rs
+++ b/native-ui/crates/attn-protocol/src/lib.rs
@@ -14,4 +14,8 @@ pub use types::*;
 
 /// Current protocol version — must match `ProtocolVersion` in
 /// `internal/protocol/constants.go`.
-pub const PROTOCOL_VERSION: &str = "56";
+pub const PROTOCOL_VERSION: &str = "57";
+
+/// Capability strings advertised in `ClientHelloMessage.capabilities`.
+/// Mirror of `protocol.Capability*` in `internal/protocol/constants.go`.
+pub const CAPABILITY_SHELL_AS_SESSION: &str = "shell_as_session";


### PR DESCRIPTION
## Summary

- Adds a TCP automation sidecar to the GPUI native canvas app (`attn-spike5`) matching the Tauri bridge wire format, so external test scripts can drive both apps with the same client. Ships with a full end-to-end harness scenario (`make scenario-native-canvas`) that exercises plumbing, panel manipulation, and a PTY round-trip against the live binary. Action set: `ping`, `get_state`, `list_sessions`, `get_window_geometry`, `select_workspace`, `move_panel`, `send_pty_input`, `read_pane_text`, `tail_events`.
- Introduces a `client_hello` handshake on the daemon websocket so clients can advertise capabilities at connect time. Native canvas advertises `shell_as_session` (treats shell agents as first-class workspace sessions); Tauri sends no capabilities and continues filtering shell-as-session out of its sidebar. Protocol bumps 56 → 57.
- Structured event tap (`tail_events`) — cursor-based ring buffer of in-process events for scenarios that need to verify side-effects beyond what `get_state` can show. Caught the bug that drove this PR: panels weren't appearing for shell agents because the daemon wasn't broadcasting `session_registered` for them, fixed by the capability handshake.
- Automation gating moves from compile-time to runtime (`ATTN_AUTOMATION` + `ATTN_PROFILE`); `build-app-ui-automation` Make target is gone. The bridge token also moves from a predictable pid+nanos string to 32 OS-random bytes hex-encoded. **Breaking**: anyone relying on automation against a prod source install must now launch with `ATTN_AUTOMATION=1`.
- Server now echoes the wire `id` (string/number/bool) on malformed request errors so multiplexing clients can correlate the failure to their pending request. Previously the error went to a synthetic id no client could match, hanging the request silently until timeout. New regression test: `echoes_id_when_type_mismatched`.

## Test plan

- [x] `cargo test -p attn-native-app --bin attn-spike5` — 19 passed (was 18; one new test for id-echo behavior)
- [x] `go build ./...` clean
- [x] `make generate-types` — no drift
- [x] Frontend tests at parity with baseline (5 pre-existing `App.worktreeCleanup` failures unchanged)
- [x] `make scenario-native-canvas` — passes against live binary; covers plumbing (`ping`, token enforcement, unknown-action error, geometry, state shape, `tail_events`), `move_panel`, `select_workspace`, and a full PTY round-trip with `panel_added` event verification
- [x] Manually verified canvas renders panel moves and shell session spawn — screenshots confirm visual state matches data state