### PR TITLE
perf(pty): coalesce PTY reads under sustained output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-06-10]
 
 ### Changed
+- **Heavy terminal output uses much less memory.** Sustained output (long builds, tests, log floods) is now batched into far fewer, larger messages on its way to the app, cutting the app's memory growth during heavy streaming by roughly 40% and reducing CPU overhead. Typing and interactive prompts are unaffected — keystroke echo still arrives immediately.
 - **Streaming terminal output is cheaper.** Live terminal output now travels from the daemon to the app as compact binary messages instead of base64-encoded JSON, cutting per-chunk encode/decode work and message size by a third. This lowers CPU and bandwidth during sustained heavy output (busy agents, long builds) and modestly reduces the app's memory high-water.
 
 ---

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -160,20 +160,90 @@ func (s *Session) fanOut(data []byte, seq uint32) {
 	}
 }
 
+// PTY reads are coalesced before fan-out so sustained output (builds, logs,
+// `seq`-style floods) produces few large downstream messages instead of one
+// per read. macOS pty reads return tiny chunks under load (~100 bytes, the
+// tty queue's pacing), and every message costs real memory in the WebKit
+// frontend regardless of size — message count, not byte volume, is what
+// balloons the app during heavy output. Interactive traffic must not pay for
+// this: a read with nothing queued behind it is emitted immediately, so echo
+// latency is unchanged, and a flood batch is bounded by ptyCoalesceWindow.
+const (
+	ptyReadBufBytes     = 16 * 1024
+	ptyCoalesceMaxBytes = 256 * 1024
+	ptyCoalesceWindow   = 5 * time.Millisecond
+)
+
+type ptyRead struct {
+	data []byte
+	err  error
+}
+
+// nextCoalescedRead returns the next batch of PTY output, blocking for the
+// first read. If no further read is already queued the first one is returned
+// as-is — the interactive path adds zero latency. A queued read means the
+// producer is outpacing the pipeline, so reads are folded in until the batch
+// reaches maxBytes or the window elapses. The returned error belongs to the
+// last read folded into the batch; callers must not receive again after it.
+func nextCoalescedRead(reads <-chan ptyRead, maxBytes int, window time.Duration) ([]byte, error) {
+	first := <-reads
+	if first.err != nil {
+		return first.data, first.err
+	}
+
+	var batch []byte
+	select {
+	case r := <-reads:
+		batch = append(make([]byte, 0, maxBytes+ptyReadBufBytes), first.data...)
+		batch = append(batch, r.data...)
+		if r.err != nil {
+			return batch, r.err
+		}
+	default:
+		return first.data, nil
+	}
+
+	timer := time.NewTimer(window)
+	defer timer.Stop()
+	for len(batch) < maxBytes {
+		select {
+		case r := <-reads:
+			batch = append(batch, r.data...)
+			if r.err != nil {
+				return batch, r.err
+			}
+		case <-timer.C:
+			return batch, nil
+		}
+	}
+	return batch, nil
+}
+
 func (s *Session) readLoop(onExit func(exitCode int, signal string), logf func(string, ...interface{})) {
 	defer func() {
 		_ = s.ptmx.Close()
 	}()
 
-	buf := make([]byte, 16*1024)
+	reads := make(chan ptyRead, 4)
+	go func() {
+		for {
+			buf := make([]byte, ptyReadBufBytes)
+			n, err := s.ptmx.Read(buf)
+			reads <- ptyRead{data: buf[:n], err: err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
 	carryover := make([]byte, 0, 64)
 
 	for {
-		n, err := s.ptmx.Read(buf)
-		if n > 0 {
-			chunk := make([]byte, len(carryover)+n)
+		batch, err := nextCoalescedRead(reads, ptyCoalesceMaxBytes, ptyCoalesceWindow)
+		if len(batch) > 0 {
+			chunk := make([]byte, len(carryover)+len(batch))
 			copy(chunk, carryover)
-			copy(chunk[len(carryover):], buf[:n])
+			copy(chunk[len(carryover):], batch)
 
 			boundary := findSafeBoundary(chunk)
 			if boundary < len(chunk) {

--- a/internal/pty/session_test.go
+++ b/internal/pty/session_test.go
@@ -1,6 +1,7 @@
 package pty
 
 import (
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -296,5 +297,102 @@ func TestWriteTerminalQueryResponsesAllowResend(t *testing.T) {
 	want := wantOnce + wantOnce
 	if string(got) != want {
 		t.Fatalf("writeTerminalQueryResponses() wrote %q, want %q", string(got), want)
+	}
+}
+
+func readOf(b byte, n int) ptyRead {
+	data := make([]byte, n)
+	for i := range data {
+		data[i] = b
+	}
+	return ptyRead{data: data}
+}
+
+func TestNextCoalescedReadLoneReadReturnsImmediately(t *testing.T) {
+	t.Parallel()
+
+	reads := make(chan ptyRead, 1)
+	reads <- ptyRead{data: []byte("x")}
+
+	// A huge window proves no timer wait happens on the interactive path:
+	// the test would time out if a lone read were held for coalescing.
+	data, err := nextCoalescedRead(reads, 100, time.Minute)
+	if err != nil {
+		t.Fatalf("nextCoalescedRead() error = %v", err)
+	}
+	if string(data) != "x" {
+		t.Fatalf("nextCoalescedRead() = %q, want %q", data, "x")
+	}
+}
+
+func TestNextCoalescedReadBatchesQueuedReadsUpToMax(t *testing.T) {
+	t.Parallel()
+
+	reads := make(chan ptyRead, 4)
+	reads <- readOf('a', 4)
+	reads <- readOf('b', 4)
+	reads <- readOf('c', 4)
+	reads <- readOf('d', 4)
+
+	data, err := nextCoalescedRead(reads, 12, time.Minute)
+	if err != nil {
+		t.Fatalf("nextCoalescedRead() error = %v", err)
+	}
+	if string(data) != "aaaabbbbcccc" {
+		t.Fatalf("nextCoalescedRead() = %q, want %q", data, "aaaabbbbcccc")
+	}
+	if got := len(reads); got != 1 {
+		t.Fatalf("reads left in channel = %d, want 1", got)
+	}
+}
+
+func TestNextCoalescedReadReturnsErrorWithBatchedData(t *testing.T) {
+	t.Parallel()
+
+	reads := make(chan ptyRead, 2)
+	reads <- readOf('a', 4)
+	reads <- ptyRead{err: io.EOF}
+
+	data, err := nextCoalescedRead(reads, 100, time.Minute)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("nextCoalescedRead() error = %v, want io.EOF", err)
+	}
+	if string(data) != "aaaa" {
+		t.Fatalf("nextCoalescedRead() = %q, want %q", data, "aaaa")
+	}
+}
+
+func TestNextCoalescedReadFirstReadErrorReturnsImmediately(t *testing.T) {
+	t.Parallel()
+
+	reads := make(chan ptyRead, 1)
+	reads <- ptyRead{data: []byte("tail"), err: io.EOF}
+
+	data, err := nextCoalescedRead(reads, 100, time.Minute)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("nextCoalescedRead() error = %v, want io.EOF", err)
+	}
+	if string(data) != "tail" {
+		t.Fatalf("nextCoalescedRead() = %q, want %q", data, "tail")
+	}
+}
+
+func TestNextCoalescedReadWindowBoundsLatency(t *testing.T) {
+	t.Parallel()
+
+	reads := make(chan ptyRead, 2)
+	reads <- readOf('a', 4)
+	reads <- readOf('b', 4)
+
+	start := time.Now()
+	data, err := nextCoalescedRead(reads, 100, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("nextCoalescedRead() error = %v", err)
+	}
+	if string(data) != "aaaabbbb" {
+		t.Fatalf("nextCoalescedRead() = %q, want %q", data, "aaaabbbb")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("nextCoalescedRead() blocked %v, want ~10ms window", elapsed)
 	}
 }


### PR DESCRIPTION
## What

Lever B from the memory investigation: the daemon's PTY read loop now coalesces reads under sustained output, so heavy streaming reaches the app as few large `pty_output` messages instead of a flood of tiny ones. No protocol change — JSON and binary transports both benefit.

## Why

The ingest-stage bisect (#296-era findings) showed the frontend memory balloon tracks **message count**, not byte volume: WebKit's per-message receive machinery retains memory in bmalloc that the scavenger barely returns while a pane is live. Binary frames (#298) attacked per-message *size* and bought only ~10%; this attacks per-message *count*.

A direct probe of real macOS PTY reads under an `awk` flood was decisive: reads return **~96 bytes** (about 2 lines), not the 16 KiB buffer size — so a 47 MB pane fill was ~580k messages end to end.

## How

- A reader goroutine feeds raw reads into a channel; `nextCoalescedRead` folds them into a batch **only when another read is already queued** behind the current one (the producer is outpacing the pipeline), bounded by 256 KiB / 5 ms.
- A lone read — which is all interactive traffic — is returned immediately: the echo path takes the `default` branch of a non-blocking select and adds **zero latency**.
- One batch = one seq, so attach/replay/dedup semantics are untouched. Covers both the worker and embedded PTY backends (both use `pty.Session`).

## UX verification (the stated concern)

- **Keystroke echo latency, measured end-to-end** through a real daemon PTY (spawn shell via WS, time `pty_input` → first `pty_output` frame, 20 keystrokes): **p50 0.8 ms, p90 1.1 ms, max 1.1 ms.**
- Worst-case added display latency during a flood is the 5 ms window — under one 120 Hz frame.
- `binary-pty-output-realpty` e2e passes (real PTY spawn → live output → renders).

## Memory result (packaged dev app, 2 panes × 1M ascii lines, same fill/machine/day)

| build | webContent RSS |
|---|---|
| pre-coalescing (this branch's parent) | 839.6 MB |
| coalescing, run 1 | **468.0 MB** |
| coalescing, run 2 | **456.9 MB** |

**−44% webContent / −370 MB total app RSS.** Flood probe: 119,201 raw reads → 58 batches (~161 KiB avg, 256 KiB max). Run-to-run spread also collapsed (±6 MB vs the historic ±50 MB — message count was the variance driver).

## Tests

- New unit tests for `nextCoalescedRead` (immediate lone-read path proven by construction — a timer wait would hang the test; batching, max-bytes bound, window bound, error folding).
- `go test ./...` green, `-race` on pty packages green, frontend untouched.