### PR TITLE
fix(settings): show daemon-discovered GitHub hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Changed
 - **Input Assistance Disabled**: attn no longer allows browser or operating-system autocorrection, auto-capitalization, or spellchecking to rewrite typed paths, branches, commands, prompts, comments, or searches.
 - **GitHub Host Visibility**: Settings now lists daemon-discovered authenticated GitHub hosts even when a host has no currently visible pull requests.
+- **Terminal Colors**: Interactive terminals no longer inherit `NO_COLOR` from the process that launched attn, so shells and coding agents can emit their normal colored output.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Changed
 - **Input Assistance Disabled**: attn no longer allows browser or operating-system autocorrection, auto-capitalization, or spellchecking to rewrite typed paths, branches, commands, prompts, comments, or searches.
+- **GitHub Host Visibility**: Settings now lists daemon-discovered authenticated GitHub hosts even when a host has no currently visible pull requests.
 
 ---
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -121,6 +121,7 @@ function App() {
   const [daemonEndpoints, setDaemonEndpoints] = useState<DaemonEndpoint[]>([]);
   const [daemonPlugins, setDaemonPlugins] = useState<DaemonPlugin[]>([]);
   const [daemonPluginIssues, setDaemonPluginIssues] = useState<DaemonPluginIssue[]>([]);
+  const [daemonGitHubHosts, setDaemonGitHubHosts] = useState<string[]>([]);
   const handlePluginsUpdate = useCallback((plugins: DaemonPlugin[], issues: DaemonPluginIssue[]) => {
     setDaemonPlugins(plugins);
     setDaemonPluginIssues(issues);
@@ -315,6 +316,7 @@ function App() {
     onPRsUpdate: setPRs,
     onEndpointsUpdate: setDaemonEndpoints,
     onPluginsUpdate: handlePluginsUpdate,
+    onGitHubHostsUpdate: setDaemonGitHubHosts,
     onReposUpdate: setRepoStates,
     onAuthorsUpdate: setAuthorStates,
     onSettingsUpdate: setSettings,
@@ -351,6 +353,7 @@ function App() {
         daemonEndpoints={daemonEndpoints}
         daemonPlugins={daemonPlugins}
         daemonPluginIssues={daemonPluginIssues}
+        daemonGitHubHosts={daemonGitHubHosts}
         settings={settings}
         gitStatus={gitStatus}
         reviewLoopsBySessionId={reviewLoopsBySessionId}
@@ -430,6 +433,7 @@ interface AppContentProps {
   daemonEndpoints: DaemonEndpoint[];
   daemonPlugins: DaemonPlugin[];
   daemonPluginIssues: DaemonPluginIssue[];
+  daemonGitHubHosts: string[];
   settings: Record<string, string>;
   gitStatus: GitStatusUpdate | null;
   reviewLoopsBySessionId: Record<string, ReviewLoopState>;
@@ -505,6 +509,7 @@ function AppContent({
   daemonEndpoints,
   daemonPlugins,
   daemonPluginIssues,
+  daemonGitHubHosts,
   settings,
   gitStatus,
   reviewLoopsBySessionId,
@@ -605,14 +610,6 @@ sendFetchPRDetails,
     authorStates.filter(a => a.muted).map(a => a.author),
     [authorStates],
   );
-  const connectedHosts = useMemo(() => {
-    const set = new Set<string>();
-    for (const pr of prs) {
-      if (pr.host) set.add(pr.host);
-    }
-    return Array.from(set).sort();
-  }, [prs]);
-
   // Track PR refresh state for progress indicator
   const [isRefreshingPRs, setIsRefreshingPRs] = useState(false);
   const [refreshError, setRefreshError] = useState<string | null>(null);
@@ -2279,7 +2276,7 @@ sendFetchPRDetails,
         isOpen={settingsOpen}
         onClose={() => setSettingsOpen(false)}
         mutedRepos={mutedRepos}
-        connectedHosts={connectedHosts}
+        githubHosts={daemonGitHubHosts}
         onUnmuteRepo={sendMuteRepo}
         mutedAuthors={mutedAuthors}
         onUnmuteAuthor={sendMuteAuthor}

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -11,7 +11,7 @@ describe('SettingsModal review loop prompts', () => {
         isOpen
         onClose={onClose}
         mutedRepos={[]}
-        connectedHosts={[]}
+        githubHosts={[]}
         onUnmuteRepo={vi.fn()}
         mutedAuthors={[]}
         onUnmuteAuthor={vi.fn()}
@@ -39,6 +39,38 @@ describe('SettingsModal review loop prompts', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('renders authenticated GitHub hosts provided by the daemon', async () => {
+    render(
+      <SettingsModal
+        isOpen
+        onClose={vi.fn()}
+        mutedRepos={[]}
+        githubHosts={['ghe.example.test', 'github.com']}
+        onUnmuteRepo={vi.fn()}
+        mutedAuthors={[]}
+        onUnmuteAuthor={vi.fn()}
+        settings={{}}
+        endpoints={[]}
+        plugins={[]}
+        pluginIssues={[]}
+        onAddEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onUpdateEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onRemoveEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onSetEndpointRemoteWeb={vi.fn().mockResolvedValue({ success: true })}
+        onListPlugins={vi.fn().mockResolvedValue({ plugins: [], issues: [] })}
+        onInstallPlugin={vi.fn().mockResolvedValue({ success: true })}
+        onRemovePlugin={vi.fn().mockResolvedValue({ success: true })}
+        onSetPluginPriority={vi.fn().mockResolvedValue({ success: true })}
+        onSetSetting={vi.fn()}
+        themePreference="system"
+        onSetTheme={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText('ghe.example.test')).toBeInTheDocument();
+    expect(screen.getByText('github.com')).toBeInTheDocument();
+  });
+
   it('saves a custom review loop preset to settings', async () => {
     const onSetSetting = vi.fn();
 
@@ -47,7 +79,7 @@ describe('SettingsModal review loop prompts', () => {
         isOpen
         onClose={vi.fn()}
         mutedRepos={[]}
-        connectedHosts={[]}
+        githubHosts={[]}
         onUnmuteRepo={vi.fn()}
         mutedAuthors={[]}
         onUnmuteAuthor={vi.fn()}
@@ -97,7 +129,7 @@ describe('SettingsModal review loop prompts', () => {
         isOpen
         onClose={vi.fn()}
         mutedRepos={[]}
-        connectedHosts={[]}
+        githubHosts={[]}
         onUnmuteRepo={vi.fn()}
         mutedAuthors={[]}
         onUnmuteAuthor={vi.fn()}
@@ -137,7 +169,7 @@ describe('SettingsModal review loop prompts', () => {
         isOpen
         onClose={vi.fn()}
         mutedRepos={[]}
-        connectedHosts={[]}
+        githubHosts={[]}
         onUnmuteRepo={vi.fn()}
         mutedAuthors={[]}
         onUnmuteAuthor={vi.fn()}
@@ -177,7 +209,7 @@ describe('SettingsModal review loop prompts', () => {
         isOpen
         onClose={vi.fn()}
         mutedRepos={[]}
-        connectedHosts={[]}
+        githubHosts={[]}
         onUnmuteRepo={vi.fn()}
         mutedAuthors={[]}
         onUnmuteAuthor={vi.fn()}
@@ -231,7 +263,7 @@ describe('SettingsModal review loop prompts', () => {
       isOpen: true,
       onClose: vi.fn(),
       mutedRepos: [] as string[],
-      connectedHosts: [] as string[],
+      githubHosts: [] as string[],
       onUnmuteRepo: vi.fn(),
       mutedAuthors: [] as string[],
       onUnmuteAuthor: vi.fn(),
@@ -291,7 +323,7 @@ describe('SettingsModal review loop prompts', () => {
         isOpen
         onClose={vi.fn()}
         mutedRepos={[]}
-        connectedHosts={[]}
+        githubHosts={[]}
         onUnmuteRepo={vi.fn()}
         mutedAuthors={[]}
         onUnmuteAuthor={vi.fn()}
@@ -331,7 +363,7 @@ describe('SettingsModal review loop prompts', () => {
         isOpen
         onClose={vi.fn()}
         mutedRepos={[]}
-        connectedHosts={[]}
+        githubHosts={[]}
         onUnmuteRepo={vi.fn()}
         mutedAuthors={[]}
         onUnmuteAuthor={vi.fn()}
@@ -383,7 +415,7 @@ describe('SettingsModal review loop prompts', () => {
         isOpen
         onClose={vi.fn()}
         mutedRepos={[]}
-        connectedHosts={[]}
+        githubHosts={[]}
         onUnmuteRepo={vi.fn()}
         mutedAuthors={[]}
         onUnmuteAuthor={vi.fn()}

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -37,7 +37,7 @@ interface SettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
   mutedRepos: string[];
-  connectedHosts: string[];
+  githubHosts: string[];
   onUnmuteRepo: (repo: string) => void;
   mutedAuthors: string[];
   onUnmuteAuthor: (author: string) => void;
@@ -78,7 +78,7 @@ export function SettingsModal({
   isOpen,
   onClose,
   mutedRepos,
-  connectedHosts,
+  githubHosts,
   onUnmuteRepo,
   mutedAuthors,
   onUnmuteAuthor,
@@ -595,7 +595,7 @@ export function SettingsModal({
           label: 'Mobile, hosts, remotes',
           title: 'Mobile web, hosts, and remote endpoints',
           description: 'Controls for mobile browser access, GitHub host detection, and remote attn peers.',
-          count: Math.max(3, endpoints.length + connectedHosts.length + 1),
+          count: Math.max(3, endpoints.length + githubHosts.length + 1),
           keywords: 'tailscale mobile web github hosts ssh remote endpoint daemon',
         },
       ],
@@ -653,7 +653,7 @@ export function SettingsModal({
       ],
     },
   ], [
-    connectedHosts.length,
+    githubHosts.length,
     endpoints.length,
     mutedItemCount,
     orderedAgentList.length,
@@ -881,11 +881,11 @@ export function SettingsModal({
           </p>
         </div>
         <div className="settings-block-body">
-          {connectedHosts.length === 0 ? (
+          {githubHosts.length === 0 ? (
             <p className="settings-empty">No authenticated hosts detected.</p>
           ) : (
             <div className="settings-token-list">
-              {connectedHosts.map((host) => (
+              {githubHosts.map((host) => (
                 <span key={host} className="settings-token">{host}</span>
               ))}
             </div>

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -430,6 +430,43 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     unmount();
   });
 
+  it('reports daemon-discovered GitHub hosts from snapshots and refresh events', async () => {
+    const onGitHubHostsUpdate = vi.fn();
+    const { unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        onGitHubHostsUpdate,
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+    act(() => {
+      ws.emit({
+        event: 'initial_state',
+        sessions: [],
+        session_layouts: [],
+        prs: [],
+        repos: [],
+        authors: [],
+        github_hosts: ['github.com'],
+        settings: {},
+      });
+      ws.emit({
+        event: 'github_hosts_updated',
+        github_hosts: ['ghe.example.test', 'github.com'],
+      });
+    });
+
+    expect(onGitHubHostsUpdate).toHaveBeenNthCalledWith(1, ['github.com']);
+    expect(onGitHubHostsUpdate).toHaveBeenNthCalledWith(2, ['ghe.example.test', 'github.com']);
+    unmount();
+  });
+
   it('retries transient worker attach failures after respawn', async () => {
     const waits: number[] = [];
     const attach = vi.fn()
@@ -472,7 +509,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '63',
+        protocol_version: '64',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -548,7 +585,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '63',
+        protocol_version: '64',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -627,7 +664,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '63',
+        protocol_version: '64',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -720,7 +757,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '63',
+        protocol_version: '64',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -817,7 +854,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '63',
+        protocol_version: '64',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -900,7 +937,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '63',
+        protocol_version: '64',
         sessions: [],
         session_layouts: [{
           session_id: 'sess-remote',
@@ -1009,7 +1046,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '63',
+        protocol_version: '64',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -1067,7 +1104,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '63',
+        protocol_version: '64',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -130,6 +130,7 @@ type WebSocketEvent = GeneratedWebSocketEvent & {
   inspection?: PathInspection;
   plugins?: DaemonPlugin[];
   issues?: DaemonPluginIssue[];
+  github_hosts?: string[];
   // Legacy review event fields
   review_id?: string;
   session_id?: string;
@@ -151,7 +152,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '63';
+const PROTOCOL_VERSION = '64';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 // Runtime gate (flipped from VITE_UI_AUTOMATION). The Rust shell
 // injects this global before any page script runs — see
@@ -404,6 +405,7 @@ interface UseDaemonSocketOptions {
   onPRsUpdate: (prs: DaemonPR[]) => void;
   onEndpointsUpdate?: (endpoints: DaemonEndpoint[]) => void;
   onPluginsUpdate?: (plugins: DaemonPlugin[], issues: DaemonPluginIssue[]) => void;
+  onGitHubHostsUpdate?: (hosts: string[]) => void;
   onReposUpdate: (repos: RepoState[]) => void;
   onAuthorsUpdate: (authors: AuthorState[]) => void;
   onWorktreesUpdate?: (worktrees: DaemonWorktree[]) => void;
@@ -631,6 +633,7 @@ export function useDaemonSocket({
   onPRsUpdate,
   onEndpointsUpdate,
   onPluginsUpdate,
+  onGitHubHostsUpdate,
   onReposUpdate,
   onAuthorsUpdate,
   onWorktreesUpdate,
@@ -1035,6 +1038,8 @@ export function useDaemonSocket({
             const nextAuthors = data.authors || [];
             authorsRef.current = nextAuthors;
             onAuthorsUpdate(nextAuthors);
+
+            onGitHubHostsUpdate?.(data.github_hosts || []);
 
             const nextSettings = data.settings || {};
             settingsRef.current = nextSettings;
@@ -1563,6 +1568,10 @@ export function useDaemonSocket({
             }
             break;
 
+          case 'github_hosts_updated':
+            onGitHubHostsUpdate?.(data.github_hosts || []);
+            break;
+
           case 'plugins_updated': {
             const plugins = data.plugins || [];
             const issues = data.issues || [];
@@ -2023,7 +2032,7 @@ export function useDaemonSocket({
     };
 
     wsRef.current = ws;
-  }, [resolvedWsUrl, onSessionsUpdate, onWorkspacesUpdate, onPRsUpdate, onEndpointsUpdate, onPluginsUpdate, onReposUpdate, onAuthorsUpdate, onWorktreesUpdate, onSettingsUpdate, onSettingError, onGitStatusUpdate, rejectPendingForCommand, ensureDaemonRunning, showRecoveringNoticeForCommand, flushQueuedCommands, pruneAttachedPtySessions]);
+  }, [resolvedWsUrl, onSessionsUpdate, onWorkspacesUpdate, onPRsUpdate, onEndpointsUpdate, onPluginsUpdate, onGitHubHostsUpdate, onReposUpdate, onAuthorsUpdate, onWorktreesUpdate, onSettingsUpdate, onSettingError, onGitStatusUpdate, rejectPendingForCommand, ensureDaemonRunning, showRecoveringNoticeForCommand, flushQueuedCommands, pruneAttachedPtySessions]);
 
   useEffect(() => {
     void connect();

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MuteMessage, MutePRMessage, MuteRepoMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionAgent, SessionExitedMessage, SessionLayout, SessionLayoutActionResultMessage, SessionLayoutClosePaneMessage, SessionLayoutFocusPaneMessage, SessionLayoutGetMessage, SessionLayoutMessage, SessionLayoutPane, SessionLayoutPaneKind, SessionLayoutRenamePaneMessage, SessionLayoutRuntimeExitedMessage, SessionLayoutSplitDirection, SessionLayoutSplitPaneMessage, SessionLayoutUpdatedMessage, SessionRegisteredMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, UpdateWorkspacePanelGeometryMessage, WebSocketEvent, Workspace, WorkspacePanel, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MuteMessage, MutePRMessage, MuteRepoMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionAgent, SessionExitedMessage, SessionLayout, SessionLayoutActionResultMessage, SessionLayoutClosePaneMessage, SessionLayoutFocusPaneMessage, SessionLayoutGetMessage, SessionLayoutMessage, SessionLayoutPane, SessionLayoutPaneKind, SessionLayoutRenamePaneMessage, SessionLayoutRuntimeExitedMessage, SessionLayoutSplitDirection, SessionLayoutSplitPaneMessage, SessionLayoutUpdatedMessage, SessionRegisteredMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, UpdateWorkspacePanelGeometryMessage, WebSocketEvent, Workspace, WorkspacePanel, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -62,6 +62,7 @@
 //   const getReviewStateResultMessage = Convert.toGetReviewStateResultMessage(json);
 //   const getSettingsMessage = Convert.toGetSettingsMessage(json);
 //   const gitFileChange = Convert.toGitFileChange(json);
+//   const gitHubHostsUpdatedMessage = Convert.toGitHubHostsUpdatedMessage(json);
 //   const gitOperation = Convert.toGitOperation(json);
 //   const gitOperationFinishedMessage = Convert.toGitOperationFinishedMessage(json);
 //   const gitOperationKind = Convert.toGitOperationKind(json);
@@ -1065,6 +1066,16 @@ export interface GitFileChange {
     [property: string]: any;
 }
 
+export interface GitHubHostsUpdatedMessage {
+    event:        GitHubHostsUpdatedMessageEvent;
+    github_hosts: string[];
+    [property: string]: any;
+}
+
+export enum GitHubHostsUpdatedMessageEvent {
+    GithubHostsUpdated = "github_hosts_updated",
+}
+
 export interface GitOperation {
     duration_ms?: number;
     endpoint_id?: string;
@@ -1159,6 +1170,7 @@ export interface InitialStateMessage {
     daemon_instance_id?: string;
     endpoints?:          Endpoint[];
     event:               InitialStateMessageEvent;
+    github_hosts?:       string[];
     protocol_version?:   string;
     prs?:                PRElement[];
     repos?:              RepoElement[];
@@ -3205,6 +3217,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("GitFileChange")), null, 2);
     }
 
+    public static toGitHubHostsUpdatedMessage(json: string): GitHubHostsUpdatedMessage {
+        return cast(JSON.parse(json), r("GitHubHostsUpdatedMessage"));
+    }
+
+    public static gitHubHostsUpdatedMessageToJson(value: GitHubHostsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("GitHubHostsUpdatedMessage")), null, 2);
+    }
+
     public static toGitOperation(json: string): GitOperation {
         return cast(JSON.parse(json), r("GitOperation"));
     }
@@ -4893,6 +4913,10 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
         { json: "status", js: "status", typ: "" },
     ], "any"),
+    "GitHubHostsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("GitHubHostsUpdatedMessageEvent") },
+        { json: "github_hosts", js: "github_hosts", typ: a("") },
+    ], "any"),
     "GitOperation": o([
         { json: "duration_ms", js: "duration_ms", typ: u(undefined, 0) },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
@@ -4951,6 +4975,7 @@ const typeMap: any = {
         { json: "daemon_instance_id", js: "daemon_instance_id", typ: u(undefined, "") },
         { json: "endpoints", js: "endpoints", typ: u(undefined, a(r("Endpoint"))) },
         { json: "event", js: "event", typ: r("InitialStateMessageEvent") },
+        { json: "github_hosts", js: "github_hosts", typ: u(undefined, a("")) },
         { json: "protocol_version", js: "protocol_version", typ: u(undefined, "") },
         { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
         { json: "repos", js: "repos", typ: u(undefined, a(r("RepoElement"))) },
@@ -6029,6 +6054,9 @@ const typeMap: any = {
     ],
     "GetSettingsMessageCmd": [
         "get_settings",
+    ],
+    "GitHubHostsUpdatedMessageEvent": [
+        "github_hosts_updated",
     ],
     "GitOperationStatus": [
         "failed",

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1310,6 +1310,7 @@ func (d *Daemon) refreshGitHubHosts() error {
 		if err := d.registerMockClient(mockURL); err != nil {
 			d.logf("Mock GitHub client not available: %v", err)
 		}
+		d.broadcastGitHubHosts()
 		return nil
 	}
 
@@ -1359,7 +1360,26 @@ func (d *Daemon) refreshGitHubHosts() error {
 		}
 	}
 
+	d.broadcastGitHubHosts()
 	return nil
+}
+
+func (d *Daemon) gitHubHosts() []string {
+	if d.ghRegistry == nil {
+		return nil
+	}
+	return d.ghRegistry.Hosts()
+}
+
+func (d *Daemon) broadcastGitHubHosts() {
+	d.wsHub.BroadcastValue(d.gitHubHostsUpdatedMessage())
+}
+
+func (d *Daemon) gitHubHostsUpdatedMessage() *protocol.GitHubHostsUpdatedMessage {
+	return &protocol.GitHubHostsUpdatedMessage{
+		Event:       protocol.EventGitHubHostsUpdated,
+		GithubHosts: d.gitHubHosts(),
+	}
 }
 
 func (d *Daemon) registerMockClient(mockURL string) error {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2539,6 +2539,36 @@ func TestDaemon_InitialState_IncludesDaemonInstanceID(t *testing.T) {
 	}
 }
 
+func TestDaemon_GitHubHostsMessages_UseRegisteredHosts(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ghRegistry.Register("ghe.example.test", nil)
+	d.ghRegistry.Register("github.com", nil)
+
+	client := &wsClient{
+		send:            make(chan outboundMessage, 2),
+		attachedStreams: make(map[string]ptybackend.Stream),
+	}
+
+	d.sendInitialState(client)
+	msg := <-client.send
+
+	var initial protocol.InitialStateMessage
+	if err := json.Unmarshal(msg.payload, &initial); err != nil {
+		t.Fatalf("decode initial_state: %v", err)
+	}
+	if got := strings.Join(initial.GithubHosts, ","); got != "ghe.example.test,github.com" {
+		t.Fatalf("initial github_hosts = %q, want registered hosts", got)
+	}
+
+	updated := d.gitHubHostsUpdatedMessage()
+	if updated.Event != protocol.EventGitHubHostsUpdated {
+		t.Fatalf("updated event = %q, want %q", updated.Event, protocol.EventGitHubHostsUpdated)
+	}
+	if got := strings.Join(updated.GithubHosts, ","); got != "ghe.example.test,github.com" {
+		t.Fatalf("updated github_hosts = %q, want registered hosts", got)
+	}
+}
+
 func TestDaemon_RecoveryBarrier_BlocksPTYCommands(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.setRecovering(true)

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -583,6 +583,7 @@ func (d *Daemon) sendInitialState(client *wsClient) {
 		Prs:               protocol.PRsToValues(d.store.ListPRs("")),
 		Repos:             protocol.RepoStatesToValues(d.store.ListRepoStates()),
 		Authors:           protocol.AuthorStatesToValues(d.store.ListAuthorStates()),
+		GithubHosts:       d.gitHubHosts(),
 		Settings:          d.settingsWithAgentAvailability(),
 		Warnings:          d.getWarnings(),
 	}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "63"
+const ProtocolVersion = "64"
 
 // Commands
 const (
@@ -128,6 +128,7 @@ const (
 	EventGitOperationStarted        = "git_operation_started"
 	EventGitOperationFinished       = "git_operation_finished"
 	EventSettingsUpdated            = "settings_updated"
+	EventGitHubHostsUpdated         = "github_hosts_updated"
 	EventPluginsUpdated             = "plugins_updated"
 	EventPluginActionResult         = "plugin_action_result"
 	EventRateLimited                = "rate_limited"

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -834,6 +834,14 @@ type GitFileChange struct {
 	Status string `json:"status"`
 }
 
+type GitHubHostsUpdatedMessage struct {
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// GithubHosts corresponds to the JSON schema field "github_hosts".
+	GithubHosts []string `json:"github_hosts"`
+}
+
 type GitOperation struct {
 	// DurationMs corresponds to the JSON schema field "duration_ms".
 	DurationMs *int `json:"duration_ms,omitempty,omitzero"`
@@ -947,6 +955,9 @@ type InitialStateMessage struct {
 
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
+
+	// GithubHosts corresponds to the JSON schema field "github_hosts".
+	GithubHosts []string `json:"github_hosts,omitempty,omitzero"`
 
 	// ProtocolVersion corresponds to the JSON schema field "protocol_version".
 	ProtocolVersion *string `json:"protocol_version,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -873,6 +873,7 @@ model InitialStateMessage {
   prs?: PR[];
   repos?: RepoState[];
   authors?: AuthorState[];
+  github_hosts?: string[];
   settings?: Record<string>;
   warnings?: DaemonWarning[];
 }
@@ -1057,6 +1058,11 @@ model SettingsUpdatedMessage {
   changed_key?: string;
   success?: boolean;
   error?: string;
+}
+
+model GitHubHostsUpdatedMessage {
+  event: "github_hosts_updated";
+  github_hosts: string[];
 }
 
 model PluginsUpdatedMessage {
@@ -1553,6 +1559,7 @@ alias DaemonEvent =
   | GitOperationStartedMessage
   | GitOperationFinishedMessage
   | SettingsUpdatedMessage
+  | GitHubHostsUpdatedMessage
   | PluginsUpdatedMessage
   | PluginActionResultMessage
   | RecentLocationsResultMessage

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -449,6 +449,11 @@ func buildSpawnEnv(loginShell string, opts SpawnOptions, agent, wrapperPath stri
 	// because the login shell inherits the current process environment.
 	env = filterEnvKeys(env, "CLAUDECODE")
 
+	// Interactive terminals should not inherit NO_COLOR from whichever
+	// process launched attn. Agent runners commonly set it for their own
+	// output, which would otherwise disable colors inside every PTY.
+	env = filterEnvKeys(env, "NO_COLOR")
+
 	env = mergeEnvironment(env, []string{"TERM=xterm-256color"})
 	if agent != "shell" {
 		env = mergeEnvironment(env, []string{

--- a/internal/pty/manager_test.go
+++ b/internal/pty/manager_test.go
@@ -166,3 +166,24 @@ func TestBuildSpawnEnv_SetsAgentExecutableForExplicitOverride(t *testing.T) {
 		t.Fatalf("expected ATTN_CODEX_EXECUTABLE override in env, got %v", env)
 	}
 }
+
+func TestBuildSpawnEnv_StripsInheritedNoColorFromInteractiveSessions(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	for _, agent := range []string{"shell", "codex"} {
+		t.Run(agent, func(t *testing.T) {
+			env := buildSpawnEnv(
+				"",
+				SpawnOptions{ID: "session-1", LoginShellEnv: []string{"NO_COLOR=1"}},
+				agent,
+				"/tmp/attn-wrapper",
+				nil,
+			)
+			for _, entry := range env {
+				if strings.HasPrefix(entry, "NO_COLOR=") {
+					t.Fatalf("did not expect NO_COLOR in %s PTY environment, got %v", agent, env)
+				}
+			}
+		})
+	}
+}

--- a/native-ui/crates/attn-native-app/src/adapters/daemon.rs
+++ b/native-ui/crates/attn-native-app/src/adapters/daemon.rs
@@ -1,7 +1,7 @@
 use attn_protocol::{
     BrowseDirectoryResultMessage, ClientHelloMessage, CreateWorktreeResultMessage, EndpointInfo,
-    GetRepoInfoResultMessage, InspectPathResultMessage, RepoState, ServerEvent, Session, SettingsMap,
-    Workspace, CAPABILITY_SHELL_AS_SESSION, PROTOCOL_VERSION,
+    GetRepoInfoResultMessage, InspectPathResultMessage, RepoState, ServerEvent, Session,
+    SettingsMap, Workspace, CAPABILITY_SHELL_AS_SESSION, PROTOCOL_VERSION,
 };
 use futures_util::{SinkExt, StreamExt};
 use gpui::{AsyncApp, Context, EventEmitter, WeakEntity};

--- a/native-ui/crates/attn-native-app/src/adapters/daemon.rs
+++ b/native-ui/crates/attn-native-app/src/adapters/daemon.rs
@@ -40,6 +40,7 @@ pub enum DaemonEvent {
         prs: Vec<PullRequestSummary>,
         repos: Vec<RepoState>,
         authors: Vec<attn_protocol::AuthorState>,
+        github_hosts: Vec<String>,
         settings: SettingsMap,
     },
     SettingsUpdated {
@@ -47,6 +48,9 @@ pub enum DaemonEvent {
         changed_key: Option<String>,
         success: Option<bool>,
         error: Option<String>,
+    },
+    GitHubHostsUpdated {
+        hosts: Vec<String>,
     },
     EndpointsUpdated {
         endpoints: Vec<EndpointInfo>,
@@ -285,6 +289,7 @@ impl DaemonClient {
                     prs: msg.prs,
                     repos: msg.repos,
                     authors: msg.authors,
+                    github_hosts: msg.github_hosts,
                     settings: msg.settings,
                 });
             }
@@ -294,6 +299,11 @@ impl DaemonClient {
                     changed_key: msg.changed_key,
                     success: msg.success,
                     error: msg.error,
+                });
+            }
+            ServerEvent::GitHubHostsUpdated(msg) => {
+                cx.emit(DaemonEvent::GitHubHostsUpdated {
+                    hosts: msg.github_hosts,
                 });
             }
             ServerEvent::EndpointsUpdated(msg) => {
@@ -429,6 +439,7 @@ fn record_inbound_event(event: &ServerEvent) {
             "session_count": m.sessions.len(),
             "workspace_count": m.workspaces.len(),
             "endpoint_count": m.endpoints.len(),
+            "github_host_count": m.github_hosts.len(),
             "settings_count": m.settings.len(),
         }),
         ServerEvent::SettingsUpdated(m) => json!({
@@ -437,6 +448,10 @@ fn record_inbound_event(event: &ServerEvent) {
             "changed_key": m.changed_key.as_deref(),
             "success": m.success,
             "error": m.error.as_deref(),
+        }),
+        ServerEvent::GitHubHostsUpdated(m) => json!({
+            "kind": "github_hosts_updated",
+            "github_host_count": m.github_hosts.len(),
         }),
         ServerEvent::EndpointsUpdated(m) => json!({
             "kind": "endpoints_updated",

--- a/native-ui/crates/attn-native-app/src/adapters/daemon.rs
+++ b/native-ui/crates/attn-native-app/src/adapters/daemon.rs
@@ -1,7 +1,7 @@
 use attn_protocol::{
     BrowseDirectoryResultMessage, ClientHelloMessage, CreateWorktreeResultMessage, EndpointInfo,
-    GetRepoInfoResultMessage, InspectPathResultMessage, PullRequestSummary, RepoState, ServerEvent,
-    Session, SettingsMap, Workspace, CAPABILITY_SHELL_AS_SESSION, PROTOCOL_VERSION,
+    GetRepoInfoResultMessage, InspectPathResultMessage, RepoState, ServerEvent, Session, SettingsMap,
+    Workspace, CAPABILITY_SHELL_AS_SESSION, PROTOCOL_VERSION,
 };
 use futures_util::{SinkExt, StreamExt};
 use gpui::{AsyncApp, Context, EventEmitter, WeakEntity};
@@ -37,7 +37,6 @@ pub enum DaemonEvent {
         sessions: Vec<Session>,
         workspaces: Vec<Workspace>,
         endpoints: Vec<EndpointInfo>,
-        prs: Vec<PullRequestSummary>,
         repos: Vec<RepoState>,
         authors: Vec<attn_protocol::AuthorState>,
         github_hosts: Vec<String>,
@@ -63,9 +62,6 @@ pub enum DaemonEvent {
     },
     AuthorsUpdated {
         authors: Vec<attn_protocol::AuthorState>,
-    },
-    PRsUpdated {
-        prs: Vec<PullRequestSummary>,
     },
     /// A session appeared (newly spawned or registered).
     SessionRegistered {
@@ -286,7 +282,6 @@ impl DaemonClient {
                     sessions: msg.sessions,
                     workspaces: msg.workspaces,
                     endpoints: msg.endpoints,
-                    prs: msg.prs,
                     repos: msg.repos,
                     authors: msg.authors,
                     github_hosts: msg.github_hosts,
@@ -324,9 +319,7 @@ impl DaemonClient {
                     authors: msg.authors,
                 });
             }
-            ServerEvent::PRsUpdated(msg) => {
-                cx.emit(DaemonEvent::PRsUpdated { prs: msg.prs });
-            }
+            ServerEvent::PRsUpdated(_msg) => {}
             ServerEvent::SessionRegistered(msg) => {
                 cx.emit(DaemonEvent::SessionRegistered {
                     session: msg.session,

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -220,9 +220,10 @@ impl NativeApp {
                     sessions,
                     workspaces,
                     endpoints,
-                    prs,
+                    prs: _,
                     repos,
                     authors,
+                    github_hosts,
                     settings,
                 } => {
                     events::record(
@@ -235,7 +236,7 @@ impl NativeApp {
                     this.settings_state = SettingsPageState::from_wire(
                         settings.clone(),
                         endpoints.clone(),
-                        prs.clone(),
+                        github_hosts.clone(),
                         repos.clone(),
                         authors.clone(),
                     );
@@ -263,6 +264,12 @@ impl NativeApp {
                         });
                     }
                 }
+                DaemonEvent::GitHubHostsUpdated { hosts } => {
+                    this.settings_state.github_hosts = hosts.clone();
+                    if let Some(page) = this.settings_page.clone() {
+                        page.update(cx, |page, cx| page.apply_github_hosts(hosts.clone(), cx));
+                    }
+                }
                 DaemonEvent::EndpointsUpdated { endpoints } => {
                     this.settings_state.endpoints = endpoints.clone();
                     if let Some(page) = this.settings_page.clone() {
@@ -286,12 +293,6 @@ impl NativeApp {
                     this.settings_state.authors = authors.clone();
                     if let Some(page) = this.settings_page.clone() {
                         page.update(cx, |page, cx| page.apply_authors(authors.clone(), cx));
-                    }
-                }
-                DaemonEvent::PRsUpdated { prs } => {
-                    this.settings_state.set_prs(prs);
-                    if let Some(page) = this.settings_page.clone() {
-                        page.update(cx, |page, cx| page.apply_prs(prs.clone(), cx));
                     }
                 }
                 DaemonEvent::WorkspaceRegistered { workspace } => {

--- a/native-ui/crates/attn-native-app/src/app.rs
+++ b/native-ui/crates/attn-native-app/src/app.rs
@@ -220,7 +220,6 @@ impl NativeApp {
                     sessions,
                     workspaces,
                     endpoints,
-                    prs: _,
                     repos,
                     authors,
                     github_hosts,

--- a/native-ui/crates/attn-native-app/src/views/settings_page.rs
+++ b/native-ui/crates/attn-native-app/src/views/settings_page.rs
@@ -1,13 +1,10 @@
 //! Native Settings surface. It mirrors the daemon-backed settings exposed
 //! by the Tauri client while keeping native-only canvas controls nearby.
 
-use std::collections::HashSet;
-
 use attn_protocol::{
     AddEndpointMessage, AuthorState, BootstrapEndpointMessage, EndpointInfo, ListEndpointsMessage,
-    PullRequestSummary, RemoveEndpointMessage, RepoState, SetEndpointRemoteWebMessage,
-    SetSettingMessage, SettingsMap, ToggleAuthorMuteMessage, ToggleRepoMuteMessage,
-    UpdateEndpointMessage,
+    RemoveEndpointMessage, RepoState, SetEndpointRemoteWebMessage, SetSettingMessage, SettingsMap,
+    ToggleAuthorMuteMessage, ToggleRepoMuteMessage, UpdateEndpointMessage,
 };
 use gpui::{
     div, hsla, point, prelude::*, px, BoxShadow, Context, Entity, FocusHandle, Focusable,
@@ -36,7 +33,7 @@ type ToggleSidebarHandler = dyn Fn(&mut Window, &mut gpui::App) -> bool + 'stati
 pub struct SettingsPageState {
     pub settings: SettingsMap,
     pub endpoints: Vec<EndpointInfo>,
-    pub connected_hosts: Vec<String>,
+    pub github_hosts: Vec<String>,
     pub repos: Vec<RepoState>,
     pub authors: Vec<AuthorState>,
 }
@@ -45,21 +42,17 @@ impl SettingsPageState {
     pub fn from_wire(
         settings: SettingsMap,
         endpoints: Vec<EndpointInfo>,
-        prs: Vec<PullRequestSummary>,
+        github_hosts: Vec<String>,
         repos: Vec<RepoState>,
         authors: Vec<AuthorState>,
     ) -> Self {
         Self {
             settings,
             endpoints,
-            connected_hosts: connected_hosts_from_prs(&prs),
+            github_hosts,
             repos,
             authors,
         }
-    }
-
-    pub fn set_prs(&mut self, prs: &[PullRequestSummary]) {
-        self.connected_hosts = connected_hosts_from_prs(prs);
     }
 }
 
@@ -166,8 +159,8 @@ impl SettingsPage {
         cx.notify();
     }
 
-    pub fn apply_prs(&mut self, prs: Vec<PullRequestSummary>, cx: &mut Context<Self>) {
-        self.state.connected_hosts = connected_hosts_from_prs(&prs);
+    pub fn apply_github_hosts(&mut self, hosts: Vec<String>, cx: &mut Context<Self>) {
+        self.state.github_hosts = hosts;
         cx.notify();
     }
 
@@ -860,11 +853,14 @@ impl SettingsPage {
             }
         }
 
-        let mut hosts = card("GitHub hosts", "Detected from authenticated pull requests");
-        if self.state.connected_hosts.is_empty() {
+        let mut hosts = card(
+            "GitHub hosts",
+            "Authenticated hosts registered by the daemon",
+        );
+        if self.state.github_hosts.is_empty() {
             hosts = hosts.child(empty_row("No authenticated hosts detected"));
         } else {
-            for host in &self.state.connected_hosts {
+            for host in &self.state.github_hosts {
                 hosts = hosts.child(token_row(host, "host"));
             }
         }
@@ -958,8 +954,8 @@ impl SettingsPage {
                 self.state.endpoints.len().to_string(),
             ))
             .child(metric_row(
-                "Connected hosts",
-                self.state.connected_hosts.len().to_string(),
+                "Authenticated hosts",
+                self.state.github_hosts.len().to_string(),
             ))
             .child(metric_row(
                 "Settings loaded",
@@ -1298,18 +1294,6 @@ impl SettingsPage {
     }
 }
 
-fn connected_hosts_from_prs(prs: &[PullRequestSummary]) -> Vec<String> {
-    let mut set = HashSet::new();
-    for pr in prs {
-        if let Some(host) = pr.host.as_ref().filter(|host| !host.trim().is_empty()) {
-            set.insert(host.clone());
-        }
-    }
-    let mut hosts: Vec<_> = set.into_iter().collect();
-    hosts.sort();
-    hosts
-}
-
 fn setting<'a>(settings: &'a SettingsMap, key: &str) -> &'a str {
     settings.get(key).map(String::as_str).unwrap_or("")
 }
@@ -1450,7 +1434,7 @@ fn summary_strip(state: &SettingsPageState) -> gpui::Div {
         .gap_2()
         .child(summary_line("settings", state.settings.len()))
         .child(summary_line("endpoints", state.endpoints.len()))
-        .child(summary_line("hosts", state.connected_hosts.len()))
+        .child(summary_line("hosts", state.github_hosts.len()))
 }
 
 fn summary_line(label: &'static str, count: usize) -> gpui::Div {

--- a/native-ui/crates/attn-protocol/src/events.rs
+++ b/native-ui/crates/attn-protocol/src/events.rs
@@ -25,6 +25,8 @@ pub struct InitialStateMessage {
     #[serde(default)]
     pub authors: Vec<AuthorState>,
     #[serde(default)]
+    pub github_hosts: Vec<String>,
+    #[serde(default)]
     pub settings: SettingsMap,
 }
 
@@ -39,6 +41,12 @@ pub struct SettingsUpdatedMessage {
     pub success: Option<bool>,
     #[serde(default)]
     pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitHubHostsUpdatedMessage {
+    pub event: String,
+    pub github_hosts: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -239,6 +247,7 @@ struct EventPeek {
 pub enum ServerEvent {
     InitialState(InitialStateMessage),
     SettingsUpdated(SettingsUpdatedMessage),
+    GitHubHostsUpdated(GitHubHostsUpdatedMessage),
     EndpointsUpdated(EndpointsUpdatedMessage),
     EndpointStatusChanged(EndpointStatusChangedMessage),
     ReposUpdated(ReposUpdatedMessage),
@@ -275,6 +284,10 @@ impl ServerEvent {
             "settings_updated" => {
                 let msg: SettingsUpdatedMessage = serde_json::from_str(data)?;
                 Ok(Self::SettingsUpdated(msg))
+            }
+            "github_hosts_updated" => {
+                let msg: GitHubHostsUpdatedMessage = serde_json::from_str(data)?;
+                Ok(Self::GitHubHostsUpdated(msg))
             }
             "endpoints_updated" => {
                 let msg: EndpointsUpdatedMessage = serde_json::from_str(data)?;
@@ -365,6 +378,40 @@ impl ServerEvent {
                 Ok(Self::CreateWorktreeResult(msg))
             }
             other => Ok(Self::Unknown(other.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ServerEvent;
+
+    #[test]
+    fn parses_github_hosts_from_initial_state() {
+        let event =
+            ServerEvent::parse(r#"{"event":"initial_state","github_hosts":["github.example"]}"#)
+                .expect("parse initial_state");
+
+        match event {
+            ServerEvent::InitialState(message) => {
+                assert_eq!(message.github_hosts, vec!["github.example"]);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_github_hosts_update() {
+        let event = ServerEvent::parse(
+            r#"{"event":"github_hosts_updated","github_hosts":["github.example"]}"#,
+        )
+        .expect("parse github_hosts_updated");
+
+        match event {
+            ServerEvent::GitHubHostsUpdated(message) => {
+                assert_eq!(message.github_hosts, vec!["github.example"]);
+            }
+            other => panic!("unexpected event: {other:?}"),
         }
     }
 }

--- a/native-ui/crates/attn-protocol/src/lib.rs
+++ b/native-ui/crates/attn-protocol/src/lib.rs
@@ -14,7 +14,7 @@ pub use types::*;
 
 /// Current protocol version — must match `ProtocolVersion` in
 /// `internal/protocol/constants.go`.
-pub const PROTOCOL_VERSION: &str = "63";
+pub const PROTOCOL_VERSION: &str = "64";
 
 /// Capability strings advertised in `ClientHelloMessage.capabilities`.
 /// Mirror of `protocol.Capability*` in `internal/protocol/constants.go`.


### PR DESCRIPTION
## Intent / Why
Settings currently infers authenticated GitHub hosts from visible pull requests. That hides configured hosts when they have no loaded PRs, even though the daemon can already use them. During verification, interactive sessions were also found to inherit `NO_COLOR` from the process that launched attn, making shells and agents appear monochrome.

## Summary
- expose the daemon GitHub host registry through initial state and a refresh event, so host visibility follows configured access rather than current PR data
- consume daemon host state in both the Tauri and native Settings surfaces
- bump the websocket protocol to v64 across daemon, Tauri, and native clients, and regenerate generated bindings
- strip inherited `NO_COLOR` at interactive PTY launch so shells and agents can emit their normal colored output
- add daemon, frontend, native protocol, and PTY environment coverage

## Test plan
- [x] `go test ./...`
- [x] `make test-frontend`
- [x] `pnpm --dir app run build`
- [x] `git diff --check`
- [x] `cd native-ui && cargo fmt --check && cargo test -p attn-protocol`
- [ ] `cd native-ui && cargo test --workspace` in CI or a native build environment with Apple Metal tooling and Zig 0.15.2 available; the local environment lacks `metal` and has Zig 0.16.0
- [ ] Install the updated app and confirm an authenticated host with no visible PRs appears in Settings.
- [ ] Start a new terminal/agent session from attn and confirm ANSI colors render normally.