### PR TITLE
release: v0.11.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.10.2",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.10.2"
+version = "0.11.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "attn",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "identifier": "com.attn.manager",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
Version bump for the **v0.11.0** release.

Bumps `app/package.json`, `app/src-tauri/tauri.conf.json`, `app/src-tauri/Cargo.toml`, and `Cargo.lock` to `0.11.0`. Generated by `scripts/release.sh` (full validation passed locally: `go test ./...`, frontend build, 555 frontend tests).

Once merged, tag `v0.11.0` on the merge commit and push the tag to trigger `.github/workflows/release.yml`.

### Highlights since v0.10.2
- Rename workspaces and sessions from the sidebar and pane headers.
- Move panes and docked tiles between workspaces by dragging.
- Resizable splits and docked markdown panels.
- Fix: terminal text selection no longer gets stuck when it ends at a split pane edge.

See `CHANGELOG.md` for full detail.