### PR TITLE
perf(pty): cut per-session worker memory (scrollback + debug capture)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-08]
+
+### Changed
+- **attn uses noticeably less memory per session.** Each running session's terminal backend used to reserve 8 MB of scrollback up front and grow a second 8 MB replay buffer, even though only the most recent 256 KB is ever replayed when you switch back to a session — both are now capped at 1 MB, freeing roughly 7–14 MB of RAM per session. Separately, diagnostic terminal capture (which quietly held up to ~20 MB of recent output in memory for every Claude and Codex session) is now off unless you explicitly turn it on with `ATTN_DEBUG_PTY_CAPTURE`. With several sessions open this reclaims hundreds of megabytes.
+
 ## [2026-06-07]
 
 ### Added

--- a/docs/plans/2026-06-08-performance-memory-cpu.md
+++ b/docs/plans/2026-06-08-performance-memory-cpu.md
@@ -1,0 +1,151 @@
+# attn performance roadmap — memory (P1) + CPU (P2)
+
+Produced 2026-06-08 by a multi-agent audit (8 subsystem finders → per-finding adversarial verification → synthesis; 42 findings confirmed, 0 rejected). Memory is priority 1, CPU priority 2.
+
+**Live baseline (measured `ps`, prod app):** total attn ≈ **782 MB** — pty-workers **585 MB / ~75%** (avg 73 MB, peak 109 MB; idle ~14 MB), daemon ~77–111 MB, frontend ~85 MB. The prize is **per-session footprint**, not the daemon heap.
+
+## Status tracker
+
+- [x] **WS-2 step 1 — shrink PTY scrollback 8 MiB → 1 MiB** (`internal/pty/manager.go`). Measured **7 MiB/session idle, 14 MiB/session full**. Shipped 2026-06-08.
+- [x] **pty-2 — debug PTY capture off by default** (`internal/ptyworker/debug_capture.go`). Saves up to ~16–22 MiB per claude/codex worker. Shipped 2026-06-08.
+- [ ] WS-7 — guarded loopback pprof + expvar (measurement enabler; do before WS-3)
+- [ ] WS-1 — virtualize off-screen terminal workspaces (largest single lever, ~200+ MiB; UX tradeoff: backgrounded panes rehydrate on focus)
+- [ ] WS-4 — kill per-PTY-chunk synchronous logging + preview allocs (biggest CPU lever)
+- [ ] WS-5 — gate idle background loops on client presence (branch monitor / markdown / PR poll)
+- [ ] WS-3 — daemon GOMEMLIMIT soft cap + GOGC + gated idle FreeOSMemory (after WS-7)
+- [ ] WS-6 — transcript tail-read instead of full-file scan
+- [ ] WS-2 step 2 + fe-term-2 (atlas shrink) + deferred riders — see below
+
+---
+
+## Executive summary
+
+attn's biggest memory wins are NOT in the long-lived daemon heap — they're in **per-session footprint** that multiplies across many concurrent sessions, in two places: (1) the **frontend keeps a full Ghostty WASM model + WebGL renderer (≈32 MiB fixed atlas+texture, plus growing scrollback) mounted for every session**, even though only one is visible; and (2) each **PTY worker subprocess eagerly commits an 8 MiB ring buffer (plus a second buffer that grows to 8 MiB) to ever serve at most 256 KiB**. Both scale linearly with session count, which the daemon is explicitly built to host many of.
+
+The daemon heap itself is dominated by *transient* garbage (PR poll, broadcast snapshots, transcript scans), so it benefits from a soft GC cap (`GOMEMLIMIT`) more than from removing any single retained structure — but that cap is unmeasured today and must be sized against a real live-set, which means **we should land measurement (pprof/expvar) before tuning**.
+
+On CPU, the cleanest universal wins are **removing per-PTY-chunk synchronous disk logging and string/preview allocations** that run regardless of `DEBUG` (daemon side and worker side), and **gating idle background work** (branch monitor forking 3N git processes every 15s with zero clients; markdown/transcript pollers waking forever). The single highest-frequency CPU amplifier is the per-output-chunk log+preview on the PTY datapath.
+
+A recurring theme across the audit: several "daemon RSS" headline numbers were **misattributed** — the default `worker` PTY backend means scrollback and debug-capture buffers live in **separate per-session child processes**, not the daemon. The roadmap reflects the corrected locus.
+
+---
+
+## Biggest levers (memory, then CPU)
+
+**Single biggest MEMORY lever: virtualize off-screen terminals (fe-term-1 + fe-term-2 combined).**
+Every open session keeps a live `GhosttyTerminal` (WASM model with up to 50k-line scrollback) + a `WebGlTerminalRenderer` whose constructor unconditionally allocates a 2048×2048 RGBA atlas canvas (~16 MiB process bitmap) **and** a 2048×2048 GPU texture (~16 MiB VRAM) — verified at `GhosttyWebGlRenderer.ts:234-245`, mounted per pane at `SessionTerminalWorkspace/index.tsx:677-688` with inactive workspaces only hidden via `display:none` (`App.css:196`). At ~8 sessions / 7 backgrounded that's ≈224 MiB of fixed atlas+texture alone (≈half RSS, ≈half VRAM), plus variable scrollback. This is the largest reclaimable per-session footprint in the whole app, and the code already supports teardown+replay rehydration. Shrinking the atlas default (term-2) is a cheaper partial win that also helps the documented WKWebView WebGL-context-starvation freezes.
+
+**Runner-up MEMORY lever: shrink PTY scrollback buffers (pty-1).**
+Each worker subprocess does `NewRingBuffer(8 MiB)` (eager `make([]byte, size)`, `ringbuffer.go:19`) **and** `NewReplayLog(8 MiB)` (lazy, grows under output) — `manager.go:215-216` — to serve a downstream clip of 256 KiB. Lowering `DefaultScrollbackSize` (`manager.go:25`) to ~512 KiB–1 MiB removes ~7–7.5 MiB committed per session on spawn, across all worker processes. Low-risk first step; no protocol/consumer changes.
+
+**Single biggest CPU lever: stop per-PTY-chunk disk logging + preview allocation (ws-1 + pty-3 + hub-1, same root pattern).**
+On the highest-frequency path (one event per output chunk per attached client), the daemon calls `d.logf("pty_output forward: ... preview=%q", ..., previewBinaryForLog(...))` unconditionally — `ws_pty.go:692` — and `d.logf`→`Info`→`log()` is **not level-gated** (`logging.go:75-84`), so it takes the global log mutex and does a synchronous `os.File` write for every chunk even with `DEBUG` unset. The same un-gated per-chunk pattern repeats in the worker subprocess (`ptyworker/runtime.go:668-676`, whose stderr is an unrotated per-session `.log`) and in the hub relay (`internal/hub/manager.go:686,705` — a *second* full JSON unmarshal + disk write per relayed chunk). Gating these behind a cached debug flag removes a mutex-held disk write + a `string(data)`/preview allocation per chunk and de-contends the global log mutex.
+
+---
+
+## Ranked workstreams
+
+Ordered biggest-memory-first. Each is independently shippable and testable.
+
+### WS-1 — Virtualize off-screen terminal workspaces (MEMORY, top priority)
+- **Impact (memory):** Highest in the app. Frees ≈32 MiB fixed (atlas canvas RSS + GPU texture) **per backgrounded pane**, plus that pane's WASM scrollback. ~7 backgrounded sessions ≈ 200+ MiB reclaimed; scales linearly. Also relieves WKWebView live-WebGL-context starvation (a known freeze cause, per the code comment at `GhosttyTerminal.tsx:743-756` and commit `5735c2a1`).
+- **Effort:** Large. **Risk:** Medium-high (touches focus + PTY-resize authority).
+- **Files:** `app/src/App.tsx` (2910 map), `app/src/components/SessionTerminalWorkspace/index.tsx` (677-688 mount gate), `app/src/pty/useGhosttyPaneRuntime.ts` (attach policy `same_app_remount`), `app/src/components/GhosttyTerminal.tsx` (unmount loseContext already present, 757-762).
+- **Sketch:** Gate the `<GhosttyTerminal>` mount on `isActiveSession || isRecentlyActive` (keep active + optionally 1 MRU live); render a lightweight placeholder `<div>` otherwise. On re-select, the existing `forceResizeBeforeAttach='same_app_remount'` + replay path rehydrates the pane from daemon scrollback. Drive from `isActiveSession`/`isSessionViewVisible` already passed in.
+- **Invariants to preserve (FLAGGED):** Terminal Focus Ownership (AGENTS.md #6) — only focus the newly-active pane, respect utility-vs-main. PTY single-authority + replay-is-provisional (#7) — only the newly-active pane drives `pty_resize` (existing `!isActiveSessionRef.current` guard at `useGhosttyPaneRuntime.ts:162`); keep `suppressResponses` for `source==='attach_replay'` (line 68) so replayed queries don't generate live PTY input. Accept known loss: backgrounded pane's local scroll offset.
+- **Tests:** Render test asserting only active (+N MRU) workspaces mount a `GhosttyTerminal`, others render a placeholder. E2E (`utility-terminal-realpty.spec.ts` pattern, `VITE_MOCK_PTY=0 VITE_FORCE_REAL_PTY=1`): switch-away/switch-back rehydrates content via replay, types into the correct PTY without an extra click, emits no stray `pty_resize` from a backgrounded pane.
+
+### WS-2 — Shrink PTY scrollback buffers (MEMORY, high value-to-effort)
+- **Impact (memory):** ~7–7.5 MiB removed per session immediately on spawn (incl. probe/short shells), across worker subprocesses. ~10–20 sessions ≈ 70–150 MiB of system RSS spread across processes.
+- **Effort:** Small (step 1) / Medium (step 2). **Risk:** Low (step 1).
+- **Files:** `internal/pty/manager.go` (25 const), and for step 2: `internal/pty/ringbuffer.go`, `internal/pty/replaylog.go`, `internal/daemon/ws_pty.go` (227-279 flat-replay consumers), `internal/ptyworker/runtime.go` (731 `info.Scrollback`), `internal/pty/session.go` (616-622 startup-query flush).
+- **Sketch:** **Step 1 (ship first, low-risk):** lower `DefaultScrollbackSize` from `8*1024*1024` to ~`512*1024`–`1024*1024`. Must stay `>= maxAgentRawReplayBytes` (256 KiB, `ws_pty.go:54`) so clip/`ScrollbackTruncated` semantics are unchanged and Codex fresh-spawn startup-query replay still fits. **Step 2 (optional, later):** make `RingBuffer` allocate lazily (grow to size) so idle/short sessions don't pre-commit; or eliminate the redundancy by keeping only `ReplayLog` (it carries per-segment cols/rows required by the geometry invariant) and redirecting every `info.Scrollback` consumer to a `ReplayLog`-derived flat byte stream.
+- **Invariants to preserve (FLAGGED):** PTY-geometry/replay-is-provisional — if dropping `RingBuffer`, keep `ReplayLog` for per-segment cols/rows. Cap must stay ≥256 KiB.
+- **Tests:** Go test asserting per-session buffer bound (and, for step 2, that eager allocation no longer occurs). Keep `ringbuffer_test`/`replaylog_test` green. E2E attach-replay (Codex fresh spawn) and relaunch-restore still rehydrate with the smaller cap.
+
+### WS-3 — Daemon GC cap + idle scavenge (MEMORY, depends on WS-7 measurement)
+- **Impact (memory):** Single-digit to low-double-digit % steady-state daemon RSS. Caps the GOGC=100 ~2× heap ratchet from transient spikes (PR poll JSON, `store.List` snapshots, transcript reads); idle `FreeOSMemory` returns reserved pages while the app is closed. Honest caveat: modern Go on macOS already scavenges spike pages, so this lowers the *ceiling*, it doesn't rescue a permanent floor. Magnitude unmeasured — **do WS-7 first**.
+- **Effort:** Small. **Risk:** Medium (a too-tight cap causes GC thrash = CPU regression).
+- **Files:** `cmd/attn/main.go` (296-308 `runDaemon`) or a `package daemon` init.
+- **Sketch:** `debug.SetMemoryLimit(softCap)` driven by env `ATTN_MEMLIMIT` with a generous default (≈512 MiB–1 GiB, sized *above* the WS-7-measured live set), and moderate `debug.SetGCPercent(50–75)` (not 10). Optional idle scavenge: piggy-back on the existing 5-min ticker (`daemon.go:1381`), rate-limited, calling `debug.FreeOSMemory()` only when truly idle.
+- **Invariants to preserve (FLAGGED):** Idle gate must exclude in-flight classification, not just `wsHub.ClientCount()==0` — clients are routinely absent (app closed) while classifier/transcript/review-loop goroutines run; pausing mid-classification interacts badly with classifier-timestamp work. Gate on zero clients AND no `working` sessions AND no pending classification.
+- **Tests:** Wiring test that `SetMemoryLimit` is invoked at bootstrap; unit test that the idle-scavenge gate returns false when a session is `working` or classification is pending. Don't assert runtime GC behavior. Use WS-7's pprof/expvar to measure RSS before/after.
+
+### WS-4 — Kill per-PTY-chunk logging + preview allocations (CPU, top CPU priority)
+- **Impact (CPU):** Removes, per output chunk per attached client, a mutex-held synchronous disk write + a `fmt.Sprintf` + a preview build (`string(data)` + 3× `strings.ReplaceAll`), and de-contends the single global `logging.mu` that serializes ALL daemon logging. On a focused streaming agent that's tens-to-hundreds of writes/sec eliminated. Worker side additionally stops an unbounded per-session `.log` from growing forever (a real disk leak). Mostly affects active/attached streams, not idle RSS.
+- **Effort:** Small. **Risk:** Low.
+- **Files:** `internal/daemon/ws_pty.go` (692-698 output, 717 desync, 741-754 input), `internal/daemon/logging.go` (add gate / `Debugf` route), `internal/ptyworker/runtime.go` (668-676 + wire `cfg.Logf` in `cmd/attn/main.go:278` to honor DEBUG + add `.log` rotation/cap), `internal/daemon/worker.go` (649 eager `previewBytesForLog` on input; 455/469-470 log file open).
+- **Sketch:** Cache `d.debugLogging := config.DebugLevel() >= LogDebug` at init; wrap each per-chunk verbose `logf` in `if d.debugLogging { ... }` **before** building args (Go evaluates args eagerly, so the `if` is mandatory — a lazy closure isn't enough). Keep error/lifecycle logs (`pty_output marshal/send failed`, desync, attach/detach) unconditional. For the worker: make `cfg.Logf` a no-op when debug off, keep startup/lifecycle/error lines, add size-based rotation for `<sessionID>.log`. Note: the `base64` on this path is the **required wire payload**, not removed by gating — only the preview/`string(data)`/`Fprintf`/write go away.
+- **Invariants to preserve (FLAGGED):** None of the PTY/protocol invariants — these are log-only edits. Do NOT alter the `sendOutboundBlocking`/backpressure/`stream.Close` logic or base64 payload forwarding.
+- **Tests:** With `DEBUG` unset, attaching a subscriber and pushing output produces no growth in `daemon.log` / worker `.log` and no `pty_output`/`pty_input` lines, but send/marshal failures still record. A rotation test that the worker log is capped. Avoid tests that restate that `Fprintf` writes bytes.
+
+### WS-5 — Gate idle background loops on client presence (CPU, strong)
+- **Impact (CPU):** Branch monitor (`daemon.go:3092-3132`, 15s ticker) forks **3 git subprocesses per session** + a full `store.List` SQL scan every 15s **with no client gate** — ~3N forks every 15s forever (~17,280·N/day) producing a state change only on a rare manual `git checkout`. Markdown watcher (`tilecontent.go:452`, 750ms) wakes ~115k times/day doing N+1 SQL even with no markdown tile open and no client. PR poll (`daemon.go:2554`, 90s) does 3 GitHub Search HTTP calls/host + detail refresh with no client gate (~2,880/day/host). Gating these collapses idle wakeups/forks/network toward zero when the app is closed.
+- **Effort:** Medium (branch monitor) + Small (markdown, PR poll). **Risk:** Low-medium.
+- **Files:** `internal/daemon/daemon.go` (branch monitor 3092-3132; PR poll 2554-2659; recompute-on-connect via `scheduleInitialState`/`websocket.go:663`), `internal/daemon/tilecontent.go` (449-505), `internal/daemon/git/git.go` (optional 3→1 fork collapse).
+- **Sketch:** Branch monitor — skip the tick when `wsHub.ClientCount()==0`; recompute on client (re)connect and after daemon-driven git ops; back off to ~60s when clients present; optionally collapse the 3 forks into one `git rev-parse --is-inside-work-tree --abbrev-ref HEAD --git-dir`. Markdown — interim: skip the pass when `ClientCount()==0`; better: stop the ticker when zero markdown subscribers and re-arm on `open_markdown`/subscribe. PR poll — **idle backoff, not hard stop** (see flag below): poll 90s when clients present, ~10–15 min when none, immediate poll on first connect.
+- **Invariants to preserve (FLAGGED):** PR poll — attn is a **notification app**; before fully gating PR polling, confirm background PR/CI notifications don't depend on polling while no UI client is attached (removing that would be a user-facing functionality removal, an AGENTS.md violation). Prefer idle backoff. Branch monitor — keep detached-HEAD fallback (`--abbrev-ref` returns literal `HEAD`; retain `symbolic-ref`→`rev-parse --short HEAD`) and the `worktrees` substring worktree detection. Recompute on connect is the correctness contract for gating.
+- **Tests:** With zero ws clients assert the branch monitor / markdown pass does not enumerate the store (store call-counter); on connect assert a branch recompute + `EventSessionsUpdated` fires when on-disk branch differs. PR poll: assert suppressed/backed-off when `ClientCount==0`, fires once on first connect, resumes 90s while connected — via observable broadcast/call counts on a fake gh client, not internal fields.
+
+### WS-6 — Transcript tail-read instead of full-file scan (CPU, moderate; some GC relief)
+- **Impact (CPU):** Each classification (once per assistant turn per session) reads the **entire** transcript from offset 0 and JSON-unmarshals every line several times — `parser.go:172-220`. Real files reach ~23 MiB (Claude) / ~6.8 MiB (Codex); the Claude path can re-read up to ~20× in a 2s retry loop (`claude.go:176-200`). Tail-read (seek to `size-256KB` with full-scan fallback) collapses the common case to a sub-MB read + a few hundred lines: ~10–90× less I/O and allocation per classification. Transient GC relief, not retained RSS — so it sits below the memory workstreams.
+- **Effort:** Medium. **Risk:** Medium (boundary correctness). **Bundle with:** tc-2 (stat-skip when size/mtime unchanged), tc-3 (one combined-struct unmarshal/line), tc-5 (single-block fast path) — they're cheap riders once the scan is touched.
+- **Files:** `internal/transcript/parser.go` (126-148, 172-220, 339-363), `internal/agent/claude.go` (176-200), reuse seek pattern from `internal/daemon/transcript_watcher.go:320`.
+- **Sketch:** Seek to `max(0, size-window)` (window ~256 KiB matching existing `BootstrapBytes`), discard the first partial line, scan the suffix for last assistant + last user within window; widen/fall back to full scan if the window lacks a user OR assistant boundary. Stat-skip the re-parse in the retry loop when size+mtime unchanged. Collapse per-line multi-unmarshal into one combined struct (Claude `message`, Codex `payload`, Copilot `data` — distinct top-level keys, no collision).
+- **Invariants to preserve (FLAGGED):** Classifier semantics — last-assistant-only-after-last-user (`parser.go:205`), `minAssistantTimestamp` staleness (`parser.go:208`), Claude UUID dedup / `ErrNoNewAssistantTurn` (`claude.go:185-198`). Classifier timestamp protection is daemon-side (`classificationStartTime` captured at `daemon.go:1921`) and must remain untouched. Multi-line-aware partial-line handling like `readTranscriptDelta`.
+- **Tests:** Keep `parser_test.go:254-345` boundary tests green. ADD: last assistant beyond the tail window returns the same result as full scan (proves fallback); a single assistant message spanning > window; a stable file parsed at most once across the retry window; combined-struct output equivalence vs current per-format parsing. A Go benchmark over a large fixture to prove the I/O/unmarshal reduction and guard regression (legitimate benchmark, not a compile-time restatement).
+
+### WS-7 — Measurement: guarded pprof + expvar (ENABLER — do early, before WS-3)
+- **Impact:** None directly, but it's the prerequisite to *verify* every memory claim (there is zero pprof/expvar/GOMEMLIMIT today — confirmed: 0 hits across non-test Go). Without it WS-3's cap is a guess and we can't prove WS-1/WS-2 wins.
+- **Effort:** Small. **Risk:** Low (must be opt-in / loopback-guarded).
+- **Files:** `cmd/attn/main.go` or `package daemon` init; optionally a tiny `attn` CLI subcommand to fetch/dump.
+- **Sketch:** Behind an env flag (e.g. `ATTN_PPROF=1`, default off) start `net/http/pprof` on `127.0.0.1:<port>` (loopback only). Add an `expvar` (or a one-line `/debug/vars`) publishing `runtime.MemStats` (HeapAlloc, HeapSys, HeapIdle, NumGC) + session count + per-backend worker count. Optionally a `attn debug heapdump` that hits the local endpoint and writes a profile. Measure RSS via `ps`/`vmmap` against the worker PIDs for per-session footprint (WS-1/WS-2).
+- **Invariants to preserve:** None. Keep it strictly loopback + opt-in (no new attack surface). macOS-only fine.
+- **Tests:** Start the daemon with the flag, assert the endpoint serves and is bound to loopback; assert it's absent when the flag is unset.
+
+---
+
+## Measurement gap & how to close it
+
+There is **no pprof, no expvar, no `GOMEMLIMIT`/`GOGC` tuning, and no `debug.FreeOSMemory`** anywhere in non-test Go (verified: zero grep hits across `internal/`, `cmd/`). We are currently flying blind on the exact thing prioritized #1. Two specifics make this worse:
+
+1. **Per-session memory lives in child processes.** The default `worker` backend (`daemon.go:506-507`) spawns one `pty-worker` subprocess per session, so the 8 MiB scrollback and debug-capture buffers are in those PIDs, not the daemon. Any RSS measurement must sum the daemon + all worker PIDs (`ps`/`vmmap`), or WS-2's win will look like it "did nothing" to the daemon.
+2. **VRAM is invisible to RSS.** Half of WS-1/WS-2's win is GPU texture memory; measure it via the WKWebView/WebGL side (Instruments / `Activity Monitor` GPU, or count live contexts), not just process RSS.
+
+**Smallest change to unblock:** WS-7 (guarded loopback pprof + an `expvar` of `MemStats`). Land it first so WS-1, WS-2, WS-3 can be verified rather than assumed. Then for each memory workstream, capture daemon RSS + summed worker RSS before/after with a fixed scenario (e.g. 8 sessions, 2 streaming) and attach the numbers to the PR.
+
+---
+
+## Lower-priority / deferred
+
+These are real but low severity (mostly transient CPU/GC with no steady-state RSS benefit, or gated behind off-by-default features). Defer unless they ride along a touched file.
+
+- **pty-2 (debug PTY capture ON by default):** trivial — default `ATTN_DEBUG_PTY_CAPTURE` empty to OFF; removes a per-chunk base64 alloc + O(n) prune in worker processes. Update `debug_capture_test.go:11-29`. Worth bundling with WS-4 (same worker-CPU theme). FLAG: keep the opt-in.
+- **pty-4 / pty-5 (readLoop chunk alloc, fanOut copy):** per-read/per-chunk transient allocations; CPU-only, modest. Optional rider on any `session.go` work. FLAG (pty-5): preserve the embedded backend's own copy and document the "subscriber send must not retain the slice" invariant.
+- **pty-6 (state detector full pipeline per chunk):** CPU-only; applies to **claude/copilot** (NOT codex — it has no detector). Implement as a raw-byte working-signature fast-path short-circuit. FLAG: do NOT blanket-throttle `Observe` — it's incremental and would drop transition frames; only short-circuit unambiguous working pulses inside the pulse window.
+- **store-1 (SQLite pool/PRAGMAs):** magnitude is a few hundred KB (live DB is ~356 KiB), not 6–10 MB. SAFE subset only: `SetMaxOpenConns(2–4)`, `SetMaxIdleConns(1)`, `SetConnMaxIdleTime`. FLAG: do NOT add `_foreign_keys=on` (would activate currently-inert `ON DELETE CASCADE` and change delete semantics) or WAL — those need their own audited PR.
+- **store-2/3/4/5 (prepared statements, SetPRs tx, handleTodos→Get, session_id index):** CPU/GC only. Highest-value slice is `handleTodos` calling `store.List("")` then linear-scanning for one id → replace with `Get(msg.ID)` (`daemon.go:2421-2437`). `SetPRs` single-tx + drop the redundant trailing `ListPRs("")` is a clean idle-IO win. FLAG (store-2/4): use prepared-statement caching, NOT a read-through Get cache (would violate classifier-timestamp protection at `store.go:489`).
+- **ws-2/ws-3/ws-4/ws-5 (per-client encode dedup, fat WebSocketEvent marshal, send-buffer bound, hub relay re-parse):** ws-3 (purpose-built 4-field struct replacing the 71-field `WebSocketEvent` marshal for `EventPtyOutput`) is the best of these — real GC relief on the hot outbound path; FLAG: produce byte-identical JSON (no ProtocolVersion bump) and do NOT pool the payload buffer naively (it's enqueued on a 256-cap channel and outlives the call — data race). ws-2 is neutral for the single-desktop user (M=1). ws-4 is "document the bound" more than a code change.
+- **hub-1/hub-2/hub-3 (remote relay):** only active with SSH endpoints configured (off by default). hub-1 (gate the per-chunk relay log+unmarshal) is the worthwhile one if remote is used — pairs with WS-4. hub-3 route caches are bounded-in-practice (reset on reconnect).
+- **fe-socket-1/fe-socket-4/fe-term-5/fe-term-6 (React re-render storm):** the *stated* fe-socket-1 fix (scope App's selectors) is near-useless because the hot event mutates `daemonSessions` which App legitimately forwards. The **real** lever is `React.memo` on `Sidebar`/`Dashboard`/`SessionTerminalWorkspace` + pushing store slices into memoized leaves + identity-preserving `syncFromDaemonSessions` (return prior array ref when all elements are reference-equal) — a larger, careful refactor of the 3207-line `App.tsx`. CPU-only, bursty (per state transition, NOT per byte — pty_output bypasses React), no memory benefit. fe-term-3 (background panes still WebGL-render on output) is a good small CPU win and is **subsumed by WS-1** once off-screen panes are torn down; if WS-1 keeps an MRU pane warm, still gate `renderSurface` on `isActiveSession`. FLAG: any memo work must preserve Focus Ownership (#6) and the `setWorkspaceRef(id)` callback-ref identity churn.
+- **fe-socket-2 (gitOperations dead state):** trivial cleanup — unbounded-but-rare (one tiny object per worktree delete), zero consumers. Remove the state + return field; update `useDaemonSocket.test.tsx:305,328`.
+- **fe-socket-3 (ptyPerf per-message alloc):** trivial — gate `recordWsJsonParse` behind a default-off flag; tiny gen-0 allocations only.
+- **fe-socket-5 (rate_limited uncanceled setTimeout):** trivial — store the timer in a ref, clear-before-set (also dedups the 90s re-broadcasts), clear in effect cleanup. Bounded by the rate-limit window.
+- **tc-4/tc-6 (watcher delta string copy; discovery walks):** CPU-only, modest; tc-4's "halve the unmarshal" claim is false for Claude (its `HandleLine` is a no-op). tc-6 is cold-path (launch window only).
+
+---
+
+## Invariant watch-list (for implementers)
+
+Findings whose fixes touch a protected invariant — read before implementing:
+
+- **WS-1 (terminal virtualization):** Focus Ownership (#6) + PTY single-authority/replay-is-provisional (#7). Only the newly-active pane drives `pty_resize`; keep `suppressResponses` for `attach_replay`.
+- **WS-2 step 2 (drop a PTY buffer):** PTY-geometry — `ReplayLog` must remain (per-segment cols/rows). Cap ≥256 KiB to keep clip/`ScrollbackTruncated` semantics.
+- **WS-3 (idle scavenge):** Don't pause mid-classification — gate on no clients AND no `working` session AND no pending classification (indirectly protects classifier-timestamp work).
+- **WS-5 (PR poll gating):** Do NOT remove background notification behavior (user-facing functionality / AGENTS.md). Prefer idle backoff. Branch monitor: preserve detached-HEAD fallback + worktree detection.
+- **WS-6 (transcript tail-read):** Preserve last-assistant-after-last-user, `minAssistantTimestamp` staleness, Claude UUID dedup. Classifier-timestamp protection stays untouched (daemon-side).
+- **store-1 deferred:** Do NOT enable `_foreign_keys=on` or WAL casually — changes delete semantics; separate audited PR with cascade tests.
+- **store-2/store-4 deferred:** Prepared-statement caching, not a read-through Get cache (classifier-timestamp protection reads live `state_updated_at`).
+- **ws-3 deferred:** Byte-identical JSON (no ProtocolVersion bump); do NOT naively pool the marshal buffer (outlives the call on a 256-cap channel).
+- **fe-term-5/6 deferred (memo):** Preserve Focus Ownership; memoize the `setWorkspaceRef(id)` ref callback or the imperative handle churns.
+- **General:** No finding here requires a protocol message-shape change, so **no `ProtocolVersion` bump is needed** for any workstream as scoped. If any implementation drifts into changing a protocol shape, stop and follow the versioning steps in AGENTS.md.

--- a/internal/daemon/ws_pty_scrollback_test.go
+++ b/internal/daemon/ws_pty_scrollback_test.go
@@ -1,0 +1,20 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/victorarias/attn/internal/pty"
+)
+
+// The per-session PTY scrollback buffers exist only to feed attach/re-attach
+// replay, which is always clipped to maxAgentRawReplayBytes (see
+// buildAttachReplayPayload). The buffers are intentionally sized well above that
+// clip for memory reasons; if the default ever drops below the clip, replay and
+// Codex startup-query rehydration would be silently starved. Guard the
+// invariant so future shrinks stay safe.
+func TestDefaultScrollbackCoversRawReplayClip(t *testing.T) {
+	if pty.DefaultScrollbackSize < maxAgentRawReplayBytes {
+		t.Fatalf("DefaultScrollbackSize (%d) must be >= maxAgentRawReplayBytes (%d) or attach replay is starved",
+			pty.DefaultScrollbackSize, maxAgentRawReplayBytes)
+	}
+}

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -20,9 +20,15 @@ import (
 )
 
 const (
-	// Keep a deeper PTY history so session restore/re-attach can replay
-	// substantially more terminal output.
-	DefaultScrollbackSize = 8 * 1024 * 1024
+	// DefaultScrollbackSize bounds both the eager per-session ring buffer and
+	// the lazily-grown replay log. Attach/re-attach only ever serves the last
+	// maxAgentRawReplayBytes (256 KiB) of history (see daemon.buildAttachReplayPayload),
+	// so anything beyond that is committed RAM per session that is never sent to
+	// a client. 1 MiB keeps a comfortable 4x headroom over that clip while
+	// removing ~7 MiB of eager allocation from every PTY worker subprocess.
+	// Must stay >= maxAgentRawReplayBytes so clip/ScrollbackTruncated semantics
+	// and Codex startup-query replay are unchanged.
+	DefaultScrollbackSize = 1 * 1024 * 1024
 	defaultKillTimeout    = 10 * time.Second
 	shellEnvTimeout       = 2 * time.Second
 )

--- a/internal/ptyworker/debug_capture.go
+++ b/internal/ptyworker/debug_capture.go
@@ -80,7 +80,10 @@ func shouldEnableDebugCapture(agent string) bool {
 
 	raw := strings.TrimSpace(strings.ToLower(os.Getenv("ATTN_DEBUG_PTY_CAPTURE")))
 	switch raw {
-	case "0", "false", "off", "no", "disabled":
+	case "", "0", "false", "off", "no", "disabled":
+		// Off by default: capture retains up to debugCaptureMaxEvents base64
+		// chunks (~16-22 MiB) in every worker subprocess for its whole lifetime.
+		// It is a debugging aid and must be explicitly opted into.
 		return false
 	case "1", "true", "on", "yes", "all":
 		return true
@@ -88,12 +91,10 @@ func shouldEnableDebugCapture(agent string) bool {
 		return normalized == "codex"
 	case "copilot":
 		return normalized == "copilot"
-	case "":
-		// Temporary debugging default: capture the interactive agent runtimes we
-		// are actively debugging without extra environment setup.
-		return normalized == "codex" || normalized == "claude"
+	case "claude":
+		return normalized == "claude"
 	default:
-		return normalized == "codex" || normalized == "claude"
+		return false
 	}
 }
 

--- a/internal/ptyworker/debug_capture_test.go
+++ b/internal/ptyworker/debug_capture_test.go
@@ -9,17 +9,35 @@ import (
 )
 
 func TestShouldEnableDebugCapture_DefaultAndOverrides(t *testing.T) {
+	// Off by default for every agent: the capture buffer is a debugging aid that
+	// otherwise retains ~16-22 MiB per claude/codex worker for its lifetime.
 	t.Setenv("ATTN_DEBUG_PTY_CAPTURE", "")
-	if !shouldEnableDebugCapture("codex") {
-		t.Fatal("expected codex capture enabled by default")
-	}
-	if shouldEnableDebugCapture("copilot") {
-		t.Fatal("expected copilot capture disabled by default")
+	for _, agent := range []string{"codex", "claude", "copilot"} {
+		if shouldEnableDebugCapture(agent) {
+			t.Fatalf("expected %s capture disabled by default", agent)
+		}
 	}
 
 	t.Setenv("ATTN_DEBUG_PTY_CAPTURE", "all")
 	if !shouldEnableDebugCapture("copilot") {
 		t.Fatal("expected copilot capture enabled with ATTN_DEBUG_PTY_CAPTURE=all")
+	}
+
+	// Explicit per-agent opt-in is scoped to that agent only.
+	t.Setenv("ATTN_DEBUG_PTY_CAPTURE", "codex")
+	if !shouldEnableDebugCapture("codex") {
+		t.Fatal("expected codex capture enabled with ATTN_DEBUG_PTY_CAPTURE=codex")
+	}
+	if shouldEnableDebugCapture("claude") {
+		t.Fatal("expected claude capture disabled with ATTN_DEBUG_PTY_CAPTURE=codex")
+	}
+
+	t.Setenv("ATTN_DEBUG_PTY_CAPTURE", "claude")
+	if !shouldEnableDebugCapture("claude") {
+		t.Fatal("expected claude capture enabled with ATTN_DEBUG_PTY_CAPTURE=claude")
+	}
+	if shouldEnableDebugCapture("codex") {
+		t.Fatal("expected codex capture disabled with ATTN_DEBUG_PTY_CAPTURE=claude")
 	}
 
 	t.Setenv("ATTN_DEBUG_PTY_CAPTURE", "0")


### PR DESCRIPTION
**PR 1 of a stacked performance series** (memory = P1, CPU = P2). Roadmap: `docs/plans/2026-06-08-performance-memory-cpu.md`.

## Why
A multi-agent audit + live `ps` baseline showed per-session **`pty-worker` subprocesses are ~75% of attn's memory** (~782 MB total; workers avg ~73 MB, peak ~109 MB). This PR trims two over-provisioned per-session allocations in the worker.

## Changes
- **PTY scrollback 8 MiB → 1 MiB** (`internal/pty/manager.go`). The eager ring buffer + lazily-grown replay log were each 8 MiB, but attach/re-attach only ever replays the last **256 KiB** (`maxAgentRawReplayBytes`). 1 MiB keeps 4× headroom over that clip.
  - Measured heap delta: **~7 MiB/session idle** (eager ring), **~14 MiB/session** when scrollback+replay are full.
  - Added `TestDefaultScrollbackCoversRawReplayClip` so the default can never silently drop below the replay clip (which would starve attach/Codex-startup replay).
- **Debug PTY capture off by default** (`internal/ptyworker/debug_capture.go`). `ATTN_DEBUG_PTY_CAPTURE` was effectively ON for claude/codex (a *"temporary debugging default"*), retaining up to **~16–22 MiB** of base64 per worker. Now strictly opt-in; added explicit per-agent cases (`codex`/`claude`/`copilot`).

For a user running ~8 sessions this reclaims roughly **150–250 MB**.

## Safety
- No protocol shape change → no `ProtocolVersion` bump.
- Replay/attach behavior unchanged. `pty`, `ptyworker`, `ptybackend`, and `daemon` test suites pass.

## Test
`go build ./...`; `go test ./internal/pty/... ./internal/ptyworker/... ./internal/ptybackend/... ./internal/daemon/...` (all green). Heap delta measured with a throwaway in-process benchmark (removed).

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#273** 👈 current
2. #274
<!-- stack:links:end -->