### PR TITLE
feat(terminal): restore deep scrollback on remount and grow live caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-06-10]
 
 ### Changed
+- **Terminals keep much more scrollback.** Live panes now hold roughly 8× more history, and switching back to a workspace (or restarting the app) restores up to 8 MB of terminal history instead of just the visible screen. This especially helps Codex sessions, which rely on the terminal's own scrollback and previously came back from a restart with no history at all.
 - **Heavy terminal output uses much less memory.** Sustained output (long builds, tests, log floods) is now batched into far fewer, larger messages on its way to the app, cutting the app's memory growth during heavy streaming by roughly 40% and reducing CPU overhead. Typing and interactive prompts are unaffected — keystroke echo still arrives immediately.
 - **Streaming terminal output is cheaper.** Live terminal output now travels from the daemon to the app as compact binary messages instead of base64-encoded JSON, cutting per-chunk encode/decode work and message size by a third. This lowers CPU and bandwidth during sustained heavy output (busy agents, long builds) and modestly reduces the app's memory high-water.
 

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -23,7 +23,7 @@ import {
 } from '../utils/terminalSynchronizedOutput';
 import {
   FONT_FAMILY,
-  TERMINAL_SCROLLBACK_LINES,
+  TERMINAL_SCROLLBACK_BYTES,
   getTerminalAnsiPalette,
   getTerminalTheme,
   type ResolvedTheme,
@@ -761,7 +761,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         const theme = getTerminalTheme(resolvedTheme);
         const initialSize = modelSizeRef.current;
         const terminal = ghostty.createTerminal(initialSize.cols, initialSize.rows, {
-          scrollbackLimit: TERMINAL_SCROLLBACK_LINES,
+          scrollbackLimit: TERMINAL_SCROLLBACK_BYTES,
           fgColor: colorNumber(theme.foreground),
           bgColor: colorNumber(theme.background),
           cursorColor: colorNumber(theme.cursor),
@@ -856,7 +856,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           bufferLength: terminal.rows + terminal.getScrollbackLength(),
           baseY: terminal.getScrollbackLength(),
           viewportY: viewportOffsetRef.current,
-          scrollbackLimit: TERMINAL_SCROLLBACK_LINES,
+          scrollbackLimit: TERMINAL_SCROLLBACK_BYTES,
           alternateScreen: terminal.isAlternateScreen(),
           mouseTracking: terminal.hasMouseTracking(),
           renderer: 'ghostty-webgl',

--- a/app/src/components/grid/GridView.tsx
+++ b/app/src/components/grid/GridView.tsx
@@ -34,7 +34,7 @@ import { setGridAutomationHandle, INACTIVE_GRID_STATE } from './gridAutomation';
 import {
   FONT_FAMILY,
   FONT_SIZE,
-  TERMINAL_SCROLLBACK_LINES,
+  TERMINAL_SCROLLBACK_BYTES,
   colorNumber,
   measureCanonicalCell,
 } from './gridConfig';
@@ -188,7 +188,7 @@ export function GridView({
     void Ghostty.load(ghosttyWasmUrl).then((ghostty) => {
       if (disposed) return;
       const comp = new GridCompositor(renderer, ghostty, stage, metrics, {
-        scrollbackLimit: TERMINAL_SCROLLBACK_LINES,
+        scrollbackLimit: TERMINAL_SCROLLBACK_BYTES,
         fgColor: colorNumber(theme.foreground),
         bgColor: colorNumber(theme.background),
         cursorColor: colorNumber(theme.cursor),

--- a/app/src/components/grid/gridConfig.ts
+++ b/app/src/components/grid/gridConfig.ts
@@ -4,10 +4,10 @@
 // shrinks it per-tile via the baked vertex transform.
 import {
   FONT_FAMILY,
-  TERMINAL_SCROLLBACK_LINES,
+  TERMINAL_SCROLLBACK_BYTES,
 } from '../../utils/terminalSizing';
 
-export { FONT_FAMILY, TERMINAL_SCROLLBACK_LINES };
+export { FONT_FAMILY, TERMINAL_SCROLLBACK_BYTES };
 
 export const FONT_SIZE = 13;
 

--- a/app/src/utils/terminalSizing.ts
+++ b/app/src/utils/terminalSizing.ts
@@ -1,7 +1,13 @@
 export type ResolvedTheme = 'dark' | 'light';
 
 export const FONT_FAMILY = 'Iosevka, Menlo, Monaco, "Courier New", monospace';
-export const TERMINAL_SCROLLBACK_LINES = 50000;
+// Ghostty's `scrollbackLimit` is documented as lines but ghostty-web 0.4.0
+// passes it straight through to libghostty's `max_scrollback`, which is BYTES
+// of page data (and floors small values to ~1 MiB internally). This constant
+// is therefore an intentional byte budget — the previous value of 50000 was
+// "lines" in spirit but ~1 MiB in effect. Revisit if ghostty-web ever fixes
+// the unit pass-through.
+export const TERMINAL_SCROLLBACK_BYTES = 8 * 1024 * 1024;
 
 export const DARK_TERMINAL_THEME = {
   background: '#1e1e1e',

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2135,7 +2135,7 @@ func TestDaemon_HandleAttachSession_PrefersSegmentedRawReplayForStoredAgentSessi
 	}
 }
 
-func TestDaemon_HandleAttachSession_FallsBackToFreshSnapshotWhenSegmentedCodexReplayExceedsBudget(t *testing.T) {
+func TestDaemon_HandleAttachSession_ServesVerifiedClippedSegmentedCodexReplay(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeAttachBackend{}
 
@@ -2180,16 +2180,8 @@ func TestDaemon_HandleAttachSession_FallsBackToFreshSnapshotWhenSegmentedCodexRe
 	if !clipped {
 		t.Fatal("expected segmented replay to exceed the transport budget")
 	}
-	boundedBackend := make([]ptybackend.ReplaySegment, 0, len(bounded))
-	for _, segment := range bounded {
-		boundedBackend = append(boundedBackend, ptybackend.ReplaySegment{
-			Cols: segment.Cols,
-			Rows: segment.Rows,
-			Data: append([]byte(nil), segment.Data...),
-		})
-	}
-	if matches, reason := rawReplaySegmentsMatchFreshSnapshot(boundedBackend, info); !matches {
-		t.Fatalf("expected bounded segmented tail to still match the fresh snapshot, got reason=%s", reason)
+	if len(bounded) != 1 || !bytes.Equal(bounded[0].Data, segments[1].Data) {
+		t.Fatalf("expected whole-segment tail to keep only the newest segment, got %d segments", len(bounded))
 	}
 
 	backend.SetAttachInfo(info)
@@ -2221,21 +2213,24 @@ func TestDaemon_HandleAttachSession_FallsBackToFreshSnapshotWhenSegmentedCodexRe
 		if !result.Success {
 			t.Fatalf("attach_result success=false error=%q", protocol.Deref(result.Error))
 		}
-		if len(result.ReplaySegments) != 0 {
-			t.Fatalf("replay_segments = %d, want 0", len(result.ReplaySegments))
+		// The clipped tail reproduces the live screen (Codex repaints in full
+		// frames), so it must be served as deep scrollback instead of
+		// degrading the restore to a bare screen snapshot.
+		if len(result.ReplaySegments) != 1 {
+			t.Fatalf("replay_segments = %d, want 1", len(result.ReplaySegments))
 		}
-		if result.Scrollback != nil {
-			t.Fatal("expected clipped segmented Codex replay to omit flat raw replay")
-		}
-		if protocol.Deref(result.ScreenSnapshot) == "" {
-			t.Fatal("expected fresh screen snapshot to remain when segmented replay exceeds budget")
-		}
-		decoded, err := base64.StdEncoding.DecodeString(protocol.Deref(result.ScreenSnapshot))
+		decoded, err := base64.StdEncoding.DecodeString(result.ReplaySegments[0].Data)
 		if err != nil {
-			t.Fatalf("decode screen snapshot: %v", err)
+			t.Fatalf("decode replay segment: %v", err)
 		}
-		if !bytes.Equal(decoded, snapshot.Payload) {
-			t.Fatal("expected attach_result to keep the fresh live snapshot")
+		if !bytes.Equal(decoded, segments[1].Data) {
+			t.Fatal("expected the clipped tail to preserve the newest segment bytes")
+		}
+		if result.ScreenSnapshot != nil {
+			t.Fatal("expected screen snapshot to be omitted when the clipped tail is served")
+		}
+		if !protocol.Deref(result.ScrollbackTruncated) {
+			t.Fatal("expected clipped replay to be marked truncated")
 		}
 	case <-time.After(1 * time.Second):
 		t.Fatal("timed out waiting for attach_result")

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2135,6 +2135,108 @@ func TestDaemon_HandleAttachSession_PrefersSegmentedRawReplayForStoredAgentSessi
 	}
 }
 
+func TestDaemon_HandleAttachSession_OverfilledReplayLogRestoresWholeBoundarySafeSegments(t *testing.T) {
+	// Regression for the review finding on #301: ReplayLog used to slice its
+	// oldest retained segment at an arbitrary byte offset when overfilled, so
+	// raw restore could open mid-escape-sequence even though the attach-side
+	// budget pass kept whole segments. Overfill a real log with escape-framed
+	// writes and prove everything served through attach is a whole write.
+	writes := [][]byte{
+		[]byte("\x1b[H\x1b[2J\x1b[31mframe-one: oldest, will be evicted\x1b[0m\r\n"),
+		[]byte("\x1b[H\x1b[2J\x1b[32mframe-two: also history\x1b[0m\r\n"),
+		[]byte("\x1b[H\x1b[2J\x1b[33mframe-three: newest repaint\x1b[0m\r\n"),
+	}
+	logSize := len(writes[1]) + len(writes[2]) + 4 // forces eviction of writes[0]
+	replayLog := pty.NewReplayLog(logSize)
+	for _, w := range writes {
+		replayLog.Write(w, 58, 46)
+	}
+	logSegments, truncated := replayLog.Snapshot()
+	if !truncated {
+		t.Fatal("expected overfilled replay log to report truncation")
+	}
+	for i, segment := range logSegments {
+		if segment.Data[0] != 0x1b {
+			t.Fatalf("retained segment[%d] = %q does not start at a write boundary", i, segment.Data)
+		}
+	}
+
+	segments := make([]ptybackend.ReplaySegment, 0, len(logSegments))
+	for _, segment := range logSegments {
+		segments = append(segments, ptybackend.ReplaySegment{
+			Cols: segment.Cols,
+			Rows: segment.Rows,
+			Data: append([]byte(nil), segment.Data...),
+		})
+	}
+	snapshot, ok := pty.ScreenSnapshotFromReplaySegments(logSegments)
+	if !ok {
+		t.Fatal("expected retained segments to derive a snapshot")
+	}
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeAttachBackend{}
+	backend.SetAttachInfo(ptybackend.AttachInfo{
+		Running:             true,
+		ReplaySegments:      segments,
+		ReplayTruncated:     truncated,
+		Cols:                58,
+		Rows:                46,
+		ScreenSnapshot:      snapshot.Payload,
+		ScreenSnapshotFresh: true,
+		ScreenCols:          snapshot.Cols,
+		ScreenRows:          snapshot.Rows,
+		ScreenCursorX:       snapshot.CursorX,
+		ScreenCursorY:       snapshot.CursorY,
+		ScreenCursorVisible: snapshot.CursorVisible,
+	})
+	d.ptyBackend = backend
+	d.store.Add(&protocol.Session{
+		ID:             "sess-1",
+		Label:          "attn",
+		Agent:          protocol.SessionAgentCodex,
+		Directory:      t.TempDir(),
+		State:          protocol.SessionStateIdle,
+		StateSince:     time.Now().UTC().Format(time.RFC3339),
+		StateUpdatedAt: time.Now().UTC().Format(time.RFC3339),
+		LastSeen:       time.Now().UTC().Format(time.RFC3339),
+	})
+
+	client := &wsClient{
+		send:            make(chan outboundMessage, 2),
+		attachedStreams: make(map[string]ptybackend.Stream),
+	}
+	d.handleAttachSession(client, &protocol.AttachSessionMessage{ID: "sess-1"})
+
+	select {
+	case outbound := <-client.send:
+		var result protocol.AttachResultMessage
+		if err := json.Unmarshal(outbound.payload, &result); err != nil {
+			t.Fatalf("decode attach_result: %v", err)
+		}
+		if !result.Success {
+			t.Fatalf("attach_result success=false error=%q", protocol.Deref(result.Error))
+		}
+		if len(result.ReplaySegments) != len(writes)-1 {
+			t.Fatalf("replay_segments = %d, want %d", len(result.ReplaySegments), len(writes)-1)
+		}
+		for i, segment := range result.ReplaySegments {
+			decoded, err := base64.StdEncoding.DecodeString(segment.Data)
+			if err != nil {
+				t.Fatalf("decode replay segment %d: %v", i, err)
+			}
+			if !bytes.Equal(decoded, writes[i+1]) {
+				t.Fatalf("served segment[%d] = %q is not the whole original write %q", i, decoded, writes[i+1])
+			}
+		}
+		if !protocol.Deref(result.ScrollbackTruncated) {
+			t.Fatal("expected truncated replay log to surface scrollback_truncated")
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for attach_result")
+	}
+}
+
 func TestDaemon_HandleAttachSession_ServesVerifiedClippedSegmentedCodexReplay(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeAttachBackend{}

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -91,7 +91,12 @@ type attachReplayPayload struct {
 	rawReplayReason     string
 }
 
-const maxAgentRawReplayBytes = 256 * 1024
+// maxAgentRawReplayBytes bounds how much raw terminal history an attach
+// replays into a remounted pane. It matches pty.DefaultReplayLogSize so a
+// restored pane gets everything the worker retained; replay delivery is cheap
+// (a handful of websocket messages) and the parse cost is a one-time burst at
+// remount.
+const maxAgentRawReplayBytes = 8 * 1024 * 1024
 
 func shouldPreferAgentRawReplay(session *protocol.Session) bool {
 	if session == nil {
@@ -232,6 +237,11 @@ func buildAttachReplayPayload(info ptybackend.AttachInfo, session *protocol.Sess
 	if (shouldPreferAgentRawReplay(session) || shouldRestoreTerminalModelHistory(policy)) &&
 		(len(info.Scrollback) > 0 || len(info.ReplaySegments) > 0) {
 		if len(info.ReplaySegments) > 0 {
+			// A clipped tail is still served as long as it reproduces the live
+			// screen: segments are whole boundary-safe writes, so the tail never
+			// opens mid-escape-sequence, and the snapshot match below proves the
+			// kept history is self-sufficient. Restored panes keep deep
+			// scrollback instead of degrading to a bare screen snapshot.
 			segments, clipped := pty.LimitReplaySegmentsTail(replaySegmentsToPTY(info.ReplaySegments), maxAgentRawReplayBytes)
 			backendSegments := make([]ptybackend.ReplaySegment, 0, len(segments))
 			for _, segment := range segments {
@@ -241,10 +251,10 @@ func buildAttachReplayPayload(info ptybackend.AttachInfo, session *protocol.Sess
 					Data: append([]byte(nil), segment.Data...),
 				})
 			}
-			if !clipped {
+			if len(backendSegments) > 0 {
 				if matches, reason := rawReplaySegmentsMatchFreshSnapshot(backendSegments, info); matches {
 					payload.replaySegments = backendSegments
-					payload.scrollbackTruncated = info.ReplayTruncated
+					payload.scrollbackTruncated = info.ReplayTruncated || clipped
 					payload.screenSnapshot = nil
 					payload.screenCols = 0
 					payload.screenRows = 0
@@ -253,7 +263,11 @@ func buildAttachReplayPayload(info ptybackend.AttachInfo, session *protocol.Sess
 					payload.screenCursorVisible = false
 					payload.screenSnapshotFresh = false
 					payload.rawReplayDecision = "use_segmented_raw_replay"
-					payload.rawReplayReason = "full_segmented_raw_replay_matches_fresh_snapshot"
+					if clipped {
+						payload.rawReplayReason = "clipped_segmented_tail_matches_fresh_snapshot"
+					} else {
+						payload.rawReplayReason = "full_segmented_raw_replay_matches_fresh_snapshot"
+					}
 					return payload
 				} else {
 					payload.rawReplayDecision = "use_fresh_snapshot"

--- a/internal/daemon/ws_pty_scrollback_test.go
+++ b/internal/daemon/ws_pty_scrollback_test.go
@@ -6,15 +6,13 @@ import (
 	"github.com/victorarias/attn/internal/pty"
 )
 
-// The per-session PTY scrollback buffers exist only to feed attach/re-attach
-// replay, which is always clipped to maxAgentRawReplayBytes (see
-// buildAttachReplayPayload). The buffers are intentionally sized well above that
-// clip for memory reasons; if the default ever drops below the clip, replay and
-// Codex startup-query rehydration would be silently starved. Guard the
-// invariant so future shrinks stay safe.
-func TestDefaultScrollbackCoversRawReplayClip(t *testing.T) {
-	if pty.DefaultScrollbackSize < maxAgentRawReplayBytes {
-		t.Fatalf("DefaultScrollbackSize (%d) must be >= maxAgentRawReplayBytes (%d) or attach replay is starved",
-			pty.DefaultScrollbackSize, maxAgentRawReplayBytes)
+// The segmented replay log exists to feed attach/re-attach replay, which is
+// clipped to maxAgentRawReplayBytes (see buildAttachReplayPayload). If the
+// log's default capacity ever drops below the clip, restored scrollback depth
+// would be silently starved. Guard the invariant so future shrinks stay safe.
+func TestDefaultReplayLogCoversRawReplayClip(t *testing.T) {
+	if pty.DefaultReplayLogSize < maxAgentRawReplayBytes {
+		t.Fatalf("DefaultReplayLogSize (%d) must be >= maxAgentRawReplayBytes (%d) or attach replay is starved",
+			pty.DefaultReplayLogSize, maxAgentRawReplayBytes)
 	}
 }

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -20,17 +20,20 @@ import (
 )
 
 const (
-	// DefaultScrollbackSize bounds both the eager per-session ring buffer and
-	// the lazily-grown replay log. Attach/re-attach only ever serves the last
-	// maxAgentRawReplayBytes (256 KiB) of history (see daemon.buildAttachReplayPayload),
-	// so anything beyond that is committed RAM per session that is never sent to
-	// a client. 1 MiB keeps a comfortable 4x headroom over that clip while
-	// removing ~7 MiB of eager allocation from every PTY worker subprocess.
-	// Must stay >= maxAgentRawReplayBytes so clip/ScrollbackTruncated semantics
-	// and Codex startup-query replay are unchanged.
+	// DefaultScrollbackSize bounds the eager per-session ring buffer (flat
+	// scrollback, used for snapshot derivation and legacy flat replay). It is
+	// allocated up front in every PTY worker subprocess, so it stays small.
 	DefaultScrollbackSize = 1 * 1024 * 1024
-	defaultKillTimeout    = 10 * time.Second
-	shellEnvTimeout       = 2 * time.Second
+	// DefaultReplayLogSize bounds the lazily-grown segmented replay log — the
+	// source of terminal history restored on remount/relaunch (see
+	// daemon.buildAttachReplayPayload). Unlike the ring it only costs memory
+	// proportional to what a session actually emitted, so it can afford real
+	// scrollback depth: agents that rely on terminal-native history (Codex)
+	// get this much restored after an app restart or warm-set rehydrate.
+	// Must stay >= daemon.maxAgentRawReplayBytes or attach replay is starved.
+	DefaultReplayLogSize = 8 * 1024 * 1024
+	defaultKillTimeout   = 10 * time.Second
+	shellEnvTimeout      = 2 * time.Second
 )
 
 var ErrSessionNotFound = errors.New("session not found")
@@ -220,7 +223,7 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 		ptmx:        ptmx,
 		cmd:         cmd,
 		scrollback:  NewRingBuffer(m.scrollbackSize),
-		replayLog:   NewReplayLog(m.scrollbackSize),
+		replayLog:   NewReplayLog(DefaultReplayLogSize),
 		subscribers: make(map[string]*sessionSubscriber),
 		running:     true,
 		exited:      make(chan struct{}),

--- a/internal/pty/replaylog.go
+++ b/internal/pty/replaylog.go
@@ -86,6 +86,11 @@ func (r *ReplayLog) trimLocked() {
 	}
 }
 
+// LimitReplaySegmentsTail keeps the newest whole segments that fit the byte
+// limit. A partially-fitting oldest segment is dropped rather than sliced:
+// every segment starts at a safe parse boundary (the read loop only emits
+// boundary-safe writes), so whole-segment trimming guarantees the replayed
+// tail never opens mid-escape-sequence or mid-rune.
 func LimitReplaySegmentsTail(segments []ReplaySegment, limit int) ([]ReplaySegment, bool) {
 	if len(segments) == 0 {
 		return nil, false
@@ -102,18 +107,12 @@ func LimitReplaySegmentsTail(segments []ReplaySegment, limit int) ([]ReplaySegme
 		return cloneReplaySegments(segments), false
 	}
 
-	remainingTrim := total - limit
+	remaining := total
 	startIndex := 0
 	cloned := cloneReplaySegments(segments)
-	for startIndex < len(cloned) && remainingTrim > 0 {
-		headLen := len(cloned[startIndex].Data)
-		if headLen <= remainingTrim {
-			remainingTrim -= headLen
-			startIndex += 1
-			continue
-		}
-		cloned[startIndex].Data = append([]byte(nil), cloned[startIndex].Data[remainingTrim:]...)
-		remainingTrim = 0
+	for startIndex < len(cloned) && remaining > limit {
+		remaining -= len(cloned[startIndex].Data)
+		startIndex += 1
 	}
 	if startIndex >= len(cloned) {
 		return nil, true

--- a/internal/pty/replaylog.go
+++ b/internal/pty/replaylog.go
@@ -8,11 +8,17 @@ type ReplaySegment struct {
 	Data []byte
 }
 
+// ReplayLog retains the newest PTY output as whole write segments. Segments
+// are never sliced: every write enters at a safe parse boundary (the read
+// loop only emits boundary-safe chunks), and attach replays the retained
+// segments verbatim, so a partially-kept segment could open the restored
+// terminal mid-escape-sequence or mid-rune.
 type ReplayLog struct {
-	mu    sync.RWMutex
-	size  int
-	total int
-	items []ReplaySegment
+	mu        sync.RWMutex
+	size      int
+	total     int
+	truncated bool
+	items     []ReplaySegment
 }
 
 func NewReplayLog(size int) *ReplayLog {
@@ -31,12 +37,14 @@ func (r *ReplayLog) Write(data []byte, cols, rows uint16) {
 	defer r.mu.Unlock()
 
 	if len(data) >= r.size {
-		r.items = []ReplaySegment{{
-			Cols: cols,
-			Rows: rows,
-			Data: append([]byte(nil), data[len(data)-r.size:]...),
-		}}
-		r.total = r.size
+		// A single write larger than the whole log cannot be retained without
+		// slicing it mid-stream, so drop history rather than keep a segment
+		// with an unsafe start. Attach then derives a screen snapshot instead
+		// of trusting raw replay. The PTY read loop bounds writes far below
+		// any realistic log size, so this is a degenerate-input guard.
+		r.items = nil
+		r.total = 0
+		r.truncated = true
 		return
 	}
 
@@ -55,7 +63,7 @@ func (r *ReplayLog) Snapshot() ([]ReplaySegment, bool) {
 	defer r.mu.RUnlock()
 
 	if len(r.items) == 0 {
-		return nil, false
+		return nil, r.truncated
 	}
 
 	out := make([]ReplaySegment, 0, len(r.items))
@@ -67,22 +75,16 @@ func (r *ReplayLog) Snapshot() ([]ReplaySegment, bool) {
 		})
 	}
 
-	truncated := r.total >= r.size
-	return out, truncated
+	return out, r.truncated
 }
 
+// trimLocked drops whole oldest segments until the log fits its capacity.
+// It never slices a segment (see the ReplayLog doc comment).
 func (r *ReplayLog) trimLocked() {
 	for len(r.items) > 0 && r.total > r.size {
-		excess := r.total - r.size
-		headLen := len(r.items[0].Data)
-		if headLen <= excess {
-			r.total -= headLen
-			r.items = r.items[1:]
-			continue
-		}
-		r.items[0].Data = append([]byte(nil), r.items[0].Data[excess:]...)
-		r.total -= excess
-		break
+		r.total -= len(r.items[0].Data)
+		r.items = r.items[1:]
+		r.truncated = true
 	}
 }
 

--- a/internal/pty/replaylog_test.go
+++ b/internal/pty/replaylog_test.go
@@ -23,7 +23,9 @@ func TestReplayLogSnapshotPreservesGeometrySegments(t *testing.T) {
 	}
 }
 
-func TestLimitReplaySegmentsTailKeepsNewestGeometryTransitions(t *testing.T) {
+func TestLimitReplaySegmentsTailDropsPartialOldestSegmentWhole(t *testing.T) {
+	// A partially-fitting oldest segment must be dropped, not sliced: slicing
+	// at a byte budget can open the replay mid-escape-sequence.
 	segments, truncated := LimitReplaySegmentsTail([]ReplaySegment{
 		{Cols: 118, Rows: 48, Data: []byte("wide-history")},
 		{Cols: 58, Rows: 46, Data: []byte("narrow-tail")},
@@ -31,13 +33,25 @@ func TestLimitReplaySegmentsTailKeepsNewestGeometryTransitions(t *testing.T) {
 	if !truncated {
 		t.Fatal("expected replay segments tail to be marked truncated")
 	}
-	if len(segments) != 2 {
-		t.Fatalf("segments = %d, want 2", len(segments))
+	if len(segments) != 1 {
+		t.Fatalf("segments = %d, want 1", len(segments))
 	}
-	if string(segments[0].Data) != "history" {
-		t.Fatalf("segments[0].data = %q, want history", segments[0].Data)
+	if string(segments[0].Data) != "narrow-tail" {
+		t.Fatalf("segments[0].data = %q, want narrow-tail", segments[0].Data)
 	}
-	if segments[1].Cols != 58 || segments[1].Rows != 46 {
-		t.Fatalf("segment[1] geometry = %dx%d, want 58x46", segments[1].Cols, segments[1].Rows)
+	if segments[0].Cols != 58 || segments[0].Rows != 46 {
+		t.Fatalf("segment[0] geometry = %dx%d, want 58x46", segments[0].Cols, segments[0].Rows)
+	}
+}
+
+func TestLimitReplaySegmentsTailDropsAllWhenNewestSegmentExceedsLimit(t *testing.T) {
+	segments, truncated := LimitReplaySegmentsTail([]ReplaySegment{
+		{Cols: 80, Rows: 24, Data: []byte("oversized-newest-segment")},
+	}, 4)
+	if !truncated {
+		t.Fatal("expected replay segments tail to be marked truncated")
+	}
+	if len(segments) != 0 {
+		t.Fatalf("segments = %d, want 0", len(segments))
 	}
 }

--- a/internal/pty/replaylog_test.go
+++ b/internal/pty/replaylog_test.go
@@ -23,6 +23,59 @@ func TestReplayLogSnapshotPreservesGeometrySegments(t *testing.T) {
 	}
 }
 
+func TestReplayLogTrimDropsWholeSegmentsOnly(t *testing.T) {
+	// Each write enters at a safe parse boundary; trimming must never slice a
+	// retained segment or replay can open mid-escape-sequence after restore.
+	log := NewReplayLog(40)
+	writes := [][]byte{
+		[]byte("\x1b[31moldest-frame-aaaa\x1b[0m"),
+		[]byte("\x1b[32mmiddle-frame-bbb\x1b[0m"),
+		[]byte("\x1b[33mnewest-frame-cc\x1b[0m"),
+	}
+	for _, w := range writes {
+		log.Write(w, 80, 24)
+	}
+
+	segments, truncated := log.Snapshot()
+	if !truncated {
+		t.Fatal("expected overfilled replay log to report truncation")
+	}
+	total := 0
+	for i, segment := range segments {
+		total += len(segment.Data)
+		matchesWholeWrite := false
+		for _, w := range writes {
+			if string(segment.Data) == string(w) {
+				matchesWholeWrite = true
+				break
+			}
+		}
+		if !matchesWholeWrite {
+			t.Fatalf("segment[%d] = %q is not one of the original whole writes", i, segment.Data)
+		}
+	}
+	if total > 40 {
+		t.Fatalf("retained %d bytes, want <= capacity 40", total)
+	}
+	if len(segments) == 0 || string(segments[len(segments)-1].Data) != string(writes[2]) {
+		t.Fatal("expected the newest write to be retained")
+	}
+}
+
+func TestReplayLogDropsOversizedSingleWrite(t *testing.T) {
+	log := NewReplayLog(16)
+	log.Write([]byte("\x1b[35mkeep-me\x1b[0m"), 80, 24)
+	log.Write([]byte("this single write is larger than the whole log"), 80, 24)
+
+	segments, truncated := log.Snapshot()
+	if !truncated {
+		t.Fatal("expected oversized write to report truncation")
+	}
+	if len(segments) != 0 {
+		t.Fatalf("segments = %d, want 0 (a sliced segment could start mid-escape)", len(segments))
+	}
+}
+
 func TestLimitReplaySegmentsTailDropsPartialOldestSegmentWhole(t *testing.T) {
 	// A partially-fitting oldest segment must be dropped, not sliced: slicing
 	// at a byte budget can open the replay mid-escape-sequence.


### PR DESCRIPTION
## Problem

Codex panes lose all scrollback on every remount (app restart, warm-set rehydrate). The attach replay budget was 256 KiB, and history beyond it wasn't clipped — it was **discarded**, degrading the restore to a bare screen snapshot (`segmented_raw_replay_exceeds_budget` → `use_fresh_snapshot`). Claude panes hid the same loss because that TUI re-renders its own transcript; Codex relies on terminal-native scrollback and exposed it. On top of that, the live-pane cap was an accident: `TERMINAL_SCROLLBACK_LINES = 50000` reaches libghostty's `max_scrollback`, which is **bytes** (ghostty-web passes it through unconverted), so live panes held ~1 MiB of stream bytes regardless of intent.

All of these caps were sized by a memory fear the perf effort has since disproven — scrollback was never the balloon (the libghostty model self-bounds; the cost was ingestion, fixed in #298/#299).

## Changes

1. **Serve the clipped tail instead of discarding it.** `LimitReplaySegmentsTail` now keeps whole segments only — each segment is a boundary-safe write, so the replayed tail never opens mid-escape-sequence — and the tail is still verified against the live screen snapshot (`rawReplaySegmentsMatchFreshSnapshot`) before being used. The correctness invariant is unchanged; only the "over budget → throw it all away" rule is gone.
2. **Replay log 1 MiB → lazy 8 MiB** (`DefaultReplayLogSize`), attach budget raised to match. The eager 1 MiB ring is untouched, so the per-worker idle floor stays flat; only sessions that actually emit history pay.
3. **`TERMINAL_SCROLLBACK_BYTES = 8 MiB`** — renamed and sized as the byte budget it factually is, with a comment documenting the ghostty-web unit pass-through.

## Verification

- **End-to-end against a real daemon PTY:** spawn shell → stream 3.3 MB → fresh client attaches with `same_app_remount` → **3.26 MB restored across 30 segments** (before: snapshot only, zero scrollback), `flat=0B snapshot=0B`.
- Memory cost measured on the packaged dev app (2 panes × 1M lines): webContent 484.7 MB vs 457–468 MB post-#299 baseline — **~12 MB per heavily-flooded pane**, bounded by the caps.
- New/updated unit tests: whole-segment tail semantics (drops partial oldest segment; drops all when newest exceeds limit), daemon test rewritten from "discard clipped codex replay" to "serve verified clipped tail", guard test now pins `DefaultReplayLogSize >= maxAgentRawReplayBytes`.
- `go test ./...` green, tsc clean, 680 vitest green.