### PR TITLE
feat(plugins): add daemon healthchecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-05-22]
+
+### Added
+- **Plugin Healthchecks**: The daemon now pings connected plugins, records healthy/unhealthy/unknown state separately from process and socket state, and shows that health in Settings.
+
+---
+
 ## [2026-05-21]
 
 ### Added

--- a/app/src/components/SettingsModal.css
+++ b/app/src/components/SettingsModal.css
@@ -263,6 +263,31 @@
   background: var(--color-bg-secondary);
 }
 
+.plugin-health-badge {
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.plugin-health-badge.healthy {
+  color: #1f8f4c;
+  background: rgba(31, 143, 76, 0.12);
+}
+
+.plugin-health-badge.unhealthy {
+  color: #b42318;
+  background: rgba(180, 35, 24, 0.12);
+}
+
+.plugin-health-badge.unknown {
+  color: var(--color-text-secondary);
+  background: var(--color-bg-secondary);
+}
+
 .endpoint-card {
   border: 1px solid var(--color-border);
   border-radius: 8px;

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -254,6 +254,7 @@ describe('SettingsModal review loop prompts', () => {
       priority: 0,
       connected: false,
       running: true,
+      health_status: 'unknown',
     };
 
     const { rerender } = render(
@@ -268,11 +269,12 @@ describe('SettingsModal review loop prompts', () => {
     rerender(
       <SettingsModal
         {...baseProps}
-        plugins={[{ ...startingPlugin, connected: true }]}
+        plugins={[{ ...startingPlugin, connected: true, health_status: 'healthy' }]}
       />,
     );
 
     expect(await screen.findByText('connected')).toBeInTheDocument();
+    expect(await screen.findByText('healthy')).toBeInTheDocument();
   });
 
   it('toggles tailscale serve on the existing device', async () => {

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -935,6 +935,7 @@ export function SettingsModal({
                 {plugins.map((plugin) => {
                   const busy = pluginActionName === plugin.name;
                   const draftPriority = pluginPriorityDrafts[plugin.name] ?? String(plugin.priority);
+                  const healthStatus = plugin.health_status || 'unknown';
                   return (
                     <div key={plugin.name} className="plugin-card">
                       <div className="plugin-card-header">
@@ -944,12 +945,20 @@ export function SettingsModal({
                           <span className={`plugin-status-badge ${plugin.connected ? 'connected' : plugin.running ? 'starting' : 'stopped'}`}>
                             {plugin.connected ? 'connected' : plugin.running ? 'starting' : 'stopped'}
                           </span>
+                          <span className={`plugin-health-badge ${healthStatus}`}>
+                            {healthStatus}
+                          </span>
                         </div>
                         <button className="browse-btn danger" onClick={() => void handleRemovePlugin(plugin.name)} disabled={pluginActionName !== null}>
                           Remove
                         </button>
                       </div>
                       {plugin.description && <p className="settings-description plugin-description">{plugin.description}</p>}
+                      {plugin.health_message && (
+                        <div className="settings-agent-warning">
+                          Healthcheck: {plugin.health_message}
+                        </div>
+                      )}
                       <div className="plugin-meta-grid">
                         <div className="endpoint-meta">
                           <span className="endpoint-meta-label">Path</span>

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -472,7 +472,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '62',
+        protocol_version: '63',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -548,7 +548,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '62',
+        protocol_version: '63',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -627,7 +627,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '62',
+        protocol_version: '63',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -720,7 +720,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '62',
+        protocol_version: '63',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -817,7 +817,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '62',
+        protocol_version: '63',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -900,7 +900,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '62',
+        protocol_version: '63',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -1009,7 +1009,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '62',
+        protocol_version: '63',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -1067,7 +1067,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '62',
+        protocol_version: '63',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -151,7 +151,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '62';
+const PROTOCOL_VERSION = '63';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 // Runtime gate (flipped from VITE_UI_AUTOMATION). The Rust shell
 // injects this global before any page script runs — see

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1540,13 +1540,16 @@ export enum PluginActionResultMessageEvent {
 }
 
 export interface PluginInfo {
-    connected:    boolean;
-    description?: string;
-    dir:          string;
-    name:         string;
-    priority:     number;
-    running:      boolean;
-    version:      string;
+    connected:       boolean;
+    description?:    string;
+    dir:             string;
+    health_message?: string;
+    health_status?:  string;
+    last_health_at?: string;
+    name:            string;
+    priority:        number;
+    running:         boolean;
+    version:         string;
     [property: string]: any;
 }
 
@@ -1574,13 +1577,16 @@ export interface IssueElement {
 }
 
 export interface PluginElement {
-    connected:    boolean;
-    description?: string;
-    dir:          string;
-    name:         string;
-    priority:     number;
-    running:      boolean;
-    version:      string;
+    connected:       boolean;
+    description?:    string;
+    dir:             string;
+    health_message?: string;
+    health_status?:  string;
+    last_health_at?: string;
+    name:            string;
+    priority:        number;
+    running:         boolean;
+    version:         string;
     [property: string]: any;
 }
 
@@ -5154,6 +5160,9 @@ const typeMap: any = {
         { json: "connected", js: "connected", typ: true },
         { json: "description", js: "description", typ: u(undefined, "") },
         { json: "dir", js: "dir", typ: "" },
+        { json: "health_message", js: "health_message", typ: u(undefined, "") },
+        { json: "health_status", js: "health_status", typ: u(undefined, "") },
+        { json: "last_health_at", js: "last_health_at", typ: u(undefined, "") },
         { json: "name", js: "name", typ: "" },
         { json: "priority", js: "priority", typ: 0 },
         { json: "running", js: "running", typ: true },
@@ -5176,6 +5185,9 @@ const typeMap: any = {
         { json: "connected", js: "connected", typ: true },
         { json: "description", js: "description", typ: u(undefined, "") },
         { json: "dir", js: "dir", typ: "" },
+        { json: "health_message", js: "health_message", typ: u(undefined, "") },
+        { json: "health_status", js: "health_status", typ: u(undefined, "") },
+        { json: "last_health_at", js: "last_health_at", typ: u(undefined, "") },
         { json: "name", js: "name", typ: "" },
         { json: "priority", js: "priority", typ: 0 },
         { json: "running", js: "running", typ: true },

--- a/internal/daemon/plugin_rpc.go
+++ b/internal/daemon/plugin_rpc.go
@@ -13,9 +13,13 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 const pluginAPIVersion = 1
+const pluginHealthMethod = "attn.health"
+const pluginHealthInterval = 15 * time.Second
+const pluginHealthTimeout = 2 * time.Second
 
 const (
 	jsonRPCParseError     = -32700
@@ -33,6 +37,15 @@ type pluginHelloParams struct {
 
 type pluginHelloResult struct {
 	OK bool `json:"ok"`
+}
+
+type pluginHealthParams struct {
+	Now string `json:"now"`
+}
+
+type pluginHealthResult struct {
+	OK      bool   `json:"ok"`
+	Message string `json:"message,omitempty"`
 }
 
 type jsonRPCMessage struct {
@@ -233,14 +246,20 @@ type pluginConnection struct {
 	pending   map[string]chan jsonRPCMessage
 	nextID    uint64
 	closed    bool
+
+	healthMu      sync.RWMutex
+	healthStatus  string
+	healthMessage string
+	lastHealthAt  time.Time
 }
 
 func newPluginConnection(conn net.Conn, reader *bufio.Reader, params pluginHelloParams) *pluginConnection {
 	return &pluginConnection{
-		name:    strings.TrimSpace(params.Name),
-		conn:    conn,
-		reader:  reader,
-		pending: make(map[string]chan jsonRPCMessage),
+		name:         strings.TrimSpace(params.Name),
+		conn:         conn,
+		reader:       reader,
+		pending:      make(map[string]chan jsonRPCMessage),
+		healthStatus: "unknown",
 	}
 }
 
@@ -335,6 +354,23 @@ func (p *pluginConnection) request(ctx context.Context, method string, params in
 		}
 		return nil
 	}
+}
+
+func (p *pluginConnection) setHealth(status, message string, at time.Time) {
+	p.healthMu.Lock()
+	defer p.healthMu.Unlock()
+	p.healthStatus = strings.TrimSpace(status)
+	if p.healthStatus == "" {
+		p.healthStatus = "unknown"
+	}
+	p.healthMessage = strings.TrimSpace(message)
+	p.lastHealthAt = at
+}
+
+func (p *pluginConnection) healthSnapshot() (string, string, time.Time) {
+	p.healthMu.RLock()
+	defer p.healthMu.RUnlock()
+	return p.healthStatus, p.healthMessage, p.lastHealthAt
 }
 
 func readSocketFrame(reader *bufio.Reader) ([]byte, error) {
@@ -504,6 +540,7 @@ func (d *Daemon) handlePluginConnection(conn net.Conn, reader *bufio.Reader, hel
 		return
 	}
 	d.broadcastPluginsUpdated()
+	go d.monitorPluginHealth(plugin)
 
 	for {
 		data, err := readSocketFrame(reader)
@@ -545,4 +582,53 @@ func (d *Daemon) callPlugin(ctx context.Context, name, method string, params int
 		return fmt.Errorf("plugin %q is not connected", name)
 	}
 	return plugin.request(ctx, method, params, result)
+}
+
+func (d *Daemon) monitorPluginHealth(plugin *pluginConnection) {
+	timer := time.NewTimer(500 * time.Millisecond)
+	defer timer.Stop()
+	for {
+		select {
+		case <-d.done:
+			return
+		case <-timer.C:
+		}
+
+		if d.ensurePluginRegistry().get(plugin.name) != plugin {
+			return
+		}
+		d.checkPluginHealth(plugin)
+		timer.Reset(pluginHealthInterval)
+	}
+}
+
+func (d *Daemon) checkPluginHealth(plugin *pluginConnection) {
+	now := time.Now().UTC()
+	ctx, cancel := context.WithTimeout(context.Background(), pluginHealthTimeout)
+	defer cancel()
+
+	var result pluginHealthResult
+	err := plugin.request(ctx, pluginHealthMethod, pluginHealthParams{
+		Now: now.Format(time.RFC3339Nano),
+	}, &result)
+	if err != nil {
+		plugin.setHealth("unhealthy", err.Error(), now)
+		d.logf("plugin health plugin=%s status=unhealthy error=%s", plugin.name, providerLogValue(err.Error()))
+		d.broadcastPluginsUpdated()
+		return
+	}
+	if !result.OK {
+		message := strings.TrimSpace(result.Message)
+		if message == "" {
+			message = "plugin reported unhealthy"
+		}
+		plugin.setHealth("unhealthy", message, now)
+		d.logf("plugin health plugin=%s status=unhealthy error=%s", plugin.name, providerLogValue(message))
+		d.broadcastPluginsUpdated()
+		return
+	}
+
+	plugin.setHealth("healthy", result.Message, now)
+	d.logf("plugin health plugin=%s status=healthy", plugin.name)
+	d.broadcastPluginsUpdated()
 }

--- a/internal/daemon/plugin_rpc_test.go
+++ b/internal/daemon/plugin_rpc_test.go
@@ -333,6 +333,67 @@ func TestDaemon_Surfaces_OrderHandlersAndCleanUpOnDisconnect(t *testing.T) {
 	}
 }
 
+func TestDaemon_PluginHealthCheckRecordsStatus(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.pluginDir = filepath.Join(t.TempDir(), "plugins")
+	writeTestPluginManifest(t, d.pluginDir, "health-provider")
+
+	client, done := startPluginPipe(t, d, "health-provider", []string{"worktree.create"})
+	defer client.Close()
+
+	plugin := d.plugins.get("health-provider")
+	if plugin == nil {
+		t.Fatal("plugin registry missing health-provider")
+	}
+
+	healthDone := make(chan struct{})
+	go func() {
+		defer close(healthDone)
+		request := decodeJSONRPCMessage(t, client)
+		if request.Method != pluginHealthMethod {
+			t.Errorf("health method=%q, want %s", request.Method, pluginHealthMethod)
+			return
+		}
+		result, err := json.Marshal(pluginHealthResult{OK: true})
+		if err != nil {
+			t.Errorf("marshal health result: %v", err)
+			return
+		}
+		if err := json.NewEncoder(client).Encode(jsonRPCMessage{
+			JSONRPC: "2.0",
+			ID:      request.ID,
+			Result:  result,
+		}); err != nil {
+			t.Errorf("encode health result: %v", err)
+		}
+	}()
+
+	d.checkPluginHealth(plugin)
+	select {
+	case <-healthDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("health request did not complete")
+	}
+
+	plugins := d.pluginsUpdatedMessage().Plugins
+	if len(plugins) != 1 {
+		t.Fatalf("plugin count=%d, want 1", len(plugins))
+	}
+	if got := protocol.Deref(plugins[0].HealthStatus); got != "healthy" {
+		t.Fatalf("health status=%q, want healthy", got)
+	}
+	if protocol.Deref(plugins[0].LastHealthAt) == "" {
+		t.Fatal("last health timestamp empty")
+	}
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("health provider connection did not close")
+	}
+}
+
 func startPluginPipe(t *testing.T, d *Daemon, name string, surfaces []string) (net.Conn, <-chan struct{}) {
 	t.Helper()
 	serverConn, clientConn := net.Pipe()

--- a/internal/daemon/ws_plugins.go
+++ b/internal/daemon/ws_plugins.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/victorarias/attn/internal/plugins"
 	"github.com/victorarias/attn/internal/protocol"
@@ -78,16 +79,35 @@ func (d *Daemon) pluginsUpdatedMessage() *protocol.PluginsUpdatedMessage {
 	priorities := d.pluginPriorities()
 	pluginInfos := make([]protocol.PluginInfo, 0, len(manifests))
 	for _, manifest := range manifests {
+		connection := d.ensurePluginRegistry().get(manifest.Name)
+		healthStatus := "unknown"
+		var healthMessage string
+		var lastHealthAt string
+		if connection != nil {
+			status, message, checkedAt := connection.healthSnapshot()
+			healthStatus = status
+			healthMessage = message
+			if !checkedAt.IsZero() {
+				lastHealthAt = checkedAt.Format(time.RFC3339Nano)
+			}
+		}
 		info := protocol.PluginInfo{
-			Name:      manifest.Name,
-			Version:   manifest.Version,
-			Dir:       manifest.Dir,
-			Priority:  priorities[manifest.Name],
-			Connected: d.ensurePluginRegistry().get(manifest.Name) != nil,
-			Running:   d.ensurePluginProcessRegistry().isRunning(manifest.Name),
+			Name:         manifest.Name,
+			Version:      manifest.Version,
+			Dir:          manifest.Dir,
+			Priority:     priorities[manifest.Name],
+			Connected:    connection != nil,
+			Running:      d.ensurePluginProcessRegistry().isRunning(manifest.Name),
+			HealthStatus: protocol.Ptr(healthStatus),
 		}
 		if manifest.Description != "" {
 			info.Description = protocol.Ptr(manifest.Description)
+		}
+		if healthMessage != "" {
+			info.HealthMessage = protocol.Ptr(healthMessage)
+		}
+		if lastHealthAt != "" {
+			info.LastHealthAt = protocol.Ptr(lastHealthAt)
 		}
 		pluginInfos = append(pluginInfos, info)
 	}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "62"
+const ProtocolVersion = "63"
 
 // Commands
 const (

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1336,6 +1336,15 @@ type PluginInfo struct {
 	// Dir corresponds to the JSON schema field "dir".
 	Dir string `json:"dir"`
 
+	// HealthMessage corresponds to the JSON schema field "health_message".
+	HealthMessage *string `json:"health_message,omitempty,omitzero"`
+
+	// HealthStatus corresponds to the JSON schema field "health_status".
+	HealthStatus *string `json:"health_status,omitempty,omitzero"`
+
+	// LastHealthAt corresponds to the JSON schema field "last_health_at".
+	LastHealthAt *string `json:"last_health_at,omitempty,omitzero"`
+
 	// Name corresponds to the JSON schema field "name".
 	Name string `json:"name"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -219,6 +219,9 @@ model PluginInfo {
   priority: int32;
   connected: boolean;
   running: boolean;
+  health_status?: string;
+  health_message?: string;
+  last_health_at?: string;
 }
 
 model PluginIssue {

--- a/native-ui/crates/attn-protocol/src/lib.rs
+++ b/native-ui/crates/attn-protocol/src/lib.rs
@@ -14,7 +14,7 @@ pub use types::*;
 
 /// Current protocol version — must match `ProtocolVersion` in
 /// `internal/protocol/constants.go`.
-pub const PROTOCOL_VERSION: &str = "62";
+pub const PROTOCOL_VERSION: &str = "63";
 
 /// Capability strings advertised in `ClientHelloMessage.capabilities`.
 /// Mirror of `protocol.Capability*` in `internal/protocol/constants.go`.

--- a/sdk/plugin/README.md
+++ b/sdk/plugin/README.md
@@ -7,6 +7,7 @@ This first cut focuses on the worktree extension path already exercised by attn:
 - connect to the attn daemon over its plugin socket
 - send the `hello` handshake
 - declare concrete handled surfaces during the connection handshake
+- respond to daemon healthchecks automatically
 - handle daemon-initiated JSON-RPC requests
 - return structured `handled`, `decline`, or `error` results
 
@@ -43,6 +44,10 @@ registered surface in the daemon handshake, so plugin code does not maintain a
 second registration list. Managed plugins get `ATTN_SOCKET_PATH` and
 `ATTN_PLUGIN_NAME` from attn; manually-launched plugins can still pass
 `socketPath` or `name` explicitly.
+
+The SDK handles `attn.health` internally and returns `{ ok: true }`. Plugin
+authors do not need to register a health handler for the daemon to distinguish a
+live plugin from a process that merely started.
 
 Create lifecycle hooks use the same registration path:
 

--- a/sdk/plugin/package.json
+++ b/sdk/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@victorarias/attn-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript SDK for attn plugins",
   "license": "GPL-3.0-only",
   "type": "module",

--- a/sdk/plugin/src/index.ts
+++ b/sdk/plugin/src/index.ts
@@ -114,6 +114,10 @@ type HelloResult = {
   ok: boolean;
 };
 
+type HealthResult = {
+  ok: boolean;
+};
+
 const pluginAPIVersion = 1;
 
 export class AttnPluginClient {
@@ -247,6 +251,15 @@ export class AttnPluginClient {
   }
 
   private async handleRequest(request: JsonRpcRequest): Promise<void> {
+    if (request.method === "attn.health") {
+      this.send({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: { ok: true } satisfies HealthResult,
+      });
+      return;
+    }
+
     const handler = this.handlers.get(request.method as PluginSurface);
     if (!handler) {
       this.sendError(request.id, -32601, `unknown method ${request.method}`);

--- a/sdk/plugin/test/client.test.ts
+++ b/sdk/plugin/test/client.test.ts
@@ -142,6 +142,36 @@ describe("AttnPluginClient", () => {
     await server.close();
   });
 
+  test("responds to daemon healthchecks without plugin code", async () => {
+    const server = await startServer(async (socket, request) => {
+      if (request.method === "hello") {
+        socket.write(`${JSON.stringify(response(request.id, { ok: true }))}\n`);
+        socket.write(
+          `${JSON.stringify({
+            jsonrpc: "2.0",
+            id: 100,
+            method: "attn.health",
+            params: { now: "2026-05-22T00:00:00Z" },
+          })}\n`,
+        );
+      }
+    });
+
+    const client = new AttnPluginClient({
+      socketPath: server.socketPath,
+      name: "sdk-health",
+      version: "0.1.0",
+    });
+
+    await client.connect();
+    await waitFor(() => server.responses.length === 1);
+
+    expect(server.responses[0]).toEqual(response(100, { ok: true }));
+
+    client.close();
+    await server.close();
+  });
+
   test("drops pending requests when send fails before writing", async () => {
     const client = new AttnPluginClient({
       socketPath: "/tmp/unused.sock",


### PR DESCRIPTION
## Intent/Why

Plugins can currently look stuck or alive based only on process and socket state. This adds a daemon-owned healthcheck so Settings can distinguish a started process, a connected plugin, and a plugin that is actually responding to daemon RPC.

## Summary

- Adds daemon health polling for connected plugins and records healthy, unhealthy, or unknown state.
- Extends plugin info with health fields and bumps protocol version to 63 across Go, Tauri, and native protocol constants.
- Updates Settings to show plugin health separately from running/connected state.
- Updates the TypeScript plugin SDK to answer healthchecks automatically and bumps the SDK package version to 0.1.1.

## Test plan

- [x] `go test -count=1 ./internal/daemon -run 'TestDaemon_PluginHealthCheckRecordsStatus'`
- [x] `go test ./internal/daemon ./internal/protocol`
- [x] `bun test sdk/plugin/test/client.test.ts`
- [x] `pnpm --dir app test SettingsModal.test.tsx useDaemonSocket.test.tsx --run`
- [x] `pnpm --dir app run build`

## Out of scope

- Publishing `@victorarias/attn-plugin@0.1.1` to npm after this lands.
- Redesigning the Settings panel layout.
