### PR TITLE
fix(terminal): ignore click-sized selection jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Terminal Selection and Link Activation**: Ghostty terminals now select words on double-click, preserve Option-drag selection inside mouse-tracking applications, and open URLs only with Command-click while showing a pointer cursor when Command is held.
 - **Terminal Screenshot Paste**: Ghostty terminal sessions now forward macOS Control-V image-paste triggers and translate image paste events so Claude and Codex can read pasted clipboard images again without breaking text paste on other platforms.
 - **Session Switching Shortcuts**: Command-number session switching no longer writes the selected session number into the focused Ghostty terminal.
+- **Terminal Click Selection**: Small pointer movement during an ordinary terminal click no longer creates and copies a single-cell text selection.
 
 ## [2026-05-27]
 

--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -230,6 +230,23 @@ test.describe('Ghostty terminal interactions', () => {
       .toBe('selectable-word');
   });
 
+  test('does not create a selection from click-sized pointer jitter', async ({ page, context, daemon }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const terminal = await openTerminalSession(page, daemon, 's-click-jitter');
+    await writeTerminalOutput(page, 's-click-jitter', '\u001b[2J\u001b[Hclick-jitter-target');
+    await page.evaluate(() => navigator.clipboard.writeText('clipboard-sentinel'));
+
+    const bounds = await terminal.boundingBox();
+    expect(bounds).not.toBeNull();
+    await page.mouse.move(bounds!.x + 55, bounds!.y + 8);
+    await page.mouse.down();
+    await page.mouse.move(bounds!.x + 56, bounds!.y + 8);
+    await page.mouse.up();
+
+    await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText()), { timeout: 3000 })
+      .toBe('clipboard-sentinel');
+  });
+
   test('option-drag selects text while terminal mouse tracking is active', async ({ page, context, daemon }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
     const terminal = await openTerminalSession(page, daemon, 's-option-selection');

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -179,6 +179,8 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const selectedTextRef = useRef<string | null>(null);
     const applicationSelectionAnchorRef = useRef<ApplicationSelectionAnchor | null>(null);
     const selectingRef = useRef(false);
+    const selectionPointerStartRef = useRef<{ clientX: number; clientY: number } | null>(null);
+    const selectionDragThresholdMetRef = useRef(false);
     const trackedMouseButtonRef = useRef<number | null>(null);
     const hoveredCellRef = useRef<{ row: number; col: number } | null>(null);
     const acceleratorHeldRef = useRef(false);
@@ -801,6 +803,8 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           selectedTextRef.current = null;
           applicationSelectionAnchorRef.current = null;
           selectingRef.current = true;
+          selectionPointerStartRef.current = { clientX: event.clientX, clientY: event.clientY };
+          selectionDragThresholdMetRef.current = false;
           selectionRef.current = { startRow: row, startCol: cell.col, endRow: row, endCol: cell.col };
           renderSurface(true);
         }}
@@ -814,8 +818,17 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             return;
           }
           const terminal = terminalRef.current;
+          const renderer = rendererRef.current;
           const cell = cellFromPointer(event);
-          if (!terminal || !cell) return;
+          const pointerStart = selectionPointerStartRef.current;
+          if (!terminal || !renderer || !cell || !pointerStart) return;
+          if (!selectionDragThresholdMetRef.current) {
+            const deltaX = event.clientX - pointerStart.clientX;
+            const deltaY = event.clientY - pointerStart.clientY;
+            const threshold = renderer.cellWidth * 0.5;
+            if (deltaX * deltaX + deltaY * deltaY < threshold * threshold) return;
+            selectionDragThresholdMetRef.current = true;
+          }
           const row = bufferRowFromViewportRow(cell.row, terminal.getScrollbackLength(), viewportOffsetRef.current);
           selectionRef.current = { ...selectionRef.current, endRow: row, endCol: cell.col + 1 };
           renderSurface(true);
@@ -830,6 +843,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             return;
           }
           selectingRef.current = false;
+          selectionPointerStartRef.current = null;
+          if (!selectionDragThresholdMetRef.current) {
+            selectionRef.current = null;
+            renderSurface(true);
+          }
           const text = textForSelectionRange(selectionRef.current);
           selectedTextRef.current = text || null;
           if (text) await writeClipboardText(text);


### PR DESCRIPTION
## Intent / Why

Clicking in a Ghostty terminal can sometimes look like a tiny drag and copy a one-cell selection. Ordinary focus clicks should not unexpectedly select or replace clipboard content.

## Summary

- Apply a half-cell pointer-movement threshold before the custom WebGL terminal selection path begins a drag, matching Ghostty selection behavior.
- Clear pending click selections on release when the pointer never crosses the drag threshold.
- Add browser regression coverage for one-pixel click jitter while keeping explicit drag and double-click selection coverage intact.
- Record the user-visible fix in the changelog.

## Test plan

- [x] `pnpm --dir app run build`
- [x] `pnpm --dir app run e2e e2e/terminal-interactions.spec.ts`
- [x] `git diff --check`