### PR TITLE
Make attn resolve correctly when a stale binary shadows it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 
 ## [2026-06-01]
 
+### Changed
+- **`attn` is clearer about being its own command.** `attn --help`, unknown commands, and unknown flags now print attn's own usage (with its version) instead of quietly handing them to the coding agent. `attn` understands only `-s`, `--resume`, and `--yolo`; it no longer forwards other flags — or anything after `--` — through to the agent.
+- **Stale-`attn` warning.** When the `attn` on your `PATH` is a different version from the running app, attn prints a one-line warning so you can catch an out-of-date binary shadowing the current one (`which -a attn`).
+
 ### Fixed
 - **Workspace Sessions**: Creating a worktree from the `⌘N` new-session picker now adds the session to the current workspace instead of creating a separate workspace.
 - **Worktree Cleanup**: Provider-managed worktrees with local changes now offer force delete after the normal delete attempt is rejected.

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -139,7 +139,7 @@ func main() {
 	case "open":
 		maybePrintProfileBanner()
 		runOpen()
-	case "help":
+	case "help", "-h", "--help":
 		runHelp()
 	case "_hook-stop":
 		runHookStop()
@@ -155,7 +155,8 @@ func main() {
 			maybePrintProfileBanner()
 			runWrapper()
 		} else {
-			fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+			fmt.Fprintf(os.Stderr, "attn %s: unknown command %q\n\n", buildinfo.Version, os.Args[1])
+			writeHelp(os.Stderr)
 			os.Exit(1)
 		}
 	}
@@ -335,6 +336,7 @@ func runWSRelay() {
 }
 
 func runList() {
+	warnIfDaemonVersionMismatch()
 	c := client.New("")
 	sessions, err := c.Query("")
 	if err != nil {
@@ -357,6 +359,7 @@ func detectPresence() (sessionID string, present bool) {
 }
 
 func runPresence() {
+	warnIfDaemonVersionMismatch()
 	sessionID, present := detectPresence()
 	if !present {
 		fmt.Println("not running inside attn")
@@ -426,6 +429,7 @@ func parseOpenArgs(args []string) (rawPath string, sessionFlag string, err error
 // ATTN_SESSION_ID (set inside attn-managed agents), then the daemon's currently
 // selected session.
 func runOpen() {
+	warnIfDaemonVersionMismatch()
 	rawPath, sessionFlag, err := parseOpenArgs(os.Args[2:])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "attn open: %v\nusage: attn open <file.md> [--session <id>]\n", err)
@@ -455,6 +459,7 @@ func runReviewLoop() {
 		fmt.Fprintln(os.Stderr, "usage: attn review-loop <start|stop|status|show|set-iterations|answer> ...")
 		os.Exit(1)
 	}
+	warnIfDaemonVersionMismatch()
 
 	c := client.New("")
 	switch os.Args[2] {
@@ -618,55 +623,43 @@ type directLaunchArgs struct {
 	resumeID     string
 	resumePicker bool
 	yoloMode     bool
-	agentArgs    []string
 }
 
-func parseDirectLaunchArgs(args []string) directLaunchArgs {
-	fs := flag.NewFlagSet("attn", flag.ContinueOnError)
-	labelFlag := fs.String("s", "", "session label")
-	resumeFlag := fs.String("resume", "", "session ID to resume from")
-	yoloFlag := fs.Bool("yolo", false, "launch agent in yolo mode")
-	resumePicker := false
-
-	var attnArgs []string
-	var agentArgs []string
+// parseDirectLaunchArgs parses the wrapper launch flags. attn understands only
+// -s, --resume, and --yolo; any other argument is an error. We deliberately do
+// not forward unrecognized args to the underlying agent — that implicit
+// passthrough was never used by attn itself and only created confusion (e.g.
+// `attn --help` printing the agent's help instead of attn's).
+func parseDirectLaunchArgs(args []string) (directLaunchArgs, error) {
+	parsed := directLaunchArgs{}
+	label := ""
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch arg {
 		case "-s":
-			if i+1 < len(args) {
-				attnArgs = append(attnArgs, arg, args[i+1])
-				i++
+			if i+1 >= len(args) {
+				return directLaunchArgs{}, fmt.Errorf("flag -s needs a value")
 			}
+			label = args[i+1]
+			i++
 		case "--resume":
-			if i+1 < len(args) && args[i+1] != "--" && !strings.HasPrefix(args[i+1], "-") {
-				attnArgs = append(attnArgs, arg, args[i+1])
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				parsed.resumeID = args[i+1]
 				i++
 			} else {
-				resumePicker = true
+				parsed.resumePicker = true
 			}
 		case "--yolo":
-			attnArgs = append(attnArgs, arg)
-		case "--":
-			agentArgs = append(agentArgs, args[i+1:]...)
-			i = len(args)
+			parsed.yoloMode = true
 		default:
-			agentArgs = append(agentArgs, arg)
+			return directLaunchArgs{}, fmt.Errorf("unknown flag %q", arg)
 		}
 	}
-	_ = fs.Parse(attnArgs)
-
-	label := *labelFlag
 	if label == "" {
 		label = wrapper.DefaultLabel()
 	}
-	return directLaunchArgs{
-		label:        label,
-		resumeID:     *resumeFlag,
-		resumePicker: resumePicker,
-		yoloMode:     *yoloFlag,
-		agentArgs:    agentArgs,
-	}
+	parsed.label = label
+	return parsed, nil
 }
 
 func mergeEnv(base []string, extra []string) []string {
@@ -697,6 +690,13 @@ func mergeEnv(base []string, extra []string) []string {
 }
 
 func runAgentDirectly(requestedAgent string) {
+	parsed, err := parseDirectLaunchArgs(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "attn: %v\n\n", err)
+		writeHelp(os.Stderr)
+		os.Exit(1)
+	}
+
 	pathutil.EnsureGUIPath()
 
 	driver := agentdriver.Get(requestedAgent)
@@ -706,7 +706,6 @@ func runAgentDirectly(requestedAgent string) {
 	}
 	caps := agentdriver.EffectiveCapabilities(driver)
 
-	parsed := parseDirectLaunchArgs(os.Args[1:])
 	if !caps.HasResume && (parsed.resumeID != "" || parsed.resumePicker) {
 		fmt.Fprintf(os.Stderr, "warning: %s resume not supported yet (ignoring --resume)\n", driver.Name())
 		parsed.resumeID = ""
@@ -746,7 +745,6 @@ func runAgentDirectly(requestedAgent string) {
 		Executable:      driver.ResolveExecutable(""),
 		SocketPath:      config.SocketPath(),
 		WrapperPath:     resolveWrapperPath(),
-		AgentArgs:       append([]string(nil), parsed.agentArgs...),
 	}
 
 	if preparer, ok := driver.(agentdriver.LaunchPreparer); ok {

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -196,7 +196,10 @@ func TestResolveCopilotTranscript_FallsBackWhenResumePathMissing(t *testing.T) {
 }
 
 func TestParseDirectLaunchArgs_ResumePickerWithFlagAfterResume(t *testing.T) {
-	parsed := parseDirectLaunchArgs([]string{"--resume", "--yolo", "--", "--model", "foo"})
+	parsed, err := parseDirectLaunchArgs([]string{"--resume", "--yolo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !parsed.resumePicker {
 		t.Fatalf("expected resume picker to be enabled")
 	}
@@ -206,13 +209,13 @@ func TestParseDirectLaunchArgs_ResumePickerWithFlagAfterResume(t *testing.T) {
 	if !parsed.yoloMode {
 		t.Fatalf("expected yolo flag to be preserved")
 	}
-	if len(parsed.agentArgs) != 2 || parsed.agentArgs[0] != "--model" || parsed.agentArgs[1] != "foo" {
-		t.Fatalf("unexpected agent args: %#v", parsed.agentArgs)
-	}
 }
 
 func TestParseDirectLaunchArgs_ResumeIDStillAccepted(t *testing.T) {
-	parsed := parseDirectLaunchArgs([]string{"--resume", "abc123"})
+	parsed, err := parseDirectLaunchArgs([]string{"--resume", "abc123"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if parsed.resumePicker {
 		t.Fatalf("expected resume picker to be disabled")
 	}
@@ -221,13 +224,32 @@ func TestParseDirectLaunchArgs_ResumeIDStillAccepted(t *testing.T) {
 	}
 }
 
-func TestParseDirectLaunchArgs_YoloFlag(t *testing.T) {
-	parsed := parseDirectLaunchArgs([]string{"--yolo", "--", "--model", "foo"})
+func TestParseDirectLaunchArgs_LabelAndYolo(t *testing.T) {
+	parsed, err := parseDirectLaunchArgs([]string{"-s", "my-label", "--yolo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if parsed.label != "my-label" {
+		t.Fatalf("expected label my-label, got %q", parsed.label)
+	}
 	if !parsed.yoloMode {
 		t.Fatal("expected yolo mode to be enabled")
 	}
-	if len(parsed.agentArgs) != 2 || parsed.agentArgs[0] != "--model" || parsed.agentArgs[1] != "foo" {
-		t.Fatalf("unexpected agent args: %#v", parsed.agentArgs)
+}
+
+// parseDirectLaunchArgs understands only -s/--resume/--yolo. Everything else is
+// rejected rather than silently forwarded to the underlying agent.
+func TestParseDirectLaunchArgs_RejectsUnrecognizedArgs(t *testing.T) {
+	for _, args := range [][]string{
+		{"--model", "foo"}, // arbitrary agent flag
+		{"--"},             // the old passthrough separator
+		{"--help"},         // must not reach the agent
+		{"random"},         // bare positional
+		{"-s"},             // missing label value
+	} {
+		if _, err := parseDirectLaunchArgs(args); err == nil {
+			t.Fatalf("expected error for args %#v, got nil", args)
+		}
 	}
 }
 

--- a/cmd/attn/versioncheck.go
+++ b/cmd/attn/versioncheck.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/buildinfo"
+	"github.com/victorarias/attn/internal/config"
+)
+
+// warnIfDaemonVersionMismatch best-effort compares this CLI's build version
+// against the running daemon's reported version and prints a one-line stderr
+// warning when they differ.
+//
+// It exists to surface the failure mode where a stale or unrelated `attn`
+// shadows the current one on PATH: the daemon is spawned from the installed
+// app, so its version is authoritative for "what attn actually is" on this
+// machine. A version skew almost always means the CLI on PATH is not the one
+// the app installed.
+//
+// Always best-effort and non-fatal: a missing daemon, a non-comparable build
+// (dev/unknown), a probe timeout, or any decode error simply skips the warning.
+func warnIfDaemonVersionMismatch() {
+	// Skip the network probe entirely for non-comparable builds.
+	if !comparableBuildVersion(strings.TrimSpace(buildinfo.Version)) {
+		return
+	}
+	if msg, ok := versionMismatchWarning(buildinfo.Version, fetchDaemonVersion()); ok {
+		fmt.Fprintln(os.Stderr, msg)
+	}
+}
+
+// versionMismatchWarning is the pure decision behind warnIfDaemonVersionMismatch:
+// it returns a warning message and true only when both versions are comparable
+// release versions and they differ.
+func versionMismatchWarning(cliVersion, daemonVersion string) (string, bool) {
+	cliVersion = strings.TrimSpace(cliVersion)
+	daemonVersion = strings.TrimSpace(daemonVersion)
+	if !comparableBuildVersion(cliVersion) || !comparableBuildVersion(daemonVersion) {
+		return "", false
+	}
+	if cliVersion == daemonVersion {
+		return "", false
+	}
+	return fmt.Sprintf(
+		"attn: warning: this CLI is %s but the running attn app is %s. "+
+			"You may be running a stale attn — check `which -a attn`, then reinstall or use $ATTN_WRAPPER_PATH.",
+		cliVersion, daemonVersion), true
+}
+
+// comparableBuildVersion reports whether a version string is a real release
+// version we can meaningfully compare. Source/dev builds carry sentinel values
+// that would produce noisy false positives.
+func comparableBuildVersion(v string) bool {
+	switch v {
+	case "", "dev", "unknown":
+		return false
+	default:
+		return true
+	}
+}
+
+// fetchDaemonVersion reads the daemon's reported version from its /health
+// endpoint. Returns "" on any failure. The probe targets 127.0.0.1 directly
+// (the daemon always listens locally) so it works even when bound to 0.0.0.0.
+func fetchDaemonVersion() string {
+	httpClient := &http.Client{Timeout: 400 * time.Millisecond}
+	url := "http://" + net.JoinHostPort("127.0.0.1", config.WSPort()) + "/health"
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	var health struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(health.Version)
+}

--- a/cmd/attn/versioncheck_test.go
+++ b/cmd/attn/versioncheck_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersionMismatchWarning(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		daemon   string
+		wantWarn bool
+	}{
+		{name: "different releases warn", cli: "0.5.0", daemon: "0.10.2", wantWarn: true},
+		{name: "same release is quiet", cli: "0.10.2", daemon: "0.10.2", wantWarn: false},
+		{name: "whitespace tolerated", cli: " 0.10.2 ", daemon: "0.10.2", wantWarn: false},
+		{name: "dev cli skipped", cli: "dev", daemon: "0.10.2", wantWarn: false},
+		{name: "unknown daemon skipped", cli: "0.10.2", daemon: "unknown", wantWarn: false},
+		{name: "empty daemon skipped", cli: "0.10.2", daemon: "", wantWarn: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, ok := versionMismatchWarning(tt.cli, tt.daemon)
+			if ok != tt.wantWarn {
+				t.Fatalf("versionMismatchWarning(%q, %q) ok = %v, want %v", tt.cli, tt.daemon, ok, tt.wantWarn)
+			}
+			if ok {
+				if !strings.Contains(msg, strings.TrimSpace(tt.cli)) || !strings.Contains(msg, strings.TrimSpace(tt.daemon)) {
+					t.Fatalf("warning %q should mention both versions", msg)
+				}
+				if !strings.Contains(msg, "which -a attn") {
+					t.Fatalf("warning %q should point at the shadowing check", msg)
+				}
+			}
+		})
+	}
+}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -82,7 +82,6 @@ func (c *Claude) BuildCommand(opts SpawnOpts) *exec.Cmd {
 		args = append(args, "--dangerously-skip-permissions")
 	}
 
-	args = append(args, opts.AgentArgs...)
 	return exec.Command(opts.Executable, args...)
 }
 

--- a/internal/agent/claude_skill.go
+++ b/internal/agent/claude_skill.go
@@ -19,6 +19,21 @@ Start by checking if the user is running inside attn:
 
 You can get help via ` + "`attn help`" + `.
 
+## Which attn binary to run
+
+Inside an attn session the ATTN_WRAPPER_PATH environment variable points at the
+correct attn binary. Prefer it for every command in this skill:
+
+    "$ATTN_WRAPPER_PATH" presence
+
+This skill writes attn for brevity, but run "$ATTN_WRAPPER_PATH" whenever it is
+set, and fall back to attn on PATH only when it is not.
+
+If an attn command fails with "unknown command: ..." or prints Claude Code's
+help instead of attn's, a stale or unrelated attn is probably shadowing the real
+one on PATH. Confirm with "attn --version" and "which -a attn", then prefer
+"$ATTN_WRAPPER_PATH".
+
 Use this skill when a prompt tells you to:
 
 1. use your attn skill to start a review loop

--- a/internal/agent/claude_skill_test.go
+++ b/internal/agent/claude_skill_test.go
@@ -33,6 +33,12 @@ func TestEnsureAttnClaudeSkillInstalled(t *testing.T) {
 	if !strings.Contains(text, "attn help") {
 		t.Fatalf("skill content missing help command: %q", text)
 	}
+	if !strings.Contains(text, "ATTN_WRAPPER_PATH") {
+		t.Fatalf("skill content missing ATTN_WRAPPER_PATH resolution guidance: %q", text)
+	}
+	if !strings.Contains(text, "which -a attn") {
+		t.Fatalf("skill content missing stale-binary collision note: %q", text)
+	}
 	if !strings.Contains(text, "attn review-loop answer --loop <loop-id> --interaction <interaction-id> --answer") {
 		t.Fatalf("skill content missing review loop answer command: %q", text)
 	}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -62,21 +62,11 @@ func (c *Codex) BuildCommand(opts SpawnOpts) *exec.Cmd {
 		args = append(args, "resume")
 	}
 
-	hasCwdFlag := false
-	for i := 0; i < len(opts.AgentArgs); i++ {
-		if opts.AgentArgs[i] == "-C" || opts.AgentArgs[i] == "--cd" {
-			hasCwdFlag = true
-			break
-		}
-	}
-	if !hasCwdFlag {
-		args = append(args, "-C", opts.CWD)
-	}
+	args = append(args, "-C", opts.CWD)
 	if opts.YoloMode {
 		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
 	}
 
-	args = append(args, opts.AgentArgs...)
 	return exec.Command(opts.Executable, args...)
 }
 

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -53,7 +53,6 @@ func (c *Copilot) BuildCommand(opts SpawnOpts) *exec.Cmd {
 	if opts.YoloMode {
 		args = append(args, "--yolo")
 	}
-	args = append(args, opts.AgentArgs...)
 	return exec.Command(opts.Executable, args...)
 }
 

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -207,9 +207,6 @@ type SpawnOpts struct {
 
 	// ConfigOverrides are agent CLI config overrides generated for this launch.
 	ConfigOverrides []string
-
-	// AgentArgs are passthrough CLI args provided after attn wrapper flags.
-	AgentArgs []string
 }
 
 // --- Optional capability interfaces ---


### PR DESCRIPTION
## Why

While using the attn skill from Claude Code, `attn open` failed with `unknown command: open`. Root cause: a **stale `attn` v0.5.0 (Apr 12)** at `~/.local/bin/attn` sat ahead of the app on `PATH` and shadowed the current v0.10.2 wrapper. Every command hit the old binary, which predates `open`/`presence`. The errors were misleading because (a) the old binary's `unknown command` error looks identical to a real one, and (b) `attn` forwards unrecognized flags to the agent, so `attn --help` printed *Claude's* help, hiding the fact that the wrong binary was running.

This PR makes attn (and its skill) resilient to that failure mode.

## Changes

**Skill — binary resolution + collision note** (`internal/agent/claude_skill.go`)
- Tell agents to prefer `$ATTN_WRAPPER_PATH` (always set inside a session, points at the authoritative binary), falling back to `attn` on PATH only when unset.
- Add a troubleshooting note: if a command says `unknown command: ...` or prints Claude's help, a stale/unrelated `attn` is probably shadowing the real one — confirm with `attn --version` / `which -a attn`.

**CLI — remove the implicit agent passthrough** (`cmd/attn`, `internal/agent`)
- `attn` now understands only `-s`, `--resume`, `--yolo`. Any other flag, the `--` separator, or a stray positional is rejected with attn's own usage. This passthrough was never used internally — the only launcher (`internal/pty/manager.go`) emits exactly those three flags.
- `attn --help`/`-h` now print attn's help; unknown-command errors include the attn version, so a stale binary is obvious at a glance.
- Removed the now-dead `SpawnOpts.AgentArgs` field and its three driver consumers (codex always passes `-C <cwd>` now).

**CLI — version-skew warning** (`cmd/attn/versioncheck.go`)
- Human commands (`presence`, `list`, `open`, `review-loop`) best-effort probe the daemon's existing `/health` endpoint and print one stderr line when the running CLI's version differs from the app's. No protocol change; dev/unknown builds are skipped; fully non-fatal.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt` — clean.
- New/updated unit tests for `parseDirectLaunchArgs` (rejects unrecognized args), the skill content, and the version-skew decision. `go test ./cmd/attn/... ./internal/agent/...` passes.
- Manual smoke tests on the built binary: unknown command shows version + usage; `attn --help` shows attn help; unknown flag / `--` rejected; the nudge fires against the live daemon on a fake-version build and stays silent on a match.

## Notes
- Removing the passthrough only affects a human manually passing arbitrary agent flags through the `attn` wrapper from a terminal — confirmed unused.
- The stale `~/.local/bin/attn` itself was removed out-of-band (no local code path writes there; only the remote SSH hub bootstrap targets that path on *remote* hosts).