### PR TITLE
Guard worktree cleanup prompt completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Changed
 - **Worktree Cleanup Prompt**: Deleting a closed session's worktree now stays visible while Git runs, collapses into a resumable bottom-right cleanup job when the operation takes longer than an instant, and keeps failures actionable with retry/keep choices instead of closing silently.
 
+### Fixed
+- **Worktree Cleanup Prompt**: Finishing a slow worktree delete can no longer clear a newer cleanup prompt for another worktree.
+
 ### Removed
 - **Session Forking**: Removed the local Fork Session dialog, its keyboard shortcut, and the `fork_session` spawn path so attn no longer exposes or forwards session-fork launches.
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -591,11 +591,13 @@ sendFetchPRDetails,
   const [branchDiffRefreshing, setBranchDiffRefreshing] = useState(false);
 
   // Worktree cleanup prompt state
-  const [closedWorktree, setClosedWorktree] = useState<{ path: string; branch?: string } | null>(null);
+  const cleanupRequestIdRef = useRef(0);
+  const [closedWorktree, setClosedWorktree] = useState<{ id: number; path: string; branch?: string } | null>(null);
   const [worktreeCleanupState, setWorktreeCleanupState] = useState<{
+    requestId: number | null;
     isDeleting: boolean;
     error: string | null;
-  }>({ isDeleting: false, error: null });
+  }>({ requestId: null, isDeleting: false, error: null });
   const [pendingSessionClose, setPendingSessionClose] = useState<{
     id: string;
     label: string;
@@ -1207,8 +1209,10 @@ sendFetchPRDetails,
 
         if (isLastSession && !alwaysKeepWorktrees) {
           // Show cleanup prompt
-          setWorktreeCleanupState({ isDeleting: false, error: null });
-          setClosedWorktree({ path: session.cwd, branch: session.branch });
+          const cleanupRequestId = cleanupRequestIdRef.current + 1;
+          cleanupRequestIdRef.current = cleanupRequestId;
+          setWorktreeCleanupState({ requestId: cleanupRequestId, isDeleting: false, error: null });
+          setClosedWorktree({ id: cleanupRequestId, path: session.cwd, branch: session.branch });
         }
       }
 
@@ -1400,30 +1404,49 @@ sendFetchPRDetails,
 
   // Worktree cleanup prompt handlers
   const handleWorktreeKeep = useCallback(() => {
-    setWorktreeCleanupState({ isDeleting: false, error: null });
+    setWorktreeCleanupState({ requestId: null, isDeleting: false, error: null });
     setClosedWorktree(null);
   }, []);
 
   const handleWorktreeDelete = useCallback(async () => {
-    if (!closedWorktree || worktreeCleanupState.isDeleting) {
+    if (
+      !closedWorktree
+      || worktreeCleanupState.requestId !== closedWorktree.id
+      || worktreeCleanupState.isDeleting
+    ) {
       return;
     }
-    setWorktreeCleanupState({ isDeleting: true, error: null });
+    const deleteTarget = closedWorktree;
+    setWorktreeCleanupState((current) => (
+      current.requestId === deleteTarget.id
+        ? { requestId: deleteTarget.id, isDeleting: true, error: null }
+        : current
+    ));
     try {
-      await sendDeleteWorktree(closedWorktree.path);
+      await sendDeleteWorktree(deleteTarget.path);
       // Note: Deleted paths are automatically filtered by daemon on next fetch
-      setWorktreeCleanupState({ isDeleting: false, error: null });
-      setClosedWorktree(null);
+      setWorktreeCleanupState((current) => (
+        current.requestId === deleteTarget.id
+          ? { requestId: null, isDeleting: false, error: null }
+          : current
+      ));
+      setClosedWorktree((current) => (
+        current?.id === deleteTarget.id ? null : current
+      ));
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to delete worktree';
       console.error('[App] Failed to delete worktree:', err);
-      setWorktreeCleanupState({ isDeleting: false, error: message });
+      setWorktreeCleanupState((current) => (
+        current.requestId === deleteTarget.id
+          ? { requestId: deleteTarget.id, isDeleting: false, error: message }
+          : current
+      ));
     }
-  }, [closedWorktree, sendDeleteWorktree, worktreeCleanupState.isDeleting]);
+  }, [closedWorktree, sendDeleteWorktree, worktreeCleanupState.isDeleting, worktreeCleanupState.requestId]);
 
   const handleWorktreeAlwaysKeep = useCallback(() => {
     setAlwaysKeepWorktrees(true);
-    setWorktreeCleanupState({ isDeleting: false, error: null });
+    setWorktreeCleanupState({ requestId: null, isDeleting: false, error: null });
     setClosedWorktree(null);
   }, []);
 

--- a/app/src/App.worktreeCleanup.test.tsx
+++ b/app/src/App.worktreeCleanup.test.tsx
@@ -11,6 +11,19 @@ const mockUseKeyboardShortcuts = vi.fn();
 const mockSendWorkspaceClosePane = vi.fn(async () => ({ success: true }));
 const mockCloseSession = vi.fn();
 const mockOpenPR = vi.hoisted(() => vi.fn());
+let mockSessionStoreReturn: Record<string, unknown>;
+let mockDaemonStoreReturn: Record<string, unknown>;
+let mockDaemonSocketReturn: Record<string, unknown>;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
 
 vi.mock('@tauri-apps/plugin-deep-link', () => ({
   onOpenUrl: vi.fn(async () => () => {}),
@@ -142,7 +155,7 @@ describe('worktree cleanup prompt', () => {
     });
     mockSendWorkspaceClosePane.mockResolvedValue({ success: true });
 
-    mockUseSessionStore.mockReturnValue({
+    mockSessionStoreReturn = {
       sessions: [
         {
           id: 's1',
@@ -172,9 +185,10 @@ describe('worktree cleanup prompt', () => {
       setLauncherConfig: vi.fn(),
       syncFromDaemonSessions: vi.fn(),
       syncFromDaemonWorkspaces: vi.fn(),
-    });
+    };
+    mockUseSessionStore.mockReturnValue(mockSessionStoreReturn);
 
-    mockUseDaemonStore.mockReturnValue({
+    mockDaemonStoreReturn = {
       daemonSessions: [
         {
           id: 's1',
@@ -192,10 +206,11 @@ describe('worktree cleanup prompt', () => {
       setRepoStates: vi.fn(),
       authorStates: [],
       setAuthorStates: vi.fn(),
-    });
+    };
+    mockUseDaemonStore.mockReturnValue(mockDaemonStoreReturn);
 
     const fn = vi.fn();
-    mockUseDaemonSocket.mockReturnValue({
+    mockDaemonSocketReturn = {
       sendPRAction: fn,
       sendMutePR: fn,
       sendMuteRepo: fn,
@@ -236,7 +251,8 @@ describe('worktree cleanup prompt', () => {
       rateLimit: null,
       warnings: [],
       clearWarnings: fn,
-    });
+    };
+    mockUseDaemonSocket.mockReturnValue(mockDaemonSocketReturn);
   });
 
   afterEach(() => {
@@ -252,6 +268,73 @@ describe('worktree cleanup prompt', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
+  });
+
+  it('ignores stale delete completion after another worktree prompt becomes active', async () => {
+    const deleteA = deferred<{ success: true }>();
+    const sendDeleteWorktree = vi.fn((path: string) => {
+      if (path === '/tmp/repo/.worktrees/feature-a') {
+        return deleteA.promise;
+      }
+      return Promise.resolve({ success: true });
+    });
+    mockDaemonSocketReturn.sendDeleteWorktree = sendDeleteWorktree;
+
+    const { rerender } = render(<App />);
+
+    await userEvent.click(screen.getByTestId('close-session'));
+    await waitFor(() => {
+      expect(screen.getByText('/tmp/repo/.worktrees/feature-a')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete worktree' }));
+    await waitFor(() => {
+      expect(sendDeleteWorktree).toHaveBeenCalledWith('/tmp/repo/.worktrees/feature-a');
+    });
+
+    mockSessionStoreReturn.sessions = [
+      {
+        id: 's2',
+        label: 'second-worktree-session',
+        state: 'working',
+        cwd: '/tmp/repo/.worktrees/feature-b',
+        agent: 'claude',
+        transcriptMatched: true,
+        branch: 'feature-b',
+        isWorktree: true,
+        daemonActivePaneId: 'main',
+        workspace: {
+          terminals: [],
+          layoutTree: { type: 'pane', paneId: 'main' },
+        },
+      },
+    ];
+    mockSessionStoreReturn.activeSessionId = 's2';
+    mockDaemonStoreReturn.daemonSessions = [
+      {
+        id: 's2',
+        label: 'second-worktree-session',
+        directory: '/tmp/repo/.worktrees/feature-b',
+        state: 'working',
+        branch: 'feature-b',
+        is_worktree: true,
+      },
+    ];
+
+    rerender(<App />);
+
+    await userEvent.click(screen.getByTestId('close-session'));
+    await waitFor(() => {
+      expect(screen.getByText('/tmp/repo/.worktrees/feature-b')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      deleteA.resolve({ success: true });
+      await deleteA.promise;
+    });
+
+    expect(screen.getByText('/tmp/repo/.worktrees/feature-b')).toBeInTheDocument();
+    expect(screen.queryByText('/tmp/repo/.worktrees/feature-a')).not.toBeInTheDocument();
   });
 
   it('marks remote long-run sessions as visualized after the visibility delay', async () => {


### PR DESCRIPTION
## Summary
- add a per-prompt cleanup request id so slow delete completions only update the prompt they started from
- keep a newer worktree cleanup prompt visible when an older delete succeeds or fails later
- add an App-level regression for closing worktree B while worktree A delete is still pending

## Tests
- pnpm --dir app test App.worktreeCleanup.test.tsx WorktreeCleanupPrompt.test.tsx
- pnpm --dir app exec tsc --noEmit
- git diff --check
- pnpm --dir app test