### PR TITLE
[codex] Add native workspace management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run build build-linux-amd64 build-linux-arm64 install install-daemon install-dev install-daemon-dev dev test test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app build-app-dev app-screenshot scenario-native-canvas dist release release-skip-tests
+.PHONY: run build build-linux-amd64 build-linux-arm64 install install-daemon install-dev install-daemon-dev dev dev-native test test-v test-quick test-watch test-all test-frontend test-e2e test-harness clean generate-types check-types build-app build-app-dev app-screenshot scenario-native-canvas dist release release-skip-tests
 
 # Bare `make` does the full prod inner loop: install + open the app.
 # `make install` is install-only (for scripts/CI that drive the launch
@@ -211,12 +211,28 @@ build-app-dev: build
 app-screenshot:
 	cd app && node scripts/real-app-harness/capture-app-screenshot.mjs $(if $(SCREENSHOT_PATH),--path "$(SCREENSHOT_PATH)",) $(APP_SCREENSHOT_FLAGS)
 
+# Run the native canvas app from source against the dev daemon, with
+# automation enabled (ATTN_PROFILE=dev). Self-sufficient: builds the Go
+# binary, ad-hoc codesigns it (so macOS doesn't SIGKILL the spawned
+# daemon), ensures a dev daemon is running on port 29849, then launches
+# the native app via cargo run. `daemon ensure` is idempotent — if a dev
+# daemon is already running (e.g. from `make dev`), it's a no-op and the
+# native app reuses it. Prod daemon is never touched.
+#
+# The bin name is `attn-native`; swap to `attn-spike3/4/5` to run an
+# older spike side-by-side without rebuilding the main binary.
+dev-native: build
+	@echo ">>> Ensuring dev daemon (profile=dev, port=29849, data=~/.attn-dev)"
+	@if [ "$(UNAME_S)" = "Darwin" ]; then codesign -s - -f $(OUTPUT) >/dev/null 2>&1 || true; fi
+	@ATTN_PROFILE=dev ./$(OUTPUT) daemon ensure >/dev/null
+	@echo ">>> Launching attn-native (profile=dev, daemon=ws://localhost:29849/ws)"
+	cd native-ui && ATTN_PROFILE=dev ATTN_WS_URL=ws://localhost:29849/ws cargo run --bin attn-native
+
 # End-to-end scenario for the native canvas app driven through its UI
-# automation sidecar. Assumes a native binary is already running with
-# automation enabled — typically:
-#   ATTN_PROFILE=dev ATTN_WS_URL=ws://localhost:29849/ws \
-#     cargo run --manifest-path native-ui/Cargo.toml --bin attn-spike5
-# The script reads ATTN_PROFILE itself to find the matching manifest.
+# automation sidecar. Assumes the native binary is already running with
+# automation enabled — `make dev-native` in another terminal sets up the
+# right env. The script reads ATTN_PROFILE itself to find the matching
+# manifest at ~/Library/Application Support/com.attn.native.dev/.
 scenario-native-canvas:
 	cd app && node scripts/real-app-harness/scenario-native-canvas.mjs
 

--- a/app/scripts/real-app-harness/scenario-native-canvas.mjs
+++ b/app/scripts/real-app-harness/scenario-native-canvas.mjs
@@ -2,17 +2,23 @@
 /**
  * Behavioral scenario for the native canvas app driven through its UI
  * automation sidecar. Assumes the native binary is already running with
- * automation enabled (e.g. `ATTN_PROFILE=dev cargo run --bin attn-spike5`).
+ * automation enabled (e.g. `ATTN_PROFILE=dev cargo run --bin attn-native`).
  *
  * Coverage:
  *   - wire plumbing: manifest discovery, ping, token rejection, unknown
  *     actions, get_state shape, list_sessions consistency, window geom
  *   - mutate spatial state: move_panel + assert post-state
  *   - mutate selection: select_workspace happy path + bogus id error
+ *   - workspace lifecycle: create_workspace + destroy_workspace, asserting
+ *     both get_state convergence and the observation events that prove
+ *     the canvas sync path executed (not just the daemon ack)
  *   - end-to-end PTY: spawn an `agent=shell` session via the daemon WS,
- *     wait for it to attach as a canvas panel, send `echo HELLO-<uuid>`,
- *     poll read_pane_text until the marker appears, unregister the
- *     session, confirm cleanup
+ *     wait for it to attach as a canvas panel, exercise BOTH input
+ *     paths back-to-back — `send_pty_input` (direct daemon route) and
+ *     `type_into_panel` (through TerminalView::on_key_down so a
+ *     regression in focus or key encoding trips the second case but
+ *     not the first) — poll read_pane_text for the marker, unregister
+ *     the session, confirm cleanup
  *
  * Tearing down: every resource the scenario creates is unregistered in
  * `finally` blocks, even on assertion failure.
@@ -434,7 +440,6 @@ async function checkPtyRoundTrip(conn, daemon) {
     return;
   }
   const cwd = ws.directory || process.env.HOME || '/tmp';
-  const marker = `MARK-${crypto.randomUUID().slice(0, 8)}`;
 
   // Capture the event cursor BEFORE spawning so we can prove (or refute)
   // that every step of the chain — daemon broadcast, app receipt, panel
@@ -448,7 +453,7 @@ async function checkPtyRoundTrip(conn, daemon) {
     // us assert on the actual UI transition rather than poll-until-state-
     // converges; on failure we'll dump every event since spawn so we can
     // see exactly where the chain stopped (daemon broadcast?
-    // Spike5App SessionsChanged? sync_terminal_panels?).
+    // NativeApp SessionsChanged? sync_terminal_panels?).
     try {
       await pollUntil(
         async () => {
@@ -469,44 +474,17 @@ async function checkPtyRoundTrip(conn, daemon) {
     }
     info(`  panel attached`);
 
-    // Capture another cursor so the type-and-echo step gets its own
-    // diagnostic window if it fails.
-    const cursorBeforeType = (await tailEvents(conn)).next_cursor;
-
-    // Type the marker. Newline triggers the shell to execute echo, so
-    // the marker shows up on the screen via shell echo.
-    const sent = await conn.request('send_pty_input', {
+    // Exercise both input paths back-to-back. send_pty_input bypasses
+    // GPUI entirely (constructs the wire message in the action handler);
+    // type_into_panel routes through TerminalView::on_key_down so a
+    // regression in focus, key encoding, or the keystroke→send_input
+    // chain trips this case but not the first.
+    await sendAndExpectMarker(conn, sessionId, 'send_pty_input', {
       session_id: sessionId,
-      text: `echo ${marker}\n`,
     });
-    if (!sent.ok) fail(`send_pty_input: ${sent.error}`);
-
-    // Poll read_pane_text until the marker is present somewhere.
-    try {
-      await pollUntil(
-        async () => {
-          const r = await conn.request('read_pane_text', { session_id: sessionId });
-          if (!r.ok) return false;
-          return r.result.text.includes(marker);
-        },
-        { timeoutMs: 5000, label: `marker ${marker} on screen` },
-      );
-    } catch (error) {
-      await dumpEventsSince(conn, cursorBeforeType, 'send_pty_input');
-      // Also dump the current screen text — the most likely failure mode
-      // is "input arrived but the shell hasn't echoed it back yet".
-      try {
-        const pane = await conn.request('read_pane_text', { session_id: sessionId });
-        if (pane.ok) {
-          console.error(`current screen rows:`);
-          for (const row of pane.result.rows.slice(-10)) {
-            console.error(`  ${JSON.stringify(row)}`);
-          }
-        }
-      } catch (_) {}
-      throw error;
-    }
-    info(`  ok (typed and echoed ${marker})`);
+    await sendAndExpectMarker(conn, sessionId, 'type_into_panel', {
+      session_id: sessionId,
+    });
   } finally {
     await daemon.unregisterSession(sessionId).catch(() => {});
     try {
@@ -521,6 +499,148 @@ async function checkPtyRoundTrip(conn, daemon) {
       info(`  cleanup ok (panel + session removed)`);
     } catch (cleanupError) {
       console.error(`WARNING: ${cleanupError.message}`);
+    }
+  }
+}
+
+/**
+ * Send `echo <marker>\n` via the named action and wait for the marker to
+ * appear on screen. Both `send_pty_input` and `type_into_panel` accept the
+ * same `{ session_id, text }` shape, so the only thing that varies between
+ * paths is the action name.
+ */
+async function sendAndExpectMarker(conn, sessionId, action, baseArgs) {
+  const marker = `MARK-${action}-${crypto.randomUUID().slice(0, 8)}`;
+  const cursorBefore = (await tailEvents(conn)).next_cursor;
+
+  const sent = await conn.request(action, {
+    ...baseArgs,
+    text: `echo ${marker}\n`,
+  });
+  if (!sent.ok) fail(`${action}: ${sent.error}`);
+
+  try {
+    await pollUntil(
+      async () => {
+        const r = await conn.request('read_pane_text', { session_id: sessionId });
+        if (!r.ok) return false;
+        return r.result.text.includes(marker);
+      },
+      { timeoutMs: 5000, label: `marker ${marker} on screen via ${action}` },
+    );
+  } catch (error) {
+    await dumpEventsSince(conn, cursorBefore, action);
+    // Also dump the current screen text — the most likely failure mode
+    // is "input arrived but the shell hasn't echoed it back yet".
+    try {
+      const pane = await conn.request('read_pane_text', { session_id: sessionId });
+      if (pane.ok) {
+        console.error(`current screen rows:`);
+        for (const row of pane.result.rows.slice(-10)) {
+          console.error(`  ${JSON.stringify(row)}`);
+        }
+      }
+    } catch (_) {}
+    throw error;
+  }
+  info(`  ok (${action}: typed and echoed ${marker})`);
+}
+
+/**
+ * Round-trip workspace registration through `create_workspace` /
+ * `destroy_workspace` against the live daemon. Asserts both that
+ * `get_state` reflects the new workspace (so the canvas observed the
+ * daemon broadcast) and that `tail_events` fired
+ * `workspace_registered_observed` / `workspace_unregistered_observed`
+ * (so the path through `NativeApp::DaemonEvent::WorkspaceRegistered`
+ * actually executed — not just the daemon ack).
+ */
+async function checkWorkspaceLifecycle(conn) {
+  const cursorBefore = (await tailEvents(conn)).next_cursor;
+
+  const directory = `/tmp/attn-scenario-ws-${crypto.randomUUID().slice(0, 8)}`;
+  const title = `Scenario WS ${new Date().toISOString().slice(11, 19)}`;
+  const created = await conn.request('create_workspace', { directory, title });
+  if (!created.ok) fail(`create_workspace: ${created.error}`);
+  const wsId = created.result.id;
+  if (typeof wsId !== 'string' || wsId.length < 16) {
+    fail(`create_workspace returned suspicious id: ${JSON.stringify(created.result)}`);
+  }
+  info(`  created workspace ${wsId.slice(0, 8)}…`);
+
+  let cleanupNeeded = true;
+  try {
+    // Wait for the workspace to land in get_state — proves the canvas
+    // observed the daemon's workspace_registered broadcast and updated
+    // its workspace map.
+    try {
+      await pollUntil(
+        async () => {
+          const s = await conn.request('get_state');
+          return (
+            s.ok &&
+            s.result.workspaces?.some((w) => w.id === wsId) &&
+            s.result.selected_workspace_id === wsId
+          );
+        },
+        {
+          timeoutMs: 5000,
+          intervalMs: 100,
+          label: `workspace ${wsId.slice(0, 8)} in get_state and selected`,
+        },
+      );
+    } catch (error) {
+      await dumpEventsSince(conn, cursorBefore, 'create_workspace');
+      throw error;
+    }
+
+    // Confirm the corresponding observation event fired. Catches the
+    // failure mode where get_state is right because of a fresh poll but
+    // the event-driven sync path silently broke.
+    const tail = await tailEvents(conn, cursorBefore);
+    const observed = tail.events.find(
+      (e) => e.category === 'workspace_registered_observed' && e.payload.workspace_id === wsId,
+    );
+    if (!observed) {
+      await dumpEventsSince(conn, cursorBefore, 'create_workspace');
+      fail(`no workspace_registered_observed event for ${wsId}`);
+    }
+    info(`  observed workspace_registered_observed for ${wsId.slice(0, 8)}…`);
+
+    // Tear down through the same wire surface and assert the inverse.
+    const cursorBeforeDestroy = (await tailEvents(conn)).next_cursor;
+    const destroyed = await conn.request('destroy_workspace', { id: wsId });
+    if (!destroyed.ok) fail(`destroy_workspace: ${destroyed.error}`);
+    cleanupNeeded = false;
+
+    try {
+      await pollUntil(
+        async () => {
+          const s = await conn.request('get_state');
+          return s.ok && !s.result.workspaces?.some((w) => w.id === wsId);
+        },
+        { timeoutMs: 5000, intervalMs: 100, label: `workspace ${wsId.slice(0, 8)} gone from get_state` },
+      );
+    } catch (error) {
+      await dumpEventsSince(conn, cursorBeforeDestroy, 'destroy_workspace');
+      throw error;
+    }
+
+    const tailAfter = await tailEvents(conn, cursorBeforeDestroy);
+    const unregistered = tailAfter.events.find(
+      (e) =>
+        e.category === 'workspace_unregistered_observed' && e.payload.workspace_id === wsId,
+    );
+    if (!unregistered) {
+      await dumpEventsSince(conn, cursorBeforeDestroy, 'destroy_workspace');
+      fail(`no workspace_unregistered_observed event for ${wsId}`);
+    }
+    info(`  ok (created ${wsId.slice(0, 8)}, observed both lifecycle events, destroyed)`);
+  } finally {
+    if (cleanupNeeded) {
+      // destroy_workspace is idempotent on the daemon, so a best-effort
+      // cleanup on assertion failure won't double-fault.
+      await conn.request('destroy_workspace', { id: wsId }).catch(() => {});
     }
   }
 }
@@ -551,6 +671,9 @@ async function main() {
 
     info(`\n[select_workspace]`);
     await checkSelectWorkspace(conn);
+
+    info(`\n[workspace lifecycle]`);
+    await checkWorkspaceLifecycle(conn);
 
     info(`\n[pty round-trip]`);
     await checkPtyRoundTrip(conn, daemon);

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -77,7 +77,16 @@ impl NativeApp {
                 move |id, _window, cx| {
                     let app_handle = app_handle_destroy.clone();
                     let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
-                        app.unregister_workspace_by_id(id, cx);
+                        let id_for_event = id.clone();
+                        if let Err(error) = app.unregister_workspace_by_id(id, cx) {
+                            events::record(
+                                "workspace_destroy_failed",
+                                json!({
+                                    "id": id_for_event.as_ref(),
+                                    "error": error,
+                                }),
+                            );
+                        }
                     });
                 },
                 cx,
@@ -216,14 +225,32 @@ impl NativeApp {
                 .unwrap_or_else(|| directory.clone());
             let id = generate_workspace_id();
             let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
-                events::record(
-                    "workspace_create_submitted",
-                    json!({
-                        "id": id.as_str(),
-                        "directory": directory.as_str(),
-                    }),
-                );
-                app.register_workspace_and_select(id.clone(), title.clone(), directory.clone(), cx);
+                match app.register_workspace_and_select(
+                    id.clone(),
+                    title.clone(),
+                    directory.clone(),
+                    cx,
+                ) {
+                    Ok(()) => {
+                        events::record(
+                            "workspace_create_submitted",
+                            json!({
+                                "id": id.as_str(),
+                                "directory": directory.as_str(),
+                            }),
+                        );
+                    }
+                    Err(error) => {
+                        events::record(
+                            "workspace_create_failed",
+                            json!({
+                                "id": id.as_str(),
+                                "directory": directory.as_str(),
+                                "error": error,
+                            }),
+                        );
+                    }
+                }
             });
         })
         .detach();
@@ -238,23 +265,30 @@ impl NativeApp {
         title: String,
         directory: String,
         cx: &Context<Self>,
-    ) {
-        self.pending_select_workspace_ids
-            .insert(SharedString::from(id.clone()));
+    ) -> Result<(), String> {
         self.daemon
             .read(cx)
-            .send_cmd(&RegisterWorkspaceMessage::new(id, title, directory));
+            .send_cmd(&RegisterWorkspaceMessage::new(id.clone(), title, directory))?;
+        self.pending_select_workspace_ids
+            .insert(SharedString::from(id));
+        Ok(())
     }
 
     /// Send `unregister_workspace` for the given id. Daemon cascades
     /// (kills member sessions, broadcasts unregister), so the canvas +
     /// sidebar update reactively. No confirmation dialog yet — see plan
     /// doc M1.0; revisit when destroy gets a richer affordance.
-    pub fn unregister_workspace_by_id(&self, id: SharedString, cx: &Context<Self>) {
-        events::record("workspace_destroy_submitted", json!({"id": id.as_ref()}));
+    pub fn unregister_workspace_by_id(
+        &self,
+        id: SharedString,
+        cx: &Context<Self>,
+    ) -> Result<(), String> {
+        let id_string = id.to_string();
         self.daemon
             .read(cx)
-            .send_cmd(&UnregisterWorkspaceMessage::new(id.to_string()));
+            .send_cmd(&UnregisterWorkspaceMessage::new(id_string.clone()))?;
+        events::record("workspace_destroy_submitted", json!({"id": id_string.as_str()}));
+        Ok(())
     }
 
     /// Switch the canvas + sidebar to the given workspace id. Shared by
@@ -390,7 +424,7 @@ impl NativeApp {
         for ws_entity in self.workspaces_by_id.values() {
             for panel in ws_entity.read(cx).panels.iter() {
                 if let PanelContent::Terminal { session_id, .. } = &panel.content {
-                    daemon.send_cmd(&AttachSessionMessage::new(session_id.to_string()));
+                    let _ = daemon.send_cmd(&AttachSessionMessage::new(session_id.to_string()));
                 }
             }
         }
@@ -498,7 +532,8 @@ impl NativeApp {
 
             // Send attach. The TerminalView's render path will emit the
             // initial PtyResize once it sees its first content_size.
-            self.daemon
+            let _ = self
+                .daemon
                 .read(cx)
                 .send_cmd(&AttachSessionMessage::new(session_id.clone()));
 

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -4,15 +4,21 @@
 /// vanish on the wire.
 ///
 /// Layout: sidebar pinned left at fixed width, canvas fills the rest.
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use attn_protocol::{AttachSessionMessage, Session};
-use gpui::{div, prelude::*, rgb, App, Context, Entity, ParentElement, Render, SharedString, Window};
+use attn_protocol::{
+    AttachSessionMessage, RegisterWorkspaceMessage, Session, UnregisterWorkspaceMessage,
+};
+use gpui::{
+    div, prelude::*, rgb, App, Context, Entity, ParentElement, PathPromptOptions, Render,
+    SharedString, Window,
+};
 use serde_json::{json, Value};
 
 use crate::automation;
+use crate::automation::actions::generate_workspace_id;
 use crate::automation::events;
 use crate::canvas::WorkspaceCanvas;
 use crate::daemon_client::{DaemonClient, DaemonEvent};
@@ -34,6 +40,7 @@ pub struct NativeApp {
     sidebar: Entity<Sidebar>,
     canvas: Entity<WorkspaceCanvas>,
     selected_id: Option<SharedString>,
+    pending_select_workspace_ids: HashSet<SharedString>,
     /// Live automation server handle. Drop deletes the manifest. `None`
     /// when automation is disabled for this launch (default in prod) or
     /// when bind/start failed — in which case we still want the app to
@@ -50,13 +57,27 @@ impl NativeApp {
     pub fn new(daemon: Entity<DaemonClient>, cx: &mut Context<Self>) -> Self {
         let canvas = cx.new(|cx| WorkspaceCanvas::new(cx));
         let app_handle = cx.entity().downgrade();
+        let app_handle_create = app_handle.clone();
+        let app_handle_destroy = app_handle.clone();
         let sidebar = cx.new(|cx| {
             Sidebar::new(
                 Vec::new(),
                 move |id, _window, cx| {
                     let app_handle = app_handle.clone();
                     let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
-                        app.select_workspace(id, cx);
+                        app.select_workspace_from_sidebar(id, cx);
+                    });
+                },
+                move |_window, cx| {
+                    let app_handle = app_handle_create.clone();
+                    let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
+                        app.prompt_and_register_workspace(cx);
+                    });
+                },
+                move |id, _window, cx| {
+                    let app_handle = app_handle_destroy.clone();
+                    let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
+                        app.unregister_workspace_by_id(id, cx);
                     });
                 },
                 cx,
@@ -70,6 +91,7 @@ impl NativeApp {
                     json!({"workspace_id": workspace.id.as_str()}),
                 );
                 this.upsert_workspace(workspace.clone(), cx);
+                this.select_workspace_if_pending(&workspace.id, cx);
                 this.sync_terminal_panels(cx);
             }
             DaemonEvent::WorkspaceUnregistered { workspace_id } => {
@@ -85,6 +107,7 @@ impl NativeApp {
                     json!({"workspace_id": workspace.id.as_str()}),
                 );
                 this.apply_workspace_snapshot(workspace.clone(), cx);
+                this.select_workspace_if_pending(&workspace.id, cx);
             }
             DaemonEvent::SessionsChanged => {
                 events::record(
@@ -120,6 +143,7 @@ impl NativeApp {
             sidebar,
             canvas,
             selected_id: None,
+            pending_select_workspace_ids: HashSet::new(),
             _automation: automation_handle,
             synthetic: Vec::new(),
         };
@@ -161,11 +185,98 @@ impl NativeApp {
         self.workspaces_by_id.values()
     }
 
+    /// Open the platform's directory picker. On selection, derive the
+    /// workspace title from the directory's basename and send
+    /// `register_workspace` to the daemon. The canvas + sidebar update
+    /// reactively when the daemon's `workspace_registered` broadcast lands
+    /// — same path the automation `create_workspace` action exercises.
+    /// User cancellation (no path picked) is silent.
+    pub fn prompt_and_register_workspace(&mut self, cx: &mut Context<Self>) {
+        events::record("workspace_create_prompt", json!({}));
+        let receiver = cx.prompt_for_paths(PathPromptOptions {
+            files: false,
+            directories: true,
+            multiple: false,
+            prompt: Some(SharedString::from("Pick a workspace directory")),
+        });
+        let app_handle = cx.entity().downgrade();
+        cx.spawn(async move |_, cx| {
+            let outcome = match receiver.await {
+                Ok(Ok(Some(paths))) if !paths.is_empty() => Some(paths[0].clone()),
+                Ok(Ok(_)) | Ok(Err(_)) | Err(_) => None,
+            };
+            let Some(path) = outcome else {
+                events::record("workspace_create_cancelled", json!({}));
+                return;
+            };
+            let directory = path.to_string_lossy().to_string();
+            let title = path
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_else(|| directory.clone());
+            let id = generate_workspace_id();
+            let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
+                events::record(
+                    "workspace_create_submitted",
+                    json!({
+                        "id": id.as_str(),
+                        "directory": directory.as_str(),
+                    }),
+                );
+                app.register_workspace_and_select(id.clone(), title.clone(), directory.clone(), cx);
+            });
+        })
+        .detach();
+    }
+
+    /// Register a workspace and select it once the daemon confirms it.
+    /// The daemon broadcast is still the source of truth for creating or
+    /// updating the local workspace entity.
+    pub fn register_workspace_and_select(
+        &mut self,
+        id: String,
+        title: String,
+        directory: String,
+        cx: &Context<Self>,
+    ) {
+        self.pending_select_workspace_ids
+            .insert(SharedString::from(id.clone()));
+        self.daemon
+            .read(cx)
+            .send_cmd(&RegisterWorkspaceMessage::new(id, title, directory));
+    }
+
+    /// Send `unregister_workspace` for the given id. Daemon cascades
+    /// (kills member sessions, broadcasts unregister), so the canvas +
+    /// sidebar update reactively. No confirmation dialog yet — see plan
+    /// doc M1.0; revisit when destroy gets a richer affordance.
+    pub fn unregister_workspace_by_id(&self, id: SharedString, cx: &Context<Self>) {
+        events::record("workspace_destroy_submitted", json!({"id": id.as_ref()}));
+        self.daemon
+            .read(cx)
+            .send_cmd(&UnregisterWorkspaceMessage::new(id.to_string()));
+    }
+
     /// Switch the canvas + sidebar to the given workspace id. Shared by
     /// the sidebar's click callback and the automation `select_workspace`
     /// action so both paths produce identical state. No-op when `id`
     /// doesn't match a known workspace.
     pub fn select_workspace(&mut self, id: SharedString, cx: &mut Context<Self>) {
+        self.select_workspace_impl(id, true, cx);
+    }
+
+    /// Sidebar click handlers already hold a mutable lease on the
+    /// `Sidebar` entity, so this path must not re-enter `sidebar.update`.
+    fn select_workspace_from_sidebar(&mut self, id: SharedString, cx: &mut Context<Self>) {
+        self.select_workspace_impl(id, false, cx);
+    }
+
+    fn select_workspace_impl(
+        &mut self,
+        id: SharedString,
+        sync_sidebar: bool,
+        cx: &mut Context<Self>,
+    ) {
         let Some(ws) = self.workspaces_by_id.get(&id).cloned() else {
             events::record(
                 "workspace_select_missed",
@@ -177,8 +288,17 @@ impl NativeApp {
         let canvas = self.canvas.clone();
         canvas.update(cx, |canvas, cx| canvas.set_selected(Some(ws), cx));
         self.selected_id = Some(id.clone());
-        self.sidebar
-            .update(cx, |sidebar, cx| sidebar.set_selected(Some(id), cx));
+        if sync_sidebar {
+            self.sidebar
+                .update(cx, |sidebar, cx| sidebar.set_selected(Some(id), cx));
+        }
+    }
+
+    fn select_workspace_if_pending(&mut self, id: &str, cx: &mut Context<Self>) {
+        let id = SharedString::from(id.to_string());
+        if self.pending_select_workspace_ids.remove(&id) {
+            self.select_workspace(id, cx);
+        }
     }
 
     /// Build a JSON snapshot of everything an external test script needs

--- a/native-ui/crates/attn-native-app/src/automation/actions.rs
+++ b/native-ui/crates/attn-native-app/src/automation/actions.rs
@@ -191,7 +191,7 @@ fn send_pty_input(
         // it's strictly equivalent and adds an indirection.
         app.daemon()
             .read(cx)
-            .send_cmd(&PtyInputMessage::new(session_id.clone(), text.clone()));
+            .send_cmd(&PtyInputMessage::new(session_id.clone(), text.clone()))?;
         Ok(json!({
             "session_id": session_id,
             "bytes_sent": text.len(),
@@ -204,11 +204,11 @@ fn send_pty_input(
 /// for deterministic test setups; otherwise we generate a UUIDv4-style
 /// hex id locally. Daemon enforces `directory` non-empty but does not
 /// validate filesystem existence — tests can use `/tmp/whatever` freely.
-/// Returns immediately after sending the wire message; observers (canvas,
-/// sidebar) react to the daemon's `workspace_registered` broadcast on
-/// their own schedule, so callers should poll `get_state` or `tail_events`
-/// for the post-condition rather than treating action success as
-/// "workspace is now in the UI".
+/// Fails if the daemon command cannot be queued for delivery. Observers
+/// (canvas, sidebar) still react to the daemon's `workspace_registered`
+/// broadcast on their own schedule, so callers should poll `get_state` or
+/// `tail_events` for the post-condition rather than treating action
+/// success as "workspace is now in the UI".
 fn create_workspace(
     app: &WeakEntity<NativeApp>,
     cx: &mut AsyncApp,
@@ -235,9 +235,9 @@ fn create_workspace(
 
     let app_entity = app.upgrade().ok_or("NativeApp entity dropped")?;
     cx.update_entity(&app_entity, |app: &mut NativeApp, cx| {
-        app.register_workspace_and_select(id.clone(), title.clone(), directory.clone(), cx);
+        app.register_workspace_and_select(id.clone(), title.clone(), directory.clone(), cx)
     })
-    .map_err(|e| format!("update entity: {e}"))?;
+    .map_err(|e| format!("update entity: {e}"))??;
 
     Ok(json!({
         "id": id,
@@ -270,9 +270,9 @@ fn destroy_workspace(
     cx.read_entity(&app_entity, |app: &NativeApp, cx: &App| {
         app.daemon()
             .read(cx)
-            .send_cmd(&UnregisterWorkspaceMessage::new(id.clone()));
+            .send_cmd(&UnregisterWorkspaceMessage::new(id.clone()))
     })
-    .map_err(|e| format!("read entity: {e}"))?;
+    .map_err(|e| format!("read entity: {e}"))??;
 
     Ok(json!({ "id": id }))
 }

--- a/native-ui/crates/attn-native-app/src/automation/actions.rs
+++ b/native-ui/crates/attn-native-app/src/automation/actions.rs
@@ -8,13 +8,14 @@
 use std::sync::Arc;
 
 use async_channel::{unbounded, Receiver, Sender};
-use attn_protocol::PtyInputMessage;
-use gpui::{prelude::*, AnyView, App, AsyncApp, Entity, SharedString, WeakEntity, Window};
+use attn_protocol::{PtyInputMessage, UnregisterWorkspaceMessage};
+use gpui::{prelude::*, AnyView, App, AsyncApp, Entity, Keystroke, Modifiers, SharedString, WeakEntity, Window};
 use serde_json::{json, Value};
 
 use crate::app::NativeApp;
 use crate::panel::PanelContent;
 use crate::terminal_model::TerminalModel;
+use crate::terminal_view::TerminalView;
 use crate::viewport::pf;
 
 use super::events;
@@ -83,9 +84,12 @@ async fn handle_action(
         "select_workspace" => select_workspace(app, cx, payload),
         "move_panel" => move_panel(app, cx, payload),
         "send_pty_input" => send_pty_input(app, cx, payload),
+        "type_into_panel" => type_into_panel(app, cx, payload),
         "read_pane_text" => read_pane_text(app, cx, payload),
         "tail_events" => tail_events(payload),
         "set_zoom" => set_zoom(app, cx, payload),
+        "create_workspace" => create_workspace(app, cx, payload),
+        "destroy_workspace" => destroy_workspace(app, cx, payload),
         _ => Err(format!("unknown action: {action}")),
     }
 }
@@ -196,6 +200,227 @@ fn send_pty_input(
     .map_err(|e| format!("read entity: {e}"))?
 }
 
+/// Register a new workspace with the daemon. Caller may supply an `id`
+/// for deterministic test setups; otherwise we generate a UUIDv4-style
+/// hex id locally. Daemon enforces `directory` non-empty but does not
+/// validate filesystem existence — tests can use `/tmp/whatever` freely.
+/// Returns immediately after sending the wire message; observers (canvas,
+/// sidebar) react to the daemon's `workspace_registered` broadcast on
+/// their own schedule, so callers should poll `get_state` or `tail_events`
+/// for the post-condition rather than treating action success as
+/// "workspace is now in the UI".
+fn create_workspace(
+    app: &WeakEntity<NativeApp>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let directory = payload
+        .get("directory")
+        .and_then(Value::as_str)
+        .ok_or("payload.directory (string) is required")?
+        .trim()
+        .to_string();
+    if directory.is_empty() {
+        return Err("payload.directory must be non-empty".to_string());
+    }
+    let title = payload
+        .get("title")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let id = match payload.get("id").and_then(Value::as_str) {
+        Some(s) if !s.trim().is_empty() => s.trim().to_string(),
+        _ => generate_workspace_id(),
+    };
+
+    let app_entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    cx.update_entity(&app_entity, |app: &mut NativeApp, cx| {
+        app.register_workspace_and_select(id.clone(), title.clone(), directory.clone(), cx);
+    })
+    .map_err(|e| format!("update entity: {e}"))?;
+
+    Ok(json!({
+        "id": id,
+        "title": title,
+        "directory": directory,
+    }))
+}
+
+/// Send `unregister_workspace` to the daemon. Daemon cascades: SIGTERMs
+/// every member session and broadcasts `session_unregistered` for each
+/// before broadcasting `workspace_unregistered`. Idempotent on unknown id
+/// (daemon silently no-ops), so tests don't have to guard against double-
+/// destroy in cleanup paths.
+fn destroy_workspace(
+    app: &WeakEntity<NativeApp>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let id = payload
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or("payload.id (string) is required")?
+        .trim()
+        .to_string();
+    if id.is_empty() {
+        return Err("payload.id must be non-empty".to_string());
+    }
+
+    let app_entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    cx.read_entity(&app_entity, |app: &NativeApp, cx: &App| {
+        app.daemon()
+            .read(cx)
+            .send_cmd(&UnregisterWorkspaceMessage::new(id.clone()));
+    })
+    .map_err(|e| format!("read entity: {e}"))?;
+
+    Ok(json!({ "id": id }))
+}
+
+/// UUIDv4-shaped hex id (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`) so
+/// generated workspace ids look like the daemon's CLI-generated ones in
+/// logs and the recent-locations table. Pulling in the `uuid` crate just
+/// for this would add a dep without buying anything; `getrandom` is
+/// already a workspace dependency. `pub(crate)` so the sidebar's "+ New
+/// Workspace" flow can mint ids the same way.
+pub(crate) fn generate_workspace_id() -> String {
+    let mut bytes = [0u8; 16];
+    if getrandom::getrandom(&mut bytes).is_err() {
+        // OS RNG failure shouldn't happen, but if it does, fall back to a
+        // process-pid + timestamp scheme so the action still produces a
+        // distinguishable id rather than panicking the action pump.
+        let pid = std::process::id();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or_default();
+        let mut idx = 0;
+        for b in pid.to_le_bytes() {
+            bytes[idx] = b;
+            idx += 1;
+        }
+        for b in now.to_le_bytes() {
+            if idx >= bytes.len() {
+                break;
+            }
+            bytes[idx] = b;
+            idx += 1;
+        }
+    }
+    // Set version (4) and variant (10) bits per RFC 4122.
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    let mut s = String::with_capacity(36);
+    for (i, b) in bytes.iter().enumerate() {
+        if matches!(i, 4 | 6 | 8 | 10) {
+            s.push('-');
+        }
+        s.push(hex_nibble(b >> 4));
+        s.push(hex_nibble(b & 0x0f));
+    }
+    s
+}
+
+fn hex_nibble(n: u8) -> char {
+    match n {
+        0..=9 => (b'0' + n) as char,
+        10..=15 => (b'a' + n - 10) as char,
+        _ => unreachable!(),
+    }
+}
+
+/// Pump a string of text through the focused panel's keyboard handler so
+/// tests exercise the same encode/send path as real keypresses
+/// (`TerminalView::on_key_down → encode_key → send_input`). Differs from
+/// `send_pty_input`, which constructs the wire message directly and
+/// therefore can't catch regressions in focus routing or key encoding.
+fn type_into_panel(
+    app: &WeakEntity<NativeApp>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .ok_or("payload.session_id (string) is required")?
+        .to_string();
+    let text = payload
+        .get("text")
+        .and_then(Value::as_str)
+        .ok_or("payload.text (string) is required")?
+        .to_string();
+
+    let app_entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    let view = cx
+        .read_entity(&app_entity, |app: &NativeApp, cx: &App| {
+            find_terminal_view(app, &session_id, cx)
+        })
+        .map_err(|e| format!("read entity: {e}"))?
+        .ok_or_else(|| format!("no terminal panel for session: {session_id}"))?;
+
+    let window = cx
+        .update(|app: &mut App| app.windows().into_iter().next())
+        .map_err(|e| format!("list windows: {e}"))?
+        .ok_or("no open windows")?;
+
+    let keystrokes = keystrokes_for_text(&text);
+    let count = keystrokes.len();
+
+    cx.update_window(window, |_root: AnyView, window: &mut Window, app: &mut App| {
+        view.update(app, |view: &mut TerminalView, cx| {
+            // Focus first so the on_key_down handler accepts the
+            // keystroke. Mirrors what a real click would do before the
+            // user starts typing — we want the test to fail if focus
+            // routing is broken, not silently succeed.
+            view.focus_handle.clone().focus(window);
+            for keystroke in keystrokes {
+                view.inject_keystroke(keystroke, window, cx);
+            }
+        });
+    })
+    .map_err(|e| format!("update window: {e}"))?;
+
+    Ok(json!({
+        "session_id": session_id,
+        "keystrokes": count,
+    }))
+}
+
+/// Translate a UTF-8 string into one `Keystroke` per logical key press,
+/// matching what GPUI would deliver if a real user typed the text. `\n`
+/// becomes `Enter`, `\t` becomes `Tab`; printable chars round-trip through
+/// `key_char` (which `encode_key` prefers over `key` for non-modified
+/// printable input). Doesn't try to model international layouts or IME
+/// composition — single-line ASCII commands are the test surface here.
+fn keystrokes_for_text(text: &str) -> Vec<Keystroke> {
+    let mut out = Vec::with_capacity(text.len());
+    for ch in text.chars() {
+        let keystroke = match ch {
+            '\n' => Keystroke {
+                modifiers: Modifiers::default(),
+                key: "enter".to_string(),
+                key_char: None,
+            },
+            '\t' => Keystroke {
+                modifiers: Modifiers::default(),
+                key: "tab".to_string(),
+                key_char: None,
+            },
+            other => {
+                let s = other.to_string();
+                Keystroke {
+                    modifiers: Modifiers::default(),
+                    key: s.clone(),
+                    key_char: Some(s),
+                }
+            }
+        };
+        out.push(keystroke);
+    }
+    out
+}
+
 fn read_pane_text(
     app: &WeakEntity<NativeApp>,
     cx: &mut AsyncApp,
@@ -241,6 +466,26 @@ fn find_terminal_model(
             if let PanelContent::Terminal { session_id: sid, view } = &panel.content {
                 if sid.as_ref() == session_id {
                     return Some(view.read(cx).model().clone());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Like `find_terminal_model` but returns the GPUI view entity. Needed by
+/// `type_into_panel` because keystroke dispatch happens on the view, not
+/// the model.
+fn find_terminal_view(
+    app: &NativeApp,
+    session_id: &str,
+    cx: &App,
+) -> Option<Entity<TerminalView>> {
+    for ws in app.workspaces() {
+        for panel in ws.read(cx).panels.iter() {
+            if let PanelContent::Terminal { session_id: sid, view } = &panel.content {
+                if sid.as_ref() == session_id {
+                    return Some(view.clone());
                 }
             }
         }
@@ -309,4 +554,64 @@ fn get_window_geometry(cx: &mut AsyncApp) -> Result<Value, String> {
         },
     )
     .map_err(|e| format!("update window: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Newline must map to `Enter` with `key_char: None` (not `\n`) so
+    /// `terminal_view::encode_key` takes the dedicated-escape branch and
+    /// emits `\r`. If `\n` ever leaks into `key_char`, encode_key returns
+    /// `\n` and shells stop running the typed command — broken e2e but
+    /// silent in production. Locking the shape here.
+    #[test]
+    fn keystrokes_for_text_uses_named_keys_for_newline_and_tab() {
+        let ks = keystrokes_for_text("a\n\tb");
+        assert_eq!(ks.len(), 4);
+        assert_eq!(ks[0].key, "a");
+        assert_eq!(ks[0].key_char.as_deref(), Some("a"));
+        assert_eq!(ks[1].key, "enter");
+        assert!(ks[1].key_char.is_none());
+        assert_eq!(ks[2].key, "tab");
+        assert!(ks[2].key_char.is_none());
+        assert_eq!(ks[3].key, "b");
+        assert_eq!(ks[3].key_char.as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn keystrokes_for_text_default_modifiers_are_clear() {
+        // Bare ASCII shouldn't pick up shift/ctrl/alt — the encoder
+        // branches on those modifiers and would emit control sequences
+        // instead of the literal char.
+        let ks = keystrokes_for_text("X");
+        assert_eq!(ks.len(), 1);
+        let m = &ks[0].modifiers;
+        assert!(!m.shift && !m.control && !m.alt);
+    }
+
+    #[test]
+    fn generated_workspace_id_is_uuidv4_shaped() {
+        let id = generate_workspace_id();
+        assert_eq!(id.len(), 36, "uuid: {id}");
+        let bytes = id.as_bytes();
+        for (i, b) in bytes.iter().enumerate() {
+            if matches!(i, 8 | 13 | 18 | 23) {
+                assert_eq!(*b, b'-', "expected '-' at {i} of {id}");
+            } else {
+                assert!(b.is_ascii_hexdigit(), "non-hex at {i} of {id}");
+                assert!(!b.is_ascii_uppercase(), "uppercase at {i} of {id}");
+            }
+        }
+        // Version + variant nibbles per RFC 4122.
+        assert_eq!(bytes[14], b'4', "version nibble: {id}");
+        assert!(matches!(bytes[19], b'8' | b'9' | b'a' | b'b'), "variant nibble: {id}");
+    }
+
+    #[test]
+    fn generated_workspace_ids_differ() {
+        // Two consecutive calls should never collide; if they do the test
+        // fails fast rather than leaking duplicate ids into the daemon.
+        assert_ne!(generate_workspace_id(), generate_workspace_id());
+    }
 }

--- a/native-ui/crates/attn-native-app/src/daemon_client.rs
+++ b/native-ui/crates/attn-native-app/src/daemon_client.rs
@@ -168,11 +168,17 @@ impl DaemonClient {
         }
     }
 
-    /// Send a serializable command to the daemon. Silently drops if not connected.
-    pub fn send_cmd<T: Serialize>(&self, msg: &T) {
-        let Some(tx) = &self.cmd_tx else { return };
-        let Ok(json) = serde_json::to_string(msg) else { return };
-        let _ = tx.try_send(json);
+    /// Send a serializable command to the daemon.
+    pub fn send_cmd<T: Serialize>(&self, msg: &T) -> Result<(), String> {
+        let tx = self.cmd_tx.as_ref().ok_or_else(|| {
+            self.error
+                .clone()
+                .unwrap_or_else(|| "daemon websocket is not connected".to_string())
+        })?;
+        let json = serde_json::to_string(msg)
+            .map_err(|e| format!("serialize daemon command: {e}"))?;
+        tx.try_send(json)
+            .map_err(|e| format!("queue daemon command: {e}"))
     }
 
     fn handle_event(&mut self, event: ServerEvent, cx: &mut Context<Self>) {

--- a/native-ui/crates/attn-native-app/src/sidebar.rs
+++ b/native-ui/crates/attn-native-app/src/sidebar.rs
@@ -20,6 +20,15 @@ pub struct Sidebar {
     /// at construction time so the app can swap the canvas's selected
     /// workspace handle.
     on_select: Box<dyn Fn(SharedString, &mut Window, &mut gpui::App) + 'static>,
+    /// Callback fired when the user clicks "+ New Workspace". Owns the
+    /// directory picker → daemon `register_workspace` flow on the app
+    /// side; the sidebar just dispatches.
+    on_create: Box<dyn Fn(&mut Window, &mut gpui::App) + 'static>,
+    /// Callback fired when the user clicks a row's "×" delete affordance.
+    /// Sends `unregister_workspace` for the given id. Daemon cascades to
+    /// member sessions, so callers don't need a separate session-cleanup
+    /// step.
+    on_destroy: Box<dyn Fn(SharedString, &mut Window, &mut gpui::App) + 'static>,
     focus_handle: FocusHandle,
 }
 
@@ -27,6 +36,8 @@ impl Sidebar {
     pub fn new(
         workspaces: Vec<Entity<Workspace>>,
         on_select: impl Fn(SharedString, &mut Window, &mut gpui::App) + 'static,
+        on_create: impl Fn(&mut Window, &mut gpui::App) + 'static,
+        on_destroy: impl Fn(SharedString, &mut Window, &mut gpui::App) + 'static,
         cx: &mut Context<Self>,
     ) -> Self {
         // Re-render this whole view when any member workspace updates.
@@ -38,6 +49,8 @@ impl Sidebar {
             workspaces,
             selected_id: None,
             on_select: Box::new(on_select),
+            on_create: Box::new(on_create),
+            on_destroy: Box::new(on_destroy),
             focus_handle: cx.focus_handle(),
         }
     }
@@ -89,13 +102,24 @@ impl Render for Sidebar {
                 let status = ws.status;
                 let selected = self.selected_id.as_ref() == Some(&id);
                 let click_id = id.clone();
-                row(id.clone(), title, status, selected)
+                let destroy_id = id.clone();
+                let row_div = workspace_row(title, status, selected)
                     .on_mouse_down(MouseButton::Left, cx.listener(move |this, _, window, cx| {
                         let id = click_id.clone();
                         (this.on_select)(id.clone(), window, cx);
                         this.set_selected(Some(id), cx);
                     }))
-                    .into_any_element()
+                    .child(
+                        delete_button()
+                            .on_mouse_down(MouseButton::Left, cx.listener(move |this, _, window, cx| {
+                                // Stop the row's `on_select` from firing too —
+                                // clicking × shouldn't also select the
+                                // workspace it's about to delete.
+                                cx.stop_propagation();
+                                (this.on_destroy)(destroy_id.clone(), window, cx);
+                            })),
+                    );
+                row_div.into_any_element()
             })
             .collect();
 
@@ -116,12 +140,21 @@ impl Render for Sidebar {
                     .child(SharedString::from("WORKSPACES")),
             )
             .children(rows)
+            .child(
+                create_row().on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|this, _, window, cx| {
+                        (this.on_create)(window, cx);
+                    }),
+                ),
+            )
     }
 }
 
-/// One row. Pulled out so the click handler in `render` stays readable.
-fn row(
-    _id: SharedString,
+/// One workspace row. Title + status badge on the left. Caller appends
+/// the delete affordance — pulled out so the click handler in `render`
+/// stays readable.
+fn workspace_row(
     title: SharedString,
     status: WorkspaceStatus,
     selected: bool,
@@ -138,7 +171,38 @@ fn row(
         .text_color(rgb(0xe0e0eb))
         .text_size(px(13.))
         .child(status_badge(status))
-        .child(title)
+        .child(div().flex_1().child(title))
+}
+
+/// Trailing delete affordance on each row. Always visible (no hover gate
+/// yet — that's a follow-up once we have a hover-state pattern in this
+/// crate). Dim by default so the eye lands on titles, not crosses.
+fn delete_button() -> gpui::Div {
+    div()
+        .w(px(20.))
+        .h(px(20.))
+        .flex()
+        .items_center()
+        .justify_center()
+        .text_color(rgb(0x6a6a78))
+        .text_size(px(14.))
+        .child(SharedString::from("×"))
+}
+
+/// "+ New Workspace" entry below the workspace list. Visually distinct
+/// from real workspaces so the eye reads it as an action, not a row to
+/// select.
+fn create_row() -> gpui::Div {
+    div()
+        .w_full()
+        .px_4()
+        .py_2()
+        .flex()
+        .items_center()
+        .gap_2()
+        .text_color(rgb(0x8a8a95))
+        .text_size(px(13.))
+        .child(SharedString::from("+ New Workspace"))
 }
 
 /// Coloured dot reflecting the workspace's rolled-up status. The colour

--- a/native-ui/crates/attn-native-app/src/terminal_view.rs
+++ b/native-ui/crates/attn-native-app/src/terminal_view.rs
@@ -3,7 +3,7 @@ use alacritty_terminal::vte::ansi::{Color, NamedColor};
 use gpui::{
     div, fill, point, prelude::*, px, rgb, size, App, Bounds, ElementId,
     Font, GlobalElementId, Hsla, InspectorElementId, LayoutId, Pixels, Size, Style, TextRun,
-    Window, Context, Entity, FocusHandle, Focusable, KeyDownEvent,
+    Window, Context, Entity, FocusHandle, Focusable, KeyDownEvent, Keystroke,
 };
 
 use attn_protocol::{PtyInputMessage, PtyResizeMessage};
@@ -373,6 +373,23 @@ impl TerminalView {
         if !seq.is_empty() {
             self.send_input(&seq, cx);
         }
+    }
+
+    /// Synthesize a keystroke from outside the GPUI event loop and run it
+    /// through the same path real keystrokes take. Used by the automation
+    /// `type_into_panel` action so test scripts exercise the full
+    /// focus → encode → send_input chain rather than bypassing it via
+    /// `send_pty_input`. Caller is responsible for focusing this view
+    /// first; an unfocused view drops the keystroke (matching production
+    /// behavior).
+    pub fn inject_keystroke(
+        &mut self,
+        keystroke: Keystroke,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let event = KeyDownEvent { keystroke, is_held: false };
+        self.on_key_down(&event, window, cx);
     }
 }
 

--- a/native-ui/crates/attn-native-app/src/terminal_view.rs
+++ b/native-ui/crates/attn-native-app/src/terminal_view.rs
@@ -362,7 +362,7 @@ impl TerminalView {
     fn send_input(&self, data: &str, cx: &mut Context<Self>) {
         let session_id = self.terminal.read(cx).session_id.clone();
         let msg = PtyInputMessage::new(session_id, data);
-        self.daemon.read(cx).send_cmd(&msg);
+        let _ = self.daemon.read(cx).send_cmd(&msg);
     }
 
     fn on_key_down(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
@@ -412,7 +412,10 @@ impl Render for TerminalView {
         };
         if new_cols != cur_cols || new_rows != cur_rows {
             self.terminal.update(cx, |t, _| t.resize(new_cols, new_rows));
-            self.daemon.read(cx).send_cmd(&PtyResizeMessage::new(session_id, new_cols, new_rows));
+            let _ = self
+                .daemon
+                .read(cx)
+                .send_cmd(&PtyResizeMessage::new(session_id, new_cols, new_rows));
         }
 
         let terminal = self.terminal.read(cx);


### PR DESCRIPTION
## Summary

Adds native canvas workspace management support:

- Adds sidebar create/delete affordances for native workspaces.
- Registers new workspaces through the daemon and auto-selects them after daemon confirmation.
- Fixes the sidebar click crash by avoiding a nested `Sidebar` entity update while its mouse handler is already updating the entity.
- Extends the native automation surface with workspace lifecycle actions and keyboard-path typing coverage.
- Adds `make dev-native` and expands the native canvas scenario to cover workspace lifecycle, auto-selection, and both PTY input paths.

## Validation

- `cargo test -p attn-native-app`
- `node --check app/scripts/real-app-harness/scenario-native-canvas.mjs`
- `git diff --check`
- `NODE_OPTIONS="--localstorage-file=/tmp/attn-vitest-localstorage.json" make test-harness GOTESTSUM=$(command -v gotestsum)`

Notes: the first `make test-harness` attempt failed before this env adjustment because local Node 25 exposes an incomplete `localStorage` unless `--localstorage-file` is set, and the Makefile's default `~/go/bin/gotestsum` path did not match this asdf Go install. The rerun above passed: Go tests, frontend unit tests, and Playwright e2e.