### PR TITLE
chore: run pnpm install before app builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,7 @@ check-types: generate-types
 define build_tauri_app
 	@mkdir -p app/src-tauri/binaries
 	cp $(BINARY_NAME) app/src-tauri/binaries/$(BINARY_NAME)-aarch64-apple-darwin
+	cd app && pnpm install
 	cd app && $(1) pnpm tauri build --bundles app $(3)
 	@if [ "$(UNAME_S)" = "Darwin" ]; then \
 		mkdir -p app/src-tauri/target/release/bundle/macos/$(2).app/Contents/Resources; \


### PR DESCRIPTION
## What

Add `cd app && pnpm install` to the `build_tauri_app` Makefile macro so it runs right before every Tauri app build.

## Why

`make`/`make install` (and `make dev`) now always reconcile `app/`'s dependencies against `package.json` before building, avoiding stale/missing-dep build failures in the dev inner loop. Both prod (`build-app`) and dev (`build-app-dev`) install paths flow through this macro, so a single change covers them; `dist` depends on `build-app` and is covered too.

Plain `pnpm install` (not `--frozen-lockfile`) is intentional — this is a dev convenience that should reconcile drift, not fail on it. It's a no-op when deps are already current.