### PR TITLE
[codex] Add native sidebar settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-05-03]
 
 ### Added
+- **Native Sidebar Settings Entry**: The native workspace sidebar now has a bottom settings cog and `Cmd+,` shortcut that open a native Settings surface with a sidebar display control.
 - **Native Canvas Trackpad Zoom**: The native canvas now responds to trackpad pinch/magnify gestures and precise control-scroll zoom, keeping the cursor's world point anchored while zooming.
 - **Native Canvas Panel Status**: Native canvas panel headers now show each session's live state, including working, waiting for input, approval-needed, idle, and long-run review status.
+
+### Changed
+- **Native Sidebar Collapse**: The native workspace sidebar can now collapse with `Cmd+B`, keeping workspace status colors visible in the narrow rail while freeing canvas space.
 
 ### Fixed
 - **Native Canvas Shell Splits**: `Cmd+D` and `Cmd+Shift+D` now skip over already-occupied adjacent panels instead of opening a new Shell panel on top of an existing neighbor.

--- a/app/scripts/real-app-harness/scenario-native-canvas.mjs
+++ b/app/scripts/real-app-harness/scenario-native-canvas.mjs
@@ -224,16 +224,60 @@ async function checkPlumbing(conn, manifest) {
 
   const state = await conn.request('get_state');
   if (!state.ok) fail(`get_state: ${state.error}`);
-  for (const field of ['workspaces', 'sessions', 'canvas', 'daemon', 'selected_workspace_id']) {
+  for (const field of ['workspaces', 'sessions', 'canvas', 'sidebar', 'settings_open', 'daemon', 'selected_workspace_id']) {
     if (!(field in state.result)) fail(`get_state missing field: ${field}`);
   }
+  if (state.result.sidebar.collapsed !== false || state.result.sidebar.width !== 240) {
+    fail(`initial sidebar state wrong: ${JSON.stringify(state.result.sidebar)}`);
+  }
+  const collapsed = await conn.request('set_sidebar_collapsed', { collapsed: true });
+  if (!collapsed.ok) fail(`set_sidebar_collapsed true: ${collapsed.error}`);
+  const collapsedState = await conn.request('get_state');
+  if (!collapsedState.ok) fail(`get_state after sidebar collapse: ${collapsedState.error}`);
+  if (collapsedState.result.sidebar.collapsed !== true || collapsedState.result.sidebar.width !== 52) {
+    fail(`collapsed sidebar state wrong: ${JSON.stringify(collapsedState.result.sidebar)}`);
+  }
+  const expanded = await conn.request('set_sidebar_collapsed', { collapsed: false });
+  if (!expanded.ok) fail(`set_sidebar_collapsed false: ${expanded.error}`);
+  const openedSettings = await conn.request('click_sidebar_settings');
+  if (!openedSettings.ok) fail(`click_sidebar_settings: ${openedSettings.error}`);
+  const settingsOpenState = await conn.request('get_state');
+  if (!settingsOpenState.ok) fail(`get_state after click_sidebar_settings: ${settingsOpenState.error}`);
+  if (settingsOpenState.result.settings_open !== true) {
+    fail(`settings dialog did not open from sidebar click: ${JSON.stringify(settingsOpenState.result)}`);
+  }
+  const clickedSidebarMode = await conn.request('click_settings_sidebar_mode');
+  if (!clickedSidebarMode.ok) fail(`click_settings_sidebar_mode: ${clickedSidebarMode.error}`);
+  const settingsToggledState = await conn.request('get_state');
+  if (!settingsToggledState.ok) fail(`get_state after click_settings_sidebar_mode: ${settingsToggledState.error}`);
+  if (settingsToggledState.result.sidebar.collapsed !== true) {
+    fail(`settings sidebar mode click did not collapse sidebar: ${JSON.stringify(settingsToggledState.result.sidebar)}`);
+  }
+  const closedSettings = await conn.request('click_settings_close');
+  if (!closedSettings.ok) fail(`click_settings_close: ${closedSettings.error}`);
+  const settingsClosedState = await conn.request('get_state');
+  if (!settingsClosedState.ok) fail(`get_state after click_settings_close: ${settingsClosedState.error}`);
+  if (settingsClosedState.result.settings_open !== false) {
+    fail(`settings dialog did not close from close click: ${JSON.stringify(settingsClosedState.result)}`);
+  }
+  const expandedAfterSettings = await conn.request('set_sidebar_collapsed', { collapsed: false });
+  if (!expandedAfterSettings.ok) fail(`set_sidebar_collapsed after settings click-through: ${expandedAfterSettings.error}`);
+  const shortcutSettings = await conn.request('press_canvas_cmd_comma');
+  if (!shortcutSettings.ok) fail(`press_canvas_cmd_comma: ${shortcutSettings.error}`);
+  const shortcutSettingsState = await conn.request('get_state');
+  if (!shortcutSettingsState.ok) fail(`get_state after press_canvas_cmd_comma: ${shortcutSettingsState.error}`);
+  if (shortcutSettingsState.result.settings_open !== true) {
+    fail(`Cmd+, did not open settings: ${JSON.stringify(shortcutSettingsState.result)}`);
+  }
+  const closedShortcutSettings = await conn.request('click_settings_close');
+  if (!closedShortcutSettings.ok) fail(`click_settings_close after Cmd+,: ${closedShortcutSettings.error}`);
   const list = await conn.request('list_sessions');
   if (!list.ok) fail(`list_sessions: ${list.error}`);
   if (list.result.length !== state.result.sessions.length) {
     fail(`list_sessions/get_state.sessions length mismatch`);
   }
   info(
-    `  state shape ok (workspaces=${state.result.workspaces.length} sessions=${state.result.sessions.length})`,
+    `  state shape ok (workspaces=${state.result.workspaces.length} sessions=${state.result.sessions.length}, sidebar toggles + settings click-through + Cmd+,)`,
   );
 
   // tail_events sanity: shape is right and cursor advances. Other tests

--- a/app/scripts/real-app-harness/scenario-native-canvas.mjs
+++ b/app/scripts/real-app-harness/scenario-native-canvas.mjs
@@ -271,6 +271,21 @@ async function checkPlumbing(conn, manifest) {
   }
   const closedShortcutSettings = await conn.request('click_settings_close');
   if (!closedShortcutSettings.ok) fail(`click_settings_close after Cmd+,: ${closedShortcutSettings.error}`);
+  const unfocusedShortcutSettings = await conn.request('press_window_cmd_comma_without_view_focus');
+  if (!unfocusedShortcutSettings.ok) {
+    fail(`press_window_cmd_comma_without_view_focus: ${unfocusedShortcutSettings.error}`);
+  }
+  const unfocusedShortcutSettingsState = await conn.request('get_state');
+  if (!unfocusedShortcutSettingsState.ok) {
+    fail(`get_state after press_window_cmd_comma_without_view_focus: ${unfocusedShortcutSettingsState.error}`);
+  }
+  if (unfocusedShortcutSettingsState.result.settings_open !== true) {
+    fail(`Cmd+, did not open settings without view focus: ${JSON.stringify(unfocusedShortcutSettingsState.result)}`);
+  }
+  const closedUnfocusedShortcutSettings = await conn.request('click_settings_close');
+  if (!closedUnfocusedShortcutSettings.ok) {
+    fail(`click_settings_close after unfocused Cmd+,: ${closedUnfocusedShortcutSettings.error}`);
+  }
   const list = await conn.request('list_sessions');
   if (!list.ok) fail(`list_sessions: ${list.error}`);
   if (list.result.length !== state.result.sessions.length) {

--- a/native-ui/crates/attn-native-app/src/adapters/automation/actions.rs
+++ b/native-ui/crates/attn-native-app/src/adapters/automation/actions.rs
@@ -94,6 +94,11 @@ async fn handle_action(
         "read_pane_text" => read_pane_text(app, cx, payload),
         "tail_events" => tail_events(payload),
         "set_zoom" => set_zoom(app, cx, payload),
+        "set_sidebar_collapsed" => set_sidebar_collapsed(app, cx, payload),
+        "click_sidebar_settings" => click_sidebar_settings(app, cx),
+        "click_settings_sidebar_mode" => click_settings_sidebar_mode(app, cx),
+        "click_settings_close" => click_settings_close(app, cx),
+        "press_canvas_cmd_comma" => press_canvas_cmd_comma(app, cx),
         "create_workspace" => create_workspace(app, cx, payload),
         "destroy_workspace" => destroy_workspace(app, cx, payload),
         "spawn_session" => spawn_session(app, cx, payload),
@@ -101,6 +106,136 @@ async fn handle_action(
         "unregister_session" => unregister_session(app, cx, payload),
         _ => Err(format!("unknown action: {action}")),
     }
+}
+
+fn press_canvas_cmd_comma(app: &WeakEntity<NativeApp>, cx: &mut AsyncApp) -> Result<Value, String> {
+    let entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    let canvas = cx
+        .read_entity(&entity, |app: &NativeApp, _cx: &App| app.canvas_entity())
+        .map_err(|e| format!("read entity: {e}"))?;
+    let window = cx
+        .update(|app: &mut App| app.windows().into_iter().next())
+        .map_err(|e| format!("list windows: {e}"))?
+        .ok_or("no open windows")?;
+
+    cx.update_window(
+        window,
+        move |_root: AnyView, window: &mut Window, app: &mut App| {
+            canvas.update(app, |canvas, cx| {
+                canvas.inject_keystroke(
+                    Keystroke {
+                        key: ",".into(),
+                        modifiers: Modifiers {
+                            platform: true,
+                            ..Modifiers::default()
+                        },
+                        key_char: None,
+                    },
+                    window,
+                    cx,
+                );
+            });
+        },
+    )
+    .map_err(|e| format!("update window: {e}"))?;
+
+    Ok(json!({ "shortcut": "cmd+," }))
+}
+
+fn click_sidebar_settings(app: &WeakEntity<NativeApp>, cx: &mut AsyncApp) -> Result<Value, String> {
+    let entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    let sidebar = cx
+        .read_entity(&entity, |app: &NativeApp, _cx: &App| app.sidebar_entity())
+        .map_err(|e| format!("read entity: {e}"))?;
+    let window = cx
+        .update(|app: &mut App| app.windows().into_iter().next())
+        .map_err(|e| format!("list windows: {e}"))?
+        .ok_or("no open windows")?;
+
+    cx.update_window(
+        window,
+        move |_root: AnyView, window: &mut Window, app: &mut App| {
+            sidebar.update(app, |sidebar, cx| {
+                sidebar.click_settings_for_automation(window, cx);
+            });
+        },
+    )
+    .map_err(|e| format!("update window: {e}"))?;
+
+    Ok(json!({ "settings_open": true }))
+}
+
+fn click_settings_sidebar_mode(
+    app: &WeakEntity<NativeApp>,
+    cx: &mut AsyncApp,
+) -> Result<Value, String> {
+    let entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    let settings_page = cx
+        .read_entity(&entity, |app: &NativeApp, _cx: &App| {
+            app.settings_page_entity()
+        })
+        .map_err(|e| format!("read entity: {e}"))?
+        .ok_or("settings page is not open")?;
+    let window = cx
+        .update(|app: &mut App| app.windows().into_iter().next())
+        .map_err(|e| format!("list windows: {e}"))?
+        .ok_or("no open windows")?;
+
+    cx.update_window(
+        window,
+        move |_root: AnyView, window: &mut Window, app: &mut App| {
+            settings_page.update(app, |settings, cx| {
+                settings.click_sidebar_mode_for_automation(window, cx);
+            });
+        },
+    )
+    .map_err(|e| format!("update window: {e}"))?;
+
+    Ok(json!({ "clicked": "settings_sidebar_mode" }))
+}
+
+fn click_settings_close(app: &WeakEntity<NativeApp>, cx: &mut AsyncApp) -> Result<Value, String> {
+    let entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    let settings_page = cx
+        .read_entity(&entity, |app: &NativeApp, _cx: &App| {
+            app.settings_page_entity()
+        })
+        .map_err(|e| format!("read entity: {e}"))?
+        .ok_or("settings page is not open")?;
+    let window = cx
+        .update(|app: &mut App| app.windows().into_iter().next())
+        .map_err(|e| format!("list windows: {e}"))?
+        .ok_or("no open windows")?;
+
+    cx.update_window(
+        window,
+        move |_root: AnyView, window: &mut Window, app: &mut App| {
+            settings_page.update(app, |settings, cx| {
+                settings.click_close_for_automation(window, cx);
+            });
+        },
+    )
+    .map_err(|e| format!("update window: {e}"))?;
+
+    Ok(json!({ "settings_open": false }))
+}
+
+fn set_sidebar_collapsed(
+    app: &WeakEntity<NativeApp>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let collapsed = payload
+        .get("collapsed")
+        .and_then(Value::as_bool)
+        .ok_or("payload.collapsed (bool) is required")?;
+    let entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    cx.update_entity(&entity, |app, cx| {
+        app.set_sidebar_collapsed(collapsed, cx);
+    })
+    .map_err(|e| format!("update entity: {e}"))?;
+
+    Ok(json!({ "collapsed": collapsed }))
 }
 
 fn focus_panel(

--- a/native-ui/crates/attn-native-app/src/adapters/automation/actions.rs
+++ b/native-ui/crates/attn-native-app/src/adapters/automation/actions.rs
@@ -99,6 +99,9 @@ async fn handle_action(
         "click_settings_sidebar_mode" => click_settings_sidebar_mode(app, cx),
         "click_settings_close" => click_settings_close(app, cx),
         "press_canvas_cmd_comma" => press_canvas_cmd_comma(app, cx),
+        "press_window_cmd_comma_without_view_focus" => {
+            press_window_cmd_comma_without_view_focus(cx)
+        }
         "create_workspace" => create_workspace(app, cx, payload),
         "destroy_workspace" => destroy_workspace(app, cx, payload),
         "spawn_session" => spawn_session(app, cx, payload),
@@ -140,6 +143,34 @@ fn press_canvas_cmd_comma(app: &WeakEntity<NativeApp>, cx: &mut AsyncApp) -> Res
     .map_err(|e| format!("update window: {e}"))?;
 
     Ok(json!({ "shortcut": "cmd+," }))
+}
+
+fn press_window_cmd_comma_without_view_focus(cx: &mut AsyncApp) -> Result<Value, String> {
+    let window = cx
+        .update(|app: &mut App| app.windows().into_iter().next())
+        .map_err(|e| format!("list windows: {e}"))?
+        .ok_or("no open windows")?;
+
+    cx.update_window(
+        window,
+        move |_root: AnyView, window: &mut Window, app: &mut App| {
+            window.blur();
+            window.dispatch_keystroke(
+                Keystroke {
+                    key: ",".into(),
+                    modifiers: Modifiers {
+                        platform: true,
+                        ..Modifiers::default()
+                    },
+                    key_char: None,
+                },
+                app,
+            );
+        },
+    )
+    .map_err(|e| format!("update window: {e}"))?;
+
+    Ok(json!({ "shortcut": "cmd+,", "view_focus": false }))
 }
 
 fn click_sidebar_settings(app: &WeakEntity<NativeApp>, cx: &mut AsyncApp) -> Result<Value, String> {

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -34,6 +34,7 @@ use crate::state::workspace_registry::{PendingSpawn, UpsertOutcome, WorkspaceReg
 use crate::theme;
 use crate::views::canvas::WorkspaceCanvas;
 use crate::views::location_dialog::{LocationDialog, LocationDialogMode, LocationDialogOutcome};
+use crate::views::settings_page::SettingsPage;
 use crate::views::sidebar::Sidebar;
 use crate::views::terminal_view::TerminalView;
 
@@ -57,6 +58,7 @@ pub struct NativeApp {
     sidebar: Entity<Sidebar>,
     canvas: Entity<WorkspaceCanvas>,
     location_dialog: Option<Entity<LocationDialog>>,
+    settings_page: Option<Entity<SettingsPage>>,
     /// True from the moment the location dialog closes until the next
     /// render restores focus to the canvas. Without this hand-off, focus
     /// stays on the dialog's dropped focus handle and global shortcuts
@@ -89,6 +91,8 @@ impl NativeApp {
         let app_handle_canvas_close = app_handle.clone();
         let app_handle_canvas_split = app_handle.clone();
         let app_handle_canvas_geometry = app_handle.clone();
+        let app_handle_canvas_sidebar = app_handle.clone();
+        let app_handle_canvas_settings = app_handle.clone();
         let (trackpad_tx, trackpad_rx) = async_channel::unbounded();
         let trackpad_zoom = trackpad_zoom::install(trackpad_tx);
         let canvas = cx.new(|cx| {
@@ -134,10 +138,23 @@ impl NativeApp {
                         );
                     });
                 },
+                move |_window, cx| {
+                    let app_handle = app_handle_canvas_sidebar.clone();
+                    let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
+                        app.toggle_sidebar_collapsed(cx);
+                    });
+                },
+                move |_window, cx| {
+                    let app_handle = app_handle_canvas_settings.clone();
+                    let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
+                        app.open_settings_page_from_app(cx);
+                    });
+                },
             )
         });
         let canvas_subscription = cx.observe(&canvas, |_, _, cx| cx.notify());
         let app_handle_create = app_handle.clone();
+        let app_handle_settings = app_handle.clone();
         let app_handle_destroy = app_handle.clone();
         let sidebar = cx.new(|cx| {
             Sidebar::new(
@@ -152,6 +169,12 @@ impl NativeApp {
                     let app_handle = app_handle_create.clone();
                     let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
                         app.open_workspace_dialog(cx);
+                    });
+                },
+                move |sidebar_collapsed, _window, cx| {
+                    let app_handle = app_handle_settings.clone();
+                    let _ = app_handle.update(cx, |app: &mut NativeApp, cx| {
+                        app.open_settings_page(sidebar_collapsed, cx);
                     });
                 },
                 move |id, _window, cx| {
@@ -335,6 +358,7 @@ impl NativeApp {
             sidebar,
             canvas,
             location_dialog: None,
+            settings_page: None,
             canvas_needs_refocus: false,
             _canvas_subscription: canvas_subscription,
             _automation: automation_handle,
@@ -348,6 +372,21 @@ impl NativeApp {
         self.canvas.update(cx, |canvas, cx| {
             canvas.zoom_at_window_position(position, factor, cx);
         });
+    }
+
+    pub fn set_sidebar_collapsed(&mut self, collapsed: bool, cx: &mut Context<Self>) -> bool {
+        self.sidebar
+            .update(cx, |sidebar, cx| sidebar.set_collapsed(collapsed, cx));
+        cx.notify();
+        collapsed
+    }
+
+    pub fn toggle_sidebar_collapsed(&mut self, cx: &mut Context<Self>) -> bool {
+        let collapsed = self
+            .sidebar
+            .update(cx, |sidebar, cx| sidebar.toggle_collapsed(cx));
+        cx.notify();
+        collapsed
     }
 
     /// Apply a zoom level to the canvas, centered on the canvas
@@ -401,6 +440,18 @@ impl NativeApp {
     /// state registry, not the daemon adapter.
     pub fn sessions_snapshot(&self) -> Vec<Session> {
         self.sessions.snapshot()
+    }
+
+    pub fn sidebar_entity(&self) -> Entity<Sidebar> {
+        self.sidebar.clone()
+    }
+
+    pub fn canvas_entity(&self) -> Entity<WorkspaceCanvas> {
+        self.canvas.clone()
+    }
+
+    pub fn settings_page_entity(&self) -> Option<Entity<SettingsPage>> {
+        self.settings_page.clone()
     }
 
     fn open_session_dialog(
@@ -479,6 +530,42 @@ impl NativeApp {
         });
         self.location_dialog = Some(dialog);
         cx.notify();
+    }
+
+    fn open_settings_page(&mut self, sidebar_collapsed: bool, cx: &mut Context<Self>) {
+        let app_handle = cx.entity().downgrade();
+        let app_handle_close = app_handle.clone();
+        let app_handle_toggle = app_handle.clone();
+        let settings_page = cx.new(|cx| {
+            SettingsPage::new(
+                sidebar_collapsed,
+                move |_window, cx| {
+                    if let Some(app) = app_handle_close.upgrade() {
+                        app.update(cx, |app: &mut NativeApp, cx| {
+                            app.settings_page = None;
+                            app.canvas_needs_refocus = true;
+                            cx.notify();
+                        });
+                    }
+                },
+                move |_window, cx| {
+                    app_handle_toggle
+                        .update(cx, |app: &mut NativeApp, cx| {
+                            let collapsed = !app.sidebar.read(cx).is_collapsed();
+                            app.set_sidebar_collapsed(collapsed, cx)
+                        })
+                        .unwrap_or(sidebar_collapsed)
+                },
+                cx,
+            )
+        });
+        self.settings_page = Some(settings_page);
+        cx.notify();
+    }
+
+    fn open_settings_page_from_app(&mut self, cx: &mut Context<Self>) {
+        let sidebar_collapsed = self.sidebar.read(cx).is_collapsed();
+        self.open_settings_page(sidebar_collapsed, cx);
     }
 
     fn forward_location_dialog_event(&mut self, event: &DaemonEvent, cx: &mut Context<Self>) {
@@ -935,12 +1022,15 @@ impl NativeApp {
             .collect();
 
         let canvas = self.canvas.read(cx).automation_snapshot();
+        let sidebar = self.sidebar.read(cx).automation_snapshot();
 
         json!({
             "selected_workspace_id": self.registry.selected_id().map(|s| s.to_string()),
             "workspaces": workspaces,
             "sessions": serde_json::to_value(self.sessions.snapshot()).unwrap_or(Value::Null),
             "canvas": canvas,
+            "sidebar": sidebar,
+            "settings_open": self.settings_page.is_some(),
             "daemon": {
                 "connected": daemon.connected(),
                 "error": daemon.error(),
@@ -1299,6 +1389,9 @@ impl Render for NativeApp {
         };
         if let Some(dialog) = self.location_dialog.clone() {
             root = root.child(dialog);
+        }
+        if let Some(settings_page) = self.settings_page.clone() {
+            root = root.child(settings_page);
         }
         root
     }

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -37,6 +37,7 @@ use crate::views::location_dialog::{LocationDialog, LocationDialogMode, Location
 use crate::views::settings_page::SettingsPage;
 use crate::views::sidebar::Sidebar;
 use crate::views::terminal_view::TerminalView;
+use crate::{OpenSettings, ToggleSidebar};
 
 /// Initial terminal panel size in world-space units. ~720×560 gives
 /// ~92 cols × ~31 rows once the title bar is subtracted.
@@ -563,9 +564,27 @@ impl NativeApp {
         cx.notify();
     }
 
-    fn open_settings_page_from_app(&mut self, cx: &mut Context<Self>) {
+    pub fn open_settings_page_from_app(&mut self, cx: &mut Context<Self>) {
         let sidebar_collapsed = self.sidebar.read(cx).is_collapsed();
         self.open_settings_page(sidebar_collapsed, cx);
+    }
+
+    fn open_settings_action(
+        &mut self,
+        _: &OpenSettings,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_settings_page_from_app(cx);
+    }
+
+    fn toggle_sidebar_action(
+        &mut self,
+        _: &ToggleSidebar,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.toggle_sidebar_collapsed(cx);
     }
 
     fn forward_location_dialog_event(&mut self, event: &DaemonEvent, cx: &mut Context<Self>) {
@@ -1380,7 +1399,9 @@ impl Render for NativeApp {
             .size_full()
             .flex()
             .flex_row()
-            .bg(theme::ink::midnight());
+            .bg(theme::ink::midnight())
+            .on_action(cx.listener(Self::open_settings_action))
+            .on_action(cx.listener(Self::toggle_sidebar_action));
         root = if self.canvas.read(cx).is_panel_fullscreen() {
             root.child(div().flex_1().overflow_hidden().child(self.canvas.clone()))
         } else {

--- a/native-ui/crates/attn-native-app/src/main.rs
+++ b/native-ui/crates/attn-native-app/src/main.rs
@@ -18,11 +18,15 @@ use gpui::{
 use adapters::daemon::DaemonClient;
 use app::NativeApp;
 
-actions!(attn_native, [Quit]);
+actions!(attn_native, [Quit, OpenSettings, ToggleSidebar]);
 
 fn main() {
     Application::new().run(|cx: &mut App| {
-        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
+        cx.bind_keys([
+            KeyBinding::new("cmd-q", Quit, None),
+            KeyBinding::new("cmd-,", OpenSettings, None),
+            KeyBinding::new("cmd-b", ToggleSidebar, None),
+        ]);
         cx.on_action::<Quit>(|_, cx| cx.quit());
         let _ = cx.on_window_closed(|cx| cx.quit());
 

--- a/native-ui/crates/attn-native-app/src/views/canvas.rs
+++ b/native-ui/crates/attn-native-app/src/views/canvas.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use gpui::{
     canvas, div, point, prelude::*, px, AnyElement, App, Bounds, BoxShadow, Context, Entity,
-    FocusHandle, Focusable, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent,
+    FocusHandle, Focusable, KeyDownEvent, Keystroke, MouseButton, MouseDownEvent, MouseMoveEvent,
     MouseUpEvent, ParentElement, Pixels, Render, ScrollDelta, ScrollWheelEvent, SharedString,
     Subscription, Window,
 };
@@ -40,6 +40,10 @@ pub type SplitShellHandler = dyn Fn(SharedString, SharedString, AdjacentPanelDir
 /// final daemon panel id + geometry to the app coordinator.
 pub type PanelGeometryCommitHandler =
     dyn Fn(SharedString, SharedString, f32, f32, f32, f32, &mut Window, &mut gpui::App) + 'static;
+
+/// Callback invoked by global canvas shortcuts that affect app chrome.
+pub type ToggleSidebarHandler = dyn Fn(&mut Window, &mut gpui::App) + 'static;
+pub type OpenSettingsHandler = dyn Fn(&mut Window, &mut gpui::App) + 'static;
 
 use serde_json::{json, Value};
 
@@ -146,6 +150,8 @@ pub struct WorkspaceCanvas {
     on_close_session: Box<CloseSessionHandler>,
     on_split_shell: Box<SplitShellHandler>,
     on_panel_geometry_commit: Box<PanelGeometryCommitHandler>,
+    on_toggle_sidebar: Box<ToggleSidebarHandler>,
+    on_open_settings: Box<OpenSettingsHandler>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -169,6 +175,8 @@ impl WorkspaceCanvas {
             ) + 'static,
         on_panel_geometry_commit: impl Fn(SharedString, SharedString, f32, f32, f32, f32, &mut Window, &mut gpui::App)
             + 'static,
+        on_toggle_sidebar: impl Fn(&mut Window, &mut gpui::App) + 'static,
+        on_open_settings: impl Fn(&mut Window, &mut gpui::App) + 'static,
     ) -> Self {
         let fps = if env_flag("ATTN_NATIVE_FPS") {
             Some(FpsCounter::new())
@@ -194,6 +202,8 @@ impl WorkspaceCanvas {
             on_close_session: Box::new(on_close_session),
             on_split_shell: Box::new(on_split_shell),
             on_panel_geometry_commit: Box::new(on_panel_geometry_commit),
+            on_toggle_sidebar: Box::new(on_toggle_sidebar),
+            on_open_settings: Box::new(on_open_settings),
         }
     }
 
@@ -735,6 +745,14 @@ impl WorkspaceCanvas {
                 cx.stop_propagation();
                 self.split_shell_for_selected(AdjacentPanelDirection::Right, window, cx);
             }
+            "b" if event.keystroke.modifiers.platform => {
+                cx.stop_propagation();
+                (self.on_toggle_sidebar)(window, cx);
+            }
+            "," if event.keystroke.modifiers.platform => {
+                cx.stop_propagation();
+                (self.on_open_settings)(window, cx);
+            }
             "enter" if event.keystroke.modifiers.platform && event.keystroke.modifiers.shift => {
                 cx.stop_propagation();
                 self.toggle_selected_panel_fullscreen(window, cx);
@@ -917,9 +935,23 @@ impl WorkspaceCanvas {
                 }
             }
         }
+
         self.drag_state = DragState::Idle;
         self.snap_lines.clear();
         cx.notify();
+    }
+
+    pub fn inject_keystroke(
+        &mut self,
+        keystroke: Keystroke,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let event = KeyDownEvent {
+            keystroke,
+            is_held: false,
+        };
+        self.on_key_down(&event, window, cx);
     }
 
     fn on_scroll_wheel(

--- a/native-ui/crates/attn-native-app/src/views/mod.rs
+++ b/native-ui/crates/attn-native-app/src/views/mod.rs
@@ -6,5 +6,6 @@
 pub mod canvas;
 pub mod fps_overlay;
 pub mod location_dialog;
+pub mod settings_page;
 pub mod sidebar;
 pub mod terminal_view;

--- a/native-ui/crates/attn-native-app/src/views/settings_page.rs
+++ b/native-ui/crates/attn-native-app/src/views/settings_page.rs
@@ -1,0 +1,376 @@
+//! Native Settings surface. Kept small for the MVP: it owns only the
+//! pixels and delegates state mutations back to `NativeApp`.
+
+use gpui::{
+    div, hsla, point, prelude::*, px, BoxShadow, Context, FocusHandle, Focusable, KeyDownEvent,
+    MouseButton, ParentElement, Render, SharedString, Window,
+};
+
+use crate::theme;
+
+type CloseHandler = dyn Fn(&mut Window, &mut gpui::App) + 'static;
+type ToggleSidebarHandler = dyn Fn(&mut Window, &mut gpui::App) -> bool + 'static;
+
+pub struct SettingsPage {
+    sidebar_collapsed: bool,
+    on_close: Box<CloseHandler>,
+    on_toggle_sidebar: Box<ToggleSidebarHandler>,
+    focus_handle: FocusHandle,
+}
+
+impl SettingsPage {
+    pub fn new(
+        sidebar_collapsed: bool,
+        on_close: impl Fn(&mut Window, &mut gpui::App) + 'static,
+        on_toggle_sidebar: impl Fn(&mut Window, &mut gpui::App) -> bool + 'static,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self {
+            sidebar_collapsed,
+            on_close: Box::new(on_close),
+            on_toggle_sidebar: Box::new(on_toggle_sidebar),
+            focus_handle: cx.focus_handle(),
+        }
+    }
+
+    fn close(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        (self.on_close)(window, cx);
+    }
+
+    pub fn click_close_for_automation(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.close(window, cx);
+    }
+
+    fn toggle_sidebar(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.sidebar_collapsed = (self.on_toggle_sidebar)(window, cx);
+        cx.notify();
+    }
+
+    pub fn click_sidebar_mode_for_automation(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.toggle_sidebar(window, cx);
+    }
+
+    fn on_key_down(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                cx.stop_propagation();
+                self.close(window, cx);
+            }
+            "b" if event.keystroke.modifiers.platform => {
+                cx.stop_propagation();
+                self.toggle_sidebar(window, cx);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Focusable for SettingsPage {
+    fn focus_handle(&self, _cx: &gpui::App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for SettingsPage {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if !self.focus_handle.is_focused(window) {
+            self.focus_handle.focus(window);
+        }
+
+        let panel = div()
+            .w(px(760.0))
+            .rounded(px(theme::radius::R2))
+            .bg(theme::ink::nocturne())
+            .border_1()
+            .border_color(theme::line::firm())
+            .overflow_hidden()
+            .shadow(vec![
+                BoxShadow {
+                    color: hsla(0.0, 0.0, 0.0, 0.56),
+                    offset: point(px(0.0), px(24.0)),
+                    blur_radius: px(60.0),
+                    spread_radius: px(-8.0),
+                },
+                BoxShadow {
+                    color: hsla(0.0, 0.0, 0.0, 0.35),
+                    offset: point(px(0.0), px(2.0)),
+                    blur_radius: px(8.0),
+                    spread_radius: px(0.0),
+                },
+            ])
+            .track_focus(&self.focus_handle)
+            .on_key_down(cx.listener(Self::on_key_down))
+            .child(settings_header().child(close_button().on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    cx.stop_propagation();
+                    this.close(window, cx);
+                }),
+            )))
+            .child(
+                div()
+                    .px_6()
+                    .py_6()
+                    .min_h(px(320.0))
+                    .flex()
+                    .flex_col()
+                    .child(interface_card(self.sidebar_collapsed).on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, _, window, cx| {
+                            cx.stop_propagation();
+                            this.toggle_sidebar(window, cx);
+                        }),
+                    )),
+            );
+
+        div()
+            .absolute()
+            .size_full()
+            .bg(theme::ink::veil())
+            .flex()
+            .items_center()
+            .justify_center()
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, window, cx| this.close(window, cx)),
+            )
+            .child(panel.on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|_, _, _, cx| cx.stop_propagation()),
+            ))
+    }
+}
+
+fn settings_header() -> gpui::Div {
+    div()
+        .w_full()
+        .px_5()
+        .py_4()
+        .border_b_1()
+        .border_color(theme::line::weak())
+        .bg(theme::ink::shade())
+        .flex()
+        .items_center()
+        .justify_between()
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap_3()
+                .child(
+                    div()
+                        .w(px(3.0))
+                        .h(px(31.0))
+                        .rounded(px(theme::radius::R0))
+                        .bg(theme::sodium::vapor())
+                        .shadow(vec![BoxShadow {
+                            color: theme::sodium::glow().into(),
+                            offset: point(px(0.0), px(0.0)),
+                            blur_radius: px(14.0),
+                            spread_radius: px(0.0),
+                        }]),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .gap_1()
+                        .child(
+                            div()
+                                .text_color(theme::moon::moonstone())
+                                .text_size(px(17.0))
+                                .child(SharedString::from("Settings")),
+                        )
+                        .child(
+                            div()
+                                .text_color(theme::moon::ash())
+                                .text_size(px(10.0))
+                                .child(SharedString::from("Native client")),
+                        ),
+                ),
+        )
+}
+
+fn interface_card(collapsed: bool) -> gpui::Div {
+    div()
+        .w_full()
+        .flex_1()
+        .rounded(px(theme::radius::R1))
+        .bg(theme::ink::shade())
+        .border_1()
+        .border_color(theme::line::mild())
+        .p_5()
+        .flex()
+        .items_center()
+        .justify_between()
+        .gap_6()
+        .child(
+            div()
+                .flex_1()
+                .min_w(px(0.0))
+                .flex()
+                .flex_col()
+                .gap_4()
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .gap_2()
+                        .child(
+                            div()
+                                .text_color(theme::moon::moonstone())
+                                .text_size(px(16.0))
+                                .child(SharedString::from("Workspace rail")),
+                        )
+                        .child(
+                            div()
+                                .text_color(theme::moon::ash())
+                                .text_size(px(11.0))
+                                .child(SharedString::from(if collapsed {
+                                    "Narrow"
+                                } else {
+                                    "Wide"
+                                })),
+                        ),
+                )
+                .child(sidebar_mode_control(collapsed)),
+        )
+        .child(sidebar_preview(collapsed))
+}
+
+fn sidebar_preview(collapsed: bool) -> gpui::Div {
+    let rail_w = if collapsed { 48.0 } else { 146.0 };
+    div()
+        .w(px(220.0))
+        .h(px(176.0))
+        .rounded(px(theme::radius::R1))
+        .bg(theme::ink::midnight())
+        .border_1()
+        .border_color(theme::line::weak())
+        .p_2()
+        .flex()
+        .gap_2()
+        .child(
+            div()
+                .w(px(rail_w))
+                .h_full()
+                .rounded(px(theme::radius::R0))
+                .bg(theme::ink::nocturne())
+                .border_1()
+                .border_color(theme::line::mild())
+                .p_2()
+                .flex()
+                .flex_col()
+                .gap_2()
+                .child(preview_row(collapsed, theme::state::working(), true))
+                .child(preview_row(collapsed, theme::state::waiting(), false))
+                .child(preview_row(collapsed, theme::state::approval(), false)),
+        )
+        .child(
+            div()
+                .flex_1()
+                .h_full()
+                .rounded(px(theme::radius::R0))
+                .bg(theme::ink::void())
+                .border_1()
+                .border_color(theme::line::weak()),
+        )
+}
+
+fn preview_row(collapsed: bool, color: gpui::Rgba, selected: bool) -> gpui::Div {
+    let mut row = div()
+        .w_full()
+        .h(px(28.0))
+        .rounded(px(theme::radius::R0))
+        .bg(if selected {
+            theme::surface::selected_row()
+        } else {
+            theme::ink::shade()
+        })
+        .border_l_2()
+        .border_color(if selected {
+            theme::sodium::vapor()
+        } else {
+            theme::ink::shade()
+        })
+        .flex()
+        .items_center()
+        .gap_2()
+        .px_2()
+        .child(div().w(px(7.0)).h(px(7.0)).rounded_full().bg(color));
+
+    if !collapsed {
+        row = row.child(
+            div()
+                .w(px(58.0))
+                .h(px(5.0))
+                .rounded(px(theme::radius::R0))
+                .bg(if selected {
+                    theme::moon::bone()
+                } else {
+                    theme::moon::cinder()
+                }),
+        );
+    }
+
+    row
+}
+
+fn close_button() -> gpui::Div {
+    div()
+        .w(px(28.0))
+        .h(px(28.0))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(theme::radius::R0))
+        .border_1()
+        .border_color(theme::line::mild())
+        .text_color(theme::moon::bone())
+        .text_size(px(14.0))
+        .child(SharedString::from("x"))
+}
+
+fn sidebar_mode_control(collapsed: bool) -> gpui::Div {
+    div()
+        .rounded(px(theme::radius::R1))
+        .border_1()
+        .border_color(theme::line::mild())
+        .bg(theme::ink::midnight())
+        .p_1()
+        .flex()
+        .items_center()
+        .gap_1()
+        .child(mode_segment("Wide", !collapsed))
+        .child(mode_segment("Narrow", collapsed))
+}
+
+fn mode_segment(label: &'static str, active: bool) -> gpui::Div {
+    let mut segment = div()
+        .h(px(28.0))
+        .px_3p5()
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(theme::radius::R0))
+        .text_size(px(11.0))
+        .text_color(if active {
+            theme::moon::moonstone()
+        } else {
+            theme::moon::ash()
+        })
+        .child(SharedString::from(label));
+
+    if active {
+        segment = segment
+            .bg(theme::surface::selected_row())
+            .border_1()
+            .border_color(theme::sodium::deep());
+    }
+
+    segment
+}

--- a/native-ui/crates/attn-native-app/src/views/sidebar.rs
+++ b/native-ui/crates/attn-native-app/src/views/sidebar.rs
@@ -13,9 +13,11 @@ use crate::state::workspace::Workspace;
 use crate::theme;
 
 pub const SIDEBAR_WIDTH: f32 = 240.0;
+pub const SIDEBAR_COLLAPSED_WIDTH: f32 = 52.0;
 
 type SelectHandler = dyn Fn(SharedString, &mut Window, &mut gpui::App) + 'static;
 type CreateHandler = dyn Fn(&mut Window, &mut gpui::App) + 'static;
+type SettingsHandler = dyn Fn(bool, &mut Window, &mut gpui::App) + 'static;
 type DestroyHandler =
     dyn Fn(SharedString, &mut Window, &mut gpui::App) -> Result<(), String> + 'static;
 
@@ -30,11 +32,15 @@ pub struct Sidebar {
     /// directory picker → daemon `register_workspace` flow on the app
     /// side; the sidebar just dispatches.
     on_create: Box<CreateHandler>,
+    /// Callback fired by the bottom cog. `NativeApp` owns the settings
+    /// surface; the sidebar only exposes the affordance.
+    on_open_settings: Box<SettingsHandler>,
     /// Callback fired after the user confirms a row's delete affordance.
     /// Sends `unregister_workspace` for the given id. Daemon cascades to
     /// member sessions, so callers don't need a separate session-cleanup
     /// step.
     on_destroy: Box<DestroyHandler>,
+    collapsed: bool,
     confirm_destroy_id: Option<SharedString>,
     destroying_id: Option<SharedString>,
     destroy_error: Option<(SharedString, SharedString)>,
@@ -46,6 +52,7 @@ impl Sidebar {
         workspaces: Vec<Entity<Workspace>>,
         on_select: impl Fn(SharedString, &mut Window, &mut gpui::App) + 'static,
         on_create: impl Fn(&mut Window, &mut gpui::App) + 'static,
+        on_open_settings: impl Fn(bool, &mut Window, &mut gpui::App) + 'static,
         on_destroy: impl Fn(SharedString, &mut Window, &mut gpui::App) -> Result<(), String> + 'static,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -59,7 +66,9 @@ impl Sidebar {
             selected_id: None,
             on_select: Box::new(on_select),
             on_create: Box::new(on_create),
+            on_open_settings: Box::new(on_open_settings),
             on_destroy: Box::new(on_destroy),
+            collapsed: false,
             confirm_destroy_id: None,
             destroying_id: None,
             destroy_error: None,
@@ -98,6 +107,42 @@ impl Sidebar {
             self.selected_id = id;
             cx.notify();
         }
+    }
+
+    pub fn is_collapsed(&self) -> bool {
+        self.collapsed
+    }
+
+    pub fn set_collapsed(&mut self, collapsed: bool, cx: &mut Context<Self>) {
+        if self.collapsed != collapsed {
+            self.collapsed = collapsed;
+            if collapsed {
+                self.confirm_destroy_id = None;
+                self.destroy_error = None;
+            }
+            cx.notify();
+        }
+    }
+
+    pub fn toggle_collapsed(&mut self, cx: &mut Context<Self>) -> bool {
+        let collapsed = !self.collapsed;
+        self.set_collapsed(collapsed, cx);
+        collapsed
+    }
+
+    pub fn automation_snapshot(&self) -> serde_json::Value {
+        serde_json::json!({
+            "collapsed": self.collapsed,
+            "width": if self.collapsed {
+                SIDEBAR_COLLAPSED_WIDTH
+            } else {
+                SIDEBAR_WIDTH
+            },
+        })
+    }
+
+    pub fn click_settings_for_automation(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        (self.on_open_settings)(self.collapsed, window, cx);
     }
 
     fn clear_destroy_state_for(&mut self, id: &str) {
@@ -150,24 +195,31 @@ impl Render for Sidebar {
                     }
                 });
                 let click_id = id.clone();
-                let mut row_div = workspace_row(title, status, selected, confirming, destroying)
-                    .on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(move |this, _, window, cx| {
-                            let id = click_id.clone();
-                            let cleared_destroy_state =
-                                this.confirm_destroy_id.is_some() || this.destroy_error.is_some();
-                            this.confirm_destroy_id = None;
-                            this.destroy_error = None;
-                            (this.on_select)(id.clone(), window, cx);
-                            this.set_selected(Some(id), cx);
-                            if cleared_destroy_state {
-                                cx.notify();
-                            }
-                        }),
-                    );
+                let mut row_div = if self.collapsed {
+                    workspace_row_collapsed(status, selected, confirming, destroying)
+                } else {
+                    workspace_row(title, status, selected, confirming, destroying)
+                }
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, window, cx| {
+                        let id = click_id.clone();
+                        let cleared_destroy_state =
+                            this.confirm_destroy_id.is_some() || this.destroy_error.is_some();
+                        this.confirm_destroy_id = None;
+                        this.destroy_error = None;
+                        (this.on_select)(id.clone(), window, cx);
+                        this.set_selected(Some(id), cx);
+                        if cleared_destroy_state {
+                            cx.notify();
+                        }
+                    }),
+                );
 
-                if confirming {
+                if self.collapsed {
+                    // Destructive actions stay in the expanded rail where
+                    // the confirm/cancel copy has room to be explicit.
+                } else if confirming {
                     let cancel_id = id.clone();
                     let confirm_id = id.clone();
                     row_div = row_div
@@ -233,44 +285,124 @@ impl Render for Sidebar {
             .collect();
 
         let count = self.workspaces.len();
-        div()
-            .w(px(SIDEBAR_WIDTH))
+        let width = if self.collapsed {
+            SIDEBAR_COLLAPSED_WIDTH
+        } else {
+            SIDEBAR_WIDTH
+        };
+        let root = div()
+            .w(px(width))
             .h_full()
             .bg(theme::ink::nocturne())
             .border_r_1()
             .border_color(theme::ink::firm())
             .flex()
             .flex_col()
-            .child(sidebar_header(count))
-            .children(rows)
-            .child(create_row().on_mouse_down(
+            .child(sidebar_header(count, self.collapsed).on_mouse_down(
                 MouseButton::Left,
-                cx.listener(|this, _, window, cx| {
-                    (this.on_create)(window, cx);
+                cx.listener(|this, _, _, cx| {
+                    this.toggle_collapsed(cx);
                 }),
             ))
+            .child(div().flex_1().flex().flex_col().children(rows));
+
+        let create = create_row(self.collapsed).on_mouse_down(
+            MouseButton::Left,
+            cx.listener(|this, _, window, cx| {
+                (this.on_create)(window, cx);
+            }),
+        );
+        let settings = settings_button(self.collapsed).on_mouse_down(
+            MouseButton::Left,
+            cx.listener(|this, _, window, cx| {
+                (this.on_open_settings)(this.collapsed, window, cx);
+            }),
+        );
+
+        if self.collapsed {
+            root.child(
+                div()
+                    .w_full()
+                    .pb_3()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .gap_2()
+                    .border_t_1()
+                    .border_color(theme::line::weak())
+                    .child(create)
+                    .child(settings),
+            )
+        } else {
+            root.child(create).child(
+                div()
+                    .w_full()
+                    .px_3()
+                    .py_3()
+                    .border_t_1()
+                    .border_color(theme::line::weak())
+                    .flex()
+                    .items_center()
+                    .justify_end()
+                    .child(settings),
+            )
+        }
     }
 }
 
-/// Section header at the top of the workspace rail. Mono label on the
-/// left, count on the right — pulls from the language defined in plate
-/// 04 (sidebar) of the design system.
-fn sidebar_header(count: usize) -> impl IntoElement {
+/// Section header at the top of the workspace rail. Expanded mode shows
+/// the ledger label and count; collapsed mode becomes a compact toggle
+/// cap so the narrow rail still has a clear affordance.
+fn sidebar_header(count: usize, collapsed: bool) -> gpui::Div {
+    if collapsed {
+        return div()
+            .w_full()
+            .h(px(42.0))
+            .flex()
+            .items_center()
+            .justify_center()
+            .border_b_1()
+            .border_color(theme::line::weak())
+            .text_color(theme::moon::bone())
+            .text_size(px(16.0))
+            .child(SharedString::from(">"));
+    }
+
     div()
         .w_full()
         .px_4()
         .pt_3()
         .pb_2()
         .flex()
-        .items_baseline()
+        .items_center()
         .justify_between()
         .text_color(theme::moon::bone())
         .text_size(px(10.))
-        .child(SharedString::from("WORKSPACES"))
         .child(
             div()
-                .text_color(theme::moon::parchment())
-                .child(SharedString::from(format!("{:02}", count))),
+                .flex()
+                .items_baseline()
+                .gap_2()
+                .child(SharedString::from("WORKSPACES"))
+                .child(
+                    div()
+                        .text_color(theme::moon::parchment())
+                        .child(SharedString::from(format!("{:02}", count))),
+                ),
+        )
+        .child(
+            div()
+                .w(px(24.0))
+                .h(px(24.0))
+                .flex()
+                .items_center()
+                .justify_center()
+                .rounded(px(theme::radius::R0))
+                .border_1()
+                .border_color(theme::line::mild())
+                .text_color(theme::moon::bone())
+                .text_size(px(13.0))
+                .child(SharedString::from("<")),
         )
 }
 
@@ -328,6 +460,49 @@ fn workspace_row(
         .text_size(px(13.))
         .child(status_badge(status))
         .child(div().flex_1().truncate().child(title))
+}
+
+fn workspace_row_collapsed(
+    status: WorkspaceStatus,
+    selected: bool,
+    confirming_delete: bool,
+    destroying: bool,
+) -> gpui::Div {
+    let bg = if confirming_delete {
+        theme::surface::danger_row()
+    } else if destroying {
+        theme::surface::pending_row()
+    } else if selected {
+        theme::surface::selected_row()
+    } else {
+        theme::ink::nocturne()
+    };
+    let accent = if selected { theme::sodium::vapor() } else { bg };
+    div()
+        .w_full()
+        .h(px(34.0))
+        .flex()
+        .items_center()
+        .justify_center()
+        .bg(bg)
+        .border_l_2()
+        .border_color(accent)
+        .child(
+            div()
+                .w(px(16.0))
+                .h(px(16.0))
+                .rounded_full()
+                .border_1()
+                .border_color(if selected {
+                    theme::sodium::deep()
+                } else {
+                    theme::line::mild()
+                })
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(status_badge(status)),
+        )
 }
 
 /// Trailing delete affordance on each row. Always visible (no hover gate
@@ -390,7 +565,11 @@ fn destroy_error_row(message: SharedString) -> gpui::Div {
 /// from real workspaces so the eye reads it as an action, not a row to
 /// select. A faint top divider separates the "live workspaces" stack
 /// from this "open new" affordance, matching the sidebar plate.
-fn create_row() -> gpui::Div {
+fn create_row(collapsed: bool) -> gpui::Div {
+    if collapsed {
+        return icon_button("+");
+    }
+
     div()
         .w_full()
         .pt_2()
@@ -413,6 +592,42 @@ fn create_row() -> gpui::Div {
                 .child(create_glyph())
                 .child(SharedString::from("New Workspace")),
         )
+}
+
+fn settings_button(collapsed: bool) -> gpui::Div {
+    if collapsed {
+        icon_button("⚙")
+    } else {
+        div()
+            .w(px(28.0))
+            .h(px(28.0))
+            .flex_shrink_0()
+            .flex()
+            .items_center()
+            .justify_center()
+            .rounded(px(theme::radius::R0))
+            .border_1()
+            .border_color(theme::line::mild())
+            .text_color(theme::moon::bone())
+            .text_size(px(15.0))
+            .child(SharedString::from("⚙"))
+    }
+}
+
+fn icon_button(label: &'static str) -> gpui::Div {
+    div()
+        .w(px(32.0))
+        .h(px(32.0))
+        .flex_shrink_0()
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(theme::radius::R1))
+        .border_1()
+        .border_color(theme::line::mild())
+        .text_color(theme::moon::bone())
+        .text_size(px(16.0))
+        .child(SharedString::from(label))
 }
 
 /// Leading "+" glyph for the create row. Sits in the column where status


### PR DESCRIPTION
## Summary

- Add a native Settings surface reachable from the sidebar cog and `Cmd+,`.
- Make the native sidebar collapsible with `Cmd+B`, preserving workspace status colors in the narrow rail.
- Extend native automation and the canvas scenario to cover sidebar collapse, settings click-through, and the `Cmd+,` shortcut.

## Validation

- `rtk cargo fmt --all`
- `rtk node --check app/scripts/real-app-harness/scenario-native-canvas.mjs`
- `rtk cargo test --manifest-path native-ui/Cargo.toml`
- `rtk make scenario-native-canvas ATTN_PROFILE=dev` against `make dev-native`