### PR TITLE
Emit git operation events for worktree delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Changed
 - **Worktree Cleanup Prompt**: Deleting a closed session's worktree now stays visible while Git runs, collapses into a resumable bottom-right cleanup job when the operation takes longer than an instant, and keeps failures actionable with retry/keep choices instead of closing silently.
+- **Git Operations**: The daemon now emits lifecycle events for worktree deletion so future UI surfaces can use daemon-owned progress instead of frontend timers.
 
 ### Fixed
 - **Worktree Cleanup Prompt**: Finishing a slow worktree delete can no longer clear a newer cleanup prompt for another worktree.

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -196,6 +196,66 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     unmount();
   });
 
+  it('stores daemon git operation lifecycle events by operation id', async () => {
+    const { result, unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+
+    act(() => {
+      ws.emit({
+        event: 'git_operation_started',
+        operation: {
+          id: 'op-1',
+          kind: 'delete_worktree',
+          status: 'running',
+          path: '/tmp/repo/.worktrees/feature-a',
+          started_at: '2026-05-16T16:00:00Z',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.gitOperations['op-1']).toMatchObject({
+        kind: 'delete_worktree',
+        status: 'running',
+        path: '/tmp/repo/.worktrees/feature-a',
+      });
+    });
+
+    act(() => {
+      ws.emit({
+        event: 'git_operation_finished',
+        operation: {
+          id: 'op-1',
+          kind: 'delete_worktree',
+          status: 'succeeded',
+          path: '/tmp/repo/.worktrees/feature-a',
+          started_at: '2026-05-16T16:00:00Z',
+          finished_at: '2026-05-16T16:00:05Z',
+          duration_ms: 5000,
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.gitOperations['op-1']).toMatchObject({
+        status: 'succeeded',
+        duration_ms: 5000,
+      });
+    });
+
+    unmount();
+  });
+
   it('rejects answerReviewLoop immediately when error result only echoes loop_id', async () => {
     const { result, unmount } = renderHook(() =>
       useDaemonSocket({
@@ -344,7 +404,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '59',
+        protocol_version: '60',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -420,7 +480,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '59',
+        protocol_version: '60',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -499,7 +559,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '59',
+        protocol_version: '60',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -592,7 +652,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '59',
+        protocol_version: '60',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -689,7 +749,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '59',
+        protocol_version: '60',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -772,7 +832,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '59',
+        protocol_version: '60',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -881,7 +941,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '59',
+        protocol_version: '60',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -939,7 +999,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '59',
+        protocol_version: '60',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -6,6 +6,7 @@ import type {
   SessionLayout as GeneratedWorkspaceSnapshot,
   PR as GeneratedPR,
   Worktree as GeneratedWorktree,
+  GitOperation as GeneratedGitOperation,
   Endpoint as GeneratedEndpoint,
   RepoState as GeneratedRepoState,
   AuthorState as GeneratedAuthorState,
@@ -54,6 +55,7 @@ export type DaemonSession = GeneratedSession;
 export type DaemonWorkspace = GeneratedWorkspaceSnapshot;
 export type DaemonPR = GeneratedPR;
 export type DaemonWorktree = GeneratedWorktree;
+export type DaemonGitOperation = GeneratedGitOperation;
 export type DaemonEndpoint = GeneratedEndpoint;
 export type RepoState = GeneratedRepoState;
 export type AuthorState = GeneratedAuthorState;
@@ -141,7 +143,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '59';
+const PROTOCOL_VERSION = '60';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 // Runtime gate (flipped from VITE_UI_AUTOMATION). The Rust shell
 // injects this global before any page script runs — see
@@ -644,6 +646,7 @@ export function useDaemonSocket({
   const [hasReceivedInitialState, setHasReceivedInitialState] = useState(false);
   const [rateLimit, setRateLimit] = useState<RateLimitState | null>(null);
   const [warnings, setWarnings] = useState<DaemonWarning[]>([]);
+  const [gitOperations, setGitOperations] = useState<Record<string, DaemonGitOperation>>({});
 
   // Circuit breaker state for reconnect storms
   const reconnectAttemptsRef = useRef(0);
@@ -1582,6 +1585,18 @@ export function useDaemonSocket({
           case 'worktree_deleted':
             // These events are informational, UI updates handled via worktrees_updated
             break;
+
+          case 'git_operation_started':
+          case 'git_operation_finished': {
+            const operation = data.operation as DaemonGitOperation | undefined;
+            if (operation?.id) {
+              setGitOperations((current) => ({
+                ...current,
+                [operation.id]: operation,
+              }));
+            }
+            break;
+          }
 
           case 'create_worktree_result':
           case 'delete_worktree_result':
@@ -3400,6 +3415,7 @@ export function useDaemonSocket({
     settings: settingsRef.current,
     rateLimit,
     warnings,
+    gitOperations,
     clearWarnings,
     retryConnection,
     sendPRAction,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MuteMessage, MutePRMessage, MuteRepoMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionAgent, SessionExitedMessage, SessionLayout, SessionLayoutActionResultMessage, SessionLayoutClosePaneMessage, SessionLayoutFocusPaneMessage, SessionLayoutGetMessage, SessionLayoutMessage, SessionLayoutPane, SessionLayoutPaneKind, SessionLayoutRenamePaneMessage, SessionLayoutRuntimeExitedMessage, SessionLayoutSplitDirection, SessionLayoutSplitPaneMessage, SessionLayoutUpdatedMessage, SessionRegisteredMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, UpdateWorkspacePanelGeometryMessage, WebSocketEvent, Workspace, WorkspacePanel, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MuteMessage, MutePRMessage, MuteRepoMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionAgent, SessionExitedMessage, SessionLayout, SessionLayoutActionResultMessage, SessionLayoutClosePaneMessage, SessionLayoutFocusPaneMessage, SessionLayoutGetMessage, SessionLayoutMessage, SessionLayoutPane, SessionLayoutPaneKind, SessionLayoutRenamePaneMessage, SessionLayoutRuntimeExitedMessage, SessionLayoutSplitDirection, SessionLayoutSplitPaneMessage, SessionLayoutUpdatedMessage, SessionRegisteredMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, UpdateWorkspacePanelGeometryMessage, WebSocketEvent, Workspace, WorkspacePanel, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -62,6 +62,11 @@
 //   const getReviewStateResultMessage = Convert.toGetReviewStateResultMessage(json);
 //   const getSettingsMessage = Convert.toGetSettingsMessage(json);
 //   const gitFileChange = Convert.toGitFileChange(json);
+//   const gitOperation = Convert.toGitOperation(json);
+//   const gitOperationFinishedMessage = Convert.toGitOperationFinishedMessage(json);
+//   const gitOperationKind = Convert.toGitOperationKind(json);
+//   const gitOperationStartedMessage = Convert.toGitOperationStartedMessage(json);
+//   const gitOperationStatus = Convert.toGitOperationStatus(json);
 //   const gitStatusUpdateMessage = Convert.toGitStatusUpdateMessage(json);
 //   const heartbeatMessage = Convert.toHeartbeatMessage(json);
 //   const heatState = Convert.toHeatState(json);
@@ -607,13 +612,13 @@ export enum DeleteCommentResultMessageEvent {
 }
 
 export interface DeleteWorktreeMessage {
-    cmd:          DeleteWorktreeMessageCmd;
+    cmd:          GitOperationKind;
     endpoint_id?: string;
     path:         string;
     [property: string]: any;
 }
 
-export enum DeleteWorktreeMessageCmd {
+export enum GitOperationKind {
     DeleteWorktree = "delete_worktree",
 }
 
@@ -1050,6 +1055,58 @@ export interface GitFileChange {
     path:       string;
     status:     string;
     [property: string]: any;
+}
+
+export interface GitOperation {
+    duration_ms?: number;
+    endpoint_id?: string;
+    error?:       string;
+    finished_at?: string;
+    id:           string;
+    kind:         GitOperationKind;
+    path?:        string;
+    started_at:   string;
+    status:       GitOperationStatus;
+    [property: string]: any;
+}
+
+export enum GitOperationStatus {
+    Failed = "failed",
+    Running = "running",
+    Succeeded = "succeeded",
+}
+
+export interface GitOperationFinishedMessage {
+    event:     GitOperationFinishedMessageEvent;
+    operation: Operation;
+    [property: string]: any;
+}
+
+export enum GitOperationFinishedMessageEvent {
+    GitOperationFinished = "git_operation_finished",
+}
+
+export interface Operation {
+    duration_ms?: number;
+    endpoint_id?: string;
+    error?:       string;
+    finished_at?: string;
+    id:           string;
+    kind:         GitOperationKind;
+    path?:        string;
+    started_at:   string;
+    status:       GitOperationStatus;
+    [property: string]: any;
+}
+
+export interface GitOperationStartedMessage {
+    event:     GitOperationStartedMessageEvent;
+    operation: Operation;
+    [property: string]: any;
+}
+
+export enum GitOperationStartedMessageEvent {
+    GitOperationStarted = "git_operation_started",
 }
 
 export interface GitStatusUpdateMessage {
@@ -2410,6 +2467,7 @@ export interface WebSocketEvent {
     id?:                    string;
     last_seq?:              number;
     modified?:              string;
+    operation?:             Operation;
     original?:              string;
     pane_id?:               string;
     path?:                  string;
@@ -3025,6 +3083,46 @@ export class Convert {
 
     public static gitFileChangeToJson(value: GitFileChange): string {
         return JSON.stringify(uncast(value, r("GitFileChange")), null, 2);
+    }
+
+    public static toGitOperation(json: string): GitOperation {
+        return cast(JSON.parse(json), r("GitOperation"));
+    }
+
+    public static gitOperationToJson(value: GitOperation): string {
+        return JSON.stringify(uncast(value, r("GitOperation")), null, 2);
+    }
+
+    public static toGitOperationFinishedMessage(json: string): GitOperationFinishedMessage {
+        return cast(JSON.parse(json), r("GitOperationFinishedMessage"));
+    }
+
+    public static gitOperationFinishedMessageToJson(value: GitOperationFinishedMessage): string {
+        return JSON.stringify(uncast(value, r("GitOperationFinishedMessage")), null, 2);
+    }
+
+    public static toGitOperationKind(json: string): GitOperationKind {
+        return cast(JSON.parse(json), r("GitOperationKind"));
+    }
+
+    public static gitOperationKindToJson(value: GitOperationKind): string {
+        return JSON.stringify(uncast(value, r("GitOperationKind")), null, 2);
+    }
+
+    public static toGitOperationStartedMessage(json: string): GitOperationStartedMessage {
+        return cast(JSON.parse(json), r("GitOperationStartedMessage"));
+    }
+
+    public static gitOperationStartedMessageToJson(value: GitOperationStartedMessage): string {
+        return JSON.stringify(uncast(value, r("GitOperationStartedMessage")), null, 2);
+    }
+
+    public static toGitOperationStatus(json: string): GitOperationStatus {
+        return cast(JSON.parse(json), r("GitOperationStatus"));
+    }
+
+    public static gitOperationStatusToJson(value: GitOperationStatus): string {
+        return JSON.stringify(uncast(value, r("GitOperationStatus")), null, 2);
     }
 
     public static toGitStatusUpdateMessage(json: string): GitStatusUpdateMessage {
@@ -4359,7 +4457,7 @@ const typeMap: any = {
         { json: "success", js: "success", typ: true },
     ], "any"),
     "DeleteWorktreeMessage": o([
-        { json: "cmd", js: "cmd", typ: r("DeleteWorktreeMessageCmd") },
+        { json: "cmd", js: "cmd", typ: r("GitOperationKind") },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "path", js: "path", typ: "" },
     ], "any"),
@@ -4610,6 +4708,36 @@ const typeMap: any = {
         { json: "old_path", js: "old_path", typ: u(undefined, "") },
         { json: "path", js: "path", typ: "" },
         { json: "status", js: "status", typ: "" },
+    ], "any"),
+    "GitOperation": o([
+        { json: "duration_ms", js: "duration_ms", typ: u(undefined, 0) },
+        { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "finished_at", js: "finished_at", typ: u(undefined, "") },
+        { json: "id", js: "id", typ: "" },
+        { json: "kind", js: "kind", typ: r("GitOperationKind") },
+        { json: "path", js: "path", typ: u(undefined, "") },
+        { json: "started_at", js: "started_at", typ: "" },
+        { json: "status", js: "status", typ: r("GitOperationStatus") },
+    ], "any"),
+    "GitOperationFinishedMessage": o([
+        { json: "event", js: "event", typ: r("GitOperationFinishedMessageEvent") },
+        { json: "operation", js: "operation", typ: r("Operation") },
+    ], "any"),
+    "Operation": o([
+        { json: "duration_ms", js: "duration_ms", typ: u(undefined, 0) },
+        { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "finished_at", js: "finished_at", typ: u(undefined, "") },
+        { json: "id", js: "id", typ: "" },
+        { json: "kind", js: "kind", typ: r("GitOperationKind") },
+        { json: "path", js: "path", typ: u(undefined, "") },
+        { json: "started_at", js: "started_at", typ: "" },
+        { json: "status", js: "status", typ: r("GitOperationStatus") },
+    ], "any"),
+    "GitOperationStartedMessage": o([
+        { json: "event", js: "event", typ: r("GitOperationStartedMessageEvent") },
+        { json: "operation", js: "operation", typ: r("Operation") },
     ], "any"),
     "GitStatusUpdateMessage": o([
         { json: "directory", js: "directory", typ: "" },
@@ -5377,6 +5505,7 @@ const typeMap: any = {
         { json: "id", js: "id", typ: u(undefined, "") },
         { json: "last_seq", js: "last_seq", typ: u(undefined, 0) },
         { json: "modified", js: "modified", typ: u(undefined, "") },
+        { json: "operation", js: "operation", typ: u(undefined, r("Operation")) },
         { json: "original", js: "original", typ: u(undefined, "") },
         { json: "pane_id", js: "pane_id", typ: u(undefined, "") },
         { json: "path", js: "path", typ: u(undefined, "") },
@@ -5559,7 +5688,7 @@ const typeMap: any = {
     "DeleteCommentResultMessageEvent": [
         "delete_comment_result",
     ],
-    "DeleteWorktreeMessageCmd": [
+    "GitOperationKind": [
         "delete_worktree",
     ],
     "DeleteWorktreeResultMessageEvent": [
@@ -5648,6 +5777,17 @@ const typeMap: any = {
     ],
     "GetSettingsMessageCmd": [
         "get_settings",
+    ],
+    "GitOperationStatus": [
+        "failed",
+        "running",
+        "succeeded",
+    ],
+    "GitOperationFinishedMessageEvent": [
+        "git_operation_finished",
+    ],
+    "GitOperationStartedMessageEvent": [
+        "git_operation_started",
     ],
     "GitStatusUpdateMessageEvent": [
         "git_status_update",

--- a/internal/daemon/git_operation.go
+++ b/internal/daemon/git_operation.go
@@ -1,0 +1,43 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func (d *Daemon) beginGitOperation(kind protocol.GitOperationKind, path string, endpointID *string) func(error) {
+	startedAt := time.Now()
+	operation := protocol.GitOperation{
+		ID:         uuid.NewString(),
+		Kind:       kind,
+		Status:     protocol.GitOperationStatusRunning,
+		Path:       protocol.Ptr(path),
+		EndpointID: endpointID,
+		StartedAt:  startedAt.Format(time.RFC3339),
+	}
+
+	startedOperation := operation
+	d.wsHub.Broadcast(&protocol.WebSocketEvent{
+		Event:     protocol.EventGitOperationStarted,
+		Operation: &startedOperation,
+	})
+
+	return func(err error) {
+		finishedAt := time.Now()
+		operation.Status = protocol.GitOperationStatusSucceeded
+		if err != nil {
+			operation.Status = protocol.GitOperationStatusFailed
+			operation.Error = protocol.Ptr(err.Error())
+		}
+		operation.FinishedAt = protocol.Ptr(finishedAt.Format(time.RFC3339))
+		operation.DurationMs = protocol.Ptr(int(finishedAt.Sub(startedAt).Milliseconds()))
+
+		finishedOperation := operation
+		d.wsHub.Broadcast(&protocol.WebSocketEvent{
+			Event:     protocol.EventGitOperationFinished,
+			Operation: &finishedOperation,
+		})
+	}
+}

--- a/internal/daemon/worktree.go
+++ b/internal/daemon/worktree.go
@@ -186,7 +186,12 @@ func (d *Daemon) discoverWorktree(path string) *store.Worktree {
 
 // doDeleteWorktree removes a worktree from git and the store.
 // Also cleans up any sessions in that directory.
-func (d *Daemon) doDeleteWorktree(path string) error {
+func (d *Daemon) doDeleteWorktree(path string, endpointID *string) (err error) {
+	finishOperation := d.beginGitOperation(protocol.GitOperationKindDeleteWorktree, path, endpointID)
+	defer func() {
+		finishOperation(err)
+	}()
+
 	// Stop/remove sessions in this directory before deleting the worktree.
 	for _, session := range d.store.List("") {
 		if session.Directory != path {
@@ -283,7 +288,7 @@ func (d *Daemon) handleCreateWorktree(conn net.Conn, msg *protocol.CreateWorktre
 }
 
 func (d *Daemon) handleDeleteWorktree(conn net.Conn, msg *protocol.DeleteWorktreeMessage) {
-	if err := d.doDeleteWorktree(msg.Path); err != nil {
+	if err := d.doDeleteWorktree(msg.Path, msg.EndpointID); err != nil {
 		d.sendError(conn, err.Error())
 		return
 	}
@@ -329,7 +334,7 @@ func (d *Daemon) handleDeleteWorktreeWS(client *wsClient, msg *protocol.DeleteWo
 			})
 		}()
 
-		err := d.doDeleteWorktree(msg.Path)
+		err := d.doDeleteWorktree(msg.Path, msg.EndpointID)
 		result := protocol.DeleteWorktreeResultMessage{
 			Event:      protocol.EventDeleteWorktreeResult,
 			Path:       msg.Path,

--- a/internal/daemon/worktree_naming_test.go
+++ b/internal/daemon/worktree_naming_test.go
@@ -83,6 +83,77 @@ func TestDoCreateWorktreeFromBranch_ResolvesMainRepoFromWorktree(t *testing.T) {
 	}
 }
 
+func TestDoDeleteWorktree_BroadcastsGitOperationLifecycle(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainDir := filepath.Join(tmpDir, "hurdy-gurdy")
+	if err := os.MkdirAll(mainDir, 0755); err != nil {
+		t.Fatalf("failed to create main repo dir: %v", err)
+	}
+
+	runGitDaemon(t, mainDir, "init")
+	runGitDaemon(t, mainDir, "commit", "--allow-empty", "-m", "init")
+	worktreePath := filepath.Join(tmpDir, "hurdy-gurdy--feature-slow-delete")
+	runGitDaemon(t, mainDir, "worktree", "add", "-b", "feature/slow-delete", worktreePath)
+	worktreePath = canonicalPathDaemon(worktreePath)
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	cap := captureBroadcasts(d)
+	endpointID := "endpoint-1"
+
+	if err := d.doDeleteWorktree(worktreePath, protocol.Ptr(endpointID)); err != nil {
+		t.Fatalf("doDeleteWorktree failed: %v", err)
+	}
+
+	var started, finished protocol.WebSocketEvent
+	var sawStarted, sawFinished bool
+	for _, event := range cap.snapshot() {
+		switch event.Event {
+		case protocol.EventGitOperationStarted:
+			started = event
+			sawStarted = true
+		case protocol.EventGitOperationFinished:
+			finished = event
+			sawFinished = true
+		}
+	}
+	if !sawStarted {
+		t.Fatalf("missing %s event", protocol.EventGitOperationStarted)
+	}
+	if !sawFinished {
+		t.Fatalf("missing %s event", protocol.EventGitOperationFinished)
+	}
+	if started.Operation == nil || finished.Operation == nil {
+		t.Fatalf("expected operation payloads: started=%#v finished=%#v", started.Operation, finished.Operation)
+	}
+	if started.Operation.ID == "" {
+		t.Fatalf("started operation id is empty")
+	}
+	if finished.Operation.ID != started.Operation.ID {
+		t.Fatalf("finished operation id = %q, want %q", finished.Operation.ID, started.Operation.ID)
+	}
+	if started.Operation.Kind != protocol.GitOperationKindDeleteWorktree {
+		t.Fatalf("started operation kind = %q", started.Operation.Kind)
+	}
+	if started.Operation.Status != protocol.GitOperationStatusRunning {
+		t.Fatalf("started operation status = %q", started.Operation.Status)
+	}
+	if finished.Operation.Status != protocol.GitOperationStatusSucceeded {
+		t.Fatalf("finished operation status = %q", finished.Operation.Status)
+	}
+	if protocol.Deref(started.Operation.Path) != worktreePath {
+		t.Fatalf("started operation path = %q, want %q", protocol.Deref(started.Operation.Path), worktreePath)
+	}
+	if protocol.Deref(started.Operation.EndpointID) != endpointID {
+		t.Fatalf("started endpoint = %q, want %q", protocol.Deref(started.Operation.EndpointID), endpointID)
+	}
+	if finished.Operation.FinishedAt == nil {
+		t.Fatalf("finished operation missing finished_at")
+	}
+	if finished.Operation.DurationMs == nil {
+		t.Fatalf("finished operation missing duration_ms")
+	}
+}
+
 func runGitDaemon(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "59"
+const ProtocolVersion = "60"
 
 // Commands
 const (
@@ -121,6 +121,8 @@ const (
 	EventWorktreesUpdated           = "worktrees_updated"
 	EventCreateWorktreeResult       = "create_worktree_result"
 	EventDeleteWorktreeResult       = "delete_worktree_result"
+	EventGitOperationStarted        = "git_operation_started"
+	EventGitOperationFinished       = "git_operation_finished"
 	EventSettingsUpdated            = "settings_updated"
 	EventRateLimited                = "rate_limited"
 	EventRecentLocationsResult      = "recent_locations_result"

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -834,6 +834,61 @@ type GitFileChange struct {
 	Status string `json:"status"`
 }
 
+type GitOperation struct {
+	// DurationMs corresponds to the JSON schema field "duration_ms".
+	DurationMs *int `json:"duration_ms,omitempty,omitzero"`
+
+	// EndpointID corresponds to the JSON schema field "endpoint_id".
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// FinishedAt corresponds to the JSON schema field "finished_at".
+	FinishedAt *string `json:"finished_at,omitempty,omitzero"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// Kind corresponds to the JSON schema field "kind".
+	Kind GitOperationKind `json:"kind"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path *string `json:"path,omitempty,omitzero"`
+
+	// StartedAt corresponds to the JSON schema field "started_at".
+	StartedAt string `json:"started_at"`
+
+	// Status corresponds to the JSON schema field "status".
+	Status GitOperationStatus `json:"status"`
+}
+
+type GitOperationFinishedMessage struct {
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Operation corresponds to the JSON schema field "operation".
+	Operation GitOperation `json:"operation"`
+}
+
+type GitOperationKind string
+
+const GitOperationKindDeleteWorktree GitOperationKind = "delete_worktree"
+
+type GitOperationStartedMessage struct {
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Operation corresponds to the JSON schema field "operation".
+	Operation GitOperation `json:"operation"`
+}
+
+type GitOperationStatus string
+
+const GitOperationStatusFailed GitOperationStatus = "failed"
+const GitOperationStatusRunning GitOperationStatus = "running"
+const GitOperationStatusSucceeded GitOperationStatus = "succeeded"
+
 type GitStatusUpdateMessage struct {
 	// Directory corresponds to the JSON schema field "directory".
 	Directory string `json:"directory"`
@@ -2485,6 +2540,9 @@ type WebSocketEvent struct {
 
 	// Modified corresponds to the JSON schema field "modified".
 	Modified *string `json:"modified,omitempty,omitzero"`
+
+	// Operation corresponds to the JSON schema field "operation".
+	Operation *GitOperation `json:"operation,omitempty,omitzero"`
 
 	// Original corresponds to the JSON schema field "original".
 	Original *string `json:"original,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -109,6 +109,16 @@ enum ReviewLoopInteractionStatus {
   consumed,
 }
 
+enum GitOperationKind {
+  delete_worktree,
+}
+
+enum GitOperationStatus {
+  running,
+  succeeded,
+  failed,
+}
+
 // ============================================================================
 // Core Entities
 // ============================================================================
@@ -199,6 +209,18 @@ model Worktree {
   branch: string;
   main_repo: string;
   created_at?: string; // ISO timestamp
+}
+
+model GitOperation {
+  id: string;
+  kind: GitOperationKind;
+  status: GitOperationStatus;
+  path?: string;
+  endpoint_id?: string;
+  started_at: string;   // ISO timestamp
+  finished_at?: string; // ISO timestamp
+  duration_ms?: int32;
+  error?: string;
 }
 
 model RepoState {
@@ -981,6 +1003,16 @@ model DeleteWorktreeResultMessage {
   error?: string;
 }
 
+model GitOperationStartedMessage {
+  event: "git_operation_started";
+  operation: GitOperation;
+}
+
+model GitOperationFinishedMessage {
+  event: "git_operation_finished";
+  operation: GitOperation;
+}
+
 model SettingsUpdatedMessage {
   event: "settings_updated";
   settings?: Record<string>;
@@ -1368,6 +1400,7 @@ model WebSocketEvent {
   repos?: RepoState[];
   authors?: AuthorState[];
   worktrees?: Worktree[];
+  operation?: GitOperation;
   branches?: Branch[];
   recent_locations?: RecentLocation[];
   settings?: Record<string>;
@@ -1457,6 +1490,8 @@ alias DaemonEvent =
   | WorktreesUpdatedMessage
   | CreateWorktreeResultMessage
   | DeleteWorktreeResultMessage
+  | GitOperationStartedMessage
+  | GitOperationFinishedMessage
   | SettingsUpdatedMessage
   | RecentLocationsResultMessage
   | BranchesResultMessage

--- a/native-ui/crates/attn-protocol/src/lib.rs
+++ b/native-ui/crates/attn-protocol/src/lib.rs
@@ -14,7 +14,7 @@ pub use types::*;
 
 /// Current protocol version — must match `ProtocolVersion` in
 /// `internal/protocol/constants.go`.
-pub const PROTOCOL_VERSION: &str = "58";
+pub const PROTOCOL_VERSION: &str = "60";
 
 /// Capability strings advertised in `ClientHelloMessage.capabilities`.
 /// Mirror of `protocol.Capability*` in `internal/protocol/constants.go`.


### PR DESCRIPTION
## Summary
- add protocol-level git operation lifecycle payloads and bump protocol version to 60
- emit started/finished git operation events around the shared delete_worktree path
- store git operation events in the Tauri daemon socket hook for future UI wiring

## Tests
- make generate-types
- go test ./internal/daemon ./internal/protocol
- pnpm --dir app exec tsc --noEmit
- pnpm --dir app test useDaemonSocket.test.tsx
- git diff --check
- go test ./internal/...
- pnpm --dir app test