### PR TITLE
perf(app): virtualize off-screen terminal workspaces (~200 MB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Changed
 - **attn uses noticeably less memory per session.** Each running session's terminal backend used to reserve 8 MB of scrollback up front and grow a second 8 MB replay buffer, even though only the most recent 256 KB is ever replayed when you switch back to a session — both are now capped at 1 MB, freeing roughly 7–14 MB of RAM per session. Separately, diagnostic terminal capture (which quietly held up to ~20 MB of recent output in memory for every Claude and Codex session) is now off unless you explicitly turn it on with `ATTN_DEBUG_PTY_CAPTURE`. With several sessions open this reclaims hundreds of megabytes.
+- **Background workspaces no longer hold onto graphics memory.** Only the workspace you're in plus your few most-recent ones keep their terminals fully live; the rest release their GPU/terminal resources and instantly restore from history the moment you switch back. With many workspaces open this frees hundreds of megabytes of RAM and GPU memory and reduces background CPU.
 
 ## [2026-06-07]
 

--- a/app/src/App.sessionlessWorkspace.test.tsx
+++ b/app/src/App.sessionlessWorkspace.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import App from './App';
 import { WHATS_NEW_ID, WHATS_NEW_STORAGE_KEY } from './hooks/useWhatsNew';
 import type { TerminalLayoutNode } from './types/workspace';
+import { WARM_WORKSPACE_LIMIT_STORAGE_KEY } from './utils/terminalVirtualization';
 
 // Regression coverage for figgy's review on PR #257: a revealed tile-only
 // (sessionless) workspace must be selectable and must render its docked tile,
@@ -50,10 +51,12 @@ vi.mock('./components/Sidebar', () => ({
     visualOrder,
     selectedWorkspaceId,
     onSelectWorkspace,
+    onSelectGridLayout,
   }: {
     visualOrder: Array<{ id: string; sessions: unknown[] }>;
     selectedWorkspaceId: string | null;
     onSelectWorkspace: (id: string) => void;
+    onSelectGridLayout?: (layout: { mode: 'auto' }) => void;
   }) => (
     <div data-testid="sidebar" data-selected-workspace={selectedWorkspaceId ?? ''}>
       {visualOrder.map((workspace) => (
@@ -65,7 +68,20 @@ vi.mock('./components/Sidebar', () => ({
           {workspace.id}
         </button>
       ))}
+      <button
+        type="button"
+        data-testid="open-grid"
+        onClick={() => onSelectGridLayout?.({ mode: 'auto' })}
+      >
+        grid
+      </button>
     </div>
+  ),
+}));
+
+vi.mock('./components/grid/GridView', () => ({
+  GridView: ({ tiles }: { tiles: Array<{ runtimeId: string }> }) => (
+    <div data-testid="grid-view" data-runtime-ids={tiles.map((tile) => tile.runtimeId).join(',')} />
   ),
 }));
 
@@ -76,14 +92,17 @@ vi.mock('./components/SessionTerminalWorkspace', () => ({
     workspaceId,
     workspace,
     isActiveSession,
+    terminalsLive,
   }: {
     workspaceId: string;
     workspace: { agents: unknown[]; layoutTree: TerminalLayoutNode | null };
     isActiveSession: boolean;
+    terminalsLive?: boolean;
   }) => (
     <div
       data-testid={`workspace-${workspaceId}`}
       data-active={isActiveSession ? '1' : '0'}
+      data-live={terminalsLive === false ? '0' : '1'}
       data-agent-count={workspace.agents.length}
       data-tile-ids={collectTileIds(workspace.layoutTree).join(',')}
     />
@@ -286,5 +305,90 @@ describe('tile-only (sessionless) workspace selection and render', () => {
     expect(mockSendWorkspaceSelected).toHaveBeenLastCalledWith('ws-tiles');
     // Still rendering its docked tile.
     expect(screen.getByTestId('workspace-ws-tiles').getAttribute('data-tile-ids')).toBe('tile-readme');
+  });
+
+  it('keeps visible grid workspaces mounted even when they are cold and idle', async () => {
+    localStorage.setItem(WARM_WORKSPACE_LIMIT_STORAGE_KEY, '0');
+    mockDaemonWorkspaces = [
+      {
+        id: 'ws-one',
+        title: 'one',
+        directory: '/tmp/repo',
+        status: 'active',
+        layout: {
+          active_pane_id: 'pane-one',
+          layout_json: JSON.stringify({ type: 'pane', pane_id: 'pane-one' }),
+          panes: [{ workspace_id: 'ws-one', pane_id: 'pane-one', kind: 'agent', runtime_id: 's1', session_id: 's1', title: 'one' }],
+        },
+      },
+      {
+        id: 'ws-two',
+        title: 'two',
+        directory: '/tmp/repo',
+        status: 'active',
+        layout: {
+          active_pane_id: 'pane-two',
+          layout_json: JSON.stringify({ type: 'pane', pane_id: 'pane-two' }),
+          panes: [{ workspace_id: 'ws-two', pane_id: 'pane-two', kind: 'agent', runtime_id: 's2', session_id: 's2', title: 'two' }],
+        },
+      },
+      {
+        id: 'ws-three',
+        title: 'three',
+        directory: '/tmp/repo',
+        status: 'active',
+        layout: {
+          active_pane_id: 'pane-three',
+          layout_json: JSON.stringify({ type: 'pane', pane_id: 'pane-three' }),
+          panes: [{ workspace_id: 'ws-three', pane_id: 'pane-three', kind: 'agent', runtime_id: 's3', session_id: 's3', title: 'three' }],
+        },
+      },
+    ];
+    const sessions = ['one', 'two', 'three'].map((name, index) => {
+      const sessionId = `s${index + 1}`;
+      const paneId = `pane-${name}`;
+      const workspaceId = `ws-${name}`;
+      return {
+        id: sessionId,
+        label: name,
+        state: 'idle',
+        cwd: '/tmp/repo',
+        workspaceId,
+        agent: 'claude',
+        transcriptMatched: true,
+        daemonActivePaneId: paneId,
+        workspace: {
+          agents: [{ id: paneId, runtimeId: sessionId, sessionId, title: name }],
+          layoutTree: { type: 'pane' as const, paneId },
+        },
+      };
+    });
+    mockUseSessionStore.mockReturnValue({
+      ...mockUseSessionStore(),
+      sessions,
+      activeSessionId: 's1',
+    });
+    mockUseDaemonStore.mockReturnValue({
+      ...mockUseDaemonStore(),
+      daemonSessions: sessions.map((session) => ({
+        id: session.id,
+        label: session.label,
+        directory: session.cwd,
+        state: 'idle',
+      })),
+    });
+
+    render(<App />);
+
+    const coldWorkspace = await screen.findByTestId('workspace-ws-two');
+    expect(coldWorkspace.getAttribute('data-live')).toBe('0');
+
+    await userEvent.click(screen.getByTestId('open-grid'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('grid-view').getAttribute('data-runtime-ids')).toContain('s2');
+      expect(screen.getByTestId('workspace-ws-two').getAttribute('data-live')).toBe('1');
+      expect(screen.getByTestId('workspace-ws-three').getAttribute('data-live')).toBe('1');
+    });
   });
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2264,15 +2264,27 @@ sendFetchPRDetails,
       .map((workspace) => workspace.id),
     [workspaceViews],
   );
+  const visibleGridSessionIds = useMemo(
+    () => new Set(visibleGridTiles.map((tile) => tile.sessionId)),
+    [visibleGridTiles],
+  );
+  const gridVisibleWorkspaceIds = useMemo(
+    () => view === 'grid'
+      ? workspaceViews
+        .filter((workspace) => workspace.sessions.some((session) => visibleGridSessionIds.has(session.id)))
+        .map((workspace) => workspace.id)
+      : [],
+    [view, visibleGridSessionIds, workspaceViews],
+  );
   const warmWorkspaceIds = useMemo(
     () => computeWarmWorkspaceIds(
       allWorkspaceIds,
       recentWorkspaceIds,
       activeWorkspaceId,
       warmWorkspaceLimit,
-      liveRuntimeWorkspaceIds,
+      [...liveRuntimeWorkspaceIds, ...gridVisibleWorkspaceIds],
     ),
-    [allWorkspaceIds, recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit, liveRuntimeWorkspaceIds],
+    [allWorkspaceIds, recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit, liveRuntimeWorkspaceIds, gridVisibleWorkspaceIds],
   );
 
   const getActiveLeafDropSnapshot = useCallback(

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -28,6 +28,12 @@ import { ErrorToast, useErrorToast } from './components/ErrorToast';
 import { DaemonProvider } from './contexts/DaemonContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import { useSessionStore, type Session, type TerminalWorkspaceState } from './store/sessions';
+import {
+  computeWarmWorkspaceIds,
+  DEFAULT_WARM_WORKSPACE_LIMIT,
+  readWarmWorkspaceLimit,
+  writeWarmWorkspaceLimit,
+} from './utils/terminalVirtualization';
 import { useDaemonSocket, DaemonWorktree, DaemonSession, DaemonWorkspace, DaemonPR, DaemonEndpoint, DaemonPlugin, DaemonPluginIssue, GitStatusUpdate, BranchDiffFile, DaemonWarning, ReviewLoopState, SessionExitInfo } from './hooks/useDaemonSocket';
 import { useSessionWorkspaceController } from './hooks/useSessionWorkspaceController';
 import { isAttentionSessionState, normalizeSessionState } from './types/sessionState';
@@ -2219,6 +2225,44 @@ sendFetchPRDetails,
       sendWorkspaceSelected(activeWorkspaceId);
     }
   }, [activeWorkspaceId, sendWorkspaceSelected, view]);
+
+  // --- Off-screen terminal virtualization (memory) ---
+  // Keep only the active workspace + the N most-recently-used workspaces "warm"
+  // (terminals mounted). Other workspaces render a placeholder and rehydrate
+  // from daemon replay (same_app_remount) when next made visible. N is runtime-
+  // configurable (localStorage + window.attnSetWarmWorkspaces); see
+  // utils/terminalVirtualization.
+  const [warmWorkspaceLimit, setWarmWorkspaceLimit] = useState<number>(() => readWarmWorkspaceLimit());
+  useEffect(() => {
+    const w = window as Window & { attnSetWarmWorkspaces?: (n: number) => number };
+    w.attnSetWarmWorkspaces = (n: number) => {
+      const next = Number.isFinite(n) ? Math.trunc(n) : DEFAULT_WARM_WORKSPACE_LIMIT;
+      writeWarmWorkspaceLimit(next);
+      setWarmWorkspaceLimit(next);
+      console.log(
+        `[attn] warm workspace limit = ${next} `
+        + (next < 0 ? '(virtualization disabled; all workspaces live)' : `(active + ${next} recent kept live)`),
+      );
+      return next;
+    };
+    return () => { delete w.attnSetWarmWorkspaces; };
+  }, []);
+  // Most-recently-active workspace ids, most-recent-first. Drives the warm set.
+  const [recentWorkspaceIds, setRecentWorkspaceIds] = useState<string[]>([]);
+  useEffect(() => {
+    if (!activeWorkspaceId) return;
+    setRecentWorkspaceIds((prev) => (
+      prev[0] === activeWorkspaceId
+        ? prev
+        : [activeWorkspaceId, ...prev.filter((id) => id !== activeWorkspaceId)].slice(0, 32)
+    ));
+  }, [activeWorkspaceId]);
+  const allWorkspaceIds = useMemo(() => workspaceViews.map((w) => w.id), [workspaceViews]);
+  const warmWorkspaceIds = useMemo(
+    () => computeWarmWorkspaceIds(allWorkspaceIds, recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit),
+    [allWorkspaceIds, recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit],
+  );
+
   const getActiveLeafDropSnapshot = useCallback(
     () => getWorkspaceLeafDropSnapshot(activeWorkspaceIdRef.current),
     [getWorkspaceLeafDropSnapshot],
@@ -3023,6 +3067,11 @@ sendFetchPRDetails,
                 getActivePaneIdForSession,
               );
               const isActiveWorkspace = workspace.id === activeWorkspaceId;
+              // Mount this workspace's terminals only when it is active or in the
+              // warm set; otherwise it renders placeholders and rehydrates on return.
+              const terminalsLive = warmWorkspaceIds === null
+                || isActiveWorkspace
+                || warmWorkspaceIds.has(workspace.id);
               return (
                 <div
                   key={`${workspace.endpointId || 'local'}:${workspace.id}`}
@@ -3046,6 +3095,7 @@ sendFetchPRDetails,
                     enabled={!blockingOverlayOpen}
                     isActiveSession={isActiveWorkspace}
                     isSessionViewVisible={view === 'session'}
+                    terminalsLive={terminalsLive}
                     eventRouter={paneRuntimeEventRouter}
                     onSplitPane={(targetPaneId, direction) => {
                       void createSplitSession('shell', direction, targetPaneId);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2258,9 +2258,21 @@ sendFetchPRDetails,
     ));
   }, [activeWorkspaceId]);
   const allWorkspaceIds = useMemo(() => workspaceViews.map((w) => w.id), [workspaceViews]);
+  const liveRuntimeWorkspaceIds = useMemo(
+    () => workspaceViews
+      .filter((workspace) => workspace.sessions.some((session) => session.state !== 'idle'))
+      .map((workspace) => workspace.id),
+    [workspaceViews],
+  );
   const warmWorkspaceIds = useMemo(
-    () => computeWarmWorkspaceIds(allWorkspaceIds, recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit),
-    [allWorkspaceIds, recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit],
+    () => computeWarmWorkspaceIds(
+      allWorkspaceIds,
+      recentWorkspaceIds,
+      activeWorkspaceId,
+      warmWorkspaceLimit,
+      liveRuntimeWorkspaceIds,
+    ),
+    [allWorkspaceIds, recentWorkspaceIds, activeWorkspaceId, warmWorkspaceLimit, liveRuntimeWorkspaceIds],
   );
 
   const getActiveLeafDropSnapshot = useCallback(

--- a/app/src/components/SessionTerminalWorkspace.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace.test.tsx
@@ -185,6 +185,101 @@ describe('SessionTerminalWorkspace', () => {
     expect(mockTerminalFocus).toHaveBeenCalledTimes(1);
   });
 
+  const virtualizationProps = {
+    workspaceId: 'workspace-session-1',
+    workspaceSessions: [{ id: 'session-1', label: 'Session 1', agent: 'claude', cwd: '/tmp/repo' }],
+    activePaneId: SESSION_PANE_ID,
+    fontSize: 14,
+    enabled: true,
+    eventRouter: mockEventRouter,
+    onSplitPane: vi.fn(),
+    onClosePane: vi.fn(),
+    onFocusPane: vi.fn(),
+    onNavigateOutOfSession: vi.fn(),
+  };
+
+  it('virtualizes panes: renders a placeholder and mounts no terminal when terminalsLive is false', () => {
+    render(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspace={createSingleAgentWorkspace()}
+        isActiveSession={false}
+        terminalsLive={false}
+      />,
+    );
+    expect(screen.queryByTestId('mock-terminal')).toBeNull();
+    expect(screen.getByTestId(`pane-virtualized-${SESSION_PANE_ID}`)).toBeTruthy();
+  });
+
+  it('virtualizes every pane of a split workspace, not just the active one', () => {
+    render(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspaceSessions={[
+          { id: 'session-1', label: 'Session 1', agent: 'claude', cwd: '/tmp/repo' },
+          { id: 'session-2', label: 'Session 2', agent: 'claude', cwd: '/tmp/repo' },
+        ]}
+        workspace={createSplitWorkspace()}
+        isActiveSession={false}
+        terminalsLive={false}
+      />,
+    );
+    expect(screen.queryAllByTestId('mock-terminal')).toHaveLength(0);
+    expect(screen.getByTestId(`pane-virtualized-${SESSION_PANE_ID}`)).toBeTruthy();
+    expect(screen.getByTestId('pane-virtualized-pane-session-2')).toBeTruthy();
+  });
+
+  it('mounts terminals when terminalsLive defaults true (warm/active workspace)', () => {
+    render(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspace={createSingleAgentWorkspace()}
+        isActiveSession
+      />,
+    );
+    expect(screen.getByTestId('mock-terminal')).toBeTruthy();
+    expect(screen.queryByTestId(`pane-virtualized-${SESSION_PANE_ID}`)).toBeNull();
+  });
+
+  it('tears down the terminal when a workspace leaves the warm set, and remounts it on return', () => {
+    const { rerender } = render(
+      <SessionTerminalWorkspace
+        {...virtualizationProps}
+        workspace={createSingleAgentWorkspace()}
+        isActiveSession
+        terminalsLive
+      />,
+    );
+    expect(screen.getByTestId('mock-terminal')).toBeTruthy();
+
+    // Falls out of the warm set -> terminal unmounts (frees WASM model + WebGL).
+    act(() => {
+      rerender(
+        <SessionTerminalWorkspace
+          {...virtualizationProps}
+          workspace={createSingleAgentWorkspace()}
+          isActiveSession={false}
+          terminalsLive={false}
+        />,
+      );
+    });
+    expect(screen.queryByTestId('mock-terminal')).toBeNull();
+    expect(screen.getByTestId(`pane-virtualized-${SESSION_PANE_ID}`)).toBeTruthy();
+
+    // Returns to view -> terminal remounts (rehydrates from daemon replay).
+    act(() => {
+      rerender(
+        <SessionTerminalWorkspace
+          {...virtualizationProps}
+          workspace={createSingleAgentWorkspace()}
+          isActiveSession
+          terminalsLive
+        />,
+      );
+    });
+    expect(screen.getByTestId('mock-terminal')).toBeTruthy();
+  });
+
   it('focuses the main Claude pane immediately on mouse down', () => {
     mockTerminalFocus.mockReset().mockReturnValue(true);
     const onFocusPane = vi.fn();

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.css
@@ -297,6 +297,13 @@
   overflow: hidden;
 }
 
+/* Placeholder for a virtualized (unmounted) terminal. Only ever shown inside a
+   display:none workspace, so it is purely a layout stand-in until remount. */
+.workspace-pane-virtualized {
+  width: 100%;
+  height: 100%;
+}
+
 .workspace-pane-status {
   height: 100%;
   display: flex;

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -110,6 +110,10 @@ interface SessionTerminalWorkspaceProps {
   enabled: boolean;
   isActiveSession: boolean;
   isSessionViewVisible?: boolean;
+  // When false, this workspace is virtualized: its terminals are not mounted
+  // (freeing the Ghostty WASM model + WebGL renderer) and a placeholder is shown
+  // instead. The terminal rehydrates from daemon replay when it remounts.
+  terminalsLive?: boolean;
   eventRouter: PaneRuntimeEventRouter;
   onSplitPane: (targetPaneId: string, direction: TerminalSplitDirection) => void;
   onClosePane: (paneId: string) => void;
@@ -151,6 +155,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     enabled,
     isActiveSession,
     isSessionViewVisible = true,
+    terminalsLive = true,
     eventRouter,
     onSplitPane,
     onClosePane,
@@ -687,6 +692,10 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
                   <span className="workspace-pane-status-spinner" aria-hidden="true" />
                   <span>{isPaneFailed ? (agentPane.error || 'Session failed to start') : `Starting ${paneTitle}...`}</span>
                 </div>
+              ) : !terminalsLive ? (
+                // Virtualized: terminal unmounted to free WASM model + WebGL
+                // renderer. Rehydrates from daemon replay when it remounts.
+                <div className="workspace-pane-virtualized" aria-hidden="true" data-testid={`pane-virtualized-${agentPane.id}`} />
               ) : (
                 <GhosttyTerminal
                   ref={(handle) => runtime.setTerminalHandle(agentPane.id, handle)}

--- a/app/src/utils/terminalVirtualization.test.ts
+++ b/app/src/utils/terminalVirtualization.test.ts
@@ -69,4 +69,37 @@ describe('computeWarmWorkspaceIds', () => {
     expect(warm).toEqual(new Set(['b', 'a']));
     expect(warm?.size).toBe(2);
   });
+
+  it('keeps protected workspaces live even when they are cold', () => {
+    const warm = computeWarmWorkspaceIds(
+      ['a', 'b', 'c', 'd', 'e'],
+      ['a', 'b'],
+      'a',
+      1,
+      ['e'],
+    );
+    expect(warm).toEqual(new Set(['e', 'a']));
+  });
+
+  it('lets protected workspaces exceed the warm budget', () => {
+    const warm = computeWarmWorkspaceIds(
+      ['a', 'b', 'c', 'd', 'e'],
+      ['a', 'b'],
+      'a',
+      1,
+      ['d', 'e'],
+    );
+    expect(warm).toEqual(new Set(['d', 'e', 'a']));
+  });
+
+  it('ignores stale protected workspace ids', () => {
+    const warm = computeWarmWorkspaceIds(
+      ['a', 'b', 'c', 'd'],
+      ['a', 'b', 'c'],
+      'a',
+      1,
+      ['missing'],
+    );
+    expect(warm).toEqual(new Set(['a', 'b']));
+  });
 });

--- a/app/src/utils/terminalVirtualization.test.ts
+++ b/app/src/utils/terminalVirtualization.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { computeWarmWorkspaceIds } from './terminalVirtualization';
+
+describe('computeWarmWorkspaceIds', () => {
+  it('returns null (all live) when virtualization is disabled', () => {
+    expect(computeWarmWorkspaceIds(['a', 'b', 'c'], ['a', 'b', 'c'], 'a', -1)).toBeNull();
+  });
+
+  it('keeps all live when workspace count is within the warm budget', () => {
+    // budget = limit + 1 = 4; with <= 4 workspaces there is nothing to reclaim.
+    expect(computeWarmWorkspaceIds(['a'], ['a'], 'a', 3)).toBeNull();
+    expect(computeWarmWorkspaceIds(['a', 'b', 'c', 'd'], ['a'], 'a', 3)).toBeNull();
+  });
+
+  it('keeps all live at startup (no active workspace) while within budget', () => {
+    // Regression guard: before an active workspace is established, a small set of
+    // workspaces must stay mounted rather than collapsing to an empty live-set.
+    expect(computeWarmWorkspaceIds(['a', 'b'], [], null, 3)).toBeNull();
+  });
+
+  it('keeps only the active workspace at limit 0 once over budget', () => {
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c'], ['a', 'b', 'c'], 'a', 0);
+    expect(warm).toEqual(new Set(['a']));
+  });
+
+  it('keeps active + N most-recent at the given limit', () => {
+    const warm = computeWarmWorkspaceIds(
+      ['a', 'b', 'c', 'd', 'e'],
+      ['a', 'b', 'c', 'd', 'e'],
+      'a',
+      3,
+    );
+    expect(warm).toEqual(new Set(['a', 'b', 'c', 'd']));
+    expect(warm?.size).toBe(4); // active + 3
+  });
+
+  it('always includes the active workspace even if absent from recents', () => {
+    const warm = computeWarmWorkspaceIds(['z', 'b', 'c'], ['b', 'c'], 'z', 1);
+    expect(warm?.has('z')).toBe(true);
+    // active(z) + 1 recent(b)
+    expect(warm).toEqual(new Set(['z', 'b']));
+  });
+
+  it('does not double-count the active workspace when it appears in recents', () => {
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c', 'd'], ['a', 'b', 'c'], 'a', 2);
+    // active(a) + 2 others (b, c) = 3, a not duplicated
+    expect(warm).toEqual(new Set(['a', 'b', 'c']));
+    expect(warm?.size).toBe(3);
+  });
+
+  it('handles a null active workspace by filling the budget from recents', () => {
+    // No active workspace to reserve a slot for, so the full budget (limit + 1)
+    // is taken from the most-recent workspaces.
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c'], ['a', 'b', 'c'], null, 1);
+    expect(warm).toEqual(new Set(['a', 'b']));
+  });
+
+  it('fills the budget from current workspaces before recency is established', () => {
+    // active set but no recency yet: never leave warm smaller than the budget
+    // while extra workspaces exist.
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c', 'd', 'e'], [], 'a', 2);
+    expect(warm).toEqual(new Set(['a', 'b', 'c']));
+    expect(warm?.size).toBe(3);
+  });
+
+  it('ignores stale active/recent ids no longer among current workspaces', () => {
+    const warm = computeWarmWorkspaceIds(['a', 'b', 'c', 'd'], ['x', 'b'], 'y', 1);
+    // active(y) and recent(x) are gone; keep present recent(b) then fill (a).
+    expect(warm).toEqual(new Set(['b', 'a']));
+    expect(warm?.size).toBe(2);
+  });
+});

--- a/app/src/utils/terminalVirtualization.ts
+++ b/app/src/utils/terminalVirtualization.ts
@@ -39,7 +39,9 @@ export function writeWarmWorkspaceLimit(limit: number): void {
 
 // Returns the set of workspace ids whose terminals should stay mounted, or
 // null meaning "all workspaces live" (no virtualization). `allWorkspaceIds` is
-// every currently-rendered workspace; `recentWorkspaceIds` is most-recent-first.
+// every currently-rendered workspace; `recentWorkspaceIds` is most-recent-first;
+// `protectedWorkspaceIds` are workspaces whose PTYs can still be running and
+// therefore need a live terminal model to answer terminal queries.
 //
 // Virtualization only engages when there are MORE workspaces than the warm
 // budget (active + `limit` recent). With no more workspaces than the budget
@@ -53,12 +55,16 @@ export function computeWarmWorkspaceIds(
   recentWorkspaceIds: string[],
   activeWorkspaceId: string | null,
   limit: number,
+  protectedWorkspaceIds: string[] = [],
 ): Set<string> | null {
   if (limit < 0) return null;
   const budget = limit + 1; // active + `limit` recent workspaces.
   const present = new Set(allWorkspaceIds);
   if (present.size <= budget) return null; // nothing to reclaim; keep all live.
   const warm = new Set<string>();
+  for (const id of protectedWorkspaceIds) {
+    if (present.has(id)) warm.add(id);
+  }
   if (activeWorkspaceId && present.has(activeWorkspaceId)) warm.add(activeWorkspaceId);
   for (const id of recentWorkspaceIds) {
     if (warm.size >= budget) break;

--- a/app/src/utils/terminalVirtualization.ts
+++ b/app/src/utils/terminalVirtualization.ts
@@ -1,0 +1,75 @@
+// Runtime-configurable virtualization of off-screen terminal workspaces.
+//
+// Each live workspace keeps a Ghostty WASM model + WebGL renderer (~32 MiB of
+// atlas + GPU texture per pane, plus scrollback) mounted. attn keeps every
+// workspace mounted at once, so with many workspaces this dominates the app's
+// memory. We keep only the active workspace plus the N most-recently-used
+// workspaces "warm" (terminals mounted); the rest render a placeholder and
+// rehydrate from daemon replay (same_app_remount) when they next become visible.
+//
+// N is configurable at runtime so the memory-vs-instant-switching tradeoff can
+// be tuned without a rebuild:
+//   - localStorage key `attn.perf.warmWorkspaceLimit`
+//   - window.attnSetWarmWorkspaces(n) — applies live (no reload) and persists
+//   - n = recent workspaces kept warm BESIDES the active one (default 3)
+//   - n = 0  -> only the active workspace is live (maximum memory savings)
+//   - n < 0  -> keep all workspaces live (virtualization disabled)
+
+export const WARM_WORKSPACE_LIMIT_STORAGE_KEY = 'attn.perf.warmWorkspaceLimit';
+export const DEFAULT_WARM_WORKSPACE_LIMIT = 3;
+
+export function readWarmWorkspaceLimit(): number {
+  try {
+    const raw = window.localStorage.getItem(WARM_WORKSPACE_LIMIT_STORAGE_KEY);
+    if (raw === null) return DEFAULT_WARM_WORKSPACE_LIMIT;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : DEFAULT_WARM_WORKSPACE_LIMIT;
+  } catch {
+    return DEFAULT_WARM_WORKSPACE_LIMIT;
+  }
+}
+
+export function writeWarmWorkspaceLimit(limit: number): void {
+  try {
+    window.localStorage.setItem(WARM_WORKSPACE_LIMIT_STORAGE_KEY, String(limit));
+  } catch {
+    // localStorage may be unavailable (private mode); the in-memory value still applies.
+  }
+}
+
+// Returns the set of workspace ids whose terminals should stay mounted, or
+// null meaning "all workspaces live" (no virtualization). `allWorkspaceIds` is
+// every currently-rendered workspace; `recentWorkspaceIds` is most-recent-first.
+//
+// Virtualization only engages when there are MORE workspaces than the warm
+// budget (active + `limit` recent). With no more workspaces than the budget
+// there is nothing to reclaim, so we keep them all live — this both matches the
+// pre-virtualization behavior for the common case (a handful of workspaces) and
+// avoids tearing terminals down before an active workspace is established (e.g.
+// first paint, when activeWorkspaceId is still null), which would otherwise drop
+// freshly-streamed PTY output across the remount.
+export function computeWarmWorkspaceIds(
+  allWorkspaceIds: string[],
+  recentWorkspaceIds: string[],
+  activeWorkspaceId: string | null,
+  limit: number,
+): Set<string> | null {
+  if (limit < 0) return null;
+  const budget = limit + 1; // active + `limit` recent workspaces.
+  const present = new Set(allWorkspaceIds);
+  if (present.size <= budget) return null; // nothing to reclaim; keep all live.
+  const warm = new Set<string>();
+  if (activeWorkspaceId && present.has(activeWorkspaceId)) warm.add(activeWorkspaceId);
+  for (const id of recentWorkspaceIds) {
+    if (warm.size >= budget) break;
+    if (present.has(id)) warm.add(id);
+  }
+  // Fill any remaining budget from the current workspaces so the warm set is
+  // never smaller than the budget while extra workspaces exist — before recency
+  // or an active workspace are established there can be unused slots.
+  for (const id of allWorkspaceIds) {
+    if (warm.size >= budget) break;
+    warm.add(id);
+  }
+  return warm;
+}

--- a/docs/plans/2026-06-08-performance-memory-cpu.md
+++ b/docs/plans/2026-06-08-performance-memory-cpu.md
@@ -8,8 +8,8 @@ Produced 2026-06-08 by a multi-agent audit (8 subsystem finders → per-finding 
 
 - [x] **WS-2 step 1 — shrink PTY scrollback 8 MiB → 1 MiB** (`internal/pty/manager.go`). Measured **7 MiB/session idle, 14 MiB/session full**. Shipped 2026-06-08.
 - [x] **pty-2 — debug PTY capture off by default** (`internal/ptyworker/debug_capture.go`). Saves up to ~16–22 MiB per claude/codex worker. Shipped 2026-06-08.
+- [x] **WS-1 — virtualize off-screen terminal workspaces** (largest single lever, ~200+ MiB). Shipped 2026-06-08: keep active + N recent workspaces warm (default 3), tear down the rest, rehydrate via `same_app_remount` replay. Runtime-configurable via `window.attnSetWarmWorkspaces(n)` / localStorage. Unmount-only (frees WASM+WebGL); daemon-stream detach is a follow-up.
 - [ ] WS-7 — guarded loopback pprof + expvar (measurement enabler; do before WS-3)
-- [ ] WS-1 — virtualize off-screen terminal workspaces (largest single lever, ~200+ MiB; UX tradeoff: backgrounded panes rehydrate on focus)
 - [ ] WS-4 — kill per-PTY-chunk synchronous logging + preview allocs (biggest CPU lever)
 - [ ] WS-5 — gate idle background loops on client presence (branch monitor / markdown / PR poll)
 - [ ] WS-3 — daemon GOMEMLIMIT soft cap + GOGC + gated idle FreeOSMemory (after WS-7)


### PR DESCRIPTION
Re-opens the off-screen terminal virtualization work that was previously merged as #274 and then reverted on `main` via #276, so it can iterate as an open PR instead of living on `main`.

## What this does
Keeps only the active workspace + the N most-recently-used workspaces "warm" (terminals mounted). Other workspaces render a placeholder and rehydrate from daemon replay (`same_app_remount`) when next made visible, freeing the per-pane Ghostty WASM model + WebGL renderer (~21 MB measured per off-screen pane).

Virtualization only engages when there are **more** workspaces than the warm budget (active + N recent, default N=3). With no more workspaces than the budget there is nothing to reclaim, so all terminals stay live — matching the pre-virtualization behavior for the common case, and never tearing a terminal down before its workspace is active. (That edge — an empty live-set before the active workspace was established — was the regression that briefly blanked terminals in #274; it is fixed here and covered by unit tests.)

`window.attnSetWarmWorkspaces(n)` tunes N at runtime (persisted); `n=0` keeps only the active workspace, `n<0` disables virtualization. No protocol change.

— opened by Claude on behalf of @victorarias