### PR TITLE
fix(chief-of-staff): hide closed dispatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Terminals use less graphics memory.** Every live terminal used to preallocate a large fixed GPU texture to cache rendered characters. It now starts small and grows only if a session actually displays many distinct characters (such as heavy CJK or emoji output). Text looks identical, and with several sessions open this frees roughly 90 MB of graphics memory.
 
 ### Fixed
+- **Closed delegated sessions no longer remain on the Chief of Staff dashboard.** Closing a delegated session now removes it from the active home view while retaining its dispatch report as history.
 - **Closed sessions no longer flicker back into the sidebar as launching.** The daemon now publishes an authoritative empty layout when shared context keeps a workspace alive after its final pane closes, and the app also discards cached layouts that still reference an explicitly closed session.
 
 ## [2026-06-08]

--- a/app/src/components/Dashboard.test.tsx
+++ b/app/src/components/Dashboard.test.tsx
@@ -158,4 +158,54 @@ describe('Dashboard sessions', () => {
     fireEvent.click(dispatch);
     expect(onSelectSession).toHaveBeenCalledWith('worker-1');
   });
+
+  it('hides a dispatch after its delegated session is closed', () => {
+    daemonStoreState.chiefOfStaffDispatches = [{
+      id: 'dispatch-closed',
+      chief_session_id: 'chief-1',
+      session_id: 'worker-closed',
+      workspace_id: 'workspace-1',
+      brief: 'Investigate the parser.',
+      label: 'Parser investigation',
+      agent: 'codex',
+      directory: '/repo/a',
+      status: 'closed',
+      status_since: '',
+      latest_report: 'Investigation complete.',
+      reported_at: '2026-06-09T10:10:00Z',
+      created_at: '2026-06-09T10:00:00Z',
+      updated_at: '2026-06-09T10:10:00Z',
+    }];
+
+    const props = {
+      prs: [],
+      isLoading: false,
+      onSelectSession: vi.fn(),
+      onNewSession: vi.fn(),
+      onOpenSettings: vi.fn(),
+    };
+    const { rerender } = render(
+      <Dashboard
+        sessions={[
+          { id: 'chief-1', label: 'planner', state: 'working', cwd: '/repo/a', chiefOfStaff: true },
+          { id: 'worker-closed', label: 'parser-worker', state: 'idle', cwd: '/repo/a' },
+        ]}
+        {...props}
+      />
+    );
+
+    expect(screen.getByTestId('chief-dispatch-dispatch-closed')).toBeInTheDocument();
+
+    rerender(
+      <Dashboard
+        sessions={[
+          { id: 'chief-1', label: 'planner', state: 'working', cwd: '/repo/a', chiefOfStaff: true },
+        ]}
+        {...props}
+      />
+    );
+
+    expect(screen.queryByTestId('chief-dispatch-dispatch-closed')).not.toBeInTheDocument();
+    expect(screen.getByText('No delegated work yet.')).toBeInTheDocument();
+  });
 });

--- a/app/src/components/Dashboard.tsx
+++ b/app/src/components/Dashboard.tsx
@@ -109,10 +109,13 @@ export function Dashboard({
   const [fadingPRs, setFadingPRs] = useState<Set<string>>(new Set());
   const { sendMuteRepo, sendPRVisited } = useDaemonContext();
   const { chiefOfStaffDispatches } = useDaemonStore();
+  const visibleDispatches = chiefOfStaffDispatches.filter((dispatch) =>
+    dispatchSessions.some((session) => session.id === dispatch.session_id)
+  );
   const activeChiefDispatches = chiefSession
-    ? chiefOfStaffDispatches.filter((dispatch) => dispatch.chief_session_id === chiefSession.id)
+    ? visibleDispatches.filter((dispatch) => dispatch.chief_session_id === chiefSession.id)
     : [];
-  const historicalChiefDispatches = chiefOfStaffDispatches.filter(
+  const historicalChiefDispatches = visibleDispatches.filter(
     (dispatch) => dispatch.chief_session_id !== chiefSession?.id,
   );
 
@@ -493,7 +496,7 @@ export function Dashboard({
             <h2>Chief of Staff</h2>
           </div>
           <div className="card-body">
-            {!chiefSession && chiefOfStaffDispatches.length === 0 ? (
+            {!chiefSession && visibleDispatches.length === 0 ? (
               <div className="card-empty">Assign a session as chief to track delegated work.</div>
             ) : (
               <>


### PR DESCRIPTION
## Why

The home dashboard is an operational view of work the user can still inspect and steer. A persisted chief-of-staff dispatch remained there after its delegated session was closed, leaving a disabled historical row with no useful action.

## What changed

- Show chief-of-staff dispatches on home only while their delegated session is open.
- Keep the persisted dispatch report intact so a later delegation registry can expose history.
- Add a regression test covering session removal without dispatch deletion.
- Document the user-visible behavior.

## Test plan

- [x] `pnpm --dir app exec vitest run src/components/Dashboard.test.tsx`
- [x] `pnpm --dir app exec tsc --noEmit`
- [x] Full frontend suite: 83 files, 666 tests
- [x] `git diff --check`