### PR TITLE
[codex] Fix terminal URL click hit testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Session Creation**: Creating sessions from new worktrees now runs in the background with the same compact progress surface as worktree cleanup, so slow repository/plugin setup no longer traps the app in the picker.
+- **Terminal URL Clicks**: Command-clicking URLs in Ghostty terminals now uses the rendered terminal canvas position, preventing clicks on the row above a URL from opening it when the canvas is vertically offset.
 - **Codex Resize Redraws**: Attn now coalesces Codex's synchronized terminal redraws during pane resizes, preventing old scrollback from visibly streaming through the embedded terminal when layouts change.
 - **Ghostty Shift-Tab**: Shift-Tab in embedded Ghostty terminals now reaches agents as reverse-tab input instead of being treated like a prompt submit.
 - **Worktree Cleanup**: Failed worktree deletes now keep attn state intact, explain forceable local-change failures, and let you explicitly force-delete the local worktree and local branch without touching remotes.

--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -124,11 +124,44 @@ test.describe('Ghostty terminal interactions', () => {
     await expectOpenedUrl(page, url);
   });
 
+  test('hit-tests URL clicks against the rendered canvas when it is vertically offset', async ({ page, daemon }) => {
+    await installOpenerProbe(page);
+    const terminal = await openTerminalSession(page, daemon, 's-link-offset');
+    await page.addStyleTag({
+      content: '.terminal-container canvas { margin-top: 18px !important; }',
+    });
+    const url = 'https://example.test/offset-link';
+    await writeTerminalOutput(page, 's-link-offset', `\u001b[2J\u001b[Hnot-a-link\u001b[2;1H${url}`);
+
+    await expect
+      .poll(
+        async () => page.evaluate(() => window.__TEST_GET_MAIN_TERMINAL_TEXT?.('s-link-offset') ?? ''),
+        { timeout: 5000 },
+      )
+      .toContain(url);
+
+    await page.keyboard.down('Meta');
+    await terminal.click({ position: { x: 100, y: 26 } });
+    await expect
+      .poll(
+        async () => page.evaluate(
+          () => (window as Window & { __OPENED_TERMINAL_URLS?: string[] }).__OPENED_TERMINAL_URLS ?? [],
+        ),
+        { timeout: 500 },
+      )
+      .toEqual([]);
+
+    await terminal.click({ position: { x: 100, y: 48 } });
+    await page.keyboard.up('Meta');
+
+    await expectOpenedUrl(page, url);
+  });
+
   test('cmd+click opens a visible URL while terminal mouse tracking is active', async ({ page, daemon }) => {
     await installOpenerProbe(page);
     const terminal = await openTerminalSession(page, daemon, 's-link-tracked');
     const url = 'https://example.test/tracked-link';
-    await writeTerminalOutput(page, 's-link-tracked', `\u001b[2J\u001b[H\u001b[?1000h${url}`);
+    await writeTerminalOutput(page, 's-link-tracked', `\u001b[2J\u001b[H\u001b[?1000h${url} `);
 
     await expect
       .poll(

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -144,6 +144,14 @@ function cellFromRect(
   cols: number,
 ) {
   if (!rect) return null;
+  if (
+    event.clientX < rect.left
+    || event.clientX >= rect.right
+    || event.clientY < rect.top
+    || event.clientY >= rect.bottom
+  ) {
+    return null;
+  }
   return {
     row: Math.max(0, Math.min(rows - 1, Math.floor((event.clientY - rect.top) / cellHeight))),
     col: Math.max(0, Math.min(cols, Math.floor((event.clientX - rect.left) / cellWidth))),
@@ -731,10 +739,18 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // from verified replay without sending historical replies to the live PTY.
     }, [clearSynchronizedOutputRenderTimer, fit, fontSize, getText, getVisibleContent, getVisibleStyleSummary, renderSurface, resizeLocal, resolvedTheme, write]);
 
-    const cellFromPointer = (event: React.MouseEvent) => {
+    const cellFromPointer = (event: React.MouseEvent | React.WheelEvent) => {
       const renderer = rendererRef.current;
-      const rect = containerRef.current?.getBoundingClientRect();
+      const rect = canvasRef.current?.getBoundingClientRect();
       if (!renderer || !rect) return null;
+      if (
+        event.clientX < rect.left
+        || event.clientX >= rect.right
+        || event.clientY < rect.top
+        || event.clientY >= rect.bottom
+      ) {
+        return null;
+      }
       return {
         row: Math.max(0, Math.min((terminalRef.current?.rows ?? 1) - 1, Math.floor((event.clientY - rect.top) / renderer.cellHeight))),
         col: Math.max(0, Math.min((terminalRef.current?.cols ?? 1), Math.floor((event.clientX - rect.left) / renderer.cellWidth))),


### PR DESCRIPTION
## What changed

- Hit-test Ghostty terminal pointer interactions against the rendered canvas instead of the outer terminal container.
- Treat pointers outside the rendered canvas as no cell instead of clamping them into the nearest row.
- Add e2e coverage for a vertically offset canvas so clicking the row above a URL does not open it.
- Stabilize the mouse-tracking URL e2e fixture with a delimiter after the URL.

## Why

The URL click debug log showed a vertical offset between the terminal container and canvas. The opener used the container-derived row, which could resolve to a URL one row below the pointer while the canvas-derived row had no URL.

## Validation

- `pnpm --dir app run build`
- `go build -o ./attn ./cmd/attn`
- `pnpm --dir app exec playwright test e2e/terminal-interactions.spec.ts --grep "opens a visible URL|vertically offset"`
