### PR TITLE
[codex] Fix Ghostty Shift-Tab input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Codex Resize Redraws**: Attn now coalesces Codex's synchronized terminal redraws during pane resizes, preventing old scrollback from visibly streaming through the embedded terminal when layouts change.
+- **Ghostty Shift-Tab**: Shift-Tab in embedded Ghostty terminals now reaches agents as reverse-tab input instead of being treated like a prompt submit.
 - **Worktree Cleanup**: Failed worktree deletes now keep attn state intact, explain forceable local-change failures, and let you explicitly force-delete the local worktree and local branch without touching remotes.
 - **Empty Git Repositories**: Selecting an empty Git repository now loads repo metadata instead of failing while resolving the current branch.
 

--- a/app/src/components/SessionTerminalWorkspace/terminalKeyHandler.test.ts
+++ b/app/src/components/SessionTerminalWorkspace/terminalKeyHandler.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { installTerminalKeyHandler } from './terminalKeyHandler';
+
+describe('installTerminalKeyHandler', () => {
+  it('sends Shift+Tab as terminal reverse-tab input', () => {
+    const sendToPty = vi.fn();
+    const handler = installTerminalKeyHandler(sendToPty);
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+    });
+
+    expect(handler(event)).toBe(false);
+    expect(sendToPty).toHaveBeenCalledWith('\x1b[Z');
+  });
+
+  it('leaves plain Tab for Ghostty to encode', () => {
+    const sendToPty = vi.fn();
+    const handler = installTerminalKeyHandler(sendToPty);
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+    });
+
+    expect(handler(event)).toBe(true);
+    expect(sendToPty).not.toHaveBeenCalled();
+  });
+
+  it('handles WebKit reverse-tab key names', () => {
+    const sendToPty = vi.fn();
+    const handler = installTerminalKeyHandler(sendToPty);
+    const event = new KeyboardEvent('keydown', {
+      key: 'ISO_Left_Tab',
+      shiftKey: true,
+    });
+
+    expect(handler(event)).toBe(false);
+    expect(sendToPty).toHaveBeenCalledWith('\x1b[Z');
+  });
+});

--- a/app/src/components/SessionTerminalWorkspace/terminalKeyHandler.ts
+++ b/app/src/components/SessionTerminalWorkspace/terminalKeyHandler.ts
@@ -5,6 +5,17 @@ export function installTerminalKeyHandler(sendToPty: (data: string) => void) {
   return (event: KeyboardEvent) => {
     if (
       event.type === 'keydown'
+      && (event.key === 'Tab' || event.key === 'ISO_Left_Tab')
+      && event.shiftKey
+      && !event.ctrlKey
+      && !event.metaKey
+      && !event.altKey
+    ) {
+      sendToPty('\x1b[Z');
+      return false;
+    }
+    if (
+      event.type === 'keydown'
       && event.ctrlKey
       && !event.metaKey
       && !event.altKey


### PR DESCRIPTION
## Summary

- Send bare Shift-Tab from embedded Ghostty terminal panes as reverse-tab input (`ESC [ Z`) directly to the PTY.
- Cover WebKit's legacy `ISO_Left_Tab` key name and keep plain Tab delegated to Ghostty.
- Document the user-visible terminal fix in the changelog.

## Root Cause

Shift-Tab is also a browser/WebView focus traversal key. In the embedded terminal path, that meant the event could be handled before Ghostty reliably encoded terminal reverse-tab input, causing agents to observe prompt submission behavior instead of the intended Shift-Tab binding.

## Validation

- `pnpm --dir app exec vitest run src/components/SessionTerminalWorkspace/terminalKeyHandler.test.ts`
- `pnpm --dir app exec tsc --noEmit`