### PR TITLE
perf(frontend): grow glyph atlas on demand (1024²→2048²) — ~100 MB idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Claude and Codex are taught to use workspace context when a session starts or resets.** attn checks out the live context file and injects concise instructions to read it, keep durable goals and decisions current, publish edits, and reconcile revision conflicts without copying the context itself into the prompt.
 
+### Changed
+- **Terminals use less graphics memory.** Every live terminal used to preallocate a large fixed GPU texture to cache rendered characters. It now starts small and grows only if a session actually displays many distinct characters (such as heavy CJK or emoji output). Text looks identical, and with several sessions open this frees roughly 90 MB of graphics memory.
+
 ## [2026-06-08]
 
 ### Added

--- a/app/src/components/GhosttyWebGlRenderer.test.ts
+++ b/app/src/components/GhosttyWebGlRenderer.test.ts
@@ -5,6 +5,7 @@ import {
   nextAtlasSize,
   INITIAL_ATLAS_SIZE,
   MAX_ATLAS_SIZE,
+  WebGlTerminalRenderer,
 } from './GhosttyWebGlRenderer';
 
 function terminalWithHistory(history: number) {
@@ -51,5 +52,177 @@ describe('nextAtlasSize (grow-on-demand policy)', () => {
       size = grown;
     }
     expect(size).toBe(MAX_ATLAS_SIZE);
+  });
+});
+
+// --- grow-path regression harness -------------------------------------------
+// The renderer needs a real WebGL2 context plus a 2D canvas, neither of which
+// happy-dom provides. We stub both: a no-op WebGL2 proxy, and a recording 2D
+// context that faithfully reproduces the one browser behavior the bug hinges on
+// -- assigning canvas.width/height resets ALL 2D context state (font included)
+// back to defaults. That lets us drive the real getGlyph() grow path and assert
+// the glyph that triggers a grow is rasterized with the intended font rather
+// than the post-resize default.
+
+interface FillTextCall {
+  text: string;
+  x: number;
+  y: number;
+  font: string;
+}
+
+function makeRecordingContext() {
+  return {
+    font: '10px sans-serif',
+    fillStyle: '#000000',
+    textBaseline: 'alphabetic',
+    fillTextCalls: [] as FillTextCall[],
+    measureText(text: string) {
+      return { width: text.length * 8 };
+    },
+    clearRect() {},
+    fillRect() {},
+    fillText(text: string, x: number, y: number) {
+      this.fillTextCalls.push({ text, x, y, font: this.font });
+    },
+    getImageData(_x: number, _y: number, w: number, h: number) {
+      return { data: new Uint8ClampedArray(Math.max(1, w * h * 4)), width: w, height: h };
+    },
+  };
+}
+
+type RecordingContext = ReturnType<typeof makeRecordingContext>;
+
+// Any property accessed as a constant (gl.TEXTURE_2D) or called as a no-op
+// method resolves to a throwaway function; only the handful of calls whose
+// return value the renderer actually inspects get real-ish values.
+function makeFakeGl() {
+  const truthy = new Set(['getShaderParameter', 'getProgramParameter']);
+  const handles = new Set([
+    'createShader',
+    'createProgram',
+    'createBuffer',
+    'createTexture',
+    'getUniformLocation',
+  ]);
+  return new Proxy(
+    {},
+    {
+      get(_target, prop: string) {
+        if (truthy.has(prop)) return () => true;
+        if (handles.has(prop)) return () => ({});
+        if (prop === 'getAttribLocation') return () => 0;
+        return () => undefined;
+      },
+    },
+  );
+}
+
+function makeFakeCanvas() {
+  let ctx2d: RecordingContext | null = null;
+  return {
+    _w: 0,
+    _h: 0,
+    get width() {
+      return this._w;
+    },
+    set width(v: number) {
+      this._w = v;
+      if (ctx2d) ctx2d.font = '10px sans-serif'; // resize resets 2D context state
+    },
+    get height() {
+      return this._h;
+    },
+    set height(v: number) {
+      this._h = v;
+      if (ctx2d) ctx2d.font = '10px sans-serif';
+    },
+    getContext(type: string) {
+      if (type === '2d') {
+        ctx2d = ctx2d ?? makeRecordingContext();
+        return ctx2d;
+      }
+      if (type === 'webgl2') {
+        return makeFakeGl();
+      }
+      return null;
+    },
+    get recordingContext() {
+      return ctx2d;
+    },
+  };
+}
+
+function makeRenderer(fontSize = 14, fontFamily = 'monospace') {
+  // Constructor creates two canvases via document.createElement: [0] metrics,
+  // [1] atlas. Intercept those; the main canvas is supplied directly.
+  const created: ReturnType<typeof makeFakeCanvas>[] = [];
+  const realCreate = document.createElement.bind(document);
+  const spy = vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+    if (tag === 'canvas') {
+      const canvas = makeFakeCanvas();
+      created.push(canvas);
+      return canvas;
+    }
+    return realCreate(tag);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any);
+
+  let renderer: WebGlTerminalRenderer;
+  try {
+    const mainCanvas = makeFakeCanvas() as unknown as HTMLCanvasElement;
+    renderer = new WebGlTerminalRenderer(mainCanvas, fontSize, fontFamily, {
+      background: '#000000',
+      foreground: '#ffffff',
+      cursor: '#ffffff',
+    });
+  } finally {
+    spy.mockRestore();
+  }
+
+  const atlasContext = created[1].recordingContext as RecordingContext;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { renderer: renderer as any, atlasContext };
+}
+
+describe('WebGlTerminalRenderer glyph atlas grow path', () => {
+  it('keeps the intended font on the glyph that triggers a grow and an at-cap reset', () => {
+    const { renderer, atlasContext } = makeRenderer(14, 'monospace');
+    const intendedFont = `${14 * renderer.dpr}px monospace`;
+
+    // A normal (non-grow) glyph draws with the intended font.
+    renderer.getGlyph('A', 0);
+    const normalDraw = atlasContext.fillTextCalls[atlasContext.fillTextCalls.length - 1];
+    expect(normalDraw?.text).toBe('A');
+    expect(normalDraw?.font).toBe(intendedFont);
+
+    // Force a vertical overflow so the next glyph triggers a real 1024->2048 grow.
+    expect(renderer.atlasSize).toBe(INITIAL_ATLAS_SIZE);
+    renderer.atlasY = INITIAL_ATLAS_SIZE;
+    atlasContext.fillTextCalls.length = 0;
+
+    renderer.getGlyph('B', 0);
+
+    // The grow happened...
+    expect(renderer.atlasSize).toBe(MAX_ATLAS_SIZE);
+    // ...and the glyph that triggered it was drawn with the intended font, NOT
+    // the '10px sans-serif' that resizing the backing canvas reset it to. This
+    // is the regression: a cached glyph drawn with the default font survives the
+    // render() retry forever.
+    const growDraw = atlasContext.fillTextCalls[atlasContext.fillTextCalls.length - 1];
+    expect(growDraw?.text).toBe('B');
+    expect(growDraw?.font).toBe(intendedFont);
+    expect(growDraw?.font).not.toBe('10px sans-serif');
+
+    // At the cap, the next overflow takes the resetAtlas() branch (clear & reuse
+    // at 2048) instead of growing. It resizes the backing canvas the same way,
+    // so the font has to survive that path too.
+    renderer.atlasY = MAX_ATLAS_SIZE;
+    atlasContext.fillTextCalls.length = 0;
+    renderer.getGlyph('C', 0);
+    expect(renderer.atlasSize).toBe(MAX_ATLAS_SIZE); // capped: reset, not grown
+    const resetDraw = atlasContext.fillTextCalls[atlasContext.fillTextCalls.length - 1];
+    expect(resetDraw?.text).toBe('C');
+    expect(resetDraw?.font).toBe(intendedFont);
   });
 });

--- a/app/src/components/GhosttyWebGlRenderer.test.ts
+++ b/app/src/components/GhosttyWebGlRenderer.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { GhosttyTerminal } from 'ghostty-web';
-import { graphemeAtViewportCell } from './GhosttyWebGlRenderer';
+import {
+  graphemeAtViewportCell,
+  nextAtlasSize,
+  INITIAL_ATLAS_SIZE,
+  MAX_ATLAS_SIZE,
+} from './GhosttyWebGlRenderer';
 
 function terminalWithHistory(history: number) {
   return {
@@ -23,5 +28,28 @@ describe('graphemeAtViewportCell', () => {
 
     expect(graphemeAtViewportCell(terminal, 2, 4, 1)).toBe('live:1:4');
     expect(terminal.getGraphemeString).toHaveBeenCalledWith(1, 4);
+  });
+});
+
+describe('nextAtlasSize (grow-on-demand policy)', () => {
+  it('starts at 1024² and doubles to the 2048² cap', () => {
+    expect(INITIAL_ATLAS_SIZE).toBe(1024);
+    expect(MAX_ATLAS_SIZE).toBe(2048);
+    expect(nextAtlasSize(INITIAL_ATLAS_SIZE)).toBe(2048);
+  });
+
+  it('is idempotent at the cap (never grows unbounded)', () => {
+    expect(nextAtlasSize(MAX_ATLAS_SIZE)).toBe(MAX_ATLAS_SIZE);
+  });
+
+  it('always converges to the cap and never exceeds it under repeated growth', () => {
+    let size = INITIAL_ATLAS_SIZE;
+    for (let i = 0; i < 16; i += 1) {
+      const grown = nextAtlasSize(size);
+      expect(grown).toBeLessThanOrEqual(MAX_ATLAS_SIZE);
+      expect(grown).toBeGreaterThanOrEqual(size);
+      size = grown;
+    }
+    expect(size).toBe(MAX_ATLAS_SIZE);
   });
 });

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -63,9 +63,25 @@ export function graphemeAtViewportCell(
     : terminal.getGraphemeString(bufferRow - history, col);
 }
 
-const ATLAS_SIZE = 2048;
+// The glyph atlas is allocated eagerly and in full (a backing 2D canvas plus a
+// GPU texture of the same dimensions), so its size is a fixed per-renderer
+// memory cost paid up front regardless of how many glyphs a session actually
+// uses. A terminal renders a small, mostly-fixed glyph set (ASCII + styles +
+// box-drawing + the occasional Unicode/emoji), so most panes fit comfortably in
+// 1024². We therefore start small and grow on demand up to the previous fixed
+// size only when a glyph-heavy session (e.g. CJK/emoji) actually overflows the
+// atlas — keeping the common case cheap (≈8 MB/renderer vs ≈32 MB at 2048²)
+// without risking glyph-atlas thrash on heavy content. See growAtlas/resetAtlas.
+export const INITIAL_ATLAS_SIZE = 1024;
+export const MAX_ATLAS_SIZE = 2048;
 const FLOATS_PER_VERTEX = 8;
-const SOLID_TEXEL_CENTER = 0.5 / ATLAS_SIZE;
+
+// Next atlas size when the current one fills: double it, but never exceed the
+// cap. Idempotent at the cap, so repeated growth always converges to
+// MAX_ATLAS_SIZE and can never grow unbounded.
+export function nextAtlasSize(current: number, max: number = MAX_ATLAS_SIZE): number {
+  return Math.min(current * 2, max);
+}
 const BLOCK_ELEMENT_RECTS: Readonly<Record<number, readonly BlockRect[]>> = {
   0x2580: [{ x: 0, y: 0, width: 1, height: 1 / 2 }],
   0x2581: [{ x: 0, y: 7 / 8, width: 1, height: 1 / 8 }],
@@ -202,10 +218,17 @@ export class WebGlTerminalRenderer {
   private readonly fontSize: number;
   private readonly fontFamily: string;
   private readonly theme: RendererTheme;
+  private atlasSize = INITIAL_ATLAS_SIZE;
   private atlasX = 2;
   private atlasY = 1;
   private atlasRowHeight = 0;
   private atlasGeneration = 0;
+
+  // UV of the center of the 1×1 solid white texel at atlas pixel (0,0). Depends
+  // on the current atlas size, so it is recomputed rather than precomputed.
+  private get solidTexelCenter(): number {
+    return 0.5 / this.atlasSize;
+  }
   private retryingAtlasFrame = false;
   private cols = 0;
   private rows = 0;
@@ -237,8 +260,8 @@ export class WebGlTerminalRenderer {
     this.buffer = gl.createBuffer() ?? (() => { throw new Error('Unable to allocate WebGL buffer'); })();
     this.texture = gl.createTexture() ?? (() => { throw new Error('Unable to allocate glyph texture'); })();
     this.atlas = document.createElement('canvas');
-    this.atlas.width = ATLAS_SIZE;
-    this.atlas.height = ATLAS_SIZE;
+    this.atlas.width = this.atlasSize;
+    this.atlas.height = this.atlasSize;
     this.atlasContext = this.atlas.getContext('2d') ?? (() => { throw new Error('Unable to allocate glyph atlas'); })();
     this.atlasContext.fillStyle = '#ffffff';
     this.atlasContext.fillRect(0, 0, 1, 1);
@@ -248,7 +271,7 @@ export class WebGlTerminalRenderer {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, ATLAS_SIZE, ATLAS_SIZE, 0, gl.RGBA, gl.UNSIGNED_BYTE, this.atlas);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, this.atlasSize, this.atlasSize, 0, gl.RGBA, gl.UNSIGNED_BYTE, this.atlas);
 
     gl.useProgram(this.program);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
@@ -442,13 +465,19 @@ export class WebGlTerminalRenderer {
     context.font = `${style}${this.fontSize * scale}px ${this.fontFamily}`;
     const width = Math.max(Math.ceil(context.measureText(text).width) + 4, this.cellWidth * scale);
     const height = this.cellHeight * scale;
-    if (this.atlasX + width >= ATLAS_SIZE) {
+    if (this.atlasX + width >= this.atlasSize) {
       this.atlasX = 2;
       this.atlasY += this.atlasRowHeight + 1;
       this.atlasRowHeight = 0;
     }
-    if (this.atlasY + height >= ATLAS_SIZE) {
-      this.resetAtlas();
+    if (this.atlasY + height >= this.atlasSize) {
+      // Atlas is full: grow it (doubling, up to the cap) so glyph-heavy sessions
+      // get more room instead of thrashing; only clear-and-reuse once at the cap.
+      if (this.atlasSize < MAX_ATLAS_SIZE) {
+        this.growAtlas();
+      } else {
+        this.resetAtlas();
+      }
     }
 
     const x = this.atlasX;
@@ -461,10 +490,10 @@ export class WebGlTerminalRenderer {
     this.gl.texSubImage2D(this.gl.TEXTURE_2D, 0, x, y, width, height, this.gl.RGBA, this.gl.UNSIGNED_BYTE, context.getImageData(x, y, width, height));
 
     const glyph = {
-      u0: x / ATLAS_SIZE,
-      v0: y / ATLAS_SIZE,
-      u1: (x + width) / ATLAS_SIZE,
-      v1: (y + height) / ATLAS_SIZE,
+      u0: x / this.atlasSize,
+      v0: y / this.atlasSize,
+      u1: (x + width) / this.atlasSize,
+      v1: (y + height) / this.atlasSize,
       width,
       height,
     };
@@ -474,13 +503,35 @@ export class WebGlTerminalRenderer {
     return glyph;
   }
 
+  // Double the atlas (up to the cap) when a glyph-heavy session fills it, then
+  // re-seed at the new size. Glyph-light sessions never call this and stay at
+  // INITIAL_ATLAS_SIZE.
+  private growAtlas(): void {
+    this.atlasSize = nextAtlasSize(this.atlasSize, MAX_ATLAS_SIZE);
+    this.reseedAtlas();
+  }
+
+  // Clear the glyph cache and reuse the atlas at its current size. Only reached
+  // once the atlas has already grown to the cap.
   private resetAtlas(): void {
+    this.reseedAtlas();
+  }
+
+  // Clear the glyph cache and (re)initialize the backing canvas + GPU texture at
+  // the current atlas size, re-seeding the solid white texel at (0,0). Setting
+  // the canvas dimensions also clears its bitmap, so this covers both same-size
+  // resets and post-grow reallocations. Bumps the generation so an in-flight
+  // frame re-rasterizes against the fresh atlas (see render()'s retry). getGlyph
+  // re-establishes font/baseline on every call, so resetting the 2D context
+  // state here is safe.
+  private reseedAtlas(): void {
     this.glyphs.clear();
     this.atlasX = 2;
     this.atlasY = 1;
     this.atlasRowHeight = 0;
     this.atlasGeneration += 1;
-    this.atlasContext.clearRect(0, 0, ATLAS_SIZE, ATLAS_SIZE);
+    this.atlas.width = this.atlasSize;
+    this.atlas.height = this.atlasSize;
     this.atlasContext.fillStyle = '#ffffff';
     this.atlasContext.fillRect(0, 0, 1, 1);
     this.gl.bindTexture(this.gl.TEXTURE_2D, this.texture);
@@ -488,8 +539,8 @@ export class WebGlTerminalRenderer {
       this.gl.TEXTURE_2D,
       0,
       this.gl.RGBA,
-      ATLAS_SIZE,
-      ATLAS_SIZE,
+      this.atlasSize,
+      this.atlasSize,
       0,
       this.gl.RGBA,
       this.gl.UNSIGNED_BYTE,
@@ -500,7 +551,7 @@ export class WebGlTerminalRenderer {
   private pushSolidQuad(vertices: number[], x: number, y: number, width: number, height: number, color: Rgb, alpha: number): void {
     // Keep all samples within the white texel. Sampling its edges with LINEAR
     // filtering blends into transparent atlas neighbours and leaves seams.
-    this.pushQuad(vertices, x, y, width, height, SOLID_TEXEL_CENTER, SOLID_TEXEL_CENTER, SOLID_TEXEL_CENTER, SOLID_TEXEL_CENTER, color, alpha);
+    this.pushQuad(vertices, x, y, width, height, this.solidTexelCenter, this.solidTexelCenter, this.solidTexelCenter, this.solidTexelCenter, color, alpha);
   }
 
   private pushBlockElement(vertices: number[], codepoint: number, x: number, y: number, width: number, height: number, color: Rgb, alpha: number): boolean {

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -462,7 +462,8 @@ export class WebGlTerminalRenderer {
 
     const context = this.atlasContext;
     const scale = this.dpr;
-    context.font = `${style}${this.fontSize * scale}px ${this.fontFamily}`;
+    const font = `${style}${this.fontSize * scale}px ${this.fontFamily}`;
+    context.font = font;
     const width = Math.max(Math.ceil(context.measureText(text).width) + 4, this.cellWidth * scale);
     const height = this.cellHeight * scale;
     if (this.atlasX + width >= this.atlasSize) {
@@ -478,6 +479,13 @@ export class WebGlTerminalRenderer {
       } else {
         this.resetAtlas();
       }
+      // growAtlas/resetAtlas resize the backing canvas, and resizing a canvas
+      // resets ALL 2D context state (font included) to defaults. Re-apply the
+      // font so THIS glyph -- the one that triggered the grow -- is rasterized
+      // with the intended font instead of the browser default. Without this the
+      // wrong bitmap is cached, and the render() retry reuses the cache so it
+      // never self-corrects.
+      context.font = font;
     }
 
     const x = this.atlasX;
@@ -521,9 +529,9 @@ export class WebGlTerminalRenderer {
   // the current atlas size, re-seeding the solid white texel at (0,0). Setting
   // the canvas dimensions also clears its bitmap, so this covers both same-size
   // resets and post-grow reallocations. Bumps the generation so an in-flight
-  // frame re-rasterizes against the fresh atlas (see render()'s retry). getGlyph
-  // re-establishes font/baseline on every call, so resetting the 2D context
-  // state here is safe.
+  // frame re-rasterizes against the fresh atlas (see render()'s retry). Resetting
+  // the 2D context state here is recovered by getGlyph, which re-applies the font
+  // both before measuring and again after a grow, before drawing.
   private reseedAtlas(): void {
     this.glyphs.clear();
     this.atlasX = 2;


### PR DESCRIPTION
## What

Each terminal's WebGL renderer eagerly allocated a **2048×2048 backing canvas + 2048×2048 RGBA GPU texture (~32 MB/renderer)** up front, independent of how many glyphs a session actually uses (`GhosttyWebGlRenderer.ts`). A terminal renders a small, mostly-fixed glyph set (ASCII + styles + box-drawing + the occasional Unicode), so this was heavily over-provisioned for the common case.

This change makes the atlas **start at 1024² (~8 MB/renderer) and grow on demand** — doubling, capped at the previous 2048² — only when a glyph-heavy session (large CJK/emoji output) actually overflows it. `resetAtlas` reuses the atlas once at the cap. Glyph-light sessions (the common case) stay small; heavy sessions grow to today's capacity, so there's **no atlas thrash and no worst-case regression**.

## Measured impact

Dev app, 8 `shell` sessions, **idle**, warm-set 3 (`scenario-perf-baseline.mjs`, full process-tree RSS incl. WebKit GPU process):

| metric | before (2048²) | after (grow-on-demand) | Δ |
|---|---|---|---|
| total RSS | 825.1 MB | 723.7 MB | **−101 MB** |
| WebKit total | 456.9 MB | 355.4 MB | **−101 MB** |
| WebKit GPU process | ~181 MB | 90.2 MB | **−91 MB** |

The win lands in the GPU process (texture + canvas backing), ≈24 MB × ~4 live renderers at warm-set 3.

## Verification

- **Rendering through a real grow:** flooded a pane with ~3000 distinct CJK glyphs (well past the 1024² capacity ~1150 at DPR 2), forcing a grow to 2048². All CJK glyphs, a trailing ASCII marker line, and the powerline prompt render correctly (no tofu/garble/misalignment) — confirms grow-trigger + post-grow UV recomputation + re-rasterization.
- **Unit test:** `nextAtlasSize` policy — starts 1024², doubles to the 2048² cap, idempotent at the cap, converges and never exceeds it under repeated growth.
- Full frontend suite green (656 tests); `tsc` clean.

## Scope / safety

Render-only change, isolated to the glyph atlas allocator. AGENTS.md invariants **#6 (focus ownership)** and **#7 (PTY single-authority + replay)** are untouched.

Independent of the measurement-harness PR (#284).