### PR TITLE
Tile polish: title docked tiles from content + focus tile on select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,12 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 
 ## [2026-06-03]
 
+### Changed
+- **Docked tiles read a little nicer.** A markdown tile's header now shows the document's title (its first heading) rather than the file name, falling back to the file name when there's no heading. And when you open a tile-only workspace, the keyboard lands on the tile right away, so the arrow keys scroll it without an extra click.
+
 ### Fixed
 - **Approving a permission request clears the attention light right away.** When an agent is blocked on a permission prompt and you approve it, the session now returns to "working" within about a second — even while the approved command keeps running, and even for a second prompt back-to-back. It used to stay in the flashing "needs you" state for the entire duration of the approved tool, which defeated the point of the light. Works for both Claude and Codex.
 - **Codex sessions no longer get stuck in the purple "unknown" state.** When a Codex turn finished outside a git repository (for example in `/tmp`), attn could not classify it and fell back to "unknown." Codex sessions now settle into the correct done/waiting state regardless of where they run. The end-of-turn check is also leaner and quieter — it no longer loads your Codex MCP servers or tools.
-
----
 
 ## [2026-06-02]
 

--- a/app/scripts/real-app-harness/scenario-tile-only-workspace-select.mjs
+++ b/app/scripts/real-app-harness/scenario-tile-only-workspace-select.mjs
@@ -167,11 +167,15 @@ async function main() {
     const afterSelect = await waitForWorkspaceUi(
       client,
       workspaceId,
-      (state) => state?.active === true && state.sessionVisible === true,
-      'tile-only workspace to become the active, visible workspace after selection',
+      (state) => state?.active === true && state.sessionVisible === true && state.tileBodyFocused === true,
+      'tile-only workspace to become active, visible, and focus its tile body after selection',
     );
     if (!afterSelect.tileIds.includes(tileId) || afterSelect.paneCount !== 0) {
       throw new Error(`Selected tile-only workspace lost its tile or grew panes: ${JSON.stringify(afterSelect, null, 2)}`);
+    }
+    // Title is derived from the markdown H1, not the file basename.
+    if (!afterSelect.tileTitles?.includes('Tile only notes')) {
+      throw new Error(`Tile header did not derive its title from the markdown H1: ${JSON.stringify(afterSelect, null, 2)}`);
     }
 
     const summary = {

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.tileOnly.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.tileOnly.test.tsx
@@ -78,4 +78,15 @@ describe('SessionTerminalWorkspace tile-only (sessionless) rendering', () => {
     // real layout renders the tile surface inside the panes container.
     expect(workspaceRoot?.querySelector('.session-terminal-panes')).not.toBeNull();
   });
+
+  // With no terminal to own focus, selecting (showing) a tile-only workspace
+  // should focus the tile's scrollable body so keyboard scrolling works at once.
+  it('focuses the tile body so the tile-only workspace is keyboard-scrollable', () => {
+    const { container } = renderTileOnly();
+
+    const body = container.querySelector('.workspace-dock-tile-body');
+    expect(body).not.toBeNull();
+    expect(body).toHaveAttribute('tabindex', '-1');
+    expect(document.activeElement).toBe(body);
+  });
 });

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.css
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.css
@@ -71,6 +71,12 @@
   line-height: 1.55;
 }
 
+/* The body is focused programmatically (tabIndex=-1) so a tile-only workspace
+   can scroll by keyboard on select; it is not a tab stop, so suppress the ring. */
+.workspace-dock-tile-body:focus {
+  outline: none;
+}
+
 /* Non-content states (loading, empty file, unsupported kind, read error). */
 .workspace-dock-tile-message {
   color: var(--color-text-tertiary);

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { invoke } from '@tauri-apps/api/core';
-import { WorkspaceDockTile, resolveMarkdownTarget } from './WorkspaceDockTile';
+import { WorkspaceDockTile, deriveTileTitle, resolveMarkdownTarget } from './WorkspaceDockTile';
+import type { TileLeaf } from '../../types/workspace';
 
 const opener = vi.hoisted(() => ({
   openUrl: vi.fn(async () => {}),
@@ -106,5 +107,57 @@ describe('WorkspaceDockTile Markdown rendering', () => {
       'setup',
       'setup-1',
     ]);
+  });
+});
+
+describe('deriveTileTitle', () => {
+  const markdownTile: TileLeaf = {
+    type: 'tile',
+    tileId: 'tile-markdown',
+    tileKind: 'markdown',
+    tileParams: '/tmp/project/notes.md',
+  };
+
+  it('uses the H1 heading when the document leads with one', () => {
+    expect(deriveTileTitle(markdownTile, { path: '/tmp/project/notes.md', content: '# Project notes\n\nbody' }))
+      .toBe('Project notes');
+  });
+
+  it('strips a heading marker of any level and inline markdown', () => {
+    expect(deriveTileTitle(markdownTile, { path: '/tmp/project/notes.md', content: '## **Setup** `steps`' }))
+      .toBe('Setup steps');
+  });
+
+  it('falls back to the first non-empty line when there is no heading', () => {
+    expect(deriveTileTitle(markdownTile, { path: '/tmp/project/notes.md', content: '\n\nJust some plain notes here' }))
+      .toBe('Just some plain notes here');
+  });
+
+  it('skips a closed YAML frontmatter block', () => {
+    const content = '---\ntitle: ignored\n---\n# Real title\n';
+    expect(deriveTileTitle(markdownTile, { path: '/tmp/project/notes.md', content })).toBe('Real title');
+  });
+
+  it('keeps a leading horizontal rule as content when there is no closing fence', () => {
+    expect(deriveTileTitle(markdownTile, { path: '/tmp/project/notes.md', content: '---\nstill text' }))
+      .toBe('still text');
+  });
+
+  it('truncates a very long title with an ellipsis', () => {
+    const long = `# ${'word '.repeat(40).trim()}`;
+    const title = deriveTileTitle(markdownTile, { path: '/tmp/project/notes.md', content: long });
+    expect(title.endsWith('…')).toBe(true);
+    expect(title.length).toBeLessThanOrEqual(80);
+  });
+
+  it('falls back to the basename for empty or error content', () => {
+    expect(deriveTileTitle(markdownTile, { path: '/tmp/project/notes.md', content: '   \n  ' })).toBe('notes.md');
+    expect(deriveTileTitle(markdownTile, { path: '/tmp/project/notes.md', content: '', error: 'boom' }))
+      .toBe('notes.md');
+  });
+
+  it('uses the basename before content loads, and tile kind without a path', () => {
+    expect(deriveTileTitle(markdownTile, undefined)).toBe('notes.md');
+    expect(deriveTileTitle({ type: 'tile', tileId: 'tile-x', tileKind: 'markdown' }, undefined)).toBe('markdown');
   });
 });

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
@@ -1,5 +1,5 @@
 import { createElement, isValidElement, useEffect } from 'react';
-import type { PointerEvent as ReactPointerEvent, ReactNode } from 'react';
+import type { PointerEvent as ReactPointerEvent, ReactNode, Ref } from 'react';
 import ReactMarkdown from 'react-markdown';
 import type { Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -12,6 +12,60 @@ function basename(path: string): string {
   const trimmed = path.replace(/\/+$/, '');
   const segment = trimmed.split('/').pop();
   return segment && segment.length > 0 ? segment : trimmed;
+}
+
+const MAX_TILE_TITLE_LENGTH = 80;
+
+// Reduce a single line of Markdown to readable plain text for a tile header:
+// drop link/image syntax (keep the label) and emphasis/code markers, collapse
+// whitespace. Intentionally shallow — this titles a header, it doesn't render.
+function stripInlineMarkdown(text: string): string {
+  return text
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[*_`~]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Title a markdown tile from its content: the first meaningful line, with a
+// leading ATX heading marker stripped. For the common `# Title` first line this
+// yields the H1 text; otherwise it yields the beginning of the text. Returns
+// null when the content carries no usable line (caller falls back to basename).
+function markdownTitle(markdown: string): string | null {
+  const lines = markdown.split('\n');
+  let i = 0;
+  // Skip a leading YAML frontmatter block, but only when it is actually closed
+  // (a bare leading `---` is otherwise a horizontal rule we should keep).
+  if (lines[0]?.trim() === '---') {
+    let close = 1;
+    while (close < lines.length && lines[close].trim() !== '---') close += 1;
+    if (close < lines.length) i = close + 1;
+  }
+  for (; i < lines.length; i += 1) {
+    const raw = lines[i].trim();
+    if (!raw) continue;
+    // Skip a thematic break (`---`, `***`, `___`) — a lone leading rule, or an
+    // unclosed frontmatter fence, should not become the title.
+    if (/^(-{3,}|\*{3,}|_{3,})$/.test(raw.replace(/\s/g, ''))) continue;
+    const withoutHeading = raw.replace(/^#{1,6}\s+/, '').replace(/\s+#*$/, '');
+    const cleaned = stripInlineMarkdown(withoutHeading);
+    if (!cleaned) continue;
+    return cleaned.length > MAX_TILE_TITLE_LENGTH
+      ? `${cleaned.slice(0, MAX_TILE_TITLE_LENGTH - 1).trimEnd()}…`
+      : cleaned;
+  }
+  return null;
+}
+
+// Display title for a tile header. Prefers a title derived from loaded markdown
+// content, falling back to the file basename and finally the tile kind.
+export function deriveTileTitle(tile: TileLeaf, content?: TileContentState): string {
+  if (tile.tileKind === 'markdown' && content && !content.error) {
+    const fromContent = markdownTitle(content.content);
+    if (fromContent) return fromContent;
+  }
+  const path = content?.path || tile.tileParams || '';
+  return path ? basename(path) : tile.tileKind;
 }
 
 type MarkdownTarget =
@@ -215,6 +269,10 @@ interface WorkspaceDockTileProps {
   onClose: () => void;
   onHeaderPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
   onRequestContent: (workspaceId: string, tileId: string) => void;
+  // Handle to the scrollable body. A tile-only workspace has no terminal to
+  // focus on select, so the workspace focuses this element to enable keyboard
+  // scrolling. Left undefined for tiles that never receive select-time focus.
+  bodyRef?: Ref<HTMLDivElement>;
 }
 
 export function WorkspaceDockTile({
@@ -226,6 +284,7 @@ export function WorkspaceDockTile({
   onClose,
   onHeaderPointerDown,
   onRequestContent,
+  bodyRef,
 }: WorkspaceDockTileProps) {
   // Pull the current content on mount and whenever the tile retargets a new
   // file. Live-reload updates then arrive as broadcasts (no re-request needed).
@@ -234,7 +293,7 @@ export function WorkspaceDockTile({
   }, [workspaceId, tile.tileId, tile.tileParams, onRequestContent]);
 
   const path = content?.path || tile.tileParams || '';
-  const title = path ? basename(path) : tile.tileKind;
+  const title = deriveTileTitle(tile, content);
 
   return (
     <div className={`workspace-dock-tile ${dragging ? 'workspace-dock-tile--dragging' : ''}`.trim()}>
@@ -255,7 +314,7 @@ export function WorkspaceDockTile({
           ×
         </button>
       </div>
-      <div className="workspace-dock-tile-body">
+      <div className="workspace-dock-tile-body" ref={bodyRef} tabIndex={-1}>
         {tile.tileKind === 'markdown' ? (
           <MarkdownBody content={content} allowLocalTargets={allowLocalTargets} />
         ) : (

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -150,6 +150,9 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     const [dockTarget, setDockTarget] = useState<DockTarget | null>(null);
     const [ghostPos, setGhostPos] = useState<{ x: number; y: number } | null>(null);
     const tileDragCleanupRef = useRef<(() => void) | null>(null);
+    // Scrollable body of the first docked tile, focused on select when the
+    // workspace has no terminal to own focus (see the focus effect below).
+    const firstTileBodyRef = useRef<HTMLDivElement | null>(null);
     const draggingSplitRef = useRef<string | null>(null);
     const activePaneIdRef = useRef(activePaneId);
     const isActiveSessionRef = useRef(isActiveSession);
@@ -208,6 +211,13 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       walk(workspace.layoutTree);
       return map;
     }, [workspace.layoutTree]);
+
+    // First tile in tree order (DFS-left). Used only to route the select-time
+    // focus ref to a single tile when the workspace is fully tile-only.
+    const firstTileId = useMemo(
+      () => (tileLeafById.size > 0 ? tileLeafById.keys().next().value ?? null : null),
+      [tileLeafById],
+    );
 
     const runtimePanes = useMemo(() => ([
       ...agentPanes.filter((pane) => !pane.status || pane.status === 'ready').map((pane) => {
@@ -369,12 +379,23 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       runtime.focusPane(activePaneId, 0);
     }, [activePaneId, runtime]);
 
+    // A fully tile-only workspace has no terminal to own focus. Focus the first
+    // tile's scrollable body so keyboard scrolling works the moment it is shown.
+    // preventScroll keeps the body's own scroll position from jumping on focus.
+    const focusFirstTile = useCallback(() => {
+      firstTileBodyRef.current?.focus({ preventScroll: true });
+    }, []);
+
     useEffect(() => {
       if (!sessionVisible) {
         return;
       }
-      focusActivePane();
-    }, [activePaneId, focusActivePane, focusRequestToken, isActiveSession, isSessionViewVisible, workspaceId, sessionVisible]);
+      if (activePaneId) {
+        focusActivePane();
+        return;
+      }
+      focusFirstTile();
+    }, [activePaneId, focusActivePane, focusFirstTile, focusRequestToken, isActiveSession, isSessionViewVisible, workspaceId, sessionVisible]);
 
     // After relaunch, first-show, or split topology changes, the terminal can briefly keep
     // stale narrow geometry from the previous layout. Re-fitting immediately and then
@@ -617,6 +638,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
               onClose={() => onUndockTile?.(tileLeaf.tileId)}
               onHeaderPointerDown={(event) => beginLeafDrag(tileLeaf.tileId, event)}
               onRequestContent={onRequestTileContent ?? (() => {})}
+              bodyRef={tileLeaf.tileId === firstTileId ? firstTileBodyRef : undefined}
             />
           </div>
         );
@@ -629,6 +651,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       draggingLeafId,
       onUndockTile,
       tileLeafById,
+      firstTileId,
       tileContents,
       allowLocalTileTargets,
       onRequestTileContent,

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1416,6 +1416,17 @@ export function useUiAutomationBridge({
         const paneCount = surface
           ? surface.querySelectorAll('[data-pane-kind="agent"]').length
           : 0;
+        const tileTitles = surface
+          ? Array.from(surface.querySelectorAll('.workspace-dock-tile-title'))
+            .map((node) => node.textContent?.trim() || '')
+          : [];
+        const activeBody = document.activeElement;
+        const tileBodyFocused = Boolean(
+          surface
+            && activeBody instanceof HTMLElement
+            && activeBody.classList.contains('workspace-dock-tile-body')
+            && surface.contains(activeBody),
+        );
         return {
           workspaceId,
           rendered: Boolean(surface),
@@ -1423,6 +1434,8 @@ export function useUiAutomationBridge({
           sessionVisible: surface?.getAttribute('data-session-visible') === '1',
           tileIds,
           paneCount,
+          tileTitles,
+          tileBodyFocused,
         };
       }
       case 'location_picker_get_state':

--- a/docs/plans/2026-06-01-uniform-leaf-docking.md
+++ b/docs/plans/2026-06-01-uniform-leaf-docking.md
@@ -234,9 +234,10 @@ gap; figgy was right.)
 - [x] Render loop builds a `TerminalWorkspaceState` for zero-session workspaces straight from the daemon's broadcast layout (`workspaceSnapshotFromDaemonWorkspace`, fallback only when no session carries the layout). `SessionTerminalWorkspace` already renders a tiles-only tree (no agent panes) — no component change needed.
 - [x] Tests: controller unit + `SessionTerminalWorkspace.tileOnly` render test + `App.sessionlessWorkspace` integration (reveal→select→active+tile). Real-app harness scenario `tile-only-workspace-select` (dock tile via `attn open`, close last pane, select by id, assert active + tile rendered) added to the serial matrix. New automation verbs `select_workspace` / `get_workspace_ui_state` mirror the sidebar/⌘1–9 path (no daemon protocol change).
 
-Deferred to a small follow-up (genuinely cosmetic):
-- [ ] Tile header title from content: markdown H1 → beginning of text → basename fallback (`WorkspaceDockTile.tsx:237`). A sessionless workspace already renders fine; the tile just shows its basename until this lands.
-- [ ] Focus a tile on select for fully tile-only workspaces (extend the AGENTS.md terminal-focus rule with a "no terminal" branch). Tiles are not interactive focus targets today; selection renders the layout without stealing focus, which is acceptable for v1.
+### PR D — Tile polish (title from content + focus on select) ✅
+- [x] Tile header title from content: `deriveTileTitle(tile, content)` in `WorkspaceDockTile.tsx` returns the first meaningful markdown line with a leading ATX heading marker stripped (so `# Title` → "Title"), skipping closed YAML frontmatter and lone thematic breaks, truncating past 80 chars; falls back to the file basename, then the tile kind. Unit-tested (8 cases).
+- [x] Focus a tile on select for fully tile-only workspaces: `.workspace-dock-tile-body` is now `tabIndex=-1` (programmatically focusable, not a tab stop); `SessionTerminalWorkspace`'s select-time focus effect focuses the first tile's body via `firstTileBodyRef` when there is no agent pane (`activePaneId === ''`). Mixed pane+tile workspaces are unaffected (a real pane keeps focus). The terminal-focus path is untouched.
+- [x] Tests: `deriveTileTitle` unit tests; `SessionTerminalWorkspace.tileOnly` asserts the body is focused on render. Real-app scenario `tile-only-workspace-select` extended to assert the header shows the markdown H1 and the tile body is focused after select (new `tileTitles` / `tileBodyFocused` fields on the `get_workspace_ui_state` automation verb).
 
 ## Decisions
 


### PR DESCRIPTION
Two tile-only workspace polish items from the uniform-leaf-docking plan (the genuinely-cosmetic follow-ups deferred from #257).

## What changed

- **Docked tile titles come from the document.** A markdown tile header now derives its title from the document's first meaningful line — a leading ATX heading marker is stripped (so `# Title` → "Title"), closed YAML frontmatter and lone thematic breaks (`---`) are skipped, and very long titles truncate at 80 chars. Falls back to the file basename, then the tile kind. `deriveTileTitle` is pure and unit-tested.
- **Selecting a tile-only workspace focuses the tile.** A fully tile-only workspace (no agent pane) has no terminal to own focus, so it now focuses the first tile's scrollable body on select — the arrow keys scroll it immediately, no extra click. The body is `tabIndex=-1` (programmatically focusable, not a tab stop). The terminal-focus path is untouched, and mixed pane+tile workspaces still keep a real pane focused.

## Testing

- 540 frontend tests pass (+9: 8 `deriveTileTitle` unit cases, 1 focus assertion in the tile-only render test). `tsc` clean.
- **Verified end-to-end in the packaged dev app.** The `tile-only-workspace-select` real-app scenario now asserts the header shows the markdown H1 (`tileTitles: ["Tile only notes"]`, not `notes.md`) and the tile body is focused after select (`tileBodyFocused: true`, and `false` before select). New `tileTitles` / `tileBodyFocused` fields on the `get_workspace_ui_state` automation verb (frontend-only, no protocol bump).

CHANGELOG (`[2026-06-03]`) and the plan doc (new "PR D" section) updated.