### PR TITLE
[codex] Handle slow git operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-05-15]
+
+### Changed
+- **Large Repository Git Operations**: Git worktree, status, diff, fetch, clone, and repository metadata operations now use shared long-running command handling with slow-command daemon logging. UI waits for these operations are much longer, and background git polling is less aggressive so giant monorepos are less likely to look failed while Git is still working.
+
+---
+
 ## [2026-05-03]
 
 ### Added

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -505,6 +505,12 @@ function workspaceActionKey(action: string, sessionId: string, paneId?: string):
 
 const ATTACH_RETRY_TIMEOUT_MS = 3_000;
 const ATTACH_RETRY_DELAY_MS = 150;
+const GIT_METADATA_TIMEOUT_MS = 30 * 60_000;
+const GIT_DIFF_TIMEOUT_MS = 10 * 60_000;
+const GIT_WORKTREE_TIMEOUT_MS = 30 * 60_000;
+const GIT_NETWORK_TIMEOUT_MS = 30 * 60_000;
+const GIT_CLONE_TIMEOUT_MS = 60 * 60_000;
+const GITHUB_REFRESH_TIMEOUT_MS = 5 * 60_000;
 
 export function isTransientAttachError(error: unknown): boolean {
   const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
@@ -2450,13 +2456,12 @@ export function useDaemonSocket({
 
       ws.send(JSON.stringify({ cmd: 'refresh_prs' }));
 
-      // Timeout after 30 seconds
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
           reject(new Error('Refresh timed out'));
         }
-      }, 30000);
+      }, GITHUB_REFRESH_TIMEOUT_MS);
     });
   }, []);
 
@@ -2479,7 +2484,7 @@ export function useDaemonSocket({
           pendingActionsRef.current.delete(key);
           reject(new Error('Fetch PR details timed out'));
         }
-      }, 30000);
+      }, GITHUB_REFRESH_TIMEOUT_MS);
     });
   }, []);
 
@@ -2551,13 +2556,12 @@ export function useDaemonSocket({
       const actionKey = `worktree_create_worktree_result_${endpointId || 'local'}`;
       pendingActionsRef.current.set(actionKey, { resolve, reject });
 
-      // Set timeout for action
       setTimeout(() => {
         if (pendingActionsRef.current.has(actionKey)) {
           pendingActionsRef.current.delete(actionKey);
           reject(new Error('Create worktree timed out'));
         }
-      }, 30000);
+      }, GIT_WORKTREE_TIMEOUT_MS);
 
       ws.send(JSON.stringify({
         cmd: 'create_worktree',
@@ -2581,13 +2585,12 @@ export function useDaemonSocket({
       const actionKey = `worktree_delete_worktree_result_${endpointId || 'local'}`;
       pendingActionsRef.current.set(actionKey, { resolve, reject });
 
-      // Set timeout for action
       setTimeout(() => {
         if (pendingActionsRef.current.has(actionKey)) {
           pendingActionsRef.current.delete(actionKey);
           reject(new Error('Delete worktree timed out'));
         }
-      }, 30000);
+      }, GIT_WORKTREE_TIMEOUT_MS);
 
       ws.send(JSON.stringify({
         cmd: 'delete_worktree',
@@ -2805,7 +2808,7 @@ export function useDaemonSocket({
           pendingActionsRef.current.delete(key);
           reject(new Error('Browse directory timed out'));
         }
-      }, 10000);
+      }, GIT_METADATA_TIMEOUT_MS);
     });
   }, [nextRequestID]);
 
@@ -2833,7 +2836,7 @@ export function useDaemonSocket({
           pendingActionsRef.current.delete(key);
           reject(new Error('Inspect path timed out'));
         }
-      }, 10000);
+      }, GIT_METADATA_TIMEOUT_MS);
     });
   }, [nextRequestID]);
 
@@ -2854,7 +2857,7 @@ export function useDaemonSocket({
           pendingActionsRef.current.delete(actionKey);
           reject(new Error('Create worktree from branch timed out'));
         }
-      }, 30000);
+      }, GIT_WORKTREE_TIMEOUT_MS);
 
       ws.send(JSON.stringify({
         cmd: 'create_worktree_from_branch',
@@ -2884,7 +2887,7 @@ export function useDaemonSocket({
           pendingActionsRef.current.delete(key);
           reject(new Error('Fetch remotes timed out'));
         }
-      }, 60000); // Longer timeout for network operations
+      }, GIT_NETWORK_TIMEOUT_MS);
     });
   }, []);
 
@@ -2906,13 +2909,12 @@ export function useDaemonSocket({
         clone_url: cloneUrl,
       }));
 
-      // Longer timeout for clone operations (2 minutes)
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
           reject(new Error('Ensure repo timed out'));
         }
-      }, 120000);
+      }, GIT_CLONE_TIMEOUT_MS);
     });
   }, []);
 
@@ -2985,7 +2987,7 @@ export function useDaemonSocket({
           pendingActionsRef.current.delete(key);
           reject(new Error('Get file diff timed out'));
         }
-      }, 10000);
+      }, GIT_DIFF_TIMEOUT_MS);
     });
   }, []);
 
@@ -3029,7 +3031,7 @@ export function useDaemonSocket({
           branchDiffInFlightRef.current.delete(key);
           reject(new Error('Get branch diff files timed out'));
         }
-      }, 30000); // 30s timeout for potentially large diffs
+      }, GIT_DIFF_TIMEOUT_MS);
     });
 
     branchDiffInFlightRef.current.set(key, request);
@@ -3055,7 +3057,7 @@ export function useDaemonSocket({
           pendingActionsRef.current.delete(key);
           reject(new Error('get_repo_info timeout'));
         }
-      }, 30000);
+      }, GIT_METADATA_TIMEOUT_MS);
     });
   }, []);
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -509,7 +509,7 @@ const GIT_METADATA_TIMEOUT_MS = 30 * 60_000;
 const GIT_DIFF_TIMEOUT_MS = 10 * 60_000;
 const GIT_WORKTREE_TIMEOUT_MS = 30 * 60_000;
 const GIT_NETWORK_TIMEOUT_MS = 30 * 60_000;
-const GIT_CLONE_TIMEOUT_MS = 60 * 60_000;
+const GIT_CLONE_TIMEOUT_MS = 90 * 60_000;
 const GITHUB_REFRESH_TIMEOUT_MS = 5 * 60_000;
 
 export function isTransientAttachError(error: unknown): boolean {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -62,6 +62,7 @@ type longRunSession struct {
 const (
 	longRunReviewThreshold = 5 * time.Minute
 	forcedStopSuppressTTL  = 30 * time.Second
+	branchMonitorInterval  = 15 * time.Second
 
 	startupRecoveryRetryMax       = 2
 	startupRecoveryRetryDelay     = 500 * time.Millisecond
@@ -271,6 +272,9 @@ func New(socketPath string) *Daemon {
 
 	// Wire up classifier logger to daemon logger
 	classifier.SetLogger(func(format string, args ...interface{}) {
+		logger.Infof(format, args...)
+	})
+	git.SetLogFunc(func(format string, args ...interface{}) {
 		logger.Infof(format, args...)
 	})
 
@@ -2832,12 +2836,12 @@ func (d *Daemon) fetchPRDetailsImmediate(prID string) {
 
 // monitorBranches polls git branch info for all sessions every 5 seconds
 func (d *Daemon) monitorBranches() {
-	d.log("Branch monitoring started (5s interval)")
+	d.logf("Branch monitoring started (%s interval)", branchMonitorInterval)
 
 	// Initial check
 	d.checkAllBranches()
 
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(branchMonitorInterval)
 	defer ticker.Stop()
 
 	for {

--- a/internal/daemon/gitstatus.go
+++ b/internal/daemon/gitstatus.go
@@ -46,7 +46,10 @@ func walkUntrackedDir(repoDir, dirPath string) []protocol.GitFileChange {
 
 	// Use git check-ignore to filter out ignored files
 	// Pass all paths at once for efficiency
-	ignoredOutput, _ := attngit.OutputWithStdin(attngit.OpStatus, repoDir, strings.NewReader(strings.Join(filePaths, "\n")), "check-ignore", "--stdin")
+	ignoredOutput, err := attngit.OutputWithStdin(attngit.OpStatus, repoDir, strings.NewReader(strings.Join(filePaths, "\n")), "check-ignore", "--stdin")
+	if err != nil && len(ignoredOutput) == 0 && strings.Contains(err.Error(), "timed out") {
+		return files
+	}
 
 	// Build a set of ignored paths
 	ignoredSet := make(map[string]bool)

--- a/internal/daemon/gitstatus.go
+++ b/internal/daemon/gitstatus.go
@@ -5,11 +5,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	attngit "github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -46,10 +46,7 @@ func walkUntrackedDir(repoDir, dirPath string) []protocol.GitFileChange {
 
 	// Use git check-ignore to filter out ignored files
 	// Pass all paths at once for efficiency
-	cmd := exec.Command("git", append([]string{"check-ignore", "--stdin"}, []string{}...)...)
-	cmd.Dir = repoDir
-	cmd.Stdin = strings.NewReader(strings.Join(filePaths, "\n"))
-	ignoredOutput, _ := cmd.Output()
+	ignoredOutput, _ := attngit.OutputWithStdin(attngit.OpStatus, repoDir, strings.NewReader(strings.Join(filePaths, "\n")), "check-ignore", "--stdin")
 
 	// Build a set of ignored paths
 	ignoredSet := make(map[string]bool)
@@ -178,9 +175,7 @@ func getGitStatus(dir string) (*protocol.GitStatusUpdateMessage, error) {
 	// --untracked-files=all expands brand-new untracked directories into
 	// their individual files; the default collapses each into a single
 	// "?? dir/" line which hides everything inside.
-	statusCmd := exec.Command("git", "status", "--porcelain", "-z", "--untracked-files=all")
-	statusCmd.Dir = dir
-	statusOutput, err := statusCmd.Output()
+	statusOutput, err := attngit.Output(attngit.OpStatus, dir, "status", "--porcelain", "-z", "--untracked-files=all")
 	if err != nil {
 		return &protocol.GitStatusUpdateMessage{
 			Event:     protocol.EventGitStatusUpdate,
@@ -193,9 +188,7 @@ func getGitStatus(dir string) (*protocol.GitStatusUpdateMessage, error) {
 
 	// Get numstat for unstaged changes
 	if len(unstaged) > 0 {
-		numstatCmd := exec.Command("git", "diff", "--numstat")
-		numstatCmd.Dir = dir
-		numstatOutput, _ := numstatCmd.Output()
+		numstatOutput, _ := attngit.Output(attngit.OpDiff, dir, "diff", "--numstat")
 		stats := parseGitDiffNumstat(string(numstatOutput))
 
 		for i := range unstaged {
@@ -208,9 +201,7 @@ func getGitStatus(dir string) (*protocol.GitStatusUpdateMessage, error) {
 
 	// Get numstat for staged changes
 	if len(staged) > 0 {
-		numstatCmd := exec.Command("git", "diff", "--numstat", "--cached")
-		numstatCmd.Dir = dir
-		numstatOutput, _ := numstatCmd.Output()
+		numstatOutput, _ := attngit.Output(attngit.OpDiff, dir, "diff", "--numstat", "--cached")
 		stats := parseGitDiffNumstat(string(numstatOutput))
 
 		for i := range staged {

--- a/internal/daemon/ws_git.go
+++ b/internal/daemon/ws_git.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -10,18 +9,20 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
+const gitStatusPollInterval = 2 * time.Second
+
 func (d *Daemon) handleSubscribeGitStatus(client *wsClient, msg *protocol.SubscribeGitStatusMessage) {
 	client.stopGitStatusPoll()
 
 	client.gitStatusMu.Lock()
 	client.gitStatusDir = msg.Directory
 	client.gitStatusStop = make(chan struct{})
-	client.gitStatusTicker = time.NewTicker(500 * time.Millisecond)
+	client.gitStatusTicker = time.NewTicker(gitStatusPollInterval)
 	stopChan := client.gitStatusStop
 	ticker := client.gitStatusTicker
 	client.gitStatusMu.Unlock()
 
-	d.sendGitStatusUpdate(client)
+	go d.sendGitStatusUpdate(client)
 
 	go func() {
 		for {
@@ -86,9 +87,7 @@ func (d *Daemon) handleGetFileDiff(client *wsClient, msg *protocol.GetFileDiffMe
 		baseRef = *msg.BaseRef
 	}
 
-	origCmd := exec.Command("git", "show", baseRef+":"+msg.Path)
-	origCmd.Dir = msg.Directory
-	origOutput, origErr := origCmd.Output()
+	origOutput, origErr := git.Output(git.OpDiff, msg.Directory, "show", baseRef+":"+msg.Path)
 
 	var original string
 	if origErr == nil {
@@ -97,9 +96,7 @@ func (d *Daemon) handleGetFileDiff(client *wsClient, msg *protocol.GetFileDiffMe
 
 	var modified string
 	if msg.Staged != nil && *msg.Staged {
-		stagedCmd := exec.Command("git", "show", ":"+msg.Path)
-		stagedCmd.Dir = msg.Directory
-		stagedOutput, err := stagedCmd.Output()
+		stagedOutput, err := git.Output(git.OpDiff, msg.Directory, "show", ":"+msg.Path)
 		if err != nil {
 			result.Error = protocol.Ptr("Failed to read staged file: " + err.Error())
 			d.sendToClient(client, result)

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -4,7 +4,6 @@ package git
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -44,9 +43,7 @@ func ExpandPath(path string) string {
 // Uses: git branch --format='%(refname:short)'
 func ListBranches(repoDir string) ([]string, error) {
 	// Get all local branches
-	cmd := exec.Command("git", "branch", "--format=%(refname:short)")
-	cmd.Dir = repoDir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, repoDir, "branch", "--format=%(refname:short)")
 	if err != nil {
 		return nil, fmt.Errorf("git branch failed: %w", err)
 	}
@@ -87,9 +84,7 @@ func ListBranchesWithCommits(repoDir string) ([]BranchWithCommit, error) {
 
 	// Get all local branches with commit info
 	// Format: refname:short | committerdate:iso-strict | objectname:short
-	cmd := exec.Command("git", "branch", "--format=%(refname:short)|%(committerdate:iso-strict)|%(objectname:short)")
-	cmd.Dir = repoDir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, repoDir, "branch", "--format=%(refname:short)|%(committerdate:iso-strict)|%(objectname:short)")
 	if err != nil {
 		return nil, fmt.Errorf("git branch failed: %w", err)
 	}
@@ -143,9 +138,7 @@ func DeleteBranch(repoDir, branch string, force bool) error {
 		flag = "-D"
 	}
 
-	cmd := exec.Command("git", "branch", flag, branch)
-	cmd.Dir = repoDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpMetadata, repoDir, "branch", flag, branch); err != nil {
 		return fmt.Errorf("git branch %s failed: %s", flag, out)
 	}
 	return nil
@@ -154,9 +147,7 @@ func DeleteBranch(repoDir, branch string, force bool) error {
 // SwitchBranch switches the repository to a different branch.
 // Uses: git checkout <branch>
 func SwitchBranch(repoDir, branch string) error {
-	cmd := exec.Command("git", "checkout", branch)
-	cmd.Dir = repoDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpWorktree, repoDir, "checkout", branch); err != nil {
 		return fmt.Errorf("git checkout failed: %s", out)
 	}
 	return nil
@@ -165,9 +156,7 @@ func SwitchBranch(repoDir, branch string) error {
 // CreateBranch creates a new branch from the current HEAD.
 // Uses: git branch <name>
 func CreateBranch(repoDir, branch string) error {
-	cmd := exec.Command("git", "branch", branch)
-	cmd.Dir = repoDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpMetadata, repoDir, "branch", branch); err != nil {
 		return fmt.Errorf("git branch failed: %s", out)
 	}
 	return nil
@@ -175,9 +164,7 @@ func CreateBranch(repoDir, branch string) error {
 
 // GetCurrentBranch returns the current branch name for the repository.
 func GetCurrentBranch(repoDir string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
-	cmd.Dir = repoDir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, repoDir, "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("git rev-parse failed: %w", err)
 	}
@@ -186,13 +173,11 @@ func GetCurrentBranch(repoDir string) (string, error) {
 
 // ListRemotes returns the configured remote names for the repository.
 func ListRemotes(repoDir string) ([]string, error) {
-	cmd := exec.Command("git", "remote")
 	resolvedDir, err := ResolveRepoDir(repoDir)
 	if err != nil {
 		return nil, err
 	}
-	cmd.Dir = resolvedDir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, resolvedDir, "remote")
 	if err != nil {
 		return nil, fmt.Errorf("git remote failed: %w", err)
 	}
@@ -208,13 +193,11 @@ func ListRemotes(repoDir string) ([]string, error) {
 // FetchRemoteBranch fetches a single branch from a remote.
 // remote should be e.g. "origin", branch should be e.g. "main".
 func FetchRemoteBranch(repoDir, remote, branch string) error {
-	cmd := exec.Command("git", "fetch", remote, branch)
 	resolvedDir, err := ResolveRepoDir(repoDir)
 	if err != nil {
 		return err
 	}
-	cmd.Dir = resolvedDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpNetwork, resolvedDir, "fetch", remote, branch); err != nil {
 		outStr := strings.TrimSpace(string(out))
 		if outStr == "" {
 			return fmt.Errorf("git fetch failed: %w", err)
@@ -226,13 +209,11 @@ func FetchRemoteBranch(repoDir, remote, branch string) error {
 
 // FetchRemotes fetches all remotes with prune.
 func FetchRemotes(repoDir string) error {
-	cmd := exec.Command("git", "fetch", "--all", "--prune")
 	resolvedDir, err := ResolveRepoDir(repoDir)
 	if err != nil {
 		return err
 	}
-	cmd.Dir = resolvedDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpNetwork, resolvedDir, "fetch", "--all", "--prune"); err != nil {
 		outStr := strings.TrimSpace(string(out))
 		if outStr == "" {
 			return fmt.Errorf("git fetch failed: %w", err)
@@ -245,9 +226,7 @@ func FetchRemotes(repoDir string) error {
 // ListRemoteBranches returns remote branches not checked out locally.
 func ListRemoteBranches(repoDir string) ([]string, error) {
 	// Get remote branches
-	cmd := exec.Command("git", "branch", "-r", "--format=%(refname:short)")
-	cmd.Dir = repoDir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, repoDir, "branch", "-r", "--format=%(refname:short)")
 	if err != nil {
 		return nil, fmt.Errorf("git branch -r failed: %w", err)
 	}
@@ -258,9 +237,7 @@ func ListRemoteBranches(repoDir string) ([]string, error) {
 	}
 
 	// Get local branches
-	localCmd := exec.Command("git", "branch", "--format=%(refname:short)")
-	localCmd.Dir = repoDir
-	localOut, err := localCmd.Output()
+	localOut, err := runGitOutput(OpMetadata, repoDir, "branch", "--format=%(refname:short)")
 	if err != nil {
 		return nil, fmt.Errorf("git branch failed: %w", err)
 	}
@@ -292,16 +269,12 @@ func ListRemoteBranches(repoDir string) ([]string, error) {
 // CheckoutBranch checks out a branch, creating tracking branch if needed.
 func CheckoutBranch(repoDir, branch string) error {
 	// First try simple checkout
-	cmd := exec.Command("git", "checkout", branch)
-	cmd.Dir = repoDir
-	if _, err := cmd.CombinedOutput(); err == nil {
+	if _, err := runGitCombined(OpWorktree, repoDir, "checkout", branch); err == nil {
 		return nil
 	}
 
 	// If that failed, try creating tracking branch from origin
-	cmd = exec.Command("git", "checkout", "-b", branch, "origin/"+branch)
-	cmd.Dir = repoDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpWorktree, repoDir, "checkout", "-b", branch, "origin/"+branch); err != nil {
 		return fmt.Errorf("git checkout failed: %s", out)
 	}
 	return nil
@@ -309,9 +282,7 @@ func CheckoutBranch(repoDir, branch string) error {
 
 // GetHeadCommitInfo returns the short hash and ISO timestamp of HEAD
 func GetHeadCommitInfo(repoDir string) (hash string, time string) {
-	cmd := exec.Command("git", "log", "-1", "--format=%h|%cI")
-	cmd.Dir = repoDir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, repoDir, "log", "-1", "--format=%h|%cI")
 	if err != nil {
 		return "", ""
 	}
@@ -325,9 +296,7 @@ func GetHeadCommitInfo(repoDir string) (hash string, time string) {
 // GetDefaultBranch returns the default branch name (main, master, etc).
 func GetDefaultBranch(repoDir string) (string, error) {
 	// Try to get from remote HEAD
-	cmd := exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD")
-	cmd.Dir = repoDir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, repoDir, "symbolic-ref", "refs/remotes/origin/HEAD")
 	if err == nil {
 		// Format: refs/remotes/origin/main
 		ref := strings.TrimSpace(string(out))
@@ -339,9 +308,7 @@ func GetDefaultBranch(repoDir string) (string, error) {
 
 	// Fallback: check if main or master exists
 	for _, branch := range []string{"main", "master"} {
-		cmd := exec.Command("git", "rev-parse", "--verify", branch)
-		cmd.Dir = repoDir
-		if err := cmd.Run(); err == nil {
+		if err := runGitNoOutput(OpMetadata, repoDir, "rev-parse", "--verify", branch); err == nil {
 			return branch, nil
 		}
 	}

--- a/internal/git/clone.go
+++ b/internal/git/clone.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 )
 
@@ -23,9 +22,7 @@ func Clone(cloneURL, targetPath string) error {
 		return fmt.Errorf("failed to create parent directory: %w", err)
 	}
 
-	// Clone the repo
-	cmd := exec.Command("git", "clone", cloneURL, targetPath)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpNetwork, "", "clone", cloneURL, targetPath); err != nil {
 		return fmt.Errorf("git clone failed: %s", string(out))
 	}
 

--- a/internal/git/clone.go
+++ b/internal/git/clone.go
@@ -22,7 +22,7 @@ func Clone(cloneURL, targetPath string) error {
 		return fmt.Errorf("failed to create parent directory: %w", err)
 	}
 
-	if out, err := runGitCombined(OpNetwork, "", "clone", cloneURL, targetPath); err != nil {
+	if out, err := runGitCombined(OpClone, "", "clone", cloneURL, targetPath); err != nil {
 		return fmt.Errorf("git clone failed: %s", string(out))
 	}
 

--- a/internal/git/command.go
+++ b/internal/git/command.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os/exec"
 	"strings"
 	"sync"
@@ -19,6 +20,7 @@ const (
 	OpDiff     Operation = "diff"
 	OpWorktree Operation = "worktree"
 	OpNetwork  Operation = "network"
+	OpClone    Operation = "clone"
 )
 
 const slowGitLogThreshold = 2 * time.Second
@@ -52,6 +54,8 @@ func defaultTimeout(op Operation) time.Duration {
 		return 10 * time.Minute
 	case OpWorktree, OpNetwork:
 		return 30 * time.Minute
+	case OpClone:
+		return 60 * time.Minute
 	default:
 		return 2 * time.Minute
 	}
@@ -123,7 +127,7 @@ func runGitCommand(op Operation, dir string, stdin io.Reader, combined bool, arg
 	logGitCommand(op, dir, args, duration, ctx.Err())
 
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return out, fmt.Errorf("git %s timed out after %s: git %s", op, timeout, strings.Join(args, " "))
+		return out, fmt.Errorf("git %s timed out after %s: git %s", op, timeout, strings.Join(redactGitArgs(args), " "))
 	}
 	return out, err
 }
@@ -142,5 +146,35 @@ func logGitCommand(op Operation, dir string, args []string, duration time.Durati
 	if errors.Is(ctxErr, context.DeadlineExceeded) {
 		status = "timeout"
 	}
-	fn("git command %s: op=%s duration=%s dir=%s args=%q", status, op, duration.Round(time.Millisecond), dir, args)
+	fn("git command %s: op=%s duration=%s dir=%s args=%q", status, op, duration.Round(time.Millisecond), dir, redactGitArgs(args))
+}
+
+func redactGitArgs(args []string) []string {
+	redacted := make([]string, len(args))
+	for i, arg := range args {
+		redacted[i] = redactGitArg(arg)
+	}
+	return redacted
+}
+
+func redactGitArg(arg string) string {
+	parsed, err := url.Parse(arg)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return arg
+	}
+	switch parsed.Scheme {
+	case "http", "https", "ssh":
+	default:
+		return arg
+	}
+	if parsed.User != nil {
+		parsed.User = url.User("REDACTED")
+	}
+	if parsed.RawQuery != "" {
+		parsed.RawQuery = "REDACTED"
+	}
+	if parsed.Fragment != "" {
+		parsed.Fragment = "REDACTED"
+	}
+	return parsed.String()
 }

--- a/internal/git/command.go
+++ b/internal/git/command.go
@@ -1,0 +1,146 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Operation string
+
+const (
+	OpMetadata Operation = "metadata"
+	OpStatus   Operation = "status"
+	OpDiff     Operation = "diff"
+	OpWorktree Operation = "worktree"
+	OpNetwork  Operation = "network"
+)
+
+const slowGitLogThreshold = 2 * time.Second
+
+var (
+	logMu       sync.RWMutex
+	logf        func(format string, args ...interface{})
+	timeoutMu   sync.RWMutex
+	timeoutByOp = map[Operation]time.Duration{}
+)
+
+// SetLogFunc wires git command duration logging into the daemon logger.
+func SetLogFunc(fn func(format string, args ...interface{})) {
+	logMu.Lock()
+	defer logMu.Unlock()
+	logf = fn
+}
+
+func defaultTimeout(op Operation) time.Duration {
+	timeoutMu.RLock()
+	if timeout, ok := timeoutByOp[op]; ok {
+		timeoutMu.RUnlock()
+		return timeout
+	}
+	timeoutMu.RUnlock()
+
+	switch op {
+	case OpStatus, OpMetadata:
+		return 2 * time.Minute
+	case OpDiff:
+		return 10 * time.Minute
+	case OpWorktree, OpNetwork:
+		return 30 * time.Minute
+	default:
+		return 2 * time.Minute
+	}
+}
+
+func setTimeoutForTesting(op Operation, timeout time.Duration) func() {
+	timeoutMu.Lock()
+	previous, hadPrevious := timeoutByOp[op]
+	timeoutByOp[op] = timeout
+	timeoutMu.Unlock()
+
+	return func() {
+		timeoutMu.Lock()
+		defer timeoutMu.Unlock()
+		if hadPrevious {
+			timeoutByOp[op] = previous
+			return
+		}
+		delete(timeoutByOp, op)
+	}
+}
+
+func runGitOutput(op Operation, dir string, args ...string) ([]byte, error) {
+	return runGitCommand(op, dir, nil, false, args...)
+}
+
+func Output(op Operation, dir string, args ...string) ([]byte, error) {
+	return runGitOutput(op, dir, args...)
+}
+
+func runGitCombined(op Operation, dir string, args ...string) ([]byte, error) {
+	return runGitCommand(op, dir, nil, true, args...)
+}
+
+func runGitWithStdin(op Operation, dir string, stdin io.Reader, args ...string) ([]byte, error) {
+	return runGitCommand(op, dir, stdin, false, args...)
+}
+
+func OutputWithStdin(op Operation, dir string, stdin io.Reader, args ...string) ([]byte, error) {
+	return runGitWithStdin(op, dir, stdin, args...)
+}
+
+func runGitNoOutput(op Operation, dir string, args ...string) error {
+	_, err := runGitCommand(op, dir, nil, true, args...)
+	return err
+}
+
+func runGitCommand(op Operation, dir string, stdin io.Reader, combined bool, args ...string) ([]byte, error) {
+	timeout := defaultTimeout(op)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	if stdin != nil {
+		cmd.Stdin = stdin
+	}
+
+	started := time.Now()
+	var out []byte
+	var err error
+	if combined {
+		out, err = cmd.CombinedOutput()
+	} else {
+		out, err = cmd.Output()
+	}
+	duration := time.Since(started)
+
+	logGitCommand(op, dir, args, duration, ctx.Err())
+
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return out, fmt.Errorf("git %s timed out after %s: git %s", op, timeout, strings.Join(args, " "))
+	}
+	return out, err
+}
+
+func logGitCommand(op Operation, dir string, args []string, duration time.Duration, ctxErr error) {
+	logMu.RLock()
+	fn := logf
+	logMu.RUnlock()
+	if fn == nil {
+		return
+	}
+	if duration < slowGitLogThreshold && ctxErr == nil {
+		return
+	}
+	status := "slow"
+	if errors.Is(ctxErr, context.DeadlineExceeded) {
+		status = "timeout"
+	}
+	fn("git command %s: op=%s duration=%s dir=%s args=%q", status, op, duration.Round(time.Millisecond), dir, args)
+}

--- a/internal/git/command_test.go
+++ b/internal/git/command_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,5 +52,40 @@ func TestRunGitOutputLogsSlowCommand(t *testing.T) {
 	}
 	if len(logs) == 0 {
 		t.Fatal("expected slow command log")
+	}
+}
+
+func TestRunGitOutputRedactsCredentialURLsInLogsAndTimeouts(t *testing.T) {
+	secretURL := "https://user:super-secret-token@example.com/acme/repo.git?token=also-secret#frag"
+
+	fakeBin := t.TempDir()
+	fakeGit := filepath.Join(fakeBin, "git")
+	if err := os.WriteFile(fakeGit, []byte("#!/bin/sh\nexec sleep 5\n"), 0755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cleanup := setTimeoutForTesting(OpClone, 25*time.Millisecond)
+	defer cleanup()
+
+	var logs []string
+	SetLogFunc(func(format string, args ...interface{}) {
+		logs = append(logs, fmt.Sprintf(format, args...))
+	})
+	defer SetLogFunc(nil)
+
+	_, err := runGitOutput(OpClone, t.TempDir(), "clone", secretURL, "/tmp/repo")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	combined := strings.Join(append(logs, err.Error()), "\n")
+	for _, forbidden := range []string{"super-secret-token", "also-secret", "user:"} {
+		if strings.Contains(combined, forbidden) {
+			t.Fatalf("secret %q leaked in log/error output:\n%s", forbidden, combined)
+		}
+	}
+	if !strings.Contains(combined, "https://REDACTED@example.com/acme/repo.git") {
+		t.Fatalf("redacted URL missing from log/error output:\n%s", combined)
 	}
 }

--- a/internal/git/command_test.go
+++ b/internal/git/command_test.go
@@ -1,0 +1,55 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunGitOutputTimesOut(t *testing.T) {
+	fakeBin := t.TempDir()
+	fakeGit := filepath.Join(fakeBin, "git")
+	if err := os.WriteFile(fakeGit, []byte("#!/bin/sh\nexec sleep 5\n"), 0755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cleanup := setTimeoutForTesting(OpMetadata, 25*time.Millisecond)
+	defer cleanup()
+
+	_, err := runGitOutput(OpMetadata, t.TempDir(), "status")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("timeout error = %v, want timed out", err)
+	}
+}
+
+func TestRunGitOutputLogsSlowCommand(t *testing.T) {
+	fakeBin := t.TempDir()
+	fakeGit := filepath.Join(fakeBin, "git")
+	if err := os.WriteFile(fakeGit, []byte("#!/bin/sh\nsleep 3\nprintf ok\n"), 0755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var logs []string
+	SetLogFunc(func(format string, args ...interface{}) {
+		logs = append(logs, format)
+	})
+	defer SetLogFunc(nil)
+
+	out, err := runGitOutput(OpMetadata, t.TempDir(), "status")
+	if err != nil {
+		t.Fatalf("runGitOutput failed: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "ok" {
+		t.Fatalf("output = %q, want ok", out)
+	}
+	if len(logs) == 0 {
+		t.Fatal("expected slow command log")
+	}
+}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -2,7 +2,6 @@
 package git
 
 import (
-	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -26,9 +25,7 @@ func GetBranchDiffFiles(repoDir, baseRef string) ([]DiffFileInfo, error) {
 	fileMap := make(map[string]*DiffFileInfo)
 
 	// 1. Get committed changes: git diff --name-status baseRef...HEAD
-	statusCmd := exec.Command("git", "diff", "--name-status", baseRef+"...HEAD")
-	statusCmd.Dir = repoDir
-	statusOut, err := statusCmd.Output()
+	statusOut, err := runGitOutput(OpDiff, repoDir, "diff", "--name-status", baseRef+"...HEAD")
 	if err != nil {
 		// If baseRef doesn't exist or there's no merge-base, this will fail
 		// That's OK - we'll fall back to just uncommitted changes
@@ -66,9 +63,7 @@ func GetBranchDiffFiles(repoDir, baseRef string) ([]DiffFileInfo, error) {
 	}
 
 	// 2. Get line stats: git diff --numstat baseRef...HEAD
-	numstatCmd := exec.Command("git", "diff", "--numstat", baseRef+"...HEAD")
-	numstatCmd.Dir = repoDir
-	numstatOut, _ := numstatCmd.Output() // Ignore errors, stats are optional
+	numstatOut, _ := runGitOutput(OpDiff, repoDir, "diff", "--numstat", baseRef+"...HEAD") // Ignore errors, stats are optional
 
 	// Parse --numstat output
 	// Format: "10\t5\tfile.go" (additions deletions path)
@@ -102,9 +97,7 @@ func GetBranchDiffFiles(repoDir, baseRef string) ([]DiffFileInfo, error) {
 	// --untracked-files=all expands a brand-new untracked directory into
 	// its individual files; without it, git collapses the whole folder
 	// into a single "?? dir/" entry, which hides every file inside.
-	porcelainCmd := exec.Command("git", "status", "--porcelain", "--untracked-files=all")
-	porcelainCmd.Dir = repoDir
-	porcelainOut, _ := porcelainCmd.Output()
+	porcelainOut, _ := runGitOutput(OpStatus, repoDir, "status", "--porcelain", "--untracked-files=all")
 
 	uncommittedFiles := make(map[string]bool)
 	if len(porcelainOut) > 0 {
@@ -147,9 +140,7 @@ func GetBranchDiffFiles(repoDir, baseRef string) ([]DiffFileInfo, error) {
 	// 4. Get line stats for uncommitted changes
 	// For files that are only uncommitted (not in committed diff)
 	if len(uncommittedFiles) > 0 {
-		unstatsCmd := exec.Command("git", "diff", "--numstat")
-		unstatsCmd.Dir = repoDir
-		unstatsOut, _ := unstatsCmd.Output()
+		unstatsOut, _ := runGitOutput(OpDiff, repoDir, "diff", "--numstat")
 
 		if len(unstatsOut) > 0 {
 			lines := strings.Split(strings.TrimSpace(string(unstatsOut)), "\n")
@@ -170,9 +161,7 @@ func GetBranchDiffFiles(repoDir, baseRef string) ([]DiffFileInfo, error) {
 		}
 
 		// Also get staged numstat
-		stagedStatsCmd := exec.Command("git", "diff", "--numstat", "--cached")
-		stagedStatsCmd.Dir = repoDir
-		stagedStatsOut, _ := stagedStatsCmd.Output()
+		stagedStatsOut, _ := runGitOutput(OpDiff, repoDir, "diff", "--numstat", "--cached")
 
 		if len(stagedStatsOut) > 0 {
 			lines := strings.Split(strings.TrimSpace(string(stagedStatsOut)), "\n")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -3,7 +3,6 @@ package git
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -49,25 +48,19 @@ func GetBranchInfo(dir string) (*BranchInfo, error) {
 }
 
 func isGitRepo(dir string) bool {
-	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
-	cmd.Dir = dir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, dir, "rev-parse", "--is-inside-work-tree")
 	return err == nil && strings.TrimSpace(string(out)) == "true"
 }
 
 func getCurrentBranch(dir string) (string, error) {
 	// Try symbolic-ref first (works for normal branches)
-	cmd := exec.Command("git", "symbolic-ref", "--short", "HEAD")
-	cmd.Dir = dir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, dir, "symbolic-ref", "--short", "HEAD")
 	if err == nil {
 		return strings.TrimSpace(string(out)), nil
 	}
 
 	// Fallback to rev-parse for detached HEAD (returns short SHA)
-	cmd = exec.Command("git", "rev-parse", "--short", "HEAD")
-	cmd.Dir = dir
-	out, err = cmd.Output()
+	out, err = runGitOutput(OpMetadata, dir, "rev-parse", "--short", "HEAD")
 	if err != nil {
 		return "", err
 	}
@@ -76,9 +69,7 @@ func getCurrentBranch(dir string) (string, error) {
 
 // GetRepoRoot returns the worktree root for dir when it is inside a git worktree.
 func GetRepoRoot(dir string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	cmd.Dir = dir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, dir, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", err
 	}
@@ -114,9 +105,7 @@ func ResolvePickerRepoTarget(dir string) (repoRoot string, ok bool, err error) {
 
 // GetHeadCommit returns the full SHA of the HEAD commit
 func GetHeadCommit(dir string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "HEAD")
-	cmd.Dir = dir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, dir, "rev-parse", "HEAD")
 	if err != nil {
 		return "", err
 	}
@@ -125,9 +114,7 @@ func GetHeadCommit(dir string) (string, error) {
 
 func getWorktreeInfo(dir string) (mainRepo string, isWorktree bool) {
 	// Get the git dir
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
-	cmd.Dir = dir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, dir, "rev-parse", "--git-dir")
 	if err != nil {
 		return "", false
 	}

--- a/internal/git/resolve.go
+++ b/internal/git/resolve.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -70,8 +69,7 @@ func ResolveRepoDir(repoDir string) (string, error) {
 }
 
 func originRepoName(path string) string {
-	cmd := exec.Command("git", "-C", path, "remote", "get-url", "origin")
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpMetadata, path, "remote", "get-url", "origin")
 	if err != nil {
 		return ""
 	}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -4,7 +4,6 @@ package git
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -19,13 +18,9 @@ type WorktreeEntry struct {
 // Runs prune first to clean up any stale worktree entries
 func ListWorktrees(repoDir string) ([]WorktreeEntry, error) {
 	// Prune stale worktrees first to ensure clean listing
-	pruneCmd := exec.Command("git", "worktree", "prune")
-	pruneCmd.Dir = repoDir
-	_ = pruneCmd.Run() // Best effort - don't fail if prune fails
+	_ = runGitNoOutput(OpWorktree, repoDir, "worktree", "prune") // Best effort - don't fail if prune fails
 
-	cmd := exec.Command("git", "worktree", "list", "--porcelain")
-	cmd.Dir = repoDir
-	out, err := cmd.Output()
+	out, err := runGitOutput(OpWorktree, repoDir, "worktree", "list", "--porcelain")
 	if err != nil {
 		return nil, err
 	}
@@ -53,9 +48,7 @@ func ListWorktrees(repoDir string) ([]WorktreeEntry, error) {
 
 // CreateWorktree creates a new worktree with a new branch
 func CreateWorktree(repoDir, branch, path string) error {
-	cmd := exec.Command("git", "worktree", "add", "-b", branch, CanonicalizePath(path))
-	cmd.Dir = repoDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpWorktree, repoDir, "worktree", "add", "-b", branch, CanonicalizePath(path)); err != nil {
 		return fmt.Errorf("git worktree add failed: %s", out)
 	}
 	return nil
@@ -67,9 +60,7 @@ func CreateWorktreeFromPoint(repoDir, branch, path, startingFrom string) error {
 	if startingFrom != "" {
 		args = append(args, startingFrom)
 	}
-	cmd := exec.Command("git", args...)
-	cmd.Dir = repoDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpWorktree, repoDir, args...); err != nil {
 		return fmt.Errorf("git worktree add failed: %s", out)
 	}
 	return nil
@@ -77,13 +68,11 @@ func CreateWorktreeFromPoint(repoDir, branch, path, startingFrom string) error {
 
 // CreateWorktreeFromBranch creates a worktree from an existing branch
 func CreateWorktreeFromBranch(repoDir, branch, path string) error {
-	cmd := exec.Command("git", "worktree", "add", ExpandPath(path), branch)
 	resolvedDir, err := ResolveRepoDir(repoDir)
 	if err != nil {
 		return err
 	}
-	cmd.Dir = resolvedDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpWorktree, resolvedDir, "worktree", "add", ExpandPath(path), branch); err != nil {
 		return fmt.Errorf("git worktree add failed: %s", out)
 	}
 	return nil
@@ -100,13 +89,11 @@ func CreateWorktreeFromRemoteBranch(repoDir, remoteBranch, path string) (string,
 	}
 
 	// git worktree add <path> -b <local-branch> <remote-branch>
-	cmd := exec.Command("git", "worktree", "add", ExpandPath(path), "-b", localBranch, remoteBranch)
 	resolvedDir, err := ResolveRepoDir(repoDir)
 	if err != nil {
 		return "", err
 	}
-	cmd.Dir = resolvedDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpWorktree, resolvedDir, "worktree", "add", ExpandPath(path), "-b", localBranch, remoteBranch); err != nil {
 		return "", fmt.Errorf("git worktree add failed: %s", out)
 	}
 	return localBranch, nil
@@ -120,26 +107,20 @@ func DeleteWorktree(repoDir, path string) error {
 	// Check if directory exists
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		// Directory doesn't exist - prune stale worktree entries
-		cmd := exec.Command("git", "worktree", "prune")
-		cmd.Dir = repoDir
-		if out, err := cmd.CombinedOutput(); err != nil {
+		if out, err := runGitCombined(OpWorktree, repoDir, "worktree", "prune"); err != nil {
 			return fmt.Errorf("git worktree prune failed: %s", out)
 		}
 		return nil
 	}
 
 	// Directory exists - remove normally
-	cmd := exec.Command("git", "worktree", "remove", path)
-	cmd.Dir = repoDir
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := runGitCombined(OpWorktree, repoDir, "worktree", "remove", path); err != nil {
 		return fmt.Errorf("git worktree remove failed: %s", out)
 	}
 
 	// Always prune after removal to ensure git metadata is fully cleaned
 	// This prevents the worktree from reappearing in subsequent list operations
-	pruneCmd := exec.Command("git", "worktree", "prune")
-	pruneCmd.Dir = repoDir
-	_ = pruneCmd.Run() // Best effort - don't fail if prune fails
+	_ = runGitNoOutput(OpWorktree, repoDir, "worktree", "prune") // Best effort - don't fail if prune fails
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Add a shared git command runner with operation-specific long timeouts and slow-command daemon logging.
- Route git metadata, status, diff, fetch, clone, and worktree operations through the runner.
- Reduce background git pressure and extend frontend waits for long git/GitHub operations.

## Why
Gigantic monorepos can make normal git operations take far longer than attn's old assumptions. The previous behavior could make the UI report timeouts while the daemon was still legitimately working.

## Validation
- `go test ./internal/git ./internal/daemon`
- `pnpm --dir app test -- useDaemonSocket`