### PR TITLE
feat(grid): visualize session states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-06-08]
 
 ### Changed
+- **Grid view can show session state with colored borders or tile tints.** Use the new State control in grid mode to compare the two treatments; waiting-for-input sessions flash amber, the choice persists across launches, and zoom focus remains clearly separated from session status.
 - **attn uses noticeably less memory per session.** Each running session's terminal backend used to reserve 8 MB of scrollback up front and grow a second 8 MB replay buffer, even though only the most recent 256 KB is ever replayed when you switch back to a session — both are now capped at 1 MB, freeing roughly 7–14 MB of RAM per session. Separately, diagnostic terminal capture (which quietly held up to ~20 MB of recent output in memory for every Claude and Codex session) is now off unless you explicitly turn it on with `ATTN_DEBUG_PTY_CAPTURE`. With several sessions open this reclaims hundreds of megabytes.
 - **Background workspaces no longer hold onto graphics memory.** Only the workspace you're in plus your few most-recent ones keep their terminals fully live; the rest release their GPU/terminal resources and instantly restore from history the moment you switch back. With many workspaces open this frees hundreds of megabytes of RAM and GPU memory and reduces background CPU.
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2098,13 +2098,17 @@ sendFetchPRDetails,
     for (const s of unmutedEnrichedSessions) {
       const pane = s.workspace.agents.find((agent) => agent.sessionId === s.id);
       if (!pane) continue;
+      const state = s.reviewLoopStatus === 'error'
+        ? 'unknown'
+        : s.reviewLoopStatus === 'awaiting_user'
+          ? 'waiting_input'
+          : s.state;
       result.push({
         runtimeId: pane.runtimeId,
         sessionId: s.id,
         title: pane.title,
-        attention: isAttentionSessionState(s.state)
-          || s.reviewLoopStatus === 'awaiting_user'
-          || s.reviewLoopStatus === 'error',
+        state,
+        attention: isAttentionSessionState(state),
       });
     }
     return result;

--- a/app/src/components/grid/GridCompositor.test.ts
+++ b/app/src/components/grid/GridCompositor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { GridCompositor } from './GridCompositor';
+import { GridCompositor, type GridTileSpec } from './GridCompositor';
 import { EMPTY_STATS, type GridRenderer, type TileFrame, type TileModel } from './GridRenderer';
 
 // Minimal fakes: the compositor takes its renderer + ghostty + container as
@@ -120,10 +120,17 @@ function makeCompositor() {
   return { comp, renderer, created };
 }
 
+function tileSpec(
+  id: string,
+  overrides: Partial<Omit<GridTileSpec, 'id'>> = {},
+): GridTileSpec {
+  return { id, attention: false, state: 'working', ...overrides };
+}
+
 describe('GridCompositor', () => {
   it('creates one model per tile spec and registers them with the renderer', () => {
     const { comp, renderer, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }, { id: 'b', attention: true }]);
+    comp.syncTiles([tileSpec('a'), tileSpec('b', { attention: true, state: 'waiting_input' })]);
 
     expect(created).toHaveLength(2);
     expect(renderer.tiles.map((t) => t.id)).toEqual(['a', 'b']);
@@ -133,10 +140,10 @@ describe('GridCompositor', () => {
 
   it('preserves existing models across syncs and frees only removed ones', () => {
     const { comp, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }, { id: 'b', attention: false }]);
+    comp.syncTiles([tileSpec('a'), tileSpec('b')]);
     const [modelA, modelB] = created;
 
-    comp.syncTiles([{ id: 'a', attention: false }]); // drop b
+    comp.syncTiles([tileSpec('a')]); // drop b
 
     expect(created).toHaveLength(2); // no new model created for the kept tile
     expect(modelA.freed).toBe(false);
@@ -151,7 +158,7 @@ describe('GridCompositor', () => {
     // 2×2 must still trigger a render, or the removed tile's stale frame lingers
     // until the next dirtying event ("only every other hide actually hides").
     const { comp, renderer } = makeCompositor();
-    const spec = (id: string) => ({ id, attention: false });
+    const spec = (id: string) => tileSpec(id);
     comp.syncTiles(['a', 'b', 'c', 'd'].map(spec));
     comp.setLayout(2, 2);
 
@@ -160,6 +167,7 @@ describe('GridCompositor', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const internal = comp as any;
     internal.reflowStart = -1;
+    internal.tick();
     const before = renderer.frames.length;
     internal.tick();
     expect(renderer.frames.length).toBe(before);
@@ -174,9 +182,55 @@ describe('GridCompositor', () => {
     expect(last.map((f) => f.id)).toEqual(['a', 'b', 'c']);
   });
 
+  it('renders state-only changes even when the terminal model is clean', () => {
+    const { comp, renderer } = makeCompositor();
+    const internal = comp as any;
+    comp.syncTiles([tileSpec('a')]);
+    internal.reflowStart = -1;
+    internal.tick();
+    const before = renderer.frames.length;
+
+    comp.syncTiles([tileSpec('a', { state: 'idle' })]);
+    internal.tick();
+
+    expect(renderer.frames.length).toBe(before + 1);
+    expect(renderer.frames[renderer.frames.length - 1]?.[0]).toMatchObject({
+      state: 'idle',
+      statePresentation: 'border',
+    });
+  });
+
+  it('renders immediately when the state presentation changes', () => {
+    const { comp, renderer } = makeCompositor();
+    const internal = comp as any;
+    comp.syncTiles([tileSpec('a')]);
+    internal.reflowStart = -1;
+    internal.tick();
+    const before = renderer.frames.length;
+
+    comp.setStatePresentation('background');
+    internal.tick();
+
+    expect(renderer.frames.length).toBe(before + 1);
+    expect(renderer.frames[renderer.frames.length - 1]?.[0].statePresentation).toBe('background');
+  });
+
+  it('keeps rendering while a visible session is waiting for input', () => {
+    const { comp, renderer } = makeCompositor();
+    const internal = comp as any;
+    comp.syncTiles([tileSpec('a', { state: 'waiting_input', attention: false })]);
+    internal.reflowStart = -1;
+    internal.tick();
+    const before = renderer.frames.length;
+
+    internal.tick();
+
+    expect(renderer.frames.length).toBe(before + 1);
+  });
+
   it('routes live bytes to the matching model and drains responses without echoing them', () => {
     const { comp, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }]);
+    comp.syncTiles([tileSpec('a')]);
     const model = created[0];
     model.responses = ['\x1b[0n', 'extra'];
 
@@ -193,7 +247,7 @@ describe('GridCompositor', () => {
 
   it('exposes a tile\'s visible screen text and reports emptiness', () => {
     const { comp, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }]);
+    comp.syncTiles([tileSpec('a')]);
     const model = created[0];
 
     expect(comp.getTileText('a')).toBe('');
@@ -209,21 +263,21 @@ describe('GridCompositor', () => {
 
   it('tracks zoom state and cancels zoom when the zoomed tile disappears', () => {
     const { comp } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }, { id: 'b', attention: false }]);
+    comp.syncTiles([tileSpec('a'), tileSpec('b')]);
 
     expect(comp.isZoomed()).toBe(false);
     comp.zoomTo('a');
     expect(comp.isZoomed()).toBe(true);
     expect(comp.zoomedId()).toBe('a');
 
-    comp.syncTiles([{ id: 'b', attention: false }]); // remove the zoomed tile
+    comp.syncTiles([tileSpec('b')]); // remove the zoomed tile
     expect(comp.zoomedId()).toBeNull();
     expect(comp.isZoomed()).toBe(false);
   });
 
   it('reports the zoomed tile\'s terminal mode for input encoding (off when nothing is zoomed)', () => {
     const { comp, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }, { id: 'b', attention: false }]);
+    comp.syncTiles([tileSpec('a'), tileSpec('b')]);
     created[0].modes[1] = true; // tile a: application cursor keys on; tile b: off
 
     // Overview: no input target, so modes read off regardless of any model.
@@ -238,7 +292,7 @@ describe('GridCompositor', () => {
 
   it('toggles tile visibility', () => {
     const { comp } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }]);
+    comp.syncTiles([tileSpec('a')]);
     expect(comp.tileSummaries()[0].hidden).toBe(false);
     comp.toggleHide('a');
     expect(comp.tileSummaries()[0].hidden).toBe(true);
@@ -246,7 +300,7 @@ describe('GridCompositor', () => {
 
   it('resolves the resting tile + rect under a pointer, on demand without a render loop', () => {
     const { comp } = makeCompositor(); // container 800×600, cell 8×16, models 80×24
-    comp.syncTiles([{ id: 'a', attention: false }]);
+    comp.syncTiles([tileSpec('a')]);
     comp.setLayout(1, 1);
 
     // A single 80×24 tile fits 800×600 at scale 1.25 → 800×480, centred vertically
@@ -262,7 +316,7 @@ describe('GridCompositor', () => {
 
   it('frees every model on dispose', () => {
     const { comp, renderer, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }, { id: 'b', attention: false }]);
+    comp.syncTiles([tileSpec('a'), tileSpec('b')]);
     comp.dispose();
     expect(created.every((m) => m.freed)).toBe(true);
     expect(renderer.disposed).toBe(true);
@@ -275,7 +329,7 @@ describe('GridCompositor seeding + sequence dedup', () => {
 
   it('applies live bytes immediately and drops chunks at or below the watermark', () => {
     const { comp, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }]);
+    comp.syncTiles([tileSpec('a')]);
     const model = created[0];
 
     comp.writeBytes('a', bytes(1), 5); // first seq sets the watermark
@@ -288,7 +342,7 @@ describe('GridCompositor seeding + sequence dedup', () => {
 
   it('buffers live bytes while seeding, then paints the snapshot before flushing newer ones', () => {
     const { comp, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }]);
+    comp.syncTiles([tileSpec('a')]);
     const model = created[0];
 
     comp.beginSeeding('a');
@@ -304,7 +358,7 @@ describe('GridCompositor seeding + sequence dedup', () => {
 
   it('resizes the model to the snapshot geometry so an absolute repaint is not clamped', () => {
     const { comp, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }]);
+    comp.syncTiles([tileSpec('a')]);
     const model = created[0];
     expect([model.cols, model.rows]).toEqual([80, 24]);
 
@@ -317,7 +371,7 @@ describe('GridCompositor seeding + sequence dedup', () => {
 
   it('flushes buffered bytes best-effort when seeding is cancelled (no snapshot)', () => {
     const { comp, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }]);
+    comp.syncTiles([tileSpec('a')]);
     const model = created[0];
 
     comp.beginSeeding('a');
@@ -332,7 +386,7 @@ describe('GridCompositor seeding + sequence dedup', () => {
 
   it('ignores seedTile unless the tile is awaiting a seed', () => {
     const { comp, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }]);
+    comp.syncTiles([tileSpec('a')]);
     const model = created[0];
 
     // Tiles default to live; a stray seed must not clobber live content.
@@ -342,7 +396,7 @@ describe('GridCompositor seeding + sequence dedup', () => {
 
   it('tracks live geometry via resizeTile and no-ops on unchanged or invalid sizes', () => {
     const { comp, created } = makeCompositor();
-    comp.syncTiles([{ id: 'a', attention: false }]);
+    comp.syncTiles([tileSpec('a')]);
     const model = created[0];
 
     comp.resizeTile('a', 100, 30);

--- a/app/src/components/grid/GridCompositor.ts
+++ b/app/src/components/grid/GridCompositor.ts
@@ -8,8 +8,10 @@
 // processes terminal responses but never echoes them back to the PTY (that would
 // inject phantom input into the user's session).
 import type { Ghostty, GhosttyTerminal } from 'ghostty-web';
+import type { UISessionState } from '../../types/sessionState';
 import type { GridRenderer, GridRenderStats, Rect, TileFrame } from './GridRenderer';
 import { TILE_COLS, TILE_ROWS, type CellMetrics } from './gridConfig';
+import type { GridStatePresentation } from './gridStatePresentation';
 
 const GAP = 12;
 const REFLOW_MS = 280;
@@ -31,6 +33,7 @@ type TerminalConfig = Parameters<Ghostty['createTerminal']>[2];
 export interface GridTileSpec {
   id: string;
   attention: boolean;
+  state: UISessionState;
 }
 
 export interface CompositorStats extends GridRenderStats {
@@ -57,6 +60,7 @@ export interface GridTileSummary {
 interface Tile {
   id: string;
   model: GhosttyTerminal;
+  state: UISessionState;
   attention: number;
   attentionTarget: number;
   hidden: boolean;
@@ -116,6 +120,8 @@ export class GridCompositor {
   private lastStats: GridRenderStats | null = null;
   private lastCompositorStats: CompositorStats | null = null;
   private statsEmitAt = 0;
+  private statePresentation: GridStatePresentation = 'border';
+  private presentationDirty = true;
 
   onStats: ((stats: CompositorStats) => void) | null = null;
 
@@ -139,6 +145,12 @@ export class GridCompositor {
     // Snapshot current placement so tiles slide from where they are.
     this.beginReflow();
     this.layout = { rows, cols };
+  }
+
+  setStatePresentation(presentation: GridStatePresentation): void {
+    if (presentation === this.statePresentation) return;
+    this.statePresentation = presentation;
+    this.presentationDirty = true;
   }
 
   // Snapshot every tile's resting rect under the CURRENT layout and start the
@@ -180,13 +192,19 @@ export class GridCompositor {
     const next: Tile[] = specs.map((spec) => {
       const existing = this.tileIndex.get(spec.id);
       if (existing) {
+        if (existing.state !== spec.state || existing.attentionTarget !== (spec.attention ? 1 : 0)) {
+          this.presentationDirty = true;
+        }
+        existing.state = spec.state;
         existing.attentionTarget = spec.attention ? 1 : 0;
         return existing;
       }
+      this.presentationDirty = true;
       const model = this.ghostty.createTerminal(TILE_COLS, TILE_ROWS, this.modelOptions);
       return {
         id: spec.id,
         model,
+        state: spec.state,
         attention: 0,
         attentionTarget: spec.attention ? 1 : 0,
         hidden: false,
@@ -453,6 +471,7 @@ export class GridCompositor {
       if (Math.abs(next - tile.attention) > 0.001) attentionAnimating = true;
       tile.attention = next;
       if (tile.attention > 0.01) attentionAnimating = true; // keep pulsing
+      if (!tile.hidden && tile.state === 'waiting_input') attentionAnimating = true;
     }
 
     // Advance zoom clock.
@@ -473,12 +492,13 @@ export class GridCompositor {
       if (!tile.hidden && tile.model.update() !== 0) anyDirty = true;
     }
 
-    const shouldRender = anyDirty || reflowActive || zoomActive || attentionAnimating;
+    const shouldRender = anyDirty || reflowActive || zoomActive || attentionAnimating || this.presentationDirty;
     let rendered = false;
     if (shouldRender) {
       const frames = this.computeFrames(now, reflowActive);
       this.lastFrames = frames;
       this.lastStats = this.renderer.frame(frames, now);
+      this.presentationDirty = false;
       rendered = true;
     }
 
@@ -533,6 +553,8 @@ export class GridCompositor {
         scale,
         alpha,
         attention: tile.id === this.zoomId ? 0 : tile.attention,
+        state: tile.state,
+        statePresentation: this.statePresentation,
         hidden: tile.hidden,
         focused,
       };

--- a/app/src/components/grid/GridRenderer.ts
+++ b/app/src/components/grid/GridRenderer.ts
@@ -9,6 +9,8 @@
 // (GhosttyTerminal) spends one context per pane, so a global "see every session"
 // surface has to composite into a single context to scale.
 import type { GhosttyTerminal } from 'ghostty-web';
+import type { UISessionState } from '../../types/sessionState';
+import type { GridStatePresentation } from './gridStatePresentation';
 
 export interface TileModel {
   id: string;
@@ -30,7 +32,9 @@ export interface TileFrame {
   rect: Rect; // where the scaled content sits, in container CSS px
   scale: number; // 1.0 == native 1:1 (logical px); thumbnails are < 1
   alpha: number; // 0..1 — fade non-focused tiles during a zoom morph
-  attention: number; // 0..1 — pulsing border intensity ("needs you")
+  attention: number; // 0..1 — pulsing state emphasis ("needs you")
+  state: UISessionState;
+  statePresentation: GridStatePresentation;
   hidden: boolean; // excluded from the batch / surface
   focused: boolean;
 }

--- a/app/src/components/grid/GridView.tsx
+++ b/app/src/components/grid/GridView.tsx
@@ -109,7 +109,11 @@ export function GridView({
   const selectStatePresentation = useCallback((presentation: GridStatePresentation) => {
     setStatePresentation(presentation);
     persistGridStatePresentation(presentation);
-    compRef.current?.setStatePresentation(presentation);
+    const comp = compRef.current;
+    comp?.setStatePresentation(presentation);
+    if (comp?.isZoomed()) {
+      stageRef.current?.focus({ preventScroll: true });
+    }
   }, []);
 
   // runtimeId -> sessionId, so the hover-remove button (which knows the

--- a/app/src/components/grid/GridView.tsx
+++ b/app/src/components/grid/GridView.tsx
@@ -18,12 +18,13 @@
 // claims no geometry, so AGENTS.md #7 still holds: we never attach or resize).
 // We grab stage focus on open/zoom so input follows the zoom instead of leaking
 // to whichever pane held focus when the grid opened.
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Ghostty, InputHandler } from 'ghostty-web';
 import ghosttyWasmUrl from 'ghostty-web/ghostty-vt.wasm?url';
 import { listenPtyEvents, ptyWrite } from '../../pty/bridge';
 import { installTerminalKeyHandler } from '../SessionTerminalWorkspace/terminalKeyHandler';
 import type { ScreenSnapshotResult } from '../../hooks/useDaemonSocket';
+import type { UISessionState } from '../../types/sessionState';
 import { getTerminalTheme, getTerminalAnsiPalette } from '../../utils/terminalSizing';
 import { UnifiedGridRenderer } from './UnifiedGridRenderer';
 import { GridCompositor, type GridTileSpec } from './GridCompositor';
@@ -37,6 +38,11 @@ import {
   colorNumber,
   measureCanonicalCell,
 } from './gridConfig';
+import {
+  persistGridStatePresentation,
+  readGridStatePresentation,
+  type GridStatePresentation,
+} from './gridStatePresentation';
 import './grid.css';
 
 export interface GridSessionTile {
@@ -46,6 +52,7 @@ export interface GridSessionTile {
   sessionId: string;
   title: string;
   attention: boolean;
+  state: UISessionState;
 }
 
 interface GridViewProps {
@@ -80,7 +87,7 @@ function b64ToBytes(b64: string): Uint8Array {
 }
 
 const toSpecs = (tiles: GridSessionTile[]): GridTileSpec[] =>
-  tiles.map((t) => ({ id: t.runtimeId, attention: t.attention }));
+  tiles.map((t) => ({ id: t.runtimeId, attention: t.attention, state: t.state }));
 
 export function GridView({
   tiles,
@@ -96,6 +103,14 @@ export function GridView({
   const compRef = useRef<GridCompositor | null>(null);
   const tilesRef = useRef(tiles);
   tilesRef.current = tiles;
+  const [statePresentation, setStatePresentation] = useState<GridStatePresentation>(readGridStatePresentation);
+  const statePresentationRef = useRef(statePresentation);
+  statePresentationRef.current = statePresentation;
+  const selectStatePresentation = useCallback((presentation: GridStatePresentation) => {
+    setStatePresentation(presentation);
+    persistGridStatePresentation(presentation);
+    compRef.current?.setStatePresentation(presentation);
+  }, []);
 
   // runtimeId -> sessionId, so the hover-remove button (which knows the
   // compositor's tile id == runtimeId) can report the stable session identity.
@@ -162,7 +177,7 @@ export function GridView({
   // A content signature so the sync effect only fires on real changes, not on
   // every parent render (the tiles array is rebuilt each render upstream).
   const signature = useMemo(
-    () => tiles.map((t) => `${t.runtimeId}:${t.attention ? 1 : 0}`).join('|'),
+    () => tiles.map((t) => `${t.runtimeId}:${t.state}:${t.attention ? 1 : 0}`).join('|'),
     [tiles],
   );
 
@@ -194,6 +209,7 @@ export function GridView({
       });
       compRef.current = comp;
       const current = tilesRef.current;
+      comp.setStatePresentation(statePresentationRef.current);
       comp.syncTiles(toSpecs(current));
       comp.setLayout(layoutRef.current.rows, layoutRef.current.cols);
       reconcileSeeding(comp);
@@ -232,12 +248,14 @@ export function GridView({
             tileCount: tileStates.length,
             zoomedId: c.zoomedId(),
             layout: c.currentLayout(),
+            statePresentation: statePresentationRef.current,
             stats: c.getStats(),
             tiles: tileStates,
           };
         },
         getTileText: (id) => compRef.current?.getTileText(id) ?? null,
         zoom: (id) => compRef.current?.zoomTo(id),
+        setStatePresentation: selectStatePresentation,
         hitTest: (x, y) => compRef.current?.hitTest(x, y) ?? null,
         sendText: (text) => {
           const stageEl = stageRef.current;
@@ -290,7 +308,7 @@ export function GridView({
       if (comp) comp.dispose();
       else renderer.dispose();
     };
-  }, [resolvedTheme, reconcileSeeding]);
+  }, [resolvedTheme, reconcileSeeding, selectStatePresentation]);
 
   // Reconcile the live tile set whenever sessions change. Layout is applied by
   // the dedicated effect below; setLayout here keeps the reflow snapshot aligned
@@ -371,6 +389,22 @@ export function GridView({
   return (
     <div className="grid-view" onMouseMove={updateRemoveTarget} onMouseLeave={clearRemoveTarget}>
       <div className="grid-view-stage" ref={stageRef} onClick={onStageClick} />
+      <div className="grid-state-presentation" role="radiogroup" aria-label="Session state appearance">
+        <span className="grid-state-presentation-label">State</span>
+        {(['border', 'background'] as const).map((presentation) => (
+          <button
+            key={presentation}
+            type="button"
+            className={`grid-state-presentation-option ${statePresentation === presentation ? 'active' : ''}`}
+            data-presentation={presentation}
+            role="radio"
+            aria-checked={statePresentation === presentation}
+            onClick={() => selectStatePresentation(presentation)}
+          >
+            {presentation === 'border' ? 'Border' : 'Tint'}
+          </button>
+        ))}
+      </div>
       {tiles.length === 0 && (
         <div className="grid-view-empty">No active sessions</div>
       )}

--- a/app/src/components/grid/UnifiedGridRenderer.test.ts
+++ b/app/src/components/grid/UnifiedGridRenderer.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { waitingInputFlash } from './UnifiedGridRenderer';
+
+describe('waitingInputFlash', () => {
+  it('produces a repeating flash with a clear dim and bright phase', () => {
+    expect(waitingInputFlash(0)).toBeCloseTo(0.25);
+    expect(waitingInputFlash(400)).toBeCloseTo(1);
+    expect(waitingInputFlash(1_200)).toBeCloseTo(0);
+    expect(waitingInputFlash(2_000)).toBeCloseTo(1);
+  });
+});

--- a/app/src/components/grid/UnifiedGridRenderer.ts
+++ b/app/src/components/grid/UnifiedGridRenderer.ts
@@ -12,6 +12,7 @@
 //      an index cursor — NOT `number[].push(...)` + `new Float32Array(...)`,
 //      which benchmarked at ~57ms/frame for 25 tiles (hard jank).
 import { CellFlags, type GhosttyCell, type GhosttyTerminal } from 'ghostty-web';
+import type { UISessionState } from '../../types/sessionState';
 import type {
   GridRenderer,
   GridRenderStats,
@@ -46,15 +47,28 @@ const ATLAS_SIZE = 2048;
 const FLOATS_PER_VERTEX = 8;
 const FLOATS_PER_QUAD = FLOATS_PER_VERTEX * 6;
 const SOLID_TEXEL_CENTER = 0.5 / ATLAS_SIZE;
-const ATTENTION: Rgb = { r: 245, g: 158, b: 11 };
 // Blue accent for the focused (zoomed/input-target) tile, so it is obvious which
-// tile keyboard input is going to. Distinct from the amber attention pulse.
+// tile keyboard input is going to. Distinct from the semantic session state.
 const FOCUS: Rgb = { r: 96, g: 165, b: 250 };
+const STATE_COLORS: Record<UISessionState, Rgb> = {
+  launching: { r: 96, g: 165, b: 250 },
+  working: { r: 34, g: 197, b: 94 },
+  waiting_input: { r: 245, g: 158, b: 11 },
+  idle: { r: 107, g: 114, b: 128 },
+  pending_approval: { r: 234, g: 179, b: 8 },
+  unknown: { r: 168, g: 85, b: 247 },
+};
 // Idle tiles get a faint outline so they read as separate panels against the
 // shared canvas background (tiles only paint non-default cell backgrounds, so
 // without this they blend into the gaps).
 const IDLE_BORDER_ALPHA = 0.22;
 const FOCUS_BORDER_ALPHA = 0.95;
+const WAITING_INPUT_FLASH_PERIOD_MS = 1_600;
+
+export function waitingInputFlash(now: number): number {
+  const wave = 0.5 + 0.5 * Math.sin((now / WAITING_INPUT_FLASH_PERIOD_MS) * Math.PI * 2);
+  return wave * wave;
+}
 
 const BLOCK_ELEMENT_RECTS: Readonly<Record<number, readonly BlockRect[]>> = {
   0x2580: [{ x: 0, y: 0, width: 1, height: 1 / 2 }],
@@ -385,6 +399,26 @@ export class UnifiedGridRenderer implements GridRenderer {
 
     const cellW = m.cellWidth * gs;
     const cellH = m.cellHeight * gs;
+    const w = cols * cellW;
+    const h = rows * cellH;
+    const stateColor = STATE_COLORS[frame.state];
+    const waitingFlash = frame.state === 'waiting_input' ? waitingInputFlash(now) : 0;
+
+    if (frame.statePresentation === 'background') {
+      const pulse = frame.state === 'waiting_input'
+        ? 0.02 + 0.14 * waitingFlash
+        : frame.attention > 0.001
+          ? frame.attention * (0.04 + 0.08 * (0.5 + 0.5 * Math.sin(now / 320)))
+          : 0;
+      this.pushSolid(
+        ox,
+        oy,
+        w,
+        h,
+        stateColor,
+        Math.min(0.24, this.stateBackgroundAlpha(frame.state) + pulse) * alpha,
+      );
+    }
 
     for (let row = 0; row < rows; row += 1) {
       for (let col = 0; col < cols; col += 1) {
@@ -423,24 +457,70 @@ export class UnifiedGridRenderer implements GridRenderer {
       }
     }
 
-    const w = cols * cellW;
-    const h = rows * cellH;
     // Always outline the tile so it reads as a panel; the focused tile gets a
     // brighter accent so the keyboard-input target is unambiguous. Both fade with
     // the frame alpha during a zoom morph.
     if (frame.focused) {
       this.pushBorder(ox, oy, w, h, FOCUS, FOCUS_BORDER_ALPHA * alpha, Math.max(2 * this.dpr, 2));
+    } else if (frame.statePresentation === 'border') {
+      this.pushBorder(
+        ox,
+        oy,
+        w,
+        h,
+        stateColor,
+        (
+          frame.state === 'waiting_input'
+            ? 0.28 + 0.72 * waitingFlash
+            : this.stateBorderAlpha(frame.state)
+        ) * alpha,
+        Math.max(2 * this.dpr, 1.5),
+      );
     } else {
       this.pushBorder(ox, oy, w, h, this.borderColor, IDLE_BORDER_ALPHA * alpha, Math.max(this.dpr, 1));
     }
-    if (frame.attention > 0.001) {
-      this.pushAttentionBorder(ox, oy, w, h, frame.attention, now);
+    if (
+      frame.statePresentation === 'border'
+      && frame.state !== 'waiting_input'
+      && frame.attention > 0.001
+    ) {
+      this.pushAttentionBorder(ox, oy, w, h, stateColor, frame.attention, now);
     }
   }
 
-  private pushAttentionBorder(x: number, y: number, w: number, h: number, intensity: number, now: number): void {
+  private stateBorderAlpha(state: UISessionState): number {
+    if (state === 'idle') return 0.5;
+    if (state === 'working') return 0.72;
+    return 0.82;
+  }
+
+  private stateBackgroundAlpha(state: UISessionState): number {
+    switch (state) {
+      case 'idle':
+        return 0.055;
+      case 'working':
+        return 0.07;
+      case 'launching':
+        return 0.085;
+      case 'waiting_input':
+      case 'pending_approval':
+        return 0.12;
+      case 'unknown':
+        return 0.1;
+    }
+  }
+
+  private pushAttentionBorder(
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    color: Rgb,
+    intensity: number,
+    now: number,
+  ): void {
     const pulse = 0.45 + 0.55 * (0.5 + 0.5 * Math.sin(now / 320));
-    this.pushBorder(x, y, w, h, ATTENTION, Math.min(1, intensity) * pulse, Math.max(2 * this.dpr, 1.5));
+    this.pushBorder(x, y, w, h, color, Math.min(1, intensity) * pulse, Math.max(2 * this.dpr, 1.5));
   }
 
   // Draw a 1-quad-per-edge rectangular outline inset to sit on the content box.

--- a/app/src/components/grid/grid.css
+++ b/app/src/components/grid/grid.css
@@ -23,6 +23,69 @@
   pointer-events: none;
 }
 
+.grid-state-presentation {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 4px;
+  color: #8d8d8d;
+  background: rgba(16, 16, 16, 0.78);
+  border: 1px solid #2c2c2c;
+  border-radius: 9px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
+  backdrop-filter: blur(10px);
+}
+
+.grid-state-presentation-label {
+  padding: 0 6px 0 4px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.grid-state-presentation-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 24px;
+  padding: 0 8px;
+  color: #969696;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.grid-state-presentation-option::before {
+  width: 9px;
+  height: 7px;
+  border: 1px solid #f59e0b;
+  border-radius: 2px;
+  content: '';
+}
+
+.grid-state-presentation-option[data-presentation='background']::before {
+  background: rgba(245, 158, 11, 0.34);
+}
+
+.grid-state-presentation-option:hover {
+  color: #d7d7d7;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.grid-state-presentation-option.active {
+  color: #f1f1f1;
+  background: #292929;
+  border-color: #3b3b3b;
+}
+
 .grid-view-hint {
   position: absolute;
   bottom: 12px;

--- a/app/src/components/grid/gridAutomation.ts
+++ b/app/src/components/grid/gridAutomation.ts
@@ -5,12 +5,14 @@
 // exposes read state, zoom control, and (since zoomed tiles are interactive)
 // keyboard input into the zoomed tile, exercising the real InputHandler path.
 import type { CompositorStats, GridTileSummary } from './GridCompositor';
+import type { GridStatePresentation } from './gridStatePresentation';
 
 export interface GridAutomationState {
   active: boolean;
   tileCount: number;
   zoomedId: string | null;
   layout: { rows: number; cols: number };
+  statePresentation: GridStatePresentation;
   stats: CompositorStats | null;
   tiles: GridTileSummary[];
 }
@@ -19,6 +21,7 @@ export interface GridAutomationHandle {
   getState(): GridAutomationState;
   getTileText(id: string): string | null;
   zoom(id: string | null): void;
+  setStatePresentation(presentation: GridStatePresentation): void;
   hitTest(x: number, y: number): string | null;
   // Type into the zoomed tile via the real keydown -> InputHandler -> PTY path.
   // Returns false if there is no stage to receive the keys.
@@ -41,6 +44,7 @@ export const INACTIVE_GRID_STATE: GridAutomationState = {
   tileCount: 0,
   zoomedId: null,
   layout: { rows: 0, cols: 0 },
+  statePresentation: 'border',
   stats: null,
   tiles: [],
 };

--- a/app/src/components/grid/gridStatePresentation.test.ts
+++ b/app/src/components/grid/gridStatePresentation.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_GRID_STATE_PRESENTATION,
+  persistGridStatePresentation,
+  readGridStatePresentation,
+} from './gridStatePresentation';
+
+describe('grid state presentation persistence', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('round-trips both presentation modes', () => {
+    persistGridStatePresentation('background');
+    expect(readGridStatePresentation()).toBe('background');
+
+    persistGridStatePresentation('border');
+    expect(readGridStatePresentation()).toBe('border');
+  });
+
+  it('defaults to borders for missing or unsupported values', () => {
+    expect(readGridStatePresentation()).toBe(DEFAULT_GRID_STATE_PRESENTATION);
+
+    window.localStorage.setItem('attn.grid.statePresentation', 'glow');
+    expect(readGridStatePresentation()).toBe(DEFAULT_GRID_STATE_PRESENTATION);
+  });
+});

--- a/app/src/components/grid/gridStatePresentation.ts
+++ b/app/src/components/grid/gridStatePresentation.ts
@@ -1,0 +1,24 @@
+export type GridStatePresentation = 'border' | 'background';
+
+export const DEFAULT_GRID_STATE_PRESENTATION: GridStatePresentation = 'border';
+
+const GRID_STATE_PRESENTATION_STORAGE_KEY = 'attn.grid.statePresentation';
+
+export function readGridStatePresentation(): GridStatePresentation {
+  try {
+    const value = window.localStorage.getItem(GRID_STATE_PRESENTATION_STORAGE_KEY);
+    return value === 'background' || value === 'border'
+      ? value
+      : DEFAULT_GRID_STATE_PRESENTATION;
+  } catch {
+    return DEFAULT_GRID_STATE_PRESENTATION;
+  }
+}
+
+export function persistGridStatePresentation(presentation: GridStatePresentation): void {
+  try {
+    window.localStorage.setItem(GRID_STATE_PRESENTATION_STORAGE_KEY, presentation);
+  } catch (err) {
+    console.warn('[grid] Failed to persist state presentation preference:', err);
+  }
+}

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1330,6 +1330,14 @@ export function useUiAutomationBridge({
         handle.zoom(runtimeId);
         return { requested: runtimeId, zoomedId: handle.getState().zoomedId };
       }
+      case 'grid_set_state_presentation': {
+        const handle = getGridAutomationHandle();
+        if (!handle) throw new Error('grid is not active');
+        const presentation = payload.presentation === 'background' ? 'background' : 'border';
+        handle.setStatePresentation(presentation);
+        await settleUi();
+        return { statePresentation: handle.getState().statePresentation };
+      }
       case 'grid_send_text': {
         const handle = getGridAutomationHandle();
         if (!handle) throw new Error('grid is not active');

--- a/app/test-harness/harnesses/GridViewHarness.tsx
+++ b/app/test-harness/harnesses/GridViewHarness.tsx
@@ -17,12 +17,18 @@ import { GridView, type GridSessionTile } from '../../src/components/grid/GridVi
 import type { HarnessProps } from '../types';
 
 const BASE_TILES: GridSessionTile[] = [
-  { runtimeId: 'rt-1', sessionId: 's1', title: 'api server', attention: false },
-  { runtimeId: 'rt-2', sessionId: 's2', title: 'web client', attention: true },
-  { runtimeId: 'rt-3', sessionId: 's3', title: 'worker', attention: false },
+  { runtimeId: 'rt-1', sessionId: 's1', title: 'api server', attention: false, state: 'working' },
+  { runtimeId: 'rt-2', sessionId: 's2', title: 'web client', attention: true, state: 'waiting_input' },
+  { runtimeId: 'rt-3', sessionId: 's3', title: 'worker', attention: false, state: 'idle' },
 ];
 
-const FIXED_EXTRA: GridSessionTile = { runtimeId: 'rt-4', sessionId: 's4', title: 'database', attention: false };
+const FIXED_EXTRA: GridSessionTile = {
+  runtimeId: 'rt-4',
+  sessionId: 's4',
+  title: 'database',
+  attention: true,
+  state: 'pending_approval',
+};
 
 const CONTENT: Record<string, string> = {
   'rt-1': '\x1b[2J\x1b[H$ api server listening on :8080\r\n',


### PR DESCRIPTION
## Intent / Why

Grid mode shows many live sessions at once, but terminal content alone makes it hard to scan which sessions are active or need attention. This adds an experimental state treatment so the visual hierarchy can be evaluated directly in the app.

## Summary

- color grid tiles by session state using either borders or subtle background tints
- add a persistent `State` control for switching between Border and Tint treatments
- flash waiting-for-input sessions in amber so required action is visible at a glance
- keep the blue zoom focus treatment separate from semantic session state
- map review-loop waiting and error states into the same grid state model
- add render-on-state-change, persistence, animation, and automation coverage

## Test plan

- [x] Run focused grid tests: 22 tests passed
- [x] Run TypeScript checking with `pnpm exec tsc --noEmit`
- [x] Build and install the signed production app with `make`
- [x] Verify Border and Tint presentations with multiple live sessions
- [ ] Compare both treatments during normal multi-session use and choose a default
