### PR TITLE
Make Changes diff refresh demand-driven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-05-17]
+
+### Changed
+- **Changes Panel Refreshes**: The Changes panel now avoids branch-diff refreshes while closed, refreshes once when opened, and coalesces status-triggered refreshes so slow monorepos do not stack repeated Git diff work behind every status update.
+
+---
+
 ## [2026-05-16]
 
 ### Changed

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1628,11 +1628,11 @@ sendFetchPRDetails,
       }
       setBranchDiffError(err instanceof Error ? err.message : 'Failed to load branch diff');
     } finally {
-      const durationMs = Date.now() - startedAt;
-      if (durationMs >= CHANGES_BRANCH_DIFF_SLOW_THRESHOLD_MS) {
-        branchDiffCooldownUntilRef.current = Date.now() + CHANGES_BRANCH_DIFF_SLOW_COOLDOWN_MS;
-      }
       if (requestId === branchDiffRequestId.current) {
+        const durationMs = Date.now() - startedAt;
+        if (durationMs >= CHANGES_BRANCH_DIFF_SLOW_THRESHOLD_MS) {
+          branchDiffCooldownUntilRef.current = Date.now() + CHANGES_BRANCH_DIFF_SLOW_COOLDOWN_MS;
+        }
         branchDiffInFlightRef.current = false;
         setBranchDiffLoading(false);
         setBranchDiffRefreshing(false);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -50,6 +50,10 @@ const RELEASES_LATEST_WEB = 'https://github.com/victorarias/attn/releases/latest
 const RELEASE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const UPDATE_BANNER_DISMISSED_STORAGE_KEY = 'attn.update_banner.dismissed_version';
 const DOCK_PANEL_EXIT_MS = 260;
+const CHANGES_BRANCH_DIFF_INTERVAL_MS = 30_000;
+const CHANGES_BRANCH_DIFF_STATUS_DEBOUNCE_MS = 750;
+const CHANGES_BRANCH_DIFF_SLOW_THRESHOLD_MS = 5_000;
+const CHANGES_BRANCH_DIFF_SLOW_COOLDOWN_MS = 30_000;
 
 interface GitHubReleaseResponse {
   tag_name?: string;
@@ -1085,6 +1089,7 @@ sendFetchPRDetails,
   const reviewLoopPanelOpen = openDockPanels.reviewLoop;
   const attentionPanelOpen = openDockPanels.attention;
   const diffDetailPanelOpen = openDockPanels.diffDetail;
+  const changesPanelVisible = view === 'session' && diffPanelOpen && Boolean(activeRepoDaemonSession?.directory);
   const waitingReviewSessions = useMemo(
     () => sessions
       .map((session) => ({
@@ -1564,9 +1569,36 @@ sendFetchPRDetails,
 
   const branchDiffRequestId = useRef(0);
   const branchDiffLoadedRef = useRef(false);
+  const branchDiffInFlightRef = useRef(false);
+  const branchDiffDirtyAfterCurrentRef = useRef(false);
+  const branchDiffVisibleRef = useRef(false);
+  const branchDiffDirectoryRef = useRef<string | null>(null);
+  const branchDiffCooldownUntilRef = useRef(0);
+  const branchDiffScheduledTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    branchDiffVisibleRef.current = changesPanelVisible;
+    branchDiffDirectoryRef.current = activeRepoDaemonSession?.directory ?? null;
+  }, [activeRepoDaemonSession?.directory, changesPanelVisible]);
+
+  const clearScheduledBranchDiffRefresh = useCallback(() => {
+    if (branchDiffScheduledTimerRef.current !== null) {
+      window.clearTimeout(branchDiffScheduledTimerRef.current);
+      branchDiffScheduledTimerRef.current = null;
+    }
+  }, []);
+
   const refreshBranchDiff = useCallback(async (directory: string) => {
+    if (branchDiffInFlightRef.current) {
+      branchDiffDirtyAfterCurrentRef.current = true;
+      return;
+    }
+
+    branchDiffInFlightRef.current = true;
+    branchDiffDirtyAfterCurrentRef.current = false;
     const requestId = ++branchDiffRequestId.current;
     const hadLoadedBranchDiff = branchDiffLoadedRef.current;
+    const startedAt = Date.now();
     setBranchDiffLoading(!hadLoadedBranchDiff);
     setBranchDiffRefreshing(hadLoadedBranchDiff);
     setBranchDiffError(null);
@@ -1596,26 +1628,76 @@ sendFetchPRDetails,
       }
       setBranchDiffError(err instanceof Error ? err.message : 'Failed to load branch diff');
     } finally {
+      const durationMs = Date.now() - startedAt;
+      if (durationMs >= CHANGES_BRANCH_DIFF_SLOW_THRESHOLD_MS) {
+        branchDiffCooldownUntilRef.current = Date.now() + CHANGES_BRANCH_DIFF_SLOW_COOLDOWN_MS;
+      }
       if (requestId === branchDiffRequestId.current) {
+        branchDiffInFlightRef.current = false;
         setBranchDiffLoading(false);
         setBranchDiffRefreshing(false);
+        if (
+          branchDiffDirtyAfterCurrentRef.current &&
+          branchDiffVisibleRef.current &&
+          branchDiffDirectoryRef.current === directory
+        ) {
+          const delayMs = Math.max(0, branchDiffCooldownUntilRef.current - Date.now());
+          clearScheduledBranchDiffRefresh();
+          branchDiffScheduledTimerRef.current = window.setTimeout(() => {
+            branchDiffScheduledTimerRef.current = null;
+            void refreshBranchDiff(directory);
+          }, delayMs);
+        }
       }
     }
-  }, [sendGetBranchDiffFiles]);
+  }, [clearScheduledBranchDiffRefresh, sendGetBranchDiffFiles]);
+
+  const scheduleBranchDiffRefresh = useCallback((options?: { force?: boolean; debounceMs?: number }) => {
+    const directory = branchDiffDirectoryRef.current;
+    if (!directory) {
+      return;
+    }
+
+    if (!branchDiffVisibleRef.current) {
+      branchDiffDirtyAfterCurrentRef.current = true;
+      return;
+    }
+
+    if (branchDiffInFlightRef.current) {
+      branchDiffDirtyAfterCurrentRef.current = true;
+      return;
+    }
+
+    const cooldownDelayMs = options?.force
+      ? 0
+      : Math.max(0, branchDiffCooldownUntilRef.current - Date.now());
+    const delayMs = Math.max(options?.debounceMs ?? 0, cooldownDelayMs);
+
+    clearScheduledBranchDiffRefresh();
+    branchDiffScheduledTimerRef.current = window.setTimeout(() => {
+      branchDiffScheduledTimerRef.current = null;
+      void refreshBranchDiff(directory);
+    }, delayMs);
+  }, [clearScheduledBranchDiffRefresh, refreshBranchDiff]);
 
   useEffect(() => {
+    clearScheduledBranchDiffRefresh();
     branchDiffRequestId.current += 1;
     branchDiffLoadedRef.current = false;
+    branchDiffInFlightRef.current = false;
+    branchDiffDirtyAfterCurrentRef.current = false;
+    branchDiffCooldownUntilRef.current = 0;
     setBranchDiffLoaded(false);
     setBranchDiffFiles([]);
     setBranchDiffBaseRef('');
     setBranchDiffError(null);
     setBranchDiffLoading(false);
     setBranchDiffRefreshing(false);
-  }, [activeRepoDaemonSession?.directory]);
+  }, [activeRepoDaemonSession?.directory, clearScheduledBranchDiffRefresh]);
 
   useEffect(() => {
     if (view !== 'session' || !activeRepoDaemonSession?.directory) {
+      clearScheduledBranchDiffRefresh();
       branchDiffLoadedRef.current = false;
       setBranchDiffLoaded(false);
       setBranchDiffFiles([]);
@@ -1626,21 +1708,35 @@ sendFetchPRDetails,
       return;
     }
 
-    refreshBranchDiff(activeRepoDaemonSession.directory);
+    if (!changesPanelVisible) {
+      clearScheduledBranchDiffRefresh();
+      return;
+    }
+
+    scheduleBranchDiffRefresh({ force: true });
     const intervalId = window.setInterval(() => {
-      refreshBranchDiff(activeRepoDaemonSession.directory);
-    }, 30000);
+      scheduleBranchDiffRefresh();
+    }, CHANGES_BRANCH_DIFF_INTERVAL_MS);
 
     return () => {
       window.clearInterval(intervalId);
+      clearScheduledBranchDiffRefresh();
     };
-  }, [view, activeRepoDaemonSession?.directory, refreshBranchDiff]);
+  }, [
+    activeRepoDaemonSession?.directory,
+    changesPanelVisible,
+    clearScheduledBranchDiffRefresh,
+    scheduleBranchDiffRefresh,
+    view,
+  ]);
 
   useEffect(() => {
     if (!gitStatus || !activeRepoDaemonSession?.directory) return;
     if (gitStatus.directory !== activeRepoDaemonSession.directory) return;
-    refreshBranchDiff(activeRepoDaemonSession.directory);
-  }, [gitStatus, activeRepoDaemonSession?.directory, refreshBranchDiff]);
+    branchDiffDirtyAfterCurrentRef.current = true;
+    if (!changesPanelVisible) return;
+    scheduleBranchDiffRefresh({ debounceMs: CHANGES_BRANCH_DIFF_STATUS_DEBOUNCE_MS });
+  }, [activeRepoDaemonSession?.directory, changesPanelVisible, gitStatus, scheduleBranchDiffRefresh]);
 
   // Diff detail panel handlers
   const handleOpenDiffDetailPanel = useCallback(() => {

--- a/app/src/App.worktreeCleanup.test.tsx
+++ b/app/src/App.worktreeCleanup.test.tsx
@@ -270,6 +270,86 @@ describe('worktree cleanup prompt', () => {
     });
   });
 
+  it('does not refresh Changes branch diff while the Changes panel is closed', async () => {
+    const sendGetBranchDiffFiles = vi.fn(async () => ({ success: true, base_ref: 'main', files: [] }));
+    mockDaemonSocketReturn.sendGetBranchDiffFiles = sendGetBranchDiffFiles;
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(sendGetBranchDiffFiles).not.toHaveBeenCalled();
+
+    const daemonSocketArgs = mockUseDaemonSocket.mock.calls[mockUseDaemonSocket.mock.calls.length - 1]?.[0] as {
+      onGitStatusUpdate?: (status: { directory: string; staged: unknown[]; unstaged: unknown[]; untracked: unknown[] }) => void;
+    };
+    act(() => {
+      daemonSocketArgs.onGitStatusUpdate?.({
+        directory: '/tmp/repo/.worktrees/feature-a',
+        staged: [],
+        unstaged: [],
+        untracked: [],
+      });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(sendGetBranchDiffFiles).not.toHaveBeenCalled();
+  });
+
+  it('refreshes Changes branch diff on open and coalesces status updates while in flight', async () => {
+    const firstBranchDiff = deferred<{ success: true; base_ref: string; files: [] }>();
+    const sendGetBranchDiffFiles = vi.fn()
+      .mockReturnValueOnce(firstBranchDiff.promise)
+      .mockResolvedValue({ success: true, base_ref: 'main', files: [] });
+    mockDaemonSocketReturn.sendGetBranchDiffFiles = sendGetBranchDiffFiles;
+
+    render(<App />);
+
+    const keyboardArgs = mockUseKeyboardShortcuts.mock.calls[mockUseKeyboardShortcuts.mock.calls.length - 1]?.[0] as {
+      onToggleDiffPanel?: () => void;
+    };
+    act(() => {
+      keyboardArgs.onToggleDiffPanel?.();
+    });
+
+    await waitFor(() => {
+      expect(sendGetBranchDiffFiles).toHaveBeenCalledTimes(1);
+    });
+
+    const daemonSocketArgs = mockUseDaemonSocket.mock.calls[mockUseDaemonSocket.mock.calls.length - 1]?.[0] as {
+      onGitStatusUpdate?: (status: { directory: string; staged: unknown[]; unstaged: unknown[]; untracked: unknown[] }) => void;
+    };
+    act(() => {
+      daemonSocketArgs.onGitStatusUpdate?.({
+        directory: '/tmp/repo/.worktrees/feature-a',
+        staged: [],
+        unstaged: [{ path: 'app/src/App.tsx' }],
+        untracked: [],
+      });
+      daemonSocketArgs.onGitStatusUpdate?.({
+        directory: '/tmp/repo/.worktrees/feature-a',
+        staged: [],
+        unstaged: [{ path: 'app/src/App.tsx' }, { path: 'internal/git/command.go' }],
+        untracked: [],
+      });
+    });
+
+    expect(sendGetBranchDiffFiles).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstBranchDiff.resolve({ success: true, base_ref: 'main', files: [] });
+      await firstBranchDiff.promise;
+    });
+
+    await waitFor(() => {
+      expect(sendGetBranchDiffFiles).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it('ignores stale delete completion after another worktree prompt becomes active', async () => {
     const deleteA = deferred<{ success: true }>();
     const sendDeleteWorktree = vi.fn((path: string) => {

--- a/docs/plans/long-git-operation-surface-map.html
+++ b/docs/plans/long-git-operation-surface-map.html
@@ -1,0 +1,864 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Long Git Operation Surface Map</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #1f2a24;
+      --muted: #647067;
+      --page: #f4f1e8;
+      --panel: #fffdf5;
+      --line: #d8d0bf;
+      --heavy: #22251f;
+      --blocking: #b2452f;
+      --panel-refresh: #2c6f66;
+      --background: #7a612d;
+      --silent: #59626f;
+      --target: #0f5f4f;
+      --shadow: 0 20px 60px rgba(52, 47, 35, 0.14);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background:
+        linear-gradient(90deg, rgba(31, 42, 36, 0.045) 1px, transparent 1px) 0 0 / 28px 28px,
+        linear-gradient(rgba(31, 42, 36, 0.035) 1px, transparent 1px) 0 0 / 28px 28px,
+        var(--page);
+      color: var(--ink);
+      font-family: ui-serif, Georgia, "Times New Roman", serif;
+    }
+
+    button,
+    input {
+      font: inherit;
+    }
+
+    .shell {
+      width: min(1480px, calc(100vw - 40px));
+      margin: 0 auto;
+      padding: 34px 0 56px;
+    }
+
+    .masthead {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 28px;
+      align-items: end;
+      border-bottom: 3px solid var(--heavy);
+      padding-bottom: 24px;
+      margin-bottom: 22px;
+    }
+
+    h1 {
+      margin: 0;
+      max-width: 880px;
+      font-size: clamp(38px, 5vw, 78px);
+      line-height: 0.92;
+      letter-spacing: 0;
+      font-weight: 900;
+    }
+
+    .subtitle {
+      margin: 18px 0 0;
+      max-width: 820px;
+      color: var(--muted);
+      font: 17px/1.5 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .doc-meta {
+      display: grid;
+      gap: 8px;
+      min-width: 210px;
+      padding: 16px;
+      border: 2px solid var(--heavy);
+      background: #efe5cf;
+      box-shadow: 6px 6px 0 var(--heavy);
+      font: 13px/1.35 ui-monospace, "SFMono-Regular", Consolas, monospace;
+    }
+
+    .meta-label {
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 11px;
+    }
+
+    .decision-strip {
+      display: grid;
+      grid-template-columns: 1.15fr 0.85fr;
+      gap: 18px;
+      margin: 24px 0;
+    }
+
+    .decision,
+    .rules,
+    .board,
+    .section {
+      background: var(--panel);
+      border: 2px solid var(--heavy);
+      box-shadow: var(--shadow);
+    }
+
+    .decision {
+      padding: 22px;
+      display: grid;
+      gap: 16px;
+    }
+
+    .eyebrow {
+      color: var(--target);
+      font: 800 12px/1 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    .decision h2,
+    .section h2 {
+      margin: 0;
+      font-size: clamp(24px, 3vw, 40px);
+      line-height: 1;
+      letter-spacing: 0;
+    }
+
+    .decision p,
+    .section p {
+      margin: 0;
+      color: var(--muted);
+      font: 15px/1.55 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .target-pills {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 34px;
+      padding: 7px 11px;
+      border: 1px solid var(--heavy);
+      background: #f8eed8;
+      font: 800 13px/1 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .pill strong {
+      font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+      font-size: 12px;
+    }
+
+    .rules {
+      padding: 18px;
+      display: grid;
+      gap: 12px;
+    }
+
+    .rule {
+      display: grid;
+      grid-template-columns: 10px 1fr;
+      gap: 12px;
+      align-items: start;
+      font: 14px/1.45 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .rule::before {
+      content: "";
+      width: 10px;
+      height: 10px;
+      margin-top: 5px;
+      background: var(--heavy);
+    }
+
+    .toolbar {
+      position: sticky;
+      top: 0;
+      z-index: 3;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      padding: 12px 0;
+      background: color-mix(in srgb, var(--page) 88%, transparent);
+      backdrop-filter: blur(12px);
+    }
+
+    .filter {
+      border: 1px solid var(--heavy);
+      background: var(--panel);
+      min-height: 34px;
+      padding: 7px 11px;
+      cursor: pointer;
+      font: 800 12px/1 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .filter[aria-pressed="true"] {
+      background: var(--heavy);
+      color: var(--panel);
+    }
+
+    .board {
+      padding: 14px;
+      margin-top: 8px;
+    }
+
+    .lanes {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(240px, 1fr));
+      gap: 14px;
+      align-items: start;
+    }
+
+    .lane {
+      min-height: 420px;
+      padding: 12px;
+      background: #f7f2e6;
+      border: 1px solid var(--line);
+    }
+
+    .lane-header {
+      position: sticky;
+      top: 58px;
+      z-index: 2;
+      display: grid;
+      gap: 5px;
+      padding: 8px 8px 12px;
+      margin: -12px -12px 10px;
+      background: #f7f2e6;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .lane-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      font: 900 15px/1 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .lane-subtitle {
+      color: var(--muted);
+      font: 12px/1.35 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .count {
+      min-width: 28px;
+      height: 22px;
+      display: inline-grid;
+      place-items: center;
+      border: 1px solid currentColor;
+      font: 800 12px/1 ui-monospace, "SFMono-Regular", Consolas, monospace;
+    }
+
+    .card {
+      position: relative;
+      display: grid;
+      gap: 10px;
+      padding: 13px;
+      margin-bottom: 10px;
+      border: 1px solid var(--heavy);
+      background: var(--panel);
+      cursor: pointer;
+      transition: transform 160ms ease, box-shadow 160ms ease;
+    }
+
+    .card:hover,
+    .card:focus-visible {
+      outline: none;
+      transform: translateY(-2px);
+      box-shadow: 5px 5px 0 var(--heavy);
+    }
+
+    .card.target {
+      border-width: 2px;
+      box-shadow: inset 6px 0 0 var(--target);
+    }
+
+    .card.hidden {
+      display: none;
+    }
+
+    .card-top {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 9px;
+      align-items: start;
+    }
+
+    .rid {
+      display: inline-grid;
+      place-items: center;
+      width: 34px;
+      height: 28px;
+      background: var(--heavy);
+      color: var(--panel);
+      font: 900 12px/1 ui-monospace, "SFMono-Regular", Consolas, monospace;
+    }
+
+    .card h3 {
+      margin: 1px 0 0;
+      font: 900 16px/1.15 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }
+
+    .trigger {
+      margin: 0;
+      color: var(--muted);
+      font: 12px/1.45 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .tag {
+      padding: 4px 7px;
+      background: #efe7d8;
+      border: 1px solid var(--line);
+      color: var(--ink);
+      font: 700 11px/1 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .tag.next {
+      background: #dcecdf;
+      border-color: var(--target);
+      color: var(--target);
+    }
+
+    .detail {
+      display: none;
+      margin-top: 4px;
+      padding-top: 10px;
+      border-top: 1px dashed var(--line);
+      color: var(--muted);
+      font: 12px/1.5 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .card.open .detail {
+      display: grid;
+      gap: 8px;
+    }
+
+    .detail b {
+      color: var(--ink);
+    }
+
+    .section {
+      margin-top: 22px;
+      padding: 20px;
+    }
+
+    .sequence {
+      display: grid;
+      grid-template-columns: repeat(6, minmax(140px, 1fr));
+      gap: 10px;
+      margin-top: 16px;
+    }
+
+    .step {
+      min-height: 130px;
+      padding: 13px;
+      border: 1px solid var(--heavy);
+      background: #f8f0df;
+      display: grid;
+      align-content: start;
+      gap: 9px;
+      font: 13px/1.4 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .step:first-child {
+      background: #dcecdf;
+      border-width: 2px;
+    }
+
+    .step-num {
+      font: 900 12px/1 ui-monospace, "SFMono-Regular", Consolas, monospace;
+      color: var(--target);
+    }
+
+    .step b {
+      font-size: 14px;
+    }
+
+    .legend {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(160px, 1fr));
+      gap: 10px;
+      margin-top: 16px;
+    }
+
+    .legend-item {
+      padding: 12px;
+      border: 1px solid var(--line);
+      background: #f7f2e6;
+      font: 13px/1.45 ui-sans-serif, "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .legend-item strong {
+      display: block;
+      margin-bottom: 6px;
+      color: var(--ink);
+    }
+
+    [data-kind="blocking"] .lane-title,
+    .card[data-kind="blocking"] .rid {
+      color: var(--blocking);
+    }
+
+    .card[data-kind="blocking"] .rid {
+      background: var(--blocking);
+      color: white;
+    }
+
+    .card[data-kind="panel"] .rid {
+      background: var(--panel-refresh);
+    }
+
+    .card[data-kind="background"] .rid {
+      background: var(--background);
+    }
+
+    .card[data-kind="silent"] .rid {
+      background: var(--silent);
+    }
+
+    @media (max-width: 1180px) {
+      .decision-strip,
+      .masthead {
+        grid-template-columns: 1fr;
+      }
+
+      .lanes,
+      .sequence,
+      .legend {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (max-width: 720px) {
+      .shell {
+        width: min(100vw - 24px, 1480px);
+        padding-top: 20px;
+      }
+
+      .lanes,
+      .sequence,
+      .legend {
+        grid-template-columns: 1fr;
+      }
+
+      .toolbar {
+        position: static;
+      }
+
+      .lane-header {
+        position: static;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header class="masthead">
+      <div>
+        <h1>Long Git Operation Surface Map</h1>
+        <p class="subtitle">A visual map of every current git-producing surface in attn, grouped by the policy it should use in a giant monorepo.</p>
+      </div>
+      <aside class="doc-meta" aria-label="Document metadata">
+        <div>
+          <div class="meta-label">Plan</div>
+          <div>2026-05-15</div>
+        </div>
+        <div>
+          <div class="meta-label">Updated</div>
+          <div>2026-05-16</div>
+        </div>
+        <div>
+          <div class="meta-label">Sources</div>
+          <div>19 refresh paths</div>
+        </div>
+      </aside>
+    </header>
+
+    <section class="decision-strip" aria-label="Main decision">
+      <div class="decision">
+        <div class="eyebrow">Next implementation target</div>
+        <h2>Make hidden Changes refreshes visibility-aware first.</h2>
+        <p>`R4/R5` are expensive, repeated, and currently run from app-level state even when the Changes panel is closed. That makes them the safest high-value starting point before touching git status polling.</p>
+        <div class="target-pills">
+          <span class="pill"><strong>R4</strong> interval branch diff</span>
+          <span class="pill"><strong>R5</strong> status-triggered branch diff</span>
+          <span class="pill"><strong>Rule</strong> stale data beats surprise work</span>
+        </div>
+      </div>
+      <div class="rules">
+        <div class="rule">Do not add a loud progress surface for every slow git command. Slow can be normal in a monorepo.</div>
+        <div class="rule">User-blocking actions run immediately and report progress where the user acted.</div>
+        <div class="rule">Visible panels keep stale data visible and refresh subtly.</div>
+        <div class="rule">Hidden/background work is the adaptive backoff zone.</div>
+      </div>
+    </section>
+
+    <nav class="toolbar" aria-label="Filters">
+      <button class="filter" data-filter="all" aria-pressed="true">All</button>
+      <button class="filter" data-filter="blocking" aria-pressed="false">User-blocking</button>
+      <button class="filter" data-filter="panel" aria-pressed="false">Visible panel</button>
+      <button class="filter" data-filter="background" aria-pressed="false">Background</button>
+      <button class="filter" data-filter="silent" aria-pressed="false">Silent metadata</button>
+      <button class="filter" data-filter="target" aria-pressed="false">First target</button>
+    </nav>
+
+    <section class="board" aria-label="Refresh map">
+      <div class="lanes">
+        <section class="lane" data-kind="blocking">
+          <div class="lane-header">
+            <div class="lane-title">User-blocking <span class="count">9</span></div>
+            <div class="lane-subtitle">Run immediately. Progress belongs where the user acted.</div>
+          </div>
+        </section>
+
+        <section class="lane" data-kind="panel">
+          <div class="lane-header">
+            <div class="lane-title">Visible panel <span class="count">4</span></div>
+            <div class="lane-subtitle">Keep stale data visible. Refresh quietly in the panel.</div>
+          </div>
+        </section>
+
+        <section class="lane" data-kind="background">
+          <div class="lane-header">
+            <div class="lane-title">Background <span class="count">5</span></div>
+            <div class="lane-subtitle">Adaptive policy lives here first.</div>
+          </div>
+        </section>
+
+        <section class="lane" data-kind="silent">
+          <div class="lane-header">
+            <div class="lane-title">Silent metadata <span class="count">3</span></div>
+            <div class="lane-subtitle">Useful labels and future commands. No UX noise.</div>
+          </div>
+        </section>
+      </div>
+    </section>
+
+    <section class="section" aria-label="Implementation sequence">
+      <div class="eyebrow">Fix sequence from here</div>
+      <h2>Constrain the adaptive work before touching status polling.</h2>
+      <p>The tricky part is preserving freshness where it matters. These are the next small PR slices in order.</p>
+      <div class="sequence">
+        <div class="step">
+          <span class="step-num">01</span>
+          <b>Gate hidden Changes diff</b>
+          Skip or delay `R4/R5` when the Changes panel is closed.
+        </div>
+        <div class="step">
+          <span class="step-num">02</span>
+          <b>Refresh on open</b>
+          Show cached data immediately, then refresh once when the panel opens.
+        </div>
+        <div class="step">
+          <span class="step-num">03</span>
+          <b>Measure `R3`</b>
+          Add duration/failure signal before changing git status cadence.
+        </div>
+        <div class="step">
+          <span class="step-num">04</span>
+          <b>Guard `R9` fan-out</b>
+          Prevent viewed-file background checks from launching many diffs at once.
+        </div>
+        <div class="step">
+          <span class="step-num">05</span>
+          <b>Back off repeated slow paths</b>
+          Apply repo/worktree-specific cadence after measurement.
+        </div>
+        <div class="step">
+          <span class="step-num">06</span>
+          <b>Keep manual refresh immediate</b>
+          User-requested refreshes bypass background backoff.
+        </div>
+      </div>
+    </section>
+
+    <section class="section" aria-label="Legend">
+      <div class="eyebrow">Reading the map</div>
+      <h2>Click cards for details.</h2>
+      <div class="legend">
+        <div class="legend-item"><strong>User-blocking</strong> Path inspection, create/delete worktree, selected-file diff, Open PR setup, review-loop snapshots.</div>
+        <div class="legend-item"><strong>Visible panel</strong> Branch diff and remote sync work when Changes or Diff Detail is actually open.</div>
+        <div class="legend-item"><strong>Background</strong> Branch monitor, git status polling, hidden Changes refreshes, viewed-file checks.</div>
+        <div class="legend-item"><strong>Silent metadata</strong> Branch badges and latent branch lookup commands that should not create progress UI.</div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const items = [
+      {
+        id: "R1",
+        kind: "silent",
+        title: "Session registration branch metadata",
+        trigger: "CLI register or websocket PTY spawn registers a session.",
+        tags: ["registration", "branch badge"],
+        work: "GetBranchInfo: rev-parse, symbolic-ref, fallback short SHA, git-dir.",
+        behavior: "Synchronous inside registration path; failures are ignored.",
+        policy: "Keep registration moving. Do not show progress."
+      },
+      {
+        id: "R2",
+        kind: "background",
+        also: ["silent"],
+        title: "Session branch monitor",
+        trigger: "Daemon startup, then every 15 seconds for all stored sessions.",
+        tags: ["polling", "metadata"],
+        work: "GetBranchInfo for each session.",
+        behavior: "Silent polling; broadcasts only when metadata changes.",
+        policy: "Measure and consider daemon-side backoff across many sessions."
+      },
+      {
+        id: "R3",
+        kind: "background",
+        title: "Active session git status subscription",
+        trigger: "Entering session view with an active repo directory.",
+        tags: ["2s poll", "status", "feeds downstream"],
+        work: "git status porcelain, check-ignore, diff numstat, cached numstat.",
+        behavior: "Unchanged events are suppressed, but commands still run every 2s.",
+        policy: "Measure first. Do not blindly back off because many UI behaviors depend on it."
+      },
+      {
+        id: "R4",
+        kind: "background",
+        also: ["panel"],
+        target: true,
+        title: "Changes branch diff: initial and interval",
+        trigger: "Session view with active repo directory; immediately and every 30 seconds.",
+        tags: ["first target", "hidden dock risk", "branch diff"],
+        work: "get_branch_diff_files, default branch lookup, branch diff file scan.",
+        behavior: "Runs from App.tsx, independent of Changes panel visibility.",
+        policy: "Skip or delay while the Changes panel is closed. Refresh once on open."
+      },
+      {
+        id: "R5",
+        kind: "background",
+        also: ["panel"],
+        target: true,
+        title: "Changes branch diff: status-triggered",
+        trigger: "Every git_status_update for the active repo.",
+        tags: ["first target", "status-triggered", "branch diff"],
+        work: "Same branch diff path as R4.",
+        behavior: "Dedupes in-flight requests, but can repeat after every completed slow diff.",
+        policy: "Debounce and make visibility-aware separately from git status polling."
+      },
+      {
+        id: "R6",
+        kind: "panel",
+        title: "Diff Detail branch file list: local refs",
+        trigger: "Opening Diff Detail without cache; delayed 150ms unless remote sync wins.",
+        tags: ["diff detail", "cache"],
+        work: "get_branch_diff_files with default base ref.",
+        behavior: "Shows loading only if no cached file list.",
+        policy: "Do not skip while panel is open. Use cached stale data during refresh."
+      },
+      {
+        id: "R7",
+        kind: "panel",
+        title: "Diff Detail remote sync and refreshed file list",
+        trigger: "Opening Diff Detail.",
+        tags: ["fetch", "panel sync"],
+        work: "git fetch --all --prune, then branch diff.",
+        behavior: "Panel sync state and warning are local to Diff Detail.",
+        policy: "Keep local fallback. Treat network fetch separately from local diff."
+      },
+      {
+        id: "R8",
+        kind: "blocking",
+        title: "Diff Detail selected-file diff",
+        trigger: "Selected file, base ref, or selected file stats key changes.",
+        tags: ["selected file", "review"],
+        work: "git show base:path, optional git show :path, working-copy read.",
+        behavior: "First view shows per-file loading; errors appear in diff area.",
+        policy: "Do not background-throttle. Cache last successful diff where possible."
+      },
+      {
+        id: "R9",
+        kind: "background",
+        title: "Viewed-file change detection",
+        trigger: "Every active-session git_status_update while viewed files exist.",
+        tags: ["fan-out", "background diff"],
+        work: "One get_file_diff per viewed non-selected file still in the list.",
+        behavior: "Silent fan-out; no in-flight cap; only changed badge is surfaced.",
+        policy: "Add concurrency/in-flight guard before timing policy."
+      },
+      {
+        id: "R10",
+        kind: "blocking",
+        title: "Location picker path inspection",
+        trigger: "User submits a path from the new-session picker.",
+        tags: ["picker", "path"],
+        work: "Filesystem stat/canonicalization plus repo-root detection.",
+        behavior: "Inline picker operation text; stale results guarded by request generation.",
+        policy: "Run immediately. Keep keyboard focus and cancel/back behavior."
+      },
+      {
+        id: "R11",
+        kind: "blocking",
+        title: "Location picker repo options initial load",
+        trigger: "Path inspection resolves a repo root.",
+        tags: ["picker", "repo options"],
+        work: "Current branch, head commit, default branch, worktree prune/list.",
+        behavior: "Inline loading repo options text; failure can fall back to direct launch.",
+        policy: "User-blocking modal action. Reuse stale options once loaded."
+      },
+      {
+        id: "R12",
+        kind: "blocking",
+        title: "Repo options manual refresh",
+        trigger: "User presses refresh in repo options.",
+        tags: ["manual refresh", "stale visible"],
+        work: "Same get_repo_info path as R11.",
+        behavior: "Existing repo options stay visible; errors are logged.",
+        policy: "Run immediately. Keep stale data visible."
+      },
+      {
+        id: "R13",
+        kind: "blocking",
+        title: "Repo options create worktree",
+        trigger: "User submits create-worktree form.",
+        tags: ["worktree", "modal"],
+        work: "Optional list remotes/fetch branch, then git worktree add.",
+        behavior: "Row/form operation state; success launches session.",
+        policy: "Covered by localized long-operation UX, not adaptive background policy."
+      },
+      {
+        id: "R14",
+        kind: "blocking",
+        title: "Repo options delete worktree and refresh",
+        trigger: "User confirms delete from repo options.",
+        tags: ["worktree", "row action"],
+        work: "Resolve/list worktrees, terminate sessions, remove/prune, optional branch delete, refresh repo info.",
+        behavior: "Row delete state followed by repo-options refresh.",
+        policy: "Keep localized. Do not globalize or background-throttle."
+      },
+      {
+        id: "R15",
+        kind: "blocking",
+        title: "Close worktree cleanup delete",
+        trigger: "User closes a session and confirms cleanup.",
+        tags: ["cleanup", "prompt"],
+        work: "Same delete path as R14.",
+        behavior: "Prompt collapses if slow; failure keeps retry/keep options.",
+        policy: "Already localized. Keep out of adaptive refresh policy."
+      },
+      {
+        id: "R16",
+        kind: "blocking",
+        title: "Open PR launcher ensure repo",
+        trigger: "User opens PR into a worktree.",
+        tags: ["launcher", "clone", "fetch"],
+        work: "git clone if missing; git fetch --all --prune.",
+        behavior: "Launcher progress step exists; errors are classified.",
+        policy: "Needs daemon lifecycle coverage, not background throttling."
+      },
+      {
+        id: "R17",
+        kind: "blocking",
+        title: "Open PR launcher create worktree",
+        trigger: "After ensure repo succeeds.",
+        tags: ["launcher", "worktree"],
+        work: "git worktree add from local or remote branch.",
+        behavior: "Launcher progress step exists; create result resolves the job.",
+        policy: "Needs daemon lifecycle coverage, not background throttling."
+      },
+      {
+        id: "R18",
+        kind: "blocking",
+        title: "Review loop snapshots",
+        trigger: "Review loop starts and each iteration computes change stats.",
+        tags: ["review loop", "correctness"],
+        work: "GetDefaultBranch and GetBranchDiffFiles.",
+        behavior: "Folded into review-loop running state.",
+        policy: "Do not skip. Surface slow phase only inside review-loop UI if needed."
+      },
+      {
+        id: "R19",
+        kind: "silent",
+        title: "Latent branch lookup protocol commands",
+        trigger: "No active frontend caller found today.",
+        tags: ["future caller", "protocol"],
+        work: "list_branches, get_default_branch, list_remote_branches.",
+        behavior: "Promise/result plumbing exists, but no UI surface owns it.",
+        policy: "Future callers must declare modal or picker ownership before use."
+      }
+    ];
+
+    const lanes = document.querySelectorAll(".lane");
+    const laneByKind = new Map(Array.from(lanes).map((lane) => [lane.dataset.kind, lane]));
+
+    function cardFor(item) {
+      const node = document.createElement("article");
+      node.className = `card${item.target ? " target" : ""}`;
+      node.dataset.kind = item.kind;
+      if (item.also) node.dataset.also = item.also.join(",");
+      if (item.target) node.dataset.target = "true";
+      node.tabIndex = 0;
+      node.innerHTML = `
+        <div class="card-top">
+          <span class="rid">${item.id}</span>
+          <div>
+            <h3>${item.title}</h3>
+            <p class="trigger">${item.trigger}</p>
+          </div>
+        </div>
+        <div class="tags">
+          ${item.tags.map((tag) => `<span class="tag${tag === "first target" ? " next" : ""}">${tag}</span>`).join("")}
+        </div>
+        <div class="detail">
+          <div><b>Git work:</b> ${item.work}</div>
+          <div><b>Today:</b> ${item.behavior}</div>
+          <div><b>Policy:</b> ${item.policy}</div>
+        </div>
+      `;
+      node.addEventListener("click", () => node.classList.toggle("open"));
+      node.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          node.classList.toggle("open");
+        }
+      });
+      return node;
+    }
+
+    items.forEach((item) => {
+      laneByKind.get(item.kind).appendChild(cardFor(item));
+    });
+
+    const filters = document.querySelectorAll(".filter");
+    filters.forEach((button) => {
+      button.addEventListener("click", () => {
+        const filter = button.dataset.filter;
+        filters.forEach((candidate) => {
+          candidate.setAttribute("aria-pressed", String(candidate === button));
+        });
+        document.querySelectorAll(".card").forEach((card) => {
+          const matches = filter === "all"
+            || card.dataset.kind === filter
+            || (card.dataset.also || "").split(",").includes(filter)
+            || (filter === "target" && card.dataset.target === "true");
+          card.classList.toggle("hidden", !matches);
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/docs/plans/long-git-operation-surface-map.md
+++ b/docs/plans/long-git-operation-surface-map.md
@@ -1,6 +1,7 @@
 # Long Git Operation Surface Map
 
 Date: 2026-05-15
+Last updated: 2026-05-16
 
 Purpose: map every product surface that waits on git today before choosing UI patterns. The problem is not one spinner. Different surfaces need different treatment depending on whether the user is blocked, whether existing data can stay visible, and whether the surface is even mounted.
 
@@ -36,6 +37,83 @@ Purpose: map every product surface that waits on git today before choosing UI pa
 | Worktree list pruning | Repo info/load worktrees | `git worktree prune`, `git worktree list --porcelain` | Hidden inside repo info/list events | No unless picker waits | Can delay repo options and branch metadata | Fold into repo-options state; never global. |
 | Review loop snapshots | Start/end review loop iteration | `GetDefaultBranch`, `GetBranchDiffFiles` before and after reviewer work | Review loop bar has its own running/error state, but git snapshot time is not distinct | Yes for review loop startup/completion reporting | Slow snapshot can make review loop appear stuck before/after actual reviewer work | Keep inside review-loop panel state. Label as "capturing diff snapshot" only if slow. Do not show global git state. |
 | Latent branch protocol commands | Currently protocol/daemon only; no active frontend caller found | `list_branches`, `get_default_branch`, `list_remote_branches` | No current UI surface | N/A | Future callers may accidentally inherit generic promise/no-UX behavior | Treat as modal/picker-owned if used for branch/worktree selection. Do not add global UI by default. |
+
+## Current Git Refresh Source Map
+
+This section maps the actual producers of git work today. It is intentionally lower-level than the surface inventory because the same UI surface can be fed by several refresh paths with different policy needs.
+
+| ID | Producer | Trigger | Code path | Git work | Current behavior | Classification |
+| --- | --- | --- | --- | --- | --- | --- |
+| R1 | Session registration branch metadata | CLI register or websocket PTY spawn registers a session | `internal/daemon/daemon.go` `handleRegister`; `internal/daemon/ws_pty.go` spawn registration | `GetBranchInfo`: `rev-parse --is-inside-work-tree`, `symbolic-ref --short HEAD`, fallback `rev-parse --short HEAD`, `rev-parse --git-dir` | Synchronous inside registration path; failures ignored; session appears with missing branch metadata if git lookup fails | Correctness-adjacent background. Do not show progress. Keep registration moving if metadata is slow or unavailable. |
+| R2 | Session branch monitor | Daemon startup, then every 15s for all stored sessions | `internal/daemon/daemon.go` `monitorBranches` / `checkAllBranches` | Same `GetBranchInfo` sequence as R1 for each session | Silent polling; broadcasts sessions only when branch/worktree metadata changed | Silent background. Candidate for measurement and daemon-side backoff, especially across many sessions. |
+| R3 | Active session git status subscription | Frontend enters session view and active session has a directory; daemon sends immediate result then polls every 2s | `app/src/App.tsx` active-session subscribe effect; `internal/daemon/ws_git.go` `sendGitStatusUpdate`; `internal/daemon/gitstatus.go` `getGitStatus` | `git status --porcelain -z --untracked-files=all`; optional filesystem walk for collapsed untracked dirs; `git check-ignore --stdin`; `git diff --numstat`; `git diff --numstat --cached` | Daemon hashes and suppresses unchanged events, but still runs the commands every 2s. Errors are logged and not sent unless status parsing returns a structured "not a git repo" status. | Silent active-session background. Needs adaptive cadence before UX. Never show every poll. |
+| R4 | Changes panel branch diff, initial and interval refresh | Any session view with active repo directory; immediately and every 30s | `app/src/App.tsx` `refreshBranchDiff` interval effect | `get_branch_diff_files`; daemon gets default branch if none supplied, then `GetBranchDiffFiles` | Runs from app-level state, not dock visibility. Keeps previous result after the first load; exposes loading/refreshing/error only when `ChangesPanel` renders. | Panel-owned data but currently app-level producer. First adaptive target: skip or delay when Changes panel is closed. |
+| R5 | Changes panel branch diff on status update | Every `git_status_update` for the active repo | `app/src/App.tsx` gitStatus effect calls `refreshBranchDiff` | Same as R4 | Every status change schedules branch diff refresh. `useDaemonSocket` dedupes in-flight requests by directory, but completed slow diffs can still be repeated on every status change. | Panel-owned reactive refresh. Must be debounced/backed off separately from R3. |
+| R6 | Diff detail branch file list, local refs path | Opening Diff Detail panel without cache; delayed 150ms unless remote sync wins | `app/src/components/DiffDetailPanel.tsx` open effect `runLocalDiff` | `get_branch_diff_files` with default base ref | Panel shows loading only if no cached list. Local result is ignored if newer remote-ref result lands first. | User-visible panel load. Do not skip when panel is open; can use cached stale data while refreshing. |
+| R7 | Diff detail remote sync and refreshed branch file list | Opening Diff Detail panel | `DiffDetailPanel` open effect `sendFetchRemotes(...).then(sendGetBranchDiffFiles)` | `git fetch --all --prune`, then same branch diff as R6 | Shows panel sync state/warning. Cache is shown immediately when present. | User-visible panel sync. Keep local fallback; consider making fetch opt-in/backed off for slow repos later. |
+| R8 | Diff detail selected-file diff | Selected file changes, base ref changes, or selected file stats key changes | `app/src/App.tsx` `fetchDiffForReview`; `DiffDetailPanel` selected-file effect; `internal/daemon/ws_git.go` `handleGetFileDiff` | `git show base:path`; optionally `git show :path`; filesystem read for working copy | First view shows per-file loading; later updates avoid flicker. Errors appear in diff area. | User-blocking panel action. Do not background-throttle. Cache last successful file diff where possible. |
+| R9 | Diff detail viewed-file change detection | Every active-session `git_status_update` while Diff Detail panel has viewed files | `DiffDetailPanel` viewed-files effect | One `get_file_diff` per viewed non-selected file still in the file list | Silent background fan-out; no in-flight cap; errors ignored; only changed badge is surfaced | Silent panel background. Needs concurrency/in-flight guard before cadence tuning. |
+| R10 | Location picker path inspection | User submits a path from the new-session picker | `app/src/components/LocationPicker.tsx` `handleSelectPath`; `internal/daemon/ws_picker.go` `inspect_path` | Filesystem stat/canonicalization plus repo root detection via `ResolvePickerRepoTarget` / `rev-parse --show-toplevel` / worktree main repo detection | Picker shows inline operation text (`Inspecting path`). Request generation prevents stale results applying. | User-blocking modal action. No background backoff; keep keyboard focus/cancel behavior. |
+| R11 | Location picker repo options initial load | Path inspection resolves a repo root | `LocationPicker` `handleSelectPath`; `internal/daemon/branch.go` `handleGetRepoInfoWS` | `GetCurrentBranch`, `GetHeadCommitInfo`, `GetDefaultBranch`, `ListWorktrees` (`worktree prune`, `worktree list --porcelain`) | Picker shows inline operation text (`Loading repo options`). On failure, error is shown and direct launch continues. | User-blocking modal action, but stale options can be reused once loaded. |
+| R12 | Repo options manual refresh | User presses refresh in repo options | `LocationPicker` `handleRefresh`; `RepoOptions` refresh prop | Same as R11 | Existing repo options stay visible; refresh flag passed to `RepoOptions`; errors logged | Explicit modal refresh. Run immediately; keep stale data visible. |
+| R13 | Repo options create worktree | User submits create-worktree form | `LocationPicker` `handleCreateWorktree`; `RepoOptions`; `internal/daemon/worktree.go` `handleCreateWorktree` | Optional `ListRemotes`, optional `fetch remote branch`, `git worktree add`; store update and worktree event | Row/form operation state exists. On success launches session; on failure reports error. | User-blocking modal action. Covered by long-operation UX; not part of background adaptive policy. |
+| R14 | Repo options delete worktree and refresh | User confirms delete from repo options | `RepoOptions` delete state; `LocationPicker` delete callback; `internal/daemon/worktree.go` `handleDeleteWorktree`; then `get_repo_info` | Resolve main repo/list worktrees; terminate sessions; `git worktree remove` or prune; optional `git branch -D`; then R11 work | Row-level delete state, then repo-options refresh. | User-blocking row action followed by explicit modal refresh. Keep localized. |
+| R15 | Close worktree cleanup delete | User closes a session and confirms cleanup | `app/src/App.tsx` cleanup prompt; `WorktreeCleanupPrompt`; daemon `delete_worktree` | Same delete path as R14 | Prompt collapses to small progress surface if slow; failure keeps retry/keep options | User-blocking cleanup action. Already localized; keep out of adaptive refresh policy. |
+| R16 | Open PR launcher ensure repo | User opens PR into a worktree | `app/src/hooks/useOpenPR.ts`; `internal/daemon/branch.go` `handleEnsureRepoWS` | `git clone` if missing; `git fetch --all --prune` | Launcher progress step exists; errors are classified for retry/reporting | User-blocking launcher action. Needs daemon lifecycle coverage, not background throttling. |
+| R17 | Open PR launcher create worktree from branch | After R16 succeeds | `useOpenPR`; `internal/daemon/branch.go` `handleCreateWorktreeFromBranchWS` | `git worktree add` from local or remote branch | Launcher progress step exists; create result resolves the job | User-blocking launcher action. Needs daemon lifecycle coverage, not background throttling. |
+| R18 | Diff/review loop snapshots | Review loop starts and each iteration computes change stats | `internal/daemon/review_loop.go` `captureReviewLoopSnapshot`; `computeReviewLoopIterationChangeStats` | `GetDefaultBranch`; `GetBranchDiffFiles` | Work is folded into review-loop running state; snapshot phase is not separately visible | Correctness-critical workflow work. Do not skip; show review-loop-local slow phase if needed. |
+| R19 | Latent branch lookup protocol commands | No active frontend caller found in current app code | `list_branches`, `get_default_branch`, `list_remote_branches` websocket handlers | Branch list/default/remote branch metadata commands | Promise/result plumbing exists; no active UI surface owns it today | Future modal/picker-owned. Any new caller must declare ownership before use. |
+
+## Refresh Classification
+
+### User-Blocking
+
+These operations directly answer a user action. They can be slow, but they should run immediately, report progress in the owning surface, and fail locally with retry/keep options where appropriate.
+
+- R8 selected-file diff in Diff Detail.
+- R10 path inspection.
+- R11 repo options initial load after path inspection.
+- R13 create worktree from repo options.
+- R14 delete worktree from repo options.
+- R15 close-session worktree cleanup.
+- R16 ensure repo for Open PR.
+- R17 create worktree for Open PR.
+- R18 review-loop snapshots, because the review loop depends on the snapshot being accurate.
+
+### Visible Panel Refresh
+
+These refreshes should keep stale data visible and only show subtle state in the panel that owns the data. They should not create global operation UI.
+
+- R4 Changes panel initial/interval branch diff when the Changes panel is visible.
+- R5 Changes panel branch diff after active git status changes, when the Changes panel is visible.
+- R6 Diff Detail local branch file list.
+- R7 Diff Detail remote sync and refreshed branch file list.
+
+### Hidden Or Background Refresh
+
+These are the first candidates for adaptive behavior. The user did not ask for them at that moment, and loud progress would be noise.
+
+- R2 branch monitor across all stored sessions.
+- R3 active-session git status polling.
+- R4 Changes branch diff interval while the Changes panel is closed.
+- R5 Changes branch diff after git status while the Changes panel is closed.
+- R9 viewed-file change detection fan-out.
+
+### Metadata That Should Stay Silent
+
+These paths update useful labels/badges but should not block the main product experience.
+
+- R1 registration-time branch metadata.
+- R2 branch monitor branch/worktree metadata.
+- R19 latent branch lookup commands until a concrete UI caller owns them.
+
+## Adaptive Policy Boundaries
+
+- Start adaptive work with R4/R5 hidden Changes refreshes. They are expensive, repeated, and currently detached from dock visibility.
+- Measure R3 before changing cadence. It feeds several downstream behaviors, so backing it off blindly can make the app feel stale in surprising places.
+- Add an in-flight/concurrency guard for R9 before any timing policy. A single status update can fan out to multiple file diffs.
+- Do not apply background backoff to R8, R10, R11, R13-R18. Those are user-blocking or correctness-critical.
+- Treat R7 fetch-remotes separately from branch diff. It is panel-visible, but network fetch cost and failure semantics differ from local diff cost.
 
 ## Current UI Pattern Buckets
 


### PR DESCRIPTION
## Summary
- make Changes branch-diff refreshes run only while the Changes panel is visible
- coalesce status-triggered refreshes behind a single in-flight branch diff and add cooldown after slow automatic refreshes
- add the git refresh source map plus standalone HTML visualization

## Tests
- pnpm --dir app exec tsc --noEmit
- pnpm --dir app test -- App.worktreeCleanup.test.tsx
- git diff --check