### PR TITLE
[codex] Improve repository picker git operation UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Changed
 - **Large Repository Git Operations**: Git worktree, status, diff, fetch, clone, and repository metadata operations now use shared long-running command handling with slow-command daemon logging. UI waits for these operations are much longer, and background git polling is less aggressive so giant monorepos are less likely to look failed while Git is still working.
 - **Changes Panel Refreshes**: The Changes panel now keeps the last successful diff visible while background refreshes run or fail, using small stale/refresh indicators instead of replacing existing results with loading placeholders.
+- **New Session Repository Picker**: The location picker now shows inline progress while inspecting paths, loading repository options, refreshing repo metadata, creating worktrees, and deleting worktrees so slow git operations do not leave the dialog looking frozen.
 
 ---
 

--- a/app/src/components/LocationPicker.css
+++ b/app/src/components/LocationPicker.css
@@ -343,6 +343,44 @@
   border-radius: 3px;
 }
 
+.picker-operation {
+  margin-top: 10px;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 18px;
+  border: 1px solid rgba(255, 107, 53, 0.18);
+  border-radius: 4px;
+  background: rgba(255, 107, 53, 0.06);
+  color: #ffb391;
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-size: var(--font-size-sm);
+}
+
+.picker-operation-pulse {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #ff6b35;
+  box-shadow: 0 0 0 0 rgba(255, 107, 53, 0.35);
+  animation: picker-operation-pulse 1.15s ease-out infinite;
+  flex: 0 0 auto;
+}
+
+.picker-operation-path {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-tertiary);
+}
+
+@keyframes picker-operation-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(255, 107, 53, 0.35); }
+  100% { box-shadow: 0 0 0 8px rgba(255, 107, 53, 0); }
+}
+
 /* Results area */
 .picker-results {
   max-height: 340px;
@@ -476,5 +514,4 @@
   min-width: 20px;
   text-align: center;
 }
-
 

--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -821,6 +821,89 @@ describe('LocationPicker', () => {
     expect(screen.queryByTestId('repo-options')).not.toBeInTheDocument();
   });
 
+  it('shows inline path inspection progress while a path submission is pending', async () => {
+    const inspectGate = deferred<Awaited<ReturnType<NonNullable<LocationPickerProps['onInspectPath']>>>>();
+    const onInspectPath = vi.fn(() => inspectGate.promise);
+    const { onSelect } = renderPicker({ onInspectPath });
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '~/projects/exsin' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(await screen.findByRole('status', { name: 'Inspecting path' })).toBeInTheDocument();
+
+    inspectGate.resolve({
+      success: true,
+      inspection: {
+        input_path: '~/projects/exsin',
+        resolved_path: '/home/remote/projects/exsin',
+        home_path: '/home/remote',
+        exists: true,
+        is_directory: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/exsin', 'claude', undefined, false);
+    });
+  });
+
+  it('clears path inspection progress when inspection fails', async () => {
+    const onInspectPath = vi.fn(async () => ({
+      success: true,
+      inspection: {
+        input_path: '~/missing',
+        resolved_path: '/home/remote/missing',
+        home_path: '/home/remote',
+        exists: false,
+        is_directory: false,
+      },
+    }));
+    const onError = vi.fn();
+    renderPicker({ onInspectPath, onError });
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '~/missing' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith('Directory not found: ~/missing');
+    });
+    expect(screen.queryByRole('status', { name: 'Inspecting path' })).not.toBeInTheDocument();
+  });
+
+  it('shows repo-options progress after path inspection finds a git repo', async () => {
+    const repoInfoGate = deferred<Awaited<ReturnType<NonNullable<LocationPickerProps['onGetRepoInfo']>>>>();
+    const onInspectPath = vi.fn(async () => ({
+      success: true,
+      inspection: {
+        input_path: '~/projects/exsin',
+        resolved_path: '/home/remote/projects/exsin',
+        home_path: '/home/remote',
+        exists: true,
+        is_directory: true,
+        repo_root: '/home/remote/projects/exsin',
+      },
+    }));
+    const onGetRepoInfo = vi.fn(() => repoInfoGate.promise);
+    renderPicker({ onInspectPath, onGetRepoInfo });
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '~/projects/exsin' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(await screen.findByRole('status', { name: 'Loading repo options' })).toBeInTheDocument();
+
+    repoInfoGate.resolve({
+      success: true,
+      info: buildRepoInfo(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('repo-options')).toBeInTheDocument();
+    });
+  });
+
   it('suppresses stale inspect errors after the picker state has changed', async () => {
     const inspectGate = deferred<Awaited<ReturnType<NonNullable<LocationPickerProps['onInspectPath']>>>>();
     const onInspectPath = vi.fn(() => inspectGate.promise);

--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -904,6 +904,35 @@ describe('LocationPicker', () => {
     });
   });
 
+  it('falls back to launching the selected path when repo options fail to load', async () => {
+    const onInspectPath = vi.fn(async () => ({
+      success: true,
+      inspection: {
+        input_path: '~/projects/exsin',
+        resolved_path: '/home/remote/projects/exsin',
+        home_path: '/home/remote',
+        exists: true,
+        is_directory: true,
+        repo_root: '/home/remote/projects/exsin',
+      },
+    }));
+    const onGetRepoInfo = vi.fn(async () => ({
+      success: false,
+      error: 'unborn HEAD',
+    }));
+    const onError = vi.fn();
+    const { onSelect } = renderPicker({ onInspectPath, onGetRepoInfo, onError });
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '~/projects/exsin' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith('unborn HEAD');
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/exsin', 'claude', undefined, false);
+    });
+  });
+
   it('suppresses stale inspect errors after the picker state has changed', async () => {
     const inspectGate = deferred<Awaited<ReturnType<NonNullable<LocationPickerProps['onInspectPath']>>>>();
     const onInspectPath = vi.fn(() => inspectGate.promise);

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -67,7 +67,7 @@ interface LocationPickerProps {
   onBrowseDirectory?: (inputPath: string, endpointId?: string) => Promise<BrowseDirectoryResult>;
   onInspectPath?: (path: string, endpointId?: string) => Promise<InspectPathResult>;
   onGetRepoInfo?: (mainRepo: string, endpointId?: string) => Promise<{ success: boolean; info?: BackendRepoInfo; error?: string }>;
-  onCreateWorktree?: (mainRepo: string, branch: string, path?: string, startingFrom?: string, endpointId?: string) => Promise<{ success: boolean; path?: string }>;
+  onCreateWorktree?: (mainRepo: string, branch: string, path?: string, startingFrom?: string, endpointId?: string) => Promise<{ success: boolean; path?: string; error?: string }>;
   onDeleteWorktree?: (path: string, endpointId?: string) => Promise<{ success: boolean; error?: string }>;
   onError?: (message: string) => void;
   projectsDirectory?: string;
@@ -183,6 +183,7 @@ export function LocationPicker({
   const [repoRootPath, setRepoRootPath] = useState<string | null>(null);
   const [repoInfo, setRepoInfo] = useState<RepoInfo | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+  const [pickerOperation, setPickerOperation] = useState<string | null>(null);
   const [hasSelectedSinceTab, setHasSelectedSinceTab] = useState(true);
   const requestGenerationRef = useRef(0);
 
@@ -352,6 +353,7 @@ export function LocationPicker({
     setRepoRootPath(null);
     setRepoInfo(null);
     setRefreshing(false);
+    setPickerOperation(null);
   }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
@@ -468,6 +470,7 @@ export function LocationPicker({
     setHighlightedItemKey(null);
     setSelectedPath('');
     setHasSelectedSinceTab(true);
+    setPickerOperation(null);
   }, [inputValue, invalidateRequestGeneration]);
 
   const handleTabComplete = useCallback((nextPath: string) => {
@@ -479,6 +482,7 @@ export function LocationPicker({
     setHighlightedItemKey(null);
     setSelectedPath('');
     setHasSelectedSinceTab(false);
+    setPickerOperation(null);
   }, [inputValue, invalidateRequestGeneration]);
 
   const handlePathSelect = useCallback((path: string) => {
@@ -500,6 +504,7 @@ export function LocationPicker({
       return;
     }
     const requestGeneration = beginRequestGeneration();
+    setPickerOperation('Inspecting path');
 
     try {
       const inspected = await onInspectPath(sanitizedPath, selectedEndpointId);
@@ -508,6 +513,7 @@ export function LocationPicker({
       }
       const inspection = inspected.inspection;
       if (!inspection?.exists || !inspection.is_directory) {
+        setPickerOperation(null);
         onError?.(`Directory not found: ${sanitizedPath}`);
         return;
       }
@@ -520,6 +526,7 @@ export function LocationPicker({
       setSelectedPathFromPhysical(resolvedPath);
       const repoRoot = inspection.repo_root;
       if (repoRoot && onGetRepoInfo) {
+        setPickerOperation('Loading repo options');
         const result = await onGetRepoInfo(repoRoot, selectedEndpointId);
         if (!isRequestCurrent(requestGeneration)) {
           return;
@@ -528,19 +535,25 @@ export function LocationPicker({
           setMode('repo-options');
           setRepoRootPath(repoRoot);
           setRepoInfo(toChooserRepoInfo(result.info));
+          setPickerOperation(null);
           return;
         }
+        onError?.(result.error || 'Failed to load repo options');
+        setPickerOperation(null);
+        return;
       }
 
       if (!isRequestCurrent(requestGeneration)) {
         return;
       }
+      setPickerOperation(null);
       launchSelection(resolvedPath);
     } catch (err) {
       if (!isRequestCurrent(requestGeneration)) {
         return;
       }
       console.log('[LocationPicker] inspect path error:', err);
+      setPickerOperation(null);
       onError?.(err instanceof Error ? err.message : String(err));
     }
   }, [
@@ -589,6 +602,7 @@ export function LocationPicker({
     setRepoInfo(null);
     setRecentLocations([]);
     setRefreshing(false);
+    setPickerOperation(null);
   }, [homePath, invalidateRequestGeneration, selectableTargets, selectedTarget.id, setSetting, yoloMode, yoloSettingKey, yoloSupported]);
 
   const handlePathInputSubmit = useCallback(() => {
@@ -635,6 +649,8 @@ export function LocationPicker({
       if (result.success && result.path) {
         setSelectedPathFromPhysical(result.path);
         launchSelection(result.path);
+      } else {
+        onError?.(result.error || 'Failed to create worktree');
       }
     } catch (err) {
       if (!isRequestCurrent(requestGeneration)) {
@@ -682,6 +698,7 @@ export function LocationPicker({
     setRepoRootPath(null);
     setRepoInfo(null);
     setRefreshing(false);
+    setPickerOperation(null);
   }, [invalidateRequestGeneration]);
 
   const movePathSelection = useCallback((direction: 'up' | 'down') => {
@@ -868,6 +885,13 @@ export function LocationPicker({
                   <span className="picker-breadcrumb-path" data-testid="location-picker-breadcrumb-path">{currentDir}</span>
                 </div>
               )}
+              {pickerOperation && (
+                <div className="picker-operation" role="status" aria-label={pickerOperation}>
+                  <span className="picker-operation-pulse" aria-hidden="true" />
+                  <span>{pickerOperation}</span>
+                  {selectedPath && <span className="picker-operation-path">{toDisplayPath(selectedPath, homePath)}</span>}
+                </div>
+              )}
             </div>
 
             <div className="picker-results">
@@ -949,11 +973,16 @@ export function LocationPicker({
             onCreateWorktree={handleCreateWorktree}
             onDeleteWorktree={onDeleteWorktree ? async (path) => {
               const requestGeneration = requestGenerationRef.current;
-              await onDeleteWorktree(path, selectedEndpointId);
+              const deleteResult = await onDeleteWorktree(path, selectedEndpointId);
+              if (!deleteResult.success) {
+                throw new Error(deleteResult.error || 'Failed to delete worktree');
+              }
               if (repoRootPath && onGetRepoInfo) {
                 const result = await onGetRepoInfo(repoRootPath, selectedEndpointId);
                 if (isRequestCurrent(requestGeneration) && result.success && result.info) {
                   setRepoInfo(toChooserRepoInfo(result.info));
+                } else if (isRequestCurrent(requestGeneration) && !result.success) {
+                  throw new Error(result.error || 'Failed to refresh repo options');
                 }
               }
             } : undefined}

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -540,6 +540,7 @@ export function LocationPicker({
         }
         onError?.(result.error || 'Failed to load repo options');
         setPickerOperation(null);
+        launchSelection(resolvedPath);
         return;
       }
 

--- a/app/src/components/NewSessionDialog/RepoOptions.css
+++ b/app/src/components/NewSessionDialog/RepoOptions.css
@@ -42,6 +42,34 @@
   flex: 0 0 auto;
 }
 
+.repo-operation-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid rgba(255, 107, 53, 0.18);
+  border-radius: 4px;
+  background: rgba(255, 107, 53, 0.06);
+  color: #ffb391;
+  font-size: var(--font-size-sm);
+}
+
+.repo-operation-dot,
+.operation-spinner {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #ff6b35;
+  box-shadow: 0 0 0 0 rgba(255, 107, 53, 0.35);
+  animation: repo-operation-pulse 1.15s ease-out infinite;
+  flex: 0 0 auto;
+}
+
+@keyframes repo-operation-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(255, 107, 53, 0.35); }
+  100% { box-shadow: 0 0 0 8px rgba(255, 107, 53, 0); }
+}
+
 /* Section headers */
 .repo-section-header {
   text-transform: uppercase;
@@ -81,6 +109,16 @@
 .repo-option-item.selected {
   background: rgba(255, 107, 53, 0.08);
   border-color: rgba(255, 107, 53, 0.2);
+}
+
+.repo-option-item[aria-disabled="true"] {
+  cursor: wait;
+  opacity: 0.68;
+}
+
+.repo-option-item.operation-running {
+  grid-template-columns: 24px minmax(0, max-content) minmax(0, 1fr);
+  cursor: wait;
 }
 
 /* Delete confirmation */
@@ -203,6 +241,11 @@
   box-shadow: 0 0 0 2px rgba(255, 107, 53, 0.1);
 }
 
+.new-worktree-input:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
 .new-worktree-input::placeholder {
   color: var(--color-text-dimmed);
 }
@@ -250,6 +293,14 @@
   text-align: center;
   padding-top: 10px;
   border-top: 1px solid var(--color-border-subtle);
+}
+
+.new-worktree-hint.operation-running {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: #ffb391;
 }
 
 .new-worktree-hint kbd {

--- a/app/src/components/NewSessionDialog/RepoOptions.test.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.test.tsx
@@ -12,6 +12,16 @@ const repoInfo = {
   worktrees: [{ path: '/tmp/repo--feature', branch: 'feature' }],
 };
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('RepoOptions', () => {
   it('selects the main repo when the row is clicked', () => {
     const onSelectMainRepo = vi.fn();
@@ -217,5 +227,86 @@ describe('RepoOptions', () => {
 
     expect(screen.queryByText(/Delete repo--feature/)).not.toBeInTheDocument();
     expect(screen.getByTestId('repo-new-worktree-form')).toBeInTheDocument();
+  });
+
+  it('keeps destinations visible while repo info is refreshing', () => {
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={vi.fn(async () => {})}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+        refreshing
+      />,
+    );
+
+    expect(screen.getByRole('status', { name: 'Refreshing repo options' })).toBeInTheDocument();
+    expect(screen.getByTestId('repo-option-0')).toBeInTheDocument();
+    expect(screen.getByTestId('repo-option-1')).toBeInTheDocument();
+  });
+
+  it('shows form-local progress while creating a worktree', async () => {
+    const createGate = deferred<void>();
+    const onCreateWorktree = vi.fn(() => createGate.promise);
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={onCreateWorktree}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('repo-option-2'));
+    fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'feature-2' } });
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+    expect(screen.getByText('Creating worktree...')).toBeInTheDocument();
+    expect(screen.getByTestId('repo-new-worktree-input')).toBeDisabled();
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+    expect(onCreateWorktree).toHaveBeenCalledTimes(1);
+
+    createGate.resolve();
+    await waitFor(() => {
+      expect(screen.getByTestId('repo-new-worktree-input')).not.toBeDisabled();
+    });
+  });
+
+  it('shows row-local progress while deleting a worktree', async () => {
+    const deleteGate = deferred<void>();
+    const onDeleteWorktree = vi.fn(() => deleteGate.promise);
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo--feature"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={vi.fn(async () => {})}
+        onDeleteWorktree={onDeleteWorktree}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'D' });
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'y' });
+
+    expect(await screen.findByRole('status', { name: 'Deleting repo--feature' })).toBeInTheDocument();
+    expect(screen.queryByText(/Delete repo--feature/)).not.toBeInTheDocument();
+
+    deleteGate.resolve();
+    await waitFor(() => {
+      expect(screen.queryByRole('status', { name: 'Deleting repo--feature' })).not.toBeInTheDocument();
+    });
   });
 });

--- a/app/src/components/NewSessionDialog/RepoOptions.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.tsx
@@ -120,6 +120,9 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   const [newWorktreeName, setNewWorktreeName] = useState('');
   const [startingBranch, setStartingBranch] = useState<'current' | 'default'>('current');
   const [pendingDeletePath, setPendingDeletePath] = useState<string | null>(null);
+  const [creatingWorktree, setCreatingWorktree] = useState(false);
+  const [deletingPath, setDeletingPath] = useState<string | null>(null);
+  const isBusy = creatingWorktree || deletingPath !== null;
 
   // Sub-state Escape handling via the stack so LIFO order is preserved.
   // pendingDeletePath and showNewWorktree are pushed above LocationPicker's handler.
@@ -187,18 +190,27 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   }, [destinationItems, onSelectedPathChange]);
 
   const openNewWorktree = useCallback(() => {
+    if (isBusy) {
+      return;
+    }
     setPendingDeletePath(null);
     setFocusIndex(createWorktreeIndex);
     setShowNewWorktree(true);
-  }, [createWorktreeIndex]);
+  }, [createWorktreeIndex, isBusy]);
 
   const beginDeleteWorktree = useCallback((path: string) => {
+    if (isBusy) {
+      return;
+    }
     setShowNewWorktree(false);
     setNewWorktreeName('');
     setPendingDeletePath(path);
-  }, []);
+  }, [isBusy]);
 
   const handleActivate = useCallback((index: number) => {
+    if (isBusy) {
+      return;
+    }
     if (index < destinationItems.length) {
       const item = destinationItems[index];
       onSelectedPathChange(item.path);
@@ -210,30 +222,40 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
       return;
     }
     openNewWorktree();
-  }, [destinationItems, onSelectMainRepo, onSelectWorktree, onSelectedPathChange, openNewWorktree]);
+  }, [destinationItems, isBusy, onSelectMainRepo, onSelectWorktree, onSelectedPathChange, openNewWorktree]);
 
   const executeDelete = useCallback(async () => {
-    if (!pendingDeletePath || !onDeleteWorktree) {
+    if (!pendingDeletePath || !onDeleteWorktree || deletingPath) {
       return;
     }
 
+    const pathToDelete = pendingDeletePath;
     const deletedIndex = destinationItems.findIndex((item) => item.path === pendingDeletePath);
     const survivingItems = destinationItems.filter((item) => item.path !== pendingDeletePath);
     const nextSelectedPath = survivingItems[Math.min(deletedIndex, survivingItems.length - 1)]?.path || repoInfo.repo;
 
     try {
-      await onDeleteWorktree(pendingDeletePath);
+      setDeletingPath(pathToDelete);
+      setPendingDeletePath(null);
+      await onDeleteWorktree(pathToDelete);
       onSelectedPathChange(nextSelectedPath);
       setFocusIndex(Math.min(deletedIndex, survivingItems.length - 1));
     } catch (err) {
       console.error('Delete failed:', err);
       onError?.(err instanceof Error ? err.message : 'Delete failed');
     } finally {
+      setDeletingPath(null);
       setPendingDeletePath(null);
     }
-  }, [destinationItems, onDeleteWorktree, onError, onSelectedPathChange, pendingDeletePath, repoInfo.repo]);
+  }, [deletingPath, destinationItems, onDeleteWorktree, onError, onSelectedPathChange, pendingDeletePath, repoInfo.repo]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (isBusy) {
+      e.stopPropagation();
+      e.preventDefault();
+      return;
+    }
+
     if (pendingDeletePath) {
       e.stopPropagation();
       if (e.key === 'y' || e.key === 'Y') {
@@ -259,7 +281,15 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
         const startFrom = startingBranch === 'current'
           ? selectedDestination?.branch || repoInfo.currentBranch
           : `origin/${repoInfo.defaultBranch}`;
-        void onCreateWorktree(newWorktreeName.trim(), startFrom);
+        setCreatingWorktree(true);
+        void onCreateWorktree(newWorktreeName.trim(), startFrom)
+          .catch((err) => {
+            console.error('Create worktree failed:', err);
+            onError?.(err instanceof Error ? err.message : 'Create worktree failed');
+          })
+          .finally(() => {
+            setCreatingWorktree(false);
+          });
         e.preventDefault();
       } else if (e.key === 'Tab') {
         setStartingBranch((prev) => prev === 'current' ? 'default' : 'current');
@@ -336,9 +366,11 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
     executeDelete,
     focusedDestination,
     handleActivate,
+    isBusy,
     newWorktreeName,
     onBack,
     onCreateWorktree,
+    onError,
     onRefresh,
     openNewWorktree,
     pendingDeletePath,
@@ -352,6 +384,17 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   const renderDestination = (itemIndex: number, item: DestinationItem) => {
     const isSelected = committedDestinationIndex === itemIndex;
     const isDeleting = pendingDeletePath === item.path;
+    const isDeleteRunning = deletingPath === item.path;
+
+    if (isDeleteRunning) {
+      return (
+        <div className="repo-option-item selected operation-running" role="status" aria-label={`Deleting ${baseName(item.path)}`}>
+          <span className="repo-option-icon operation-spinner" aria-hidden="true" />
+          <span className="repo-option-name">Deleting {baseName(item.path)}</span>
+          <span className="repo-option-detail">Removing worktree and refreshing repo options</span>
+        </div>
+      );
+    }
 
     if (isDeleting) {
       return (
@@ -386,6 +429,12 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
       onKeyDown={handleKeyDown}
     >
       <div className="repo-options-content">
+        {refreshing && (
+          <div className="repo-operation-banner" role="status" aria-label="Refreshing repo options">
+            <span className="repo-operation-dot" aria-hidden="true" />
+            <span>Refreshing repo options</span>
+          </div>
+        )}
         <div className="repo-options-destinations">
           <div className="repo-section-header">DESTINATIONS</div>
           <div
@@ -414,6 +463,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
                   placeholder="Branch name..."
                   value={newWorktreeName}
                   onChange={(e) => setNewWorktreeName(e.target.value)}
+                  disabled={creatingWorktree}
                   autoFocus
                   autoCorrect="off"
                   autoCapitalize="off"
@@ -444,8 +494,15 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
                   Start from origin/{repoInfo.defaultBranch}
                 </label>
               </div>
-              <div className="new-worktree-hint">
-                Press Enter to create • Tab to toggle • Esc to cancel
+              <div className={`new-worktree-hint ${creatingWorktree ? 'operation-running' : ''}`}>
+                {creatingWorktree ? (
+                  <>
+                    <span className="repo-operation-dot" aria-hidden="true" />
+                    Creating worktree...
+                  </>
+                ) : (
+                  'Press Enter to create • Tab to toggle • Esc to cancel'
+                )}
               </div>
             </div>
           ) : (
@@ -455,6 +512,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
               data-option-index={createWorktreeIndex}
               data-option-kind="new-worktree"
               onClick={openNewWorktree}
+              aria-disabled={isBusy}
             >
               <span className="repo-option-icon icon-blue">+</span>
               <span className="repo-option-name">Create worktree...</span>


### PR DESCRIPTION
## Summary

This is the next small slice from the long git operation surface map. It adds local progress states to the new-session repository picker and repo-options surfaces, where slow git work can happen before a terminal or right-side dock exists.

- Show inline picker status while path inspection and repository option loading are pending.
- Keep repo destinations visible while repo metadata refreshes.
- Show form-local progress while creating a worktree and row-local progress while deleting one.
- Surface create/delete/refresh failures through the existing picker error path instead of silently clearing state.
- Update the changelog for the user-visible picker behavior.

## Validation

- `rtk pnpm --dir app test -- LocationPicker.test.tsx RepoOptions.test.tsx`
- `rtk pnpm --dir app run build`
- `rtk git diff --check`