### PR TITLE
feat(diag): opt-in loopback pprof + /debug/vars endpoint (WS-7)

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,65 @@
+# Diagnostics: pprof + /debug/vars
+
+attn ships an **opt-in, loopback-only** diagnostics endpoint for measuring memory
+and CPU. It is **off by default** and binds `127.0.0.1` only, so it never adds
+remote attack surface.
+
+## Enable
+
+Set `ATTN_PPROF` in the daemon's environment:
+
+| `ATTN_PPROF`        | Effect                              |
+| ------------------- | ----------------------------------- |
+| unset / `0` / `off` | disabled (default)                  |
+| `1` / `on` / `true` | enabled on `127.0.0.1:6060`         |
+| `6061`, `:6061`     | enabled on that loopback port       |
+
+The daemon logs `diagnostics endpoint listening on http://127.0.0.1:<port>/` on
+startup. The simplest controlled setup for a measurement run is a manual daemon
+on a throwaway profile (its own socket/port/data dir, never touches prod):
+
+```bash
+env ATTN_PROFILE=perf ATTN_PPROF=6060 attn daemon
+```
+
+To profile the live app daemon instead, set `ATTN_PPROF` in the environment it is
+launched from.
+
+## Endpoints
+
+- `GET /debug/vars` — JSON snapshot: Go `runtime.MemStats` heap fields
+  (`heap_alloc`, `heap_sys`, `heap_idle`, `heap_released`, `num_gc`, …),
+  goroutine/CPU counts, PTY session count, the active `pty_backend`, and
+  `worker_pids` (sessionID → worker subprocess PID).
+- `GET /debug/pprof/` — standard Go pprof index (`heap`, `goroutine`, `profile`,
+  `trace`, …).
+
+## Measurement recipes
+
+```bash
+# Live heap/runtime snapshot
+curl -s http://127.0.0.1:6060/debug/vars | jq
+
+# Heap profile, symbolized
+go tool pprof -top http://127.0.0.1:6060/debug/pprof/heap
+
+# 30s CPU profile
+go tool pprof http://127.0.0.1:6060/debug/pprof/profile?seconds=30
+```
+
+### Per-session RSS (the dominant memory locus)
+
+The default `worker` PTY backend runs **one subprocess per session**, so the bulk
+of per-session memory lives in those child PIDs, not the daemon heap. Sum the
+daemon RSS plus every worker PID from `/debug/vars`:
+
+```bash
+# daemon + all worker subprocesses
+curl -s http://127.0.0.1:6060/debug/vars \
+  | jq -r '.pid, (.worker_pids[]|tostring)' \
+  | xargs ps -o pid,rss,command -p
+```
+
+`rss` is in KiB. This is the measurement to capture before/after each memory
+workstream (e.g. WS-1 terminal virtualization, WS-2 scrollback shrink) with a
+fixed scenario such as 8 sessions, 2 streaming.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -432,4 +433,39 @@ func DebugLevel() int {
 	default:
 		return LogError
 	}
+}
+
+// DefaultPprofPort is the loopback port used when ATTN_PPROF is enabled without
+// an explicit port (e.g. ATTN_PPROF=1).
+const DefaultPprofPort = 6060
+
+// PprofAddr reports whether the opt-in diagnostics endpoint (pprof + expvar) is
+// enabled and, if so, the loopback address to bind. It is strictly off unless
+// ATTN_PPROF is set, and always binds 127.0.0.1 so it adds no remote attack
+// surface (any host in the value is ignored on purpose).
+//
+//	unset / "0" / "off" / "false" / "no" → disabled
+//	"1" / "on" / "true" / "yes"          → enabled on DefaultPprofPort
+//	"<port>" or ":<port>" or "host:port" → enabled on that port (loopback)
+func PprofAddr() (addr string, enabled bool) {
+	raw := strings.TrimSpace(os.Getenv("ATTN_PPROF"))
+	if raw == "" {
+		return "", false
+	}
+	switch strings.ToLower(raw) {
+	case "0", "off", "false", "no":
+		return "", false
+	case "1", "on", "true", "yes":
+		return fmt.Sprintf("127.0.0.1:%d", DefaultPprofPort), true
+	}
+	// Accept "host:port", ":port", or a bare port; ignore the host and force
+	// loopback so the endpoint can never be exposed off the machine.
+	portPart := raw
+	if i := strings.LastIndex(portPart, ":"); i >= 0 {
+		portPart = portPart[i+1:]
+	}
+	if p, err := strconv.Atoi(portPart); err == nil && p > 0 && p <= 65535 {
+		return fmt.Sprintf("127.0.0.1:%d", p), true
+	}
+	return "", false
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -368,3 +368,49 @@ func TestValidateProfileName_PureFunction(t *testing.T) {
 		t.Error("ValidateProfileName(\"bad name\") should have errored")
 	}
 }
+
+func TestPprofAddr(t *testing.T) {
+	orig, had := os.LookupEnv("ATTN_PPROF")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("ATTN_PPROF", orig)
+		} else {
+			os.Unsetenv("ATTN_PPROF")
+		}
+	})
+
+	cases := []struct {
+		name        string
+		set         bool
+		val         string
+		wantAddr    string
+		wantEnabled bool
+	}{
+		{name: "unset", set: false},
+		{name: "empty", set: true, val: ""},
+		{name: "off", set: true, val: "off"},
+		{name: "zero", set: true, val: "0"},
+		{name: "false", set: true, val: "false"},
+		{name: "one_default_port", set: true, val: "1", wantAddr: "127.0.0.1:6060", wantEnabled: true},
+		{name: "on", set: true, val: "on", wantAddr: "127.0.0.1:6060", wantEnabled: true},
+		{name: "true", set: true, val: "true", wantAddr: "127.0.0.1:6060", wantEnabled: true},
+		{name: "bare_port", set: true, val: "6061", wantAddr: "127.0.0.1:6061", wantEnabled: true},
+		{name: "colon_port", set: true, val: ":7070", wantAddr: "127.0.0.1:7070", wantEnabled: true},
+		{name: "host_port_forced_loopback", set: true, val: "0.0.0.0:8080", wantAddr: "127.0.0.1:8080", wantEnabled: true},
+		{name: "garbage", set: true, val: "banana"},
+		{name: "out_of_range", set: true, val: "70000"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				os.Setenv("ATTN_PPROF", tc.val)
+			} else {
+				os.Unsetenv("ATTN_PPROF")
+			}
+			addr, enabled := PprofAddr()
+			if enabled != tc.wantEnabled || addr != tc.wantAddr {
+				t.Fatalf("PprofAddr() = (%q, %v), want (%q, %v)", addr, enabled, tc.wantAddr, tc.wantEnabled)
+			}
+		})
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -22,6 +22,7 @@ import (
 	"github.com/victorarias/attn/internal/buildinfo"
 	"github.com/victorarias/attn/internal/classifier"
 	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/diag"
 	"github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/github"
 	"github.com/victorarias/attn/internal/hub"
@@ -96,6 +97,7 @@ type Daemon struct {
 	listener         net.Listener
 	httpServer       *http.Server
 	httpHandler      http.Handler
+	diagServer       *diag.Server // opt-in loopback pprof/expvar; nil unless ATTN_PPROF set
 	wsHub            *wsHub
 	done             chan struct{}
 	logger           *logging.Logger
@@ -610,6 +612,7 @@ func (d *Daemon) Start() error {
 	// Create HTTP server for WebSocket (must be created synchronously to avoid race with Stop())
 	d.initHTTPServer()
 	go d.runHTTPServer()
+	d.maybeStartDiagServer()
 	d.removeLegacyEmbeddedTailscaleState()
 	go d.ensureTailscaleServeFromSettingsAndBroadcast()
 	d.hubManager.Start(d.doneContext())
@@ -1145,6 +1148,9 @@ func (d *Daemon) Stop() {
 		defer cancel()
 		d.httpServer.Shutdown(ctx)
 	}
+	if d.diagServer != nil {
+		_ = d.diagServer.Close()
+	}
 	if d.listener != nil {
 		d.listener.Close()
 	}
@@ -1353,6 +1359,41 @@ func (d *Daemon) runHTTPServer() {
 	if err := d.httpServer.ListenAndServe(); err != http.ErrServerClosed {
 		d.logf("HTTP server error: %v", err)
 	}
+}
+
+// maybeStartDiagServer starts the opt-in loopback diagnostics endpoint (pprof +
+// /debug/vars) when ATTN_PPROF is set. It is off by default and binds 127.0.0.1
+// only. A bind failure is logged but never fatal — diagnostics must not take the
+// daemon down.
+func (d *Daemon) maybeStartDiagServer() {
+	addr, enabled := config.PprofAddr()
+	if !enabled {
+		return
+	}
+	srv, err := diag.Start(addr, d.diagStats)
+	if err != nil {
+		d.logf("diagnostics endpoint failed to start on %s: %v", addr, err)
+		return
+	}
+	d.diagServer = srv
+	d.logf("diagnostics endpoint listening on http://%s/ (pprof + /debug/vars)", srv.Addr())
+}
+
+// diagStats reports live PTY-session counts and worker subprocess PIDs for the
+// diagnostics /debug/vars snapshot. The worker PIDs are the per-session RSS
+// handles for the worker backend; the embedded backend reports none.
+func (d *Daemon) diagStats() diag.Stats {
+	stats := diag.Stats{PtyBackend: "embedded"}
+	if d.ptyBackend == nil {
+		return stats
+	}
+	ctx := context.Background()
+	stats.Sessions = len(d.ptyBackend.SessionIDs(ctx))
+	if wp, ok := d.ptyBackend.(ptybackend.WorkerProcessProvider); ok {
+		stats.PtyBackend = "worker"
+		stats.WorkerPIDs = wp.WorkerPIDs(ctx)
+	}
+	return stats
 }
 
 func (d *Daemon) log(msg string) {

--- a/internal/daemon/diag_test.go
+++ b/internal/daemon/diag_test.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func freeLoopbackPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func TestMaybeStartDiagServer_DisabledByDefault(t *testing.T) {
+	t.Setenv("ATTN_PPROF", "")
+	d := NewForTesting(filepath.Join(t.TempDir(), "attn.sock"))
+	d.maybeStartDiagServer()
+	if d.diagServer != nil {
+		_ = d.diagServer.Close()
+		t.Fatal("diag server started with ATTN_PPROF unset")
+	}
+}
+
+func TestMaybeStartDiagServer_EnabledServesLoopback(t *testing.T) {
+	port := freeLoopbackPort(t)
+	t.Setenv("ATTN_PPROF", strconv.Itoa(port))
+	d := NewForTesting(filepath.Join(t.TempDir(), "attn.sock"))
+	d.maybeStartDiagServer()
+	if d.diagServer == nil {
+		t.Fatal("diag server did not start with ATTN_PPROF set")
+	}
+	defer d.diagServer.Close()
+
+	addr := d.diagServer.Addr()
+	if !strings.HasPrefix(addr, "127.0.0.1:") {
+		t.Fatalf("diag server not on loopback: %q", addr)
+	}
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://" + addr + "/debug/vars")
+	if err != nil {
+		t.Fatalf("GET /debug/vars: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/debug/vars status = %d", resp.StatusCode)
+	}
+	var vars map[string]any
+	if err := json.Unmarshal(body, &vars); err != nil {
+		t.Fatalf("/debug/vars not JSON: %v", err)
+	}
+	// NewForTesting uses the embedded backend → no worker subprocesses.
+	if vars["pty_backend"] != "embedded" {
+		t.Errorf("pty_backend = %v, want embedded", vars["pty_backend"])
+	}
+	if vars["sessions"] != float64(0) {
+		t.Errorf("sessions = %v, want 0", vars["sessions"])
+	}
+}
+
+func TestDiagStats_EmbeddedBackend(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "attn.sock"))
+	stats := d.diagStats()
+	if stats.PtyBackend != "embedded" {
+		t.Errorf("PtyBackend = %q, want embedded", stats.PtyBackend)
+	}
+	if stats.Sessions != 0 {
+		t.Errorf("Sessions = %d, want 0", stats.Sessions)
+	}
+	if len(stats.WorkerPIDs) != 0 {
+		t.Errorf("WorkerPIDs = %v, want empty", stats.WorkerPIDs)
+	}
+}

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -1,0 +1,139 @@
+// Package diag exposes an opt-in, loopback-only diagnostics endpoint
+// (net/http/pprof profiles plus a /debug/vars JSON snapshot) used to measure
+// attn's memory and CPU footprint. It is disabled unless ATTN_PPROF is set (see
+// config.PprofAddr) and binds 127.0.0.1 only, so it adds no remote attack
+// surface.
+//
+// Importing net/http/pprof registers handlers on http.DefaultServeMux, but the
+// daemon serves its own mux and nothing in the process serves the default mux,
+// so that registration stays inert; this package re-registers the same handlers
+// on a private mux it actually serves.
+package diag
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"runtime"
+	"time"
+)
+
+// Stats is the live daemon snapshot the endpoint reports under /debug/vars,
+// alongside Go runtime and heap numbers. The worker PTY backend runs one
+// subprocess per session, so WorkerPIDs lets a measurement script sum
+// per-session RSS (ps/vmmap) — the dominant memory locus. It is empty for the
+// embedded backend, which has no separate worker processes.
+type Stats struct {
+	Sessions   int            `json:"sessions"`
+	PtyBackend string         `json:"pty_backend"`
+	WorkerPIDs map[string]int `json:"worker_pids,omitempty"`
+}
+
+// StatsFunc returns the current daemon stats. It is invoked on each /debug/vars
+// request, so it must be cheap and safe for concurrent use. May be nil.
+type StatsFunc func() Stats
+
+// Server is a running diagnostics endpoint. The zero value is not usable; obtain
+// one from Start.
+type Server struct {
+	httpServer *http.Server
+	addr       string
+	stats      StatsFunc
+}
+
+// Start binds a loopback HTTP server at addr and serves net/http/pprof plus a
+// /debug/vars JSON snapshot on a private mux (http.DefaultServeMux is left
+// untouched). addr should be a loopback address; callers resolve it via
+// config.PprofAddr, which always yields 127.0.0.1. Pass "127.0.0.1:0" to bind an
+// ephemeral port and read it back with Addr. stats may be nil.
+func Start(addr string, stats StatsFunc) (*Server, error) {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("diag: listen %s: %w", addr, err)
+	}
+	s := &Server{addr: ln.Addr().String(), stats: stats}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.HandleFunc("/debug/vars", s.handleVars)
+	mux.HandleFunc("/", s.handleIndex)
+
+	s.httpServer = &http.Server{Handler: mux}
+	go func() { _ = s.httpServer.Serve(ln) }()
+	return s, nil
+}
+
+// Addr is the resolved loopback address the endpoint is bound to (host:port).
+func (s *Server) Addr() string {
+	if s == nil {
+		return ""
+	}
+	return s.addr
+}
+
+// Close gracefully shuts the endpoint down. Safe to call on a nil *Server.
+func (s *Server) Close() error {
+	if s == nil || s.httpServer == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return s.httpServer.Shutdown(ctx)
+}
+
+func (s *Server) handleVars(w http.ResponseWriter, _ *http.Request) {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	var stats Stats
+	if s.stats != nil {
+		stats = s.stats()
+	}
+
+	out := map[string]any{
+		"pid":         os.Getpid(),
+		"goroutines":  runtime.NumGoroutine(),
+		"gomaxprocs":  runtime.GOMAXPROCS(0),
+		"num_cpu":     runtime.NumCPU(),
+		"go_version":  runtime.Version(),
+		"sessions":    stats.Sessions,
+		"pty_backend": stats.PtyBackend,
+		"worker_pids": stats.WorkerPIDs,
+		"memstats": map[string]any{
+			"heap_alloc":        ms.HeapAlloc,
+			"heap_sys":          ms.HeapSys,
+			"heap_idle":         ms.HeapIdle,
+			"heap_inuse":        ms.HeapInuse,
+			"heap_released":     ms.HeapReleased,
+			"heap_objects":      ms.HeapObjects,
+			"sys":               ms.Sys,
+			"next_gc":           ms.NextGC,
+			"num_gc":            ms.NumGC,
+			"gc_pause_total_ns": ms.PauseTotalNs,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(out)
+}
+
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprint(w, "attn diagnostics\n\n"+
+		"/debug/vars    runtime + session/worker snapshot (JSON)\n"+
+		"/debug/pprof/  Go pprof index (heap, goroutine, profile, trace, ...)\n")
+}

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -1,0 +1,112 @@
+package diag
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func get(t *testing.T, url string) (*http.Response, []byte) {
+	t.Helper()
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read body %s: %v", url, err)
+	}
+	return resp, body
+}
+
+func TestStart_ServesLoopbackPprofAndVars(t *testing.T) {
+	srv, err := Start("127.0.0.1:0", func() Stats {
+		return Stats{Sessions: 3, PtyBackend: "worker", WorkerPIDs: map[string]int{"s1": 111, "s2": 222}}
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer srv.Close()
+
+	if !strings.HasPrefix(srv.Addr(), "127.0.0.1:") {
+		t.Fatalf("endpoint not bound to loopback: %q", srv.Addr())
+	}
+	base := "http://" + srv.Addr()
+
+	// /debug/vars returns the daemon snapshot merged with runtime heap stats.
+	resp, body := get(t, base+"/debug/vars")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/debug/vars status = %d", resp.StatusCode)
+	}
+	var vars map[string]any
+	if err := json.Unmarshal(body, &vars); err != nil {
+		t.Fatalf("/debug/vars not JSON: %v\n%s", err, body)
+	}
+	if got := vars["sessions"]; got != float64(3) {
+		t.Errorf("sessions = %v, want 3", got)
+	}
+	if got := vars["pty_backend"]; got != "worker" {
+		t.Errorf("pty_backend = %v, want worker", got)
+	}
+	if _, ok := vars["worker_pids"].(map[string]any); !ok {
+		t.Errorf("worker_pids missing/wrong type: %v", vars["worker_pids"])
+	}
+	ms, ok := vars["memstats"].(map[string]any)
+	if !ok {
+		t.Fatalf("memstats missing/wrong type: %v", vars["memstats"])
+	}
+	for _, k := range []string{"heap_alloc", "heap_sys", "heap_idle", "heap_released", "num_gc"} {
+		if _, ok := ms[k]; !ok {
+			t.Errorf("memstats.%s missing", k)
+		}
+	}
+
+	// pprof index and a concrete profile both serve.
+	if resp, _ := get(t, base+"/debug/pprof/"); resp.StatusCode != http.StatusOK {
+		t.Errorf("/debug/pprof/ status = %d", resp.StatusCode)
+	}
+	if resp, _ := get(t, base+"/debug/pprof/heap"); resp.StatusCode != http.StatusOK {
+		t.Errorf("/debug/pprof/heap status = %d", resp.StatusCode)
+	}
+}
+
+func TestStart_NilStats(t *testing.T) {
+	srv, err := Start("127.0.0.1:0", nil)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer srv.Close()
+
+	resp, body := get(t, "http://"+srv.Addr()+"/debug/vars")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/debug/vars status = %d", resp.StatusCode)
+	}
+	var vars map[string]any
+	if err := json.Unmarshal(body, &vars); err != nil {
+		t.Fatalf("/debug/vars not JSON: %v", err)
+	}
+	if got := vars["sessions"]; got != float64(0) {
+		t.Errorf("sessions = %v, want 0 with nil stats", got)
+	}
+}
+
+func TestStart_BadAddr(t *testing.T) {
+	if _, err := Start("definitely-not-an-address", nil); err == nil {
+		t.Fatal("expected error for invalid bind address")
+	}
+}
+
+func TestClose_NilSafe(t *testing.T) {
+	var s *Server
+	if err := s.Close(); err != nil {
+		t.Errorf("nil Close = %v, want nil", err)
+	}
+	if got := s.Addr(); got != "" {
+		t.Errorf("nil Addr = %q, want empty", got)
+	}
+}

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -133,6 +133,15 @@ type SessionInfoProvider interface {
 	SessionInfo(ctx context.Context, sessionID string) (SessionInfo, error)
 }
 
+// WorkerProcessProvider is implemented by backends that run each session in its
+// own worker subprocess. It exposes those PIDs (sessionID -> worker pid) so
+// diagnostics can sum per-session RSS via ps/vmmap — the dominant memory locus
+// for the worker backend. Backends without subprocesses (e.g. embedded) do not
+// implement it.
+type WorkerProcessProvider interface {
+	WorkerPIDs(ctx context.Context) map[string]int
+}
+
 // SnapshotProvider returns the current rendered screen of a session without
 // attaching. Backends that cannot serve a snapshot (e.g. a worker built before
 // the capability existed) return an error; callers degrade gracefully.

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -719,6 +719,26 @@ func (b *WorkerBackend) SessionIDs(_ context.Context) []string {
 	return ids
 }
 
+// Compile-time guard: the daemon detects the worker backend via this interface
+// to report worker PIDs in diagnostics. If it drifts, the daemon would silently
+// fall back to reporting "embedded" instead of failing to build.
+var _ WorkerProcessProvider = (*WorkerBackend)(nil)
+
+// WorkerPIDs returns the live worker subprocess PID for each session that has
+// one, satisfying WorkerProcessProvider. Sessions whose worker has not been
+// spawned (or has been reaped) are omitted.
+func (b *WorkerBackend) WorkerPIDs(_ context.Context) map[string]int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	pids := make(map[string]int, len(b.sessions))
+	for id, session := range b.sessions {
+		if session.WorkerPID > 0 {
+			pids[id] = session.WorkerPID
+		}
+	}
+	return pids
+}
+
 func (b *WorkerBackend) Recover(ctx context.Context) (RecoveryReport, error) {
 	report := RecoveryReport{}
 	// Best-effort: restore registries that were quarantined due to historical

--- a/internal/ptybackend/worker_pids_test.go
+++ b/internal/ptybackend/worker_pids_test.go
@@ -1,0 +1,27 @@
+package ptybackend
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWorkerBackend_WorkerPIDs(t *testing.T) {
+	b := &WorkerBackend{
+		sessions: map[string]*workerSession{
+			"spawned":     {WorkerPID: 4242},
+			"also":        {WorkerPID: 99},
+			"not-spawned": {WorkerPID: 0}, // no live worker yet → omitted
+		},
+	}
+
+	got := b.WorkerPIDs(context.Background())
+	if len(got) != 2 {
+		t.Fatalf("WorkerPIDs len = %d, want 2 (%v)", len(got), got)
+	}
+	if got["spawned"] != 4242 || got["also"] != 99 {
+		t.Errorf("WorkerPIDs = %v, want spawned=4242 also=99", got)
+	}
+	if _, ok := got["not-spawned"]; ok {
+		t.Errorf("WorkerPIDs included a session with no live worker: %v", got)
+	}
+}


### PR DESCRIPTION
## WS-7 — measurement enabler (pprof + /debug/vars)

There is currently **zero** pprof / expvar / GOMEMLIMIT anywhere in the daemon, so the perf roadmap's memory work (WS-1/WS-2 landed, WS-3 pending) is unmeasurable. This adds the smallest thing that unblocks it: an **opt-in, loopback-only** diagnostics endpoint.

Independent of #281 (WS-4); branches off `main`.

### What

- New `internal/diag` package: `Start(addr, StatsFunc)` binds a loopback `http.Server` on a **private** mux serving `net/http/pprof` + a custom `/debug/vars` JSON snapshot. (`http.DefaultServeMux` is left untouched — the WS server already uses its own mux, so the pprof import's default-mux registration stays inert.)
- `config.PprofAddr()` gates it on `ATTN_PPROF` (unset/`off` → disabled; `1`/`on` → `127.0.0.1:6060`; `<port>`/`:<port>` → that loopback port; any host in the value is ignored and forced to `127.0.0.1`).
- Wired into the daemon lifecycle: started after the WS server in `Start()`, closed in `Stop()`. A bind failure is logged, never fatal.
- `/debug/vars` reports `runtime.MemStats` heap fields (`heap_alloc/sys/idle/released`, `num_gc`, …), goroutine/CPU counts, PTY session count, the active `pty_backend`, and **`worker_pids`** (sessionID → worker subprocess PID).
- New `ptybackend.WorkerProcessProvider` exposes worker PIDs. The default `worker` backend runs one subprocess per session, so summing RSS over those PIDs is the per-session memory measurement (the dominant locus). Compile-time guarded so it can't silently degrade to "embedded".

### Safety

Strictly **off by default** and **loopback-only** — no new remote attack surface. macOS-only is fine.

### Tests

- `config.PprofAddr` parsing table (on/off/port/`:port`/host:port→loopback/garbage/out-of-range).
- `internal/diag`: serves `/debug/vars` (valid JSON + memstats keys) and pprof index/heap, bound to `127.0.0.1`, nil-stats safe, bad-addr errors, nil-Close safe.
- Daemon wiring: `ATTN_PPROF` set → loopback server serving `/debug/vars`; unset → no server; `diagStats()` reports the embedded backend.
- `WorkerPIDs` filters out sessions with no live worker.

### Verified on the real daemon

Ran an isolated throwaway-profile daemon with `ATTN_PPROF`:

```
$ curl -s http://127.0.0.1:16060/debug/vars
{ "pty_backend": "worker", "sessions": 0, "worker_pids": {},
  "memstats": { "heap_alloc": 997776, "heap_sys": 7634944, "heap_idle": 4743168,
                "heap_released": 2809856, "num_gc": 2, ... }, ... }

$ go tool pprof -top http://127.0.0.1:16060/debug/pprof/heap
  1026kB 49.66%  runtime.allocm
528.17kB 25.56%  regexp.(*bitState).reset
512.05kB 24.78%  os/exec.(*Cmd).watchCtx
         ...     github.com/victorarias/attn/internal/daemon.(*Daemon).Start.func4
```

`pty_backend: "worker"` confirms the backend detection; `go tool pprof` symbolizes real attn frames. SIGTERM released the port cleanly (graceful `Close()`).

Usage runbook: `docs/diagnostics.md`.
