### PR TITLE
refactor(store): limit rank repair to migration

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -433,10 +433,6 @@ func OpenDB(dbPath string) (*sql.DB, error) {
 		db.Close()
 		return nil, err
 	}
-	if err := ensureWorkspaceRankSchema(db); err != nil {
-		db.Close()
-		return nil, err
-	}
 
 	return db, nil
 }
@@ -719,24 +715,6 @@ func applyMigration49(tx *sql.Tx) error {
 		if _, err := tx.Exec(`UPDATE workspaces SET rank = ? WHERE id = ?`, seeds[i], id); err != nil {
 			return err
 		}
-	}
-	return nil
-}
-
-// ensureWorkspaceRankSchema repairs schema drift caused by development builds
-// that reused a migration version. It runs independently of migration history
-// so a database marked at or beyond version 50 cannot skip the required repair.
-func ensureWorkspaceRankSchema(db *sql.DB) error {
-	tx, err := db.Begin()
-	if err != nil {
-		return fmt.Errorf("starting workspace rank schema repair: %w", err)
-	}
-	if err := applyMigration49(tx); err != nil {
-		tx.Rollback()
-		return fmt.Errorf("repairing workspace rank schema: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("committing workspace rank schema repair: %w", err)
 	}
 	return nil
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -453,91 +453,74 @@ func TestMigration49_BackfillsRankInCreatedAtOrder(t *testing.T) {
 	}
 }
 
-func TestOpenDBRepairsWorkspaceRankRegardlessOfRecordedVersion(t *testing.T) {
-	for _, tc := range []struct {
-		name            string
-		recordedVersion int
-	}{
-		{name: "version 49 collision", recordedVersion: 49},
-		{name: "version 50 collision", recordedVersion: 50},
-		{name: "higher development version", recordedVersion: 999},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			dbPath := filepath.Join(t.TempDir(), "workspace-rank-repair.db")
-			rawDB, err := sql.Open("sqlite3", dbPath)
-			if err != nil {
-				t.Fatalf("open raw sqlite db: %v", err)
-			}
-			if _, err := rawDB.Exec(`
-				CREATE TABLE workspaces (
-					id TEXT PRIMARY KEY,
-					title TEXT NOT NULL,
-					directory TEXT NOT NULL,
-					muted INTEGER NOT NULL DEFAULT 0,
-					created_at TEXT NOT NULL
-				);
-				CREATE TABLE schema_migrations (
-					version INTEGER PRIMARY KEY,
-					applied_at TEXT NOT NULL
-				);
-				INSERT INTO workspaces (id, title, directory, created_at) VALUES
-					('ws-second', 'Second', '/repo/second', '2026-05-31T00:00:02Z'),
-					('ws-first', 'First', '/repo/first', '2026-05-31T00:00:01Z');
-			`); err != nil {
-				rawDB.Close()
-				t.Fatalf("seed workspace rank repair db: %v", err)
-			}
-			if _, err := rawDB.Exec(
-				"INSERT INTO schema_migrations (version, applied_at) VALUES (?, datetime('now'))",
-				tc.recordedVersion,
-			); err != nil {
-				rawDB.Close()
-				t.Fatalf("seed migration version %d: %v", tc.recordedVersion, err)
-			}
-			rawDB.Close()
+func TestMigration50RepairsRankWhenVersion49WasAlreadyRecorded(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "workspace-rank-repair.db")
+	rawDB, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open raw sqlite db: %v", err)
+	}
+	if _, err := rawDB.Exec(`
+		CREATE TABLE workspaces (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			directory TEXT NOT NULL,
+			muted INTEGER NOT NULL DEFAULT 0,
+			created_at TEXT NOT NULL
+		);
+		CREATE TABLE schema_migrations (
+			version INTEGER PRIMARY KEY,
+			applied_at TEXT NOT NULL
+		);
+		INSERT INTO workspaces (id, title, directory, created_at) VALUES
+			('ws-second', 'Second', '/repo/second', '2026-05-31T00:00:02Z'),
+			('ws-first', 'First', '/repo/first', '2026-05-31T00:00:01Z');
+		INSERT INTO schema_migrations (version, applied_at) VALUES (49, datetime('now'));
+	`); err != nil {
+		rawDB.Close()
+		t.Fatalf("seed workspace rank repair db: %v", err)
+	}
+	rawDB.Close()
 
-			db, err := OpenDB(dbPath)
-			if err != nil {
-				t.Fatalf("OpenDB() repairing version %d collision: %v", tc.recordedVersion, err)
-			}
-			defer db.Close()
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB() repairing version 49 collision: %v", err)
+	}
+	defer db.Close()
 
-			var count int
-			if err := db.QueryRow(`
-				SELECT COUNT(*) FROM pragma_table_info('workspaces') WHERE name = 'rank'
-			`).Scan(&count); err != nil {
-				t.Fatalf("query rank column: %v", err)
-			}
-			if count != 1 {
-				t.Fatalf("workspaces.rank columns = %d, want 1", count)
-			}
+	var count int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM pragma_table_info('workspaces') WHERE name = 'rank'
+	`).Scan(&count); err != nil {
+		t.Fatalf("query rank column: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("workspaces.rank columns = %d, want 1", count)
+	}
 
-			rows, err := db.Query("SELECT id, rank FROM workspaces ORDER BY rank")
-			if err != nil {
-				t.Fatalf("query repaired ranks: %v", err)
-			}
-			var ids []string
-			for rows.Next() {
-				var id, rank string
-				if err := rows.Scan(&id, &rank); err != nil {
-					rows.Close()
-					t.Fatalf("scan repaired rank: %v", err)
-				}
-				if rank == "" {
-					rows.Close()
-					t.Fatalf("workspace %s has empty repaired rank", id)
-				}
-				ids = append(ids, id)
-			}
-			if err := rows.Err(); err != nil {
-				rows.Close()
-				t.Fatalf("repaired rank rows: %v", err)
-			}
+	rows, err := db.Query("SELECT id, rank FROM workspaces ORDER BY rank")
+	if err != nil {
+		t.Fatalf("query repaired ranks: %v", err)
+	}
+	var ids []string
+	for rows.Next() {
+		var id, rank string
+		if err := rows.Scan(&id, &rank); err != nil {
 			rows.Close()
-			if want := []string{"ws-first", "ws-second"}; !reflect.DeepEqual(ids, want) {
-				t.Fatalf("workspace order = %v, want %v", ids, want)
-			}
-		})
+			t.Fatalf("scan repaired rank: %v", err)
+		}
+		if rank == "" {
+			rows.Close()
+			t.Fatalf("workspace %s has empty repaired rank", id)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		t.Fatalf("repaired rank rows: %v", err)
+	}
+	rows.Close()
+	if want := []string{"ws-first", "ws-second"}; !reflect.DeepEqual(ids, want) {
+		t.Fatalf("workspace order = %v, want %v", ids, want)
 	}
 }
 


### PR DESCRIPTION
## Intent / Why

Published attn releases through `v0.11.1` stop at migration 41, so supported release upgrades always execute migration 49 and create `workspaces.rank` normally. The unconditional schema repair added in #333 was broader than the release compatibility contract and performed unnecessary work on every database open.

## Summary

- remove the post-migration workspace-rank schema check from every `OpenDB` call
- retain migration 50 as a one-time repair and reserved migration number for the known version-49 development-build collision
- narrow regression coverage to that one-time migration repair

## Test plan

- [x] `go test ./internal/store`
- [x] `git diff --check`

## Related

- #333