### PR TITLE
fix(workspaces): keep worktree sessions in current workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 
 ---
 
+## [2026-06-01]
+
+### Fixed
+- **Workspace Sessions**: Creating a worktree from the `⌘N` new-session picker now adds the session to the current workspace instead of creating a separate workspace.
+
+---
+
 ## [2026-05-31]
 
 ### Added

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -70,7 +70,7 @@ type LocationPickerPurpose = 'workspace' | 'session';
 interface SplitSessionOptions {
   baseSessionId?: string;
   cwd?: string;
-  endpointId?: string;
+  endpointId?: string | null;
   label?: string;
   yoloMode?: boolean;
 }
@@ -1414,6 +1414,9 @@ sendFetchPRDetails,
     const paneId = targetPaneId || getActivePaneIdForSession(activeSession);
     const newPaneId = paneIdForSession(sessionId);
     const label = options.label || nextSplitSessionLabel(workspaceId, agent);
+    const endpointId = options.endpointId === null
+      ? undefined
+      : options.endpointId ?? activeSession.endpointId;
     let paneAdded = false;
 
     try {
@@ -1422,7 +1425,7 @@ sendFetchPRDetails,
         options.cwd || activeSession.cwd,
         sessionId,
         agent,
-        options.endpointId ?? activeSession.endpointId,
+        endpointId,
         agent === 'shell' ? false : options.yoloMode ?? activeSession.yoloMode,
         workspaceId,
       );
@@ -1503,7 +1506,7 @@ sendFetchPRDetails,
       if (locationPickerPurpose === 'session' && activeLocalSession?.workspaceId) {
         await createSplitSession(selectedAgent, locationPickerSessionDirection, undefined, {
           cwd: path,
-          endpointId,
+          endpointId: endpointId ?? null,
           label: folderName,
           yoloMode,
         });
@@ -1574,7 +1577,7 @@ sendFetchPRDetails,
         if (locationPickerPurpose === 'session' && activeLocalSession?.workspaceId) {
           await createSplitSession(agent, locationPickerSessionDirection, undefined, {
             cwd: worktreePath,
-            endpointId,
+            endpointId: endpointId ?? null,
             label: folderName,
             yoloMode,
           });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1571,6 +1571,18 @@ sendFetchPRDetails,
             : current
         ));
         const folderName = worktreePath.split('/').pop() || branchName || 'session';
+        if (locationPickerPurpose === 'session' && activeLocalSession?.workspaceId) {
+          await createSplitSession(agent, locationPickerSessionDirection, undefined, {
+            cwd: worktreePath,
+            endpointId,
+            label: folderName,
+            yoloMode,
+          });
+          setSessionCreationJob((current) => (
+            current?.id === jobId ? null : current
+          ));
+          return;
+        }
         const sessionId = await createWorkspaceSession(folderName, worktreePath, undefined, agent, endpointId, yoloMode);
         setSessionCreationJob((current) => (
           current?.id === jobId
@@ -1587,7 +1599,7 @@ sendFetchPRDetails,
         worktreeSessionCreateEndpointsRef.current.delete(endpointKey);
       }
     })();
-  }, [createWorkspaceSession, sendCreateWorktree, showError]);
+  }, [activeLocalSession?.workspaceId, createSplitSession, createWorkspaceSession, locationPickerPurpose, locationPickerSessionDirection, sendCreateWorktree, showError]);
 
   const closeLocationPicker = useCallback(() => {
     setLocationPickerOpen(false);

--- a/app/src/App.worktreeCleanup.test.tsx
+++ b/app/src/App.worktreeCleanup.test.tsx
@@ -450,6 +450,62 @@ describe('worktree cleanup prompt', () => {
     });
   });
 
+  it('keeps Cmd+N worktree-backed sessions in the current workspace', async () => {
+    const createSession = vi.fn(async (_label: string, _cwd: string, id: string) => id);
+    mockSessionStoreReturn.createSession = createSession;
+    mockSessionStoreReturn.takeSessionSpawnArgs = vi.fn((id: string) => ({
+      id,
+      cwd: '/tmp/repo--feat-async',
+      cols: 80,
+      rows: 24,
+      label: 'repo--feat-async',
+      agent: 'codex',
+      workspace_id: 'workspace-s1',
+    }));
+    mockDaemonSocketReturn.sendCreateWorktree = vi.fn(async () => ({
+      success: true,
+      path: '/tmp/repo--feat-async',
+    }));
+
+    render(<App />);
+
+    const keyboardArgs = mockUseKeyboardShortcuts.mock.calls[mockUseKeyboardShortcuts.mock.calls.length - 1]?.[0] as {
+      onNewSession?: () => void;
+    };
+    act(() => {
+      keyboardArgs.onNewSession?.();
+    });
+
+    await userEvent.click(screen.getByTestId('mock-create-worktree-session'));
+
+    await waitFor(() => {
+      expect(createSession).toHaveBeenCalledWith(
+        'repo--feat-async',
+        '/tmp/repo--feat-async',
+        expect.any(String),
+        'codex',
+        undefined,
+        false,
+        'workspace-s1',
+      );
+    });
+    const sessionId = createSession.mock.calls[0][2];
+    expect(mockSendRegisterWorkspace).not.toHaveBeenCalled();
+    expect(mockDaemonSocketReturn.sendWorkspaceAddSessionPane).toHaveBeenCalledWith(
+      'workspace-s1',
+      sessionId,
+      'repo--feat-async',
+      {
+        paneId: `pane-${sessionId}`,
+        targetPaneId: 'pane-session',
+        direction: 'vertical',
+      },
+    );
+    await waitFor(() => {
+      expect(screen.queryByText('Starting session')).not.toBeInTheDocument();
+    });
+  });
+
   it('disables app shortcuts while the first-run whats-new modal is open', async () => {
     localStorage.removeItem(WHATS_NEW_STORAGE_KEY);
 

--- a/app/src/App.worktreeCleanup.test.tsx
+++ b/app/src/App.worktreeCleanup.test.tsx
@@ -452,6 +452,7 @@ describe('worktree cleanup prompt', () => {
 
   it('keeps Cmd+N worktree-backed sessions in the current workspace', async () => {
     const createSession = vi.fn(async (_label: string, _cwd: string, id: string) => id);
+    (mockSessionStoreReturn.sessions as Array<{ endpointId?: string }>)[0].endpointId = 'ep-remote';
     mockSessionStoreReturn.createSession = createSession;
     mockSessionStoreReturn.takeSessionSpawnArgs = vi.fn((id: string) => ({
       id,


### PR DESCRIPTION
## Intent / Why

Creating a worktree from the `Cmd+N` new-session picker incorrectly created a separate workspace. `Cmd+N` should always add the new session to the current workspace, regardless of whether the selected location already exists or is created as a new worktree.

## Summary

- Route worktree-backed `Cmd+N` sessions through the existing split-session path so they join the active workspace.
- Keep new-workspace picker behavior unchanged.
- Add a regression test that verifies no workspace registration occurs and the new pane is added to the current workspace.
- Document the user-visible fix in `CHANGELOG.md`.

## Test plan

- [x] `pnpm --dir app test -- App.worktreeCleanup.test.tsx`
- [x] `pnpm --dir app exec tsc --noEmit`
- [x] `git diff --check`