### PR TITLE
[codex] Replace native terminal with libghostty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,11 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.3'
+
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,11 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
       - name: Cargo fmt
         run: cargo fmt --check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Native Canvas Panel Status**: Native canvas panel headers now show each session's live state, including working, waiting for input, approval-needed, idle, and long-run review status.
 
 ### Changed
+- **Native Terminal Engine**: Native canvas terminals now use Ghostty's `libghostty-vt` terminal emulator for VT parsing, screen state, cursor position, wide-cell handling, and ANSI color resolution while keeping the existing daemon PTY transport.
 - **Native Sidebar Collapse**: The native workspace sidebar can now collapse with `Cmd+B`, keeping workspace status colors visible in the narrow rail while freeing canvas space.
 
 ### Fixed

--- a/native-ui/Cargo.lock
+++ b/native-ui/Cargo.lock
@@ -43,31 +43,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alacritty_terminal"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda177466b9524d59f1b12f0dd30b68696788e9992a7e959021c4a0ed96fcf59"
-dependencies = [
- "base64",
- "bitflags 2.11.0",
- "home",
- "libc",
- "log",
- "miow",
- "parking_lot",
- "piper",
- "polling",
- "regex-automata",
- "rustix 1.1.4",
- "rustix-openpty",
- "serde",
- "signal-hook",
- "unicode-width",
- "vte",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "aligned"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,7 +442,6 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 name = "attn-native-app"
 version = "0.1.0"
 dependencies = [
- "alacritty_terminal",
  "async-channel 2.5.0",
  "async-tungstenite",
  "attn-protocol",
@@ -477,6 +451,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.17",
  "gpui",
+ "libghostty-vt",
  "objc",
  "serde",
  "serde_json",
@@ -599,9 +574,6 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "bitstream-io"
@@ -1284,12 +1256,6 @@ name = "ctor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
-
-[[package]]
-name = "cursor-icon"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "data-encoding"
@@ -2774,6 +2740,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "int-enum"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366a1634cccc76b4cfd3e7580de9b605e4d93f1edac48d786c1f867c0def495"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +2935,21 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "libghostty-vt"
+version = "0.1.1"
+source = "git+https://github.com/Uzaaft/libghostty-rs.git?rev=5ac47e9eb166add2c00c432bc65c279133629712#5ac47e9eb166add2c00c432bc65c279133629712"
+dependencies = [
+ "bitflags 2.11.0",
+ "int-enum",
+ "libghostty-vt-sys",
+]
+
+[[package]]
+name = "libghostty-vt-sys"
+version = "0.1.1"
+source = "git+https://github.com/Uzaaft/libghostty-rs.git?rev=5ac47e9eb166add2c00c432bc65c279133629712#5ac47e9eb166add2c00c432bc65c279133629712"
 
 [[package]]
 name = "libloading"
@@ -3210,15 +3203,6 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "miow"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
-dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -3927,6 +3911,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+]
+
+[[package]]
 name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4446,17 +4442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix-openpty"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de16c7c59892b870a6336f185dc10943517f1327447096bbb7bb32cd85e2393"
-dependencies = [
- "errno",
- "libc",
- "rustix 1.1.4",
-]
-
-[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4830,16 +4815,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -5937,20 +5912,6 @@ checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "vte"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
-dependencies = [
- "arrayvec",
- "bitflags 2.11.0",
- "cursor-icon",
- "log",
- "memchr",
- "serde",
 ]
 
 [[package]]

--- a/native-ui/crates/attn-native-app/Cargo.toml
+++ b/native-ui/crates/attn-native-app/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 futures-util = { workspace = true }
 async-tungstenite = { version = "0.28", features = ["async-std-runtime"] }
 smol = "2"
-alacritty_terminal = "0.26.0"
+libghostty-vt = { git = "https://github.com/Uzaaft/libghostty-rs.git", rev = "5ac47e9eb166add2c00c432bc65c279133629712", default-features = false, features = ["link-static"] }
 base64 = "0.22"
 async-channel = "2"
 getrandom = { workspace = true }

--- a/native-ui/crates/attn-native-app/src/state/terminal_model.rs
+++ b/native-ui/crates/attn-native-app/src/state/terminal_model.rs
@@ -1,19 +1,18 @@
-use alacritty_terminal::{
-    event::VoidListener,
-    grid::Dimensions,
-    index::{Column, Line},
-    term::{cell::Cell, Config as TermConfig},
-    vte::ansi::Processor as AnsiProcessor,
-    Term,
-};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use gpui::{Context, Entity, EventEmitter};
+use libghostty_vt::{
+    render::{CellIterator, CursorViewport, RenderState, RowIterator},
+    screen::CellWide,
+    style::RgbColor,
+    Terminal, TerminalOptions,
+};
 use serde_json::json;
 
 use attn_protocol::AttachResultMessage;
 
 use crate::adapters::automation::events;
 use crate::adapters::daemon::{DaemonClient, DaemonEvent};
+use crate::theme;
 
 /// Emitted when the terminal screen content changes and needs to be repainted.
 #[derive(Debug, Clone)]
@@ -23,29 +22,18 @@ pub enum TerminalEvent {
     Desync,
 }
 
-/// A simple dimensions struct for alacritty_terminal.
-struct TermSize {
-    cols: usize,
-    lines: usize,
-}
-
-impl Dimensions for TermSize {
-    fn total_lines(&self) -> usize {
-        self.lines
-    }
-    fn screen_lines(&self) -> usize {
-        self.lines
-    }
-    fn columns(&self) -> usize {
-        self.cols
-    }
-}
+const COLOR_BG: u32 = theme::ink::MIDNIGHT_HEX;
+const COLOR_FG: u32 = theme::moon::PARCHMENT_HEX;
 
 /// Holds the terminal emulation state for a single session.
 pub struct TerminalModel {
     pub session_id: String,
-    term: Term<VoidListener>,
-    parser: AnsiProcessor,
+    terminal: Terminal<'static, 'static>,
+    render_state: RenderState<'static>,
+    row_iterator: RowIterator<'static>,
+    cell_iterator: CellIterator<'static>,
+    rendered_rows: Vec<Vec<RenderedCell>>,
+    cursor: (usize, usize),
     last_seq: i32,
     pub cols: u16,
     pub rows: u16,
@@ -62,12 +50,15 @@ impl TerminalModel {
         cx: &mut Context<Self>,
     ) -> Self {
         let session_id = session_id.into();
-        let size = TermSize {
-            cols: cols as usize,
-            lines: rows as usize,
-        };
-        let term = Term::new(TermConfig::default(), &size, VoidListener);
-        let parser = AnsiProcessor::new();
+        let terminal = Terminal::new(TerminalOptions {
+            cols,
+            rows,
+            max_scrollback: 10_000,
+        })
+        .expect("create libghostty terminal");
+        let render_state = RenderState::new().expect("create libghostty render state");
+        let row_iterator = RowIterator::new().expect("create libghostty row iterator");
+        let cell_iterator = CellIterator::new().expect("create libghostty cell iterator");
 
         // Subscribe to daemon events so PTY output routes directly to this model.
         cx.subscribe(
@@ -102,14 +93,20 @@ impl TerminalModel {
         )
         .detach();
 
-        Self {
+        let mut model = Self {
             session_id,
-            term,
-            parser,
+            terminal,
+            render_state,
+            row_iterator,
+            cell_iterator,
+            rendered_rows: Vec::new(),
+            cursor: (0, 0),
             last_seq: -1,
             cols,
             rows,
-        }
+        };
+        model.refresh_render_rows();
+        model
     }
 
     fn handle_attach_result(&mut self, msg: &AttachResultMessage, cx: &mut Context<Self>) {
@@ -139,7 +136,7 @@ impl TerminalModel {
         // This restores the visible terminal state.
         if let Some(snapshot) = &msg.screen_snapshot {
             if let Ok(bytes) = BASE64.decode(snapshot) {
-                self.parser.advance(&mut self.term, &bytes);
+                self.terminal.vt_write(&bytes);
             }
         }
 
@@ -153,7 +150,7 @@ impl TerminalModel {
                     self.resize(seg_cols, seg_rows);
                 }
                 if let Ok(bytes) = BASE64.decode(&seg.data) {
-                    self.parser.advance(&mut self.term, &bytes);
+                    self.terminal.vt_write(&bytes);
                 }
             }
         }
@@ -163,6 +160,7 @@ impl TerminalModel {
             self.last_seq = seq;
         }
 
+        self.refresh_render_rows();
         cx.emit(TerminalEvent::DataReceived);
         cx.notify();
     }
@@ -175,8 +173,9 @@ impl TerminalModel {
         self.last_seq = seq;
 
         if let Ok(bytes) = BASE64.decode(data) {
-            self.parser.advance(&mut self.term, &bytes);
+            self.terminal.vt_write(&bytes);
         }
+        self.refresh_render_rows();
 
         cx.emit(TerminalEvent::DataReceived);
         cx.notify();
@@ -186,24 +185,14 @@ impl TerminalModel {
     pub fn resize(&mut self, cols: u16, rows: u16) {
         self.cols = cols;
         self.rows = rows;
-        let size = TermSize {
-            cols: cols as usize,
-            lines: rows as usize,
-        };
-        self.term.resize(size);
-    }
-
-    /// Access the underlying Term for rendering.
-    #[allow(dead_code)]
-    pub fn term(&self) -> &Term<VoidListener> {
-        &self.term
+        let _ = self.terminal.resize(cols, rows, 8, 17);
+        self.refresh_render_rows();
     }
 
     /// Cursor position as (col, row), 0-based.
     #[allow(dead_code)]
     pub fn cursor(&self) -> (usize, usize) {
-        let point = self.term.grid().cursor.point;
-        (point.column.0, point.line.0 as usize)
+        self.cursor
     }
 
     /// Plain-text snapshot of the current screen, one row per Vec entry.
@@ -212,63 +201,130 @@ impl TerminalModel {
     /// space-only rows are kept (callers can trim) so callers see the
     /// real screen geometry.
     pub fn screen_text(&self) -> Vec<String> {
-        let grid = self.term.grid();
-        let lines = grid.screen_lines();
-        let cols = grid.columns();
-        let mut out = Vec::with_capacity(lines);
-        for row in 0..lines {
-            let line = Line(row as i32 - grid.display_offset() as i32);
-            let mut s = String::with_capacity(cols);
-            for col in 0..cols {
-                let cell: &Cell = &grid[line][Column(col)];
-                s.push(cell.c);
-            }
-            // Trailing spaces on a row are noise for substring matching;
-            // trim them but keep the row entry so row indices line up
-            // with what the user sees on screen.
-            while s.ends_with(' ') {
-                s.pop();
-            }
-            out.push(s);
-        }
-        out
+        self.rendered_rows
+            .iter()
+            .map(|row| {
+                let mut s = String::with_capacity(row.len());
+                for cell in row {
+                    if cell.is_spacer {
+                        continue;
+                    }
+                    if cell.text.is_empty() {
+                        s.push(' ');
+                    } else {
+                        s.push_str(&cell.text);
+                    }
+                }
+                while s.ends_with(' ') {
+                    s.pop();
+                }
+                s
+            })
+            .collect()
     }
 
-    /// Render a single row as a sequence of (character, fg_color, is_cursor) triples.
+    /// Render a single row as the normalized cell data consumed by the GPUI painter.
     /// Returns None if line index is out of range.
     pub fn render_row(&self, row: usize) -> Option<Vec<RenderedCell>> {
-        let grid = self.term.grid();
-        let lines = grid.screen_lines();
-        if row >= lines {
-            return None;
-        }
-        let cursor_point = grid.cursor.point;
-        let cursor_row = (cursor_point.line.0 + grid.display_offset() as i32) as usize;
-        let cursor_col = cursor_point.column.0;
+        self.rendered_rows.get(row).cloned()
+    }
 
-        let line = Line(row as i32 - grid.display_offset() as i32);
-        let cols = grid.columns();
-        let mut cells = Vec::with_capacity(cols);
-        for col in 0..cols {
-            let cell: &Cell = &grid[line][Column(col)];
-            let is_cursor = row == cursor_row && col == cursor_col;
-            cells.push(RenderedCell {
-                ch: cell.c,
-                fg: cell.fg,
-                bg: cell.bg,
-                flags: cell.flags,
-                is_cursor,
-            });
+    fn refresh_render_rows(&mut self) {
+        let Ok(snapshot) = self.render_state.update(&self.terminal) else {
+            return;
+        };
+        let default_fg = COLOR_FG;
+        let default_bg = COLOR_BG;
+        let cursor = snapshot
+            .cursor_visible()
+            .ok()
+            .filter(|visible| *visible)
+            .and_then(|_| snapshot.cursor_viewport().ok().flatten());
+        self.cursor = cursor
+            .map(|CursorViewport { x, y, .. }| (x as usize, y as usize))
+            .unwrap_or((0, 0));
+
+        let mut rows = Vec::with_capacity(self.rows as usize);
+        let Ok(mut row_iter) = self.row_iterator.update(&snapshot) else {
+            return;
+        };
+        let mut row_idx = 0usize;
+        while let Some(row) = row_iter.next() {
+            let Ok(mut cell_iter) = self.cell_iterator.update(row) else {
+                row_idx += 1;
+                continue;
+            };
+            let mut cells = Vec::with_capacity(self.cols as usize);
+            let mut col_idx = 0usize;
+            while let Some(cell) = cell_iter.next() {
+                let style = cell.style().unwrap_or_default();
+                let raw_cell = cell.raw_cell().ok();
+                let wide = raw_cell
+                    .and_then(|raw| raw.wide().ok())
+                    .unwrap_or(CellWide::Narrow);
+                let is_spacer = matches!(wide, CellWide::SpacerTail | CellWide::SpacerHead);
+                let mut fg = cell
+                    .fg_color()
+                    .ok()
+                    .flatten()
+                    .map(color_to_u32)
+                    .unwrap_or(default_fg);
+                let mut bg = cell
+                    .bg_color()
+                    .ok()
+                    .flatten()
+                    .map(color_to_u32)
+                    .unwrap_or(default_bg);
+
+                if style.inverse {
+                    std::mem::swap(&mut fg, &mut bg);
+                }
+                if style.invisible {
+                    fg = bg;
+                }
+
+                let text = if is_spacer {
+                    String::new()
+                } else {
+                    let chars = cell.graphemes().unwrap_or_default();
+                    if chars.is_empty() {
+                        String::from(" ")
+                    } else {
+                        chars.into_iter().collect()
+                    }
+                };
+                let is_cursor = cursor
+                    .map(|cursor| cursor.x as usize == col_idx && cursor.y as usize == row_idx)
+                    .unwrap_or(false);
+
+                cells.push(RenderedCell {
+                    text,
+                    fg,
+                    bg,
+                    is_wide: matches!(wide, CellWide::Wide),
+                    is_spacer,
+                    is_cursor,
+                });
+                col_idx += 1;
+            }
+            rows.push(cells);
+            row_idx += 1;
         }
-        Some(cells)
+        self.rendered_rows = rows;
     }
 }
 
 /// A single rendered terminal cell.
+#[derive(Clone)]
 pub struct RenderedCell {
-    pub ch: char,
-    pub fg: alacritty_terminal::vte::ansi::Color,
-    pub bg: alacritty_terminal::vte::ansi::Color,
-    pub flags: alacritty_terminal::term::cell::Flags,
+    pub text: String,
+    pub fg: u32,
+    pub bg: u32,
+    pub is_wide: bool,
+    pub is_spacer: bool,
     pub is_cursor: bool,
+}
+
+fn color_to_u32(color: RgbColor) -> u32 {
+    ((color.r as u32) << 16) | ((color.g as u32) << 8) | color.b as u32
 }

--- a/native-ui/crates/attn-native-app/src/state/terminal_model.rs
+++ b/native-ui/crates/attn-native-app/src/state/terminal_model.rs
@@ -24,6 +24,8 @@ pub enum TerminalEvent {
 
 const COLOR_BG: u32 = theme::ink::MIDNIGHT_HEX;
 const COLOR_FG: u32 = theme::moon::PARCHMENT_HEX;
+const DEFAULT_CELL_WIDTH_PX: u32 = 8;
+const DEFAULT_CELL_HEIGHT_PX: u32 = 17;
 
 /// Holds the terminal emulation state for a single session.
 pub struct TerminalModel {
@@ -34,6 +36,8 @@ pub struct TerminalModel {
     cell_iterator: CellIterator<'static>,
     rendered_rows: Vec<Vec<RenderedCell>>,
     cursor: (usize, usize),
+    cell_width_px: u32,
+    cell_height_px: u32,
     last_seq: i32,
     pub cols: u16,
     pub rows: u16,
@@ -82,7 +86,7 @@ impl TerminalModel {
                     cols,
                     rows,
                 } if *session_id == this.session_id => {
-                    this.resize(*cols, *rows);
+                    this.resize(*cols, *rows, this.cell_width_px, this.cell_height_px);
                     cx.emit(TerminalEvent::DataReceived);
                 }
                 DaemonEvent::SessionExited { session_id, .. } if *session_id == this.session_id => {
@@ -101,6 +105,8 @@ impl TerminalModel {
             cell_iterator,
             rendered_rows: Vec::new(),
             cursor: (0, 0),
+            cell_width_px: DEFAULT_CELL_WIDTH_PX,
+            cell_height_px: DEFAULT_CELL_HEIGHT_PX,
             last_seq: -1,
             cols,
             rows,
@@ -128,7 +134,7 @@ impl TerminalModel {
         // Apply daemon-reported dimensions if provided.
         if let (Some(cols), Some(rows)) = (msg.cols, msg.rows) {
             if cols != self.cols || rows != self.rows {
-                self.resize(cols, rows);
+                self.resize(cols, rows, self.cell_width_px, self.cell_height_px);
             }
         }
 
@@ -147,7 +153,7 @@ impl TerminalModel {
                 let seg_cols = seg.cols as u16;
                 let seg_rows = seg.rows as u16;
                 if seg_cols != self.cols || seg_rows != self.rows {
-                    self.resize(seg_cols, seg_rows);
+                    self.resize(seg_cols, seg_rows, self.cell_width_px, self.cell_height_px);
                 }
                 if let Ok(bytes) = BASE64.decode(&seg.data) {
                     self.terminal.vt_write(&bytes);
@@ -182,10 +188,24 @@ impl TerminalModel {
     }
 
     /// Resize the terminal to new dimensions.
-    pub fn resize(&mut self, cols: u16, rows: u16) {
+    pub fn resize(&mut self, cols: u16, rows: u16, cell_width_px: u32, cell_height_px: u32) {
+        let cell_width_px = cell_width_px.max(1);
+        let cell_height_px = cell_height_px.max(1);
+        if self.cols == cols
+            && self.rows == rows
+            && self.cell_width_px == cell_width_px
+            && self.cell_height_px == cell_height_px
+        {
+            return;
+        }
+
         self.cols = cols;
         self.rows = rows;
-        let _ = self.terminal.resize(cols, rows, 8, 17);
+        self.cell_width_px = cell_width_px;
+        self.cell_height_px = cell_height_px;
+        let _ = self
+            .terminal
+            .resize(cols, rows, self.cell_width_px, self.cell_height_px);
         self.refresh_render_rows();
     }
 

--- a/native-ui/crates/attn-native-app/src/views/terminal_view.rs
+++ b/native-ui/crates/attn-native-app/src/views/terminal_view.rs
@@ -1,5 +1,3 @@
-use alacritty_terminal::term::cell::Flags;
-use alacritty_terminal::vte::ansi::{Color, NamedColor};
 use gpui::{
     div, fill, point, prelude::*, px, rgb, size, App, Bounds, Context, ElementId, Entity,
     FocusHandle, Focusable, Font, GlobalElementId, Hsla, InspectorElementId, KeyDownEvent,
@@ -19,9 +17,8 @@ pub const ROW_HEIGHT: f32 = 17.0;
 /// Default terminal colors. The chrome side of the terminal pulls from
 /// the design-system tokens (panel body = `ink::midnight`, default text
 /// = `moon::parchment`, cursor = the sodium accent — the same caret
-/// language used everywhere else). The 16-entry ANSI palette below stays
-/// fixed so external tools that paint with ANSI escapes look the way
-/// their authors intended.
+/// language used everywhere else). ANSI color resolution now comes from
+/// libghostty's render state.
 const COLOR_BG: u32 = theme::ink::MIDNIGHT_HEX;
 const COLOR_FG: u32 = theme::moon::PARCHMENT_HEX;
 /// Cursor block uses the sodium accent — same caret language as every
@@ -30,64 +27,6 @@ const COLOR_CURSOR_BG: u32 = theme::sodium::VAPOR_HEX;
 /// Inverse: text under the cursor block reads as the deepest ink so the
 /// glyph stays legible on the bright sodium fill.
 const COLOR_CURSOR_FG: u32 = theme::ink::VOID_HEX;
-
-/// 16 standard ANSI colors (normal then bright).
-const ANSI_COLORS: [u32; 16] = [
-    0x2e3436, // Black
-    0xcc0000, // Red
-    0x4e9a06, // Green
-    0xc4a000, // Yellow/Brown
-    0x3465a4, // Blue
-    0x75507b, // Magenta
-    0x06989a, // Cyan
-    0xd3d7cf, // White
-    0x555753, // Bright Black
-    0xef2929, // Bright Red
-    0x8ae234, // Bright Green
-    0xfce94f, // Bright Yellow
-    0x729fcf, // Bright Blue
-    0xad7fa8, // Bright Magenta
-    0x34e2e2, // Bright Cyan
-    0xeeeeec, // Bright White
-];
-
-fn resolve_color(color: &Color, default_color: u32) -> u32 {
-    match color {
-        Color::Named(NamedColor::Foreground) => COLOR_FG,
-        Color::Named(NamedColor::Background) => COLOR_BG,
-        Color::Named(c) => {
-            let idx = *c as usize;
-            if idx < ANSI_COLORS.len() {
-                ANSI_COLORS[idx]
-            } else {
-                default_color
-            }
-        }
-        Color::Indexed(idx) => {
-            let i = *idx as usize;
-            if i < 16 {
-                ANSI_COLORS[i]
-            } else if (16..232).contains(&i) {
-                // 6×6×6 color cube
-                let i = i - 16;
-                let b = (i % 6) as u32;
-                let g = ((i / 6) % 6) as u32;
-                let r = ((i / 36) % 6) as u32;
-                let c = |v: u32| if v == 0 { 0 } else { 55 + v * 40 };
-                (c(r) << 16) | (c(g) << 8) | c(b)
-            } else if i < 256 {
-                // Grayscale ramp
-                let v = ((i - 232) as u32) * 10 + 8;
-                (v << 16) | (v << 8) | v
-            } else {
-                default_color
-            }
-        }
-        Color::Spec(rgb_val) => {
-            ((rgb_val.r as u32) << 16) | ((rgb_val.g as u32) << 8) | (rgb_val.b as u32)
-        }
-    }
-}
 
 /// Canvas-based terminal element. Paints background quads and shaped text
 /// directly onto the GPUI scene rather than relying on div layout.
@@ -194,17 +133,15 @@ impl Element for TerminalElement {
         for (row_idx, row) in self.cells.iter().enumerate() {
             let y = origin.y + line_height * row_idx as f32;
             for (col_idx, cell) in row.iter().enumerate() {
-                // SPACER cells are covered by the preceding WIDE_CHAR cell.
-                if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                // Spacer cells are covered by the paired wide cell.
+                if cell.is_spacer {
                     continue;
                 }
 
                 let bg = if cell.is_cursor {
                     COLOR_CURSOR_BG
-                } else if cell.flags.contains(Flags::INVERSE) {
-                    resolve_color(&cell.fg, COLOR_FG)
                 } else {
-                    resolve_color(&cell.bg, COLOR_BG)
+                    cell.bg
                 };
 
                 if bg == COLOR_BG {
@@ -212,7 +149,7 @@ impl Element for TerminalElement {
                 }
 
                 // Wide characters occupy two cell columns.
-                let bg_width = if cell.flags.contains(Flags::WIDE_CHAR) {
+                let bg_width = if cell.is_wide {
                     cell_width * 2.0
                 } else {
                     cell_width
@@ -237,24 +174,20 @@ impl Element for TerminalElement {
             let mut first_cell = true;
 
             for cell in row.iter() {
-                // SPACER cells have no character to render; skip them from the
-                // text string. Because WIDE_CHAR naturally advances 2× cell_width,
-                // the column positions remain correct without a placeholder.
-                if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                // Spacer cells have no character to render.
+                if cell.is_spacer {
                     continue;
                 }
 
-                let ch = if cell.ch == '\0' || cell.ch == '\u{FEFF}' {
-                    ' '
+                let cell_text = if cell.text.is_empty() {
+                    " "
                 } else {
-                    cell.ch
+                    cell.text.as_str()
                 };
                 let fg = if cell.is_cursor {
                     COLOR_CURSOR_FG
-                } else if cell.flags.contains(Flags::INVERSE) {
-                    resolve_color(&cell.bg, COLOR_BG)
                 } else {
-                    resolve_color(&cell.fg, COLOR_FG)
+                    cell.fg
                 };
 
                 if first_cell {
@@ -275,8 +208,8 @@ impl Element for TerminalElement {
                     run_len = 0;
                 }
 
-                text.push(ch);
-                run_len += ch.len_utf8();
+                text.push_str(cell_text);
+                run_len += cell_text.len();
             }
 
             if run_len > 0 {

--- a/native-ui/crates/attn-native-app/src/views/terminal_view.rs
+++ b/native-ui/crates/attn-native-app/src/views/terminal_view.rs
@@ -403,13 +403,20 @@ impl Render for TerminalView {
             let t = self.terminal.read(cx);
             (t.cols, t.rows, t.session_id.clone())
         };
+        let cell_width_px = (CHAR_WIDTH * self.zoom).round().max(1.0) as u32;
+        let cell_height_px = (ROW_HEIGHT * self.zoom).round().max(1.0) as u32;
         if new_cols != cur_cols || new_rows != cur_rows {
-            self.terminal
-                .update(cx, |t, _| t.resize(new_cols, new_rows));
+            self.terminal.update(cx, |t, _| {
+                t.resize(new_cols, new_rows, cell_width_px, cell_height_px)
+            });
             let _ = self
                 .daemon
                 .read(cx)
                 .send_cmd(&PtyResizeMessage::new(session_id, new_cols, new_rows));
+        } else {
+            self.terminal.update(cx, |t, _| {
+                t.resize(new_cols, new_rows, cell_width_px, cell_height_px)
+            });
         }
 
         let terminal = self.terminal.read(cx);

--- a/native-ui/rust-toolchain.toml
+++ b/native-ui/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Replace the native canvas terminal emulator from `alacritty_terminal` to Ghostty's `libghostty-vt`.
- Keep the existing daemon PTY transport and GPUI canvas renderer, but feed rendering from Ghostty `Terminal` + `RenderState` snapshots.
- Normalize Ghostty cells for the painter, including cursor position, wide-cell spacers, foreground/background colors, and plain-text automation snapshots.
- Pin native UI Rust to stable and configure native CI with Xcode 26.3 plus Zig 0.15.2, which Ghostty's vendored build currently requires.

## Why

The native client MVP should use Ghostty's terminal engine instead of maintaining our own Alacritty-backed VT model/render translation. This moves VT parsing, screen state, cursor handling, and ANSI color resolution closer to the terminal engine we want long term while preserving the current session/PTY architecture.

## Validation

- `cargo check -p attn-native-app`
- `cargo test --workspace` in `native-ui` passed, 77 tests.
- Also verified the earlier Xcode 26.4/Zig 0.15.2 blocker is resolved locally by selecting Xcode 26.3.