### PR TITLE
[codex] Improve Changes panel git refresh UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Changed
 - **Large Repository Git Operations**: Git worktree, status, diff, fetch, clone, and repository metadata operations now use shared long-running command handling with slow-command daemon logging. UI waits for these operations are much longer, and background git polling is less aggressive so giant monorepos are less likely to look failed while Git is still working.
+- **Changes Panel Refreshes**: The Changes panel now keeps the last successful diff visible while background refreshes run or fail, using small stale/refresh indicators instead of replacing existing results with loading placeholders.
 
 ---
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -579,6 +579,7 @@ sendFetchPRDetails,
   const [branchDiffFiles, setBranchDiffFiles] = useState<BranchDiffFile[]>([]);
   const [branchDiffBaseRef, setBranchDiffBaseRef] = useState('');
   const [branchDiffError, setBranchDiffError] = useState<string | null>(null);
+  const [branchDiffLoaded, setBranchDiffLoaded] = useState(false);
   const [branchDiffLoading, setBranchDiffLoading] = useState(false);
   const [branchDiffRefreshing, setBranchDiffRefreshing] = useState(false);
 
@@ -1605,10 +1606,12 @@ sendFetchPRDetails,
         setBranchDiffBaseRef(result.base_ref);
         setBranchDiffError(null);
         branchDiffLoadedRef.current = true;
+        setBranchDiffLoaded(true);
       } else {
         if (!branchDiffLoadedRef.current) {
           setBranchDiffFiles([]);
           setBranchDiffBaseRef(result.base_ref || '');
+          setBranchDiffLoaded(false);
         }
         setBranchDiffError(result.error || 'Failed to load branch diff');
       }
@@ -1617,6 +1620,7 @@ sendFetchPRDetails,
       if (!branchDiffLoadedRef.current) {
         setBranchDiffFiles([]);
         setBranchDiffBaseRef('');
+        setBranchDiffLoaded(false);
       }
       setBranchDiffError(err instanceof Error ? err.message : 'Failed to load branch diff');
     } finally {
@@ -1630,6 +1634,7 @@ sendFetchPRDetails,
   useEffect(() => {
     branchDiffRequestId.current += 1;
     branchDiffLoadedRef.current = false;
+    setBranchDiffLoaded(false);
     setBranchDiffFiles([]);
     setBranchDiffBaseRef('');
     setBranchDiffError(null);
@@ -1640,6 +1645,7 @@ sendFetchPRDetails,
   useEffect(() => {
     if (view !== 'session' || !activeRepoDaemonSession?.directory) {
       branchDiffLoadedRef.current = false;
+      setBranchDiffLoaded(false);
       setBranchDiffFiles([]);
       setBranchDiffBaseRef('');
       setBranchDiffError(null);
@@ -2041,6 +2047,7 @@ sendFetchPRDetails,
                   branchDiffFiles={branchDiffFiles}
                   branchDiffBaseRef={branchDiffBaseRef}
                   branchDiffError={branchDiffError}
+                  branchDiffLoaded={branchDiffLoaded}
                   branchDiffLoading={branchDiffLoading}
                   branchDiffRefreshing={branchDiffRefreshing}
                   selectedFile={null}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -579,6 +579,8 @@ sendFetchPRDetails,
   const [branchDiffFiles, setBranchDiffFiles] = useState<BranchDiffFile[]>([]);
   const [branchDiffBaseRef, setBranchDiffBaseRef] = useState('');
   const [branchDiffError, setBranchDiffError] = useState<string | null>(null);
+  const [branchDiffLoading, setBranchDiffLoading] = useState(false);
+  const [branchDiffRefreshing, setBranchDiffRefreshing] = useState(false);
 
   // Worktree cleanup prompt state
   const [closedWorktree, setClosedWorktree] = useState<{ path: string; branch?: string } | null>(null);
@@ -1588,8 +1590,12 @@ sendFetchPRDetails,
   }, [activeRepoDaemonSession?.directory, sendGetFileDiff]);
 
   const branchDiffRequestId = useRef(0);
+  const branchDiffLoadedRef = useRef(false);
   const refreshBranchDiff = useCallback(async (directory: string) => {
     const requestId = ++branchDiffRequestId.current;
+    const hadLoadedBranchDiff = branchDiffLoadedRef.current;
+    setBranchDiffLoading(!hadLoadedBranchDiff);
+    setBranchDiffRefreshing(hadLoadedBranchDiff);
     setBranchDiffError(null);
     try {
       const result = await sendGetBranchDiffFiles(directory);
@@ -1597,31 +1603,48 @@ sendFetchPRDetails,
       if (result.success) {
         setBranchDiffFiles(result.files);
         setBranchDiffBaseRef(result.base_ref);
+        setBranchDiffError(null);
+        branchDiffLoadedRef.current = true;
       } else {
-        setBranchDiffFiles([]);
-        setBranchDiffBaseRef(result.base_ref || '');
+        if (!branchDiffLoadedRef.current) {
+          setBranchDiffFiles([]);
+          setBranchDiffBaseRef(result.base_ref || '');
+        }
         setBranchDiffError(result.error || 'Failed to load branch diff');
       }
     } catch (err) {
       if (requestId !== branchDiffRequestId.current) return;
-      setBranchDiffFiles([]);
-      setBranchDiffBaseRef('');
+      if (!branchDiffLoadedRef.current) {
+        setBranchDiffFiles([]);
+        setBranchDiffBaseRef('');
+      }
       setBranchDiffError(err instanceof Error ? err.message : 'Failed to load branch diff');
+    } finally {
+      if (requestId === branchDiffRequestId.current) {
+        setBranchDiffLoading(false);
+        setBranchDiffRefreshing(false);
+      }
     }
   }, [sendGetBranchDiffFiles]);
 
   useEffect(() => {
     branchDiffRequestId.current += 1;
+    branchDiffLoadedRef.current = false;
     setBranchDiffFiles([]);
     setBranchDiffBaseRef('');
     setBranchDiffError(null);
+    setBranchDiffLoading(false);
+    setBranchDiffRefreshing(false);
   }, [activeRepoDaemonSession?.directory]);
 
   useEffect(() => {
     if (view !== 'session' || !activeRepoDaemonSession?.directory) {
+      branchDiffLoadedRef.current = false;
       setBranchDiffFiles([]);
       setBranchDiffBaseRef('');
       setBranchDiffError(null);
+      setBranchDiffLoading(false);
+      setBranchDiffRefreshing(false);
       return;
     }
 
@@ -2018,6 +2041,8 @@ sendFetchPRDetails,
                   branchDiffFiles={branchDiffFiles}
                   branchDiffBaseRef={branchDiffBaseRef}
                   branchDiffError={branchDiffError}
+                  branchDiffLoading={branchDiffLoading}
+                  branchDiffRefreshing={branchDiffRefreshing}
                   selectedFile={null}
                   onFileSelect={handleFileSelect}
                   onOpenDiffClick={handleOpenDiffDetailPanel}

--- a/app/src/components/ChangesPanel.css
+++ b/app/src/components/ChangesPanel.css
@@ -30,6 +30,28 @@
   gap: 8px;
 }
 
+.changes-refreshing,
+.changes-warning {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  line-height: 1;
+  border-radius: 4px;
+  padding: 3px 6px;
+}
+
+.changes-refreshing {
+  color: #93c5fd;
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.24);
+}
+
+.changes-warning {
+  color: #fbbf24;
+  background: rgba(251, 191, 36, 0.11);
+  border: 1px solid rgba(251, 191, 36, 0.24);
+}
+
 .editor-btn {
   background: rgba(31, 41, 55, 0.7);
   border: 1px solid #374151;
@@ -190,6 +212,16 @@
   padding: 12px;
   color: #ef4444;
   font-size: var(--font-size-sm);
+}
+
+.changes-inline-warning {
+  margin: 0 12px 8px;
+  padding: 7px 8px;
+  border: 1px solid rgba(251, 191, 36, 0.22);
+  border-radius: 4px;
+  background: rgba(251, 191, 36, 0.08);
+  color: #d6a72a;
+  font-size: var(--font-size-xs);
 }
 
 .changes-loading {

--- a/app/src/components/ChangesPanel.test.tsx
+++ b/app/src/components/ChangesPanel.test.tsx
@@ -29,7 +29,7 @@ describe('ChangesPanel', () => {
   });
 
   it('shows no changes after an empty successful load', () => {
-    renderPanel({ branchDiffLoading: false });
+    renderPanel({ branchDiffLoaded: true, branchDiffLoading: false });
 
     expect(screen.getByText('No changes')).toBeInTheDocument();
     expect(document.querySelector('.changes-loading')).not.toBeInTheDocument();
@@ -39,6 +39,7 @@ describe('ChangesPanel', () => {
     renderPanel({
       branchDiffFiles: changedFiles,
       branchDiffBaseRef: 'origin/main',
+      branchDiffLoaded: true,
       branchDiffRefreshing: true,
     });
 
@@ -52,9 +53,22 @@ describe('ChangesPanel', () => {
     renderPanel({
       branchDiffFiles: changedFiles,
       branchDiffError: 'Get branch diff files timed out',
+      branchDiffLoaded: true,
     });
 
     expect(screen.getByTitle('app/src/App.tsx')).toBeInTheDocument();
+    expect(screen.getByText('Could not refresh changes. Showing last result.')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Stale' })).toBeInTheDocument();
+    expect(screen.queryByText('Get branch diff files timed out')).not.toBeInTheDocument();
+  });
+
+  it('keeps the empty no-changes state visible when refresh fails after data loaded', () => {
+    renderPanel({
+      branchDiffError: 'Get branch diff files timed out',
+      branchDiffLoaded: true,
+    });
+
+    expect(screen.getByText('No changes')).toBeInTheDocument();
     expect(screen.getByText('Could not refresh changes. Showing last result.')).toBeInTheDocument();
     expect(screen.getByRole('status', { name: 'Stale' })).toBeInTheDocument();
     expect(screen.queryByText('Get branch diff files timed out')).not.toBeInTheDocument();

--- a/app/src/components/ChangesPanel.test.tsx
+++ b/app/src/components/ChangesPanel.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ChangesPanel } from './ChangesPanel';
+import type { BranchDiffFile } from '../hooks/useDaemonSocket';
+
+const changedFiles: BranchDiffFile[] = [
+  { path: 'app/src/App.tsx', status: 'modified', additions: 12, deletions: 3 },
+  { path: 'internal/git/command.go', status: 'added', additions: 20 },
+];
+
+function renderPanel(overrides: Partial<ComponentProps<typeof ChangesPanel>> = {}) {
+  return render(
+    <ChangesPanel
+      branchDiffFiles={[]}
+      selectedFile={null}
+      onFileSelect={vi.fn()}
+      {...overrides}
+    />
+  );
+}
+
+describe('ChangesPanel', () => {
+  it('shows initial loading only when explicitly loading', () => {
+    renderPanel({ branchDiffLoading: true });
+
+    expect(screen.queryByText('No changes')).not.toBeInTheDocument();
+    expect(document.querySelector('.changes-loading')).toBeInTheDocument();
+  });
+
+  it('shows no changes after an empty successful load', () => {
+    renderPanel({ branchDiffLoading: false });
+
+    expect(screen.getByText('No changes')).toBeInTheDocument();
+    expect(document.querySelector('.changes-loading')).not.toBeInTheDocument();
+  });
+
+  it('keeps files visible during background refresh', () => {
+    renderPanel({
+      branchDiffFiles: changedFiles,
+      branchDiffBaseRef: 'origin/main',
+      branchDiffRefreshing: true,
+    });
+
+    expect(screen.getByTitle('app/src/App.tsx')).toBeInTheDocument();
+    expect(screen.getByTitle('internal/git/command.go')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Refreshing' })).toBeInTheDocument();
+    expect(document.querySelector('.changes-loading')).not.toBeInTheDocument();
+  });
+
+  it('keeps the last files visible when refresh fails after data loaded', () => {
+    renderPanel({
+      branchDiffFiles: changedFiles,
+      branchDiffError: 'Get branch diff files timed out',
+    });
+
+    expect(screen.getByTitle('app/src/App.tsx')).toBeInTheDocument();
+    expect(screen.getByText('Could not refresh changes. Showing last result.')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Stale' })).toBeInTheDocument();
+    expect(screen.queryByText('Get branch diff files timed out')).not.toBeInTheDocument();
+  });
+
+  it('shows the error as the main body when no previous data exists', () => {
+    renderPanel({ branchDiffError: 'Get branch diff files timed out' });
+
+    expect(screen.getByText('Get branch diff files timed out')).toBeInTheDocument();
+    expect(screen.queryByText('Could not refresh changes. Showing last result.')).not.toBeInTheDocument();
+  });
+});

--- a/app/src/components/ChangesPanel.tsx
+++ b/app/src/components/ChangesPanel.tsx
@@ -7,6 +7,7 @@ interface ChangesPanelProps {
   branchDiffFiles: BranchDiffFile[];
   branchDiffBaseRef?: string;
   branchDiffError?: string | null;
+  branchDiffLoaded?: boolean;
   branchDiffLoading?: boolean;
   branchDiffRefreshing?: boolean;
   selectedFile: string | null;
@@ -109,6 +110,7 @@ export const ChangesPanel = memo(function ChangesPanel({
   branchDiffFiles,
   branchDiffBaseRef,
   branchDiffError,
+  branchDiffLoaded = false,
   branchDiffLoading = false,
   branchDiffRefreshing = false,
   selectedFile,
@@ -121,9 +123,10 @@ export const ChangesPanel = memo(function ChangesPanel({
 
     return { files: branchDiffFiles.length, additions, deletions };
   }, [branchDiffFiles]);
+  const hasLoadedResult = branchDiffLoaded;
   const hasFiles = totalStats.files > 0;
-  const isInitialLoading = branchDiffLoading && !hasFiles && !branchDiffError;
-  const showInlineWarning = Boolean(branchDiffError && hasFiles);
+  const isInitialLoading = branchDiffLoading && !hasLoadedResult && !branchDiffError;
+  const showInlineWarning = Boolean(branchDiffError && hasLoadedResult);
 
   // Memoize tree building to avoid rebuilding on every render
   const branchTree = useMemo(() => buildTree(branchDiffFiles), [branchDiffFiles]);
@@ -189,7 +192,7 @@ export const ChangesPanel = memo(function ChangesPanel({
       <div className="changes-header">
         <span className="changes-title">Changes</span>
         <div className="changes-header-actions">
-          {branchDiffRefreshing && hasFiles && (
+          {branchDiffRefreshing && hasLoadedResult && (
             <span className="changes-refreshing" role="status" aria-label="Refreshing">Refreshing</span>
           )}
           {showInlineWarning && (
@@ -218,7 +221,7 @@ export const ChangesPanel = memo(function ChangesPanel({
             Could not refresh changes. Showing last result.
           </div>
         )}
-        {branchDiffError && !hasFiles ? (
+        {branchDiffError && !hasLoadedResult ? (
           <div className="changes-error">{branchDiffError}</div>
         ) : isInitialLoading ? (
           <div className="changes-loading">

--- a/app/src/components/ChangesPanel.tsx
+++ b/app/src/components/ChangesPanel.tsx
@@ -7,6 +7,8 @@ interface ChangesPanelProps {
   branchDiffFiles: BranchDiffFile[];
   branchDiffBaseRef?: string;
   branchDiffError?: string | null;
+  branchDiffLoading?: boolean;
+  branchDiffRefreshing?: boolean;
   selectedFile: string | null;
   onFileSelect: (path: string, staged: boolean) => void;
   onOpenDiffClick?: () => void;
@@ -107,6 +109,8 @@ export const ChangesPanel = memo(function ChangesPanel({
   branchDiffFiles,
   branchDiffBaseRef,
   branchDiffError,
+  branchDiffLoading = false,
+  branchDiffRefreshing = false,
   selectedFile,
   onFileSelect,
   onOpenDiffClick,
@@ -117,7 +121,9 @@ export const ChangesPanel = memo(function ChangesPanel({
 
     return { files: branchDiffFiles.length, additions, deletions };
   }, [branchDiffFiles]);
-  const isLoading = !branchDiffError && totalStats.files === 0;
+  const hasFiles = totalStats.files > 0;
+  const isInitialLoading = branchDiffLoading && !hasFiles && !branchDiffError;
+  const showInlineWarning = Boolean(branchDiffError && hasFiles);
 
   // Memoize tree building to avoid rebuilding on every render
   const branchTree = useMemo(() => buildTree(branchDiffFiles), [branchDiffFiles]);
@@ -183,7 +189,13 @@ export const ChangesPanel = memo(function ChangesPanel({
       <div className="changes-header">
         <span className="changes-title">Changes</span>
         <div className="changes-header-actions">
-          {totalStats.files > 0 && onOpenDiffClick && (
+          {branchDiffRefreshing && hasFiles && (
+            <span className="changes-refreshing" role="status" aria-label="Refreshing">Refreshing</span>
+          )}
+          {showInlineWarning && (
+            <span className="changes-warning" role="status" aria-label="Stale" title={branchDiffError || undefined}>Stale</span>
+          )}
+          {hasFiles && onOpenDiffClick && (
             <button className="review-btn" onClick={onOpenDiffClick} title="Open diff detail">
               Open Diff
             </button>
@@ -201,9 +213,14 @@ export const ChangesPanel = memo(function ChangesPanel({
       )}
 
       <div className="changes-body">
-        {branchDiffError ? (
+        {showInlineWarning && (
+          <div className="changes-inline-warning">
+            Could not refresh changes. Showing last result.
+          </div>
+        )}
+        {branchDiffError && !hasFiles ? (
           <div className="changes-error">{branchDiffError}</div>
-        ) : isLoading ? (
+        ) : isInitialLoading ? (
           <div className="changes-loading">
             <div className="loading-header" />
             {Array.from({ length: 5 }).map((_, index) => (

--- a/docs/plans/long-git-operation-surface-map.md
+++ b/docs/plans/long-git-operation-surface-map.md
@@ -1,0 +1,63 @@
+# Long Git Operation Surface Map
+
+Date: 2026-05-15
+
+Purpose: map every product surface that waits on git today before choosing UI patterns. The problem is not one spinner. Different surfaces need different treatment depending on whether the user is blocked, whether existing data can stay visible, and whether the surface is even mounted.
+
+## Operating Principles
+
+- Do not show a loud progress surface for every slow git command. In large repos, "slow" may be normal.
+- Prefer stale-but-usable UI for background refreshes. Mark data as refreshing only when the user needs to know.
+- Escalate only when the user is blocked from completing the action they initiated.
+- Do not anchor git operation UX only in the right dock. The right dock may be closed or irrelevant.
+- Keep terminal space for agent/user interaction. Avoid terminal overlays unless the terminal itself initiated the operation.
+- Operation state should come from daemon protocol, not inferred only from frontend promise timers.
+
+## Surface Inventory
+
+| Surface | Trigger | Daemon/git path | Current UI pattern | Blocking? | Problem in large repos | Recommended policy |
+| --- | --- | --- | --- | --- | --- | --- |
+| Active session branch metadata | Session register; branch monitor every 15s | `git.GetBranchInfo`: `rev-parse`, `symbolic-ref`, worktree detection | No explicit UI; branch/worktree badge updates when session data changes | No | Slow branch reads can lag session metadata but should not distract | Silent background. Log slow ops only. Keep previous branch/worktree metadata until fresh data arrives. |
+| Active session git status subscription | Selecting a session | `getGitStatus`: `git status --porcelain -z --untracked-files=all`, `diff --numstat`, `check-ignore` | No direct indicator; drives downstream changes state | No | Polling every 2s can be expensive; errors are logged but invisible | Background with adaptive cadence. Do not show every poll. Expose "status stale" only after repeated failures or when user opens changes. |
+| Changes panel branch diff summary | Session view open; every 30s; every git status update | `get_branch_diff_files`: default branch lookup, `git diff --name-status`, `--numstat`, status scan | Skeleton when no files; panel error on failure | Usually no | Repeated slow diffs will make the panel feel permanently busy; dock may be closed | Preserve last result. Show compact "refreshing" in panel header only while panel is visible. If hidden, do not surface unless failure affects a later user action. Consider slowing/reducing refresh after slow results. |
+| Diff detail panel initial file list | Opening diff detail panel | `sendFetchRemotes`, then `get_branch_diff_files` | Panel-level loading/empty/error behavior | Yes, for reviewing | User intentionally opened review; they need to know why files are unavailable | Local panel progress. Show last cached list if available with "updating". Escalate timeout/error in panel, not globally. |
+| Diff detail selected file | Selecting/navigating a file | `get_file_diff`: `git show base:path`, file read, optional staged `git show :path` | Diff area loads/fails per file | Yes, for selected file | Slow per-file diff can interrupt review repeatedly | Per-file inline loading in diff area. Cache last file diff. Do not block file list navigation. |
+| Diff detail viewed-file change detection | Git status update for viewed files | Background `fetchDiff` for viewed files | No direct UI; marks changed badge | No | Can issue hidden diff reads for already-viewed files | Silent background. Cap concurrency and skip if a previous check is in flight. Surface only as a changed badge when complete. |
+| Location picker path inspection | User selects/types a path | `inspect_path`: path stat, repo root detection via git | Picker waits; errors via toast | Yes, for opening a location | Selecting repo root can feel frozen before repo options appear | Inline picker progress after short delay, tied to selected path. Keep keyboard focus and allow cancel/back. |
+| Location picker repo options load | Path inspection finds repo root | `get_repo_info`: current branch, head commit, default branch, worktree list | Picker switches to repo options after result; no intermediate repo-specific state | Yes | Large worktree lists/default branch lookup can delay opening | Inline "loading repo options" inside picker. If slow, show repo path and allow "open main repo now" if enough info exists. |
+| Repo options refresh | User refreshes repo options | `get_repo_info` | Existing options remain; refresh flag passed to `RepoOptions` | No | This is already close to correct; only needs clearer stale/refresh state | Keep stale options visible. Small header spinner/text only. |
+| Repo options create worktree | User submits create-worktree form | `create_worktree`: optional fetch remote branch, `git worktree add` | Form remains; errors toast/dialog callback; no explicit progress in form | Yes | Worktree add/fetch may take minutes; user needs cancellable progress | Inline form operation state. Disable conflicting create/delete/select actions, not whole picker. On success launch session. |
+| Repo options delete worktree | User deletes from picker | `delete_worktree`: terminate sessions, `git worktree remove`, delete branch | Await then refresh repo info; limited row state | Yes for selected row, not whole picker | Slow delete can make picker ambiguous | Row-level pending state with optimistic "deleting..." and undo only if feasible. Keep other rows usable. |
+| Fork session with worktree | User forks active session and checks create worktree | `create_worktree`, then spawn session; cleanup delete on downstream failure | Fork dialog shows errors, no long-running progress | Yes | Dialog can sit inert while worktree is created | Dialog-local progress stepper: creating worktree, starting session, cleaning up on failure. |
+| Close worktree cleanup delete | User closes session and chooses delete | `delete_worktree` | Prompt closes after await; failure only console logged | Yes, but narrow | User can lose feedback if delete hangs/fails | Keep prompt or toast-style progress until result. Show failure with retry/keep. |
+| PR dashboard refresh | User refreshes PRs | GitHub, not git | Refresh button spinner/error icon | No | Not part of git slowness, but same async vocabulary | Leave mostly as-is. Do not mix with git operation UX. |
+| Open PR into worktree | User clicks PR "New" | Fetch PR details, `ensure_repo` clone/fetch, `create_worktree_from_branch`, spawn session | No local progress; errors eventually alert/toast | Yes | This is the clearest "no right dock exists yet" case. Clone/fetch/worktree can be very long before any session appears | Global app-level job toast or launcher modal, not terminal/right dock. Show steps: fetching PR, ensuring repo, creating worktree, starting session. |
+| Ensure repo | Open PR flow | `git clone` if missing, then `git fetch --all --prune` | Hidden inside open-PR promise | Yes | Longest operation; current UI has no durable status | Needs daemon operation lifecycle events. Frontend should show progress owned by the launcher/open-PR flow. |
+| Fetch remotes | Diff detail open; ensure repo; explicit command | `git fetch --all --prune` | Hidden or panel warning | Sometimes | Can be long but not always blocking | If user opened diff detail, show panel sync state. If part of open PR, show launcher step. If background, stay quiet. |
+| Worktree list pruning | Repo info/load worktrees | `git worktree prune`, `git worktree list --porcelain` | Hidden inside repo info/list events | No unless picker waits | Can delay repo options and branch metadata | Fold into repo-options state; never global. |
+| Review loop snapshots | Start/end review loop iteration | `GetDefaultBranch`, `GetBranchDiffFiles` before and after reviewer work | Review loop bar has its own running/error state, but git snapshot time is not distinct | Yes for review loop startup/completion reporting | Slow snapshot can make review loop appear stuck before/after actual reviewer work | Keep inside review-loop panel state. Label as "capturing diff snapshot" only if slow. Do not show global git state. |
+| Latent branch protocol commands | Currently protocol/daemon only; no active frontend caller found | `list_branches`, `get_default_branch`, `list_remote_branches` | No current UI surface | N/A | Future callers may accidentally inherit generic promise/no-UX behavior | Treat as modal/picker-owned if used for branch/worktree selection. Do not add global UI by default. |
+
+## Current UI Pattern Buckets
+
+- Button-local: PR refresh, PR approve/merge. Good for short explicit actions.
+- Modal-local: Location picker, repo options, fork dialog, worktree cleanup prompt. This is where create/delete/open flows should report progress.
+- Panel-local: Changes panel and diff detail. This is where diff/status/sync state belongs when the panel is visible.
+- Silent background: branch monitor, git status polling, viewed-file change checks. These should keep prior data and avoid noisy progress.
+- Missing global job surface: open PR/ensure repo before a session exists. This needs a lightweight launcher job surface that is not terminal or right-dock anchored.
+
+## Proposed Fix Sequence
+
+1. **State model first:** add a small frontend operation taxonomy and map existing calls to `background`, `panel`, `modal`, or `launcher` ownership. This can initially be frontend-only for request promises.
+2. **Panel-local diff/status UX:** keep previous branch diff results during refresh, add subdued panel header state, and stop showing skeletons for routine refreshes after first load.
+3. **Picker/worktree modal UX:** add operation state to repo options create/delete/refresh and fork-worktree creation.
+4. **Open PR launcher job:** show durable progress while `fetch_pr_details`, `ensure_repo`, `create_worktree_from_branch`, and `createSession` run before any terminal/right dock exists.
+5. **Daemon lifecycle events:** add protocol-level `git_operation_started/updated/finished` only after the frontend ownership model is clear. Use this for true long-running git subprocesses, cancellation, and elapsed-time accuracy.
+6. **Adaptive background behavior:** reduce refresh pressure when status/diff commands are repeatedly slow, and skip hidden panel refreshes where stale cached data is good enough.
+
+## Open Questions
+
+- Should hidden Changes panel refresh at all, or only refresh on open plus git status debounce?
+- What threshold counts as "show slow state" for user-initiated actions: 500ms, 1s, or 2s?
+- Which operations should be cancellable in the UI versus merely dismissible while they continue?
+- Do we need a single global "jobs" tray eventually, or only launcher/modal/panel-local state for now?


### PR DESCRIPTION
## Summary
- add a long-git-operation surface map to guide follow-up UX work
- keep the Changes panel's last successful branch diff visible during background refreshes and refresh failures
- add subtle refreshing/stale indicators instead of replacing existing results with skeleton placeholders

## Tests
- `pnpm --dir app test -- ChangesPanel.test.tsx`
- `pnpm --dir app run build`