### PR TITLE
release: v0.10.0

### DIFF
--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -350,6 +350,7 @@ test.describe('Ghostty terminal interactions', () => {
   test('keeps copied selection attached to its text while scrolling', async ({ page, context, daemon }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
     const terminal = await openTerminalSession(page, daemon, 's-selection-scroll');
+    await page.evaluate(() => navigator.clipboard.writeText(''));
     const anchor = 'SELECTED_ANCHOR_LINE';
     const lines = Array.from({ length: 80 }, (_, index) => (
       index === 79 ? anchor : `SCROLL_LINE_${String(index).padStart(3, '0')}`
@@ -361,10 +362,10 @@ test.describe('Ghostty terminal interactions', () => {
 
     const terminalBounds = await terminal.boundingBox();
     expect(terminalBounds).not.toBeNull();
-    const rowY = terminalBounds!.height - 8;
-    await terminal.hover({ position: { x: 2, y: rowY } });
+    const rowY = terminalBounds!.y + terminalBounds!.height - 12;
+    await page.mouse.move(terminalBounds!.x + 2, rowY);
     await page.mouse.down();
-    await terminal.hover({ position: { x: 220, y: rowY } });
+    await page.mouse.move(terminalBounds!.x + 220, rowY);
     await page.mouse.up();
     await expect
       .poll(async () => page.evaluate(() => navigator.clipboard.readText()), { timeout: 3000 })

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.9.4",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.9.4"
+version = "0.10.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "attn",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "identifier": "com.attn.manager",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
Release v0.10.0.\n\nBumps app package, Tauri config, Cargo manifest, and Cargo lock versions from 0.9.4 to 0.10.0.\n\nValidation already run by scripts/release.sh before this PR:\n- go test ./...\n- pnpm --dir app run build\n- pnpm --dir app test