### PR TITLE
fix(daemon): scrub inherited agent session env from spawned sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-14]
+
+### Fixed
+- **Agents and shells launched by attn no longer inherit a stale Claude Code session identity.** When attn itself was started from inside a Claude Code session (for example an agent running `make install`), that session's per-session environment — including its session ID — leaked into the daemon and then into every agent or shell attn spawned, which broke things like transcript generation. attn now drops those inherited per-session variables on startup, while still honoring any Claude Code settings you've configured in your shell profile.
+
 ## [2026-06-13]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-06-14]
 
 ### Fixed
-- **Agents and shells launched by attn no longer inherit a stale Claude Code session identity.** When attn itself was started from inside a Claude Code session (for example an agent running `make install`), that session's per-session environment — including its session ID — leaked into the daemon and then into every agent or shell attn spawned, which broke things like transcript generation. attn now drops those inherited per-session variables on startup, while still honoring any Claude Code settings you've configured in your shell profile.
+- **Agents and shells launched by attn no longer inherit a stale Claude Code session identity.** When attn itself was started from inside a Claude Code session (for example an agent running `make install`), that session's per-session environment — including its session ID — leaked into the daemon and then into every agent or shell attn spawned, which broke things like transcript generation. attn now drops those inherited per-session identifiers before launching agents and shells, while still honoring any Claude Code settings you've configured in your shell profile.
 
 ## [2026-06-13]
 

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -397,6 +397,13 @@ func runPTYWorker() {
 		fmt.Fprintf(os.Stderr, "[pty-worker] "+format+"\n", args...)
 	}
 
+	// Belt-and-suspenders: the daemon already scrubs these before spawning the
+	// worker, but a worker spawned from any unscrubbed parent self-protects so
+	// the leaked per-session agent env never reaches the PTY it spawns.
+	if scrubbed := config.ScrubInheritedAgentSessionEnv(); len(scrubbed) > 0 {
+		cfg.Logf("scrubbed inherited agent session env before startup: %v", scrubbed)
+	}
+
 	if err := ptyworker.Run(context.Background(), cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "pty-worker error: %v\n", err)
 		os.Exit(1)
@@ -419,6 +426,10 @@ func runDaemon() {
 	}
 
 	d := daemon.New(socketPath)
+	// Drop any per-session agent env (e.g. CLAUDE_CODE_SESSION_ID) inherited
+	// when attn was launched from inside an agent session, before Start() warms
+	// the login-shell env cache or spawns anything.
+	d.ScrubInheritedAgentSessionEnv()
 	if err := d.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "daemon error: %v\n", err)
 		os.Exit(1)

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -1916,6 +1916,12 @@ func runAgentDirectly(requestedAgent string) {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	// If this wrapper was launched from inside another agent's session (e.g. a
+	// terminal that is itself a Claude Code session), drop that session's
+	// identity so the agent we launch gets a fresh one. Only the identity vars
+	// are scrubbed here: this path inherits the live shell env directly, so
+	// tuning vars the user exported in their profile must be left intact.
+	config.ScrubAgentSessionIdentityEnv()
 	cmd.Env = mergeEnv(os.Environ(), driver.BuildEnv(opts))
 
 	startedAt := time.Now()

--- a/internal/config/agentenv.go
+++ b/internal/config/agentenv.go
@@ -2,45 +2,64 @@ package config
 
 import "os"
 
-// inheritedAgentSessionEnvKeys are the per-session environment variables a
-// running coding agent (Claude Code today) injects into its child processes.
+// agentSessionIdentityEnvKeys uniquely identify the *parent* agent session that
+// launched this attn process. They must never be inherited by a freshly
+// launched agent: a nested agent that reuses CLAUDE_CODE_SESSION_ID writes to
+// its parent's transcript, which breaks transcript generation.
 //
-// attn is frequently (re)launched from inside such a session — most commonly an
-// agent running `make install` — so these leak into the long-lived daemon and,
-// from there, into every agent or shell the daemon spawns. A nested agent that
-// inherits CLAUDE_CODE_SESSION_ID reuses its parent's session identity, which
-// breaks transcript generation and other per-session behavior.
-//
-// These are runtime/session values, never user configuration. We scrub them
-// from the daemon/worker process at startup (see ScrubInheritedAgentSessionEnv)
-// rather than at each spawn site on purpose: with the process env clean, the
-// login-shell env capture is spawned from a clean process and re-exports only
-// what the user's shell profile genuinely sets (e.g. CLAUDE_CODE_USE_BEDROCK),
-// so legitimate configuration survives while the leaked per-session values are
-// dropped. Stripping at the spawn site cannot tell the two apart.
-//
-// When the agent adds a new per-session variable, add it here.
-var inheritedAgentSessionEnvKeys = []string{
+// These are pure runtime identity — never user configuration — so they are
+// always safe to scrub, including on launch paths that inherit the live shell
+// environment directly (the foreground `attn` wrapper) without re-capturing a
+// login shell.
+var agentSessionIdentityEnvKeys = []string{
 	"CLAUDECODE",
 	"CLAUDE_CODE_ENTRYPOINT",
 	"CLAUDE_CODE_SESSION_ID",
 	"CLAUDE_CODE_CHILD_SESSION",
 	"CLAUDE_CODE_EXECPATH",
+	"CLAUDE_CODE_SSE_PORT",
+}
+
+// agentSessionTuningEnvKeys are per-session runtime *tuning* values the agent
+// injects (effort, compaction window, rendering flags). They leak the same way
+// the identity vars do, but unlike identity vars a user might deliberately
+// export some of them from their shell profile (e.g. CLAUDE_CODE_NO_FLICKER).
+//
+// They are therefore only scrubbed from long-lived attn processes (the daemon
+// and PTY worker) that re-capture a clean login shell afterward: that capture
+// re-exports whatever the profile genuinely sets, so legitimate configuration
+// survives while the leaked per-session values are dropped. Launch paths that
+// inherit the live shell env directly must NOT scrub these — there is no
+// re-capture to restore the user's configuration.
+var agentSessionTuningEnvKeys = []string{
 	"CLAUDE_CODE_AUTO_COMPACT_WINDOW",
 	"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",
 	"CLAUDE_CODE_NO_FLICKER",
-	"CLAUDE_CODE_SSE_PORT",
 	"CLAUDE_EFFORT",
 }
 
-// ScrubInheritedAgentSessionEnv removes the inherited agent-session variables
-// from the current process environment and returns the keys that were actually
-// set (for logging). Call it once, early, in any long-lived attn process that
-// spawns agent or shell sessions — the daemon and the PTY worker — before the
-// login-shell env is captured so the leaked values never reach spawned sessions.
+// ScrubAgentSessionIdentityEnv removes only the parent-session identity vars
+// from the current process environment and returns the keys that were set.
+// Use it on launch paths that inherit the live shell env directly (the
+// foreground `attn` wrapper), where scrubbing tuning vars would drop user
+// configuration that nothing re-exports.
+func ScrubAgentSessionIdentityEnv() []string {
+	return scrubEnvKeys(agentSessionIdentityEnvKeys)
+}
+
+// ScrubInheritedAgentSessionEnv removes the full set of inherited agent-session
+// vars (identity + tuning) and returns the keys that were set (for logging).
+// Call it once, early, in any long-lived attn process that spawns agent or
+// shell sessions — the daemon and the PTY worker — before the login-shell env
+// is captured, so the leaked values never reach spawned sessions.
 func ScrubInheritedAgentSessionEnv() []string {
-	scrubbed := make([]string, 0, len(inheritedAgentSessionEnvKeys))
-	for _, key := range inheritedAgentSessionEnvKeys {
+	scrubbed := scrubEnvKeys(agentSessionIdentityEnvKeys)
+	return append(scrubbed, scrubEnvKeys(agentSessionTuningEnvKeys)...)
+}
+
+func scrubEnvKeys(keys []string) []string {
+	scrubbed := make([]string, 0, len(keys))
+	for _, key := range keys {
 		if _, ok := os.LookupEnv(key); ok {
 			_ = os.Unsetenv(key)
 			scrubbed = append(scrubbed, key)

--- a/internal/config/agentenv.go
+++ b/internal/config/agentenv.go
@@ -1,0 +1,50 @@
+package config
+
+import "os"
+
+// inheritedAgentSessionEnvKeys are the per-session environment variables a
+// running coding agent (Claude Code today) injects into its child processes.
+//
+// attn is frequently (re)launched from inside such a session — most commonly an
+// agent running `make install` — so these leak into the long-lived daemon and,
+// from there, into every agent or shell the daemon spawns. A nested agent that
+// inherits CLAUDE_CODE_SESSION_ID reuses its parent's session identity, which
+// breaks transcript generation and other per-session behavior.
+//
+// These are runtime/session values, never user configuration. We scrub them
+// from the daemon/worker process at startup (see ScrubInheritedAgentSessionEnv)
+// rather than at each spawn site on purpose: with the process env clean, the
+// login-shell env capture is spawned from a clean process and re-exports only
+// what the user's shell profile genuinely sets (e.g. CLAUDE_CODE_USE_BEDROCK),
+// so legitimate configuration survives while the leaked per-session values are
+// dropped. Stripping at the spawn site cannot tell the two apart.
+//
+// When the agent adds a new per-session variable, add it here.
+var inheritedAgentSessionEnvKeys = []string{
+	"CLAUDECODE",
+	"CLAUDE_CODE_ENTRYPOINT",
+	"CLAUDE_CODE_SESSION_ID",
+	"CLAUDE_CODE_CHILD_SESSION",
+	"CLAUDE_CODE_EXECPATH",
+	"CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+	"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",
+	"CLAUDE_CODE_NO_FLICKER",
+	"CLAUDE_CODE_SSE_PORT",
+	"CLAUDE_EFFORT",
+}
+
+// ScrubInheritedAgentSessionEnv removes the inherited agent-session variables
+// from the current process environment and returns the keys that were actually
+// set (for logging). Call it once, early, in any long-lived attn process that
+// spawns agent or shell sessions — the daemon and the PTY worker — before the
+// login-shell env is captured so the leaked values never reach spawned sessions.
+func ScrubInheritedAgentSessionEnv() []string {
+	scrubbed := make([]string, 0, len(inheritedAgentSessionEnvKeys))
+	for _, key := range inheritedAgentSessionEnvKeys {
+		if _, ok := os.LookupEnv(key); ok {
+			_ = os.Unsetenv(key)
+			scrubbed = append(scrubbed, key)
+		}
+	}
+	return scrubbed
+}

--- a/internal/config/agentenv_test.go
+++ b/internal/config/agentenv_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 func TestScrubInheritedAgentSessionEnv(t *testing.T) {
-	// Leaked per-session vars that must be removed.
+	// Leaked per-session vars (identity + tuning) that must be removed.
 	t.Setenv("CLAUDE_CODE_SESSION_ID", "cbcaa879-725b-44b2-8d91-212f6b00a516")
 	t.Setenv("CLAUDE_CODE_CHILD_SESSION", "1")
 	t.Setenv("CLAUDE_EFFORT", "xhigh")
+	t.Setenv("CLAUDE_CODE_NO_FLICKER", "1")
 
 	// User configuration and unrelated vars that must survive — they are not in
 	// the scrub list, mirroring how a real login shell re-exports profile config.
@@ -20,7 +21,7 @@ func TestScrubInheritedAgentSessionEnv(t *testing.T) {
 
 	scrubbed := ScrubInheritedAgentSessionEnv()
 
-	for _, key := range []string{"CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_CHILD_SESSION", "CLAUDE_EFFORT"} {
+	for _, key := range []string{"CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_CHILD_SESSION", "CLAUDE_EFFORT", "CLAUDE_CODE_NO_FLICKER"} {
 		if _, ok := os.LookupEnv(key); ok {
 			t.Errorf("%s should have been scrubbed but is still set", key)
 		}
@@ -37,9 +38,35 @@ func TestScrubInheritedAgentSessionEnv(t *testing.T) {
 	}
 }
 
+// ScrubAgentSessionIdentityEnv runs on launch paths that inherit the live shell
+// env directly, so it must drop the parent-session identity but keep tuning vars
+// the user may have deliberately exported (nothing re-exports them there).
+func TestScrubAgentSessionIdentityEnv_KeepsTuningVars(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "cbcaa879-leaked")
+	t.Setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
+	t.Setenv("CLAUDE_CODE_NO_FLICKER", "1")
+	t.Setenv("CLAUDE_EFFORT", "xhigh")
+
+	scrubbed := ScrubAgentSessionIdentityEnv()
+
+	for _, key := range []string{"CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_ENTRYPOINT"} {
+		if _, ok := os.LookupEnv(key); ok {
+			t.Errorf("identity var %s should have been scrubbed but is still set", key)
+		}
+	}
+	for _, key := range []string{"CLAUDE_CODE_NO_FLICKER", "CLAUDE_EFFORT"} {
+		if _, ok := os.LookupEnv(key); !ok {
+			t.Errorf("tuning var %s must survive identity-only scrub (no login shell re-captures it)", key)
+		}
+		if slices.Contains(scrubbed, key) {
+			t.Errorf("identity scrub should not report tuning var %s", key)
+		}
+	}
+}
+
 func TestScrubInheritedAgentSessionEnv_OnlyReportsSetKeys(t *testing.T) {
 	// Ensure none of the scrub keys are set in this process.
-	for _, key := range inheritedAgentSessionEnvKeys {
+	for _, key := range append(slices.Clone(agentSessionIdentityEnvKeys), agentSessionTuningEnvKeys...) {
 		t.Setenv(key, "")
 		os.Unsetenv(key)
 	}

--- a/internal/config/agentenv_test.go
+++ b/internal/config/agentenv_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"os"
+	"slices"
+	"testing"
+)
+
+func TestScrubInheritedAgentSessionEnv(t *testing.T) {
+	// Leaked per-session vars that must be removed.
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "cbcaa879-725b-44b2-8d91-212f6b00a516")
+	t.Setenv("CLAUDE_CODE_CHILD_SESSION", "1")
+	t.Setenv("CLAUDE_EFFORT", "xhigh")
+
+	// User configuration and unrelated vars that must survive — they are not in
+	// the scrub list, mirroring how a real login shell re-exports profile config.
+	t.Setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	t.Setenv("PATH", os.Getenv("PATH"))
+
+	scrubbed := ScrubInheritedAgentSessionEnv()
+
+	for _, key := range []string{"CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_CHILD_SESSION", "CLAUDE_EFFORT"} {
+		if _, ok := os.LookupEnv(key); ok {
+			t.Errorf("%s should have been scrubbed but is still set", key)
+		}
+	}
+	if !slices.Contains(scrubbed, "CLAUDE_CODE_SESSION_ID") {
+		t.Errorf("returned scrubbed keys %v missing CLAUDE_CODE_SESSION_ID", scrubbed)
+	}
+
+	if got, ok := os.LookupEnv("CLAUDE_CODE_USE_BEDROCK"); !ok || got != "1" {
+		t.Errorf("CLAUDE_CODE_USE_BEDROCK should survive (user config), got %q ok=%v", got, ok)
+	}
+	if got, ok := os.LookupEnv("ANTHROPIC_API_KEY"); !ok || got != "sk-test" {
+		t.Errorf("ANTHROPIC_API_KEY should survive, got %q ok=%v", got, ok)
+	}
+}
+
+func TestScrubInheritedAgentSessionEnv_OnlyReportsSetKeys(t *testing.T) {
+	// Ensure none of the scrub keys are set in this process.
+	for _, key := range inheritedAgentSessionEnvKeys {
+		t.Setenv(key, "")
+		os.Unsetenv(key)
+	}
+	t.Setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
+
+	scrubbed := ScrubInheritedAgentSessionEnv()
+
+	if len(scrubbed) != 1 || scrubbed[0] != "CLAUDE_CODE_ENTRYPOINT" {
+		t.Errorf("expected only CLAUDE_CODE_ENTRYPOINT reported, got %v", scrubbed)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -291,6 +291,17 @@ func (d *Daemon) cachedLoginShellEnv() []string {
 	return env
 }
 
+// ScrubInheritedAgentSessionEnv strips per-session environment variables leaked
+// from a parent agent (e.g. when attn is launched via `make install` from
+// inside a Claude Code session) so they never propagate to spawned sessions or
+// to the captured login-shell env. Call before Start(), which warms the
+// login-shell env cache.
+func (d *Daemon) ScrubInheritedAgentSessionEnv() {
+	if scrubbed := config.ScrubInheritedAgentSessionEnv(); len(scrubbed) > 0 {
+		d.logf("scrubbed inherited agent session env before startup: %v", scrubbed)
+	}
+}
+
 func (d *Daemon) signalStarted() {
 	d.startedOnce.Do(func() {
 		if d.startedCh == nil {

--- a/internal/pty/manager_test.go
+++ b/internal/pty/manager_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/victorarias/attn/internal/config"
 )
 
 func TestParseNullSeparatedEnv(t *testing.T) {
@@ -244,6 +246,28 @@ func TestBuildSpawnEnv_StripsInheritedNoColorFromInteractiveSessions(t *testing.
 			for _, entry := range env {
 				if strings.HasPrefix(entry, "NO_COLOR=") {
 					t.Fatalf("did not expect NO_COLOR in %s PTY environment, got %v", agent, env)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildSpawnEnv_OmitsScrubbedAgentSessionEnv ties the daemon/worker startup
+// scrub to the real spawn-env builder: once the process env has been scrubbed
+// (as runDaemon/runPTYWorker do before spawning), a per-session agent var that
+// leaked into the process must not reappear in any spawned PTY's environment.
+func TestBuildSpawnEnv_OmitsScrubbedAgentSessionEnv(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "cbcaa879-leaked")
+
+	// Simulate the daemon/worker scrubbing its inherited env at startup.
+	config.ScrubInheritedAgentSessionEnv()
+
+	for _, agent := range []string{"shell", "codex"} {
+		t.Run(agent, func(t *testing.T) {
+			env := buildSpawnEnv("", SpawnOptions{ID: "session-1"}, agent, "/tmp/attn-wrapper", nil)
+			for _, entry := range env {
+				if strings.HasPrefix(entry, "CLAUDE_CODE_SESSION_ID=") {
+					t.Fatalf("spawned %s PTY leaked CLAUDE_CODE_SESSION_ID: %v", agent, env)
 				}
 			}
 		})


### PR DESCRIPTION
## Problem

When attn is launched from inside a Claude Code session — most commonly an agent running `make install` — that session's per-session environment leaks into the long-lived daemon, and from there into every agent or shell the daemon spawns:

```
CLAUDE_CODE_SESSION_ID=cbcaa879-...
CLAUDE_CODE_CHILD_SESSION=1
CLAUDE_CODE_ENTRYPOINT=cli
CLAUDE_EFFORT=xhigh
CLAUDECODE=1
...
```

A nested agent that inherits `CLAUDE_CODE_SESSION_ID` reuses its parent's session identity, which breaks transcript generation (and other per-session behavior). The leak reaches spawned sessions through both the daemon's own `os.Environ()` base **and** the login-shell env capture (the login shell is spawned from the daemon's contaminated env and re-exports the vars).

## Fix

Scrub the leaked per-session vars from the processes that launch agents/shells, at the leak carrier — not at each spawn site.

The set is split into two:

- **identity vars** (`CLAUDE_CODE_SESSION_ID`, `CLAUDE_CODE_CHILD_SESSION`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_EXECPATH`, `CLAUDE_CODE_SSE_PORT`, `CLAUDECODE`) — pure parent-session identity, never user config → always safe to scrub on any launch path.
- **tuning vars** (`CLAUDE_EFFORT`, `CLAUDE_CODE_NO_FLICKER`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) — per-session runtime knobs a user might deliberately export in their profile.

Scrub points:

- **Daemon + PTY worker startup** (`runDaemon` before `Start()`, `runPTYWorker`): scrub the **full** set. Doing it at the process level — before the login shell is captured — keeps the captured env clean while letting the login shell re-export whatever the user genuinely sets in their profile (e.g. `CLAUDE_CODE_USE_BEDROCK`, or a deliberately-exported `CLAUDE_CODE_NO_FLICKER`). So real config survives; only the leaked per-session values are dropped.
- **Foreground `attn` launch** (`runAgentDirectly`): scrub **identity only**. This path inherits the live shell env directly with no login-shell re-capture, so scrubbing tuning vars would drop user config that nothing restores. Identity-only kills the session-id leak with zero common-case regression (identity vars are absent in a normal terminal).

Files:

- `internal/config/agentenv.go` — the two var sets + `ScrubInheritedAgentSessionEnv()` / `ScrubAgentSessionIdentityEnv()`, with the rationale documented.
- `internal/daemon/daemon.go` — `d.ScrubInheritedAgentSessionEnv()`, called in `runDaemon()` before `Start()` warms the login-shell cache.
- `cmd/attn/main.go` — full scrub in `runDaemon`/`runPTYWorker`; identity scrub in the foreground `runAgentDirectly`.

## Tests

- `internal/config`: full scrub removes identity + tuning and **preserves** `ANTHROPIC_API_KEY` / `CLAUDE_CODE_USE_BEDROCK`; identity-only scrub removes identity but **keeps** tuning vars (`CLAUDE_CODE_NO_FLICKER`, `CLAUDE_EFFORT`) — the regression guard for the foreground path.
- `internal/pty`: hermetic integration test — a scrubbed process env feeds the real `buildSpawnEnv`, and no `CLAUDE_CODE_SESSION_ID` reaches the spawned PTY (shell + agent).

## Verification (live)

Ran a real daemon on an isolated profile, contaminated exactly as in the bug:

- Daemon log: `scrubbed inherited agent session env before startup: [CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION_ID …]` — caught all present vars; login-shell prewarm ran **after** the scrub.
- fish login re-export, contaminated vs scrubbed parent: contaminated re-exports `CLAUDE_CODE_SESSION_ID=…` (+8 more); scrubbed re-exports only `CLAUDE_CODE_NO_FLICKER=1` (a real fish-config setting) — proving session identity is dropped while genuine profile config is preserved.