### PR TITLE
feat(chief-of-staff): add profile session role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Added
 - **Claude and Codex receive workspace-context guidance without cluttering their terminals.** attn gives each session a local checkout and concise hidden instructions to read it, keep durable goals and decisions current, publish edits, and reconcile revision conflicts without copying the shared context itself into the prompt.
+- **Promote one running session to chief of staff.** Session actions in the sidebar can assign, transfer, or remove the profile-wide role, with confirmation before replacing the current chief and clear badges in the sidebar and dashboard.
 
 ### Changed
 - **Workspace context guidance is safer and less noisy.** Agents now publish only durable shared changes, keep each fact in one appropriate section, treat copied context as untrusted data, and save local edits before refreshing a conflicting revision.

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,6 +11,7 @@ import { LocationPicker } from './components/LocationPicker';
 import { UndoToast } from './components/UndoToast';
 import { WorktreeCleanupPrompt } from './components/WorktreeCleanupPrompt';
 import { CloseSessionPrompt } from './components/CloseSessionPrompt';
+import { ChiefOfStaffTransferPrompt } from './components/ChiefOfStaffTransferPrompt';
 import { ChangesPanel } from './components/ChangesPanel';
 import { DiffDetailPanel } from './components/DiffDetailPanel';
 import { SessionReviewLoopBar } from './components/SessionReviewLoopBar';
@@ -412,6 +413,7 @@ function App() {
     sendUnregisterWorkspace,
     sendRenameSession,
     sendRenameWorkspace,
+    sendSetChiefOfStaff,
     sendUnregisterSession,
     sendSetSetting,
     sendCreateWorktree,
@@ -540,6 +542,7 @@ function App() {
         sendUnregisterWorkspace={sendUnregisterWorkspace}
         sendRenameSession={sendRenameSession}
         sendRenameWorkspace={sendRenameWorkspace}
+        sendSetChiefOfStaff={sendSetChiefOfStaff}
         sendUnregisterSession={sendUnregisterSession}
         sendSetSetting={sendSetSetting}
         sendCreateWorktree={sendCreateWorktree}
@@ -635,6 +638,7 @@ interface AppContentProps {
   sendUnregisterWorkspace: ReturnType<typeof useDaemonSocket>['sendUnregisterWorkspace'];
   sendRenameSession: ReturnType<typeof useDaemonSocket>['sendRenameSession'];
   sendRenameWorkspace: ReturnType<typeof useDaemonSocket>['sendRenameWorkspace'];
+  sendSetChiefOfStaff: ReturnType<typeof useDaemonSocket>['sendSetChiefOfStaff'];
   sendUnregisterSession: ReturnType<typeof useDaemonSocket>['sendUnregisterSession'];
   sendSetSetting: ReturnType<typeof useDaemonSocket>['sendSetSetting'];
   sendCreateWorktree: ReturnType<typeof useDaemonSocket>['sendCreateWorktree'];
@@ -725,6 +729,7 @@ function AppContent({
   sendUnregisterWorkspace,
   sendRenameSession,
   sendRenameWorkspace,
+  sendSetChiefOfStaff,
   sendUnregisterSession,
   sendSetSetting,
   sendCreateWorktree,
@@ -1086,6 +1091,7 @@ sendFetchPRDetails,
       isWorktree: daemonSession?.is_worktree ?? s.isWorktree,
       recoverable: daemonSession?.recoverable ?? false,
       reviewLoopStatus: reviewLoop?.status,
+      chiefOfStaff: daemonSession?.chief_of_staff ?? false,
     };
   });
 
@@ -1408,6 +1414,12 @@ sendFetchPRDetails,
   const [zoomModeBySessionId, setZoomModeBySessionId] = useState<Record<string, boolean>>({});
   const { message: copyMessage, showToast: showCopyToast, clearToast: clearCopyToast } = useCopyToast();
   const { message: errorMessage, showError, clearError } = useErrorToast();
+  const [chiefTransferTarget, setChiefTransferTarget] = useState<{
+    sessionId: string;
+    targetLabel: string;
+    currentLabel: string;
+  } | null>(null);
+  const [chiefTransferSaving, setChiefTransferSaving] = useState(false);
 
   const handleRebootstrapEndpoint = useCallback(async (endpointId: string) => {
     try {
@@ -1416,6 +1428,50 @@ sendFetchPRDetails,
       showError(err instanceof Error ? err.message : 'Sync failed.');
     }
   }, [sendBootstrapEndpoint, showError]);
+
+  const applyChiefOfStaffChange = useCallback(async (sessionId: string, enabled: boolean) => {
+    try {
+      await sendSetChiefOfStaff(sessionId, enabled);
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Chief of staff update failed.');
+      throw err;
+    }
+  }, [sendSetChiefOfStaff, showError]);
+
+  const handleChangeChiefOfStaff = useCallback((sessionId: string, enabled: boolean) => {
+    const target = enrichedLocalSessions.find((session) => session.id === sessionId);
+    if (!target) {
+      showError('Session not found.');
+      return;
+    }
+    if (!enabled) {
+      void applyChiefOfStaffChange(sessionId, false).catch(() => {});
+      return;
+    }
+    const current = enrichedLocalSessions.find((session) => session.chiefOfStaff);
+    if (current && current.id !== sessionId) {
+      setChiefTransferTarget({
+        sessionId,
+        targetLabel: target.label,
+        currentLabel: current.label,
+      });
+      return;
+    }
+    void applyChiefOfStaffChange(sessionId, true).catch(() => {});
+  }, [applyChiefOfStaffChange, enrichedLocalSessions, showError]);
+
+  const handleConfirmChiefTransfer = useCallback(async () => {
+    if (!chiefTransferTarget || chiefTransferSaving) return;
+    setChiefTransferSaving(true);
+    try {
+      await applyChiefOfStaffChange(chiefTransferTarget.sessionId, true);
+      setChiefTransferTarget(null);
+    } catch {
+      // The shared error toast already contains the daemon error.
+    } finally {
+      setChiefTransferSaving(false);
+    }
+  }, [applyChiefOfStaffChange, chiefTransferSaving, chiefTransferTarget]);
 
   const activeReviewLoopState = useMemo(
     () => (activeSessionId ? reviewLoopsBySessionId[activeSessionId] ?? null : null),
@@ -1462,6 +1518,7 @@ sendFetchPRDetails,
     || whatsNew.isOpen
     || settingsOpen
     || shortcutsOpen
+    || chiefTransferTarget !== null
     || closedWorktree !== null
     || pendingSessionClose !== null
     || sessionCreationJob !== null
@@ -3054,6 +3111,7 @@ sendFetchPRDetails,
           onMuteWorkspace={sendMuteWorkspace}
           onRenameSession={sendRenameSession}
           onRenameWorkspace={sendRenameWorkspace}
+          onChangeChiefOfStaff={handleChangeChiefOfStaff}
           showSessionless={showSessionlessWorkspaces}
           onToggleShowSessionless={handleToggleShowSessionlessWorkspaces}
           leafDrag={leafWorkspaceDrag ? {
@@ -3347,6 +3405,18 @@ sendFetchPRDetails,
         splitCount={pendingSessionClose?.splitCount || 0}
         onConfirm={handleConfirmSessionClose}
         onCancel={handleCancelSessionClose}
+      />
+      <ChiefOfStaffTransferPrompt
+        isVisible={chiefTransferTarget !== null}
+        currentLabel={chiefTransferTarget?.currentLabel ?? ''}
+        targetLabel={chiefTransferTarget?.targetLabel ?? ''}
+        isSaving={chiefTransferSaving}
+        onConfirm={() => void handleConfirmChiefTransfer()}
+        onCancel={() => {
+          if (!chiefTransferSaving) {
+            setChiefTransferTarget(null);
+          }
+        }}
       />
       <ThumbsModal
         isOpen={thumbsOpen}

--- a/app/src/components/ChiefOfStaffBadge.css
+++ b/app/src/components/ChiefOfStaffBadge.css
@@ -1,0 +1,25 @@
+.chief-of-staff-badge {
+  align-items: center;
+  background: rgba(255, 107, 53, 0.1);
+  border: 1px solid rgba(255, 107, 53, 0.32);
+  border-radius: 4px;
+  color: #ff8b61;
+  display: inline-flex;
+  flex-shrink: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  gap: 3px;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  padding: 3px 5px;
+  text-transform: uppercase;
+}
+
+.chief-of-staff-badge.compact {
+  border-radius: 999px;
+  height: 18px;
+  justify-content: center;
+  min-width: 18px;
+  padding: 0 5px;
+}

--- a/app/src/components/ChiefOfStaffBadge.tsx
+++ b/app/src/components/ChiefOfStaffBadge.tsx
@@ -1,0 +1,18 @@
+import './ChiefOfStaffBadge.css';
+
+interface ChiefOfStaffBadgeProps {
+  compact?: boolean;
+}
+
+export function ChiefOfStaffBadge({ compact = false }: ChiefOfStaffBadgeProps) {
+  return (
+    <span
+      className={`chief-of-staff-badge ${compact ? 'compact' : ''}`}
+      title="Chief of staff"
+      aria-label="Chief of staff"
+    >
+      <span aria-hidden="true">⌁</span>
+      {!compact && <span>chief</span>}
+    </span>
+  );
+}

--- a/app/src/components/ChiefOfStaffTransferPrompt.css
+++ b/app/src/components/ChiefOfStaffTransferPrompt.css
@@ -1,0 +1,78 @@
+.chief-transfer-prompt {
+  align-items: center;
+  background: var(--color-bg-overlay);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  position: fixed;
+  z-index: 320;
+}
+
+.chief-transfer-content {
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.42);
+  max-width: min(92vw, 460px);
+  min-width: 380px;
+  padding: 20px 22px;
+  text-align: center;
+}
+
+.chief-transfer-title {
+  color: var(--color-text-muted);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  margin-bottom: 11px;
+  text-transform: uppercase;
+}
+
+.chief-transfer-message {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  line-height: 1.55;
+  margin-bottom: 18px;
+}
+
+.chief-transfer-message span {
+  color: #ff9b76;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.chief-transfer-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.chief-transfer-actions button {
+  border: 1px solid var(--color-border-hover);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  padding: 8px 16px;
+}
+
+.chief-transfer-actions button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.chief-transfer-actions .cancel {
+  background: var(--color-border);
+  color: var(--color-text-primary);
+}
+
+.chief-transfer-actions .confirm {
+  background: rgba(255, 107, 53, 0.14);
+  border-color: rgba(255, 107, 53, 0.35);
+  color: #ff8b61;
+}
+
+.chief-transfer-actions button:focus-visible {
+  outline: 2px solid rgba(255, 107, 53, 0.6);
+  outline-offset: 2px;
+}

--- a/app/src/components/ChiefOfStaffTransferPrompt.test.tsx
+++ b/app/src/components/ChiefOfStaffTransferPrompt.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ChiefOfStaffTransferPrompt } from './ChiefOfStaffTransferPrompt';
+
+describe('ChiefOfStaffTransferPrompt', () => {
+  it('describes the transfer without implying either session stops', () => {
+    const onConfirm = vi.fn();
+    render(
+      <ChiefOfStaffTransferPrompt
+        isVisible
+        currentLabel="Current planner"
+        targetLabel="New planner"
+        isSaving={false}
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/Both sessions will keep running/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Transfer role' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/ChiefOfStaffTransferPrompt.tsx
+++ b/app/src/components/ChiefOfStaffTransferPrompt.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
+import './ChiefOfStaffTransferPrompt.css';
+
+interface ChiefOfStaffTransferPromptProps {
+  isVisible: boolean;
+  currentLabel: string;
+  targetLabel: string;
+  isSaving: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ChiefOfStaffTransferPrompt({
+  isVisible,
+  currentLabel,
+  targetLabel,
+  isSaving,
+  onConfirm,
+  onCancel,
+}: ChiefOfStaffTransferPromptProps) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEscapeStack(onCancel, isVisible && !isSaving);
+
+  useEffect(() => {
+    if (!isVisible) return;
+    const raf = requestAnimationFrame(() => confirmRef.current?.focus());
+    return () => cancelAnimationFrame(raf);
+  }, [isVisible]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div
+      className="chief-transfer-prompt"
+      data-testid="chief-transfer-prompt"
+      role="presentation"
+      onClick={isSaving ? undefined : onCancel}
+    >
+      <div
+        className="chief-transfer-content"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="chief-transfer-title"
+        aria-describedby="chief-transfer-message"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="chief-transfer-title" id="chief-transfer-title">
+          Transfer chief of staff role?
+        </div>
+        <div className="chief-transfer-message" id="chief-transfer-message">
+          <span>{currentLabel}</span> currently holds the role. Move it to <span>{targetLabel}</span>?
+          <br />
+          Both sessions will keep running.
+        </div>
+        <div className="chief-transfer-actions">
+          <button
+            type="button"
+            className="cancel"
+            data-testid="chief-transfer-cancel"
+            onClick={onCancel}
+            disabled={isSaving}
+          >
+            Cancel
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            className="confirm"
+            data-testid="chief-transfer-confirm"
+            onClick={onConfirm}
+            disabled={isSaving}
+          >
+            {isSaving ? 'Transferring…' : 'Transfer role'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/Dashboard.test.tsx
+++ b/app/src/components/Dashboard.test.tsx
@@ -87,4 +87,21 @@ describe('Dashboard sessions', () => {
 
     expect(screen.getByText('gpu-box')).toBeInTheDocument();
   });
+
+  it('marks the chief-of-staff session', () => {
+    render(
+      <Dashboard
+        sessions={[
+          { id: 's1', label: 'planner', state: 'working', cwd: '/repo/a', chiefOfStaff: true },
+        ]}
+        prs={[]}
+        isLoading={false}
+        onSelectSession={vi.fn()}
+        onNewSession={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Chief of staff')).toBeInTheDocument();
+  });
 });

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { DaemonEndpoint, DaemonPR, RateLimitState } from '../hooks/useDaemonSock
 import { usePRsNeedingAttention } from '../hooks/usePRsNeedingAttention';
 import { PRActions } from './PRActions';
 import { StateIndicator } from './StateIndicator';
+import { ChiefOfStaffBadge } from './ChiefOfStaffBadge';
 import { useDaemonContext } from '../contexts/DaemonContext';
 import { getRepoName } from '../utils/repo';
 import { openUrl } from '@tauri-apps/plugin-opener';
@@ -19,6 +20,7 @@ type DashboardSession = {
   endpointName?: string;
   endpointStatus?: string;
   reviewLoopStatus?: string;
+  chiefOfStaff?: boolean;
 };
 
 type DashboardWorkspace = {
@@ -287,6 +289,7 @@ export function Dashboard({
                       >
                         <StateIndicator state="waiting_input" size="sm" seed={s.id} />
                         <span className="session-name">{s.label}</span>
+                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
                         {renderEndpointBadge(s)}
                         {reviewLoopIndicator(s.reviewLoopStatus) && (
                           <span
@@ -314,6 +317,7 @@ export function Dashboard({
                       >
                         <StateIndicator state="pending_approval" size="sm" seed={s.id} />
                         <span className="session-name">{s.label}</span>
+                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
                         {renderEndpointBadge(s)}
                         {reviewLoopIndicator(s.reviewLoopStatus) && (
                           <span className={`session-loop-indicator session-loop-indicator--${s.reviewLoopStatus}`} title={reviewLoopIndicator(s.reviewLoopStatus)?.label} aria-label={reviewLoopIndicator(s.reviewLoopStatus)?.label}>
@@ -337,6 +341,7 @@ export function Dashboard({
                       >
                         <StateIndicator state="launching" size="sm" seed={s.id} />
                         <span className="session-name">{s.label}</span>
+                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
                         {renderEndpointBadge(s)}
                         {reviewLoopIndicator(s.reviewLoopStatus) && (
                           <span className={`session-loop-indicator session-loop-indicator--${s.reviewLoopStatus}`} title={reviewLoopIndicator(s.reviewLoopStatus)?.label} aria-label={reviewLoopIndicator(s.reviewLoopStatus)?.label}>
@@ -360,6 +365,7 @@ export function Dashboard({
                       >
                         <StateIndicator state="working" size="sm" seed={s.id} />
                         <span className="session-name">{s.label}</span>
+                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
                         {renderEndpointBadge(s)}
                         {reviewLoopIndicator(s.reviewLoopStatus) && (
                           <span className={`session-loop-indicator session-loop-indicator--${s.reviewLoopStatus}`} title={reviewLoopIndicator(s.reviewLoopStatus)?.label} aria-label={reviewLoopIndicator(s.reviewLoopStatus)?.label}>
@@ -383,6 +389,7 @@ export function Dashboard({
                       >
                         <StateIndicator state="idle" size="sm" seed={s.id} />
                         <span className="session-name">{s.label}</span>
+                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
                         {renderEndpointBadge(s)}
                         {reviewLoopIndicator(s.reviewLoopStatus) && (
                           <span className={`session-loop-indicator session-loop-indicator--${s.reviewLoopStatus}`} title={reviewLoopIndicator(s.reviewLoopStatus)?.label} aria-label={reviewLoopIndicator(s.reviewLoopStatus)?.label}>
@@ -406,6 +413,7 @@ export function Dashboard({
                       >
                         <StateIndicator state="unknown" size="sm" seed={s.id} />
                         <span className="session-name">{s.label}</span>
+                        {s.chiefOfStaff && <ChiefOfStaffBadge compact />}
                         {renderEndpointBadge(s)}
                         {reviewLoopIndicator(s.reviewLoopStatus) && (
                           <span className={`session-loop-indicator session-loop-indicator--${s.reviewLoopStatus}`} title={reviewLoopIndicator(s.reviewLoopStatus)?.label} aria-label={reviewLoopIndicator(s.reviewLoopStatus)?.label}>

--- a/app/src/components/SessionActionsPopover.css
+++ b/app/src/components/SessionActionsPopover.css
@@ -1,0 +1,50 @@
+.session-actions-popover {
+  background: var(--color-bg-panel);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.42);
+  padding: 5px;
+  position: fixed;
+  width: 190px;
+  z-index: 1000;
+}
+
+.session-actions-popover button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  display: flex;
+  font-size: var(--font-size-sm);
+  gap: 9px;
+  padding: 8px 9px;
+  text-align: left;
+  width: 100%;
+}
+
+.session-actions-popover button:hover,
+.session-actions-popover button:focus-visible {
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  outline: none;
+}
+
+.session-actions-popover button > span {
+  align-items: center;
+  display: inline-flex;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  justify-content: center;
+  width: 14px;
+}
+
+.session-actions-popover .chief-of-staff-action {
+  color: #ff8b61;
+}
+
+.session-actions-divider {
+  border-top: 1px solid var(--color-border-subtle);
+  margin: 4px 3px;
+}

--- a/app/src/components/SessionActionsPopover.tsx
+++ b/app/src/components/SessionActionsPopover.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
+import './SessionActionsPopover.css';
+
+interface SessionActionsPopoverProps {
+  sessionLabel: string;
+  chiefOfStaff: boolean;
+  anchor: { top: number; left: number };
+  canRename: boolean;
+  onRename: () => void;
+  onChangeChiefOfStaff: (enabled: boolean) => void;
+  onCloseSession: () => void;
+  onReloadSession: () => void;
+  onClose: () => void;
+}
+
+const VIEWPORT_MARGIN = 8;
+
+export function SessionActionsPopover({
+  sessionLabel,
+  chiefOfStaff,
+  anchor,
+  canRename,
+  onRename,
+  onChangeChiefOfStaff,
+  onCloseSession,
+  onReloadSession,
+  onClose,
+}: SessionActionsPopoverProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState(anchor);
+
+  useEscapeStack(onClose, true);
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const rect = menu.getBoundingClientRect();
+    setPosition({
+      top: Math.max(
+        VIEWPORT_MARGIN,
+        Math.min(anchor.top, window.innerHeight - rect.height - VIEWPORT_MARGIN),
+      ),
+      left: Math.max(
+        VIEWPORT_MARGIN,
+        Math.min(anchor.left, window.innerWidth - rect.width - VIEWPORT_MARGIN),
+      ),
+    });
+  }, [anchor]);
+
+  useEffect(() => {
+    const handleMouseDown = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const id = window.setTimeout(() => document.addEventListener('mousedown', handleMouseDown), 0);
+    return () => {
+      window.clearTimeout(id);
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, [onClose]);
+
+  const run = (action: () => void) => {
+    onClose();
+    action();
+  };
+
+  return (
+    <div
+      ref={menuRef}
+      className="session-actions-popover"
+      style={{ top: position.top, left: position.left }}
+      role="menu"
+      aria-label={`Actions for ${sessionLabel}`}
+    >
+      {canRename && (
+        <button type="button" role="menuitem" data-testid="rename-session-action" onClick={() => run(onRename)}>
+          <span aria-hidden="true">✎</span>
+          Rename session
+        </button>
+      )}
+      <button
+        type="button"
+        role="menuitem"
+        className="chief-of-staff-action"
+        data-testid="chief-of-staff-session-action"
+        onClick={() => run(() => onChangeChiefOfStaff(!chiefOfStaff))}
+      >
+        <span aria-hidden="true">⌁</span>
+        {chiefOfStaff ? 'Remove chief role' : 'Make chief of staff'}
+      </button>
+      <div className="session-actions-divider" />
+      <button type="button" role="menuitem" data-testid="reload-session-action" onClick={() => run(onReloadSession)}>
+        <span aria-hidden="true">↻</span>
+        Reload session
+      </button>
+      <button type="button" role="menuitem" data-testid="close-session-action" onClick={() => run(onCloseSession)}>
+        <span aria-hidden="true">×</span>
+        Close session
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -521,7 +521,7 @@
   gap: 2px;
   flex-shrink: 0;
   margin-left: auto;
-  min-width: 48px;
+  min-width: 24px;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.1s;
@@ -584,6 +584,12 @@
   overflow: hidden;
 }
 
+.session-more-btn {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: -1px;
+  width: 24px;
+}
 
 .session-action-btn:hover {
   color: var(--color-text-primary);

--- a/app/src/components/Sidebar.test.tsx
+++ b/app/src/components/Sidebar.test.tsx
@@ -28,6 +28,7 @@ interface TestSession {
   endpointStatus?: string;
   recoverable?: boolean;
   reviewLoopStatus?: string;
+  chiefOfStaff?: boolean;
 }
 
 function buildSidebarData(sessions: TestSession[]) {
@@ -156,7 +157,8 @@ describe('Sidebar', () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId('reload-session-s1'));
+    fireEvent.click(screen.getByTestId('session-actions-s1'));
+    fireEvent.click(screen.getByTestId('reload-session-action'));
     expect(onReloadSession).toHaveBeenCalledWith('s1');
   });
 
@@ -176,7 +178,8 @@ describe('Sidebar', () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId('close-session-s1'));
+    fireEvent.click(screen.getByTestId('session-actions-s1'));
+    fireEvent.click(screen.getByTestId('close-session-action'));
     expect(onCloseSession).toHaveBeenCalledWith('s1');
   });
 
@@ -421,8 +424,9 @@ describe('Sidebar', () => {
     );
 
     expect(screen.getAllByText('gpu-box')).toHaveLength(2);
-    expect(screen.getByTestId('close-session-remote-1')).toBeInTheDocument();
-    expect(screen.getByTestId('reload-session-remote-1')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('session-actions-remote-1'));
+    expect(screen.getByTestId('close-session-action')).toBeInTheDocument();
+    expect(screen.getByTestId('reload-session-action')).toBeInTheDocument();
   });
 
   it('mutes workspaces instead of individual sessions', () => {
@@ -470,7 +474,8 @@ describe('Sidebar', () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId('rename-session-s1'));
+    fireEvent.click(screen.getByTestId('session-actions-s1'));
+    fireEvent.click(screen.getByTestId('rename-session-action'));
     const input = screen.getByRole('textbox') as HTMLInputElement;
     expect(input.value).toBe('claude');
     fireEvent.change(input, { target: { value: 'renamed-session' } });
@@ -496,5 +501,45 @@ describe('Sidebar', () => {
     fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Enter' });
 
     await waitFor(() => expect(onRenameWorkspace).toHaveBeenCalledWith('workspace-s1', 'renamed-workspace'));
+  });
+
+  it('shows the chief role and requests removal from the session menu', () => {
+    const sessions: TestSession[] = [{
+      id: 's1',
+      label: 'coordinator',
+      state: 'working',
+      chiefOfStaff: true,
+    }];
+    const onChangeChiefOfStaff = vi.fn();
+    render(
+      <Sidebar
+        {...baseProps}
+        onChangeChiefOfStaff={onChangeChiefOfStaff}
+        {...buildSidebarData(sessions)}
+      />
+    );
+
+    expect(screen.getByLabelText('Chief of staff')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('session-actions-s1'));
+    fireEvent.click(screen.getByTestId('chief-of-staff-session-action'));
+
+    expect(onChangeChiefOfStaff).toHaveBeenCalledWith('s1', false);
+  });
+
+  it('requests promotion from the session menu', () => {
+    const sessions: TestSession[] = [{ id: 's1', label: 'worker', state: 'idle' }];
+    const onChangeChiefOfStaff = vi.fn();
+    render(
+      <Sidebar
+        {...baseProps}
+        onChangeChiefOfStaff={onChangeChiefOfStaff}
+        {...buildSidebarData(sessions)}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('session-actions-s1'));
+    fireEvent.click(screen.getByTestId('chief-of-staff-session-action'));
+
+    expect(onChangeChiefOfStaff).toHaveBeenCalledWith('s1', true);
   });
 });

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -2,6 +2,8 @@ import './Sidebar.css';
 import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react';
 import { useState } from 'react';
 import { RenamePopover } from './RenamePopover';
+import { ChiefOfStaffBadge } from './ChiefOfStaffBadge';
+import { SessionActionsPopover } from './SessionActionsPopover';
 import { GridLayoutControl } from './grid/GridLayoutControl';
 import type { GridLayout } from './grid/gridLayout';
 import { StateIndicator } from './StateIndicator';
@@ -24,6 +26,7 @@ interface LocalSession {
   endpointStatus?: string;
   recoverable?: boolean;
   reviewLoopStatus?: string;
+  chiefOfStaff?: boolean;
 }
 
 type SidebarWorkspace = WorkspaceWithSessions<LocalSession>;
@@ -142,6 +145,7 @@ interface SidebarProps {
   onMuteWorkspace?: (workspaceId: string, endpointId?: string) => void;
   onRenameSession?: (sessionId: string, label: string) => Promise<void>;
   onRenameWorkspace?: (workspaceId: string, title: string) => Promise<void>;
+  onChangeChiefOfStaff?: (sessionId: string, enabled: boolean) => void;
   showSessionless?: boolean;
   onToggleShowSessionless?: () => void;
   leafDrag?: { sourceWorkspaceId: string; endpointId?: string } | null;
@@ -289,6 +293,7 @@ export function Sidebar({
   onMuteWorkspace,
   onRenameSession,
   onRenameWorkspace,
+  onChangeChiefOfStaff,
   showSessionless = false,
   onToggleShowSessionless,
   leafDrag = null,
@@ -316,6 +321,12 @@ export function Sidebar({
     name: string;
     anchor: { top: number; left: number };
   } | null>(null);
+  const [sessionActionsTarget, setSessionActionsTarget] = useState<{
+    id: string;
+    label: string;
+    chiefOfStaff: boolean;
+    anchor: { top: number; left: number };
+  } | null>(null);
 
   const openRename = (
     kind: 'session' | 'workspace',
@@ -326,6 +337,19 @@ export function Sidebar({
     event.stopPropagation();
     const rect = event.currentTarget.getBoundingClientRect();
     setRenameTarget({ kind, id, name, anchor: { top: rect.bottom + 4, left: rect.left } });
+  };
+  const openSessionActions = (
+    session: LocalSession,
+    event: ReactMouseEvent,
+  ) => {
+    event.stopPropagation();
+    const rect = event.currentTarget.getBoundingClientRect();
+    setSessionActionsTarget({
+      id: session.id,
+      label: session.label,
+      chiefOfStaff: Boolean(session.chiefOfStaff),
+      anchor: { top: rect.bottom + 4, left: rect.right - 190 },
+    });
   };
   const mutedExpanded = mutedExpandedProp ?? mutedExpandedLocal;
   const setMutedExpanded = (v: boolean) => {
@@ -617,6 +641,7 @@ export function Sidebar({
                     {session.recoverable && (
                       <span className="session-recoverable">recoverable</span>
                     )}
+                    {session.chiefOfStaff && <ChiefOfStaffBadge />}
                     {reviewLoopIndicator(session.reviewLoopStatus) && (
                       <span
                         className={`session-loop-indicator session-loop-indicator--${session.reviewLoopStatus}`}
@@ -628,40 +653,14 @@ export function Sidebar({
                     )}
                     {session.isWorktree && <span className="worktree-indicator">⎇</span>}
                     <div className="session-actions">
-                      {onRenameSession && (
-                        <button
-                          className="session-action-btn rename-session-btn"
-                          data-testid={`rename-session-${session.id}`}
-                          onClick={(e) => openRename('session', session.id, session.label, e)}
-                          title="Rename session"
-                          aria-label={`Rename session ${session.label}`}
-                        >
-                          ✎
-                        </button>
-                      )}
                       <button
-                        className="session-action-btn close-session-btn"
-                        data-testid={`close-session-${session.id}`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onCloseSession(session.id);
-                        }}
-                        title={`Close session (${formatShortcut('session.close')})`}
-                        aria-label={`Close session ${session.label}`}
+                        className="session-action-btn session-more-btn"
+                        data-testid={`session-actions-${session.id}`}
+                        onClick={(event) => openSessionActions(session, event)}
+                        title={`Session actions (${formatShortcut('session.close')} closes)`}
+                        aria-label={`Actions for ${session.label}`}
                       >
-                        ×
-                      </button>
-                      <button
-                        className="session-action-btn reload-session-btn"
-                        data-testid={`reload-session-${session.id}`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onReloadSession(session.id);
-                        }}
-                        title="Reload session"
-                        aria-label={`Reload session ${session.label}`}
-                      >
-                        ↻
+                        •••
                       </button>
                     </div>
                   </div>
@@ -764,6 +763,7 @@ export function Sidebar({
                         >
                           <StateIndicator state={session.state} size="md" seed={session.id} />
                           <span className="session-label">{session.label}</span>
+                          {session.chiefOfStaff && <ChiefOfStaffBadge />}
                           {session.endpointName && (
                             <span className={`session-endpoint-badge status-${session.endpointStatus || 'connected'}`}>
                               {session.endpointName}
@@ -808,6 +808,26 @@ export function Sidebar({
             }
           }}
           onClose={() => setRenameTarget(null)}
+        />
+      )}
+      {sessionActionsTarget && (
+        <SessionActionsPopover
+          sessionLabel={sessionActionsTarget.label}
+          chiefOfStaff={sessionActionsTarget.chiefOfStaff}
+          anchor={sessionActionsTarget.anchor}
+          canRename={Boolean(onRenameSession)}
+          onRename={() => {
+            setRenameTarget({
+              kind: 'session',
+              id: sessionActionsTarget.id,
+              name: sessionActionsTarget.label,
+              anchor: sessionActionsTarget.anchor,
+            });
+          }}
+          onChangeChiefOfStaff={(enabled) => onChangeChiefOfStaff?.(sessionActionsTarget.id, enabled)}
+          onCloseSession={() => onCloseSession(sessionActionsTarget.id)}
+          onReloadSession={() => onReloadSession(sessionActionsTarget.id)}
+          onClose={() => setSessionActionsTarget(null)}
         />
       )}
     </div>

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -649,7 +649,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [
           {
             id: 'agent-1',
@@ -735,7 +735,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [],
         workspaces: [{
           id: 'workspace-1',
@@ -819,7 +819,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -904,7 +904,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1036,7 +1036,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1102,7 +1102,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1166,7 +1166,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1228,7 +1228,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1288,7 +1288,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [],
         workspaces: [{
           id: 'workspace-1',
@@ -1388,7 +1388,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     };
     const initialState = {
       event: 'initial_state',
-      protocol_version: '91',
+      protocol_version: '92',
       sessions: [],
       workspaces: [workspace],
       prs: [],
@@ -1465,7 +1465,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1559,7 +1559,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1658,7 +1658,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1743,7 +1743,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -1822,7 +1822,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -1892,7 +1892,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '91',
+        protocol_version: '92',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',
@@ -2028,6 +2028,70 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     const lastSessions = calls.length > 0 ? calls[calls.length - 1][0] : [];
     expect(lastSessions).toHaveLength(1);
     expect(lastSessions[0]).toMatchObject({ id: 'sess-1', label: 'renamed' });
+
+    unmount();
+  });
+
+  it('resolves a chief-of-staff update from its result event', async () => {
+    const onSessionsUpdate = vi.fn();
+    const onWorkspacesUpdate = vi.fn();
+    const onPRsUpdate = vi.fn();
+    const onReposUpdate = vi.fn();
+    const onAuthorsUpdate = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate,
+        onWorkspacesUpdate,
+        onPRsUpdate,
+        onReposUpdate,
+        onAuthorsUpdate,
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+    act(() => {
+      ws.emit({
+        event: 'initial_state',
+        protocol_version: '92',
+        sessions: [],
+        workspaces: [],
+        prs: [],
+        repos: [],
+        authors: [],
+        settings: {},
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.hasReceivedInitialState).toBe(true);
+    });
+
+    let updatePromise!: Promise<void>;
+    act(() => {
+      updatePromise = result.current.sendSetChiefOfStaff('session-1', true);
+    });
+    let commandSocket: FakeWebSocket | undefined;
+    await waitFor(() => {
+      commandSocket = FakeWebSocket.instances.find((instance) => (
+        instance.sent.some((entry) => JSON.parse(entry).cmd === 'set_chief_of_staff')
+      ));
+      expect(commandSocket).toBeDefined();
+      expect(commandSocket!.sent.map((entry) => JSON.parse(entry))).toContainEqual({
+        cmd: 'set_chief_of_staff',
+        session_id: 'session-1',
+        chief_of_staff: true,
+      });
+    });
+
+    act(() => {
+      commandSocket!.emit({
+        event: 'chief_of_staff_result',
+        session_id: 'session-1',
+        chief_of_staff: true,
+        success: true,
+      });
+    });
+    await expect(updatePromise).resolves.toBeUndefined();
 
     unmount();
   });

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -161,7 +161,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '91';
+const PROTOCOL_VERSION = '92';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -1161,6 +1161,22 @@ export function useDaemonSocket({
                   pending.resolve(undefined);
                 } else {
                   pending.reject(new Error(data.error || 'Rename failed'));
+                }
+              }
+            }
+            break;
+          }
+
+          case 'chief_of_staff_result': {
+            if (typeof data.session_id === 'string') {
+              const key = `chief_of_staff:${data.session_id}`;
+              const pending = pendingActionsRef.current.get(key);
+              if (pending) {
+                pendingActionsRef.current.delete(key);
+                if (data.success) {
+                  pending.resolve(undefined);
+                } else {
+                  pending.reject(new Error(data.error || 'Chief of staff update failed'));
                 }
               }
             }
@@ -2846,6 +2862,34 @@ export function useDaemonSocket({
     });
   }, [sendOrQueueCommand]);
 
+  const sendSetChiefOfStaff = useCallback((sessionId: string, chiefOfStaff: boolean): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      if (!sessionId) {
+        reject(new Error('Session is required'));
+        return;
+      }
+      const ws = wsRef.current;
+      if (!hasReceivedInitialStateRef.current || !ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const key = `chief_of_staff:${sessionId}`;
+      pendingActionsRef.current.set(key, { resolve: () => resolve(), reject });
+      ws.send(JSON.stringify({
+        cmd: 'set_chief_of_staff',
+        session_id: sessionId,
+        chief_of_staff: chiefOfStaff,
+      }));
+      window.setTimeout(() => {
+        if (!pendingActionsRef.current.has(key)) {
+          return;
+        }
+        pendingActionsRef.current.delete(key);
+        reject(new Error(`Chief of staff update timed out for session ${sessionId}`));
+      }, 10_000);
+    });
+  }, []);
+
   // Unregister a single session from daemon
   const sendUnregisterSession = useCallback((sessionId: string): Promise<void> => {
     return new Promise((resolve, reject) => {
@@ -3861,6 +3905,7 @@ export function useDaemonSocket({
     sendUnregisterWorkspace,
     sendRenameSession,
     sendRenameWorkspace,
+    sendSetChiefOfStaff,
     sendPRVisited,
     sendListWorktrees,
     sendCreateWorktree,

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1380,6 +1380,61 @@ export function useUiAutomationBridge({
         });
         return session ? serializeSession(session, getActivePaneIdForSession) : null;
       }
+      case 'chief_of_staff_get_state':
+        return {
+          sessions: sessions.map((session) => {
+            const row = document.querySelector(`[data-testid="sidebar-session-${session.id}"]`);
+            const chiefOfStaff = Boolean(row?.querySelector('.chief-of-staff-badge'));
+            return {
+              id: session.id,
+              label: session.label,
+              chiefOfStaff,
+              sidebarBadge: chiefOfStaff,
+            };
+          }),
+          actionsOpen: Boolean(document.querySelector('.session-actions-popover')),
+          transferPrompt: document.querySelector('[data-testid="chief-transfer-prompt"]')?.textContent?.trim() || null,
+        };
+      case 'chief_of_staff_open_actions': {
+        const sessionId = typeof payload.sessionId === 'string' ? payload.sessionId : '';
+        if (!sessionId) {
+          throw new Error('chief_of_staff_open_actions requires sessionId');
+        }
+        const button = document.querySelector(`[data-testid="session-actions-${sessionId}"]`);
+        if (!(button instanceof HTMLElement)) {
+          throw new Error(`Session actions not found for ${sessionId}`);
+        }
+        clickElement(button);
+        await settleUi(2);
+        return { sessionId };
+      }
+      case 'chief_of_staff_toggle': {
+        const button = document.querySelector('[data-testid="chief-of-staff-session-action"]');
+        if (!(button instanceof HTMLElement)) {
+          throw new Error('Chief of staff action is not open');
+        }
+        clickElement(button);
+        await settleUi(2);
+        return { requested: true };
+      }
+      case 'chief_of_staff_confirm_transfer': {
+        const button = document.querySelector('[data-testid="chief-transfer-confirm"]');
+        if (!(button instanceof HTMLElement)) {
+          throw new Error('Chief of staff transfer prompt is not open');
+        }
+        clickElement(button);
+        await settleUi(2);
+        return { requested: true };
+      }
+      case 'chief_of_staff_cancel_transfer': {
+        const button = document.querySelector('[data-testid="chief-transfer-cancel"]');
+        if (!(button instanceof HTMLElement)) {
+          throw new Error('Chief of staff transfer prompt is not open');
+        }
+        clickElement(button);
+        await settleUi(2);
+        return { requested: true };
+      }
       case 'create_session': {
         const cwd = typeof payload.cwd === 'string' ? payload.cwd : '';
         const label = typeof payload.label === 'string' && payload.label.length > 0

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -24,6 +24,7 @@
 //   const browserControlRequestMessage = Convert.toBrowserControlRequestMessage(json);
 //   const browserControlResponseMessage = Convert.toBrowserControlResponseMessage(json);
 //   const browserControlResultMessage = Convert.toBrowserControlResultMessage(json);
+//   const chiefOfStaffResultMessage = Convert.toChiefOfStaffResultMessage(json);
 //   const clearSessionsMessage = Convert.toClearSessionsMessage(json);
 //   const clearWarningsMessage = Convert.toClearWarningsMessage(json);
 //   const clientHelloMessage = Convert.toClientHelloMessage(json);
@@ -164,6 +165,7 @@
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
 //   const sessionVisualizedMessage = Convert.toSessionVisualizedMessage(json);
 //   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
+//   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
 //   const setPluginPriorityMessage = Convert.toSetPluginPriorityMessage(json);
 //   const setReviewLoopIterationLimitMessage = Convert.toSetReviewLoopIterationLimitMessage(json);
@@ -407,6 +409,7 @@ export enum BranchChangedMessageEvent {
 export interface SessionElement {
     agent:                        string;
     branch?:                      string;
+    chief_of_staff?:              boolean;
     directory:                    string;
     endpoint_id?:                 string;
     id:                           string;
@@ -578,6 +581,20 @@ export interface BrowserControlResultMessage {
 
 export enum BrowserControlResultMessageCmd {
     BrowserControlResult = "browser_control_result",
+}
+
+export interface ChiefOfStaffResultMessage {
+    chief_of_staff:       boolean;
+    error?:               string;
+    event:                ChiefOfStaffResultMessageEvent;
+    previous_session_id?: string;
+    session_id:           string;
+    success:              boolean;
+    [property: string]: any;
+}
+
+export enum ChiefOfStaffResultMessageEvent {
+    ChiefOfStaffResult = "chief_of_staff_result",
 }
 
 export interface ClearSessionsMessage {
@@ -2367,6 +2384,7 @@ export interface ReviewState {
 export interface Session {
     agent:                        string;
     branch?:                      string;
+    chief_of_staff?:              boolean;
     directory:                    string;
     endpoint_id?:                 string;
     id:                           string;
@@ -2464,6 +2482,17 @@ export interface SessionsUpdatedMessage {
 
 export enum SessionsUpdatedMessageEvent {
     SessionsUpdated = "sessions_updated",
+}
+
+export interface SetChiefOfStaffMessage {
+    chief_of_staff: boolean;
+    cmd:            SetChiefOfStaffMessageCmd;
+    session_id:     string;
+    [property: string]: any;
+}
+
+export enum SetChiefOfStaffMessageCmd {
+    SetChiefOfStaff = "set_chief_of_staff",
 }
 
 export interface SetEndpointRemoteWebMessage {
@@ -2709,6 +2738,7 @@ export interface WebSocketEvent {
     base_ref?:                 string;
     branch?:                   string;
     branches?:                 BranchElement[];
+    chief_of_staff?:           boolean;
     cloned?:                   boolean;
     cmd?:                      string;
     cols?:                     number;
@@ -2733,6 +2763,7 @@ export interface WebSocketEvent {
     pid?:                      number;
     plugin_issues?:            IssueElement[];
     plugins?:                  PluginElement[];
+    previous_session_id?:      string;
     priority?:                 number;
     protocol_version?:         string;
     prs?:                      PRElement[];
@@ -3363,6 +3394,14 @@ export class Convert {
 
     public static browserControlResultMessageToJson(value: BrowserControlResultMessage): string {
         return JSON.stringify(uncast(value, r("BrowserControlResultMessage")), null, 2);
+    }
+
+    public static toChiefOfStaffResultMessage(json: string): ChiefOfStaffResultMessage {
+        return cast(JSON.parse(json), r("ChiefOfStaffResultMessage"));
+    }
+
+    public static chiefOfStaffResultMessageToJson(value: ChiefOfStaffResultMessage): string {
+        return JSON.stringify(uncast(value, r("ChiefOfStaffResultMessage")), null, 2);
     }
 
     public static toClearSessionsMessage(json: string): ClearSessionsMessage {
@@ -4485,6 +4524,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
     }
 
+    public static toSetChiefOfStaffMessage(json: string): SetChiefOfStaffMessage {
+        return cast(JSON.parse(json), r("SetChiefOfStaffMessage"));
+    }
+
+    public static setChiefOfStaffMessageToJson(value: SetChiefOfStaffMessage): string {
+        return JSON.stringify(uncast(value, r("SetChiefOfStaffMessage")), null, 2);
+    }
+
     public static toSetEndpointRemoteWebMessage(json: string): SetEndpointRemoteWebMessage {
         return cast(JSON.parse(json), r("SetEndpointRemoteWebMessage"));
     }
@@ -5222,6 +5269,7 @@ const typeMap: any = {
     "SessionElement": o([
         { json: "agent", js: "agent", typ: "" },
         { json: "branch", js: "branch", typ: u(undefined, "") },
+        { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
         { json: "directory", js: "directory", typ: "" },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "id", js: "id", typ: "" },
@@ -5326,6 +5374,14 @@ const typeMap: any = {
         { json: "data", js: "data", typ: u(undefined, "") },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "request_id", js: "request_id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "ChiefOfStaffResultMessage": o([
+        { json: "chief_of_staff", js: "chief_of_staff", typ: true },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("ChiefOfStaffResultMessageEvent") },
+        { json: "previous_session_id", js: "previous_session_id", typ: u(undefined, "") },
+        { json: "session_id", js: "session_id", typ: "" },
         { json: "success", js: "success", typ: true },
     ], "any"),
     "ClearSessionsMessage": o([
@@ -6355,6 +6411,7 @@ const typeMap: any = {
     "Session": o([
         { json: "agent", js: "agent", typ: "" },
         { json: "branch", js: "branch", typ: u(undefined, "") },
+        { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
         { json: "directory", js: "directory", typ: "" },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "id", js: "id", typ: "" },
@@ -6403,6 +6460,11 @@ const typeMap: any = {
     "SessionsUpdatedMessage": o([
         { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
         { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
+    ], "any"),
+    "SetChiefOfStaffMessage": o([
+        { json: "chief_of_staff", js: "chief_of_staff", typ: true },
+        { json: "cmd", js: "cmd", typ: r("SetChiefOfStaffMessageCmd") },
+        { json: "session_id", js: "session_id", typ: "" },
     ], "any"),
     "SetEndpointRemoteWebMessage": o([
         { json: "cmd", js: "cmd", typ: r("SetEndpointRemoteWebMessageCmd") },
@@ -6527,6 +6589,7 @@ const typeMap: any = {
         { json: "base_ref", js: "base_ref", typ: u(undefined, "") },
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "branches", js: "branches", typ: u(undefined, a(r("BranchElement"))) },
+        { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
         { json: "cloned", js: "cloned", typ: u(undefined, true) },
         { json: "cmd", js: "cmd", typ: u(undefined, "") },
         { json: "cols", js: "cols", typ: u(undefined, 0) },
@@ -6551,6 +6614,7 @@ const typeMap: any = {
         { json: "pid", js: "pid", typ: u(undefined, 0) },
         { json: "plugin_issues", js: "plugin_issues", typ: u(undefined, a(r("IssueElement"))) },
         { json: "plugins", js: "plugins", typ: u(undefined, a(r("PluginElement"))) },
+        { json: "previous_session_id", js: "previous_session_id", typ: u(undefined, "") },
         { json: "priority", js: "priority", typ: u(undefined, 0) },
         { json: "protocol_version", js: "protocol_version", typ: u(undefined, "") },
         { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
@@ -6876,6 +6940,9 @@ const typeMap: any = {
     ],
     "BrowserControlResultMessageCmd": [
         "browser_control_result",
+    ],
+    "ChiefOfStaffResultMessageEvent": [
+        "chief_of_staff_result",
     ],
     "ClearSessionsMessageCmd": [
         "clear_sessions",
@@ -7262,6 +7329,9 @@ const typeMap: any = {
     ],
     "SessionsUpdatedMessageEvent": [
         "sessions_updated",
+    ],
+    "SetChiefOfStaffMessageCmd": [
+        "set_chief_of_staff",
     ],
     "SetEndpointRemoteWebMessageCmd": [
         "set_endpoint_remote_web",

--- a/docs/plans/2026-06-08-chief-of-staff.md
+++ b/docs/plans/2026-06-08-chief-of-staff.md
@@ -104,7 +104,7 @@ ChiefOfStaff {
 - [x] Emit `workspace_context_changed` and keep context-bearing workspaces alive.
 - [x] Inject workspace-context management guidance through supported agent
       session-start hooks without embedding a stale context snapshot.
-- [ ] Add the unique profile-scoped chief-of-staff session role.
+- [x] Add the unique profile-scoped chief-of-staff session role.
 - [ ] Add tracked dispatch status/reporting and UI visualization.
 
 ## Decisions

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -1,0 +1,98 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+const profileRoleChiefOfStaff = "chief_of_staff"
+
+func (d *Daemon) chiefOfStaffSessionID() string {
+	if d.store == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.store.GetProfileRole(profileRoleChiefOfStaff))
+}
+
+func (d *Daemon) decorateChiefOfStaffWithSessionID(session *protocol.Session, chiefOfStaffSessionID string) {
+	if session == nil {
+		return
+	}
+	if session.ID == chiefOfStaffSessionID {
+		session.ChiefOfStaff = protocol.Ptr(true)
+		return
+	}
+	session.ChiefOfStaff = nil
+}
+
+func (d *Daemon) sessionExists(sessionID string) bool {
+	if d.store != nil && d.store.Get(sessionID) != nil {
+		return true
+	}
+	return d.hubManager != nil && d.hubManager.RemoteSession(sessionID) != nil
+}
+
+func (d *Daemon) clearChiefOfStaffIfSession(sessionID string) {
+	if d.store == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	if err := d.store.ClearProfileRole(profileRoleChiefOfStaff, sessionID); err != nil {
+		d.logf("clear chief of staff role failed for session %s: %v", sessionID, err)
+	}
+}
+
+func (d *Daemon) handleSetChiefOfStaff(client *wsClient, msg *protocol.SetChiefOfStaffMessage) {
+	sessionID := strings.TrimSpace(msg.SessionID)
+	if sessionID == "" {
+		d.sendChiefOfStaffResult(client, sessionID, msg.ChiefOfStaff, "", fmt.Errorf("missing session_id"))
+		return
+	}
+
+	previousSessionID := d.chiefOfStaffSessionID()
+	if msg.ChiefOfStaff {
+		if !d.sessionExists(sessionID) {
+			d.sendChiefOfStaffResult(
+				client,
+				sessionID,
+				true,
+				previousSessionID,
+				fmt.Errorf("session not found: %s", sessionID),
+			)
+			return
+		}
+		if err := d.store.SetProfileRole(profileRoleChiefOfStaff, sessionID); err != nil {
+			d.sendChiefOfStaffResult(client, sessionID, true, previousSessionID, err)
+			return
+		}
+	} else if err := d.store.ClearProfileRole(profileRoleChiefOfStaff, sessionID); err != nil {
+		d.sendChiefOfStaffResult(client, sessionID, false, previousSessionID, err)
+		return
+	}
+
+	d.broadcastSessionsUpdated()
+	d.sendChiefOfStaffResult(client, sessionID, msg.ChiefOfStaff, previousSessionID, nil)
+}
+
+func (d *Daemon) sendChiefOfStaffResult(
+	client *wsClient,
+	sessionID string,
+	chiefOfStaff bool,
+	previousSessionID string,
+	err error,
+) {
+	result := protocol.ChiefOfStaffResultMessage{
+		Event:        protocol.EventChiefOfStaffResult,
+		SessionID:    sessionID,
+		ChiefOfStaff: chiefOfStaff,
+		Success:      err == nil,
+	}
+	if previousSessionID != "" {
+		result.PreviousSessionID = protocol.Ptr(previousSessionID)
+	}
+	if err != nil {
+		result.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, result)
+}

--- a/internal/daemon/chief_of_staff_test.go
+++ b/internal/daemon/chief_of_staff_test.go
@@ -1,0 +1,115 @@
+package daemon
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func readChiefOfStaffResult(t *testing.T, client *wsClient) protocol.ChiefOfStaffResultMessage {
+	t.Helper()
+	select {
+	case raw := <-client.send:
+		var result protocol.ChiefOfStaffResultMessage
+		if err := json.Unmarshal(raw.payload, &result); err != nil {
+			t.Fatalf("decode chief_of_staff_result: %v", err)
+		}
+		return result
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for chief_of_staff_result")
+		return protocol.ChiefOfStaffResultMessage{}
+	}
+}
+
+func newChiefOfStaffTestDaemon(t *testing.T) (*Daemon, *wsClient) {
+	t.Helper()
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(func() { _ = d.store.Close() })
+	return d, newRenameTestClient()
+}
+
+func addChiefOfStaffTestSession(d *Daemon, id, label string) {
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID: id, Label: label, Agent: protocol.SessionAgentCodex,
+		Directory: "/tmp/" + id, WorkspaceID: "workspace-" + id,
+		State: protocol.SessionStateIdle, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+}
+
+func TestSetChiefOfStaffTransfersSingletonRole(t *testing.T) {
+	d, client := newChiefOfStaffTestDaemon(t)
+	addChiefOfStaffTestSession(d, "session-a", "first")
+	addChiefOfStaffTestSession(d, "session-b", "second")
+
+	d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+		Cmd: protocol.CmdSetChiefOfStaff, SessionID: "session-a", ChiefOfStaff: true,
+	})
+	first := readChiefOfStaffResult(t, client)
+	if !first.Success || d.chiefOfStaffSessionID() != "session-a" {
+		t.Fatalf("first assignment = %+v role=%q", first, d.chiefOfStaffSessionID())
+	}
+
+	d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+		Cmd: protocol.CmdSetChiefOfStaff, SessionID: "session-b", ChiefOfStaff: true,
+	})
+	second := readChiefOfStaffResult(t, client)
+	if !second.Success || protocol.Deref(second.PreviousSessionID) != "session-a" {
+		t.Fatalf("transfer result = %+v", second)
+	}
+	if got := d.chiefOfStaffSessionID(); got != "session-b" {
+		t.Fatalf("role after transfer = %q, want session-b", got)
+	}
+
+	sessions := d.mergedSessionsForBroadcast()
+	for _, session := range sessions {
+		switch session.ID {
+		case "session-a":
+			if protocol.Deref(session.ChiefOfStaff) {
+				t.Fatal("previous session still marked chief")
+			}
+		case "session-b":
+			if !protocol.Deref(session.ChiefOfStaff) {
+				t.Fatal("new session not marked chief")
+			}
+		}
+	}
+}
+
+func TestSetChiefOfStaffRejectsUnknownSession(t *testing.T) {
+	d, client := newChiefOfStaffTestDaemon(t)
+
+	d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+		Cmd: protocol.CmdSetChiefOfStaff, SessionID: "missing", ChiefOfStaff: true,
+	})
+	result := readChiefOfStaffResult(t, client)
+	if result.Success || protocol.Deref(result.Error) == "" {
+		t.Fatalf("result = %+v, want failure", result)
+	}
+	if got := d.chiefOfStaffSessionID(); got != "" {
+		t.Fatalf("role = %q, want empty", got)
+	}
+}
+
+func TestClearChiefOfStaffKeepsTransferredRole(t *testing.T) {
+	d, client := newChiefOfStaffTestDaemon(t)
+	addChiefOfStaffTestSession(d, "session-a", "first")
+	addChiefOfStaffTestSession(d, "session-b", "second")
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, "session-b"); err != nil {
+		t.Fatal(err)
+	}
+
+	d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+		Cmd: protocol.CmdSetChiefOfStaff, SessionID: "session-a", ChiefOfStaff: false,
+	})
+	result := readChiefOfStaffResult(t, client)
+	if !result.Success {
+		t.Fatalf("clear result = %+v", result)
+	}
+	if got := d.chiefOfStaffSessionID(); got != "session-b" {
+		t.Fatalf("role after stale clear = %q, want session-b", got)
+	}
+}

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -118,6 +118,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdBrowserControlResult:               commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdRenameSession:                      commandMetadata(ScopeSession, false, true),
 	protocol.CmdRenameWorkspace:                    commandMetadata(ScopeEndpoint, false, true),
+	protocol.CmdSetChiefOfStaff:                    commandMetadata(ScopeHubLocal, false, true),
 }
 
 func shouldLogWSCommand(cmd string) bool {

--- a/internal/daemon/command_meta_test.go
+++ b/internal/daemon/command_meta_test.go
@@ -85,6 +85,7 @@ func TestCommandMetaCoversAllCommands(t *testing.T) {
 		protocol.CmdWorkspaceTileContentGet,
 		protocol.CmdRenameSession,
 		protocol.CmdRenameWorkspace,
+		protocol.CmdSetChiefOfStaff,
 	}
 
 	for _, cmd := range commands {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1285,6 +1285,7 @@ func (d *Daemon) unregisterSession(sessionID string, sig syscall.Signal) *protoc
 	d.handleReviewLoopSourceSessionExit(sessionID)
 	d.setPendingInputSource(sessionID, "")
 	d.store.Remove(sessionID)
+	d.clearChiefOfStaffIfSession(sessionID)
 	if d.hubManager != nil {
 		d.hubManager.ForgetSession(sessionID)
 	}
@@ -1296,6 +1297,7 @@ func (d *Daemon) unregisterSession(sessionID string, sig syscall.Signal) *protoc
 
 func (d *Daemon) removeReapedSession(sessionID string) {
 	d.store.Remove(sessionID)
+	d.clearChiefOfStaffIfSession(sessionID)
 	d.dissociateSessionFromWorkspace(sessionID)
 	d.removeWorkspaceLayoutPaneForSession(sessionID)
 }
@@ -2350,6 +2352,13 @@ func cloneSession(session *protocol.Session) *protocol.Session {
 }
 
 func (d *Daemon) sessionForBroadcast(session *protocol.Session) *protocol.Session {
+	return d.sessionForBroadcastWithChiefOfStaff(session, d.chiefOfStaffSessionID())
+}
+
+func (d *Daemon) sessionForBroadcastWithChiefOfStaff(
+	session *protocol.Session,
+	chiefOfStaffSessionID string,
+) *protocol.Session {
 	clone := cloneSession(session)
 	if clone == nil {
 		return nil
@@ -2359,6 +2368,7 @@ func (d *Daemon) sessionForBroadcast(session *protocol.Session) *protocol.Sessio
 	} else {
 		clone.NeedsReviewAfterLongRun = nil
 	}
+	d.decorateChiefOfStaffWithSessionID(clone, chiefOfStaffSessionID)
 	d.decorateSessionWithWorkspace(clone)
 	return clone
 }
@@ -2367,9 +2377,10 @@ func (d *Daemon) sessionsForBroadcast(sessions []*protocol.Session) []protocol.S
 	if len(sessions) == 0 {
 		return nil
 	}
+	chiefOfStaffSessionID := d.chiefOfStaffSessionID()
 	out := make([]protocol.Session, 0, len(sessions))
 	for _, session := range sessions {
-		if decorated := d.sessionForBroadcast(session); decorated != nil {
+		if decorated := d.sessionForBroadcastWithChiefOfStaff(session, chiefOfStaffSessionID); decorated != nil {
 			out = append(out, *decorated)
 		}
 	}
@@ -2395,7 +2406,12 @@ func (d *Daemon) remoteSessionsForBroadcast() []protocol.Session {
 	if d.hubManager == nil {
 		return nil
 	}
-	return d.hubManager.RemoteSessions()
+	sessions := d.hubManager.RemoteSessions()
+	chiefOfStaffSessionID := d.chiefOfStaffSessionID()
+	for i := range sessions {
+		d.decorateChiefOfStaffWithSessionID(&sessions[i], chiefOfStaffSessionID)
+	}
+	return sessions
 }
 
 func (d *Daemon) broadcastSessionStateChanged(sessionID string) {

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -1036,6 +1036,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleRenameSession(client, msg.(*protocol.RenameSessionMessage))
 	case protocol.CmdRenameWorkspace:
 		d.handleRenameWorkspace(client, msg.(*protocol.RenameWorkspaceMessage))
+	case protocol.CmdSetChiefOfStaff:
+		d.handleSetChiefOfStaff(client, msg.(*protocol.SetChiefOfStaffMessage))
 	default:
 		d.sendCommandError(client, cmd, "unsupported command")
 	}

--- a/internal/daemon/worktree.go
+++ b/internal/daemon/worktree.go
@@ -316,6 +316,7 @@ func (d *Daemon) cleanupDeletedWorktreeSessions(path string) {
 		}
 		d.terminateSession(session.ID, syscall.SIGTERM)
 		d.store.Remove(session.ID)
+		d.clearChiefOfStaffIfSession(session.ID)
 		d.clearLongRunTracking(session.ID)
 		d.wsHub.Broadcast(&protocol.WebSocketEvent{
 			Event:   protocol.EventSessionUnregistered,

--- a/internal/daemon/ws_session.go
+++ b/internal/daemon/ws_session.go
@@ -104,5 +104,6 @@ func (d *Daemon) clearAllSessions() {
 		d.clearLongRunTracking(sessionID)
 	}
 	d.store.ClearSessions()
+	d.clearChiefOfStaffIfSession(d.chiefOfStaffSessionID())
 	d.broadcastSessionsUpdated()
 }

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "91"
+const ProtocolVersion = "92"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -136,6 +136,7 @@ const (
 	CmdUnregisterWorkspace                = "unregister_workspace"
 	CmdRenameSession                      = "rename_session"
 	CmdRenameWorkspace                    = "rename_workspace"
+	CmdSetChiefOfStaff                    = "set_chief_of_staff"
 )
 
 // WebSocket Events (daemon -> client)
@@ -150,6 +151,7 @@ const (
 	EventSessionTodosUpdated         = "session_todos_updated"
 	EventSessionsUpdated             = "sessions_updated"
 	EventRenameResult                = "rename_result"
+	EventChiefOfStaffResult          = "chief_of_staff_result"
 	EventDelegateResult              = "delegate_result"
 	EventWorkspaceContextResult      = "workspace_context_result"
 	EventPRsUpdated                  = "prs_updated"
@@ -995,6 +997,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		var msg RenameWorkspaceMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, fmt.Errorf("unmarshal rename_workspace: %w", err)
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdSetChiefOfStaff:
+		var msg SetChiefOfStaffMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal set_chief_of_staff: %w", err)
 		}
 		return peek.Cmd, &msg, nil
 

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -380,6 +380,26 @@ type BrowserControlResultMessage struct {
 	Success bool `json:"success"`
 }
 
+type ChiefOfStaffResultMessage struct {
+	// ChiefOfStaff corresponds to the JSON schema field "chief_of_staff".
+	ChiefOfStaff bool `json:"chief_of_staff"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// PreviousSessionID corresponds to the JSON schema field "previous_session_id".
+	PreviousSessionID *string `json:"previous_session_id,omitempty,omitzero"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type ClearSessionsMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -2337,6 +2357,9 @@ type Session struct {
 	// Branch corresponds to the JSON schema field "branch".
 	Branch *string `json:"branch,omitempty,omitzero"`
 
+	// ChiefOfStaff corresponds to the JSON schema field "chief_of_staff".
+	ChiefOfStaff *bool `json:"chief_of_staff,omitempty,omitzero"`
+
 	// Directory corresponds to the JSON schema field "directory".
 	Directory string `json:"directory"`
 
@@ -2458,6 +2481,17 @@ type SessionsUpdatedMessage struct {
 
 	// Sessions corresponds to the JSON schema field "sessions".
 	Sessions []Session `json:"sessions,omitempty,omitzero"`
+}
+
+type SetChiefOfStaffMessage struct {
+	// ChiefOfStaff corresponds to the JSON schema field "chief_of_staff".
+	ChiefOfStaff bool `json:"chief_of_staff"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
 }
 
 type SetEndpointRemoteWebMessage struct {
@@ -2747,6 +2781,9 @@ type WebSocketEvent struct {
 	// Branches corresponds to the JSON schema field "branches".
 	Branches []Branch `json:"branches,omitempty,omitzero"`
 
+	// ChiefOfStaff corresponds to the JSON schema field "chief_of_staff".
+	ChiefOfStaff *bool `json:"chief_of_staff,omitempty,omitzero"`
+
 	// Cloned corresponds to the JSON schema field "cloned".
 	Cloned *bool `json:"cloned,omitempty,omitzero"`
 
@@ -2818,6 +2855,9 @@ type WebSocketEvent struct {
 
 	// Plugins corresponds to the JSON schema field "plugins".
 	Plugins []PluginInfo `json:"plugins,omitempty,omitzero"`
+
+	// PreviousSessionID corresponds to the JSON schema field "previous_session_id".
+	PreviousSessionID *string `json:"previous_session_id,omitempty,omitzero"`
 
 	// Priority corresponds to the JSON schema field "priority".
 	Priority *int `json:"priority,omitempty,omitzero"`

--- a/internal/protocol/parse_test.go
+++ b/internal/protocol/parse_test.go
@@ -349,3 +349,17 @@ func TestParseBrowserMessages(t *testing.T) {
 		}
 	})
 }
+
+func TestParseSetChiefOfStaff(t *testing.T) {
+	cmd, data, err := ParseMessage([]byte(`{"cmd":"set_chief_of_staff","session_id":"session-1","chief_of_staff":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd != CmdSetChiefOfStaff {
+		t.Fatalf("cmd = %q, want %q", cmd, CmdSetChiefOfStaff)
+	}
+	msg, ok := data.(*SetChiefOfStaffMessage)
+	if !ok || msg.SessionID != "session-1" || !msg.ChiefOfStaff {
+		t.Fatalf("message = %#v, want chief-of-staff assignment", data)
+	}
+}

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -140,6 +140,7 @@ model Session {
   state_updated_at: string;     // ISO timestamp, always set
   needs_review_after_long_run?: boolean; // True when a 5m+ run finished and awaits user visualization
   recoverable?: boolean;        // True when session can be recovered after daemon restart (agent has resumable conversation)
+  chief_of_staff?: boolean;     // True when this session holds the profile-wide coordinator role
   todos?: string[];             // Optional: can be empty/absent
   last_seen: string;            // ISO timestamp, always set
 }
@@ -1042,6 +1043,14 @@ model RenameWorkspaceMessage {
   title: string;
 }
 
+// Assign or remove the profile-wide chief-of-staff role. Assigning a new
+// session transfers the singleton role from the previous holder.
+model SetChiefOfStaffMessage {
+  cmd: "set_chief_of_staff";
+  session_id: string;
+  chief_of_staff: boolean;
+}
+
 // ============================================================================
 // Result/Event Messages (Daemon → Client)
 // ============================================================================
@@ -1146,6 +1155,15 @@ model RenameResultMessage {
   event: "rename_result";
   cmd: string;
   id: string;
+  success: boolean;
+  error?: string;
+}
+
+model ChiefOfStaffResultMessage {
+  event: "chief_of_staff_result";
+  session_id: string;
+  chief_of_staff: boolean;
+  previous_session_id?: string;
   success: boolean;
   error?: string;
 }
@@ -1741,6 +1759,8 @@ model WebSocketEvent {
   content?: string;
   runtime_id?: string;
   session_id?: string;
+  chief_of_staff?: boolean;
+  previous_session_id?: string;
   workspace_id?: string;
   session?: Session;
   sessions?: Session[];
@@ -1834,6 +1854,7 @@ alias DaemonEvent =
   | WorkspaceLayoutUpdatedMessage
   | WorkspaceLayoutActionResultMessage
   | RenameResultMessage
+  | ChiefOfStaffResultMessage
   | WorkspaceTileContentMessage
   | BrowserControlResponseMessage
   | PRsUpdatedMessage

--- a/internal/store/profile_roles_test.go
+++ b/internal/store/profile_roles_test.go
@@ -1,0 +1,35 @@
+package store
+
+import "testing"
+
+func TestStoreProfileRoleAssignmentAndConditionalClear(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if got := s.GetProfileRole("chief_of_staff"); got != "" {
+		t.Fatalf("initial role = %q, want empty", got)
+	}
+	if err := s.SetProfileRole("chief_of_staff", "session-a"); err != nil {
+		t.Fatalf("assign role: %v", err)
+	}
+	if got := s.GetProfileRole("chief_of_staff"); got != "session-a" {
+		t.Fatalf("role = %q, want session-a", got)
+	}
+
+	if err := s.SetProfileRole("chief_of_staff", "session-b"); err != nil {
+		t.Fatalf("transfer role: %v", err)
+	}
+	if err := s.ClearProfileRole("chief_of_staff", "session-a"); err != nil {
+		t.Fatalf("stale clear: %v", err)
+	}
+	if got := s.GetProfileRole("chief_of_staff"); got != "session-b" {
+		t.Fatalf("role after stale clear = %q, want session-b", got)
+	}
+
+	if err := s.ClearProfileRole("chief_of_staff", "session-b"); err != nil {
+		t.Fatalf("clear role: %v", err)
+	}
+	if got := s.GetProfileRole("chief_of_staff"); got != "" {
+		t.Fatalf("role after clear = %q, want empty", got)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -337,6 +337,12 @@ var migrations = []migration{
 			updated_at TEXT NOT NULL
 		);
 	`},
+	{43, "create profile roles table", `
+		CREATE TABLE IF NOT EXISTS profile_roles (
+			role TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL
+		);
+	`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -24,6 +24,7 @@ type Store struct {
 	sessions        map[string]*protocol.Session
 	agentDriverRuns map[string]AgentDriverReportCursor
 	agentMetadata   map[string]string
+	profileRoles    map[string]string
 	workspaces      map[string]workspacelayout.WorkspaceLayout
 	recentLocations map[string]*protocol.RecentLocation
 }
@@ -42,6 +43,7 @@ func New() *Store {
 			sessions:        make(map[string]*protocol.Session),
 			agentDriverRuns: make(map[string]AgentDriverReportCursor),
 			agentMetadata:   make(map[string]string),
+			profileRoles:    make(map[string]string),
 			workspaces:      make(map[string]workspacelayout.WorkspaceLayout),
 			recentLocations: make(map[string]*protocol.RecentLocation),
 		}
@@ -1565,6 +1567,85 @@ func (s *Store) GetAllSettings() map[string]string {
 		}
 	}
 	return result
+}
+
+// GetProfileRole returns the session assigned to a profile-wide role.
+func (s *Store) GetProfileRole(role string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	role = strings.TrimSpace(role)
+	if role == "" {
+		return ""
+	}
+	if s.db == nil {
+		return strings.TrimSpace(s.profileRoles[role])
+	}
+
+	var sessionID string
+	if err := s.db.QueryRow(
+		"SELECT session_id FROM profile_roles WHERE role = ?",
+		role,
+	).Scan(&sessionID); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(sessionID)
+}
+
+// SetProfileRole atomically assigns a profile-wide role to one session.
+func (s *Store) SetProfileRole(role, sessionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	role = strings.TrimSpace(role)
+	sessionID = strings.TrimSpace(sessionID)
+	if role == "" {
+		return fmt.Errorf("role cannot be empty")
+	}
+	if sessionID == "" {
+		return fmt.Errorf("session id cannot be empty")
+	}
+	if s.db == nil {
+		if s.profileRoles == nil {
+			s.profileRoles = make(map[string]string)
+		}
+		s.profileRoles[role] = sessionID
+		return nil
+	}
+
+	_, err := s.db.Exec(`
+		INSERT INTO profile_roles (role, session_id) VALUES (?, ?)
+		ON CONFLICT(role) DO UPDATE SET session_id = excluded.session_id`,
+		role,
+		sessionID,
+	)
+	return err
+}
+
+// ClearProfileRole removes a role only when the expected session still holds
+// it, so a stale client cannot clear a role that has since been transferred.
+func (s *Store) ClearProfileRole(role, sessionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	role = strings.TrimSpace(role)
+	sessionID = strings.TrimSpace(sessionID)
+	if role == "" {
+		return fmt.Errorf("role cannot be empty")
+	}
+	if s.db == nil {
+		if strings.TrimSpace(s.profileRoles[role]) == sessionID {
+			delete(s.profileRoles, role)
+		}
+		return nil
+	}
+
+	_, err := s.db.Exec(
+		"DELETE FROM profile_roles WHERE role = ? AND session_id = ?",
+		role,
+		sessionID,
+	)
+	return err
 }
 
 // Recent Locations methods


### PR DESCRIPTION
## Intent

Establish the first chief-of-staff primitive before tracked dispatches: one running session per attn profile can be designated as the coordinator, and users can move or remove that role without stopping either session.

## Summary

- persist a singleton `chief_of_staff` profile role and project it onto local and remote session snapshots
- add a request/result WebSocket command with protocol version 92 and cleanup when local sessions are removed
- replace per-session hover actions with a compact action menu containing rename, chief role, reload, and close
- confirm transfers explicitly and show the active role in the sidebar and dashboard
- add packaged-app automation controls plus daemon, store, protocol, socket, sidebar, dashboard, and dialog coverage

## Test plan

- [x] `go test ./...`
- [x] `pnpm --dir app test` (663 tests)
- [x] `pnpm --dir app exec tsc --noEmit`
- [x] `pnpm --dir app run build`
- [x] packaged attn-dev: assign the first role through the sidebar menu
- [x] packaged attn-dev: request and confirm transfer; verify exactly one badge moves
- [x] packaged attn-dev: restart the dev daemon and verify the role persists
- [x] packaged attn-dev: remove the role and verify all badges disappear
- [x] install the production app with `make install`

## Out of scope

Tracked chief-of-staff dispatches, status/reporting, and agent communication remain the next phase.