### PR TITLE
fix(terminal): prevent resize render storms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ make install-daemon-dev  # faster: only rebuild the Go sidecar inside attn-dev.a
 
 The dev install is fully isolated: its own bundle identifier (`com.attn.manager.dev`), its own data dir (`~/.attn-dev/`), its own socket, its own port. Once a fix is verified, run `make` to install the production app so the user receives the fix immediately. The production install closes and reopens the app and restarts its daemon; attn is designed to recover persisted session state gracefully. `make install` and `make install-daemon` refuse at parse time if `ATTN_PROFILE` is set in the environment — if you hit that error during iteration, you meant `make dev`.
 
+Run full app builds and installs via `make` or `make dev` outside the sandbox. These commands need access to the user's macOS keychain so `security find-identity` can select the stable code-signing identity. Inside the sandbox, identity discovery can incorrectly return nothing, causing certificate creation or ad-hoc signing and breaking the app's persistent macOS permissions.
+
 To make CLI commands (`attn`, `attn list`, etc.) target the dev daemon in your shell, run `eval "$(./attn profile-env dev)"` (bash/zsh) or `./attn profile-env --fish dev | source` (fish). Any `attn` subcommand then prints a one-line `[attn profile=dev ...]` banner so you can always see which daemon you're talking to. Unset with `eval "$(attn profile-env --unset)"`.
 
 Frontend-only shortcuts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Closed delegated sessions no longer remain on the Chief of Staff dashboard.** Closing a delegated session now removes it from the active home view while retaining its dispatch report as history.
+- **Returning to a resized workspace no longer lets busy split terminals freeze the app.** Hidden workspaces keep their terminal state current without continuously repainting WebGL surfaces, live output paints at most once per animation frame, and duplicate same-size PTY resize acknowledgements no longer trigger full redraws.
 - **Closed sessions no longer flicker back into the sidebar as launching.** The daemon now publishes an authoritative empty layout when shared context keeps a workspace alive after its final pane closes, and the app also discards cached layouts that still reference an explicitly closed session.
 
 ## [2026-06-08]

--- a/app/e2e/split-blank-repro.spec.ts
+++ b/app/e2e/split-blank-repro.spec.ts
@@ -54,7 +54,11 @@ async function readTrace(
   sessionId: string,
 ): Promise<RenderTraceEntry[]> {
   return page.evaluate((sid) => {
-    const all = (window as Window & { __ATTN_RENDER_TRACE?: RenderTraceEntry[] }).__ATTN_RENDER_TRACE ?? [];
+    const diagnostics = window as Window & {
+      __ATTN_RENDER_TRACE?: RenderTraceEntry[];
+      __ATTN_TERMINAL_DIAG_DUMP?: () => RenderTraceEntry[];
+    };
+    const all = diagnostics.__ATTN_TERMINAL_DIAG_DUMP?.() ?? diagnostics.__ATTN_RENDER_TRACE ?? [];
     return all.filter((entry) =>
       entry.kind === 'paint'
       && (entry.session === sid || (typeof entry.pane === 'string' && entry.pane.includes(sid))));
@@ -274,4 +278,62 @@ test('agent stays painted when split lands while scrolled up', async ({ page, da
   await terminal.screenshot({ path: 'test-results/split-blank-scrolled.png' }).catch(() => {});
   // Diagnostic only: report whether a stale scrollback slice was painted.
   console.log('offset on last paint:', last?.offset, 'force:', last?.force, 'quads:', last?.quads);
+});
+
+test('hidden split workspace defers paints until return after a window resize', async ({ page, daemon }) => {
+  await daemon.start();
+  await page.setViewportSize({ width: 1400, height: 900 });
+  await page.goto('/');
+  await page.waitForSelector('.dashboard');
+
+  const agentId = 's-agent-home-resize';
+  const terminal = await setupAgent(page, daemon, agentId);
+  await emit(page, agentId, fullFrame('BASELINE'));
+  await expect
+    .poll(async () => page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_TEXT?.(sid) ?? '', agentId))
+    .toContain('BASELINE line 0');
+
+  const sizeBeforeSplit = await page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_SIZE?.(sid) ?? null, agentId);
+  await terminal.click({ position: { x: 80, y: 8 } });
+  await page.keyboard.press('Meta+d');
+  await expect
+    .poll(async () => {
+      const size = await page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_SIZE?.(sid) ?? null, agentId);
+      if (!size || !sizeBeforeSplit) return 'no-size';
+      return size.rows !== sizeBeforeSplit.rows || size.cols !== sizeBeforeSplit.cols ? 'resized' : 'same';
+    })
+    .toBe('resized');
+  await page.waitForTimeout(100);
+
+  await page.keyboard.press('Meta+Shift+h');
+  await expect(page.locator('.dashboard')).toBeVisible();
+  await page.setViewportSize({ width: 900, height: 650 });
+  await page.waitForTimeout(100);
+
+  const paintsBeforeBurst = (await readTrace(page, agentId)).length;
+  const hiddenFrame = fullFrame('HIDDEN', 35, 90);
+  await page.evaluate(({ id, payloads }) => {
+    for (const payload of payloads) {
+      window.__TEST_EMIT_PTY_DATA?.(id, payload);
+    }
+  }, { id: agentId, payloads: chunks(hiddenFrame, 32) });
+  await expect
+    .poll(async () => page.evaluate((sid) => window.__TEST_GET_SESSION_PANE_TEXT?.(sid) ?? '', agentId))
+    .toContain('HIDDEN line 0');
+  await page.waitForTimeout(100);
+  expect((await readTrace(page, agentId)).length).toBe(paintsBeforeBurst);
+
+  await page.locator(`[data-testid="session-${agentId}"]`).click();
+  await expect(terminal).toBeVisible();
+  await expect
+    .poll(async () => (await readTrace(page, agentId)).length)
+    .toBeGreaterThan(paintsBeforeBurst);
+
+  const trace = await readTrace(page, agentId);
+  const postReturnPaints = trace
+    .slice(paintsBeforeBurst)
+    .filter((entry) => (entry.quads ?? 0) > 0);
+  const substantivePaint = postReturnPaints[postReturnPaints.length - 1];
+  expect(substantivePaint?.cols).toBeLessThan(100);
+  expect(substantivePaint?.quads ?? 0).toBeGreaterThan(50);
 });

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -275,6 +275,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const osc52StateRef = useRef<Osc52State>({ pending: '' });
     const synchronizedOutputStateRef = useRef<SynchronizedOutputState>({ active: false, pending: '' });
     const synchronizedOutputRenderTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const scheduledOutputRenderRef = useRef<number | null>(null);
     const renderCountRef = useRef(0);
     const writeCountRef = useRef(0);
     // Diagnostics: model instance (increments on rebuild) and last paint quads,
@@ -324,6 +325,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       const terminal = terminalRef.current;
       const renderer = rendererRef.current;
       if (!terminal || !renderer) return;
+      if (runtimeMetaRef.current && !runtimeMetaRef.current.isActiveSession) return;
       const range = selectionRef.current ? normalizeSelection(selectionRef.current) : null;
       const scrollbackLength = terminal.getScrollbackLength();
       const overlay: WebGlSelection | null = range ? {
@@ -360,19 +362,33 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       synchronizedOutputRenderTimerRef.current = null;
     }, []);
 
+    const cancelScheduledOutputRender = useCallback(() => {
+      if (scheduledOutputRenderRef.current === null) return;
+      cancelAnimationFrame(scheduledOutputRenderRef.current);
+      scheduledOutputRenderRef.current = null;
+    }, []);
+
+    const scheduleOutputRender = useCallback(() => {
+      if (scheduledOutputRenderRef.current !== null) return;
+      scheduledOutputRenderRef.current = requestAnimationFrame(() => {
+        scheduledOutputRenderRef.current = null;
+        renderSurface(true);
+      });
+    }, [renderSurface]);
+
     const flushSynchronizedOutputRender = useCallback(() => {
       clearSynchronizedOutputRenderTimer();
-      renderSurface(true);
-    }, [clearSynchronizedOutputRenderTimer, renderSurface]);
+      scheduleOutputRender();
+    }, [clearSynchronizedOutputRenderTimer, scheduleOutputRender]);
 
     const scheduleSynchronizedOutputRenderFallback = useCallback(() => {
       if (synchronizedOutputRenderTimerRef.current) return;
       synchronizedOutputRenderTimerRef.current = setTimeout(() => {
         synchronizedOutputRenderTimerRef.current = null;
         synchronizedOutputStateRef.current = { active: false, pending: '' };
-        renderSurface(true);
+        scheduleOutputRender();
       }, SYNCHRONIZED_OUTPUT_RENDER_TIMEOUT_MS);
-    }, [renderSurface]);
+    }, [scheduleOutputRender]);
 
     const lineAtVisibleRow = useCallback((row: number): string => {
       const terminal = terminalRef.current;
@@ -644,6 +660,16 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       if (!terminal || !renderer) return;
       const fromCols = terminal.cols;
       const fromRows = terminal.rows;
+      if (fromCols === cols && fromRows === rows) {
+        modelSizeRef.current = { cols, rows };
+        noteResize(diagKeyRef.current, {
+          session: runtimeMetaRef.current?.sessionId ?? undefined,
+          paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
+          source: 'resizeLocal', fromCols, fromRows, toCols: cols, toRows: rows,
+          noop: true,
+        });
+        return;
+      }
       terminal.resize(cols, rows);
       modelSizeRef.current = { cols, rows };
       renderer.resize(cols, rows);
@@ -651,7 +677,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         session: runtimeMetaRef.current?.sessionId ?? undefined,
         paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
         source: 'resizeLocal', fromCols, fromRows, toCols: cols, toRows: rows,
-        noop: fromCols === cols && fromRows === rows,
+        noop: false,
       });
       renderSurface(true);
     }), [enqueueOperation, renderSurface]);
@@ -677,6 +703,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       }
       if (dims.cols === terminal.cols && dims.rows === terminal.rows) {
         noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'sameSize', toCols: dims.cols, toRows: dims.rows });
+        renderSurface(false);
         return;
       }
       const fromCols = terminal.cols;
@@ -861,6 +888,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         canvas.removeEventListener('webglcontextlost', handleContextLost);
         unregister();
         clearSynchronizedOutputRenderTimer();
+        cancelScheduledOutputRender();
         inputRef.current?.dispose();
         rendererRef.current?.dispose();
         terminalRef.current?.free();
@@ -871,7 +899,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // Ghostty cells contain their resolved default RGB values, so theme
     // changes require a fresh model. The pane runtime rehydrates this model
     // from verified replay without sending historical replies to the live PTY.
-    }, [clearSynchronizedOutputRenderTimer, fit, fontSize, getText, getVisibleContent, getVisibleStyleSummary, renderSurface, resizeLocal, resolvedTheme, write]);
+    }, [cancelScheduledOutputRender, clearSynchronizedOutputRenderTimer, fit, fontSize, getText, getVisibleContent, getVisibleStyleSummary, renderSurface, resizeLocal, resolvedTheme, write]);
 
     // Release this pane's WebGL2 context when the pane unmounts. Browsers cap the
     // number of simultaneously-live WebGL contexts (WKWebView's cap is low), and

--- a/app/src/utils/terminalDiagnosticsLog.test.ts
+++ b/app/src/utils/terminalDiagnosticsLog.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { recordDiag } from './terminalDiagnosticsLog';
+
+describe('terminal diagnostics ring', () => {
+  it('keeps the newest events in chronological order after wrapping', () => {
+    window.localStorage.setItem('attn:terminal-diagnostics', '1');
+    for (let sequence = 0; sequence < 3005; sequence += 1) {
+      recordDiag({ kind: 'write', sequence });
+    }
+
+    const events = window.__ATTN_TERMINAL_DIAG_DUMP?.() ?? [];
+    expect(events).toHaveLength(3000);
+    expect(events[0]?.sequence).toBe(5);
+    expect(events[events.length - 1]?.sequence).toBe(3004);
+  });
+});

--- a/app/src/utils/terminalDiagnosticsLog.ts
+++ b/app/src/utils/terminalDiagnosticsLog.ts
@@ -113,6 +113,8 @@ declare global {
 }
 
 const ring: DiagEvent[] = [];
+let ringNextIndex = 0;
+let ringWrapped = false;
 const paneHealth = new Map<string, PaneHealth>();
 const renderProbes = new Map<string, () => RenderProbe | null>();
 const watchdogTimers = new Map<string, ReturnType<typeof setTimeout>[]>();
@@ -156,7 +158,7 @@ function ensureGlobals() {
     incidents: `$APPLOCALDATA/${INCIDENT_FILE}`,
   };
   if (!window.__ATTN_TERMINAL_DIAG_DUMP) {
-    window.__ATTN_TERMINAL_DIAG_DUMP = () => [...ring];
+    window.__ATTN_TERMINAL_DIAG_DUMP = ringSnapshot;
   }
   if (!window.__ATTN_TERMINAL_DIAG_ENABLE) {
     window.__ATTN_TERMINAL_DIAG_ENABLE = (enabled: boolean) => {
@@ -216,10 +218,20 @@ function enqueueWrite(file: 'lifecycle' | 'incident', line: string) {
 }
 
 function pushRing(event: DiagEvent) {
-  ring.push(event);
-  if (ring.length > RING_LIMIT) {
-    ring.splice(0, ring.length - RING_LIMIT);
+  if (ring.length < RING_LIMIT) {
+    ring.push(event);
+    return;
   }
+  ring[ringNextIndex] = event;
+  ringNextIndex = (ringNextIndex + 1) % RING_LIMIT;
+  ringWrapped = true;
+}
+
+function ringSnapshot(): DiagEvent[] {
+  if (!ringWrapped) {
+    return [...ring];
+  }
+  return [...ring.slice(ringNextIndex), ...ring.slice(0, ringNextIndex)];
 }
 
 export function recordDiag(event: Omit<DiagEvent, 'at'>): void {
@@ -436,7 +448,7 @@ function maybeFlushIncident(pane: string, reason: string, detail: Record<string,
     session: health?.session,
     reason,
     detail,
-    context: ring.slice(-INCIDENT_CONTEXT_EVENTS),
+    context: ringSnapshot().slice(-INCIDENT_CONTEXT_EVENTS),
   };
   enqueueWrite('incident', `${JSON.stringify(record)}\n`);
 }


### PR DESCRIPTION
## Intent / Why

Returning from Home to a resized workspace with busy split terminals could starve the WebView main thread and freeze the entire attn window. Runtime evidence showed the daemon and PTYs remained responsive while frontend diagnostics stopped, pointing to repeated WebGL rendering rather than a daemon deadlock.

## Summary

- defer WebGL paints for hidden workspaces while keeping their Ghostty models current, then repaint dirty cells when the workspace becomes active
- coalesce output-driven paints to one animation frame and skip exact-size PTY resize acknowledgements
- replace the terminal diagnostics array shift with a true O(1) circular ring buffer
- add an end-to-end regression for Home -> window resize -> hidden output burst -> return to a split workspace
- document that signed app builds must run outside the sandbox so keychain identity discovery remains stable

## Test plan

- [x] `pnpm --dir app exec tsc --noEmit`
- [x] `pnpm --dir app exec vitest run src/utils/terminalDiagnosticsLog.test.ts src/utils/terminalSynchronizedOutput.test.ts src/utils/terminalSizing.test.ts`
- [x] `pnpm --dir app exec playwright test e2e/split-blank-repro.spec.ts`
- [x] packaged `attn-dev` reproduction with a real 1 MiB hidden-pane output burst and Home/resize/return flow
- [x] production app rebuilt, strictly signature-verified, installed, and relaunched with sessions recovered