### PR TITLE
[codex] Prepare workspace-first sidebar migration

### DIFF
--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -30,6 +30,7 @@ import {
 } from '../utils/terminalSizing';
 import { buildTerminalQueryResponses } from '../utils/terminalQueryResponses';
 import { isSuspiciousTerminalSize } from '../utils/terminalDebug';
+import { recordTerminalLinkHitTestEvent } from '../utils/terminalLinkHitTestLog';
 import type { TerminalVisibleContentSnapshot } from '../utils/terminalVisibleContent';
 import { analyzeTerminalVisibleLines } from '../utils/terminalVisibleContent';
 import type { TerminalVisibleStyleSnapshot, TerminalVisibleStyleLineSnapshot } from '../utils/terminalStyleSummary';
@@ -118,6 +119,35 @@ function wordRangeAtColumn(line: string, col: number): { startCol: number; endCo
   let endCol = col + 1;
   while (endCol < line.length && isWordCharacter(line[endCol])) endCol += 1;
   return { startCol, endCol };
+}
+
+function rectSnapshot(rect: DOMRect | null) {
+  if (!rect) return null;
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+    top: rect.top,
+    left: rect.left,
+    right: rect.right,
+    bottom: rect.bottom,
+  };
+}
+
+function cellFromRect(
+  event: React.MouseEvent,
+  rect: DOMRect | null,
+  cellWidth: number,
+  cellHeight: number,
+  rows: number,
+  cols: number,
+) {
+  if (!rect) return null;
+  return {
+    row: Math.max(0, Math.min(rows - 1, Math.floor((event.clientY - rect.top) / cellHeight))),
+    col: Math.max(0, Math.min(cols, Math.floor((event.clientX - rect.left) / cellWidth))),
+  };
 }
 
 function colorNumber(value: string): number {
@@ -711,6 +741,100 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       };
     };
 
+    const recordPointerHitTest = useCallback((
+      eventName: string,
+      event: React.MouseEvent,
+      extra: Record<string, unknown> = {},
+    ) => {
+      const terminal = terminalRef.current;
+      const renderer = rendererRef.current;
+      const container = containerRef.current;
+      const canvas = canvasRef.current;
+      if (!terminal || !renderer || !container || !canvas) return;
+      const containerRect = container.getBoundingClientRect();
+      const canvasRect = canvas.getBoundingClientRect();
+      const containerCell = cellFromRect(event, containerRect, renderer.cellWidth, renderer.cellHeight, terminal.rows, terminal.cols);
+      const canvasCell = cellFromRect(event, canvasRect, renderer.cellWidth, renderer.cellHeight, terminal.rows, terminal.cols);
+      const selectedText = selectedTextRef.current;
+      const selection = selectionRef.current;
+      const containerLine = containerCell ? lineAtVisibleRow(containerCell.row) : '';
+      const canvasLine = canvasCell ? lineAtVisibleRow(canvasCell.row) : '';
+      const containerUri = containerCell ? literalUrlAtColumn(containerLine, containerCell.col) : null;
+      const canvasUri = canvasCell ? literalUrlAtColumn(canvasLine, canvasCell.col) : null;
+      recordTerminalLinkHitTestEvent({
+        event: eventName,
+        debugName: debugNameRef.current,
+        sessionId: runtimeMetaRef.current?.sessionId,
+        paneId: runtimeMetaRef.current?.paneId,
+        runtimeId: runtimeMetaRef.current?.runtimeId,
+        details: {
+          pointer: {
+            clientX: event.clientX,
+            clientY: event.clientY,
+            offsetFromContainer: {
+              x: event.clientX - containerRect.left,
+              y: event.clientY - containerRect.top,
+            },
+            offsetFromCanvas: {
+              x: event.clientX - canvasRect.left,
+              y: event.clientY - canvasRect.top,
+            },
+            metaKey: event.metaKey,
+            ctrlKey: event.ctrlKey,
+            altKey: event.altKey,
+            shiftKey: event.shiftKey,
+            button: event.button,
+            buttons: event.buttons,
+          },
+          cells: {
+            container: containerCell,
+            canvas: canvasCell,
+          },
+          detected: {
+            containerUri,
+            canvasUri,
+            containerLinePreview: containerLine,
+            canvasLinePreview: canvasLine,
+          },
+          selection: {
+            selecting: selectingRef.current,
+            dragThresholdMet: selectionDragThresholdMetRef.current,
+            range: selection,
+            selectedTextPreview: selectedText,
+            selectedTextLength: selectedText?.length ?? 0,
+          },
+          terminal: {
+            cols: terminal.cols,
+            rows: terminal.rows,
+            scrollbackLength: terminal.getScrollbackLength(),
+            viewportOffset: viewportOffsetRef.current,
+            alternateScreen: terminal.isAlternateScreen(),
+            mouseTracking: terminal.hasMouseTracking(),
+          },
+          geometry: {
+            containerRect: rectSnapshot(containerRect),
+            canvasRect: rectSnapshot(canvasRect),
+            containerClient: {
+              width: container.clientWidth,
+              height: container.clientHeight,
+            },
+            canvasClient: {
+              width: canvas.clientWidth,
+              height: canvas.clientHeight,
+            },
+            canvasBacking: {
+              width: canvas.width,
+              height: canvas.height,
+            },
+            devicePixelRatio: window.devicePixelRatio,
+            cellWidth: renderer.cellWidth,
+            cellHeight: renderer.cellHeight,
+          },
+          ...extra,
+        },
+      });
+    }, [lineAtVisibleRow]);
+
     const mouseModifiers = (event: React.MouseEvent) =>
       (event.shiftKey ? 4 : 0) + (event.altKey ? 8 : 0) + (event.ctrlKey ? 16 : 0);
 
@@ -849,6 +973,12 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           if (!terminal || !cell) return;
           const uri = literalUrlAtColumn(lineAtVisibleRow(cell.row), cell.col);
           const opensUri = Boolean(uri && (event.metaKey || event.ctrlKey));
+          recordPointerHitTest('mousedown', event, {
+            activeCell: cell,
+            activeUri: uri,
+            opensUri,
+            phase: 'before-selection',
+          });
           if (!opensUri && !event.altKey && sendTrackedMouse('press', event)) return;
           const row = bufferRowFromViewportRow(cell.row, terminal.getScrollbackLength(), viewportOffsetRef.current);
           selectedTextRef.current = null;
@@ -864,6 +994,15 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           hoveredCellRef.current = hoveredCell;
           acceleratorHeldRef.current = event.metaKey || event.ctrlKey;
           updateLinkCursor(hoveredCell, acceleratorHeldRef.current);
+          const hoveredLine = hoveredCell ? lineAtVisibleRow(hoveredCell.row) : '';
+          const hoveredUri = hoveredCell ? literalUrlAtColumn(hoveredLine, hoveredCell.col) : null;
+          if (acceleratorHeldRef.current || hoveredUri || selectingRef.current) {
+            recordPointerHitTest('mousemove', event, {
+              activeCell: hoveredCell,
+              activeUri: hoveredUri,
+              phase: selectingRef.current ? 'selection-drag' : 'hover',
+            });
+          }
           if (!selectingRef.current || !selectionRef.current) {
             sendTrackedMouse('move', event);
             return;
@@ -890,6 +1029,9 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         }}
         onMouseUp={async (event) => {
           if (!selectingRef.current) {
+            recordPointerHitTest('mouseup', event, {
+              phase: 'tracked-mouse-release',
+            });
             sendTrackedMouse('release', event);
             return;
           }
@@ -904,6 +1046,13 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           if (text) await writeClipboardText(text);
           const cell = cellFromPointer(event);
           const uri = cell ? literalUrlAtColumn(lineAtVisibleRow(cell.row), cell.col) : null;
+          recordPointerHitTest('mouseup', event, {
+            activeCell: cell,
+            activeUri: uri,
+            opensUri: Boolean(uri && !text && (event.metaKey || event.ctrlKey)),
+            copiedTextLength: text.length,
+            phase: 'after-selection',
+          });
           if (uri && !text && (event.metaKey || event.ctrlKey)) {
             void openUrl(uri);
           }
@@ -911,6 +1060,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         onDoubleClick={async (event) => {
           const terminal = terminalRef.current;
           const cell = cellFromPointer(event);
+          recordPointerHitTest('doubleclick', event, {
+            activeCell: cell,
+            phase: 'before-word-selection',
+          });
           if (!terminal || !cell || (terminal.hasMouseTracking() && !event.altKey)) return;
           const range = wordRangeAtColumn(lineAtVisibleRow(cell.row), cell.col);
           if (!range) return;

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceLayoutRenderer.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceLayoutRenderer.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react';
+import type { TerminalLayoutNode } from '../../types/workspace';
+
+function clampSplitRatio(ratio: number): number {
+  if (ratio > 0 && ratio < 1) {
+    return ratio;
+  }
+  return 0.5;
+}
+
+function renderLayoutMetadata(node: TerminalLayoutNode, path = 'root'): ReactNode {
+  if (node.type === 'pane') {
+    return null;
+  }
+
+  const firstRatio = clampSplitRatio(node.ratio);
+  const secondRatio = clampSplitRatio(1 - firstRatio);
+  const firstPath = `${path}/0`;
+  const secondPath = `${path}/1`;
+  const splitStyle = node.direction === 'vertical'
+    ? { gridTemplateColumns: `minmax(0, ${firstRatio}fr) minmax(0, ${secondRatio}fr)` }
+    : { gridTemplateRows: `minmax(0, ${firstRatio}fr) minmax(0, ${secondRatio}fr)` };
+
+  return (
+    <div
+      key={node.splitId}
+      className={`workspace-split split-${node.direction}`}
+      data-split-id={node.splitId}
+      data-split-path={path}
+      data-split-direction={node.direction}
+      data-split-ratio={firstRatio.toFixed(3)}
+      style={splitStyle}
+    >
+      <div
+        className="workspace-split-child"
+        data-split-child-index="0"
+        data-split-child-path={firstPath}
+      >
+        {renderLayoutMetadata(node.children[0], firstPath)}
+      </div>
+      <div
+        className="workspace-split-child"
+        data-split-child-index="1"
+        data-split-child-path={secondPath}
+      >
+        {renderLayoutMetadata(node.children[1], secondPath)}
+      </div>
+    </div>
+  );
+}
+
+interface WorkspaceLayoutRendererProps {
+  layoutTree: TerminalLayoutNode;
+  paneIds: string[];
+  renderPane: (paneId: string) => ReactNode;
+}
+
+export function WorkspaceLayoutRenderer({
+  layoutTree,
+  paneIds,
+  renderPane,
+}: WorkspaceLayoutRendererProps) {
+  return (
+    <div className="session-terminal-panes">
+      <div className="workspace-layout-metadata" aria-hidden="true">
+        {renderLayoutMetadata(layoutTree)}
+      </div>
+      {paneIds.map((paneId) => renderPane(paneId))}
+    </div>
+  );
+}

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -23,15 +23,9 @@ import './SessionTerminalWorkspace.css';
 import type { TerminalVisibleContentSnapshot } from '../../utils/terminalVisibleContent';
 import type { TerminalVisibleStyleSnapshot } from '../../utils/terminalStyleSummary';
 import type { ResolvedTheme } from '../../utils/terminalSizing';
+import { WorkspaceLayoutRenderer } from './WorkspaceLayoutRenderer';
 
 const ZOOM_PATH_RATIO = 0.76;
-
-function clampSplitRatio(ratio: number): number {
-  if (ratio > 0 && ratio < 1) {
-    return ratio;
-  }
-  return 0.5;
-}
 
 function zoomLayoutTowardPane(node: TerminalLayoutNode, paneId: string): TerminalLayoutNode {
   if (node.type === 'pane') {
@@ -485,46 +479,6 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     useShortcut('terminal.focusUp', () => handleMovePane('up'), sessionVisible);
     useShortcut('terminal.focusDown', () => handleMovePane('down'), sessionVisible);
 
-    const renderLayoutMetadata = useCallback((node: TerminalLayoutNode, path = 'root'): React.ReactNode => {
-      if (node.type === 'split') {
-        const firstRatio = clampSplitRatio(node.ratio);
-        const secondRatio = clampSplitRatio(1 - firstRatio);
-        const firstPath = `${path}/0`;
-        const secondPath = `${path}/1`;
-        const splitStyle = node.direction === 'vertical'
-          ? { gridTemplateColumns: `minmax(0, ${firstRatio}fr) minmax(0, ${secondRatio}fr)` }
-          : { gridTemplateRows: `minmax(0, ${firstRatio}fr) minmax(0, ${secondRatio}fr)` };
-        return (
-          <div
-            key={node.splitId}
-            className={`workspace-split split-${node.direction}`}
-            data-split-id={node.splitId}
-            data-split-path={path}
-            data-split-direction={node.direction}
-            data-split-ratio={firstRatio.toFixed(3)}
-            style={splitStyle}
-          >
-            <div
-              className="workspace-split-child"
-              data-split-child-index="0"
-              data-split-child-path={firstPath}
-            >
-              {renderLayoutMetadata(node.children[0], firstPath)}
-            </div>
-            <div
-              className="workspace-split-child"
-              data-split-child-index="1"
-              data-split-child-path={secondPath}
-            >
-              {renderLayoutMetadata(node.children[1], secondPath)}
-            </div>
-          </div>
-        );
-      }
-
-      return null;
-    }, []);
-
     const paneFrameStyle = useCallback((bounds: NormalizedPaneBounds) => ({
       left: `${bounds.left * 100}%`,
       top: `${bounds.top * 100}%`,
@@ -671,12 +625,11 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
             </button>
           </div>
         )}
-        <div className="session-terminal-panes">
-          <div className="workspace-layout-metadata" aria-hidden="true">
-            {renderLayoutMetadata(renderedLayoutTree)}
-          </div>
-          {renderedPaneIds.map((paneId) => renderPaneSurface(paneId))}
-        </div>
+        <WorkspaceLayoutRenderer
+          layoutTree={renderedLayoutTree}
+          paneIds={renderedPaneIds}
+          renderPane={renderPaneSurface}
+        />
       </div>
     );
   }

--- a/app/src/hooks/useWorkspaceSelectionController.test.ts
+++ b/app/src/hooks/useWorkspaceSelectionController.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { buildWorkspaceSelectionState } from './useWorkspaceSelectionController';
+import type { WorkspaceWithSessions } from '../utils/workspaceViewModels';
+
+function workspace(id: string, sessionIds: string[]): WorkspaceWithSessions<{ id: string; label: string; workspaceId: string }> {
+  return {
+    id,
+    title: id,
+    directory: `/tmp/${id}`,
+    sessions: sessionIds.map((sessionId) => ({ id: sessionId, label: sessionId, workspaceId: id })),
+    firstSessionId: sessionIds[0] ?? null,
+    focusedSessionId: sessionIds[0] ?? null,
+  };
+}
+
+describe('buildWorkspaceSelectionState', () => {
+  it('derives the active workspace from the active session', () => {
+    const selection = buildWorkspaceSelectionState({
+      workspaces: [workspace('workspace-a', ['a1']), workspace('workspace-b', ['b1', 'b2'])],
+      activeSessionId: 'b2',
+    });
+
+    expect(selection.activeWorkspaceId).toBe('workspace-b');
+    expect(selection.focusedSessionIdByWorkspace).toEqual({
+      'workspace-a': 'a1',
+      'workspace-b': 'b2',
+    });
+  });
+
+  it('keeps remembered focus for inactive workspaces when the session still exists', () => {
+    const selection = buildWorkspaceSelectionState({
+      workspaces: [workspace('workspace-a', ['a1', 'a2']), workspace('workspace-b', ['b1'])],
+      activeSessionId: 'b1',
+      previousFocusedSessionIdByWorkspace: {
+        'workspace-a': 'a2',
+      },
+    });
+
+    expect(selection.focusedSessionIdByWorkspace).toEqual({
+      'workspace-a': 'a2',
+      'workspace-b': 'b1',
+    });
+  });
+
+  it('drops stale remembered focus and falls back to the first session', () => {
+    const selection = buildWorkspaceSelectionState({
+      workspaces: [workspace('workspace-a', ['a1'])],
+      activeSessionId: null,
+      previousFocusedSessionIdByWorkspace: {
+        'workspace-a': 'missing',
+      },
+    });
+
+    expect(selection.activeWorkspaceId).toBeNull();
+    expect(selection.focusedSessionIdByWorkspace).toEqual({
+      'workspace-a': 'a1',
+    });
+  });
+});

--- a/app/src/hooks/useWorkspaceSelectionController.ts
+++ b/app/src/hooks/useWorkspaceSelectionController.ts
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+import type { WorkspaceViewSession, WorkspaceWithSessions } from '../utils/workspaceViewModels';
+
+export interface WorkspaceSelectionState {
+  activeWorkspaceId: string | null;
+  activeSessionId: string | null;
+  focusedSessionIdByWorkspace: Record<string, string>;
+}
+
+interface BuildWorkspaceSelectionArgs<TSession extends WorkspaceViewSession> {
+  workspaces: WorkspaceWithSessions<TSession>[];
+  activeSessionId: string | null;
+  previousFocusedSessionIdByWorkspace?: Record<string, string | null | undefined>;
+}
+
+export function buildWorkspaceSelectionState<TSession extends WorkspaceViewSession>({
+  workspaces,
+  activeSessionId,
+  previousFocusedSessionIdByWorkspace = {},
+}: BuildWorkspaceSelectionArgs<TSession>): WorkspaceSelectionState {
+  const sessionWorkspaceById = new Map<string, string>();
+  const focusedSessionIdByWorkspace: Record<string, string> = {};
+
+  for (const workspace of workspaces) {
+    for (const session of workspace.sessions) {
+      sessionWorkspaceById.set(session.id, workspace.id);
+    }
+  }
+
+  const activeWorkspaceId = activeSessionId
+    ? sessionWorkspaceById.get(activeSessionId) ?? null
+    : null;
+
+  for (const workspace of workspaces) {
+    const previousFocus = previousFocusedSessionIdByWorkspace[workspace.id] || null;
+    const validPreviousFocus = previousFocus && workspace.sessions.some((session) => session.id === previousFocus)
+      ? previousFocus
+      : null;
+    const activeFocus = activeWorkspaceId === workspace.id ? activeSessionId : null;
+    const focus = activeFocus || validPreviousFocus || workspace.firstSessionId;
+    if (focus) {
+      focusedSessionIdByWorkspace[workspace.id] = focus;
+    }
+  }
+
+  return {
+    activeWorkspaceId,
+    activeSessionId,
+    focusedSessionIdByWorkspace,
+  };
+}
+
+export function useWorkspaceSelectionController<TSession extends WorkspaceViewSession>(
+  workspaces: WorkspaceWithSessions<TSession>[],
+  activeSessionId: string | null,
+  previousFocusedSessionIdByWorkspace?: Record<string, string | null | undefined>,
+): WorkspaceSelectionState {
+  return useMemo(
+    () => buildWorkspaceSelectionState({
+      workspaces,
+      activeSessionId,
+      previousFocusedSessionIdByWorkspace,
+    }),
+    [activeSessionId, previousFocusedSessionIdByWorkspace, workspaces],
+  );
+}

--- a/app/src/utils/terminalLinkHitTestLog.ts
+++ b/app/src/utils/terminalLinkHitTestLog.ts
@@ -1,0 +1,73 @@
+import { isTauri } from '@tauri-apps/api/core';
+
+const TERMINAL_LINK_HIT_TEST_DIR = 'debug';
+const TERMINAL_LINK_HIT_TEST_FILE = `${TERMINAL_LINK_HIT_TEST_DIR}/terminal-link-hit-test.jsonl`;
+const MAX_STRING_LENGTH = 500;
+
+export interface TerminalLinkHitTestEvent {
+  at: string;
+  event: string;
+  debugName: string;
+  sessionId?: string;
+  paneId?: string;
+  runtimeId?: string;
+  details: Record<string, unknown>;
+}
+
+let fileWriteChain: Promise<void> = Promise.resolve();
+
+declare global {
+  interface Window {
+    __ATTN_TERMINAL_LINK_HIT_TEST_FILE?: string;
+  }
+}
+
+function redactString(value: string): string {
+  return value
+    .replace(/\bsk-[A-Za-z0-9_-]{20,}\b/g, '[REDACTED]')
+    .replace(/\b[A-Za-z0-9_-]{80,}\b/g, '[REDACTED_LONG_TOKEN]')
+    .slice(0, MAX_STRING_LENGTH);
+}
+
+function sanitizeForLog(value: unknown): unknown {
+  if (typeof value === 'string') return redactString(value);
+  if (Array.isArray(value)) return value.map(sanitizeForLog);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, sanitizeForLog(entry)]),
+  );
+}
+
+async function appendLinkHitTestEventToFile(entry: TerminalLinkHitTestEvent) {
+  if (!isTauri()) return;
+  try {
+    const { mkdir, writeTextFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+    await mkdir(TERMINAL_LINK_HIT_TEST_DIR, {
+      baseDir: BaseDirectory.AppLocalData,
+      recursive: true,
+    });
+    await writeTextFile(
+      TERMINAL_LINK_HIT_TEST_FILE,
+      `${JSON.stringify(sanitizeForLog(entry))}\n`,
+      { baseDir: BaseDirectory.AppLocalData, append: true, create: true },
+    );
+  } catch (error) {
+    console.warn('[TerminalLinkHitTest] Failed to append hit-test event:', error);
+  }
+}
+
+export function recordTerminalLinkHitTestEvent(
+  event: Omit<TerminalLinkHitTestEvent, 'at'>,
+) {
+  if (typeof window !== 'undefined') {
+    window.__ATTN_TERMINAL_LINK_HIT_TEST_FILE = `$APPLOCALDATA/${TERMINAL_LINK_HIT_TEST_FILE}`;
+  }
+  const entry: TerminalLinkHitTestEvent = {
+    at: new Date().toISOString(),
+    ...event,
+  };
+  fileWriteChain = fileWriteChain
+    .catch(() => undefined)
+    .then(() => appendLinkHitTestEventToFile(entry));
+}
+

--- a/app/src/utils/workspaceViewModels.test.ts
+++ b/app/src/utils/workspaceViewModels.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { buildWorkspaceViewModels, firstSessionIdForWorkspace } from './workspaceViewModels';
+
+describe('workspaceViewModels', () => {
+  it('orders workspaces by daemon order and nests sessions by workspace id', () => {
+    const workspaces = [
+      { id: 'workspace-a', title: 'A', directory: '/repo/a', status: 'idle' },
+      { id: 'workspace-b', title: 'B', directory: '/repo/b', status: 'working' },
+    ];
+    const sessions = [
+      { id: 'b1', label: 'B1', workspaceId: 'workspace-b', cwd: '/repo/b' },
+      { id: 'a1', label: 'A1', workspaceId: 'workspace-a', cwd: '/repo/a' },
+      { id: 'a2', label: 'A2', workspaceId: 'workspace-a', cwd: '/repo/a' },
+    ];
+
+    const viewModels = buildWorkspaceViewModels(workspaces, sessions);
+
+    expect(viewModels.map((workspace) => workspace.id)).toEqual(['workspace-a', 'workspace-b']);
+    expect(viewModels.map((workspace) => workspace.sessions.map((session) => session.id))).toEqual([
+      ['a1', 'a2'],
+      ['b1'],
+    ]);
+    expect(viewModels.map((workspace) => workspace.firstSessionId)).toEqual(['a1', 'b1']);
+  });
+
+  it('creates fallback workspaces for sessions missing daemon workspace snapshots', () => {
+    const viewModels = buildWorkspaceViewModels([], [
+      { id: 's1', label: 'One', workspaceId: 'workspace-s1', cwd: '/repo/one' },
+      { id: 's2', label: 'Two', cwd: '/repo/two' },
+    ]);
+
+    expect(viewModels.map((workspace) => ({
+      id: workspace.id,
+      title: workspace.title,
+      directory: workspace.directory,
+      sessions: workspace.sessions.map((session) => session.id),
+    }))).toEqual([
+      { id: 'workspace-s1', title: 'one', directory: '/repo/one', sessions: ['s1'] },
+      { id: 'workspace-s2', title: 'two', directory: '/repo/two', sessions: ['s2'] },
+    ]);
+  });
+
+  it('uses remembered focused session when it still belongs to the workspace', () => {
+    const [workspace] = buildWorkspaceViewModels(
+      [{ id: 'workspace-a', title: 'A', directory: '/repo/a' }],
+      [
+        { id: 'a1', label: 'A1', workspaceId: 'workspace-a' },
+        { id: 'a2', label: 'A2', workspaceId: 'workspace-a' },
+      ],
+      { focusedSessionIdByWorkspace: { 'workspace-a': 'a2' } },
+    );
+
+    expect(workspace.focusedSessionId).toBe('a2');
+    expect(firstSessionIdForWorkspace(workspace)).toBe('a1');
+  });
+
+  it('falls back to the first child when remembered focus is stale', () => {
+    const [workspace] = buildWorkspaceViewModels(
+      [{ id: 'workspace-a', title: 'A', directory: '/repo/a' }],
+      [{ id: 'a1', label: 'A1', workspaceId: 'workspace-a' }],
+      { focusedSessionIdByWorkspace: { 'workspace-a': 'missing' } },
+    );
+
+    expect(workspace.focusedSessionId).toBe('a1');
+  });
+});

--- a/app/src/utils/workspaceViewModels.test.ts
+++ b/app/src/utils/workspaceViewModels.test.ts
@@ -40,6 +40,44 @@ describe('workspaceViewModels', () => {
     ]);
   });
 
+  it('nests remote sessions under endpoint-less daemon workspace snapshots', () => {
+    const viewModels = buildWorkspaceViewModels(
+      [{ id: 'workspace-remote', title: 'Remote', directory: '/srv/repo' }],
+      [
+        {
+          id: 'remote-session',
+          label: 'Remote Session',
+          workspace_id: 'workspace-remote',
+          endpoint_id: 'ep-remote',
+          directory: '/srv/repo',
+        },
+      ],
+    );
+
+    expect(viewModels).toHaveLength(1);
+    expect(viewModels[0].endpointId).toBe('ep-remote');
+    expect(viewModels[0].sessions.map((session) => session.id)).toEqual(['remote-session']);
+  });
+
+  it('pairs duplicate endpoint-less workspace snapshots with distinct endpoint session groups', () => {
+    const viewModels = buildWorkspaceViewModels(
+      [
+        { id: 'workspace-shared', title: 'Remote A', directory: '/srv/a' },
+        { id: 'workspace-shared', title: 'Remote B', directory: '/srv/b' },
+      ],
+      [
+        { id: 'a1', label: 'A1', workspace_id: 'workspace-shared', endpoint_id: 'ep-a', directory: '/srv/a' },
+        { id: 'b1', label: 'B1', workspace_id: 'workspace-shared', endpoint_id: 'ep-b', directory: '/srv/b' },
+      ],
+    );
+
+    expect(viewModels.map((workspace) => workspace.sessions.map((session) => session.id))).toEqual([
+      ['a1'],
+      ['b1'],
+    ]);
+    expect(viewModels.map((workspace) => workspace.endpointId)).toEqual(['ep-a', 'ep-b']);
+  });
+
   it('uses remembered focused session when it still belongs to the workspace', () => {
     const [workspace] = buildWorkspaceViewModels(
       [{ id: 'workspace-a', title: 'A', directory: '/repo/a' }],

--- a/app/src/utils/workspaceViewModels.ts
+++ b/app/src/utils/workspaceViewModels.ts
@@ -1,0 +1,128 @@
+export interface WorkspaceViewSession {
+  id: string;
+  label: string;
+  workspaceId?: string;
+  workspace_id?: string;
+  cwd?: string;
+  directory?: string;
+  endpointId?: string;
+  endpoint_id?: string;
+  state?: string;
+}
+
+export interface WorkspaceViewWorkspace {
+  id: string;
+  title: string;
+  directory: string;
+  status?: string;
+  endpoint_id?: string;
+}
+
+export interface WorkspaceWithSessions<TSession extends WorkspaceViewSession = WorkspaceViewSession> {
+  id: string;
+  title: string;
+  directory: string;
+  status?: string;
+  endpointId?: string;
+  sessions: TSession[];
+  firstSessionId: string | null;
+  focusedSessionId: string | null;
+}
+
+interface WorkspaceViewModelOptions {
+  focusedSessionIdByWorkspace?: Record<string, string | null | undefined>;
+}
+
+function sessionWorkspaceId(session: WorkspaceViewSession): string {
+  return session.workspaceId || session.workspace_id || `workspace-${session.id}`;
+}
+
+function sessionDirectory(session: WorkspaceViewSession): string {
+  return session.cwd || session.directory || session.id;
+}
+
+function sessionEndpointId(session: WorkspaceViewSession): string | undefined {
+  return session.endpointId || session.endpoint_id;
+}
+
+function fallbackTitle(directory: string): string {
+  return directory.split('/').filter(Boolean).pop() || directory;
+}
+
+function workspaceKey(workspaceId: string, endpointId?: string): string {
+  return `${endpointId || 'local'}::${workspaceId}`;
+}
+
+export function buildWorkspaceViewModels<TSession extends WorkspaceViewSession>(
+  workspaces: WorkspaceViewWorkspace[],
+  sessions: TSession[],
+  options: WorkspaceViewModelOptions = {},
+): WorkspaceWithSessions<TSession>[] {
+  const sessionsByWorkspace = new Map<string, TSession[]>();
+
+  for (const session of sessions) {
+    const key = workspaceKey(sessionWorkspaceId(session), sessionEndpointId(session));
+    const current = sessionsByWorkspace.get(key) || [];
+    current.push(session);
+    sessionsByWorkspace.set(key, current);
+  }
+
+  const result: WorkspaceWithSessions<TSession>[] = [];
+  const consumed = new Set<string>();
+
+  for (const workspace of workspaces) {
+    const key = workspaceKey(workspace.id, workspace.endpoint_id);
+    const workspaceSessions = sessionsByWorkspace.get(key) || [];
+    consumed.add(key);
+    result.push(toWorkspaceViewModel(workspace, workspaceSessions, options));
+  }
+
+  for (const session of sessions) {
+    const workspaceId = sessionWorkspaceId(session);
+    const endpointId = sessionEndpointId(session);
+    const key = workspaceKey(workspaceId, endpointId);
+    if (consumed.has(key)) {
+      continue;
+    }
+    consumed.add(key);
+    const workspaceSessions = sessionsByWorkspace.get(key) || [];
+    const directory = sessionDirectory(workspaceSessions[0] || session);
+    result.push(toWorkspaceViewModel({
+      id: workspaceId,
+      title: fallbackTitle(directory),
+      directory,
+      endpoint_id: endpointId,
+    }, workspaceSessions, options));
+  }
+
+  return result;
+}
+
+function toWorkspaceViewModel<TSession extends WorkspaceViewSession>(
+  workspace: WorkspaceViewWorkspace,
+  sessions: TSession[],
+  options: WorkspaceViewModelOptions,
+): WorkspaceWithSessions<TSession> {
+  const firstSessionId = sessions[0]?.id ?? null;
+  const requestedFocus = options.focusedSessionIdByWorkspace?.[workspace.id] || null;
+  const focusedSessionId = requestedFocus && sessions.some((session) => session.id === requestedFocus)
+    ? requestedFocus
+    : firstSessionId;
+
+  return {
+    id: workspace.id,
+    title: workspace.title,
+    directory: workspace.directory,
+    status: workspace.status,
+    endpointId: workspace.endpoint_id,
+    sessions,
+    firstSessionId,
+    focusedSessionId,
+  };
+}
+
+export function firstSessionIdForWorkspace<TSession extends WorkspaceViewSession>(
+  workspace: WorkspaceWithSessions<TSession> | undefined | null,
+): string | null {
+  return workspace?.firstSessionId ?? null;
+}

--- a/app/src/utils/workspaceViewModels.ts
+++ b/app/src/utils/workspaceViewModels.ts
@@ -15,6 +15,7 @@ export interface WorkspaceViewWorkspace {
   title: string;
   directory: string;
   status?: string;
+  endpointId?: string;
   endpoint_id?: string;
 }
 
@@ -45,6 +46,10 @@ function sessionEndpointId(session: WorkspaceViewSession): string | undefined {
   return session.endpointId || session.endpoint_id;
 }
 
+function workspaceEndpointId(workspace: WorkspaceViewWorkspace): string | undefined {
+  return workspace.endpointId || workspace.endpoint_id;
+}
+
 function fallbackTitle(directory: string): string {
   return directory.split('/').filter(Boolean).pop() || directory;
 }
@@ -59,19 +64,28 @@ export function buildWorkspaceViewModels<TSession extends WorkspaceViewSession>(
   options: WorkspaceViewModelOptions = {},
 ): WorkspaceWithSessions<TSession>[] {
   const sessionsByWorkspace = new Map<string, TSession[]>();
+  const sessionKeysByWorkspaceId = new Map<string, string[]>();
 
   for (const session of sessions) {
-    const key = workspaceKey(sessionWorkspaceId(session), sessionEndpointId(session));
+    const workspaceId = sessionWorkspaceId(session);
+    const key = workspaceKey(workspaceId, sessionEndpointId(session));
     const current = sessionsByWorkspace.get(key) || [];
     current.push(session);
     sessionsByWorkspace.set(key, current);
+    if (!sessionKeysByWorkspaceId.has(workspaceId)) {
+      sessionKeysByWorkspaceId.set(workspaceId, []);
+    }
+    const keys = sessionKeysByWorkspaceId.get(workspaceId)!;
+    if (!keys.includes(key)) {
+      keys.push(key);
+    }
   }
 
   const result: WorkspaceWithSessions<TSession>[] = [];
   const consumed = new Set<string>();
 
   for (const workspace of workspaces) {
-    const key = workspaceKey(workspace.id, workspace.endpoint_id);
+    const key = resolveWorkspaceSessionKey(workspace, sessionKeysByWorkspaceId, consumed);
     const workspaceSessions = sessionsByWorkspace.get(key) || [];
     consumed.add(key);
     result.push(toWorkspaceViewModel(workspace, workspaceSessions, options));
@@ -98,6 +112,20 @@ export function buildWorkspaceViewModels<TSession extends WorkspaceViewSession>(
   return result;
 }
 
+function resolveWorkspaceSessionKey(
+  workspace: WorkspaceViewWorkspace,
+  sessionKeysByWorkspaceId: Map<string, string[]>,
+  consumed: Set<string>,
+): string {
+  const endpointId = workspaceEndpointId(workspace);
+  if (endpointId) {
+    return workspaceKey(workspace.id, endpointId);
+  }
+  const unconsumedSessionKey = (sessionKeysByWorkspaceId.get(workspace.id) || [])
+    .find((key) => !consumed.has(key));
+  return unconsumedSessionKey || workspaceKey(workspace.id);
+}
+
 function toWorkspaceViewModel<TSession extends WorkspaceViewSession>(
   workspace: WorkspaceViewWorkspace,
   sessions: TSession[],
@@ -114,7 +142,7 @@ function toWorkspaceViewModel<TSession extends WorkspaceViewSession>(
     title: workspace.title,
     directory: workspace.directory,
     status: workspace.status,
-    endpointId: workspace.endpoint_id,
+    endpointId: workspaceEndpointId(workspace) || sessionEndpointId(sessions[0]),
     sessions,
     firstSessionId,
     focusedSessionId,

--- a/docs/plans/workspace-first-sidebar.md
+++ b/docs/plans/workspace-first-sidebar.md
@@ -1,0 +1,45 @@
+# Workspace-First Sidebar Sketch
+
+## Target
+
+The sidebar should make workspaces the top-level navigation unit. Selecting a
+workspace shows the whole workspace: every child session is rendered as a pane
+in the workspace layout. Selecting a child session focuses that pane without
+leaving the workspace.
+
+```text
+Sessions
+
+> fish                         # Workspace row, selected
+  ~/repo
+
+> attn                         # Workspace row
+  ~/projects/victor/attn
+  - exit          main         # Session row, focused
+  - attn          main
+  - fish          master
+
+> victor                       # Workspace row
+  ~
+  - victor        shell
+```
+
+## Behavior
+
+- `Cmd+1..9` selects workspaces by sidebar order, not sessions.
+- Selecting a workspace focuses its remembered child session, or its first
+  session when there is no remembered focus.
+- Creating a workspace always creates the initial session in the same flow.
+- Creating a session inside a workspace uses the workspace directory as cwd.
+- Closing a child session removes that pane from the workspace layout.
+- Closing the last session in a workspace closes the workspace.
+- Shell panes become full sessions with `agent = "shell"`.
+
+## Implementation Notes
+
+- The prep PR keeps the current session-first UI running while adding
+  workspace view models and selection helpers.
+- The implementation PR should make `activeWorkspaceId` primary and treat the
+  active session as the focused pane within the active workspace.
+- The workspace layout leaf should identify a session, not an anonymous
+  terminal runtime.

--- a/internal/protocol/helpers_test.go
+++ b/internal/protocol/helpers_test.go
@@ -43,3 +43,12 @@ func TestFormatPRID(t *testing.T) {
 		t.Fatalf("FormatPRID default host = %s", id)
 	}
 }
+
+func TestNormalizeSpawnAgentAcceptsShell(t *testing.T) {
+	if got := NormalizeSpawnAgent(" shell ", string(SessionAgentCodex)); got != AgentShellValue {
+		t.Fatalf("NormalizeSpawnAgent(shell) = %q, want %q", got, AgentShellValue)
+	}
+	if got := NormalizeSpawnAgent("", AgentShellValue); got != AgentShellValue {
+		t.Fatalf("NormalizeSpawnAgent fallback shell = %q, want %q", got, AgentShellValue)
+	}
+}

--- a/internal/store/workspacelayout.go
+++ b/internal/store/workspacelayout.go
@@ -157,6 +157,17 @@ func (s *Store) HasWorkspaceLayout(workspaceID string) bool {
 	return exists == 1
 }
 
+// ListWorkspaceLayoutPanes returns the persisted pane records for a workspace
+// without exposing the layout tree. This is a prep seam for moving layout
+// leaves from runtime-owned panes to session-owned panes.
+func (s *Store) ListWorkspaceLayoutPanes(workspaceID string) []workspacelayout.Pane {
+	snapshot := s.GetWorkspaceLayout(workspaceID)
+	if snapshot == nil || len(snapshot.Panes) == 0 {
+		return nil
+	}
+	return append([]workspacelayout.Pane(nil), snapshot.Panes...)
+}
+
 func (s *Store) FindWorkspaceLayoutPaneByRuntimeID(runtimeID string) (workspaceID string, paneID string, ok bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -181,6 +192,36 @@ func (s *Store) FindWorkspaceLayoutPaneByRuntimeID(runtimeID string) (workspaceI
 	if err != nil {
 		if err != sql.ErrNoRows {
 			log.Printf("[store] FindWorkspaceLayoutPaneByRuntimeID: query failed for runtime %s: %v", runtimeID, err)
+		}
+		return "", "", false
+	}
+	return rowWorkspaceID, rowPaneID, true
+}
+
+func (s *Store) FindWorkspaceLayoutPaneBySessionID(sessionID string) (workspaceID string, paneID string, ok bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		for workspaceID, snapshot := range s.workspaces {
+			for _, pane := range snapshot.Panes {
+				if pane.SessionID == sessionID {
+					return workspaceID, pane.PaneID, true
+				}
+			}
+		}
+		return "", "", false
+	}
+
+	var rowWorkspaceID, rowPaneID string
+	err := s.db.QueryRow(`
+		SELECT workspace_id, pane_id
+		FROM workspace_layout_panes
+		WHERE session_id = ?
+	`, sessionID).Scan(&rowWorkspaceID, &rowPaneID)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			log.Printf("[store] FindWorkspaceLayoutPaneBySessionID: query failed for session %s: %v", sessionID, err)
 		}
 		return "", "", false
 	}

--- a/internal/store/workspacelayout_test.go
+++ b/internal/store/workspacelayout_test.go
@@ -59,6 +59,20 @@ func TestWorkspaceSaveLoadRoundTrip(t *testing.T) {
 	if loaded.Layout.Type != "split" || len(loaded.Layout.Children) != 2 {
 		t.Fatalf("Layout = %+v, want split with 2 children", loaded.Layout)
 	}
+
+	panes := s.ListWorkspaceLayoutPanes("workspace-1")
+	if len(panes) != 2 {
+		t.Fatalf("ListWorkspaceLayoutPanes() len = %d, want 2", len(panes))
+	}
+	if panes[0].PaneID != workspacelayout.MainPaneID || panes[1].PaneID != "pane-b" {
+		t.Fatalf("ListWorkspaceLayoutPanes() = %+v, want stable pane order", panes)
+	}
+	if workspaceID, paneID, ok := s.FindWorkspaceLayoutPaneBySessionID("sess-1"); !ok || workspaceID != "workspace-1" || paneID != workspacelayout.MainPaneID {
+		t.Fatalf("FindWorkspaceLayoutPaneBySessionID() = (%q, %q, %v), want workspace-1/main/true", workspaceID, paneID, ok)
+	}
+	if workspaceID, paneID, ok := s.FindWorkspaceLayoutPaneByRuntimeID("runtime-b"); !ok || workspaceID != "workspace-1" || paneID != "pane-b" {
+		t.Fatalf("FindWorkspaceLayoutPaneByRuntimeID() = (%q, %q, %v), want workspace-1/pane-b/true", workspaceID, paneID, ok)
+	}
 }
 
 func TestRemoveWorkspaceDeletesLayoutRows(t *testing.T) {


### PR DESCRIPTION
## Summary
- add workspace-first frontend view-model and selection-controller prep helpers
- extract the workspace layout renderer from the current session terminal wrapper without behavior changes
- add backend workspace layout pane helper seams and shell-agent normalization coverage
- document the workspace-first sidebar target sketch

## Validation
- pnpm --dir app test -- workspaceViewModels useWorkspaceSelectionController SessionTerminalWorkspace
- pnpm --dir app build
- go test ./internal/store ./internal/workspacelayout ./internal/protocol ./internal/daemon

## Notes
This is the prep PR only. It does not change the runtime model, schema, or current sidebar behavior.