### PR TITLE
[codex] Add native panel state indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Added
 - **Native Canvas Trackpad Zoom**: The native canvas now responds to trackpad pinch/magnify gestures and precise control-scroll zoom, keeping the cursor's world point anchored while zooming.
+- **Native Canvas Panel Status**: Native canvas panel headers now show each session's live state, including working, waiting for input, approval-needed, idle, and long-run review status.
 
 ### Fixed
 - **Native Canvas Shell Splits**: `Cmd+D` and `Cmd+Shift+D` now skip over already-occupied adjacent panels instead of opening a new Shell panel on top of an existing neighbor.

--- a/app/scripts/real-app-harness/scenario-native-canvas.mjs
+++ b/app/scripts/real-app-harness/scenario-native-canvas.mjs
@@ -933,6 +933,34 @@ async function checkWorkspaceLifecycle(conn) {
   }
 }
 
+function assertPanelMirrorsSessionState(state, sessionId) {
+  const session = state.sessions?.find((item) => item.id === sessionId);
+  if (!session) fail(`session ${sessionId} missing from get_state`);
+
+  const panel = state.workspaces
+    ?.flatMap((workspace) => workspace.panels || [])
+    .find((item) => item.session_id === sessionId);
+  if (!panel) fail(`panel for session ${sessionId} missing from get_state`);
+
+  if (panel.session_state !== session.state) {
+    fail(
+      `panel/session state mismatch for ${sessionId}: panel=${panel.session_state} session=${session.state}`,
+    );
+  }
+  if (typeof panel.needs_review_after_long_run !== 'boolean') {
+    fail(`panel missing boolean needs_review_after_long_run: ${JSON.stringify(panel)}`);
+  }
+
+  const expectedNeedsReview = Boolean(session.needs_review_after_long_run);
+  if (panel.needs_review_after_long_run !== expectedNeedsReview) {
+    fail(
+      `panel/session review flag mismatch for ${sessionId}: panel=${panel.needs_review_after_long_run} session=${expectedNeedsReview}`,
+    );
+  }
+
+  return panel;
+}
+
 /**
  * Round-trip a session through the new `spawn_session` and
  * `unregister_session` automation actions — the same wire path the
@@ -1000,6 +1028,11 @@ async function checkSessionLifecycle(conn) {
       throw error;
     }
     info(`  panel + spawn ack observed`);
+
+    const stateAfterSpawn = await conn.request('get_state');
+    if (!stateAfterSpawn.ok) fail(`get_state after spawn_session: ${stateAfterSpawn.error}`);
+    const panel = assertPanelMirrorsSessionState(stateAfterSpawn.result, sessionId);
+    info(`  panel status snapshot ok (${panel.session_state})`);
 
     const cursorBeforeKill = (await tailEvents(conn)).next_cursor;
     const killed = await conn.request('unregister_session', { session_id: sessionId });

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -1140,6 +1140,9 @@ impl NativeApp {
                             panel.world_y = daemon_panel.world_y;
                             panel.width = daemon_panel.width;
                             panel.height = daemon_panel.height;
+                            panel.session_state = session.state;
+                            panel.needs_review_after_long_run =
+                                session.needs_review_after_long_run.unwrap_or(false);
                             cx.notify();
                         }
                     });
@@ -1214,6 +1217,10 @@ impl NativeApp {
                     width,
                     height,
                     session_id: SharedString::from(session_id.clone()),
+                    session_state: session.state,
+                    needs_review_after_long_run: session
+                        .needs_review_after_long_run
+                        .unwrap_or(false),
                     view,
                 };
 

--- a/native-ui/crates/attn-native-app/src/state/panel.rs
+++ b/native-ui/crates/attn-native-app/src/state/panel.rs
@@ -1,6 +1,7 @@
 /// Panels are the canvas's spatial terminal objects. Each carries
 /// world-space position + size and the terminal view that handles rendering,
 /// focus, resize, and PTY input.
+use attn_protocol::SessionState;
 use gpui::{Entity, SharedString};
 
 use crate::views::terminal_view::TerminalView;
@@ -20,5 +21,7 @@ pub struct Panel {
     pub width: f32,
     pub height: f32,
     pub session_id: SharedString,
+    pub session_state: SessionState,
+    pub needs_review_after_long_run: bool,
     pub view: Entity<TerminalView>,
 }

--- a/native-ui/crates/attn-native-app/src/state/workspace.rs
+++ b/native-ui/crates/attn-native-app/src/state/workspace.rs
@@ -96,5 +96,7 @@ fn panel_snapshot(panel: &Panel) -> Value {
         "world_y": panel.world_y,
         "width": panel.width,
         "height": panel.height,
+        "session_state": panel.session_state.to_string(),
+        "needs_review_after_long_run": panel.needs_review_after_long_run,
     })
 }

--- a/native-ui/crates/attn-native-app/src/theme.rs
+++ b/native-ui/crates/attn-native-app/src/theme.rs
@@ -412,6 +412,21 @@ pub fn workspace_status_color(status: attn_protocol::WorkspaceStatus) -> Rgba {
     }
 }
 
+/// Resolve the classification hue for a `SessionState`. `unknown` is
+/// deliberately error-coloured because it means the daemon/client cannot
+/// classify where keyboard attention belongs.
+pub fn session_state_color(status: attn_protocol::SessionState) -> Rgba {
+    use attn_protocol::SessionState;
+    match status {
+        SessionState::Launching => state::launching(),
+        SessionState::Working => state::working(),
+        SessionState::WaitingInput => state::waiting(),
+        SessionState::PendingApproval => state::approval(),
+        SessionState::Idle => state::idle(),
+        SessionState::Unknown => state::error(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -491,5 +506,26 @@ mod tests {
                 assert_ne!(a, b, "state hue collision: {:#08x} vs {:#08x}", a, b);
             }
         }
+    }
+
+    #[test]
+    fn session_state_mapping_covers_every_wire_state() {
+        use attn_protocol::SessionState;
+
+        assert_eq!(
+            session_state_color(SessionState::Launching),
+            state::launching()
+        );
+        assert_eq!(session_state_color(SessionState::Working), state::working());
+        assert_eq!(
+            session_state_color(SessionState::WaitingInput),
+            state::waiting()
+        );
+        assert_eq!(
+            session_state_color(SessionState::PendingApproval),
+            state::approval()
+        );
+        assert_eq!(session_state_color(SessionState::Idle), state::idle());
+        assert_eq!(session_state_color(SessionState::Unknown), state::error());
     }
 }

--- a/native-ui/crates/attn-native-app/src/views/canvas.rs
+++ b/native-ui/crates/attn-native-app/src/views/canvas.rs
@@ -43,6 +43,8 @@ pub type PanelGeometryCommitHandler =
 
 use serde_json::{json, Value};
 
+use attn_protocol::SessionState;
+
 use crate::domain::panel_navigation::{navigate_panel, NavigationDirection, PanelNavItem};
 use crate::domain::panel_placement::{
     place_panel_adjacent_avoiding, AdjacentPanelDirection, PanelPlacementItem, Rect,
@@ -1181,25 +1183,7 @@ impl Render for WorkspaceCanvas {
                 });
 
                 let body: AnyElement = panel.view.clone().into_any_element();
-                let mut title_bar = div()
-                    .w_full()
-                    .h(px(title_h))
-                    .bg(theme::ink::shade())
-                    .border_b_1()
-                    .border_color(theme::line::firm())
-                    .flex()
-                    .items_center()
-                    .pl(px(theme::space::S1))
-                    .pr(px(theme::space::S0))
-                    .child(
-                        div()
-                            .flex_1()
-                            .truncate()
-                            .text_xs()
-                            .text_color(theme::moon::moonstone())
-                            .child(panel.title.clone()),
-                    );
-                title_bar = title_bar.child(panel_close_button(panel.session_id.clone(), cx));
+                let title_bar = panel_title_bar(panel, title_h, false, cx);
 
                 let mut panel_div = div()
                     .absolute()
@@ -1265,29 +1249,9 @@ impl Render for WorkspaceCanvas {
             let is_selected = selected_panel == Some(panel.id);
             let border_color = panel_border_color(has_input_focus, is_selected);
             let content_h = (sh - title_h).max(0.0);
-            let title = panel.title.clone();
-
             let body: AnyElement = panel.view.clone().into_any_element();
 
-            let mut title_bar = div()
-                .w_full()
-                .h(px(title_h))
-                .bg(theme::ink::shade())
-                .border_b_1()
-                .border_color(theme::line::firm())
-                .flex()
-                .items_center()
-                .pl(px(theme::space::S1))
-                .pr(px(theme::space::S0))
-                .child(
-                    div()
-                        .flex_1()
-                        .truncate()
-                        .text_xs()
-                        .text_color(theme::moon::moonstone())
-                        .child(title),
-                );
-            title_bar = title_bar.child(panel_close_button(panel.session_id.clone(), cx));
+            let title_bar = panel_title_bar(panel, title_h, sw < 220.0, cx);
 
             let mut panel_div = div()
                 .absolute()
@@ -1447,6 +1411,118 @@ fn panel_shadow(has_input_focus: bool) -> Vec<BoxShadow> {
             spread_radius: px(-6.0),
         },
     ]
+}
+
+fn panel_title_bar(
+    panel: &Panel,
+    title_h: f32,
+    compact_status: bool,
+    cx: &mut Context<WorkspaceCanvas>,
+) -> gpui::Div {
+    div()
+        .w_full()
+        .h(px(title_h))
+        .bg(theme::ink::shade())
+        .border_b_1()
+        .border_color(theme::line::firm())
+        .flex()
+        .items_center()
+        .gap(px(theme::space::S1))
+        .pl(px(theme::space::S1))
+        .pr(px(theme::space::S0))
+        .child(
+            div()
+                .flex_1()
+                .min_w(px(0.0))
+                .truncate()
+                .text_xs()
+                .text_color(theme::moon::moonstone())
+                .child(panel.title.clone()),
+        )
+        .child(panel_status_pill(panel, compact_status))
+        .child(panel_close_button(panel.session_id.clone(), cx))
+}
+
+fn panel_status_pill(panel: &Panel, compact: bool) -> gpui::Div {
+    let color = panel_status_color(panel);
+    let mut pill = div()
+        .h(px(16.0))
+        .flex_shrink_0()
+        .flex()
+        .items_center()
+        .gap(px(5.0))
+        .px(px(if compact { 5.0 } else { 6.0 }))
+        .rounded(px(theme::radius::R0))
+        .border_1()
+        .border_color(with_alpha(color, 0.32))
+        .bg(with_alpha(color, 0.10))
+        .child(
+            div()
+                .w(px(6.0))
+                .h(px(6.0))
+                .rounded_full()
+                .bg(color)
+                .shadow(status_dot_shadow(color, panel.session_state)),
+        );
+
+    if !compact {
+        pill = pill.child(
+            div()
+                .text_size(px(10.0))
+                .text_color(theme::moon::bone())
+                .child(SharedString::from(panel_status_label(panel))),
+        );
+    }
+
+    pill
+}
+
+fn panel_status_color(panel: &Panel) -> gpui::Rgba {
+    if panel.needs_review_after_long_run {
+        theme::state::review()
+    } else {
+        theme::session_state_color(panel.session_state)
+    }
+}
+
+fn panel_status_label(panel: &Panel) -> &'static str {
+    if panel.needs_review_after_long_run {
+        "review"
+    } else {
+        session_state_label(panel.session_state)
+    }
+}
+
+fn session_state_label(state: SessionState) -> &'static str {
+    match state {
+        SessionState::Launching => "launching",
+        SessionState::Working => "working",
+        SessionState::WaitingInput => "waiting",
+        SessionState::Idle => "idle",
+        SessionState::PendingApproval => "approval",
+        SessionState::Unknown => "unknown",
+    }
+}
+
+fn status_dot_shadow(color: gpui::Rgba, state: SessionState) -> Vec<BoxShadow> {
+    if !matches!(
+        state,
+        SessionState::Working | SessionState::WaitingInput | SessionState::PendingApproval
+    ) {
+        return Vec::new();
+    }
+
+    vec![BoxShadow {
+        color: with_alpha(color, 0.34).into(),
+        offset: point(px(0.0), px(0.0)),
+        blur_radius: px(8.0),
+        spread_radius: px(1.0),
+    }]
+}
+
+fn with_alpha(mut color: gpui::Rgba, alpha: f32) -> gpui::Rgba {
+    color.a = alpha.clamp(0.0, 1.0);
+    color
 }
 
 fn selection_glint(width: f32, height: f32) -> gpui::Div {

--- a/native-ui/crates/attn-protocol/src/types.rs
+++ b/native-ui/crates/attn-protocol/src/types.rs
@@ -18,7 +18,7 @@ pub struct ReplaySegment {
     pub data: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionState {
     Launching,


### PR DESCRIPTION
## Summary
- Show live session state in native canvas panel headers with Observatory state colors.
- Carry session state and long-run review status into panel state and automation snapshots.
- Extend the native canvas scenario to assert panel status mirrors daemon session state.

## Validation
- `cargo test --manifest-path native-ui/Cargo.toml`
- `node --check app/scripts/real-app-harness/scenario-native-canvas.mjs`
- `ATTN_PROFILE=dev make scenario-native-canvas`