### PR TITLE
Use Codex hooks for live state detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Changed
 - **Worktree Provider Coverage**: Worktree providers now participate when attn creates a worktree from an existing branch, including preserving the source branch/ref context for user-owned tooling.
+- **Codex State Detection**: Codex sessions now rely on Codex hooks, including `PreToolUse`, instead of PTY output heuristics for live state changes.
 
 ---
 

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -42,7 +42,7 @@ func (c *Codex) Capabilities() Capabilities {
 		HasTranscript:        true,
 		HasTranscriptWatcher: true,
 		HasClassifier:        true,
-		HasStateDetector:     true,
+		HasStateDetector:     false,
 		HasResume:            true,
 		HasYolo:              true,
 	}
@@ -120,23 +120,11 @@ func (c *Codex) NewTranscriptWatcherBehavior() TranscriptWatcherBehavior {
 }
 
 func (c *Codex) RecoveredRunningState(ptyState string) protocol.SessionState {
-	switch ptyState {
-	case protocol.StatePendingApproval:
-		return protocol.SessionStatePendingApproval
-	default:
-		return protocol.SessionStateLaunching
-	}
+	return protocol.SessionStateLaunching
 }
 
 func (c *Codex) ShouldApplyPTYState(current protocol.SessionState, incoming string) bool {
-	switch incoming {
-	case protocol.StatePendingApproval:
-		return true
-	case protocol.StateWorking:
-		return current == protocol.SessionStateWorking
-	default:
-		return false
-	}
+	return false
 }
 
 func (c *Codex) ResolveSpawnResumeSessionID(existingSessionID, requestedResumeID, storedResumeID string) string {

--- a/internal/agent/daemon_policy_test.go
+++ b/internal/agent/daemon_policy_test.go
@@ -53,23 +53,27 @@ func TestRecoveredRunningSessionState_DefaultAndAgentOverrides(t *testing.T) {
 	if got := RecoveredRunningSessionState(Get("codex"), protocol.StateWaitingInput); got != protocol.SessionStateLaunching {
 		t.Fatalf("codex recovered waiting_input = %s, want launching", got)
 	}
+	if got := RecoveredRunningSessionState(Get("codex"), protocol.StatePendingApproval); got != protocol.SessionStateLaunching {
+		t.Fatalf("codex recovered pending_approval = %s, want launching", got)
+	}
 	if got := RecoveredRunningSessionState(Get("copilot"), protocol.StatePendingApproval); got != protocol.SessionStatePendingApproval {
 		t.Fatalf("copilot recovered pending_approval = %s, want pending_approval", got)
 	}
 }
 
 func TestShouldApplyPTYState_AgentOverrides(t *testing.T) {
-	if ShouldApplyPTYState(Get("codex"), protocol.SessionStateWorking, protocol.StateWaitingInput) {
-		t.Fatal("codex should ignore waiting_input PTY state updates")
-	}
-	if !ShouldApplyPTYState(Get("codex"), protocol.SessionStateWorking, protocol.StatePendingApproval) {
-		t.Fatal("codex should accept pending_approval PTY state updates")
+	for _, incoming := range []string{
+		protocol.StateWorking,
+		protocol.StateWaitingInput,
+		protocol.StatePendingApproval,
+		protocol.StateIdle,
+	} {
+		if ShouldApplyPTYState(Get("codex"), protocol.SessionStateWorking, incoming) {
+			t.Fatalf("codex should ignore %s PTY state updates", incoming)
+		}
 	}
 	if ShouldApplyPTYState(Get("codex"), protocol.SessionStateLaunching, protocol.StateWorking) {
 		t.Fatal("codex should ignore launch-time working PTY noise")
-	}
-	if !ShouldApplyPTYState(Get("codex"), protocol.SessionStateWorking, protocol.StateWorking) {
-		t.Fatal("codex should accept working PTY state updates while already working")
 	}
 	if ShouldApplyPTYState(Get("codex"), protocol.SessionStateIdle, protocol.StateWorking) {
 		t.Fatal("codex should ignore working PTY noise while idle")

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -259,8 +259,11 @@ func TestClient_SocketPath(t *testing.T) {
 	config.SetBinaryName("attn")
 
 	// Test default socket path
-	os.Setenv("HOME", "/home/testuser")
-	defer os.Unsetenv("HOME")
+	t.Setenv("HOME", "/home/testuser")
+	t.Setenv("ATTN_PROFILE", "")
+	t.Setenv("ATTN_SOCKET_PATH", "")
+	t.Setenv("ATTN_CONFIG_PATH", filepath.Join(t.TempDir(), "missing-config.json"))
+	config.ReloadForTesting()
 
 	path := DefaultSocketPath()
 	expected := "/home/testuser/.attn/attn.sock"

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1072,8 +1072,13 @@ func TestSessionStateFromRecoveredInfo(t *testing.T) {
 			want: protocol.SessionStateLaunching,
 		},
 		{
-			name: "pending approval",
+			name: "codex pending approval normalizes to launching",
 			info: ptybackend.SessionInfo{Running: true, State: protocol.StatePendingApproval},
+			want: protocol.SessionStateLaunching,
+		},
+		{
+			name: "claude pending approval",
+			info: ptybackend.SessionInfo{Running: true, Agent: string(protocol.SessionAgentClaude), State: protocol.StatePendingApproval},
 			want: protocol.SessionStatePendingApproval,
 		},
 		{

--- a/internal/daemon/transcript_watcher_test.go
+++ b/internal/daemon/transcript_watcher_test.go
@@ -8,34 +8,32 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-func TestHandlePTYState_CodexIgnoresWaitingAndIdle(t *testing.T) {
+func TestHandlePTYState_CodexIgnoresPTYState(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "sock"))
 
-	nowStr := string(protocol.TimestampNow())
-	d.store.Add(&protocol.Session{
-		ID:             "codex-sess",
-		Label:          "codex",
-		Agent:          protocol.SessionAgentCodex,
-		Directory:      "/tmp",
-		State:          protocol.SessionStateWorking,
-		StateSince:     nowStr,
-		StateUpdatedAt: nowStr,
-		LastSeen:       nowStr,
-	})
+	for _, state := range []string{
+		protocol.StateWaitingInput,
+		protocol.StateIdle,
+		protocol.StatePendingApproval,
+		protocol.StateWorking,
+	} {
+		id := "codex-sess-" + state
+		nowStr := string(protocol.TimestampNow())
+		d.store.Add(&protocol.Session{
+			ID:             id,
+			Label:          "codex",
+			Agent:          protocol.SessionAgentCodex,
+			Directory:      "/tmp",
+			State:          protocol.SessionStateIdle,
+			StateSince:     nowStr,
+			StateUpdatedAt: nowStr,
+			LastSeen:       nowStr,
+		})
 
-	d.handlePTYState("codex-sess", protocol.StateWaitingInput)
-	if got := d.store.Get("codex-sess"); got.State != protocol.SessionStateWorking {
-		t.Fatalf("codex waiting_input should be ignored, got=%s", got.State)
-	}
-
-	d.handlePTYState("codex-sess", protocol.StateIdle)
-	if got := d.store.Get("codex-sess"); got.State != protocol.SessionStateWorking {
-		t.Fatalf("codex idle should be ignored, got=%s", got.State)
-	}
-
-	d.handlePTYState("codex-sess", protocol.StatePendingApproval)
-	if got := d.store.Get("codex-sess"); got.State != protocol.SessionStatePendingApproval {
-		t.Fatalf("codex pending_approval should be applied, got=%s", got.State)
+		d.handlePTYState(id, state)
+		if got := d.store.Get(id); got.State != protocol.SessionStateIdle {
+			t.Fatalf("codex %s PTY state should be ignored, got=%s", state, got.State)
+		}
 	}
 }
 

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -40,6 +40,7 @@ func GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath string) []s
 	sessionStart := command("_hook-session-start")
 	userPromptSubmit := command("_hook-state", "working")
 	permissionRequest := command("_hook-state", "pending_approval")
+	preToolUse := command("_hook-state", "working")
 	postToolUse := command("_hook-state", "working")
 	stop := command("_hook-stop")
 
@@ -49,12 +50,14 @@ func GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath string) []s
 			{eventKey: "session_start", matcher: "startup|resume", command: sessionStart},
 			{eventKey: "user_prompt_submit", command: userPromptSubmit},
 			{eventKey: "permission_request", matcher: "*", command: permissionRequest},
+			{eventKey: "pre_tool_use", matcher: "*", command: preToolUse},
 			{eventKey: "post_tool_use", matcher: "*", command: postToolUse},
 			{eventKey: "stop", command: stop},
 		}),
 		"hooks.SessionStart=" + group("startup|resume", sessionStart),
 		"hooks.UserPromptSubmit=" + group("", userPromptSubmit),
 		"hooks.PermissionRequest=" + group("*", permissionRequest),
+		"hooks.PreToolUse=" + group("*", preToolUse),
 		"hooks.PostToolUse=" + group("*", postToolUse),
 		"hooks.Stop=" + group("", stop),
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -121,6 +121,12 @@ func TestGenerateCodexConfigOverrides_UsesStableEnvBasedCommands(t *testing.T) {
 	if !strings.Contains(joined, "features.hooks=true") {
 		t.Fatal("codex overrides should enable hooks for attn-managed sessions")
 	}
+	if !strings.Contains(joined, "hooks.PreToolUse=") {
+		t.Fatal("codex overrides should include PreToolUse hook")
+	}
+	if !strings.Contains(joined, `"/<session-flags>/config.toml:pre_tool_use:0:0" = { trusted_hash =`) {
+		t.Fatal("codex overrides should trust attn-managed PreToolUse hook")
+	}
 	if !strings.Contains(joined, `hooks.state={`) ||
 		!strings.Contains(joined, `"/<session-flags>/config.toml:session_start:0:0" = { trusted_hash =`) {
 		t.Fatal("codex overrides should trust attn-managed session flag hooks")

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -226,8 +226,8 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 	}
 	if detectorEnabled {
 		switch agent {
-		case "codex", "copilot":
-			session.detector = newCodexStateDetector()
+		case "copilot":
+			session.detector = newCopilotStateDetector()
 		case "claude":
 			session.detector = newClaudeWorkingDetector()
 		}

--- a/internal/pty/state_detector.go
+++ b/internal/pty/state_detector.go
@@ -39,7 +39,7 @@ var defaultStateHeuristics = stateHeuristics{
 	listRequestTriggers: []string{"pick one", "choose", "select", "tell me"},
 }
 
-type codexStateDetector struct {
+type copilotStateDetector struct {
 	tail             string
 	lastState        string
 	lastWorkingPulse time.Time
@@ -51,8 +51,8 @@ type claudeWorkingDetector struct {
 	lastWorkingPulse time.Time
 }
 
-func newCodexStateDetector() *codexStateDetector {
-	return &codexStateDetector{}
+func newCopilotStateDetector() *copilotStateDetector {
+	return &copilotStateDetector{}
 }
 
 func newClaudeWorkingDetector() *claudeWorkingDetector {
@@ -64,7 +64,7 @@ const workingPulseInterval = 1200 * time.Millisecond
 var claudeStatusTimerPattern = regexp.MustCompile(`\((?:\d+h\s+)?(?:\d+m\s+)?\d+s(?:\s+·[^)]*)?\)`)
 var claudeFinalSummaryPattern = regexp.MustCompile(`(?i)\bfor\s+(?:\d+h\s+)?(?:\d+m\s+)?\d+s\b`)
 
-func (d *codexStateDetector) Observe(chunk []byte) (string, bool) {
+func (d *copilotStateDetector) Observe(chunk []byte) (string, bool) {
 	if len(chunk) == 0 {
 		return "", false
 	}

--- a/internal/pty/state_detector_test.go
+++ b/internal/pty/state_detector_test.go
@@ -71,8 +71,8 @@ up/down to navigate - Enter to select - Esc to cancel`
 	}
 }
 
-func TestCodexStateDetector_EmitsWorkingPulseForAnimationFrames(t *testing.T) {
-	d := newCodexStateDetector()
+func TestCopilotStateDetector_EmitsWorkingPulseForAnimationFrames(t *testing.T) {
+	d := newCopilotStateDetector()
 	frame := []byte("\x1b[2m• working\x1b[0m\r")
 
 	state, changed := d.Observe(frame)


### PR DESCRIPTION
## Summary
- add Codex PreToolUse state hook so tool execution marks sessions working
- disable Codex PTY-derived state detection and recovered PTY state promotion
- rename the remaining PTY heuristic detector to Copilot since Codex no longer uses it

## Tests
- go test ./cmd/attn ./internal/agent ./internal/hooks ./internal/daemon ./internal/pty