### PR TITLE
fix(daemon): guard isolated socket stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Changed
 - **Worktree Provider Coverage**: Worktree providers now participate when attn creates a worktree from an existing branch, including preserving the source branch/ref context for user-owned tooling.
 
+### Fixed
+- **Daemon Isolation Guard**: attn now refuses to start a daemon with an alternate socket/PID root while still pointing at the active profile's normal session database, preventing auxiliary daemon runs from pruning live sessions they do not own.
+
 ---
 
 ## [2026-05-17]

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -268,7 +268,13 @@ func runDaemonCommand() {
 }
 
 func runDaemon() {
-	d := daemon.New(config.SocketPath())
+	socketPath := config.SocketPath()
+	if err := config.ValidateDaemonIsolation(socketPath); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	d := daemon.New(socketPath)
 	if err := d.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "daemon error: %v\n", err)
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -263,6 +263,57 @@ func SocketPath() string {
 	return filepath.Join(attnDir(), "attn.sock")
 }
 
+// ValidateDaemonIsolation rejects daemon configurations that split the
+// runtime root (socket/PID/workers) away from the active profile's data dir
+// while still pointing at that profile's default durable store.
+//
+// That combination lets an auxiliary daemon reconcile the shared session DB
+// against a different worker registry and mistakenly reap live sessions.
+func ValidateDaemonIsolation(socketPath string) error {
+	socketDir, err := comparableDaemonIsolationPath(filepath.Dir(strings.TrimSpace(socketPath)))
+	if err != nil {
+		return fmt.Errorf("resolve daemon socket root: %w", err)
+	}
+	profileDataDir, err := comparableDaemonIsolationPath(DataDir())
+	if err != nil {
+		return fmt.Errorf("resolve profile data dir: %w", err)
+	}
+	if socketDir == profileDataDir {
+		return nil
+	}
+
+	dbPath, err := comparableDaemonIsolationPath(DBPath())
+	if err != nil {
+		return fmt.Errorf("resolve daemon DB path: %w", err)
+	}
+	defaultDBPath, err := comparableDaemonIsolationPath(filepath.Join(profileDataDir, "attn.db"))
+	if err != nil {
+		return fmt.Errorf("resolve profile DB path: %w", err)
+	}
+	if dbPath != defaultDBPath {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"refusing to start daemon with socket root %q while DB path still resolves to the %s profile store %q; set ATTN_DB_PATH to an isolated database or use ATTN_PROFILE",
+		socketDir,
+		ProfileLabel(),
+		defaultDBPath,
+	)
+}
+
+func comparableDaemonIsolationPath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", nil
+	}
+	absolute, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(absolute), nil
+}
+
 // StatePath returns the legacy state file path (for migration/cleanup)
 func StatePath() string {
 	home, err := os.UserHomeDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -58,6 +58,71 @@ func TestSocketPath_EnvVarOverridesDefault(t *testing.T) {
 	}
 }
 
+func TestValidateDaemonIsolation_RejectsForeignSocketRootWithProfileDB(t *testing.T) {
+	t.Setenv("ATTN_PROFILE", "")
+	t.Setenv("ATTN_SOCKET_PATH", filepath.Join(t.TempDir(), "attn.sock"))
+	t.Setenv("ATTN_DB_PATH", "")
+	t.Setenv("ATTN_CONFIG_PATH", "")
+	reloadConfig()
+
+	err := ValidateDaemonIsolation(SocketPath())
+	if err == nil {
+		t.Fatal("ValidateDaemonIsolation() accepted an alternate socket root with the default profile DB")
+	}
+	if !strings.Contains(err.Error(), "refusing to start daemon") {
+		t.Fatalf("ValidateDaemonIsolation() error = %q, want refusal message", err)
+	}
+}
+
+func TestValidateDaemonIsolation_AllowsForeignSocketRootWithIsolatedDB(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("ATTN_PROFILE", "")
+	t.Setenv("ATTN_SOCKET_PATH", filepath.Join(tmpDir, "attn.sock"))
+	t.Setenv("ATTN_DB_PATH", filepath.Join(tmpDir, "attn.db"))
+	t.Setenv("ATTN_CONFIG_PATH", "")
+	reloadConfig()
+
+	if err := ValidateDaemonIsolation(SocketPath()); err != nil {
+		t.Fatalf("ValidateDaemonIsolation() returned unexpected error: %v", err)
+	}
+}
+
+func TestValidateDaemonIsolation_RejectsRelativeDBPathInProfileDir(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("ATTN_PROFILE", "")
+	t.Setenv("ATTN_SOCKET_PATH", filepath.Join(t.TempDir(), "attn.sock"))
+	t.Setenv("ATTN_DB_PATH", "attn.db")
+	t.Setenv("ATTN_CONFIG_PATH", "")
+	reloadConfig()
+
+	profileDataDir := DataDir()
+	if err := os.MkdirAll(profileDataDir, 0o755); err != nil {
+		t.Fatalf("mkdir profile data dir: %v", err)
+	}
+	t.Chdir(profileDataDir)
+
+	err := ValidateDaemonIsolation(SocketPath())
+	if err == nil {
+		t.Fatal("ValidateDaemonIsolation() accepted a relative DB path that resolves to the default profile DB")
+	}
+	if !strings.Contains(err.Error(), "refusing to start daemon") {
+		t.Fatalf("ValidateDaemonIsolation() error = %q, want refusal message", err)
+	}
+}
+
+func TestValidateDaemonIsolation_AllowsSocketOverrideInsideProfileDataDir(t *testing.T) {
+	t.Setenv("ATTN_PROFILE", "dev")
+	t.Setenv("ATTN_DB_PATH", "")
+	t.Setenv("ATTN_CONFIG_PATH", "")
+	reloadConfig()
+	t.Setenv("ATTN_SOCKET_PATH", filepath.Join(DataDir(), "custom.sock"))
+
+	if err := ValidateDaemonIsolation(SocketPath()); err != nil {
+		t.Fatalf("ValidateDaemonIsolation() returned unexpected error: %v", err)
+	}
+}
+
 func TestPluginDir_DefaultsToAttnDir(t *testing.T) {
 	os.Unsetenv("ATTN_PLUGIN_DIR")
 	os.Unsetenv("ATTN_PROFILE")

--- a/internal/daemonctl/ensure.go
+++ b/internal/daemonctl/ensure.go
@@ -46,6 +46,9 @@ func Ensure(ctx context.Context, binaryPath string) (EnsureResult, error) {
 	if strings.TrimSpace(binaryPath) == "" {
 		return EnsureResult{}, fmt.Errorf("missing binary path")
 	}
+	if err := config.ValidateDaemonIsolation(config.SocketPath()); err != nil {
+		return EnsureResult{}, err
+	}
 
 	if !isSocketLive(config.SocketPath()) {
 		if err := removeStaleSocketFiles(); err != nil {

--- a/internal/daemonctl/ensure_test.go
+++ b/internal/daemonctl/ensure_test.go
@@ -1,9 +1,13 @@
 package daemonctl
 
 import (
+	"context"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/victorarias/attn/internal/buildinfo"
+	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -46,5 +50,21 @@ func TestMismatchReason_ReportsMissingFingerprint(t *testing.T) {
 
 	if got := mismatchReason(nil, healthResponse{}); got != "source_fingerprint_missing" {
 		t.Fatalf("mismatchReason() = %q, want source_fingerprint_missing", got)
+	}
+}
+
+func TestEnsure_RejectsMixedSocketAndDefaultStoreIsolation(t *testing.T) {
+	t.Setenv("ATTN_PROFILE", "")
+	t.Setenv("ATTN_SOCKET_PATH", filepath.Join(t.TempDir(), "attn.sock"))
+	t.Setenv("ATTN_DB_PATH", "")
+	t.Setenv("ATTN_CONFIG_PATH", "")
+	config.ReloadForTesting()
+
+	_, err := Ensure(context.Background(), "/tmp/attn")
+	if err == nil {
+		t.Fatal("Ensure() accepted an alternate socket root with the default profile DB")
+	}
+	if !strings.Contains(err.Error(), "refusing to start daemon") {
+		t.Fatalf("Ensure() error = %q, want isolation refusal", err)
 	}
 }


### PR DESCRIPTION
## Intent / Why
A temporary daemon launched with an isolated socket/PID root but the default profile database can reconcile against the wrong worker registry and prune live sessions it does not own. This fixes the class of failure that orphaned a running session from attn's persisted session list.

## Summary
- Reject daemon startup when the socket/PID root is outside the active profile data directory while the DB still points at that profile's default `attn.db`.
- Apply the same isolation guard to `attn daemon ensure` so recovery paths fail before spawning an unsafe daemon.
- Add focused config and daemonctl regression tests for blocked mixed isolation plus allowed isolated/same-profile layouts.
- Document the user-visible protection in `CHANGELOG.md`.

## Test plan
- [x] `go test ./internal/config ./internal/daemonctl ./cmd/attn`
- [x] `git diff --check`
- [ ] Manually verify a packaged app fallback/recovery flow still starts normally when it uses a proper profile or explicitly isolated DB.