### PR TITLE
[codex] Make muting workspace-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-05-31]
+
+### Changed
+- **Workspace Muting**: Muting now applies to whole workspaces instead of individual sessions. Muted workspaces move to the muted section together with all of their sessions, and session rows no longer expose mute controls.
+
+### Removed
+- **Session Muting**: Session-level mute state was removed from the app, daemon protocol, and session database schema.
+
+---
+
 ## [2026-05-30]
 
 ### Changed

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -331,7 +331,7 @@ function App() {
     sendMutePR,
     sendMuteRepo,
     sendMuteAuthor,
-    sendMuteSession,
+    sendMuteWorkspace,
     sendPRVisited,
     sendRefreshPRs,
     sendRegisterWorkspace,
@@ -446,7 +446,7 @@ function App() {
         sendMutePR={sendMutePR}
         sendMuteRepo={sendMuteRepo}
         sendMuteAuthor={sendMuteAuthor}
-        sendMuteSession={sendMuteSession}
+        sendMuteWorkspace={sendMuteWorkspace}
         sendPRVisited={sendPRVisited}
         sendRefreshPRs={sendRefreshPRs}
         sendRegisterWorkspace={sendRegisterWorkspace}
@@ -528,7 +528,7 @@ interface AppContentProps {
   sendMutePR: ReturnType<typeof useDaemonSocket>['sendMutePR'];
   sendMuteRepo: ReturnType<typeof useDaemonSocket>['sendMuteRepo'];
   sendMuteAuthor: ReturnType<typeof useDaemonSocket>['sendMuteAuthor'];
-  sendMuteSession: ReturnType<typeof useDaemonSocket>['sendMuteSession'];
+  sendMuteWorkspace: ReturnType<typeof useDaemonSocket>['sendMuteWorkspace'];
   sendPRVisited: ReturnType<typeof useDaemonSocket>['sendPRVisited'];
   sendRefreshPRs: ReturnType<typeof useDaemonSocket>['sendRefreshPRs'];
   sendRegisterWorkspace: ReturnType<typeof useDaemonSocket>['sendRegisterWorkspace'];
@@ -605,7 +605,7 @@ function AppContent({
   sendMutePR,
   sendMuteRepo,
   sendMuteAuthor,
-  sendMuteSession,
+  sendMuteWorkspace,
   sendPRVisited,
   sendRefreshPRs,
   sendRegisterWorkspace,
@@ -946,13 +946,10 @@ sendFetchPRDetails,
       isWorktree: daemonSession?.is_worktree ?? s.isWorktree,
       recoverable: daemonSession?.recoverable ?? false,
       reviewLoopStatus: reviewLoop?.status,
-      muted: daemonSession?.muted ?? false,
     };
   });
 
   const visibleEnrichedSessions = filterSessionsRepresentedInWorkspaceLayouts(daemonWorkspaces, enrichedLocalSessions);
-  const unmutedEnrichedSessions = visibleEnrichedSessions.filter((s) => !s.muted);
-  const mutedEnrichedSessions = visibleEnrichedSessions.filter((s) => s.muted);
 
   const {
     eventRouter: paneRuntimeEventRouter,
@@ -1879,7 +1876,24 @@ sendFetchPRDetails,
     setClosedWorktree(null);
   }, []);
 
-  // Calculate attention count for drawer badge (muted sessions excluded)
+  const workspaceViews = useMemo(
+    () => buildWorkspaceViewModels(daemonWorkspaces, visibleEnrichedSessions),
+    [daemonWorkspaces, visibleEnrichedSessions],
+  );
+  const unmutedWorkspaceViews = useMemo(
+    () => workspaceViews.filter((workspace) => !workspace.muted && workspace.sessions.length > 0),
+    [workspaceViews],
+  );
+  const mutedWorkspaceViews = useMemo(
+    () => workspaceViews.filter((workspace) => workspace.muted && workspace.sessions.length > 0),
+    [workspaceViews],
+  );
+  const unmutedEnrichedSessions = useMemo(
+    () => unmutedWorkspaceViews.flatMap((workspace) => workspace.sessions),
+    [unmutedWorkspaceViews],
+  );
+
+  // Calculate attention count for drawer badge (muted workspaces excluded)
   const waitingLocalSessions = unmutedEnrichedSessions
     .filter((s) => isAttentionSessionState(s.state) || s.reviewLoopStatus === 'awaiting_user' || s.reviewLoopStatus === 'error')
     .map((s) => ({
@@ -1903,14 +1917,9 @@ sendFetchPRDetails,
     }
   }, [unmutedEnrichedSessions, handleSelectSession]);
 
-  const workspaceViews = useMemo(
-    () => buildWorkspaceViewModels(daemonWorkspaces, visibleEnrichedSessions),
-    [daemonWorkspaces, visibleEnrichedSessions],
-  );
   const sidebarWorkspaceViews = useMemo(
-    () => buildWorkspaceViewModels(daemonWorkspaces, unmutedEnrichedSessions)
-      .filter((workspace) => workspace.sessions.length > 0),
-    [daemonWorkspaces, unmutedEnrichedSessions],
+    () => unmutedWorkspaceViews,
+    [unmutedWorkspaceViews],
   );
   const workspaceSelection = useWorkspaceSelectionController(workspaceViews, activeSessionId);
   const activeWorkspaceId = workspaceSelection.activeWorkspaceId;
@@ -2470,7 +2479,7 @@ sendFetchPRDetails,
       <div className={`view-container ${view === 'dashboard' ? 'visible' : 'hidden'}`}>
         <Dashboard
           sessions={unmutedEnrichedSessions}
-          mutedSessions={mutedEnrichedSessions}
+          mutedWorkspaces={mutedWorkspaceViews}
           prs={prs}
           isLoading={!hasReceivedInitialState}
           isRefreshing={isRefreshingPRs}
@@ -2502,10 +2511,10 @@ sendFetchPRDetails,
           collapsed={sidebarCollapsed}
           headerActions={sidebarHeaderActions}
           footerShortcuts={sidebarFooterShortcuts}
-          mutedSessions={mutedEnrichedSessions}
+          mutedWorkspaces={mutedWorkspaceViews}
           mutedExpanded={sidebarMutedExpanded}
           onMutedExpandedChange={setSidebarMutedExpanded}
-          onMuteSession={sendMuteSession}
+          onMuteWorkspace={sendMuteWorkspace}
           onSelectSession={handleSelectSession}
           onSelectWorkspace={handleSelectWorkspace}
           onNewSession={() => handleNewSession('vertical')}

--- a/app/src/components/Dashboard.css
+++ b/app/src/components/Dashboard.css
@@ -934,7 +934,7 @@
   opacity: 0.8;
 }
 
-/* Muted sessions summary group */
+/* Muted workspaces summary group */
 .session-group.muted-summary {
   cursor: pointer;
   border-top: 1px solid var(--color-border);

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -32,9 +32,15 @@ type DashboardSession = {
   reviewLoopStatus?: string;
 };
 
+type DashboardWorkspace = {
+  id: string;
+  title: string;
+  sessions: DashboardSession[];
+};
+
 interface DashboardProps {
   sessions: DashboardSession[];
-  mutedSessions?: DashboardSession[];
+  mutedWorkspaces?: DashboardWorkspace[];
   prs: DaemonPR[];
   isLoading: boolean;
   isRefreshing?: boolean;
@@ -52,7 +58,7 @@ interface DashboardProps {
 
 export function Dashboard({
   sessions,
-  mutedSessions = [],
+  mutedWorkspaces = [],
   prs,
   isLoading,
   isRefreshing,
@@ -312,7 +318,7 @@ export function Dashboard({
             </button>
           </div>
           <div className="card-body">
-            {sessions.length === 0 && mutedSessions.length === 0 ? (
+            {sessions.length === 0 && mutedWorkspaces.length === 0 ? (
               <div className="card-empty">No active sessions</div>
             ) : (
               <>
@@ -458,13 +464,13 @@ export function Dashboard({
                     ))}
                   </div>
                 )}
-                {mutedSessions.length > 0 && (
+                {mutedWorkspaces.length > 0 && (
                   <div
                     className="session-group muted-summary clickable"
                     data-testid="session-group-muted"
                     onClick={onMutedGroupClick}
                   >
-                    <div className="group-label dim">Muted Sessions ({mutedSessions.length})</div>
+                    <div className="group-label dim">Muted Workspaces ({mutedWorkspaces.length})</div>
                   </div>
                 )}
               </>

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -478,6 +478,41 @@
   transition: opacity 0.1s;
 }
 
+.workspace-actions {
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
+  margin-left: 6px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.1s;
+}
+
+.workspace-group-header:hover .workspace-actions,
+.workspace-group-header:focus-within .workspace-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.workspace-action-btn {
+  align-items: center;
+  background: none;
+  border: none;
+  color: var(--color-text-dimmed);
+  cursor: pointer;
+  display: flex;
+  font-size: 14px;
+  height: 20px;
+  justify-content: center;
+  line-height: 1;
+  padding: 0;
+  width: 18px;
+}
+
+.workspace-action-btn:hover {
+  color: var(--color-text-primary);
+}
+
 .session-item:hover .session-actions,
 .session-item:focus-within .session-actions {
   opacity: 1;
@@ -753,7 +788,7 @@
   50% { opacity: 0.3; }
 }
 
-/* Muted sessions section */
+/* Muted workspaces section */
 .muted-sessions-section {
   border-top: 1px solid var(--color-border);
   padding: 4px 0;
@@ -799,18 +834,23 @@
   opacity: 0.55;
 }
 
+.muted-workspace {
+  opacity: 0.68;
+}
+
+.muted-workspace:hover,
+.muted-workspace.selected {
+  opacity: 0.9;
+}
+
+.muted-workspace-sessions {
+  padding-bottom: 4px;
+}
+
 .muted-session:hover {
   opacity: 0.75;
 }
 
 .muted-session[data-state="waiting_input"]::before {
   display: none;
-}
-
-.session-action-btn.mute-session-btn {
-  opacity: 0;
-}
-
-.session-item:hover .session-action-btn.mute-session-btn {
-  opacity: 1;
 }

--- a/app/src/components/Sidebar.test.tsx
+++ b/app/src/components/Sidebar.test.tsx
@@ -35,6 +35,7 @@ function buildSidebarData(sessions: TestSession[]) {
         id: session.workspaceId,
         title: session.label,
         directory: session.cwd || session.id,
+        muted: false,
       })),
     viewSessions,
   );
@@ -264,5 +265,39 @@ describe('Sidebar', () => {
     expect(screen.getAllByText('gpu-box')).toHaveLength(2);
     expect(screen.getByTestId('close-session-remote-1')).toBeInTheDocument();
     expect(screen.getByTestId('reload-session-remote-1')).toBeInTheDocument();
+  });
+
+  it('mutes workspaces instead of individual sessions', () => {
+    const sidebarData = buildSidebarData([
+      { id: 's1', label: 'active', state: 'idle', cwd: '/repo/active' },
+      { id: 's2', label: 'quiet', state: 'waiting_input', cwd: '/repo/quiet' },
+    ]);
+    const mutedWorkspace = {
+      ...sidebarData.workspaces[1],
+      muted: true,
+    };
+    const onMuteWorkspace = vi.fn();
+
+    render(
+      <Sidebar
+        {...baseProps}
+        workspaces={[sidebarData.workspaces[0]]}
+        visualOrder={[sidebarData.workspaces[0]]}
+        visualIndexByWorkspaceId={new Map([[sidebarData.workspaces[0].id, 0]])}
+        mutedWorkspaces={[mutedWorkspace]}
+        mutedExpanded
+        onMuteWorkspace={onMuteWorkspace}
+      />
+    );
+
+    expect(screen.queryByTestId('mute-session-s1')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('mute-workspace-workspace-/repo/active'));
+    expect(onMuteWorkspace).toHaveBeenCalledWith('workspace-/repo/active', undefined);
+
+    expect(screen.getByText('Muted Workspaces (1)')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-muted-workspace-workspace-/repo/quiet')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Unmute workspace quiet' }));
+    expect(onMuteWorkspace).toHaveBeenCalledWith('workspace-/repo/quiet', undefined);
   });
 });

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -18,7 +18,6 @@ interface LocalSession {
   endpointStatus?: string;
   recoverable?: boolean;
   reviewLoopStatus?: string;
-  muted?: boolean;
 }
 
 type SidebarWorkspace = WorkspaceWithSessions<LocalSession>;
@@ -49,10 +48,10 @@ interface SidebarProps {
   collapsed: boolean;
   headerActions: SidebarHeaderAction[];
   footerShortcuts?: FooterShortcut[];
-  mutedSessions?: LocalSession[];
+  mutedWorkspaces?: SidebarWorkspace[];
   mutedExpanded?: boolean;
   onMutedExpandedChange?: (expanded: boolean) => void;
-  onMuteSession?: (id: string) => void;
+  onMuteWorkspace?: (workspaceId: string, endpointId?: string) => void;
   onSelectSession: (id: string) => void;
   onSelectWorkspace: (id: string) => void;
   onNewSession: () => void;
@@ -170,10 +169,10 @@ export function Sidebar({
   collapsed,
   headerActions,
   footerShortcuts,
-  mutedSessions = [],
+  mutedWorkspaces = [],
   mutedExpanded: mutedExpandedProp,
   onMutedExpandedChange,
-  onMuteSession,
+  onMuteWorkspace,
   onSelectSession,
   onSelectWorkspace,
   onNewSession,
@@ -328,10 +327,17 @@ export function Sidebar({
               className={`workspace-group ${selectedWorkspaceId === workspace.id ? 'selected' : ''}`}
               data-testid={`sidebar-workspace-${workspace.id}`}
             >
-              <button
-                type="button"
+              <div
+                role="button"
+                tabIndex={0}
                 className="workspace-group-header"
                 onClick={() => onSelectWorkspace(workspace.id)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    onSelectWorkspace(workspace.id);
+                  }
+                }}
               >
                 <StateIndicator state={(workspace.status as UISessionState | undefined) || 'idle'} size="md" seed={workspace.id} />
                 <span className="workspace-label">{workspace.title}</span>
@@ -341,7 +347,24 @@ export function Sidebar({
                   </span>
                 )}
                 <span className="session-shortcut">⌘{workspaceIndex + 1}</span>
-              </button>
+                {onMuteWorkspace && (
+                  <span className="workspace-actions">
+                    <button
+                      type="button"
+                      className="workspace-action-btn mute-workspace-btn"
+                      data-testid={`mute-workspace-${workspace.id}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onMuteWorkspace(workspace.id, workspace.endpointId);
+                      }}
+                      title="Mute workspace"
+                      aria-label={`Mute workspace ${workspace.title}`}
+                    >
+                      ⊘
+                    </button>
+                  </span>
+                )}
+              </div>
               {workspace.sessions.map((session) => {
                 return (
                   <div
@@ -373,20 +396,6 @@ export function Sidebar({
                     )}
                     {session.isWorktree && <span className="worktree-indicator">⎇</span>}
                     <div className="session-actions">
-                      {onMuteSession && (
-                        <button
-                          className="session-action-btn mute-session-btn"
-                          data-testid={`mute-session-${session.id}`}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onMuteSession(session.id);
-                          }}
-                          title="Mute session"
-                          aria-label={`Mute session ${session.label}`}
-                        >
-                          ⊘
-                        </button>
-                      )}
                       <button
                         className="session-action-btn close-session-btn"
                         data-testid={`close-session-${session.id}`}
@@ -420,7 +429,7 @@ export function Sidebar({
         })}
       </div>
 
-      {mutedSessions.length > 0 && (
+      {mutedWorkspaces.length > 0 && (
         <div className="muted-sessions-section">
           <button
             className="muted-sessions-header"
@@ -428,44 +437,65 @@ export function Sidebar({
             aria-expanded={mutedExpanded}
           >
             <span className={`muted-sessions-chevron ${mutedExpanded ? 'expanded' : ''}`}>▸</span>
-            Muted Sessions ({mutedSessions.length})
+            Muted Workspaces ({mutedWorkspaces.length})
           </button>
           {mutedExpanded && (
             <div className="muted-sessions-list">
-              {mutedSessions.map((session) => (
+              {mutedWorkspaces.map((workspace) => (
                 <div
-                  key={session.id}
-                  className={`session-item muted-session ${selectedId === session.id ? 'selected' : ''}`}
-                  data-testid={`sidebar-session-${session.id}`}
-                  data-state={session.state}
-                  onClick={() => onSelectSession(session.id)}
+                  key={`${workspace.endpointId || 'local'}:${workspace.id}`}
+                  className={`workspace-group muted-workspace ${selectedWorkspaceId === workspace.id ? 'selected' : ''}`}
+                  data-testid={`sidebar-muted-workspace-${workspace.id}`}
                 >
-                  <StateIndicator state={session.state} size="md" seed={session.id} />
-                  <div className="session-info">
-                    <span className="session-label">{session.label}</span>
-                    {session.endpointName && (
-                      <span className={`session-endpoint-badge status-${session.endpointStatus || 'connected'}`}>
-                        {session.endpointName}
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    className="workspace-group-header"
+                    onClick={() => onSelectWorkspace(workspace.id)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        onSelectWorkspace(workspace.id);
+                      }
+                    }}
+                  >
+                    <StateIndicator state={(workspace.status as UISessionState | undefined) || 'idle'} size="md" seed={workspace.id} />
+                    <span className="workspace-label">{workspace.title}</span>
+                    {onMuteWorkspace && (
+                      <span className="workspace-actions">
+                        <button
+                          type="button"
+                          className="workspace-action-btn unmute-workspace-btn"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onMuteWorkspace(workspace.id, workspace.endpointId);
+                          }}
+                          title="Unmute workspace"
+                          aria-label={`Unmute workspace ${workspace.title}`}
+                        >
+                          ⊙
+                        </button>
                       </span>
                     )}
-                    {session.branch && (
-                      <span className="session-branch">{session.branch}</span>
-                    )}
                   </div>
-                  <div className="session-actions">
-                    {onMuteSession && (
-                      <button
-                        className="session-action-btn unmute-session-btn"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onMuteSession(session.id);
-                        }}
-                        title="Unmute session"
-                        aria-label={`Unmute session ${session.label}`}
+                  <div className="muted-workspace-sessions">
+                    {workspace.sessions.map((session) => (
+                      <div
+                        key={session.id}
+                        className={`session-item grouped muted-session ${selectedId === session.id ? 'selected' : ''}`}
+                        data-testid={`sidebar-session-${session.id}`}
+                        data-state={session.state}
+                        onClick={() => onSelectSession(session.id)}
                       >
-                        ⊙
-                      </button>
-                    )}
+                        <StateIndicator state={session.state} size="md" seed={session.id} />
+                        <span className="session-label">{session.label}</span>
+                        {session.endpointName && (
+                          <span className={`session-endpoint-badge status-${session.endpointStatus || 'connected'}`}>
+                            {session.endpointName}
+                          </span>
+                        )}
+                      </div>
+                    ))}
                   </div>
                 </div>
               ))}

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -571,7 +571,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '72',
+        protocol_version: '73',
         sessions: [
           {
             id: 'agent-1',
@@ -669,13 +669,14 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '72',
+        protocol_version: '73',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
           title: 'Remote',
           directory: '/tmp/repo',
           status: 'idle',
+          muted: false,
           layout: {
             workspace_id: 'workspace-sess-remote',
             active_pane_id: 'pane-session',
@@ -753,7 +754,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '72',
+        protocol_version: '73',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -885,7 +886,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '72',
+        protocol_version: '73',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -953,7 +954,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '72',
+        protocol_version: '73',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1047,7 +1048,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '72',
+        protocol_version: '73',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1146,7 +1147,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '72',
+        protocol_version: '73',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1231,13 +1232,14 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '72',
+        protocol_version: '73',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
           title: 'Remote',
           directory: '/tmp/repo',
           status: 'idle',
+          muted: false,
           layout: {
             workspace_id: 'workspace-sess-remote',
             active_pane_id: 'pane-session',
@@ -1309,7 +1311,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '72',
+        protocol_version: '73',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -1323,6 +1325,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
           title: 'stale',
           directory: '/tmp/repo',
           status: 'working',
+          muted: false,
           layout: {
             workspace_id: 'workspace-sess-stale',
             active_pane_id: 'pane-session',
@@ -1378,7 +1381,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '72',
+        protocol_version: '73',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',
@@ -1392,6 +1395,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
           title: 'removed',
           directory: '/tmp/repo',
           status: 'working',
+          muted: false,
           layout: {
             workspace_id: 'workspace-sess-removed',
             active_pane_id: 'pane-session',
@@ -1438,6 +1442,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
           title: 'removed',
           directory: '/tmp/repo',
           status: 'idle',
+          muted: false,
         },
       });
     });

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -152,7 +152,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '72';
+const PROTOCOL_VERSION = '73';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 // Runtime gate (flipped from VITE_UI_AUTOMATION). The Rust shell
 // injects this global before any page script runs — see
@@ -2579,11 +2579,15 @@ export function useDaemonSocket({
     ws.send(JSON.stringify({ cmd: 'mute_author', author }));
   }, [onAuthorsUpdate]);
 
-  // Mute a session (toggle muted state)
-  const sendMuteSession = useCallback((id: string) => {
+  // Mute a workspace (toggle muted state)
+  const sendMuteWorkspace = useCallback((workspaceId: string, endpointId?: string) => {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    ws.send(JSON.stringify({ cmd: 'mute', id }));
+    ws.send(JSON.stringify({
+      cmd: 'mute_workspace',
+      workspace_id: workspaceId,
+      ...(endpointId ? { endpoint_id: endpointId } : {}),
+    }));
   }, []);
 
   // Request daemon to refresh PRs from GitHub
@@ -3675,7 +3679,7 @@ export function useDaemonSocket({
     sendMutePR,
     sendMuteRepo,
     sendMuteAuthor,
-    sendMuteSession,
+    sendMuteWorkspace,
     sendRefreshPRs,
     sendFetchPRDetails,
     sendClearSessions,

--- a/app/src/store/sessions.test.ts
+++ b/app/src/store/sessions.test.ts
@@ -326,6 +326,7 @@ describe('sessions store', () => {
         title: 'Workspace',
         directory: '/tmp/workspace',
         status: WorkspaceStatus.Idle,
+        muted: false,
         layout: {
           workspace_id: `workspace-${sessionId}`,
           active_pane_id: 'pane-shell',
@@ -376,6 +377,7 @@ describe('sessions store', () => {
         title: 'Workspace',
         directory: '/tmp/workspace',
         status: WorkspaceStatus.Idle,
+        muted: false,
         layout: {
           workspace_id: `workspace-${sessionId}`,
           active_pane_id: 'missing-pane',
@@ -390,6 +392,7 @@ describe('sessions store', () => {
         title: 'Unknown',
         directory: '/tmp/unknown',
         status: WorkspaceStatus.Idle,
+        muted: false,
         layout: {
           workspace_id: 'workspace-unknown-session',
           active_pane_id: 'pane-x',

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MuteMessage, MutePRMessage, MuteRepoMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -88,9 +88,9 @@
 //   const markFileViewedResultMessage = Convert.toMarkFileViewedResultMessage(json);
 //   const mergePRMessage = Convert.toMergePRMessage(json);
 //   const muteAuthorMessage = Convert.toMuteAuthorMessage(json);
-//   const muteMessage = Convert.toMuteMessage(json);
 //   const mutePRMessage = Convert.toMutePRMessage(json);
 //   const muteRepoMessage = Convert.toMuteRepoMessage(json);
+//   const muteWorkspaceMessage = Convert.toMuteWorkspaceMessage(json);
 //   const pR = Convert.toPR(json);
 //   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
 //   const pRRole = Convert.toPRRole(json);
@@ -381,7 +381,6 @@ export interface SessionElement {
     label:                        string;
     last_seen:                    string;
     main_repo?:                   string;
-    muted:                        boolean;
     needs_review_after_long_run?: boolean;
     recoverable?:                 boolean;
     state:                        SessionState;
@@ -1202,6 +1201,7 @@ export interface WorkspaceElement {
     directory: string;
     id:        string;
     layout?:   Layout;
+    muted:     boolean;
     status:    WorkspaceStatus;
     title:     string;
     [property: string]: any;
@@ -1430,16 +1430,6 @@ export enum MuteAuthorMessageCmd {
     MuteAuthor = "mute_author",
 }
 
-export interface MuteMessage {
-    cmd: MuteMessageCmd;
-    id:  string;
-    [property: string]: any;
-}
-
-export enum MuteMessageCmd {
-    Mute = "mute",
-}
-
 export interface MutePRMessage {
     cmd: MutePRMessageCmd;
     id:  string;
@@ -1458,6 +1448,17 @@ export interface MuteRepoMessage {
 
 export enum MuteRepoMessageCmd {
     MuteRepo = "mute_repo",
+}
+
+export interface MuteWorkspaceMessage {
+    cmd:          MuteWorkspaceMessageCmd;
+    endpoint_id?: string;
+    workspace_id: string;
+    [property: string]: any;
+}
+
+export enum MuteWorkspaceMessageCmd {
+    MuteWorkspace = "mute_workspace",
 }
 
 export interface PR {
@@ -2109,7 +2110,6 @@ export interface Session {
     label:                        string;
     last_seen:                    string;
     main_repo?:                   string;
-    muted:                        boolean;
     needs_review_after_long_run?: boolean;
     recoverable?:                 boolean;
     state:                        SessionState;
@@ -2503,6 +2503,7 @@ export interface Workspace {
     directory: string;
     id:        string;
     layout?:   Layout;
+    muted:     boolean;
     status:    WorkspaceStatus;
     title:     string;
     [property: string]: any;
@@ -3386,14 +3387,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("MuteAuthorMessage")), null, 2);
     }
 
-    public static toMuteMessage(json: string): MuteMessage {
-        return cast(JSON.parse(json), r("MuteMessage"));
-    }
-
-    public static muteMessageToJson(value: MuteMessage): string {
-        return JSON.stringify(uncast(value, r("MuteMessage")), null, 2);
-    }
-
     public static toMutePRMessage(json: string): MutePRMessage {
         return cast(JSON.parse(json), r("MutePRMessage"));
     }
@@ -3408,6 +3401,14 @@ export class Convert {
 
     public static muteRepoMessageToJson(value: MuteRepoMessage): string {
         return JSON.stringify(uncast(value, r("MuteRepoMessage")), null, 2);
+    }
+
+    public static toMuteWorkspaceMessage(json: string): MuteWorkspaceMessage {
+        return cast(JSON.parse(json), r("MuteWorkspaceMessage"));
+    }
+
+    public static muteWorkspaceMessageToJson(value: MuteWorkspaceMessage): string {
+        return JSON.stringify(uncast(value, r("MuteWorkspaceMessage")), null, 2);
     }
 
     public static toPR(json: string): PR {
@@ -4474,7 +4475,6 @@ const typeMap: any = {
         { json: "label", js: "label", typ: "" },
         { json: "last_seen", js: "last_seen", typ: "" },
         { json: "main_repo", js: "main_repo", typ: u(undefined, "") },
-        { json: "muted", js: "muted", typ: true },
         { json: "needs_review_after_long_run", js: "needs_review_after_long_run", typ: u(undefined, true) },
         { json: "recoverable", js: "recoverable", typ: u(undefined, true) },
         { json: "state", js: "state", typ: r("SessionState") },
@@ -4938,6 +4938,7 @@ const typeMap: any = {
         { json: "directory", js: "directory", typ: "" },
         { json: "id", js: "id", typ: "" },
         { json: "layout", js: "layout", typ: u(undefined, r("Layout")) },
+        { json: "muted", js: "muted", typ: true },
         { json: "status", js: "status", typ: r("WorkspaceStatus") },
         { json: "title", js: "title", typ: "" },
     ], "any"),
@@ -5044,10 +5045,6 @@ const typeMap: any = {
         { json: "author", js: "author", typ: "" },
         { json: "cmd", js: "cmd", typ: r("MuteAuthorMessageCmd") },
     ], "any"),
-    "MuteMessage": o([
-        { json: "cmd", js: "cmd", typ: r("MuteMessageCmd") },
-        { json: "id", js: "id", typ: "" },
-    ], "any"),
     "MutePRMessage": o([
         { json: "cmd", js: "cmd", typ: r("MutePRMessageCmd") },
         { json: "id", js: "id", typ: "" },
@@ -5055,6 +5052,11 @@ const typeMap: any = {
     "MuteRepoMessage": o([
         { json: "cmd", js: "cmd", typ: r("MuteRepoMessageCmd") },
         { json: "repo", js: "repo", typ: "" },
+    ], "any"),
+    "MuteWorkspaceMessage": o([
+        { json: "cmd", js: "cmd", typ: r("MuteWorkspaceMessageCmd") },
+        { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "PR": o([
         { json: "approved_by_me", js: "approved_by_me", typ: true },
@@ -5463,7 +5465,6 @@ const typeMap: any = {
         { json: "label", js: "label", typ: "" },
         { json: "last_seen", js: "last_seen", typ: "" },
         { json: "main_repo", js: "main_repo", typ: u(undefined, "") },
-        { json: "muted", js: "muted", typ: true },
         { json: "needs_review_after_long_run", js: "needs_review_after_long_run", typ: u(undefined, true) },
         { json: "recoverable", js: "recoverable", typ: u(undefined, true) },
         { json: "state", js: "state", typ: r("SessionState") },
@@ -5691,6 +5692,7 @@ const typeMap: any = {
         { json: "directory", js: "directory", typ: "" },
         { json: "id", js: "id", typ: "" },
         { json: "layout", js: "layout", typ: u(undefined, r("Layout")) },
+        { json: "muted", js: "muted", typ: true },
         { json: "status", js: "status", typ: r("WorkspaceStatus") },
         { json: "title", js: "title", typ: "" },
     ], "any"),
@@ -6053,14 +6055,14 @@ const typeMap: any = {
     "MuteAuthorMessageCmd": [
         "mute_author",
     ],
-    "MuteMessageCmd": [
-        "mute",
-    ],
     "MutePRMessageCmd": [
         "mute_pr",
     ],
     "MuteRepoMessageCmd": [
         "mute_repo",
+    ],
+    "MuteWorkspaceMessageCmd": [
+        "mute_workspace",
     ],
     "PRActionResultMessageEvent": [
         "pr_action_result",

--- a/app/src/utils/workspaceViewModels.test.ts
+++ b/app/src/utils/workspaceViewModels.test.ts
@@ -8,8 +8,8 @@ import {
 describe('workspaceViewModels', () => {
   it('orders workspaces by daemon order and nests sessions by workspace id', () => {
     const workspaces = [
-      { id: 'workspace-a', title: 'A', directory: '/repo/a', status: 'idle' },
-      { id: 'workspace-b', title: 'B', directory: '/repo/b', status: 'working' },
+      { id: 'workspace-a', title: 'A', directory: '/repo/a', status: 'idle', muted: false },
+      { id: 'workspace-b', title: 'B', directory: '/repo/b', status: 'working', muted: false },
     ];
     const sessions = [
       { id: 'b1', label: 'B1', workspaceId: 'workspace-b', cwd: '/repo/b' },
@@ -38,7 +38,7 @@ describe('workspaceViewModels', () => {
 
   it('keeps daemon workspaces renderable before their sessions arrive', () => {
     const viewModels = buildWorkspaceViewModels(
-      [{ id: 'workspace-pending', title: 'Pending', directory: '/repo/pending', status: 'launching' }],
+      [{ id: 'workspace-pending', title: 'Pending', directory: '/repo/pending', status: 'launching', muted: false }],
       [],
     );
 
@@ -48,6 +48,7 @@ describe('workspaceViewModels', () => {
         title: 'Pending',
         directory: '/repo/pending',
         status: 'launching',
+        muted: false,
         endpointId: undefined,
         sessions: [],
         firstSessionId: null,

--- a/app/src/utils/workspaceViewModels.ts
+++ b/app/src/utils/workspaceViewModels.ts
@@ -15,6 +15,7 @@ export interface WorkspaceViewWorkspace {
   title: string;
   directory: string;
   status?: string;
+  muted?: boolean;
   endpointId?: string;
   endpoint_id?: string;
   layout?: {
@@ -29,6 +30,7 @@ export interface WorkspaceWithSessions<TSession extends WorkspaceViewSession = W
   title: string;
   directory: string;
   status?: string;
+  muted?: boolean;
   endpointId?: string;
   sessions: TSession[];
   firstSessionId: string | null;
@@ -125,6 +127,7 @@ function toWorkspaceViewModel<TSession extends WorkspaceViewSession>(
     title: workspace.title,
     directory: workspace.directory,
     status: workspace.status,
+    muted: workspace.muted ?? false,
     endpointId: workspaceEndpointId(workspace) || (sessions[0] ? sessionEndpointId(sessions[0]) : undefined),
     sessions,
     firstSessionId,

--- a/internal/attention/adapters.go
+++ b/internal/attention/adapters.go
@@ -24,9 +24,6 @@ func (s SessionAdapter) AttentionLabel() string {
 }
 
 func (s SessionAdapter) NeedsAttention() bool {
-	if s.Session.Muted {
-		return false
-	}
 	return s.Session.State == protocol.SessionStateWaitingInput ||
 		s.Session.State == protocol.SessionStatePendingApproval ||
 		s.Session.State == protocol.SessionStateUnknown
@@ -50,7 +47,7 @@ func (s SessionAdapter) AttentionSince() time.Time {
 }
 
 func (s SessionAdapter) AttentionMuted() bool {
-	return s.Session.Muted
+	return false
 }
 
 // PRAdapter wraps a protocol.PR to implement Source.

--- a/internal/attention/aggregator_test.go
+++ b/internal/attention/aggregator_test.go
@@ -18,21 +18,18 @@ func TestAggregator_Aggregate(t *testing.T) {
 			Label:      "working-session",
 			State:      protocol.SessionStateWorking,
 			StateSince: protocol.NewTimestamp(now).String(),
-			Muted:      false,
 		},
 		{
 			ID:         "sess-2",
 			Label:      "waiting-session",
 			State:      protocol.SessionStateWaitingInput,
 			StateSince: protocol.NewTimestamp(older).String(),
-			Muted:      false,
 		},
 		{
 			ID:         "sess-3",
-			Label:      "muted-waiting",
+			Label:      "another-waiting",
 			State:      protocol.SessionStateWaitingInput,
 			StateSince: protocol.NewTimestamp(now).String(),
-			Muted:      true,
 		},
 	}
 
@@ -73,13 +70,13 @@ func TestAggregator_Aggregate(t *testing.T) {
 	agg := NewAggregator(repos, nil)
 	result := agg.Aggregate(sessions, prs)
 
-	// Should have 2 items needing attention: sess-2 and github.com:owner/repo#1
-	if result.TotalCount != 2 {
-		t.Errorf("TotalCount = %d, want 2", result.TotalCount)
+	// Should have 3 items needing attention: two sessions and github.com:owner/repo#1.
+	if result.TotalCount != 3 {
+		t.Errorf("TotalCount = %d, want 3", result.TotalCount)
 	}
 
-	if result.SessionCount != 1 {
-		t.Errorf("SessionCount = %d, want 1", result.SessionCount)
+	if result.SessionCount != 2 {
+		t.Errorf("SessionCount = %d, want 2", result.SessionCount)
 	}
 
 	if result.PRCount != 1 {
@@ -88,8 +85,8 @@ func TestAggregator_Aggregate(t *testing.T) {
 
 	// Items should be sorted by Since (oldest first)
 	// oldest is the PR, then older is the session
-	if len(result.Items) != 2 {
-		t.Fatalf("Expected 2 items, got %d", len(result.Items))
+	if len(result.Items) != 3 {
+		t.Fatalf("Expected 3 items, got %d", len(result.Items))
 	}
 
 	if result.Items[0].Kind != "pr" {
@@ -114,17 +111,7 @@ func TestAggregator_EmptyInput(t *testing.T) {
 	}
 }
 
-func TestAggregator_AllMuted(t *testing.T) {
-	sessions := []protocol.Session{
-		{
-			ID:         "sess-1",
-			Label:      "muted",
-			State:      protocol.SessionStateWaitingInput,
-			StateSince: protocol.TimestampNow().String(),
-			Muted:      true,
-		},
-	}
-
+func TestAggregator_AllPRsMuted(t *testing.T) {
 	prs := []protocol.PR{
 		{
 			ID:          "github.com:owner/repo#1",
@@ -137,10 +124,10 @@ func TestAggregator_AllMuted(t *testing.T) {
 	}
 
 	agg := NewAggregator(nil, nil)
-	result := agg.Aggregate(sessions, prs)
+	result := agg.Aggregate(nil, prs)
 
 	if result.TotalCount != 0 {
-		t.Errorf("TotalCount = %d, want 0 (all muted)", result.TotalCount)
+		t.Errorf("TotalCount = %d, want 0 (all PRs muted)", result.TotalCount)
 	}
 }
 
@@ -174,7 +161,6 @@ func TestSessionAdapter(t *testing.T) {
 		Label:      "Test",
 		State:      protocol.SessionStateWaitingInput,
 		StateSince: protocol.TimestampNow().String(),
-		Muted:      false,
 	}
 
 	adapter := SessionAdapter{Session: session}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -165,11 +165,11 @@ func (c *Client) Heartbeat(id string) error {
 	return err
 }
 
-// ToggleMute toggles a session's muted state
-func (c *Client) ToggleMute(id string) error {
-	msg := protocol.MuteMessage{
-		Cmd: protocol.CmdMute,
-		ID:  id,
+// ToggleWorkspaceMute toggles a workspace's muted state.
+func (c *Client) ToggleWorkspaceMute(workspaceID string) error {
+	msg := protocol.MuteWorkspaceMessage{
+		Cmd:         protocol.CmdMuteWorkspace,
+		WorkspaceID: workspaceID,
 	}
 	_, err := c.send(msg)
 	return err

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -37,7 +37,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdQuery:                         commandMetadata(ScopeHubMerge, false, true),
 	protocol.CmdHeartbeat:                     commandMetadata(ScopeSession, false, true),
 	protocol.CmdSessionVisualized:             commandMetadata(ScopeSession, false, true),
-	protocol.CmdMute:                          commandMetadata(ScopeSession, false, true),
+	protocol.CmdMuteWorkspace:                 commandMetadata(ScopeEndpoint, false, true),
 	protocol.CmdQueryPRs:                      commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdMutePR:                        commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdMuteRepo:                      commandMetadata(ScopeHubLocal, false, true),

--- a/internal/daemon/command_meta_test.go
+++ b/internal/daemon/command_meta_test.go
@@ -17,7 +17,7 @@ func TestCommandMetaCoversAllCommands(t *testing.T) {
 		protocol.CmdQuery,
 		protocol.CmdHeartbeat,
 		protocol.CmdSessionVisualized,
-		protocol.CmdMute,
+		protocol.CmdMuteWorkspace,
 		protocol.CmdQueryPRs,
 		protocol.CmdMutePR,
 		protocol.CmdMuteRepo,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1622,8 +1622,6 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		visualizedMsg := msg.(*protocol.SessionVisualizedMessage)
 		d.handleSessionVisualized(visualizedMsg.ID)
 		d.sendOK(conn)
-	case protocol.CmdMute:
-		d.handleMute(conn, msg.(*protocol.MuteMessage))
 	case protocol.CmdQueryPRs:
 		d.handleQueryPRs(conn, msg.(*protocol.QueryPRsMessage))
 	case protocol.CmdMutePR:
@@ -1691,7 +1689,7 @@ func (d *Daemon) handleRegister(conn net.Conn, msg *protocol.RegisterMessage) {
 	}
 	session.WorkspaceID = workspaceID
 	d.store.AddWorkspace(&protocol.Workspace{ID: workspaceID, Title: session.Label, Directory: session.Directory, Status: protocol.WorkspaceStatusLaunching})
-	d.workspaces.register(workspaceID, session.Label, session.Directory)
+	d.workspaces.register(workspaceID, session.Label, session.Directory, false)
 	d.store.Add(session)
 	if resumeSessionID := d.consumePendingResumeSessionID(session.ID); resumeSessionID != "" {
 		d.store.SetResumeSessionID(session.ID, resumeSessionID)
@@ -2400,11 +2398,6 @@ func (d *Daemon) handleHeartbeat(conn net.Conn, msg *protocol.HeartbeatMessage) 
 	d.sendOK(conn)
 }
 
-func (d *Daemon) handleMute(conn net.Conn, msg *protocol.MuteMessage) {
-	d.store.ToggleMute(msg.ID)
-	d.sendOK(conn)
-}
-
 func (d *Daemon) handleQueryPRs(conn net.Conn, msg *protocol.QueryPRsMessage) {
 	prs := d.store.ListPRs(protocol.Deref(msg.Filter))
 	resp := protocol.Response{
@@ -2856,7 +2849,7 @@ func (d *Daemon) handleInjectTestSession(conn net.Conn, msg *protocol.InjectTest
 			Status:    protocol.WorkspaceStatusLaunching,
 		})
 	}
-	d.workspaces.register(workspaceID, msg.Session.Label, msg.Session.Directory)
+	d.workspaces.register(workspaceID, msg.Session.Label, msg.Session.Directory, false)
 
 	// Add session directly to store
 	d.store.Add(&msg.Session)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1628,6 +1628,12 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleMutePR(conn, msg.(*protocol.MutePRMessage))
 	case protocol.CmdMuteRepo:
 		d.handleMuteRepo(conn, msg.(*protocol.MuteRepoMessage))
+	case protocol.CmdMuteWorkspace:
+		if _, errMsg := d.toggleWorkspaceMute(msg.(*protocol.MuteWorkspaceMessage).WorkspaceID); errMsg != "" {
+			d.sendError(conn, errMsg)
+			return
+		}
+		d.sendOK(conn)
 	case protocol.CmdCollapseRepo:
 		d.handleCollapseRepo(conn, msg.(*protocol.CollapseRepoMessage))
 	case protocol.CmdQueryRepos:

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1447,7 +1447,7 @@ func (b *fakeReviewLoopBackend) SetScrollback(sessionID, text string) {
 
 func addTestWorkspace(d *Daemon, id, directory string) {
 	d.store.AddWorkspace(&protocol.Workspace{ID: id, Title: id, Directory: directory, Status: protocol.WorkspaceStatusLaunching})
-	d.workspaces.register(id, id, directory)
+	d.workspaces.register(id, id, directory, false)
 }
 
 func TestDaemon_HandleSpawnSession_UsesStoredResumeSessionIDForRecoverableClaudeSession(t *testing.T) {

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -752,8 +752,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleMuteRepoWS(msg.(*protocol.MuteRepoMessage))
 	case protocol.CmdMuteAuthor:
 		d.handleMuteAuthorWS(msg.(*protocol.MuteAuthorMessage))
-	case protocol.CmdMute:
-		d.handleMuteSessionWS(msg.(*protocol.MuteMessage))
+	case protocol.CmdMuteWorkspace:
+		d.handleMuteWorkspaceWS(client, msg.(*protocol.MuteWorkspaceMessage))
 	case protocol.CmdRefreshPRs:
 		d.handleRefreshPRsWS(client)
 	case protocol.CmdFetchPRDetails:
@@ -979,10 +979,6 @@ func (d *Daemon) tryHandleRemoteWSCommand(client *wsClient, cmd string, msg inte
 
 func remoteCommandSessionID(cmd string, msg interface{}) string {
 	switch cmd {
-	case protocol.CmdMute:
-		if typed, ok := msg.(*protocol.MuteMessage); ok {
-			return typed.ID
-		}
 	case protocol.CmdSessionVisualized:
 		if typed, ok := msg.(*protocol.SessionVisualizedMessage); ok {
 			return typed.ID
@@ -1053,6 +1049,10 @@ func remoteCommandEndpointID(cmd string, msg interface{}) string {
 		}
 	case protocol.CmdRegisterWorkspace:
 		if typed, ok := msg.(*protocol.RegisterWorkspaceMessage); ok {
+			return strings.TrimSpace(protocol.Deref(typed.EndpointID))
+		}
+	case protocol.CmdMuteWorkspace:
+		if typed, ok := msg.(*protocol.MuteWorkspaceMessage); ok {
 			return strings.TrimSpace(protocol.Deref(typed.EndpointID))
 		}
 	case protocol.CmdCreateWorktree:

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -314,25 +314,29 @@ func (d *Daemon) handleRegisterWorkspace(client *wsClient, msg *protocol.Registe
 }
 
 func (d *Daemon) handleMuteWorkspaceWS(client *wsClient, msg *protocol.MuteWorkspaceMessage) {
-	id := strings.TrimSpace(msg.WorkspaceID)
+	if _, errMsg := d.toggleWorkspaceMute(msg.WorkspaceID); errMsg != "" {
+		d.sendCommandError(client, protocol.CmdMuteWorkspace, errMsg)
+	}
+}
+
+func (d *Daemon) toggleWorkspaceMute(workspaceID string) (protocol.Workspace, string) {
+	id := strings.TrimSpace(workspaceID)
 	if id == "" {
-		d.sendCommandError(client, protocol.CmdMuteWorkspace, "missing workspace_id")
-		return
+		return protocol.Workspace{}, "missing workspace_id"
 	}
 	if d.workspaces == nil {
-		d.sendCommandError(client, protocol.CmdMuteWorkspace, "workspace registry unavailable")
-		return
+		return protocol.Workspace{}, "workspace registry unavailable"
 	}
 	snapshot, ok := d.workspaces.toggleMuted(id)
 	if !ok {
-		d.sendCommandError(client, protocol.CmdMuteWorkspace, "workspace not found")
-		return
+		return protocol.Workspace{}, "workspace not found"
 	}
 	d.store.ToggleWorkspaceMute(id)
 	d.wsHub.Broadcast(&protocol.WebSocketEvent{
 		Event:     protocol.EventWorkspaceStateChanged,
 		Workspace: &snapshot,
 	})
+	return snapshot, ""
 }
 
 // handleUnregisterWorkspace closes the workspace AND every session that

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -18,6 +18,7 @@ type workspaceEntry struct {
 	title     string
 	directory string
 	status    protocol.WorkspaceStatus
+	muted     bool
 	// sessionIDs in this workspace, used for status rollup.
 	sessionIDs map[string]struct{}
 }
@@ -39,7 +40,7 @@ func newWorkspaceRegistry() *workspaceRegistry {
 
 // register inserts or updates a workspace. Returns the snapshot to broadcast
 // and a flag indicating whether this is a new registration vs an update.
-func (r *workspaceRegistry) register(id, title, directory string) (protocol.Workspace, bool) {
+func (r *workspaceRegistry) register(id, title, directory string, muted bool) (protocol.Workspace, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -54,7 +55,19 @@ func (r *workspaceRegistry) register(id, title, directory string) (protocol.Work
 	}
 	entry.title = title
 	entry.directory = directory
+	entry.muted = muted
 	return snapshotEntry(entry), !existed
+}
+
+func (r *workspaceRegistry) toggleMuted(id string) (protocol.Workspace, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, ok := r.workspaces[id]
+	if !ok {
+		return protocol.Workspace{}, false
+	}
+	entry.muted = !entry.muted
+	return snapshotEntry(entry), true
 }
 
 func (r *workspaceRegistry) unregister(id string) (protocol.Workspace, bool) {
@@ -173,6 +186,7 @@ func snapshotEntry(e *workspaceEntry) protocol.Workspace {
 		Title:     e.title,
 		Directory: e.directory,
 		Status:    e.status,
+		Muted:     e.muted,
 	}
 }
 
@@ -271,7 +285,9 @@ func (d *Daemon) handleRegisterWorkspace(client *wsClient, msg *protocol.Registe
 	if d.workspaces == nil {
 		d.workspaces = newWorkspaceRegistry()
 	}
-	snapshot, isNew := d.workspaces.register(id, title, directory)
+	existing := d.store.GetWorkspace(id)
+	muted := existing != nil && existing.Muted
+	snapshot, isNew := d.workspaces.register(id, title, directory, muted)
 	d.store.AddWorkspace(&snapshot)
 	// Make workspace directories available in the recent-locations picker.
 	label := title
@@ -293,6 +309,28 @@ func (d *Daemon) handleRegisterWorkspace(client *wsClient, msg *protocol.Registe
 	}
 	d.wsHub.Broadcast(&protocol.WebSocketEvent{
 		Event:     eventName,
+		Workspace: &snapshot,
+	})
+}
+
+func (d *Daemon) handleMuteWorkspaceWS(client *wsClient, msg *protocol.MuteWorkspaceMessage) {
+	id := strings.TrimSpace(msg.WorkspaceID)
+	if id == "" {
+		d.sendCommandError(client, protocol.CmdMuteWorkspace, "missing workspace_id")
+		return
+	}
+	if d.workspaces == nil {
+		d.sendCommandError(client, protocol.CmdMuteWorkspace, "workspace registry unavailable")
+		return
+	}
+	snapshot, ok := d.workspaces.toggleMuted(id)
+	if !ok {
+		d.sendCommandError(client, protocol.CmdMuteWorkspace, "workspace not found")
+		return
+	}
+	d.store.ToggleWorkspaceMute(id)
+	d.wsHub.Broadcast(&protocol.WebSocketEvent{
+		Event:     protocol.EventWorkspaceStateChanged,
 		Workspace: &snapshot,
 	})
 }
@@ -351,7 +389,7 @@ func (d *Daemon) loadWorkspacesFromStore() {
 		if ws == nil {
 			continue
 		}
-		d.workspaces.register(ws.ID, ws.Title, ws.Directory)
+		d.workspaces.register(ws.ID, ws.Title, ws.Directory, ws.Muted)
 	}
 	for _, session := range d.store.List("") {
 		if session == nil {

--- a/internal/daemon/workspace_test.go
+++ b/internal/daemon/workspace_test.go
@@ -1,9 +1,12 @@
 package daemon
 
 import (
+	"encoding/json"
+	"net"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
 )
@@ -260,6 +263,59 @@ func TestHandleRegisterWorkspace_BroadcastsRegisteredThenStateChanged(t *testing
 	}
 	if events[1].Event != protocol.EventWorkspaceStateChanged {
 		t.Fatalf("second broadcast = %q, want workspace_state_changed", events[1].Event)
+	}
+}
+
+func TestHandleConnection_MuteWorkspaceDispatchesSocketCommand(t *testing.T) {
+	d := newDaemonForTest(t)
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        "ws1",
+		Title:     "Workspace 1",
+		Directory: "/repo",
+	})
+	cap := captureBroadcasts(d)
+
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.handleConnection(serverConn)
+	}()
+
+	if err := json.NewEncoder(clientConn).Encode(protocol.MuteWorkspaceMessage{
+		Cmd:         protocol.CmdMuteWorkspace,
+		WorkspaceID: "ws1",
+	}); err != nil {
+		t.Fatalf("send mute_workspace command: %v", err)
+	}
+	var resp protocol.Response
+	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+		t.Fatalf("decode mute_workspace response: %v", err)
+	}
+	if !resp.Ok {
+		t.Fatalf("mute_workspace response ok=false error=%v", resp.Error)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("mute_workspace connection did not finish")
+	}
+
+	workspace := d.store.GetWorkspace("ws1")
+	if workspace == nil {
+		t.Fatal("workspace missing from store after mute")
+	}
+	if !workspace.Muted {
+		t.Fatal("workspace not muted in store after socket command")
+	}
+	events := cap.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("expected one workspace_state_changed broadcast, got %d: %+v", len(events), events)
+	}
+	if events[0].Event != protocol.EventWorkspaceStateChanged || events[0].Workspace == nil || !events[0].Workspace.Muted {
+		t.Fatalf("unexpected broadcast: %+v", events[0])
 	}
 }
 

--- a/internal/daemon/workspace_test.go
+++ b/internal/daemon/workspace_test.go
@@ -82,7 +82,7 @@ func TestRollupWorkspaceStatus_PriorityOrdering(t *testing.T) {
 
 func TestWorkspaceRegistry_RegisterUnregister(t *testing.T) {
 	r := newWorkspaceRegistry()
-	snapshot, isNew := r.register("ws1", "Workspace 1", "/repo")
+	snapshot, isNew := r.register("ws1", "Workspace 1", "/repo", false)
 	if !isNew {
 		t.Fatal("first register should be new")
 	}
@@ -93,7 +93,7 @@ func TestWorkspaceRegistry_RegisterUnregister(t *testing.T) {
 		t.Fatalf("initial status = %q, want idle", snapshot.Status)
 	}
 
-	_, isNew = r.register("ws1", "Renamed", "/repo")
+	_, isNew = r.register("ws1", "Renamed", "/repo", false)
 	if isNew {
 		t.Fatal("second register should not be new")
 	}
@@ -112,8 +112,8 @@ func TestWorkspaceRegistry_RegisterUnregister(t *testing.T) {
 
 func TestWorkspaceRegistry_AssociateAndDissociate(t *testing.T) {
 	r := newWorkspaceRegistry()
-	r.register("ws1", "ws", "/repo")
-	r.register("ws2", "ws", "/repo")
+	r.register("ws1", "ws", "/repo", false)
+	r.register("ws2", "ws", "/repo", false)
 
 	if !r.associateSession("s1", "ws1", "Session 1") {
 		t.Fatal("associate should succeed")
@@ -182,7 +182,7 @@ func TestDissociateLastSessionUnregistersWorkspace(t *testing.T) {
 
 func TestWorkspaceRegistry_UnregisterCleansSessionLinks(t *testing.T) {
 	r := newWorkspaceRegistry()
-	r.register("ws1", "ws", "/repo")
+	r.register("ws1", "ws", "/repo", false)
 	r.associateSession("s1", "ws1", "Session 1")
 	r.associateSession("s2", "ws1", "Session 2")
 

--- a/internal/daemon/ws_session.go
+++ b/internal/daemon/ws_session.go
@@ -9,11 +9,6 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-func (d *Daemon) handleMuteSessionWS(msg *protocol.MuteMessage) {
-	d.store.ToggleMute(msg.ID)
-	d.broadcastSessionsUpdated()
-}
-
 func (d *Daemon) handleClearSessionsWS() {
 	d.logf("Clearing all sessions")
 	d.clearAllSessions()

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -1338,8 +1338,7 @@ func sessionsMatch(left, right protocol.Session) bool {
 		protocol.Deref(left.NeedsReviewAfterLongRun) == protocol.Deref(right.NeedsReviewAfterLongRun) &&
 		protocol.Deref(left.Recoverable) == protocol.Deref(right.Recoverable) &&
 		strings.Join(left.Todos, "\x00") == strings.Join(right.Todos, "\x00") &&
-		left.LastSeen == right.LastSeen &&
-		left.Muted == right.Muted
+		left.LastSeen == right.LastSeen
 }
 
 func workspaceLayoutsEqual(left, right map[string]protocol.Workspace) bool {

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "72"
+const ProtocolVersion = "73"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -40,7 +40,7 @@ const (
 	CmdQuery                         = "query"
 	CmdHeartbeat                     = "heartbeat"
 	CmdSessionVisualized             = "session_visualized"
-	CmdMute                          = "mute"
+	CmdMuteWorkspace                 = "mute_workspace"
 	CmdQueryPRs                      = "query_prs"
 	CmdMutePR                        = "mute_pr"
 	CmdMuteRepo                      = "mute_repo"
@@ -322,8 +322,8 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		}
 		return peek.Cmd, &msg, nil
 
-	case CmdMute:
-		var msg MuteMessage
+	case CmdMuteWorkspace:
+		var msg MuteWorkspaceMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1163,14 +1163,6 @@ type MuteAuthorMessage struct {
 	Cmd string `json:"cmd"`
 }
 
-type MuteMessage struct {
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
-
-	// ID corresponds to the JSON schema field "id".
-	ID string `json:"id"`
-}
-
 type MutePRMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -1185,6 +1177,17 @@ type MuteRepoMessage struct {
 
 	// Repo corresponds to the JSON schema field "repo".
 	Repo string `json:"repo"`
+}
+
+type MuteWorkspaceMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// EndpointID corresponds to the JSON schema field "endpoint_id".
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
 }
 
 type PR struct {
@@ -2058,9 +2061,6 @@ type Session struct {
 	// MainRepo corresponds to the JSON schema field "main_repo".
 	MainRepo *string `json:"main_repo,omitempty,omitzero"`
 
-	// Muted corresponds to the JSON schema field "muted".
-	Muted bool `json:"muted"`
-
 	// NeedsReviewAfterLongRun corresponds to the JSON schema field
 	// "needs_review_after_long_run".
 	NeedsReviewAfterLongRun *bool `json:"needs_review_after_long_run,omitempty,omitzero"`
@@ -2638,6 +2638,9 @@ type Workspace struct {
 
 	// Layout corresponds to the JSON schema field "layout".
 	Layout *WorkspaceLayout `json:"layout,omitempty,omitzero"`
+
+	// Muted corresponds to the JSON schema field "muted".
+	Muted bool `json:"muted"`
 
 	// Status corresponds to the JSON schema field "status".
 	Status WorkspaceStatus `json:"status"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -134,7 +134,6 @@ model Session {
   recoverable?: boolean;        // True when session can be recovered after daemon restart (agent has resumable conversation)
   todos?: string[];             // Optional: can be empty/absent
   last_seen: string;            // ISO timestamp, always set
-  muted: boolean;               // Always has value (defaults false)
 }
 
 // Workspace is a directory plus one or more agent sessions and its split layout.
@@ -143,6 +142,7 @@ model Workspace {
   title: string;
   directory: string;
   status: WorkspaceStatus;
+  muted: boolean;               // Muting parks the whole workspace out of attention surfaces.
   layout?: WorkspaceLayout;
 }
 
@@ -386,9 +386,10 @@ model SessionVisualizedMessage {
   id: string;
 }
 
-model MuteMessage {
-  cmd: "mute";
-  id: string;
+model MuteWorkspaceMessage {
+  cmd: "mute_workspace";
+  workspace_id: string;
+  endpoint_id?: string;
 }
 
 model QueryPRsMessage {

--- a/internal/store/review_loop_runs_test.go
+++ b/internal/store/review_loop_runs_test.go
@@ -223,7 +223,6 @@ func insertTestSession(t *testing.T, s *Store, sessionID string) {
 		StateSince:     "2026-03-06T09:00:00Z",
 		StateUpdatedAt: "2026-03-06T09:00:00Z",
 		LastSeen:       "2026-03-06T09:00:00Z",
-		Muted:          false,
 	})
 	if got := s.Get(sessionID); got == nil {
 		t.Fatalf("insert test session %q did not persist", sessionID)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -810,6 +810,19 @@ func applyMigration41(tx *sql.Tx) error {
 		return err
 	}
 	if hasSessionMuted {
+		if _, err := tx.Exec(`
+			UPDATE workspaces
+			SET muted = 1
+			WHERE id IN (
+				SELECT DISTINCT workspace_id
+				FROM sessions
+				WHERE muted = 1
+					AND workspace_id IS NOT NULL
+					AND workspace_id != ''
+			)
+		`); err != nil {
+			return err
+		}
 		if _, err := tx.Exec("ALTER TABLE sessions DROP COLUMN muted"); err != nil {
 			return err
 		}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -20,8 +20,7 @@ CREATE TABLE IF NOT EXISTS sessions (
 	state_since TEXT NOT NULL,
 	state_updated_at TEXT NOT NULL,
 	todos TEXT,
-	last_seen TEXT NOT NULL,
-	muted INTEGER NOT NULL DEFAULT 0
+	last_seen TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS prs (
@@ -288,12 +287,13 @@ var migrations = []migration{
 	{33, "drop unused wont_fix columns from review_comments", ""},
 	{34, "add profile to endpoints", "ALTER TABLE endpoints ADD COLUMN profile TEXT NOT NULL DEFAULT ''"},
 	{35, "create canvas-workspaces table and add workspace_id to sessions", `
-		CREATE TABLE IF NOT EXISTS workspaces (
-			id TEXT PRIMARY KEY,
-			title TEXT NOT NULL,
-			directory TEXT NOT NULL,
-			created_at TEXT NOT NULL
-		);
+	CREATE TABLE IF NOT EXISTS workspaces (
+		id TEXT PRIMARY KEY,
+		title TEXT NOT NULL,
+		directory TEXT NOT NULL,
+		muted INTEGER NOT NULL DEFAULT 0,
+		created_at TEXT NOT NULL
+	);
 		ALTER TABLE sessions ADD COLUMN workspace_id TEXT;
 		CREATE INDEX IF NOT EXISTS idx_sessions_workspace_id ON sessions(workspace_id);
 	`},
@@ -325,6 +325,9 @@ var migrations = []migration{
 		ALTER TABLE sessions ADD COLUMN agent_driver_report_seq INTEGER NOT NULL DEFAULT 0;
 	`},
 	{40, "add workspace pane lifecycle status", ""},
+	{41, "move session mute state to workspaces", `
+		ALTER TABLE workspaces ADD COLUMN muted INTEGER NOT NULL DEFAULT 0;
+	`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -455,6 +458,11 @@ func migrateDB(db *sql.DB) error {
 			}
 		} else if m.version == 40 {
 			if err := applyMigration40(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 41 {
+			if err := applyMigration41(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -781,6 +789,28 @@ func applyMigration40(tx *sql.Tx) error {
 	}
 	if !hasError {
 		if _, err := tx.Exec("ALTER TABLE workspace_layout_panes ADD COLUMN error TEXT NOT NULL DEFAULT ''"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyMigration41(tx *sql.Tx) error {
+	hasWorkspaceMuted, err := columnExists(tx, "workspaces", "muted")
+	if err != nil {
+		return err
+	}
+	if !hasWorkspaceMuted {
+		if _, err := tx.Exec("ALTER TABLE workspaces ADD COLUMN muted INTEGER NOT NULL DEFAULT 0"); err != nil {
+			return err
+		}
+	}
+	hasSessionMuted, err := columnExists(tx, "sessions", "muted")
+	if err != nil {
+		return err
+	}
+	if hasSessionMuted {
+		if _, err := tx.Exec("ALTER TABLE sessions DROP COLUMN muted"); err != nil {
 			return err
 		}
 	}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"path/filepath"
 	"testing"
 )
@@ -274,6 +275,89 @@ func TestMigration37_ConvertsSessionLayoutToWorkspaceLayout(t *testing.T) {
 		if count != 0 {
 			t.Fatalf("legacy table %s still exists", legacyTable)
 		}
+	}
+}
+
+func TestMigration41_PreservesMutedSessionsAsMutedWorkspaces(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "migration-41.db")
+	rawDB, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open raw sqlite db: %v", err)
+	}
+	if _, err := rawDB.Exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			label TEXT NOT NULL,
+			directory TEXT NOT NULL,
+			state TEXT NOT NULL DEFAULT 'idle',
+			state_since TEXT NOT NULL,
+			state_updated_at TEXT NOT NULL,
+			todos TEXT,
+			last_seen TEXT NOT NULL,
+			workspace_id TEXT,
+			muted INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE workspaces (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			directory TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		);
+		CREATE TABLE schema_migrations (
+			version INTEGER PRIMARY KEY,
+			applied_at TEXT NOT NULL
+		);
+		INSERT INTO workspaces (id, title, directory, created_at) VALUES
+			('ws-muted', 'Muted workspace', '/repo/muted', '2026-05-31T00:00:00Z'),
+			('ws-active', 'Active workspace', '/repo/active', '2026-05-31T00:00:00Z');
+		INSERT INTO sessions (
+			id, label, directory, state, state_since, state_updated_at, last_seen, workspace_id, muted
+		) VALUES
+			('s-muted', 'Muted session', '/repo/muted', 'idle', '2026-05-31T00:00:00Z', '2026-05-31T00:00:00Z', '2026-05-31T00:00:00Z', 'ws-muted', 1),
+			('s-active', 'Active session', '/repo/active', 'idle', '2026-05-31T00:00:00Z', '2026-05-31T00:00:00Z', '2026-05-31T00:00:00Z', 'ws-active', 0);
+	`); err != nil {
+		rawDB.Close()
+		t.Fatalf("seed migration 41 legacy db: %v", err)
+	}
+	for version := 1; version <= 40; version++ {
+		if _, err := rawDB.Exec(
+			"INSERT INTO schema_migrations (version, applied_at) VALUES (?, datetime('now'))",
+			version,
+		); err != nil {
+			rawDB.Close()
+			t.Fatalf("seed migration version %d: %v", version, err)
+		}
+	}
+	rawDB.Close()
+
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB() migrating version 41 error = %v", err)
+	}
+	defer db.Close()
+
+	for _, tc := range []struct {
+		workspaceID string
+		wantMuted   int
+	}{
+		{"ws-muted", 1},
+		{"ws-active", 0},
+	} {
+		var got int
+		if err := db.QueryRow("SELECT muted FROM workspaces WHERE id = ?", tc.workspaceID).Scan(&got); err != nil {
+			t.Fatalf("query workspace %s muted: %v", tc.workspaceID, err)
+		}
+		if got != tc.wantMuted {
+			t.Fatalf("workspace %s muted = %d, want %d", tc.workspaceID, got, tc.wantMuted)
+		}
+	}
+
+	var sessionMutedColumns int
+	if err := db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'muted'").Scan(&sessionMutedColumns); err != nil {
+		t.Fatalf("query sessions.muted column: %v", err)
+	}
+	if sessionMutedColumns != 0 {
+		t.Fatalf("sessions.muted column still exists after migration")
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -141,8 +141,8 @@ func (s *Store) Add(session *protocol.Session) {
 	session.Agent = protocol.SessionAgent(normalizedAgent)
 	_, err = s.db.Exec(`
 		INSERT INTO sessions
-		(id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, todos, last_seen, muted, recoverable)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		(id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, todos, last_seen, recoverable)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			label = excluded.label,
 			agent = excluded.agent,
@@ -157,7 +157,6 @@ func (s *Store) Add(session *protocol.Session) {
 			state_updated_at = excluded.state_updated_at,
 			todos = excluded.todos,
 			last_seen = excluded.last_seen,
-			muted = excluded.muted,
 			recoverable = excluded.recoverable`,
 		session.ID,
 		session.Label,
@@ -173,7 +172,6 @@ func (s *Store) Add(session *protocol.Session) {
 		session.StateUpdatedAt,
 		string(todosJSON),
 		session.LastSeen,
-		boolToInt(session.Muted),
 		boolToInt(protocol.Deref(session.Recoverable)),
 	)
 	if err != nil {
@@ -193,11 +191,11 @@ func (s *Store) Get(id string) *protocol.Session {
 	var session protocol.Session
 	var todosJSON string
 	var stateSince, stateUpdatedAt, lastSeen string
-	var muted, isWorktree, recoverable int
+	var isWorktree, recoverable int
 	var endpointID, workspaceID, branch, mainRepo sql.NullString
 
 	err := s.db.QueryRow(`
-		SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, todos, last_seen, muted, recoverable
+		SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, todos, last_seen, recoverable
 		FROM sessions WHERE id = ?`, id).Scan(
 		&session.ID,
 		&session.Label,
@@ -213,7 +211,6 @@ func (s *Store) Get(id string) *protocol.Session {
 		&stateUpdatedAt,
 		&todosJSON,
 		&lastSeen,
-		&muted,
 		&recoverable,
 	)
 	if err != nil {
@@ -238,7 +235,6 @@ func (s *Store) Get(id string) *protocol.Session {
 	session.StateSince = stateSince
 	session.StateUpdatedAt = stateUpdatedAt
 	session.LastSeen = lastSeen
-	session.Muted = muted == 1
 	if recoverable == 1 {
 		session.Recoverable = protocol.Ptr(true)
 	}
@@ -322,11 +318,11 @@ func (s *Store) List(stateFilter string) []*protocol.Session {
 
 	if stateFilter == "" {
 		rows, err = s.db.Query(`
-			SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, todos, last_seen, muted, recoverable
+			SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, todos, last_seen, recoverable
 			FROM sessions ORDER BY label, id`)
 	} else {
 		rows, err = s.db.Query(`
-			SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, todos, last_seen, muted, recoverable
+			SELECT id, label, agent, directory, endpoint_id, workspace_id, branch, is_worktree, main_repo, state, state_since, state_updated_at, todos, last_seen, recoverable
 			FROM sessions WHERE state = ? ORDER BY label, id`, stateFilter)
 	}
 	if err != nil {
@@ -339,7 +335,7 @@ func (s *Store) List(stateFilter string) []*protocol.Session {
 		var session protocol.Session
 		var todosJSON string
 		var stateSince, stateUpdatedAt, lastSeen string
-		var muted, isWorktree, recoverable int
+		var isWorktree, recoverable int
 		var endpointID, workspaceID, branch, mainRepo sql.NullString
 
 		err := rows.Scan(
@@ -357,7 +353,6 @@ func (s *Store) List(stateFilter string) []*protocol.Session {
 			&stateUpdatedAt,
 			&todosJSON,
 			&lastSeen,
-			&muted,
 			&recoverable,
 		)
 		if err != nil {
@@ -382,7 +377,6 @@ func (s *Store) List(stateFilter string) []*protocol.Session {
 		session.StateSince = stateSince
 		session.StateUpdatedAt = stateUpdatedAt
 		session.LastSeen = lastSeen
-		session.Muted = muted == 1
 		if recoverable == 1 {
 			session.Recoverable = protocol.Ptr(true)
 		}
@@ -831,24 +825,6 @@ func (s *Store) ApplyAgentDriverMetadata(id, runID string, seq uint64, metadata 
 	}
 	updated, _ := result.RowsAffected()
 	return updated == 1
-}
-
-// ToggleMute toggles a session's muted state
-func (s *Store) ToggleMute(id string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.db == nil {
-		if session := s.sessions[id]; session != nil {
-			session.Muted = !session.Muted
-		}
-		return
-	}
-
-	_, err := s.db.Exec("UPDATE sessions SET muted = NOT muted WHERE id = ?", id)
-	if err != nil {
-		log.Printf("[store] ToggleMute: failed for session %s: %v", id, err)
-	}
 }
 
 // SetPRs replaces all PRs, preserving muted state, detail fields, and computing HasNewChanges

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -370,34 +370,6 @@ func TestStore_UpdateStateWithTimestamp_BackwardCompatibleWithRFC3339(t *testing
 	}
 }
 
-func TestStore_ToggleMute(t *testing.T) {
-	s := New()
-
-	s.Add(&protocol.Session{
-		ID:    "abc123",
-		Muted: false,
-	})
-
-	// First toggle: false -> true
-	s.ToggleMute("abc123")
-	if !s.Get("abc123").Muted {
-		t.Error("expected Muted=true after first toggle")
-	}
-
-	// Second toggle: true -> false
-	s.ToggleMute("abc123")
-	if s.Get("abc123").Muted {
-		t.Error("expected Muted=false after second toggle")
-	}
-}
-
-func TestStore_ToggleMute_NonExistent(t *testing.T) {
-	s := New()
-
-	// Should not panic on non-existent session
-	s.ToggleMute("nonexistent")
-}
-
 func TestStore_SetAndListPRs(t *testing.T) {
 	s := New()
 

--- a/internal/store/workspace.go
+++ b/internal/store/workspace.go
@@ -19,12 +19,12 @@ func (s *Store) AddWorkspace(ws *protocol.Workspace) {
 	}
 	createdAt := time.Now().UTC().Format(time.RFC3339Nano)
 	if _, err := s.db.Exec(`
-		INSERT INTO workspaces (id, title, directory, created_at)
-		VALUES (?, ?, ?, ?)
+		INSERT INTO workspaces (id, title, directory, muted, created_at)
+		VALUES (?, ?, ?, COALESCE(?, 0), ?)
 		ON CONFLICT(id) DO UPDATE SET
 			title = excluded.title,
 			directory = excluded.directory`,
-		ws.ID, ws.Title, ws.Directory, createdAt,
+		ws.ID, ws.Title, ws.Directory, boolToInt(ws.Muted), createdAt,
 	); err != nil {
 		log.Printf("[store] AddWorkspace: failed to upsert workspace %s: %v", ws.ID, err)
 	}
@@ -57,12 +57,14 @@ func (s *Store) GetWorkspace(id string) *protocol.Workspace {
 		return nil
 	}
 	var ws protocol.Workspace
+	var muted int
 	err := s.db.QueryRow(`
-		SELECT id, title, directory FROM workspaces WHERE id = ?`, id).
-		Scan(&ws.ID, &ws.Title, &ws.Directory)
+		SELECT id, title, directory, muted FROM workspaces WHERE id = ?`, id).
+		Scan(&ws.ID, &ws.Title, &ws.Directory, &muted)
 	if err != nil {
 		return nil
 	}
+	ws.Muted = muted == 1
 	return &ws
 }
 
@@ -75,7 +77,7 @@ func (s *Store) ListWorkspaces() []*protocol.Workspace {
 	if s.db == nil {
 		return nil
 	}
-	rows, err := s.db.Query(`SELECT id, title, directory FROM workspaces ORDER BY created_at`)
+	rows, err := s.db.Query(`SELECT id, title, directory, muted FROM workspaces ORDER BY created_at`)
 	if err != nil {
 		return nil
 	}
@@ -84,12 +86,29 @@ func (s *Store) ListWorkspaces() []*protocol.Workspace {
 	var out []*protocol.Workspace
 	for rows.Next() {
 		var ws protocol.Workspace
-		if err := rows.Scan(&ws.ID, &ws.Title, &ws.Directory); err != nil {
+		var muted int
+		if err := rows.Scan(&ws.ID, &ws.Title, &ws.Directory, &muted); err != nil {
 			continue
 		}
+		ws.Muted = muted == 1
 		out = append(out, &ws)
 	}
 	return out
+}
+
+// ToggleWorkspaceMute toggles a workspace's muted state. Session mute state is
+// not part of the app-facing model; muting is owned by the workspace.
+func (s *Store) ToggleWorkspaceMute(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return
+	}
+
+	if _, err := s.db.Exec(`UPDATE workspaces SET muted = NOT muted WHERE id = ?`, id); err != nil {
+		log.Printf("[store] ToggleWorkspaceMute: failed for workspace %s: %v", id, err)
+	}
 }
 
 // AssignSessionWorkspace updates the workspace_id column on a session. A live

--- a/internal/store/workspace_test.go
+++ b/internal/store/workspace_test.go
@@ -26,9 +26,32 @@ func TestStoreWorkspaceRoundTripAndMembership(t *testing.T) {
 	if got == nil || got.Title != "Project" {
 		t.Fatalf("GetWorkspace() = %#v, want persisted workspace", got)
 	}
+	if got.Muted {
+		t.Fatalf("new workspace muted = true, want false")
+	}
 	members := s.SessionsInWorkspace("workspace-1")
 	if len(members) != 1 || members[0] != "session-1" {
 		t.Fatalf("SessionsInWorkspace() = %#v, want session-1", members)
+	}
+}
+
+func TestToggleWorkspaceMute(t *testing.T) {
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	s.AddWorkspace(&protocol.Workspace{ID: "workspace-1", Title: "Project", Directory: "/tmp/project"})
+
+	s.ToggleWorkspaceMute("workspace-1")
+	if got := s.GetWorkspace("workspace-1"); got == nil || !got.Muted {
+		t.Fatalf("workspace after first toggle = %+v, want muted", got)
+	}
+
+	s.ToggleWorkspaceMute("workspace-1")
+	if got := s.GetWorkspace("workspace-1"); got == nil || got.Muted {
+		t.Fatalf("workspace after second toggle = %+v, want unmuted", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make muting a workspace-level action instead of a session-level action
- move persisted mute state from `sessions` to `workspaces` and update the daemon protocol to `mute_workspace`
- update sidebar/dashboard UI so muted workspaces move as a whole, with no session mute affordances

## Why
Sessions now live inside workspaces as panels, so muting one session leaves the workspace model split between visible and muted surfaces. The product behavior should be simpler: the whole workspace is either active or parked.

## Validation
- `pnpm --dir app build`
- `pnpm --dir app test`
- `go test ./...`
