### PR TITLE
feat(shortcuts): config-driven collapsible sidebar dock (PR 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Added
 - **Keyboard shortcuts are now customizable.** A new shortcut editor (open it from the keyboard-shortcuts cheatsheet's "Edit shortcuts" button, or the command menu's "Customize keyboard shortcuts") lets you rebind any shortcut by clicking it and pressing the new keys. Binding a combo that's already taken offers to reassign it, freeing the previous shortcut. A few essential shortcuts (Quit, Settings, and the cheatsheet) can be rebound but not left unbound so you can't lock yourself out, and "Restore Defaults" resets everything. Your bindings are saved automatically and apply everywhere, including inside the terminal.
+- **The sidebar dock is now yours to arrange.** Pick exactly which shortcuts appear in the dock with the ☆ pin next to any shortcut in the editor, reorder them, and collapse the whole dock with the toggle in its header when you want more room. Dock chips for the diff, review-loop, and PRs panels are now clickable, and every chip updates instantly when you rebind its shortcut.
 
 ## [2026-06-12]
 

--- a/app/e2e/keyboard-shortcuts.spec.ts
+++ b/app/e2e/keyboard-shortcuts.spec.ts
@@ -194,7 +194,9 @@ test.describe('Keyboard Shortcuts', () => {
       const mainPane = page.locator('[data-pane-session-id="s-zoom"][data-pane-id="pane-session"]');
       const utilityPane = page.locator('[data-pane-session-id="s-zoom"][data-pane-id="pane-shell-1"]').first();
       const rootSplit = page.locator('[data-split-id="root"]');
-      const zoomHint = page.getByText('⌘⇧Z zoom');
+      // Dock chips render their key tokens in a styled child span, so match the
+      // chip by its label rather than the full "keys + label" string.
+      const zoomHint = page.locator('.shortcut-hint', { hasText: 'zoom' });
 
       await expect(zoomHint).toHaveAttribute('data-active', 'false');
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3070,8 +3070,12 @@ sendFetchPRDetails,
     available?: boolean;
   }>>>(() => ({
     'dock.diffDetail': {
-      run: handleOpenEditorForSession,
-      available: Boolean(activeSessionId) && !(activeRemoteSession && !remoteEditorAvailable),
+      // Must match the dock.diffDetail keyboard shortcut, which toggles the
+      // diff-detail panel — not the external-editor action (that stays on the
+      // sidebar's "Open in Editor" tool button).
+      run: () => toggleDockPanel('diffDetail'),
+      isActive: diffDetailPanelOpen,
+      available: Boolean(activeSessionId),
     },
     'dock.reviewLoop': {
       run: () => toggleDockPanel('reviewLoop'),
@@ -3093,14 +3097,12 @@ sendFetchPRDetails,
     'terminal.toggleZoom': { isActive: activeSessionZoomed, available: Boolean(activeSessionId) },
   }), [
     activeSessionId,
-    activeRemoteSession,
-    remoteEditorAvailable,
     reviewLoopPanelOpen,
     activeReviewLoopAvailable,
     diffPanelOpen,
+    diffDetailPanelOpen,
     attentionPanelOpen,
     activeSessionZoomed,
-    handleOpenEditorForSession,
     toggleDockPanel,
   ]);
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,7 +3,7 @@ import { onOpenUrl, getCurrent } from '@tauri-apps/plugin-deep-link';
 import { invoke, isTauri } from '@tauri-apps/api/core';
 import { getVersion } from '@tauri-apps/api/app';
 import { openUrl } from '@tauri-apps/plugin-opener';
-import { Sidebar, type SidebarHeaderAction, type FooterShortcut, ReviewLoopIcon, EditorIcon, DiffIcon, PRsIcon } from './components/Sidebar';
+import { Sidebar, type SidebarHeaderAction, type DockItem, ReviewLoopIcon, EditorIcon, DiffIcon, PRsIcon } from './components/Sidebar';
 import { Dashboard } from './components/Dashboard';
 import { AttentionDrawer } from './components/AttentionDrawer';
 import { LocationPicker } from './components/LocationPicker';
@@ -31,7 +31,7 @@ import { CopyToast, useCopyToast } from './components/CopyToast';
 import { ErrorToast, useErrorToast } from './components/ErrorToast';
 import { DaemonProvider } from './contexts/DaemonContext';
 import { SettingsProvider } from './contexts/SettingsContext';
-import { KeybindingsProvider } from './contexts/KeybindingsContext';
+import { KeybindingsProvider, useKeybindings } from './contexts/KeybindingsContext';
 import { useSessionStore, type Session, type TerminalWorkspaceState } from './store/sessions';
 import {
   computeWarmWorkspaceIds,
@@ -57,7 +57,8 @@ import { useDaemonStore } from './store/daemonSessions';
 import { usePRsNeedingAttention } from './hooks/usePRsNeedingAttention';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useWhatsNew } from './hooks/useWhatsNew';
-import { formatShortcut, modifierTokens, shortcutTokens } from './shortcuts';
+import { shortcutTokens, dockShortcutLabel } from './shortcuts';
+import type { ShortcutId } from './shortcuts';
 import { useUIScale } from './hooks/useUIScale';
 import { useTheme } from './hooks/useTheme';
 import { useOpenPR, type OpenPRProgress } from './hooks/useOpenPR';
@@ -959,6 +960,7 @@ sendFetchPRDetails,
 
   // Theme (dark/light/system)
   const { preference: themePreference, resolved: resolvedTheme, setTheme } = useTheme();
+  const keybindings = useKeybindings();
 
   // Settings modal (lifted from Dashboard for Cmd+, access)
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -3017,7 +3019,6 @@ sendFetchPRDetails,
           : 'Open in Editor',
       icon: <EditorIcon />,
       disabled: !activeSessionId || (activeRemoteSession && !remoteEditorAvailable),
-      shortcutHint: `${formatShortcut('dock.diffDetail')} detail`,
       onClick: handleOpenEditorForSession,
     },
     {
@@ -3027,7 +3028,6 @@ sendFetchPRDetails,
       active: reviewLoopPanelOpen,
       disabled: !activeReviewLoopAvailable,
       toneClassName: activeReviewLoopState?.status ? `sidebar-tool-btn--loop-${activeReviewLoopState.status}` : undefined,
-      shortcutHint: `${formatShortcut('dock.reviewLoop')} loop`,
       onClick: () => toggleDockPanel('reviewLoop'),
     },
     {
@@ -3036,7 +3036,6 @@ sendFetchPRDetails,
       icon: <DiffIcon />,
       active: diffPanelOpen,
       disabled: !activeSessionId,
-      shortcutHint: `${formatShortcut('dock.diff')} diff`,
       onClick: () => toggleDockPanel('diff'),
     },
     {
@@ -3045,7 +3044,6 @@ sendFetchPRDetails,
       icon: <PRsIcon />,
       active: attentionPanelOpen,
       badge: attentionCount > 0 ? attentionCount : undefined,
-      shortcutHint: `${formatShortcut('dock.attention')} PRs`,
       onClick: () => toggleDockPanel('attention'),
     },
   ]), [
@@ -3063,17 +3061,67 @@ sendFetchPRDetails,
 
   const activeSessionZoomed = activeWorkspaceId ? Boolean(zoomModeBySessionId[activeWorkspaceId]) : false;
 
-  const sidebarFooterShortcuts = useMemo<FooterShortcut[]>(() => (
-    activeSessionId
-      ? [
-          { label: `${formatShortcut('terminal.splitVertical')} split v` },
-          { label: `${formatShortcut('terminal.splitHorizontal')} split h` },
-          { label: `${formatShortcut('session.newHorizontal')} session h` },
-          { label: `${formatShortcut('terminal.toggleZoom')} zoom`, active: activeSessionZoomed },
-          { label: `${modifierTokens('terminal.focusLeft').join('')}←↑→↓ pane` },
-        ]
-      : []
-  ), [activeSessionId, activeSessionZoomed]);
+  // Interactive/contextual behavior for dock chips, keyed by shortcut id. Ids
+  // not present here render as informational chips (keys + label, no click).
+  // `available: false` hides the chip in the current context (e.g. no session).
+  const dockActions = useMemo<Partial<Record<ShortcutId, {
+    run?: () => void;
+    isActive?: boolean;
+    available?: boolean;
+  }>>>(() => ({
+    'dock.diffDetail': {
+      run: handleOpenEditorForSession,
+      available: Boolean(activeSessionId) && !(activeRemoteSession && !remoteEditorAvailable),
+    },
+    'dock.reviewLoop': {
+      run: () => toggleDockPanel('reviewLoop'),
+      isActive: reviewLoopPanelOpen,
+      available: activeReviewLoopAvailable,
+    },
+    'dock.diff': {
+      run: () => toggleDockPanel('diff'),
+      isActive: diffPanelOpen,
+      available: Boolean(activeSessionId),
+    },
+    'dock.attention': {
+      run: () => toggleDockPanel('attention'),
+      isActive: attentionPanelOpen,
+    },
+    'terminal.splitVertical': { available: Boolean(activeSessionId) },
+    'terminal.splitHorizontal': { available: Boolean(activeSessionId) },
+    'session.newHorizontal': { available: Boolean(activeSessionId) },
+    'terminal.toggleZoom': { isActive: activeSessionZoomed, available: Boolean(activeSessionId) },
+  }), [
+    activeSessionId,
+    activeRemoteSession,
+    remoteEditorAvailable,
+    reviewLoopPanelOpen,
+    activeReviewLoopAvailable,
+    diffPanelOpen,
+    attentionPanelOpen,
+    activeSessionZoomed,
+    handleOpenEditorForSession,
+    toggleDockPanel,
+  ]);
+
+  // The dock is rebuilt from config on every relevant change, so rebinds and
+  // membership/order edits reflect live. Unbound ids and context-unavailable
+  // ids are filtered out.
+  const dockItems = useMemo<DockItem[]>(() => (
+    keybindings.dock.items.flatMap((id) => {
+      const action = dockActions[id];
+      if (action && action.available === false) return [];
+      const keys = shortcutTokens(id).join('');
+      if (!keys) return []; // unbound -> nothing to show
+      return [{
+        id,
+        label: dockShortcutLabel(id),
+        keys,
+        active: action?.isActive ?? false,
+        onClick: action?.run,
+      }];
+    })
+  ), [keybindings.dock.items, keybindings.config, dockActions]);
 
   const handleStartReviewLoop = useCallback(async (prompt: string, iterationLimit: number, presetId?: string) => {
     if (!activeSessionId) return;
@@ -3255,7 +3303,9 @@ sendFetchPRDetails,
           headerActions={sidebarHeaderActions}
           gridLayout={gridLayout}
           onSelectGridLayout={handleSelectGridLayout}
-          footerShortcuts={sidebarFooterShortcuts}
+          dockItems={dockItems}
+          dockCollapsed={keybindings.dock.collapsed}
+          onToggleDockCollapsed={() => keybindings.setDockCollapsed(!keybindings.dock.collapsed)}
           mutedWorkspaces={mutedWorkspaceViews}
           mutedExpanded={sidebarMutedExpanded}
           onMutedExpandedChange={setSidebarMutedExpanded}

--- a/app/src/components/ShortcutEditorModal.css
+++ b/app/src/components/ShortcutEditorModal.css
@@ -179,6 +179,73 @@
   border-color: var(--color-border);
 }
 
+.shortcut-editor-icon-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.shortcut-editor-icon-btn:disabled:hover {
+  color: var(--color-text-dimmed);
+  background: transparent;
+  border-color: transparent;
+}
+
+.shortcut-editor-icon-btn--on,
+.shortcut-editor-icon-btn--on:hover {
+  color: #ff6b35;
+}
+
+/* Dock section (reorderable membership list at the top of the editor) */
+.shortcut-editor-dock-hint {
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: var(--color-text-dimmed);
+}
+
+.shortcut-editor-dock-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-text-dimmed);
+  font-style: italic;
+}
+
+.shortcut-editor-dock-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.shortcut-editor-dock-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 3px 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.shortcut-editor-dock-item:last-child {
+  border-bottom: none;
+}
+
+.shortcut-editor-dock-name {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shortcut-editor-dock-keys {
+  font-size: 12px;
+  color: var(--color-text-dimmed);
+  font-variant-numeric: tabular-nums;
+}
+
 .shortcut-editor-reassign {
   display: flex;
   align-items: center;

--- a/app/src/components/ShortcutEditorModal.test.tsx
+++ b/app/src/components/ShortcutEditorModal.test.tsx
@@ -105,6 +105,46 @@ describe('ShortcutEditorModal', () => {
     expect(cfg.overrides['dock.diff']).toBeNull();
   });
 
+  it('pins a shortcut to the dock from its row star', () => {
+    const { setSetting } = renderEditor();
+    const newSession = row('New session in this workspace');
+    // Not in the default dock -> star offers to add.
+    fireEvent.click(within(newSession).getByLabelText('Add to dock'));
+
+    expect(lastConfig(setSetting).dock.items).toContain('session.new');
+    // Star now reflects membership (same row node, re-rendered in place).
+    expect(within(newSession).getByLabelText('Remove from dock')).toBeInTheDocument();
+  });
+
+  it('reorders dock items with the up/down controls', () => {
+    const { setSetting } = renderEditor({
+      [KEYBINDINGS_SETTING_KEY]: JSON.stringify({
+        version: 1,
+        overrides: {},
+        dock: { collapsed: false, items: ['dock.diff', 'dock.attention'] },
+      }),
+    });
+
+    // First item can't move up; move it down instead.
+    fireEvent.click(screen.getByLabelText('Move Diff panel down'));
+
+    expect(lastConfig(setSetting).dock.items).toEqual(['dock.attention', 'dock.diff']);
+  });
+
+  it('removes a dock item from the dock section', () => {
+    const { setSetting } = renderEditor({
+      [KEYBINDINGS_SETTING_KEY]: JSON.stringify({
+        version: 1,
+        overrides: {},
+        dock: { collapsed: false, items: ['dock.diff', 'dock.attention'] },
+      }),
+    });
+
+    fireEvent.click(screen.getByLabelText('Remove Diff panel from dock'));
+
+    expect(lastConfig(setSetting).dock.items).toEqual(['dock.attention']);
+  });
+
   it('restores defaults', () => {
     const { setSetting } = renderEditor({
       [KEYBINDINGS_SETTING_KEY]: JSON.stringify({

--- a/app/src/components/ShortcutEditorModal.tsx
+++ b/app/src/components/ShortcutEditorModal.tsx
@@ -138,6 +138,54 @@ export function ShortcutEditorModal({ isOpen, onClose }: ShortcutEditorModalProp
           </div>
 
           <div className="shortcut-editor-body">
+            <section className="shortcut-editor-category shortcut-editor-dock">
+              <h3 className="shortcut-editor-category-title">Dock</h3>
+              <p className="shortcut-editor-dock-hint">
+                Shortcuts shown in the sidebar dock, in order. Reorder or remove them here, or
+                pin any shortcut with ☆ below.
+              </p>
+              {kb.dock.items.length === 0 ? (
+                <p className="shortcut-editor-dock-empty">No shortcuts pinned to the dock.</p>
+              ) : (
+                <ol className="shortcut-editor-dock-list">
+                  {kb.dock.items.map((id, index) => (
+                    <li className="shortcut-editor-dock-item" key={id}>
+                      <span className="shortcut-editor-dock-name">{SHORTCUT_META[id].label}</span>
+                      <span className="shortcut-editor-dock-keys">{formatShortcut(id)}</span>
+                      <button
+                        type="button"
+                        className="shortcut-editor-icon-btn"
+                        title="Move up"
+                        aria-label={`Move ${SHORTCUT_META[id].label} up`}
+                        disabled={index === 0}
+                        onClick={() => kb.moveDockItem(id, -1)}
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        className="shortcut-editor-icon-btn"
+                        title="Move down"
+                        aria-label={`Move ${SHORTCUT_META[id].label} down`}
+                        disabled={index === kb.dock.items.length - 1}
+                        onClick={() => kb.moveDockItem(id, 1)}
+                      >
+                        ↓
+                      </button>
+                      <button
+                        type="button"
+                        className="shortcut-editor-icon-btn"
+                        title="Remove from dock"
+                        aria-label={`Remove ${SHORTCUT_META[id].label} from dock`}
+                        onClick={() => kb.setInDock(id, false)}
+                      >
+                        ✕
+                      </button>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </section>
             {SHORTCUT_CATEGORY_ORDER.map((category) => (
               <section className="shortcut-editor-category" key={category}>
                 <h3 className="shortcut-editor-category-title">
@@ -199,6 +247,16 @@ export function ShortcutEditorModal({ isOpen, onClose }: ShortcutEditorModalProp
                               onCapture={(def) => applyBinding(id, def)}
                               onCancel={() => setRecordingId(null)}
                             />
+                            <button
+                              type="button"
+                              className={`shortcut-editor-icon-btn ${kb.isInDock(id) ? 'shortcut-editor-icon-btn--on' : ''}`.trim()}
+                              title={kb.isInDock(id) ? 'Remove from dock' : 'Add to dock'}
+                              aria-label={kb.isInDock(id) ? 'Remove from dock' : 'Add to dock'}
+                              aria-pressed={kb.isInDock(id)}
+                              onClick={() => kb.setInDock(id, !kb.isInDock(id))}
+                            >
+                              {kb.isInDock(id) ? '★' : '☆'}
+                            </button>
                             {customized && (
                               <button
                                 type="button"

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -597,14 +597,20 @@
 
 .sidebar-footer {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px 12px;
+  flex-direction: column;
+  gap: 8px;
   padding: 12px;
   border-top: 1px solid var(--color-border);
 }
 
+.sidebar-footer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .sidebar-footer-label {
-  width: 100%;
   color: var(--color-text-muted);
   font-family: 'JetBrains Mono', monospace;
   font-size: var(--font-size-xs);
@@ -613,10 +619,61 @@
   text-transform: uppercase;
 }
 
+.dock-collapse-btn {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--color-text-dimmed);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 120ms ease-out;
+}
+
+.dock-collapse-btn:hover {
+  color: var(--color-text-primary);
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--color-border);
+}
+
+.sidebar-dock-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+
 .shortcut-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-size: var(--font-size-sm);
   color: var(--color-text-dimmed);
   font-family: 'JetBrains Mono', monospace;
+}
+
+.shortcut-hint-keys {
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.shortcut-hint--action {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: all 120ms ease-out;
+}
+
+.shortcut-hint--action:hover {
+  color: var(--color-text-primary);
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--color-border);
 }
 
 .shortcut-hint.active {

--- a/app/src/components/Sidebar.test.tsx
+++ b/app/src/components/Sidebar.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import { Sidebar, type FooterShortcut } from './Sidebar';
+import { Sidebar, type DockItem } from './Sidebar';
 import { buildWorkspaceViewModels, type WorkspaceWithSessions } from '../utils/workspaceViewModels';
 
 function sessionlessWorkspace(): WorkspaceWithSessions<TestSession> {
@@ -94,7 +94,7 @@ const baseProps = {
   selectedWorkspaceId: null,
   collapsed: false,
   headerActions: [],
-  footerShortcuts: undefined as FooterShortcut[] | undefined,
+  dockItems: undefined as DockItem[] | undefined,
   onSelectSession: () => {},
   onSelectWorkspace: () => {},
   onNewSession: () => {},
@@ -377,34 +377,60 @@ describe('Sidebar', () => {
     expect(screen.getByRole('dialog', { name: 'Sidebar settings' })).toBeInTheDocument();
   });
 
-  it('renders dock action hints alongside custom footer shortcuts when provided', () => {
+  it('renders config-driven dock items, marks active ones, and fires actions on click', () => {
+    const onDiff = vi.fn();
     render(
       <Sidebar
         {...baseProps}
-        headerActions={[{
-          id: 'diff',
-          title: 'Diff',
-          shortcutHint: '⌘⇧G diff',
-          onClick: () => {},
-          icon: null,
-        }]}
-        footerShortcuts={[
-          { label: '⌘D split v' },
-          { label: '⌘⇧D split h' },
-          { label: '⌘⇧Z zoom', active: true },
-          { label: '⌘⌥←↑→↓ pane' },
+        dockItems={[
+          { id: 'dock.diff', label: 'diff', keys: '⌘⇧G', onClick: onDiff },
+          { id: 'terminal.toggleZoom', label: 'zoom', keys: '⌘⇧Z', active: true },
+          { id: 'session.toggleSidebar', label: 'sidebar', keys: '⌘⇧B' },
         ]}
         {...buildSidebarData([])}
       />
     );
 
-    expect(screen.getByText('⌘⇧G diff')).toBeInTheDocument();
-    expect(screen.getByText('⌘D split v')).toBeInTheDocument();
-    expect(screen.getByText('⌘⇧D split h')).toBeInTheDocument();
-    expect(screen.getByText('⌘⇧Z zoom')).toBeInTheDocument();
-    expect(screen.getByText('⌘⇧Z zoom')).toHaveAttribute('data-active', 'true');
-    expect(screen.getByText('⌘⌥←↑→↓ pane')).toBeInTheDocument();
-    expect(screen.getByText('⌘⇧B sidebar')).toBeInTheDocument();
+    // Actionable item is a button and fires its handler.
+    const diff = screen.getByRole('button', { name: /diff/ });
+    expect(diff).toBeInTheDocument();
+    fireEvent.click(diff);
+    expect(onDiff).toHaveBeenCalledTimes(1);
+
+    // Informational items render their keys + label.
+    expect(screen.getByText('zoom')).toBeInTheDocument();
+    expect(screen.getByText('zoom').closest('.shortcut-hint')).toHaveAttribute('data-active', 'true');
+    expect(screen.getByText('sidebar')).toBeInTheDocument();
+    expect(screen.getByText('⌘⇧B')).toBeInTheDocument();
+  });
+
+  it('hides dock items behind the collapse toggle and toggles via the header button', () => {
+    const onToggle = vi.fn();
+    const { rerender } = render(
+      <Sidebar
+        {...baseProps}
+        dockItems={[{ id: 'dock.diff', label: 'diff', keys: '⌘⇧G' }]}
+        dockCollapsed={false}
+        onToggleDockCollapsed={onToggle}
+        {...buildSidebarData([])}
+      />
+    );
+    expect(screen.getByText('diff')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide dock' }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Sidebar
+        {...baseProps}
+        dockItems={[{ id: 'dock.diff', label: 'diff', keys: '⌘⇧G' }]}
+        dockCollapsed={true}
+        onToggleDockCollapsed={onToggle}
+        {...buildSidebarData([])}
+      />
+    );
+    expect(screen.queryByText('diff')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show dock' })).toBeInTheDocument();
   });
 
   it('shows endpoint badge and renders actions for remote sessions', () => {

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -138,7 +138,10 @@ interface SidebarProps {
   // Optional so existing Sidebar tests render without wiring the grid picker.
   gridLayout?: GridLayout;
   onSelectGridLayout?: (layout: GridLayout) => void;
-  footerShortcuts?: FooterShortcut[];
+  // Config-driven dock chips (ordered). Built in App from the keybindings config.
+  dockItems?: DockItem[];
+  dockCollapsed?: boolean;
+  onToggleDockCollapsed?: () => void;
   mutedWorkspaces?: SidebarWorkspace[];
   mutedExpanded?: boolean;
   onMutedExpandedChange?: (expanded: boolean) => void;
@@ -173,13 +176,18 @@ export interface SidebarHeaderAction {
   active?: boolean;
   toneClassName?: string;
   badge?: string | number;
-  shortcutHint?: string;
   onClick: () => void;
 }
 
-export interface FooterShortcut {
+export interface DockItem {
+  id: string;
+  /** Terse chip label, e.g. "diff". */
   label: string;
+  /** Rendered key tokens, e.g. "⌘⇧G". Empty when the shortcut is unbound. */
+  keys: string;
   active?: boolean;
+  /** When set, the chip is an actionable button; otherwise an informational hint. */
+  onClick?: () => void;
 }
 
 function HomeIcon() {
@@ -286,7 +294,9 @@ export function Sidebar({
   headerActions,
   gridLayout,
   onSelectGridLayout,
-  footerShortcuts,
+  dockItems = [],
+  dockCollapsed = false,
+  onToggleDockCollapsed,
   mutedWorkspaces = [],
   mutedExpanded: mutedExpandedProp,
   onMutedExpandedChange,
@@ -385,13 +395,6 @@ export function Sidebar({
   const visualIndexOfWorkspace = (id: string) => (
     visibleVisualIndexByWorkspaceId.get(id) ?? visualIndexByWorkspaceId.get(id) ?? -1
   );
-  const dockShortcutHints = Array.from(new Map([
-    ...headerActions
-      .filter((action) => action.shortcutHint && !action.disabled)
-      .map((action) => [action.shortcutHint as string, { label: action.shortcutHint as string, active: false }] as const),
-    ...(footerShortcuts ?? []).map((shortcut) => [shortcut.label, shortcut] as const),
-  ]).values());
-
   if (collapsed) {
     return (
       <div className="sidebar collapsed">
@@ -780,18 +783,50 @@ export function Sidebar({
         </div>
       )}
 
-      <div className="sidebar-footer">
-        <span className="sidebar-footer-label">Dock</span>
-        {dockShortcutHints.map((shortcut) => (
-          <span
-            key={shortcut.label}
-            className={`shortcut-hint ${shortcut.active ? 'active' : ''}`.trim()}
-            data-active={shortcut.active ? 'true' : 'false'}
-          >
-            {shortcut.label}
-          </span>
-        ))}
-        <span className="shortcut-hint">{`${formatShortcut('session.toggleSidebar')} sidebar`}</span>
+      <div className={`sidebar-footer ${dockCollapsed ? 'sidebar-footer--collapsed' : ''}`.trim()}>
+        <div className="sidebar-footer-head">
+          <span className="sidebar-footer-label">Dock</span>
+          {onToggleDockCollapsed && (
+            <button
+              type="button"
+              className="dock-collapse-btn"
+              onClick={onToggleDockCollapsed}
+              aria-expanded={!dockCollapsed}
+              title={dockCollapsed ? 'Show dock' : 'Hide dock'}
+              aria-label={dockCollapsed ? 'Show dock' : 'Hide dock'}
+            >
+              {dockCollapsed ? '+' : '−'}
+            </button>
+          )}
+        </div>
+        {!dockCollapsed && (
+          <div className="sidebar-dock-items">
+            {dockItems.map((item) => (
+              item.onClick ? (
+                <button
+                  key={item.id}
+                  type="button"
+                  className={`shortcut-hint shortcut-hint--action ${item.active ? 'active' : ''}`.trim()}
+                  data-active={item.active ? 'true' : 'false'}
+                  onClick={item.onClick}
+                  title={item.label}
+                >
+                  {item.keys && <span className="shortcut-hint-keys">{item.keys}</span>}
+                  {item.label}
+                </button>
+              ) : (
+                <span
+                  key={item.id}
+                  className={`shortcut-hint ${item.active ? 'active' : ''}`.trim()}
+                  data-active={item.active ? 'true' : 'false'}
+                >
+                  {item.keys && <span className="shortcut-hint-keys">{item.keys}</span>}
+                  {item.label}
+                </span>
+              )
+            ))}
+          </div>
+        )}
       </div>
 
       {renameTarget && (

--- a/app/src/contexts/KeybindingsContext.test.tsx
+++ b/app/src/contexts/KeybindingsContext.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SettingsProvider } from './SettingsContext';
+import { KeybindingsProvider, useKeybindings } from './KeybindingsContext';
+import {
+  KEYBINDINGS_SETTING_KEY,
+  DEFAULT_DOCK_ITEMS,
+  setShortcutOverrides,
+} from '../shortcuts/resolver';
+
+afterEach(() => setShortcutOverrides({}));
+
+function Consumer() {
+  const kb = useKeybindings();
+  return (
+    <div>
+      <span data-testid="collapsed">{String(kb.dock.collapsed)}</span>
+      <span data-testid="items">{kb.dock.items.join(',')}</span>
+      <span data-testid="indock-new">{String(kb.isInDock('session.new'))}</span>
+      <button onClick={() => kb.setDockCollapsed(true)}>collapse</button>
+      <button onClick={() => kb.setDockCollapsed(false)}>expand</button>
+      <button onClick={() => kb.setInDock('session.new', true)}>add-new</button>
+      <button onClick={() => kb.moveDockItem('dock.diff', 1)}>move-diff-down</button>
+    </div>
+  );
+}
+
+function renderConsumer(initial: Record<string, string> = {}) {
+  const setSetting = vi.fn();
+  render(
+    <SettingsProvider settings={initial} setSetting={setSetting}>
+      <KeybindingsProvider>
+        <Consumer />
+      </KeybindingsProvider>
+    </SettingsProvider>,
+  );
+  return { setSetting };
+}
+
+function lastConfig(setSetting: ReturnType<typeof vi.fn>) {
+  const calls = setSetting.mock.calls.filter(([k]) => k === KEYBINDINGS_SETTING_KEY);
+  return JSON.parse(calls[calls.length - 1][1]);
+}
+
+function dockSetting(initial: { collapsed?: boolean; items: string[] }) {
+  return {
+    [KEYBINDINGS_SETTING_KEY]: JSON.stringify({
+      version: 1,
+      overrides: {},
+      dock: { collapsed: initial.collapsed ?? false, items: initial.items },
+    }),
+  };
+}
+
+describe('KeybindingsContext dock', () => {
+  it('exposes the default dock when no config is persisted', () => {
+    renderConsumer();
+    expect(screen.getByTestId('collapsed').textContent).toBe('false');
+    expect(screen.getByTestId('items').textContent).toBe(DEFAULT_DOCK_ITEMS.join(','));
+  });
+
+  it('persists collapse without disturbing membership', () => {
+    const { setSetting } = renderConsumer(dockSetting({ items: ['dock.diff'] }));
+    fireEvent.click(screen.getByText('collapse'));
+
+    const cfg = lastConfig(setSetting);
+    expect(cfg.dock.collapsed).toBe(true);
+    expect(cfg.dock.items).toEqual(['dock.diff']);
+    expect(screen.getByTestId('collapsed').textContent).toBe('true');
+  });
+
+  it('does not write when collapse state is unchanged', () => {
+    const { setSetting } = renderConsumer(dockSetting({ collapsed: false, items: ['dock.diff'] }));
+    fireEvent.click(screen.getByText('expand')); // already expanded
+    expect(setSetting.mock.calls.filter(([k]) => k === KEYBINDINGS_SETTING_KEY)).toHaveLength(0);
+  });
+
+  it('adds a shortcut to the dock and reflects membership', () => {
+    const { setSetting } = renderConsumer(dockSetting({ items: ['dock.diff'] }));
+    expect(screen.getByTestId('indock-new').textContent).toBe('false');
+
+    fireEvent.click(screen.getByText('add-new'));
+
+    expect(lastConfig(setSetting).dock.items).toEqual(['dock.diff', 'session.new']);
+    expect(screen.getByTestId('indock-new').textContent).toBe('true');
+  });
+
+  it('reorders dock items and persists the new order', () => {
+    const { setSetting } = renderConsumer(dockSetting({ items: ['dock.diff', 'dock.attention'] }));
+    fireEvent.click(screen.getByText('move-diff-down'));
+    expect(lastConfig(setSetting).dock.items).toEqual(['dock.attention', 'dock.diff']);
+  });
+
+  it('preserves the dock when only overrides change (restoreDefaults aside)', () => {
+    // Editing a keybinding must not wipe a customized dock.
+    const { setSetting } = renderConsumer(dockSetting({ items: ['dock.attention'] }));
+    fireEvent.click(screen.getByText('add-new'));
+    const cfg = lastConfig(setSetting);
+    expect(cfg.dock.items).toEqual(['dock.attention', 'session.new']);
+    expect(cfg.overrides).toEqual({});
+  });
+});

--- a/app/src/contexts/KeybindingsContext.tsx
+++ b/app/src/contexts/KeybindingsContext.tsx
@@ -18,6 +18,8 @@ import { ShortcutDef, ShortcutId } from '../shortcuts/registry';
 import { isProtectedShortcut } from '../shortcuts/metadata';
 import {
   KeybindingsConfig,
+  DockConfig,
+  DEFAULT_DOCK,
   KEYBINDINGS_SETTING_KEY,
   parseKeybindingsConfig,
   serializeKeybindingsConfig,
@@ -31,12 +33,19 @@ export type OverrideChange = ShortcutDef | null | undefined;
 
 interface KeybindingsContextValue {
   config: KeybindingsConfig;
+  dock: DockConfig;
   resolve: (id: ShortcutId) => ShortcutDef | null;
   isProtected: (id: ShortcutId) => boolean;
   isCustomized: (id: ShortcutId) => boolean;
   findConflict: (def: ShortcutDef, excludeId: ShortcutId) => ShortcutId | null;
   /** Apply one or more override changes in a single persisted write (atomic). */
   applyOverrides: (changes: Partial<Record<ShortcutId, OverrideChange>>) => void;
+  isInDock: (id: ShortcutId) => boolean;
+  /** Add (append) or remove a shortcut from the dock membership list. */
+  setInDock: (id: ShortcutId, inDock: boolean) => void;
+  /** Move a dock item one slot earlier (-1) or later (+1); no-op at the ends. */
+  moveDockItem: (id: ShortcutId, direction: -1 | 1) => void;
+  setDockCollapsed: (collapsed: boolean) => void;
   restoreDefaults: () => void;
 }
 
@@ -88,23 +97,51 @@ export function KeybindingsProvider({ children }: { children: ReactNode }) {
         overrides[id] = change;
       }
     }
-    commit({ version: 1, overrides });
+    commit({ ...configRef.current, overrides });
+  }, [commit]);
+
+  const setInDock = useCallback((id: ShortcutId, inDock: boolean) => {
+    const items = configRef.current.dock.items;
+    const present = items.includes(id);
+    if (inDock === present) return;
+    const nextItems = inDock ? [...items, id] : items.filter((x) => x !== id);
+    commit({ ...configRef.current, dock: { ...configRef.current.dock, items: nextItems } });
+  }, [commit]);
+
+  const moveDockItem = useCallback((id: ShortcutId, direction: -1 | 1) => {
+    const items = [...configRef.current.dock.items];
+    const from = items.indexOf(id);
+    if (from === -1) return;
+    const to = from + direction;
+    if (to < 0 || to >= items.length) return;
+    [items[from], items[to]] = [items[to], items[from]];
+    commit({ ...configRef.current, dock: { ...configRef.current.dock, items } });
+  }, [commit]);
+
+  const setDockCollapsed = useCallback((collapsed: boolean) => {
+    if (configRef.current.dock.collapsed === collapsed) return;
+    commit({ ...configRef.current, dock: { ...configRef.current.dock, collapsed } });
   }, [commit]);
 
   const restoreDefaults = useCallback(() => {
-    commit({ version: 1, overrides: {} });
+    commit({ version: 1, overrides: {}, dock: { ...DEFAULT_DOCK, items: [...DEFAULT_DOCK.items] } });
   }, [commit]);
 
   const value = useMemo<KeybindingsContextValue>(() => ({
     config,
+    dock: config.dock,
     resolve: resolveBinding,
     isProtected: isProtectedShortcut,
     isCustomized: (id: ShortcutId) =>
       Object.prototype.hasOwnProperty.call(config.overrides, id),
     findConflict,
     applyOverrides,
+    isInDock: (id: ShortcutId) => config.dock.items.includes(id),
+    setInDock,
+    moveDockItem,
+    setDockCollapsed,
     restoreDefaults,
-  }), [config, applyOverrides, restoreDefaults]);
+  }), [config, applyOverrides, setInDock, moveDockItem, setDockCollapsed, restoreDefaults]);
 
   return (
     <KeybindingsContext.Provider value={value}>

--- a/app/src/shortcuts/index.ts
+++ b/app/src/shortcuts/index.ts
@@ -16,8 +16,11 @@ export {
 } from './cheatsheet';
 export {
   type KeybindingsConfig,
+  type DockConfig,
   KEYBINDINGS_SETTING_KEY,
   EMPTY_KEYBINDINGS_CONFIG,
+  DEFAULT_DOCK,
+  DEFAULT_DOCK_ITEMS,
   resolveBinding,
   resolvedShortcutEntries,
   isUnbound,
@@ -36,4 +39,5 @@ export {
   SHORTCUT_CATEGORY_LABELS,
   SHORTCUT_CATEGORY_ORDER,
   isProtectedShortcut,
+  dockShortcutLabel,
 } from './metadata';

--- a/app/src/shortcuts/metadata.ts
+++ b/app/src/shortcuts/metadata.ts
@@ -18,6 +18,11 @@ export interface ShortcutMeta {
   category: ShortcutCategory;
   /** Cannot be unbound (still rebindable). Guards the escape hatches. */
   protected?: boolean;
+  /**
+   * Terse text for the sidebar dock chip. Falls back to `label` when absent, so
+   * any shortcut is dock-eligible while the default dock entries stay compact.
+   */
+  dockLabel?: string;
 }
 
 export const SHORTCUT_CATEGORY_LABELS: Record<ShortcutCategory, string> = {
@@ -38,7 +43,7 @@ export const SHORTCUT_CATEGORY_ORDER: ShortcutCategory[] = [
 export const SHORTCUT_META: Record<ShortcutId, ShortcutMeta> = {
   // Workspaces & Sessions
   'session.new': { label: 'New session in this workspace', category: 'sessions' },
-  'session.newHorizontal': { label: 'New session, split sideways', category: 'sessions' },
+  'session.newHorizontal': { label: 'New session, split sideways', category: 'sessions', dockLabel: 'session h' },
   'session.newWorkspace': { label: 'New workspace', category: 'sessions' },
   'session.close': { label: 'Close session (or focused pane)', category: 'sessions' },
   'session.prev': { label: 'Previous session', category: 'sessions' },
@@ -46,7 +51,7 @@ export const SHORTCUT_META: Record<ShortcutId, ShortcutMeta> = {
   'session.goToDashboard': { label: 'Go to dashboard (home)', category: 'sessions' },
   'view.toggleGrid': { label: 'Toggle grid view', category: 'sessions' },
   'session.jumpToWaiting': { label: 'Jump to next waiting session', category: 'sessions' },
-  'session.toggleSidebar': { label: 'Toggle sidebar', category: 'sessions' },
+  'session.toggleSidebar': { label: 'Toggle sidebar', category: 'sessions', dockLabel: 'sidebar' },
   'workspace.select1': { label: 'Jump to workspace 1', category: 'sessions' },
   'workspace.select2': { label: 'Jump to workspace 2', category: 'sessions' },
   'workspace.select3': { label: 'Jump to workspace 3', category: 'sessions' },
@@ -60,9 +65,9 @@ export const SHORTCUT_META: Record<ShortcutId, ShortcutMeta> = {
   // Panes & Terminals
   'terminal.open': { label: 'Focus utility terminal', category: 'panes' },
   'terminal.collapse': { label: 'Collapse utility terminal', category: 'panes' },
-  'terminal.splitVertical': { label: 'Split pane down', category: 'panes' },
-  'terminal.splitHorizontal': { label: 'Split pane sideways', category: 'panes' },
-  'terminal.toggleZoom': { label: 'Zoom active pane', category: 'panes' },
+  'terminal.splitVertical': { label: 'Split pane down', category: 'panes', dockLabel: 'split v' },
+  'terminal.splitHorizontal': { label: 'Split pane sideways', category: 'panes', dockLabel: 'split h' },
+  'terminal.toggleZoom': { label: 'Zoom active pane', category: 'panes', dockLabel: 'zoom' },
   'terminal.toggleMaximize': { label: 'Maximize active pane', category: 'panes' },
   'terminal.close': { label: 'Close focused pane', category: 'panes' },
   'terminal.focusLeft': { label: 'Move focus left', category: 'panes' },
@@ -72,10 +77,10 @@ export const SHORTCUT_META: Record<ShortcutId, ShortcutMeta> = {
   'terminal.find': { label: 'Find in terminal', category: 'panes' },
 
   // Review & Git
-  'dock.diff': { label: 'Diff panel', category: 'review' },
-  'dock.diffDetail': { label: 'Diff detail', category: 'review' },
-  'dock.reviewLoop': { label: 'Review loop', category: 'review' },
-  'dock.attention': { label: 'PRs drawer', category: 'review' },
+  'dock.diff': { label: 'Diff panel', category: 'review', dockLabel: 'diff' },
+  'dock.diffDetail': { label: 'Diff detail', category: 'review', dockLabel: 'detail' },
+  'dock.reviewLoop': { label: 'Review loop', category: 'review', dockLabel: 'loop' },
+  'dock.attention': { label: 'PRs drawer', category: 'review', dockLabel: 'PRs' },
   'session.refreshPRs': { label: 'Refresh PRs', category: 'review' },
 
   // App
@@ -91,4 +96,9 @@ export const SHORTCUT_META: Record<ShortcutId, ShortcutMeta> = {
 
 export function isProtectedShortcut(id: ShortcutId): boolean {
   return SHORTCUT_META[id].protected === true;
+}
+
+/** Terse text shown on a dock chip; falls back to the full editor label. */
+export function dockShortcutLabel(id: ShortcutId): string {
+  return SHORTCUT_META[id].dockLabel ?? SHORTCUT_META[id].label;
 }

--- a/app/src/shortcuts/resolver.test.ts
+++ b/app/src/shortcuts/resolver.test.ts
@@ -7,7 +7,7 @@ vi.mock('./platform', () => ({
   isAccelKeyPressed: (e: KeyboardEvent) => e.metaKey,
 }));
 
-import { SHORTCUTS } from './registry';
+import { SHORTCUTS, ShortcutId } from './registry';
 import {
   setShortcutOverrides,
   resolveBinding,
@@ -19,6 +19,7 @@ import {
   isRiskyBinding,
   parseKeybindingsConfig,
   serializeKeybindingsConfig,
+  DEFAULT_DOCK,
 } from './resolver';
 
 beforeEach(() => setShortcutOverrides({}));
@@ -153,7 +154,43 @@ describe('parseKeybindingsConfig', () => {
   });
 
   it('round-trips through serialize', () => {
-    const cfg = { version: 1 as const, overrides: { 'session.new': { key: 'm', meta: true } } };
+    const cfg = {
+      version: 1 as const,
+      overrides: { 'session.new': { key: 'm', meta: true } },
+      dock: { collapsed: true, items: ['dock.diff', 'session.toggleSidebar'] as ShortcutId[] },
+    };
     expect(parseKeybindingsConfig(serializeKeybindingsConfig(cfg))).toEqual(cfg);
+  });
+});
+
+describe('dock config', () => {
+  it('falls back to the default dock when absent or malformed', () => {
+    expect(parseKeybindingsConfig(undefined).dock).toEqual(DEFAULT_DOCK);
+    expect(parseKeybindingsConfig(JSON.stringify({ overrides: {} })).dock).toEqual(DEFAULT_DOCK);
+    expect(parseKeybindingsConfig(JSON.stringify({ dock: 'nope' })).dock).toEqual(DEFAULT_DOCK);
+    // items present but not an array -> default
+    expect(parseKeybindingsConfig(JSON.stringify({ dock: { items: 5 } })).dock).toEqual(DEFAULT_DOCK);
+  });
+
+  it('keeps known ids in order, drops unknown ids, and dedups', () => {
+    const raw = JSON.stringify({
+      dock: { collapsed: true, items: ['dock.diff', 'bogus.id', 'dock.diff', 'session.new'] },
+    });
+    expect(parseKeybindingsConfig(raw).dock).toEqual({
+      collapsed: true,
+      items: ['dock.diff', 'session.new'],
+    });
+  });
+
+  it('coerces collapsed to a boolean', () => {
+    const raw = JSON.stringify({ dock: { collapsed: 'yes', items: [] } });
+    expect(parseKeybindingsConfig(raw).dock.collapsed).toBe(false);
+  });
+
+  it('does not share the default dock array between parses (no cross-mutation)', () => {
+    const a = parseKeybindingsConfig(undefined).dock.items;
+    const b = parseKeybindingsConfig(undefined).dock.items;
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
   });
 });

--- a/app/src/shortcuts/resolver.ts
+++ b/app/src/shortcuts/resolver.ts
@@ -16,15 +16,44 @@ import {
 } from './registry';
 import { isMacLikePlatform } from './platform';
 
+export interface DockConfig {
+  /** When true the sidebar dock chips are hidden behind a "show dock" affordance. */
+  collapsed: boolean;
+  /** Ordered membership; each id renders one dock chip. */
+  items: ShortcutId[];
+}
+
 export interface KeybindingsConfig {
   version: 1;
   // Absent id  -> use default.
   // ShortcutDef -> rebind to this combo.
   // null        -> explicitly unbound.
   overrides: Partial<Record<ShortcutId, ShortcutDef | null>>;
+  dock: DockConfig;
 }
 
-export const EMPTY_KEYBINDINGS_CONFIG: KeybindingsConfig = { version: 1, overrides: {} };
+// Default dock membership, in render order. Mirrors the chips the sidebar showed
+// before the dock became config-driven (panel toggles, the common terminal
+// actions, then the sidebar toggle). Every entry must be a real ShortcutId.
+export const DEFAULT_DOCK_ITEMS: ShortcutId[] = [
+  'dock.diffDetail',
+  'dock.reviewLoop',
+  'dock.diff',
+  'dock.attention',
+  'terminal.splitVertical',
+  'terminal.splitHorizontal',
+  'session.newHorizontal',
+  'terminal.toggleZoom',
+  'session.toggleSidebar',
+];
+
+export const DEFAULT_DOCK: DockConfig = { collapsed: false, items: DEFAULT_DOCK_ITEMS };
+
+export const EMPTY_KEYBINDINGS_CONFIG: KeybindingsConfig = {
+  version: 1,
+  overrides: {},
+  dock: DEFAULT_DOCK,
+};
 
 export const KEYBINDINGS_SETTING_KEY = 'keybindings_config';
 
@@ -142,19 +171,49 @@ function sanitizeDef(value: unknown): ShortcutDef | null {
   return def;
 }
 
+/** A fresh empty config (own copy of the default dock so callers can't mutate it). */
+function emptyConfig(): KeybindingsConfig {
+  return { version: 1, overrides: {}, dock: defaultDock() };
+}
+
+function defaultDock(): DockConfig {
+  return { collapsed: false, items: [...DEFAULT_DOCK_ITEMS] };
+}
+
+/**
+ * Sanitize a persisted dock blob: keep only real, deduped ShortcutIds in order,
+ * coerce `collapsed` to a boolean. A missing/malformed dock falls back to the
+ * default so the sidebar always has a usable dock.
+ */
+function sanitizeDock(value: unknown): DockConfig {
+  if (!value || typeof value !== 'object') return defaultDock();
+  const v = value as Record<string, unknown>;
+  if (!Array.isArray(v.items)) return defaultDock();
+  const seen = new Set<string>();
+  const items: ShortcutId[] = [];
+  for (const id of v.items) {
+    if (typeof id !== 'string') continue;
+    if (!Object.prototype.hasOwnProperty.call(SHORTCUTS, id)) continue; // unknown id
+    if (seen.has(id)) continue; // dedup
+    seen.add(id);
+    items.push(id as ShortcutId);
+  }
+  return { collapsed: v.collapsed === true, items };
+}
+
 /**
  * Parse a persisted blob into a config, dropping anything unrecognized so a bad
  * value can never crash dispatch (the affected id just keeps its default).
  */
 export function parseKeybindingsConfig(raw: string | undefined | null): KeybindingsConfig {
-  if (!raw) return { version: 1, overrides: {} };
+  if (!raw) return emptyConfig();
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    return { version: 1, overrides: {} };
+    return emptyConfig();
   }
-  if (!parsed || typeof parsed !== 'object') return { version: 1, overrides: {} };
+  if (!parsed || typeof parsed !== 'object') return emptyConfig();
 
   const rawOverrides = (parsed as Record<string, unknown>).overrides;
   const overridesOut: Partial<Record<ShortcutId, ShortcutDef | null>> = {};
@@ -171,7 +230,11 @@ export function parseKeybindingsConfig(raw: string | undefined | null): Keybindi
     }
   }
 
-  return { version: 1, overrides: overridesOut };
+  return {
+    version: 1,
+    overrides: overridesOut,
+    dock: sanitizeDock((parsed as Record<string, unknown>).dock),
+  };
 }
 
 export function serializeKeybindingsConfig(config: KeybindingsConfig): string {

--- a/docs/plans/2026-06-13-configurable-shortcuts.md
+++ b/docs/plans/2026-06-13-configurable-shortcuts.md
@@ -142,11 +142,23 @@ PR 1 — Foundation + single-key rebinding + editor (chords/dock deferred) — D
   rebinds only on next natural re-render. PR 2's ID-driven dock fixes live reactivity.
 
 PR 2 — Config-driven collapsible dock + "show in dock"
-- [ ] ID-driven dock model in `App.tsx` + `Sidebar.tsx`; dedup by id; `dockActions` map
-- [ ] Default `dock.items` migrated from current hardcoded chips (mapped to ids)
-- [ ] Independent `dock.collapsed` + collapse toggle UI in the dock header
-- [ ] "show in dock" checkbox in editor -> `config.dock.items`; reorder support
-- [ ] Tests: dock rebuilds from config, reflects rebinds, collapse persists
+- [x] `KeybindingsConfig` gains `dock: { collapsed, items: ShortcutId[] }`; resolver parses/sanitizes
+      (drop unknown ids, dedup) with a `DEFAULT_DOCK` fallback
+- [x] `dockLabel?` added to `ShortcutMeta` (terse dock chip text, falls back to `label`)
+- [x] ID-driven dock model in `App.tsx` (`dockActions` map: `run?`/`isActive?`/`available?`) +
+      `Sidebar.tsx` renders `DockItem[]`; dedup by id; tokens resolve live (fixes PR1 reactivity note)
+- [x] Default `dock.items` migrated from current chips (panel toggles + split/zoom/session-h + sidebar)
+- [x] Independent `dock.collapsed` + chevron toggle in the sidebar dock header
+- [x] Editor: per-row pin (show in dock) + a "Dock" section with up/down reorder + remove
+- [x] `KeybindingsContext` dock mutations: `setInDock`, `moveDockItem`, `setDockCollapsed`, `isInDock`
+- [x] Tests: resolver dock parse/sanitize, context mutations persist, editor pin/reorder, Sidebar render
+
+Notes / refinements during implementation:
+- Dock chips use `dockLabel ?? label` so the dock stays terse while any shortcut is dock-eligible.
+- The combined `⌘⌥←↑→↓ pane` hint is dropped from the *default* dock — it can't be one id. The four
+  focus shortcuts remain dock-eligible individually. Pane focus itself is unchanged.
+- `Restore Defaults` resets the whole config (overrides + dock), not just keybindings.
+- Reorder uses up/down buttons (not drag-drop): accessible, testable in happy-dom.
 
 PR 3 — Leader-key chords (depth 2)
 - [ ] Extend `Binding`/resolver/validation for `{leader, then}`; enforce leader exclusivity


### PR DESCRIPTION
PR 2 of the configurable-shortcuts plan (`docs/plans/2026-06-13-configurable-shortcuts.md`). Builds on the keybindings foundation merged in #310.

## What this does

The sidebar dock is now **rebuilt from the keybindings config** instead of hardcoded chip strings. The dock becomes a user-curated, ordered list of shortcut IDs.

- **Config-driven** — `KeybindingsConfig` gains `dock: { collapsed, items: ShortcutId[] }`. Chips resolve their keys/labels live, so rebinds reflect instantly (fixes the PR1 reactivity caveat), dedup by id, and hide when a shortcut is unbound or unavailable in the current context (e.g. terminal actions with no active session).
- **Collapsible** — an independent collapse toggle in the dock header (persisted via `dock.collapsed`), separate from the sidebar's own collapse.
- **Editor: show in dock + reorder** — a ☆ pin on every shortcut row adds/removes it from the dock, and a new **Dock** section lists current items with up/down reorder and remove. `Restore Defaults` now resets the dock too.
- **Clickable chips** — the diff, review-loop, and PRs dock chips now trigger their panels; the rest stay informational. (Previously the footer chips were static text.)
- Dock chips use a terse `dockLabel` (falling back to the full editor label), so any shortcut is dock-eligible while the defaults stay compact.

Resolver tolerates any persisted blob: unknown ids dropped, items deduped, `collapsed` coerced, malformed dock falls back to `DEFAULT_DOCK`. No protocol bump (reuses the existing `keybindings_config` settings key).

### Note on the default dock
The old combined `⌘⌥←↑→↓ pane` hint is dropped from the *default* dock — it can't be expressed as a single id. Pane-focus shortcuts are unchanged and remain individually dock-eligible.

## Tests
- `resolver.test.ts` — dock parse/sanitize (unknown-id drop, dedup, collapsed coercion, no shared default array)
- `KeybindingsContext.test.tsx` (new) — add/reorder/collapse persist; no write when unchanged; dock preserved across keybinding edits
- `ShortcutEditorModal.test.tsx` — pin from row star, reorder, remove
- `Sidebar.test.tsx` — config-driven render, active state, clickable actions, collapse toggle

Full frontend suite green (849 tests), typecheck clean.

## Manual verification (dev app)
Verified end to end in `attn-dev`: dock renders config-driven with styled keys; collapse hides chips behind a show-toggle; editor Dock section reorders/removes; per-row ☆/★ pins reflect membership; full persistence loop (set_setting → parse → render).