### PR TITLE
[codex] Fix native shell split overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-05-03]
+
+### Fixed
+- **Native Canvas Shell Splits**: `Cmd+D` and `Cmd+Shift+D` now skip over already-occupied adjacent panels instead of opening a new Shell panel on top of an existing neighbor.
+
+---
+
 ## [2026-05-02]
 
 ### Changed

--- a/app/scripts/real-app-harness/scenario-native-canvas.mjs
+++ b/app/scripts/real-app-harness/scenario-native-canvas.mjs
@@ -583,6 +583,31 @@ async function checkNativeShellSplits(conn) {
     await expectSessionDirectory(conn, rightSessionId, anchorDirectory);
     await waitForCanvasPanelFocus(conn, rightSessionId, { inputFocus: true });
 
+    const cursorBeforeSecondRight = (await tailEvents(conn)).next_cursor;
+    const secondRight = await conn.request('split_shell', {
+      session_id: anchorSessionId,
+      direction: 'right',
+    });
+    if (!secondRight.ok) fail(`split_shell second right: ${secondRight.error}`);
+    const secondRightSessionId = secondRight.result.session_id;
+    const secondRightExpected = {
+      world_x: anchorRect.world_x + (anchorRect.width + 32) * 2,
+      world_y: anchorRect.world_y,
+      width: anchorRect.width,
+      height: anchorRect.height,
+    };
+    await waitForPanelGeometry(
+      conn,
+      workspaceId,
+      secondRightSessionId,
+      secondRightExpected,
+      cursorBeforeSecondRight,
+      'second right split skips occupied neighbor',
+    );
+    await expectSessionAgent(conn, secondRightSessionId, 'shell');
+    await expectSessionDirectory(conn, secondRightSessionId, anchorDirectory);
+    await waitForCanvasPanelFocus(conn, secondRightSessionId, { inputFocus: true });
+
     const cursorBeforeBottom = (await tailEvents(conn)).next_cursor;
     const bottom = await conn.request('split_shell', {
       session_id: anchorSessionId,
@@ -608,7 +633,7 @@ async function checkNativeShellSplits(conn) {
     await expectSessionDirectory(conn, bottomSessionId, anchorDirectory);
     await waitForCanvasPanelFocus(conn, bottomSessionId, { inputFocus: true });
 
-    info(`  ok (right and bottom shell splits placed adjacent to anchor cwd)`);
+    info(`  ok (right and bottom shell splits placed adjacent to anchor cwd without overlap)`);
   } finally {
     await conn.request('destroy_workspace', { id: workspaceId }).catch(() => {});
     await pollUntil(

--- a/native-ui/crates/attn-native-app/src/adapters/automation/actions.rs
+++ b/native-ui/crates/attn-native-app/src/adapters/automation/actions.rs
@@ -16,7 +16,9 @@ use gpui::{
 use serde_json::{json, Value};
 
 use crate::app::NativeApp;
-use crate::domain::panel_placement::{place_panel_adjacent, AdjacentPanelDirection, Rect};
+use crate::domain::panel_placement::{
+    place_panel_adjacent_avoiding, AdjacentPanelDirection, PanelPlacementItem, Rect,
+};
 use crate::domain::viewport::pf;
 use crate::state::terminal_model::TerminalModel;
 use crate::views::terminal_view::TerminalView;
@@ -492,9 +494,22 @@ fn split_shell(
                         width: panel.width,
                         height: panel.height,
                     };
+                    let existing = ws
+                        .panels
+                        .iter()
+                        .map(|panel| PanelPlacementItem {
+                            id: panel.id,
+                            rect: Rect {
+                                x: panel.world_x,
+                                y: panel.world_y,
+                                width: panel.width,
+                                height: panel.height,
+                            },
+                        })
+                        .collect::<Vec<_>>();
                     return Ok::<_, String>((
                         ws.id.clone(),
-                        place_panel_adjacent(anchor, direction),
+                        place_panel_adjacent_avoiding(anchor, direction, &existing),
                     ));
                 }
             }

--- a/native-ui/crates/attn-native-app/src/domain/panel_placement.rs
+++ b/native-ui/crates/attn-native-app/src/domain/panel_placement.rs
@@ -98,6 +98,43 @@ pub fn place_panel_adjacent(anchor: Rect, direction: AdjacentPanelDirection) -> 
     }
 }
 
+pub fn place_panel_adjacent_avoiding(
+    anchor: Rect,
+    direction: AdjacentPanelDirection,
+    existing: &[PanelPlacementItem],
+) -> Rect {
+    let mut candidate = place_panel_adjacent(anchor, direction);
+
+    for _ in 0..existing.len() {
+        let Some(blocking_edge) = blocking_edge_in_direction(&candidate, direction, existing)
+        else {
+            break;
+        };
+
+        match direction {
+            AdjacentPanelDirection::Right => candidate.x = blocking_edge + GAP,
+            AdjacentPanelDirection::Bottom => candidate.y = blocking_edge + GAP,
+        }
+    }
+
+    candidate
+}
+
+fn blocking_edge_in_direction(
+    candidate: &Rect,
+    direction: AdjacentPanelDirection,
+    existing: &[PanelPlacementItem],
+) -> Option<f32> {
+    existing
+        .iter()
+        .filter(|item| candidate.overlaps(&item.rect))
+        .map(|item| match direction {
+            AdjacentPanelDirection::Right => item.rect.right(),
+            AdjacentPanelDirection::Bottom => item.rect.bottom(),
+        })
+        .reduce(f32::max)
+}
+
 fn size_for_visible_rect(default_size: PanelSize, visible: Rect) -> PanelSize {
     let available_width = visible.width - VISIBLE_MARGIN * 2.0;
     let available_height = visible.height - VISIBLE_MARGIN * 2.0;
@@ -484,6 +521,79 @@ mod tests {
                 y: 652.0,
                 width: 640.0,
                 height: 420.0,
+            }
+        );
+    }
+
+    #[test]
+    fn adjacent_right_skips_occupied_neighbors_in_row() {
+        let existing = [
+            item(1, 0.0, 120.0, 320.0, 240.0),
+            item(2, 352.0, 120.0, 320.0, 240.0),
+            item(3, 704.0, 120.0, 320.0, 240.0),
+        ];
+
+        assert_eq!(
+            place_panel_adjacent_avoiding(
+                existing[1].rect,
+                AdjacentPanelDirection::Right,
+                &existing,
+            ),
+            Rect {
+                x: 1056.0,
+                y: 120.0,
+                width: 320.0,
+                height: 240.0,
+            }
+        );
+    }
+
+    #[test]
+    fn adjacent_bottom_skips_occupied_neighbors_in_column() {
+        let existing = [
+            item(1, 120.0, 0.0, 320.0, 240.0),
+            item(2, 120.0, 272.0, 320.0, 240.0),
+            item(3, 120.0, 544.0, 320.0, 240.0),
+        ];
+
+        assert_eq!(
+            place_panel_adjacent_avoiding(
+                existing[1].rect,
+                AdjacentPanelDirection::Bottom,
+                &existing,
+            ),
+            Rect {
+                x: 120.0,
+                y: 816.0,
+                width: 320.0,
+                height: 240.0,
+            }
+        );
+    }
+
+    #[test]
+    fn adjacent_right_ignores_vertically_separate_panels() {
+        let anchor = Rect {
+            x: 352.0,
+            y: 120.0,
+            width: 320.0,
+            height: 240.0,
+        };
+        let existing = [
+            PanelPlacementItem {
+                id: 1,
+                rect: anchor,
+            },
+            item(2, 704.0, 520.0, 320.0, 240.0),
+        ];
+
+        assert_eq!(
+            place_panel_adjacent_avoiding(anchor, AdjacentPanelDirection::Right, &existing),
+            Rect {
+                x: 704.0,
+                y: 120.0,
+                width: 320.0,
+                height: 240.0,
             }
         );
     }

--- a/native-ui/crates/attn-native-app/src/views/canvas.rs
+++ b/native-ui/crates/attn-native-app/src/views/canvas.rs
@@ -44,7 +44,9 @@ pub type PanelGeometryCommitHandler =
 use serde_json::{json, Value};
 
 use crate::domain::panel_navigation::{navigate_panel, NavigationDirection, PanelNavItem};
-use crate::domain::panel_placement::{place_panel_adjacent, AdjacentPanelDirection, Rect};
+use crate::domain::panel_placement::{
+    place_panel_adjacent_avoiding, AdjacentPanelDirection, PanelPlacementItem, Rect,
+};
 use crate::domain::panel_snapping::{
     snap_panel_move, snap_panel_resize, PanelRect, ResizeEdges, SnapAxis, SnapLine,
 };
@@ -495,18 +497,32 @@ impl WorkspaceCanvas {
         let Some(ws) = self.selected.as_ref() else {
             return;
         };
-        let Some(panel) = self.selected_panel_snapshot(cx) else {
-            return;
+        let (workspace_id, anchor_session_id, placement) = {
+            let ws = ws.read(cx);
+            let Some(panel) = self
+                .selected_panel
+                .and_then(|id| ws.panels.iter().find(|panel| panel.id == id))
+                .cloned()
+            else {
+                return;
+            };
+            let anchor = Rect {
+                x: panel.world_x,
+                y: panel.world_y,
+                width: panel.width,
+                height: panel.height,
+            };
+            let existing = ws
+                .panels
+                .iter()
+                .map(panel_placement_item)
+                .collect::<Vec<_>>();
+            (
+                ws.id.clone(),
+                panel.session_id.clone(),
+                place_panel_adjacent_avoiding(anchor, direction, &existing),
+            )
         };
-        let workspace_id = ws.read(cx).id.clone();
-        let anchor_session_id = panel.session_id.clone();
-        let anchor = Rect {
-            x: panel.world_x,
-            y: panel.world_y,
-            width: panel.width,
-            height: panel.height,
-        };
-        let placement = place_panel_adjacent(anchor, direction);
         (self.on_split_shell)(
             workspace_id,
             anchor_session_id,
@@ -904,6 +920,18 @@ fn panel_rect(panel: &Panel) -> PanelRect {
         y: panel.world_y,
         width: panel.width,
         height: panel.height,
+    }
+}
+
+fn panel_placement_item(panel: &Panel) -> PanelPlacementItem {
+    PanelPlacementItem {
+        id: panel.id,
+        rect: Rect {
+            x: panel.world_x,
+            y: panel.world_y,
+            width: panel.width,
+            height: panel.height,
+        },
     }
 }
 


### PR DESCRIPTION
## Summary
- make native canvas shell splits collision-aware when opening right or bottom
- keep split placement on the requested axis while skipping occupied adjacent panels
- extend the native canvas scenario to cover repeated right splits from the same anchor

## Root Cause
`Cmd+D` and the automation `split_shell` action placed new shell panels with only the selected panel's rectangle. They did not consider existing workspace panels, so a restored adjacent neighbor could occupy the computed right or bottom slot.

## Validation
- `cargo test --manifest-path native-ui/Cargo.toml -p attn-native-app`
- `cargo clippy --manifest-path native-ui/Cargo.toml -p attn-native-app --all-targets -- -D warnings`
- `node --check app/scripts/real-app-harness/scenario-native-canvas.mjs`
- `ATTN_PROFILE=dev make scenario-native-canvas`