### PR TITLE
[codex] Make session creation asynchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-05-30]
 
 ### Fixed
+- **Session Creation**: Creating sessions from new worktrees now runs in the background with the same compact progress surface as worktree cleanup, so slow repository/plugin setup no longer traps the app in the picker.
 - **Codex Resize Redraws**: Attn now coalesces Codex's synchronized terminal redraws during pane resizes, preventing old scrollback from visibly streaming through the embedded terminal when layouts change.
 - **Worktree Cleanup**: Failed worktree deletes now keep attn state intact, explain forceable local-change failures, and let you explicitly force-delete the local worktree and local branch without touching remotes.
 - **Empty Git Repositories**: Selecting an empty Git repository now loads repo metadata instead of failing while resolving the current branch.

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -15,6 +15,7 @@ import { ChangesPanel } from './components/ChangesPanel';
 import { DiffDetailPanel } from './components/DiffDetailPanel';
 import { SessionReviewLoopBar } from './components/SessionReviewLoopBar';
 import { OpenPRLauncherProgress } from './components/OpenPRLauncherProgress';
+import { SessionCreationProgress, type SessionCreationPhase } from './components/SessionCreationProgress';
 import { RightDock } from './components/RightDock';
 import { SessionTerminalWorkspace } from './components/SessionTerminalWorkspace';
 import { ThumbsModal } from './components/ThumbsModal';
@@ -113,6 +114,15 @@ type OpenPRLauncherJob = {
   id: number;
   pr: DaemonPR;
   progress: OpenPRProgress;
+};
+
+type SessionCreationJob = {
+  id: number;
+  label: string;
+  path: string;
+  phase: SessionCreationPhase;
+  sessionId?: string;
+  error?: string | null;
 };
 
 function App() {
@@ -583,6 +593,9 @@ sendFetchPRDetails,
 }: AppContentProps) {
   const [openPRLauncherJob, setOpenPRLauncherJob] = useState<OpenPRLauncherJob | null>(null);
   const openPRLauncherIdRef = useRef(0);
+  const [sessionCreationJob, setSessionCreationJob] = useState<SessionCreationJob | null>(null);
+  const sessionCreationJobIdRef = useRef(0);
+  const worktreeSessionCreateEndpointsRef = useRef<Set<string>>(new Set());
   const {
     connect,
     sessions,
@@ -610,6 +623,26 @@ sendFetchPRDetails,
     sendRegisterWorkspace(workspaceId, label, cwd, endpointId);
     return createSession(label, cwd, sessionId, agent, endpointId, yoloMode, workspaceId);
   }, [createSession, sendRegisterWorkspace]);
+
+  useEffect(() => {
+    if (!sessionCreationJob?.sessionId || sessionCreationJob.error) {
+      return;
+    }
+    if (daemonSessions.some((session) => session.id === sessionCreationJob.sessionId)) {
+      setSessionCreationJob((current) => (
+        current?.id === sessionCreationJob.id ? null : current
+      ));
+      return;
+    }
+    const timeoutId = window.setTimeout(() => {
+      setSessionCreationJob((current) => (
+        current?.id === sessionCreationJob.id
+          ? { ...current, error: 'Session startup timed out.' }
+          : current
+      ));
+    }, 35_000);
+    return () => window.clearTimeout(timeoutId);
+  }, [daemonSessions, sessionCreationJob]);
 
   // UI scale for font sizing (Cmd+/Cmd-) - now uses SettingsContext
   const { scale, increaseScale, decreaseScale, resetScale } = useUIScale();
@@ -1202,6 +1235,8 @@ sendFetchPRDetails,
 
   const handleLocationSelect = useCallback(
     async (path: string, agent: SessionAgent, endpointId?: string, yoloMode = false) => {
+      const jobId = sessionCreationJobIdRef.current + 1;
+      sessionCreationJobIdRef.current = jobId;
       let selectedAgent: SessionAgent;
       if (endpointId) {
         const endpoint = daemonEndpoints.find((entry) => entry.id === endpointId);
@@ -1227,10 +1262,85 @@ sendFetchPRDetails,
       }
       // Note: Location is automatically tracked by daemon when session registers
       const folderName = path.split('/').pop() || 'session';
-      await createWorkspaceSession(folderName, path, undefined, selectedAgent, endpointId, yoloMode);
+      setSessionCreationJob({
+        id: jobId,
+        label: folderName,
+        path,
+        phase: 'starting_session',
+        error: null,
+      });
+      try {
+        const sessionId = await createWorkspaceSession(folderName, path, undefined, selectedAgent, endpointId, yoloMode);
+        setSessionCreationJob((current) => (
+          current?.id === jobId
+            ? { ...current, sessionId, phase: 'starting_session' }
+            : current
+        ));
+      } catch (err) {
+        setSessionCreationJob((current) => (
+          current?.id === jobId
+            ? { ...current, error: err instanceof Error ? err.message : 'Failed to create session' }
+            : current
+        ));
+      }
     },
     [agentAvailability, createWorkspaceSession, daemonEndpoints, hasAvailableAgents, showError]
   );
+
+  const handleCreateWorktreeSession = useCallback((
+    mainRepo: string,
+    branchName: string,
+    startingFrom: string,
+    endpointId: string | undefined,
+    agent: SessionAgent,
+    yoloMode: boolean,
+  ) => {
+    const endpointKey = endpointId || 'local';
+    if (worktreeSessionCreateEndpointsRef.current.has(endpointKey)) {
+      showError('A worktree session is already being created for this target.');
+      return;
+    }
+    worktreeSessionCreateEndpointsRef.current.add(endpointKey);
+    const jobId = sessionCreationJobIdRef.current + 1;
+    sessionCreationJobIdRef.current = jobId;
+    setSessionCreationJob({
+      id: jobId,
+      label: branchName,
+      path: mainRepo,
+      phase: 'creating_worktree',
+      error: null,
+    });
+
+    void (async () => {
+      try {
+        const result = await sendCreateWorktree(mainRepo, branchName, undefined, startingFrom, endpointId);
+        if (!result.success || !result.path) {
+          throw new Error(result.error || 'Failed to create worktree');
+        }
+        const worktreePath = result.path;
+        setSessionCreationJob((current) => (
+          current?.id === jobId
+            ? { ...current, path: worktreePath, phase: 'starting_session' }
+            : current
+        ));
+        const folderName = worktreePath.split('/').pop() || branchName || 'session';
+        const sessionId = await createWorkspaceSession(folderName, worktreePath, undefined, agent, endpointId, yoloMode);
+        setSessionCreationJob((current) => (
+          current?.id === jobId
+            ? { ...current, label: folderName, path: worktreePath, phase: 'starting_session', sessionId }
+            : current
+        ));
+      } catch (err) {
+        setSessionCreationJob((current) => (
+          current?.id === jobId
+            ? { ...current, error: err instanceof Error ? err.message : 'Failed to create session' }
+            : current
+        ));
+      } finally {
+        worktreeSessionCreateEndpointsRef.current.delete(endpointKey);
+      }
+    })();
+  }, [createWorkspaceSession, sendCreateWorktree, showError]);
 
   const closeLocationPicker = useCallback(() => {
     setLocationPickerOpen(false);
@@ -2276,6 +2386,7 @@ sendFetchPRDetails,
         onInspectPath={sendInspectPath}
         onGetRepoInfo={getRepoInfo}
         onCreateWorktree={sendCreateWorktree}
+        onCreateWorktreeSession={handleCreateWorktreeSession}
         onDeleteWorktree={sendDeleteWorktree}
         onError={showError}
         projectsDirectory={settings.projects_directory}
@@ -2283,6 +2394,14 @@ sendFetchPRDetails,
         endpoints={daemonEndpoints}
       />
       <UndoToast />
+      <SessionCreationProgress
+        isVisible={sessionCreationJob !== null}
+        label={sessionCreationJob?.label || ''}
+        path={sessionCreationJob?.path || ''}
+        phase={sessionCreationJob?.phase || 'starting_session'}
+        error={sessionCreationJob?.error}
+        onDismiss={() => setSessionCreationJob(null)}
+      />
       <WorktreeCleanupPrompt
         isVisible={closedWorktree !== null}
         worktreePath={closedWorktree?.path || ''}

--- a/app/src/App.worktreeCleanup.test.tsx
+++ b/app/src/App.worktreeCleanup.test.tsx
@@ -86,7 +86,36 @@ vi.mock('./components/Dashboard', () => ({
   ),
 }));
 vi.mock('./components/AttentionDrawer', () => ({ AttentionDrawer: () => null }));
-vi.mock('./components/LocationPicker', () => ({ LocationPicker: () => null }));
+vi.mock('./components/LocationPicker', () => ({
+  LocationPicker: ({
+    isOpen,
+    onClose,
+    onCreateWorktreeSession,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onCreateWorktreeSession?: (
+      mainRepo: string,
+      branch: string,
+      startingFrom: string,
+      endpointId: string | undefined,
+      agent: 'codex',
+      yoloMode: boolean,
+    ) => void;
+  }) => (
+    isOpen ? (
+      <button
+        data-testid="mock-create-worktree-session"
+        onClick={() => {
+          onCreateWorktreeSession?.('/tmp/repo', 'feat-async', 'main', undefined, 'codex', false);
+          onClose();
+        }}
+      >
+        Create Worktree Session
+      </button>
+    ) : null
+  ),
+}));
 vi.mock('./components/UndoToast', () => ({ UndoToast: () => null }));
 vi.mock('./components/ChangesPanel', () => ({ ChangesPanel: () => null }));
 vi.mock('./components/DiffDetailPanel', () => ({ DiffDetailPanel: () => null }));
@@ -271,6 +300,62 @@ describe('worktree cleanup prompt', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  it('moves worktree-backed session creation out of the picker', async () => {
+    const createWorktree = deferred<{ success: true; path: string }>();
+    const createSession = vi.fn(async () => 'created-1');
+    mockSessionStoreReturn.sessions = [];
+    mockSessionStoreReturn.activeSessionId = null;
+    mockSessionStoreReturn.createSession = createSession;
+    mockDaemonStoreReturn.daemonSessions = [];
+    mockDaemonSocketReturn.sendCreateWorktree = vi.fn(() => createWorktree.promise);
+
+    const { rerender } = render(<App />);
+
+    const keyboardArgs = mockUseKeyboardShortcuts.mock.calls[mockUseKeyboardShortcuts.mock.calls.length - 1]?.[0] as {
+      onNewSession?: () => void;
+    };
+    act(() => {
+      keyboardArgs.onNewSession?.();
+    });
+
+    await userEvent.click(screen.getByTestId('mock-create-worktree-session'));
+
+    expect(screen.queryByTestId('mock-create-worktree-session')).not.toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toHaveTextContent('Creating worktree');
+    expect(mockDaemonSocketReturn.sendCreateWorktree).toHaveBeenCalledWith('/tmp/repo', 'feat-async', undefined, 'main', undefined);
+
+    act(() => {
+      keyboardArgs.onNewSession?.();
+    });
+    await userEvent.click(screen.getByTestId('mock-create-worktree-session'));
+    expect(mockDaemonSocketReturn.sendCreateWorktree).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      createWorktree.resolve({ success: true, path: '/tmp/repo--feat-async' });
+      await createWorktree.promise;
+    });
+
+    await waitFor(() => {
+      expect(createSession).toHaveBeenCalledWith(
+        'repo--feat-async',
+        '/tmp/repo--feat-async',
+        expect.any(String),
+        'codex',
+        undefined,
+        false,
+        expect.stringMatching(/^workspace-/),
+      );
+    });
+    expect(screen.getByRole('dialog')).toHaveTextContent('Starting session');
+
+    mockDaemonStoreReturn.daemonSessions = [{ id: 'created-1', label: 'repo--feat-async', directory: '/tmp/repo--feat-async', state: 'launching' }];
+    rerender(<App />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Starting session')).not.toBeInTheDocument();
     });
   });
 

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -69,6 +69,7 @@ interface LocationPickerProps {
   onInspectPath?: (path: string, endpointId?: string) => Promise<InspectPathResult>;
   onGetRepoInfo?: (mainRepo: string, endpointId?: string) => Promise<{ success: boolean; info?: BackendRepoInfo; error?: string }>;
   onCreateWorktree?: (mainRepo: string, branch: string, path?: string, startingFrom?: string, endpointId?: string) => Promise<{ success: boolean; path?: string; error?: string }>;
+  onCreateWorktreeSession?: (mainRepo: string, branch: string, startingFrom: string, endpointId: string | undefined, agent: SessionAgent, yoloMode: boolean) => void;
   onDeleteWorktree?: (path: string, endpointId?: string, options?: { force?: boolean }) => Promise<{ success: boolean; error?: string }>;
   onError?: (message: string) => void;
   projectsDirectory?: string;
@@ -160,6 +161,7 @@ export function LocationPicker({
   onInspectPath,
   onGetRepoInfo,
   onCreateWorktree,
+  onCreateWorktreeSession,
   onDeleteWorktree,
   onError,
   projectsDirectory,
@@ -657,6 +659,20 @@ export function LocationPicker({
       return;
     }
 
+    if (onCreateWorktreeSession) {
+      const selectedAgent = resolvePreferredAgent(agent, effectiveAgentAvailability, 'codex');
+      onCreateWorktreeSession(
+        repoRootPath,
+        branchName,
+        startingFrom,
+        selectedEndpointId,
+        selectedAgent,
+        yoloMode && yoloSupported,
+      );
+      onClose();
+      return;
+    }
+
     const requestGeneration = beginRequestGeneration();
     try {
       const result = await onCreateWorktree(repoRootPath, branchName, undefined, startingFrom, selectedEndpointId);
@@ -681,11 +697,17 @@ export function LocationPicker({
     hasAvailableAgents,
     isRequestCurrent,
     launchSelection,
+    onClose,
     onCreateWorktree,
+    onCreateWorktreeSession,
     onError,
     repoRootPath,
+    agent,
+    effectiveAgentAvailability,
     selectedEndpointId,
     setSelectedPathFromPhysical,
+    yoloMode,
+    yoloSupported,
   ]);
 
   const handleRefresh = useCallback(async () => {

--- a/app/src/components/SessionCreationProgress.test.tsx
+++ b/app/src/components/SessionCreationProgress.test.tsx
@@ -52,15 +52,18 @@ describe('SessionCreationProgress', () => {
     );
 
     expect(screen.getByRole('dialog')).toHaveTextContent('Creating worktree');
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    screen.getByRole('button', { name: 'Other work' }).focus();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(700);
     });
 
-    expect(screen.getByRole('button', { name: /session setup/i })).toHaveFocus();
+    expect(screen.getByRole('button', { name: 'Other work' })).toHaveFocus();
     expect(container.querySelector('.worktree-cleanup-prompt')).toHaveClass('surface-hidden');
 
-    screen.getByRole('button', { name: 'Other work' }).focus();
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1000);
     });

--- a/app/src/components/SessionCreationProgress.test.tsx
+++ b/app/src/components/SessionCreationProgress.test.tsx
@@ -1,0 +1,109 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionCreationProgress } from './SessionCreationProgress';
+
+describe('SessionCreationProgress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function getBoundingClientRect(this: Element) {
+      if (this.classList.contains('worktree-cleanup-compact')) {
+        return {
+          x: 900,
+          y: 680,
+          left: 900,
+          top: 680,
+          right: 1240,
+          bottom: 760,
+          width: 340,
+          height: 80,
+          toJSON: () => ({}),
+        } as DOMRect;
+      }
+      return {
+        x: 360,
+        y: 230,
+        left: 360,
+        top: 230,
+        right: 920,
+        bottom: 430,
+        width: 560,
+        height: 200,
+        toJSON: () => ({}),
+      } as DOMRect;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('collapses a running creation job into a compact job', async () => {
+    const { container } = render(
+      <>
+        <button type="button">Other work</button>
+        <SessionCreationProgress
+          isVisible
+          label="feat-async"
+          path="/tmp/repo"
+          phase="creating_worktree"
+        />
+      </>,
+    );
+
+    expect(screen.getByRole('dialog')).toHaveTextContent('Creating worktree');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700);
+    });
+
+    expect(screen.getByRole('button', { name: /session setup/i })).toHaveFocus();
+    expect(container.querySelector('.worktree-cleanup-prompt')).toHaveClass('surface-hidden');
+
+    screen.getByRole('button', { name: 'Other work' }).focus();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(screen.getByRole('button', { name: 'Other work' })).toHaveFocus();
+  });
+
+  it('keeps failures reopenable from compact mode', async () => {
+    const onDismiss = vi.fn();
+    const { rerender } = render(
+      <SessionCreationProgress
+        isVisible
+        label="feat-async"
+        path="/tmp/repo"
+        phase="creating_worktree"
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700);
+    });
+
+    rerender(
+      <SessionCreationProgress
+        isVisible
+        label="feat-async"
+        path="/tmp/repo"
+        phase="creating_worktree"
+        error="branch already exists"
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const compactJob = screen.getByRole('button', { name: /create failed/i });
+    expect(compactJob).toHaveClass('failed');
+
+    fireEvent.click(compactJob);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('branch already exists');
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/SessionCreationProgress.tsx
+++ b/app/src/components/SessionCreationProgress.tsx
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import './WorktreeCleanupPrompt.css';
+
+export type SessionCreationPhase = 'creating_worktree' | 'starting_session';
+
+interface SessionCreationProgressProps {
+  isVisible: boolean;
+  label: string;
+  path: string;
+  phase: SessionCreationPhase;
+  error?: string | null;
+  onDismiss?: () => void;
+}
+
+export function SessionCreationProgress({
+  isVisible,
+  label,
+  path,
+  phase,
+  error = null,
+  onDismiss,
+}: SessionCreationProgressProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const compactRef = useRef<HTMLButtonElement>(null);
+  const compactTimerRef = useRef<number | null>(null);
+  const mountedRef = useRef(false);
+  const hasCompactedRef = useRef(false);
+  const [isCompact, setIsCompact] = useState(false);
+  const hasError = Boolean(error);
+
+  const clearCompactTimer = useCallback(() => {
+    if (compactTimerRef.current !== null) {
+      window.clearTimeout(compactTimerRef.current);
+      compactTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      clearCompactTimer();
+    };
+  }, [clearCompactTimer]);
+
+  const createMotionGhost = useCallback((source: HTMLElement, rect: DOMRect) => {
+    const ghost = source.cloneNode(true) as HTMLElement;
+    ghost.removeAttribute('id');
+    ghost.querySelectorAll('[id]').forEach((node) => node.removeAttribute('id'));
+    ghost.classList.remove('surface-hidden', 'motion-fade', 'motion-target', 'motion-underlay', 'motion-lit');
+    ghost.classList.add('motion-ghost');
+    ghost.setAttribute('aria-hidden', 'true');
+    ghost.style.left = `${rect.left}px`;
+    ghost.style.top = `${rect.top}px`;
+    ghost.style.width = `${rect.width}px`;
+    ghost.style.height = `${rect.height}px`;
+    document.body.appendChild(ghost);
+    return ghost;
+  }, []);
+
+  const finishMotion = useCallback((ghost: HTMLElement, callback: () => void) => {
+    let done = false;
+    const complete = (event?: TransitionEvent) => {
+      if (event && event.propertyName !== 'transform') {
+        return;
+      }
+      if (done) {
+        return;
+      }
+      done = true;
+      ghost.removeEventListener('transitionend', complete);
+      callback();
+      requestAnimationFrame(() => ghost.remove());
+    };
+    ghost.addEventListener('transitionend', complete);
+    window.setTimeout(() => complete(), 360);
+  }, []);
+
+  const applyCompact = useCallback((next: boolean, focus = true) => {
+    if (!mountedRef.current) {
+      return;
+    }
+    setIsCompact(next);
+    if (focus) {
+      requestAnimationFrame(() => {
+        if (next) {
+          compactRef.current?.focus();
+        } else {
+          dialogRef.current?.focus();
+        }
+      });
+    }
+  }, []);
+
+  const setCompactAnimated = useCallback((next: boolean, focus = true) => {
+    if (next === isCompact) {
+      applyCompact(next, focus);
+      return;
+    }
+
+    const overlay = overlayRef.current;
+    const dialog = dialogRef.current;
+    const compact = compactRef.current;
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+    if (!overlay || !dialog || !compact || reduceMotion) {
+      applyCompact(next, focus);
+      return;
+    }
+
+    if (next) {
+      const from = dialog.getBoundingClientRect();
+      const to = compact.getBoundingClientRect();
+      if (!from.width || !from.height || !to.width || !to.height) {
+        applyCompact(true, focus);
+        return;
+      }
+      const ghost = createMotionGhost(dialog, from);
+      overlay.classList.add('motion-fade');
+      ghost.getBoundingClientRect();
+      ghost.style.transition = 'transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1), opacity 220ms ease';
+      ghost.style.transform = `translate(${to.left - from.left}px, ${to.top - from.top}px) scale(${to.width / from.width}, ${to.height / from.height})`;
+      ghost.style.opacity = '0.08';
+      finishMotion(ghost, () => {
+        compact.classList.add('motion-target');
+        applyCompact(true, focus);
+        overlay.classList.remove('motion-fade');
+        requestAnimationFrame(() => compact.classList.remove('motion-target'));
+      });
+      return;
+    }
+
+    const from = compact.getBoundingClientRect();
+    const to = dialog.getBoundingClientRect();
+    if (!from.width || !from.height || !to.width || !to.height) {
+      applyCompact(false, focus);
+      return;
+    }
+    const ghost = createMotionGhost(dialog, to);
+    overlay.classList.add('motion-target', 'motion-underlay');
+    overlay.classList.remove('surface-hidden');
+    overlay.getBoundingClientRect();
+    overlay.classList.add('motion-lit');
+    compact.classList.add('motion-fade');
+    ghost.style.transform = `translate(${from.left - to.left}px, ${from.top - to.top}px) scale(${from.width / to.width}, ${from.height / to.height})`;
+    ghost.style.opacity = '0.16';
+    ghost.getBoundingClientRect();
+    ghost.style.transition = 'transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1), opacity 220ms ease';
+    ghost.style.transform = 'translate(0, 0) scale(1, 1)';
+    ghost.style.opacity = '1';
+    finishMotion(ghost, () => {
+      overlay.classList.remove('motion-underlay', 'motion-lit');
+      applyCompact(false, focus);
+      compact.classList.remove('motion-fade');
+      requestAnimationFrame(() => overlay.classList.remove('motion-target'));
+    });
+  }, [applyCompact, createMotionGhost, finishMotion, isCompact]);
+
+  useEffect(() => {
+    if (!isVisible) {
+      clearCompactTimer();
+      hasCompactedRef.current = false;
+      setIsCompact(false);
+      return;
+    }
+    if (hasError) {
+      clearCompactTimer();
+      return;
+    }
+    if (hasCompactedRef.current || isCompact) {
+      return;
+    }
+    hasCompactedRef.current = true;
+    compactTimerRef.current = window.setTimeout(() => {
+      setCompactAnimated(true, true);
+    }, 280);
+    return clearCompactTimer;
+  }, [clearCompactTimer, hasError, isVisible, setCompactAnimated]);
+
+  useEffect(() => {
+    if (!isVisible || isCompact) {
+      return;
+    }
+    requestAnimationFrame(() => dialogRef.current?.focus());
+  }, [isCompact, isVisible]);
+
+  if (!isVisible) return null;
+
+  const displayName = label || path.split('/').pop() || 'session';
+  const phaseLabel = phase === 'creating_worktree' ? 'Creating worktree' : 'Starting session';
+  const detail = phase === 'creating_worktree' ? 'git worktree add' : 'launching agent runtime';
+
+  return (
+    <>
+      <div
+        ref={overlayRef}
+        className={`worktree-cleanup-prompt ${isCompact ? 'surface-hidden' : ''}`}
+        role="presentation"
+      >
+        <div
+          ref={dialogRef}
+          className="cleanup-content"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="session-creation-title"
+          aria-describedby="session-creation-message"
+          tabIndex={-1}
+        >
+          <div className={`cleanup-status-pin ${hasError ? 'failed' : ''}`} aria-hidden="true" />
+          <div className="cleanup-copy">
+            <div className="cleanup-title">{hasError ? 'Action needed' : 'Session setup'}</div>
+            <div className="cleanup-heading" id="session-creation-title">
+              {hasError ? 'Session was not created' : phaseLabel}
+            </div>
+            <div className="cleanup-message" id="session-creation-message">
+              <span className="cleanup-branch">{displayName}</span>
+              <span className="cleanup-path">{path}</span>
+            </div>
+            <div className={`cleanup-operation ${hasError ? 'failed' : ''}`} role={hasError ? 'alert' : 'status'}>
+              <span className="cleanup-operation-label">{hasError ? 'Create failed' : phaseLabel}</span>
+              <span className="cleanup-operation-detail">{hasError ? error : detail}</span>
+              {!hasError && <span className="cleanup-meter" aria-hidden="true"><span /></span>}
+            </div>
+          </div>
+          {hasError && onDismiss && (
+            <div className="cleanup-actions">
+              <button type="button" className="cleanup-btn keep" onClick={onDismiss}>
+                Dismiss
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <button
+        ref={compactRef}
+        className={`worktree-cleanup-compact ${isCompact ? '' : 'surface-hidden'} ${hasError ? 'failed' : ''}`}
+        type="button"
+        aria-live="polite"
+        onClick={() => setCompactAnimated(false)}
+      >
+        <span className="compact-pin" aria-hidden="true" />
+        <span className="compact-copy">
+          <span className="compact-kicker">{hasError ? 'Create failed' : 'Session setup'}</span>
+          <span className="compact-title">{hasError ? `${displayName} failed` : phaseLabel}</span>
+          <span className="compact-detail">
+            <span>{hasError ? 'open to resolve' : displayName}</span>
+            {!hasError && <span className="compact-meter" aria-hidden="true"><span /></span>}
+          </span>
+        </span>
+      </button>
+    </>
+  );
+}

--- a/app/src/components/SessionCreationProgress.tsx
+++ b/app/src/components/SessionCreationProgress.tsx
@@ -172,17 +172,17 @@ export function SessionCreationProgress({
     }
     hasCompactedRef.current = true;
     compactTimerRef.current = window.setTimeout(() => {
-      setCompactAnimated(true, true);
+      setCompactAnimated(true, false);
     }, 280);
     return clearCompactTimer;
   }, [clearCompactTimer, hasError, isVisible, setCompactAnimated]);
 
   useEffect(() => {
-    if (!isVisible || isCompact) {
+    if (!isVisible || isCompact || !hasError) {
       return;
     }
     requestAnimationFrame(() => dialogRef.current?.focus());
-  }, [isCompact, isVisible]);
+  }, [hasError, isCompact, isVisible]);
 
   if (!isVisible) return null;
 


### PR DESCRIPTION
## Summary

- Move worktree-backed session creation out of the blocking location picker flow.
- Add a compact session creation progress surface that mirrors the slow worktree cleanup animation semantics.
- Guard overlapping same-endpoint worktree session creation so existing websocket result correlation cannot cross-wire jobs.
- Cover the async handoff, compact focus behavior, and test cleanup behavior.

## Validation

- `pnpm --dir app test -- App.worktreeCleanup.test.tsx SessionCreationProgress.test.tsx LocationPicker.test.tsx`
- `pnpm --dir app build`
- `$HOME/.codex/skills/autoreview/scripts/autoreview --mode local` -> clean: no accepted/actionable findings reported

## Notes

The in-app Browser plugin was unavailable in this session (`iab` backend unavailable), so I could not complete a browser smoke. The focused React tests and production build pass.