### PR TITLE
feat(workspaces): add shared context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Added
 - **Agents can delegate a task without leaving their current work.** `attn delegate` starts Claude, Codex, or a plugin agent that explicitly supports delegated prompts with a focused brief from `--brief` or `--brief-file`. The delegated agent can join the current or another existing workspace, start in a new workspace at a chosen directory, or get an isolated branch in a newly created worktree. The bundled attn skill uses a concise capability index and loads separate delegation, review-loop, markdown, or browser guidance only when needed.
+- **Agents can maintain shared context for a workspace.** `attn workspace context show` returns a semi-persistent markdown file that an agent can edit in place, while `update` publishes revision-checked changes and `status` reports local edits or newer shared revisions. Context-bearing workspaces survive after their last session closes, and clients receive `workspace_context_changed` when another session publishes an update.
 
 ### Changed
 - **Grid view shows session state with colored borders and subtle tile tints.** Waiting-for-input sessions flash amber, while zoom focus remains clearly separated from session status.

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -649,7 +649,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [
           {
             id: 'agent-1',
@@ -735,7 +735,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [],
         workspaces: [{
           id: 'workspace-1',
@@ -819,7 +819,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -904,7 +904,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1036,7 +1036,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1102,7 +1102,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1166,7 +1166,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1228,7 +1228,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1288,7 +1288,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [],
         workspaces: [{
           id: 'workspace-1',
@@ -1388,7 +1388,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     };
     const initialState = {
       event: 'initial_state',
-      protocol_version: '90',
+      protocol_version: '91',
       sessions: [],
       workspaces: [workspace],
       prs: [],
@@ -1465,7 +1465,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1559,7 +1559,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1658,7 +1658,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1743,7 +1743,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -1822,7 +1822,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -1892,7 +1892,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '90',
+        protocol_version: '91',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -161,7 +161,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '90';
+const PROTOCOL_VERSION = '91';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -1225,6 +1225,10 @@ export function useDaemonSocket({
               workspacesRef.current = nextWorkspaces;
               onWorkspacesUpdate(nextWorkspaces);
             }
+            break;
+
+          case 'workspace_context_changed':
+          case 'workspace_context_result':
             break;
 
           case 'workspace_unregistered':

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -186,6 +186,13 @@
 //   const updateEndpointMessage = Convert.toUpdateEndpointMessage(json);
 //   const webSocketEvent = Convert.toWebSocketEvent(json);
 //   const workspace = Convert.toWorkspace(json);
+//   const workspaceContext = Convert.toWorkspaceContext(json);
+//   const workspaceContextChangedMessage = Convert.toWorkspaceContextChangedMessage(json);
+//   const workspaceContextCheckoutMessage = Convert.toWorkspaceContextCheckoutMessage(json);
+//   const workspaceContextResult = Convert.toWorkspaceContextResult(json);
+//   const workspaceContextResultMessage = Convert.toWorkspaceContextResultMessage(json);
+//   const workspaceContextStatusMessage = Convert.toWorkspaceContextStatusMessage(json);
+//   const workspaceContextUpdateMessage = Convert.toWorkspaceContextUpdateMessage(json);
 //   const workspaceLayout = Convert.toWorkspaceLayout(json);
 //   const workspaceLayoutActionResultMessage = Convert.toWorkspaceLayoutActionResultMessage(json);
 //   const workspaceLayoutAddSessionPaneMessage = Convert.toWorkspaceLayoutAddSessionPaneMessage(json);
@@ -711,7 +718,7 @@ export interface DelegateResult {
 export interface DelegateResultMessage {
     error?:  string;
     event:   DelegateResultMessageEvent;
-    result?: Result;
+    result?: DelegateResultObject;
     success: boolean;
     [property: string]: any;
 }
@@ -720,7 +727,7 @@ export enum DelegateResultMessageEvent {
     DelegateResult = "delegate_result",
 }
 
-export interface Result {
+export interface DelegateResultObject {
     branch?:           string;
     directory:         string;
     placement:         string;
@@ -2105,15 +2112,16 @@ export enum ResolveCommentResultMessageEvent {
 }
 
 export interface Response {
-    authors?:         AuthorElement[];
-    data?:            string;
-    delegate_result?: Result;
-    error?:           string;
-    ok:               boolean;
-    prs?:             PRElement[];
-    repos?:           RepoElement[];
-    review_loop_run?: ReviewLoopRunObject;
-    sessions?:        SessionElement[];
+    authors?:                  AuthorElement[];
+    data?:                     string;
+    delegate_result?:          DelegateResultObject;
+    error?:                    string;
+    ok:                        boolean;
+    prs?:                      PRElement[];
+    repos?:                    RepoElement[];
+    review_loop_run?:          ReviewLoopRunObject;
+    sessions?:                 SessionElement[];
+    workspace_context_result?: WorkspaceContextResultObject;
     [property: string]: any;
 }
 
@@ -2204,6 +2212,19 @@ export enum ReviewLoopRunStatus {
     Error = "error",
     Running = "running",
     Stopped = "stopped",
+}
+
+export interface WorkspaceContextResultObject {
+    canonical_revision:     number;
+    modified:               boolean;
+    path:                   string;
+    revision:               number;
+    session_id:             string;
+    stale:                  boolean;
+    updated_at?:            string;
+    updated_by_session_id?: string;
+    workspace_id:           string;
+    [property: string]: any;
 }
 
 export interface ReviewComment {
@@ -2683,77 +2704,78 @@ export enum UpdateEndpointMessageCmd {
 }
 
 export interface WebSocketEvent {
-    action?:                string;
-    authors?:               AuthorElement[];
-    base_ref?:              string;
-    branch?:                string;
-    branches?:              BranchElement[];
-    cloned?:                boolean;
-    cmd?:                   string;
-    cols?:                  number;
-    conflict?:              boolean;
-    content?:               string;
-    data?:                  string;
-    directory?:             string;
-    dirty?:                 boolean;
-    error?:                 string;
-    event:                  string;
-    exit_code?:             number;
-    files?:                 FileElement[];
-    found?:                 boolean;
-    id?:                    string;
-    last_seq?:              number;
-    modified?:              string;
-    name?:                  string;
-    operation?:             Operation;
-    original?:              string;
-    pane_id?:               string;
-    path?:                  string;
-    pid?:                   number;
-    plugin_issues?:         IssueElement[];
-    plugins?:               PluginElement[];
-    priority?:              number;
-    protocol_version?:      string;
-    prs?:                   PRElement[];
-    rate_limit_reset_at?:   string;
-    rate_limit_resource?:   string;
-    reason?:                string;
-    recent_locations?:      RecentLocationElement[];
-    repos?:                 RepoElement[];
-    review_loop_run?:       ReviewLoopRunObject;
-    rows?:                  number;
-    running?:               boolean;
-    runtime_id?:            string;
-    screen_cols?:           number;
-    screen_cursor_visible?: boolean;
-    screen_cursor_x?:       number;
-    screen_cursor_y?:       number;
-    screen_rows?:           number;
-    screen_snapshot?:       string;
-    screen_snapshot_fresh?: boolean;
-    scrollback?:            string;
-    scrollback_truncated?:  boolean;
-    seq?:                   number;
-    session?:               SessionElement;
-    session_id?:            string;
-    sessions?:              SessionElement[];
-    settings?:              { [key: string]: any };
-    signal?:                string;
-    split_id?:              string;
-    staged?:                StagedElement[];
-    stash_ref?:             string;
-    success?:               boolean;
-    target_path?:           string;
-    tile_id?:               string;
-    tile_kind?:             string;
-    unstaged?:              StagedElement[];
-    untracked?:             StagedElement[];
-    warnings?:              WarningElement[];
-    workspace?:             WorkspaceElement;
-    workspace_id?:          string;
-    workspace_layout?:      Layout;
-    workspaces?:            WorkspaceElement[];
-    worktrees?:             WorktreeElement[];
+    action?:                   string;
+    authors?:                  AuthorElement[];
+    base_ref?:                 string;
+    branch?:                   string;
+    branches?:                 BranchElement[];
+    cloned?:                   boolean;
+    cmd?:                      string;
+    cols?:                     number;
+    conflict?:                 boolean;
+    content?:                  string;
+    data?:                     string;
+    directory?:                string;
+    dirty?:                    boolean;
+    error?:                    string;
+    event:                     string;
+    exit_code?:                number;
+    files?:                    FileElement[];
+    found?:                    boolean;
+    id?:                       string;
+    last_seq?:                 number;
+    modified?:                 string;
+    name?:                     string;
+    operation?:                Operation;
+    original?:                 string;
+    pane_id?:                  string;
+    path?:                     string;
+    pid?:                      number;
+    plugin_issues?:            IssueElement[];
+    plugins?:                  PluginElement[];
+    priority?:                 number;
+    protocol_version?:         string;
+    prs?:                      PRElement[];
+    rate_limit_reset_at?:      string;
+    rate_limit_resource?:      string;
+    reason?:                   string;
+    recent_locations?:         RecentLocationElement[];
+    repos?:                    RepoElement[];
+    review_loop_run?:          ReviewLoopRunObject;
+    rows?:                     number;
+    running?:                  boolean;
+    runtime_id?:               string;
+    screen_cols?:              number;
+    screen_cursor_visible?:    boolean;
+    screen_cursor_x?:          number;
+    screen_cursor_y?:          number;
+    screen_rows?:              number;
+    screen_snapshot?:          string;
+    screen_snapshot_fresh?:    boolean;
+    scrollback?:               string;
+    scrollback_truncated?:     boolean;
+    seq?:                      number;
+    session?:                  SessionElement;
+    session_id?:               string;
+    sessions?:                 SessionElement[];
+    settings?:                 { [key: string]: any };
+    signal?:                   string;
+    split_id?:                 string;
+    staged?:                   StagedElement[];
+    stash_ref?:                string;
+    success?:                  boolean;
+    target_path?:              string;
+    tile_id?:                  string;
+    tile_kind?:                string;
+    unstaged?:                 StagedElement[];
+    untracked?:                StagedElement[];
+    warnings?:                 WarningElement[];
+    workspace?:                WorkspaceElement;
+    workspace_context_result?: WorkspaceContextResultObject;
+    workspace_id?:             string;
+    workspace_layout?:         Layout;
+    workspaces?:               WorkspaceElement[];
+    worktrees?:                WorktreeElement[];
     [property: string]: any;
 }
 
@@ -2765,6 +2787,85 @@ export interface Workspace {
     status:    WorkspaceStatus;
     title:     string;
     [property: string]: any;
+}
+
+export interface WorkspaceContext {
+    content:               string;
+    revision:              number;
+    updated_at:            string;
+    updated_by_session_id: string;
+    workspace_id:          string;
+    [property: string]: any;
+}
+
+export interface WorkspaceContextChangedMessage {
+    event:                 WorkspaceContextChangedMessageEvent;
+    revision:              number;
+    updated_at:            string;
+    updated_by_session_id: string;
+    workspace_id:          string;
+    [property: string]: any;
+}
+
+export enum WorkspaceContextChangedMessageEvent {
+    WorkspaceContextChanged = "workspace_context_changed",
+}
+
+export interface WorkspaceContextCheckoutMessage {
+    cmd:               WorkspaceContextCheckoutMessageCmd;
+    force?:            boolean;
+    source_session_id: string;
+    [property: string]: any;
+}
+
+export enum WorkspaceContextCheckoutMessageCmd {
+    WorkspaceContextCheckout = "workspace_context_checkout",
+}
+
+export interface WorkspaceContextResult {
+    canonical_revision:     number;
+    modified:               boolean;
+    path:                   string;
+    revision:               number;
+    session_id:             string;
+    stale:                  boolean;
+    updated_at?:            string;
+    updated_by_session_id?: string;
+    workspace_id:           string;
+    [property: string]: any;
+}
+
+export interface WorkspaceContextResultMessage {
+    action:  string;
+    error?:  string;
+    event:   WorkspaceContextResultMessageEvent;
+    result?: WorkspaceContextResultObject;
+    success: boolean;
+    [property: string]: any;
+}
+
+export enum WorkspaceContextResultMessageEvent {
+    WorkspaceContextResult = "workspace_context_result",
+}
+
+export interface WorkspaceContextStatusMessage {
+    cmd:               WorkspaceContextStatusMessageCmd;
+    source_session_id: string;
+    [property: string]: any;
+}
+
+export enum WorkspaceContextStatusMessageCmd {
+    WorkspaceContextStatus = "workspace_context_status",
+}
+
+export interface WorkspaceContextUpdateMessage {
+    cmd:               WorkspaceContextUpdateMessageCmd;
+    source_session_id: string;
+    [property: string]: any;
+}
+
+export enum WorkspaceContextUpdateMessageCmd {
+    WorkspaceContextUpdate = "workspace_context_update",
 }
 
 export interface WorkspaceLayout {
@@ -4560,6 +4661,62 @@ export class Convert {
         return JSON.stringify(uncast(value, r("Workspace")), null, 2);
     }
 
+    public static toWorkspaceContext(json: string): WorkspaceContext {
+        return cast(JSON.parse(json), r("WorkspaceContext"));
+    }
+
+    public static workspaceContextToJson(value: WorkspaceContext): string {
+        return JSON.stringify(uncast(value, r("WorkspaceContext")), null, 2);
+    }
+
+    public static toWorkspaceContextChangedMessage(json: string): WorkspaceContextChangedMessage {
+        return cast(JSON.parse(json), r("WorkspaceContextChangedMessage"));
+    }
+
+    public static workspaceContextChangedMessageToJson(value: WorkspaceContextChangedMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceContextChangedMessage")), null, 2);
+    }
+
+    public static toWorkspaceContextCheckoutMessage(json: string): WorkspaceContextCheckoutMessage {
+        return cast(JSON.parse(json), r("WorkspaceContextCheckoutMessage"));
+    }
+
+    public static workspaceContextCheckoutMessageToJson(value: WorkspaceContextCheckoutMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceContextCheckoutMessage")), null, 2);
+    }
+
+    public static toWorkspaceContextResult(json: string): WorkspaceContextResult {
+        return cast(JSON.parse(json), r("WorkspaceContextResult"));
+    }
+
+    public static workspaceContextResultToJson(value: WorkspaceContextResult): string {
+        return JSON.stringify(uncast(value, r("WorkspaceContextResult")), null, 2);
+    }
+
+    public static toWorkspaceContextResultMessage(json: string): WorkspaceContextResultMessage {
+        return cast(JSON.parse(json), r("WorkspaceContextResultMessage"));
+    }
+
+    public static workspaceContextResultMessageToJson(value: WorkspaceContextResultMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceContextResultMessage")), null, 2);
+    }
+
+    public static toWorkspaceContextStatusMessage(json: string): WorkspaceContextStatusMessage {
+        return cast(JSON.parse(json), r("WorkspaceContextStatusMessage"));
+    }
+
+    public static workspaceContextStatusMessageToJson(value: WorkspaceContextStatusMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceContextStatusMessage")), null, 2);
+    }
+
+    public static toWorkspaceContextUpdateMessage(json: string): WorkspaceContextUpdateMessage {
+        return cast(JSON.parse(json), r("WorkspaceContextUpdateMessage"));
+    }
+
+    public static workspaceContextUpdateMessageToJson(value: WorkspaceContextUpdateMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceContextUpdateMessage")), null, 2);
+    }
+
     public static toWorkspaceLayout(json: string): WorkspaceLayout {
         return cast(JSON.parse(json), r("WorkspaceLayout"));
     }
@@ -5249,10 +5406,10 @@ const typeMap: any = {
     "DelegateResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("DelegateResultMessageEvent") },
-        { json: "result", js: "result", typ: u(undefined, r("Result")) },
+        { json: "result", js: "result", typ: u(undefined, r("DelegateResultObject")) },
         { json: "success", js: "success", typ: true },
     ], "any"),
-    "Result": o([
+    "DelegateResultObject": o([
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "directory", js: "directory", typ: "" },
         { json: "placement", js: "placement", typ: "" },
@@ -6017,13 +6174,14 @@ const typeMap: any = {
     "Response": o([
         { json: "authors", js: "authors", typ: u(undefined, a(r("AuthorElement"))) },
         { json: "data", js: "data", typ: u(undefined, "") },
-        { json: "delegate_result", js: "delegate_result", typ: u(undefined, r("Result")) },
+        { json: "delegate_result", js: "delegate_result", typ: u(undefined, r("DelegateResultObject")) },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "ok", js: "ok", typ: true },
         { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
         { json: "repos", js: "repos", typ: u(undefined, a(r("RepoElement"))) },
         { json: "review_loop_run", js: "review_loop_run", typ: u(undefined, r("ReviewLoopRunObject")) },
         { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
+        { json: "workspace_context_result", js: "workspace_context_result", typ: u(undefined, r("WorkspaceContextResultObject")) },
     ], "any"),
     "ReviewLoopRunObject": o([
         { json: "completed_at", js: "completed_at", typ: u(undefined, "") },
@@ -6078,6 +6236,17 @@ const typeMap: any = {
         { json: "loop_id", js: "loop_id", typ: "" },
         { json: "question", js: "question", typ: "" },
         { json: "status", js: "status", typ: r("ReviewLoopInteractionStatus") },
+    ], "any"),
+    "WorkspaceContextResultObject": o([
+        { json: "canonical_revision", js: "canonical_revision", typ: 0 },
+        { json: "modified", js: "modified", typ: true },
+        { json: "path", js: "path", typ: "" },
+        { json: "revision", js: "revision", typ: 0 },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "stale", js: "stale", typ: true },
+        { json: "updated_at", js: "updated_at", typ: u(undefined, "") },
+        { json: "updated_by_session_id", js: "updated_by_session_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "ReviewComment": o([
         { json: "author", js: "author", typ: "" },
@@ -6420,6 +6589,7 @@ const typeMap: any = {
         { json: "untracked", js: "untracked", typ: u(undefined, a(r("StagedElement"))) },
         { json: "warnings", js: "warnings", typ: u(undefined, a(r("WarningElement"))) },
         { json: "workspace", js: "workspace", typ: u(undefined, r("WorkspaceElement")) },
+        { json: "workspace_context_result", js: "workspace_context_result", typ: u(undefined, r("WorkspaceContextResultObject")) },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
         { json: "workspace_layout", js: "workspace_layout", typ: u(undefined, r("Layout")) },
         { json: "workspaces", js: "workspaces", typ: u(undefined, a(r("WorkspaceElement"))) },
@@ -6432,6 +6602,51 @@ const typeMap: any = {
         { json: "muted", js: "muted", typ: true },
         { json: "status", js: "status", typ: r("WorkspaceStatus") },
         { json: "title", js: "title", typ: "" },
+    ], "any"),
+    "WorkspaceContext": o([
+        { json: "content", js: "content", typ: "" },
+        { json: "revision", js: "revision", typ: 0 },
+        { json: "updated_at", js: "updated_at", typ: "" },
+        { json: "updated_by_session_id", js: "updated_by_session_id", typ: "" },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
+    "WorkspaceContextChangedMessage": o([
+        { json: "event", js: "event", typ: r("WorkspaceContextChangedMessageEvent") },
+        { json: "revision", js: "revision", typ: 0 },
+        { json: "updated_at", js: "updated_at", typ: "" },
+        { json: "updated_by_session_id", js: "updated_by_session_id", typ: "" },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
+    "WorkspaceContextCheckoutMessage": o([
+        { json: "cmd", js: "cmd", typ: r("WorkspaceContextCheckoutMessageCmd") },
+        { json: "force", js: "force", typ: u(undefined, true) },
+        { json: "source_session_id", js: "source_session_id", typ: "" },
+    ], "any"),
+    "WorkspaceContextResult": o([
+        { json: "canonical_revision", js: "canonical_revision", typ: 0 },
+        { json: "modified", js: "modified", typ: true },
+        { json: "path", js: "path", typ: "" },
+        { json: "revision", js: "revision", typ: 0 },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "stale", js: "stale", typ: true },
+        { json: "updated_at", js: "updated_at", typ: u(undefined, "") },
+        { json: "updated_by_session_id", js: "updated_by_session_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
+    "WorkspaceContextResultMessage": o([
+        { json: "action", js: "action", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("WorkspaceContextResultMessageEvent") },
+        { json: "result", js: "result", typ: u(undefined, r("WorkspaceContextResultObject")) },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "WorkspaceContextStatusMessage": o([
+        { json: "cmd", js: "cmd", typ: r("WorkspaceContextStatusMessageCmd") },
+        { json: "source_session_id", js: "source_session_id", typ: "" },
+    ], "any"),
+    "WorkspaceContextUpdateMessage": o([
+        { json: "cmd", js: "cmd", typ: r("WorkspaceContextUpdateMessageCmd") },
+        { json: "source_session_id", js: "source_session_id", typ: "" },
     ], "any"),
     "WorkspaceLayout": o([
         { json: "active_pane_id", js: "active_pane_id", typ: "" },
@@ -7107,6 +7322,21 @@ const typeMap: any = {
     ],
     "UpdateEndpointMessageCmd": [
         "update_endpoint",
+    ],
+    "WorkspaceContextChangedMessageEvent": [
+        "workspace_context_changed",
+    ],
+    "WorkspaceContextCheckoutMessageCmd": [
+        "workspace_context_checkout",
+    ],
+    "WorkspaceContextResultMessageEvent": [
+        "workspace_context_result",
+    ],
+    "WorkspaceContextStatusMessageCmd": [
+        "workspace_context_status",
+    ],
+    "WorkspaceContextUpdateMessageCmd": [
+        "workspace_context_update",
     ],
     "WorkspaceLayoutActionResultMessageEvent": [
         "workspace_layout_action_result",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -141,6 +141,9 @@ func main() {
 	case "delegate":
 		maybePrintProfileBanner()
 		runDelegate()
+	case "workspace":
+		maybePrintProfileBanner()
+		runWorkspace()
 	case "open":
 		maybePrintProfileBanner()
 		runOpen()
@@ -391,6 +394,7 @@ func writeHelp(w io.Writer) {
 commands:
   presence                          check whether the current shell runs inside attn
   delegate --brief-file <path>      start another agent with a delegated brief
+  workspace context <command>       edit shared workspace context
   open <file.md> [--session <id>]   show a markdown file in attn
   browser <command>                 open and control the in-app browser
   review-loop <command>             manage an autonomous review loop
@@ -441,6 +445,94 @@ session options:
   --source-session <id>      source session (defaults to ATTN_SESSION_ID)
   --yolo                     bypass agent approval prompts
 `)
+}
+
+func runWorkspace() {
+	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
+		writeWorkspaceHelp(os.Stdout)
+		return
+	}
+	if os.Args[2] != "context" {
+		fmt.Fprintf(os.Stderr, "workspace: unknown command %q\n\n", os.Args[2])
+		writeWorkspaceHelp(os.Stderr)
+		os.Exit(2)
+	}
+	runWorkspaceContext(os.Args[3:])
+}
+
+func writeWorkspaceHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn workspace context <command>
+
+commands:
+  show [--session <id>] [--force]  print the editable context file path
+  checkout                         alias for show
+  update [--session <id>]          publish local edits if the revision matches
+  status [--session <id>]          show local and canonical revision state
+`)
+}
+
+func workspaceContextSourceSession(args []string, allowForce bool) (string, bool, error) {
+	fs := flag.NewFlagSet("workspace context", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionID := fs.String("session", "", "source session id (defaults to ATTN_SESSION_ID)")
+	force := fs.Bool("force", false, "discard local edits and replace the checkout")
+	if err := fs.Parse(args); err != nil {
+		return "", false, err
+	}
+	if fs.NArg() != 0 {
+		return "", false, fmt.Errorf("unexpected arguments: %v", fs.Args())
+	}
+	if !allowForce && *force {
+		return "", false, errors.New("--force is only valid with show or checkout")
+	}
+	source := strings.TrimSpace(*sessionID)
+	if source == "" {
+		source = strings.TrimSpace(os.Getenv("ATTN_SESSION_ID"))
+	}
+	if source == "" {
+		return "", false, errors.New("no source session; run inside attn or pass --session")
+	}
+	return source, *force, nil
+}
+
+func runWorkspaceContext(args []string) {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		writeWorkspaceHelp(os.Stdout)
+		return
+	}
+	warnIfDaemonVersionMismatch()
+	action := args[0]
+	switch action {
+	case "show", "checkout", "update", "status":
+	default:
+		fmt.Fprintf(os.Stderr, "workspace context: unknown command %q\n\n", action)
+		writeWorkspaceHelp(os.Stderr)
+		os.Exit(2)
+	}
+	sourceSessionID, force, err := workspaceContextSourceSession(args[1:], action == "show" || action == "checkout")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "workspace context: %v\n", err)
+		os.Exit(2)
+	}
+	c := client.New("")
+	var result *protocol.WorkspaceContextResult
+	switch action {
+	case "show", "checkout":
+		result, err = c.CheckoutWorkspaceContext(sourceSessionID, force)
+		if err == nil {
+			fmt.Println(result.Path)
+			return
+		}
+	case "update":
+		result, err = c.UpdateWorkspaceContext(sourceSessionID)
+	case "status":
+		result, err = c.WorkspaceContextStatus(sourceSessionID)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "workspace context %s: %v\n", action, err)
+		os.Exit(1)
+	}
+	printJSON(result)
 }
 
 type delegateCLIArgs struct {

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -445,10 +445,28 @@ func TestWriteHelpMentionsPresenceAndOpen(t *testing.T) {
 	writeHelp(&output)
 
 	text := output.String()
-	for _, expected := range []string{"presence", "delegate --brief-file <path>", "open <file.md> [--session <id>]", "review-loop <command>"} {
+	for _, expected := range []string{"presence", "delegate --brief-file <path>", "workspace context <command>", "open <file.md> [--session <id>]", "review-loop <command>"} {
 		if !strings.Contains(text, expected) {
 			t.Fatalf("help output missing %q: %q", expected, text)
 		}
+	}
+}
+
+func TestWorkspaceContextSourceSessionDefaultsToEnvironment(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "session-1")
+	sessionID, force, err := workspaceContextSourceSession([]string{"--force"}, true)
+	if err != nil {
+		t.Fatalf("workspaceContextSourceSession error: %v", err)
+	}
+	if sessionID != "session-1" || !force {
+		t.Fatalf("workspaceContextSourceSession = (%q, %v)", sessionID, force)
+	}
+}
+
+func TestWorkspaceContextSourceSessionRejectsForceForStatus(t *testing.T) {
+	_, _, err := workspaceContextSourceSession([]string{"--session", "session-1", "--force"}, false)
+	if err == nil || !strings.Contains(err.Error(), "--force is only valid") {
+		t.Fatalf("workspaceContextSourceSession error = %v", err)
 	}
 }
 

--- a/docs/plans/2026-06-08-chief-of-staff.md
+++ b/docs/plans/2026-06-08-chief-of-staff.md
@@ -100,8 +100,8 @@ ChiefOfStaff {
       directory and explicit worktree path.
 - [ ] Reuse the daemon operation from the Tauri app to remove duplicate React
       orchestration.
-- [ ] Add workspace-context checkout/update/status with revision conflicts.
-- [ ] Emit `workspace_context_changed` and keep context-bearing workspaces alive.
+- [x] Add workspace-context checkout/update/status with revision conflicts.
+- [x] Emit `workspace_context_changed` and keep context-bearing workspaces alive.
 - [ ] Add the unique profile-scoped chief-of-staff session role.
 - [ ] Add tracked dispatch status/reporting and UI visualization.
 

--- a/internal/agent/attn_skill/SKILL.md
+++ b/internal/agent/attn_skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attn
-description: Drive attn from an agent. Use to delegate work, run review loops, open markdown, or control attn's persistent in-app browser.
+description: Drive attn from an agent. Use to delegate work, maintain shared workspace context, run review loops, open markdown, or control attn's persistent in-app browser.
 ---
 
 # attn
@@ -24,6 +24,8 @@ If a command reports an unknown subcommand or shows another tool's help, check
 
 - **Delegate a side task to another agent:** read
   [references/delegation.md](references/delegation.md).
+- **Read or update shared workspace context:** read
+  [references/workspace-context.md](references/workspace-context.md).
 - **Start, monitor, or answer a review loop:** read
   [references/review-loops.md](references/review-loops.md).
 - **Show the user a markdown document:** read

--- a/internal/agent/attn_skill/references/workspace-context.md
+++ b/internal/agent/attn_skill/references/workspace-context.md
@@ -1,0 +1,49 @@
+# Workspace Context
+
+Workspace context is a shared, living markdown document for every agent in the
+current workspace. Use it for durable goals, decisions, constraints, progress,
+and handoff information that should survive individual sessions.
+
+## Edit And Publish
+
+Check out the current revision and capture the editable file path:
+
+```sh
+context_file="$("$ATTN_WRAPPER_PATH" workspace context show)"
+```
+
+Edit that file in place, then publish it:
+
+```sh
+"$ATTN_WRAPPER_PATH" workspace context update
+```
+
+`show` preserves local edits. When the local file is clean, it refreshes to the
+latest canonical revision. Use an explicit session only when targeting another
+session:
+
+```sh
+"$ATTN_WRAPPER_PATH" workspace context show --session <session-id>
+```
+
+## Check Status
+
+```sh
+"$ATTN_WRAPPER_PATH" workspace context status
+```
+
+The result reports:
+
+- `modified`: the local file differs from its checked-out revision.
+- `stale`: another session has published a newer canonical revision.
+- `revision`: the local checkout revision.
+- `canonical_revision`: the latest shared revision.
+
+Updates use revision checks. If an update conflicts, keep the local edits,
+inspect status, reconcile them with the latest context, and publish again.
+`show --force` discards local edits and replaces the checkout; use it only when
+discarding those edits is intentional.
+
+The `workspace_context_changed` event exists for clients, but attn does not yet
+interrupt or inject messages into running agents when another session updates
+the context.

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -26,6 +26,7 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 		"delegate work",
 		"ATTN_WRAPPER_PATH",
 		"references/delegation.md",
+		"references/workspace-context.md",
 		"references/review-loops.md",
 		"references/markdown.md",
 		"references/browser.md",
@@ -56,6 +57,20 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 	} {
 		if !strings.Contains(delegation, expected) {
 			t.Fatalf("delegation reference missing %q: %q", expected, delegation)
+		}
+	}
+
+	workspaceContext := readSkillFile(t, skillDir, "references/workspace-context.md")
+	for _, expected := range []string{
+		"workspace context show",
+		"workspace context update",
+		"workspace context status",
+		"canonical_revision",
+		"show --force",
+		"workspace_context_changed",
+	} {
+		if !strings.Contains(workspaceContext, expected) {
+			t.Fatalf("workspace context reference missing %q: %q", expected, workspaceContext)
 		}
 	}
 
@@ -129,6 +144,7 @@ func TestAttnSkillInstallsAreIdentical(t *testing.T) {
 	for _, relative := range []string{
 		"SKILL.md",
 		"references/delegation.md",
+		"references/workspace-context.md",
 		"references/review-loops.md",
 		"references/markdown.md",
 		"references/browser.md",

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -200,6 +200,42 @@ func (c *Client) Delegate(sourceSessionID, brief string, opts DelegateOptions) (
 	return resp.DelegateResult, nil
 }
 
+func (c *Client) CheckoutWorkspaceContext(sourceSessionID string, force bool) (*protocol.WorkspaceContextResult, error) {
+	msg := protocol.WorkspaceContextCheckoutMessage{
+		Cmd:             protocol.CmdWorkspaceContextCheckout,
+		SourceSessionID: sourceSessionID,
+	}
+	if force {
+		msg.Force = protocol.Ptr(true)
+	}
+	return c.workspaceContextResult(msg)
+}
+
+func (c *Client) UpdateWorkspaceContext(sourceSessionID string) (*protocol.WorkspaceContextResult, error) {
+	return c.workspaceContextResult(protocol.WorkspaceContextUpdateMessage{
+		Cmd:             protocol.CmdWorkspaceContextUpdate,
+		SourceSessionID: sourceSessionID,
+	})
+}
+
+func (c *Client) WorkspaceContextStatus(sourceSessionID string) (*protocol.WorkspaceContextResult, error) {
+	return c.workspaceContextResult(protocol.WorkspaceContextStatusMessage{
+		Cmd:             protocol.CmdWorkspaceContextStatus,
+		SourceSessionID: sourceSessionID,
+	})
+}
+
+func (c *Client) workspaceContextResult(msg interface{}) (*protocol.WorkspaceContextResult, error) {
+	resp, err := c.send(msg)
+	if err != nil {
+		return nil, err
+	}
+	if resp.WorkspaceContextResult == nil {
+		return nil, errors.New("daemon returned no workspace context result")
+	}
+	return resp.WorkspaceContextResult, nil
+}
+
 // Query returns sessions matching the filter
 func (c *Client) Query(filter string) ([]protocol.Session, error) {
 	var filterPtr *string

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -259,6 +259,58 @@ func TestClient_Delegate(t *testing.T) {
 	}
 }
 
+func TestClient_CheckoutWorkspaceContext(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "attn-wc-client-")
+	if err != nil {
+		t.Fatalf("MkdirTemp error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	sockPath := filepath.Join(tmpDir, "test.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen error: %v", err)
+	}
+	defer listener.Close()
+
+	requests := make(chan *protocol.WorkspaceContextCheckoutMessage, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var raw json.RawMessage
+		if err := json.NewDecoder(conn).Decode(&raw); err != nil {
+			return
+		}
+		cmd, msg, err := protocol.ParseMessage(raw)
+		if err != nil || cmd != protocol.CmdWorkspaceContextCheckout {
+			return
+		}
+		requests <- msg.(*protocol.WorkspaceContextCheckoutMessage)
+		_ = json.NewEncoder(conn).Encode(protocol.Response{
+			Ok: true,
+			WorkspaceContextResult: &protocol.WorkspaceContextResult{
+				WorkspaceID: "workspace-1",
+				SessionID:   "session-1",
+				Path:        "/tmp/context.md",
+			},
+		})
+	}()
+
+	result, err := New(sockPath).CheckoutWorkspaceContext("session-1", true)
+	if err != nil {
+		t.Fatalf("CheckoutWorkspaceContext error: %v", err)
+	}
+	if result.Path != "/tmp/context.md" {
+		t.Fatalf("CheckoutWorkspaceContext result = %+v", result)
+	}
+	request := <-requests
+	if request.SourceSessionID != "session-1" || !protocol.Deref(request.Force) {
+		t.Fatalf("CheckoutWorkspaceContext request = %+v", request)
+	}
+}
+
 func TestClient_NotRunning(t *testing.T) {
 	c := New("/nonexistent/socket.sock")
 	err := c.Register("id", "label", "/tmp")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1618,6 +1618,12 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleRegister(conn, msg.(*protocol.RegisterMessage))
 	case protocol.CmdDelegate:
 		d.handleDelegate(conn, msg.(*protocol.DelegateMessage))
+	case protocol.CmdWorkspaceContextCheckout:
+		d.handleWorkspaceContextCheckout(conn, msg.(*protocol.WorkspaceContextCheckoutMessage))
+	case protocol.CmdWorkspaceContextUpdate:
+		d.handleWorkspaceContextUpdate(conn, msg.(*protocol.WorkspaceContextUpdateMessage))
+	case protocol.CmdWorkspaceContextStatus:
+		d.handleWorkspaceContextStatus(conn, msg.(*protocol.WorkspaceContextStatusMessage))
 	case protocol.CmdUnregister:
 		d.handleUnregister(conn, msg.(*protocol.UnregisterMessage))
 	case protocol.CmdState:

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -859,6 +859,21 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleClientHello(client, msg.(*protocol.ClientHelloMessage))
 	case protocol.CmdDelegate:
 		go d.handleDelegateWS(client, msg.(*protocol.DelegateMessage))
+	case protocol.CmdWorkspaceContextCheckout:
+		go func() {
+			result, err := d.checkoutWorkspaceContext(msg.(*protocol.WorkspaceContextCheckoutMessage))
+			d.sendWorkspaceContextWSResult(client, "checkout", result, err)
+		}()
+	case protocol.CmdWorkspaceContextUpdate:
+		go func() {
+			result, _, err := d.updateWorkspaceContext(msg.(*protocol.WorkspaceContextUpdateMessage))
+			d.sendWorkspaceContextWSResult(client, "update", result, err)
+		}()
+	case protocol.CmdWorkspaceContextStatus:
+		go func() {
+			result, err := d.workspaceContextStatus(msg.(*protocol.WorkspaceContextStatusMessage))
+			d.sendWorkspaceContextWSResult(client, "status", result, err)
+		}()
 	case protocol.CmdApprovePR:
 		d.handleApprovePRWS(client, msg.(*protocol.ApprovePRMessage))
 	case protocol.CmdMergePR:

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -426,7 +426,10 @@ func (d *Daemon) loadWorkspacesFromStore() {
 			// a docked tile keeps a workspace alive across restarts with no
 			// session of its own.
 			_, registered := d.workspaces.snapshot(ws.ID)
-			if !registered && !d.workspaceHasPendingSpawn(ws.ID) && !d.workspaceLayoutHasTiles(ws.ID) {
+			if !registered &&
+				!d.workspaceHasPendingSpawn(ws.ID) &&
+				!d.workspaceLayoutHasTiles(ws.ID) &&
+				!d.store.HasWorkspaceContext(ws.ID) {
 				d.store.RemoveWorkspace(ws.ID)
 				continue
 			}
@@ -520,7 +523,7 @@ func (d *Daemon) dissociateSessionFromWorkspace(sessionID string) {
 		// user left a docked tile behind, the workspace lives on as a
 		// sessionless, tile-only workspace. We run before the layout's session
 		// pane is removed, so the stored layout still reflects those tiles.
-		if d.workspaceLayoutHasTiles(workspaceID) {
+		if d.workspaceLayoutHasTiles(workspaceID) || d.store.HasWorkspaceContext(workspaceID) {
 			updated, changed := d.recomputeWorkspaceStatus(workspaceID)
 			if !changed {
 				updated, _ = d.workspaces.snapshot(workspaceID)

--- a/internal/daemon/workspace_context.go
+++ b/internal/daemon/workspace_context.go
@@ -1,0 +1,300 @@
+package daemon
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+const workspaceContextFilename = "context.md"
+
+type workspaceContextCheckoutMetadata struct {
+	WorkspaceID   string `json:"workspace_id"`
+	SessionID     string `json:"session_id"`
+	Revision      int    `json:"revision"`
+	CanonicalHash string `json:"canonical_hash"`
+	CheckedOutAt  string `json:"checked_out_at"`
+}
+
+func contextContentHash(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+func workspaceContextCheckoutDir(dataRoot, sessionID string) string {
+	sum := sha256.Sum256([]byte(sessionID))
+	return filepath.Join(dataRoot, "workspace-contexts", hex.EncodeToString(sum[:8]))
+}
+
+func workspaceContextCheckoutPaths(dataRoot, sessionID string) (string, string) {
+	dir := workspaceContextCheckoutDir(dataRoot, sessionID)
+	return filepath.Join(dir, workspaceContextFilename), filepath.Join(dir, "checkout.json")
+}
+
+func writeWorkspaceContextFile(path string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create workspace context directory: %w", err)
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".context-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary workspace context: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return fmt.Errorf("set workspace context permissions: %w", err)
+	}
+	if _, err := temp.Write(content); err != nil {
+		temp.Close()
+		return fmt.Errorf("write workspace context: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close workspace context: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace workspace context: %w", err)
+	}
+	return nil
+}
+
+func writeWorkspaceContextMetadata(path string, metadata workspaceContextCheckoutMetadata) error {
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode workspace context checkout metadata: %w", err)
+	}
+	data = append(data, '\n')
+	return writeWorkspaceContextFile(path, data)
+}
+
+func readWorkspaceContextMetadata(path string) (*workspaceContextCheckoutMetadata, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var metadata workspaceContextCheckoutMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, fmt.Errorf("decode workspace context checkout metadata: %w", err)
+	}
+	return &metadata, nil
+}
+
+func (d *Daemon) resolveWorkspaceContextSource(sourceSessionID string) (*protocol.Session, error) {
+	sourceSessionID = strings.TrimSpace(sourceSessionID)
+	if sourceSessionID == "" {
+		return nil, errors.New("source_session_id is required")
+	}
+	session := d.store.Get(sourceSessionID)
+	if session == nil {
+		return nil, fmt.Errorf("source session not found: %s", sourceSessionID)
+	}
+	if endpointID := strings.TrimSpace(protocol.Deref(session.EndpointID)); endpointID != "" {
+		return nil, fmt.Errorf("workspace context for remote session %s on endpoint %s is not supported", sourceSessionID, endpointID)
+	}
+	if strings.TrimSpace(session.WorkspaceID) == "" || d.store.GetWorkspace(session.WorkspaceID) == nil {
+		return nil, fmt.Errorf("source session has no local workspace")
+	}
+	return session, nil
+}
+
+func workspaceContextResult(session *protocol.Session, canonical *protocol.WorkspaceContext, path string, metadata *workspaceContextCheckoutMetadata, content []byte) *protocol.WorkspaceContextResult {
+	modified := contextContentHash(content) != metadata.CanonicalHash
+	result := &protocol.WorkspaceContextResult{
+		WorkspaceID:       session.WorkspaceID,
+		SessionID:         session.ID,
+		Path:              path,
+		Revision:          metadata.Revision,
+		CanonicalRevision: canonical.Revision,
+		Modified:          modified,
+		Stale:             metadata.Revision != canonical.Revision,
+	}
+	if canonical.UpdatedBySessionID != "" {
+		result.UpdatedBySessionID = protocol.Ptr(canonical.UpdatedBySessionID)
+	}
+	if canonical.UpdatedAt != "" {
+		result.UpdatedAt = protocol.Ptr(canonical.UpdatedAt)
+	}
+	return result
+}
+
+func (d *Daemon) checkoutWorkspaceContext(msg *protocol.WorkspaceContextCheckoutMessage) (*protocol.WorkspaceContextResult, error) {
+	session, err := d.resolveWorkspaceContextSource(msg.SourceSessionID)
+	if err != nil {
+		return nil, err
+	}
+	canonical, err := d.store.GetWorkspaceContext(session.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	contextPath, metadataPath := workspaceContextCheckoutPaths(d.dataRoot, session.ID)
+	localContent, contentErr := os.ReadFile(contextPath)
+	metadata, metadataErr := readWorkspaceContextMetadata(metadataPath)
+	if contentErr != nil && !os.IsNotExist(contentErr) {
+		return nil, fmt.Errorf("read workspace context checkout: %w", contentErr)
+	}
+	if metadataErr != nil && !os.IsNotExist(metadataErr) && !protocol.Deref(msg.Force) {
+		return nil, fmt.Errorf("workspace context checkout metadata is invalid; local file preserved; use `show --force` to replace it: %w", metadataErr)
+	}
+	validCheckout := contentErr == nil &&
+		metadataErr == nil &&
+		metadata.SessionID == session.ID &&
+		metadata.WorkspaceID == session.WorkspaceID
+	if !protocol.Deref(msg.Force) &&
+		(contentErr == nil || metadataErr == nil) &&
+		!validCheckout {
+		return nil, errors.New("workspace context checkout is incomplete or belongs to another session; local files preserved; use `show --force` to replace them")
+	}
+
+	if validCheckout && !protocol.Deref(msg.Force) {
+		modified := contextContentHash(localContent) != metadata.CanonicalHash
+		if modified {
+			return workspaceContextResult(session, canonical, contextPath, metadata, localContent), nil
+		}
+		if metadata.Revision == canonical.Revision {
+			return workspaceContextResult(session, canonical, contextPath, metadata, localContent), nil
+		}
+	}
+
+	content := []byte(canonical.Content)
+	metadata = &workspaceContextCheckoutMetadata{
+		WorkspaceID:   session.WorkspaceID,
+		SessionID:     session.ID,
+		Revision:      canonical.Revision,
+		CanonicalHash: contextContentHash(content),
+		CheckedOutAt:  time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if err := writeWorkspaceContextFile(contextPath, content); err != nil {
+		return nil, err
+	}
+	if err := writeWorkspaceContextMetadata(metadataPath, *metadata); err != nil {
+		return nil, err
+	}
+	return workspaceContextResult(session, canonical, contextPath, metadata, content), nil
+}
+
+func (d *Daemon) workspaceContextStatus(msg *protocol.WorkspaceContextStatusMessage) (*protocol.WorkspaceContextResult, error) {
+	session, err := d.resolveWorkspaceContextSource(msg.SourceSessionID)
+	if err != nil {
+		return nil, err
+	}
+	canonical, err := d.store.GetWorkspaceContext(session.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	contextPath, metadataPath := workspaceContextCheckoutPaths(d.dataRoot, session.ID)
+	content, err := os.ReadFile(contextPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.New("workspace context is not checked out; run `attn workspace context show`")
+		}
+		return nil, fmt.Errorf("read workspace context checkout: %w", err)
+	}
+	metadata, err := readWorkspaceContextMetadata(metadataPath)
+	if err != nil {
+		return nil, fmt.Errorf("read workspace context checkout metadata: %w", err)
+	}
+	if metadata.SessionID != session.ID || metadata.WorkspaceID != session.WorkspaceID {
+		return nil, errors.New("workspace context checkout does not match the source session")
+	}
+	return workspaceContextResult(session, canonical, contextPath, metadata, content), nil
+}
+
+func (d *Daemon) updateWorkspaceContext(msg *protocol.WorkspaceContextUpdateMessage) (*protocol.WorkspaceContextResult, bool, error) {
+	session, err := d.resolveWorkspaceContextSource(msg.SourceSessionID)
+	if err != nil {
+		return nil, false, err
+	}
+	contextPath, metadataPath := workspaceContextCheckoutPaths(d.dataRoot, session.ID)
+	content, err := os.ReadFile(contextPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, errors.New("workspace context is not checked out; run `attn workspace context show`")
+		}
+		return nil, false, fmt.Errorf("read workspace context checkout: %w", err)
+	}
+	metadata, err := readWorkspaceContextMetadata(metadataPath)
+	if err != nil {
+		return nil, false, fmt.Errorf("read workspace context checkout metadata: %w", err)
+	}
+	if metadata.SessionID != session.ID || metadata.WorkspaceID != session.WorkspaceID {
+		return nil, false, errors.New("workspace context checkout does not match the source session")
+	}
+	canonical, changed, err := d.store.UpdateWorkspaceContext(
+		session.WorkspaceID,
+		string(content),
+		session.ID,
+		metadata.Revision,
+	)
+	if err != nil {
+		if errors.Is(err, store.ErrWorkspaceContextConflict) {
+			return nil, false, fmt.Errorf("%w; run `attn workspace context status`, then reconcile or use `show --force` to discard local edits", err)
+		}
+		return nil, false, err
+	}
+	metadata.Revision = canonical.Revision
+	metadata.CanonicalHash = contextContentHash(content)
+	metadata.CheckedOutAt = time.Now().UTC().Format(time.RFC3339Nano)
+	if err := writeWorkspaceContextMetadata(metadataPath, *metadata); err != nil {
+		return nil, false, err
+	}
+	result := workspaceContextResult(session, canonical, contextPath, metadata, content)
+	if changed {
+		d.broadcastMessage(protocol.WorkspaceContextChangedMessage{
+			Event:              protocol.EventWorkspaceContextChanged,
+			WorkspaceID:        canonical.WorkspaceID,
+			Revision:           canonical.Revision,
+			UpdatedBySessionID: canonical.UpdatedBySessionID,
+			UpdatedAt:          canonical.UpdatedAt,
+		})
+	}
+	return result, changed, nil
+}
+
+func (d *Daemon) handleWorkspaceContextCheckout(conn net.Conn, msg *protocol.WorkspaceContextCheckoutMessage) {
+	result, err := d.checkoutWorkspaceContext(msg)
+	d.sendWorkspaceContextResponse(conn, result, err)
+}
+
+func (d *Daemon) handleWorkspaceContextUpdate(conn net.Conn, msg *protocol.WorkspaceContextUpdateMessage) {
+	result, _, err := d.updateWorkspaceContext(msg)
+	d.sendWorkspaceContextResponse(conn, result, err)
+}
+
+func (d *Daemon) handleWorkspaceContextStatus(conn net.Conn, msg *protocol.WorkspaceContextStatusMessage) {
+	result, err := d.workspaceContextStatus(msg)
+	d.sendWorkspaceContextResponse(conn, result, err)
+}
+
+func (d *Daemon) sendWorkspaceContextResponse(conn net.Conn, result *protocol.WorkspaceContextResult, err error) {
+	if err != nil {
+		d.sendError(conn, "workspace context: "+err.Error())
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(protocol.Response{
+		Ok:                     true,
+		WorkspaceContextResult: result,
+	})
+}
+
+func (d *Daemon) sendWorkspaceContextWSResult(client *wsClient, action string, result *protocol.WorkspaceContextResult, err error) {
+	response := protocol.WorkspaceContextResultMessage{
+		Event:   protocol.EventWorkspaceContextResult,
+		Action:  action,
+		Success: err == nil,
+		Result:  result,
+	}
+	if err != nil {
+		response.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, response)
+}

--- a/internal/daemon/workspace_context_test.go
+++ b/internal/daemon/workspace_context_test.go
@@ -1,0 +1,182 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func setupWorkspaceContextSession(t *testing.T, d *Daemon, sessionID, workspaceID string) {
+	t.Helper()
+	d.store.AddWorkspace(&protocol.Workspace{
+		ID:        workspaceID,
+		Title:     workspaceID,
+		Directory: t.TempDir(),
+	})
+	d.workspaces.register(workspaceID, workspaceID, t.TempDir(), false)
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID:             sessionID,
+		Label:          sessionID,
+		Agent:          protocol.SessionAgentCodex,
+		Directory:      t.TempDir(),
+		WorkspaceID:    workspaceID,
+		State:          protocol.SessionStateIdle,
+		StateSince:     now,
+		StateUpdatedAt: now,
+		LastSeen:       now,
+	})
+	d.workspaces.associateSession(sessionID, workspaceID, sessionID)
+}
+
+func TestWorkspaceContextCheckoutEditUpdateAndStatus(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+
+	checkout, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{
+		SourceSessionID: "session-1",
+	})
+	if err != nil {
+		t.Fatalf("checkoutWorkspaceContext error: %v", err)
+	}
+	if checkout.Revision != 0 || checkout.Modified || checkout.Stale {
+		t.Fatalf("initial checkout = %+v", checkout)
+	}
+	if !strings.HasPrefix(checkout.Path, d.dataRoot+string(filepath.Separator)) {
+		t.Fatalf("checkout path %q is outside data root %q", checkout.Path, d.dataRoot)
+	}
+	if err := os.WriteFile(checkout.Path, []byte("# Shared goal\n"), 0o600); err != nil {
+		t.Fatalf("edit checkout: %v", err)
+	}
+	status, err := d.workspaceContextStatus(&protocol.WorkspaceContextStatusMessage{
+		SourceSessionID: "session-1",
+	})
+	if err != nil {
+		t.Fatalf("workspaceContextStatus error: %v", err)
+	}
+	if !status.Modified || status.Stale {
+		t.Fatalf("edited status = %+v", status)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 1)}
+	d.wsHub.clients[client] = true
+	go d.wsHub.run()
+
+	updated, changed, err := d.updateWorkspaceContext(&protocol.WorkspaceContextUpdateMessage{
+		SourceSessionID: "session-1",
+	})
+	if err != nil {
+		t.Fatalf("updateWorkspaceContext error: %v", err)
+	}
+	if !changed || updated.Revision != 1 || updated.Modified || updated.Stale {
+		t.Fatalf("updated result = %+v, changed=%v", updated, changed)
+	}
+	select {
+	case message := <-client.send:
+		var event protocol.WorkspaceContextChangedMessage
+		if err := json.Unmarshal(message.payload, &event); err != nil {
+			t.Fatalf("decode workspace context event: %v", err)
+		}
+		if event.Event != protocol.EventWorkspaceContextChanged ||
+			event.WorkspaceID != "workspace-1" ||
+			event.Revision != 1 ||
+			event.UpdatedBySessionID != "session-1" {
+			t.Fatalf("workspace context event = %+v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("workspace_context_changed was not broadcast")
+	}
+}
+
+func TestWorkspaceContextConflictPreservesLocalEdits(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+	setupWorkspaceContextSession(t, d, "session-2", "workspace-1")
+
+	first, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{SourceSessionID: "session-1"})
+	if err != nil {
+		t.Fatalf("first checkout error: %v", err)
+	}
+	second, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{SourceSessionID: "session-2"})
+	if err != nil {
+		t.Fatalf("second checkout error: %v", err)
+	}
+	if err := os.WriteFile(first.Path, []byte("first update\n"), 0o600); err != nil {
+		t.Fatalf("edit first checkout: %v", err)
+	}
+	if _, _, err := d.updateWorkspaceContext(&protocol.WorkspaceContextUpdateMessage{SourceSessionID: "session-1"}); err != nil {
+		t.Fatalf("first update error: %v", err)
+	}
+	if err := os.WriteFile(second.Path, []byte("second local edit\n"), 0o600); err != nil {
+		t.Fatalf("edit second checkout: %v", err)
+	}
+	if _, _, err := d.updateWorkspaceContext(&protocol.WorkspaceContextUpdateMessage{SourceSessionID: "session-2"}); err == nil ||
+		!strings.Contains(err.Error(), "revision conflict") {
+		t.Fatalf("second update error = %v, want revision conflict", err)
+	}
+	content, err := os.ReadFile(second.Path)
+	if err != nil {
+		t.Fatalf("read preserved checkout: %v", err)
+	}
+	if string(content) != "second local edit\n" {
+		t.Fatalf("local edits after conflict = %q", content)
+	}
+	status, err := d.workspaceContextStatus(&protocol.WorkspaceContextStatusMessage{SourceSessionID: "session-2"})
+	if err != nil {
+		t.Fatalf("status after conflict error: %v", err)
+	}
+	if !status.Modified || !status.Stale || status.Revision != 0 || status.CanonicalRevision != 1 {
+		t.Fatalf("status after conflict = %+v", status)
+	}
+}
+
+func TestWorkspaceContextCheckoutDoesNotOverwriteIncompleteLocalState(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+
+	checkout, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{SourceSessionID: "session-1"})
+	if err != nil {
+		t.Fatalf("initial checkout error: %v", err)
+	}
+	if err := os.WriteFile(checkout.Path, []byte("keep this edit\n"), 0o600); err != nil {
+		t.Fatalf("edit checkout: %v", err)
+	}
+	_, metadataPath := workspaceContextCheckoutPaths(d.dataRoot, "session-1")
+	if err := os.Remove(metadataPath); err != nil {
+		t.Fatalf("remove checkout metadata: %v", err)
+	}
+
+	if _, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{SourceSessionID: "session-1"}); err == nil ||
+		!strings.Contains(err.Error(), "local files preserved") {
+		t.Fatalf("checkout error = %v, want preserved-local-state error", err)
+	}
+	content, err := os.ReadFile(checkout.Path)
+	if err != nil {
+		t.Fatalf("read preserved checkout: %v", err)
+	}
+	if string(content) != "keep this edit\n" {
+		t.Fatalf("checkout content after failed refresh = %q", content)
+	}
+}
+
+func TestWorkspaceContextKeepsSessionlessWorkspaceAlive(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+	if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", "shared", "session-1", 0); err != nil {
+		t.Fatalf("seed workspace context: %v", err)
+	}
+
+	d.dissociateSessionFromWorkspace("session-1")
+
+	if d.store.GetWorkspace("workspace-1") == nil {
+		t.Fatal("context-bearing workspace was removed after its last session left")
+	}
+	if _, ok := d.workspaces.snapshot("workspace-1"); !ok {
+		t.Fatal("context-bearing workspace was removed from the registry")
+	}
+}

--- a/internal/daemon/workspace_context_test.go
+++ b/internal/daemon/workspace_context_test.go
@@ -93,6 +93,42 @@ func TestWorkspaceContextCheckoutEditUpdateAndStatus(t *testing.T) {
 	}
 }
 
+func TestWorkspaceContextUntouchedInitialUpdateIsNoOp(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+
+	checkout, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{
+		SourceSessionID: "session-1",
+	})
+	if err != nil {
+		t.Fatalf("checkoutWorkspaceContext error: %v", err)
+	}
+	if checkout.Revision != 0 || checkout.Modified || checkout.Stale {
+		t.Fatalf("initial checkout = %+v", checkout)
+	}
+
+	updated, changed, err := d.updateWorkspaceContext(&protocol.WorkspaceContextUpdateMessage{
+		SourceSessionID: "session-1",
+	})
+	if err != nil {
+		t.Fatalf("updateWorkspaceContext error: %v", err)
+	}
+	if changed || updated.Revision != 0 || updated.Modified || updated.Stale {
+		t.Fatalf("updated result = %+v, changed=%v", updated, changed)
+	}
+	if d.store.HasWorkspaceContext("workspace-1") {
+		t.Fatal("untouched initial update created a workspace context row")
+	}
+	if queued := len(d.wsHub.broadcast); queued != 0 {
+		t.Fatalf("untouched initial update queued %d broadcast messages", queued)
+	}
+
+	d.dissociateSessionFromWorkspace("session-1")
+	if d.store.GetWorkspace("workspace-1") != nil {
+		t.Fatal("empty-context workspace survived after its last session left")
+	}
+}
+
 func TestWorkspaceContextConflictPreservesLocalEdits(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")

--- a/internal/daemon/workspacelayout.go
+++ b/internal/daemon/workspacelayout.go
@@ -807,7 +807,9 @@ func (d *Daemon) unregisterWorkspaceIfEmptyAfterMove(workspaceID string) {
 	if d.workspaces == nil {
 		return
 	}
-	if len(d.workspaces.sessionIDs(workspaceID)) > 0 || d.workspaceLayoutHasTiles(workspaceID) {
+	if len(d.workspaces.sessionIDs(workspaceID)) > 0 ||
+		d.workspaceLayoutHasTiles(workspaceID) ||
+		d.store.HasWorkspaceContext(workspaceID) {
 		d.recomputeAndBroadcastWorkspace(workspaceID)
 		return
 	}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "90"
+const ProtocolVersion = "91"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -37,6 +37,9 @@ const (
 	CmdClientHello                        = "client_hello"
 	CmdRegister                           = "register"
 	CmdDelegate                           = "delegate"
+	CmdWorkspaceContextCheckout           = "workspace_context_checkout"
+	CmdWorkspaceContextUpdate             = "workspace_context_update"
+	CmdWorkspaceContextStatus             = "workspace_context_status"
 	CmdUnregister                         = "unregister"
 	CmdState                              = "state"
 	CmdSetSessionResumeID                 = "set_session_resume_id"
@@ -143,10 +146,12 @@ const (
 	EventWorkspaceRegistered         = "workspace_registered"
 	EventWorkspaceUnregistered       = "workspace_unregistered"
 	EventWorkspaceStateChanged       = "workspace_state_changed"
+	EventWorkspaceContextChanged     = "workspace_context_changed"
 	EventSessionTodosUpdated         = "session_todos_updated"
 	EventSessionsUpdated             = "sessions_updated"
 	EventRenameResult                = "rename_result"
 	EventDelegateResult              = "delegate_result"
+	EventWorkspaceContextResult      = "workspace_context_result"
 	EventPRsUpdated                  = "prs_updated"
 	EventReposUpdated                = "repos_updated"
 	EventAuthorsUpdated              = "authors_updated"
@@ -295,6 +300,27 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdDelegate:
 		var msg DelegateMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdWorkspaceContextCheckout:
+		var msg WorkspaceContextCheckoutMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdWorkspaceContextUpdate:
+		var msg WorkspaceContextUpdateMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdWorkspaceContextStatus:
+		var msg WorkspaceContextStatusMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2004,6 +2004,10 @@ type Response struct {
 
 	// Sessions corresponds to the JSON schema field "sessions".
 	Sessions []Session `json:"sessions,omitempty,omitzero"`
+
+	// WorkspaceContextResult corresponds to the JSON schema field
+	// "workspace_context_result".
+	WorkspaceContextResult *WorkspaceContextResult `json:"workspace_context_result,omitempty,omitzero"`
 }
 
 type ReviewComment struct {
@@ -2932,6 +2936,10 @@ type WebSocketEvent struct {
 	// Workspace corresponds to the JSON schema field "workspace".
 	Workspace *Workspace `json:"workspace,omitempty,omitzero"`
 
+	// WorkspaceContextResult corresponds to the JSON schema field
+	// "workspace_context_result".
+	WorkspaceContextResult *WorkspaceContextResult `json:"workspace_context_result,omitempty,omitzero"`
+
 	// WorkspaceID corresponds to the JSON schema field "workspace_id".
 	WorkspaceID *string `json:"workspace_id,omitempty,omitzero"`
 
@@ -2963,6 +2971,116 @@ type Workspace struct {
 
 	// Title corresponds to the JSON schema field "title".
 	Title string `json:"title"`
+}
+
+type WorkspaceContext struct {
+	// Content corresponds to the JSON schema field "content".
+	Content string `json:"content"`
+
+	// Revision corresponds to the JSON schema field "revision".
+	Revision int `json:"revision"`
+
+	// UpdatedAt corresponds to the JSON schema field "updated_at".
+	UpdatedAt string `json:"updated_at"`
+
+	// UpdatedBySessionID corresponds to the JSON schema field
+	// "updated_by_session_id".
+	UpdatedBySessionID string `json:"updated_by_session_id"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
+}
+
+type WorkspaceContextChangedMessage struct {
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Revision corresponds to the JSON schema field "revision".
+	Revision int `json:"revision"`
+
+	// UpdatedAt corresponds to the JSON schema field "updated_at".
+	UpdatedAt string `json:"updated_at"`
+
+	// UpdatedBySessionID corresponds to the JSON schema field
+	// "updated_by_session_id".
+	UpdatedBySessionID string `json:"updated_by_session_id"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
+}
+
+type WorkspaceContextCheckoutMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Force corresponds to the JSON schema field "force".
+	Force *bool `json:"force,omitempty,omitzero"`
+
+	// SourceSessionID corresponds to the JSON schema field "source_session_id".
+	SourceSessionID string `json:"source_session_id"`
+}
+
+type WorkspaceContextResult struct {
+	// CanonicalRevision corresponds to the JSON schema field "canonical_revision".
+	CanonicalRevision int `json:"canonical_revision"`
+
+	// Modified corresponds to the JSON schema field "modified".
+	Modified bool `json:"modified"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+
+	// Revision corresponds to the JSON schema field "revision".
+	Revision int `json:"revision"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
+
+	// Stale corresponds to the JSON schema field "stale".
+	Stale bool `json:"stale"`
+
+	// UpdatedAt corresponds to the JSON schema field "updated_at".
+	UpdatedAt *string `json:"updated_at,omitempty,omitzero"`
+
+	// UpdatedBySessionID corresponds to the JSON schema field
+	// "updated_by_session_id".
+	UpdatedBySessionID *string `json:"updated_by_session_id,omitempty,omitzero"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
+}
+
+type WorkspaceContextResultMessage struct {
+	// Action corresponds to the JSON schema field "action".
+	Action string `json:"action"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Result corresponds to the JSON schema field "result".
+	Result *WorkspaceContextResult `json:"result,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
+type WorkspaceContextStatusMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// SourceSessionID corresponds to the JSON schema field "source_session_id".
+	SourceSessionID string `json:"source_session_id"`
+}
+
+type WorkspaceContextUpdateMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// SourceSessionID corresponds to the JSON schema field "source_session_id".
+	SourceSessionID string `json:"source_session_id"`
 }
 
 type WorkspaceLayout struct {

--- a/internal/protocol/parse_test.go
+++ b/internal/protocol/parse_test.go
@@ -147,6 +147,26 @@ func TestParseDelegatePlacementAndWorktree(t *testing.T) {
 	}
 }
 
+func TestParseWorkspaceContextCommands(t *testing.T) {
+	tests := []struct {
+		input string
+		cmd   string
+	}{
+		{`{"cmd":"workspace_context_checkout","source_session_id":"session-1","force":true}`, CmdWorkspaceContextCheckout},
+		{`{"cmd":"workspace_context_update","source_session_id":"session-1"}`, CmdWorkspaceContextUpdate},
+		{`{"cmd":"workspace_context_status","source_session_id":"session-1"}`, CmdWorkspaceContextStatus},
+	}
+	for _, test := range tests {
+		cmd, _, err := ParseMessage([]byte(test.input))
+		if err != nil {
+			t.Fatalf("ParseMessage(%s) error = %v", test.input, err)
+		}
+		if cmd != test.cmd {
+			t.Fatalf("ParseMessage(%s) cmd = %q, want %q", test.input, cmd, test.cmd)
+		}
+	}
+}
+
 func TestParseWorkspaceLayoutSetSplitRatio(t *testing.T) {
 	input := `{"cmd":"workspace_layout_set_split_ratio","workspace_id":"ws1","split_id":"split-1","ratio":0.3}`
 	cmd, data, err := ParseMessage([]byte(input))

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -154,6 +154,14 @@ model Workspace {
   layout?: WorkspaceLayout;
 }
 
+model WorkspaceContext {
+  workspace_id: string;
+  content: string;
+  revision: int32;
+  updated_by_session_id: string;
+  updated_at: string;
+}
+
 model PR {
   // Core identity - always present
   // ID format: "host:owner/repo#number" (e.g. github.com:acme/widget#42)
@@ -391,6 +399,22 @@ model DelegateMessage {
   workspace_id?: string;
   cwd?: string;
   worktree?: DelegateWorktreeRequest;
+}
+
+model WorkspaceContextCheckoutMessage {
+  cmd: "workspace_context_checkout";
+  source_session_id: string;
+  force?: boolean;
+}
+
+model WorkspaceContextUpdateMessage {
+  cmd: "workspace_context_update";
+  source_session_id: string;
+}
+
+model WorkspaceContextStatusMessage {
+  cmd: "workspace_context_status";
+  source_session_id: string;
 }
 
 model DelegateWorktreeRequest {
@@ -1086,6 +1110,14 @@ model WorkspaceStateChangedMessage {
   workspace: Workspace;
 }
 
+model WorkspaceContextChangedMessage {
+  event: "workspace_context_changed";
+  workspace_id: string;
+  revision: int32;
+  updated_by_session_id: string;
+  updated_at: string;
+}
+
 model SessionTodosUpdatedMessage {
   event: "session_todos_updated";
   session: Session;
@@ -1644,6 +1676,7 @@ model Response {
   error?: string;
   data?: string;
   delegate_result?: DelegateResult;
+  workspace_context_result?: WorkspaceContextResult;
   sessions?: Session[];
   prs?: PR[];
   repos?: RepoState[];
@@ -1665,6 +1698,26 @@ model DelegateResultMessage {
   success: boolean;
   error?: string;
   result?: DelegateResult;
+}
+
+model WorkspaceContextResult {
+  workspace_id: string;
+  session_id: string;
+  path: string;
+  revision: int32;
+  canonical_revision: int32;
+  modified: boolean;
+  stale: boolean;
+  updated_by_session_id?: string;
+  updated_at?: string;
+}
+
+model WorkspaceContextResultMessage {
+  event: "workspace_context_result";
+  action: string;
+  success: boolean;
+  error?: string;
+  result?: WorkspaceContextResult;
 }
 
 // Warning for non-critical issues (e.g., gh version too old)
@@ -1763,6 +1816,7 @@ model WebSocketEvent {
   signal?: string;
 
   review_loop_run?: ReviewLoopRun;
+  workspace_context_result?: WorkspaceContextResult;
 }
 
 alias DaemonEvent =
@@ -1773,6 +1827,7 @@ alias DaemonEvent =
   | WorkspaceRegisteredMessage
   | WorkspaceUnregisteredMessage
   | WorkspaceStateChangedMessage
+  | WorkspaceContextChangedMessage
   | SessionTodosUpdatedMessage
   | SessionsUpdatedMessage
   | WorkspaceLayoutMessage
@@ -1813,6 +1868,7 @@ alias DaemonEvent =
   | GetReviewStateResultMessage
   | ReviewLoopResultMessage
   | ReviewLoopUpdatedMessage
+  | WorkspaceContextResultMessage
   | MarkFileViewedResultMessage
   | AddCommentResultMessage
   | UpdateCommentResultMessage

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -328,6 +328,15 @@ var migrations = []migration{
 	{41, "move session mute state to workspaces", `
 		ALTER TABLE workspaces ADD COLUMN muted INTEGER NOT NULL DEFAULT 0;
 	`},
+	{42, "create workspace contexts table", `
+		CREATE TABLE IF NOT EXISTS workspace_contexts (
+			workspace_id TEXT PRIMARY KEY,
+			content TEXT NOT NULL,
+			revision INTEGER NOT NULL,
+			updated_by_session_id TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+	`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -17,7 +17,7 @@ func TestOpenDB_CreatesSchema(t *testing.T) {
 	defer db.Close()
 
 	// Verify tables exist by querying them
-	tables := []string{"sessions", "prs", "repos", "review_loop_runs", "review_loop_iterations", "review_loop_interactions"}
+	tables := []string{"sessions", "prs", "repos", "review_loop_runs", "review_loop_iterations", "review_loop_interactions", "workspace_contexts"}
 	for _, table := range tables {
 		var count int
 		err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&count)

--- a/internal/store/workspace.go
+++ b/internal/store/workspace.go
@@ -43,6 +43,7 @@ func (s *Store) RemoveWorkspace(id string) {
 	}
 	_, _ = s.db.Exec(`DELETE FROM workspace_layout_panes WHERE workspace_id = ?`, id)
 	_, _ = s.db.Exec(`DELETE FROM workspace_layouts WHERE workspace_id = ?`, id)
+	_, _ = s.db.Exec(`DELETE FROM workspace_contexts WHERE workspace_id = ?`, id)
 	if _, err := s.db.Exec(`DELETE FROM workspaces WHERE id = ?`, id); err != nil {
 		log.Printf("[store] RemoveWorkspace: failed to delete workspace %s: %v", id, err)
 	}

--- a/internal/store/workspace_context.go
+++ b/internal/store/workspace_context.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+var ErrWorkspaceContextConflict = errors.New("workspace context revision conflict")
+
+// GetWorkspaceContext returns the canonical context. A workspace without
+// context has revision zero and empty content.
+func (s *Store) GetWorkspaceContext(workspaceID string) (*protocol.WorkspaceContext, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return &protocol.WorkspaceContext{WorkspaceID: workspaceID}, nil
+	}
+	var context protocol.WorkspaceContext
+	err := s.db.QueryRow(`
+		SELECT workspace_id, content, revision, updated_by_session_id, updated_at
+		FROM workspace_contexts
+		WHERE workspace_id = ?`,
+		workspaceID,
+	).Scan(
+		&context.WorkspaceID,
+		&context.Content,
+		&context.Revision,
+		&context.UpdatedBySessionID,
+		&context.UpdatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return &protocol.WorkspaceContext{WorkspaceID: workspaceID}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get workspace context %s: %w", workspaceID, err)
+	}
+	return &context, nil
+}
+
+// UpdateWorkspaceContext replaces the canonical content when expectedRevision
+// still matches. It returns changed=false for an identical update.
+func (s *Store) UpdateWorkspaceContext(workspaceID, content, updatedBySessionID string, expectedRevision int) (*protocol.WorkspaceContext, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil, false, errors.New("workspace context persistence unavailable")
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, false, fmt.Errorf("begin workspace context update: %w", err)
+	}
+	defer tx.Rollback()
+
+	var current protocol.WorkspaceContext
+	err = tx.QueryRow(`
+		SELECT workspace_id, content, revision, updated_by_session_id, updated_at
+		FROM workspace_contexts
+		WHERE workspace_id = ?`,
+		workspaceID,
+	).Scan(
+		&current.WorkspaceID,
+		&current.Content,
+		&current.Revision,
+		&current.UpdatedBySessionID,
+		&current.UpdatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		current = protocol.WorkspaceContext{WorkspaceID: workspaceID}
+	} else if err != nil {
+		return nil, false, fmt.Errorf("read workspace context %s: %w", workspaceID, err)
+	}
+	if current.Revision != expectedRevision {
+		return nil, false, fmt.Errorf("%w: expected revision %d, current revision %d", ErrWorkspaceContextConflict, expectedRevision, current.Revision)
+	}
+	if current.Content == content && current.Revision > 0 {
+		if err := tx.Commit(); err != nil {
+			return nil, false, fmt.Errorf("commit unchanged workspace context: %w", err)
+		}
+		return &current, false, nil
+	}
+
+	updated := &protocol.WorkspaceContext{
+		WorkspaceID:        workspaceID,
+		Content:            content,
+		Revision:           current.Revision + 1,
+		UpdatedBySessionID: updatedBySessionID,
+		UpdatedAt:          time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO workspace_contexts
+			(workspace_id, content, revision, updated_by_session_id, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(workspace_id) DO UPDATE SET
+			content = excluded.content,
+			revision = excluded.revision,
+			updated_by_session_id = excluded.updated_by_session_id,
+			updated_at = excluded.updated_at`,
+		updated.WorkspaceID,
+		updated.Content,
+		updated.Revision,
+		updated.UpdatedBySessionID,
+		updated.UpdatedAt,
+	); err != nil {
+		return nil, false, fmt.Errorf("write workspace context %s: %w", workspaceID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, false, fmt.Errorf("commit workspace context update: %w", err)
+	}
+	return updated, true, nil
+}
+
+func (s *Store) HasWorkspaceContext(workspaceID string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return false
+	}
+	var exists int
+	return s.db.QueryRow(`SELECT 1 FROM workspace_contexts WHERE workspace_id = ?`, workspaceID).Scan(&exists) == nil
+}
+
+func (s *Store) RemoveWorkspaceContext(workspaceID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return
+	}
+	_, _ = s.db.Exec(`DELETE FROM workspace_contexts WHERE workspace_id = ?`, workspaceID)
+}

--- a/internal/store/workspace_context.go
+++ b/internal/store/workspace_context.go
@@ -78,7 +78,7 @@ func (s *Store) UpdateWorkspaceContext(workspaceID, content, updatedBySessionID 
 	if current.Revision != expectedRevision {
 		return nil, false, fmt.Errorf("%w: expected revision %d, current revision %d", ErrWorkspaceContextConflict, expectedRevision, current.Revision)
 	}
-	if current.Content == content && current.Revision > 0 {
+	if current.Content == content {
 		if err := tx.Commit(); err != nil {
 			return nil, false, fmt.Errorf("commit unchanged workspace context: %w", err)
 		}

--- a/internal/store/workspace_context_test.go
+++ b/internal/store/workspace_context_test.go
@@ -23,6 +23,17 @@ func TestWorkspaceContextRevisionCheckedUpdate(t *testing.T) {
 		t.Fatalf("initial context = %+v", initial)
 	}
 
+	unchanged, changed, err := s.UpdateWorkspaceContext("workspace-1", "", "session-1", 0)
+	if err != nil {
+		t.Fatalf("initial empty UpdateWorkspaceContext error: %v", err)
+	}
+	if changed || unchanged.Revision != 0 || unchanged.Content != "" {
+		t.Fatalf("initial unchanged context = %+v, changed=%v", unchanged, changed)
+	}
+	if s.HasWorkspaceContext("workspace-1") {
+		t.Fatal("initial empty update created a workspace context row")
+	}
+
 	updated, changed, err := s.UpdateWorkspaceContext("workspace-1", "# Goal\n", "session-1", 0)
 	if err != nil {
 		t.Fatalf("UpdateWorkspaceContext error: %v", err)
@@ -34,7 +45,7 @@ func TestWorkspaceContextRevisionCheckedUpdate(t *testing.T) {
 		t.Fatal("HasWorkspaceContext returned false")
 	}
 
-	unchanged, changed, err := s.UpdateWorkspaceContext("workspace-1", "# Goal\n", "session-1", 1)
+	unchanged, changed, err = s.UpdateWorkspaceContext("workspace-1", "# Goal\n", "session-1", 1)
 	if err != nil {
 		t.Fatalf("identical UpdateWorkspaceContext error: %v", err)
 	}

--- a/internal/store/workspace_context_test.go
+++ b/internal/store/workspace_context_test.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestWorkspaceContextRevisionCheckedUpdate(t *testing.T) {
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	initial, err := s.GetWorkspaceContext("workspace-1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceContext error: %v", err)
+	}
+	if initial.Revision != 0 || initial.Content != "" {
+		t.Fatalf("initial context = %+v", initial)
+	}
+
+	updated, changed, err := s.UpdateWorkspaceContext("workspace-1", "# Goal\n", "session-1", 0)
+	if err != nil {
+		t.Fatalf("UpdateWorkspaceContext error: %v", err)
+	}
+	if !changed || updated.Revision != 1 || updated.Content != "# Goal\n" {
+		t.Fatalf("updated context = %+v, changed=%v", updated, changed)
+	}
+	if !s.HasWorkspaceContext("workspace-1") {
+		t.Fatal("HasWorkspaceContext returned false")
+	}
+
+	unchanged, changed, err := s.UpdateWorkspaceContext("workspace-1", "# Goal\n", "session-1", 1)
+	if err != nil {
+		t.Fatalf("identical UpdateWorkspaceContext error: %v", err)
+	}
+	if changed || unchanged.Revision != 1 {
+		t.Fatalf("unchanged context = %+v, changed=%v", unchanged, changed)
+	}
+
+	_, _, err = s.UpdateWorkspaceContext("workspace-1", "# Stale\n", "session-2", 0)
+	if !errors.Is(err, ErrWorkspaceContextConflict) {
+		t.Fatalf("stale update error = %v, want revision conflict", err)
+	}
+	current, err := s.GetWorkspaceContext("workspace-1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceContext after conflict error: %v", err)
+	}
+	if current.Revision != 1 || current.Content != "# Goal\n" {
+		t.Fatalf("context changed after conflict: %+v", current)
+	}
+}
+
+func TestRemoveWorkspaceRemovesContext(t *testing.T) {
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	s.AddWorkspace(&protocol.Workspace{ID: "workspace-1", Title: "Project", Directory: "/tmp/project"})
+	if _, _, err := s.UpdateWorkspaceContext("workspace-1", "context", "session-1", 0); err != nil {
+		t.Fatalf("UpdateWorkspaceContext error: %v", err)
+	}
+	s.RemoveWorkspace("workspace-1")
+	if s.HasWorkspaceContext("workspace-1") {
+		t.Fatal("workspace context survived explicit workspace removal")
+	}
+}


### PR DESCRIPTION
## Intent / Why

Long-running and delegated agents need durable workspace-level context so new sessions can start with current goals, decisions, constraints, and progress instead of reconstructing them from scratch. This introduces the shared context foundation before adding the chief-of-staff role.

## Summary

- add `attn workspace context show`, `update`, and `status` with semi-persistent per-session markdown checkouts
- persist canonical workspace context with revision-based conflict detection and preserve local edits on conflicts
- emit `workspace_context_changed` and keep context-bearing workspaces alive after their last session closes
- expose the operations over socket and WebSocket protocols and bump the protocol version to 91
- teach agents the file-based workflow through the split attn skill reference

## Test plan

- [x] `go test ./...`
- [x] `pnpm --dir app test -- --run` (635 tests)
- [x] `pnpm --dir app run build`
- [x] `pnpm --dir app run e2e` (104 passed, 1 skipped)
- [x] manual dev test: Claude publishes context and Codex reads and updates it in the same workspace
- [x] manual dev test: stale update is rejected while preserving local edits
- [x] manual dev test: context-bearing workspace survives session close and daemon restart, then is removed by explicit workspace deletion

## Out of scope

- injecting or pinging a running agent when another session changes workspace context
- the unique chief-of-staff agent role and tracked dispatch relationships
- Tauri UI for editing or visualizing workspace context