### PR TITLE
fix(app): prevent blank screen after shell exit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ pnpm run e2e
 - Prefer `pnpm --dir app run real-app:serial-matrix` for multiple packaged-app scenarios.
 - If you need one scenario, run exactly one packaged-app scenario at a time and wait for it to finish.
 - Rebuild first when packaged-app evidence matters, or you may be testing an older installed app.
-- The serial matrix targets the **dev** install (`~/Applications/attn-dev.app`, port 29849) by default so it never takes over the live prod app. Run `make dev` first if there's no dev install yet. To target prod explicitly, run with `ATTN_HARNESS_PROFILE=` (empty).
+- All real-app harness commands target the **dev** install (`~/Applications/attn-dev.app`, port 29849) by default so they never take over the live prod app. Run `make dev` first if there's no dev install yet. To target prod explicitly, set `ATTN_HARNESS_PROFILE=` (empty) and pass `--run-against-prod`; the harness refuses production lifecycle operations without that flag.
 - When a packaged-app scenario fails, always inspect the captured pane text and any native screenshot artifacts before diagnosing the cause. Startup prompts, permission dialogs, and agent-owned redraws are part of the evidence.
 
 ## Debugging And Logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 
 ### Fixed
 - **Selecting terminal text to the edge of a split pane no longer gets stuck.** When you dragged a selection up to the divider between split panes, the cursor flipped to the resize arrow and the selection froze — and the text wasn't copied until you clicked again. Selections now finish and copy normally even when you release the mouse right at a pane edge.
+- **Closing a shell no longer leaves a fully black screen.** When a shell exited while its cached pane was still marked as starting, the app could keep an invisible stale session and suppress the normal empty state. Exited shells now disappear cleanly.
 
 ## [2026-06-03]
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ git clone https://github.com/victorarias/attn.git && cd attn
 
 If you use attn daily and want to develop attn *with* attn running, use the dev sibling install instead of reinstalling your live copy. `make dev` builds and launches `~/Applications/attn-dev.app` — separate bundle identifier (`com.attn.manager.dev`), separate data dir (`~/.attn-dev/`), separate WebSocket port (`29849`). Both apps run side-by-side with zero cross-contamination. `make install` and `make install-daemon` refuse at parse time if `ATTN_PROFILE` is set in your shell, so you can't accidentally reinstall the live app while iterating on dev.
 
-The same `ATTN_PROFILE=<name>` env var scopes CLI commands (`eval "$(attn profile-env dev)"` to set it shell-wide), and the real-app serial matrix defaults to the dev install so it never takes over your live app.
+The same `ATTN_PROFILE=<name>` env var scopes CLI commands (`eval "$(attn profile-env dev)"` to set it shell-wide), and every real-app harness command defaults to the dev install so it never takes over your live app. Production harness runs require both an explicit production target and `--run-against-prod`.
 
 ## Docs
 

--- a/app/scripts/real-app-harness/AGENTS.md
+++ b/app/scripts/real-app-harness/AGENTS.md
@@ -7,6 +7,7 @@ This policy applies to packaged-app scenarios in this directory.
 - Scenarios must match real app usage. Do not invent command sequences that the app cannot perform.
 - If workspace/session product behavior changes, update these scenarios in the same PR.
 - If these scenarios pass while users can reproduce workspace/session errors in the packaged app, treat that as a test design bug.
+- Real-app commands target `attn-dev.app` by default. Production runs must pass `--run-against-prod`; never bypass the shared production-target guard.
 
 ## Workspace Sessions
 

--- a/app/scripts/real-app-harness/bridge-diagnose-session.mjs
+++ b/app/scripts/real-app-harness/bridge-diagnose-session.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { createRunContext } from './common.mjs';
+import { assertProductionRunAllowed, defaultAppPathForProfile } from './harnessProfile.mjs';
 import { captureFrontWindowScreenshot } from './nativeWindowCapture.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 
@@ -11,7 +12,7 @@ function printHelp() {
   console.log(`Usage: pnpm exec node scripts/real-app-harness/bridge-diagnose-session.mjs [options]
 
 Options:
-  --app-path <path>          Packaged app path (default: ~/Applications/attn.app)
+  --app-path <path>          Packaged app path (default: ~/Applications/attn-dev.app)
   --artifacts-dir <path>     Directory for diagnostic output
   --session-root-dir <path>  Unused here, kept for consistent harness output
   --fresh-launch             Quit and relaunch the packaged app before capture
@@ -20,6 +21,7 @@ Options:
   --cwd <path>               Inspect the first session matching this cwd
   --no-select-session        Capture the session as-is without sending select_session
   --settle-frames <n>        Frames to settle before perf capture (default: 2)
+  --run-against-prod         Explicitly allow targeting the production app
 
 Examples:
   pnpm exec node scripts/real-app-harness/bridge-diagnose-session.mjs --label blubs
@@ -33,7 +35,7 @@ function parseArgs(argv) {
     args.shift();
   }
   const options = {
-    appPath: process.env.ATTN_REAL_APP_PATH || path.join(os.homedir(), 'Applications', 'attn.app'),
+    appPath: process.env.ATTN_REAL_APP_PATH || defaultAppPathForProfile(),
     artifactsDir: process.env.ATTN_REAL_APP_ARTIFACTS_DIR || path.join(os.tmpdir(), 'attn-real-app-harness'),
     sessionRootDir: process.env.ATTN_REAL_APP_SESSION_ROOT || path.join(os.tmpdir(), 'attn-real-app-sessions'),
     freshLaunch: false,
@@ -42,6 +44,7 @@ function parseArgs(argv) {
     cwd: '',
     noSelectSession: false,
     settleFrames: 2,
+    runAgainstProd: false,
     help: false,
   };
 
@@ -56,10 +59,17 @@ function parseArgs(argv) {
     else if (arg === '--cwd') options.cwd = args[++index] || '';
     else if (arg === '--no-select-session') options.noSelectSession = true;
     else if (arg === '--settle-frames') options.settleFrames = Math.max(0, Number.parseInt(args[++index] || '2', 10) || 0);
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
     else if (arg === '--help' || arg === '-h') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
 
+  if (!options.help) {
+    assertProductionRunAllowed(
+      { appPath: options.appPath },
+      options.runAgainstProd ? ['--run-against-prod'] : args,
+    );
+  }
   return options;
 }
 
@@ -67,9 +77,9 @@ function saveJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
 
-async function tryCaptureNativeWindow(runDir) {
+async function tryCaptureNativeWindow(runDir, client) {
   try {
-    return await captureFrontWindowScreenshot(path.join(runDir, 'native-window.png'));
+    return await captureFrontWindowScreenshot(path.join(runDir, 'native-window.png'), { client });
   } catch (error) {
     fs.writeFileSync(
       path.join(runDir, 'native-window.txt'),
@@ -217,7 +227,7 @@ async function main() {
   if (!options.noSelectSession) {
     await client.request('select_session', { sessionId });
   }
-  const nativeScreenshot = await tryCaptureNativeWindow(runDir);
+  const nativeScreenshot = await tryCaptureNativeWindow(runDir, client);
 
   const uiState = await client.request('get_session_ui_state', { sessionId });
   const structuredSnapshot = await client.request('capture_structured_snapshot', {

--- a/app/scripts/real-app-harness/buildPreflight.mjs
+++ b/app/scripts/real-app-harness/buildPreflight.mjs
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { assertProductionRunAllowed, defaultAppPathForProfile } from './harnessProfile.mjs';
 
 const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HARNESS_DIR, '../../..');
@@ -134,9 +135,10 @@ function readBinaryBuildInfoSync(binaryPath) {
 }
 
 export function assertPackagedAppBuildMatchesCurrentSource({
-  appPath = path.join(os.homedir(), 'Applications', 'attn.app'),
+  appPath = defaultAppPathForProfile(),
   launchEnv = null,
 } = {}) {
+  assertProductionRunAllowed({ appPath });
   const currentSource = getCurrentSourceIdentitySync();
   const currentFingerprint = readNonEmptyString(currentSource?.fingerprint);
   if (!currentFingerprint) {

--- a/app/scripts/real-app-harness/capture-app-screenshot.mjs
+++ b/app/scripts/real-app-harness/capture-app-screenshot.mjs
@@ -8,8 +8,9 @@ function printHelp() {
 
 Options:
   --path <file>      Save a native macOS window screenshot to an explicit path
-  --launch           Launch ~/Applications/attn.app before capturing
-  --fresh-launch     Quit and relaunch ~/Applications/attn.app before capturing
+  --launch           Launch the selected packaged app before capturing
+  --fresh-launch     Quit and relaunch the selected packaged app before capturing
+  --run-against-prod Explicitly allow targeting the production app
   --help, -h         Show this help
 
 Examples:
@@ -33,6 +34,10 @@ async function main() {
     }
     if (arg === '--fresh-launch') {
       freshLaunch = true;
+      continue;
+    }
+    if (arg === '--run-against-prod') {
+      // The shared UiAutomationClient guard reads this explicit acknowledgement.
       continue;
     }
     if (arg === '--path') {
@@ -60,7 +65,7 @@ async function main() {
   await client.waitForFrontendResponsive(20_000);
 
   const targetPath = outputPath || '/tmp/attn-app-window.png';
-  const result = await captureFrontWindowScreenshot(targetPath);
+  const result = await captureFrontWindowScreenshot(targetPath, { client });
   console.log(JSON.stringify(result, null, 2));
 }
 

--- a/app/scripts/real-app-harness/common.mjs
+++ b/app/scripts/real-app-harness/common.mjs
@@ -7,6 +7,7 @@ import {
   defaultAppPathForProfile,
   defaultWSURLForProfile,
   deepLinkSchemeForProfile,
+  profileForAppPath,
 } from './harnessProfile.mjs';
 
 export function parseCommonArgs(argv) {
@@ -29,6 +30,10 @@ export function parseCommonArgs(argv) {
     else if (arg === '--run-against-prod') options.runAgainstProd = true;
     else if (arg === '--help' || arg === '-h') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!process.env.ATTN_REAL_APP_WS_URL && !argv.includes('--ws-url')) {
+    options.wsUrl = defaultWSURLForProfile(profileForAppPath(options.appPath));
   }
 
   const safetyArgv = argv.length > 0 ? argv : process.argv.slice(2);
@@ -143,10 +148,9 @@ export async function bootstrapPackagedAppSession({
   await driver.activateBackground();
   await captureScreenshot(driver, path.join(runDir, '01-app-launched.png'));
 
-  // Scheme is profile-scoped: ATTN_HARNESS_PROFILE=dev → `attn-dev://`,
-  // which the dev bundle registers. Sending `attn://` under a dev
-  // profile would open the prod app instead of attn-dev.app.
-  const scheme = deepLinkSchemeForProfile();
+  // Scheme follows the selected app path so an explicit prod target opens
+  // prod while the default dev target stays isolated.
+  const scheme = deepLinkSchemeForProfile(profileForAppPath(driver.appPath));
   const deepLink = `${scheme}://spawn?cwd=${encodeURIComponent(sessionDir)}&label=${encodeURIComponent(sessionLabel)}`;
   console.log(`[RealAppHarness] deepLink=${deepLink}`);
   await driver.openDeepLink(deepLink);

--- a/app/scripts/real-app-harness/common.mjs
+++ b/app/scripts/real-app-harness/common.mjs
@@ -3,20 +3,21 @@ import os from 'node:os';
 import path from 'node:path';
 import { waitForFirstWorkspacePane, waitForPaneVisible } from './scenarioAssertions.mjs';
 import {
+  assertProductionRunAllowed,
   defaultAppPathForProfile,
   defaultWSURLForProfile,
   deepLinkSchemeForProfile,
 } from './harnessProfile.mjs';
 
 export function parseCommonArgs(argv) {
-  // Default to the prod install; ATTN_HARNESS_PROFILE=dev switches the
-  // whole harness (ws port, app path, bundle id) to the dev sibling
-  // without the caller having to set three separate env vars.
+  // Default to the isolated dev install. Production requires both an explicit
+  // prod target and the --run-against-prod acknowledgement.
   const options = {
     wsUrl: process.env.ATTN_REAL_APP_WS_URL || defaultWSURLForProfile(),
     appPath: process.env.ATTN_REAL_APP_PATH || defaultAppPathForProfile(),
     artifactsDir: process.env.ATTN_REAL_APP_ARTIFACTS_DIR || path.join(os.tmpdir(), 'attn-real-app-harness'),
     sessionRootDir: process.env.ATTN_REAL_APP_SESSION_ROOT || path.join(os.tmpdir(), 'attn-real-app-sessions'),
+    runAgainstProd: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -25,21 +26,31 @@ export function parseCommonArgs(argv) {
     else if (arg === '--app-path') options.appPath = argv[++index];
     else if (arg === '--artifacts-dir') options.artifactsDir = argv[++index];
     else if (arg === '--session-root-dir') options.sessionRootDir = argv[++index];
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
     else if (arg === '--help' || arg === '-h') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
 
+  const safetyArgv = argv.length > 0 ? argv : process.argv.slice(2);
+  const isHelp = options.help || safetyArgv.includes('--help') || safetyArgv.includes('-h');
+  if (!isHelp) assertCommonTargetAllowed(options, safetyArgv);
   return options;
+}
+
+export function assertCommonTargetAllowed(options, argv = process.argv.slice(2)) {
+  const safetyArgv = options.runAgainstProd ? ['--run-against-prod'] : argv;
+  assertProductionRunAllowed({ appPath: options.appPath, wsUrl: options.wsUrl }, safetyArgv);
 }
 
 export function printCommonHelp(scriptName) {
   console.log(`Usage: pnpm exec node ${scriptName} [options]
 
 Options:
-  --ws-url <url>             Daemon websocket URL (default: ws://127.0.0.1:9849/ws)
-  --app-path <path>          Packaged app path (default: ~/Applications/attn.app)
+  --ws-url <url>             Daemon websocket URL (default: ws://127.0.0.1:29849/ws)
+  --app-path <path>          Packaged app path (default: ~/Applications/attn-dev.app)
   --artifacts-dir <path>     Directory for screenshots and summary output
   --session-root-dir <path>  Directory where harness-created session cwd roots are created
+  --run-against-prod         Explicitly allow targeting the production app
 `);
 }
 

--- a/app/scripts/real-app-harness/common.test.mjs
+++ b/app/scripts/real-app-harness/common.test.mjs
@@ -44,6 +44,19 @@ describe('parseCommonArgs production safety', () => {
     expect(() => parseCommonArgs(['--run-against-prod'])).not.toThrow();
   });
 
+  it('derives the production daemon from an acknowledged production app path', () => {
+    delete process.env.ATTN_HARNESS_PROFILE;
+    delete process.env.ATTN_REAL_APP_WS_URL;
+
+    const options = parseCommonArgs([
+      '--app-path',
+      path.join(os.homedir(), 'Applications', 'attn.app'),
+      '--run-against-prod',
+    ]);
+
+    expect(options.wsUrl).toBe('ws://127.0.0.1:9849/ws');
+  });
+
   it('refuses an explicit production websocket while using the dev app', () => {
     delete process.env.ATTN_HARNESS_PROFILE;
 

--- a/app/scripts/real-app-harness/common.test.mjs
+++ b/app/scripts/real-app-harness/common.test.mjs
@@ -1,0 +1,54 @@
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { parseCommonArgs } from './common.mjs';
+
+const originalProfile = process.env.ATTN_HARNESS_PROFILE;
+const originalAppPath = process.env.ATTN_REAL_APP_PATH;
+const originalWsUrl = process.env.ATTN_REAL_APP_WS_URL;
+
+afterEach(() => {
+  for (const [name, value] of [
+    ['ATTN_HARNESS_PROFILE', originalProfile],
+    ['ATTN_REAL_APP_PATH', originalAppPath],
+    ['ATTN_REAL_APP_WS_URL', originalWsUrl],
+  ]) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
+
+describe('parseCommonArgs production safety', () => {
+  it('defaults every real-app command to the isolated dev target', () => {
+    delete process.env.ATTN_HARNESS_PROFILE;
+    delete process.env.ATTN_REAL_APP_PATH;
+    delete process.env.ATTN_REAL_APP_WS_URL;
+
+    const options = parseCommonArgs([]);
+
+    expect(options.appPath).toBe(path.join(os.homedir(), 'Applications', 'attn-dev.app'));
+    expect(options.wsUrl).toBe('ws://127.0.0.1:29849/ws');
+  });
+
+  it('refuses the production profile without the explicit acknowledgement', () => {
+    process.env.ATTN_HARNESS_PROFILE = '';
+
+    expect(() => parseCommonArgs([])).toThrow(
+      'Refusing to run the real-app harness against production',
+    );
+  });
+
+  it('allows the production profile only with the explicit acknowledgement', () => {
+    process.env.ATTN_HARNESS_PROFILE = '';
+
+    expect(() => parseCommonArgs(['--run-against-prod'])).not.toThrow();
+  });
+
+  it('refuses an explicit production websocket while using the dev app', () => {
+    delete process.env.ATTN_HARNESS_PROFILE;
+
+    expect(() => parseCommonArgs(['--ws-url', 'ws://127.0.0.1:9849/ws'])).toThrow(
+      'Refusing to run the real-app harness against production',
+    );
+  });
+});

--- a/app/scripts/real-app-harness/daemonObserver.mjs
+++ b/app/scripts/real-app-harness/daemonObserver.mjs
@@ -1,4 +1,5 @@
 import WebSocket from 'ws';
+import { assertProductionRunAllowed, defaultWSURLForProfile } from './harnessProfile.mjs';
 
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -26,9 +27,10 @@ function pruneWorkspacesBySessions(sessionsById, workspacesBySessionId) {
 
 export class DaemonObserver {
   constructor({
-    wsUrl = 'ws://127.0.0.1:9849/ws',
+    wsUrl = defaultWSURLForProfile(),
     connectTimeoutMs = 45_000,
   } = {}) {
+    assertProductionRunAllowed({ wsUrl });
     this.wsUrl = wsUrl;
     this.connectTimeoutMs = connectTimeoutMs;
     this.ws = null;

--- a/app/scripts/real-app-harness/dev-launch-focus-probe.mjs
+++ b/app/scripts/real-app-harness/dev-launch-focus-probe.mjs
@@ -96,7 +96,7 @@ async function main() {
   }
 
   const finalFrontmost = await frontmost();
-  const attnDriver = new MacOSDriver({ bundleId: 'com.attn.manager' });
+  const attnDriver = new MacOSDriver({ bundleId: client.bundleId, appPath: client.appPath });
   const attnWid = await attnDriver.mainWindowId();
   console.log(`[probe] attn window id after launch=${attnWid}`);
   await client.quitApp().catch(() => {});

--- a/app/scripts/real-app-harness/dev-raf-throttle-probe.mjs
+++ b/app/scripts/real-app-harness/dev-raf-throttle-probe.mjs
@@ -35,10 +35,15 @@ import {
   createSessionAndWaitForInitialPane,
   launchFreshAppAndConnect,
 } from './common.mjs';
+import {
+  bundleIdentifierForProfile,
+  defaultAppPathForProfile,
+  defaultWSURLForProfile,
+} from './harnessProfile.mjs';
 import { sleep, waitForFirstWorkspacePane } from './scenarioAssertions.mjs';
 
 const execFileAsync = promisify(execFile);
-const ATTN_BUNDLE_ID = 'com.attn.manager';
+const ATTN_BUNDLE_ID = bundleIdentifierForProfile();
 
 async function frontmostBundle() {
   try {
@@ -105,8 +110,8 @@ async function main() {
   const callerBundleId = await frontmostBundle();
   console.log(`[raf-probe] caller frontmost=${callerBundleId}`);
 
-  const appPath = path.join(os.homedir(), 'Applications', 'attn.app');
-  const observer = new DaemonObserver({ wsUrl: 'ws://127.0.0.1:9849/ws' });
+  const appPath = defaultAppPathForProfile();
+  const observer = new DaemonObserver({ wsUrl: defaultWSURLForProfile() });
   const client = new UiAutomationClient({ appPath });
   const sessionDir = fs.mkdtempSync(path.join(os.tmpdir(), 'raf-probe-'));
 

--- a/app/scripts/real-app-harness/dev-wkwv-occlusion-probe.mjs
+++ b/app/scripts/real-app-harness/dev-wkwv-occlusion-probe.mjs
@@ -43,6 +43,11 @@ import {
   createSessionAndWaitForInitialPane,
 } from './common.mjs';
 import {
+  bundleIdentifierForProfile,
+  defaultAppPathForProfile,
+  defaultWSURLForProfile,
+} from './harnessProfile.mjs';
+import {
   waitForFirstWorkspacePane,
   waitForNewShellPane,
   waitForPaneInputFocus,
@@ -59,7 +64,7 @@ const runDir = path.join(os.tmpdir(), 'wkwebview-occlusion', runId);
 fs.mkdirSync(runDir, { recursive: true });
 console.log(`[probe] runDir=${runDir}`);
 
-async function findWindowId(bundleId = 'com.attn.manager') {
+async function findWindowId(bundleId = bundleIdentifierForProfile()) {
   const { stdout } = await execFileAsync('/tmp/find-window-id', [bundleId], { timeout: 5_000 });
   const line = stdout.trim().split('\n')[0] || '';
   const match = line.match(/wid=(\d+)/);
@@ -128,8 +133,8 @@ async function typeAndWaitForEcho(client, sessionId, paneId, token, { useUi = tr
 }
 
 async function main() {
-  const appPath = path.join(os.homedir(), 'Applications', 'attn.app');
-  const observer = new DaemonObserver({ wsUrl: 'ws://127.0.0.1:9849/ws' });
+  const appPath = defaultAppPathForProfile();
+  const observer = new DaemonObserver({ wsUrl: defaultWSURLForProfile() });
   // Setup phase runs with attn frontmost so WKWebView initializes normally;
   // we deliberately occlude later to test paint delivery.
   const client = new UiAutomationClient({ appPath, backgroundLaunch: false });

--- a/app/scripts/real-app-harness/harnessProfile.mjs
+++ b/app/scripts/real-app-harness/harnessProfile.mjs
@@ -1,6 +1,11 @@
 import os from 'node:os';
 import path from 'node:path';
 
+const DEV_PROFILE = 'dev';
+const PROD_BUNDLE_ID = 'com.attn.manager';
+const PROD_APP_NAME = 'attn.app';
+const PROD_DAEMON_PORT = '9849';
+
 /**
  * Harness profile resolution. A single env var, ATTN_HARNESS_PROFILE,
  * switches the whole real-app harness between the prod install
@@ -15,27 +20,27 @@ import path from 'node:path';
  */
 
 export function currentHarnessProfile() {
-  return (process.env.ATTN_HARNESS_PROFILE || '').trim().toLowerCase();
+  return (process.env.ATTN_HARNESS_PROFILE ?? DEV_PROFILE).trim().toLowerCase();
 }
 
 export function bundleIdentifierForProfile(profile = currentHarnessProfile()) {
-  return profile === 'dev' ? 'com.attn.manager.dev' : 'com.attn.manager';
+  return profile === DEV_PROFILE ? 'com.attn.manager.dev' : PROD_BUNDLE_ID;
 }
 
 export function defaultAppPathForProfile(profile = currentHarnessProfile()) {
-  const name = profile === 'dev' ? 'attn-dev.app' : 'attn.app';
+  const name = profile === DEV_PROFILE ? 'attn-dev.app' : PROD_APP_NAME;
   return path.join(os.homedir(), 'Applications', name);
 }
 
 export function defaultDaemonPortForProfile(profile = currentHarnessProfile()) {
-  return profile === 'dev' ? 29849 : 9849;
+  return profile === DEV_PROFILE ? 29849 : 9849;
 }
 
 // Unix socket the `attn` CLI talks to for the active profile. Dev keeps its
 // state under ~/.attn-dev/; prod under ~/.attn/. Pass this as ATTN_SOCKET_PATH
 // when driving the CLI (e.g. `attn open`) against the harness daemon.
 export function socketPathForProfile(profile = currentHarnessProfile()) {
-  const dir = profile === 'dev' ? '.attn-dev' : '.attn';
+  const dir = profile === DEV_PROFILE ? '.attn-dev' : '.attn';
   return path.join(os.homedir(), dir, 'attn.sock');
 }
 
@@ -59,5 +64,40 @@ export function manifestPathForProfile(profile = currentHarnessProfile()) {
 //   - dev:  tauri.dev.conf.json declares `attn-dev`
 // Must stay in sync with config.DeepLinkScheme() on the Go side.
 export function deepLinkSchemeForProfile(profile = currentHarnessProfile()) {
-  return profile === 'dev' ? 'attn-dev' : 'attn';
+  return profile === DEV_PROFILE ? 'attn-dev' : 'attn';
+}
+
+export function hasRunAgainstProdFlag(argv = process.argv.slice(2)) {
+  return argv.includes('--run-against-prod');
+}
+
+export function isProductionHarnessTarget({
+  appPath,
+  bundleId,
+  wsUrl,
+  profile = currentHarnessProfile(),
+} = {}) {
+  let wsPort = '';
+  try {
+    wsPort = new URL(wsUrl).port;
+  } catch {
+    // Invalid URLs are handled by their consumer; they are not evidence of prod.
+  }
+  return (
+    profile !== DEV_PROFILE
+    || path.basename(appPath || '') === PROD_APP_NAME
+    || bundleId === PROD_BUNDLE_ID
+    || wsPort === PROD_DAEMON_PORT
+  );
+}
+
+export function assertProductionRunAllowed(target = {}, argv = process.argv.slice(2)) {
+  if (!isProductionHarnessTarget(target) || hasRunAgainstProdFlag(argv)) {
+    return;
+  }
+  throw new Error(
+    'Refusing to run the real-app harness against production. '
+    + 'Use the dev install (default; run `make dev` first), or pass '
+    + '`--run-against-prod` explicitly to allow production app or daemon operations.',
+  );
 }

--- a/app/scripts/real-app-harness/harnessProfile.mjs
+++ b/app/scripts/real-app-harness/harnessProfile.mjs
@@ -27,6 +27,17 @@ export function bundleIdentifierForProfile(profile = currentHarnessProfile()) {
   return profile === DEV_PROFILE ? 'com.attn.manager.dev' : PROD_BUNDLE_ID;
 }
 
+export function profileForAppPath(appPath, fallbackProfile = currentHarnessProfile()) {
+  const appName = path.basename(appPath || '');
+  if (appName === PROD_APP_NAME) return '';
+  if (appName === 'attn-dev.app') return DEV_PROFILE;
+  return fallbackProfile;
+}
+
+export function bundleIdentifierForAppPath(appPath, fallbackProfile = currentHarnessProfile()) {
+  return bundleIdentifierForProfile(profileForAppPath(appPath, fallbackProfile));
+}
+
 export function defaultAppPathForProfile(profile = currentHarnessProfile()) {
   const name = profile === DEV_PROFILE ? 'attn-dev.app' : PROD_APP_NAME;
   return path.join(os.homedir(), 'Applications', name);

--- a/app/scripts/real-app-harness/harnessProfile.test.mjs
+++ b/app/scripts/real-app-harness/harnessProfile.test.mjs
@@ -1,0 +1,73 @@
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  assertProductionRunAllowed,
+  currentHarnessProfile,
+  defaultAppPathForProfile,
+  defaultDaemonPortForProfile,
+  hasRunAgainstProdFlag,
+  isProductionHarnessTarget,
+} from './harnessProfile.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { MacOSDriver } from './macosDriver.mjs';
+import { getFrontWindowBounds } from './nativeWindowCapture.mjs';
+
+const originalProfile = process.env.ATTN_HARNESS_PROFILE;
+
+afterEach(() => {
+  if (originalProfile === undefined) {
+    delete process.env.ATTN_HARNESS_PROFILE;
+  } else {
+    process.env.ATTN_HARNESS_PROFILE = originalProfile;
+  }
+});
+
+describe('real-app harness production safety', () => {
+  it('defaults to the isolated dev app and daemon', () => {
+    delete process.env.ATTN_HARNESS_PROFILE;
+
+    expect(currentHarnessProfile()).toBe('dev');
+    expect(defaultAppPathForProfile()).toBe(path.join(os.homedir(), 'Applications', 'attn-dev.app'));
+    expect(defaultDaemonPortForProfile()).toBe(29849);
+  });
+
+  it('detects production from profile, app path, bundle id, or websocket', () => {
+    expect(isProductionHarnessTarget({ profile: '' })).toBe(true);
+    expect(isProductionHarnessTarget({
+      profile: 'dev',
+      appPath: path.join(os.homedir(), 'Applications', 'attn.app'),
+    })).toBe(true);
+    expect(isProductionHarnessTarget({ profile: 'dev', bundleId: 'com.attn.manager' })).toBe(true);
+    expect(isProductionHarnessTarget({ profile: 'dev', wsUrl: 'ws://127.0.0.1:9849/ws' })).toBe(true);
+    expect(isProductionHarnessTarget({
+      profile: 'dev',
+      appPath: path.join(os.homedir(), 'Applications', 'attn-dev.app'),
+      bundleId: 'com.attn.manager.dev',
+    })).toBe(false);
+  });
+
+  it('requires the explicit production acknowledgement flag', () => {
+    expect(() => assertProductionRunAllowed({ profile: '' }, [])).toThrow(
+      'Refusing to run the real-app harness against production',
+    );
+    expect(() => assertProductionRunAllowed({ profile: '' }, ['--run-against-prod'])).not.toThrow();
+    expect(hasRunAgainstProdFlag(['--run-against-prod'])).toBe(true);
+  });
+
+  it('protects low-level macOS lifecycle operations', () => {
+    expect(() => new MacOSDriver({
+      appPath: path.join(os.homedir(), 'Applications', 'attn.app'),
+      bundleId: 'com.attn.manager',
+    })).toThrow('Refusing to run the real-app harness against production');
+  });
+
+  it('protects low-level daemon and native-window operations', async () => {
+    expect(() => new DaemonObserver({ wsUrl: 'ws://127.0.0.1:9849/ws' })).toThrow(
+      'Refusing to run the real-app harness against production',
+    );
+    await expect(getFrontWindowBounds('com.attn.manager')).rejects.toThrow(
+      'Refusing to run the real-app harness against production',
+    );
+  });
+});

--- a/app/scripts/real-app-harness/harnessProfile.test.mjs
+++ b/app/scripts/real-app-harness/harnessProfile.test.mjs
@@ -3,19 +3,23 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   assertProductionRunAllowed,
+  bundleIdentifierForAppPath,
   currentHarnessProfile,
   defaultAppPathForProfile,
   defaultDaemonPortForProfile,
   hasRunAgainstProdFlag,
   isProductionHarnessTarget,
+  profileForAppPath,
 } from './harnessProfile.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { MacOSDriver } from './macosDriver.mjs';
 import { getFrontWindowBounds } from './nativeWindowCapture.mjs';
 
 const originalProfile = process.env.ATTN_HARNESS_PROFILE;
+const originalArgv = process.argv;
 
 afterEach(() => {
+  process.argv = originalArgv;
   if (originalProfile === undefined) {
     delete process.env.ATTN_HARNESS_PROFILE;
   } else {
@@ -47,6 +51,16 @@ describe('real-app harness production safety', () => {
     })).toBe(false);
   });
 
+  it('derives the matching profile and bundle from explicit packaged app paths', () => {
+    const prodAppPath = path.join(os.homedir(), 'Applications', 'attn.app');
+    const devAppPath = path.join(os.homedir(), 'Applications', 'attn-dev.app');
+
+    expect(profileForAppPath(prodAppPath)).toBe('');
+    expect(bundleIdentifierForAppPath(prodAppPath)).toBe('com.attn.manager');
+    expect(profileForAppPath(devAppPath, '')).toBe('dev');
+    expect(bundleIdentifierForAppPath(devAppPath, '')).toBe('com.attn.manager.dev');
+  });
+
   it('requires the explicit production acknowledgement flag', () => {
     expect(() => assertProductionRunAllowed({ profile: '' }, [])).toThrow(
       'Refusing to run the real-app harness against production',
@@ -60,6 +74,16 @@ describe('real-app harness production safety', () => {
       appPath: path.join(os.homedir(), 'Applications', 'attn.app'),
       bundleId: 'com.attn.manager',
     })).toThrow('Refusing to run the real-app harness against production');
+  });
+
+  it('targets the production bundle for an acknowledged production app path', () => {
+    process.argv = [...process.argv, '--run-against-prod'];
+
+    const driver = new MacOSDriver({
+      appPath: path.join(os.homedir(), 'Applications', 'attn.app'),
+    });
+
+    expect(driver.bundleId).toBe('com.attn.manager');
   });
 
   it('protects low-level daemon and native-window operations', async () => {

--- a/app/scripts/real-app-harness/macosDriver.mjs
+++ b/app/scripts/real-app-harness/macosDriver.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import {
   assertProductionRunAllowed,
-  bundleIdentifierForProfile,
+  bundleIdentifierForAppPath,
   defaultAppPathForProfile,
 } from './harnessProfile.mjs';
 
@@ -22,12 +22,13 @@ function delay(ms) {
 
 export class MacOSDriver {
   constructor({
-    bundleId = bundleIdentifierForProfile(),
+    bundleId = null,
     appPath = defaultAppPathForProfile(),
     actionDelayMs = 250,
   } = {}) {
-    assertProductionRunAllowed({ appPath, bundleId });
-    this.bundleId = bundleId;
+    const resolvedBundleId = bundleId || bundleIdentifierForAppPath(appPath);
+    assertProductionRunAllowed({ appPath, bundleId: resolvedBundleId });
+    this.bundleId = resolvedBundleId;
     this.appPath = appPath;
     this.actionDelayMs = actionDelayMs;
   }

--- a/app/scripts/real-app-harness/macosDriver.mjs
+++ b/app/scripts/real-app-harness/macosDriver.mjs
@@ -1,9 +1,13 @@
 import { execFile } from 'node:child_process';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import {
+  assertProductionRunAllowed,
+  bundleIdentifierForProfile,
+  defaultAppPathForProfile,
+} from './harnessProfile.mjs';
 
 const execFileAsync = promisify(execFile);
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -18,10 +22,11 @@ function delay(ms) {
 
 export class MacOSDriver {
   constructor({
-    bundleId = 'com.attn.manager',
-    appPath = path.join(os.homedir(), 'Applications', 'attn.app'),
+    bundleId = bundleIdentifierForProfile(),
+    appPath = defaultAppPathForProfile(),
     actionDelayMs = 250,
   } = {}) {
+    assertProductionRunAllowed({ appPath, bundleId });
     this.bundleId = bundleId;
     this.appPath = appPath;
     this.actionDelayMs = actionDelayMs;

--- a/app/scripts/real-app-harness/nativeWindowCapture.mjs
+++ b/app/scripts/real-app-harness/nativeWindowCapture.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { assertProductionRunAllowed, bundleIdentifierForProfile } from './harnessProfile.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -93,7 +94,9 @@ end tell
   return parseWindowBoundsOutput(output, bundleId);
 }
 
-export async function getFrontWindowBounds(bundleId = 'com.attn.manager', options = {}) {
+export async function getFrontWindowBounds(bundleId = null, options = {}) {
+  const targetBundleId = bundleId || options.client?.bundleId || bundleIdentifierForProfile();
+  assertProductionRunAllowed({ bundleId: targetBundleId });
   const automationBounds = await readUiAutomationWindowBounds(options.client);
   if (automationBounds) {
     return automationBounds;
@@ -102,11 +105,11 @@ export async function getFrontWindowBounds(bundleId = 'com.attn.manager', option
   let lastError = null;
   for (let attempt = 0; attempt < 5; attempt += 1) {
     if (attempt > 0) {
-      await activateBundle(bundleId);
+      await activateBundle(targetBundleId);
       await delay(250);
     }
     try {
-      return await readFrontWindowBoundsForBundle(bundleId);
+      return await readFrontWindowBoundsForBundle(targetBundleId);
     } catch (error) {
       lastError = error;
     }
@@ -114,7 +117,7 @@ export async function getFrontWindowBounds(bundleId = 'com.attn.manager', option
 
   throw lastError instanceof Error
     ? lastError
-    : new Error(`Failed to resolve front window bounds for ${bundleId}`);
+    : new Error(`Failed to resolve front window bounds for ${targetBundleId}`);
 }
 
 function boundsWithinTolerance(actual, target, tolerancePx = 6) {
@@ -163,7 +166,8 @@ async function writeUiAutomationWindowBounds(client, targetBounds) {
 }
 
 export async function setFrontWindowBounds(targetBounds, options = {}) {
-  const bundleId = options.bundleId || 'com.attn.manager';
+  const bundleId = options.bundleId || options.client?.bundleId || bundleIdentifierForProfile();
+  assertProductionRunAllowed({ bundleId });
   const normalizedTarget = normalizeLogicalBounds(targetBounds);
   if (!normalizedTarget) {
     throw new Error(`Invalid target window bounds: ${JSON.stringify(targetBounds)}`);
@@ -219,7 +223,8 @@ export async function setFrontWindowBounds(targetBounds, options = {}) {
 }
 
 export async function captureFrontWindowScreenshot(outputPath, options = {}) {
-  const bundleId = options.bundleId || 'com.attn.manager';
+  const bundleId = options.bundleId || options.client?.bundleId || bundleIdentifierForProfile();
+  assertProductionRunAllowed({ bundleId });
   const bounds = await getFrontWindowBounds(bundleId, options);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   await execFileAsync('/usr/sbin/screencapture', [

--- a/app/scripts/real-app-harness/run-serial-matrix.mjs
+++ b/app/scripts/real-app-harness/run-serial-matrix.mjs
@@ -2,14 +2,18 @@
 
 import { spawn } from 'node:child_process';
 import { assertPackagedAppBuildMatchesCurrentSource } from './buildPreflight.mjs';
-import { defaultAppPathForProfile } from './harnessProfile.mjs';
+import {
+  assertProductionRunAllowed,
+  defaultAppPathForProfile,
+  defaultWSURLForProfile,
+} from './harnessProfile.mjs';
 
 // Matrix runs against the dev install by default. The dev install is the
 // whole point of the profile feature: iterate on attn-on-attn test
 // scenarios without ever taking over the live prod app. Opt out by
 // setting ATTN_HARNESS_PROFILE to an empty string (prod) or a different
-// profile name explicitly. This must happen before any import that reads
-// the env var at module-load time.
+// profile name explicitly, plus --run-against-prod. This must happen before
+// any import that reads the env var at module-load time.
 if (process.env.ATTN_HARNESS_PROFILE === undefined) {
   process.env.ATTN_HARNESS_PROFILE = 'dev';
 }
@@ -135,6 +139,7 @@ function parseArgs(argv) {
   const selected = [];
   let failFast = false;
   let timeoutMs = 120_000;
+  let runAgainstProd = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
@@ -144,8 +149,10 @@ function parseArgs(argv) {
       failFast = true;
     } else if (arg === '--timeout-ms') {
       timeoutMs = Number(args[++index]);
+    } else if (arg === '--run-against-prod') {
+      runAgainstProd = true;
     } else if (arg === '--help' || arg === '-h') {
-      return { help: true, selected: [], failFast: false, timeoutMs: 120_000 };
+      return { help: true, selected: [], failFast: false, timeoutMs: 120_000, runAgainstProd: false };
     } else {
       throw new Error(`Unknown argument: ${arg}`);
     }
@@ -155,7 +162,7 @@ function parseArgs(argv) {
     throw new Error(`Invalid --timeout-ms value: ${timeoutMs}`);
   }
 
-  return { help: false, selected, failFast, timeoutMs };
+  return { help: false, selected, failFast, timeoutMs, runAgainstProd };
 }
 
 function printHelp() {
@@ -164,11 +171,12 @@ function printHelp() {
   node scripts/real-app-harness/run-serial-matrix.mjs --scenario tr205-codex --scenario tr504
   node scripts/real-app-harness/run-serial-matrix.mjs --fail-fast
   node scripts/real-app-harness/run-serial-matrix.mjs --timeout-ms 180000
+  ATTN_HARNESS_PROFILE= node scripts/real-app-harness/run-serial-matrix.mjs --run-against-prod
 
 Target: defaults to the dev install (~/Applications/attn-dev.app, port 29849)
   so the matrix never takes over your live prod app. Run \`make dev\` first
-  if you haven't built one. To point at a different profile set
-  ATTN_HARNESS_PROFILE=<name> (empty for prod) before invoking.
+  if you haven't built one. Production additionally requires the explicit
+  --run-against-prod acknowledgement.
 
 Available scenarios:
 ${scenarioCatalog.map((scenario) => `  - ${scenario.id}: ${scenario.label}`).join('\n')}
@@ -226,10 +234,17 @@ for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
   });
 }
 
-function runScenario(scenario, timeoutMs) {
+function runScenario(scenario, timeoutMs, runAgainstProd) {
   return new Promise((resolve) => {
     const startedAt = Date.now();
-    const child = spawn(scenario.command[0], scenario.command.slice(1), {
+    const childArgs = [...scenario.command.slice(1)];
+    if (runAgainstProd) {
+      if (!childArgs.includes('--')) {
+        childArgs.push('--');
+      }
+      childArgs.push('--run-against-prod');
+    }
+    const child = spawn(scenario.command[0], childArgs, {
       cwd: process.cwd(),
       stdio: 'inherit',
       env: process.env,
@@ -259,7 +274,7 @@ function runScenario(scenario, timeoutMs) {
 }
 
 async function main() {
-  const { help, selected, failFast, timeoutMs } = parseArgs(process.argv.slice(2));
+  const { help, selected, failFast, timeoutMs, runAgainstProd } = parseArgs(process.argv.slice(2));
   if (help) {
     printHelp();
     return;
@@ -267,6 +282,11 @@ async function main() {
 
   const scenarios = resolveScenarios(selected);
   const appPath = process.env.ATTN_REAL_APP_PATH || defaultAppPathForProfile();
+  const wsUrl = process.env.ATTN_REAL_APP_WS_URL || defaultWSURLForProfile();
+  assertProductionRunAllowed(
+    { appPath, wsUrl },
+    runAgainstProd ? ['--run-against-prod'] : process.argv.slice(2),
+  );
   console.log(`Matrix target: ${appPath} (ATTN_HARNESS_PROFILE=${process.env.ATTN_HARNESS_PROFILE || '<default>'})`);
   const preflightKeys = new Set();
   for (const scenario of scenarios) {
@@ -285,7 +305,7 @@ async function main() {
 
   for (const scenario of scenarios) {
     console.log(`\n=== ${scenario.label} (${scenario.id}) ===`);
-    const result = await runScenario(scenario, timeoutMs);
+    const result = await runScenario(scenario, timeoutMs, runAgainstProd);
     results.push(result);
     const status = result.code === 0 ? 'ok' : (result.timedOut ? 'timed-out' : 'failed');
     console.log(`--- ${scenario.id}: ${status} (${result.durationMs}ms) ---`);

--- a/app/scripts/real-app-harness/scenario-codex-resume-mapping.mjs
+++ b/app/scripts/real-app-harness/scenario-codex-resume-mapping.mjs
@@ -7,6 +7,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import {
   createSessionAndWaitForInitialPane,
+  assertCommonTargetAllowed,
   launchFreshAppAndConnect,
   parseCommonArgs,
   printCommonHelp,
@@ -42,10 +43,12 @@ function parseArgs(argv) {
     else if (arg === '--artifacts-dir') options.artifactsDir = args[++index];
     else if (arg === '--session-root-dir') options.sessionRootDir = args[++index];
     else if (arg === '--codex-executable') options.codexExecutable = args[++index] || '';
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
     else if (arg === '--help' || arg === '-h') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
 
+  if (!options.help) assertCommonTargetAllowed(options, args);
   return {
     options,
     help: Boolean(options.help),

--- a/app/scripts/real-app-harness/scenario-focus-probe.mjs
+++ b/app/scripts/real-app-harness/scenario-focus-probe.mjs
@@ -15,13 +15,14 @@ import {
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { MacOSDriver } from './macosDriver.mjs';
+import { bundleIdentifierForProfile } from './harnessProfile.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
 import { cleanupSessionViaAppClose } from './scenarioCleanup.mjs';
 import { waitForFirstWorkspacePane } from './scenarioAssertions.mjs';
 
 const execFileAsync = promisify(execFile);
 const WITNESS_BUNDLE_ID = 'com.apple.Terminal';
-const ATTN_BUNDLE_ID = 'com.attn.manager';
+const ATTN_BUNDLE_ID = bundleIdentifierForProfile();
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/app/scripts/real-app-harness/scenario-tr205-remote-relaunch-close-redraw.mjs
+++ b/app/scripts/real-app-harness/scenario-tr205-remote-relaunch-close-redraw.mjs
@@ -2,6 +2,7 @@
 
 import {
   createSessionAndWaitForInitialPane,
+  assertCommonTargetAllowed,
   launchFreshAppAndConnect,
   parseCommonArgs,
   printCommonHelp,
@@ -73,10 +74,12 @@ function parseArgs(argv) {
     else if (arg === '--ssh-target') options.sshTarget = args[++index] || options.sshTarget;
     else if (arg === '--remote-directory') options.remoteDirectory = args[++index] || '';
     else if (arg === '--remote-agent') options.remoteAgent = args[++index] || options.remoteAgent;
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
     else if (arg === '--help' || arg === '-h') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
 
+  if (!options.help) assertCommonTargetAllowed(options, args);
   return {
     options,
     help: Boolean(options.help),

--- a/app/scripts/real-app-harness/scenario-tr401-local-codex-main-window-resize.mjs
+++ b/app/scripts/real-app-harness/scenario-tr401-local-codex-main-window-resize.mjs
@@ -121,8 +121,8 @@ async function main() {
     });
 
     baselineWindow = await runner.step('normalize_window_bounds', async () => {
-      const currentBounds = await getFrontWindowBounds('com.attn.manager', { client });
-      return setFrontWindowBounds(normalizeBaselineWindowBounds(currentBounds), { client, bundleId: 'com.attn.manager' });
+      const currentBounds = await getFrontWindowBounds(client.bundleId, { client });
+      return setFrontWindowBounds(normalizeBaselineWindowBounds(currentBounds), { client });
     });
 
     sessionId = await runner.step('create_codex_session', async () => {
@@ -152,7 +152,7 @@ async function main() {
     });
 
     narrowWindow = await runner.step('narrow_window_and_capture_header', async () => {
-      const nextWindow = await setFrontWindowBounds(narrowWindowBounds(baselineWindow), { client, bundleId: 'com.attn.manager' });
+      const nextWindow = await setFrontWindowBounds(narrowWindowBounds(baselineWindow), { client });
       narrowMain = await waitForPaneState(
         client,
         sessionId,
@@ -184,7 +184,7 @@ async function main() {
     });
 
     restoredWindow = await runner.step('restore_window_and_capture_header', async () => {
-      const nextWindow = await setFrontWindowBounds(baselineWindow, { client, bundleId: 'com.attn.manager' });
+      const nextWindow = await setFrontWindowBounds(baselineWindow, { client });
       restoredMain = await waitForPaneState(
         client,
         sessionId,

--- a/app/scripts/real-app-harness/scenario-tr401-local-window-resize.mjs
+++ b/app/scripts/real-app-harness/scenario-tr401-local-window-resize.mjs
@@ -2,6 +2,7 @@
 
 import {
   createSessionAndWaitForInitialPane,
+  assertCommonTargetAllowed,
   launchFreshAppAndConnect,
   parseCommonArgs,
   printCommonHelp,
@@ -48,9 +49,11 @@ function parseArgs(argv) {
     else if (arg === '--artifacts-dir') options.artifactsDir = args[++index];
     else if (arg === '--session-root-dir') options.sessionRootDir = args[++index];
     else if (arg === '--agent') options.agent = args[++index] || options.agent;
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
     else if (arg === '--help' || arg === '-h') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
+  if (!options.help) assertCommonTargetAllowed(options, args);
   options.agent = String(options.agent || 'claude').toLowerCase();
   if (options.agent !== 'codex' && options.agent !== 'claude') {
     throw new Error(`Unsupported agent for local window-resize scenario: ${options.agent}`);
@@ -224,9 +227,9 @@ async function main() {
     });
 
     baselineWindow = await runner.step('normalize_window_bounds', async () => {
-      const currentBounds = await getFrontWindowBounds('com.attn.manager', { client });
+      const currentBounds = await getFrontWindowBounds(client.bundleId, { client });
       const targetBounds = normalizeBaselineWindowBounds(currentBounds);
-      return setFrontWindowBounds(targetBounds, { client, bundleId: 'com.attn.manager' });
+      return setFrontWindowBounds(targetBounds, { client });
     });
 
     sessionId = await runner.step('create_local_session', async () => {
@@ -371,7 +374,7 @@ async function main() {
 
     shrunkWindow = await runner.step('shrink_window_and_assert', async () => {
       const targetBounds = shrunkWindowBounds(baselineWindow);
-      const nextWindow = await setFrontWindowBounds(targetBounds, { client, bundleId: 'com.attn.manager' });
+      const nextWindow = await setFrontWindowBounds(targetBounds, { client });
 
       const mainThreshold = paneShrinkThreshold(baselineMainState?.pane?.bounds || {});
       const utilityThreshold = paneShrinkThreshold(baselineUtilityState?.pane?.bounds || {});
@@ -475,7 +478,7 @@ async function main() {
     });
 
     restoredWindow = await runner.step('restore_window_and_assert', async () => {
-      const nextWindow = await setFrontWindowBounds(baselineWindow, { client, bundleId: 'com.attn.manager' });
+      const nextWindow = await setFrontWindowBounds(baselineWindow, { client });
 
       const mainThreshold = paneRecoveryThreshold(baselineMainState?.pane?.bounds || {});
       const utilityThreshold = paneRecoveryThreshold(baselineUtilityState?.pane?.bounds || {});

--- a/app/scripts/real-app-harness/scenario-tr402-local-close-redraw.mjs
+++ b/app/scripts/real-app-harness/scenario-tr402-local-close-redraw.mjs
@@ -2,6 +2,7 @@
 
 import {
   createSessionAndWaitForInitialPane,
+  assertCommonTargetAllowed,
   launchFreshAppAndConnect,
   parseCommonArgs,
   printCommonHelp,
@@ -51,10 +52,12 @@ function parseArgs(argv) {
     else if (arg === '--artifacts-dir') options.artifactsDir = args[++index];
     else if (arg === '--session-root-dir') options.sessionRootDir = args[++index];
     else if (arg === '--agent') options.agent = args[++index] || options.agent;
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
     else if (arg === '--help' || arg === '-h') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
 
+  if (!options.help) assertCommonTargetAllowed(options, args);
   options.agent = String(options.agent || 'codex').toLowerCase();
   if (options.agent !== 'codex' && options.agent !== 'claude') {
     throw new Error(`Unsupported agent for local close-redraw scenario: ${options.agent}`);
@@ -218,8 +221,8 @@ async function main() {
     });
 
     await runner.step('normalize_window_origin_for_capture', async () => {
-      const bounds = await getFrontWindowBounds('com.attn.manager', { client });
-      await setFrontWindowBounds({ ...bounds, x: 80, y: 80 }, { client, bundleId: 'com.attn.manager' });
+      const bounds = await getFrontWindowBounds(client.bundleId, { client });
+      await setFrontWindowBounds({ ...bounds, x: 80, y: 80 }, { client });
     });
 
     if (options.agent === 'claude') {

--- a/app/scripts/real-app-harness/scenario-tr402-remote-close-redraw.mjs
+++ b/app/scripts/real-app-harness/scenario-tr402-remote-close-redraw.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { parseCommonArgs, printCommonHelp } from './common.mjs';
+import { assertCommonTargetAllowed, parseCommonArgs, printCommonHelp } from './common.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
@@ -48,10 +48,12 @@ function parseArgs(argv) {
     else if (arg === '--ssh-target') options.sshTarget = args[++index] || options.sshTarget;
     else if (arg === '--remote-directory') options.remoteDirectory = args[++index] || '';
     else if (arg === '--remote-agent') options.remoteAgent = args[++index] || options.remoteAgent;
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
     else if (arg === '--help' || arg === '-h') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
 
+  if (!options.help) assertCommonTargetAllowed(options, args);
   return {
     options,
     help: Boolean(options.help),

--- a/app/scripts/real-app-harness/scenario-tr502-remote-relaunch-splits.mjs
+++ b/app/scripts/real-app-harness/scenario-tr502-remote-relaunch-splits.mjs
@@ -2,6 +2,7 @@
 
 import {
   createSessionAndWaitForInitialPane,
+  assertCommonTargetAllowed,
   launchFreshAppAndConnect,
   parseCommonArgs,
   printCommonHelp,
@@ -77,10 +78,12 @@ function parseArgs(argv) {
     else if (arg === '--remote-directory') options.remoteDirectory = args[++index] || '';
     else if (arg === '--remote-agent') options.remoteAgent = args[++index] || options.remoteAgent;
     else if (arg === '--echo-threshold-ms') options.echoThresholdMs = Number.parseInt(args[++index] || '2500', 10);
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
     else if (arg === '--help' || arg === '-h') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
 
+  if (!options.help) assertCommonTargetAllowed(options, args);
   return {
     options,
     help: Boolean(options.help),

--- a/app/scripts/real-app-harness/scenario-tr504-remote-cleanup.mjs
+++ b/app/scripts/real-app-harness/scenario-tr504-remote-cleanup.mjs
@@ -3,6 +3,7 @@
 import path from 'node:path';
 import {
   createSessionAndWaitForInitialPane,
+  assertCommonTargetAllowed,
   launchFreshAppAndConnect,
   parseCommonArgs,
   printCommonHelp,
@@ -53,10 +54,12 @@ function parseArgs(argv) {
     else if (arg === '--ssh-target') options.sshTarget = args[++index] || options.sshTarget;
     else if (arg === '--remote-directory') options.remoteDirectory = args[++index] || '';
     else if (arg === '--remote-agent') options.remoteAgent = args[++index] || options.remoteAgent;
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
     else if (arg === '--help' || arg === '-h') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
 
+  if (!options.help) assertCommonTargetAllowed(options, args);
   return {
     options,
     help: Boolean(options.help),

--- a/app/scripts/real-app-harness/scenario-workspace-creation-shortcuts.mjs
+++ b/app/scripts/real-app-harness/scenario-workspace-creation-shortcuts.mjs
@@ -9,7 +9,6 @@ import {
   printCommonHelp,
 } from './common.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
-import { bundleIdentifierForProfile } from './harnessProfile.mjs';
 import { MacOSDriver } from './macosDriver.mjs';
 import {
   waitForPaneAttached,
@@ -144,7 +143,6 @@ async function main() {
   const observer = new DaemonObserver({ wsUrl: options.wsUrl });
   const driver = new MacOSDriver({
     appPath: options.appPath,
-    bundleId: bundleIdentifierForProfile(),
   });
   const createdSessionIds = [];
 

--- a/app/scripts/real-app-harness/scenario-workspace-switching.mjs
+++ b/app/scripts/real-app-harness/scenario-workspace-switching.mjs
@@ -10,7 +10,6 @@ import {
   printCommonHelp,
 } from './common.mjs';
 import { DaemonObserver } from './daemonObserver.mjs';
-import { bundleIdentifierForProfile } from './harnessProfile.mjs';
 import { MacOSDriver } from './macosDriver.mjs';
 import {
   captureSessionArtifacts,
@@ -206,7 +205,6 @@ async function main() {
   const observer = new DaemonObserver({ wsUrl: options.wsUrl });
   const driver = new MacOSDriver({
     appPath: options.appPath,
-    bundleId: bundleIdentifierForProfile(),
   });
   const createdSessionIds = [];
 

--- a/app/scripts/real-app-harness/ui-automation-cli.mjs
+++ b/app/scripts/real-app-harness/ui-automation-cli.mjs
@@ -6,9 +6,11 @@ function printHelp() {
   console.log(`Usage: pnpm exec node scripts/real-app-harness/ui-automation-cli.mjs [options] <action> [json-payload]
 
 Options:
-  --launch         Launch ~/Applications/attn.app before connecting
-  --fresh-launch   Quit and relaunch ~/Applications/attn.app before connecting
+  --launch         Launch the selected packaged app before connecting
+  --fresh-launch   Quit and relaunch the selected packaged app before connecting
   --wait-ready     Wait for the frontend automation hook before sending the action
+  --run-against-prod
+                   Explicitly allow targeting the production app
 
 Examples:
   pnpm exec node scripts/real-app-harness/ui-automation-cli.mjs ping
@@ -32,6 +34,9 @@ async function main() {
     if (flag === '--launch') launch = true;
     else if (flag === '--fresh-launch') freshLaunch = true;
     else if (flag === '--wait-ready') waitReady = true;
+    else if (flag === '--run-against-prod') {
+      // The shared UiAutomationClient guard reads this explicit acknowledgement.
+    }
     else if (flag === '--help' || flag === '-h') {
       printHelp();
       return;

--- a/app/scripts/real-app-harness/uiAutomationClient.mjs
+++ b/app/scripts/real-app-harness/uiAutomationClient.mjs
@@ -8,9 +8,10 @@ import { promisify } from 'node:util';
 import { MacOSDriver } from './macosDriver.mjs';
 import {
   assertProductionRunAllowed,
-  bundleIdentifierForProfile,
+  bundleIdentifierForAppPath,
   defaultAppPathForProfile,
   manifestPathForProfile,
+  profileForAppPath,
 } from './harnessProfile.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -21,12 +22,6 @@ const MINIMAL_SYSTEM_PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
 
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function defaultManifestPath() {
-  // Profile-aware: the dev bundle writes its manifest under
-  // ~/Library/Application Support/com.attn.manager.dev/...
-  return manifestPathForProfile();
 }
 
 function isTransientManifestReadError(error) {
@@ -115,17 +110,19 @@ function isFatalFrontendResponsivenessError(error) {
 export class UiAutomationClient {
   constructor({
     appPath = defaultAppPathForProfile(),
-    manifestPath = defaultManifestPath(),
+    manifestPath = null,
     launchEnv = null,
     backgroundLaunch = false,
-    bundleId = bundleIdentifierForProfile(),
+    bundleId = null,
   } = {}) {
-    assertProductionRunAllowed({ appPath, bundleId });
+    const appProfile = profileForAppPath(appPath);
+    const resolvedBundleId = bundleId || bundleIdentifierForAppPath(appPath);
+    assertProductionRunAllowed({ appPath, bundleId: resolvedBundleId });
     this.appPath = appPath;
-    this.manifestPath = manifestPath;
+    this.manifestPath = manifestPath || manifestPathForProfile(appProfile);
     this.launchEnv = launchEnv;
     this.backgroundLaunch = backgroundLaunch;
-    this.bundleId = bundleId;
+    this.bundleId = resolvedBundleId;
     this.currentSourceIdentityPromise = null;
     this.verifiedBuildIdentityKey = null;
   }

--- a/app/scripts/real-app-harness/uiAutomationClient.mjs
+++ b/app/scripts/real-app-harness/uiAutomationClient.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { MacOSDriver } from './macosDriver.mjs';
 import {
+  assertProductionRunAllowed,
   bundleIdentifierForProfile,
   defaultAppPathForProfile,
   manifestPathForProfile,
@@ -119,6 +120,7 @@ export class UiAutomationClient {
     backgroundLaunch = false,
     bundleId = bundleIdentifierForProfile(),
   } = {}) {
+    assertProductionRunAllowed({ appPath, bundleId });
     this.appPath = appPath;
     this.manifestPath = manifestPath;
     this.launchEnv = launchEnv;
@@ -188,7 +190,7 @@ export class UiAutomationClient {
 
   #focusDriver() {
     if (!this._focusDriver) {
-      this._focusDriver = new MacOSDriver({ bundleId: this.bundleId });
+      this._focusDriver = new MacOSDriver({ bundleId: this.bundleId, appPath: this.appPath });
     }
     return this._focusDriver;
   }

--- a/app/scripts/real-app-harness/uiAutomationClient.test.mjs
+++ b/app/scripts/real-app-harness/uiAutomationClient.test.mjs
@@ -40,6 +40,21 @@ describe('UiAutomationClient production safety', () => {
       bundleId: 'com.attn.manager',
     })).toThrow('Refusing to run the real-app harness against production');
   });
+
+  it('uses the production bundle and manifest for an acknowledged production app path', () => {
+    const originalArgv = process.argv;
+    process.argv = [...process.argv, '--run-against-prod'];
+    try {
+      const client = new UiAutomationClient({
+        appPath: path.join(os.homedir(), 'Applications', 'attn.app'),
+      });
+
+      expect(client.bundleId).toBe('com.attn.manager');
+      expect(client.manifestPath).toContain('Application Support/com.attn.manager/debug/ui-automation.json');
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
 });
 
 describe('UiAutomationClient.waitForFrontendResponsive', () => {

--- a/app/scripts/real-app-harness/uiAutomationClient.test.mjs
+++ b/app/scripts/real-app-harness/uiAutomationClient.test.mjs
@@ -1,3 +1,5 @@
+import os from 'node:os';
+import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 
@@ -28,6 +30,15 @@ describe('UiAutomationClient.request', () => {
       'Automation request failed: list_sessions: Session not found',
     );
     expect(client.requestOnce).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('UiAutomationClient production safety', () => {
+  it('refuses a production app target without the explicit acknowledgement', () => {
+    expect(() => new UiAutomationClient({
+      appPath: path.join(os.homedir(), 'Applications', 'attn.app'),
+      bundleId: 'com.attn.manager',
+    })).toThrow('Refusing to run the real-app harness against production');
   });
 });
 

--- a/app/scripts/real-app-harness/verify-focus-behavior.mjs
+++ b/app/scripts/real-app-harness/verify-focus-behavior.mjs
@@ -11,9 +11,13 @@
 //     --command 'pnpm --dir app run real-app:scenario-tr204'
 import { spawn, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import {
+  assertProductionRunAllowed,
+  bundleIdentifierForProfile,
+} from './harnessProfile.mjs';
 
 const execFileAsync = promisify(execFile);
-const ATTN_BUNDLE_ID = 'com.attn.manager';
+const ATTN_BUNDLE_ID = bundleIdentifierForProfile();
 
 const scenarioCommands = {
   tr201: ['pnpm', ['--dir', 'app', 'run', 'real-app:scenario-tr201']],
@@ -26,12 +30,18 @@ const scenarioCommands = {
 function parseArgs(argv) {
   const args = [...argv];
   if (args[0] === '--') args.shift();
-  const options = { scenario: null, command: null, intervalMs: 1000 };
+  const options = {
+    scenario: null,
+    command: null,
+    intervalMs: 1000,
+    runAgainstProd: false,
+  };
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === '--scenario') options.scenario = args[++i];
     else if (arg === '--command') options.command = args[++i];
     else if (arg === '--interval-ms') options.intervalMs = Number(args[++i]);
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
     else if (arg === '--help' || arg === '-h') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
@@ -56,11 +66,16 @@ async function main() {
     console.log(`Usage:
   node verify-focus-behavior.mjs --scenario <id>
   node verify-focus-behavior.mjs --command '<shell>'
+  node verify-focus-behavior.mjs --scenario <id> --run-against-prod
 
 Known scenario ids: ${Object.keys(scenarioCommands).join(', ')}
 `);
     return;
   }
+  assertProductionRunAllowed(
+    { bundleId: ATTN_BUNDLE_ID },
+    options.runAgainstProd ? ['--run-against-prod'] : [],
+  );
 
   let spawnCmd;
   let spawnArgs;
@@ -68,6 +83,9 @@ Known scenario ids: ${Object.keys(scenarioCommands).join(', ')}
     const entry = scenarioCommands[options.scenario];
     if (!entry) throw new Error(`Unknown scenario id: ${options.scenario}`);
     [spawnCmd, spawnArgs] = entry;
+    if (options.runAgainstProd) {
+      spawnArgs = [...spawnArgs, '--', '--run-against-prod'];
+    }
   } else if (options.command) {
     spawnCmd = 'bash';
     spawnArgs = ['-lc', options.command];

--- a/app/src/store/sessions.test.ts
+++ b/app/src/store/sessions.test.ts
@@ -184,6 +184,74 @@ describe('sessions store', () => {
     expect(state.recentSessionIds).toEqual([]);
   });
 
+  it('syncFromDaemonSessions retains a genuinely launching session with a pending workspace pane', () => {
+    useSessionStore.setState({
+      activeSessionId: 'launching-session',
+      recentSessionIds: [],
+      sessions: [
+        {
+          id: 'launching-session',
+          label: 'Launching',
+          state: 'launching',
+          cwd: '/tmp/launching',
+          workspaceId: 'workspace-launching',
+          agent: 'shell',
+          transcriptMatched: true,
+          daemonActivePaneId: 'pane-launching',
+          workspace: {
+            agents: [{
+              id: 'pane-launching',
+              runtimeId: 'launching-session',
+              title: 'Launching',
+              sessionId: 'launching-session',
+              status: 'spawning',
+            }],
+            layoutTree: { type: 'pane', paneId: 'pane-launching' },
+          },
+        },
+      ],
+    });
+
+    useSessionStore.getState().syncFromDaemonSessions([]);
+
+    expect(useSessionStore.getState().sessions.map((session) => session.id)).toEqual(['launching-session']);
+    expect(useSessionStore.getState().activeSessionId).toBe('launching-session');
+  });
+
+  it('syncFromDaemonSessions removes an exited session with a stale spawning pane', () => {
+    useSessionStore.setState({
+      activeSessionId: 'exited-session',
+      recentSessionIds: [],
+      sessions: [
+        {
+          id: 'exited-session',
+          label: 'Exited shell',
+          state: 'idle',
+          cwd: '/tmp/exited',
+          workspaceId: 'workspace-exited',
+          agent: 'shell',
+          transcriptMatched: true,
+          daemonActivePaneId: 'pane-exited',
+          workspace: {
+            agents: [{
+              id: 'pane-exited',
+              runtimeId: 'exited-session',
+              title: 'Exited shell',
+              sessionId: 'exited-session',
+              status: 'spawning',
+            }],
+            layoutTree: { type: 'pane', paneId: 'pane-exited' },
+          },
+        },
+      ],
+    });
+
+    useSessionStore.getState().syncFromDaemonSessions([]);
+
+    expect(useSessionStore.getState().sessions).toEqual([]);
+    expect(useSessionStore.getState().activeSessionId).toBeNull();
+  });
+
   it('syncFromDaemonSessions falls back to a remaining same-workspace session when recent selection is empty', () => {
     useSessionStore.setState({
       activeSessionId: 'split-session',

--- a/app/src/store/sessions.ts
+++ b/app/src/store/sessions.ts
@@ -378,6 +378,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
 
       const pendingLayoutSessions = state.sessions.filter((session) => (
         !syncedSessions.some((synced) => synced.id === session.id)
+        && session.state === 'launching'
         && session.workspace.agents.some((pane) => pane.sessionId === session.id && pane.status === 'spawning')
       ));
       const allSessions = [...syncedSessions, ...pendingLayoutSessions];


### PR DESCRIPTION
## Intent / Why

Closing a cleanly exited shell could leave attn showing an entirely black app because a stale local session suppressed the empty state after the daemon had removed its workspace. While reproducing that issue, the real-app harness also exposed that several commands could target the live production app without an explicit acknowledgement.

## Summary

- only preserve daemon-missing workspace sessions while they are genuinely launching, so exited shells cannot remain as invisible stale sessions
- add regression coverage for both genuine pending launches and stale spawning panes after exit
- default every real-app harness path to the isolated dev app and require `--run-against-prod` for production app, bundle, or daemon targets
- enforce the production guard in shared low-level lifecycle helpers, standalone commands, serial-matrix children, and research probes
- document the explicit production opt-in

## Test plan

- [x] `pnpm --dir app test` (70 files, 567 tests)
- [x] `pnpm --dir app run build`
- [x] `pnpm --dir app run real-app:scenario-autoclose-on-exit` against `attn-dev.app`
- [x] `pnpm --dir app run real-app:scenario-workspace-close-last-session-switches-back` against `attn-dev.app`
- [x] `git diff --check origin/main...HEAD`

## Out of scope

- The production app was not reinstalled or restarted during verification.
