### PR TITLE
native canvas: session create + destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-04-30]
+
+### Added
+- **Native Canvas Session Lifecycle**: The native canvas now spawns and tears down sessions inline. A "+ Session" pill at the top-left of the canvas expands to a Claude / Codex / Shell agent picker; clicking an agent spawns a new session in the selected workspace's directory and the panel appears on the canvas as soon as the daemon broadcasts it. Each panel's title bar gains an `x` close button that asks the daemon to unregister the session, after which the panel is pruned automatically. Spawn failures are recorded as structured events (`session_spawn_failed`) carrying the wire error so they're discoverable from the automation tail. Two new automation actions — `spawn_session` and `unregister_session` — let the test harness drive the same path as the UI; the canvas scenario covers them end to end.
+
+---
+
 ## [2026-04-29]
 
 ### Changed

--- a/app/scripts/real-app-harness/scenario-native-canvas.mjs
+++ b/app/scripts/real-app-harness/scenario-native-canvas.mjs
@@ -688,6 +688,124 @@ async function checkWorkspaceLifecycle(conn) {
   }
 }
 
+/**
+ * Round-trip a session through the new `spawn_session` and
+ * `unregister_session` automation actions — the same wire path the
+ * canvas's "+ Session" toolbar and the per-panel close button drive.
+ * Different from `checkPtyRoundTrip`, which goes daemon-direct and
+ * exists to prove the panel-mirroring path works regardless of who
+ * issued the spawn. Here we exercise the action plumbing end to end so
+ * a regression in `NativeApp::spawn_session_in_workspace`,
+ * pending-spawn tracking, or `unregister` wiring is caught by CI.
+ */
+async function checkSessionLifecycle(conn) {
+  // Always provision a fresh host workspace rather than trusting any
+  // previously-selected one — earlier tests destroy workspaces without
+  // awaiting the daemon's broadcast, which can leave a stale
+  // selected_workspace_id pointing at a workspace that's already gone.
+  // Use an existing directory (HOME or /tmp): unlike workspace metadata
+  // (which the daemon never opens), the cwd flows through to the
+  // session's PTY spawn, and a non-existent path makes the worker stall.
+  const directory = process.env.HOME || '/tmp';
+  const created = await conn.request('create_workspace', {
+    directory,
+    title: `Scenario Session Host ${new Date().toISOString().slice(11, 19)}`,
+  });
+  if (!created.ok) fail(`create_workspace (session host): ${created.error}`);
+  const hostWorkspaceId = created.result.id;
+  await pollUntil(
+    async () => {
+      const s = await conn.request('get_state');
+      return s.ok && s.result.workspaces?.some((w) => w.id === hostWorkspaceId);
+    },
+    { timeoutMs: 5000, label: `host workspace ${hostWorkspaceId.slice(0, 8)} in get_state` },
+  );
+
+  const cursorBefore = (await tailEvents(conn)).next_cursor;
+  const spawned = await conn.request('spawn_session', {
+    workspace_id: hostWorkspaceId,
+    agent: 'shell',
+  });
+  if (!spawned.ok) fail(`spawn_session: ${spawned.error}`);
+  const sessionId = spawned.result.session_id;
+  if (typeof sessionId !== 'string' || sessionId.length < 16) {
+    fail(`spawn_session returned suspicious id: ${JSON.stringify(spawned)}`);
+  }
+  info(`  spawned session ${sessionId.slice(0, 8)}… via action`);
+
+  let panelCleanupNeeded = true;
+  try {
+    // Wait for the panel + the spawn-success ack. Both prove different
+    // things: panel_added → sessions_changed sync ran; spawn_result
+    // success → the daemon accepted the wire message.
+    try {
+      await pollUntil(
+        async () => {
+          const tail = await tailEvents(conn, cursorBefore);
+          const sawPanel = tail.events.some(
+            (e) => e.category === 'panel_added' && e.payload.session_id === sessionId,
+          );
+          const sawAck = tail.events.some(
+            (e) =>
+              e.category === 'session_spawn_succeeded' && e.payload.session_id === sessionId,
+          );
+          return sawPanel && sawAck;
+        },
+        { timeoutMs: 15000, intervalMs: 200, label: `panel + spawn ack for ${sessionId.slice(0, 8)}` },
+      );
+    } catch (error) {
+      await dumpEventsSince(conn, cursorBefore, 'spawn_session');
+      throw error;
+    }
+    info(`  panel + spawn ack observed`);
+
+    const cursorBeforeKill = (await tailEvents(conn)).next_cursor;
+    const killed = await conn.request('unregister_session', { session_id: sessionId });
+    if (!killed.ok) fail(`unregister_session: ${killed.error}`);
+
+    try {
+      await pollUntil(
+        async () => {
+          const s = await conn.request('get_state');
+          if (!s.ok) return false;
+          const ws = s.result.workspaces.find((w) => w.id === hostWorkspaceId);
+          return !ws?.panels?.some((p) => p.session_id === sessionId);
+        },
+        {
+          timeoutMs: 5000,
+          intervalMs: 200,
+          label: `panel ${sessionId.slice(0, 8)} pruned after unregister_session`,
+        },
+      );
+    } catch (error) {
+      await dumpEventsSince(conn, cursorBeforeKill, 'unregister_session');
+      throw error;
+    }
+    panelCleanupNeeded = false;
+    info(`  cleanup ok (panel + session removed via action)`);
+  } finally {
+    if (panelCleanupNeeded) {
+      // Best-effort fallback so a failed assertion doesn't leak the
+      // session into subsequent scenarios.
+      await conn.request('unregister_session', { session_id: sessionId }).catch(() => {});
+    }
+    // Block on the workspace actually disappearing — the action
+    // returns once the cmd is queued, but the broadcast that drops
+    // it from the canvas's workspaces_by_id may still be in flight.
+    // If we returned now, the next scenario's `pickFirst('workspaces')`
+    // could grab this stale workspace and race the daemon into spawning
+    // a session in a workspace that's about to vanish.
+    await conn.request('destroy_workspace', { id: hostWorkspaceId }).catch(() => {});
+    await pollUntil(
+      async () => {
+        const s = await conn.request('get_state');
+        return s.ok && !s.result.workspaces?.some((w) => w.id === hostWorkspaceId);
+      },
+      { timeoutMs: 5000, intervalMs: 100, label: `host workspace ${hostWorkspaceId.slice(0, 8)} drained` },
+    ).catch(() => {});
+  }
+}
+
 async function main() {
   info(`profile=${PROFILE} bundle=${BUNDLE_ID}`);
   info(`automationEnabledForProfile=${automationEnabledForNativeProfile()}`);
@@ -717,6 +835,9 @@ async function main() {
 
     info(`\n[workspace lifecycle]`);
     await checkWorkspaceLifecycle(conn);
+
+    info(`\n[session lifecycle via action]`);
+    await checkSessionLifecycle(conn);
 
     info(`\n[pty round-trip]`);
     await checkPtyRoundTrip(conn, daemon);

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -9,7 +9,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use attn_protocol::{
-    AttachSessionMessage, RegisterWorkspaceMessage, Session, UnregisterWorkspaceMessage,
+    AttachSessionMessage, RegisterWorkspaceMessage, Session, SpawnSessionMessage,
+    UnregisterSessionMessage, UnregisterWorkspaceMessage,
 };
 use gpui::{
     div, prelude::*, rgb, App, Context, Entity, ParentElement, PathPromptOptions, Render,
@@ -41,6 +42,11 @@ pub struct NativeApp {
     canvas: Entity<WorkspaceCanvas>,
     selected_id: Option<SharedString>,
     pending_select_workspace_ids: HashSet<SharedString>,
+    /// Spawns we've issued but the daemon hasn't acked yet. Keyed by
+    /// session id (the same one we sent on the wire). On `SpawnResult`
+    /// the entry is consumed and either dropped (success) or surfaced as
+    /// a failure event.
+    pending_spawns: HashMap<SharedString, PendingSpawn>,
     /// Live automation server handle. Drop deletes the manifest. `None`
     /// when automation is disabled for this launch (default in prod) or
     /// when bind/start failed — in which case we still want the app to
@@ -53,10 +59,37 @@ pub struct NativeApp {
     synthetic: Vec<SyntheticSource>,
 }
 
+/// In-flight spawn metadata. We track just enough to attribute a
+/// `SpawnResult` failure back to the workspace + agent the user selected
+/// when they triggered the spawn.
+#[derive(Debug, Clone)]
+struct PendingSpawn {
+    workspace_id: SharedString,
+    agent: SharedString,
+}
+
 impl NativeApp {
     pub fn new(daemon: Entity<DaemonClient>, cx: &mut Context<Self>) -> Self {
-        let canvas = cx.new(WorkspaceCanvas::new);
         let app_handle = cx.entity().downgrade();
+        let app_handle_canvas_spawn = app_handle.clone();
+        let app_handle_canvas_close = app_handle.clone();
+        let canvas = cx.new(|cx| {
+            WorkspaceCanvas::new(
+                cx,
+                move |workspace_id, agent, _window, cx| {
+                    let app_handle = app_handle_canvas_spawn.clone();
+                    let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
+                        let _ = app.spawn_session_in_workspace(workspace_id, agent, cx);
+                    });
+                },
+                move |session_id, _window, cx| {
+                    let app_handle = app_handle_canvas_close.clone();
+                    let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
+                        app.unregister_session_by_id(session_id, cx);
+                    });
+                },
+            )
+        });
         let app_handle_create = app_handle.clone();
         let app_handle_destroy = app_handle.clone();
         let sidebar = cx.new(|cx| {
@@ -142,6 +175,34 @@ impl NativeApp {
                     );
                     this.sync_terminal_panels(cx);
                 }
+                DaemonEvent::SpawnResult {
+                    session_id,
+                    success,
+                    error,
+                } => {
+                    let key = SharedString::from(session_id.clone());
+                    let pending = this.pending_spawns.remove(&key);
+                    if *success {
+                        events::record(
+                            "session_spawn_succeeded",
+                            json!({
+                                "session_id": session_id,
+                                "workspace_id": pending.as_ref().map(|p| p.workspace_id.as_ref()),
+                                "agent": pending.as_ref().map(|p| p.agent.as_ref()),
+                            }),
+                        );
+                    } else {
+                        events::record(
+                            "session_spawn_failed",
+                            json!({
+                                "session_id": session_id,
+                                "workspace_id": pending.as_ref().map(|p| p.workspace_id.as_ref()),
+                                "agent": pending.as_ref().map(|p| p.agent.as_ref()),
+                                "error": error.as_deref(),
+                            }),
+                        );
+                    }
+                }
                 DaemonEvent::Connected => {
                     events::record("daemon_connected", json!({}));
                     // Daemon tracks PTY attachments per client connection,
@@ -171,6 +232,7 @@ impl NativeApp {
             canvas,
             selected_id: None,
             pending_select_workspace_ids: HashSet::new(),
+            pending_spawns: HashMap::new(),
             _automation: automation_handle,
             synthetic: Vec::new(),
         };
@@ -311,6 +373,100 @@ impl NativeApp {
             json!({"id": id_string.as_str()}),
         );
         Ok(())
+    }
+
+    /// Spawn a new session inside `workspace_id`, using the workspace's
+    /// directory as the cwd and the canvas's default panel-derived
+    /// terminal dimensions. The daemon's `session_registered` broadcast
+    /// is the source of truth for the panel appearing — `sync_terminal_panels`
+    /// picks it up and adds the panel — so we don't optimistically push
+    /// anything into the canvas here. Returns the freshly generated session
+    /// id on successful queue, an error string on lookup or wire failure.
+    pub fn spawn_session_in_workspace(
+        &mut self,
+        workspace_id: SharedString,
+        agent: SharedString,
+        cx: &mut Context<Self>,
+    ) -> Result<SharedString, String> {
+        let Some(ws_entity) = self.workspaces_by_id.get(&workspace_id).cloned() else {
+            let known: Vec<String> = self
+                .workspaces_by_id
+                .keys()
+                .map(|s| s.to_string())
+                .collect();
+            events::record(
+                "session_spawn_missed",
+                json!({
+                    "workspace_id": workspace_id.as_ref(),
+                    "reason": "unknown_workspace",
+                    "known_workspace_ids": known,
+                }),
+            );
+            return Err(format!("unknown workspace id: {workspace_id}"));
+        };
+        let directory = ws_entity.read(cx).directory.to_string();
+        let session_id = automation::actions::generate_workspace_id();
+        let (cols, rows) = panel_terminal_dims(TERMINAL_W, TERMINAL_H);
+        let msg = SpawnSessionMessage::new(
+            session_id.clone(),
+            directory.clone(),
+            workspace_id.to_string(),
+            agent.to_string(),
+            cols,
+            rows,
+        );
+        if let Err(error) = self.daemon.read(cx).send_cmd(&msg) {
+            events::record(
+                "session_spawn_send_failed",
+                json!({
+                    "session_id": session_id,
+                    "workspace_id": workspace_id.as_ref(),
+                    "agent": agent.as_ref(),
+                    "error": error,
+                }),
+            );
+            return Err(format!("send spawn_session: {error}"));
+        }
+        let id_shared = SharedString::from(session_id.clone());
+        self.pending_spawns.insert(
+            id_shared.clone(),
+            PendingSpawn {
+                workspace_id: workspace_id.clone(),
+                agent: agent.clone(),
+            },
+        );
+        events::record(
+            "session_spawn_submitted",
+            json!({
+                "session_id": session_id,
+                "workspace_id": workspace_id.as_ref(),
+                "agent": agent.as_ref(),
+                "directory": directory,
+            }),
+        );
+        Ok(id_shared)
+    }
+
+    /// Tear down a session by sending `unregister`. The daemon SIGTERMs
+    /// the PTY, drops the session record, and broadcasts
+    /// `session_unregistered`; `sync_terminal_panels` prunes the panel.
+    pub fn unregister_session_by_id(&mut self, session_id: SharedString, cx: &Context<Self>) {
+        let id = session_id.to_string();
+        match self
+            .daemon
+            .read(cx)
+            .send_cmd(&UnregisterSessionMessage::new(id.clone()))
+        {
+            Ok(()) => {
+                events::record("session_unregister_submitted", json!({"session_id": id}));
+            }
+            Err(error) => {
+                events::record(
+                    "session_unregister_send_failed",
+                    json!({"session_id": id, "error": error}),
+                );
+            }
+        }
     }
 
     /// Switch the canvas + sidebar to the given workspace id. Shared by

--- a/native-ui/crates/attn-native-app/src/automation/actions.rs
+++ b/native-ui/crates/attn-native-app/src/automation/actions.rs
@@ -8,8 +8,11 @@
 use std::sync::Arc;
 
 use async_channel::{unbounded, Receiver, Sender};
-use attn_protocol::{PtyInputMessage, UnregisterWorkspaceMessage};
-use gpui::{prelude::*, AnyView, App, AsyncApp, Entity, Keystroke, Modifiers, SharedString, WeakEntity, Window};
+use attn_protocol::{PtyInputMessage, UnregisterSessionMessage, UnregisterWorkspaceMessage};
+use gpui::{
+    prelude::*, AnyView, App, AsyncApp, Entity, Keystroke, Modifiers, SharedString, WeakEntity,
+    Window,
+};
 use serde_json::{json, Value};
 
 use crate::app::NativeApp;
@@ -90,14 +93,18 @@ async fn handle_action(
         "set_zoom" => set_zoom(app, cx, payload),
         "create_workspace" => create_workspace(app, cx, payload),
         "destroy_workspace" => destroy_workspace(app, cx, payload),
+        "spawn_session" => spawn_session(app, cx, payload),
+        "unregister_session" => unregister_session(app, cx, payload),
         _ => Err(format!("unknown action: {action}")),
     }
 }
 
 fn get_state(app: &WeakEntity<NativeApp>, cx: &mut AsyncApp) -> Result<Value, String> {
     let entity = app.upgrade().ok_or("NativeApp entity dropped")?;
-    cx.read_entity(&entity, |app: &NativeApp, cx: &App| app.automation_snapshot(cx))
-        .map_err(|e| format!("read entity: {e}"))
+    cx.read_entity(&entity, |app: &NativeApp, cx: &App| {
+        app.automation_snapshot(cx)
+    })
+    .map_err(|e| format!("read entity: {e}"))
 }
 
 fn list_sessions(app: &WeakEntity<NativeApp>, cx: &mut AsyncApp) -> Result<Value, String> {
@@ -144,10 +151,22 @@ fn move_panel(
         .get("panel_id")
         .and_then(Value::as_u64)
         .ok_or("payload.panel_id (number) is required")? as usize;
-    let world_x = payload.get("world_x").and_then(Value::as_f64).map(|n| n as f32);
-    let world_y = payload.get("world_y").and_then(Value::as_f64).map(|n| n as f32);
-    let width = payload.get("width").and_then(Value::as_f64).map(|n| n as f32);
-    let height = payload.get("height").and_then(Value::as_f64).map(|n| n as f32);
+    let world_x = payload
+        .get("world_x")
+        .and_then(Value::as_f64)
+        .map(|n| n as f32);
+    let world_y = payload
+        .get("world_y")
+        .and_then(Value::as_f64)
+        .map(|n| n as f32);
+    let width = payload
+        .get("width")
+        .and_then(Value::as_f64)
+        .map(|n| n as f32);
+    let height = payload
+        .get("height")
+        .and_then(Value::as_f64)
+        .map(|n| n as f32);
 
     let app_entity = app.upgrade().ok_or("NativeApp entity dropped")?;
     let workspace = cx
@@ -277,6 +296,84 @@ fn destroy_workspace(
     Ok(json!({ "id": id }))
 }
 
+/// Spawn a new session inside an existing workspace through the same
+/// `NativeApp::spawn_session_in_workspace` path the canvas toolbar uses,
+/// so a regression in id generation, pending-spawn tracking, or wire
+/// shape trips this action just like it would in the UI. Caller may
+/// override `cwd` for tests that want to spawn outside the workspace's
+/// recorded directory; otherwise we fall back to the workspace's cwd
+/// (matching the toolbar's behaviour).
+fn spawn_session(
+    app: &WeakEntity<NativeApp>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let workspace_id = payload
+        .get("workspace_id")
+        .and_then(Value::as_str)
+        .ok_or("payload.workspace_id (string) is required")?
+        .trim()
+        .to_string();
+    if workspace_id.is_empty() {
+        return Err("payload.workspace_id must be non-empty".to_string());
+    }
+    let agent = payload
+        .get("agent")
+        .and_then(Value::as_str)
+        .ok_or("payload.agent (string) is required")?
+        .trim()
+        .to_string();
+    if agent.is_empty() {
+        return Err("payload.agent must be non-empty".to_string());
+    }
+
+    let app_entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    let session_id = cx
+        .update_entity(&app_entity, |app: &mut NativeApp, cx| {
+            app.spawn_session_in_workspace(
+                SharedString::from(workspace_id.clone()),
+                SharedString::from(agent.clone()),
+                cx,
+            )
+        })
+        .map_err(|e| format!("update entity: {e}"))??;
+
+    Ok(json!({
+        "session_id": session_id.as_ref(),
+        "workspace_id": workspace_id,
+        "agent": agent,
+    }))
+}
+
+/// Tear down a session through the same daemon command the canvas's
+/// panel close button issues. Idempotent on the daemon — retrying after
+/// a missed response can't double-fault.
+fn unregister_session(
+    app: &WeakEntity<NativeApp>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .ok_or("payload.session_id (string) is required")?
+        .trim()
+        .to_string();
+    if session_id.is_empty() {
+        return Err("payload.session_id must be non-empty".to_string());
+    }
+
+    let app_entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    cx.read_entity(&app_entity, |app: &NativeApp, cx: &App| {
+        app.daemon()
+            .read(cx)
+            .send_cmd(&UnregisterSessionMessage::new(session_id.clone()))
+    })
+    .map_err(|e| format!("read entity: {e}"))??;
+
+    Ok(json!({ "session_id": session_id }))
+}
+
 /// UUIDv4-shaped hex id (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`) so
 /// generated workspace ids look like the daemon's CLI-generated ones in
 /// logs and the recent-locations table. Pulling in the `uuid` crate just
@@ -367,18 +464,21 @@ fn type_into_panel(
     let keystrokes = keystrokes_for_text(&text);
     let count = keystrokes.len();
 
-    cx.update_window(window, |_root: AnyView, window: &mut Window, app: &mut App| {
-        view.update(app, |view: &mut TerminalView, cx| {
-            // Focus first so the on_key_down handler accepts the
-            // keystroke. Mirrors what a real click would do before the
-            // user starts typing — we want the test to fail if focus
-            // routing is broken, not silently succeed.
-            view.focus_handle.clone().focus(window);
-            for keystroke in keystrokes {
-                view.inject_keystroke(keystroke, window, cx);
-            }
-        });
-    })
+    cx.update_window(
+        window,
+        |_root: AnyView, window: &mut Window, app: &mut App| {
+            view.update(app, |view: &mut TerminalView, cx| {
+                // Focus first so the on_key_down handler accepts the
+                // keystroke. Mirrors what a real click would do before the
+                // user starts typing — we want the test to fail if focus
+                // routing is broken, not silently succeed.
+                view.focus_handle.clone().focus(window);
+                for keystroke in keystrokes {
+                    view.inject_keystroke(keystroke, window, cx);
+                }
+            });
+        },
+    )
     .map_err(|e| format!("update window: {e}"))?;
 
     Ok(json!({
@@ -463,7 +563,11 @@ fn find_terminal_model(
 ) -> Option<Entity<TerminalModel>> {
     for ws in app.workspaces() {
         for panel in ws.read(cx).panels.iter() {
-            if let PanelContent::Terminal { session_id: sid, view } = &panel.content {
+            if let PanelContent::Terminal {
+                session_id: sid,
+                view,
+            } = &panel.content
+            {
                 if sid.as_ref() == session_id {
                     return Some(view.read(cx).model().clone());
                 }
@@ -476,14 +580,14 @@ fn find_terminal_model(
 /// Like `find_terminal_model` but returns the GPUI view entity. Needed by
 /// `type_into_panel` because keystroke dispatch happens on the view, not
 /// the model.
-fn find_terminal_view(
-    app: &NativeApp,
-    session_id: &str,
-    cx: &App,
-) -> Option<Entity<TerminalView>> {
+fn find_terminal_view(app: &NativeApp, session_id: &str, cx: &App) -> Option<Entity<TerminalView>> {
     for ws in app.workspaces() {
         for panel in ws.read(cx).panels.iter() {
-            if let PanelContent::Terminal { session_id: sid, view } = &panel.content {
+            if let PanelContent::Terminal {
+                session_id: sid,
+                view,
+            } = &panel.content
+            {
                 if sid.as_ref() == session_id {
                     return Some(view.clone());
                 }
@@ -498,10 +602,7 @@ fn find_terminal_view(
 /// access — the buffer is global — but routes through the action pump
 /// for protocol uniformity.
 fn tail_events(payload: Value) -> Result<Value, String> {
-    let cursor = payload
-        .get("since_id")
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
+    let cursor = payload.get("since_id").and_then(Value::as_u64).unwrap_or(0);
     Ok(events::tail_events_response(cursor))
 }
 
@@ -605,7 +706,10 @@ mod tests {
         }
         // Version + variant nibbles per RFC 4122.
         assert_eq!(bytes[14], b'4', "version nibble: {id}");
-        assert!(matches!(bytes[19], b'8' | b'9' | b'a' | b'b'), "variant nibble: {id}");
+        assert!(
+            matches!(bytes[19], b'8' | b'9' | b'a' | b'b'),
+            "variant nibble: {id}"
+        );
     }
 
     #[test]

--- a/native-ui/crates/attn-native-app/src/canvas.rs
+++ b/native-ui/crates/attn-native-app/src/canvas.rs
@@ -15,6 +15,19 @@ use gpui::{
     Render, ScrollDelta, ScrollWheelEvent, SharedString, Subscription, Window,
 };
 
+/// Callback invoked when the user picks an agent from the canvas's
+/// "+ Session" toolbar. The canvas only knows the selected workspace
+/// and the chosen agent label; resolving the cwd and minting a session
+/// id happen on the `NativeApp` side.
+pub type SpawnSessionHandler =
+    dyn Fn(SharedString, SharedString, &mut Window, &mut gpui::App) + 'static;
+
+/// Callback invoked when the user clicks a panel's close button. The
+/// canvas hands off the session id; `NativeApp` sends the daemon
+/// `unregister`, which cascades to `session_unregistered` and the panel
+/// is pruned by `sync_terminal_panels`.
+pub type CloseSessionHandler = dyn Fn(SharedString, &mut Window, &mut gpui::App) + 'static;
+
 use serde_json::{json, Value};
 
 use crate::fps_overlay::{self, FpsCounter};
@@ -41,9 +54,18 @@ enum ResizeHandle {
 #[derive(Clone, Debug)]
 enum DragState {
     Idle,
-    PanningCanvas { last_screen: gpui::Point<Pixels> },
-    DraggingPanel { panel_id: usize, last_screen: gpui::Point<Pixels> },
-    ResizingPanel { panel_id: usize, handle: ResizeHandle, last_screen: gpui::Point<Pixels> },
+    PanningCanvas {
+        last_screen: gpui::Point<Pixels>,
+    },
+    DraggingPanel {
+        panel_id: usize,
+        last_screen: gpui::Point<Pixels>,
+    },
+    ResizingPanel {
+        panel_id: usize,
+        handle: ResizeHandle,
+        last_screen: gpui::Point<Pixels>,
+    },
 }
 
 #[derive(Debug)]
@@ -72,10 +94,19 @@ pub struct WorkspaceCanvas {
     /// Frame-time overlay. `Some` only when `ATTN_NATIVE_FPS=1` was set
     /// at startup. Off by default — no record cost, no overlay paint.
     fps: Option<FpsCounter>,
+    /// True while the agent picker chip strip is expanded under the
+    /// "+ Session" pill. Click outside or pick an agent to dismiss.
+    spawn_picker_open: bool,
+    on_spawn: Box<SpawnSessionHandler>,
+    on_close_session: Box<CloseSessionHandler>,
 }
 
 impl WorkspaceCanvas {
-    pub fn new(cx: &mut Context<Self>) -> Self {
+    pub fn new(
+        cx: &mut Context<Self>,
+        on_spawn: impl Fn(SharedString, SharedString, &mut Window, &mut gpui::App) + 'static,
+        on_close_session: impl Fn(SharedString, &mut Window, &mut gpui::App) + 'static,
+    ) -> Self {
         let fps = if env_flag("ATTN_NATIVE_FPS") {
             Some(FpsCounter::new())
         } else {
@@ -90,6 +121,9 @@ impl WorkspaceCanvas {
             focus_handle: cx.focus_handle(),
             bounds: Rc::new(Cell::new(None)),
             fps,
+            spawn_picker_open: false,
+            on_spawn: Box::new(on_spawn),
+            on_close_session: Box::new(on_close_session),
         }
     }
 
@@ -98,14 +132,12 @@ impl WorkspaceCanvas {
     /// scripts can drive perf measurements at known zoom levels.
     /// `reset_fps=true` clears the FPS counter (when enabled) so
     /// post-change samples reflect the new steady state.
-    pub fn set_zoom_centered(
-        &mut self,
-        target_zoom: f32,
-        reset_fps: bool,
-        cx: &mut Context<Self>,
-    ) {
+    pub fn set_zoom_centered(&mut self, target_zoom: f32, reset_fps: bool, cx: &mut Context<Self>) {
         let center = match self.bounds.get() {
-            Some(b) => point(b.origin.x + b.size.width / 2.0, b.origin.y + b.size.height / 2.0),
+            Some(b) => point(
+                b.origin.x + b.size.width / 2.0,
+                b.origin.y + b.size.height / 2.0,
+            ),
             None => point(gpui::px(500.0), gpui::px(400.0)),
         };
         let local = self.local_pos(center);
@@ -187,7 +219,9 @@ impl WorkspaceCanvas {
 
         // Check panels in reverse so the topmost (last rendered) wins.
         for panel in panels.iter().rev() {
-            let sp = self.viewport.world_to_screen(point(panel.world_x, panel.world_y));
+            let sp = self
+                .viewport
+                .world_to_screen(point(panel.world_x, panel.world_y));
             let sx = pf(sp.x);
             let sy = pf(sp.y);
             let sw = panel.width * zoom;
@@ -237,11 +271,17 @@ impl WorkspaceCanvas {
         match hit {
             HitResult::TitleBar(id) => {
                 self.focused_panel = Some(id);
-                self.drag_state = DragState::DraggingPanel { panel_id: id, last_screen: pos };
+                self.drag_state = DragState::DraggingPanel {
+                    panel_id: id,
+                    last_screen: pos,
+                };
             }
             HitResult::ResizeHandle(id, handle) => {
-                self.drag_state =
-                    DragState::ResizingPanel { panel_id: id, handle, last_screen: pos };
+                self.drag_state = DragState::ResizingPanel {
+                    panel_id: id,
+                    handle,
+                    last_screen: pos,
+                };
             }
             HitResult::PanelBody(id) => {
                 self.focused_panel = Some(id);
@@ -281,7 +321,10 @@ impl WorkspaceCanvas {
                 self.drag_state = DragState::PanningCanvas { last_screen: pos };
             }
 
-            DragState::DraggingPanel { panel_id, last_screen } => {
+            DragState::DraggingPanel {
+                panel_id,
+                last_screen,
+            } => {
                 let dx = (pf(pos.x) - pf(last_screen.x)) / self.viewport.zoom;
                 let dy = (pf(pos.y) - pf(last_screen.y)) / self.viewport.zoom;
                 if let Some(ws) = self.selected.as_ref() {
@@ -293,10 +336,17 @@ impl WorkspaceCanvas {
                         }
                     });
                 }
-                self.drag_state = DragState::DraggingPanel { panel_id, last_screen: pos };
+                self.drag_state = DragState::DraggingPanel {
+                    panel_id,
+                    last_screen: pos,
+                };
             }
 
-            DragState::ResizingPanel { panel_id, handle, last_screen } => {
+            DragState::ResizingPanel {
+                panel_id,
+                handle,
+                last_screen,
+            } => {
                 // Screen delta → world delta so resize feels zoom-invariant.
                 let dx = (pf(pos.x) - pf(last_screen.x)) / self.viewport.zoom;
                 let dy = (pf(pos.y) - pf(last_screen.y)) / self.viewport.zoom;
@@ -308,19 +358,17 @@ impl WorkspaceCanvas {
                         }
                     });
                 }
-                self.drag_state =
-                    DragState::ResizingPanel { panel_id, handle, last_screen: pos };
+                self.drag_state = DragState::ResizingPanel {
+                    panel_id,
+                    handle,
+                    last_screen: pos,
+                };
             }
         }
         cx.notify();
     }
 
-    fn on_mouse_up(
-        &mut self,
-        _event: &MouseUpEvent,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
+    fn on_mouse_up(&mut self, _event: &MouseUpEvent, _window: &mut Window, cx: &mut Context<Self>) {
         self.drag_state = DragState::Idle;
         cx.notify();
     }
@@ -341,7 +389,9 @@ impl WorkspaceCanvas {
             // space so the focal point lands under the actual cursor and
             // not 240px to its right.
             let factor = if dy > 0.0 { 1.08 } else { 1.0 / 1.08 };
-            self.viewport = self.viewport.zoom_toward(self.local_pos(event.position), factor);
+            self.viewport = self
+                .viewport
+                .zoom_toward(self.local_pos(event.position), factor);
         } else {
             // Regular scroll → pan.
             self.viewport.origin.x -= dx / self.viewport.zoom;
@@ -432,14 +482,8 @@ impl Render for WorkspaceCanvas {
             return r;
         };
 
+        let workspace_id = selected.read(cx).id.clone();
         let panels = selected.read(cx).panels.clone();
-        if panels.is_empty() {
-            let mut r = root.child(empty_state(SharedString::from("Workspace has no panels yet")));
-            if let Some(readout) = readout {
-                r = r.child(fps_overlay::overlay(readout, 0, viewport.zoom));
-            }
-            return r;
-        }
 
         // Push content_size + zoom into every TerminalView so their next
         // render syncs cell dims and emits PtyResize on actual change.
@@ -472,14 +516,42 @@ impl Render for WorkspaceCanvas {
             }
 
             let is_focused = focused_panel == Some(panel.id);
-            let border_color = if is_focused { rgb(0x4a9eff) } else { rgb(0x2a2a35) };
+            let border_color = if is_focused {
+                rgb(0x4a9eff)
+            } else {
+                rgb(0x2a2a35)
+            };
             let content_h = (sh - title_h).max(0.0);
             let title = panel.title.clone();
+            let close_target = match &panel.content {
+                PanelContent::Terminal { session_id, .. } => Some(session_id.clone()),
+                PanelContent::Placeholder(_) => None,
+            };
 
             let body: AnyElement = match &panel.content {
                 PanelContent::Placeholder(view) => view.clone().into_any_element(),
                 PanelContent::Terminal { view, .. } => view.clone().into_any_element(),
             };
+
+            let mut title_bar = div()
+                .w_full()
+                .h(px(title_h))
+                .bg(rgb(0x252535))
+                .flex()
+                .items_center()
+                .pl(px(8.0))
+                .pr(px(4.0))
+                .child(
+                    div()
+                        .flex_1()
+                        .truncate()
+                        .text_xs()
+                        .text_color(rgb(0xa0a0b0))
+                        .child(title),
+                );
+            if let Some(session_id) = close_target {
+                title_bar = title_bar.child(panel_close_button(session_id, cx));
+            }
 
             let panel_div = div()
                 .absolute()
@@ -490,17 +562,14 @@ impl Render for WorkspaceCanvas {
                 .bg(rgb(0x1c1c26))
                 .border_1()
                 .border_color(border_color)
+                .child(title_bar)
                 .child(
                     div()
                         .w_full()
-                        .h(px(title_h))
-                        .bg(rgb(0x252535))
-                        .flex()
-                        .items_center()
-                        .pl(px(8.0))
-                        .child(div().text_xs().text_color(rgb(0xa0a0b0)).child(title)),
+                        .h(px(content_h))
+                        .overflow_hidden()
+                        .child(body),
                 )
-                .child(div().w_full().h(px(content_h)).overflow_hidden().child(body))
                 .child(corner_handle(0.0, 0.0))
                 .child(corner_handle(sw - HANDLE_SIZE, 0.0))
                 .child(corner_handle(0.0, sh - HANDLE_SIZE))
@@ -509,11 +578,133 @@ impl Render for WorkspaceCanvas {
             root = root.child(panel_div);
         }
 
+        if panels.is_empty() {
+            root = root.child(empty_state(SharedString::from(
+                "Workspace has no panels yet — pick an agent above to start one",
+            )));
+        }
+
+        // Render the spawn toolbar last so it sits on top of panels and
+        // empty-state copy. Always visible when a workspace is selected so
+        // the entry point to dogfood is unmissable.
+        root = root.child(self.render_spawn_toolbar(workspace_id, cx));
+
         if let Some(readout) = readout {
             root = root.child(fps_overlay::overlay(readout, panels.len(), viewport.zoom));
         }
         root
     }
+}
+
+impl WorkspaceCanvas {
+    /// Top-left "+ Session" pill plus an inline agent picker (Claude /
+    /// Codex / Shell) that expands when the pill is clicked. All chips
+    /// stop propagation so clicks don't also pan the canvas underneath.
+    fn render_spawn_toolbar(
+        &self,
+        workspace_id: SharedString,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let mut row = div()
+            .absolute()
+            .top(px(12.0))
+            .left(px(12.0))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(6.0))
+            .child(spawn_pill(self.spawn_picker_open).on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, _, cx| {
+                    cx.stop_propagation();
+                    this.spawn_picker_open = !this.spawn_picker_open;
+                    cx.notify();
+                }),
+            ));
+
+        if self.spawn_picker_open {
+            for (label, agent_id) in SPAWNABLE_AGENTS {
+                let agent = SharedString::from(*agent_id);
+                let workspace_id = workspace_id.clone();
+                row = row.child(agent_chip(SharedString::from(*label)).on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, window, cx| {
+                        cx.stop_propagation();
+                        let workspace_id = workspace_id.clone();
+                        let agent = agent.clone();
+                        this.spawn_picker_open = false;
+                        (this.on_spawn)(workspace_id, agent, window, cx);
+                        cx.notify();
+                    }),
+                ));
+            }
+        }
+
+        row.into_any_element()
+    }
+}
+
+/// Trailing close button rendered on each terminal panel's title bar.
+/// Shares the dim grey treatment of corner_handle / sidebar's delete `x`
+/// so the eye reads it as an affordance, not a primary action.
+fn panel_close_button(session_id: SharedString, cx: &mut Context<WorkspaceCanvas>) -> gpui::Div {
+    div()
+        .w(px(20.0))
+        .h(px(18.0))
+        .flex_shrink_0()
+        .flex()
+        .items_center()
+        .justify_center()
+        .text_color(rgb(0x6a6a78))
+        .text_size(px(13.0))
+        .child(SharedString::from("x"))
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _, window, cx| {
+                // Stop propagation so the click doesn't also trigger the
+                // canvas's title-bar drag-start hit (which would mid-drag
+                // the panel we're about to remove).
+                cx.stop_propagation();
+                let id = session_id.clone();
+                (this.on_close_session)(id, window, cx);
+            }),
+        )
+}
+
+/// Static list of agents the canvas spawn toolbar offers. Strings on the
+/// right are the wire-level agent identifiers the daemon understands
+/// (`internal/protocol/schema/main.tsp` SessionAgent enum). Adding more
+/// is a one-line append once we have icons / labels for them.
+const SPAWNABLE_AGENTS: &[(&str, &str)] =
+    &[("Claude", "claude"), ("Codex", "codex"), ("Shell", "shell")];
+
+/// "+ Session" pill. Visually distinct from agent chips so it reads as
+/// the disclosure trigger, not one of the choices. Highlighted when the
+/// picker is expanded so it's clear which surface is active.
+fn spawn_pill(open: bool) -> gpui::Div {
+    let bg = if open { rgb(0x3a3a4a) } else { rgb(0x252535) };
+    let text = if open { rgb(0xf0f0f5) } else { rgb(0xc8c8d2) };
+    div()
+        .px(px(10.0))
+        .py(px(4.0))
+        .rounded(px(4.0))
+        .bg(bg)
+        .text_color(text)
+        .text_size(px(12.0))
+        .child(SharedString::from("+ Session"))
+}
+
+fn agent_chip(label: SharedString) -> gpui::Div {
+    div()
+        .px(px(8.0))
+        .py(px(4.0))
+        .rounded(px(4.0))
+        .bg(rgb(0x2c2c3a))
+        .border_1()
+        .border_color(rgb(0x3a3a4a))
+        .text_color(rgb(0xd8d8e2))
+        .text_size(px(12.0))
+        .child(label)
 }
 
 fn env_flag(name: &str) -> bool {

--- a/native-ui/crates/attn-native-app/src/daemon_client.rs
+++ b/native-ui/crates/attn-native-app/src/daemon_client.rs
@@ -65,6 +65,15 @@ pub enum DaemonEvent {
         #[allow(dead_code)]
         exit_code: i32,
     },
+    /// Daemon ack for a `spawn_session` we issued. `success=false` carries
+    /// `error` describing the failure (invalid agent, executable missing,
+    /// PTY spawn failure). The client surfaces this so spawns that go
+    /// nowhere don't fail silently.
+    SpawnResult {
+        session_id: String,
+        success: bool,
+        error: Option<String>,
+    },
 }
 
 pub struct DaemonClient {
@@ -319,6 +328,13 @@ impl DaemonClient {
                     exit_code: msg.exit_code,
                 });
             }
+            ServerEvent::SpawnResult(msg) => {
+                cx.emit(DaemonEvent::SpawnResult {
+                    session_id: msg.id,
+                    success: msg.success,
+                    error: msg.error,
+                });
+            }
             ServerEvent::Unknown(_) => {}
         }
     }
@@ -410,6 +426,12 @@ fn record_inbound_event(event: &ServerEvent) {
             "kind": "session_exited",
             "session_id": m.id.as_str(),
             "exit_code": m.exit_code,
+        }),
+        ServerEvent::SpawnResult(m) => json!({
+            "kind": "spawn_result",
+            "session_id": m.id.as_str(),
+            "success": m.success,
+            "error": m.error.as_deref(),
         }),
         ServerEvent::PtyOutput(_) => return,
         ServerEvent::Unknown(name) => json!({"kind": "unknown", "event": name.as_str()}),

--- a/native-ui/crates/attn-protocol/src/commands.rs
+++ b/native-ui/crates/attn-protocol/src/commands.rs
@@ -148,3 +148,64 @@ impl UnregisterWorkspaceMessage {
         }
     }
 }
+
+/// Ask the daemon to spawn a new session inside an existing workspace.
+/// Mirrors `spawn_session` in `internal/protocol/schema/main.tsp`. Only the
+/// fields the native canvas needs are modelled — the legacy executable
+/// override fields are skipped (clients that need them can extend later).
+#[derive(Debug, Serialize)]
+pub struct SpawnSessionMessage {
+    pub cmd: &'static str,
+    pub id: String,
+    pub cwd: String,
+    pub workspace_id: String,
+    pub agent: String,
+    pub cols: u16,
+    pub rows: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+impl SpawnSessionMessage {
+    pub fn new(
+        id: impl Into<String>,
+        cwd: impl Into<String>,
+        workspace_id: impl Into<String>,
+        agent: impl Into<String>,
+        cols: u16,
+        rows: u16,
+    ) -> Self {
+        Self {
+            cmd: "spawn_session",
+            id: id.into(),
+            cwd: cwd.into(),
+            workspace_id: workspace_id.into(),
+            agent: agent.into(),
+            cols,
+            rows,
+            label: None,
+        }
+    }
+
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+}
+
+/// Tear down a session: SIGTERM the PTY, drop the daemon's session record,
+/// broadcast `session_unregistered`. Same wire shape the Tauri app uses.
+#[derive(Debug, Serialize)]
+pub struct UnregisterSessionMessage {
+    pub cmd: &'static str,
+    pub id: String,
+}
+
+impl UnregisterSessionMessage {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            cmd: "unregister",
+            id: id.into(),
+        }
+    }
+}

--- a/native-ui/crates/attn-protocol/src/events.rs
+++ b/native-ui/crates/attn-protocol/src/events.rs
@@ -57,6 +57,18 @@ pub struct WorkspaceStateChangedMessage {
     pub workspace: Workspace,
 }
 
+/// Daemon ack for a `spawn_session` command. Carries success+error so the
+/// client can surface failures (invalid agent, executable missing, PTY
+/// spawn failure) without inferring them from "no session ever appeared".
+#[derive(Debug, Clone, Deserialize)]
+pub struct SpawnResultMessage {
+    pub event: String,
+    pub id: String,
+    pub success: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct AttachResultMessage {
     pub event: String,
@@ -126,6 +138,7 @@ pub enum ServerEvent {
     WorkspaceUnregistered(WorkspaceUnregisteredMessage),
     WorkspaceStateChanged(WorkspaceStateChangedMessage),
     AttachResult(AttachResultMessage),
+    SpawnResult(SpawnResultMessage),
     PtyOutput(PtyOutputMessage),
     PtyDesync(PtyDesyncMessage),
     PtyResized(PtyResizedMessage),
@@ -172,6 +185,10 @@ impl ServerEvent {
             "attach_result" => {
                 let msg: AttachResultMessage = serde_json::from_str(data)?;
                 Ok(Self::AttachResult(msg))
+            }
+            "spawn_result" => {
+                let msg: SpawnResultMessage = serde_json::from_str(data)?;
+                Ok(Self::SpawnResult(msg))
             }
             "pty_output" => {
                 let msg: PtyOutputMessage = serde_json::from_str(data)?;


### PR DESCRIPTION
## Summary
- Wire spawn / unregister round-trip into the native canvas: `+ Session` pill in the top-left expands to a Claude / Codex / Shell picker that spawns into the selected workspace's directory; panel title bars gain an `x` close button that unregisters the session, and panels are pruned once the daemon broadcasts.
- New `spawn_session` / `unregister_session` automation actions drive the same path as the UI; the native canvas scenario covers them end to end and asserts both panel add/remove and `session_spawn_succeeded` events fire.
- Spawn failures emit structured `session_spawn_failed` diagnostic events with the wire error so they're discoverable from the automation tail.

## Notes
- Reuses the existing native folder picker for workspace creation — that's known-rough and will be replaced with a custom dialog (Tauri-style) in a follow-up. Not in scope here.
- No agent picker for cwd-different-from-workspace yet; cwd defaults to the workspace's directory.
- No close confirmation; tearing down is one-click.

## Test plan
- [x] `pnpm --dir app run real-app:serial-matrix` (native canvas scenario) — session lifecycle step passes
- [x] `cargo build` (native-ui workspace)
- [x] Manual: spawn Claude / Codex / Shell from `+ Session`, observe panel mount; close via `x`, observe daemon unregister + panel prune