### PR TITLE
feat(plugins): add lifecycle cli and branch dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-05-21]
+
+### Added
+- **Plugin Lifecycle CLI**: `attn plugin install --path`, `attn plugin list`, and `attn plugin remove` now manage user-owned plugins under attn's configured plugin directory and report when a daemon restart is required.
+
+### Changed
+- **Worktree Provider Coverage**: Worktree providers now participate when attn creates a worktree from an existing branch, including preserving the source branch/ref context for user-owned tooling.
+
+---
+
 ## [2026-05-17]
 
 ### Changed

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -128,6 +128,9 @@ func main() {
 		runPTYWorker()
 	case "review-loop":
 		runReviewLoop()
+	case "plugin":
+		maybePrintProfileBanner()
+		runPluginCommand()
 	case "list":
 		maybePrintProfileBanner()
 		runList()

--- a/cmd/attn/plugin.go
+++ b/cmd/attn/plugin.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/plugins"
+)
+
+type pluginCommandResult struct {
+	OK              bool              `json:"ok"`
+	Plugin          *plugins.Manifest `json:"plugin,omitempty"`
+	PluginDir       string            `json:"plugin_dir,omitempty"`
+	RestartRequired bool              `json:"restart_required,omitempty"`
+}
+
+type pluginListResult struct {
+	Plugins []plugins.Manifest    `json:"plugins"`
+	Issues  []pluginManifestIssue `json:"issues,omitempty"`
+}
+
+type pluginManifestIssue struct {
+	Path  string `json:"path"`
+	Error string `json:"error"`
+}
+
+func runPluginCommand() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "usage: attn plugin <install|list|remove> ...")
+		os.Exit(1)
+	}
+
+	switch os.Args[2] {
+	case "install":
+		runPluginInstall()
+	case "list":
+		runPluginList()
+	case "remove":
+		runPluginRemove()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown plugin command: %s\n", os.Args[2])
+		os.Exit(1)
+	}
+}
+
+func runPluginInstall() {
+	fs := flag.NewFlagSet("plugin install", flag.ExitOnError)
+	path := fs.String("path", "", "local plugin directory")
+	_ = fs.Parse(os.Args[3:])
+	sourcePath := strings.TrimSpace(*path)
+	if sourcePath == "" {
+		fmt.Fprintln(os.Stderr, "plugin install: --path is required")
+		os.Exit(1)
+	}
+	sourcePath, err := resolveCLIPath(sourcePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "plugin install: %v\n", err)
+		os.Exit(1)
+	}
+	manifest, err := plugins.InstallPath(sourcePath, config.PluginDir())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "plugin install: %v\n", err)
+		os.Exit(1)
+	}
+	printJSON(pluginCommandResult{
+		OK:              true,
+		Plugin:          &manifest,
+		PluginDir:       config.PluginDir(),
+		RestartRequired: true,
+	})
+}
+
+func runPluginList() {
+	manifests, issues := plugins.Discover(config.PluginDir())
+	result := pluginListResult{
+		Plugins: manifests,
+	}
+	for _, issue := range issues {
+		result.Issues = append(result.Issues, pluginManifestIssue{
+			Path:  issue.Path,
+			Error: issue.Err.Error(),
+		})
+	}
+	printJSON(result)
+}
+
+func runPluginRemove() {
+	if len(os.Args) != 4 || strings.TrimSpace(os.Args[3]) == "" {
+		fmt.Fprintln(os.Stderr, "usage: attn plugin remove <name>")
+		os.Exit(1)
+	}
+	name := strings.TrimSpace(os.Args[3])
+	if err := plugins.Remove(config.PluginDir(), name); err != nil {
+		fmt.Fprintf(os.Stderr, "plugin remove: %v\n", err)
+		os.Exit(1)
+	}
+	printJSON(pluginCommandResult{
+		OK:              true,
+		PluginDir:       config.PluginDir(),
+		RestartRequired: true,
+	})
+}
+
+func resolveCLIPath(path string) (string, error) {
+	switch {
+	case path == "~":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		path = home
+	case strings.HasPrefix(path, "~/"):
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		path = filepath.Join(home, path[2:])
+	}
+	resolved, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve path %q: %w", path, err)
+	}
+	return resolved, nil
+}

--- a/internal/daemon/branch.go
+++ b/internal/daemon/branch.go
@@ -3,11 +3,9 @@ package daemon
 
 import (
 	"strings"
-	"time"
 
 	"github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
-	"github.com/victorarias/attn/internal/store"
 )
 
 // doCreateWorktreeFromBranch creates a worktree from an existing branch
@@ -22,12 +20,22 @@ func (d *Daemon) doCreateWorktreeFromBranch(msg *protocol.CreateWorktreeFromBran
 		localBranch = strings.TrimPrefix(branch, "origin/")
 	}
 
-	path := protocol.Deref(msg.Path)
+	requestedPath := protocol.Deref(msg.Path)
+	path := requestedPath
 	if path == "" {
 		// Use local branch name for cleaner worktree path
 		path = git.GenerateWorktreePath(mainRepo, localBranch)
 	}
 	path = git.ExpandPath(path)
+
+	providerPath, providerBranch, handled, err := d.dispatchWorktreeCreateProvider(mainRepo, localBranch, branch, requestedPath)
+	if err != nil {
+		return "", err
+	}
+	if handled {
+		d.registerCreatedWorktree(mainRepo, providerPath, providerBranch)
+		return providerPath, nil
+	}
 
 	if isRemote {
 		// Create worktree with local branch tracking remote
@@ -42,25 +50,7 @@ func (d *Daemon) doCreateWorktreeFromBranch(msg *protocol.CreateWorktreeFromBran
 		}
 	}
 
-	wt := &store.Worktree{
-		Path:      path,
-		Branch:    localBranch, // Store local branch name, not origin/xxx
-		MainRepo:  mainRepo,
-		CreatedAt: time.Now(),
-	}
-	d.store.AddWorktree(wt)
-
-	// Broadcast created event to all clients
-	d.wsHub.Broadcast(&protocol.WebSocketEvent{
-		Event: protocol.EventWorktreeCreated,
-		Worktrees: []protocol.Worktree{{
-			Path:      wt.Path,
-			Branch:    wt.Branch,
-			MainRepo:  wt.MainRepo,
-			CreatedAt: protocol.Ptr(wt.CreatedAt.Format(time.RFC3339)),
-		}},
-	})
-
+	d.registerCreatedWorktree(mainRepo, path, localBranch)
 	return path, nil
 }
 

--- a/internal/daemon/plugin_runtime.go
+++ b/internal/daemon/plugin_runtime.go
@@ -5,103 +5,22 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"sort"
-	"strings"
 	"sync"
 
-	"github.com/BurntSushi/toml"
+	"github.com/victorarias/attn/internal/plugins"
 )
 
-const pluginManifestName = "attn-plugin.toml"
+const pluginManifestName = plugins.ManifestName
 
-type pluginManifest struct {
-	Name           string `toml:"name"`
-	Version        string `toml:"version"`
-	AttnAPIVersion int    `toml:"attn_api_version"`
-	Plugin         struct {
-		Entrypoint string `toml:"entrypoint"`
-	} `toml:"plugin"`
-
-	dir string
-}
-
-type pluginManifestIssue struct {
-	Path string
-	Err  error
-}
-
-func (i pluginManifestIssue) Error() string {
-	return fmt.Sprintf("%s: %v", i.Path, i.Err)
-}
+type pluginManifest = plugins.Manifest
+type pluginManifestIssue = plugins.ManifestIssue
 
 func discoverPluginManifests(pluginDir string) ([]pluginManifest, []pluginManifestIssue) {
-	pluginDir = strings.TrimSpace(pluginDir)
-	if pluginDir == "" {
-		return nil, nil
-	}
-
-	entries, err := os.ReadDir(pluginDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, []pluginManifestIssue{{Path: pluginDir, Err: err}}
-	}
-
-	manifests := make([]pluginManifest, 0, len(entries))
-	var issues []pluginManifestIssue
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		manifestPath := filepath.Join(pluginDir, entry.Name(), pluginManifestName)
-		manifest, err := loadPluginManifest(manifestPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			issues = append(issues, pluginManifestIssue{Path: manifestPath, Err: err})
-			continue
-		}
-		manifests = append(manifests, manifest)
-	}
-
-	sort.Slice(manifests, func(i, j int) bool {
-		return manifests[i].Name < manifests[j].Name
-	})
-	return manifests, issues
+	return plugins.Discover(pluginDir)
 }
 
 func loadPluginManifest(path string) (pluginManifest, error) {
-	var manifest pluginManifest
-	if _, err := toml.DecodeFile(path, &manifest); err != nil {
-		return pluginManifest{}, err
-	}
-
-	manifest.Name = strings.TrimSpace(manifest.Name)
-	manifest.Version = strings.TrimSpace(manifest.Version)
-	manifest.Plugin.Entrypoint = strings.TrimSpace(manifest.Plugin.Entrypoint)
-	manifest.dir = filepath.Dir(path)
-
-	switch {
-	case manifest.Name == "":
-		return pluginManifest{}, errors.New("name is required")
-	case manifest.Version == "":
-		return pluginManifest{}, errors.New("version is required")
-	case manifest.AttnAPIVersion != pluginAPIVersion:
-		return pluginManifest{}, fmt.Errorf("unsupported attn_api_version %d", manifest.AttnAPIVersion)
-	case manifest.Plugin.Entrypoint == "":
-		return pluginManifest{}, errors.New("plugin.entrypoint is required")
-	case filepath.IsAbs(manifest.Plugin.Entrypoint):
-		return pluginManifest{}, errors.New("plugin.entrypoint must be relative to the plugin directory")
-	}
-
-	entrypointPath := filepath.Join(manifest.dir, manifest.Plugin.Entrypoint)
-	if _, err := os.Stat(entrypointPath); err != nil {
-		return pluginManifest{}, fmt.Errorf("plugin.entrypoint %q: %w", manifest.Plugin.Entrypoint, err)
-	}
-	return manifest, nil
+	return plugins.LoadManifest(path)
 }
 
 type pluginProcessRegistry struct {
@@ -170,7 +89,7 @@ func (d *Daemon) startInstalledPlugins() {
 
 func (d *Daemon) startInstalledPlugin(manifest pluginManifest) error {
 	cmd := exec.Command("bun", "run", manifest.Plugin.Entrypoint)
-	cmd.Dir = manifest.dir
+	cmd.Dir = manifest.Dir
 	cmd.Env = append(
 		os.Environ(),
 		"ATTN_SOCKET_PATH="+d.socketPath,

--- a/internal/daemon/plugin_runtime_test.go
+++ b/internal/daemon/plugin_runtime_test.go
@@ -51,6 +51,40 @@ attn_api_version = 1
 	}
 }
 
+func TestDiscoverPluginManifests_AllowsRuntimeOnlyManifestNames(t *testing.T) {
+	pluginDir := filepath.Join(t.TempDir(), "plugins")
+	root := filepath.Join(pluginDir, "manual-provider")
+	entrypointDir := filepath.Join(root, "src")
+	if err := os.MkdirAll(entrypointDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entrypointDir, "index.ts"), []byte("// fake entrypoint\n"), 0o644); err != nil {
+		t.Fatalf("write fake entrypoint: %v", err)
+	}
+	manifest := []byte(`
+name = "manual/provider"
+version = "0.1.0"
+attn_api_version = 1
+
+[plugin]
+entrypoint = "src/index.ts"
+`)
+	if err := os.WriteFile(filepath.Join(root, pluginManifestName), manifest, 0o644); err != nil {
+		t.Fatalf("write plugin manifest: %v", err)
+	}
+
+	manifests, issues := discoverPluginManifests(pluginDir)
+	if len(issues) != 0 {
+		t.Fatalf("manifest issues=%v, want none", issues)
+	}
+	if len(manifests) != 1 {
+		t.Fatalf("manifest count=%d, want 1", len(manifests))
+	}
+	if manifests[0].Name != "manual/provider" {
+		t.Fatalf("manifest name=%q, want manual/provider", manifests[0].Name)
+	}
+}
+
 func TestDaemon_StartInstalledPlugins_SpawnsProviderPlugin(t *testing.T) {
 	t.Setenv("ATTN_WS_PORT", "19971")
 	t.Setenv("ATTN_PLUGIN_HELPER", "1")

--- a/internal/daemon/plugin_worktree_test.go
+++ b/internal/daemon/plugin_worktree_test.go
@@ -168,6 +168,55 @@ func TestDoCreateWorktree_ProviderHandledPathMustBeNewWorktree(t *testing.T) {
 	}
 }
 
+func TestDoCreateWorktreeFromBranch_ProviderHandledRegistersValidatedWorktree(t *testing.T) {
+	tmpDir, mainDir := initProviderTestRepo(t)
+	runGitDaemon(t, mainDir, "branch", "feature/existing")
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	client, done := startPluginPipe(t, d, "branch-create-provider", []string{"provider"})
+	defer client.Close()
+	registerProvider(t, client, []string{worktreeCreateProviderSurface}, 100)
+
+	providerPath := filepath.Join(tmpDir, "provider-existing-branch")
+	responseDone := respondToCreateProviderCall(t, client, func(params worktreeCreateProviderParams) worktreeCreateProviderResult {
+		if params.Branch != "feature/existing" {
+			t.Fatalf("provider branch=%q, want feature/existing", params.Branch)
+		}
+		if params.StartingFrom != "feature/existing" {
+			t.Fatalf("provider starting_from=%q, want feature/existing", params.StartingFrom)
+		}
+		runGitDaemon(t, mainDir, "worktree", "add", providerPath, params.StartingFrom)
+		return worktreeCreateProviderResult{
+			Status: providerStatusHandled,
+			Path:   providerPath,
+			Branch: params.Branch,
+		}
+	})
+
+	path, err := d.doCreateWorktreeFromBranch(&protocol.CreateWorktreeFromBranchMessage{
+		MainRepo: mainDir,
+		Branch:   "feature/existing",
+	})
+	if err != nil {
+		t.Fatalf("doCreateWorktreeFromBranch failed: %v", err)
+	}
+	waitForProviderResponse(t, responseDone)
+
+	if canonicalPathDaemon(path) != canonicalPathDaemon(providerPath) {
+		t.Fatalf("created path=%q, want %q", path, providerPath)
+	}
+	if wt := d.store.GetWorktree(git.CanonicalizePath(providerPath)); wt == nil {
+		t.Fatalf("expected branch-provider worktree %q in store", providerPath)
+	}
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("branch create provider connection did not close")
+	}
+}
+
 func TestDoDeleteWorktree_ProviderHandledFinalizesDaemonState(t *testing.T) {
 	tmpDir, mainDir := initProviderTestRepo(t)
 	worktreePath := filepath.Join(tmpDir, "provider-delete")

--- a/internal/daemon/plugin_worktree_test.go
+++ b/internal/daemon/plugin_worktree_test.go
@@ -217,6 +217,113 @@ func TestDoCreateWorktreeFromBranch_ProviderHandledRegistersValidatedWorktree(t 
 	}
 }
 
+func TestDoCreateWorktreeFromBranch_ProviderHandledRemoteBranchStoresLocalBranch(t *testing.T) {
+	tmpDir, mainDir := initProviderTestRepo(t)
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	client, done := startPluginPipe(t, d, "remote-branch-create-provider", []string{"provider"})
+	defer client.Close()
+	registerProvider(t, client, []string{worktreeCreateProviderSurface}, 100)
+
+	providerPath := filepath.Join(tmpDir, "provider-remote-branch")
+	responseDone := respondToCreateProviderCall(t, client, func(params worktreeCreateProviderParams) worktreeCreateProviderResult {
+		if params.Branch != "feature/remote" {
+			t.Fatalf("provider branch=%q, want feature/remote", params.Branch)
+		}
+		if params.StartingFrom != "origin/feature/remote" {
+			t.Fatalf("provider starting_from=%q, want origin/feature/remote", params.StartingFrom)
+		}
+		runGitDaemon(t, mainDir, "worktree", "add", "-b", params.Branch, providerPath)
+		return worktreeCreateProviderResult{
+			Status: providerStatusHandled,
+			Path:   providerPath,
+			Branch: params.Branch,
+		}
+	})
+
+	path, err := d.doCreateWorktreeFromBranch(&protocol.CreateWorktreeFromBranchMessage{
+		MainRepo: mainDir,
+		Branch:   "origin/feature/remote",
+	})
+	if err != nil {
+		t.Fatalf("doCreateWorktreeFromBranch failed: %v", err)
+	}
+	waitForProviderResponse(t, responseDone)
+
+	if canonicalPathDaemon(path) != canonicalPathDaemon(providerPath) {
+		t.Fatalf("created path=%q, want %q", path, providerPath)
+	}
+	created := d.store.GetWorktree(git.CanonicalizePath(providerPath))
+	if created == nil {
+		t.Fatalf("expected remote branch provider worktree %q in store", providerPath)
+	}
+	if created.Branch != "feature/remote" {
+		t.Fatalf("stored branch=%q, want feature/remote", created.Branch)
+	}
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("remote branch create provider connection did not close")
+	}
+}
+
+func TestDoCreateWorktreeFromBranch_ProviderDeclinesRemoteBranchFallsBackToBuiltInGit(t *testing.T) {
+	tmpDir, mainDir := initProviderTestRepo(t)
+	remoteBranch := "feature/remote-fallback"
+	originDir := filepath.Join(tmpDir, "origin.git")
+	runGitDaemon(t, tmpDir, "init", "--bare", originDir)
+	runGitDaemon(t, mainDir, "remote", "add", "origin", originDir)
+	runGitDaemon(t, mainDir, "branch", remoteBranch)
+	runGitDaemon(t, mainDir, "push", "origin", remoteBranch)
+	runGitDaemon(t, mainDir, "branch", "-D", remoteBranch)
+	runGitDaemon(t, mainDir, "fetch", "origin")
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	client, done := startPluginPipe(t, d, "declining-remote-branch-provider", []string{"provider"})
+	defer client.Close()
+	registerProvider(t, client, []string{worktreeCreateProviderSurface}, 100)
+
+	responseDone := respondToCreateProviderCall(t, client, func(params worktreeCreateProviderParams) worktreeCreateProviderResult {
+		if params.Branch != remoteBranch {
+			t.Fatalf("provider branch=%q, want %s", params.Branch, remoteBranch)
+		}
+		if params.StartingFrom != "origin/"+remoteBranch {
+			t.Fatalf("provider starting_from=%q, want origin/%s", params.StartingFrom, remoteBranch)
+		}
+		return worktreeCreateProviderResult{Status: providerStatusDecline}
+	})
+
+	path, err := d.doCreateWorktreeFromBranch(&protocol.CreateWorktreeFromBranchMessage{
+		MainRepo: mainDir,
+		Branch:   "origin/" + remoteBranch,
+	})
+	if err != nil {
+		t.Fatalf("doCreateWorktreeFromBranch fallback failed: %v", err)
+	}
+	waitForProviderResponse(t, responseDone)
+
+	wantPath := git.GenerateWorktreePath(mainDir, remoteBranch)
+	if canonicalPathDaemon(path) != canonicalPathDaemon(wantPath) {
+		t.Fatalf("fallback path=%q, want %q", path, wantPath)
+	}
+	created := d.store.GetWorktree(path)
+	if created == nil {
+		t.Fatalf("expected fallback remote worktree %q in store", path)
+	}
+	if created.Branch != remoteBranch {
+		t.Fatalf("stored branch=%q, want %s", created.Branch, remoteBranch)
+	}
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("declining remote branch provider connection did not close")
+	}
+}
+
 func TestDoDeleteWorktree_ProviderHandledFinalizesDaemonState(t *testing.T) {
 	tmpDir, mainDir := initProviderTestRepo(t)
 	worktreePath := filepath.Join(tmpDir, "provider-delete")

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -1,0 +1,227 @@
+package plugins
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+const (
+	APIVersion   = 1
+	ManifestName = "attn-plugin.toml"
+)
+
+type Manifest struct {
+	Name           string `toml:"name" json:"name"`
+	Version        string `toml:"version" json:"version"`
+	AttnAPIVersion int    `toml:"attn_api_version" json:"attn_api_version"`
+	Description    string `toml:"description" json:"description,omitempty"`
+	Plugin         struct {
+		Entrypoint string `toml:"entrypoint" json:"entrypoint"`
+	} `toml:"plugin" json:"plugin"`
+
+	Dir string `toml:"-" json:"dir"`
+}
+
+type ManifestIssue struct {
+	Path string `json:"path"`
+	Err  error  `json:"-"`
+}
+
+func (i ManifestIssue) Error() string {
+	return fmt.Sprintf("%s: %v", i.Path, i.Err)
+}
+
+func LoadManifest(path string) (Manifest, error) {
+	var manifest Manifest
+	if _, err := toml.DecodeFile(path, &manifest); err != nil {
+		return Manifest{}, err
+	}
+
+	manifest.Name = strings.TrimSpace(manifest.Name)
+	manifest.Version = strings.TrimSpace(manifest.Version)
+	manifest.Description = strings.TrimSpace(manifest.Description)
+	manifest.Plugin.Entrypoint = strings.TrimSpace(manifest.Plugin.Entrypoint)
+	manifest.Dir = filepath.Dir(path)
+
+	switch {
+	case manifest.Name == "":
+		return Manifest{}, errors.New("name is required")
+	case !validInstallName(manifest.Name):
+		return Manifest{}, fmt.Errorf("name %q cannot be used as an install directory", manifest.Name)
+	case manifest.Version == "":
+		return Manifest{}, errors.New("version is required")
+	case manifest.AttnAPIVersion != APIVersion:
+		return Manifest{}, fmt.Errorf("unsupported attn_api_version %d", manifest.AttnAPIVersion)
+	case manifest.Plugin.Entrypoint == "":
+		return Manifest{}, errors.New("plugin.entrypoint is required")
+	case filepath.IsAbs(manifest.Plugin.Entrypoint):
+		return Manifest{}, errors.New("plugin.entrypoint must be relative to the plugin directory")
+	}
+
+	entrypointPath := filepath.Join(manifest.Dir, manifest.Plugin.Entrypoint)
+	if _, err := os.Stat(entrypointPath); err != nil {
+		return Manifest{}, fmt.Errorf("plugin.entrypoint %q: %w", manifest.Plugin.Entrypoint, err)
+	}
+	return manifest, nil
+}
+
+func Discover(pluginDir string) ([]Manifest, []ManifestIssue) {
+	pluginDir = strings.TrimSpace(pluginDir)
+	if pluginDir == "" {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(pluginDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, []ManifestIssue{{Path: pluginDir, Err: err}}
+	}
+
+	manifests := make([]Manifest, 0, len(entries))
+	var issues []ManifestIssue
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		manifestPath := filepath.Join(pluginDir, entry.Name(), ManifestName)
+		manifest, err := LoadManifest(manifestPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			issues = append(issues, ManifestIssue{Path: manifestPath, Err: err})
+			continue
+		}
+		manifests = append(manifests, manifest)
+	}
+
+	sort.Slice(manifests, func(i, j int) bool {
+		return manifests[i].Name < manifests[j].Name
+	})
+	return manifests, issues
+}
+
+func InstallPath(sourceDir, pluginDir string) (Manifest, error) {
+	sourceDir, err := filepath.Abs(strings.TrimSpace(sourceDir))
+	if err != nil {
+		return Manifest{}, fmt.Errorf("resolve source directory: %w", err)
+	}
+	sourceManifest, err := LoadManifest(filepath.Join(sourceDir, ManifestName))
+	if err != nil {
+		return Manifest{}, fmt.Errorf("load source manifest: %w", err)
+	}
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		return Manifest{}, fmt.Errorf("create plugin directory: %w", err)
+	}
+
+	targetDir := filepath.Join(pluginDir, sourceManifest.Name)
+	if _, err := os.Stat(targetDir); err == nil {
+		return Manifest{}, fmt.Errorf("plugin %q is already installed", sourceManifest.Name)
+	} else if !os.IsNotExist(err) {
+		return Manifest{}, fmt.Errorf("inspect install path: %w", err)
+	}
+	if err := copyTree(sourceDir, targetDir); err != nil {
+		_ = os.RemoveAll(targetDir)
+		return Manifest{}, err
+	}
+	installed, err := LoadManifest(filepath.Join(targetDir, ManifestName))
+	if err != nil {
+		_ = os.RemoveAll(targetDir)
+		return Manifest{}, fmt.Errorf("validate installed manifest: %w", err)
+	}
+	return installed, nil
+}
+
+func Remove(pluginDir, name string) error {
+	name = strings.TrimSpace(name)
+	if !validInstallName(name) {
+		return fmt.Errorf("invalid plugin name %q", name)
+	}
+	path := filepath.Join(pluginDir, name)
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("plugin %q is not installed", name)
+		}
+		return fmt.Errorf("inspect plugin %q: %w", name, err)
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("remove plugin %q: %w", name, err)
+	}
+	return nil
+}
+
+func validInstallName(name string) bool {
+	return name != "." &&
+		name != ".." &&
+		name == filepath.Base(name) &&
+		!strings.ContainsAny(name, `/\`)
+}
+
+func copyTree(sourceDir, targetDir string) error {
+	return filepath.WalkDir(sourceDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return fmt.Errorf("relative plugin path: %w", err)
+		}
+		if rel == "." {
+			return os.MkdirAll(targetDir, 0o755)
+		}
+		if entry.IsDir() && entry.Name() == ".git" {
+			return filepath.SkipDir
+		}
+
+		targetPath := filepath.Join(targetDir, rel)
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("inspect %s: %w", rel, err)
+		}
+		switch {
+		case entry.Type()&os.ModeSymlink != 0:
+			return fmt.Errorf("copy %s: symlinks are not supported in plugin installs", rel)
+		case entry.IsDir():
+			if err := os.MkdirAll(targetPath, info.Mode().Perm()); err != nil {
+				return fmt.Errorf("create directory %s: %w", rel, err)
+			}
+			return nil
+		case info.Mode().IsRegular():
+			if err := copyRegularFile(path, targetPath, info.Mode().Perm()); err != nil {
+				return fmt.Errorf("copy file %s: %w", rel, err)
+			}
+			return nil
+		default:
+			return fmt.Errorf("copy %s: unsupported file type", rel)
+		}
+	})
+}
+
+func copyRegularFile(sourcePath, targetPath string, mode fs.FileMode) error {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	target, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	defer target.Close()
+
+	if _, err := io.Copy(target, source); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -135,19 +135,30 @@ func InstallPath(sourceDir, pluginDir string) (Manifest, error) {
 	} else if !os.IsNotExist(err) {
 		return Manifest{}, fmt.Errorf("inspect install path: %w", err)
 	}
-	if err := copyTree(sourceDir, targetDir); err != nil {
-		_ = os.RemoveAll(targetDir)
+
+	stagingDir, err := os.MkdirTemp(pluginDir, "."+sourceManifest.Name+".install-*")
+	if err != nil {
+		return Manifest{}, fmt.Errorf("create staging install directory: %w", err)
+	}
+	defer os.RemoveAll(stagingDir)
+
+	if err := copyTree(sourceDir, stagingDir); err != nil {
 		return Manifest{}, err
 	}
-	installed, err := LoadManifest(filepath.Join(targetDir, ManifestName))
+	installed, err := LoadManifest(filepath.Join(stagingDir, ManifestName))
 	if err != nil {
-		_ = os.RemoveAll(targetDir)
 		return Manifest{}, fmt.Errorf("validate installed manifest: %w", err)
 	}
-	if err := installDependencies(targetDir); err != nil {
-		_ = os.RemoveAll(targetDir)
+	if err := installDependencies(stagingDir); err != nil {
 		return Manifest{}, err
 	}
+	if err := os.Rename(stagingDir, targetDir); err != nil {
+		if _, statErr := os.Stat(targetDir); statErr == nil {
+			return Manifest{}, fmt.Errorf("plugin %q is already installed", sourceManifest.Name)
+		}
+		return Manifest{}, fmt.Errorf("publish plugin %q: %w", sourceManifest.Name, err)
+	}
+	installed.Dir = targetDir
 	return installed, nil
 }
 

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -54,8 +55,6 @@ func LoadManifest(path string) (Manifest, error) {
 	switch {
 	case manifest.Name == "":
 		return Manifest{}, errors.New("name is required")
-	case !validInstallName(manifest.Name):
-		return Manifest{}, fmt.Errorf("name %q cannot be used as an install directory", manifest.Name)
 	case manifest.Version == "":
 		return Manifest{}, errors.New("version is required")
 	case manifest.AttnAPIVersion != APIVersion:
@@ -66,7 +65,10 @@ func LoadManifest(path string) (Manifest, error) {
 		return Manifest{}, errors.New("plugin.entrypoint must be relative to the plugin directory")
 	}
 
-	entrypointPath := filepath.Join(manifest.Dir, manifest.Plugin.Entrypoint)
+	entrypointPath := filepath.Clean(filepath.Join(manifest.Dir, manifest.Plugin.Entrypoint))
+	if !pathWithinDir(manifest.Dir, entrypointPath) {
+		return Manifest{}, errors.New("plugin.entrypoint must stay within the plugin directory")
+	}
 	if _, err := os.Stat(entrypointPath); err != nil {
 		return Manifest{}, fmt.Errorf("plugin.entrypoint %q: %w", manifest.Plugin.Entrypoint, err)
 	}
@@ -120,6 +122,9 @@ func InstallPath(sourceDir, pluginDir string) (Manifest, error) {
 	if err != nil {
 		return Manifest{}, fmt.Errorf("load source manifest: %w", err)
 	}
+	if !validInstallName(sourceManifest.Name) {
+		return Manifest{}, fmt.Errorf("name %q cannot be used as an install directory", sourceManifest.Name)
+	}
 	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
 		return Manifest{}, fmt.Errorf("create plugin directory: %w", err)
 	}
@@ -138,6 +143,10 @@ func InstallPath(sourceDir, pluginDir string) (Manifest, error) {
 	if err != nil {
 		_ = os.RemoveAll(targetDir)
 		return Manifest{}, fmt.Errorf("validate installed manifest: %w", err)
+	}
+	if err := installDependencies(targetDir); err != nil {
+		_ = os.RemoveAll(targetDir)
+		return Manifest{}, err
 	}
 	return installed, nil
 }
@@ -165,6 +174,30 @@ func validInstallName(name string) bool {
 		name != ".." &&
 		name == filepath.Base(name) &&
 		!strings.ContainsAny(name, `/\`)
+}
+
+func pathWithinDir(root, target string) bool {
+	root = filepath.Clean(root)
+	target = filepath.Clean(target)
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
+func installDependencies(pluginDir string) error {
+	cmd := exec.Command("bun", "install")
+	cmd.Dir = pluginDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		details := strings.TrimSpace(string(output))
+		if details == "" {
+			return fmt.Errorf("run bun install: %w", err)
+		}
+		return fmt.Errorf("run bun install: %w: %s", err, details)
+	}
+	return nil
 }
 
 func copyTree(sourceDir, targetDir string) error {

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestInstallPathDiscoverAndRemove(t *testing.T) {
+	installMarker := installFakeBun(t)
 	sourceDir := filepath.Join(t.TempDir(), "source")
 	writeTestPlugin(t, sourceDir, "worktree-provider")
 
@@ -20,6 +21,9 @@ func TestInstallPathDiscoverAndRemove(t *testing.T) {
 	}
 	if manifest.Dir != filepath.Join(pluginDir, "worktree-provider") {
 		t.Fatalf("installed dir=%q", manifest.Dir)
+	}
+	if _, err := os.Stat(filepath.Join(manifest.Dir, installMarker)); err != nil {
+		t.Fatalf("bun install marker stat failed: %v", err)
 	}
 
 	manifests, issues := Discover(pluginDir)
@@ -39,6 +43,7 @@ func TestInstallPathDiscoverAndRemove(t *testing.T) {
 }
 
 func TestInstallPathRejectsDuplicatePlugin(t *testing.T) {
+	installFakeBun(t)
 	sourceDir := filepath.Join(t.TempDir(), "source")
 	writeTestPlugin(t, sourceDir, "worktree-provider")
 	pluginDir := filepath.Join(t.TempDir(), "plugins")
@@ -50,11 +55,63 @@ func TestInstallPathRejectsDuplicatePlugin(t *testing.T) {
 	}
 }
 
-func TestLoadManifestRejectsTraversalName(t *testing.T) {
+func TestInstallPathRemovesCopiedPluginWhenDependencyInstallFails(t *testing.T) {
+	installFailingBun(t)
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	writeTestPlugin(t, sourceDir, "worktree-provider")
+	pluginDir := filepath.Join(t.TempDir(), "plugins")
+
+	if _, err := InstallPath(sourceDir, pluginDir); err == nil {
+		t.Fatal("InstallPath error=nil, want bun install failure")
+	}
+	if _, err := os.Stat(filepath.Join(pluginDir, "worktree-provider")); !os.IsNotExist(err) {
+		t.Fatalf("failed install directory still exists, stat err=%v", err)
+	}
+}
+
+func TestInstallPathRejectsTraversalName(t *testing.T) {
+	installFakeBun(t)
 	sourceDir := filepath.Join(t.TempDir(), "source")
 	writeTestPlugin(t, sourceDir, "../bad")
+	if _, err := InstallPath(sourceDir, filepath.Join(t.TempDir(), "plugins")); err == nil {
+		t.Fatal("InstallPath error=nil, want invalid install name")
+	}
+}
+
+func TestLoadManifestAllowsRuntimeOnlyNames(t *testing.T) {
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	writeTestPlugin(t, sourceDir, "team/worktree-provider")
+	manifest, err := LoadManifest(filepath.Join(sourceDir, ManifestName))
+	if err != nil {
+		t.Fatalf("LoadManifest failed: %v", err)
+	}
+	if manifest.Name != "team/worktree-provider" {
+		t.Fatalf("manifest name=%q, want team/worktree-provider", manifest.Name)
+	}
+}
+
+func TestLoadManifestRejectsEntrypointTraversal(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "outside.ts"), []byte("// outside\n"), 0o644); err != nil {
+		t.Fatalf("write outside entrypoint: %v", err)
+	}
+	manifest := []byte(`
+name = "worktree-provider"
+version = "0.1.0"
+attn_api_version = 1
+
+[plugin]
+entrypoint = "../outside.ts"
+`)
+	if err := os.WriteFile(filepath.Join(sourceDir, ManifestName), manifest, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
 	if _, err := LoadManifest(filepath.Join(sourceDir, ManifestName)); err == nil {
-		t.Fatal("LoadManifest error=nil, want invalid name")
+		t.Fatal("LoadManifest error=nil, want traversal entrypoint rejection")
 	}
 }
 
@@ -77,4 +134,32 @@ entrypoint = "src/index.ts"
 	if err := os.WriteFile(filepath.Join(root, ManifestName), manifest, 0o644); err != nil {
 		t.Fatalf("write manifest: %v", err)
 	}
+}
+
+func installFakeBun(t *testing.T) string {
+	t.Helper()
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir fake bun dir: %v", err)
+	}
+	const installMarker = "node_modules/.bun-install-ran"
+	script := "#!/bin/sh\nmkdir -p node_modules\n: > " + installMarker + "\n"
+	if err := os.WriteFile(filepath.Join(binDir, "bun"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bun: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return installMarker
+}
+
+func installFailingBun(t *testing.T) {
+	t.Helper()
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir failing bun dir: %v", err)
+	}
+	script := "#!/bin/sh\necho dependency install failed >&2\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(binDir, "bun"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write failing bun: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -52,6 +53,43 @@ func TestInstallPathRejectsDuplicatePlugin(t *testing.T) {
 	}
 	if _, err := InstallPath(sourceDir, pluginDir); err == nil {
 		t.Fatal("second InstallPath error=nil, want duplicate install error")
+	}
+}
+
+func TestInstallPathConcurrentDuplicateInstallsPublishExactlyOnePlugin(t *testing.T) {
+	installFakeBun(t)
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	writeTestPlugin(t, sourceDir, "worktree-provider")
+	pluginDir := filepath.Join(t.TempDir(), "plugins")
+
+	const installs = 8
+	results := make([]error, installs)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range installs {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			_, results[index] = InstallPath(sourceDir, pluginDir)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	successes := 0
+	for _, err := range results {
+		if err == nil {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successful installs=%d, want exactly 1; errors=%v", successes, results)
+	}
+
+	installedManifest := filepath.Join(pluginDir, "worktree-provider", ManifestName)
+	if _, err := LoadManifest(installedManifest); err != nil {
+		t.Fatalf("installed manifest missing or invalid after concurrent install: %v", err)
 	}
 }
 

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -1,0 +1,80 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallPathDiscoverAndRemove(t *testing.T) {
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	writeTestPlugin(t, sourceDir, "worktree-provider")
+
+	pluginDir := filepath.Join(t.TempDir(), "plugins")
+	manifest, err := InstallPath(sourceDir, pluginDir)
+	if err != nil {
+		t.Fatalf("InstallPath failed: %v", err)
+	}
+	if manifest.Name != "worktree-provider" {
+		t.Fatalf("installed name=%q, want worktree-provider", manifest.Name)
+	}
+	if manifest.Dir != filepath.Join(pluginDir, "worktree-provider") {
+		t.Fatalf("installed dir=%q", manifest.Dir)
+	}
+
+	manifests, issues := Discover(pluginDir)
+	if len(issues) != 0 {
+		t.Fatalf("discover issues=%v, want none", issues)
+	}
+	if len(manifests) != 1 || manifests[0].Name != "worktree-provider" {
+		t.Fatalf("discover manifests=%v, want worktree-provider", manifests)
+	}
+
+	if err := Remove(pluginDir, "worktree-provider"); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(pluginDir, "worktree-provider")); !os.IsNotExist(err) {
+		t.Fatalf("installed directory still exists, stat err=%v", err)
+	}
+}
+
+func TestInstallPathRejectsDuplicatePlugin(t *testing.T) {
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	writeTestPlugin(t, sourceDir, "worktree-provider")
+	pluginDir := filepath.Join(t.TempDir(), "plugins")
+	if _, err := InstallPath(sourceDir, pluginDir); err != nil {
+		t.Fatalf("first InstallPath failed: %v", err)
+	}
+	if _, err := InstallPath(sourceDir, pluginDir); err == nil {
+		t.Fatal("second InstallPath error=nil, want duplicate install error")
+	}
+}
+
+func TestLoadManifestRejectsTraversalName(t *testing.T) {
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	writeTestPlugin(t, sourceDir, "../bad")
+	if _, err := LoadManifest(filepath.Join(sourceDir, ManifestName)); err == nil {
+		t.Fatal("LoadManifest error=nil, want invalid name")
+	}
+}
+
+func writeTestPlugin(t *testing.T, root, name string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir plugin source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "index.ts"), []byte("// entrypoint\n"), 0o644); err != nil {
+		t.Fatalf("write entrypoint: %v", err)
+	}
+	manifest := []byte(`
+name = "` + name + `"
+version = "0.1.0"
+attn_api_version = 1
+
+[plugin]
+entrypoint = "src/index.ts"
+`)
+	if err := os.WriteFile(filepath.Join(root, ManifestName), manifest, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}


### PR DESCRIPTION
## Intent / Why
Plugins are useful only if users can install and manage them without reaching into attn internals, and worktree providers need to cover both "new branch" and "existing branch" creation flows cleanly.

## Summary
- add `attn plugin install --path`, `attn plugin list`, and `attn plugin remove` backed by shared plugin manifest/install logic
- prepare installed plugin dependencies with `bun install`, and roll back the copied install when dependency setup fails
- keep daemon discovery compatible with manually managed plugin names while constraining installed plugin names to safe directory keys
- reject plugin entrypoints that escape the plugin directory
- move daemon manifest discovery onto the shared plugin package so CLI and runtime validate plugins consistently
- route `create_worktree_from_branch` through `worktree.create` providers while preserving the source branch/ref context
- cover install/remove behavior, invalid entrypoint traversal, manual plugin discovery compatibility, and local/remote branch provider flows with focused Go tests
- document the user-visible CLI and provider expansion in `CHANGELOG.md`

## Test plan
- [x] `go test ./internal/plugins`
- [x] `go test ./cmd/attn`
- [x] focused daemon provider tests for create/delete plus local and remote `create_worktree_from_branch` flows
- [x] `go test ./internal/daemon`
- [x] smoke-tested `attn plugin install --path`, `attn plugin list`, and `attn plugin remove` with a local provider plugin and a temp `ATTN_PLUGIN_DIR`

## Out of scope
- hot-reloading plugin installs into an already-running daemon; the CLI reports `restart_required: true` for now
- plugin UX beyond the initial lifecycle commands in this PR