### PR TITLE
feat(notebook): dreaming scheduler + persistence + lock recovery (dreaming PR-B1)

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '108';
+export const PROTOCOL_VERSION = '109';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -2081,8 +2081,13 @@ export enum NotebookDreamStatusMessageCmd {
 export interface NotebookDreamStatusResult {
     candidate_count:     number;
     enabled:             boolean;
+    last_run_at?:        string;
     multi_context_count: number;
+    next_run_at?:        string;
+    persisted_count:     number;
+    schedule?:           string;
     source_counts:       SourceCountElement[];
+    timezone?:           string;
     top:                 CandidateElement[];
     [property: string]: any;
 }
@@ -2815,8 +2820,13 @@ export interface NotebookDreamRun {
 export interface NotebookDreamStatus {
     candidate_count:     number;
     enabled:             boolean;
+    last_run_at?:        string;
     multi_context_count: number;
+    next_run_at?:        string;
+    persisted_count:     number;
+    schedule?:           string;
     source_counts:       SourceCountElement[];
+    timezone?:           string;
     top:                 CandidateElement[];
     [property: string]: any;
 }
@@ -7436,8 +7446,13 @@ const typeMap: any = {
     "NotebookDreamStatusResult": o([
         { json: "candidate_count", js: "candidate_count", typ: 0 },
         { json: "enabled", js: "enabled", typ: true },
+        { json: "last_run_at", js: "last_run_at", typ: u(undefined, "") },
         { json: "multi_context_count", js: "multi_context_count", typ: 0 },
+        { json: "next_run_at", js: "next_run_at", typ: u(undefined, "") },
+        { json: "persisted_count", js: "persisted_count", typ: 0 },
+        { json: "schedule", js: "schedule", typ: u(undefined, "") },
         { json: "source_counts", js: "source_counts", typ: a(r("SourceCountElement")) },
+        { json: "timezone", js: "timezone", typ: u(undefined, "") },
         { json: "top", js: "top", typ: a(r("CandidateElement")) },
     ], "any"),
     "NotebookEntry": o([
@@ -7864,8 +7879,13 @@ const typeMap: any = {
     "NotebookDreamStatus": o([
         { json: "candidate_count", js: "candidate_count", typ: 0 },
         { json: "enabled", js: "enabled", typ: true },
+        { json: "last_run_at", js: "last_run_at", typ: u(undefined, "") },
         { json: "multi_context_count", js: "multi_context_count", typ: 0 },
+        { json: "next_run_at", js: "next_run_at", typ: u(undefined, "") },
+        { json: "persisted_count", js: "persisted_count", typ: 0 },
+        { json: "schedule", js: "schedule", typ: u(undefined, "") },
         { json: "source_counts", js: "source_counts", typ: a(r("SourceCountElement")) },
+        { json: "timezone", js: "timezone", typ: u(undefined, "") },
         { json: "top", js: "top", typ: a(r("CandidateElement")) },
     ], "any"),
     "NotebookGuide": o([

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -1283,9 +1283,34 @@ func printDreamCandidate(w io.Writer, cand protocol.NotebookDreamCandidate) {
 	}
 }
 
+// formatDreamTime renders a persisted RFC3339 timestamp in local time for
+// display, falling back to the raw string if it cannot be parsed.
+func formatDreamTime(s string) string {
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.Local().Format("2006-01-02 15:04")
+		}
+	}
+	return s
+}
+
 func printDreamStatus(w io.Writer, res *protocol.NotebookDreamStatusResult) {
 	fmt.Fprintf(w, "dreaming: %s\n", dreamEnabledLabel(res.Enabled))
-	fmt.Fprintf(w, "candidates: %d (%d across multiple contexts)\n", res.CandidateCount, res.MultiContextCount)
+	if sched := strings.TrimSpace(protocol.Deref(res.Schedule)); sched != "" {
+		line := "schedule: " + sched
+		if tz := strings.TrimSpace(protocol.Deref(res.Timezone)); tz != "" {
+			line += " (" + tz + ")"
+		}
+		if next := strings.TrimSpace(protocol.Deref(res.NextRunAt)); next != "" {
+			line += ", next run " + formatDreamTime(next)
+		}
+		fmt.Fprintln(w, line)
+	}
+	if last := strings.TrimSpace(protocol.Deref(res.LastRunAt)); last != "" {
+		fmt.Fprintf(w, "last run: %s\n", formatDreamTime(last))
+	}
+	fmt.Fprintf(w, "candidates: %d (%d across multiple contexts), %d persisted\n",
+		res.CandidateCount, res.MultiContextCount, res.PersistedCount)
 	printDreamSourceCounts(w, res.SourceCounts)
 	if len(res.Top) > 0 {
 		fmt.Fprintln(w, "top candidates:")

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -527,6 +527,11 @@ func TestPrintDreamStatus(t *testing.T) {
 		Enabled:           false,
 		CandidateCount:    3,
 		MultiContextCount: 1,
+		PersistedCount:    2,
+		Schedule:          protocol.Ptr("0 3 * * *"),
+		Timezone:          protocol.Ptr("America/New_York"),
+		NextRunAt:         protocol.Ptr("2026-06-15T07:00:00Z"),
+		LastRunAt:         protocol.Ptr("2026-06-14T07:00:00Z"),
 		SourceCounts: []protocol.NotebookDreamSourceCount{
 			{Source: "context", Count: 1},
 			{Source: "journal", Count: 2},
@@ -536,7 +541,13 @@ func TestPrintDreamStatus(t *testing.T) {
 		},
 	})
 	out := buf.String()
-	for _, want := range []string{"dreaming: disabled", "candidates: 3 (1 across multiple contexts)", "context:", "journal:", "[2× ·2 ctx]", "Daemon owns every notebook write."} {
+	for _, want := range []string{
+		"dreaming: disabled",
+		"schedule: 0 3 * * * (America/New_York), next run ",
+		"last run: ",
+		"candidates: 3 (1 across multiple contexts), 2 persisted",
+		"context:", "journal:", "[2× ·2 ctx]", "Daemon owns every notebook write.",
+	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("status output missing %q:\n%s", want, out)
 		}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require github.com/BurntSushi/toml v1.5.0
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/robfig/cron/v3 v3.0.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 h1:AgcIVYPa6XJnU3phs
 github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/victorarias/claude-agent-sdk-go v0.1.2-0.20260218145855-698f077a144c h1:Jfrj/udsu3FQ68Le4pAknK/dwlGkFj5CuTR619UgxEo=
 github.com/victorarias/claude-agent-sdk-go v0.1.2-0.20260218145855-698f077a144c/go.mod h1:jgle5NmNKHfdJHSWyJBx2KwQgzAcUBingOBFIttfOSc=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -192,6 +192,13 @@ type Daemon struct {
 	workspaceContextJanitorDebounce        time.Duration
 	workspaceContextJanitorTimeout         time.Duration
 	workspaceContextBeforeJanitorApply     func()
+
+	// Dreaming scheduler (notebook consolidation janitor). dreamMu guards the
+	// single-flight dreamRunning guard; dreamSchedulerInterval overrides the tick
+	// cadence in tests (zero = default).
+	dreamMu                sync.Mutex
+	dreamRunning           bool
+	dreamSchedulerInterval time.Duration
 }
 
 // addWarning adds a warning to be surfaced to the UI
@@ -668,6 +675,10 @@ func (d *Daemon) Start() error {
 
 	// Start branch monitoring
 	go d.monitorBranches()
+
+	// Start the dreaming consolidation scheduler (clears orphaned run locks, then
+	// runs the nightly harvest when due). Off unless notebook.dreaming.enabled.
+	go d.startDreamingScheduler(d.done)
 
 	d.signalStarted()
 	startSucceeded = true

--- a/internal/daemon/notebook_dreaming.go
+++ b/internal/daemon/notebook_dreaming.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/victorarias/attn/internal/notebook"
 	"github.com/victorarias/attn/internal/protocol"
@@ -32,16 +33,47 @@ const topDreamCandidates = 10
 // returns, so a large notebook can't produce an unbounded response.
 const maxDreamRunCandidates = 200
 
-// harvestDreamCandidates scans all three v1 sources into a merged candidate set.
-// It is read-only: callers decide what to do with the result (status summary,
-// dry-run preview). Failure to read any single source is logged and skipped — a
-// partial harvest is more useful than none, and the preview is advisory.
+// harvestDreamCandidates scans all three v1 sources into a fresh merged candidate
+// set. It is read-only: callers decide what to do with the result. Failure to read
+// any single source is logged and skipped — a partial harvest is more useful than
+// none, and the preview is advisory.
 func (d *Daemon) harvestDreamCandidates() (*notebook.DreamCandidateSet, error) {
-	store, err := d.notebookStoreFor()
-	if err != nil {
+	set := notebook.NewDreamCandidateSet()
+	if err := d.harvestInto(set); err != nil {
 		return nil, err
 	}
-	set := notebook.NewDreamCandidateSet()
+	return set, nil
+}
+
+// dreamHarvestUnion loads the persisted candidate set and merges a fresh harvest
+// into it, returning the union and how many candidates were already persisted
+// before the harvest. This is exactly what the next scheduled run would persist,
+// so status and dry-run preview the real accumulated state — not just what one
+// in-the-moment scan happens to see. It never writes; runDreamHarvest persists.
+func (d *Daemon) dreamHarvestUnion() (set *notebook.DreamCandidateSet, persisted int, err error) {
+	root, err := d.notebookRoot()
+	if err != nil {
+		return nil, 0, err
+	}
+	cands, err := notebook.LoadDreamCandidates(root)
+	if err != nil {
+		return nil, 0, err
+	}
+	set = notebook.LoadDreamCandidateSet(cands)
+	persisted = set.Len()
+	if err := d.harvestInto(set); err != nil {
+		return nil, 0, err
+	}
+	return set, persisted, nil
+}
+
+// harvestInto scans all three v1 sources into the supplied set, merging with
+// whatever it already holds (re-adding a known source ref is idempotent).
+func (d *Daemon) harvestInto(set *notebook.DreamCandidateSet) error {
+	store, err := d.notebookStoreFor()
+	if err != nil {
+		return err
+	}
 
 	// 1. Journals: each dated note's blocks (the raw system of record).
 	entries, err := store.List(notebook.DirJournal)
@@ -91,7 +123,7 @@ func (d *Daemon) harvestDreamCandidates() (*notebook.DreamCandidateSet, error) {
 		}
 	}
 
-	return set, nil
+	return nil
 }
 
 // contextDurableHeadings are the workspace-context sections whose bullets are
@@ -235,29 +267,65 @@ func dispatchDecisionText(req *protocol.DispatchDecisionRequest) string {
 }
 
 // dreamStatus returns a cheap summary of what a dream would consolidate now: the
-// gate flag, candidate totals (overall and recurring-across-contexts), per-source
-// counts, and the top candidates by durability signal.
+// gate flag, the persisted-plus-fresh candidate totals (overall and recurring-
+// across-contexts), per-source counts, the top candidates by durability signal,
+// and the schedule bracketing the nightly runs.
 func (d *Daemon) dreamStatus() (*protocol.NotebookDreamStatusResult, error) {
-	set, err := d.harvestDreamCandidates()
+	set, persisted, err := d.dreamHarvestUnion()
 	if err != nil {
 		return nil, err
 	}
 	candidates := set.Candidates()
 	res := &protocol.NotebookDreamStatusResult{
-		Enabled:           parseBooleanSetting(d.store.GetSetting(SettingNotebookDreamingEnabled)),
+		Enabled:           d.dreamingEnabled(),
 		CandidateCount:    len(candidates),
 		MultiContextCount: countMultiContext(candidates),
+		PersistedCount:    persisted,
 		SourceCounts:      sourceCounts(candidates),
 		Top:               toProtocolDreamCandidates(candidates, topDreamCandidates),
 	}
+	d.fillDreamSchedule(res)
 	return res, nil
+}
+
+// fillDreamSchedule populates the schedule/timezone/last-run/next-run fields from
+// the configured cron and persisted run state. A misconfigured frequency leaves
+// the schedule fields unset rather than failing the whole status.
+func (d *Daemon) fillDreamSchedule(res *protocol.NotebookDreamStatusResult) {
+	sched, raw, err := d.dreamingSchedule()
+	if err != nil {
+		return
+	}
+	loc := d.dreamingLocation()
+	res.Schedule = protocol.Ptr(raw)
+	res.Timezone = protocol.Ptr(loc.String())
+
+	root, err := d.notebookRoot()
+	if err != nil {
+		return
+	}
+	state, err := notebook.LoadDreamRunState(root)
+	if err != nil {
+		return
+	}
+	if state.LastRunAt != "" {
+		res.LastRunAt = protocol.Ptr(state.LastRunAt)
+	}
+	// Next run is computed from the persisted anchor, or from now when dreaming
+	// has never been anchored yet (its first run will land at the next slot).
+	anchor, ok := parseDreamTime(state.ScheduledFrom)
+	if !ok {
+		anchor = time.Now()
+	}
+	res.NextRunAt = protocol.Ptr(sched.Next(anchor.In(loc)).UTC().Format(time.RFC3339))
 }
 
 // dreamRun performs a harvest and returns the candidate preview. apply is
 // accepted for forward compatibility with the promote phase, but this phase is
-// preview-only: it always reports Applied=false and writes nothing.
+// preview-only: it always reports Applied=false and writes nothing. The nightly
+// scheduler is what persists; this command only previews the union.
 func (d *Daemon) dreamRun(apply bool) (*protocol.NotebookDreamRunResult, error) {
-	set, err := d.harvestDreamCandidates()
+	set, _, err := d.dreamHarvestUnion()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/notebook_dreaming_scheduler.go
+++ b/internal/daemon/notebook_dreaming_scheduler.go
@@ -1,0 +1,248 @@
+package daemon
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/victorarias/attn/internal/notebook"
+)
+
+// Dreaming scheduler — phase B1 (deterministic, no LLM).
+//
+// This file makes the dreaming pass RUN on a schedule and remember what it saw
+// across daemon restarts. A timezone-aware cron drives a nightly harvest that
+// merges into the persisted candidate set under .attn/dreams/; the LLM promote
+// pass that turns candidates into durable memory arrives in the follow-up PR.
+//
+// Lifecycle mirrors the workspace-context janitor: a single-flight guard so two
+// runs never overlap, a filesystem lock for crash auditability, and startup
+// recovery that clears a lock orphaned by a crashed run. The scheduler is a
+// ticker loop that asks, each tick, whether a run is due — granularity of a
+// minute is ample for a daily janitor and keeps catch-up logic trivial.
+
+const (
+	// defaultDreamingFrequency runs the pass nightly at 03:00 in the configured
+	// timezone — quiet hours, after a day's journals and dispatches have landed.
+	defaultDreamingFrequency = "0 3 * * *"
+
+	// defaultDreamSchedulerInterval is how often the scheduler checks whether a
+	// run is due. A daily janitor does not need finer granularity.
+	defaultDreamSchedulerInterval = time.Minute
+)
+
+// errDreamRunning signals that a dreaming run is already in progress; the
+// scheduler treats it as a benign skip rather than an error to log loudly.
+var errDreamRunning = errors.New("dreaming pass already running")
+
+// dreamingEnabled reports whether the notebook.dreaming.enabled gate is on.
+func (d *Daemon) dreamingEnabled() bool {
+	if d.store == nil {
+		return false
+	}
+	return parseBooleanSetting(d.store.GetSetting(SettingNotebookDreamingEnabled))
+}
+
+// dreamingFrequency returns the configured cron frequency or the default.
+func (d *Daemon) dreamingFrequency() string {
+	if d.store != nil {
+		if f := strings.TrimSpace(d.store.GetSetting(SettingNotebookDreamingFrequency)); f != "" {
+			return f
+		}
+	}
+	return defaultDreamingFrequency
+}
+
+// dreamingSchedule parses the configured frequency into a cron schedule, also
+// returning the raw expression for display/logging.
+func (d *Daemon) dreamingSchedule() (cron.Schedule, string, error) {
+	raw := d.dreamingFrequency()
+	sched, err := cron.ParseStandard(raw)
+	if err != nil {
+		return nil, raw, err
+	}
+	return sched, raw, nil
+}
+
+// dreamingLocation returns the configured IANA timezone, falling back to the
+// machine's local time when unset or unparseable (so a bad setting degrades to a
+// sensible default rather than disabling the scheduler).
+func (d *Daemon) dreamingLocation() *time.Location {
+	if d.store == nil {
+		return time.Local
+	}
+	tz := strings.TrimSpace(d.store.GetSetting(SettingNotebookDreamingTimezone))
+	if tz == "" {
+		return time.Local
+	}
+	if loc, err := time.LoadLocation(tz); err == nil {
+		return loc
+	}
+	d.logf("dreaming scheduler: invalid timezone %q, using local time", tz)
+	return time.Local
+}
+
+// parseDreamTime parses a persisted RFC3339 timestamp.
+func parseDreamTime(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// startDreamingScheduler clears any orphaned lock from a crashed run, then blocks
+// running the scheduler tick loop until done is closed. Intended to be launched in
+// its own goroutine from Start.
+//
+// Shutdown is by done alone (close(d.done) in Stop), like the daemon's other
+// d.done-driven loops; there is no explicit join. A harvest in flight when done
+// closes is not waited for, which is safe: state writes are atomic (temp+rename)
+// and a lock left by an abrupt stop is reclaimed by ClearOrphanDreamLocks on the
+// next start — the same crash path the lock is designed around.
+func (d *Daemon) startDreamingScheduler(done <-chan struct{}) {
+	if root, err := d.notebookRoot(); err == nil {
+		if n, err := notebook.ClearOrphanDreamLocks(root); err != nil {
+			d.logf("dreaming scheduler: clear orphan locks: %v", err)
+		} else if n > 0 {
+			d.logf("dreaming scheduler: cleared %d orphan dream lock(s)", n)
+		}
+	}
+
+	interval := d.dreamSchedulerInterval
+	if interval <= 0 {
+		interval = defaultDreamSchedulerInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			d.dreamSchedulerTick(time.Now())
+		}
+	}
+}
+
+// dreamSchedulerTick runs at most one harvest per tick, when the schedule says a
+// run is due. It is the unit-testable core of the scheduler: tests drive it with
+// synthetic times instead of waiting on a real ticker.
+//
+// Anchoring: the very FIRST observation with no persisted anchor records "now" and
+// returns, so enabling dreaming never fires an immediate harvest on daemon startup
+// — the first real run lands at the next scheduled slot. After that a run is due
+// once schedule.Next(anchor) has passed; the run advances the anchor to its
+// completion time.
+//
+// Catch-up semantics: several scheduled slots missed while the daemon was down (a
+// sleeping laptop) collapse into a SINGLE catch-up run on the next tick — not one
+// run per missed slot — because the anchor jumps forward to the run time. Two
+// nuances follow from anchoring on wall-clock time, both deliberate and benign for
+// this harvest-only phase (it writes idempotent machine state, no LLM): a wake
+// shortly BEFORE the day's slot runs the catch-up and then that slot when it
+// arrives; and re-enabling after a long disable performs one catch-up run (the
+// persisted anchor is stale), unlike a first-ever enable. The promote phase will
+// revisit whether either warrants suppression before attaching an LLM pass.
+func (d *Daemon) dreamSchedulerTick(now time.Time) {
+	if !d.dreamingEnabled() {
+		return
+	}
+	sched, raw, err := d.dreamingSchedule()
+	if err != nil {
+		d.logf("dreaming scheduler: invalid frequency %q: %v", raw, err)
+		return
+	}
+	root, err := d.notebookRoot()
+	if err != nil {
+		d.logf("dreaming scheduler: resolve root: %v", err)
+		return
+	}
+	state, err := notebook.LoadDreamRunState(root)
+	if err != nil {
+		d.logf("dreaming scheduler: load state: %v", err)
+		return
+	}
+
+	anchor, ok := parseDreamTime(state.ScheduledFrom)
+	if !ok {
+		// First enable (or a corrupt anchor): anchor at now so the first run lands
+		// at the next scheduled slot instead of immediately.
+		state.ScheduledFrom = now.UTC().Format(time.RFC3339)
+		if err := notebook.SaveDreamRunState(root, state); err != nil {
+			d.logf("dreaming scheduler: anchor schedule: %v", err)
+		}
+		return
+	}
+
+	loc := d.dreamingLocation()
+	next := sched.Next(anchor.In(loc))
+	if next.IsZero() {
+		// An unsatisfiable schedule has no next occurrence. Validation rejects these,
+		// but a value persisted by an older daemon could slip through — treat it as
+		// never-due rather than always-due (which would re-harvest every tick).
+		d.logf("dreaming scheduler: frequency %q never occurs; skipping", raw)
+		return
+	}
+	if next.After(now) {
+		return // not due yet
+	}
+	if _, err := d.runDreamHarvest(now); err != nil && !errors.Is(err, errDreamRunning) {
+		d.logf("dreaming scheduler: run: %v", err)
+	}
+}
+
+// runDreamHarvest performs one scheduled harvest: under a single-writer guard and
+// filesystem lock, it merges a fresh harvest into the persisted candidate set,
+// saves it, and advances the schedule anchor. This phase writes only machine state
+// under .attn/dreams/ — no durable memory and no LLM (that is the promote phase).
+func (d *Daemon) runDreamHarvest(now time.Time) (*notebook.DreamRunState, error) {
+	d.dreamMu.Lock()
+	if d.dreamRunning {
+		d.dreamMu.Unlock()
+		return nil, errDreamRunning
+	}
+	d.dreamRunning = true
+	d.dreamMu.Unlock()
+	defer func() {
+		d.dreamMu.Lock()
+		d.dreamRunning = false
+		d.dreamMu.Unlock()
+	}()
+
+	root, err := d.notebookRoot()
+	if err != nil {
+		return nil, err
+	}
+	release, err := notebook.AcquireDreamLock(root)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = release() }()
+
+	set, persisted, err := d.dreamHarvestUnion()
+	if err != nil {
+		return nil, err
+	}
+	candidates := set.Candidates()
+	if err := notebook.SaveDreamCandidates(root, candidates); err != nil {
+		return nil, err
+	}
+	state := notebook.DreamRunState{
+		ScheduledFrom:         now.UTC().Format(time.RFC3339),
+		LastRunAt:             now.UTC().Format(time.RFC3339),
+		LastRunNewCandidates:  len(candidates) - persisted,
+		LastRunCandidateCount: len(candidates),
+	}
+	if err := notebook.SaveDreamRunState(root, state); err != nil {
+		return nil, err
+	}
+	d.logf("dreaming: harvested %d candidates (%d new) into %s", len(candidates), len(candidates)-persisted, root)
+	return &state, nil
+}

--- a/internal/daemon/notebook_dreaming_scheduler_test.go
+++ b/internal/daemon/notebook_dreaming_scheduler_test.go
@@ -1,0 +1,471 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/notebook"
+)
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", s, err)
+	}
+	return parsed
+}
+
+// enableDreaming turns the gate on and pins the timezone to UTC so schedule math
+// in tests is independent of the machine's local time.
+func enableDreaming(t *testing.T, d *Daemon) {
+	t.Helper()
+	d.store.SetSetting(SettingNotebookDreamingEnabled, "true")
+	d.store.SetSetting(SettingNotebookDreamingTimezone, "UTC")
+}
+
+func dreamRoot(t *testing.T, d *Daemon) string {
+	t.Helper()
+	root, err := d.notebookRoot()
+	if err != nil {
+		t.Fatalf("notebook root: %v", err)
+	}
+	return root
+}
+
+// A disabled scheduler tick is fully inert: it neither anchors the schedule nor
+// harvests, so turning dreaming off leaves no machine state behind.
+func TestDreamSchedulerTickDisabledIsInert(t *testing.T) {
+	d := newNotebookDaemon(t)
+	appendDreamJournal(t, d, "2026-06-10", "A durable fact that would harvest if enabled.")
+
+	d.dreamSchedulerTick(mustTime(t, "2026-06-14T12:00:00Z"))
+
+	root := dreamRoot(t, d)
+	state, _ := notebook.LoadDreamRunState(root)
+	if state.ScheduledFrom != "" || state.LastRunAt != "" {
+		t.Fatalf("disabled tick wrote run state: %+v", state)
+	}
+	if cands, _ := notebook.LoadDreamCandidates(root); len(cands) != 0 {
+		t.Fatalf("disabled tick persisted %d candidates", len(cands))
+	}
+}
+
+// The first tick after enabling anchors the schedule at "now" and does NOT run —
+// so enabling dreaming never triggers an immediate harvest on daemon startup; the
+// first real run lands at the next scheduled slot.
+func TestDreamSchedulerTickFirstEnableAnchorsWithoutRunning(t *testing.T) {
+	d := newNotebookDaemon(t)
+	enableDreaming(t, d)
+	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
+
+	d.dreamSchedulerTick(mustTime(t, "2026-06-14T12:00:00Z"))
+
+	root := dreamRoot(t, d)
+	state, _ := notebook.LoadDreamRunState(root)
+	if state.ScheduledFrom == "" {
+		t.Fatal("first enable should anchor the schedule")
+	}
+	if state.LastRunAt != "" {
+		t.Fatalf("first enable must not run; got LastRunAt=%q", state.LastRunAt)
+	}
+	if cands, _ := notebook.LoadDreamCandidates(root); len(cands) != 0 {
+		t.Fatalf("first enable persisted %d candidates", len(cands))
+	}
+}
+
+// An anchored schedule whose next slot is still in the future does not run, and
+// leaves the anchor untouched.
+func TestDreamSchedulerTickNotDue(t *testing.T) {
+	d := newNotebookDaemon(t)
+	enableDreaming(t, d)
+	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
+	root := dreamRoot(t, d)
+
+	// Anchor at 04:00 UTC; the next "0 3 * * *" slot is the following day 03:00.
+	if err := notebook.SaveDreamRunState(root, notebook.DreamRunState{ScheduledFrom: "2026-06-14T04:00:00Z"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	d.dreamSchedulerTick(mustTime(t, "2026-06-14T05:00:00Z"))
+
+	state, _ := notebook.LoadDreamRunState(root)
+	if state.LastRunAt != "" {
+		t.Fatalf("not-due tick ran: %+v", state)
+	}
+	if state.ScheduledFrom != "2026-06-14T04:00:00Z" {
+		t.Fatalf("not-due tick mutated the anchor: %q", state.ScheduledFrom)
+	}
+}
+
+// A due schedule runs once, persisting the harvested candidates and advancing the
+// anchor; a second tick the same day does NOT run again — proving a laptop that
+// slept past several nightly slots catches up with exactly one run, not one per
+// missed slot.
+func TestDreamSchedulerTickDueRunsOnceWithCatchUp(t *testing.T) {
+	d := newNotebookDaemon(t)
+	enableDreaming(t, d)
+	appendDreamJournal(t, d, "2026-06-10", "A durable fact worth consolidating.")
+	root := dreamRoot(t, d)
+
+	// Anchor several days back: many 03:00 slots were missed (laptop asleep).
+	if err := notebook.SaveDreamRunState(root, notebook.DreamRunState{ScheduledFrom: "2026-06-10T03:00:00Z"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	now := mustTime(t, "2026-06-14T12:00:00Z")
+	d.dreamSchedulerTick(now)
+
+	state, _ := notebook.LoadDreamRunState(root)
+	if state.LastRunAt == "" {
+		t.Fatal("due tick should have run")
+	}
+	firstRun := state.LastRunAt
+	cands, _ := notebook.LoadDreamCandidates(root)
+	if len(cands) == 0 {
+		t.Fatal("due run should persist harvested candidates")
+	}
+	if state.LastRunCandidateCount != len(cands) {
+		t.Fatalf("run state count %d != persisted %d", state.LastRunCandidateCount, len(cands))
+	}
+
+	// One minute later the next slot is tomorrow's 03:00 → not due → no second run.
+	d.dreamSchedulerTick(now.Add(time.Minute))
+	state2, _ := notebook.LoadDreamRunState(root)
+	if state2.LastRunAt != firstRun {
+		t.Fatalf("catch-up fired twice: first=%q second=%q", firstRun, state2.LastRunAt)
+	}
+}
+
+// runDreamHarvest merges a fresh harvest into the persisted set: a re-run picks up
+// only genuinely new facts (idempotent on already-seen sources) and reports the
+// new-candidate delta.
+func TestRunDreamHarvestMergesPersisted(t *testing.T) {
+	d := newNotebookDaemon(t)
+	enableDreaming(t, d)
+	appendDreamJournal(t, d, "2026-06-10", "First durable fact about the harvest.")
+
+	first, err := d.runDreamHarvest(mustTime(t, "2026-06-14T03:00:00Z"))
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if first.LastRunNewCandidates == 0 || first.LastRunCandidateCount != first.LastRunNewCandidates {
+		t.Fatalf("first run should be all-new: %+v", first)
+	}
+
+	// Add one genuinely new fact, then re-run: only the new one counts as new, and
+	// the total grows by exactly that (the prior fact is not double-counted).
+	appendDreamJournal(t, d, "2026-06-11", "Second durable fact, distinct from the first.")
+	second, err := d.runDreamHarvest(mustTime(t, "2026-06-15T03:00:00Z"))
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if second.LastRunCandidateCount != first.LastRunCandidateCount+1 {
+		t.Fatalf("second run total = %d, want %d (one new fact merged)", second.LastRunCandidateCount, first.LastRunCandidateCount+1)
+	}
+	if second.LastRunNewCandidates != 1 {
+		t.Fatalf("second run new = %d, want exactly 1", second.LastRunNewCandidates)
+	}
+}
+
+// A run in progress (the in-memory single-flight guard) refuses a concurrent run.
+func TestRunDreamHarvestSingleFlight(t *testing.T) {
+	d := newNotebookDaemon(t)
+	enableDreaming(t, d)
+	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
+
+	d.dreamMu.Lock()
+	d.dreamRunning = true
+	d.dreamMu.Unlock()
+
+	if _, err := d.runDreamHarvest(mustTime(t, "2026-06-14T03:00:00Z")); !errors.Is(err, errDreamRunning) {
+		t.Fatalf("expected errDreamRunning, got %v", err)
+	}
+}
+
+// The filesystem lock blocks a run while held; clearing an orphaned lock (startup
+// recovery) unblocks the next run.
+func TestRunDreamHarvestFileLockAndRecovery(t *testing.T) {
+	d := newNotebookDaemon(t)
+	enableDreaming(t, d)
+	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
+	root := dreamRoot(t, d)
+
+	// Simulate a crashed run that left its lock behind (never released).
+	if _, err := notebook.AcquireDreamLock(root); err != nil {
+		t.Fatalf("seed orphan lock: %v", err)
+	}
+	if _, err := d.runDreamHarvest(mustTime(t, "2026-06-14T03:00:00Z")); err == nil {
+		t.Fatal("run should fail while the lock is held")
+	}
+
+	cleared, err := notebook.ClearOrphanDreamLocks(root)
+	if err != nil || cleared != 1 {
+		t.Fatalf("orphan recovery: cleared=%d err=%v", cleared, err)
+	}
+	if _, err := d.runDreamHarvest(mustTime(t, "2026-06-14T03:05:00Z")); err != nil {
+		t.Fatalf("run should succeed after recovery: %v", err)
+	}
+}
+
+// dreamStatus surfaces the schedule, timezone, last/next run, and persisted count
+// once a run has happened.
+func TestDreamStatusSurfacesSchedule(t *testing.T) {
+	d := newNotebookDaemon(t)
+	enableDreaming(t, d)
+	appendDreamJournal(t, d, "2026-06-10", "A durable fact worth consolidating.")
+
+	if _, err := d.runDreamHarvest(mustTime(t, "2026-06-14T03:00:00Z")); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	res, err := d.dreamStatus()
+	if err != nil {
+		t.Fatalf("dreamStatus: %v", err)
+	}
+	if res.Schedule == nil || *res.Schedule != defaultDreamingFrequency {
+		t.Fatalf("schedule = %v, want %q", res.Schedule, defaultDreamingFrequency)
+	}
+	if res.Timezone == nil || *res.Timezone != "UTC" {
+		t.Fatalf("timezone = %v, want UTC", res.Timezone)
+	}
+	if res.LastRunAt == nil || res.NextRunAt == nil {
+		t.Fatalf("expected last/next run set: last=%v next=%v", res.LastRunAt, res.NextRunAt)
+	}
+	// The run anchored at 2026-06-14T03:00:00Z; the next "0 3 * * *" UTC slot is the
+	// following day. Asserting the exact value pins that next_run is computed from
+	// the persisted anchor (and timezone), not merely non-nil.
+	if *res.NextRunAt != "2026-06-15T03:00:00Z" {
+		t.Fatalf("next_run = %q, want 2026-06-15T03:00:00Z", *res.NextRunAt)
+	}
+	if res.PersistedCount == 0 {
+		t.Fatal("expected persisted candidates after a run")
+	}
+}
+
+// Before any run/anchor, status still computes a next_run (from "now") rather than
+// panicking or leaving it unset — covering fillDreamSchedule's never-anchored path.
+func TestDreamStatusNextRunBeforeFirstRun(t *testing.T) {
+	d := newNotebookDaemon(t)
+	enableDreaming(t, d)
+	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
+
+	res, err := d.dreamStatus()
+	if err != nil {
+		t.Fatalf("dreamStatus: %v", err)
+	}
+	if res.LastRunAt != nil {
+		t.Fatalf("no run has happened, last_run should be unset: %v", res.LastRunAt)
+	}
+	if res.NextRunAt == nil {
+		t.Fatal("next_run should be computed even before the first run")
+	}
+	next, err := time.Parse(time.RFC3339, *res.NextRunAt)
+	if err != nil {
+		t.Fatalf("next_run not a timestamp: %q", *res.NextRunAt)
+	}
+	if !next.After(time.Now()) {
+		t.Fatalf("next_run %s should be in the future", next)
+	}
+}
+
+// The configured timezone genuinely flips the due decision: the same anchor and
+// "now" produce opposite verdicts under different zones. A scheduler that dropped
+// the timezone conversion (computing everything in one fixed zone) would fail at
+// least one direction of this table.
+func TestDreamSchedulerTickTimezoneAffectsDueDecision(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		tz      string
+		anchor  string
+		now     string
+		wantRun bool
+	}{
+		// 04:00Z = 00:00 EDT; next 03:00 EDT slot is 07:00Z, before now 08:30Z → due
+		// in New York, but the next 03:00 UTC slot is the following day → not due.
+		{"NewYork due", "America/New_York", "2026-06-14T04:00:00Z", "2026-06-14T08:30:00Z", true},
+		{"UTC not due (same instants)", "UTC", "2026-06-14T04:00:00Z", "2026-06-14T08:30:00Z", false},
+		// Mirror: 03:00 UTC slot is at 03:00Z ≤ now 04:00Z → due in UTC, but the next
+		// 03:00 EDT slot is 07:00Z → not due in New York.
+		{"UTC due", "UTC", "2026-06-14T01:00:00Z", "2026-06-14T04:00:00Z", true},
+		{"NewYork not due (same instants)", "America/New_York", "2026-06-14T01:00:00Z", "2026-06-14T04:00:00Z", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newNotebookDaemon(t)
+			d.store.SetSetting(SettingNotebookDreamingEnabled, "true")
+			d.store.SetSetting(SettingNotebookDreamingTimezone, tc.tz)
+			appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
+			root := dreamRoot(t, d)
+			if err := notebook.SaveDreamRunState(root, notebook.DreamRunState{ScheduledFrom: tc.anchor}); err != nil {
+				t.Fatalf("seed state: %v", err)
+			}
+
+			d.dreamSchedulerTick(mustTime(t, tc.now))
+
+			state, _ := notebook.LoadDreamRunState(root)
+			if ran := state.LastRunAt != ""; ran != tc.wantRun {
+				t.Fatalf("tz=%s anchor=%s now=%s: ran=%v want=%v", tc.tz, tc.anchor, tc.now, ran, tc.wantRun)
+			}
+		})
+	}
+}
+
+// A frequency that never occurs (validation normally rejects it, but an older
+// daemon could have persisted one) must be treated as never-due, not always-due —
+// otherwise every tick would re-harvest. Set the raw setting directly to bypass
+// validation, then tick twice and assert nothing ran.
+func TestDreamSchedulerUnsatisfiableFrequencyDoesNotRun(t *testing.T) {
+	d := newNotebookDaemon(t)
+	enableDreaming(t, d)
+	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
+	d.store.SetSetting(SettingNotebookDreamingFrequency, "0 0 30 2 *") // Feb 30 — never occurs
+	root := dreamRoot(t, d)
+	if err := notebook.SaveDreamRunState(root, notebook.DreamRunState{ScheduledFrom: "2026-06-10T03:00:00Z"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	d.dreamSchedulerTick(mustTime(t, "2026-06-14T12:00:00Z"))
+	d.dreamSchedulerTick(mustTime(t, "2026-06-14T12:01:00Z"))
+
+	if state, _ := notebook.LoadDreamRunState(root); state.LastRunAt != "" {
+		t.Fatalf("an unsatisfiable frequency must never be due, but a run happened: %+v", state)
+	}
+}
+
+// Documented catch-up nuance: when the daemon wakes shortly BEFORE the day's slot
+// after missing several nights, the missed slots collapse into one catch-up run
+// now, and the day's own slot then runs when it arrives. Two runs, by design — this
+// pins that behavior so it cannot regress silently in either direction.
+func TestDreamSchedulerCatchUpBeforeSlotAlsoRunsTheSlot(t *testing.T) {
+	d := newNotebookDaemon(t)
+	enableDreaming(t, d) // UTC
+	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
+	root := dreamRoot(t, d)
+	if err := notebook.SaveDreamRunState(root, notebook.DreamRunState{ScheduledFrom: "2026-06-10T03:00:00Z"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	// 02:00, before today's 03:00 slot: one catch-up run for the missed nights.
+	d.dreamSchedulerTick(mustTime(t, "2026-06-14T02:00:00Z"))
+	s1, _ := notebook.LoadDreamRunState(root)
+	if s1.LastRunAt == "" {
+		t.Fatal("missed nights should trigger a catch-up run")
+	}
+	catchUp := s1.LastRunAt
+
+	// 02:30, still before the slot: anchor advanced to 02:00 → not due again.
+	d.dreamSchedulerTick(mustTime(t, "2026-06-14T02:30:00Z"))
+	s2, _ := notebook.LoadDreamRunState(root)
+	if s2.LastRunAt != catchUp {
+		t.Fatalf("catch-up must not repeat before the slot: %q -> %q", catchUp, s2.LastRunAt)
+	}
+
+	// 03:00:30, today's scheduled slot arrives → the documented second run.
+	d.dreamSchedulerTick(mustTime(t, "2026-06-14T03:00:30Z"))
+	s3, _ := notebook.LoadDreamRunState(root)
+	if s3.LastRunAt == catchUp {
+		t.Fatal("today's scheduled slot should run after the pre-slot catch-up")
+	}
+
+	// 03:01:30, no further runs today.
+	d.dreamSchedulerTick(mustTime(t, "2026-06-14T03:01:30Z"))
+	s4, _ := notebook.LoadDreamRunState(root)
+	if s4.LastRunAt != s3.LastRunAt {
+		t.Fatalf("the slot run must not repeat: %q -> %q", s3.LastRunAt, s4.LastRunAt)
+	}
+}
+
+// The scheduler goroutine actually ticks at its configured interval (exercising
+// dreamSchedulerInterval) and returns promptly when its done channel closes.
+func TestDreamSchedulerGoroutineRunsAndStops(t *testing.T) {
+	d := newNotebookDaemon(t)
+	enableDreaming(t, d)
+	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
+	root := dreamRoot(t, d)
+	// Anchor in the past relative to the real clock so the first tick is due
+	// regardless of when the test runs.
+	if err := notebook.SaveDreamRunState(root, notebook.DreamRunState{
+		ScheduledFrom: time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	d.dreamSchedulerInterval = 5 * time.Millisecond
+
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() { d.startDreamingScheduler(done); close(stopped) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if state, _ := notebook.LoadDreamRunState(root); state.LastRunAt != "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("scheduler goroutine did not run within timeout")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	close(done)
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler goroutine did not stop after done closed")
+	}
+}
+
+func TestDreamingLocation(t *testing.T) {
+	d := newNotebookDaemon(t)
+	if got := d.dreamingLocation(); got != time.Local {
+		t.Fatalf("default location = %v, want local", got)
+	}
+	d.store.SetSetting(SettingNotebookDreamingTimezone, "America/New_York")
+	if got := d.dreamingLocation(); got.String() != "America/New_York" {
+		t.Fatalf("configured location = %v, want America/New_York", got)
+	}
+	d.store.SetSetting(SettingNotebookDreamingTimezone, "Not/ARealZone")
+	if got := d.dreamingLocation(); got != time.Local {
+		t.Fatalf("invalid location should fall back to local, got %v", got)
+	}
+}
+
+func TestValidateDreamingSettings(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"empty frequency ok", "", false},
+		{"valid cron", "0 3 * * *", false},
+		{"valid every-minute cron", "* * * * *", false},
+		{"descriptor ok", "@daily", false},
+		{"garbage cron", "not a cron", true},
+		{"too few fields", "0 3 * *", true},
+		{"impossible date (Feb 30) rejected", "0 0 30 2 *", true},
+		{"embedded CRON_TZ rejected", "CRON_TZ=Asia/Tokyo 0 3 * * *", true},
+		{"embedded TZ rejected", "TZ=Asia/Tokyo 0 3 * * *", true},
+	} {
+		t.Run("frequency/"+tc.name, func(t *testing.T) {
+			if err := validateNotebookDreamingFrequency(tc.value); (err != nil) != tc.wantErr {
+				t.Fatalf("validate %q err=%v wantErr=%v", tc.value, err, tc.wantErr)
+			}
+		})
+	}
+	for _, tc := range []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"empty tz ok", "", false},
+		{"valid IANA", "America/New_York", false},
+		{"utc", "UTC", false},
+		{"garbage tz", "Not/ARealZone", true},
+	} {
+		t.Run("timezone/"+tc.name, func(t *testing.T) {
+			if err := validateNotebookDreamingTimezone(tc.value); (err != nil) != tc.wantErr {
+				t.Fatalf("validate %q err=%v wantErr=%v", tc.value, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/robfig/cron/v3"
 	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
@@ -43,9 +45,14 @@ const (
 	SettingNotebookRoot = "notebook.root"
 	// SettingNotebookDreamingEnabled gates the nightly dreaming consolidation
 	// pass. Default false; `attn notebook dream status`/`--dry-run` inspect the
-	// harvest regardless (the gate only governs autonomous runs). The scheduler
-	// that consumes it lands with the promote phase.
+	// harvest regardless (the gate only governs autonomous runs).
 	SettingNotebookDreamingEnabled = "notebook.dreaming.enabled"
+	// SettingNotebookDreamingFrequency is the 5-field cron expression for the
+	// nightly pass. Empty => the default ("0 3 * * *").
+	SettingNotebookDreamingFrequency = "notebook.dreaming.frequency"
+	// SettingNotebookDreamingTimezone is the IANA timezone the frequency is
+	// evaluated in. Empty => the machine's local time.
+	SettingNotebookDreamingTimezone = "notebook.dreaming.timezone"
 )
 
 func (d *Daemon) handleGetSettingsWS(client *wsClient) {
@@ -247,6 +254,10 @@ func (d *Daemon) validateSetting(key, value string) error {
 		return validateNotebookRoot(value)
 	case SettingNotebookDreamingEnabled:
 		return validateBooleanSetting(value)
+	case SettingNotebookDreamingFrequency:
+		return validateNotebookDreamingFrequency(value)
+	case SettingNotebookDreamingTimezone:
+		return validateNotebookDreamingTimezone(value)
 	case SettingKeybindingsConfig:
 		return validateKeybindingsConfig(value)
 	case SettingReviewLoopPresets, SettingReviewLoopLastPreset, SettingReviewLoopLastPrompt, SettingReviewLoopLastIterations, SettingReviewLoopModel, SettingReviewerModel:
@@ -315,6 +326,49 @@ func validateNotebookRoot(value string) error {
 	clean := filepath.Clean(path)
 	if clean == dataDir || strings.HasPrefix(clean, dataDir+string(filepath.Separator)) {
 		return fmt.Errorf("notebook.root must be outside the attn data dir (%s)", dataDir)
+	}
+	return nil
+}
+
+// validateNotebookDreamingFrequency accepts an empty value (use the default) or a
+// cron expression the scheduler can fire. It rejects two parseable-but-wrong
+// forms: an embedded CRON_TZ=/TZ= prefix (a second timezone source that would
+// silently compete with notebook.dreaming.timezone) and a schedule whose date can
+// never occur (e.g. "0 0 30 2 *", Feb 30) — robfig cron returns the zero time for
+// those, which the scheduler would treat as perpetually due and re-harvest in a
+// tight loop.
+func validateNotebookDreamingFrequency(value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	if hasCronTZPrefix(trimmed) {
+		return fmt.Errorf("notebook.dreaming.frequency must not embed a CRON_TZ=/TZ= prefix; set notebook.dreaming.timezone instead")
+	}
+	sched, err := cron.ParseStandard(trimmed)
+	if err != nil {
+		return fmt.Errorf("notebook.dreaming.frequency must be a cron expression (5 fields, or a descriptor like @daily): %w", err)
+	}
+	if sched.Next(time.Now()).IsZero() {
+		return fmt.Errorf("notebook.dreaming.frequency %q describes a time that never occurs", trimmed)
+	}
+	return nil
+}
+
+// hasCronTZPrefix reports whether a cron string carries a leading TZ=/CRON_TZ=
+// timezone prefix (the form robfig/cron's ParseStandard honors).
+func hasCronTZPrefix(expr string) bool {
+	return strings.HasPrefix(expr, "TZ=") || strings.HasPrefix(expr, "CRON_TZ=")
+}
+
+// validateNotebookDreamingTimezone accepts an empty value (local time) or an IANA
+// timezone name loadable on this machine.
+func validateNotebookDreamingTimezone(value string) error {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	if _, err := time.LoadLocation(strings.TrimSpace(value)); err != nil {
+		return fmt.Errorf("notebook.dreaming.timezone must be an IANA timezone: %w", err)
 	}
 	return nil
 }

--- a/internal/notebook/dreams.go
+++ b/internal/notebook/dreams.go
@@ -109,6 +109,28 @@ func NewDreamCandidateSet() *DreamCandidateSet {
 	return &DreamCandidateSet{byKey: make(map[string]*DreamCandidate)}
 }
 
+// LoadDreamCandidateSet rebuilds a set from previously persisted candidates so a
+// run can merge fresh signals into the accumulated state. Re-adding a signal whose
+// SourceRef is already recorded is idempotent, so re-harvesting the same source
+// into a loaded set never inflates a candidate's occurrence count. Candidates with
+// no SignalKey or a duplicate key (corrupt state) are skipped.
+func LoadDreamCandidateSet(cands []DreamCandidate) *DreamCandidateSet {
+	s := NewDreamCandidateSet()
+	for i := range cands {
+		key := strings.TrimSpace(cands[i].SignalKey)
+		if key == "" {
+			continue
+		}
+		if _, ok := s.byKey[key]; ok {
+			continue
+		}
+		c := cands[i]
+		s.byKey[key] = &c
+		s.order = append(s.order, key)
+	}
+	return s
+}
+
 // Add merges one signal into the set. A signal whose text is blank (after
 // normalization) is ignored. Re-adding the same SourceRef is idempotent, so a
 // scanner may safely re-scan a source without inflating Occurrences.

--- a/internal/notebook/dreams_state.go
+++ b/internal/notebook/dreams_state.go
@@ -1,0 +1,194 @@
+package notebook
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Dreaming machine state.
+//
+// The dreaming pass persists its working state under <root>/.attn/dreams/ as
+// plain JSON — self-describing and git-diffable. This is MACHINE state, not a
+// notebook document: it lives in the .attn dotdir (skipped by List and by any
+// dotfile-aware external sync scanner) and never goes through Store.Write, whose
+// CleanPath rejects dotdir and non-.md paths. The state files are:
+//
+//	candidates.json  — the accumulated harvest candidate set (grows monotonically;
+//	                   harvest only ever merges, never prunes — compaction is a
+//	                   separate, deferred op)
+//	state.json       — run bookkeeping: the schedule anchor + last-run summary
+//	locks/dream.lock — single-writer lock held for the duration of a run
+//	runs/            — reserved for the promote phase's dated run reports
+//
+// All writes reuse the package's atomic temp+rename writer so a crash mid-write
+// never leaves a half-written state file.
+
+const (
+	dreamsDir            = "dreams"
+	dreamsCandidatesFile = "candidates.json"
+	dreamsStateFile      = "state.json"
+	dreamsLocksDir       = "locks"
+	dreamsLockFile       = "dream.lock"
+
+	// dreamStateVersion tags persisted state so a future format change can be
+	// detected and migrated rather than silently mis-read.
+	dreamStateVersion = 1
+)
+
+// DreamsStateDir returns the absolute .attn/dreams directory for a notebook root.
+func DreamsStateDir(root string) string {
+	return filepath.Join(root, machineDir, dreamsDir)
+}
+
+// DreamRunState is the persisted run bookkeeping for the dreaming pass. It is
+// deliberately small and separate from candidates.json so the (potentially large)
+// candidate list and the tiny run metadata are written independently.
+type DreamRunState struct {
+	Version int `json:"version"`
+	// ScheduledFrom is the anchor the next run is computed from (RFC3339, UTC):
+	// set to "now" on the first enable (so the first run lands at the next
+	// scheduled slot, not at daemon startup) and advanced to the run time after
+	// each completed run. A run is due when schedule.Next(ScheduledFrom) has passed;
+	// because the anchor jumps forward to the run time, slots missed while the
+	// daemon was down collapse into a single catch-up run. See dreamSchedulerTick
+	// for the full catch-up semantics (and its two deliberate wall-clock nuances).
+	ScheduledFrom string `json:"scheduled_from,omitempty"`
+	// LastRunAt is when the last harvest run completed (RFC3339, UTC; display).
+	LastRunAt string `json:"last_run_at,omitempty"`
+	// LastRunNewCandidates is how many candidates that run added that were not
+	// already persisted.
+	LastRunNewCandidates int `json:"last_run_new_candidates"`
+	// LastRunCandidateCount is the total persisted candidate count after that run.
+	LastRunCandidateCount int `json:"last_run_candidate_count"`
+}
+
+// LoadDreamCandidates reads the persisted candidate set. A missing file is not an
+// error — it means no run has persisted candidates yet — and yields an empty set.
+func LoadDreamCandidates(root string) ([]DreamCandidate, error) {
+	path := filepath.Join(DreamsStateDir(root), dreamsCandidatesFile)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var cands []DreamCandidate
+	if err := json.Unmarshal(data, &cands); err != nil {
+		return nil, fmt.Errorf("notebook: parse %s: %w", dreamsCandidatesFile, err)
+	}
+	return cands, nil
+}
+
+// SaveDreamCandidates writes the candidate set atomically.
+func SaveDreamCandidates(root string, cands []DreamCandidate) error {
+	if cands == nil {
+		cands = []DreamCandidate{}
+	}
+	data, err := json.MarshalIndent(cands, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeAtomic(filepath.Join(DreamsStateDir(root), dreamsCandidatesFile), data)
+}
+
+// LoadDreamRunState reads the run bookkeeping. A missing file yields the zero
+// value (no run has happened yet), not an error.
+func LoadDreamRunState(root string) (DreamRunState, error) {
+	path := filepath.Join(DreamsStateDir(root), dreamsStateFile)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return DreamRunState{}, nil
+	}
+	if err != nil {
+		return DreamRunState{}, err
+	}
+	var state DreamRunState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return DreamRunState{}, fmt.Errorf("notebook: parse %s: %w", dreamsStateFile, err)
+	}
+	return state, nil
+}
+
+// SaveDreamRunState writes the run bookkeeping atomically, stamping the current
+// format version.
+func SaveDreamRunState(root string, state DreamRunState) error {
+	state.Version = dreamStateVersion
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeAtomic(filepath.Join(DreamsStateDir(root), dreamsStateFile), data)
+}
+
+// dreamLockInfo records who holds the dream lock, for crash auditability.
+type dreamLockInfo struct {
+	PID      int    `json:"pid"`
+	Acquired string `json:"acquired"`
+}
+
+// AcquireDreamLock takes the single-writer dream lock by creating
+// locks/dream.lock exclusively. It returns a release func that removes the lock;
+// release is idempotent. If the lock already exists the call fails — the caller
+// must treat that as "a run is already in progress" (startup orphan recovery
+// clears a lock left behind by a crashed run).
+func AcquireDreamLock(root string) (release func() error, err error) {
+	dir := filepath.Join(DreamsStateDir(root), dreamsLocksDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	lockPath := filepath.Join(dir, dreamsLockFile)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("notebook: dream lock already held at %s", lockPath)
+		}
+		return nil, err
+	}
+	info, _ := json.Marshal(dreamLockInfo{PID: os.Getpid(), Acquired: time.Now().UTC().Format(time.RFC3339)})
+	_, _ = f.Write(info)
+	_ = f.Close()
+
+	released := false
+	return func() error {
+		if released {
+			return nil
+		}
+		released = true
+		return os.Remove(lockPath)
+	}, nil
+}
+
+// ClearOrphanDreamLocks removes any lock files left under locks/. For every
+// supported configuration this is safe: the daemon is a process singleton (the PID
+// lock kills any prior daemon on startup) and the notebook root is per-profile (the
+// default root is profile-namespaced), so a lock present at startup is necessarily
+// orphaned by a crashed run. The one way to defeat this is unsupported — pointing
+// two profiles' daemons at one EXPLICIT notebook.root, where startup recovery could
+// clear the other daemon's live lock. The lock records its holder PID for auditing
+// if that ever needs hardening into a liveness check. Returns how many lock files
+// were removed; a missing locks dir is not an error.
+func ClearOrphanDreamLocks(root string) (int, error) {
+	dir := filepath.Join(DreamsStateDir(root), dreamsLocksDir)
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	cleared := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, e.Name())); err == nil {
+			cleared++
+		}
+	}
+	return cleared, nil
+}

--- a/internal/notebook/dreams_state_test.go
+++ b/internal/notebook/dreams_state_test.go
@@ -1,0 +1,163 @@
+package notebook
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDreamCandidatesRoundTrip(t *testing.T) {
+	root := t.TempDir()
+
+	// Missing file reads as an empty set, not an error.
+	got, err := LoadDreamCandidates(root)
+	if err != nil {
+		t.Fatalf("load missing: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty, got %d", len(got))
+	}
+
+	want := []DreamCandidate{
+		{SignalKey: "k1", Source: "journal", Snippet: "a fact", Sources: []string{"/journal/2026-06-13.md"}, Contexts: []string{"journal:2026-06-13"}, Occurrences: 1},
+		{SignalKey: "k2", Source: "context", Snippet: "another", Sources: []string{"context:ws-a", "context:ws-b"}, Contexts: []string{"workspace:ws-a", "workspace:ws-b"}, Occurrences: 2},
+	}
+	if err := SaveDreamCandidates(root, want); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err = LoadDreamCandidates(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(got) != 2 || got[0].SignalKey != "k1" || got[1].Occurrences != 2 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	// The state lives under the .attn dreams dir, never as a surfaced note.
+	if _, err := os.Stat(filepath.Join(DreamsStateDir(root), dreamsCandidatesFile)); err != nil {
+		t.Fatalf("candidates file not written: %v", err)
+	}
+}
+
+func TestDreamRunStateRoundTrip(t *testing.T) {
+	root := t.TempDir()
+
+	zero, err := LoadDreamRunState(root)
+	if err != nil {
+		t.Fatalf("load missing: %v", err)
+	}
+	if zero.ScheduledFrom != "" || zero.LastRunAt != "" {
+		t.Fatalf("expected zero state, got %+v", zero)
+	}
+
+	if err := SaveDreamRunState(root, DreamRunState{
+		ScheduledFrom:         "2026-06-14T03:00:00Z",
+		LastRunAt:             "2026-06-14T03:00:00Z",
+		LastRunNewCandidates:  3,
+		LastRunCandidateCount: 10,
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := LoadDreamRunState(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.Version != dreamStateVersion {
+		t.Fatalf("expected version stamped to %d, got %d", dreamStateVersion, got.Version)
+	}
+	if got.LastRunCandidateCount != 10 || got.LastRunNewCandidates != 3 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+}
+
+func TestDreamLockSingleFlightAndRecovery(t *testing.T) {
+	root := t.TempDir()
+
+	release, err := AcquireDreamLock(root)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	// A second acquire while held must fail (single writer).
+	if _, err := AcquireDreamLock(root); err == nil {
+		t.Fatal("expected second acquire to fail while lock is held")
+	}
+
+	if err := release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	// Release is idempotent.
+	if err := release(); err != nil {
+		t.Fatalf("second release should be a no-op: %v", err)
+	}
+
+	// After release the lock is free again.
+	release2, err := AcquireDreamLock(root)
+	if err != nil {
+		t.Fatalf("re-acquire after release: %v", err)
+	}
+	_ = release2()
+}
+
+func TestClearOrphanDreamLocks(t *testing.T) {
+	root := t.TempDir()
+
+	// No locks dir yet → nothing to clear, no error.
+	if n, err := ClearOrphanDreamLocks(root); err != nil || n != 0 {
+		t.Fatalf("clear empty: n=%d err=%v", n, err)
+	}
+
+	// A lock left behind by a crashed run is orphaned: clear it, then the lock is
+	// re-acquirable (proving recovery unblocks the next scheduled run).
+	if _, err := AcquireDreamLock(root); err != nil {
+		t.Fatalf("acquire (simulating crash that never released): %v", err)
+	}
+	if _, err := AcquireDreamLock(root); err == nil {
+		t.Fatal("sanity: lock should still be held before recovery")
+	}
+	n, err := ClearOrphanDreamLocks(root)
+	if err != nil || n != 1 {
+		t.Fatalf("clear orphan: n=%d err=%v", n, err)
+	}
+	release, err := AcquireDreamLock(root)
+	if err != nil {
+		t.Fatalf("acquire after recovery: %v", err)
+	}
+	_ = release()
+}
+
+func TestLoadDreamCandidateSetMergesIdempotently(t *testing.T) {
+	persisted := []DreamCandidate{
+		{SignalKey: signalKey("a durable fact worth keeping"), Source: "journal",
+			Snippet: "a durable fact worth keeping", Sources: []string{"/journal/2026-06-13.md"},
+			Contexts: []string{"journal:2026-06-13"}, Occurrences: 1},
+	}
+	set := LoadDreamCandidateSet(persisted)
+	if set.Len() != 1 {
+		t.Fatalf("expected 1 rehydrated candidate, got %d", set.Len())
+	}
+
+	// Re-adding the SAME source ref must not inflate occurrences (idempotent
+	// re-harvest of an already-persisted source).
+	set.Add(DreamSignal{Source: "journal", Text: "a durable fact worth keeping",
+		SourceRef: "/journal/2026-06-13.md", Context: "journal:2026-06-13", Seen: "2026-06-13"})
+	if got := set.Candidates()[0].Occurrences; got != 1 {
+		t.Fatalf("idempotent re-add inflated occurrences to %d", got)
+	}
+
+	// A NEW distinct source for the same fact recurs → occurrences and contexts grow.
+	set.Add(DreamSignal{Source: "journal", Text: "a durable fact worth keeping",
+		SourceRef: "/journal/2026-06-20.md", Context: "journal:2026-06-20", Seen: "2026-06-20"})
+	c := set.Candidates()[0]
+	if c.Occurrences != 2 || c.DistinctContexts() != 2 {
+		t.Fatalf("expected occurrences=2 contexts=2, got occ=%d ctx=%d", c.Occurrences, c.DistinctContexts())
+	}
+
+	// Corrupt entries (empty / duplicate keys) are skipped on load.
+	dup := LoadDreamCandidateSet([]DreamCandidate{
+		{SignalKey: "x", Snippet: "1"}, {SignalKey: "x", Snippet: "2"}, {SignalKey: "", Snippet: "3"},
+	})
+	if dup.Len() != 1 {
+		t.Fatalf("expected dedup/skip to yield 1, got %d", dup.Len())
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "108"
+const ProtocolVersion = "109"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1832,11 +1832,26 @@ type NotebookDreamStatusResult struct {
 	// Enabled corresponds to the JSON schema field "enabled".
 	Enabled bool `json:"enabled"`
 
+	// LastRunAt corresponds to the JSON schema field "last_run_at".
+	LastRunAt *string `json:"last_run_at,omitempty,omitzero"`
+
 	// MultiContextCount corresponds to the JSON schema field "multi_context_count".
 	MultiContextCount int `json:"multi_context_count"`
 
+	// NextRunAt corresponds to the JSON schema field "next_run_at".
+	NextRunAt *string `json:"next_run_at,omitempty,omitzero"`
+
+	// PersistedCount corresponds to the JSON schema field "persisted_count".
+	PersistedCount int `json:"persisted_count"`
+
+	// Schedule corresponds to the JSON schema field "schedule".
+	Schedule *string `json:"schedule,omitempty,omitzero"`
+
 	// SourceCounts corresponds to the JSON schema field "source_counts".
 	SourceCounts []NotebookDreamSourceCount `json:"source_counts"`
+
+	// Timezone corresponds to the JSON schema field "timezone".
+	Timezone *string `json:"timezone,omitempty,omitzero"`
 
 	// Top corresponds to the JSON schema field "top".
 	Top []NotebookDreamCandidate `json:"top"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -2092,13 +2092,21 @@ model NotebookDreamSourceCount {
 
 // Summary of what a dream would consolidate now. enabled reflects the
 // notebook.dreaming.enabled gate; multi_context_count is the subset of
-// candidates seen in more than one distinct context.
+// candidates seen in more than one distinct context. candidate_count is the live
+// preview (persisted candidates merged with a fresh harvest); persisted_count is
+// how many are durably saved on disk from prior scheduled runs. schedule/timezone
+// describe the cron; last_run_at/next_run_at bracket the scheduled runs.
 model NotebookDreamStatusResult {
   enabled: boolean;
   candidate_count: int32;
   multi_context_count: int32;
+  persisted_count: int32;
   source_counts: NotebookDreamSourceCount[];
   top: NotebookDreamCandidate[];
+  schedule?: string;
+  timezone?: string;
+  last_run_at?: string;
+  next_run_at?: string;
 }
 
 // Result of notebook_dream_run. applied is false in the preview-only phase (the


### PR DESCRIPTION
## Dreaming PR-B1 — scheduler + persistence + lock/recovery (no LLM)

The deterministic half of the dreaming PR-B (split from PR-B2's LLM promote pass to keep each reviewable). Dreaming now **runs on a schedule and remembers what it harvested across restarts**, with the full single-flight + crash-recovery lifecycle — the groundwork the gated LLM promote pass (PR-B2) will consume. Off by default; produces no durable memory yet.

### What it adds
- **Persistence** under `<notebook-root>/.attn/dreams/`: `candidates.json` (the accumulated harvest set — an idempotent monotonic union) + `state.json` (schedule anchor + last-run summary), atomic temp+rename. This is machine state, so it bypasses `Store.Write` (whose `CleanPath` rejects dotdir/non-`.md` paths) and reuses the notebook package's atomic writer.
- **Timezone-aware cron scheduler** (`robfig/cron/v3`; default `0 3 * * *`). A ticker asks each minute whether a run is due. First-enable anchors at "now" so enabling never fires an immediate run on startup; nightly slots missed while the daemon was down collapse into a single catch-up run.
- **Single-flight + recovery**: in-memory guard + a filesystem lock (`O_CREATE|O_EXCL`) + startup orphan-lock recovery, mirroring the workspace-context janitor lifecycle.
- **Settings** `notebook.dreaming.frequency` / `.timezone`, validated (rejects unsatisfiable crons like Feb 30 and embedded `CRON_TZ=` prefixes that would compete with the timezone setting).
- **`dream status`** now surfaces schedule / timezone / last-run / next-run / persisted count. `dream --apply` is still rejected (PR-B2). Protocol `v108 → v109`.

### Scope decisions (deliberate)
- Per-source incremental cursors (`checkpoints.json`) are **deferred**: harvest re-scans fully each run and relies on the idempotent union, so cursors would be a pure perf optimization, not correctness.
- `candidates.json` grows monotonically (harvest never prunes); compaction is an explicitly separate, deferred op.
- **CHANGELOG deferred to PR-B2**, when dreaming actually writes durable memory (the real user-visible outcome). B1 is off-by-default groundwork with no notebook output.

### Testing
Unit + integration across the stack: persistence round-trip, lock acquire/conflict/idempotent-release + orphan recovery, scheduler due/not-due/first-enable/catch-up/**timezone-flips-the-decision**/unsatisfiable-frequency, the persisted-union merge, the goroutine run-and-stop lifecycle, settings validation, and CLI rendering. Full daemon + notebook + cmd + protocol suites green; `go vet` + `gofmt` clean; `tsc` clean.

Hardened against an adversarial multi-dimension review (15 findings raised, 11 confirmed and addressed — notably a runaway-loop on impossible-date crons and an overstated "exactly once" catch-up doc — 4 rejected as self-refuting/by-design).

🤖 Authored by Claude Code on behalf of Victor.