### PR TITLE
fix(workspaces): prune stale empty workspace rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,14 +25,14 @@ Use `make install` as the default source/dev install path; it rebuilds and insta
 
 ### Iterating On Attn Itself (Attn-On-Attn Testing)
 
-When changing attn code while the user has a live attn install running, **never** run `make install` or `make install-daemon` — they overwrite the live `attn.app` / restart its daemon mid-session. Use the dev sibling install instead:
+While iterating on attn code, prefer the dev sibling install so rebuilds do not repeatedly interrupt the live production app:
 
 ```bash
 make dev              # builds + installs ~/Applications/attn-dev.app, starts dev daemon on port 29849
 make install-daemon-dev  # faster: only rebuild the Go sidecar inside attn-dev.app
 ```
 
-The dev install is fully isolated: its own bundle identifier (`com.attn.manager.dev`), its own data dir (`~/.attn-dev/`), its own socket, its own port. Prod is never touched. `make install` and `make install-daemon` refuse at parse time if `ATTN_PROFILE` is set in the environment — if you hit that error, you meant `make dev`.
+The dev install is fully isolated: its own bundle identifier (`com.attn.manager.dev`), its own data dir (`~/.attn-dev/`), its own socket, its own port. Once a fix is verified, run `make` to install the production app so the user receives the fix immediately. The production install closes and reopens the app and restarts its daemon; attn is designed to recover persisted session state gracefully. `make install` and `make install-daemon` refuse at parse time if `ATTN_PROFILE` is set in the environment — if you hit that error during iteration, you meant `make dev`.
 
 To make CLI commands (`attn`, `attn list`, etc.) target the dev daemon in your shell, run `eval "$(./attn profile-env dev)"` (bash/zsh) or `./attn profile-env --fish dev | source` (fish). Any `attn` subcommand then prints a one-line `[attn profile=dev ...]` banner so you can always see which daemon you're talking to. Unset with `eval "$(attn profile-env --unset)"`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 - **Auto-Close On Exit**: When a session's process exits cleanly (exit code 0), the session now closes itself instead of leaving a dead `[Process exited]` pane around. Sessions that crash or are killed (non-zero exit) stay open so you can still read the error.
 - **Workspace Muting**: Muting now applies to whole workspaces instead of individual sessions. Muted workspaces move to the muted section together with all of their sessions, and session rows no longer expose mute controls.
 
+### Fixed
+- **Workspace Sidebar**: Startup recovery now removes stale empty workspaces left behind by sessions that no longer have a live terminal, preventing old workspace rows from reappearing in the sidebar.
+
 ### Removed
 - **Session Muting**: Session-level mute state was removed from the app, daemon protocol, and session database schema.
 - **Footer Debug Buttons**: The dashboard footer no longer shows the developer debug toggles (resize debug, runtime trace, pane debug). The footer now points to the `⌘/` shortcuts cheatsheet next to `⌘,` settings.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -668,7 +668,7 @@ func (d *Daemon) pruneSessionsWithoutPTY() int {
 			recoverable++
 			continue
 		}
-		d.store.Remove(session.ID)
+		d.removeReapedSession(session.ID)
 		removed++
 	}
 	if recoverable > 0 {
@@ -977,7 +977,7 @@ func (d *Daemon) reconcileSessionsWithWorkerBackend(ctx context.Context, allowId
 			report.MarkedRecoverable++
 			report.Changed = true
 		} else {
-			d.store.Remove(session.ID)
+			d.removeReapedSession(session.ID)
 			report.Reaped++
 			report.Changed = true
 		}
@@ -1266,6 +1266,12 @@ func (d *Daemon) unregisterSession(sessionID string, sig syscall.Signal) *protoc
 	d.clearClassifiedTurn(sessionID)
 	d.clearClassifyingTurn(sessionID)
 	return session
+}
+
+func (d *Daemon) removeReapedSession(sessionID string) {
+	d.store.Remove(sessionID)
+	d.dissociateSessionFromWorkspace(sessionID)
+	d.removeWorkspaceLayoutPaneForSession(sessionID)
 }
 
 func (d *Daemon) handlePTYState(sessionID, state string) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -744,6 +744,35 @@ func TestDaemon_ReconcileSessionsWithWorkerBackend(t *testing.T) {
 	}
 }
 
+func TestDaemon_ReconcileSessionsWithWorkerBackend_ReapRemovesEmptyWorkspace(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	now := string(protocol.TimestampNow())
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: "ws-stale", Title: "stale", Directory: "/tmp/stale",
+	})
+	d.store.Add(&protocol.Session{
+		ID: "stale-session", Label: "stale", Agent: protocol.SessionAgentCodex, Directory: "/tmp/stale",
+		State: protocol.SessionStateWorking, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	d.associateSessionWithWorkspace("stale-session", "ws-stale")
+	d.ptyBackend = &fakeWorkerReconcileBackend{
+		liveIDs: nil,
+		info:    map[string]ptybackend.SessionInfo{},
+	}
+
+	report := d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	if report.Reaped != 1 {
+		t.Fatalf("reaped = %d, want 1", report.Reaped)
+	}
+	if workspace := d.store.GetWorkspace("ws-stale"); workspace != nil {
+		t.Fatalf("empty workspace still persisted after session reap: %+v", workspace)
+	}
+	if _, ok := d.workspaces.snapshot("ws-stale"); ok {
+		t.Fatal("empty workspace still registered after session reap")
+	}
+}
+
 func TestDaemon_ReconcileSessionsWithWorkerBackend_ClaudeSessionsRecoverable(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	now := string(protocol.TimestampNow())

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -393,6 +393,15 @@ func (d *Daemon) loadWorkspacesFromStore() {
 		if ws == nil {
 			continue
 		}
+		if len(d.store.SessionsInWorkspace(ws.ID)) == 0 {
+			// Older startup reconciliation paths could reap a session without
+			// removing its workspace. Preserve workspaces already registered
+			// in memory because they may be waiting for their first spawn.
+			if _, ok := d.workspaces.snapshot(ws.ID); !ok {
+				d.store.RemoveWorkspace(ws.ID)
+				continue
+			}
+		}
 		d.workspaces.register(ws.ID, ws.Title, ws.Directory, ws.Muted)
 	}
 	for _, session := range d.store.List("") {

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/workspacelayout"
 )
 
 // The in-memory registry is the runtime cache; the SQLite store is the source
@@ -395,9 +396,11 @@ func (d *Daemon) loadWorkspacesFromStore() {
 		}
 		if len(d.store.SessionsInWorkspace(ws.ID)) == 0 {
 			// Older startup reconciliation paths could reap a session without
-			// removing its workspace. Preserve workspaces already registered
-			// in memory because they may be waiting for their first spawn.
-			if _, ok := d.workspaces.snapshot(ws.ID); !ok {
+			// removing its workspace. Preserve workspaces waiting for their
+			// first spawn: the layout pane is persisted before spawn_session
+			// creates the session row, and load can run after a daemon restart
+			// in that gap.
+			if _, ok := d.workspaces.snapshot(ws.ID); !ok && !d.workspaceHasPendingSpawn(ws.ID) {
 				d.store.RemoveWorkspace(ws.ID)
 				continue
 			}
@@ -417,6 +420,19 @@ func (d *Daemon) loadWorkspacesFromStore() {
 	for _, ws := range d.workspaces.list() {
 		d.recomputeWorkspaceStatus(ws.ID)
 	}
+}
+
+func (d *Daemon) workspaceHasPendingSpawn(workspaceID string) bool {
+	layout := d.store.GetWorkspaceLayout(workspaceID)
+	if layout == nil {
+		return false
+	}
+	for _, pane := range layout.Panes {
+		if pane.Status == workspacelayout.PaneStatusSpawning {
+			return true
+		}
+	}
+	return false
 }
 
 // listWorkspaces returns a snapshot of the current workspaces for InitialState.

--- a/internal/daemon/workspace_test.go
+++ b/internal/daemon/workspace_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/workspacelayout"
 )
 
 func TestRollupWorkspaceStatus_PriorityOrdering(t *testing.T) {
@@ -567,6 +568,9 @@ func TestLoadWorkspacesFromStore_RemovesPersistedOrphans(t *testing.T) {
 	now := string(protocol.TimestampNow())
 
 	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-orphan", Title: "orphan", Directory: "/repo/orphan"})
+	if err := d.store.SaveWorkspaceLayout(workspacelayout.DefaultWorkspaceLayout("ws-orphan", "pane-orphan", "s-orphan")); err != nil {
+		t.Fatalf("SaveWorkspaceLayout() error = %v", err)
+	}
 	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-live", Title: "live", Directory: "/repo/live"})
 	d.store.Add(&protocol.Session{
 		ID: "s-live", Label: "live", Agent: protocol.SessionAgentCodex, Directory: "/repo/live",
@@ -584,24 +588,44 @@ func TestLoadWorkspacesFromStore_RemovesPersistedOrphans(t *testing.T) {
 	if _, ok := d.workspaces.snapshot("ws-orphan"); ok {
 		t.Fatal("orphan workspace registered during load")
 	}
+	if layout := d.store.GetWorkspaceLayout("ws-orphan"); layout != nil {
+		t.Fatalf("orphan workspace layout still persisted after load: %+v", layout)
+	}
 	if workspace := d.store.GetWorkspace("ws-live"); workspace == nil {
 		t.Fatal("live workspace was removed during load")
 	}
 }
 
-func TestLoadWorkspacesFromStore_PreservesRegisteredEmptyWorkspace(t *testing.T) {
+func TestLoadWorkspacesFromStore_PreservesPendingSpawnAcrossRestart(t *testing.T) {
 	d := newDaemonForTest(t)
-	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
-		Cmd: protocol.CmdRegisterWorkspace, ID: "ws-pending", Title: "pending", Directory: "/repo/pending",
-	})
+	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-pending", Title: "pending", Directory: "/repo/pending"})
+	if err := d.store.SaveWorkspaceLayout(workspacelayout.WorkspaceLayout{
+		WorkspaceID:  "ws-pending",
+		ActivePaneID: "pane-pending",
+		Layout:       workspacelayout.DefaultLayout("pane-pending"),
+		Panes: []workspacelayout.Pane{{
+			PaneID:    "pane-pending",
+			RuntimeID: "s-pending",
+			SessionID: "s-pending",
+			Kind:      workspacelayout.PaneKindAgent,
+			Title:     workspacelayout.DefaultPaneTitle,
+			Status:    workspacelayout.PaneStatusSpawning,
+		}},
+	}); err != nil {
+		t.Fatalf("SaveWorkspaceLayout() error = %v", err)
+	}
 
+	d.workspaces = newWorkspaceRegistry()
 	d.loadWorkspacesFromStore()
 
 	if workspace := d.store.GetWorkspace("ws-pending"); workspace == nil {
-		t.Fatal("registered empty workspace was removed during load")
+		t.Fatal("pending empty workspace was removed during restart load")
 	}
 	if _, ok := d.workspaces.snapshot("ws-pending"); !ok {
-		t.Fatal("registered empty workspace missing after load")
+		t.Fatal("pending empty workspace missing after restart load")
+	}
+	if layout := d.store.GetWorkspaceLayout("ws-pending"); layout == nil {
+		t.Fatal("pending workspace layout was removed during restart load")
 	}
 }
 

--- a/internal/daemon/workspace_test.go
+++ b/internal/daemon/workspace_test.go
@@ -562,6 +562,49 @@ func TestLoadWorkspacesFromStore_RebuildsRegistryAndReassociates(t *testing.T) {
 	}
 }
 
+func TestLoadWorkspacesFromStore_RemovesPersistedOrphans(t *testing.T) {
+	d := newDaemonForTest(t)
+	now := string(protocol.TimestampNow())
+
+	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-orphan", Title: "orphan", Directory: "/repo/orphan"})
+	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-live", Title: "live", Directory: "/repo/live"})
+	d.store.Add(&protocol.Session{
+		ID: "s-live", Label: "live", Agent: protocol.SessionAgentCodex, Directory: "/repo/live",
+		WorkspaceID: "ws-live",
+		State:       protocol.SessionStateWorking,
+		StateSince:  now, StateUpdatedAt: now, LastSeen: now,
+	})
+
+	d.workspaces = newWorkspaceRegistry()
+	d.loadWorkspacesFromStore()
+
+	if workspace := d.store.GetWorkspace("ws-orphan"); workspace != nil {
+		t.Fatalf("orphan workspace still persisted after load: %+v", workspace)
+	}
+	if _, ok := d.workspaces.snapshot("ws-orphan"); ok {
+		t.Fatal("orphan workspace registered during load")
+	}
+	if workspace := d.store.GetWorkspace("ws-live"); workspace == nil {
+		t.Fatal("live workspace was removed during load")
+	}
+}
+
+func TestLoadWorkspacesFromStore_PreservesRegisteredEmptyWorkspace(t *testing.T) {
+	d := newDaemonForTest(t)
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: "ws-pending", Title: "pending", Directory: "/repo/pending",
+	})
+
+	d.loadWorkspacesFromStore()
+
+	if workspace := d.store.GetWorkspace("ws-pending"); workspace == nil {
+		t.Fatal("registered empty workspace was removed during load")
+	}
+	if _, ok := d.workspaces.snapshot("ws-pending"); !ok {
+		t.Fatal("registered empty workspace missing after load")
+	}
+}
+
 func TestAssociateSessionWithWorkspace_PersistsToStore(t *testing.T) {
 	d := newDaemonForTest(t)
 	now := string(protocol.TimestampNow())

--- a/internal/daemon/worktree.go
+++ b/internal/daemon/worktree.go
@@ -324,6 +324,8 @@ func (d *Daemon) cleanupDeletedWorktreeSessions(path string) {
 			Event:   protocol.EventSessionUnregistered,
 			Session: d.sessionForBroadcast(session),
 		})
+		d.dissociateSessionFromWorkspace(session.ID)
+		d.removeWorkspaceLayoutPaneForSession(session.ID)
 	}
 }
 

--- a/internal/daemon/worktree_naming_test.go
+++ b/internal/daemon/worktree_naming_test.go
@@ -216,6 +216,10 @@ func TestDoDeleteWorktree_ForceDeleteCleansUpAfterGitDelete(t *testing.T) {
 	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
 	d.registerCreatedWorktree(mainDir, worktreePath, "feat/dirty-force")
 	addWorktreeSession(t, d, "session-force", worktreePath, mainDir, "feat/dirty-force")
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: "workspace-session-force", Title: "dirty-force", Directory: worktreePath,
+	})
+	d.associateSessionWithWorkspace("session-force", "workspace-session-force")
 
 	if err := d.doDeleteWorktree(worktreePath, nil, deleteWorktreeOptions{Force: true}); err != nil {
 		t.Fatalf("doDeleteWorktree force failed: %v", err)
@@ -225,6 +229,9 @@ func TestDoDeleteWorktree_ForceDeleteCleansUpAfterGitDelete(t *testing.T) {
 	}
 	if session := d.store.Get("session-force"); session != nil {
 		t.Fatal("session remains after successful force delete")
+	}
+	if workspace := d.store.GetWorkspace("workspace-session-force"); workspace != nil {
+		t.Fatalf("workspace remains after successful force delete: %+v", workspace)
 	}
 	worktrees := d.store.ListWorktreesByRepo(mainDir)
 	for _, wt := range worktrees {


### PR DESCRIPTION
## Intent / Why

Startup recovery could reap sessions without removing their workspace associations. That left stale empty workspace rows persisted in SQLite, causing old workspaces such as `attn--feat-snipe` to reappear in the sidebar after restart.

## Summary

- route startup and worker-backend session reaping through workspace association and layout cleanup
- remove already-persisted orphan workspace rows while preserving freshly registered empty workspaces that are still waiting for their first spawn
- clean workspace associations when deleting a worktree
- document that `make dev` is preferred during iteration, while verified fixes should be installed for the user with production `make`
- add daemon regression coverage and a user-facing changelog entry

## Test plan

- [x] `go test ./internal/daemon`
- [x] `go test ./internal/store`
- [x] `git diff --check origin/main...HEAD`
- [x] `make dev`
- [x] `make`
- [x] Confirm production restart removes the persisted `attn--feat-snipe` workspace row from `~/.attn/attn.db`
