### PR TITLE
Add confirmed force delete for worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Codex Resize Redraws**: Attn now coalesces Codex's synchronized terminal redraws during pane resizes, preventing old scrollback from visibly streaming through the embedded terminal when layouts change.
+- **Worktree Cleanup**: Failed worktree deletes now keep attn state intact, explain forceable local-change failures, and let you explicitly force-delete the local worktree and local branch without touching remotes.
 
 ---
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -646,7 +646,8 @@ sendFetchPRDetails,
     requestId: number | null;
     isDeleting: boolean;
     error: string | null;
-  }>({ requestId: null, isDeleting: false, error: null });
+    forceable: boolean;
+  }>({ requestId: null, isDeleting: false, error: null, forceable: false });
   const [pendingSessionClose, setPendingSessionClose] = useState<{
     id: string;
     label: string;
@@ -1268,7 +1269,7 @@ sendFetchPRDetails,
           // Show cleanup prompt
           const cleanupRequestId = cleanupRequestIdRef.current + 1;
           cleanupRequestIdRef.current = cleanupRequestId;
-          setWorktreeCleanupState({ requestId: cleanupRequestId, isDeleting: false, error: null });
+          setWorktreeCleanupState({ requestId: cleanupRequestId, isDeleting: false, error: null, forceable: false });
           setClosedWorktree({ id: cleanupRequestId, path: session.cwd, branch: session.branch });
         }
       }
@@ -1466,7 +1467,7 @@ sendFetchPRDetails,
 
   // Worktree cleanup prompt handlers
   const handleWorktreeKeep = useCallback(() => {
-    setWorktreeCleanupState({ requestId: null, isDeleting: false, error: null });
+    setWorktreeCleanupState({ requestId: null, isDeleting: false, error: null, forceable: false });
     setClosedWorktree(null);
   }, []);
 
@@ -1479,17 +1480,22 @@ sendFetchPRDetails,
       return;
     }
     const deleteTarget = closedWorktree;
+    const force = worktreeCleanupState.forceable;
     setWorktreeCleanupState((current) => (
       current.requestId === deleteTarget.id
-        ? { requestId: deleteTarget.id, isDeleting: true, error: null }
+        ? { requestId: deleteTarget.id, isDeleting: true, error: null, forceable: false }
         : current
     ));
     try {
-      await sendDeleteWorktree(deleteTarget.path);
+      if (force) {
+        await sendDeleteWorktree(deleteTarget.path, undefined, { force: true });
+      } else {
+        await sendDeleteWorktree(deleteTarget.path);
+      }
       // Note: Deleted paths are automatically filtered by daemon on next fetch
       setWorktreeCleanupState((current) => (
         current.requestId === deleteTarget.id
-          ? { requestId: null, isDeleting: false, error: null }
+          ? { requestId: null, isDeleting: false, error: null, forceable: false }
           : current
       ));
       setClosedWorktree((current) => (
@@ -1500,15 +1506,15 @@ sendFetchPRDetails,
       console.error('[App] Failed to delete worktree:', err);
       setWorktreeCleanupState((current) => (
         current.requestId === deleteTarget.id
-          ? { requestId: deleteTarget.id, isDeleting: false, error: message }
+          ? { requestId: deleteTarget.id, isDeleting: false, error: message, forceable: Boolean((err as { forceable?: boolean }).forceable) }
           : current
       ));
     }
-  }, [closedWorktree, sendDeleteWorktree, worktreeCleanupState.isDeleting, worktreeCleanupState.requestId]);
+  }, [closedWorktree, sendDeleteWorktree, worktreeCleanupState.forceable, worktreeCleanupState.isDeleting, worktreeCleanupState.requestId]);
 
   const handleWorktreeAlwaysKeep = useCallback(() => {
     setAlwaysKeepWorktrees(true);
-    setWorktreeCleanupState({ requestId: null, isDeleting: false, error: null });
+    setWorktreeCleanupState({ requestId: null, isDeleting: false, error: null, forceable: false });
     setClosedWorktree(null);
   }, []);
 
@@ -2283,6 +2289,7 @@ sendFetchPRDetails,
         branchName={closedWorktree?.branch}
         isDeleting={worktreeCleanupState.isDeleting}
         deleteError={worktreeCleanupState.error}
+        deleteForceable={worktreeCleanupState.forceable}
         onKeep={handleWorktreeKeep}
         onDelete={handleWorktreeDelete}
         onAlwaysKeep={handleWorktreeAlwaysKeep}

--- a/app/src/App.worktreeCleanup.test.tsx
+++ b/app/src/App.worktreeCleanup.test.tsx
@@ -421,6 +421,39 @@ describe('worktree cleanup prompt', () => {
     expect(screen.queryByText('/tmp/repo/.worktrees/feature-a')).not.toBeInTheDocument();
   });
 
+  it('retries cleanup delete with force after a forceable failure', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const forceableError = Object.assign(new Error('contains modified or untracked files'), {
+      forceable: true,
+    });
+    const sendDeleteWorktree = vi.fn((_path: string, _endpointId?: string, options?: { force?: boolean }) => {
+      if (!options?.force) {
+        return Promise.reject(forceableError);
+      }
+      return Promise.resolve({ success: true });
+    });
+    mockDaemonSocketReturn.sendDeleteWorktree = sendDeleteWorktree;
+
+    render(<App />);
+
+    await userEvent.click(screen.getByTestId('close-session'));
+    await waitFor(() => {
+      expect(screen.getByText('/tmp/repo/.worktrees/feature-a')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete worktree' }));
+
+    expect(await screen.findByRole('button', { name: 'Force delete' })).toBeInTheDocument();
+    expect(screen.getByText(/contains modified or untracked files/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Force delete' }));
+
+    await waitFor(() => {
+      expect(sendDeleteWorktree).toHaveBeenLastCalledWith('/tmp/repo/.worktrees/feature-a', undefined, { force: true });
+    });
+    consoleError.mockRestore();
+  });
+
   it('marks remote long-run sessions as visualized after the visibility delay', async () => {
     vi.useFakeTimers();
     const sendSessionVisualized = vi.fn();

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -69,7 +69,7 @@ interface LocationPickerProps {
   onInspectPath?: (path: string, endpointId?: string) => Promise<InspectPathResult>;
   onGetRepoInfo?: (mainRepo: string, endpointId?: string) => Promise<{ success: boolean; info?: BackendRepoInfo; error?: string }>;
   onCreateWorktree?: (mainRepo: string, branch: string, path?: string, startingFrom?: string, endpointId?: string) => Promise<{ success: boolean; path?: string; error?: string }>;
-  onDeleteWorktree?: (path: string, endpointId?: string) => Promise<{ success: boolean; error?: string }>;
+  onDeleteWorktree?: (path: string, endpointId?: string, options?: { force?: boolean }) => Promise<{ success: boolean; error?: string }>;
   onError?: (message: string) => void;
   projectsDirectory?: string;
   agentAvailability?: AgentAvailability;
@@ -988,9 +988,11 @@ export function LocationPicker({
             onSelectMainRepo={handleSelectMainRepo}
             onSelectWorktree={handleSelectWorktree}
             onCreateWorktree={handleCreateWorktree}
-            onDeleteWorktree={onDeleteWorktree ? async (path) => {
+            onDeleteWorktree={onDeleteWorktree ? async (path, options) => {
               const requestGeneration = requestGenerationRef.current;
-              const deleteResult = await onDeleteWorktree(path, selectedEndpointId);
+              const deleteResult = options
+                ? await onDeleteWorktree(path, selectedEndpointId, options)
+                : await onDeleteWorktree(path, selectedEndpointId);
               if (!deleteResult.success) {
                 throw new Error(deleteResult.error || 'Failed to delete worktree');
               }

--- a/app/src/components/NewSessionDialog/RepoOptions.css
+++ b/app/src/components/NewSessionDialog/RepoOptions.css
@@ -131,6 +131,16 @@
   color: #dc2626;
   font-weight: 500;
   grid-column: 1 / -1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.delete-prompt-detail {
+  color: #fca5a5;
+  font-size: var(--font-size-sm);
+  grid-column: 1 / -1;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 /* Icons */

--- a/app/src/components/NewSessionDialog/RepoOptions.test.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.test.tsx
@@ -309,4 +309,42 @@ describe('RepoOptions', () => {
       expect(screen.queryByRole('status', { name: 'Deleting repo--feature' })).not.toBeInTheDocument();
     });
   });
+
+  it('offers force delete after normal delete fails with a forceable error', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const error = Object.assign(new Error('contains modified or untracked files'), {
+      forceable: true,
+    });
+    const onDeleteWorktree = vi.fn(async (_path: string, options?: { force?: boolean }) => {
+      if (!options?.force) {
+        throw error;
+      }
+    });
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo--feature"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={vi.fn(async () => {})}
+        onDeleteWorktree={onDeleteWorktree}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'D' });
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'y' });
+
+    expect(await screen.findByText(/Delete failed: contains modified or untracked files/)).toBeInTheDocument();
+    expect(screen.getByText(/Force delete local worktree and branch/)).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'y' });
+
+    await waitFor(() => {
+      expect(onDeleteWorktree).toHaveBeenLastCalledWith('/tmp/repo--feature', { force: true });
+    });
+    consoleError.mockRestore();
+  });
 });

--- a/app/src/components/NewSessionDialog/RepoOptions.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.tsx
@@ -18,7 +18,7 @@ interface RepoOptionsProps {
   onSelectMainRepo: () => void;
   onSelectWorktree: (path: string) => void;
   onCreateWorktree: (branchName: string, startingFrom: string) => Promise<void>;
-  onDeleteWorktree?: (path: string) => Promise<void>;
+  onDeleteWorktree?: (path: string, options?: { force?: boolean }) => Promise<void>;
   onError?: (message: string) => void;
   onRefresh: () => void;
   onBack: () => void;
@@ -68,6 +68,16 @@ type DestinationItem =
       name: string;
       detail: string;
     };
+
+type DeleteFailure = {
+  path: string;
+  message: string;
+  forceable: boolean;
+};
+
+type ForceableError = Error & {
+  forceable?: boolean;
+};
 
 export const RepoOptions: React.FC<RepoOptionsProps> = ({
   repoInfo,
@@ -120,14 +130,18 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   const [newWorktreeName, setNewWorktreeName] = useState('');
   const [startingBranch, setStartingBranch] = useState<'current' | 'default'>('current');
   const [pendingDeletePath, setPendingDeletePath] = useState<string | null>(null);
+  const [deleteFailure, setDeleteFailure] = useState<DeleteFailure | null>(null);
   const [creatingWorktree, setCreatingWorktree] = useState(false);
   const [deletingPath, setDeletingPath] = useState<string | null>(null);
   const isBusy = creatingWorktree || deletingPath !== null;
 
   // Sub-state Escape handling via the stack so LIFO order is preserved.
   // pendingDeletePath and showNewWorktree are pushed above LocationPicker's handler.
-  const cancelPendingDelete = useCallback(() => setPendingDeletePath(null), []);
-  useEscapeStack(cancelPendingDelete, pendingDeletePath !== null);
+  const cancelPendingDelete = useCallback(() => {
+    setPendingDeletePath(null);
+    setDeleteFailure(null);
+  }, []);
+  useEscapeStack(cancelPendingDelete, pendingDeletePath !== null || deleteFailure !== null);
 
   const cancelNewWorktree = useCallback(() => {
     setShowNewWorktree(false);
@@ -138,6 +152,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
 
   useEffect(() => {
     setPendingDeletePath(null);
+    setDeleteFailure(null);
     setFocusIndex((prev) => {
       if (showNewWorktree || prev === createWorktreeIndex) {
         return prev;
@@ -160,8 +175,9 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   }, [pendingDeletePath]);
 
   useEffect(() => {
-    const activeIndex = pendingDeletePath
-      ? destinationItems.findIndex((item) => item.path === pendingDeletePath)
+    const activeDeletePath = pendingDeletePath || deleteFailure?.path || null;
+    const activeIndex = activeDeletePath
+      ? destinationItems.findIndex((item) => item.path === activeDeletePath)
       : committedDestinationIndex;
     if (activeIndex < 0) {
       return;
@@ -169,7 +185,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
     destinationListRef.current
       ?.querySelector<HTMLElement>(`[data-option-index="${activeIndex}"]`)
       ?.scrollIntoView({ block: 'nearest' });
-  }, [committedDestinationIndex, destinationItems, pendingDeletePath]);
+  }, [committedDestinationIndex, deleteFailure, destinationItems, pendingDeletePath]);
 
   const focusedDestination = focusIndex >= 0 && focusIndex < destinationItems.length
     ? destinationItems[focusIndex]
@@ -194,6 +210,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
       return;
     }
     setPendingDeletePath(null);
+    setDeleteFailure(null);
     setFocusIndex(createWorktreeIndex);
     setShowNewWorktree(true);
   }, [createWorktreeIndex, isBusy]);
@@ -204,6 +221,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
     }
     setShowNewWorktree(false);
     setNewWorktreeName('');
+    setDeleteFailure(null);
     setPendingDeletePath(path);
   }, [isBusy]);
 
@@ -224,30 +242,40 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
     openNewWorktree();
   }, [destinationItems, isBusy, onSelectMainRepo, onSelectWorktree, onSelectedPathChange, openNewWorktree]);
 
-  const executeDelete = useCallback(async () => {
-    if (!pendingDeletePath || !onDeleteWorktree || deletingPath) {
+  const executeDelete = useCallback(async (force = false) => {
+    const targetPath = force ? deleteFailure?.path : pendingDeletePath;
+    if (!targetPath || !onDeleteWorktree || deletingPath) {
       return;
     }
 
-    const pathToDelete = pendingDeletePath;
-    const deletedIndex = destinationItems.findIndex((item) => item.path === pendingDeletePath);
-    const survivingItems = destinationItems.filter((item) => item.path !== pendingDeletePath);
+    const pathToDelete = targetPath;
+    const deletedIndex = destinationItems.findIndex((item) => item.path === pathToDelete);
+    const survivingItems = destinationItems.filter((item) => item.path !== pathToDelete);
     const nextSelectedPath = survivingItems[Math.min(deletedIndex, survivingItems.length - 1)]?.path || repoInfo.repo;
 
     try {
       setDeletingPath(pathToDelete);
       setPendingDeletePath(null);
-      await onDeleteWorktree(pathToDelete);
+      setDeleteFailure(null);
+      await onDeleteWorktree(pathToDelete, force ? { force: true } : undefined);
       onSelectedPathChange(nextSelectedPath);
       setFocusIndex(Math.min(deletedIndex, survivingItems.length - 1));
     } catch (err) {
       console.error('Delete failed:', err);
-      onError?.(err instanceof Error ? err.message : 'Delete failed');
+      const message = err instanceof Error ? err.message : 'Delete failed';
+      if (!force && (err as ForceableError)?.forceable) {
+        setDeleteFailure({ path: pathToDelete, message, forceable: true });
+      } else {
+        onError?.(message);
+        if (force) {
+          setDeleteFailure({ path: pathToDelete, message, forceable: false });
+        }
+      }
     } finally {
       setDeletingPath(null);
       setPendingDeletePath(null);
     }
-  }, [deletingPath, destinationItems, onDeleteWorktree, onError, onSelectedPathChange, pendingDeletePath, repoInfo.repo]);
+  }, [deleteFailure, deletingPath, destinationItems, onDeleteWorktree, onError, onSelectedPathChange, pendingDeletePath, repoInfo.repo]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if (isBusy) {
@@ -256,10 +284,24 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
       return;
     }
 
+    if (deleteFailure) {
+      e.stopPropagation();
+      if ((e.key === 'y' || e.key === 'Y') && deleteFailure.forceable) {
+        void executeDelete(true);
+        e.preventDefault();
+      } else if (e.key === 'n' || e.key === 'N' || e.key === 'Escape') {
+        setDeleteFailure(null);
+        e.preventDefault();
+      } else {
+        setDeleteFailure(null);
+      }
+      return;
+    }
+
     if (pendingDeletePath) {
       e.stopPropagation();
       if (e.key === 'y' || e.key === 'Y') {
-        void executeDelete();
+        void executeDelete(false);
         e.preventDefault();
       } else if (e.key === 'n' || e.key === 'N' || e.key === 'Escape') {
         setPendingDeletePath(null);
@@ -374,6 +416,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
     onRefresh,
     openNewWorktree,
     pendingDeletePath,
+    deleteFailure,
     repoInfo.currentBranch,
     repoInfo.defaultBranch,
     committedDestinationIndex,
@@ -384,6 +427,7 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   const renderDestination = (itemIndex: number, item: DestinationItem) => {
     const isSelected = committedDestinationIndex === itemIndex;
     const isDeleting = pendingDeletePath === item.path;
+    const failedDelete = deleteFailure?.path === item.path ? deleteFailure : null;
     const isDeleteRunning = deletingPath === item.path;
 
     if (isDeleteRunning) {
@@ -400,6 +444,19 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
       return (
         <div className="repo-option-item selected delete-confirm">
           <span className="delete-prompt">Delete {baseName(item.path)}? (y/n)</span>
+        </div>
+      );
+    }
+
+    if (failedDelete) {
+      return (
+        <div className="repo-option-item selected delete-confirm delete-failed">
+          <span className="delete-prompt">
+            Delete failed: {failedDelete.message}
+          </span>
+          <span className="delete-prompt-detail">
+            {failedDelete.forceable ? 'Force delete local worktree and branch? (y/n)' : 'Press Esc to dismiss'}
+          </span>
         </div>
       );
     }

--- a/app/src/components/WorktreeCleanupPrompt.tsx
+++ b/app/src/components/WorktreeCleanupPrompt.tsx
@@ -10,6 +10,7 @@ interface WorktreeCleanupPromptProps {
   branchName?: string;
   isDeleting?: boolean;
   deleteError?: string | null;
+  deleteForceable?: boolean;
   onKeep: () => void;
   onDelete: () => void;
   onAlwaysKeep: () => void;
@@ -21,6 +22,7 @@ export function WorktreeCleanupPrompt({
   branchName,
   isDeleting = false,
   deleteError = null,
+  deleteForceable = false,
   onKeep,
   onDelete,
   onAlwaysKeep,
@@ -291,7 +293,7 @@ export function WorktreeCleanupPrompt({
   if (!isVisible) return null;
 
   const dialogTitle = hasError
-    ? 'Worktree was not deleted'
+    ? deleteForceable ? 'Force delete this worktree?' : 'Worktree was not deleted'
     : isDeleting
       ? 'Deleting worktree'
       : 'Keep this worktree for later?';
@@ -335,6 +337,9 @@ export function WorktreeCleanupPrompt({
               <div className={`cleanup-operation ${hasError ? 'failed' : ''}`} role={isDeleting ? 'status' : 'alert'}>
                 <span className="cleanup-operation-label">{hasError ? 'Delete failed' : 'Removing worktree'}</span>
                 <span className="cleanup-operation-detail">{statusCopy}</span>
+                {hasError && deleteForceable && (
+                  <span className="cleanup-operation-detail">This removes the local folder and local branch. Remote branches are untouched.</span>
+                )}
                 {isDeleting && <span className="cleanup-meter" aria-hidden="true"><span /></span>}
               </div>
             )}
@@ -350,7 +355,7 @@ export function WorktreeCleanupPrompt({
             onClick={onDelete}
               disabled={isDeleting}
           >
-            {hasError ? 'Retry delete' : 'Delete worktree'}
+            {hasError ? deleteForceable ? 'Force delete' : 'Retry delete' : 'Delete worktree'}
           </button>
           <button
             ref={alwaysRef}

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -256,6 +256,78 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     unmount();
   });
 
+  it('sends force option for delete worktree requests', async () => {
+    const { result, unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+
+    const promise = result.current.sendDeleteWorktree('/tmp/repo--feature', undefined, { force: true });
+
+    await waitFor(() => {
+      expect(JSON.parse(ws.sent[ws.sent.length - 1])).toMatchObject({
+        cmd: 'delete_worktree',
+        path: '/tmp/repo--feature',
+        force: true,
+      });
+    });
+
+    act(() => {
+      ws.emit({
+        event: 'delete_worktree_result',
+        path: '/tmp/repo--feature',
+        success: true,
+      });
+    });
+
+    await expect(promise).resolves.toMatchObject({ success: true });
+
+    unmount();
+  });
+
+  it('preserves forceable delete worktree failure details on rejection', async () => {
+    const { result, unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+    const promise = result.current.sendDeleteWorktree('/tmp/repo--feature');
+
+    act(() => {
+      ws.emit({
+        event: 'delete_worktree_result',
+        path: '/tmp/repo--feature',
+        success: false,
+        error: 'contains modified or untracked files',
+        forceable: true,
+        reason_kind: 'dirty_worktree',
+      });
+    });
+
+    await expect(promise).rejects.toMatchObject({
+      message: 'contains modified or untracked files',
+      forceable: true,
+      reason_kind: 'dirty_worktree',
+    });
+
+    unmount();
+  });
+
   it('rejects answerReviewLoop immediately when error result only echoes loop_id', async () => {
     const { result, unmount } = renderHook(() =>
       useDaemonSocket({
@@ -525,7 +597,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '67',
+        protocol_version: '68',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -607,7 +679,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '67',
+        protocol_version: '68',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -742,7 +814,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '67',
+        protocol_version: '68',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -835,7 +907,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '67',
+        protocol_version: '68',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -932,7 +1004,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '67',
+        protocol_version: '68',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1015,7 +1087,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '67',
+        protocol_version: '68',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -1130,7 +1202,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '67',
+        protocol_version: '68',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -1197,7 +1269,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '67',
+        protocol_version: '68',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -153,7 +153,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '67';
+const PROTOCOL_VERSION = '68';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 // Runtime gate (flipped from VITE_UI_AUTOMATION). The Rust shell
 // injects this global before any page script runs — see
@@ -223,7 +223,18 @@ interface WorktreeActionResult {
   path?: string;
   endpoint_id?: string;
   error?: string;
+  forceable?: boolean;
+  reason_kind?: string;
 }
+
+export type DeleteWorktreeOptions = {
+  force?: boolean;
+};
+
+export type WorktreeActionError = Error & {
+  forceable?: boolean;
+  reason_kind?: string;
+};
 
 interface PluginActionResult {
   success: boolean;
@@ -1718,7 +1729,10 @@ export function useDaemonSocket({
               if (data.success) {
                 pendingAction.resolve({ success: true, path: data.path, endpoint_id: data.endpoint_id });
               } else {
-                pendingAction.reject(new Error(data.error || 'Worktree action failed'));
+                const error = new Error(data.error || 'Worktree action failed') as WorktreeActionError;
+                error.forceable = data.forceable;
+                error.reason_kind = data.reason_kind;
+                pendingAction.reject(error);
               }
             }
             break;
@@ -2734,7 +2748,7 @@ export function useDaemonSocket({
     });
   }, []);
 
-  const sendDeleteWorktree = useCallback((path: string, endpointId?: string): Promise<WorktreeActionResult> => {
+  const sendDeleteWorktree = useCallback((path: string, endpointId?: string, options: DeleteWorktreeOptions = {}): Promise<WorktreeActionResult> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -2756,6 +2770,7 @@ export function useDaemonSocket({
         cmd: 'delete_worktree',
         path,
         ...(endpointId && { endpoint_id: endpointId }),
+        ...(options.force && { force: true }),
       }));
     });
   }, []);

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -612,6 +612,7 @@ export enum DeleteCommentResultMessageEvent {
 export interface DeleteWorktreeMessage {
     cmd:          GitOperationKind;
     endpoint_id?: string;
+    force?:       boolean;
     path:         string;
     [property: string]: any;
 }
@@ -624,13 +625,22 @@ export interface DeleteWorktreeResultMessage {
     endpoint_id?: string;
     error?:       string;
     event:        DeleteWorktreeResultMessageEvent;
+    forceable?:   boolean;
     path:         string;
+    reason_kind?: ReasonKind;
     success:      boolean;
     [property: string]: any;
 }
 
 export enum DeleteWorktreeResultMessageEvent {
     DeleteWorktreeResult = "delete_worktree_result",
+}
+
+export enum ReasonKind {
+    DirtyWorktree = "dirty_worktree",
+    GitError = "git_error",
+    NotFound = "not_found",
+    ProviderError = "provider_error",
 }
 
 export interface DetachSessionMessage {
@@ -4592,13 +4602,16 @@ const typeMap: any = {
     "DeleteWorktreeMessage": o([
         { json: "cmd", js: "cmd", typ: r("GitOperationKind") },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
+        { json: "force", js: "force", typ: u(undefined, true) },
         { json: "path", js: "path", typ: "" },
     ], "any"),
     "DeleteWorktreeResultMessage": o([
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("DeleteWorktreeResultMessageEvent") },
+        { json: "forceable", js: "forceable", typ: u(undefined, true) },
         { json: "path", js: "path", typ: "" },
+        { json: "reason_kind", js: "reason_kind", typ: u(undefined, r("ReasonKind")) },
         { json: "success", js: "success", typ: true },
     ], "any"),
     "DetachSessionMessage": o([
@@ -5866,6 +5879,12 @@ const typeMap: any = {
     ],
     "DeleteWorktreeResultMessageEvent": [
         "delete_worktree_result",
+    ],
+    "ReasonKind": [
+        "dirty_worktree",
+        "git_error",
+        "not_found",
+        "provider_error",
     ],
     "DetachSessionMessageCmd": [
         "detach_session",

--- a/docs/plans/2026-05-30-confirmed-worktree-delete.md
+++ b/docs/plans/2026-05-30-confirmed-worktree-delete.md
@@ -95,7 +95,14 @@ The first user confirmation authorizes a normal delete only. The second confirma
 - [x] Update frontend confirmation UI.
 - [x] Add backend and frontend tests.
 - [x] Run focused Go and frontend verification.
-- [ ] Run real-app/manual verification.
+- [x] Run real-app/manual verification.
+- [x] Open PR, resolve merge conflict with `main`, pass CI, and receive required review.
+
+## Outcome
+
+PR: https://github.com/victorarias/attn/pull/239
+
+Status: ready to merge. CI passed, `figgyster` approved, Codex review returned `+1`, and there are no inline review comments.
 
 ## Decisions
 

--- a/docs/plans/2026-05-30-confirmed-worktree-delete.md
+++ b/docs/plans/2026-05-30-confirmed-worktree-delete.md
@@ -1,0 +1,138 @@
+# Plan: Confirmed Worktree Delete
+
+## Goal
+
+Make worktree deletion reliable when the worktree has local changes, while keeping the destructive path explicit. The usual flow should stay lightweight: the user confirms a normal delete, attn tries it, and only if that fails does attn show the concrete reason and offer a force delete. If the user confirms force, attn deletes the worktree folder and local branch. Remote refs are never deleted.
+
+## Current Understanding
+
+- Worktree deletion is initiated from the new-session `LocationPicker` / `RepoOptions` flow and from the post-session `WorktreeCleanupPrompt`.
+- `RepoOptions` currently has a compact inline `Delete <name>? (y/n)` prompt, then calls `sendDeleteWorktree(path)`.
+- `WorktreeCleanupPrompt` already frames deletion as a user choice, but failed deletion only exposes the raw error and retry uses the same non-force path.
+- `sendDeleteWorktree` sends `delete_worktree` over websocket and waits for `delete_worktree_result`.
+- `internal/daemon.doDeleteWorktree` currently stops sessions in that directory before asking any `worktree.delete` plugin provider or calling `git.DeleteWorktree(mainRepo, path)`.
+- `internal/git.DeleteWorktree` uses `git worktree remove <path>` without `--force`, so dirty worktrees fail before `finalizeDeletedWorktree` can remove the local branch.
+- `finalizeDeletedWorktree` already deletes the local branch with `git branch -D`; it logs branch delete failure but does not fail the whole worktree deletion.
+- Worktree provider plugins receive `main_repo`, `path`, and `branch`; they do not currently know whether the user confirmed a force delete.
+
+## Components
+
+- `internal/protocol/schema/main.tsp`: add protocol shape for force deletion and structured delete failure details, then regenerate Go/TS protocol files.
+- `internal/git/worktree.go`: support non-force and force worktree removal.
+- `internal/daemon/worktree.go`: thread force options through deletion, move provider/built-in deletion before irreversible attn session/store cleanup, and preserve store/broadcast behavior after successful deletion.
+- `internal/daemon/plugin_worktree.go` and `sdk/plugin/src/index.ts`: include a `force` boolean for `worktree.delete` provider calls.
+- `app/src/hooks/useDaemonSocket.ts`: expose `sendDeleteWorktree(path, endpointId?, { force })` and structured failure details from `delete_worktree_result`.
+- `app/src/components/NewSessionDialog/RepoOptions.tsx`: keep the terse inline normal-delete prompt, then show a force option only after a failed normal delete explains why it failed.
+- `app/src/components/WorktreeCleanupPrompt.tsx` and its handler in `App.tsx`: after normal delete failure, show the reason and let retry send `force: true`.
+
+## Code Shape
+
+```text
+User presses delete
+  -> existing inline prompt asks Delete <name>? (y/n)
+  -> user confirms normal delete
+    -> UI sends delete_worktree { path }
+    -> daemon discovers worktree
+    -> daemon dispatches worktree.delete provider with force=false
+      -> if provider handles deletion, validate and finalize
+      -> if provider errors, return failure; do not fall back to built-in force
+    -> built-in fallback runs git worktree remove <path>
+  -> if normal delete fails
+    -> daemon returns delete_worktree_result with reason and forceable=true when appropriate
+    -> UI keeps the row lightweight but shows the reason and offers Force delete / cancel
+  -> user confirms force delete
+    -> UI sends delete_worktree { path, force: true }
+    -> daemon dispatches worktree.delete provider with force=true
+      -> if provider handles deletion, validate and finalize
+      -> if provider errors, return failure; respect the plugin
+    -> built-in fallback runs git worktree remove --force <path>
+  -> after successful provider or built-in deletion
+    -> daemon stops/removes attn sessions in that directory
+    -> daemon removes registry row and git branch -D <branch>
+    -> daemon broadcasts worktree_deleted and sessions_updated
+```
+
+Suggested structured delete failure shape:
+
+```ts
+type DeleteWorktreeResultMessage = {
+  event: "delete_worktree_result";
+  path: string;
+  endpoint_id?: string;
+  success: boolean;
+  error?: string;
+  forceable?: boolean;
+  reason_kind?: "dirty_worktree" | "provider_error" | "not_found" | "git_error";
+};
+```
+
+The first user confirmation authorizes a normal delete only. The second confirmation, shown only after a failed normal delete, authorizes `force: true`.
+
+## Approach
+
+- Add `force?: boolean` to `DeleteWorktreeMessage`.
+- Add structured fields to `DeleteWorktreeResultMessage` so the UI can distinguish forceable dirty-worktree failures from provider errors and other hard failures.
+- Implement `git.DeleteWorktree(repoDir, path, force)` with `git worktree remove --force <path>` only when requested. Keep prune behavior for missing directories.
+- Change `doDeleteWorktree` to accept an options struct, including `Force bool`, and pass that into provider dispatch and the built-in git delete fallback.
+- Keep local branch deletion as-is: after the worktree is gone, delete the local branch with `git branch -D`; do not touch remotes.
+- Have provider plugins receive `force` so custom deletion policies can honor the same user confirmation. If a plugin claims the delete and fails, attn should return that failure instead of bypassing the plugin with built-in deletion.
+- Move deletion before irreversible attn cleanup:
+  - Discover the worktree and branch first.
+  - Dispatch the plugin provider before stopping/removing sessions.
+  - If no provider handles it, run built-in git delete.
+  - Only after deletion succeeds, stop/remove attn sessions, remove the store row, delete the local branch, and broadcast.
+- In `RepoOptions`, preserve the current inline normal-delete prompt. On normal delete failure, replace that row with compact failure copy plus `Force delete` and cancel options.
+- In `WorktreeCleanupPrompt`, keep the first delete as normal delete. On failure, show the reason and make retry an explicit force-delete action when the failure is forceable.
+- Preserve the existing operation-running state and refresh of repo options after deletion.
+
+## Progress
+
+- [x] Identify current deletion flow and failure point.
+- [x] Draft implementation plan.
+- [x] Add protocol changes and regenerate generated files.
+- [x] Implement git/daemon force delete and structured failure support.
+- [x] Update plugin delete params and SDK types.
+- [x] Update frontend confirmation UI.
+- [x] Add backend and frontend tests.
+- [x] Run focused Go and frontend verification.
+- [ ] Run real-app/manual verification.
+
+## Decisions
+
+- Decision: Force deletion should require an explicit confirmed request from the UI.
+  Reason: Dirty worktree deletion is destructive; a plain delete action should attempt normal deletion first, then let the user opt into force after seeing the failure reason.
+
+- Decision: Keep the lightweight inline delete UX and add the force option only after normal deletion fails.
+  Reason: The inline prompt is intentional and keeps the picker fast; forcing should be a recovery path, not the first confirmation path.
+
+- Decision: Respect worktree delete providers before attn tears down local session state.
+  Reason: Plugins may own custom deletion policy. If they fail, the delete fails and attn should not have already removed sessions or local tracking.
+
+- Decision: Keep remote refs out of scope.
+  Reason: Victor wants local cleanup only: folder, worktree metadata, and local branch.
+
+## Tests
+
+- Go:
+  - `internal/git`: non-force delete fails on dirty worktree; force delete succeeds and removes worktree metadata.
+  - `internal/daemon`: failed normal delete leaves sessions, store rows, and branch intact.
+  - `internal/daemon`: `doDeleteWorktree(...Force: true)` removes dirty worktree, then removes attn sessions, deletes local branch, broadcasts lifecycle events, and does not call remote-delete git operations.
+  - `internal/daemon`: provider delete receives `force=false` on normal delete and `force=true` on force retry.
+  - `internal/daemon`: provider failure leaves sessions/state intact and does not fall back to built-in delete.
+  - Protocol parse/dispatch tests for the new result fields and `force` field.
+- Frontend:
+  - `RepoOptions` keeps normal inline confirmation, renders failed-delete reason, supports cancel, and sends force flag only from the force action.
+  - `LocationPicker` passes endpoint id and force option through.
+  - `WorktreeCleanupPrompt` first attempts normal delete, then shows failed-delete reason and retries with force only after explicit action.
+- Manual:
+  - Use dev install, create a worktree with unstaged and untracked files, delete from the picker, confirm normal delete, see the failure reason, force delete, and verify the folder and local branch are gone.
+  - Repeat from the post-session cleanup prompt.
+  - Verify remote branch still exists when the local branch tracked a remote.
+
+## Open Questions
+
+- Should failed dirty-worktree copy include a small sample of file names, or is Git's failure reason enough? A count plus first few paths would be useful if we can get it cheaply from a one-shot status after failure.
+
+## Follow-ups
+
+- Consider a reusable destructive-confirmation component if more local cleanup flows need the same preview/confirm pattern later.

--- a/internal/daemon/plugin_worktree.go
+++ b/internal/daemon/plugin_worktree.go
@@ -39,6 +39,7 @@ type worktreeDeleteProviderParams struct {
 	MainRepo string `json:"main_repo"`
 	Path     string `json:"path"`
 	Branch   string `json:"branch,omitempty"`
+	Force    bool   `json:"force"`
 }
 
 type worktreeDeleteProviderResult struct {
@@ -141,7 +142,7 @@ func (d *Daemon) dispatchWorktreeCreateProvider(mainRepo, branch, startingFrom, 
 	return "", "", false, nil
 }
 
-func (d *Daemon) dispatchWorktreeDeleteProvider(mainRepo, path, branch string) (bool, error) {
+func (d *Daemon) dispatchWorktreeDeleteProvider(mainRepo, path, branch string, force bool) (bool, error) {
 	providers := d.ensurePluginRegistry().handlersForSurface(worktreeDeleteProviderSurface)
 	if len(providers) == 0 {
 		return false, nil
@@ -151,6 +152,7 @@ func (d *Daemon) dispatchWorktreeDeleteProvider(mainRepo, path, branch string) (
 		MainRepo: mainRepo,
 		Path:     path,
 		Branch:   branch,
+		Force:    force,
 	}
 	for _, provider := range providers {
 		var result worktreeDeleteProviderResult

--- a/internal/daemon/plugin_worktree_test.go
+++ b/internal/daemon/plugin_worktree_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -421,13 +422,16 @@ func TestDoDeleteWorktree_ProviderHandledFinalizesDaemonState(t *testing.T) {
 		if params.Branch != "feat/provider-delete" {
 			t.Fatalf("provider delete branch=%q, want feat/provider-delete", params.Branch)
 		}
-		if err := git.DeleteWorktree(mainDir, worktreePath); err != nil {
+		if !params.Force {
+			t.Fatalf("provider delete force=false, want true")
+		}
+		if err := git.DeleteWorktree(mainDir, worktreePath, params.Force); err != nil {
 			t.Fatalf("provider delete worktree failed: %v", err)
 		}
 		return worktreeDeleteProviderResult{Status: providerStatusHandled}
 	})
 
-	if err := d.doDeleteWorktree(worktreePath, nil); err != nil {
+	if err := d.doDeleteWorktree(worktreePath, nil, deleteWorktreeOptions{Force: true}); err != nil {
 		t.Fatalf("doDeleteWorktree failed: %v", err)
 	}
 	waitForProviderResponse(t, responseDone)
@@ -474,10 +478,13 @@ func TestDoDeleteWorktree_ProviderDeclineFallsBackToBuiltInGit(t *testing.T) {
 		if params.Path != worktreePath {
 			t.Fatalf("provider delete path=%q, want %q", params.Path, worktreePath)
 		}
+		if params.Force {
+			t.Fatal("provider delete force=true, want false")
+		}
 		return worktreeDeleteProviderResult{Status: providerStatusDecline}
 	})
 
-	if err := d.doDeleteWorktree(worktreePath, nil); err != nil {
+	if err := d.doDeleteWorktree(worktreePath, nil, deleteWorktreeOptions{}); err != nil {
 		t.Fatalf("doDeleteWorktree fallback failed: %v", err)
 	}
 	waitForProviderResponse(t, responseDone)
@@ -495,6 +502,63 @@ func TestDoDeleteWorktree_ProviderDeclineFallsBackToBuiltInGit(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("declining delete provider connection did not close")
+	}
+}
+
+func TestDoDeleteWorktree_ProviderErrorPreservesDaemonState(t *testing.T) {
+	tmpDir, mainDir := initProviderTestRepo(t)
+	worktreePath := filepath.Join(tmpDir, "provider-error-delete")
+	runGitDaemon(t, mainDir, "worktree", "add", "-b", "feat/provider-error-delete", worktreePath)
+	worktreePath = git.CanonicalizePath(worktreePath)
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	d.registerCreatedWorktree(mainDir, worktreePath, "feat/provider-error-delete")
+
+	client, done := startPluginPipe(t, d, "failing-delete-provider", []string{worktreeDeleteProviderSurface})
+	defer client.Close()
+
+	responseDone := respondToDeleteProviderCall(t, client, func(params worktreeDeleteProviderParams) worktreeDeleteProviderResult {
+		if !params.Force {
+			t.Fatal("provider delete force=false, want true")
+		}
+		return worktreeDeleteProviderResult{Status: providerStatusError, Error: "custom policy failed"}
+	})
+
+	err := d.doDeleteWorktree(worktreePath, nil, deleteWorktreeOptions{Force: true})
+	if err == nil {
+		t.Fatal("doDeleteWorktree succeeded after provider error")
+	}
+	waitForProviderResponse(t, responseDone)
+
+	var deleteErr *deleteWorktreeError
+	if !errors.As(err, &deleteErr) {
+		t.Fatalf("error type = %T, want *deleteWorktreeError", err)
+	}
+	if deleteErr.kind != deleteWorktreeFailureProviderError || deleteErr.forceable {
+		t.Fatalf("delete error kind=%q forceable=%v, want provider non-forceable", deleteErr.kind, deleteErr.forceable)
+	}
+	if wt := d.store.GetWorktree(worktreePath); wt == nil {
+		t.Fatal("provider failure removed worktree from store")
+	}
+	worktrees, listErr := git.ListWorktrees(mainDir)
+	if listErr != nil {
+		t.Fatalf("list worktrees after provider error: %v", listErr)
+	}
+	var found bool
+	for _, worktree := range worktrees {
+		if worktree.Path == worktreePath {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("provider failure removed git worktree")
+	}
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("failing delete provider connection did not close")
 	}
 }
 

--- a/internal/daemon/worktree.go
+++ b/internal/daemon/worktree.go
@@ -2,6 +2,7 @@
 package daemon
 
 import (
+	"errors"
 	"net"
 	"os"
 	"slices"
@@ -206,27 +207,40 @@ func (d *Daemon) discoverWorktree(path string) *store.Worktree {
 	return nil
 }
 
+type deleteWorktreeOptions struct {
+	Force bool
+}
+
+type deleteWorktreeFailureKind string
+
+const (
+	deleteWorktreeFailureDirtyWorktree deleteWorktreeFailureKind = "dirty_worktree"
+	deleteWorktreeFailureProviderError deleteWorktreeFailureKind = "provider_error"
+	deleteWorktreeFailureNotFound      deleteWorktreeFailureKind = "not_found"
+	deleteWorktreeFailureGitError      deleteWorktreeFailureKind = "git_error"
+)
+
+type deleteWorktreeError struct {
+	err       error
+	kind      deleteWorktreeFailureKind
+	forceable bool
+}
+
+func (e *deleteWorktreeError) Error() string {
+	return e.err.Error()
+}
+
+func (e *deleteWorktreeError) Unwrap() error {
+	return e.err
+}
+
 // doDeleteWorktree removes a worktree from git and the store.
-// Also cleans up any sessions in that directory.
-func (d *Daemon) doDeleteWorktree(path string, endpointID *string) (err error) {
+// Also cleans up any sessions in that directory after external deletion succeeds.
+func (d *Daemon) doDeleteWorktree(path string, endpointID *string, opts deleteWorktreeOptions) (err error) {
 	finishOperation := d.beginGitOperation(protocol.GitOperationKindDeleteWorktree, path, endpointID)
 	defer func() {
 		finishOperation(err)
 	}()
-
-	// Stop/remove sessions in this directory before deleting the worktree.
-	for _, session := range d.store.List("") {
-		if session.Directory != path {
-			continue
-		}
-		d.terminateSession(session.ID, syscall.SIGTERM)
-		d.store.Remove(session.ID)
-		d.clearLongRunTracking(session.ID)
-		d.wsHub.Broadcast(&protocol.WebSocketEvent{
-			Event:   protocol.EventSessionUnregistered,
-			Session: d.sessionForBroadcast(session),
-		})
-	}
 
 	wt := d.store.GetWorktree(path)
 	if wt == nil {
@@ -244,9 +258,13 @@ func (d *Daemon) doDeleteWorktree(path string, endpointID *string) (err error) {
 						Path: path,
 					}},
 				})
+				d.cleanupDeletedWorktreeSessions(path)
 				return nil
 			}
-			return &worktreeNotFoundError{path: path}
+			return &deleteWorktreeError{
+				err:  &worktreeNotFoundError{path: path},
+				kind: deleteWorktreeFailureNotFound,
+			}
 		}
 	}
 
@@ -254,13 +272,16 @@ func (d *Daemon) doDeleteWorktree(path string, endpointID *string) (err error) {
 	branch := wt.Branch
 	mainRepo := wt.MainRepo
 
-	handled, err := d.dispatchWorktreeDeleteProvider(mainRepo, path, branch)
+	handled, err := d.dispatchWorktreeDeleteProvider(mainRepo, path, branch, opts.Force)
 	if err != nil {
-		return err
+		return &deleteWorktreeError{
+			err:  err,
+			kind: deleteWorktreeFailureProviderError,
+		}
 	}
 	if !handled {
-		if err := git.DeleteWorktree(mainRepo, path); err != nil {
-			return err
+		if err := git.DeleteWorktree(mainRepo, path, opts.Force); err != nil {
+			return d.classifyDeleteWorktreeGitError(path, opts.Force, err)
 		}
 	}
 
@@ -269,6 +290,7 @@ func (d *Daemon) doDeleteWorktree(path string, endpointID *string) (err error) {
 }
 
 func (d *Daemon) finalizeDeletedWorktree(path, mainRepo, branch string) {
+	d.cleanupDeletedWorktreeSessions(path)
 	d.store.RemoveWorktree(path)
 
 	// Also delete the branch (force=true since worktree is already deleted).
@@ -288,6 +310,45 @@ func (d *Daemon) finalizeDeletedWorktree(path, mainRepo, branch string) {
 			Path: path,
 		}},
 	})
+}
+
+func (d *Daemon) cleanupDeletedWorktreeSessions(path string) {
+	for _, session := range d.store.List("") {
+		if session.Directory != path {
+			continue
+		}
+		d.terminateSession(session.ID, syscall.SIGTERM)
+		d.store.Remove(session.ID)
+		d.clearLongRunTracking(session.ID)
+		d.wsHub.Broadcast(&protocol.WebSocketEvent{
+			Event:   protocol.EventSessionUnregistered,
+			Session: d.sessionForBroadcast(session),
+		})
+	}
+}
+
+func (d *Daemon) classifyDeleteWorktreeGitError(path string, force bool, err error) error {
+	kind := deleteWorktreeFailureGitError
+	forceable := false
+	if !force && d.worktreeHasLocalChanges(path) {
+		kind = deleteWorktreeFailureDirtyWorktree
+		forceable = true
+	}
+	return &deleteWorktreeError{
+		err:       err,
+		kind:      kind,
+		forceable: forceable,
+	}
+}
+
+func (d *Daemon) worktreeHasLocalChanges(path string) bool {
+	status, err := getGitStatusWithOptions(path, gitStatusOptions{
+		mode: gitStatusModeFull,
+	})
+	if err != nil || status == nil || status.Error != nil {
+		return false
+	}
+	return len(status.Staged) > 0 || len(status.Unstaged) > 0 || len(status.Untracked) > 0
 }
 
 type worktreeNotFoundError struct {
@@ -319,7 +380,9 @@ func (d *Daemon) handleCreateWorktree(conn net.Conn, msg *protocol.CreateWorktre
 }
 
 func (d *Daemon) handleDeleteWorktree(conn net.Conn, msg *protocol.DeleteWorktreeMessage) {
-	if err := d.doDeleteWorktree(msg.Path, msg.EndpointID); err != nil {
+	if err := d.doDeleteWorktree(msg.Path, msg.EndpointID, deleteWorktreeOptions{
+		Force: protocol.Deref(msg.Force),
+	}); err != nil {
 		d.sendError(conn, err.Error())
 		return
 	}
@@ -365,7 +428,9 @@ func (d *Daemon) handleDeleteWorktreeWS(client *wsClient, msg *protocol.DeleteWo
 			})
 		}()
 
-		err := d.doDeleteWorktree(msg.Path, msg.EndpointID)
+		err := d.doDeleteWorktree(msg.Path, msg.EndpointID, deleteWorktreeOptions{
+			Force: protocol.Deref(msg.Force),
+		})
 		result := protocol.DeleteWorktreeResultMessage{
 			Event:      protocol.EventDeleteWorktreeResult,
 			Path:       msg.Path,
@@ -374,6 +439,13 @@ func (d *Daemon) handleDeleteWorktreeWS(client *wsClient, msg *protocol.DeleteWo
 		}
 		if err != nil {
 			result.Error = protocol.Ptr(err.Error())
+			var deleteErr *deleteWorktreeError
+			if errors.As(err, &deleteErr) {
+				if deleteErr.kind != "" {
+					result.ReasonKind = string(deleteErr.kind)
+				}
+				result.Forceable = protocol.Ptr(deleteErr.forceable)
+			}
 			d.logf("Delete worktree failed for %s: %v", msg.Path, err)
 		} else {
 			d.logf("Delete worktree succeeded: %s", msg.Path)

--- a/internal/daemon/worktree_naming_test.go
+++ b/internal/daemon/worktree_naming_test.go
@@ -1,10 +1,12 @@
 package daemon
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
 )
@@ -100,7 +102,7 @@ func TestDoDeleteWorktree_BroadcastsGitOperationLifecycle(t *testing.T) {
 	cap := captureBroadcasts(d)
 	endpointID := "endpoint-1"
 
-	if err := d.doDeleteWorktree(worktreePath, protocol.Ptr(endpointID)); err != nil {
+	if err := d.doDeleteWorktree(worktreePath, protocol.Ptr(endpointID), deleteWorktreeOptions{}); err != nil {
 		t.Fatalf("doDeleteWorktree failed: %v", err)
 	}
 
@@ -152,6 +154,117 @@ func TestDoDeleteWorktree_BroadcastsGitOperationLifecycle(t *testing.T) {
 	if finished.Operation.DurationMs == nil {
 		t.Fatalf("finished operation missing duration_ms")
 	}
+}
+
+func TestDoDeleteWorktree_NormalDeleteFailurePreservesAttnState(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainDir := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(mainDir, 0755); err != nil {
+		t.Fatalf("failed to create main repo dir: %v", err)
+	}
+	runGitDaemon(t, mainDir, "init")
+	runGitDaemon(t, mainDir, "commit", "--allow-empty", "-m", "init")
+	worktreePath := filepath.Join(tmpDir, "repo--dirty")
+	runGitDaemon(t, mainDir, "worktree", "add", "-b", "feat/dirty", worktreePath)
+	if err := os.WriteFile(filepath.Join(worktreePath, "local.txt"), []byte("local change\n"), 0644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	d.registerCreatedWorktree(mainDir, worktreePath, "feat/dirty")
+	addWorktreeSession(t, d, "session-dirty", worktreePath, mainDir, "feat/dirty")
+
+	err := d.doDeleteWorktree(worktreePath, nil, deleteWorktreeOptions{})
+	if err == nil {
+		t.Fatal("doDeleteWorktree succeeded on dirty worktree without force")
+	}
+	var deleteErr *deleteWorktreeError
+	if !errors.As(err, &deleteErr) {
+		t.Fatalf("error type = %T, want *deleteWorktreeError", err)
+	}
+	if deleteErr.kind != deleteWorktreeFailureDirtyWorktree || !deleteErr.forceable {
+		t.Fatalf("delete error kind=%q forceable=%v, want dirty forceable", deleteErr.kind, deleteErr.forceable)
+	}
+	if wt := d.store.GetWorktree(worktreePath); wt == nil {
+		t.Fatal("worktree store row was removed after failed normal delete")
+	}
+	if session := d.store.Get("session-dirty"); session == nil {
+		t.Fatal("session was removed after failed normal delete")
+	}
+	if _, statErr := os.Stat(worktreePath); statErr != nil {
+		t.Fatalf("worktree path missing after failed normal delete: %v", statErr)
+	}
+	if !gitCommandSucceeds(mainDir, "rev-parse", "--verify", "feat/dirty") {
+		t.Fatal("local branch was deleted after failed normal delete")
+	}
+}
+
+func TestDoDeleteWorktree_ForceDeleteCleansUpAfterGitDelete(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainDir := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(mainDir, 0755); err != nil {
+		t.Fatalf("failed to create main repo dir: %v", err)
+	}
+	runGitDaemon(t, mainDir, "init")
+	runGitDaemon(t, mainDir, "commit", "--allow-empty", "-m", "init")
+	worktreePath := filepath.Join(tmpDir, "repo--dirty-force")
+	runGitDaemon(t, mainDir, "worktree", "add", "-b", "feat/dirty-force", worktreePath)
+	if err := os.WriteFile(filepath.Join(worktreePath, "local.txt"), []byte("local change\n"), 0644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	d.registerCreatedWorktree(mainDir, worktreePath, "feat/dirty-force")
+	addWorktreeSession(t, d, "session-force", worktreePath, mainDir, "feat/dirty-force")
+
+	if err := d.doDeleteWorktree(worktreePath, nil, deleteWorktreeOptions{Force: true}); err != nil {
+		t.Fatalf("doDeleteWorktree force failed: %v", err)
+	}
+	if wt := d.store.GetWorktree(worktreePath); wt != nil {
+		t.Fatal("worktree store row remains after force delete")
+	}
+	if session := d.store.Get("session-force"); session != nil {
+		t.Fatal("session remains after successful force delete")
+	}
+	worktrees := d.store.ListWorktreesByRepo(mainDir)
+	for _, wt := range worktrees {
+		if wt.Path == worktreePath {
+			t.Fatal("worktree still listed by store after force delete")
+		}
+	}
+	if gitCommandSucceeds(mainDir, "rev-parse", "--verify", "feat/dirty-force") {
+		t.Fatal("local branch remains after force delete")
+	}
+}
+
+func addWorktreeSession(t *testing.T, d *Daemon, id, directory, mainRepo, branch string) {
+	t.Helper()
+	now := time.Now().Format(time.RFC3339Nano)
+	d.store.Add(&protocol.Session{
+		ID:             id,
+		Label:          id,
+		Agent:          protocol.SessionAgentCodex,
+		Directory:      directory,
+		Branch:         protocol.Ptr(branch),
+		IsWorktree:     protocol.Ptr(true),
+		MainRepo:       protocol.Ptr(mainRepo),
+		State:          protocol.SessionStateIdle,
+		StateSince:     now,
+		StateUpdatedAt: now,
+		LastSeen:       now,
+	})
+}
+
+func gitCommandSucceeds(dir string, args ...string) bool {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	return cmd.Run() == nil
 }
 
 func runGitDaemon(t *testing.T, dir string, args ...string) {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -102,7 +102,7 @@ func CreateWorktreeFromRemoteBranch(repoDir, remoteBranch, path string) (string,
 // DeleteWorktree removes a worktree
 // If the worktree directory doesn't exist, it prunes stale entries instead
 // Always runs prune after removal to ensure git metadata is fully cleaned
-func DeleteWorktree(repoDir, path string) error {
+func DeleteWorktree(repoDir, path string, force bool) error {
 	path = CanonicalizePath(path)
 	// Check if directory exists
 	if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -114,7 +114,12 @@ func DeleteWorktree(repoDir, path string) error {
 	}
 
 	// Directory exists - remove normally
-	if out, err := runGitCombined(OpWorktree, repoDir, "worktree", "remove", path); err != nil {
+	args := []string{"worktree", "remove"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, path)
+	if out, err := runGitCombined(OpWorktree, repoDir, args...); err != nil {
 		return fmt.Errorf("git worktree remove failed: %s", out)
 	}
 

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -85,7 +85,7 @@ func TestDeleteWorktree(t *testing.T) {
 	wtDir := filepath.Join(tmpDir, "wt-to-delete")
 	runGit(t, mainDir, "worktree", "add", "-b", "temp", wtDir)
 
-	err := DeleteWorktree(mainDir, wtDir)
+	err := DeleteWorktree(mainDir, wtDir, false)
 	if err != nil {
 		t.Fatalf("DeleteWorktree failed: %v", err)
 	}
@@ -95,6 +95,42 @@ func TestDeleteWorktree(t *testing.T) {
 	for _, wt := range worktrees {
 		if wt.Path == wtDir {
 			t.Error("worktree should have been removed")
+		}
+	}
+}
+
+func TestDeleteWorktreeDirtyRequiresForce(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainDir := filepath.Join(tmpDir, "main")
+	if err := os.MkdirAll(mainDir, 0755); err != nil {
+		t.Fatalf("Failed to create main dir: %v", err)
+	}
+	runGit(t, mainDir, "init")
+	runGit(t, mainDir, "commit", "--allow-empty", "-m", "init")
+
+	wtDir := filepath.Join(tmpDir, "dirty-wt")
+	runGit(t, mainDir, "worktree", "add", "-b", "dirty", wtDir)
+	if err := os.WriteFile(filepath.Join(wtDir, "local.txt"), []byte("local change\n"), 0644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	if err := DeleteWorktree(mainDir, wtDir, false); err == nil {
+		t.Fatal("DeleteWorktree without force succeeded on dirty worktree")
+	}
+	if _, err := os.Stat(wtDir); err != nil {
+		t.Fatalf("dirty worktree disappeared after non-force delete: %v", err)
+	}
+
+	if err := DeleteWorktree(mainDir, wtDir, true); err != nil {
+		t.Fatalf("DeleteWorktree with force failed: %v", err)
+	}
+	worktrees, err := ListWorktrees(mainDir)
+	if err != nil {
+		t.Fatalf("ListWorktrees failed: %v", err)
+	}
+	for _, wt := range worktrees {
+		if wt.Path == wtDir {
+			t.Fatal("force-deleted worktree should have been removed")
 		}
 	}
 }

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "67"
+const ProtocolVersion = "68"
 
 // SessionAgent labels in-tree and externally registered agent identifiers.
 type SessionAgent = string

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -428,6 +428,9 @@ type DeleteWorktreeMessage struct {
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
 	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
+	// Force corresponds to the JSON schema field "force".
+	Force *bool `json:"force,omitempty,omitzero"`
+
 	// Path corresponds to the JSON schema field "path".
 	Path string `json:"path"`
 }
@@ -442,8 +445,14 @@ type DeleteWorktreeResultMessage struct {
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
 
+	// Forceable corresponds to the JSON schema field "forceable".
+	Forceable *bool `json:"forceable,omitempty,omitzero"`
+
 	// Path corresponds to the JSON schema field "path".
 	Path string `json:"path"`
+
+	// ReasonKind corresponds to the JSON schema field "reason_kind".
+	ReasonKind interface{} `json:"reason_kind,omitempty,omitzero"`
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -460,6 +460,7 @@ model DeleteWorktreeMessage {
   cmd: "delete_worktree";
   path: string;
   endpoint_id?: string;
+  force?: boolean;
 }
 
 model GetSettingsMessage {
@@ -1000,6 +1001,8 @@ model DeleteWorktreeResultMessage {
   endpoint_id?: string;
   success: boolean;
   error?: string;
+  forceable?: boolean;
+  reason_kind?: "dirty_worktree" | "provider_error" | "not_found" | "git_error";
 }
 
 model GitOperationStartedMessage {

--- a/sdk/plugin/src/index.ts
+++ b/sdk/plugin/src/index.ts
@@ -36,6 +36,7 @@ export type WorktreeDeleteParams = {
   main_repo: string;
   path: string;
   branch?: string;
+  force: boolean;
 };
 
 export type WorktreeDeleteResult = ProviderResult;


### PR DESCRIPTION
## Summary
- add a force-delete retry path when normal worktree deletion fails for dirty local changes or other forceable local failures
- keep plugin-owned deletion authoritative by invoking the plugin before attn session/store cleanup, and pass the new force flag through the plugin SDK
- extend the websocket protocol/results so the UI can show why normal delete failed and retry with force after explicit y/n confirmation

## Validation
- go test ./...
- make test-frontend
- pnpm --dir app build
- pnpm --dir sdk/plugin test
- git diff --check
- regenerated protocol types and verified generation stability
- dev daemon/app smoke check after pruning a stale dev recovery session
