### PR TITLE
[codex] Fix native location dialog submit crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-05-02]
+
+### Fixed
+- **Native Location Dialog Crash**: Opening a new native-canvas session from the location dialog no longer crashes when the dialog submit is triggered by an asynchronous daemon path inspection or worktree result while the root app is already processing that daemon event.
+
+---
+
 ## [2026-05-01]
 
 ### Changed

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -14,7 +14,7 @@ use attn_protocol::{
 };
 use gpui::{
     div, prelude::*, App, Context, Entity, Focusable, ParentElement, Render, SharedString,
-    Subscription, Window,
+    Subscription, WeakEntity, Window,
 };
 use serde_json::{json, Value};
 
@@ -386,12 +386,7 @@ impl NativeApp {
                 },
                 daemon,
                 move |outcome, cx| {
-                    let app = app_handle_submit
-                        .upgrade()
-                        .ok_or_else(|| "NativeApp entity dropped".to_string())?;
-                    app.update(cx, |app: &mut NativeApp, cx| {
-                        app.handle_location_dialog_outcome(outcome, cx)
-                    })
+                    schedule_location_dialog_submit(app_handle_submit.clone(), outcome, cx)
                 },
                 move |cx| {
                     if let Some(app) = app_handle_close.upgrade() {
@@ -424,12 +419,7 @@ impl NativeApp {
                 LocationDialogMode::NewWorkspace { initial_directory },
                 daemon,
                 move |outcome, cx| {
-                    let app = app_handle_submit
-                        .upgrade()
-                        .ok_or_else(|| "NativeApp entity dropped".to_string())?;
-                    app.update(cx, |app: &mut NativeApp, cx| {
-                        app.handle_location_dialog_outcome(outcome, cx)
-                    })
+                    schedule_location_dialog_submit(app_handle_submit.clone(), outcome, cx)
                 },
                 move |cx| {
                     if let Some(app) = app_handle_close.upgrade() {
@@ -477,6 +467,12 @@ impl NativeApp {
             }
         }
         Ok(())
+    }
+
+    fn close_location_dialog_after_submit(&mut self, cx: &mut Context<Self>) {
+        self.location_dialog = None;
+        self.canvas_needs_refocus = true;
+        cx.notify();
     }
 
     /// Register a workspace and select it once the daemon confirms it.
@@ -1118,6 +1114,33 @@ impl NativeApp {
             }
         }
     }
+}
+
+fn schedule_location_dialog_submit(
+    app_handle: WeakEntity<NativeApp>,
+    outcome: LocationDialogOutcome,
+    cx: &mut App,
+) -> Result<(), String> {
+    if app_handle.upgrade().is_none() {
+        return Err("NativeApp entity dropped".to_string());
+    }
+
+    cx.defer(move |cx| {
+        let Some(app_handle) = app_handle.upgrade() else {
+            return;
+        };
+        app_handle.update(cx, |app: &mut NativeApp, cx| {
+            match app.handle_location_dialog_outcome(outcome, cx) {
+                Ok(()) => app.close_location_dialog_after_submit(cx),
+                Err(error) => {
+                    if let Some(dialog) = app.location_dialog.clone() {
+                        dialog.update(cx, |dialog, cx| dialog.set_error(error, cx));
+                    }
+                }
+            }
+        });
+    });
+    Ok(())
 }
 
 impl Render for NativeApp {

--- a/native-ui/crates/attn-native-app/src/views/location_dialog.rs
+++ b/native-ui/crates/attn-native-app/src/views/location_dialog.rs
@@ -145,6 +145,12 @@ impl LocationDialog {
         }
     }
 
+    pub fn set_error(&mut self, error: String, cx: &mut Context<Self>) {
+        self.loading_label = None;
+        self.error = Some(SharedString::from(error));
+        cx.notify();
+    }
+
     fn next_request_id(&mut self, prefix: &str) -> String {
         self.request_seq += 1;
         format!("native-{prefix}-{}", self.request_seq)
@@ -349,13 +355,8 @@ impl LocationDialog {
             }
         };
 
-        match (self.on_submit)(outcome, cx) {
-            Ok(()) => {
-                (self.on_close)(cx);
-            }
-            Err(error) => {
-                self.error = Some(SharedString::from(error));
-            }
+        if let Err(error) = (self.on_submit)(outcome, cx) {
+            self.error = Some(SharedString::from(error));
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a native GPUI crash when submitting the location dialog after an asynchronous daemon result.

The dialog could receive a daemon path inspection or worktree result while `NativeApp` was already processing a daemon event. If that result caused the dialog to submit immediately, the submit callback synchronously re-entered `NativeApp::update`, and GPUI panicked because the same entity was already leased for update.

This PR defers the parent `NativeApp` mutation until the current GPUI effect cycle completes. On success the parent closes the dialog and refocuses the canvas; on failure it leaves the dialog open and writes the error back into it.

## Validation

- `cd native-ui && cargo fmt --check`
- `cd native-ui && cargo test --workspace`
- `cd native-ui && cargo clippy --workspace --all-targets -- -D warnings`
- `ATTN_PROFILE=dev make scenario-native-canvas`