### PR TITLE
feat(workspace): drag any pane or panel to re-dock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 
 ## [2026-06-01]
 
+### Added
+- **Drag any pane or panel to rearrange a workspace.** Grab a terminal pane's header (or a markdown panel's header) and drop it on another pane's edge to re-dock it — left, right, top, or bottom. How far in you drop sets the new split's size, snapping to a quarter, third, or half; drop into the workspace's outer edge to span the whole side. Dropping a pane on itself does nothing.
+
 ### Changed
 - **`attn` is clearer about being its own command.** `attn --help`, unknown commands, and unknown flags now print attn's own usage (with its version) instead of quietly handing them to the coding agent. `attn` understands only `-s`, `--resume`, and `--yolo`; it no longer forwards other flags — or anything after `--` — through to the agent.
 - **Stale-`attn` warning.** When the `attn` on your `PATH` is a different version from the running app, attn prints a one-line warning so you can catch an out-of-date binary shadowing the current one (`which -a attn`).

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -380,8 +380,8 @@ function App() {
     sendWorkspaceAddSessionPane,
     sendWorkspaceClosePane,
     sendWorkspaceSetSplitRatio,
-    sendWorkspaceDockPanel,
     sendWorkspaceUndockPanel,
+    sendWorkspaceMoveLeaf,
     panelContents,
     requestPanelContent,
     sendRuntimeInput,
@@ -502,8 +502,8 @@ function App() {
         sendWorkspaceAddSessionPane={sendWorkspaceAddSessionPane}
         sendWorkspaceClosePane={sendWorkspaceClosePane}
         sendWorkspaceSetSplitRatio={sendWorkspaceSetSplitRatio}
-        sendWorkspaceDockPanel={sendWorkspaceDockPanel}
         sendWorkspaceUndockPanel={sendWorkspaceUndockPanel}
+        sendWorkspaceMoveLeaf={sendWorkspaceMoveLeaf}
         panelContents={panelContents}
         requestPanelContent={requestPanelContent}
         sendRuntimeInput={sendRuntimeInput}
@@ -591,8 +591,8 @@ interface AppContentProps {
   sendWorkspaceAddSessionPane: ReturnType<typeof useDaemonSocket>['sendWorkspaceAddSessionPane'];
   sendWorkspaceClosePane: ReturnType<typeof useDaemonSocket>['sendWorkspaceClosePane'];
   sendWorkspaceSetSplitRatio: ReturnType<typeof useDaemonSocket>['sendWorkspaceSetSplitRatio'];
-  sendWorkspaceDockPanel: ReturnType<typeof useDaemonSocket>['sendWorkspaceDockPanel'];
   sendWorkspaceUndockPanel: ReturnType<typeof useDaemonSocket>['sendWorkspaceUndockPanel'];
+  sendWorkspaceMoveLeaf: ReturnType<typeof useDaemonSocket>['sendWorkspaceMoveLeaf'];
   panelContents: ReturnType<typeof useDaemonSocket>['panelContents'];
   requestPanelContent: ReturnType<typeof useDaemonSocket>['requestPanelContent'];
   sendRuntimeInput: ReturnType<typeof useDaemonSocket>['sendRuntimeInput'];
@@ -675,8 +675,8 @@ sendFetchPRDetails,
   sendWorkspaceAddSessionPane,
   sendWorkspaceClosePane,
   sendWorkspaceSetSplitRatio,
-  sendWorkspaceDockPanel,
   sendWorkspaceUndockPanel,
+  sendWorkspaceMoveLeaf,
   panelContents,
   requestPanelContent,
   sendRuntimeInput,
@@ -2686,11 +2686,11 @@ sendFetchPRDetails,
                       ));
                     }}
                     onNavigateOutOfSession={handleNavigateOutOfSession}
-                    onDockPanel={(panelId, panelKind, anchorPaneId, edge) => {
-                      void sendWorkspaceDockPanel(workspace.id, panelId, panelKind, { anchorPaneId, edge }).catch(() => {});
-                    }}
                     onUndockPanel={(panelId) => {
                       void sendWorkspaceUndockPanel(workspace.id, panelId).catch(() => {});
+                    }}
+                    onMoveLeaf={(leafId, anchorId, edge, ratio) => {
+                      void sendWorkspaceMoveLeaf(workspace.id, leafId, { anchorId, edge, ratio }).catch(() => {});
                     }}
                     panelContents={panelContents}
                     allowLocalPanelTargets={!workspace.endpointId}

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -216,6 +216,22 @@
   display: none;
 }
 
+/* The header doubles as the drag-to-move handle when the workspace has more than
+   one leaf. */
+.workspace-pane-header--draggable {
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+
+.workspace-pane-header--draggable:active {
+  cursor: grabbing;
+}
+
+.workspace-pane--dragging {
+  opacity: 0.5;
+}
+
 .workspace-pane-title {
   color: var(--color-text-secondary);
   font-size: var(--font-size-xs);

--- a/app/src/components/SessionTerminalWorkspace/dockTarget.test.ts
+++ b/app/src/components/SessionTerminalWorkspace/dockTarget.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { computeDockTarget, computeContainerSides, type DockEdgeFlags } from './dockTarget';
+import type { NormalizedPaneBounds } from '../../types/workspace';
+
+function bounds(left: number, top: number, right: number, bottom: number): NormalizedPaneBounds {
+  return {
+    left,
+    top,
+    right,
+    bottom,
+    width: right - left,
+    height: bottom - top,
+    centerX: (left + right) / 2,
+    centerY: (top + bottom) / 2,
+  };
+}
+
+// 1000x1000 container so clientX/Y map 1:1 to normalized * 1000.
+const RECT = { left: 0, top: 0, width: 1000, height: 1000 };
+const NO_SIDES: DockEdgeFlags = { left: false, right: false, top: false, bottom: false };
+const FULL = bounds(0, 0, 1, 1);
+
+describe('computeDockTarget — depth sizes the incoming leaf', () => {
+  const leaf = [{ leafId: 'B', bounds: FULL }];
+
+  it('is a thin strip near the edge', () => {
+    const t = computeDockTarget(150, 500, RECT, leaf, NO_SIDES);
+    expect(t).toMatchObject({ anchorId: 'B', edge: 'left' });
+    expect(t!.ratio).toBeCloseTo(0.15, 5);
+    expect(t!.rect).toMatchObject({ left: 0, top: 0, height: 1 });
+    expect(t!.rect.width).toBeCloseTo(0.15, 5);
+  });
+
+  it('snaps to one third', () => {
+    const t = computeDockTarget(340, 500, RECT, leaf, NO_SIDES);
+    expect(t!.edge).toBe('left');
+    expect(t!.ratio).toBeCloseTo(1 / 3, 5);
+  });
+
+  it('snaps to half near the center', () => {
+    const t = computeDockTarget(480, 500, RECT, leaf, NO_SIDES);
+    expect(t!.ratio).toBeCloseTo(0.5, 5);
+  });
+
+  it('picks the nearest edge via the X-pattern', () => {
+    expect(computeDockTarget(500, 120, RECT, leaf, NO_SIDES)!.edge).toBe('top');
+    expect(computeDockTarget(500, 880, RECT, leaf, NO_SIDES)!.edge).toBe('bottom');
+    expect(computeDockTarget(880, 500, RECT, leaf, NO_SIDES)!.edge).toBe('right');
+  });
+});
+
+describe('computeDockTarget — no target', () => {
+  it('returns null when the only leaf is excluded (self-drop)', () => {
+    expect(computeDockTarget(500, 500, RECT, [], NO_SIDES)).toBeNull();
+  });
+
+  it('returns null for a degenerate container', () => {
+    expect(computeDockTarget(5, 5, { left: 0, top: 0, width: 0, height: 0 }, [{ leafId: 'B', bounds: FULL }], NO_SIDES)).toBeNull();
+  });
+});
+
+describe('computeDockTarget — container frame', () => {
+  const leaf = [{ leafId: 'B', bounds: FULL }];
+
+  it('docks against the whole workspace in the perimeter band when the side has 2+ leaves', () => {
+    const t = computeDockTarget(8, 500, RECT, leaf, { ...NO_SIDES, left: true });
+    expect(t).toMatchObject({ anchorId: '', edge: 'left', ratio: 0.5 });
+    expect(t!.rect).toMatchObject({ left: 0, top: 0, width: 0.5, height: 1 });
+  });
+
+  it('is suppressed on a side with a single full-span leaf — falls through to the leaf edge', () => {
+    const t = computeDockTarget(8, 500, RECT, leaf, NO_SIDES);
+    expect(t!.anchorId).toBe('B');
+    expect(t!.edge).toBe('left');
+  });
+});
+
+describe('computeContainerSides', () => {
+  it('flags a side only when 2+ leaves touch it', () => {
+    const sides = computeContainerSides([
+      bounds(0, 0, 0.5, 0.5),
+      bounds(0, 0.5, 0.5, 1),
+      bounds(0.5, 0, 1, 1),
+    ]);
+    expect(sides).toEqual({ left: true, right: false, top: true, bottom: true });
+  });
+
+  it('flags nothing for a single full-span leaf', () => {
+    expect(computeContainerSides([FULL])).toEqual({ left: false, right: false, top: false, bottom: false });
+  });
+});

--- a/app/src/components/SessionTerminalWorkspace/dockTarget.ts
+++ b/app/src/components/SessionTerminalWorkspace/dockTarget.ts
@@ -1,0 +1,163 @@
+import type { TerminalDockEdge } from '../../types/workspace';
+import type { NormalizedPaneBounds } from '../../types/workspace';
+
+// Drag-to-dock geometry: pure functions that turn a pointer position into a drop
+// target (which leaf or the whole workspace, which edge, and how big). Kept out
+// of the component so the math is unit-testable in isolation.
+
+// Drop sizing: how deep the pointer sits in the target leaf sets the incoming
+// leaf's fraction — thin at the edge (DOCK_F_MIN), up to half at the center —
+// magnetically snapping to clean splits when close.
+const DOCK_F_MIN = 0.15;
+const DOCK_F_MAX = 0.5;
+const DOCK_SNAP_POINTS = [0.25, 1 / 3, 0.5];
+const DOCK_SNAP_TOLERANCE = 0.045;
+// A thin perimeter band docks against the whole workspace (the root) instead of
+// one leaf. It splits the workspace in half; refine with the divider afterward.
+const DOCK_CONTAINER_FRAME_PX = 28;
+const DOCK_CONTAINER_FRACTION = 0.5;
+// A leaf counts as touching a container edge within this normalized slack.
+const DOCK_EDGE_EPSILON = 0.01;
+
+export type DockEdgeFlags = Record<TerminalDockEdge, boolean>;
+
+export interface DockNormalizedRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface DockTarget {
+  // The leaf the incoming leaf docks beside, or '' to dock against the whole
+  // workspace (a container dock).
+  anchorId: string;
+  edge: TerminalDockEdge;
+  // The incoming leaf's fraction of the new split (snapped).
+  ratio: number;
+  rect: DockNormalizedRect;
+}
+
+function snapDockFraction(fraction: number): number {
+  for (const point of DOCK_SNAP_POINTS) {
+    if (Math.abs(fraction - point) <= DOCK_SNAP_TOLERANCE) {
+      return point;
+    }
+  }
+  return fraction;
+}
+
+function leafBandRect(bounds: NormalizedPaneBounds, edge: TerminalDockEdge, fraction: number): DockNormalizedRect {
+  const bandW = bounds.width * fraction;
+  const bandH = bounds.height * fraction;
+  switch (edge) {
+    case 'left':
+      return { left: bounds.left, top: bounds.top, width: bandW, height: bounds.height };
+    case 'right':
+      return { left: bounds.right - bandW, top: bounds.top, width: bandW, height: bounds.height };
+    case 'top':
+      return { left: bounds.left, top: bounds.top, width: bounds.width, height: bandH };
+    default:
+      return { left: bounds.left, top: bounds.bottom - bandH, width: bounds.width, height: bandH };
+  }
+}
+
+function containerBandRect(edge: TerminalDockEdge, fraction: number): DockNormalizedRect {
+  switch (edge) {
+    case 'left':
+      return { left: 0, top: 0, width: fraction, height: 1 };
+    case 'right':
+      return { left: 1 - fraction, top: 0, width: fraction, height: 1 };
+    case 'top':
+      return { left: 0, top: 0, width: 1, height: fraction };
+    default:
+      return { left: 0, top: 1 - fraction, width: 1, height: fraction };
+  }
+}
+
+// computeContainerSides reports which workspace edges hold 2+ leaves, so a
+// container dock is only offered where it would differ from the leaf edge
+// already on that border (a single full-span leaf makes them coincide).
+export function computeContainerSides(boundsList: NormalizedPaneBounds[]): DockEdgeFlags {
+  let left = 0;
+  let right = 0;
+  let top = 0;
+  let bottom = 0;
+  for (const bounds of boundsList) {
+    if (bounds.left <= DOCK_EDGE_EPSILON) left += 1;
+    if (bounds.right >= 1 - DOCK_EDGE_EPSILON) right += 1;
+    if (bounds.top <= DOCK_EDGE_EPSILON) top += 1;
+    if (bounds.bottom >= 1 - DOCK_EDGE_EPSILON) bottom += 1;
+  }
+  return { left: left >= 2, right: right >= 2, top: top >= 2, bottom: bottom >= 2 };
+}
+
+function containerDockTarget(nx: number, ny: number, frameX: number, frameY: number, sides: DockEdgeFlags): DockTarget | null {
+  const candidates: Array<{ edge: TerminalDockEdge; dist: number }> = [];
+  if (sides.left && nx <= frameX) candidates.push({ edge: 'left', dist: nx });
+  if (sides.right && 1 - nx <= frameX) candidates.push({ edge: 'right', dist: 1 - nx });
+  if (sides.top && ny <= frameY) candidates.push({ edge: 'top', dist: ny });
+  if (sides.bottom && 1 - ny <= frameY) candidates.push({ edge: 'bottom', dist: 1 - ny });
+  if (candidates.length === 0) {
+    return null;
+  }
+  candidates.sort((a, b) => a.dist - b.dist);
+  const edge = candidates[0].edge;
+  return {
+    anchorId: '',
+    edge,
+    ratio: DOCK_CONTAINER_FRACTION,
+    rect: containerBandRect(edge, DOCK_CONTAINER_FRACTION),
+  };
+}
+
+// computeDockTarget maps a pointer position to a drop target: a container dock
+// when the pointer is in the workspace's perimeter frame (on a side that holds
+// 2+ leaves), otherwise the leaf it's over plus the nearest edge (X-pattern),
+// sized by how deep the pointer sits. The dragged leaf is excluded from
+// leafRects, so hovering it returns null — a self-drop no-op.
+export function computeDockTarget(
+  clientX: number,
+  clientY: number,
+  containerRect: { left: number; top: number; width: number; height: number },
+  leafRects: Array<{ leafId: string; bounds: NormalizedPaneBounds }>,
+  containerSides: DockEdgeFlags,
+): DockTarget | null {
+  if (containerRect.width <= 0 || containerRect.height <= 0) {
+    return null;
+  }
+  const nx = (clientX - containerRect.left) / containerRect.width;
+  const ny = (clientY - containerRect.top) / containerRect.height;
+
+  if (nx >= 0 && nx <= 1 && ny >= 0 && ny <= 1) {
+    const container = containerDockTarget(
+      nx,
+      ny,
+      DOCK_CONTAINER_FRAME_PX / containerRect.width,
+      DOCK_CONTAINER_FRAME_PX / containerRect.height,
+      containerSides,
+    );
+    if (container) {
+      return container;
+    }
+  }
+
+  for (const { leafId, bounds } of leafRects) {
+    if (nx < bounds.left || nx > bounds.right || ny < bounds.top || ny > bounds.bottom) {
+      continue;
+    }
+    const px = (nx - bounds.left) / Math.max(bounds.width, 1e-6);
+    const py = (ny - bounds.top) / Math.max(bounds.height, 1e-6);
+    const distances: Array<{ edge: TerminalDockEdge; dist: number }> = [
+      { edge: 'left', dist: px },
+      { edge: 'right', dist: 1 - px },
+      { edge: 'top', dist: py },
+      { edge: 'bottom', dist: 1 - py },
+    ];
+    distances.sort((a, b) => a.dist - b.dist);
+    const { edge, dist } = distances[0];
+    const fraction = snapDockFraction(Math.min(Math.max(dist, DOCK_F_MIN), DOCK_F_MAX));
+    return { anchorId: leafId, edge, ratio: fraction, rect: leafBandRect(bounds, edge, fraction) };
+  }
+  return null;
+}

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -30,76 +30,10 @@ import type { TerminalVisibleStyleSnapshot } from '../../utils/terminalStyleSumm
 import type { ResolvedTheme } from '../../utils/terminalSizing';
 import { WorkspaceLayoutRenderer } from './WorkspaceLayoutRenderer';
 import { WorkspaceDockPanel } from './WorkspaceDockPanel';
+import { startLeafDrag } from './leafDrag';
+import type { DockTarget } from './dockTarget';
 
 const ZOOM_PATH_RATIO = 0.76;
-
-// Fraction of the target pane the dock-preview band (and the resulting panel)
-// occupies on the chosen edge.
-const DOCK_BAND_FRACTION = 0.32;
-
-interface DockNormalizedRect {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-}
-
-interface DockTarget {
-  anchorPaneId: string;
-  edge: TerminalDockEdge;
-  rect: DockNormalizedRect;
-}
-
-// computeDockTarget maps a pointer position to the pane it's over and the edge
-// it's nearest, returning the band the docked panel would occupy. Only terminal
-// panes are drop targets; a pointer outside every pane returns null (a no-op
-// drop that leaves the panel where it is).
-function computeDockTarget(
-  clientX: number,
-  clientY: number,
-  containerRect: DOMRect,
-  paneRects: Array<{ paneId: string; bounds: NormalizedPaneBounds }>,
-): DockTarget | null {
-  if (containerRect.width <= 0 || containerRect.height <= 0) {
-    return null;
-  }
-  const nx = (clientX - containerRect.left) / containerRect.width;
-  const ny = (clientY - containerRect.top) / containerRect.height;
-  for (const { paneId, bounds } of paneRects) {
-    if (nx < bounds.left || nx > bounds.right || ny < bounds.top || ny > bounds.bottom) {
-      continue;
-    }
-    const px = (nx - bounds.left) / Math.max(bounds.width, 1e-6);
-    const py = (ny - bounds.top) / Math.max(bounds.height, 1e-6);
-    const distances: Array<{ edge: TerminalDockEdge; dist: number }> = [
-      { edge: 'left', dist: px },
-      { edge: 'right', dist: 1 - px },
-      { edge: 'top', dist: py },
-      { edge: 'bottom', dist: 1 - py },
-    ];
-    distances.sort((a, b) => a.dist - b.dist);
-    const edge = distances[0].edge;
-    const bandW = bounds.width * DOCK_BAND_FRACTION;
-    const bandH = bounds.height * DOCK_BAND_FRACTION;
-    let rect: DockNormalizedRect;
-    switch (edge) {
-      case 'left':
-        rect = { left: bounds.left, top: bounds.top, width: bandW, height: bounds.height };
-        break;
-      case 'right':
-        rect = { left: bounds.right - bandW, top: bounds.top, width: bandW, height: bounds.height };
-        break;
-      case 'top':
-        rect = { left: bounds.left, top: bounds.top, width: bounds.width, height: bandH };
-        break;
-      default:
-        rect = { left: bounds.left, top: bounds.bottom - bandH, width: bounds.width, height: bandH };
-        break;
-    }
-    return { anchorPaneId: paneId, edge, rect };
-  }
-  return null;
-}
 
 function zoomLayoutTowardPane(node: TerminalLayoutNode, paneId: string): TerminalLayoutNode {
   if (node.type !== 'split') {
@@ -169,7 +103,10 @@ interface SessionTerminalWorkspaceProps {
   onZoomModeChange?: (zoomed: boolean) => void;
   onNavigateOutOfSession: (direction: TerminalNavigationDirection) => void;
   onResizeSplit?: (splitId: string, ratio: number) => Promise<unknown> | void;
-  onDockPanel?: (panelId: string, panelKind: string, anchorPaneId: string, edge: TerminalDockEdge) => void;
+  // Move an existing leaf (terminal pane or docked panel) beside an anchor leaf,
+  // or against the whole workspace when anchorId is ''. ratio is the moved leaf's
+  // fraction of the new split.
+  onMoveLeaf?: (leafId: string, anchorId: string, edge: TerminalDockEdge, ratio: number) => void;
   onUndockPanel?: (panelId: string) => void;
   panelContents?: Record<string, PanelContentState>;
   allowLocalPanelTargets?: boolean;
@@ -195,7 +132,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     onZoomModeChange,
     onNavigateOutOfSession,
     onResizeSplit,
-    onDockPanel,
+    onMoveLeaf,
     onUndockPanel,
     panelContents,
     allowLocalPanelTargets = true,
@@ -209,7 +146,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     // Drag-to-dock state. The panel stays docked in the daemon tree throughout
     // the drag — this is a transient preview (ghost + target highlight) that
     // resolves to a single dock command on drop.
-    const [draggingPanelId, setDraggingPanelId] = useState<string | null>(null);
+    const [draggingLeafId, setDraggingLeafId] = useState<string | null>(null);
     const [dockTarget, setDockTarget] = useState<DockTarget | null>(null);
     const [ghostPos, setGhostPos] = useState<{ x: number; y: number } | null>(null);
     const panelDragCleanupRef = useRef<(() => void) | null>(null);
@@ -290,7 +227,10 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     const fitPane = runtime.fitPane;
     const getPaneSize = runtime.getPaneSize;
     const splitLayoutActive = workspace.layoutTree?.type === 'split';
-    const showPaneHeader = paneIds.length > 1;
+    // Show the pane header (which doubles as the drag-to-move handle) whenever the
+    // workspace holds more than one leaf — including panels, so a lone pane sharing
+    // space with a docked panel is still draggable.
+    const showPaneHeader = paneIds.length + panelLeafById.size > 1;
     const effectivePaneId = maximizedPaneId && paneIds.includes(maximizedPaneId) ? maximizedPaneId : null;
     const effectiveZoomedPaneId = zoomedPaneId && paneIds.includes(zoomedPaneId) ? zoomedPaneId : null;
     const baseLayoutTree = useMemo(() => (
@@ -569,9 +509,11 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       height: `${bounds.height * 100}%`,
     }), []);
 
-    // Drag a docked panel's header to relocate it. The daemon tree is untouched
-    // until drop, when a single dock command moves it to the previewed target.
-    const beginPanelDrag = useCallback((panelId: string, event: React.PointerEvent<HTMLDivElement>) => {
+    // Drag any leaf's header (terminal pane or docked panel) to relocate it. The
+    // daemon tree is untouched until drop, when a single move command sends it to
+    // the previewed target. The dragged leaf is excluded from the drop targets so
+    // hovering it is a no-op (self-drop).
+    const beginLeafDrag = useCallback((leafId: string, event: React.PointerEvent<HTMLDivElement>) => {
       if (event.button !== 0) {
         return;
       }
@@ -580,50 +522,22 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       if (!container) {
         return;
       }
-      const containerRect = container.getBoundingClientRect();
-      // Snapshot terminal-pane targets: the layout is static during the drag.
-      const paneRects: Array<{ paneId: string; bounds: NormalizedPaneBounds }> = [];
-      for (const [slotId, bounds] of renderedPaneBounds) {
-        if (agentPaneById.has(slotId)) {
-          paneRects.push({ paneId: slotId, bounds });
-        }
-      }
       const releaseSelectionLock = lockTextSelection('grabbing');
-      setDraggingPanelId(panelId);
-      setGhostPos({ x: event.clientX, y: event.clientY });
-
-      const onMove = (ev: PointerEvent) => {
-        setGhostPos({ x: ev.clientX, y: ev.clientY });
-        setDockTarget(computeDockTarget(ev.clientX, ev.clientY, containerRect, paneRects));
-      };
-      const teardown = () => {
-        window.removeEventListener('pointermove', onMove);
-        window.removeEventListener('pointerup', onUp);
-        window.removeEventListener('pointercancel', onCancel);
-        window.removeEventListener('blur', onCancel);
-        releaseSelectionLock();
-        setDraggingPanelId(null);
-        setDockTarget(null);
-        setGhostPos(null);
-        panelDragCleanupRef.current = null;
-      };
-      const onUp = (ev: PointerEvent) => {
-        const finalTarget = computeDockTarget(ev.clientX, ev.clientY, containerRect, paneRects);
-        teardown();
-        if (finalTarget) {
-          const panelKind = panelLeafById.get(panelId)?.panelKind ?? '';
-          onDockPanel?.(panelId, panelKind, finalTarget.anchorPaneId, finalTarget.edge);
-        }
-      };
-      const onCancel = () => {
-        teardown();
-      };
+      setDraggingLeafId(leafId);
+      const teardown = startLeafDrag(leafId, event.clientX, event.clientY, container, renderedPaneBounds, {
+        onGhostMove: (x, y) => setGhostPos({ x, y }),
+        onPreview: (target) => setDockTarget(target),
+        onDrop: (id, target) => onMoveLeaf?.(id, target.anchorId, target.edge, target.ratio),
+        onCleanup: () => {
+          releaseSelectionLock();
+          setDraggingLeafId(null);
+          setDockTarget(null);
+          setGhostPos(null);
+          panelDragCleanupRef.current = null;
+        },
+      });
       panelDragCleanupRef.current = teardown;
-      window.addEventListener('pointermove', onMove);
-      window.addEventListener('pointerup', onUp);
-      window.addEventListener('pointercancel', onCancel);
-      window.addEventListener('blur', onCancel);
-    }, [renderedPaneBounds, agentPaneById, panelLeafById, onDockPanel]);
+    }, [renderedPaneBounds, onMoveLeaf]);
 
     const renderPaneSurface = useCallback((paneId: string): React.ReactNode => {
       const path = panePaths.get(paneId) || 'root';
@@ -643,7 +557,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         return (
           <div
             key={agentPane.id}
-            className={`workspace-pane ${activePaneId === agentPane.id ? 'active' : ''}`}
+            className={`workspace-pane ${activePaneId === agentPane.id ? 'active' : ''} ${draggingLeafId === agentPane.id ? 'workspace-pane--dragging' : ''}`.trim()}
             onMouseDown={() => handleAgentPaneMouseDown(agentPane.id)}
             data-pane-session-id={agentPane.sessionId}
             data-pane-id={agentPane.id}
@@ -652,8 +566,10 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
             style={frameStyle}
           >
             <div
-              className={`workspace-pane-header ${showPaneHeader ? '' : 'workspace-pane-header-hidden'}`.trim()}
+              className={`workspace-pane-header ${showPaneHeader ? 'workspace-pane-header--draggable' : 'workspace-pane-header-hidden'}`.trim()}
               aria-hidden={showPaneHeader ? undefined : true}
+              onPointerDown={showPaneHeader ? (event) => beginLeafDrag(agentPane.id, event) : undefined}
+              title={showPaneHeader ? 'Drag to move' : undefined}
             >
               {showPaneHeader ? <span className="workspace-pane-title">{paneTitle}</span> : null}
             </div>
@@ -697,9 +613,9 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
               workspaceId={workspaceId}
               content={panelContents?.[panelContentKey(workspaceId, panelLeaf.panelId)]}
               allowLocalTargets={allowLocalPanelTargets}
-              dragging={draggingPanelId === panelLeaf.panelId}
+              dragging={draggingLeafId === panelLeaf.panelId}
               onClose={() => onUndockPanel?.(panelLeaf.panelId)}
-              onHeaderPointerDown={(event) => beginPanelDrag(panelLeaf.panelId, event)}
+              onHeaderPointerDown={(event) => beginLeafDrag(panelLeaf.panelId, event)}
               onRequestContent={onRequestPanelContent ?? (() => {})}
             />
           </div>
@@ -709,8 +625,8 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       return null;
     }, [
       activePaneId,
-      beginPanelDrag,
-      draggingPanelId,
+      beginLeafDrag,
+      draggingLeafId,
       onUndockPanel,
       panelLeafById,
       panelContents,
@@ -740,6 +656,24 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       }
       return 'Pane';
     }, [agentPaneById, effectivePaneId, sessionById]);
+
+    // Label shown in the drag ghost: the dragged leaf's session/title (pane) or
+    // file name/kind (panel).
+    const draggingLeafLabel = useMemo(() => {
+      if (!draggingLeafId) {
+        return '';
+      }
+      const agentPane = agentPaneById.get(draggingLeafId);
+      if (agentPane) {
+        return sessionById.get(agentPane.sessionId)?.label || agentPane.title || 'Pane';
+      }
+      const panel = panelLeafById.get(draggingLeafId);
+      if (panel) {
+        const base = (panel.panelParams ?? '').split('/').filter(Boolean).pop();
+        return base || panel.panelKind || 'Panel';
+      }
+      return 'Pane';
+    }, [draggingLeafId, agentPaneById, sessionById, panelLeafById]);
 
     // Draggable dividers, one per split. Hidden in focus/zoom mode where there
     // is no real split to resize.
@@ -909,12 +843,12 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
             />
           ) : null}
         />
-        {ghostPos && draggingPanelId && (
+        {ghostPos && draggingLeafId && (
           <div
             className="workspace-dock-ghost"
             style={{ left: ghostPos.x + 12, top: ghostPos.y + 12 }}
           >
-            {panelLeafById.get(draggingPanelId)?.panelKind === 'markdown' ? 'README.md' : 'Panel'}
+            {draggingLeafLabel}
           </div>
         )}
       </div>

--- a/app/src/components/SessionTerminalWorkspace/leafDrag.test.ts
+++ b/app/src/components/SessionTerminalWorkspace/leafDrag.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { startLeafDrag, type LeafDragHandlers } from './leafDrag';
+import type { DockTarget } from './dockTarget';
+import type { NormalizedPaneBounds } from '../../types/workspace';
+
+// These tests drive the real pointerdown → pointermove → pointerup wiring with
+// synthetic events against a mocked 1000x1000 container, instead of a real OS
+// drag. The pure geometry (computeDockTarget) is covered in dockTarget.test.ts;
+// here we verify the gesture state machine: window listeners fire the preview,
+// the drop reports the final target, and teardown unbinds everything.
+
+function bounds(left: number, top: number, right: number, bottom: number): NormalizedPaneBounds {
+  return {
+    left,
+    top,
+    right,
+    bottom,
+    width: right - left,
+    height: bottom - top,
+    centerX: (left + right) / 2,
+    centerY: (top + bottom) / 2,
+  };
+}
+
+// A 1000x1000 container at the origin so clientX/Y map 1:1 to normalized * 1000.
+function makeContainer(): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'session-terminal-panes';
+  el.getBoundingClientRect = () =>
+    ({ left: 0, top: 0, right: 1000, bottom: 1000, width: 1000, height: 1000, x: 0, y: 0, toJSON() {} }) as DOMRect;
+  document.body.appendChild(el);
+  return el;
+}
+
+function pointer(type: string, clientX: number, clientY: number): Event {
+  // happy-dom dispatches by event-type string, so a MouseEvent carrying
+  // clientX/clientY triggers the 'pointermove'/'pointerup' listeners.
+  return new MouseEvent(type, { clientX, clientY, bubbles: true });
+}
+
+function spyHandlers(): LeafDragHandlers & {
+  previews: Array<DockTarget | null>;
+  drops: Array<{ leafId: string; target: DockTarget }>;
+  cleanups: number;
+} {
+  const previews: Array<DockTarget | null> = [];
+  const drops: Array<{ leafId: string; target: DockTarget }> = [];
+  let cleanups = 0;
+  return {
+    previews,
+    drops,
+    get cleanups() {
+      return cleanups;
+    },
+    onPreview: (t) => previews.push(t),
+    onGhostMove: () => {},
+    onDrop: (leafId, target) => drops.push({ leafId, target }),
+    onCleanup: () => {
+      cleanups += 1;
+    },
+  };
+}
+
+describe('startLeafDrag — synthesized pointer gesture', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = makeContainer();
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('previews a leaf edge on move and drops there on pointerup', () => {
+    // Two side-by-side panes. Drag A; hover over B near its right edge.
+    const paneBounds = new Map<string, NormalizedPaneBounds>([
+      ['A', bounds(0, 0, 0.5, 1)],
+      ['B', bounds(0.5, 0, 1, 1)],
+    ]);
+    const h = spyHandlers();
+
+    startLeafDrag('A', 250, 500, container, paneBounds, h);
+
+    window.dispatchEvent(pointer('pointermove', 900, 500));
+    const preview = h.previews[h.previews.length - 1];
+    expect(preview).toMatchObject({ anchorId: 'B', edge: 'right' });
+    expect(preview!.ratio).toBeCloseTo(0.2, 5);
+
+    window.dispatchEvent(pointer('pointerup', 900, 500));
+    expect(h.drops).toHaveLength(1);
+    expect(h.drops[0].leafId).toBe('A');
+    expect(h.drops[0].target).toMatchObject({ anchorId: 'B', edge: 'right' });
+    expect(h.cleanups).toBe(1);
+  });
+
+  it('unbinds listeners after drop so later moves do nothing', () => {
+    const paneBounds = new Map<string, NormalizedPaneBounds>([
+      ['A', bounds(0, 0, 0.5, 1)],
+      ['B', bounds(0.5, 0, 1, 1)],
+    ]);
+    const h = spyHandlers();
+
+    startLeafDrag('A', 250, 500, container, paneBounds, h);
+    window.dispatchEvent(pointer('pointerup', 900, 500));
+    const previewsAfterDrop = h.previews.length;
+
+    window.dispatchEvent(pointer('pointermove', 700, 500));
+    expect(h.previews.length).toBe(previewsAfterDrop);
+  });
+
+  it('hovering the dragged leaf itself previews nothing and drops nowhere (self-drop)', () => {
+    const paneBounds = new Map<string, NormalizedPaneBounds>([
+      ['A', bounds(0, 0, 0.5, 1)],
+      ['B', bounds(0.5, 0, 1, 1)],
+    ]);
+    const h = spyHandlers();
+
+    startLeafDrag('A', 250, 500, container, paneBounds, h);
+    // Pointer stays over A's own area; A is excluded from drop targets and the
+    // left side has only one leaf, so no container edge either.
+    window.dispatchEvent(pointer('pointermove', 100, 500));
+    expect(h.previews[h.previews.length - 1]).toBeNull();
+
+    window.dispatchEvent(pointer('pointerup', 100, 500));
+    expect(h.drops).toHaveLength(0);
+    expect(h.cleanups).toBe(1);
+  });
+
+  it('docks against the whole workspace when a side holds 2+ leaves', () => {
+    // Left column has two stacked panes; drag the right pane to the left frame.
+    const paneBounds = new Map<string, NormalizedPaneBounds>([
+      ['A', bounds(0, 0, 0.5, 0.5)],
+      ['B', bounds(0, 0.5, 0.5, 1)],
+      ['C', bounds(0.5, 0, 1, 1)],
+    ]);
+    const h = spyHandlers();
+
+    startLeafDrag('C', 750, 500, container, paneBounds, h);
+    window.dispatchEvent(pointer('pointermove', 10, 500));
+    expect(h.previews[h.previews.length - 1]).toMatchObject({ anchorId: '', edge: 'left', ratio: 0.5 });
+
+    window.dispatchEvent(pointer('pointerup', 10, 500));
+    expect(h.drops).toHaveLength(1);
+    expect(h.drops[0].target).toMatchObject({ anchorId: '', edge: 'left' });
+  });
+
+  it('pointercancel ends the gesture without a drop', () => {
+    const paneBounds = new Map<string, NormalizedPaneBounds>([
+      ['A', bounds(0, 0, 0.5, 1)],
+      ['B', bounds(0.5, 0, 1, 1)],
+    ]);
+    const h = spyHandlers();
+
+    startLeafDrag('A', 250, 500, container, paneBounds, h);
+    window.dispatchEvent(pointer('pointermove', 900, 500));
+    window.dispatchEvent(new Event('pointercancel'));
+
+    expect(h.drops).toHaveLength(0);
+    expect(h.cleanups).toBe(1);
+
+    // Listeners are gone: a subsequent up does nothing.
+    window.dispatchEvent(pointer('pointerup', 900, 500));
+    expect(h.drops).toHaveLength(0);
+  });
+});

--- a/app/src/components/SessionTerminalWorkspace/leafDrag.ts
+++ b/app/src/components/SessionTerminalWorkspace/leafDrag.ts
@@ -1,0 +1,73 @@
+import type { NormalizedPaneBounds } from '../../types/workspace';
+import { computeDockTarget, computeContainerSides, type DockTarget } from './dockTarget';
+
+// startLeafDrag owns the pointerdown → pointermove → pointerup gesture for moving
+// a leaf. It snapshots drop targets from the container once (the layout is static
+// during a drag), drives a live preview, and reports the final drop. Side effects
+// (selection lock, React state, the actual move command) are injected as handlers
+// so the gesture is testable with synthetic pointer events.
+
+export interface LeafDragHandlers {
+  // Live dock preview as the pointer moves (null = no valid target right now).
+  onPreview: (target: DockTarget | null) => void;
+  // Ghost label position follows the pointer.
+  onGhostMove: (clientX: number, clientY: number) => void;
+  // The gesture resolved over a target: relocate leafId there.
+  onDrop: (leafId: string, target: DockTarget) => void;
+  // Always runs when the gesture ends (drop, cancel, or blur): release locks and
+  // clear transient state.
+  onCleanup: () => void;
+}
+
+// startLeafDrag registers window listeners for one drag and returns a teardown
+// fn (also invoked internally on drop/cancel). The dragged leaf is excluded from
+// the drop targets, so hovering it previews nothing — a self-drop no-op.
+export function startLeafDrag(
+  leafId: string,
+  clientX: number,
+  clientY: number,
+  container: HTMLElement,
+  paneBounds: Map<string, NormalizedPaneBounds>,
+  handlers: LeafDragHandlers,
+): () => void {
+  const containerRect = container.getBoundingClientRect();
+  const leafRects: Array<{ leafId: string; bounds: NormalizedPaneBounds }> = [];
+  const allBounds: NormalizedPaneBounds[] = [];
+  for (const [slotId, bounds] of paneBounds) {
+    allBounds.push(bounds);
+    if (slotId !== leafId) {
+      leafRects.push({ leafId: slotId, bounds });
+    }
+  }
+  const containerSides = computeContainerSides(allBounds);
+
+  handlers.onGhostMove(clientX, clientY);
+
+  const onMove = (ev: PointerEvent) => {
+    handlers.onGhostMove(ev.clientX, ev.clientY);
+    handlers.onPreview(computeDockTarget(ev.clientX, ev.clientY, containerRect, leafRects, containerSides));
+  };
+  const teardown = () => {
+    window.removeEventListener('pointermove', onMove);
+    window.removeEventListener('pointerup', onUp);
+    window.removeEventListener('pointercancel', onCancel);
+    window.removeEventListener('blur', onCancel);
+    handlers.onCleanup();
+  };
+  const onUp = (ev: PointerEvent) => {
+    const finalTarget = computeDockTarget(ev.clientX, ev.clientY, containerRect, leafRects, containerSides);
+    teardown();
+    if (finalTarget) {
+      handlers.onDrop(leafId, finalTarget);
+    }
+  };
+  const onCancel = () => {
+    teardown();
+  };
+
+  window.addEventListener('pointermove', onMove);
+  window.addEventListener('pointerup', onUp);
+  window.addEventListener('pointercancel', onCancel);
+  window.addEventListener('blur', onCancel);
+  return teardown;
+}

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -598,7 +598,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [
           {
             id: 'agent-1',
@@ -696,7 +696,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -781,7 +781,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -913,7 +913,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -978,7 +978,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1041,7 +1041,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1101,7 +1101,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [],
         workspaces: [{
           id: 'workspace-1',
@@ -1201,7 +1201,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     };
     const initialState = {
       event: 'initial_state',
-      protocol_version: '78',
+      protocol_version: '79',
       sessions: [],
       workspaces: [workspace],
       prs: [],
@@ -1278,7 +1278,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1372,7 +1372,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1471,7 +1471,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1556,7 +1556,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -1635,7 +1635,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -1705,7 +1705,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '78',
+        protocol_version: '79',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -153,7 +153,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '78';
+const PROTOCOL_VERSION = '79';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -2257,31 +2257,6 @@ export function useDaemonSocket({
     );
   }, [nextRequestID, sendWorkspaceCommand]);
 
-  // Dock (or move) a panel into the workspace layout. Like set_split_ratio, the
-  // daemon's action result carries an empty pane_id. An empty anchorPaneId lets
-  // the daemon pick a sensible anchor (the active pane).
-  const sendWorkspaceDockPanel = useCallback((
-    workspaceId: string,
-    panelId: string,
-    panelKind: string,
-    options: { anchorPaneId?: string; edge?: TerminalDockEdge; ratio?: number } = {},
-  ) => {
-    return sendWorkspaceCommand(
-      'workspace_layout_dock_panel',
-      workspaceId,
-      {
-        cmd: 'workspace_layout_dock_panel',
-        workspace_id: workspaceId,
-        anchor_pane_id: options.anchorPaneId ?? '',
-        edge: options.edge ?? 'right',
-        panel_id: panelId,
-        panel_kind: panelKind,
-        ...(options.ratio != null ? { ratio: options.ratio } : {}),
-      },
-      panelId,
-    );
-  }, [sendWorkspaceCommand]);
-
   const sendWorkspaceUndockPanel = useCallback((workspaceId: string, panelId: string) => {
     return sendWorkspaceCommand(
       'workspace_layout_undock_panel',
@@ -2292,6 +2267,31 @@ export function useDaemonSocket({
         panel_id: panelId,
       },
       panelId,
+    );
+  }, [sendWorkspaceCommand]);
+
+  // Move an existing leaf (terminal pane or docked panel) beside an anchor leaf.
+  // An empty anchorId docks the leaf against the whole workspace (the root). The
+  // daemon broadcasts the authoritative layout, so this is effectively
+  // fire-and-forget; a rejected move (self-drop, only leaf) just leaves the
+  // layout unchanged.
+  const sendWorkspaceMoveLeaf = useCallback((
+    workspaceId: string,
+    leafId: string,
+    options: { anchorId?: string; edge?: TerminalDockEdge; ratio?: number } = {},
+  ) => {
+    return sendWorkspaceCommand(
+      'workspace_layout_move_leaf',
+      workspaceId,
+      {
+        cmd: 'workspace_layout_move_leaf',
+        workspace_id: workspaceId,
+        leaf_id: leafId,
+        anchor_id: options.anchorId ?? '',
+        edge: options.edge ?? 'right',
+        ...(options.ratio != null ? { ratio: options.ratio } : {}),
+      },
+      leafId,
     );
   }, [sendWorkspaceCommand]);
 
@@ -3603,8 +3603,8 @@ export function useDaemonSocket({
     sendWorkspaceFocusPane,
     sendWorkspaceRenamePane,
     sendWorkspaceSetSplitRatio,
-    sendWorkspaceDockPanel,
     sendWorkspaceUndockPanel,
+    sendWorkspaceMoveLeaf,
     panelContents,
     requestPanelContent,
     sendRuntimeInput: sendPtyInput,

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -815,6 +815,57 @@ function dragPaneSelection(
   }));
 }
 
+// dragLeafHeader synthesizes a leaf re-dock drag: pointerdown on the leaf's
+// draggable header, then pointermove/pointerup on window at a drop point given
+// as a fraction of the panes container. This exercises the real beginLeafDrag →
+// computeDockTarget → onMoveLeaf path without a physical OS drag.
+function dragLeafHeader(leafId: string, dropFracX: number, dropFracY: number) {
+  const leaf = document.querySelector(`[data-pane-id="${leafId}"]`);
+  const header = leaf?.querySelector('.workspace-pane-header, .workspace-dock-panel-header');
+  if (!(header instanceof HTMLElement)) {
+    throw new Error(`Draggable leaf header not found for ${leafId}`);
+  }
+  const container = header.closest('.session-terminal-panes');
+  if (!(container instanceof HTMLElement)) {
+    throw new Error(`Panes container not found for leaf ${leafId}`);
+  }
+  const headerRect = header.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+  const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+  const startX = headerRect.left + headerRect.width / 2;
+  const startY = headerRect.top + headerRect.height / 2;
+  const dropX = containerRect.left + clamp01(dropFracX) * containerRect.width;
+  const dropY = containerRect.top + clamp01(dropFracY) * containerRect.height;
+
+  const fire = (
+    type: string,
+    target: EventTarget,
+    clientX: number,
+    clientY: number,
+    extra: PointerEventInit,
+  ) => {
+    target.dispatchEvent(new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      pointerId: 1,
+      pointerType: 'mouse',
+      isPrimary: true,
+      clientX,
+      clientY,
+      ...extra,
+    }));
+  };
+
+  // pointerdown bubbles to React's onPointerDown (beginLeafDrag); move/up reach
+  // the window listeners beginLeafDrag registers.
+  fire('pointerdown', header, startX, startY, { button: 0, buttons: 1 });
+  fire('pointermove', window, dropX, dropY, { buttons: 1 });
+  fire('pointerup', window, dropX, dropY, { button: 0, buttons: 0 });
+
+  return { startX, startY, dropX, dropY };
+}
+
 function clickElement(element: HTMLElement) {
   element.dispatchEvent(new MouseEvent('mousedown', {
     bubbles: true,
@@ -1584,6 +1635,25 @@ export function useUiAutomationBridge({
         );
         await settleUi(2);
         return { sessionId, paneId, viewSessionId, start, end };
+      }
+      case 'drag_leaf': {
+        const sessionId = typeof payload.sessionId === 'string' ? payload.sessionId : '';
+        const session = sessions.find((entry) => entry.id === sessionId);
+        if (!session) {
+          throw new Error('Session not found');
+        }
+        const leafId = typeof payload.leafId === 'string' ? payload.leafId : '';
+        if (!leafId) {
+          throw new Error('drag_leaf requires leafId');
+        }
+        const dropFracX = typeof payload.dropFracX === 'number' ? payload.dropFracX : 0.5;
+        const dropFracY = typeof payload.dropFracY === 'number' ? payload.dropFracY : 0.5;
+        const viewSessionId = resolveWorkspaceViewSessionId(session, sessions, activeSessionId);
+        selectSession(sessionId);
+        await settleUi(2);
+        const points = dragLeafHeader(leafId, dropFracX, dropFracY);
+        await settleUi(2);
+        return { sessionId, leafId, viewSessionId, dropFracX, dropFracY, ...points };
       }
       case 'dispatch_shortcut': {
         const shortcutId = typeof payload.shortcutId === 'string' ? payload.shortcutId as ShortcutId : null;

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockPanelMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockPanelMessage, WorkspaceLayoutUpdatedMessage, WorkspacePanelContentGetMessage, WorkspacePanelContentMessage, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockPanelMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockPanelMessage, WorkspaceLayoutUpdatedMessage, WorkspacePanelContentGetMessage, WorkspacePanelContentMessage, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -181,6 +181,7 @@
 //   const workspaceLayoutFocusPaneMessage = Convert.toWorkspaceLayoutFocusPaneMessage(json);
 //   const workspaceLayoutGetMessage = Convert.toWorkspaceLayoutGetMessage(json);
 //   const workspaceLayoutMessage = Convert.toWorkspaceLayoutMessage(json);
+//   const workspaceLayoutMoveLeafMessage = Convert.toWorkspaceLayoutMoveLeafMessage(json);
 //   const workspaceLayoutPane = Convert.toWorkspaceLayoutPane(json);
 //   const workspaceLayoutPaneKind = Convert.toWorkspaceLayoutPaneKind(json);
 //   const workspaceLayoutPaneStatus = Convert.toWorkspaceLayoutPaneStatus(json);
@@ -2652,6 +2653,20 @@ export enum WorkspaceLayoutMessageEvent {
     WorkspaceLayout = "workspace_layout",
 }
 
+export interface WorkspaceLayoutMoveLeafMessage {
+    anchor_id:    string;
+    cmd:          WorkspaceLayoutMoveLeafMessageCmd;
+    edge:         WorkspaceLayoutDockEdge;
+    leaf_id:      string;
+    ratio?:       number;
+    workspace_id: string;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutMoveLeafMessageCmd {
+    WorkspaceLayoutMoveLeaf = "workspace_layout_move_leaf",
+}
+
 export interface WorkspaceLayoutPane {
     error?:       string;
     kind:         WorkspaceLayoutPaneKind;
@@ -4237,6 +4252,14 @@ export class Convert {
 
     public static workspaceLayoutMessageToJson(value: WorkspaceLayoutMessage): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutMessage")), null, 2);
+    }
+
+    public static toWorkspaceLayoutMoveLeafMessage(json: string): WorkspaceLayoutMoveLeafMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutMoveLeafMessage"));
+    }
+
+    public static workspaceLayoutMoveLeafMessageToJson(value: WorkspaceLayoutMoveLeafMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutMoveLeafMessage")), null, 2);
     }
 
     public static toWorkspaceLayoutPane(json: string): WorkspaceLayoutPane {
@@ -5935,6 +5958,14 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("WorkspaceLayoutMessageEvent") },
         { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
     ], "any"),
+    "WorkspaceLayoutMoveLeafMessage": o([
+        { json: "anchor_id", js: "anchor_id", typ: "" },
+        { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutMoveLeafMessageCmd") },
+        { json: "edge", js: "edge", typ: r("WorkspaceLayoutDockEdge") },
+        { json: "leaf_id", js: "leaf_id", typ: "" },
+        { json: "ratio", js: "ratio", typ: u(undefined, 3.14) },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
     "WorkspaceLayoutPane": o([
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "kind", js: "kind", typ: r("WorkspaceLayoutPaneKind") },
@@ -6518,6 +6549,9 @@ const typeMap: any = {
     ],
     "WorkspaceLayoutMessageEvent": [
         "workspace_layout",
+    ],
+    "WorkspaceLayoutMoveLeafMessageCmd": [
+        "workspace_layout_move_leaf",
     ],
     "WorkspaceLayoutRenamePaneMessageCmd": [
         "workspace_layout_rename_pane",

--- a/docs/plans/2026-06-01-uniform-leaf-docking.md
+++ b/docs/plans/2026-06-01-uniform-leaf-docking.md
@@ -1,0 +1,255 @@
+# Plan: Uniform Leaf Docking (drag any pane/panel, depth-sized drops, panel-only workspaces)
+
+## Goal
+
+Today only the markdown panel can be dragged to re-dock. Generalize the existing
+markdown drag into one uniform model:
+
+1. **Any leaf is draggable** — terminal panes and panels alike — onto any other
+   leaf's edge (including panel-on-panel).
+2. **The drop signals the size** — how deep you drop sets the incoming leaf's
+   fraction (thin at the edge → ½ at center), with magnetic snaps at ¼ / ⅓ / ½.
+3. **Container edges** — a perimeter frame docks against the whole workspace
+   (the root), not just one neighbor.
+4. **A workspace lives while it holds any leaf** — closing the last terminal no
+   longer discards panels you deliberately left behind. Sessionless (PTY-less)
+   workspaces are shown/hidden via the sidebar display popover.
+
+The throughline: markdown's drag path is special-cased in ways that are mostly
+arbitrary (panel-only targets, only-pane anchors, a carried fraction). Collapse
+that special path into one generic operation; the only genuine invariant left is
+"don't orphan the last leaf."
+
+Extends and revises `docs/decisions/2026-05-31-docked-panels.md` (which currently
+says "closing the last terminal tears down the workspace"). Update that doc in
+the lifecycle PR to reflect last-*leaf* teardown.
+
+## Background / why these limits were arbitrary
+
+- The low-level tree ops are already leaf-generic: `Remove`/`removeNode`,
+  `insertBesideLeaf`, `hasLeaf` all handle `"pane"` and `"panel"`
+  (`internal/workspacelayout/workspacelayout.go:386,488,611`).
+- Markdown-on-markdown is blocked only by two guard layers above that core: the
+  frontend offers only `agentPaneById` as drop targets (`index.tsx:586`), and
+  daemon `dockPanel` forces the anchor to a terminal pane (`daemon/workspacelayout.go:405`).
+- The "no panel-only workspace" rule is the one with real substance — it encoded
+  "workspace == agent session." We are deliberately changing it to "workspace ==
+  arranged content, usually but not always with an agent."
+
+## Architecture Map
+
+```text
+Current drag flow:
+panel header pointerdown                         // WorkspaceDockPanel.tsx:243
+  -> beginPanelDrag(panelId)                     // index.tsx:574  (panels only)
+    -> computeDockTarget(x,y)                    // index.tsx:57   targets = agent panes only;
+    |                                            //                edge = min(px,1-px,py,1-py) [X-pattern];
+    |                                            //                band = fixed DOCK_BAND_FRACTION 0.32 (index.tsx:38)
+    -> onDockPanel(panelId, kind, anchorPaneId, edge)   // on pointerup
+      -> ws: workspace_layout_dock_panel
+        -> daemon.dockPanel()                    // daemon/workspacelayout.go:387  anchor forced to a pane (:405)
+          -> workspacelayout.DockPanel()         // inserts a *panel* leaf beside anchor (:573)
+
+Target drag flow:
+leaf header pointerdown (pane OR panel)          // pane header at index.tsx:654 gains a drag handle
+  -> beginLeafDrag(leafId)                       // generalized from beginPanelDrag
+    -> computeDockTarget(x,y)                    // targets = ALL leaves (panes+panels);
+    |                                            // depth (distances[0].dist) -> incoming fraction, snapped;
+    |                                            // + container frame zones on the workspace perimeter
+    -> onMoveLeaf(leafId, anchorId|"", edge, ratio)     // anchorId "" => container/root dock
+      -> ws: workspace_layout_move_leaf          // self-drop (leafId == anchorId) => no-op, no command
+        -> daemon.moveLeaf()                     // anchor may be pane, panel, or root
+          -> workspacelayout.MoveLeaf()          // remove-then-reinsert; guards below
+
+Rendering (unchanged invariant worth protecting):
+WorkspaceLayoutRenderer renders panes FLAT, keyed by id, positioned from
+renderedPaneBounds (WorkspaceLayoutRenderer.tsx:93). The split "tree" is
+aria-hidden geometry metadata only. => rearranging the tree repositions a
+GhosttyTerminal; it does NOT unmount/remount. A move must not break this (no
+key changes, no remount) or it kills the PTY.
+```
+
+## Interaction Design
+
+### Drop zones within a leaf (per-leaf docking)
+
+Keep the existing X-pattern edge selection — `min(px,1-px,py,1-py)` already picks
+the diagonal triangle (= edge + which side the incoming leaf lands). The new part
+is using the depth it already computes (`distances[0].dist`, currently discarded)
+to size the drop instead of the fixed `0.32` band.
+
+```text
+   edge = X-pattern (already works)           depth -> size (new)
+
+  ┌───────────────────────────┐        near edge -> thin       near center -> half
+  │\          TOP           /│      ┌──┬──────────────┐    ┌──────────┬──────────┐
+  │  \                   /   │      │▓▓│              │    │▓▓▓▓▓▓▓▓▓▓│          │
+  │ L  \       ·       /   R │      │▓▓│      B       │ …  │▓▓ new ▓▓▓│    B     │
+  │      \           /       │      │▓▓│              │    │▓▓▓▓▓▓▓▓▓▓│          │
+  │        \  BOTTOM /       │      └──┴──────────────┘    └──────────┴──────────┘
+  └───────────────────────────┘         f ≈ 0.15               f ≈ 0.50
+```
+
+- `f = clamp(distances[0].dist, F_MIN, 0.5)` (≈ one-line change in `computeDockTarget`).
+- Magnetic snap to ¼ / ⅓ / ½ within a small tolerance; show the fraction as a tick/label.
+- The orange preview rect = the actual resulting area (already true; just size it from `f`).
+- The gesture sizes the **incoming** leaf, max ½ (center). Want it bigger? Drag
+  the divider after — deliberate boundary that keeps one pointer position = one
+  unambiguous result.
+- Center square (·): v1 resolves to ½ on the last-stable axis. (Swap gesture = follow-up.)
+
+### Container edges (dock against the whole workspace)
+
+A perimeter **frame** (~24–32px), rendered only during a drag, captures docks
+against the root. Mechanically it's `insertBesideLeaf`/`panelSplit` targeting the
+**root** instead of a leaf — wrap the whole tree.
+
+```text
+┌══════════════════════════┐   ══ / ║  = container frame  (dock at root, spans that side)
+║ ┌──────┬───────────────┐ ║   inner    = per-leaf X-pattern
+║ │  LT  │               │ ║
+║ ├──────┤       R       │ ║   precedence: outermost ~24px = container; inward = leaf edge
+║ │  LB  │               │ ║   corners: resolve to nearer outer edge
+║ └──────┴───────────────┘ ║
+└══════════════════════════┘
+```
+
+Container vs per-leaf only differ when a side holds 2+ leaves:
+
+```text
+   workspace            left edge of LT (leaf)        left container edge
+┌────────┬───────┐    ┌───┬────┬───────┐           ┌───┬────┬───────┐
+│   LT   │       │    │ N │ LT │       │           │   │ LT │       │
+├────────┤   R   │ →  ├───┴────┤   R   │   vs.     │ N ├────┤   R   │
+│   LB   │       │    │   LB   │       │           │   │ LB │       │
+└────────┴───────┘    └────────┴───────┘           └───┴────┴───────┘
+                       N half-height                N full-height
+```
+
+Polish: **only show a side's container zone when that side has ≥2 leaves** — when
+they'd coincide, suppress it (no redundant zone; teaches what the frame is for).
+
+Container size: **snapped default ½** (thin gutter can't carry a depth gesture);
+refine via divider. Graduated frame = follow-up if it feels missing.
+
+## Data Model / Interfaces
+
+```ts
+// frontend -> daemon (new command). Protocol bump required.
+WorkspaceLayoutMoveLeaf = {
+  workspace_id: string
+  leaf_id: string                              // dragged pane OR panel id
+  anchor_id: string                            // target leaf id; "" => container (root) dock
+  edge: 'left' | 'right' | 'top' | 'bottom'
+  ratio?: number                               // incoming leaf fraction from depth gesture (snapped)
+}
+// daemon replies with the existing *_result pattern; broadcasts workspace_layout_updated.
+```
+
+```go
+// internal/workspacelayout/workspacelayout.go (new; reuses Remove + insertBesideLeaf + panelSplit)
+// MoveLeaf relocates an existing leaf (pane or panel) beside anchorID, or wraps
+// the root when anchorID == "" (container dock).
+func MoveLeaf(node Node, leafID, anchorID string, dir Direction, before bool, splitID string, ratio float64) (Node, bool)
+//  guards:
+//   leafID == "" || leafID == anchorID  -> (node,false)   // self-drop no-op
+//   !hasLeaf(node, leafID)              -> (node,false)
+//   cleaned = Remove(node, leafID)
+//   if cleaned empty (was the only leaf) -> (node,false)   // nothing to anchor against
+//   anchorID == ""  -> panelSplit(cleaned-root, movedLeaf, dir, before, splitID, ratio)  // container
+//   else            -> insertBesideLeaf(cleaned, anchorID, dir, before, splitID, ratio, movedLeaf)
+//   if anchor vanished with the removal (e.g. collapsed) -> (node,false)
+```
+
+- `DockPanel` stays for **first** dock (a panel that doesn't exist yet, e.g.
+  `attn open file.md`). `MoveLeaf` handles **relocating** an existing leaf. Both
+  funnel through `insertBesideLeaf`.
+- Daemon `moveLeaf()` (new, in `daemon/workspacelayout.go`) must accept pane,
+  panel, **or** empty (root) anchors — i.e. do not force the anchor to a pane the
+  way `dockPanel` does at `:405`.
+
+### Lifecycle change (the substantive one)
+
+```text
+handleWorkspaceLayoutClosePane (daemon/workspacelayout.go:607)
+  before:  if len(normalized.Panes) == 0 { RemoveWorkspaceLayout }   // panels excluded => dies w/ panel present
+  after:   if layoutEmpty(normalized.Layout) { RemoveWorkspaceLayout } // empty == no panes AND no panels
+
+removeWorkspaceLayoutPaneForSession (daemon/workspacelayout.go:622)
+  same rule when an agent exits on its own: keep the workspace if a panel remains.
+
+Audit also: RemoveWorkspaceLayout call near daemon/workspacelayout.go:26 (normalize-empty path),
+firstWorkspaceLayoutPaneID, and session-spawn reconcile (must NOT resurrect the closed agent).
+```
+
+A sessionless workspace = `Panes: []` + a layout tree of panel leaf(s). Sidebar
+gets a toggle in the existing display popover (`Sidebar.tsx:197` `displayMode`
+state; popover at `:311`) to show/hide PTY-less workspaces.
+
+## Boundaries
+
+- `computeDockTarget` (frontend) owns geometry only: pointer → {anchorId | root,
+  edge, ratio, preview rect}. It never mutates the tree.
+- `MoveLeaf` (workspacelayout) owns the pure tree transform + all structural
+  guards (self-drop, last-leaf, vanished anchor). No daemon/session knowledge.
+- `daemon.moveLeaf` owns persistence + broadcast + the result event. It must not
+  re-impose "anchor must be a pane."
+- The flat-render invariant (panes keyed, positioned from bounds) must survive —
+  a move is a bounds change, never a remount.
+
+## Implementation Steps
+
+Two PRs along the natural risk seam. **PR A** is additive and shippable on its
+own — closing the last terminal still tears down as today, so it needs nothing
+from PR B. **PR B** changes daemon teardown semantics, the riskier half, isolated
+so a revert doesn't drag the docking UX with it.
+
+### PR A — Uniform docking interaction (drag any leaf, depth size, container edges) ✅
+- [x] `MoveLeaf` in `workspacelayout` + unit tests (self-drop, only-leaf, unknown leaf, pane↔panel, nesting, container/root wrap, locked-ratio survives normalize). `panelSplit` generalized to `lockedSplit`; new `findLeaf` helper.
+- [x] Protocol: added `workspace_layout_move_leaf` (TypeSpec → `make generate-types` → constants → `ProtocolVersion` 78→79; frontend `PROTOCOL_VERSION` + test fixtures bumped).
+- [x] `daemon.moveLeaf` handler + dispatch + command metadata; accepts pane / panel / "" (root) anchors. Daemon integration tests (relocate, self-drop reject).
+- [x] Frontend: `beginPanelDrag` → `beginLeafDrag`; pane header is a drag handle (`workspace-pane-header--draggable`, grab cursor); `showPaneHeader` now counts panels too; targets widened to all leaves; self-drop excluded.
+- [x] Depth-driven size + magnetic ¼/⅓/½ snaps; `ratio` plumbed `onMoveLeaf` → `moveLeaf`. Geometry extracted to pure `dockTarget.ts` + 10 unit tests.
+- [x] Container edges: perimeter frame → root wrap; per-side suppression when a side has <2 leaves; snapped-½ default.
+- [x] Flat-render invariant holds (panes keyed + positioned from bounds; a move repositions, never remounts). Removed the now-dead frontend dock path (`onDockPanel`/`sendWorkspaceDockPanel`); `attn open` still creates panels server-side.
+- [x] Gesture state machine extracted to pure `leafDrag.ts` (`startLeafDrag`) so the pointerdown→move→up wiring is testable; `beginLeafDrag` is now a thin React wrapper injecting selection-lock/state/`onMoveLeaf` as handlers. `leafDrag.test.ts` drives the real window listeners with synthetic `PointerEvent`s (edge preview, drop target, self-drop no-op, container-edge dock, cancel/teardown).
+- [x] CHANGELOG updated.
+- [x] Live end-to-end verification in the packaged dev app via a new `drag_leaf` automation verb (synthesizes pointerdown on a leaf header + window move/up). Confirmed: pane→pane bottom dock restructures the tree (pane + panel + pane → panel + stacked pane/pane); fresh split panes keep their PTY scrollback markers across the move and still accept input afterward (no remount). `drag_leaf` lives beside `split_pane`/`click_pane` in `useUiAutomationBridge.ts` and only activates when automation is enabled.
+
+### PR B — Panel-only workspaces (lifecycle + sidebar + panel titling)
+- [ ] `layoutEmpty` teardown rule in `handleWorkspaceLayoutClosePane` (`:607`) + `removeWorkspaceLayoutPaneForSession`; audit the other `RemoveWorkspaceLayout` paths (`:26`) + session-spawn reconcile (must not resurrect the closed agent).
+- [ ] Sessionless workspace: keep workspace name + neutral (non-state) indicator; focus the panel on select (extend the AGENTS.md terminal-focus rule with a "no terminal" branch).
+- [ ] Panel header title from content: markdown H1 → beginning of text → basename fallback (`WorkspaceDockPanel.tsx:237`).
+- [ ] Sidebar display popover toggle for PTY-less workspaces, **hidden by default** (+ persistence) (`Sidebar.tsx:197,311`).
+- [ ] Update `docs/decisions/2026-05-31-docked-panels.md` to last-leaf teardown.
+- [ ] Daemon protocol tests model the real app flow (per `internal/daemon/CLAUDE.md`).
+
+## Decisions
+
+- **Edge + depth, capped at ½** over divider-position sizing. One pointer
+  position = one unambiguous {edge, size}; bigger-than-half is a divider drag.
+- **One generic `MoveLeaf`** rather than a bolted-on `MovePane`. The tree ops are
+  already leaf-generic; the markdown special-casing was the accident.
+- **Container size is a snapped default, not depth-driven.** A 24px perimeter
+  gutter can't carry a depth gesture without tiny/unusable sizes or corner math.
+- **Workspace teardown moves from last-terminal to last-leaf.** Reflects "if I
+  left a panel here, I want it." Revises the docked-panels decision doc.
+- **Keep `DockPanel` for first-dock, add `MoveLeaf` for relocation.** Creating a
+  new leaf and moving an existing one are different ops sharing `insertBesideLeaf`.
+
+## Resolved
+
+- **PTY-less workspaces hidden by default**; the sidebar display popover toggle
+  reveals them.
+- **Sessionless workspace keeps its workspace name** (don't relabel it to the
+  panel). Separately, the **panel header title** derives from content: markdown
+  H1 title → else beginning of text → else filename basename (today it's always
+  `basename(path)`, `WorkspaceDockPanel.tsx:237`). Title may start as basename and
+  refine once content arrives.
+
+## Follow-ups
+
+- Center-square **swap** gesture (drop a leaf on another's center → swap places).
+- Graduated container frame (depth-sized container docks) if fixed-½ feels limiting.
+- Document-only workspaces created without any agent (e.g. `attn open file.md`
+  into a fresh sessionless workspace) — only meaningful once PR4 lands.

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -109,6 +109,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdWorkspaceLayoutSetSplitRatio:  commandMetadata(ScopeSession, true, true),
 	protocol.CmdWorkspaceLayoutDockPanel:      commandMetadata(ScopeSession, true, true),
 	protocol.CmdWorkspaceLayoutUndockPanel:    commandMetadata(ScopeSession, true, true),
+	protocol.CmdWorkspaceLayoutMoveLeaf:       commandMetadata(ScopeSession, true, true),
 	protocol.CmdWorkspacePanelContentGet:      commandMetadata(ScopeSession, true, true),
 }
 

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -916,6 +916,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleWorkspaceLayoutDockPanel(client, msg.(*protocol.WorkspaceLayoutDockPanelMessage))
 	case protocol.CmdWorkspaceLayoutUndockPanel:
 		d.handleWorkspaceLayoutUndockPanel(client, msg.(*protocol.WorkspaceLayoutUndockPanelMessage))
+	case protocol.CmdWorkspaceLayoutMoveLeaf:
+		d.handleWorkspaceLayoutMoveLeaf(client, msg.(*protocol.WorkspaceLayoutMoveLeafMessage))
 	case protocol.CmdWorkspacePanelContentGet:
 		d.handleWorkspacePanelContentGet(client, msg.(*protocol.WorkspacePanelContentGetMessage))
 	case protocol.CmdRegisterWorkspace:
@@ -1096,6 +1098,10 @@ func remoteCommandWorkspaceID(cmd string, msg interface{}) string {
 		}
 	case protocol.CmdWorkspaceLayoutUndockPanel:
 		if typed, ok := msg.(*protocol.WorkspaceLayoutUndockPanelMessage); ok {
+			return typed.WorkspaceID
+		}
+	case protocol.CmdWorkspaceLayoutMoveLeaf:
+		if typed, ok := msg.(*protocol.WorkspaceLayoutMoveLeafMessage); ok {
 			return typed.WorkspaceID
 		}
 	case protocol.CmdWorkspacePanelContentGet:

--- a/internal/daemon/workspace_moveleaf_protocol_test.go
+++ b/internal/daemon/workspace_moveleaf_protocol_test.go
@@ -1,0 +1,117 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/workspacelayout"
+)
+
+// addAndSpawnSessionPane registers a session pane the way the app does — add the
+// layout pane, then spawn the runtime — so move tests run against a real
+// multi-pane layout.
+func addAndSpawnSessionPane(t *testing.T, d *Daemon, client *wsClient, workspaceID, sessionID, paneID, targetPaneID, cwd string) {
+	t.Helper()
+	add := &protocol.WorkspaceLayoutAddSessionPaneMessage{
+		Cmd:         protocol.CmdWorkspaceLayoutAddSessionPane,
+		WorkspaceID: workspaceID,
+		PaneID:      protocol.Ptr(paneID),
+		SessionID:   sessionID,
+		Title:       protocol.Ptr(sessionID),
+	}
+	if targetPaneID != "" {
+		add.TargetPaneID = protocol.Ptr(targetPaneID)
+	}
+	d.handleWorkspaceLayoutAddSessionPane(client, add)
+	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutAddSessionPane, workspaceID, paneID, true)
+
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:         protocol.CmdSpawnSession,
+		ID:          sessionID,
+		Label:       protocol.Ptr(sessionID),
+		Cwd:         cwd,
+		Agent:       protocol.AgentShellValue,
+		WorkspaceID: workspaceID,
+		Cols:        80,
+		Rows:        24,
+	})
+	expectSpawnResult(t, client, sessionID, true)
+}
+
+func TestWorkspaceLayoutMoveLeafRelocatesPane(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &fakeSpawnBackend{}
+	client := newWorkspaceProtocolTestClient()
+	workspaceID := "ws-move"
+	cwd := t.TempDir()
+
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        workspaceID,
+		Title:     "Move",
+		Directory: cwd,
+	})
+	addAndSpawnSessionPane(t, d, client, workspaceID, "s-1", "pane-1", "", cwd)
+	addAndSpawnSessionPane(t, d, client, workspaceID, "s-2", "pane-2", "pane-1", cwd)
+
+	// Move pane-1 onto the bottom edge of pane-2: the left/right split collapses
+	// and pane-1 is restacked under pane-2 in a horizontal split.
+	d.handleWorkspaceLayoutMoveLeaf(client, &protocol.WorkspaceLayoutMoveLeafMessage{
+		Cmd:         protocol.CmdWorkspaceLayoutMoveLeaf,
+		WorkspaceID: workspaceID,
+		LeafID:      "pane-1",
+		AnchorID:    "pane-2",
+		Edge:        protocol.WorkspaceLayoutDockEdgeBottom,
+		Ratio:       protocol.Ptr(0.5),
+	})
+	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutMoveLeaf, workspaceID, "pane-1", true)
+
+	snapshot := d.store.GetWorkspaceLayout(workspaceID)
+	if snapshot == nil {
+		t.Fatal("workspace layout missing after move")
+	}
+	layout := snapshot.Layout
+	if layout.Type != "split" || layout.Direction != workspacelayout.DirectionHorizontal {
+		t.Fatalf("root = %+v, want a horizontal split (top/bottom stack)", layout)
+	}
+	if layout.Children[0].PaneID != "pane-2" || layout.Children[1].PaneID != "pane-1" {
+		t.Fatalf("children = %+v, want [pane-2, pane-1]", layout.Children)
+	}
+	// The move must not tear down either session.
+	if d.store.Get("s-1") == nil || d.store.Get("s-2") == nil {
+		t.Fatal("a session was lost during a pane move")
+	}
+}
+
+func TestWorkspaceLayoutMoveLeafSelfDropIsRejected(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &fakeSpawnBackend{}
+	client := newWorkspaceProtocolTestClient()
+	workspaceID := "ws-self"
+	cwd := t.TempDir()
+
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        workspaceID,
+		Title:     "Self",
+		Directory: cwd,
+	})
+	addAndSpawnSessionPane(t, d, client, workspaceID, "s-1", "pane-1", "", cwd)
+	addAndSpawnSessionPane(t, d, client, workspaceID, "s-2", "pane-2", "pane-1", cwd)
+	before := d.store.GetWorkspaceLayout(workspaceID).Layout
+
+	d.handleWorkspaceLayoutMoveLeaf(client, &protocol.WorkspaceLayoutMoveLeafMessage{
+		Cmd:         protocol.CmdWorkspaceLayoutMoveLeaf,
+		WorkspaceID: workspaceID,
+		LeafID:      "pane-1",
+		AnchorID:    "pane-1",
+		Edge:        protocol.WorkspaceLayoutDockEdgeRight,
+	})
+	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutMoveLeaf, workspaceID, "pane-1", false)
+
+	after := d.store.GetWorkspaceLayout(workspaceID).Layout
+	if after.SplitID != before.SplitID || after.Children[0].PaneID != before.Children[0].PaneID {
+		t.Fatalf("self-drop changed the layout: before=%+v after=%+v", before, after)
+	}
+}

--- a/internal/daemon/workspacelayout.go
+++ b/internal/daemon/workspacelayout.go
@@ -472,6 +472,60 @@ func (d *Daemon) handleWorkspaceLayoutUndockPanel(client *wsClient, msg *protoco
 	d.sendWorkspaceLayoutPanelActionResult(client, protocol.CmdWorkspaceLayoutUndockPanel, msg.WorkspaceID, panelID, nil)
 }
 
+func (d *Daemon) handleWorkspaceLayoutMoveLeaf(client *wsClient, msg *protocol.WorkspaceLayoutMoveLeafMessage) {
+	err := d.moveLeaf(msg.WorkspaceID, msg.LeafID, msg.AnchorID, msg.Edge, msg.Ratio)
+	d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutMoveLeaf, msg.WorkspaceID, protocol.Ptr(strings.TrimSpace(msg.LeafID)), err)
+}
+
+// moveLeaf relocates an existing leaf (terminal pane or docked panel) within a
+// workspace layout and persists it. An empty anchorID docks the leaf against the
+// whole workspace (the root). edge picks the split direction and side; ratio is
+// the moved leaf's fraction of the new split, defaulting to an equal split. The
+// move is rejected (returns an error the client ignores) when it can't happen —
+// a self-drop, an unknown leaf, or the only leaf in the workspace.
+func (d *Daemon) moveLeaf(workspaceID, leafID, anchorID string, edge protocol.WorkspaceLayoutDockEdge, ratio *float64) error {
+	snapshot, err := d.ensureWorkspaceLayout(workspaceID)
+	if err != nil {
+		return err
+	}
+	leafID = strings.TrimSpace(leafID)
+	anchorID = strings.TrimSpace(anchorID)
+	if leafID == "" {
+		return fmt.Errorf("leaf_id is required")
+	}
+
+	direction, before := dockEdgeToSplit(edge)
+	leafFraction := workspacelayout.DefaultSplitRatio
+	if ratio != nil && *ratio > 0 && *ratio < 1 {
+		leafFraction = *ratio
+	}
+	// MoveLeaf takes the children[0] fraction; convert from the moved leaf's share.
+	childZeroRatio := leafFraction
+	if !before {
+		childZeroRatio = 1 - leafFraction
+	}
+
+	layout, ok := workspacelayout.MoveLeaf(
+		snapshot.Layout,
+		leafID,
+		anchorID,
+		newWorkspaceLayoutEntityID("split"),
+		direction,
+		before,
+		childZeroRatio,
+	)
+	if !ok {
+		return fmt.Errorf("could not move leaf: %s", leafID)
+	}
+	snapshot.Layout = layout
+	normalized := workspacelayout.NormalizeWorkspaceLayout(*snapshot)
+	if err := d.store.SaveWorkspaceLayout(normalized); err != nil {
+		return err
+	}
+	d.broadcastWorkspaceLayoutUpdated(workspaceID)
+	return nil
+}
+
 func (d *Daemon) handleWorkspaceLayoutAddSessionPane(client *wsClient, msg *protocol.WorkspaceLayoutAddSessionPaneMessage) {
 	snapshot, err := d.currentOrEmptyWorkspaceLayout(msg.WorkspaceID)
 	if err != nil {

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "78"
+const ProtocolVersion = "79"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -114,6 +114,7 @@ const (
 	CmdWorkspaceLayoutSetSplitRatio  = "workspace_layout_set_split_ratio"
 	CmdWorkspaceLayoutDockPanel      = "workspace_layout_dock_panel"
 	CmdWorkspaceLayoutUndockPanel    = "workspace_layout_undock_panel"
+	CmdWorkspaceLayoutMoveLeaf       = "workspace_layout_move_leaf"
 	CmdWorkspacePanelContentGet      = "workspace_panel_content_get"
 	CmdOpenMarkdown                  = "open_markdown"
 	CmdRegisterWorkspace             = "register_workspace"
@@ -844,6 +845,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		var msg WorkspaceLayoutUndockPanelMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, fmt.Errorf("unmarshal workspace_layout_undock_panel: %w", err)
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdWorkspaceLayoutMoveLeaf:
+		var msg WorkspaceLayoutMoveLeafMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal workspace_layout_move_leaf: %w", err)
 		}
 		return peek.Cmd, &msg, nil
 

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2817,6 +2817,26 @@ type WorkspaceLayoutMessage struct {
 	WorkspaceLayout WorkspaceLayout `json:"workspace_layout"`
 }
 
+type WorkspaceLayoutMoveLeafMessage struct {
+	// AnchorID corresponds to the JSON schema field "anchor_id".
+	AnchorID string `json:"anchor_id"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Edge corresponds to the JSON schema field "edge".
+	Edge WorkspaceLayoutDockEdge `json:"edge"`
+
+	// LeafID corresponds to the JSON schema field "leaf_id".
+	LeafID string `json:"leaf_id"`
+
+	// Ratio corresponds to the JSON schema field "ratio".
+	Ratio *float64 `json:"ratio,omitempty,omitzero"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
+}
+
 type WorkspaceLayoutPane struct {
 	// Error corresponds to the JSON schema field "error".
 	Error *string `json:"error,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -858,6 +858,21 @@ model WorkspaceLayoutUndockPanelMessage {
   panel_id: string;
 }
 
+// Move an existing leaf (terminal pane or docked panel) so it sits beside an
+// anchor leaf on the given edge. An empty anchor_id docks the leaf against the
+// whole workspace (the root), spanning that edge. ratio is the moved leaf's
+// fraction of the new split (optional; defaults to an equal split). Dropping a
+// leaf on itself (leaf_id == anchor_id) is a no-op. The new split is ratio-locked
+// so the dropped size survives normalization.
+model WorkspaceLayoutMoveLeafMessage {
+  cmd: "workspace_layout_move_leaf";
+  workspace_id: string;
+  leaf_id: string;
+  anchor_id: string;
+  edge: WorkspaceLayoutDockEdge;
+  ratio?: float64;
+}
+
 // Request the current rendered content of a docked panel (e.g. the markdown
 // file a markdown panel points at). The daemon resolves the file from the
 // panel's persisted params, reads it, and replies with WorkspacePanelContentMessage.

--- a/internal/workspacelayout/moveleaf_test.go
+++ b/internal/workspacelayout/moveleaf_test.go
@@ -1,0 +1,185 @@
+package workspacelayout
+
+import (
+	"math"
+	"slices"
+	"testing"
+)
+
+func twoPaneTree() Node {
+	return Node{
+		Type:      "split",
+		SplitID:   "root",
+		Direction: DirectionVertical,
+		Ratio:     DefaultSplitRatio,
+		Children: []Node{
+			{Type: "pane", PaneID: "pane-a"},
+			{Type: "pane", PaneID: "pane-b"},
+		},
+	}
+}
+
+func TestMoveLeafRelocatesPaneBesidePane(t *testing.T) {
+	// Move pane-a to the right of pane-b: a|b -> b|a.
+	moved, ok := MoveLeaf(twoPaneTree(), "pane-a", "pane-b", "split-x", DirectionVertical, false, 0.4)
+	if !ok {
+		t.Fatal("MoveLeaf did not change layout")
+	}
+	if moved.Type != "split" || moved.Children[0].PaneID != "pane-b" || moved.Children[1].PaneID != "pane-a" {
+		t.Fatalf("children = %+v, want [pane-b, pane-a]", moved.Children)
+	}
+	if ids := PaneIDs(moved); len(ids) != 2 || !slices.Contains(ids, "pane-a") || !slices.Contains(ids, "pane-b") {
+		t.Fatalf("pane ids = %v, want exactly pane-a and pane-b (no duplicates)", ids)
+	}
+}
+
+func TestMoveLeafLocksDroppedRatioSoSizeSticks(t *testing.T) {
+	moved, ok := MoveLeaf(twoPaneTree(), "pane-a", "pane-b", "split-x", DirectionVertical, false, 0.4)
+	if !ok {
+		t.Fatal("MoveLeaf did not change layout")
+	}
+	if !moved.RatioLocked || math.Abs(moved.Ratio-0.4) > 1e-9 {
+		t.Fatalf("new split = {locked:%v ratio:%v}, want locked at 0.4 so the drop size survives", moved.RatioLocked, moved.Ratio)
+	}
+	// And the lock must survive normalization (otherwise the depth gesture is lost).
+	normalized := NormalizeWorkspaceLayout(WorkspaceLayout{
+		WorkspaceID: "ws",
+		Layout:      moved,
+		Panes: []Pane{
+			{PaneID: "pane-a", RuntimeID: "rt-a", SessionID: "s-a", Status: PaneStatusReady},
+			{PaneID: "pane-b", RuntimeID: "rt-b", SessionID: "s-b", Status: PaneStatusReady},
+		},
+	})
+	if math.Abs(normalized.Layout.Ratio-0.4) > 1e-9 {
+		t.Fatalf("normalized ratio = %v, want 0.4 preserved", normalized.Layout.Ratio)
+	}
+}
+
+func TestMoveLeafSelfDropIsNoOp(t *testing.T) {
+	tree := twoPaneTree()
+	moved, ok := MoveLeaf(tree, "pane-a", "pane-a", "split-x", DirectionVertical, false, 0.4)
+	if ok {
+		t.Fatal("dropping a leaf on itself must be a no-op")
+	}
+	if moved.Children[0].PaneID != "pane-a" || moved.Children[1].PaneID != "pane-b" {
+		t.Fatalf("tree changed on self-drop: %+v", moved.Children)
+	}
+}
+
+func TestMoveLeafOnlyLeafCannotMove(t *testing.T) {
+	if _, ok := MoveLeaf(DefaultLayout("solo"), "solo", "", "split-x", DirectionVertical, true, 0.4); ok {
+		t.Fatal("container-docking the only leaf must fail: removing it leaves nothing to wrap")
+	}
+	if _, ok := MoveLeaf(DefaultLayout("solo"), "solo", "ghost", "split-x", DirectionVertical, true, 0.4); ok {
+		t.Fatal("moving the only leaf must fail")
+	}
+}
+
+func TestMoveLeafUnknownLeafFails(t *testing.T) {
+	if _, ok := MoveLeaf(twoPaneTree(), "ghost", "pane-a", "split-x", DirectionVertical, false, 0.4); ok {
+		t.Fatal("moving a leaf that isn't in the tree must fail")
+	}
+}
+
+func TestMoveLeafContainerDockWrapsRoot(t *testing.T) {
+	// Left column (lt over lb) beside a full-height right pane. Container-dock
+	// pane-r to the left: it should span the full height, pushing the column right.
+	tree := Node{
+		Type:      "split",
+		SplitID:   "root",
+		Direction: DirectionVertical,
+		Ratio:     DefaultSplitRatio,
+		Children: []Node{
+			{
+				Type:      "split",
+				SplitID:   "left",
+				Direction: DirectionHorizontal,
+				Ratio:     DefaultSplitRatio,
+				Children: []Node{
+					{Type: "pane", PaneID: "pane-lt"},
+					{Type: "pane", PaneID: "pane-lb"},
+				},
+			},
+			{Type: "pane", PaneID: "pane-r"},
+		},
+	}
+	moved, ok := MoveLeaf(tree, "pane-r", "", "split-c", DirectionVertical, true, 0.3)
+	if !ok {
+		t.Fatal("container dock did not change layout")
+	}
+	if moved.Type != "split" || moved.Direction != DirectionVertical {
+		t.Fatalf("root = %+v, want a vertical split", moved)
+	}
+	if moved.Children[0].PaneID != "pane-r" {
+		t.Fatalf("children[0] = %+v, want pane-r spanning the full left edge", moved.Children[0])
+	}
+	left := moved.Children[1]
+	if left.Type != "split" || left.SplitID != "left" || left.Children[0].PaneID != "pane-lt" || left.Children[1].PaneID != "pane-lb" {
+		t.Fatalf("children[1] = %+v, want the intact lt/lb column", left)
+	}
+}
+
+func TestMoveLeafMovesPanelPreservingKindAndParams(t *testing.T) {
+	tree := Node{
+		Type:      "split",
+		SplitID:   "root",
+		Direction: DirectionVertical,
+		Ratio:     DefaultSplitRatio,
+		Children: []Node{
+			{Type: "panel", PanelID: "md1", PanelKind: string(PanelKindMarkdown), PanelParams: "/a.md"},
+			{Type: "panel", PanelID: "md2", PanelKind: string(PanelKindMarkdown), PanelParams: "/b.md"},
+		},
+	}
+	moved, ok := MoveLeaf(tree, "md1", "md2", "split-x", DirectionHorizontal, false, 0.5)
+	if !ok {
+		t.Fatal("panel-on-panel move did not change layout")
+	}
+	// md2 stays put; md1 lands beside it carrying its kind + params.
+	right := moved.Children[1]
+	if right.Type != "panel" || right.PanelID != "md1" {
+		t.Fatalf("children[1] = %+v, want relocated md1 panel", right)
+	}
+	if right.PanelKind != string(PanelKindMarkdown) || right.PanelParams != "/a.md" {
+		t.Fatalf("relocated panel lost data: kind=%q params=%q", right.PanelKind, right.PanelParams)
+	}
+	if ids := PanelIDs(moved); len(ids) != 2 {
+		t.Fatalf("panel ids = %v, want exactly two (no duplicate from the move)", ids)
+	}
+}
+
+func TestMoveLeafCollapsesSourceSplitWhenNested(t *testing.T) {
+	// a | (b / c). Move c next to a; the right column collapses to bare b.
+	tree := Node{
+		Type:      "split",
+		SplitID:   "root",
+		Direction: DirectionVertical,
+		Ratio:     DefaultSplitRatio,
+		Children: []Node{
+			{Type: "pane", PaneID: "pane-a"},
+			{
+				Type:      "split",
+				SplitID:   "right",
+				Direction: DirectionHorizontal,
+				Ratio:     DefaultSplitRatio,
+				Children: []Node{
+					{Type: "pane", PaneID: "pane-b"},
+					{Type: "pane", PaneID: "pane-c"},
+				},
+			},
+		},
+	}
+	moved, ok := MoveLeaf(tree, "pane-c", "pane-a", "split-x", DirectionVertical, true, 0.4)
+	if !ok {
+		t.Fatal("nested move did not change layout")
+	}
+	if moved.Children[1].PaneID != "pane-b" {
+		t.Fatalf("children[1] = %+v, want the right column collapsed to bare pane-b", moved.Children[1])
+	}
+	host := moved.Children[0]
+	if host.Type != "split" || host.Children[0].PaneID != "pane-c" || host.Children[1].PaneID != "pane-a" {
+		t.Fatalf("children[0] = %+v, want [pane-c, pane-a]", host)
+	}
+	if ids := PaneIDs(moved); len(ids) != 3 {
+		t.Fatalf("pane ids = %v, want all three present exactly once", ids)
+	}
+}

--- a/internal/workspacelayout/workspacelayout.go
+++ b/internal/workspacelayout/workspacelayout.go
@@ -488,6 +488,30 @@ func hasLeaf(node Node, leafID string) bool {
 	return HasPane(node, leafID) || HasPanel(node, leafID)
 }
 
+// findLeaf returns the leaf (pane or panel) with the given id so a move can
+// re-insert it elsewhere with its identity intact — and, for panels, its kind
+// and params. The bool reports whether such a leaf exists. Leaves carry no
+// children, so the returned node is self-contained.
+func findLeaf(node Node, leafID string) (Node, bool) {
+	switch node.Type {
+	case "pane":
+		if node.PaneID == leafID {
+			return node, true
+		}
+	case "panel":
+		if node.PanelID == leafID {
+			return node, true
+		}
+	case "split":
+		for _, child := range node.Children {
+			if leaf, ok := findLeaf(child, leafID); ok {
+				return leaf, true
+			}
+		}
+	}
+	return Node{}, false
+}
+
 // PanelParamsByID returns the opaque params of the panel with the given id.
 // The bool reports whether such a panel exists.
 func PanelParamsByID(node Node, panelID string) (string, bool) {
@@ -614,12 +638,12 @@ func insertBesideLeaf(node Node, anchorID string, direction Direction, before bo
 		if node.PaneID != anchorID {
 			return node, false
 		}
-		return panelSplit(node, panel, direction, before, splitID, ratio), true
+		return lockedSplit(node, panel, direction, before, splitID, ratio), true
 	case "panel":
 		if node.PanelID != anchorID {
 			return node, false
 		}
-		return panelSplit(node, panel, direction, before, splitID, ratio), true
+		return lockedSplit(node, panel, direction, before, splitID, ratio), true
 	case "split":
 		children := make([]Node, len(node.Children))
 		copy(children, node.Children)
@@ -635,10 +659,15 @@ func insertBesideLeaf(node Node, anchorID string, direction Direction, before bo
 	return node, false
 }
 
-func panelSplit(anchor, panel Node, direction Direction, before bool, splitID string, ratio float64) Node {
-	children := []Node{anchor, panel}
+// lockedSplit pairs an existing subtree with an incoming leaf under a new split.
+// The split is ratio-locked because the ratio came from an explicit user gesture
+// — a panel dock, or a leaf dropped at a chosen depth — so normalization keeps it
+// instead of rebalancing the pair back to an equal split. `before` places the
+// incoming leaf as children[0] (its left/top side).
+func lockedSplit(existing, incoming Node, direction Direction, before bool, splitID string, ratio float64) Node {
+	children := []Node{existing, incoming}
 	if before {
-		children = []Node{panel, anchor}
+		children = []Node{incoming, existing}
 	}
 	return Node{
 		Type:        "split",
@@ -648,6 +677,59 @@ func panelSplit(anchor, panel Node, direction Direction, before bool, splitID st
 		RatioLocked: true,
 		Children:    children,
 	}
+}
+
+// MoveLeaf relocates an existing leaf (pane or panel) so it sits beside anchorID
+// on the given side. When anchorID is empty the leaf docks against the whole
+// workspace: the entire remaining layout becomes one side of a new root split and
+// the moved leaf the other (a "container" dock). The moved leaf keeps its
+// identity, and for panels its kind and params. The new split is ratio-locked
+// because the ratio came from the user's drop, so normalization preserves the
+// chosen size. `ratio` is the children[0] fraction, matching DockPanel.
+//
+// It is a no-op (returns the input and false) when the move can't or shouldn't
+// happen:
+//   - leafID is empty, or equals anchorID (dropping a leaf on itself)
+//   - leafID is not in the tree
+//   - leafID is the only leaf, so removing it would leave nothing to dock against
+//   - anchorID is non-empty but missing once the leaf is pulled out
+func MoveLeaf(node Node, leafID, anchorID, splitID string, direction Direction, before bool, ratio float64) (Node, bool) {
+	leafID = strings.TrimSpace(leafID)
+	anchorID = strings.TrimSpace(anchorID)
+	if leafID == "" || leafID == anchorID {
+		return node, false
+	}
+	moved, found := findLeaf(node, leafID)
+	if !found {
+		return node, false
+	}
+	if ratio <= 0 || ratio >= 1 {
+		ratio = DefaultSplitRatio
+	}
+	if direction != DirectionVertical && direction != DirectionHorizontal {
+		direction = DirectionVertical
+	}
+	if strings.TrimSpace(splitID) == "" {
+		splitID = "split"
+	}
+
+	cleaned, removed := Remove(node, leafID)
+	if !removed || cleaned.Type == "" {
+		// The leaf was the only thing in the tree; there's nowhere to move it.
+		return node, false
+	}
+
+	if anchorID == "" {
+		return lockedSplit(cleaned, moved, direction, before, splitID, ratio), true
+	}
+	if !hasLeaf(cleaned, anchorID) {
+		return node, false
+	}
+	next, ok := insertBesideLeaf(cleaned, anchorID, direction, before, splitID, ratio, moved)
+	if !ok {
+		return node, false
+	}
+	return next, true
 }
 
 // UndockPanel removes a docked panel from the tree, collapsing the split that


### PR DESCRIPTION
## What

Extends drag-to-redock from markdown panels to **every leaf** in a workspace. Grab a terminal pane's header (or a panel's header) and drop it on another leaf's edge — left/right/top/bottom — to rearrange the layout.

This collapses the old markdown-only `DockPanel` path into one generic `MoveLeaf(leaf, anchor, edge, ratio)` operation. Any leaf can drop on any other leaf's edge, or on the workspace's outer frame.

## Behavior

- **Any pane or panel is draggable** by its header. `showPaneHeader` now counts panels too.
- **Drop depth sizes the incoming leaf:** thin strip near the edge → ½ near center, with magnetic snaps at ¼ / ⅓ / ½. Edge picked via the X-pattern (nearest of the four).
- **Container edges:** a perimeter frame docks against the whole workspace (root), shown per-side only when that side holds 2+ leaves; container dock = snapped ½.
- **Self-drop is a no-op** (the dragged leaf is excluded from its own targets).
- **PTYs survive the move.** The flat-render invariant (panes keyed + absolutely positioned from bounds) means a move repositions a `GhosttyTerminal`, never remounts it.

## Shape

- `internal/workspacelayout`: `MoveLeaf` (remove-then-reinsert, identity-preserving, locked dropped ratio); `panelSplit` generalized to `lockedSplit`; new `findLeaf` helper.
- `internal/protocol`: `workspace_layout_move_leaf` message; `ProtocolVersion` 78 → 79 (forces app/daemon reconnect on skew).
- `internal/daemon`: `moveLeaf` handler accepting pane / panel / `""` (root) anchors.
- Frontend: `beginLeafDrag` (pane header = grab handle); pure geometry in `dockTarget.ts`; gesture state machine extracted to `leafDrag.ts` (`startLeafDrag`); removed the now-dead `onDockPanel`/`sendWorkspaceDockPanel` path (`attn open` still creates panels server-side).

## Tests

- **Go:** `MoveLeaf` unit tests (self-drop, only-leaf, unknown leaf, pane↔panel, nesting, container/root wrap, locked-ratio-survives-normalize) + daemon protocol tests (relocate, self-drop reject).
- **Frontend:** `dockTarget.test.ts` (10, depth/edge/container geometry); `leafDrag.test.ts` (5, synthetic `PointerEvent`s drive the real window-listener wiring: preview, drop, self-drop no-op, container dock, cancel/teardown).
- **Live packaged app:** drove a real drag via a new `drag_leaf` automation verb. Confirmed the tree restructures correctly and that fresh split panes keep their PTY scrollback markers across the move and stay interactive (no remount).

## Notes

- A docking-interaction PR by design; a follow-up (PR B) handles panel-only-workspace lifecycle (keep a workspace alive while it holds any leaf, sidebar toggle for PTY-less workspaces, panel titling). Plan: `docs/plans/2026-06-01-uniform-leaf-docking.md`.
- The `drag_leaf` automation verb only activates when automation is enabled (dev/harness profiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)