### PR TITLE
Fix Codex resume and idle state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Changes Panel Refreshes**: The Changes panel now avoids branch-diff refreshes while closed, refreshes once when opened, and coalesces status-triggered refreshes so slow monorepos do not stack repeated Git diff work behind every status update.
 - **Diff Detail Loading**: The Diff detail view now shows a foreground pending state when the selected file diff is slow, keeps cached content visible while it refreshes, and caps background viewed-file checks so status bursts do not fan out into repeated Git diff work.
 
+### Fixed
+- **Codex Session Resume**: Reloading a Codex session from attn now records Codex's native session id from hooks and resumes the same Codex conversation instead of handing Codex attn's wrapper session id.
+- **Codex Activity State**: Reloaded or completed Codex sessions no longer stay green just because the Codex TUI process is alive at an idle prompt.
+
 ---
 
 ## [2026-05-16]

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
     "real-app:scenario-tr204": "node scripts/real-app-harness/scenario-tr204-local-relaunch-formatting.mjs",
     "real-app:scenario-tr301": "node scripts/real-app-harness/scenario-tr301-local-utility-session-switch.mjs",
     "real-app:scenario-tr303-local-codex": "node scripts/real-app-harness/scenario-tr303-local-codex-post-close-typing.mjs",
+    "real-app:scenario-codex-resume": "node scripts/real-app-harness/scenario-codex-resume-mapping.mjs",
     "real-app:scenario-tr401": "node scripts/real-app-harness/scenario-tr401-local-window-resize.mjs",
     "real-app:scenario-tr205": "node scripts/real-app-harness/scenario-tr205-remote-relaunch-close-redraw.mjs",
     "real-app:scenario-tr402": "node scripts/real-app-harness/scenario-tr402-remote-close-redraw.mjs",

--- a/app/scripts/real-app-harness/run-serial-matrix.mjs
+++ b/app/scripts/real-app-harness/run-serial-matrix.mjs
@@ -70,6 +70,11 @@ const scenarioCatalog = [
     label: 'TR-303 local codex',
     command: ['pnpm', 'run', 'real-app:scenario-tr303-local-codex'],
   },
+  {
+    id: 'codex-resume',
+    label: 'Codex native resume id mapping',
+    command: ['pnpm', 'run', 'real-app:scenario-codex-resume'],
+  },
 ];
 
 function parseArgs(argv) {

--- a/app/scripts/real-app-harness/scenario-codex-resume-mapping.mjs
+++ b/app/scripts/real-app-harness/scenario-codex-resume-mapping.mjs
@@ -1,0 +1,425 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import {
+  createSessionAndWaitForMain,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { cleanupSessionViaAppClose } from './scenarioCleanup.mjs';
+import {
+  captureSessionArtifacts,
+  waitForPaneVisible,
+} from './scenarioAssertions.mjs';
+import { ensureCodexMainPromptReady } from './scenarioAgents.mjs';
+import { currentHarnessProfile } from './harnessProfile.mjs';
+
+const execFileAsync = promisify(execFile);
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') {
+    args.shift();
+  }
+
+  const options = {
+    ...parseCommonArgs([]),
+    codexExecutable: process.env.ATTN_REAL_CODEX_EXECUTABLE || '',
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--ws-url') options.wsUrl = args[++index];
+    else if (arg === '--app-path') options.appPath = args[++index];
+    else if (arg === '--artifacts-dir') options.artifactsDir = args[++index];
+    else if (arg === '--session-root-dir') options.sessionRootDir = args[++index];
+    else if (arg === '--codex-executable') options.codexExecutable = args[++index] || '';
+    else if (arg === '--help' || arg === '-h') options.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    options,
+    help: Boolean(options.help),
+  };
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function submitCodexPromptViaUi(client, sessionId, text) {
+  await client.request('type_pane_via_ui', {
+    sessionId,
+    paneId: 'main',
+    text,
+  });
+  // Codex treats fast character streams as paste bursts and intentionally
+  // makes a following Enter insert a newline. Wait past that suppression
+  // window so this is a real submit gesture.
+  await delay(250);
+  await client.request('type_pane_via_ui', {
+    sessionId,
+    paneId: 'main',
+    text: '\n',
+  });
+}
+
+async function resolveCodexExecutable(configured) {
+  const trimmed = String(configured || '').trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  const { stdout } = await execFileAsync('/bin/sh', ['-lc', 'command -v codex']);
+  const resolved = stdout.trim();
+  if (!resolved) {
+    throw new Error('codex executable not found in PATH');
+  }
+  return resolved;
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function prepareIsolatedCodexExecutable(realExecutable) {
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), 'attn-real-codex-home-'));
+  const sourceHome = path.join(os.homedir(), '.codex');
+  const authFile = path.join(sourceHome, 'auth.json');
+  const isolatedAuthFile = path.join(codexHome, 'auth.json');
+  if (fs.existsSync(authFile)) {
+    fs.copyFileSync(authFile, isolatedAuthFile);
+    fs.chmodSync(isolatedAuthFile, 0o600);
+  }
+
+  const wrapperPath = path.join(codexHome, 'codex-real-wrapper.sh');
+  fs.writeFileSync(
+    wrapperPath,
+    [
+      '#!/bin/sh',
+      `export CODEX_HOME=${shellQuote(codexHome)}`,
+      `exec ${shellQuote(realExecutable)} -c features.apps=false -c features.enable_mcp_apps=false "$@"`,
+      '',
+    ].join('\n'),
+    { mode: 0o700 }
+  );
+  return { codexHome, executable: wrapperPath, realExecutable };
+}
+
+function dataDirForProfile(profile) {
+  const normalized = String(profile || '').trim().toLowerCase();
+  if (!normalized || normalized === 'default') {
+    return path.join(os.homedir(), '.attn');
+  }
+  return path.join(os.homedir(), `.attn-${normalized}`);
+}
+
+function dbPathForHarnessProfile() {
+  return process.env.ATTN_DB_PATH || path.join(dataDirForProfile(currentHarnessProfile()), 'attn.db');
+}
+
+function sqlString(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+async function queryStoredResumeId(dbPath, sessionId) {
+  const sql = `SELECT resume_session_id FROM sessions WHERE id = ${sqlString(sessionId)} LIMIT 1;`;
+  try {
+    const { stdout } = await execFileAsync('sqlite3', [dbPath, sql], { timeout: 5_000 });
+    return stdout.trim();
+  } catch {
+    return '';
+  }
+}
+
+async function waitForStoredResumeId(dbPath, sessionId, timeoutMs = 30_000) {
+  const startedAt = Date.now();
+  let lastValue = '';
+  while (Date.now() - startedAt < timeoutMs) {
+    lastValue = await queryStoredResumeId(dbPath, sessionId);
+    if (lastValue) {
+      return lastValue;
+    }
+    await delay(250);
+  }
+  throw new Error(`Timed out waiting for stored Codex resume id in ${dbPath}; last value=${JSON.stringify(lastValue)}`);
+}
+
+async function waitForSessionNotWorking(observer, sessionId, timeoutMs = 20_000) {
+  return observer.waitFor(() => {
+    const session = observer.getSession(sessionId);
+    if (!session) {
+      return null;
+    }
+    return session.state !== 'working' ? session : null;
+  }, `session ${sessionId} to leave working state`, timeoutMs);
+}
+
+function codexSessionsRoot(codexHome) {
+  return path.join(codexHome, 'sessions');
+}
+
+function walkJsonlFiles(rootDir) {
+  const files = [];
+  const stack = [rootDir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let entries = [];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        files.push(fullPath);
+      }
+    }
+  }
+  return files;
+}
+
+function readCodexSessionMeta(filePath) {
+  let fd = null;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const buffer = Buffer.alloc(64 * 1024);
+    const bytes = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    const text = buffer.subarray(0, bytes).toString('utf8');
+    for (const line of text.split('\n')) {
+      if (!line.trim()) {
+        continue;
+      }
+      const event = JSON.parse(line);
+      if (event?.type === 'session_meta') {
+        return event.payload || null;
+      }
+    }
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) {
+      fs.closeSync(fd);
+    }
+  }
+  return null;
+}
+
+function normalizeExistingPath(value) {
+  const resolved = path.resolve(String(value || ''));
+  try {
+    return fs.realpathSync.native(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function findCodexTranscript({ codexHome, sessionId, cwd }) {
+  const expectedCwd = normalizeExistingPath(cwd);
+  for (const filePath of walkJsonlFiles(codexSessionsRoot(codexHome))) {
+    const meta = readCodexSessionMeta(filePath);
+    if (meta?.id === sessionId && normalizeExistingPath(meta.cwd) === expectedCwd) {
+      return { filePath, meta };
+    }
+  }
+  return null;
+}
+
+async function waitForCodexTranscript({ codexHome, sessionId, cwd, timeoutMs = 30_000 }) {
+  const startedAt = Date.now();
+  let found = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    found = findCodexTranscript({ codexHome, sessionId, cwd });
+    if (found) {
+      return found;
+    }
+    await delay(500);
+  }
+  throw new Error(`Timed out waiting for Codex transcript id=${sessionId} cwd=${cwd}`);
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-codex-resume-mapping.mjs');
+    console.log(`Additional options:
+  --codex-executable <path>   Real Codex executable to run (default: command -v codex)
+`);
+    return;
+  }
+
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'TR-CODEX-RESUME',
+    tier: 'tier2-local-real-agent',
+    prefix: 'scenario-codex-resume-mapping',
+    metadata: {
+      agent: 'codex',
+      focus: 'Real Codex native session id is preserved across app reload-session flow',
+    },
+  });
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+
+  const dbPath = dbPathForHarnessProfile();
+  let sessionId = null;
+  let codexExecutable = null;
+  let realCodexExecutable = null;
+  let isolatedCodexHome = null;
+  let nativeSessionId = null;
+  let transcript = null;
+
+  try {
+    realCodexExecutable = await runner.step('resolve_real_codex_executable', async () => {
+      return resolveCodexExecutable(options.codexExecutable);
+    });
+    const isolatedCodex = await runner.step('prepare_isolated_real_codex_home', async () => {
+      return prepareIsolatedCodexExecutable(realCodexExecutable);
+    });
+    codexExecutable = isolatedCodex.executable;
+    isolatedCodexHome = isolatedCodex.codexHome;
+
+    await runner.step('launch_app', async () => {
+      await launchFreshAppAndConnect(client, observer);
+    });
+
+    await runner.step('point_codex_setting_at_real_executable', async () => {
+      await client.request('set_setting', {
+        key: 'codex_executable',
+        value: codexExecutable,
+      });
+    });
+
+    sessionId = await runner.step('create_real_codex_session', async () => {
+      return createSessionAndWaitForMain({
+        client,
+        observer,
+        cwd: runner.sessionDir,
+        label: `codex-resume-${runner.runId}`,
+        agent: 'codex',
+        waitForMainVisible: false,
+      });
+    });
+
+    nativeSessionId = await runner.step('assert_real_codex_hook_records_native_id', async () => {
+      await waitForPaneVisible(client, sessionId, 'main', 30_000);
+      const readiness = await ensureCodexMainPromptReady(client, sessionId, 60_000);
+      runner.writeJson('codex-readiness.json', readiness);
+      await submitCodexPromptViaUi(client, sessionId, 'Reply with exactly: ok');
+      await delay(1000);
+      runner.writeJson('codex-after-submit.json', await client.request('read_pane_text', {
+        sessionId,
+        paneId: 'main',
+      }));
+      const resumeId = await waitForStoredResumeId(dbPath, sessionId, 45_000);
+      runner.assert(resumeId !== sessionId, 'stored resume id is Codex native id, not attn wrapper id', {
+        attnSessionId: sessionId,
+        resumeId,
+      });
+      return resumeId;
+    });
+
+    transcript = await runner.step('assert_resume_id_matches_real_codex_transcript', async () => {
+      const found = await waitForCodexTranscript({
+        codexHome: isolatedCodexHome,
+        sessionId: nativeSessionId,
+        cwd: runner.sessionDir,
+        timeoutMs: 45_000,
+      });
+      runner.writeJson('codex-transcript.json', found);
+      const stoppedSession = await waitForSessionNotWorking(observer, sessionId, 20_000);
+      runner.assert(stoppedSession.state !== 'working', 'real Codex session is not green after the turn stops', {
+        state: stoppedSession.state,
+      });
+      await captureSessionArtifacts(client, runner.runDir, '01-first-launch', sessionId);
+      return found;
+    });
+
+    await runner.step('reload_session_from_ui_automation', async () => {
+      await client.request('reload_session', { sessionId }, { timeoutMs: 45_000 });
+      await observer.waitForSession({ id: sessionId, timeoutMs: 20_000 });
+    });
+
+    await runner.step('assert_reload_preserves_real_codex_resume_id', async () => {
+      const resumeIdAfterReload = await waitForStoredResumeId(dbPath, sessionId, 30_000);
+      runner.assert(resumeIdAfterReload === nativeSessionId, 'reload keeps the same real Codex native resume id', {
+        nativeSessionId,
+        resumeIdAfterReload,
+      });
+      const reloadedSession = await waitForSessionNotWorking(observer, sessionId, 20_000);
+      runner.assert(reloadedSession.state !== 'working', 'reloaded stopped Codex session is not green', {
+        state: reloadedSession.state,
+      });
+      const transcriptAfterReload = await waitForCodexTranscript({
+        codexHome: isolatedCodexHome,
+        sessionId: nativeSessionId,
+        cwd: runner.sessionDir,
+        timeoutMs: 30_000,
+      });
+      runner.assert(transcriptAfterReload.filePath === transcript.filePath, 'reload still points at the original real Codex transcript', {
+        before: transcript.filePath,
+        after: transcriptAfterReload.filePath,
+      });
+      await captureSessionArtifacts(client, runner.runDir, '02-after-reload', sessionId);
+    });
+
+    const summary = runner.finishSuccess({
+      sessionId,
+      codexExecutable: realCodexExecutable,
+      dbPath,
+      nativeSessionId,
+      transcriptPath: transcript?.filePath || null,
+    });
+    console.log(JSON.stringify(summary, null, 2));
+  } catch (error) {
+    const summary = runner.finishFailure(error, {
+      sessionId,
+      codexExecutable: realCodexExecutable,
+      dbPath,
+      nativeSessionId,
+      transcriptPath: transcript?.filePath || null,
+    });
+    console.error(summary.error);
+    process.exitCode = 1;
+  } finally {
+    try {
+      await client.request('set_setting', {
+        key: 'codex_executable',
+        value: '',
+      }, { timeoutMs: 10_000 });
+    } catch {}
+    try {
+      await cleanupSessionViaAppClose(client, observer, sessionId);
+    } catch {}
+    try {
+      if (isolatedCodexHome) {
+        fs.rmSync(isolatedCodexHome, { recursive: true, force: true });
+      }
+    } catch {}
+    try {
+      await client.quitApp();
+    } catch {}
+    try {
+      await observer.close();
+    } catch {}
+  }
+}
+
+main()
+  .then(() => {
+    process.exit(process.exitCode ?? 0);
+  })
+  .catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exit(1);
+  });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1290,6 +1290,7 @@ sendFetchPRDetails,
     selectSession: handleSelectSession,
     closeSession: handleCloseSession,
     reloadSession,
+    setSetting: sendSetSetting,
     splitPane: sendWorkspaceSplitPane,
     closePane: handleClosePane,
     focusPane: (sessionId: string, paneId: string) => {

--- a/app/src/components/Terminal.tsx
+++ b/app/src/components/Terminal.tsx
@@ -407,8 +407,13 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
       // fires it regardless of document.activeElement. No focus dance required.
       const descriptor = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');
       const setValue = descriptor?.set;
-      for (const char of text) {
+      const chars = Array.from(text);
+      for (let index = 0; index < chars.length; index += 1) {
+        const char = chars[index];
         if (char === '\n' || char === '\r') {
+          if (char === '\r' && chars[index + 1] === '\n') {
+            index += 1;
+          }
           textarea.dispatchEvent(new KeyboardEvent('keydown', {
             bubbles: true,
             cancelable: true,

--- a/app/src/components/Terminal.tsx
+++ b/app/src/components/Terminal.tsx
@@ -408,6 +408,18 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
       const descriptor = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');
       const setValue = descriptor?.set;
       for (const char of text) {
+        if (char === '\n' || char === '\r') {
+          textarea.dispatchEvent(new KeyboardEvent('keydown', {
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+            key: 'Enter',
+            code: 'Enter',
+            keyCode: 13,
+            which: 13,
+          }));
+          continue;
+        }
         if (setValue) {
           setValue.call(textarea, char);
         } else {

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -60,6 +60,7 @@ interface UseUiAutomationBridgeArgs {
   selectSession: (sessionId: string) => void;
   closeSession: (sessionId: string) => Promise<void>;
   reloadSession?: (sessionId: string, size?: { cols: number; rows: number }) => Promise<void>;
+  setSetting?: (key: string, value: string) => void;
   splitPane: (sessionId: string, targetPaneId: string, direction: TerminalSplitDirection) => Promise<unknown>;
   closePane: (sessionId: string, paneId: string) => Promise<unknown>;
   focusPane: (sessionId: string, paneId: string) => void;
@@ -1122,6 +1123,7 @@ export function useUiAutomationBridge({
   selectSession,
   closeSession,
   reloadSession,
+  setSetting,
   splitPane,
   closePane,
   focusPane,
@@ -1235,6 +1237,19 @@ export function useUiAutomationBridge({
         await closeSession(sessionId);
         await settleUi();
         return { sessionId };
+      }
+      case 'set_setting': {
+        if (!setSetting) {
+          throw new Error('set_setting is not configured');
+        }
+        const key = typeof payload.key === 'string' ? payload.key : '';
+        const value = typeof payload.value === 'string' ? payload.value : '';
+        if (!key) {
+          throw new Error('set_setting requires key');
+        }
+        setSetting(key, value);
+        await settleUi();
+        return { key, value };
       }
       case 'reload_session': {
         if (!reloadSession) {

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -37,7 +37,7 @@ var (
 	gitCommit         = ""
 )
 
-// hookInput represents the JSON input from Claude Code hooks
+// hookInput represents the JSON input from agent hooks.
 type hookInput struct {
 	SessionID      string          `json:"session_id"`
 	TranscriptPath string          `json:"transcript_path"`
@@ -133,6 +133,8 @@ func main() {
 		runList()
 	case "_hook-stop":
 		runHookStop()
+	case "_hook-session-start":
+		runHookSessionStart()
 	case "_hook-state":
 		runHookState()
 	case "_hook-todo":
@@ -633,6 +635,9 @@ func runAgentDirectly(requestedAgent string) {
 	}
 
 	hasHooks := false
+	if cp, ok := agentdriver.GetConfigOverrideProvider(driver); ok {
+		opts.ConfigOverrides = cp.GenerateConfigOverrides(sessionID, opts.SocketPath, opts.WrapperPath)
+	}
 	if hp, ok := agentdriver.GetHookProvider(driver); ok {
 		content := hp.GenerateHooksConfig(sessionID, opts.SocketPath, opts.WrapperPath)
 		settingsPath, err := wrapper.WriteSettingsConfig(os.TempDir(), sessionID, content)
@@ -763,11 +768,11 @@ func startDaemonBackground() error {
 }
 
 func runHookStop() {
-	if len(os.Args) < 3 {
-		fmt.Fprintf(os.Stderr, "usage: attn _hook-stop <session_id>\n")
+	sessionID := hookSessionIDFromArgOrEnv(2)
+	if sessionID == "" {
+		fmt.Fprintf(os.Stderr, "usage: attn _hook-stop [session_id]\n")
 		os.Exit(1)
 	}
-	sessionID := os.Args[2]
 
 	// Parse hook input from stdin to extract transcript path
 	var input hookInput
@@ -786,13 +791,26 @@ func runHookStop() {
 	}
 }
 
-func runHookState() {
-	if len(os.Args) < 4 {
-		fmt.Fprintf(os.Stderr, "usage: attn _hook-state <session_id> <state>\n")
+func runHookSessionStart() {
+	sessionID := hookSessionIDFromArgOrEnv(2)
+	if sessionID == "" {
+		fmt.Fprintf(os.Stderr, "usage: attn _hook-session-start [session_id]\n")
 		os.Exit(1)
 	}
-	sessionID := os.Args[2]
-	state := os.Args[3]
+
+	var input hookInput
+	_ = json.NewDecoder(os.Stdin).Decode(&input)
+
+	c := client.New(strings.TrimSpace(os.Getenv("ATTN_SOCKET_PATH")))
+	syncSessionResumeID(c, sessionID, input.SessionID)
+}
+
+func runHookState() {
+	sessionID, state := parseHookStateArgs()
+	if sessionID == "" || state == "" {
+		fmt.Fprintf(os.Stderr, "usage: attn _hook-state [session_id] <state>\n")
+		os.Exit(1)
+	}
 
 	var input hookInput
 	_ = json.NewDecoder(os.Stdin).Decode(&input)
@@ -806,11 +824,11 @@ func runHookState() {
 }
 
 func runHookTodo() {
-	if len(os.Args) < 3 {
-		fmt.Fprintf(os.Stderr, "usage: attn _hook-todo <session_id>\n")
+	sessionID := hookSessionIDFromArgOrEnv(2)
+	if sessionID == "" {
+		fmt.Fprintf(os.Stderr, "usage: attn _hook-todo [session_id]\n")
 		os.Exit(1)
 	}
-	sessionID := os.Args[2]
 
 	// Parse hook input from stdin
 	var input hookInput
@@ -847,12 +865,30 @@ func runHookTodo() {
 	}
 }
 
-func syncSessionResumeID(c *client.Client, attnSessionID, claudeSessionID string) {
-	claudeSessionID = strings.TrimSpace(claudeSessionID)
-	if claudeSessionID == "" {
+func hookSessionIDFromArgOrEnv(index int) string {
+	if len(os.Args) > index {
+		return strings.TrimSpace(os.Args[index])
+	}
+	return strings.TrimSpace(os.Getenv("ATTN_SESSION_ID"))
+}
+
+func parseHookStateArgs() (sessionID string, state string) {
+	switch {
+	case len(os.Args) >= 4:
+		return strings.TrimSpace(os.Args[2]), strings.TrimSpace(os.Args[3])
+	case len(os.Args) >= 3:
+		return strings.TrimSpace(os.Getenv("ATTN_SESSION_ID")), strings.TrimSpace(os.Args[2])
+	default:
+		return "", ""
+	}
+}
+
+func syncSessionResumeID(c *client.Client, attnSessionID, agentSessionID string) {
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if agentSessionID == "" {
 		return
 	}
-	if err := c.SetSessionResumeID(attnSessionID, claudeSessionID); err != nil {
+	if err := c.SetSessionResumeID(attnSessionID, agentSessionID); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not sync resume session id: %v\n", err)
 	}
 }

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -2,9 +2,11 @@ package agent
 
 import (
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/victorarias/attn/internal/classifier"
+	"github.com/victorarias/attn/internal/hooks"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/transcript"
 )
@@ -18,6 +20,8 @@ var _ TranscriptWatcherBehaviorProvider = (*Codex)(nil)
 var _ ClassifierProvider = (*Codex)(nil)
 var _ PTYStatePolicyProvider = (*Codex)(nil)
 var _ ExecutableClassifierProvider = (*Codex)(nil)
+var _ ConfigOverrideProvider = (*Codex)(nil)
+var _ ResumePolicyProvider = (*Codex)(nil)
 
 func init() {
 	Register(&Codex{})
@@ -34,7 +38,7 @@ func (c *Codex) ResolveExecutable(configured string) string {
 
 func (c *Codex) Capabilities() Capabilities {
 	return Capabilities{
-		HasHooks:             false,
+		HasHooks:             true,
 		HasTranscript:        true,
 		HasTranscriptWatcher: true,
 		HasClassifier:        true,
@@ -46,6 +50,12 @@ func (c *Codex) Capabilities() Capabilities {
 
 func (c *Codex) BuildCommand(opts SpawnOpts) *exec.Cmd {
 	args := []string{}
+	for _, override := range opts.ConfigOverrides {
+		if strings.TrimSpace(override) == "" {
+			continue
+		}
+		args = append(args, "-c", override)
+	}
 
 	if opts.ResumeSessionID != "" {
 		args = append(args, "resume", opts.ResumeSessionID)
@@ -72,11 +82,23 @@ func (c *Codex) BuildCommand(opts SpawnOpts) *exec.Cmd {
 }
 
 func (c *Codex) BuildEnv(opts SpawnOpts) []string {
-	var env []string
+	env := []string{
+		"ATTN_SESSION_ID=" + opts.SessionID,
+		"ATTN_AGENT=codex",
+	}
+	if opts.SocketPath != "" {
+		env = append(env, "ATTN_SOCKET_PATH="+opts.SocketPath)
+	}
 	if opts.Executable != "" && opts.Executable != c.DefaultExecutable() {
 		env = append(env, c.ExecutableEnvVar()+"="+opts.Executable)
 	}
 	return env
+}
+
+// --- ConfigOverrideProvider ---
+
+func (c *Codex) GenerateConfigOverrides(sessionID, socketPath, wrapperPath string) []string {
+	return hooks.GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath)
 }
 
 // --- TranscriptFinder ---
@@ -107,7 +129,31 @@ func (c *Codex) RecoveredRunningState(ptyState string) protocol.SessionState {
 }
 
 func (c *Codex) ShouldApplyPTYState(current protocol.SessionState, incoming string) bool {
-	return incoming == protocol.StateWorking || incoming == protocol.StatePendingApproval
+	switch incoming {
+	case protocol.StatePendingApproval:
+		return true
+	case protocol.StateWorking:
+		return current == protocol.SessionStateWorking
+	default:
+		return false
+	}
+}
+
+func (c *Codex) ResolveSpawnResumeSessionID(existingSessionID, requestedResumeID, storedResumeID string) string {
+	requested := strings.TrimSpace(requestedResumeID)
+	stored := strings.TrimSpace(storedResumeID)
+	if stored != "" && (requested == "" || requested == strings.TrimSpace(existingSessionID)) {
+		return stored
+	}
+	return requested
+}
+
+func (c *Codex) SpawnResumeSessionID(sessionID, resolvedResumeID string, resumePicker bool) string {
+	return strings.TrimSpace(resolvedResumeID)
+}
+
+func (c *Codex) ResumeSessionIDFromStopTranscriptPath(transcriptPath string) string {
+	return ""
 }
 
 // --- ClassifierProvider ---

--- a/internal/agent/daemon_policy_test.go
+++ b/internal/agent/daemon_policy_test.go
@@ -65,6 +65,21 @@ func TestShouldApplyPTYState_AgentOverrides(t *testing.T) {
 	if !ShouldApplyPTYState(Get("codex"), protocol.SessionStateWorking, protocol.StatePendingApproval) {
 		t.Fatal("codex should accept pending_approval PTY state updates")
 	}
+	if ShouldApplyPTYState(Get("codex"), protocol.SessionStateLaunching, protocol.StateWorking) {
+		t.Fatal("codex should ignore launch-time working PTY noise")
+	}
+	if !ShouldApplyPTYState(Get("codex"), protocol.SessionStateWorking, protocol.StateWorking) {
+		t.Fatal("codex should accept working PTY state updates while already working")
+	}
+	if ShouldApplyPTYState(Get("codex"), protocol.SessionStateIdle, protocol.StateWorking) {
+		t.Fatal("codex should ignore working PTY noise while idle")
+	}
+	if ShouldApplyPTYState(Get("codex"), protocol.SessionStateWaitingInput, protocol.StateWorking) {
+		t.Fatal("codex should ignore working PTY noise while waiting_input")
+	}
+	if ShouldApplyPTYState(Get("codex"), protocol.SessionStatePendingApproval, protocol.StateWorking) {
+		t.Fatal("codex should ignore working PTY noise while pending_approval")
+	}
 	if ShouldApplyPTYState(Get("copilot"), protocol.SessionStatePendingApproval, protocol.StateWorking) {
 		t.Fatal("copilot should ignore working PTY noise while pending_approval")
 	}
@@ -83,6 +98,18 @@ func TestResumePolicy_Claude(t *testing.T) {
 	pathResume := ResumeSessionIDFromStopTranscriptPath(claude, "/tmp/abc-123.jsonl")
 	if pathResume != "abc-123" {
 		t.Fatalf("ResumeSessionIDFromStopTranscriptPath() = %q, want abc-123", pathResume)
+	}
+}
+
+func TestResumePolicy_Codex(t *testing.T) {
+	codex := Get("codex")
+	resolved := ResolveSpawnResumeSessionID(codex, "attn-session", "attn-session", "codex-session")
+	if resolved != "codex-session" {
+		t.Fatalf("ResolveSpawnResumeSessionID() = %q, want codex-session", resolved)
+	}
+	persisted := SpawnResumeSessionID(codex, "attn-session", "", false)
+	if persisted != "" {
+		t.Fatalf("SpawnResumeSessionID() = %q, want empty until hook reports Codex id", persisted)
 	}
 }
 

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -77,7 +77,7 @@ type Driver interface {
 type Capabilities struct {
 	// HasHooks indicates the agent supports a hook/settings system
 	// (e.g. Claude Code hooks that report state changes via IPC).
-	// If true, the driver should implement HookProvider.
+	// If true, the driver should implement HookProvider or ConfigOverrideProvider.
 	HasHooks bool
 
 	// HasTranscript indicates the agent writes transcript files that attn
@@ -205,6 +205,9 @@ type SpawnOpts struct {
 	// support it (e.g. Claude's --settings <path>).
 	SettingsPath string
 
+	// ConfigOverrides are agent CLI config overrides generated for this launch.
+	ConfigOverrides []string
+
 	// AgentArgs are passthrough CLI args provided after attn wrapper flags.
 	AgentArgs []string
 }
@@ -212,11 +215,16 @@ type SpawnOpts struct {
 // --- Optional capability interfaces ---
 
 // HookProvider generates hook/settings configurations for agents that support them.
-// Currently only Claude Code uses this (its hooks report state changes via IPC).
+// Some agents consume these through a generated settings file.
 type HookProvider interface {
 	// GenerateHooksConfig returns the content of a settings/hooks config file.
 	// The caller writes it to a temp file and passes --settings to the agent.
 	GenerateHooksConfig(sessionID, socketPath, wrapperPath string) string
+}
+
+// ConfigOverrideProvider generates per-launch CLI config overrides.
+type ConfigOverrideProvider interface {
+	GenerateConfigOverrides(sessionID, socketPath, wrapperPath string) []string
 }
 
 // TranscriptFinder locates transcript files written by the agent.
@@ -303,6 +311,15 @@ func GetHookProvider(d Driver) (HookProvider, bool) {
 	}
 	hp, ok := d.(HookProvider)
 	return hp, ok
+}
+
+// GetConfigOverrideProvider returns the ConfigOverrideProvider if supported.
+func GetConfigOverrideProvider(d Driver) (ConfigOverrideProvider, bool) {
+	if d == nil || !EffectiveCapabilities(d).HasHooks {
+		return nil, false
+	}
+	cp, ok := d.(ConfigOverrideProvider)
+	return cp, ok
 }
 
 // GetTranscriptFinder returns the TranscriptFinder if the driver supports transcripts.

--- a/internal/agent/yolo_test.go
+++ b/internal/agent/yolo_test.go
@@ -1,6 +1,9 @@
 package agent
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestBuildCommand_YoloMapping(t *testing.T) {
 	tests := []struct {
@@ -32,6 +35,21 @@ func TestBuildCommand_YoloMapping(t *testing.T) {
 				t.Fatalf("%s args = %#v, want flag %q", tt.name, cmd.Args, tt.wantFlag)
 			}
 		})
+	}
+}
+
+func TestCodexBuildCommand_IncludesConfigOverridesBeforeResume(t *testing.T) {
+	cmd := (&Codex{}).BuildCommand(SpawnOpts{
+		CWD:             "/tmp/project",
+		Executable:      "codex",
+		ResumeSessionID: "codex-session",
+		ConfigOverrides: []string{"features.hooks=true"},
+	})
+	args := strings.Join(cmd.Args, "\x00")
+	wantArgs := []string{"codex", "-c", "features.hooks=true", "resume", "codex-session", "-C", "/tmp/project"}
+	want := strings.Join(wantArgs, "\x00")
+	if args != want {
+		t.Fatalf("args = %#v, want %#v", cmd.Args, wantArgs)
 	}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -104,7 +104,7 @@ func (c *Client) UpdateState(id, state string) error {
 	return err
 }
 
-// SetSessionResumeID stores the Claude resume session id for an attn session.
+// SetSessionResumeID stores the agent-native resume session id for an attn session.
 func (c *Client) SetSessionResumeID(id, resumeSessionID string) error {
 	msg := protocol.SetSessionResumeIDMessage{
 		Cmd:             protocol.CmdSetSessionResumeID,

--- a/internal/daemon/codex_resume_e2e_test.go
+++ b/internal/daemon/codex_resume_e2e_test.go
@@ -1,0 +1,191 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
+)
+
+func TestCodexResumeMappingEndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping PTY end-to-end test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	repoRoot := findRepoRootForTest(t)
+	attnBin := filepath.Join(tmpDir, "attn")
+	build := exec.Command("go", "build", "-o", attnBin, "./cmd/attn")
+	build.Dir = repoRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build attn test binary: %v\n%s", err, string(output))
+	}
+
+	fakeCodexLog := filepath.Join(tmpDir, "fake-codex.log")
+	fakeCodex := filepath.Join(tmpDir, "fake-codex")
+	nativeCodexID := "codex-native-session-123"
+	fakeScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+printf 'ARGS:%%s\n' "$*" >> %q
+printf '{"session_id":%q,"transcript_path":"/tmp/fake-codex.jsonl"}' | "$ATTN_WRAPPER_PATH" _hook-session-start
+trap 'exit 0' TERM INT
+while :; do sleep 1; done
+`, fakeCodexLog, nativeCodexID)
+	if err := os.WriteFile(fakeCodex, []byte(fakeScript), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	port, err := freeTCPPort()
+	if err != nil {
+		t.Fatalf("allocate ws port: %v", err)
+	}
+	sockPath := filepath.Join(tmpDir, "attn.sock")
+	t.Setenv("ATTN_WS_PORT", fmt.Sprintf("%d", port))
+	t.Setenv("ATTN_SOCKET_PATH", sockPath)
+	t.Setenv("ATTN_WRAPPER_PATH", attnBin)
+
+	d := NewForTesting(sockPath)
+	go func() {
+		if err := d.Start(); err != nil {
+			t.Logf("daemon exited: %v", err)
+		}
+	}()
+	defer d.Stop()
+	waitForSocket(t, sockPath, 5*time.Second)
+
+	client := &wsClient{
+		send:            make(chan outboundMessage, 8),
+		attachedStreams: make(map[string]ptybackend.Stream),
+	}
+	sessionID := "attn-codex-e2e"
+	cwd := tmpDir
+
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:             protocol.CmdSpawnSession,
+		ID:              sessionID,
+		Cwd:             cwd,
+		Agent:           "codex",
+		Label:           protocol.Ptr("codex-e2e"),
+		CodexExecutable: protocol.Ptr(fakeCodex),
+		Cols:            80,
+		Rows:            24,
+	})
+	expectSpawnSuccess(t, client)
+
+	waitForCondition(t, 5*time.Second, func() bool {
+		return d.store.GetResumeSessionID(sessionID) == nativeCodexID
+	}, "codex hook to store native session id")
+
+	removePTYSession(t, d, sessionID)
+
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:             protocol.CmdSpawnSession,
+		ID:              sessionID,
+		Cwd:             cwd,
+		Agent:           "codex",
+		Label:           protocol.Ptr("codex-e2e"),
+		CodexExecutable: protocol.Ptr(fakeCodex),
+		ResumeSessionID: protocol.Ptr(sessionID),
+		Cols:            80,
+		Rows:            24,
+	})
+	expectSpawnSuccess(t, client)
+	defer removePTYSession(t, d, sessionID)
+
+	waitForCondition(t, 5*time.Second, func() bool {
+		lines := readFakeCodexLog(t, fakeCodexLog)
+		if len(lines) < 2 {
+			return false
+		}
+		first := lines[0]
+		second := lines[len(lines)-1]
+		return strings.Contains(first, "_hook-session-start") &&
+			strings.Contains(first, "features.hooks=true") &&
+			strings.Contains(first, `"/<session-flags>/config.toml:session_start:0:0"`) &&
+			strings.Contains(first, "trusted_hash") &&
+			strings.Contains(second, "resume "+nativeCodexID)
+	}, "reload to invoke fake codex with native resume id")
+}
+
+func expectSpawnSuccess(t *testing.T, client *wsClient) {
+	t.Helper()
+	select {
+	case outbound := <-client.send:
+		var result protocol.SpawnResultMessage
+		if err := json.Unmarshal(outbound.payload, &result); err != nil {
+			t.Fatalf("decode spawn_result: %v", err)
+		}
+		if !result.Success {
+			t.Fatalf("spawn_result success=false error=%q", protocol.Deref(result.Error))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for spawn_result")
+	}
+}
+
+func removePTYSession(t *testing.T, d *Daemon, sessionID string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	_ = d.ptyBackend.Kill(ctx, sessionID, syscall.SIGTERM)
+	cancel()
+
+	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := d.ptyBackend.Remove(ctx, sessionID); err != nil {
+		t.Fatalf("remove pty session: %v", err)
+	}
+}
+
+func readFakeCodexLog(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var lines []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, ok func() bool, description string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ok() {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", description)
+}
+
+func findRepoRootForTest(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root")
+		}
+		dir = parent
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -115,6 +115,8 @@ type Daemon struct {
 	longRun          map[string]longRunSession
 	forcedStopMu     sync.Mutex
 	forcedStop       map[string]time.Time
+	pendingResumeMu  sync.Mutex
+	pendingResumeID  map[string]string
 	reviewLoopMu     sync.Mutex
 	reviewLoopCancel map[string]context.CancelFunc
 	inputSourceMu    sync.Mutex
@@ -336,6 +338,7 @@ func New(socketPath string) *Daemon {
 		classifyingTurn:  make(map[string]string),
 		longRun:          make(map[string]longRunSession),
 		forcedStop:       make(map[string]time.Time),
+		pendingResumeID:  make(map[string]string),
 		reviewLoopCancel: make(map[string]context.CancelFunc),
 		pendingInputSrc:  make(map[string]string),
 		tailscale:        newTailscaleRuntime(),
@@ -367,6 +370,7 @@ func NewForTesting(socketPath string) *Daemon {
 		classifyingTurn:  make(map[string]string),
 		longRun:          make(map[string]longRunSession),
 		forcedStop:       make(map[string]time.Time),
+		pendingResumeID:  make(map[string]string),
 		reviewLoopCancel: make(map[string]context.CancelFunc),
 		pendingInputSrc:  make(map[string]string),
 		tailscale:        newTailscaleRuntime(),
@@ -402,6 +406,7 @@ func NewWithGitHubClient(socketPath string, ghClient github.GitHubClient) *Daemo
 		classifyingTurn:  make(map[string]string),
 		longRun:          make(map[string]longRunSession),
 		forcedStop:       make(map[string]time.Time),
+		pendingResumeID:  make(map[string]string),
 		reviewLoopCancel: make(map[string]context.CancelFunc),
 		pendingInputSrc:  make(map[string]string),
 		tailscale:        newTailscaleRuntime(),
@@ -1552,6 +1557,9 @@ func (d *Daemon) handleRegister(conn net.Conn, msg *protocol.RegisterMessage) {
 		}
 	}
 	d.store.Add(session)
+	if resumeSessionID := d.consumePendingResumeSessionID(session.ID); resumeSessionID != "" {
+		d.store.SetResumeSessionID(session.ID, resumeSessionID)
+	}
 	if _, err := d.ensureSessionLayout(session.ID); err != nil {
 		d.logf("session layout bootstrap failed for session %s: %v", session.ID, err)
 	}
@@ -1622,8 +1630,38 @@ func (d *Daemon) handleSetSessionResumeID(conn net.Conn, msg *protocol.SetSessio
 		d.sendError(conn, "missing resume_session_id")
 		return
 	}
-	d.store.SetResumeSessionID(msg.ID, resumeSessionID)
+	d.setOrQueueResumeSessionID(msg.ID, resumeSessionID)
 	d.sendOK(conn)
+}
+
+func (d *Daemon) setOrQueueResumeSessionID(sessionID, resumeSessionID string) {
+	sessionID = strings.TrimSpace(sessionID)
+	resumeSessionID = strings.TrimSpace(resumeSessionID)
+	if sessionID == "" || resumeSessionID == "" {
+		return
+	}
+	if d.store.Get(sessionID) != nil {
+		d.store.SetResumeSessionID(sessionID, resumeSessionID)
+		return
+	}
+	d.pendingResumeMu.Lock()
+	if d.pendingResumeID == nil {
+		d.pendingResumeID = make(map[string]string)
+	}
+	d.pendingResumeID[sessionID] = resumeSessionID
+	d.pendingResumeMu.Unlock()
+}
+
+func (d *Daemon) consumePendingResumeSessionID(sessionID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return ""
+	}
+	d.pendingResumeMu.Lock()
+	defer d.pendingResumeMu.Unlock()
+	resumeSessionID := d.pendingResumeID[sessionID]
+	delete(d.pendingResumeID, sessionID)
+	return strings.TrimSpace(resumeSessionID)
 }
 
 func (d *Daemon) handleStop(conn net.Conn, msg *protocol.StopMessage) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1640,16 +1640,16 @@ func (d *Daemon) setOrQueueResumeSessionID(sessionID, resumeSessionID string) {
 	if sessionID == "" || resumeSessionID == "" {
 		return
 	}
+	d.pendingResumeMu.Lock()
+	defer d.pendingResumeMu.Unlock()
 	if d.store.Get(sessionID) != nil {
 		d.store.SetResumeSessionID(sessionID, resumeSessionID)
 		return
 	}
-	d.pendingResumeMu.Lock()
 	if d.pendingResumeID == nil {
 		d.pendingResumeID = make(map[string]string)
 	}
 	d.pendingResumeID[sessionID] = resumeSessionID
-	d.pendingResumeMu.Unlock()
 }
 
 func (d *Daemon) consumePendingResumeSessionID(sessionID string) string {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1380,6 +1380,105 @@ func TestDaemon_HandleSpawnSession_UsesStoredResumeSessionIDEvenWhenNotRecoverab
 	}
 }
 
+func TestDaemon_HandleSpawnSession_UsesStoredResumeSessionIDForCodexSession(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	d.ptyBackend = backend
+
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID:             "attn-session",
+		Label:          "attn-session",
+		Agent:          protocol.SessionAgentCodex,
+		Directory:      t.TempDir(),
+		State:          protocol.SessionStateIdle,
+		StateSince:     now,
+		StateUpdatedAt: now,
+		LastSeen:       now,
+	})
+	d.store.SetResumeSessionID("attn-session", "codex-session")
+
+	client := &wsClient{
+		send:            make(chan outboundMessage, 2),
+		attachedStreams: make(map[string]ptybackend.Stream),
+	}
+	msg := &protocol.SpawnSessionMessage{
+		Cmd:             protocol.CmdSpawnSession,
+		ID:              "attn-session",
+		Cwd:             t.TempDir(),
+		Cols:            80,
+		Rows:            24,
+		Agent:           "codex",
+		ResumeSessionID: protocol.Ptr("attn-session"),
+	}
+
+	d.handleSpawnSession(client, msg)
+
+	lastSpawn, ok := backend.LastSpawn()
+	if !ok {
+		t.Fatal("expected spawn call")
+	}
+	if lastSpawn.ResumeSessionID != "codex-session" {
+		t.Fatalf("resume session id = %q, want %q", lastSpawn.ResumeSessionID, "codex-session")
+	}
+	if got := d.store.Get("attn-session"); got == nil || got.State != protocol.SessionStateIdle {
+		t.Fatalf("reloaded existing codex session state = %v, want %s", got, protocol.SessionStateIdle)
+	}
+}
+
+func TestDaemon_HandleSetSessionResumeID_QueuesUntilSessionExists(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handleSetSessionResumeID(serverConn, &protocol.SetSessionResumeIDMessage{
+			ID:              "attn-session",
+			ResumeSessionID: "codex-session",
+		})
+		_ = serverConn.Close()
+	}()
+
+	var resp protocol.Response
+	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+		t.Fatalf("decode set resume response: %v", err)
+	}
+	_ = clientConn.Close()
+	<-done
+	if !resp.Ok {
+		t.Fatalf("set resume response ok=%v, want true", resp.Ok)
+	}
+	if got := d.store.GetResumeSessionID("attn-session"); got != "" {
+		t.Fatalf("resume id before registration = %q, want empty", got)
+	}
+
+	serverConn, clientConn = net.Pipe()
+	done = make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handleRegister(serverConn, &protocol.RegisterMessage{
+			ID:    "attn-session",
+			Label: protocol.Ptr("attn-session"),
+			Dir:   t.TempDir(),
+			Agent: protocol.Ptr(protocol.SessionAgentCodex),
+		})
+		_ = serverConn.Close()
+	}()
+
+	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+		t.Fatalf("decode register response: %v", err)
+	}
+	_ = clientConn.Close()
+	<-done
+	if !resp.Ok {
+		t.Fatalf("register response ok=%v, want true", resp.Ok)
+	}
+	if got := d.store.GetResumeSessionID("attn-session"); got != "codex-session" {
+		t.Fatalf("resume id after registration = %q, want codex-session", got)
+	}
+}
+
 func TestDaemon_ForwardPTYStreamEvents_ClosesStreamOnSendFailure(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	client := &wsClient{

--- a/internal/daemon/testharness.go
+++ b/internal/daemon/testharness.go
@@ -256,6 +256,7 @@ func (b *TestHarnessBuilder) Build() *TestHarness {
 		classifiedTurn:   make(map[string]string),
 		classifyingTurn:  make(map[string]string),
 		longRun:          make(map[string]longRunSession),
+		pendingResumeID:  make(map[string]string),
 		reviewLoopCancel: make(map[string]context.CancelFunc),
 		pendingInputSrc:  make(map[string]string),
 	}

--- a/internal/daemon/transcript_watcher_test.go
+++ b/internal/daemon/transcript_watcher_test.go
@@ -39,6 +39,42 @@ func TestHandlePTYState_CodexIgnoresWaitingAndIdle(t *testing.T) {
 	}
 }
 
+func TestHandlePTYState_CodexWorkingDoesNotOverrideStoppedStates(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "sock"))
+
+	addCodexSession := func(id string, state protocol.SessionState) {
+		nowStr := string(protocol.TimestampNow())
+		d.store.Add(&protocol.Session{
+			ID:             id,
+			Label:          id,
+			Agent:          protocol.SessionAgentCodex,
+			Directory:      "/tmp",
+			State:          state,
+			StateSince:     nowStr,
+			StateUpdatedAt: nowStr,
+			LastSeen:       nowStr,
+		})
+	}
+
+	addCodexSession("codex-idle", protocol.SessionStateIdle)
+	d.handlePTYState("codex-idle", protocol.StateWorking)
+	if got := d.store.Get("codex-idle"); got.State != protocol.SessionStateIdle {
+		t.Fatalf("codex working PTY should not override idle, got=%s", got.State)
+	}
+
+	addCodexSession("codex-waiting", protocol.SessionStateWaitingInput)
+	d.handlePTYState("codex-waiting", protocol.StateWorking)
+	if got := d.store.Get("codex-waiting"); got.State != protocol.SessionStateWaitingInput {
+		t.Fatalf("codex working PTY should not override waiting_input, got=%s", got.State)
+	}
+
+	addCodexSession("codex-pending", protocol.SessionStatePendingApproval)
+	d.handlePTYState("codex-pending", protocol.StateWorking)
+	if got := d.store.Get("codex-pending"); got.State != protocol.SessionStatePendingApproval {
+		t.Fatalf("codex working PTY should not override pending_approval, got=%s", got.State)
+	}
+}
+
 func TestHandlePTYState_ClaudeAcceptsWaiting(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "sock"))
 

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -419,14 +419,28 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		d.clearLongRunTracking(msg.ID)
 		branchInfo, _ := git.GetBranchInfo(cwd)
 		nowStr := string(protocol.TimestampNow())
+		initialState := protocol.SessionStateLaunching
+		initialStateSince := nowStr
+		initialStateUpdatedAt := nowStr
+		if existingSession != nil {
+			initialState = existingSession.State
+			initialStateSince = existingSession.StateSince
+			initialStateUpdatedAt = existingSession.StateUpdatedAt
+			if initialStateSince == "" {
+				initialStateSince = nowStr
+			}
+			if initialStateUpdatedAt == "" {
+				initialStateUpdatedAt = nowStr
+			}
+		}
 		session := &protocol.Session{
 			ID:             msg.ID,
 			Label:          label,
 			Agent:          protocol.SessionAgent(agent),
 			Directory:      cwd,
-			State:          protocol.SessionStateLaunching,
-			StateSince:     nowStr,
-			StateUpdatedAt: nowStr,
+			State:          initialState,
+			StateSince:     initialStateSince,
+			StateUpdatedAt: initialStateUpdatedAt,
 			LastSeen:       nowStr,
 		}
 		if branchInfo != nil {
@@ -451,6 +465,9 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 			protocol.Deref(msg.ResumePicker),
 		); persistResumeID != "" {
 			d.store.SetResumeSessionID(session.ID, persistResumeID)
+		}
+		if pendingResumeID := d.consumePendingResumeSessionID(session.ID); pendingResumeID != "" {
+			d.store.SetResumeSessionID(session.ID, pendingResumeID)
 		}
 		d.startTranscriptWatcher(session.ID, session.Agent, session.Directory, spawnStartedAt)
 		d.store.UpsertRecentLocation(cwd, label)

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -1,0 +1,113 @@
+package hooks
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// GenerateCodexConfigOverrides returns Codex CLI -c overrides that install
+// attn's per-launch hooks without mutating user or project Codex config.
+func GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath string) []string {
+	_ = sessionID  // Commands read ATTN_SESSION_ID from the Codex process env.
+	_ = socketPath // Hook commands inherit ATTN_SOCKET_PATH from the Codex process env.
+	wrapper := strings.TrimSpace(wrapperPath)
+	if wrapper == "" {
+		wrapper = "attn"
+	}
+
+	command := func(args ...string) string {
+		parts := []string{shellQuote(wrapper)}
+		for _, arg := range args {
+			parts = append(parts, shellQuote(arg))
+		}
+		return strings.Join(parts, " ")
+	}
+
+	hook := func(command string) string {
+		return fmt.Sprintf(`{ type = "command", command = %s, timeout = 5 }`, strconv.Quote(command))
+	}
+	group := func(matcher string, command string) string {
+		if strings.TrimSpace(matcher) == "" {
+			return fmt.Sprintf(`[{ hooks = [%s] }]`, hook(command))
+		}
+		return fmt.Sprintf(`[{ matcher = %s, hooks = [%s] }]`, strconv.Quote(matcher), hook(command))
+	}
+
+	sessionStart := command("_hook-session-start")
+	userPromptSubmit := command("_hook-state", "working")
+	permissionRequest := command("_hook-state", "pending_approval")
+	postToolUse := command("_hook-state", "working")
+	stop := command("_hook-stop")
+
+	return []string{
+		"features.hooks=true",
+		trustedHashOverrides([]codexHookTrustEntry{
+			{eventKey: "session_start", matcher: "startup|resume", command: sessionStart},
+			{eventKey: "user_prompt_submit", command: userPromptSubmit},
+			{eventKey: "permission_request", matcher: "*", command: permissionRequest},
+			{eventKey: "post_tool_use", matcher: "*", command: postToolUse},
+			{eventKey: "stop", command: stop},
+		}),
+		"hooks.SessionStart=" + group("startup|resume", sessionStart),
+		"hooks.UserPromptSubmit=" + group("", userPromptSubmit),
+		"hooks.PermissionRequest=" + group("*", permissionRequest),
+		"hooks.PostToolUse=" + group("*", postToolUse),
+		"hooks.Stop=" + group("", stop),
+	}
+}
+
+type codexHookTrustEntry struct {
+	eventKey string
+	matcher  string
+	command  string
+}
+
+func trustedHashOverrides(entries []codexHookTrustEntry) string {
+	parts := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		key := fmt.Sprintf("/<session-flags>/config.toml:%s:0:0", entry.eventKey)
+		parts = append(parts, fmt.Sprintf(
+			"%s = { trusted_hash = %s }",
+			strconv.Quote(key),
+			strconv.Quote(commandHookHash(entry.eventKey, entry.matcher, entry.command)),
+		))
+	}
+	return fmt.Sprintf("hooks.state={ %s }", strings.Join(parts, ", "))
+}
+
+func commandHookHash(eventKey, matcher, command string) string {
+	group := map[string]any{
+		"event_name": eventKey,
+		"hooks": []any{
+			map[string]any{
+				"async":   false,
+				"command": command,
+				"timeout": 5,
+				"type":    "command",
+			},
+		},
+	}
+	if normalized := normalizedMatcher(eventKey, matcher); normalized != "" {
+		group["matcher"] = normalized
+	}
+
+	serialized, err := json.Marshal(group)
+	if err != nil {
+		panic(fmt.Sprintf("failed to hash Codex hook identity: %v", err))
+	}
+	sum := sha256.Sum256(serialized)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func normalizedMatcher(eventKey, matcher string) string {
+	switch eventKey {
+	case "user_prompt_submit", "stop":
+		return ""
+	default:
+		return strings.TrimSpace(matcher)
+	}
+}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -102,6 +102,31 @@ func TestGenerateHooks_DefaultsWrapperToAttn(t *testing.T) {
 	}
 }
 
+func TestGenerateCodexConfigOverrides_UsesStableEnvBasedCommands(t *testing.T) {
+	overrides := GenerateCodexConfigOverrides("session-1", "/tmp/attn.sock", "/tmp/attn")
+	joined := strings.Join(overrides, "\n")
+
+	if !strings.Contains(joined, "hooks.SessionStart=") {
+		t.Fatal("codex overrides should include SessionStart hook")
+	}
+	if !strings.Contains(joined, "_hook-session-start") {
+		t.Fatal("codex overrides should sync session id on start")
+	}
+	if strings.Contains(joined, "session-1") {
+		t.Fatal("codex hook commands should not embed per-session attn ids")
+	}
+	if strings.Contains(joined, "/tmp/attn.sock") {
+		t.Fatal("codex hook commands should not embed per-session socket paths")
+	}
+	if !strings.Contains(joined, "features.hooks=true") {
+		t.Fatal("codex overrides should enable hooks for attn-managed sessions")
+	}
+	if !strings.Contains(joined, `hooks.state={`) ||
+		!strings.Contains(joined, `"/<session-flags>/config.toml:session_start:0:0" = { trusted_hash =`) {
+		t.Fatal("codex overrides should trust attn-managed session flag hooks")
+	}
+}
+
 // NOTE: AskUserQuestion PostToolUse hook was removed because it fires
 // AFTER the user responds, not when the question is displayed.
 // See: https://github.com/anthropics/claude-code/issues/10168

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -639,9 +639,9 @@ func (s *Store) SetRecoverable(id string, recoverable bool) {
 	}
 }
 
-// SetResumeSessionID stores the Claude resume session id for an attn session.
-// This allows recovery to use the real Claude conversation id when it differs
-// from the attn session id (for example, when using Claude resume picker).
+// SetResumeSessionID stores the agent-native resume session id for an attn session.
+// This allows recovery to use the real agent conversation id when it differs
+// from the attn session id (for example, when using an agent resume picker).
 func (s *Store) SetResumeSessionID(id, resumeSessionID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -656,7 +656,7 @@ func (s *Store) SetResumeSessionID(id, resumeSessionID string) {
 	}
 }
 
-// GetResumeSessionID returns the stored Claude resume session id for an attn session.
+// GetResumeSessionID returns the stored agent-native resume session id for an attn session.
 func (s *Store) GetResumeSessionID(id string) string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/transcript/discovery.go
+++ b/internal/transcript/discovery.go
@@ -74,8 +74,7 @@ func FindCodexTranscript(cwd string, startedAt time.Time) string {
 			return nil
 		}
 
-		entryCwd := filepath.Clean(entry.Payload.Cwd)
-		if entryCwd != cwdClean {
+		if !pathsEquivalent(entry.Payload.Cwd, cwdClean) {
 			return nil
 		}
 
@@ -110,6 +109,17 @@ func FindCodexTranscript(cwd string, startedAt time.Time) string {
 		return bestPath
 	}
 	return fallbackPath
+}
+
+func pathsEquivalent(a, b string) bool {
+	aClean := filepath.Clean(a)
+	bClean := filepath.Clean(b)
+	if aClean == bClean {
+		return true
+	}
+	aReal, aErr := filepath.EvalSymlinks(aClean)
+	bReal, bErr := filepath.EvalSymlinks(bClean)
+	return aErr == nil && bErr == nil && filepath.Clean(aReal) == filepath.Clean(bReal)
 }
 
 func readCopilotWorkspaceCWD(workspacePath string) string {

--- a/internal/transcript/discovery_test.go
+++ b/internal/transcript/discovery_test.go
@@ -55,6 +55,76 @@ func writeCopilotSessionState(
 	return eventsPath
 }
 
+func writeCodexTranscript(
+	t *testing.T,
+	homeDir,
+	sessionID,
+	cwd string,
+	startTime time.Time,
+	modTime time.Time,
+) string {
+	t.Helper()
+
+	sessionDir := filepath.Join(homeDir, ".codex", "sessions", "2026", "05", "17")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir codex session dir: %v", err)
+	}
+
+	transcriptPath := filepath.Join(sessionDir, fmt.Sprintf("rollout-%s-%s.jsonl", startTime.UTC().Format("2006-01-02T15-04-05"), sessionID))
+	lines := fmt.Sprintf(
+		`{"timestamp":"%s","type":"session_meta","payload":{"id":"%s","timestamp":"%s","cwd":"%s"}}`+"\n",
+		startTime.UTC().Format(time.RFC3339Nano),
+		sessionID,
+		startTime.UTC().Format(time.RFC3339Nano),
+		cwd,
+	)
+	if err := os.WriteFile(transcriptPath, []byte(lines), 0o644); err != nil {
+		t.Fatalf("write codex transcript: %v", err)
+	}
+	if err := os.Chtimes(transcriptPath, modTime, modTime); err != nil {
+		t.Fatalf("chtimes codex transcript: %v", err)
+	}
+
+	return transcriptPath
+}
+
+func TestFindCodexTranscript_MatchesSymlinkEquivalentCWD(t *testing.T) {
+	homeDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", oldHome)
+	})
+
+	root := t.TempDir()
+	realCWD := filepath.Join(root, "real", "project")
+	if err := os.MkdirAll(realCWD, 0o755); err != nil {
+		t.Fatalf("mkdir real cwd: %v", err)
+	}
+	linkRoot := filepath.Join(root, "link")
+	if err := os.Symlink(filepath.Join(root, "real"), linkRoot); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	linkCWD := filepath.Join(linkRoot, "project")
+	startedAt := time.Date(2026, 5, 17, 14, 6, 42, 0, time.UTC)
+
+	expected := writeCodexTranscript(
+		t,
+		homeDir,
+		"codex-session-123",
+		realCWD,
+		startedAt,
+		startedAt.Add(1*time.Minute),
+	)
+
+	got := FindCodexTranscript(linkCWD, startedAt)
+	if got != expected {
+		t.Fatalf("FindCodexTranscript() = %q, want %q", got, expected)
+	}
+}
+
 func TestFindCopilotTranscript_PrefersClosestStartTime(t *testing.T) {
 	homeDir := t.TempDir()
 	oldHome := os.Getenv("HOME")


### PR DESCRIPTION
## Summary
- add Codex hook injection so attn records Codex's native session id and uses it for reload/resume
- keep completed/reloaded Codex sessions from going green solely because the TUI process is still alive
- add real packaged-app Codex resume coverage that accepts the trust prompt, records the native id, reloads, and verifies the stopped state is not working

## Testing
- `go test ./cmd/attn ./internal/agent ./internal/hooks ./internal/daemon ./internal/client ./internal/store ./internal/transcript`
- `pnpm --dir app run build`
- `git diff --check`
- `ATTN_HARNESS_PROFILE=dev pnpm --dir app run real-app:scenario-codex-resume`