### PR TITLE
Clear pending_approval promptly on approval; fix codex stop-classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 
 ---
 
+## [2026-06-03]
+
+### Fixed
+- **Approving a permission request clears the attention light right away.** When an agent is blocked on a permission prompt and you approve it, the session now returns to "working" within about a second — even while the approved command keeps running, and even for a second prompt back-to-back. It used to stay in the flashing "needs you" state for the entire duration of the approved tool, which defeated the point of the light. Works for both Claude and Codex.
+- **Codex sessions no longer get stuck in the purple "unknown" state.** When a Codex turn finished outside a git repository (for example in `/tmp`), attn could not classify it and fell back to "unknown." Codex sessions now settle into the correct done/waiting state regardless of where they run. The end-of-turn check is also leaner and quieter — it no longer loads your Codex MCP servers or tools.
+
+---
+
 ## [2026-06-02]
 
 ### Changed

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -53,6 +53,7 @@ func (c *Claude) Capabilities() Capabilities {
 		HasTranscriptWatcher: true,
 		HasClassifier:        true,
 		HasStateDetector:     true,
+		HasApprovalResolver:  true,
 		HasResume:            true,
 		HasYolo:              true,
 	}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -38,12 +38,13 @@ func (c *Codex) ResolveExecutable(configured string) string {
 func (c *Codex) Capabilities() Capabilities {
 	// Transcripts remain needed for Stop-hook classification; live state is hook-owned.
 	return Capabilities{
-		HasHooks:         true,
-		HasTranscript:    true,
-		HasClassifier:    true,
-		HasStateDetector: false,
-		HasResume:        true,
-		HasYolo:          true,
+		HasHooks:            true,
+		HasTranscript:       true,
+		HasClassifier:       true,
+		HasStateDetector:    false,
+		HasApprovalResolver: true,
+		HasResume:           true,
+		HasYolo:             true,
 	}
 }
 
@@ -109,7 +110,11 @@ func (c *Codex) RecoveredRunningState(ptyState string) protocol.SessionState {
 }
 
 func (c *Codex) ShouldApplyPTYState(current protocol.SessionState, incoming string) bool {
-	return false
+	// Codex live state is hook-owned, with one exception: no hook fires when the
+	// user approves a permission request, so the approval prompt leaving the
+	// rendered screen is the only signal the tool is now running. Allow that
+	// single pending_approval -> working transition; ignore all other PTY state.
+	return current == protocol.SessionStatePendingApproval && incoming == protocol.StateWorking
 }
 
 func (c *Codex) ResolveSpawnResumeSessionID(existingSessionID, requestedResumeID, storedResumeID string) string {

--- a/internal/agent/daemon_policy_test.go
+++ b/internal/agent/daemon_policy_test.go
@@ -81,8 +81,20 @@ func TestShouldApplyPTYState_AgentOverrides(t *testing.T) {
 	if ShouldApplyPTYState(Get("codex"), protocol.SessionStateWaitingInput, protocol.StateWorking) {
 		t.Fatal("codex should ignore working PTY noise while waiting_input")
 	}
-	if ShouldApplyPTYState(Get("codex"), protocol.SessionStatePendingApproval, protocol.StateWorking) {
-		t.Fatal("codex should ignore working PTY noise while pending_approval")
+	// The one exception: no hook fires when the user approves, so codex relies on
+	// the rendered screen to clear pending_approval -> working.
+	if !ShouldApplyPTYState(Get("codex"), protocol.SessionStatePendingApproval, protocol.StateWorking) {
+		t.Fatal("codex should apply working PTY state to clear pending_approval")
+	}
+	// But only working clears it; other transitions out of pending stay hook-owned.
+	for _, incoming := range []string{
+		protocol.StateWaitingInput,
+		protocol.StateIdle,
+		protocol.StatePendingApproval,
+	} {
+		if ShouldApplyPTYState(Get("codex"), protocol.SessionStatePendingApproval, incoming) {
+			t.Fatalf("codex should ignore %s PTY state while pending_approval", incoming)
+		}
 	}
 	if ShouldApplyPTYState(Get("copilot"), protocol.SessionStatePendingApproval, protocol.StateWorking) {
 		t.Fatal("copilot should ignore working PTY noise while pending_approval")

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -95,6 +95,12 @@ type Capabilities struct {
 	// HasStateDetector indicates PTY state detection is enabled for this agent.
 	HasStateDetector bool
 
+	// HasApprovalResolver indicates the daemon should clear pending_approval ->
+	// working off the rendered PTY screen for this agent. Needed by hook-driven
+	// agents that fire no hook when an approval is granted, so the only signal
+	// the tool is now running is the approval prompt leaving the screen.
+	HasApprovalResolver bool
+
 	// HasResume indicates the agent supports resuming previous sessions.
 	HasResume bool
 
@@ -112,6 +118,7 @@ var capabilityEnvNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9]+`)
 //   - ATTN_AGENT_<AGENT>_TRANSCRIPT_WATCHER=0|1
 //   - ATTN_AGENT_<AGENT>_CLASSIFIER=0|1
 //   - ATTN_AGENT_<AGENT>_STATE_DETECTOR=0|1
+//   - ATTN_AGENT_<AGENT>_APPROVAL_RESOLVER=0|1
 //   - ATTN_AGENT_<AGENT>_RESUME=0|1
 //   - ATTN_AGENT_<AGENT>_YOLO=0|1
 //
@@ -138,6 +145,9 @@ func EffectiveCapabilities(d Driver) Capabilities {
 	}
 	if v, ok := boolEnv(prefix + "STATE_DETECTOR"); ok {
 		caps.HasStateDetector = v
+	}
+	if v, ok := boolEnv(prefix + "APPROVAL_RESOLVER"); ok {
+		caps.HasApprovalResolver = v
 	}
 	if v, ok := boolEnv(prefix + "RESUME"); ok {
 		caps.HasResume = v

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -60,12 +60,14 @@ var verdictLineRegex = regexp.MustCompile(`(?i)^\s*(?:VERDICT\s*[:=]\s*)?(WAITIN
 const classifierLogSnippetMaxChars = 600
 
 const (
-	defaultCodexClassifierModels   = "gpt-5.3-codex-spark,gpt-5.3-codex"
-	defaultCodexReasoningEffort    = "low"
-	defaultCodexClassifierTimeout  = 30 * time.Second
-	defaultCodexExecutable         = "codex"
-	codexConfigReasoningEffortKey  = "model_reasoning_effort"
-	codexConfigDisableMCPServersKV = "mcp_servers={}"
+	defaultCodexClassifierModel   = "gpt-5.4-mini"
+	defaultCodexReasoningEffort   = "low"
+	defaultCodexClassifierTimeout = 30 * time.Second
+	defaultCodexExecutable        = "codex"
+	codexConfigReasoningEffortKey = "model_reasoning_effort"
+	// codexConfigDisableShellToolKV removes the built-in shell tool: the
+	// classifier only needs the model to emit a verdict, never to run commands.
+	codexConfigDisableShellToolKV = "features.shell_tool=false"
 )
 
 type codexEvent struct {
@@ -281,22 +283,6 @@ func classifyClaudeMessages(messages []types.Message) (result string, ok bool, l
 	return "", false, lastAssistantResponse
 }
 
-func parseCodexModels(raw string) []string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		raw = defaultCodexClassifierModels
-	}
-	parts := strings.Split(raw, ",")
-	models := make([]string, 0, len(parts))
-	for _, part := range parts {
-		model := strings.TrimSpace(part)
-		if model != "" {
-			models = append(models, model)
-		}
-	}
-	return models
-}
-
 func resolveCodexExecutable(configuredExecutable string) string {
 	if envExecutable := strings.TrimSpace(os.Getenv("ATTN_CODEX_EXECUTABLE")); envExecutable != "" {
 		return envExecutable
@@ -367,9 +353,17 @@ func runCodexClassifierAttempt(ctx context.Context, executable, model, reasoning
 		"exec",
 		"--json",
 		"--output-last-message", lastMessagePath,
+		// Classify regardless of the session's cwd. Codex refuses `exec` outside a
+		// trusted git repo otherwise, which is how a codex turn that ends in an
+		// untrusted dir (e.g. /tmp) gets misclassified as unknown.
+		"--skip-git-repo-check",
+		// Ignore the user's config.toml entirely: the classifier must not inherit
+		// their MCP servers (which add startup latency, auth noise, and tool-schema
+		// tokens) or other agent settings. Auth is read separately and still works.
+		"--ignore-user-config",
 		"-m", model,
 		"-c", fmt.Sprintf("%s=%q", codexConfigReasoningEffortKey, reasoningEffort),
-		"-c", codexConfigDisableMCPServersKV,
+		"-c", codexConfigDisableShellToolKV,
 		prompt,
 	}
 
@@ -554,15 +548,15 @@ func ClassifyWithCopilot(text string, timeout time.Duration) (string, error) {
 	return result, nil
 }
 
-// ClassifyWithCodex uses Codex CLI with explicit model fallback:
-// gpt-5.3-codex-spark (low effort) -> gpt-5.3-codex (low effort).
+// ClassifyWithCodex uses Codex CLI with a single model (default gpt-5.4-mini,
+// low effort; override via ATTN_CODEX_CLASSIFIER_MODEL).
 // Returns "waiting_input", "idle", or "unknown".
 func ClassifyWithCodex(text string, timeout time.Duration) (string, error) {
 	return ClassifyWithCodexExecutable(text, "", timeout)
 }
 
-// ClassifyWithCodexExecutable uses Codex CLI with explicit model fallback:
-// gpt-5.3-codex-spark (low effort) -> gpt-5.3-codex (low effort).
+// ClassifyWithCodexExecutable uses Codex CLI with a single model (default
+// gpt-5.4-mini, low effort; override via ATTN_CODEX_CLASSIFIER_MODEL).
 // Executable resolution order:
 // 1) ATTN_CODEX_EXECUTABLE env var
 // 2) configuredExecutable argument
@@ -592,47 +586,39 @@ func ClassifyWithCodexExecutableInDir(text, configuredExecutable, workDir string
 	if reasoningEffort == "" {
 		reasoningEffort = defaultCodexReasoningEffort
 	}
-	models := parseCodexModels(os.Getenv("ATTN_CODEX_CLASSIFIER_MODELS"))
-	if len(models) == 0 {
-		return "unknown", fmt.Errorf("no codex classifier models configured")
+	model := strings.TrimSpace(os.Getenv("ATTN_CODEX_CLASSIFIER_MODEL"))
+	if model == "" {
+		model = defaultCodexClassifierModel
 	}
 
 	prompt := BuildPrompt(text)
-	var lastErr error
-	for _, model := range models {
-		DefaultLogger(
-			"classifier: calling codex CLI executable=%s model=%s reasoning_effort=%s timeout=%d seconds work_dir=%q",
-			executable,
-			model,
-			reasoningEffort,
-			int(timeout.Seconds()),
-			strings.TrimSpace(workDir),
-		)
+	DefaultLogger(
+		"classifier: calling codex CLI executable=%s model=%s reasoning_effort=%s timeout=%d seconds work_dir=%q",
+		executable,
+		model,
+		reasoningEffort,
+		int(timeout.Seconds()),
+		strings.TrimSpace(workDir),
+	)
 
-		lastMessage, rawJSONL, err := runCodexClassifierAttempt(ctx, executable, model, reasoningEffort, prompt, workDir)
-		if err != nil {
-			DefaultLogger("classifier: codex CLI attempt failed model=%s err=%v", model, err)
-			lastErr = err
-			continue
-		}
+	lastMessage, rawJSONL, err := runCodexClassifierAttempt(ctx, executable, model, reasoningEffort, prompt, workDir)
+	if err != nil {
+		DefaultLogger("classifier: codex CLI failed model=%s err=%v", model, err)
+		return "unknown", fmt.Errorf("codex cli: %w", err)
+	}
 
-		if lastMessage != "" {
-			DefaultLogger("classifier: codex CLI last message (%d chars): %q", len(lastMessage), lastMessage)
-			if result, ok := parseVerdictFromResponse(lastMessage); ok {
-				DefaultLogger("classifier: parsed result: %s", result)
-				return result, nil
-			}
-		}
-
-		if result, ok := parseVerdictFromCodexJSONL([]byte(rawJSONL)); ok {
-			DefaultLogger("classifier: parsed result from codex json stream: %s", result)
+	if lastMessage != "" {
+		DefaultLogger("classifier: codex CLI last message (%d chars): %q", len(lastMessage), lastMessage)
+		if result, ok := parseVerdictFromResponse(lastMessage); ok {
+			DefaultLogger("classifier: parsed result: %s", result)
 			return result, nil
 		}
-		DefaultLogger("classifier: codex response missing explicit WAITING/DONE verdict, returning unknown")
-		return "unknown", nil
 	}
-	if lastErr != nil {
-		return "unknown", fmt.Errorf("codex cli: %w", lastErr)
+
+	if result, ok := parseVerdictFromCodexJSONL([]byte(rawJSONL)); ok {
+		DefaultLogger("classifier: parsed result from codex json stream: %s", result)
+		return result, nil
 	}
+	DefaultLogger("classifier: codex response missing explicit WAITING/DONE verdict, returning unknown")
 	return "unknown", nil
 }

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -359,12 +359,14 @@ func TestParseVerdictFromCodexJSONL_LargeLine(t *testing.T) {
 	}
 }
 
-func TestClassifyWithCodex_ModelFallbackAndLastMessageParse(t *testing.T) {
+func TestClassifyWithCodex_SingleModelAndFlags(t *testing.T) {
 	tmp := t.TempDir()
 	logPath := filepath.Join(tmp, "invocations.log")
+	argsPath := filepath.Join(tmp, "args.log")
 	scriptPath := filepath.Join(tmp, "codex")
 	script := fmt.Sprintf(`#!/bin/sh
 set -eu
+printf '%%s\n' "$*" > %s
 model=""
 last=""
 while [ "$#" -gt 0 ]; do
@@ -385,23 +387,17 @@ done
 echo "$model" >> %s
 echo '{"type":"thread.started","thread_id":"abc"}'
 echo '{"type":"turn.started"}'
-if [ "$model" = "spark" ]; then
-  echo '{"type":"error","message":"model_not_found"}'
-  echo '{"type":"turn.failed","error":{"message":"model_not_found"}}'
-  echo 'rollout noise' >&2
-  exit 1
-fi
 printf '{"verdict":"DONE"}\n' > "$last"
 echo '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"{\"verdict\":\"DONE\"}"}}'
 echo '{"type":"turn.completed"}'
-`, shellEscapeSingleQuotes(logPath))
+`, shellEscapeSingleQuotes(argsPath), shellEscapeSingleQuotes(logPath))
 
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write script: %v", err)
 	}
 
 	t.Setenv("ATTN_CODEX_EXECUTABLE", scriptPath)
-	t.Setenv("ATTN_CODEX_CLASSIFIER_MODELS", "spark,base")
+	t.Setenv("ATTN_CODEX_CLASSIFIER_MODEL", "test-model")
 	t.Setenv("ATTN_CODEX_CLASSIFIER_REASONING_EFFORT", "low")
 
 	got, err := ClassifyWithCodex("done text", 10*time.Second)
@@ -412,13 +408,27 @@ echo '{"type":"turn.completed"}'
 		t.Fatalf("ClassifyWithCodex() = %q, want idle", got)
 	}
 
+	// Exactly one invocation, with the configured model: the fallback is gone.
 	invocationsRaw, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read log file: %v", err)
 	}
 	invocations := strings.Split(strings.TrimSpace(string(invocationsRaw)), "\n")
-	if len(invocations) != 2 || invocations[0] != "spark" || invocations[1] != "base" {
-		t.Fatalf("model invocations = %q, want [spark base]", invocations)
+	if len(invocations) != 1 || invocations[0] != "test-model" {
+		t.Fatalf("model invocations = %q, want [test-model] (no fallback)", invocations)
+	}
+
+	// The flags that make classification robust must be present: classify
+	// regardless of cwd trust, and ignore the user's config (MCP/tools).
+	argsRaw, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	args := string(argsRaw)
+	for _, want := range []string{"--skip-git-repo-check", "--ignore-user-config", "features.shell_tool=false"} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("codex args missing %q; got: %s", want, args)
+		}
 	}
 }
 
@@ -466,7 +476,7 @@ echo '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","tex
 	}
 
 	t.Setenv("ATTN_CODEX_EXECUTABLE", "")
-	t.Setenv("ATTN_CODEX_CLASSIFIER_MODELS", "base")
+	t.Setenv("ATTN_CODEX_CLASSIFIER_MODEL", "base")
 	t.Setenv("ATTN_CODEX_CLASSIFIER_REASONING_EFFORT", "low")
 
 	got, err := ClassifyWithCodexExecutable("done text", scriptPath, 10*time.Second)
@@ -515,7 +525,7 @@ echo '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","tex
 	}
 
 	t.Setenv("ATTN_CODEX_EXECUTABLE", "")
-	t.Setenv("ATTN_CODEX_CLASSIFIER_MODELS", "base")
+	t.Setenv("ATTN_CODEX_CLASSIFIER_MODEL", "base")
 	t.Setenv("ATTN_CODEX_CLASSIFIER_REASONING_EFFORT", "low")
 
 	got, err := ClassifyWithCodexExecutableInDir("done text", scriptPath, workDir, 10*time.Second)

--- a/internal/daemon/transcript_watcher_test.go
+++ b/internal/daemon/transcript_watcher_test.go
@@ -65,11 +65,30 @@ func TestHandlePTYState_CodexWorkingDoesNotOverrideStoppedStates(t *testing.T) {
 	if got := d.store.Get("codex-waiting"); got.State != protocol.SessionStateWaitingInput {
 		t.Fatalf("codex working PTY should not override waiting_input, got=%s", got.State)
 	}
+}
 
-	addCodexSession("codex-pending", protocol.SessionStatePendingApproval)
+// TestHandlePTYState_CodexWorkingClearsPendingApproval covers the one exception
+// to codex's hook-owned live state: no hook fires when the user approves a
+// permission request, so the approval prompt leaving the rendered screen (a PTY
+// working signal) is the only thing that can move codex out of pending_approval.
+func TestHandlePTYState_CodexWorkingClearsPendingApproval(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "sock"))
+
+	nowStr := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID:             "codex-pending",
+		Label:          "codex-pending",
+		Agent:          protocol.SessionAgentCodex,
+		Directory:      "/tmp",
+		State:          protocol.SessionStatePendingApproval,
+		StateSince:     nowStr,
+		StateUpdatedAt: nowStr,
+		LastSeen:       nowStr,
+	})
+
 	d.handlePTYState("codex-pending", protocol.StateWorking)
-	if got := d.store.Get("codex-pending"); got.State != protocol.SessionStatePendingApproval {
-		t.Fatalf("codex working PTY should not override pending_approval, got=%s", got.State)
+	if got := d.store.Get("codex-pending"); got.State != protocol.SessionStateWorking {
+		t.Fatalf("codex working PTY should clear pending_approval, got=%s", got.State)
 	}
 }
 

--- a/internal/pty/approval_resolver.go
+++ b/internal/pty/approval_resolver.go
@@ -1,0 +1,60 @@
+package pty
+
+import "time"
+
+// approvalResolver detects the user resolving an approval prompt by watching the
+// rendered screen, and emits a single "working" transition once the prompt is
+// gone. It exists because neither Claude nor Codex fire a hook at the moment a
+// permission request is approved: the only signal back to "working" before the
+// approved (possibly long-running) tool finishes is the approval UI disappearing
+// from the terminal.
+//
+// State machine (driven by rendered-screen samples):
+//   - on the first sample where the approval prompt is visible, arm and emit
+//     statePendingApproval. The onset itself is hook-driven, but re-emitting it
+//     here syncs the PTY layer's own state view: the worker only forwards a state
+//     to the daemon when it differs from the last PTY-emitted state, and the
+//     onset hook bypasses the worker. Without this, a working clear that follows
+//     a hook-set pending (e.g. a chained second approval) would look unchanged to
+//     the worker and never be forwarded. (Agents may emit no output while
+//     blocked, so we arm on first sight rather than waiting for a dwell.)
+//   - once armed and the prompt is no longer visible, require the absence to hold
+//     for clearDebounce of continued output before emitting "working", so a
+//     prompt repaint or a chained multi-step approval does not flap to working
+const approvalClearDebounce = 750 * time.Millisecond
+
+type approvalResolver struct {
+	armed        bool
+	clearedSince time.Time
+}
+
+// observe consumes one rendered-screen sample and returns a state transition to
+// emit: statePendingApproval once when the prompt first appears, then
+// stateWorking once when the prompt has been gone for clearDebounce.
+func (r *approvalResolver) observe(screenText string, now time.Time) (string, bool) {
+	if isPendingApproval(screenText) {
+		r.clearedSince = time.Time{}
+		if !r.armed {
+			r.armed = true
+			return statePendingApproval, true
+		}
+		return "", false
+	}
+
+	if !r.armed {
+		return "", false
+	}
+
+	if r.clearedSince.IsZero() {
+		r.clearedSince = now
+		return "", false
+	}
+
+	if now.Sub(r.clearedSince) >= approvalClearDebounce {
+		r.armed = false
+		r.clearedSince = time.Time{}
+		return stateWorking, true
+	}
+
+	return "", false
+}

--- a/internal/pty/approval_resolver.go
+++ b/internal/pty/approval_resolver.go
@@ -19,42 +19,67 @@ import "time"
 //     the worker and never be forwarded. (Agents may emit no output while
 //     blocked, so we arm on first sight rather than waiting for a dwell.)
 //   - once armed and the prompt is no longer visible, require the absence to hold
-//     for clearDebounce of continued output before emitting "working", so a
-//     prompt repaint or a chained multi-step approval does not flap to working
+//     for approvalClearDebounce before emitting "working", so a prompt repaint or
+//     a chained multi-step approval does not flap to working.
+//
+// The debounce must NOT depend on further PTY output: a quiet approved command
+// (one that produces no output while it runs) would otherwise stay stuck in
+// pending_approval. observe reports approvalClearStarted the moment the prompt
+// first disappears so the session can schedule an independent recheck.
 const approvalClearDebounce = 750 * time.Millisecond
+
+// approvalSignal is the action the session should take after observe consumes one
+// rendered-screen sample.
+type approvalSignal int
+
+const (
+	// approvalNone: nothing to do for this sample.
+	approvalNone approvalSignal = iota
+	// approvalArmedPending: the prompt just appeared. Emit statePendingApproval
+	// to (re)sync the PTY layer's state view (see the type comment).
+	approvalArmedPending
+	// approvalClearStarted: the prompt just left the screen. The session should
+	// schedule a recheck after approvalClearDebounce so the clear completes even
+	// if no further PTY output arrives.
+	approvalClearStarted
+	// approvalCleared: the prompt has stayed gone for the debounce. Emit
+	// stateWorking.
+	approvalCleared
+)
 
 type approvalResolver struct {
 	armed        bool
 	clearedSince time.Time
 }
 
-// observe consumes one rendered-screen sample and returns a state transition to
-// emit: statePendingApproval once when the prompt first appears, then
-// stateWorking once when the prompt has been gone for clearDebounce.
-func (r *approvalResolver) observe(screenText string, now time.Time) (string, bool) {
+// observe consumes one rendered-screen sample and reports the transition to act
+// on: approvalArmedPending once when the prompt first appears, approvalClearStarted
+// once when it first disappears, then approvalCleared once the prompt has been
+// gone for approvalClearDebounce.
+func (r *approvalResolver) observe(screenText string, now time.Time) approvalSignal {
 	if isPendingApproval(screenText) {
 		r.clearedSince = time.Time{}
 		if !r.armed {
 			r.armed = true
-			return statePendingApproval, true
+			return approvalArmedPending
 		}
-		return "", false
+		return approvalNone
 	}
 
 	if !r.armed {
-		return "", false
+		return approvalNone
 	}
 
 	if r.clearedSince.IsZero() {
 		r.clearedSince = now
-		return "", false
+		return approvalClearStarted
 	}
 
 	if now.Sub(r.clearedSince) >= approvalClearDebounce {
 		r.armed = false
 		r.clearedSince = time.Time{}
-		return stateWorking, true
+		return approvalCleared
 	}
 
-	return "", false
+	return approvalNone
 }

--- a/internal/pty/approval_resolver_test.go
+++ b/internal/pty/approval_resolver_test.go
@@ -1,0 +1,157 @@
+package pty
+
+import (
+	"testing"
+	"time"
+)
+
+// Rendered-screen text as it appears (vt10x-resolved) while each agent shows an
+// approval prompt. Captured from real Claude/Codex sessions.
+const (
+	claudeApprovalScreen = `Bash command
+  rm /tmp/scratch_demo.txt
+  Remove the scratch file
+
+Permission rule Bash(rm:*) requires confirmation for this command.
+/permissions to update rules
+
+Do you want to proceed?
+❯ 1. Yes
+  2. No
+
+Esc to cancel · Tab to amend · ctrl+e to explain`
+
+	claudeWorkingScreen = `⏺ I'll remove the file.
+
+⏺ Bash(rm /tmp/scratch_demo.txt)
+  ⎿  Done
+  ⎿  Allowed by PermissionRequest hook
+
+✻ Fiddle-faddling… (7s · ↓ 269 tokens)`
+
+	codexApprovalScreen = `• Running rm approval-prompt-test-file.txt
+  Would you like to run the following command?
+  Reason: requested by user
+
+  1. Yes
+  2. Yes, and don't ask again for commands that start with ` + "`rm`" + `
+  3. No, and tell Codex what to do differently`
+
+	codexWorkingScreen = `✔ You approved codex to run rm approval-prompt-test-file.txt this time
+• Running rm approval-prompt-test-file.txt
+• Working (10s • esc to interrupt)
+› Write tests for @filename`
+)
+
+func TestIsPendingApproval_RealRenderedScreens(t *testing.T) {
+	tests := []struct {
+		name   string
+		screen string
+		want   bool
+	}{
+		{"claude prompt", claudeApprovalScreen, true},
+		{"claude working", claudeWorkingScreen, false},
+		{"codex prompt", codexApprovalScreen, true},
+		{"codex working", codexWorkingScreen, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPendingApproval(tt.screen); got != tt.want {
+				t.Fatalf("isPendingApproval(%s) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApprovalResolver_ClearsAfterPromptGoneAndDebounce(t *testing.T) {
+	r := &approvalResolver{}
+	base := time.Unix(0, 0)
+
+	// Prompt first visible: arm and re-emit pending_approval to sync the PTY
+	// layer's state view (so the later working clear is seen as a change).
+	if state, changed := r.observe(claudeApprovalScreen, base); !changed || state != statePendingApproval {
+		t.Fatalf("expected (%q,true) on first prompt sight, got (%q,%v)", statePendingApproval, state, changed)
+	}
+	if !r.armed {
+		t.Fatal("resolver should arm while the prompt is visible")
+	}
+	// Prompt still visible on the next sample: armed, no repeat emit.
+	if state, changed := r.observe(claudeApprovalScreen, base.Add(time.Millisecond)); changed {
+		t.Fatalf("should not re-emit pending while prompt stays visible: %q", state)
+	}
+
+	// Prompt gone: this sample starts the clear debounce window.
+	clearStart := base.Add(100 * time.Millisecond)
+	if _, changed := r.observe(claudeWorkingScreen, clearStart); changed {
+		t.Fatal("should not clear on the first prompt-gone sample")
+	}
+
+	// Still within the debounce window: no transition yet.
+	if _, changed := r.observe(claudeWorkingScreen, clearStart.Add(approvalClearDebounce-time.Millisecond)); changed {
+		t.Fatal("should not clear before debounce elapses")
+	}
+
+	// Debounce elapsed: emit working exactly once.
+	state, changed := r.observe(claudeWorkingScreen, clearStart.Add(approvalClearDebounce+time.Millisecond))
+	if !changed || state != stateWorking {
+		t.Fatalf("expected (%q,true) after debounce, got (%q,%v)", stateWorking, state, changed)
+	}
+	if state, changed := r.observe(claudeWorkingScreen, base.Add(2*time.Second)); changed {
+		t.Fatalf("should not re-emit after clearing: %q", state)
+	}
+}
+
+// renderedText must resolve absolute-cursor-addressed output (how TUIs actually
+// paint the prompt) into linear text, where the raw byte tail would not.
+func TestRenderedText_ResolvesCursorAddressedPrompt(t *testing.T) {
+	screen := newVirtualScreen(80, 24)
+	// Clear + home, then paint the prompt out of order via absolute moves.
+	screen.Observe([]byte("\x1b[2J\x1b[H"))
+	screen.Observe([]byte("\x1b[7;3H2. No"))
+	screen.Observe([]byte("\x1b[5;1HDo you want to proceed?"))
+	screen.Observe([]byte("\x1b[6;1H❯ 1. Yes"))
+
+	text := screen.renderedText()
+	if !isPendingApproval(text) {
+		t.Fatalf("rendered prompt should be detected as pending approval; got:\n%s", text)
+	}
+
+	// After approval the area is repainted with the result; prompt is gone.
+	screen.Observe([]byte("\x1b[2J\x1b[H\x1b[5;1H⏺ Done"))
+	if isPendingApproval(screen.renderedText()) {
+		t.Fatalf("repainted screen should no longer look pending; got:\n%s", screen.renderedText())
+	}
+}
+
+func TestApprovalResolver_NoTransitionWithoutPrompt(t *testing.T) {
+	r := &approvalResolver{}
+	now := time.Unix(0, 0)
+	for i := range 10 {
+		if state, changed := r.observe(claudeWorkingScreen, now.Add(time.Duration(i)*time.Second)); changed {
+			t.Fatalf("never-armed resolver must not emit: %q", state)
+		}
+	}
+}
+
+func TestApprovalResolver_PromptReappearsResetsDebounce(t *testing.T) {
+	r := &approvalResolver{}
+	base := time.Unix(0, 0)
+
+	r.observe(codexApprovalScreen, base)                          // arm
+	r.observe(codexWorkingScreen, base.Add(200*time.Millisecond)) // start debounce
+
+	// A second prompt appears (chained multi-step approval) before debounce ends.
+	if _, changed := r.observe(codexApprovalScreen, base.Add(400*time.Millisecond)); changed {
+		t.Fatal("a reappearing prompt must not produce a working transition")
+	}
+	if r.clearedSince != (time.Time{}) {
+		t.Fatal("reappearing prompt should reset the clear debounce")
+	}
+
+	// Now resolved for real.
+	r.observe(codexWorkingScreen, base.Add(500*time.Millisecond)) // restart debounce
+	state, changed := r.observe(codexWorkingScreen, base.Add(500*time.Millisecond+approvalClearDebounce))
+	if !changed || state != stateWorking {
+		t.Fatalf("expected working after second prompt resolved, got (%q,%v)", state, changed)
+	}
+}

--- a/internal/pty/approval_resolver_test.go
+++ b/internal/pty/approval_resolver_test.go
@@ -1,6 +1,7 @@
 package pty
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -69,35 +70,34 @@ func TestApprovalResolver_ClearsAfterPromptGoneAndDebounce(t *testing.T) {
 
 	// Prompt first visible: arm and re-emit pending_approval to sync the PTY
 	// layer's state view (so the later working clear is seen as a change).
-	if state, changed := r.observe(claudeApprovalScreen, base); !changed || state != statePendingApproval {
-		t.Fatalf("expected (%q,true) on first prompt sight, got (%q,%v)", statePendingApproval, state, changed)
+	if sig := r.observe(claudeApprovalScreen, base); sig != approvalArmedPending {
+		t.Fatalf("expected approvalArmedPending on first prompt sight, got %v", sig)
 	}
 	if !r.armed {
 		t.Fatal("resolver should arm while the prompt is visible")
 	}
-	// Prompt still visible on the next sample: armed, no repeat emit.
-	if state, changed := r.observe(claudeApprovalScreen, base.Add(time.Millisecond)); changed {
-		t.Fatalf("should not re-emit pending while prompt stays visible: %q", state)
+	// Prompt still visible on the next sample: armed, no repeat signal.
+	if sig := r.observe(claudeApprovalScreen, base.Add(time.Millisecond)); sig != approvalNone {
+		t.Fatalf("should not re-signal while prompt stays visible, got %v", sig)
 	}
 
 	// Prompt gone: this sample starts the clear debounce window.
 	clearStart := base.Add(100 * time.Millisecond)
-	if _, changed := r.observe(claudeWorkingScreen, clearStart); changed {
-		t.Fatal("should not clear on the first prompt-gone sample")
+	if sig := r.observe(claudeWorkingScreen, clearStart); sig != approvalClearStarted {
+		t.Fatalf("expected approvalClearStarted on first prompt-gone sample, got %v", sig)
 	}
 
 	// Still within the debounce window: no transition yet.
-	if _, changed := r.observe(claudeWorkingScreen, clearStart.Add(approvalClearDebounce-time.Millisecond)); changed {
-		t.Fatal("should not clear before debounce elapses")
+	if sig := r.observe(claudeWorkingScreen, clearStart.Add(approvalClearDebounce-time.Millisecond)); sig != approvalNone {
+		t.Fatalf("should not clear before debounce elapses, got %v", sig)
 	}
 
 	// Debounce elapsed: emit working exactly once.
-	state, changed := r.observe(claudeWorkingScreen, clearStart.Add(approvalClearDebounce+time.Millisecond))
-	if !changed || state != stateWorking {
-		t.Fatalf("expected (%q,true) after debounce, got (%q,%v)", stateWorking, state, changed)
+	if sig := r.observe(claudeWorkingScreen, clearStart.Add(approvalClearDebounce+time.Millisecond)); sig != approvalCleared {
+		t.Fatalf("expected approvalCleared after debounce, got %v", sig)
 	}
-	if state, changed := r.observe(claudeWorkingScreen, base.Add(2*time.Second)); changed {
-		t.Fatalf("should not re-emit after clearing: %q", state)
+	if sig := r.observe(claudeWorkingScreen, base.Add(2*time.Second)); sig != approvalNone {
+		t.Fatalf("should not re-signal after clearing, got %v", sig)
 	}
 }
 
@@ -127,8 +127,8 @@ func TestApprovalResolver_NoTransitionWithoutPrompt(t *testing.T) {
 	r := &approvalResolver{}
 	now := time.Unix(0, 0)
 	for i := range 10 {
-		if state, changed := r.observe(claudeWorkingScreen, now.Add(time.Duration(i)*time.Second)); changed {
-			t.Fatalf("never-armed resolver must not emit: %q", state)
+		if sig := r.observe(claudeWorkingScreen, now.Add(time.Duration(i)*time.Second)); sig != approvalNone {
+			t.Fatalf("never-armed resolver must not signal: %v", sig)
 		}
 	}
 }
@@ -141,7 +141,7 @@ func TestApprovalResolver_PromptReappearsResetsDebounce(t *testing.T) {
 	r.observe(codexWorkingScreen, base.Add(200*time.Millisecond)) // start debounce
 
 	// A second prompt appears (chained multi-step approval) before debounce ends.
-	if _, changed := r.observe(codexApprovalScreen, base.Add(400*time.Millisecond)); changed {
+	if sig := r.observe(codexApprovalScreen, base.Add(400*time.Millisecond)); sig == approvalCleared {
 		t.Fatal("a reappearing prompt must not produce a working transition")
 	}
 	if r.clearedSince != (time.Time{}) {
@@ -150,8 +150,56 @@ func TestApprovalResolver_PromptReappearsResetsDebounce(t *testing.T) {
 
 	// Now resolved for real.
 	r.observe(codexWorkingScreen, base.Add(500*time.Millisecond)) // restart debounce
-	state, changed := r.observe(codexWorkingScreen, base.Add(500*time.Millisecond+approvalClearDebounce))
-	if !changed || state != stateWorking {
-		t.Fatalf("expected working after second prompt resolved, got (%q,%v)", state, changed)
+	if sig := r.observe(codexWorkingScreen, base.Add(500*time.Millisecond+approvalClearDebounce)); sig != approvalCleared {
+		t.Fatalf("expected approvalCleared after second prompt resolved, got %v", sig)
+	}
+}
+
+// TestSession_ApprovalClearsWithoutFurtherOutput is the regression for the core
+// contract: once the approval prompt disappears, the session returns to working
+// even when the approved command produces no further PTY output. The clear must be
+// driven by the scheduled recheck, not by the next output frame — so after the
+// prompt-gone sample we make no further evaluateApproval calls and rely solely on
+// the timer.
+func TestSession_ApprovalClearsWithoutFurtherOutput(t *testing.T) {
+	states := make(chan string, 8)
+	s := &Session{
+		approvalResolver: &approvalResolver{},
+		screen:           newVirtualScreen(80, 24),
+		onState:          func(state string) { states <- state },
+	}
+	s.running = true
+
+	paint := func(screen string) {
+		// Clear+home, then paint the screen with CRLF line breaks so each row
+		// starts at column 0 (matching how a TUI repaints).
+		s.screen.Observe([]byte("\x1b[2J\x1b[H"))
+		s.screen.Observe([]byte(strings.ReplaceAll(screen, "\n", "\r\n")))
+	}
+
+	// Approval prompt appears -> pending emitted immediately (readLoop path).
+	paint(codexApprovalScreen)
+	s.evaluateApproval(time.Now(), false)
+	select {
+	case st := <-states:
+		if st != statePendingApproval {
+			t.Fatalf("expected %q when the prompt appears, got %q", statePendingApproval, st)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected pending_approval when the prompt appears")
+	}
+
+	// User approves: the screen repaints to the working view in a single burst,
+	// then the command goes silent. Only the scheduled recheck can drive the clear.
+	paint(codexWorkingScreen)
+	s.evaluateApproval(time.Now(), false)
+
+	select {
+	case st := <-states:
+		if st != stateWorking {
+			t.Fatalf("expected %q from the scheduled recheck, got %q", stateWorking, st)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("working was not emitted without further PTY output (timer did not drive the clear)")
 	}
 }

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -228,8 +228,11 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 	m.mu.Unlock()
 
 	detectorEnabled := true
+	approvalResolverEnabled := false
 	if d := agentdriver.Get(agent); d != nil {
-		detectorEnabled = agentdriver.EffectiveCapabilities(d).HasStateDetector
+		caps := agentdriver.EffectiveCapabilities(d)
+		detectorEnabled = caps.HasStateDetector
+		approvalResolverEnabled = caps.HasApprovalResolver
 	}
 	if detectorEnabled {
 		switch agent {
@@ -239,7 +242,10 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 			session.detector = newClaudeWorkingDetector()
 		}
 	}
-	if session.detector != nil && onState != nil {
+	if approvalResolverEnabled {
+		session.approvalResolver = &approvalResolver{}
+	}
+	if (session.detector != nil || session.approvalResolver != nil) && onState != nil {
 		session.onState = func(state string) {
 			onState(opts.ID, state)
 		}

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -80,6 +80,12 @@ type Session struct {
 	stateMu       sync.RWMutex
 	detectorState string
 
+	// approvalResolver clears pending_approval->working off the rendered screen
+	// when the user resolves an approval prompt (no hook fires at that moment).
+	// Driven from readLoop only; throttled by lastApprovalEval.
+	approvalResolver *approvalResolver
+	lastApprovalEval time.Time
+
 	exitMu     sync.RWMutex
 	running    bool
 	exitCode   *int
@@ -215,6 +221,7 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 						s.onState(state)
 					}
 				}
+				s.resolveApproval(data)
 			}
 		}
 		if err != nil {
@@ -247,6 +254,35 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 
 	if onExit != nil {
 		onExit(exitCode, signal)
+	}
+}
+
+// approvalEvalInterval throttles how often the approval resolver inspects the
+// rendered screen. Rendering is cheap but the output stream is dominated by many
+// tiny cursor-addressed frames; sampling at this cadence keeps cost bounded while
+// staying well below approvalClearDebounce.
+const approvalEvalInterval = 100 * time.Millisecond
+
+// resolveApproval feeds the current rendered screen to the approval resolver,
+// throttled to approvalEvalInterval, and forwards any state transition it
+// reports (pending_approval on first sight of the prompt, working once it is
+// resolved). Called from readLoop only.
+func (s *Session) resolveApproval(data []byte) {
+	if s.approvalResolver == nil || s.onState == nil || s.screen == nil || len(data) == 0 {
+		return
+	}
+	now := time.Now()
+	if !s.lastApprovalEval.IsZero() && now.Sub(s.lastApprovalEval) < approvalEvalInterval {
+		return
+	}
+	s.lastApprovalEval = now
+	text := s.screen.renderedText()
+	state, changed := s.approvalResolver.observe(text, now)
+	if changed {
+		s.stateMu.Lock()
+		s.detectorState = state
+		s.stateMu.Unlock()
+		s.onState(state)
 	}
 }
 

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -82,9 +82,13 @@ type Session struct {
 
 	// approvalResolver clears pending_approval->working off the rendered screen
 	// when the user resolves an approval prompt (no hook fires at that moment).
-	// Driven from readLoop only; throttled by lastApprovalEval.
+	// Sampled from readLoop (throttled by lastApprovalEval) and from an
+	// independent approvalTimer so the clear completes even when the approved
+	// command produces no further output. approvalMu serializes the two paths.
 	approvalResolver *approvalResolver
+	approvalMu       sync.Mutex
 	lastApprovalEval time.Time
+	approvalTimer    *time.Timer
 
 	exitMu     sync.RWMutex
 	running    bool
@@ -221,7 +225,9 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 						s.onState(state)
 					}
 				}
-				s.resolveApproval(data)
+				if len(data) > 0 {
+					s.evaluateApproval(time.Now(), true)
+				}
 			}
 		}
 		if err != nil {
@@ -257,33 +263,83 @@ func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(s
 	}
 }
 
-// approvalEvalInterval throttles how often the approval resolver inspects the
+// approvalEvalInterval throttles how often the readLoop path inspects the
 // rendered screen. Rendering is cheap but the output stream is dominated by many
 // tiny cursor-addressed frames; sampling at this cadence keeps cost bounded while
 // staying well below approvalClearDebounce.
 const approvalEvalInterval = 100 * time.Millisecond
 
-// resolveApproval feeds the current rendered screen to the approval resolver,
-// throttled to approvalEvalInterval, and forwards any state transition it
-// reports (pending_approval on first sight of the prompt, working once it is
-// resolved). Called from readLoop only.
-func (s *Session) resolveApproval(data []byte) {
-	if s.approvalResolver == nil || s.onState == nil || s.screen == nil || len(data) == 0 {
+// evaluateApproval samples the rendered screen and applies any approval-state
+// transition the resolver reports. It runs on two paths: the readLoop output path
+// (throttle=true, so high-frequency frames don't re-render constantly) and a
+// scheduled recheck (throttle=false). The scheduled recheck is what lets the
+// pending_approval->working clear complete even when the approved command goes
+// quiet and emits no further PTY output.
+func (s *Session) evaluateApproval(now time.Time, throttle bool) {
+	if s.approvalResolver == nil || s.onState == nil || s.screen == nil {
 		return
 	}
-	now := time.Now()
-	if !s.lastApprovalEval.IsZero() && now.Sub(s.lastApprovalEval) < approvalEvalInterval {
+	// Never emit a transition for a session that has already exited; a late
+	// timer firing after exit must not resurrect a "working" state.
+	s.exitMu.RLock()
+	running := s.running
+	s.exitMu.RUnlock()
+	if !running {
+		return
+	}
+
+	s.approvalMu.Lock()
+	if throttle && !s.lastApprovalEval.IsZero() && now.Sub(s.lastApprovalEval) < approvalEvalInterval {
+		s.approvalMu.Unlock()
 		return
 	}
 	s.lastApprovalEval = now
-	text := s.screen.renderedText()
-	state, changed := s.approvalResolver.observe(text, now)
-	if changed {
-		s.stateMu.Lock()
-		s.detectorState = state
-		s.stateMu.Unlock()
-		s.onState(state)
+	signal := s.approvalResolver.observe(s.screen.renderedText(), now)
+	switch signal {
+	case approvalClearStarted:
+		s.scheduleApprovalRecheckLocked()
+	case approvalCleared:
+		s.stopApprovalTimerLocked()
 	}
+	s.approvalMu.Unlock()
+
+	switch signal {
+	case approvalArmedPending:
+		s.applyApprovalState(statePendingApproval)
+	case approvalCleared:
+		s.applyApprovalState(stateWorking)
+	}
+}
+
+func (s *Session) applyApprovalState(state string) {
+	s.stateMu.Lock()
+	s.detectorState = state
+	s.stateMu.Unlock()
+	s.onState(state)
+}
+
+// scheduleApprovalRecheckLocked arms a one-shot recheck a little past the
+// debounce window so the prompt-gone -> working clear fires without depending on
+// further PTY output. Caller holds approvalMu. The small extra margin guarantees
+// the recheck's now.Sub(clearedSince) has crossed approvalClearDebounce.
+func (s *Session) scheduleApprovalRecheckLocked() {
+	s.stopApprovalTimerLocked()
+	s.approvalTimer = time.AfterFunc(approvalClearDebounce+approvalEvalInterval, func() {
+		s.evaluateApproval(time.Now(), false)
+	})
+}
+
+func (s *Session) stopApprovalTimerLocked() {
+	if s.approvalTimer != nil {
+		s.approvalTimer.Stop()
+		s.approvalTimer = nil
+	}
+}
+
+func (s *Session) stopApprovalTimer() {
+	s.approvalMu.Lock()
+	s.stopApprovalTimerLocked()
+	s.approvalMu.Unlock()
 }
 
 func parseExitStatus(waitErr error) (int, string) {
@@ -308,6 +364,10 @@ func parseExitStatus(waitErr error) (int, string) {
 }
 
 func (s *Session) markExited(exitCode int, signal string) {
+	// Cancel any pending approval recheck before flipping running=false so a
+	// timer cannot fire a stale "working" against an exited session.
+	s.stopApprovalTimer()
+
 	s.exitMu.Lock()
 	defer s.exitMu.Unlock()
 

--- a/internal/pty/snapshot.go
+++ b/internal/pty/snapshot.go
@@ -3,6 +3,7 @@ package pty
 import (
 	"bytes"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/hinshun/vt10x"
@@ -189,6 +190,49 @@ func (v *virtualScreen) Snapshot() (screenSnapshot, bool) {
 		cursorY:       uint16(cursorY),
 		cursorVisible: view.CursorVisible(),
 	}, true
+}
+
+// renderedText returns the currently visible screen as plain text, one row per
+// line with trailing blanks trimmed. Unlike the raw output tail, this reflects
+// exactly what the user sees after vt10x resolves cursor-addressed redraws and
+// scrollback, which is what state detection (e.g. approval-prompt presence)
+// needs. Returns "" before any output has been observed.
+func (v *virtualScreen) renderedText() string {
+	if v == nil {
+		return ""
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if !v.wrote {
+		return ""
+	}
+
+	view := v.term
+	view.Lock()
+	defer view.Unlock()
+
+	cols, rows := view.Size()
+	if cols <= 0 || rows <= 0 {
+		return ""
+	}
+
+	var out strings.Builder
+	var line strings.Builder
+	for y := 0; y < rows; y++ {
+		line.Reset()
+		for x := 0; x < cols; x++ {
+			ch := view.Cell(x, y).Char
+			if ch == 0 {
+				ch = ' '
+			}
+			line.WriteRune(ch)
+		}
+		out.WriteString(strings.TrimRight(line.String(), " "))
+		out.WriteByte('\n')
+	}
+	return out.String()
 }
 
 func renderVisibleFrame(view vt10x.View, cols, rows, cursorX, cursorY int, cursorVisible bool) []byte {


### PR DESCRIPTION
## Why

Two related "the attention light lies to you" bugs:

1. **Approval doesn't clear the light.** No Claude/Codex hook fires when the user *approves* a permission request. The onset is hook-driven (`PermissionRequest`/`permission_request` → `pending_approval`), but the only signal back to `working` is `PostToolUse`, which fires *after the approved tool finishes*. So a session sat in the flashing "needs you" state for the entire duration of the approved command — exactly when it didn't need you.
2. **Codex turns end purple.** The stop-time classifier (`codex exec`) refuses to run outside a trusted git dir, so a Codex turn ending in e.g. `/tmp` failed to classify and fell back to `unknown` (purple).

## What

**Approval → working, off the rendered PTY screen** (the interaction is only visible in the PTY):
- New `approvalResolver` (`internal/pty/approval_resolver.go`): arms on first sight of the approval prompt and emits `working` once the prompt has been gone for a 750ms debounce (so a repaint or a chained multi-step approval doesn't flap).
- It re-emits `pending_approval` on arm to sync the **pty-worker's own dedup view**. The worker only forwards a state when it differs from its last PTY-emitted state, and the onset hook sets pending *behind the worker's back* — without the re-emit, a chained second approval's `working` clear looks unchanged and gets dropped. (This was the day-long bug.)
- Detection uses the vt10x `virtualScreen.renderedText()` (what the user actually sees), not the raw byte tail — the tail keeps scrollback and re-matches the stale prompt.
- Wired via a new `HasApprovalResolver` capability (claude + codex), env-overridable like the other caps. Codex `ShouldApplyPTYState` now allows **only** the single `pending_approval → working` transition; all other live state stays hook-owned.

**Codex stop-classifier fixes** (`internal/classifier`):
- `--skip-git-repo-check` — classify regardless of the session's cwd (the actual unknown-state fix).
- `--ignore-user-config` — don't inherit the user's `config.toml`: no MCP servers (latency, auth noise, tool-schema tokens) or other agent settings. Auth is read separately and still works. (`-c mcp_servers={}` merges and does nothing; this is the clean global disable.)
- `-c features.shell_tool=false` — the classifier only emits a verdict, never runs commands.
- Single model `gpt-5.4-mini` (low effort), fallback list removed. Override via `ATTN_CODEX_CLASSIFIER_MODEL`. (`gpt-5.3-codex` isn't available on a ChatGPT-account login.)
- Net: ~26.4k → ~22.5k input tokens per classification, no honeycomb MCP startup.

## Testing

- `go build ./...` clean; `go test ./internal/classifier ./internal/pty ./internal/agent` green.
- `approval_resolver_test.go`: arm emits pending, clear-after-debounce emits working, repaint resets the debounce, no transition without a prompt.
- `daemon_policy_test.go`: codex applies `working` to clear pending, ignores every other transition out of pending.
- `classifier_test.go`: single invocation with the expected model and that the args carry `--skip-git-repo-check`, `--ignore-user-config`, `features.shell_tool=false`.
- Resolver verified live earlier for both Claude and Codex (fast PTY-driven pending→working, not a slow post-tool one). Codex classifier verified at the CLI level (exact code-produced invocation returns the right verdict with 0 MCP lines).

## Notes for review
- macOS-only, per repo policy.
- CHANGELOG updated under `## [2026-06-03]`.
- The classifier runs in the **daemon** process (needs a daemon restart to exercise end-to-end); the resolver runs in the per-session **worker** (new sessions pick it up automatically).