### PR TITLE
feat(notebook): dreaming harvest + read-only inspect (dreaming PR-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-14]
+
+### Added
+- **Preview what the Notebook's nightly memory pass would keep.** A new `attn notebook dream` command shows the recurring, durable facts attn could distill into lasting memory — gathered from your journals, your workspaces' decisions and constraints, and finished chief-of-staff dispatches, with the ones that recur across several places ranked first. `attn notebook dream status` is a quick summary; `attn notebook dream --dry-run` lists the candidates. It's read-only — nothing is written yet — so you can see the raw material before the automatic consolidation pass that acts on it arrives in an upcoming release.
+
 ## [2026-06-13]
 
 ### Added

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '107';
+export const PROTOCOL_VERSION = '108';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListDispatchMessagesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookAppendJournalMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookInitMessage, NotebookInitResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, ReportDispatchMessage, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListDispatchMessagesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookAppendJournalMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookDreamCandidate, NotebookDreamRunMessage, NotebookDreamRunResult, NotebookDreamSourceCount, NotebookDreamStatusMessage, NotebookDreamStatusResult, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookInitMessage, NotebookInitResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, ReportDispatchMessage, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const acknowledgeDispatchMessage = Convert.toAcknowledgeDispatchMessage(json);
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
@@ -120,6 +120,12 @@
 //   const notebookBacklinksMessage = Convert.toNotebookBacklinksMessage(json);
 //   const notebookBacklinksResultMessage = Convert.toNotebookBacklinksResultMessage(json);
 //   const notebookChangedMessage = Convert.toNotebookChangedMessage(json);
+//   const notebookDreamCandidate = Convert.toNotebookDreamCandidate(json);
+//   const notebookDreamRunMessage = Convert.toNotebookDreamRunMessage(json);
+//   const notebookDreamRunResult = Convert.toNotebookDreamRunResult(json);
+//   const notebookDreamSourceCount = Convert.toNotebookDreamSourceCount(json);
+//   const notebookDreamStatusMessage = Convert.toNotebookDreamStatusMessage(json);
+//   const notebookDreamStatusResult = Convert.toNotebookDreamStatusResult(json);
 //   const notebookEntry = Convert.toNotebookEntry(json);
 //   const notebookGuideMessage = Convert.toNotebookGuideMessage(json);
 //   const notebookGuideResult = Convert.toNotebookGuideResult(json);
@@ -2006,6 +2012,81 @@ export enum NotebookChangedMessageEvent {
     NotebookChanged = "notebook_changed",
 }
 
+export interface NotebookDreamCandidate {
+    contexts:    string[];
+    first_seen?: string;
+    last_seen?:  string;
+    occurrences: number;
+    signal_key:  string;
+    snippet:     string;
+    source:      string;
+    sources:     string[];
+    title?:      string;
+    [property: string]: any;
+}
+
+export interface NotebookDreamRunMessage {
+    apply?: boolean;
+    cmd:    NotebookDreamRunMessageCmd;
+    [property: string]: any;
+}
+
+export enum NotebookDreamRunMessageCmd {
+    NotebookDreamRun = "notebook_dream_run",
+}
+
+export interface NotebookDreamRunResult {
+    applied:             boolean;
+    candidate_count:     number;
+    candidates:          CandidateElement[];
+    multi_context_count: number;
+    source_counts:       SourceCountElement[];
+    [property: string]: any;
+}
+
+export interface CandidateElement {
+    contexts:    string[];
+    first_seen?: string;
+    last_seen?:  string;
+    occurrences: number;
+    signal_key:  string;
+    snippet:     string;
+    source:      string;
+    sources:     string[];
+    title?:      string;
+    [property: string]: any;
+}
+
+export interface SourceCountElement {
+    count:  number;
+    source: string;
+    [property: string]: any;
+}
+
+export interface NotebookDreamSourceCount {
+    count:  number;
+    source: string;
+    [property: string]: any;
+}
+
+export interface NotebookDreamStatusMessage {
+    cmd: NotebookDreamStatusMessageCmd;
+    [property: string]: any;
+}
+
+export enum NotebookDreamStatusMessageCmd {
+    NotebookDreamStatus = "notebook_dream_status",
+}
+
+export interface NotebookDreamStatusResult {
+    candidate_count:     number;
+    enabled:             boolean;
+    multi_context_count: number;
+    source_counts:       SourceCountElement[];
+    top:                 CandidateElement[];
+    [property: string]: any;
+}
+
 export interface NotebookEntry {
     kind?:    string;
     path:     string;
@@ -2691,6 +2772,8 @@ export interface Response {
     dispatch_message?:                     DispatchMessageObject;
     dispatch_messages?:                    DispatchMessageObject[];
     error?:                                string;
+    notebook_dream_run?:                   NotebookDreamRun;
+    notebook_dream_status?:                NotebookDreamStatus;
     notebook_entries?:                     NotebookEntryElement[];
     notebook_guide?:                       NotebookGuide;
     notebook_init?:                        NotebookInit;
@@ -2717,6 +2800,24 @@ export interface DispatchMessageObject {
     read_at?:          string;
     sender_session_id: string;
     target_session_id: string;
+    [property: string]: any;
+}
+
+export interface NotebookDreamRun {
+    applied:             boolean;
+    candidate_count:     number;
+    candidates:          CandidateElement[];
+    multi_context_count: number;
+    source_counts:       SourceCountElement[];
+    [property: string]: any;
+}
+
+export interface NotebookDreamStatus {
+    candidate_count:     number;
+    enabled:             boolean;
+    multi_context_count: number;
+    source_counts:       SourceCountElement[];
+    top:                 CandidateElement[];
     [property: string]: any;
 }
 
@@ -4874,6 +4975,54 @@ export class Convert {
 
     public static notebookChangedMessageToJson(value: NotebookChangedMessage): string {
         return JSON.stringify(uncast(value, r("NotebookChangedMessage")), null, 2);
+    }
+
+    public static toNotebookDreamCandidate(json: string): NotebookDreamCandidate {
+        return cast(JSON.parse(json), r("NotebookDreamCandidate"));
+    }
+
+    public static notebookDreamCandidateToJson(value: NotebookDreamCandidate): string {
+        return JSON.stringify(uncast(value, r("NotebookDreamCandidate")), null, 2);
+    }
+
+    public static toNotebookDreamRunMessage(json: string): NotebookDreamRunMessage {
+        return cast(JSON.parse(json), r("NotebookDreamRunMessage"));
+    }
+
+    public static notebookDreamRunMessageToJson(value: NotebookDreamRunMessage): string {
+        return JSON.stringify(uncast(value, r("NotebookDreamRunMessage")), null, 2);
+    }
+
+    public static toNotebookDreamRunResult(json: string): NotebookDreamRunResult {
+        return cast(JSON.parse(json), r("NotebookDreamRunResult"));
+    }
+
+    public static notebookDreamRunResultToJson(value: NotebookDreamRunResult): string {
+        return JSON.stringify(uncast(value, r("NotebookDreamRunResult")), null, 2);
+    }
+
+    public static toNotebookDreamSourceCount(json: string): NotebookDreamSourceCount {
+        return cast(JSON.parse(json), r("NotebookDreamSourceCount"));
+    }
+
+    public static notebookDreamSourceCountToJson(value: NotebookDreamSourceCount): string {
+        return JSON.stringify(uncast(value, r("NotebookDreamSourceCount")), null, 2);
+    }
+
+    public static toNotebookDreamStatusMessage(json: string): NotebookDreamStatusMessage {
+        return cast(JSON.parse(json), r("NotebookDreamStatusMessage"));
+    }
+
+    public static notebookDreamStatusMessageToJson(value: NotebookDreamStatusMessage): string {
+        return JSON.stringify(uncast(value, r("NotebookDreamStatusMessage")), null, 2);
+    }
+
+    public static toNotebookDreamStatusResult(json: string): NotebookDreamStatusResult {
+        return cast(JSON.parse(json), r("NotebookDreamStatusResult"));
+    }
+
+    public static notebookDreamStatusResultToJson(value: NotebookDreamStatusResult): string {
+        return JSON.stringify(uncast(value, r("NotebookDreamStatusResult")), null, 2);
     }
 
     public static toNotebookEntry(json: string): NotebookEntry {
@@ -7240,6 +7389,57 @@ const typeMap: any = {
         { json: "origin", js: "origin", typ: "" },
         { json: "paths", js: "paths", typ: a("") },
     ], "any"),
+    "NotebookDreamCandidate": o([
+        { json: "contexts", js: "contexts", typ: a("") },
+        { json: "first_seen", js: "first_seen", typ: u(undefined, "") },
+        { json: "last_seen", js: "last_seen", typ: u(undefined, "") },
+        { json: "occurrences", js: "occurrences", typ: 0 },
+        { json: "signal_key", js: "signal_key", typ: "" },
+        { json: "snippet", js: "snippet", typ: "" },
+        { json: "source", js: "source", typ: "" },
+        { json: "sources", js: "sources", typ: a("") },
+        { json: "title", js: "title", typ: u(undefined, "") },
+    ], "any"),
+    "NotebookDreamRunMessage": o([
+        { json: "apply", js: "apply", typ: u(undefined, true) },
+        { json: "cmd", js: "cmd", typ: r("NotebookDreamRunMessageCmd") },
+    ], "any"),
+    "NotebookDreamRunResult": o([
+        { json: "applied", js: "applied", typ: true },
+        { json: "candidate_count", js: "candidate_count", typ: 0 },
+        { json: "candidates", js: "candidates", typ: a(r("CandidateElement")) },
+        { json: "multi_context_count", js: "multi_context_count", typ: 0 },
+        { json: "source_counts", js: "source_counts", typ: a(r("SourceCountElement")) },
+    ], "any"),
+    "CandidateElement": o([
+        { json: "contexts", js: "contexts", typ: a("") },
+        { json: "first_seen", js: "first_seen", typ: u(undefined, "") },
+        { json: "last_seen", js: "last_seen", typ: u(undefined, "") },
+        { json: "occurrences", js: "occurrences", typ: 0 },
+        { json: "signal_key", js: "signal_key", typ: "" },
+        { json: "snippet", js: "snippet", typ: "" },
+        { json: "source", js: "source", typ: "" },
+        { json: "sources", js: "sources", typ: a("") },
+        { json: "title", js: "title", typ: u(undefined, "") },
+    ], "any"),
+    "SourceCountElement": o([
+        { json: "count", js: "count", typ: 0 },
+        { json: "source", js: "source", typ: "" },
+    ], "any"),
+    "NotebookDreamSourceCount": o([
+        { json: "count", js: "count", typ: 0 },
+        { json: "source", js: "source", typ: "" },
+    ], "any"),
+    "NotebookDreamStatusMessage": o([
+        { json: "cmd", js: "cmd", typ: r("NotebookDreamStatusMessageCmd") },
+    ], "any"),
+    "NotebookDreamStatusResult": o([
+        { json: "candidate_count", js: "candidate_count", typ: 0 },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "multi_context_count", js: "multi_context_count", typ: 0 },
+        { json: "source_counts", js: "source_counts", typ: a(r("SourceCountElement")) },
+        { json: "top", js: "top", typ: a(r("CandidateElement")) },
+    ], "any"),
     "NotebookEntry": o([
         { json: "kind", js: "kind", typ: u(undefined, "") },
         { json: "path", js: "path", typ: "" },
@@ -7627,6 +7827,8 @@ const typeMap: any = {
         { json: "dispatch_message", js: "dispatch_message", typ: u(undefined, r("DispatchMessageObject")) },
         { json: "dispatch_messages", js: "dispatch_messages", typ: u(undefined, a(r("DispatchMessageObject"))) },
         { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "notebook_dream_run", js: "notebook_dream_run", typ: u(undefined, r("NotebookDreamRun")) },
+        { json: "notebook_dream_status", js: "notebook_dream_status", typ: u(undefined, r("NotebookDreamStatus")) },
         { json: "notebook_entries", js: "notebook_entries", typ: u(undefined, a(r("NotebookEntryElement"))) },
         { json: "notebook_guide", js: "notebook_guide", typ: u(undefined, r("NotebookGuide")) },
         { json: "notebook_init", js: "notebook_init", typ: u(undefined, r("NotebookInit")) },
@@ -7651,6 +7853,20 @@ const typeMap: any = {
         { json: "read_at", js: "read_at", typ: u(undefined, "") },
         { json: "sender_session_id", js: "sender_session_id", typ: "" },
         { json: "target_session_id", js: "target_session_id", typ: "" },
+    ], "any"),
+    "NotebookDreamRun": o([
+        { json: "applied", js: "applied", typ: true },
+        { json: "candidate_count", js: "candidate_count", typ: 0 },
+        { json: "candidates", js: "candidates", typ: a(r("CandidateElement")) },
+        { json: "multi_context_count", js: "multi_context_count", typ: 0 },
+        { json: "source_counts", js: "source_counts", typ: a(r("SourceCountElement")) },
+    ], "any"),
+    "NotebookDreamStatus": o([
+        { json: "candidate_count", js: "candidate_count", typ: 0 },
+        { json: "enabled", js: "enabled", typ: true },
+        { json: "multi_context_count", js: "multi_context_count", typ: 0 },
+        { json: "source_counts", js: "source_counts", typ: a(r("SourceCountElement")) },
+        { json: "top", js: "top", typ: a(r("CandidateElement")) },
     ], "any"),
     "NotebookGuide": o([
         { json: "guidance", js: "guidance", typ: "" },
@@ -8713,6 +8929,12 @@ const typeMap: any = {
     ],
     "NotebookChangedMessageEvent": [
         "notebook_changed",
+    ],
+    "NotebookDreamRunMessageCmd": [
+        "notebook_dream_run",
+    ],
+    "NotebookDreamStatusMessageCmd": [
+        "notebook_dream_status",
     ],
     "NotebookGuideMessageCmd": [
         "notebook_guide",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -1001,6 +1001,8 @@ commands:
   memory write --path P      write/edit a durable note; content from --file or stdin
                              (--base-hash H for a safe hash-CAS edit)
   guide                      print the notebook operating guidance
+  dream status               summarize what a consolidation pass would harvest
+  dream [--dry-run]          preview the harvested candidates (nothing is written)
 `)
 }
 
@@ -1077,6 +1079,8 @@ func runNotebook() {
 			os.Exit(1)
 		}
 		fmt.Println(res.Guidance)
+	case "dream":
+		runNotebookDream(c, args)
 	default:
 		fmt.Fprintf(os.Stderr, "notebook: unknown command %q\n\n", action)
 		writeNotebookHelp(os.Stderr)
@@ -1207,6 +1211,100 @@ func runNotebookMemory(c *client.Client, args []string) {
 		hash = *res.Hash
 	}
 	fmt.Printf("wrote %s (%s)\n", res.Path, hash)
+}
+
+// runNotebookDream handles `attn notebook dream status` and `attn notebook dream
+// [--dry-run]`. Both are read-only: status summarizes the harvest, the bare/
+// --dry-run form previews the candidates. Nothing is written — the promote phase
+// is not yet available, so --apply is rejected with a clear message.
+func runNotebookDream(c *client.Client, args []string) {
+	sub := ""
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	switch sub {
+	case "status":
+		if len(args) != 1 {
+			fmt.Fprintln(os.Stderr, "usage: attn notebook dream status")
+			os.Exit(2)
+		}
+		res, err := c.NotebookDreamStatus()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "notebook dream status: %v\n", err)
+			os.Exit(1)
+		}
+		printDreamStatus(os.Stdout, res)
+	case "", "--dry-run":
+		if len(args) > 1 {
+			fmt.Fprintln(os.Stderr, "usage: attn notebook dream [--dry-run]")
+			os.Exit(2)
+		}
+		res, err := c.NotebookDreamRun(false)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "notebook dream: %v\n", err)
+			os.Exit(1)
+		}
+		printDreamRun(os.Stdout, res)
+	case "--apply":
+		fmt.Fprintln(os.Stderr, "notebook dream: --apply is not available yet — the consolidation pass that promotes candidates to durable memory lands in a follow-up. Use `--dry-run` to preview.")
+		os.Exit(2)
+	default:
+		fmt.Fprintf(os.Stderr, "notebook dream: unknown argument %q (want: status, --dry-run)\n", sub)
+		os.Exit(2)
+	}
+}
+
+func dreamEnabledLabel(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+func printDreamSourceCounts(w io.Writer, counts []protocol.NotebookDreamSourceCount) {
+	for _, sc := range counts {
+		fmt.Fprintf(w, "  %-9s %d\n", sc.Source+":", sc.Count)
+	}
+}
+
+// printDreamCandidate renders one candidate line plus its snippet, e.g.
+//
+//	[3× ·2 ctx] journal  2026-06-13
+//	    we decided to split the dreaming PR along the LLM seam …
+func printDreamCandidate(w io.Writer, cand protocol.NotebookDreamCandidate) {
+	label := strings.TrimSpace(protocol.Deref(cand.Title))
+	header := fmt.Sprintf("  [%d× ·%d ctx] %-8s", cand.Occurrences, len(cand.Contexts), cand.Source)
+	if label != "" {
+		header += "  " + label
+	}
+	fmt.Fprintln(w, header)
+	if snippet := strings.TrimSpace(cand.Snippet); snippet != "" {
+		fmt.Fprintf(w, "      %s\n", snippet)
+	}
+}
+
+func printDreamStatus(w io.Writer, res *protocol.NotebookDreamStatusResult) {
+	fmt.Fprintf(w, "dreaming: %s\n", dreamEnabledLabel(res.Enabled))
+	fmt.Fprintf(w, "candidates: %d (%d across multiple contexts)\n", res.CandidateCount, res.MultiContextCount)
+	printDreamSourceCounts(w, res.SourceCounts)
+	if len(res.Top) > 0 {
+		fmt.Fprintln(w, "top candidates:")
+		for _, cand := range res.Top {
+			printDreamCandidate(w, cand)
+		}
+	}
+}
+
+func printDreamRun(w io.Writer, res *protocol.NotebookDreamRunResult) {
+	fmt.Fprintf(w, "harvested %d candidates (%d across multiple contexts) — preview only, nothing written\n",
+		res.CandidateCount, res.MultiContextCount)
+	printDreamSourceCounts(w, res.SourceCounts)
+	if len(res.Candidates) > 0 {
+		fmt.Fprintf(w, "\ncandidates (showing %d):\n", len(res.Candidates))
+		for _, cand := range res.Candidates {
+			printDreamCandidate(w, cand)
+		}
+	}
 }
 
 func workspaceContextSourceSession(args []string, allowForce bool) (string, bool, error) {

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -521,6 +521,48 @@ func TestParseNotebookJournalArgs(t *testing.T) {
 	}
 }
 
+func TestPrintDreamStatus(t *testing.T) {
+	var buf bytes.Buffer
+	printDreamStatus(&buf, &protocol.NotebookDreamStatusResult{
+		Enabled:           false,
+		CandidateCount:    3,
+		MultiContextCount: 1,
+		SourceCounts: []protocol.NotebookDreamSourceCount{
+			{Source: "context", Count: 1},
+			{Source: "journal", Count: 2},
+		},
+		Top: []protocol.NotebookDreamCandidate{
+			{Source: "context", Title: protocol.Ptr("ws-a"), Snippet: "Daemon owns every notebook write.", Occurrences: 2, Contexts: []string{"workspace:ws-a", "workspace:ws-b"}},
+		},
+	})
+	out := buf.String()
+	for _, want := range []string{"dreaming: disabled", "candidates: 3 (1 across multiple contexts)", "context:", "journal:", "[2× ·2 ctx]", "Daemon owns every notebook write."} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("status output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintDreamRunPreviewOnly(t *testing.T) {
+	var buf bytes.Buffer
+	printDreamRun(&buf, &protocol.NotebookDreamRunResult{
+		Applied:           false,
+		CandidateCount:    1,
+		MultiContextCount: 0,
+		SourceCounts:      []protocol.NotebookDreamSourceCount{{Source: "journal", Count: 1}},
+		Candidates: []protocol.NotebookDreamCandidate{
+			{Source: "journal", Snippet: "A durable fact.", Occurrences: 1, Contexts: []string{"journal:2026-06-13"}},
+		},
+	})
+	out := buf.String()
+	if !strings.Contains(out, "preview only, nothing written") {
+		t.Fatalf("run output should state it is preview-only:\n%s", out)
+	}
+	if !strings.Contains(out, "A durable fact.") {
+		t.Fatalf("run output missing the candidate snippet:\n%s", out)
+	}
+}
+
 func TestParseNotebookMemoryArgs(t *testing.T) {
 	t.Run("create (no base-hash, stdin)", func(t *testing.T) {
 		got, err := parseNotebookMemoryArgs([]string{"write", "--path", "/memory/decisions/x.md"})

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -497,6 +497,37 @@ func (c *Client) NotebookGuide(sessionID string) (*protocol.NotebookGuideResult,
 	return resp.NotebookGuide, nil
 }
 
+// NotebookDreamStatus returns a summary of what the dreaming pass would
+// consolidate now (the deterministic harvest preview; nothing is written).
+func (c *Client) NotebookDreamStatus() (*protocol.NotebookDreamStatusResult, error) {
+	resp, err := c.send(protocol.NotebookDreamStatusMessage{Cmd: protocol.CmdNotebookDreamStatus})
+	if err != nil {
+		return nil, err
+	}
+	if resp.NotebookDreamStatus == nil {
+		return nil, errors.New("daemon returned no notebook dream status result")
+	}
+	return resp.NotebookDreamStatus, nil
+}
+
+// NotebookDreamRun runs a dreaming harvest and returns the candidate preview.
+// apply is reserved for the promote phase; this phase is preview-only and writes
+// nothing.
+func (c *Client) NotebookDreamRun(apply bool) (*protocol.NotebookDreamRunResult, error) {
+	msg := protocol.NotebookDreamRunMessage{Cmd: protocol.CmdNotebookDreamRun}
+	if apply {
+		msg.Apply = protocol.Ptr(true)
+	}
+	resp, err := c.send(msg)
+	if err != nil {
+		return nil, err
+	}
+	if resp.NotebookDreamRun == nil {
+		return nil, errors.New("daemon returned no notebook dream run result")
+	}
+	return resp.NotebookDreamRun, nil
+}
+
 // Query returns sessions matching the filter
 func (c *Client) Query(filter string) ([]protocol.Session, error) {
 	var filterPtr *string

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1744,6 +1744,10 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleNotebookGuide(conn, msg.(*protocol.NotebookGuideMessage))
 	case protocol.CmdNotebookBacklinks:
 		d.handleNotebookBacklinks(conn, msg.(*protocol.NotebookBacklinksMessage))
+	case protocol.CmdNotebookDreamStatus:
+		d.handleNotebookDreamStatus(conn)
+	case protocol.CmdNotebookDreamRun:
+		d.handleNotebookDreamRun(conn, msg.(*protocol.NotebookDreamRunMessage))
 	case protocol.CmdUnregister:
 		d.handleUnregister(conn, msg.(*protocol.UnregisterMessage))
 	case protocol.CmdState:

--- a/internal/daemon/notebook_dreaming.go
+++ b/internal/daemon/notebook_dreaming.go
@@ -1,0 +1,358 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+
+	"github.com/victorarias/attn/internal/notebook"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// Dreaming — harvest + read-only inspection (phase one).
+//
+// This file implements the deterministic, LLM-free harvest and the inspection
+// commands that surface it (`attn notebook dream status` / `--dry-run`). It scans
+// the three v1 sources — dated journals, canonical workspace-context snapshots,
+// and closed chief-of-staff dispatches — into deduplicated candidates ordered by
+// durability signal (recurrence across distinct contexts).
+//
+// Harvest here is preview-only: it never writes candidates.json, never advances a
+// cursor, and never touches durable memory. Persistence, the nightly scheduler,
+// and the gated LLM promote pass arrive in the follow-up dreaming PR; keeping
+// this phase side-effect-free makes the harvest model observable and reviewable
+// before anything runs autonomously.
+
+// topDreamCandidates bounds how many candidates `dream status` returns inline.
+const topDreamCandidates = 10
+
+// maxDreamRunCandidates bounds how many candidates a `dream --dry-run` preview
+// returns, so a large notebook can't produce an unbounded response.
+const maxDreamRunCandidates = 200
+
+// harvestDreamCandidates scans all three v1 sources into a merged candidate set.
+// It is read-only: callers decide what to do with the result (status summary,
+// dry-run preview). Failure to read any single source is logged and skipped — a
+// partial harvest is more useful than none, and the preview is advisory.
+func (d *Daemon) harvestDreamCandidates() (*notebook.DreamCandidateSet, error) {
+	store, err := d.notebookStoreFor()
+	if err != nil {
+		return nil, err
+	}
+	set := notebook.NewDreamCandidateSet()
+
+	// 1. Journals: each dated note's blocks (the raw system of record).
+	entries, err := store.List(notebook.DirJournal)
+	if err != nil {
+		d.logf("dreaming harvest: list journals: %v", err)
+	}
+	for _, e := range entries {
+		// attn never writes a note larger than MaxFileSize, so anything bigger is
+		// an oversized externally-synced file. Skip it rather than pull its whole
+		// body into memory (mirrors Store.Backlinks and List's scan cap).
+		if e.Size > notebook.MaxFileSize {
+			d.logf("dreaming harvest: skip oversized journal %s (%d bytes)", e.Path, e.Size)
+			continue
+		}
+		content, _, rerr := store.Read(e.Path)
+		if rerr != nil {
+			d.logf("dreaming harvest: read %s: %v", e.Path, rerr)
+			continue
+		}
+		date := notebook.JournalDateFromPath(e.Path)
+		doc := notebook.ParsePermissive(content)
+		for _, sig := range notebook.ExtractJournalSignals(e.Path, date, doc.Body) {
+			set.Add(sig)
+		}
+	}
+
+	// 2. Workspace-context snapshots: durable Decisions/Constraints per workspace.
+	if d.store != nil {
+		contexts, cerr := d.store.ListWorkspaceContexts()
+		if cerr != nil {
+			d.logf("dreaming harvest: list workspace contexts: %v", cerr)
+		}
+		for _, wc := range contexts {
+			for _, sig := range extractContextSignals(wc.WorkspaceID, wc.Content, wc.UpdatedAt) {
+				set.Add(sig)
+			}
+		}
+
+		// 3. Closed dispatches: a dispatch is closed when its target session is gone.
+		for _, disp := range d.store.ListChiefOfStaffDispatches("") {
+			if disp == nil || d.store.Get(disp.SessionID) != nil {
+				continue
+			}
+			for _, sig := range dispatchSignals(disp) {
+				set.Add(sig)
+			}
+		}
+	}
+
+	return set, nil
+}
+
+// contextDurableHeadings are the workspace-context sections whose bullets are
+// durable enough to harvest. Area/Current Picture/Threads are working state;
+// Decisions and Constraints are the facts meant to outlive a workspace.
+var contextDurableHeadings = map[string]bool{
+	"## decisions":   true,
+	"## constraints": true,
+}
+
+// extractContextSignals harvests each Decisions/Constraints bullet from a
+// canonical workspace-context snapshot. The workspace is both the source ref and
+// the distinct-context label, so a decision echoed across several workspaces
+// reads as recurring.
+func extractContextSignals(workspaceID, content, updatedAt string) []notebook.DreamSignal {
+	ref := "context:" + workspaceID
+	ctx := "workspace:" + workspaceID
+	var out []notebook.DreamSignal
+	for _, bullet := range collectBulletsUnderHeadings(content, contextDurableHeadings) {
+		out = append(out, notebook.DreamSignal{
+			Source:    notebook.SignalSourceContext,
+			Text:      bullet,
+			SourceRef: ref,
+			Context:   ctx,
+			Seen:      updatedAt,
+		})
+	}
+	return out
+}
+
+// collectBulletsUnderHeadings returns the list bullets (with their continuation
+// lines) that appear under any of the target "## " headings. A heading toggles
+// the active section; a blank line or new bullet ends the current bullet; any
+// new heading ends the section.
+func collectBulletsUnderHeadings(content string, headings map[string]bool) []string {
+	var bullets []string
+	var cur []string
+	inSection := false
+	flush := func() {
+		if len(cur) > 0 {
+			bullets = append(bullets, strings.Join(cur, "\n"))
+			cur = nil
+		}
+	}
+	for line := range strings.SplitSeq(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "## "):
+			flush()
+			inSection = headings[strings.ToLower(trimmed)]
+			continue
+		case strings.HasPrefix(trimmed, "# "):
+			flush()
+			inSection = false
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		if trimmed == "" {
+			flush()
+			continue
+		}
+		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
+			flush()
+			cur = append(cur, trimmed)
+		} else if len(cur) > 0 {
+			cur = append(cur, trimmed) // continuation of the current bullet
+		}
+	}
+	flush()
+	return bullets
+}
+
+// dispatchSignals harvests the durable outcome of a closed dispatch: its
+// structured summary and any resolved decision, falling back to the latest
+// freeform report. The dispatch id grounds it; its workspace is the context.
+func dispatchSignals(disp *protocol.ChiefOfStaffDispatch) []notebook.DreamSignal {
+	if disp == nil {
+		return nil
+	}
+	title := strings.TrimSpace(disp.Label)
+	if title == "" {
+		title = strings.TrimSpace(disp.Brief)
+	}
+	ref := "dispatch:" + disp.ID
+	ctx := "workspace:" + disp.WorkspaceID
+	seen := strings.TrimSpace(disp.UpdatedAt)
+	if disp.ReportedAt != nil && strings.TrimSpace(*disp.ReportedAt) != "" {
+		seen = strings.TrimSpace(*disp.ReportedAt)
+	}
+
+	var texts []string
+	if r := disp.StructuredReport; r != nil {
+		if s := strings.TrimSpace(r.Summary); s != "" {
+			texts = append(texts, s)
+		}
+		if decision := dispatchDecisionText(r.Request); decision != "" {
+			texts = append(texts, decision)
+		}
+	}
+	if len(texts) == 0 && disp.LatestReport != nil {
+		if s := strings.TrimSpace(*disp.LatestReport); s != "" {
+			texts = append(texts, s)
+		}
+	}
+
+	out := make([]notebook.DreamSignal, 0, len(texts))
+	for _, t := range texts {
+		out = append(out, notebook.DreamSignal{
+			Source:    notebook.SignalSourceDispatch,
+			Title:     title,
+			Text:      t,
+			SourceRef: ref,
+			Context:   ctx,
+			Seen:      seen,
+		})
+	}
+	return out
+}
+
+// dispatchDecisionText renders a resolved decision request as a single durable
+// line ("Decision: <question> → <answer>"). An unanswered request carries no
+// durable outcome yet, so it is skipped.
+func dispatchDecisionText(req *protocol.DispatchDecisionRequest) string {
+	if req == nil {
+		return ""
+	}
+	question := strings.TrimSpace(req.Question)
+	answer := ""
+	if req.Response != nil {
+		answer = strings.TrimSpace(*req.Response)
+	}
+	if answer == "" && req.Recommendation != nil {
+		answer = strings.TrimSpace(*req.Recommendation)
+	}
+	if question == "" || answer == "" {
+		return ""
+	}
+	return fmt.Sprintf("Decision: %s → %s", question, answer)
+}
+
+// dreamStatus returns a cheap summary of what a dream would consolidate now: the
+// gate flag, candidate totals (overall and recurring-across-contexts), per-source
+// counts, and the top candidates by durability signal.
+func (d *Daemon) dreamStatus() (*protocol.NotebookDreamStatusResult, error) {
+	set, err := d.harvestDreamCandidates()
+	if err != nil {
+		return nil, err
+	}
+	candidates := set.Candidates()
+	res := &protocol.NotebookDreamStatusResult{
+		Enabled:           parseBooleanSetting(d.store.GetSetting(SettingNotebookDreamingEnabled)),
+		CandidateCount:    len(candidates),
+		MultiContextCount: countMultiContext(candidates),
+		SourceCounts:      sourceCounts(candidates),
+		Top:               toProtocolDreamCandidates(candidates, topDreamCandidates),
+	}
+	return res, nil
+}
+
+// dreamRun performs a harvest and returns the candidate preview. apply is
+// accepted for forward compatibility with the promote phase, but this phase is
+// preview-only: it always reports Applied=false and writes nothing.
+func (d *Daemon) dreamRun(apply bool) (*protocol.NotebookDreamRunResult, error) {
+	set, err := d.harvestDreamCandidates()
+	if err != nil {
+		return nil, err
+	}
+	candidates := set.Candidates()
+	res := &protocol.NotebookDreamRunResult{
+		Applied:           false,
+		CandidateCount:    len(candidates),
+		MultiContextCount: countMultiContext(candidates),
+		SourceCounts:      sourceCounts(candidates),
+		Candidates:        toProtocolDreamCandidates(candidates, maxDreamRunCandidates),
+	}
+	return res, nil
+}
+
+func countMultiContext(candidates []notebook.DreamCandidate) int {
+	n := 0
+	for _, c := range candidates {
+		if c.DistinctContexts() > 1 {
+			n++
+		}
+	}
+	return n
+}
+
+// sourceCounts tallies candidates by originating source, in a stable order.
+func sourceCounts(candidates []notebook.DreamCandidate) []protocol.NotebookDreamSourceCount {
+	counts := map[string]int{}
+	for _, c := range candidates {
+		counts[c.Source]++
+	}
+	sources := make([]string, 0, len(counts))
+	for s := range counts {
+		sources = append(sources, s)
+	}
+	sort.Strings(sources)
+	out := make([]protocol.NotebookDreamSourceCount, 0, len(sources))
+	for _, s := range sources {
+		out = append(out, protocol.NotebookDreamSourceCount{Source: s, Count: counts[s]})
+	}
+	return out
+}
+
+// toProtocolDreamCandidates converts up to limit candidates to their protocol
+// shape (limit <= 0 means all).
+func toProtocolDreamCandidates(candidates []notebook.DreamCandidate, limit int) []protocol.NotebookDreamCandidate {
+	if limit > 0 && len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+	out := make([]protocol.NotebookDreamCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		pc := protocol.NotebookDreamCandidate{
+			SignalKey:   c.SignalKey,
+			Source:      c.Source,
+			Snippet:     c.Snippet,
+			Occurrences: c.Occurrences,
+			Contexts:    c.Contexts,
+			Sources:     c.Sources,
+		}
+		if c.Title != "" {
+			pc.Title = protocol.Ptr(c.Title)
+		}
+		if c.FirstSeen != "" {
+			pc.FirstSeen = protocol.Ptr(c.FirstSeen)
+		}
+		if c.LastSeen != "" {
+			pc.LastSeen = protocol.Ptr(c.LastSeen)
+		}
+		out = append(out, pc)
+	}
+	return out
+}
+
+// handleNotebookDreamStatus serves `attn notebook dream status` over the unix
+// socket (synchronous Response).
+func (d *Daemon) handleNotebookDreamStatus(conn net.Conn) {
+	res, err := d.dreamStatus()
+	if err != nil {
+		d.sendError(conn, "notebook dream status: "+err.Error())
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, NotebookDreamStatus: res})
+}
+
+// handleNotebookDreamRun serves `attn notebook dream [--dry-run]` over the unix
+// socket. This phase is preview-only; the apply flag is reserved for the promote
+// pass and currently never writes.
+func (d *Daemon) handleNotebookDreamRun(conn net.Conn, msg *protocol.NotebookDreamRunMessage) {
+	apply := false
+	if msg.Apply != nil {
+		apply = *msg.Apply
+	}
+	res, err := d.dreamRun(apply)
+	if err != nil {
+		d.sendError(conn, "notebook dream: "+err.Error())
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, NotebookDreamRun: res})
+}

--- a/internal/daemon/notebook_dreaming_test.go
+++ b/internal/daemon/notebook_dreaming_test.go
@@ -1,0 +1,280 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/notebook"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// appendDreamJournal writes a journal entry through the daemon's notebook store.
+func appendDreamJournal(t *testing.T, d *Daemon, date, entry string) {
+	t.Helper()
+	store, err := d.notebookStoreFor()
+	if err != nil {
+		t.Fatalf("notebook store: %v", err)
+	}
+	if _, _, err := store.AppendJournal(date, entry); err != nil {
+		t.Fatalf("append journal %s: %v", date, err)
+	}
+}
+
+func setWorkspaceContext(t *testing.T, d *Daemon, workspaceID, content string) {
+	t.Helper()
+	// ListWorkspaceContexts inner-joins the workspaces table, so the workspace
+	// must be registered for its context to be harvestable (mirrors production:
+	// contexts only exist for real workspaces).
+	d.store.AddWorkspace(&protocol.Workspace{ID: workspaceID, Title: workspaceID, Directory: t.TempDir()})
+	if _, _, err := d.store.UpdateWorkspaceContext(workspaceID, content, "sess", 0); err != nil {
+		t.Fatalf("update workspace context %s: %v", workspaceID, err)
+	}
+}
+
+// findCandidate returns the first candidate whose snippet contains substr.
+func findCandidate(cands []protocol.NotebookDreamCandidate, substr string) *protocol.NotebookDreamCandidate {
+	for i := range cands {
+		if strings.Contains(cands[i].Snippet, substr) {
+			return &cands[i]
+		}
+	}
+	return nil
+}
+
+// Harvest pulls from all three v1 sources, merges a fact echoed across two
+// workspace contexts into one recurring candidate, and excludes a dispatch whose
+// target session is still live (only closed dispatches are durable).
+func TestHarvestDreamCandidatesAcrossSources(t *testing.T) {
+	d := newNotebookDaemon(t)
+
+	appendDreamJournal(t, d, "2026-06-10", "The harvest pass scans journals, context snapshots, and closed dispatches.")
+
+	const sharedDecision = "Daemon owns every notebook write through one in-process store."
+	ctxTemplate := "# Workspace Context\n\n## Area\nfoo\n\n## Decisions\n- " + sharedDecision + "\n"
+	setWorkspaceContext(t, d, "ws-a", ctxTemplate)
+	setWorkspaceContext(t, d, "ws-b", ctxTemplate+"- A second decision only in ws-b about hash-CAS edits.\n")
+
+	// Closed dispatch: its target session is absent from the store.
+	if err := d.store.AddChiefOfStaffDispatch(&protocol.ChiefOfStaffDispatch{
+		ID: "dsp-closed", ChiefSessionID: "chief", SessionID: "worker-gone", WorkspaceID: "ws-a",
+		Label: "Ship the editor", Agent: "claude", CreatedAt: "2026-06-09", UpdatedAt: "2026-06-09",
+		StructuredReport: &protocol.DispatchReport{Summary: "Shipped the in-app markdown editor with hash-CAS conflict handling."},
+	}); err != nil {
+		t.Fatalf("add closed dispatch: %v", err)
+	}
+	// Live dispatch: its target session exists, so it is not yet closed.
+	addIdleNotebookSession(d, "worker-live", protocol.SessionStateWorking)
+	if err := d.store.AddChiefOfStaffDispatch(&protocol.ChiefOfStaffDispatch{
+		ID: "dsp-live", ChiefSessionID: "chief", SessionID: "worker-live", WorkspaceID: "ws-b",
+		Label: "Still working", Agent: "claude", CreatedAt: "2026-06-13", UpdatedAt: "2026-06-13",
+		StructuredReport: &protocol.DispatchReport{Summary: "LIVE-WORK-IN-PROGRESS should not be harvested."},
+	}); err != nil {
+		t.Fatalf("add live dispatch: %v", err)
+	}
+
+	res, err := d.dreamRun(false)
+	if err != nil {
+		t.Fatalf("dreamRun: %v", err)
+	}
+	if res.Applied {
+		t.Fatal("dreamRun must be preview-only (applied=false)")
+	}
+
+	// The shared decision recurs across both workspaces.
+	shared := findCandidate(res.Candidates, sharedDecision)
+	if shared == nil {
+		t.Fatalf("shared decision not harvested; candidates = %+v", res.Candidates)
+	}
+	if shared.Occurrences != 2 || len(shared.Contexts) != 2 {
+		t.Fatalf("shared decision occurrences=%d contexts=%d, want 2/2", shared.Occurrences, len(shared.Contexts))
+	}
+	if shared.Source != notebook.SignalSourceContext {
+		t.Fatalf("shared decision source = %q, want context", shared.Source)
+	}
+
+	// Exactly one candidate recurs across multiple contexts (the shared decision);
+	// the journal block, ws-b's second decision, and the dispatch summary are each
+	// single-context. This pins the ">1" multi-context threshold that the user-
+	// facing "N across multiple contexts" count and the promote-phase gate rest on.
+	if res.MultiContextCount != 1 {
+		t.Fatalf("multi-context count = %d, want exactly 1 (only the shared decision recurs); candidates = %+v", res.MultiContextCount, res.Candidates)
+	}
+	if res.CandidateCount <= 1 {
+		t.Fatalf("candidate count = %d, want several so the multi-context subset is meaningful", res.CandidateCount)
+	}
+
+	// The closed dispatch's summary is harvested; the live one is not.
+	if findCandidate(res.Candidates, "Shipped the in-app markdown editor") == nil {
+		t.Fatal("closed dispatch summary should be harvested")
+	}
+	if findCandidate(res.Candidates, "LIVE-WORK-IN-PROGRESS") != nil {
+		t.Fatal("a dispatch whose target session is still live must not be harvested")
+	}
+
+	// All three sources contributed.
+	srcs := map[string]bool{}
+	for _, sc := range res.SourceCounts {
+		srcs[sc.Source] = true
+	}
+	for _, want := range []string{notebook.SignalSourceJournal, notebook.SignalSourceContext, notebook.SignalSourceDispatch} {
+		if !srcs[want] {
+			t.Fatalf("source %q missing from counts %+v", want, res.SourceCounts)
+		}
+	}
+}
+
+// extractContextSignals harvests only the Decisions/Constraints sections (working
+// state like Area is ignored) and joins a wrapped bullet's continuation lines.
+func TestExtractContextSignals(t *testing.T) {
+	content := "# Workspace Context\n\n" +
+		"## Area\nThis is working context, not durable memory.\n\n" +
+		"## Decisions\n- A decision that wraps\n  onto a second line.\n- A second decision.\n\n" +
+		"## Constraints\n- A hard constraint.\n\n" +
+		"## Threads\n- Not harvested.\n"
+
+	sigs := extractContextSignals("ws-1", content, "2026-06-13T00:00:00Z")
+	if len(sigs) != 3 {
+		t.Fatalf("signals = %d, want 3 (2 decisions + 1 constraint): %+v", len(sigs), sigs)
+	}
+	var joined bool
+	for _, s := range sigs {
+		if s.SourceRef != "context:ws-1" || s.Context != "workspace:ws-1" {
+			t.Fatalf("signal grounding = ref %q ctx %q, want context:ws-1 / workspace:ws-1", s.SourceRef, s.Context)
+		}
+		if strings.Contains(s.Text, "wraps") && strings.Contains(s.Text, "second line") {
+			joined = true
+		}
+		if strings.Contains(s.Text, "Not harvested") || strings.Contains(s.Text, "working context") {
+			t.Fatalf("harvested a non-durable section: %q", s.Text)
+		}
+	}
+	if !joined {
+		t.Fatal("a wrapped bullet's continuation line should be joined into one signal")
+	}
+}
+
+// A resolved decision request renders as a single durable line; a dispatch with
+// only a freeform report falls back to it.
+func TestDispatchSignals(t *testing.T) {
+	resolved := &protocol.ChiefOfStaffDispatch{
+		ID: "dsp-1", WorkspaceID: "ws-1", Label: "Decide split",
+		StructuredReport: &protocol.DispatchReport{
+			Summary: "Split the dreaming work in two.",
+			Request: &protocol.DispatchDecisionRequest{
+				Question: "Split dreaming into two PRs?",
+				Response: protocol.Ptr("Yes — harvest first, promote second."),
+			},
+		},
+	}
+	sigs := dispatchSignals(resolved)
+	if len(sigs) != 2 {
+		t.Fatalf("signals = %d, want 2 (summary + decision): %+v", len(sigs), sigs)
+	}
+	var sawDecision bool
+	for _, s := range sigs {
+		if s.SourceRef != "dispatch:dsp-1" || s.Context != "workspace:ws-1" {
+			t.Fatalf("dispatch grounding = ref %q ctx %q", s.SourceRef, s.Context)
+		}
+		if strings.HasPrefix(s.Text, "Decision: ") && strings.Contains(s.Text, "→") {
+			sawDecision = true
+		}
+	}
+	if !sawDecision {
+		t.Fatalf("expected a rendered decision line; got %+v", sigs)
+	}
+
+	freeform := &protocol.ChiefOfStaffDispatch{
+		ID: "dsp-2", WorkspaceID: "ws-2", LatestReport: protocol.Ptr("Freeform progress note."),
+	}
+	if got := dispatchSignals(freeform); len(got) != 1 || !strings.Contains(got[0].Text, "Freeform progress note") {
+		t.Fatalf("freeform fallback = %+v, want one signal from the latest report", got)
+	}
+
+	// With no explicit response, a recommendation is the recorded outcome.
+	rec := dispatchDecisionText(&protocol.DispatchDecisionRequest{
+		Question: "Which agent?", Recommendation: protocol.Ptr("Use claude."),
+	})
+	if !strings.Contains(rec, "Which agent?") || !strings.Contains(rec, "Use claude.") {
+		t.Fatalf("recommendation fallback = %q, want question + recommendation", rec)
+	}
+
+	// An unanswered decision request carries no durable outcome.
+	if got := dispatchDecisionText(&protocol.DispatchDecisionRequest{Question: "Pending?"}); got != "" {
+		t.Fatalf("unanswered request text = %q, want empty", got)
+	}
+}
+
+// A journal note larger than MaxFileSize (only possible via external sync, since
+// attn never writes one) is skipped rather than read fully into memory, mirroring
+// the Backlinks/List size guard.
+func TestHarvestSkipsOversizedJournal(t *testing.T) {
+	d := newNotebookDaemon(t)
+	appendDreamJournal(t, d, "2026-06-10", "A normal durable fact worth harvesting.")
+
+	// Write an oversized journal file directly on disk (an external-sync scenario).
+	root := d.store.GetSetting(SettingNotebookRoot)
+	big := "# 2026-06-11\n\n" + strings.Repeat("x", int(notebook.MaxFileSize)+1) + "\n"
+	if err := os.WriteFile(filepath.Join(root, "journal", "2026-06-11.md"), []byte(big), 0o600); err != nil {
+		t.Fatalf("write oversized journal: %v", err)
+	}
+
+	res, err := d.dreamRun(false)
+	if err != nil {
+		t.Fatalf("dreamRun: %v", err)
+	}
+	// The normal journal still harvests; the oversized one contributes nothing.
+	if findCandidate(res.Candidates, "A normal durable fact") == nil {
+		t.Fatal("the normal journal should still be harvested")
+	}
+	if findCandidate(res.Candidates, "xxxxxxxx") != nil {
+		t.Fatal("an oversized externally-synced journal must be skipped, not read into memory")
+	}
+}
+
+// dream status reflects the notebook.dreaming.enabled gate.
+func TestDreamStatusReportsEnabledGate(t *testing.T) {
+	d := newNotebookDaemon(t)
+	appendDreamJournal(t, d, "2026-06-10", "A durable decision worth remembering across days.")
+
+	off, err := d.dreamStatus()
+	if err != nil {
+		t.Fatalf("dreamStatus: %v", err)
+	}
+	if off.Enabled {
+		t.Fatal("dreaming should be disabled by default")
+	}
+	if off.CandidateCount == 0 {
+		t.Fatal("status should surface harvested candidates even when disabled")
+	}
+
+	d.store.SetSetting(SettingNotebookDreamingEnabled, "true")
+	on, err := d.dreamStatus()
+	if err != nil {
+		t.Fatalf("dreamStatus: %v", err)
+	}
+	if !on.Enabled {
+		t.Fatal("status should reflect the enabled gate")
+	}
+}
+
+// The dream commands round-trip through the full unix-socket path
+// (ParseMessage -> dispatch -> handler -> Response), proving the protocol wiring.
+func TestNotebookDreamDispatchesThroughClientMessage(t *testing.T) {
+	d := newNotebookDaemon(t)
+	appendDreamJournal(t, d, "2026-06-10", "A durable decision harvested through the socket path.")
+
+	status := sendNotebookCmd(t, d, protocol.NotebookDreamStatusMessage{Cmd: protocol.CmdNotebookDreamStatus})
+	if status.NotebookDreamStatus == nil {
+		t.Fatalf("dream status response missing result: %+v", status)
+	}
+
+	run := sendNotebookCmd(t, d, protocol.NotebookDreamRunMessage{Cmd: protocol.CmdNotebookDreamRun})
+	if run.NotebookDreamRun == nil || run.NotebookDreamRun.Applied {
+		t.Fatalf("dream run result = %+v, want a preview (applied=false)", run.NotebookDreamRun)
+	}
+	if run.NotebookDreamRun.CandidateCount == 0 {
+		t.Fatal("dream run should surface the harvested candidate")
+	}
+}

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -41,6 +41,11 @@ const (
 	// SettingNotebookRoot overrides the notebook's filesystem root. Empty =>
 	// the profile-derived default (~/attn-notebook[-profile]).
 	SettingNotebookRoot = "notebook.root"
+	// SettingNotebookDreamingEnabled gates the nightly dreaming consolidation
+	// pass. Default false; `attn notebook dream status`/`--dry-run` inspect the
+	// harvest regardless (the gate only governs autonomous runs). The scheduler
+	// that consumes it lands with the promote phase.
+	SettingNotebookDreamingEnabled = "notebook.dreaming.enabled"
 )
 
 func (d *Daemon) handleGetSettingsWS(client *wsClient) {
@@ -240,6 +245,8 @@ func (d *Daemon) validateSetting(key, value string) error {
 		return d.validateWorkspaceContextJanitorSetting(value)
 	case SettingNotebookRoot:
 		return validateNotebookRoot(value)
+	case SettingNotebookDreamingEnabled:
+		return validateBooleanSetting(value)
 	case SettingKeybindingsConfig:
 		return validateKeybindingsConfig(value)
 	case SettingReviewLoopPresets, SettingReviewLoopLastPreset, SettingReviewLoopLastPrompt, SettingReviewLoopLastIterations, SettingReviewLoopModel, SettingReviewerModel:

--- a/internal/notebook/dreams.go
+++ b/internal/notebook/dreams.go
@@ -1,0 +1,346 @@
+package notebook
+
+import (
+	"path"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Dreaming harvest model.
+//
+// The dreaming pass consolidates durable memory in two phases. The first —
+// "harvest" — is deterministic and LLM-free: it scans recent inputs (journals,
+// workspace-context snapshots, closed dispatches), extracts candidate signals,
+// and deduplicates them by content. The second — "promote" — is the gated LLM
+// pass that distills surviving candidates into grounded memory notes.
+//
+// This file holds the harvest's pure core: the candidate/signal types, the
+// content-keyed merge that turns many sightings of the same fact into one
+// candidate with an occurrence count, and the journal block extractor. The
+// daemon supplies the workspace-context and dispatch signals (they depend on
+// store types) and orchestrates the scan; everything here is store-agnostic and
+// unit-testable in isolation.
+
+// Signal source kinds — where a harvested signal originated.
+const (
+	SignalSourceJournal  = "journal"
+	SignalSourceContext  = "context"
+	SignalSourceDispatch = "dispatch"
+)
+
+// maxSnippetWords bounds a candidate snippet to roughly ~160 tokens (a snippet is
+// a pointer back to the full source via Sources, not a copy of it). Word-bounding
+// is a deliberate approximation of token-bounding — close enough to keep
+// candidates.json compact without a tokenizer dependency.
+const maxSnippetWords = 120
+
+// maxSnippetRunes is a hard backstop on snippet length. The word cap alone lets a
+// single pathological token (a base64 blob, minified JSON — plausible in an
+// externally-synced .md) through unbounded, since it counts as one "word"; this
+// clamps such input. It sits well above any normal ~120-word block so real prose
+// is never clipped by it. Dedup is unaffected — signalKey hashes the full text.
+const maxSnippetRunes = 2000
+
+// minSignalRunes filters out trivially short blocks (a bare list marker, a stray
+// word) that carry no durable signal. Measured in runes so multibyte text isn't
+// unfairly truncated.
+const minSignalRunes = 16
+
+// DreamSignal is one raw sighting of a potential durable fact, emitted by a
+// source scanner. Many signals collapse into one DreamCandidate when their
+// normalized text matches.
+type DreamSignal struct {
+	// Source is the originating scanner (journal|context|dispatch).
+	Source string
+	// Title is an optional human label (a journal date, a dispatch label).
+	Title string
+	// Text is the raw signal text; it is normalized for the dedup key and
+	// word-bounded for the stored snippet.
+	Text string
+	// SourceRef is a resolvable provenance pointer the promote phase grounds
+	// against (a root-absolute note path, "dispatch:<id>", "context:<workspace>").
+	SourceRef string
+	// Context is the distinct-context label (a workspace id, a journal date) used
+	// to measure recurrence-across-contexts, the strongest durability signal.
+	Context string
+	// Seen is an ISO timestamp/date for recency (the journal date, a dispatch's
+	// reported-at). May be empty.
+	Seen string
+}
+
+// DreamCandidate is one deduplicated harvest signal: a unit of source material
+// the promote phase may later distill into durable memory. Candidates are keyed
+// by normalized content, so the same fact seen in multiple places accumulates
+// Sources/Contexts and an Occurrences count instead of duplicating.
+type DreamCandidate struct {
+	// SignalKey is the content hash that identifies this candidate (the dedup key).
+	SignalKey string `json:"signal_key"`
+	// Source is the scanner that first surfaced this candidate.
+	Source string `json:"source"`
+	// Title is an optional human label carried from the first sighting that had one.
+	Title string `json:"title,omitempty"`
+	// Snippet is the word-bounded representative text.
+	Snippet string `json:"snippet"`
+	// Sources holds the distinct resolvable provenance refs (sorted, unique).
+	Sources []string `json:"sources"`
+	// Contexts holds the distinct context labels (sorted, unique).
+	Contexts []string `json:"contexts"`
+	// Occurrences == len(Sources): how many distinct source units carry this fact.
+	Occurrences int `json:"occurrences"`
+	// FirstSeen / LastSeen bound the candidate's sightings (ISO; may be empty).
+	FirstSeen string `json:"first_seen,omitempty"`
+	LastSeen  string `json:"last_seen,omitempty"`
+}
+
+// DistinctContexts reports how many distinct contexts carry this candidate — the
+// promote phase's recurrence gate ("appears in >= N distinct contexts").
+func (c DreamCandidate) DistinctContexts() int { return len(c.Contexts) }
+
+// DreamCandidateSet accumulates signals and merges them by normalized content.
+// Not safe for concurrent use; the harvest scans sources serially.
+type DreamCandidateSet struct {
+	byKey map[string]*DreamCandidate
+	order []string
+}
+
+// NewDreamCandidateSet returns an empty set ready to Add signals.
+func NewDreamCandidateSet() *DreamCandidateSet {
+	return &DreamCandidateSet{byKey: make(map[string]*DreamCandidate)}
+}
+
+// Add merges one signal into the set. A signal whose text is blank (after
+// normalization) is ignored. Re-adding the same SourceRef is idempotent, so a
+// scanner may safely re-scan a source without inflating Occurrences.
+func (s *DreamCandidateSet) Add(sig DreamSignal) {
+	text := strings.TrimSpace(sig.Text)
+	if text == "" {
+		return
+	}
+	key := signalKey(text)
+	if key == "" {
+		return
+	}
+	c := s.byKey[key]
+	if c == nil {
+		c = &DreamCandidate{
+			SignalKey: key,
+			Source:    sig.Source,
+			Title:     strings.TrimSpace(sig.Title),
+			Snippet:   boundedSnippet(text),
+			FirstSeen: sig.Seen,
+			LastSeen:  sig.Seen,
+		}
+		s.byKey[key] = c
+		s.order = append(s.order, key)
+	}
+	if ref := strings.TrimSpace(sig.SourceRef); ref != "" {
+		c.Sources = insertUniqueSorted(c.Sources, ref)
+		c.Occurrences = len(c.Sources)
+	}
+	if ctx := strings.TrimSpace(sig.Context); ctx != "" {
+		c.Contexts = insertUniqueSorted(c.Contexts, ctx)
+	}
+	if c.Title == "" {
+		c.Title = strings.TrimSpace(sig.Title)
+	}
+	if sig.Seen != "" {
+		// Compare chronologically, not lexically: a candidate merges sightings in
+		// mixed formats — date-only journal dates, UTC context timestamps, and
+		// dispatch timestamps that may carry a local UTC offset — and a raw string
+		// compare of an offset-bearing timestamp against a Z timestamp is wrong.
+		if c.FirstSeen == "" || seenBefore(sig.Seen, c.FirstSeen) {
+			c.FirstSeen = sig.Seen
+		}
+		if c.LastSeen == "" || seenBefore(c.LastSeen, sig.Seen) {
+			c.LastSeen = sig.Seen
+		}
+	}
+}
+
+// seenBefore reports whether sighting timestamp x is chronologically before y.
+// It parses RFC3339(Nano) and date-only ("2006-01-02", treated as UTC midnight)
+// forms; if either value is unparseable it falls back to a lexical compare so a
+// surprising format never panics or silently swaps the window.
+func seenBefore(x, y string) bool {
+	tx, okx := parseSeen(x)
+	ty, oky := parseSeen(y)
+	if okx && oky {
+		return tx.Before(ty)
+	}
+	return x < y
+}
+
+func parseSeen(s string) (time.Time, bool) {
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// Candidates returns the merged candidates ordered by durability signal: most
+// occurrences first, then most distinct contexts, then signal key for a stable
+// total order.
+func (s *DreamCandidateSet) Candidates() []DreamCandidate {
+	out := make([]DreamCandidate, 0, len(s.order))
+	for _, k := range s.order {
+		out = append(out, *s.byKey[k])
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Occurrences != out[j].Occurrences {
+			return out[i].Occurrences > out[j].Occurrences
+		}
+		if len(out[i].Contexts) != len(out[j].Contexts) {
+			return len(out[i].Contexts) > len(out[j].Contexts)
+		}
+		return out[i].SignalKey < out[j].SignalKey
+	})
+	return out
+}
+
+// Len reports how many distinct candidates the set holds.
+func (s *DreamCandidateSet) Len() int { return len(s.order) }
+
+// ExtractJournalSignals splits a journal note's body into block-level signals.
+// Each blank-line-delimited block becomes one signal (heading-only blocks and
+// blocks below the minimum length are skipped). The note path is the source ref
+// at file granularity — a fact repeated within one day counts once; the same
+// fact on a different day is a second, recurring sighting — and the date is both
+// the seen-timestamp and the distinct-context label, so recurrence is measured
+// across days.
+func ExtractJournalSignals(rel, dateISO, body string) []DreamSignal {
+	var out []DreamSignal
+	ref := rel
+	if !strings.HasPrefix(ref, "/") {
+		ref = "/" + ref
+	}
+	context := SignalSourceJournal
+	if dateISO != "" {
+		context = SignalSourceJournal + ":" + dateISO
+	}
+	for _, block := range splitBlocks(body) {
+		trimmed := strings.TrimSpace(block)
+		if trimmed == "" || isHeadingOnly(trimmed) {
+			continue
+		}
+		if len([]rune(trimmed)) < minSignalRunes {
+			continue
+		}
+		out = append(out, DreamSignal{
+			Source:    SignalSourceJournal,
+			Title:     dateISO,
+			Text:      trimmed,
+			SourceRef: ref,
+			Context:   context,
+			Seen:      dateISO,
+		})
+	}
+	return out
+}
+
+// JournalDateFromPath extracts the YYYY-MM-DD label from a journal note path
+// ("journal/2026-06-13.md" -> "2026-06-13"). A non-date basename yields an empty
+// label (the blocks still harvest; they just carry no date context).
+func JournalDateFromPath(rel string) string {
+	base := strings.TrimSuffix(path.Base(rel), ".md")
+	if journalDateRE.MatchString(base) {
+		return base
+	}
+	return ""
+}
+
+// signalKey is the dedup key: the hash of the normalized text. Empty when the
+// text normalizes to nothing.
+func signalKey(text string) string {
+	norm := normalizeSignal(text)
+	if norm == "" {
+		return ""
+	}
+	return Hash([]byte(norm))
+}
+
+// normalizeSignal canonicalizes signal text so cosmetically-different sightings
+// of the same fact share a key: per line it strips leading list/quote/heading
+// markers, lowercases, then collapses all whitespace to single spaces and trims
+// trailing sentence punctuation (so "X." and "X" are one fact). It is
+// deliberately conservative — it never drops interior words — so distinct facts
+// stay distinct.
+func normalizeSignal(text string) string {
+	var parts []string
+	for line := range strings.SplitSeq(text, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimLeft(line, "-*>#+ \t")
+		if line == "" {
+			continue
+		}
+		parts = append(parts, strings.ToLower(line))
+	}
+	collapsed := strings.Join(strings.Fields(strings.Join(parts, " ")), " ")
+	return strings.TrimRight(collapsed, " .,:;!?")
+}
+
+// boundedSnippet returns text bounded to maxSnippetWords AND maxSnippetRunes,
+// appending an ellipsis when truncated by either bound. Whitespace runs are
+// collapsed to keep the snippet compact.
+func boundedSnippet(text string) string {
+	words := strings.Fields(text)
+	truncated := len(words) > maxSnippetWords
+	if truncated {
+		words = words[:maxSnippetWords]
+	}
+	out := strings.Join(words, " ")
+	if r := []rune(out); len(r) > maxSnippetRunes {
+		out = strings.TrimRight(string(r[:maxSnippetRunes]), " ")
+		truncated = true
+	}
+	if truncated {
+		out += " …"
+	}
+	return out
+}
+
+// splitBlocks splits markdown text into blank-line-delimited blocks.
+func splitBlocks(body string) []string {
+	lines := strings.Split(body, "\n")
+	var blocks []string
+	var cur []string
+	flush := func() {
+		if len(cur) > 0 {
+			blocks = append(blocks, strings.Join(cur, "\n"))
+			cur = nil
+		}
+	}
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			flush()
+			continue
+		}
+		cur = append(cur, line)
+	}
+	flush()
+	return blocks
+}
+
+// isHeadingOnly reports whether a block is a single markdown heading line (the
+// journal's "# date" title or a lone section heading) with no body.
+func isHeadingOnly(block string) bool {
+	if strings.Contains(block, "\n") {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(block), "#")
+}
+
+// insertUniqueSorted inserts v into the sorted slice s if absent, keeping it
+// sorted and deduplicated.
+func insertUniqueSorted(s []string, v string) []string {
+	i := sort.SearchStrings(s, v)
+	if i < len(s) && s[i] == v {
+		return s
+	}
+	s = append(s, "")
+	copy(s[i+1:], s[i:])
+	s[i] = v
+	return s
+}

--- a/internal/notebook/dreams_test.go
+++ b/internal/notebook/dreams_test.go
@@ -1,0 +1,251 @@
+package notebook
+
+import (
+	"strings"
+	"testing"
+)
+
+// The same fact written two cosmetically-different ways (bullet marker, case,
+// whitespace) collapses into one candidate. Each distinct source unit counts
+// once, so occurrences and distinct contexts both reach 2.
+func TestDreamCandidateSetMergesCosmeticVariants(t *testing.T) {
+	set := NewDreamCandidateSet()
+	set.Add(DreamSignal{
+		Source: SignalSourceContext, Text: "- Daemon owns every notebook write.",
+		SourceRef: "context:ws-a", Context: "workspace:ws-a", Seen: "2026-06-10",
+	})
+	set.Add(DreamSignal{
+		Source: SignalSourceContext, Text: "* daemon owns   every notebook write",
+		SourceRef: "context:ws-b", Context: "workspace:ws-b", Seen: "2026-06-12",
+	})
+
+	got := set.Candidates()
+	if len(got) != 1 {
+		t.Fatalf("candidates = %d, want 1 (cosmetic variants merge); got %+v", len(got), got)
+	}
+	c := got[0]
+	if c.Occurrences != 2 {
+		t.Fatalf("occurrences = %d, want 2", c.Occurrences)
+	}
+	if c.DistinctContexts() != 2 {
+		t.Fatalf("distinct contexts = %d, want 2", c.DistinctContexts())
+	}
+	if c.FirstSeen != "2026-06-10" || c.LastSeen != "2026-06-12" {
+		t.Fatalf("seen window = [%s, %s], want [2026-06-10, 2026-06-12]", c.FirstSeen, c.LastSeen)
+	}
+	if len(c.Sources) != 2 {
+		t.Fatalf("sources = %v, want 2 distinct refs", c.Sources)
+	}
+}
+
+// Re-adding the same source ref is idempotent: a scanner can re-scan a source
+// without inflating occurrences (the merge is keyed by source ref, set-union).
+func TestDreamCandidateSetReAddIsIdempotent(t *testing.T) {
+	set := NewDreamCandidateSet()
+	sig := DreamSignal{
+		Source: SignalSourceJournal, Text: "A durable decision worth remembering.",
+		SourceRef: "/journal/2026-06-10.md", Context: "journal:2026-06-10", Seen: "2026-06-10",
+	}
+	set.Add(sig)
+	set.Add(sig)
+
+	got := set.Candidates()
+	if len(got) != 1 || got[0].Occurrences != 1 {
+		t.Fatalf("candidates = %+v, want one candidate with occurrences=1", got)
+	}
+}
+
+// Genuinely different facts stay separate — normalization is conservative and
+// never drops words.
+func TestDreamCandidateSetKeepsDistinctFactsSeparate(t *testing.T) {
+	set := NewDreamCandidateSet()
+	set.Add(DreamSignal{Source: SignalSourceJournal, Text: "Notebook is filesystem-canonical.", SourceRef: "/journal/a.md", Context: "journal:a"})
+	set.Add(DreamSignal{Source: SignalSourceJournal, Text: "Dreaming is off by default.", SourceRef: "/journal/b.md", Context: "journal:b"})
+	if got := set.Candidates(); len(got) != 2 {
+		t.Fatalf("candidates = %d, want 2 distinct facts", len(got))
+	}
+}
+
+// A blank/marker-only signal carries no durable content and is dropped.
+func TestDreamCandidateSetDropsEmptySignals(t *testing.T) {
+	set := NewDreamCandidateSet()
+	set.Add(DreamSignal{Source: SignalSourceJournal, Text: "   \n- \n#", SourceRef: "/journal/a.md"})
+	if got := set.Candidates(); len(got) != 0 {
+		t.Fatalf("candidates = %d, want 0 for an empty signal", len(got))
+	}
+}
+
+// Candidates are ordered by durability signal: more occurrences first, then more
+// distinct contexts.
+func TestDreamCandidatesOrderedByDurabilitySignal(t *testing.T) {
+	set := NewDreamCandidateSet()
+	// One occurrence.
+	set.Add(DreamSignal{Source: SignalSourceJournal, Text: "rare fact", SourceRef: "/journal/a.md", Context: "journal:a"})
+	// Three occurrences across three contexts.
+	for i, ref := range []string{"context:ws-a", "context:ws-b", "context:ws-c"} {
+		_ = i
+		set.Add(DreamSignal{Source: SignalSourceContext, Text: "recurring fact", SourceRef: ref, Context: "workspace:" + ref})
+	}
+	got := set.Candidates()
+	if len(got) != 2 {
+		t.Fatalf("candidates = %d, want 2", len(got))
+	}
+	if got[0].Occurrences != 3 {
+		t.Fatalf("first candidate occurrences = %d, want the 3× recurring fact first", got[0].Occurrences)
+	}
+}
+
+// Journal occurrences are file-granular: the same fact repeated within ONE day's
+// note counts once (one source unit), but the same fact on TWO different days is a
+// genuine recurrence (occurrences=2, two distinct date contexts). This is the
+// core durability invariant the promote phase will gate on.
+func TestExtractJournalSignalsFileGranularRecurrence(t *testing.T) {
+	const fact = "Daemon owns every notebook write through one in-process store."
+
+	// Same fact twice within a single day's note -> one source unit.
+	sameDay := "# 2026-06-10\n\n" + fact + "\n\n" + fact + "\n"
+	set := NewDreamCandidateSet()
+	for _, s := range ExtractJournalSignals("journal/2026-06-10.md", "2026-06-10", sameDay) {
+		set.Add(s)
+	}
+	got := set.Candidates()
+	if len(got) != 1 || got[0].Occurrences != 1 {
+		t.Fatalf("within-file repeat = %+v, want one candidate with occurrences=1 (file-granular)", got)
+	}
+
+	// Same fact on a second day -> a recurring candidate across two contexts.
+	for _, s := range ExtractJournalSignals("journal/2026-06-11.md", "2026-06-11", "# 2026-06-11\n\n"+fact+"\n") {
+		set.Add(s)
+	}
+	got = set.Candidates()
+	if len(got) != 1 {
+		t.Fatalf("candidates = %d, want 1 (same fact merges across days)", len(got))
+	}
+	if got[0].Occurrences != 2 || got[0].DistinctContexts() != 2 {
+		t.Fatalf("cross-day recurrence occurrences=%d contexts=%d, want 2/2", got[0].Occurrences, got[0].DistinctContexts())
+	}
+}
+
+// With equal occurrences, the candidate seen in more distinct contexts ranks
+// first (the recurrence-breadth tiebreaker).
+func TestDreamCandidatesDistinctContextTiebreaker(t *testing.T) {
+	set := NewDreamCandidateSet()
+	// "narrow": 2 occurrences, but both from the same context label.
+	set.Add(DreamSignal{Source: SignalSourceContext, Text: "narrow fact", SourceRef: "context:ws-a", Context: "workspace:ws-a"})
+	set.Add(DreamSignal{Source: SignalSourceContext, Text: "narrow fact", SourceRef: "context:ws-a-mirror", Context: "workspace:ws-a"})
+	// "broad": 2 occurrences across two distinct contexts.
+	set.Add(DreamSignal{Source: SignalSourceContext, Text: "broad fact", SourceRef: "context:ws-b", Context: "workspace:ws-b"})
+	set.Add(DreamSignal{Source: SignalSourceContext, Text: "broad fact", SourceRef: "context:ws-c", Context: "workspace:ws-c"})
+
+	got := set.Candidates()
+	if len(got) != 2 {
+		t.Fatalf("candidates = %d, want 2", len(got))
+	}
+	if got[0].Occurrences != got[1].Occurrences {
+		t.Fatalf("precondition: both candidates should have equal occurrences, got %d vs %d", got[0].Occurrences, got[1].Occurrences)
+	}
+	if got[0].DistinctContexts() != 2 {
+		t.Fatalf("with equal occurrences the broader-context candidate must rank first; got %+v", got)
+	}
+}
+
+// ExtractJournalSignals splits a journal body into block-level signals, skipping
+// the heading-only title and blocks below the minimum length, and grounds each
+// signal at the note path (root-absolute) with the date as the context label.
+func TestExtractJournalSignals(t *testing.T) {
+	body := "# 2026-06-10\n\n" +
+		"We split the dreaming PR along the deterministic versus LLM seam to keep it reviewable.\n\n" +
+		"Short.\n\n" +
+		"## A lone heading\n\n" +
+		"Harvest scans journals, context snapshots, and closed dispatches into candidates.\n"
+
+	sigs := ExtractJournalSignals("journal/2026-06-10.md", "2026-06-10", body)
+	if len(sigs) != 2 {
+		t.Fatalf("signals = %d, want 2 (heading-only and too-short blocks skipped): %+v", len(sigs), sigs)
+	}
+	for _, s := range sigs {
+		if s.SourceRef != "/journal/2026-06-10.md" {
+			t.Fatalf("source ref = %q, want root-absolute note path", s.SourceRef)
+		}
+		if s.Context != "journal:2026-06-10" {
+			t.Fatalf("context = %q, want journal:2026-06-10", s.Context)
+		}
+		if s.Seen != "2026-06-10" {
+			t.Fatalf("seen = %q, want the journal date", s.Seen)
+		}
+	}
+}
+
+func TestJournalDateFromPath(t *testing.T) {
+	cases := map[string]string{
+		"journal/2026-06-13.md":  "2026-06-13",
+		"/journal/2026-01-01.md": "2026-01-01",
+		"journal/notes.md":       "",
+		"journal/2026-6-1.md":    "",
+	}
+	for in, want := range cases {
+		if got := JournalDateFromPath(in); got != want {
+			t.Fatalf("JournalDateFromPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The seen-window is chronological, not lexical: a candidate merging a date-only
+// journal sighting, a UTC context sighting, and a dispatch sighting that carries a
+// local UTC offset must report the truly-earliest and truly-latest sightings. A
+// raw string compare would mis-pick the offset-bearing one (it sorts below a Z
+// timestamp it actually post-dates).
+func TestDreamCandidateSeenWindowIsChronological(t *testing.T) {
+	set := NewDreamCandidateSet()
+	const fact = "shared durable fact"
+	// 08:00Z added first so it seeds both bounds; the offset sighting is 09:00Z
+	// (chronologically latest) but sorts lexically below "…08:00:00Z".
+	set.Add(DreamSignal{Source: SignalSourceContext, Text: fact, SourceRef: "context:a", Context: "a", Seen: "2026-06-10T08:00:00Z"})
+	set.Add(DreamSignal{Source: SignalSourceJournal, Text: fact, SourceRef: "/journal/x.md", Context: "j", Seen: "2026-06-10"})
+	set.Add(DreamSignal{Source: SignalSourceDispatch, Text: fact, SourceRef: "dispatch:1", Context: "d", Seen: "2026-06-10T02:00:00-07:00"})
+
+	got := set.Candidates()
+	if len(got) != 1 {
+		t.Fatalf("candidates = %d, want 1", len(got))
+	}
+	if got[0].FirstSeen != "2026-06-10" {
+		t.Fatalf("FirstSeen = %q, want the date-only midnight (chronologically earliest)", got[0].FirstSeen)
+	}
+	if got[0].LastSeen != "2026-06-10T02:00:00-07:00" {
+		t.Fatalf("LastSeen = %q, want the offset sighting (09:00Z, chronologically latest)", got[0].LastSeen)
+	}
+}
+
+func TestBoundedSnippetClampsHugeSingleToken(t *testing.T) {
+	huge := strings.Repeat("x", 500_000) // one "word", far over the rune cap
+	got := boundedSnippet(huge)
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("a huge single token should be clamped with an ellipsis; got %d runes", len([]rune(got)))
+	}
+	// The clamped body (excluding the " …" suffix) must not exceed the rune cap.
+	body := strings.TrimSuffix(got, " …")
+	if n := len([]rune(body)); n > maxSnippetRunes {
+		t.Fatalf("clamped snippet body = %d runes, want <= %d", n, maxSnippetRunes)
+	}
+}
+
+func TestBoundedSnippetTruncatesAtWordBoundary(t *testing.T) {
+	words := make([]string, maxSnippetWords+50)
+	for i := range words {
+		words[i] = "w"
+	}
+	long := strings.Join(words, " ")
+	got := boundedSnippet(long)
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("expected an ellipsis suffix on a truncated snippet; got %q", got)
+	}
+	// maxSnippetWords words + the ellipsis token.
+	if n := len(strings.Fields(got)); n != maxSnippetWords+1 {
+		t.Fatalf("snippet word count = %d, want %d + ellipsis", n, maxSnippetWords)
+	}
+
+	short := "just a few words"
+	if got := boundedSnippet(short); got != short {
+		t.Fatalf("short snippet = %q, want unchanged %q", got, short)
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "107"
+const ProtocolVersion = "108"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -66,6 +66,8 @@ const (
 	CmdNotebookGuide                      = "notebook_guide"
 	CmdNotebookBacklinks                  = "notebook_backlinks"
 	CmdNotebookSendToChief                = "notebook_send_to_chief"
+	CmdNotebookDreamStatus                = "notebook_dream_status"
+	CmdNotebookDreamRun                   = "notebook_dream_run"
 	CmdUnregister                         = "unregister"
 	CmdState                              = "state"
 	CmdSetSessionResumeID                 = "set_session_resume_id"
@@ -499,6 +501,20 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdNotebookSendToChief:
 		var msg NotebookSendToChiefMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdNotebookDreamStatus:
+		var msg NotebookDreamStatusMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdNotebookDreamRun:
+		var msg NotebookDreamRunMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1758,6 +1758,90 @@ type NotebookChangedMessage struct {
 	Paths []string `json:"paths"`
 }
 
+type NotebookDreamCandidate struct {
+	// Contexts corresponds to the JSON schema field "contexts".
+	Contexts []string `json:"contexts"`
+
+	// FirstSeen corresponds to the JSON schema field "first_seen".
+	FirstSeen *string `json:"first_seen,omitempty,omitzero"`
+
+	// LastSeen corresponds to the JSON schema field "last_seen".
+	LastSeen *string `json:"last_seen,omitempty,omitzero"`
+
+	// Occurrences corresponds to the JSON schema field "occurrences".
+	Occurrences int `json:"occurrences"`
+
+	// SignalKey corresponds to the JSON schema field "signal_key".
+	SignalKey string `json:"signal_key"`
+
+	// Snippet corresponds to the JSON schema field "snippet".
+	Snippet string `json:"snippet"`
+
+	// Source corresponds to the JSON schema field "source".
+	Source string `json:"source"`
+
+	// Sources corresponds to the JSON schema field "sources".
+	Sources []string `json:"sources"`
+
+	// Title corresponds to the JSON schema field "title".
+	Title *string `json:"title,omitempty,omitzero"`
+}
+
+type NotebookDreamRunMessage struct {
+	// Apply corresponds to the JSON schema field "apply".
+	Apply *bool `json:"apply,omitempty,omitzero"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+}
+
+type NotebookDreamRunResult struct {
+	// Applied corresponds to the JSON schema field "applied".
+	Applied bool `json:"applied"`
+
+	// CandidateCount corresponds to the JSON schema field "candidate_count".
+	CandidateCount int `json:"candidate_count"`
+
+	// Candidates corresponds to the JSON schema field "candidates".
+	Candidates []NotebookDreamCandidate `json:"candidates"`
+
+	// MultiContextCount corresponds to the JSON schema field "multi_context_count".
+	MultiContextCount int `json:"multi_context_count"`
+
+	// SourceCounts corresponds to the JSON schema field "source_counts".
+	SourceCounts []NotebookDreamSourceCount `json:"source_counts"`
+}
+
+type NotebookDreamSourceCount struct {
+	// Count corresponds to the JSON schema field "count".
+	Count int `json:"count"`
+
+	// Source corresponds to the JSON schema field "source".
+	Source string `json:"source"`
+}
+
+type NotebookDreamStatusMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+}
+
+type NotebookDreamStatusResult struct {
+	// CandidateCount corresponds to the JSON schema field "candidate_count".
+	CandidateCount int `json:"candidate_count"`
+
+	// Enabled corresponds to the JSON schema field "enabled".
+	Enabled bool `json:"enabled"`
+
+	// MultiContextCount corresponds to the JSON schema field "multi_context_count".
+	MultiContextCount int `json:"multi_context_count"`
+
+	// SourceCounts corresponds to the JSON schema field "source_counts".
+	SourceCounts []NotebookDreamSourceCount `json:"source_counts"`
+
+	// Top corresponds to the JSON schema field "top".
+	Top []NotebookDreamCandidate `json:"top"`
+}
+
 type NotebookEntry struct {
 	// Kind corresponds to the JSON schema field "kind".
 	Kind *string `json:"kind,omitempty,omitzero"`
@@ -2590,6 +2674,13 @@ type Response struct {
 
 	// Error corresponds to the JSON schema field "error".
 	Error *string `json:"error,omitempty,omitzero"`
+
+	// NotebookDreamRun corresponds to the JSON schema field "notebook_dream_run".
+	NotebookDreamRun *NotebookDreamRunResult `json:"notebook_dream_run,omitempty,omitzero"`
+
+	// NotebookDreamStatus corresponds to the JSON schema field
+	// "notebook_dream_status".
+	NotebookDreamStatus *NotebookDreamStatusResult `json:"notebook_dream_status,omitempty,omitzero"`
 
 	// NotebookEntries corresponds to the JSON schema field "notebook_entries".
 	NotebookEntries []NotebookEntry `json:"notebook_entries,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -660,6 +660,18 @@ model NotebookGuideMessage {
   session_id?: string; // when set, session_is_chief reflects this session's role
 }
 
+// Dreaming inspection (phase one): a deterministic, LLM-free harvest surfaced
+// read-only. notebook_dream_status returns a summary; notebook_dream_run returns
+// the candidate preview. Neither writes durable memory.
+model NotebookDreamStatusMessage {
+  cmd: "notebook_dream_status";
+}
+
+model NotebookDreamRunMessage {
+  cmd: "notebook_dream_run";
+  apply?: boolean; // reserved for the promote pass; harvest is preview-only for now
+}
+
 model DelegateWorktreeRequest {
   repo?: string;
   branch: string;
@@ -1974,6 +1986,8 @@ model Response {
   notebook_read?: NotebookReadResult;
   notebook_write?: NotebookWriteResult;
   notebook_guide?: NotebookGuideResult;
+  notebook_dream_status?: NotebookDreamStatusResult;
+  notebook_dream_run?: NotebookDreamRunResult;
 }
 
 model DelegateResult {
@@ -2052,6 +2066,49 @@ model NotebookGuideResult {
   guidance: string;
   root: string;
   session_is_chief: boolean;
+}
+
+// One deduplicated dreaming harvest candidate. occurrences is the number of
+// distinct source units carrying the fact; contexts are the distinct context
+// labels (workspaces, journal dates) — recurrence across contexts is the
+// promote phase's strongest durability signal. sources are resolvable
+// provenance pointers; snippet is word-bounded.
+model NotebookDreamCandidate {
+  signal_key: string;
+  source: string;
+  title?: string;
+  snippet: string;
+  occurrences: int32;
+  contexts: string[];
+  sources: string[];
+  first_seen?: string;
+  last_seen?: string;
+}
+
+model NotebookDreamSourceCount {
+  source: string;
+  count: int32;
+}
+
+// Summary of what a dream would consolidate now. enabled reflects the
+// notebook.dreaming.enabled gate; multi_context_count is the subset of
+// candidates seen in more than one distinct context.
+model NotebookDreamStatusResult {
+  enabled: boolean;
+  candidate_count: int32;
+  multi_context_count: int32;
+  source_counts: NotebookDreamSourceCount[];
+  top: NotebookDreamCandidate[];
+}
+
+// Result of notebook_dream_run. applied is false in the preview-only phase (the
+// run wrote nothing); candidates is the bounded harvested preview.
+model NotebookDreamRunResult {
+  applied: boolean;
+  candidate_count: int32;
+  multi_context_count: int32;
+  source_counts: NotebookDreamSourceCount[];
+  candidates: NotebookDreamCandidate[];
 }
 
 // WS result events for the frontend's notebook reads (request/result pattern).


### PR DESCRIPTION
First of two dreaming PRs, split along the deterministic/LLM seam to keep each reviewable. **This half is the LLM-free harvest plus a read-only CLI to inspect it** — it writes nothing and runs nothing autonomously, so the harvest model is observable before anything acts on it.

## What it does
`attn notebook dream status` / `attn notebook dream [--dry-run]` show what a consolidation pass *would* keep, harvested from three v1 sources into deduplicated candidates ranked by recurrence:
- **journals** — block-level, file-granular dedup (a fact repeated in one day's note counts once; the same fact on another day is a genuine recurrence)
- **workspace-context** Decisions/Constraints — per workspace
- **closed dispatches** — chief-of-staff dispatches whose target session is gone

Candidates dedup by normalized content; `occurrences` counts distinct source units and distinct **contexts** measure recurrence (the durability signal the promote phase will gate on). Adds `notebook.dreaming.enabled` (default false) so status can report the gate; `--apply` is reserved for the promote phase. Protocol v107→108.

## Out of scope by design (follow-up PR-B)
Persistence of `.attn/dreams` state, the cron scheduler, single-flight locks, orphan recovery, and the gated LLM **promote** pass that writes durable memory.

## Tests
Notebook-level (merge/dedup/idempotency/ordering/extraction/snippet/timestamp), daemon-level (harvest across all three sources, closed-vs-live dispatch filter, oversized-journal skip, multi-context count, enabled gate, full unix-socket round-trip), and CLI print-format. Full Go suite + `go vet` + `tsc` green.

## Review
Ran an adversarial multi-lens review (correctness / integration / robustness / tests). 3 confirmed findings fixed here:
- skip oversized externally-synced journals (mirrors `Backlinks`/`List`)
- chronological (not lexical) `FirstSeen`/`LastSeen` so a dispatch's local-offset timestamp can't mis-bound the seen window
- byte/rune cap on snippets so one huge token can't bloat the preview
- behavioral coverage for the multi-context recurrence count

CI does not run on PRs to `feat/chifplace` (ci.yml triggers only on PRs to `main`); gate is the local Go + frontend suites.

🤖 Authored by Claude Code on behalf of Victor.