### PR TITLE
[codex] fix shell input stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Terminal Screenshot Paste**: Ghostty terminal sessions now forward macOS Control-V image-paste triggers and translate image paste events so Claude and Codex can read pasted clipboard images again without breaking text paste on other platforms.
 - **Session Switching Shortcuts**: Command-number session switching no longer writes the selected session number into the focused Ghostty terminal.
 - **Terminal Click Selection**: Small pointer movement during an ordinary terminal click no longer creates and copies a single-cell text selection.
+- **Shell Terminal Input**: Shell panes now answer common terminal capability and color queries, preventing prompts from delaying typed input while they wait for a terminal response.
+- **Location Picker Background Work**: Hidden location pickers no longer keep sending directory-browse requests, reducing avoidable daemon and terminal UI load while working in sessions.
 
 ## [2026-05-27]
 

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -24,6 +24,7 @@ import {
   getTerminalTheme,
   type ResolvedTheme,
 } from '../utils/terminalSizing';
+import { buildTerminalQueryResponses } from '../utils/terminalQueryResponses';
 import { isSuspiciousTerminalSize } from '../utils/terminalDebug';
 import type { TerminalVisibleContentSnapshot } from '../utils/terminalVisibleContent';
 import { analyzeTerminalVisibleLines } from '../utils/terminalVisibleContent';
@@ -445,9 +446,18 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         const scrollbackBefore = terminal.getScrollbackLength();
         const viewportOffsetBefore = viewportOffsetRef.current;
         terminal.write(data);
+        const responses: string[] = [];
         while (terminal.hasResponse()) {
           const response = terminal.readResponse();
-          if (response && !options?.suppressResponses) onInputRef.current(response);
+          if (response) responses.push(response);
+        }
+        if (!options?.suppressResponses) {
+          for (const response of responses) {
+            onInputRef.current(response);
+          }
+          for (const response of buildTerminalQueryResponses(data, resolvedTheme, responses)) {
+            onInputRef.current(response);
+          }
         }
         viewportOffsetRef.current = offsetAfterWrite(
           viewportOffsetBefore,

--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -119,6 +119,15 @@ describe('LocationPicker', () => {
     }));
   });
 
+  it('disables filesystem suggestions while closed', () => {
+    renderPicker({ isOpen: false });
+
+    expect(useFilesystemSuggestionsMock).toHaveBeenCalled();
+    const calls = useFilesystemSuggestionsMock.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall?.[5]).toBe(false);
+  });
+
   it('spawns a remote session with an agent advertised only by that endpoint', async () => {
     const onGetRecentLocations = vi.fn(async () => ({ locations: [], home_path: '/home/remote' }));
     const onInspectPath = vi.fn(async () => ({

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -270,14 +270,17 @@ export function LocationPicker({
     return shortcuts;
   }, [selectableTargets]);
 
+  const handleHomePathChange = useCallback((nextHomePath: string) => {
+    setHomePath((prev) => (prev === nextHomePath ? prev : nextHomePath));
+  }, []);
+
   const { suggestions: fsSuggestions, currentDir } = useFilesystemSuggestions(
     inputValue,
     selectedEndpointId,
     onBrowseDirectory,
     homePath,
-    (nextHomePath) => {
-      setHomePath((prev) => (prev === nextHomePath ? prev : nextHomePath));
-    },
+    handleHomePathChange,
+    isOpen,
   );
 
   const orderedAgentList = useMemo(() => {

--- a/app/src/hooks/useFilesystemSuggestions.test.ts
+++ b/app/src/hooks/useFilesystemSuggestions.test.ts
@@ -12,6 +12,50 @@ describe('useFilesystemSuggestions', () => {
     vi.useRealTimers();
   });
 
+  it('does not browse while disabled and clears visible suggestion state', async () => {
+    const browseDirectory = vi.fn(async () => ({
+      success: true,
+      input_path: '~/projects/',
+      directory: '/Users/victor/projects',
+      entries: [{ name: 'attn', path: '/Users/victor/projects/attn' }],
+      home_path: '/Users/victor',
+    }));
+
+    const { result, rerender } = renderHook(
+      ({ inputPath, enabled }) => useFilesystemSuggestions(
+        inputPath,
+        undefined,
+        browseDirectory,
+        undefined,
+        undefined,
+        enabled,
+      ),
+      { initialProps: { inputPath: '~/projects/', enabled: true } },
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+    });
+
+    expect(result.current.suggestions.map((entry) => entry.name)).toEqual(['attn']);
+
+    act(() => {
+      rerender({ inputPath: '~/projects/attn', enabled: false });
+    });
+
+    expect(result.current.suggestions).toEqual([]);
+    expect(result.current.currentDir).toBe('');
+    expect(result.current.loading).toBe(false);
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(browseDirectory).toHaveBeenCalledTimes(1);
+  });
+
   it('refreshes immediately and clears stale results when the target endpoint changes', async () => {
     let resolveRemote: ((value: BrowseDirectoryResult) => void) | null = null;
     const browseDirectory = vi.fn(async (_inputPath: string, endpointId?: string) => {

--- a/app/src/hooks/useFilesystemSuggestions.ts
+++ b/app/src/hooks/useFilesystemSuggestions.ts
@@ -20,6 +20,7 @@ export function useFilesystemSuggestions(
   browseDirectory?: (inputPath: string, endpointId?: string) => Promise<BrowseDirectoryResult>,
   homePath?: string,
   onHomePathChange?: (nextHomePath: string) => void,
+  enabled = true,
 ): UseFilesystemSuggestionsResult {
   const [suggestions, setSuggestions] = useState<FilesystemSuggestion[]>([]);
   const [loading, setLoading] = useState(false);
@@ -30,9 +31,11 @@ export function useFilesystemSuggestions(
   const previousEndpointIdRef = useRef<string | undefined>(endpointId);
 
   const fetchSuggestions = useCallback(async (path: string, targetEndpointId?: string) => {
-    if (!browseDirectory || !path || path.length < 1) {
+    if (!enabled || !browseDirectory || !path || path.length < 1) {
       setSuggestions([]);
       setCurrentDir('');
+      setError(null);
+      setLoading(false);
       return;
     }
 
@@ -68,11 +71,20 @@ export function useFilesystemSuggestions(
         setLoading(false);
       }
     }
-  }, [browseDirectory, homePath, onHomePathChange]);
+  }, [browseDirectory, enabled, homePath, onHomePathChange]);
 
   useEffect(() => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
+    }
+
+    if (!enabled) {
+      requestIdRef.current += 1;
+      setSuggestions([]);
+      setCurrentDir('');
+      setError(null);
+      setLoading(false);
+      return;
     }
 
     const endpointChanged = previousEndpointIdRef.current !== endpointId;
@@ -97,7 +109,7 @@ export function useFilesystemSuggestions(
         clearTimeout(debounceRef.current);
       }
     };
-  }, [endpointId, fetchSuggestions, inputPath]);
+  }, [enabled, endpointId, fetchSuggestions, inputPath]);
 
   return { suggestions, loading, error, currentDir };
 }

--- a/app/src/utils/terminalQueryResponses.test.ts
+++ b/app/src/utils/terminalQueryResponses.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { buildTerminalQueryResponses } from './terminalQueryResponses';
+
+describe('buildTerminalQueryResponses', () => {
+  it('answers shell prompt terminal queries not handled by ghostty-web', () => {
+    expect(buildTerminalQueryResponses('\u001b]11;?\u001b\\\u001b[0c', 'dark')).toEqual([
+      '\u001b]11;rgb:1e1e/1e1e/1e1e\u001b\\',
+      '\u001b[?1;2c',
+    ]);
+  });
+
+  it('uses the active terminal theme for OSC color query responses', () => {
+    expect(buildTerminalQueryResponses('\u001b]10;?\u0007\u001b]12;?\u0007', 'light')).toEqual([
+      '\u001b]10;rgb:3b3b/3b3b/3b3b\u001b\\',
+      '\u001b]12;rgb:3b3b/3b3b/3b3b\u001b\\',
+    ]);
+  });
+
+  it('does not duplicate model-provided responses', () => {
+    expect(buildTerminalQueryResponses(
+      '\u001b]11;?\u001b\\\u001b[0c',
+      'dark',
+      ['\u001b]11;rgb:0000/0000/0000\u001b\\', '\u001b[?62;4;6;22c'],
+    )).toEqual([]);
+  });
+
+  it('detects terminal queries in byte writes', () => {
+    const bytes = new TextEncoder().encode('\u001b]11;?\u0007');
+    expect(buildTerminalQueryResponses(bytes, 'light')).toEqual([
+      '\u001b]11;rgb:ffff/ffff/ffff\u001b\\',
+    ]);
+  });
+});

--- a/app/src/utils/terminalQueryResponses.ts
+++ b/app/src/utils/terminalQueryResponses.ts
@@ -1,0 +1,60 @@
+import {
+  getTerminalTheme,
+  type ResolvedTheme,
+} from './terminalSizing';
+
+const OSC_TERMINATOR_RE = '(?:\\u0007|\\u001b\\\\)';
+const PRIMARY_DEVICE_ATTRIBUTES_QUERY_RE = /\u001b\[(?:0)?c/;
+const PRIMARY_DEVICE_ATTRIBUTES_RESPONSE_RE = /\u001b\[\?[0-9;]*c/;
+
+function oscQueryRe(code: number): RegExp {
+  return new RegExp(`\\u001b\\]${code};\\?${OSC_TERMINATOR_RE}`);
+}
+
+function hasOscResponse(code: number, responses: readonly string[]): boolean {
+  const prefix = `\u001b]${code};`;
+  return responses.some((response) => response.startsWith(prefix));
+}
+
+function hexToTerminalRgb(color: string): string {
+  const value = color.startsWith('#') ? color.slice(1) : color;
+  if (value.length !== 6) return '0000/0000/0000';
+  return `${value.slice(0, 2).repeat(2)}/${value.slice(2, 4).repeat(2)}/${value.slice(4, 6).repeat(2)}`;
+}
+
+function textFromTerminalWrite(data: string | Uint8Array): string {
+  return typeof data === 'string' ? data : new TextDecoder().decode(data);
+}
+
+export function buildTerminalQueryResponses(
+  data: string | Uint8Array,
+  resolvedTheme: ResolvedTheme,
+  existingResponses: readonly string[] = [],
+): string[] {
+  const text = textFromTerminalWrite(data);
+  if (!text) return [];
+
+  const theme = getTerminalTheme(resolvedTheme);
+  const responses: string[] = [];
+
+  if (oscQueryRe(10).test(text) && !hasOscResponse(10, existingResponses)) {
+    responses.push(`\u001b]10;rgb:${hexToTerminalRgb(theme.foreground)}\u001b\\`);
+  }
+
+  if (oscQueryRe(11).test(text) && !hasOscResponse(11, existingResponses)) {
+    responses.push(`\u001b]11;rgb:${hexToTerminalRgb(theme.background)}\u001b\\`);
+  }
+
+  if (oscQueryRe(12).test(text) && !hasOscResponse(12, existingResponses)) {
+    responses.push(`\u001b]12;rgb:${hexToTerminalRgb(theme.cursor)}\u001b\\`);
+  }
+
+  if (
+    PRIMARY_DEVICE_ATTRIBUTES_QUERY_RE.test(text)
+    && !existingResponses.some((response) => PRIMARY_DEVICE_ATTRIBUTES_RESPONSE_RE.test(response))
+  ) {
+    responses.push('\u001b[?1;2c');
+  }
+
+  return responses;
+}


### PR DESCRIPTION
## Summary
- answer shell prompt terminal color and device-attribute queries that ghostty-web does not currently emit
- keep terminal query responses suppressed for attach replay so historical output cannot write back to live PTYs
- stop hidden location pickers from continuing directory-browse requests while closed

## Root Cause
Shell panes could accept typed bytes immediately in the daemon while the shell prompt waited on terminal capability/color query responses before echoing or processing the queued input. Separately, mounted-but-closed location pickers were still browsing directories in the background.

## Validation
- pnpm --dir app test -- terminalQueryResponses.test.ts useGhosttyPaneRuntime.test.ts LocationPicker.test.tsx useFilesystemSuggestions.test.ts
- pnpm --dir app run build
- make install
- manual live attn shell typing check