### PR TITLE
fix(terminal): keep text selection alive when it ends over a split divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 
 ---
 
+## [2026-06-04]
+
+### Fixed
+- **Selecting terminal text to the edge of a split pane no longer gets stuck.** When you dragged a selection up to the divider between split panes, the cursor flipped to the resize arrow and the selection froze — and the text wasn't copied until you clicked again. Selections now finish and copy normally even when you release the mouse right at a pane edge.
+
 ## [2026-06-03]
 
 ### Added

--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -347,6 +347,42 @@ test.describe('Ghostty terminal interactions', () => {
       .toEqual([]);
   });
 
+  test('copies a selection even when the mouse is released outside the terminal', async ({ page, context, daemon }) => {
+    // Regression: a selection drag that ends over a sibling overlay (e.g. a split
+    // divider above the pane edge) used to retarget the mouseup away from the
+    // terminal, leaving the selection stuck and never copying it. The drag is now
+    // tracked on the document, so releasing outside the terminal still finalizes.
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const terminal = await openTerminalSession(page, daemon, 's-release-outside');
+    const text = 'release-outside-target';
+    await writeTerminalOutput(page, 's-release-outside', `[2J[H${text}`);
+    await page.evaluate(() => navigator.clipboard.writeText('clipboard-sentinel'));
+
+    await expect
+      .poll(
+        async () => page.evaluate(() => window.__TEST_GET_SESSION_PANE_TEXT?.('s-release-outside') ?? ''),
+        { timeout: 5000 },
+      )
+      .toContain(text);
+
+    const bounds = await terminal.boundingBox();
+    expect(bounds).not.toBeNull();
+    // Select the text rightward, then jump straight out of the terminal (a single
+    // mousemove, so no intermediate cell shrinks the selection) and release over a
+    // non-terminal element — the way a release on a split divider above the pane
+    // edge retargets the mouseup away from the terminal.
+    const selectionEndX = bounds!.x + bounds!.width / 2;
+    await page.mouse.move(bounds!.x + 2, bounds!.y + 8);
+    await page.mouse.down();
+    await page.mouse.move(selectionEndX, bounds!.y + 8);
+    await page.mouse.move(Math.max(1, bounds!.x - 60), bounds!.y + 8);
+    await page.mouse.up();
+
+    await expect
+      .poll(async () => page.evaluate(() => navigator.clipboard.readText()), { timeout: 3000 })
+      .toContain(text);
+  });
+
   test('keeps copied selection attached to its text while scrolling', async ({ page, context, daemon }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
     const terminal = await openTerminalSession(page, daemon, 's-selection-scroll');

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -136,7 +136,7 @@ function rectSnapshot(rect: DOMRect | null) {
 }
 
 function cellFromRect(
-  event: React.MouseEvent,
+  event: { clientX: number; clientY: number },
   rect: DOMRect | null,
   cellWidth: number,
   cellHeight: number,
@@ -227,6 +227,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const selectingRef = useRef(false);
     const selectionPointerStartRef = useRef<{ clientX: number; clientY: number } | null>(null);
     const selectionDragThresholdMetRef = useRef(false);
+    const selectionDragCleanupRef = useRef<(() => void) | null>(null);
     const trackedMouseButtonRef = useRef<number | null>(null);
     const hoveredCellRef = useRef<{ row: number; col: number } | null>(null);
     const acceleratorHeldRef = useRef(false);
@@ -760,7 +761,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       };
     }, []);
 
-    const cellFromPointer = (event: React.MouseEvent | React.WheelEvent) => {
+    const cellFromPointer = (event: React.MouseEvent | React.WheelEvent | MouseEvent) => {
       const renderer = rendererRef.current;
       const rect = canvasRef.current?.getBoundingClientRect();
       if (!renderer || !rect) return null;
@@ -780,7 +781,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
 
     const recordPointerHitTest = useCallback((
       eventName: string,
-      event: React.MouseEvent,
+      event: React.MouseEvent | MouseEvent,
       extra: Record<string, unknown> = {},
     ) => {
       const terminal = terminalRef.current;
@@ -900,6 +901,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       };
     }, [updateLinkCursor]);
 
+    useEffect(() => () => {
+      selectionDragCleanupRef.current?.();
+      selectionDragCleanupRef.current = null;
+    }, []);
+
     const sendTrackedMouse = (
       action: 'press' | 'move' | 'release',
       event: React.MouseEvent,
@@ -928,6 +934,83 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       if (action === 'release') trackedMouseButtonRef.current = null;
       event.preventDefault();
       return true;
+    };
+
+    const stopSelectionDrag = () => {
+      selectionDragCleanupRef.current?.();
+      selectionDragCleanupRef.current = null;
+    };
+
+    const finishSelectionDrag = async (event: MouseEvent) => {
+      stopSelectionDrag();
+      if (!selectingRef.current) return;
+      selectingRef.current = false;
+      selectionPointerStartRef.current = null;
+      if (!selectionDragThresholdMetRef.current) {
+        selectionRef.current = null;
+        renderSurface(true);
+      }
+      const text = textForSelectionRange(selectionRef.current);
+      selectedTextRef.current = text || null;
+      if (text) await writeClipboardText(text);
+      const cell = cellFromPointer(event);
+      const uri = cell ? literalUrlAtColumn(lineAtVisibleRow(cell.row), cell.col) : null;
+      recordPointerHitTest('mouseup', event, {
+        activeCell: cell,
+        activeUri: uri,
+        opensUri: Boolean(uri && !text && (event.metaKey || event.ctrlKey)),
+        copiedTextLength: text.length,
+        phase: 'after-selection',
+      });
+      if (uri && !text && (event.metaKey || event.ctrlKey)) {
+        void openUrl(uri);
+      }
+    };
+
+    // Track an in-progress selection on the document rather than the terminal
+    // element. The drag must keep updating and finalize even when the pointer
+    // crosses a sibling overlay (e.g. a split divider sitting above the pane
+    // edge), which would otherwise steal the mousemove/mouseup and strand the
+    // selection without ever copying it.
+    const startSelectionDrag = () => {
+      stopSelectionDrag();
+      const onMove = (event: MouseEvent) => {
+        if (!selectingRef.current || !selectionRef.current) return;
+        // The button was released without a mouseup we observed (e.g. focus
+        // loss while over another window): finalize so we never get stuck.
+        if ((event.buttons & 1) === 0) {
+          void finishSelectionDrag(event);
+          return;
+        }
+        const terminal = terminalRef.current;
+        const renderer = rendererRef.current;
+        const cell = cellFromPointer(event);
+        const pointerStart = selectionPointerStartRef.current;
+        if (!terminal || !renderer || !cell || !pointerStart) return;
+        if (!selectionDragThresholdMetRef.current) {
+          const deltaX = event.clientX - pointerStart.clientX;
+          const deltaY = event.clientY - pointerStart.clientY;
+          const threshold = renderer.cellWidth * 0.5;
+          if (deltaX * deltaX + deltaY * deltaY < threshold * threshold) return;
+          selectionDragThresholdMetRef.current = true;
+        }
+        recordPointerHitTest('mousemove', event, {
+          activeCell: cell,
+          phase: 'selection-drag',
+        });
+        const row = bufferRowFromViewportRow(cell.row, terminal.getScrollbackLength(), viewportOffsetRef.current);
+        selectionRef.current = { ...selectionRef.current, endRow: row, endCol: cell.col + 1 };
+        renderSurface(true);
+      };
+      const onUp = (event: MouseEvent) => {
+        void finishSelectionDrag(event);
+      };
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+      selectionDragCleanupRef.current = () => {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
     };
 
     return (
@@ -1025,74 +1108,39 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           selectionDragThresholdMetRef.current = false;
           selectionRef.current = { startRow: row, startCol: cell.col, endRow: row, endCol: cell.col };
           renderSurface(true);
+          startSelectionDrag();
         }}
         onMouseMove={(event) => {
+          // While selecting, the drag is owned by the document listeners in
+          // startSelectionDrag() so it survives crossing sibling overlays.
+          if (selectingRef.current) return;
           const hoveredCell = cellFromPointer(event);
           hoveredCellRef.current = hoveredCell;
           acceleratorHeldRef.current = event.metaKey || event.ctrlKey;
           updateLinkCursor(hoveredCell, acceleratorHeldRef.current);
           const hoveredLine = hoveredCell ? lineAtVisibleRow(hoveredCell.row) : '';
           const hoveredUri = hoveredCell ? literalUrlAtColumn(hoveredLine, hoveredCell.col) : null;
-          if (acceleratorHeldRef.current || hoveredUri || selectingRef.current) {
+          if (acceleratorHeldRef.current || hoveredUri) {
             recordPointerHitTest('mousemove', event, {
               activeCell: hoveredCell,
               activeUri: hoveredUri,
-              phase: selectingRef.current ? 'selection-drag' : 'hover',
+              phase: 'hover',
             });
           }
-          if (!selectingRef.current || !selectionRef.current) {
-            sendTrackedMouse('move', event);
-            return;
-          }
-          const terminal = terminalRef.current;
-          const renderer = rendererRef.current;
-          const cell = cellFromPointer(event);
-          const pointerStart = selectionPointerStartRef.current;
-          if (!terminal || !renderer || !cell || !pointerStart) return;
-          if (!selectionDragThresholdMetRef.current) {
-            const deltaX = event.clientX - pointerStart.clientX;
-            const deltaY = event.clientY - pointerStart.clientY;
-            const threshold = renderer.cellWidth * 0.5;
-            if (deltaX * deltaX + deltaY * deltaY < threshold * threshold) return;
-            selectionDragThresholdMetRef.current = true;
-          }
-          const row = bufferRowFromViewportRow(cell.row, terminal.getScrollbackLength(), viewportOffsetRef.current);
-          selectionRef.current = { ...selectionRef.current, endRow: row, endCol: cell.col + 1 };
-          renderSurface(true);
+          sendTrackedMouse('move', event);
         }}
         onMouseLeave={() => {
           hoveredCellRef.current = null;
           setLinkCursorActive(false);
         }}
-        onMouseUp={async (event) => {
-          if (!selectingRef.current) {
-            recordPointerHitTest('mouseup', event, {
-              phase: 'tracked-mouse-release',
-            });
-            sendTrackedMouse('release', event);
-            return;
-          }
-          selectingRef.current = false;
-          selectionPointerStartRef.current = null;
-          if (!selectionDragThresholdMetRef.current) {
-            selectionRef.current = null;
-            renderSurface(true);
-          }
-          const text = textForSelectionRange(selectionRef.current);
-          selectedTextRef.current = text || null;
-          if (text) await writeClipboardText(text);
-          const cell = cellFromPointer(event);
-          const uri = cell ? literalUrlAtColumn(lineAtVisibleRow(cell.row), cell.col) : null;
+        onMouseUp={(event) => {
+          // A selection release is finalized by the document mouseup listener so
+          // it fires even when the pointer ends over a sibling overlay.
+          if (selectingRef.current) return;
           recordPointerHitTest('mouseup', event, {
-            activeCell: cell,
-            activeUri: uri,
-            opensUri: Boolean(uri && !text && (event.metaKey || event.ctrlKey)),
-            copiedTextLength: text.length,
-            phase: 'after-selection',
+            phase: 'tracked-mouse-release',
           });
-          if (uri && !text && (event.metaKey || event.ctrlKey)) {
-            void openUrl(uri);
-          }
+          sendTrackedMouse('release', event);
         }}
         onDoubleClick={async (event) => {
           const terminal = terminalRef.current;


### PR DESCRIPTION
## The bug

Selecting text in a split terminal: if the selection drag reached the **divider between panes**, the cursor flipped to the resize arrow, the selection froze, and the text wasn't copied — it stayed stuck until you clicked again.

## Root cause

Terminal selection used **element-scoped React handlers** (`onMouseDown/Move/Up` on the terminal `<div>`). The split divider is an absolutely-positioned sibling at `z-index: 5` straddling the pane edge, so once a drag reached it, `mousemove`/`mouseup` retargeted to the divider. The terminal's `onMouseMove` stopped (selection froze) and its `onMouseUp` — where `selectingRef` is cleared and the clipboard copy happens — never fired.

## The fix

When a selection starts, the drag is now tracked on `document` (`mousemove`/`mouseup`) rather than the terminal element, so it keeps updating and finalizes regardless of which sibling overlay the pointer crosses — the same pattern the divider/leaf drags already use. Fully contained in `GhosttyTerminal`; the terminal mouse-tracking protocol path is untouched. Includes a `buttons`-released guard (finalize on a missed mouseup) and unmount cleanup.

## Validation

- `tsc` clean; **555 unit tests** pass.
- **11/11** terminal-interaction e2e tests pass (all existing copy/selection tests included — no regression).
- New regression test `copies a selection even when the mouse is released outside the terminal` was verified to **fail on the pre-fix code** and **pass with the fix**.

## Note / follow-up

Cosmetic and deliberately out of scope: while dragging *over* the divider's 9px band the cursor still briefly shows the resize arrow (the divider's own CSS cursor). Selection and copy now work correctly through it; suppressing the cursor too would mean a small body-class + CSS change, happy to do it in a follow-up if wanted.

🤖 Opened by Claude on behalf of Victor.