### PR TITLE
fix(workspaces): prevent closed session sidebar flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Claude and Codex are taught to use workspace context when a session starts or resets.** attn checks out the live context file and injects concise instructions to read it, keep durable goals and decisions current, publish edits, and reconcile revision conflicts without copying the context itself into the prompt.
 
+### Fixed
+- **Closed sessions no longer flicker back into the sidebar as launching.** The daemon now publishes an authoritative empty layout when shared context keeps a workspace alive after its final pane closes, and the app also discards cached layouts that still reference an explicitly closed session.
+
 ## [2026-06-08]
 
 ### Added

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -1873,7 +1873,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     unmount();
   });
 
-  it('removes a workspace only after workspace_unregistered', async () => {
+  it('invalidates a closed session layout but retains the workspace until workspace_unregistered', async () => {
     const onSessionsUpdate = vi.fn();
     const onWorkspacesUpdate = vi.fn();
     const { unmount } = renderHook(() =>
@@ -1915,8 +1915,10 @@ describe('useDaemonSocket PTY kill sequencing', () => {
               workspace_id: 'workspace-sess-removed',
               pane_id: 'pane-session',
               kind: 'agent',
+              runtime_id: 'sess-removed',
               title: 'Agent',
               session_id: 'sess-removed',
+              status: 'spawning',
             }],
           },
         }],
@@ -1941,7 +1943,32 @@ describe('useDaemonSocket PTY kill sequencing', () => {
 
     await waitFor(() => {
       expect(onWorkspacesUpdate).toHaveBeenLastCalledWith([
-        expect.objectContaining({ id: 'workspace-sess-removed' }),
+        expect.objectContaining({
+          id: 'workspace-sess-removed',
+          layout: undefined,
+        }),
+      ]);
+    });
+
+    act(() => {
+      ws.emit({
+        event: 'workspace_state_changed',
+        workspace: {
+          id: 'workspace-sess-removed',
+          title: 'removed',
+          directory: '/tmp/repo',
+          status: 'idle',
+          muted: false,
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(onWorkspacesUpdate).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          id: 'workspace-sess-removed',
+          layout: undefined,
+        }),
       ]);
     });
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -449,6 +449,24 @@ function pruneWorkspacesBySessions(
   return workspaces;
 }
 
+function invalidateWorkspaceLayoutsForSession(
+  workspaces: DaemonWorkspace[],
+  sessionID: string,
+): DaemonWorkspace[] {
+  let changed = false;
+  const nextWorkspaces = workspaces.map((workspace) => {
+    const referencesSession = (workspace.layout?.panes || []).some(
+      (pane) => pane.session_id === sessionID || pane.runtime_id === sessionID,
+    );
+    if (!referencesSession) {
+      return workspace;
+    }
+    changed = true;
+    return { ...workspace, layout: undefined };
+  });
+  return changed ? nextWorkspaces : workspaces;
+}
+
 function workspacesIncludeRuntimeID(workspaces: DaemonWorkspace[], runtimeID: string): boolean {
   for (const workspace of workspaces) {
     for (const pane of workspace.layout?.panes || []) {
@@ -1532,9 +1550,13 @@ export function useDaemonSocket({
                 (s) => s.id !== data.session!.id
               );
               onSessionsUpdate(sessionsRef.current);
+              const layoutsInvalidated = invalidateWorkspaceLayoutsForSession(
+                workspacesRef.current,
+                data.session.id,
+              );
               const nextWorkspaces = pruneWorkspacesBySessions(
                 sessionsRef.current,
-                workspacesRef.current,
+                layoutsInvalidated,
               );
               if (nextWorkspaces !== workspacesRef.current) {
                 workspacesRef.current = nextWorkspaces;

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -422,14 +422,12 @@ func (d *Daemon) loadWorkspacesFromStore() {
 			// removing its workspace. Preserve workspaces waiting for their
 			// first spawn: the layout pane is persisted before spawn_session
 			// creates the session row, and load can run after a daemon restart
-			// in that gap. Also preserve sessionless, tile-only workspaces —
-			// a docked tile keeps a workspace alive across restarts with no
-			// session of its own.
+			// in that gap. Also preserve workspaces with durable sessionless
+			// content such as docked tiles or shared context.
 			_, registered := d.workspaces.snapshot(ws.ID)
 			if !registered &&
 				!d.workspaceHasPendingSpawn(ws.ID) &&
-				!d.workspaceLayoutHasTiles(ws.ID) &&
-				!d.store.HasWorkspaceContext(ws.ID) {
+				!d.workspaceHasSessionlessContent(ws.ID) {
 				d.store.RemoveWorkspace(ws.ID)
 				continue
 			}
@@ -462,6 +460,13 @@ func (d *Daemon) workspaceHasPendingSpawn(workspaceID string) bool {
 		}
 	}
 	return false
+}
+
+// workspaceHasSessionlessContent is the single retention rule for a workspace
+// after its final session leaves. Tiles remain visible UI content, while shared
+// context remains durable agent state; either one keeps the workspace alive.
+func (d *Daemon) workspaceHasSessionlessContent(workspaceID string) bool {
+	return d.workspaceLayoutHasTiles(workspaceID) || d.store.HasWorkspaceContext(workspaceID)
 }
 
 // listWorkspaces returns a snapshot of the current workspaces for InitialState.
@@ -519,11 +524,10 @@ func (d *Daemon) dissociateSessionFromWorkspace(sessionID string) {
 		return
 	}
 	if remaining == 0 {
-		// A workspace whose last session leaves normally tears down. But if the
-		// user left a docked tile behind, the workspace lives on as a
-		// sessionless, tile-only workspace. We run before the layout's session
-		// pane is removed, so the stored layout still reflects those tiles.
-		if d.workspaceLayoutHasTiles(workspaceID) || d.store.HasWorkspaceContext(workspaceID) {
+		// A workspace whose last session leaves normally tears down. Durable
+		// sessionless content keeps it alive. This runs before the session pane
+		// is removed, so a retained tile is still visible in the stored layout.
+		if d.workspaceHasSessionlessContent(workspaceID) {
 			updated, changed := d.recomputeWorkspaceStatus(workspaceID)
 			if !changed {
 				updated, _ = d.workspaces.snapshot(workspaceID)

--- a/internal/daemon/workspace_context_test.go
+++ b/internal/daemon/workspace_context_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/workspacelayout"
 )
 
 func setupWorkspaceContextSession(t *testing.T, d *Daemon, sessionID, workspaceID string) {
@@ -214,5 +215,63 @@ func TestWorkspaceContextKeepsSessionlessWorkspaceAlive(t *testing.T) {
 	}
 	if _, ok := d.workspaces.snapshot("workspace-1"); !ok {
 		t.Fatal("context-bearing workspace was removed from the registry")
+	}
+}
+
+func TestClosingFinalPanePublishesEmptyLayoutForContextWorkspace(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &fakeSpawnBackend{}
+	client := newWorkspaceProtocolTestClient()
+	workspaceID := "workspace-context-close"
+	sessionID := "session-context-close"
+	paneID := "pane-context-close"
+	cwd := t.TempDir()
+
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: workspaceID, Title: "Context", Directory: cwd,
+	})
+	d.handleWorkspaceLayoutAddSessionPane(client, &protocol.WorkspaceLayoutAddSessionPaneMessage{
+		Cmd: protocol.CmdWorkspaceLayoutAddSessionPane, WorkspaceID: workspaceID,
+		PaneID: protocol.Ptr(paneID), SessionID: sessionID, Title: protocol.Ptr("codex"),
+	})
+	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutAddSessionPane, workspaceID, paneID, true)
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd: protocol.CmdSpawnSession, ID: sessionID, Label: protocol.Ptr("codex"),
+		Cwd: cwd, Agent: string(protocol.SessionAgentCodex), WorkspaceID: workspaceID, Cols: 80, Rows: 24,
+	})
+	expectSpawnResult(t, client, sessionID, true)
+	if _, _, err := d.store.UpdateWorkspaceContext(workspaceID, "shared", sessionID, 0); err != nil {
+		t.Fatalf("seed workspace context: %v", err)
+	}
+
+	cap := captureBroadcasts(d)
+	d.handleWorkspaceLayoutClosePane(client, &protocol.WorkspaceLayoutClosePaneMessage{
+		Cmd: protocol.CmdWorkspaceLayoutClosePane, WorkspaceID: workspaceID, PaneID: paneID,
+	})
+	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutClosePane, workspaceID, paneID, true)
+
+	if d.store.GetWorkspace(workspaceID) == nil {
+		t.Fatal("context-bearing workspace was removed")
+	}
+	if layout := d.store.GetWorkspaceLayout(workspaceID); layout != nil {
+		t.Fatalf("empty workspace layout remained persisted: %+v", layout)
+	}
+
+	events := cap.snapshot()
+	if len(events) != 3 {
+		t.Fatalf("close broadcasts = %d, want 3: %+v", len(events), events)
+	}
+	if events[0].Event != protocol.EventSessionUnregistered ||
+		events[1].Event != protocol.EventWorkspaceStateChanged ||
+		events[2].Event != protocol.EventWorkspaceLayoutUpdated {
+		t.Fatalf("close broadcast order = [%s, %s, %s]", events[0].Event, events[1].Event, events[2].Event)
+	}
+	layout := events[2].WorkspaceLayout
+	if layout == nil || layout.WorkspaceID != workspaceID || len(layout.Panes) != 0 {
+		t.Fatalf("empty layout broadcast = %+v", layout)
+	}
+	layoutNode, err := workspacelayout.DecodeLayout(layout.LayoutJson)
+	if err != nil || !workspacelayout.LayoutEmpty(layoutNode) {
+		t.Fatalf("empty layout JSON = %q, err=%v", layout.LayoutJson, err)
 	}
 }

--- a/internal/daemon/workspacelayout.go
+++ b/internal/daemon/workspacelayout.go
@@ -220,6 +220,14 @@ func (d *Daemon) broadcastWorkspaceLayoutUpdated(workspaceID string) {
 		d.logf("workspace layout update failed for workspace %s: %v", workspaceID, err)
 		return
 	}
+	d.broadcastWorkspaceLayoutSnapshotUpdated(snapshot)
+}
+
+func (d *Daemon) broadcastWorkspaceLayoutSnapshotUpdated(snapshot *protocol.WorkspaceLayout) {
+	if snapshot == nil {
+		return
+	}
+	workspaceID := snapshot.WorkspaceID
 	d.pruneTileContentSubscriptionsForWorkspace(workspaceID)
 	d.wsHub.Broadcast(&protocol.WebSocketEvent{
 		Event:           protocol.EventWorkspaceLayoutUpdated,
@@ -808,8 +816,7 @@ func (d *Daemon) unregisterWorkspaceIfEmptyAfterMove(workspaceID string) {
 		return
 	}
 	if len(d.workspaces.sessionIDs(workspaceID)) > 0 ||
-		d.workspaceLayoutHasTiles(workspaceID) ||
-		d.store.HasWorkspaceContext(workspaceID) {
+		d.workspaceHasSessionlessContent(workspaceID) {
 		d.recomputeAndBroadcastWorkspace(workspaceID)
 		return
 	}
@@ -988,7 +995,18 @@ func (d *Daemon) handleWorkspaceLayoutClosePane(client *wsClient, msg *protocol.
 	}
 	d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutClosePane, msg.WorkspaceID, protocol.Ptr(msg.PaneID), nil)
 
-	if !layoutEmpty {
+	if layoutEmpty {
+		// A context-bearing workspace can survive with no layout. Publish that
+		// empty state so clients cannot retain and replay the removed pane.
+		if d.store.GetWorkspace(msg.WorkspaceID) != nil {
+			emptyLayout, err := protocolWorkspaceLayout(normalized)
+			if err != nil {
+				d.logf("workspace empty layout update failed for workspace %s: %v", msg.WorkspaceID, err)
+				return
+			}
+			d.broadcastWorkspaceLayoutSnapshotUpdated(emptyLayout)
+		}
+	} else {
 		d.broadcastWorkspaceLayoutUpdated(msg.WorkspaceID)
 	}
 }


### PR DESCRIPTION
## Intent / Why
A workspace with shared context survives after its final session closes. The app could retain that session's old spawning layout and reconstruct it during later workspace state updates, making the closed session repeatedly appear and disappear in the sidebar.

## Summary
- centralize daemon retention for sessionless workspaces around durable tiles or shared context
- publish an authoritative empty layout when context keeps a workspace alive after its final pane closes
- invalidate frontend layout caches that still reference an explicitly unregistered session
- cover the full context to final-pane-close to later-state-update lifecycle

## Test plan
- [x] go test ./internal/daemon
- [x] pnpm --dir app test
- [x] git diff --check
- [x] installed and verified in the production profile