### PR TITLE
feat(settings): redesign workbench and preserve typed text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,20 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-05-23]
+
+### Changed
+- **Input Assistance Disabled**: attn no longer allows browser or operating-system autocorrection, auto-capitalization, or spellchecking to rewrite typed paths, branches, commands, prompts, comments, or searches.
+
+---
+
 ## [2026-05-22]
 
 ### Added
 - **Plugin Healthchecks**: The daemon now pings connected plugins, records healthy/unhealthy/unknown state separately from process and socket state, and shows that health in Settings.
+
+### Changed
+- **Settings Workbench**: Settings now opens as a larger workbench with separate navigation for general preferences, connectivity, plugins, agents, review settings, and muted items instead of one long mixed page.
 
 ---
 

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -11,6 +11,8 @@ node_modules
 dist
 dist-ssr
 *.local
+playwright-report
+test-results
 
 # Editor directories and files
 .vscode/*

--- a/app/e2e/settings-visual.spec.ts
+++ b/app/e2e/settings-visual.spec.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import { test, expect } from './fixtures';
+
+const viewports = [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'tablet', width: 1024, height: 820 },
+  { name: 'mobile', width: 430, height: 860 },
+] as const;
+
+const sections = ['general', 'connectivity', 'plugins', 'agents', 'review', 'hygiene'] as const;
+
+test.describe('Settings visual harness', () => {
+  for (const viewport of viewports) {
+    test(`captures settings workbench at ${viewport.name} size`, async ({ page, startDaemonWithPRs }, testInfo) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await startDaemonWithPRs();
+      await page.goto('/');
+
+      await expect(page.locator('.dashboard')).toBeVisible({ timeout: 5000 });
+      await page.getByTestId('settings-button').click();
+
+      const modal = page.getByTestId('settings-modal');
+      await expect(modal).toBeVisible({ timeout: 2000 });
+
+      const modalBox = await modal.boundingBox();
+      expect(modalBox?.width ?? 0).toBeGreaterThan(Math.min(300, viewport.width - 80));
+      expect(modalBox?.height ?? 0).toBeGreaterThan(Math.min(320, viewport.height - 120));
+
+      const body = page.getByTestId('settings-body');
+      for (const section of sections) {
+        await modal.getByTestId(`settings-nav-${section}`).click();
+        await body.evaluate((node) => {
+          node.scrollTop = 0;
+        });
+        await page.waitForTimeout(80);
+
+        const sectionPath = testInfo.outputPath(`settings-modal-${viewport.name}-${section}.png`);
+        await modal.screenshot({ path: sectionPath });
+        expect(fs.existsSync(sectionPath)).toBe(true);
+      }
+
+      await modal.getByTestId('settings-nav-agents').click();
+      await body.evaluate((node) => {
+        node.scrollTop = node.scrollHeight;
+      });
+      await page.waitForTimeout(80);
+
+      const bottomPath = testInfo.outputPath(`settings-modal-${viewport.name}-agents-bottom.png`);
+      await modal.screenshot({ path: bottomPath });
+      expect(fs.existsSync(bottomPath)).toBe(true);
+    });
+  }
+});

--- a/app/e2e/settings.spec.ts
+++ b/app/e2e/settings.spec.ts
@@ -10,19 +10,26 @@ test.describe('Settings', () => {
     await expect(page.locator('.dashboard')).toBeVisible({ timeout: 5000 });
 
     // Click settings button
-    const settingsBtn = page.locator('.settings-btn');
+    const settingsBtn = page.getByTestId('settings-button');
     await settingsBtn.click();
 
     // Settings modal should open
-    const modal = page.locator('.settings-modal');
+    const modal = page.getByTestId('settings-modal');
     await expect(modal).toBeVisible({ timeout: 2000 });
+    const searchInput = modal.getByRole('searchbox', { name: 'Search settings' });
+    await expect(searchInput).toHaveAttribute('autocorrect', 'off');
+    await expect(searchInput).toHaveAttribute('autocapitalize', 'none');
+    await expect(searchInput).toHaveAttribute('spellcheck', 'false');
 
-    // Verify modal has expected sections
+    // Verify workbench navigation exposes separated settings areas
+    await expect(modal.locator('h3', { hasText: 'Mobile Web Client' })).toBeVisible();
+    await modal.getByTestId('settings-nav-general').click();
     await expect(modal.locator('h3', { hasText: 'Projects Directory' })).toBeVisible();
+    await modal.getByTestId('settings-nav-hygiene').click();
     await expect(modal.locator('h3', { hasText: 'Muted Repositories' })).toBeVisible();
 
     // Close modal via X button
-    const closeBtn = modal.locator('.settings-close');
+    const closeBtn = modal.getByTestId('settings-close');
     await closeBtn.click();
 
     // Modal should be hidden
@@ -36,12 +43,12 @@ test.describe('Settings', () => {
     await expect(page.locator('.dashboard')).toBeVisible({ timeout: 5000 });
 
     // Open settings
-    await page.locator('.settings-btn').click();
-    const modal = page.locator('.settings-modal');
+    await page.getByTestId('settings-button').click();
+    const modal = page.getByTestId('settings-modal');
     await expect(modal).toBeVisible({ timeout: 2000 });
 
     // Click overlay (outside modal)
-    await page.locator('.settings-overlay').click({ position: { x: 10, y: 10 } });
+    await page.getByTestId('settings-overlay').click({ position: { x: 10, y: 10 } });
 
     // Modal should be hidden
     await expect(modal).not.toBeVisible();
@@ -54,23 +61,25 @@ test.describe('Settings', () => {
     await expect(page.locator('.dashboard')).toBeVisible({ timeout: 5000 });
 
     // Open settings
-    await page.locator('.settings-btn').click();
-    const modal = page.locator('.settings-modal');
+    await page.getByTestId('settings-button').click();
+    const modal = page.getByTestId('settings-modal');
     await expect(modal).toBeVisible({ timeout: 2000 });
+    await modal.getByTestId('settings-nav-general').click();
 
     // Type a projects directory
     const projectsDir = '/tmp/attn-e2e-projects-manual';
-    const input = modal.locator('.projects-dir-input .settings-input');
+    const input = modal.getByTestId('settings-projects-directory-input');
     await input.fill(projectsDir);
     await input.blur();
 
     // Close and reopen to verify persistence
-    await modal.locator('.settings-close').click();
+    await modal.getByTestId('settings-close').click();
     await expect(modal).not.toBeVisible();
 
     // Reopen settings
-    await page.locator('.settings-btn').click();
+    await page.getByTestId('settings-button').click();
     await expect(modal).toBeVisible({ timeout: 2000 });
+    await modal.getByTestId('settings-nav-general').click();
 
     // Value should be preserved
     await expect(input).toHaveValue(projectsDir);
@@ -100,12 +109,13 @@ test.describe('Settings', () => {
     await expect(prCard).not.toBeVisible({ timeout: 5000 });
 
     // Open settings
-    await page.locator('.settings-btn').click();
-    const modal = page.locator('.settings-modal');
+    await page.getByTestId('settings-button').click();
+    const modal = page.getByTestId('settings-modal');
     await expect(modal).toBeVisible({ timeout: 2000 });
+    await modal.getByTestId('settings-nav-hygiene').click();
 
     // Muted repo should appear in list
-    const mutedRepoItem = modal.locator('.muted-item').filter({ hasText: 'test/settings-repo' });
+    const mutedRepoItem = modal.getByTestId('settings-muted-repository-item').filter({ hasText: 'test/settings-repo' });
     await expect(mutedRepoItem).toBeVisible();
   });
 
@@ -131,16 +141,17 @@ test.describe('Settings', () => {
     await expect(prCard).not.toBeVisible({ timeout: 5000 });
 
     // Open settings
-    await page.locator('.settings-btn').click();
-    const modal = page.locator('.settings-modal');
+    await page.getByTestId('settings-button').click();
+    const modal = page.getByTestId('settings-modal');
     await expect(modal).toBeVisible({ timeout: 2000 });
+    await modal.getByTestId('settings-nav-hygiene').click();
 
     // Click unmute button
-    const mutedRepoItem = modal.locator('.muted-item').filter({ hasText: 'test/unmute-repo' });
-    await mutedRepoItem.locator('.unmute-btn').click();
+    const mutedRepoItem = modal.getByTestId('settings-muted-repository-item').filter({ hasText: 'test/unmute-repo' });
+    await mutedRepoItem.getByTestId('settings-unmute-repository-button').click();
 
     // Close modal
-    await modal.locator('.settings-close').click();
+    await modal.getByTestId('settings-close').click();
     await expect(modal).not.toBeVisible();
 
     // PR should reappear
@@ -177,15 +188,16 @@ test.describe('Settings', () => {
     await expect(prCard).not.toBeVisible({ timeout: 5000 });
 
     // Open settings
-    await page.locator('.settings-btn').click();
-    const modal = page.locator('.settings-modal');
+    await page.getByTestId('settings-button').click();
+    const modal = page.getByTestId('settings-modal');
     await expect(modal).toBeVisible({ timeout: 2000 });
+    await modal.getByTestId('settings-nav-hygiene').click();
 
     // Verify Muted Authors section exists
     await expect(modal.locator('h3', { hasText: 'Muted Authors' })).toBeVisible();
 
     // Muted author should appear in list
-    const mutedAuthorItem = modal.locator('.muted-item').filter({ hasText: 'dependabot' });
+    const mutedAuthorItem = modal.getByTestId('settings-muted-author-item').filter({ hasText: 'dependabot' });
     await expect(mutedAuthorItem).toBeVisible();
   });
 
@@ -213,16 +225,17 @@ test.describe('Settings', () => {
     await expect(prCard).not.toBeVisible({ timeout: 5000 });
 
     // Open settings
-    await page.locator('.settings-btn').click();
-    const modal = page.locator('.settings-modal');
+    await page.getByTestId('settings-button').click();
+    const modal = page.getByTestId('settings-modal');
     await expect(modal).toBeVisible({ timeout: 2000 });
+    await modal.getByTestId('settings-nav-hygiene').click();
 
     // Click unmute button for the author
-    const mutedAuthorItem = modal.locator('.muted-item').filter({ hasText: 'renovate' });
-    await mutedAuthorItem.locator('.unmute-btn').click();
+    const mutedAuthorItem = modal.getByTestId('settings-muted-author-item').filter({ hasText: 'renovate' });
+    await mutedAuthorItem.getByTestId('settings-unmute-author-button').click();
 
     // Close modal
-    await modal.locator('.settings-close').click();
+    await modal.getByTestId('settings-close').click();
     await expect(modal).not.toBeVisible();
 
     // PR should reappear

--- a/app/package.json
+++ b/app/package.json
@@ -38,6 +38,7 @@
     "real-app:scenario-tr502": "node scripts/real-app-harness/scenario-tr502-remote-relaunch-splits.mjs",
     "real-app:serial-matrix": "node scripts/real-app-harness/run-serial-matrix.mjs",
     "e2e": "playwright test",
+    "e2e:settings-visual": "playwright test e2e/settings-visual.spec.ts",
     "e2e:headed": "playwright test --headed"
   },
   "dependencies": {

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -249,6 +249,7 @@ export function Dashboard({
         </div>
         <button
           className="settings-btn"
+          data-testid="settings-button"
           onClick={onOpenSettings}
           title="Settings"
         >

--- a/app/src/components/SettingsModal.css
+++ b/app/src/components/SettingsModal.css
@@ -6,155 +6,559 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 300;
+  z-index: 10000;
+  padding: 20px;
+  isolation: isolate;
+  contain: paint;
 }
 
 .settings-modal {
-  width: 960px;
-  max-width: calc(100vw - 48px);
-  max-height: 80vh;
+  position: relative;
+  z-index: 10001;
+  isolation: isolate;
+  contain: paint;
+  transform: translateZ(0);
+  width: min(1380px, calc(100vw - 40px));
+  height: min(880px, calc(100vh - 40px));
+  min-height: 520px;
   background: var(--color-bg-panel);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-border-hover);
   border-radius: 8px;
-  box-shadow: 0 24px 64px var(--color-bg-overlay);
-  display: flex;
-  flex-direction: column;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.48);
+  display: grid;
+  grid-template-rows: 58px minmax(0, 1fr);
+  overflow: hidden;
 }
 
 .settings-header {
-  padding: 16px;
-  border-bottom: 1px solid var(--color-border);
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 18px 0 22px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-panel);
 }
 
-.settings-header h2 {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--color-text-primary);
+.settings-title {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.settings-title h2 {
   margin: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.settings-profile {
+  border-left: 1px solid var(--color-border);
+  padding-left: 16px;
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+}
+
+.settings-top-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.settings-search {
+  width: 280px;
+  height: 34px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-input);
+  color: var(--color-text-primary);
+  padding: 0 12px;
+  font-size: var(--font-size-sm);
+  outline: none;
+}
+
+.settings-search:focus {
+  border-color: var(--color-border-focus);
 }
 
 .settings-close {
-  background: transparent;
-  border: none;
-  color: var(--color-text-dimmed);
-  font-size: 20px;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--color-border-hover);
+  border-radius: 6px;
+  background: var(--color-bg-button);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
+  font-weight: 700;
   cursor: pointer;
-  padding: 0;
-  line-height: 1;
 }
 
 .settings-close:hover {
   color: var(--color-text-primary);
+  border-color: var(--color-border-focus);
+}
+
+.settings-layout {
+  position: relative;
+  z-index: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 258px minmax(0, 1fr);
+  background: var(--color-bg-panel);
+}
+
+.settings-nav {
+  min-height: 0;
+  overflow: auto;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-bg-app);
+  padding: 18px 12px;
+}
+
+.settings-nav-group + .settings-nav-group {
+  margin-top: 20px;
+}
+
+.settings-nav-label,
+.settings-kicker,
+.settings-label,
+.settings-meta-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  line-height: 1;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--color-text-dimmed);
+}
+
+.settings-nav-label {
+  padding: 0 10px 8px;
+}
+
+.settings-nav-item {
+  width: 100%;
+  min-height: 38px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  padding: 8px 10px;
+  text-align: left;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.settings-nav-item:hover {
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+}
+
+.settings-nav-item.active {
+  background: rgba(245, 155, 74, 0.12);
+  color: var(--color-text-primary);
+  box-shadow: inset 3px 0 0 #f59b4a;
+}
+
+.settings-nav-count {
+  min-width: 22px;
+  height: 20px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-text-tertiary);
+  text-align: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  line-height: 18px;
 }
 
 .settings-body {
-  padding: 16px;
-  overflow-y: auto;
+  position: relative;
+  min-height: 0;
+  overflow: auto;
+  background: var(--color-bg-panel);
+  padding: 26px 28px 32px;
+  contain: paint;
 }
 
-.settings-body h3 {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--color-text-dimmed);
-  margin: 0 0 12px 0;
+.settings-section-content {
+  background: var(--color-bg-panel);
+}
+
+.settings-content-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.settings-content-head h1 {
+  margin: 7px 0 0;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-lg);
+  line-height: 1.1;
+  font-weight: 750;
+  letter-spacing: 0;
+}
+
+.settings-lead {
+  max-width: 680px;
+  margin: 9px 0 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
+  line-height: 1.45;
+}
+
+.settings-status-pair {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.settings-block {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  border-top: 1px solid var(--color-border);
+  padding: 20px 0 22px;
+}
+
+.settings-block:last-child {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.settings-block h3 {
+  margin: 7px 0 8px;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  line-height: 1.2;
+}
+
+.settings-description {
+  margin: 0;
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-md);
+  line-height: 1.45;
+}
+
+.settings-block-body {
+  min-width: 0;
+  display: grid;
+  gap: 10px;
+  align-content: start;
 }
 
 .settings-empty {
-  color: var(--color-text-dimmed);
-  font-size: 13px;
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-md);
+  line-height: 1.4;
   margin: 0;
 }
 
-.muted-items-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.nav-empty {
+  padding: 0 10px;
 }
 
-.muted-item {
-  display: flex;
+.settings-hint {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+}
+
+.settings-warning {
+  color: #ff9f7a;
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.settings-warning a,
+.settings-meta-row a {
+  color: #77a7ff;
+}
+
+.settings-pill,
+.endpoint-status-badge,
+.plugin-status-badge,
+.plugin-health-badge,
+.agent-capability-pill {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 10px 12px;
-  border-radius: 6px;
-  margin-bottom: 4px;
-}
-
-.muted-item:hover {
+  min-height: 24px;
+  width: fit-content;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
   background: var(--color-bg-elevated);
+  color: var(--color-text-secondary);
+  padding: 2px 8px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 
-.muted-item-name {
-  font-size: 13px;
+.settings-pill.good,
+.endpoint-status-badge.status-connected,
+.plugin-status-badge.connected,
+.plugin-health-badge.healthy,
+.agent-capability-pill.enabled {
+  color: #60c287;
+  border-color: rgba(96, 194, 135, 0.42);
+  background: rgba(96, 194, 135, 0.11);
+}
+
+.settings-pill.warn,
+.endpoint-status-badge.status-connecting,
+.endpoint-status-badge.status-bootstrapping,
+.plugin-status-badge.starting {
+  color: #f59b4a;
+  border-color: rgba(245, 155, 74, 0.42);
+  background: rgba(245, 155, 74, 0.11);
+}
+
+.settings-pill.bad,
+.endpoint-status-badge.status-error,
+.endpoint-status-badge.status-disconnected,
+.plugin-health-badge.unhealthy,
+.agent-capability-pill.disabled {
+  color: #ff746c;
+  border-color: rgba(255, 116, 108, 0.42);
+  background: rgba(255, 116, 108, 0.11);
+}
+
+.settings-inline-form,
+.settings-form-grid {
+  display: grid;
+  gap: 8px;
+  align-items: start;
+}
+
+.settings-inline-form {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.plugin-form {
+  grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+.endpoint-form {
+  grid-template-columns: minmax(120px, 0.85fr) minmax(160px, 1.2fr) minmax(92px, 0.55fr) auto;
+}
+
+.endpoint-form-inline {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.settings-input,
+.settings-textarea {
+  width: 100%;
+  min-width: 0;
+  background: var(--color-bg-input);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
   color: var(--color-text-primary);
   font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-sm);
+  outline: none;
 }
 
-.unmute-btn {
-  background: var(--color-bg-button);
+.settings-input {
+  height: 38px;
+  padding: 0 12px;
+}
+
+.settings-textarea {
+  min-height: 138px;
+  padding: 10px 12px;
+  resize: vertical;
+}
+
+.settings-input:focus,
+.settings-textarea:focus {
+  border-color: var(--color-border-focus);
+}
+
+.settings-input::placeholder,
+.settings-textarea::placeholder {
+  color: var(--color-text-dimmed);
+}
+
+.settings-action {
+  min-height: 38px;
   border: 1px solid var(--color-border-hover);
-  border-radius: 4px;
-  padding: 4px 10px;
-  font-size: 11px;
-  font-weight: 600;
+  border-radius: 6px;
+  background: var(--color-bg-button);
   color: var(--color-text-secondary);
+  padding: 0 14px;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  white-space: nowrap;
   cursor: pointer;
-  transition: all 150ms ease-out;
 }
 
-.unmute-btn:hover {
+.settings-action:hover:not(:disabled) {
   background: var(--color-bg-panel);
   color: var(--color-text-primary);
   border-color: var(--color-border-focus);
 }
 
-.unmute-btn:focus {
-  outline: 2px solid #ff6b35;
-  outline-offset: 1px;
+.settings-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
 }
 
-/* Settings sections */
-.settings-section {
-  margin-bottom: 24px;
+.settings-action.danger {
+  color: #ff746c;
+  border-color: rgba(255, 116, 108, 0.38);
 }
 
-.settings-section:last-child {
-  margin-bottom: 0;
+.settings-segmented {
+  width: fit-content;
+  max-width: 100%;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-elevated);
+  padding: 5px;
 }
 
-.settings-description {
-  font-size: 12px;
-  color: var(--color-text-tertiary);
-  margin: 0 0 12px 0;
+.settings-segmented-option {
+  min-height: 32px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  padding: 0 12px;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.settings-segmented-option:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  background: var(--color-bg-button);
+}
+
+.settings-segmented-option.active {
+  color: #1c1308;
+  background: #f59b4a;
+  border-color: rgba(245, 155, 74, 0.8);
+}
+
+.settings-segmented-option:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.settings-row-card {
+  min-height: 56px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 7px;
+  background: var(--color-bg-elevated);
+  padding: 12px 14px;
+}
+
+.settings-row-card.compact {
+  min-height: 48px;
+}
+
+.settings-row-title {
+  margin: 0 0 4px;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  font-weight: 750;
+}
+
+.settings-row-copy {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.settings-token-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.settings-token {
+  display: inline-flex;
+  align-items: center;
+  min-height: 31px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-input);
+  color: var(--color-text-primary);
+  padding: 0 10px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+}
+
+.settings-meta-row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
   line-height: 1.4;
 }
 
-.host-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.host-pill {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+.settings-meta-row code {
   color: var(--color-text-primary);
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--color-border);
-  padding: 4px 8px;
-  border-radius: 12px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-sm);
+  overflow-wrap: anywhere;
 }
 
-.settings-hint {
-  margin-top: 8px;
-  font-size: 11px;
-  color: var(--color-text-muted);
+.endpoint-list,
+.plugin-list,
+.review-loop-settings,
+.review-loop-settings-list,
+.agent-capabilities-list,
+.settings-field-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.settings-field-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.settings-field-grid.two-column {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.settings-field {
+  min-width: 0;
+  display: grid;
+  gap: 7px;
 }
 
 .settings-row-inline {
@@ -164,439 +568,116 @@
   gap: 10px;
 }
 
-.endpoint-form {
-  display: grid;
-  grid-template-columns: 1fr 1.2fr auto;
-  gap: 8px;
-  margin-bottom: 12px;
-}
-
-.endpoint-form-inline {
-  margin-bottom: 0;
-}
-
-.endpoint-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.plugin-form {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  gap: 8px;
-  margin-bottom: 12px;
-}
-
-.plugin-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.plugin-card {
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  padding: 12px;
-  background: var(--color-bg-elevated);
-}
-
-.plugin-card-header,
-.plugin-card-title,
-.plugin-meta-grid,
-.plugin-priority-control {
-  display: flex;
-  align-items: center;
-}
-
-.plugin-card-header {
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.plugin-card-title {
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.plugin-description {
-  margin-top: 10px;
-}
-
-.plugin-meta-grid {
-  justify-content: space-between;
-  gap: 16px;
-  flex-wrap: wrap;
-}
-
-.plugin-priority-control {
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.plugin-priority-input {
-  width: 96px;
-}
-
-.plugin-status-badge {
-  border-radius: 999px;
-  border: 1px solid var(--color-border);
-  padding: 2px 8px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.plugin-status-badge.connected {
-  color: #1f8f4c;
-  background: rgba(31, 143, 76, 0.12);
-}
-
-.plugin-status-badge.starting {
-  color: #b26a00;
-  background: rgba(178, 106, 0, 0.12);
-}
-
-.plugin-status-badge.stopped {
-  color: var(--color-text-secondary);
-  background: var(--color-bg-secondary);
-}
-
-.plugin-health-badge {
-  border-radius: 999px;
-  border: 1px solid var(--color-border);
-  padding: 2px 8px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.plugin-health-badge.healthy {
-  color: #1f8f4c;
-  background: rgba(31, 143, 76, 0.12);
-}
-
-.plugin-health-badge.unhealthy {
-  color: #b42318;
-  background: rgba(180, 35, 24, 0.12);
-}
-
-.plugin-health-badge.unknown {
-  color: var(--color-text-secondary);
-  background: var(--color-bg-secondary);
-}
-
-.endpoint-card {
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  padding: 12px;
-  background: var(--color-bg-elevated);
-}
-
-@media (max-width: 720px) {
-  .plugin-form {
-    grid-template-columns: 1fr;
-  }
-
-  .plugin-card-header,
-  .plugin-meta-grid {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-}
-
-.endpoint-card-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 10px;
-}
-
-.endpoint-card-title {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.endpoint-name {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
-  color: var(--color-text-primary);
-  font-weight: 600;
-}
-
-.endpoint-status-badge {
-  border-radius: 999px;
-  padding: 2px 8px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  border: 1px solid var(--color-border);
-}
-
-.endpoint-profile-badge {
-  border-radius: 999px;
-  padding: 2px 8px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  border: 1px solid var(--color-border);
-  color: var(--color-text-secondary);
-  background: var(--color-bg-secondary);
-}
-
-.endpoint-status-badge.status-connected {
-  color: #1f8f4c;
-  background: rgba(31, 143, 76, 0.12);
-}
-
-.endpoint-status-badge.status-connecting,
-.endpoint-status-badge.status-bootstrapping {
-  color: #a56a00;
-  background: rgba(165, 106, 0, 0.12);
-}
-
-.endpoint-status-badge.status-error,
-.endpoint-status-badge.status-disconnected {
-  color: #b24040;
-  background: rgba(178, 64, 64, 0.12);
-}
-
-.endpoint-card-actions {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
-.endpoint-summary {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.endpoint-meta {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  font-size: 12px;
-  color: var(--color-text-secondary);
-}
-
-.endpoint-meta code {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  color: var(--color-text-primary);
-  word-break: break-all;
-}
-
-.endpoint-meta-label {
-  width: 62px;
-  flex: 0 0 62px;
-  color: var(--color-text-dimmed);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 10px;
-}
-
-/* Projects directory input */
-.projects-dir-input {
-  display: flex;
-  gap: 8px;
-}
-
-.settings-input {
-  flex: 1;
-  background: var(--color-bg-input);
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  padding: 10px 12px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
-  color: var(--color-text-primary);
-  outline: none;
-}
-
-@media (max-width: 700px) {
-  .endpoint-form {
-    grid-template-columns: 1fr;
-  }
-
-  .endpoint-card-header {
-    flex-direction: column;
-  }
-
-  .endpoint-card-actions {
-    justify-content: flex-start;
-  }
-
-  .endpoint-meta {
-    flex-direction: column;
-    gap: 4px;
-  }
-
-  .endpoint-meta-label {
-    width: auto;
-    flex-basis: auto;
-  }
-}
-
-.settings-input:focus {
-  border-color: var(--color-border-focus);
-}
-
-.settings-input::placeholder {
-  color: var(--color-text-dimmed);
-}
-
-.settings-textarea {
-  width: 100%;
-  background: var(--color-bg-input);
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  padding: 10px 12px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 13px;
-  color: var(--color-text-primary);
-  outline: none;
-  resize: vertical;
-}
-
-.settings-textarea:focus {
-  border-color: var(--color-border-focus);
-}
-
-.settings-field {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-bottom: 12px;
-}
-
-.settings-field:last-child {
-  margin-bottom: 0;
-}
-
-.review-loop-settings {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.review-loop-settings-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
 .review-loop-settings-actions {
   justify-content: flex-start;
 }
 
-.settings-agent-toggle {
-  display: inline-flex;
-  gap: 8px;
-  border-radius: 10px;
+.endpoint-card,
+.plugin-card {
+  border: 1px solid var(--color-border);
+  border-radius: 7px;
   background: var(--color-bg-elevated);
-  padding: 6px;
+  padding: 14px;
+  display: grid;
+  gap: 12px;
 }
 
-.settings-agent-toggle .agent-option {
-  border: 1px solid transparent;
-  border-radius: 8px;
-  padding: 8px 14px;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--color-text-secondary);
-  background: transparent;
-  cursor: pointer;
-  transition: all 120ms ease;
+.endpoint-card-header,
+.plugin-card-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: start;
 }
 
-.settings-agent-toggle .agent-option:hover {
+.endpoint-card-title,
+.plugin-card-title {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.endpoint-name {
   color: var(--color-text-primary);
-  background: var(--color-bg-button);
-}
-
-.settings-agent-toggle .agent-option:disabled {
-  cursor: not-allowed;
-  opacity: 0.45;
-  color: var(--color-text-muted);
-}
-
-.settings-agent-toggle .agent-option.active {
-  color: #0b0f1c;
-  background: linear-gradient(135deg, #7dd3fc, #38bdf8);
-  border-color: rgba(56, 189, 248, 0.6);
-  box-shadow: 0 8px 16px rgba(56, 189, 248, 0.25);
-}
-
-.settings-agent-toggle .agent-option.active:disabled {
-  background: var(--color-bg-button);
-  color: var(--color-text-secondary);
-  box-shadow: none;
-  border-color: var(--color-border);
-}
-
-.settings-label {
-  font-size: 12px;
-  color: var(--color-text-secondary);
   font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.endpoint-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.endpoint-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 14px;
+}
+
+.plugin-description {
+  margin-top: -2px;
+}
+
+.plugin-meta-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+  align-items: start;
+}
+
+.plugin-priority-control {
+  min-width: 0;
+  display: flex;
+  align-items: end;
+  gap: 8px;
+  justify-self: start;
+}
+
+.plugin-priority-input {
+  width: 92px;
+}
+
+.plugin-health-badge.unknown {
+  color: var(--color-text-secondary);
+  background: var(--color-bg-button);
 }
 
 .settings-status {
-  font-size: 11px;
+  color: var(--color-text-secondary);
   font-family: 'JetBrains Mono', monospace;
-  margin-top: -4px;
+  font-size: var(--font-size-xs);
+  line-height: 1.3;
 }
 
-.settings-status.available {
-  color: #79d29a;
-}
-
-.settings-status.missing {
-  color: #ff9f7a;
-}
-
+.settings-status.available,
 .settings-status.mode-worker {
-  color: #79d29a;
+  color: #60c287;
+}
+
+.settings-status.missing,
+.settings-status.mode-unknown {
+  color: #f59b4a;
 }
 
 .settings-status.mode-embedded {
-  color: #86b7ff;
-}
-
-.settings-status.mode-unknown {
-  color: #ffcf7a;
-}
-
-.settings-agent-warning {
-  margin-bottom: 10px;
-  font-size: 11px;
-  color: #ff9f7a;
-}
-
-.agent-capabilities-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+  color: #77a7ff;
 }
 
 .agent-capabilities-item {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  display: grid;
+  gap: 7px;
 }
 
 .agent-capabilities-agent {
-  font-size: 12px;
   color: var(--color-text-secondary);
   font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-sm);
 }
 
 .agent-capabilities-pills {
@@ -605,51 +686,145 @@
   gap: 6px;
 }
 
-.agent-capability-pill {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+.muted-items-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.muted-item {
+  min-height: 46px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
   border: 1px solid var(--color-border);
-  border-radius: 999px;
-  padding: 4px 8px;
+  border-radius: 7px;
   background: var(--color-bg-elevated);
-  color: var(--color-text-secondary);
+  padding: 8px 10px 8px 12px;
 }
 
-.agent-capability-pill.enabled {
-  border-color: rgba(121, 210, 154, 0.55);
-  color: #79d29a;
-}
-
-.agent-capability-pill.disabled {
-  border-color: rgba(255, 159, 122, 0.55);
-  color: #ff9f7a;
-}
-
-.browse-btn {
-  background: var(--color-bg-button);
-  border: 1px solid var(--color-border-hover);
-  border-radius: 6px;
-  padding: 10px 16px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  transition: all 150ms ease-out;
-  white-space: nowrap;
-}
-
-.browse-btn.danger {
-  border-color: rgba(220, 38, 38, 0.35);
-  color: #ef4444;
-}
-
-.browse-btn:hover {
-  background: var(--color-bg-panel);
+.muted-item-name {
   color: var(--color-text-primary);
-  border-color: var(--color-border-focus);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-sm);
+  overflow-wrap: anywhere;
 }
 
-.browse-btn:focus {
-  outline: 2px solid #ff6b35;
-  outline-offset: 1px;
+@media (max-width: 1180px) {
+  .settings-layout {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .endpoint-card-header {
+    grid-template-columns: 1fr;
+  }
+
+  .endpoint-card-actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 860px) {
+  .settings-overlay {
+    padding: 8px;
+  }
+
+  .settings-modal {
+    width: calc(100vw - 16px);
+    height: calc(100vh - 16px);
+    min-height: 0;
+  }
+
+  .settings-profile {
+    display: none;
+  }
+
+  .settings-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .settings-nav {
+    display: flex;
+    gap: 12px;
+    border-right: 0;
+    border-bottom: 1px solid var(--color-border);
+    padding: 10px 12px;
+  }
+
+  .settings-nav-group {
+    min-width: 184px;
+  }
+
+  .settings-nav-group + .settings-nav-group {
+    margin-top: 0;
+  }
+
+  .settings-body {
+    padding: 20px 18px 24px;
+  }
+
+  .settings-content-head,
+  .settings-block {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-content-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .settings-status-pair {
+    justify-content: flex-start;
+  }
+
+  .settings-block {
+    gap: 14px;
+  }
+
+  .endpoint-form,
+  .endpoint-form-inline,
+  .settings-field-grid,
+  .settings-field-grid.two-column,
+  .endpoint-summary {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .settings-header {
+    padding: 0 12px;
+  }
+
+  .settings-search {
+    display: none;
+  }
+  .settings-inline-form,
+  .plugin-form,
+  .plugin-card-header,
+  .settings-row-card,
+  .muted-item,
+  .settings-meta-row {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-action {
+    width: 100%;
+  }
+
+  .settings-row-inline {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .settings-segmented {
+    width: 100%;
+  }
+
+  .settings-segmented-option {
+    flex: 1 1 auto;
+  }
 }

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -33,7 +33,7 @@ describe('SettingsModal review loop prompts', () => {
       />
     );
 
-    await screen.findByText('No plugins installed.');
+    await screen.findByText('Mobile Web Client');
     fireEvent.keyDown(window, { key: 'Escape' });
 
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -69,7 +69,8 @@ describe('SettingsModal review loop prompts', () => {
       />
     );
 
-    await screen.findByText('No plugins installed.');
+    fireEvent.click(screen.getByTestId('settings-nav-review'));
+    await screen.findByText('Review Loop Prompts');
     fireEvent.change(screen.getByLabelText('Prompt name'), { target: { value: 'Architect Pass' } });
     fireEvent.change(screen.getByLabelText('Default iterations'), { target: { value: '5' } });
     fireEvent.change(screen.getByLabelText('Prompt'), { target: { value: 'Review like an architect' } });
@@ -158,6 +159,7 @@ describe('SettingsModal review loop prompts', () => {
       />
     );
 
+    fireEvent.click(screen.getByTestId('settings-nav-plugins'));
     fireEvent.change(screen.getByLabelText('Plugin directory'), { target: { value: '/tmp/my-plugin' } });
     fireEvent.click(screen.getByText('Install Plugin'));
 
@@ -214,6 +216,7 @@ describe('SettingsModal review loop prompts', () => {
       />
     );
 
+    fireEvent.click(screen.getByTestId('settings-nav-plugins'));
     const priority = await screen.findByLabelText('services-pilot-worktrees priority');
     fireEvent.change(priority, { target: { value: '25' } });
     fireEvent.click(screen.getByText('Save'));
@@ -264,6 +267,7 @@ describe('SettingsModal review loop prompts', () => {
       />,
     );
 
+    fireEvent.click(screen.getByTestId('settings-nav-plugins'));
     expect(await screen.findByText('starting')).toBeInTheDocument();
 
     rerender(
@@ -274,7 +278,9 @@ describe('SettingsModal review loop prompts', () => {
     );
 
     expect(await screen.findByText('connected')).toBeInTheDocument();
-    expect(await screen.findByText('healthy')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getAllByText('healthy').length).toBeGreaterThan(0);
+    });
   });
 
   it('toggles tailscale serve on the existing device', async () => {
@@ -311,7 +317,7 @@ describe('SettingsModal review loop prompts', () => {
       />
     );
 
-    await screen.findByText('No plugins installed.');
+    await screen.findByText('Mobile Web Client');
     fireEvent.click(screen.getByText('Enable'));
     expect(onSetSetting).toHaveBeenCalledWith('tailscale_enabled', 'true');
     expect(screen.getByText(/does not register a second tailnet device/i)).toBeInTheDocument();

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -58,6 +58,22 @@ interface SettingsModalProps {
   onSetTheme: (theme: ThemePreference) => void;
 }
 
+type SettingsSectionID = 'general' | 'connectivity' | 'plugins' | 'agents' | 'review' | 'hygiene';
+
+interface SettingsNavItem {
+  id: SettingsSectionID;
+  label: string;
+  title: string;
+  description: string;
+  count: number;
+  keywords: string;
+}
+
+interface SettingsNavGroup {
+  label: string;
+  items: SettingsNavItem[];
+}
+
 export function SettingsModal({
   isOpen,
   onClose,
@@ -107,6 +123,8 @@ export function SettingsModal({
   const [pluginError, setPluginError] = useState<string | null>(null);
   const [pluginActionName, setPluginActionName] = useState<string | null>(null);
   const [pluginsLoading, setPluginsLoading] = useState(false);
+  const [selectedSection, setSelectedSection] = useState<SettingsSectionID>('connectivity');
+  const [settingsSearch, setSettingsSearch] = useState('');
   const agentAvailability = useMemo(() => getAgentAvailability(settings), [settings]);
   const hasAvailableAgents = useMemo(
     () => hasAnyAvailableAgents(agentAvailability),
@@ -547,455 +565,688 @@ export function SettingsModal({
     }
   }, [onSetPluginPriority, pluginPriorityDrafts, refreshPlugins]);
 
-  if (!isOpen) return null;
+  const connectedEndpointCount = endpoints.filter((endpoint) => endpoint.status === 'connected').length;
+  const activePluginCount = plugins.filter((plugin) => plugin.connected || plugin.running).length;
+  const availableAgentCount = orderedAgentList.filter((agent) => isAgentAvailable(agentAvailability, agent)).length;
+  const mutedItemCount = mutedRepos.length + mutedAuthors.length;
+  const pluginProblemCount = pluginIssues.length + plugins.filter((plugin) => plugin.health_status === 'unhealthy').length;
+  const hasProjectsDirChange = projectsDir !== actualProjectsDir;
+  const hasReviewModelChange = reviewLoopModel !== actualReviewLoopModel || reviewerModel !== actualReviewerModel;
 
-  return (
-    <div className="settings-overlay" onClick={onClose}>
-      <div className="settings-modal" onClick={e => e.stopPropagation()}>
-        <div className="settings-header">
-          <h2>Settings</h2>
-          <button className="settings-close" onClick={onClose}>×</button>
+  const settingsNavGroups = useMemo<SettingsNavGroup[]>(() => [
+    {
+      label: 'General',
+      items: [
+        {
+          id: 'general',
+          label: 'Appearance and projects',
+          title: 'Appearance and project roots',
+          description: 'Theme selection and the directory attn uses when opening repositories and worktrees.',
+          count: 2,
+          keywords: 'theme appearance dark light system projects directory worktrees roots',
+        },
+      ],
+    },
+    {
+      label: 'Connectivity',
+      items: [
+        {
+          id: 'connectivity',
+          label: 'Mobile, hosts, remotes',
+          title: 'Mobile web, hosts, and remote endpoints',
+          description: 'Controls for mobile browser access, GitHub host detection, and remote attn peers.',
+          count: Math.max(3, endpoints.length + connectedHosts.length + 1),
+          keywords: 'tailscale mobile web github hosts ssh remote endpoint daemon',
+        },
+      ],
+    },
+    {
+      label: 'Extensions',
+      items: [
+        {
+          id: 'plugins',
+          label: 'Plugins',
+          title: 'Plugins',
+          description: 'Install user-owned plugins and tune provider dispatch priority.',
+          count: Math.max(1, plugins.length + pluginIssues.length),
+          keywords: 'plugins extensions providers priority install healthcheck',
+        },
+      ],
+    },
+    {
+      label: 'Agents',
+      items: [
+        {
+          id: 'agents',
+          label: 'Executables and defaults',
+          title: 'Agent runtime',
+          description: 'Agent executable paths, the default session agent, capability reporting, and PTY runtime mode.',
+          count: orderedAgentList.length + 3,
+          keywords: 'agents executables claude codex cursor default capabilities pty backend editor',
+        },
+      ],
+    },
+    {
+      label: 'Review',
+      items: [
+        {
+          id: 'review',
+          label: 'Loop prompts and models',
+          title: 'Review loop prompts and models',
+          description: 'Saved review-loop prompt presets and model overrides for review automation.',
+          count: Math.max(2, reviewLoopPresets.length + 2),
+          keywords: 'review loop prompt preset model reviewer iterations',
+        },
+      ],
+    },
+    {
+      label: 'Hygiene',
+      items: [
+        {
+          id: 'hygiene',
+          label: 'Muted repos and authors',
+          title: 'Muted repositories and authors',
+          description: 'Repositories and authors hidden from the attention queue.',
+          count: mutedItemCount,
+          keywords: 'muted repositories repos authors hide unmute hygiene',
+        },
+      ],
+    },
+  ], [
+    connectedHosts.length,
+    endpoints.length,
+    mutedItemCount,
+    orderedAgentList.length,
+    pluginIssues.length,
+    plugins.length,
+    reviewLoopPresets.length,
+  ]);
+
+  const filteredNavGroups = useMemo(() => {
+    const query = settingsSearch.trim().toLowerCase();
+    if (query === '') return settingsNavGroups;
+    return settingsNavGroups
+      .map((group) => ({
+        ...group,
+        items: group.items.filter((item) => (
+          `${item.label} ${item.title} ${item.description} ${item.keywords}`.toLowerCase().includes(query)
+        )),
+      }))
+      .filter((group) => group.items.length > 0);
+  }, [settingsNavGroups, settingsSearch]);
+
+  const flatNavItems = useMemo(
+    () => settingsNavGroups.flatMap((group) => group.items),
+    [settingsNavGroups],
+  );
+
+  const selectedNavItem = flatNavItems.find((item) => item.id === selectedSection) || flatNavItems[0];
+
+  const renderSectionStatusPills = () => {
+    switch (selectedSection) {
+      case 'connectivity':
+        return (
+          <>
+            <span className={`settings-pill ${tailscaleEnabled && tailscaleStatus !== 'error' ? 'good' : ''}`}>
+              {tailscaleEnabled ? tailscaleStatus : 'mobile off'}
+            </span>
+            <span className={`settings-pill ${endpoints.length === 0 || connectedEndpointCount === endpoints.length ? 'good' : 'warn'}`}>
+              {connectedEndpointCount}/{endpoints.length} remotes
+            </span>
+          </>
+        );
+      case 'plugins':
+        return (
+          <>
+            <span className={`settings-pill ${pluginProblemCount === 0 ? 'good' : 'bad'}`}>
+              {pluginProblemCount === 0 ? 'healthy' : `${pluginProblemCount} issue${pluginProblemCount === 1 ? '' : 's'}`}
+            </span>
+            <span className="settings-pill">{activePluginCount}/{plugins.length} running</span>
+          </>
+        );
+      case 'agents':
+        return (
+          <>
+            <span className={`settings-pill ${hasAvailableAgents ? 'good' : 'bad'}`}>
+              {availableAgentCount}/{orderedAgentList.length} available
+            </span>
+            <span className="settings-pill">{ptyBackendMode}</span>
+          </>
+        );
+      case 'review':
+        return (
+          <>
+            <span className="settings-pill">{reviewLoopPresets.length} saved prompts</span>
+            <span className={`settings-pill ${hasReviewModelChange ? 'warn' : 'good'}`}>
+              {hasReviewModelChange ? 'unsaved edits' : 'models saved'}
+            </span>
+          </>
+        );
+      case 'hygiene':
+        return (
+          <>
+            <span className="settings-pill">{mutedRepos.length} repos</span>
+            <span className="settings-pill">{mutedAuthors.length} authors</span>
+          </>
+        );
+      case 'general':
+      default:
+        return (
+          <>
+            <span className="settings-pill">{themePreference}</span>
+            <span className={`settings-pill ${hasProjectsDirChange ? 'warn' : 'good'}`}>
+              {hasProjectsDirChange ? 'project path edited' : 'project path saved'}
+            </span>
+          </>
+        );
+    }
+  };
+
+  const renderGeneralSettings = () => (
+    <>
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Appearance</div>
+          <h3>Theme</h3>
+          <p className="settings-description">
+            Choose how attn renders the application chrome.
+          </p>
         </div>
-        <div className="settings-body">
-          <div className="settings-section">
-            <h3>Theme</h3>
-            <div className="settings-agent-toggle" role="radiogroup" aria-label="Theme preference">
-              <button
-                type="button"
-                className={`agent-option ${themePreference === 'dark' ? 'active' : ''}`}
-                onClick={() => onSetTheme('dark')}
-                aria-checked={themePreference === 'dark'}
-              >
-                Dark
-              </button>
-              <button
-                type="button"
-                className={`agent-option ${themePreference === 'light' ? 'active' : ''}`}
-                onClick={() => onSetTheme('light')}
-                aria-checked={themePreference === 'light'}
-              >
-                Light
-              </button>
-              <button
-                type="button"
-                className={`agent-option ${themePreference === 'system' ? 'active' : ''}`}
-                onClick={() => onSetTheme('system')}
-                aria-checked={themePreference === 'system'}
-              >
-                System
-              </button>
-            </div>
+        <div className="settings-block-body">
+          <div className="settings-segmented" role="radiogroup" aria-label="Theme preference">
+            <button
+              type="button"
+              className={`settings-segmented-option ${themePreference === 'dark' ? 'active' : ''}`}
+              onClick={() => onSetTheme('dark')}
+              aria-checked={themePreference === 'dark'}
+            >
+              Dark
+            </button>
+            <button
+              type="button"
+              className={`settings-segmented-option ${themePreference === 'light' ? 'active' : ''}`}
+              onClick={() => onSetTheme('light')}
+              aria-checked={themePreference === 'light'}
+            >
+              Light
+            </button>
+            <button
+              type="button"
+              className={`settings-segmented-option ${themePreference === 'system' ? 'active' : ''}`}
+              onClick={() => onSetTheme('system')}
+              aria-checked={themePreference === 'system'}
+            >
+              System
+            </button>
           </div>
+        </div>
+      </section>
 
-          <div className="settings-section">
-            <h3>Projects Directory</h3>
-            <p className="settings-description">
-              Directory where your Git repositories are cloned. Used to open PRs in worktrees.
-            </p>
-            <div className="projects-dir-input">
-              <input
-                type="text"
-                value={projectsDir}
-                onChange={handleInputChange}
-                onBlur={handleInputBlur}
-                onKeyDown={handleKeyDown}
-                placeholder="/Users/you/projects"
-                className="settings-input"
-                autoCapitalize="none"
-                autoCorrect="off"
-                spellCheck={false}
-              />
-              <button className="browse-btn" onClick={handleBrowse}>
-                Browse
-              </button>
-            </div>
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Projects</div>
+          <h3>Projects Directory</h3>
+          <p className="settings-description">
+            Directory where Git repositories are cloned and opened in worktrees.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          <div className="settings-inline-form projects-dir-input">
+            <input
+              data-testid="settings-projects-directory-input"
+              type="text"
+              value={projectsDir}
+              onChange={handleInputChange}
+              onBlur={handleInputBlur}
+              onKeyDown={handleKeyDown}
+              placeholder="/Users/you/projects"
+              className="settings-input"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+            <button className="settings-action" onClick={handleBrowse}>
+              Browse
+            </button>
           </div>
+        </div>
+      </section>
+    </>
+  );
 
-          <div className="settings-section">
-            <h3>Mobile Web Client</h3>
-            <p className="settings-description">
-              Expose the daemon through this machine&apos;s existing Tailscale device identity so the embedded mobile web client can attach to running sessions from Safari or any browser.
-            </p>
-            <div className="settings-row-inline">
-              <span className="settings-label">Tailscale Serve</span>
-              <button className="browse-btn" onClick={handleToggleTailscale}>
-                {tailscaleEnabled ? 'Disable' : 'Enable'}
-              </button>
+  const renderConnectivitySettings = () => (
+    <>
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Mobile</div>
+          <h3>Mobile Web Client</h3>
+          <p className="settings-description">
+            Expose this daemon through the existing Tailscale device identity for mobile browser access.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          <div className="settings-row-card">
+            <div>
+              <p className="settings-row-title">Tailscale Serve</p>
+              <p className="settings-row-copy">
+                {tailscaleURL || tailscaleDomain || 'Uses the host Tailscale client and does not register a second tailnet device for attn.'}
+              </p>
             </div>
-            <div className="settings-hint">Status: {tailscaleStatus}</div>
-            {tailscaleDomain && (
-              <div className="settings-hint">Device DNS name: <code>{tailscaleDomain}</code></div>
-            )}
-            {tailscaleURL && (
-              <div className="settings-hint">
-                Web URL: <a href={tailscaleURL} target="_blank" rel="noreferrer">{tailscaleURL}</a>
-              </div>
-            )}
-            {tailscaleAuthURL && (
-              <div className="settings-agent-warning">
-                Sign this machine into Tailscale:
-                {' '}
-                <a href={tailscaleAuthURL} target="_blank" rel="noreferrer">{tailscaleAuthURL}</a>
-              </div>
-            )}
-            {tailscaleError && (
-              <div className="settings-agent-warning">{tailscaleError}</div>
-            )}
-            <div className="settings-hint">
-              This uses the host Tailscale client and does not register a second tailnet device for attn.
-            </div>
+            <button className="settings-action" onClick={handleToggleTailscale}>
+              {tailscaleEnabled ? 'Disable' : 'Enable'}
+            </button>
           </div>
-
-          <div className="settings-section">
-            <h3>GitHub Hosts</h3>
-            <p className="settings-description">
-              Hosts currently detected from authenticated PRs.
-            </p>
-            {connectedHosts.length === 0 ? (
-              <p className="settings-empty">No authenticated hosts detected.</p>
-            ) : (
-              <div className="host-list">
-                {connectedHosts.map((host) => (
-                  <span key={host} className="host-pill">{host}</span>
-                ))}
-              </div>
-            )}
-            <div className="settings-hint">Add hosts with `gh auth login --hostname &lt;host&gt;`.</div>
-          </div>
-
-          <div className="settings-section">
-            <h3>Remote Endpoints</h3>
-            <p className="settings-description">
-              SSH targets that the local daemon bootstraps and keeps connected as remote attn peers.
-            </p>
-            <div className="endpoint-form">
-              <input
-                type="text"
-                value={newEndpointName}
-                onChange={(e) => setNewEndpointName(e.target.value)}
-                placeholder="gpu-box"
-                className="settings-input"
-                aria-label="Endpoint name"
-                disabled={endpointActionInFlight}
-                autoCapitalize="none"
-                autoCorrect="off"
-                spellCheck={false}
-              />
-              <input
-                type="text"
-                value={newEndpointTarget}
-                onChange={(e) => setNewEndpointTarget(e.target.value)}
-                placeholder="user@gpu-box"
-                className="settings-input"
-                aria-label="SSH target"
-                disabled={endpointActionInFlight}
-                autoCapitalize="none"
-                autoCorrect="off"
-                spellCheck={false}
-              />
-              <input
-                type="text"
-                value={newEndpointProfile}
-                onChange={(e) => setNewEndpointProfile(e.target.value)}
-                placeholder="default"
-                pattern="[a-z0-9][a-z0-9-]{0,15}"
-                className="settings-input"
-                aria-label="Profile"
-                disabled={endpointActionInFlight}
-                autoCapitalize="none"
-                autoCorrect="off"
-                spellCheck={false}
-              />
-              <button
-                className="browse-btn"
-                onClick={() => void handleAddEndpoint()}
-                disabled={endpointActionInFlight}
-              >
-                Add Endpoint
-              </button>
+          <div className="settings-row-card compact">
+            <div>
+              <p className="settings-row-title">Sign-in status</p>
+              <p className="settings-row-copy">Status: {tailscaleStatus}</p>
             </div>
-            {endpointError && <div className="settings-agent-warning">{endpointError}</div>}
-            {endpoints.length === 0 ? (
-              <p className="settings-empty">No remote endpoints configured.</p>
-            ) : (
-              <div className="endpoint-list">
-                {endpoints.map((endpoint) => {
-                  const isEditing = editingEndpointID === endpoint.id;
-                  const isBusy = endpointActionID === endpoint.id;
-                  const availableAgents = endpoint.capabilities?.agents_available || [];
-                  const remoteWebEnabled = endpoint.capabilities?.tailscale_enabled === true;
-                  const remoteWebStatus = endpoint.capabilities?.tailscale_status || (remoteWebEnabled ? 'starting' : 'disabled');
-                  const remoteWebURL = endpoint.capabilities?.tailscale_url;
-                  const remoteWebAuthURL = endpoint.capabilities?.tailscale_auth_url;
-                  const remoteWebError = endpoint.capabilities?.tailscale_error;
-                  const canToggleRemoteWeb = endpoint.status === 'connected' && !endpointActionInFlight;
-                  const canRebootstrap = endpoint.enabled !== false && !endpointActionInFlight;
-                  return (
-                    <div key={endpoint.id} className={`endpoint-card status-${endpoint.status}`}>
-                      <div className="endpoint-card-header">
-                        <div className="endpoint-card-title">
-                          <span className="endpoint-name">{endpoint.name}</span>
-                          <span className="endpoint-profile-badge">{endpoint.profile || 'default'}</span>
-                          <span className={`endpoint-status-badge status-${endpoint.status}`}>
-                            {endpoint.status}
-                          </span>
-                        </div>
-                        <div className="endpoint-card-actions">
-                          {isEditing ? (
-                            <>
-                              <button className="browse-btn" onClick={() => void handleSaveEndpoint(endpoint.id)} disabled={isBusy}>
-                                Save
-                              </button>
-                              <button className="browse-btn" onClick={cancelEditEndpoint} disabled={endpointActionInFlight}>
-                                Cancel
-                              </button>
-                            </>
-                          ) : (
-                            <button className="browse-btn" onClick={() => beginEditEndpoint(endpoint)} disabled={endpointActionInFlight}>
-                              Edit
-                            </button>
-                          )}
-                          <button className="browse-btn" onClick={() => void handleToggleEndpoint(endpoint)} disabled={endpointActionInFlight}>
-                            {endpoint.enabled === false ? 'Enable' : 'Disable'}
-                          </button>
-                          <button
-                            className="browse-btn"
-                            onClick={() => void handleRebootstrapEndpoint(endpoint)}
-                            disabled={!canRebootstrap}
-                          >
-                            Re-bootstrap
-                          </button>
-                          <button
-                            className="browse-btn"
-                            onClick={() => void handleSetEndpointRemoteWeb(endpoint.id, !remoteWebEnabled)}
-                            disabled={!canToggleRemoteWeb}
-                          >
-                            {remoteWebEnabled ? 'Disable Web' : 'Enable Web'}
-                          </button>
-                          <button className="browse-btn danger" onClick={() => void handleRemoveEndpoint(endpoint.id)} disabled={endpointActionInFlight}>
-                            Remove
-                          </button>
-                        </div>
+            <span className={`settings-pill ${tailscaleEnabled && tailscaleStatus !== 'error' ? 'good' : ''}`}>
+              {tailscaleEnabled ? tailscaleStatus : 'disabled'}
+            </span>
+          </div>
+          <div className="settings-hint">
+            This uses the host Tailscale client and does not register a second tailnet device for attn.
+          </div>
+          {tailscaleDomain && (
+            <div className="settings-meta-row">
+              <span className="settings-meta-label">Device DNS</span>
+              <code>{tailscaleDomain}</code>
+            </div>
+          )}
+          {tailscaleURL && (
+            <div className="settings-meta-row">
+              <span className="settings-meta-label">Web URL</span>
+              <a href={tailscaleURL} target="_blank" rel="noreferrer">{tailscaleURL}</a>
+            </div>
+          )}
+          {tailscaleAuthURL && (
+            <div className="settings-warning">
+              Sign this machine into Tailscale:{' '}
+              <a href={tailscaleAuthURL} target="_blank" rel="noreferrer">{tailscaleAuthURL}</a>
+            </div>
+          )}
+          {tailscaleError && (
+            <div className="settings-warning">{tailscaleError}</div>
+          )}
+        </div>
+      </section>
+
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">GitHub</div>
+          <h3>GitHub Hosts</h3>
+          <p className="settings-description">
+            Authenticated hosts used by PR actions, review lookup, and repository metadata.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          {connectedHosts.length === 0 ? (
+            <p className="settings-empty">No authenticated hosts detected.</p>
+          ) : (
+            <div className="settings-token-list">
+              {connectedHosts.map((host) => (
+                <span key={host} className="settings-token">{host}</span>
+              ))}
+            </div>
+          )}
+          <div className="settings-hint">Add hosts with `gh auth login --hostname &lt;host&gt;`.</div>
+        </div>
+      </section>
+
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Remote</div>
+          <h3>Remote Endpoints</h3>
+          <p className="settings-description">
+            SSH targets that the local daemon bootstraps and keeps connected as remote attn peers.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          <div className="settings-form-grid endpoint-form">
+            <input
+              type="text"
+              value={newEndpointName}
+              onChange={(e) => setNewEndpointName(e.target.value)}
+              placeholder="gpu-box"
+              className="settings-input"
+              aria-label="Endpoint name"
+              disabled={endpointActionInFlight}
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+            <input
+              type="text"
+              value={newEndpointTarget}
+              onChange={(e) => setNewEndpointTarget(e.target.value)}
+              placeholder="user@gpu-box"
+              className="settings-input"
+              aria-label="SSH target"
+              disabled={endpointActionInFlight}
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+            <input
+              type="text"
+              value={newEndpointProfile}
+              onChange={(e) => setNewEndpointProfile(e.target.value)}
+              placeholder="default"
+              pattern="[a-z0-9][a-z0-9-]{0,15}"
+              className="settings-input"
+              aria-label="Profile"
+              disabled={endpointActionInFlight}
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+            <button
+              className="settings-action"
+              onClick={() => void handleAddEndpoint()}
+              disabled={endpointActionInFlight}
+            >
+              Add Endpoint
+            </button>
+          </div>
+          {endpointError && <div className="settings-warning">{endpointError}</div>}
+          {endpoints.length === 0 ? (
+            <p className="settings-empty">No remote endpoints configured.</p>
+          ) : (
+            <div className="endpoint-list">
+              {endpoints.map((endpoint) => {
+                const isEditing = editingEndpointID === endpoint.id;
+                const isBusy = endpointActionID === endpoint.id;
+                const availableAgents = endpoint.capabilities?.agents_available || [];
+                const remoteWebEnabled = endpoint.capabilities?.tailscale_enabled === true;
+                const remoteWebStatus = endpoint.capabilities?.tailscale_status || (remoteWebEnabled ? 'starting' : 'disabled');
+                const remoteWebURL = endpoint.capabilities?.tailscale_url;
+                const remoteWebAuthURL = endpoint.capabilities?.tailscale_auth_url;
+                const remoteWebError = endpoint.capabilities?.tailscale_error;
+                const canToggleRemoteWeb = endpoint.status === 'connected' && !endpointActionInFlight;
+                const canRebootstrap = endpoint.enabled !== false && !endpointActionInFlight;
+                return (
+                  <div key={endpoint.id} className={`endpoint-card status-${endpoint.status}`}>
+                    <div className="endpoint-card-header">
+                      <div className="endpoint-card-title">
+                        <span className="endpoint-name">{endpoint.name}</span>
+                        <span className="settings-pill">{endpoint.profile || 'default'}</span>
+                        <span className={`endpoint-status-badge status-${endpoint.status}`}>
+                          {endpoint.status}
+                        </span>
                       </div>
-                      {isEditing ? (
-                        <div className="endpoint-form endpoint-form-inline">
-                          <input
-                            type="text"
-                            value={editingEndpointName}
-                            onChange={(e) => setEditingEndpointName(e.target.value)}
-                            className="settings-input"
-                            aria-label="Edit endpoint name"
-                            disabled={endpointActionInFlight}
-                            autoCapitalize="none"
-                            autoCorrect="off"
-                            spellCheck={false}
-                          />
-                          <input
-                            type="text"
-                            value={editingEndpointTarget}
-                            onChange={(e) => setEditingEndpointTarget(e.target.value)}
-                            className="settings-input"
-                            aria-label="Edit SSH target"
-                            disabled={endpointActionInFlight}
-                            autoCapitalize="none"
-                            autoCorrect="off"
-                            spellCheck={false}
-                          />
-                          <input
-                            type="text"
-                            value={editingEndpointProfile}
-                            onChange={(e) => setEditingEndpointProfile(e.target.value)}
-                            className="settings-input"
-                            aria-label="Edit profile"
-                            placeholder="default"
-                            pattern="[a-z0-9][a-z0-9-]{0,15}"
-                            disabled={endpointActionInFlight}
-                            autoCapitalize="none"
-                            autoCorrect="off"
-                            spellCheck={false}
-                          />
-                        </div>
-                      ) : (
-                        <div className="endpoint-summary">
-                          <div className="endpoint-meta">
-                            <span className="endpoint-meta-label">SSH</span>
-                            <code>{endpoint.ssh_target}</code>
-                          </div>
-                          <div className="endpoint-meta">
-                            <span className="endpoint-meta-label">Enabled</span>
-                            <span>{endpoint.enabled === false ? 'No' : 'Yes'}</span>
-                          </div>
-                          {endpoint.status_message && (
-                            <div className="endpoint-meta">
-                              <span className="endpoint-meta-label">Status</span>
-                              <span>{endpoint.status_message}</span>
-                            </div>
-                          )}
-                          {endpoint.capabilities && (
-                            <>
-                              <div className="endpoint-meta">
-                                <span className="endpoint-meta-label">Protocol</span>
-                                <span>{endpoint.capabilities.protocol_version}</span>
-                              </div>
-                              <div className="endpoint-meta">
-                                <span className="endpoint-meta-label">PTY</span>
-                                <span>{endpoint.capabilities.pty_backend_mode || 'unknown'}</span>
-                              </div>
-                              <div className="endpoint-meta">
-                                <span className="endpoint-meta-label">Sessions</span>
-                                <span>{endpoint.session_count ?? 0}</span>
-                              </div>
-                              <div className="endpoint-meta">
-                                <span className="endpoint-meta-label">Remote Web</span>
-                                <span>{remoteWebStatus}</span>
-                              </div>
-                              <div className="endpoint-meta">
-                                <span className="endpoint-meta-label">Agents</span>
-                                <span>{availableAgents.length > 0 ? availableAgents.join(', ') : 'none reported'}</span>
-                              </div>
-                              {remoteWebURL && (
-                                <div className="endpoint-meta">
-                                  <span className="endpoint-meta-label">Remote URL</span>
-                                  <a href={remoteWebURL} target="_blank" rel="noreferrer">{remoteWebURL}</a>
-                                </div>
-                              )}
-                              {remoteWebAuthURL && (
-                                <div className="settings-agent-warning">
-                                  Sign this host into Tailscale:
-                                  {' '}
-                                  <a href={remoteWebAuthURL} target="_blank" rel="noreferrer">{remoteWebAuthURL}</a>
-                                </div>
-                              )}
-                              {endpoint.capabilities.tailscale_domain && !remoteWebURL && (
-                                <div className="endpoint-meta">
-                                  <span className="endpoint-meta-label">Remote DNS</span>
-                                  <code>{endpoint.capabilities.tailscale_domain}</code>
-                                </div>
-                              )}
-                              {remoteWebError && (
-                                <div className="settings-agent-warning">{remoteWebError}</div>
-                              )}
-                              {endpoint.capabilities.projects_directory && (
-                                <div className="endpoint-meta">
-                                  <span className="endpoint-meta-label">Projects</span>
-                                  <code>{endpoint.capabilities.projects_directory}</code>
-                                </div>
-                              )}
-                            </>
-                          )}
-                          {!canToggleRemoteWeb && (
-                            <div className="settings-hint">Connect to the remote daemon before changing its web access.</div>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-
-          <div className="settings-section">
-            <h3>Plugins</h3>
-            <p className="settings-description">
-              Install user-owned plugins from local directories and control provider dispatch priority. Higher numbers run first.
-            </p>
-            <div className="plugin-form">
-              <input
-                type="text"
-                value={pluginSourcePath}
-                onChange={(e) => setPluginSourcePath(e.target.value)}
-                placeholder="/Users/you/src/my-attn-plugin"
-                className="settings-input"
-                aria-label="Plugin directory"
-                disabled={pluginActionName !== null}
-                autoCapitalize="none"
-                autoCorrect="off"
-                spellCheck={false}
-              />
-              <button className="browse-btn" onClick={() => void handleBrowsePluginPath()} disabled={pluginActionName !== null}>
-                Browse
-              </button>
-              <button className="browse-btn" onClick={() => void handleInstallPlugin()} disabled={pluginActionName !== null}>
-                Install Plugin
-              </button>
-            </div>
-            {pluginError && <div className="settings-agent-warning">{pluginError}</div>}
-            {pluginIssues.map((issue) => (
-              <div key={issue.path} className="settings-agent-warning">
-                {issue.path}: {issue.error}
-              </div>
-            ))}
-            {pluginsLoading ? (
-              <p className="settings-empty">Loading plugins...</p>
-            ) : plugins.length === 0 ? (
-              <p className="settings-empty">No plugins installed.</p>
-            ) : (
-              <div className="plugin-list">
-                {plugins.map((plugin) => {
-                  const busy = pluginActionName === plugin.name;
-                  const draftPriority = pluginPriorityDrafts[plugin.name] ?? String(plugin.priority);
-                  const healthStatus = plugin.health_status || 'unknown';
-                  return (
-                    <div key={plugin.name} className="plugin-card">
-                      <div className="plugin-card-header">
-                        <div className="plugin-card-title">
-                          <span className="endpoint-name">{plugin.name}</span>
-                          <span className="endpoint-profile-badge">v{plugin.version}</span>
-                          <span className={`plugin-status-badge ${plugin.connected ? 'connected' : plugin.running ? 'starting' : 'stopped'}`}>
-                            {plugin.connected ? 'connected' : plugin.running ? 'starting' : 'stopped'}
-                          </span>
-                          <span className={`plugin-health-badge ${healthStatus}`}>
-                            {healthStatus}
-                          </span>
-                        </div>
-                        <button className="browse-btn danger" onClick={() => void handleRemovePlugin(plugin.name)} disabled={pluginActionName !== null}>
+                      <div className="endpoint-card-actions">
+                        {isEditing ? (
+                          <>
+                            <button className="settings-action" onClick={() => void handleSaveEndpoint(endpoint.id)} disabled={isBusy}>
+                              Save
+                            </button>
+                            <button className="settings-action" onClick={cancelEditEndpoint} disabled={endpointActionInFlight}>
+                              Cancel
+                            </button>
+                          </>
+                        ) : (
+                          <button className="settings-action" onClick={() => beginEditEndpoint(endpoint)} disabled={endpointActionInFlight}>
+                            Edit
+                          </button>
+                        )}
+                        <button className="settings-action" onClick={() => void handleToggleEndpoint(endpoint)} disabled={endpointActionInFlight}>
+                          {endpoint.enabled === false ? 'Enable' : 'Disable'}
+                        </button>
+                        <button
+                          className="settings-action"
+                          onClick={() => void handleRebootstrapEndpoint(endpoint)}
+                          disabled={!canRebootstrap}
+                        >
+                          Re-bootstrap
+                        </button>
+                        <button
+                          className="settings-action"
+                          onClick={() => void handleSetEndpointRemoteWeb(endpoint.id, !remoteWebEnabled)}
+                          disabled={!canToggleRemoteWeb}
+                        >
+                          {remoteWebEnabled ? 'Disable Web' : 'Enable Web'}
+                        </button>
+                        <button className="settings-action danger" onClick={() => void handleRemoveEndpoint(endpoint.id)} disabled={endpointActionInFlight}>
                           Remove
                         </button>
                       </div>
-                      {plugin.description && <p className="settings-description plugin-description">{plugin.description}</p>}
-                      {plugin.health_message && (
-                        <div className="settings-agent-warning">
-                          Healthcheck: {plugin.health_message}
-                        </div>
-                      )}
-                      <div className="plugin-meta-grid">
-                        <div className="endpoint-meta">
-                          <span className="endpoint-meta-label">Path</span>
-                          <code>{plugin.dir}</code>
-                        </div>
-                        <label className="plugin-priority-control">
-                          <span className="endpoint-meta-label">Priority</span>
-                          <input
-                            type="number"
-                            value={draftPriority}
-                            onChange={(e) => handlePluginPriorityChange(plugin.name, e.target.value)}
-                            className="settings-input plugin-priority-input"
-                            aria-label={`${plugin.name} priority`}
-                            disabled={pluginActionName !== null}
-                          />
-                          <button
-                            className="browse-btn"
-                            onClick={() => void handleSavePluginPriority(plugin.name)}
-                            disabled={pluginActionName !== null || draftPriority === String(plugin.priority)}
-                          >
-                            Save
-                          </button>
-                        </label>
-                      </div>
-                      {busy && <div className="settings-hint">Updating {plugin.name}...</div>}
                     </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
+                    {isEditing ? (
+                      <div className="settings-form-grid endpoint-form-inline">
+                        <input
+                          type="text"
+                          value={editingEndpointName}
+                          onChange={(e) => setEditingEndpointName(e.target.value)}
+                          className="settings-input"
+                          aria-label="Edit endpoint name"
+                          disabled={endpointActionInFlight}
+                          autoCapitalize="none"
+                          autoCorrect="off"
+                          spellCheck={false}
+                        />
+                        <input
+                          type="text"
+                          value={editingEndpointTarget}
+                          onChange={(e) => setEditingEndpointTarget(e.target.value)}
+                          className="settings-input"
+                          aria-label="Edit SSH target"
+                          disabled={endpointActionInFlight}
+                          autoCapitalize="none"
+                          autoCorrect="off"
+                          spellCheck={false}
+                        />
+                        <input
+                          type="text"
+                          value={editingEndpointProfile}
+                          onChange={(e) => setEditingEndpointProfile(e.target.value)}
+                          className="settings-input"
+                          aria-label="Edit profile"
+                          placeholder="default"
+                          pattern="[a-z0-9][a-z0-9-]{0,15}"
+                          disabled={endpointActionInFlight}
+                          autoCapitalize="none"
+                          autoCorrect="off"
+                          spellCheck={false}
+                        />
+                      </div>
+                    ) : (
+                      <div className="endpoint-summary">
+                        <div className="settings-meta-row">
+                          <span className="settings-meta-label">SSH</span>
+                          <code>{endpoint.ssh_target}</code>
+                        </div>
+                        <div className="settings-meta-row">
+                          <span className="settings-meta-label">Enabled</span>
+                          <span>{endpoint.enabled === false ? 'No' : 'Yes'}</span>
+                        </div>
+                        {endpoint.status_message && (
+                          <div className="settings-meta-row">
+                            <span className="settings-meta-label">Status</span>
+                            <span>{endpoint.status_message}</span>
+                          </div>
+                        )}
+                        {endpoint.capabilities && (
+                          <>
+                            <div className="settings-meta-row">
+                              <span className="settings-meta-label">Protocol</span>
+                              <span>{endpoint.capabilities.protocol_version}</span>
+                            </div>
+                            <div className="settings-meta-row">
+                              <span className="settings-meta-label">PTY</span>
+                              <span>{endpoint.capabilities.pty_backend_mode || 'unknown'}</span>
+                            </div>
+                            <div className="settings-meta-row">
+                              <span className="settings-meta-label">Sessions</span>
+                              <span>{endpoint.session_count ?? 0}</span>
+                            </div>
+                            <div className="settings-meta-row">
+                              <span className="settings-meta-label">Remote Web</span>
+                              <span>{remoteWebStatus}</span>
+                            </div>
+                            <div className="settings-meta-row">
+                              <span className="settings-meta-label">Agents</span>
+                              <span>{availableAgents.length > 0 ? availableAgents.join(', ') : 'none reported'}</span>
+                            </div>
+                            {remoteWebURL && (
+                              <div className="settings-meta-row">
+                                <span className="settings-meta-label">Remote URL</span>
+                                <a href={remoteWebURL} target="_blank" rel="noreferrer">{remoteWebURL}</a>
+                              </div>
+                            )}
+                            {remoteWebAuthURL && (
+                              <div className="settings-warning">
+                                Sign this host into Tailscale:{' '}
+                                <a href={remoteWebAuthURL} target="_blank" rel="noreferrer">{remoteWebAuthURL}</a>
+                              </div>
+                            )}
+                            {endpoint.capabilities.tailscale_domain && !remoteWebURL && (
+                              <div className="settings-meta-row">
+                                <span className="settings-meta-label">Remote DNS</span>
+                                <code>{endpoint.capabilities.tailscale_domain}</code>
+                              </div>
+                            )}
+                            {remoteWebError && (
+                              <div className="settings-warning">{remoteWebError}</div>
+                            )}
+                            {endpoint.capabilities.projects_directory && (
+                              <div className="settings-meta-row">
+                                <span className="settings-meta-label">Projects</span>
+                                <code>{endpoint.capabilities.projects_directory}</code>
+                              </div>
+                            )}
+                          </>
+                        )}
+                        {!canToggleRemoteWeb && (
+                          <div className="settings-hint">Connect to the remote daemon before changing its web access.</div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </section>
+    </>
+  );
 
-          <div className="settings-section">
-            <h3>Executables</h3>
-            <p className="settings-description">
-              Override the CLI used to launch agents. Leave empty to use the default on your PATH.
-            </p>
+  const renderPluginSettings = () => (
+    <section className="settings-block">
+      <div className="settings-block-intro">
+        <div className="settings-kicker">Extensions</div>
+        <h3>Plugins</h3>
+        <p className="settings-description">
+          Install user-owned plugins from local directories and control provider dispatch priority.
+        </p>
+      </div>
+      <div className="settings-block-body">
+        <div className="settings-inline-form plugin-form">
+          <input
+            type="text"
+            value={pluginSourcePath}
+            onChange={(e) => setPluginSourcePath(e.target.value)}
+            placeholder="/Users/you/src/my-attn-plugin"
+            className="settings-input"
+            aria-label="Plugin directory"
+            disabled={pluginActionName !== null}
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+          />
+          <button className="settings-action" onClick={() => void handleBrowsePluginPath()} disabled={pluginActionName !== null}>
+            Browse
+          </button>
+          <button className="settings-action" onClick={() => void handleInstallPlugin()} disabled={pluginActionName !== null}>
+            Install Plugin
+          </button>
+        </div>
+        {pluginError && <div className="settings-warning">{pluginError}</div>}
+        {pluginIssues.map((issue) => (
+          <div key={issue.path} className="settings-warning">
+            {issue.path}: {issue.error}
+          </div>
+        ))}
+        {pluginsLoading ? (
+          <p className="settings-empty">Loading plugins...</p>
+        ) : plugins.length === 0 ? (
+          <p className="settings-empty">No plugins installed.</p>
+        ) : (
+          <div className="plugin-list">
+            {plugins.map((plugin) => {
+              const busy = pluginActionName === plugin.name;
+              const draftPriority = pluginPriorityDrafts[plugin.name] ?? String(plugin.priority);
+              const healthStatus = plugin.health_status || 'unknown';
+              return (
+                <div key={plugin.name} className="plugin-card">
+                  <div className="plugin-card-header">
+                    <div className="plugin-card-title">
+                      <span className="endpoint-name">{plugin.name}</span>
+                      <span className="settings-pill">v{plugin.version}</span>
+                      <span className={`plugin-status-badge ${plugin.connected ? 'connected' : plugin.running ? 'starting' : 'stopped'}`}>
+                        {plugin.connected ? 'connected' : plugin.running ? 'starting' : 'stopped'}
+                      </span>
+                      <span className={`plugin-health-badge ${healthStatus}`}>
+                        {healthStatus}
+                      </span>
+                    </div>
+                    <button className="settings-action danger" onClick={() => void handleRemovePlugin(plugin.name)} disabled={pluginActionName !== null}>
+                      Remove
+                    </button>
+                  </div>
+                  {plugin.description && <p className="settings-description plugin-description">{plugin.description}</p>}
+                  {plugin.health_message && (
+                    <div className="settings-warning">
+                      Healthcheck: {plugin.health_message}
+                    </div>
+                  )}
+                  <div className="plugin-meta-grid">
+                    <div className="settings-meta-row">
+                      <span className="settings-meta-label">Path</span>
+                      <code>{plugin.dir}</code>
+                    </div>
+                    <label className="plugin-priority-control">
+                      <span className="settings-meta-label">Priority</span>
+                      <input
+                        type="number"
+                        value={draftPriority}
+                        onChange={(e) => handlePluginPriorityChange(plugin.name, e.target.value)}
+                        className="settings-input plugin-priority-input"
+                        aria-label={`${plugin.name} priority`}
+                        disabled={pluginActionName !== null}
+                      />
+                      <button
+                        className="settings-action"
+                        onClick={() => void handleSavePluginPriority(plugin.name)}
+                        disabled={pluginActionName !== null || draftPriority === String(plugin.priority)}
+                      >
+                        Save
+                      </button>
+                    </label>
+                  </div>
+                  {busy && <div className="settings-hint">Updating {plugin.name}...</div>}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+
+  const renderAgentSettings = () => (
+    <>
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Paths</div>
+          <h3>Executables</h3>
+          <p className="settings-description">
+            Override the CLI used to launch agents. Empty values use the default on PATH.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          <div className="settings-field-grid">
             {orderedAgentList.map((agent) => {
               const available = isAgentAvailable(agentAvailability, agent);
               const inputId = `settings-${agent}-exec`;
@@ -1028,6 +1279,7 @@ export function SettingsModal({
             })}
             <div className="settings-field">
               <label className="settings-label" htmlFor="settings-editor-exec">Editor</label>
+              <span className="settings-status">Used when opening files</span>
               <input
                 id="settings-editor-exec"
                 type="text"
@@ -1043,96 +1295,208 @@ export function SettingsModal({
               />
             </div>
           </div>
+        </div>
+      </section>
 
-          <div className="settings-section">
-            <h3>Review Loop Prompts</h3>
-            <p className="settings-description">
-              Manage saved custom prompts for session review loops. Built-in presets stay available in the loop bar.
-            </p>
-            <div className="review-loop-settings">
-              <div className="review-loop-settings-list">
-                <div className="settings-row-inline">
-                  <label className="settings-label" htmlFor="review-loop-preset-select">Saved prompts</label>
-                  <button className="browse-btn" onClick={handleNewReviewLoopPreset}>New</button>
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Default</div>
+          <h3>Default Session Agent</h3>
+          <p className="settings-description">
+            Used for new sessions and opening PRs. Individual sessions can still choose a different agent.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          {!hasAvailableAgents && (
+            <div className="settings-warning">No supported agent CLI found in PATH.</div>
+          )}
+          <div className="settings-segmented" role="radiogroup" aria-label="Default session agent">
+            {orderedAgentList.map((agent) => {
+              const available = isAgentAvailable(agentAvailability, agent);
+              return (
+                <button
+                  key={agent}
+                  type="button"
+                  className={`settings-segmented-option ${defaultAgent === agent ? 'active' : ''}`}
+                  onClick={() => handleDefaultAgentChange(agent)}
+                  aria-checked={defaultAgent === agent}
+                  disabled={!available}
+                  title={!available ? `${agentLabel(agent)} CLI not found in PATH` : undefined}
+                >
+                  {agentLabel(agent)}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Capabilities</div>
+          <h3>Agent Capabilities</h3>
+          <p className="settings-description">
+            Optional integration features reported by each agent.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          <div className="agent-capabilities-list">
+            {orderedAgentList.map((agent) => {
+              const caps = actualAgentCapabilities[agent] || {};
+              const knownCaps = agentCapabilityOrder.filter((cap) => cap in caps);
+              const extraCaps = Object.keys(caps)
+                .filter((cap) => !agentCapabilityOrder.includes(cap))
+                .sort((a, b) => a.localeCompare(b));
+              const capKeys = [...knownCaps, ...extraCaps];
+              return (
+                <div key={agent} className="agent-capabilities-item">
+                  <div className="agent-capabilities-agent">{agentLabel(agent)}</div>
+                  {capKeys.length === 0 ? (
+                    <span className="agent-capability-pill">No capability metadata</span>
+                  ) : (
+                    <div className="agent-capabilities-pills">
+                      {capKeys.map((cap) => (
+                        <span
+                          key={`${agent}-${cap}`}
+                          className={`agent-capability-pill ${caps[cap] ? 'enabled' : 'disabled'}`}
+                          title={caps[cap] ? 'Enabled' : 'Disabled'}
+                        >
+                          {agentCapabilityLabel(cap)}: {caps[cap] ? 'on' : 'off'}
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
-                {reviewLoopPresets.length === 0 ? (
-                  <p className="settings-empty">No saved review-loop prompts</p>
-                ) : (
-                  <select
-                    id="review-loop-preset-select"
-                    className="settings-input"
-                    value={selectedReviewLoopPresetID}
-                    onChange={(e) => handleSelectReviewLoopPreset(e.target.value)}
-                  >
-                    {reviewLoopPresets.map((preset) => (
-                      <option key={preset.id} value={preset.id}>{preset.name}</option>
-                    ))}
-                  </select>
-                )}
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Terminal</div>
+          <h3>PTY Backend</h3>
+          <p className="settings-description">
+            Shows whether terminal sessions run in external worker processes or directly in the daemon.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          <div className="settings-row-card compact">
+            <div>
+              <p className="settings-row-title">Runtime mode</p>
+              <p className="settings-row-copy">{ptyBackendHint}</p>
+            </div>
+            <span className={`settings-status mode-${ptyBackendMode}`}>
+              {ptyBackendLabel}
+            </span>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+
+  const renderReviewSettings = () => (
+    <>
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Prompts</div>
+          <h3>Review Loop Prompts</h3>
+          <p className="settings-description">
+            Saved custom prompts for session review loops. Built-in presets stay available in the loop bar.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          <div className="review-loop-settings">
+            <div className="review-loop-settings-list">
+              <div className="settings-row-inline">
+                <label className="settings-label" htmlFor="review-loop-preset-select">Saved prompts</label>
+                <button className="settings-action" onClick={handleNewReviewLoopPreset}>New</button>
               </div>
-              <div className="settings-field">
-                <label className="settings-label" htmlFor="review-loop-preset-name">Prompt name</label>
-                <input
-                  id="review-loop-preset-name"
-                  type="text"
+              {reviewLoopPresets.length === 0 ? (
+                <p className="settings-empty">No saved review-loop prompts</p>
+              ) : (
+                <select
+                  id="review-loop-preset-select"
                   className="settings-input"
-                  value={reviewLoopPresetName}
-                  onChange={(e) => setReviewLoopPresetName(e.target.value)}
-                  placeholder="Architect pass"
-                  autoCapitalize="none"
-                  autoCorrect="off"
-                  spellCheck={false}
-                />
-              </div>
-              <div className="settings-field">
-                <label className="settings-label" htmlFor="review-loop-preset-iterations">Default iterations</label>
-                <input
-                  id="review-loop-preset-iterations"
-                  type="number"
-                  min={1}
-                  className="settings-input"
-                  value={reviewLoopIterations}
-                  onChange={(e) => setReviewLoopIterations(Number(e.target.value) || 1)}
-                />
-              </div>
-              <div className="settings-field">
-                <label className="settings-label" htmlFor="review-loop-preset-prompt">Prompt</label>
-                <textarea
-                  id="review-loop-preset-prompt"
-                  className="settings-textarea"
-                  value={reviewLoopPrompt}
-                  onChange={(e) => setReviewLoopPrompt(e.target.value)}
-                  rows={6}
-                  autoCapitalize="none"
-                  autoCorrect="off"
-                  spellCheck={false}
-                  placeholder="Do a full review of these changes..."
-                />
-              </div>
-              <div className="settings-row-inline review-loop-settings-actions">
-                <button
-                  className="browse-btn"
-                  onClick={handleSaveReviewLoopPreset}
-                  disabled={!reviewLoopPresetName.trim() || !reviewLoopPrompt.trim()}
+                  value={selectedReviewLoopPresetID}
+                  onChange={(e) => handleSelectReviewLoopPreset(e.target.value)}
                 >
-                  Save Prompt
-                </button>
-                <button
-                  className="browse-btn danger"
-                  onClick={handleDeleteReviewLoopPreset}
-                  disabled={!selectedReviewLoopPresetID}
-                >
-                  Delete
-                </button>
-              </div>
+                  {reviewLoopPresets.map((preset) => (
+                    <option key={preset.id} value={preset.id}>{preset.name}</option>
+                  ))}
+                </select>
+              )}
+            </div>
+            <div className="settings-field">
+              <label className="settings-label" htmlFor="review-loop-preset-name">Prompt name</label>
+              <input
+                id="review-loop-preset-name"
+                type="text"
+                className="settings-input"
+                value={reviewLoopPresetName}
+                onChange={(e) => setReviewLoopPresetName(e.target.value)}
+                placeholder="Architect pass"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+              />
+            </div>
+            <div className="settings-field">
+              <label className="settings-label" htmlFor="review-loop-preset-iterations">Default iterations</label>
+              <input
+                id="review-loop-preset-iterations"
+                type="number"
+                min={1}
+                className="settings-input"
+                value={reviewLoopIterations}
+                onChange={(e) => setReviewLoopIterations(Number(e.target.value) || 1)}
+              />
+            </div>
+            <div className="settings-field">
+              <label className="settings-label" htmlFor="review-loop-preset-prompt">Prompt</label>
+              <textarea
+                id="review-loop-preset-prompt"
+                className="settings-textarea"
+                value={reviewLoopPrompt}
+                onChange={(e) => setReviewLoopPrompt(e.target.value)}
+                rows={6}
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+                placeholder="Do a full review of these changes..."
+              />
+            </div>
+            <div className="settings-row-inline review-loop-settings-actions">
+              <button
+                className="settings-action"
+                onClick={handleSaveReviewLoopPreset}
+                disabled={!reviewLoopPresetName.trim() || !reviewLoopPrompt.trim()}
+              >
+                Save Prompt
+              </button>
+              <button
+                className="settings-action danger"
+                onClick={handleDeleteReviewLoopPreset}
+                disabled={!selectedReviewLoopPresetID}
+              >
+                Delete
+              </button>
             </div>
           </div>
+        </div>
+      </section>
 
-          <div className="settings-section">
-            <h3>Review Models</h3>
-            <p className="settings-description">
-              Override the Claude models used for SDK-based review work. Leave empty to use the built-in defaults.
-            </p>
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Models</div>
+          <h3>Review Models</h3>
+          <p className="settings-description">
+            Override the Claude models used for SDK-based review work. Empty values use built-in defaults.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          <div className="settings-field-grid two-column">
             <div className="settings-field">
               <label className="settings-label" htmlFor="settings-review-loop-model">Review loop model</label>
               <input
@@ -1174,127 +1538,158 @@ export function SettingsModal({
               />
             </div>
           </div>
+        </div>
+      </section>
+    </>
+  );
 
-          <div className="settings-section">
-            <h3>Default Session Agent</h3>
-            <p className="settings-description">
-              Used for new sessions and when opening PRs. You can override per session in the new session dialog.
-            </p>
-            {!hasAvailableAgents && (
-              <div className="settings-agent-warning">No supported agent CLI found in PATH.</div>
-            )}
-            <div className="settings-agent-toggle" role="radiogroup" aria-label="Default session agent">
-              {orderedAgentList.map((agent) => {
-                const available = isAgentAvailable(agentAvailability, agent);
-                return (
+  const renderHygieneSettings = () => (
+    <>
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Repositories</div>
+          <h3>Muted Repositories</h3>
+          <p className="settings-description">
+            Repositories hidden from the attention queue.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          {mutedRepos.length === 0 ? (
+            <p className="settings-empty">No muted repositories</p>
+          ) : (
+            <ul className="muted-items-list" data-testid="settings-muted-repositories-list">
+              {mutedRepos.map(repo => (
+                <li key={repo} className="muted-item" data-testid="settings-muted-repository-item">
+                  <span className="muted-item-name">{repo}</span>
                   <button
-                    key={agent}
-                    type="button"
-                    className={`agent-option ${defaultAgent === agent ? 'active' : ''}`}
-                    onClick={() => handleDefaultAgentChange(agent)}
-                    aria-checked={defaultAgent === agent}
-                    disabled={!available}
-                    title={!available ? `${agentLabel(agent)} CLI not found in PATH` : undefined}
+                    className="settings-action"
+                    data-testid="settings-unmute-repository-button"
+                    onClick={() => onUnmuteRepo(repo)}
                   >
-                    {agentLabel(agent)}
+                    Unmute
                   </button>
-                );
-              })}
-            </div>
-          </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
 
-          <div className="settings-section">
-            <h3>Agent Capabilities</h3>
-            <p className="settings-description">
-              Shows which optional integration features are enabled per agent.
-            </p>
-            <div className="agent-capabilities-list">
-              {orderedAgentList.map((agent) => {
-                const caps = actualAgentCapabilities[agent] || {};
-                const knownCaps = agentCapabilityOrder.filter((cap) => cap in caps);
-                const extraCaps = Object.keys(caps)
-                  .filter((cap) => !agentCapabilityOrder.includes(cap))
-                  .sort((a, b) => a.localeCompare(b));
-                const capKeys = [...knownCaps, ...extraCaps];
-                return (
-                  <div key={agent} className="agent-capabilities-item">
-                    <div className="agent-capabilities-agent">{agentLabel(agent)}</div>
-                    {capKeys.length === 0 ? (
-                      <span className="agent-capability-pill">No capability metadata</span>
-                    ) : (
-                      <div className="agent-capabilities-pills">
-                        {capKeys.map((cap) => (
-                          <span
-                            key={`${agent}-${cap}`}
-                            className={`agent-capability-pill ${caps[cap] ? 'enabled' : 'disabled'}`}
-                            title={caps[cap] ? 'Enabled' : 'Disabled'}
-                          >
-                            {agentCapabilityLabel(cap)}: {caps[cap] ? 'on' : 'off'}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Authors</div>
+          <h3>Muted Authors</h3>
+          <p className="settings-description">
+            Authors hidden from the attention queue.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          {mutedAuthors.length === 0 ? (
+            <p className="settings-empty">No muted authors</p>
+          ) : (
+            <ul className="muted-items-list" data-testid="settings-muted-authors-list">
+              {mutedAuthors.map(author => (
+                <li key={author} className="muted-item" data-testid="settings-muted-author-item">
+                  <span className="muted-item-name">{author}</span>
+                  <button
+                    className="settings-action"
+                    data-testid="settings-unmute-author-button"
+                    onClick={() => onUnmuteAuthor(author)}
+                  >
+                    Unmute
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+    </>
+  );
 
-          <div className="settings-section">
-            <h3>PTY Backend</h3>
-            <p className="settings-description">
-              Shows whether terminal sessions run in external worker processes or directly in the daemon.
-            </p>
-            <div className="settings-field">
-              <label className="settings-label">Runtime mode</label>
-              <span className={`settings-status mode-${ptyBackendMode}`}>
-                {ptyBackendLabel}
-              </span>
-              <div className="settings-hint">{ptyBackendHint}</div>
-            </div>
-          </div>
+  const renderSelectedSection = () => {
+    switch (selectedSection) {
+      case 'general':
+        return renderGeneralSettings();
+      case 'plugins':
+        return renderPluginSettings();
+      case 'agents':
+        return renderAgentSettings();
+      case 'review':
+        return renderReviewSettings();
+      case 'hygiene':
+        return renderHygieneSettings();
+      case 'connectivity':
+      default:
+        return renderConnectivitySettings();
+    }
+  };
 
-          <div className="settings-section">
-            <h3>Muted Repositories</h3>
-            {mutedRepos.length === 0 ? (
-              <p className="settings-empty">No muted repositories</p>
+  if (!isOpen) return null;
+
+  return (
+    <div className="settings-overlay" data-testid="settings-overlay" onClick={onClose}>
+      <div className="settings-modal" data-testid="settings-modal" onClick={e => e.stopPropagation()}>
+        <div className="settings-header" data-testid="settings-header">
+          <div className="settings-title">
+            <h2>Settings</h2>
+            <span className="settings-profile">local daemon</span>
+          </div>
+          <div className="settings-top-actions">
+            <input
+              className="settings-search"
+              type="search"
+              value={settingsSearch}
+              onChange={(e) => setSettingsSearch(e.target.value)}
+              placeholder="Search settings"
+              aria-label="Search settings"
+            />
+            <button className="settings-close" data-testid="settings-close" onClick={onClose} aria-label="Close settings">
+              x
+            </button>
+          </div>
+        </div>
+
+        <div className="settings-layout">
+          <nav className="settings-nav" aria-label="Settings sections">
+            {filteredNavGroups.length === 0 ? (
+              <p className="settings-empty nav-empty">No matching settings.</p>
             ) : (
-              <ul className="muted-items-list">
-                {mutedRepos.map(repo => (
-                  <li key={repo} className="muted-item">
-                    <span className="muted-item-name">{repo}</span>
+              filteredNavGroups.map((group) => (
+                <div className="settings-nav-group" key={group.label}>
+                  <div className="settings-nav-label">{group.label}</div>
+                  {group.items.map((item) => (
                     <button
-                      className="unmute-btn"
-                      onClick={() => onUnmuteRepo(repo)}
+                      key={item.id}
+                      type="button"
+                      data-testid={`settings-nav-${item.id}`}
+                      className={`settings-nav-item ${selectedSection === item.id ? 'active' : ''}`}
+                      onClick={() => setSelectedSection(item.id)}
                     >
-                      Unmute
+                      <span>{item.label}</span>
+                      <span className="settings-nav-count">{item.count}</span>
                     </button>
-                  </li>
-                ))}
-              </ul>
+                  ))}
+                </div>
+              ))
             )}
-          </div>
+          </nav>
 
-          <div className="settings-section">
-            <h3>Muted Authors</h3>
-            {mutedAuthors.length === 0 ? (
-              <p className="settings-empty">No muted authors</p>
-            ) : (
-              <ul className="muted-items-list">
-                {mutedAuthors.map(author => (
-                  <li key={author} className="muted-item">
-                    <span className="muted-item-name">{author.toLowerCase().includes('bot') ? '🤖' : '👤'} {author}</span>
-                    <button
-                      className="unmute-btn"
-                      onClick={() => onUnmuteAuthor(author)}
-                    >
-                      Unmute
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
+          <main className="settings-body" data-testid="settings-body">
+            <div className="settings-content-head">
+              <div>
+                <div className="settings-kicker">{selectedNavItem?.label}</div>
+                <h1>{selectedNavItem?.title}</h1>
+                <p className="settings-lead">{selectedNavItem?.description}</p>
+              </div>
+              <div className="settings-status-pair">
+                {renderSectionStatusPills()}
+              </div>
+            </div>
+            <div className="settings-section-content" data-testid={`settings-section-${selectedSection}`}>
+              {renderSelectedSection()}
+            </div>
+          </main>
         </div>
       </div>
     </div>

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,7 +1,10 @@
+import { installVerbatimTextEntryGuard } from './utils/verbatimTextEntry';
+
 declare global { interface Window { __dbg?: (msg: string) => void } }
 const dbg = (msg: string) => window.__dbg?.(msg);
 
 dbg('main.tsx: imports resolved');
+installVerbatimTextEntryGuard(document);
 
 async function boot() {
   dbg('boot: loading ReactDOM');

--- a/app/src/utils/verbatimTextEntry.test.ts
+++ b/app/src/utils/verbatimTextEntry.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { waitFor } from '../test/utils';
+import { installVerbatimTextEntryGuard } from './verbatimTextEntry';
+
+describe('installVerbatimTextEntryGuard', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('disables browser rewriting on existing editable controls', () => {
+    document.body.innerHTML = '<input type="search"><textarea></textarea><div contenteditable="true"></div>';
+
+    const dispose = installVerbatimTextEntryGuard(document.body);
+
+    for (const element of document.body.querySelectorAll('input, textarea, [contenteditable]')) {
+      expect(element).toHaveAttribute('autocorrect', 'off');
+      expect(element).toHaveAttribute('autocapitalize', 'none');
+      expect(element).toHaveAttribute('spellcheck', 'false');
+    }
+
+    dispose();
+  });
+
+  it('disables browser rewriting on controls created by runtime widgets', async () => {
+    const dispose = installVerbatimTextEntryGuard(document.body);
+    const terminalTextarea = document.createElement('textarea');
+    terminalTextarea.className = 'xterm-helper-textarea';
+    terminalTextarea.setAttribute('autocorrect', 'on');
+    document.body.appendChild(terminalTextarea);
+
+    await waitFor(() => {
+      expect(terminalTextarea).toHaveAttribute('autocorrect', 'off');
+      expect(terminalTextarea).toHaveAttribute('autocapitalize', 'none');
+      expect(terminalTextarea).toHaveAttribute('spellcheck', 'false');
+    });
+
+    dispose();
+  });
+});

--- a/app/src/utils/verbatimTextEntry.ts
+++ b/app/src/utils/verbatimTextEntry.ts
@@ -1,0 +1,57 @@
+const EDITABLE_SELECTOR = 'input, textarea, [contenteditable]';
+const VERBATIM_ENTRY_ATTRIBUTES = {
+  autocorrect: 'off',
+  autocapitalize: 'none',
+  spellcheck: 'false',
+} as const;
+
+function isEditableElement(node: Node): node is HTMLElement {
+  return node instanceof HTMLElement && node.matches(EDITABLE_SELECTOR);
+}
+
+function enforceVerbatimTextEntry(element: HTMLElement): void {
+  for (const [attribute, value] of Object.entries(VERBATIM_ENTRY_ATTRIBUTES)) {
+    if (element.getAttribute(attribute) !== value) {
+      element.setAttribute(attribute, value);
+    }
+  }
+}
+
+function enforceInSubtree(root: ParentNode | Node): void {
+  if (isEditableElement(root as Node)) {
+    enforceVerbatimTextEntry(root as HTMLElement);
+  }
+
+  if ('querySelectorAll' in root) {
+    root.querySelectorAll<HTMLElement>(EDITABLE_SELECTOR).forEach(enforceVerbatimTextEntry);
+  }
+}
+
+/**
+ * Text entry in attn is preserved as typed, including controls created later
+ * by xterm and editor widgets.
+ */
+export function installVerbatimTextEntryGuard(root: Document | HTMLElement): () => void {
+  enforceInSubtree(root);
+
+  const observedRoot = root instanceof Document ? root.documentElement : root;
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type === 'attributes') {
+        enforceVerbatimTextEntry(mutation.target as HTMLElement);
+        continue;
+      }
+
+      mutation.addedNodes.forEach(enforceInSubtree);
+    }
+  });
+
+  observer.observe(observedRoot, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: Object.keys(VERBATIM_ENTRY_ATTRIBUTES),
+  });
+
+  return () => observer.disconnect();
+}

--- a/app/test-harness/main.tsx
+++ b/app/test-harness/main.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import { installVerbatimTextEntryGuard } from '../src/utils/verbatimTextEntry';
 import { harnesses } from './harnesses';
 import type { HarnessAPI } from './types';
 // Note: Base styles are included via component CSS imports
@@ -87,6 +88,8 @@ function HarnessApp() {
     <HarnessComponent onReady={handleReady} setTriggerRerender={setTriggerRerender} />
   );
 }
+
+installVerbatimTextEntryGuard(document);
 
 const root = createRoot(document.getElementById('harness-root')!);
 root.render(


### PR DESCRIPTION
## Intent / Why

Settings had grown into one crowded surface, making plugin and runtime configuration difficult to scan and causing narrow layouts to collapse important values. Text fields also allowed native correction behavior that can mutate paths, branch names, prompts, and commands.

## Summary

- Reworks Settings into a larger navigable workbench with separated areas for preferences, connectivity, plugins, agents, review configuration, and muted items, so each workflow has usable space.
- Removes the extra summary rail, uses the application font scaling variables, and stacks section content so plugin paths and controls remain readable at smaller widths.
- Adds `installVerbatimTextEntryGuard()` so all editable controls, including dynamically inserted terminal and editor textareas, preserve typed text without autocorrection, automatic capitalization, or spellchecking.
- Adds stable Settings test hooks and a visual Playwright harness for desktop, tablet, and mobile section coverage.
- Documents the user-visible Settings and input behavior changes in `CHANGELOG.md`.

## Test plan

- [x] `pnpm --dir app build`
- [x] `pnpm --dir app exec vitest run src/utils/verbatimTextEntry.test.ts src/components/SettingsModal.test.tsx src/components/Terminal.test.tsx src/components/UnifiedDiffEditor.test.ts`
- [x] `pnpm --dir app e2e -- e2e/settings.spec.ts e2e/settings-visual.spec.ts`
- [x] Built and launched the packaged app with `make` for manual inspection.

## Out of scope

- Additional Settings information architecture changes beyond the sections and layout in this PR.