### PR TITLE
Improve Diff Detail slow Git UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Changed
 - **Changes Panel Refreshes**: The Changes panel now avoids branch-diff refreshes while closed, refreshes once when opened, and coalesces status-triggered refreshes so slow monorepos do not stack repeated Git diff work behind every status update.
+- **Diff Detail Loading**: The Diff detail view now shows a foreground pending state when the selected file diff is slow, keeps cached content visible while it refreshes, and caps background viewed-file checks so status bursts do not fan out into repeated Git diff work.
 
 ---
 

--- a/app/src/components/DiffDetailPanel.css
+++ b/app/src/components/DiffDetailPanel.css
@@ -51,6 +51,21 @@
   color: #fbbf24;
 }
 
+.review-sync-status.background-checking {
+  color: #8ea3ba;
+}
+
+.review-sync-status.background-checking::before {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 6px;
+  border-radius: 999px;
+  background: #60a5fa;
+  animation: diff-status-pulse 1.2s ease-in-out infinite;
+}
+
 .review-close {
   background: var(--color-border);
   border: 1px solid var(--color-border-hover);
@@ -254,6 +269,44 @@
   flex-shrink: 0;
 }
 
+.diff-primary-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex-shrink: 0;
+  max-width: min(360px, 38vw);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 1px solid rgba(96, 165, 250, 0.42);
+  background: rgba(96, 165, 250, 0.1);
+  color: #bfdbfe;
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-size: calc(11px * var(--ui-scale));
+  font-weight: 600;
+}
+
+.diff-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: #60a5fa;
+  flex-shrink: 0;
+  animation: diff-status-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes diff-status-pulse {
+  0%, 100% {
+    opacity: 0.45;
+    transform: scale(0.82);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 .diff-actions {
   display: flex;
   gap: 4px;
@@ -289,6 +342,16 @@
   background: var(--color-bg-editor);
 }
 
+.diff-editor-shell {
+  height: 100%;
+  min-height: 0;
+  transition: opacity 0.16s ease;
+}
+
+.diff-editor-shell.refreshing {
+  opacity: 0.55;
+}
+
 .diff-loading,
 .diff-error,
 .diff-placeholder {
@@ -299,6 +362,64 @@
   color: var(--color-text-muted);
   font-size: calc(14px * var(--ui-scale));
   background: var(--color-bg-editor);
+}
+
+.diff-loading-detail {
+  flex-direction: column;
+  gap: 18px;
+  padding: 24px;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.diff-loading-copy {
+  display: grid;
+  gap: 6px;
+  justify-items: center;
+}
+
+.diff-loading-title {
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+.diff-loading-subtitle {
+  color: var(--color-text-tertiary);
+  font-size: calc(12px * var(--ui-scale));
+}
+
+.diff-loading-skeleton {
+  width: min(720px, 82%);
+  margin: 0 auto;
+  display: grid;
+  gap: 10px;
+}
+
+.diff-loading-skeleton span {
+  height: 12px;
+  border-radius: 2px;
+  background: var(--color-border);
+  opacity: 0.72;
+}
+
+.diff-loading-skeleton span:nth-child(1) {
+  width: 92%;
+}
+
+.diff-loading-skeleton span:nth-child(2) {
+  width: 76%;
+}
+
+.diff-loading-skeleton span:nth-child(3) {
+  width: 88%;
+}
+
+.diff-loading-skeleton span:nth-child(4) {
+  width: 64%;
+}
+
+.diff-loading-skeleton span:nth-child(5) {
+  width: 81%;
 }
 
 .diff-error {

--- a/app/src/components/DiffDetailPanel.test.tsx
+++ b/app/src/components/DiffDetailPanel.test.tsx
@@ -647,6 +647,51 @@ describe('DiffDetailPanel', () => {
         'file-D.tsx': 1,
       });
     });
+
+    it('rechecks a viewed file when another status update arrives while its background check is in flight', async () => {
+      const files = ['file-A.tsx', 'file-B.tsx'];
+      const view = await prepareViewedFiles(files, 'file-A.tsx');
+
+      const pending: Array<(value: ReturnType<typeof createFileDiffResult> & { path: string }) => void> = [];
+      mockDaemon.setResponse('fetchDiff', (args: unknown[]) => {
+        const [path] = args as [string];
+        return new Promise((resolve) => {
+          pending.push((value) => resolve({ ...value, path }));
+        });
+      });
+
+      view.rerender(
+        <ControlledDiffDetailPanel
+          gitStatus={createGitStatus(['file-B.tsx'])}
+          isOpen={true}
+          initialSelectedFile="file-A.tsx"
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockDaemon.getCalls('fetchDiff').map((call) => call.args[0])).toEqual(['file-B.tsx']);
+      });
+
+      view.rerender(
+        <ControlledDiffDetailPanel
+          gitStatus={createGitStatus(['file-B.tsx'], { additions: 11 })}
+          isOpen={true}
+          initialSelectedFile="file-A.tsx"
+        />
+      );
+
+      pending[0]?.({
+        ...createFileDiffResult('// original file-B.tsx', '// modified file-B.tsx'),
+        path: 'file-B.tsx',
+      });
+
+      await waitFor(() => {
+        expect(mockDaemon.getCalls('fetchDiff').map((call) => call.args[0])).toEqual([
+          'file-B.tsx',
+          'file-B.tsx',
+        ]);
+      });
+    });
   });
 
   describe('guard rails', () => {

--- a/app/src/components/DiffDetailPanel.test.tsx
+++ b/app/src/components/DiffDetailPanel.test.tsx
@@ -24,6 +24,7 @@ vi.mock('./UnifiedDiffEditor', () => ({
   )),
   buildUnifiedDocument: vi.fn(() => []),
   resolveAnchor: vi.fn(() => ({ docLine: 1, isOutdated: false, isOrphaned: false })),
+  hashContent: vi.fn((content: string) => content),
 }));
 
 describe('DiffDetailPanel', () => {
@@ -433,6 +434,48 @@ describe('DiffDetailPanel', () => {
   });
 
   describe('change detection', () => {
+    async function prepareViewedFiles(files: string[], selectedAtEnd: string) {
+      mockDaemon.setResponse('getBranchDiffFiles', () =>
+        createBranchDiffFilesResult(files)
+      );
+      mockDaemon.setResponse('fetchDiff', (args: unknown[]) => {
+        const [path] = args as [string];
+        return {
+          ...createFileDiffResult(`// original ${path}`, `// modified ${path}`),
+          path,
+        };
+      });
+
+      const initialGitStatus = createGitStatus(files);
+      const view = renderPanel({
+        gitStatus: initialGitStatus,
+        initialSelectedFile: files[0],
+      });
+
+      await waitFor(() => {
+        expect(getFileInList(files[0])).toBeInTheDocument();
+      });
+
+      for (const file of files) {
+        getFileInList(file).click();
+        await waitFor(() => {
+          expect(mockDaemon.getCalls('fetchDiff').some((call) => call.args[0] === file)).toBe(true);
+        });
+      }
+
+      getFileInList(selectedAtEnd).click();
+      await waitFor(() => {
+        expect(getFileInList(selectedAtEnd)).toHaveClass('selected');
+      });
+
+      await waitFor(() => {
+        expect(mockDaemon.getCalls('fetchDiff').some((call) => call.args[0] === selectedAtEnd)).toBe(true);
+      });
+      mockDaemon.clearCalls();
+
+      return view;
+    }
+
     it('shows CHANGED badge when file content differs from last view', async () => {
       const gitStatus = createGitStatus(['src/App.tsx']);
 
@@ -485,6 +528,124 @@ describe('DiffDetailPanel', () => {
 
       // Badge should not be visible (no changes detected in this test)
       expect(screen.queryByText('changed')).not.toBeInTheDocument();
+    });
+
+    it('shows foreground pending state when the selected diff is slow', async () => {
+      mockDaemon.setResponse('getBranchDiffFiles', () =>
+        createBranchDiffFilesResult(['src/slow.ts'])
+      );
+      let resolveDiff: ((value: ReturnType<typeof createFileDiffResult> & { path: string }) => void) | undefined;
+      mockDaemon.setResponse('fetchDiff', (args: unknown[]) => {
+        const [path] = args as [string];
+        return new Promise((resolve) => {
+          resolveDiff = resolve;
+        }).then((result) => ({ ...(result as ReturnType<typeof createFileDiffResult>), path }));
+      });
+
+      renderPanel({
+        gitStatus: createGitStatus(['src/slow.ts']),
+        initialSelectedFile: 'src/slow.ts',
+      });
+
+      await waitFor(() => {
+        expect(mockDaemon.getCalls('fetchDiff').some((call) => call.args[0] === 'src/slow.ts')).toBe(true);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('status')).toHaveTextContent('Loading selected diff...');
+      });
+
+      expect(screen.getByText('Waiting for git to return the file diff.')).toBeInTheDocument();
+
+      resolveDiff?.({
+        ...createFileDiffResult('// original slow', '// modified slow'),
+        path: 'src/slow.ts',
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+      });
+    });
+
+    it('caps viewed-file background checks at two concurrent diff requests', async () => {
+      const files = ['file-A.tsx', 'file-B.tsx', 'file-C.tsx', 'file-D.tsx'];
+      const view = await prepareViewedFiles(files, 'file-A.tsx');
+
+      const pending = new Map<string, (value: ReturnType<typeof createFileDiffResult> & { path: string }) => void>();
+      mockDaemon.setResponse('fetchDiff', (args: unknown[]) => {
+        const [path] = args as [string];
+        return new Promise((resolve) => {
+          pending.set(path, resolve);
+        });
+      });
+
+      view.rerender(
+        <ControlledDiffDetailPanel
+          gitStatus={createGitStatus(['file-B.tsx', 'file-C.tsx', 'file-D.tsx'])}
+          isOpen={true}
+          initialSelectedFile="file-A.tsx"
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Checking 3 viewed files...')).toBeInTheDocument();
+      });
+      await sleep(650);
+
+      const backgroundCalls = mockDaemon.getCalls('fetchDiff').map((call) => call.args[0]);
+      expect(backgroundCalls).toEqual(['file-B.tsx', 'file-C.tsx']);
+      expect(pending.size).toBe(2);
+      expect(pending.has('file-D.tsx')).toBe(false);
+    });
+
+    it('coalesces duplicate viewed-file background checks across status bursts', async () => {
+      const files = ['file-A.tsx', 'file-B.tsx', 'file-C.tsx', 'file-D.tsx'];
+      const view = await prepareViewedFiles(files, 'file-A.tsx');
+
+      mockDaemon.setResponse('fetchDiff', (args: unknown[]) => {
+        const [path] = args as [string];
+        return {
+          ...createFileDiffResult(`// original ${path}`, `// modified ${path} updated`),
+          path,
+        };
+      });
+
+      view.rerender(
+        <ControlledDiffDetailPanel
+          gitStatus={createGitStatus(['file-B.tsx', 'file-C.tsx', 'file-D.tsx'])}
+          isOpen={true}
+          initialSelectedFile="file-A.tsx"
+        />
+      );
+      view.rerender(
+        <ControlledDiffDetailPanel
+          gitStatus={createGitStatus(['file-B.tsx', 'file-C.tsx', 'file-D.tsx'])}
+          isOpen={true}
+          initialSelectedFile="file-A.tsx"
+        />
+      );
+      view.rerender(
+        <ControlledDiffDetailPanel
+          gitStatus={createGitStatus(['file-B.tsx', 'file-C.tsx', 'file-D.tsx'])}
+          isOpen={true}
+          initialSelectedFile="file-A.tsx"
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockDaemon.getCalls('fetchDiff').length).toBe(3);
+      }, { timeout: 1500 });
+
+      const counts = mockDaemon.getCalls('fetchDiff').reduce<Record<string, number>>((acc, call) => {
+        const path = call.args[0] as string;
+        acc[path] = (acc[path] || 0) + 1;
+        return acc;
+      }, {});
+      expect(counts).toEqual({
+        'file-B.tsx': 1,
+        'file-C.tsx': 1,
+        'file-D.tsx': 1,
+      });
     });
   });
 

--- a/app/src/components/DiffDetailPanel.tsx
+++ b/app/src/components/DiffDetailPanel.tsx
@@ -315,6 +315,7 @@ export function DiffDetailPanel({
   const backgroundCheckQueueRef = useRef<string[]>([]);
   const backgroundCheckQueuedPathsRef = useRef<Set<string>>(new Set());
   const backgroundCheckInFlightPathsRef = useRef<Set<string>>(new Set());
+  const backgroundCheckRerunPathsRef = useRef<Set<string>>(new Set());
   const backgroundCheckTimerRef = useRef<number | null>(null);
   const backgroundCheckGenerationRef = useRef(0);
   const selectedFilePathRef = useRef<string | null>(selectedFilePath);
@@ -331,9 +332,12 @@ export function DiffDetailPanel({
   }, [baseRef, contentVisible, fetchDiff, selectedFilePath]);
 
   const syncBackgroundChangeCheckCount = useCallback(() => {
-    setBackgroundChangeCheckCount(
-      backgroundCheckQueueRef.current.length + backgroundCheckInFlightPathsRef.current.size
-    );
+    const activePaths = new Set([
+      ...backgroundCheckQueueRef.current,
+      ...backgroundCheckInFlightPathsRef.current,
+      ...backgroundCheckRerunPathsRef.current,
+    ]);
+    setBackgroundChangeCheckCount(activePaths.size);
   }, []);
 
   const clearSelectedDiffPendingTimer = useCallback(() => {
@@ -356,6 +360,7 @@ export function DiffDetailPanel({
     backgroundCheckQueueRef.current = [];
     backgroundCheckQueuedPathsRef.current.clear();
     backgroundCheckInFlightPathsRef.current.clear();
+    backgroundCheckRerunPathsRef.current.clear();
     setBackgroundChangeCheckCount(0);
   }, [clearBackgroundChangeCheckTimer]);
 
@@ -421,6 +426,15 @@ export function DiffDetailPanel({
             return;
           }
           backgroundCheckInFlightPathsRef.current.delete(viewedPath);
+          if (
+            backgroundCheckRerunPathsRef.current.delete(viewedPath) &&
+            contentVisibleRef.current &&
+            viewedPath !== selectedFilePathRef.current &&
+            viewedDiffHashesRef.current.has(viewedPath)
+          ) {
+            backgroundCheckQueueRef.current.push(viewedPath);
+            backgroundCheckQueuedPathsRef.current.add(viewedPath);
+          }
           syncBackgroundChangeCheckCount();
           drainBackgroundChangeChecks();
         });
@@ -439,9 +453,15 @@ export function DiffDetailPanel({
         continue;
       }
       if (
-        backgroundCheckQueuedPathsRef.current.has(path) ||
-        backgroundCheckInFlightPathsRef.current.has(path)
+        backgroundCheckQueuedPathsRef.current.has(path)
       ) {
+        continue;
+      }
+      if (backgroundCheckInFlightPathsRef.current.has(path)) {
+        if (!backgroundCheckRerunPathsRef.current.has(path)) {
+          backgroundCheckRerunPathsRef.current.add(path);
+          added = true;
+        }
         continue;
       }
       backgroundCheckQueueRef.current.push(path);

--- a/app/src/components/DiffDetailPanel.tsx
+++ b/app/src/components/DiffDetailPanel.tsx
@@ -27,6 +27,9 @@ const AUTO_SKIP_PATTERNS = [
   'poetry.lock',
 ];
 
+const BACKGROUND_CHANGE_CHECK_CONCURRENCY = 2;
+const BACKGROUND_CHANGE_CHECK_DEBOUNCE_MS = 500;
+
 // ============================================================================
 // Comment Conversion Utilities (for UnifiedDiffEditor integration)
 // ============================================================================
@@ -119,6 +122,11 @@ interface ReviewFile {
   hasUncommitted?: boolean;  // True if file has uncommitted changes on top of committed
   oldPath?: string;  // For renames
 }
+
+type DiffContent = {
+  original: string;
+  modified: string;
+};
 
 type TreeNode = {
   type: 'file' | 'dir';
@@ -240,12 +248,15 @@ export function DiffDetailPanel({
   const [viewedFiles, setViewedFiles] = useState<Set<string>>(new Set());
   const [reviewId, setReviewId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [showSelectedDiffPending, setShowSelectedDiffPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [diffContent, setDiffContent] = useState<{ original: string; modified: string } | null>(null);
+  const [diffContent, setDiffContent] = useState<DiffContent | null>(null);
   const [expandedContext, setExpandedContext] = useState(0); // 0 = hunks mode (uses 3 lines context), -1 = full file
   const fontSize = Math.round(13 * scale);
   const [scrollToLine, setScrollToLine] = useState<number | undefined>(undefined);
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const diffContentCacheRef = useRef<Map<string, DiffContent>>(new Map());
+  const selectedDiffPendingTimerRef = useRef<number | null>(null);
 
   // Branch diff state - PR-like comparison against origin/main
   const [branchDiffFiles, setBranchDiffFiles] = useState<BranchDiffFile[]>([]);
@@ -300,6 +311,156 @@ export function DiffDetailPanel({
   const viewedDiffHashesRef = useRef<Map<string, string>>(new Map());
   const [changedSinceViewed, setChangedSinceViewed] = useState<Set<string>>(new Set());
   const previousSelectedPathRef = useRef<string | null>(null);
+  const [backgroundChangeCheckCount, setBackgroundChangeCheckCount] = useState(0);
+  const backgroundCheckQueueRef = useRef<string[]>([]);
+  const backgroundCheckQueuedPathsRef = useRef<Set<string>>(new Set());
+  const backgroundCheckInFlightPathsRef = useRef<Set<string>>(new Set());
+  const backgroundCheckTimerRef = useRef<number | null>(null);
+  const backgroundCheckGenerationRef = useRef(0);
+  const selectedFilePathRef = useRef<string | null>(selectedFilePath);
+  const contentVisibleRef = useRef(contentVisible);
+  const baseRefRef = useRef(baseRef);
+  const fetchDiffRef = useRef(fetchDiff);
+  const lastBackgroundGitStatusRef = useRef<GitStatusUpdate | null>(null);
+
+  useEffect(() => {
+    selectedFilePathRef.current = selectedFilePath;
+    contentVisibleRef.current = contentVisible;
+    baseRefRef.current = baseRef;
+    fetchDiffRef.current = fetchDiff;
+  }, [baseRef, contentVisible, fetchDiff, selectedFilePath]);
+
+  const syncBackgroundChangeCheckCount = useCallback(() => {
+    setBackgroundChangeCheckCount(
+      backgroundCheckQueueRef.current.length + backgroundCheckInFlightPathsRef.current.size
+    );
+  }, []);
+
+  const clearSelectedDiffPendingTimer = useCallback(() => {
+    if (selectedDiffPendingTimerRef.current !== null) {
+      window.clearTimeout(selectedDiffPendingTimerRef.current);
+      selectedDiffPendingTimerRef.current = null;
+    }
+  }, []);
+
+  const clearBackgroundChangeCheckTimer = useCallback(() => {
+    if (backgroundCheckTimerRef.current !== null) {
+      window.clearTimeout(backgroundCheckTimerRef.current);
+      backgroundCheckTimerRef.current = null;
+    }
+  }, []);
+
+  const resetBackgroundChangeChecks = useCallback(() => {
+    backgroundCheckGenerationRef.current += 1;
+    clearBackgroundChangeCheckTimer();
+    backgroundCheckQueueRef.current = [];
+    backgroundCheckQueuedPathsRef.current.clear();
+    backgroundCheckInFlightPathsRef.current.clear();
+    setBackgroundChangeCheckCount(0);
+  }, [clearBackgroundChangeCheckTimer]);
+
+  const drainBackgroundChangeChecks = useCallback(() => {
+    if (!contentVisibleRef.current) {
+      resetBackgroundChangeChecks();
+      return;
+    }
+
+    while (
+      backgroundCheckInFlightPathsRef.current.size < BACKGROUND_CHANGE_CHECK_CONCURRENCY &&
+      backgroundCheckQueueRef.current.length > 0
+    ) {
+      const viewedPath = backgroundCheckQueueRef.current.shift();
+      if (!viewedPath) {
+        continue;
+      }
+
+      backgroundCheckQueuedPathsRef.current.delete(viewedPath);
+      if (backgroundCheckInFlightPathsRef.current.has(viewedPath)) {
+        continue;
+      }
+
+      if (viewedPath === selectedFilePathRef.current) {
+        continue;
+      }
+
+      const prevHash = viewedDiffHashesRef.current.get(viewedPath);
+      if (!prevHash) {
+        continue;
+      }
+
+      const generation = backgroundCheckGenerationRef.current;
+      backgroundCheckInFlightPathsRef.current.add(viewedPath);
+      syncBackgroundChangeCheckCount();
+
+      fetchDiffRef.current(viewedPath, { baseRef: baseRefRef.current })
+        .then((result) => {
+          if (
+            generation !== backgroundCheckGenerationRef.current ||
+            !contentVisibleRef.current ||
+            viewedPath === selectedFilePathRef.current
+          ) {
+            return;
+          }
+
+          const newHash = hashContent(result.original + result.modified);
+          const currentHash = viewedDiffHashesRef.current.get(viewedPath);
+          if (currentHash && currentHash !== newHash) {
+            setChangedSinceViewed(prev => new Set(prev).add(viewedPath));
+            viewedDiffHashesRef.current.set(viewedPath, newHash);
+            diffContentCacheRef.current.set(viewedPath, {
+              original: result.original,
+              modified: result.modified,
+            });
+          }
+        })
+        .catch(() => {
+          // Background checks are advisory. Keep the foreground diff stable.
+        })
+        .finally(() => {
+          if (generation !== backgroundCheckGenerationRef.current) {
+            return;
+          }
+          backgroundCheckInFlightPathsRef.current.delete(viewedPath);
+          syncBackgroundChangeCheckCount();
+          drainBackgroundChangeChecks();
+        });
+    }
+
+    syncBackgroundChangeCheckCount();
+  }, [resetBackgroundChangeChecks, syncBackgroundChangeCheckCount]);
+
+  const scheduleBackgroundChangeChecks = useCallback((paths: string[]) => {
+    let added = false;
+    for (const path of paths) {
+      if (path === selectedFilePathRef.current) {
+        continue;
+      }
+      if (!viewedDiffHashesRef.current.has(path)) {
+        continue;
+      }
+      if (
+        backgroundCheckQueuedPathsRef.current.has(path) ||
+        backgroundCheckInFlightPathsRef.current.has(path)
+      ) {
+        continue;
+      }
+      backgroundCheckQueueRef.current.push(path);
+      backgroundCheckQueuedPathsRef.current.add(path);
+      added = true;
+    }
+
+    if (!added) {
+      syncBackgroundChangeCheckCount();
+      return;
+    }
+
+    syncBackgroundChangeCheckCount();
+    clearBackgroundChangeCheckTimer();
+    backgroundCheckTimerRef.current = window.setTimeout(() => {
+      backgroundCheckTimerRef.current = null;
+      drainBackgroundChangeChecks();
+    }, BACKGROUND_CHANGE_CHECK_DEBOUNCE_MS);
+  }, [clearBackgroundChangeCheckTimer, drainBackgroundChangeChecks, syncBackgroundChangeCheckCount]);
 
   // Fetch branch diff files when panel opens (PR-like comparison vs origin/main)
   // Load local refs immediately, then refresh in background after fetching remotes.
@@ -598,14 +759,19 @@ export function DiffDetailPanel({
       setError(null);
       setExpandedContext(0);
       setScrollToLine(undefined);
+      setLoading(false);
+      setShowSelectedDiffPending(false);
+      clearSelectedDiffPendingTimer();
       setIsLoadingBranchDiff(false);
       setIsSyncingRemotes(false);
       setRemotesSyncWarning(null);
+      diffContentCacheRef.current.clear();
       // Clear change detection state
       viewedDiffHashesRef.current.clear();
       setChangedSinceViewed(new Set());
+      resetBackgroundChangeChecks();
     }
-  }, [contentVisible]);
+  }, [clearSelectedDiffPendingTimer, contentVisible, resetBackgroundChangeChecks]);
 
   const previousRepoPathRef = useRef<string | null>(null);
   useEffect(() => {
@@ -616,17 +782,21 @@ export function DiffDetailPanel({
       setDiffContent(null);
       setError(null);
       setLoading(false);
+      setShowSelectedDiffPending(false);
+      clearSelectedDiffPendingTimer();
       setExpandedContext(0);
       setScrollToLine(undefined);
       setBranchDiffFiles([]);
       setBaseRef('');
       setRemotesSyncWarning(null);
+      diffContentCacheRef.current.clear();
       viewedDiffHashesRef.current.clear();
       setChangedSinceViewed(new Set());
       setViewedFiles(new Set());
+      resetBackgroundChangeChecks();
     }
     previousRepoPathRef.current = repoPath;
-  }, [isOpen, repoPath]);
+  }, [clearSelectedDiffPendingTimer, isOpen, repoPath, resetBackgroundChangeChecks]);
 
   // Create a stable key that changes when we need to refetch the diff
   // This includes the file path and a representation of the git status for that file
@@ -640,31 +810,44 @@ export function DiffDetailPanel({
   useEffect(() => {
     if (!selectedFile || !diffFetchKey) {
       setDiffContent(null);
+      setLoading(false);
+      setShowSelectedDiffPending(false);
+      clearSelectedDiffPendingTimer();
       return;
     }
 
     // Store current path to check if we're still viewing the same file when fetch completes
     const fetchPath = selectedFile.path;
     const isFirstView = !viewedFiles.has(fetchPath);
+    const cachedContent = diffContentCacheRef.current.get(fetchPath) || null;
 
-    // Only show loading on first view to avoid flickering during updates
-    if (isFirstView) {
-      setLoading(true);
-    }
+    setDiffContent(cachedContent);
+    setLoading(true);
+    setShowSelectedDiffPending(false);
     setError(null);
+    clearSelectedDiffPendingTimer();
+    selectedDiffPendingTimerRef.current = window.setTimeout(() => {
+      selectedDiffPendingTimerRef.current = null;
+      if (selectedFilePathRef.current === fetchPath) {
+        setShowSelectedDiffPending(true);
+      }
+    }, 250);
 
     // Use baseRef for PR-like diff comparison (origin/main vs working directory)
     fetchDiff(fetchPath, { baseRef })
       .then((result) => {
         // Only update if we're still viewing the same file
-        if (selectedFilePath !== fetchPath) return;
+        if (selectedFilePathRef.current !== fetchPath) return;
 
         const newContent = { original: result.original, modified: result.modified };
         const newHash = hashContent(result.original + result.modified);
         const prevHash = viewedDiffHashesRef.current.get(fetchPath);
 
+        diffContentCacheRef.current.set(fetchPath, newContent);
         setDiffContent(newContent);
         setLoading(false);
+        setShowSelectedDiffPending(false);
+        clearSelectedDiffPendingTimer();
 
         // Check if file changed since last viewed
         if (prevHash && prevHash !== newHash) {
@@ -689,41 +872,41 @@ export function DiffDetailPanel({
         }
       })
       .catch((err) => {
-        if (selectedFilePath !== fetchPath) return;
+        if (selectedFilePathRef.current !== fetchPath) return;
         setError(err.message || 'Failed to load diff');
         setLoading(false);
+        setShowSelectedDiffPending(false);
+        clearSelectedDiffPendingTimer();
       });
+    return () => {
+      clearSelectedDiffPendingTimer();
+    };
   // Note: viewedFiles intentionally excluded - we read it but don't want re-runs when it changes
-  }, [diffFetchKey, selectedFile, selectedFilePath, fetchDiff, baseRef, reviewId, markFileViewed]);
+  }, [clearSelectedDiffPendingTimer, diffFetchKey, selectedFile, fetchDiff, baseRef, reviewId, markFileViewed]);
 
   // Check for changes in viewed files when gitStatus updates (for files not currently selected)
   useEffect(() => {
-    if (!gitStatus) return;
+    if (!gitStatus || !contentVisible) return;
+    if (lastBackgroundGitStatusRef.current === gitStatus) return;
+    lastBackgroundGitStatusRef.current = gitStatus;
 
-    // For each viewed file that's still in the changes, check if it changed
-    viewedFiles.forEach(async (viewedPath) => {
-      // Skip currently selected file (handled by the main effect)
-      if (viewedPath === selectedFilePath) return;
+    const changedPaths = new Set(
+      [...gitStatus.staged, ...gitStatus.unstaged, ...gitStatus.untracked].flatMap((file) => (
+        file.old_path ? [file.path, file.old_path] : [file.path]
+      ))
+    );
+    const candidates = Array.from(viewedFiles).filter((viewedPath) => (
+      viewedPath !== selectedFilePath &&
+      changedPaths.has(viewedPath) &&
+      viewedDiffHashesRef.current.has(viewedPath)
+    ));
 
-      // Find the file in current git status
-      const fileInChanges = allFiles.find(f => f.path === viewedPath);
-      if (!fileInChanges) return; // File no longer in changes
+    if (candidates.length === 0) {
+      return;
+    }
 
-      // Fetch and check hash using baseRef for PR-like diff
-      try {
-        const result = await fetchDiff(viewedPath, { baseRef });
-        const newHash = hashContent(result.original + result.modified);
-        const prevHash = viewedDiffHashesRef.current.get(viewedPath);
-
-        if (prevHash && prevHash !== newHash) {
-          setChangedSinceViewed(prev => new Set(prev).add(viewedPath));
-          viewedDiffHashesRef.current.set(viewedPath, newHash);
-        }
-      } catch {
-        // Ignore errors for background checks
-      }
-    });
-  }, [gitStatus, viewedFiles, selectedFilePath, allFiles, fetchDiff, baseRef]);
+    scheduleBackgroundChangeChecks(candidates);
+  }, [allFiles, contentVisible, gitStatus, scheduleBackgroundChangeChecks, selectedFilePath, viewedFiles]);
 
   useEscapeStack(onClose, isOpen);
 
@@ -1075,6 +1258,10 @@ export function DiffDetailPanel({
   }, [selectedFilePath, viewedFiles, changedSinceViewed, getFileIcon, getStatusLabel, fileCommentCounts]);
 
   const currentFileIndex = selectedFile ? allFiles.findIndex(f => f.path === selectedFile.path) : -1;
+  const selectedDiffIsPending = loading && showSelectedDiffPending;
+  const selectedDiffPendingLabel = diffContent
+    ? 'Loading selected diff... showing cached content'
+    : 'Loading selected diff...';
 
   return (
       <div className="review-panel" ref={panelRef} tabIndex={-1}>
@@ -1093,6 +1280,11 @@ export function DiffDetailPanel({
           )}
           {remotesSyncWarning && (
             <span className="review-sync-status warning">{remotesSyncWarning}</span>
+          )}
+          {backgroundChangeCheckCount > 0 && (
+            <span className="review-sync-status background-checking">
+              Checking {backgroundChangeCheckCount} viewed {backgroundChangeCheckCount === 1 ? 'file' : 'files'}...
+            </span>
           )}
           <div className="review-header-actions">
             {onOpenEditor && (
@@ -1150,6 +1342,12 @@ export function DiffDetailPanel({
                   <span className="changed-badge">changed</span>
                 )}
               </span>
+              {selectedDiffIsPending && selectedFile && (
+                <span className="diff-primary-status" role="status">
+                  <span className="diff-status-dot" />
+                  {selectedDiffPendingLabel}
+                </span>
+              )}
               <div className="diff-actions">
                 <button
                   className={`expand-btn ${expandedContext === 0 ? 'active' : ''}`}
@@ -1168,34 +1366,46 @@ export function DiffDetailPanel({
               </div>
             </div>
             <div className="diff-content">
-              {loading && !diffContent ? (
-                <div className="diff-loading">Loading diff...</div>
-              ) : error ? (
+              {error ? (
                 <div className="diff-error">{error}</div>
               ) : !selectedFile ? (
                 <div className="diff-placeholder">Select a file to view diff</div>
               ) : !diffContent ? (
-                <div className="diff-loading">Loading diff...</div>
+                <div className="diff-loading diff-loading-detail">
+                  <div className="diff-loading-copy">
+                    <span className="diff-loading-title">Loading selected diff...</span>
+                    <span className="diff-loading-subtitle">Waiting for git to return the file diff.</span>
+                  </div>
+                  <div className="diff-loading-skeleton" aria-hidden="true">
+                    <span />
+                    <span />
+                    <span />
+                    <span />
+                    <span />
+                  </div>
+                </div>
               ) : (
-                <UnifiedDiffEditor
-                  original={diffContent.original}
-                  modified={diffContent.modified}
-                  comments={editorComments}
-                  editingCommentId={editingCommentId}
-                  resolvedTheme={resolvedTheme}
-                  fontSize={fontSize}
-                  language={editorLanguage}
-                  contextLines={expandedContext === -1 ? 0 : 3}
-                  scrollToLine={scrollToLine}
-                  filePath={selectedFilePath || undefined}
-                  onAddComment={handleEditorAddComment}
-                  onEditComment={handleEditorEditComment}
-                  onStartEdit={handleEditorStartEdit}
-                  onCancelEdit={handleEditorCancelEdit}
-                  onResolveComment={handleEditorResolveComment}
-                  onDeleteComment={handleEditorDeleteComment}
-                  onSendToClaude={onSendToClaude ? sendToClaudeAndClose : undefined}
-                />
+                <div className={`diff-editor-shell ${selectedDiffIsPending ? 'refreshing' : ''}`}>
+                  <UnifiedDiffEditor
+                    original={diffContent.original}
+                    modified={diffContent.modified}
+                    comments={editorComments}
+                    editingCommentId={editingCommentId}
+                    resolvedTheme={resolvedTheme}
+                    fontSize={fontSize}
+                    language={editorLanguage}
+                    contextLines={expandedContext === -1 ? 0 : 3}
+                    scrollToLine={scrollToLine}
+                    filePath={selectedFilePath || undefined}
+                    onAddComment={handleEditorAddComment}
+                    onEditComment={handleEditorEditComment}
+                    onStartEdit={handleEditorStartEdit}
+                    onCancelEdit={handleEditorCancelEdit}
+                    onResolveComment={handleEditorResolveComment}
+                    onDeleteComment={handleEditorDeleteComment}
+                    onSendToClaude={onSendToClaude ? sendToClaudeAndClose : undefined}
+                  />
+                </div>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add foreground pending UI for slow selected-file diffs, keeping cached diff content visible while refreshing
- cap and dedupe viewed-file background change checks so git status bursts do not fan out into repeated file diffs
- add focused coverage for slow selected diffs, background check concurrency, and status burst coalescing

## Tests
- pnpm --dir app exec tsc --noEmit
- pnpm --dir app exec vitest run src/components/DiffDetailPanel.test.tsx
- pnpm --dir app test
- git diff --check