### PR TITLE
fix(terminal): restore Ghostty link and image paste interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Codex Activity State**: Codex sessions now use hooks exclusively for live activity state, preventing completed sessions from remaining green due to stale transcript activity.
+- **Terminal Link Activation**: Ghostty terminal URLs now open only with Command-click and show a pointer cursor while Command is held, consistently across interactive applications.
+- **Terminal Screenshot Paste**: Ghostty terminal sessions now forward Control-V image-paste triggers and translate Command-V screenshot paste events so Claude and Codex can read pasted clipboard images again.
 
 ## [2026-05-27]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Codex Activity State**: Codex sessions now use hooks exclusively for live activity state, preventing completed sessions from remaining green due to stale transcript activity.
-- **Terminal Link Activation**: Ghostty terminal URLs now open only with Command-click and show a pointer cursor while Command is held, consistently across interactive applications.
-- **Terminal Screenshot Paste**: Ghostty terminal sessions now forward Control-V image-paste triggers and translate Command-V screenshot paste events so Claude and Codex can read pasted clipboard images again.
+- **Terminal Selection and Link Activation**: Ghostty terminals now select words on double-click, preserve Option-drag selection inside mouse-tracking applications, and open URLs only with Command-click while showing a pointer cursor when Command is held.
+- **Terminal Screenshot Paste**: Ghostty terminal sessions now forward macOS Control-V image-paste triggers and translate image paste events so Claude and Codex can read pasted clipboard images again without breaking text paste on other platforms.
 
 ## [2026-05-27]
 

--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -57,6 +57,25 @@ async function expectOpenedUrl(page: import('@playwright/test').Page, url: strin
     .toContain(url);
 }
 
+async function expectTerminalInputCount(
+  page: import('@playwright/test').Page,
+  sessionId: string,
+  data: string,
+  count: number,
+) {
+  await expect
+    .poll(
+      async () => page.evaluate(
+        ({ id, expectedData }) => (
+          window.__TEST_GET_SESSION_INPUT_EVENTS?.(id) ?? []
+        ).filter((event) => event.event === 'send_to_pty' && event.data === expectedData).length,
+        { id: sessionId, expectedData: data },
+      ),
+      { timeout: 3000 },
+    )
+    .toBe(count);
+}
+
 async function openTerminalSession(
   page: import('@playwright/test').Page,
   daemon: { injectSession: (session: { id: string; label: string; state: string; directory?: string }) => Promise<void> },
@@ -73,7 +92,7 @@ async function openTerminalSession(
 }
 
 test.describe('Ghostty terminal interactions', () => {
-  test('opens a visible URL when clicked', async ({ page, daemon }) => {
+  test('opens a visible URL only when cmd+clicked', async ({ page, daemon }) => {
     await installOpenerProbe(page);
     const terminal = await openTerminalSession(page, daemon, 's-link');
     const url = 'https://example.test/terminal-link';
@@ -86,7 +105,21 @@ test.describe('Ghostty terminal interactions', () => {
       )
       .toContain(url);
 
+    await terminal.hover({ position: { x: 100, y: 8 } });
+    await expect(terminal).toHaveCSS('cursor', 'text');
     await terminal.click({ position: { x: 100, y: 8 } });
+    await expect
+      .poll(
+        async () => page.evaluate(
+          () => (window as Window & { __OPENED_TERMINAL_URLS?: string[] }).__OPENED_TERMINAL_URLS ?? [],
+        ),
+        { timeout: 500 },
+      )
+      .toEqual([]);
+    await page.keyboard.down('Meta');
+    await expect(terminal).toHaveCSS('cursor', 'pointer');
+    await terminal.click({ position: { x: 100, y: 8 } });
+    await page.keyboard.up('Meta');
 
     await expectOpenedUrl(page, url);
   });
@@ -104,9 +137,51 @@ test.describe('Ghostty terminal interactions', () => {
       )
       .toContain(url);
 
-    await terminal.click({ modifiers: ['Meta'], position: { x: 100, y: 8 } });
+    await terminal.hover({ position: { x: 100, y: 8 } });
+    await expect(terminal).toHaveCSS('cursor', 'text');
+    await page.keyboard.down('Meta');
+    await expect(terminal).toHaveCSS('cursor', 'pointer');
+    await terminal.click({ position: { x: 100, y: 8 } });
+    await page.keyboard.up('Meta');
 
     await expectOpenedUrl(page, url);
+  });
+
+  test('forwards screenshot paste triggers from ctrl+v and command paste', async ({ page, daemon }) => {
+    const terminal = await openTerminalSession(page, daemon, 's-image-paste');
+    await writeTerminalOutput(page, 's-image-paste', '\u001b[2J\u001b[Hready');
+    await expect
+      .poll(
+        async () => page.evaluate(() => window.__TEST_GET_MAIN_TERMINAL_TEXT?.('s-image-paste') ?? ''),
+        { timeout: 5000 },
+      )
+      .toContain('ready');
+
+    await terminal.focus();
+    await page.keyboard.press('Control+v');
+    await expectTerminalInputCount(page, 's-image-paste', '\u0016', 1);
+
+    await terminal.evaluate((element) => {
+      const data = new DataTransfer();
+      data.items.add(new File(['image'], 'screenshot.png', { type: 'image/png' }));
+      element.dispatchEvent(new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: data,
+      }));
+    });
+    await expectTerminalInputCount(page, 's-image-paste', '\u0016', 2);
+
+    await terminal.evaluate((element) => {
+      const data = new DataTransfer();
+      data.setData('text/plain', 'pasted text');
+      element.dispatchEvent(new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: data,
+      }));
+    });
+    await expectTerminalInputCount(page, 's-image-paste', 'pasted text', 1);
   });
 
   test('copies selected terminal text without opening a dragged URL', async ({ page, context, daemon }) => {

--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -184,6 +184,66 @@ test.describe('Ghostty terminal interactions', () => {
     await expectTerminalInputCount(page, 's-image-paste', 'pasted text', 1);
   });
 
+  test('leaves ctrl+v text paste available on non-mac platforms', async ({ page, daemon }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'platform', { value: 'Linux x86_64', configurable: true });
+      Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (X11; Linux x86_64)', configurable: true });
+    });
+    const terminal = await openTerminalSession(page, daemon, 's-text-paste-linux');
+    await terminal.focus();
+
+    await page.keyboard.press('Control+v');
+    await expectTerminalInputCount(page, 's-text-paste-linux', '\u0016', 0);
+
+    await terminal.evaluate((element) => {
+      const data = new DataTransfer();
+      data.setData('text/plain', 'linux pasted text');
+      element.dispatchEvent(new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: data,
+      }));
+    });
+    await expectTerminalInputCount(page, 's-text-paste-linux', 'linux pasted text', 1);
+  });
+
+  test('double-click selects and copies a terminal word', async ({ page, context, daemon }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const terminal = await openTerminalSession(page, daemon, 's-double-click');
+    await writeTerminalOutput(page, 's-double-click', '\u001b[2J\u001b[Hselectable-word suffix');
+
+    await expect
+      .poll(
+        async () => page.evaluate(() => window.__TEST_GET_MAIN_TERMINAL_TEXT?.('s-double-click') ?? ''),
+        { timeout: 5000 },
+      )
+      .toContain('selectable-word');
+
+    await terminal.dblclick({ position: { x: 55, y: 8 } });
+
+    await expect
+      .poll(async () => page.evaluate(() => navigator.clipboard.readText()), { timeout: 3000 })
+      .toBe('selectable-word');
+  });
+
+  test('option-drag selects text while terminal mouse tracking is active', async ({ page, context, daemon }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const terminal = await openTerminalSession(page, daemon, 's-option-selection');
+    const text = 'select while tracked';
+    await writeTerminalOutput(page, 's-option-selection', `\u001b[2J\u001b[H\u001b[?1000h${text}`);
+
+    await terminal.hover({ position: { x: 2, y: 8 } });
+    await page.keyboard.down('Alt');
+    await page.mouse.down();
+    await terminal.hover({ position: { x: 200, y: 8 } });
+    await page.mouse.up();
+    await page.keyboard.up('Alt');
+
+    await expect
+      .poll(async () => page.evaluate(() => navigator.clipboard.readText()), { timeout: 3000 })
+      .toContain(text);
+  });
+
   test('copies selected terminal text without opening a dragged URL', async ({ page, context, daemon }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
     await installOpenerProbe(page);

--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -148,6 +148,10 @@ test.describe('Ghostty terminal interactions', () => {
   });
 
   test('forwards screenshot paste triggers from ctrl+v and command paste', async ({ page, daemon }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'platform', { value: 'MacIntel', configurable: true });
+      Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X)', configurable: true });
+    });
     const terminal = await openTerminalSession(page, daemon, 's-image-paste');
     await writeTerminalOutput(page, 's-image-paste', '\u001b[2J\u001b[Hready');
     await expect

--- a/app/src/components/GhosttyTerminal.css
+++ b/app/src/components/GhosttyTerminal.css
@@ -13,6 +13,10 @@
   display: block;
 }
 
+.ghostty-terminal-link-hover {
+  cursor: pointer;
+}
+
 .ghostty-terminal-error {
   padding: 12px;
   color: var(--color-fg-error, #f48771);

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -102,6 +102,16 @@ function literalUrlAtColumn(line: string, col: number): string | null {
   return null;
 }
 
+function wordRangeAtColumn(line: string, col: number): { startCol: number; endCol: number } | null {
+  const isWordCharacter = (character: string | undefined) => Boolean(character && /[\w-]/.test(character));
+  if (!isWordCharacter(line[col])) return null;
+  let startCol = col;
+  while (startCol > 0 && isWordCharacter(line[startCol - 1])) startCol -= 1;
+  let endCol = col + 1;
+  while (endCol < line.length && isWordCharacter(line[endCol])) endCol += 1;
+  return { startCol, endCol };
+}
+
 function colorNumber(value: string): number {
   return Number.parseInt(value.slice(1), 16);
 }
@@ -786,7 +796,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           if (!terminal || !cell) return;
           const uri = literalUrlAtColumn(lineAtVisibleRow(cell.row), cell.col);
           const opensUri = Boolean(uri && (event.metaKey || event.ctrlKey));
-          if (!opensUri && !event.shiftKey && sendTrackedMouse('press', event)) return;
+          if (!opensUri && !event.altKey && sendTrackedMouse('press', event)) return;
           const row = bufferRowFromViewportRow(cell.row, terminal.getScrollbackLength(), viewportOffsetRef.current);
           selectedTextRef.current = null;
           applicationSelectionAnchorRef.current = null;
@@ -828,6 +838,25 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           if (uri && !text && (event.metaKey || event.ctrlKey)) {
             void openUrl(uri);
           }
+        }}
+        onDoubleClick={async (event) => {
+          const terminal = terminalRef.current;
+          const cell = cellFromPointer(event);
+          if (!terminal || !cell || (terminal.hasMouseTracking() && !event.altKey)) return;
+          const range = wordRangeAtColumn(lineAtVisibleRow(cell.row), cell.col);
+          if (!range) return;
+          const row = bufferRowFromViewportRow(cell.row, terminal.getScrollbackLength(), viewportOffsetRef.current);
+          selectionRef.current = {
+            startRow: row,
+            startCol: range.startCol,
+            endRow: row,
+            endCol: range.endCol,
+          };
+          applicationSelectionAnchorRef.current = null;
+          const text = textForSelectionRange(selectionRef.current);
+          selectedTextRef.current = text || null;
+          renderSurface(true);
+          if (text) await writeClipboardText(text);
         }}
         onKeyDown={(event) => {
           if (event.metaKey && event.shiftKey && event.key.toLowerCase() === 'c') {

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -170,6 +170,8 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const applicationSelectionAnchorRef = useRef<ApplicationSelectionAnchor | null>(null);
     const selectingRef = useRef(false);
     const trackedMouseButtonRef = useRef<number | null>(null);
+    const hoveredCellRef = useRef<{ row: number; col: number } | null>(null);
+    const acceleratorHeldRef = useRef(false);
     const writeChainRef = useRef(Promise.resolve());
     const osc52StateRef = useRef<Osc52State>({ pending: '' });
     const renderCountRef = useRef(0);
@@ -184,6 +186,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const runtimeMetaRef = useRef(runtimeLogMeta);
     const debugNameRef = useRef(debugName);
     const [error, setError] = useState<string | null>(null);
+    const [linkCursorActive, setLinkCursorActive] = useState(false);
 
     onInputRef.current = onInput;
     onReadyRef.current = onReady;
@@ -654,6 +657,25 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       return 0;
     };
 
+    const updateLinkCursor = useCallback((cell: { row: number; col: number } | null, acceleratorHeld: boolean) => {
+      const uri = cell ? literalUrlAtColumn(lineAtVisibleRow(cell.row), cell.col) : null;
+      setLinkCursorActive(Boolean(uri && acceleratorHeld));
+    }, [lineAtVisibleRow]);
+
+    useEffect(() => {
+      const handleModifierChange = (event: KeyboardEvent) => {
+        if (event.key !== 'Meta' && event.key !== 'Control') return;
+        acceleratorHeldRef.current = event.metaKey || event.ctrlKey;
+        updateLinkCursor(hoveredCellRef.current, acceleratorHeldRef.current);
+      };
+      window.addEventListener('keydown', handleModifierChange);
+      window.addEventListener('keyup', handleModifierChange);
+      return () => {
+        window.removeEventListener('keydown', handleModifierChange);
+        window.removeEventListener('keyup', handleModifierChange);
+      };
+    }, [updateLinkCursor]);
+
     const sendTrackedMouse = (
       action: 'press' | 'move' | 'release',
       event: React.MouseEvent,
@@ -687,7 +709,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     return (
       <div
         ref={containerRef}
-        className="terminal-container ghostty-terminal"
+        className={`terminal-container ghostty-terminal${linkCursorActive ? ' ghostty-terminal-link-hover' : ''}`}
         data-terminal-renderer="ghostty-webgl"
         tabIndex={0}
         contentEditable
@@ -697,6 +719,17 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         aria-multiline="true"
         spellCheck={false}
         onBeforeInput={(event) => event.preventDefault()}
+        onPasteCapture={(event) => {
+          const hasImage = Array.from(event.clipboardData.items).some((item) => (
+            item.kind === 'file' && item.type.startsWith('image/')
+          ));
+          if (!hasImage) return;
+          // Browser paste events cannot send image bytes through a PTY. Both
+          // supported agent TUIs handle Ctrl+V by reading the native clipboard.
+          event.preventDefault();
+          event.stopPropagation();
+          onInputRef.current('\x16');
+        }}
         onWheel={(event) => {
           if (event.defaultPrevented) return;
           const terminal = terminalRef.current;
@@ -752,7 +785,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           const cell = cellFromPointer(event);
           if (!terminal || !cell) return;
           const uri = literalUrlAtColumn(lineAtVisibleRow(cell.row), cell.col);
-          const opensUri = Boolean(uri && ((event.metaKey || event.ctrlKey) || !terminal.hasMouseTracking()));
+          const opensUri = Boolean(uri && (event.metaKey || event.ctrlKey));
           if (!opensUri && !event.shiftKey && sendTrackedMouse('press', event)) return;
           const row = bufferRowFromViewportRow(cell.row, terminal.getScrollbackLength(), viewportOffsetRef.current);
           selectedTextRef.current = null;
@@ -762,6 +795,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           renderSurface(true);
         }}
         onMouseMove={(event) => {
+          const hoveredCell = cellFromPointer(event);
+          hoveredCellRef.current = hoveredCell;
+          acceleratorHeldRef.current = event.metaKey || event.ctrlKey;
+          updateLinkCursor(hoveredCell, acceleratorHeldRef.current);
           if (!selectingRef.current || !selectionRef.current) {
             sendTrackedMouse('move', event);
             return;
@@ -772,6 +809,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           const row = bufferRowFromViewportRow(cell.row, terminal.getScrollbackLength(), viewportOffsetRef.current);
           selectionRef.current = { ...selectionRef.current, endRow: row, endCol: cell.col + 1 };
           renderSurface(true);
+        }}
+        onMouseLeave={() => {
+          hoveredCellRef.current = null;
+          setLinkCursorActive(false);
         }}
         onMouseUp={async (event) => {
           if (!selectingRef.current) {
@@ -784,7 +825,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           if (text) await writeClipboardText(text);
           const cell = cellFromPointer(event);
           const uri = cell ? literalUrlAtColumn(lineAtVisibleRow(cell.row), cell.col) : null;
-          if (uri && !text && ((event.metaKey || event.ctrlKey) || !terminalRef.current?.hasMouseTracking())) {
+          if (uri && !text && (event.metaKey || event.ctrlKey)) {
             void openUrl(uri);
           }
         }}

--- a/app/src/components/SessionTerminalWorkspace/terminalKeyHandler.ts
+++ b/app/src/components/SessionTerminalWorkspace/terminalKeyHandler.ts
@@ -3,6 +3,18 @@ import { isMacLikePlatform } from '../../shortcuts/platform';
 
 export function installTerminalKeyHandler(sendToPty: (data: string) => void) {
   return (event: KeyboardEvent) => {
+    if (
+      event.type === 'keydown'
+      && event.ctrlKey
+      && !event.metaKey
+      && !event.altKey
+      && !event.shiftKey
+      && event.key.toLowerCase() === 'v'
+    ) {
+      // Claude and Codex read image clipboard content after receiving Ctrl+V.
+      sendToPty('\x16');
+      return false;
+    }
     const accel = isMacLikePlatform() ? event.metaKey : (event.metaKey || event.ctrlKey);
     if (event.type === 'keydown' && accel && !event.altKey) {
       if (!event.shiftKey && event.key.toLowerCase() === 't') {

--- a/app/src/components/SessionTerminalWorkspace/terminalKeyHandler.ts
+++ b/app/src/components/SessionTerminalWorkspace/terminalKeyHandler.ts
@@ -10,8 +10,10 @@ export function installTerminalKeyHandler(sendToPty: (data: string) => void) {
       && !event.altKey
       && !event.shiftKey
       && event.key.toLowerCase() === 'v'
+      && isMacLikePlatform()
     ) {
-      // Claude and Codex read image clipboard content after receiving Ctrl+V.
+      // On macOS Ctrl+V is available for the agent image-paste trigger;
+      // elsewhere it is the normal browser text-paste accelerator.
       sendToPty('\x16');
       return false;
     }


### PR DESCRIPTION
## Intent / Why

The Ghostty terminal migration changed several user-facing interactions: URL activation differed between Codex and Claude depending on mouse-tracking mode, screenshot paste no longer reached either agent because Ghostty consumes image clipboard events without forwarding them, and custom selection handling omitted existing terminal selection gestures.

## Summary

- Require Command/Ctrl-click for terminal URL opening and show the pointer cursor only while the modifier makes the URL actionable.
- Restore screenshot paste by forwarding the macOS Ctrl+V trigger and translating image paste events into the control sequence Claude and Codex use to read the native clipboard.
- Preserve non-mac text paste by leaving Ctrl+V to Ghostty where it is the platform paste accelerator.
- Restore double-click word selection and Option-drag selection inside mouse-tracking applications.
- Extend browser regression coverage and document the user-visible terminal fixes in `CHANGELOG.md`.

## Out of scope

- OSC 8 labeled links remain unsupported until the Ghostty model provides the hyperlink URI needed by the opener.
- Restoring the prior blinking cursor and visible scrollbar/overview feedback is separate follow-up work.

## Test plan

- [x] `pnpm --dir app exec tsc --noEmit`
- [x] `pnpm --dir app test` (406 passed)
- [x] `pnpm --dir app run build`
- [x] `pnpm --dir app run e2e -- e2e/terminal-interactions.spec.ts` (8 passed)