### PR TITLE
[codex] Coordinate daemon git reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Diff Detail Loading**: The Diff detail view now shows a foreground pending state when the selected file diff is slow, keeps cached content visible while it refreshes, and caps background viewed-file checks so status bursts do not fan out into repeated Git diff work.
 - **Active Git Status Refreshes**: Active-session Git status now uses a coalesced scheduler instead of a hot two-second poll loop, with slower fallback refreshes after expensive status runs.
 - **Large Repository Git Status**: Active-session Git status now caps full untracked scans, falls back to tracked-file status when the full scan is slow, and marks the Changes panel as tracked-only while background refresh is limited.
+- **Repository Git Coordination**: The daemon now routes status, branch-diff, and file-diff reads through a repo-scoped coordinator that shares in-flight work and daemon-owned branch-diff snapshots across connected clients.
 
 ### Fixed
 - **Codex Session Resume**: Reloading a Codex session from attn now records Codex's native session id from hooks and resumes the same Codex conversation instead of handing Codex attn's wrapper session id.

--- a/docs/plans/long-git-operation-surface-map.md
+++ b/docs/plans/long-git-operation-surface-map.md
@@ -1,9 +1,20 @@
 # Long Git Operation Surface Map
 
 Date: 2026-05-15
-Last updated: 2026-05-16
+Last updated: 2026-05-17
 
 Purpose: map every product surface that waits on git today before choosing UI patterns. The problem is not one spinner. Different surfaces need different treatment depending on whether the user is blocked, whether existing data can stay visible, and whether the surface is even mounted.
+
+## Recent Work Coverage
+
+Recent PRs already cover part of the giant-repo latency problem:
+
+- Changes panel branch diff refreshes are demand-driven and coalesced while the panel is visible.
+- Diff detail keeps cached content visible and caps background viewed-file checks.
+- Active-session git status refreshes are coalesced and slow full status scans fall back to a limited tracked-only result.
+- Git status, branch-diff, and file-diff reads are routed through a daemon repo coordinator, with branch-diff snapshots owned per repo/base ref and in-flight work shared across connected clients.
+
+The remaining latency gap is not that session navigation blocks on Git. It is that slow repositories can still leave panel-owned Git data in a first-load state when the daemon has no prior snapshot. Clients should keep rendering daemon-owned state and avoid adding independent Git intelligence.
 
 ## Operating Principles
 

--- a/internal/daemon/branch.go
+++ b/internal/daemon/branch.go
@@ -123,7 +123,7 @@ func (d *Daemon) handleGetRepoInfoWS(client *wsClient, msg *protocol.GetRepoInfo
 		commitHash, commitTime := git.GetHeadCommitInfo(repo)
 
 		// Get default branch
-		defaultBranch, _ := git.GetDefaultBranch(repo)
+		defaultBranch, _ := d.coordinator().DefaultBranch(repo)
 		if defaultBranch == "" {
 			defaultBranch = "main"
 		}
@@ -149,7 +149,7 @@ func (d *Daemon) handleGetRepoInfoWS(client *wsClient, msg *protocol.GetRepoInfo
 
 func (d *Daemon) handleGetDefaultBranchWS(client *wsClient, msg *protocol.GetDefaultBranchMessage) {
 	go func() {
-		branch, err := git.GetDefaultBranch(msg.Repo)
+		branch, err := d.coordinator().DefaultBranch(msg.Repo)
 		result := &protocol.WebSocketEvent{
 			Event:   protocol.EventGetDefaultBranchResult,
 			Success: protocol.Ptr(err == nil),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -103,6 +103,8 @@ type Daemon struct {
 	reviewLoopExec   ReviewLoopExecutor
 	repoCaches       map[string]*repoCache
 	repoCacheMu      sync.RWMutex
+	gitCoordMu       sync.Mutex
+	gitCoord         *gitCoordinator
 	warnings         []protocol.DaemonWarning
 	warningsMu       sync.RWMutex
 	ptyBackend       ptybackend.Backend
@@ -329,6 +331,7 @@ func New(socketPath string) *Daemon {
 		hubManager:       nil,
 		reviewLoopExec:   reviewLoopExecutor,
 		repoCaches:       make(map[string]*repoCache),
+		gitCoord:         newGitCoordinator(),
 		warnings:         startupWarnings,
 		ptyBackend:       ptybackend.NewEmbedded(manager),
 		transcriptWatch:  make(map[string]*transcriptWatcher),
@@ -362,6 +365,7 @@ func NewForTesting(socketPath string) *Daemon {
 		ghRegistry:       github.NewClientRegistry(),
 		hubManager:       nil,
 		repoCaches:       make(map[string]*repoCache),
+		gitCoord:         newGitCoordinator(),
 		ptyBackend:       ptybackend.NewEmbedded(manager),
 		transcriptWatch:  make(map[string]*transcriptWatcher),
 		pendingInitialWS: make(map[*wsClient]struct{}),
@@ -398,6 +402,7 @@ func NewWithGitHubClient(socketPath string, ghClient github.GitHubClient) *Daemo
 		ghRegistry:       registry,
 		hubManager:       nil,
 		repoCaches:       make(map[string]*repoCache),
+		gitCoord:         newGitCoordinator(),
 		ptyBackend:       ptybackend.NewEmbedded(manager),
 		transcriptWatch:  make(map[string]*transcriptWatcher),
 		pendingInitialWS: make(map[*wsClient]struct{}),

--- a/internal/daemon/git_coordinator.go
+++ b/internal/daemon/git_coordinator.go
@@ -193,6 +193,7 @@ func (c *gitCoordinator) finishBranchDiffRefresh(key branchDiffCacheKey, refresh
 	if err != nil {
 		refresh.err = err
 		c.mu.Lock()
+		delete(c.branchDiffCache, key)
 		if c.branchDiffActive[key] == refresh {
 			delete(c.branchDiffActive, key)
 		}

--- a/internal/daemon/git_coordinator.go
+++ b/internal/daemon/git_coordinator.go
@@ -1,0 +1,342 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	attngit "github.com/victorarias/attn/internal/git"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+type gitCoordinator struct {
+	mu sync.Mutex
+
+	statusActive map[gitStatusCacheKey]*gitStatusRefresh
+
+	branchDiffCache  map[branchDiffCacheKey]branchDiffSnapshot
+	branchDiffActive map[branchDiffCacheKey]*branchDiffRefresh
+
+	fileDiffActive map[fileDiffCacheKey]*fileDiffRefresh
+}
+
+var (
+	getGitStatusForDaemon       = getGitStatusForSubscription
+	getDefaultBranchForDaemon   = attngit.GetDefaultBranch
+	getBranchDiffFilesForDaemon = attngit.GetBranchDiffFiles
+	readFileDiffForDaemon       = readFileDiff
+)
+
+type gitStatusCacheKey struct {
+	directory string
+	mode      gitStatusMode
+}
+
+type gitStatusRefresh struct {
+	done     chan struct{}
+	status   *protocol.GitStatusUpdateMessage
+	err      error
+	duration time.Duration
+}
+
+type branchDiffCacheKey struct {
+	directory string
+	baseRef   string
+}
+
+type branchDiffSnapshot struct {
+	baseRef string
+	raw     []attngit.DiffFileInfo
+	files   []protocol.BranchDiffFile
+}
+
+type branchDiffRefresh struct {
+	done     chan struct{}
+	snapshot branchDiffSnapshot
+	err      error
+}
+
+type fileDiffCacheKey struct {
+	directory string
+	path      string
+	baseRef   string
+	staged    bool
+}
+
+type fileDiffContent struct {
+	original string
+	modified string
+}
+
+type fileDiffRefresh struct {
+	done    chan struct{}
+	content fileDiffContent
+	err     error
+}
+
+func newGitCoordinator() *gitCoordinator {
+	return &gitCoordinator{
+		statusActive:     make(map[gitStatusCacheKey]*gitStatusRefresh),
+		branchDiffCache:  make(map[branchDiffCacheKey]branchDiffSnapshot),
+		branchDiffActive: make(map[branchDiffCacheKey]*branchDiffRefresh),
+		fileDiffActive:   make(map[fileDiffCacheKey]*fileDiffRefresh),
+	}
+}
+
+func (d *Daemon) coordinator() *gitCoordinator {
+	d.gitCoordMu.Lock()
+	defer d.gitCoordMu.Unlock()
+	if d.gitCoord == nil {
+		d.gitCoord = newGitCoordinator()
+	}
+	return d.gitCoord
+}
+
+func (c *gitCoordinator) Status(directory string, mode gitStatusMode) (*protocol.GitStatusUpdateMessage, time.Duration, error) {
+	key := gitStatusCacheKey{directory: directory, mode: mode}
+
+	c.mu.Lock()
+	if refresh, ok := c.statusActive[key]; ok {
+		done := refresh.done
+		c.mu.Unlock()
+		<-done
+		return cloneGitStatusUpdate(refresh.status), refresh.duration, refresh.err
+	}
+
+	refresh := &gitStatusRefresh{done: make(chan struct{})}
+	c.statusActive[key] = refresh
+	c.mu.Unlock()
+
+	started := time.Now()
+	status, err := getGitStatusForDaemon(directory, mode)
+	refresh.duration = time.Since(started)
+	refresh.status = status
+	refresh.err = err
+
+	c.mu.Lock()
+	if c.statusActive[key] == refresh {
+		delete(c.statusActive, key)
+	}
+	c.mu.Unlock()
+	close(refresh.done)
+
+	return cloneGitStatusUpdate(status), refresh.duration, err
+}
+
+func (c *gitCoordinator) DefaultBranch(directory string) (string, error) {
+	return getDefaultBranchForDaemon(directory)
+}
+
+func (c *gitCoordinator) BranchDiffSnapshot(directory, baseRef string) (branchDiffSnapshot, error) {
+	key := branchDiffCacheKey{directory: directory, baseRef: baseRef}
+
+	c.mu.Lock()
+	if cached, ok := c.branchDiffCache[key]; ok {
+		if _, running := c.branchDiffActive[key]; !running {
+			refresh := &branchDiffRefresh{done: make(chan struct{})}
+			c.branchDiffActive[key] = refresh
+			go c.finishBranchDiffRefresh(key, refresh)
+		}
+		c.mu.Unlock()
+		return cloneBranchDiffSnapshot(cached), nil
+	}
+
+	if refresh, ok := c.branchDiffActive[key]; ok {
+		done := refresh.done
+		c.mu.Unlock()
+		<-done
+		if refresh.err != nil {
+			return branchDiffSnapshot{}, refresh.err
+		}
+		return cloneBranchDiffSnapshot(refresh.snapshot), nil
+	}
+
+	refresh := &branchDiffRefresh{done: make(chan struct{})}
+	c.branchDiffActive[key] = refresh
+	c.mu.Unlock()
+
+	c.finishBranchDiffRefresh(key, refresh)
+	if refresh.err != nil {
+		return branchDiffSnapshot{}, refresh.err
+	}
+	return cloneBranchDiffSnapshot(refresh.snapshot), nil
+}
+
+func (c *gitCoordinator) RefreshBranchDiffFiles(directory, baseRef string) ([]attngit.DiffFileInfo, error) {
+	key := branchDiffCacheKey{directory: directory, baseRef: baseRef}
+
+	c.mu.Lock()
+	if refresh, ok := c.branchDiffActive[key]; ok {
+		done := refresh.done
+		c.mu.Unlock()
+		<-done
+		if refresh.err != nil {
+			return nil, refresh.err
+		}
+		return cloneDiffFileInfos(refresh.snapshot.raw), nil
+	}
+
+	refresh := &branchDiffRefresh{done: make(chan struct{})}
+	c.branchDiffActive[key] = refresh
+	c.mu.Unlock()
+
+	c.finishBranchDiffRefresh(key, refresh)
+	if refresh.err != nil {
+		return nil, refresh.err
+	}
+	return cloneDiffFileInfos(refresh.snapshot.raw), nil
+}
+
+func (c *gitCoordinator) finishBranchDiffRefresh(key branchDiffCacheKey, refresh *branchDiffRefresh) {
+	files, err := getBranchDiffFilesForDaemon(key.directory, key.baseRef)
+	if err != nil {
+		refresh.err = err
+		c.mu.Lock()
+		if c.branchDiffActive[key] == refresh {
+			delete(c.branchDiffActive, key)
+		}
+		c.mu.Unlock()
+		close(refresh.done)
+		return
+	}
+
+	snapshot := branchDiffSnapshot{
+		baseRef: key.baseRef,
+		raw:     cloneDiffFileInfos(files),
+		files:   gitDiffFilesToProtocol(files),
+	}
+	refresh.snapshot = snapshot
+
+	c.mu.Lock()
+	c.branchDiffCache[key] = cloneBranchDiffSnapshot(snapshot)
+	if c.branchDiffActive[key] == refresh {
+		delete(c.branchDiffActive, key)
+	}
+	c.mu.Unlock()
+	close(refresh.done)
+}
+
+func (c *gitCoordinator) FileDiff(directory, path, baseRef string, staged bool) (fileDiffContent, error) {
+	key := fileDiffCacheKey{directory: directory, path: path, baseRef: baseRef, staged: staged}
+
+	c.mu.Lock()
+	if refresh, ok := c.fileDiffActive[key]; ok {
+		done := refresh.done
+		c.mu.Unlock()
+		<-done
+		return refresh.content, refresh.err
+	}
+
+	refresh := &fileDiffRefresh{done: make(chan struct{})}
+	c.fileDiffActive[key] = refresh
+	c.mu.Unlock()
+
+	refresh.content, refresh.err = readFileDiffForDaemon(directory, path, baseRef, staged)
+
+	c.mu.Lock()
+	if c.fileDiffActive[key] == refresh {
+		delete(c.fileDiffActive, key)
+	}
+	c.mu.Unlock()
+	close(refresh.done)
+
+	return refresh.content, refresh.err
+}
+
+func readFileDiff(directory, path, baseRef string, staged bool) (fileDiffContent, error) {
+	content := fileDiffContent{}
+
+	origOutput, origErr := attngit.Output(attngit.OpDiff, directory, "show", baseRef+":"+path)
+	if origErr == nil {
+		content.original = string(origOutput)
+	}
+
+	if staged {
+		stagedOutput, err := attngit.Output(attngit.OpDiff, directory, "show", ":"+path)
+		if err != nil {
+			return fileDiffContent{}, err
+		}
+		content.modified = string(stagedOutput)
+		return content, nil
+	}
+
+	filePath := filepath.Join(directory, path)
+	modified, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			content.modified = ""
+			return content, nil
+		}
+		return fileDiffContent{}, err
+	}
+	content.modified = string(modified)
+	return content, nil
+}
+
+func gitDiffFilesToProtocol(files []attngit.DiffFileInfo) []protocol.BranchDiffFile {
+	protoFiles := make([]protocol.BranchDiffFile, len(files))
+	for i, f := range files {
+		protoFiles[i] = protocol.BranchDiffFile{
+			Path:   f.Path,
+			Status: f.Status,
+		}
+		if f.OldPath != "" {
+			protoFiles[i].OldPath = &f.OldPath
+		}
+		if f.Additions > 0 {
+			protoFiles[i].Additions = &f.Additions
+		}
+		if f.Deletions > 0 {
+			protoFiles[i].Deletions = &f.Deletions
+		}
+		if f.HasUncommitted {
+			protoFiles[i].HasUncommitted = &f.HasUncommitted
+		}
+	}
+	return protoFiles
+}
+
+func cloneGitStatusUpdate(status *protocol.GitStatusUpdateMessage) *protocol.GitStatusUpdateMessage {
+	if status == nil {
+		return nil
+	}
+	cloned := *status
+	cloned.Staged = cloneGitFileChanges(status.Staged)
+	cloned.Unstaged = cloneGitFileChanges(status.Unstaged)
+	cloned.Untracked = cloneGitFileChanges(status.Untracked)
+	return &cloned
+}
+
+func cloneGitFileChanges(files []protocol.GitFileChange) []protocol.GitFileChange {
+	if files == nil {
+		return nil
+	}
+	cloned := make([]protocol.GitFileChange, len(files))
+	copy(cloned, files)
+	return cloned
+}
+
+func cloneBranchDiffSnapshot(snapshot branchDiffSnapshot) branchDiffSnapshot {
+	snapshot.raw = cloneDiffFileInfos(snapshot.raw)
+	snapshot.files = cloneBranchDiffFiles(snapshot.files)
+	return snapshot
+}
+
+func cloneDiffFileInfos(files []attngit.DiffFileInfo) []attngit.DiffFileInfo {
+	if files == nil {
+		return nil
+	}
+	cloned := make([]attngit.DiffFileInfo, len(files))
+	copy(cloned, files)
+	return cloned
+}
+
+func cloneBranchDiffFiles(files []protocol.BranchDiffFile) []protocol.BranchDiffFile {
+	if files == nil {
+		return nil
+	}
+	cloned := make([]protocol.BranchDiffFile, len(files))
+	copy(cloned, files)
+	return cloned
+}

--- a/internal/daemon/gitstatus_test.go
+++ b/internal/daemon/gitstatus_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -444,6 +445,54 @@ func TestBranchDiffSnapshotReturnsCachedResultDuringRefresh(t *testing.T) {
 	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
 		return calls.Load() >= 3
 	})
+}
+
+func TestBranchDiffSnapshotInvalidatesCachedResultAfterRefreshFailure(t *testing.T) {
+	previousGetBranchDiffFiles := getBranchDiffFilesForDaemon
+	var calls atomic.Int32
+	refreshStarted := make(chan struct{})
+	refreshDone := make(chan struct{})
+	refreshErr := errors.New("branch diff unavailable")
+	getBranchDiffFilesForDaemon = func(_, _ string) ([]attngit.DiffFileInfo, error) {
+		switch calls.Add(1) {
+		case 1:
+			return []attngit.DiffFileInfo{{Path: "src/old.ts", Status: "modified"}}, nil
+		case 2:
+			close(refreshStarted)
+			close(refreshDone)
+			return nil, refreshErr
+		default:
+			return nil, refreshErr
+		}
+	}
+	defer func() {
+		getBranchDiffFilesForDaemon = previousGetBranchDiffFiles
+	}()
+
+	d := &Daemon{}
+	first, err := d.coordinator().BranchDiffSnapshot("/repo", "origin/main")
+	if err != nil {
+		t.Fatalf("first BranchDiffSnapshot failed: %v", err)
+	}
+	if got := first.files[0].Path; got != "src/old.ts" {
+		t.Fatalf("first cached path = %q, want old snapshot", got)
+	}
+
+	second, err := d.coordinator().BranchDiffSnapshot("/repo", "origin/main")
+	if err != nil {
+		t.Fatalf("second BranchDiffSnapshot failed: %v", err)
+	}
+	if got := second.files[0].Path; got != "src/old.ts" {
+		t.Fatalf("second cached path = %q, want old snapshot during background refresh", got)
+	}
+
+	<-refreshStarted
+	<-refreshDone
+
+	_, err = d.coordinator().BranchDiffSnapshot("/repo", "origin/main")
+	if !errors.Is(err, refreshErr) {
+		t.Fatalf("third BranchDiffSnapshot error = %v, want %v", err, refreshErr)
+	}
 }
 
 func TestGitCoordinatorSharesInFlightFileDiff(t *testing.T) {

--- a/internal/daemon/gitstatus_test.go
+++ b/internal/daemon/gitstatus_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	attngit "github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -207,6 +208,50 @@ func TestGitStatusSchedulerUsesTrackedOnlyAfterLimitedRefresh(t *testing.T) {
 	}
 }
 
+func TestGitStatusCoordinatorSharesInFlightStatusForRepoAndMode(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	previousGetGitStatus := getGitStatusForDaemon
+	getGitStatusForDaemon = func(dir string, _ gitStatusMode) (*protocol.GitStatusUpdateMessage, error) {
+		call := calls.Add(1)
+		if call == 1 {
+			close(started)
+			<-release
+		}
+		return testGitStatus(dir, "src/shared.ts"), nil
+	}
+	defer func() {
+		getGitStatusForDaemon = previousGetGitStatus
+	}()
+
+	d := &Daemon{}
+	results := make(chan *protocol.GitStatusUpdateMessage, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			status, _, err := d.coordinator().Status("/repo", gitStatusModeFull)
+			if err != nil {
+				t.Errorf("Status failed: %v", err)
+			}
+			results <- status
+		}()
+	}
+
+	<-started
+	time.Sleep(20 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("git status calls while first refresh is in flight = %d, want 1", got)
+	}
+	close(release)
+
+	for i := 0; i < 2; i++ {
+		status := <-results
+		if status == nil || len(status.Unstaged) != 1 || status.Unstaged[0].Path != "src/shared.ts" {
+			t.Fatalf("status = %+v, want shared status result", status)
+		}
+	}
+}
+
 func TestTrackedOnlyStatusResultStaysLimited(t *testing.T) {
 	previousRunGitStatusCommand := runGitStatusCommandForDaemon
 	runGitStatusCommandForDaemon = func(_ string, _ time.Duration, args ...string) ([]byte, error) {
@@ -296,6 +341,152 @@ func TestSameOrNestedPath(t *testing.T) {
 				t.Fatalf("sameOrNestedPath(%q, %q) = %v, want %v", tt.path, tt.dir, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBranchDiffSnapshotSharesInFlightRefreshWithoutCache(t *testing.T) {
+	previousGetBranchDiffFiles := getBranchDiffFilesForDaemon
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	getBranchDiffFilesForDaemon = func(_, _ string) ([]attngit.DiffFileInfo, error) {
+		call := calls.Add(1)
+		if call == 1 {
+			close(started)
+			<-release
+		}
+		return []attngit.DiffFileInfo{{Path: "src/shared.ts", Status: "modified"}}, nil
+	}
+	defer func() {
+		getBranchDiffFilesForDaemon = previousGetBranchDiffFiles
+	}()
+
+	d := &Daemon{}
+	results := make(chan branchDiffSnapshot, 2)
+	errs := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			snapshot, err := d.coordinator().BranchDiffSnapshot("/repo", "origin/main")
+			results <- snapshot
+			errs <- err
+		}()
+	}
+
+	<-started
+	time.Sleep(20 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("branch diff calls while first refresh is in flight = %d, want 1", got)
+	}
+	close(release)
+
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("getBranchDiffSnapshot failed: %v", err)
+		}
+		snapshot := <-results
+		if len(snapshot.files) != 1 || snapshot.files[0].Path != "src/shared.ts" {
+			t.Fatalf("snapshot files = %+v, want shared file", snapshot.files)
+		}
+	}
+}
+
+func TestBranchDiffSnapshotReturnsCachedResultDuringRefresh(t *testing.T) {
+	previousGetBranchDiffFiles := getBranchDiffFilesForDaemon
+	var calls atomic.Int32
+	refreshStarted := make(chan struct{})
+	refreshDone := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	getBranchDiffFilesForDaemon = func(_, _ string) ([]attngit.DiffFileInfo, error) {
+		switch calls.Add(1) {
+		case 1:
+			return []attngit.DiffFileInfo{{Path: "src/old.ts", Status: "modified"}}, nil
+		case 2:
+			close(refreshStarted)
+			<-releaseRefresh
+			close(refreshDone)
+			return []attngit.DiffFileInfo{{Path: "src/new.ts", Status: "modified"}}, nil
+		default:
+			return []attngit.DiffFileInfo{{Path: "src/new.ts", Status: "modified"}}, nil
+		}
+	}
+	defer func() {
+		getBranchDiffFilesForDaemon = previousGetBranchDiffFiles
+	}()
+
+	d := &Daemon{}
+	first, err := d.coordinator().BranchDiffSnapshot("/repo", "origin/main")
+	if err != nil {
+		t.Fatalf("first getBranchDiffSnapshot failed: %v", err)
+	}
+	if got := first.files[0].Path; got != "src/old.ts" {
+		t.Fatalf("first cached path = %q, want old snapshot", got)
+	}
+
+	second, err := d.coordinator().BranchDiffSnapshot("/repo", "origin/main")
+	if err != nil {
+		t.Fatalf("second getBranchDiffSnapshot failed: %v", err)
+	}
+	if got := second.files[0].Path; got != "src/old.ts" {
+		t.Fatalf("second cached path = %q, want old snapshot while refresh runs", got)
+	}
+
+	<-refreshStarted
+	close(releaseRefresh)
+	<-refreshDone
+
+	third, err := d.coordinator().BranchDiffSnapshot("/repo", "origin/main")
+	if err != nil {
+		t.Fatalf("third getBranchDiffSnapshot failed: %v", err)
+	}
+	if got := third.files[0].Path; got != "src/new.ts" {
+		t.Fatalf("third cached path = %q, want refreshed snapshot", got)
+	}
+	waitForGitStatusTestCondition(t, 500*time.Millisecond, func() bool {
+		return calls.Load() >= 3
+	})
+}
+
+func TestGitCoordinatorSharesInFlightFileDiff(t *testing.T) {
+	previousReadFileDiff := readFileDiffForDaemon
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	readFileDiffForDaemon = func(_, _, _ string, _ bool) (fileDiffContent, error) {
+		call := calls.Add(1)
+		if call == 1 {
+			close(started)
+			<-release
+		}
+		return fileDiffContent{original: "before", modified: "after"}, nil
+	}
+	defer func() {
+		readFileDiffForDaemon = previousReadFileDiff
+	}()
+
+	d := &Daemon{}
+	results := make(chan fileDiffContent, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			content, err := d.coordinator().FileDiff("/repo", "src/file.ts", "HEAD", false)
+			if err != nil {
+				t.Errorf("FileDiff failed: %v", err)
+			}
+			results <- content
+		}()
+	}
+
+	<-started
+	time.Sleep(20 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("file diff calls while first refresh is in flight = %d, want 1", got)
+	}
+	close(release)
+
+	for i := 0; i < 2; i++ {
+		content := <-results
+		if content.original != "before" || content.modified != "after" {
+			t.Fatalf("file diff content = %+v, want shared content", content)
+		}
 	}
 }
 

--- a/internal/daemon/review_loop.go
+++ b/internal/daemon/review_loop.go
@@ -666,12 +666,12 @@ func normalizeReviewLoopPaths(repoPath string, candidates ...string) []string {
 }
 
 func (d *Daemon) captureReviewLoopSnapshot(repoPath string) (map[string]attngit.DiffFileInfo, string, error) {
-	defaultBranch, err := attngit.GetDefaultBranch(repoPath)
+	defaultBranch, err := d.coordinator().DefaultBranch(repoPath)
 	if err != nil {
 		return nil, "", err
 	}
 	baseRef := "origin/" + defaultBranch
-	files, err := attngit.GetBranchDiffFiles(repoPath, baseRef)
+	files, err := d.coordinator().RefreshBranchDiffFiles(repoPath, baseRef)
 	if err != nil {
 		return nil, baseRef, err
 	}
@@ -682,7 +682,7 @@ func (d *Daemon) computeReviewLoopIterationChangeStats(repoPath, baseRef string,
 	if baseRef == "" {
 		return nil, nil
 	}
-	files, err := attngit.GetBranchDiffFiles(repoPath, baseRef)
+	files, err := d.coordinator().RefreshBranchDiffFiles(repoPath, baseRef)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/ws_git.go
+++ b/internal/daemon/ws_git.go
@@ -1,12 +1,10 @@
 package daemon
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -32,7 +30,6 @@ var (
 	gitStatusSlowSafetyInterval  = 2 * time.Minute
 	gitStatusSlowRefreshDuration = 5 * time.Second
 	gitStatusFullBudget          = 5 * time.Second
-	getGitStatusForDaemon        = getGitStatusForSubscription
 )
 
 func (d *Daemon) handleSubscribeGitStatus(client *wsClient, msg *protocol.SubscribeGitStatusMessage) {
@@ -119,9 +116,7 @@ func (d *Daemon) sendGitStatusUpdate(client *wsClient, dir string, mode gitStatu
 		return gitStatusRefreshResult{}
 	}
 
-	started := time.Now()
-	status, err := getGitStatusForDaemon(dir, mode)
-	duration := time.Since(started)
+	status, duration, err := d.coordinator().Status(dir, mode)
 	if err != nil {
 		d.logf("Git status error for %s: %v", dir, err)
 		return gitStatusRefreshResult{duration: duration}
@@ -195,40 +190,16 @@ func (d *Daemon) handleGetFileDiff(client *wsClient, msg *protocol.GetFileDiffMe
 		baseRef = *msg.BaseRef
 	}
 
-	origOutput, origErr := git.Output(git.OpDiff, msg.Directory, "show", baseRef+":"+msg.Path)
-
-	var original string
-	if origErr == nil {
-		original = string(origOutput)
+	staged := msg.Staged != nil && *msg.Staged
+	content, err := d.coordinator().FileDiff(msg.Directory, msg.Path, baseRef, staged)
+	if err != nil {
+		result.Error = protocol.Ptr("Failed to read file diff: " + err.Error())
+		d.sendToClient(client, result)
+		return
 	}
 
-	var modified string
-	if msg.Staged != nil && *msg.Staged {
-		stagedOutput, err := git.Output(git.OpDiff, msg.Directory, "show", ":"+msg.Path)
-		if err != nil {
-			result.Error = protocol.Ptr("Failed to read staged file: " + err.Error())
-			d.sendToClient(client, result)
-			return
-		}
-		modified = string(stagedOutput)
-	} else {
-		filePath := filepath.Join(msg.Directory, msg.Path)
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				modified = ""
-			} else {
-				result.Error = protocol.Ptr("Failed to read file: " + err.Error())
-				d.sendToClient(client, result)
-				return
-			}
-		} else {
-			modified = string(content)
-		}
-	}
-
-	result.Original = original
-	result.Modified = modified
+	result.Original = content.original
+	result.Modified = content.modified
 	result.Success = true
 	d.sendToClient(client, result)
 }
@@ -249,7 +220,7 @@ func (d *Daemon) handleGetBranchDiffFiles(client *wsClient, msg *protocol.GetBra
 	if msg.BaseRef != nil && *msg.BaseRef != "" {
 		baseRef = *msg.BaseRef
 	} else {
-		defaultBranch, err := git.GetDefaultBranch(msg.Directory)
+		defaultBranch, err := d.coordinator().DefaultBranch(msg.Directory)
 		if err != nil {
 			result.Error = protocol.Ptr("Failed to get default branch: " + err.Error())
 			d.sendToClient(client, result)
@@ -259,34 +230,14 @@ func (d *Daemon) handleGetBranchDiffFiles(client *wsClient, msg *protocol.GetBra
 	}
 	result.BaseRef = baseRef
 
-	files, err := git.GetBranchDiffFiles(msg.Directory, baseRef)
+	snapshot, err := d.coordinator().BranchDiffSnapshot(msg.Directory, baseRef)
 	if err != nil {
 		result.Error = protocol.Ptr("Failed to get branch diff: " + err.Error())
 		d.sendToClient(client, result)
 		return
 	}
 
-	protoFiles := make([]protocol.BranchDiffFile, len(files))
-	for i, f := range files {
-		protoFiles[i] = protocol.BranchDiffFile{
-			Path:   f.Path,
-			Status: f.Status,
-		}
-		if f.OldPath != "" {
-			protoFiles[i].OldPath = &f.OldPath
-		}
-		if f.Additions > 0 {
-			protoFiles[i].Additions = &f.Additions
-		}
-		if f.Deletions > 0 {
-			protoFiles[i].Deletions = &f.Deletions
-		}
-		if f.HasUncommitted {
-			protoFiles[i].HasUncommitted = &f.HasUncommitted
-		}
-	}
-
-	result.Files = protoFiles
+	result.Files = snapshot.files
 	result.Success = true
 	d.sendToClient(client, result)
 }


### PR DESCRIPTION
## Summary

Routes daemon git status, branch-diff, and file-diff reads through a single daemon-owned git coordinator.

The coordinator shares in-flight work for identical repo keys, owns branch-diff snapshots per repo/base ref, and gives review-loop code a fresh daemon-mediated branch diff path instead of direct git access.

## Why

Large repositories can make even basic git reads slow. When multiple clients or panels request the same status or diff at once, attn should not fan out duplicate git processes. This keeps git visibility daemon-owned so every connected client sees the same coordinator-backed state.

## Validation

- Manual isolated daemon test with a 1s git shim against a full OpenJDK checkout:
  - 2 concurrent `get_branch_diff_files` requests produced one underlying branch diff/status sequence
  - 2 concurrent `subscribe_git_status` clients produced one underlying `git status`
  - 2 concurrent `get_file_diff` requests produced one underlying `git show`
- `go test -race ./internal/daemon -run 'TestGitStatusCoordinator|TestBranchDiffSnapshot|TestGitCoordinatorSharesInFlightFileDiff'`
- `env -u ATTN_SOCKET_PATH -u ATTN_PROFILE -u ATTN_WRAPPER_PATH -u ATTN_INSIDE_APP -u ATTN_DAEMON_MANAGED -u ATTN_PTY_WORKER -u ATTN_SESSION_ID go test ./...`
- `pnpm --dir app exec vitest run src/App.worktreeCleanup.test.tsx src/components/ChangesPanel.test.tsx src/components/DiffDetailPanel.test.tsx`
- `pnpm --dir app run build`
- `git diff --check`