### PR TITLE
[codex] Bound daemon log size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 ### Fixed
 - **Workspace Sessions**: Creating a worktree from the `⌘N` new-session picker now adds the session to the current workspace instead of creating a separate workspace.
 - **Worktree Cleanup**: Provider-managed worktrees with local changes now offer force delete after the normal delete attempt is rejected.
+- **Daemon Logging**: `daemon.log` now automatically keeps a bounded recent tail so long-running installs do not accumulate an unbounded log file.
 
 ---
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -80,7 +80,7 @@ func (l *Logger) log(level, msg string) {
 	line := fmt.Sprintf("[%s] %s: %s", timestamp, level, msg)
 	l.logger.Print(line)
 	l.bytesSinceSizeCheck += int64(len(line) + 1)
-	_ = l.maybeTruncateLocked(false)
+	_ = l.maybeTruncateLocked(true)
 }
 
 func (l *Logger) Info(msg string) {
@@ -150,12 +150,14 @@ func (l *Logger) maybeTruncateLocked(force bool) error {
 		}
 	}
 
-	marker := fmt.Sprintf(
-		"[%s] INFO: daemon.log truncated; retained last %d bytes from previous %d-byte log\n",
-		time.Now().Format(truncationMarkerTimeLayout),
-		len(tail),
-		size,
-	)
+	marker := truncationMarker(len(tail), size)
+	if l.maxBytes <= int64(len(marker)) {
+		tail = nil
+		marker = marker[:int(l.maxBytes)]
+	} else if int64(len(marker)+len(tail)) > l.maxBytes {
+		tail = tail[len(tail)-int(l.maxBytes-int64(len(marker))):]
+		marker = truncationMarker(len(tail), size)
+	}
 	if err := l.file.Truncate(0); err != nil {
 		return err
 	}
@@ -179,4 +181,13 @@ func firstNewline(data []byte) int {
 		}
 	}
 	return -1
+}
+
+func truncationMarker(retainedBytes int, previousBytes int64) string {
+	return fmt.Sprintf(
+		"[%s] INFO: daemon.log truncated; retained=%d previous=%d\n",
+		time.Now().Format(truncationMarkerTimeLayout),
+		retainedBytes,
+		previousBytes,
+	)
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -11,32 +12,57 @@ import (
 	"github.com/victorarias/attn/internal/config"
 )
 
+const (
+	defaultMaxLogBytes         int64 = 20 << 20
+	defaultRetainedLogBytes    int64 = 5 << 20
+	defaultLogSizeCheckBytes   int64 = 256 << 10
+	truncationMarkerTimeLayout       = "2006-01-02 15:04:05"
+)
+
 type Logger struct {
-	file   *os.File
-	logger *log.Logger
-	debug  bool
-	mu     sync.Mutex
+	file                *os.File
+	logger              *log.Logger
+	debug               bool
+	maxBytes            int64
+	retainedBytes       int64
+	sizeCheckBytes      int64
+	bytesSinceSizeCheck int64
+	mu                  sync.Mutex
 }
 
 func New(path string) (*Logger, error) {
+	return newWithLimits(path, defaultMaxLogBytes, defaultRetainedLogBytes, defaultLogSizeCheckBytes)
+}
+
+func newWithLimits(path string, maxBytes, retainedBytes, sizeCheckBytes int64) (*Logger, error) {
 	// Ensure directory exists
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, err
 	}
 
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0644)
 	if err != nil {
 		return nil, err
 	}
 
 	debug := config.DebugLevel() >= config.LogDebug
 
-	return &Logger{
-		file:   file,
-		logger: log.New(file, "", 0),
-		debug:  debug,
-	}, nil
+	logger := &Logger{
+		file:           file,
+		logger:         log.New(file, "", 0),
+		debug:          debug,
+		maxBytes:       maxBytes,
+		retainedBytes:  retainedBytes,
+		sizeCheckBytes: sizeCheckBytes,
+	}
+	logger.mu.Lock()
+	err = logger.maybeTruncateLocked(true)
+	logger.mu.Unlock()
+	if err != nil {
+		logger.Errorf("daemon.log truncation failed: %v", err)
+	}
+	return logger, nil
 }
 
 func (l *Logger) Close() error {
@@ -49,8 +75,11 @@ func (l *Logger) Close() error {
 func (l *Logger) log(level, msg string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	timestamp := time.Now().Format("2006-01-02 15:04:05")
-	l.logger.Printf("[%s] %s: %s", timestamp, level, msg)
+	_ = l.maybeTruncateLocked(false)
+	timestamp := time.Now().Format(truncationMarkerTimeLayout)
+	line := fmt.Sprintf("[%s] %s: %s", timestamp, level, msg)
+	l.logger.Print(line)
+	l.bytesSinceSizeCheck += int64(len(line) + 1)
 }
 
 func (l *Logger) Info(msg string) {
@@ -81,4 +110,72 @@ func (l *Logger) Debugf(format string, args ...interface{}) {
 
 func DefaultLogPath() string {
 	return config.LogPath()
+}
+
+func (l *Logger) maybeTruncateLocked(force bool) error {
+	if l == nil || l.file == nil || l.maxBytes <= 0 || l.retainedBytes <= 0 {
+		return nil
+	}
+	if !force && l.sizeCheckBytes > 0 && l.bytesSinceSizeCheck < l.sizeCheckBytes {
+		return nil
+	}
+	l.bytesSinceSizeCheck = 0
+
+	info, err := l.file.Stat()
+	if err != nil {
+		return err
+	}
+	size := info.Size()
+	if size <= l.maxBytes {
+		return nil
+	}
+
+	retainedBytes := l.retainedBytes
+	if retainedBytes > l.maxBytes {
+		retainedBytes = l.maxBytes
+	}
+	if retainedBytes > size {
+		retainedBytes = size
+	}
+
+	tail := make([]byte, retainedBytes)
+	start := size - retainedBytes
+	if _, err := l.file.ReadAt(tail, start); err != nil && err != io.EOF {
+		return err
+	}
+	if start > 0 {
+		if newline := firstNewline(tail); newline >= 0 && newline+1 < len(tail) {
+			tail = tail[newline+1:]
+		}
+	}
+
+	marker := fmt.Sprintf(
+		"[%s] INFO: daemon.log truncated; retained last %d bytes from previous %d-byte log\n",
+		time.Now().Format(truncationMarkerTimeLayout),
+		len(tail),
+		size,
+	)
+	if err := l.file.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := l.file.Seek(0, 0); err != nil {
+		return err
+	}
+	if _, err := l.file.WriteString(marker); err != nil {
+		return err
+	}
+	if _, err := l.file.Write(tail); err != nil {
+		return err
+	}
+	_, err = l.file.Seek(0, io.SeekEnd)
+	return err
+}
+
+func firstNewline(data []byte) int {
+	for i, b := range data {
+		if b == '\n' {
+			return i
+		}
+	}
+	return -1
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -80,6 +80,7 @@ func (l *Logger) log(level, msg string) {
 	line := fmt.Sprintf("[%s] %s: %s", timestamp, level, msg)
 	l.logger.Print(line)
 	l.bytesSinceSizeCheck += int64(len(line) + 1)
+	_ = l.maybeTruncateLocked(false)
 }
 
 func (l *Logger) Info(msg string) {

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -205,3 +205,36 @@ func TestLogger_TruncatesOversizedLogAfterWrites(t *testing.T) {
 		t.Fatalf("expected earliest log lines to be removed, got: %s", text)
 	}
 }
+
+func TestLogger_TruncatesAfterSingleLargeWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "daemon.log")
+
+	logger, err := newWithLimits(logPath, 220, 40, 20)
+	if err != nil {
+		t.Fatalf("newWithLimits() error: %v", err)
+	}
+	defer logger.Close()
+
+	logger.Info("large " + strings.Repeat("x", 300) + " tail")
+
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("Stat error: %v", err)
+	}
+	if info.Size() > 220 {
+		t.Fatalf("expected large write to be truncated immediately, size=%d", info.Size())
+	}
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile error: %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "daemon.log truncated") {
+		t.Fatalf("expected truncation marker, got: %s", text)
+	}
+	if !strings.Contains(text, "tail") {
+		t.Fatalf("expected retained tail of large write, got: %s", text)
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -210,19 +210,19 @@ func TestLogger_TruncatesAfterSingleLargeWrite(t *testing.T) {
 	tmpDir := t.TempDir()
 	logPath := filepath.Join(tmpDir, "daemon.log")
 
-	logger, err := newWithLimits(logPath, 220, 40, 20)
+	logger, err := newWithLimits(logPath, 100, 40, 1000)
 	if err != nil {
 		t.Fatalf("newWithLimits() error: %v", err)
 	}
 	defer logger.Close()
 
-	logger.Info("large " + strings.Repeat("x", 300) + " tail")
+	logger.Info("large " + strings.Repeat("x", 500) + " tail")
 
 	info, err := os.Stat(logPath)
 	if err != nil {
 		t.Fatalf("Stat error: %v", err)
 	}
-	if info.Size() > 220 {
+	if info.Size() > 100 {
 		t.Fatalf("expected large write to be truncated immediately, size=%d", info.Size())
 	}
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -144,3 +144,64 @@ func TestLogger_Errorf(t *testing.T) {
 		t.Errorf("log file should contain ERROR level, got: %s", content)
 	}
 }
+
+func TestLogger_TruncatesOversizedLogOnStartup(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "daemon.log")
+	original := strings.Repeat("old line should be removed\n", 20) + "keep line 1\nkeep line 2\n"
+	if err := os.WriteFile(logPath, []byte(original), 0644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	logger, err := newWithLimits(logPath, 120, 40, 16)
+	if err != nil {
+		t.Fatalf("newWithLimits() error: %v", err)
+	}
+	defer logger.Close()
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile error: %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "daemon.log truncated") {
+		t.Fatalf("expected truncation marker, got: %s", text)
+	}
+	if !strings.Contains(text, "keep line 1\nkeep line 2\n") {
+		t.Fatalf("expected retained tail, got: %s", text)
+	}
+	if strings.Contains(text, "old line should be removed") {
+		t.Fatalf("expected old prefix to be removed, got: %s", text)
+	}
+}
+
+func TestLogger_TruncatesOversizedLogAfterWrites(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "daemon.log")
+
+	logger, err := newWithLimits(logPath, 180, 80, 1)
+	if err != nil {
+		t.Fatalf("newWithLimits() error: %v", err)
+	}
+	defer logger.Close()
+
+	for i := 0; i < 10; i++ {
+		logger.Infof("line %02d %s", i, strings.Repeat("x", 20))
+	}
+	logger.Info("tail survives")
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile error: %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "daemon.log truncated") {
+		t.Fatalf("expected truncation marker, got: %s", text)
+	}
+	if !strings.Contains(text, "tail survives") {
+		t.Fatalf("expected writes after truncation to continue, got: %s", text)
+	}
+	if strings.Contains(text, "line 00") {
+		t.Fatalf("expected earliest log lines to be removed, got: %s", text)
+	}
+}


### PR DESCRIPTION
## Summary
- Keep `daemon.log` bounded by compacting it in-process once it exceeds 20 MiB.
- Retain the recent tail in the same file and add a marker line after truncation.
- Add focused tests for startup truncation, periodic truncation, and continued writes.

## Why
Long-running installs could accumulate an unbounded daemon log. Keeping the single documented `daemon.log` path while retaining recent context makes debugging predictable without requiring external log rotation setup.

## Validation
- `go test ./internal/logging`
- `go test ./internal/logging ./internal/daemon`