### PR TITLE
fix(worktree): extend create provider timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Heavy terminal output uses much less memory.** Sustained output (long builds, tests, log floods) is now batched into far fewer, larger messages on its way to the app, cutting the app's memory growth during heavy streaming by roughly 40% and reducing CPU overhead. Typing and interactive prompts are unaffected — keystroke echo still arrives immediately.
 - **Streaming terminal output is cheaper.** Live terminal output now travels from the daemon to the app as compact binary messages instead of base64-encoded JSON, cutting per-chunk encode/decode work and message size by a third. This lowers CPU and bandwidth during sustained heavy output (busy agents, long builds) and modestly reduces the app's memory high-water.
 
+### Fixed
+- **Provider-managed worktree creation has more time to finish.** Worktree providers now get up to two minutes to create and bootstrap worktrees in large repositories, avoiding false timeout failures after the provider has already created the worktree. Hooks and worktree deletion keep their existing 30-second deadline.
+
 ---
 
 ## [2026-06-09]

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -142,6 +142,9 @@ type Daemon struct {
 	pluginExits      map[string]ptybackend.ExitInfo
 	pluginDir        string
 
+	worktreePluginCallTimeout         time.Duration
+	worktreeCreateProviderCallTimeout time.Duration
+
 	loginShellEnvMu sync.RWMutex
 	loginShellEnv   []string
 

--- a/internal/daemon/plugin_worktree.go
+++ b/internal/daemon/plugin_worktree.go
@@ -14,7 +14,9 @@ const (
 	worktreeCreateProviderSurface = "worktree.create"
 	worktreeAfterCreateSurface    = "worktree.after_create"
 	worktreeDeleteProviderSurface = "worktree.delete"
-	worktreePluginCallTimeout     = 30 * time.Second
+
+	defaultWorktreePluginCallTimeout         = 30 * time.Second
+	defaultWorktreeCreateProviderCallTimeout = 2 * time.Minute
 
 	providerStatusHandled = "handled"
 	providerStatusDecline = "decline"
@@ -76,7 +78,7 @@ func (d *Daemon) dispatchWorktreeAfterCreateHooks(mainRepo, path, branch string)
 func (d *Daemon) dispatchWorktreeHooks(surface string, params interface{}) error {
 	handlers := d.ensurePluginRegistry().handlersForSurface(surface)
 	for _, handler := range handlers {
-		ctx, cancel := context.WithTimeout(context.Background(), worktreePluginCallTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), d.worktreePluginCallTimeoutDuration(surface))
 		err := d.callPlugin(ctx, handler.PluginName, surface, params, nil)
 		cancel()
 		if err != nil {
@@ -109,7 +111,7 @@ func (d *Daemon) dispatchWorktreeCreateProvider(mainRepo, branch, startingFrom, 
 
 	for _, provider := range providers {
 		var result worktreeCreateProviderResult
-		ctx, cancel := context.WithTimeout(context.Background(), worktreePluginCallTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), d.worktreePluginCallTimeoutDuration(worktreeCreateProviderSurface))
 		err := d.callPlugin(ctx, provider.PluginName, worktreeCreateProviderSurface, params, &result)
 		cancel()
 		if err != nil {
@@ -156,7 +158,7 @@ func (d *Daemon) dispatchWorktreeDeleteProvider(mainRepo, path, branch string, f
 	}
 	for _, provider := range providers {
 		var result worktreeDeleteProviderResult
-		ctx, cancel := context.WithTimeout(context.Background(), worktreePluginCallTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), d.worktreePluginCallTimeoutDuration(worktreeDeleteProviderSurface))
 		err := d.callPlugin(ctx, provider.PluginName, worktreeDeleteProviderSurface, params, &result)
 		cancel()
 		if err != nil {
@@ -186,6 +188,19 @@ func (d *Daemon) dispatchWorktreeDeleteProvider(mainRepo, path, branch string, f
 
 	d.logf("worktree provider surface=%s status=fallback main_repo=%s path=%s branch=%s", worktreeDeleteProviderSurface, mainRepo, path, branch)
 	return false, nil
+}
+
+func (d *Daemon) worktreePluginCallTimeoutDuration(surface string) time.Duration {
+	if surface == worktreeCreateProviderSurface {
+		if d.worktreeCreateProviderCallTimeout > 0 {
+			return d.worktreeCreateProviderCallTimeout
+		}
+		return defaultWorktreeCreateProviderCallTimeout
+	}
+	if d.worktreePluginCallTimeout > 0 {
+		return d.worktreePluginCallTimeout
+	}
+	return defaultWorktreePluginCallTimeout
 }
 
 func providerOperationError(pluginName, surface, message string) error {

--- a/internal/daemon/plugin_worktree_test.go
+++ b/internal/daemon/plugin_worktree_test.go
@@ -185,6 +185,52 @@ func TestDoCreateWorktree_ProviderDeclineFallsBackToBuiltInGit(t *testing.T) {
 	}
 }
 
+func TestDispatchWorktreeCreateProvider_UsesCreateProviderTimeout(t *testing.T) {
+	_, mainDir := initProviderTestRepo(t)
+	d := NewForTesting(filepath.Join(t.TempDir(), "attn.sock"))
+
+	if got := d.worktreePluginCallTimeoutDuration(worktreeCreateProviderSurface); got != 2*time.Minute {
+		t.Fatalf("default create provider timeout=%v, want 2m", got)
+	}
+	if got := d.worktreePluginCallTimeoutDuration(worktreeDeleteProviderSurface); got != 30*time.Second {
+		t.Fatalf("default delete provider timeout=%v, want 30s", got)
+	}
+
+	d.worktreePluginCallTimeout = 10 * time.Millisecond
+	d.worktreeCreateProviderCallTimeout = 250 * time.Millisecond
+
+	if got := d.worktreePluginCallTimeoutDuration(worktreeCreateProviderSurface); got != 250*time.Millisecond {
+		t.Fatalf("create provider timeout=%v, want 250ms", got)
+	}
+	if got := d.worktreePluginCallTimeoutDuration(worktreeDeleteProviderSurface); got != 10*time.Millisecond {
+		t.Fatalf("delete provider timeout=%v, want 10ms", got)
+	}
+
+	client, done := startPluginPipe(t, d, "slow-declining-create-provider", []string{worktreeCreateProviderSurface})
+	defer client.Close()
+
+	responseDone := respondToCreateProviderCall(t, client, func(params worktreeCreateProviderParams) worktreeCreateProviderResult {
+		time.Sleep(50 * time.Millisecond)
+		return worktreeCreateProviderResult{Status: providerStatusDecline}
+	})
+
+	_, _, handled, err := d.dispatchWorktreeCreateProvider(mainDir, "feat/slow-provider", "", "")
+	if err != nil {
+		t.Fatalf("dispatchWorktreeCreateProvider failed: %v", err)
+	}
+	if handled {
+		t.Fatal("dispatchWorktreeCreateProvider handled=true, want declined provider")
+	}
+	waitForProviderResponse(t, responseDone)
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow create provider connection did not close")
+	}
+}
+
 func TestDoCreateWorktree_ProviderHandledPathMustBeRealExpectedWorktree(t *testing.T) {
 	tmpDir, mainDir := initProviderTestRepo(t)
 	d := NewForTesting(filepath.Join(tmpDir, "attn.sock"))


### PR DESCRIPTION
## Intent

`worktree.create` providers can perform expensive repository setup and bootstrap work before returning. In the reported services-pilot failure, the provider completed the Git worktree side effect but crossed attn's shared 30-second deadline before returning, so attn reported failure for a worktree that already existed.

Creation needs a larger budget because retrying or falling back after a timed-out side effect is unsafe. Hooks and delete providers do not have the same evidence or workload, so they retain the existing shorter deadline.

## Summary

- give `worktree.create` providers a dedicated two-minute timeout
- keep before/after hooks and `worktree.delete` providers at 30 seconds
- add a short-duration regression seam and delayed-provider test that fails if create calls use the generic timeout
- document the user-visible reliability fix in the changelog

## Test plan

- [x] `go test ./internal/daemon -run 'Test(DispatchWorktreeCreateProvider_UsesCreateProviderTimeout|DoCreateWorktree_|DoCreateWorktreeFromBranch_|DoDeleteWorktree_Provider)' -count=1`
- [x] `go test ./internal/daemon -run 'Worktree' -count=1`
- [x] `$HOME/.codex/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
- [x] GitHub Actions full test suite

Local `go test ./internal/daemon -count=1` reached the package's 10-minute timeout in an existing order-dependent provider test after hundreds of earlier daemon tests. The named test passes in both the focused provider run and the broader worktree subset; CI is the authoritative full-suite check.
