### PR TITLE
feat(plugins): add daemon runtime foundation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,5 @@ require (
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
 	golang.org/x/time v0.14.0
 )
+
+require github.com/BurntSushi/toml v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,6 +186,15 @@ func DataDir() string {
 	return attnDir()
 }
 
+// PluginDir returns the installed plugin directory for the active profile.
+// Priority: ATTN_PLUGIN_DIR env var > per-profile data directory default.
+func PluginDir() string {
+	if envPath := strings.TrimSpace(os.Getenv("ATTN_PLUGIN_DIR")); envPath != "" {
+		return envPath
+	}
+	return filepath.Join(attnDir(), "plugins")
+}
+
 // DataDirForProfile computes the canonical data directory for a given
 // profile name (without reading ATTN_PROFILE). Pass "" for the default
 // profile. Callers use this to probe whether the *other* profile's

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -58,6 +58,24 @@ func TestSocketPath_EnvVarOverridesDefault(t *testing.T) {
 	}
 }
 
+func TestPluginDir_DefaultsToAttnDir(t *testing.T) {
+	os.Unsetenv("ATTN_PLUGIN_DIR")
+	os.Unsetenv("ATTN_PROFILE")
+
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".attn", "plugins")
+	if got := PluginDir(); got != want {
+		t.Errorf("PluginDir() = %q, want %q", got, want)
+	}
+}
+
+func TestPluginDir_EnvVarOverridesDefault(t *testing.T) {
+	t.Setenv("ATTN_PLUGIN_DIR", "/tmp/attn-test-plugins")
+	if got := PluginDir(); got != "/tmp/attn-test-plugins" {
+		t.Errorf("PluginDir() = %q, want %q", got, "/tmp/attn-test-plugins")
+	}
+}
+
 func TestDBPath_ConfigFileOverridesDefault(t *testing.T) {
 	os.Unsetenv("ATTN_DB_PATH")
 	os.Unsetenv("ATTN_PROFILE")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1474,15 +1474,15 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 	defer conn.Close()
 
 	// Legacy hook traffic is one JSON object per connection and does not
-	// consistently include a trailing newline. Keep that first read
-	// opportunistic; plugin-mode connections switch to line framing only
-	// after the JSON-RPC hello has been identified.
-	buf := make([]byte, 65536)
-	n, err := conn.Read(buf)
+	// consistently include a trailing newline. Read exactly one complete
+	// top-level JSON object here; plugin-mode connections switch to line
+	// framing only after their hello has been identified, and any pipelined
+	// bytes stay buffered for that loop.
+	reader := bufio.NewReader(conn)
+	data, err := readInitialSocketFrame(reader, 65536)
 	if err != nil {
 		return
 	}
-	data := buf[:n]
 
 	helloID, helloParams, pluginMode, err := parsePluginHello(data)
 	if pluginMode {
@@ -1490,7 +1490,7 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 			_ = json.NewEncoder(conn).Encode(jsonRPCFailure(helloID, jsonRPCInvalidRequest, err.Error()))
 			return
 		}
-		d.handlePluginConnection(conn, bufio.NewReader(conn), helloID, helloParams)
+		d.handlePluginConnection(conn, reader, helloID, helloParams)
 		return
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -129,6 +130,9 @@ type Daemon struct {
 	startedOnce      sync.Once
 	startedCh        chan struct{}
 	tailscale        *tailscaleRuntime
+	plugins          *pluginRegistry
+	pluginProcesses  *pluginProcessRegistry
+	pluginDir        string
 
 	loginShellEnvMu sync.RWMutex
 	loginShellEnv   []string
@@ -345,6 +349,9 @@ func New(socketPath string) *Daemon {
 		reviewLoopCancel: make(map[string]context.CancelFunc),
 		pendingInputSrc:  make(map[string]string),
 		tailscale:        newTailscaleRuntime(),
+		plugins:          newPluginRegistry(),
+		pluginProcesses:  newPluginProcessRegistry(),
+		pluginDir:        config.PluginDir(),
 		workspaces:       newWorkspaceRegistry(),
 	}
 }
@@ -378,6 +385,8 @@ func NewForTesting(socketPath string) *Daemon {
 		reviewLoopCancel: make(map[string]context.CancelFunc),
 		pendingInputSrc:  make(map[string]string),
 		tailscale:        newTailscaleRuntime(),
+		plugins:          newPluginRegistry(),
+		pluginProcesses:  newPluginProcessRegistry(),
 		workspaces:       newWorkspaceRegistry(),
 	}
 }
@@ -415,6 +424,8 @@ func NewWithGitHubClient(socketPath string, ghClient github.GitHubClient) *Daemo
 		reviewLoopCancel: make(map[string]context.CancelFunc),
 		pendingInputSrc:  make(map[string]string),
 		tailscale:        newTailscaleRuntime(),
+		plugins:          newPluginRegistry(),
+		pluginProcesses:  newPluginProcessRegistry(),
 		workspaces:       newWorkspaceRegistry(),
 	}
 }
@@ -453,6 +464,12 @@ func (d *Daemon) Start() error {
 	}
 	if d.workspaces == nil {
 		d.workspaces = newWorkspaceRegistry()
+	}
+	if d.plugins == nil {
+		d.plugins = newPluginRegistry()
+	}
+	if d.pluginProcesses == nil {
+		d.pluginProcesses = newPluginProcessRegistry()
 	}
 	d.loadWorkspacesFromStore()
 	if d.daemonInstanceID == "" {
@@ -533,6 +550,7 @@ func (d *Daemon) Start() error {
 		if startSucceeded {
 			return
 		}
+		d.stopInstalledPlugins()
 		if d.httpServer != nil {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			_ = d.httpServer.Shutdown(ctx)
@@ -554,6 +572,7 @@ func (d *Daemon) Start() error {
 	}
 	d.listener = listener
 	d.log("daemon started")
+	d.startInstalledPlugins()
 
 	// Start WebSocket hub with daemon's logger
 	d.wsHub.logf = d.logf
@@ -1054,6 +1073,7 @@ func (d *Daemon) Stop() {
 	if d.hubManager != nil {
 		d.hubManager.Stop()
 	}
+	d.stopInstalledPlugins()
 	d.stopAllTranscriptWatchers()
 	if d.ptyBackend != nil {
 		_ = d.ptyBackend.Shutdown(context.Background())
@@ -1453,14 +1473,28 @@ func (d *Daemon) releasePIDLock() {
 func (d *Daemon) handleConnection(conn net.Conn) {
 	defer conn.Close()
 
-	// Read message
+	// Legacy hook traffic is one JSON object per connection and does not
+	// consistently include a trailing newline. Keep that first read
+	// opportunistic; plugin-mode connections switch to line framing only
+	// after the JSON-RPC hello has been identified.
 	buf := make([]byte, 65536)
 	n, err := conn.Read(buf)
 	if err != nil {
 		return
 	}
+	data := buf[:n]
 
-	cmd, msg, err := protocol.ParseMessage(buf[:n])
+	helloID, helloParams, pluginMode, err := parsePluginHello(data)
+	if pluginMode {
+		if err != nil {
+			_ = json.NewEncoder(conn).Encode(jsonRPCFailure(helloID, jsonRPCInvalidRequest, err.Error()))
+			return
+		}
+		d.handlePluginConnection(conn, bufio.NewReader(conn), helloID, helloParams)
+		return
+	}
+
+	cmd, msg, err := protocol.ParseMessage(data)
 	if err != nil {
 		d.sendError(conn, err.Error())
 		return

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3784,8 +3784,8 @@ func TestDaemon_MutePR_ViaWebSocket(t *testing.T) {
 		os.Remove(sockPath)
 	}()
 
-	// Wait for daemon to start
-	time.Sleep(200 * time.Millisecond)
+	// Wait for daemon to start before dialing its Unix socket.
+	waitForSocket(t, sockPath, 5*time.Second)
 
 	// Inject test PR via unix socket
 	testPR := protocol.PR{

--- a/internal/daemon/plugin_rpc.go
+++ b/internal/daemon/plugin_rpc.go
@@ -327,15 +327,85 @@ func (p *pluginConnection) request(ctx context.Context, method string, params in
 }
 
 func readSocketFrame(reader *bufio.Reader) ([]byte, error) {
-	data, err := reader.ReadBytes('\n')
-	data = bytes.TrimSpace(data)
-	if len(data) > 0 {
-		return data, nil
+	for {
+		data, err := reader.ReadBytes('\n')
+		data = bytes.TrimSpace(data)
+		if len(data) > 0 {
+			return data, nil
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
-	if err != nil {
-		return nil, err
+}
+
+func readInitialSocketFrame(reader *bufio.Reader, maxBytes int) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, errors.New("initial socket frame size limit must be positive")
 	}
-	return nil, io.EOF
+
+	var (
+		frame    []byte
+		started  bool
+		depth    int
+		inString bool
+		escaped  bool
+	)
+
+	for len(frame) < maxBytes {
+		b, err := reader.ReadByte()
+		if err != nil {
+			return nil, err
+		}
+		frame = append(frame, b)
+
+		if !started {
+			if isJSONWhitespace(b) {
+				continue
+			}
+			if b != '{' {
+				return nil, errors.New("initial socket frame must be a JSON object")
+			}
+			started = true
+			depth = 1
+			continue
+		}
+
+		if inString {
+			switch {
+			case escaped:
+				escaped = false
+			case b == '\\':
+				escaped = true
+			case b == '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch b {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return bytes.TrimSpace(frame), nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("initial socket frame exceeds %d bytes", maxBytes)
+}
+
+func isJSONWhitespace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\r', '\n':
+		return true
+	default:
+		return false
+	}
 }
 
 func parsePluginHello(data []byte) (json.RawMessage, pluginHelloParams, bool, error) {

--- a/internal/daemon/plugin_rpc.go
+++ b/internal/daemon/plugin_rpc.go
@@ -1,0 +1,474 @@
+package daemon
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const pluginAPIVersion = 1
+
+const (
+	jsonRPCParseError     = -32700
+	jsonRPCInvalidRequest = -32600
+	jsonRPCMethodNotFound = -32601
+	jsonRPCInternalError  = -32603
+)
+
+type pluginHelloParams struct {
+	Name           string   `json:"name"`
+	Version        string   `json:"version"`
+	AttnAPIVersion int      `json:"attn_api_version"`
+	Roles          []string `json:"roles"`
+}
+
+type pluginHelloResult struct {
+	OK bool `json:"ok"`
+}
+
+type providerRegisterParams struct {
+	Surfaces []string `json:"surfaces"`
+	Priority int      `json:"priority,omitempty"`
+}
+
+type providerRegisterResult struct {
+	OK       bool     `json:"ok"`
+	Surfaces []string `json:"surfaces"`
+}
+
+type jsonRPCMessage struct {
+	JSONRPC string          `json:"jsonrpc,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
+}
+
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type pluginRegistry struct {
+	mu        sync.RWMutex
+	plugins   map[string]*pluginConnection
+	providers map[string][]pluginProvider
+}
+
+func newPluginRegistry() *pluginRegistry {
+	return &pluginRegistry{
+		plugins:   make(map[string]*pluginConnection),
+		providers: make(map[string][]pluginProvider),
+	}
+}
+
+func (r *pluginRegistry) register(plugin *pluginConnection) error {
+	if plugin == nil || plugin.name == "" {
+		return errors.New("plugin name is required")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.plugins[plugin.name]; exists {
+		return fmt.Errorf("plugin %q is already connected", plugin.name)
+	}
+	r.plugins[plugin.name] = plugin
+	return nil
+}
+
+func (r *pluginRegistry) unregister(plugin *pluginConnection) {
+	if plugin == nil || plugin.name == "" {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.plugins[plugin.name] == plugin {
+		delete(r.plugins, plugin.name)
+		r.unregisterProvidersLocked(plugin.name)
+	}
+}
+
+func (r *pluginRegistry) get(name string) *pluginConnection {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.plugins[name]
+}
+
+type pluginProvider struct {
+	PluginName string
+	Surface    string
+	Priority   int
+}
+
+func (r *pluginRegistry) registerProvider(plugin *pluginConnection, params providerRegisterParams) ([]string, error) {
+	if plugin == nil || plugin.name == "" {
+		return nil, errors.New("plugin name is required")
+	}
+	if !plugin.hasRole("provider") {
+		return nil, fmt.Errorf("plugin %q did not declare provider role", plugin.name)
+	}
+
+	surfaces := normalizeProviderSurfaces(params.Surfaces)
+	if len(surfaces) == 0 {
+		return nil, errors.New("provider.register requires at least one surface")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.plugins[plugin.name] != plugin {
+		return nil, fmt.Errorf("plugin %q is not connected", plugin.name)
+	}
+
+	r.unregisterProvidersLocked(plugin.name)
+	for _, surface := range surfaces {
+		r.providers[surface] = append(r.providers[surface], pluginProvider{
+			PluginName: plugin.name,
+			Surface:    surface,
+			Priority:   params.Priority,
+		})
+		sort.Slice(r.providers[surface], func(i, j int) bool {
+			left := r.providers[surface][i]
+			right := r.providers[surface][j]
+			if left.Priority != right.Priority {
+				return left.Priority > right.Priority
+			}
+			return left.PluginName < right.PluginName
+		})
+	}
+	return surfaces, nil
+}
+
+func (r *pluginRegistry) providersForSurface(surface string) []pluginProvider {
+	surface = strings.TrimSpace(surface)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	providers := r.providers[surface]
+	if len(providers) == 0 {
+		return nil
+	}
+	out := make([]pluginProvider, len(providers))
+	copy(out, providers)
+	return out
+}
+
+func (r *pluginRegistry) unregisterProvidersLocked(pluginName string) {
+	for surface, providers := range r.providers {
+		filtered := providers[:0]
+		for _, provider := range providers {
+			if provider.PluginName != pluginName {
+				filtered = append(filtered, provider)
+			}
+		}
+		if len(filtered) == 0 {
+			delete(r.providers, surface)
+			continue
+		}
+		r.providers[surface] = filtered
+	}
+}
+
+func normalizeProviderSurfaces(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	surfaces := make([]string, 0, len(values))
+	for _, value := range values {
+		surface := strings.TrimSpace(value)
+		if surface == "" {
+			continue
+		}
+		if _, exists := seen[surface]; exists {
+			continue
+		}
+		seen[surface] = struct{}{}
+		surfaces = append(surfaces, surface)
+	}
+	sort.Strings(surfaces)
+	return surfaces
+}
+
+type pluginConnection struct {
+	name    string
+	version string
+	roles   []string
+
+	conn   net.Conn
+	reader *bufio.Reader
+
+	writeMu sync.Mutex
+
+	pendingMu sync.Mutex
+	pending   map[string]chan jsonRPCMessage
+	nextID    uint64
+	closed    bool
+}
+
+func newPluginConnection(conn net.Conn, reader *bufio.Reader, params pluginHelloParams) *pluginConnection {
+	return &pluginConnection{
+		name:    strings.TrimSpace(params.Name),
+		version: strings.TrimSpace(params.Version),
+		roles:   append([]string(nil), params.Roles...),
+		conn:    conn,
+		reader:  reader,
+		pending: make(map[string]chan jsonRPCMessage),
+	}
+}
+
+func (p *pluginConnection) hasRole(role string) bool {
+	role = strings.TrimSpace(role)
+	for _, candidate := range p.roles {
+		if strings.TrimSpace(candidate) == role {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *pluginConnection) send(msg jsonRPCMessage) error {
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
+	return json.NewEncoder(p.conn).Encode(msg)
+}
+
+func (p *pluginConnection) closePending(err error) {
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+	if p.closed {
+		return
+	}
+	p.closed = true
+	for key, ch := range p.pending {
+		delete(p.pending, key)
+		ch <- jsonRPCMessage{
+			Error: &jsonRPCError{Code: jsonRPCInternalError, Message: err.Error()},
+		}
+	}
+}
+
+func (p *pluginConnection) routeResponse(msg jsonRPCMessage) bool {
+	key := jsonRPCIDKey(msg.ID)
+	if key == "" {
+		return false
+	}
+
+	p.pendingMu.Lock()
+	ch, exists := p.pending[key]
+	if exists {
+		delete(p.pending, key)
+	}
+	p.pendingMu.Unlock()
+	if !exists {
+		return false
+	}
+	ch <- msg
+	return true
+}
+
+func (p *pluginConnection) request(ctx context.Context, method string, params interface{}, result interface{}) error {
+	payload, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("marshal plugin request params: %w", err)
+	}
+
+	p.pendingMu.Lock()
+	if p.closed {
+		p.pendingMu.Unlock()
+		return errors.New("plugin connection is closed")
+	}
+	p.nextID++
+	id := strconv.FormatUint(p.nextID, 10)
+	responseCh := make(chan jsonRPCMessage, 1)
+	p.pending[id] = responseCh
+	p.pendingMu.Unlock()
+
+	request := jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(id),
+		Method:  method,
+		Params:  payload,
+	}
+	if err := p.send(request); err != nil {
+		p.pendingMu.Lock()
+		delete(p.pending, id)
+		p.pendingMu.Unlock()
+		return fmt.Errorf("send plugin request: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		p.pendingMu.Lock()
+		delete(p.pending, id)
+		p.pendingMu.Unlock()
+		return ctx.Err()
+	case response := <-responseCh:
+		if response.Error != nil {
+			return fmt.Errorf("plugin %s: %s", method, response.Error.Message)
+		}
+		if result == nil {
+			return nil
+		}
+		if len(response.Result) == 0 {
+			return fmt.Errorf("plugin %s returned no result", method)
+		}
+		if err := json.Unmarshal(response.Result, result); err != nil {
+			return fmt.Errorf("decode plugin %s result: %w", method, err)
+		}
+		return nil
+	}
+}
+
+func readSocketFrame(reader *bufio.Reader) ([]byte, error) {
+	data, err := reader.ReadBytes('\n')
+	data = bytes.TrimSpace(data)
+	if len(data) > 0 {
+		return data, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return nil, io.EOF
+}
+
+func parsePluginHello(data []byte) (json.RawMessage, pluginHelloParams, bool, error) {
+	var msg jsonRPCMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil, pluginHelloParams{}, false, nil
+	}
+	if msg.JSONRPC == "" && msg.Method == "" {
+		return nil, pluginHelloParams{}, false, nil
+	}
+	if msg.JSONRPC != "2.0" {
+		return msg.ID, pluginHelloParams{}, true, errors.New(`jsonrpc must be "2.0"`)
+	}
+	if msg.Method != "hello" {
+		return msg.ID, pluginHelloParams{}, true, fmt.Errorf("first plugin method must be hello, got %q", msg.Method)
+	}
+	if jsonRPCIDKey(msg.ID) == "" {
+		return msg.ID, pluginHelloParams{}, true, errors.New("hello requires an id")
+	}
+
+	var params pluginHelloParams
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		return msg.ID, pluginHelloParams{}, true, fmt.Errorf("decode hello params: %w", err)
+	}
+	if strings.TrimSpace(params.Name) == "" {
+		return msg.ID, pluginHelloParams{}, true, errors.New("hello params.name is required")
+	}
+	if params.AttnAPIVersion != pluginAPIVersion {
+		return msg.ID, pluginHelloParams{}, true, fmt.Errorf("unsupported attn_api_version %d", params.AttnAPIVersion)
+	}
+	return msg.ID, params, true, nil
+}
+
+func jsonRPCIDKey(id json.RawMessage) string {
+	return string(bytes.TrimSpace(id))
+}
+
+func jsonRPCResult(id json.RawMessage, result interface{}) jsonRPCMessage {
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return jsonRPCFailure(id, jsonRPCInternalError, "marshal JSON-RPC result")
+	}
+	return jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  payload,
+	}
+}
+
+func jsonRPCFailure(id json.RawMessage, code int, message string) jsonRPCMessage {
+	return jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &jsonRPCError{Code: code, Message: message},
+	}
+}
+
+func (d *Daemon) ensurePluginRegistry() *pluginRegistry {
+	if d.plugins == nil {
+		d.plugins = newPluginRegistry()
+	}
+	return d.plugins
+}
+
+func (d *Daemon) handlePluginConnection(conn net.Conn, reader *bufio.Reader, helloID json.RawMessage, params pluginHelloParams) {
+	plugin := newPluginConnection(conn, reader, params)
+	registry := d.ensurePluginRegistry()
+	if err := registry.register(plugin); err != nil {
+		_ = plugin.send(jsonRPCFailure(helloID, jsonRPCInvalidRequest, err.Error()))
+		return
+	}
+	defer func() {
+		registry.unregister(plugin)
+		plugin.closePending(io.EOF)
+	}()
+
+	if err := plugin.send(jsonRPCResult(helloID, pluginHelloResult{OK: true})); err != nil {
+		return
+	}
+
+	for {
+		data, err := readSocketFrame(reader)
+		if err != nil {
+			return
+		}
+
+		var msg jsonRPCMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			_ = plugin.send(jsonRPCFailure(nil, jsonRPCParseError, "parse JSON-RPC message"))
+			continue
+		}
+		if msg.JSONRPC != "2.0" {
+			_ = plugin.send(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, `jsonrpc must be "2.0"`))
+			continue
+		}
+		if msg.Method != "" {
+			d.handlePluginMethod(plugin, msg)
+			continue
+		}
+		if !plugin.routeResponse(msg) {
+			_ = plugin.send(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, "response id is not pending"))
+		}
+	}
+}
+
+func (d *Daemon) handlePluginMethod(plugin *pluginConnection, msg jsonRPCMessage) {
+	if jsonRPCIDKey(msg.ID) == "" {
+		_ = plugin.send(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, "plugin method calls require an id"))
+		return
+	}
+
+	switch msg.Method {
+	case "provider.register":
+		var params providerRegisterParams
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			_ = plugin.send(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, fmt.Sprintf("decode provider.register params: %v", err)))
+			return
+		}
+		surfaces, err := d.ensurePluginRegistry().registerProvider(plugin, params)
+		if err != nil {
+			_ = plugin.send(jsonRPCFailure(msg.ID, jsonRPCInvalidRequest, err.Error()))
+			return
+		}
+		_ = plugin.send(jsonRPCResult(msg.ID, providerRegisterResult{OK: true, Surfaces: surfaces}))
+	default:
+		_ = plugin.send(jsonRPCFailure(msg.ID, jsonRPCMethodNotFound, fmt.Sprintf("unknown method %q", msg.Method)))
+	}
+}
+
+func (d *Daemon) callPlugin(ctx context.Context, name, method string, params interface{}, result interface{}) error {
+	plugin := d.ensurePluginRegistry().get(strings.TrimSpace(name))
+	if plugin == nil {
+		return fmt.Errorf("plugin %q is not connected", name)
+	}
+	return plugin.request(ctx, method, params, result)
+}

--- a/internal/daemon/plugin_rpc_test.go
+++ b/internal/daemon/plugin_rpc_test.go
@@ -1,0 +1,307 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestDaemon_HandleConnection_LegacySocketMessageStillWorks(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handleConnection(serverConn)
+	}()
+
+	heartbeatPayload, err := json.Marshal(protocol.HeartbeatMessage{
+		Cmd: protocol.CmdHeartbeat,
+		ID:  "legacy-session",
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy heartbeat: %v", err)
+	}
+	if _, err := clientConn.Write(heartbeatPayload); err != nil {
+		t.Fatalf("write legacy heartbeat: %v", err)
+	}
+
+	var resp protocol.Response
+	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+		t.Fatalf("decode legacy heartbeat response: %v", err)
+	}
+	if !resp.Ok {
+		t.Fatalf("legacy heartbeat response ok=%v, want true", resp.Ok)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("legacy connection did not finish")
+	}
+}
+
+func TestDaemon_HandleConnection_PluginHelloRegistersLongLivedConnection(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handleConnection(serverConn)
+	}()
+
+	sendPluginHello(t, clientConn, "worktree-provider")
+	helloResp := decodeJSONRPCMessage(t, clientConn)
+	if helloResp.Error != nil {
+		t.Fatalf("hello error = %#v, want nil", helloResp.Error)
+	}
+	var result pluginHelloResult
+	if err := json.Unmarshal(helloResp.Result, &result); err != nil {
+		t.Fatalf("decode hello result: %v", err)
+	}
+	if !result.OK {
+		t.Fatal("hello result ok=false, want true")
+	}
+	if got := d.plugins.get("worktree-provider"); got == nil {
+		t.Fatal("plugin registry missing worktree-provider after hello")
+	}
+
+	_ = clientConn.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("plugin connection did not close after client disconnect")
+	}
+}
+
+func TestDaemon_CallPlugin_RoundTripsRequestAndResponse(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handleConnection(serverConn)
+	}()
+
+	sendPluginHello(t, clientConn, "probe-plugin")
+	helloResp := decodeJSONRPCMessage(t, clientConn)
+	if helloResp.Error != nil {
+		t.Fatalf("hello error = %#v, want nil", helloResp.Error)
+	}
+
+	type probeResult struct {
+		Accepted bool `json:"accepted"`
+	}
+	resultCh := make(chan error, 1)
+	var result probeResult
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		resultCh <- d.callPlugin(ctx, "probe-plugin", "transport.probe", map[string]string{"kind": "roundtrip"}, &result)
+	}()
+
+	request := decodeJSONRPCMessage(t, clientConn)
+	if request.Method != "transport.probe" {
+		t.Fatalf("plugin request method=%q, want transport.probe", request.Method)
+	}
+	var params map[string]string
+	if err := json.Unmarshal(request.Params, &params); err != nil {
+		t.Fatalf("decode plugin request params: %v", err)
+	}
+	if got := params["kind"]; got != "roundtrip" {
+		t.Fatalf("plugin request params.kind=%q, want roundtrip", got)
+	}
+
+	responseResult, err := json.Marshal(probeResult{Accepted: true})
+	if err != nil {
+		t.Fatalf("marshal plugin response result: %v", err)
+	}
+	if err := json.NewEncoder(clientConn).Encode(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      request.ID,
+		Result:  responseResult,
+	}); err != nil {
+		t.Fatalf("encode plugin response: %v", err)
+	}
+
+	select {
+	case err := <-resultCh:
+		if err != nil {
+			t.Fatalf("callPlugin error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("callPlugin did not complete")
+	}
+	if !result.Accepted {
+		t.Fatal("callPlugin result accepted=false, want true")
+	}
+
+	_ = clientConn.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("plugin connection did not close after round trip")
+	}
+}
+
+func TestDaemon_ProviderRegister_OrdersProvidersAndCleansUpOnDisconnect(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+	lowClient, lowDone := startPluginPipe(t, d, "alpha-provider", []string{"provider"})
+	defer lowClient.Close()
+	highClient, highDone := startPluginPipe(t, d, "zeta-provider", []string{"provider"})
+	defer highClient.Close()
+
+	registerProvider(t, lowClient, []string{"worktree.create", "worktree.delete"}, 10)
+	registerProvider(t, highClient, []string{"worktree.create"}, 100)
+
+	providers := d.plugins.providersForSurface("worktree.create")
+	if len(providers) != 2 {
+		t.Fatalf("worktree.create provider count=%d, want 2", len(providers))
+	}
+	if providers[0].PluginName != "zeta-provider" || providers[1].PluginName != "alpha-provider" {
+		t.Fatalf("worktree.create provider order=%v, want zeta-provider then alpha-provider", providers)
+	}
+	deleteProviders := d.plugins.providersForSurface("worktree.delete")
+	if len(deleteProviders) != 1 || deleteProviders[0].PluginName != "alpha-provider" {
+		t.Fatalf("worktree.delete providers=%v, want alpha-provider only", deleteProviders)
+	}
+
+	_ = highClient.Close()
+	select {
+	case <-highDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("high-priority plugin connection did not close")
+	}
+	providers = d.plugins.providersForSurface("worktree.create")
+	if len(providers) != 1 || providers[0].PluginName != "alpha-provider" {
+		t.Fatalf("worktree.create providers after disconnect=%v, want alpha-provider only", providers)
+	}
+
+	_ = lowClient.Close()
+	select {
+	case <-lowDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("low-priority plugin connection did not close")
+	}
+}
+
+func TestDaemon_ProviderRegister_RequiresProviderRole(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	client, done := startPluginPipe(t, d, "observer-only", []string{"observer"})
+	defer client.Close()
+
+	params, err := json.Marshal(providerRegisterParams{Surfaces: []string{"worktree.create"}})
+	if err != nil {
+		t.Fatalf("marshal provider.register params: %v", err)
+	}
+	if err := json.NewEncoder(client).Encode(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("2"),
+		Method:  "provider.register",
+		Params:  params,
+	}); err != nil {
+		t.Fatalf("encode provider.register: %v", err)
+	}
+
+	resp := decodeJSONRPCMessage(t, client)
+	if resp.Error == nil || resp.Error.Code != jsonRPCInvalidRequest {
+		t.Fatalf("provider.register error=%#v, want invalid request", resp.Error)
+	}
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("observer-only plugin connection did not close")
+	}
+}
+
+func startPluginPipe(t *testing.T, d *Daemon, name string, roles []string) (net.Conn, <-chan struct{}) {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handleConnection(serverConn)
+	}()
+
+	sendPluginHelloWithRoles(t, clientConn, name, roles)
+	helloResp := decodeJSONRPCMessage(t, clientConn)
+	if helloResp.Error != nil {
+		t.Fatalf("hello error = %#v, want nil", helloResp.Error)
+	}
+	return clientConn, done
+}
+
+func registerProvider(t *testing.T, conn net.Conn, surfaces []string, priority int) {
+	t.Helper()
+	params, err := json.Marshal(providerRegisterParams{Surfaces: surfaces, Priority: priority})
+	if err != nil {
+		t.Fatalf("marshal provider.register params: %v", err)
+	}
+	if err := json.NewEncoder(conn).Encode(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("2"),
+		Method:  "provider.register",
+		Params:  params,
+	}); err != nil {
+		t.Fatalf("encode provider.register: %v", err)
+	}
+	resp := decodeJSONRPCMessage(t, conn)
+	if resp.Error != nil {
+		t.Fatalf("provider.register error = %#v, want nil", resp.Error)
+	}
+	var result providerRegisterResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("decode provider.register result: %v", err)
+	}
+	if !result.OK {
+		t.Fatal("provider.register result ok=false, want true")
+	}
+}
+
+func sendPluginHello(t *testing.T, conn net.Conn, name string) {
+	sendPluginHelloWithRoles(t, conn, name, []string{"provider"})
+}
+
+func sendPluginHelloWithRoles(t *testing.T, conn net.Conn, name string, roles []string) {
+	t.Helper()
+	params, err := json.Marshal(pluginHelloParams{
+		Name:           name,
+		Version:        "0.1.0",
+		AttnAPIVersion: pluginAPIVersion,
+		Roles:          roles,
+	})
+	if err != nil {
+		t.Fatalf("marshal hello params: %v", err)
+	}
+	if err := json.NewEncoder(conn).Encode(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("1"),
+		Method:  "hello",
+		Params:  params,
+	}); err != nil {
+		t.Fatalf("encode hello: %v", err)
+	}
+}
+
+func decodeJSONRPCMessage(t *testing.T, conn net.Conn) jsonRPCMessage {
+	t.Helper()
+	var msg jsonRPCMessage
+	if err := json.NewDecoder(conn).Decode(&msg); err != nil {
+		t.Fatalf("decode JSON-RPC message: %v", err)
+	}
+	return msg
+}

--- a/internal/daemon/plugin_rpc_test.go
+++ b/internal/daemon/plugin_rpc_test.go
@@ -83,6 +83,129 @@ func TestDaemon_HandleConnection_PluginHelloRegistersLongLivedConnection(t *test
 	}
 }
 
+func TestDaemon_HandleConnection_PluginHelloCanArriveAcrossWrites(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handleConnection(serverConn)
+	}()
+
+	payload, err := json.Marshal(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("1"),
+		Method:  "hello",
+		Params: mustMarshalPluginHelloParams(t, pluginHelloParams{
+			Name:           "split-provider",
+			Version:        "0.1.0",
+			AttnAPIVersion: pluginAPIVersion,
+			Roles:          []string{"provider"},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("marshal split hello: %v", err)
+	}
+
+	splitAt := len(payload) / 2
+	if _, err := clientConn.Write(payload[:splitAt]); err != nil {
+		t.Fatalf("write first hello fragment: %v", err)
+	}
+	if _, err := clientConn.Write(payload[splitAt:]); err != nil {
+		t.Fatalf("write second hello fragment: %v", err)
+	}
+
+	resp := decodeJSONRPCMessage(t, clientConn)
+	if resp.Error != nil {
+		t.Fatalf("split hello error=%#v, want nil", resp.Error)
+	}
+	if got := d.plugins.get("split-provider"); got == nil {
+		t.Fatal("plugin registry missing split-provider after fragmented hello")
+	}
+
+	_ = clientConn.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fragmented plugin connection did not close after client disconnect")
+	}
+}
+
+func TestDaemon_HandleConnection_PluginHelloPreservesPipelinedFrames(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handleConnection(serverConn)
+	}()
+
+	hello, err := json.Marshal(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("1"),
+		Method:  "hello",
+		Params: mustMarshalPluginHelloParams(t, pluginHelloParams{
+			Name:           "pipelined-provider",
+			Version:        "0.1.0",
+			AttnAPIVersion: pluginAPIVersion,
+			Roles:          []string{"provider"},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("marshal pipelined hello: %v", err)
+	}
+	registerParams, err := json.Marshal(providerRegisterParams{
+		Surfaces: []string{"worktree.create"},
+		Priority: 50,
+	})
+	if err != nil {
+		t.Fatalf("marshal pipelined provider params: %v", err)
+	}
+	register, err := json.Marshal(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("2"),
+		Method:  "provider.register",
+		Params:  registerParams,
+	})
+	if err != nil {
+		t.Fatalf("marshal pipelined provider.register: %v", err)
+	}
+
+	payload := append(append(append([]byte(nil), hello...), '\n'), register...)
+	payload = append(payload, '\n')
+	writeErr := make(chan error, 1)
+	go func() {
+		_, err := clientConn.Write(payload)
+		writeErr <- err
+	}()
+
+	if resp := decodeJSONRPCMessage(t, clientConn); resp.Error != nil {
+		t.Fatalf("pipelined hello error=%#v, want nil", resp.Error)
+	}
+	if resp := decodeJSONRPCMessage(t, clientConn); resp.Error != nil {
+		t.Fatalf("pipelined provider.register error=%#v, want nil", resp.Error)
+	}
+	if err := <-writeErr; err != nil {
+		t.Fatalf("write pipelined frames: %v", err)
+	}
+
+	providers := d.plugins.providersForSurface("worktree.create")
+	if len(providers) != 1 || providers[0].PluginName != "pipelined-provider" {
+		t.Fatalf("worktree.create providers=%v, want pipelined-provider only", providers)
+	}
+
+	_ = clientConn.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pipelined plugin connection did not close after client disconnect")
+	}
+}
+
 func TestDaemon_CallPlugin_RoundTripsRequestAndResponse(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	serverConn, clientConn := net.Pipe()
@@ -304,4 +427,13 @@ func decodeJSONRPCMessage(t *testing.T, conn net.Conn) jsonRPCMessage {
 		t.Fatalf("decode JSON-RPC message: %v", err)
 	}
 	return msg
+}
+
+func mustMarshalPluginHelloParams(t *testing.T, params pluginHelloParams) json.RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal hello params: %v", err)
+	}
+	return payload
 }

--- a/internal/daemon/plugin_runtime.go
+++ b/internal/daemon/plugin_runtime.go
@@ -1,0 +1,214 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/BurntSushi/toml"
+)
+
+const pluginManifestName = "attn-plugin.toml"
+
+type pluginManifest struct {
+	Name           string `toml:"name"`
+	Version        string `toml:"version"`
+	AttnAPIVersion int    `toml:"attn_api_version"`
+	Plugin         struct {
+		Entrypoint string `toml:"entrypoint"`
+	} `toml:"plugin"`
+
+	dir string
+}
+
+type pluginManifestIssue struct {
+	Path string
+	Err  error
+}
+
+func (i pluginManifestIssue) Error() string {
+	return fmt.Sprintf("%s: %v", i.Path, i.Err)
+}
+
+func discoverPluginManifests(pluginDir string) ([]pluginManifest, []pluginManifestIssue) {
+	pluginDir = strings.TrimSpace(pluginDir)
+	if pluginDir == "" {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(pluginDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, []pluginManifestIssue{{Path: pluginDir, Err: err}}
+	}
+
+	manifests := make([]pluginManifest, 0, len(entries))
+	var issues []pluginManifestIssue
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		manifestPath := filepath.Join(pluginDir, entry.Name(), pluginManifestName)
+		manifest, err := loadPluginManifest(manifestPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			issues = append(issues, pluginManifestIssue{Path: manifestPath, Err: err})
+			continue
+		}
+		manifests = append(manifests, manifest)
+	}
+
+	sort.Slice(manifests, func(i, j int) bool {
+		return manifests[i].Name < manifests[j].Name
+	})
+	return manifests, issues
+}
+
+func loadPluginManifest(path string) (pluginManifest, error) {
+	var manifest pluginManifest
+	if _, err := toml.DecodeFile(path, &manifest); err != nil {
+		return pluginManifest{}, err
+	}
+
+	manifest.Name = strings.TrimSpace(manifest.Name)
+	manifest.Version = strings.TrimSpace(manifest.Version)
+	manifest.Plugin.Entrypoint = strings.TrimSpace(manifest.Plugin.Entrypoint)
+	manifest.dir = filepath.Dir(path)
+
+	switch {
+	case manifest.Name == "":
+		return pluginManifest{}, errors.New("name is required")
+	case manifest.Version == "":
+		return pluginManifest{}, errors.New("version is required")
+	case manifest.AttnAPIVersion != pluginAPIVersion:
+		return pluginManifest{}, fmt.Errorf("unsupported attn_api_version %d", manifest.AttnAPIVersion)
+	case manifest.Plugin.Entrypoint == "":
+		return pluginManifest{}, errors.New("plugin.entrypoint is required")
+	case filepath.IsAbs(manifest.Plugin.Entrypoint):
+		return pluginManifest{}, errors.New("plugin.entrypoint must be relative to the plugin directory")
+	}
+
+	entrypointPath := filepath.Join(manifest.dir, manifest.Plugin.Entrypoint)
+	if _, err := os.Stat(entrypointPath); err != nil {
+		return pluginManifest{}, fmt.Errorf("plugin.entrypoint %q: %w", manifest.Plugin.Entrypoint, err)
+	}
+	return manifest, nil
+}
+
+type pluginProcessRegistry struct {
+	mu        sync.Mutex
+	processes map[string]*pluginProcess
+}
+
+type pluginProcess struct {
+	manifest pluginManifest
+	cmd      *exec.Cmd
+}
+
+func newPluginProcessRegistry() *pluginProcessRegistry {
+	return &pluginProcessRegistry{processes: make(map[string]*pluginProcess)}
+}
+
+func (r *pluginProcessRegistry) add(process *pluginProcess) error {
+	if process == nil || process.manifest.Name == "" {
+		return errors.New("plugin process name is required")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.processes[process.manifest.Name]; exists {
+		return fmt.Errorf("plugin process %q is already running", process.manifest.Name)
+	}
+	r.processes[process.manifest.Name] = process
+	return nil
+}
+
+func (r *pluginProcessRegistry) remove(name string, process *pluginProcess) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.processes[name] == process {
+		delete(r.processes, name)
+	}
+}
+
+func (r *pluginProcessRegistry) list() []*pluginProcess {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	processes := make([]*pluginProcess, 0, len(r.processes))
+	for _, process := range r.processes {
+		processes = append(processes, process)
+	}
+	return processes
+}
+
+func (d *Daemon) ensurePluginProcessRegistry() *pluginProcessRegistry {
+	if d.pluginProcesses == nil {
+		d.pluginProcesses = newPluginProcessRegistry()
+	}
+	return d.pluginProcesses
+}
+
+func (d *Daemon) startInstalledPlugins() {
+	manifests, issues := discoverPluginManifests(d.pluginDir)
+	for _, issue := range issues {
+		d.logf("plugin manifest skipped: %v", issue)
+	}
+	for _, manifest := range manifests {
+		if err := d.startInstalledPlugin(manifest); err != nil {
+			d.logf("plugin %s failed to start: %v", manifest.Name, err)
+		}
+	}
+}
+
+func (d *Daemon) startInstalledPlugin(manifest pluginManifest) error {
+	cmd := exec.Command("bun", "run", manifest.Plugin.Entrypoint)
+	cmd.Dir = manifest.dir
+	cmd.Env = append(
+		os.Environ(),
+		"ATTN_SOCKET_PATH="+d.socketPath,
+		"ATTN_PLUGIN_NAME="+manifest.Name,
+	)
+
+	process := &pluginProcess{manifest: manifest, cmd: cmd}
+	registry := d.ensurePluginProcessRegistry()
+	if err := registry.add(process); err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		registry.remove(manifest.Name, process)
+		return fmt.Errorf("start bun process: %w", err)
+	}
+
+	go func() {
+		err := cmd.Wait()
+		registry.remove(manifest.Name, process)
+		select {
+		case <-d.done:
+			return
+		default:
+		}
+		if err != nil {
+			d.logf("plugin %s exited: %v", manifest.Name, err)
+			return
+		}
+		d.logf("plugin %s exited", manifest.Name)
+	}()
+	return nil
+}
+
+func (d *Daemon) stopInstalledPlugins() {
+	for _, process := range d.ensurePluginProcessRegistry().list() {
+		if process.cmd == nil || process.cmd.Process == nil {
+			continue
+		}
+		_ = process.cmd.Process.Kill()
+	}
+}

--- a/internal/daemon/plugin_runtime_test.go
+++ b/internal/daemon/plugin_runtime_test.go
@@ -1,0 +1,173 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDiscoverPluginManifests_LoadsValidInstalledPlugins(t *testing.T) {
+	pluginDir := filepath.Join(t.TempDir(), "plugins")
+	writeTestPluginManifest(t, pluginDir, "worktree-provider")
+
+	manifests, issues := discoverPluginManifests(pluginDir)
+	if len(issues) != 0 {
+		t.Fatalf("manifest issues=%v, want none", issues)
+	}
+	if len(manifests) != 1 {
+		t.Fatalf("manifest count=%d, want 1", len(manifests))
+	}
+	if manifests[0].Name != "worktree-provider" {
+		t.Fatalf("manifest name=%q, want worktree-provider", manifests[0].Name)
+	}
+	if manifests[0].Plugin.Entrypoint != "src/index.ts" {
+		t.Fatalf("manifest entrypoint=%q, want src/index.ts", manifests[0].Plugin.Entrypoint)
+	}
+}
+
+func TestDiscoverPluginManifests_ReportsInvalidManifest(t *testing.T) {
+	pluginDir := filepath.Join(t.TempDir(), "plugins")
+	badDir := filepath.Join(pluginDir, "bad-plugin")
+	if err := os.MkdirAll(badDir, 0o755); err != nil {
+		t.Fatalf("mkdir bad plugin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(badDir, pluginManifestName), []byte(`
+name = "bad-plugin"
+version = "0.1.0"
+attn_api_version = 1
+`), 0o644); err != nil {
+		t.Fatalf("write bad manifest: %v", err)
+	}
+
+	manifests, issues := discoverPluginManifests(pluginDir)
+	if len(manifests) != 0 {
+		t.Fatalf("manifests=%v, want none", manifests)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues=%v, want one issue", issues)
+	}
+}
+
+func TestDaemon_StartInstalledPlugins_SpawnsProviderPlugin(t *testing.T) {
+	t.Setenv("ATTN_WS_PORT", "19971")
+	t.Setenv("ATTN_PLUGIN_HELPER", "1")
+	t.Setenv("ATTN_TEST_HELPER_BINARY", os.Args[0])
+
+	tmpDir := shortTempDir(t)
+	sockPath := filepath.Join(tmpDir, "plugin-runtime.sock")
+	pluginDir := filepath.Join(tmpDir, "plugins")
+	writeTestPluginManifest(t, pluginDir, "spawned-provider")
+
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir fake bun dir: %v", err)
+	}
+	bunPath := filepath.Join(binDir, "bun")
+	if err := os.WriteFile(bunPath, []byte("#!/bin/sh\nexec \"$ATTN_TEST_HELPER_BINARY\" -test.run '^TestDaemonPluginProcessHelper$'\n"), 0o755); err != nil {
+		t.Fatalf("write fake bun: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	d := NewForTesting(sockPath)
+	d.pluginDir = pluginDir
+	go d.Start()
+	defer d.Stop()
+
+	waitForSocket(t, sockPath, 5*time.Second)
+	waitForProviders(t, d, "worktree.create", 1, 5*time.Second)
+
+	providers := d.plugins.providersForSurface("worktree.create")
+	if providers[0].PluginName != "spawned-provider" {
+		t.Fatalf("spawned provider=%q, want spawned-provider", providers[0].PluginName)
+	}
+}
+
+func TestDaemonPluginProcessHelper(t *testing.T) {
+	if os.Getenv("ATTN_PLUGIN_HELPER") != "1" {
+		return
+	}
+
+	socketPath := os.Getenv("ATTN_SOCKET_PATH")
+	conn, err := dialPluginHelper(socketPath, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial daemon socket: %v", err)
+	}
+	defer conn.Close()
+
+	name := os.Getenv("ATTN_PLUGIN_NAME")
+	sendPluginHello(t, conn, name)
+	if resp := decodeJSONRPCMessage(t, conn); resp.Error != nil {
+		t.Fatalf("helper hello error=%#v", resp.Error)
+	}
+
+	params, err := json.Marshal(providerRegisterParams{
+		Surfaces: []string{"worktree.create", "worktree.delete"},
+		Priority: 25,
+	})
+	if err != nil {
+		t.Fatalf("marshal helper provider params: %v", err)
+	}
+	if err := json.NewEncoder(conn).Encode(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("2"),
+		Method:  "provider.register",
+		Params:  params,
+	}); err != nil {
+		t.Fatalf("encode helper provider.register: %v", err)
+	}
+	if resp := decodeJSONRPCMessage(t, conn); resp.Error != nil {
+		t.Fatalf("helper provider.register error=%#v", resp.Error)
+	}
+
+	time.Sleep(30 * time.Second)
+}
+
+func writeTestPluginManifest(t *testing.T, pluginDir, name string) {
+	t.Helper()
+	root := filepath.Join(pluginDir, name)
+	entrypointDir := filepath.Join(root, "src")
+	if err := os.MkdirAll(entrypointDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entrypointDir, "index.ts"), []byte("// fake entrypoint\n"), 0o644); err != nil {
+		t.Fatalf("write fake entrypoint: %v", err)
+	}
+	manifest := []byte(`
+name = "` + name + `"
+version = "0.1.0"
+attn_api_version = 1
+
+[plugin]
+entrypoint = "src/index.ts"
+`)
+	if err := os.WriteFile(filepath.Join(root, pluginManifestName), manifest, 0o644); err != nil {
+		t.Fatalf("write plugin manifest: %v", err)
+	}
+}
+
+func waitForProviders(t *testing.T, d *Daemon, surface string, count int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(d.plugins.providersForSurface(surface)) == count {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("surface %s did not reach provider count %d before timeout", surface, count)
+}
+
+func dialPluginHelper(socketPath string, timeout time.Duration) (net.Conn, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("unix", socketPath, 100*time.Millisecond)
+		if err == nil {
+			return conn, nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil, os.ErrDeadlineExceeded
+}

--- a/internal/daemon/testharness.go
+++ b/internal/daemon/testharness.go
@@ -259,6 +259,8 @@ func (b *TestHarnessBuilder) Build() *TestHarness {
 		pendingResumeID:  make(map[string]string),
 		reviewLoopCancel: make(map[string]context.CancelFunc),
 		pendingInputSrc:  make(map[string]string),
+		plugins:          newPluginRegistry(),
+		pluginProcesses:  newPluginProcessRegistry(),
 	}
 
 	return &TestHarness{


### PR DESCRIPTION
## Intent / Why

The plugin-system plan now depends on daemon-owned plugin startup and a real bidirectional transport before we can wire concrete provider operations like worktree creation/deletion. This PR lands that substrate so the next PR can focus on provider dispatch rather than transport mechanics.

Related: #209

## Summary

- add JSON-RPC plugin handshakes on the existing daemon unix socket while preserving legacy one-shot socket traffic
- add a live plugin registry plus provider registration ordering/cleanup so surfaces such as `worktree.create` can be claimed deterministically
- add installed-plugin discovery from `~/.attn/plugins`, TOML manifest validation, and daemon-owned Bun process startup/shutdown
- add `ATTN_PLUGIN_DIR` support for isolated plugin roots in tests/dev loops
- cover transport round trips, provider registration behavior, manifest parsing, and daemon-spawned plugin registration in daemon/config tests

## Test plan

- [x] `go test ./internal/config ./internal/daemon`
- [x] manual smoke: isolated daemon accepts plugin `hello`, keeps the connection open, and still accepts legacy no-newline heartbeat traffic
- [x] manual smoke: isolated daemon discovers a plugin manifest, starts a Bun-shaped plugin process, and observes `provider.register` over the daemon socket
- [ ] follow-up PR wires `worktree.create` / `worktree.delete` through registered providers

## Out of scope

- invoking provider plugins from real worktree operations
- the `attn plugin ...` CLI family and install/update flows
- SDK extraction or non-Bun runtime support
