### PR TITLE
Snap native canvas panel geometry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,58 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    name: Changes
+    runs-on: ubuntu-latest
+    outputs:
+      daemon: ${{ steps.filter.outputs.daemon }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      tauri: ${{ steps.filter.outputs.tauri }}
+      native_ui: ${{ steps.filter.outputs.native_ui }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Classify changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            daemon:
+              - '**/*.go'
+              - 'cmd/**'
+              - 'internal/**'
+              - 'test/**'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'scripts/source-fingerprint.sh'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'app/src/**'
+              - 'app/e2e/**'
+              - 'app/test-harness/**'
+              - 'app/public/**'
+              - 'app/index.html'
+              - 'app/package.json'
+              - 'app/pnpm-lock.yaml'
+              - 'app/playwright.config.ts'
+              - 'app/tsconfig*.json'
+              - 'app/vite.config.ts'
+              - 'internal/protocol/schema/**'
+              - '.github/workflows/ci.yml'
+            tauri:
+              - 'app/src-tauri/**'
+              - '.github/workflows/ci.yml'
+            native_ui:
+              - 'native-ui/**'
+              - 'internal/protocol/schema/**'
+              - 'app/scripts/real-app-harness/scenario-native-canvas.mjs'
+              - '.github/workflows/ci.yml'
+
   backend:
     name: Daemon
+    needs: changes
+    if: needs.changes.outputs.daemon == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +84,8 @@ jobs:
 
   frontend:
     name: Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -83,6 +135,8 @@ jobs:
 
   rust:
     name: Tauri
+    needs: changes
+    if: needs.changes.outputs.tauri == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -127,6 +181,8 @@ jobs:
 
   native-ui:
     name: Native UI
+    needs: changes
+    if: needs.changes.outputs.native_ui == 'true'
     runs-on: macos-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,26 @@ jobs:
 
       - name: Cargo test
         run: cargo test
+
+  native-ui:
+    name: Native UI
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: native-ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cargo fmt
+        run: cargo fmt --check
+
+      - name: Cargo test
+        run: cargo test --workspace
+
+      - name: Cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-05-01]
 
 ### Changed
+- **Native Canvas Panel Snapping**: Moving or resizing native-canvas panels now magnetically aligns nearby edges and centers to other panels, keeping a small gap between neighboring panels and showing short contextual guide lines while a lock is active.
 - **Native Canvas Focus Modes**: `Cmd+Enter` now focuses the selected panel and fits the canvas viewport around it without changing panel geometry. `Cmd+Shift+Enter` toggles a temporary window-wide panel fullscreen mode that covers the sidebar without resizing or persisting the panel.
 - **Native Canvas Clipping And Keyboard Panning**: Zoomed native-canvas panels are now clipped to the canvas area instead of painting over the sidebar. `Shift+h/j/k/l` now pan the canvas alongside `Shift+Arrow`, and new native terminal panels are taller by default.
 - **Native Canvas Panel Placement**: New native-canvas sessions now use larger default terminal panels and place newly spawned panels in the visible canvas when space is available. When a panel is selected, new panels prefer clockwise slots around it before falling back to other visible space or the closest non-overlapping off-screen slot. `Shift+Arrow` now pans the canvas from the keyboard without changing panel selection.

--- a/docs/plans/native-canvas-architecture.md
+++ b/docs/plans/native-canvas-architecture.md
@@ -79,8 +79,8 @@ content's local state.
 The pannable, zoomable surface. A `Viewport { origin, zoom }` transforms
 world coordinates to screen coordinates and back. Panels are rendered as
 absolute-positioned elements; the canvas itself is an empty interaction
-target. No visible grid (snapping reads `GRID_SPACING` directly when
-implemented).
+target. No visible grid; snapping is magnetic against nearby panel
+edges/centers and paints only transient alignment guides.
 
 ### Focus model — two stages
 

--- a/native-ui/crates/attn-native-app/src/domain/mod.rs
+++ b/native-ui/crates/attn-native-app/src/domain/mod.rs
@@ -7,4 +7,5 @@
 
 pub mod panel_navigation;
 pub mod panel_placement;
+pub mod panel_snapping;
 pub mod viewport;

--- a/native-ui/crates/attn-native-app/src/domain/panel_snapping.rs
+++ b/native-ui/crates/attn-native-app/src/domain/panel_snapping.rs
@@ -1,0 +1,627 @@
+//! Panel geometry snapping for native canvas drag and resize.
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PanelRect {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ResizeEdges {
+    pub left: bool,
+    pub top: bool,
+    pub right: bool,
+    pub bottom: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SnapAxis {
+    X,
+    Y,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SnapLine {
+    pub axis: SnapAxis,
+    pub position: f32,
+    pub start: f32,
+    pub end: f32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SnapResult {
+    pub rect: PanelRect,
+    pub lines: Vec<SnapLine>,
+}
+
+const SNAP_GAP: f32 = 32.0;
+
+impl ResizeEdges {
+    pub const fn new(left: bool, top: bool, right: bool, bottom: bool) -> Self {
+        Self {
+            left,
+            top,
+            right,
+            bottom,
+        }
+    }
+}
+
+pub fn snap_panel_move(rect: PanelRect, targets: &[PanelRect], threshold: f32) -> SnapResult {
+    let x_match = best_axis_match(
+        &moving_x_anchors(rect),
+        &target_x_anchors(targets),
+        threshold,
+    );
+    let y_match = best_axis_match(
+        &moving_y_anchors(rect),
+        &target_y_anchors(targets),
+        threshold,
+    );
+    let mut snapped = rect;
+    let mut lines = Vec::new();
+
+    if let Some(axis_match) = x_match {
+        snapped.x += axis_match.delta();
+    }
+    if let Some(axis_match) = y_match {
+        snapped.y += axis_match.delta();
+    }
+    if let Some(axis_match) = x_match {
+        lines.push(axis_match.line(SnapAxis::X, snapped.y, snapped.bottom()));
+    }
+    if let Some(axis_match) = y_match {
+        lines.push(axis_match.line(SnapAxis::Y, snapped.x, snapped.right()));
+    }
+
+    SnapResult {
+        rect: snapped,
+        lines,
+    }
+}
+
+pub fn snap_panel_resize(
+    rect: PanelRect,
+    edges: ResizeEdges,
+    targets: &[PanelRect],
+    min_width: f32,
+    min_height: f32,
+    threshold: f32,
+) -> SnapResult {
+    let mut left = rect.x;
+    let mut top = rect.y;
+    let mut right = rect.x + rect.width;
+    let mut bottom = rect.y + rect.height;
+    let x_targets = target_x_anchors(targets);
+    let y_targets = target_y_anchors(targets);
+
+    if edges.left && right - left < min_width {
+        left = right - min_width;
+    }
+    if edges.right && right - left < min_width {
+        right = left + min_width;
+    }
+    if edges.top && bottom - top < min_height {
+        top = bottom - min_height;
+    }
+    if edges.bottom && bottom - top < min_height {
+        bottom = top + min_height;
+    }
+
+    let x_match = best_axis_match(
+        &resizing_x_anchors(left, right, edges),
+        &x_targets,
+        threshold,
+    );
+    if let Some(axis_match) = x_match {
+        if edges.left && right - axis_match.target.position >= min_width {
+            left = axis_match.target.position;
+        } else if edges.right && axis_match.target.position - left >= min_width {
+            right = axis_match.target.position;
+        }
+    }
+
+    let y_match = best_axis_match(
+        &resizing_y_anchors(top, bottom, edges),
+        &y_targets,
+        threshold,
+    );
+    if let Some(axis_match) = y_match {
+        if edges.top && bottom - axis_match.target.position >= min_height {
+            top = axis_match.target.position;
+        } else if edges.bottom && axis_match.target.position - top >= min_height {
+            bottom = axis_match.target.position;
+        }
+    }
+
+    let rect = PanelRect {
+        x: left,
+        y: top,
+        width: right - left,
+        height: bottom - top,
+    };
+    let mut lines = Vec::new();
+    if let Some(axis_match) = x_match {
+        let position = if edges.left { left } else { right };
+        if (axis_match.target.position - position).abs() < 0.001 {
+            lines.push(axis_match.line(SnapAxis::X, rect.y, rect.bottom()));
+        }
+    }
+    if let Some(axis_match) = y_match {
+        let position = if edges.top { top } else { bottom };
+        if (axis_match.target.position - position).abs() < 0.001 {
+            lines.push(axis_match.line(SnapAxis::Y, rect.x, rect.right()));
+        }
+    }
+
+    SnapResult { rect, lines }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct MovingAnchor {
+    position: f32,
+    kind: AnchorKind,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TargetAnchor {
+    position: f32,
+    span_start: f32,
+    span_end: f32,
+    kind: AnchorKind,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct AxisMatch {
+    moving: MovingAnchor,
+    target: TargetAnchor,
+    distance: f32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AnchorKind {
+    Start,
+    Center,
+    End,
+}
+
+impl AxisMatch {
+    fn delta(&self) -> f32 {
+        self.target.position - self.moving.position
+    }
+
+    fn line(&self, axis: SnapAxis, active_start: f32, active_end: f32) -> SnapLine {
+        SnapLine {
+            axis,
+            position: self.target.position,
+            start: active_start.min(active_end).min(self.target.span_start),
+            end: active_start.max(active_end).max(self.target.span_end),
+        }
+    }
+}
+
+fn best_axis_match(
+    moving: &[MovingAnchor],
+    targets: &[TargetAnchor],
+    threshold: f32,
+) -> Option<AxisMatch> {
+    let mut best: Option<AxisMatch> = None;
+    for moving in moving {
+        for target in targets {
+            if moving.kind != target.kind {
+                continue;
+            }
+            let distance = (moving.position - target.position).abs();
+            if distance > threshold {
+                continue;
+            }
+            if best.is_none_or(|candidate| distance < candidate.distance) {
+                best = Some(AxisMatch {
+                    moving: *moving,
+                    target: *target,
+                    distance,
+                });
+            }
+        }
+    }
+    best
+}
+
+impl PanelRect {
+    fn right(&self) -> f32 {
+        self.x + self.width
+    }
+
+    fn bottom(&self) -> f32 {
+        self.y + self.height
+    }
+
+    fn center_x(&self) -> f32 {
+        self.x + self.width / 2.0
+    }
+
+    fn center_y(&self) -> f32 {
+        self.y + self.height / 2.0
+    }
+}
+
+fn moving_x_anchors(rect: PanelRect) -> [MovingAnchor; 3] {
+    [
+        MovingAnchor {
+            position: rect.x,
+            kind: AnchorKind::Start,
+        },
+        MovingAnchor {
+            position: rect.center_x(),
+            kind: AnchorKind::Center,
+        },
+        MovingAnchor {
+            position: rect.right(),
+            kind: AnchorKind::End,
+        },
+    ]
+}
+
+fn moving_y_anchors(rect: PanelRect) -> [MovingAnchor; 3] {
+    [
+        MovingAnchor {
+            position: rect.y,
+            kind: AnchorKind::Start,
+        },
+        MovingAnchor {
+            position: rect.center_y(),
+            kind: AnchorKind::Center,
+        },
+        MovingAnchor {
+            position: rect.bottom(),
+            kind: AnchorKind::End,
+        },
+    ]
+}
+
+fn resizing_x_anchors(left: f32, right: f32, edges: ResizeEdges) -> Vec<MovingAnchor> {
+    let mut anchors = Vec::new();
+    if edges.left {
+        anchors.push(MovingAnchor {
+            position: left,
+            kind: AnchorKind::Start,
+        });
+    }
+    if edges.right {
+        anchors.push(MovingAnchor {
+            position: right,
+            kind: AnchorKind::End,
+        });
+    }
+    anchors
+}
+
+fn resizing_y_anchors(top: f32, bottom: f32, edges: ResizeEdges) -> Vec<MovingAnchor> {
+    let mut anchors = Vec::new();
+    if edges.top {
+        anchors.push(MovingAnchor {
+            position: top,
+            kind: AnchorKind::Start,
+        });
+    }
+    if edges.bottom {
+        anchors.push(MovingAnchor {
+            position: bottom,
+            kind: AnchorKind::End,
+        });
+    }
+    anchors
+}
+
+fn target_x_anchors(targets: &[PanelRect]) -> Vec<TargetAnchor> {
+    let mut anchors = Vec::with_capacity(targets.len() * 5);
+    for target in targets {
+        anchors.extend([
+            TargetAnchor {
+                position: target.x,
+                span_start: target.y,
+                span_end: target.bottom(),
+                kind: AnchorKind::Start,
+            },
+            TargetAnchor {
+                position: target.center_x(),
+                span_start: target.y,
+                span_end: target.bottom(),
+                kind: AnchorKind::Center,
+            },
+            TargetAnchor {
+                position: target.right(),
+                span_start: target.y,
+                span_end: target.bottom(),
+                kind: AnchorKind::End,
+            },
+            TargetAnchor {
+                position: target.x - SNAP_GAP,
+                span_start: target.y,
+                span_end: target.bottom(),
+                kind: AnchorKind::End,
+            },
+            TargetAnchor {
+                position: target.right() + SNAP_GAP,
+                span_start: target.y,
+                span_end: target.bottom(),
+                kind: AnchorKind::Start,
+            },
+        ]);
+    }
+    anchors
+}
+
+fn target_y_anchors(targets: &[PanelRect]) -> Vec<TargetAnchor> {
+    let mut anchors = Vec::with_capacity(targets.len() * 5);
+    for target in targets {
+        anchors.extend([
+            TargetAnchor {
+                position: target.y,
+                span_start: target.x,
+                span_end: target.right(),
+                kind: AnchorKind::Start,
+            },
+            TargetAnchor {
+                position: target.center_y(),
+                span_start: target.x,
+                span_end: target.right(),
+                kind: AnchorKind::Center,
+            },
+            TargetAnchor {
+                position: target.bottom(),
+                span_start: target.x,
+                span_end: target.right(),
+                kind: AnchorKind::End,
+            },
+            TargetAnchor {
+                position: target.y - SNAP_GAP,
+                span_start: target.x,
+                span_end: target.right(),
+                kind: AnchorKind::End,
+            },
+            TargetAnchor {
+                position: target.bottom() + SNAP_GAP,
+                span_start: target.x,
+                span_end: target.right(),
+                kind: AnchorKind::Start,
+            },
+        ]);
+    }
+    anchors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn move_snaps_edges_to_nearby_panel_edges() {
+        let result = snap_panel_move(
+            PanelRect {
+                x: 329.0,
+                y: 126.0,
+                width: 200.0,
+                height: 120.0,
+            },
+            &[PanelRect {
+                x: 100.0,
+                y: 120.0,
+                width: 200.0,
+                height: 120.0,
+            }],
+            10.0,
+        );
+
+        assert_eq!(
+            result.rect,
+            PanelRect {
+                x: 332.0,
+                y: 120.0,
+                width: 200.0,
+                height: 120.0,
+            }
+        );
+        assert_eq!(
+            result.lines,
+            vec![
+                SnapLine {
+                    axis: SnapAxis::X,
+                    position: 332.0,
+                    start: 120.0,
+                    end: 240.0,
+                },
+                SnapLine {
+                    axis: SnapAxis::Y,
+                    position: 120.0,
+                    start: 100.0,
+                    end: 532.0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn move_snaps_center_to_nearby_panel_center() {
+        let result = snap_panel_move(
+            PanelRect {
+                x: 475.0,
+                y: 310.0,
+                width: 100.0,
+                height: 100.0,
+            },
+            &[PanelRect {
+                x: 400.0,
+                y: 100.0,
+                width: 240.0,
+                height: 160.0,
+            }],
+            12.0,
+        );
+
+        assert_eq!(
+            result.rect,
+            PanelRect {
+                x: 470.0,
+                y: 310.0,
+                width: 100.0,
+                height: 100.0,
+            }
+        );
+        assert_eq!(
+            result.lines,
+            vec![SnapLine {
+                axis: SnapAxis::X,
+                position: 520.0,
+                start: 100.0,
+                end: 410.0,
+            }]
+        );
+    }
+
+    #[test]
+    fn move_does_not_snap_without_a_nearby_panel_anchor() {
+        let result = snap_panel_move(
+            PanelRect {
+                x: 321.0,
+                y: 276.0,
+                width: 200.0,
+                height: 120.0,
+            },
+            &[PanelRect {
+                x: 100.0,
+                y: 100.0,
+                width: 160.0,
+                height: 90.0,
+            }],
+            10.0,
+        );
+
+        assert_eq!(
+            result.rect,
+            PanelRect {
+                x: 321.0,
+                y: 276.0,
+                width: 200.0,
+                height: 120.0,
+            }
+        );
+        assert!(result.lines.is_empty());
+    }
+
+    #[test]
+    fn bottom_right_resize_snaps_moved_edges_to_panel_edges() {
+        let result = snap_panel_resize(
+            PanelRect {
+                x: 100.0,
+                y: 100.0,
+                width: 177.0,
+                height: 146.0,
+            },
+            ResizeEdges::new(false, false, true, true),
+            &[PanelRect {
+                x: 310.0,
+                y: 280.0,
+                width: 180.0,
+                height: 120.0,
+            }],
+            120.0,
+            80.0,
+            10.0,
+        );
+
+        assert_eq!(
+            result.rect,
+            PanelRect {
+                x: 100.0,
+                y: 100.0,
+                width: 178.0,
+                height: 148.0,
+            }
+        );
+        assert_eq!(
+            result.lines,
+            vec![
+                SnapLine {
+                    axis: SnapAxis::X,
+                    position: 278.0,
+                    start: 100.0,
+                    end: 400.0,
+                },
+                SnapLine {
+                    axis: SnapAxis::Y,
+                    position: 248.0,
+                    start: 100.0,
+                    end: 490.0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn top_left_resize_snaps_moved_edges_and_preserves_opposite_corner() {
+        let result = snap_panel_resize(
+            PanelRect {
+                x: 185.0,
+                y: 239.0,
+                width: 215.0,
+                height: 161.0,
+            },
+            ResizeEdges::new(true, true, false, false),
+            &[PanelRect {
+                x: 100.0,
+                y: 120.0,
+                width: 50.0,
+                height: 90.0,
+            }],
+            120.0,
+            80.0,
+            10.0,
+        );
+
+        assert_eq!(
+            result.rect,
+            PanelRect {
+                x: 182.0,
+                y: 242.0,
+                width: 218.0,
+                height: 158.0,
+            }
+        );
+    }
+
+    #[test]
+    fn resize_respects_minimum_size_over_nearby_anchor() {
+        let result = snap_panel_resize(
+            PanelRect {
+                x: 100.0,
+                y: 100.0,
+                width: 21.0,
+                height: 19.0,
+            },
+            ResizeEdges::new(false, false, true, true),
+            &[PanelRect {
+                x: 120.0,
+                y: 80.0,
+                width: 40.0,
+                height: 40.0,
+            }],
+            120.0,
+            80.0,
+            30.0,
+        );
+
+        assert_eq!(
+            result.rect,
+            PanelRect {
+                x: 100.0,
+                y: 100.0,
+                width: 120.0,
+                height: 80.0,
+            }
+        );
+        assert!(result.lines.is_empty());
+    }
+}

--- a/native-ui/crates/attn-native-app/src/domain/viewport.rs
+++ b/native-ui/crates/attn-native-app/src/domain/viewport.rs
@@ -5,12 +5,6 @@
 /// position and extents follow zoom so the canvas feels like tldraw.
 use gpui::{point, px, Pixels};
 
-/// World-space grid step. The visible grid was removed after the perf
-/// spike (paint cost dominated at zoom-out); this constant survives as
-/// the snap-to target for future panel-drag snapping.
-#[allow(dead_code)] // unused until snapping lands; see docs/plans/2026-04-28-canvas-perf-spike.md
-pub const GRID_SPACING: f32 = 50.0;
-
 const ZOOM_MIN: f32 = 0.15;
 const ZOOM_MAX: f32 = 5.0;
 

--- a/native-ui/crates/attn-native-app/src/views/canvas.rs
+++ b/native-ui/crates/attn-native-app/src/views/canvas.rs
@@ -39,6 +39,9 @@ use serde_json::{json, Value};
 
 use crate::domain::panel_navigation::{navigate_panel, NavigationDirection, PanelNavItem};
 use crate::domain::panel_placement::Rect;
+use crate::domain::panel_snapping::{
+    snap_panel_move, snap_panel_resize, PanelRect, ResizeEdges, SnapAxis, SnapLine,
+};
 use crate::domain::viewport::{pf, Viewport, WorldRect};
 use crate::state::panel::{Panel, TITLE_HEIGHT};
 use crate::state::workspace::Workspace;
@@ -52,6 +55,7 @@ const PANEL_MIN_H: f32 = 80.0; // world-space
 const TITLE_SCREEN_MIN_H: f32 = 18.0; // screen-space; keeps title dragging usable when zoomed out
 const KEYBOARD_PAN_STEP: f32 = 160.0; // screen-space pixels
 const PANEL_FIT_MARGIN: f32 = 32.0; // screen-space pixels
+const SNAP_LOCK_SCREEN_THRESHOLD: f32 = 10.0; // screen-space pixels
 
 // ── Drag/resize state ─────────────────────────────────────────────────────────
 
@@ -71,12 +75,14 @@ enum DragState {
     },
     DraggingPanel {
         panel_id: usize,
-        last_screen: gpui::Point<Pixels>,
+        start_screen: gpui::Point<Pixels>,
+        start_rect: PanelRect,
     },
     ResizingPanel {
         panel_id: usize,
         handle: ResizeHandle,
-        last_screen: gpui::Point<Pixels>,
+        start_screen: gpui::Point<Pixels>,
+        start_rect: PanelRect,
     },
 }
 
@@ -104,6 +110,7 @@ pub struct WorkspaceCanvas {
     selected_panel: Option<usize>,
     input_focused_panel: Option<usize>,
     fullscreen_panel: Option<usize>,
+    snap_lines: Vec<SnapLine>,
     focus_handle: FocusHandle,
     /// Window-relative bounds of the canvas's root element, captured each
     /// frame via a `canvas()` prepaint callback. Mouse events arrive with
@@ -149,6 +156,7 @@ impl WorkspaceCanvas {
             selected_panel: None,
             input_focused_panel: None,
             fullscreen_panel: None,
+            snap_lines: Vec::new(),
             focus_handle: cx.focus_handle(),
             bounds: Rc::new(Cell::new(None)),
             fps,
@@ -252,6 +260,7 @@ impl WorkspaceCanvas {
         self.selected_panel = None;
         self.input_focused_panel = None;
         self.fullscreen_panel = None;
+        self.snap_lines.clear();
         cx.notify();
     }
 
@@ -334,6 +343,31 @@ impl WorkspaceCanvas {
             .iter()
             .find(|panel| panel.id == selected_id)
             .cloned()
+    }
+
+    fn panel_rect_by_id(&self, panel_id: usize, cx: &App) -> Option<PanelRect> {
+        self.selected
+            .as_ref()?
+            .read(cx)
+            .panels
+            .iter()
+            .find(|panel| panel.id == panel_id)
+            .map(panel_rect)
+    }
+
+    fn panel_snap_targets(&self, panel_id: usize, cx: &App) -> Vec<PanelRect> {
+        self.selected
+            .as_ref()
+            .map(|workspace| {
+                workspace
+                    .read(cx)
+                    .panels
+                    .iter()
+                    .filter(|panel| panel.id != panel_id)
+                    .map(panel_rect)
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     fn fit_panel_to_viewport(&mut self, panel: &Panel) {
@@ -494,21 +528,28 @@ impl WorkspaceCanvas {
             HitResult::TitleBar(id) => {
                 self.select_panel(id);
                 self.release_input_focus(window);
-                self.drag_state = DragState::DraggingPanel {
-                    panel_id: id,
-                    last_screen: pos,
-                };
+                if let Some(start_rect) = self.panel_rect_by_id(id, cx) {
+                    self.drag_state = DragState::DraggingPanel {
+                        panel_id: id,
+                        start_screen: pos,
+                        start_rect,
+                    };
+                }
             }
             HitResult::ResizeHandle(id, handle) => {
                 self.select_panel(id);
                 self.release_input_focus(window);
-                self.drag_state = DragState::ResizingPanel {
-                    panel_id: id,
-                    handle,
-                    last_screen: pos,
-                };
+                if let Some(start_rect) = self.panel_rect_by_id(id, cx) {
+                    self.drag_state = DragState::ResizingPanel {
+                        panel_id: id,
+                        handle,
+                        start_screen: pos,
+                        start_rect,
+                    };
+                }
             }
             HitResult::PanelBody(id) => {
+                self.snap_lines.clear();
                 if let Some(ws) = self.selected.as_ref() {
                     let panel = ws.read(cx).panels.iter().find(|p| p.id == id).cloned();
                     if let Some(panel) = panel {
@@ -518,6 +559,7 @@ impl WorkspaceCanvas {
                 self.drag_state = DragState::Idle;
             }
             HitResult::Canvas => {
+                self.snap_lines.clear();
                 self.release_input_focus(window);
                 self.drag_state = DragState::PanningCanvas { last_screen: pos };
             }
@@ -609,6 +651,7 @@ impl WorkspaceCanvas {
             DragState::Idle => return,
 
             DragState::PanningCanvas { last_screen } => {
+                self.snap_lines.clear();
                 let dx = pf(pos.x) - pf(last_screen.x);
                 let dy = pf(pos.y) - pf(last_screen.y);
                 self.viewport.origin.x -= dx / self.viewport.zoom;
@@ -618,37 +661,59 @@ impl WorkspaceCanvas {
 
             DragState::DraggingPanel {
                 panel_id,
-                last_screen,
+                start_screen,
+                start_rect,
             } => {
-                let dx = (pf(pos.x) - pf(last_screen.x)) / self.viewport.zoom;
-                let dy = (pf(pos.y) - pf(last_screen.y)) / self.viewport.zoom;
+                let dx = (pf(pos.x) - pf(start_screen.x)) / self.viewport.zoom;
+                let dy = (pf(pos.y) - pf(start_screen.y)) / self.viewport.zoom;
+                let snap = snap_panel_move(
+                    PanelRect {
+                        x: start_rect.x + dx,
+                        y: start_rect.y + dy,
+                        ..start_rect
+                    },
+                    &self.panel_snap_targets(panel_id, cx),
+                    snap_threshold_world(self.viewport.zoom),
+                );
+                self.snap_lines = snap.lines.clone();
                 if let Some(ws) = self.selected.as_ref() {
                     ws.update(cx, |ws, cx| {
                         if let Some(p) = ws.panels.iter_mut().find(|p| p.id == panel_id) {
-                            p.world_x += dx;
-                            p.world_y += dy;
+                            set_panel_rect(p, snap.rect);
                             cx.notify();
                         }
                     });
                 }
                 self.drag_state = DragState::DraggingPanel {
                     panel_id,
-                    last_screen: pos,
+                    start_screen,
+                    start_rect,
                 };
             }
 
             DragState::ResizingPanel {
                 panel_id,
                 handle,
-                last_screen,
+                start_screen,
+                start_rect,
             } => {
                 // Screen delta → world delta so resize feels zoom-invariant.
-                let dx = (pf(pos.x) - pf(last_screen.x)) / self.viewport.zoom;
-                let dy = (pf(pos.y) - pf(last_screen.y)) / self.viewport.zoom;
+                let dx = (pf(pos.x) - pf(start_screen.x)) / self.viewport.zoom;
+                let dy = (pf(pos.y) - pf(start_screen.y)) / self.viewport.zoom;
+                let resized = apply_resize(start_rect, handle, dx, dy);
+                let snap = snap_panel_resize(
+                    resized,
+                    resize_edges(handle),
+                    &self.panel_snap_targets(panel_id, cx),
+                    PANEL_MIN_W,
+                    PANEL_MIN_H,
+                    snap_threshold_world(self.viewport.zoom),
+                );
+                self.snap_lines = snap.lines.clone();
                 if let Some(ws) = self.selected.as_ref() {
                     ws.update(cx, |ws, cx| {
                         if let Some(p) = ws.panels.iter_mut().find(|p| p.id == panel_id) {
-                            apply_resize(p, handle, dx, dy);
+                            set_panel_rect(p, snap.rect);
                             cx.notify();
                         }
                     });
@@ -656,7 +721,8 @@ impl WorkspaceCanvas {
                 self.drag_state = DragState::ResizingPanel {
                     panel_id,
                     handle,
-                    last_screen: pos,
+                    start_screen,
+                    start_rect,
                 };
             }
         }
@@ -686,6 +752,7 @@ impl WorkspaceCanvas {
             }
         }
         self.drag_state = DragState::Idle;
+        self.snap_lines.clear();
         cx.notify();
     }
 
@@ -717,33 +784,64 @@ impl WorkspaceCanvas {
     }
 }
 
-fn apply_resize(p: &mut Panel, handle: ResizeHandle, dx: f32, dy: f32) {
+fn panel_rect(panel: &Panel) -> PanelRect {
+    PanelRect {
+        x: panel.world_x,
+        y: panel.world_y,
+        width: panel.width,
+        height: panel.height,
+    }
+}
+
+fn set_panel_rect(panel: &mut Panel, rect: PanelRect) {
+    panel.world_x = rect.x;
+    panel.world_y = rect.y;
+    panel.width = rect.width;
+    panel.height = rect.height;
+}
+
+fn apply_resize(rect: PanelRect, handle: ResizeHandle, dx: f32, dy: f32) -> PanelRect {
+    let mut next = rect;
     match handle {
         ResizeHandle::TopLeft => {
-            let new_w = (p.width - dx).max(PANEL_MIN_W);
-            let new_h = (p.height - dy).max(PANEL_MIN_H);
-            p.world_x += p.width - new_w;
-            p.world_y += p.height - new_h;
-            p.width = new_w;
-            p.height = new_h;
+            let new_w = (next.width - dx).max(PANEL_MIN_W);
+            let new_h = (next.height - dy).max(PANEL_MIN_H);
+            next.x += next.width - new_w;
+            next.y += next.height - new_h;
+            next.width = new_w;
+            next.height = new_h;
         }
         ResizeHandle::TopRight => {
-            let new_h = (p.height - dy).max(PANEL_MIN_H);
-            p.world_y += p.height - new_h;
-            p.height = new_h;
-            p.width = (p.width + dx).max(PANEL_MIN_W);
+            let new_h = (next.height - dy).max(PANEL_MIN_H);
+            next.y += next.height - new_h;
+            next.height = new_h;
+            next.width = (next.width + dx).max(PANEL_MIN_W);
         }
         ResizeHandle::BottomLeft => {
-            let new_w = (p.width - dx).max(PANEL_MIN_W);
-            p.world_x += p.width - new_w;
-            p.width = new_w;
-            p.height = (p.height + dy).max(PANEL_MIN_H);
+            let new_w = (next.width - dx).max(PANEL_MIN_W);
+            next.x += next.width - new_w;
+            next.width = new_w;
+            next.height = (next.height + dy).max(PANEL_MIN_H);
         }
         ResizeHandle::BottomRight => {
-            p.width = (p.width + dx).max(PANEL_MIN_W);
-            p.height = (p.height + dy).max(PANEL_MIN_H);
+            next.width = (next.width + dx).max(PANEL_MIN_W);
+            next.height = (next.height + dy).max(PANEL_MIN_H);
         }
     }
+    next
+}
+
+fn resize_edges(handle: ResizeHandle) -> ResizeEdges {
+    match handle {
+        ResizeHandle::TopLeft => ResizeEdges::new(true, true, false, false),
+        ResizeHandle::TopRight => ResizeEdges::new(false, true, true, false),
+        ResizeHandle::BottomLeft => ResizeEdges::new(true, false, false, true),
+        ResizeHandle::BottomRight => ResizeEdges::new(false, false, true, true),
+    }
+}
+
+fn snap_threshold_world(zoom: f32) -> f32 {
+    SNAP_LOCK_SCREEN_THRESHOLD / zoom.max(0.001)
 }
 
 fn title_screen_height(zoom: f32) -> f32 {
@@ -800,10 +898,9 @@ impl Render for WorkspaceCanvas {
         let focus_handle = self.focus_handle.clone();
 
         let bounds_capture = self.bounds.clone();
-        // Grid dots intentionally omitted: snapping (when added) reads
-        // `viewport::GRID_SPACING` directly in code, no visible grid
-        // required. Removing the per-frame paint_quad-per-dot work keeps
-        // the frame budget clear at every zoom level.
+        // Grid dots intentionally omitted. Magnetic snapping uses nearby
+        // panel anchors and only paints short active guides during a
+        // gesture, keeping the frame budget clear at every zoom level.
         let mut root = div()
             .size_full()
             .bg(rgb(0x0e0e14))
@@ -1007,6 +1104,10 @@ impl Render for WorkspaceCanvas {
             )));
         }
 
+        for line in &self.snap_lines {
+            root = root.child(snap_guide(*line, viewport, ws_w, ws_h));
+        }
+
         // Render the spawn toolbar last so it sits on top of panels and
         // empty-state copy. Always visible when a workspace is selected so
         // the entry point to dogfood is unmissable.
@@ -1157,6 +1258,44 @@ fn corner_handle(left: f32, top: f32) -> impl IntoElement {
         .rounded(px(1.0))
 }
 
+fn snap_guide(
+    line: SnapLine,
+    viewport: Viewport,
+    screen_w: f32,
+    screen_h: f32,
+) -> impl IntoElement {
+    match line.axis {
+        SnapAxis::X => {
+            let screen_x = pf(viewport.world_to_screen(point(line.position, 0.0)).x).round();
+            let start_y = pf(viewport.world_to_screen(point(0.0, line.start)).y).round();
+            let end_y = pf(viewport.world_to_screen(point(0.0, line.end)).y).round();
+            let top = start_y.min(end_y).clamp(0.0, screen_h);
+            let bottom = start_y.max(end_y).clamp(0.0, screen_h);
+            div()
+                .absolute()
+                .left(px(screen_x))
+                .top(px(top))
+                .w(px(1.0))
+                .h(px((bottom - top).max(1.0)))
+                .bg(rgb(0xc59b45))
+        }
+        SnapAxis::Y => {
+            let screen_y = pf(viewport.world_to_screen(point(0.0, line.position)).y).round();
+            let start_x = pf(viewport.world_to_screen(point(line.start, 0.0)).x).round();
+            let end_x = pf(viewport.world_to_screen(point(line.end, 0.0)).x).round();
+            let left = start_x.min(end_x).clamp(0.0, screen_w);
+            let right = start_x.max(end_x).clamp(0.0, screen_w);
+            div()
+                .absolute()
+                .left(px(left))
+                .top(px(screen_y))
+                .w(px((right - left).max(1.0)))
+                .h(px(1.0))
+                .bg(rgb(0xc59b45))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1208,6 +1347,13 @@ mod tests {
         assert_eq!(keyboard_pan_delta("right"), Some((KEYBOARD_PAN_STEP, 0.0)));
         assert_eq!(keyboard_pan_delta("l"), Some((KEYBOARD_PAN_STEP, 0.0)));
         assert_eq!(keyboard_pan_delta("x"), None);
+    }
+
+    #[test]
+    fn snap_threshold_keeps_lock_zone_screen_sized() {
+        assert_eq!(snap_threshold_world(1.0), SNAP_LOCK_SCREEN_THRESHOLD);
+        assert_eq!(snap_threshold_world(0.5), SNAP_LOCK_SCREEN_THRESHOLD * 2.0);
+        assert_eq!(snap_threshold_world(2.0), SNAP_LOCK_SCREEN_THRESHOLD / 2.0);
     }
 
     #[test]

--- a/native-ui/crates/attn-native-app/src/views/fps_overlay.rs
+++ b/native-ui/crates/attn-native-app/src/views/fps_overlay.rs
@@ -39,7 +39,10 @@ impl FpsCounter {
     /// Record that a frame is being rendered right now and return the
     /// latest readout. Must be called once per `Render::render` call.
     pub fn record_frame(&mut self) -> Readout {
-        let now = Instant::now();
+        self.record_sample_at(Instant::now())
+    }
+
+    fn record_sample_at(&mut self, now: Instant) -> Readout {
         self.samples.push_back(now);
 
         let cutoff = now - WINDOW;
@@ -124,12 +127,11 @@ pub fn overlay(readout: Readout, panel_count: usize, zoom: f32) -> impl IntoElem
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::thread::sleep;
 
     #[test]
     fn empty_counter_reports_zero() {
         let mut c = FpsCounter::new();
-        let r = c.record_frame();
+        let r = c.record_sample_at(Instant::now());
         assert_eq!(r.fps, 1.0);
         assert_eq!(r.avg_ms, 0.0);
         assert_eq!(r.last_ms, 0.0);
@@ -138,24 +140,21 @@ mod tests {
     #[test]
     fn two_samples_produce_inter_frame_interval() {
         let mut c = FpsCounter::new();
-        c.record_frame();
-        sleep(Duration::from_millis(10));
-        let r = c.record_frame();
+        let first = Instant::now();
+        c.record_sample_at(first);
+        let r = c.record_sample_at(first + Duration::from_millis(10));
         assert_eq!(r.fps, 2.0);
-        assert!(
-            r.last_ms >= 9.0 && r.last_ms <= 30.0,
-            "last_ms = {}",
-            r.last_ms
-        );
-        assert!(r.avg_ms >= 9.0 && r.avg_ms <= 30.0, "avg_ms = {}", r.avg_ms);
+        assert_eq!(r.last_ms, 10.0);
+        assert_eq!(r.avg_ms, 10.0);
     }
 
     #[test]
     fn samples_outside_window_are_dropped() {
         let mut c = FpsCounter::new();
-        c.samples.push_back(Instant::now() - Duration::from_secs(5));
-        c.samples.push_back(Instant::now() - Duration::from_secs(2));
-        let r = c.record_frame();
+        let now = Instant::now();
+        c.samples.push_back(now - Duration::from_secs(5));
+        c.samples.push_back(now - Duration::from_secs(2));
+        let r = c.record_sample_at(now);
         assert_eq!(r.fps, 1.0, "old samples should be evicted");
     }
 }

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -129,7 +129,6 @@ if has_changed '^internal/protocol/schema/'; then
 fi
 
 if has_changed '^app/src-tauri/'; then
-  run_daemon_checks=true
   run_tauri_checks=true
 fi
 
@@ -138,7 +137,6 @@ if has_frontend_files; then
 fi
 
 if has_changed '^(native-ui/|app/scripts/real-app-harness/scenario-native-canvas\.mjs$)'; then
-  run_daemon_checks=true
   run_native_checks=true
 fi
 


### PR DESCRIPTION
## Summary

- Replaces grid-based native-canvas snapping with panel-to-panel magnetism: moving panels can align edges/centers to nearby panel edges/centers, and resizing snaps only the active resize edges.
- Keeps a small 32px gap when snapping one panel beside or above/below another, while same-side and center alignment still snap directly.
- Keeps the lock zone screen-sized across zoom levels, so snapping feels consistent when zoomed in or out.
- Shows short contextual alignment guides spanning the involved panels while a lock is active, instead of full-canvas grid lines.
- Reworks drag/resize gestures to recompute from the gesture's starting rect so snapped geometry does not drift during pointer movement.
- Adds pure snapping tests for panel edge/center targets, margin targets, proximity thresholds, resize edge anchoring, and minimum-size handling.
- Adds path-aware CI selection plus a macOS `Native UI` job for native Rust format, tests, and clippy.
- Makes the native FPS overlay interval test deterministic so CI scheduling delays do not fail it spuriously.

## Validation

- `cargo fmt --check` in `native-ui`
- `cargo test --workspace` in `native-ui` — 53 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `make scenario-native-canvas ATTN_PROFILE=dev` — PASS after launching `make dev-native` from this branch
- `bash -n scripts/pre-commit.sh`
- Parsed `.github/workflows/ci.yml` with Ruby YAML
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml`
- GitHub PR checks: 6 passed, 0 failed