### PR TITLE
Clip native canvas panels and add pan aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-05-01]
 
 ### Changed
+- **Native Canvas Clipping And Keyboard Panning**: Zoomed native-canvas panels are now clipped to the canvas area instead of painting over the sidebar. `Shift+h/j/k/l` now pan the canvas alongside `Shift+Arrow`, and new native terminal panels are taller by default.
 - **Native Canvas Panel Placement**: New native-canvas sessions now use larger default terminal panels and place newly spawned panels in the visible canvas when space is available. When a panel is selected, new panels prefer clockwise slots around it before falling back to other visible space or the closest non-overlapping off-screen slot. `Shift+Arrow` now pans the canvas from the keyboard without changing panel selection.
 
 ---

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -239,7 +239,7 @@ func snapshotEntry(e *workspaceEntry) protocol.Workspace {
 
 const (
 	defaultWorkspacePanelWidth  = 720.0
-	defaultWorkspacePanelHeight = 480.0
+	defaultWorkspacePanelHeight = 560.0
 	defaultWorkspacePanelX      = 30.0
 	defaultWorkspacePanelY      = 50.0
 	defaultWorkspacePanelGap    = 30.0

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -32,10 +32,10 @@ use crate::views::canvas::WorkspaceCanvas;
 use crate::views::sidebar::Sidebar;
 use crate::views::terminal_view::TerminalView;
 
-/// Initial terminal panel size in world-space units. ~720×480 gives
-/// ~92 cols × ~26 rows once the title bar is subtracted.
+/// Initial terminal panel size in world-space units. ~720×560 gives
+/// ~92 cols × ~31 rows once the title bar is subtracted.
 const TERMINAL_W: f32 = 720.0;
-const TERMINAL_H: f32 = 480.0;
+const TERMINAL_H: f32 = 560.0;
 
 pub struct NativeApp {
     daemon: Entity<DaemonClient>,
@@ -1030,7 +1030,7 @@ impl Render for NativeApp {
             .flex_row()
             .bg(rgb(0x0e0e14))
             .child(self.sidebar.clone())
-            .child(div().flex_1().child(self.canvas.clone()))
+            .child(div().flex_1().overflow_hidden().child(self.canvas.clone()))
     }
 }
 

--- a/native-ui/crates/attn-native-app/src/views/canvas.rs
+++ b/native-ui/crates/attn-native-app/src/views/canvas.rs
@@ -297,12 +297,8 @@ impl WorkspaceCanvas {
     }
 
     fn pan_viewport_with_keyboard(&mut self, key: &str) {
-        let (dx, dy) = match key {
-            "left" => (-KEYBOARD_PAN_STEP, 0.0),
-            "right" => (KEYBOARD_PAN_STEP, 0.0),
-            "up" => (0.0, -KEYBOARD_PAN_STEP),
-            "down" => (0.0, KEYBOARD_PAN_STEP),
-            _ => return,
+        let Some((dx, dy)) = keyboard_pan_delta(key) else {
+            return;
         };
         self.viewport = self.viewport.pan_view_by_screen_delta(dx, dy);
     }
@@ -445,7 +441,7 @@ impl WorkspaceCanvas {
                 }
                 cx.notify();
             }
-            key @ ("up" | "down" | "left" | "right")
+            key @ ("up" | "down" | "left" | "right" | "h" | "j" | "k" | "l")
                 if self.focus_handle.is_focused(window) && event.keystroke.modifiers.shift =>
             {
                 cx.stop_propagation();
@@ -664,6 +660,16 @@ fn reconcile_panel_focus(
     cleared_input_focus
 }
 
+fn keyboard_pan_delta(key: &str) -> Option<(f32, f32)> {
+    match key {
+        "left" | "h" => Some((-KEYBOARD_PAN_STEP, 0.0)),
+        "right" | "l" => Some((KEYBOARD_PAN_STEP, 0.0)),
+        "up" | "k" => Some((0.0, -KEYBOARD_PAN_STEP)),
+        "down" | "j" => Some((0.0, KEYBOARD_PAN_STEP)),
+        _ => None,
+    }
+}
+
 impl Focusable for WorkspaceCanvas {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
         self.focus_handle.clone()
@@ -690,6 +696,7 @@ impl Render for WorkspaceCanvas {
         let mut root = div()
             .size_full()
             .bg(rgb(0x0e0e14))
+            .overflow_hidden()
             .track_focus(&focus_handle)
             .capture_key_down(cx.listener(Self::on_key_down))
             .on_key_down(cx.listener(Self::on_key_down))
@@ -1010,5 +1017,18 @@ mod tests {
         assert!(!cleared_input);
         assert_eq!(selected, Some(2));
         assert_eq!(input, Some(2));
+    }
+
+    #[test]
+    fn keyboard_pan_delta_supports_arrows_and_vim_keys() {
+        assert_eq!(keyboard_pan_delta("left"), Some((-KEYBOARD_PAN_STEP, 0.0)));
+        assert_eq!(keyboard_pan_delta("h"), Some((-KEYBOARD_PAN_STEP, 0.0)));
+        assert_eq!(keyboard_pan_delta("down"), Some((0.0, KEYBOARD_PAN_STEP)));
+        assert_eq!(keyboard_pan_delta("j"), Some((0.0, KEYBOARD_PAN_STEP)));
+        assert_eq!(keyboard_pan_delta("up"), Some((0.0, -KEYBOARD_PAN_STEP)));
+        assert_eq!(keyboard_pan_delta("k"), Some((0.0, -KEYBOARD_PAN_STEP)));
+        assert_eq!(keyboard_pan_delta("right"), Some((KEYBOARD_PAN_STEP, 0.0)));
+        assert_eq!(keyboard_pan_delta("l"), Some((KEYBOARD_PAN_STEP, 0.0)));
+        assert_eq!(keyboard_pan_delta("x"), None);
     }
 }


### PR DESCRIPTION
## Summary

- Clips the native canvas host and root so zoomed panels cannot render over the sidebar.
- Adds `Shift+h/j/k/l` as canvas pan aliases alongside `Shift+Arrow`.
- Increases default native canvas terminal panel height from 480 to 560.

## Validation

- `cargo fmt --check` in `native-ui`
- `cargo test --workspace` in `native-ui` — 44 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `go test ./internal/daemon ./internal/store` — 241 passed
- `make scenario-native-canvas ATTN_PROFILE=dev` — PASS