### PR TITLE
Add native canvas panel focus modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-05-01]
 
 ### Changed
+- **Native Canvas Focus Modes**: `Cmd+Enter` now focuses the selected panel and fits the canvas viewport around it without changing panel geometry. `Cmd+Shift+Enter` toggles a temporary window-wide panel fullscreen mode that covers the sidebar without resizing or persisting the panel.
 - **Native Canvas Clipping And Keyboard Panning**: Zoomed native-canvas panels are now clipped to the canvas area instead of painting over the sidebar. `Shift+h/j/k/l` now pan the canvas alongside `Shift+Arrow`, and new native terminal panels are taller by default.
 - **Native Canvas Panel Placement**: New native-canvas sessions now use larger default terminal panels and place newly spawned panels in the visible canvas when space is available. When a panel is selected, new panels prefer clockwise slots around it before falling back to other visible space or the closest non-overlapping off-screen slot. `Shift+Arrow` now pans the canvas from the keyboard without changing panel selection.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-05-01]
 
 ### Changed
+- **Native Canvas Clipping And Keyboard Panning**: Zoomed native-canvas panels are now clipped to the canvas area instead of painting over the sidebar. `Shift+h/j/k/l` now pan the canvas alongside `Shift+Arrow`, and new native terminal panels are taller by default.
 - **Native Canvas Panel Placement**: New native-canvas sessions now use larger default terminal panels and place newly spawned panels in the visible canvas when space is available. When a panel is selected, new panels prefer clockwise slots around it before falling back to other visible space or the closest non-overlapping off-screen slot. `Shift+Arrow` now pans the canvas from the keyboard without changing panel selection.
 
 ---

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -239,7 +239,7 @@ func snapshotEntry(e *workspaceEntry) protocol.Workspace {
 
 const (
 	defaultWorkspacePanelWidth  = 720.0
-	defaultWorkspacePanelHeight = 480.0
+	defaultWorkspacePanelHeight = 560.0
 	defaultWorkspacePanelX      = 30.0
 	defaultWorkspacePanelY      = 50.0
 	defaultWorkspacePanelGap    = 30.0

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -32,10 +32,10 @@ use crate::views::canvas::WorkspaceCanvas;
 use crate::views::sidebar::Sidebar;
 use crate::views::terminal_view::TerminalView;
 
-/// Initial terminal panel size in world-space units. ~720×480 gives
-/// ~92 cols × ~26 rows once the title bar is subtracted.
+/// Initial terminal panel size in world-space units. ~720×560 gives
+/// ~92 cols × ~31 rows once the title bar is subtracted.
 const TERMINAL_W: f32 = 720.0;
-const TERMINAL_H: f32 = 480.0;
+const TERMINAL_H: f32 = 560.0;
 
 pub struct NativeApp {
     daemon: Entity<DaemonClient>,
@@ -1030,7 +1030,7 @@ impl Render for NativeApp {
             .flex_row()
             .bg(rgb(0x0e0e14))
             .child(self.sidebar.clone())
-            .child(div().flex_1().child(self.canvas.clone()))
+            .child(div().flex_1().overflow_hidden().child(self.canvas.clone()))
     }
 }
 

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -14,7 +14,7 @@ use attn_protocol::{
 };
 use gpui::{
     div, prelude::*, rgb, App, Context, Entity, ParentElement, PathPromptOptions, Render,
-    SharedString, Window,
+    SharedString, Subscription, Window,
 };
 use serde_json::{json, Value};
 
@@ -51,6 +51,7 @@ pub struct NativeApp {
     sessions: SessionRegistry,
     sidebar: Entity<Sidebar>,
     canvas: Entity<WorkspaceCanvas>,
+    _canvas_subscription: Subscription,
     /// Live automation server handle. Drop deletes the manifest. `None`
     /// when automation is disabled for this launch (default in prod) or
     /// when bind/start failed — in which case we still want the app to
@@ -106,6 +107,7 @@ impl NativeApp {
                 },
             )
         });
+        let canvas_subscription = cx.observe(&canvas, |_, _, cx| cx.notify());
         let app_handle_create = app_handle.clone();
         let app_handle_destroy = app_handle.clone();
         let sidebar = cx.new(|cx| {
@@ -289,6 +291,7 @@ impl NativeApp {
             sessions: SessionRegistry::new(),
             sidebar,
             canvas,
+            _canvas_subscription: canvas_subscription,
             _automation: automation_handle,
         }
     }
@@ -1023,14 +1026,14 @@ impl NativeApp {
 }
 
 impl Render for NativeApp {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        div()
-            .size_full()
-            .flex()
-            .flex_row()
-            .bg(rgb(0x0e0e14))
-            .child(self.sidebar.clone())
-            .child(div().flex_1().overflow_hidden().child(self.canvas.clone()))
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let root = div().size_full().flex().flex_row().bg(rgb(0x0e0e14));
+        if self.canvas.read(cx).is_panel_fullscreen() {
+            root.child(div().flex_1().overflow_hidden().child(self.canvas.clone()))
+        } else {
+            root.child(self.sidebar.clone())
+                .child(div().flex_1().overflow_hidden().child(self.canvas.clone()))
+        }
     }
 }
 

--- a/native-ui/crates/attn-native-app/src/domain/viewport.rs
+++ b/native-ui/crates/attn-native-app/src/domain/viewport.rs
@@ -28,6 +28,14 @@ pub struct Viewport {
     pub zoom: f32,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct WorldRect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
 impl Default for Viewport {
     fn default() -> Self {
         Viewport {
@@ -78,6 +86,32 @@ impl Viewport {
             zoom: self.zoom,
         }
     }
+
+    pub fn fit_world_rect(
+        &self,
+        rect: WorldRect,
+        screen_width: f32,
+        screen_height: f32,
+        margin: f32,
+    ) -> Viewport {
+        if rect.width <= 0.0 || rect.height <= 0.0 || screen_width <= 0.0 || screen_height <= 0.0 {
+            return *self;
+        }
+        let available_width = (screen_width - margin * 2.0).max(1.0);
+        let available_height = (screen_height - margin * 2.0).max(1.0);
+        let zoom = (available_width / rect.width)
+            .min(available_height / rect.height)
+            .clamp(ZOOM_MIN, ZOOM_MAX);
+        let world_center_x = rect.x + rect.width / 2.0;
+        let world_center_y = rect.y + rect.height / 2.0;
+        Viewport {
+            origin: point(
+                world_center_x - screen_width / (2.0 * zoom),
+                world_center_y - screen_height / (2.0 * zoom),
+            ),
+            zoom,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -94,5 +128,24 @@ mod tests {
         assert_eq!(panned.origin.x, 90.0);
         assert_eq!(panned.origin.y, -20.0);
         assert_eq!(panned.zoom, 2.0);
+    }
+
+    #[test]
+    fn fit_world_rect_centers_rect_and_uses_limiting_axis() {
+        let viewport = Viewport::default();
+        let fitted = viewport.fit_world_rect(
+            WorldRect {
+                x: 100.0,
+                y: 120.0,
+                width: 500.0,
+                height: 200.0,
+            },
+            1000.0,
+            800.0,
+            32.0,
+        );
+        assert!((fitted.zoom - 1.872).abs() < 0.001);
+        assert!(((100.0 - fitted.origin.x) * fitted.zoom - 32.0).abs() < 0.001);
+        assert!(((120.0 - fitted.origin.y) * fitted.zoom - 212.8).abs() < 0.01);
     }
 }

--- a/native-ui/crates/attn-native-app/src/views/canvas.rs
+++ b/native-ui/crates/attn-native-app/src/views/canvas.rs
@@ -297,12 +297,8 @@ impl WorkspaceCanvas {
     }
 
     fn pan_viewport_with_keyboard(&mut self, key: &str) {
-        let (dx, dy) = match key {
-            "left" => (-KEYBOARD_PAN_STEP, 0.0),
-            "right" => (KEYBOARD_PAN_STEP, 0.0),
-            "up" => (0.0, -KEYBOARD_PAN_STEP),
-            "down" => (0.0, KEYBOARD_PAN_STEP),
-            _ => return,
+        let Some((dx, dy)) = keyboard_pan_delta(key) else {
+            return;
         };
         self.viewport = self.viewport.pan_view_by_screen_delta(dx, dy);
     }
@@ -445,7 +441,7 @@ impl WorkspaceCanvas {
                 }
                 cx.notify();
             }
-            key @ ("up" | "down" | "left" | "right")
+            key @ ("up" | "down" | "left" | "right" | "h" | "j" | "k" | "l")
                 if self.focus_handle.is_focused(window) && event.keystroke.modifiers.shift =>
             {
                 cx.stop_propagation();
@@ -664,6 +660,16 @@ fn reconcile_panel_focus(
     cleared_input_focus
 }
 
+fn keyboard_pan_delta(key: &str) -> Option<(f32, f32)> {
+    match key {
+        "left" | "h" => Some((-KEYBOARD_PAN_STEP, 0.0)),
+        "right" | "l" => Some((KEYBOARD_PAN_STEP, 0.0)),
+        "up" | "k" => Some((0.0, -KEYBOARD_PAN_STEP)),
+        "down" | "j" => Some((0.0, KEYBOARD_PAN_STEP)),
+        _ => None,
+    }
+}
+
 impl Focusable for WorkspaceCanvas {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
         self.focus_handle.clone()
@@ -690,6 +696,7 @@ impl Render for WorkspaceCanvas {
         let mut root = div()
             .size_full()
             .bg(rgb(0x0e0e14))
+            .overflow_hidden()
             .track_focus(&focus_handle)
             .capture_key_down(cx.listener(Self::on_key_down))
             .on_key_down(cx.listener(Self::on_key_down))
@@ -1010,5 +1017,18 @@ mod tests {
         assert!(!cleared_input);
         assert_eq!(selected, Some(2));
         assert_eq!(input, Some(2));
+    }
+
+    #[test]
+    fn keyboard_pan_delta_supports_arrows_and_vim_keys() {
+        assert_eq!(keyboard_pan_delta("left"), Some((-KEYBOARD_PAN_STEP, 0.0)));
+        assert_eq!(keyboard_pan_delta("h"), Some((-KEYBOARD_PAN_STEP, 0.0)));
+        assert_eq!(keyboard_pan_delta("down"), Some((0.0, KEYBOARD_PAN_STEP)));
+        assert_eq!(keyboard_pan_delta("j"), Some((0.0, KEYBOARD_PAN_STEP)));
+        assert_eq!(keyboard_pan_delta("up"), Some((0.0, -KEYBOARD_PAN_STEP)));
+        assert_eq!(keyboard_pan_delta("k"), Some((0.0, -KEYBOARD_PAN_STEP)));
+        assert_eq!(keyboard_pan_delta("right"), Some((KEYBOARD_PAN_STEP, 0.0)));
+        assert_eq!(keyboard_pan_delta("l"), Some((KEYBOARD_PAN_STEP, 0.0)));
+        assert_eq!(keyboard_pan_delta("x"), None);
     }
 }

--- a/native-ui/crates/attn-native-app/src/views/canvas.rs
+++ b/native-ui/crates/attn-native-app/src/views/canvas.rs
@@ -39,7 +39,7 @@ use serde_json::{json, Value};
 
 use crate::domain::panel_navigation::{navigate_panel, NavigationDirection, PanelNavItem};
 use crate::domain::panel_placement::Rect;
-use crate::domain::viewport::{pf, Viewport};
+use crate::domain::viewport::{pf, Viewport, WorldRect};
 use crate::state::panel::{Panel, TITLE_HEIGHT};
 use crate::state::workspace::Workspace;
 use crate::views::fps_overlay::{self, FpsCounter};
@@ -51,6 +51,7 @@ const PANEL_MIN_W: f32 = 120.0; // world-space
 const PANEL_MIN_H: f32 = 80.0; // world-space
 const TITLE_SCREEN_MIN_H: f32 = 18.0; // screen-space; keeps title dragging usable when zoomed out
 const KEYBOARD_PAN_STEP: f32 = 160.0; // screen-space pixels
+const PANEL_FIT_MARGIN: f32 = 32.0; // screen-space pixels
 
 // ── Drag/resize state ─────────────────────────────────────────────────────────
 
@@ -87,6 +88,12 @@ enum HitResult {
     ResizeHandle(usize, ResizeHandle),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum FullscreenHitResult {
+    Body,
+    TitleBar,
+}
+
 pub struct WorkspaceCanvas {
     selected: Option<Entity<Workspace>>,
     /// Drop = unsubscribe. Replaced when selection changes so re-renders
@@ -96,6 +103,7 @@ pub struct WorkspaceCanvas {
     drag_state: DragState,
     selected_panel: Option<usize>,
     input_focused_panel: Option<usize>,
+    fullscreen_panel: Option<usize>,
     focus_handle: FocusHandle,
     /// Window-relative bounds of the canvas's root element, captured each
     /// frame via a `canvas()` prepaint callback. Mouse events arrive with
@@ -140,6 +148,7 @@ impl WorkspaceCanvas {
             drag_state: DragState::Idle,
             selected_panel: None,
             input_focused_panel: None,
+            fullscreen_panel: None,
             focus_handle: cx.focus_handle(),
             bounds: Rc::new(Cell::new(None)),
             fps,
@@ -230,6 +239,7 @@ impl WorkspaceCanvas {
             "focused_panel_id": self.selected_panel,
             "selected_panel_id": self.selected_panel,
             "input_focused_panel_id": self.input_focused_panel,
+            "fullscreen_panel_id": self.fullscreen_panel,
             "bounds": bounds,
             "fps": fps,
         })
@@ -241,7 +251,12 @@ impl WorkspaceCanvas {
         self.drag_state = DragState::Idle;
         self.selected_panel = None;
         self.input_focused_panel = None;
+        self.fullscreen_panel = None;
         cx.notify();
+    }
+
+    pub fn is_panel_fullscreen(&self) -> bool {
+        self.fullscreen_panel.is_some()
     }
 
     /// Select a panel by session id and optionally route keyboard input
@@ -301,6 +316,58 @@ impl WorkspaceCanvas {
             return;
         };
         self.viewport = self.viewport.pan_view_by_screen_delta(dx, dy);
+    }
+
+    fn canvas_screen_size(&self) -> (f32, f32) {
+        self.bounds
+            .get()
+            .map(|bounds| (pf(bounds.size.width), pf(bounds.size.height)))
+            .unwrap_or((1040.0, 760.0))
+    }
+
+    fn selected_panel_snapshot(&self, cx: &App) -> Option<Panel> {
+        let selected_id = self.selected_panel?;
+        self.selected
+            .as_ref()?
+            .read(cx)
+            .panels
+            .iter()
+            .find(|panel| panel.id == selected_id)
+            .cloned()
+    }
+
+    fn fit_panel_to_viewport(&mut self, panel: &Panel) {
+        let (screen_w, screen_h) = self.canvas_screen_size();
+        self.viewport = self.viewport.fit_world_rect(
+            WorldRect {
+                x: panel.world_x,
+                y: panel.world_y,
+                width: panel.width,
+                height: panel.height,
+            },
+            screen_w,
+            screen_h,
+            PANEL_FIT_MARGIN,
+        );
+    }
+
+    fn enter_selected_panel_input_and_fit(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(panel) = self.selected_panel_snapshot(cx) {
+            self.fullscreen_panel = None;
+            self.fit_panel_to_viewport(&panel);
+            self.focus_panel_input(&panel, window, cx);
+        }
+    }
+
+    fn toggle_selected_panel_fullscreen(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.fullscreen_panel.is_some() {
+            self.fullscreen_panel = None;
+            return;
+        }
+        if let Some(panel) = self.selected_panel_snapshot(cx) {
+            self.fullscreen_panel = Some(panel.id);
+            self.focus_panel_input(&panel, window, cx);
+        }
     }
 
     fn release_input_focus(&mut self, window: &mut Window) {
@@ -375,6 +442,14 @@ impl WorkspaceCanvas {
         HitResult::Canvas
     }
 
+    fn fullscreen_hit_test(screen_pos: gpui::Point<Pixels>) -> FullscreenHitResult {
+        if pf(screen_pos.y) <= TITLE_HEIGHT {
+            FullscreenHitResult::TitleBar
+        } else {
+            FullscreenHitResult::Body
+        }
+    }
+
     // ── Mouse handlers ────────────────────────────────────────────────────────
 
     fn on_mouse_down(
@@ -383,6 +458,32 @@ impl WorkspaceCanvas {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if let Some(fullscreen_id) = self.fullscreen_panel {
+            let panel = self.selected.as_ref().and_then(|ws| {
+                ws.read(cx)
+                    .panels
+                    .iter()
+                    .find(|panel| panel.id == fullscreen_id)
+                    .cloned()
+            });
+            if let Some(panel) = panel {
+                match Self::fullscreen_hit_test(self.local_pos(event.position)) {
+                    FullscreenHitResult::TitleBar => {
+                        self.select_panel(panel.id);
+                        self.release_input_focus(window);
+                    }
+                    FullscreenHitResult::Body => {
+                        self.focus_panel_input(&panel, window, cx);
+                    }
+                }
+                self.drag_state = DragState::Idle;
+                cx.notify();
+                return;
+            }
+            self.fullscreen_panel = None;
+            cx.notify();
+        }
+
         // hit_test takes canvas-local coords (panel screen positions are
         // computed from world*zoom with no canvas offset). DragState's
         // last_screen stays window-relative so it matches on_mouse_move,
@@ -426,6 +527,16 @@ impl WorkspaceCanvas {
 
     fn on_key_down(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
         match event.keystroke.key.as_str() {
+            "enter" if event.keystroke.modifiers.platform && event.keystroke.modifiers.shift => {
+                cx.stop_propagation();
+                self.toggle_selected_panel_fullscreen(window, cx);
+                cx.notify();
+            }
+            "enter" if event.keystroke.modifiers.platform => {
+                cx.stop_propagation();
+                self.enter_selected_panel_input_and_fit(window, cx);
+                cx.notify();
+            }
             "escape" if self.input_focused_panel.is_some() => {
                 cx.stop_propagation();
                 self.release_input_focus(window);
@@ -735,6 +846,73 @@ impl Render for WorkspaceCanvas {
         }
         let selected_panel = self.selected_panel;
         let input_focused_panel = self.input_focused_panel;
+        if self
+            .fullscreen_panel
+            .is_some_and(|id| !panels.iter().any(|panel| panel.id == id))
+        {
+            self.fullscreen_panel = None;
+            cx.notify();
+        }
+        let fullscreen_panel = self.fullscreen_panel;
+
+        if let Some(fullscreen_id) = fullscreen_panel {
+            if let Some(panel) = panels.iter().find(|panel| panel.id == fullscreen_id) {
+                let title_h = TITLE_HEIGHT;
+                let content_h = (ws_h - title_h).max(0.0);
+                let input_enabled = input_focused_panel == Some(panel.id);
+                panel.view.update(cx, |tv, inner_cx| {
+                    let size_changed = tv.set_content_size(ws_w, content_h);
+                    let zoom_changed = tv.set_zoom(1.0);
+                    let input_changed = tv.set_input_enabled(input_enabled);
+                    if size_changed || zoom_changed || input_changed {
+                        inner_cx.notify();
+                    }
+                });
+
+                let body: AnyElement = panel.view.clone().into_any_element();
+                let mut title_bar = div()
+                    .w_full()
+                    .h(px(title_h))
+                    .bg(rgb(0x252535))
+                    .flex()
+                    .items_center()
+                    .pl(px(8.0))
+                    .pr(px(4.0))
+                    .child(
+                        div()
+                            .flex_1()
+                            .truncate()
+                            .text_xs()
+                            .text_color(rgb(0xa0a0b0))
+                            .child(panel.title.clone()),
+                    );
+                title_bar = title_bar.child(panel_close_button(panel.session_id.clone(), cx));
+
+                root = root.child(
+                    div()
+                        .absolute()
+                        .left(px(0.0))
+                        .top(px(0.0))
+                        .w(px(ws_w))
+                        .h(px(ws_h))
+                        .bg(rgb(0x1c1c26))
+                        .border_1()
+                        .border_color(rgb(0x4a9eff))
+                        .child(title_bar)
+                        .child(
+                            div()
+                                .w_full()
+                                .h(px(content_h))
+                                .overflow_hidden()
+                                .child(body),
+                        ),
+                );
+                if let Some(readout) = readout {
+                    root = root.child(fps_overlay::overlay(readout, panels.len(), 1.0));
+                }
+                return root;
+            }
+        }
 
         // Push content_size + zoom into every TerminalView so their next
         // render syncs cell dims and emits PtyResize on actual change.
@@ -1030,5 +1208,17 @@ mod tests {
         assert_eq!(keyboard_pan_delta("right"), Some((KEYBOARD_PAN_STEP, 0.0)));
         assert_eq!(keyboard_pan_delta("l"), Some((KEYBOARD_PAN_STEP, 0.0)));
         assert_eq!(keyboard_pan_delta("x"), None);
+    }
+
+    #[test]
+    fn fullscreen_hit_test_treats_expanded_surface_as_panel() {
+        assert_eq!(
+            WorkspaceCanvas::fullscreen_hit_test(point(px(500.0), px(12.0))),
+            FullscreenHitResult::TitleBar,
+        );
+        assert_eq!(
+            WorkspaceCanvas::fullscreen_hit_test(point(px(500.0), px(320.0))),
+            FullscreenHitResult::Body,
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Includes the native canvas clipping/pan alias updates from #176: zoomed panels are clipped to the canvas, `Shift+h/j/k/l` pan the canvas, and default native panels are taller.
- Adds `Cmd+Enter` to focus the selected native canvas panel and fit the viewport around it without changing persisted panel geometry.
- Adds `Cmd+Shift+Enter` to toggle a temporary window-wide fullscreen mode for the selected panel, covering the sidebar without making the OS window fullscreen.
- Adds viewport fit math with unit coverage and exposes fullscreen state in the automation snapshot.
- Addresses review feedback by notifying the root app when stale fullscreen state is cleared and by making fullscreen mouse hit-testing treat the expanded surface as panel chrome/body instead of canvas.

## Validation

- `cargo fmt --check` in `native-ui`
- `cargo test --workspace` in `native-ui` — 46 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `go test ./internal/daemon ./internal/store` — 241 passed before the review-feedback-only adjustment
- `make scenario-native-canvas ATTN_PROFILE=dev` — PASS before the review-feedback-only adjustment