### PR TITLE
[codex] Coalesce active git status refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Changed
 - **Changes Panel Refreshes**: The Changes panel now avoids branch-diff refreshes while closed, refreshes once when opened, and coalesces status-triggered refreshes so slow monorepos do not stack repeated Git diff work behind every status update.
 - **Diff Detail Loading**: The Diff detail view now shows a foreground pending state when the selected file diff is slow, keeps cached content visible while it refreshes, and caps background viewed-file checks so status bursts do not fan out into repeated Git diff work.
+- **Active Git Status Refreshes**: Active-session Git status now uses a coalesced scheduler instead of a hot two-second poll loop, with slower fallback refreshes after expensive status runs.
 
 ### Fixed
 - **Codex Session Resume**: Reloading a Codex session from attn now records Codex's native session id from hooks and resumes the same Codex conversation instead of handing Codex attn's wrapper session id.

--- a/internal/daemon/git_operation.go
+++ b/internal/daemon/git_operation.go
@@ -39,5 +39,6 @@ func (d *Daemon) beginGitOperation(kind protocol.GitOperationKind, path string, 
 			Event:     protocol.EventGitOperationFinished,
 			Operation: &finishedOperation,
 		})
+		d.refreshGitStatusSubscribersForPath(path)
 	}
 }

--- a/internal/daemon/gitstatus_test.go
+++ b/internal/daemon/gitstatus_test.go
@@ -1,7 +1,12 @@
 package daemon
 
 import (
+	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
 )
 
 func TestParseGitStatusPorcelain(t *testing.T) {
@@ -29,4 +34,191 @@ func TestParseGitDiffNumstat(t *testing.T) {
 	if stats["src/App.tsx"].Additions != 42 || stats["src/App.tsx"].Deletions != 12 {
 		t.Errorf("Expected 42/12 for App.tsx, got %v", stats["src/App.tsx"])
 	}
+}
+
+func TestGitStatusSchedulerCoalescesDirtyRefreshes(t *testing.T) {
+	restore := overrideGitStatusSchedulerForTesting(10*time.Millisecond, time.Hour, time.Hour, time.Hour)
+	defer restore()
+
+	var calls atomic.Int32
+	var inFlight atomic.Int32
+	var overlapped atomic.Bool
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+
+	previousGetGitStatus := getGitStatusForDaemon
+	getGitStatusForDaemon = func(dir string) (*protocol.GitStatusUpdateMessage, error) {
+		if inFlight.Add(1) > 1 {
+			overlapped.Store(true)
+		}
+		defer inFlight.Add(-1)
+
+		call := calls.Add(1)
+		if call == 1 {
+			close(firstStarted)
+			<-releaseFirst
+		}
+		return testGitStatus(dir, fmt.Sprintf("file-%d.txt", call)), nil
+	}
+	defer func() {
+		getGitStatusForDaemon = previousGetGitStatus
+	}()
+
+	d := &Daemon{}
+	client := &wsClient{send: make(chan outboundMessage, 10)}
+	d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
+		Cmd:       protocol.CmdSubscribeGitStatus,
+		Directory: "/repo",
+	})
+	defer client.stopGitStatusPoll()
+
+	<-firstStarted
+	for i := 0; i < 5; i++ {
+		client.requestGitStatusRefresh(gitStatusRefreshRequest{reason: gitStatusRefreshReasonDirty})
+	}
+	close(releaseFirst)
+
+	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
+		return calls.Load() == 2
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("git status calls = %d, want 2", got)
+	}
+	if overlapped.Load() {
+		t.Fatal("git status refreshes overlapped")
+	}
+}
+
+func TestGitOperationMarksMatchingStatusSubscriptionDirty(t *testing.T) {
+	restore := overrideGitStatusSchedulerForTesting(10*time.Millisecond, time.Hour, time.Hour, time.Hour)
+	defer restore()
+
+	var calls atomic.Int32
+	previousGetGitStatus := getGitStatusForDaemon
+	getGitStatusForDaemon = func(dir string) (*protocol.GitStatusUpdateMessage, error) {
+		call := calls.Add(1)
+		return testGitStatus(dir, fmt.Sprintf("file-%d.txt", call)), nil
+	}
+	defer func() {
+		getGitStatusForDaemon = previousGetGitStatus
+	}()
+
+	hub := newWSHub()
+	d := &Daemon{wsHub: hub}
+	client := &wsClient{send: make(chan outboundMessage, 10)}
+	hub.clients[client] = true
+
+	d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
+		Cmd:       protocol.CmdSubscribeGitStatus,
+		Directory: "/repo",
+	})
+	defer client.stopGitStatusPoll()
+	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
+		return calls.Load() == 1
+	})
+
+	finish := d.beginGitOperation(protocol.GitOperationKindDeleteWorktree, "/repo/worktree", nil)
+	finish(nil)
+
+	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
+		return calls.Load() == 2
+	})
+}
+
+func TestGitStatusSchedulerDelaysSafetyRefreshAfterSlowRun(t *testing.T) {
+	restore := overrideGitStatusSchedulerForTesting(10*time.Millisecond, 20*time.Millisecond, time.Hour, time.Millisecond)
+	defer restore()
+
+	var calls atomic.Int32
+	previousGetGitStatus := getGitStatusForDaemon
+	getGitStatusForDaemon = func(dir string) (*protocol.GitStatusUpdateMessage, error) {
+		call := calls.Add(1)
+		time.Sleep(5 * time.Millisecond)
+		return testGitStatus(dir, fmt.Sprintf("file-%d.txt", call)), nil
+	}
+	defer func() {
+		getGitStatusForDaemon = previousGetGitStatus
+	}()
+
+	d := &Daemon{}
+	client := &wsClient{send: make(chan outboundMessage, 10)}
+	d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
+		Cmd:       protocol.CmdSubscribeGitStatus,
+		Directory: "/repo",
+	})
+	defer client.stopGitStatusPoll()
+
+	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
+		return calls.Load() == 1
+	})
+	time.Sleep(60 * time.Millisecond)
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("git status calls = %d, want 1 slow run without normal safety refresh", got)
+	}
+}
+
+func TestSameOrNestedPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		dir  string
+		want bool
+	}{
+		{name: "same", path: "/repo", dir: "/repo", want: true},
+		{name: "nested", path: "/repo/worktree", dir: "/repo", want: true},
+		{name: "sibling prefix", path: "/repo-two", dir: "/repo", want: false},
+		{name: "parent", path: "/repo", dir: "/repo/worktree", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameOrNestedPath(tt.path, tt.dir); got != tt.want {
+				t.Fatalf("sameOrNestedPath(%q, %q) = %v, want %v", tt.path, tt.dir, got, tt.want)
+			}
+		})
+	}
+}
+
+func overrideGitStatusSchedulerForTesting(debounce, safety, slowSafety, slowThreshold time.Duration) func() {
+	previousDebounce := gitStatusRefreshDebounce
+	previousSafety := gitStatusSafetyInterval
+	previousSlowSafety := gitStatusSlowSafetyInterval
+	previousSlowThreshold := gitStatusSlowRefreshDuration
+
+	gitStatusRefreshDebounce = debounce
+	gitStatusSafetyInterval = safety
+	gitStatusSlowSafetyInterval = slowSafety
+	gitStatusSlowRefreshDuration = slowThreshold
+
+	return func() {
+		gitStatusRefreshDebounce = previousDebounce
+		gitStatusSafetyInterval = previousSafety
+		gitStatusSlowSafetyInterval = previousSlowSafety
+		gitStatusSlowRefreshDuration = previousSlowThreshold
+	}
+}
+
+func testGitStatus(dir, path string) *protocol.GitStatusUpdateMessage {
+	return &protocol.GitStatusUpdateMessage{
+		Event:     protocol.EventGitStatusUpdate,
+		Directory: dir,
+		Staged:    []protocol.GitFileChange{},
+		Unstaged:  []protocol.GitFileChange{{Path: path, Status: "modified"}},
+		Untracked: []protocol.GitFileChange{},
+	}
+}
+
+func waitForGitStatusTestCondition(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for condition")
 }

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -47,8 +47,8 @@ type wsClient struct {
 
 	// Git status subscription state
 	gitStatusDir        string
-	gitStatusTicker     *time.Ticker
 	gitStatusStop       chan struct{}
+	gitStatusRefresh    chan gitStatusRefreshRequest
 	gitStatusHash       string // hash of last sent status for dedup
 	gitStatusEndpointID string
 	gitStatusMu         sync.Mutex
@@ -143,22 +143,35 @@ func (c *wsClient) sendWithWait(message outboundMessage, wait time.Duration) boo
 	}
 }
 
-// stopGitStatusPoll stops any active git status polling for this client
+// stopGitStatusPoll stops any active git status subscription for this client.
 func (c *wsClient) stopGitStatusPoll() {
 	c.gitStatusMu.Lock()
 	defer c.gitStatusMu.Unlock()
 
-	if c.gitStatusTicker != nil {
-		c.gitStatusTicker.Stop()
-		c.gitStatusTicker = nil
-	}
 	if c.gitStatusStop != nil {
 		close(c.gitStatusStop)
 		c.gitStatusStop = nil
 	}
+	c.gitStatusRefresh = nil
 	c.gitStatusDir = ""
 	c.gitStatusHash = ""
 	c.gitStatusEndpointID = ""
+}
+
+func (c *wsClient) requestGitStatusRefresh(req gitStatusRefreshRequest) bool {
+	c.gitStatusMu.Lock()
+	refresh := c.gitStatusRefresh
+	c.gitStatusMu.Unlock()
+
+	if refresh == nil {
+		return false
+	}
+	select {
+	case refresh <- req:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *wsClient) setGitStatusEndpointID(endpointID string) {

--- a/internal/daemon/ws_git.go
+++ b/internal/daemon/ws_git.go
@@ -3,13 +3,31 @@ package daemon
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-const gitStatusPollInterval = 2 * time.Second
+const (
+	gitStatusRefreshReasonSubscribe = "subscribe"
+	gitStatusRefreshReasonDirty     = "dirty"
+	gitStatusRefreshReasonSafety    = "safety"
+)
+
+type gitStatusRefreshRequest struct {
+	immediate bool
+	reason    string
+}
+
+var (
+	gitStatusRefreshDebounce     = 1 * time.Second
+	gitStatusSafetyInterval      = 30 * time.Second
+	gitStatusSlowSafetyInterval  = 2 * time.Minute
+	gitStatusSlowRefreshDuration = 5 * time.Second
+	getGitStatusForDaemon        = getGitStatus
+)
 
 func (d *Daemon) handleSubscribeGitStatus(client *wsClient, msg *protocol.SubscribeGitStatusMessage) {
 	client.stopGitStatusPoll()
@@ -17,23 +35,13 @@ func (d *Daemon) handleSubscribeGitStatus(client *wsClient, msg *protocol.Subscr
 	client.gitStatusMu.Lock()
 	client.gitStatusDir = msg.Directory
 	client.gitStatusStop = make(chan struct{})
-	client.gitStatusTicker = time.NewTicker(gitStatusPollInterval)
 	stopChan := client.gitStatusStop
-	ticker := client.gitStatusTicker
+	refreshChan := make(chan gitStatusRefreshRequest, 1)
+	client.gitStatusRefresh = refreshChan
 	client.gitStatusMu.Unlock()
 
-	go d.sendGitStatusUpdate(client)
-
-	go func() {
-		for {
-			select {
-			case <-stopChan:
-				return
-			case <-ticker.C:
-				d.sendGitStatusUpdate(client)
-			}
-		}
-	}()
+	go d.runGitStatusScheduler(client, msg.Directory, stopChan, refreshChan)
+	client.requestGitStatusRefresh(gitStatusRefreshRequest{immediate: true, reason: gitStatusRefreshReasonSubscribe})
 }
 
 func (d *Daemon) handleUnsubscribeGitStatusWS(client *wsClient) {
@@ -41,32 +49,121 @@ func (d *Daemon) handleUnsubscribeGitStatusWS(client *wsClient) {
 	client.stopGitStatusPoll()
 }
 
-func (d *Daemon) sendGitStatusUpdate(client *wsClient) {
+func (d *Daemon) runGitStatusScheduler(client *wsClient, dir string, stop <-chan struct{}, refresh <-chan gitStatusRefreshRequest) {
+	debounce := time.NewTimer(time.Hour)
+	if !debounce.Stop() {
+		<-debounce.C
+	}
+	safety := time.NewTimer(time.Hour)
+	if !safety.Stop() {
+		<-safety.C
+	}
+	defer debounce.Stop()
+	defer safety.Stop()
+
+	resetTimer := func(timer *time.Timer, delay time.Duration) {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(delay)
+	}
+
+	run := func(reason string) {
+		duration := d.sendGitStatusUpdate(client, dir)
+		interval := gitStatusSafetyInterval
+		if duration >= gitStatusSlowRefreshDuration {
+			interval = gitStatusSlowSafetyInterval
+			d.logf("git status refresh for %s took %s via %s; delaying safety refresh to %s", dir, duration.Round(time.Millisecond), reason, interval)
+		}
+		resetTimer(safety, interval)
+	}
+
+	for {
+		select {
+		case <-stop:
+			return
+		case req := <-refresh:
+			if req.immediate {
+				run(req.reason)
+				continue
+			}
+			resetTimer(debounce, gitStatusRefreshDebounce)
+		case <-debounce.C:
+			run(gitStatusRefreshReasonDirty)
+		case <-safety.C:
+			run(gitStatusRefreshReasonSafety)
+		}
+	}
+}
+
+func (d *Daemon) sendGitStatusUpdate(client *wsClient, dir string) time.Duration {
 	client.gitStatusMu.Lock()
-	dir := client.gitStatusDir
+	currentDir := client.gitStatusDir
 	lastHash := client.gitStatusHash
 	client.gitStatusMu.Unlock()
 
-	if dir == "" {
-		return
+	if dir == "" || currentDir != dir {
+		return 0
 	}
 
-	status, err := getGitStatus(dir)
+	started := time.Now()
+	status, err := getGitStatusForDaemon(dir)
+	duration := time.Since(started)
 	if err != nil {
 		d.logf("Git status error for %s: %v", dir, err)
-		return
+		return duration
 	}
 
 	newHash := hashGitStatus(status)
 	if newHash == lastHash {
-		return
+		return duration
 	}
 
 	client.gitStatusMu.Lock()
+	if client.gitStatusDir != dir {
+		client.gitStatusMu.Unlock()
+		return duration
+	}
 	client.gitStatusHash = newHash
 	client.gitStatusMu.Unlock()
 
 	d.sendToClient(client, status)
+	return duration
+}
+
+func (d *Daemon) refreshGitStatusSubscribersForPath(path string) {
+	if d.wsHub == nil {
+		return
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return
+	}
+	d.wsHub.ForEachClient(func(client *wsClient) {
+		client.gitStatusMu.Lock()
+		dir := client.gitStatusDir
+		client.gitStatusMu.Unlock()
+		if dir == "" || !sameOrNestedPath(path, dir) {
+			return
+		}
+		client.requestGitStatusRefresh(gitStatusRefreshRequest{reason: gitStatusRefreshReasonDirty})
+	})
+}
+
+func sameOrNestedPath(path, dir string) bool {
+	cleanPath := filepath.Clean(path)
+	cleanDir := filepath.Clean(dir)
+	if cleanPath == cleanDir {
+		return true
+	}
+	rel, err := filepath.Rel(cleanDir, cleanPath)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func (d *Daemon) handleGetFileDiffWS(client *wsClient, msg *protocol.GetFileDiffMessage) {


### PR DESCRIPTION
## Summary
- replace the active-session git status 2s ticker with a coalesced per-subscription scheduler
- keep an immediate refresh on subscribe, then use dirty refresh requests plus a slower safety refresh
- back off safety refreshes after slow status runs and mark matching subscriptions dirty after daemon-owned git operations

## Why
Large repositories can make `git status` expensive. The previous subscription loop kept invoking status every two seconds even when nothing had changed, which is hostile to monorepos and creates the wrong foundation for slow/huge repo behavior.

## Validation
- `go test ./internal/daemon -run 'TestGitStatusScheduler|TestGitOperationMarks|TestSameOrNestedPath|TestParseGit'`
- `go test ./internal/daemon ./internal/git ./cmd/attn`
- `go test ./...` was attempted; it still hits the existing `internal/client` socket-path expectation on this machine (`/home/testuser/.attn/attn.sock` expected, `/Users/victor/.attn/attn.sock` actual).