### PR TITLE
feat(picker): folder-name recents with frecency ranking and Enter-to-open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-06-12]
 
+### Changed
+- **The new-session location picker is faster to use and easier to scan.** Recent locations now always show the folder name instead of session names like "shell" or manual renames, so the list reads as a list of places again. The list is ranked by how often *and* how recently you use each location, keeping your main projects in stable slots near the top, and all worktrees of a repository collapse into a single entry for its main checkout. The top recent location is pre-highlighted when the picker opens, so pressing Enter immediately opens your most-used project — typing or arrow keys take over as before, and Escape still closes the dialog right away.
+
 ### Fixed
 - **Resizing or splitting a pane while its history is still restoring no longer wipes the terminal.** A geometry change landing mid-restore used to silently discard the queued history, leaving the pane blank (after an app relaunch) or without scrollback (after a split). A resize that matches where the restore already ends now lets it finish, and a genuine size change re-requests the history at the new size — including the command blocks, which come back clickable.
 - **The first output after reconnecting to a session no longer goes missing, and new panes no longer intermittently get stuck loading.** Reconnecting (relaunch, split, or recovery) could silently swallow the next chunk of terminal output — typed commands would run but never appear. Separately, two rapid attachments to the same session could pair a response with the wrong request and leave the pane waiting forever. Both reconnect handoffs are now exact: output resumes with no gap, and attachments run one at a time per session.

--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -472,6 +472,34 @@ describe('LocationPicker', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('does not auto-highlight cached recents on reopen until the fresh request resolves', async () => {
+    const gates: Array<ReturnType<typeof deferred<{ locations: RecentLocation[]; home_path?: string }>>> = [];
+    const onGetRecentLocations = vi.fn(() => {
+      const gate = deferred<{ locations: RecentLocation[]; home_path?: string }>();
+      gates.push(gate);
+      return gate.promise;
+    });
+    renderClosablePicker({ onGetRecentLocations });
+
+    gates[0].resolve({ locations: [buildRecentLocation()], home_path: '/home/remote' });
+    await waitFor(() => {
+      expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
+    });
+
+    fireEvent.click(screen.getByTestId('location-picker-overlay'));
+    fireEvent.click(screen.getByRole('button', { name: 'Reopen' }));
+
+    // The cached row still renders for instant feedback, but it must not be
+    // auto-highlighted: bare Enter could launch a stale path.
+    const cachedItem = await screen.findByTestId('location-picker-item-0');
+    expect(cachedItem).not.toHaveClass('selected');
+
+    gates[1].resolve({ locations: [buildRecentLocation()], home_path: '/home/remote' });
+    await waitFor(() => {
+      expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
+    });
+  });
+
   it('typing consumes the automatic highlight so Enter submits the typed path', async () => {
     const onGetRecentLocations = vi.fn(async () => ({
       locations: [buildRecentLocation()],

--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -15,7 +15,6 @@ type LocationPickerProps = ComponentProps<typeof LocationPicker>;
 
 function buildRecentLocation(overrides?: Partial<RecentLocation>) {
   return {
-    label: 'Recent Repo',
     path: '/home/remote/projects/recent-repo',
     last_seen: '2026-04-11T08:30:00Z',
     use_count: 4,
@@ -390,6 +389,117 @@ describe('LocationPicker', () => {
     await waitFor(() => {
       expect(onInspectPath).toHaveBeenCalledWith('/tmp/project', undefined);
       expect(onSelect).toHaveBeenCalledWith('/tmp/project', 'claude', undefined, false);
+    });
+  });
+
+  it('shows the folder name derived from the path on recent rows', async () => {
+    const onGetRecentLocations = vi.fn(async () => ({
+      locations: [buildRecentLocation()],
+      home_path: '/home/remote',
+    }));
+    renderPicker({ onGetRecentLocations });
+
+    await waitFor(() => {
+      const item = screen.getByTestId('location-picker-item-0');
+      expect(within(item).getByText('recent-repo')).toBeInTheDocument();
+      expect(within(item).getByText('~/projects/recent-repo')).toBeInTheDocument();
+    });
+  });
+
+  it('pre-highlights the top recent location so a bare Enter opens it', async () => {
+    const onGetRecentLocations = vi.fn(async () => ({
+      locations: [buildRecentLocation()],
+      home_path: '/home/remote',
+    }));
+    const onInspectPath = vi.fn(async () => ({
+      success: true,
+      inspection: {
+        input_path: '~/projects/recent-repo',
+        resolved_path: '/home/remote/projects/recent-repo',
+        home_path: '/home/remote',
+        exists: true,
+        is_directory: true,
+      },
+    }));
+    const { onSelect } = renderPicker({ onGetRecentLocations, onInspectPath });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
+    });
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onInspectPath).toHaveBeenCalledWith('/home/remote/projects/recent-repo', undefined);
+      expect(onSelect).toHaveBeenCalledWith('/home/remote/projects/recent-repo', 'claude', undefined, false);
+    });
+  });
+
+  it('Escape closes the picker while the automatic highlight is active', async () => {
+    const onGetRecentLocations = vi.fn(async () => ({
+      locations: [buildRecentLocation()],
+      home_path: '/home/remote',
+    }));
+    const { onClose } = renderPicker({ onGetRecentLocations });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
+    });
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('arrow navigation converts the automatic highlight into a manual one', async () => {
+    const onGetRecentLocations = vi.fn(async () => ({
+      locations: [buildRecentLocation()],
+      home_path: '/home/remote',
+    }));
+    const { onClose } = renderPicker({ onGetRecentLocations });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
+    });
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowDown' });
+
+    // After manual navigation, Escape deselects first and only then closes.
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('location-picker-item-0')).not.toHaveClass('selected');
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('typing consumes the automatic highlight so Enter submits the typed path', async () => {
+    const onGetRecentLocations = vi.fn(async () => ({
+      locations: [buildRecentLocation()],
+      home_path: '/home/remote',
+    }));
+    const onInspectPath = vi.fn(async () => ({
+      success: true,
+      inspection: {
+        input_path: '/tmp/other',
+        resolved_path: '/tmp/other',
+        home_path: '/home/remote',
+        exists: true,
+        is_directory: true,
+      },
+    }));
+    const { onSelect } = renderPicker({ onGetRecentLocations, onInspectPath });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-picker-item-0')).toHaveClass('selected');
+    });
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '/tmp/other' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onInspectPath).toHaveBeenCalledWith('/tmp/other', undefined);
+      expect(onSelect).toHaveBeenCalledWith('/tmp/other', 'claude', undefined, false);
     });
   });
 

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -228,6 +228,11 @@ export function LocationPicker({
   const [pickerOperation, setPickerOperation] = useState<string | null>(null);
   const [hasSelectedSinceTab, setHasSelectedSinceTab] = useState(true);
   const [autoHighlight, setAutoHighlight] = useState(false);
+  // True only once the recents request issued for the current open/endpoint
+  // has resolved. Cached recents from a previous open still render, but they
+  // must never drive the automatic highlight: bare Enter could launch a path
+  // from another target.
+  const [recentsFresh, setRecentsFresh] = useState(false);
   const autoHighlightDoneRef = useRef(false);
   const requestGenerationRef = useRef(0);
 
@@ -425,6 +430,7 @@ export function LocationPicker({
   }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    setRecentsFresh(false);
     if (!isOpen) {
       return;
     }
@@ -441,6 +447,7 @@ export function LocationPicker({
           return;
         }
         setRecentLocations(result.locations);
+        setRecentsFresh(true);
         const nextHomePath = result.home_path;
         if (nextHomePath) {
           setHomePath((prev) => (prev === nextHomePath ? prev : nextHomePath));
@@ -515,16 +522,17 @@ export function LocationPicker({
   }, [highlightedIndex, highlightedItemKey]);
 
   // Pre-highlight the top recent location when it loads so a bare Enter opens
-  // it. One-shot per open: typing or tab-completing consumes it, and Esc still
-  // closes the picker while the automatic highlight is in place.
+  // it. Only fresh recents qualify (never a cached list from a previous open
+  // or target). One-shot per open: typing or tab-completing consumes it, and
+  // Esc still closes the picker while the automatic highlight is in place.
   useEffect(() => {
-    if (!isOpen || mode !== 'path-input' || autoHighlightDoneRef.current || visibleRecent.length === 0) {
+    if (!isOpen || mode !== 'path-input' || !recentsFresh || autoHighlightDoneRef.current || visibleRecent.length === 0) {
       return;
     }
     autoHighlightDoneRef.current = true;
     setAutoHighlight(true);
     setHighlightedItemKey(`recent:${visibleRecent[0].path}`);
-  }, [isOpen, mode, visibleRecent]);
+  }, [isOpen, mode, recentsFresh, visibleRecent]);
 
   useEffect(() => {
     if (highlightedIndex >= 0) {
@@ -683,6 +691,7 @@ export function LocationPicker({
     setInputValue(buildInitialPickerInput(initialInputPathForTarget(nextTarget), homePath));
     setHighlightedItemKey(null);
     setAutoHighlight(false);
+    setRecentsFresh(false);
     autoHighlightDoneRef.current = false;
     setSelectedPath('');
     setRepoRootPath(null);

--- a/app/src/components/LocationPicker.tsx
+++ b/app/src/components/LocationPicker.tsx
@@ -18,6 +18,7 @@ import {
   buildInitialPickerInput,
   expandDisplayPath,
   normalizePickerPath,
+  pathBasename,
   toDisplayPath,
 } from '../utils/locationPickerPaths';
 import './LocationPicker.css';
@@ -56,7 +57,6 @@ interface PickerTarget {
 interface PathSelectableItem {
   kind: 'recent' | 'directory';
   key: string;
-  label: string;
   path: string;
 }
 
@@ -227,6 +227,8 @@ export function LocationPicker({
   const [refreshing, setRefreshing] = useState(false);
   const [pickerOperation, setPickerOperation] = useState<string | null>(null);
   const [hasSelectedSinceTab, setHasSelectedSinceTab] = useState(true);
+  const [autoHighlight, setAutoHighlight] = useState(false);
+  const autoHighlightDoneRef = useRef(false);
   const requestGenerationRef = useRef(0);
 
   const agentCapabilities = useMemo(() => getAgentCapabilities(settings), [settings]);
@@ -413,6 +415,8 @@ export function LocationPicker({
     setMode('path-input');
     setInputValue(buildInitialPickerInput(initialInputPathForTarget(selectedTarget), homePath));
     setHighlightedItemKey(null);
+    setAutoHighlight(false);
+    autoHighlightDoneRef.current = false;
     setSelectedPath('');
     setRepoRootPath(null);
     setRepoInfo(null);
@@ -459,9 +463,7 @@ export function LocationPicker({
   const filteredRecent = useMemo(
     () => (expandedInput
       ? recentLocations.filter(
-          (loc) =>
-            loc.label.toLowerCase().includes(expandedInput.toLowerCase()) ||
-            loc.path.toLowerCase().includes(expandedInput.toLowerCase()),
+          (loc) => loc.path.toLowerCase().includes(expandedInput.toLowerCase()),
         )
       : recentLocations),
     [expandedInput, recentLocations],
@@ -469,6 +471,7 @@ export function LocationPicker({
   const visibleRecent = useMemo(
     () => filteredRecent.slice(0, MAX_RECENT_LOCATIONS).map((loc) => ({
       ...loc,
+      name: pathBasename(loc.path),
       selectionPath: homePath ? toDisplayPath(loc.path, homePath) : loc.path,
     })),
     [filteredRecent, homePath],
@@ -478,13 +481,11 @@ export function LocationPicker({
       ...visibleRecent.map((loc) => ({
         kind: 'recent' as const,
         key: `recent:${loc.path}`,
-        label: loc.label,
         path: loc.selectionPath,
       })),
       ...fsSuggestions.map((item) => ({
         kind: 'directory' as const,
         key: `directory:${item.path}`,
-        label: item.name,
         path: item.path,
       })),
     ],
@@ -513,6 +514,18 @@ export function LocationPicker({
     }
   }, [highlightedIndex, highlightedItemKey]);
 
+  // Pre-highlight the top recent location when it loads so a bare Enter opens
+  // it. One-shot per open: typing or tab-completing consumes it, and Esc still
+  // closes the picker while the automatic highlight is in place.
+  useEffect(() => {
+    if (!isOpen || mode !== 'path-input' || autoHighlightDoneRef.current || visibleRecent.length === 0) {
+      return;
+    }
+    autoHighlightDoneRef.current = true;
+    setAutoHighlight(true);
+    setHighlightedItemKey(`recent:${visibleRecent[0].path}`);
+  }, [isOpen, mode, visibleRecent]);
+
   useEffect(() => {
     if (highlightedIndex >= 0) {
       document.querySelector(`[data-index="${highlightedIndex}"]`)?.scrollIntoView({ block: 'nearest' });
@@ -530,6 +543,8 @@ export function LocationPicker({
       return;
     }
     invalidateRequestGeneration();
+    autoHighlightDoneRef.current = true;
+    setAutoHighlight(false);
     setInputValue(nextPath);
     setHighlightedItemKey(null);
     setSelectedPath('');
@@ -542,6 +557,8 @@ export function LocationPicker({
       return;
     }
     invalidateRequestGeneration();
+    autoHighlightDoneRef.current = true;
+    setAutoHighlight(false);
     setInputValue(nextPath);
     setHighlightedItemKey(null);
     setSelectedPath('');
@@ -665,6 +682,8 @@ export function LocationPicker({
     setMode('path-input');
     setInputValue(buildInitialPickerInput(initialInputPathForTarget(nextTarget), homePath));
     setHighlightedItemKey(null);
+    setAutoHighlight(false);
+    autoHighlightDoneRef.current = false;
     setSelectedPath('');
     setRepoRootPath(null);
     setRepoInfo(null);
@@ -800,6 +819,7 @@ export function LocationPicker({
       : (highlightedIndex <= 0 ? totalItems - 1 : highlightedIndex - 1);
     const nextItem = selectableItems[nextIndex];
     if (nextItem) {
+      setAutoHighlight(false);
       setHighlightedItemKey(nextItem.key);
     }
   }, [highlightedIndex, selectableItems]);
@@ -814,12 +834,12 @@ export function LocationPicker({
       // RepoOptions pushes its own sub-state handlers (pendingDeletePath, showNewWorktree)
       // above this one in the escape stack. This branch fires only when those are inactive.
       handleBack();
-    } else if (highlightedItemKey) {
+    } else if (highlightedItemKey && !autoHighlight) {
       setHighlightedItemKey(null);
     } else {
       handleClosePicker();
     }
-  }, [mode, handleBack, highlightedItemKey, handleClosePicker]);
+  }, [mode, handleBack, highlightedItemKey, autoHighlight, handleClosePicker]);
   useEscapeStack(handleEscape, isOpen);
 
   const handleDialogKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -1008,7 +1028,7 @@ export function LocationPicker({
                     >
                       <div className="picker-icon">🕐</div>
                       <div className="picker-info">
-                        <div className="picker-name">{loc.label}</div>
+                        <div className="picker-name">{loc.name}</div>
                         <div className="picker-path">{loc.selectionPath}</div>
                       </div>
                     </div>

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '100';
+export const PROTOCOL_VERSION = '101';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchMessagesMessage, ListDispatchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReportDispatchMessage, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockPanelMessage, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockPanelMessage, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspacePanelContentGetMessage, WorkspacePanelContentMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListDispatchMessagesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, ReportDispatchMessage, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const acknowledgeDispatchMessage = Convert.toAcknowledgeDispatchMessage(json);
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
@@ -102,8 +102,8 @@
 //   const installPluginMessage = Convert.toInstallPluginMessage(json);
 //   const killSessionMessage = Convert.toKillSessionMessage(json);
 //   const listBranchesMessage = Convert.toListBranchesMessage(json);
-//   const listDispatchMessagesMessage = Convert.toListDispatchMessagesMessage(json);
 //   const listDispatchesMessage = Convert.toListDispatchesMessage(json);
+//   const listDispatchMessagesMessage = Convert.toListDispatchMessagesMessage(json);
 //   const listEndpointsMessage = Convert.toListEndpointsMessage(json);
 //   const listPluginsMessage = Convert.toListPluginsMessage(json);
 //   const listRemoteBranchesMessage = Convert.toListRemoteBranchesMessage(json);
@@ -118,21 +118,21 @@
 //   const muteWorkspaceMessage = Convert.toMuteWorkspaceMessage(json);
 //   const openBrowserMessage = Convert.toOpenBrowserMessage(json);
 //   const openMarkdownMessage = Convert.toOpenMarkdownMessage(json);
-//   const pR = Convert.toPR(json);
-//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
-//   const pRRole = Convert.toPRRole(json);
-//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
-//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
 //   const pathInspection = Convert.toPathInspection(json);
 //   const pluginActionResultMessage = Convert.toPluginActionResultMessage(json);
 //   const pluginInfo = Convert.toPluginInfo(json);
 //   const pluginIssue = Convert.toPluginIssue(json);
 //   const pluginsUpdatedMessage = Convert.toPluginsUpdatedMessage(json);
+//   const pR = Convert.toPR(json);
+//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
+//   const pRRole = Convert.toPRRole(json);
+//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
+//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
 //   const ptyDesyncMessage = Convert.toPtyDesyncMessage(json);
 //   const ptyInputMessage = Convert.toPtyInputMessage(json);
 //   const ptyOutputMessage = Convert.toPtyOutputMessage(json);
-//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
+//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const queryAuthorsMessage = Convert.toQueryAuthorsMessage(json);
 //   const queryMessage = Convert.toQueryMessage(json);
 //   const queryPRsMessage = Convert.toQueryPRsMessage(json);
@@ -152,8 +152,8 @@
 //   const renameWorkspaceMessage = Convert.toRenameWorkspaceMessage(json);
 //   const replaySegment = Convert.toReplaySegment(json);
 //   const repoInfo = Convert.toRepoInfo(json);
-//   const repoState = Convert.toRepoState(json);
 //   const reportDispatchMessage = Convert.toReportDispatchMessage(json);
+//   const repoState = Convert.toRepoState(json);
 //   const reposUpdatedMessage = Convert.toReposUpdatedMessage(json);
 //   const resolveCommentMessage = Convert.toResolveCommentMessage(json);
 //   const resolveCommentResultMessage = Convert.toResolveCommentResultMessage(json);
@@ -179,10 +179,10 @@
 //   const sessionSelectedMessage = Convert.toSessionSelectedMessage(json);
 //   const sessionState = Convert.toSessionState(json);
 //   const sessionStateChangedMessage = Convert.toSessionStateChangedMessage(json);
+//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const sessionTodosUpdatedMessage = Convert.toSessionTodosUpdatedMessage(json);
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
 //   const sessionVisualizedMessage = Convert.toSessionVisualizedMessage(json);
-//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
 //   const setPluginPriorityMessage = Convert.toSetPluginPriorityMessage(json);
@@ -226,7 +226,6 @@
 //   const workspaceLayoutAddSessionPaneMessage = Convert.toWorkspaceLayoutAddSessionPaneMessage(json);
 //   const workspaceLayoutClosePaneMessage = Convert.toWorkspaceLayoutClosePaneMessage(json);
 //   const workspaceLayoutDockEdge = Convert.toWorkspaceLayoutDockEdge(json);
-//   const workspaceLayoutDockPanelMessage = Convert.toWorkspaceLayoutDockPanelMessage(json);
 //   const workspaceLayoutDockTileMessage = Convert.toWorkspaceLayoutDockTileMessage(json);
 //   const workspaceLayoutFocusPaneMessage = Convert.toWorkspaceLayoutFocusPaneMessage(json);
 //   const workspaceLayoutGetMessage = Convert.toWorkspaceLayoutGetMessage(json);
@@ -239,12 +238,9 @@
 //   const workspaceLayoutRenamePaneMessage = Convert.toWorkspaceLayoutRenamePaneMessage(json);
 //   const workspaceLayoutSetSplitRatioMessage = Convert.toWorkspaceLayoutSetSplitRatioMessage(json);
 //   const workspaceLayoutSplitDirection = Convert.toWorkspaceLayoutSplitDirection(json);
-//   const workspaceLayoutUndockPanelMessage = Convert.toWorkspaceLayoutUndockPanelMessage(json);
 //   const workspaceLayoutUndockTileMessage = Convert.toWorkspaceLayoutUndockTileMessage(json);
-//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
-//   const workspacePanelContentGetMessage = Convert.toWorkspacePanelContentGetMessage(json);
-//   const workspacePanelContentMessage = Convert.toWorkspacePanelContentMessage(json);
+//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceRegisteredMessage = Convert.toWorkspaceRegisteredMessage(json);
 //   const workspaceSelectedMessage = Convert.toWorkspaceSelectedMessage(json);
 //   const workspaceStateChangedMessage = Convert.toWorkspaceStateChangedMessage(json);
@@ -1782,6 +1778,16 @@ export enum ListBranchesMessageCmd {
     ListBranches = "list_branches",
 }
 
+export interface ListDispatchesMessage {
+    cmd:               ListDispatchesMessageCmd;
+    source_session_id: string;
+    [property: string]: any;
+}
+
+export enum ListDispatchesMessageCmd {
+    ListDispatches = "list_dispatches",
+}
+
 export interface ListDispatchMessagesMessage {
     cmd:               ListDispatchMessagesMessageCmd;
     dispatch_id?:      string;
@@ -1792,16 +1798,6 @@ export interface ListDispatchMessagesMessage {
 
 export enum ListDispatchMessagesMessageCmd {
     ListDispatchMessages = "list_dispatch_messages",
-}
-
-export interface ListDispatchesMessage {
-    cmd:               ListDispatchesMessageCmd;
-    source_session_id: string;
-    [property: string]: any;
-}
-
-export enum ListDispatchesMessageCmd {
-    ListDispatches = "list_dispatches",
 }
 
 export interface ListEndpointsMessage {
@@ -1954,69 +1950,6 @@ export enum OpenMarkdownMessageCmd {
     OpenMarkdown = "open_markdown",
 }
 
-export interface PR {
-    approved_by_me:         boolean;
-    author:                 string;
-    ci_status?:             string;
-    comment_count?:         number;
-    details_fetched:        boolean;
-    details_fetched_at?:    string;
-    has_new_changes:        boolean;
-    head_branch?:           string;
-    head_sha?:              string;
-    heat_state?:            HeatState;
-    host:                   string;
-    id:                     string;
-    last_heat_activity_at?: string;
-    last_polled:            string;
-    last_updated:           string;
-    mergeable?:             boolean;
-    mergeable_state?:       string;
-    muted:                  boolean;
-    number:                 number;
-    reason:                 string;
-    repo:                   string;
-    review_status?:         string;
-    role:                   PRRole;
-    state:                  string;
-    title:                  string;
-    url:                    string;
-    [property: string]: any;
-}
-
-export interface PRActionResultMessage {
-    action:  string;
-    error?:  string;
-    event:   PRActionResultMessageEvent;
-    id:      string;
-    success: boolean;
-    [property: string]: any;
-}
-
-export enum PRActionResultMessageEvent {
-    PRActionResult = "pr_action_result",
-}
-
-export interface PRVisitedMessage {
-    cmd: PRVisitedMessageCmd;
-    id:  string;
-    [property: string]: any;
-}
-
-export enum PRVisitedMessageCmd {
-    PRVisited = "pr_visited",
-}
-
-export interface PRsUpdatedMessage {
-    event: PRsUpdatedMessageEvent;
-    prs?:  PRElement[];
-    [property: string]: any;
-}
-
-export enum PRsUpdatedMessageEvent {
-    PrsUpdated = "prs_updated",
-}
-
 export interface PathInspection {
     exists:        boolean;
     home_path?:    string;
@@ -2091,6 +2024,69 @@ export interface PluginElement {
     [property: string]: any;
 }
 
+export interface PR {
+    approved_by_me:         boolean;
+    author:                 string;
+    ci_status?:             string;
+    comment_count?:         number;
+    details_fetched:        boolean;
+    details_fetched_at?:    string;
+    has_new_changes:        boolean;
+    head_branch?:           string;
+    head_sha?:              string;
+    heat_state?:            HeatState;
+    host:                   string;
+    id:                     string;
+    last_heat_activity_at?: string;
+    last_polled:            string;
+    last_updated:           string;
+    mergeable?:             boolean;
+    mergeable_state?:       string;
+    muted:                  boolean;
+    number:                 number;
+    reason:                 string;
+    repo:                   string;
+    review_status?:         string;
+    role:                   PRRole;
+    state:                  string;
+    title:                  string;
+    url:                    string;
+    [property: string]: any;
+}
+
+export interface PRActionResultMessage {
+    action:  string;
+    error?:  string;
+    event:   PRActionResultMessageEvent;
+    id:      string;
+    success: boolean;
+    [property: string]: any;
+}
+
+export enum PRActionResultMessageEvent {
+    PRActionResult = "pr_action_result",
+}
+
+export interface PRsUpdatedMessage {
+    event: PRsUpdatedMessageEvent;
+    prs?:  PRElement[];
+    [property: string]: any;
+}
+
+export enum PRsUpdatedMessageEvent {
+    PrsUpdated = "prs_updated",
+}
+
+export interface PRVisitedMessage {
+    cmd: PRVisitedMessageCmd;
+    id:  string;
+    [property: string]: any;
+}
+
+export enum PRVisitedMessageCmd {
+    PRVisited = "pr_visited",
+}
+
 export interface PtyDesyncMessage {
     event:  PtyDesyncMessageEvent;
     id:     string;
@@ -2126,18 +2122,6 @@ export enum PtyOutputMessageEvent {
     PtyOutput = "pty_output",
 }
 
-export interface PtyResizeMessage {
-    cmd:  PtyResizeMessageCmd;
-    cols: number;
-    id:   string;
-    rows: number;
-    [property: string]: any;
-}
-
-export enum PtyResizeMessageCmd {
-    PtyResize = "pty_resize",
-}
-
 export interface PtyResizedMessage {
     cols:  number;
     event: PtyResizedMessageEvent;
@@ -2148,6 +2132,18 @@ export interface PtyResizedMessage {
 
 export enum PtyResizedMessageEvent {
     PtyResized = "pty_resized",
+}
+
+export interface PtyResizeMessage {
+    cmd:  PtyResizeMessageCmd;
+    cols: number;
+    id:   string;
+    rows: number;
+    [property: string]: any;
+}
+
+export enum PtyResizeMessageCmd {
+    PtyResize = "pty_resize",
 }
 
 export interface QueryAuthorsMessage {
@@ -2212,7 +2208,6 @@ export enum ReadDispatchMessageCmd {
 }
 
 export interface RecentLocation {
-    label:     string;
     last_seen: string;
     path:      string;
     use_count: number;
@@ -2235,7 +2230,6 @@ export enum RecentLocationsResultMessageEvent {
 }
 
 export interface RecentLocationElement {
-    label:     string;
     last_seen: string;
     path:      string;
     use_count: number;
@@ -2363,13 +2357,6 @@ export interface RepoInfo {
     [property: string]: any;
 }
 
-export interface RepoState {
-    collapsed: boolean;
-    muted:     boolean;
-    repo:      string;
-    [property: string]: any;
-}
-
 export interface ReportDispatchMessage {
     cmd:                ReportDispatchMessageCmd;
     report:             string;
@@ -2380,6 +2367,13 @@ export interface ReportDispatchMessage {
 
 export enum ReportDispatchMessageCmd {
     ReportDispatch = "report_dispatch",
+}
+
+export interface RepoState {
+    collapsed: boolean;
+    muted:     boolean;
+    repo:      string;
+    [property: string]: any;
 }
 
 export interface ReposUpdatedMessage {
@@ -2799,6 +2793,16 @@ export enum SessionStateChangedMessageEvent {
     SessionStateChanged = "session_state_changed",
 }
 
+export interface SessionsUpdatedMessage {
+    event:     SessionsUpdatedMessageEvent;
+    sessions?: SessionElement[];
+    [property: string]: any;
+}
+
+export enum SessionsUpdatedMessageEvent {
+    SessionsUpdated = "sessions_updated",
+}
+
 export interface SessionTodosUpdatedMessage {
     event:   SessionTodosUpdatedMessageEvent;
     session: SessionElement;
@@ -2827,16 +2831,6 @@ export interface SessionVisualizedMessage {
 
 export enum SessionVisualizedMessageCmd {
     SessionVisualized = "session_visualized",
-}
-
-export interface SessionsUpdatedMessage {
-    event:     SessionsUpdatedMessageEvent;
-    sessions?: SessionElement[];
-    [property: string]: any;
-}
-
-export enum SessionsUpdatedMessageEvent {
-    SessionsUpdated = "sessions_updated",
 }
 
 export interface SetChiefOfStaffMessage {
@@ -3399,28 +3393,6 @@ export enum WorkspaceLayoutClosePaneMessageCmd {
     WorkspaceLayoutClosePane = "workspace_layout_close_pane",
 }
 
-export interface WorkspaceLayoutDockPanelMessage {
-    anchor_pane_id: string;
-    cmd:            WorkspaceLayoutDockPanelMessageCmd;
-    edge:           WorkspaceLayoutDockEdge;
-    panel_id:       string;
-    panel_kind:     string;
-    ratio?:         number;
-    workspace_id:   string;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutDockPanelMessageCmd {
-    WorkspaceLayoutDockPanel = "workspace_layout_dock_panel",
-}
-
-export enum WorkspaceLayoutDockEdge {
-    Bottom = "bottom",
-    Left = "left",
-    Right = "right",
-    Top = "top",
-}
-
 export interface WorkspaceLayoutDockTileMessage {
     anchor_pane_id: string;
     cmd:            WorkspaceLayoutDockTileMessageCmd;
@@ -3434,6 +3406,13 @@ export interface WorkspaceLayoutDockTileMessage {
 
 export enum WorkspaceLayoutDockTileMessageCmd {
     WorkspaceLayoutDockTile = "workspace_layout_dock_tile",
+}
+
+export enum WorkspaceLayoutDockEdge {
+    Bottom = "bottom",
+    Left = "left",
+    Right = "right",
+    Top = "top",
 }
 
 export interface WorkspaceLayoutFocusPaneMessage {
@@ -3533,17 +3512,6 @@ export enum WorkspaceLayoutSetSplitRatioMessageCmd {
     WorkspaceLayoutSetSplitRatio = "workspace_layout_set_split_ratio",
 }
 
-export interface WorkspaceLayoutUndockPanelMessage {
-    cmd:          WorkspaceLayoutUndockPanelMessageCmd;
-    panel_id:     string;
-    workspace_id: string;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutUndockPanelMessageCmd {
-    WorkspaceLayoutUndockPanel = "workspace_layout_undock_panel",
-}
-
 export interface WorkspaceLayoutUndockTileMessage {
     cmd:          WorkspaceLayoutUndockTileMessageCmd;
     tile_id:      string;
@@ -3553,6 +3521,16 @@ export interface WorkspaceLayoutUndockTileMessage {
 
 export enum WorkspaceLayoutUndockTileMessageCmd {
     WorkspaceLayoutUndockTile = "workspace_layout_undock_tile",
+}
+
+export interface WorkspaceLayoutUpdatedMessage {
+    event:            WorkspaceLayoutUpdatedMessageEvent;
+    workspace_layout: Layout;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutUpdatedMessageEvent {
+    WorkspaceLayoutUpdated = "workspace_layout_updated",
 }
 
 export interface WorkspaceLayoutUpdateTileMessage {
@@ -3566,42 +3544,6 @@ export interface WorkspaceLayoutUpdateTileMessage {
 
 export enum WorkspaceLayoutUpdateTileMessageCmd {
     WorkspaceLayoutUpdateTile = "workspace_layout_update_tile",
-}
-
-export interface WorkspaceLayoutUpdatedMessage {
-    event:            WorkspaceLayoutUpdatedMessageEvent;
-    workspace_layout: Layout;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutUpdatedMessageEvent {
-    WorkspaceLayoutUpdated = "workspace_layout_updated",
-}
-
-export interface WorkspacePanelContentGetMessage {
-    cmd:          WorkspacePanelContentGetMessageCmd;
-    panel_id:     string;
-    workspace_id: string;
-    [property: string]: any;
-}
-
-export enum WorkspacePanelContentGetMessageCmd {
-    WorkspacePanelContentGet = "workspace_panel_content_get",
-}
-
-export interface WorkspacePanelContentMessage {
-    content:      string;
-    error?:       string;
-    event:        WorkspacePanelContentMessageEvent;
-    panel_id:     string;
-    panel_kind:   string;
-    path:         string;
-    workspace_id: string;
-    [property: string]: any;
-}
-
-export enum WorkspacePanelContentMessageEvent {
-    WorkspacePanelContent = "workspace_panel_content",
 }
 
 export interface WorkspaceRegisteredMessage {
@@ -4511,20 +4453,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("ListBranchesMessage")), null, 2);
     }
 
-    public static toListDispatchMessagesMessage(json: string): ListDispatchMessagesMessage {
-        return cast(JSON.parse(json), r("ListDispatchMessagesMessage"));
-    }
-
-    public static listDispatchMessagesMessageToJson(value: ListDispatchMessagesMessage): string {
-        return JSON.stringify(uncast(value, r("ListDispatchMessagesMessage")), null, 2);
-    }
-
     public static toListDispatchesMessage(json: string): ListDispatchesMessage {
         return cast(JSON.parse(json), r("ListDispatchesMessage"));
     }
 
     public static listDispatchesMessageToJson(value: ListDispatchesMessage): string {
         return JSON.stringify(uncast(value, r("ListDispatchesMessage")), null, 2);
+    }
+
+    public static toListDispatchMessagesMessage(json: string): ListDispatchMessagesMessage {
+        return cast(JSON.parse(json), r("ListDispatchMessagesMessage"));
+    }
+
+    public static listDispatchMessagesMessageToJson(value: ListDispatchMessagesMessage): string {
+        return JSON.stringify(uncast(value, r("ListDispatchMessagesMessage")), null, 2);
     }
 
     public static toListEndpointsMessage(json: string): ListEndpointsMessage {
@@ -4639,46 +4581,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("OpenMarkdownMessage")), null, 2);
     }
 
-    public static toPR(json: string): PR {
-        return cast(JSON.parse(json), r("PR"));
-    }
-
-    public static pRToJson(value: PR): string {
-        return JSON.stringify(uncast(value, r("PR")), null, 2);
-    }
-
-    public static toPRActionResultMessage(json: string): PRActionResultMessage {
-        return cast(JSON.parse(json), r("PRActionResultMessage"));
-    }
-
-    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
-        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
-    }
-
-    public static toPRRole(json: string): PRRole {
-        return cast(JSON.parse(json), r("PRRole"));
-    }
-
-    public static pRRoleToJson(value: PRRole): string {
-        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
-    }
-
-    public static toPRVisitedMessage(json: string): PRVisitedMessage {
-        return cast(JSON.parse(json), r("PRVisitedMessage"));
-    }
-
-    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
-        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
-    }
-
-    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
-        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
-    }
-
-    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
-    }
-
     public static toPathInspection(json: string): PathInspection {
         return cast(JSON.parse(json), r("PathInspection"));
     }
@@ -4719,6 +4621,46 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PluginsUpdatedMessage")), null, 2);
     }
 
+    public static toPR(json: string): PR {
+        return cast(JSON.parse(json), r("PR"));
+    }
+
+    public static pRToJson(value: PR): string {
+        return JSON.stringify(uncast(value, r("PR")), null, 2);
+    }
+
+    public static toPRActionResultMessage(json: string): PRActionResultMessage {
+        return cast(JSON.parse(json), r("PRActionResultMessage"));
+    }
+
+    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
+        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
+    }
+
+    public static toPRRole(json: string): PRRole {
+        return cast(JSON.parse(json), r("PRRole"));
+    }
+
+    public static pRRoleToJson(value: PRRole): string {
+        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
+    }
+
+    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
+        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
+    }
+
+    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
+    }
+
+    public static toPRVisitedMessage(json: string): PRVisitedMessage {
+        return cast(JSON.parse(json), r("PRVisitedMessage"));
+    }
+
+    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
+        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
+    }
+
     public static toPtyDesyncMessage(json: string): PtyDesyncMessage {
         return cast(JSON.parse(json), r("PtyDesyncMessage"));
     }
@@ -4743,20 +4685,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PtyOutputMessage")), null, 2);
     }
 
-    public static toPtyResizeMessage(json: string): PtyResizeMessage {
-        return cast(JSON.parse(json), r("PtyResizeMessage"));
-    }
-
-    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
-        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
-    }
-
     public static toPtyResizedMessage(json: string): PtyResizedMessage {
         return cast(JSON.parse(json), r("PtyResizedMessage"));
     }
 
     public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
         return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
+    }
+
+    public static toPtyResizeMessage(json: string): PtyResizeMessage {
+        return cast(JSON.parse(json), r("PtyResizeMessage"));
+    }
+
+    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
+        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
     }
 
     public static toQueryAuthorsMessage(json: string): QueryAuthorsMessage {
@@ -4911,20 +4853,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("RepoInfo")), null, 2);
     }
 
-    public static toRepoState(json: string): RepoState {
-        return cast(JSON.parse(json), r("RepoState"));
-    }
-
-    public static repoStateToJson(value: RepoState): string {
-        return JSON.stringify(uncast(value, r("RepoState")), null, 2);
-    }
-
     public static toReportDispatchMessage(json: string): ReportDispatchMessage {
         return cast(JSON.parse(json), r("ReportDispatchMessage"));
     }
 
     public static reportDispatchMessageToJson(value: ReportDispatchMessage): string {
         return JSON.stringify(uncast(value, r("ReportDispatchMessage")), null, 2);
+    }
+
+    public static toRepoState(json: string): RepoState {
+        return cast(JSON.parse(json), r("RepoState"));
+    }
+
+    public static repoStateToJson(value: RepoState): string {
+        return JSON.stringify(uncast(value, r("RepoState")), null, 2);
     }
 
     public static toReposUpdatedMessage(json: string): ReposUpdatedMessage {
@@ -5127,6 +5069,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionStateChangedMessage")), null, 2);
     }
 
+    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
+        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
+    }
+
+    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
+    }
+
     public static toSessionTodosUpdatedMessage(json: string): SessionTodosUpdatedMessage {
         return cast(JSON.parse(json), r("SessionTodosUpdatedMessage"));
     }
@@ -5149,14 +5099,6 @@ export class Convert {
 
     public static sessionVisualizedMessageToJson(value: SessionVisualizedMessage): string {
         return JSON.stringify(uncast(value, r("SessionVisualizedMessage")), null, 2);
-    }
-
-    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
-        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
-    }
-
-    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
     }
 
     public static toSetChiefOfStaffMessage(json: string): SetChiefOfStaffMessage {
@@ -5503,14 +5445,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutDockEdge")), null, 2);
     }
 
-    public static toWorkspaceLayoutDockPanelMessage(json: string): WorkspaceLayoutDockPanelMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutDockPanelMessage"));
-    }
-
-    public static workspaceLayoutDockPanelMessageToJson(value: WorkspaceLayoutDockPanelMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutDockPanelMessage")), null, 2);
-    }
-
     public static toWorkspaceLayoutDockTileMessage(json: string): WorkspaceLayoutDockTileMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutDockTileMessage"));
     }
@@ -5607,28 +5541,12 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutSplitDirection")), null, 2);
     }
 
-    public static toWorkspaceLayoutUndockPanelMessage(json: string): WorkspaceLayoutUndockPanelMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutUndockPanelMessage"));
-    }
-
-    public static workspaceLayoutUndockPanelMessageToJson(value: WorkspaceLayoutUndockPanelMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockPanelMessage")), null, 2);
-    }
-
     public static toWorkspaceLayoutUndockTileMessage(json: string): WorkspaceLayoutUndockTileMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutUndockTileMessage"));
     }
 
     public static workspaceLayoutUndockTileMessageToJson(value: WorkspaceLayoutUndockTileMessage): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockTileMessage")), null, 2);
-    }
-
-    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
-    }
-
-    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
     }
 
     public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
@@ -5639,20 +5557,12 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
     }
 
-    public static toWorkspacePanelContentGetMessage(json: string): WorkspacePanelContentGetMessage {
-        return cast(JSON.parse(json), r("WorkspacePanelContentGetMessage"));
+    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
     }
 
-    public static workspacePanelContentGetMessageToJson(value: WorkspacePanelContentGetMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspacePanelContentGetMessage")), null, 2);
-    }
-
-    public static toWorkspacePanelContentMessage(json: string): WorkspacePanelContentMessage {
-        return cast(JSON.parse(json), r("WorkspacePanelContentMessage"));
-    }
-
-    public static workspacePanelContentMessageToJson(value: WorkspacePanelContentMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspacePanelContentMessage")), null, 2);
+    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
     }
 
     public static toWorkspaceRegisteredMessage(json: string): WorkspaceRegisteredMessage {
@@ -6795,15 +6705,15 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("ListBranchesMessageCmd") },
         { json: "main_repo", js: "main_repo", typ: "" },
     ], "any"),
+    "ListDispatchesMessage": o([
+        { json: "cmd", js: "cmd", typ: r("ListDispatchesMessageCmd") },
+        { json: "source_session_id", js: "source_session_id", typ: "" },
+    ], "any"),
     "ListDispatchMessagesMessage": o([
         { json: "cmd", js: "cmd", typ: r("ListDispatchMessagesMessageCmd") },
         { json: "dispatch_id", js: "dispatch_id", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "unread_only", js: "unread_only", typ: u(undefined, true) },
-    ], "any"),
-    "ListDispatchesMessage": o([
-        { json: "cmd", js: "cmd", typ: r("ListDispatchesMessageCmd") },
-        { json: "source_session_id", js: "source_session_id", typ: "" },
     ], "any"),
     "ListEndpointsMessage": o([
         { json: "cmd", js: "cmd", typ: r("ListEndpointsMessageCmd") },
@@ -6871,49 +6781,6 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
         { json: "session_id", js: "session_id", typ: u(undefined, "") },
     ], "any"),
-    "PR": o([
-        { json: "approved_by_me", js: "approved_by_me", typ: true },
-        { json: "author", js: "author", typ: "" },
-        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
-        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
-        { json: "details_fetched", js: "details_fetched", typ: true },
-        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
-        { json: "has_new_changes", js: "has_new_changes", typ: true },
-        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
-        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
-        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
-        { json: "host", js: "host", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
-        { json: "last_polled", js: "last_polled", typ: "" },
-        { json: "last_updated", js: "last_updated", typ: "" },
-        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
-        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
-        { json: "muted", js: "muted", typ: true },
-        { json: "number", js: "number", typ: 0 },
-        { json: "reason", js: "reason", typ: "" },
-        { json: "repo", js: "repo", typ: "" },
-        { json: "review_status", js: "review_status", typ: u(undefined, "") },
-        { json: "role", js: "role", typ: r("PRRole") },
-        { json: "state", js: "state", typ: "" },
-        { json: "title", js: "title", typ: "" },
-        { json: "url", js: "url", typ: "" },
-    ], "any"),
-    "PRActionResultMessage": o([
-        { json: "action", js: "action", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "success", js: "success", typ: true },
-    ], "any"),
-    "PRVisitedMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
-        { json: "id", js: "id", typ: "" },
-    ], "any"),
-    "PRsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
-        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
-    ], "any"),
     "PathInspection": o([
         { json: "exists", js: "exists", typ: true },
         { json: "home_path", js: "home_path", typ: u(undefined, "") },
@@ -6966,6 +6833,49 @@ const typeMap: any = {
         { json: "running", js: "running", typ: true },
         { json: "version", js: "version", typ: "" },
     ], "any"),
+    "PR": o([
+        { json: "approved_by_me", js: "approved_by_me", typ: true },
+        { json: "author", js: "author", typ: "" },
+        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
+        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
+        { json: "details_fetched", js: "details_fetched", typ: true },
+        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
+        { json: "has_new_changes", js: "has_new_changes", typ: true },
+        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
+        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
+        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
+        { json: "host", js: "host", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
+        { json: "last_polled", js: "last_polled", typ: "" },
+        { json: "last_updated", js: "last_updated", typ: "" },
+        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
+        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
+        { json: "muted", js: "muted", typ: true },
+        { json: "number", js: "number", typ: 0 },
+        { json: "reason", js: "reason", typ: "" },
+        { json: "repo", js: "repo", typ: "" },
+        { json: "review_status", js: "review_status", typ: u(undefined, "") },
+        { json: "role", js: "role", typ: r("PRRole") },
+        { json: "state", js: "state", typ: "" },
+        { json: "title", js: "title", typ: "" },
+        { json: "url", js: "url", typ: "" },
+    ], "any"),
+    "PRActionResultMessage": o([
+        { json: "action", js: "action", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "PRsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
+        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
+    ], "any"),
+    "PRVisitedMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
+        { json: "id", js: "id", typ: "" },
+    ], "any"),
     "PtyDesyncMessage": o([
         { json: "event", js: "event", typ: r("PtyDesyncMessageEvent") },
         { json: "id", js: "id", typ: "" },
@@ -6983,15 +6893,15 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "seq", js: "seq", typ: 0 },
     ], "any"),
-    "PtyResizeMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
-        { json: "cols", js: "cols", typ: 0 },
-        { json: "id", js: "id", typ: "" },
-        { json: "rows", js: "rows", typ: 0 },
-    ], "any"),
     "PtyResizedMessage": o([
         { json: "cols", js: "cols", typ: 0 },
         { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "rows", js: "rows", typ: 0 },
+    ], "any"),
+    "PtyResizeMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
+        { json: "cols", js: "cols", typ: 0 },
         { json: "id", js: "id", typ: "" },
         { json: "rows", js: "rows", typ: 0 },
     ], "any"),
@@ -7021,7 +6931,6 @@ const typeMap: any = {
         { json: "source_session_id", js: "source_session_id", typ: "" },
     ], "any"),
     "RecentLocation": o([
-        { json: "label", js: "label", typ: "" },
         { json: "last_seen", js: "last_seen", typ: "" },
         { json: "path", js: "path", typ: "" },
         { json: "use_count", js: "use_count", typ: 0 },
@@ -7036,7 +6945,6 @@ const typeMap: any = {
         { json: "success", js: "success", typ: true },
     ], "any"),
     "RecentLocationElement": o([
-        { json: "label", js: "label", typ: "" },
         { json: "last_seen", js: "last_seen", typ: "" },
         { json: "path", js: "path", typ: "" },
         { json: "use_count", js: "use_count", typ: 0 },
@@ -7104,16 +7012,16 @@ const typeMap: any = {
         { json: "repo", js: "repo", typ: "" },
         { json: "worktrees", js: "worktrees", typ: a(r("WorktreeElement")) },
     ], "any"),
-    "RepoState": o([
-        { json: "collapsed", js: "collapsed", typ: true },
-        { json: "muted", js: "muted", typ: true },
-        { json: "repo", js: "repo", typ: "" },
-    ], "any"),
     "ReportDispatchMessage": o([
         { json: "cmd", js: "cmd", typ: r("ReportDispatchMessageCmd") },
         { json: "report", js: "report", typ: "" },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "structured_report", js: "structured_report", typ: u(undefined, r("Report")) },
+    ], "any"),
+    "RepoState": o([
+        { json: "collapsed", js: "collapsed", typ: true },
+        { json: "muted", js: "muted", typ: true },
+        { json: "repo", js: "repo", typ: "" },
     ], "any"),
     "ReposUpdatedMessage": o([
         { json: "event", js: "event", typ: r("ReposUpdatedMessageEvent") },
@@ -7393,6 +7301,10 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("SessionStateChangedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
     ], "any"),
+    "SessionsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
+        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
+    ], "any"),
     "SessionTodosUpdatedMessage": o([
         { json: "event", js: "event", typ: r("SessionTodosUpdatedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
@@ -7404,10 +7316,6 @@ const typeMap: any = {
     "SessionVisualizedMessage": o([
         { json: "cmd", js: "cmd", typ: r("SessionVisualizedMessageCmd") },
         { json: "id", js: "id", typ: "" },
-    ], "any"),
-    "SessionsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
-        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
     ], "any"),
     "SetChiefOfStaffMessage": o([
         { json: "chief_of_staff", js: "chief_of_staff", typ: true },
@@ -7742,15 +7650,6 @@ const typeMap: any = {
         { json: "pane_id", js: "pane_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
-    "WorkspaceLayoutDockPanelMessage": o([
-        { json: "anchor_pane_id", js: "anchor_pane_id", typ: "" },
-        { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutDockPanelMessageCmd") },
-        { json: "edge", js: "edge", typ: r("WorkspaceLayoutDockEdge") },
-        { json: "panel_id", js: "panel_id", typ: "" },
-        { json: "panel_kind", js: "panel_kind", typ: "" },
-        { json: "ratio", js: "ratio", typ: u(undefined, 3.14) },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
     "WorkspaceLayoutDockTileMessage": o([
         { json: "anchor_pane_id", js: "anchor_pane_id", typ: "" },
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutDockTileMessageCmd") },
@@ -7813,39 +7712,20 @@ const typeMap: any = {
         { json: "split_id", js: "split_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
-    "WorkspaceLayoutUndockPanelMessage": o([
-        { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUndockPanelMessageCmd") },
-        { json: "panel_id", js: "panel_id", typ: "" },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
     "WorkspaceLayoutUndockTileMessage": o([
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUndockTileMessageCmd") },
         { json: "tile_id", js: "tile_id", typ: "" },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
-    "WorkspaceLayoutUpdateTileMessage": o([
-        { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUpdateTileMessageCmd") },
-        { json: "request_id", js: "request_id", typ: "" },
-        { json: "tile_id", js: "tile_id", typ: "" },
-        { json: "tile_params", js: "tile_params", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "WorkspaceLayoutUpdatedMessage": o([
         { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
         { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
     ], "any"),
-    "WorkspacePanelContentGetMessage": o([
-        { json: "cmd", js: "cmd", typ: r("WorkspacePanelContentGetMessageCmd") },
-        { json: "panel_id", js: "panel_id", typ: "" },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
-    "WorkspacePanelContentMessage": o([
-        { json: "content", js: "content", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("WorkspacePanelContentMessageEvent") },
-        { json: "panel_id", js: "panel_id", typ: "" },
-        { json: "panel_kind", js: "panel_kind", typ: "" },
-        { json: "path", js: "path", typ: "" },
+    "WorkspaceLayoutUpdateTileMessage": o([
+        { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUpdateTileMessageCmd") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "tile_id", js: "tile_id", typ: "" },
+        { json: "tile_params", js: "tile_params", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "WorkspaceRegisteredMessage": o([
@@ -8190,11 +8070,11 @@ const typeMap: any = {
     "ListBranchesMessageCmd": [
         "list_branches",
     ],
-    "ListDispatchMessagesMessageCmd": [
-        "list_dispatch_messages",
-    ],
     "ListDispatchesMessageCmd": [
         "list_dispatches",
+    ],
+    "ListDispatchMessagesMessageCmd": [
+        "list_dispatch_messages",
     ],
     "ListEndpointsMessageCmd": [
         "list_endpoints",
@@ -8238,20 +8118,20 @@ const typeMap: any = {
     "OpenMarkdownMessageCmd": [
         "open_markdown",
     ],
-    "PRActionResultMessageEvent": [
-        "pr_action_result",
-    ],
-    "PRVisitedMessageCmd": [
-        "pr_visited",
-    ],
-    "PRsUpdatedMessageEvent": [
-        "prs_updated",
-    ],
     "PluginActionResultMessageEvent": [
         "plugin_action_result",
     ],
     "PluginsUpdatedMessageEvent": [
         "plugins_updated",
+    ],
+    "PRActionResultMessageEvent": [
+        "pr_action_result",
+    ],
+    "PRsUpdatedMessageEvent": [
+        "prs_updated",
+    ],
+    "PRVisitedMessageCmd": [
+        "pr_visited",
     ],
     "PtyDesyncMessageEvent": [
         "pty_desync",
@@ -8262,11 +8142,11 @@ const typeMap: any = {
     "PtyOutputMessageEvent": [
         "pty_output",
     ],
-    "PtyResizeMessageCmd": [
-        "pty_resize",
-    ],
     "PtyResizedMessageEvent": [
         "pty_resized",
+    ],
+    "PtyResizeMessageCmd": [
+        "pty_resize",
     ],
     "QueryAuthorsMessageCmd": [
         "query_authors",
@@ -8389,6 +8269,9 @@ const typeMap: any = {
     "SessionStateChangedMessageEvent": [
         "session_state_changed",
     ],
+    "SessionsUpdatedMessageEvent": [
+        "sessions_updated",
+    ],
     "SessionTodosUpdatedMessageEvent": [
         "session_todos_updated",
     ],
@@ -8397,9 +8280,6 @@ const typeMap: any = {
     ],
     "SessionVisualizedMessageCmd": [
         "session_visualized",
-    ],
-    "SessionsUpdatedMessageEvent": [
-        "sessions_updated",
     ],
     "SetChiefOfStaffMessageCmd": [
         "set_chief_of_staff",
@@ -8510,17 +8390,14 @@ const typeMap: any = {
     "WorkspaceLayoutClosePaneMessageCmd": [
         "workspace_layout_close_pane",
     ],
-    "WorkspaceLayoutDockPanelMessageCmd": [
-        "workspace_layout_dock_panel",
+    "WorkspaceLayoutDockTileMessageCmd": [
+        "workspace_layout_dock_tile",
     ],
     "WorkspaceLayoutDockEdge": [
         "bottom",
         "left",
         "right",
         "top",
-    ],
-    "WorkspaceLayoutDockTileMessageCmd": [
-        "workspace_layout_dock_tile",
     ],
     "WorkspaceLayoutFocusPaneMessageCmd": [
         "workspace_layout_focus_pane",
@@ -8543,23 +8420,14 @@ const typeMap: any = {
     "WorkspaceLayoutSetSplitRatioMessageCmd": [
         "workspace_layout_set_split_ratio",
     ],
-    "WorkspaceLayoutUndockPanelMessageCmd": [
-        "workspace_layout_undock_panel",
-    ],
     "WorkspaceLayoutUndockTileMessageCmd": [
         "workspace_layout_undock_tile",
-    ],
-    "WorkspaceLayoutUpdateTileMessageCmd": [
-        "workspace_layout_update_tile",
     ],
     "WorkspaceLayoutUpdatedMessageEvent": [
         "workspace_layout_updated",
     ],
-    "WorkspacePanelContentGetMessageCmd": [
-        "workspace_panel_content_get",
-    ],
-    "WorkspacePanelContentMessageEvent": [
-        "workspace_panel_content",
+    "WorkspaceLayoutUpdateTileMessageCmd": [
+        "workspace_layout_update_tile",
     ],
     "WorkspaceRegisteredMessageEvent": [
         "workspace_registered",

--- a/app/src/utils/locationPickerPaths.ts
+++ b/app/src/utils/locationPickerPaths.ts
@@ -1,3 +1,12 @@
+export function pathBasename(path: string): string {
+  const trimmed = path.replace(/\/+$/, '');
+  if (!trimmed) {
+    return path ? '/' : '';
+  }
+  const idx = trimmed.lastIndexOf('/');
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+}
+
 export function toDisplayPath(path: string, homePath: string): string {
   if (!path) {
     return '';

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1843,8 +1843,7 @@ func (d *Daemon) handleRegister(conn net.Conn, msg *protocol.RegisterMessage) {
 	}
 
 	// Track this location in recent locations
-	label := filepath.Base(msg.Dir)
-	d.store.UpsertRecentLocation(msg.Dir, label)
+	d.store.UpsertRecentLocation(msg.Dir)
 
 	d.sendOK(conn)
 

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -313,11 +313,7 @@ func (d *Daemon) handleRegisterWorkspace(client *wsClient, msg *protocol.Registe
 	snapshot, isNew := d.workspaces.register(id, title, directory, muted)
 	d.store.AddWorkspace(&snapshot)
 	// Make workspace directories available in the recent-locations picker.
-	label := title
-	if label == "" {
-		label = directory
-	}
-	d.store.UpsertRecentLocation(directory, label)
+	d.store.UpsertRecentLocation(directory)
 	if !isNew {
 		// Re-register: pick up any new associations that occurred while it
 		// was registered, then publish a state-changed event so clients

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -671,7 +671,7 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		if !isShell {
 			d.startTranscriptWatcher(session.ID, session.Agent, session.Directory, spawnStartedAt)
 		}
-		d.store.UpsertRecentLocation(cwd, label)
+		d.store.UpsertRecentLocation(cwd)
 		d.associateSessionWithWorkspace(session.ID, workspaceID)
 		d.setWorkspacePaneStatusForSession(session.ID, workspacelayout.PaneStatusReady, "")
 		eventType := protocol.EventSessionRegistered

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "100"
+const ProtocolVersion = "101"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2056,9 +2056,6 @@ type ReadDispatchMessage struct {
 }
 
 type RecentLocation struct {
-	// Label corresponds to the JSON schema field "label".
-	Label string `json:"label"`
-
 	// LastSeen corresponds to the JSON schema field "last_seen".
 	LastSeen string `json:"last_seen"`
 
@@ -3688,29 +3685,6 @@ const WorkspaceLayoutDockEdgeLeft WorkspaceLayoutDockEdge = "left"
 const WorkspaceLayoutDockEdgeRight WorkspaceLayoutDockEdge = "right"
 const WorkspaceLayoutDockEdgeTop WorkspaceLayoutDockEdge = "top"
 
-type WorkspaceLayoutDockPanelMessage struct {
-	// AnchorPaneID corresponds to the JSON schema field "anchor_pane_id".
-	AnchorPaneID string `json:"anchor_pane_id"`
-
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
-
-	// Edge corresponds to the JSON schema field "edge".
-	Edge WorkspaceLayoutDockEdge `json:"edge"`
-
-	// PanelID corresponds to the JSON schema field "panel_id".
-	PanelID string `json:"panel_id"`
-
-	// PanelKind corresponds to the JSON schema field "panel_kind".
-	PanelKind string `json:"panel_kind"`
-
-	// Ratio corresponds to the JSON schema field "ratio".
-	Ratio *float64 `json:"ratio,omitempty,omitzero"`
-
-	// WorkspaceID corresponds to the JSON schema field "workspace_id".
-	WorkspaceID string `json:"workspace_id"`
-}
-
 type WorkspaceLayoutDockTileMessage struct {
 	// AnchorPaneID corresponds to the JSON schema field "anchor_pane_id".
 	AnchorPaneID string `json:"anchor_pane_id"`
@@ -3876,17 +3850,6 @@ type WorkspaceLayoutSplitDirection string
 const WorkspaceLayoutSplitDirectionHorizontal WorkspaceLayoutSplitDirection = "horizontal"
 const WorkspaceLayoutSplitDirectionVertical WorkspaceLayoutSplitDirection = "vertical"
 
-type WorkspaceLayoutUndockPanelMessage struct {
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
-
-	// PanelID corresponds to the JSON schema field "panel_id".
-	PanelID string `json:"panel_id"`
-
-	// WorkspaceID corresponds to the JSON schema field "workspace_id".
-	WorkspaceID string `json:"workspace_id"`
-}
-
 type WorkspaceLayoutUndockTileMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -3921,40 +3884,6 @@ type WorkspaceLayoutUpdatedMessage struct {
 
 	// WorkspaceLayout corresponds to the JSON schema field "workspace_layout".
 	WorkspaceLayout WorkspaceLayout `json:"workspace_layout"`
-}
-
-type WorkspacePanelContentGetMessage struct {
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
-
-	// PanelID corresponds to the JSON schema field "panel_id".
-	PanelID string `json:"panel_id"`
-
-	// WorkspaceID corresponds to the JSON schema field "workspace_id".
-	WorkspaceID string `json:"workspace_id"`
-}
-
-type WorkspacePanelContentMessage struct {
-	// Content corresponds to the JSON schema field "content".
-	Content string `json:"content"`
-
-	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty,omitzero"`
-
-	// Event corresponds to the JSON schema field "event".
-	Event string `json:"event"`
-
-	// PanelID corresponds to the JSON schema field "panel_id".
-	PanelID string `json:"panel_id"`
-
-	// PanelKind corresponds to the JSON schema field "panel_kind".
-	PanelKind string `json:"panel_kind"`
-
-	// Path corresponds to the JSON schema field "path".
-	Path string `json:"path"`
-
-	// WorkspaceID corresponds to the JSON schema field "workspace_id".
-	WorkspaceID string `json:"workspace_id"`
 }
 
 type WorkspaceRegisteredMessage struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -354,7 +354,6 @@ model AuthorState {
 
 model RecentLocation {
   path: string;
-  label: string;
   last_seen: string;    // ISO timestamp
   use_count: int32;
 }

--- a/internal/store/recent_locations_test.go
+++ b/internal/store/recent_locations_test.go
@@ -1,0 +1,143 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newRecentLocationsStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+// seedRecentLocation inserts a row directly so tests control last_seen and
+// can model rows written before upsert-time worktree resolution existed.
+func seedRecentLocation(t *testing.T, s *Store, path, lastSeen string, useCount int) {
+	t.Helper()
+	_, err := s.db.Exec(
+		"INSERT INTO recent_locations (path, last_seen, use_count) VALUES (?, ?, ?)",
+		path, lastSeen, useCount,
+	)
+	if err != nil {
+		t.Fatalf("failed to seed recent location: %v", err)
+	}
+}
+
+func TestUpsertRecentLocationAccumulatesUseCount(t *testing.T) {
+	s := newRecentLocationsStore(t)
+	dir := t.TempDir()
+
+	s.UpsertRecentLocation(dir)
+	s.UpsertRecentLocation(dir)
+
+	locs := s.GetRecentLocations(10)
+	if len(locs) != 1 {
+		t.Fatalf("expected 1 location, got %d", len(locs))
+	}
+	if locs[0].Path != dir {
+		t.Errorf("expected path %s, got %s", dir, locs[0].Path)
+	}
+	if locs[0].UseCount != 2 {
+		t.Errorf("expected use_count 2, got %d", locs[0].UseCount)
+	}
+}
+
+func TestGetRecentLocationsRanksByFrecency(t *testing.T) {
+	s := newRecentLocationsStore(t)
+	now := time.Now()
+	frequentOld := t.TempDir() // 10 uses 3 days ago: 10 * 0.5 = 5
+	recentOnce := t.TempDir()  // 1 use just now:      1 * 4   = 4
+	staleOnce := t.TempDir()   // 1 use a month ago:   1 * 0.25
+
+	seedRecentLocation(t, s, frequentOld, now.Add(-72*time.Hour).Format(time.RFC3339), 10)
+	seedRecentLocation(t, s, recentOnce, now.Format(time.RFC3339), 1)
+	seedRecentLocation(t, s, staleOnce, now.Add(-30*24*time.Hour).Format(time.RFC3339), 1)
+
+	locs := s.GetRecentLocations(10)
+	if len(locs) != 3 {
+		t.Fatalf("expected 3 locations, got %d", len(locs))
+	}
+	// Pure last_seen ordering would put recentOnce first; frecency keeps the
+	// heavily-used project on top.
+	want := []string{frequentOld, recentOnce, staleOnce}
+	for i, path := range want {
+		if locs[i].Path != path {
+			t.Errorf("position %d: expected %s, got %s", i, path, locs[i].Path)
+		}
+	}
+}
+
+func TestRecentLocationsCollapseWorktreesIntoMainRepo(t *testing.T) {
+	s := newRecentLocationsStore(t)
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "repo")
+	worktree := filepath.Join(root, "repo--feat")
+	if err := os.MkdirAll(filepath.Join(mainRepo, ".git", "worktrees", "feat"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(worktree, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitFile := "gitdir: " + filepath.Join(mainRepo, ".git", "worktrees", "feat") + "\n"
+	if err := os.WriteFile(filepath.Join(worktree, ".git"), []byte(gitFile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Upserts record the main repo even when the session lives in the
+	// worktree or below it.
+	s.UpsertRecentLocation(worktree)
+	s.UpsertRecentLocation(filepath.Join(worktree, "sub"))
+
+	locs := s.GetRecentLocations(10)
+	if len(locs) != 1 {
+		t.Fatalf("expected 1 location, got %d: %+v", len(locs), locs)
+	}
+	if locs[0].Path != mainRepo {
+		t.Errorf("expected path %s, got %s", mainRepo, locs[0].Path)
+	}
+	if locs[0].UseCount != 2 {
+		t.Errorf("expected use_count 2, got %d", locs[0].UseCount)
+	}
+
+	// Rows recorded before upsert-time resolution merge at read time.
+	seedRecentLocation(t, s, worktree, time.Now().Format(time.RFC3339), 3)
+	locs = s.GetRecentLocations(10)
+	if len(locs) != 1 {
+		t.Fatalf("expected legacy worktree row to merge, got %d locations", len(locs))
+	}
+	if locs[0].Path != mainRepo {
+		t.Errorf("expected path %s, got %s", mainRepo, locs[0].Path)
+	}
+	if locs[0].UseCount != 5 {
+		t.Errorf("expected merged use_count 5, got %d", locs[0].UseCount)
+	}
+}
+
+func TestRecentLocationsKeepMainRepoSubdirectories(t *testing.T) {
+	s := newRecentLocationsStore(t)
+	mainRepo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(mainRepo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(mainRepo, "app")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s.UpsertRecentLocation(sub)
+
+	locs := s.GetRecentLocations(10)
+	if len(locs) != 1 {
+		t.Fatalf("expected 1 location, got %d", len(locs))
+	}
+	if locs[0].Path != sub {
+		t.Errorf("subdirectory of a main repo should not collapse: expected %s, got %s", sub, locs[0].Path)
+	}
+}

--- a/internal/store/recent_locations_test.go
+++ b/internal/store/recent_locations_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -71,6 +72,37 @@ func TestGetRecentLocationsRanksByFrecency(t *testing.T) {
 		if locs[i].Path != path {
 			t.Errorf("position %d: expected %s, got %s", i, path, locs[i].Path)
 		}
+	}
+}
+
+func TestGetRecentLocationsRanksBeforeTruncating(t *testing.T) {
+	s := newRecentLocationsStore(t)
+	root := t.TempDir()
+	now := time.Now()
+
+	// An old but heavily used project must beat hundreds of fresher one-off
+	// rows, so ranking has to happen over the full table, not a recency-
+	// truncated prefix of it.
+	frequentOld := filepath.Join(root, "frequent-old")
+	if err := os.MkdirAll(frequentOld, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedRecentLocation(t, s, frequentOld, now.Add(-30*24*time.Hour).Format(time.RFC3339), 100) // 100 * 0.25 = 25
+
+	for i := 0; i < 250; i++ {
+		dir := filepath.Join(root, fmt.Sprintf("fresh-%03d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		seedRecentLocation(t, s, dir, now.Format(time.RFC3339), 1) // 1 * 4 = 4
+	}
+
+	locs := s.GetRecentLocations(10)
+	if len(locs) != 10 {
+		t.Fatalf("expected 10 locations, got %d", len(locs))
+	}
+	if locs[0].Path != frequentOld {
+		t.Errorf("expected %s first, got %s", frequentOld, locs[0].Path)
 	}
 }
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -395,6 +395,7 @@ var migrations = []migration{
 			created_at TEXT NOT NULL
 		);
 	`},
+	{48, "drop label from recent_locations", "ALTER TABLE recent_locations DROP COLUMN label"},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -538,6 +539,11 @@ func migrateDB(db *sql.DB) error {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
+		} else if m.version == 48 {
+			if err := applyMigration48(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
 		} else {
 			if _, err := tx.Exec(m.sql); err != nil {
 				tx.Rollback()
@@ -639,6 +645,21 @@ func applyMigration45(tx *sql.Tx) error {
 		ALTER TABLE chief_of_staff_dispatches
 			ADD COLUMN structured_report_json TEXT NOT NULL DEFAULT ''
 	`)
+	return err
+}
+
+// applyMigration48 drops the label column from recent_locations. Labels are
+// derived from the path now. Skips databases (including partial test
+// fixtures) where the table or column never existed.
+func applyMigration48(tx *sql.Tx) error {
+	hasLabel, err := columnExists(tx, "recent_locations", "label")
+	if err != nil {
+		return err
+	}
+	if !hasLabel {
+		return nil
+	}
+	_, err = tx.Exec("ALTER TABLE recent_locations DROP COLUMN label")
 	return err
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1746,11 +1746,13 @@ func (s *Store) GetRecentLocations(limit int) []*protocol.RecentLocation {
 			raw = append(raw, &cloned)
 		}
 	} else {
+		// Fetch every row: ranking happens below, and pre-truncating here
+		// (e.g. by last_seen) would hide old-but-frequent locations. The
+		// table stays small via missing-path cleanup and
+		// CleanupStaleLocations.
 		rows, err := s.db.Query(`
 			SELECT path, last_seen, use_count
-			FROM recent_locations
-			ORDER BY last_seen DESC
-			LIMIT 200`)
+			FROM recent_locations`)
 		if err != nil {
 			s.mu.RUnlock()
 			return nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/workspacelayout"
 )
@@ -1654,102 +1656,159 @@ func (s *Store) ClearProfileRole(role, sessionID string) error {
 
 // Recent Locations methods
 
+// resolveRecentLocationPath collapses a path inside a linked git worktree to
+// the worktree's main repository root so all worktrees of a repo share one
+// recent-locations entry. Non-worktree paths are returned unchanged.
+func resolveRecentLocationPath(path string) string {
+	for dir := filepath.Clean(path); ; {
+		if _, err := os.Lstat(filepath.Join(dir, ".git")); err == nil {
+			if mainRepo := git.GetMainRepoFromWorktree(dir); mainRepo != "" {
+				return mainRepo
+			}
+			return path
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return path
+		}
+		dir = parent
+	}
+}
+
+// frecencyScore ranks a location by combining how often it is used with how
+// recently it was used, so a frequently-used project keeps a stable slot near
+// the top of the picker even after one-off sessions elsewhere.
+func frecencyScore(useCount int, lastSeen string, now time.Time) float64 {
+	count := float64(useCount)
+	t, err := time.Parse(time.RFC3339, lastSeen)
+	if err != nil {
+		return count * 0.25
+	}
+	switch age := now.Sub(t); {
+	case age < time.Hour:
+		return count * 4
+	case age < 24*time.Hour:
+		return count * 2
+	case age < 7*24*time.Hour:
+		return count * 0.5
+	default:
+		return count * 0.25
+	}
+}
+
 // UpsertRecentLocation adds or updates a location in the recent locations table
-func (s *Store) UpsertRecentLocation(path, label string) {
+func (s *Store) UpsertRecentLocation(path string) {
+	path = resolveRecentLocationPath(path)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	now := time.Now().Format(time.RFC3339)
 	if s.db == nil {
 		if s.recentLocations == nil {
 			s.recentLocations = make(map[string]*protocol.RecentLocation)
 		}
-		now := time.Now().Format(time.RFC3339)
 		if existing := s.recentLocations[path]; existing != nil {
-			existing.Label = label
 			existing.LastSeen = now
 			existing.UseCount++
 			return
 		}
 		s.recentLocations[path] = &protocol.RecentLocation{
 			Path:     path,
-			Label:    label,
 			LastSeen: now,
 			UseCount: 1,
 		}
 		return
 	}
 
-	now := time.Now().Format(time.RFC3339)
 	s.execLog(`
-		INSERT INTO recent_locations (path, label, last_seen, use_count)
-		VALUES (?, ?, ?, 1)
+		INSERT INTO recent_locations (path, last_seen, use_count)
+		VALUES (?, ?, 1)
 		ON CONFLICT(path) DO UPDATE SET
-			label = excluded.label,
 			last_seen = excluded.last_seen,
 			use_count = use_count + 1`,
-		path, label, now)
+		path, now)
 }
 
-// GetRecentLocations returns recent locations that still exist on disk, sorted by last_seen DESC
+// GetRecentLocations returns recent locations that still exist on disk,
+// ranked by frecency (frequency weighted by recency)
 func (s *Store) GetRecentLocations(limit int) []*protocol.RecentLocation {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	if s.db == nil {
-		if limit <= 0 {
-			limit = 20
-		}
-		result := make([]*protocol.RecentLocation, 0, len(s.recentLocations))
-		for _, loc := range s.recentLocations {
-			if _, err := os.Stat(loc.Path); os.IsNotExist(err) {
-				continue
-			}
-			cloned := *loc
-			result = append(result, &cloned)
-		}
-		sort.Slice(result, func(i, j int) bool {
-			return result[i].LastSeen > result[j].LastSeen
-		})
-		if len(result) > limit {
-			result = result[:limit]
-		}
-		return result
-	}
-
 	if limit <= 0 {
 		limit = 20
 	}
 
-	rows, err := s.db.Query(`
-		SELECT path, label, last_seen, use_count
-		FROM recent_locations
-		ORDER BY last_seen DESC
-		LIMIT ?`, limit)
-	if err != nil {
-		return nil
-	}
-	defer rows.Close()
-
-	var result []*protocol.RecentLocation
-	var toDelete []string
-
-	for rows.Next() {
-		var loc protocol.RecentLocation
-		if err := rows.Scan(&loc.Path, &loc.Label, &loc.LastSeen, &loc.UseCount); err != nil {
-			continue
+	s.mu.RLock()
+	var raw []*protocol.RecentLocation
+	if s.db == nil {
+		raw = make([]*protocol.RecentLocation, 0, len(s.recentLocations))
+		for _, loc := range s.recentLocations {
+			cloned := *loc
+			raw = append(raw, &cloned)
 		}
+	} else {
+		rows, err := s.db.Query(`
+			SELECT path, last_seen, use_count
+			FROM recent_locations
+			ORDER BY last_seen DESC
+			LIMIT 200`)
+		if err != nil {
+			s.mu.RUnlock()
+			return nil
+		}
+		for rows.Next() {
+			var loc protocol.RecentLocation
+			if err := rows.Scan(&loc.Path, &loc.LastSeen, &loc.UseCount); err != nil {
+				continue
+			}
+			raw = append(raw, &loc)
+		}
+		rows.Close()
+	}
+	s.mu.RUnlock()
 
-		// Validate path still exists
+	// Merge rows recorded before worktree paths collapsed into their main
+	// repository root, and drop entries whose directory disappeared.
+	var toDelete []string
+	merged := make(map[string]*protocol.RecentLocation, len(raw))
+	for _, loc := range raw {
 		if _, err := os.Stat(loc.Path); os.IsNotExist(err) {
 			toDelete = append(toDelete, loc.Path)
 			continue
 		}
+		resolved := resolveRecentLocationPath(loc.Path)
+		if existing := merged[resolved]; existing != nil {
+			existing.UseCount += loc.UseCount
+			if loc.LastSeen > existing.LastSeen {
+				existing.LastSeen = loc.LastSeen
+			}
+			continue
+		}
+		loc.Path = resolved
+		merged[resolved] = loc
+	}
 
-		result = append(result, &loc)
+	result := make([]*protocol.RecentLocation, 0, len(merged))
+	for _, loc := range merged {
+		result = append(result, loc)
+	}
+	now := time.Now()
+	sort.Slice(result, func(i, j int) bool {
+		si := frecencyScore(result[i].UseCount, result[i].LastSeen, now)
+		sj := frecencyScore(result[j].UseCount, result[j].LastSeen, now)
+		if si != sj {
+			return si > sj
+		}
+		if result[i].LastSeen != result[j].LastSeen {
+			return result[i].LastSeen > result[j].LastSeen
+		}
+		return result[i].Path < result[j].Path
+	})
+	if len(result) > limit {
+		result = result[:limit]
 	}
 
 	// Clean up non-existent paths (async, don't block the read)
-	if len(toDelete) > 0 {
+	if len(toDelete) > 0 && s.db != nil {
 		go func() {
 			s.mu.Lock()
 			defer s.mu.Unlock()
@@ -1811,13 +1870,6 @@ func boolToInt(b bool) int {
 		return 1
 	}
 	return 0
-}
-
-func nullString(s string) interface{} {
-	if s == "" {
-		return nil
-	}
-	return s
 }
 
 func nullPtrString(s *string) interface{} {


### PR DESCRIPTION
## Problem

Since terminal sessions and session renames landed, the location picker's RECENT list shows session labels ("shell", manual renames) instead of identifying the *place* — see the repeated "shell" rows. The list also reshuffles on pure recency, and each worktree of a repo occupies its own slot.

## Changes

- **Remove `RecentLocation.label` end to end** (protocol → 98, store, daemon call sites, app). The picker derives the display name from the path's folder name, so session naming can never leak into the location list again. Migration 48 drops the column; **47 is an explicit no-op** because a pre-release build burned that version in existing DBs on 2026-06-10 (a real migration numbered 47 would be silently skipped there).
- **Frecency ranking**: `use_count × recency decay` (×4 <1h, ×2 <1d, ×0.5 <1w, ×0.25 beyond) instead of `last_seen DESC`, so main projects keep stable top slots.
- **Worktree collapse**: paths inside a linked worktree resolve to the main repo root (pure-FS walk via `git.GetMainRepoFromWorktree`, no subprocess) at write time; legacy rows merge at read time. Main-repo subdirectories deliberately do not collapse.
- **Pre-highlight top recent on open**: bare Enter opens your most-used location immediately. Typing/Tab consume the highlight (Enter then submits the typed path as before), arrows convert it to a manual highlight, and Esc still closes the dialog in one press.

## Testing

- 4 new store tests: use-count accumulation, frecency order (discriminates against pure recency), worktree collapse + legacy-row merge, subdir non-collapse.
- 5 new picker tests: basename rendering, bare-Enter open, Esc-during-auto-highlight closes, arrow→manual highlight, typing reclaims Enter.
- Full `go test ./...` and 685 frontend tests green.
- Verified live in the dev app (screenshot-checked: folder names render, top recent pre-highlighted, Enter lands on repo destinations) and migration 48 confirmed against real dev+prod DBs.

---
PR opened by Claude on behalf of Victor.