### PR TITLE
feat(rename): rename workspaces and sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 ## [2026-06-03]
 
 ### Added
+- **Rename workspaces and sessions.** Hover a workspace or session in the sidebar and click the pencil to give it a name that means something to you. When a workspace has more than one pane, each pane header has the same pencil so you can rename its session right where you're looking. A small popup opens with the current name selected — type to replace it, or press → to keep it and append. Renames stick: they survive reconnects and reloading a session.
 - **Move panes and tiles between workspaces.** Drag a pane or docked tile toward another workspace in the sidebar to switch to it, then drop on the target layout for exact placement. Dropping directly on the sidebar workspace moves it to the left side of that workspace.
 
 ### Changed

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -387,6 +387,8 @@ function App() {
     sendRefreshPRs,
     sendRegisterWorkspace,
     sendUnregisterWorkspace,
+    sendRenameSession,
+    sendRenameWorkspace,
     sendUnregisterSession,
     sendSetSetting,
     sendCreateWorktree,
@@ -510,6 +512,8 @@ function App() {
         sendRefreshPRs={sendRefreshPRs}
         sendRegisterWorkspace={sendRegisterWorkspace}
         sendUnregisterWorkspace={sendUnregisterWorkspace}
+        sendRenameSession={sendRenameSession}
+        sendRenameWorkspace={sendRenameWorkspace}
         sendUnregisterSession={sendUnregisterSession}
         sendSetSetting={sendSetSetting}
         sendCreateWorktree={sendCreateWorktree}
@@ -600,6 +604,8 @@ interface AppContentProps {
   sendRefreshPRs: ReturnType<typeof useDaemonSocket>['sendRefreshPRs'];
   sendRegisterWorkspace: ReturnType<typeof useDaemonSocket>['sendRegisterWorkspace'];
   sendUnregisterWorkspace: ReturnType<typeof useDaemonSocket>['sendUnregisterWorkspace'];
+  sendRenameSession: ReturnType<typeof useDaemonSocket>['sendRenameSession'];
+  sendRenameWorkspace: ReturnType<typeof useDaemonSocket>['sendRenameWorkspace'];
   sendUnregisterSession: ReturnType<typeof useDaemonSocket>['sendUnregisterSession'];
   sendSetSetting: ReturnType<typeof useDaemonSocket>['sendSetSetting'];
   sendCreateWorktree: ReturnType<typeof useDaemonSocket>['sendCreateWorktree'];
@@ -685,6 +691,8 @@ function AppContent({
   sendRefreshPRs,
   sendRegisterWorkspace,
   sendUnregisterWorkspace,
+  sendRenameSession,
+  sendRenameWorkspace,
   sendUnregisterSession,
   sendSetSetting,
   sendCreateWorktree,
@@ -2810,6 +2818,8 @@ sendFetchPRDetails,
           mutedExpanded={sidebarMutedExpanded}
           onMutedExpandedChange={setSidebarMutedExpanded}
           onMuteWorkspace={sendMuteWorkspace}
+          onRenameSession={sendRenameSession}
+          onRenameWorkspace={sendRenameWorkspace}
           showSessionless={showSessionlessWorkspaces}
           onToggleShowSessionless={handleToggleShowSessionlessWorkspaces}
           leafDrag={leafWorkspaceDrag ? {
@@ -2881,6 +2891,7 @@ sendFetchPRDetails,
                         void handleClosePane(paneSessionId, paneId).catch(console.error);
                       }
                     }}
+                    onRenameSession={sendRenameSession}
                     onResizeSplit={(splitId, ratio) => {
                       return sendWorkspaceSetSplitRatio(workspace.id, splitId, ratio);
                     }}

--- a/app/src/components/RenamePopover.css
+++ b/app/src/components/RenamePopover.css
@@ -1,0 +1,74 @@
+.rename-popover {
+  position: fixed;
+  z-index: 1000;
+  width: 240px;
+  padding: 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-panel);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.34);
+}
+
+.rename-popover-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-input, rgba(255, 255, 255, 0.04));
+  color: var(--color-text-primary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-sm, 13px);
+  line-height: 1.4;
+  outline: none;
+}
+
+.rename-popover-input:focus {
+  border-color: var(--color-accent, #5b8cff);
+}
+
+.rename-popover-error {
+  margin-top: 6px;
+  color: var(--color-danger, #ff6b6b);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+}
+
+.rename-popover-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.rename-popover-btn {
+  padding: 5px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  line-height: 1;
+}
+
+.rename-popover-btn:hover:not(:disabled) {
+  color: var(--color-text-primary);
+}
+
+.rename-popover-btn.save {
+  border-color: var(--color-accent, #5b8cff);
+  background: var(--color-accent, #5b8cff);
+  color: #fff;
+}
+
+.rename-popover-btn.save:hover:not(:disabled) {
+  filter: brightness(1.08);
+  color: #fff;
+}
+
+.rename-popover-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/app/src/components/RenamePopover.test.tsx
+++ b/app/src/components/RenamePopover.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from '../test/utils';
+import { describe, expect, it, vi } from 'vitest';
+import { RenamePopover } from './RenamePopover';
+
+function renderPopover(overrides: Partial<Parameters<typeof RenamePopover>[0]> = {}) {
+  const onSubmit = overrides.onSubmit ?? vi.fn(async () => {});
+  const onClose = overrides.onClose ?? vi.fn();
+  render(
+    <RenamePopover
+      initialValue="original-name"
+      label="Rename session"
+      anchor={{ top: 100, left: 40 }}
+      onSubmit={onSubmit}
+      onClose={onClose}
+    />,
+  );
+  return { onSubmit, onClose };
+}
+
+describe('RenamePopover', () => {
+  it('focuses and selects the whole name so typing replaces it', () => {
+    renderPopover();
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(document.activeElement).toBe(input);
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe('original-name'.length);
+  });
+
+  it('submits the trimmed new value on Enter and then closes', async () => {
+    const onSubmit = vi.fn(async () => {});
+    const onClose = vi.fn();
+    renderPopover({ onSubmit, onClose });
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '  renamed  ' } });
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Enter' });
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('renamed'));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it('rejects an empty name without calling onSubmit', () => {
+    const onSubmit = vi.fn(async () => {});
+    renderPopover({ onSubmit });
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Enter' });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText('Name cannot be empty')).toBeInTheDocument();
+  });
+
+  it('closes without submitting when the name is unchanged', () => {
+    const onSubmit = vi.fn(async () => {});
+    const onClose = vi.fn();
+    renderPopover({ onSubmit, onClose });
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Enter' });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    renderPopover({ onClose });
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/RenamePopover.tsx
+++ b/app/src/components/RenamePopover.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
+import './RenamePopover.css';
+
+interface RenamePopoverProps {
+  /** Current name, shown pre-selected so typing replaces and ArrowRight appends. */
+  initialValue: string;
+  /** Accessible label / header, e.g. "Rename session". */
+  label: string;
+  /** Viewport-relative anchor; the popover opens just below it. */
+  anchor: { top: number; left: number };
+  onSubmit: (value: string) => Promise<void>;
+  onClose: () => void;
+}
+
+const VIEWPORT_MARGIN = 8;
+
+export function RenamePopover({ initialValue, label, anchor, onSubmit, onClose }: RenamePopoverProps) {
+  const [value, setValue] = useState(initialValue);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [position, setPosition] = useState(anchor);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEscapeStack(onClose, true);
+
+  // Select-all on mount: typing replaces the whole name, ArrowRight collapses to
+  // the end to append, ArrowLeft to the start — all native input behavior.
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    input.focus();
+    input.select();
+  }, []);
+
+  // Keep the popover on-screen by clamping against the viewport once measured.
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    let top = anchor.top;
+    let left = anchor.left;
+    if (left + rect.width > window.innerWidth - VIEWPORT_MARGIN) {
+      left = Math.max(VIEWPORT_MARGIN, window.innerWidth - rect.width - VIEWPORT_MARGIN);
+    }
+    if (top + rect.height > window.innerHeight - VIEWPORT_MARGIN) {
+      top = Math.max(VIEWPORT_MARGIN, anchor.top - rect.height - 8);
+    }
+    setPosition({ top, left });
+  }, [anchor]);
+
+  // Dismiss on outside click. Deferred a tick so the click that opened the
+  // popover doesn't immediately close it.
+  useEffect(() => {
+    const handleMouseDown = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const id = window.setTimeout(() => document.addEventListener('mousedown', handleMouseDown), 0);
+    return () => {
+      window.clearTimeout(id);
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, [onClose]);
+
+  const handleSubmit = async () => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setError('Name cannot be empty');
+      return;
+    }
+    if (trimmed === initialValue.trim()) {
+      onClose();
+      return;
+    }
+    setIsSaving(true);
+    setError(null);
+    try {
+      await onSubmit(trimmed);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Rename failed');
+      setIsSaving(false);
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      void handleSubmit();
+    }
+    // Escape is handled by useEscapeStack (capture phase).
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="rename-popover"
+      style={{ top: position.top, left: position.left }}
+      role="dialog"
+      aria-label={label}
+      onKeyDown={handleKeyDown}
+    >
+      <input
+        ref={inputRef}
+        className="rename-popover-input"
+        value={value}
+        onChange={(event) => {
+          setValue(event.target.value);
+          if (error) setError(null);
+        }}
+        disabled={isSaving}
+        spellCheck={false}
+        aria-label={label}
+      />
+      {error ? <div className="rename-popover-error">{error}</div> : null}
+      <div className="rename-popover-actions">
+        <button
+          type="button"
+          className="rename-popover-btn cancel"
+          onClick={onClose}
+          disabled={isSaving}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="rename-popover-btn save"
+          onClick={handleSubmit}
+          disabled={isSaving || !value.trim()}
+        >
+          {isSaving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -233,6 +233,8 @@
 }
 
 .workspace-pane-title {
+  flex: 1;
+  min-width: 0;
   color: var(--color-text-secondary);
   font-size: var(--font-size-xs);
   font-weight: 600;
@@ -241,6 +243,33 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.workspace-pane-rename-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--color-text-dimmed);
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 0.1s, color 0.1s;
+}
+
+.workspace-pane-header:hover .workspace-pane-rename-btn,
+.workspace-pane-header:focus-within .workspace-pane-rename-btn {
+  opacity: 1;
+}
+
+.workspace-pane-rename-btn:hover {
+  color: var(--color-text-primary);
 }
 
 .workspace-pane-body {

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { GhosttyTerminal, type GhosttyTerminalHandle } from '../GhosttyTerminal';
+import { RenamePopover } from '../RenamePopover';
 import { useShortcut } from '../../shortcuts';
 import {
   getNormalizedPaneBounds,
@@ -101,6 +102,7 @@ interface SessionTerminalWorkspaceProps {
   onSplitPane: (targetPaneId: string, direction: TerminalSplitDirection) => void;
   onClosePane: (paneId: string) => void;
   onFocusPane: (paneId: string) => void;
+  onRenameSession?: (sessionId: string, label: string) => Promise<void>;
   onZoomModeChange?: (zoomed: boolean) => void;
   onNavigateOutOfSession: (direction: TerminalNavigationDirection) => void;
   onResizeSplit?: (splitId: string, ratio: number) => Promise<unknown> | void;
@@ -140,6 +142,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     onSplitPane,
     onClosePane,
     onFocusPane,
+    onRenameSession,
     onZoomModeChange,
     onNavigateOutOfSession,
     onResizeSplit,
@@ -157,6 +160,11 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
   }, ref) {
     const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null);
     const [zoomedPaneId, setZoomedPaneId] = useState<string | null>(null);
+    const [renamePane, setRenamePane] = useState<{
+      sessionId: string;
+      name: string;
+      anchor: { top: number; left: number };
+    } | null>(null);
     // Live, optimistic split ratios while dragging a divider. Reconciled against
     // the daemon layout once it echoes the persisted (locked) ratio back.
     const [ratioOverrides, setRatioOverrides] = useState<Map<string, number>>(() => new Map());
@@ -628,6 +636,28 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
               title={showPaneHeader ? 'Drag to move' : undefined}
             >
               {showPaneHeader ? <span className="workspace-pane-title">{paneTitle}</span> : null}
+              {showPaneHeader && onRenameSession ? (
+                <button
+                  type="button"
+                  className="workspace-pane-rename-btn"
+                  data-testid={`rename-pane-${agentPane.id}`}
+                  // Stop the header's pointerdown drag from starting on the button.
+                  onPointerDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    const rect = event.currentTarget.getBoundingClientRect();
+                    setRenamePane({
+                      sessionId: agentPane.sessionId,
+                      name: paneTitle,
+                      anchor: { top: rect.bottom + 4, left: rect.left },
+                    });
+                  }}
+                  title="Rename session"
+                  aria-label={`Rename session ${paneTitle}`}
+                >
+                  ✎
+                </button>
+              ) : null}
             </div>
             <div className="workspace-pane-body">
               {isPaneStarting || isPaneFailed ? (
@@ -909,6 +939,16 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
           >
             {draggingLeafLabel}
           </div>
+        )}
+        {renamePane && onRenameSession && (
+          <RenamePopover
+            key={renamePane.sessionId}
+            initialValue={renamePane.name}
+            label="Rename session"
+            anchor={renamePane.anchor}
+            onSubmit={(value) => onRenameSession(renamePane.sessionId, value)}
+            onClose={() => setRenamePane(null)}
+          />
         )}
       </div>
     );

--- a/app/src/components/Sidebar.test.tsx
+++ b/app/src/components/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { Sidebar, type FooterShortcut } from './Sidebar';
 import { buildWorkspaceViewModels, type WorkspaceWithSessions } from '../utils/workspaceViewModels';
@@ -394,5 +394,44 @@ describe('Sidebar', () => {
     expect(screen.getByTestId('sidebar-muted-workspace-workspace-/repo/quiet')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Unmute workspace quiet' }));
     expect(onMuteWorkspace).toHaveBeenCalledWith('workspace-/repo/quiet', undefined);
+  });
+
+  it('renames a session through the pencil trigger and popover', async () => {
+    const sessions: TestSession[] = [{ id: 's1', label: 'claude', state: 'idle', agent: 'claude' }];
+    const onRenameSession = vi.fn(async () => {});
+    render(
+      <Sidebar
+        {...baseProps}
+        onRenameSession={onRenameSession}
+        {...buildSidebarData(sessions)}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('rename-session-s1'));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe('claude');
+    fireEvent.change(input, { target: { value: 'renamed-session' } });
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Enter' });
+
+    await waitFor(() => expect(onRenameSession).toHaveBeenCalledWith('s1', 'renamed-session'));
+  });
+
+  it('renames a workspace through the pencil trigger and popover', async () => {
+    const sessions: TestSession[] = [{ id: 's1', label: 'claude', state: 'idle', agent: 'claude' }];
+    const onRenameWorkspace = vi.fn(async () => {});
+    render(
+      <Sidebar
+        {...baseProps}
+        onRenameWorkspace={onRenameWorkspace}
+        {...buildSidebarData(sessions)}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('rename-workspace-workspace-s1'));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'renamed-workspace' } });
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Enter' });
+
+    await waitFor(() => expect(onRenameWorkspace).toHaveBeenCalledWith('workspace-s1', 'renamed-workspace'));
   });
 });

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import './Sidebar.css';
-import type { ReactNode } from 'react';
+import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react';
 import { useState } from 'react';
+import { RenamePopover } from './RenamePopover';
 import { StateIndicator } from './StateIndicator';
 import { formatShortcut } from '../shortcuts';
 import { isAttentionSessionState, type UISessionState } from '../types/sessionState';
@@ -61,6 +62,8 @@ interface SidebarProps {
   mutedExpanded?: boolean;
   onMutedExpandedChange?: (expanded: boolean) => void;
   onMuteWorkspace?: (workspaceId: string, endpointId?: string) => void;
+  onRenameSession?: (sessionId: string, label: string) => Promise<void>;
+  onRenameWorkspace?: (workspaceId: string, title: string) => Promise<void>;
   showSessionless?: boolean;
   onToggleShowSessionless?: () => void;
   leafDrag?: { sourceWorkspaceId: string; endpointId?: string } | null;
@@ -199,6 +202,8 @@ export function Sidebar({
   mutedExpanded: mutedExpandedProp,
   onMutedExpandedChange,
   onMuteWorkspace,
+  onRenameSession,
+  onRenameWorkspace,
   showSessionless = false,
   onToggleShowSessionless,
   leafDrag = null,
@@ -217,6 +222,23 @@ export function Sidebar({
   const [mutedExpandedLocal, setMutedExpandedLocal] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [displayMode, setDisplayMode] = useState<'open' | 'tight' | 'boxed'>('boxed');
+  const [renameTarget, setRenameTarget] = useState<{
+    kind: 'session' | 'workspace';
+    id: string;
+    name: string;
+    anchor: { top: number; left: number };
+  } | null>(null);
+
+  const openRename = (
+    kind: 'session' | 'workspace',
+    id: string,
+    name: string,
+    event: ReactMouseEvent,
+  ) => {
+    event.stopPropagation();
+    const rect = event.currentTarget.getBoundingClientRect();
+    setRenameTarget({ kind, id, name, anchor: { top: rect.bottom + 4, left: rect.left } });
+  };
   const mutedExpanded = mutedExpandedProp ?? mutedExpandedLocal;
   const setMutedExpanded = (v: boolean) => {
     setMutedExpandedLocal(v);
@@ -434,8 +456,21 @@ export function Sidebar({
                   </span>
                 )}
                 <span className="session-shortcut">⌘{workspaceIndex + 1}</span>
-                {onMuteWorkspace && (
+                {(onRenameWorkspace || onMuteWorkspace) && (
                   <span className="workspace-actions">
+                    {onRenameWorkspace && (
+                      <button
+                        type="button"
+                        className="workspace-action-btn rename-workspace-btn"
+                        data-testid={`rename-workspace-${workspace.id}`}
+                        onClick={(e) => openRename('workspace', workspace.id, workspace.title, e)}
+                        title="Rename workspace"
+                        aria-label={`Rename workspace ${workspace.title}`}
+                      >
+                        ✎
+                      </button>
+                    )}
+                    {onMuteWorkspace && (
                     <button
                       type="button"
                       className="workspace-action-btn mute-workspace-btn"
@@ -449,6 +484,7 @@ export function Sidebar({
                     >
                       ⊘
                     </button>
+                    )}
                   </span>
                 )}
               </div>
@@ -483,6 +519,17 @@ export function Sidebar({
                     )}
                     {session.isWorktree && <span className="worktree-indicator">⎇</span>}
                     <div className="session-actions">
+                      {onRenameSession && (
+                        <button
+                          className="session-action-btn rename-session-btn"
+                          data-testid={`rename-session-${session.id}`}
+                          onClick={(e) => openRename('session', session.id, session.label, e)}
+                          title="Rename session"
+                          aria-label={`Rename session ${session.label}`}
+                        >
+                          ✎
+                        </button>
+                      )}
                       <button
                         className="session-action-btn close-session-btn"
                         data-testid={`close-session-${session.id}`}
@@ -619,6 +666,23 @@ export function Sidebar({
         ))}
         <span className="shortcut-hint">{`${formatShortcut('session.toggleSidebar')} sidebar`}</span>
       </div>
+
+      {renameTarget && (
+        <RenamePopover
+          key={`${renameTarget.kind}:${renameTarget.id}`}
+          initialValue={renameTarget.name}
+          label={renameTarget.kind === 'workspace' ? 'Rename workspace' : 'Rename session'}
+          anchor={renameTarget.anchor}
+          onSubmit={async (value) => {
+            if (renameTarget.kind === 'workspace') {
+              await onRenameWorkspace?.(renameTarget.id, value);
+            } else {
+              await onRenameSession?.(renameTarget.id, value);
+            }
+          }}
+          onClose={() => setRenameTarget(null)}
+        />
+      )}
     </div>
   );
 }

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -598,7 +598,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [
           {
             id: 'agent-1',
@@ -684,7 +684,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [],
         workspaces: [{
           id: 'workspace-1',
@@ -768,7 +768,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -853,7 +853,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -985,7 +985,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1050,7 +1050,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1113,7 +1113,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1173,7 +1173,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [],
         workspaces: [{
           id: 'workspace-1',
@@ -1273,7 +1273,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     };
     const initialState = {
       event: 'initial_state',
-      protocol_version: '80',
+      protocol_version: '81',
       sessions: [],
       workspaces: [workspace],
       prs: [],
@@ -1350,7 +1350,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1444,7 +1444,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1543,7 +1543,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1628,7 +1628,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -1707,7 +1707,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -1777,7 +1777,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '80',
+        protocol_version: '81',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',
@@ -1846,6 +1846,46 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     await waitFor(() => {
       expect(onWorkspacesUpdate).toHaveBeenLastCalledWith([]);
     });
+
+    unmount();
+  });
+
+  it('updates a renamed session in place without duplicating the sidebar row', async () => {
+    const onSessionsUpdate = vi.fn();
+    const { unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate,
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+    const session = {
+      id: 'sess-1',
+      label: 'original',
+      agent: 'shell',
+      directory: '/tmp',
+      workspace_id: 'workspace-sess-1',
+      state: 'idle',
+    };
+
+    // First sighting registers the row; the rename arrives as another
+    // session_state_changed for the same id. It must replace, not append.
+    act(() => {
+      ws.emit({ event: 'session_state_changed', session });
+    });
+    act(() => {
+      ws.emit({ event: 'session_state_changed', session: { ...session, label: 'renamed' } });
+    });
+
+    const calls = onSessionsUpdate.mock.calls;
+    const lastSessions = calls.length > 0 ? calls[calls.length - 1][0] : [];
+    expect(lastSessions).toHaveLength(1);
+    expect(lastSessions[0]).toMatchObject({ id: 'sess-1', label: 'renamed' });
 
     unmount();
   });

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -157,7 +157,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '80';
+const PROTOCOL_VERSION = '81';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -1086,6 +1086,22 @@ export function useDaemonSocket({
                 pending.resolve({ success: true, final_leaf_id: data.final_leaf_id });
               } else {
                 pending.reject(new Error(data.error || 'Workspace action failed'));
+              }
+            }
+            break;
+          }
+
+          case 'rename_result': {
+            if (typeof data.cmd === 'string' && typeof data.id === 'string') {
+              const key = `${data.cmd}:${data.id}`;
+              const pending = pendingActionsRef.current.get(key);
+              if (pending) {
+                pendingActionsRef.current.delete(key);
+                if (data.success) {
+                  pending.resolve(undefined);
+                } else {
+                  pending.reject(new Error(data.error || 'Rename failed'));
+                }
               }
             }
             break;
@@ -2599,6 +2615,52 @@ export function useDaemonSocket({
     });
   }, []);
 
+  const sendRenameSession = useCallback((sessionId: string, label: string): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      const trimmed = label.trim();
+      if (!sessionId || !trimmed) {
+        reject(new Error('Session name cannot be empty'));
+        return;
+      }
+      const key = `rename_session:${sessionId}`;
+      pendingActionsRef.current.set(key, { resolve: () => resolve(), reject });
+      sendOrQueueCommand(
+        { cmd: 'rename_session', session_id: sessionId, label: trimmed },
+        { waitForInitialState: true },
+      );
+      window.setTimeout(() => {
+        if (!pendingActionsRef.current.has(key)) {
+          return;
+        }
+        pendingActionsRef.current.delete(key);
+        reject(new Error(`Rename timed out for session ${sessionId}`));
+      }, 10_000);
+    });
+  }, [sendOrQueueCommand]);
+
+  const sendRenameWorkspace = useCallback((workspaceId: string, title: string): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      const trimmed = title.trim();
+      if (!workspaceId || !trimmed) {
+        reject(new Error('Workspace name cannot be empty'));
+        return;
+      }
+      const key = `rename_workspace:${workspaceId}`;
+      pendingActionsRef.current.set(key, { resolve: () => resolve(), reject });
+      sendOrQueueCommand(
+        { cmd: 'rename_workspace', workspace_id: workspaceId, title: trimmed },
+        { waitForInitialState: true },
+      );
+      window.setTimeout(() => {
+        if (!pendingActionsRef.current.has(key)) {
+          return;
+        }
+        pendingActionsRef.current.delete(key);
+        reject(new Error(`Rename timed out for workspace ${workspaceId}`));
+      }, 10_000);
+    });
+  }, [sendOrQueueCommand]);
+
   // Unregister a single session from daemon
   const sendUnregisterSession = useCallback((sessionId: string): Promise<void> => {
     return new Promise((resolve, reject) => {
@@ -3604,6 +3666,8 @@ export function useDaemonSocket({
     sendUnregisterSession,
     sendRegisterWorkspace,
     sendUnregisterWorkspace,
+    sendRenameSession,
+    sendRenameWorkspace,
     sendPRVisited,
     sendListWorktrees,
     sendCreateWorktree,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -120,6 +120,9 @@
 //   const registerWorkspaceMessage = Convert.toRegisterWorkspaceMessage(json);
 //   const removeEndpointMessage = Convert.toRemoveEndpointMessage(json);
 //   const removePluginMessage = Convert.toRemovePluginMessage(json);
+//   const renameResultMessage = Convert.toRenameResultMessage(json);
+//   const renameSessionMessage = Convert.toRenameSessionMessage(json);
+//   const renameWorkspaceMessage = Convert.toRenameWorkspaceMessage(json);
 //   const replaySegment = Convert.toReplaySegment(json);
 //   const repoInfo = Convert.toRepoInfo(json);
 //   const repoState = Convert.toRepoState(json);
@@ -1824,6 +1827,41 @@ export interface RemovePluginMessage {
 
 export enum RemovePluginMessageCmd {
     RemovePlugin = "remove_plugin",
+}
+
+export interface RenameResultMessage {
+    cmd:     string;
+    error?:  string;
+    event:   RenameResultMessageEvent;
+    id:      string;
+    success: boolean;
+    [property: string]: any;
+}
+
+export enum RenameResultMessageEvent {
+    RenameResult = "rename_result",
+}
+
+export interface RenameSessionMessage {
+    cmd:        RenameSessionMessageCmd;
+    label:      string;
+    session_id: string;
+    [property: string]: any;
+}
+
+export enum RenameSessionMessageCmd {
+    RenameSession = "rename_session",
+}
+
+export interface RenameWorkspaceMessage {
+    cmd:          RenameWorkspaceMessageCmd;
+    title:        string;
+    workspace_id: string;
+    [property: string]: any;
+}
+
+export enum RenameWorkspaceMessageCmd {
+    RenameWorkspace = "rename_workspace",
 }
 
 export interface ReplaySegment {
@@ -3786,6 +3824,30 @@ export class Convert {
         return JSON.stringify(uncast(value, r("RemovePluginMessage")), null, 2);
     }
 
+    public static toRenameResultMessage(json: string): RenameResultMessage {
+        return cast(JSON.parse(json), r("RenameResultMessage"));
+    }
+
+    public static renameResultMessageToJson(value: RenameResultMessage): string {
+        return JSON.stringify(uncast(value, r("RenameResultMessage")), null, 2);
+    }
+
+    public static toRenameSessionMessage(json: string): RenameSessionMessage {
+        return cast(JSON.parse(json), r("RenameSessionMessage"));
+    }
+
+    public static renameSessionMessageToJson(value: RenameSessionMessage): string {
+        return JSON.stringify(uncast(value, r("RenameSessionMessage")), null, 2);
+    }
+
+    public static toRenameWorkspaceMessage(json: string): RenameWorkspaceMessage {
+        return cast(JSON.parse(json), r("RenameWorkspaceMessage"));
+    }
+
+    public static renameWorkspaceMessageToJson(value: RenameWorkspaceMessage): string {
+        return JSON.stringify(uncast(value, r("RenameWorkspaceMessage")), null, 2);
+    }
+
     public static toReplaySegment(json: string): ReplaySegment {
         return cast(JSON.parse(json), r("ReplaySegment"));
     }
@@ -5482,6 +5544,23 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("RemovePluginMessageCmd") },
         { json: "name", js: "name", typ: "" },
     ], "any"),
+    "RenameResultMessage": o([
+        { json: "cmd", js: "cmd", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("RenameResultMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "RenameSessionMessage": o([
+        { json: "cmd", js: "cmd", typ: r("RenameSessionMessageCmd") },
+        { json: "label", js: "label", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
+    ], "any"),
+    "RenameWorkspaceMessage": o([
+        { json: "cmd", js: "cmd", typ: r("RenameWorkspaceMessageCmd") },
+        { json: "title", js: "title", typ: "" },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
     "ReplaySegment": o([
         { json: "cols", js: "cols", typ: 0 },
         { json: "data", js: "data", typ: "" },
@@ -6427,6 +6506,15 @@ const typeMap: any = {
     ],
     "RemovePluginMessageCmd": [
         "remove_plugin",
+    ],
+    "RenameResultMessageEvent": [
+        "rename_result",
+    ],
+    "RenameSessionMessageCmd": [
+        "rename_session",
+    ],
+    "RenameWorkspaceMessageCmd": [
+        "rename_workspace",
     ],
     "ReposUpdatedMessageEvent": [
         "repos_updated",

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -112,6 +112,8 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdWorkspaceLayoutMoveLeaf:            commandMetadata(ScopeSession, true, true),
 	protocol.CmdWorkspaceLayoutMoveLeafToWorkspace: commandMetadata(ScopeSession, true, true),
 	protocol.CmdWorkspaceTileContentGet:            commandMetadata(ScopeSession, true, true),
+	protocol.CmdRenameSession:                      commandMetadata(ScopeSession, false, true),
+	protocol.CmdRenameWorkspace:                    commandMetadata(ScopeEndpoint, false, true),
 }
 
 func shouldLogWSCommand(cmd string) bool {

--- a/internal/daemon/command_meta_test.go
+++ b/internal/daemon/command_meta_test.go
@@ -220,6 +220,12 @@ func TestRemoteCommandSessionID_IncludesReviewLoopCommands(t *testing.T) {
 			msg:  &protocol.SetReviewLoopIterationLimitMessage{SessionID: "sess-set"},
 			want: "sess-set",
 		},
+		{
+			name: "rename_session",
+			cmd:  protocol.CmdRenameSession,
+			msg:  &protocol.RenameSessionMessage{SessionID: "sess-rename"},
+			want: "sess-rename",
+		},
 	}
 
 	for _, tc := range cases {
@@ -232,6 +238,13 @@ func TestRemoteCommandSessionID_IncludesReviewLoopCommands(t *testing.T) {
 func TestRemoteCommandWorkspaceID_IncludesTileContentGet(t *testing.T) {
 	msg := &protocol.WorkspaceTileContentGetMessage{WorkspaceID: "workspace-remote"}
 	if got := remoteCommandWorkspaceID(protocol.CmdWorkspaceTileContentGet, msg); got != msg.WorkspaceID {
+		t.Fatalf("remoteCommandWorkspaceID() = %q, want %q", got, msg.WorkspaceID)
+	}
+}
+
+func TestRemoteCommandWorkspaceID_IncludesRenameWorkspace(t *testing.T) {
+	msg := &protocol.RenameWorkspaceMessage{WorkspaceID: "workspace-rename"}
+	if got := remoteCommandWorkspaceID(protocol.CmdRenameWorkspace, msg); got != msg.WorkspaceID {
 		t.Fatalf("remoteCommandWorkspaceID() = %q, want %q", got, msg.WorkspaceID)
 	}
 }

--- a/internal/daemon/command_meta_test.go
+++ b/internal/daemon/command_meta_test.go
@@ -82,6 +82,8 @@ func TestCommandMetaCoversAllCommands(t *testing.T) {
 		protocol.CmdWorkspaceLayoutDockTile,
 		protocol.CmdWorkspaceLayoutUndockTile,
 		protocol.CmdWorkspaceTileContentGet,
+		protocol.CmdRenameSession,
+		protocol.CmdRenameWorkspace,
 	}
 
 	for _, cmd := range commands {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1688,9 +1688,15 @@ func (d *Daemon) handleRegister(conn net.Conn, msg *protocol.RegisterMessage) {
 
 	nowStr := string(protocol.TimestampNow())
 	agent := normalizeStoredSessionAgent(string(protocol.Deref(msg.Agent)), protocol.SessionAgentClaude)
+	// The label from register is a default for first registration. A non-empty
+	// stored label is authoritative so a user rename survives re-registration.
+	sessionLabel := protocol.Deref(msg.Label)
+	if existing != nil && strings.TrimSpace(existing.Label) != "" {
+		sessionLabel = existing.Label
+	}
 	session := &protocol.Session{
 		ID:             msg.ID,
-		Label:          protocol.Deref(msg.Label),
+		Label:          sessionLabel,
 		Agent:          agent,
 		Directory:      msg.Dir,
 		State:          protocol.SessionStateLaunching,
@@ -1715,8 +1721,14 @@ func (d *Daemon) handleRegister(conn net.Conn, msg *protocol.RegisterMessage) {
 		return
 	}
 	session.WorkspaceID = workspaceID
-	d.store.AddWorkspace(&protocol.Workspace{ID: workspaceID, Title: session.Label, Directory: session.Directory, Status: protocol.WorkspaceStatusLaunching})
-	d.workspaces.register(workspaceID, session.Label, session.Directory, false)
+	// Re-deriving the workspace title from the session label would clobber a
+	// renamed workspace. Preserve a non-empty stored title instead.
+	workspaceTitle := session.Label
+	if existingWS := d.store.GetWorkspace(workspaceID); existingWS != nil && strings.TrimSpace(existingWS.Title) != "" {
+		workspaceTitle = existingWS.Title
+	}
+	d.store.AddWorkspace(&protocol.Workspace{ID: workspaceID, Title: workspaceTitle, Directory: session.Directory, Status: protocol.WorkspaceStatusLaunching})
+	d.workspaces.register(workspaceID, workspaceTitle, session.Directory, false)
 	d.store.Add(session)
 	if resumeSessionID := d.consumePendingResumeSessionID(session.ID); resumeSessionID != "" {
 		d.store.SetResumeSessionID(session.ID, resumeSessionID)

--- a/internal/daemon/rename.go
+++ b/internal/daemon/rename.go
@@ -1,0 +1,82 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// handleRenameSession updates a session's display label. The store is the durable
+// authority for the name (registration/respawn preserve a non-empty stored
+// label), so the rename survives reconnects and reloads. On success the renamed
+// session is broadcast to every client via session_state_changed.
+func (d *Daemon) handleRenameSession(client *wsClient, msg *protocol.RenameSessionMessage) {
+	sessionID := strings.TrimSpace(msg.SessionID)
+	label := strings.TrimSpace(msg.Label)
+	if sessionID == "" {
+		d.sendRenameResult(client, protocol.CmdRenameSession, sessionID, fmt.Errorf("missing session_id"))
+		return
+	}
+	if label == "" {
+		d.sendRenameResult(client, protocol.CmdRenameSession, sessionID, fmt.Errorf("name cannot be empty"))
+		return
+	}
+	session := d.store.Get(sessionID)
+	if session == nil {
+		d.sendRenameResult(client, protocol.CmdRenameSession, sessionID, fmt.Errorf("session not found: %s", sessionID))
+		return
+	}
+	d.store.UpdateSessionLabel(sessionID, label)
+	session.Label = label
+	d.wsHub.Broadcast(&protocol.WebSocketEvent{
+		Event:   protocol.EventSessionStateChanged,
+		Session: d.sessionForBroadcast(session),
+	})
+	d.sendRenameResult(client, protocol.CmdRenameSession, sessionID, nil)
+}
+
+// handleRenameWorkspace updates a workspace's title in both the in-memory
+// registry and the store, then broadcasts workspace_state_changed. Like the
+// session label, the stored title is preserved over the name re-derived at
+// register time, so the rename is durable.
+func (d *Daemon) handleRenameWorkspace(client *wsClient, msg *protocol.RenameWorkspaceMessage) {
+	workspaceID := strings.TrimSpace(msg.WorkspaceID)
+	title := strings.TrimSpace(msg.Title)
+	if workspaceID == "" {
+		d.sendRenameResult(client, protocol.CmdRenameWorkspace, workspaceID, fmt.Errorf("missing workspace_id"))
+		return
+	}
+	if title == "" {
+		d.sendRenameResult(client, protocol.CmdRenameWorkspace, workspaceID, fmt.Errorf("name cannot be empty"))
+		return
+	}
+	if d.workspaces == nil {
+		d.sendRenameResult(client, protocol.CmdRenameWorkspace, workspaceID, fmt.Errorf("workspace registry unavailable"))
+		return
+	}
+	snapshot, ok := d.workspaces.rename(workspaceID, title)
+	if !ok {
+		d.sendRenameResult(client, protocol.CmdRenameWorkspace, workspaceID, fmt.Errorf("workspace not found: %s", workspaceID))
+		return
+	}
+	d.store.UpdateWorkspaceTitle(workspaceID, title)
+	d.wsHub.Broadcast(&protocol.WebSocketEvent{
+		Event:     protocol.EventWorkspaceStateChanged,
+		Workspace: &snapshot,
+	})
+	d.sendRenameResult(client, protocol.CmdRenameWorkspace, workspaceID, nil)
+}
+
+func (d *Daemon) sendRenameResult(client *wsClient, cmd, id string, err error) {
+	result := protocol.RenameResultMessage{
+		Event:   protocol.EventRenameResult,
+		Cmd:     cmd,
+		ID:      id,
+		Success: err == nil,
+	}
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, result)
+}

--- a/internal/daemon/rename_test.go
+++ b/internal/daemon/rename_test.go
@@ -1,0 +1,121 @@
+package daemon
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
+)
+
+func expectRenameResult(t *testing.T, client *wsClient) protocol.RenameResultMessage {
+	t.Helper()
+	select {
+	case outbound := <-client.send:
+		var result protocol.RenameResultMessage
+		if err := json.Unmarshal(outbound.payload, &result); err != nil {
+			t.Fatalf("decode rename_result: %v", err)
+		}
+		return result
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for rename_result")
+		return protocol.RenameResultMessage{}
+	}
+}
+
+func newRenameTestClient() *wsClient {
+	return &wsClient{
+		send:            make(chan outboundMessage, 4),
+		attachedStreams: make(map[string]ptybackend.Stream),
+	}
+}
+
+// A renamed session label is persisted and, crucially, survives a respawn that
+// carries a stale label — the stored label is the durable authority.
+func TestDaemon_HandleRenameSession_PersistsAndSurvivesRespawn(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	d.ptyBackend = backend
+
+	dir := t.TempDir()
+	now := string(protocol.TimestampNow())
+	addTestWorkspace(d, "workspace-s1", dir)
+	d.store.Add(&protocol.Session{
+		ID: "s1", Label: "original", Agent: protocol.SessionAgentClaude,
+		Directory: dir, WorkspaceID: "workspace-s1",
+		State: protocol.SessionStateIdle, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	d.workspaces.associateSession("s1", "workspace-s1", "original")
+
+	client := newRenameTestClient()
+	d.handleRenameSession(client, &protocol.RenameSessionMessage{
+		Cmd: protocol.CmdRenameSession, SessionID: "s1", Label: "renamed",
+	})
+
+	if res := expectRenameResult(t, client); !res.Success {
+		t.Fatalf("rename_result success=false error=%q", protocol.Deref(res.Error))
+	}
+	if got := d.store.Get("s1"); got == nil || got.Label != "renamed" {
+		t.Fatalf("stored label = %+v, want renamed", got)
+	}
+
+	// Respawn with a stale label, as a reload from a client with out-of-date
+	// local state would. The rename must not be reverted.
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd: protocol.CmdSpawnSession, ID: "s1", Cwd: dir, Cols: 80, Rows: 24,
+		Agent: "claude", WorkspaceID: "workspace-s1", Label: protocol.Ptr("original"),
+	})
+	if got := d.store.Get("s1"); got == nil || got.Label != "renamed" {
+		t.Fatalf("label after stale respawn = %+v, want renamed", got)
+	}
+	if last, ok := backend.LastSpawn(); !ok || last.Label != "renamed" {
+		t.Fatalf("spawn label = %q ok=%v, want renamed", last.Label, ok)
+	}
+}
+
+func TestDaemon_HandleRenameWorkspace_PersistsTitle(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	dir := t.TempDir()
+	addTestWorkspace(d, "workspace-1", dir)
+
+	client := newRenameTestClient()
+	d.handleRenameWorkspace(client, &protocol.RenameWorkspaceMessage{
+		Cmd: protocol.CmdRenameWorkspace, WorkspaceID: "workspace-1", Title: "Renamed",
+	})
+
+	if res := expectRenameResult(t, client); !res.Success {
+		t.Fatalf("rename_result success=false error=%q", protocol.Deref(res.Error))
+	}
+	if got := d.store.GetWorkspace("workspace-1"); got == nil || got.Title != "Renamed" {
+		t.Fatalf("stored title = %+v, want Renamed", got)
+	}
+	if snap, ok := d.workspaces.snapshot("workspace-1"); !ok || snap.Title != "Renamed" {
+		t.Fatalf("registry title = %q ok=%v, want Renamed", snap.Title, ok)
+	}
+}
+
+func TestDaemon_HandleRenameSession_RejectsEmptyName(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	dir := t.TempDir()
+	now := string(protocol.TimestampNow())
+	addTestWorkspace(d, "workspace-s1", dir)
+	d.store.Add(&protocol.Session{
+		ID: "s1", Label: "original", Agent: protocol.SessionAgentClaude,
+		Directory: dir, WorkspaceID: "workspace-s1",
+		State: protocol.SessionStateIdle, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+
+	client := newRenameTestClient()
+	d.handleRenameSession(client, &protocol.RenameSessionMessage{
+		Cmd: protocol.CmdRenameSession, SessionID: "s1", Label: "   ",
+	})
+
+	if res := expectRenameResult(t, client); res.Success {
+		t.Fatal("rename with blank label should fail")
+	}
+	if got := d.store.Get("s1"); got == nil || got.Label != "original" {
+		t.Fatalf("label after rejected rename = %+v, want original", got)
+	}
+}

--- a/internal/daemon/rename_test.go
+++ b/internal/daemon/rename_test.go
@@ -96,6 +96,41 @@ func TestDaemon_HandleRenameWorkspace_PersistsTitle(t *testing.T) {
 	}
 }
 
+// A user rename of a workspace must survive a later register_workspace that
+// carries the old derived title — the kind of stale re-registration a
+// reconnect or retry produces. Without the guard the derived title clobbers
+// the rename in both the store and the in-memory registry.
+func TestDaemon_HandleRegisterWorkspace_PreservesRenamedTitleOnReRegister(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	dir := t.TempDir()
+	client := newRenameTestClient()
+
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: "workspace-1", Title: "derived-title", Directory: dir,
+	})
+	if got := d.store.GetWorkspace("workspace-1"); got == nil || got.Title != "derived-title" {
+		t.Fatalf("initial title = %+v, want derived-title", got)
+	}
+
+	d.handleRenameWorkspace(client, &protocol.RenameWorkspaceMessage{
+		Cmd: protocol.CmdRenameWorkspace, WorkspaceID: "workspace-1", Title: "User Renamed",
+	})
+	if res := expectRenameResult(t, client); !res.Success {
+		t.Fatalf("rename_result success=false error=%q", protocol.Deref(res.Error))
+	}
+
+	// Reconnect/retry re-registers with the stale derived title.
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: "workspace-1", Title: "derived-title", Directory: dir,
+	})
+	if got := d.store.GetWorkspace("workspace-1"); got == nil || got.Title != "User Renamed" {
+		t.Fatalf("stored title after re-register = %+v, want User Renamed", got)
+	}
+	if snap, ok := d.workspaces.snapshot("workspace-1"); !ok || snap.Title != "User Renamed" {
+		t.Fatalf("registry title after re-register = %q ok=%v, want User Renamed", snap.Title, ok)
+	}
+}
+
 func TestDaemon_HandleRenameSession_RejectsEmptyName(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	dir := t.TempDir()

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -926,6 +926,10 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleRegisterWorkspace(client, msg.(*protocol.RegisterWorkspaceMessage))
 	case protocol.CmdUnregisterWorkspace:
 		d.handleUnregisterWorkspace(client, msg.(*protocol.UnregisterWorkspaceMessage))
+	case protocol.CmdRenameSession:
+		d.handleRenameSession(client, msg.(*protocol.RenameSessionMessage))
+	case protocol.CmdRenameWorkspace:
+		d.handleRenameWorkspace(client, msg.(*protocol.RenameWorkspaceMessage))
 	default:
 		d.sendCommandError(client, cmd, "unsupported command")
 	}

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1068,6 +1068,10 @@ func remoteCommandSessionID(cmd string, msg interface{}) string {
 		if typed, ok := msg.(*protocol.SetReviewLoopIterationLimitMessage); ok {
 			return typed.SessionID
 		}
+	case protocol.CmdRenameSession:
+		if typed, ok := msg.(*protocol.RenameSessionMessage); ok {
+			return typed.SessionID
+		}
 	}
 	return ""
 }
@@ -1116,6 +1120,10 @@ func remoteCommandWorkspaceID(cmd string, msg interface{}) string {
 		}
 	case protocol.CmdWorkspaceTileContentGet:
 		if typed, ok := msg.(*protocol.WorkspaceTileContentGetMessage); ok {
+			return typed.WorkspaceID
+		}
+	case protocol.CmdRenameWorkspace:
+		if typed, ok := msg.(*protocol.RenameWorkspaceMessage); ok {
 			return typed.WorkspaceID
 		}
 	}

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -302,6 +302,14 @@ func (d *Daemon) handleRegisterWorkspace(client *wsClient, msg *protocol.Registe
 	}
 	existing := d.store.GetWorkspace(id)
 	muted := existing != nil && existing.Muted
+	// Preserve a user-applied rename across re-registration. A reconnect or
+	// retry can re-register the same workspace id with the old derived title;
+	// the only authoritative way to change a title is the rename_workspace
+	// command, so a non-empty stored title always wins here. Mirrors the
+	// session/workspace title guards in handleRegister.
+	if existing != nil && strings.TrimSpace(existing.Title) != "" {
+		title = existing.Title
+	}
 	snapshot, isNew := d.workspaces.register(id, title, directory, muted)
 	d.store.AddWorkspace(&snapshot)
 	// Make workspace directories available in the recent-locations picker.

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -60,6 +60,20 @@ func (r *workspaceRegistry) register(id, title, directory string, muted bool) (p
 	return snapshotEntry(entry), !existed
 }
 
+// rename updates a workspace's cached title. Returns the refreshed snapshot and
+// whether the workspace was found. The store is the durable authority; callers
+// persist the new title alongside this in-memory update.
+func (r *workspaceRegistry) rename(id, title string) (protocol.Workspace, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, ok := r.workspaces[id]
+	if !ok {
+		return protocol.Workspace{}, false
+	}
+	entry.title = title
+	return snapshotEntry(entry), true
+}
+
 func (r *workspaceRegistry) toggleMuted(id string) (protocol.Workspace, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -400,6 +400,11 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 	if label == "" {
 		label = filepath.Base(cwd)
 	}
+	// A non-empty stored label is the durable authority — a respawn or reload
+	// must not revert a user rename, even if the client sends a stale label.
+	if existingSession != nil && strings.TrimSpace(existingSession.Label) != "" {
+		label = existingSession.Label
+	}
 	if msg.Cols <= 0 || msg.Rows <= 0 || msg.Cols > maxPTYDimValue || msg.Rows > maxPTYDimValue {
 		d.sendSpawnFailure(client, msg.ID, fmt.Errorf("invalid terminal size cols=%d rows=%d (expected 1..%d)", msg.Cols, msg.Rows, maxPTYDimValue))
 		return

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "80"
+const ProtocolVersion = "81"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -120,6 +120,8 @@ const (
 	CmdOpenMarkdown                       = "open_markdown"
 	CmdRegisterWorkspace                  = "register_workspace"
 	CmdUnregisterWorkspace                = "unregister_workspace"
+	CmdRenameSession                      = "rename_session"
+	CmdRenameWorkspace                    = "rename_workspace"
 )
 
 // WebSocket Events (daemon -> client)
@@ -132,6 +134,7 @@ const (
 	EventWorkspaceStateChanged       = "workspace_state_changed"
 	EventSessionTodosUpdated         = "session_todos_updated"
 	EventSessionsUpdated             = "sessions_updated"
+	EventRenameResult                = "rename_result"
 	EventPRsUpdated                  = "prs_updated"
 	EventReposUpdated                = "repos_updated"
 	EventAuthorsUpdated              = "authors_updated"
@@ -888,6 +891,20 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		var msg UnregisterWorkspaceMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, fmt.Errorf("unmarshal unregister_workspace: %w", err)
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdRenameSession:
+		var msg RenameSessionMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal rename_session: %w", err)
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdRenameWorkspace:
+		var msg RenameWorkspaceMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal rename_workspace: %w", err)
 		}
 		return peek.Cmd, &msg, nil
 

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1623,6 +1623,45 @@ type RemovePluginMessage struct {
 	Name string `json:"name"`
 }
 
+type RenameResultMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
+type RenameSessionMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Label corresponds to the JSON schema field "label".
+	Label string `json:"label"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
+}
+
+type RenameWorkspaceMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Title corresponds to the JSON schema field "title".
+	Title string `json:"title"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
+}
+
 type ReplaySegment struct {
 	// Cols corresponds to the JSON schema field "cols".
 	Cols int `json:"cols"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -919,6 +919,22 @@ model UnregisterWorkspaceMessage {
   id: string;
 }
 
+// Rename a session's display label. The stored label is authoritative once set:
+// it survives session re-registration and respawn so a rename is durable.
+model RenameSessionMessage {
+  cmd: "rename_session";
+  session_id: string;
+  label: string;
+}
+
+// Rename a workspace's title. Like the session label, the stored title wins over
+// the name re-derived at register time, so a rename sticks across reconnects.
+model RenameWorkspaceMessage {
+  cmd: "rename_workspace";
+  workspace_id: string;
+  title: string;
+}
+
 // ============================================================================
 // Result/Event Messages (Daemon → Client)
 // ============================================================================
@@ -1005,6 +1021,18 @@ model WorkspaceLayoutMessage {
 model WorkspaceLayoutUpdatedMessage {
   event: "workspace_layout_updated";
   workspace_layout: WorkspaceLayout;
+}
+
+// Result of a rename_session / rename_workspace command. cmd echoes the command
+// name and id is the renamed session_id or workspace_id, so the client can match
+// it to the pending request. The renamed entity is also broadcast separately via
+// session_state_changed / workspace_state_changed.
+model RenameResultMessage {
+  event: "rename_result";
+  cmd: string;
+  id: string;
+  success: boolean;
+  error?: string;
 }
 
 model WorkspaceLayoutActionResultMessage {
@@ -1620,6 +1648,7 @@ alias DaemonEvent =
   | WorkspaceLayoutMessage
   | WorkspaceLayoutUpdatedMessage
   | WorkspaceLayoutActionResultMessage
+  | RenameResultMessage
   | WorkspaceTileContentMessage
   | PRsUpdatedMessage
   | ReposUpdatedMessage

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -562,6 +562,25 @@ func (s *Store) UpdateBranch(id, branch string, isWorktree bool, mainRepo string
 	}
 }
 
+// UpdateSessionLabel sets a session's display label. This is the durable
+// authority for the name: registration and respawn paths preserve a non-empty
+// stored label rather than overwrite it, so a user rename sticks.
+func (s *Store) UpdateSessionLabel(id, label string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		if session := s.sessions[id]; session != nil {
+			session.Label = label
+		}
+		return
+	}
+
+	if _, err := s.db.Exec(`UPDATE sessions SET label = ? WHERE id = ?`, label, id); err != nil {
+		log.Printf("[store] UpdateSessionLabel: failed for session %s: %v", id, err)
+	}
+}
+
 // Touch updates a session's last seen time
 func (s *Store) Touch(id string) {
 	s.mu.Lock()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -297,6 +298,33 @@ func TestStore_UpdateTodos(t *testing.T) {
 	}
 	if got.Todos[0] != "task 1" {
 		t.Errorf("Todos[0] = %q, want %q", got.Todos[0], "task 1")
+	}
+}
+
+func TestStore_UpdateSessionLabel(t *testing.T) {
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	now := string(protocol.TimestampNow())
+	s.Add(&protocol.Session{
+		ID: "abc123", Label: "original", Agent: protocol.SessionAgentCodex,
+		Directory: "/tmp/project", WorkspaceID: "workspace-1",
+		State: protocol.SessionStateIdle, StateSince: now,
+		StateUpdatedAt: now, LastSeen: now,
+	})
+
+	s.UpdateSessionLabel("abc123", "renamed")
+
+	got := s.Get("abc123")
+	if got == nil || got.Label != "renamed" {
+		t.Fatalf("label after rename = %+v, want renamed", got)
+	}
+	// Unrelated columns must survive the targeted update.
+	if got.Directory != "/tmp/project" || got.State != protocol.SessionStateIdle {
+		t.Fatalf("rename mutated unrelated fields: %+v", got)
 	}
 }
 

--- a/internal/store/workspace.go
+++ b/internal/store/workspace.go
@@ -111,6 +111,22 @@ func (s *Store) ToggleWorkspaceMute(id string) {
 	}
 }
 
+// UpdateWorkspaceTitle sets a workspace's title. The stored title is the durable
+// authority for the name: the register path preserves a non-empty stored title
+// instead of re-deriving it from a session label, so a user rename sticks.
+func (s *Store) UpdateWorkspaceTitle(id, title string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return
+	}
+
+	if _, err := s.db.Exec(`UPDATE workspaces SET title = ? WHERE id = ?`, title, id); err != nil {
+		log.Printf("[store] UpdateWorkspaceTitle: failed for workspace %s: %v", id, err)
+	}
+}
+
 // AssignSessionWorkspace updates the workspace_id column on a session. A live
 // persisted session must always have an owning workspace; callers that are
 // unregistering a session should delete the session row instead of clearing

--- a/internal/store/workspace_test.go
+++ b/internal/store/workspace_test.go
@@ -55,6 +55,27 @@ func TestToggleWorkspaceMute(t *testing.T) {
 	}
 }
 
+func TestUpdateWorkspaceTitle(t *testing.T) {
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	s.AddWorkspace(&protocol.Workspace{ID: "workspace-1", Title: "Project", Directory: "/tmp/project"})
+
+	s.UpdateWorkspaceTitle("workspace-1", "Renamed")
+
+	got := s.GetWorkspace("workspace-1")
+	if got == nil || got.Title != "Renamed" {
+		t.Fatalf("workspace title after rename = %+v, want Renamed", got)
+	}
+	// Other columns must be left intact.
+	if got.Directory != "/tmp/project" {
+		t.Fatalf("directory changed during rename = %q", got.Directory)
+	}
+}
+
 func TestAssignSessionWorkspaceRefusesEmptyWorkspace(t *testing.T) {
 	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {


### PR DESCRIPTION
## What

Adds inline rename for both **workspaces** and **sessions**.

**Triggers:**
- Hover pencil (✎) on sidebar workspace and session rows
- Pencil button in the pane header, shown when more than one pane is visible

**Interaction:** Clicking a trigger opens a small anchored popover with the current name preselected — type to replace, or arrow-right to append. Enter submits (trimmed); empty is rejected; unchanged closes silently; Escape / outside-click dismisses.

## How

- New `RenamePopover` component (anchored, viewport-clamped, escape-stack aware)
- Request/result websocket round-trip: `rename_session` / `rename_workspace` → `rename_result`, following the canonical pending-action pattern
- Store gains `UpdateSessionLabel` / `UpdateWorkspaceTitle`
- **Durability:** register, respawn, and reload paths now preserve a non-empty stored name, so renames survive reconnect and session reload (verified against the real daemon)
- Protocol version bumped to **81** (TypeSpec schema + generated types regenerated)

## No sidebar duplication

The earlier concern about renames duplicating rows was verified four ways: daemon query (single row, no dup IDs after rename), live screenshot, code reasoning (`upsertSessionByID` replaces strictly by `id`), and a dedicated regression test asserting two `session_state_changed` emits for the same id collapse to one row.

## Testing

- `npm run build` (tsc + vite) clean; `make dev` builds/bundles/installs/launches
- 550 frontend tests pass (incl. new `RenamePopover`, `Sidebar`, and dedup regression tests)
- Go daemon/store/protocol tests pass; new `rename_test.go` covers persistence-across-respawn and empty-name rejection