### PR TITLE
[codex] Handle empty git repo branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Codex Resize Redraws**: Attn now coalesces Codex's synchronized terminal redraws during pane resizes, preventing old scrollback from visibly streaming through the embedded terminal when layouts change.
+- **Empty Git Repositories**: Selecting an empty Git repository now loads repo metadata instead of failing while resolving the current branch.
 
 ---
 

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -164,9 +164,14 @@ func CreateBranch(repoDir, branch string) error {
 
 // GetCurrentBranch returns the current branch name for the repository.
 func GetCurrentBranch(repoDir string) (string, error) {
-	out, err := runGitOutput(OpMetadata, repoDir, "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := runGitOutput(OpMetadata, repoDir, "symbolic-ref", "--short", "HEAD")
+	if err == nil {
+		return strings.TrimSpace(string(out)), nil
+	}
+
+	out, err = runGitOutput(OpMetadata, repoDir, "rev-parse", "--short", "HEAD")
 	if err != nil {
-		return "", fmt.Errorf("git rev-parse failed: %w", err)
+		return "", fmt.Errorf("git current branch failed: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -58,6 +58,32 @@ func TestCheckoutRemoteBranch(t *testing.T) {
 	}
 }
 
+func TestGetCurrentBranchEmptyRepo(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+
+	branch, err := GetCurrentBranch(dir)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch failed: %v", err)
+	}
+	if branch != "main" {
+		t.Fatalf("expected main, got %q", branch)
+	}
+}
+
+func TestListBranchesWithCommitsEmptyRepo(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+
+	branches, err := ListBranchesWithCommits(dir)
+	if err != nil {
+		t.Fatalf("ListBranchesWithCommits failed: %v", err)
+	}
+	if len(branches) != 0 {
+		t.Fatalf("expected no committed branches, got %+v", branches)
+	}
+}
+
 func TestListBranchesWithCommits(t *testing.T) {
 	// Create temp directory with subdirectories for main repo and worktree
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary
- Resolve the current branch through symbolic-ref before falling back to detached HEAD SHA lookup.
- Add empty-repository coverage for branch metadata and branch listing.
- Document the user-visible fix in the changelog.

## Root Cause
The repo-info path used `git rev-parse --abbrev-ref HEAD`, which fails in a newly initialized repository before the first commit even though the unborn branch name is available from `git symbolic-ref --short HEAD`.

## Validation
- `go test ./internal/git`
- `go test ./internal/daemon`