### PR TITLE
chore(plugins): publish sdk as victorarias package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Added
 - **Plugin Lifecycle CLI**: `attn plugin install --path`, `attn plugin list`, and `attn plugin remove` now manage user-owned plugins under attn's configured plugin directory and report when a daemon restart is required.
-- **Plugin SDK Foundation**: attn now includes an initial `@attn/plugin` TypeScript SDK for worktree plugin surfaces, covering the daemon handshake, typed surface registration, request routing, structured provider results, and typed worktree provider/lifecycle contracts.
+- **Plugin SDK Foundation**: attn now includes an initial `@victorarias/attn-plugin` TypeScript SDK for worktree plugin surfaces, covering the daemon handshake, typed surface registration, request routing, structured provider results, and typed worktree provider/lifecycle contracts.
 
 ### Changed
 - **Worktree Provider Coverage**: Worktree providers now participate when attn creates a worktree from an existing branch, including preserving the source branch/ref context for user-owned tooling.

--- a/docs/plans/2026-04-16-plugin-system.md
+++ b/docs/plans/2026-04-16-plugin-system.md
@@ -298,7 +298,7 @@ Provider dispatch and future driver work are the tightest V1 requirements. Assis
 
 In priority order of what might come next:
 
-- **SDK expansion.** Extend `@attn/plugin` beyond the initial provider foundation once broader surfaces have real plugin implementations. Reconnect logic and richer typed helpers belong here, not in the first extraction.
+- **SDK expansion.** Extend `@victorarias/attn-plugin` beyond the initial provider foundation once broader surfaces have real plugin implementations. Reconnect logic and richer typed helpers belong here, not in the first extraction.
 - **Cross-daemon control API.** Expose the same JSON-RPC surface over the hub's existing WebSocket at `:9849` so future control plugins can span daemons. Useful for attn-as-agent and dashboards.
 - **Custom UI extensions.** Separate design.
 - **Plugin install over SSH / hub** — `attn --endpoint <server> plugin install <url>`. Nice-to-have, requires proxying through the hub.

--- a/examples/plugins/worktree-deps-hook/README.md
+++ b/examples/plugins/worktree-deps-hook/README.md
@@ -1,6 +1,6 @@
 # Worktree dependency bootstrap hook
 
-Example attn plugin built with `@attn/plugin`.
+Example attn plugin built with `@victorarias/attn-plugin`.
 
 It demonstrates:
 
@@ -17,7 +17,7 @@ The example keeps the behavior genuinely useful:
 - otherwise run `npm install` when `package-lock.json` is present
 - surface package-manager failures back to attn through the hook RPC call
 
-This example consumes `@attn/plugin` through a local `file:` dependency back
+This example consumes `@victorarias/attn-plugin` through a local `file:` dependency back
 into this repository. Until the SDK has a publishable external consumption path,
 treat this as a source-tree example rather than a plugin to install with
 `attn plugin install --path`.

--- a/examples/plugins/worktree-deps-hook/package.json
+++ b/examples/plugins/worktree-deps-hook/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "version": "0.1.0",
   "dependencies": {
-    "@attn/plugin": "file:../../../sdk/plugin"
+    "@victorarias/attn-plugin": "file:../../../sdk/plugin"
   }
 }

--- a/examples/plugins/worktree-deps-hook/src/index.ts
+++ b/examples/plugins/worktree-deps-hook/src/index.ts
@@ -1,4 +1,4 @@
-import { AttnPluginClient } from "@attn/plugin";
+import { AttnPluginClient } from "@victorarias/attn-plugin";
 import { spawn } from "node:child_process";
 import { stat } from "node:fs/promises";
 import { join } from "node:path";

--- a/sdk/plugin/README.md
+++ b/sdk/plugin/README.md
@@ -1,4 +1,4 @@
-# `@attn/plugin`
+# `@victorarias/attn-plugin`
 
 Small TypeScript SDK for attn plugins.
 
@@ -15,7 +15,7 @@ import {
   AttnPluginClient,
   decline,
   handled,
-} from "@attn/plugin";
+} from "@victorarias/attn-plugin";
 
 const client = new AttnPluginClient({
   version: "0.1.0",
@@ -49,7 +49,7 @@ Create lifecycle hooks use the same registration path:
 ```ts
 import {
   type WorktreeAfterCreateParams,
-} from "@attn/plugin";
+} from "@victorarias/attn-plugin";
 
 client.handle<"worktree.after_create">(
   "worktree.after_create",

--- a/sdk/plugin/package.json
+++ b/sdk/plugin/package.json
@@ -1,8 +1,23 @@
 {
-  "name": "@attn/plugin",
+  "name": "@victorarias/attn-plugin",
   "version": "0.1.0",
+  "description": "TypeScript SDK for attn plugins",
+  "license": "GPL-3.0-only",
   "type": "module",
+  "types": "./src/index.ts",
   "exports": "./src/index.ts",
+  "files": [
+    "README.md",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/victorarias/attn.git",
+    "directory": "sdk/plugin"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "bun test"
   }


### PR DESCRIPTION
## Intent / Why
External attn plugins now have a stable SDK shape, but the package name that landed in-tree (`@attn/plugin`) cannot be published from the maintainer npm account today because the `@attn` scope is unavailable. This keeps the source tree aligned with the package that is actually publishable and now published for plugin authors.

## Summary
- rename the SDK package and examples from `@attn/plugin` to `@victorarias/attn-plugin`
- add the package metadata needed for a clean public npm release: description, license, repository pointer, `types`, packed files, and public scoped publish config
- update SDK docs, example plugin imports/dependency metadata, changelog copy, and the plugin-system plan to match the published package name
- publish `@victorarias/attn-plugin@0.1.0` to npmjs.org

## Test plan
- [x] `cd sdk/plugin && bun test`
- [x] `cd examples/plugins/worktree-deps-hook && bun build src/index.ts --external @victorarias/attn-plugin --outfile /private/tmp/worktree-deps-hook.js`
- [x] `cd sdk/plugin && npm pack --dry-run --json`
- [x] npm package access metadata shows `@victorarias/attn-plugin` registered to `victorarias`

## Out of scope
- claiming or creating the `@attn` npm organization scope
- changing the SDK API itself
- building the first external services-pilot provider plugin; this PR only makes the published dependency available for it