### PR TITLE
[codex] Limit slow active git status scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Changes Panel Refreshes**: The Changes panel now avoids branch-diff refreshes while closed, refreshes once when opened, and coalesces status-triggered refreshes so slow monorepos do not stack repeated Git diff work behind every status update.
 - **Diff Detail Loading**: The Diff detail view now shows a foreground pending state when the selected file diff is slow, keeps cached content visible while it refreshes, and caps background viewed-file checks so status bursts do not fan out into repeated Git diff work.
 - **Active Git Status Refreshes**: Active-session Git status now uses a coalesced scheduler instead of a hot two-second poll loop, with slower fallback refreshes after expensive status runs.
+- **Large Repository Git Status**: Active-session Git status now caps full untracked scans, falls back to tracked-file status when the full scan is slow, and marks the Changes panel as tracked-only while background refresh is limited.
 
 ### Fixed
 - **Codex Session Resume**: Reloading a Codex session from attn now records Codex's native session id from hooks and resumes the same Codex conversation instead of handing Codex attn's wrapper session id.

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2126,6 +2126,8 @@ sendFetchPRDetails,
                   branchDiffLoaded={branchDiffLoaded}
                   branchDiffLoading={branchDiffLoading}
                   branchDiffRefreshing={branchDiffRefreshing}
+                  gitStatusLimited={Boolean(gitStatus?.limited && gitStatus.directory === activeRepoDaemonSession?.directory)}
+                  gitStatusLimitedReason={gitStatus?.limited_reason}
                   selectedFile={null}
                   onFileSelect={handleFileSelect}
                   onOpenDiffClick={handleOpenDiffDetailPanel}

--- a/app/src/components/ChangesPanel.css
+++ b/app/src/components/ChangesPanel.css
@@ -31,7 +31,8 @@
 }
 
 .changes-refreshing,
-.changes-warning {
+.changes-warning,
+.changes-limited {
   font-family: 'JetBrains Mono', monospace;
   font-size: var(--font-size-xs);
   font-weight: 600;
@@ -50,6 +51,12 @@
   color: #fbbf24;
   background: rgba(251, 191, 36, 0.11);
   border: 1px solid rgba(251, 191, 36, 0.24);
+}
+
+.changes-limited {
+  color: #c4b5fd;
+  background: rgba(124, 58, 237, 0.11);
+  border: 1px solid rgba(124, 58, 237, 0.24);
 }
 
 .editor-btn {
@@ -222,6 +229,12 @@
   background: rgba(251, 191, 36, 0.08);
   color: #d6a72a;
   font-size: var(--font-size-xs);
+}
+
+.changes-inline-warning--limited {
+  border-color: rgba(124, 58, 237, 0.22);
+  background: rgba(124, 58, 237, 0.08);
+  color: #b9a7ee;
 }
 
 .changes-loading {

--- a/app/src/components/ChangesPanel.test.tsx
+++ b/app/src/components/ChangesPanel.test.tsx
@@ -80,4 +80,16 @@ describe('ChangesPanel', () => {
     expect(screen.getByText('Get branch diff files timed out')).toBeInTheDocument();
     expect(screen.queryByText('Could not refresh changes. Showing last result.')).not.toBeInTheDocument();
   });
+
+  it('shows tracked-only status when background git status is limited', () => {
+    renderPanel({
+      branchDiffFiles: changedFiles,
+      branchDiffLoaded: true,
+      gitStatusLimited: true,
+      gitStatusLimitedReason: 'Untracked files hidden because full git status was slow.',
+    });
+
+    expect(screen.getByRole('status', { name: 'Tracked files only' })).toBeInTheDocument();
+    expect(screen.getByText('Full status was slow. Background refresh is tracking changed files already known to Git.')).toBeInTheDocument();
+  });
 });

--- a/app/src/components/ChangesPanel.tsx
+++ b/app/src/components/ChangesPanel.tsx
@@ -10,6 +10,8 @@ interface ChangesPanelProps {
   branchDiffLoaded?: boolean;
   branchDiffLoading?: boolean;
   branchDiffRefreshing?: boolean;
+  gitStatusLimited?: boolean;
+  gitStatusLimitedReason?: string;
   selectedFile: string | null;
   onFileSelect: (path: string, staged: boolean) => void;
   onOpenDiffClick?: () => void;
@@ -113,6 +115,8 @@ export const ChangesPanel = memo(function ChangesPanel({
   branchDiffLoaded = false,
   branchDiffLoading = false,
   branchDiffRefreshing = false,
+  gitStatusLimited = false,
+  gitStatusLimitedReason,
   selectedFile,
   onFileSelect,
   onOpenDiffClick,
@@ -198,6 +202,9 @@ export const ChangesPanel = memo(function ChangesPanel({
           {showInlineWarning && (
             <span className="changes-warning" role="status" aria-label="Stale" title={branchDiffError || undefined}>Stale</span>
           )}
+          {gitStatusLimited && (
+            <span className="changes-limited" role="status" aria-label="Tracked files only" title={gitStatusLimitedReason || undefined}>Tracked only</span>
+          )}
           {hasFiles && onOpenDiffClick && (
             <button className="review-btn" onClick={onOpenDiffClick} title="Open diff detail">
               Open Diff
@@ -219,6 +226,11 @@ export const ChangesPanel = memo(function ChangesPanel({
         {showInlineWarning && (
           <div className="changes-inline-warning">
             Could not refresh changes. Showing last result.
+          </div>
+        )}
+        {gitStatusLimited && (
+          <div className="changes-inline-warning changes-inline-warning--limited">
+            Full status was slow. Background refresh is tracking changed files already known to Git.
           </div>
         )}
         {branchDiffError && !hasLoadedResult ? (

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -404,7 +404,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '60',
+        protocol_version: '61',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -480,7 +480,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '60',
+        protocol_version: '61',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -559,7 +559,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '60',
+        protocol_version: '61',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -652,7 +652,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '60',
+        protocol_version: '61',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -749,7 +749,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '60',
+        protocol_version: '61',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -832,7 +832,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '60',
+        protocol_version: '61',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -941,7 +941,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '60',
+        protocol_version: '61',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -999,7 +999,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '60',
+        protocol_version: '61',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -143,7 +143,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '60';
+const PROTOCOL_VERSION = '61';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 // Runtime gate (flipped from VITE_UI_AUTOMATION). The Rust shell
 // injects this global before any page script runs — see
@@ -350,6 +350,10 @@ export interface GitStatusUpdate {
   unstaged: GitFileChange[];
   untracked: GitFileChange[];
   error?: string;
+  mode?: string;
+  limited?: boolean;
+  limited_reason?: string;
+  duration_ms?: number;
 }
 
 export interface FileDiffResult {
@@ -1730,6 +1734,10 @@ export function useDaemonSocket({
                 unstaged: data.unstaged || [],
                 untracked: data.untracked || [],
                 error: data.error,
+                mode: data.mode,
+                limited: data.limited,
+                limited_reason: data.limited_reason,
+                duration_ms: data.duration_ms,
               });
             }
             break;

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1110,12 +1110,16 @@ export enum GitOperationStartedMessageEvent {
 }
 
 export interface GitStatusUpdateMessage {
-    directory: string;
-    error?:    string;
-    event:     GitStatusUpdateMessageEvent;
-    staged:    StagedElement[];
-    unstaged:  StagedElement[];
-    untracked: StagedElement[];
+    directory:       string;
+    duration_ms?:    number;
+    error?:          string;
+    event:           GitStatusUpdateMessageEvent;
+    limited?:        boolean;
+    limited_reason?: string;
+    mode?:           string;
+    staged:          StagedElement[];
+    unstaged:        StagedElement[];
+    untracked:       StagedElement[];
     [property: string]: any;
 }
 
@@ -4741,8 +4745,12 @@ const typeMap: any = {
     ], "any"),
     "GitStatusUpdateMessage": o([
         { json: "directory", js: "directory", typ: "" },
+        { json: "duration_ms", js: "duration_ms", typ: u(undefined, 0) },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("GitStatusUpdateMessageEvent") },
+        { json: "limited", js: "limited", typ: u(undefined, true) },
+        { json: "limited_reason", js: "limited_reason", typ: u(undefined, "") },
+        { json: "mode", js: "mode", typ: u(undefined, "") },
         { json: "staged", js: "staged", typ: a(r("StagedElement")) },
         { json: "unstaged", js: "unstaged", typ: a(r("StagedElement")) },
         { json: "untracked", js: "untracked", typ: a(r("StagedElement")) },

--- a/internal/daemon/gitstatus.go
+++ b/internal/daemon/gitstatus.go
@@ -8,10 +8,26 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	attngit "github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
 )
+
+type gitStatusMode string
+
+const (
+	gitStatusModeFull        gitStatusMode = "full"
+	gitStatusModeTrackedOnly gitStatusMode = "tracked_only"
+)
+
+type gitStatusOptions struct {
+	mode         gitStatusMode
+	fullTimeout  time.Duration
+	includeStats bool
+}
+
+var runGitStatusCommandForDaemon = runGitStatusCommand
 
 type diffStats struct {
 	Additions int
@@ -172,25 +188,66 @@ func parseGitDiffNumstat(output string) map[string]diffStats {
 	return result
 }
 
-// getGitStatus runs git commands and returns parsed status
+// getGitStatus runs git commands and returns parsed status.
 func getGitStatus(dir string) (*protocol.GitStatusUpdateMessage, error) {
+	return getGitStatusWithOptions(dir, gitStatusOptions{
+		mode:         gitStatusModeFull,
+		includeStats: true,
+	})
+}
+
+func getGitStatusForSubscription(dir string, mode gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
+	return getGitStatusWithOptions(dir, gitStatusOptions{
+		mode:         mode,
+		fullTimeout:  gitStatusFullBudget,
+		includeStats: false,
+	})
+}
+
+func getGitStatusWithOptions(dir string, opts gitStatusOptions) (*protocol.GitStatusUpdateMessage, error) {
+	mode := opts.mode
+	if mode == "" {
+		mode = gitStatusModeFull
+	}
+
 	// Get porcelain status
 	// --untracked-files=all expands brand-new untracked directories into
 	// their individual files; the default collapses each into a single
 	// "?? dir/" line which hides everything inside.
-	statusOutput, err := attngit.Output(attngit.OpStatus, dir, "status", "--porcelain", "-z", "--untracked-files=all")
+	statusArgs := []string{"status", "--porcelain", "-z", "--untracked-files=all"}
+	if mode == gitStatusModeTrackedOnly {
+		statusArgs = []string{"status", "--porcelain", "-z", "--untracked-files=no"}
+	}
+
+	statusOutput, err := runGitStatusCommandForDaemon(dir, opts.fullTimeout, statusArgs...)
+	limited := mode == gitStatusModeTrackedOnly
+	var limitedReason *string
+	if limited {
+		limitedReason = protocol.Ptr("Untracked files hidden because full git status was slow.")
+	}
+	if err != nil && mode == gitStatusModeFull && isGitStatusTimeout(err) {
+		statusArgs = []string{"status", "--porcelain", "-z", "--untracked-files=no"}
+		statusOutput, err = runGitStatusCommandForDaemon(dir, opts.fullTimeout, statusArgs...)
+		mode = gitStatusModeTrackedOnly
+		limited = true
+		limitedReason = protocol.Ptr("Untracked files hidden because full git status was slow.")
+	}
 	if err != nil {
+		errorMessage := "Not a git repository"
+		if isGitStatusTimeout(err) {
+			errorMessage = "Git status timed out"
+		}
 		return &protocol.GitStatusUpdateMessage{
 			Event:     protocol.EventGitStatusUpdate,
 			Directory: dir,
-			Error:     protocol.Ptr("Not a git repository"),
+			Error:     protocol.Ptr(errorMessage),
 		}, nil
 	}
 
 	staged, unstaged, untracked := parseGitStatusPorcelain(string(statusOutput), dir)
 
 	// Get numstat for unstaged changes
-	if len(unstaged) > 0 {
+	if opts.includeStats && len(unstaged) > 0 {
 		numstatOutput, _ := attngit.Output(attngit.OpDiff, dir, "diff", "--numstat")
 		stats := parseGitDiffNumstat(string(numstatOutput))
 
@@ -203,7 +260,7 @@ func getGitStatus(dir string) (*protocol.GitStatusUpdateMessage, error) {
 	}
 
 	// Get numstat for staged changes
-	if len(staged) > 0 {
+	if opts.includeStats && len(staged) > 0 {
 		numstatOutput, _ := attngit.Output(attngit.OpDiff, dir, "diff", "--numstat", "--cached")
 		stats := parseGitDiffNumstat(string(numstatOutput))
 
@@ -216,17 +273,33 @@ func getGitStatus(dir string) (*protocol.GitStatusUpdateMessage, error) {
 	}
 
 	return &protocol.GitStatusUpdateMessage{
-		Event:     protocol.EventGitStatusUpdate,
-		Directory: dir,
-		Staged:    staged,
-		Unstaged:  unstaged,
-		Untracked: untracked,
+		Event:         protocol.EventGitStatusUpdate,
+		Directory:     dir,
+		Staged:        staged,
+		Unstaged:      unstaged,
+		Untracked:     untracked,
+		Mode:          protocol.Ptr(string(mode)),
+		Limited:       protocol.Ptr(limited),
+		LimitedReason: limitedReason,
 	}, nil
+}
+
+func runGitStatusCommand(dir string, timeout time.Duration, args ...string) ([]byte, error) {
+	if timeout > 0 {
+		return attngit.OutputWithTimeout(attngit.OpStatus, timeout, dir, args...)
+	}
+	return attngit.Output(attngit.OpStatus, dir, args...)
+}
+
+func isGitStatusTimeout(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "timed out")
 }
 
 // hashGitStatus returns a hash of the status for change detection
 func hashGitStatus(status *protocol.GitStatusUpdateMessage) string {
-	data, _ := json.Marshal(status)
+	stableStatus := *status
+	stableStatus.DurationMs = nil
+	data, _ := json.Marshal(stableStatus)
 	hash := sha256.Sum256(data)
 	return hex.EncodeToString(hash[:8]) // First 8 bytes is enough
 }

--- a/internal/daemon/gitstatus_test.go
+++ b/internal/daemon/gitstatus_test.go
@@ -47,7 +47,7 @@ func TestGitStatusSchedulerCoalescesDirtyRefreshes(t *testing.T) {
 	releaseFirst := make(chan struct{})
 
 	previousGetGitStatus := getGitStatusForDaemon
-	getGitStatusForDaemon = func(dir string) (*protocol.GitStatusUpdateMessage, error) {
+	getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
 		if inFlight.Add(1) > 1 {
 			overlapped.Store(true)
 		}
@@ -97,7 +97,7 @@ func TestGitOperationMarksMatchingStatusSubscriptionDirty(t *testing.T) {
 
 	var calls atomic.Int32
 	previousGetGitStatus := getGitStatusForDaemon
-	getGitStatusForDaemon = func(dir string) (*protocol.GitStatusUpdateMessage, error) {
+	getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
 		call := calls.Add(1)
 		return testGitStatus(dir, fmt.Sprintf("file-%d.txt", call)), nil
 	}
@@ -133,7 +133,7 @@ func TestGitStatusSchedulerDelaysSafetyRefreshAfterSlowRun(t *testing.T) {
 
 	var calls atomic.Int32
 	previousGetGitStatus := getGitStatusForDaemon
-	getGitStatusForDaemon = func(dir string) (*protocol.GitStatusUpdateMessage, error) {
+	getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
 		call := calls.Add(1)
 		time.Sleep(5 * time.Millisecond)
 		return testGitStatus(dir, fmt.Sprintf("file-%d.txt", call)), nil
@@ -160,6 +160,123 @@ func TestGitStatusSchedulerDelaysSafetyRefreshAfterSlowRun(t *testing.T) {
 	}
 }
 
+func TestGitStatusSchedulerUsesTrackedOnlyAfterLimitedRefresh(t *testing.T) {
+	restore := overrideGitStatusSchedulerForTesting(10*time.Millisecond, time.Hour, time.Hour, time.Hour)
+	defer restore()
+
+	var calls atomic.Int32
+	modes := make(chan gitStatusMode, 2)
+	previousGetGitStatus := getGitStatusForDaemon
+	getGitStatusForDaemon = func(dir string, mode gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
+		modes <- mode
+		call := calls.Add(1)
+		status := testGitStatus(dir, fmt.Sprintf("file-%d.txt", call))
+		if call == 1 {
+			status.Limited = protocol.Ptr(true)
+			status.Mode = protocol.Ptr(string(gitStatusModeTrackedOnly))
+		}
+		return status, nil
+	}
+	defer func() {
+		getGitStatusForDaemon = previousGetGitStatus
+	}()
+
+	d := &Daemon{}
+	client := &wsClient{send: make(chan outboundMessage, 10)}
+	d.handleSubscribeGitStatus(client, &protocol.SubscribeGitStatusMessage{
+		Cmd:       protocol.CmdSubscribeGitStatus,
+		Directory: "/repo",
+	})
+	defer client.stopGitStatusPoll()
+
+	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
+		return calls.Load() == 1
+	})
+	client.requestGitStatusRefresh(gitStatusRefreshRequest{reason: gitStatusRefreshReasonDirty})
+	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
+		return calls.Load() == 2
+	})
+
+	first := <-modes
+	second := <-modes
+	if first != gitStatusModeFull {
+		t.Fatalf("first mode = %q, want %q", first, gitStatusModeFull)
+	}
+	if second != gitStatusModeTrackedOnly {
+		t.Fatalf("second mode = %q, want %q", second, gitStatusModeTrackedOnly)
+	}
+}
+
+func TestTrackedOnlyStatusResultStaysLimited(t *testing.T) {
+	previousRunGitStatusCommand := runGitStatusCommandForDaemon
+	runGitStatusCommandForDaemon = func(_ string, _ time.Duration, args ...string) ([]byte, error) {
+		if !containsArg(args, "--untracked-files=no") {
+			t.Fatalf("args = %v, want tracked-only status", args)
+		}
+		return []byte(" M tracked.txt\x00"), nil
+	}
+	defer func() {
+		runGitStatusCommandForDaemon = previousRunGitStatusCommand
+	}()
+
+	status, err := getGitStatusWithOptions("/repo", gitStatusOptions{
+		mode: gitStatusModeTrackedOnly,
+	})
+	if err != nil {
+		t.Fatalf("getGitStatusWithOptions failed: %v", err)
+	}
+	if !protocol.Deref(status.Limited) {
+		t.Fatal("tracked-only status limited = false, want true")
+	}
+	if protocol.Deref(status.LimitedReason) == "" {
+		t.Fatal("tracked-only status missing limited reason")
+	}
+}
+
+func TestGetGitStatusWithOptionsFallsBackToTrackedOnlyAfterFullTimeout(t *testing.T) {
+	var calls atomic.Int32
+	argsSeen := make(chan []string, 2)
+	previousRunGitStatusCommand := runGitStatusCommandForDaemon
+	runGitStatusCommandForDaemon = func(_ string, _ time.Duration, args ...string) ([]byte, error) {
+		argsSeen <- append([]string(nil), args...)
+		if calls.Add(1) == 1 {
+			return nil, fmt.Errorf("git status timed out after 5s: git status")
+		}
+		return []byte(" M tracked.txt\x00"), nil
+	}
+	defer func() {
+		runGitStatusCommandForDaemon = previousRunGitStatusCommand
+	}()
+
+	status, err := getGitStatusWithOptions("/repo", gitStatusOptions{
+		mode:        gitStatusModeFull,
+		fullTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("getGitStatusWithOptions failed: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("status command calls = %d, want 2", calls.Load())
+	}
+	firstArgs := <-argsSeen
+	secondArgs := <-argsSeen
+	if !containsArg(firstArgs, "--untracked-files=all") {
+		t.Fatalf("first args = %v, want full untracked status", firstArgs)
+	}
+	if !containsArg(secondArgs, "--untracked-files=no") {
+		t.Fatalf("second args = %v, want tracked-only status", secondArgs)
+	}
+	if !protocol.Deref(status.Limited) {
+		t.Fatal("status limited = false, want true")
+	}
+	if got := protocol.Deref(status.Mode); got != string(gitStatusModeTrackedOnly) {
+		t.Fatalf("status mode = %q, want %q", got, gitStatusModeTrackedOnly)
+	}
+	if len(status.Untracked) != 0 {
+		t.Fatalf("untracked = %v, want none in tracked-only fallback", status.Untracked)
+	}
+}
+
 func TestSameOrNestedPath(t *testing.T) {
 	tests := []struct {
 		name string
@@ -180,6 +297,15 @@ func TestSameOrNestedPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
 }
 
 func overrideGitStatusSchedulerForTesting(debounce, safety, slowSafety, slowThreshold time.Duration) func() {

--- a/internal/daemon/ws_git.go
+++ b/internal/daemon/ws_git.go
@@ -21,12 +21,18 @@ type gitStatusRefreshRequest struct {
 	reason    string
 }
 
+type gitStatusRefreshResult struct {
+	duration time.Duration
+	limited  bool
+}
+
 var (
 	gitStatusRefreshDebounce     = 1 * time.Second
 	gitStatusSafetyInterval      = 30 * time.Second
 	gitStatusSlowSafetyInterval  = 2 * time.Minute
 	gitStatusSlowRefreshDuration = 5 * time.Second
-	getGitStatusForDaemon        = getGitStatus
+	gitStatusFullBudget          = 5 * time.Second
+	getGitStatusForDaemon        = getGitStatusForSubscription
 )
 
 func (d *Daemon) handleSubscribeGitStatus(client *wsClient, msg *protocol.SubscribeGitStatusMessage) {
@@ -71,12 +77,16 @@ func (d *Daemon) runGitStatusScheduler(client *wsClient, dir string, stop <-chan
 		timer.Reset(delay)
 	}
 
+	mode := gitStatusModeFull
 	run := func(reason string) {
-		duration := d.sendGitStatusUpdate(client, dir)
+		result := d.sendGitStatusUpdate(client, dir, mode)
+		if result.limited {
+			mode = gitStatusModeTrackedOnly
+		}
 		interval := gitStatusSafetyInterval
-		if duration >= gitStatusSlowRefreshDuration {
+		if result.duration >= gitStatusSlowRefreshDuration || result.limited {
 			interval = gitStatusSlowSafetyInterval
-			d.logf("git status refresh for %s took %s via %s; delaying safety refresh to %s", dir, duration.Round(time.Millisecond), reason, interval)
+			d.logf("git status refresh for %s took %s via %s; limited=%v; delaying safety refresh to %s", dir, result.duration.Round(time.Millisecond), reason, result.limited, interval)
 		}
 		resetTimer(safety, interval)
 	}
@@ -99,39 +109,40 @@ func (d *Daemon) runGitStatusScheduler(client *wsClient, dir string, stop <-chan
 	}
 }
 
-func (d *Daemon) sendGitStatusUpdate(client *wsClient, dir string) time.Duration {
+func (d *Daemon) sendGitStatusUpdate(client *wsClient, dir string, mode gitStatusMode) gitStatusRefreshResult {
 	client.gitStatusMu.Lock()
 	currentDir := client.gitStatusDir
 	lastHash := client.gitStatusHash
 	client.gitStatusMu.Unlock()
 
 	if dir == "" || currentDir != dir {
-		return 0
+		return gitStatusRefreshResult{}
 	}
 
 	started := time.Now()
-	status, err := getGitStatusForDaemon(dir)
+	status, err := getGitStatusForDaemon(dir, mode)
 	duration := time.Since(started)
 	if err != nil {
 		d.logf("Git status error for %s: %v", dir, err)
-		return duration
+		return gitStatusRefreshResult{duration: duration}
 	}
+	status.DurationMs = protocol.Ptr(int(duration.Milliseconds()))
 
 	newHash := hashGitStatus(status)
 	if newHash == lastHash {
-		return duration
+		return gitStatusRefreshResult{duration: duration, limited: protocol.Deref(status.Limited)}
 	}
 
 	client.gitStatusMu.Lock()
 	if client.gitStatusDir != dir {
 		client.gitStatusMu.Unlock()
-		return duration
+		return gitStatusRefreshResult{duration: duration, limited: protocol.Deref(status.Limited)}
 	}
 	client.gitStatusHash = newHash
 	client.gitStatusMu.Unlock()
 
 	d.sendToClient(client, status)
-	return duration
+	return gitStatusRefreshResult{duration: duration, limited: protocol.Deref(status.Limited)}
 }
 
 func (d *Daemon) refreshGitStatusSubscribersForPath(path string) {

--- a/internal/git/command.go
+++ b/internal/git/command.go
@@ -86,6 +86,10 @@ func Output(op Operation, dir string, args ...string) ([]byte, error) {
 	return runGitOutput(op, dir, args...)
 }
 
+func OutputWithTimeout(op Operation, timeout time.Duration, dir string, args ...string) ([]byte, error) {
+	return runGitCommandWithTimeout(op, timeout, dir, nil, false, args...)
+}
+
 func runGitCombined(op Operation, dir string, args ...string) ([]byte, error) {
 	return runGitCommand(op, dir, nil, true, args...)
 }
@@ -105,6 +109,10 @@ func runGitNoOutput(op Operation, dir string, args ...string) error {
 
 func runGitCommand(op Operation, dir string, stdin io.Reader, combined bool, args ...string) ([]byte, error) {
 	timeout := defaultTimeout(op)
+	return runGitCommandWithTimeout(op, timeout, dir, stdin, combined, args...)
+}
+
+func runGitCommandWithTimeout(op Operation, timeout time.Duration, dir string, stdin io.Reader, combined bool, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "60"
+const ProtocolVersion = "61"
 
 // Commands
 const (

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -893,11 +893,23 @@ type GitStatusUpdateMessage struct {
 	// Directory corresponds to the JSON schema field "directory".
 	Directory string `json:"directory"`
 
+	// DurationMs corresponds to the JSON schema field "duration_ms".
+	DurationMs *int `json:"duration_ms,omitempty,omitzero"`
+
 	// Error corresponds to the JSON schema field "error".
 	Error *string `json:"error,omitempty,omitzero"`
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
+
+	// Limited corresponds to the JSON schema field "limited".
+	Limited *bool `json:"limited,omitempty,omitzero"`
+
+	// LimitedReason corresponds to the JSON schema field "limited_reason".
+	LimitedReason *string `json:"limited_reason,omitempty,omitzero"`
+
+	// Mode corresponds to the JSON schema field "mode".
+	Mode *string `json:"mode,omitempty,omitzero"`
 
 	// Staged corresponds to the JSON schema field "staged".
 	Staged []GitFileChange `json:"staged"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1094,6 +1094,10 @@ model GitStatusUpdateMessage {
   unstaged: GitFileChange[];
   untracked: GitFileChange[];
   error?: string;
+  mode?: string;                 // "full" or "tracked_only"
+  limited?: boolean;             // true when untracked files were skipped
+  limited_reason?: string;       // user-facing reason for the limited result
+  duration_ms?: int32;           // daemon-side status command duration
 }
 
 model FileDiffResultMessage {


### PR DESCRIPTION
## Summary
- cap active-session full git status scans with a 5s budget
- fall back to tracked-only status when the full untracked scan is slow, then keep automatic refreshes in tracked-only mode for that subscription
- expose limited status metadata through the protocol and show a compact tracked-only notice in the Changes panel

## Why
In giant repositories, especially with large untracked trees, `git status --untracked-files=all` can dominate the active-session refresh path. The previous scheduler stopped repeated hot polling, but the first full status could still block for a long time. This change bounds that path and preserves useful tracked-file refresh instead of leaving the UI waiting on an unbounded untracked scan.

## Large-repo validation
Used a shallow Linux kernel checkout from GitHub (`torvalds/linux`) with ~93,696 tracked files, then added 120,000 untracked files locally:

- `git status --porcelain -z --untracked-files=all`: 0.42s, 4,569,444 bytes output
- `git status --porcelain -z --untracked-files=no`: 0.09s, 549 bytes output

This machine did not reproduce a 45s status, but the large-repo run confirms the tracked-only fallback avoids the high-output untracked path, and the daemon test covers the timeout fallback path directly.

## Validation
- `make generate-types`
- `go test ./internal/git ./internal/daemon ./internal/protocol ./cmd/attn`
- `pnpm --dir app test -- ChangesPanel useDaemonSocket`
- `pnpm --dir app run build`
- `git diff --check`