### PR TITLE
fix(state): rollup unknown sessions and stop shells showing permanent green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **A session running work in the background no longer flips to a confusing "unknown" state.** When Claude Code hands off to a background workflow or background shell command and pauses its turn, the session now stays shown as working until the background work finishes and the turn resumes — instead of briefly being mis-detected as "unknown" because it paused before its transcript was written.
+- **A workspace's status dot now matches the sessions inside it.** A workspace whose only session was in the "unknown" state used to show a settled gray dot that disagreed with the session's own indicator; the unknown state now rolls up to the workspace so the two agree. The workspace dot also stays correct right after the app reopens — restored sessions no longer leave the workspace showing a stale status from before the restart.
+- **Shell sessions no longer show a permanent green "working" dot.** A plain terminal isn't running an agent turn, so it now starts (and stays) idle instead of appearing busy forever until you close it.
 
 ## [2026-06-12]
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -20,7 +20,6 @@ import type {
   ReviewLoopInteraction as GeneratedReviewLoopInteraction,
   WarningElement as GeneratedWarning,
   WorkspaceContext as GeneratedWorkspaceContext,
-  SessionState,
   PRRole,
   HeatState,
 } from '../types/generated';
@@ -90,7 +89,7 @@ export interface PathInspection {
 export type { DaemonEndpointProfile };
 
 // Re-export enums and useful types
-export { SessionState, PRRole, HeatState };
+export { PRRole, HeatState };
 
 // Extended WebSocketEvent with action result fields (generated allows extra properties)
 type WebSocketEvent = GeneratedWebSocketEvent & {
@@ -169,7 +168,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '104';
+export const PROTOCOL_VERSION = '105';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -459,7 +459,7 @@ export interface SessionElement {
     main_repo?:                   string;
     needs_review_after_long_run?: boolean;
     recoverable?:                 boolean;
-    state:                        SessionState;
+    state:                        WorkspaceStatus;
     state_since:                  string;
     state_updated_at:             string;
     todos?:                       string[];
@@ -467,7 +467,7 @@ export interface SessionElement {
     [property: string]: any;
 }
 
-export enum SessionState {
+export enum WorkspaceStatus {
     Idle = "idle",
     Launching = "launching",
     PendingApproval = "pending_approval",
@@ -1687,15 +1687,6 @@ export enum WorkspaceLayoutPaneStatus {
     Spawning = "spawning",
 }
 
-export enum WorkspaceStatus {
-    Idle = "idle",
-    Launching = "launching",
-    PendingApproval = "pending_approval",
-    Scheduled = "scheduled",
-    WaitingInput = "waiting_input",
-    Working = "working",
-}
-
 export interface InjectTestPRMessage {
     cmd: InjectTestPRMessageCmd;
     pr:  PRElement;
@@ -2748,7 +2739,7 @@ export interface Session {
     main_repo?:                   string;
     needs_review_after_long_run?: boolean;
     recoverable?:                 boolean;
-    state:                        SessionState;
+    state:                        WorkspaceStatus;
     state_since:                  string;
     state_updated_at:             string;
     todos?:                       string[];
@@ -5085,12 +5076,12 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionSelectedMessage")), null, 2);
     }
 
-    public static toSessionState(json: string): SessionState {
-        return cast(JSON.parse(json), r("SessionState"));
+    public static toSessionState(json: string): WorkspaceStatus {
+        return cast(JSON.parse(json), r("WorkspaceStatus"));
     }
 
-    public static sessionStateToJson(value: SessionState): string {
-        return JSON.stringify(uncast(value, r("SessionState")), null, 2);
+    public static sessionStateToJson(value: WorkspaceStatus): string {
+        return JSON.stringify(uncast(value, r("WorkspaceStatus")), null, 2);
     }
 
     public static toSessionStateChangedMessage(json: string): SessionStateChangedMessage {
@@ -5974,7 +5965,7 @@ const typeMap: any = {
         { json: "main_repo", js: "main_repo", typ: u(undefined, "") },
         { json: "needs_review_after_long_run", js: "needs_review_after_long_run", typ: u(undefined, true) },
         { json: "recoverable", js: "recoverable", typ: u(undefined, true) },
-        { json: "state", js: "state", typ: r("SessionState") },
+        { json: "state", js: "state", typ: r("WorkspaceStatus") },
         { json: "state_since", js: "state_since", typ: "" },
         { json: "state_updated_at", js: "state_updated_at", typ: "" },
         { json: "todos", js: "todos", typ: u(undefined, a("")) },
@@ -7326,7 +7317,7 @@ const typeMap: any = {
         { json: "main_repo", js: "main_repo", typ: u(undefined, "") },
         { json: "needs_review_after_long_run", js: "needs_review_after_long_run", typ: u(undefined, true) },
         { json: "recoverable", js: "recoverable", typ: u(undefined, true) },
-        { json: "state", js: "state", typ: r("SessionState") },
+        { json: "state", js: "state", typ: r("WorkspaceStatus") },
         { json: "state_since", js: "state_since", typ: "" },
         { json: "state_updated_at", js: "state_updated_at", typ: "" },
         { json: "todos", js: "todos", typ: u(undefined, a("")) },
@@ -7878,7 +7869,7 @@ const typeMap: any = {
     "BranchChangedMessageEvent": [
         "branch_changed",
     ],
-    "SessionState": [
+    "WorkspaceStatus": [
         "idle",
         "launching",
         "pending_approval",
@@ -8106,14 +8097,6 @@ const typeMap: any = {
         "failed",
         "ready",
         "spawning",
-    ],
-    "WorkspaceStatus": [
-        "idle",
-        "launching",
-        "pending_approval",
-        "scheduled",
-        "waiting_input",
-        "working",
     ],
     "InjectTestPRMessageCmd": [
         "inject_test_pr",

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -772,6 +772,9 @@ func (d *Daemon) performStartupPTYRecovery(recoveryStartedAt time.Time) {
 	if _, ok := d.ptyBackend.(ptybackend.RecoverableRuntime); ok {
 		d.reconcileStartupWorkerSessions(recoveryReport, recoverErr, recoveryStartedAt)
 		d.reconcileWorkspaceLayoutsWithPTYBackend(context.Background())
+		// Recovery rewrote session states in the store; refresh the cached
+		// workspace rollups so InitialState matches.
+		d.reseedWorkspaceStatuses()
 		return
 	}
 
@@ -784,6 +787,9 @@ func (d *Daemon) performStartupPTYRecovery(recoveryStartedAt time.Time) {
 		)
 	}
 	d.reconcileWorkspaceLayoutsWithPTYBackend(context.Background())
+	// Pruning flipped recovered sessions to idle in the store; refresh the
+	// cached workspace rollups so InitialState matches.
+	d.reseedWorkspaceStatuses()
 }
 
 func (d *Daemon) recoverPTYBackend(timeout time.Duration) (ptybackend.RecoveryReport, error) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -423,6 +423,59 @@ func TestDaemon_PrunesSessionsWithoutLivePTYOnStart(t *testing.T) {
 	}
 }
 
+// Startup recovery rewrites session states directly in the store (prune flips a
+// recoverable session to idle) without going through the per-session broadcast
+// that normally refreshes the workspace rollup. reseedWorkspaceStatuses, run at
+// the end of recovery, must repair the cached rollup so the first InitialState
+// snapshot shows a workspace dot consistent with its recovered sessions.
+func TestDaemon_ReseedWorkspaceStatusesAfterRecovery(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "reseed.sock"))
+	d.ptyBackend = nil // no live PTYs, so prune treats the session as missing
+	d.workspaces = newWorkspaceRegistry()
+
+	workspaceID := "ws-reseed"
+	sessionID := "sess-reseed"
+	cwd := t.TempDir()
+
+	d.store.AddWorkspace(&protocol.Workspace{ID: workspaceID, Title: "Reseed", Directory: cwd})
+	d.workspaces.register(workspaceID, "Reseed", cwd, "a0", false)
+	nowStr := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID:             sessionID,
+		Label:          "claude",
+		Agent:          protocol.SessionAgentClaude, // recoverable: prune keeps it
+		Directory:      cwd,
+		State:          protocol.SessionStateWorking,
+		StateSince:     nowStr,
+		StateUpdatedAt: nowStr,
+		LastSeen:       nowStr,
+		WorkspaceID:    workspaceID,
+	})
+	d.workspaces.associateSession(sessionID, workspaceID, "claude")
+
+	// Seed the cached rollup the way loadWorkspacesFromStore does at startup.
+	d.recomputeWorkspaceStatus(workspaceID)
+	if ws, _ := d.workspaces.snapshot(workspaceID); ws.Status != protocol.WorkspaceStatusWorking {
+		t.Fatalf("precondition: seeded rollup = %q, want working", ws.Status)
+	}
+
+	// Recovery flips the missing-PTY session to idle in the store, but does NOT
+	// recompute the rollup — so the cached status is now stale.
+	d.pruneSessionsWithoutPTY()
+	if got := d.store.Get(sessionID); got == nil || got.State != protocol.SessionStateIdle {
+		t.Fatalf("prune should keep recoverable session and mark it idle, got %+v", got)
+	}
+	if ws, _ := d.workspaces.snapshot(workspaceID); ws.Status != protocol.WorkspaceStatusWorking {
+		t.Fatalf("rollup should still be stale-working before reseed, got %q", ws.Status)
+	}
+
+	// The reseed performStartupPTYRecovery runs after pruning repairs it.
+	d.reseedWorkspaceStatuses()
+	if ws, _ := d.workspaces.snapshot(workspaceID); ws.Status != protocol.WorkspaceStatusIdle {
+		t.Fatalf("rollup after reseed = %q, want idle", ws.Status)
+	}
+}
+
 func TestDaemon_Start_SelectsWorkerBackendWhenRequested(t *testing.T) {
 	t.Setenv("ATTN_PTY_BACKEND", "worker")
 	t.Setenv("ATTN_PTY_SKIP_STARTUP_PROBE", "1")

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -261,20 +261,26 @@ func snapshotEntry(e *workspaceEntry) protocol.Workspace {
 
 // rollupWorkspaceStatus returns the workspace status that summarizes the
 // supplied session states. Higher-priority states win:
-// working > waiting_input > pending_approval > scheduled > idle > launching.
+// working > waiting_input > pending_approval > unknown > scheduled > idle > launching.
+// `unknown` sits just below the explicit attention states: a session whose
+// state could not be determined still wants a look, so it must out-prioritize
+// the quiet `scheduled`/`idle` peers and surface at the workspace level (at the
+// session level `unknown` is already an attention state — see
+// isAttentionSessionState — so a single-session workspace whose only session is
+// `unknown` would otherwise show an `idle` dot that disagrees with its session).
 // `scheduled` sits above `idle` because a parked-on-schedule session will
 // auto-resume — more informative than a settled idle peer — but below the
 // attention states since it needs no steering. `launching` sits below `idle`
 // on purpose — it carries less information than any settled state, so as soon
 // as one session reports a real state, that one wins over a peer that's still
-// booting. There's no `unknown` workspace status: an empty slice or sessions
-// all in `unknown` fall through to `idle`, since a workspace always has a
-// directory and a registry entry, so the rollup always has a meaningful answer.
+// booting. Only a truly empty slice (no member sessions) falls through to the
+// `idle` default.
 func rollupWorkspaceStatus(sessionStates []protocol.SessionState) protocol.WorkspaceStatus {
 	priority := map[protocol.SessionState]int{
-		protocol.SessionStateWorking:         6,
-		protocol.SessionStateWaitingInput:    5,
-		protocol.SessionStatePendingApproval: 4,
+		protocol.SessionStateWorking:         7,
+		protocol.SessionStateWaitingInput:    6,
+		protocol.SessionStatePendingApproval: 5,
+		protocol.SessionStateUnknown:         4,
 		protocol.SessionStateScheduled:       3,
 		protocol.SessionStateIdle:            2,
 		protocol.SessionStateLaunching:       1,
@@ -284,6 +290,7 @@ func rollupWorkspaceStatus(sessionStates []protocol.SessionState) protocol.Works
 		protocol.SessionStateWorking:         protocol.WorkspaceStatusWorking,
 		protocol.SessionStateWaitingInput:    protocol.WorkspaceStatusWaitingInput,
 		protocol.SessionStatePendingApproval: protocol.WorkspaceStatusPendingApproval,
+		protocol.SessionStateUnknown:         protocol.WorkspaceStatusUnknown,
 		protocol.SessionStateScheduled:       protocol.WorkspaceStatusScheduled,
 		protocol.SessionStateIdle:            protocol.WorkspaceStatusIdle,
 	}
@@ -292,8 +299,8 @@ func rollupWorkspaceStatus(sessionStates []protocol.SessionState) protocol.Works
 	for _, s := range sessionStates {
 		p, ok := priority[s]
 		if !ok {
-			// Unrecognised state (e.g. SessionStateUnknown) — skip; we
-			// fall back to `idle` if nothing scores higher.
+			// Unrecognised state — skip; we fall back to `idle` if nothing
+			// scores higher.
 			continue
 		}
 		if p > bestPriority {
@@ -320,6 +327,25 @@ func (d *Daemon) recomputeWorkspaceStatus(workspaceID string) (protocol.Workspac
 	}
 	status := rollupWorkspaceStatus(states)
 	return d.workspaces.applyStatus(workspaceID, status)
+}
+
+// reseedWorkspaceStatuses recomputes every workspace's cached rollup from the
+// current store session states WITHOUT broadcasting. Startup recovery mutates
+// session states directly in the store (pruneSessionsWithoutPTY,
+// reconcileSessionsWithWorkerBackend) without going through the normal
+// per-session broadcast path, so the cached rollup seeded by
+// loadWorkspacesFromStore goes stale before the recovery barrier flushes
+// InitialState. Reseeding here keeps the workspace dot consistent with the
+// recovered session states in that first snapshot. No broadcast is needed:
+// clients are still parked behind the recovery barrier and read the corrected
+// status from InitialState. Mirrors the seed loop in loadWorkspacesFromStore.
+func (d *Daemon) reseedWorkspaceStatuses() {
+	if d.workspaces == nil {
+		return
+	}
+	for _, ws := range d.workspaces.list() {
+		d.recomputeWorkspaceStatus(ws.ID)
+	}
 }
 
 // recomputeAndBroadcastWorkspaceForSession is a convenience used after a

--- a/internal/daemon/workspace_session_protocol_test.go
+++ b/internal/daemon/workspace_session_protocol_test.go
@@ -76,6 +76,63 @@ func TestWorkspaceSessionProtocolLifecycleMatchesAppOrder(t *testing.T) {
 	}
 }
 
+func TestWorkspaceSessionProtocolShellSpawnsIdleNotWorking(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &fakeSpawnBackend{}
+	client := newWorkspaceProtocolTestClient()
+	workspaceID := "workspace-shell-idle"
+	sessionID := "session-shell-idle"
+	paneID := "pane-session-shell-idle"
+	cwd := t.TempDir()
+
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        workspaceID,
+		Title:     "Shell Idle",
+		Directory: cwd,
+	})
+	d.handleWorkspaceLayoutAddSessionPane(client, &protocol.WorkspaceLayoutAddSessionPaneMessage{
+		Cmd:         protocol.CmdWorkspaceLayoutAddSessionPane,
+		WorkspaceID: workspaceID,
+		PaneID:      protocol.Ptr(paneID),
+		SessionID:   sessionID,
+		Title:       protocol.Ptr("shell"),
+	})
+	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutAddSessionPane, workspaceID, paneID, true)
+
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:         protocol.CmdSpawnSession,
+		ID:          sessionID,
+		Label:       protocol.Ptr("shell"),
+		Cwd:         cwd,
+		Agent:       protocol.AgentShellValue,
+		WorkspaceID: workspaceID,
+		Cols:        80,
+		Rows:        24,
+	})
+	expectSpawnResult(t, client, sessionID, true)
+
+	// A shell has no agent lifecycle, no Stop hook, and no state detector, so it
+	// would be stuck in whatever state it spawns with. It must spawn `idle`, not
+	// `working` — otherwise every shell shows a permanent green dot it can never
+	// leave until the process exits.
+	session := d.store.Get(sessionID)
+	if session == nil {
+		t.Fatalf("session %s was not registered", sessionID)
+	}
+	if session.State != protocol.SessionStateIdle {
+		t.Fatalf("shell session state = %q, want %q", session.State, protocol.SessionStateIdle)
+	}
+	// The workspace dot rolls up from its only session, so it must agree: idle.
+	ws, ok := d.workspaces.snapshot(workspaceID)
+	if !ok {
+		t.Fatalf("workspace %s missing from registry", workspaceID)
+	}
+	if ws.Status != protocol.WorkspaceStatusIdle {
+		t.Fatalf("workspace rollup status = %q, want %q", ws.Status, protocol.WorkspaceStatusIdle)
+	}
+}
+
 func TestWorkspaceLayoutClosePaneKeepsLayoutUntilSessionUnregistered(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	client := newWorkspaceProtocolTestClient()

--- a/internal/daemon/workspace_test.go
+++ b/internal/daemon/workspace_test.go
@@ -74,14 +74,34 @@ func TestRollupWorkspaceStatus_PriorityOrdering(t *testing.T) {
 			want:   protocol.WorkspaceStatusIdle,
 		},
 		{
-			name:   "launching beats unrecognised session_state_unknown",
+			name:   "unknown beats launching",
 			states: []protocol.SessionState{protocol.SessionStateUnknown, protocol.SessionStateLaunching},
-			want:   protocol.WorkspaceStatusLaunching,
+			want:   protocol.WorkspaceStatusUnknown,
 		},
 		{
-			name:   "all session_state_unknown yields idle",
+			name:   "unknown beats idle",
+			states: []protocol.SessionState{protocol.SessionStateIdle, protocol.SessionStateUnknown},
+			want:   protocol.WorkspaceStatusUnknown,
+		},
+		{
+			name:   "unknown beats scheduled",
+			states: []protocol.SessionState{protocol.SessionStateScheduled, protocol.SessionStateUnknown},
+			want:   protocol.WorkspaceStatusUnknown,
+		},
+		{
+			name:   "pending_approval beats unknown",
+			states: []protocol.SessionState{protocol.SessionStateUnknown, protocol.SessionStatePendingApproval},
+			want:   protocol.WorkspaceStatusPendingApproval,
+		},
+		{
+			name:   "working beats unknown",
+			states: []protocol.SessionState{protocol.SessionStateUnknown, protocol.SessionStateWorking},
+			want:   protocol.WorkspaceStatusWorking,
+		},
+		{
+			name:   "all session_state_unknown yields unknown",
 			states: []protocol.SessionState{protocol.SessionStateUnknown, protocol.SessionStateUnknown},
-			want:   protocol.WorkspaceStatusIdle,
+			want:   protocol.WorkspaceStatusUnknown,
 		},
 		{
 			name:   "all idle yields idle",

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -595,7 +595,13 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		nowStr := string(protocol.TimestampNow())
 		initialState := protocol.SessionStateLaunching
 		if isShell {
-			initialState = protocol.SessionStateWorking
+			// A shell is a plain user-driven PTY: it has no agent turn
+			// lifecycle, no Stop hook, and (deliberately) no state detector, so
+			// nothing ever transitions it once spawned. Seed it `idle` rather
+			// than `working` — a shell sitting at a prompt is not "working", and
+			// the old `working` seed made every shell (and its workspace) show a
+			// permanent green dot it could never leave until the process exited.
+			initialState = protocol.SessionStateIdle
 		}
 		initialStateSince := nowStr
 		initialStateUpdatedAt := nowStr

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "104"
+const ProtocolVersion = "105"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -3954,6 +3954,7 @@ const WorkspaceStatusIdle WorkspaceStatus = "idle"
 const WorkspaceStatusLaunching WorkspaceStatus = "launching"
 const WorkspaceStatusPendingApproval WorkspaceStatus = "pending_approval"
 const WorkspaceStatusScheduled WorkspaceStatus = "scheduled"
+const WorkspaceStatusUnknown WorkspaceStatus = "unknown"
 const WorkspaceStatusWaitingInput WorkspaceStatus = "waiting_input"
 const WorkspaceStatusWorking WorkspaceStatus = "working"
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -25,19 +25,24 @@ enum PRRole {
 }
 
 // WorkspaceStatus is the rolled-up status of all sessions in a workspace.
-// Priority (highest first): working > waiting_input > pending_approval > scheduled > idle > launching.
+// Priority (highest first): working > waiting_input > pending_approval > unknown > scheduled > idle > launching.
+// `unknown` sits just below the explicit attention states: a session whose
+// state could not be determined still wants a look, so it out-prioritizes the
+// quiet `scheduled`/`idle` peers — but a clear "needs steering" signal wins.
+// (At the session level `unknown` is already an attention state, so the
+// workspace dot must be able to surface it rather than masquerading as idle.)
 // `scheduled` sits above `idle` because a parked-on-schedule session will
 // auto-resume and carries more information than a settled idle peer, but below
 // the attention states since it needs no steering. `launching` sits below
 // `idle` because it carries less information — any session in a settled state
-// out-prioritizes a peer that's still booting. No `unknown` value: a workspace
-// always has a directory and a registry entry, so the rollup always has a
-// meaningful answer (empty/all-unknown member sessions roll up to `idle`).
+// out-prioritizes a peer that's still booting. A truly empty workspace (no
+// member sessions) rolls up to `idle`.
 enum WorkspaceStatus {
   launching,
   working,
   waiting_input,
   pending_approval,
+  status_unknown: "unknown",
   scheduled,
   idle,
 }


### PR DESCRIPTION
## Why

Two reported symptoms, both real and independent:
- A workspace whose **single session** showed a different state than the workspace dot.
- **Shell sessions all showed a green ("working") dot**, regardless of what they were doing.

Diagnosed via a multi-agent audit (13 findings confirmed with state traces, 5 refuted). Root causes below.

## What

**1. Workspace rollup couldn't represent `unknown`.**
`rollupWorkspaceStatus` had no entry for `SessionStateUnknown`, so an unknown session was skipped and the workspace fell through to `idle`. A single-session workspace then showed a gray dot while its session showed purple. Added `WorkspaceStatus.unknown` (**proto 104→105**) and ranked it just below the steering states (`working > waiting_input > pending_approval > unknown > scheduled > idle > launching`) so it surfaces. The collapsed-rail mini-badge's previously-dead `status === 'unknown'` branch is now reachable.

**2. Stale workspace dot after a daemon restart.**
Startup recovery (`pruneSessionsWithoutPTY` / `reconcileSessionsWithWorkerBackend`) rewrites session states directly in the store without the per-session broadcast that refreshes the cached rollup, so the first `InitialState` after a respawn carried a pre-crash workspace status. Added `reseedWorkspaceStatuses()`, run at the end of both recovery branches (no broadcast — clients read it from `InitialState`).

**3. Shells showed permanent green.**
A shell was seeded `working` at spawn and never transitions while alive (no agent turn lifecycle, no Stop hook, no state detector). Now seeded `idle` — idle while alive, idle on exit. No classifier/detector added.

### Note
Adding `unknown` made `WorkspaceStatus` value-identical to `SessionState`, so quicktype merges the two enums in `generated.ts`; the **dead** `SessionState` re-export in `useDaemonSocket.ts` is removed (the frontend types session state via the local `UISessionState`). Type-safe.

## Tests
- `rollupWorkspaceStatus` unknown-priority cases (unknown beats idle/scheduled/launching; loses to pending/working; all-unknown → unknown).
- `TestWorkspaceSessionProtocolShellSpawnsIdleNotWorking` — spawned shell stores `idle` and its workspace rolls up `idle`.
- `TestDaemon_ReseedWorkspaceStatusesAfterRecovery` — stale cached rollup is repaired after prune.
- Go `daemon`/`protocol`/`store` green; frontend `tsc` + Sidebar/state tests green.

## Manual verification
Built the isolated dev app (proto 105, clean handshake) and spawned a fresh shell via the automation bridge → reports `"state": "idle"` (was `working` before).

## Not included (deliberate)
The two-event (`session_state_changed` / `workspace_state_changed`) drop hazard on a slow client. Every fix variant carries a cost the others don't (another protocol change, or a TS copy of the rollup that can drift from the Go authority) and it self-heals on the next state change/reconnect. Left out pending evidence it actually bites.