### PR TITLE
test(e2e): fix split-blank-repro flake (gate emit on pane readiness)

### DIFF
--- a/app/e2e/split-blank-repro.spec.ts
+++ b/app/e2e/split-blank-repro.spec.ts
@@ -72,27 +72,7 @@ test('agent pane stays painted after opening a shell split', async ({ page, daem
   await page.waitForSelector('.dashboard');
 
   const agentId = 's-agent-split';
-  const workspaceId = `workspace-${agentId}`;
-  await page.evaluate(({ sessionId, workspaceId }) => {
-    window.__TEST_INJECT_SESSION?.({
-      id: sessionId,
-      label: 'Agent Split',
-      state: 'working',
-      cwd: '/tmp/test/agent-split',
-      workspaceId,
-    });
-  }, { sessionId: agentId, workspaceId });
-  await daemon.injectSession({
-    id: agentId,
-    label: 'Agent Split',
-    state: 'working',
-    directory: '/tmp/test/agent-split',
-    workspace_id: workspaceId,
-  });
-
-  await page.locator(`[data-testid="session-${agentId}"]`).click();
-  const terminal = page.locator(`[data-pane-session-id="${agentId}"][data-pane-kind="agent"] .terminal-container`);
-  await expect(terminal).toBeVisible({ timeout: 5000 });
+  const terminal = await setupAgent(page, daemon, agentId);
 
   // 1) Paint a full frame and confirm it actually rendered (high quad count).
   await emit(page, agentId, fullFrame('OLD'));
@@ -175,7 +155,31 @@ async function setupAgent(
   await page.locator(`[data-testid="session-${agentId}"]`).click();
   const terminal = page.locator(`[data-pane-session-id="${agentId}"][data-pane-kind="agent"] .terminal-container`);
   await expect(terminal).toBeVisible({ timeout: 5000 });
+  await waitForPaneReady(page, agentId);
   return terminal;
+}
+
+// The terminal CONTAINER becoming visible is not the same as the pane being
+// ready to receive PTY data. `__TEST_EMIT_PTY_DATA` delivers to the live
+// terminal handle and silently DROPS the event when no handle is registered yet
+// (useGhosttyPaneRuntime.deliverEvent: `if (!terminal) return`). The handle is
+// only registered once the Ghostty WASM model has finished loading
+// (handleTerminalReady), which lands strictly after the DOM container is
+// visible. Emitting in that window loses the bytes and the model never updates,
+// so the downstream `toContain('… line 0')` poll times out — the flake. In prod
+// this race cannot happen: data only arrives in response to attach, which is
+// itself fired from handleTerminalReady (after the handle exists). `getPaneSize`
+// returns a size only once the handle is registered, so it is the precise
+// "emit will be delivered" signal to gate on.
+async function waitForPaneReady(
+  page: import('@playwright/test').Page,
+  sessionId: string,
+) {
+  await expect
+    .poll(async () => page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_SIZE?.(sid) ?? null, sessionId), {
+      timeout: 10000,
+    })
+    .not.toBeNull();
 }
 
 function chunks(value: string, size: number): string[] {


### PR DESCRIPTION
## Problem

`app/e2e/split-blank-repro.spec.ts` flakes in CI — it failed two consecutive runs on #286 on *different* tests in the file (`:196` then `:64`), which is the signature of a flaky **file**, not a real regression.

## Root cause (investigated, not band-aided)

The tests emit synthetic PTY data via `__TEST_EMIT_PTY_DATA` immediately after the terminal container becomes visible (`toBeVisible`). But that data is delivered to the **live terminal handle** and is **silently dropped** when no handle is registered yet:

```ts
// useGhosttyPaneRuntime.ts deliverEvent
const terminal = handlesRef.current.get(paneId);
if (!terminal) return; // <-- bytes dropped
```

The handle is only registered at `handleTerminalReady`, which fires **after** the Ghostty WASM model finishes loading — strictly *after* the DOM container is visible. Under CI load (slow WASM init), the first `fullFrame('OLD')` emit lands in that window, gets dropped, the model never updates, and the downstream `toContain('OLD line 0')` poll times out.

## Confirmed NOT an app bug

In production this race **cannot** happen: PTY data only flows in response to `attach`, and `attach` is itself fired from `handleTerminalReady` — i.e. only *after* the handle exists. `__TEST_EMIT_PTY_DATA` is a test-only hook that bypasses `attach`, which is what opens the race. So there is no product behavior to improve here; the fix belongs in the test.

## Fix

Gate the first emit on **real handle readiness** before emitting. `getPaneSize` returns non-null only once the handle is registered (same point as data delivery becomes possible), so it's the precise "emit will be delivered" signal. The gate lives in `setupAgent`, and test 1 is refactored to use `setupAgent` so all three tests are covered (also DRYs ~20 lines of duplicated setup).

No application code changes.

## Verification

`npx playwright test e2e/split-blank-repro.spec.ts --repeat-each=6 --workers=1` → **18/18 passed**. (The gate is also strictly *more* tolerant of slow WASM than the prior implicit 5s text-poll, since it waits up to 10s for the handle and only then emits.)