### PR TITLE
feat(plugins): dispatch worktree providers

### DIFF
--- a/internal/daemon/plugin_worktree.go
+++ b/internal/daemon/plugin_worktree.go
@@ -1,0 +1,168 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/victorarias/attn/internal/git"
+)
+
+const (
+	worktreeCreateProviderSurface = "worktree.create"
+	worktreeDeleteProviderSurface = "worktree.delete"
+
+	providerStatusHandled = "handled"
+	providerStatusDecline = "decline"
+	providerStatusError   = "error"
+)
+
+type worktreeCreateProviderParams struct {
+	MainRepo      string  `json:"main_repo"`
+	Branch        string  `json:"branch"`
+	StartingFrom  string  `json:"starting_from,omitempty"`
+	RequestedPath *string `json:"requested_path"`
+}
+
+type worktreeCreateProviderResult struct {
+	Status string `json:"status"`
+	Path   string `json:"path,omitempty"`
+	Branch string `json:"branch,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+type worktreeDeleteProviderParams struct {
+	MainRepo string `json:"main_repo"`
+	Path     string `json:"path"`
+	Branch   string `json:"branch,omitempty"`
+}
+
+type worktreeDeleteProviderResult struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+func (d *Daemon) dispatchWorktreeCreateProvider(mainRepo, branch, startingFrom, requestedPath string) (string, string, bool, error) {
+	providers := d.ensurePluginRegistry().providersForSurface(worktreeCreateProviderSurface)
+	if len(providers) == 0 {
+		return "", "", false, nil
+	}
+
+	params := worktreeCreateProviderParams{
+		MainRepo:     mainRepo,
+		Branch:       branch,
+		StartingFrom: startingFrom,
+	}
+	if requestedPath != "" {
+		params.RequestedPath = &requestedPath
+	}
+
+	for _, provider := range providers {
+		var result worktreeCreateProviderResult
+		if err := d.callPlugin(context.Background(), provider.PluginName, worktreeCreateProviderSurface, params, &result); err != nil {
+			return "", "", false, fmt.Errorf("worktree provider %q create call failed: %w", provider.PluginName, err)
+		}
+
+		switch strings.TrimSpace(result.Status) {
+		case providerStatusDecline:
+			continue
+		case providerStatusError:
+			return "", "", false, providerOperationError(provider.PluginName, worktreeCreateProviderSurface, result.Error)
+		case providerStatusHandled:
+			path, createdBranch, err := validateCreatedProviderWorktree(mainRepo, result)
+			if err != nil {
+				return "", "", false, fmt.Errorf("worktree provider %q returned invalid create result: %w", provider.PluginName, err)
+			}
+			return path, createdBranch, true, nil
+		default:
+			return "", "", false, fmt.Errorf("worktree provider %q returned unsupported create status %q", provider.PluginName, result.Status)
+		}
+	}
+
+	return "", "", false, nil
+}
+
+func (d *Daemon) dispatchWorktreeDeleteProvider(mainRepo, path, branch string) (bool, error) {
+	providers := d.ensurePluginRegistry().providersForSurface(worktreeDeleteProviderSurface)
+	if len(providers) == 0 {
+		return false, nil
+	}
+
+	params := worktreeDeleteProviderParams{
+		MainRepo: mainRepo,
+		Path:     path,
+		Branch:   branch,
+	}
+	for _, provider := range providers {
+		var result worktreeDeleteProviderResult
+		if err := d.callPlugin(context.Background(), provider.PluginName, worktreeDeleteProviderSurface, params, &result); err != nil {
+			return false, fmt.Errorf("worktree provider %q delete call failed: %w", provider.PluginName, err)
+		}
+
+		switch strings.TrimSpace(result.Status) {
+		case providerStatusDecline:
+			continue
+		case providerStatusError:
+			return false, providerOperationError(provider.PluginName, worktreeDeleteProviderSurface, result.Error)
+		case providerStatusHandled:
+			if err := validateDeletedProviderWorktree(mainRepo, path); err != nil {
+				return false, fmt.Errorf("worktree provider %q returned invalid delete result: %w", provider.PluginName, err)
+			}
+			return true, nil
+		default:
+			return false, fmt.Errorf("worktree provider %q returned unsupported delete status %q", provider.PluginName, result.Status)
+		}
+	}
+
+	return false, nil
+}
+
+func providerOperationError(pluginName, surface, message string) error {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		message = "provider reported an error"
+	}
+	return fmt.Errorf("worktree provider %q %s: %s", pluginName, surface, message)
+}
+
+func validateCreatedProviderWorktree(mainRepo string, result worktreeCreateProviderResult) (string, string, error) {
+	path := git.CanonicalizePath(strings.TrimSpace(result.Path))
+	if path == "" {
+		return "", "", fmt.Errorf("handled create result is missing path")
+	}
+
+	branch := strings.TrimSpace(result.Branch)
+	if branch == "" {
+		return "", "", fmt.Errorf("handled create result is missing branch")
+	}
+
+	worktrees, err := git.ListWorktrees(mainRepo)
+	if err != nil {
+		return "", "", fmt.Errorf("list worktrees: %w", err)
+	}
+	for _, worktree := range worktrees {
+		if git.CanonicalizePath(worktree.Path) != path {
+			continue
+		}
+		if worktree.Branch != branch {
+			return "", "", fmt.Errorf("created worktree branch is %q, provider reported %q", worktree.Branch, branch)
+		}
+		return path, branch, nil
+	}
+
+	return "", "", fmt.Errorf("created path %q is not a worktree of %q", path, mainRepo)
+}
+
+func validateDeletedProviderWorktree(mainRepo, path string) error {
+	expectedPath := git.CanonicalizePath(path)
+	worktrees, err := git.ListWorktrees(mainRepo)
+	if err != nil {
+		return fmt.Errorf("list worktrees: %w", err)
+	}
+	for _, worktree := range worktrees {
+		if git.CanonicalizePath(worktree.Path) == expectedPath {
+			return fmt.Errorf("deleted path %q is still a worktree of %q", expectedPath, mainRepo)
+		}
+	}
+	return nil
+}

--- a/internal/daemon/plugin_worktree.go
+++ b/internal/daemon/plugin_worktree.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/victorarias/attn/internal/git"
 )
@@ -11,6 +12,7 @@ import (
 const (
 	worktreeCreateProviderSurface = "worktree.create"
 	worktreeDeleteProviderSurface = "worktree.delete"
+	worktreeProviderCallTimeout   = 30 * time.Second
 
 	providerStatusHandled = "handled"
 	providerStatusDecline = "decline"
@@ -47,6 +49,10 @@ func (d *Daemon) dispatchWorktreeCreateProvider(mainRepo, branch, startingFrom, 
 	if len(providers) == 0 {
 		return "", "", false, nil
 	}
+	preExisting, err := currentWorktreePathSet(mainRepo)
+	if err != nil {
+		return "", "", false, fmt.Errorf("list worktrees before provider create: %w", err)
+	}
 
 	params := worktreeCreateProviderParams{
 		MainRepo:     mainRepo,
@@ -59,7 +65,10 @@ func (d *Daemon) dispatchWorktreeCreateProvider(mainRepo, branch, startingFrom, 
 
 	for _, provider := range providers {
 		var result worktreeCreateProviderResult
-		if err := d.callPlugin(context.Background(), provider.PluginName, worktreeCreateProviderSurface, params, &result); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), worktreeProviderCallTimeout)
+		err := d.callPlugin(ctx, provider.PluginName, worktreeCreateProviderSurface, params, &result)
+		cancel()
+		if err != nil {
 			return "", "", false, fmt.Errorf("worktree provider %q create call failed: %w", provider.PluginName, err)
 		}
 
@@ -69,7 +78,7 @@ func (d *Daemon) dispatchWorktreeCreateProvider(mainRepo, branch, startingFrom, 
 		case providerStatusError:
 			return "", "", false, providerOperationError(provider.PluginName, worktreeCreateProviderSurface, result.Error)
 		case providerStatusHandled:
-			path, createdBranch, err := validateCreatedProviderWorktree(mainRepo, result)
+			path, createdBranch, err := validateCreatedProviderWorktree(mainRepo, result, preExisting)
 			if err != nil {
 				return "", "", false, fmt.Errorf("worktree provider %q returned invalid create result: %w", provider.PluginName, err)
 			}
@@ -95,7 +104,10 @@ func (d *Daemon) dispatchWorktreeDeleteProvider(mainRepo, path, branch string) (
 	}
 	for _, provider := range providers {
 		var result worktreeDeleteProviderResult
-		if err := d.callPlugin(context.Background(), provider.PluginName, worktreeDeleteProviderSurface, params, &result); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), worktreeProviderCallTimeout)
+		err := d.callPlugin(ctx, provider.PluginName, worktreeDeleteProviderSurface, params, &result)
+		cancel()
+		if err != nil {
 			return false, fmt.Errorf("worktree provider %q delete call failed: %w", provider.PluginName, err)
 		}
 
@@ -125,10 +137,13 @@ func providerOperationError(pluginName, surface, message string) error {
 	return fmt.Errorf("worktree provider %q %s: %s", pluginName, surface, message)
 }
 
-func validateCreatedProviderWorktree(mainRepo string, result worktreeCreateProviderResult) (string, string, error) {
+func validateCreatedProviderWorktree(mainRepo string, result worktreeCreateProviderResult, preExisting map[string]bool) (string, string, error) {
 	path := git.CanonicalizePath(strings.TrimSpace(result.Path))
 	if path == "" {
 		return "", "", fmt.Errorf("handled create result is missing path")
+	}
+	if preExisting[path] {
+		return "", "", fmt.Errorf("handled create result path %q already existed before provider create", path)
 	}
 
 	branch := strings.TrimSpace(result.Branch)
@@ -151,6 +166,18 @@ func validateCreatedProviderWorktree(mainRepo string, result worktreeCreateProvi
 	}
 
 	return "", "", fmt.Errorf("created path %q is not a worktree of %q", path, mainRepo)
+}
+
+func currentWorktreePathSet(mainRepo string) (map[string]bool, error) {
+	worktrees, err := git.ListWorktrees(mainRepo)
+	if err != nil {
+		return nil, err
+	}
+	paths := make(map[string]bool, len(worktrees))
+	for _, worktree := range worktrees {
+		paths[git.CanonicalizePath(worktree.Path)] = true
+	}
+	return paths, nil
 }
 
 func validateDeletedProviderWorktree(mainRepo, path string) error {

--- a/internal/daemon/plugin_worktree_test.go
+++ b/internal/daemon/plugin_worktree_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -47,7 +48,7 @@ func TestDoCreateWorktree_ProviderHandledRegistersValidatedWorktree(t *testing.T
 	if err != nil {
 		t.Fatalf("doCreateWorktree failed: %v", err)
 	}
-	<-responseDone
+	waitForProviderResponse(t, responseDone)
 
 	if canonicalPathDaemon(path) != canonicalPathDaemon(providerPath) {
 		t.Fatalf("created path=%q, want %q", path, providerPath)
@@ -83,7 +84,7 @@ func TestDoCreateWorktree_ProviderDeclineFallsBackToBuiltInGit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("doCreateWorktree fallback failed: %v", err)
 	}
-	<-responseDone
+	waitForProviderResponse(t, responseDone)
 
 	wantPath := git.GenerateWorktreePath(mainDir, "feat/fallback-create")
 	if canonicalPathDaemon(path) != canonicalPathDaemon(wantPath) {
@@ -123,7 +124,7 @@ func TestDoCreateWorktree_ProviderHandledPathMustBeRealExpectedWorktree(t *testi
 	}); err == nil {
 		t.Fatal("doCreateWorktree error=nil, want invalid provider result")
 	}
-	<-responseDone
+	waitForProviderResponse(t, responseDone)
 
 	_ = client.Close()
 	select {
@@ -162,7 +163,7 @@ func TestDoDeleteWorktree_ProviderHandledFinalizesDaemonState(t *testing.T) {
 	if err := d.doDeleteWorktree(worktreePath, nil); err != nil {
 		t.Fatalf("doDeleteWorktree failed: %v", err)
 	}
-	<-responseDone
+	waitForProviderResponse(t, responseDone)
 
 	if wt := d.store.GetWorktree(worktreePath); wt != nil {
 		t.Fatalf("expected deleted worktree removed from store, got %#v", wt)
@@ -201,18 +202,20 @@ func respondToCreateProviderCall(
 	t *testing.T,
 	conn net.Conn,
 	handle func(worktreeCreateProviderParams) worktreeCreateProviderResult,
-) <-chan struct{} {
+) <-chan error {
 	t.Helper()
-	done := make(chan struct{})
+	done := make(chan error, 1)
 	go func() {
 		defer close(done)
 		request := decodeJSONRPCMessage(t, conn)
 		if request.Method != worktreeCreateProviderSurface {
-			t.Fatalf("provider method=%q, want %s", request.Method, worktreeCreateProviderSurface)
+			done <- fmt.Errorf("provider method=%q, want %s", request.Method, worktreeCreateProviderSurface)
+			return
 		}
 		var params worktreeCreateProviderParams
 		if err := json.Unmarshal(request.Params, &params); err != nil {
-			t.Fatalf("decode create provider params: %v", err)
+			done <- fmt.Errorf("decode create provider params: %w", err)
+			return
 		}
 		writeProviderResult(t, conn, request.ID, handle(params))
 	}()
@@ -223,22 +226,31 @@ func respondToDeleteProviderCall(
 	t *testing.T,
 	conn net.Conn,
 	handle func(worktreeDeleteProviderParams) worktreeDeleteProviderResult,
-) <-chan struct{} {
+) <-chan error {
 	t.Helper()
-	done := make(chan struct{})
+	done := make(chan error, 1)
 	go func() {
 		defer close(done)
 		request := decodeJSONRPCMessage(t, conn)
 		if request.Method != worktreeDeleteProviderSurface {
-			t.Fatalf("provider method=%q, want %s", request.Method, worktreeDeleteProviderSurface)
+			done <- fmt.Errorf("provider method=%q, want %s", request.Method, worktreeDeleteProviderSurface)
+			return
 		}
 		var params worktreeDeleteProviderParams
 		if err := json.Unmarshal(request.Params, &params); err != nil {
-			t.Fatalf("decode delete provider params: %v", err)
+			done <- fmt.Errorf("decode delete provider params: %w", err)
+			return
 		}
 		writeProviderResult(t, conn, request.ID, handle(params))
 	}()
 	return done
+}
+
+func waitForProviderResponse(t *testing.T, done <-chan error) {
+	t.Helper()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
 }
 
 func writeProviderResult(t *testing.T, conn net.Conn, id json.RawMessage, result interface{}) {

--- a/internal/daemon/plugin_worktree_test.go
+++ b/internal/daemon/plugin_worktree_test.go
@@ -1,0 +1,257 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/git"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestDoCreateWorktree_ProviderHandledRegistersValidatedWorktree(t *testing.T) {
+	tmpDir, mainDir := initProviderTestRepo(t)
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+
+	client, done := startPluginPipe(t, d, "custom-create-provider", []string{"provider"})
+	defer client.Close()
+	registerProvider(t, client, []string{worktreeCreateProviderSurface}, 100)
+
+	providerPath := filepath.Join(tmpDir, "provider-created")
+	responseDone := respondToCreateProviderCall(t, client, func(params worktreeCreateProviderParams) worktreeCreateProviderResult {
+		if params.MainRepo != git.ResolveMainRepoPath(mainDir) {
+			t.Fatalf("provider main repo=%q, want %q", params.MainRepo, git.ResolveMainRepoPath(mainDir))
+		}
+		if params.Branch != "feat/provider-create" {
+			t.Fatalf("provider branch=%q, want feat/provider-create", params.Branch)
+		}
+		if params.RequestedPath != nil {
+			t.Fatalf("provider requested path=%q, want nil", *params.RequestedPath)
+		}
+
+		runGitDaemon(t, mainDir, "worktree", "add", "-b", params.Branch, providerPath)
+		return worktreeCreateProviderResult{
+			Status: providerStatusHandled,
+			Path:   providerPath,
+			Branch: params.Branch,
+		}
+	})
+
+	path, err := d.doCreateWorktree(&protocol.CreateWorktreeMessage{
+		MainRepo: mainDir,
+		Branch:   "feat/provider-create",
+	})
+	if err != nil {
+		t.Fatalf("doCreateWorktree failed: %v", err)
+	}
+	<-responseDone
+
+	if canonicalPathDaemon(path) != canonicalPathDaemon(providerPath) {
+		t.Fatalf("created path=%q, want %q", path, providerPath)
+	}
+	if wt := d.store.GetWorktree(git.CanonicalizePath(providerPath)); wt == nil {
+		t.Fatalf("expected provider-created worktree %q in store", providerPath)
+	}
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("create provider connection did not close")
+	}
+}
+
+func TestDoCreateWorktree_ProviderDeclineFallsBackToBuiltInGit(t *testing.T) {
+	tmpDir, mainDir := initProviderTestRepo(t)
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+
+	client, done := startPluginPipe(t, d, "declining-create-provider", []string{"provider"})
+	defer client.Close()
+	registerProvider(t, client, []string{worktreeCreateProviderSurface}, 100)
+
+	responseDone := respondToCreateProviderCall(t, client, func(params worktreeCreateProviderParams) worktreeCreateProviderResult {
+		return worktreeCreateProviderResult{Status: providerStatusDecline}
+	})
+
+	path, err := d.doCreateWorktree(&protocol.CreateWorktreeMessage{
+		MainRepo: mainDir,
+		Branch:   "feat/fallback-create",
+	})
+	if err != nil {
+		t.Fatalf("doCreateWorktree fallback failed: %v", err)
+	}
+	<-responseDone
+
+	wantPath := git.GenerateWorktreePath(mainDir, "feat/fallback-create")
+	if canonicalPathDaemon(path) != canonicalPathDaemon(wantPath) {
+		t.Fatalf("fallback path=%q, want generated git worktree path", path)
+	}
+	if wt := d.store.GetWorktree(path); wt == nil {
+		t.Fatalf("expected fallback-created worktree %q in store", path)
+	}
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("declining create provider connection did not close")
+	}
+}
+
+func TestDoCreateWorktree_ProviderHandledPathMustBeRealExpectedWorktree(t *testing.T) {
+	tmpDir, mainDir := initProviderTestRepo(t)
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+
+	client, done := startPluginPipe(t, d, "invalid-create-provider", []string{"provider"})
+	defer client.Close()
+	registerProvider(t, client, []string{worktreeCreateProviderSurface}, 100)
+
+	responseDone := respondToCreateProviderCall(t, client, func(params worktreeCreateProviderParams) worktreeCreateProviderResult {
+		return worktreeCreateProviderResult{
+			Status: providerStatusHandled,
+			Path:   filepath.Join(tmpDir, "not-a-worktree"),
+			Branch: params.Branch,
+		}
+	})
+
+	if _, err := d.doCreateWorktree(&protocol.CreateWorktreeMessage{
+		MainRepo: mainDir,
+		Branch:   "feat/invalid-create",
+	}); err == nil {
+		t.Fatal("doCreateWorktree error=nil, want invalid provider result")
+	}
+	<-responseDone
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("invalid create provider connection did not close")
+	}
+}
+
+func TestDoDeleteWorktree_ProviderHandledFinalizesDaemonState(t *testing.T) {
+	tmpDir, mainDir := initProviderTestRepo(t)
+	worktreePath := filepath.Join(tmpDir, "provider-delete")
+	runGitDaemon(t, mainDir, "worktree", "add", "-b", "feat/provider-delete", worktreePath)
+	worktreePath = git.CanonicalizePath(worktreePath)
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	d.registerCreatedWorktree(mainDir, worktreePath, "feat/provider-delete")
+
+	client, done := startPluginPipe(t, d, "custom-delete-provider", []string{"provider"})
+	defer client.Close()
+	registerProvider(t, client, []string{worktreeDeleteProviderSurface}, 100)
+
+	responseDone := respondToDeleteProviderCall(t, client, func(params worktreeDeleteProviderParams) worktreeDeleteProviderResult {
+		if params.Path != worktreePath {
+			t.Fatalf("provider delete path=%q, want %q", params.Path, worktreePath)
+		}
+		if params.Branch != "feat/provider-delete" {
+			t.Fatalf("provider delete branch=%q, want feat/provider-delete", params.Branch)
+		}
+		if err := git.DeleteWorktree(mainDir, worktreePath); err != nil {
+			t.Fatalf("provider delete worktree failed: %v", err)
+		}
+		return worktreeDeleteProviderResult{Status: providerStatusHandled}
+	})
+
+	if err := d.doDeleteWorktree(worktreePath, nil); err != nil {
+		t.Fatalf("doDeleteWorktree failed: %v", err)
+	}
+	<-responseDone
+
+	if wt := d.store.GetWorktree(worktreePath); wt != nil {
+		t.Fatalf("expected deleted worktree removed from store, got %#v", wt)
+	}
+	worktrees, err := git.ListWorktrees(mainDir)
+	if err != nil {
+		t.Fatalf("list worktrees after provider delete: %v", err)
+	}
+	for _, worktree := range worktrees {
+		if worktree.Path == worktreePath {
+			t.Fatalf("provider-deleted worktree still listed: %#v", worktree)
+		}
+	}
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("delete provider connection did not close")
+	}
+}
+
+func initProviderTestRepo(t *testing.T) (string, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	mainDir := filepath.Join(tmpDir, "main")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		t.Fatalf("mkdir main repo: %v", err)
+	}
+	runGitDaemon(t, mainDir, "init")
+	runGitDaemon(t, mainDir, "commit", "--allow-empty", "-m", "init")
+	return tmpDir, git.ResolveMainRepoPath(mainDir)
+}
+
+func respondToCreateProviderCall(
+	t *testing.T,
+	conn net.Conn,
+	handle func(worktreeCreateProviderParams) worktreeCreateProviderResult,
+) <-chan struct{} {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		request := decodeJSONRPCMessage(t, conn)
+		if request.Method != worktreeCreateProviderSurface {
+			t.Fatalf("provider method=%q, want %s", request.Method, worktreeCreateProviderSurface)
+		}
+		var params worktreeCreateProviderParams
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			t.Fatalf("decode create provider params: %v", err)
+		}
+		writeProviderResult(t, conn, request.ID, handle(params))
+	}()
+	return done
+}
+
+func respondToDeleteProviderCall(
+	t *testing.T,
+	conn net.Conn,
+	handle func(worktreeDeleteProviderParams) worktreeDeleteProviderResult,
+) <-chan struct{} {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		request := decodeJSONRPCMessage(t, conn)
+		if request.Method != worktreeDeleteProviderSurface {
+			t.Fatalf("provider method=%q, want %s", request.Method, worktreeDeleteProviderSurface)
+		}
+		var params worktreeDeleteProviderParams
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			t.Fatalf("decode delete provider params: %v", err)
+		}
+		writeProviderResult(t, conn, request.ID, handle(params))
+	}()
+	return done
+}
+
+func writeProviderResult(t *testing.T, conn net.Conn, id json.RawMessage, result interface{}) {
+	t.Helper()
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal provider result: %v", err)
+	}
+	if err := json.NewEncoder(conn).Encode(jsonRPCMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  payload,
+	}); err != nil {
+		t.Fatalf("encode provider result: %v", err)
+	}
+}

--- a/internal/daemon/plugin_worktree_test.go
+++ b/internal/daemon/plugin_worktree_test.go
@@ -134,6 +134,40 @@ func TestDoCreateWorktree_ProviderHandledPathMustBeRealExpectedWorktree(t *testi
 	}
 }
 
+func TestDoCreateWorktree_ProviderHandledPathMustBeNewWorktree(t *testing.T) {
+	tmpDir, mainDir := initProviderTestRepo(t)
+	existingPath := filepath.Join(tmpDir, "existing")
+	runGitDaemon(t, mainDir, "worktree", "add", "-b", "feat/existing", existingPath)
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	client, done := startPluginPipe(t, d, "existing-create-provider", []string{"provider"})
+	defer client.Close()
+	registerProvider(t, client, []string{worktreeCreateProviderSurface}, 100)
+
+	responseDone := respondToCreateProviderCall(t, client, func(params worktreeCreateProviderParams) worktreeCreateProviderResult {
+		return worktreeCreateProviderResult{
+			Status: providerStatusHandled,
+			Path:   existingPath,
+			Branch: "feat/existing",
+		}
+	})
+
+	if _, err := d.doCreateWorktree(&protocol.CreateWorktreeMessage{
+		MainRepo: mainDir,
+		Branch:   "feat/new-request",
+	}); err == nil {
+		t.Fatal("doCreateWorktree error=nil, want pre-existing provider result rejected")
+	}
+	waitForProviderResponse(t, responseDone)
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("existing create provider connection did not close")
+	}
+}
+
 func TestDoDeleteWorktree_ProviderHandledFinalizesDaemonState(t *testing.T) {
 	tmpDir, mainDir := initProviderTestRepo(t)
 	worktreePath := filepath.Join(tmpDir, "provider-delete")

--- a/internal/daemon/worktree.go
+++ b/internal/daemon/worktree.go
@@ -99,13 +99,23 @@ func (d *Daemon) doListWorktrees(mainRepo string) []protocol.Worktree {
 func (d *Daemon) doCreateWorktree(msg *protocol.CreateWorktreeMessage) (string, error) {
 	mainRepo := git.ResolveMainRepoPath(msg.MainRepo)
 
-	path := protocol.Deref(msg.Path)
+	requestedPath := protocol.Deref(msg.Path)
+	path := requestedPath
 	if path == "" {
 		path = git.GenerateWorktreePath(mainRepo, msg.Branch)
 	}
 	path = git.CanonicalizePath(path)
 
 	startingFrom := protocol.Deref(msg.StartingFrom)
+	providerPath, providerBranch, handled, err := d.dispatchWorktreeCreateProvider(mainRepo, msg.Branch, startingFrom, requestedPath)
+	if err != nil {
+		return "", err
+	}
+	if handled {
+		d.registerCreatedWorktree(mainRepo, providerPath, providerBranch)
+		return providerPath, nil
+	}
+
 	// If starting from a remote tracking ref (e.g. "origin/main"), fetch it
 	// first so the worktree is created from the latest upstream commit.
 	// Guard against local branches that happen to contain "/" (e.g. "feat/x")
@@ -117,19 +127,24 @@ func (d *Daemon) doCreateWorktree(msg *protocol.CreateWorktreeMessage) (string, 
 			}
 		}
 	}
-	var err error
+	var createErr error
 	if startingFrom != "" {
-		err = git.CreateWorktreeFromPoint(mainRepo, msg.Branch, path, startingFrom)
+		createErr = git.CreateWorktreeFromPoint(mainRepo, msg.Branch, path, startingFrom)
 	} else {
-		err = git.CreateWorktree(mainRepo, msg.Branch, path)
+		createErr = git.CreateWorktree(mainRepo, msg.Branch, path)
 	}
-	if err != nil {
-		return "", err
+	if createErr != nil {
+		return "", createErr
 	}
 
+	d.registerCreatedWorktree(mainRepo, path, msg.Branch)
+	return path, nil
+}
+
+func (d *Daemon) registerCreatedWorktree(mainRepo, path, branch string) {
 	wt := &store.Worktree{
 		Path:      path,
-		Branch:    msg.Branch,
+		Branch:    branch,
 		MainRepo:  mainRepo,
 		CreatedAt: time.Now(),
 	}
@@ -145,8 +160,6 @@ func (d *Daemon) doCreateWorktree(msg *protocol.CreateWorktreeMessage) (string, 
 			CreatedAt: protocol.Ptr(wt.CreatedAt.Format(time.RFC3339)),
 		}},
 	})
-
-	return path, nil
 }
 
 // discoverWorktree tries to find a worktree from git state when it's not in the registry.
@@ -232,31 +245,40 @@ func (d *Daemon) doDeleteWorktree(path string, endpointID *string) (err error) {
 	branch := wt.Branch
 	mainRepo := wt.MainRepo
 
-	if err := git.DeleteWorktree(mainRepo, path); err != nil {
+	handled, err := d.dispatchWorktreeDeleteProvider(mainRepo, path, branch)
+	if err != nil {
 		return err
 	}
+	if !handled {
+		if err := git.DeleteWorktree(mainRepo, path); err != nil {
+			return err
+		}
+	}
 
+	d.finalizeDeletedWorktree(path, mainRepo, branch)
+	return nil
+}
+
+func (d *Daemon) finalizeDeletedWorktree(path, mainRepo, branch string) {
 	d.store.RemoveWorktree(path)
 
-	// Also delete the branch (force=true since worktree is already deleted)
+	// Also delete the branch (force=true since worktree is already deleted).
 	if branch != "" {
 		if err := git.DeleteBranch(mainRepo, branch, true); err != nil {
 			d.logf("Warning: worktree deleted but failed to delete branch %s: %v", branch, err)
-			// Don't fail the whole operation - worktree is already deleted
+			// Don't fail the whole operation - worktree is already deleted.
 		} else {
 			d.logf("Deleted branch %s along with worktree", branch)
 		}
 	}
 
-	// Broadcast deleted event to all clients
+	// Broadcast deleted event to all clients.
 	d.wsHub.Broadcast(&protocol.WebSocketEvent{
 		Event: protocol.EventWorktreeDeleted,
 		Worktrees: []protocol.Worktree{{
 			Path: path,
 		}},
 	})
-
-	return nil
 }
 
 type worktreeNotFoundError struct {


### PR DESCRIPTION
## Intent / Why

PR #210 established daemon-owned plugin startup, JSON-RPC transport, and provider registration. The plugin plan only becomes useful for the initial services-pilot worktree use case once registered providers can participate in the daemon's real worktree operations.

Related: #210, #209

## Summary

- offer `worktree.create` to registered providers before the built-in Git path, accepting `handled`, `decline`, or `error` results
- validate handled create results against actual Git worktree state before registering the path in attn
- offer `worktree.delete` to registered providers, validate that handled deletes removed the Git worktree, then keep daemon-owned store cleanup, branch cleanup, and broadcasts intact
- preserve built-in Git fallback when providers decline or no provider is registered
- cover handled create/delete, decline fallback, and invalid handled-create results with daemon tests

## Test plan

- [x] `go test ./internal/daemon -run 'TestDo(Create|Delete)Worktree_Provider|TestDoCreateWorktree_ResolvesMainRepoFromWorktree|TestDoDeleteWorktree_BroadcastsGitOperationLifecycle'`\n- [x] `go test ./internal/config ./internal/daemon`\n- [ ] follow-up proving plugin mirrors the user-owned `wt-create` / `wt-remove` policy for services-pilot\n\n## Out of scope\n\n- `create_worktree_from_branch` provider dispatch; this PR wires the planned `worktree.create` / `worktree.delete` surfaces first\n- plugin install/list/update CLI flows\n- SDK extraction\n