### PR TITLE
[codex] Add native shell splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-05-02]
 
+### Changed
+- **Native Canvas Shell Splits**: `Cmd+D` now opens a new Shell panel to the right of the selected native-canvas panel, and `Cmd+Shift+D` opens one below it. Split panels inherit the anchor panel's size, persist their daemon-owned geometry, and take input focus once attached.
+
 ### Fixed
 - **Native Location Dialog Crash**: Opening a new native-canvas session from the location dialog no longer crashes when the dialog submit is triggered by an asynchronous daemon path inspection or worktree result while the root app is already processing that daemon event.
 

--- a/app/scripts/real-app-harness/scenario-native-canvas.mjs
+++ b/app/scripts/real-app-harness/scenario-native-canvas.mjs
@@ -20,6 +20,9 @@
  *     not the first), including the selected-vs-input-focused canvas
  *     gate — poll read_pane_text for the marker, unregister the
  *     session, confirm cleanup
+ *   - native shell splits: create a selected shell panel, split right
+ *     and bottom, assert both new panels are shell sessions placed
+ *     adjacent to the anchor
  *
  * Tearing down: every resource the scenario creates is unregistered in
  * `finally` blocks, even on assertion failure.
@@ -504,6 +507,200 @@ async function expectCanvasPanelFocus(conn, sessionId, { inputFocus }) {
   }
 }
 
+async function checkNativeShellSplits(conn) {
+  const directory = process.env.HOME || '/tmp';
+  const anchorDirectory = '/tmp';
+  if (directory === anchorDirectory) {
+    info(`  skipped cwd-difference assertion because workspace cwd is already ${anchorDirectory}`);
+  }
+  const created = await conn.request('create_workspace', {
+    directory,
+    title: `Scenario Split Host ${new Date().toISOString().slice(11, 19)}`,
+  });
+  if (!created.ok) fail(`create_workspace (split host): ${created.error}`);
+  const workspaceId = created.result.id;
+
+  try {
+    await pollUntil(
+      async () => {
+        const s = await conn.request('get_state');
+        return s.ok && s.result.selected_workspace_id === workspaceId;
+      },
+      { timeoutMs: 5000, label: `split host ${workspaceId.slice(0, 8)} selected` },
+    );
+
+    const spawned = await conn.request('spawn_session', {
+      workspace_id: workspaceId,
+      agent: 'shell',
+      cwd: anchorDirectory,
+    });
+    if (!spawned.ok) fail(`spawn_session split anchor: ${spawned.error}`);
+    const anchorSessionId = spawned.result.session_id;
+    const anchorPanel = await waitForPanel(conn, workspaceId, anchorSessionId, 'split anchor panel');
+
+    const anchorRect = {
+      world_x: 120,
+      world_y: 90,
+      width: 420,
+      height: 300,
+    };
+    const moved = await conn.request('move_panel', {
+      workspace_id: workspaceId,
+      panel_id: anchorPanel.id,
+      ...anchorRect,
+    });
+    if (!moved.ok) fail(`move_panel split anchor: ${moved.error}`);
+    await pollUntil(
+      async () => {
+        const panel = await getPanel(conn, workspaceId, anchorSessionId);
+        return panel && panelApproxEquals(panel, anchorRect);
+      },
+      { timeoutMs: 5000, intervalMs: 100, label: 'split anchor geometry persisted' },
+    );
+
+    const cursorBeforeRight = (await tailEvents(conn)).next_cursor;
+    const right = await conn.request('split_shell', {
+      session_id: anchorSessionId,
+      direction: 'right',
+    });
+    if (!right.ok) fail(`split_shell right: ${right.error}`);
+    const rightSessionId = right.result.session_id;
+    const rightExpected = {
+      world_x: anchorRect.world_x + anchorRect.width + 32,
+      world_y: anchorRect.world_y,
+      width: anchorRect.width,
+      height: anchorRect.height,
+    };
+    await waitForPanelGeometry(
+      conn,
+      workspaceId,
+      rightSessionId,
+      rightExpected,
+      cursorBeforeRight,
+      'right split',
+    );
+    await expectSessionAgent(conn, rightSessionId, 'shell');
+    await expectSessionDirectory(conn, rightSessionId, anchorDirectory);
+    await waitForCanvasPanelFocus(conn, rightSessionId, { inputFocus: true });
+
+    const cursorBeforeBottom = (await tailEvents(conn)).next_cursor;
+    const bottom = await conn.request('split_shell', {
+      session_id: anchorSessionId,
+      direction: 'bottom',
+    });
+    if (!bottom.ok) fail(`split_shell bottom: ${bottom.error}`);
+    const bottomSessionId = bottom.result.session_id;
+    const bottomExpected = {
+      world_x: anchorRect.world_x,
+      world_y: anchorRect.world_y + anchorRect.height + 32,
+      width: anchorRect.width,
+      height: anchorRect.height,
+    };
+    await waitForPanelGeometry(
+      conn,
+      workspaceId,
+      bottomSessionId,
+      bottomExpected,
+      cursorBeforeBottom,
+      'bottom split',
+    );
+    await expectSessionAgent(conn, bottomSessionId, 'shell');
+    await expectSessionDirectory(conn, bottomSessionId, anchorDirectory);
+    await waitForCanvasPanelFocus(conn, bottomSessionId, { inputFocus: true });
+
+    info(`  ok (right and bottom shell splits placed adjacent to anchor cwd)`);
+  } finally {
+    await conn.request('destroy_workspace', { id: workspaceId }).catch(() => {});
+    await pollUntil(
+      async () => {
+        const s = await conn.request('get_state');
+        return s.ok && !s.result.workspaces?.some((w) => w.id === workspaceId);
+      },
+      { timeoutMs: 5000, intervalMs: 100, label: `split host ${workspaceId.slice(0, 8)} drained` },
+    ).catch(() => {});
+  }
+}
+
+async function waitForPanel(conn, workspaceId, sessionId, label) {
+  return await pollUntil(
+    async () => getPanel(conn, workspaceId, sessionId),
+    { timeoutMs: 15000, intervalMs: 200, label },
+  );
+}
+
+async function waitForPanelGeometry(conn, workspaceId, sessionId, expected, cursor, label) {
+  try {
+    return await pollUntil(
+      async () => {
+        const panel = await getPanel(conn, workspaceId, sessionId);
+        return panel && panelApproxEquals(panel, expected) ? panel : false;
+      },
+      { timeoutMs: 15000, intervalMs: 200, label },
+    );
+  } catch (error) {
+    await dumpEventsSince(conn, cursor, label);
+    throw error;
+  }
+}
+
+async function getPanel(conn, workspaceId, sessionId) {
+  const state = await conn.request('get_state');
+  if (!state.ok) return null;
+  const workspace = state.result.workspaces?.find((w) => w.id === workspaceId);
+  return workspace?.panels?.find((panel) => panel.session_id === sessionId) || null;
+}
+
+function panelApproxEquals(panel, expected) {
+  return (
+    nearlyEqual(panel.world_x, expected.world_x) &&
+    nearlyEqual(panel.world_y, expected.world_y) &&
+    nearlyEqual(panel.width, expected.width) &&
+    nearlyEqual(panel.height, expected.height)
+  );
+}
+
+function nearlyEqual(actual, expected) {
+  return Math.abs(actual - expected) <= 0.5;
+}
+
+async function expectSessionAgent(conn, sessionId, agent) {
+  const state = await conn.request('get_state');
+  if (!state.ok) fail(`get_state: ${state.error}`);
+  const session = state.result.sessions?.find((candidate) => candidate.id === sessionId);
+  if (!session) fail(`session ${sessionId} not found in get_state`);
+  if (session.agent !== agent) fail(`session ${sessionId} agent=${session.agent}, expected ${agent}`);
+}
+
+async function expectSessionDirectory(conn, sessionId, directory) {
+  const state = await conn.request('get_state');
+  if (!state.ok) fail(`get_state: ${state.error}`);
+  const session = state.result.sessions?.find((candidate) => candidate.id === sessionId);
+  if (!session) fail(`session ${sessionId} not found in get_state`);
+  if (session.directory !== directory) {
+    fail(`session ${sessionId} directory=${session.directory}, expected ${directory}`);
+  }
+}
+
+async function waitForCanvasPanelFocus(conn, sessionId, { inputFocus }) {
+  await pollUntil(
+    async () => {
+      const state = await conn.request('get_state');
+      if (!state.ok) return false;
+      const panel = state.result.workspaces
+        .flatMap((workspace) => workspace.panels || [])
+        .find((candidate) => candidate.session_id === sessionId);
+      if (!panel) return false;
+      const canvas = state.result.canvas;
+      const expectedInputPanel = inputFocus ? panel.id : null;
+      return (
+        canvas.selected_panel_id === panel.id &&
+        canvas.input_focused_panel_id === expectedInputPanel
+      );
+    },
+    { timeoutMs: 5000, intervalMs: 100, label: `canvas focus for ${sessionId.slice(0, 8)}` },
+  );
+}
+
 /**
  * Send `echo <marker>\n` via the named action and wait for the marker to
  * appear on screen. Both `send_pty_input` and `type_into_panel` accept the
@@ -853,6 +1050,9 @@ async function main() {
 
     info(`\n[session lifecycle via action]`);
     await checkSessionLifecycle(conn);
+
+    info(`\n[native shell splits]`);
+    await checkNativeShellSplits(conn);
 
     info(`\n[pty round-trip]`);
     await checkPtyRoundTrip(conn);

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1017,7 +1017,7 @@ func normalizeStoredSessionAgent(agent string, fallback protocol.SessionAgent) p
 		return protocol.NormalizeSessionAgent(fallback, protocol.SessionAgentCodex)
 	}
 	if normalized == protocol.AgentShellValue {
-		return protocol.SessionAgentCodex
+		return protocol.SessionAgentShell
 	}
 	if agentdriver.Get(normalized) != nil {
 		return protocol.SessionAgent(normalized)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -134,12 +134,10 @@ func (s *Store) Add(session *protocol.Session) {
 	if normalizedAgent == "" {
 		normalizedAgent = string(protocol.SessionAgentCodex)
 	}
-	if normalizedAgent == protocol.AgentShellValue {
-		normalizedAgent = string(protocol.SessionAgentCodex)
-	}
 	if normalizedAgent != string(protocol.SessionAgentClaude) &&
 		normalizedAgent != string(protocol.SessionAgentCodex) &&
-		normalizedAgent != string(protocol.SessionAgentCopilot) {
+		normalizedAgent != string(protocol.SessionAgentCopilot) &&
+		normalizedAgent != protocol.AgentShellValue {
 		if agentdriver.Get(normalizedAgent) == nil {
 			normalizedAgent = string(protocol.SessionAgentCodex)
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -57,6 +57,30 @@ func TestStore_AddAndGet_PreservesAgent(t *testing.T) {
 	}
 }
 
+func TestStore_AddAndGet_PreservesShellAgent(t *testing.T) {
+	s := New()
+
+	session := &protocol.Session{
+		ID:         "shell123",
+		Label:      "shell-session",
+		Agent:      protocol.SessionAgentShell,
+		Directory:  "/home/user/project",
+		State:      protocol.SessionStateWorking,
+		StateSince: protocol.TimestampNow().String(),
+		LastSeen:   protocol.TimestampNow().String(),
+	}
+
+	s.Add(session)
+
+	got := s.Get("shell123")
+	if got == nil {
+		t.Fatal("expected session, got nil")
+	}
+	if got.Agent != protocol.SessionAgentShell {
+		t.Errorf("Agent = %q, want %q", got.Agent, protocol.SessionAgentShell)
+	}
+}
+
 func TestStore_AddAndGet_PreservesEndpointID(t *testing.T) {
 	s := New()
 

--- a/native-ui/crates/attn-native-app/src/adapters/automation/actions.rs
+++ b/native-ui/crates/attn-native-app/src/adapters/automation/actions.rs
@@ -16,6 +16,7 @@ use gpui::{
 use serde_json::{json, Value};
 
 use crate::app::NativeApp;
+use crate::domain::panel_placement::{place_panel_adjacent, AdjacentPanelDirection, Rect};
 use crate::domain::viewport::pf;
 use crate::state::terminal_model::TerminalModel;
 use crate::views::terminal_view::TerminalView;
@@ -94,6 +95,7 @@ async fn handle_action(
         "create_workspace" => create_workspace(app, cx, payload),
         "destroy_workspace" => destroy_workspace(app, cx, payload),
         "spawn_session" => spawn_session(app, cx, payload),
+        "split_shell" => split_shell(app, cx, payload),
         "unregister_session" => unregister_session(app, cx, payload),
         _ => Err(format!("unknown action: {action}")),
     }
@@ -421,15 +423,27 @@ fn spawn_session(
     if agent.is_empty() {
         return Err("payload.agent must be non-empty".to_string());
     }
+    let cwd = payload
+        .get("cwd")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
 
     let app_entity = app.upgrade().ok_or("NativeApp entity dropped")?;
     let session_id = cx
-        .update_entity(&app_entity, |app: &mut NativeApp, cx| {
-            app.spawn_session_in_workspace(
+        .update_entity(&app_entity, |app: &mut NativeApp, cx| match cwd.clone() {
+            Some(directory) => app.spawn_session_in_workspace_at(
+                SharedString::from(workspace_id.clone()),
+                directory,
+                SharedString::from(agent.clone()),
+                cx,
+            ),
+            None => app.spawn_session_in_workspace(
                 SharedString::from(workspace_id.clone()),
                 SharedString::from(agent.clone()),
                 cx,
-            )
+            ),
         })
         .map_err(|e| format!("update entity: {e}"))??;
 
@@ -437,6 +451,81 @@ fn spawn_session(
         "session_id": session_id.as_ref(),
         "workspace_id": workspace_id,
         "agent": agent,
+        "cwd": cwd,
+    }))
+}
+
+fn split_shell(
+    app: &WeakEntity<NativeApp>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .ok_or("payload.session_id (string) is required")?
+        .trim()
+        .to_string();
+    if session_id.is_empty() {
+        return Err("payload.session_id must be non-empty".to_string());
+    }
+    let direction = parse_adjacent_direction(
+        payload
+            .get("direction")
+            .and_then(Value::as_str)
+            .unwrap_or("right"),
+    )?;
+
+    let app_entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    let (workspace_id, placement) = cx
+        .read_entity(&app_entity, |app: &NativeApp, cx: &App| {
+            for ws in app.workspaces() {
+                let ws = ws.read(cx);
+                if let Some(panel) = ws
+                    .panels
+                    .iter()
+                    .find(|panel| panel.session_id.as_ref() == session_id.as_str())
+                {
+                    let anchor = Rect {
+                        x: panel.world_x,
+                        y: panel.world_y,
+                        width: panel.width,
+                        height: panel.height,
+                    };
+                    return Ok::<_, String>((
+                        ws.id.clone(),
+                        place_panel_adjacent(anchor, direction),
+                    ));
+                }
+            }
+            Err(format!("no terminal panel for session: {session_id}"))
+        })
+        .map_err(|e| format!("read entity: {e}"))??;
+
+    let spawned = cx
+        .update_entity(&app_entity, |app: &mut NativeApp, cx| {
+            app.spawn_shell_split_in_workspace(
+                workspace_id.clone(),
+                SharedString::from(session_id.clone()),
+                direction,
+                placement,
+                cx,
+            )
+        })
+        .map_err(|e| format!("update entity: {e}"))??;
+
+    Ok(json!({
+        "session_id": spawned.as_ref(),
+        "workspace_id": workspace_id.as_ref(),
+        "anchor_session_id": session_id.as_str(),
+        "agent": "shell",
+        "direction": adjacent_direction_name(direction),
+        "placement": {
+            "world_x": placement.x,
+            "world_y": placement.y,
+            "width": placement.width,
+            "height": placement.height,
+        },
     }))
 }
 
@@ -579,6 +668,9 @@ fn type_into_panel(
                 })?;
             }
             view.update(app, |view: &mut TerminalView, cx| {
+                if focus && view.set_input_enabled(true) {
+                    cx.notify();
+                }
                 for keystroke in keystrokes {
                     view.inject_keystroke(keystroke, window, cx);
                 }
@@ -753,6 +845,21 @@ fn get_window_geometry(cx: &mut AsyncApp) -> Result<Value, String> {
     .map_err(|e| format!("update window: {e}"))
 }
 
+fn parse_adjacent_direction(value: &str) -> Result<AdjacentPanelDirection, String> {
+    match value.trim() {
+        "right" => Ok(AdjacentPanelDirection::Right),
+        "bottom" | "down" => Ok(AdjacentPanelDirection::Bottom),
+        other => Err(format!("unsupported direction: {other}")),
+    }
+}
+
+fn adjacent_direction_name(direction: AdjacentPanelDirection) -> &'static str {
+    match direction {
+        AdjacentPanelDirection::Right => "right",
+        AdjacentPanelDirection::Bottom => "bottom",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -813,5 +920,22 @@ mod tests {
         // Two consecutive calls should never collide; if they do the test
         // fails fast rather than leaking duplicate ids into the daemon.
         assert_ne!(generate_workspace_id(), generate_workspace_id());
+    }
+
+    #[test]
+    fn parse_adjacent_direction_accepts_right_and_bottom() {
+        assert_eq!(
+            parse_adjacent_direction("right").unwrap(),
+            AdjacentPanelDirection::Right
+        );
+        assert_eq!(
+            parse_adjacent_direction("bottom").unwrap(),
+            AdjacentPanelDirection::Bottom
+        );
+        assert_eq!(
+            parse_adjacent_direction("down").unwrap(),
+            AdjacentPanelDirection::Bottom
+        );
+        assert!(parse_adjacent_direction("left").is_err());
     }
 }

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -22,7 +22,9 @@ use crate::adapters::automation;
 use crate::adapters::automation::actions::generate_workspace_id;
 use crate::adapters::automation::events;
 use crate::adapters::daemon::{DaemonClient, DaemonEvent};
-use crate::domain::panel_placement::{place_panel, PanelPlacementItem, PanelSize, Rect};
+use crate::domain::panel_placement::{
+    place_panel, AdjacentPanelDirection, PanelPlacementItem, PanelSize, Rect,
+};
 use crate::state::panel::{Panel, TITLE_HEIGHT};
 use crate::state::session_registry::SessionRegistry;
 use crate::state::terminal_model::TerminalModel;
@@ -81,6 +83,7 @@ impl NativeApp {
         let app_handle = cx.entity().downgrade();
         let app_handle_canvas_spawn = app_handle.clone();
         let app_handle_canvas_close = app_handle.clone();
+        let app_handle_canvas_split = app_handle.clone();
         let app_handle_canvas_geometry = app_handle.clone();
         let canvas = cx.new(|cx| {
             WorkspaceCanvas::new(
@@ -95,6 +98,18 @@ impl NativeApp {
                     let app_handle = app_handle_canvas_close.clone();
                     let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
                         app.unregister_session_by_id(session_id, cx);
+                    });
+                },
+                move |workspace_id, anchor_session_id, direction, placement, _window, cx| {
+                    let app_handle = app_handle_canvas_split.clone();
+                    let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
+                        let _ = app.spawn_shell_split_in_workspace(
+                            workspace_id,
+                            anchor_session_id,
+                            direction,
+                            placement,
+                            cx,
+                        );
                     });
                 },
                 move |workspace_id, panel_id, world_x, world_y, width, height, _window, cx| {
@@ -544,11 +559,73 @@ impl NativeApp {
         self.spawn_session_in_workspace_at(workspace_id, directory, agent, cx)
     }
 
-    fn spawn_session_in_workspace_at(
+    pub fn spawn_shell_split_in_workspace(
+        &mut self,
+        workspace_id: SharedString,
+        anchor_session_id: SharedString,
+        direction: AdjacentPanelDirection,
+        placement: Rect,
+        cx: &mut Context<Self>,
+    ) -> Result<SharedString, String> {
+        let Some(anchor_session) = self.sessions.get(anchor_session_id.as_ref()) else {
+            events::record(
+                "shell_split_failed",
+                json!({
+                    "workspace_id": workspace_id.as_ref(),
+                    "anchor_session_id": anchor_session_id.as_ref(),
+                    "reason": "unknown_anchor_session",
+                }),
+            );
+            return Err(format!("unknown anchor session: {anchor_session_id}"));
+        };
+        let directory = anchor_session.directory.clone();
+        events::record(
+            "shell_split_submitted",
+            json!({
+                "workspace_id": workspace_id.as_ref(),
+                "anchor_session_id": anchor_session_id.as_ref(),
+                "direction": adjacent_direction_name(direction),
+                "directory": directory.as_str(),
+                "world_x": placement.x,
+                "world_y": placement.y,
+                "width": placement.width,
+                "height": placement.height,
+            }),
+        );
+        self.spawn_session_in_workspace_at_with_initial_placement(
+            workspace_id,
+            directory,
+            SharedString::from("shell"),
+            Some(placement),
+            true,
+            cx,
+        )
+    }
+
+    pub fn spawn_session_in_workspace_at(
         &mut self,
         workspace_id: SharedString,
         directory: String,
         agent: SharedString,
+        cx: &mut Context<Self>,
+    ) -> Result<SharedString, String> {
+        self.spawn_session_in_workspace_at_with_initial_placement(
+            workspace_id,
+            directory,
+            agent,
+            None,
+            false,
+            cx,
+        )
+    }
+
+    fn spawn_session_in_workspace_at_with_initial_placement(
+        &mut self,
+        workspace_id: SharedString,
+        directory: String,
+        agent: SharedString,
+        initial_placement: Option<Rect>,
+        focus_after_spawn: bool,
         cx: &mut Context<Self>,
     ) -> Result<SharedString, String> {
         let Some(ws_entity) = self.registry.workspace(workspace_id.as_ref()) else {
@@ -569,7 +646,10 @@ impl NativeApp {
         };
         let _ = ws_entity;
         let session_id = automation::actions::generate_workspace_id();
-        let (cols, rows) = panel_terminal_dims(TERMINAL_W, TERMINAL_H);
+        let (terminal_w, terminal_h) = initial_placement
+            .map(|placement| (placement.width, placement.height))
+            .unwrap_or((TERMINAL_W, TERMINAL_H));
+        let (cols, rows) = panel_terminal_dims(terminal_w, terminal_h);
         let msg = SpawnSessionMessage::new(
             session_id.clone(),
             directory.clone(),
@@ -596,6 +676,8 @@ impl NativeApp {
             PendingSpawn {
                 workspace_id: workspace_id.clone(),
                 agent: agent.clone(),
+                initial_placement,
+                focus_after_spawn,
             },
         );
         events::record(
@@ -605,6 +687,12 @@ impl NativeApp {
                 "workspace_id": workspace_id.as_ref(),
                 "agent": agent.as_ref(),
                 "directory": directory,
+                "initial_placement": initial_placement.map(|placement| json!({
+                    "world_x": placement.x,
+                    "world_y": placement.y,
+                    "width": placement.width,
+                    "height": placement.height,
+                })),
             }),
         );
         Ok(id_shared)
@@ -1041,6 +1129,7 @@ impl NativeApp {
                 let mut world_y = daemon_panel.world_y;
                 let mut width = daemon_panel.width;
                 let mut height = daemon_panel.height;
+                let mut focus_after_spawn = false;
                 if let Some(pending) = self
                     .registry
                     .pending_spawn_for_panel_placement(&session_key)
@@ -1048,7 +1137,10 @@ impl NativeApp {
                         pending.workspace_id.as_ref() == ws_entity.read(cx).id.as_ref()
                     })
                 {
-                    if let Some(placement) = self.placement_for_new_panel(&ws_entity, cx) {
+                    if let Some(placement) = pending
+                        .initial_placement
+                        .or_else(|| self.placement_for_new_panel(&ws_entity, cx))
+                    {
                         world_x = placement.x;
                         world_y = placement.y;
                         width = placement.width;
@@ -1062,6 +1154,7 @@ impl NativeApp {
                             cx,
                         );
                     }
+                    focus_after_spawn = pending.focus_after_spawn;
                     self.registry.mark_panel_placed(session_key.clone());
                 }
 
@@ -1111,6 +1204,14 @@ impl NativeApp {
                     ws.panels.push(panel);
                     cx.notify();
                 });
+                if focus_after_spawn {
+                    self.canvas.update(cx, |canvas, cx| {
+                        canvas.focus_panel_by_session_on_next_render(
+                            SharedString::from(session_id),
+                            cx,
+                        )
+                    });
+                }
             }
         }
     }
@@ -1189,6 +1290,13 @@ fn directory_title(directory: &str) -> String {
         .map(|s| s.to_string_lossy().to_string())
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| directory.to_string())
+}
+
+fn adjacent_direction_name(direction: AdjacentPanelDirection) -> &'static str {
+    match direction {
+        AdjacentPanelDirection::Right => "right",
+        AdjacentPanelDirection::Bottom => "bottom",
+    }
 }
 
 /// Bring up the UI automation TCP server + dispatch pump. Errors are

--- a/native-ui/crates/attn-native-app/src/domain/panel_placement.rs
+++ b/native-ui/crates/attn-native-app/src/domain/panel_placement.rs
@@ -42,6 +42,12 @@ pub struct PanelSize {
     pub height: f32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdjacentPanelDirection {
+    Right,
+    Bottom,
+}
+
 const GAP: f32 = 32.0;
 const VISIBLE_MARGIN: f32 = 32.0;
 const MIN_VISIBLE_WIDTH: f32 = 420.0;
@@ -73,6 +79,23 @@ pub fn place_panel(
     }
 
     first_panel_rect(visible, size)
+}
+
+pub fn place_panel_adjacent(anchor: Rect, direction: AdjacentPanelDirection) -> Rect {
+    match direction {
+        AdjacentPanelDirection::Right => Rect {
+            x: anchor.right() + GAP,
+            y: anchor.y,
+            width: anchor.width,
+            height: anchor.height,
+        },
+        AdjacentPanelDirection::Bottom => Rect {
+            x: anchor.x,
+            y: anchor.bottom() + GAP,
+            width: anchor.width,
+            height: anchor.height,
+        },
+    }
 }
 
 fn size_for_visible_rect(default_size: PanelSize, visible: Rect) -> PanelSize {
@@ -423,5 +446,45 @@ mod tests {
         assert_eq!(placed.height, 356.0);
         assert_eq!(placed.x, 132.0);
         assert_eq!(placed.y, 232.0);
+    }
+
+    #[test]
+    fn adjacent_right_preserves_anchor_size() {
+        let anchor = Rect {
+            x: 100.0,
+            y: 200.0,
+            width: 640.0,
+            height: 420.0,
+        };
+
+        assert_eq!(
+            place_panel_adjacent(anchor, AdjacentPanelDirection::Right),
+            Rect {
+                x: 772.0,
+                y: 200.0,
+                width: 640.0,
+                height: 420.0,
+            }
+        );
+    }
+
+    #[test]
+    fn adjacent_bottom_preserves_anchor_size() {
+        let anchor = Rect {
+            x: 100.0,
+            y: 200.0,
+            width: 640.0,
+            height: 420.0,
+        };
+
+        assert_eq!(
+            place_panel_adjacent(anchor, AdjacentPanelDirection::Bottom),
+            Rect {
+                x: 100.0,
+                y: 652.0,
+                width: 640.0,
+                height: 420.0,
+            }
+        );
     }
 }

--- a/native-ui/crates/attn-native-app/src/state/session_registry.rs
+++ b/native-ui/crates/attn-native-app/src/state/session_registry.rs
@@ -30,6 +30,12 @@ impl SessionRegistry {
         self.sessions_by_id.values().cloned().collect()
     }
 
+    pub fn get(&self, id: &str) -> Option<Session> {
+        self.sessions_by_id
+            .get(&SharedString::from(id.to_string()))
+            .cloned()
+    }
+
     /// Insert or update a session by id.
     pub fn upsert(&mut self, session: Session) {
         let id = SharedString::from(session.id.clone());

--- a/native-ui/crates/attn-native-app/src/state/workspace_registry.rs
+++ b/native-ui/crates/attn-native-app/src/state/workspace_registry.rs
@@ -16,6 +16,7 @@ use attn_protocol::Workspace as ProtocolWorkspace;
 use gpui::{App, AppContext, Context, Entity, SharedString};
 
 use crate::app::NativeApp;
+use crate::domain::panel_placement::Rect;
 use crate::state::workspace::Workspace;
 
 /// In-flight spawn metadata. We track just enough to attribute a
@@ -25,6 +26,8 @@ use crate::state::workspace::Workspace;
 pub struct PendingSpawn {
     pub workspace_id: SharedString,
     pub agent: SharedString,
+    pub initial_placement: Option<Rect>,
+    pub focus_after_spawn: bool,
 }
 
 /// Outcome of an `upsert` — distinguishes "we just learned about this

--- a/native-ui/crates/attn-native-app/src/views/canvas.rs
+++ b/native-ui/crates/attn-native-app/src/views/canvas.rs
@@ -29,6 +29,11 @@ pub type SpawnSessionHandler =
 /// is pruned by `sync_terminal_panels`.
 pub type CloseSessionHandler = dyn Fn(SharedString, &mut Window, &mut gpui::App) + 'static;
 
+/// Callback invoked when a keyboard split command asks for a new shell
+/// panel adjacent to the selected panel.
+pub type SplitShellHandler = dyn Fn(SharedString, SharedString, AdjacentPanelDirection, Rect, &mut Window, &mut gpui::App)
+    + 'static;
+
 /// Callback invoked when a drag/resize gesture ends. The canvas keeps
 /// transient geometry local while the pointer is moving, then commits the
 /// final daemon panel id + geometry to the app coordinator.
@@ -38,7 +43,7 @@ pub type PanelGeometryCommitHandler =
 use serde_json::{json, Value};
 
 use crate::domain::panel_navigation::{navigate_panel, NavigationDirection, PanelNavItem};
-use crate::domain::panel_placement::Rect;
+use crate::domain::panel_placement::{place_panel_adjacent, AdjacentPanelDirection, Rect};
 use crate::domain::panel_snapping::{
     snap_panel_move, snap_panel_resize, PanelRect, ResizeEdges, SnapAxis, SnapLine,
 };
@@ -110,6 +115,7 @@ pub struct WorkspaceCanvas {
     drag_state: DragState,
     selected_panel: Option<usize>,
     input_focused_panel: Option<usize>,
+    pending_input_focus_session: Option<SharedString>,
     fullscreen_panel: Option<usize>,
     snap_lines: Vec<SnapLine>,
     focus_handle: FocusHandle,
@@ -124,6 +130,7 @@ pub struct WorkspaceCanvas {
     fps: Option<FpsCounter>,
     on_spawn: Box<SpawnSessionHandler>,
     on_close_session: Box<CloseSessionHandler>,
+    on_split_shell: Box<SplitShellHandler>,
     on_panel_geometry_commit: Box<PanelGeometryCommitHandler>,
 }
 
@@ -138,6 +145,14 @@ impl WorkspaceCanvas {
         cx: &mut Context<Self>,
         on_spawn: impl Fn(SharedString, SharedString, &mut Window, &mut gpui::App) + 'static,
         on_close_session: impl Fn(SharedString, &mut Window, &mut gpui::App) + 'static,
+        on_split_shell: impl Fn(
+                SharedString,
+                SharedString,
+                AdjacentPanelDirection,
+                Rect,
+                &mut Window,
+                &mut gpui::App,
+            ) + 'static,
         on_panel_geometry_commit: impl Fn(SharedString, SharedString, f32, f32, f32, f32, &mut Window, &mut gpui::App)
             + 'static,
     ) -> Self {
@@ -153,6 +168,7 @@ impl WorkspaceCanvas {
             drag_state: DragState::Idle,
             selected_panel: None,
             input_focused_panel: None,
+            pending_input_focus_session: None,
             fullscreen_panel: None,
             snap_lines: Vec::new(),
             focus_handle: cx.focus_handle(),
@@ -160,6 +176,7 @@ impl WorkspaceCanvas {
             fps,
             on_spawn: Box::new(on_spawn),
             on_close_session: Box::new(on_close_session),
+            on_split_shell: Box::new(on_split_shell),
             on_panel_geometry_commit: Box::new(on_panel_geometry_commit),
         }
     }
@@ -256,6 +273,7 @@ impl WorkspaceCanvas {
         self.drag_state = DragState::Idle;
         self.selected_panel = None;
         self.input_focused_panel = None;
+        self.pending_input_focus_session = None;
         self.fullscreen_panel = None;
         self.snap_lines.clear();
         cx.notify();
@@ -263,6 +281,25 @@ impl WorkspaceCanvas {
 
     pub fn is_panel_fullscreen(&self) -> bool {
         self.fullscreen_panel.is_some()
+    }
+
+    pub fn focus_panel_by_session_on_next_render(
+        &mut self,
+        session_id: SharedString,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(panel) = self.selected.as_ref().and_then(|ws| {
+            ws.read(cx)
+                .panels
+                .iter()
+                .find(|panel| panel.session_id.as_ref() == session_id.as_ref())
+                .cloned()
+        }) {
+            self.selected_panel = Some(panel.id);
+            self.input_focused_panel = Some(panel.id);
+        }
+        self.pending_input_focus_session = Some(session_id);
+        cx.notify();
     }
 
     /// Select a panel by session id and optionally route keyboard input
@@ -410,6 +447,37 @@ impl WorkspaceCanvas {
         self.selected_panel = Some(panel.id);
         self.input_focused_panel = Some(panel.id);
         panel.view.read(cx).focus_handle.clone().focus(window);
+    }
+
+    fn split_shell_for_selected(
+        &self,
+        direction: AdjacentPanelDirection,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(ws) = self.selected.as_ref() else {
+            return;
+        };
+        let Some(panel) = self.selected_panel_snapshot(cx) else {
+            return;
+        };
+        let workspace_id = ws.read(cx).id.clone();
+        let anchor_session_id = panel.session_id.clone();
+        let anchor = Rect {
+            x: panel.world_x,
+            y: panel.world_y,
+            width: panel.width,
+            height: panel.height,
+        };
+        let placement = place_panel_adjacent(anchor, direction);
+        (self.on_split_shell)(
+            workspace_id,
+            anchor_session_id,
+            direction,
+            placement,
+            window,
+            cx,
+        );
     }
 
     /// Panel snapshot for hit testing and rendering. Cloning is cheap
@@ -569,6 +637,14 @@ impl WorkspaceCanvas {
             "n" if event.keystroke.modifiers.platform => {
                 cx.stop_propagation();
                 self.open_session_dialog_for_selected(window, cx);
+            }
+            "d" if event.keystroke.modifiers.platform && event.keystroke.modifiers.shift => {
+                cx.stop_propagation();
+                self.split_shell_for_selected(AdjacentPanelDirection::Bottom, window, cx);
+            }
+            "d" if event.keystroke.modifiers.platform => {
+                cx.stop_propagation();
+                self.split_shell_for_selected(AdjacentPanelDirection::Right, window, cx);
             }
             "enter" if event.keystroke.modifiers.platform && event.keystroke.modifiers.shift => {
                 cx.stop_propagation();
@@ -941,6 +1017,15 @@ impl Render for WorkspaceCanvas {
             panels.iter().map(|panel| panel.id),
         ) {
             self.focus_handle.clone().focus(window);
+        }
+        if let Some(session_id) = self.pending_input_focus_session.clone() {
+            if let Some(panel) = panels
+                .iter()
+                .find(|panel| panel.session_id.as_ref() == session_id.as_ref())
+            {
+                self.focus_panel_input(panel, window, cx);
+                self.pending_input_focus_session = None;
+            }
         }
         let selected_panel = self.selected_panel;
         let input_focused_panel = self.input_focused_panel;

--- a/native-ui/crates/attn-native-app/src/views/terminal_view.rs
+++ b/native-ui/crates/attn-native-app/src/views/terminal_view.rs
@@ -420,6 +420,9 @@ impl TerminalView {
         if !self.input_enabled {
             return;
         }
+        if event.keystroke.modifiers.platform {
+            return;
+        }
         let seq = encode_key(event);
         if !seq.is_empty() {
             self.send_input(&seq, cx);


### PR DESCRIPTION
## Summary

- Add native canvas shell splits: `Cmd+D` opens a shell panel to the right of the selected panel and `Cmd+Shift+D` opens one below it.
- Place split panels adjacent to the anchor panel, inherit the anchor size, persist daemon-owned geometry, and focus the new shell when it attaches.
- Spawn split shells from the anchor panel session's cwd, not just the workspace cwd.
- Preserve `shell` as a first-class session agent in daemon/store state for native canvas shell sessions.
- Includes the earlier native location-dialog submit crash fix already present on this branch.

## Validation

- `cargo test -p attn-native-app`
- `cargo clippy -p attn-native-app --all-targets -- -D warnings`
- `go test ./internal/store ./internal/daemon`
- `pnpm --dir app test -- scenario-native-canvas`
- `ATTN_PROFILE=dev make scenario-native-canvas`