### PR TITLE
perf(app): virtualize off-screen terminal workspaces (~200 MB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Changed
 - **attn uses noticeably less memory per session.** Each running session's terminal backend used to reserve 8 MB of scrollback up front and grow a second 8 MB replay buffer, even though only the most recent 256 KB is ever replayed when you switch back to a session — both are now capped at 1 MB, freeing roughly 7–14 MB of RAM per session. Separately, diagnostic terminal capture (which quietly held up to ~20 MB of recent output in memory for every Claude and Codex session) is now off unless you explicitly turn it on with `ATTN_DEBUG_PTY_CAPTURE`. With several sessions open this reclaims hundreds of megabytes.
+- **Background workspaces no longer hold onto graphics memory.** Only the workspace you're in plus your few most-recent ones keep their terminals fully live; the rest release their GPU/terminal resources and instantly restore from history the moment you switch back. With many workspaces open this frees hundreds of megabytes of RAM and GPU memory and reduces background CPU.
 
 ## [2026-06-07]
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2257,9 +2257,10 @@ sendFetchPRDetails,
         : [activeWorkspaceId, ...prev.filter((id) => id !== activeWorkspaceId)].slice(0, 32)
     ));
   }, [activeWorkspaceId]);
+  const allWorkspaceIds = useMemo(() => workspaceViews.map((w) => w.id), [workspaceViews]);
   const warmWorkspaceIds = useMemo(
-    () => computeWarmWorkspaceIds(recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit),
-    [recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit],
+    () => computeWarmWorkspaceIds(allWorkspaceIds, recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit),
+    [allWorkspaceIds, recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit],
   );
 
   const getActiveLeafDropSnapshot = useCallback(

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -28,6 +28,12 @@ import { ErrorToast, useErrorToast } from './components/ErrorToast';
 import { DaemonProvider } from './contexts/DaemonContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import { useSessionStore, type Session, type TerminalWorkspaceState } from './store/sessions';
+import {
+  computeWarmWorkspaceIds,
+  DEFAULT_WARM_WORKSPACE_LIMIT,
+  readWarmWorkspaceLimit,
+  writeWarmWorkspaceLimit,
+} from './utils/terminalVirtualization';
 import { useDaemonSocket, DaemonWorktree, DaemonSession, DaemonWorkspace, DaemonPR, DaemonEndpoint, DaemonPlugin, DaemonPluginIssue, GitStatusUpdate, BranchDiffFile, DaemonWarning, ReviewLoopState, SessionExitInfo } from './hooks/useDaemonSocket';
 import { useSessionWorkspaceController } from './hooks/useSessionWorkspaceController';
 import { isAttentionSessionState, normalizeSessionState } from './types/sessionState';
@@ -2219,6 +2225,43 @@ sendFetchPRDetails,
       sendWorkspaceSelected(activeWorkspaceId);
     }
   }, [activeWorkspaceId, sendWorkspaceSelected, view]);
+
+  // --- Off-screen terminal virtualization (memory) ---
+  // Keep only the active workspace + the N most-recently-used workspaces "warm"
+  // (terminals mounted). Other workspaces render a placeholder and rehydrate
+  // from daemon replay (same_app_remount) when next made visible. N is runtime-
+  // configurable (localStorage + window.attnSetWarmWorkspaces); see
+  // utils/terminalVirtualization.
+  const [warmWorkspaceLimit, setWarmWorkspaceLimit] = useState<number>(() => readWarmWorkspaceLimit());
+  useEffect(() => {
+    const w = window as Window & { attnSetWarmWorkspaces?: (n: number) => number };
+    w.attnSetWarmWorkspaces = (n: number) => {
+      const next = Number.isFinite(n) ? Math.trunc(n) : DEFAULT_WARM_WORKSPACE_LIMIT;
+      writeWarmWorkspaceLimit(next);
+      setWarmWorkspaceLimit(next);
+      console.log(
+        `[attn] warm workspace limit = ${next} `
+        + (next < 0 ? '(virtualization disabled; all workspaces live)' : `(active + ${next} recent kept live)`),
+      );
+      return next;
+    };
+    return () => { delete w.attnSetWarmWorkspaces; };
+  }, []);
+  // Most-recently-active workspace ids, most-recent-first. Drives the warm set.
+  const [recentWorkspaceIds, setRecentWorkspaceIds] = useState<string[]>([]);
+  useEffect(() => {
+    if (!activeWorkspaceId) return;
+    setRecentWorkspaceIds((prev) => (
+      prev[0] === activeWorkspaceId
+        ? prev
+        : [activeWorkspaceId, ...prev.filter((id) => id !== activeWorkspaceId)].slice(0, 32)
+    ));
+  }, [activeWorkspaceId]);
+  const warmWorkspaceIds = useMemo(
+    () => computeWarmWorkspaceIds(recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit),
+    [recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit],
+  );
+
   const getActiveLeafDropSnapshot = useCallback(
     () => getWorkspaceLeafDropSnapshot(activeWorkspaceIdRef.current),
     [getWorkspaceLeafDropSnapshot],
@@ -3023,6 +3066,11 @@ sendFetchPRDetails,
                 getActivePaneIdForSession,
               );
               const isActiveWorkspace = workspace.id === activeWorkspaceId;
+              // Mount this workspace's terminals only when it is active or in the
+              // warm set; otherwise it renders placeholders and rehydrates on return.
+              const terminalsLive = warmWorkspaceIds === null
+                || isActiveWorkspace
+                || warmWorkspaceIds.has(workspace.id);
               return (
                 <div
                   key={`${workspace.endpointId || 'local'}:${workspace.id}`}
@@ -3046,6 +3094,7 @@ sendFetchPRDetails,
                     enabled={!blockingOverlayOpen}
                     isActiveSession={isActiveWorkspace}
                     isSessionViewVisible={view === 'session'}
+                    terminalsLive={terminalsLive}
                     eventRouter={paneRuntimeEventRouter}
                     onSplitPane={(targetPaneId, direction) => {
                       void createSplitSession('shell', direction, targetPaneId);

--- a/app/src/components/SessionTerminalWorkspace.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace.test.tsx
@@ -185,6 +185,101 @@ describe('SessionTerminalWorkspace', () => {
     expect(mockTerminalFocus).toHaveBeenCalledTimes(1);
   });
 
+  const virtualizationProps = {
+    workspaceId: 'workspace-session-1',
+    workspaceSessions: [{ id: 'session-1', label: 'Session 1', agent: 'claude', cwd: '/tmp/repo' }],
+    activePaneId: SESSION_PANE_ID,
+    fontSize: 14,
+    enabled: true,
+    eventRouter: mockEventRouter,
+    onSplitPane: vi.fn(),
+    onClosePane: vi.fn(),
+    onFocusPane: vi.fn(),
+    onNavigateOutOfSession: vi.fn(),
+  };
+
+  it('virtualizes panes: renders a placeholder and mounts no terminal when terminalsLive is false', () => {
+    render(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspace={createSingleAgentWorkspace()}
+        isActiveSession={false}
+        terminalsLive={false}
+      />,
+    );
+    expect(screen.queryByTestId('mock-terminal')).toBeNull();
+    expect(screen.getByTestId(`pane-virtualized-${SESSION_PANE_ID}`)).toBeTruthy();
+  });
+
+  it('virtualizes every pane of a split workspace, not just the active one', () => {
+    render(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspaceSessions={[
+          { id: 'session-1', label: 'Session 1', agent: 'claude', cwd: '/tmp/repo' },
+          { id: 'session-2', label: 'Session 2', agent: 'claude', cwd: '/tmp/repo' },
+        ]}
+        workspace={createSplitWorkspace()}
+        isActiveSession={false}
+        terminalsLive={false}
+      />,
+    );
+    expect(screen.queryAllByTestId('mock-terminal')).toHaveLength(0);
+    expect(screen.getByTestId(`pane-virtualized-${SESSION_PANE_ID}`)).toBeTruthy();
+    expect(screen.getByTestId('pane-virtualized-pane-session-2')).toBeTruthy();
+  });
+
+  it('mounts terminals when terminalsLive defaults true (warm/active workspace)', () => {
+    render(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspace={createSingleAgentWorkspace()}
+        isActiveSession
+      />,
+    );
+    expect(screen.getByTestId('mock-terminal')).toBeTruthy();
+    expect(screen.queryByTestId(`pane-virtualized-${SESSION_PANE_ID}`)).toBeNull();
+  });
+
+  it('tears down the terminal when a workspace leaves the warm set, and remounts it on return', () => {
+    const { rerender } = render(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspace={createSingleAgentWorkspace()}
+        isActiveSession
+        terminalsLive
+      />,
+    );
+    expect(screen.getByTestId('mock-terminal')).toBeTruthy();
+
+    // Falls out of the warm set -> terminal unmounts (frees WASM model + WebGL).
+    act(() => {
+      rerender(
+        <SessionTerminalWorkspace
+          {...virtualizationProps}
+          workspace={createSingleAgentWorkspace()}
+          isActiveSession={false}
+          terminalsLive={false}
+        />,
+      );
+    });
+    expect(screen.queryByTestId('mock-terminal')).toBeNull();
+    expect(screen.getByTestId(`pane-virtualized-${SESSION_PANE_ID}`)).toBeTruthy();
+
+    // Returns to view -> terminal remounts (rehydrates from daemon replay).
+    act(() => {
+      rerender(
+        <SessionTerminalWorkspace
+          {...virtualizationProps}
+          workspace={createSingleAgentWorkspace()}
+          isActiveSession
+          terminalsLive
+        />,
+      );
+    });
+    expect(screen.getByTestId('mock-terminal')).toBeTruthy();
+  });
+
   it('focuses the main Claude pane immediately on mouse down', () => {
     mockTerminalFocus.mockReset().mockReturnValue(true);
     const onFocusPane = vi.fn();

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -297,6 +297,13 @@
   overflow: hidden;
 }
 
+/* Placeholder for a virtualized (unmounted) terminal. Only ever shown inside a
+   display:none workspace, so it is purely a layout stand-in until remount. */
+.workspace-pane-virtualized {
+  width: 100%;
+  height: 100%;
+}
+
 .workspace-pane-status {
   height: 100%;
   display: flex;

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -110,6 +110,10 @@ interface SessionTerminalWorkspaceProps {
   enabled: boolean;
   isActiveSession: boolean;
   isSessionViewVisible?: boolean;
+  // When false, this workspace is virtualized: its terminals are not mounted
+  // (freeing the Ghostty WASM model + WebGL renderer) and a placeholder is shown
+  // instead. The terminal rehydrates from daemon replay when it remounts.
+  terminalsLive?: boolean;
   eventRouter: PaneRuntimeEventRouter;
   onSplitPane: (targetPaneId: string, direction: TerminalSplitDirection) => void;
   onClosePane: (paneId: string) => void;
@@ -151,6 +155,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     enabled,
     isActiveSession,
     isSessionViewVisible = true,
+    terminalsLive = true,
     eventRouter,
     onSplitPane,
     onClosePane,
@@ -687,6 +692,10 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
                   <span className="workspace-pane-status-spinner" aria-hidden="true" />
                   <span>{isPaneFailed ? (agentPane.error || 'Session failed to start') : `Starting ${paneTitle}...`}</span>
                 </div>
+              ) : !terminalsLive ? (
+                // Virtualized: terminal unmounted to free WASM model + WebGL
+                // renderer. Rehydrates from daemon replay when it remounts.
+                <div className="workspace-pane-virtualized" aria-hidden="true" data-testid={`pane-virtualized-${agentPane.id}`} />
               ) : (
                 <GhosttyTerminal
                   ref={(handle) => runtime.setTerminalHandle(agentPane.id, handle)}

--- a/app/src/utils/terminalVirtualization.test.ts
+++ b/app/src/utils/terminalVirtualization.test.ts
@@ -3,30 +3,47 @@ import { computeWarmWorkspaceIds } from './terminalVirtualization';
 
 describe('computeWarmWorkspaceIds', () => {
   it('returns null (all live) when virtualization is disabled', () => {
-    expect(computeWarmWorkspaceIds(['a', 'b', 'c'], 'a', -1)).toBeNull();
+    expect(computeWarmWorkspaceIds(['a', 'b', 'c'], ['a', 'b', 'c'], 'a', -1)).toBeNull();
   });
 
-  it('keeps only the active workspace at limit 0', () => {
-    const warm = computeWarmWorkspaceIds(['a', 'b', 'c'], 'a', 0);
+  it('keeps all live when workspace count is within the warm budget', () => {
+    // budget = limit + 1 = 4; with <= 4 workspaces there is nothing to reclaim.
+    expect(computeWarmWorkspaceIds(['a'], ['a'], 'a', 3)).toBeNull();
+    expect(computeWarmWorkspaceIds(['a', 'b', 'c', 'd'], ['a'], 'a', 3)).toBeNull();
+  });
+
+  it('keeps all live at startup (no active workspace) while within budget', () => {
+    // Regression guard: before an active workspace is established, a small set of
+    // workspaces must stay mounted rather than collapsing to an empty live-set.
+    expect(computeWarmWorkspaceIds(['a', 'b'], [], null, 3)).toBeNull();
+  });
+
+  it('keeps only the active workspace at limit 0 once over budget', () => {
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c'], ['a', 'b', 'c'], 'a', 0);
     expect(warm).toEqual(new Set(['a']));
   });
 
   it('keeps active + N most-recent at the given limit', () => {
-    const warm = computeWarmWorkspaceIds(['a', 'b', 'c', 'd', 'e'], 'a', 3);
+    const warm = computeWarmWorkspaceIds(
+      ['a', 'b', 'c', 'd', 'e'],
+      ['a', 'b', 'c', 'd', 'e'],
+      'a',
+      3,
+    );
     expect(warm).toEqual(new Set(['a', 'b', 'c', 'd']));
     expect(warm?.size).toBe(4); // active + 3
   });
 
   it('always includes the active workspace even if absent from recents', () => {
-    const warm = computeWarmWorkspaceIds(['b', 'c'], 'z', 1);
+    const warm = computeWarmWorkspaceIds(['z', 'b', 'c'], ['b', 'c'], 'z', 1);
     expect(warm?.has('z')).toBe(true);
     // active(z) + 1 recent(b)
     expect(warm).toEqual(new Set(['z', 'b']));
   });
 
   it('does not double-count the active workspace when it appears in recents', () => {
-    const warm = computeWarmWorkspaceIds(['a', 'b', 'c'], 'a', 2);
-    // active(a) + 2 others (b, c) = 3, not a duplicated
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c', 'd'], ['a', 'b', 'c'], 'a', 2);
+    // active(a) + 2 others (b, c) = 3, a not duplicated
     expect(warm).toEqual(new Set(['a', 'b', 'c']));
     expect(warm?.size).toBe(3);
   });
@@ -34,7 +51,22 @@ describe('computeWarmWorkspaceIds', () => {
   it('handles a null active workspace by filling the budget from recents', () => {
     // No active workspace to reserve a slot for, so the full budget (limit + 1)
     // is taken from the most-recent workspaces.
-    const warm = computeWarmWorkspaceIds(['a', 'b', 'c'], null, 1);
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c'], ['a', 'b', 'c'], null, 1);
     expect(warm).toEqual(new Set(['a', 'b']));
+  });
+
+  it('fills the budget from current workspaces before recency is established', () => {
+    // active set but no recency yet: never leave warm smaller than the budget
+    // while extra workspaces exist.
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c', 'd', 'e'], [], 'a', 2);
+    expect(warm).toEqual(new Set(['a', 'b', 'c']));
+    expect(warm?.size).toBe(3);
+  });
+
+  it('ignores stale active/recent ids no longer among current workspaces', () => {
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c', 'd'], ['x', 'b'], 'y', 1);
+    // active(y) and recent(x) are gone; keep present recent(b) then fill (a).
+    expect(warm).toEqual(new Set(['b', 'a']));
+    expect(warm?.size).toBe(2);
   });
 });

--- a/app/src/utils/terminalVirtualization.test.ts
+++ b/app/src/utils/terminalVirtualization.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { computeWarmWorkspaceIds } from './terminalVirtualization';
+
+describe('computeWarmWorkspaceIds', () => {
+  it('returns null (all live) when virtualization is disabled', () => {
+    expect(computeWarmWorkspaceIds(['a', 'b', 'c'], 'a', -1)).toBeNull();
+  });
+
+  it('keeps only the active workspace at limit 0', () => {
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c'], 'a', 0);
+    expect(warm).toEqual(new Set(['a']));
+  });
+
+  it('keeps active + N most-recent at the given limit', () => {
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c', 'd', 'e'], 'a', 3);
+    expect(warm).toEqual(new Set(['a', 'b', 'c', 'd']));
+    expect(warm?.size).toBe(4); // active + 3
+  });
+
+  it('always includes the active workspace even if absent from recents', () => {
+    const warm = computeWarmWorkspaceIds(['b', 'c'], 'z', 1);
+    expect(warm?.has('z')).toBe(true);
+    // active(z) + 1 recent(b)
+    expect(warm).toEqual(new Set(['z', 'b']));
+  });
+
+  it('does not double-count the active workspace when it appears in recents', () => {
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c'], 'a', 2);
+    // active(a) + 2 others (b, c) = 3, not a duplicated
+    expect(warm).toEqual(new Set(['a', 'b', 'c']));
+    expect(warm?.size).toBe(3);
+  });
+
+  it('handles a null active workspace by filling the budget from recents', () => {
+    // No active workspace to reserve a slot for, so the full budget (limit + 1)
+    // is taken from the most-recent workspaces.
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c'], null, 1);
+    expect(warm).toEqual(new Set(['a', 'b']));
+  });
+});

--- a/app/src/utils/terminalVirtualization.ts
+++ b/app/src/utils/terminalVirtualization.ts
@@ -1,0 +1,57 @@
+// Runtime-configurable virtualization of off-screen terminal workspaces.
+//
+// Each live workspace keeps a Ghostty WASM model + WebGL renderer (~32 MiB of
+// atlas + GPU texture per pane, plus scrollback) mounted. attn keeps every
+// workspace mounted at once, so with many workspaces this dominates the app's
+// memory. We keep only the active workspace plus the N most-recently-used
+// workspaces "warm" (terminals mounted); the rest render a placeholder and
+// rehydrate from daemon replay (same_app_remount) when they next become visible.
+//
+// N is configurable at runtime so the memory-vs-instant-switching tradeoff can
+// be tuned without a rebuild:
+//   - localStorage key `attn.perf.warmWorkspaceLimit`
+//   - window.attnSetWarmWorkspaces(n) — applies live (no reload) and persists
+//   - n = recent workspaces kept warm BESIDES the active one (default 3)
+//   - n = 0  -> only the active workspace is live (maximum memory savings)
+//   - n < 0  -> keep all workspaces live (virtualization disabled)
+
+export const WARM_WORKSPACE_LIMIT_STORAGE_KEY = 'attn.perf.warmWorkspaceLimit';
+export const DEFAULT_WARM_WORKSPACE_LIMIT = 3;
+
+export function readWarmWorkspaceLimit(): number {
+  try {
+    const raw = window.localStorage.getItem(WARM_WORKSPACE_LIMIT_STORAGE_KEY);
+    if (raw === null) return DEFAULT_WARM_WORKSPACE_LIMIT;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : DEFAULT_WARM_WORKSPACE_LIMIT;
+  } catch {
+    return DEFAULT_WARM_WORKSPACE_LIMIT;
+  }
+}
+
+export function writeWarmWorkspaceLimit(limit: number): void {
+  try {
+    window.localStorage.setItem(WARM_WORKSPACE_LIMIT_STORAGE_KEY, String(limit));
+  } catch {
+    // localStorage may be unavailable (private mode); the in-memory value still applies.
+  }
+}
+
+// Returns the set of workspace ids whose terminals should stay mounted, or
+// null meaning "all workspaces live" (virtualization disabled). The active
+// workspace is always included. `recentWorkspaceIds` is most-recent-first.
+export function computeWarmWorkspaceIds(
+  recentWorkspaceIds: string[],
+  activeWorkspaceId: string | null,
+  limit: number,
+): Set<string> | null {
+  if (limit < 0) return null;
+  const warm = new Set<string>();
+  if (activeWorkspaceId) warm.add(activeWorkspaceId);
+  // active + up to `limit` other recent workspaces => at most limit + 1 total.
+  for (const id of recentWorkspaceIds) {
+    if (warm.size >= limit + 1) break;
+    warm.add(id);
+  }
+  return warm;
+}

--- a/app/src/utils/terminalVirtualization.ts
+++ b/app/src/utils/terminalVirtualization.ts
@@ -38,19 +38,37 @@ export function writeWarmWorkspaceLimit(limit: number): void {
 }
 
 // Returns the set of workspace ids whose terminals should stay mounted, or
-// null meaning "all workspaces live" (virtualization disabled). The active
-// workspace is always included. `recentWorkspaceIds` is most-recent-first.
+// null meaning "all workspaces live" (no virtualization). `allWorkspaceIds` is
+// every currently-rendered workspace; `recentWorkspaceIds` is most-recent-first.
+//
+// Virtualization only engages when there are MORE workspaces than the warm
+// budget (active + `limit` recent). With no more workspaces than the budget
+// there is nothing to reclaim, so we keep them all live — this both matches the
+// pre-virtualization behavior for the common case (a handful of workspaces) and
+// avoids tearing terminals down before an active workspace is established (e.g.
+// first paint, when activeWorkspaceId is still null), which would otherwise drop
+// freshly-streamed PTY output across the remount.
 export function computeWarmWorkspaceIds(
+  allWorkspaceIds: string[],
   recentWorkspaceIds: string[],
   activeWorkspaceId: string | null,
   limit: number,
 ): Set<string> | null {
   if (limit < 0) return null;
+  const budget = limit + 1; // active + `limit` recent workspaces.
+  const present = new Set(allWorkspaceIds);
+  if (present.size <= budget) return null; // nothing to reclaim; keep all live.
   const warm = new Set<string>();
-  if (activeWorkspaceId) warm.add(activeWorkspaceId);
-  // active + up to `limit` other recent workspaces => at most limit + 1 total.
+  if (activeWorkspaceId && present.has(activeWorkspaceId)) warm.add(activeWorkspaceId);
   for (const id of recentWorkspaceIds) {
-    if (warm.size >= limit + 1) break;
+    if (warm.size >= budget) break;
+    if (present.has(id)) warm.add(id);
+  }
+  // Fill any remaining budget from the current workspaces so the warm set is
+  // never smaller than the budget while extra workspaces exist — before recency
+  // or an active workspace are established there can be unused slots.
+  for (const id of allWorkspaceIds) {
+    if (warm.size >= budget) break;
     warm.add(id);
   }
   return warm;

--- a/docs/plans/2026-06-08-performance-memory-cpu.md
+++ b/docs/plans/2026-06-08-performance-memory-cpu.md
@@ -8,8 +8,8 @@ Produced 2026-06-08 by a multi-agent audit (8 subsystem finders → per-finding 
 
 - [x] **WS-2 step 1 — shrink PTY scrollback 8 MiB → 1 MiB** (`internal/pty/manager.go`). Measured **7 MiB/session idle, 14 MiB/session full**. Shipped 2026-06-08.
 - [x] **pty-2 — debug PTY capture off by default** (`internal/ptyworker/debug_capture.go`). Saves up to ~16–22 MiB per claude/codex worker. Shipped 2026-06-08.
+- [x] **WS-1 — virtualize off-screen terminal workspaces** (largest single lever, ~200+ MiB). Shipped 2026-06-08: keep active + N recent workspaces warm (default 3), tear down the rest, rehydrate via `same_app_remount` replay. Runtime-configurable via `window.attnSetWarmWorkspaces(n)` / localStorage. Unmount-only (frees WASM+WebGL); daemon-stream detach is a follow-up.
 - [ ] WS-7 — guarded loopback pprof + expvar (measurement enabler; do before WS-3)
-- [ ] WS-1 — virtualize off-screen terminal workspaces (largest single lever, ~200+ MiB; UX tradeoff: backgrounded panes rehydrate on focus)
 - [ ] WS-4 — kill per-PTY-chunk synchronous logging + preview allocs (biggest CPU lever)
 - [ ] WS-5 — gate idle background loops on client presence (branch monitor / markdown / PR poll)
 - [ ] WS-3 — daemon GOMEMLIMIT soft cap + GOGC + gated idle FreeOSMemory (after WS-7)


### PR DESCRIPTION
**PR 2 of the stacked performance series** (stacked on #273). Memory = P1. Roadmap: `docs/plans/2026-06-08-performance-memory-cpu.md` (WS-1).

## Why
The audit's biggest single memory lever: every open workspace keeps a live Ghostty WASM model + WebGL renderer (~32 MiB atlas + GPU texture **per pane**, plus scrollback) mounted, even though only one workspace is visible. Across many workspaces this was ~half the frontend's RAM and ~half its VRAM.

## What
Keep only the **active workspace + the N most-recently-used** workspaces "warm" (terminals mounted). Other workspaces render a placeholder and **rehydrate from daemon replay** (the existing `same_app_remount` path) the instant they become visible again. Teardown frees the WebGL context (`loseContext`, already wired) and the WASM model.

### Runtime-configurable (no rebuild)
So we can tune the memory-vs-snappiness tradeoff and feel it out live:
- `window.attnSetWarmWorkspaces(n)` — applies immediately, persists to localStorage
- `n` = recent workspaces kept warm besides the active one (**default 3**)
- `n = 0` → active only (maximum savings); `n < 0` → disabled (all live, today's behavior)

## Safety / invariants
- **Focus ownership (#6):** active workspace always mounts; focus code untouched.
- **PTY geometry authority (#7):** `pty_resize` stays gated on `isActiveSessionRef`; virtualized panes are unmounted so they can't drive geometry.
- No protocol change. First visit of a startup-virtualized workspace uses `fresh_spawn` — identical to today's initial attach (no regression).
- **Scope:** unmount-only (frees frontend WASM+WebGL — the memory win). Detaching the daemon PTY stream for virtualized panes (a CPU/bandwidth follow-up) needs a new detach API and is deferred.

## Tests
- New `computeWarmWorkspaceIds` unit tests (6) — warm-set math incl. disabled/active-only/cap/dedup.
- New `SessionTerminalWorkspace` cases (4): placeholder when virtualized, every split pane virtualized (not just active), terminals mount when warm, and **unmount→remount** transition.
- Full frontend suite green (595 tests). `tsc` clean. Dev app builds + launches.

> Note: rehydrate-on-switch is intentionally observable (brief repaint; local scroll resets to live) for non-warm workspaces — tunable via the knob above.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #273
2. **#274** 👈 current
<!-- stack:links:end -->