### PR TITLE
[codex] Show progress while opening PR worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Large Repository Git Operations**: Git worktree, status, diff, fetch, clone, and repository metadata operations now use shared long-running command handling with slow-command daemon logging. UI waits for these operations are much longer, and background git polling is less aggressive so giant monorepos are less likely to look failed while Git is still working.
 - **Changes Panel Refreshes**: The Changes panel now keeps the last successful diff visible while background refreshes run or fail, using small stale/refresh indicators instead of replacing existing results with loading placeholders.
 - **New Session Repository Picker**: The location picker now shows inline progress while inspecting paths, loading repository options, refreshing repo metadata, creating worktrees, and deleting worktrees so slow git operations do not leave the dialog looking frozen.
+- **Opening Pull Requests**: Opening a PR in a new worktree now shows launcher-level progress while attn fetches PR details, syncs the local repository, creates the worktree, and starts the session.
 
 ---
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,6 +14,7 @@ import { CloseSessionPrompt } from './components/CloseSessionPrompt';
 import { ChangesPanel } from './components/ChangesPanel';
 import { DiffDetailPanel } from './components/DiffDetailPanel';
 import { SessionReviewLoopBar } from './components/SessionReviewLoopBar';
+import { OpenPRLauncherProgress } from './components/OpenPRLauncherProgress';
 import { RightDock } from './components/RightDock';
 import { SessionTerminalWorkspace } from './components/SessionTerminalWorkspace';
 import { ThumbsModal } from './components/ThumbsModal';
@@ -33,7 +34,7 @@ import { usePRsNeedingAttention } from './hooks/usePRsNeedingAttention';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useUIScale } from './hooks/useUIScale';
 import { useTheme } from './hooks/useTheme';
-import { useOpenPR } from './hooks/useOpenPR';
+import { useOpenPR, type OpenPRProgress } from './hooks/useOpenPR';
 import { useUiAutomationBridge } from './hooks/useUiAutomationBridge';
 import {
   getAgentAvailability,
@@ -103,6 +104,12 @@ function toneForDockPanel(status?: string): 'default' | 'idle' | 'running' | 'aw
       return 'default';
   }
 }
+
+type OpenPRLauncherJob = {
+  id: number;
+  pr: DaemonPR;
+  progress: OpenPRProgress;
+};
 
 function App() {
   // Settings state (must be declared before useDaemonSocket to pass as callback)
@@ -532,6 +539,8 @@ sendFetchPRDetails,
   setReviewLoopStateForSession,
   clearGitStatus,
 }: AppContentProps) {
+  const [openPRLauncherJob, setOpenPRLauncherJob] = useState<OpenPRLauncherJob | null>(null);
+  const openPRLauncherIdRef = useRef(0);
   const {
     connect,
     sessions,
@@ -1421,7 +1430,26 @@ sendFetchPRDetails,
       }
       const configuredDefaultAgent = normalizeSessionAgent(settings.new_session_agent, 'claude');
       const defaultAgent = resolvePreferredAgent(configuredDefaultAgent, agentAvailability, 'codex');
-      const result = await openPR(pr, defaultAgent);
+      const launcherId = openPRLauncherIdRef.current + 1;
+      openPRLauncherIdRef.current = launcherId;
+      const isActiveLauncher = () => openPRLauncherIdRef.current === launcherId;
+      const updateLauncherProgress = (progress: OpenPRProgress) => {
+        setOpenPRLauncherJob((current) => current?.id === launcherId ? { ...current, progress } : current);
+      };
+
+      setOpenPRLauncherJob({
+        id: launcherId,
+        pr,
+        progress: { step: pr.head_branch ? 'ensuring_repo' : 'fetching_pr_details' },
+      });
+      const result = await openPR(pr, defaultAgent, { onProgress: updateLauncherProgress }).finally(() => {
+        if (isActiveLauncher()) {
+          setOpenPRLauncherJob(null);
+        }
+      });
+      if (!isActiveLauncher()) {
+        return;
+      }
       if (result.success) {
         console.log(`[App] Worktree created at ${result.worktreePath}`);
         return;
@@ -1935,6 +1963,14 @@ sendFetchPRDetails,
             ×
           </button>
         </div>
+      )}
+      {openPRLauncherJob && (
+        <OpenPRLauncherProgress
+          repo={openPRLauncherJob.pr.repo}
+          number={openPRLauncherJob.pr.number}
+          title={openPRLauncherJob.pr.title}
+          step={openPRLauncherJob.progress.step}
+        />
       )}
       {/* Dashboard - always rendered, shown/hidden via z-index */}
       <div className={`view-container ${view === 'dashboard' ? 'visible' : 'hidden'}`}>

--- a/app/src/App.worktreeCleanup.test.tsx
+++ b/app/src/App.worktreeCleanup.test.tsx
@@ -10,6 +10,7 @@ const mockSendUnregisterSession = vi.fn();
 const mockUseKeyboardShortcuts = vi.fn();
 const mockSendWorkspaceClosePane = vi.fn(async () => ({ success: true }));
 const mockCloseSession = vi.fn();
+const mockOpenPR = vi.hoisted(() => vi.fn());
 
 vi.mock('@tauri-apps/plugin-deep-link', () => ({
   onOpenUrl: vi.fn(async () => () => {}),
@@ -41,7 +42,34 @@ vi.mock('./components/Sidebar', () => ({
   ),
 }));
 
-vi.mock('./components/Dashboard', () => ({ Dashboard: () => null }));
+vi.mock('./components/Dashboard', () => ({
+  Dashboard: ({ onOpenPR }: { onOpenPR?: (pr: Record<string, unknown>) => void }) => (
+    <button
+      data-testid="open-pr"
+      onClick={() => onOpenPR?.({
+        approved_by_me: false,
+        author: 'octo',
+        details_fetched: true,
+        has_new_changes: false,
+        head_branch: 'feature/slow-pr',
+        host: 'github.com',
+        id: 'pr-1',
+        last_polled: '2026-05-16T00:00:00Z',
+        last_updated: '2026-05-16T00:00:00Z',
+        muted: false,
+        number: 42,
+        reason: 'review_requested',
+        repo: 'acme/widgets',
+        role: 'reviewer',
+        state: 'open',
+        title: 'Make widgets faster',
+        url: 'https://github.com/acme/widgets/pull/42',
+      })}
+    >
+      Open PR
+    </button>
+  ),
+}));
 vi.mock('./components/AttentionDrawer', () => ({ AttentionDrawer: () => null }));
 vi.mock('./components/LocationPicker', () => ({ LocationPicker: () => null }));
 vi.mock('./components/UndoToast', () => ({ UndoToast: () => null }));
@@ -83,12 +111,7 @@ vi.mock('./hooks/useUIScale', () => ({
 }));
 
 vi.mock('./hooks/useOpenPR', () => ({
-  useOpenPR: () =>
-    vi.fn(async () => ({
-      success: true,
-      worktreePath: '/tmp/wt',
-      sessionId: 's1',
-    })),
+  useOpenPR: () => mockOpenPR,
 }));
 
 vi.mock('./hooks/usePRsNeedingAttention', () => ({
@@ -113,6 +136,11 @@ describe('worktree cleanup prompt', () => {
     vi.clearAllMocks();
     localStorage.clear();
     vi.useRealTimers();
+    mockOpenPR.mockResolvedValue({
+      success: true,
+      worktreePath: '/tmp/wt',
+      sessionId: 's1',
+    });
     mockSendWorkspaceClosePane.mockResolvedValue({ success: true });
 
     mockUseSessionStore.mockReturnValue({
@@ -340,6 +368,64 @@ describe('worktree cleanup prompt', () => {
     });
 
     expect(sendSessionVisualized).toHaveBeenCalledWith('remote-1');
+  });
+
+  it('only lets the active PR launcher request update or clear progress', async () => {
+    const progressHandlers: Array<(progress: { step: string }) => void> = [];
+    const resolvers: Array<(result: { success: true; worktreePath: string; sessionId: string }) => void> = [];
+
+    mockUseSessionStore.mockReturnValue({
+      sessions: [],
+      activeSessionId: null,
+      connect: vi.fn(async () => {}),
+      connected: true,
+      launcherConfig: { executables: {} },
+      createSession: vi.fn(async () => 's1'),
+      closeSession: mockCloseSession,
+      setActiveSession: vi.fn(),
+      takeSessionSpawnArgs: vi.fn(() => null),
+      reloadSession: vi.fn(async () => {}),
+      setForkParams: vi.fn(),
+      setLauncherConfig: vi.fn(),
+      syncFromDaemonSessions: vi.fn(),
+      syncFromDaemonWorkspaces: vi.fn(),
+    });
+
+    mockOpenPR.mockImplementation((_pr, _agent, options) => new Promise((resolve) => {
+      progressHandlers.push(options.onProgress);
+      resolvers.push(resolve);
+    }));
+
+    render(<App />);
+
+    await userEvent.click(screen.getByTestId('open-pr'));
+    expect(screen.getByRole('status')).toHaveTextContent('Ensuring local repository');
+
+    await userEvent.click(screen.getByTestId('open-pr'));
+
+    act(() => {
+      progressHandlers[0]({ step: 'creating_worktree' });
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('Ensuring local repository');
+
+    act(() => {
+      progressHandlers[1]({ step: 'starting_session' });
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('Starting session');
+
+    await act(async () => {
+      resolvers[0]({ success: true, worktreePath: '/tmp/first', sessionId: 's1' });
+      await Promise.resolve();
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('Starting session');
+
+    await act(async () => {
+      resolvers[1]({ success: true, worktreePath: '/tmp/second', sessionId: 's2' });
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
   });
 
   it('prompts before closing a split session from the main pane with Cmd+W', async () => {

--- a/app/src/components/OpenPRLauncherProgress.css
+++ b/app/src/components/OpenPRLauncherProgress.css
@@ -1,0 +1,129 @@
+.open-pr-launcher {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  z-index: 8000;
+  width: min(520px, calc(100vw - 32px));
+  transform: translateX(-50%);
+  padding: 14px 16px 12px;
+  border: 1px solid rgba(255, 107, 53, 0.26);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(26, 26, 29, 0.96) 0%, rgba(13, 13, 15, 0.98) 100%);
+  box-shadow:
+    0 18px 46px rgba(0, 0, 0, 0.52),
+    0 0 0 1px rgba(255, 255, 255, 0.03),
+    0 0 32px rgba(255, 107, 53, 0.08);
+  color: var(--color-text-primary);
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+}
+
+.open-pr-launcher-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+  margin-bottom: 6px;
+}
+
+.open-pr-launcher-kicker {
+  color: #ff6b35;
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.open-pr-launcher-target {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-sm);
+}
+
+.open-pr-launcher-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+}
+
+.open-pr-launcher-current {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  color: #ffb391;
+  font-size: var(--font-size-sm);
+}
+
+.open-pr-launcher-pulse,
+.open-pr-launcher-step-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #ff6b35;
+  flex: 0 0 auto;
+}
+
+.open-pr-launcher-pulse {
+  box-shadow: 0 0 0 0 rgba(255, 107, 53, 0.35);
+  animation: open-pr-launcher-pulse 1.15s ease-out infinite;
+}
+
+@keyframes open-pr-launcher-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(255, 107, 53, 0.35); }
+  100% { box-shadow: 0 0 0 8px rgba(255, 107, 53, 0); }
+}
+
+.open-pr-launcher-steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.open-pr-launcher-step {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.open-pr-launcher-step span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.open-pr-launcher-step.done {
+  color: var(--color-text-tertiary);
+}
+
+.open-pr-launcher-step.active {
+  color: #ffb391;
+}
+
+.open-pr-launcher-step.pending .open-pr-launcher-step-dot {
+  background: var(--color-border-hover);
+}
+
+.open-pr-launcher-step.done .open-pr-launcher-step-dot {
+  background: #ff6b35;
+  opacity: 0.7;
+}
+
+@media (max-width: 560px) {
+  .open-pr-launcher {
+    bottom: 14px;
+  }
+
+  .open-pr-launcher-steps {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/app/src/components/OpenPRLauncherProgress.test.tsx
+++ b/app/src/components/OpenPRLauncherProgress.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { OpenPRLauncherProgress } from './OpenPRLauncherProgress';
+
+describe('OpenPRLauncherProgress', () => {
+  it('shows the current launcher step and PR identity', () => {
+    render(
+      <OpenPRLauncherProgress
+        repo="acme/widgets"
+        number={42}
+        title="Make widgets faster"
+        step="creating_worktree"
+      />,
+    );
+
+    expect(screen.getByRole('status', { name: 'Opening PR 42' })).toBeInTheDocument();
+    expect(screen.getByText('acme/widgets#42')).toBeInTheDocument();
+    expect(screen.getByText('Make widgets faster')).toBeInTheDocument();
+    expect(screen.getByText('Creating worktree')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/OpenPRLauncherProgress.tsx
+++ b/app/src/components/OpenPRLauncherProgress.tsx
@@ -1,0 +1,52 @@
+import type { OpenPRProgressStep } from '../hooks/useOpenPR';
+import './OpenPRLauncherProgress.css';
+
+interface OpenPRLauncherProgressProps {
+  repo: string;
+  number: number;
+  title: string;
+  step: OpenPRProgressStep;
+}
+
+const STEPS: Array<{ step: OpenPRProgressStep; label: string }> = [
+  { step: 'fetching_pr_details', label: 'Fetch PR' },
+  { step: 'ensuring_repo', label: 'Sync repo' },
+  { step: 'creating_worktree', label: 'Create worktree' },
+  { step: 'starting_session', label: 'Start session' },
+];
+
+const STEP_COPY: Record<OpenPRProgressStep, string> = {
+  fetching_pr_details: 'Fetching branch details',
+  ensuring_repo: 'Ensuring local repository',
+  creating_worktree: 'Creating worktree',
+  starting_session: 'Starting session',
+};
+
+export function OpenPRLauncherProgress({ repo, number, title, step }: OpenPRLauncherProgressProps) {
+  const activeIndex = Math.max(0, STEPS.findIndex((entry) => entry.step === step));
+
+  return (
+    <div className="open-pr-launcher" role="status" aria-live="polite" aria-label={`Opening PR ${number}`}>
+      <div className="open-pr-launcher-header">
+        <span className="open-pr-launcher-kicker">Opening PR</span>
+        <span className="open-pr-launcher-target">{repo}#{number}</span>
+      </div>
+      <div className="open-pr-launcher-title">{title}</div>
+      <div className="open-pr-launcher-current">
+        <span className="open-pr-launcher-pulse" aria-hidden="true" />
+        <span>{STEP_COPY[step]}</span>
+      </div>
+      <div className="open-pr-launcher-steps" aria-hidden="true">
+        {STEPS.map((entry, index) => {
+          const state = index < activeIndex ? 'done' : index === activeIndex ? 'active' : 'pending';
+          return (
+            <div key={entry.step} className={`open-pr-launcher-step ${state}`}>
+              <span className="open-pr-launcher-step-dot" />
+              <span>{entry.label}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/src/hooks/useOpenPR.test.tsx
+++ b/app/src/hooks/useOpenPR.test.tsx
@@ -1,0 +1,84 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useOpenPR, type OpenPRProgressStep } from './useOpenPR';
+import type { DaemonPR } from './useDaemonSocket';
+import { PRRole } from '../types/generated';
+
+function buildPR(overrides: Partial<DaemonPR> = {}): DaemonPR {
+  return {
+    approved_by_me: false,
+    author: 'octo',
+    details_fetched: true,
+    has_new_changes: false,
+    head_branch: 'feature/slow-pr',
+    host: 'github.com',
+    id: 'pr-1',
+    last_polled: '2026-05-16T00:00:00Z',
+    last_updated: '2026-05-16T00:00:00Z',
+    muted: false,
+    number: 42,
+    reason: 'review_requested',
+    repo: 'acme/widgets',
+    role: PRRole.Reviewer,
+    state: 'open',
+    title: 'Make widgets faster',
+    url: 'https://github.com/acme/widgets/pull/42',
+    ...overrides,
+  };
+}
+
+describe('useOpenPR', () => {
+  it('reports launcher progress for each blocking git/session step', async () => {
+    const progress: OpenPRProgressStep[] = [];
+    const sendFetchPRDetails = vi.fn();
+    const sendEnsureRepo = vi.fn(async () => ({ success: true }));
+    const sendCreateWorktreeFromBranch = vi.fn(async () => ({ success: true, path: '/projects/widgets--feature-slow-pr' }));
+    const createSession = vi.fn(async () => 'session-1');
+    const { result } = renderHook(() => useOpenPR({
+      settings: { projects_directory: '/projects' },
+      sendFetchPRDetails,
+      sendEnsureRepo,
+      sendCreateWorktreeFromBranch,
+      createSession,
+    }));
+
+    let openResult: Awaited<ReturnType<typeof result.current>>;
+    await act(async () => {
+      openResult = await result.current(buildPR(), 'codex', {
+        onProgress: (next) => progress.push(next.step),
+      });
+    });
+
+    expect(openResult!).toMatchObject({ success: true, sessionId: 'session-1' });
+    expect(progress).toEqual(['ensuring_repo', 'creating_worktree', 'starting_session']);
+    expect(sendFetchPRDetails).not.toHaveBeenCalled();
+  });
+
+  it('reports PR detail progress before repo sync when branch data is missing', async () => {
+    const progress: OpenPRProgressStep[] = [];
+    const sendFetchPRDetails = vi.fn(async () => ({
+      success: true,
+      prs: [buildPR({ head_branch: 'feature/from-details' })],
+    }));
+    const sendEnsureRepo = vi.fn(async () => ({ success: true }));
+    const sendCreateWorktreeFromBranch = vi.fn(async () => ({ success: true, path: '/projects/widgets--feature-from-details' }));
+    const createSession = vi.fn(async () => 'session-1');
+    const { result } = renderHook(() => useOpenPR({
+      settings: { projects_directory: '/projects' },
+      sendFetchPRDetails,
+      sendEnsureRepo,
+      sendCreateWorktreeFromBranch,
+      createSession,
+    }));
+
+    await act(async () => {
+      await result.current(buildPR({ head_branch: undefined }), 'codex', {
+        onProgress: (next) => progress.push(next.step),
+      });
+    });
+
+    expect(progress).toEqual(['fetching_pr_details', 'ensuring_repo', 'creating_worktree', 'starting_session']);
+    expect(sendEnsureRepo).toHaveBeenCalledWith('/projects/widgets', 'https://github.com/acme/widgets.git');
+    expect(sendCreateWorktreeFromBranch).toHaveBeenCalledWith('/projects/widgets', 'origin/feature/from-details');
+  });
+});

--- a/app/src/hooks/useOpenPR.ts
+++ b/app/src/hooks/useOpenPR.ts
@@ -17,9 +17,23 @@ export interface OpenPRError {
   message?: string;
 }
 
+export type OpenPRProgressStep =
+  | 'fetching_pr_details'
+  | 'ensuring_repo'
+  | 'creating_worktree'
+  | 'starting_session';
+
+export interface OpenPRProgress {
+  step: OpenPRProgressStep;
+}
+
 export type OpenPRResult =
   | { success: true; sessionId: string; worktreePath: string; pr: DaemonPR }
   | { success: false; error: OpenPRError };
+
+export interface OpenPROptions {
+  onProgress?: (progress: OpenPRProgress) => void;
+}
 
 export interface UseOpenPRDeps {
   settings: DaemonSettings;
@@ -39,7 +53,7 @@ export function useOpenPR({
   sendCreateWorktreeFromBranch,
   createSession,
 }: UseOpenPRDeps) {
-  return useCallback(async (pr: DaemonPR, agent?: SessionAgent): Promise<OpenPRResult> => {
+  return useCallback(async (pr: DaemonPR, agent?: SessionAgent, options: OpenPROptions = {}): Promise<OpenPRResult> => {
     const projectsDir = settings.projects_directory;
     if (!projectsDir) {
       return { success: false, error: { kind: 'missing_projects_directory' } };
@@ -47,6 +61,7 @@ export function useOpenPR({
 
     let prWithBranch = pr;
     if (!prWithBranch.head_branch) {
+      options.onProgress?.({ step: 'fetching_pr_details' });
       let detailsResult: { success: boolean; prs?: DaemonPR[]; error?: string };
       try {
         detailsResult = await sendFetchPRDetails(pr.id);
@@ -83,6 +98,7 @@ export function useOpenPR({
     const cloneUrl = `https://${pr.host}/${pr.repo}.git`;
 
     // Ensure repo exists (clone if needed) and fetch remotes
+    options.onProgress?.({ step: 'ensuring_repo' });
     let ensureResult: { success: boolean; cloned?: boolean; error?: string };
     try {
       ensureResult = await sendEnsureRepo(localRepoPath, cloneUrl);
@@ -98,6 +114,7 @@ export function useOpenPR({
     }
 
     const remoteBranch = `origin/${prWithBranch.head_branch}`;
+    options.onProgress?.({ step: 'creating_worktree' });
     let worktreeResult: { success: boolean; path?: string; error?: string };
     try {
       worktreeResult = await sendCreateWorktreeFromBranch(localRepoPath, remoteBranch);
@@ -113,6 +130,7 @@ export function useOpenPR({
     }
 
     const label = `${repoName}#${pr.number}`;
+    options.onProgress?.({ step: 'starting_session' });
     let sessionId: string;
     try {
       sessionId = await createSession(label, worktreeResult.path, undefined, agent);


### PR DESCRIPTION
## Summary

This is the next launcher-surface slice for long git operations. Opening a PR into a new worktree can spend time before a terminal, session, or right dock exists, so this PR adds a durable app-level progress panel for that flow.

- Add progress callbacks to `useOpenPR` for fetching PR details, ensuring/syncing the repo, creating the worktree, and starting the session.
- Render a small launcher progress panel from `App` while the open-PR flow is running.
- Add focused tests for the progress sequence and the rendered launcher panel.
- Update the changelog for the user-visible behavior.

## Validation

- `rtk pnpm --dir app test -- useOpenPR.test.tsx OpenPRLauncherProgress.test.tsx`
- `rtk pnpm --dir app run build`
- `rtk git diff --check`