### PR TITLE
fix(terminal): stop session shortcut input leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Codex Activity State**: Codex sessions now use hooks exclusively for live activity state, preventing completed sessions from remaining green due to stale transcript activity.
 - **Terminal Selection and Link Activation**: Ghostty terminals now select words on double-click, preserve Option-drag selection inside mouse-tracking applications, and open URLs only with Command-click while showing a pointer cursor when Command is held.
 - **Terminal Screenshot Paste**: Ghostty terminal sessions now forward macOS Control-V image-paste triggers and translate image paste events so Claude and Codex can read pasted clipboard images again without breaking text paste on other platforms.
+- **Session Switching Shortcuts**: Command-number session switching no longer writes the selected session number into the focused Ghostty terminal.
 
 ## [2026-05-27]
 

--- a/app/e2e/keyboard-shortcuts.spec.ts
+++ b/app/e2e/keyboard-shortcuts.spec.ts
@@ -214,9 +214,17 @@ test.describe('Keyboard Shortcuts', () => {
 
       await expect(page.locator('[data-testid="session-s1"]')).toBeVisible({ timeout: 5000 });
 
-      // ⌘2 should select second session
+      // Switching from a focused Ghostty terminal must not forward the shortcut's digit.
+      await page.locator('[data-testid="session-s1"]').click();
+      const firstTerminal = page.locator('[data-pane-session-id="s1"][data-pane-id="main"] .terminal-container');
+      await expect(firstTerminal).toBeVisible({ timeout: 5000 });
+      await firstTerminal.focus();
+
       await page.keyboard.press('Meta+2');
-      await expect(page.locator('.terminal-wrapper.active')).toBeVisible({ timeout: 2000 });
+      await expect(page.locator('[data-session-terminal-workspace="s2"]')).toBeVisible({ timeout: 2000 });
+      expect(await page.evaluate(() => (
+        window.__TEST_GET_SESSION_INPUT_EVENTS?.('s1') ?? []
+      ).filter((event) => event.event === 'send_to_pty').length)).toBe(0);
 
       // Go back to dashboard
       await page.keyboard.press('Escape');

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -107,6 +107,7 @@ export function useKeyboardShortcuts({
       // ⌘1-9 - Select session by index
       if (isMeta && e.key >= '1' && e.key <= '9') {
         e.preventDefault();
+        e.stopPropagation();
         const index = parseInt(e.key, 10) - 1;
         onSelectSession(index);
       }


### PR DESCRIPTION
## Intent / Why

Pressing Command-number to switch sessions while a Ghostty pane is focused currently also writes the selected number into the outgoing terminal. Session navigation should not mutate terminal input.

## Summary

- Stop propagation after the manual Command-1 through Command-9 session selector handles a keydown, keeping the consumed shortcut out of Ghostty PTY input.
- Extend the keyboard shortcut browser coverage to switch away from a focused Ghostty terminal and assert that it sends no PTY input.
- Record the user-visible fix in the changelog.

## Test plan

- [x] `pnpm --dir app run build`
- [x] `pnpm --dir app run e2e e2e/keyboard-shortcuts.spec.ts`
- [x] `git diff --check`