### PR TITLE
feat(workspace): browse shared contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-06-09]
 
 ### Added
-- **⌘K opens a searchable action menu.** The first action opens a fullscreen workspace-context browser with search, keyboard navigation, revision metadata, and rendered Markdown. The existing attention drawer remains available from the menu and its dedicated ⌘⇧P shortcut.
+- **⌘K opens a searchable action menu.** The first action opens a fullscreen browser for workspace contexts stored on this Mac, with search, keyboard navigation, revision metadata, and rendered Markdown. The existing attention drawer remains available from the menu and its dedicated ⌘⇧P shortcut.
 - **Claude and Codex receive workspace-context guidance without cluttering their terminals.** attn gives each session a local checkout and concise hidden instructions to read it, keep durable goals and decisions current, publish edits, and reconcile revision conflicts without copying the shared context itself into the prompt.
 - **Promote one running session to chief of staff.** Session actions in the sidebar can assign, transfer, or remove the profile-wide role, with confirmation before replacing the current chief and clear badges in the sidebar and dashboard.
 - **Chiefs can track delegated work separately from agent runtime state.** Delegated agents can attach structured work state, next ownership, constraints, artifact-bound verification, and one decision request to the existing narrative report. Chiefs can resolve that request durably, agents can read the response with `attn dispatch status`, and the dashboard highlights actionable work without showing the full brief.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-06-09]
 
 ### Added
+- **⌘K opens a searchable action menu.** The first action opens a fullscreen workspace-context browser with search, keyboard navigation, revision metadata, and rendered Markdown. The existing attention drawer remains available from the menu and its dedicated ⌘⇧P shortcut.
 - **Claude and Codex receive workspace-context guidance without cluttering their terminals.** attn gives each session a local checkout and concise hidden instructions to read it, keep durable goals and decisions current, publish edits, and reconcile revision conflicts without copying the shared context itself into the prompt.
 - **Promote one running session to chief of staff.** Session actions in the sidebar can assign, transfer, or remove the profile-wide role, with confirmation before replacing the current chief and clear badges in the sidebar and dashboard.
 - **Chiefs can track delegated work separately from agent runtime state.** Delegated agents can attach structured work state, next ownership, constraints, artifact-bound verification, and one decision request to the existing narrative report. Chiefs can resolve that request durably, agents can read the response with `attn dispatch status`, and the dashboard highlights actionable work without showing the full brief.
@@ -21,9 +22,10 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Terminals use less graphics memory.** Every live terminal used to preallocate a large fixed GPU texture to cache rendered characters. It now starts small and grows only if a session actually displays many distinct characters (such as heavy CJK or emoji output). Text looks identical, and with several sessions open this frees roughly 90 MB of graphics memory.
 
 ### Fixed
+- **Closing a workspace now removes its shared context.** Workspace context no longer keeps an otherwise empty workspace alive, and startup cleanup removes context left behind by older closed workspaces. Workspaces with docked tiles still remain available.
 - **Closed delegated sessions no longer remain on the Chief of Staff dashboard.** Closing a delegated session now removes it from the active home view while retaining its dispatch report as history.
 - **Returning to a resized workspace no longer lets busy split terminals freeze the app.** Hidden workspaces keep their terminal state current without continuously repainting WebGL surfaces, live output paints at most once per animation frame, and duplicate same-size PTY resize acknowledgements no longer trigger full redraws.
-- **Closed sessions no longer flicker back into the sidebar as launching.** The daemon now publishes an authoritative empty layout when shared context keeps a workspace alive after its final pane closes, and the app also discards cached layouts that still reference an explicitly closed session.
+- **Closed sessions no longer flicker back into the sidebar as launching.** The daemon now publishes authoritative layout updates as final panes close, and the app also discards cached layouts that still reference an explicitly closed session.
 
 ## [2026-06-08]
 

--- a/app/e2e/keyboard-shortcuts.spec.ts
+++ b/app/e2e/keyboard-shortcuts.spec.ts
@@ -252,6 +252,16 @@ test.describe('Keyboard Shortcuts', () => {
       await expect(page.getByRole('dialog', { name: 'Action menu' })).toBeVisible();
       await expect(page.getByText('Browse workspace contexts')).toBeVisible();
 
+      await page.getByText('Browse workspace contexts').click();
+      const contextNavigator = page.getByRole('dialog', { name: 'Workspace contexts on this Mac' });
+      await expect(contextNavigator).toBeVisible();
+
+      await page.keyboard.press('Meta+k');
+      await expect(page.getByRole('dialog', { name: 'Action menu' })).not.toBeVisible();
+      await expect(contextNavigator).toBeVisible();
+
+      await page.keyboard.press('Escape');
+      await page.keyboard.press('Meta+k');
       await page.getByText('Open attention drawer').click();
       await expect(page.locator('.side-panel-shell.is-open .attention-drawer .attention-drawer-panel')).toBeVisible({ timeout: 2000 });
     });

--- a/app/e2e/keyboard-shortcuts.spec.ts
+++ b/app/e2e/keyboard-shortcuts.spec.ts
@@ -252,8 +252,15 @@ test.describe('Keyboard Shortcuts', () => {
       await expect(page.getByRole('dialog', { name: 'Action menu' })).toBeVisible();
       await expect(page.getByText('Browse workspace contexts')).toBeVisible();
 
+      await page.keyboard.press('Meta+n');
+      await expect(page.locator('.location-picker-overlay')).not.toBeVisible();
+
       await page.getByText('Browse workspace contexts').click();
       const contextNavigator = page.getByRole('dialog', { name: 'Workspace contexts on this Mac' });
+      await expect(contextNavigator).toBeVisible();
+
+      await page.keyboard.press('Meta+n');
+      await expect(page.locator('.location-picker-overlay')).not.toBeVisible();
       await expect(contextNavigator).toBeVisible();
 
       await page.keyboard.press('Meta+k');

--- a/app/e2e/keyboard-shortcuts.spec.ts
+++ b/app/e2e/keyboard-shortcuts.spec.ts
@@ -242,25 +242,19 @@ test.describe('Keyboard Shortcuts', () => {
     });
   });
 
-  test.describe('Attention Drawer', () => {
-    test('⌘K toggles attention drawer', async ({ page, daemon }) => {
+  test.describe('Action Menu', () => {
+    test('⌘K opens the action menu and preserves attention drawer access', async ({ page, daemon }) => {
       await daemon.start();
       await page.goto('/');
       await page.waitForSelector('.dashboard');
 
-      // Drawer should be closed initially
-      await expect(page.locator('.side-panel-shell.is-open .attention-drawer .attention-drawer-panel')).toHaveCount(0);
-
-      // Open with ⌘K
       await page.keyboard.press('Meta+k');
+      await expect(page.getByRole('dialog', { name: 'Action menu' })).toBeVisible();
+      await expect(page.getByText('Browse workspace contexts')).toBeVisible();
+
+      await page.getByText('Open attention drawer').click();
       await expect(page.locator('.side-panel-shell.is-open .attention-drawer .attention-drawer-panel')).toBeVisible({ timeout: 2000 });
-
-      // Close with ⌘K
-      await page.keyboard.press('Meta+k');
-      await expect(page.locator('.side-panel-shell.is-open .attention-drawer .attention-drawer-panel')).toHaveCount(0, { timeout: 2000 });
     });
-
-    // Removed ⌘. test - this shortcut was never implemented. Use ⌘K to toggle drawer.
   });
 
   test.describe('Dashboard Navigation', () => {

--- a/app/e2e/session-states.spec.ts
+++ b/app/e2e/session-states.spec.ts
@@ -127,8 +127,9 @@ test.describe('Session State Changes', () => {
     // Wait for sessions to load
     await expect(page.locator('[data-testid="session-s1"]')).toBeVisible({ timeout: 5000 });
 
-    // Open attention drawer (Cmd+K)
+    // Open attention drawer through the action menu.
     await page.keyboard.press('Meta+k');
+    await page.getByText('Open attention drawer').click();
 
     // Wait for drawer to open
     await expect(page.locator('.side-panel-shell.is-open .attention-drawer .attention-drawer-panel')).toBeVisible({ timeout: 2000 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -24,6 +24,8 @@ import { ThumbsModal } from './components/ThumbsModal';
 import { SettingsModal } from './components/SettingsModal';
 import { ShortcutsModal } from './components/ShortcutsModal';
 import { WhatsNewModal } from './components/WhatsNewModal';
+import { ActionMenu, type ActionMenuItem } from './components/ActionMenu';
+import { WorkspaceContextNavigator, type WorkspaceContextView } from './components/WorkspaceContextNavigator';
 import { CopyToast, useCopyToast } from './components/CopyToast';
 import { ErrorToast, useErrorToast } from './components/ErrorToast';
 import { DaemonProvider } from './contexts/DaemonContext';
@@ -53,7 +55,7 @@ import { useDaemonStore } from './store/daemonSessions';
 import { usePRsNeedingAttention } from './hooks/usePRsNeedingAttention';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useWhatsNew } from './hooks/useWhatsNew';
-import { formatShortcut, modifierTokens } from './shortcuts';
+import { formatShortcut, modifierTokens, shortcutTokens } from './shortcuts';
 import { useUIScale } from './hooks/useUIScale';
 import { useTheme } from './hooks/useTheme';
 import { useOpenPR, type OpenPRProgress } from './hooks/useOpenPR';
@@ -89,6 +91,24 @@ function handleAppPointerDownCapture(event: { target: EventTarget | null }): voi
   if (!isBrowserHostOwnedTarget(event.target)) {
     clearBrowserHostFocus();
   }
+}
+
+function ContextActionIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M6 3.5h9l3 3V20a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4.5a1 1 0 0 1 1-1Z" />
+      <path d="M15 3.5V7h3M8 11h7M8 14.5h7M8 18h4" />
+    </svg>
+  );
+}
+
+function AttentionActionIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M12 3.5a6 6 0 0 0-6 6v3.2L4.5 16h15L18 12.7V9.5a6 6 0 0 0-6-6Z" />
+      <path d="M9.5 19a2.8 2.8 0 0 0 5 0" />
+    </svg>
+  );
 }
 
 interface SplitSessionOptions {
@@ -428,6 +448,7 @@ function App() {
     sendRemoveEndpoint,
     sendSetEndpointRemoteWeb,
     sendBootstrapEndpoint,
+    sendListWorkspaceContexts,
     sendGetRecentLocations,
     sendBrowseDirectory,
     sendInspectPath,
@@ -558,6 +579,7 @@ function App() {
         sendRemoveEndpoint={sendRemoveEndpoint}
         sendSetEndpointRemoteWeb={sendSetEndpointRemoteWeb}
         sendBootstrapEndpoint={sendBootstrapEndpoint}
+        sendListWorkspaceContexts={sendListWorkspaceContexts}
         sendGetRecentLocations={sendGetRecentLocations}
         sendBrowseDirectory={sendBrowseDirectory}
         sendInspectPath={sendInspectPath}
@@ -654,6 +676,7 @@ interface AppContentProps {
   sendRemoveEndpoint: ReturnType<typeof useDaemonSocket>['sendRemoveEndpoint'];
   sendSetEndpointRemoteWeb: ReturnType<typeof useDaemonSocket>['sendSetEndpointRemoteWeb'];
   sendBootstrapEndpoint: ReturnType<typeof useDaemonSocket>['sendBootstrapEndpoint'];
+  sendListWorkspaceContexts: ReturnType<typeof useDaemonSocket>['sendListWorkspaceContexts'];
   sendGetRecentLocations: ReturnType<typeof useDaemonSocket>['sendGetRecentLocations'];
   sendBrowseDirectory: ReturnType<typeof useDaemonSocket>['sendBrowseDirectory'];
   sendInspectPath: ReturnType<typeof useDaemonSocket>['sendInspectPath'];
@@ -745,6 +768,7 @@ function AppContent({
   sendRemoveEndpoint,
   sendSetEndpointRemoteWeb,
   sendBootstrapEndpoint,
+  sendListWorkspaceContexts,
   sendGetRecentLocations,
   sendBrowseDirectory,
 sendInspectPath,
@@ -921,6 +945,11 @@ sendFetchPRDetails,
   // Settings modal (lifted from Dashboard for Cmd+, access)
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [actionMenuOpen, setActionMenuOpen] = useState(false);
+  const [workspaceContextsOpen, setWorkspaceContextsOpen] = useState(false);
+  const [workspaceContextsLoading, setWorkspaceContextsLoading] = useState(false);
+  const [workspaceContextsError, setWorkspaceContextsError] = useState<string | null>(null);
+  const [workspaceContexts, setWorkspaceContexts] = useState<Awaited<ReturnType<typeof sendListWorkspaceContexts>>>([]);
   const whatsNew = useWhatsNew();
   const { repoStates, authorStates } = useDaemonStore();
   const mutedRepos = useMemo(() =>
@@ -1520,11 +1549,90 @@ sendFetchPRDetails,
     || whatsNew.isOpen
     || settingsOpen
     || shortcutsOpen
+    || actionMenuOpen
+    || workspaceContextsOpen
     || chiefTransferTarget !== null
     || closedWorktree !== null
     || pendingSessionClose !== null
     || sessionCreationJob !== null
     || openPRLauncherJob !== null;
+
+  const workspaceContextViews = useMemo<WorkspaceContextView[]>(() => {
+    const workspacesById = new Map(daemonWorkspaces.map((workspace) => [workspace.id, workspace]));
+    const sessionsById = new Map(daemonSessions.map((session) => [session.id, session]));
+    return workspaceContexts.map((context) => {
+      const workspace = workspacesById.get(context.workspace_id);
+      const updatedBy = sessionsById.get(context.updated_by_session_id);
+      return {
+        context,
+        title: workspace?.title || context.workspace_id,
+        directory: workspace?.directory || 'Workspace no longer registered',
+        updatedByLabel: updatedBy?.label,
+      };
+    });
+  }, [daemonSessions, daemonWorkspaces, workspaceContexts]);
+
+  const loadWorkspaceContexts = useCallback(async () => {
+    setWorkspaceContextsLoading(true);
+    setWorkspaceContextsError(null);
+    try {
+      setWorkspaceContexts(await sendListWorkspaceContexts());
+    } catch (error) {
+      setWorkspaceContextsError(error instanceof Error ? error.message : 'Failed to load workspace contexts');
+    } finally {
+      setWorkspaceContextsLoading(false);
+    }
+  }, [sendListWorkspaceContexts]);
+
+  const openWorkspaceContextNavigator = useCallback(() => {
+    setWorkspaceContextsOpen(true);
+    void loadWorkspaceContexts();
+  }, [loadWorkspaceContexts]);
+
+  const actionMenuItems = useMemo<ActionMenuItem[]>(() => [
+    {
+      id: 'workspace-contexts',
+      title: 'Browse workspace contexts',
+      description: 'Navigate the shared context published for each workspace',
+      keywords: ['memory', 'shared', 'agents', 'context'],
+      icon: <ContextActionIcon />,
+      run: openWorkspaceContextNavigator,
+    },
+    {
+      id: 'attention',
+      title: 'Open attention drawer',
+      description: 'Show sessions and pull requests that need a response',
+      keywords: ['waiting', 'pull requests', 'prs', 'notifications'],
+      icon: <AttentionActionIcon />,
+      shortcut: [shortcutTokens('dock.attention')],
+      run: () => openDockPanel('attention'),
+    },
+  ], [openDockPanel, openWorkspaceContextNavigator]);
+
+  const handleToggleActionMenu = useCallback(() => {
+    if (actionMenuOpen) {
+      setActionMenuOpen(false);
+      return;
+    }
+    if (settingsOpen || shortcutsOpen || locationPickerOpen || thumbsOpen || whatsNew.isOpen
+      || chiefTransferTarget !== null || closedWorktree !== null || pendingSessionClose !== null
+      || sessionCreationJob !== null || openPRLauncherJob !== null) {
+      return;
+    }
+    setActionMenuOpen(true);
+  }, [
+    actionMenuOpen,
+    chiefTransferTarget,
+    closedWorktree,
+    locationPickerOpen,
+    openPRLauncherJob,
+    pendingSessionClose,
+    sessionCreationJob,
+    settingsOpen,
+    shortcutsOpen,
+    thumbsOpen,
+    whatsNew.isOpen,
+  ]);
   const waitingReviewSessions = useMemo(
     () => sessions
       .map((session) => ({
@@ -2992,7 +3100,7 @@ sendFetchPRDetails,
     onNewSessionHorizontal: () => handleNewSession('horizontal'),
     onNewWorkspace: handleNewWorkspace,
     onCloseSession: handleCloseCurrentSessionShortcut,
-    onToggleDrawer: () => toggleDockPanel('attention'),
+    onToggleActionMenu: handleToggleActionMenu,
     onGoToDashboard: goToDashboard,
     onToggleGridMode: toggleGridMode,
     onJumpToWaiting: handleJumpToWaiting,
@@ -3429,6 +3537,19 @@ sendFetchPRDetails,
       />
       <CopyToast message={copyMessage} onDone={clearCopyToast} />
       <ErrorToast message={errorMessage} onDone={clearError} />
+      <WorkspaceContextNavigator
+        isOpen={workspaceContextsOpen}
+        contexts={workspaceContextViews}
+        isLoading={workspaceContextsLoading}
+        error={workspaceContextsError}
+        onClose={() => setWorkspaceContextsOpen(false)}
+        onRetry={() => void loadWorkspaceContexts()}
+      />
+      <ActionMenu
+        isOpen={actionMenuOpen}
+        actions={actionMenuItems}
+        onClose={() => setActionMenuOpen(false)}
+      />
       <ShortcutsModal
         isOpen={shortcutsOpen}
         onClose={() => setShortcutsOpen(false)}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1619,6 +1619,7 @@ sendFetchPRDetails,
       return;
     }
     if (settingsOpen || shortcutsOpen || locationPickerOpen || thumbsOpen || whatsNew.isOpen
+      || workspaceContextsOpen
       || chiefTransferTarget !== null || closedWorktree !== null || pendingSessionClose !== null
       || sessionCreationJob !== null || openPRLauncherJob !== null) {
       return;
@@ -1636,6 +1637,7 @@ sendFetchPRDetails,
     shortcutsOpen,
     thumbsOpen,
     whatsNew.isOpen,
+    workspaceContextsOpen,
   ]);
   const waitingReviewSessions = useMemo(
     () => sessions

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3132,7 +3132,11 @@ sendFetchPRDetails,
     onDecreaseFontSize: decreaseScale,
     onResetFontSize: resetScale,
     onQuit: handleQuitApp,
-    enabled: !locationPickerOpen && !thumbsOpen && !whatsNew.isOpen,
+    enabled: !locationPickerOpen
+      && !thumbsOpen
+      && !whatsNew.isOpen
+      && !actionMenuOpen
+      && !workspaceContextsOpen,
   });
 
   return (

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1558,7 +1558,11 @@ sendFetchPRDetails,
     || openPRLauncherJob !== null;
 
   const workspaceContextViews = useMemo<WorkspaceContextView[]>(() => {
-    const workspacesById = new Map(daemonWorkspaces.map((workspace) => [workspace.id, workspace]));
+    const workspacesById = new Map(
+      daemonWorkspaces
+        .filter((workspace) => !workspace.endpoint_id)
+        .map((workspace) => [workspace.id, workspace]),
+    );
     const sessionsById = new Map(daemonSessions.map((session) => [session.id, session]));
     return workspaceContexts.map((context) => {
       const workspace = workspacesById.get(context.workspace_id);
@@ -1593,7 +1597,7 @@ sendFetchPRDetails,
     {
       id: 'workspace-contexts',
       title: 'Browse workspace contexts',
-      description: 'Navigate the shared context published for each workspace',
+      description: 'Navigate shared contexts stored on this Mac',
       keywords: ['memory', 'shared', 'agents', 'context'],
       icon: <ContextActionIcon />,
       run: openWorkspaceContextNavigator,

--- a/app/src/components/ActionMenu.css
+++ b/app/src/components/ActionMenu.css
@@ -1,0 +1,200 @@
+.action-menu-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 420;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: min(18vh, 160px);
+  background: rgba(3, 3, 5, 0.66);
+  backdrop-filter: blur(8px) saturate(0.8);
+  animation: action-menu-fade 100ms ease-out;
+}
+
+.action-menu {
+  width: min(640px, calc(100vw - 40px));
+  overflow: hidden;
+  color: var(--color-text-primary);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent 80px),
+    var(--color-bg-panel);
+  border: 1px solid var(--color-border-hover);
+  border-radius: 14px;
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.72), 0 0 0 1px rgba(255, 255, 255, 0.025);
+  animation: action-menu-rise 150ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.action-menu-search {
+  height: 62px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.action-menu-search svg {
+  width: 19px;
+  height: 19px;
+  flex: 0 0 auto;
+  fill: none;
+  stroke: var(--color-text-tertiary);
+  stroke-width: 1.6;
+  stroke-linecap: round;
+}
+
+.action-menu-search input {
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--color-text-primary);
+  font: 500 17px/1.2 -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif;
+}
+
+.action-menu-search input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.action-menu-esc {
+  padding: 3px 6px;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: 5px;
+  font: 600 10px/1.2 ui-monospace, 'SFMono-Regular', monospace;
+  text-transform: uppercase;
+}
+
+.action-menu-results {
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.action-menu-item {
+  width: 100%;
+  min-height: 66px;
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr) auto 22px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  color: inherit;
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  cursor: pointer;
+}
+
+.action-menu-item.is-selected {
+  background: var(--color-bg-elevated);
+  border-color: var(--color-border);
+}
+
+.action-menu-icon {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 11%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  border-radius: 8px;
+}
+
+.action-menu-icon svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.action-menu-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.action-menu-copy strong {
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.action-menu-copy span {
+  overflow: hidden;
+  color: var(--color-text-tertiary);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.action-menu-enter {
+  color: transparent;
+  font-size: 16px;
+}
+
+.action-menu-item.is-selected .action-menu-enter {
+  color: var(--color-text-tertiary);
+}
+
+.action-menu-empty {
+  padding: 44px 20px;
+  color: var(--color-text-muted);
+  text-align: center;
+  font-size: 13px;
+}
+
+.action-menu-footer {
+  height: 34px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 16px;
+  padding: 0 14px;
+  color: var(--color-text-muted);
+  background: color-mix(in srgb, var(--color-bg-elevated) 50%, transparent);
+  border-top: 1px solid var(--color-border-subtle);
+  font-size: 10px;
+}
+
+.action-menu-footer span {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.action-menu-footer kbd {
+  min-width: 17px;
+  padding: 2px 4px;
+  color: var(--color-text-tertiary);
+  background: var(--color-bg-app);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font: inherit;
+  text-align: center;
+}
+
+@keyframes action-menu-fade {
+  from { opacity: 0; }
+}
+
+@keyframes action-menu-rise {
+  from { opacity: 0; transform: translateY(-8px) scale(0.985); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .action-menu-overlay,
+  .action-menu {
+    animation: none;
+  }
+}

--- a/app/src/components/ActionMenu.test.tsx
+++ b/app/src/components/ActionMenu.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ActionMenu, type ActionMenuItem } from './ActionMenu';
+
+function actions(overrides: Partial<ActionMenuItem>[] = []): ActionMenuItem[] {
+  const base: ActionMenuItem[] = [
+    {
+      id: 'contexts',
+      title: 'Browse workspace contexts',
+      description: 'Navigate shared context',
+      keywords: ['memory'],
+      icon: <span>C</span>,
+      run: vi.fn(),
+    },
+    {
+      id: 'attention',
+      title: 'Open attention drawer',
+      description: 'Show waiting work',
+      keywords: ['notifications'],
+      icon: <span>A</span>,
+      run: vi.fn(),
+    },
+  ];
+  return base.map((action, index) => ({ ...action, ...overrides[index] }));
+}
+
+describe('ActionMenu', () => {
+  it('filters actions by keywords and runs the selected result', () => {
+    const items = actions();
+    const onClose = vi.fn();
+    render(<ActionMenu isOpen actions={items} onClose={onClose} />);
+
+    fireEvent.change(screen.getByLabelText('Search actions'), { target: { value: 'memory' } });
+    expect(screen.getByText('Browse workspace contexts')).toBeVisible();
+    expect(screen.queryByText('Open attention drawer')).toBeNull();
+
+    fireEvent.keyDown(screen.getByLabelText('Search actions'), { key: 'Enter' });
+    expect(items[0].run).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('moves selection with arrow keys', () => {
+    const items = actions();
+    render(<ActionMenu isOpen actions={items} onClose={() => {}} />);
+
+    const input = screen.getByLabelText('Search actions');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(items[1].run).toHaveBeenCalledOnce();
+  });
+});

--- a/app/src/components/ActionMenu.tsx
+++ b/app/src/components/ActionMenu.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import FocusTrap from 'focus-trap-react';
+import { useEscapeStack } from '../hooks/useEscapeStack';
+import { KeyCombos } from './Keycap';
+import './ActionMenu.css';
+
+export interface ActionMenuItem {
+  id: string;
+  title: string;
+  description: string;
+  keywords?: string[];
+  icon: ReactNode;
+  shortcut?: string[][];
+  run: () => void;
+}
+
+interface ActionMenuProps {
+  isOpen: boolean;
+  actions: ActionMenuItem[];
+  onClose: () => void;
+}
+
+function actionScore(action: ActionMenuItem, query: string): number {
+  if (!query) return 1;
+  const terms = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
+  const title = action.title.toLowerCase();
+  const searchable = [action.title, action.description, ...(action.keywords || [])].join(' ').toLowerCase();
+  if (!terms.every((term) => searchable.includes(term))) return 0;
+  return terms.reduce((score, term) => {
+    if (title.startsWith(term)) return score + 4;
+    if (title.includes(term)) return score + 2;
+    return score + 1;
+  }, 0);
+}
+
+export function ActionMenu({ isOpen, actions, onClose }: ActionMenuProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const filteredActions = useMemo(() => actions
+    .map((action) => ({ action, score: actionScore(action, query) }))
+    .filter(({ score }) => score > 0)
+    .sort((left, right) => right.score - left.score), [actions, query]);
+
+  useEscapeStack(onClose, isOpen);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setQuery('');
+    setSelectedIndex(0);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [isOpen]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  if (!isOpen) return null;
+
+  const runAction = (action: ActionMenuItem) => {
+    onClose();
+    action.run();
+  };
+
+  return (
+    <div className="action-menu-overlay" onClick={onClose}>
+      <FocusTrap focusTrapOptions={{ allowOutsideClick: true, escapeDeactivates: false }}>
+        <div
+          className="action-menu"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Action menu"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="action-menu-search">
+            <SearchIcon />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'ArrowDown') {
+                  event.preventDefault();
+                  setSelectedIndex((index) => Math.min(index + 1, filteredActions.length - 1));
+                } else if (event.key === 'ArrowUp') {
+                  event.preventDefault();
+                  setSelectedIndex((index) => Math.max(index - 1, 0));
+                } else if (event.key === 'Enter') {
+                  event.preventDefault();
+                  const selected = filteredActions[selectedIndex]?.action;
+                  if (selected) runAction(selected);
+                }
+              }}
+              placeholder="Type an action..."
+              aria-label="Search actions"
+            />
+            <span className="action-menu-esc">esc</span>
+          </div>
+          <div className="action-menu-results" role="listbox">
+            {filteredActions.map(({ action }, index) => (
+              <button
+                key={action.id}
+                type="button"
+                className={`action-menu-item${index === selectedIndex ? ' is-selected' : ''}`}
+                role="option"
+                aria-selected={index === selectedIndex}
+                onMouseEnter={() => setSelectedIndex(index)}
+                onClick={() => runAction(action)}
+              >
+                <span className="action-menu-icon">{action.icon}</span>
+                <span className="action-menu-copy">
+                  <strong>{action.title}</strong>
+                  <span>{action.description}</span>
+                </span>
+                {action.shortcut && <KeyCombos combos={action.shortcut} />}
+                <span className="action-menu-enter" aria-hidden="true">↵</span>
+              </button>
+            ))}
+            {filteredActions.length === 0 && (
+              <div className="action-menu-empty">No matching actions</div>
+            )}
+          </div>
+          <div className="action-menu-footer">
+            <span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
+            <span><kbd>↵</kbd> open</span>
+          </div>
+        </div>
+      </FocusTrap>
+    </div>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <circle cx="8.5" cy="8.5" r="5.5" />
+      <path d="m12.5 12.5 4 4" />
+    </svg>
+  );
+}
+

--- a/app/src/components/ActionMenu.tsx
+++ b/app/src/components/ActionMenu.tsx
@@ -138,4 +138,3 @@ function SearchIcon() {
     </svg>
   );
 }
-

--- a/app/src/components/WorkspaceContextNavigator.css
+++ b/app/src/components/WorkspaceContextNavigator.css
@@ -1,0 +1,478 @@
+.workspace-context-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 400;
+  padding: 12px;
+  background: var(--color-bg-app);
+  animation: workspace-context-reveal 170ms ease-out;
+}
+
+.workspace-context-navigator {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: var(--color-text-primary);
+  background:
+    radial-gradient(circle at 80% 0%, color-mix(in srgb, var(--accent) 8%, transparent), transparent 32%),
+    var(--color-bg-panel);
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+}
+
+.workspace-context-header {
+  min-height: 72px;
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(260px, 520px) minmax(220px, 1fr);
+  align-items: center;
+  gap: 24px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.workspace-context-heading {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.workspace-context-heading > svg {
+  width: 25px;
+  height: 25px;
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 1.45;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.workspace-context-eyebrow {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--accent);
+  font: 700 9px/1.1 ui-monospace, 'SFMono-Regular', monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.workspace-context-heading h1 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+}
+
+.workspace-context-search {
+  height: 38px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 12px;
+  background: var(--color-bg-input);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+}
+
+.workspace-context-search:focus-within {
+  border-color: color-mix(in srgb, var(--accent) 60%, var(--color-border));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.workspace-context-search svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: var(--color-text-tertiary);
+  stroke-width: 1.6;
+  stroke-linecap: round;
+}
+
+.workspace-context-search input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--color-text-primary);
+  font-size: 12px;
+}
+
+.workspace-context-close {
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 8px 7px 11px;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.workspace-context-close:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-elevated);
+  border-color: var(--color-border);
+}
+
+.workspace-context-close kbd {
+  padding: 2px 5px;
+  color: var(--color-text-tertiary);
+  background: var(--color-bg-app);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font: 600 9px/1.2 ui-monospace, monospace;
+}
+
+.workspace-context-body {
+  min-height: 0;
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(230px, 300px) minmax(0, 1fr);
+}
+
+.workspace-context-list {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 14px 10px;
+  background: color-mix(in srgb, var(--color-bg-app) 58%, transparent);
+  border-right: 1px solid var(--color-border-subtle);
+}
+
+.workspace-context-list-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 8px 9px;
+  color: var(--color-text-muted);
+  font: 700 9px/1 ui-monospace, monospace;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.workspace-context-list-label strong {
+  color: var(--color-text-tertiary);
+  font-size: 10px;
+}
+
+.workspace-context-list-item {
+  position: relative;
+  width: 100%;
+  min-height: 60px;
+  display: grid;
+  grid-template-columns: 3px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 9px 8px 5px;
+  color: inherit;
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.workspace-context-list-item:hover {
+  background: color-mix(in srgb, var(--color-bg-elevated) 60%, transparent);
+}
+
+.workspace-context-list-item.is-selected {
+  background: var(--color-bg-elevated);
+  border-color: var(--color-border);
+}
+
+.workspace-context-list-marker {
+  width: 3px;
+  height: 28px;
+  background: transparent;
+  border-radius: 4px;
+}
+
+.workspace-context-list-item.is-selected .workspace-context-list-marker {
+  background: var(--accent);
+  box-shadow: 0 0 12px var(--accent-glow);
+}
+
+.workspace-context-list-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.workspace-context-list-copy strong,
+.workspace-context-list-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-context-list-copy strong {
+  font-size: 12px;
+  font-weight: 620;
+}
+
+.workspace-context-list-copy span {
+  color: var(--color-text-muted);
+  font: 10px/1.2 ui-monospace, 'SFMono-Regular', monospace;
+}
+
+.workspace-context-revision {
+  color: var(--color-text-muted);
+  font: 10px/1 ui-monospace, monospace;
+}
+
+.workspace-context-list-state,
+.workspace-context-document-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.workspace-context-list-state {
+  min-height: 160px;
+  gap: 12px;
+  font-size: 11px;
+}
+
+.workspace-context-list-state button {
+  padding: 6px 9px;
+  color: var(--color-text-primary);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.workspace-context-document {
+  min-width: 0;
+  overflow-y: auto;
+}
+
+.workspace-context-document-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 30px;
+  padding: 28px clamp(28px, 6vw, 90px) 20px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.workspace-context-document-meta > div > span,
+.workspace-context-document-meta dt {
+  color: var(--color-text-muted);
+  font: 700 9px/1 ui-monospace, monospace;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.workspace-context-document-meta h2 {
+  margin: 6px 0 4px;
+  font-size: 24px;
+  font-weight: 680;
+  letter-spacing: -0.035em;
+}
+
+.workspace-context-document-meta p {
+  color: var(--color-text-tertiary);
+  font: 11px/1.4 ui-monospace, 'SFMono-Regular', monospace;
+}
+
+.workspace-context-document-meta dl {
+  display: flex;
+  align-items: flex-start;
+  gap: 24px;
+  margin: 0;
+}
+
+.workspace-context-document-meta dl > div {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.workspace-context-document-meta dd {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.workspace-context-markdown {
+  max-width: 900px;
+  padding: 34px clamp(28px, 6vw, 90px) 80px;
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.workspace-context-markdown h1,
+.workspace-context-markdown h2,
+.workspace-context-markdown h3 {
+  color: var(--color-text-primary);
+  letter-spacing: -0.02em;
+}
+
+.workspace-context-markdown h1 {
+  margin: 0 0 24px;
+  font-size: 28px;
+}
+
+.workspace-context-markdown h2 {
+  margin: 34px 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  font-size: 18px;
+}
+
+.workspace-context-markdown h3 {
+  margin: 24px 0 8px;
+  font-size: 15px;
+}
+
+.workspace-context-markdown p,
+.workspace-context-markdown ul,
+.workspace-context-markdown ol,
+.workspace-context-markdown pre,
+.workspace-context-markdown blockquote {
+  margin: 0 0 16px;
+}
+
+.workspace-context-markdown ul,
+.workspace-context-markdown ol {
+  padding-left: 22px;
+}
+
+.workspace-context-markdown code {
+  padding: 2px 5px;
+  color: color-mix(in srgb, var(--accent) 75%, var(--color-text-primary));
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 4px;
+  font: 0.9em/1.4 ui-monospace, 'SFMono-Regular', monospace;
+}
+
+.workspace-context-markdown pre {
+  overflow-x: auto;
+  padding: 14px;
+  background: var(--color-bg-app);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+}
+
+.workspace-context-markdown pre code {
+  padding: 0;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 0;
+}
+
+.workspace-context-markdown blockquote {
+  padding-left: 14px;
+  color: var(--color-text-tertiary);
+  border-left: 3px solid var(--accent);
+}
+
+.workspace-context-markdown a {
+  color: var(--accent);
+}
+
+.workspace-context-document-state {
+  height: 100%;
+  min-height: 360px;
+}
+
+.workspace-context-document-state svg {
+  width: 34px;
+  height: 34px;
+  margin-bottom: 18px;
+  fill: none;
+  stroke: var(--color-text-dimmed);
+  stroke-width: 1.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.workspace-context-document-state h2 {
+  margin-bottom: 7px;
+  color: var(--color-text-secondary);
+  font-size: 15px;
+}
+
+.workspace-context-document-state p {
+  max-width: 360px;
+  font-size: 12px;
+}
+
+.workspace-context-skeleton-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.workspace-context-skeleton-list span,
+.workspace-context-skeleton-document span {
+  display: block;
+  background: linear-gradient(90deg, var(--color-bg-elevated), var(--color-border-subtle), var(--color-bg-elevated));
+  background-size: 220% 100%;
+  border-radius: 7px;
+  animation: workspace-context-shimmer 1.4s linear infinite;
+}
+
+.workspace-context-skeleton-list span {
+  height: 56px;
+}
+
+.workspace-context-skeleton-document {
+  padding: 80px clamp(28px, 6vw, 90px);
+}
+
+.workspace-context-skeleton-document span {
+  height: 14px;
+  margin-bottom: 16px;
+}
+
+.workspace-context-skeleton-document span:first-child {
+  width: 42%;
+  height: 30px;
+  margin-bottom: 34px;
+}
+
+.workspace-context-skeleton-document span:nth-child(3) {
+  width: 82%;
+}
+
+.workspace-context-skeleton-document span:nth-child(4) {
+  width: 63%;
+}
+
+@keyframes workspace-context-reveal {
+  from { opacity: 0; transform: scale(0.995); }
+}
+
+@keyframes workspace-context-shimmer {
+  to { background-position: -220% 0; }
+}
+
+@media (max-width: 760px) {
+  .workspace-context-shell { padding: 0; }
+  .workspace-context-navigator { border: 0; border-radius: 0; }
+  .workspace-context-header {
+    grid-template-columns: 1fr auto;
+    gap: 10px;
+  }
+  .workspace-context-search { grid-column: 1 / -1; grid-row: 2; }
+  .workspace-context-body { grid-template-columns: 210px minmax(0, 1fr); }
+  .workspace-context-document-meta { flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-context-shell,
+  .workspace-context-skeleton-list span,
+  .workspace-context-skeleton-document span {
+    animation: none;
+  }
+}

--- a/app/src/components/WorkspaceContextNavigator.test.tsx
+++ b/app/src/components/WorkspaceContextNavigator.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { WorkspaceContextNavigator, type WorkspaceContextView } from './WorkspaceContextNavigator';
+
+const contexts: WorkspaceContextView[] = [
+  {
+    title: 'Attn',
+    directory: '/projects/attn',
+    updatedByLabel: 'Agent one',
+    context: {
+      workspace_id: 'workspace-attn',
+      content: '# Goal\n\nBuild the action menu.',
+      revision: 3,
+      updated_at: '2026-06-09T10:00:00Z',
+      updated_by_session_id: 'session-1',
+    },
+  },
+  {
+    title: 'Services pilot',
+    directory: '/projects/services-pilot',
+    context: {
+      workspace_id: 'workspace-services',
+      content: '# Handoff\n\nDeploy the service.',
+      revision: 1,
+      updated_at: '2026-06-09T11:00:00Z',
+      updated_by_session_id: 'session-2',
+    },
+  },
+];
+
+describe('WorkspaceContextNavigator', () => {
+  it('navigates contexts and renders the selected markdown', () => {
+    render(
+      <WorkspaceContextNavigator
+        isOpen
+        contexts={contexts}
+        isLoading={false}
+        error={null}
+        onClose={() => {}}
+        onRetry={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Goal' })).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: /Services pilot/ }));
+    expect(screen.getByRole('heading', { name: 'Handoff' })).toBeVisible();
+    expect(screen.getByText('Deploy the service.')).toBeVisible();
+  });
+
+  it('filters by context content', () => {
+    render(
+      <WorkspaceContextNavigator
+        isOpen
+        contexts={contexts}
+        isLoading={false}
+        error={null}
+        onClose={() => {}}
+        onRetry={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Search workspace contexts'), {
+      target: { value: 'deploy' },
+    });
+    expect(screen.queryByRole('button', { name: /Attn/ })).toBeNull();
+    expect(screen.getByRole('button', { name: /Services pilot/ })).toBeVisible();
+    expect(screen.getByText('Deploy the service.')).toBeVisible();
+  });
+});

--- a/app/src/components/WorkspaceContextNavigator.tsx
+++ b/app/src/components/WorkspaceContextNavigator.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import FocusTrap from 'focus-trap-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { DaemonWorkspaceContext } from '../hooks/useDaemonSocket';
+import { useEscapeStack } from '../hooks/useEscapeStack';
+import './WorkspaceContextNavigator.css';
+
+export interface WorkspaceContextView {
+  context: DaemonWorkspaceContext;
+  title: string;
+  directory: string;
+  updatedByLabel?: string;
+}
+
+interface WorkspaceContextNavigatorProps {
+  isOpen: boolean;
+  contexts: WorkspaceContextView[];
+  isLoading: boolean;
+  error: string | null;
+  onClose: () => void;
+  onRetry: () => void;
+}
+
+export function WorkspaceContextNavigator({
+  isOpen,
+  contexts,
+  isLoading,
+  error,
+  onClose,
+  onRetry,
+}: WorkspaceContextNavigatorProps) {
+  const searchRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState('');
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+  const filteredContexts = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return contexts;
+    return contexts.filter(({ title, directory, context }) => (
+      `${title} ${directory} ${context.content}`.toLowerCase().includes(normalized)
+    ));
+  }, [contexts, query]);
+  const selected = filteredContexts.find(({ context }) => context.workspace_id === selectedWorkspaceId)
+    || filteredContexts[0]
+    || null;
+
+  useEscapeStack(onClose, isOpen);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setQuery('');
+    requestAnimationFrame(() => searchRef.current?.focus());
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!contexts.some(({ context }) => context.workspace_id === selectedWorkspaceId)) {
+      setSelectedWorkspaceId(contexts[0]?.context.workspace_id || null);
+    }
+  }, [contexts, selectedWorkspaceId]);
+
+  if (!isOpen) return null;
+
+  const moveSelection = (offset: number) => {
+    if (filteredContexts.length === 0) return;
+    const currentIndex = Math.max(0, filteredContexts.findIndex(({ context }) => (
+      context.workspace_id === selected?.context.workspace_id
+    )));
+    const nextIndex = Math.min(filteredContexts.length - 1, Math.max(0, currentIndex + offset));
+    setSelectedWorkspaceId(filteredContexts[nextIndex].context.workspace_id);
+  };
+
+  return (
+    <div className="workspace-context-shell">
+      <FocusTrap focusTrapOptions={{ escapeDeactivates: false }}>
+        <div
+          className="workspace-context-navigator"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="workspace-context-title"
+        >
+          <header className="workspace-context-header">
+            <div className="workspace-context-heading">
+              <ContextIcon />
+              <div>
+                <span className="workspace-context-eyebrow">Shared memory</span>
+                <h1 id="workspace-context-title">Workspace contexts</h1>
+              </div>
+            </div>
+            <div className="workspace-context-search">
+              <SearchIcon />
+              <input
+                ref={searchRef}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    moveSelection(1);
+                  } else if (event.key === 'ArrowUp') {
+                    event.preventDefault();
+                    moveSelection(-1);
+                  }
+                }}
+                placeholder="Search contexts..."
+                aria-label="Search workspace contexts"
+              />
+            </div>
+            <button type="button" className="workspace-context-close" onClick={onClose}>
+              <span>Close</span><kbd>esc</kbd>
+            </button>
+          </header>
+
+          <div className="workspace-context-body">
+            <aside className="workspace-context-list" aria-label="Workspace contexts">
+              <div className="workspace-context-list-label">
+                <span>Contexts</span>
+                <strong>{filteredContexts.length}</strong>
+              </div>
+              {isLoading && <ContextListSkeleton />}
+              {!isLoading && error && (
+                <div className="workspace-context-list-state">
+                  <span>Could not load contexts</span>
+                  <button type="button" onClick={onRetry}>Try again</button>
+                </div>
+              )}
+              {!isLoading && !error && filteredContexts.map((item) => (
+                <button
+                  type="button"
+                  key={item.context.workspace_id}
+                  className={`workspace-context-list-item${
+                    item.context.workspace_id === selected?.context.workspace_id ? ' is-selected' : ''
+                  }`}
+                  onClick={() => setSelectedWorkspaceId(item.context.workspace_id)}
+                >
+                  <span className="workspace-context-list-marker" />
+                  <span className="workspace-context-list-copy">
+                    <strong>{item.title}</strong>
+                    <span>{item.directory}</span>
+                  </span>
+                  <span className="workspace-context-revision">r{item.context.revision}</span>
+                </button>
+              ))}
+              {!isLoading && !error && filteredContexts.length === 0 && (
+                <div className="workspace-context-list-state">
+                  <span>{query ? 'No matching contexts' : 'No workspace contexts yet'}</span>
+                </div>
+              )}
+            </aside>
+
+            <main className="workspace-context-document">
+              {isLoading && <DocumentSkeleton />}
+              {!isLoading && error && (
+                <div className="workspace-context-document-state">
+                  <ContextIcon />
+                  <h2>Context unavailable</h2>
+                  <p>{error}</p>
+                </div>
+              )}
+              {!isLoading && !error && selected && (
+                <>
+                  <div className="workspace-context-document-meta">
+                    <div>
+                      <span>Workspace</span>
+                      <h2>{selected.title}</h2>
+                      <p>{selected.directory}</p>
+                    </div>
+                    <dl>
+                      <div><dt>Revision</dt><dd>{selected.context.revision}</dd></div>
+                      <div><dt>Updated</dt><dd>{formatUpdatedAt(selected.context.updated_at)}</dd></div>
+                      {selected.updatedByLabel && (
+                        <div><dt>By</dt><dd>{selected.updatedByLabel}</dd></div>
+                      )}
+                    </dl>
+                  </div>
+                  <article className="workspace-context-markdown">
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      components={{
+                        a: ({ children, ...props }) => <a {...props} target="_blank" rel="noreferrer">{children}</a>,
+                      }}
+                    >
+                      {selected.context.content || '_This workspace context is empty._'}
+                    </ReactMarkdown>
+                  </article>
+                </>
+              )}
+              {!isLoading && !error && !selected && (
+                <div className="workspace-context-document-state">
+                  <ContextIcon />
+                  <h2>{query ? 'No context selected' : 'No shared context yet'}</h2>
+                  <p>{query ? 'Adjust the search to find a workspace.' : 'Contexts appear here after an agent publishes one.'}</p>
+                </div>
+              )}
+            </main>
+          </div>
+        </div>
+      </FocusTrap>
+    </div>
+  );
+}
+
+function formatUpdatedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unknown';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function ContextIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M6 3.5h9l3 3V20a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4.5a1 1 0 0 1 1-1Z" />
+      <path d="M15 3.5V7h3M8 11h7M8 14.5h7M8 18h4" />
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <circle cx="8.5" cy="8.5" r="5.5" />
+      <path d="m12.5 12.5 4 4" />
+    </svg>
+  );
+}
+
+function ContextListSkeleton() {
+  return (
+    <div className="workspace-context-skeleton-list" aria-label="Loading contexts">
+      {[0, 1, 2].map((item) => <span key={item} />)}
+    </div>
+  );
+}
+
+function DocumentSkeleton() {
+  return (
+    <div className="workspace-context-skeleton-document" aria-label="Loading context">
+      <span /><span /><span /><span />
+    </div>
+  );
+}

--- a/app/src/components/WorkspaceContextNavigator.tsx
+++ b/app/src/components/WorkspaceContextNavigator.tsx
@@ -82,8 +82,8 @@ export function WorkspaceContextNavigator({
             <div className="workspace-context-heading">
               <ContextIcon />
               <div>
-                <span className="workspace-context-eyebrow">Shared memory</span>
-                <h1 id="workspace-context-title">Workspace contexts</h1>
+                <span className="workspace-context-eyebrow">Local shared memory</span>
+                <h1 id="workspace-context-title">Workspace contexts on this Mac</h1>
               </div>
             </div>
             <div className="workspace-context-search">

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -632,6 +632,50 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     unmount();
   });
 
+  it('lists canonical workspace contexts by request id', async () => {
+    const { result, unmount } = renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+      }),
+    );
+
+    const ws = await waitForOpenSocket();
+    const request = result.current.sendListWorkspaceContexts();
+    const command = ws.sent
+      .map((entry) => JSON.parse(entry))
+      .find((entry) => entry.cmd === 'workspace_context_list');
+    expect(command.request_id).toMatch(/^workspace_context_list:/);
+
+    act(() => {
+      ws.emit({
+        event: 'workspace_context_list_result',
+        request_id: command.request_id,
+        success: true,
+        contexts: [{
+          workspace_id: 'workspace-1',
+          content: '# Goal',
+          revision: 2,
+          updated_by_session_id: 'session-1',
+          updated_at: '2026-06-09T10:00:00Z',
+        }],
+      });
+    });
+
+    await expect(request).resolves.toEqual([{
+      workspace_id: 'workspace-1',
+      content: '# Goal',
+      revision: 2,
+      updated_by_session_id: 'session-1',
+      updated_at: '2026-06-09T10:00:00Z',
+    }]);
+    unmount();
+  });
+
   it('keeps shell sessions in daemon session updates', async () => {
     const onSessionsUpdate = vi.fn();
     const { unmount } = renderHook(() =>
@@ -649,7 +693,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [
           {
             id: 'agent-1',
@@ -735,7 +779,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [],
         workspaces: [{
           id: 'workspace-1',
@@ -819,7 +863,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -904,7 +948,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1036,7 +1080,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1102,7 +1146,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1166,7 +1210,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1228,7 +1272,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -1288,7 +1332,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [],
         workspaces: [{
           id: 'workspace-1',
@@ -1388,7 +1432,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     };
     const initialState = {
       event: 'initial_state',
-      protocol_version: '94',
+      protocol_version: '95',
       sessions: [],
       workspaces: [workspace],
       prs: [],
@@ -1465,7 +1509,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1559,7 +1603,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1658,7 +1702,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [{
           id: 'sess-existing',
           label: 'attn',
@@ -1743,7 +1787,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [],
         workspaces: [{
           id: 'workspace-sess-remote',
@@ -1822,7 +1866,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [{
           id: 'sess-stale',
           label: 'stale',
@@ -1892,7 +1936,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [{
           id: 'sess-removed',
           label: 'removed',
@@ -2053,7 +2097,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [],
         workspaces: [],
         prs: [],
@@ -2128,7 +2172,7 @@ describe('useDaemonSocket PTY kill sequencing', () => {
     act(() => {
       ws.emit({
         event: 'initial_state',
-        protocol_version: '94',
+        protocol_version: '95',
         sessions: [],
         workspaces: [],
         prs: [],

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -19,6 +19,7 @@ import type {
   ReviewLoopRun as GeneratedReviewLoopRun,
   ReviewLoopInteraction as GeneratedReviewLoopInteraction,
   WarningElement as GeneratedWarning,
+  WorkspaceContext as GeneratedWorkspaceContext,
   SessionState,
   PRRole,
   HeatState,
@@ -71,6 +72,7 @@ export type ReviewLoopState = GeneratedReviewLoopRun;
 export type ReviewLoopInteraction = GeneratedReviewLoopInteraction;
 export type DaemonSettings = Record<string, string>;
 export type DaemonWarning = GeneratedWarning;
+export type DaemonWorkspaceContext = GeneratedWorkspaceContext;
 export interface DirectoryEntry {
   name: string;
   path: string;
@@ -143,6 +145,7 @@ type WebSocketEvent = GeneratedWebSocketEvent & {
   issues?: DaemonPluginIssue[];
   dispatches?: ChiefOfStaffDispatch[];
   github_hosts?: string[];
+  contexts?: DaemonWorkspaceContext[];
   // Legacy review event fields
   review_id?: string;
   session_id?: string;
@@ -164,7 +167,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-const PROTOCOL_VERSION = '94';
+const PROTOCOL_VERSION = '95';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -1274,6 +1277,25 @@ export function useDaemonSocket({
           case 'workspace_context_changed':
           case 'workspace_context_result':
             break;
+
+          case 'workspace_context_list_result': {
+            const requestId = data.request_id;
+            if (typeof requestId !== 'string') {
+              break;
+            }
+            const key = `workspace_context_list:${requestId}`;
+            const pending = pendingActionsRef.current.get(key);
+            if (!pending) {
+              break;
+            }
+            pendingActionsRef.current.delete(key);
+            if (data.success) {
+              pending.resolve(data.contexts || []);
+            } else {
+              pending.reject(new Error(data.error || 'Workspace context list failed'));
+            }
+            break;
+          }
 
           case 'workspace_unregistered':
             if (data.workspace) {
@@ -3235,6 +3257,26 @@ export function useDaemonSocket({
     });
   }, []);
 
+  const sendListWorkspaceContexts = useCallback((): Promise<DaemonWorkspaceContext[]> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('workspace_context_list');
+      const key = `workspace_context_list:${requestId}`;
+      pendingActionsRef.current.set(key, { resolve, reject });
+      ws.send(JSON.stringify({ cmd: 'workspace_context_list', request_id: requestId }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Workspace context list timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
   // Get recent locations from daemon
   const sendGetRecentLocations = useCallback((endpointId?: string, limit?: number): Promise<RecentLocationsResult> => {
     return new Promise((resolve, reject) => {
@@ -3931,6 +3973,7 @@ export function useDaemonSocket({
     sendSetEndpointRemoteWeb,
     sendBootstrapEndpoint,
     sendListEndpoints,
+    sendListWorkspaceContexts,
     sendGetRecentLocations,
     sendBrowseDirectory,
     sendInspectPath,

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -8,7 +8,7 @@ interface KeyboardShortcutsConfig {
   onNewSessionHorizontal?: () => void;
   onNewWorkspace?: () => void;
   onCloseSession: () => void;
-  onToggleDrawer: () => void;
+  onToggleActionMenu: () => void;
   onGoToDashboard: () => void;
   onToggleGridMode?: () => void;
   onJumpToWaiting: () => void;
@@ -36,7 +36,7 @@ export function useKeyboardShortcuts({
   onNewSessionHorizontal,
   onNewWorkspace,
   onCloseSession,
-  onToggleDrawer,
+  onToggleActionMenu,
   onGoToDashboard,
   onToggleGridMode,
   onJumpToWaiting,
@@ -89,8 +89,8 @@ export function useKeyboardShortcuts({
   // Quick Find (thumbs)
   useShortcut('terminal.quickFind', onQuickFind ?? (() => {}), enabled && !!onQuickFind);
 
-  // Drawer
-  useShortcut('drawer.toggle', onToggleDrawer, enabled);
+  // Action menu remains available while its own input is focused.
+  useShortcut('ui.actionMenu', onToggleActionMenu, true);
 
   // Settings (always enabled)
   useShortcut('ui.openSettings', onOpenSettings ?? (() => {}), !!onOpenSettings);

--- a/app/src/shortcuts/cheatsheet.ts
+++ b/app/src/shortcuts/cheatsheet.ts
@@ -76,7 +76,7 @@ export function buildCheatsheet(): CheatsheetCategory[] {
       title: 'App',
       rows: [
         { label: 'Quick Find', combos: [fromId('terminal.quickFind')] },
-        { label: 'Attention drawer', combos: [fromId('drawer.toggle')] },
+        { label: 'Action menu', combos: [fromId('ui.actionMenu')] },
         { label: 'Settings', combos: [fromId('ui.openSettings')] },
         {
           label: 'Font size up / down / reset',

--- a/app/src/shortcuts/registry.ts
+++ b/app/src/shortcuts/registry.ts
@@ -67,8 +67,8 @@ export const SHORTCUTS = {
   'dock.diffDetail': { key: 'e', meta: true, shift: true },
   'dock.attention': { key: 'p', meta: true, shift: true },
 
-  // Drawer
-  'drawer.toggle': { key: 'k', meta: true },
+  // Action menu
+  'ui.actionMenu': { key: 'k', meta: true },
 
   // Settings
   'ui.openSettings': { key: ',', meta: true },

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReportDispatchMessage, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReportDispatchMessage, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockPanelMessage, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockPanelMessage, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspacePanelContentGetMessage, WorkspacePanelContentMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -204,6 +204,8 @@
 //   const workspaceContext = Convert.toWorkspaceContext(json);
 //   const workspaceContextChangedMessage = Convert.toWorkspaceContextChangedMessage(json);
 //   const workspaceContextCheckoutMessage = Convert.toWorkspaceContextCheckoutMessage(json);
+//   const workspaceContextListMessage = Convert.toWorkspaceContextListMessage(json);
+//   const workspaceContextListResultMessage = Convert.toWorkspaceContextListResultMessage(json);
 //   const workspaceContextResult = Convert.toWorkspaceContextResult(json);
 //   const workspaceContextResultMessage = Convert.toWorkspaceContextResultMessage(json);
 //   const workspaceContextStatusMessage = Convert.toWorkspaceContextStatusMessage(json);
@@ -213,6 +215,7 @@
 //   const workspaceLayoutAddSessionPaneMessage = Convert.toWorkspaceLayoutAddSessionPaneMessage(json);
 //   const workspaceLayoutClosePaneMessage = Convert.toWorkspaceLayoutClosePaneMessage(json);
 //   const workspaceLayoutDockEdge = Convert.toWorkspaceLayoutDockEdge(json);
+//   const workspaceLayoutDockPanelMessage = Convert.toWorkspaceLayoutDockPanelMessage(json);
 //   const workspaceLayoutDockTileMessage = Convert.toWorkspaceLayoutDockTileMessage(json);
 //   const workspaceLayoutFocusPaneMessage = Convert.toWorkspaceLayoutFocusPaneMessage(json);
 //   const workspaceLayoutGetMessage = Convert.toWorkspaceLayoutGetMessage(json);
@@ -225,9 +228,12 @@
 //   const workspaceLayoutRenamePaneMessage = Convert.toWorkspaceLayoutRenamePaneMessage(json);
 //   const workspaceLayoutSetSplitRatioMessage = Convert.toWorkspaceLayoutSetSplitRatioMessage(json);
 //   const workspaceLayoutSplitDirection = Convert.toWorkspaceLayoutSplitDirection(json);
+//   const workspaceLayoutUndockPanelMessage = Convert.toWorkspaceLayoutUndockPanelMessage(json);
 //   const workspaceLayoutUndockTileMessage = Convert.toWorkspaceLayoutUndockTileMessage(json);
 //   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
+//   const workspacePanelContentGetMessage = Convert.toWorkspacePanelContentGetMessage(json);
+//   const workspacePanelContentMessage = Convert.toWorkspacePanelContentMessage(json);
 //   const workspaceRegisteredMessage = Convert.toWorkspaceRegisteredMessage(json);
 //   const workspaceSelectedMessage = Convert.toWorkspaceSelectedMessage(json);
 //   const workspaceStateChangedMessage = Convert.toWorkspaceStateChangedMessage(json);
@@ -2373,6 +2379,7 @@ export interface Response {
     review_loop_run?:           ReviewLoopRunObject;
     sessions?:                  SessionElement[];
     workspace_context_result?:  WorkspaceContextResultObject;
+    workspace_contexts?:        WorkspaceContextElement[];
     [property: string]: any;
 }
 
@@ -2475,6 +2482,15 @@ export interface WorkspaceContextResultObject {
     updated_at?:            string;
     updated_by_session_id?: string;
     workspace_id:           string;
+    [property: string]: any;
+}
+
+export interface WorkspaceContextElement {
+    content:               string;
+    revision:              number;
+    updated_at:            string;
+    updated_by_session_id: string;
+    workspace_id:          string;
     [property: string]: any;
 }
 
@@ -3039,6 +3055,7 @@ export interface WebSocketEvent {
     warnings?:                  WarningElement[];
     workspace?:                 WorkspaceElement;
     workspace_context_result?:  WorkspaceContextResultObject;
+    workspace_contexts?:        WorkspaceContextElement[];
     workspace_id?:              string;
     workspace_layout?:          Layout;
     workspaces?:                WorkspaceElement[];
@@ -3087,6 +3104,29 @@ export interface WorkspaceContextCheckoutMessage {
 
 export enum WorkspaceContextCheckoutMessageCmd {
     WorkspaceContextCheckout = "workspace_context_checkout",
+}
+
+export interface WorkspaceContextListMessage {
+    cmd:        WorkspaceContextListMessageCmd;
+    request_id: string;
+    [property: string]: any;
+}
+
+export enum WorkspaceContextListMessageCmd {
+    WorkspaceContextList = "workspace_context_list",
+}
+
+export interface WorkspaceContextListResultMessage {
+    contexts?:  WorkspaceContextElement[];
+    error?:     string;
+    event:      WorkspaceContextListResultMessageEvent;
+    request_id: string;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum WorkspaceContextListResultMessageEvent {
+    WorkspaceContextListResult = "workspace_context_list_result",
 }
 
 export interface WorkspaceContextResult {
@@ -3196,6 +3236,28 @@ export enum WorkspaceLayoutClosePaneMessageCmd {
     WorkspaceLayoutClosePane = "workspace_layout_close_pane",
 }
 
+export interface WorkspaceLayoutDockPanelMessage {
+    anchor_pane_id: string;
+    cmd:            WorkspaceLayoutDockPanelMessageCmd;
+    edge:           WorkspaceLayoutDockEdge;
+    panel_id:       string;
+    panel_kind:     string;
+    ratio?:         number;
+    workspace_id:   string;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutDockPanelMessageCmd {
+    WorkspaceLayoutDockPanel = "workspace_layout_dock_panel",
+}
+
+export enum WorkspaceLayoutDockEdge {
+    Bottom = "bottom",
+    Left = "left",
+    Right = "right",
+    Top = "top",
+}
+
 export interface WorkspaceLayoutDockTileMessage {
     anchor_pane_id: string;
     cmd:            WorkspaceLayoutDockTileMessageCmd;
@@ -3209,13 +3271,6 @@ export interface WorkspaceLayoutDockTileMessage {
 
 export enum WorkspaceLayoutDockTileMessageCmd {
     WorkspaceLayoutDockTile = "workspace_layout_dock_tile",
-}
-
-export enum WorkspaceLayoutDockEdge {
-    Bottom = "bottom",
-    Left = "left",
-    Right = "right",
-    Top = "top",
 }
 
 export interface WorkspaceLayoutFocusPaneMessage {
@@ -3315,6 +3370,17 @@ export enum WorkspaceLayoutSetSplitRatioMessageCmd {
     WorkspaceLayoutSetSplitRatio = "workspace_layout_set_split_ratio",
 }
 
+export interface WorkspaceLayoutUndockPanelMessage {
+    cmd:          WorkspaceLayoutUndockPanelMessageCmd;
+    panel_id:     string;
+    workspace_id: string;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutUndockPanelMessageCmd {
+    WorkspaceLayoutUndockPanel = "workspace_layout_undock_panel",
+}
+
 export interface WorkspaceLayoutUndockTileMessage {
     cmd:          WorkspaceLayoutUndockTileMessageCmd;
     tile_id:      string;
@@ -3347,6 +3413,32 @@ export interface WorkspaceLayoutUpdatedMessage {
 
 export enum WorkspaceLayoutUpdatedMessageEvent {
     WorkspaceLayoutUpdated = "workspace_layout_updated",
+}
+
+export interface WorkspacePanelContentGetMessage {
+    cmd:          WorkspacePanelContentGetMessageCmd;
+    panel_id:     string;
+    workspace_id: string;
+    [property: string]: any;
+}
+
+export enum WorkspacePanelContentGetMessageCmd {
+    WorkspacePanelContentGet = "workspace_panel_content_get",
+}
+
+export interface WorkspacePanelContentMessage {
+    content:      string;
+    error?:       string;
+    event:        WorkspacePanelContentMessageEvent;
+    panel_id:     string;
+    panel_kind:   string;
+    path:         string;
+    workspace_id: string;
+    [property: string]: any;
+}
+
+export enum WorkspacePanelContentMessageEvent {
+    WorkspacePanelContent = "workspace_panel_content",
 }
 
 export interface WorkspaceRegisteredMessage {
@@ -5072,6 +5164,22 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceContextCheckoutMessage")), null, 2);
     }
 
+    public static toWorkspaceContextListMessage(json: string): WorkspaceContextListMessage {
+        return cast(JSON.parse(json), r("WorkspaceContextListMessage"));
+    }
+
+    public static workspaceContextListMessageToJson(value: WorkspaceContextListMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceContextListMessage")), null, 2);
+    }
+
+    public static toWorkspaceContextListResultMessage(json: string): WorkspaceContextListResultMessage {
+        return cast(JSON.parse(json), r("WorkspaceContextListResultMessage"));
+    }
+
+    public static workspaceContextListResultMessageToJson(value: WorkspaceContextListResultMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceContextListResultMessage")), null, 2);
+    }
+
     public static toWorkspaceContextResult(json: string): WorkspaceContextResult {
         return cast(JSON.parse(json), r("WorkspaceContextResult"));
     }
@@ -5142,6 +5250,14 @@ export class Convert {
 
     public static workspaceLayoutDockEdgeToJson(value: WorkspaceLayoutDockEdge): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutDockEdge")), null, 2);
+    }
+
+    public static toWorkspaceLayoutDockPanelMessage(json: string): WorkspaceLayoutDockPanelMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutDockPanelMessage"));
+    }
+
+    public static workspaceLayoutDockPanelMessageToJson(value: WorkspaceLayoutDockPanelMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutDockPanelMessage")), null, 2);
     }
 
     public static toWorkspaceLayoutDockTileMessage(json: string): WorkspaceLayoutDockTileMessage {
@@ -5240,6 +5356,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutSplitDirection")), null, 2);
     }
 
+    public static toWorkspaceLayoutUndockPanelMessage(json: string): WorkspaceLayoutUndockPanelMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutUndockPanelMessage"));
+    }
+
+    public static workspaceLayoutUndockPanelMessageToJson(value: WorkspaceLayoutUndockPanelMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockPanelMessage")), null, 2);
+    }
+
     public static toWorkspaceLayoutUndockTileMessage(json: string): WorkspaceLayoutUndockTileMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutUndockTileMessage"));
     }
@@ -5262,6 +5386,22 @@ export class Convert {
 
     public static workspaceLayoutUpdatedMessageToJson(value: WorkspaceLayoutUpdatedMessage): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
+    }
+
+    public static toWorkspacePanelContentGetMessage(json: string): WorkspacePanelContentGetMessage {
+        return cast(JSON.parse(json), r("WorkspacePanelContentGetMessage"));
+    }
+
+    public static workspacePanelContentGetMessageToJson(value: WorkspacePanelContentGetMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspacePanelContentGetMessage")), null, 2);
+    }
+
+    public static toWorkspacePanelContentMessage(json: string): WorkspacePanelContentMessage {
+        return cast(JSON.parse(json), r("WorkspacePanelContentMessage"));
+    }
+
+    public static workspacePanelContentMessageToJson(value: WorkspacePanelContentMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspacePanelContentMessage")), null, 2);
     }
 
     public static toWorkspaceRegisteredMessage(json: string): WorkspaceRegisteredMessage {
@@ -6728,6 +6868,7 @@ const typeMap: any = {
         { json: "review_loop_run", js: "review_loop_run", typ: u(undefined, r("ReviewLoopRunObject")) },
         { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
         { json: "workspace_context_result", js: "workspace_context_result", typ: u(undefined, r("WorkspaceContextResultObject")) },
+        { json: "workspace_contexts", js: "workspace_contexts", typ: u(undefined, a(r("WorkspaceContextElement"))) },
     ], "any"),
     "ReviewLoopRunObject": o([
         { json: "completed_at", js: "completed_at", typ: u(undefined, "") },
@@ -6792,6 +6933,13 @@ const typeMap: any = {
         { json: "stale", js: "stale", typ: true },
         { json: "updated_at", js: "updated_at", typ: u(undefined, "") },
         { json: "updated_by_session_id", js: "updated_by_session_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
+    "WorkspaceContextElement": o([
+        { json: "content", js: "content", typ: "" },
+        { json: "revision", js: "revision", typ: 0 },
+        { json: "updated_at", js: "updated_at", typ: "" },
+        { json: "updated_by_session_id", js: "updated_by_session_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "ReviewComment": o([
@@ -7146,6 +7294,7 @@ const typeMap: any = {
         { json: "warnings", js: "warnings", typ: u(undefined, a(r("WarningElement"))) },
         { json: "workspace", js: "workspace", typ: u(undefined, r("WorkspaceElement")) },
         { json: "workspace_context_result", js: "workspace_context_result", typ: u(undefined, r("WorkspaceContextResultObject")) },
+        { json: "workspace_contexts", js: "workspace_contexts", typ: u(undefined, a(r("WorkspaceContextElement"))) },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
         { json: "workspace_layout", js: "workspace_layout", typ: u(undefined, r("Layout")) },
         { json: "workspaces", js: "workspaces", typ: u(undefined, a(r("WorkspaceElement"))) },
@@ -7177,6 +7326,17 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("WorkspaceContextCheckoutMessageCmd") },
         { json: "force", js: "force", typ: u(undefined, true) },
         { json: "source_session_id", js: "source_session_id", typ: "" },
+    ], "any"),
+    "WorkspaceContextListMessage": o([
+        { json: "cmd", js: "cmd", typ: r("WorkspaceContextListMessageCmd") },
+        { json: "request_id", js: "request_id", typ: "" },
+    ], "any"),
+    "WorkspaceContextListResultMessage": o([
+        { json: "contexts", js: "contexts", typ: u(undefined, a(r("WorkspaceContextElement"))) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("WorkspaceContextListResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "success", js: "success", typ: true },
     ], "any"),
     "WorkspaceContextResult": o([
         { json: "canonical_revision", js: "canonical_revision", typ: 0 },
@@ -7238,6 +7398,15 @@ const typeMap: any = {
     "WorkspaceLayoutClosePaneMessage": o([
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutClosePaneMessageCmd") },
         { json: "pane_id", js: "pane_id", typ: "" },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
+    "WorkspaceLayoutDockPanelMessage": o([
+        { json: "anchor_pane_id", js: "anchor_pane_id", typ: "" },
+        { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutDockPanelMessageCmd") },
+        { json: "edge", js: "edge", typ: r("WorkspaceLayoutDockEdge") },
+        { json: "panel_id", js: "panel_id", typ: "" },
+        { json: "panel_kind", js: "panel_kind", typ: "" },
+        { json: "ratio", js: "ratio", typ: u(undefined, 3.14) },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "WorkspaceLayoutDockTileMessage": o([
@@ -7302,6 +7471,11 @@ const typeMap: any = {
         { json: "split_id", js: "split_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
+    "WorkspaceLayoutUndockPanelMessage": o([
+        { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUndockPanelMessageCmd") },
+        { json: "panel_id", js: "panel_id", typ: "" },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
     "WorkspaceLayoutUndockTileMessage": o([
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUndockTileMessageCmd") },
         { json: "tile_id", js: "tile_id", typ: "" },
@@ -7317,6 +7491,20 @@ const typeMap: any = {
     "WorkspaceLayoutUpdatedMessage": o([
         { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
         { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
+    ], "any"),
+    "WorkspacePanelContentGetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("WorkspacePanelContentGetMessageCmd") },
+        { json: "panel_id", js: "panel_id", typ: "" },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
+    "WorkspacePanelContentMessage": o([
+        { json: "content", js: "content", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("WorkspacePanelContentMessageEvent") },
+        { json: "panel_id", js: "panel_id", typ: "" },
+        { json: "panel_kind", js: "panel_kind", typ: "" },
+        { json: "path", js: "path", typ: "" },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "WorkspaceRegisteredMessage": o([
         { json: "event", js: "event", typ: r("WorkspaceRegisteredMessageEvent") },
@@ -7924,6 +8112,12 @@ const typeMap: any = {
     "WorkspaceContextCheckoutMessageCmd": [
         "workspace_context_checkout",
     ],
+    "WorkspaceContextListMessageCmd": [
+        "workspace_context_list",
+    ],
+    "WorkspaceContextListResultMessageEvent": [
+        "workspace_context_list_result",
+    ],
     "WorkspaceContextResultMessageEvent": [
         "workspace_context_result",
     ],
@@ -7946,14 +8140,17 @@ const typeMap: any = {
     "WorkspaceLayoutClosePaneMessageCmd": [
         "workspace_layout_close_pane",
     ],
-    "WorkspaceLayoutDockTileMessageCmd": [
-        "workspace_layout_dock_tile",
+    "WorkspaceLayoutDockPanelMessageCmd": [
+        "workspace_layout_dock_panel",
     ],
     "WorkspaceLayoutDockEdge": [
         "bottom",
         "left",
         "right",
         "top",
+    ],
+    "WorkspaceLayoutDockTileMessageCmd": [
+        "workspace_layout_dock_tile",
     ],
     "WorkspaceLayoutFocusPaneMessageCmd": [
         "workspace_layout_focus_pane",
@@ -7976,6 +8173,9 @@ const typeMap: any = {
     "WorkspaceLayoutSetSplitRatioMessageCmd": [
         "workspace_layout_set_split_ratio",
     ],
+    "WorkspaceLayoutUndockPanelMessageCmd": [
+        "workspace_layout_undock_panel",
+    ],
     "WorkspaceLayoutUndockTileMessageCmd": [
         "workspace_layout_undock_tile",
     ],
@@ -7984,6 +8184,12 @@ const typeMap: any = {
     ],
     "WorkspaceLayoutUpdatedMessageEvent": [
         "workspace_layout_updated",
+    ],
+    "WorkspacePanelContentGetMessageCmd": [
+        "workspace_panel_content_get",
+    ],
+    "WorkspacePanelContentMessageEvent": [
+        "workspace_panel_content",
     ],
     "WorkspaceRegisteredMessageEvent": [
         "workspace_registered",

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1677,6 +1677,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleWorkspaceContextUpdate(conn, msg.(*protocol.WorkspaceContextUpdateMessage))
 	case protocol.CmdWorkspaceContextStatus:
 		d.handleWorkspaceContextStatus(conn, msg.(*protocol.WorkspaceContextStatusMessage))
+	case protocol.CmdWorkspaceContextList:
+		d.handleWorkspaceContextList(conn)
 	case protocol.CmdUnregister:
 		d.handleUnregister(conn, msg.(*protocol.UnregisterMessage))
 	case protocol.CmdState:

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -875,6 +875,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 			result, err := d.workspaceContextStatus(msg.(*protocol.WorkspaceContextStatusMessage))
 			d.sendWorkspaceContextWSResult(client, "status", result, err)
 		}()
+	case protocol.CmdWorkspaceContextList:
+		go d.sendWorkspaceContextListWSResult(client, msg.(*protocol.WorkspaceContextListMessage).RequestID)
 	case protocol.CmdApprovePR:
 		d.handleApprovePRWS(client, msg.(*protocol.ApprovePRMessage))
 	case protocol.CmdMergePR:

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -422,8 +422,8 @@ func (d *Daemon) loadWorkspacesFromStore() {
 			// removing its workspace. Preserve workspaces waiting for their
 			// first spawn: the layout pane is persisted before spawn_session
 			// creates the session row, and load can run after a daemon restart
-			// in that gap. Also preserve workspaces with durable sessionless
-			// content such as docked tiles or shared context.
+			// in that gap. Also preserve workspaces with visible sessionless
+			// content such as docked tiles.
 			_, registered := d.workspaces.snapshot(ws.ID)
 			if !registered &&
 				!d.workspaceHasPendingSpawn(ws.ID) &&
@@ -463,10 +463,10 @@ func (d *Daemon) workspaceHasPendingSpawn(workspaceID string) bool {
 }
 
 // workspaceHasSessionlessContent is the single retention rule for a workspace
-// after its final session leaves. Tiles remain visible UI content, while shared
-// context remains durable agent state; either one keeps the workspace alive.
+// after its final session leaves. Only visible docked tiles keep it alive;
+// workspace context is deleted with the workspace.
 func (d *Daemon) workspaceHasSessionlessContent(workspaceID string) bool {
-	return d.workspaceLayoutHasTiles(workspaceID) || d.store.HasWorkspaceContext(workspaceID)
+	return d.workspaceLayoutHasTiles(workspaceID)
 }
 
 // listWorkspaces returns a snapshot of the current workspaces for InitialState.
@@ -524,7 +524,7 @@ func (d *Daemon) dissociateSessionFromWorkspace(sessionID string) {
 		return
 	}
 	if remaining == 0 {
-		// A workspace whose last session leaves normally tears down. Durable
+		// A workspace whose last session leaves normally tears down. Visible
 		// sessionless content keeps it alive. This runs before the session pane
 		// is removed, so a retained tile is still visible in the stored layout.
 		if d.workspaceHasSessionlessContent(workspaceID) {

--- a/internal/daemon/workspace_context.go
+++ b/internal/daemon/workspace_context.go
@@ -275,6 +275,18 @@ func (d *Daemon) handleWorkspaceContextStatus(conn net.Conn, msg *protocol.Works
 	d.sendWorkspaceContextResponse(conn, result, err)
 }
 
+func (d *Daemon) handleWorkspaceContextList(conn net.Conn) {
+	contexts, err := d.store.ListWorkspaceContexts()
+	if err != nil {
+		d.sendError(conn, "workspace context: "+err.Error())
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(protocol.Response{
+		Ok:                true,
+		WorkspaceContexts: contexts,
+	})
+}
+
 func (d *Daemon) sendWorkspaceContextResponse(conn net.Conn, result *protocol.WorkspaceContextResult, err error) {
 	if err != nil {
 		d.sendError(conn, "workspace context: "+err.Error())
@@ -292,6 +304,20 @@ func (d *Daemon) sendWorkspaceContextWSResult(client *wsClient, action string, r
 		Action:  action,
 		Success: err == nil,
 		Result:  result,
+	}
+	if err != nil {
+		response.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, response)
+}
+
+func (d *Daemon) sendWorkspaceContextListWSResult(client *wsClient, requestID string) {
+	contexts, err := d.store.ListWorkspaceContexts()
+	response := protocol.WorkspaceContextListResultMessage{
+		Event:     protocol.EventWorkspaceContextListResult,
+		RequestID: requestID,
+		Success:   err == nil,
+		Contexts:  contexts,
 	}
 	if err != nil {
 		response.Error = protocol.Ptr(err.Error())

--- a/internal/daemon/workspace_context_test.go
+++ b/internal/daemon/workspace_context_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
-	"github.com/victorarias/attn/internal/workspacelayout"
 )
 
 func setupWorkspaceContextSession(t *testing.T, d *Daemon, sessionID, workspaceID string) {
@@ -201,7 +200,7 @@ func TestWorkspaceContextCheckoutDoesNotOverwriteIncompleteLocalState(t *testing
 	}
 }
 
-func TestWorkspaceContextKeepsSessionlessWorkspaceAlive(t *testing.T) {
+func TestWorkspaceContextIsRemovedWhenLastSessionLeaves(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
 	if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", "shared", "session-1", 0); err != nil {
@@ -210,15 +209,18 @@ func TestWorkspaceContextKeepsSessionlessWorkspaceAlive(t *testing.T) {
 
 	d.dissociateSessionFromWorkspace("session-1")
 
-	if d.store.GetWorkspace("workspace-1") == nil {
-		t.Fatal("context-bearing workspace was removed after its last session left")
+	if d.store.GetWorkspace("workspace-1") != nil {
+		t.Fatal("context-only workspace survived after its last session left")
 	}
-	if _, ok := d.workspaces.snapshot("workspace-1"); !ok {
-		t.Fatal("context-bearing workspace was removed from the registry")
+	if _, ok := d.workspaces.snapshot("workspace-1"); ok {
+		t.Fatal("context-only workspace remained in the registry")
+	}
+	if d.store.HasWorkspaceContext("workspace-1") {
+		t.Fatal("workspace context survived workspace teardown")
 	}
 }
 
-func TestClosingFinalPanePublishesEmptyLayoutForContextWorkspace(t *testing.T) {
+func TestClosingFinalPaneRemovesContextWorkspace(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.ptyBackend = &fakeSpawnBackend{}
 	client := newWorkspaceProtocolTestClient()
@@ -250,28 +252,22 @@ func TestClosingFinalPanePublishesEmptyLayoutForContextWorkspace(t *testing.T) {
 	})
 	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutClosePane, workspaceID, paneID, true)
 
-	if d.store.GetWorkspace(workspaceID) == nil {
-		t.Fatal("context-bearing workspace was removed")
+	if d.store.GetWorkspace(workspaceID) != nil {
+		t.Fatal("context-only workspace survived final pane close")
+	}
+	if d.store.HasWorkspaceContext(workspaceID) {
+		t.Fatal("workspace context survived final pane close")
 	}
 	if layout := d.store.GetWorkspaceLayout(workspaceID); layout != nil {
 		t.Fatalf("empty workspace layout remained persisted: %+v", layout)
 	}
 
 	events := cap.snapshot()
-	if len(events) != 3 {
-		t.Fatalf("close broadcasts = %d, want 3: %+v", len(events), events)
+	if len(events) != 2 {
+		t.Fatalf("close broadcasts = %d, want 2: %+v", len(events), events)
 	}
 	if events[0].Event != protocol.EventSessionUnregistered ||
-		events[1].Event != protocol.EventWorkspaceStateChanged ||
-		events[2].Event != protocol.EventWorkspaceLayoutUpdated {
-		t.Fatalf("close broadcast order = [%s, %s, %s]", events[0].Event, events[1].Event, events[2].Event)
-	}
-	layout := events[2].WorkspaceLayout
-	if layout == nil || layout.WorkspaceID != workspaceID || len(layout.Panes) != 0 {
-		t.Fatalf("empty layout broadcast = %+v", layout)
-	}
-	layoutNode, err := workspacelayout.DecodeLayout(layout.LayoutJson)
-	if err != nil || !workspacelayout.LayoutEmpty(layoutNode) {
-		t.Fatalf("empty layout JSON = %q, err=%v", layout.LayoutJson, err)
+		events[1].Event != protocol.EventWorkspaceUnregistered {
+		t.Fatalf("close broadcast order = [%s, %s]", events[0].Event, events[1].Event)
 	}
 }

--- a/internal/daemon/workspace_test.go
+++ b/internal/daemon/workspace_test.go
@@ -571,6 +571,9 @@ func TestLoadWorkspacesFromStore_RemovesPersistedOrphans(t *testing.T) {
 	if err := d.store.SaveWorkspaceLayout(workspacelayout.DefaultWorkspaceLayout("ws-orphan", "pane-orphan", "s-orphan")); err != nil {
 		t.Fatalf("SaveWorkspaceLayout() error = %v", err)
 	}
+	if _, _, err := d.store.UpdateWorkspaceContext("ws-orphan", "# Old context", "s-orphan", 0); err != nil {
+		t.Fatalf("UpdateWorkspaceContext() error = %v", err)
+	}
 	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-live", Title: "live", Directory: "/repo/live"})
 	d.store.Add(&protocol.Session{
 		ID: "s-live", Label: "live", Agent: protocol.SessionAgentCodex, Directory: "/repo/live",
@@ -590,6 +593,9 @@ func TestLoadWorkspacesFromStore_RemovesPersistedOrphans(t *testing.T) {
 	}
 	if layout := d.store.GetWorkspaceLayout("ws-orphan"); layout != nil {
 		t.Fatalf("orphan workspace layout still persisted after load: %+v", layout)
+	}
+	if d.store.HasWorkspaceContext("ws-orphan") {
+		t.Fatal("orphan workspace context survived startup cleanup")
 	}
 	if workspace := d.store.GetWorkspace("ws-live"); workspace == nil {
 		t.Fatal("live workspace was removed during load")

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "94"
+const ProtocolVersion = "95"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -44,6 +44,7 @@ const (
 	CmdWorkspaceContextCheckout           = "workspace_context_checkout"
 	CmdWorkspaceContextUpdate             = "workspace_context_update"
 	CmdWorkspaceContextStatus             = "workspace_context_status"
+	CmdWorkspaceContextList               = "workspace_context_list"
 	CmdUnregister                         = "unregister"
 	CmdState                              = "state"
 	CmdSetSessionResumeID                 = "set_session_resume_id"
@@ -159,6 +160,7 @@ const (
 	EventChiefOfStaffDispatchesUpdated = "chief_of_staff_dispatches_updated"
 	EventDelegateResult                = "delegate_result"
 	EventWorkspaceContextResult        = "workspace_context_result"
+	EventWorkspaceContextListResult    = "workspace_context_list_result"
 	EventPRsUpdated                    = "prs_updated"
 	EventReposUpdated                  = "repos_updated"
 	EventAuthorsUpdated                = "authors_updated"
@@ -356,6 +358,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdWorkspaceContextStatus:
 		var msg WorkspaceContextStatusMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdWorkspaceContextList:
+		var msg WorkspaceContextListMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2279,6 +2279,9 @@ type Response struct {
 	// WorkspaceContextResult corresponds to the JSON schema field
 	// "workspace_context_result".
 	WorkspaceContextResult *WorkspaceContextResult `json:"workspace_context_result,omitempty,omitzero"`
+
+	// WorkspaceContexts corresponds to the JSON schema field "workspace_contexts".
+	WorkspaceContexts []WorkspaceContext `json:"workspace_contexts,omitempty,omitzero"`
 }
 
 type ReviewComment struct {
@@ -3239,6 +3242,9 @@ type WebSocketEvent struct {
 	// "workspace_context_result".
 	WorkspaceContextResult *WorkspaceContextResult `json:"workspace_context_result,omitempty,omitzero"`
 
+	// WorkspaceContexts corresponds to the JSON schema field "workspace_contexts".
+	WorkspaceContexts []WorkspaceContext `json:"workspace_contexts,omitempty,omitzero"`
+
 	// WorkspaceID corresponds to the JSON schema field "workspace_id".
 	WorkspaceID *string `json:"workspace_id,omitempty,omitzero"`
 
@@ -3317,6 +3323,31 @@ type WorkspaceContextCheckoutMessage struct {
 
 	// SourceSessionID corresponds to the JSON schema field "source_session_id".
 	SourceSessionID string `json:"source_session_id"`
+}
+
+type WorkspaceContextListMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+}
+
+type WorkspaceContextListResultMessage struct {
+	// Contexts corresponds to the JSON schema field "contexts".
+	Contexts []WorkspaceContext `json:"contexts,omitempty,omitzero"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
 }
 
 type WorkspaceContextResult struct {
@@ -3480,6 +3511,29 @@ const WorkspaceLayoutDockEdgeBottom WorkspaceLayoutDockEdge = "bottom"
 const WorkspaceLayoutDockEdgeLeft WorkspaceLayoutDockEdge = "left"
 const WorkspaceLayoutDockEdgeRight WorkspaceLayoutDockEdge = "right"
 const WorkspaceLayoutDockEdgeTop WorkspaceLayoutDockEdge = "top"
+
+type WorkspaceLayoutDockPanelMessage struct {
+	// AnchorPaneID corresponds to the JSON schema field "anchor_pane_id".
+	AnchorPaneID string `json:"anchor_pane_id"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Edge corresponds to the JSON schema field "edge".
+	Edge WorkspaceLayoutDockEdge `json:"edge"`
+
+	// PanelID corresponds to the JSON schema field "panel_id".
+	PanelID string `json:"panel_id"`
+
+	// PanelKind corresponds to the JSON schema field "panel_kind".
+	PanelKind string `json:"panel_kind"`
+
+	// Ratio corresponds to the JSON schema field "ratio".
+	Ratio *float64 `json:"ratio,omitempty,omitzero"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
+}
 
 type WorkspaceLayoutDockTileMessage struct {
 	// AnchorPaneID corresponds to the JSON schema field "anchor_pane_id".
@@ -3646,6 +3700,17 @@ type WorkspaceLayoutSplitDirection string
 const WorkspaceLayoutSplitDirectionHorizontal WorkspaceLayoutSplitDirection = "horizontal"
 const WorkspaceLayoutSplitDirectionVertical WorkspaceLayoutSplitDirection = "vertical"
 
+type WorkspaceLayoutUndockPanelMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// PanelID corresponds to the JSON schema field "panel_id".
+	PanelID string `json:"panel_id"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
+}
+
 type WorkspaceLayoutUndockTileMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -3680,6 +3745,40 @@ type WorkspaceLayoutUpdatedMessage struct {
 
 	// WorkspaceLayout corresponds to the JSON schema field "workspace_layout".
 	WorkspaceLayout WorkspaceLayout `json:"workspace_layout"`
+}
+
+type WorkspacePanelContentGetMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// PanelID corresponds to the JSON schema field "panel_id".
+	PanelID string `json:"panel_id"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
+}
+
+type WorkspacePanelContentMessage struct {
+	// Content corresponds to the JSON schema field "content".
+	Content string `json:"content"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// PanelID corresponds to the JSON schema field "panel_id".
+	PanelID string `json:"panel_id"`
+
+	// PanelKind corresponds to the JSON schema field "panel_kind".
+	PanelKind string `json:"panel_kind"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
 }
 
 type WorkspaceRegisteredMessage struct {

--- a/internal/protocol/parse_test.go
+++ b/internal/protocol/parse_test.go
@@ -213,6 +213,7 @@ func TestParseWorkspaceContextCommands(t *testing.T) {
 		{`{"cmd":"workspace_context_checkout","source_session_id":"session-1","force":true}`, CmdWorkspaceContextCheckout},
 		{`{"cmd":"workspace_context_update","source_session_id":"session-1"}`, CmdWorkspaceContextUpdate},
 		{`{"cmd":"workspace_context_status","source_session_id":"session-1"}`, CmdWorkspaceContextStatus},
+		{`{"cmd":"workspace_context_list","request_id":"request-1"}`, CmdWorkspaceContextList},
 	}
 	for _, test := range tests {
 		cmd, _, err := ParseMessage([]byte(test.input))

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -529,6 +529,11 @@ model WorkspaceContextStatusMessage {
   source_session_id: string;
 }
 
+model WorkspaceContextListMessage {
+  cmd: "workspace_context_list";
+  request_id: string;
+}
+
 model DelegateWorktreeRequest {
   repo?: string;
   branch: string;
@@ -1812,6 +1817,7 @@ model Response {
   data?: string;
   delegate_result?: DelegateResult;
   workspace_context_result?: WorkspaceContextResult;
+  workspace_contexts?: WorkspaceContext[];
   chief_of_staff_dispatch?: ChiefOfStaffDispatch;
   chief_of_staff_dispatches?: ChiefOfStaffDispatch[];
   sessions?: Session[];
@@ -1856,6 +1862,14 @@ model WorkspaceContextResultMessage {
   success: boolean;
   error?: string;
   result?: WorkspaceContextResult;
+}
+
+model WorkspaceContextListResultMessage {
+  event: "workspace_context_list_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  contexts?: WorkspaceContext[];
 }
 
 // Warning for non-critical issues (e.g., gh version too old)
@@ -1959,6 +1973,7 @@ model WebSocketEvent {
   workspace_context_result?: WorkspaceContextResult;
   chief_of_staff_dispatch?: ChiefOfStaffDispatch;
   chief_of_staff_dispatches?: ChiefOfStaffDispatch[];
+  workspace_contexts?: WorkspaceContext[];
 }
 
 alias DaemonEvent =
@@ -2013,6 +2028,7 @@ alias DaemonEvent =
   | ReviewLoopResultMessage
   | ReviewLoopUpdatedMessage
   | WorkspaceContextResultMessage
+  | WorkspaceContextListResultMessage
   | MarkFileViewedResultMessage
   | AddCommentResultMessage
   | UpdateCommentResultMessage

--- a/internal/store/workspace_context.go
+++ b/internal/store/workspace_context.go
@@ -42,6 +42,45 @@ func (s *Store) GetWorkspaceContext(workspaceID string) (*protocol.WorkspaceCont
 	return &context, nil
 }
 
+// ListWorkspaceContexts returns canonical contexts in workspace creation order.
+func (s *Store) ListWorkspaceContexts() ([]protocol.WorkspaceContext, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT context.workspace_id, context.content, context.revision,
+			context.updated_by_session_id, context.updated_at
+		FROM workspace_contexts AS context
+		JOIN workspaces AS workspace ON workspace.id = context.workspace_id
+		ORDER BY workspace.created_at, context.workspace_id`)
+	if err != nil {
+		return nil, fmt.Errorf("list workspace contexts: %w", err)
+	}
+	defer rows.Close()
+
+	var contexts []protocol.WorkspaceContext
+	for rows.Next() {
+		var context protocol.WorkspaceContext
+		if err := rows.Scan(
+			&context.WorkspaceID,
+			&context.Content,
+			&context.Revision,
+			&context.UpdatedBySessionID,
+			&context.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan workspace context: %w", err)
+		}
+		contexts = append(contexts, context)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workspace contexts: %w", err)
+	}
+	return contexts, nil
+}
+
 // UpdateWorkspaceContext replaces the canonical content when expectedRevision
 // still matches. It returns changed=false for an identical update.
 func (s *Store) UpdateWorkspaceContext(workspaceID, content, updatedBySessionID string, expectedRevision int) (*protocol.WorkspaceContext, bool, error) {

--- a/internal/store/workspace_context_test.go
+++ b/internal/store/workspace_context_test.go
@@ -66,6 +66,59 @@ func TestWorkspaceContextRevisionCheckedUpdate(t *testing.T) {
 	}
 }
 
+func TestListWorkspaceContextsUsesWorkspaceCreationOrder(t *testing.T) {
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+	s.AddWorkspace(&protocol.Workspace{ID: "workspace-b", Title: "B", Directory: "/tmp/b"})
+	s.AddWorkspace(&protocol.Workspace{ID: "workspace-a", Title: "A", Directory: "/tmp/a"})
+
+	if _, _, err := s.UpdateWorkspaceContext("workspace-a", "# A", "session-a", 0); err != nil {
+		t.Fatalf("UpdateWorkspaceContext workspace-a error: %v", err)
+	}
+	if _, _, err := s.UpdateWorkspaceContext("workspace-b", "# B", "session-b", 0); err != nil {
+		t.Fatalf("UpdateWorkspaceContext workspace-b error: %v", err)
+	}
+
+	contexts, err := s.ListWorkspaceContexts()
+	if err != nil {
+		t.Fatalf("ListWorkspaceContexts error: %v", err)
+	}
+	if len(contexts) != 2 {
+		t.Fatalf("ListWorkspaceContexts len = %d, want 2", len(contexts))
+	}
+	if contexts[0].WorkspaceID != "workspace-b" || contexts[1].WorkspaceID != "workspace-a" {
+		t.Fatalf("ListWorkspaceContexts order = [%s, %s], want [workspace-b, workspace-a]",
+			contexts[0].WorkspaceID, contexts[1].WorkspaceID)
+	}
+}
+
+func TestListWorkspaceContextsExcludesOrphans(t *testing.T) {
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	s.AddWorkspace(&protocol.Workspace{ID: "workspace-live", Title: "Live", Directory: "/tmp/live"})
+	if _, _, err := s.UpdateWorkspaceContext("workspace-live", "# Live", "session-live", 0); err != nil {
+		t.Fatalf("UpdateWorkspaceContext live error: %v", err)
+	}
+	if _, _, err := s.UpdateWorkspaceContext("workspace-orphan", "# Orphan", "session-old", 0); err != nil {
+		t.Fatalf("UpdateWorkspaceContext orphan error: %v", err)
+	}
+
+	contexts, err := s.ListWorkspaceContexts()
+	if err != nil {
+		t.Fatalf("ListWorkspaceContexts error: %v", err)
+	}
+	if len(contexts) != 1 || contexts[0].WorkspaceID != "workspace-live" {
+		t.Fatalf("ListWorkspaceContexts = %+v, want only workspace-live", contexts)
+	}
+}
+
 func TestRemoveWorkspaceRemovesContext(t *testing.T) {
 	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {


### PR DESCRIPTION
## Intent / Why

Workspace context is durable coordination state, but it was only visible through agent checkouts. This makes that state directly discoverable in attn and ensures contexts follow the lifecycle of the workspaces they describe instead of accumulating after workspaces close.

## Summary

- add a searchable `Cmd+K` action menu, with workspace-context browsing as its first action
- add a fullscreen two-pane context navigator with search, keyboard navigation, revision metadata, and rendered Markdown
- expose canonical contexts through a read-only, protocol-versioned daemon request
- preserve the attention drawer through the action menu and its existing `Cmd+Shift+P` shortcut
- remove context when the final session closes its workspace, while preserving sessionless workspaces that still have docked tiles
- reap legacy context-only workspaces at startup and exclude orphan context rows from listings

## Test plan

- [x] Run all frontend tests (673 tests)
- [x] Run the full Go test suite (`go test ./...`)
- [x] Run TypeScript checks
- [x] Run focused Playwright coverage for the action menu and attention drawer
- [x] Build, sign, install, and visually inspect the packaged dev app
- [x] Build, sign, install, and relaunch the production app
- [x] Verify the production store contains only contexts attached to live workspaces (4 attached, 0 orphaned)