### PR TITLE
Instrument terminal split/resize/close; coalesce split-drag PTY resizes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,8 +202,9 @@ When updating it:
 
 - write for users, not maintainers
 - summarize behavior changes, not implementation details
+- scope entries to the PR as a whole: describe the net user-visible outcome the PR delivers, not each step, iteration, or dead end taken along the way. A PR usually warrants a single focused entry even if it spanned many commits.
 - group related work into a small number of bullets
-- update it after meaningful features, fixes, removals, or commits
+- update it for meaningful user-visible features, fixes, or removals; internal-only changes (refactors, instrumentation, tests) do not need an entry
 
 ## When Something Is Broken
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ The app shows a one-time "What's new" summary after this upgrade, and `⌘/` bri
 
 ---
 
+## [2026-06-07]
+
+### Fixed
+- **Resizing workspace splits is less likely to stall active agent panes.** Split drags still update the visible terminal layout live, but attn now coalesces the PTY resize sent to each running agent while the drag is in progress so Claude and Codex are not forced to repaint repeatedly mid-drag.
+
 ## [2026-06-06]
 
 ### Changed

--- a/app/e2e/split-blank-repro.spec.ts
+++ b/app/e2e/split-blank-repro.spec.ts
@@ -1,0 +1,273 @@
+import { test, expect } from './fixtures';
+
+// Repro for: opening a shell split blanks the agent pane (canvas shows a live
+// cursor over blank cells; model still holds the content). The render trace
+// (added in GhosttyTerminal.renderSurface, gated on __ATTN_RENDER_TRACE_ON)
+// records, per paint: the cells-source offset, the printable cell count the
+// MODEL holds, and the `quads` actually submitted to the GPU. That lets us tell
+// "drew nothing despite content" (cells-source/offset) from "drew glyphs but
+// surface stayed blank" (GL/canvas).
+
+const ESC = '';
+const BSU = `${ESC}[?2026h`;
+const ESU = `${ESC}[?2026l`;
+
+// Mirrors the `paint` events pushed into the diagnostics ring
+// (see app/src/utils/terminalDiagnosticsLog.ts `PaintSample`). The ring stores
+// a pane key (paneId/sessionId/debugName) plus the session id, not a single
+// `debug` string.
+interface RenderTraceEntry {
+  at: number;
+  kind: string;
+  pane?: string;
+  session?: string;
+  force: boolean;
+  offset: number;
+  modelPrintable: number;
+  quads: number | null;
+  cellsArrayLen?: number | null;
+  skipNull?: number | null;
+  skipZeroWidth?: number | null;
+  cols: number;
+  rows: number;
+}
+
+function fullFrame(tag: string, rows = 50, cols = 140): string {
+  let out = `${BSU}${ESC}[?25l${ESC}[2J${ESC}[H`;
+  for (let r = 0; r < rows; r += 1) {
+    out += `${ESC}[${r + 1};1H` + `${tag} line ${r} `.padEnd(cols, '.').slice(0, cols);
+  }
+  out += `${ESC}[H${ESU}`;
+  return out;
+}
+
+async function emit(
+  page: import('@playwright/test').Page,
+  id: string,
+  data: string,
+) {
+  await page.evaluate(({ id, data }) => window.__TEST_EMIT_PTY_DATA?.(id, data), { id, data });
+}
+
+async function readTrace(
+  page: import('@playwright/test').Page,
+  sessionId: string,
+): Promise<RenderTraceEntry[]> {
+  return page.evaluate((sid) => {
+    const all = (window as Window & { __ATTN_RENDER_TRACE?: RenderTraceEntry[] }).__ATTN_RENDER_TRACE ?? [];
+    return all.filter((entry) =>
+      entry.kind === 'paint'
+      && (entry.session === sid || (typeof entry.pane === 'string' && entry.pane.includes(sid))));
+  }, sessionId) as Promise<RenderTraceEntry[]>;
+}
+
+test('agent pane stays painted after opening a shell split', async ({ page, daemon }) => {
+  await daemon.start();
+  await page.addInitScript(() => {
+    (window as Window & { __ATTN_RENDER_TRACE_ON?: boolean; __ATTN_RENDER_TRACE?: unknown[] }).__ATTN_RENDER_TRACE_ON = true;
+    (window as Window & { __ATTN_RENDER_TRACE?: unknown[] }).__ATTN_RENDER_TRACE = [];
+  });
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.goto('/');
+  await page.waitForSelector('.dashboard');
+
+  const agentId = 's-agent-split';
+  const workspaceId = `workspace-${agentId}`;
+  await page.evaluate(({ sessionId, workspaceId }) => {
+    window.__TEST_INJECT_SESSION?.({
+      id: sessionId,
+      label: 'Agent Split',
+      state: 'working',
+      cwd: '/tmp/test/agent-split',
+      workspaceId,
+    });
+  }, { sessionId: agentId, workspaceId });
+  await daemon.injectSession({
+    id: agentId,
+    label: 'Agent Split',
+    state: 'working',
+    directory: '/tmp/test/agent-split',
+    workspace_id: workspaceId,
+  });
+
+  await page.locator(`[data-testid="session-${agentId}"]`).click();
+  const terminal = page.locator(`[data-pane-session-id="${agentId}"][data-pane-kind="agent"] .terminal-container`);
+  await expect(terminal).toBeVisible({ timeout: 5000 });
+
+  // 1) Paint a full frame and confirm it actually rendered (high quad count).
+  await emit(page, agentId, fullFrame('OLD'));
+  await expect
+    .poll(async () => page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_TEXT?.(sid) ?? '', agentId), { timeout: 5000 })
+    .toContain('OLD line 0');
+  await expect
+    .poll(async () => {
+      const trace = await readTrace(page, agentId);
+      const last = trace[trace.length - 1];
+      return last?.quads ?? 0;
+    }, { timeout: 5000 })
+    .toBeGreaterThan(50);
+
+  const sizeBefore = await page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_SIZE?.(sid) ?? null, agentId);
+
+  // Reset the trace so we only inspect post-split paints.
+  await page.evaluate(() => { (window as Window & { __ATTN_RENDER_TRACE?: unknown[] }).__ATTN_RENDER_TRACE = []; });
+
+  // 2) Put the agent mid synchronized-frame (open BSU, no close), exactly like
+  //    the live daemon log showed right before the split SIGWINCH.
+  await emit(page, agentId, `${BSU}${ESC}[?25l${ESC}[H${ESC}[21C${ESC}[40B`);
+
+  // 3) Open the shell split (Cmd+D). This resizes the agent pane.
+  await terminal.click({ position: { x: 80, y: 8 } });
+  await page.keyboard.press('Meta+d');
+
+  // 4) Confirm the split actually resized the agent pane.
+  await expect
+    .poll(async () => {
+      const size = await page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_SIZE?.(sid) ?? null, agentId);
+      if (!size || !sizeBefore) return 'no-size';
+      return size.rows !== sizeBefore.rows || size.cols !== sizeBefore.cols ? 'resized' : 'same';
+    }, { timeout: 8000 })
+    .toBe('resized');
+
+  const sizeAfter = await page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_SIZE?.(sid) ?? null, agentId);
+
+  // 5) Agent responds to SIGWINCH with a fresh full redraw (2026 + 2J + content).
+  await emit(page, agentId, fullFrame('NEW', Math.max(10, (sizeAfter?.rows ?? 24) - 1), Math.max(20, (sizeAfter?.cols ?? 80))));
+
+  // Let paints settle.
+  await page.waitForTimeout(800);
+
+  const trace = await readTrace(page, agentId);
+  const tail = trace.slice(-12);
+  const last = trace[trace.length - 1];
+
+  console.log('=== SPLIT-BLANK REPRO DIAGNOSTICS ===');
+  console.log('sizeBefore', JSON.stringify(sizeBefore), 'sizeAfter', JSON.stringify(sizeAfter));
+  console.log('post-split render count:', trace.length);
+  console.log('last render:', JSON.stringify(last));
+  console.log('tail renders:');
+  for (const entry of tail) {
+    console.log(`  force=${entry.force} offset=${entry.offset} modelPrintable=${entry.modelPrintable} quads=${entry.quads} ${entry.cols}x${entry.rows}`);
+  }
+  const modelText = await page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_TEXT?.(sid) ?? '', agentId);
+  console.log('model contains NEW line 0:', modelText.includes('NEW line 0'));
+
+  await terminal.screenshot({ path: 'test-results/split-blank-agent.png' }).catch(() => {});
+
+  // The model must hold the redraw (sanity: bytes were applied).
+  expect(modelText).toContain('NEW line 0');
+  // The bug: the agent paints blank despite the model holding content. If the
+  // last paint drew (near) nothing, we've reproduced it.
+  expect(last, 'expected at least one agent paint after the split redraw').toBeTruthy();
+  expect(last!.quads ?? 0, `agent surface drew ${last?.quads} quads while model held ${last?.modelPrintable} printable cells`).toBeGreaterThan(50);
+});
+
+async function setupAgent(
+  page: import('@playwright/test').Page,
+  daemon: { injectSession: (s: { id: string; label: string; state: string; directory?: string; workspace_id?: string }) => Promise<void> },
+  agentId: string,
+) {
+  const workspaceId = `workspace-${agentId}`;
+  await page.evaluate(({ sessionId, workspaceId }) => {
+    window.__TEST_INJECT_SESSION?.({ id: sessionId, label: 'Agent Split', state: 'working', cwd: '/tmp/test/agent-split', workspaceId });
+  }, { sessionId: agentId, workspaceId });
+  await daemon.injectSession({ id: agentId, label: 'Agent Split', state: 'working', directory: '/tmp/test/agent-split', workspace_id: workspaceId });
+  await page.locator(`[data-testid="session-${agentId}"]`).click();
+  const terminal = page.locator(`[data-pane-session-id="${agentId}"][data-pane-kind="agent"] .terminal-container`);
+  await expect(terminal).toBeVisible({ timeout: 5000 });
+  return terminal;
+}
+
+function chunks(value: string, size: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < value.length; i += size) out.push(value.slice(i, i + size));
+  return out;
+}
+
+function dumpTail(label: string, trace: RenderTraceEntry[]) {
+  console.log(`=== ${label} ===`);
+  console.log('post-split render count:', trace.length);
+  for (const entry of trace.slice(-12)) {
+    console.log(`  force=${entry.force} offset=${entry.offset} modelPrintable=${entry.modelPrintable} quads=${entry.quads} ${entry.cols}x${entry.rows}`);
+  }
+}
+
+// Variant: redraw delivered in chunks that race the split's fit()/resize.
+test('agent stays painted when split races a chunked redraw', async ({ page, daemon }) => {
+  await daemon.start();
+  await page.addInitScript(() => {
+    (window as Window & { __ATTN_RENDER_TRACE_ON?: boolean; __ATTN_RENDER_TRACE?: unknown[] }).__ATTN_RENDER_TRACE_ON = true;
+    (window as Window & { __ATTN_RENDER_TRACE?: unknown[] }).__ATTN_RENDER_TRACE = [];
+  });
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.goto('/');
+  await page.waitForSelector('.dashboard');
+
+  const agentId = 's-agent-race';
+  const terminal = await setupAgent(page, daemon, agentId);
+
+  await emit(page, agentId, fullFrame('OLD'));
+  await expect.poll(async () => page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_TEXT?.(sid) ?? '', agentId), { timeout: 5000 }).toContain('OLD line 0');
+  await page.evaluate(() => { (window as Window & { __ATTN_RENDER_TRACE?: unknown[] }).__ATTN_RENDER_TRACE = []; });
+
+  // Open a synchronized frame (no close) — mid-frame, like the live log.
+  await emit(page, agentId, `${BSU}${ESC}[?25l${ESC}[H${ESC}[21C${ESC}[40B`);
+
+  // Fire the split, then immediately spam the redraw in small chunks WITHOUT
+  // awaiting the split to settle, so fit()/resize lands mid-redraw.
+  await terminal.click({ position: { x: 80, y: 8 } });
+  await page.keyboard.press('Meta+d');
+  const redraw = fullFrame('NEW', 44, 75);
+  for (const chunk of chunks(redraw, 180)) {
+    await emit(page, agentId, chunk);
+  }
+
+  await page.waitForTimeout(1200);
+  const trace = await readTrace(page, agentId);
+  dumpTail('CHUNKED RACE', trace);
+  const last = trace[trace.length - 1];
+  console.log('last:', JSON.stringify(last));
+  await terminal.screenshot({ path: 'test-results/split-blank-race.png' }).catch(() => {});
+  expect(last?.quads ?? 0, `agent drew ${last?.quads} quads, model had ${last?.modelPrintable}`).toBeGreaterThan(50);
+});
+
+// Variant: the user is scrolled up (viewportOffset != 0) when the split lands.
+// This matches the symptom: a live cursor over frozen/blank cells.
+test('agent stays painted when split lands while scrolled up', async ({ page, daemon }) => {
+  await daemon.start();
+  await page.addInitScript(() => {
+    (window as Window & { __ATTN_RENDER_TRACE_ON?: boolean; __ATTN_RENDER_TRACE?: unknown[] }).__ATTN_RENDER_TRACE_ON = true;
+    (window as Window & { __ATTN_RENDER_TRACE?: unknown[] }).__ATTN_RENDER_TRACE = [];
+  });
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.goto('/');
+  await page.waitForSelector('.dashboard');
+
+  const agentId = 's-agent-scroll';
+  const terminal = await setupAgent(page, daemon, agentId);
+
+  // Build scrollback so wheel-up produces a non-zero viewport offset.
+  const scrollback = Array.from({ length: 200 }, (_, i) => `HIST line ${String(i).padStart(3, '0')}`).join('\r\n');
+  await emit(page, agentId, `${ESC}[2J${ESC}[H${scrollback}`);
+  await emit(page, agentId, fullFrame('OLD'));
+  await expect.poll(async () => page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_TEXT?.(sid) ?? '', agentId), { timeout: 5000 }).toContain('OLD line 0');
+
+  // Scroll up.
+  await terminal.hover({ position: { x: 80, y: 200 } });
+  await page.mouse.wheel(0, -600);
+  await page.evaluate(() => { (window as Window & { __ATTN_RENDER_TRACE?: unknown[] }).__ATTN_RENDER_TRACE = []; });
+  await emit(page, agentId, `${BSU}${ESC}[?25l${ESC}[H${ESC}[21C${ESC}[40B`);
+
+  await page.keyboard.press('Meta+d');
+  await page.waitForTimeout(300);
+  await emit(page, agentId, fullFrame('NEW', 44, 75));
+  await page.waitForTimeout(1000);
+
+  const trace = await readTrace(page, agentId);
+  dumpTail('SCROLLED-UP SPLIT', trace);
+  const last = trace[trace.length - 1];
+  console.log('last:', JSON.stringify(last));
+  await terminal.screenshot({ path: 'test-results/split-blank-scrolled.png' }).catch(() => {});
+  // Diagnostic only: report whether a stale scrollback slice was painted.
+  console.log('offset on last paint:', last?.offset, 'force:', last?.force, 'quads:', last?.quads);
+});

--- a/app/scripts/real-app-harness/scenario-agent-split-blank-probe.mjs
+++ b/app/scripts/real-app-harness/scenario-agent-split-blank-probe.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+// DIAGNOSTIC probe for the "agent pane goes blank when a shell split opens" bug.
+// This is NOT an assertion scenario — it drives the exact user gesture (real
+// agent pane, then Cmd+D-equivalent vertical split that creates a shell pane
+// beside it) against the packaged dev app, captures native screenshots before
+// and after the split, and prints the agent paneId + split timestamp so the
+// on-disk render trace (debug/render-trace.jsonl) can be correlated.
+//
+// Remove together with the render-trace instrumentation once the root cause is
+// fixed (or promote into a proper regression scenario asserting the agent pane
+// stays painted after the split).
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  createRunContext,
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+  assertCommonTargetAllowed,
+} from './common.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import {
+  captureSessionArtifacts,
+  waitForFirstWorkspacePane,
+  waitForPaneVisible,
+  waitForSessionWorkspace,
+} from './scenarioAssertions.mjs';
+import {
+  ensureClaudeInitialPanePromptReady,
+  ensureCodexInitialPanePromptReady,
+  preTrustClaudeFolder,
+} from './scenarioAgents.mjs';
+import { getFrontWindowBounds, setFrontWindowBounds } from './nativeWindowCapture.mjs';
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs([]);
+  options.agent = 'claude';
+  options.settleMs = 5_000;
+  options.idleMs = 6_000;
+  options.splitMode = 'shortcut';
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--ws-url') options.wsUrl = args[++i];
+    else if (arg === '--app-path') options.appPath = args[++i];
+    else if (arg === '--artifacts-dir') options.artifactsDir = args[++i];
+    else if (arg === '--session-root-dir') options.sessionRootDir = args[++i];
+    else if (arg === '--agent') options.agent = (args[++i] || options.agent).toLowerCase();
+    else if (arg === '--settle-ms') options.settleMs = Number(args[++i]) || options.settleMs;
+    else if (arg === '--idle-ms') options.idleMs = Number(args[++i]) || options.idleMs;
+    else if (arg === '--split-mode') options.splitMode = args[++i] || options.splitMode;
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
+    else if (arg === '--help' || arg === '-h') options.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!options.help) assertCommonTargetAllowed(options, args);
+  if (options.agent !== 'codex' && options.agent !== 'claude') {
+    throw new Error(`Unsupported agent: ${options.agent}`);
+  }
+  return options;
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Wait until the agent stops repainting: the blank only persists when the agent
+// is IDLE at split time (a continuously-animating agent self-heals on its next
+// redraw). We consider it idle once the visible model is byte-stable for idleMs.
+async function waitForAgentIdle(client, sessionId, paneId, idleMs, maxWaitMs = 30_000) {
+  const startedAt = Date.now();
+  let lastSig = null;
+  let stableSince = Date.now();
+  while (Date.now() - startedAt < maxWaitMs) {
+    const v = await readAgentVisible(client, sessionId, paneId);
+    const sig = `${v.cols}x${v.rows}:${v.printableLines}:${v.charCount}`;
+    if (sig !== lastSig) {
+      lastSig = sig;
+      stableSince = Date.now();
+    } else if (Date.now() - stableSince >= idleMs) {
+      return { idle: true, waitedMs: Date.now() - startedAt, sig };
+    }
+    await sleep(400);
+  }
+  return { idle: false, waitedMs: Date.now() - startedAt, sig: lastSig };
+}
+
+async function readAgentVisible(client, sessionId, paneId) {
+  const state = await client.request('get_pane_state', { sessionId, paneId }, { timeoutMs: 20_000 }).catch(() => null);
+  const vc = state?.pane?.visibleContent || null;
+  if (!vc?.lines) return { cols: vc?.cols ?? null, rows: vc?.lines?.length ?? null, printableLines: 0, charCount: 0 };
+  let printableLines = 0;
+  let charCount = 0;
+  for (const line of vc.lines) {
+    const text = (line?.text || '').trim();
+    if (text.length > 0) { printableLines += 1; charCount += text.length; }
+  }
+  return { cols: vc.cols, rows: vc.lines.length, printableLines, charCount };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printCommonHelp('scripts/real-app-harness/scenario-agent-split-blank-probe.mjs');
+    console.log('  --agent <codex|claude>   agent to launch (default codex)');
+    console.log('  --settle-ms <n>          ms to wait after split before capture (default 4000)');
+    return;
+  }
+
+  const { runId, runDir, sessionDir } = createRunContext(options, `agent-split-blank-${options.agent}`);
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  let sessionId = null;
+
+  console.log(`[probe] runDir=${runDir}`);
+  console.log(`[probe] sessionDir=${sessionDir}`);
+  console.log(`[probe] agent=${options.agent}`);
+
+  try {
+    await launchFreshAppAndConnect(client, observer);
+
+    // Match the user's real geometry: a wide window so the agent pane is ~180
+    // cols before the split (~90 after), not the tiny default harness window.
+    try {
+      const bounds = await getFrontWindowBounds(client.bundleId, { client });
+      await setFrontWindowBounds({ ...bounds, x: 40, y: 40, width: 1680, height: 1050 }, { client });
+      console.log('[probe] window resized to 1680x1050');
+    } catch (error) {
+      console.log(`[probe] window resize skipped: ${error?.message || error}`);
+    }
+
+    if (options.agent === 'claude') {
+      preTrustClaudeFolder(sessionDir);
+    }
+
+    sessionId = await createSessionAndWaitForInitialPane({
+      client,
+      observer,
+      cwd: sessionDir,
+      label: `split-blank-${options.agent}-${runId}`,
+      agent: options.agent,
+      waitForInitialPaneVisible: false,
+      sessionWaitMs: 30_000,
+    });
+    console.log(`[probe] sessionId=${sessionId}`);
+
+    await client.request('select_session', { sessionId });
+    if (options.agent === 'claude') {
+      await ensureClaudeInitialPanePromptReady(client, sessionId, 45_000);
+    } else {
+      await ensureCodexInitialPanePromptReady(client, sessionId, 45_000);
+    }
+
+    const agentPane = await waitForFirstWorkspacePane(client, sessionId, `${options.agent} initial pane`, 20_000);
+    const agentPaneId = agentPane.paneId;
+    await waitForPaneVisible(client, sessionId, agentPaneId, 45_000);
+    console.log(`[probe] agentPaneId=${agentPaneId}`);
+
+    // Let the agent fully settle so it is NOT redrawing when the split opens.
+    const idleResult = await waitForAgentIdle(client, sessionId, agentPaneId, options.idleMs);
+    console.log(`[probe] idle gate: ${JSON.stringify(idleResult)}`);
+
+    const baselineVisible = await readAgentVisible(client, sessionId, agentPaneId);
+    console.log(`[probe] BASELINE agent model: ${JSON.stringify(baselineVisible)}`);
+    await captureSessionArtifacts(client, runDir, '01-baseline', sessionId);
+
+    // The decisive gesture: open the shell split beside the agent pane.
+    const workspaceBefore = await client.request('get_workspace', { sessionId });
+    const existingPaneIds = new Set((workspaceBefore.panes || []).map((p) => p.paneId));
+    // Focus the agent pane first so the shortcut targets it, then drive the
+    // real Cmd+D path (terminal.splitVertical) — same code path as the user.
+    await client.request('focus_pane', { sessionId, paneId: agentPaneId }).catch(() => {});
+    const splitAtMs = Date.now();
+    console.log(`[probe] SPLIT_AT_MS=${splitAtMs}`);
+    if (options.splitMode === 'command') {
+      await client.request('split_pane', { sessionId, targetPaneId: agentPaneId, direction: 'vertical' });
+    } else {
+      await client.request('dispatch_shortcut', { shortcutId: 'terminal.splitVertical' });
+    }
+    const wsAfter = await waitForSessionWorkspace(
+      client,
+      sessionId,
+      (ws) => (ws.panes || []).some((p) => !existingPaneIds.has(p.paneId) && p.runtimeId),
+      'new split pane beside agent',
+      30_000,
+    );
+    const shellPane = (wsAfter.panes || []).find((p) => !existingPaneIds.has(p.paneId));
+    console.log(`[probe] shellPaneId=${shellPane?.paneId} kind=${shellPane?.kind} title=${shellPane?.title}`);
+
+    await sleep(options.settleMs);
+
+    const afterVisible = await readAgentVisible(client, sessionId, agentPaneId);
+    console.log(`[probe] AFTER-SPLIT agent model: ${JSON.stringify(afterVisible)}`);
+    await captureSessionArtifacts(client, runDir, '02-after-split', sessionId);
+
+    // Re-focus the agent pane and capture once more — switching focus is one of
+    // the things the user said does NOT fix the blank.
+    await client.request('focus_pane', { sessionId, paneId: agentPaneId }).catch(() => {});
+    await sleep(1_000);
+    await captureSessionArtifacts(client, runDir, '03-agent-focused', sessionId);
+
+    const summary = {
+      ok: true,
+      runId,
+      sessionId,
+      agentPaneId,
+      shellPaneId: shellPane?.paneId ?? null,
+      splitAtMs,
+      baselineVisible,
+      afterVisible,
+      renderTraceFile: '$APPLOCALDATA/debug/render-trace.jsonl',
+    };
+    fs.writeFileSync(path.join(runDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    console.log('[probe] DONE');
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    if (sessionId) {
+      await client.request('close_session', { sessionId }).catch(() => {});
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close().catch(() => {});
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/src-tauri/capabilities/default.json
+++ b/app/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
     "fs:allow-read-text-file",
     "fs:allow-read-dir",
     "fs:allow-exists",
+    "fs:allow-stat",
     "fs:allow-mkdir",
     "clipboard-manager:allow-write-text",
     {

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -31,6 +31,13 @@ import {
 import { buildTerminalQueryResponses } from '../utils/terminalQueryResponses';
 import { isSuspiciousTerminalSize } from '../utils/terminalDebug';
 import { recordTerminalLinkHitTestEvent } from '../utils/terminalLinkHitTestLog';
+import {
+  recordDiag,
+  recordPaint,
+  noteResize,
+  registerRenderProbe,
+  disposePaneDiagnostics,
+} from '../utils/terminalDiagnosticsLog';
 import type { TerminalVisibleContentSnapshot } from '../utils/terminalVisibleContent';
 import { analyzeTerminalVisibleLines } from '../utils/terminalVisibleContent';
 import type { TerminalVisibleStyleSnapshot, TerminalVisibleStyleLineSnapshot } from '../utils/terminalStyleSummary';
@@ -43,6 +50,7 @@ import {
   createApplicationSelectionAnchor,
   offsetAfterWrite,
   relocateApplicationSelection,
+  shouldReportApplicationMouseMove,
   viewportBufferStart,
   viewportRowFromBufferRow,
   type ApplicationSelectionAnchor,
@@ -69,7 +77,7 @@ interface GhosttyTerminalProps {
   };
   onInput: (data: string) => void;
   onReady: (terminal: GhosttyTerminalHandle) => void;
-  onResize: (cols: number, rows: number, options?: { reason?: string }) => void;
+  onResize: (cols: number, rows: number, options?: { reason?: string; deferPty?: boolean }) => void;
 }
 
 export interface GhosttyTerminalHandle {
@@ -101,6 +109,24 @@ const URL_RE = /\b(?:https?:\/\/|file:\/\/|mailto:|ftp:\/\/|ssh:\/\/|git:\/\/|te
 // Ghostty's native renderer resets synchronized-output mode after 1000ms so
 // one bad producer cannot freeze rendering indefinitely.
 const SYNCHRONIZED_OUTPUT_RENDER_TIMEOUT_MS = 1000;
+
+function isWorkspaceResizeActive(element: HTMLElement | null): boolean {
+  if (document.documentElement.dataset.attnWorkspaceResizing === '1') {
+    return true;
+  }
+  const suppressUntil = Number(document.documentElement.dataset.attnWorkspaceMouseSuppressUntil || 0);
+  if (Number.isFinite(suppressUntil) && suppressUntil > Date.now()) {
+    return true;
+  }
+  return Boolean(element?.closest('.session-terminal-panes[data-resizing-split-id]'));
+}
+
+function isWorkspaceResizeDragActive(element: HTMLElement | null): boolean {
+  if (document.documentElement.dataset.attnWorkspaceResizing === '1') {
+    return true;
+  }
+  return Boolean(element?.closest('.session-terminal-panes[data-resizing-split-id]'));
+}
 
 function literalUrlAtColumn(line: string, col: number): string | null {
   for (const match of line.matchAll(URL_RE)) {
@@ -160,6 +186,20 @@ function cellFromRect(
 
 function colorNumber(value: string): number {
   return Number.parseInt(value.slice(1), 16);
+}
+
+// Count printable cells in the live viewport window. getViewport() returns a
+// fixed-capacity buffer whose tail can hold stale cells from a larger pre-resize
+// grid, so only the first cols*rows entries are counted.
+function countModelPrintable(terminal: GhosttyModel): number {
+  const viewport = terminal.getViewport();
+  const windowLen = terminal.cols * terminal.rows;
+  let printable = 0;
+  for (let i = 0; i < windowLen && i < viewport.length; i += 1) {
+    const cell = viewport[i];
+    if (cell && cell.codepoint > 32) printable += 1;
+  }
+  return printable;
 }
 
 function emptyStartup(): TerminalPerfStartupSnapshot {
@@ -237,6 +277,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const synchronizedOutputRenderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const renderCountRef = useRef(0);
     const writeCountRef = useRef(0);
+    // Diagnostics: model instance (increments on rebuild) and last paint quads,
+    // used by the blank-on-split watchdog to tell a fresh empty model and an
+    // under-drawn surface apart.
+    const modelInstanceRef = useRef(0);
+    const lastPaintQuadsRef = useRef(0);
     const lastRenderAtRef = useRef(0);
     const lastWriteAtRef = useRef(0);
     const readyRef = useRef(false);
@@ -246,6 +291,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const onResizeRef = useRef(onResize);
     const runtimeMetaRef = useRef(runtimeLogMeta);
     const debugNameRef = useRef(debugName);
+    const diagKeyRef = useRef<string>(runtimeLogMeta?.paneId ?? runtimeLogMeta?.sessionId ?? debugName);
     const [error, setError] = useState<string | null>(null);
     const [linkCursorActive, setLinkCursorActive] = useState(false);
 
@@ -254,6 +300,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     onResizeRef.current = onResize;
     runtimeMetaRef.current = runtimeLogMeta;
     debugNameRef.current = debugName;
+    // Stable diagnostics key for the per-pane watchdog/probe registries. paneId
+    // is stable for a pane's life and correlates with daemon/workspace logs;
+    // debugName can change (its agent/title segment is reassigned on relabel).
+    // A ref keeps the key out of callback dependency arrays.
+    diagKeyRef.current = runtimeLogMeta?.paneId ?? runtimeLogMeta?.sessionId ?? debugName;
 
     const getViewportCells = useCallback((): GhosttyCell[] | undefined => {
       const terminal = terminalRef.current;
@@ -286,7 +337,21 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       if (sample) {
         renderCountRef.current += 1;
         lastRenderAtRef.current = Date.now();
+        lastPaintQuadsRef.current = sample.quads;
       }
+      recordPaint({
+        pane: diagKeyRef.current,
+        session: runtimeMetaRef.current?.sessionId ?? undefined,
+        cols: terminal.cols,
+        rows: terminal.rows,
+        force,
+        offset: viewportOffsetRef.current,
+        modelPrintable: countModelPrintable(terminal),
+        quads: sample ? sample.quads : null,
+        cellsArrayLen: sample ? sample.cellsArrayLen : null,
+        skipNull: sample ? sample.printableSkippedNull : null,
+        skipZeroWidth: sample ? sample.printableSkippedZeroWidth : null,
+      });
     }, [getViewportCells, resolvedTheme]);
 
     const clearSynchronizedOutputRenderTimer = useCallback(() => {
@@ -552,6 +617,17 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           searchableOutput,
         );
         synchronizedOutputStateRef.current = synchronizedOutput.state;
+        recordDiag({
+          kind: 'write',
+          pane: diagKeyRef.current,
+          session: runtimeMetaRef.current?.sessionId ?? undefined,
+          model: modelInstanceRef.current,
+          len: searchableOutput.length,
+          syncActive: synchronizedOutput.state.active,
+          shouldRender: synchronizedOutput.shouldRender,
+          cols: terminal.cols,
+          rows: terminal.rows,
+        });
         if (synchronizedOutput.shouldRender) {
           flushSynchronizedOutputRender();
         } else {
@@ -566,9 +642,17 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       const terminal = terminalRef.current;
       const renderer = rendererRef.current;
       if (!terminal || !renderer) return;
+      const fromCols = terminal.cols;
+      const fromRows = terminal.rows;
       terminal.resize(cols, rows);
       modelSizeRef.current = { cols, rows };
       renderer.resize(cols, rows);
+      noteResize(diagKeyRef.current, {
+        session: runtimeMetaRef.current?.sessionId ?? undefined,
+        paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
+        source: 'resizeLocal', fromCols, fromRows, toCols: cols, toRows: rows,
+        noop: fromCols === cols && fromRows === rows,
+      });
       renderSurface(true);
     }), [enqueueOperation, renderSurface]);
 
@@ -580,17 +664,34 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       // Inactive session wrappers use display:none. Resizing the Ghostty
       // model from that hidden geometry discards an idle alternate-screen
       // frame before the session becomes visible again.
-      if (runtimeMetaRef.current && !runtimeMetaRef.current.isActiveSession) return;
-      const dims = renderer.fitDimensions(container.clientWidth, container.clientHeight);
-      if (runtimeMetaRef.current?.paneKind === 'agent' && isSuspiciousTerminalSize(dims.cols, dims.rows)) {
+      const paneKind = runtimeMetaRef.current?.paneKind ?? undefined;
+      const session = runtimeMetaRef.current?.sessionId ?? undefined;
+      if (runtimeMetaRef.current && !runtimeMetaRef.current.isActiveSession) {
+        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'inactiveSession' });
         return;
       }
-      if (dims.cols === terminal.cols && dims.rows === terminal.rows) return;
+      const dims = renderer.fitDimensions(container.clientWidth, container.clientHeight);
+      if (runtimeMetaRef.current?.paneKind === 'agent' && isSuspiciousTerminalSize(dims.cols, dims.rows)) {
+        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'suspiciousSize', toCols: dims.cols, toRows: dims.rows });
+        return;
+      }
+      if (dims.cols === terminal.cols && dims.rows === terminal.rows) {
+        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'sameSize', toCols: dims.cols, toRows: dims.rows });
+        return;
+      }
+      const fromCols = terminal.cols;
+      const fromRows = terminal.rows;
       terminal.resize(dims.cols, dims.rows);
       modelSizeRef.current = dims;
       renderer.resize(dims.cols, dims.rows);
+      noteResize(diagKeyRef.current, {
+        session, paneKind, source: 'fit', fromCols, fromRows, toCols: dims.cols, toRows: dims.rows,
+      });
       renderSurface(true);
-      onResizeRef.current(dims.cols, dims.rows, { reason: 'ghostty_fit' });
+      onResizeRef.current(dims.cols, dims.rows, {
+        reason: 'ghostty_fit',
+        deferPty: isWorkspaceResizeDragActive(container),
+      });
     }, [renderSurface]);
 
     useImperativeHandle(ref, () => ({
@@ -605,7 +706,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       isInputFocused: () => document.activeElement === containerRef.current,
       write,
       resizeLocal,
-      reset: () => { void write('\x1bc'); },
+      reset: () => { recordDiag({ kind: 'reset', pane: diagKeyRef.current, session: runtimeMetaRef.current?.sessionId ?? undefined, model: modelInstanceRef.current }); void write('\x1bc'); },
       scrollToTop: () => {
         const terminal = terminalRef.current;
         if (!terminal) return false;
@@ -641,6 +742,17 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         });
         synchronizedOutputStateRef.current = { active: false, pending: '' };
         clearSynchronizedOutputRenderTimer();
+        modelInstanceRef.current += 1;
+        recordDiag({
+          kind: 'pane_mount',
+          pane: diagKeyRef.current,
+          label: debugNameRef.current,
+          session: runtimeMetaRef.current?.sessionId ?? undefined,
+          paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
+          model: modelInstanceRef.current,
+          cols: initialSize.cols,
+          rows: initialSize.rows,
+        });
         const renderer = new WebGlTerminalRenderer(canvas, fontSize, FONT_FAMILY, {
           background: theme.background,
           foreground: theme.foreground,
@@ -648,6 +760,19 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         });
         terminalRef.current = terminal;
         rendererRef.current = renderer;
+        // Live probe for the blank-on-resize watchdog: lets the diagnostics
+        // module read the current model fill vs the last paint's quad count.
+        registerRenderProbe(diagKeyRef.current, () => {
+          const model = terminalRef.current;
+          if (!model) return null;
+          return {
+            cols: model.cols,
+            rows: model.rows,
+            modelPrintable: countModelPrintable(model),
+            lastPaintAt: lastRenderAtRef.current,
+            lastPaintQuads: lastPaintQuadsRef.current,
+          };
+        });
         inputRef.current = new InputHandler(
           ghostty,
           container,
@@ -671,7 +796,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           isInputFocused: () => document.activeElement === container,
           write,
           resizeLocal,
-          reset: () => { void write('\x1bc'); },
+          reset: () => { recordDiag({ kind: 'reset', pane: diagKeyRef.current, session: runtimeMetaRef.current?.sessionId ?? undefined, model: modelInstanceRef.current }); void write('\x1bc'); },
           scrollToTop: () => { viewportOffsetRef.current = terminal.getScrollbackLength(); wheelRemainderRowsRef.current = 0; renderSurface(true); return true; },
           getText,
           getSize: () => ({ cols: terminal.cols, rows: terminal.rows }),
@@ -724,6 +849,14 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       });
       return () => {
         active = false;
+        recordDiag({
+          kind: 'pane_unmount',
+          pane: diagKeyRef.current,
+          label: debugNameRef.current,
+          session: runtimeMetaRef.current?.sessionId ?? undefined,
+          model: modelInstanceRef.current,
+        });
+        disposePaneDiagnostics(diagKeyRef.current);
         observer?.disconnect();
         canvas.removeEventListener('webglcontextlost', handleContextLost);
         unregister();
@@ -910,12 +1043,22 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       action: 'press' | 'move' | 'release',
       event: React.MouseEvent,
     ): boolean => {
+      if (isWorkspaceResizeActive(containerRef.current)) return false;
       const terminal = terminalRef.current;
       const cell = cellFromPointer(event);
       if (!terminal || !cell || !terminal.hasMouseTracking()) return false;
       const activeButton = trackedMouseButtonRef.current;
       if (action === 'move') {
-        if (!terminal.getMode(1003) && !(activeButton !== null && terminal.getMode(1002))) {
+        const shouldReport = shouldReportApplicationMouseMove({
+          anyEventMouseTracking: terminal.getMode(1003),
+          dragMouseTracking: terminal.getMode(1002),
+          activeButton,
+          buttons: event.buttons,
+        });
+        if (!shouldReport) {
+          if (activeButton !== null && event.buttons === 0) {
+            trackedMouseButtonRef.current = null;
+          }
           return true;
         }
       } else if (action === 'release' && activeButton === null) {
@@ -1038,6 +1181,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           onInputRef.current('\x16');
         }}
         onWheel={(event) => {
+          if (isWorkspaceResizeActive(containerRef.current)) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+          }
           if (event.defaultPrevented) return;
           const terminal = terminalRef.current;
           const renderer = rendererRef.current;
@@ -1087,6 +1235,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           renderSurface(true);
         }}
         onMouseDown={(event) => {
+          if (isWorkspaceResizeActive(containerRef.current)) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+          }
           containerRef.current?.focus();
           const terminal = terminalRef.current;
           const cell = cellFromPointer(event);
@@ -1111,6 +1264,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           startSelectionDrag();
         }}
         onMouseMove={(event) => {
+          if (isWorkspaceResizeActive(containerRef.current)) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+          }
           // While selecting, the drag is owned by the document listeners in
           // startSelectionDrag() so it survives crossing sibling overlays.
           if (selectingRef.current) return;
@@ -1134,6 +1292,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           setLinkCursorActive(false);
         }}
         onMouseUp={(event) => {
+          if (isWorkspaceResizeActive(containerRef.current)) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+          }
           // A selection release is finalized by the document mouseup listener so
           // it fires even when the pointer ends over a sibling overlay.
           if (selectingRef.current) return;

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -42,6 +42,12 @@ export interface WebGlRenderSample {
   cells: number;
   quads: number;
   glyphUploads: number;
+  // TEMP (blank-on-split): diagnostics to explain why drawn quads can fall
+  // below the model's printable-cell count after a resize. Remove with the
+  // render-trace instrumentation once the root cause is fixed.
+  cellsArrayLen: number;
+  printableSkippedNull: number;
+  printableSkippedZeroWidth: number;
 }
 
 export function graphemeAtViewportCell(
@@ -301,6 +307,10 @@ export class WebGlTerminalRenderer {
     const vertices: number[] = [];
     const glyphCountBefore = this.glyphs.size;
     const atlasGenerationBefore = this.atlasGeneration;
+    // TEMP (blank-on-split): count printable cells dropped by the width/null
+    // skip below, to distinguish "cells array too short" from "width===0".
+    let printableSkippedNull = 0;
+    let printableSkippedZeroWidth = 0;
 
     gl.clearColor(defaultBg.r / 255, defaultBg.g / 255, defaultBg.b / 255, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
@@ -309,6 +319,15 @@ export class WebGlTerminalRenderer {
       for (let col = 0; col < terminal.cols; col += 1) {
         const cell = cells[row * terminal.cols + col];
         if (!cell || cell.width === 0) {
+          if (cell && cell.codepoint > 32) {
+            printableSkippedZeroWidth += 1;
+          } else if (!cell) {
+            // Only count as a "printable" miss if this index is in-bounds for
+            // the model grid but absent from the cells array.
+            if (row * terminal.cols + col < terminal.cols * terminal.rows) {
+              printableSkippedNull += 1;
+            }
+          }
           continue;
         }
         const width = Math.max(cell.width, 1) * this.cellWidth * scale;
@@ -373,6 +392,9 @@ export class WebGlTerminalRenderer {
       cells: terminal.cols * terminal.rows,
       quads: vertices.length / FLOATS_PER_VERTEX / 6,
       glyphUploads: this.glyphs.size - glyphCountBefore,
+      cellsArrayLen: cells.length,
+      printableSkippedNull,
+      printableSkippedZeroWidth,
     };
   }
 

--- a/app/src/components/SessionTerminalWorkspace.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace.test.tsx
@@ -149,6 +149,9 @@ describe('SessionTerminalWorkspace', () => {
     mockPtyAttach.mockReset();
     mockPtyResize.mockReset();
     mockPtyWrite.mockReset();
+    delete document.documentElement.dataset.attnWorkspaceResizing;
+    delete document.documentElement.dataset.attnWorkspaceResizeToken;
+    delete document.documentElement.dataset.attnWorkspaceMouseSuppressUntil;
     vi.useRealTimers();
   });
 
@@ -416,7 +419,16 @@ describe('SessionTerminalWorkspace', () => {
     });
 
     fireEvent.pointerDown(screen.getByRole('separator'), { button: 0, clientX: 500, clientY: 250 });
+    const shield = container.querySelector('.workspace-resize-shield');
+    expect(shield).toHaveAttribute('data-resizing-split-id', 'root');
+    expect(shield).toHaveClass('workspace-resize-shield--vertical');
+    expect(panes).toHaveAttribute('data-resizing-split-id', 'root');
+    expect(document.documentElement).toHaveAttribute('data-attn-workspace-resizing', '1');
+    expect(Number(document.documentElement.dataset.attnWorkspaceMouseSuppressUntil)).toBeGreaterThan(Date.now());
     fireEvent.pointerUp(window, { clientX: 800, clientY: 250 });
+    expect(container.querySelector('.workspace-resize-shield')).toBeNull();
+    expect(panes).not.toHaveAttribute('data-resizing-split-id');
+    expect(document.documentElement).not.toHaveAttribute('data-attn-workspace-resizing');
     expect(container.querySelector('.workspace-layout-metadata [data-split-id="root"]')).toHaveAttribute('data-split-ratio', '0.800');
 
     await act(async () => {
@@ -510,8 +522,15 @@ describe('SessionTerminalWorkspace', () => {
 
     fireEvent.pointerDown(screen.getByRole('separator'), { button: 0, clientX: 500, clientY: 250 });
     expect(document.body.style.userSelect).toBe('none');
+    expect(container.querySelector('.workspace-resize-shield')).toHaveAttribute('data-resizing-split-id', 'root');
+    expect(panes).toHaveAttribute('data-resizing-split-id', 'root');
+    expect(document.documentElement).toHaveAttribute('data-attn-workspace-resizing', '1');
+    expect(Number(document.documentElement.dataset.attnWorkspaceMouseSuppressUntil)).toBeGreaterThan(Date.now());
     fireEvent.pointerCancel(window);
     expect(document.body.style.userSelect).toBe('');
+    expect(container.querySelector('.workspace-resize-shield')).toBeNull();
+    expect(panes).not.toHaveAttribute('data-resizing-split-id');
+    expect(document.documentElement).not.toHaveAttribute('data-attn-workspace-resizing');
 
     rerender(
       <SessionTerminalWorkspace

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -166,6 +166,23 @@
   height: 3px;
 }
 
+.workspace-resize-shield {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  background: transparent;
+  pointer-events: auto;
+  touch-action: none;
+}
+
+.workspace-resize-shield--vertical {
+  cursor: col-resize;
+}
+
+.workspace-resize-shield--horizontal {
+  cursor: row-resize;
+}
+
 .workspace-split {
   display: grid;
   min-width: 0;

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -36,10 +36,15 @@ import type { DockTarget } from './dockTarget';
 
 const ZOOM_PATH_RATIO = 0.76;
 const RESIZE_MOUSE_SUPPRESSION_MS = 1_500;
+// After a drag ends the active-resize token is cleared, so suppression no longer
+// rides on it; we only need to briefly swallow the trailing pointerup/synthetic
+// click from the release itself. Keep this short so a deliberate click, select,
+// or scroll right after resizing is not dropped.
+const RESIZE_MOUSE_RELEASE_GUARD_MS = 150;
 
-function suppressTerminalMouseDuringResize(): void {
+function suppressTerminalMouseDuringResize(durationMs = RESIZE_MOUSE_SUPPRESSION_MS): void {
   document.documentElement.dataset.attnWorkspaceMouseSuppressUntil = String(
-    Date.now() + RESIZE_MOUSE_SUPPRESSION_MS,
+    Date.now() + durationMs,
   );
 }
 
@@ -912,7 +917,9 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
           delete document.documentElement.dataset.attnWorkspaceResizing;
           delete document.documentElement.dataset.attnWorkspaceResizeToken;
         }
-        suppressTerminalMouseDuringResize();
+        // Only a short trailing-event guard here — the long during-drag window
+        // would otherwise outlive the drag and swallow normal interaction.
+        suppressTerminalMouseDuringResize(RESIZE_MOUSE_RELEASE_GUARD_MS);
         releaseSelectionLock();
         setResizingSplit((current) => (current?.splitId === splitId ? null : current));
         dragCleanupRef.current = null;

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -35,6 +35,13 @@ import { startLeafDrag, type LeafDropSnapshot } from './leafDrag';
 import type { DockTarget } from './dockTarget';
 
 const ZOOM_PATH_RATIO = 0.76;
+const RESIZE_MOUSE_SUPPRESSION_MS = 1_500;
+
+function suppressTerminalMouseDuringResize(): void {
+  document.documentElement.dataset.attnWorkspaceMouseSuppressUntil = String(
+    Date.now() + RESIZE_MOUSE_SUPPRESSION_MS,
+  );
+}
 
 function zoomLayoutTowardPane(node: TerminalLayoutNode, paneId: string): TerminalLayoutNode {
   if (node.type !== 'split') {
@@ -170,6 +177,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     // Live, optimistic split ratios while dragging a divider. Reconciled against
     // the daemon layout once it echoes the persisted (locked) ratio back.
     const [ratioOverrides, setRatioOverrides] = useState<Map<string, number>>(() => new Map());
+    const [resizingSplit, setResizingSplit] = useState<{ splitId: string; direction: TerminalSplitDirection } | null>(null);
     // Drag-to-dock state. The tile stays docked in the daemon tree throughout
     // the drag — this is a transient preview (ghost + target highlight) that
     // resolves to a single dock command on drop.
@@ -821,17 +829,35 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         return;
       }
       event.preventDefault();
+      event.stopPropagation();
       const container = (event.target as HTMLElement).closest('.session-terminal-panes') as HTMLElement | null;
       if (!container) {
         return;
       }
+      const dividerElement = event.currentTarget;
+      const pointerId = event.pointerId;
+      if (typeof dividerElement.setPointerCapture === 'function') {
+        try {
+          dividerElement.setPointerCapture(pointerId);
+        } catch {
+          // The pointer can already be gone if the app loses focus mid-press.
+        }
+      }
       const rect = container.getBoundingClientRect();
       const { splitId, direction, left, top, right, bottom } = divider;
+      const resizeToken = `${splitId}:${pointerId}`;
+      suppressTerminalMouseDuringResize();
+      container.dataset.resizingSplitId = splitId;
+      container.dataset.resizingSplitDirection = direction;
+      container.dataset.resizingSplitToken = resizeToken;
+      document.documentElement.dataset.attnWorkspaceResizing = '1';
+      document.documentElement.dataset.attnWorkspaceResizeToken = resizeToken;
       const spanNorm = direction === 'vertical' ? right - left : bottom - top;
       const axisPx = direction === 'vertical' ? rect.width : rect.height;
       const spanPx = spanNorm * axisPx;
       const minRatio = spanPx > 0 ? Math.min(0.45, 120 / spanPx) : 0.1;
       draggingSplitRef.current = splitId;
+      setResizingSplit({ splitId, direction });
       const releaseSelectionLock = lockTextSelection(
         direction === 'vertical' ? 'col-resize' : 'row-resize',
       );
@@ -849,21 +875,46 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       };
 
       const onMove = (ev: PointerEvent) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        suppressTerminalMouseDuringResize();
         pendingRatioRef.current = { splitId, ratio: computeRatio(ev.clientX, ev.clientY) };
         if (ratioRafRef.current == null) {
           ratioRafRef.current = window.requestAnimationFrame(flushRatioOverride);
         }
       };
       const teardown = () => {
-        window.removeEventListener('pointermove', onMove);
-        window.removeEventListener('pointerup', onUp);
-        window.removeEventListener('pointercancel', onCancel);
+        window.removeEventListener('pointermove', onMove, true);
+        window.removeEventListener('pointerup', onUp, true);
+        window.removeEventListener('pointercancel', onCancel, true);
         window.removeEventListener('blur', onCancel);
+        if (
+          typeof dividerElement.hasPointerCapture === 'function'
+          && typeof dividerElement.releasePointerCapture === 'function'
+          && dividerElement.hasPointerCapture(pointerId)
+        ) {
+          try {
+            dividerElement.releasePointerCapture(pointerId);
+          } catch {
+            // Nothing to release if the browser already cancelled capture.
+          }
+        }
         if (ratioRafRef.current != null) {
           window.cancelAnimationFrame(ratioRafRef.current);
           ratioRafRef.current = null;
         }
+        if (container.dataset.resizingSplitToken === resizeToken) {
+          delete container.dataset.resizingSplitId;
+          delete container.dataset.resizingSplitDirection;
+          delete container.dataset.resizingSplitToken;
+        }
+        if (document.documentElement.dataset.attnWorkspaceResizeToken === resizeToken) {
+          delete document.documentElement.dataset.attnWorkspaceResizing;
+          delete document.documentElement.dataset.attnWorkspaceResizeToken;
+        }
+        suppressTerminalMouseDuringResize();
         releaseSelectionLock();
+        setResizingSplit((current) => (current?.splitId === splitId ? null : current));
         dragCleanupRef.current = null;
       };
       const onCancel = () => {
@@ -873,6 +924,8 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         clearRatioOverride(splitId);
       };
       const onUp = (ev: PointerEvent) => {
+        ev.preventDefault();
+        ev.stopPropagation();
         const ratio = computeRatio(ev.clientX, ev.clientY);
         teardown();
         pendingRatioRef.current = { splitId, ratio };
@@ -884,9 +937,9 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         }
       };
       dragCleanupRef.current = teardown;
-      window.addEventListener('pointermove', onMove);
-      window.addEventListener('pointerup', onUp);
-      window.addEventListener('pointercancel', onCancel);
+      window.addEventListener('pointermove', onMove, true);
+      window.addEventListener('pointerup', onUp, true);
+      window.addEventListener('pointercancel', onCancel, true);
       window.addEventListener('blur', onCancel);
     }, [clearRatioOverride, flushRatioOverride, onResizeSplit]);
 
@@ -942,17 +995,47 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
           containerRef={panesContainerRef}
           dividers={splitDividers}
           onDividerPointerDown={handleDividerPointerDown}
-          overlay={effectiveDockTarget ? (
-            <div
-              className="workspace-dock-target"
-              style={{
-                left: `${effectiveDockTarget.rect.left * 100}%`,
-                top: `${effectiveDockTarget.rect.top * 100}%`,
-                width: `${effectiveDockTarget.rect.width * 100}%`,
-                height: `${effectiveDockTarget.rect.height * 100}%`,
-              }}
-            />
-          ) : null}
+          overlay={(
+            <>
+              {effectiveDockTarget ? (
+                <div
+                  className="workspace-dock-target"
+                  style={{
+                    left: `${effectiveDockTarget.rect.left * 100}%`,
+                    top: `${effectiveDockTarget.rect.top * 100}%`,
+                    width: `${effectiveDockTarget.rect.width * 100}%`,
+                    height: `${effectiveDockTarget.rect.height * 100}%`,
+                  }}
+                />
+              ) : null}
+              {resizingSplit ? (
+                <div
+                  className={`workspace-resize-shield workspace-resize-shield--${resizingSplit.direction}`}
+                  data-resizing-split-id={resizingSplit.splitId}
+                  onPointerDown={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                  onPointerMove={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                  onMouseMove={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                  onMouseUp={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                />
+              ) : null}
+            </>
+          )}
         />
         {effectiveGhostPos && effectiveDraggingLeafId && (
           <div

--- a/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.test.ts
+++ b/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useGhosttyPaneRuntime } from './useGhosttyPaneRuntime';
 import type { PaneRuntimeEventBinding, PaneRuntimeEventRouter } from './paneRuntimeEventRouter';
 import type { GhosttyTerminalHandle } from '../GhosttyTerminal';
@@ -50,6 +50,10 @@ describe('useGhosttyPaneRuntime', () => {
         return () => {};
       }),
     };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('attaches with measured geometry and forwards input directly', async () => {
@@ -153,6 +157,60 @@ describe('useGhosttyPaneRuntime', () => {
     });
 
     expect(mockPtyResize).toHaveBeenCalledWith({ id: 'runtime-1', cols: 130, rows: 45, reason: 'test' });
+  });
+
+  it('coalesces deferred split-drag resize updates before sending them to the PTY', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useGhosttyPaneRuntime([
+      {
+        paneId: 'pane-session',
+        runtimeId: 'runtime-1',
+        paneKind: 'agent',
+      },
+    ], 'pane-session', router, { current: true }));
+    const terminal = createTerminal();
+    await act(async () => {
+      await result.current.handleTerminalReady('pane-session')(terminal);
+    });
+    mockPtyResize.mockClear();
+
+    act(() => {
+      result.current.handleTerminalResize('pane-session')(130, 45, { reason: 'ghostty_fit', deferPty: true });
+      result.current.handleTerminalResize('pane-session')(131, 45, { reason: 'ghostty_fit', deferPty: true });
+      vi.advanceTimersByTime(119);
+    });
+    expect(mockPtyResize).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(mockPtyResize).toHaveBeenCalledTimes(1);
+    expect(mockPtyResize).toHaveBeenCalledWith({ id: 'runtime-1', cols: 131, rows: 45, reason: 'ghostty_fit' });
+  });
+
+  it('cancels a deferred split-drag resize when a normal resize arrives', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useGhosttyPaneRuntime([
+      {
+        paneId: 'pane-session',
+        runtimeId: 'runtime-1',
+        paneKind: 'agent',
+      },
+    ], 'pane-session', router, { current: true }));
+    const terminal = createTerminal();
+    await act(async () => {
+      await result.current.handleTerminalReady('pane-session')(terminal);
+    });
+    mockPtyResize.mockClear();
+
+    act(() => {
+      result.current.handleTerminalResize('pane-session')(130, 45, { reason: 'ghostty_fit', deferPty: true });
+      result.current.handleTerminalResize('pane-session')(132, 45, { reason: 'ghostty_fit' });
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(mockPtyResize).toHaveBeenCalledTimes(1);
+    expect(mockPtyResize).toHaveBeenCalledWith({ id: 'runtime-1', cols: 132, rows: 45, reason: 'ghostty_fit' });
   });
 
   it('resizes daemon-attached runtimes after their first delivered PTY event', async () => {

--- a/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
+++ b/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
@@ -1,10 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { ptyAttach, ptyResize, ptyWrite, type PtyEventPayload } from '../../pty/bridge';
 import { isSuspiciousTerminalSize } from '../../utils/terminalDebug';
+import { recordFocus } from '../../utils/terminalDiagnosticsLog';
 import type { PaneRuntimeEventRouter } from './paneRuntimeEventRouter';
 import type { GhosttyTerminalHandle } from '../GhosttyTerminal';
 import type { TerminalVisibleContentSnapshot } from '../../utils/terminalVisibleContent';
 import type { TerminalVisibleStyleSnapshot } from '../../utils/terminalStyleSummary';
+
+const DEFERRED_RESIZE_FLUSH_MS = 120;
+
+interface TerminalResizeOptions {
+  reason?: string;
+  deferPty?: boolean;
+}
 
 export interface PaneRuntimeSpec {
   paneId: string;
@@ -24,7 +32,7 @@ export interface GhosttyPaneRuntime {
   setTerminalHandle: (paneId: string, handle: GhosttyTerminalHandle | null) => void;
   handleTerminalReady: (paneId: string) => (terminal: GhosttyTerminalHandle) => void;
   handleTerminalInput: (paneId: string) => (data: string) => void;
-  handleTerminalResize: (paneId: string) => (cols: number, rows: number, options?: { reason?: string }) => void;
+  handleTerminalResize: (paneId: string) => (cols: number, rows: number, options?: TerminalResizeOptions) => void;
   focusPane: (paneId: string, retries?: number) => void;
   fitPane: (paneId: string) => void;
   fitActivePane: () => void;
@@ -51,6 +59,12 @@ export function useGhosttyPaneRuntime(
   const handlesRef = useRef(new Map<string, GhosttyTerminalHandle>());
   const readyRuntimesRef = useRef(new Set<string>());
   const connectingRef = useRef(new Set<string>());
+  const deferredResizeRef = useRef(new Map<string, {
+    cols: number;
+    rows: number;
+    reason: string;
+    timer: ReturnType<typeof window.setTimeout>;
+  }>());
   panesRef.current = panes;
 
   const paneFor = useCallback((paneId: string) => panesRef.current.find((pane) => pane.paneId === paneId), []);
@@ -102,7 +116,20 @@ export function useGhosttyPaneRuntime(
     for (const runtimeId of readyRuntimesRef.current) {
       if (!desiredRuntimeIds.has(runtimeId)) readyRuntimesRef.current.delete(runtimeId);
     }
+    for (const [runtimeId, pending] of deferredResizeRef.current) {
+      if (!desiredRuntimeIds.has(runtimeId)) {
+        window.clearTimeout(pending.timer);
+        deferredResizeRef.current.delete(runtimeId);
+      }
+    }
   }, [panes]);
+
+  useEffect(() => () => {
+    for (const pending of deferredResizeRef.current.values()) {
+      window.clearTimeout(pending.timer);
+    }
+    deferredResizeRef.current.clear();
+  }, []);
 
   const setTerminalHandle = useCallback((paneId: string, handle: GhosttyTerminalHandle | null) => {
     if (handle) handlesRef.current.set(paneId, handle);
@@ -158,13 +185,37 @@ export function useGhosttyPaneRuntime(
     void ptyWrite({ id: pane.runtimeId, data });
   }, [paneFor]);
 
-  const handleTerminalResize = useCallback((paneId: string) => (cols: number, rows: number, options?: { reason?: string }) => {
+  const sendResize = useCallback((runtimeId: string, cols: number, rows: number, reason: string) => {
+    void ptyResize({ id: runtimeId, cols, rows, reason });
+  }, []);
+
+  const clearDeferredResize = useCallback((runtimeId: string) => {
+    const pending = deferredResizeRef.current.get(runtimeId);
+    if (!pending) return;
+    window.clearTimeout(pending.timer);
+    deferredResizeRef.current.delete(runtimeId);
+  }, []);
+
+  const handleTerminalResize = useCallback((paneId: string) => (cols: number, rows: number, options?: TerminalResizeOptions) => {
     if (!isActiveSessionRef.current) return;
     const pane = paneFor(paneId);
     if (!pane || !readyRuntimesRef.current.has(pane.runtimeId)) return;
     if (isSuspiciousTerminalSize(cols, rows)) return;
-    void ptyResize({ id: pane.runtimeId, cols, rows, reason: options?.reason ?? 'ghostty_fit' });
-  }, [isActiveSessionRef, paneFor]);
+    const reason = options?.reason ?? 'ghostty_fit';
+    if (!options?.deferPty) {
+      clearDeferredResize(pane.runtimeId);
+      sendResize(pane.runtimeId, cols, rows, reason);
+      return;
+    }
+    clearDeferredResize(pane.runtimeId);
+    const timer = window.setTimeout(() => {
+      const pending = deferredResizeRef.current.get(pane.runtimeId);
+      if (!pending) return;
+      deferredResizeRef.current.delete(pane.runtimeId);
+      sendResize(pane.runtimeId, pending.cols, pending.rows, pending.reason);
+    }, DEFERRED_RESIZE_FLUSH_MS);
+    deferredResizeRef.current.set(pane.runtimeId, { cols, rows, reason, timer });
+  }, [clearDeferredResize, isActiveSessionRef, paneFor, sendResize]);
 
   const get = useCallback((paneId: string) => handlesRef.current.get(paneId), []);
   const emptyContent = useCallback((): TerminalVisibleContentSnapshot => ({
@@ -182,6 +233,7 @@ export function useGhosttyPaneRuntime(
     handleTerminalInput,
     handleTerminalResize,
     focusPane: (paneId: string, retries = 20) => {
+      recordFocus(paneId, retries);
       const focus = (remaining: number) => {
         if (get(paneId)?.focus() || remaining <= 0) return;
         window.setTimeout(() => focus(remaining - 1), 50);

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -44,8 +44,10 @@ import {
   spawnPtyRuntime,
 } from '../pty/runtimeLifecycle';
 import { createPtyTransportState } from '../pty/transportState';
-import { tileContentKey, tileIdsFromLayoutJSON, type TerminalDockEdge, type TileContentState } from '../types/workspace';
+import { parseLayoutJSON, tileContentKey, tileIdsFromLayoutJSON, type TerminalDockEdge, type TileContentState } from '../types/workspace';
 import { isSuspiciousTerminalSize } from '../utils/terminalDebug';
+import { collectWorkspaceLayoutDiagnostics } from '../utils/workspaceDiagnostics';
+import { recordDiag, recordLayout } from '../utils/terminalDiagnosticsLog';
 import { recordPtyCommand, recordWsJsonParse } from '../utils/ptyPerf';
 import { resolveDaemonWebSocketURL, type DaemonEndpointProfile } from '../utils/daemonEndpoint';
 import { BUILD_PROFILE, daemonProfileMatches, fetchDaemonHealthProfile, profileMismatchMessage } from '../utils/buildProfile';
@@ -1064,7 +1066,11 @@ export function useDaemonSocket({
             if (ws.readyState === WebSocket.OPEN) {
               // Re-attach PTY streams only after recovery barrier has lifted and
               // initial_state has arrived.
-              for (const sessionId of ptyTransportRef.current.listAttachedRuntimeIds()) {
+              const reattachIds = ptyTransportRef.current.listAttachedRuntimeIds();
+              if (reattachIds.length > 0) {
+                recordDiag({ kind: 'attach', reason: 'recovery_reattach', sessions: reattachIds });
+              }
+              for (const sessionId of reattachIds) {
                 ws.send(JSON.stringify({ cmd: 'attach_session', id: sessionId }));
               }
             }
@@ -1075,6 +1081,10 @@ export function useDaemonSocket({
             if (data.workspace_layout) {
               const workspaceLayout = data.workspace_layout;
               const workspaceID = workspaceLayout.workspace_id;
+              const layoutDiag = collectWorkspaceLayoutDiagnostics(
+                parseLayoutJSON(workspaceLayout.layout_json || ''),
+              );
+              recordLayout(workspaceID, layoutDiag.panes.map((pane) => pane.paneId), layoutDiag.splitCount);
               const nextWorkspaces = workspacesRef.current.map((workspace) => (
                 workspace.id === workspaceID
                   ? { ...workspace, layout: workspaceLayout }
@@ -1450,6 +1460,7 @@ export function useDaemonSocket({
 
           case 'pty_desync':
             if (data.id) {
+              recordDiag({ kind: 'desync', session: data.id, reason: data.reason || 'desync' });
               emitPtyEvent({ event: 'reset', id: data.id, reason: data.reason || 'desync' });
               ptyTransportRef.current.clearRuntimeStream(data.id);
               ws.send(JSON.stringify({ cmd: 'attach_session', id: data.id }));
@@ -1458,6 +1469,7 @@ export function useDaemonSocket({
 
           case 'pty_resized':
             if (data.id && data.cols && data.rows) {
+              recordDiag({ kind: 'resize', session: data.id, source: 'pty_resized', toCols: data.cols, toRows: data.rows });
               emitPtyEvent({ event: 'local_resize', id: data.id, cols: data.cols, rows: data.rows });
             }
             break;

--- a/app/src/utils/ghosttyScroll.test.ts
+++ b/app/src/utils/ghosttyScroll.test.ts
@@ -8,6 +8,7 @@ import {
   cursorRowInViewport,
   offsetAfterWrite,
   relocateApplicationSelection,
+  shouldReportApplicationMouseMove,
   viewportRowFromBufferRow,
 } from './ghosttyScroll';
 
@@ -34,6 +35,55 @@ describe('applicationMouseInput', () => {
   it('encodes legacy mouse reports when SGR mode is disabled', () => {
     expect(applicationMouseInput('press', 0, 1, 1, false)).toBe('\x1b[M !!');
     expect(applicationMouseInput('release', 0, 1, 1, false)).toBe('\x1b[M#!!');
+  });
+});
+
+describe('shouldReportApplicationMouseMove', () => {
+  it('does not report a drag that did not start inside the terminal', () => {
+    expect(shouldReportApplicationMouseMove({
+      anyEventMouseTracking: true,
+      dragMouseTracking: true,
+      activeButton: null,
+      buttons: 1,
+    })).toBe(false);
+  });
+
+  it('reports passive hover under any-event tracking (DECSET 1003)', () => {
+    // Mode 1003 means "report all motion, including hover with no button".
+    expect(shouldReportApplicationMouseMove({
+      anyEventMouseTracking: true,
+      dragMouseTracking: false,
+      activeButton: null,
+      buttons: 0,
+    })).toBe(true);
+  });
+
+  it('does not report passive hover when only drag tracking (DECSET 1002) is on', () => {
+    // Mode 1002 reports motion only while a button is held, never plain hover.
+    expect(shouldReportApplicationMouseMove({
+      anyEventMouseTracking: false,
+      dragMouseTracking: true,
+      activeButton: null,
+      buttons: 0,
+    })).toBe(false);
+  });
+
+  it('allows terminal-owned drag tracking while the button is still down', () => {
+    expect(shouldReportApplicationMouseMove({
+      anyEventMouseTracking: false,
+      dragMouseTracking: true,
+      activeButton: 0,
+      buttons: 1,
+    })).toBe(true);
+  });
+
+  it('drops stale terminal-owned drags after the button is already released', () => {
+    expect(shouldReportApplicationMouseMove({
+      anyEventMouseTracking: true,
+      dragMouseTracking: true,
+      activeButton: 0,
+      buttons: 0,
+    })).toBe(false);
   });
 });
 

--- a/app/src/utils/ghosttyScroll.ts
+++ b/app/src/utils/ghosttyScroll.ts
@@ -44,6 +44,35 @@ export function applicationWheelInput(
 
 export type ApplicationMouseAction = 'press' | 'move' | 'release';
 
+export interface ApplicationMouseMoveReportOptions {
+  anyEventMouseTracking: boolean;
+  dragMouseTracking: boolean;
+  activeButton: number | null;
+  buttons: number;
+}
+
+export function shouldReportApplicationMouseMove({
+  anyEventMouseTracking,
+  dragMouseTracking,
+  activeButton,
+  buttons,
+}: ApplicationMouseMoveReportOptions): boolean {
+  if (buttons === 0) {
+    // No physical button held: passive hover motion. Only DECSET 1003
+    // (any-event tracking) reports hover; drag tracking (1002) stays quiet, and
+    // a lingering activeButton with no button down is a stale drag we already
+    // released, so suppress that too.
+    return activeButton === null && anyEventMouseTracking;
+  }
+  // A physical button is down. Forward the drag only when the press that started
+  // it originated inside this terminal (activeButton set); this drops
+  // split-divider drags that began outside the pane.
+  if (activeButton === null) {
+    return false;
+  }
+  return anyEventMouseTracking || dragMouseTracking;
+}
+
 export function applicationMouseInput(
   action: ApplicationMouseAction,
   button: number,

--- a/app/src/utils/terminalDiagnosticsLog.ts
+++ b/app/src/utils/terminalDiagnosticsLog.ts
@@ -1,0 +1,425 @@
+// Continuous, prod-safe terminal diagnostics for hard-to-reproduce rendering
+// issues around splitting / resizing / closing panes — most importantly the
+// "agent pane goes blank when a split opens" bug, which only surfaces under
+// live timing and cannot be reproduced in the harness.
+//
+// Design (so this can run in production indefinitely without harm):
+//   - All events go into an in-memory ring buffer (O(1) push, no I/O). This is
+//     the rich context that gets attached to any incident.
+//   - Only LOW-FREQUENCY lifecycle events (mount/unmount, resize, reset, split,
+//     focus, attach/desync) are appended to disk continuously. High-frequency
+//     events (paint, write) live only in the ring buffer.
+//   - A self-detecting watchdog inspects each agent pane shortly after a resize:
+//     if the model holds content but the surface drew ~nothing, it writes an
+//     INCIDENT record (with ring context) to a separate file. That captures the
+//     blank automatically, so the user only has to keep using the app.
+//   - Disk writes are async/non-blocking and size-capped, so they never perturb
+//     the render timing we are trying to diagnose.
+//
+// Read the results from:
+//   $APPLOCALDATA/debug/terminal-diagnostics.jsonl   (lifecycle stream)
+//   $APPLOCALDATA/debug/terminal-incidents.jsonl      (auto-captured blanks)
+//
+// Disable at runtime with localStorage['attn:terminal-diagnostics']='0'.
+import { isTauri } from '@tauri-apps/api/core';
+
+const DEBUG_DIR = 'debug';
+const LIFECYCLE_FILE = `${DEBUG_DIR}/terminal-diagnostics.jsonl`;
+const INCIDENT_FILE = `${DEBUG_DIR}/terminal-incidents.jsonl`;
+const STORAGE_KEY = 'attn:terminal-diagnostics';
+const RING_LIMIT = 3000;
+const INCIDENT_CONTEXT_EVENTS = 400;
+const FILE_SIZE_CAP_BYTES = 8 * 1024 * 1024;
+// A pane is only considered "should be showing something" once its model holds
+// at least this many printable cells; below it, an empty surface is expected.
+const MIN_CONTENT_CELLS = 40;
+// The surface is considered under-drawn if it rendered fewer quads than this
+// fraction of the model's printable-cell count.
+const UNDERDRAW_RATIO = 0.25;
+// Watchdog sampling after a resize; spans the window where a post-resize redraw
+// would normally land.
+const WATCHDOG_DELAYS_MS = [1200, 3500];
+// Do not emit more than one incident per pane within this window (avoids spam
+// while a pane stays blank across several repaint attempts).
+const INCIDENT_COOLDOWN_MS = 8000;
+
+export type DiagKind =
+  | 'pane_mount'
+  | 'pane_unmount'
+  | 'paint'
+  | 'write'
+  | 'resize'
+  | 'reset'
+  | 'layout'
+  | 'focus'
+  | 'attach'
+  | 'desync'
+  | 'watchdog'
+  | 'incident';
+
+export interface DiagEvent {
+  at: number;
+  kind: DiagKind;
+  pane?: string;
+  session?: string;
+  [key: string]: unknown;
+}
+
+// Events cheap enough to stream to disk continuously. Paint/write are excluded
+// (ring-buffer only) because an active agent paints many times per second.
+const LIFECYCLE_KINDS = new Set<DiagKind>([
+  'pane_mount',
+  'pane_unmount',
+  'resize',
+  'reset',
+  'layout',
+  'focus',
+  'attach',
+  'desync',
+  'watchdog',
+  'incident',
+]);
+
+export interface RenderProbe {
+  cols: number;
+  rows: number;
+  modelPrintable: number;
+  lastPaintAt: number;
+  lastPaintQuads: number;
+}
+
+interface PaneHealth {
+  pane: string;
+  session?: string;
+  cols: number;
+  rows: number;
+  lastResizeAt: number;
+  lastPaintAt: number;
+  lastPaintQuads: number;
+  lastModelPrintable: number;
+  lastIncidentAt: number;
+}
+
+declare global {
+  interface Window {
+    __ATTN_TERMINAL_DIAG?: DiagEvent[];
+    __ATTN_TERMINAL_DIAG_DUMP?: () => DiagEvent[];
+    __ATTN_TERMINAL_DIAG_FILES?: { lifecycle: string; incidents: string };
+    __ATTN_TERMINAL_DIAG_ENABLE?: (enabled: boolean) => void;
+    // Back-compat alias used by the split-blank e2e repro spec.
+    __ATTN_RENDER_TRACE?: unknown[];
+    __ATTN_RENDER_TRACE_ON?: boolean;
+  }
+}
+
+const ring: DiagEvent[] = [];
+const paneHealth = new Map<string, PaneHealth>();
+const renderProbes = new Map<string, () => RenderProbe | null>();
+const watchdogTimers = new Map<string, ReturnType<typeof setTimeout>[]>();
+
+let lifecycleBytes = 0;
+let incidentBytes = 0;
+let fileWriteChain: Promise<void> = Promise.resolve();
+
+function isEnabled(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) !== '0';
+  } catch {
+    return true;
+  }
+}
+
+function ensureGlobals() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.__ATTN_TERMINAL_DIAG = ring;
+  window.__ATTN_RENDER_TRACE = ring;
+  window.__ATTN_RENDER_TRACE_ON = true;
+  window.__ATTN_TERMINAL_DIAG_FILES = {
+    lifecycle: `$APPLOCALDATA/${LIFECYCLE_FILE}`,
+    incidents: `$APPLOCALDATA/${INCIDENT_FILE}`,
+  };
+  if (!window.__ATTN_TERMINAL_DIAG_DUMP) {
+    window.__ATTN_TERMINAL_DIAG_DUMP = () => [...ring];
+  }
+  if (!window.__ATTN_TERMINAL_DIAG_ENABLE) {
+    window.__ATTN_TERMINAL_DIAG_ENABLE = (enabled: boolean) => {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, enabled ? '1' : '0');
+      } catch {
+        // ignore
+      }
+    };
+  }
+}
+
+async function appendToFile(file: 'lifecycle' | 'incident', line: string) {
+  if (!isTauri()) {
+    return;
+  }
+  try {
+    const { mkdir, writeTextFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+    await mkdir(DEBUG_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
+    const path = file === 'lifecycle' ? LIFECYCLE_FILE : INCIDENT_FILE;
+    // Truncate-and-restart when a file grows past the cap so prod usage over
+    // days stays bounded. A rotate marker keeps the stream self-describing.
+    const bytes = file === 'lifecycle' ? lifecycleBytes : incidentBytes;
+    const willReset = bytes > FILE_SIZE_CAP_BYTES;
+    const payload = willReset ? `${JSON.stringify({ at: Date.now(), kind: 'rotate' })}\n${line}` : line;
+    await writeTextFile(path, payload, {
+      baseDir: BaseDirectory.AppLocalData,
+      append: !willReset,
+      create: true,
+    });
+    const written = payload.length;
+    if (file === 'lifecycle') {
+      lifecycleBytes = willReset ? written : lifecycleBytes + written;
+    } else {
+      incidentBytes = willReset ? written : incidentBytes + written;
+    }
+  } catch (error) {
+    console.warn('[TerminalDiag] write failed:', error);
+  }
+}
+
+function enqueueWrite(file: 'lifecycle' | 'incident', line: string) {
+  fileWriteChain = fileWriteChain.catch(() => {}).then(() => appendToFile(file, line));
+}
+
+function pushRing(event: DiagEvent) {
+  ring.push(event);
+  if (ring.length > RING_LIMIT) {
+    ring.splice(0, ring.length - RING_LIMIT);
+  }
+}
+
+export function recordDiag(event: Omit<DiagEvent, 'at'>): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  ensureGlobals();
+  if (!isEnabled()) {
+    return;
+  }
+  const entry = { ...event, at: Date.now() } as DiagEvent;
+  pushRing(entry);
+  if (LIFECYCLE_KINDS.has(entry.kind)) {
+    enqueueWrite('lifecycle', `${JSON.stringify(entry)}\n`);
+  }
+}
+
+// Focus is the most useful "where did keyboard input go" signal for the blank /
+// wrong-PTY bugs, but focusPane's retry loop calls it ~10x in a burst for the
+// same pane. Collapse consecutive same-pane focus events within a short window
+// so the stream shows focus *transitions*, not retry spam.
+const FOCUS_DEDUP_MS = 400;
+let lastFocus: { pane?: string; at: number } = { at: 0 };
+
+export function recordFocus(pane: string, retries: number): void {
+  const now = Date.now();
+  if (lastFocus.pane === pane && now - lastFocus.at < FOCUS_DEDUP_MS) {
+    lastFocus.at = now;
+    return;
+  }
+  lastFocus = { pane, at: now };
+  recordDiag({ kind: 'focus', pane, retries });
+}
+
+const lastLayoutSig = new Map<string, string>();
+
+// Records a workspace layout snapshot, deduped on its pane set + split count so
+// continuous split-ratio drags (which fire many layout updates with the same
+// panes) do not flood the log, while real splits/closes are always recorded.
+export function recordLayout(workspace: string, paneIds: string[], splitCount: number): void {
+  const sig = `${[...paneIds].sort().join(',')}|${splitCount}`;
+  if (lastLayoutSig.get(workspace) === sig) {
+    return;
+  }
+  lastLayoutSig.set(workspace, sig);
+  recordDiag({ kind: 'layout', workspace, paneCount: paneIds.length, splitCount, paneIds });
+}
+
+export interface PaintSample {
+  pane: string;
+  session?: string;
+  cols: number;
+  rows: number;
+  force: boolean;
+  offset: number;
+  modelPrintable: number;
+  quads: number | null;
+  cellsArrayLen: number | null;
+  skipNull: number | null;
+  skipZeroWidth: number | null;
+}
+
+export function recordPaint(sample: PaintSample): void {
+  if (typeof window === 'undefined' || !isEnabled()) {
+    ensureGlobals();
+    return;
+  }
+  ensureGlobals();
+  const now = Date.now();
+  pushRing({ at: now, kind: 'paint', ...sample });
+
+  const health = paneHealth.get(sample.pane) ?? {
+    pane: sample.pane,
+    session: sample.session,
+    cols: sample.cols,
+    rows: sample.rows,
+    lastResizeAt: 0,
+    lastPaintAt: 0,
+    lastPaintQuads: 0,
+    lastModelPrintable: 0,
+    lastIncidentAt: 0,
+  };
+  health.cols = sample.cols;
+  health.rows = sample.rows;
+  health.lastPaintAt = now;
+  health.lastPaintQuads = sample.quads ?? 0;
+  health.lastModelPrintable = sample.modelPrintable;
+  health.session = sample.session ?? health.session;
+  paneHealth.set(sample.pane, health);
+
+  // Immediate anomaly: a forced paint that drew far less than the model holds,
+  // or dropped many printable cells at the renderer skip.
+  const quads = sample.quads ?? 0;
+  const underdrawn = sample.modelPrintable >= MIN_CONTENT_CELLS
+    && quads < sample.modelPrintable * UNDERDRAW_RATIO;
+  const droppedCells = (sample.skipZeroWidth ?? 0) + (sample.skipNull ?? 0)
+    >= sample.modelPrintable * UNDERDRAW_RATIO && sample.modelPrintable >= MIN_CONTENT_CELLS;
+  if (underdrawn || droppedCells) {
+    maybeFlushIncident(sample.pane, underdrawn ? 'paint_underdraw' : 'paint_dropped_cells', {
+      modelPrintable: sample.modelPrintable,
+      quads,
+      skipNull: sample.skipNull,
+      skipZeroWidth: sample.skipZeroWidth,
+      cellsArrayLen: sample.cellsArrayLen,
+      cols: sample.cols,
+      rows: sample.rows,
+      force: sample.force,
+    });
+  }
+}
+
+export function registerRenderProbe(pane: string, probe: () => RenderProbe | null): () => void {
+  renderProbes.set(pane, probe);
+  return () => {
+    renderProbes.delete(pane);
+  };
+}
+
+export function noteResize(
+  pane: string,
+  info: { session?: string; source: string; fromCols?: number; fromRows?: number; toCols?: number; toRows?: number; bail?: string; noop?: boolean; paneKind?: string },
+): void {
+  recordDiag({ kind: 'resize', pane, ...info });
+  // A WebGL canvas only clears its drawing buffer when its pixel dimensions
+  // change, i.e. on a real grid-geometry change. A no-op/same-size resize leaves
+  // the surface intact, so "no repaint afterwards" is benign — arming the
+  // watchdog there produces false blanks on an idle pane that already painted
+  // correctly. Only a genuine geometry change invalidates the surface and can
+  // therefore leave it blank if no repaint follows.
+  const geometryChanged =
+    info.bail === undefined &&
+    !info.noop &&
+    info.toCols != null &&
+    info.toRows != null &&
+    (info.fromCols !== info.toCols || info.fromRows !== info.toRows);
+  if (!geometryChanged) {
+    return;
+  }
+  const health = paneHealth.get(pane);
+  if (health) {
+    health.lastResizeAt = Date.now();
+  }
+  // Only agent panes exhibit the blank-on-resize bug; shells redraw trivially.
+  if (info.paneKind === 'agent') {
+    armWatchdog(pane, info.session);
+  }
+}
+
+function armWatchdog(pane: string, session?: string) {
+  clearWatchdog(pane);
+  const timers = WATCHDOG_DELAYS_MS.map((delay) => setTimeout(() => runWatchdog(pane, session, delay), delay));
+  watchdogTimers.set(pane, timers);
+}
+
+function clearWatchdog(pane: string) {
+  const timers = watchdogTimers.get(pane);
+  if (timers) {
+    timers.forEach((t) => clearTimeout(t));
+    watchdogTimers.delete(pane);
+  }
+}
+
+function runWatchdog(pane: string, session: string | undefined, delay: number) {
+  const probe = renderProbes.get(pane)?.();
+  if (!probe) {
+    return;
+  }
+  const health = paneHealth.get(pane);
+  const resizeAt = health?.lastResizeAt ?? 0;
+  const paintedSinceResize = probe.lastPaintAt >= resizeAt;
+  const blank = probe.modelPrintable >= MIN_CONTENT_CELLS
+    && (!paintedSinceResize || probe.lastPaintQuads < probe.modelPrintable * UNDERDRAW_RATIO);
+  recordDiag({
+    kind: 'watchdog',
+    pane,
+    session,
+    delay,
+    blank,
+    modelPrintable: probe.modelPrintable,
+    lastPaintQuads: probe.lastPaintQuads,
+    paintedSinceResize,
+    cols: probe.cols,
+    rows: probe.rows,
+  });
+  if (blank) {
+    maybeFlushIncident(pane, 'blank_after_resize', {
+      delay,
+      modelPrintable: probe.modelPrintable,
+      lastPaintQuads: probe.lastPaintQuads,
+      paintedSinceResize,
+      cols: probe.cols,
+      rows: probe.rows,
+    });
+  }
+}
+
+function maybeFlushIncident(pane: string, reason: string, detail: Record<string, unknown>) {
+  const health = paneHealth.get(pane);
+  const now = Date.now();
+  if (health && now - health.lastIncidentAt < INCIDENT_COOLDOWN_MS) {
+    return;
+  }
+  if (health) {
+    health.lastIncidentAt = now;
+  }
+  const marker: DiagEvent = { at: now, kind: 'incident', pane, session: health?.session, reason, ...detail };
+  pushRing(marker);
+  enqueueWrite('lifecycle', `${JSON.stringify(marker)}\n`);
+  // Full incident record carries the surrounding ring context for diagnosis.
+  const record = {
+    at: now,
+    kind: 'incident',
+    pane,
+    session: health?.session,
+    reason,
+    detail,
+    context: ring.slice(-INCIDENT_CONTEXT_EVENTS),
+  };
+  enqueueWrite('incident', `${JSON.stringify(record)}\n`);
+}
+
+export function disposePaneDiagnostics(pane: string): void {
+  clearWatchdog(pane);
+  paneHealth.delete(pane);
+  renderProbes.delete(pane);
+}
+
+ensureGlobals();

--- a/app/src/utils/terminalDiagnosticsLog.ts
+++ b/app/src/utils/terminalDiagnosticsLog.ts
@@ -119,7 +119,19 @@ const watchdogTimers = new Map<string, ReturnType<typeof setTimeout>[]>();
 
 let lifecycleBytes = 0;
 let incidentBytes = 0;
+// The byte counters must reflect the real on-disk file size so the cap holds
+// across app restarts. They reset to 0 each launch, so seed them from the
+// existing file the first time we touch it — otherwise a file already near the
+// cap would accept another full session's worth of writes before rotating, and
+// across many short sessions could grow far past the promised bound.
+let lifecycleSizeSeeded = false;
+let incidentSizeSeeded = false;
 let fileWriteChain: Promise<void> = Promise.resolve();
+
+const diagTextEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+function byteLength(value: string): number {
+  return diagTextEncoder ? diagTextEncoder.encode(value).length : value.length;
+}
 
 function isEnabled(): boolean {
   if (typeof window === 'undefined') {
@@ -162,9 +174,22 @@ async function appendToFile(file: 'lifecycle' | 'incident', line: string) {
     return;
   }
   try {
-    const { mkdir, writeTextFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+    const { mkdir, stat, writeTextFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
     await mkdir(DEBUG_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
     const path = file === 'lifecycle' ? LIFECYCLE_FILE : INCIDENT_FILE;
+    // First write this session: adopt the file's current on-disk size so the cap
+    // is measured against what is already there, not from zero.
+    const seeded = file === 'lifecycle' ? lifecycleSizeSeeded : incidentSizeSeeded;
+    if (!seeded) {
+      try {
+        const info = await stat(path, { baseDir: BaseDirectory.AppLocalData });
+        const existing = typeof info?.size === 'number' ? info.size : 0;
+        if (file === 'lifecycle') lifecycleBytes = existing; else incidentBytes = existing;
+      } catch {
+        // No file yet (or stat unavailable) — leave the counter at 0.
+      }
+      if (file === 'lifecycle') lifecycleSizeSeeded = true; else incidentSizeSeeded = true;
+    }
     // Truncate-and-restart when a file grows past the cap so prod usage over
     // days stays bounded. A rotate marker keeps the stream self-describing.
     const bytes = file === 'lifecycle' ? lifecycleBytes : incidentBytes;
@@ -175,7 +200,7 @@ async function appendToFile(file: 'lifecycle' | 'incident', line: string) {
       append: !willReset,
       create: true,
     });
-    const written = payload.length;
+    const written = byteLength(payload);
     if (file === 'lifecycle') {
       lifecycleBytes = willReset ? written : lifecycleBytes + written;
     } else {


### PR DESCRIPTION
## Why

The "agent pane goes blank when a split opens" bug only reproduces under live timing — the real-app harness can't trigger it on demand. This adds continuous, prod-safe instrumentation so the bug is captured automatically during normal usage, plus general diagnostics for split / resize / close. Already installed to prod.

## Diagnostics (new)

`app/src/utils/terminalDiagnosticsLog.ts`, wired through the render pipeline:

- **Ring buffer** (3000 events) holds rich context — every paint (model-fill vs. quads drawn), write, resize, focus, layout — with zero disk I/O.
- **Lifecycle stream** → `$APPLOCALDATA/debug/terminal-diagnostics.jsonl`: low-frequency events (mount/unmount, resize, reset, split layout, focus, attach/desync). Async, size-capped at 8MB with rotation.
- **Self-detecting watchdog**: after a *real* agent-pane geometry change it probes the live model; if the model holds content but the surface drew ~nothing, it writes a full **incident** record (with 400 events of preceding context) → `terminal-incidents.jsonl`.
- Disable at runtime via `localStorage['attn:terminal-diagnostics']='0'`; DevTools globals `__ATTN_TERMINAL_DIAG_DUMP()`, `__ATTN_TERMINAL_DIAG_FILES`.

### Calibration

A WebGL canvas clears its drawing buffer only when its pixel dimensions change, so the watchdog arms **only on real grid-geometry changes** — no-op/same-size resizes (common at startup) leave the surface intact and don't produce false blanks. Validated live:

- Startup churn (8 panes dev / 56 panes prod): **0 incidents**, all watchdogs `blank=False`.
- Driven real split (`160x48→80x47`): captured cleanly, both post-split watchdogs healthy, no false incident.
- Live prod: watchdogs firing `blank=False painted=True` across varied geometries, **0 incidents**.

## Fix (tile-resize)

Coalesces the PTY resize sent to running agents while a split drag is in progress, so Claude/Codex aren't forced to repaint repeatedly mid-drag. Split drags still update the visible layout live. (CHANGELOG entry included.)

## Scaffolding

`scenario-agent-split-blank-probe.mjs` (real-app probe for the split gesture) and `split-blank-repro.spec.ts` (e2e) — diagnostic tooling to retire once the root cause is fixed.

## Testing

- `pnpm exec tsc --noEmit` clean; `pnpm test` — 577 pass.
- Validated end-to-end on dev + prod packaged apps (see above).
