### PR TITLE
[codex] Add native settings parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-05-03]
 
 ### Added
+- **Native Settings Parity**: The native Settings window now mirrors the Tauri settings surface with sections for appearance, projects, agents, review-loop models and prompts, mobile web, remote endpoints, GitHub hosts, muted filters, PTY backend state, and native sidebar controls.
 - **Native Sidebar Settings Entry**: The native workspace sidebar now has a bottom settings cog and `Cmd+,` shortcut that open a native Settings surface with a sidebar display control.
 - **Native Canvas Trackpad Zoom**: The native canvas now responds to trackpad pinch/magnify gestures and precise control-scroll zoom, keeping the cursor's world point anchored while zooming.
 - **Native Canvas Panel Status**: Native canvas panel headers now show each session's live state, including working, waiting for input, approval-needed, idle, and long-run review status.

--- a/app/scripts/real-app-harness/scenario-native-canvas.mjs
+++ b/app/scripts/real-app-harness/scenario-native-canvas.mjs
@@ -246,6 +246,15 @@ async function checkPlumbing(conn, manifest) {
   if (settingsOpenState.result.settings_open !== true) {
     fail(`settings dialog did not open from sidebar click: ${JSON.stringify(settingsOpenState.result)}`);
   }
+  for (const section of ['general', 'agents', 'review', 'network', 'filters', 'system']) {
+    const selectedSection = await conn.request('click_settings_section', { section });
+    if (!selectedSection.ok) fail(`click_settings_section ${section}: ${selectedSection.error}`);
+    if (selectedSection.result.section !== section) {
+      fail(`click_settings_section ${section} returned wrong section: ${JSON.stringify(selectedSection)}`);
+    }
+  }
+  const selectedGeneral = await conn.request('click_settings_section', { section: 'general' });
+  if (!selectedGeneral.ok) fail(`click_settings_section general restore: ${selectedGeneral.error}`);
   const clickedSidebarMode = await conn.request('click_settings_sidebar_mode');
   if (!clickedSidebarMode.ok) fail(`click_settings_sidebar_mode: ${clickedSidebarMode.error}`);
   const settingsToggledState = await conn.request('get_state');

--- a/native-ui/crates/attn-native-app/src/adapters/automation/actions.rs
+++ b/native-ui/crates/attn-native-app/src/adapters/automation/actions.rs
@@ -97,6 +97,7 @@ async fn handle_action(
         "set_sidebar_collapsed" => set_sidebar_collapsed(app, cx, payload),
         "click_sidebar_settings" => click_sidebar_settings(app, cx),
         "click_settings_sidebar_mode" => click_settings_sidebar_mode(app, cx),
+        "click_settings_section" => click_settings_section(app, cx, payload),
         "click_settings_close" => click_settings_close(app, cx),
         "press_canvas_cmd_comma" => press_canvas_cmd_comma(app, cx),
         "press_window_cmd_comma_without_view_focus" => {
@@ -223,6 +224,32 @@ fn click_settings_sidebar_mode(
     .map_err(|e| format!("update window: {e}"))?;
 
     Ok(json!({ "clicked": "settings_sidebar_mode" }))
+}
+
+fn click_settings_section(
+    app: &WeakEntity<NativeApp>,
+    cx: &mut AsyncApp,
+    payload: Value,
+) -> Result<Value, String> {
+    let section = payload
+        .get("section")
+        .and_then(Value::as_str)
+        .ok_or("section is required")?
+        .to_string();
+    let entity = app.upgrade().ok_or("NativeApp entity dropped")?;
+    let settings_page = cx
+        .read_entity(&entity, |app: &NativeApp, _cx: &App| {
+            app.settings_page_entity()
+        })
+        .map_err(|e| format!("read entity: {e}"))?
+        .ok_or("settings page is not open")?;
+
+    cx.update_entity(&settings_page, |settings, cx| {
+        settings.select_section_for_automation(section.as_str(), cx)
+    })
+    .map_err(|e| format!("update settings page: {e}"))??;
+
+    Ok(json!({ "section": section }))
 }
 
 fn click_settings_close(app: &WeakEntity<NativeApp>, cx: &mut AsyncApp) -> Result<Value, String> {

--- a/native-ui/crates/attn-native-app/src/adapters/daemon.rs
+++ b/native-ui/crates/attn-native-app/src/adapters/daemon.rs
@@ -1,7 +1,7 @@
 use attn_protocol::{
-    BrowseDirectoryResultMessage, ClientHelloMessage, CreateWorktreeResultMessage,
-    GetRepoInfoResultMessage, InspectPathResultMessage, ServerEvent, Session, Workspace,
-    CAPABILITY_SHELL_AS_SESSION, PROTOCOL_VERSION,
+    BrowseDirectoryResultMessage, ClientHelloMessage, CreateWorktreeResultMessage, EndpointInfo,
+    GetRepoInfoResultMessage, InspectPathResultMessage, PullRequestSummary, RepoState, ServerEvent,
+    Session, SettingsMap, Workspace, CAPABILITY_SHELL_AS_SESSION, PROTOCOL_VERSION,
 };
 use futures_util::{SinkExt, StreamExt};
 use gpui::{AsyncApp, Context, EventEmitter, WeakEntity};
@@ -36,6 +36,32 @@ pub enum DaemonEvent {
     InitialState {
         sessions: Vec<Session>,
         workspaces: Vec<Workspace>,
+        endpoints: Vec<EndpointInfo>,
+        prs: Vec<PullRequestSummary>,
+        repos: Vec<RepoState>,
+        authors: Vec<attn_protocol::AuthorState>,
+        settings: SettingsMap,
+    },
+    SettingsUpdated {
+        settings: SettingsMap,
+        changed_key: Option<String>,
+        success: Option<bool>,
+        error: Option<String>,
+    },
+    EndpointsUpdated {
+        endpoints: Vec<EndpointInfo>,
+    },
+    EndpointStatusChanged {
+        endpoint: EndpointInfo,
+    },
+    ReposUpdated {
+        repos: Vec<RepoState>,
+    },
+    AuthorsUpdated {
+        authors: Vec<attn_protocol::AuthorState>,
+    },
+    PRsUpdated {
+        prs: Vec<PullRequestSummary>,
     },
     /// A session appeared (newly spawned or registered).
     SessionRegistered {
@@ -255,7 +281,41 @@ impl DaemonClient {
                 cx.emit(DaemonEvent::InitialState {
                     sessions: msg.sessions,
                     workspaces: msg.workspaces,
+                    endpoints: msg.endpoints,
+                    prs: msg.prs,
+                    repos: msg.repos,
+                    authors: msg.authors,
+                    settings: msg.settings,
                 });
+            }
+            ServerEvent::SettingsUpdated(msg) => {
+                cx.emit(DaemonEvent::SettingsUpdated {
+                    settings: msg.settings,
+                    changed_key: msg.changed_key,
+                    success: msg.success,
+                    error: msg.error,
+                });
+            }
+            ServerEvent::EndpointsUpdated(msg) => {
+                cx.emit(DaemonEvent::EndpointsUpdated {
+                    endpoints: msg.endpoints,
+                });
+            }
+            ServerEvent::EndpointStatusChanged(msg) => {
+                cx.emit(DaemonEvent::EndpointStatusChanged {
+                    endpoint: msg.endpoint,
+                });
+            }
+            ServerEvent::ReposUpdated(msg) => {
+                cx.emit(DaemonEvent::ReposUpdated { repos: msg.repos });
+            }
+            ServerEvent::AuthorsUpdated(msg) => {
+                cx.emit(DaemonEvent::AuthorsUpdated {
+                    authors: msg.authors,
+                });
+            }
+            ServerEvent::PRsUpdated(msg) => {
+                cx.emit(DaemonEvent::PRsUpdated { prs: msg.prs });
             }
             ServerEvent::SessionRegistered(msg) => {
                 cx.emit(DaemonEvent::SessionRegistered {
@@ -368,6 +428,36 @@ fn record_inbound_event(event: &ServerEvent) {
             "kind": "initial_state",
             "session_count": m.sessions.len(),
             "workspace_count": m.workspaces.len(),
+            "endpoint_count": m.endpoints.len(),
+            "settings_count": m.settings.len(),
+        }),
+        ServerEvent::SettingsUpdated(m) => json!({
+            "kind": "settings_updated",
+            "settings_count": m.settings.len(),
+            "changed_key": m.changed_key.as_deref(),
+            "success": m.success,
+            "error": m.error.as_deref(),
+        }),
+        ServerEvent::EndpointsUpdated(m) => json!({
+            "kind": "endpoints_updated",
+            "endpoint_count": m.endpoints.len(),
+        }),
+        ServerEvent::EndpointStatusChanged(m) => json!({
+            "kind": "endpoint_status_changed",
+            "endpoint_id": m.endpoint.id.as_str(),
+            "status": m.endpoint.status.as_str(),
+        }),
+        ServerEvent::ReposUpdated(m) => json!({
+            "kind": "repos_updated",
+            "repo_count": m.repos.len(),
+        }),
+        ServerEvent::AuthorsUpdated(m) => json!({
+            "kind": "authors_updated",
+            "author_count": m.authors.len(),
+        }),
+        ServerEvent::PRsUpdated(m) => json!({
+            "kind": "prs_updated",
+            "pr_count": m.prs.len(),
         }),
         ServerEvent::SessionRegistered(m) => json!({
             "kind": "session_registered",

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -34,7 +34,7 @@ use crate::state::workspace_registry::{PendingSpawn, UpsertOutcome, WorkspaceReg
 use crate::theme;
 use crate::views::canvas::WorkspaceCanvas;
 use crate::views::location_dialog::{LocationDialog, LocationDialogMode, LocationDialogOutcome};
-use crate::views::settings_page::SettingsPage;
+use crate::views::settings_page::{SettingsPage, SettingsPageState};
 use crate::views::sidebar::Sidebar;
 use crate::views::terminal_view::TerminalView;
 use crate::{OpenSettings, ToggleSidebar};
@@ -60,6 +60,7 @@ pub struct NativeApp {
     canvas: Entity<WorkspaceCanvas>,
     location_dialog: Option<Entity<LocationDialog>>,
     settings_page: Option<Entity<SettingsPage>>,
+    settings_state: SettingsPageState,
     /// True from the moment the location dialog closes until the next
     /// render restores focus to the canvas. Without this hand-off, focus
     /// stays on the dialog's dropped focus handle and global shortcuts
@@ -218,6 +219,11 @@ impl NativeApp {
                 DaemonEvent::InitialState {
                     sessions,
                     workspaces,
+                    endpoints,
+                    prs,
+                    repos,
+                    authors,
+                    settings,
                 } => {
                     events::record(
                         "initial_state_observed",
@@ -226,7 +232,67 @@ impl NativeApp {
                             "workspace_count": workspaces.len(),
                         }),
                     );
+                    this.settings_state = SettingsPageState::from_wire(
+                        settings.clone(),
+                        endpoints.clone(),
+                        prs.clone(),
+                        repos.clone(),
+                        authors.clone(),
+                    );
+                    this.sync_settings_page_state(cx);
                     this.apply_initial_state(sessions.clone(), workspaces.clone(), cx);
+                }
+                DaemonEvent::SettingsUpdated {
+                    settings,
+                    changed_key,
+                    success,
+                    error,
+                } => {
+                    this.settings_state.settings = settings.clone();
+                    if let Some(page) = this.settings_page.clone() {
+                        let changed_key = changed_key.clone();
+                        let error = error.clone();
+                        page.update(cx, |page, cx| {
+                            page.apply_settings_update(
+                                settings.clone(),
+                                changed_key,
+                                *success,
+                                error,
+                                cx,
+                            )
+                        });
+                    }
+                }
+                DaemonEvent::EndpointsUpdated { endpoints } => {
+                    this.settings_state.endpoints = endpoints.clone();
+                    if let Some(page) = this.settings_page.clone() {
+                        page.update(cx, |page, cx| page.apply_endpoints(endpoints.clone(), cx));
+                    }
+                }
+                DaemonEvent::EndpointStatusChanged { endpoint } => {
+                    upsert_endpoint(&mut this.settings_state.endpoints, endpoint.clone());
+                    if let Some(page) = this.settings_page.clone() {
+                        let endpoints = this.settings_state.endpoints.clone();
+                        page.update(cx, |page, cx| page.apply_endpoints(endpoints, cx));
+                    }
+                }
+                DaemonEvent::ReposUpdated { repos } => {
+                    this.settings_state.repos = repos.clone();
+                    if let Some(page) = this.settings_page.clone() {
+                        page.update(cx, |page, cx| page.apply_repos(repos.clone(), cx));
+                    }
+                }
+                DaemonEvent::AuthorsUpdated { authors } => {
+                    this.settings_state.authors = authors.clone();
+                    if let Some(page) = this.settings_page.clone() {
+                        page.update(cx, |page, cx| page.apply_authors(authors.clone(), cx));
+                    }
+                }
+                DaemonEvent::PRsUpdated { prs } => {
+                    this.settings_state.set_prs(prs);
+                    if let Some(page) = this.settings_page.clone() {
+                        page.update(cx, |page, cx| page.apply_prs(prs.clone(), cx));
+                    }
                 }
                 DaemonEvent::WorkspaceRegistered { workspace } => {
                     events::record(
@@ -360,6 +426,7 @@ impl NativeApp {
             canvas,
             location_dialog: None,
             settings_page: None,
+            settings_state: SettingsPageState::default(),
             canvas_needs_refocus: false,
             _canvas_subscription: canvas_subscription,
             _automation: automation_handle,
@@ -455,6 +522,13 @@ impl NativeApp {
         self.settings_page.clone()
     }
 
+    fn sync_settings_page_state(&mut self, cx: &mut Context<Self>) {
+        if let Some(page) = self.settings_page.clone() {
+            let state = self.settings_state.clone();
+            page.update(cx, |page, cx| page.apply_state(state, cx));
+        }
+    }
+
     fn open_session_dialog(
         &mut self,
         workspace_id: SharedString,
@@ -539,6 +613,8 @@ impl NativeApp {
         let app_handle_toggle = app_handle.clone();
         let settings_page = cx.new(|cx| {
             SettingsPage::new(
+                self.daemon.clone(),
+                self.settings_state.clone(),
                 sidebar_collapsed,
                 move |_window, cx| {
                     if let Some(app) = app_handle_close.upgrade() {
@@ -1446,6 +1522,17 @@ fn adjacent_direction_name(direction: AdjacentPanelDirection) -> &'static str {
     match direction {
         AdjacentPanelDirection::Right => "right",
         AdjacentPanelDirection::Bottom => "bottom",
+    }
+}
+
+fn upsert_endpoint(
+    endpoints: &mut Vec<attn_protocol::EndpointInfo>,
+    next: attn_protocol::EndpointInfo,
+) {
+    if let Some(existing) = endpoints.iter_mut().find(|endpoint| endpoint.id == next.id) {
+        *existing = next;
+    } else {
+        endpoints.push(next);
     }
 }
 

--- a/native-ui/crates/attn-native-app/src/views/settings_page.rs
+++ b/native-ui/crates/attn-native-app/src/views/settings_page.rs
@@ -1682,7 +1682,7 @@ fn settings_caret() -> gpui::Div {
     div()
         .w(px(6.0))
         .h(px(15.0))
-        .rounded(px(1.0))
+        .rounded(px(theme::radius::R0))
         .bg(theme::sodium::vapor())
 }
 

--- a/native-ui/crates/attn-native-app/src/views/settings_page.rs
+++ b/native-ui/crates/attn-native-app/src/views/settings_page.rs
@@ -1,18 +1,107 @@
-//! Native Settings surface. Kept small for the MVP: it owns only the
-//! pixels and delegates state mutations back to `NativeApp`.
+//! Native Settings surface. It mirrors the daemon-backed settings exposed
+//! by the Tauri client while keeping native-only canvas controls nearby.
 
-use gpui::{
-    div, hsla, point, prelude::*, px, BoxShadow, Context, FocusHandle, Focusable, KeyDownEvent,
-    MouseButton, ParentElement, Render, SharedString, Window,
+use std::collections::HashSet;
+
+use attn_protocol::{
+    AddEndpointMessage, AuthorState, BootstrapEndpointMessage, EndpointInfo, ListEndpointsMessage,
+    PullRequestSummary, RemoveEndpointMessage, RepoState, SetEndpointRemoteWebMessage,
+    SetSettingMessage, SettingsMap, ToggleAuthorMuteMessage, ToggleRepoMuteMessage,
+    UpdateEndpointMessage,
 };
+use gpui::{
+    div, hsla, point, prelude::*, px, BoxShadow, Context, Entity, FocusHandle, Focusable,
+    FontWeight, KeyDownEvent, MouseButton, ParentElement, Render, SharedString, Window,
+};
+use serde_json::Value;
 
+use crate::adapters::daemon::DaemonClient;
 use crate::theme;
+
+const AGENTS: [&str; 4] = ["claude", "codex", "copilot", "pi"];
+const CAPS: [&str; 8] = [
+    "hooks",
+    "transcript",
+    "transcript_watcher",
+    "classifier",
+    "state_detector",
+    "resume",
+    "fork",
+    "yolo",
+];
 
 type CloseHandler = dyn Fn(&mut Window, &mut gpui::App) + 'static;
 type ToggleSidebarHandler = dyn Fn(&mut Window, &mut gpui::App) -> bool + 'static;
 
+#[derive(Clone, Debug, Default)]
+pub struct SettingsPageState {
+    pub settings: SettingsMap,
+    pub endpoints: Vec<EndpointInfo>,
+    pub connected_hosts: Vec<String>,
+    pub repos: Vec<RepoState>,
+    pub authors: Vec<AuthorState>,
+}
+
+impl SettingsPageState {
+    pub fn from_wire(
+        settings: SettingsMap,
+        endpoints: Vec<EndpointInfo>,
+        prs: Vec<PullRequestSummary>,
+        repos: Vec<RepoState>,
+        authors: Vec<AuthorState>,
+    ) -> Self {
+        Self {
+            settings,
+            endpoints,
+            connected_hosts: connected_hosts_from_prs(&prs),
+            repos,
+            authors,
+        }
+    }
+
+    pub fn set_prs(&mut self, prs: &[PullRequestSummary]) {
+        self.connected_hosts = connected_hosts_from_prs(prs);
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SettingsSection {
+    General,
+    Agents,
+    Review,
+    Network,
+    Filters,
+    System,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum EditableField {
+    Setting(&'static str),
+    AgentExecutable(&'static str),
+    NewEndpointName,
+    NewEndpointTarget,
+    NewEndpointProfile,
+    EditEndpointName(String),
+    EditEndpointTarget(String),
+    EditEndpointProfile(String),
+}
+
 pub struct SettingsPage {
+    daemon: Entity<DaemonClient>,
+    state: SettingsPageState,
     sidebar_collapsed: bool,
+    active_section: SettingsSection,
+    active_field: Option<EditableField>,
+    draft: String,
+    draft_cursor: usize,
+    new_endpoint_name: String,
+    new_endpoint_target: String,
+    new_endpoint_profile: String,
+    editing_endpoint_id: Option<String>,
+    editing_endpoint_name: String,
+    editing_endpoint_target: String,
+    editing_endpoint_profile: String,
+    notice: Option<SharedString>,
     on_close: Box<CloseHandler>,
     on_toggle_sidebar: Box<ToggleSidebarHandler>,
     focus_handle: FocusHandle,
@@ -20,17 +109,83 @@ pub struct SettingsPage {
 
 impl SettingsPage {
     pub fn new(
+        daemon: Entity<DaemonClient>,
+        state: SettingsPageState,
         sidebar_collapsed: bool,
         on_close: impl Fn(&mut Window, &mut gpui::App) + 'static,
         on_toggle_sidebar: impl Fn(&mut Window, &mut gpui::App) -> bool + 'static,
         cx: &mut Context<Self>,
     ) -> Self {
-        Self {
+        let page = Self {
+            daemon,
+            state,
             sidebar_collapsed,
+            active_section: SettingsSection::General,
+            active_field: None,
+            draft: String::new(),
+            draft_cursor: 0,
+            new_endpoint_name: String::new(),
+            new_endpoint_target: String::new(),
+            new_endpoint_profile: String::new(),
+            editing_endpoint_id: None,
+            editing_endpoint_name: String::new(),
+            editing_endpoint_target: String::new(),
+            editing_endpoint_profile: String::new(),
+            notice: None,
             on_close: Box::new(on_close),
             on_toggle_sidebar: Box::new(on_toggle_sidebar),
             focus_handle: cx.focus_handle(),
-        }
+        };
+        page.request_fresh_state(cx);
+        page
+    }
+
+    pub fn apply_state(&mut self, state: SettingsPageState, cx: &mut Context<Self>) {
+        self.state = state;
+        cx.notify();
+    }
+
+    pub fn apply_settings_update(
+        &mut self,
+        settings: SettingsMap,
+        changed_key: Option<String>,
+        success: Option<bool>,
+        error: Option<String>,
+        cx: &mut Context<Self>,
+    ) {
+        self.state.settings = settings;
+        self.notice = match (success, error) {
+            (Some(false), Some(error)) => Some(SharedString::from(error)),
+            (Some(true), _) => changed_key.map(|key| SharedString::from(format!("Saved {key}"))),
+            _ => None,
+        };
+        cx.notify();
+    }
+
+    pub fn apply_endpoints(&mut self, endpoints: Vec<EndpointInfo>, cx: &mut Context<Self>) {
+        self.state.endpoints = endpoints;
+        cx.notify();
+    }
+
+    pub fn apply_prs(&mut self, prs: Vec<PullRequestSummary>, cx: &mut Context<Self>) {
+        self.state.connected_hosts = connected_hosts_from_prs(&prs);
+        cx.notify();
+    }
+
+    pub fn apply_repos(&mut self, repos: Vec<RepoState>, cx: &mut Context<Self>) {
+        self.state.repos = repos;
+        cx.notify();
+    }
+
+    pub fn apply_authors(&mut self, authors: Vec<AuthorState>, cx: &mut Context<Self>) {
+        self.state.authors = authors;
+        cx.notify();
+    }
+
+    fn request_fresh_state(&self, cx: &mut Context<Self>) {
+        let daemon = self.daemon.read(cx);
+        let _ = daemon.send_cmd(&attn_protocol::GetSettingsMessage::new());
+        let _ = daemon.send_cmd(&ListEndpointsMessage::new());
     }
 
     fn close(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -54,17 +209,269 @@ impl SettingsPage {
         self.toggle_sidebar(window, cx);
     }
 
-    fn on_key_down(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
-        match event.keystroke.key.as_str() {
-            "escape" => {
-                cx.stop_propagation();
-                self.close(window, cx);
+    pub fn select_section_for_automation(
+        &mut self,
+        section: &str,
+        cx: &mut Context<Self>,
+    ) -> Result<(), String> {
+        self.active_section = section_from_name(section)
+            .ok_or_else(|| format!("unknown settings section: {section}"))?;
+        self.active_field = None;
+        self.draft.clear();
+        self.draft_cursor = 0;
+        cx.notify();
+        Ok(())
+    }
+
+    fn set_section(&mut self, section: SettingsSection, cx: &mut Context<Self>) {
+        self.active_section = section;
+        self.active_field = None;
+        self.draft.clear();
+        self.draft_cursor = 0;
+        self.notice = None;
+        cx.notify();
+    }
+
+    fn focus_field(&mut self, field: EditableField, cx: &mut Context<Self>) {
+        self.active_field = Some(field.clone());
+        self.draft = self.field_value(&field);
+        self.draft_cursor = self.draft.len();
+        self.notice = None;
+        cx.notify();
+    }
+
+    fn field_value(&self, field: &EditableField) -> String {
+        match field {
+            EditableField::Setting(key) => setting(&self.state.settings, key).to_string(),
+            EditableField::AgentExecutable(agent) => {
+                setting(&self.state.settings, &format!("{agent}_executable")).to_string()
             }
-            "b" if event.keystroke.modifiers.platform => {
-                cx.stop_propagation();
-                self.toggle_sidebar(window, cx);
+            EditableField::NewEndpointName => self.new_endpoint_name.clone(),
+            EditableField::NewEndpointTarget => self.new_endpoint_target.clone(),
+            EditableField::NewEndpointProfile => self.new_endpoint_profile.clone(),
+            EditableField::EditEndpointName(_) => self.editing_endpoint_name.clone(),
+            EditableField::EditEndpointTarget(_) => self.editing_endpoint_target.clone(),
+            EditableField::EditEndpointProfile(_) => self.editing_endpoint_profile.clone(),
+        }
+    }
+
+    fn write_draft_to_active_field(&mut self) {
+        match self.active_field {
+            Some(EditableField::NewEndpointName) => self.new_endpoint_name = self.draft.clone(),
+            Some(EditableField::NewEndpointTarget) => self.new_endpoint_target = self.draft.clone(),
+            Some(EditableField::NewEndpointProfile) => {
+                self.new_endpoint_profile = self.draft.clone()
+            }
+            Some(EditableField::EditEndpointName(_)) => {
+                self.editing_endpoint_name = self.draft.clone()
+            }
+            Some(EditableField::EditEndpointTarget(_)) => {
+                self.editing_endpoint_target = self.draft.clone()
+            }
+            Some(EditableField::EditEndpointProfile(_)) => {
+                self.editing_endpoint_profile = self.draft.clone()
             }
             _ => {}
+        }
+    }
+
+    fn set_setting(
+        &mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+        cx: &mut Context<Self>,
+    ) {
+        let key = key.into();
+        let value = value.into();
+        match self
+            .daemon
+            .read(cx)
+            .send_cmd(&SetSettingMessage::new(key.clone(), value.clone()))
+        {
+            Ok(()) => {
+                self.state.settings.insert(key, value);
+                self.notice = Some(SharedString::from("Saving"));
+            }
+            Err(error) => self.notice = Some(SharedString::from(error)),
+        }
+        cx.notify();
+    }
+
+    fn commit_active_field(&mut self, cx: &mut Context<Self>) {
+        let Some(field) = self.active_field.clone() else {
+            return;
+        };
+        match field {
+            EditableField::Setting(key) => self.set_setting(key, self.draft.trim().to_string(), cx),
+            EditableField::AgentExecutable(agent) => self.set_setting(
+                format!("{agent}_executable"),
+                self.draft.trim().to_string(),
+                cx,
+            ),
+            EditableField::NewEndpointName
+            | EditableField::NewEndpointTarget
+            | EditableField::NewEndpointProfile
+            | EditableField::EditEndpointName(_)
+            | EditableField::EditEndpointTarget(_)
+            | EditableField::EditEndpointProfile(_) => {}
+        }
+    }
+
+    fn send_cmd<T: serde::Serialize>(&mut self, msg: &T, label: &str, cx: &mut Context<Self>) {
+        self.notice = match self.daemon.read(cx).send_cmd(msg) {
+            Ok(()) => Some(SharedString::from(label.to_string())),
+            Err(error) => Some(SharedString::from(error)),
+        };
+        cx.notify();
+    }
+
+    fn add_endpoint(&mut self, cx: &mut Context<Self>) {
+        self.write_draft_to_active_field();
+        if self.new_endpoint_name.trim().is_empty() || self.new_endpoint_target.trim().is_empty() {
+            self.notice = Some(SharedString::from(
+                "Endpoint name and SSH target are required",
+            ));
+            cx.notify();
+            return;
+        }
+        let name = self.new_endpoint_name.trim().to_string();
+        let target = self.new_endpoint_target.trim().to_string();
+        let profile = self.new_endpoint_profile.trim().to_string();
+        self.send_cmd(
+            &AddEndpointMessage::new(name, target, profile),
+            "Adding endpoint",
+            cx,
+        );
+        self.new_endpoint_name.clear();
+        self.new_endpoint_target.clear();
+        self.new_endpoint_profile.clear();
+    }
+
+    fn begin_edit_endpoint(&mut self, endpoint: EndpointInfo, cx: &mut Context<Self>) {
+        self.editing_endpoint_id = Some(endpoint.id);
+        self.editing_endpoint_name = endpoint.name;
+        self.editing_endpoint_target = endpoint.ssh_target;
+        self.editing_endpoint_profile = endpoint.profile.unwrap_or_default();
+        self.active_field = None;
+        self.draft.clear();
+        self.draft_cursor = 0;
+        self.notice = None;
+        cx.notify();
+    }
+
+    fn cancel_edit_endpoint(&mut self, cx: &mut Context<Self>) {
+        self.editing_endpoint_id = None;
+        self.editing_endpoint_name.clear();
+        self.editing_endpoint_target.clear();
+        self.editing_endpoint_profile.clear();
+        self.active_field = None;
+        self.draft.clear();
+        self.draft_cursor = 0;
+        cx.notify();
+    }
+
+    fn save_edit_endpoint(&mut self, endpoint_id: String, cx: &mut Context<Self>) {
+        self.write_draft_to_active_field();
+        if self.editing_endpoint_name.trim().is_empty()
+            || self.editing_endpoint_target.trim().is_empty()
+        {
+            self.notice = Some(SharedString::from(
+                "Endpoint name and SSH target are required",
+            ));
+            cx.notify();
+            return;
+        }
+        let msg = UpdateEndpointMessage {
+            cmd: "update_endpoint",
+            endpoint_id,
+            name: Some(self.editing_endpoint_name.trim().to_string()),
+            ssh_target: Some(self.editing_endpoint_target.trim().to_string()),
+            enabled: None,
+            profile: Some(self.editing_endpoint_profile.trim().to_string()),
+        };
+        self.send_cmd(&msg, "Saving endpoint", cx);
+        self.cancel_edit_endpoint(cx);
+    }
+
+    fn on_key_down(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
+        cx.stop_propagation();
+        if self.active_field.is_some() {
+            self.on_text_field_key_down(event, cx);
+            return;
+        }
+
+        match event.keystroke.key.as_str() {
+            "escape" => self.close(window, cx),
+            "b" if event.keystroke.modifiers.platform => self.toggle_sidebar(window, cx),
+            "1" => self.set_section(SettingsSection::General, cx),
+            "2" => self.set_section(SettingsSection::Agents, cx),
+            "3" => self.set_section(SettingsSection::Review, cx),
+            "4" => self.set_section(SettingsSection::Network, cx),
+            "5" => self.set_section(SettingsSection::Filters, cx),
+            "6" => self.set_section(SettingsSection::System, cx),
+            _ => {}
+        }
+    }
+
+    fn on_text_field_key_down(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) {
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                self.active_field = None;
+                self.draft.clear();
+                self.draft_cursor = 0;
+                cx.notify();
+            }
+            "enter" => {
+                self.write_draft_to_active_field();
+                self.commit_active_field(cx);
+                self.active_field = None;
+                self.draft.clear();
+                self.draft_cursor = 0;
+                cx.notify();
+            }
+            "backspace" => {
+                if backspace_at_cursor(&mut self.draft, &mut self.draft_cursor) {
+                    self.write_draft_to_active_field();
+                    cx.notify();
+                }
+            }
+            "delete" => {
+                if delete_at_cursor(&mut self.draft, &mut self.draft_cursor) {
+                    self.write_draft_to_active_field();
+                    cx.notify();
+                }
+            }
+            "left" => {
+                self.draft_cursor = previous_char_boundary(&self.draft, self.draft_cursor);
+                cx.notify();
+            }
+            "right" => {
+                self.draft_cursor = next_char_boundary(&self.draft, self.draft_cursor);
+                cx.notify();
+            }
+            "home" => {
+                self.draft_cursor = 0;
+                cx.notify();
+            }
+            "end" => {
+                self.draft_cursor = self.draft.len();
+                cx.notify();
+            }
+            _ => {
+                if event.keystroke.modifiers.platform
+                    || event.keystroke.modifiers.control
+                    || event.keystroke.modifiers.alt
+                {
+                    return;
+                }
+                if let Some(key_char) = &event.keystroke.key_char {
+                    if !key_char.is_empty() {
+                        insert_at_cursor(&mut self.draft, &mut self.draft_cursor, key_char);
+                        self.write_draft_to_active_field();
+                        cx.notify();
+                    }
+                }
+            }
         }
     }
 }
@@ -81,8 +488,18 @@ impl Render for SettingsPage {
             self.focus_handle.focus(window);
         }
 
+        let content = match self.active_section {
+            SettingsSection::General => self.render_general(cx),
+            SettingsSection::Agents => self.render_agents(cx),
+            SettingsSection::Review => self.render_review(cx),
+            SettingsSection::Network => self.render_network(cx),
+            SettingsSection::Filters => self.render_filters(cx),
+            SettingsSection::System => self.render_system(cx),
+        };
+
         let panel = div()
-            .w(px(760.0))
+            .w(px(980.0))
+            .h(px(700.0))
             .rounded(px(theme::radius::R2))
             .bg(theme::ink::nocturne())
             .border_1()
@@ -90,41 +507,40 @@ impl Render for SettingsPage {
             .overflow_hidden()
             .shadow(vec![
                 BoxShadow {
-                    color: hsla(0.0, 0.0, 0.0, 0.56),
-                    offset: point(px(0.0), px(24.0)),
-                    blur_radius: px(60.0),
+                    color: hsla(0.0, 0.0, 0.0, 0.60),
+                    offset: point(px(0.0), px(28.0)),
+                    blur_radius: px(70.0),
                     spread_radius: px(-8.0),
                 },
                 BoxShadow {
-                    color: hsla(0.0, 0.0, 0.0, 0.35),
-                    offset: point(px(0.0), px(2.0)),
-                    blur_radius: px(8.0),
-                    spread_radius: px(0.0),
+                    color: theme::sodium::soft().into(),
+                    offset: point(px(0.0), px(0.0)),
+                    blur_radius: px(0.0),
+                    spread_radius: px(1.0),
                 },
             ])
             .track_focus(&self.focus_handle)
             .on_key_down(cx.listener(Self::on_key_down))
-            .child(settings_header().child(close_button().on_mouse_down(
-                MouseButton::Left,
-                cx.listener(|this, _, window, cx| {
-                    cx.stop_propagation();
-                    this.close(window, cx);
-                }),
-            )))
+            .flex()
+            .child(self.render_nav(cx))
             .child(
                 div()
-                    .px_6()
-                    .py_6()
-                    .min_h(px(320.0))
+                    .flex_1()
+                    .min_w(px(0.0))
+                    .h_full()
                     .flex()
                     .flex_col()
-                    .child(interface_card(self.sidebar_collapsed).on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(|this, _, window, cx| {
-                            cx.stop_propagation();
-                            this.toggle_sidebar(window, cx);
-                        }),
-                    )),
+                    .child(header_bar(section_title(self.active_section)).child(
+                        close_button().on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _, window, cx| {
+                                cx.stop_propagation();
+                                this.close(window, cx);
+                            }),
+                        ),
+                    ))
+                    .child(content)
+                    .child(self.render_footer()),
             );
 
         div()
@@ -145,11 +561,919 @@ impl Render for SettingsPage {
     }
 }
 
-fn settings_header() -> gpui::Div {
+impl SettingsPage {
+    fn render_nav(&self, cx: &mut Context<Self>) -> gpui::Div {
+        let mut nav = div()
+            .w(px(188.0))
+            .h_full()
+            .bg(theme::ink::void())
+            .border_r_1()
+            .border_color(theme::line::weak())
+            .p_4()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_1()
+                    .child(
+                        div()
+                            .text_size(px(10.0))
+                            .text_color(theme::sodium::vapor())
+                            .font_weight(FontWeight::MEDIUM)
+                            .child(SharedString::from("ATTN")),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(19.0))
+                            .text_color(theme::moon::moonstone())
+                            .font_weight(FontWeight::MEDIUM)
+                            .child(SharedString::from("Orchestrator")),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(10.0))
+                            .text_color(theme::moon::ash())
+                            .child(SharedString::from("Settings")),
+                    ),
+            )
+            .child(div().h(px(1.0)).w_full().bg(theme::line::weak()));
+
+        for section in [
+            SettingsSection::General,
+            SettingsSection::Agents,
+            SettingsSection::Review,
+            SettingsSection::Network,
+            SettingsSection::Filters,
+            SettingsSection::System,
+        ] {
+            nav = nav.child(
+                nav_item(section, self.active_section == section).on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.set_section(section, cx);
+                    }),
+                ),
+            );
+        }
+
+        nav.child(div().flex_1()).child(summary_strip(&self.state))
+    }
+
+    fn render_general(&self, cx: &mut Context<Self>) -> gpui::Div {
+        let theme_value = setting(&self.state.settings, "theme");
+        let scale_value = setting(&self.state.settings, "uiScale");
+        let scale = if scale_value.is_empty() {
+            "1.0"
+        } else {
+            scale_value
+        };
+        div()
+            .flex_1()
+            .p_5()
+            .flex()
+            .gap_4()
+            .child(
+                div()
+                    .flex_1()
+                    .flex()
+                    .flex_col()
+                    .gap_4()
+                    .child(
+                        card("Appearance", "Shared with the Tauri client")
+                            .child(segment_row(
+                                &["dark", "light", "system"],
+                                if theme_value.is_empty() {
+                                    "dark"
+                                } else {
+                                    theme_value
+                                },
+                                "theme",
+                                cx,
+                            ))
+                            .child(segment_row(
+                                &["0.8", "1.0", "1.2", "1.5"],
+                                scale,
+                                "uiScale",
+                                cx,
+                            )),
+                    )
+                    .child(
+                        card("Projects", "Where PR worktrees and repositories live").child(
+                            self.setting_text_field(
+                                "Projects directory",
+                                EditableField::Setting("projects_directory"),
+                                "Absolute path. Daemon creates it if needed.",
+                                cx,
+                            ),
+                        ),
+                    )
+                    .child(
+                        card("Native canvas", "Client-specific layout controls").child(
+                            sidebar_mode_control(self.sidebar_collapsed).on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, window, cx| {
+                                    cx.stop_propagation();
+                                    this.toggle_sidebar(window, cx);
+                                }),
+                            ),
+                        ),
+                    ),
+            )
+            .child(sidebar_preview(self.sidebar_collapsed))
+    }
+
+    fn render_agents(&self, cx: &mut Context<Self>) -> gpui::Div {
+        let default_agent = setting(&self.state.settings, "new_session_agent");
+        let active_agent = if default_agent.is_empty() {
+            "claude"
+        } else {
+            default_agent
+        };
+        let mut body = div().flex_1().p_5().flex().gap_4();
+        let mut left = div().flex_1().flex().flex_col().gap_4().child(
+            card(
+                "Default session agent",
+                "Used when creating new sessions and opening PRs",
+            )
+            .child(agent_segment_row(active_agent, &self.state.settings, cx)),
+        );
+
+        let mut exec_card = card(
+            "Executables",
+            "Override launch commands. Empty uses PATH defaults",
+        );
+        for agent in AGENTS {
+            exec_card = exec_card.child(self.setting_text_field(
+                agent_label(agent),
+                EditableField::AgentExecutable(agent),
+                availability_label(agent, &self.state.settings),
+                cx,
+            ));
+        }
+        exec_card = exec_card.child(self.setting_text_field(
+            "Editor",
+            EditableField::Setting("editor_executable"),
+            "Command used when opening files from reviews",
+            cx,
+        ));
+        left = left.child(exec_card);
+
+        let mut caps = card(
+            "Capabilities",
+            "Effective integration support reported by daemon",
+        );
+        for agent in AGENTS {
+            caps = caps.child(capability_row(agent, &self.state.settings));
+        }
+        body = body.child(left).child(div().w(px(300.0)).child(caps));
+        body
+    }
+
+    fn render_review(&self, cx: &mut Context<Self>) -> gpui::Div {
+        let presets =
+            review_preset_names(setting(&self.state.settings, "review_loop_prompt_presets"));
+        let mut preset_card = card(
+            "Review loop prompts",
+            "Saved custom prompts used by loop controls",
+        )
+        .child(metric_row("Saved prompts", presets.len().to_string()));
+        if presets.is_empty() {
+            preset_card = preset_card.child(empty_row("No saved custom prompts"));
+        } else {
+            for name in presets.into_iter().take(5) {
+                preset_card = preset_card.child(token_row(&name, "preset"));
+            }
+        }
+
+        div()
+            .flex_1()
+            .p_5()
+            .flex()
+            .gap_4()
+            .child(
+                div()
+                    .flex_1()
+                    .flex()
+                    .flex_col()
+                    .gap_4()
+                    .child(
+                        card("Review models", "Claude SDK model overrides")
+                            .child(self.setting_text_field(
+                                "Review loop model",
+                                EditableField::Setting("review_loop_model"),
+                                "Empty uses the built-in default",
+                                cx,
+                            ))
+                            .child(self.setting_text_field(
+                                "Reviewer model",
+                                EditableField::Setting("reviewer_model"),
+                                "Empty uses the built-in default",
+                                cx,
+                            )),
+                    )
+                    .child(preset_card),
+            )
+            .child(
+                div().w(px(340.0)).child(
+                    card("Preset data", "Raw JSON setting for full parity")
+                        .child(self.setting_text_field(
+                            "review_loop_prompt_presets",
+                            EditableField::Setting("review_loop_prompt_presets"),
+                            "Enter saves the raw preset payload",
+                            cx,
+                        ))
+                        .child(self.setting_text_field(
+                            "Last preset",
+                            EditableField::Setting("review_loop_last_preset"),
+                            "Most recently used prompt preset",
+                            cx,
+                        ))
+                        .child(self.setting_text_field(
+                            "Last iterations",
+                            EditableField::Setting("review_loop_last_iterations"),
+                            "Stored loop iteration count",
+                            cx,
+                        )),
+                ),
+            )
+    }
+
+    fn render_network(&self, cx: &mut Context<Self>) -> gpui::Div {
+        let tailscale_enabled = setting(&self.state.settings, "tailscale_enabled") == "true";
+        let mut mobile = card(
+            "Mobile web client",
+            "Expose this daemon through Tailscale Serve",
+        )
+        .child(toggle_row(
+            "Tailscale Serve",
+            if tailscale_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            tailscale_enabled,
+            "tailscale_enabled",
+            cx,
+        ))
+        .child(metric_row(
+            "Status",
+            nonempty(
+                setting(&self.state.settings, "tailscale_status"),
+                "disabled",
+            ),
+        ));
+        for (label, key) in [
+            ("Device DNS", "tailscale_domain"),
+            ("Web URL", "tailscale_url"),
+            ("Auth URL", "tailscale_auth_url"),
+            ("Error", "tailscale_error"),
+        ] {
+            let value = setting(&self.state.settings, key);
+            if !value.is_empty() {
+                mobile = mobile.child(metric_row(label, value));
+            }
+        }
+
+        let mut endpoints = card(
+            "Remote endpoints",
+            "SSH peers the local daemon keeps connected",
+        )
+        .child(self.endpoint_field("Name", EditableField::NewEndpointName, cx))
+        .child(self.endpoint_field("SSH target", EditableField::NewEndpointTarget, cx))
+        .child(self.endpoint_field("Profile", EditableField::NewEndpointProfile, cx))
+        .child(action_button("Add endpoint").on_mouse_down(
+            MouseButton::Left,
+            cx.listener(|this, _, _, cx| {
+                cx.stop_propagation();
+                this.add_endpoint(cx);
+            }),
+        ));
+
+        if self.state.endpoints.is_empty() {
+            endpoints = endpoints.child(empty_row("No remote endpoints configured"));
+        } else {
+            for endpoint in &self.state.endpoints {
+                endpoints = endpoints.child(self.render_endpoint_card(endpoint, cx));
+            }
+        }
+
+        let mut hosts = card("GitHub hosts", "Detected from authenticated pull requests");
+        if self.state.connected_hosts.is_empty() {
+            hosts = hosts.child(empty_row("No authenticated hosts detected"));
+        } else {
+            for host in &self.state.connected_hosts {
+                hosts = hosts.child(token_row(host, "host"));
+            }
+        }
+
+        div()
+            .flex_1()
+            .p_5()
+            .flex()
+            .gap_4()
+            .child(
+                div()
+                    .flex_1()
+                    .flex()
+                    .flex_col()
+                    .gap_4()
+                    .child(mobile)
+                    .child(hosts),
+            )
+            .child(div().w(px(430.0)).child(endpoints))
+    }
+
+    fn render_filters(&self, cx: &mut Context<Self>) -> gpui::Div {
+        let muted_repos: Vec<_> = self.state.repos.iter().filter(|repo| repo.muted).collect();
+        let muted_authors: Vec<_> = self
+            .state
+            .authors
+            .iter()
+            .filter(|author| author.muted)
+            .collect();
+
+        let mut repos = card("Muted repositories", "Hidden from attention queues");
+        if muted_repos.is_empty() {
+            repos = repos.child(empty_row("No muted repositories"));
+        } else {
+            for repo in muted_repos {
+                let name = repo.repo.clone();
+                repos = repos.child(filter_row(&repo.repo, "repo").on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.send_cmd(
+                            &ToggleRepoMuteMessage::new(name.clone()),
+                            "Unmuting repo",
+                            cx,
+                        );
+                    }),
+                ));
+            }
+        }
+
+        let mut authors = card("Muted authors", "Bot and author filters");
+        if muted_authors.is_empty() {
+            authors = authors.child(empty_row("No muted authors"));
+        } else {
+            for author in muted_authors {
+                let name = author.author.clone();
+                authors = authors.child(filter_row(&author.author, "author").on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.send_cmd(
+                            &ToggleAuthorMuteMessage::new(name.clone()),
+                            "Unmuting author",
+                            cx,
+                        );
+                    }),
+                ));
+            }
+        }
+
+        div()
+            .flex_1()
+            .p_5()
+            .flex()
+            .gap_4()
+            .child(div().flex_1().child(repos))
+            .child(div().flex_1().child(authors))
+    }
+
+    fn render_system(&self, _cx: &mut Context<Self>) -> gpui::Div {
+        let pty = setting(&self.state.settings, "pty_backend_mode");
+        let pty_label = match pty {
+            "worker" => "External worker sidecar",
+            "embedded" => "Embedded in daemon",
+            _ => "Unknown",
+        };
+        let mut card_el = card("Runtime", "Low-level orchestration state")
+            .child(metric_row("PTY backend", pty_label))
+            .child(metric_row(
+                "Endpoint count",
+                self.state.endpoints.len().to_string(),
+            ))
+            .child(metric_row(
+                "Connected hosts",
+                self.state.connected_hosts.len().to_string(),
+            ))
+            .child(metric_row(
+                "Settings loaded",
+                self.state.settings.len().to_string(),
+            ));
+
+        if let Some(notice) = &self.notice {
+            card_el = card_el.child(status_row(notice.as_ref()));
+        }
+
+        div()
+            .flex_1()
+            .p_5()
+            .flex()
+            .gap_4()
+            .child(div().flex_1().child(card_el))
+            .child(
+                div().w(px(360.0)).child(
+                    card("Keyboard", "Native settings shortcuts")
+                        .child(metric_row("Open settings", "Cmd+,"))
+                        .child(metric_row("Toggle sidebar", "Cmd+B"))
+                        .child(metric_row("Save field", "Enter"))
+                        .child(metric_row("Close", "Esc")),
+                ),
+            )
+    }
+
+    fn render_footer(&self) -> gpui::Div {
+        let text = self
+            .notice
+            .as_ref()
+            .map(|notice| notice.to_string())
+            .unwrap_or_else(|| {
+                if self.active_field.is_some() {
+                    "Editing field - Enter saves, Esc cancels".to_string()
+                } else {
+                    "1-6 switch sections, Cmd+B toggles sidebar, Esc closes".to_string()
+                }
+            });
+        div()
+            .h(px(34.0))
+            .px_5()
+            .border_t_1()
+            .border_color(theme::line::weak())
+            .bg(theme::ink::void())
+            .flex()
+            .items_center()
+            .justify_between()
+            .child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(if self.notice.is_some() {
+                        theme::sodium::vapor()
+                    } else {
+                        theme::moon::ash()
+                    })
+                    .child(SharedString::from(text)),
+            )
+            .child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(theme::moon::ash())
+                    .child(SharedString::from("daemon-backed")),
+            )
+    }
+
+    fn setting_text_field(
+        &self,
+        label: &'static str,
+        field: EditableField,
+        hint: impl Into<String>,
+        cx: &mut Context<Self>,
+    ) -> gpui::Div {
+        let value = if self.active_field.as_ref() == Some(&field) {
+            self.draft.clone()
+        } else {
+            self.field_value(&field)
+        };
+        text_field(
+            label,
+            value,
+            hint.into(),
+            (self.active_field.as_ref() == Some(&field)).then_some(self.draft_cursor),
+        )
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _, _, cx| {
+                cx.stop_propagation();
+                this.focus_field(field.clone(), cx);
+            }),
+        )
+    }
+
+    fn endpoint_field(
+        &self,
+        label: &'static str,
+        field: EditableField,
+        cx: &mut Context<Self>,
+    ) -> gpui::Div {
+        let value = if self.active_field.as_ref() == Some(&field) {
+            self.draft.clone()
+        } else {
+            self.field_value(&field)
+        };
+        text_field(
+            label,
+            value,
+            "New endpoint".to_string(),
+            (self.active_field.as_ref() == Some(&field)).then_some(self.draft_cursor),
+        )
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _, _, cx| {
+                cx.stop_propagation();
+                this.focus_field(field.clone(), cx);
+            }),
+        )
+    }
+
+    fn edit_endpoint_field(
+        &self,
+        label: &'static str,
+        field: EditableField,
+        cx: &mut Context<Self>,
+    ) -> gpui::Div {
+        let value = if self.active_field.as_ref() == Some(&field) {
+            self.draft.clone()
+        } else {
+            self.field_value(&field)
+        };
+        text_field(
+            label,
+            value,
+            "Editing endpoint".to_string(),
+            (self.active_field.as_ref() == Some(&field)).then_some(self.draft_cursor),
+        )
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _, _, cx| {
+                cx.stop_propagation();
+                this.focus_field(field.clone(), cx);
+            }),
+        )
+    }
+
+    fn render_endpoint_card(
+        &self,
+        endpoint: &EndpointInfo,
+        cx: &mut Context<SettingsPage>,
+    ) -> gpui::Div {
+        let endpoint_id = endpoint.id.clone();
+        let endpoint_id_enable = endpoint.id.clone();
+        let endpoint_id_bootstrap = endpoint.id.clone();
+        let endpoint_id_remove = endpoint.id.clone();
+        let endpoint_id_edit = endpoint.id.clone();
+        let endpoint_for_edit = endpoint.clone();
+        let enabled = endpoint.enabled.unwrap_or(true);
+        let remote_web = endpoint
+            .capabilities
+            .as_ref()
+            .and_then(|caps| caps.tailscale_enabled)
+            .unwrap_or(false);
+        let editing = self.editing_endpoint_id.as_deref() == Some(endpoint.id.as_str());
+
+        let mut card = div()
+            .rounded(px(theme::radius::R0))
+            .bg(theme::ink::midnight())
+            .border_1()
+            .border_color(if editing {
+                theme::sodium::deep()
+            } else {
+                theme::line::weak()
+            })
+            .p_3()
+            .flex()
+            .flex_col()
+            .gap_2()
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .gap_3()
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w(px(0.0))
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .child(
+                                div()
+                                    .truncate()
+                                    .text_size(px(12.0))
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(theme::moon::moonstone())
+                                    .child(SharedString::from(endpoint.name.clone())),
+                            )
+                            .child(
+                                div()
+                                    .truncate()
+                                    .text_size(px(10.0))
+                                    .text_color(theme::moon::ash())
+                                    .child(SharedString::from(endpoint.ssh_target.clone())),
+                            ),
+                    )
+                    .child(status_chip(&endpoint.status)),
+            );
+
+        if editing {
+            return card
+                .child(self.edit_endpoint_field(
+                    "Name",
+                    EditableField::EditEndpointName(endpoint.id.clone()),
+                    cx,
+                ))
+                .child(self.edit_endpoint_field(
+                    "SSH target",
+                    EditableField::EditEndpointTarget(endpoint.id.clone()),
+                    cx,
+                ))
+                .child(self.edit_endpoint_field(
+                    "Profile",
+                    EditableField::EditEndpointProfile(endpoint.id.clone()),
+                    cx,
+                ))
+                .child(
+                    div()
+                        .flex()
+                        .gap_2()
+                        .child(endpoint_action("Save").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| {
+                                cx.stop_propagation();
+                                this.save_edit_endpoint(endpoint_id_edit.clone(), cx);
+                            }),
+                        ))
+                        .child(endpoint_action("Cancel").on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _, _, cx| {
+                                cx.stop_propagation();
+                                this.cancel_edit_endpoint(cx);
+                            }),
+                        )),
+                );
+        }
+
+        card = card
+            .child(metric_row(
+                "profile",
+                endpoint.profile.as_deref().unwrap_or("default"),
+            ))
+            .child(metric_row(
+                "sessions",
+                endpoint.session_count.unwrap_or_default().to_string(),
+            ));
+        if let Some(caps) = &endpoint.capabilities {
+            card = card
+                .child(metric_row("protocol", caps.protocol_version.clone()))
+                .child(metric_row(
+                    "remote web",
+                    caps.tailscale_status.as_deref().unwrap_or(if remote_web {
+                        "enabled"
+                    } else {
+                        "disabled"
+                    }),
+                ));
+            if let Some(url) = &caps.tailscale_url {
+                card = card.child(metric_row("url", url.clone()));
+            }
+        }
+
+        card.child(
+            div()
+                .flex()
+                .gap_2()
+                .child(endpoint_action("Edit").on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.begin_edit_endpoint(endpoint_for_edit.clone(), cx);
+                    }),
+                ))
+                .child(
+                    endpoint_action(if enabled { "Disable" } else { "Enable" }).on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _, _, cx| {
+                            cx.stop_propagation();
+                            this.send_cmd(
+                                &UpdateEndpointMessage::enabled(
+                                    endpoint_id_enable.clone(),
+                                    !enabled,
+                                ),
+                                "Updating endpoint",
+                                cx,
+                            );
+                        }),
+                    ),
+                )
+                .child(endpoint_action("Bootstrap").on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.send_cmd(
+                            &BootstrapEndpointMessage::new(endpoint_id_bootstrap.clone()),
+                            "Bootstrapping endpoint",
+                            cx,
+                        );
+                    }),
+                ))
+                .child(
+                    endpoint_action(if remote_web { "Web off" } else { "Web on" }).on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _, _, cx| {
+                            cx.stop_propagation();
+                            this.send_cmd(
+                                &SetEndpointRemoteWebMessage::new(endpoint_id.clone(), !remote_web),
+                                "Updating web access",
+                                cx,
+                            );
+                        }),
+                    ),
+                )
+                .child(endpoint_action("Remove").on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.send_cmd(
+                            &RemoveEndpointMessage::new(endpoint_id_remove.clone()),
+                            "Removing endpoint",
+                            cx,
+                        );
+                    }),
+                )),
+        )
+    }
+}
+
+fn connected_hosts_from_prs(prs: &[PullRequestSummary]) -> Vec<String> {
+    let mut set = HashSet::new();
+    for pr in prs {
+        if let Some(host) = pr.host.as_ref().filter(|host| !host.trim().is_empty()) {
+            set.insert(host.clone());
+        }
+    }
+    let mut hosts: Vec<_> = set.into_iter().collect();
+    hosts.sort();
+    hosts
+}
+
+fn setting<'a>(settings: &'a SettingsMap, key: &str) -> &'a str {
+    settings.get(key).map(String::as_str).unwrap_or("")
+}
+
+fn nonempty<'a>(value: &'a str, fallback: &'a str) -> &'a str {
+    if value.trim().is_empty() {
+        fallback
+    } else {
+        value
+    }
+}
+
+fn clamp_char_boundary(value: &str, index: usize) -> usize {
+    let mut index = index.min(value.len());
+    while index > 0 && !value.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn previous_char_boundary(value: &str, index: usize) -> usize {
+    let index = clamp_char_boundary(value, index);
+    if index == 0 {
+        return 0;
+    }
+    value[..index]
+        .char_indices()
+        .last()
+        .map(|(position, _)| position)
+        .unwrap_or(0)
+}
+
+fn next_char_boundary(value: &str, index: usize) -> usize {
+    let index = clamp_char_boundary(value, index);
+    if index >= value.len() {
+        return value.len();
+    }
+    value[index..]
+        .char_indices()
+        .nth(1)
+        .map(|(offset, _)| index + offset)
+        .unwrap_or(value.len())
+}
+
+fn insert_at_cursor(value: &mut String, cursor: &mut usize, text: &str) {
+    let index = clamp_char_boundary(value, *cursor);
+    value.insert_str(index, text);
+    *cursor = index + text.len();
+}
+
+fn backspace_at_cursor(value: &mut String, cursor: &mut usize) -> bool {
+    let index = clamp_char_boundary(value, *cursor);
+    if index == 0 {
+        *cursor = 0;
+        return false;
+    }
+    let previous = previous_char_boundary(value, index);
+    value.replace_range(previous..index, "");
+    *cursor = previous;
+    true
+}
+
+fn delete_at_cursor(value: &mut String, cursor: &mut usize) -> bool {
+    let index = clamp_char_boundary(value, *cursor);
+    *cursor = index;
+    if index >= value.len() {
+        return false;
+    }
+    let next = next_char_boundary(value, index);
+    value.replace_range(index..next, "");
+    true
+}
+
+fn section_from_name(name: &str) -> Option<SettingsSection> {
+    match name {
+        "general" => Some(SettingsSection::General),
+        "agents" => Some(SettingsSection::Agents),
+        "review" => Some(SettingsSection::Review),
+        "network" => Some(SettingsSection::Network),
+        "filters" => Some(SettingsSection::Filters),
+        "system" => Some(SettingsSection::System),
+        _ => None,
+    }
+}
+
+fn section_title(section: SettingsSection) -> &'static str {
+    match section {
+        SettingsSection::General => "General",
+        SettingsSection::Agents => "Agents",
+        SettingsSection::Review => "Review",
+        SettingsSection::Network => "Network",
+        SettingsSection::Filters => "Filters",
+        SettingsSection::System => "System",
+    }
+}
+
+fn nav_item(section: SettingsSection, active: bool) -> gpui::Div {
+    let label = section_title(section);
+    let mut item = div()
+        .h(px(34.0))
+        .rounded(px(theme::radius::R0))
+        .px_3()
+        .flex()
+        .items_center()
+        .justify_between()
+        .text_size(px(12.0))
+        .text_color(if active {
+            theme::moon::moonstone()
+        } else {
+            theme::moon::ash()
+        })
+        .child(SharedString::from(label));
+    if active {
+        item = item
+            .bg(theme::surface::selected_row())
+            .border_1()
+            .border_color(theme::sodium::deep())
+            .child(
+                div()
+                    .w(px(6.0))
+                    .h(px(6.0))
+                    .rounded_full()
+                    .bg(theme::sodium::vapor()),
+            );
+    }
+    item
+}
+
+fn summary_strip(state: &SettingsPageState) -> gpui::Div {
     div()
-        .w_full()
+        .rounded(px(theme::radius::R1))
+        .bg(theme::ink::shade())
+        .border_1()
+        .border_color(theme::line::weak())
+        .p_3()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .child(summary_line("settings", state.settings.len()))
+        .child(summary_line("endpoints", state.endpoints.len()))
+        .child(summary_line("hosts", state.connected_hosts.len()))
+}
+
+fn summary_line(label: &'static str, count: usize) -> gpui::Div {
+    div()
+        .flex()
+        .items_center()
+        .justify_between()
+        .text_size(px(10.0))
+        .text_color(theme::moon::ash())
+        .child(SharedString::from(label))
+        .child(
+            div()
+                .text_color(theme::moon::bone())
+                .font_weight(FontWeight::MEDIUM)
+                .child(SharedString::from(count.to_string())),
+        )
+}
+
+fn header_bar(title: &'static str) -> gpui::Div {
+    div()
+        .h(px(60.0))
         .px_5()
-        .py_4()
         .border_b_1()
         .border_color(theme::line::weak())
         .bg(theme::ink::shade())
@@ -181,103 +1505,651 @@ fn settings_header() -> gpui::Div {
                         .gap_1()
                         .child(
                             div()
-                                .text_color(theme::moon::moonstone())
                                 .text_size(px(17.0))
-                                .child(SharedString::from("Settings")),
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(theme::moon::moonstone())
+                                .child(SharedString::from(title)),
                         )
                         .child(
                             div()
-                                .text_color(theme::moon::ash())
                                 .text_size(px(10.0))
-                                .child(SharedString::from("Native client")),
+                                .text_color(theme::moon::ash())
+                                .child(SharedString::from("Native client settings")),
                         ),
                 ),
         )
 }
 
-fn interface_card(collapsed: bool) -> gpui::Div {
+fn close_button() -> gpui::Div {
+    div()
+        .w(px(28.0))
+        .h(px(28.0))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(theme::radius::R0))
+        .border_1()
+        .border_color(theme::line::mild())
+        .text_color(theme::moon::bone())
+        .text_size(px(14.0))
+        .child(SharedString::from("x"))
+}
+
+fn card(title: &'static str, subtitle: &'static str) -> gpui::Div {
     div()
         .w_full()
-        .flex_1()
         .rounded(px(theme::radius::R1))
         .bg(theme::ink::shade())
         .border_1()
         .border_color(theme::line::mild())
-        .p_5()
+        .p_4()
+        .flex()
+        .flex_col()
+        .gap_3()
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .gap_1()
+                .child(
+                    div()
+                        .text_size(px(14.0))
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_color(theme::moon::moonstone())
+                        .child(SharedString::from(title)),
+                )
+                .child(
+                    div()
+                        .text_size(px(10.0))
+                        .text_color(theme::moon::ash())
+                        .child(SharedString::from(subtitle)),
+                ),
+        )
+}
+
+fn text_field(
+    label: &'static str,
+    value: String,
+    hint: String,
+    cursor: Option<usize>,
+) -> gpui::Div {
+    let active = cursor.is_some();
+    let placeholder = value.is_empty();
+    let cursor = cursor.map(|index| clamp_char_boundary(&value, index));
+
+    let text_and_caret = div()
+        .flex_1()
+        .min_w(px(0.0))
+        .overflow_hidden()
+        .flex()
+        .items_center()
+        .gap(px(2.0));
+
+    let text_and_caret = if let Some(cursor) = cursor {
+        let (before, after) = value.split_at(cursor);
+        let (before, after) = visible_field_segments(before, after);
+        let mut row = text_and_caret
+            .child(field_text(&before, placeholder && before.is_empty()))
+            .child(settings_caret());
+        if after.is_empty() && placeholder {
+            row = row.child(field_text("type", true));
+        } else {
+            row = row.child(field_text(&after, false));
+        }
+        row
+    } else {
+        text_and_caret.child(field_text(
+            if placeholder { "empty" } else { &value },
+            placeholder,
+        ))
+    };
+
+    let input = div()
+        .h(px(32.0))
+        .rounded(px(theme::radius::R0))
+        .bg(theme::ink::midnight())
+        .border_1()
+        .border_color(if active {
+            theme::sodium::vapor()
+        } else {
+            theme::line::mild()
+        })
+        .px_3()
+        .flex()
+        .items_center()
+        .gap_2()
+        .child(text_and_caret);
+    div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .justify_between()
+                .child(
+                    div()
+                        .text_size(px(10.0))
+                        .text_color(theme::moon::ash())
+                        .child(SharedString::from(label)),
+                )
+                .child(
+                    div()
+                        .text_size(px(9.0))
+                        .text_color(theme::moon::cinder())
+                        .child(SharedString::from(hint)),
+                ),
+        )
+        .child(input)
+}
+
+fn visible_field_segments(before: &str, after: &str) -> (String, String) {
+    let before = if before.chars().count() > 64 {
+        format!("...{}", tail_chars(before, 64))
+    } else {
+        before.to_string()
+    };
+    let after = if after.chars().count() > 32 {
+        format!("{}...", head_chars(after, 32))
+    } else {
+        after.to_string()
+    };
+    (before, after)
+}
+
+fn head_chars(value: &str, count: usize) -> String {
+    value.chars().take(count).collect()
+}
+
+fn tail_chars(value: &str, count: usize) -> String {
+    let chars: Vec<char> = value.chars().rev().take(count).collect();
+    chars.into_iter().rev().collect()
+}
+
+fn field_text(value: &str, placeholder: bool) -> gpui::Div {
+    div()
+        .text_size(px(11.0))
+        .text_color(if placeholder {
+            theme::moon::ash()
+        } else {
+            theme::moon::bone()
+        })
+        .child(SharedString::from(value.to_string()))
+}
+
+fn settings_caret() -> gpui::Div {
+    div()
+        .w(px(6.0))
+        .h(px(15.0))
+        .rounded(px(1.0))
+        .bg(theme::sodium::vapor())
+}
+
+fn segment_row(
+    options: &[&'static str],
+    active: &str,
+    key: &'static str,
+    cx: &mut Context<SettingsPage>,
+) -> gpui::Div {
+    let mut row = div()
+        .rounded(px(theme::radius::R1))
+        .border_1()
+        .border_color(theme::line::mild())
+        .bg(theme::ink::midnight())
+        .p_1()
+        .flex()
+        .items_center()
+        .gap_1();
+    for option in options {
+        let value = *option;
+        row = row.child(mode_segment(value, active == value).on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _, _, cx| {
+                cx.stop_propagation();
+                this.set_setting(key, value, cx);
+            }),
+        ));
+    }
+    row
+}
+
+fn agent_segment_row(
+    active: &str,
+    settings: &SettingsMap,
+    cx: &mut Context<SettingsPage>,
+) -> gpui::Div {
+    let mut row = div()
+        .rounded(px(theme::radius::R1))
+        .border_1()
+        .border_color(theme::line::mild())
+        .bg(theme::ink::midnight())
+        .p_1()
+        .flex()
+        .items_center()
+        .gap_1();
+    for agent in AGENTS {
+        let available = setting(settings, &format!("{agent}_available")) == "true";
+        row = row.child(
+            agent_segment(agent, active == agent, available).on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, _, cx| {
+                    cx.stop_propagation();
+                    if setting(&this.state.settings, &format!("{agent}_available")) == "true" {
+                        this.set_setting("new_session_agent", agent, cx);
+                    }
+                }),
+            ),
+        );
+    }
+    row
+}
+
+fn agent_segment(label: &'static str, active: bool, available: bool) -> gpui::Div {
+    let mut segment = mode_segment(agent_label(label), active);
+    if !available {
+        segment = segment.text_color(theme::moon::cinder());
+    }
+    segment
+}
+
+fn toggle_row(
+    label: &'static str,
+    status: &'static str,
+    active: bool,
+    key: &'static str,
+    cx: &mut Context<SettingsPage>,
+) -> gpui::Div {
+    div()
         .flex()
         .items_center()
         .justify_between()
-        .gap_6()
+        .gap_3()
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .gap_1()
+                .child(
+                    div()
+                        .text_size(px(12.0))
+                        .text_color(theme::moon::bone())
+                        .child(SharedString::from(label)),
+                )
+                .child(
+                    div()
+                        .text_size(px(10.0))
+                        .text_color(theme::moon::ash())
+                        .child(SharedString::from(status)),
+                ),
+        )
+        .child(toggle_pill(active).on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _, _, cx| {
+                cx.stop_propagation();
+                let next = if setting(&this.state.settings, key) == "true" {
+                    "false"
+                } else {
+                    "true"
+                };
+                this.set_setting(key, next, cx);
+            }),
+        ))
+}
+
+fn toggle_pill(active: bool) -> gpui::Div {
+    div()
+        .w(px(54.0))
+        .h(px(26.0))
+        .rounded(px(theme::radius::R1))
+        .bg(if active {
+            theme::sodium::deep()
+        } else {
+            theme::ink::midnight()
+        })
+        .border_1()
+        .border_color(if active {
+            theme::sodium::vapor()
+        } else {
+            theme::line::mild()
+        })
+        .p_1()
+        .flex()
+        .items_center()
+        .justify_end()
+        .when(!active, |el| el.justify_start())
+        .child(div().w(px(18.0)).h(px(18.0)).rounded_full().bg(if active {
+            theme::sodium::vapor()
+        } else {
+            theme::moon::ash()
+        }))
+}
+
+fn mode_segment(label: &'static str, active: bool) -> gpui::Div {
+    let mut segment = div()
+        .h(px(28.0))
+        .px_3()
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(theme::radius::R0))
+        .text_size(px(11.0))
+        .text_color(if active {
+            theme::moon::moonstone()
+        } else {
+            theme::moon::ash()
+        })
+        .child(SharedString::from(label));
+    if active {
+        segment = segment
+            .bg(theme::surface::selected_row())
+            .border_1()
+            .border_color(theme::sodium::deep());
+    }
+    segment
+}
+
+fn action_button(label: &'static str) -> gpui::Div {
+    div()
+        .h(px(30.0))
+        .rounded(px(theme::radius::R0))
+        .bg(theme::sodium::deep())
+        .border_1()
+        .border_color(theme::sodium::vapor())
+        .px_3()
+        .flex()
+        .items_center()
+        .justify_center()
+        .text_size(px(11.0))
+        .text_color(theme::moon::moonstone())
+        .child(SharedString::from(label))
+}
+
+fn metric_row(label: impl Into<String>, value: impl Into<String>) -> gpui::Div {
+    div()
+        .h(px(28.0))
+        .rounded(px(theme::radius::R0))
+        .bg(theme::ink::midnight())
+        .border_1()
+        .border_color(theme::line::weak())
+        .px_3()
+        .flex()
+        .items_center()
+        .justify_between()
+        .gap_3()
+        .child(
+            div()
+                .text_size(px(10.0))
+                .text_color(theme::moon::ash())
+                .child(SharedString::from(label.into())),
+        )
         .child(
             div()
                 .flex_1()
                 .min_w(px(0.0))
-                .flex()
-                .flex_col()
-                .gap_4()
-                .child(
-                    div()
-                        .flex()
-                        .flex_col()
-                        .gap_2()
-                        .child(
-                            div()
-                                .text_color(theme::moon::moonstone())
-                                .text_size(px(16.0))
-                                .child(SharedString::from("Workspace rail")),
-                        )
-                        .child(
-                            div()
-                                .text_color(theme::moon::ash())
-                                .text_size(px(11.0))
-                                .child(SharedString::from(if collapsed {
-                                    "Narrow"
-                                } else {
-                                    "Wide"
-                                })),
-                        ),
-                )
-                .child(sidebar_mode_control(collapsed)),
+                .text_size(px(11.0))
+                .text_color(theme::moon::bone())
+                .truncate()
+                .child(SharedString::from(value.into())),
         )
-        .child(sidebar_preview(collapsed))
 }
 
-fn sidebar_preview(collapsed: bool) -> gpui::Div {
-    let rail_w = if collapsed { 48.0 } else { 146.0 };
+fn token_row(label: &str, kind: &'static str) -> gpui::Div {
+    metric_row(kind, label.to_string())
+}
+
+fn empty_row(text: &'static str) -> gpui::Div {
     div()
-        .w(px(220.0))
-        .h(px(176.0))
-        .rounded(px(theme::radius::R1))
+        .h(px(32.0))
+        .rounded(px(theme::radius::R0))
         .bg(theme::ink::midnight())
         .border_1()
         .border_color(theme::line::weak())
-        .p_2()
+        .px_3()
         .flex()
-        .gap_2()
-        .child(
-            div()
-                .w(px(rail_w))
-                .h_full()
-                .rounded(px(theme::radius::R0))
-                .bg(theme::ink::nocturne())
-                .border_1()
-                .border_color(theme::line::mild())
-                .p_2()
-                .flex()
-                .flex_col()
-                .gap_2()
-                .child(preview_row(collapsed, theme::state::working(), true))
-                .child(preview_row(collapsed, theme::state::waiting(), false))
-                .child(preview_row(collapsed, theme::state::approval(), false)),
-        )
+        .items_center()
+        .text_size(px(11.0))
+        .text_color(theme::moon::ash())
+        .child(SharedString::from(text))
+}
+
+fn status_row(text: &str) -> gpui::Div {
+    div()
+        .rounded(px(theme::radius::R0))
+        .bg(theme::sodium::hush())
+        .border_1()
+        .border_color(theme::sodium::deep())
+        .p_3()
+        .text_size(px(11.0))
+        .text_color(theme::sodium::vapor())
+        .child(SharedString::from(text.to_string()))
+}
+
+fn filter_row(label: &str, kind: &'static str) -> gpui::Div {
+    div()
+        .h(px(34.0))
+        .rounded(px(theme::radius::R0))
+        .bg(theme::ink::midnight())
+        .border_1()
+        .border_color(theme::line::weak())
+        .px_3()
+        .flex()
+        .items_center()
+        .justify_between()
+        .gap_3()
         .child(
             div()
                 .flex_1()
-                .h_full()
+                .min_w(px(0.0))
+                .truncate()
+                .text_size(px(11.0))
+                .text_color(theme::moon::bone())
+                .child(SharedString::from(label.to_string())),
+        )
+        .child(
+            div()
+                .text_size(px(10.0))
+                .text_color(theme::sodium::vapor())
+                .child(SharedString::from(format!("unmute {kind}"))),
+        )
+}
+
+fn endpoint_action(label: &'static str) -> gpui::Div {
+    div()
+        .h(px(24.0))
+        .px_2()
+        .rounded(px(theme::radius::R0))
+        .border_1()
+        .border_color(theme::line::mild())
+        .text_size(px(10.0))
+        .text_color(theme::moon::bone())
+        .flex()
+        .items_center()
+        .justify_center()
+        .child(SharedString::from(label))
+}
+
+fn status_chip(status: &str) -> gpui::Div {
+    let color = match status {
+        "connected" => theme::state::working(),
+        "error" | "failed" => theme::state::error(),
+        "disabled" => theme::moon::cinder(),
+        _ => theme::state::waiting(),
+    };
+    div()
+        .h(px(20.0))
+        .px_2()
+        .rounded(px(theme::radius::R0))
+        .bg(theme::ink::shade())
+        .border_1()
+        .border_color(color)
+        .text_size(px(10.0))
+        .text_color(theme::moon::bone())
+        .flex()
+        .items_center()
+        .child(SharedString::from(status.to_string()))
+}
+
+fn capability_row(agent: &'static str, settings: &SettingsMap) -> gpui::Div {
+    let mut row = div().flex().flex_col().gap_1().child(
+        div()
+            .text_size(px(11.0))
+            .text_color(theme::moon::bone())
+            .font_weight(FontWeight::MEDIUM)
+            .child(SharedString::from(agent_label(agent))),
+    );
+    for cap in CAPS {
+        let key = format!("{agent}_cap_{cap}");
+        let enabled = setting(settings, &key) == "true";
+        row = row.child(
+            div()
+                .h(px(20.0))
                 .rounded(px(theme::radius::R0))
-                .bg(theme::ink::void())
+                .bg(if enabled {
+                    theme::sodium::hush()
+                } else {
+                    theme::ink::midnight()
+                })
                 .border_1()
-                .border_color(theme::line::weak()),
+                .border_color(if enabled {
+                    theme::sodium::deep()
+                } else {
+                    theme::line::weak()
+                })
+                .px_2()
+                .flex()
+                .items_center()
+                .justify_between()
+                .child(
+                    div()
+                        .text_size(px(9.0))
+                        .text_color(theme::moon::ash())
+                        .child(SharedString::from(cap_label(cap))),
+                )
+                .child(
+                    div()
+                        .text_size(px(9.0))
+                        .text_color(if enabled {
+                            theme::sodium::vapor()
+                        } else {
+                            theme::moon::cinder()
+                        })
+                        .child(SharedString::from(if enabled { "on" } else { "off" })),
+                ),
+        );
+    }
+    row
+}
+
+fn availability_label(agent: &str, settings: &SettingsMap) -> &'static str {
+    if setting(settings, &format!("{agent}_available")) == "true" {
+        "Found in PATH"
+    } else {
+        "Not found in PATH"
+    }
+}
+
+fn agent_label(agent: &str) -> &'static str {
+    match agent {
+        "claude" => "Claude",
+        "codex" => "Codex",
+        "copilot" => "Copilot",
+        "pi" => "Pi",
+        _ => "Agent",
+    }
+}
+
+fn cap_label(cap: &'static str) -> &'static str {
+    match cap {
+        "transcript_watcher" => "watcher",
+        "state_detector" => "state",
+        other => other,
+    }
+}
+
+fn review_preset_names(raw: &str) -> Vec<String> {
+    let Ok(Value::Array(values)) = serde_json::from_str::<Value>(raw) else {
+        return Vec::new();
+    };
+    values
+        .into_iter()
+        .filter_map(|value| {
+            value
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+fn sidebar_mode_control(collapsed: bool) -> gpui::Div {
+    div()
+        .rounded(px(theme::radius::R1))
+        .border_1()
+        .border_color(theme::line::mild())
+        .bg(theme::ink::midnight())
+        .p_1()
+        .flex()
+        .items_center()
+        .gap_1()
+        .child(mode_segment("Wide", !collapsed))
+        .child(mode_segment("Narrow", collapsed))
+}
+
+fn sidebar_preview(collapsed: bool) -> gpui::Div {
+    let rail_w = if collapsed { 48.0 } else { 150.0 };
+    div()
+        .w(px(260.0))
+        .rounded(px(theme::radius::R1))
+        .bg(theme::ink::shade())
+        .border_1()
+        .border_color(theme::line::mild())
+        .p_4()
+        .flex()
+        .flex_col()
+        .gap_3()
+        .child(
+            div()
+                .text_size(px(14.0))
+                .font_weight(FontWeight::MEDIUM)
+                .text_color(theme::moon::moonstone())
+                .child(SharedString::from("Workspace rail")),
+        )
+        .child(
+            div()
+                .h(px(230.0))
+                .rounded(px(theme::radius::R1))
+                .bg(theme::ink::midnight())
+                .border_1()
+                .border_color(theme::line::weak())
+                .p_2()
+                .flex()
+                .gap_2()
+                .child(
+                    div()
+                        .w(px(rail_w))
+                        .h_full()
+                        .rounded(px(theme::radius::R0))
+                        .bg(theme::ink::nocturne())
+                        .border_1()
+                        .border_color(theme::line::mild())
+                        .p_2()
+                        .flex()
+                        .flex_col()
+                        .gap_2()
+                        .child(preview_row(collapsed, theme::state::working(), true))
+                        .child(preview_row(collapsed, theme::state::waiting(), false))
+                        .child(preview_row(collapsed, theme::state::approval(), false)),
+                )
+                .child(
+                    div()
+                        .flex_1()
+                        .h_full()
+                        .rounded(px(theme::radius::R0))
+                        .bg(theme::ink::void())
+                        .border_1()
+                        .border_color(theme::line::weak()),
+                ),
         )
 }
 
@@ -302,11 +2174,10 @@ fn preview_row(collapsed: bool, color: gpui::Rgba, selected: bool) -> gpui::Div 
         .gap_2()
         .px_2()
         .child(div().w(px(7.0)).h(px(7.0)).rounded_full().bg(color));
-
     if !collapsed {
         row = row.child(
             div()
-                .w(px(58.0))
+                .w(px(76.0))
                 .h(px(5.0))
                 .rounded(px(theme::radius::R0))
                 .bg(if selected {
@@ -316,61 +2187,38 @@ fn preview_row(collapsed: bool, color: gpui::Rgba, selected: bool) -> gpui::Div 
                 }),
         );
     }
-
     row
 }
 
-fn close_button() -> gpui::Div {
-    div()
-        .w(px(28.0))
-        .h(px(28.0))
-        .flex()
-        .items_center()
-        .justify_center()
-        .rounded(px(theme::radius::R0))
-        .border_1()
-        .border_color(theme::line::mild())
-        .text_color(theme::moon::bone())
-        .text_size(px(14.0))
-        .child(SharedString::from("x"))
-}
+#[cfg(test)]
+mod tests {
+    use super::{
+        backspace_at_cursor, clamp_char_boundary, delete_at_cursor, insert_at_cursor,
+        next_char_boundary, previous_char_boundary,
+    };
 
-fn sidebar_mode_control(collapsed: bool) -> gpui::Div {
-    div()
-        .rounded(px(theme::radius::R1))
-        .border_1()
-        .border_color(theme::line::mild())
-        .bg(theme::ink::midnight())
-        .p_1()
-        .flex()
-        .items_center()
-        .gap_1()
-        .child(mode_segment("Wide", !collapsed))
-        .child(mode_segment("Narrow", collapsed))
-}
-
-fn mode_segment(label: &'static str, active: bool) -> gpui::Div {
-    let mut segment = div()
-        .h(px(28.0))
-        .px_3p5()
-        .flex()
-        .items_center()
-        .justify_center()
-        .rounded(px(theme::radius::R0))
-        .text_size(px(11.0))
-        .text_color(if active {
-            theme::moon::moonstone()
-        } else {
-            theme::moon::ash()
-        })
-        .child(SharedString::from(label));
-
-    if active {
-        segment = segment
-            .bg(theme::surface::selected_row())
-            .border_1()
-            .border_color(theme::sodium::deep());
+    #[test]
+    fn cursor_boundaries_preserve_utf8() {
+        let value = "aéz";
+        assert_eq!(clamp_char_boundary(value, 2), 1);
+        assert_eq!(previous_char_boundary(value, value.len()), 3);
+        assert_eq!(next_char_boundary(value, 1), 3);
     }
 
-    segment
+    #[test]
+    fn cursor_editing_inserts_and_deletes_at_cursor() {
+        let mut value = "ac".to_string();
+        let mut cursor = 1;
+        insert_at_cursor(&mut value, &mut cursor, "b");
+        assert_eq!(value, "abc");
+        assert_eq!(cursor, 2);
+
+        assert!(backspace_at_cursor(&mut value, &mut cursor));
+        assert_eq!(value, "ac");
+        assert_eq!(cursor, 1);
+
+        assert!(delete_at_cursor(&mut value, &mut cursor));
+        assert_eq!(value, "a");
+        assert_eq!(cursor, 1);
+    }
 }

--- a/native-ui/crates/attn-protocol/src/commands.rs
+++ b/native-ui/crates/attn-protocol/src/commands.rs
@@ -20,6 +20,12 @@ impl GetSettingsMessage {
     }
 }
 
+impl Default for GetSettingsMessage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct ListEndpointsMessage {
     pub cmd: &'static str,
@@ -30,6 +36,12 @@ impl ListEndpointsMessage {
         Self {
             cmd: "list_endpoints",
         }
+    }
+}
+
+impl Default for ListEndpointsMessage {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/native-ui/crates/attn-protocol/src/commands.rs
+++ b/native-ui/crates/attn-protocol/src/commands.rs
@@ -7,6 +7,178 @@ pub struct QueryMessage {
     pub cmd: &'static str,
 }
 
+#[derive(Debug, Serialize)]
+pub struct GetSettingsMessage {
+    pub cmd: &'static str,
+}
+
+impl GetSettingsMessage {
+    pub fn new() -> Self {
+        Self {
+            cmd: "get_settings",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListEndpointsMessage {
+    pub cmd: &'static str,
+}
+
+impl ListEndpointsMessage {
+    pub fn new() -> Self {
+        Self {
+            cmd: "list_endpoints",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct SetSettingMessage {
+    pub cmd: &'static str,
+    pub key: String,
+    pub value: String,
+}
+
+impl SetSettingMessage {
+    pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            cmd: "set_setting",
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdateEndpointMessage {
+    pub cmd: &'static str,
+    pub endpoint_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ssh_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AddEndpointMessage {
+    pub cmd: &'static str,
+    pub name: String,
+    pub ssh_target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+}
+
+impl AddEndpointMessage {
+    pub fn new(
+        name: impl Into<String>,
+        ssh_target: impl Into<String>,
+        profile: impl Into<String>,
+    ) -> Self {
+        let profile = profile.into();
+        Self {
+            cmd: "add_endpoint",
+            name: name.into(),
+            ssh_target: ssh_target.into(),
+            profile: (!profile.trim().is_empty()).then_some(profile),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct RemoveEndpointMessage {
+    pub cmd: &'static str,
+    pub endpoint_id: String,
+}
+
+impl RemoveEndpointMessage {
+    pub fn new(endpoint_id: impl Into<String>) -> Self {
+        Self {
+            cmd: "remove_endpoint",
+            endpoint_id: endpoint_id.into(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct BootstrapEndpointMessage {
+    pub cmd: &'static str,
+    pub endpoint_id: String,
+}
+
+impl BootstrapEndpointMessage {
+    pub fn new(endpoint_id: impl Into<String>) -> Self {
+        Self {
+            cmd: "bootstrap_endpoint",
+            endpoint_id: endpoint_id.into(),
+        }
+    }
+}
+
+impl UpdateEndpointMessage {
+    pub fn enabled(endpoint_id: impl Into<String>, enabled: bool) -> Self {
+        Self {
+            cmd: "update_endpoint",
+            endpoint_id: endpoint_id.into(),
+            name: None,
+            ssh_target: None,
+            enabled: Some(enabled),
+            profile: None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct SetEndpointRemoteWebMessage {
+    pub cmd: &'static str,
+    pub endpoint_id: String,
+    pub enabled: bool,
+}
+
+impl SetEndpointRemoteWebMessage {
+    pub fn new(endpoint_id: impl Into<String>, enabled: bool) -> Self {
+        Self {
+            cmd: "set_endpoint_remote_web",
+            endpoint_id: endpoint_id.into(),
+            enabled,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToggleRepoMuteMessage {
+    pub cmd: &'static str,
+    pub repo: String,
+}
+
+impl ToggleRepoMuteMessage {
+    pub fn new(repo: impl Into<String>) -> Self {
+        Self {
+            cmd: "mute_repo",
+            repo: repo.into(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToggleAuthorMuteMessage {
+    pub cmd: &'static str,
+    pub author: String,
+}
+
+impl ToggleAuthorMuteMessage {
+    pub fn new(author: impl Into<String>) -> Self {
+        Self {
+            cmd: "mute_author",
+            author: author.into(),
+        }
+    }
+}
+
 impl QueryMessage {
     pub fn new() -> Self {
         Self { cmd: "query" }

--- a/native-ui/crates/attn-protocol/src/events.rs
+++ b/native-ui/crates/attn-protocol/src/events.rs
@@ -1,6 +1,9 @@
 use serde::Deserialize;
 
-use crate::types::{DirectoryEntry, PathInspection, ReplaySegment, RepoInfo, Session, Workspace};
+use crate::types::{
+    AuthorState, DirectoryEntry, EndpointInfo, PathInspection, PullRequestSummary, ReplaySegment,
+    RepoInfo, RepoState, Session, SettingsMap, Workspace,
+};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct InitialStateMessage {
@@ -13,6 +16,63 @@ pub struct InitialStateMessage {
     pub sessions: Vec<Session>,
     #[serde(default)]
     pub workspaces: Vec<Workspace>,
+    #[serde(default)]
+    pub endpoints: Vec<EndpointInfo>,
+    #[serde(default)]
+    pub prs: Vec<PullRequestSummary>,
+    #[serde(default)]
+    pub repos: Vec<RepoState>,
+    #[serde(default)]
+    pub authors: Vec<AuthorState>,
+    #[serde(default)]
+    pub settings: SettingsMap,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SettingsUpdatedMessage {
+    pub event: String,
+    #[serde(default)]
+    pub settings: SettingsMap,
+    #[serde(default)]
+    pub changed_key: Option<String>,
+    #[serde(default)]
+    pub success: Option<bool>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EndpointsUpdatedMessage {
+    pub event: String,
+    #[serde(default)]
+    pub endpoints: Vec<EndpointInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EndpointStatusChangedMessage {
+    pub event: String,
+    pub endpoint: EndpointInfo,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReposUpdatedMessage {
+    pub event: String,
+    #[serde(default)]
+    pub repos: Vec<RepoState>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AuthorsUpdatedMessage {
+    pub event: String,
+    #[serde(default)]
+    pub authors: Vec<AuthorState>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PRsUpdatedMessage {
+    pub event: String,
+    #[serde(default)]
+    pub prs: Vec<PullRequestSummary>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -178,6 +238,12 @@ struct EventPeek {
 #[derive(Debug, Clone)]
 pub enum ServerEvent {
     InitialState(InitialStateMessage),
+    SettingsUpdated(SettingsUpdatedMessage),
+    EndpointsUpdated(EndpointsUpdatedMessage),
+    EndpointStatusChanged(EndpointStatusChangedMessage),
+    ReposUpdated(ReposUpdatedMessage),
+    AuthorsUpdated(AuthorsUpdatedMessage),
+    PRsUpdated(PRsUpdatedMessage),
     SessionRegistered(SessionRegisteredMessage),
     SessionUnregistered(SessionUnregisteredMessage),
     SessionStateChanged(SessionStateChangedMessage),
@@ -205,6 +271,30 @@ impl ServerEvent {
             "initial_state" => {
                 let msg: InitialStateMessage = serde_json::from_str(data)?;
                 Ok(Self::InitialState(msg))
+            }
+            "settings_updated" => {
+                let msg: SettingsUpdatedMessage = serde_json::from_str(data)?;
+                Ok(Self::SettingsUpdated(msg))
+            }
+            "endpoints_updated" => {
+                let msg: EndpointsUpdatedMessage = serde_json::from_str(data)?;
+                Ok(Self::EndpointsUpdated(msg))
+            }
+            "endpoint_status_changed" => {
+                let msg: EndpointStatusChangedMessage = serde_json::from_str(data)?;
+                Ok(Self::EndpointStatusChanged(msg))
+            }
+            "repos_updated" => {
+                let msg: ReposUpdatedMessage = serde_json::from_str(data)?;
+                Ok(Self::ReposUpdated(msg))
+            }
+            "authors_updated" => {
+                let msg: AuthorsUpdatedMessage = serde_json::from_str(data)?;
+                Ok(Self::AuthorsUpdated(msg))
+            }
+            "prs_updated" => {
+                let msg: PRsUpdatedMessage = serde_json::from_str(data)?;
+                Ok(Self::PRsUpdated(msg))
             }
             "session_registered" => {
                 let msg: SessionRegisteredMessage = serde_json::from_str(data)?;

--- a/native-ui/crates/attn-protocol/src/types.rs
+++ b/native-ui/crates/attn-protocol/src/types.rs
@@ -1,4 +1,7 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+pub type SettingsMap = HashMap<String, String>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -89,6 +92,69 @@ pub struct WorkspacePanel {
     pub world_y: f32,
     pub width: f32,
     pub height: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EndpointCapabilities {
+    pub protocol_version: String,
+    #[serde(default, deserialize_with = "null_or_vec")]
+    pub agents_available: Vec<String>,
+    #[serde(default)]
+    pub projects_directory: Option<String>,
+    #[serde(default)]
+    pub pty_backend_mode: Option<String>,
+    #[serde(default)]
+    pub daemon_instance_id: Option<String>,
+    #[serde(default)]
+    pub tailscale_enabled: Option<bool>,
+    #[serde(default)]
+    pub tailscale_status: Option<String>,
+    #[serde(default)]
+    pub tailscale_url: Option<String>,
+    #[serde(default)]
+    pub tailscale_domain: Option<String>,
+    #[serde(default)]
+    pub tailscale_auth_url: Option<String>,
+    #[serde(default)]
+    pub tailscale_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EndpointInfo {
+    pub id: String,
+    pub name: String,
+    pub ssh_target: String,
+    pub status: String,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub profile: Option<String>,
+    #[serde(default)]
+    pub status_message: Option<String>,
+    #[serde(default)]
+    pub session_count: Option<i32>,
+    #[serde(default)]
+    pub capabilities: Option<EndpointCapabilities>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepoState {
+    pub repo: String,
+    pub muted: bool,
+    #[serde(default)]
+    pub collapsed: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthorState {
+    pub author: String,
+    pub muted: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PullRequestSummary {
+    #[serde(default)]
+    pub host: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- Expand the native Settings window into a tabbed settings surface covering appearance, projects, agents, review, network, filters, system state, and native sidebar controls.
- Wire the native app to daemon settings, endpoint, PR host, repo, and author update events, plus the settings and endpoint commands needed to mutate those settings.
- Refactor native settings text-field editing so the caret follows a real cursor position, with UTF-8-safe insert/delete/backspace helpers and tests.
- Add native automation coverage for opening settings and clicking through all settings sections.

## Validation
- `cargo test --manifest-path native-ui/Cargo.toml` (77 tests)
- `node --check app/scripts/real-app-harness/scenario-native-canvas.mjs`
- `make dev-native` + `make scenario-native-canvas ATTN_PROFILE=dev`