### PR TITLE
[codex] Polish native workspace deletion

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+root="$(git rev-parse --show-toplevel)"
+
 unset GIT_DIR
 unset GIT_WORK_TREE
-unset GIT_INDEX_FILE
 
-go test ./...
-pnpm -C app exec tsc --noEmit
-pnpm -C app test
+exec "$root/scripts/pre-commit.sh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-04-29]
+
+### Changed
+- **Smarter Commit Checks**: The pre-commit hook now chooses validation by staged file path and auto-formats staged Go, native Rust, and Tauri Rust files when safe. Native canvas changes run daemon checks plus native Rust format, clippy, and tests; Tauri changes run daemon checks plus Tauri Rust format, clippy, and tests; frontend, shell, and daemon-only changes stay scoped to their relevant suites.
+
+### Fixed
+- **Native Workspace Deletion Polish**: The native workspace sidebar now asks for an inline confirmation before deleting a workspace, keeps the row in a pending state while the daemon unregisters it, surfaces command-send failures in the sidebar, and automatically selects another workspace after the selected one is deleted.
+
+---
+
 ## [2026-04-28]
 
 ### Added

--- a/app/scripts/real-app-harness/scenario-native-canvas.mjs
+++ b/app/scripts/real-app-harness/scenario-native-canvas.mjs
@@ -558,18 +558,40 @@ async function sendAndExpectMarker(conn, sessionId, action, baseArgs) {
 async function checkWorkspaceLifecycle(conn) {
   const cursorBefore = (await tailEvents(conn)).next_cursor;
 
-  const directory = `/tmp/attn-scenario-ws-${crypto.randomUUID().slice(0, 8)}`;
-  const title = `Scenario WS ${new Date().toISOString().slice(11, 19)}`;
-  const created = await conn.request('create_workspace', { directory, title });
-  if (!created.ok) fail(`create_workspace: ${created.error}`);
-  const wsId = created.result.id;
-  if (typeof wsId !== 'string' || wsId.length < 16) {
-    fail(`create_workspace returned suspicious id: ${JSON.stringify(created.result)}`);
-  }
-  info(`  created workspace ${wsId.slice(0, 8)}…`);
+  let fallbackId = null;
+  let wsId = null;
+  let cleanupNeeded = false;
+  let fallbackCleanupNeeded = false;
 
-  let cleanupNeeded = true;
   try {
+    const fallbackDirectory = `/tmp/attn-scenario-fallback-${crypto.randomUUID().slice(0, 8)}`;
+    const fallbackTitle = `000 Scenario Fallback ${new Date().toISOString().slice(11, 19)}`;
+    const fallback = await conn.request('create_workspace', {
+      directory: fallbackDirectory,
+      title: fallbackTitle,
+    });
+    if (!fallback.ok) fail(`create_workspace fallback: ${fallback.error}`);
+    fallbackId = fallback.result.id;
+    fallbackCleanupNeeded = true;
+
+    const directory = `/tmp/attn-scenario-ws-${crypto.randomUUID().slice(0, 8)}`;
+    const title = `Scenario WS ${new Date().toISOString().slice(11, 19)}`;
+    const created = await conn.request('create_workspace', { directory, title });
+    if (!created.ok) fail(`create_workspace: ${created.error}`);
+    wsId = created.result.id;
+    cleanupNeeded = true;
+    for (const [label, id] of [['fallback', fallbackId], ['target', wsId]]) {
+      if (typeof id !== 'string' || id.length < 16) {
+        fail(
+          `create_workspace returned suspicious ${label} id: ${JSON.stringify({
+            fallback,
+            created,
+          })}`,
+        );
+      }
+    }
+    info(`  created fallback ${fallbackId.slice(0, 8)}… and target ${wsId.slice(0, 8)}…`);
+
     // Wait for the workspace to land in get_state — proves the canvas
     // observed the daemon's workspace_registered broadcast and updated
     // its workspace map.
@@ -579,6 +601,7 @@ async function checkWorkspaceLifecycle(conn) {
           const s = await conn.request('get_state');
           return (
             s.ok &&
+            s.result.workspaces?.some((w) => w.id === fallbackId) &&
             s.result.workspaces?.some((w) => w.id === wsId) &&
             s.result.selected_workspace_id === wsId
           );
@@ -601,9 +624,13 @@ async function checkWorkspaceLifecycle(conn) {
     const observed = tail.events.find(
       (e) => e.category === 'workspace_registered_observed' && e.payload.workspace_id === wsId,
     );
-    if (!observed) {
+    const fallbackObserved = tail.events.find(
+      (e) =>
+        e.category === 'workspace_registered_observed' && e.payload.workspace_id === fallbackId,
+    );
+    if (!observed || !fallbackObserved) {
       await dumpEventsSince(conn, cursorBefore, 'create_workspace');
-      fail(`no workspace_registered_observed event for ${wsId}`);
+      fail(`missing workspace_registered_observed event for lifecycle workspaces`);
     }
     info(`  observed workspace_registered_observed for ${wsId.slice(0, 8)}…`);
 
@@ -617,9 +644,18 @@ async function checkWorkspaceLifecycle(conn) {
       await pollUntil(
         async () => {
           const s = await conn.request('get_state');
-          return s.ok && !s.result.workspaces?.some((w) => w.id === wsId);
+          return (
+            s.ok &&
+            !s.result.workspaces?.some((w) => w.id === wsId) &&
+            s.result.selected_workspace_id &&
+            s.result.selected_workspace_id !== wsId
+          );
         },
-        { timeoutMs: 5000, intervalMs: 100, label: `workspace ${wsId.slice(0, 8)} gone from get_state` },
+        {
+          timeoutMs: 5000,
+          intervalMs: 100,
+          label: `workspace ${wsId.slice(0, 8)} gone and selection restored`,
+        },
       );
     } catch (error) {
       await dumpEventsSince(conn, cursorBeforeDestroy, 'destroy_workspace');
@@ -635,12 +671,19 @@ async function checkWorkspaceLifecycle(conn) {
       await dumpEventsSince(conn, cursorBeforeDestroy, 'destroy_workspace');
       fail(`no workspace_unregistered_observed event for ${wsId}`);
     }
-    info(`  ok (created ${wsId.slice(0, 8)}, observed both lifecycle events, destroyed)`);
+    const fallbackDestroyed = await conn.request('destroy_workspace', { id: fallbackId });
+    if (!fallbackDestroyed.ok) fail(`destroy_workspace fallback: ${fallbackDestroyed.error}`);
+    fallbackCleanupNeeded = false;
+
+    info(`  ok (created ${wsId.slice(0, 8)}, restored selection after destroy, cleaned up)`);
   } finally {
-    if (cleanupNeeded) {
+    if (cleanupNeeded && wsId) {
       // destroy_workspace is idempotent on the daemon, so a best-effort
       // cleanup on assertion failure won't double-fault.
       await conn.request('destroy_workspace', { id: wsId }).catch(() => {});
+    }
+    if (fallbackCleanupNeeded && fallbackId) {
+      await conn.request('destroy_workspace', { id: fallbackId }).catch(() => {});
     }
   }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -232,7 +232,7 @@ fn stop_running_daemon(socket_path: &Path) -> Result<(), String> {
     if !wait_for_daemon_shutdown(socket_path, Duration::from_secs(5)) {
         return Err("Timed out waiting for daemon to stop".into());
     }
-    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(socket_path);
     Ok(())
 }
 

--- a/app/src-tauri/src/thumbs.rs
+++ b/app/src-tauri/src/thumbs.rs
@@ -75,7 +75,7 @@ pub fn extract_patterns(text: String) -> Vec<PatternMatch> {
     for cap in URL_REGEX.find_iter(&clean_text) {
         let value = cap.as_str().to_string();
         // Clean trailing punctuation that might have been captured
-        let value = value.trim_end_matches(|c| c == '.' || c == ',' || c == ';' || c == ':');
+        let value = value.trim_end_matches(['.', ',', ';', ':']);
         if !seen.contains(value) {
             seen.insert(value.to_string());
             matches.push(PatternMatch {

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -55,7 +55,7 @@ pub struct NativeApp {
 
 impl NativeApp {
     pub fn new(daemon: Entity<DaemonClient>, cx: &mut Context<Self>) -> Self {
-        let canvas = cx.new(|cx| WorkspaceCanvas::new(cx));
+        let canvas = cx.new(WorkspaceCanvas::new);
         let app_handle = cx.entity().downgrade();
         let app_handle_create = app_handle.clone();
         let app_handle_destroy = app_handle.clone();
@@ -76,68 +76,86 @@ impl NativeApp {
                 },
                 move |id, _window, cx| {
                     let app_handle = app_handle_destroy.clone();
-                    let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
-                        let id_for_event = id.clone();
-                        if let Err(error) = app.unregister_workspace_by_id(id, cx) {
+                    let id_for_event = id.clone();
+                    match app_handle.update(cx, |app: &mut NativeApp, cx| {
+                        app.unregister_workspace_by_id(id, cx)
+                    }) {
+                        Ok(Ok(())) => Ok(()),
+                        Ok(Err(error)) => {
                             events::record(
                                 "workspace_destroy_failed",
                                 json!({
                                     "id": id_for_event.as_ref(),
-                                    "error": error,
+                                    "error": error.as_str(),
                                 }),
                             );
+                            Err(error)
                         }
-                    });
+                        Err(error) => {
+                            let error = format!("update app: {error}");
+                            events::record(
+                                "workspace_destroy_failed",
+                                json!({
+                                    "id": id_for_event.as_ref(),
+                                    "error": error.as_str(),
+                                }),
+                            );
+                            Err(error)
+                        }
+                    }
                 },
                 cx,
             )
         });
 
-        cx.subscribe(&daemon, |this, _client, event: &DaemonEvent, cx| match event {
-            DaemonEvent::WorkspaceRegistered { workspace } => {
-                events::record(
-                    "workspace_registered_observed",
-                    json!({"workspace_id": workspace.id.as_str()}),
-                );
-                this.upsert_workspace(workspace.clone(), cx);
-                this.select_workspace_if_pending(&workspace.id, cx);
-                this.sync_terminal_panels(cx);
-            }
-            DaemonEvent::WorkspaceUnregistered { workspace_id } => {
-                events::record(
-                    "workspace_unregistered_observed",
-                    json!({"workspace_id": workspace_id.as_str()}),
-                );
-                this.remove_workspace(workspace_id.clone(), cx);
-            }
-            DaemonEvent::WorkspaceStateChanged { workspace } => {
-                events::record(
-                    "workspace_state_changed_observed",
-                    json!({"workspace_id": workspace.id.as_str()}),
-                );
-                this.apply_workspace_snapshot(workspace.clone(), cx);
-                this.select_workspace_if_pending(&workspace.id, cx);
-            }
-            DaemonEvent::SessionsChanged => {
-                events::record(
-                    "sessions_changed_observed",
-                    json!({"session_count": this.daemon.read(cx).sessions().len()}),
-                );
-                this.sync_terminal_panels(cx);
-            }
-            DaemonEvent::Connected => {
-                events::record("daemon_connected", json!({}));
-                // Daemon tracks PTY attachments per client connection,
-                // so on a fresh socket every existing TerminalView is
-                // detached on the daemon side until we re-issue
-                // AttachSession. Without this, terminals go silent
-                // after a daemon restart and only recover on app
-                // restart.
-                this.reattach_existing_terminals(cx);
-                this.sync_terminal_panels(cx);
-            }
-            _ => {}
-        })
+        cx.subscribe(
+            &daemon,
+            |this, _client, event: &DaemonEvent, cx| match event {
+                DaemonEvent::WorkspaceRegistered { workspace } => {
+                    events::record(
+                        "workspace_registered_observed",
+                        json!({"workspace_id": workspace.id.as_str()}),
+                    );
+                    this.upsert_workspace(workspace.clone(), cx);
+                    this.select_workspace_if_pending(&workspace.id, cx);
+                    this.sync_terminal_panels(cx);
+                }
+                DaemonEvent::WorkspaceUnregistered { workspace_id } => {
+                    events::record(
+                        "workspace_unregistered_observed",
+                        json!({"workspace_id": workspace_id.as_str()}),
+                    );
+                    this.remove_workspace(workspace_id.clone(), cx);
+                }
+                DaemonEvent::WorkspaceStateChanged { workspace } => {
+                    events::record(
+                        "workspace_state_changed_observed",
+                        json!({"workspace_id": workspace.id.as_str()}),
+                    );
+                    this.apply_workspace_snapshot(workspace.clone(), cx);
+                    this.select_workspace_if_pending(&workspace.id, cx);
+                }
+                DaemonEvent::SessionsChanged => {
+                    events::record(
+                        "sessions_changed_observed",
+                        json!({"session_count": this.daemon.read(cx).sessions().len()}),
+                    );
+                    this.sync_terminal_panels(cx);
+                }
+                DaemonEvent::Connected => {
+                    events::record("daemon_connected", json!({}));
+                    // Daemon tracks PTY attachments per client connection,
+                    // so on a fresh socket every existing TerminalView is
+                    // detached on the daemon side until we re-issue
+                    // AttachSession. Without this, terminals go silent
+                    // after a daemon restart and only recover on app
+                    // restart.
+                    this.reattach_existing_terminals(cx);
+                    this.sync_terminal_panels(cx);
+                }
+                _ => {}
+            },
+        )
         .detach();
 
         let automation_handle = if automation::automation_enabled() {
@@ -169,7 +187,9 @@ impl NativeApp {
     /// scripts can drive perf measurements at known zoom levels.
     pub fn set_canvas_zoom(&self, zoom: f32, reset_fps: bool, cx: &mut Context<Self>) {
         let canvas = self.canvas.clone();
-        canvas.update(cx, |canvas, cx| canvas.set_zoom_centered(zoom, reset_fps, cx));
+        canvas.update(cx, |canvas, cx| {
+            canvas.set_zoom_centered(zoom, reset_fps, cx)
+        });
     }
 
     /// Read-only handle to the daemon client, exposed so the automation
@@ -276,8 +296,7 @@ impl NativeApp {
 
     /// Send `unregister_workspace` for the given id. Daemon cascades
     /// (kills member sessions, broadcasts unregister), so the canvas +
-    /// sidebar update reactively. No confirmation dialog yet — see plan
-    /// doc M1.0; revisit when destroy gets a richer affordance.
+    /// sidebar update reactively once the daemon confirms removal.
     pub fn unregister_workspace_by_id(
         &self,
         id: SharedString,
@@ -287,7 +306,10 @@ impl NativeApp {
         self.daemon
             .read(cx)
             .send_cmd(&UnregisterWorkspaceMessage::new(id_string.clone()))?;
-        events::record("workspace_destroy_submitted", json!({"id": id_string.as_str()}));
+        events::record(
+            "workspace_destroy_submitted",
+            json!({"id": id_string.as_str()}),
+        );
         Ok(())
     }
 
@@ -371,8 +393,9 @@ impl NativeApp {
         }
         let entity = cx.new(|_| Workspace::new(data, Vec::new()));
         self.workspaces_by_id.insert(id.clone(), entity.clone());
-        self.sidebar
-            .update(cx, |sidebar, cx| sidebar.upsert_workspace(entity.clone(), cx));
+        self.sidebar.update(cx, |sidebar, cx| {
+            sidebar.upsert_workspace(entity.clone(), cx)
+        });
 
         // First workspace to appear becomes the canvas's initial selection.
         if self.selected_id.is_none() {
@@ -384,11 +407,7 @@ impl NativeApp {
         }
     }
 
-    fn apply_workspace_snapshot(
-        &mut self,
-        data: attn_protocol::Workspace,
-        cx: &mut Context<Self>,
-    ) {
+    fn apply_workspace_snapshot(&mut self, data: attn_protocol::Workspace, cx: &mut Context<Self>) {
         let id = SharedString::from(data.id.clone());
         if let Some(existing) = self.workspaces_by_id.get(&id) {
             existing.update(cx, |ws, cx| ws.apply_snapshot(data, cx));
@@ -405,14 +424,38 @@ impl NativeApp {
         if self.workspaces_by_id.remove(&id).is_none() {
             return;
         }
+        self.pending_select_workspace_ids.remove(&id);
         let id_str = id.clone();
         self.sidebar
             .update(cx, |sidebar, cx| sidebar.remove_workspace(&id_str, cx));
         if self.selected_id.as_ref() == Some(&id) {
             self.selected_id = None;
-            self.canvas
-                .update(cx, |canvas, cx| canvas.set_selected(None, cx));
+            if let Some(next_id) = self.fallback_workspace_id(cx) {
+                events::record(
+                    "workspace_selected_after_destroy",
+                    json!({"destroyed_id": id.as_ref(), "selected_id": next_id.as_ref()}),
+                );
+                self.select_workspace(next_id, cx);
+            } else {
+                self.canvas
+                    .update(cx, |canvas, cx| canvas.set_selected(None, cx));
+                self.sidebar
+                    .update(cx, |sidebar, cx| sidebar.set_selected(None, cx));
+            }
         }
+    }
+
+    fn fallback_workspace_id(&self, cx: &App) -> Option<SharedString> {
+        let mut candidates: Vec<(String, String, SharedString)> = self
+            .workspaces_by_id
+            .values()
+            .map(|ws_entity| {
+                let ws = ws_entity.read(cx);
+                (ws.title.to_string(), ws.id.to_string(), ws.id.clone())
+            })
+            .collect();
+        candidates.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        candidates.into_iter().next().map(|(_, _, id)| id)
     }
 
     /// Walk every workspace's Terminal panels and re-issue
@@ -495,10 +538,12 @@ impl NativeApp {
                 continue;
             };
 
-            let already_present = ws_entity.read(cx).panels.iter().any(|p| matches!(
-                &p.content,
-                PanelContent::Terminal { session_id, .. } if session_id.as_ref() == session.id
-            ));
+            let already_present = ws_entity.read(cx).panels.iter().any(|p| {
+                matches!(
+                    &p.content,
+                    PanelContent::Terminal { session_id, .. } if session_id.as_ref() == session.id
+                )
+            });
             if already_present {
                 continue;
             }
@@ -523,7 +568,8 @@ impl NativeApp {
             let (cols, rows) = panel_terminal_dims(TERMINAL_W, TERMINAL_H);
 
             let daemon = self.daemon.clone();
-            let model = cx.new(|cx| TerminalModel::new(session_id.clone(), cols, rows, &daemon, cx));
+            let model =
+                cx.new(|cx| TerminalModel::new(session_id.clone(), cols, rows, &daemon, cx));
             let view = cx.new(|cx| {
                 let mut tv = TerminalView::new(model, daemon.clone(), cx);
                 tv.set_content_size(TERMINAL_W, (TERMINAL_H - TITLE_HEIGHT).max(0.0));
@@ -606,7 +652,8 @@ impl NativeApp {
 
             let (cterm, rterm) = panel_terminal_dims(TERMINAL_W, TERMINAL_H);
             let daemon = self.daemon.clone();
-            let model = cx.new(|cx| TerminalModel::new(session_id.clone(), cterm, rterm, &daemon, cx));
+            let model =
+                cx.new(|cx| TerminalModel::new(session_id.clone(), cterm, rterm, &daemon, cx));
             let view = cx.new(|cx| {
                 let mut tv = TerminalView::new(model.clone(), daemon.clone(), cx);
                 tv.set_content_size(TERMINAL_W, (TERMINAL_H - TITLE_HEIGHT).max(0.0));

--- a/native-ui/crates/attn-native-app/src/daemon_client.rs
+++ b/native-ui/crates/attn-native-app/src/daemon_client.rs
@@ -26,22 +26,45 @@ pub enum DaemonEvent {
     SessionsChanged,
     /// A workspace appeared (or the InitialState batch arrived). Carries the
     /// snapshot at registration time.
-    WorkspaceRegistered { workspace: Workspace },
+    WorkspaceRegistered {
+        workspace: Workspace,
+    },
     /// A workspace was removed (cascade-closed by the daemon).
-    WorkspaceUnregistered { workspace_id: String },
+    WorkspaceUnregistered {
+        workspace_id: String,
+    },
     /// A workspace's rolled-up status changed. Carries the fresh snapshot.
-    WorkspaceStateChanged { workspace: Workspace },
+    WorkspaceStateChanged {
+        workspace: Workspace,
+    },
     /// Raw PTY output for a specific session. Delivered directly so terminal
     /// models can subscribe without triggering full workspace re-renders.
-    PtyOutput { session_id: String, data: String, seq: i32 },
+    PtyOutput {
+        session_id: String,
+        data: String,
+        seq: i32,
+    },
     /// Attach result for a session — contains screen snapshot and replay data.
-    AttachResult { session_id: String, msg: Box<attn_protocol::AttachResultMessage> },
+    AttachResult {
+        session_id: String,
+        msg: Box<attn_protocol::AttachResultMessage>,
+    },
     /// PTY desync: client should re-attach.
-    PtyDesync { session_id: String },
+    PtyDesync {
+        session_id: String,
+    },
     /// PTY was resized by another client.
-    PtyResized { session_id: String, cols: u16, rows: u16 },
+    PtyResized {
+        session_id: String,
+        cols: u16,
+        rows: u16,
+    },
     /// Session process exited.
-    SessionExited { session_id: String, #[allow(dead_code)] exit_code: i32 },
+    SessionExited {
+        session_id: String,
+        #[allow(dead_code)]
+        exit_code: i32,
+    },
 }
 
 pub struct DaemonClient {
@@ -101,9 +124,7 @@ impl DaemonClient {
                         smol::spawn(async move {
                             while let Ok(msg) = cmd_rx.recv().await {
                                 if write
-                                    .send(async_tungstenite::tungstenite::Message::Text(
-                                        msg.into(),
-                                    ))
+                                    .send(async_tungstenite::tungstenite::Message::Text(msg))
                                     .await
                                     .is_err()
                                 {
@@ -175,8 +196,8 @@ impl DaemonClient {
                 .clone()
                 .unwrap_or_else(|| "daemon websocket is not connected".to_string())
         })?;
-        let json = serde_json::to_string(msg)
-            .map_err(|e| format!("serialize daemon command: {e}"))?;
+        let json =
+            serde_json::to_string(msg).map_err(|e| format!("serialize daemon command: {e}"))?;
         tx.try_send(json)
             .map_err(|e| format!("queue daemon command: {e}"))
     }

--- a/native-ui/crates/attn-native-app/src/main.rs
+++ b/native-ui/crates/attn-native-app/src/main.rs
@@ -13,7 +13,10 @@ mod terminal_view;
 mod viewport;
 mod workspace;
 
-use gpui::{actions, px, size, App, AppContext, Application, Bounds, KeyBinding, WindowBounds, WindowOptions};
+use gpui::{
+    actions, px, size, App, AppContext, Application, Bounds, KeyBinding, WindowBounds,
+    WindowOptions,
+};
 
 use app::NativeApp;
 use daemon_client::DaemonClient;
@@ -33,7 +36,7 @@ fn main() {
                 ..Default::default()
             },
             |_window, cx| {
-                let daemon = cx.new(|cx| DaemonClient::new(cx));
+                let daemon = cx.new(DaemonClient::new);
                 cx.new(|cx| NativeApp::new(daemon, cx))
             },
         )

--- a/native-ui/crates/attn-native-app/src/sidebar.rs
+++ b/native-ui/crates/attn-native-app/src/sidebar.rs
@@ -13,22 +13,30 @@ use crate::workspace::Workspace;
 
 pub const SIDEBAR_WIDTH: f32 = 240.0;
 
+type SelectHandler = dyn Fn(SharedString, &mut Window, &mut gpui::App) + 'static;
+type CreateHandler = dyn Fn(&mut Window, &mut gpui::App) + 'static;
+type DestroyHandler =
+    dyn Fn(SharedString, &mut Window, &mut gpui::App) -> Result<(), String> + 'static;
+
 pub struct Sidebar {
     workspaces: Vec<Entity<Workspace>>,
     selected_id: Option<SharedString>,
     /// Callback fired when the user clicks a row. Set up by `NativeApp`
     /// at construction time so the app can swap the canvas's selected
     /// workspace handle.
-    on_select: Box<dyn Fn(SharedString, &mut Window, &mut gpui::App) + 'static>,
+    on_select: Box<SelectHandler>,
     /// Callback fired when the user clicks "+ New Workspace". Owns the
     /// directory picker → daemon `register_workspace` flow on the app
     /// side; the sidebar just dispatches.
-    on_create: Box<dyn Fn(&mut Window, &mut gpui::App) + 'static>,
-    /// Callback fired when the user clicks a row's "×" delete affordance.
+    on_create: Box<CreateHandler>,
+    /// Callback fired after the user confirms a row's delete affordance.
     /// Sends `unregister_workspace` for the given id. Daemon cascades to
     /// member sessions, so callers don't need a separate session-cleanup
     /// step.
-    on_destroy: Box<dyn Fn(SharedString, &mut Window, &mut gpui::App) + 'static>,
+    on_destroy: Box<DestroyHandler>,
+    confirm_destroy_id: Option<SharedString>,
+    destroying_id: Option<SharedString>,
+    destroy_error: Option<(SharedString, SharedString)>,
     focus_handle: FocusHandle,
 }
 
@@ -37,7 +45,7 @@ impl Sidebar {
         workspaces: Vec<Entity<Workspace>>,
         on_select: impl Fn(SharedString, &mut Window, &mut gpui::App) + 'static,
         on_create: impl Fn(&mut Window, &mut gpui::App) + 'static,
-        on_destroy: impl Fn(SharedString, &mut Window, &mut gpui::App) + 'static,
+        on_destroy: impl Fn(SharedString, &mut Window, &mut gpui::App) -> Result<(), String> + 'static,
         cx: &mut Context<Self>,
     ) -> Self {
         // Re-render this whole view when any member workspace updates.
@@ -51,6 +59,9 @@ impl Sidebar {
             on_select: Box::new(on_select),
             on_create: Box::new(on_create),
             on_destroy: Box::new(on_destroy),
+            confirm_destroy_id: None,
+            destroying_id: None,
+            destroy_error: None,
             focus_handle: cx.focus_handle(),
         }
     }
@@ -60,7 +71,11 @@ impl Sidebar {
     /// reused), so this is a pure insert — re-inserting the same id is a no-op.
     pub fn upsert_workspace(&mut self, ws: Entity<Workspace>, cx: &mut Context<Self>) {
         let id = ws.read(cx).id.clone();
-        if self.workspaces.iter().any(|existing| existing.read(cx).id == id) {
+        if self
+            .workspaces
+            .iter()
+            .any(|existing| existing.read(cx).id == id)
+        {
             return;
         }
         cx.observe(&ws, |_, _, cx| cx.notify()).detach();
@@ -73,6 +88,7 @@ impl Sidebar {
         if self.selected_id.as_ref().map(|s| s.as_ref()) == Some(id) {
             self.selected_id = None;
         }
+        self.clear_destroy_state_for(id);
         cx.notify();
     }
 
@@ -80,6 +96,28 @@ impl Sidebar {
         if self.selected_id != id {
             self.selected_id = id;
             cx.notify();
+        }
+    }
+
+    fn clear_destroy_state_for(&mut self, id: &str) {
+        if self
+            .confirm_destroy_id
+            .as_ref()
+            .map(|pending| pending.as_ref())
+            == Some(id)
+        {
+            self.confirm_destroy_id = None;
+        }
+        if self.destroying_id.as_ref().map(|pending| pending.as_ref()) == Some(id) {
+            self.destroying_id = None;
+        }
+        if self
+            .destroy_error
+            .as_ref()
+            .map(|(error_id, _)| error_id.as_ref())
+            == Some(id)
+        {
+            self.destroy_error = None;
         }
     }
 }
@@ -101,25 +139,95 @@ impl Render for Sidebar {
                 let title = ws.title.clone();
                 let status = ws.status;
                 let selected = self.selected_id.as_ref() == Some(&id);
+                let confirming = self.confirm_destroy_id.as_ref() == Some(&id);
+                let destroying = self.destroying_id.as_ref() == Some(&id);
+                let error = self.destroy_error.as_ref().and_then(|(error_id, message)| {
+                    if error_id == &id {
+                        Some(message.clone())
+                    } else {
+                        None
+                    }
+                });
                 let click_id = id.clone();
-                let destroy_id = id.clone();
-                let row_div = workspace_row(title, status, selected)
-                    .on_mouse_down(MouseButton::Left, cx.listener(move |this, _, window, cx| {
-                        let id = click_id.clone();
-                        (this.on_select)(id.clone(), window, cx);
-                        this.set_selected(Some(id), cx);
-                    }))
-                    .child(
-                        delete_button()
-                            .on_mouse_down(MouseButton::Left, cx.listener(move |this, _, window, cx| {
-                                // Stop the row's `on_select` from firing too —
-                                // clicking × shouldn't also select the
-                                // workspace it's about to delete.
-                                cx.stop_propagation();
-                                (this.on_destroy)(destroy_id.clone(), window, cx);
-                            })),
+                let mut row_div = workspace_row(title, status, selected, confirming, destroying)
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _, window, cx| {
+                            let id = click_id.clone();
+                            let cleared_destroy_state =
+                                this.confirm_destroy_id.is_some() || this.destroy_error.is_some();
+                            this.confirm_destroy_id = None;
+                            this.destroy_error = None;
+                            (this.on_select)(id.clone(), window, cx);
+                            this.set_selected(Some(id), cx);
+                            if cleared_destroy_state {
+                                cx.notify();
+                            }
+                        }),
                     );
-                row_div.into_any_element()
+
+                if confirming {
+                    let cancel_id = id.clone();
+                    let confirm_id = id.clone();
+                    row_div = row_div
+                        .child(cancel_delete_button().on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| {
+                                cx.stop_propagation();
+                                this.clear_destroy_state_for(cancel_id.as_ref());
+                                cx.notify();
+                            }),
+                        ))
+                        .child(confirm_delete_button().on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _, window, cx| {
+                                cx.stop_propagation();
+                                match (this.on_destroy)(confirm_id.clone(), window, cx) {
+                                    Ok(()) => {
+                                        this.confirm_destroy_id = None;
+                                        this.destroying_id = Some(confirm_id.clone());
+                                        this.destroy_error = None;
+                                    }
+                                    Err(error) => {
+                                        this.confirm_destroy_id = Some(confirm_id.clone());
+                                        this.destroying_id = None;
+                                        this.destroy_error =
+                                            Some((confirm_id.clone(), SharedString::from(error)));
+                                    }
+                                }
+                                cx.notify();
+                            }),
+                        ));
+                } else {
+                    let destroy_id = id.clone();
+                    row_div = row_div.child(delete_button(destroying).on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _, _, cx| {
+                            // Stop the row's `on_select` from firing too —
+                            // clicking delete shouldn't also select the
+                            // workspace it's about to delete.
+                            cx.stop_propagation();
+                            if this.destroying_id.as_ref() == Some(&destroy_id) {
+                                return;
+                            }
+                            this.confirm_destroy_id = Some(destroy_id.clone());
+                            this.destroy_error = None;
+                            cx.notify();
+                        }),
+                    ));
+                }
+
+                if let Some(error) = error {
+                    div()
+                        .w_full()
+                        .flex()
+                        .flex_col()
+                        .child(row_div)
+                        .child(destroy_error_row(error))
+                        .into_any_element()
+                } else {
+                    row_div.into_any_element()
+                }
             })
             .collect();
 
@@ -140,14 +248,12 @@ impl Render for Sidebar {
                     .child(SharedString::from("WORKSPACES")),
             )
             .children(rows)
-            .child(
-                create_row().on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|this, _, window, cx| {
-                        (this.on_create)(window, cx);
-                    }),
-                ),
-            )
+            .child(create_row().on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    (this.on_create)(window, cx);
+                }),
+            ))
     }
 }
 
@@ -158,8 +264,23 @@ fn workspace_row(
     title: SharedString,
     status: WorkspaceStatus,
     selected: bool,
+    confirming_delete: bool,
+    destroying: bool,
 ) -> gpui::Div {
-    let bg = if selected { rgb(0x2a2a3a) } else { rgb(0x1a1a22) };
+    let bg = if confirming_delete {
+        rgb(0x3a2428)
+    } else if destroying {
+        rgb(0x24242e)
+    } else if selected {
+        rgb(0x2a2a3a)
+    } else {
+        rgb(0x1a1a22)
+    };
+    let title_color = if destroying {
+        rgb(0x8a8a95)
+    } else {
+        rgb(0xe0e0eb)
+    };
     div()
         .w_full()
         .px_4()
@@ -168,25 +289,66 @@ fn workspace_row(
         .items_center()
         .gap_2()
         .bg(bg)
-        .text_color(rgb(0xe0e0eb))
+        .text_color(title_color)
         .text_size(px(13.))
         .child(status_badge(status))
-        .child(div().flex_1().child(title))
+        .child(div().flex_1().truncate().child(title))
 }
 
 /// Trailing delete affordance on each row. Always visible (no hover gate
 /// yet — that's a follow-up once we have a hover-state pattern in this
 /// crate). Dim by default so the eye lands on titles, not crosses.
-fn delete_button() -> gpui::Div {
+fn delete_button(disabled: bool) -> gpui::Div {
+    let label = if disabled { "..." } else { "x" };
     div()
         .w(px(20.))
         .h(px(20.))
+        .flex_shrink_0()
         .flex()
         .items_center()
         .justify_center()
         .text_color(rgb(0x6a6a78))
         .text_size(px(14.))
-        .child(SharedString::from("×"))
+        .child(SharedString::from(label))
+}
+
+fn cancel_delete_button() -> gpui::Div {
+    div()
+        .px_2()
+        .h(px(20.))
+        .flex_shrink_0()
+        .flex()
+        .items_center()
+        .justify_center()
+        .text_color(rgb(0x9a9aa8))
+        .text_size(px(11.))
+        .child(SharedString::from("Cancel"))
+}
+
+fn confirm_delete_button() -> gpui::Div {
+    div()
+        .px_2()
+        .h(px(20.))
+        .flex_shrink_0()
+        .flex()
+        .items_center()
+        .justify_center()
+        .bg(rgb(0x7a2f35))
+        .rounded_sm()
+        .text_color(rgb(0xf0dadd))
+        .text_size(px(11.))
+        .child(SharedString::from("Delete"))
+}
+
+fn destroy_error_row(message: SharedString) -> gpui::Div {
+    div()
+        .w_full()
+        .px_4()
+        .pb_2()
+        .text_color(rgb(0xff8a8a))
+        .text_size(px(11.))
+        .line_clamp(2)
+        .child(message)
 }
 
 /// "+ New Workspace" entry below the workspace list. Visually distinct
@@ -210,11 +372,11 @@ fn create_row() -> gpui::Div {
 /// consistent across frontends.
 fn status_badge(status: WorkspaceStatus) -> impl IntoElement {
     let color = match status {
-        WorkspaceStatus::Working => rgb(0x4caf50),       // green
-        WorkspaceStatus::WaitingInput => rgb(0xffc107),  // amber
+        WorkspaceStatus::Working => rgb(0x4caf50),         // green
+        WorkspaceStatus::WaitingInput => rgb(0xffc107),    // amber
         WorkspaceStatus::PendingApproval => rgb(0xff9800), // orange
-        WorkspaceStatus::Idle => rgb(0x6a6a78),          // grey
-        WorkspaceStatus::Launching => rgb(0x2196f3),     // blue
+        WorkspaceStatus::Idle => rgb(0x6a6a78),            // grey
+        WorkspaceStatus::Launching => rgb(0x2196f3),       // blue
     };
     div().w(px(8.)).h(px(8.)).rounded_full().bg(color)
 }

--- a/native-ui/crates/attn-native-app/src/synthetic.rs
+++ b/native-ui/crates/attn-native-app/src/synthetic.rs
@@ -88,7 +88,12 @@ pub struct SyntheticSource {
 
 impl SyntheticSource {
     pub fn new(model: Entity<TerminalModel>, panel_idx: usize, bytes_per_tick: usize) -> Self {
-        Self { model, panel_idx, frame: 0, bytes_per_tick }
+        Self {
+            model,
+            panel_idx,
+            frame: 0,
+            bytes_per_tick,
+        }
     }
 
     pub fn tick<C: AppContext>(&mut self, cx: &mut C) {
@@ -111,7 +116,7 @@ fn make_chunk(panel_idx: usize, frame: u64, target_len: usize) -> Vec<u8> {
     // Every 60th frame, jump the cursor home and clear-to-end so the
     // parser handles cursor-position + erase-in-display, which a
     // pure-append stream wouldn't trigger.
-    if frame % 60 == 0 {
+    if frame.is_multiple_of(60) {
         buf.extend_from_slice(b"\x1b[H\x1b[J");
     }
 
@@ -153,7 +158,11 @@ mod tests {
         // The chunk includes a small ANSI envelope on top of the filler;
         // sanity-check that it's roughly the right size and ends with a
         // newline so panels actually scroll.
-        assert!(bytes.len() >= 80, "chunk smaller than target: {}", bytes.len());
+        assert!(
+            bytes.len() >= 80,
+            "chunk smaller than target: {}",
+            bytes.len()
+        );
         assert!(bytes.ends_with(b"\r\n"));
     }
 

--- a/native-ui/crates/attn-native-app/src/terminal_view.rs
+++ b/native-ui/crates/attn-native-app/src/terminal_view.rs
@@ -1,9 +1,9 @@
 use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::vte::ansi::{Color, NamedColor};
 use gpui::{
-    div, fill, point, prelude::*, px, rgb, size, App, Bounds, ElementId,
-    Font, GlobalElementId, Hsla, InspectorElementId, LayoutId, Pixels, Size, Style, TextRun,
-    Window, Context, Entity, FocusHandle, Focusable, KeyDownEvent, Keystroke,
+    div, fill, point, prelude::*, px, rgb, size, App, Bounds, Context, ElementId, Entity,
+    FocusHandle, Focusable, Font, GlobalElementId, Hsla, InspectorElementId, KeyDownEvent,
+    Keystroke, LayoutId, Pixels, Size, Style, TextRun, Window,
 };
 
 use attn_protocol::{PtyInputMessage, PtyResizeMessage};
@@ -145,13 +145,20 @@ impl Element for TerminalElement {
             underline: None,
             strikethrough: None,
         };
-        let shaped = window.text_system().shape_line("m".into(), font_size, &[run], None);
+        let shaped = window
+            .text_system()
+            .shape_line("m".into(), font_size, &[run], None);
         let cell_width = shaped.width;
         // Scale line height by the same zoom factor applied to the font size so
         // background quads and text baselines stay aligned.
         let line_height = px(ROW_HEIGHT * self.zoom);
 
-        TerminalPrepaint { cell_width, line_height, font, font_size }
+        TerminalPrepaint {
+            cell_width,
+            line_height,
+            font,
+            font_size,
+        }
     }
 
     fn paint(
@@ -164,7 +171,12 @@ impl Element for TerminalElement {
         window: &mut Window,
         cx: &mut App,
     ) {
-        let TerminalPrepaint { cell_width, line_height, font, font_size } = prepaint;
+        let TerminalPrepaint {
+            cell_width,
+            line_height,
+            font,
+            font_size,
+        } = prepaint;
         let (cell_width, line_height, font_size) = (*cell_width, *line_height, *font_size);
         let origin = bounds.origin;
 
@@ -222,7 +234,11 @@ impl Element for TerminalElement {
                     continue;
                 }
 
-                let ch = if cell.ch == '\0' || cell.ch == '\u{FEFF}' { ' ' } else { cell.ch };
+                let ch = if cell.ch == '\0' || cell.ch == '\u{FEFF}' {
+                    ' '
+                } else {
+                    cell.ch
+                };
                 let fg = if cell.is_cursor {
                     COLOR_CURSOR_FG
                 } else if cell.flags.contains(Flags::INVERSE) {
@@ -318,15 +334,22 @@ impl TerminalView {
         let focus_handle = cx.focus_handle();
 
         // Re-render whenever terminal content changes.
-        cx.subscribe(&terminal, |_this, _term, event: &TerminalEvent, cx| {
-            match event {
+        cx.subscribe(
+            &terminal,
+            |_this, _term, event: &TerminalEvent, cx| match event {
                 TerminalEvent::DataReceived | TerminalEvent::Exited => cx.notify(),
                 TerminalEvent::Desync => cx.notify(),
-            }
-        })
+            },
+        )
         .detach();
 
-        Self { terminal, daemon, focus_handle, content_size: None, zoom: 1.0 }
+        Self {
+            terminal,
+            daemon,
+            focus_handle,
+            content_size: None,
+            zoom: 1.0,
+        }
     }
 
     /// Set the canvas zoom factor used for rendering. Returns true if changed.
@@ -388,7 +411,10 @@ impl TerminalView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let event = KeyDownEvent { keystroke, is_held: false };
+        let event = KeyDownEvent {
+            keystroke,
+            is_held: false,
+        };
         self.on_key_down(&event, window, cx);
     }
 }
@@ -398,7 +424,10 @@ impl Render for TerminalView {
         // Sync terminal size to the available content area.
         // When hosted inside a canvas panel, content_size overrides viewport size.
         let (new_cols, new_rows) = if let Some((w, h)) = self.content_size {
-            (((w / CHAR_WIDTH) as u16).max(1), ((h / ROW_HEIGHT) as u16).max(1))
+            (
+                ((w / CHAR_WIDTH) as u16).max(1),
+                ((h / ROW_HEIGHT) as u16).max(1),
+            )
         } else {
             let viewport = window.viewport_size();
             (
@@ -411,7 +440,8 @@ impl Render for TerminalView {
             (t.cols, t.rows, t.session_id.clone())
         };
         if new_cols != cur_cols || new_rows != cur_rows {
-            self.terminal.update(cx, |t, _| t.resize(new_cols, new_rows));
+            self.terminal
+                .update(cx, |t, _| t.resize(new_cols, new_rows));
             let _ = self
                 .daemon
                 .read(cx)
@@ -440,7 +470,11 @@ impl Render for TerminalView {
             .text_size(px(13. * zoom))
             .track_focus(&focus_handle)
             .on_key_down(cx.listener(Self::on_key_down))
-            .child(TerminalElement { cells: all_cells, cols, zoom })
+            .child(TerminalElement {
+                cells: all_cells,
+                cols,
+                zoom,
+            })
     }
 }
 
@@ -459,11 +493,9 @@ fn encode_key(event: &KeyDownEvent) -> String {
             match k.key.as_str() {
                 // These keys always use dedicated escape sequences regardless
                 // of what key_char says (e.g. macOS may return "\n" for Enter).
-                "enter" | "escape" | "tab" | "backspace" | "delete"
-                | "up" | "down" | "left" | "right"
-                | "home" | "end" | "pageup" | "pagedown"
-                | "f1" | "f2" | "f3" | "f4" | "f5" | "f6"
-                | "f7" | "f8" | "f9" | "f10" | "f11" | "f12" => {}
+                "enter" | "escape" | "tab" | "backspace" | "delete" | "up" | "down" | "left"
+                | "right" | "home" | "end" | "pageup" | "pagedown" | "f1" | "f2" | "f3" | "f4"
+                | "f5" | "f6" | "f7" | "f8" | "f9" | "f10" | "f11" | "f12" => {}
                 _ => return key_char.clone(),
             }
         }
@@ -474,11 +506,19 @@ fn encode_key(event: &KeyDownEvent) -> String {
         "enter" => {
             // Shift+Enter inserts a newline in apps using kitty keyboard
             // protocol (e.g. Claude Code). Plain Enter always submits (\r).
-            if shift { Some("\x1b[13;2u") } else { Some("\r") }
+            if shift {
+                Some("\x1b[13;2u")
+            } else {
+                Some("\r")
+            }
         }
         "escape" => Some("\x1b"),
         "tab" => {
-            if shift { Some("\x1b[Z") } else { Some("\t") }
+            if shift {
+                Some("\x1b[Z")
+            } else {
+                Some("\t")
+            }
         }
         "backspace" => Some("\x7f"),
         "delete" => Some("\x1b[3~"),
@@ -514,7 +554,7 @@ fn encode_key(event: &KeyDownEvent) -> String {
         let key = k.key.as_str();
         if key.len() == 1 {
             let c = key.chars().next().unwrap();
-            if ('a'..='z').contains(&c) {
+            if c.is_ascii_lowercase() {
                 // Ctrl+a = \x01, Ctrl+b = \x02, ..., Ctrl+z = \x1a
                 return String::from(char::from(c as u8 - b'a' + 1));
             }

--- a/native-ui/crates/attn-protocol/src/commands.rs
+++ b/native-ui/crates/attn-protocol/src/commands.rs
@@ -13,6 +13,12 @@ impl QueryMessage {
     }
 }
 
+impl Default for QueryMessage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct ClientHelloMessage {
     pub cmd: &'static str,
@@ -46,7 +52,11 @@ pub struct AttachSessionMessage {
 
 impl AttachSessionMessage {
     pub fn new(session_id: impl Into<String>) -> Self {
-        Self { cmd: "attach_session", id: session_id.into(), attach_policy: None }
+        Self {
+            cmd: "attach_session",
+            id: session_id.into(),
+            attach_policy: None,
+        }
     }
 }
 
@@ -58,7 +68,10 @@ pub struct DetachSessionMessage {
 
 impl DetachSessionMessage {
     pub fn new(session_id: impl Into<String>) -> Self {
-        Self { cmd: "detach_session", id: session_id.into() }
+        Self {
+            cmd: "detach_session",
+            id: session_id.into(),
+        }
     }
 }
 
@@ -71,7 +84,11 @@ pub struct PtyInputMessage {
 
 impl PtyInputMessage {
     pub fn new(session_id: impl Into<String>, data: impl Into<String>) -> Self {
-        Self { cmd: "pty_input", id: session_id.into(), data: data.into() }
+        Self {
+            cmd: "pty_input",
+            id: session_id.into(),
+            data: data.into(),
+        }
     }
 }
 
@@ -85,7 +102,12 @@ pub struct PtyResizeMessage {
 
 impl PtyResizeMessage {
     pub fn new(session_id: impl Into<String>, cols: u16, rows: u16) -> Self {
-        Self { cmd: "pty_resize", id: session_id.into(), cols, rows }
+        Self {
+            cmd: "pty_resize",
+            id: session_id.into(),
+            cols,
+            rows,
+        }
     }
 }
 
@@ -120,6 +142,9 @@ pub struct UnregisterWorkspaceMessage {
 
 impl UnregisterWorkspaceMessage {
     pub fn new(id: impl Into<String>) -> Self {
-        Self { cmd: "unregister_workspace", id: id.into() }
+        Self {
+            cmd: "unregister_workspace",
+            id: id.into(),
+        }
     }
 }

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -7,57 +7,223 @@ header() {
   printf '\n[pre-commit] %s\n' "$1"
 }
 
-header "Go format"
-go_files=$(git ls-files '*.go')
-if [ -n "$go_files" ]; then
-  fmt_out=$(gofmt -l $go_files)
-  if [ -n "$fmt_out" ]; then
-    echo "gofmt required for:"
-    echo "$fmt_out"
-    echo "Run: gofmt -w <files>"
+changed_files="$(git diff --cached --name-only --diff-filter=ACMR)"
+unset GIT_INDEX_FILE
+
+if [ -z "$changed_files" ]; then
+  header "No staged files"
+  exit 0
+fi
+
+has_changed() {
+  local pattern="$1"
+  printf '%s\n' "$changed_files" | grep -Eq "$pattern"
+}
+
+has_go_files() {
+  printf '%s\n' "$changed_files" | grep -Eq '\.go$'
+}
+
+has_frontend_files() {
+  printf '%s\n' "$changed_files" | grep -E '^app/' | grep -Ev '^app/src-tauri/' | grep -Eq '.'
+}
+
+changed_matching() {
+  local pattern="$1"
+  printf '%s\n' "$changed_files" | grep -E "$pattern" || true
+}
+
+configure_pkg_config() {
+  if ! command -v pkg-config >/dev/null 2>&1 && command -v pkgconf >/dev/null 2>&1; then
+    export PKG_CONFIG="$(command -v pkgconf)"
+  fi
+
+  if [ -z "${PKG_CONFIG_PATH:-}" ] && [ -d "$HOME/.nix-profile/lib/pkgconfig" ]; then
+    export PKG_CONFIG_PATH="$HOME/.nix-profile/lib/pkgconfig:$HOME/.nix-profile/share/pkgconfig"
+  fi
+}
+
+ensure_no_unstaged_changes() {
+  local dirty=()
+  local file
+  for file in "$@"; do
+    if ! git diff --quiet -- "$file"; then
+      dirty+=("$file")
+    fi
+  done
+
+  if [ "${#dirty[@]}" -gt 0 ]; then
+    echo "Cannot auto-format partially staged files:"
+    printf '  %s\n' "${dirty[@]}"
+    echo "Stage or stash the unstaged edits, then commit again."
     exit 1
+  fi
+}
+
+format_go_files() {
+  local go_files=()
+  mapfile -t go_files < <(changed_matching '\.go$')
+  if [ "${#go_files[@]}" -eq 0 ]; then
+    return
+  fi
+
+  ensure_no_unstaged_changes "${go_files[@]}"
+  gofmt -w "${go_files[@]}"
+  git add -- "${go_files[@]}"
+}
+
+format_rust_files() {
+  local pattern="$1"
+  local rust_files=()
+  mapfile -t rust_files < <(changed_matching "$pattern")
+  if [ "${#rust_files[@]}" -eq 0 ]; then
+    return
+  fi
+
+  ensure_no_unstaged_changes "${rust_files[@]}"
+  rustfmt --edition 2021 --config skip_children=true "${rust_files[@]}"
+  git add -- "${rust_files[@]}"
+}
+
+tmp_bin=""
+cleanup_tmp_bin() {
+  if [ -n "$tmp_bin" ]; then
+    rm -f "$tmp_bin"
+  fi
+}
+trap cleanup_tmp_bin EXIT
+
+ensure_e2e_binary() {
+  if [ -n "${ATTN_E2E_BIN:-}" ] || [ -x "$root/attn" ]; then
+    return
+  fi
+
+  header "Go build for E2E"
+  tmp_bin="$(mktemp -t attn-precommit.XXXXXX)"
+  make -C "$root" build OUTPUT="$tmp_bin"
+  export ATTN_E2E_BIN="$tmp_bin"
+}
+
+run_daemon_checks=false
+run_frontend_checks=false
+run_tauri_checks=false
+run_native_checks=false
+run_shell_checks=false
+
+if has_go_files; then
+  run_daemon_checks=true
+fi
+
+if has_changed '(^|/)[^/]+\.sh$|^\.githooks/pre-commit$'; then
+  run_shell_checks=true
+fi
+
+if has_changed '^(cmd|internal|test|scripts/source-fingerprint\.sh|go\.mod|go\.sum|Makefile)(/|$)'; then
+  run_daemon_checks=true
+fi
+
+if has_changed '^internal/protocol/schema/'; then
+  run_daemon_checks=true
+  run_frontend_checks=true
+  run_native_checks=true
+fi
+
+if has_changed '^app/src-tauri/'; then
+  run_daemon_checks=true
+  run_tauri_checks=true
+fi
+
+if has_frontend_files; then
+  run_frontend_checks=true
+fi
+
+if has_changed '^(native-ui/|app/scripts/real-app-harness/scenario-native-canvas\.mjs$)'; then
+  run_daemon_checks=true
+  run_native_checks=true
+fi
+
+if has_changed '^(\.githooks/pre-commit|scripts/pre-commit\.sh|AGENTS\.md)$'; then
+  run_daemon_checks=true
+fi
+
+if [ "$run_daemon_checks" = true ]; then
+  header "Go format"
+  format_go_files
+
+  header "Go tests"
+  (cd "$root" && go test ./...)
+
+  header "Go build"
+  tmp_bin="$(mktemp -t attn-precommit.XXXXXX)"
+  make -C "$root" build OUTPUT="$tmp_bin"
+  if [ -z "${ATTN_E2E_BIN:-}" ]; then
+    export ATTN_E2E_BIN="$tmp_bin"
+  fi
+
+  header "Tauri daemon binary"
+  target_triple="$(rustc -vV | awk '/host:/ {print $2}')"
+  tauri_bin_dir="$root/app/src-tauri/binaries"
+  tauri_bin_path="$tauri_bin_dir/attn-$target_triple"
+  mkdir -p "$tauri_bin_dir"
+  if [ ! -f "$tauri_bin_path" ]; then
+    cp "$tmp_bin" "$tauri_bin_path"
   fi
 fi
 
-header "Go tests"
-(go test ./...)
-
-header "Go build"
-tmp_bin="$(mktemp -t attn-precommit.XXXXXX)"
-make -C "$root" build OUTPUT="$tmp_bin"
-
-header "Tauri daemon binary"
-target_triple="$(rustc -vV | awk '/host:/ {print $2}')"
-tauri_bin_dir="$root/app/src-tauri/binaries"
-tauri_bin_path="$tauri_bin_dir/attn-$target_triple"
-mkdir -p "$tauri_bin_dir"
-if [ ! -f "$tauri_bin_path" ]; then
-  cp "$tmp_bin" "$tauri_bin_path"
-fi
-rm -f "$tmp_bin"
-
-header "Frontend tests"
-(cd "$root/app" && pnpm run test)
-
-header "Frontend build"
-(cd "$root/app" && pnpm run build)
-
-header "E2E"
-(cd "$root/app" && pnpm run e2e)
-
-header "Rust format"
-if ! command -v pkg-config >/dev/null 2>&1; then
-  echo "pkg-config not found. Install it to run Rust checks."
-  echo "Debian/Ubuntu: sudo apt-get install -y pkg-config"
-  echo "macOS: brew install pkgconf"
-  exit 1
+if [ "$run_shell_checks" = true ]; then
+  header "Shell syntax"
+  shell_files=()
+  mapfile -t shell_files < <(changed_matching '(^|/)[^/]+\.sh$|^\.githooks/pre-commit$')
+  if [ "${#shell_files[@]}" -gt 0 ]; then
+    bash -n "${shell_files[@]}"
+  fi
 fi
 
-if [ -z "${PKG_CONFIG_PATH:-}" ] && [ -d "$HOME/.nix-profile/lib/pkgconfig" ]; then
-  export PKG_CONFIG_PATH="$HOME/.nix-profile/lib/pkgconfig:$HOME/.nix-profile/share/pkgconfig"
+if [ "$run_frontend_checks" = true ]; then
+  if [[ "${NODE_OPTIONS:-}" != *"--localstorage-file="* ]]; then
+    export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--localstorage-file=/tmp/attn-vitest-localstorage.json"
+  fi
+
+  header "Frontend tests"
+  (cd "$root/app" && pnpm run test)
+
+  header "Frontend build"
+  (cd "$root/app" && pnpm run build)
+
+  ensure_e2e_binary
+
+  header "E2E"
+  (cd "$root/app" && pnpm run e2e)
 fi
 
-(cd "$root/app/src-tauri" && cargo fmt -- --check)
+if [ "$run_tauri_checks" = true ]; then
+  configure_pkg_config
 
-header "Rust tests"
-(cd "$root/app/src-tauri" && cargo test)
+  header "Tauri Rust format"
+  format_rust_files '^app/src-tauri/.*\.rs$'
+
+  header "Tauri Rust lint"
+  (cd "$root/app/src-tauri" && cargo clippy --all-targets -- -D warnings)
+
+  header "Tauri Rust tests"
+  (cd "$root/app/src-tauri" && cargo test)
+fi
+
+if [ "$run_native_checks" = true ]; then
+  header "Native Rust format"
+  format_rust_files '^native-ui/.*\.rs$'
+
+  header "Native Rust lint"
+  (cd "$root/native-ui" && cargo clippy --workspace --all-targets -- -D warnings)
+
+  header "Native Rust tests"
+  (cd "$root/native-ui" && cargo test --workspace)
+fi
+
+if [ "$run_daemon_checks" != true ] &&
+  [ "$run_frontend_checks" != true ] &&
+  [ "$run_tauri_checks" != true ] &&
+  [ "$run_native_checks" != true ] &&
+  [ "$run_shell_checks" != true ]; then
+  header "No matching test bucket"
+fi


### PR DESCRIPTION
## Summary
- Adds inline confirmation, pending, and error states for native workspace deletion.
- Selects a fallback workspace after deleting the currently selected workspace.
- Updates the commit hook to route checks by staged paths for daemon, frontend, Tauri, and native changes, including native/Tauri rustfmt + clippy where relevant.
- Wires the tracked `.githooks/pre-commit` wrapper to the smarter hook script and exports the temp daemon binary for E2E in clean checkouts.

## Validation
- Clean-worktree staged hook replay from the parent commit passed end to end: Go format/tests/build, frontend tests/build/E2E, Tauri Rust format/lint/tests, and native Rust format/lint/tests.
- Native workspace lifecycle harness scenario updated to assert selection is restored after deleting the selected workspace.