### PR TITLE
fix(codex): prevent resize transcript rewind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **GitHub Host Visibility**: Settings now lists daemon-discovered authenticated GitHub hosts even when a host has no currently visible pull requests.
 - **Terminal Colors**: Interactive terminals no longer inherit `NO_COLOR` from the process that launched attn, so shells and coding agents can emit their normal colored output.
 
+### Fixed
+- **Codex Resize Stability**: Long Codex sessions no longer jump back through earlier conversation content when resizing a pane or opening a split in attn's embedded terminal.
+
 ---
 
 ## [2026-05-22]

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -46,6 +46,10 @@ func GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath string) []s
 
 	return []string{
 		"features.hooks=true",
+		// Codex's transcript resize reflow emits a full inline-history redraw on
+		// SIGWINCH. xterm.js consumes that redraw as a visible jump into older
+		// conversation content for long sessions, unlike native terminals.
+		"features.terminal_resize_reflow=false",
 		trustedHashOverrides([]codexHookTrustEntry{
 			{eventKey: "session_start", matcher: "startup|resume", command: sessionStart},
 			{eventKey: "user_prompt_submit", command: userPromptSubmit},

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -121,6 +121,9 @@ func TestGenerateCodexConfigOverrides_UsesStableEnvBasedCommands(t *testing.T) {
 	if !strings.Contains(joined, "features.hooks=true") {
 		t.Fatal("codex overrides should enable hooks for attn-managed sessions")
 	}
+	if !strings.Contains(joined, "features.terminal_resize_reflow=false") {
+		t.Fatal("codex overrides should disable xterm-incompatible transcript resize reflow")
+	}
 	if !strings.Contains(joined, "hooks.PreToolUse=") {
 		t.Fatal("codex overrides should include PreToolUse hook")
 	}


### PR DESCRIPTION
## Intent/Why

Long Codex sessions rendered inside attn can jump backward through earlier conversation content when the user resizes a pane or creates a split. The issue reproduces with a resumed long Codex thread in attn's xterm.js terminal but not in native terminals such as Ghostty: Codex's `terminal_resize_reflow` path emits a large inline-history redraw after `SIGWINCH`, which leaves xterm.js showing older transcript content.

## Summary

- Add `features.terminal_resize_reflow=false` to attn-managed Codex launch overrides in `internal/hooks/codex.go`, avoiding the incompatible resize-redraw path while preserving PTY geometry changes.
- Assert the Codex launch override in `internal/hooks/hooks_test.go` so the resize-stability protection cannot be removed silently.
- Document the user-visible pane-resize stability fix in `CHANGELOG.md`.

## Test plan

- [x] Run `go test ./internal/hooks ./internal/agent`.
- [x] Run `git diff --check`.
- [x] Build and launch isolated `attn-dev.app` with `make dev`.
- [x] Resume a long Codex session in the dev app and verify a split no longer triggers full transcript redraw (`CSI 2J` / `CSI 3J`) or visible rewind.
- [ ] Confirm the behavior during reviewer manual resizing of an existing long Codex pane after starting it from this branch.

## Out of scope

- Assigning sole fault upstream between Codex and xterm.js; this change applies a scoped compatibility workaround at attn's Codex launch boundary.
