### PR TITLE
Auto-close sessions on clean process exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-05-31]
 
 ### Changed
+- **Auto-Close On Exit**: When a session's process exits cleanly (exit code 0), the session now closes itself instead of leaving a dead `[Process exited]` pane around. Sessions that crash or are killed (non-zero exit) stay open so you can still read the error.
 - **Workspace Muting**: Muting now applies to whole workspaces instead of individual sessions. Muted workspaces move to the muted section together with all of their sessions, and session rows no longer expose mute controls.
 
 ### Removed

--- a/app/package.json
+++ b/app/package.json
@@ -44,6 +44,7 @@
     "real-app:scenario-workspace-switching": "node scripts/real-app-harness/scenario-workspace-switching.mjs",
     "real-app:scenario-workspace-close-last-session-switches-back": "node scripts/real-app-harness/scenario-workspace-close-last-session-switches-back.mjs",
     "real-app:scenario-workspace-close-one-session-keeps-selection": "node scripts/real-app-harness/scenario-workspace-close-one-session-keeps-selection.mjs",
+    "real-app:scenario-autoclose-on-exit": "node scripts/real-app-harness/scenario-autoclose-on-exit.mjs",
     "real-app:serial-matrix": "node scripts/real-app-harness/run-serial-matrix.mjs",
     "e2e": "playwright test",
     "e2e:settings-visual": "playwright test e2e/settings-visual.spec.ts",

--- a/app/scripts/real-app-harness/run-serial-matrix.mjs
+++ b/app/scripts/real-app-harness/run-serial-matrix.mjs
@@ -41,6 +41,11 @@ const scenarioCatalog = [
     command: ['pnpm', 'run', 'real-app:scenario-workspace-close-one-session-keeps-selection'],
   },
   {
+    id: 'autoclose-on-exit',
+    label: 'Auto-close on clean exit, keep failed exits',
+    command: ['pnpm', 'run', 'real-app:scenario-autoclose-on-exit'],
+  },
+  {
     id: 'tr205-codex',
     label: 'TR-205 remote codex',
     command: ['pnpm', 'run', 'real-app:scenario-tr205'],

--- a/app/scripts/real-app-harness/scenario-autoclose-on-exit.mjs
+++ b/app/scripts/real-app-harness/scenario-autoclose-on-exit.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+
+// Verifies auto-close-on-exit: when a session's process exits cleanly (code 0)
+// the session closes itself, while a non-zero exit keeps the pane open so the
+// error stays readable. Drives the packaged app end-to-end against a real
+// shell PTY so the regression is caught in the product, not just unit tests.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  createRunContext,
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import {
+  waitForPaneAttached,
+  waitForPaneShellReady,
+  waitForPaneVisible,
+  waitForSessionWorkspace,
+} from './scenarioAssertions.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') {
+    args.shift();
+  }
+  const options = parseCommonArgs(args);
+  return {
+    options,
+    help: args.includes('--help') || args.includes('-h'),
+  };
+}
+
+async function waitForPaneCount(client, sessionId, count, description, timeoutMs = 30_000) {
+  return waitForSessionWorkspace(
+    client,
+    sessionId,
+    (workspace) => (workspace?.panes || []).length === count && (workspace?.panes || []).every((pane) => pane.runtimeId),
+    description,
+    timeoutMs,
+  );
+}
+
+async function waitForShellWorkspace(client, observer, cwd, label) {
+  fs.mkdirSync(cwd, { recursive: true });
+  const sessionId = await createSessionAndWaitForInitialPane({
+    client,
+    observer,
+    cwd,
+    label,
+    agent: 'shell',
+    waitForInitialPaneVisible: false,
+    sessionWaitMs: 30_000,
+  });
+  const workspace = await waitForPaneCount(client, sessionId, 1, `initial pane for ${label}`);
+  const pane = workspace.panes[0];
+  await client.request('select_session', { sessionId });
+  await waitForPaneVisible(client, sessionId, pane.paneId, 20_000);
+  await waitForPaneAttached(client, sessionId, pane.paneId, 20_000);
+  await waitForPaneShellReady(client, sessionId, pane.paneId, {
+    timeoutMs: 20_000,
+    description: `shell prompt ready for ${label}`,
+  });
+  return { sessionId, pane };
+}
+
+async function waitForSessionAbsentFromDaemon(observer, sessionId, description, timeoutMs = 20_000) {
+  await observer.waitFor(
+    () => (observer.getSession(sessionId) == null ? true : null),
+    description,
+    timeoutMs,
+  );
+}
+
+async function waitForSessionGoneFromUi(client, sessionId, description, timeoutMs = 20_000) {
+  const startedAt = Date.now();
+  let lastState = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    lastState = await client.request('get_session_ui_state', { sessionId }).catch((error) => ({ error: String(error) }));
+    if (lastState?.exists === false && lastState?.sidebarItem == null) {
+      return lastState;
+    }
+    await delay(200);
+  }
+  throw new Error(`Timed out waiting for ${description}. Last UI state:\n${JSON.stringify(lastState, null, 2)}`);
+}
+
+async function waitForPaneTextContains(client, sessionId, paneId, needle, description, timeoutMs = 20_000) {
+  const startedAt = Date.now();
+  let lastText = '';
+  while (Date.now() - startedAt < timeoutMs) {
+    const result = await client.request('read_pane_text', { sessionId, paneId }).catch((error) => ({ text: '', error: String(error) }));
+    lastText = result?.text || '';
+    if (lastText.includes(needle)) {
+      return lastText;
+    }
+    await delay(250);
+  }
+  throw new Error(`Timed out waiting for ${description}. Last pane text tail:\n${lastText.slice(-400)}`);
+}
+
+async function closeWorkspacePanes(client, sessionId) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const workspace = await client.request('get_workspace', { sessionId }).catch(() => null);
+    const pane = workspace?.panes?.[0];
+    if (!pane) {
+      return;
+    }
+    await client.request('close_pane', { sessionId, paneId: pane.paneId }).catch(() => {});
+    await delay(200);
+  }
+}
+
+async function closeExistingSessions(client, sessionRootDir) {
+  const initial = await client.request('get_state');
+  const harnessSessions = (initial.sessions || []).filter((session) => session.cwd?.startsWith(sessionRootDir));
+  for (const session of harnessSessions) {
+    await closeWorkspacePanes(client, session.id).catch(() => {});
+  }
+}
+
+async function waitForNoSessionsUnderDir(client, dir, timeoutMs = 20_000) {
+  const startedAt = Date.now();
+  let lastSessions = [];
+  while (Date.now() - startedAt < timeoutMs) {
+    const state = await client.request('get_state').catch(() => null);
+    lastSessions = (state?.sessions || []).filter((session) => session.cwd?.startsWith(dir));
+    if (lastSessions.length === 0) {
+      return;
+    }
+    await delay(200);
+  }
+  throw new Error(`Timed out waiting for harness sessions under ${dir} to close: ${JSON.stringify(lastSessions, null, 2)}`);
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-autoclose-on-exit.mjs');
+    return;
+  }
+
+  const { runId, runDir, sessionDir } = createRunContext(options, 'autoclose-on-exit');
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const createdSessionIds = [];
+
+  console.log(`[RealAppHarness] runDir=${runDir}`);
+  console.log(`[RealAppHarness] sessionDir=${sessionDir}`);
+  console.log(`[RealAppHarness] wsUrl=${options.wsUrl}`);
+
+  try {
+    process.env.ATTN_HARNESS_PARK_VISIBLE_PX ??= '0';
+    await launchFreshAppAndConnect(client, observer);
+    await closeExistingSessions(client, options.sessionRootDir);
+
+    // --- Clean exit (code 0) auto-closes the session ---
+    const clean = await waitForShellWorkspace(client, observer, path.join(sessionDir, 'clean'), `autoclose-clean-${runId}`);
+    createdSessionIds.push(clean.sessionId);
+    await client.request('write_pane', { sessionId: clean.sessionId, paneId: clean.pane.paneId, text: 'exit', submit: true });
+    await waitForSessionAbsentFromDaemon(observer, clean.sessionId, 'clean-exit session unregistered from daemon');
+    await waitForSessionGoneFromUi(client, clean.sessionId, 'clean-exit session gone from UI/sidebar');
+    console.log('[RealAppHarness] Clean exit auto-closed the session.');
+
+    // --- Non-zero exit (code 1) keeps the session open ---
+    const failed = await waitForShellWorkspace(client, observer, path.join(sessionDir, 'failed'), `autoclose-failed-${runId}`);
+    createdSessionIds.push(failed.sessionId);
+    await client.request('write_pane', { sessionId: failed.sessionId, paneId: failed.pane.paneId, text: 'exit 1', submit: true });
+    // The frontend renders the exit banner into the pane model once the process exits.
+    await waitForPaneTextContains(
+      client,
+      failed.sessionId,
+      failed.pane.paneId,
+      '[Process exited with code 1]',
+      'failed-exit pane shows exit banner',
+    );
+    // Give any (incorrect) auto-close a chance to fire, then assert the session survived.
+    await delay(2_000);
+    if (observer.getSession(failed.sessionId) == null) {
+      throw new Error(`Non-zero exit session ${failed.sessionId} was auto-closed; failed exits must stay open`);
+    }
+    const failedUi = await client.request('get_session_ui_state', { sessionId: failed.sessionId });
+    if (failedUi.exists === false || failedUi.sidebarItem == null) {
+      throw new Error(`Non-zero exit session ${failed.sessionId} missing from UI; failed exits must stay open: ${JSON.stringify(failedUi, null, 2)}`);
+    }
+    console.log('[RealAppHarness] Non-zero exit kept the session open.');
+
+    const summary = {
+      ok: true,
+      runId,
+      cleanSessionId: clean.sessionId,
+      failedSessionId: failed.sessionId,
+    };
+    fs.writeFileSync(path.join(runDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    console.log('[RealAppHarness] Auto-close-on-exit passed.');
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    for (const sessionId of createdSessionIds.reverse()) {
+      await closeWorkspacePanes(client, sessionId).catch(() => {});
+    }
+    await waitForNoSessionsUnderDir(client, sessionDir).catch(() => {});
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -25,7 +25,7 @@ import { ErrorToast, useErrorToast } from './components/ErrorToast';
 import { DaemonProvider } from './contexts/DaemonContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import { useSessionStore, type Session, type TerminalWorkspaceState } from './store/sessions';
-import { useDaemonSocket, DaemonWorktree, DaemonSession, DaemonWorkspace, DaemonPR, DaemonEndpoint, DaemonPlugin, DaemonPluginIssue, GitStatusUpdate, BranchDiffFile, DaemonWarning, ReviewLoopState } from './hooks/useDaemonSocket';
+import { useDaemonSocket, DaemonWorktree, DaemonSession, DaemonWorkspace, DaemonPR, DaemonEndpoint, DaemonPlugin, DaemonPluginIssue, GitStatusUpdate, BranchDiffFile, DaemonWarning, ReviewLoopState, SessionExitInfo } from './hooks/useDaemonSocket';
 import { useSessionWorkspaceController } from './hooks/useSessionWorkspaceController';
 import { isAttentionSessionState, normalizeSessionState } from './types/sessionState';
 import { normalizeSessionAgent, type SessionAgent } from './types/sessionAgent';
@@ -325,6 +325,18 @@ function App() {
     setUpdateAvailableVersion(null);
   }, [updateAvailableVersion]);
 
+  // Bridge daemon session-exit events to AppContent's pane-aware close handler.
+  // useDaemonSocket lives here in the outer App, but the close logic (worktree
+  // cleanup, focus fallback, pane vs session) lives in AppContent, so AppContent
+  // registers its handler into this ref and we forward exits through it.
+  const sessionExitHandlerRef = useRef<((info: SessionExitInfo) => void) | null>(null);
+  const registerSessionExitHandler = useCallback((handler: ((info: SessionExitInfo) => void) | null) => {
+    sessionExitHandlerRef.current = handler;
+  }, []);
+  const handleSessionExited = useCallback((info: SessionExitInfo) => {
+    sessionExitHandlerRef.current?.(info);
+  }, []);
+
   // Connect to daemon WebSocket
   const {
     sendPRAction,
@@ -401,6 +413,7 @@ function App() {
       if (!state) return;
       setReviewLoopsBySessionId(prev => ({ ...prev, [state.source_session_id]: state }));
     },
+    onSessionExited: handleSessionExited,
   });
 
   const setReviewLoopStateForSession = useCallback((sessionId: string, state: ReviewLoopState | null) => {
@@ -496,6 +509,7 @@ function App() {
         setReviewLoopIterationLimit={setReviewLoopIterationLimit}
         setReviewLoopStateForSession={setReviewLoopStateForSession}
         clearGitStatus={clearGitStatus}
+        registerSessionExitHandler={registerSessionExitHandler}
       />
     </SettingsProvider>
   );
@@ -578,6 +592,7 @@ interface AppContentProps {
   setReviewLoopIterationLimit: ReturnType<typeof useDaemonSocket>['setReviewLoopIterationLimit'];
   setReviewLoopStateForSession: (sessionId: string, state: ReviewLoopState | null) => void;
   clearGitStatus: () => void;
+  registerSessionExitHandler: (handler: ((info: SessionExitInfo) => void) | null) => void;
 }
 
 function AppContent({
@@ -655,6 +670,7 @@ sendFetchPRDetails,
   setReviewLoopIterationLimit,
   setReviewLoopStateForSession,
   clearGitStatus,
+  registerSessionExitHandler,
 }: AppContentProps) {
   const [openPRLauncherJob, setOpenPRLauncherJob] = useState<OpenPRLauncherJob | null>(null);
   const openPRLauncherIdRef = useRef(0);
@@ -1666,6 +1682,22 @@ sendFetchPRDetails,
 
     void handleCloseSession(id);
   }, [handleClosePane, handleCloseSession, sessions]);
+
+  // Auto-close a session when its process exits cleanly. A clean voluntary exit
+  // (code 0, no signal) means the user quit the agent/shell and there's nothing
+  // left to do in that pane. Non-zero exits and signal kills (crashes, reloads,
+  // explicit closes) keep the pane open so the error and exit code stay visible.
+  const handleSessionProcessExit = useCallback((info: SessionExitInfo) => {
+    if (info.exitCode !== 0 || info.signal) {
+      return;
+    }
+    handleRequestCloseSession(info.id);
+  }, [handleRequestCloseSession]);
+
+  useEffect(() => {
+    registerSessionExitHandler(handleSessionProcessExit);
+    return () => registerSessionExitHandler(null);
+  }, [registerSessionExitHandler, handleSessionProcessExit]);
 
   const handleCancelSessionClose = useCallback(() => {
     setPendingSessionClose(null);

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -141,6 +141,33 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     unmount();
   });
 
+  it('forwards session_exited to onSessionExited with exit code and signal', async () => {
+    const onSessionExited = vi.fn();
+    const { unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        onSessionExited,
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+
+    // Clean voluntary exit: no signal.
+    ws.emit({ event: 'session_exited', id: 'clean-exit', exit_code: 0 });
+    expect(onSessionExited).toHaveBeenCalledWith({ id: 'clean-exit', exitCode: 0, signal: undefined });
+
+    // Signal kill (e.g. reload/close): signal is forwarded so consumers can skip auto-close.
+    ws.emit({ event: 'session_exited', id: 'killed', exit_code: -1, signal: 'SIGTERM' });
+    expect(onSessionExited).toHaveBeenCalledWith({ id: 'killed', exitCode: -1, signal: 'SIGTERM' });
+
+    unmount();
+  });
+
   it('resolves getReviewLoopRun from show result keyed by loop_id', async () => {
     const { result, unmount } = renderHook(() =>
       useDaemonSocket({

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -410,6 +410,12 @@ export interface BranchDiffFilesResult {
   error?: string;
 }
 
+export interface SessionExitInfo {
+  id: string;
+  exitCode: number;
+  signal?: string;
+}
+
 interface UseDaemonSocketOptions {
   onSessionsUpdate: (sessions: DaemonSession[]) => void;
   onWorkspacesUpdate: (workspaces: DaemonWorkspace[]) => void;
@@ -424,6 +430,7 @@ interface UseDaemonSocketOptions {
   onSettingError?: (message: string) => void;
   onGitStatusUpdate?: (status: GitStatusUpdate) => void;
   onReviewLoopUpdate?: (state: ReviewLoopState | null) => void;
+  onSessionExited?: (info: SessionExitInfo) => void;
   endpoint?: DaemonEndpointProfile;
   wsUrl?: string;
 }
@@ -651,6 +658,7 @@ export function useDaemonSocket({
   onSettingError,
   onGitStatusUpdate,
   onReviewLoopUpdate,
+  onSessionExited,
   endpoint,
   wsUrl,
 }: UseDaemonSocketOptions) {
@@ -1512,6 +1520,13 @@ export function useDaemonSocket({
                 code: data.exit_code ?? 0,
                 signal: data.signal,
               });
+              if (onSessionExited) {
+                onSessionExited({
+                  id: data.id,
+                  exitCode: data.exit_code ?? 0,
+                  signal: data.signal,
+                });
+              }
             }
             break;
 


### PR DESCRIPTION
## What

When a session's process exits **cleanly** (exit code 0, no signal), the session now closes itself instead of leaving a dead `[Process exited with code 0]` pane that you can only manually close. Sessions that **crash or are killed** (non-zero exit / signal) stay open so the error and exit code remain visible.

Closes the annoyance where quitting a shell/agent left a useless lingering pane.

## How

- `useDaemonSocket` gains an `onSessionExited` callback fired on the daemon's `session_exited` event (`{ id, exitCode, signal }`).
- `App.tsx` bridges that into `AppContent`'s existing pane-aware close path (`handleRequestCloseSession`) via a small ref — so **worktree cleanup, focus fallback, and utility-pane handling are reused**, not reimplemented. Closing the exited pane collapses to removing the session/workspace when it's the last pane.
- Gate is `exitCode === 0 && !signal`. Reloads/closes kill with SIGTERM (signaled exit), so they're naturally excluded and a reloading session is never yanked out from under its respawn.
- Uses the **daemon** event rather than the PTY-bridge `exit` because the mock PTY backend emits a code-0 `exit` on every kill, which would cause false closes in tests.

## Testing

- **Unit:** `useDaemonSocket.test.tsx` asserts the hook forwards both clean and signal exits. Full frontend suite + `tsc` green.
- **Real-app harness:** new `scenario-autoclose-on-exit` drives the packaged app against real shell PTYs — clean `exit` unregisters the session (daemon + sidebar), `exit 1` renders the banner and keeps the session. Registered in the serial matrix.
- **Manual (packaged dev app):** verified shell clean exit auto-closes, shell `exit 1` stays, and a **codex** agent clean quit also auto-closes.

Run the new scenario:
```
ATTN_HARNESS_PROFILE=dev pnpm --dir app run real-app:scenario-autoclose-on-exit
```

## Known boundary

Sessions that exit while no frontend is connected (e.g. across a daemon restart) come back as `idle` on reconnect with no live `session_exited`, so they aren't retro-closed. Out of scope here; can follow up if wanted.

🤖 Opened by Claude on behalf of Victor.