### PR TITLE
feat(workspaces): teach agents shared context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-09]
+
+### Added
+- **Claude and Codex are taught to use workspace context when a session starts or resets.** attn checks out the live context file and injects concise instructions to read it, keep durable goals and decisions current, publish edits, and reconcile revision conflicts without copying the context itself into the prompt.
+
 ## [2026-06-08]
 
 ### Added

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/daemon"
 	"github.com/victorarias/attn/internal/daemonctl"
+	"github.com/victorarias/attn/internal/hooks"
 	"github.com/victorarias/attn/internal/pathutil"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/ptyworker"
@@ -1521,6 +1522,41 @@ func runHookSessionStart() {
 
 	c := client.New(strings.TrimSpace(os.Getenv("ATTN_SOCKET_PATH")))
 	syncSessionResumeID(c, sessionID, input.SessionID)
+	output, err := workspaceContextSessionStartOutput(c, sessionID, 40, 25*time.Millisecond)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not load workspace context guidance: %v\n", err)
+		return
+	}
+	if output != "" {
+		fmt.Fprintln(os.Stdout, output)
+	}
+}
+
+type workspaceContextCheckoutClient interface {
+	CheckoutWorkspaceContext(sourceSessionID string, force bool) (*protocol.WorkspaceContextResult, error)
+}
+
+func workspaceContextSessionStartOutput(
+	c workspaceContextCheckoutClient,
+	sessionID string,
+	attempts int,
+	retryDelay time.Duration,
+) (string, error) {
+	if attempts < 1 {
+		attempts = 1
+	}
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		result, err := c.CheckoutWorkspaceContext(sessionID, false)
+		if err == nil {
+			return hooks.WorkspaceContextSessionStartOutput(result.Path), nil
+		}
+		lastErr = err
+		if attempt+1 < attempts && retryDelay > 0 {
+			time.Sleep(retryDelay)
+		}
+	}
+	return "", lastErr
 }
 
 func runHookState() {

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -10,8 +10,23 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/buildinfo"
+	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/transcript"
 )
+
+type fakeWorkspaceContextCheckoutClient struct {
+	failures int
+	calls    int
+	path     string
+}
+
+func (f *fakeWorkspaceContextCheckoutClient) CheckoutWorkspaceContext(string, bool) (*protocol.WorkspaceContextResult, error) {
+	f.calls++
+	if f.calls <= f.failures {
+		return nil, fmt.Errorf("source session not found")
+	}
+	return &protocol.WorkspaceContextResult{Path: f.path}, nil
+}
 
 func TestWritePrivateFileReplacesPublicFileWithOwnerOnlyPermissions(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "capture.png")
@@ -387,6 +402,34 @@ func TestReadInitialPromptFileRemovesFile(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("prompt file still exists: %v", err)
+	}
+}
+
+func TestWorkspaceContextSessionStartOutputRetriesUntilSessionIsRegistered(t *testing.T) {
+	c := &fakeWorkspaceContextCheckoutClient{
+		failures: 2,
+		path:     "/tmp/context.md",
+	}
+	output, err := workspaceContextSessionStartOutput(c, "session-1", 3, 0)
+	if err != nil {
+		t.Fatalf("workspaceContextSessionStartOutput error: %v", err)
+	}
+	if c.calls != 3 {
+		t.Fatalf("checkout calls = %d, want 3", c.calls)
+	}
+	if !strings.Contains(output, "/tmp/context.md") {
+		t.Fatalf("hook output = %q", output)
+	}
+}
+
+func TestWorkspaceContextSessionStartOutputReturnsLastCheckoutError(t *testing.T) {
+	c := &fakeWorkspaceContextCheckoutClient{failures: 2}
+	output, err := workspaceContextSessionStartOutput(c, "session-1", 2, 0)
+	if err == nil || !strings.Contains(err.Error(), "source session not found") {
+		t.Fatalf("workspaceContextSessionStartOutput error = %v", err)
+	}
+	if output != "" {
+		t.Fatalf("hook output = %q, want empty", output)
 	}
 }
 

--- a/docs/plans/2026-06-08-chief-of-staff.md
+++ b/docs/plans/2026-06-08-chief-of-staff.md
@@ -102,6 +102,8 @@ ChiefOfStaff {
       orchestration.
 - [x] Add workspace-context checkout/update/status with revision conflicts.
 - [x] Emit `workspace_context_changed` and keep context-bearing workspaces alive.
+- [x] Inject workspace-context management guidance through supported agent
+      session-start hooks without embedding a stale context snapshot.
 - [ ] Add the unique profile-scoped chief-of-staff session role.
 - [ ] Add tracked dispatch status/reporting and UI visualization.
 

--- a/internal/agent/attn_skill/references/workspace-context.md
+++ b/internal/agent/attn_skill/references/workspace-context.md
@@ -6,7 +6,11 @@ and handoff information that should survive individual sessions.
 
 ## Edit And Publish
 
-Check out the current revision and capture the editable file path:
+For Claude and Codex sessions, attn checks out the current revision at session
+start and injects the editable file path. Read that file before substantive
+work.
+
+To refresh the checkout manually or recover the path, run:
 
 ```sh
 context_file="$("$ATTN_WRAPPER_PATH" workspace context show)"

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -62,6 +62,7 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 
 	workspaceContext := readSkillFile(t, skillDir, "references/workspace-context.md")
 	for _, expected := range []string{
+		"injects the editable file path",
 		"workspace context show",
 		"workspace context update",
 		"workspace context status",

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -52,14 +52,14 @@ func GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath string) []s
 		// reflow prevents resized inline UIs from leaving stale headers.
 		"features.terminal_resize_reflow=true",
 		trustedHashOverrides([]codexHookTrustEntry{
-			{eventKey: "session_start", matcher: "startup|resume", command: sessionStart},
+			{eventKey: "session_start", matcher: "startup|resume|clear|compact", command: sessionStart},
 			{eventKey: "user_prompt_submit", command: userPromptSubmit},
 			{eventKey: "permission_request", matcher: "*", command: permissionRequest},
 			{eventKey: "pre_tool_use", matcher: "*", command: preToolUse},
 			{eventKey: "post_tool_use", matcher: "*", command: postToolUse},
 			{eventKey: "stop", command: stop},
 		}),
-		"hooks.SessionStart=" + group("startup|resume", sessionStart),
+		"hooks.SessionStart=" + group("startup|resume|clear|compact", sessionStart),
 		"hooks.UserPromptSubmit=" + group("", userPromptSubmit),
 		"hooks.PermissionRequest=" + group("*", permissionRequest),
 		"hooks.PreToolUse=" + group("*", preToolUse),

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -23,6 +23,39 @@ type SettingsConfig struct {
 	Hooks map[string][]HookEntry `json:"hooks"`
 }
 
+type sessionStartHookSpecificOutput struct {
+	HookEventName     string `json:"hookEventName"`
+	AdditionalContext string `json:"additionalContext"`
+}
+
+type sessionStartHookOutput struct {
+	HookSpecificOutput sessionStartHookSpecificOutput `json:"hookSpecificOutput"`
+}
+
+// WorkspaceContextSessionStartOutput returns Claude/Codex-compatible hook
+// output that teaches the agent to use the live workspace context checkout.
+func WorkspaceContextSessionStartOutput(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	guidance := fmt.Sprintf(`attn provides a shared workspace context for this session.
+
+- Before substantive work, read the live checkout at %s.
+- Keep it concise and durable: goals, decisions, constraints, current progress, and handoff information. Do not use it as a transcript or scratchpad.
+- When that durable context changes, edit the file in place and run "$ATTN_WRAPPER_PATH" workspace context update.
+- Use "$ATTN_WRAPPER_PATH" workspace context status to check local edits or a newer shared revision.
+- If an update conflicts, preserve your local edits, refresh with "$ATTN_WRAPPER_PATH" workspace context show --force, merge the saved edits into the refreshed file, and retry the update.`, path)
+	output := sessionStartHookOutput{
+		HookSpecificOutput: sessionStartHookSpecificOutput{
+			HookEventName:     "SessionStart",
+			AdditionalContext: guidance,
+		},
+	}
+	data, _ := json.Marshal(output)
+	return string(data)
+}
+
 // Generate generates settings configuration with hooks for a session
 func Generate(sessionID, socketPath, wrapperPath string) string {
 	wrapper := strings.TrimSpace(wrapperPath)
@@ -34,6 +67,17 @@ func Generate(sessionID, socketPath, wrapperPath string) string {
 
 	config := SettingsConfig{
 		Hooks: map[string][]HookEntry{
+			"SessionStart": {
+				{
+					Matcher: "startup|resume|clear|compact",
+					Hooks: []Hook{
+						{
+							Type:    "command",
+							Command: fmt.Sprintf(`ATTN_SOCKET_PATH=%s %s _hook-session-start "%s"`, socketCmd, wrapperCmd, sessionID),
+						},
+					},
+				},
+			},
 			"Stop": {
 				{
 					Matcher: "*",

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -78,6 +78,20 @@ func TestGenerateHooks_HasStopHook(t *testing.T) {
 	}
 }
 
+func TestGenerateHooks_HasSessionStartHook(t *testing.T) {
+	hooks := Generate("test", "/tmp/test.sock", "/tmp/attn")
+
+	for _, expected := range []string{
+		"SessionStart",
+		"startup|resume|clear|compact",
+		"_hook-session-start",
+	} {
+		if !strings.Contains(hooks, expected) {
+			t.Fatalf("Claude hooks should include %q", expected)
+		}
+	}
+}
+
 func TestGenerateHooks_HasUserPromptSubmitHook(t *testing.T) {
 	hooks := Generate("test", "/tmp/test.sock", "/tmp/attn")
 
@@ -112,6 +126,9 @@ func TestGenerateCodexConfigOverrides_UsesStableEnvBasedCommands(t *testing.T) {
 	if !strings.Contains(joined, "_hook-session-start") {
 		t.Fatal("codex overrides should sync session id on start")
 	}
+	if !strings.Contains(joined, "startup|resume|clear|compact") {
+		t.Fatal("codex SessionStart hook should run after context resets")
+	}
 	if strings.Contains(joined, "session-1") {
 		t.Fatal("codex hook commands should not embed per-session attn ids")
 	}
@@ -133,6 +150,32 @@ func TestGenerateCodexConfigOverrides_UsesStableEnvBasedCommands(t *testing.T) {
 	if !strings.Contains(joined, `hooks.state={`) ||
 		!strings.Contains(joined, `"/<session-flags>/config.toml:session_start:0:0" = { trusted_hash =`) {
 		t.Fatal("codex overrides should trust attn-managed session flag hooks")
+	}
+}
+
+func TestWorkspaceContextSessionStartOutput(t *testing.T) {
+	raw := WorkspaceContextSessionStartOutput("/tmp/context.md")
+	var output sessionStartHookOutput
+	if err := json.Unmarshal([]byte(raw), &output); err != nil {
+		t.Fatalf("WorkspaceContextSessionStartOutput returned invalid JSON: %v", err)
+	}
+	if output.HookSpecificOutput.HookEventName != "SessionStart" {
+		t.Fatalf("hook event = %q", output.HookSpecificOutput.HookEventName)
+	}
+	guidance := output.HookSpecificOutput.AdditionalContext
+	for _, expected := range []string{
+		"/tmp/context.md",
+		"workspace context update",
+		"workspace context status",
+		"show --force",
+		"Do not use it as a transcript or scratchpad",
+	} {
+		if !strings.Contains(guidance, expected) {
+			t.Fatalf("guidance missing %q: %q", expected, guidance)
+		}
+	}
+	if strings.Contains(guidance, "# Shared goal") {
+		t.Fatal("guidance should not embed workspace context content")
 	}
 }
 


### PR DESCRIPTION
## Intent / Why

Shared workspace context is only useful if agents know where the live document is and how to maintain it. Follow-up to #282: inject management guidance at session start instead of copying a potentially stale context snapshot into the prompt.

## Summary

- Check out the live workspace context when Claude or Codex starts, resumes, clears, or compacts.
- Inject the editable path plus concise read, update, status, and conflict-recovery instructions through `SessionStart` hook context.
- Keep Copilot and plugin agents unchanged until they expose a compatible instruction channel.
- Update the bundled attn skill, implementation plan, and changelog.

## Test plan

- [x] `go test ./...`
- [x] `make dev`
- [x] Real Codex session read marker `ORBIT-417` from the injected checkout without running `show`, published revision 2, and reported clean status.
- [x] Real Claude session started afterward, read `ORBIT-417` plus Codex's handoff, published revision 3, and reported clean status.
- [x] Disposable dev sessions and workspace removed after verification.

## Out of scope

- Proactively pinging already-running agents when `workspace_context_changed` fires.
- Chief-of-staff ownership and dispatched-agent tracking.