### PR TITLE
Improve worktree cleanup delete progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-05-16]
 
+### Changed
+- **Worktree Cleanup Prompt**: Deleting a closed session's worktree now stays visible while Git runs, collapses into a resumable bottom-right cleanup job when the operation takes longer than an instant, and keeps failures actionable with retry/keep choices instead of closing silently.
+
 ### Removed
 - **Session Forking**: Removed the local Fork Session dialog, its keyboard shortcut, and the `fork_session` spawn path so attn no longer exposes or forwards session-fork launches.
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -592,6 +592,10 @@ sendFetchPRDetails,
 
   // Worktree cleanup prompt state
   const [closedWorktree, setClosedWorktree] = useState<{ path: string; branch?: string } | null>(null);
+  const [worktreeCleanupState, setWorktreeCleanupState] = useState<{
+    isDeleting: boolean;
+    error: string | null;
+  }>({ isDeleting: false, error: null });
   const [pendingSessionClose, setPendingSessionClose] = useState<{
     id: string;
     label: string;
@@ -1203,6 +1207,7 @@ sendFetchPRDetails,
 
         if (isLastSession && !alwaysKeepWorktrees) {
           // Show cleanup prompt
+          setWorktreeCleanupState({ isDeleting: false, error: null });
           setClosedWorktree({ path: session.cwd, branch: session.branch });
         }
       }
@@ -1395,23 +1400,30 @@ sendFetchPRDetails,
 
   // Worktree cleanup prompt handlers
   const handleWorktreeKeep = useCallback(() => {
+    setWorktreeCleanupState({ isDeleting: false, error: null });
     setClosedWorktree(null);
   }, []);
 
   const handleWorktreeDelete = useCallback(async () => {
-    if (closedWorktree) {
-      try {
-        await sendDeleteWorktree(closedWorktree.path);
-        // Note: Deleted paths are automatically filtered by daemon on next fetch
-      } catch (err) {
-        console.error('[App] Failed to delete worktree:', err);
-      }
+    if (!closedWorktree || worktreeCleanupState.isDeleting) {
+      return;
     }
-    setClosedWorktree(null);
-  }, [closedWorktree, sendDeleteWorktree]);
+    setWorktreeCleanupState({ isDeleting: true, error: null });
+    try {
+      await sendDeleteWorktree(closedWorktree.path);
+      // Note: Deleted paths are automatically filtered by daemon on next fetch
+      setWorktreeCleanupState({ isDeleting: false, error: null });
+      setClosedWorktree(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete worktree';
+      console.error('[App] Failed to delete worktree:', err);
+      setWorktreeCleanupState({ isDeleting: false, error: message });
+    }
+  }, [closedWorktree, sendDeleteWorktree, worktreeCleanupState.isDeleting]);
 
   const handleWorktreeAlwaysKeep = useCallback(() => {
     setAlwaysKeepWorktrees(true);
+    setWorktreeCleanupState({ isDeleting: false, error: null });
     setClosedWorktree(null);
   }, []);
 
@@ -2091,6 +2103,8 @@ sendFetchPRDetails,
         isVisible={closedWorktree !== null}
         worktreePath={closedWorktree?.path || ''}
         branchName={closedWorktree?.branch}
+        isDeleting={worktreeCleanupState.isDeleting}
+        deleteError={worktreeCleanupState.error}
         onKeep={handleWorktreeKeep}
         onDelete={handleWorktreeDelete}
         onAlwaysKeep={handleWorktreeAlwaysKeep}

--- a/app/src/components/WorktreeCleanupPrompt.css
+++ b/app/src/components/WorktreeCleanupPrompt.css
@@ -2,75 +2,227 @@
 
 .worktree-cleanup-prompt {
   position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 200;
-  animation: fadeIn 0.2s ease-out;
+  inset: 0;
+  z-index: 8000;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: var(--color-bg-overlay);
+  opacity: 1;
+  backdrop-filter: blur(2px);
+  transition: opacity 180ms ease, backdrop-filter 180ms ease;
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translate(-50%, -50%) scale(1);
-  }
+.worktree-cleanup-prompt.surface-hidden {
+  opacity: 0;
+  visibility: hidden;
+  backdrop-filter: blur(0);
+  pointer-events: none;
+}
+
+.worktree-cleanup-prompt.motion-fade {
+  opacity: 0;
+  backdrop-filter: blur(0);
+  pointer-events: none;
+}
+
+.worktree-cleanup-prompt.motion-target .cleanup-content {
+  animation: none;
+}
+
+.worktree-cleanup-prompt.motion-underlay {
+  opacity: 0;
+  backdrop-filter: blur(0);
+  pointer-events: none;
+}
+
+.worktree-cleanup-prompt.motion-underlay.motion-lit {
+  opacity: 1;
+  backdrop-filter: blur(2px);
+}
+
+.worktree-cleanup-prompt.motion-underlay .cleanup-content {
+  opacity: 0;
 }
 
 .cleanup-content {
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: 16px 20px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-  min-width: 320px;
-  text-align: center;
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr);
+  gap: 14px;
+  width: min(560px, calc(100vw - 36px));
+  background:
+    linear-gradient(135deg, rgba(255, 107, 53, 0.08), transparent 42%),
+    linear-gradient(180deg, var(--color-bg-elevated), var(--color-bg-panel));
+  border: 1px solid var(--color-border-hover);
+  border-radius: 8px;
+  padding: 18px 20px 20px;
+  box-shadow:
+    0 22px 76px rgba(0, 0, 0, 0.54),
+    0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.cleanup-content:focus {
+  outline: none;
+}
+
+.cleanup-status-pin {
+  width: 10px;
+  min-height: 72px;
+  border-radius: 999px;
+  background: #ff6b35;
+  box-shadow: 0 0 28px rgba(255, 107, 53, 0.34);
+}
+
+.cleanup-status-pin.failed {
+  background: #ef4444;
+  box-shadow: 0 0 28px rgba(239, 68, 68, 0.32);
+}
+
+.cleanup-copy {
+  min-width: 0;
 }
 
 .cleanup-title {
-  font-family: 'JetBrains Mono', monospace;
+  margin-bottom: 7px;
+  color: #ff9a6f;
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
   font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.1em;
+  font-weight: 700;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--color-text-muted);
-  margin-bottom: 8px;
+}
+
+.cleanup-heading {
+  color: var(--color-text-primary);
+  font-size: 18px;
+  font-weight: 650;
+  line-height: 1.2;
 }
 
 .cleanup-message {
-  font-size: 14px;
-  color: var(--color-text-primary);
-  margin-bottom: 16px;
+  display: grid;
+  gap: 5px;
+  margin-top: 10px;
 }
 
 .cleanup-branch {
-  color: #a78bfa;
-  font-family: 'JetBrains Mono', monospace;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
   font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cleanup-path {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-text-muted);
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cleanup-operation {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px 14px;
+  margin-top: 14px;
+  padding: 11px 12px;
+  border: 1px solid rgba(255, 107, 53, 0.28);
+  border-radius: 7px;
+  background: rgba(255, 107, 53, 0.07);
+}
+
+.cleanup-operation.failed {
+  border-color: rgba(239, 68, 68, 0.36);
+  background: rgba(239, 68, 68, 0.09);
+}
+
+.cleanup-operation-label {
+  color: var(--color-text-primary);
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.cleanup-operation-detail {
+  grid-column: 1 / -1;
+  overflow: hidden;
+  color: var(--color-text-muted);
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-size: 11px;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+}
+
+.cleanup-meter,
+.compact-meter {
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-app);
+}
+
+.cleanup-meter {
+  width: 98px;
+  height: 7px;
+}
+
+.cleanup-meter span,
+.compact-meter span {
+  display: block;
+  width: 46%;
+  height: 100%;
+  background: repeating-linear-gradient(
+    90deg,
+    #ff6b35 0 14px,
+    #ffb391 14px 18px
+  );
+  animation: worktree-cleanup-meter 950ms linear infinite;
+}
+
+@keyframes worktree-cleanup-meter {
+  from { transform: translateX(-18px); }
+  to { transform: translateX(18px); }
 }
 
 .cleanup-actions {
+  grid-column: 1 / -1;
   display: flex;
+  align-items: center;
+  justify-content: flex-end;
   gap: 8px;
-  justify-content: center;
+  margin-top: 18px;
 }
 
 .cleanup-btn {
-  padding: 8px 16px;
+  min-height: 34px;
+  padding: 8px 13px;
+  border: 1px solid transparent;
   border-radius: 6px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 650;
   cursor: pointer;
-  transition: all 0.15s;
-  border: 1px solid transparent;
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease, transform 140ms ease;
 }
 
-.cleanup-btn:focus-visible {
-  outline: 2px solid rgba(167, 139, 250, 0.7);
+.cleanup-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.cleanup-btn:focus-visible,
+.worktree-cleanup-compact:focus-visible {
+  outline: 2px solid rgba(255, 107, 53, 0.72);
   outline-offset: 2px;
+}
+
+.cleanup-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+  transform: none;
 }
 
 .cleanup-btn.keep {
@@ -79,26 +231,213 @@
   border-color: var(--color-border-hover);
 }
 
-.cleanup-btn.keep:hover {
+.cleanup-btn.keep:hover:not(:disabled) {
   background: var(--color-border-hover);
 }
 
-.cleanup-btn.delete {
-  background: rgba(239, 68, 68, 0.1);
-  color: #ef4444;
-  border-color: rgba(239, 68, 68, 0.2);
+.cleanup-btn.always {
+  background: transparent;
+  color: var(--color-text-muted);
+  border-color: transparent;
 }
 
-.cleanup-btn.delete:hover {
+.cleanup-btn.always:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.cleanup-btn.delete,
+.cleanup-btn.retry {
+  background: rgba(239, 68, 68, 0.12);
+  color: #ffb4ad;
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
+.cleanup-btn.delete:hover:not(:disabled),
+.cleanup-btn.retry:hover:not(:disabled) {
   background: rgba(239, 68, 68, 0.2);
 }
 
-.cleanup-btn.always {
-  background: none;
-  color: var(--color-text-muted);
-  border: none;
+.worktree-cleanup-compact {
+  position: fixed;
+  right: 22px;
+  bottom: 22px;
+  z-index: 8000;
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr);
+  gap: 12px;
+  width: min(360px, calc(100vw - 44px));
+  padding: 12px;
+  border: 1px solid rgba(255, 107, 53, 0.36);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(255, 107, 53, 0.09), transparent 45%),
+    rgba(20, 20, 22, 0.97);
+  color: var(--color-text-primary);
+  text-align: left;
+  cursor: pointer;
+  box-shadow:
+    0 18px 56px rgba(0, 0, 0, 0.48),
+    0 0 0 1px rgba(255, 255, 255, 0.03);
 }
 
-.cleanup-btn.always:hover {
-  color: var(--color-text-tertiary);
+.worktree-cleanup-compact:hover {
+  border-color: rgba(255, 107, 53, 0.58);
+  background:
+    linear-gradient(135deg, rgba(255, 107, 53, 0.13), transparent 45%),
+    rgba(28, 28, 31, 0.98);
+}
+
+.worktree-cleanup-compact.failed {
+  border-color: rgba(239, 68, 68, 0.52);
+  background:
+    linear-gradient(135deg, rgba(239, 68, 68, 0.12), transparent 45%),
+    rgba(31, 20, 20, 0.97);
+}
+
+.worktree-cleanup-compact.surface-hidden {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px) scale(0.98);
+  pointer-events: none;
+}
+
+.worktree-cleanup-compact.motion-fade {
+  opacity: 0;
+  transform: translateY(8px) scale(0.98);
+  transition: opacity 160ms ease, transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.worktree-cleanup-compact.motion-target {
+  animation: none;
+}
+
+.compact-pin {
+  width: 8px;
+  min-height: 54px;
+  border-radius: 999px;
+  background: #ff6b35;
+  box-shadow: 0 0 22px rgba(255, 107, 53, 0.34);
+}
+
+.worktree-cleanup-compact.failed .compact-pin {
+  background: #ef4444;
+  box-shadow: 0 0 22px rgba(239, 68, 68, 0.34);
+}
+
+.compact-copy {
+  min-width: 0;
+}
+
+.compact-kicker {
+  display: block;
+  margin-bottom: 5px;
+  color: #ff9a6f;
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.worktree-cleanup-compact.failed .compact-kicker {
+  color: #ff8f87;
+}
+
+.compact-title {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-size: 13px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compact-detail {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 7px;
+  color: var(--color-text-muted);
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-size: 11px;
+}
+
+.compact-detail > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compact-meter {
+  width: 82px;
+  height: 6px;
+  flex: 0 0 auto;
+}
+
+.worktree-cleanup-compact.failed .compact-meter span {
+  width: 100%;
+  background: #ef4444;
+  animation: none;
+}
+
+.motion-ghost {
+  position: fixed !important;
+  right: auto !important;
+  bottom: auto !important;
+  z-index: 8010;
+  margin: 0 !important;
+  pointer-events: none;
+  transform-origin: top left;
+  overflow: hidden;
+  will-change: transform, opacity;
+  contain: layout paint;
+}
+
+.motion-ghost.cleanup-content,
+.motion-ghost.worktree-cleanup-compact {
+  animation: none;
+}
+
+@media (max-width: 640px) {
+  .worktree-cleanup-prompt {
+    padding: 16px;
+  }
+
+  .cleanup-content {
+    width: calc(100vw - 32px);
+    padding: 16px;
+  }
+
+  .cleanup-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .cleanup-btn {
+    width: 100%;
+  }
+
+  .worktree-cleanup-compact {
+    right: 14px;
+    bottom: 14px;
+    width: calc(100vw - 28px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .worktree-cleanup-prompt,
+  .worktree-cleanup-compact,
+  .cleanup-btn,
+  .cleanup-meter span,
+  .compact-meter span {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
 }

--- a/app/src/components/WorktreeCleanupPrompt.test.tsx
+++ b/app/src/components/WorktreeCleanupPrompt.test.tsx
@@ -118,4 +118,18 @@ describe('WorktreeCleanupPrompt', () => {
     fireEvent.keyDown(screen.getByRole('dialog'), { key: 'ArrowRight' });
     expect(screen.getByRole('button', { name: 'Always keep' })).toHaveFocus();
   });
+
+  it('keeps Tab trapped on the dialog while delete is running', async () => {
+    render(<WorktreeCleanupPrompt {...defaultProps} isDeleting />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveFocus();
+
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+    expect(dialog).toHaveFocus();
+  });
 });

--- a/app/src/components/WorktreeCleanupPrompt.test.tsx
+++ b/app/src/components/WorktreeCleanupPrompt.test.tsx
@@ -113,9 +113,9 @@ describe('WorktreeCleanupPrompt', () => {
     expect(keepButton).toHaveFocus();
 
     fireEvent.keyDown(screen.getByRole('dialog'), { key: 'ArrowRight' });
-    expect(screen.getByRole('button', { name: 'Always keep' })).toHaveFocus();
+    expect(screen.getByRole('button', { name: 'Delete worktree' })).toHaveFocus();
 
     fireEvent.keyDown(screen.getByRole('dialog'), { key: 'ArrowRight' });
-    expect(screen.getByRole('button', { name: 'Delete worktree' })).toHaveFocus();
+    expect(screen.getByRole('button', { name: 'Always keep' })).toHaveFocus();
   });
 });

--- a/app/src/components/WorktreeCleanupPrompt.test.tsx
+++ b/app/src/components/WorktreeCleanupPrompt.test.tsx
@@ -1,0 +1,121 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetEscapeStackForTest } from '../hooks/useEscapeStack';
+import { WorktreeCleanupPrompt } from './WorktreeCleanupPrompt';
+
+const defaultProps = {
+  isVisible: true,
+  worktreePath: '/tmp/repo/.worktrees/feature-a',
+  branchName: 'feature-a',
+  onKeep: vi.fn(),
+  onDelete: vi.fn(),
+  onAlwaysKeep: vi.fn(),
+};
+
+describe('WorktreeCleanupPrompt', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Element.prototype.getBoundingClientRect = vi.fn(function getBoundingClientRect(this: Element) {
+      if (this.classList.contains('worktree-cleanup-compact')) {
+        return {
+          x: 900,
+          y: 680,
+          left: 900,
+          top: 680,
+          right: 1240,
+          bottom: 760,
+          width: 340,
+          height: 80,
+          toJSON: () => ({}),
+        } as DOMRect;
+      }
+      return {
+        x: 360,
+        y: 230,
+        left: 360,
+        top: 230,
+        right: 920,
+        bottom: 430,
+        width: 560,
+        height: 200,
+        toJSON: () => ({}),
+      } as DOMRect;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    _resetEscapeStackForTest();
+  });
+
+  it('collapses a slow delete into a keyboard-focusable compact job', async () => {
+    const { container, rerender } = render(<WorktreeCleanupPrompt {...defaultProps} />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    rerender(<WorktreeCleanupPrompt {...defaultProps} isDeleting />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700);
+    });
+
+    const compactJob = screen.getByRole('button', { name: /cleanup running/i });
+    expect(compactJob).toHaveFocus();
+    expect(container.querySelector('.worktree-cleanup-prompt')).toHaveClass('surface-hidden');
+
+    fireEvent.click(compactJob);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(container.querySelector('.worktree-cleanup-prompt')).not.toHaveClass('surface-hidden');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(container.querySelector('.worktree-cleanup-prompt')).not.toHaveClass('surface-hidden');
+  });
+
+  it('keeps a failed delete resumable from compact mode', async () => {
+    const { rerender } = render(<WorktreeCleanupPrompt {...defaultProps} isDeleting />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700);
+    });
+    rerender(
+      <WorktreeCleanupPrompt
+        {...defaultProps}
+        deleteError="git worktree remove failed: contains modified files"
+      />
+    );
+
+    const compactJob = screen.getByRole('button', { name: /delete failed/i });
+    expect(compactJob).toHaveClass('failed');
+
+    fireEvent.click(compactJob);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    const retryButton = screen.getByRole('button', { name: 'Retry delete' });
+    expect(retryButton).toHaveFocus();
+    expect(screen.getByRole('alert')).toHaveTextContent('contains modified files');
+  });
+
+  it('supports arrow-key navigation between available actions', async () => {
+    render(<WorktreeCleanupPrompt {...defaultProps} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    const keepButton = screen.getByRole('button', { name: 'Keep' });
+    expect(keepButton).toHaveFocus();
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'ArrowRight' });
+    expect(screen.getByRole('button', { name: 'Always keep' })).toHaveFocus();
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'ArrowRight' });
+    expect(screen.getByRole('button', { name: 'Delete worktree' })).toHaveFocus();
+  });
+});

--- a/app/src/components/WorktreeCleanupPrompt.tsx
+++ b/app/src/components/WorktreeCleanupPrompt.tsx
@@ -1,5 +1,5 @@
 // app/src/components/WorktreeCleanupPrompt.tsx
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 import { useEscapeStack } from '../hooks/useEscapeStack';
 import './WorktreeCleanupPrompt.css';
@@ -8,6 +8,8 @@ interface WorktreeCleanupPromptProps {
   isVisible: boolean;
   worktreePath: string;
   branchName?: string;
+  isDeleting?: boolean;
+  deleteError?: string | null;
   onKeep: () => void;
   onDelete: () => void;
   onAlwaysKeep: () => void;
@@ -17,22 +19,197 @@ export function WorktreeCleanupPrompt({
   isVisible,
   worktreePath,
   branchName,
+  isDeleting = false,
+  deleteError = null,
   onKeep,
   onDelete,
   onAlwaysKeep,
 }: WorktreeCleanupPromptProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const compactRef = useRef<HTMLButtonElement>(null);
   const keepRef = useRef<HTMLButtonElement>(null);
   const deleteRef = useRef<HTMLButtonElement>(null);
   const alwaysRef = useRef<HTMLButtonElement>(null);
+  const mountedRef = useRef(false);
+  const compactTimerRef = useRef<number | null>(null);
+  const wasDeletingRef = useRef(false);
+  const setCompactAnimatedRef = useRef<(next: boolean, focus?: boolean) => void>(() => {});
+  const [isCompact, setIsCompact] = useState(false);
 
-  useEscapeStack(onKeep, isVisible);
+  const displayName = branchName || worktreePath.split('/').pop() || 'worktree';
+  const hasError = Boolean(deleteError);
+
+  const clearCompactTimer = useCallback(() => {
+    if (compactTimerRef.current !== null) {
+      window.clearTimeout(compactTimerRef.current);
+      compactTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      clearCompactTimer();
+    };
+  }, [clearCompactTimer]);
+
+  const actionButtons = useCallback(() => {
+    return [keepRef.current, alwaysRef.current, deleteRef.current].filter((button) => {
+      return button && !button.disabled;
+    }) as HTMLButtonElement[];
+  }, []);
+
+  const focusPrimary = useCallback(() => {
+    requestAnimationFrame(() => {
+      if (isDeleting) {
+        dialogRef.current?.focus();
+        return;
+      }
+      if (hasError) {
+        deleteRef.current?.focus();
+        return;
+      }
+      keepRef.current?.focus();
+    });
+  }, [hasError, isDeleting]);
+
+  const createMotionGhost = useCallback((source: HTMLElement, rect: DOMRect) => {
+    const ghost = source.cloneNode(true) as HTMLElement;
+    ghost.removeAttribute('id');
+    ghost.querySelectorAll('[id]').forEach((node) => node.removeAttribute('id'));
+    ghost.classList.remove(
+      'surface-hidden',
+      'motion-fade',
+      'motion-target',
+      'motion-underlay',
+      'motion-lit',
+    );
+    ghost.classList.add('motion-ghost');
+    ghost.setAttribute('aria-hidden', 'true');
+    ghost.style.left = `${rect.left}px`;
+    ghost.style.top = `${rect.top}px`;
+    ghost.style.width = `${rect.width}px`;
+    ghost.style.height = `${rect.height}px`;
+    document.body.appendChild(ghost);
+    return ghost;
+  }, []);
+
+  const finishMotion = useCallback((ghost: HTMLElement, callback: () => void) => {
+    let done = false;
+    const complete = (event?: TransitionEvent) => {
+      if (event && event.propertyName !== 'transform') {
+        return;
+      }
+      if (done) {
+        return;
+      }
+      done = true;
+      ghost.removeEventListener('transitionend', complete);
+      callback();
+      requestAnimationFrame(() => ghost.remove());
+    };
+    ghost.addEventListener('transitionend', complete);
+    window.setTimeout(() => complete(), 360);
+  }, []);
+
+  const applyCompact = useCallback((next: boolean, focus = true) => {
+    if (!mountedRef.current) {
+      return;
+    }
+    setIsCompact(next);
+    if (focus) {
+      requestAnimationFrame(() => {
+        if (next) {
+          compactRef.current?.focus();
+        } else {
+          focusPrimary();
+        }
+      });
+    }
+  }, [focusPrimary]);
+
+  const setCompactAnimated = useCallback((next: boolean, focus = true) => {
+    if (next === isCompact) {
+      applyCompact(next, focus);
+      return;
+    }
+
+    const overlay = overlayRef.current;
+    const dialog = dialogRef.current;
+    const compact = compactRef.current;
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+    if (!overlay || !dialog || !compact || reduceMotion) {
+      applyCompact(next, focus);
+      return;
+    }
+
+    if (next) {
+      const from = dialog.getBoundingClientRect();
+      const to = compact.getBoundingClientRect();
+      if (!from.width || !from.height || !to.width || !to.height) {
+        applyCompact(true, focus);
+        return;
+      }
+      const ghost = createMotionGhost(dialog, from);
+      overlay.classList.add('motion-fade');
+      ghost.getBoundingClientRect();
+      ghost.style.transition = 'transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1), opacity 220ms ease';
+      ghost.style.transform = `translate(${to.left - from.left}px, ${to.top - from.top}px) scale(${to.width / from.width}, ${to.height / from.height})`;
+      ghost.style.opacity = '0.08';
+      finishMotion(ghost, () => {
+        compact.classList.add('motion-target');
+        applyCompact(true, focus);
+        overlay.classList.remove('motion-fade');
+        requestAnimationFrame(() => compact.classList.remove('motion-target'));
+      });
+      return;
+    }
+
+    const from = compact.getBoundingClientRect();
+    const to = dialog.getBoundingClientRect();
+    if (!from.width || !from.height || !to.width || !to.height) {
+      applyCompact(false, focus);
+      return;
+    }
+    const ghost = createMotionGhost(dialog, to);
+    overlay.classList.add('motion-target', 'motion-underlay');
+    overlay.classList.remove('surface-hidden');
+    overlay.getBoundingClientRect();
+    overlay.classList.add('motion-lit');
+    compact.classList.add('motion-fade');
+    ghost.style.transform = `translate(${from.left - to.left}px, ${from.top - to.top}px) scale(${from.width / to.width}, ${from.height / to.height})`;
+    ghost.style.opacity = '0.16';
+    ghost.getBoundingClientRect();
+    ghost.style.transition = 'transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1), opacity 220ms ease';
+    ghost.style.transform = 'translate(0, 0) scale(1, 1)';
+    ghost.style.opacity = '1';
+    finishMotion(ghost, () => {
+      overlay.classList.remove('motion-underlay', 'motion-lit');
+      applyCompact(false, focus);
+      compact.classList.remove('motion-fade');
+      requestAnimationFrame(() => overlay.classList.remove('motion-target'));
+    });
+  }, [applyCompact, createMotionGhost, finishMotion, isCompact]);
+
+  useEffect(() => {
+    setCompactAnimatedRef.current = setCompactAnimated;
+  }, [setCompactAnimated]);
+
+  const handleEscape = useCallback(() => {
+    if (isDeleting) {
+      setCompactAnimated(true);
+      return;
+    }
+    onKeep();
+  }, [isDeleting, onKeep, setCompactAnimated]);
+
+  useEscapeStack(handleEscape, isVisible && !isCompact);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
-      const buttons = [keepRef.current, deleteRef.current, alwaysRef.current].filter(
-        Boolean
-      ) as HTMLButtonElement[];
+      const buttons = actionButtons();
 
       if (event.key === 'Tab') {
         if (buttons.length === 0) return;
@@ -55,65 +232,152 @@ export function WorktreeCleanupPrompt({
       buttons[nextIndex]?.focus();
       event.preventDefault();
     },
-    []
+    [actionButtons]
   );
 
   useEffect(() => {
     if (!isVisible) return;
-    const focusKeepIfNeeded = () => {
+    const focusInitial = () => {
       const active = document.activeElement as HTMLElement | null;
-      if (active && dialogRef.current?.contains(active)) {
+      if (
+        active
+        && (dialogRef.current?.contains(active) || compactRef.current === active)
+      ) {
         return;
       }
-      keepRef.current?.focus();
+      focusPrimary();
     };
-    focusKeepIfNeeded();
-    const raf = requestAnimationFrame(focusKeepIfNeeded);
-    const timeoutId = window.setTimeout(focusKeepIfNeeded, 50);
+    focusInitial();
+    const raf = requestAnimationFrame(focusInitial);
+    const timeoutId = window.setTimeout(focusInitial, 50);
     return () => {
       cancelAnimationFrame(raf);
       window.clearTimeout(timeoutId);
     };
-  }, [isVisible]);
+  }, [focusPrimary, isVisible]);
+
+  useEffect(() => {
+    if (!isVisible) {
+      clearCompactTimer();
+      wasDeletingRef.current = false;
+      setIsCompact(false);
+      return;
+    }
+    if (!isDeleting) {
+      clearCompactTimer();
+      wasDeletingRef.current = false;
+      return;
+    }
+    if (wasDeletingRef.current) {
+      return;
+    }
+    wasDeletingRef.current = true;
+    compactTimerRef.current = window.setTimeout(() => {
+      setCompactAnimatedRef.current(true, true);
+    }, 280);
+    return clearCompactTimer;
+  }, [clearCompactTimer, isDeleting, isVisible]);
+
+  useEffect(() => {
+    if (hasError) {
+      clearCompactTimer();
+    }
+  }, [clearCompactTimer, hasError]);
 
   if (!isVisible) return null;
 
-  const displayName = branchName || worktreePath.split('/').pop() || 'worktree';
+  const dialogTitle = hasError
+    ? 'Worktree was not deleted'
+    : isDeleting
+      ? 'Deleting worktree'
+      : 'Keep this worktree for later?';
+  const dialogKicker = hasError ? 'Action needed' : isDeleting ? 'Cleanup running' : 'Session closed';
+  const statusCopy = hasError
+    ? deleteError
+    : isDeleting
+      ? 'git worktree remove'
+      : 'Local branch workspace';
+  const compactKicker = hasError ? 'Delete failed' : 'Cleanup running';
+  const compactTitle = hasError ? `${displayName} still exists` : `Deleting ${displayName}`;
 
   return (
-    <div className="worktree-cleanup-prompt" role="presentation">
+    <>
       <div
-        ref={dialogRef}
-        className="cleanup-content"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="worktree-cleanup-title"
-        aria-describedby="worktree-cleanup-message"
-        onKeyDown={handleKeyDown}
+        ref={overlayRef}
+        className={`worktree-cleanup-prompt ${isCompact ? 'surface-hidden' : ''}`}
+        role="presentation"
       >
-        <div className="cleanup-title" id="worktree-cleanup-title">
-          Session closed
-        </div>
-        <div className="cleanup-message" id="worktree-cleanup-message">
-          Keep worktree <span className="cleanup-branch">{displayName}</span> for later?
-        </div>
-        <div className="cleanup-actions">
-          <button ref={keepRef} type="button" autoFocus className="cleanup-btn keep" onClick={onKeep}>
-            Keep
-          </button>
-          <button ref={deleteRef} type="button" className="cleanup-btn delete" onClick={onDelete}>
-            Delete
-          </button>
-          <button
-            ref={alwaysRef}
-            type="button"
-            className="cleanup-btn always"
-            onClick={onAlwaysKeep}
-          >
-            Always keep (this app run)
-          </button>
+        <div
+          ref={dialogRef}
+          className="cleanup-content"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="worktree-cleanup-title"
+          aria-describedby="worktree-cleanup-message"
+          tabIndex={-1}
+          onKeyDown={handleKeyDown}
+        >
+          <div className={`cleanup-status-pin ${hasError ? 'failed' : ''}`} aria-hidden="true" />
+          <div className="cleanup-copy">
+            <div className="cleanup-title">{dialogKicker}</div>
+            <div className="cleanup-heading" id="worktree-cleanup-title">
+              {dialogTitle}
+            </div>
+            <div className="cleanup-message" id="worktree-cleanup-message">
+              <span className="cleanup-branch">{displayName}</span>
+              <span className="cleanup-path">{worktreePath}</span>
+            </div>
+            {(isDeleting || hasError) && (
+              <div className={`cleanup-operation ${hasError ? 'failed' : ''}`} role={isDeleting ? 'status' : 'alert'}>
+                <span className="cleanup-operation-label">{hasError ? 'Delete failed' : 'Removing worktree'}</span>
+                <span className="cleanup-operation-detail">{statusCopy}</span>
+                {isDeleting && <span className="cleanup-meter" aria-hidden="true"><span /></span>}
+              </div>
+            )}
+          </div>
+          <div className="cleanup-actions">
+            <button ref={keepRef} type="button" className="cleanup-btn keep" onClick={onKeep} disabled={isDeleting}>
+              Keep
+            </button>
+            <button
+              ref={alwaysRef}
+              type="button"
+              className="cleanup-btn always"
+              onClick={onAlwaysKeep}
+              disabled={isDeleting}
+            >
+              Always keep
+            </button>
+            <button
+              ref={deleteRef}
+              type="button"
+              className={`cleanup-btn ${hasError ? 'retry' : 'delete'}`}
+              onClick={onDelete}
+              disabled={isDeleting}
+            >
+              {hasError ? 'Retry delete' : 'Delete worktree'}
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+
+      <button
+        ref={compactRef}
+        className={`worktree-cleanup-compact ${isCompact ? '' : 'surface-hidden'} ${hasError ? 'failed' : ''}`}
+        type="button"
+        aria-live="polite"
+        onClick={() => setCompactAnimated(false)}
+      >
+        <span className="compact-pin" aria-hidden="true" />
+        <span className="compact-copy">
+          <span className="compact-kicker">{compactKicker}</span>
+          <span className="compact-title">{compactTitle}</span>
+          <span className="compact-detail">
+            <span>{hasError ? 'open to resolve' : 'git worktree remove'}</span>
+            <span className="compact-meter" aria-hidden="true"><span /></span>
+          </span>
+        </span>
+      </button>
+    </>
   );
 }

--- a/app/src/components/WorktreeCleanupPrompt.tsx
+++ b/app/src/components/WorktreeCleanupPrompt.tsx
@@ -56,7 +56,7 @@ export function WorktreeCleanupPrompt({
   }, [clearCompactTimer]);
 
   const actionButtons = useCallback(() => {
-    return [keepRef.current, alwaysRef.current, deleteRef.current].filter((button) => {
+    return [keepRef.current, deleteRef.current, alwaysRef.current].filter((button) => {
       return button && !button.disabled;
     }) as HTMLButtonElement[];
   }, []);
@@ -336,28 +336,28 @@ export function WorktreeCleanupPrompt({
             )}
           </div>
           <div className="cleanup-actions">
-            <button ref={keepRef} type="button" className="cleanup-btn keep" onClick={onKeep} disabled={isDeleting}>
-              Keep
-            </button>
-            <button
-              ref={alwaysRef}
-              type="button"
-              className="cleanup-btn always"
-              onClick={onAlwaysKeep}
+          <button ref={keepRef} type="button" className="cleanup-btn keep" onClick={onKeep} disabled={isDeleting}>
+            Keep
+          </button>
+          <button
+            ref={deleteRef}
+            type="button"
+            className={`cleanup-btn ${hasError ? 'retry' : 'delete'}`}
+            onClick={onDelete}
               disabled={isDeleting}
-            >
-              Always keep
-            </button>
-            <button
-              ref={deleteRef}
-              type="button"
-              className={`cleanup-btn ${hasError ? 'retry' : 'delete'}`}
-              onClick={onDelete}
-              disabled={isDeleting}
-            >
-              {hasError ? 'Retry delete' : 'Delete worktree'}
-            </button>
-          </div>
+          >
+            {hasError ? 'Retry delete' : 'Delete worktree'}
+          </button>
+          <button
+            ref={alwaysRef}
+            type="button"
+            className="cleanup-btn always"
+            onClick={onAlwaysKeep}
+            disabled={isDeleting}
+          >
+            Always keep
+          </button>
+        </div>
         </div>
       </div>
 

--- a/app/src/components/WorktreeCleanupPrompt.tsx
+++ b/app/src/components/WorktreeCleanupPrompt.tsx
@@ -212,7 +212,11 @@ export function WorktreeCleanupPrompt({
       const buttons = actionButtons();
 
       if (event.key === 'Tab') {
-        if (buttons.length === 0) return;
+        if (buttons.length === 0) {
+          event.preventDefault();
+          dialogRef.current?.focus();
+          return;
+        }
         const active = document.activeElement as HTMLButtonElement | null;
         const currentIndex = Math.max(0, buttons.indexOf(active || buttons[0]));
         const delta = event.shiftKey ? -1 : 1;


### PR DESCRIPTION
## Summary
- Keep the worktree cleanup prompt alive while delete is pending or failed
- Collapse slow deletes into a resumable bottom-right cleanup job with FLIP-style animation
- Add keyboard/failure coverage for the cleanup prompt and document the user-visible change

## Tests
- `pnpm --dir app test WorktreeCleanupPrompt.test.tsx App.worktreeCleanup.test.tsx`
- `pnpm --dir app test`
- `pnpm --dir app exec tsc --noEmit`
- `pnpm --dir app build`