### PR TITLE
fix(worktrees): offer force delete for provider failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 
 ### Fixed
 - **Workspace Sessions**: Creating a worktree from the `⌘N` new-session picker now adds the session to the current workspace instead of creating a separate workspace.
+- **Worktree Cleanup**: Provider-managed worktrees with local changes now offer force delete after the normal delete attempt is rejected.
 
 ---
 

--- a/internal/daemon/plugin_worktree_test.go
+++ b/internal/daemon/plugin_worktree_test.go
@@ -505,6 +505,56 @@ func TestDoDeleteWorktree_ProviderDeclineFallsBackToBuiltInGit(t *testing.T) {
 	}
 }
 
+func TestDoDeleteWorktree_ProviderDirtyWorktreeErrorIsForceable(t *testing.T) {
+	tmpDir, mainDir := initProviderTestRepo(t)
+	worktreePath := filepath.Join(tmpDir, "provider-dirty-delete")
+	runGitDaemon(t, mainDir, "worktree", "add", "-b", "feat/provider-dirty-delete", worktreePath)
+	if err := os.WriteFile(filepath.Join(worktreePath, "local.txt"), []byte("local change\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+	worktreePath = git.CanonicalizePath(worktreePath)
+
+	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))
+	d.registerCreatedWorktree(mainDir, worktreePath, "feat/provider-dirty-delete")
+
+	client, done := startPluginPipe(t, d, "dirty-delete-provider", []string{worktreeDeleteProviderSurface})
+	defer client.Close()
+
+	responseDone := respondToDeleteProviderCall(t, client, func(params worktreeDeleteProviderParams) worktreeDeleteProviderResult {
+		if params.Force {
+			t.Fatal("provider delete force=true, want false")
+		}
+		return worktreeDeleteProviderResult{
+			Status: providerStatusError,
+			Error:  "fatal: worktree contains modified or untracked files, use --force to delete it",
+		}
+	})
+
+	err := d.doDeleteWorktree(worktreePath, nil, deleteWorktreeOptions{})
+	if err == nil {
+		t.Fatal("doDeleteWorktree succeeded on dirty provider-managed worktree")
+	}
+	waitForProviderResponse(t, responseDone)
+
+	var deleteErr *deleteWorktreeError
+	if !errors.As(err, &deleteErr) {
+		t.Fatalf("error type = %T, want *deleteWorktreeError", err)
+	}
+	if deleteErr.kind != deleteWorktreeFailureDirtyWorktree || !deleteErr.forceable {
+		t.Fatalf("delete error kind=%q forceable=%v, want dirty forceable", deleteErr.kind, deleteErr.forceable)
+	}
+	if wt := d.store.GetWorktree(worktreePath); wt == nil {
+		t.Fatal("provider failure removed worktree from store")
+	}
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dirty delete provider connection did not close")
+	}
+}
+
 func TestDoDeleteWorktree_ProviderErrorPreservesDaemonState(t *testing.T) {
 	tmpDir, mainDir := initProviderTestRepo(t)
 	worktreePath := filepath.Join(tmpDir, "provider-error-delete")

--- a/internal/daemon/worktree.go
+++ b/internal/daemon/worktree.go
@@ -274,10 +274,7 @@ func (d *Daemon) doDeleteWorktree(path string, endpointID *string, opts deleteWo
 
 	handled, err := d.dispatchWorktreeDeleteProvider(mainRepo, path, branch, opts.Force)
 	if err != nil {
-		return &deleteWorktreeError{
-			err:  err,
-			kind: deleteWorktreeFailureProviderError,
-		}
+		return d.classifyDeleteWorktreeProviderError(path, opts.Force, err)
 	}
 	if !handled {
 		if err := git.DeleteWorktree(mainRepo, path, opts.Force); err != nil {
@@ -341,6 +338,26 @@ func (d *Daemon) classifyDeleteWorktreeGitError(path string, force bool, err err
 		kind:      kind,
 		forceable: forceable,
 	}
+}
+
+func (d *Daemon) classifyDeleteWorktreeProviderError(path string, force bool, err error) error {
+	kind := deleteWorktreeFailureProviderError
+	forceable := false
+	if !force && isDirtyWorktreeDeleteError(err) && d.worktreeHasLocalChanges(path) {
+		kind = deleteWorktreeFailureDirtyWorktree
+		forceable = true
+	}
+	return &deleteWorktreeError{
+		err:       err,
+		kind:      kind,
+		forceable: forceable,
+	}
+}
+
+func isDirtyWorktreeDeleteError(err error) bool {
+	message := err.Error()
+	return strings.Contains(message, "contains modified or untracked files") &&
+		strings.Contains(message, "use --force to delete it")
 }
 
 func (d *Daemon) worktreeHasLocalChanges(path string) bool {


### PR DESCRIPTION
## Intent / Why

Provider-managed worktree cleanup suppressed the force-delete option when Git rejected deletion because the worktree contained modified or untracked files. The daemon wrapped every provider failure as a generic provider error, so the existing cleanup prompt could only offer retry.

## Summary

- Classify provider delete failures as dirty-worktree failures when they contain Git's dirty-worktree signature and the worktree actually has local changes.
- Preserve retry-only behavior for unrelated provider failures.
- Add a daemon regression for dirty provider-managed worktrees.
- Document the user-visible cleanup fix in `CHANGELOG.md`.

## Test plan

- [x] `go test ./internal/daemon -run 'TestDoDeleteWorktree_(ProviderDirtyWorktreeErrorIsForceable|ProviderErrorPreservesDaemonState|ProviderDeclineFallsBackToBuiltInGit|NormalDeleteFailurePreservesAttnState|ForceDeleteCleansUpAfterGitDelete)' -count=1`\n- [x] `go test ./internal/daemon -count=1`\n- [x] `pnpm --dir app test -- WorktreeCleanupPrompt.test.tsx App.worktreeCleanup.test.tsx useDaemonSocket.test.tsx`\n- [x] `git diff --check`