### PR TITLE
feat(chief-of-staff): add structured dispatch coordination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Claude and Codex receive workspace-context guidance without cluttering their terminals.** attn gives each session a local checkout and concise hidden instructions to read it, keep durable goals and decisions current, publish edits, and reconcile revision conflicts without copying the shared context itself into the prompt.
 - **Promote one running session to chief of staff.** Session actions in the sidebar can assign, transfer, or remove the profile-wide role, with confirmation before replacing the current chief and clear badges in the sidebar and dashboard.
-- **Chiefs can track delegated agents and receive reports.** Delegations started by the current chief are recorded automatically with live session status and the latest agent update. `attn dispatch list` gives the chief a machine-readable view, delegated agents can report concise progress or submit a longer report file, and the dashboard provides a click-through view of current and previous chiefs' dispatches.
+- **Chiefs can track delegated work separately from agent runtime state.** Delegated agents can attach structured work state, next ownership, constraints, artifact-bound verification, and one decision request to the existing narrative report. Chiefs can resolve that request durably, agents can read the response with `attn dispatch status`, and the dashboard highlights actionable work without showing the full brief.
 
 ### Changed
 - **Workspace context guidance is safer and less noisy.** Agents now publish only durable shared changes, keep each fact in one appropriate section, treat copied context as untrusted data, and save local edits before refreshing a conflicting revision.
+- **Delegation guidance distinguishes visible collaborators from internal subagents.** Agents use attn delegation for full interactive sessions the user wants to inspect and steer, while internal research, adversarial analysis, verification, and parallel reasoning default to native subagents.
 
 ### Changed
 - **Terminals use less graphics memory.** Every live terminal used to preallocate a large fixed GPU texture to cache rendered characters. It now starts small and grows only if a session actually displays many distinct characters (such as heavy CJK or emoji output). Text looks identical, and with several sessions open this frees roughly 90 MB of graphics memory.

--- a/app/src/components/Dashboard.css
+++ b/app/src/components/Dashboard.css
@@ -492,6 +492,28 @@
   color: var(--color-text-tertiary);
 }
 
+.dispatch-coordination {
+  align-items: center;
+  color: var(--color-text-dimmed);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: var(--font-size-xs);
+  gap: 6px;
+}
+
+.dispatch-work-state,
+.dispatch-actionable {
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 2px 6px;
+}
+
+.dispatch-actionable {
+  border-color: #f59e0b;
+  color: #f59e0b;
+  font-weight: 600;
+}
+
 .dispatch-open-hint {
   align-self: center;
   color: var(--color-text-dimmed);

--- a/app/src/components/Dashboard.test.tsx
+++ b/app/src/components/Dashboard.test.tsx
@@ -208,4 +208,63 @@ describe('Dashboard sessions', () => {
     expect(screen.queryByTestId('chief-dispatch-dispatch-closed')).not.toBeInTheDocument();
     expect(screen.getByText('No delegated work yet.')).toBeInTheDocument();
   });
+
+  it('renders actionable structured coordination without showing the full brief', () => {
+    daemonStoreState.chiefOfStaffDispatches = [{
+      id: 'dispatch-structured',
+      chief_session_id: 'chief-1',
+      session_id: 'worker-1',
+      workspace_id: 'workspace-1',
+      brief: 'Long delegation brief that should not appear in the concise structured view.',
+      label: 'Freshness gate',
+      agent: 'codex',
+      directory: '/repo/a',
+      status: 'idle',
+      status_since: '2026-06-09T10:00:00Z',
+      latest_report: 'Human narrative with additional implementation detail.',
+      reported_at: new Date(Date.now() - 120_000).toISOString(),
+      concise_summary: 'Core freshness gate implemented locally',
+      actionable: true,
+      structured_report: {
+        report_type: 'blocker',
+        summary: 'Core freshness gate implemented locally',
+        work_state: 'needs_input',
+        next_actor: 'team',
+        next_action: 'Decide the AisNoOperationV1 event contract',
+        request: {
+          question: 'Should the worker emit AisNoOperationV1?',
+          expected_responder: 'team',
+          status: 'pending',
+        },
+        reported_at: '2026-06-09T10:02:00Z',
+      },
+      created_at: '2026-06-09T10:00:00Z',
+      updated_at: '2026-06-09T10:02:00Z',
+    }];
+    render(
+      <Dashboard
+        sessions={[
+          { id: 'chief-1', label: 'planner', state: 'working', cwd: '/repo/a', chiefOfStaff: true },
+          { id: 'worker-1', label: 'freshness-worker', state: 'idle', cwd: '/repo/a' },
+        ]}
+        prs={[]}
+        isLoading={false}
+        onSelectSession={vi.fn()}
+        onNewSession={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />
+    );
+
+    const dispatch = screen.getByTestId('chief-dispatch-dispatch-structured');
+    expect(dispatch).toHaveAttribute('data-state', 'idle');
+    expect(dispatch).toHaveAttribute('data-actionable', 'true');
+    expect(screen.getByText('Core freshness gate implemented locally')).toBeInTheDocument();
+    expect(screen.getByText('Work: needs input')).toBeInTheDocument();
+    expect(screen.getByText('Action needed')).toBeInTheDocument();
+    expect(screen.getByText('Next: team')).toBeInTheDocument();
+    expect(screen.getByText('Decide the AisNoOperationV1 event contract')).toBeInTheDocument();
+    expect(screen.getByText('Should the worker emit AisNoOperationV1?')).toBeInTheDocument();
+    expect(screen.getByText(/Reported .* ago/)).toBeInTheDocument();
+    expect(screen.queryByText(/Long delegation brief/)).not.toBeInTheDocument();
+  });
 });

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -50,6 +50,19 @@ interface DashboardProps {
   onMutedGroupClick?: () => void;
 }
 
+function formatDispatchAge(reportedAt?: string): string | null {
+  if (!reportedAt) return null;
+  const timestamp = Date.parse(reportedAt);
+  if (Number.isNaN(timestamp)) return null;
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
 export function Dashboard({
   sessions,
   dispatchSessions = sessions,
@@ -122,8 +135,12 @@ export function Dashboard({
   const renderDispatch = (dispatch: typeof chiefOfStaffDispatches[number]) => {
     const target = dispatchSessions.find((session) => session.id === dispatch.session_id);
     const state = target?.state ?? normalizeSessionState(dispatch.status === 'closed' ? 'unknown' : dispatch.status);
-    const summary = dispatch.latest_report || dispatch.brief;
+    const structured = dispatch.structured_report;
+    const summary = dispatch.concise_summary || structured?.summary || dispatch.latest_report || dispatch.brief;
     const statusLabel = target ? state.replace('_', ' ') : 'closed';
+    const workState = structured?.work_state.replace(/_/g, ' ');
+    const reportAge = formatDispatchAge(dispatch.reported_at);
+    const request = structured?.request;
     return (
       <button
         type="button"
@@ -131,6 +148,7 @@ export function Dashboard({
         className="dispatch-row"
         data-testid={`chief-dispatch-${dispatch.id}`}
         data-state={target ? state : 'closed'}
+        data-actionable={dispatch.actionable ? 'true' : 'false'}
         disabled={!target}
         onClick={() => target && onSelectSession(target.id)}
       >
@@ -140,6 +158,12 @@ export function Dashboard({
             <span>{dispatch.agent} agent</span>
             <span aria-hidden="true">·</span>
             <span>Agent status: {statusLabel}</span>
+            {reportAge && (
+              <>
+                <span aria-hidden="true">·</span>
+                <span>Reported {reportAge}</span>
+              </>
+            )}
           </span>
           <span className="dispatch-summary-label">Task</span>
           <span className="dispatch-title">
@@ -151,6 +175,29 @@ export function Dashboard({
           <span className={`dispatch-summary ${dispatch.latest_report ? 'reported' : ''}`}>
             {summary}
           </span>
+          {structured && (
+            <span className="dispatch-coordination">
+              <span className="dispatch-work-state">Work: {workState}</span>
+              {dispatch.actionable && <span className="dispatch-actionable">Action needed</span>}
+              {structured.next_actor && <span>Next: {structured.next_actor}</span>}
+            </span>
+          )}
+          {structured?.next_action && (
+            <>
+              <span className="dispatch-summary-label">Next action</span>
+              <span className="dispatch-summary">{structured.next_action}</span>
+            </>
+          )}
+          {request && (
+            <>
+              <span className="dispatch-summary-label">
+                {request.status === 'pending' ? 'Decision needed' : 'Decision resolved'}
+              </span>
+              <span className="dispatch-summary">
+                {request.status === 'pending' ? request.question : request.response || request.question}
+              </span>
+            </>
+          )}
         </span>
         <span className="dispatch-open-hint" aria-hidden="true">›</span>
       </button>

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -649,7 +649,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [
           {
             id: 'agent-1',
@@ -735,7 +735,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [],
         workspaces: [{
           id: 'workspace-1',
@@ -819,7 +819,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -904,7 +904,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1036,7 +1036,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1102,7 +1102,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1166,7 +1166,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1228,7 +1228,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1288,7 +1288,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [],
         workspaces: [{
           id: 'workspace-1',
@@ -1388,7 +1388,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     };
     const initialState = {
       event: 'initial_state',
-      protocol_version: '93',
+      protocol_version: '94',
       sessions: [],
       workspaces: [workspace],
       prs: [],
@@ -1465,7 +1465,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1559,7 +1559,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1658,7 +1658,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1743,7 +1743,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -1822,7 +1822,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -1892,7 +1892,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',
@@ -2053,7 +2053,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -2128,7 +2128,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '93',
+        protocol_version: '94',
         sessions: [],
         workspaces: [],
         prs: [],

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -164,7 +164,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '93';
+const PROTOCOL_VERSION = '94';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReportDispatchMessage, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReportDispatchMessage, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -46,6 +46,13 @@
 //   const deleteWorktreeResultMessage = Convert.toDeleteWorktreeResultMessage(json);
 //   const detachSessionMessage = Convert.toDetachSessionMessage(json);
 //   const directoryEntry = Convert.toDirectoryEntry(json);
+//   const dispatchArtifact = Convert.toDispatchArtifact(json);
+//   const dispatchDecisionRequest = Convert.toDispatchDecisionRequest(json);
+//   const dispatchReport = Convert.toDispatchReport(json);
+//   const dispatchReportType = Convert.toDispatchReportType(json);
+//   const dispatchRequestStatus = Convert.toDispatchRequestStatus(json);
+//   const dispatchVerification = Convert.toDispatchVerification(json);
+//   const dispatchWorkState = Convert.toDispatchWorkState(json);
 //   const endpointActionResultMessage = Convert.toEndpointActionResultMessage(json);
 //   const endpointCapabilities = Convert.toEndpointCapabilities(json);
 //   const endpointInfo = Convert.toEndpointInfo(json);
@@ -63,6 +70,7 @@
 //   const getCommentsResultMessage = Convert.toGetCommentsResultMessage(json);
 //   const getDefaultBranchMessage = Convert.toGetDefaultBranchMessage(json);
 //   const getDefaultBranchResultMessage = Convert.toGetDefaultBranchResultMessage(json);
+//   const getDispatchMessage = Convert.toGetDispatchMessage(json);
 //   const getFileDiffMessage = Convert.toGetFileDiffMessage(json);
 //   const getRecentLocationsMessage = Convert.toGetRecentLocationsMessage(json);
 //   const getRepoInfoMessage = Convert.toGetRepoInfoMessage(json);
@@ -145,6 +153,7 @@
 //   const reposUpdatedMessage = Convert.toReposUpdatedMessage(json);
 //   const resolveCommentMessage = Convert.toResolveCommentMessage(json);
 //   const resolveCommentResultMessage = Convert.toResolveCommentResultMessage(json);
+//   const resolveDispatchRequestMessage = Convert.toResolveDispatchRequestMessage(json);
 //   const response = Convert.toResponse(json);
 //   const reviewComment = Convert.toReviewComment(json);
 //   const reviewLoopDecision = Convert.toReviewLoopDecision(json);
@@ -588,22 +597,94 @@ export enum BrowserControlResultMessageCmd {
 }
 
 export interface ChiefOfStaffDispatch {
-    agent:            string;
-    branch?:          string;
-    brief:            string;
-    chief_session_id: string;
-    created_at:       string;
-    directory:        string;
-    id:               string;
-    label:            string;
-    latest_report?:   string;
-    reported_at?:     string;
-    session_id:       string;
-    status:           string;
-    status_since:     string;
-    updated_at:       string;
-    workspace_id:     string;
+    actionable?:        boolean;
+    agent:              string;
+    branch?:            string;
+    brief:              string;
+    chief_session_id:   string;
+    concise_summary?:   string;
+    created_at:         string;
+    directory:          string;
+    id:                 string;
+    label:              string;
+    latest_report?:     string;
+    reported_at?:       string;
+    session_id:         string;
+    status:             string;
+    status_since:       string;
+    structured_report?: Report;
+    updated_at:         string;
+    workspace_id:       string;
     [property: string]: any;
+}
+
+export interface Report {
+    artifact?:        Artifact;
+    constraints?:     string[];
+    next_action?:     string;
+    next_actor?:      string;
+    remaining_scope?: string[];
+    report_type:      DispatchReportType;
+    reported_at:      string;
+    request?:         Request;
+    summary:          string;
+    verification?:    VerificationElement[];
+    work_state:       DispatchWorkState;
+    [property: string]: any;
+}
+
+export interface Artifact {
+    branch?:       string;
+    description?:  string;
+    dirty?:        boolean;
+    identity:      string;
+    revision?:     string;
+    workspace_id?: string;
+    [property: string]: any;
+}
+
+export enum DispatchReportType {
+    Blocker = "blocker",
+    Completion = "completion",
+    Failure = "failure",
+    Handoff = "handoff",
+    Progress = "progress",
+}
+
+export interface Request {
+    consequence?:       string;
+    expected_responder: string;
+    question:           string;
+    recommendation?:    string;
+    resolution_link?:   string;
+    responded_at?:      string;
+    responded_by?:      string;
+    response?:          string;
+    status:             DispatchRequestStatus;
+    [property: string]: any;
+}
+
+export enum DispatchRequestStatus {
+    Pending = "pending",
+    Resolved = "resolved",
+}
+
+export interface VerificationElement {
+    actor:             string;
+    artifact_identity: string;
+    current?:          boolean;
+    result:            string;
+    target:            string;
+    timestamp:         string;
+    [property: string]: any;
+}
+
+export enum DispatchWorkState {
+    Completed = "completed",
+    Failed = "failed",
+    InProgress = "in_progress",
+    NeedsInput = "needs_input",
+    ReadyForReview = "ready_for_review",
 }
 
 export interface ChiefOfStaffDispatchesUpdatedMessage {
@@ -613,21 +694,24 @@ export interface ChiefOfStaffDispatchesUpdatedMessage {
 }
 
 export interface ChiefOfStaffDispatchElement {
-    agent:            string;
-    branch?:          string;
-    brief:            string;
-    chief_session_id: string;
-    created_at:       string;
-    directory:        string;
-    id:               string;
-    label:            string;
-    latest_report?:   string;
-    reported_at?:     string;
-    session_id:       string;
-    status:           string;
-    status_since:     string;
-    updated_at:       string;
-    workspace_id:     string;
+    actionable?:        boolean;
+    agent:              string;
+    branch?:            string;
+    brief:              string;
+    chief_session_id:   string;
+    concise_summary?:   string;
+    created_at:         string;
+    directory:          string;
+    id:                 string;
+    label:              string;
+    latest_report?:     string;
+    reported_at?:       string;
+    session_id:         string;
+    status:             string;
+    status_since:       string;
+    structured_report?: Report;
+    updated_at:         string;
+    workspace_id:       string;
     [property: string]: any;
 }
 
@@ -884,6 +968,54 @@ export enum DetachSessionMessageCmd {
 export interface DirectoryEntry {
     name: string;
     path: string;
+    [property: string]: any;
+}
+
+export interface DispatchArtifact {
+    branch?:       string;
+    description?:  string;
+    dirty?:        boolean;
+    identity:      string;
+    revision?:     string;
+    workspace_id?: string;
+    [property: string]: any;
+}
+
+export interface DispatchDecisionRequest {
+    consequence?:       string;
+    expected_responder: string;
+    question:           string;
+    recommendation?:    string;
+    resolution_link?:   string;
+    responded_at?:      string;
+    responded_by?:      string;
+    response?:          string;
+    status:             DispatchRequestStatus;
+    [property: string]: any;
+}
+
+export interface DispatchReport {
+    artifact?:        Artifact;
+    constraints?:     string[];
+    next_action?:     string;
+    next_actor?:      string;
+    remaining_scope?: string[];
+    report_type:      DispatchReportType;
+    reported_at:      string;
+    request?:         Request;
+    summary:          string;
+    verification?:    VerificationElement[];
+    work_state:       DispatchWorkState;
+    [property: string]: any;
+}
+
+export interface DispatchVerification {
+    actor:             string;
+    artifact_identity: string;
+    current?:          boolean;
+    result:            string;
+    target:            string;
+    timestamp:         string;
     [property: string]: any;
 }
 
@@ -1153,6 +1285,16 @@ export interface GetDefaultBranchResultMessage {
 
 export enum GetDefaultBranchResultMessageEvent {
     GetDefaultBranchResult = "get_default_branch_result",
+}
+
+export interface GetDispatchMessage {
+    cmd:               GetDispatchMessageCmd;
+    source_session_id: string;
+    [property: string]: any;
+}
+
+export enum GetDispatchMessageCmd {
+    GetDispatch = "get_dispatch",
 }
 
 export interface GetFileDiffMessage {
@@ -2162,9 +2304,10 @@ export interface RepoState {
 }
 
 export interface ReportDispatchMessage {
-    cmd:               ReportDispatchMessageCmd;
-    report:            string;
-    source_session_id: string;
+    cmd:                ReportDispatchMessageCmd;
+    report:             string;
+    source_session_id:  string;
+    structured_report?: Report;
     [property: string]: any;
 }
 
@@ -2202,6 +2345,19 @@ export interface ResolveCommentResultMessage {
 
 export enum ResolveCommentResultMessageEvent {
     ResolveCommentResult = "resolve_comment_result",
+}
+
+export interface ResolveDispatchRequestMessage {
+    cmd:               ResolveDispatchRequestMessageCmd;
+    dispatch_id:       string;
+    resolution_link?:  string;
+    response:          string;
+    source_session_id: string;
+    [property: string]: any;
+}
+
+export enum ResolveDispatchRequestMessageCmd {
+    ResolveDispatchRequest = "resolve_dispatch_request",
 }
 
 export interface Response {
@@ -3652,6 +3808,62 @@ export class Convert {
         return JSON.stringify(uncast(value, r("DirectoryEntry")), null, 2);
     }
 
+    public static toDispatchArtifact(json: string): DispatchArtifact {
+        return cast(JSON.parse(json), r("DispatchArtifact"));
+    }
+
+    public static dispatchArtifactToJson(value: DispatchArtifact): string {
+        return JSON.stringify(uncast(value, r("DispatchArtifact")), null, 2);
+    }
+
+    public static toDispatchDecisionRequest(json: string): DispatchDecisionRequest {
+        return cast(JSON.parse(json), r("DispatchDecisionRequest"));
+    }
+
+    public static dispatchDecisionRequestToJson(value: DispatchDecisionRequest): string {
+        return JSON.stringify(uncast(value, r("DispatchDecisionRequest")), null, 2);
+    }
+
+    public static toDispatchReport(json: string): DispatchReport {
+        return cast(JSON.parse(json), r("DispatchReport"));
+    }
+
+    public static dispatchReportToJson(value: DispatchReport): string {
+        return JSON.stringify(uncast(value, r("DispatchReport")), null, 2);
+    }
+
+    public static toDispatchReportType(json: string): DispatchReportType {
+        return cast(JSON.parse(json), r("DispatchReportType"));
+    }
+
+    public static dispatchReportTypeToJson(value: DispatchReportType): string {
+        return JSON.stringify(uncast(value, r("DispatchReportType")), null, 2);
+    }
+
+    public static toDispatchRequestStatus(json: string): DispatchRequestStatus {
+        return cast(JSON.parse(json), r("DispatchRequestStatus"));
+    }
+
+    public static dispatchRequestStatusToJson(value: DispatchRequestStatus): string {
+        return JSON.stringify(uncast(value, r("DispatchRequestStatus")), null, 2);
+    }
+
+    public static toDispatchVerification(json: string): DispatchVerification {
+        return cast(JSON.parse(json), r("DispatchVerification"));
+    }
+
+    public static dispatchVerificationToJson(value: DispatchVerification): string {
+        return JSON.stringify(uncast(value, r("DispatchVerification")), null, 2);
+    }
+
+    public static toDispatchWorkState(json: string): DispatchWorkState {
+        return cast(JSON.parse(json), r("DispatchWorkState"));
+    }
+
+    public static dispatchWorkStateToJson(value: DispatchWorkState): string {
+        return JSON.stringify(uncast(value, r("DispatchWorkState")), null, 2);
+    }
+
     public static toEndpointActionResultMessage(json: string): EndpointActionResultMessage {
         return cast(JSON.parse(json), r("EndpointActionResultMessage"));
     }
@@ -3786,6 +3998,14 @@ export class Convert {
 
     public static getDefaultBranchResultMessageToJson(value: GetDefaultBranchResultMessage): string {
         return JSON.stringify(uncast(value, r("GetDefaultBranchResultMessage")), null, 2);
+    }
+
+    public static toGetDispatchMessage(json: string): GetDispatchMessage {
+        return cast(JSON.parse(json), r("GetDispatchMessage"));
+    }
+
+    public static getDispatchMessageToJson(value: GetDispatchMessage): string {
+        return JSON.stringify(uncast(value, r("GetDispatchMessage")), null, 2);
     }
 
     public static toGetFileDiffMessage(json: string): GetFileDiffMessage {
@@ -4442,6 +4662,14 @@ export class Convert {
 
     public static resolveCommentResultMessageToJson(value: ResolveCommentResultMessage): string {
         return JSON.stringify(uncast(value, r("ResolveCommentResultMessage")), null, 2);
+    }
+
+    public static toResolveDispatchRequestMessage(json: string): ResolveDispatchRequestMessage {
+        return cast(JSON.parse(json), r("ResolveDispatchRequestMessage"));
+    }
+
+    public static resolveDispatchRequestMessageToJson(value: ResolveDispatchRequestMessage): string {
+        return JSON.stringify(uncast(value, r("ResolveDispatchRequestMessage")), null, 2);
     }
 
     public static toResponse(json: string): Response {
@@ -5489,10 +5717,12 @@ const typeMap: any = {
         { json: "success", js: "success", typ: true },
     ], "any"),
     "ChiefOfStaffDispatch": o([
+        { json: "actionable", js: "actionable", typ: u(undefined, true) },
         { json: "agent", js: "agent", typ: "" },
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "brief", js: "brief", typ: "" },
         { json: "chief_session_id", js: "chief_session_id", typ: "" },
+        { json: "concise_summary", js: "concise_summary", typ: u(undefined, "") },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "directory", js: "directory", typ: "" },
         { json: "id", js: "id", typ: "" },
@@ -5502,18 +5732,61 @@ const typeMap: any = {
         { json: "session_id", js: "session_id", typ: "" },
         { json: "status", js: "status", typ: "" },
         { json: "status_since", js: "status_since", typ: "" },
+        { json: "structured_report", js: "structured_report", typ: u(undefined, r("Report")) },
         { json: "updated_at", js: "updated_at", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
+    "Report": o([
+        { json: "artifact", js: "artifact", typ: u(undefined, r("Artifact")) },
+        { json: "constraints", js: "constraints", typ: u(undefined, a("")) },
+        { json: "next_action", js: "next_action", typ: u(undefined, "") },
+        { json: "next_actor", js: "next_actor", typ: u(undefined, "") },
+        { json: "remaining_scope", js: "remaining_scope", typ: u(undefined, a("")) },
+        { json: "report_type", js: "report_type", typ: r("DispatchReportType") },
+        { json: "reported_at", js: "reported_at", typ: "" },
+        { json: "request", js: "request", typ: u(undefined, r("Request")) },
+        { json: "summary", js: "summary", typ: "" },
+        { json: "verification", js: "verification", typ: u(undefined, a(r("VerificationElement"))) },
+        { json: "work_state", js: "work_state", typ: r("DispatchWorkState") },
+    ], "any"),
+    "Artifact": o([
+        { json: "branch", js: "branch", typ: u(undefined, "") },
+        { json: "description", js: "description", typ: u(undefined, "") },
+        { json: "dirty", js: "dirty", typ: u(undefined, true) },
+        { json: "identity", js: "identity", typ: "" },
+        { json: "revision", js: "revision", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
+    ], "any"),
+    "Request": o([
+        { json: "consequence", js: "consequence", typ: u(undefined, "") },
+        { json: "expected_responder", js: "expected_responder", typ: "" },
+        { json: "question", js: "question", typ: "" },
+        { json: "recommendation", js: "recommendation", typ: u(undefined, "") },
+        { json: "resolution_link", js: "resolution_link", typ: u(undefined, "") },
+        { json: "responded_at", js: "responded_at", typ: u(undefined, "") },
+        { json: "responded_by", js: "responded_by", typ: u(undefined, "") },
+        { json: "response", js: "response", typ: u(undefined, "") },
+        { json: "status", js: "status", typ: r("DispatchRequestStatus") },
+    ], "any"),
+    "VerificationElement": o([
+        { json: "actor", js: "actor", typ: "" },
+        { json: "artifact_identity", js: "artifact_identity", typ: "" },
+        { json: "current", js: "current", typ: u(undefined, true) },
+        { json: "result", js: "result", typ: "" },
+        { json: "target", js: "target", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: "" },
     ], "any"),
     "ChiefOfStaffDispatchesUpdatedMessage": o([
         { json: "dispatches", js: "dispatches", typ: a(r("ChiefOfStaffDispatchElement")) },
         { json: "event", js: "event", typ: r("ChiefOfStaffDispatchesUpdatedMessageEvent") },
     ], "any"),
     "ChiefOfStaffDispatchElement": o([
+        { json: "actionable", js: "actionable", typ: u(undefined, true) },
         { json: "agent", js: "agent", typ: "" },
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "brief", js: "brief", typ: "" },
         { json: "chief_session_id", js: "chief_session_id", typ: "" },
+        { json: "concise_summary", js: "concise_summary", typ: u(undefined, "") },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "directory", js: "directory", typ: "" },
         { json: "id", js: "id", typ: "" },
@@ -5523,6 +5796,7 @@ const typeMap: any = {
         { json: "session_id", js: "session_id", typ: "" },
         { json: "status", js: "status", typ: "" },
         { json: "status_since", js: "status_since", typ: "" },
+        { json: "structured_report", js: "structured_report", typ: u(undefined, r("Report")) },
         { json: "updated_at", js: "updated_at", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
@@ -5662,6 +5936,46 @@ const typeMap: any = {
     "DirectoryEntry": o([
         { json: "name", js: "name", typ: "" },
         { json: "path", js: "path", typ: "" },
+    ], "any"),
+    "DispatchArtifact": o([
+        { json: "branch", js: "branch", typ: u(undefined, "") },
+        { json: "description", js: "description", typ: u(undefined, "") },
+        { json: "dirty", js: "dirty", typ: u(undefined, true) },
+        { json: "identity", js: "identity", typ: "" },
+        { json: "revision", js: "revision", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
+    ], "any"),
+    "DispatchDecisionRequest": o([
+        { json: "consequence", js: "consequence", typ: u(undefined, "") },
+        { json: "expected_responder", js: "expected_responder", typ: "" },
+        { json: "question", js: "question", typ: "" },
+        { json: "recommendation", js: "recommendation", typ: u(undefined, "") },
+        { json: "resolution_link", js: "resolution_link", typ: u(undefined, "") },
+        { json: "responded_at", js: "responded_at", typ: u(undefined, "") },
+        { json: "responded_by", js: "responded_by", typ: u(undefined, "") },
+        { json: "response", js: "response", typ: u(undefined, "") },
+        { json: "status", js: "status", typ: r("DispatchRequestStatus") },
+    ], "any"),
+    "DispatchReport": o([
+        { json: "artifact", js: "artifact", typ: u(undefined, r("Artifact")) },
+        { json: "constraints", js: "constraints", typ: u(undefined, a("")) },
+        { json: "next_action", js: "next_action", typ: u(undefined, "") },
+        { json: "next_actor", js: "next_actor", typ: u(undefined, "") },
+        { json: "remaining_scope", js: "remaining_scope", typ: u(undefined, a("")) },
+        { json: "report_type", js: "report_type", typ: r("DispatchReportType") },
+        { json: "reported_at", js: "reported_at", typ: "" },
+        { json: "request", js: "request", typ: u(undefined, r("Request")) },
+        { json: "summary", js: "summary", typ: "" },
+        { json: "verification", js: "verification", typ: u(undefined, a(r("VerificationElement"))) },
+        { json: "work_state", js: "work_state", typ: r("DispatchWorkState") },
+    ], "any"),
+    "DispatchVerification": o([
+        { json: "actor", js: "actor", typ: "" },
+        { json: "artifact_identity", js: "artifact_identity", typ: "" },
+        { json: "current", js: "current", typ: u(undefined, true) },
+        { json: "result", js: "result", typ: "" },
+        { json: "target", js: "target", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: "" },
     ], "any"),
     "EndpointActionResultMessage": o([
         { json: "action", js: "action", typ: "" },
@@ -5819,6 +6133,10 @@ const typeMap: any = {
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("GetDefaultBranchResultMessageEvent") },
         { json: "success", js: "success", typ: true },
+    ], "any"),
+    "GetDispatchMessage": o([
+        { json: "cmd", js: "cmd", typ: r("GetDispatchMessageCmd") },
+        { json: "source_session_id", js: "source_session_id", typ: "" },
     ], "any"),
     "GetFileDiffMessage": o([
         { json: "base_ref", js: "base_ref", typ: u(undefined, "") },
@@ -6374,6 +6692,7 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("ReportDispatchMessageCmd") },
         { json: "report", js: "report", typ: "" },
         { json: "source_session_id", js: "source_session_id", typ: "" },
+        { json: "structured_report", js: "structured_report", typ: u(undefined, r("Report")) },
     ], "any"),
     "ReposUpdatedMessage": o([
         { json: "event", js: "event", typ: r("ReposUpdatedMessageEvent") },
@@ -6388,6 +6707,13 @@ const typeMap: any = {
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("ResolveCommentResultMessageEvent") },
         { json: "success", js: "success", typ: true },
+    ], "any"),
+    "ResolveDispatchRequestMessage": o([
+        { json: "cmd", js: "cmd", typ: r("ResolveDispatchRequestMessageCmd") },
+        { json: "dispatch_id", js: "dispatch_id", typ: "" },
+        { json: "resolution_link", js: "resolution_link", typ: u(undefined, "") },
+        { json: "response", js: "response", typ: "" },
+        { json: "source_session_id", js: "source_session_id", typ: "" },
     ], "any"),
     "Response": o([
         { json: "authors", js: "authors", typ: u(undefined, a(r("AuthorElement"))) },
@@ -7107,6 +7433,24 @@ const typeMap: any = {
     "BrowserControlResultMessageCmd": [
         "browser_control_result",
     ],
+    "DispatchReportType": [
+        "blocker",
+        "completion",
+        "failure",
+        "handoff",
+        "progress",
+    ],
+    "DispatchRequestStatus": [
+        "pending",
+        "resolved",
+    ],
+    "DispatchWorkState": [
+        "completed",
+        "failed",
+        "in_progress",
+        "needs_input",
+        "ready_for_review",
+    ],
     "ChiefOfStaffDispatchesUpdatedMessageEvent": [
         "chief_of_staff_dispatches_updated",
     ],
@@ -7217,6 +7561,9 @@ const typeMap: any = {
     ],
     "GetDefaultBranchResultMessageEvent": [
         "get_default_branch_result",
+    ],
+    "GetDispatchMessageCmd": [
+        "get_dispatch",
     ],
     "GetFileDiffMessageCmd": [
         "get_file_diff",
@@ -7441,6 +7788,9 @@ const typeMap: any = {
     ],
     "ResolveCommentResultMessageEvent": [
         "resolve_comment_result",
+    ],
+    "ResolveDispatchRequestMessageCmd": [
+        "resolve_dispatch_request",
     ],
     "ReviewLoopDecision": [
         "continue",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -473,14 +473,43 @@ func runDispatch() {
 		}
 		printJSON(dispatches)
 	case "report":
-		sourceSessionID, report, err := parseDispatchReportArgs(os.Args[3:])
+		sourceSessionID, report, structuredReport, err := parseDispatchReportArgs(os.Args[3:])
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "dispatch report: %v\n", err)
 			os.Exit(2)
 		}
-		dispatch, err := client.New("").ReportDispatch(sourceSessionID, report)
+		dispatch, err := client.New("").ReportDispatchEnvelope(sourceSessionID, report, structuredReport)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "dispatch report: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(dispatch)
+	case "status":
+		sourceSessionID, err := parseDispatchSourceSession(os.Args[3:])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "dispatch status: %v\n", err)
+			os.Exit(2)
+		}
+		dispatch, err := client.New("").GetDispatch(sourceSessionID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "dispatch status: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(dispatch)
+	case "resolve":
+		sourceSessionID, dispatchID, response, resolutionLink, err := parseDispatchResolveArgs(os.Args[3:])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "dispatch resolve: %v\n", err)
+			os.Exit(2)
+		}
+		dispatch, err := client.New("").ResolveDispatchRequest(
+			sourceSessionID,
+			dispatchID,
+			response,
+			resolutionLink,
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "dispatch resolve: %v\n", err)
 			os.Exit(1)
 		}
 		printJSON(dispatch)
@@ -497,6 +526,10 @@ func writeDispatchHelp(w io.Writer) {
 commands:
   list [--session <id>]                          list work dispatched by this chief
   report (--message <text> | --file <path>)     report progress from a dispatched agent
+         [--coordination-file <json>]
+  status [--session <id>]                        show this delegated session's report and response
+  resolve --dispatch <id>                        answer the active decision request
+          (--response <text> | --file <path>) [--link <url>] [--session <id>]
 
 The session defaults to ATTN_SESSION_ID.
 `)
@@ -522,40 +555,94 @@ func parseDispatchSourceSession(args []string) (string, error) {
 	return source, nil
 }
 
-func parseDispatchReportArgs(args []string) (string, string, error) {
+func parseDispatchReportArgs(args []string) (string, string, *protocol.DispatchReport, error) {
 	fs := flag.NewFlagSet("dispatch report", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	sessionID := fs.String("session", "", "session id (defaults to ATTN_SESSION_ID)")
 	message := fs.String("message", "", "concise progress or completion update")
 	reportFile := fs.String("file", "", "file containing a progress or completion update")
+	coordinationFile := fs.String("coordination-file", "", "JSON file containing structured coordination fields")
 	if err := fs.Parse(args); err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 	if fs.NArg() != 0 {
-		return "", "", fmt.Errorf("unexpected arguments: %v", fs.Args())
+		return "", "", nil, fmt.Errorf("unexpected arguments: %v", fs.Args())
 	}
 	source := strings.TrimSpace(*sessionID)
 	if source == "" {
 		source = strings.TrimSpace(os.Getenv("ATTN_SESSION_ID"))
 	}
 	if source == "" {
-		return "", "", errors.New("no session; run inside attn or pass --session")
+		return "", "", nil, errors.New("no session; run inside attn or pass --session")
 	}
 	if strings.TrimSpace(*message) != "" && strings.TrimSpace(*reportFile) != "" {
-		return "", "", errors.New("pass only one of --message or --file")
+		return "", "", nil, errors.New("pass only one of --message or --file")
 	}
 	report := strings.TrimSpace(*message)
 	if path := strings.TrimSpace(*reportFile); path != "" {
 		content, err := os.ReadFile(path)
 		if err != nil {
-			return "", "", fmt.Errorf("read report file: %w", err)
+			return "", "", nil, fmt.Errorf("read report file: %w", err)
 		}
 		report = strings.TrimSpace(string(content))
 	}
 	if report == "" {
-		return "", "", errors.New("--message or --file is required")
+		return "", "", nil, errors.New("--message or --file is required")
 	}
-	return source, report, nil
+	var structuredReport *protocol.DispatchReport
+	if path := strings.TrimSpace(*coordinationFile); path != "" {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return "", "", nil, fmt.Errorf("read coordination file: %w", err)
+		}
+		var parsed protocol.DispatchReport
+		if err := json.Unmarshal(content, &parsed); err != nil {
+			return "", "", nil, fmt.Errorf("parse coordination file: %w", err)
+		}
+		structuredReport = &parsed
+	}
+	return source, report, structuredReport, nil
+}
+
+func parseDispatchResolveArgs(args []string) (string, string, string, string, error) {
+	fs := flag.NewFlagSet("dispatch resolve", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionID := fs.String("session", "", "chief session id (defaults to ATTN_SESSION_ID)")
+	dispatchID := fs.String("dispatch", "", "dispatch id")
+	response := fs.String("response", "", "decision response")
+	responseFile := fs.String("file", "", "file containing the decision response")
+	resolutionLink := fs.String("link", "", "optional external decision URL")
+	if err := fs.Parse(args); err != nil {
+		return "", "", "", "", err
+	}
+	if fs.NArg() != 0 {
+		return "", "", "", "", fmt.Errorf("unexpected arguments: %v", fs.Args())
+	}
+	source := strings.TrimSpace(*sessionID)
+	if source == "" {
+		source = strings.TrimSpace(os.Getenv("ATTN_SESSION_ID"))
+	}
+	if source == "" {
+		return "", "", "", "", errors.New("no session; run inside attn or pass --session")
+	}
+	if strings.TrimSpace(*dispatchID) == "" {
+		return "", "", "", "", errors.New("--dispatch is required")
+	}
+	if strings.TrimSpace(*response) != "" && strings.TrimSpace(*responseFile) != "" {
+		return "", "", "", "", errors.New("pass only one of --response or --file")
+	}
+	resolvedResponse := strings.TrimSpace(*response)
+	if path := strings.TrimSpace(*responseFile); path != "" {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return "", "", "", "", fmt.Errorf("read response file: %w", err)
+		}
+		resolvedResponse = strings.TrimSpace(string(content))
+	}
+	if resolvedResponse == "" {
+		return "", "", "", "", errors.New("--response or --file is required")
+	}
+	return source, strings.TrimSpace(*dispatchID), resolvedResponse, strings.TrimSpace(*resolutionLink), nil
 }
 
 func runWorkspace() {

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -515,23 +515,79 @@ func TestParseDispatchReportArgsReadsFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte("Implemented the fix.\nTests pass.\n"), 0o600); err != nil {
 		t.Fatalf("write report: %v", err)
 	}
-	sessionID, report, err := parseDispatchReportArgs([]string{"--file", path})
+	sessionID, report, structuredReport, err := parseDispatchReportArgs([]string{"--file", path})
 	if err != nil {
 		t.Fatalf("parseDispatchReportArgs() error = %v", err)
 	}
-	if sessionID != "worker-1" || report != "Implemented the fix.\nTests pass." {
-		t.Fatalf("dispatch report = (%q, %q)", sessionID, report)
+	if sessionID != "worker-1" || report != "Implemented the fix.\nTests pass." || structuredReport != nil {
+		t.Fatalf("dispatch report = (%q, %q, %+v)", sessionID, report, structuredReport)
 	}
 }
 
 func TestParseDispatchReportArgsRejectsAmbiguousContent(t *testing.T) {
-	_, _, err := parseDispatchReportArgs([]string{
+	_, _, _, err := parseDispatchReportArgs([]string{
 		"--session", "worker-1",
 		"--message", "done",
 		"--file", "/tmp/report.md",
 	})
 	if err == nil || !strings.Contains(err.Error(), "only one of --message or --file") {
 		t.Fatalf("parseDispatchReportArgs() error = %v", err)
+	}
+}
+
+func TestParseDispatchReportArgsReadsCoordinationFile(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "worker-1")
+	path := filepath.Join(t.TempDir(), "coordination.json")
+	if err := os.WriteFile(path, []byte(`{
+		"report_type": "blocker",
+		"summary": "Core implementation ready locally",
+		"work_state": "needs_input",
+		"next_actor": "team",
+		"request": {
+			"question": "Which event contract should be used?",
+			"expected_responder": "team",
+			"status": "pending"
+		}
+	}`), 0o600); err != nil {
+		t.Fatalf("write coordination file: %v", err)
+	}
+	sessionID, report, structured, err := parseDispatchReportArgs([]string{
+		"--message", "Waiting for the event contract decision.",
+		"--coordination-file", path,
+	})
+	if err != nil {
+		t.Fatalf("parseDispatchReportArgs() error = %v", err)
+	}
+	if sessionID != "worker-1" || report != "Waiting for the event contract decision." {
+		t.Fatalf("dispatch report = (%q, %q)", sessionID, report)
+	}
+	if structured == nil ||
+		structured.ReportType != protocol.DispatchReportTypeBlocker ||
+		structured.WorkState != protocol.DispatchWorkStateNeedsInput ||
+		structured.Request == nil {
+		t.Fatalf("structured report = %+v", structured)
+	}
+}
+
+func TestParseDispatchResolveArgsReadsResponseFile(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "chief-1")
+	path := filepath.Join(t.TempDir(), "response.md")
+	if err := os.WriteFile(path, []byte("Use AisNoOperationV1.\n"), 0o600); err != nil {
+		t.Fatalf("write response file: %v", err)
+	}
+	sessionID, dispatchID, response, link, err := parseDispatchResolveArgs([]string{
+		"--dispatch", "dispatch-1",
+		"--file", path,
+		"--link", "https://example.test/decision",
+	})
+	if err != nil {
+		t.Fatalf("parseDispatchResolveArgs() error = %v", err)
+	}
+	if sessionID != "chief-1" ||
+		dispatchID != "dispatch-1" ||
+		response != "Use AisNoOperationV1." ||
+		link != "https://example.test/decision" {
+		t.Fatalf("dispatch resolve = (%q, %q, %q, %q)", sessionID, dispatchID, response, link)
 	}
 }
 

--- a/docs/plans/2026-06-08-chief-of-staff.md
+++ b/docs/plans/2026-06-08-chief-of-staff.md
@@ -105,6 +105,15 @@ ChiefOfStaffDispatch {
   independently of workspace context.
 - Dispatch status is projected from the target session. The dispatch store owns
   relationship metadata and reports, not a second session-state machine.
+- Structured coordination is intentionally latest-report state, not a report
+  history or customizable workflow engine.
+- Chief responses are delivered through dispatch persistence and
+  `attn dispatch status`; attn does not type arbitrary text into a live agent
+  PTY because that is not a safe prompt-delivery primitive.
+- Attn delegation is reserved for visible, full interactive agents the user
+  wants to inspect and steer. Chiefs use native subagents for internal
+  research, adversarial analysis, verification, and parallel reasoning, and
+  default to native subagents when intent is unclear.
 
 ## Implementation Steps
 
@@ -133,6 +142,12 @@ ChiefOfStaffDispatch {
 - [x] Broadcast dispatch snapshots and visualize them on the dashboard with
       status, latest report, and session navigation.
 - [x] Teach chief and delegated agents when and how to list/report dispatches.
+- [x] Separate projected runtime status from a narrow delegated-work state.
+- [x] Persist one structured latest-report envelope alongside the narrative.
+- [x] Support one durable decision request and chief resolution per dispatch.
+- [x] Derive actionable summaries and artifact-current verification for CLI/API/UI.
+- [x] Clarify the boundary between user-visible attn delegation and internal
+      native subagents in the bundled skill and protect it with focused tests.
 
 ## Verification
 

--- a/internal/agent/attn_skill/SKILL.md
+++ b/internal/agent/attn_skill/SKILL.md
@@ -22,7 +22,7 @@ If a command reports an unknown subcommand or shows another tool's help, check
 
 ## Capability Index
 
-- **Delegate a side task to another agent:** read
+- **Create a visible interactive agent the user can steer:** read
   [references/delegation.md](references/delegation.md).
 - **Coordinate or report chief-of-staff dispatches:** read
   [references/chief-of-staff.md](references/chief-of-staff.md).

--- a/internal/agent/attn_skill/references/chief-of-staff.md
+++ b/internal/agent/attn_skill/references/chief-of-staff.md
@@ -5,18 +5,35 @@ initial task says the chief of staff is tracking the work.
 
 ## As Chief of Staff
 
-Delegate with the normal `attn delegate` workflow. attn tracks the new session
-automatically only when the current source session holds the chief-of-staff
-role.
+Use the normal `attn delegate` workflow only for a visible, full interactive
+agent the user wants to inspect and steer. For internal research, adversarial
+analysis, verification, or parallel reasoning that you will synthesize, use
+native subagents instead; when intent is unclear, default to native subagents.
+See the delegation reference for the full boundary. attn tracks a delegated
+session automatically only when the current source session holds the
+chief-of-staff role.
 
 Review your dispatched work with:
 
     "$ATTN_WRAPPER_PATH" dispatch list
 
-Use the target session's live status and latest report to decide whether to
-wait, inspect its work, answer a blocker, or give the user a summary. A report
-is an agent update, not proof that the work is correct; verify important
-results before relying on them.
+Runtime status and delegated work state are separate. Use the target session's
+live status plus the latest report and its structured `work_state`, `next_actor`,
+`next_action`, actionable request, artifact, and verification to decide whether
+to wait, inspect its work, answer a blocker, or give the user a summary.
+
+Resolve the dispatch's one active decision request with:
+
+    "$ATTN_WRAPPER_PATH" dispatch resolve \
+      --dispatch <id> \
+      --response "Use AisNoOperationV1." \
+      --link "https://external-system.example/decision"
+
+The response is stored on the dispatch and becomes available to the delegated
+agent through `dispatch status`.
+
+A report is not proof that the work is correct; it is an agent update. Verify
+important results before relying on it.
 
 Do not create reports on behalf of delegated agents or repeatedly interrupt
 working agents just to request status.
@@ -37,6 +54,49 @@ Keep a short report concrete: outcome, evidence, and next action.
 For a longer report, write it to a file and submit the file:
 
     "$ATTN_WRAPPER_PATH" dispatch report --file /tmp/dispatch-report.md
+
+For actionable coordination, keep the narrative and attach a JSON envelope:
+
+```json
+{
+  "report_type": "blocker",
+  "summary": "Core freshness gate implemented locally",
+  "work_state": "needs_input",
+  "next_actor": "team",
+  "next_action": "Decide the AisNoOperationV1 event contract",
+  "remaining_scope": ["Emit the event", "Add the integration test"],
+  "constraints": ["uncommitted", "no push", "no PR"],
+  "request": {
+    "question": "Should the worker emit AisNoOperationV1?",
+    "recommendation": "Use AisNoOperationV1",
+    "consequence": "Event emission remains blocked",
+    "expected_responder": "team",
+    "status": "pending"
+  },
+  "artifact": {
+    "identity": "dirty:<stable-status-hash>",
+    "branch": "feat/example",
+    "dirty": true
+  },
+  "verification": [{
+    "actor": "agent",
+    "target": "go test ./internal/feature",
+    "result": "passed",
+    "timestamp": "2026-06-09T18:00:00Z",
+    "artifact_identity": "dirty:<stable-status-hash>"
+  }]
+}
+```
+
+Submit it with:
+
+    "$ATTN_WRAPPER_PATH" dispatch report \
+      --message "Core implementation is ready; event emission needs a decision." \
+      --coordination-file /tmp/dispatch-coordination.json
+
+After requesting a decision, read the durable chief response with:
+
+    "$ATTN_WRAPPER_PATH" dispatch status
 
 Reporting does not stop or transfer your session. Continue working unless the
 task is blocked or complete. Do not use dispatch reporting for ordinary,

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -1,8 +1,21 @@
 # Delegation
 
-Use delegation when a distinct task can proceed without interrupting your
-current work. Delegation starts another agent with a focused brief; it does not
-create durable parent-child lineage or require you to monitor the new agent.
+Attn delegation creates a visible, full interactive agent session for the user.
+Use it when the user wants another agent they can inspect, converse with, and
+steer directly while you continue coordinating the wider task.
+
+Do not use attn delegation as an internal parallel-reasoning mechanism. For
+research, adversarial analysis, verification, or other work that you alone will
+synthesize for the user, use your native subagent or multi-agent tools instead.
+Those workers are implementation details of your response; they should not
+create attn sessions or appear in the user's workspace.
+
+When the user's intent is unclear, default to native subagents. Use attn only
+when the user explicitly asks for delegation, an interactive agent, a separate
+workspace/session, or a collaborator they can steer themselves.
+
+Attn delegation starts another agent with a focused brief; it does not create
+durable parent-child lineage or require you to monitor the new agent.
 
 ## Brief Workflow
 

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -24,6 +24,7 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 	for _, expected := range []string{
 		"name: attn",
 		"delegate work",
+		"visible interactive agent",
 		"ATTN_WRAPPER_PATH",
 		"references/delegation.md",
 		"references/chief-of-staff.md",
@@ -50,6 +51,8 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 		"dispatch report --message",
 		"dispatch report --file",
 		"latest report",
+		"visible, full interactive",
+		"default to native subagents",
 		"not proof that the work is correct",
 		"Do not use dispatch reporting for ordinary",
 	} {
@@ -60,6 +63,10 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 
 	delegation := readSkillFile(t, skillDir, "references/delegation.md")
 	for _, expected := range []string{
+		"visible, full interactive agent session",
+		"native subagent or multi-agent tools",
+		"default to native subagents",
+		"user explicitly asks for delegation",
 		"delegate --brief-file",
 		"--new-workspace",
 		"--workspace <workspace-id>",

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -212,11 +212,55 @@ func (c *Client) ListDispatches(sourceSessionID string) ([]protocol.ChiefOfStaff
 }
 
 func (c *Client) ReportDispatch(sourceSessionID, report string) (*protocol.ChiefOfStaffDispatch, error) {
+	return c.ReportDispatchEnvelope(sourceSessionID, report, nil)
+}
+
+func (c *Client) ReportDispatchEnvelope(
+	sourceSessionID, report string,
+	structuredReport *protocol.DispatchReport,
+) (*protocol.ChiefOfStaffDispatch, error) {
 	resp, err := c.send(protocol.ReportDispatchMessage{
-		Cmd:             protocol.CmdReportDispatch,
-		SourceSessionID: sourceSessionID,
-		Report:          report,
+		Cmd:              protocol.CmdReportDispatch,
+		SourceSessionID:  sourceSessionID,
+		Report:           report,
+		StructuredReport: structuredReport,
 	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.ChiefOfStaffDispatch == nil {
+		return nil, errors.New("daemon returned no dispatch")
+	}
+	return resp.ChiefOfStaffDispatch, nil
+}
+
+func (c *Client) GetDispatch(sourceSessionID string) (*protocol.ChiefOfStaffDispatch, error) {
+	resp, err := c.send(protocol.GetDispatchMessage{
+		Cmd:             protocol.CmdGetDispatch,
+		SourceSessionID: sourceSessionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.ChiefOfStaffDispatch == nil {
+		return nil, errors.New("daemon returned no dispatch")
+	}
+	return resp.ChiefOfStaffDispatch, nil
+}
+
+func (c *Client) ResolveDispatchRequest(
+	sourceSessionID, dispatchID, response, resolutionLink string,
+) (*protocol.ChiefOfStaffDispatch, error) {
+	msg := protocol.ResolveDispatchRequestMessage{
+		Cmd:             protocol.CmdResolveDispatchRequest,
+		SourceSessionID: sourceSessionID,
+		DispatchID:      dispatchID,
+		Response:        response,
+	}
+	if value := strings.TrimSpace(resolutionLink); value != "" {
+		msg.ResolutionLink = protocol.Ptr(value)
+	}
+	resp, err := c.send(msg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/chief_of_staff_dispatch.go
+++ b/internal/daemon/chief_of_staff_dispatch.go
@@ -21,7 +21,11 @@ Send a concise update when you reach a meaningful milestone, need input, or fini
 
     "$ATTN_WRAPPER_PATH" dispatch report --message "<update>"
 
-For a longer update, write it to a file and use ` + "`--file <path>`" + `. Continue the assigned work after reporting unless you are blocked or finished.`
+For a longer update, write it to a file and use ` + "`--file <path>`" + `.
+When work is blocked, ready for review, completed, or failed, attach structured
+coordination fields with ` + "`--coordination-file <json>`" + `. Use
+` + "`dispatch status`" + ` to read a chief's durable response to a decision request.
+Continue the assigned work after reporting unless you are blocked or finished.`
 }
 
 func (d *Daemon) newChiefOfStaffDispatch(
@@ -62,6 +66,22 @@ func (d *Daemon) decorateChiefOfStaffDispatch(dispatch *protocol.ChiefOfStaffDis
 	if dispatch.ReportedAt != nil {
 		decorated.ReportedAt = protocol.Ptr(protocol.Deref(dispatch.ReportedAt))
 	}
+	decorated.StructuredReport = cloneDispatchReportForDisplay(dispatch.StructuredReport)
+	if decorated.StructuredReport != nil {
+		summary := strings.TrimSpace(decorated.StructuredReport.Summary)
+		if summary != "" {
+			decorated.ConciseSummary = protocol.Ptr(summary)
+		}
+		actionable := decorated.StructuredReport.WorkState == protocol.DispatchWorkStateNeedsInput ||
+			decorated.StructuredReport.WorkState == protocol.DispatchWorkStateReadyForReview
+		if request := decorated.StructuredReport.Request; request != nil {
+			actionable = request.Status == protocol.DispatchRequestStatusPending
+		}
+		decorated.Actionable = protocol.Ptr(actionable)
+	} else if dispatch.LatestReport != nil {
+		decorated.ConciseSummary = protocol.Ptr(protocol.Deref(dispatch.LatestReport))
+		decorated.Actionable = protocol.Ptr(false)
+	}
 	if session := d.store.Get(dispatch.SessionID); session != nil {
 		decorated.Status = string(session.State)
 		decorated.StatusSince = session.StateSince
@@ -70,6 +90,85 @@ func (d *Daemon) decorateChiefOfStaffDispatch(dispatch *protocol.ChiefOfStaffDis
 		decorated.StatusSince = ""
 	}
 	return &decorated
+}
+
+func cloneDispatchReportForDisplay(report *protocol.DispatchReport) *protocol.DispatchReport {
+	if report == nil {
+		return nil
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		return nil
+	}
+	var cloned protocol.DispatchReport
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return nil
+	}
+	artifactIdentity := ""
+	if cloned.Artifact != nil {
+		artifactIdentity = strings.TrimSpace(cloned.Artifact.Identity)
+	}
+	for i := range cloned.Verification {
+		current := artifactIdentity != "" &&
+			strings.TrimSpace(cloned.Verification[i].ArtifactIdentity) == artifactIdentity
+		cloned.Verification[i].Current = protocol.Ptr(current)
+	}
+	return &cloned
+}
+
+func validateDispatchReport(report *protocol.DispatchReport) error {
+	if report == nil {
+		return nil
+	}
+	switch report.ReportType {
+	case protocol.DispatchReportTypeProgress,
+		protocol.DispatchReportTypeBlocker,
+		protocol.DispatchReportTypeHandoff,
+		protocol.DispatchReportTypeCompletion,
+		protocol.DispatchReportTypeFailure:
+	default:
+		return fmt.Errorf("invalid report_type %q", report.ReportType)
+	}
+	switch report.WorkState {
+	case protocol.DispatchWorkStateInProgress,
+		protocol.DispatchWorkStateNeedsInput,
+		protocol.DispatchWorkStateReadyForReview,
+		protocol.DispatchWorkStateCompleted,
+		protocol.DispatchWorkStateFailed:
+	default:
+		return fmt.Errorf("invalid work_state %q", report.WorkState)
+	}
+	if strings.TrimSpace(report.Summary) == "" {
+		return fmt.Errorf("summary is required")
+	}
+	if report.Request != nil {
+		if strings.TrimSpace(report.Request.Question) == "" {
+			return fmt.Errorf("request.question is required")
+		}
+		if strings.TrimSpace(report.Request.ExpectedResponder) == "" {
+			return fmt.Errorf("request.expected_responder is required")
+		}
+		report.Request.Status = protocol.DispatchRequestStatusPending
+		report.Request.Response = nil
+		report.Request.ResolutionLink = nil
+		report.Request.RespondedBy = nil
+		report.Request.RespondedAt = nil
+	}
+	if report.Artifact != nil && strings.TrimSpace(report.Artifact.Identity) == "" {
+		return fmt.Errorf("artifact.identity is required")
+	}
+	for i := range report.Verification {
+		evidence := &report.Verification[i]
+		if strings.TrimSpace(evidence.Actor) == "" ||
+			strings.TrimSpace(evidence.Target) == "" ||
+			strings.TrimSpace(evidence.Result) == "" ||
+			strings.TrimSpace(evidence.Timestamp) == "" ||
+			strings.TrimSpace(evidence.ArtifactIdentity) == "" {
+			return fmt.Errorf("verification[%d] requires actor, target, result, timestamp, and artifact_identity", i)
+		}
+		evidence.Current = nil
+	}
+	return nil
 }
 
 func (d *Daemon) chiefOfStaffDispatches(chiefSessionID string) []protocol.ChiefOfStaffDispatch {
@@ -120,9 +219,68 @@ func (d *Daemon) handleReportDispatch(conn net.Conn, msg *protocol.ReportDispatc
 		d.sendError(conn, "dispatch report: report is required")
 		return
 	}
-	dispatch, err := d.store.UpdateChiefOfStaffDispatchReport(sourceSessionID, report)
+	if err := validateDispatchReport(msg.StructuredReport); err != nil {
+		d.sendError(conn, "dispatch report: "+err.Error())
+		return
+	}
+	dispatch, err := d.store.UpdateChiefOfStaffDispatchReportEnvelope(
+		sourceSessionID,
+		report,
+		msg.StructuredReport,
+	)
 	if err != nil {
 		d.sendError(conn, "dispatch report: "+err.Error())
+		return
+	}
+	decorated := d.decorateChiefOfStaffDispatch(dispatch)
+	_ = json.NewEncoder(conn).Encode(protocol.Response{
+		Ok:                   true,
+		ChiefOfStaffDispatch: decorated,
+	})
+	d.broadcastChiefOfStaffDispatchesUpdated()
+}
+
+func (d *Daemon) handleGetDispatch(conn net.Conn, msg *protocol.GetDispatchMessage) {
+	sourceSessionID := strings.TrimSpace(msg.SourceSessionID)
+	if sourceSessionID == "" {
+		d.sendError(conn, "dispatch status: source_session_id is required")
+		return
+	}
+	dispatch := d.store.GetChiefOfStaffDispatchBySession(sourceSessionID)
+	if dispatch == nil {
+		d.sendError(conn, fmt.Sprintf("dispatch status: session %s is not a tracked dispatch", sourceSessionID))
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(protocol.Response{
+		Ok:                   true,
+		ChiefOfStaffDispatch: d.decorateChiefOfStaffDispatch(dispatch),
+	})
+}
+
+func (d *Daemon) handleResolveDispatchRequest(conn net.Conn, msg *protocol.ResolveDispatchRequestMessage) {
+	sourceSessionID := strings.TrimSpace(msg.SourceSessionID)
+	dispatchID := strings.TrimSpace(msg.DispatchID)
+	response := strings.TrimSpace(msg.Response)
+	if sourceSessionID == "" {
+		d.sendError(conn, "dispatch resolve: source_session_id is required")
+		return
+	}
+	if dispatchID == "" {
+		d.sendError(conn, "dispatch resolve: dispatch_id is required")
+		return
+	}
+	if response == "" {
+		d.sendError(conn, "dispatch resolve: response is required")
+		return
+	}
+	dispatch, err := d.store.ResolveChiefOfStaffDispatchRequest(
+		dispatchID,
+		sourceSessionID,
+		response,
+		strings.TrimSpace(protocol.Deref(msg.ResolutionLink)),
+	)
+	if err != nil {
+		d.sendError(conn, "dispatch resolve: "+err.Error())
 		return
 	}
 	decorated := d.decorateChiefOfStaffDispatch(dispatch)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1667,6 +1667,10 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleListDispatches(conn, msg.(*protocol.ListDispatchesMessage))
 	case protocol.CmdReportDispatch:
 		d.handleReportDispatch(conn, msg.(*protocol.ReportDispatchMessage))
+	case protocol.CmdGetDispatch:
+		d.handleGetDispatch(conn, msg.(*protocol.GetDispatchMessage))
+	case protocol.CmdResolveDispatchRequest:
+		d.handleResolveDispatchRequest(conn, msg.(*protocol.ResolveDispatchRequestMessage))
 	case protocol.CmdWorkspaceContextCheckout:
 		d.handleWorkspaceContextCheckout(conn, msg.(*protocol.WorkspaceContextCheckoutMessage))
 	case protocol.CmdWorkspaceContextUpdate:

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -223,6 +223,155 @@ func TestDispatchReportUpdatesTrackedRecord(t *testing.T) {
 	}
 }
 
+func TestStructuredDispatchReportSeparatesRuntimeAndSupportsResolution(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, chiefSessionID, _ := setupDelegationSource(t, d, backend)
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, chiefSessionID); err != nil {
+		t.Fatalf("set chief role: %v", err)
+	}
+	consumeDelegatedPrompt(t, backend)
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: chiefSessionID,
+		Brief:           "Produce a structured tracked report.",
+		Agent:           protocol.Ptr("codex"),
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	d.store.UpdateState(result.SessionID, string(protocol.SessionStateIdle))
+
+	report := &protocol.DispatchReport{
+		ReportType: protocol.DispatchReportTypeBlocker,
+		Summary:    "Core implementation ready locally",
+		WorkState:  protocol.DispatchWorkStateNeedsInput,
+		NextActor:  protocol.Ptr("team"),
+		NextAction: protocol.Ptr("Decide the event contract"),
+		Request: &protocol.DispatchDecisionRequest{
+			Question:          "Which event contract should be used?",
+			Recommendation:    protocol.Ptr("Use AisNoOperationV1"),
+			Consequence:       protocol.Ptr("Event emission remains blocked"),
+			ExpectedResponder: "team",
+		},
+		Artifact: &protocol.DispatchArtifact{
+			Identity: "dirty:abc123",
+		},
+		Verification: []protocol.DispatchVerification{
+			{
+				Actor:            "agent",
+				Target:           "go test ./internal/feature",
+				Result:           "passed",
+				Timestamp:        string(protocol.TimestampNow()),
+				ArtifactIdentity: "commit:old",
+			},
+		},
+	}
+	server, client := net.Pipe()
+	reportDone := make(chan struct{})
+	go func() {
+		d.handleReportDispatch(server, &protocol.ReportDispatchMessage{
+			Cmd:              protocol.CmdReportDispatch,
+			SourceSessionID:  result.SessionID,
+			Report:           "Core implementation ready; decision required.",
+			StructuredReport: report,
+		})
+		_ = server.Close()
+		close(reportDone)
+	}()
+	var reportResponse protocol.Response
+	if err := json.NewDecoder(client).Decode(&reportResponse); err != nil {
+		t.Fatalf("decode report response: %v", err)
+	}
+	_ = client.Close()
+	<-reportDone
+	dispatch := reportResponse.ChiefOfStaffDispatch
+	if !reportResponse.Ok || dispatch == nil || dispatch.StructuredReport == nil {
+		t.Fatalf("report response = %+v", reportResponse)
+	}
+	if dispatch.Status != string(protocol.SessionStateIdle) ||
+		dispatch.StructuredReport.WorkState != protocol.DispatchWorkStateNeedsInput {
+		t.Fatalf("runtime/work state = (%q, %q)", dispatch.Status, dispatch.StructuredReport.WorkState)
+	}
+	if !protocol.Deref(dispatch.Actionable) ||
+		protocol.Deref(dispatch.ConciseSummary) != "Core implementation ready locally" {
+		t.Fatalf("actionable dispatch = %+v", dispatch)
+	}
+	if protocol.Deref(dispatch.StructuredReport.Verification[0].Current) {
+		t.Fatalf("stale verification shown current: %+v", dispatch.StructuredReport.Verification)
+	}
+
+	server, client = net.Pipe()
+	resolveServer := server
+	resolveDone := make(chan struct{})
+	go func() {
+		d.handleResolveDispatchRequest(resolveServer, &protocol.ResolveDispatchRequestMessage{
+			Cmd:             protocol.CmdResolveDispatchRequest,
+			SourceSessionID: chiefSessionID,
+			DispatchID:      protocol.Deref(result.DispatchID),
+			Response:        "Use AisNoOperationV1.",
+			ResolutionLink:  protocol.Ptr("https://example.test/decision"),
+		})
+		_ = resolveServer.Close()
+		close(resolveDone)
+	}()
+	var resolveResponse protocol.Response
+	if err := json.NewDecoder(client).Decode(&resolveResponse); err != nil {
+		t.Fatalf("decode resolve response: %v", err)
+	}
+	_ = client.Close()
+	<-resolveDone
+	resolved := resolveResponse.ChiefOfStaffDispatch
+	if !resolveResponse.Ok || resolved == nil || resolved.StructuredReport == nil {
+		t.Fatalf("resolve response = %+v", resolveResponse)
+	}
+	if resolved.StructuredReport.Request.Status != protocol.DispatchRequestStatusResolved ||
+		protocol.Deref(resolved.StructuredReport.Request.Response) != "Use AisNoOperationV1." ||
+		protocol.Deref(resolved.Actionable) {
+		t.Fatalf("resolved dispatch = %+v", resolved)
+	}
+	persisted := d.store.GetChiefOfStaffDispatchBySession(result.SessionID)
+	if persisted == nil {
+		t.Fatal("resolved dispatch was not persisted")
+	}
+	if _, err := json.Marshal(d.decorateChiefOfStaffDispatch(persisted)); err != nil {
+		t.Fatalf("marshal persisted dispatch: %v", err)
+	}
+
+	server, client = net.Pipe()
+	statusServer := server
+	go func() {
+		d.handleGetDispatch(statusServer, &protocol.GetDispatchMessage{
+			Cmd:             protocol.CmdGetDispatch,
+			SourceSessionID: result.SessionID,
+		})
+		_ = statusServer.Close()
+	}()
+	var statusResponse protocol.Response
+	if err := json.NewDecoder(client).Decode(&statusResponse); err != nil {
+		t.Fatalf("decode status response: %v", err)
+	}
+	_ = client.Close()
+	if !statusResponse.Ok ||
+		statusResponse.ChiefOfStaffDispatch == nil ||
+		protocol.Deref(statusResponse.ChiefOfStaffDispatch.StructuredReport.Request.Response) != "Use AisNoOperationV1." {
+		t.Fatalf("delegated status response = %+v", statusResponse)
+	}
+}
+
+func TestReadyForReviewDispatchIsActionable(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	dispatch := d.decorateChiefOfStaffDispatch(&protocol.ChiefOfStaffDispatch{
+		StructuredReport: &protocol.DispatchReport{
+			Summary:   "Implementation ready",
+			WorkState: protocol.DispatchWorkStateReadyForReview,
+		},
+	})
+	if dispatch == nil || !protocol.Deref(dispatch.Actionable) {
+		t.Fatalf("ready-for-review dispatch = %+v, want actionable", dispatch)
+	}
+}
+
 func TestDelegateRollsBackPaneWhenSpawnFails(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "93"
+const ProtocolVersion = "94"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -39,6 +39,8 @@ const (
 	CmdDelegate                           = "delegate"
 	CmdListDispatches                     = "list_dispatches"
 	CmdReportDispatch                     = "report_dispatch"
+	CmdGetDispatch                        = "get_dispatch"
+	CmdResolveDispatchRequest             = "resolve_dispatch_request"
 	CmdWorkspaceContextCheckout           = "workspace_context_checkout"
 	CmdWorkspaceContextUpdate             = "workspace_context_update"
 	CmdWorkspaceContextStatus             = "workspace_context_status"
@@ -319,6 +321,20 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdReportDispatch:
 		var msg ReportDispatchMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdGetDispatch:
+		var msg GetDispatchMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdResolveDispatchRequest:
+		var msg ResolveDispatchRequestMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -381,6 +381,9 @@ type BrowserControlResultMessage struct {
 }
 
 type ChiefOfStaffDispatch struct {
+	// Actionable corresponds to the JSON schema field "actionable".
+	Actionable *bool `json:"actionable,omitempty,omitzero"`
+
 	// Agent corresponds to the JSON schema field "agent".
 	Agent string `json:"agent"`
 
@@ -392,6 +395,9 @@ type ChiefOfStaffDispatch struct {
 
 	// ChiefSessionID corresponds to the JSON schema field "chief_session_id".
 	ChiefSessionID string `json:"chief_session_id"`
+
+	// ConciseSummary corresponds to the JSON schema field "concise_summary".
+	ConciseSummary *string `json:"concise_summary,omitempty,omitzero"`
 
 	// CreatedAt corresponds to the JSON schema field "created_at".
 	CreatedAt string `json:"created_at"`
@@ -419,6 +425,9 @@ type ChiefOfStaffDispatch struct {
 
 	// StatusSince corresponds to the JSON schema field "status_since".
 	StatusSince string `json:"status_since"`
+
+	// StructuredReport corresponds to the JSON schema field "structured_report".
+	StructuredReport *DispatchReport `json:"structured_report,omitempty,omitzero"`
 
 	// UpdatedAt corresponds to the JSON schema field "updated_at".
 	UpdatedAt string `json:"updated_at"`
@@ -721,6 +730,131 @@ type DirectoryEntry struct {
 	Path string `json:"path"`
 }
 
+type DispatchArtifact struct {
+	// Branch corresponds to the JSON schema field "branch".
+	Branch *string `json:"branch,omitempty,omitzero"`
+
+	// Description corresponds to the JSON schema field "description".
+	Description *string `json:"description,omitempty,omitzero"`
+
+	// Dirty corresponds to the JSON schema field "dirty".
+	Dirty *bool `json:"dirty,omitempty,omitzero"`
+
+	// Identity corresponds to the JSON schema field "identity".
+	Identity string `json:"identity"`
+
+	// Revision corresponds to the JSON schema field "revision".
+	Revision *string `json:"revision,omitempty,omitzero"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID *string `json:"workspace_id,omitempty,omitzero"`
+}
+
+type DispatchDecisionRequest struct {
+	// Consequence corresponds to the JSON schema field "consequence".
+	Consequence *string `json:"consequence,omitempty,omitzero"`
+
+	// ExpectedResponder corresponds to the JSON schema field "expected_responder".
+	ExpectedResponder string `json:"expected_responder"`
+
+	// Question corresponds to the JSON schema field "question".
+	Question string `json:"question"`
+
+	// Recommendation corresponds to the JSON schema field "recommendation".
+	Recommendation *string `json:"recommendation,omitempty,omitzero"`
+
+	// ResolutionLink corresponds to the JSON schema field "resolution_link".
+	ResolutionLink *string `json:"resolution_link,omitempty,omitzero"`
+
+	// RespondedAt corresponds to the JSON schema field "responded_at".
+	RespondedAt *string `json:"responded_at,omitempty,omitzero"`
+
+	// RespondedBy corresponds to the JSON schema field "responded_by".
+	RespondedBy *string `json:"responded_by,omitempty,omitzero"`
+
+	// Response corresponds to the JSON schema field "response".
+	Response *string `json:"response,omitempty,omitzero"`
+
+	// Status corresponds to the JSON schema field "status".
+	Status DispatchRequestStatus `json:"status"`
+}
+
+type DispatchReport struct {
+	// Artifact corresponds to the JSON schema field "artifact".
+	Artifact *DispatchArtifact `json:"artifact,omitempty,omitzero"`
+
+	// Constraints corresponds to the JSON schema field "constraints".
+	Constraints []string `json:"constraints,omitempty,omitzero"`
+
+	// NextAction corresponds to the JSON schema field "next_action".
+	NextAction *string `json:"next_action,omitempty,omitzero"`
+
+	// NextActor corresponds to the JSON schema field "next_actor".
+	NextActor *string `json:"next_actor,omitempty,omitzero"`
+
+	// RemainingScope corresponds to the JSON schema field "remaining_scope".
+	RemainingScope []string `json:"remaining_scope,omitempty,omitzero"`
+
+	// ReportType corresponds to the JSON schema field "report_type".
+	ReportType DispatchReportType `json:"report_type"`
+
+	// ReportedAt corresponds to the JSON schema field "reported_at".
+	ReportedAt string `json:"reported_at"`
+
+	// Request corresponds to the JSON schema field "request".
+	Request *DispatchDecisionRequest `json:"request,omitempty,omitzero"`
+
+	// Summary corresponds to the JSON schema field "summary".
+	Summary string `json:"summary"`
+
+	// Verification corresponds to the JSON schema field "verification".
+	Verification []DispatchVerification `json:"verification,omitempty,omitzero"`
+
+	// WorkState corresponds to the JSON schema field "work_state".
+	WorkState DispatchWorkState `json:"work_state"`
+}
+
+type DispatchReportType string
+
+const DispatchReportTypeBlocker DispatchReportType = "blocker"
+const DispatchReportTypeCompletion DispatchReportType = "completion"
+const DispatchReportTypeFailure DispatchReportType = "failure"
+const DispatchReportTypeHandoff DispatchReportType = "handoff"
+const DispatchReportTypeProgress DispatchReportType = "progress"
+
+type DispatchRequestStatus string
+
+const DispatchRequestStatusPending DispatchRequestStatus = "pending"
+const DispatchRequestStatusResolved DispatchRequestStatus = "resolved"
+
+type DispatchVerification struct {
+	// Actor corresponds to the JSON schema field "actor".
+	Actor string `json:"actor"`
+
+	// ArtifactIdentity corresponds to the JSON schema field "artifact_identity".
+	ArtifactIdentity string `json:"artifact_identity"`
+
+	// Current corresponds to the JSON schema field "current".
+	Current *bool `json:"current,omitempty,omitzero"`
+
+	// Result corresponds to the JSON schema field "result".
+	Result string `json:"result"`
+
+	// Target corresponds to the JSON schema field "target".
+	Target string `json:"target"`
+
+	// Timestamp corresponds to the JSON schema field "timestamp".
+	Timestamp string `json:"timestamp"`
+}
+
+type DispatchWorkState string
+
+const DispatchWorkStateCompleted DispatchWorkState = "completed"
+const DispatchWorkStateFailed DispatchWorkState = "failed"
+const DispatchWorkStateInProgress DispatchWorkState = "in_progress"
+const DispatchWorkStateNeedsInput DispatchWorkState = "needs_input"
+const DispatchWorkStateReadyForReview DispatchWorkState = "ready_for_review"
+
 type EndpointActionResultMessage struct {
 	// Action corresponds to the JSON schema field "action".
 	Action string `json:"action"`
@@ -966,6 +1100,14 @@ type GetDefaultBranchResultMessage struct {
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
+}
+
+type GetDispatchMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// SourceSessionID corresponds to the JSON schema field "source_session_id".
+	SourceSessionID string `json:"source_session_id"`
 }
 
 type GetFileDiffMessage struct {
@@ -2046,6 +2188,9 @@ type ReportDispatchMessage struct {
 
 	// SourceSessionID corresponds to the JSON schema field "source_session_id".
 	SourceSessionID string `json:"source_session_id"`
+
+	// StructuredReport corresponds to the JSON schema field "structured_report".
+	StructuredReport *DispatchReport `json:"structured_report,omitempty,omitzero"`
 }
 
 type ReposUpdatedMessage struct {
@@ -2076,6 +2221,23 @@ type ResolveCommentResultMessage struct {
 
 	// Success corresponds to the JSON schema field "success".
 	Success bool `json:"success"`
+}
+
+type ResolveDispatchRequestMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// DispatchID corresponds to the JSON schema field "dispatch_id".
+	DispatchID string `json:"dispatch_id"`
+
+	// ResolutionLink corresponds to the JSON schema field "resolution_link".
+	ResolutionLink *string `json:"resolution_link,omitempty,omitzero"`
+
+	// Response corresponds to the JSON schema field "response".
+	Response string `json:"response"`
+
+	// SourceSessionID corresponds to the JSON schema field "source_session_id".
+	SourceSessionID string `json:"source_session_id"`
 }
 
 type Response struct {

--- a/internal/protocol/parse_test.go
+++ b/internal/protocol/parse_test.go
@@ -156,13 +156,52 @@ func TestParseDispatchCommands(t *testing.T) {
 		t.Fatalf("list dispatches = %q %+v", cmd, data)
 	}
 
-	cmd, data, err = ParseMessage([]byte(`{"cmd":"report_dispatch","source_session_id":"worker-1","report":"done"}`))
+	cmd, data, err = ParseMessage([]byte(`{
+		"cmd":"report_dispatch",
+		"source_session_id":"worker-1",
+		"report":"waiting for a decision",
+		"structured_report":{
+			"report_type":"blocker",
+			"summary":"Core implementation ready",
+			"work_state":"needs_input",
+			"reported_at":""
+		}
+	}`))
 	if err != nil {
 		t.Fatalf("ParseMessage(report_dispatch) error = %v", err)
 	}
 	report := data.(*ReportDispatchMessage)
-	if cmd != CmdReportDispatch || report.SourceSessionID != "worker-1" || report.Report != "done" {
+	if cmd != CmdReportDispatch ||
+		report.SourceSessionID != "worker-1" ||
+		report.Report != "waiting for a decision" ||
+		report.StructuredReport == nil ||
+		report.StructuredReport.WorkState != DispatchWorkStateNeedsInput {
 		t.Fatalf("report dispatch = %q %+v", cmd, report)
+	}
+
+	cmd, data, err = ParseMessage([]byte(`{"cmd":"get_dispatch","source_session_id":"worker-1"}`))
+	if err != nil {
+		t.Fatalf("ParseMessage(get_dispatch) error = %v", err)
+	}
+	if cmd != CmdGetDispatch || data.(*GetDispatchMessage).SourceSessionID != "worker-1" {
+		t.Fatalf("get dispatch = %q %+v", cmd, data)
+	}
+
+	cmd, data, err = ParseMessage([]byte(`{
+		"cmd":"resolve_dispatch_request",
+		"source_session_id":"chief-1",
+		"dispatch_id":"dispatch-1",
+		"response":"Use V1.",
+		"resolution_link":"https://example.test/decision"
+	}`))
+	if err != nil {
+		t.Fatalf("ParseMessage(resolve_dispatch_request) error = %v", err)
+	}
+	resolution := data.(*ResolveDispatchRequestMessage)
+	if cmd != CmdResolveDispatchRequest ||
+		resolution.DispatchID != "dispatch-1" ||
+		resolution.Response != "Use V1." {
+		t.Fatalf("resolve dispatch request = %q %+v", cmd, resolution)
 	}
 }
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -163,6 +163,71 @@ model WorkspaceContext {
   updated_at: string;
 }
 
+enum DispatchReportType {
+  progress,
+  blocker,
+  handoff,
+  completion,
+  failure,
+}
+
+enum DispatchWorkState {
+  in_progress,
+  needs_input,
+  ready_for_review,
+  completed,
+  failed,
+}
+
+enum DispatchRequestStatus {
+  pending,
+  resolved,
+}
+
+model DispatchDecisionRequest {
+  question: string;
+  recommendation?: string;
+  consequence?: string;
+  expected_responder: string;
+  status: DispatchRequestStatus;
+  response?: string;
+  resolution_link?: string;
+  responded_by?: string;
+  responded_at?: string;
+}
+
+model DispatchArtifact {
+  identity: string;
+  workspace_id?: string;
+  branch?: string;
+  revision?: string;
+  dirty?: boolean;
+  description?: string;
+}
+
+model DispatchVerification {
+  actor: string;
+  target: string;
+  result: string;
+  timestamp: string;
+  artifact_identity: string;
+  current?: boolean;
+}
+
+model DispatchReport {
+  report_type: DispatchReportType;
+  summary: string;
+  work_state: DispatchWorkState;
+  next_actor?: string;
+  next_action?: string;
+  remaining_scope?: string[];
+  constraints?: string[];
+  request?: DispatchDecisionRequest;
+  artifact?: DispatchArtifact;
+  verification?: DispatchVerification[];
+  reported_at: string;
+}
+
 model ChiefOfStaffDispatch {
   id: string;
   chief_session_id: string;
@@ -176,6 +241,9 @@ model ChiefOfStaffDispatch {
   status: string;
   status_since: string;
   latest_report?: string;
+  structured_report?: DispatchReport;
+  concise_summary?: string;
+  actionable?: boolean;
   reported_at?: string;
   created_at: string;
   updated_at: string;
@@ -429,6 +497,20 @@ model ReportDispatchMessage {
   cmd: "report_dispatch";
   source_session_id: string;
   report: string;
+  structured_report?: DispatchReport;
+}
+
+model GetDispatchMessage {
+  cmd: "get_dispatch";
+  source_session_id: string;
+}
+
+model ResolveDispatchRequestMessage {
+  cmd: "resolve_dispatch_request";
+  source_session_id: string;
+  dispatch_id: string;
+  response: string;
+  resolution_link?: string;
 }
 
 model WorkspaceContextCheckoutMessage {

--- a/internal/store/chief_of_staff_dispatches.go
+++ b/internal/store/chief_of_staff_dispatches.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -23,7 +24,52 @@ func cloneChiefOfStaffDispatch(dispatch *protocol.ChiefOfStaffDispatch) *protoco
 	if dispatch.ReportedAt != nil {
 		cloned.ReportedAt = protocol.Ptr(protocol.Deref(dispatch.ReportedAt))
 	}
+	cloned.StructuredReport = cloneDispatchReport(dispatch.StructuredReport)
+	if dispatch.ConciseSummary != nil {
+		cloned.ConciseSummary = protocol.Ptr(protocol.Deref(dispatch.ConciseSummary))
+	}
+	if dispatch.Actionable != nil {
+		cloned.Actionable = protocol.Ptr(protocol.Deref(dispatch.Actionable))
+	}
 	return &cloned
+}
+
+func cloneDispatchReport(report *protocol.DispatchReport) *protocol.DispatchReport {
+	if report == nil {
+		return nil
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		return nil
+	}
+	var cloned protocol.DispatchReport
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return nil
+	}
+	return &cloned
+}
+
+func encodeDispatchReport(report *protocol.DispatchReport) (string, error) {
+	if report == nil {
+		return "", nil
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		return "", fmt.Errorf("encode structured dispatch report: %w", err)
+	}
+	return string(data), nil
+}
+
+func decodeDispatchReport(data string) *protocol.DispatchReport {
+	data = strings.TrimSpace(data)
+	if data == "" {
+		return nil
+	}
+	var report protocol.DispatchReport
+	if err := json.Unmarshal([]byte(data), &report); err != nil {
+		return nil
+	}
+	return &report
 }
 
 func (s *Store) AddChiefOfStaffDispatch(dispatch *protocol.ChiefOfStaffDispatch) error {
@@ -47,11 +93,16 @@ func (s *Store) AddChiefOfStaffDispatch(dispatch *protocol.ChiefOfStaffDispatch)
 		return nil
 	}
 
-	_, err := s.db.Exec(`
+	structuredReportJSON, err := encodeDispatchReport(dispatch.StructuredReport)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`
 		INSERT INTO chief_of_staff_dispatches (
 			id, chief_session_id, session_id, workspace_id, brief, label, agent,
-			directory, branch, latest_report, reported_at, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			directory, branch, latest_report, structured_report_json, reported_at,
+			created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		dispatch.ID,
 		dispatch.ChiefSessionID,
 		dispatch.SessionID,
@@ -62,6 +113,7 @@ func (s *Store) AddChiefOfStaffDispatch(dispatch *protocol.ChiefOfStaffDispatch)
 		dispatch.Directory,
 		protocol.Deref(dispatch.Branch),
 		protocol.Deref(dispatch.LatestReport),
+		structuredReportJSON,
 		protocol.Deref(dispatch.ReportedAt),
 		dispatch.CreatedAt,
 		dispatch.UpdatedAt,
@@ -107,10 +159,33 @@ func (s *Store) GetChiefOfStaffDispatchBySession(sessionID string) *protocol.Chi
 
 	row := s.db.QueryRow(`
 		SELECT id, chief_session_id, session_id, workspace_id, brief, label, agent,
-			directory, branch, latest_report, reported_at, created_at, updated_at
+			directory, branch, latest_report, structured_report_json, reported_at,
+			created_at, updated_at
 		FROM chief_of_staff_dispatches
 		WHERE session_id = ?`,
 		sessionID,
+	)
+	return scanChiefOfStaffDispatch(row)
+}
+
+func (s *Store) GetChiefOfStaffDispatch(id string) *protocol.ChiefOfStaffDispatch {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil
+	}
+	if s.db == nil {
+		return cloneChiefOfStaffDispatch(s.chiefDispatches[id])
+	}
+	row := s.db.QueryRow(`
+		SELECT id, chief_session_id, session_id, workspace_id, brief, label, agent,
+			directory, branch, latest_report, structured_report_json, reported_at,
+			created_at, updated_at
+		FROM chief_of_staff_dispatches
+		WHERE id = ?`,
+		id,
 	)
 	return scanChiefOfStaffDispatch(row)
 }
@@ -139,7 +214,8 @@ func (s *Store) ListChiefOfStaffDispatches(chiefSessionID string) []*protocol.Ch
 
 	query := `
 		SELECT id, chief_session_id, session_id, workspace_id, brief, label, agent,
-			directory, branch, latest_report, reported_at, created_at, updated_at
+			directory, branch, latest_report, structured_report_json, reported_at,
+			created_at, updated_at
 		FROM chief_of_staff_dispatches`
 	var (
 		rows *sql.Rows
@@ -165,6 +241,13 @@ func (s *Store) ListChiefOfStaffDispatches(chiefSessionID string) []*protocol.Ch
 }
 
 func (s *Store) UpdateChiefOfStaffDispatchReport(sessionID, report string) (*protocol.ChiefOfStaffDispatch, error) {
+	return s.UpdateChiefOfStaffDispatchReportEnvelope(sessionID, report, nil)
+}
+
+func (s *Store) UpdateChiefOfStaffDispatchReportEnvelope(
+	sessionID, report string,
+	structuredReport *protocol.DispatchReport,
+) (*protocol.ChiefOfStaffDispatch, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -177,6 +260,23 @@ func (s *Store) UpdateChiefOfStaffDispatchReport(sessionID, report string) (*pro
 		return nil, fmt.Errorf("report cannot be empty")
 	}
 	now := string(protocol.TimestampNow())
+	structuredReport = cloneDispatchReport(structuredReport)
+	if structuredReport != nil {
+		structuredReport.ReportedAt = now
+		artifactIdentity := ""
+		if structuredReport.Artifact != nil {
+			artifactIdentity = strings.TrimSpace(structuredReport.Artifact.Identity)
+		}
+		for i := range structuredReport.Verification {
+			current := artifactIdentity != "" &&
+				strings.TrimSpace(structuredReport.Verification[i].ArtifactIdentity) == artifactIdentity
+			structuredReport.Verification[i].Current = protocol.Ptr(current)
+		}
+	}
+	structuredReportJSON, err := encodeDispatchReport(structuredReport)
+	if err != nil {
+		return nil, err
+	}
 	if s.db == nil {
 		for id, dispatch := range s.chiefDispatches {
 			if dispatch.SessionID != sessionID {
@@ -184,6 +284,7 @@ func (s *Store) UpdateChiefOfStaffDispatchReport(sessionID, report string) (*pro
 			}
 			updated := cloneChiefOfStaffDispatch(dispatch)
 			updated.LatestReport = protocol.Ptr(report)
+			updated.StructuredReport = structuredReport
 			updated.ReportedAt = protocol.Ptr(now)
 			updated.UpdatedAt = now
 			s.chiefDispatches[id] = updated
@@ -194,9 +295,10 @@ func (s *Store) UpdateChiefOfStaffDispatchReport(sessionID, report string) (*pro
 
 	result, err := s.db.Exec(`
 		UPDATE chief_of_staff_dispatches
-		SET latest_report = ?, reported_at = ?, updated_at = ?
+		SET latest_report = ?, structured_report_json = ?, reported_at = ?, updated_at = ?
 		WHERE session_id = ?`,
 		report,
+		structuredReportJSON,
 		now,
 		now,
 		sessionID,
@@ -214,7 +316,8 @@ func (s *Store) UpdateChiefOfStaffDispatchReport(sessionID, report string) (*pro
 
 	row := s.db.QueryRow(`
 		SELECT id, chief_session_id, session_id, workspace_id, brief, label, agent,
-			directory, branch, latest_report, reported_at, created_at, updated_at
+			directory, branch, latest_report, structured_report_json, reported_at,
+			created_at, updated_at
 		FROM chief_of_staff_dispatches
 		WHERE session_id = ?`,
 		sessionID,
@@ -226,14 +329,92 @@ func (s *Store) UpdateChiefOfStaffDispatchReport(sessionID, report string) (*pro
 	return dispatch, nil
 }
 
+func (s *Store) ResolveChiefOfStaffDispatchRequest(
+	dispatchID, chiefSessionID, response, resolutionLink string,
+) (*protocol.ChiefOfStaffDispatch, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dispatchID = strings.TrimSpace(dispatchID)
+	chiefSessionID = strings.TrimSpace(chiefSessionID)
+	response = strings.TrimSpace(response)
+	resolutionLink = strings.TrimSpace(resolutionLink)
+	if dispatchID == "" {
+		return nil, fmt.Errorf("dispatch id cannot be empty")
+	}
+	if chiefSessionID == "" {
+		return nil, fmt.Errorf("chief session id cannot be empty")
+	}
+	if response == "" {
+		return nil, fmt.Errorf("response cannot be empty")
+	}
+
+	var dispatch *protocol.ChiefOfStaffDispatch
+	if s.db == nil {
+		dispatch = cloneChiefOfStaffDispatch(s.chiefDispatches[dispatchID])
+	} else {
+		row := s.db.QueryRow(`
+			SELECT id, chief_session_id, session_id, workspace_id, brief, label, agent,
+				directory, branch, latest_report, structured_report_json, reported_at,
+				created_at, updated_at
+			FROM chief_of_staff_dispatches
+			WHERE id = ?`,
+			dispatchID,
+		)
+		dispatch = scanChiefOfStaffDispatch(row)
+	}
+	if dispatch == nil {
+		return nil, fmt.Errorf("dispatch %s not found", dispatchID)
+	}
+	if dispatch.ChiefSessionID != chiefSessionID {
+		return nil, fmt.Errorf("dispatch %s is not owned by chief session %s", dispatchID, chiefSessionID)
+	}
+	if dispatch.StructuredReport == nil || dispatch.StructuredReport.Request == nil {
+		return nil, fmt.Errorf("dispatch %s has no active decision request", dispatchID)
+	}
+	if dispatch.StructuredReport.Request.Status != protocol.DispatchRequestStatusPending {
+		return nil, fmt.Errorf("dispatch %s decision request is already resolved", dispatchID)
+	}
+
+	now := string(protocol.TimestampNow())
+	dispatch.StructuredReport.Request.Status = protocol.DispatchRequestStatusResolved
+	dispatch.StructuredReport.Request.Response = protocol.Ptr(response)
+	dispatch.StructuredReport.Request.RespondedBy = protocol.Ptr(chiefSessionID)
+	dispatch.StructuredReport.Request.RespondedAt = protocol.Ptr(now)
+	if resolutionLink != "" {
+		dispatch.StructuredReport.Request.ResolutionLink = protocol.Ptr(resolutionLink)
+	}
+	dispatch.UpdatedAt = now
+
+	if s.db == nil {
+		s.chiefDispatches[dispatchID] = cloneChiefOfStaffDispatch(dispatch)
+		return cloneChiefOfStaffDispatch(dispatch), nil
+	}
+	structuredReportJSON, err := encodeDispatchReport(dispatch.StructuredReport)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.db.Exec(`
+		UPDATE chief_of_staff_dispatches
+		SET structured_report_json = ?, updated_at = ?
+		WHERE id = ?`,
+		structuredReportJSON,
+		now,
+		dispatchID,
+	); err != nil {
+		return nil, fmt.Errorf("resolve dispatch request: %w", err)
+	}
+	return dispatch, nil
+}
+
 type dispatchScanner interface {
 	Scan(dest ...interface{}) error
 }
 
 func scanChiefOfStaffDispatch(scanner dispatchScanner) *protocol.ChiefOfStaffDispatch {
 	var (
-		dispatch                         protocol.ChiefOfStaffDispatch
-		branch, latestReport, reportedAt sql.NullString
+		dispatch                                               protocol.ChiefOfStaffDispatch
+		branch, latestReport, structuredReportJSON, reportedAt sql.NullString
 	)
 	if err := scanner.Scan(
 		&dispatch.ID,
@@ -246,6 +427,7 @@ func scanChiefOfStaffDispatch(scanner dispatchScanner) *protocol.ChiefOfStaffDis
 		&dispatch.Directory,
 		&branch,
 		&latestReport,
+		&structuredReportJSON,
 		&reportedAt,
 		&dispatch.CreatedAt,
 		&dispatch.UpdatedAt,
@@ -257,6 +439,9 @@ func scanChiefOfStaffDispatch(scanner dispatchScanner) *protocol.ChiefOfStaffDis
 	}
 	if latestReport.Valid && latestReport.String != "" {
 		dispatch.LatestReport = protocol.Ptr(latestReport.String)
+	}
+	if structuredReportJSON.Valid {
+		dispatch.StructuredReport = decodeDispatchReport(structuredReportJSON.String)
 	}
 	if reportedAt.Valid && reportedAt.String != "" {
 		dispatch.ReportedAt = protocol.Ptr(reportedAt.String)

--- a/internal/store/chief_of_staff_dispatches_test.go
+++ b/internal/store/chief_of_staff_dispatches_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -48,5 +49,129 @@ func TestChiefOfStaffDispatchLifecycle(t *testing.T) {
 	}
 	if got := s.GetChiefOfStaffDispatchBySession("worker-1"); got != nil {
 		t.Fatalf("dispatch after delete = %+v", got)
+	}
+}
+
+func TestChiefOfStaffStructuredReportPersistsAndResolves(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	now := string(protocol.TimestampNow())
+	dispatch := &protocol.ChiefOfStaffDispatch{
+		ID:             "dispatch-structured",
+		ChiefSessionID: "chief-1",
+		SessionID:      "worker-1",
+		WorkspaceID:    "workspace-1",
+		Brief:          "Implement the feature.",
+		Label:          "Feature",
+		Agent:          "codex",
+		Directory:      "/tmp/project",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := s.AddChiefOfStaffDispatch(dispatch); err != nil {
+		t.Fatalf("add dispatch: %v", err)
+	}
+
+	report := &protocol.DispatchReport{
+		ReportType: protocol.DispatchReportTypeBlocker,
+		Summary:    "Core implementation ready locally",
+		WorkState:  protocol.DispatchWorkStateNeedsInput,
+		NextActor:  protocol.Ptr("team"),
+		NextAction: protocol.Ptr("Decide the event contract"),
+		RemainingScope: []string{
+			"Emit the event",
+			"Add the integration test",
+		},
+		Constraints: []string{"uncommitted", "no push", "no PR"},
+		Request: &protocol.DispatchDecisionRequest{
+			Question:          "Which event contract should be used?",
+			Recommendation:    protocol.Ptr("Use AisNoOperationV1"),
+			Consequence:       protocol.Ptr("Event emission remains blocked"),
+			ExpectedResponder: "team",
+			Status:            protocol.DispatchRequestStatusPending,
+		},
+		Artifact: &protocol.DispatchArtifact{
+			Identity: "dirty:abc123",
+			Branch:   protocol.Ptr("feat/work"),
+			Dirty:    protocol.Ptr(true),
+		},
+		Verification: []protocol.DispatchVerification{
+			{
+				Actor:            "agent",
+				Target:           "go test ./internal/feature",
+				Result:           "passed",
+				Timestamp:        now,
+				ArtifactIdentity: "dirty:abc123",
+			},
+			{
+				Actor:            "chief",
+				Target:           "go test ./internal/feature",
+				Result:           "passed on prior revision",
+				Timestamp:        now,
+				ArtifactIdentity: "commit:old",
+			},
+		},
+	}
+	updated, err := s.UpdateChiefOfStaffDispatchReportEnvelope(
+		"worker-1",
+		"Core implementation is ready; event emission needs a decision.",
+		report,
+	)
+	if err != nil {
+		t.Fatalf("update structured report: %v", err)
+	}
+	if updated.StructuredReport == nil || updated.StructuredReport.ReportedAt == "" {
+		t.Fatalf("structured report = %+v", updated.StructuredReport)
+	}
+	if !protocol.Deref(updated.StructuredReport.Verification[0].Current) {
+		t.Fatalf("matching verification not current: %+v", updated.StructuredReport.Verification)
+	}
+	if protocol.Deref(updated.StructuredReport.Verification[1].Current) {
+		t.Fatalf("mismatched verification current: %+v", updated.StructuredReport.Verification)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	s, err = NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	persisted := s.GetChiefOfStaffDispatchBySession("worker-1")
+	if persisted == nil || persisted.StructuredReport == nil {
+		t.Fatalf("persisted dispatch = %+v", persisted)
+	}
+	if persisted.StructuredReport.Summary != "Core implementation ready locally" {
+		t.Fatalf("persisted report = %+v", persisted.StructuredReport)
+	}
+
+	resolved, err := s.ResolveChiefOfStaffDispatchRequest(
+		"dispatch-structured",
+		"chief-1",
+		"Use AisNoOperationV1.",
+		"https://example.test/decision",
+	)
+	if err != nil {
+		t.Fatalf("resolve request: %v", err)
+	}
+	request := resolved.StructuredReport.Request
+	if request.Status != protocol.DispatchRequestStatusResolved ||
+		protocol.Deref(request.Response) != "Use AisNoOperationV1." ||
+		protocol.Deref(request.ResolutionLink) != "https://example.test/decision" ||
+		protocol.Deref(request.RespondedBy) != "chief-1" {
+		t.Fatalf("resolved request = %+v", request)
+	}
+	if _, err := s.ResolveChiefOfStaffDispatchRequest(
+		"dispatch-structured",
+		"chief-other",
+		"Wrong owner",
+		"",
+	); err == nil {
+		t.Fatal("resolve with wrong chief succeeded")
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -362,6 +362,10 @@ var migrations = []migration{
 		CREATE INDEX IF NOT EXISTS idx_chief_dispatches_chief_created
 			ON chief_of_staff_dispatches(chief_session_id, created_at DESC);
 	`},
+	{45, "add structured coordination report to chief dispatches", `
+		ALTER TABLE chief_of_staff_dispatches
+			ADD COLUMN structured_report_json TEXT NOT NULL DEFAULT '';
+	`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -500,6 +504,11 @@ func migrateDB(db *sql.DB) error {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
+		} else if m.version == 45 {
+			if err := applyMigration45(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
 		} else {
 			if _, err := tx.Exec(m.sql); err != nil {
 				tx.Rollback()
@@ -587,6 +596,21 @@ func applyMigration23(tx *sql.Tx) error {
 		return err
 	}
 	return nil
+}
+
+func applyMigration45(tx *sql.Tx) error {
+	hasStructuredReport, err := columnExists(tx, "chief_of_staff_dispatches", "structured_report_json")
+	if err != nil {
+		return err
+	}
+	if hasStructuredReport {
+		return nil
+	}
+	_, err = tx.Exec(`
+		ALTER TABLE chief_of_staff_dispatches
+			ADD COLUMN structured_report_json TEXT NOT NULL DEFAULT ''
+	`)
+	return err
 }
 
 func applyMigration28(tx *sql.Tx) error {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -162,6 +162,7 @@ func TestMigrations_MigratedColumnsExist(t *testing.T) {
 		{"sessions", "agent_driver_plugin_name"},
 		{"sessions", "agent_driver_run_id"},
 		{"sessions", "agent_driver_report_seq"},
+		{"chief_of_staff_dispatches", "structured_report_json"},
 	}
 
 	for _, tc := range migratedColumns {


### PR DESCRIPTION
## Why

PR #291 made chief-originated delegation visible, but runtime presence still had to stand in for the work's actual disposition. A delegated agent could be idle while its implementation was ready locally but blocked on a decision, leaving the chief to parse prose, inspect Git, and reconstruct ownership and evidence.

This adds a thin coordination protocol so chiefs can act on delegated work without turning attn into a workflow engine, approval system, or Jira replacement.

Related: #291

## Summary

- keep projected session runtime status separate from a narrow dispatch work state: in progress, needs input, ready for review, completed, or failed
- persist an optional structured latest-report envelope beside the existing narrative, including next ownership/action, remaining scope, constraints, artifact identity, and verifier-attributed evidence
- support one durable decision request per dispatch and a chief-owned `attn dispatch resolve` path; workers read the response with `attn dispatch status`
- derive concise/actionable API and dashboard views without showing the complete delegation brief
- mark verification current only when its artifact identity matches the report artifact
- preserve legacy `dispatch report --message` and `--file` behavior through additive SQLite migration 45
- clarify that attn delegation creates a visible interactive agent the user can steer, while internal research and verification default to native subagents

## Test plan

- [x] `go test ./...` before the documentation-only delegation-boundary increment
- [x] `go test ./internal/agent ./cmd/attn ./internal/protocol ./internal/store`
- [x] embedded Claude/Codex skill installation tests, repeated five times
- [x] frontend Vitest suite: 83 files, 666 tests
- [x] `pnpm --dir app run build`
- [x] structured resolution/actionability tests, repeated 20 times
- [x] deterministic `make generate-types`
- [x] `git diff --check` and `gofmt -d` on changed Go files
- [x] attn-dev report, resolve, and worker-status CLI round trip
- [x] production build/install and installed skill-content verification
- [x] GitHub required checks

## Out of scope

- report history or customizable workflows
- general-purpose chat or PTY prompt injection
- Jira or Slack lifecycle synchronization
- automatic state inference from narrative reports
- automatic artifact identity generation
