### PR TITLE
Native canvas panel placement policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-05-01]
+
+### Changed
+- **Native Canvas Panel Placement**: New native-canvas sessions now use larger default terminal panels and place newly spawned panels in the visible canvas when space is available. When a panel is selected, new panels prefer clockwise slots around it before falling back to other visible space or the closest non-overlapping off-screen slot. `Shift+Arrow` now pans the canvas from the keyboard without changing panel selection.
+
+---
+
 ## [2026-04-30]
 
 ### Added

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -238,8 +238,8 @@ func snapshotEntry(e *workspaceEntry) protocol.Workspace {
 }
 
 const (
-	defaultWorkspacePanelWidth  = 380.0
-	defaultWorkspacePanelHeight = 240.0
+	defaultWorkspacePanelWidth  = 720.0
+	defaultWorkspacePanelHeight = 480.0
 	defaultWorkspacePanelX      = 30.0
 	defaultWorkspacePanelY      = 50.0
 	defaultWorkspacePanelGap    = 30.0

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -22,6 +22,7 @@ use crate::adapters::automation;
 use crate::adapters::automation::actions::generate_workspace_id;
 use crate::adapters::automation::events;
 use crate::adapters::daemon::{DaemonClient, DaemonEvent};
+use crate::domain::panel_placement::{place_panel, PanelPlacementItem, PanelSize, Rect};
 use crate::state::panel::{Panel, TITLE_HEIGHT};
 use crate::state::session_registry::SessionRegistry;
 use crate::state::terminal_model::TerminalModel;
@@ -31,10 +32,10 @@ use crate::views::canvas::WorkspaceCanvas;
 use crate::views::sidebar::Sidebar;
 use crate::views::terminal_view::TerminalView;
 
-/// Initial terminal panel size in world-space units. ~380×240 gives
-/// ~48 cols × ~12 rows once the title bar is subtracted.
-const TERMINAL_W: f32 = 380.0;
-const TERMINAL_H: f32 = 240.0;
+/// Initial terminal panel size in world-space units. ~720×480 gives
+/// ~92 cols × ~26 rows once the title bar is subtracted.
+const TERMINAL_W: f32 = 720.0;
+const TERMINAL_H: f32 = 480.0;
 
 pub struct NativeApp {
     daemon: Entity<DaemonClient>,
@@ -237,6 +238,9 @@ impl NativeApp {
                     let key = SharedString::from(session_id.clone());
                     let pending = this.registry.take_pending_spawn(&key);
                     if *success {
+                        if let Some(spawn) = pending.clone() {
+                            this.registry.mark_spawn_succeeded(key, spawn);
+                        }
                         events::record(
                             "session_spawn_succeeded",
                             json!({
@@ -582,6 +586,87 @@ impl NativeApp {
         }
     }
 
+    fn placement_for_new_panel(
+        &self,
+        ws_entity: &Entity<Workspace>,
+        cx: &Context<Self>,
+    ) -> Option<Rect> {
+        let ws = ws_entity.read(cx);
+        if self.registry.selected_id() != Some(&ws.id) {
+            return None;
+        }
+        let frame = self.canvas.read(cx).placement_frame();
+        let existing: Vec<PanelPlacementItem> = ws
+            .panels
+            .iter()
+            .map(|panel| PanelPlacementItem {
+                id: panel.id,
+                rect: Rect {
+                    x: panel.world_x,
+                    y: panel.world_y,
+                    width: panel.width,
+                    height: panel.height,
+                },
+            })
+            .collect();
+        Some(place_panel(
+            &existing,
+            frame.selected_panel,
+            frame.visible,
+            PanelSize {
+                width: TERMINAL_W,
+                height: TERMINAL_H,
+            },
+        ))
+    }
+
+    fn persist_initial_panel_placement(
+        &self,
+        workspace_id: SharedString,
+        panel_id: SharedString,
+        placement: Rect,
+        pending: &PendingSpawn,
+        session_id: &str,
+        cx: &Context<Self>,
+    ) {
+        let result = self
+            .daemon
+            .read(cx)
+            .send_cmd(&UpdateWorkspacePanelGeometryMessage::new(
+                workspace_id.to_string(),
+                panel_id.to_string(),
+                Some(placement.x),
+                Some(placement.y),
+                Some(placement.width),
+                Some(placement.height),
+            ));
+        match result {
+            Ok(()) => events::record(
+                "panel_initial_placement_submitted",
+                json!({
+                    "workspace_id": workspace_id.as_ref(),
+                    "panel_id": panel_id.as_ref(),
+                    "session_id": session_id,
+                    "agent": pending.agent.as_ref(),
+                    "world_x": placement.x,
+                    "world_y": placement.y,
+                    "width": placement.width,
+                    "height": placement.height,
+                }),
+            ),
+            Err(error) => events::record(
+                "panel_initial_placement_send_failed",
+                json!({
+                    "workspace_id": workspace_id.as_ref(),
+                    "panel_id": panel_id.as_ref(),
+                    "session_id": session_id,
+                    "agent": pending.agent.as_ref(),
+                    "error": error,
+                }),
+            ),
+        }
+    }
+
     /// Switch the canvas + sidebar to the given workspace id. Shared by
     /// the sidebar's click callback and the automation `select_workspace`
     /// action so both paths produce identical state. No-op when `id`
@@ -857,17 +942,43 @@ impl NativeApp {
                     daemon_panel.title.clone()
                 };
 
-                let (cols, rows) = panel_terminal_dims(daemon_panel.width, daemon_panel.height);
+                let session_key = SharedString::from(session_id.clone());
+                let mut world_x = daemon_panel.world_x;
+                let mut world_y = daemon_panel.world_y;
+                let mut width = daemon_panel.width;
+                let mut height = daemon_panel.height;
+                if let Some(pending) = self
+                    .registry
+                    .pending_spawn_for_panel_placement(&session_key)
+                    .filter(|pending| {
+                        pending.workspace_id.as_ref() == ws_entity.read(cx).id.as_ref()
+                    })
+                {
+                    if let Some(placement) = self.placement_for_new_panel(&ws_entity, cx) {
+                        world_x = placement.x;
+                        world_y = placement.y;
+                        width = placement.width;
+                        height = placement.height;
+                        self.persist_initial_panel_placement(
+                            ws_entity.read(cx).id.clone(),
+                            SharedString::from(daemon_panel.id.clone()),
+                            placement,
+                            &pending,
+                            &session_id,
+                            cx,
+                        );
+                    }
+                    self.registry.mark_panel_placed(session_key.clone());
+                }
+
+                let (cols, rows) = panel_terminal_dims(width, height);
 
                 let daemon = self.daemon.clone();
                 let model =
                     cx.new(|cx| TerminalModel::new(session_id.clone(), cols, rows, &daemon, cx));
                 let view = cx.new(|cx| {
                     let mut tv = TerminalView::new(model, daemon.clone(), cx);
-                    tv.set_content_size(
-                        daemon_panel.width,
-                        (daemon_panel.height - TITLE_HEIGHT).max(0.0),
-                    );
+                    tv.set_content_size(width, (height - TITLE_HEIGHT).max(0.0));
                     tv
                 });
 
@@ -882,10 +993,10 @@ impl NativeApp {
                     id: next_panel_id(),
                     daemon_panel_id: SharedString::from(daemon_panel.id.clone()),
                     title: SharedString::from(label),
-                    world_x: daemon_panel.world_x,
-                    world_y: daemon_panel.world_y,
-                    width: daemon_panel.width,
-                    height: daemon_panel.height,
+                    world_x,
+                    world_y,
+                    width,
+                    height,
                     session_id: SharedString::from(session_id.clone()),
                     view,
                 };

--- a/native-ui/crates/attn-native-app/src/domain/mod.rs
+++ b/native-ui/crates/attn-native-app/src/domain/mod.rs
@@ -6,4 +6,5 @@
 //! `cx.subscribe`, `cx.notify`.
 
 pub mod panel_navigation;
+pub mod panel_placement;
 pub mod viewport;

--- a/native-ui/crates/attn-native-app/src/domain/panel_placement.rs
+++ b/native-ui/crates/attn-native-app/src/domain/panel_placement.rs
@@ -1,0 +1,427 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Rect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+impl Rect {
+    pub fn right(&self) -> f32 {
+        self.x + self.width
+    }
+
+    pub fn bottom(&self) -> f32 {
+        self.y + self.height
+    }
+
+    fn contains(&self, other: &Rect) -> bool {
+        other.x >= self.x
+            && other.y >= self.y
+            && other.right() <= self.right()
+            && other.bottom() <= self.bottom()
+    }
+
+    fn overlaps(&self, other: &Rect) -> bool {
+        self.x < other.right()
+            && self.right() > other.x
+            && self.y < other.bottom()
+            && self.bottom() > other.y
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PanelPlacementItem {
+    pub id: usize,
+    pub rect: Rect,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PanelSize {
+    pub width: f32,
+    pub height: f32,
+}
+
+const GAP: f32 = 32.0;
+const VISIBLE_MARGIN: f32 = 32.0;
+const MIN_VISIBLE_WIDTH: f32 = 420.0;
+const MIN_VISIBLE_HEIGHT: f32 = 280.0;
+
+pub fn place_panel(
+    existing: &[PanelPlacementItem],
+    selected_id: Option<usize>,
+    visible: Rect,
+    default_size: PanelSize,
+) -> Rect {
+    let size = size_for_visible_rect(default_size, visible);
+    if existing.is_empty() {
+        return first_panel_rect(visible, size);
+    }
+
+    let candidates = clockwise_candidates_from_three_oclock(existing, selected_id, size);
+    if let Some(candidate) = first_visible_non_overlapping(&candidates, existing, visible) {
+        return candidate;
+    }
+
+    let visible_candidates = scan_visible_slots(existing, visible, size);
+    if let Some(candidate) = visible_candidates.first().copied() {
+        return candidate;
+    }
+
+    if let Some(candidate) = closest_non_overlapping(&candidates, existing, visible) {
+        return candidate;
+    }
+
+    first_panel_rect(visible, size)
+}
+
+fn size_for_visible_rect(default_size: PanelSize, visible: Rect) -> PanelSize {
+    let available_width = visible.width - VISIBLE_MARGIN * 2.0;
+    let available_height = visible.height - VISIBLE_MARGIN * 2.0;
+    PanelSize {
+        width: if available_width >= MIN_VISIBLE_WIDTH {
+            default_size.width.min(available_width)
+        } else {
+            default_size.width
+        },
+        height: if available_height >= MIN_VISIBLE_HEIGHT {
+            default_size.height.min(available_height)
+        } else {
+            default_size.height
+        },
+    }
+}
+
+fn first_panel_rect(visible: Rect, size: PanelSize) -> Rect {
+    let x = if visible.width >= size.width + VISIBLE_MARGIN * 2.0 {
+        visible.x + (visible.width - size.width) / 2.0
+    } else {
+        visible.x + VISIBLE_MARGIN
+    };
+    let y = if visible.height >= size.height + VISIBLE_MARGIN * 2.0 {
+        visible.y + (visible.height - size.height) / 2.0
+    } else {
+        visible.y + VISIBLE_MARGIN
+    };
+    Rect {
+        x,
+        y,
+        width: size.width,
+        height: size.height,
+    }
+}
+
+fn clockwise_candidates_from_three_oclock(
+    existing: &[PanelPlacementItem],
+    selected_id: Option<usize>,
+    size: PanelSize,
+) -> Vec<Rect> {
+    let mut anchors = Vec::with_capacity(existing.len());
+    if let Some(selected) = selected_id {
+        if let Some(item) = existing.iter().find(|item| item.id == selected) {
+            anchors.push(*item);
+        }
+    }
+    for item in existing {
+        if anchors
+            .iter()
+            .any(|anchor: &PanelPlacementItem| anchor.id == item.id)
+        {
+            continue;
+        }
+        anchors.push(*item);
+    }
+
+    let mut out = Vec::with_capacity(anchors.len() * 4);
+    for anchor in anchors {
+        let rect = anchor.rect;
+        // Clockwise from 3 o'clock: right, down, left, up.
+        out.extend([
+            Rect {
+                x: rect.right() + GAP,
+                y: rect.y,
+                width: size.width,
+                height: size.height,
+            },
+            Rect {
+                x: rect.x,
+                y: rect.bottom() + GAP,
+                width: size.width,
+                height: size.height,
+            },
+            Rect {
+                x: rect.x - size.width - GAP,
+                y: rect.y,
+                width: size.width,
+                height: size.height,
+            },
+            Rect {
+                x: rect.x,
+                y: rect.y - size.height - GAP,
+                width: size.width,
+                height: size.height,
+            },
+        ]);
+    }
+    out
+}
+
+fn first_visible_non_overlapping(
+    candidates: &[Rect],
+    existing: &[PanelPlacementItem],
+    visible: Rect,
+) -> Option<Rect> {
+    candidates
+        .iter()
+        .copied()
+        .find(|candidate| visible.contains(candidate) && !overlaps_any(candidate, existing))
+}
+
+fn scan_visible_slots(
+    existing: &[PanelPlacementItem],
+    visible: Rect,
+    size: PanelSize,
+) -> Vec<Rect> {
+    if visible.width < size.width || visible.height < size.height {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    let min_x = visible.x + VISIBLE_MARGIN;
+    let min_y = visible.y + VISIBLE_MARGIN;
+    let max_x = (visible.right() - size.width - VISIBLE_MARGIN).max(min_x);
+    let max_y = (visible.bottom() - size.height - VISIBLE_MARGIN).max(min_y);
+    let step_x = (size.width + GAP).clamp(GAP, 240.0);
+    let step_y = (size.height + GAP).clamp(GAP, 180.0);
+
+    let mut y = min_y;
+    while y <= max_y + 0.1 {
+        let mut x = min_x;
+        while x <= max_x + 0.1 {
+            let candidate = Rect {
+                x,
+                y,
+                width: size.width,
+                height: size.height,
+            };
+            if !overlaps_any(&candidate, existing) {
+                out.push(candidate);
+            }
+            x += step_x;
+        }
+        y += step_y;
+    }
+    out
+}
+
+fn closest_non_overlapping(
+    candidates: &[Rect],
+    existing: &[PanelPlacementItem],
+    visible: Rect,
+) -> Option<Rect> {
+    candidates
+        .iter()
+        .copied()
+        .filter(|candidate| !overlaps_any(candidate, existing))
+        .min_by(|a, b| {
+            compare_f32(distance_to_rect(*a, visible), distance_to_rect(*b, visible))
+                .then_with(|| compare_f32(visible_area(*b, visible), visible_area(*a, visible)))
+                .then_with(|| compare_f32(a.y, b.y))
+                .then_with(|| compare_f32(a.x, b.x))
+        })
+}
+
+fn overlaps_any(candidate: &Rect, existing: &[PanelPlacementItem]) -> bool {
+    existing.iter().any(|item| candidate.overlaps(&item.rect))
+}
+
+fn distance_to_rect(candidate: Rect, visible: Rect) -> f32 {
+    let dx = if candidate.right() < visible.x {
+        visible.x - candidate.right()
+    } else if candidate.x > visible.right() {
+        candidate.x - visible.right()
+    } else {
+        0.0
+    };
+    let dy = if candidate.bottom() < visible.y {
+        visible.y - candidate.bottom()
+    } else if candidate.y > visible.bottom() {
+        candidate.y - visible.bottom()
+    } else {
+        0.0
+    };
+    dx.hypot(dy)
+}
+
+fn visible_area(candidate: Rect, visible: Rect) -> f32 {
+    let width = (candidate.right().min(visible.right()) - candidate.x.max(visible.x)).max(0.0);
+    let height = (candidate.bottom().min(visible.bottom()) - candidate.y.max(visible.y)).max(0.0);
+    width * height
+}
+
+fn compare_f32(a: f32, b: f32) -> std::cmp::Ordering {
+    a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(id: usize, x: f32, y: f32, width: f32, height: f32) -> PanelPlacementItem {
+        PanelPlacementItem {
+            id,
+            rect: Rect {
+                x,
+                y,
+                width,
+                height,
+            },
+        }
+    }
+
+    fn visible() -> Rect {
+        Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 1280.0,
+            height: 800.0,
+        }
+    }
+
+    fn size() -> PanelSize {
+        PanelSize {
+            width: 720.0,
+            height: 480.0,
+        }
+    }
+
+    #[test]
+    fn first_panel_centers_in_visible_viewport() {
+        let placed = place_panel(&[], None, visible(), size());
+        assert_eq!(
+            placed,
+            Rect {
+                x: 280.0,
+                y: 160.0,
+                width: 720.0,
+                height: 480.0,
+            }
+        );
+    }
+
+    #[test]
+    fn uses_first_clockwise_visible_slot_around_selected_panel() {
+        let existing = [item(1, 40.0, 120.0, 320.0, 240.0)];
+        let placed = place_panel(&existing, Some(1), visible(), size());
+        assert_eq!(placed.x, 392.0);
+        assert_eq!(placed.y, 120.0);
+    }
+
+    #[test]
+    fn clockwise_candidates_start_at_three_oclock() {
+        let existing = [item(1, 100.0, 200.0, 300.0, 150.0)];
+        let candidates = clockwise_candidates_from_three_oclock(
+            &existing,
+            Some(1),
+            PanelSize {
+                width: 80.0,
+                height: 60.0,
+            },
+        );
+        assert_eq!(
+            &candidates[..4],
+            &[
+                Rect {
+                    x: 432.0,
+                    y: 200.0,
+                    width: 80.0,
+                    height: 60.0,
+                },
+                Rect {
+                    x: 100.0,
+                    y: 382.0,
+                    width: 80.0,
+                    height: 60.0,
+                },
+                Rect {
+                    x: -12.0,
+                    y: 200.0,
+                    width: 80.0,
+                    height: 60.0,
+                },
+                Rect {
+                    x: 100.0,
+                    y: 108.0,
+                    width: 80.0,
+                    height: 60.0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn tries_down_after_right_when_right_slot_is_not_visible() {
+        let existing = [item(1, 480.0, 40.0, 720.0, 320.0)];
+        let placed = place_panel(&existing, Some(1), visible(), size());
+        assert_eq!(placed.x, 480.0);
+        assert_eq!(placed.y, 392.0);
+    }
+
+    #[test]
+    fn tries_clockwise_slots_around_other_existing_panels_before_going_offscreen() {
+        let existing = [
+            item(1, 350.0, 250.0, 200.0, 150.0),
+            item(2, 582.0, 250.0, 300.0, 200.0),
+            item(3, 350.0, 432.0, 300.0, 200.0),
+            item(4, 18.0, 250.0, 300.0, 200.0),
+            item(5, 350.0, 18.0, 300.0, 200.0),
+        ];
+        let placed = place_panel(
+            &existing,
+            Some(1),
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                width: 1000.0,
+                height: 700.0,
+            },
+            PanelSize {
+                width: 300.0,
+                height: 200.0,
+            },
+        );
+        assert_eq!(placed.x, 18.0);
+        assert_eq!(placed.y, 482.0);
+    }
+
+    #[test]
+    fn falls_back_to_closest_non_overlapping_clockwise_slot_when_view_is_full() {
+        let existing = [
+            item(1, 0.0, 0.0, 720.0, 480.0),
+            item(2, 752.0, 0.0, 720.0, 480.0),
+            item(3, 0.0, 512.0, 720.0, 480.0),
+        ];
+        let placed = place_panel(&existing, Some(1), visible(), size());
+        assert_eq!(placed.x, 752.0);
+        assert_eq!(placed.y, 512.0);
+    }
+
+    #[test]
+    fn shrinks_to_fit_visible_view_when_there_is_room_above_minimum() {
+        let placed = place_panel(
+            &[],
+            None,
+            Rect {
+                x: 100.0,
+                y: 200.0,
+                width: 620.0,
+                height: 420.0,
+            },
+            size(),
+        );
+        assert_eq!(placed.width, 556.0);
+        assert_eq!(placed.height, 356.0);
+        assert_eq!(placed.x, 132.0);
+        assert_eq!(placed.y, 232.0);
+    }
+}

--- a/native-ui/crates/attn-native-app/src/domain/viewport.rs
+++ b/native-ui/crates/attn-native-app/src/domain/viewport.rs
@@ -68,4 +68,31 @@ impl Viewport {
             ),
         }
     }
+
+    pub fn pan_view_by_screen_delta(&self, dx: f32, dy: f32) -> Viewport {
+        Viewport {
+            origin: point(
+                self.origin.x + dx / self.zoom,
+                self.origin.y + dy / self.zoom,
+            ),
+            zoom: self.zoom,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keyboard_pan_is_zoom_invariant_in_screen_space() {
+        let viewport = Viewport {
+            origin: point(10.0, 20.0),
+            zoom: 2.0,
+        };
+        let panned = viewport.pan_view_by_screen_delta(160.0, -80.0);
+        assert_eq!(panned.origin.x, 90.0);
+        assert_eq!(panned.origin.y, -20.0);
+        assert_eq!(panned.zoom, 2.0);
+    }
 }

--- a/native-ui/crates/attn-native-app/src/state/workspace_registry.rs
+++ b/native-ui/crates/attn-native-app/src/state/workspace_registry.rs
@@ -48,6 +48,11 @@ pub struct WorkspaceRegistry {
     /// session id (the same one we sent on the wire). Consumed on
     /// `SpawnResult` to attribute the outcome back to a workspace + agent.
     pending_spawns: HashMap<SharedString, PendingSpawn>,
+    /// Successful spawns whose daemon panel has not appeared locally yet.
+    /// Kept separate from `pending_spawns` because the workspace broadcast
+    /// and spawn result can arrive in either order on reconnect-heavy paths.
+    pending_panel_placements: HashMap<SharedString, PendingSpawn>,
+    placed_spawn_panels: HashSet<SharedString>,
 }
 
 impl WorkspaceRegistry {
@@ -164,5 +169,26 @@ impl WorkspaceRegistry {
 
     pub fn take_pending_spawn(&mut self, session_id: &SharedString) -> Option<PendingSpawn> {
         self.pending_spawns.remove(session_id)
+    }
+
+    pub fn mark_spawn_succeeded(&mut self, session_id: SharedString, spawn: PendingSpawn) {
+        if !self.placed_spawn_panels.contains(&session_id) {
+            self.pending_panel_placements.insert(session_id, spawn);
+        }
+    }
+
+    pub fn pending_spawn_for_panel_placement(
+        &self,
+        session_id: &SharedString,
+    ) -> Option<PendingSpawn> {
+        self.pending_panel_placements
+            .get(session_id)
+            .or_else(|| self.pending_spawns.get(session_id))
+            .cloned()
+    }
+
+    pub fn mark_panel_placed(&mut self, session_id: SharedString) {
+        self.pending_panel_placements.remove(&session_id);
+        self.placed_spawn_panels.insert(session_id);
     }
 }

--- a/native-ui/crates/attn-native-app/src/views/canvas.rs
+++ b/native-ui/crates/attn-native-app/src/views/canvas.rs
@@ -38,6 +38,7 @@ pub type PanelGeometryCommitHandler =
 use serde_json::{json, Value};
 
 use crate::domain::panel_navigation::{navigate_panel, NavigationDirection, PanelNavItem};
+use crate::domain::panel_placement::Rect;
 use crate::domain::viewport::{pf, Viewport};
 use crate::state::panel::{Panel, TITLE_HEIGHT};
 use crate::state::workspace::Workspace;
@@ -49,6 +50,7 @@ const HANDLE_SIZE: f32 = 8.0; // screen-space pixels (fixed, not scaled)
 const PANEL_MIN_W: f32 = 120.0; // world-space
 const PANEL_MIN_H: f32 = 80.0; // world-space
 const TITLE_SCREEN_MIN_H: f32 = 18.0; // screen-space; keeps title dragging usable when zoomed out
+const KEYBOARD_PAN_STEP: f32 = 160.0; // screen-space pixels
 
 // ── Drag/resize state ─────────────────────────────────────────────────────────
 
@@ -112,6 +114,12 @@ pub struct WorkspaceCanvas {
     on_panel_geometry_commit: Box<PanelGeometryCommitHandler>,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct PlacementFrame {
+    pub visible: Rect,
+    pub selected_panel: Option<usize>,
+}
+
 impl WorkspaceCanvas {
     pub fn new(
         cx: &mut Context<Self>,
@@ -164,6 +172,23 @@ impl WorkspaceCanvas {
             }
         }
         cx.notify();
+    }
+
+    pub fn placement_frame(&self) -> PlacementFrame {
+        let (width, height) = self
+            .bounds
+            .get()
+            .map(|bounds| (pf(bounds.size.width), pf(bounds.size.height)))
+            .unwrap_or((1040.0, 760.0));
+        PlacementFrame {
+            visible: Rect {
+                x: self.viewport.origin.x,
+                y: self.viewport.origin.y,
+                width: width / self.viewport.zoom,
+                height: height / self.viewport.zoom,
+            },
+            selected_panel: self.selected_panel,
+        }
     }
 
     /// Translate a window-relative position into canvas-local space using
@@ -269,6 +294,17 @@ impl WorkspaceCanvas {
         if let Some(next_id) = navigate_panel(&panels, self.selected_panel, direction) {
             self.selected_panel = Some(next_id);
         }
+    }
+
+    fn pan_viewport_with_keyboard(&mut self, key: &str) {
+        let (dx, dy) = match key {
+            "left" => (-KEYBOARD_PAN_STEP, 0.0),
+            "right" => (KEYBOARD_PAN_STEP, 0.0),
+            "up" => (0.0, -KEYBOARD_PAN_STEP),
+            "down" => (0.0, KEYBOARD_PAN_STEP),
+            _ => return,
+        };
+        self.viewport = self.viewport.pan_view_by_screen_delta(dx, dy);
     }
 
     fn release_input_focus(&mut self, window: &mut Window) {
@@ -407,6 +443,13 @@ impl WorkspaceCanvas {
                 } else {
                     self.navigate_selected_panel(NavigationDirection::Next, cx);
                 }
+                cx.notify();
+            }
+            key @ ("up" | "down" | "left" | "right")
+                if self.focus_handle.is_focused(window) && event.keystroke.modifiers.shift =>
+            {
+                cx.stop_propagation();
+                self.pan_viewport_with_keyboard(key);
                 cx.notify();
             }
             key @ ("up" | "down" | "left" | "right" | "h" | "j" | "k" | "l")


### PR DESCRIPTION
## Summary

- Adds a tested native-canvas panel placement policy for newly spawned panels.
- Places native-spawned panels in visible canvas space when possible, preferring clockwise slots around the selected panel before falling back to other visible slots or the closest non-overlapping off-screen slot.
- The clockwise placement order is explicitly anchored at 3 o'clock: right, down, left, up.
- Increases default canvas terminal panel size from 380x240 to 720x480.
- Adds `Shift+Arrow` keyboard panning for the native canvas without changing normal arrow-key panel selection.

## Validation

- `cargo fmt --check` in `native-ui`
- `cargo test --workspace` in `native-ui` — 42 passed before the final 3 o'clock naming/test-only adjustment
- `cargo test -p attn-native-app panel_placement` in `native-ui` — 7 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `go test ./internal/daemon ./internal/store` — 241 passed
- `make scenario-native-canvas ATTN_PROFILE=dev` — PASS before the final 3 o'clock naming/test-only adjustment