### PR TITLE
feat(notebook): deterministic raw-tier capture floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-15]
+
+### Fixed
+- **A workspace can no longer corrupt your journal or other files when it closes.** The context snapshot taken when a workspace is removed now refuses any workspace identifier that is not a plain name, so a crafted identifier can no longer steer that write out of attn's internal holding area and overwrite your curated journal or another file. Normal workspaces are unaffected.
+
+### Changed
+- **Your curated journal stays curated; raw delegated-work outcomes now feed it behind the scenes.** Auto-captured chief-of-staff dispatch outcomes no longer land directly in your daily `journal/<date>.md`. They are now recorded to an internal holding area the upcoming narration pass reads from, so the journal you read keeps only curated entries instead of machine-raw blocks. Dispatch outcomes are still captured reliably and exactly once; existing journal entries are left untouched.
+- **A workspace's shared context is preserved when the workspace goes away.** Removing a workspace used to discard its shared `context.md` overlay entirely. attn now snapshots that context the moment a workspace is torn down, keeping it as durable raw material for the journal-narration pass — so the decisions and current picture an agent recorded in a workspace are no longer lost when the workspace closes.
+
 ## [2026-06-14]
 
 ### Added

--- a/internal/daemon/notebook_dispatch_journal.go
+++ b/internal/daemon/notebook_dispatch_journal.go
@@ -9,27 +9,35 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// Auto-journaling of chief-of-staff dispatch outcomes.
+// Deterministic capture of chief-of-staff dispatch outcomes to the raw tier.
 //
 // A dispatch is delegated agent work, and its terminal report (completed/failed)
 // — or, as a fallback, its session simply ending — is exactly the "what was
 // decided / built / failed" signal the durable work-journal exists to capture.
 // This file renders that already-structured DispatchReport into a human-readable
-// journal block and appends it to the daily journal:
+// block and writes it to the notebook's raw tier
+// (.attn/raw/dispatches/<dispatchID>.md), where the later narration pass reads it.
+// It deliberately does NOT write the curated journal — the journal stays curated.
 //
 //   - deterministic: the daemon renders structured fields, no LLM is involved;
-//   - idempotent: a hidden per-dispatch marker means the terminal-report path, the
-//     session-gone fallback, and a daemon restart together write exactly one block;
-//   - grounded by construction: every block cites source: dispatch:<id>.
+//   - exactly-once: one file per dispatch id; a replay atomically overwrites that
+//     one file, so the report path, the session-gone fallback, and a daemon restart
+//     together leave exactly one entry. The overwrite is byte-identical when the
+//     dispatch carries a server ReportedAt; when it does not (a worker that ended
+//     with no structured report), the "## HH:MM" header is stamped from the wall
+//     clock at render time, so two replays in different minutes overwrite with an
+//     equivalent — not byte-identical — block. Still one file, one marker;
+//   - grounded by construction: every block cites source: dispatch:<id> and carries
+//     a hidden attn:dispatch:<id> marker.
 //
-// This is the capture half of the notebook-as-work-journal: reliable, low-noise
-// entries land without any agent having to remember to journal. LLM curation of
-// these raw entries is a separate, later pass.
+// This is the deterministic capture floor of the notebook-as-work-journal:
+// reliable, low-noise entries land without any agent having to remember to journal.
+// LLM curation of these raw entries is a separate, later pass.
 
-// journalDispatchMarker is the stable, hidden per-dispatch dedupe marker embedded
-// in each auto-journaled block. It is an HTML comment so it renders invisibly in a
-// markdown viewer while keeping the journal file self-describing — dedup needs no
-// separate ledger and survives a daemon restart.
+// journalDispatchMarker is the stable, hidden per-dispatch marker embedded in each
+// rendered block. It is an HTML comment so it renders invisibly in a markdown
+// viewer while keeping the raw dispatch file self-describing — the marker is the
+// greppable ledger the narration pass keys off, and it survives a daemon restart.
 func journalDispatchMarker(dispatchID string) string {
 	return fmt.Sprintf("<!-- attn:dispatch:%s -->", strings.TrimSpace(dispatchID))
 }
@@ -44,68 +52,84 @@ func isTerminalDispatchReport(report *protocol.DispatchReport) bool {
 			report.WorkState == protocol.DispatchWorkStateFailed)
 }
 
-// journalDispatchOutcome renders a dispatch's outcome into the daily journal,
-// exactly once. It is best-effort and safe to call from any dispatch-end path: a
-// missing/unconfigured notebook, an empty dispatch, or an already-journaled
-// dispatch is a silent no-op. Capture must never disrupt the dispatch lifecycle,
-// so every failure is logged and swallowed.
+// journalDispatchOutcome captures a dispatch's outcome to the raw tier, exactly
+// once. It is best-effort and safe to call from any dispatch-end path: a
+// missing/unconfigured notebook or an empty dispatch is a silent no-op. Capture
+// must never disrupt the dispatch lifecycle, so every failure is logged and
+// swallowed.
 //
-// Best-effort has one accepted edge: if the write itself cannot land — an
-// unwritable notebook root, or a day's journal that has reached notebook.MaxFileSize
-// — the entry is logged and dropped, and since the marker was never written the
-// later removal-path retry re-fails identically. So "exactly once" degrades to "at
-// most once" precisely when the journal cannot be written at all. Given a block is
-// a few KiB and fields are clamped, hitting the daily ceiling needs an implausible
-// per-day dispatch volume; we accept that over carrying an overflow-spill mechanism.
+// The destination is the raw tier (.attn/raw/dispatches/<dispatchID>.md), not the
+// curated journal: one file per dispatch, keyed 1:1 on the dispatch id. Existence
+// of that file plus the attn:dispatch:<id> marker embedded in the rendered block
+// is the exactly-once ledger, so a replayed trigger (report path, session-gone
+// fallback, restart) re-renders the block and atomically overwrites that one file —
+// harmless. The re-rendered block is byte-identical when the dispatch has a server
+// ReportedAt; without one, its wall-clock header can drift across minutes, so the
+// overwrite is equivalent rather than byte-identical (still one file, one marker).
+// If the write cannot land (an unwritable notebook
+// root), the entry is logged and dropped; a later removal-path retry re-attempts
+// the same write, so "exactly once" degrades to "at most once" only while the raw
+// tier itself is unwritable.
 func (d *Daemon) journalDispatchOutcome(dispatch *protocol.ChiefOfStaffDispatch) {
 	if dispatch == nil {
 		return
 	}
-	dateISO, block, ok := renderDispatchJournalEntry(dispatch, time.Now())
+	_, block, ok := renderDispatchJournalEntry(dispatch, time.Now())
 	if !ok {
 		return // nothing meaningful to record
 	}
-	store, err := d.notebookStoreFor()
+	// Redirect the deterministic dispatch capture to the raw tier
+	// (.attn/raw/dispatches/<dispatchID>.md) instead of the curated journal, so the
+	// curated journal/<date>.md never accumulates machine-raw blocks. The raw tier
+	// lives under .attn/, which CleanPath rejects and the watcher skips, so this is
+	// written with direct filesystem I/O (not notebook.Store) and emits no
+	// notebook_changed broadcast — there is no watcher echo to suppress.
+	//
+	// One file per dispatch: its existence + the attn:dispatch:<id> marker already
+	// embedded in `block` is the exactly-once ledger, so the prior in-file
+	// marker-scan dedup (AppendJournalEntryOnce) is no longer needed here. A
+	// replayed trigger re-renders the identical block and atomically overwrites the
+	// identical file — harmless.
+	root, err := d.notebookRoot()
 	if err != nil {
-		d.logf("dispatch auto-journal: store unavailable: %v", err)
+		d.logf("dispatch auto-journal %s: notebook root unavailable: %v", dispatch.ID, err)
 		return
 	}
-	rel, written, hash, err := store.AppendJournalEntryOnce(dateISO, journalDispatchMarker(dispatch.ID), block)
-	if err != nil {
+	if strings.TrimSpace(root) == "" {
+		return // notebook disabled — silent no-op
+	}
+	if err := writeRawAtomic(notebook.RawDispatchesDir(root), dispatch.ID, []byte(block)); err != nil {
 		d.logf("dispatch auto-journal %s: %v", dispatch.ID, err)
 		return
 	}
-	if !written {
-		return // already journaled — idempotent
-	}
-	// Suppress the watcher echo and surface the write like the CLI append path does.
-	d.noteNotebookSelfWrite(notebook.SelfWrite{Rel: rel, Hash: hash})
-	d.broadcastNotebookChanged(originAgent, rel)
 }
 
-// journalDispatchOnSessionGone journals the outcome of a dispatch whose target
+// journalDispatchOnSessionGone captures the outcome of a dispatch whose target
 // session is being removed — the reliability backstop for a worker that ended
-// without a terminal report. It always attempts the write and lets the journal
-// file's per-dispatch marker (checked under the notebook store lock in
-// AppendJournalEntryOnce) be the sole dedup authority. That keying-off-the-file,
-// not off store state, is deliberate:
+// without a terminal report. It always attempts the write; the per-dispatch raw
+// file (one file per dispatch id) is the exactly-once ledger. Keying off the file
+// rather than off store state is deliberate:
 //
-//   - it no-ops when the report path already journaled (marker present);
 //   - it RECOVERS a dispatch whose report-path write failed transiently — the
 //     store still holds the terminal report at removal time, so the recovered
 //     entry is the rich completed/failed block, not a degraded one. (Keying the
 //     skip off the store's terminal-state instead would strand that dispatch
-//     unjournaled forever, since the marker was never written.)
+//     uncaptured forever, since the file was never written.)
+//   - a replay (report path already captured) re-renders the block and atomically
+//     overwrites that one file — harmless (byte-identical with a server ReportedAt;
+//     with only the wall-clock fallback the header can drift across minutes, so the
+//     overwrite is equivalent rather than byte-identical).
 //
 // Non-dispatch sessions resolve to no dispatch and are ignored.
 //
 // One narrow, accepted race remains: if a teardown reads this dispatch in the
 // sub-millisecond window after a terminal report is rendered but before it commits
-// to the store, AND the teardown's append wins the marker before the report path's,
-// the journal records the lower-fidelity "(ended)" block. Exactly-once still holds
-// (the marker admits a single entry); only the fidelity of that one entry degrades,
-// and only in that window. Closing it fully would require cross-subsystem per-
-// dispatch locking — not worth it for a best-effort capture.
+// to the store, the teardown may write the lower-fidelity "(ended)" block and the
+// report path may then overwrite it with the rich block (or vice versa). Either
+// way the single per-dispatch file holds exactly one entry; only the fidelity of
+// that one entry can briefly differ, and only in that window. Closing it fully
+// would require cross-subsystem per-dispatch locking — not worth it for a
+// best-effort capture.
 func (d *Daemon) journalDispatchOnSessionGone(sessionID string) {
 	dispatch := d.store.GetChiefOfStaffDispatchBySession(strings.TrimSpace(sessionID))
 	if dispatch == nil {

--- a/internal/daemon/notebook_dispatch_journal_test.go
+++ b/internal/daemon/notebook_dispatch_journal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/victorarias/attn/internal/notebook"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -28,18 +29,74 @@ func readJournalFile(t *testing.T, d *Daemon, dateISO string) string {
 	return string(data)
 }
 
-// waitForJournal polls the dated journal until it contains substr — the journal
-// write on the dispatch-report path is a side effect that runs after the socket
-// response is sent, so socket-level tests assert it eventually, not synchronously.
-func waitForJournal(t *testing.T, d *Daemon, dateISO, substr string) string {
+// readRawDispatchFile returns the per-dispatch raw-tier file
+// (.attn/raw/dispatches/<dispatchID>.md), or "" if it does not exist. Dispatch
+// outcomes now land here, redirected out of the curated journal.
+func readRawDispatchFile(t *testing.T, d *Daemon, dispatchID string) string {
+	t.Helper()
+	root, err := d.notebookRoot()
+	if err != nil {
+		t.Fatalf("notebook root: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(notebook.RawDispatchesDir(root), dispatchID+".md"))
+	if errors.Is(err, os.ErrNotExist) {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("read raw dispatch %s: %v", dispatchID, err)
+	}
+	return string(data)
+}
+
+// waitForRawDispatch polls the per-dispatch raw file until it contains substr —
+// the redirect on the dispatch-report path is a side effect that runs after the
+// socket response is sent, so socket-level tests assert it eventually.
+func waitForRawDispatch(t *testing.T, d *Daemon, dispatchID, substr string) string {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		if body := readJournalFile(t, d, dateISO); strings.Contains(body, substr) {
+		if body := readRawDispatchFile(t, d, dispatchID); strings.Contains(body, substr) {
 			return body
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("journal %s never contained %q:\n%s", dateISO, substr, readJournalFile(t, d, dateISO))
+			t.Fatalf("raw dispatch %s never contained %q:\n%s", dispatchID, substr, readRawDispatchFile(t, d, dispatchID))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// waitForRawDispatchesQuiescent polls until the dispatches dir holds exactly the
+// expected settled .md files with no in-flight atomic-writer temp (.tmp.) sibling.
+// The report-path capture runs as a post-response side effect, so a socket-level
+// idempotency check must wait for the in-flight overwrite to settle — otherwise a
+// lingering temp file races t.TempDir() cleanup.
+func waitForRawDispatchesQuiescent(t *testing.T, d *Daemon, wantMD int) {
+	t.Helper()
+	root, err := d.notebookRoot()
+	if err != nil {
+		t.Fatalf("notebook root: %v", err)
+	}
+	dir := notebook.RawDispatchesDir(root)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		entries, err := os.ReadDir(dir)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatalf("read dispatches dir: %v", err)
+		}
+		md, temp := 0, 0
+		for _, e := range entries {
+			switch {
+			case strings.Contains(e.Name(), ".tmp."):
+				temp++
+			case strings.HasSuffix(e.Name(), ".md"):
+				md++
+			}
+		}
+		if temp == 0 && md == wantMD {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("dispatches dir not quiescent: md=%d (want %d) temp=%d", md, wantMD, temp)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -228,12 +285,16 @@ func TestRemoveReapedSessionJournalsOnce(t *testing.T) {
 
 	d.removeReapedSession("worker-reap")
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-reap")
 	if !strings.Contains(body, "Made progress before the worker was reaped.") {
-		t.Fatalf("reaped dispatch was not journaled:\n%s", body)
+		t.Fatalf("reaped dispatch was not captured:\n%s", body)
 	}
 	if n := strings.Count(body, "<!-- attn:dispatch:dsp-reap -->"); n != 1 {
-		t.Fatalf("reaped dispatch journaled %d times, want 1:\n%s", n, body)
+		t.Fatalf("reaped dispatch captured %d markers, want 1:\n%s", n, body)
+	}
+	// The redirect keeps the raw block OUT of the curated journal.
+	if j := readJournalFile(t, d, "2026-06-14"); strings.Contains(j, "dsp-reap") {
+		t.Fatalf("dispatch block leaked into the curated journal:\n%s", j)
 	}
 }
 
@@ -258,19 +319,21 @@ func TestJournalDispatchOnSessionGoneRecoversTerminal(t *testing.T) {
 		t.Fatalf("add dispatch: %v", err)
 	}
 
-	// No prior journal write exists (marker absent) — the fallback recovers it.
+	// No prior raw file exists — the fallback recovers it.
 	d.journalDispatchOnSessionGone("worker-term")
-	d.journalDispatchOnSessionGone("worker-term") // idempotent: marker now present
+	d.journalDispatchOnSessionGone("worker-term") // idempotent: identical overwrite
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-term")
 	if !strings.Contains(body, "(completed)") || !strings.Contains(body, "Finished cleanly.") {
 		t.Fatalf("recovered entry should be the rich completed block, not degraded:\n%s", body)
 	}
 	if strings.Contains(body, "(ended)") {
 		t.Fatalf("recovered entry must not use the degraded (ended) label:\n%s", body)
 	}
+	// The 1:1 <dispatchID>.md keying means a replay is an identical overwrite, so the
+	// single file holds exactly one marker regardless of how many times it is called.
 	if n := strings.Count(body, "<!-- attn:dispatch:dsp-term -->"); n != 1 {
-		t.Fatalf("terminal dispatch recovered %d times, want 1:\n%s", n, body)
+		t.Fatalf("terminal dispatch recovered %d markers, want 1:\n%s", n, body)
 	}
 }
 
@@ -293,12 +356,66 @@ func TestJournalDispatchOutcomeIdempotent(t *testing.T) {
 	d.journalDispatchOutcome(dispatch)
 	d.journalDispatchOutcome(dispatch)
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-once")
 	if n := strings.Count(body, "<!-- attn:dispatch:dsp-once -->"); n != 1 {
-		t.Fatalf("dispatch journaled %d times, want 1:\n%s", n, body)
+		t.Fatalf("dispatch captured %d markers, want 1:\n%s", n, body)
 	}
 	if !strings.Contains(body, "source: dispatch:dsp-once") {
 		t.Fatalf("entry not grounded:\n%s", body)
+	}
+}
+
+// A replay of a dispatch that carries a server ReportedAt re-renders a
+// byte-identical block, but a dispatch WITHOUT a ReportedAt stamps its "## HH:MM"
+// header from the wall clock at render time, so two replays in different minutes
+// produce an equivalent — not byte-identical — block. The exactly-once ledger still
+// holds (one file, one marker); only the header timestamp can drift. This pins the
+// softened "equivalent, not byte-identical" claim in the package comments.
+func TestRenderDispatchJournalEntryWallClockHeaderDrifts(t *testing.T) {
+	withReportedAt := &protocol.ChiefOfStaffDispatch{
+		ID:         "dsp-stamped",
+		Label:      "stamped",
+		ReportedAt: protocol.Ptr("2026-06-15T10:30:00Z"),
+		StructuredReport: &protocol.DispatchReport{
+			ReportType: protocol.DispatchReportTypeCompletion,
+			WorkState:  protocol.DispatchWorkStateCompleted,
+			Summary:    "done",
+		},
+	}
+	noReportedAt := &protocol.ChiefOfStaffDispatch{
+		ID:           "dsp-bare",
+		Label:        "bare",
+		LatestReport: protocol.Ptr("ended without a structured report"),
+		// ReportedAt deliberately absent -> wall-clock fallback for the header.
+	}
+
+	t1 := time.Date(2026, 6, 15, 10, 30, 0, 0, time.UTC)
+	t2 := time.Date(2026, 6, 15, 10, 31, 0, 0, time.UTC)
+
+	// With a server ReportedAt the render ignores the passed clock entirely, so the
+	// block is byte-identical across replays.
+	if _, a, _ := renderDispatchJournalEntry(withReportedAt, t1); true {
+		if _, b, _ := renderDispatchJournalEntry(withReportedAt, t2); a != b {
+			t.Fatalf("ReportedAt dispatch should render identically across clocks:\n%s\n---\n%s", a, b)
+		}
+	}
+
+	// Without one the header tracks the wall clock, so the two blocks differ — but
+	// only in the header line; the body and the dedup marker are unchanged.
+	_, first, ok1 := renderDispatchJournalEntry(noReportedAt, t1)
+	_, second, ok2 := renderDispatchJournalEntry(noReportedAt, t2)
+	if !ok1 || !ok2 {
+		t.Fatal("bare dispatch should still be renderable")
+	}
+	if first == second {
+		t.Fatalf("wall-clock header should drift across minutes:\n%s", first)
+	}
+	if !strings.Contains(first, "## 10:30 —") || !strings.Contains(second, "## 10:31 —") {
+		t.Fatalf("headers not stamped from the passed clock:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	marker := "<!-- attn:dispatch:dsp-bare -->"
+	if !strings.Contains(first, marker) || !strings.Contains(second, marker) {
+		t.Fatalf("dedup marker missing despite header drift")
 	}
 }
 
@@ -326,17 +443,21 @@ func TestReportDispatchAutoJournals(t *testing.T) {
 	}
 	sendNotebookCmd(t, d, report)
 
-	today := time.Now().Format("2006-01-02")
-	body := waitForJournal(t, d, today, "Wired the auto-journal into the report path.")
+	body := waitForRawDispatch(t, d, "dsp-int", "Wired the auto-journal into the report path.")
 	if !strings.Contains(body, "source: dispatch:dsp-int") {
 		t.Fatalf("entry not grounded:\n%s", body)
 	}
+	// The redirect keeps the raw block OUT of the curated journal.
+	if j := readJournalFile(t, d, time.Now().Format("2006-01-02")); strings.Contains(j, "dsp-int") {
+		t.Fatalf("dispatch block leaked into the curated journal:\n%s", j)
+	}
 
-	// A second identical report must not double-write.
+	// A second identical report is a harmless identical overwrite — one file, one marker.
 	sendNotebookCmd(t, d, report)
-	body = waitForJournal(t, d, today, "<!-- attn:dispatch:dsp-int -->")
+	waitForRawDispatchesQuiescent(t, d, 1) // the in-flight overwrite settled; still one file
+	body = readRawDispatchFile(t, d, "dsp-int")
 	if n := strings.Count(body, "<!-- attn:dispatch:dsp-int -->"); n != 1 {
-		t.Fatalf("dispatch journaled %d times after re-report, want 1:\n%s", n, body)
+		t.Fatalf("dispatch captured %d markers after re-report, want 1:\n%s", n, body)
 	}
 }
 
@@ -365,8 +486,8 @@ func TestReportDispatchNonTerminalDoesNotJournal(t *testing.T) {
 
 	// Give any (incorrect) async write a chance to land before asserting absence.
 	time.Sleep(50 * time.Millisecond)
-	if body := readJournalFile(t, d, time.Now().Format("2006-01-02")); strings.Contains(body, "dsp-mid") {
-		t.Fatalf("non-terminal report should not journal:\n%s", body)
+	if body := readRawDispatchFile(t, d, "dsp-mid"); body != "" {
+		t.Fatalf("non-terminal report should not capture a dispatch file:\n%s", body)
 	}
 }
 
@@ -384,16 +505,15 @@ func TestJournalDispatchOnSessionGoneFallback(t *testing.T) {
 	}
 
 	d.journalDispatchOnSessionGone("worker-gone")
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-gone")
 	if !strings.Contains(body, "Got partway before the session closed.") || !strings.Contains(body, "(ended)") {
-		t.Fatalf("session-gone fallback did not journal:\n%s", body)
+		t.Fatalf("session-gone fallback did not capture:\n%s", body)
 	}
 
-	// A session that is not a tracked dispatch is a silent no-op.
-	before := body
+	// A session that is not a tracked dispatch is a silent no-op — it writes no file.
 	d.journalDispatchOnSessionGone("not-a-dispatch")
-	if after := readJournalFile(t, d, "2026-06-14"); after != before {
-		t.Fatalf("non-dispatch session changed the journal:\nbefore:\n%s\nafter:\n%s", before, after)
+	if after := readRawDispatchFile(t, d, "dsp-gone"); after != body {
+		t.Fatalf("non-dispatch session changed the captured file:\nbefore:\n%s\nafter:\n%s", body, after)
 	}
 }
 
@@ -415,9 +535,9 @@ func TestUnregisterSessionJournals(t *testing.T) {
 
 	d.unregisterSession("worker-close", syscall.SIGTERM)
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-close")
 	if !strings.Contains(body, "Worked until the pane was closed.") {
-		t.Fatalf("orderly-close path did not journal:\n%s", body)
+		t.Fatalf("orderly-close path did not capture:\n%s", body)
 	}
 	if d.store.Get("worker-close") != nil {
 		t.Fatal("session record should be removed after unregister")
@@ -441,9 +561,9 @@ func TestCleanupDeletedWorktreeSessionsJournals(t *testing.T) {
 	// addIdleNotebookSession sets Directory to "/tmp/<id>"; match it.
 	d.cleanupDeletedWorktreeSessions("/tmp/worker-wt")
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-wt")
 	if !strings.Contains(body, "Ran inside a worktree that was deleted.") {
-		t.Fatalf("worktree-cleanup path did not journal:\n%s", body)
+		t.Fatalf("worktree-cleanup path did not capture:\n%s", body)
 	}
 	if d.store.Get("worker-wt") != nil {
 		t.Fatal("session record should be removed after worktree cleanup")
@@ -467,9 +587,9 @@ func TestClearAllSessionsJournals(t *testing.T) {
 
 	d.clearAllSessions()
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-clear")
 	if !strings.Contains(body, "Was mid-run when sessions were cleared.") {
-		t.Fatalf("clear-all path did not journal:\n%s", body)
+		t.Fatalf("clear-all path did not capture:\n%s", body)
 	}
 	if d.store.Get("worker-clear") != nil {
 		t.Fatal("session record should be removed after clear-all")
@@ -505,8 +625,11 @@ func TestDropSessionRecordSwallowsJournalFailure(t *testing.T) {
 }
 
 // A free-text field that contains a literal dispatch marker must not be able to
-// poison another dispatch's dedup. The renderer neutralizes HTML-comment openers in
-// the body, so dispatch B's real entry still writes even after A embedded B's marker.
+// forge another dispatch's marker. With the raw-tier redirect each dispatch is a
+// distinct 1:1 file, so A cannot suppress B's separate file; what the neutralize
+// guarantee still protects is that A's OWN file never contains a genuine
+// (un-neutralized) copy of B's marker that a marker-scanner could mistake for B's
+// real entry.
 func TestForgedMarkerDoesNotPoisonDedup(t *testing.T) {
 	d := newNotebookDaemon(t)
 
@@ -521,7 +644,7 @@ func TestForgedMarkerDoesNotPoisonDedup(t *testing.T) {
 			Summary:    "Embedding " + journalDispatchMarker("dsp-B") + " in my summary.",
 		},
 	})
-	// B's real entry must still land — its marker was not pre-written by A.
+	// B's real entry lands in its own file regardless.
 	d.journalDispatchOutcome(&protocol.ChiefOfStaffDispatch{
 		ID:         "dsp-B",
 		Label:      "Victim",
@@ -533,13 +656,21 @@ func TestForgedMarkerDoesNotPoisonDedup(t *testing.T) {
 		},
 	})
 
-	body := readJournalFile(t, d, "2026-06-14")
-	if !strings.Contains(body, "B's genuine outcome.") {
-		t.Fatalf("dispatch B was suppressed by a forged marker in A:\n%s", body)
+	bBody := readRawDispatchFile(t, d, "dsp-B")
+	if !strings.Contains(bBody, "B's genuine outcome.") {
+		t.Fatalf("dispatch B's own file is missing its outcome:\n%s", bBody)
 	}
-	// B's real marker appears exactly once (A's embedded copy was neutralized).
-	if n := strings.Count(body, journalDispatchMarker("dsp-B")); n != 1 {
-		t.Fatalf("B's marker count = %d, want 1 (A's copy should be neutralized):\n%s", n, body)
+	if n := strings.Count(bBody, journalDispatchMarker("dsp-B")); n != 1 {
+		t.Fatalf("B's file marker count = %d, want 1:\n%s", n, bBody)
+	}
+	// A's file embedded B's marker text in free prose; it must have been neutralized
+	// so A's file holds ZERO genuine B markers.
+	aBody := readRawDispatchFile(t, d, "dsp-A")
+	if n := strings.Count(aBody, journalDispatchMarker("dsp-B")); n != 0 {
+		t.Fatalf("A's file holds %d genuine B markers, want 0 (the forged copy must be neutralized):\n%s", n, aBody)
+	}
+	if !strings.Contains(aBody, "<! -- attn:dispatch:dsp-B -->") {
+		t.Fatalf("A's forged marker should be neutralized to a non-opener:\n%s", aBody)
 	}
 }
 

--- a/internal/daemon/notebook_raw_tier.go
+++ b/internal/daemon/notebook_raw_tier.go
@@ -1,0 +1,161 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/notebook"
+)
+
+// The raw tier is the deterministic capture floor for the notebook narration
+// pipeline. It holds machine inputs the narrator later consumes, under
+// <notebook.root>/.attn/raw/ — physically unreachable through the user-facing
+// notebook APIs (CleanPath rejects dotdir segments) and skipped by the watcher,
+// so raw writes emit no external-edit broadcast. Two deterministic daemon writes
+// land here and SHARE this one atomic writer + the one neutralizeJournalMarkers
+// step so they are built, reviewed, and tested together:
+//
+//   - context-snapshots/<wsID>.md — the synchronous context.md snapshot taken at
+//     every workspace-removal site, BEFORE store.RemoveWorkspace runs its
+//     DELETE FROM workspace_contexts (an async writer cannot win that race).
+//   - dispatches/<dispatchID>.md  — the redirected dispatch outcome capture (see
+//     notebook_dispatch_journal.go).
+//
+// They cannot collide: distinct per-item files under distinct subdirs, distinct
+// exactly-once ledgers (file existence + a source footer / marker), and both
+// bodies pass through neutralizeJournalMarkers so no free-text field can forge a
+// journal marker.
+
+// rawTierFilename turns a raw-tier item id (a workspace id or dispatch id) into a
+// single safe "<id>.md" filename, or errors if the id cannot be a single path
+// segment. This is the load-bearing guard that keeps a CLIENT-CONTROLLED id (the
+// workspace id from register_workspace is accepted verbatim over the socket, with
+// no UUID/segment validation) from escaping its raw-tier subdir: filepath.Join
+// cleans ".." segments, so an unvalidated id like "../../../journal/2026-06-15"
+// would resolve OUT of context-snapshots/ and overwrite the curated journal (or,
+// with enough "..", any .md file the daemon can write outside the notebook root).
+// The raw tier is supposed to be physically unreachable through the user-facing
+// notebook APIs, and the daemon must never write the curated journal; an id that
+// is not a plain filename violates both, so we reject it rather than join it.
+//
+// Dispatch ids are server UUIDs and never trip this, but routing both writers
+// through the same guard keeps the invariant in one place instead of resting on a
+// per-call-site property a future caller could quietly break.
+func rawTierFilename(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("raw-tier id is empty")
+	}
+	if strings.ContainsAny(id, `/\`) || id == "." || id == ".." || strings.HasPrefix(id, ".") {
+		return "", fmt.Errorf("raw-tier id %q is not a single safe path segment", id)
+	}
+	// Reject control characters (newlines especially): an id is interpolated into
+	// the file's plaintext "source:" footer, so a newline would let it inject a
+	// forged grounding line, and a control char has no place in a filename anyway.
+	for _, r := range id {
+		if r < 0x20 || r == 0x7f {
+			return "", fmt.Errorf("raw-tier id %q contains a control character", id)
+		}
+	}
+	name := id + ".md"
+	// Belt-and-suspenders: a Clean of the bare name must be the name itself (no
+	// separator, no dotdir reintroduced). filepath.Base of an escaping id would not
+	// round-trip to it.
+	if filepath.Base(name) != name || name != filepath.Clean(name) {
+		return "", fmt.Errorf("raw-tier id %q does not produce a safe filename", id)
+	}
+	return name, nil
+}
+
+// writeRawAtomic writes content to a raw-tier file built from dir + a validated
+// "<id>.md" filename, via a temp+rename so a reader never observes a half-written
+// file, MkdirAll'ing the parent first so a write never fails on a missing raw-tier
+// subdir. It mirrors notebook.writeAtomic / tasks.writeAtomic (no fsync, matching
+// the repo idiom). This is the one writer both deterministic raw-tier writes use,
+// and the single chokepoint that validates the id: callers pass the raw id and the
+// intended subdir, and the path is only ever dir/<safe-name> — never a join that
+// ".." could climb out of. A second containment assertion verifies the final path
+// stays under dir even if rawTierFilename is ever weakened.
+func writeRawAtomic(dir, id string, content []byte) error {
+	name, err := rawTierFilename(id)
+	if err != nil {
+		return err
+	}
+	absPath := filepath.Join(dir, name)
+	cleanDir := filepath.Clean(dir)
+	if filepath.Dir(absPath) != cleanDir {
+		return fmt.Errorf("raw-tier write for %q escapes %q", id, dir)
+	}
+	if err := os.MkdirAll(cleanDir, 0o755); err != nil {
+		return err
+	}
+	tmp := fmt.Sprintf("%s.tmp.%d.%d", absPath, os.Getpid(), time.Now().UnixNano())
+	if err := os.WriteFile(tmp, content, 0o644); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, absPath); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// snapshotWorkspaceContextOnRemove synchronously captures a workspace's
+// context.md overlay into the raw tier before the workspace row (and its
+// context.md) is deleted. It is the deterministic data-safety floor: context.md
+// is erased by store.RemoveWorkspace's DELETE FROM workspace_contexts, which an
+// async writer cannot win, so this MUST run at every removal site AFTER the
+// janitor cancel/forget (commit-fence: no in-flight janitor write is still racing
+// the context row) and BEFORE store.RemoveWorkspace.
+//
+// Best-effort: it never returns an error and never blocks or fails a teardown.
+// Every failure — read error, unresolvable/unconfigured notebook root, write
+// error — is logged and swallowed. An empty or revision-0 context (a workspace
+// that never had an overlay) is a silent no-op.
+//
+// The file is keyed 1:1 on the workspace id, so a replayed removal is a harmless
+// identical overwrite; existence of <wsID>.md plus the
+// "source: workspace-context:<id>@<revision>" footer is the exactly-once ledger
+// (no HTML-comment dedup marker is needed). title is used only for logging — the
+// file is keyed on id, so a blank title never breaks the write or the ledger.
+func (d *Daemon) snapshotWorkspaceContextOnRemove(id, title string) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return
+	}
+
+	canonical, err := d.store.GetWorkspaceContext(id)
+	if err != nil {
+		d.logf("context snapshot %s (%s): read context: %v", id, title, err)
+		return
+	}
+	if strings.TrimSpace(canonical.Content) == "" || canonical.Revision == 0 {
+		return // no overlay to preserve — silent no-op
+	}
+
+	root, err := d.notebookRoot()
+	if err != nil {
+		d.logf("context snapshot %s (%s): notebook root unavailable: %v", id, title, err)
+		return
+	}
+	if strings.TrimSpace(root) == "" {
+		return // notebook disabled — silent no-op
+	}
+
+	// Neutralize the verbatim overlay BEFORE appending the genuine source footer,
+	// so no free-text field in the body can forge a journal marker while the real
+	// footer stays intact (same pattern renderDispatchJournalEntry uses).
+	var doc strings.Builder
+	doc.WriteString(neutralizeJournalMarkers(canonical.Content))
+	fmt.Fprintf(&doc, "\nsource: workspace-context:%s@%d\n", id, canonical.Revision)
+
+	dir := notebook.RawContextSnapshotsDir(root)
+	if err := writeRawAtomic(dir, id, []byte(doc.String())); err != nil {
+		d.logf("context snapshot %s (%s): write under %s: %v", id, title, dir, err)
+		return
+	}
+}

--- a/internal/daemon/notebook_raw_tier_test.go
+++ b/internal/daemon/notebook_raw_tier_test.go
@@ -1,0 +1,321 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/notebook"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// readContextSnapshot returns the raw-tier context snapshot for a workspace
+// (.attn/raw/context-snapshots/<wsID>.md), or "" if it does not exist.
+func readContextSnapshot(t *testing.T, d *Daemon, wsID string) string {
+	t.Helper()
+	root, err := d.notebookRoot()
+	if err != nil {
+		t.Fatalf("notebook root: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(notebook.RawContextSnapshotsDir(root), wsID+".md"))
+	if errors.Is(err, os.ErrNotExist) {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("read context snapshot %s: %v", wsID, err)
+	}
+	return string(data)
+}
+
+// seedWorkspaceContext registers a workspace+session and seeds a revision-1
+// shared context with body, returning the daemon ready for a removal-site call.
+func seedWorkspaceContext(t *testing.T, d *Daemon, sessionID, workspaceID, body string) {
+	t.Helper()
+	setupWorkspaceContextSession(t, d, sessionID, workspaceID)
+	if _, _, err := d.store.UpdateWorkspaceContext(workspaceID, body, sessionID, 0); err != nil {
+		t.Fatalf("seed workspace context: %v", err)
+	}
+}
+
+// The snapshot must land at every removal site, BEFORE the workspace_contexts row
+// is deleted, with the source footer keyed on id@revision.
+func TestSnapshotWorkspaceContextAtRemovalSites(t *testing.T) {
+	cases := []struct {
+		name   string
+		wsID   string
+		remove func(d *Daemon, sessionID, workspaceID string)
+	}{
+		{
+			name: "handleUnregisterWorkspace",
+			wsID: "ws-unreg",
+			remove: func(d *Daemon, _, workspaceID string) {
+				d.handleUnregisterWorkspace(nil, &protocol.UnregisterWorkspaceMessage{ID: workspaceID})
+			},
+		},
+		{
+			name: "dissociateSessionFromWorkspace",
+			wsID: "ws-dissoc",
+			remove: func(d *Daemon, sessionID, _ string) {
+				d.dissociateSessionFromWorkspace(sessionID)
+			},
+		},
+		{
+			name: "unregisterWorkspaceIfEmptyAfterMove",
+			wsID: "ws-move",
+			remove: func(d *Daemon, sessionID, workspaceID string) {
+				// The session must be gone for the workspace to be considered empty.
+				d.workspaces.dissociateSession(sessionID)
+				d.store.Remove(sessionID)
+				d.unregisterWorkspaceIfEmptyAfterMove(workspaceID)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newNotebookDaemon(t)
+			seedWorkspaceContext(t, d, "session-1", tc.wsID, "# Decisions\nchose hash-CAS")
+
+			tc.remove(d, "session-1", tc.wsID)
+
+			// The row is gone (the removal completed) ...
+			if d.store.HasWorkspaceContext(tc.wsID) {
+				t.Fatal("workspace context row survived removal")
+			}
+			// ... yet the snapshot captured the body before the delete.
+			snap := readContextSnapshot(t, d, tc.wsID)
+			if !strings.Contains(snap, "chose hash-CAS") {
+				t.Fatalf("snapshot missing context body:\n%s", snap)
+			}
+			if !strings.Contains(snap, "source: workspace-context:"+tc.wsID+"@1") {
+				t.Fatalf("snapshot missing/incorrect source footer:\n%s", snap)
+			}
+		})
+	}
+}
+
+// The startup-reconciliation reap (loadWorkspacesFromStore) is the fourth removal
+// site. It runs before the compaction runner exists (compactRunner nil), and the
+// snapshot must still land — it does not touch the runner.
+func TestSnapshotWorkspaceContextAtLoadTimeReap(t *testing.T) {
+	d := newNotebookDaemon(t)
+	// Mimic production: an orphaned workspace row + context with no live session,
+	// reaped during Start() before startCompactRunner runs.
+	d.compactRunner = nil
+	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-orphan", Title: "orphan", Directory: "/repo/orphan"})
+	if _, _, err := d.store.UpdateWorkspaceContext("ws-orphan", "# Old context\nstale but durable", "s-orphan", 0); err != nil {
+		t.Fatalf("seed orphan context: %v", err)
+	}
+
+	d.workspaces = newWorkspaceRegistry()
+	d.loadWorkspacesFromStore() // must not panic with a nil runner
+
+	if d.store.GetWorkspace("ws-orphan") != nil {
+		t.Fatal("orphan workspace survived load reap")
+	}
+	snap := readContextSnapshot(t, d, "ws-orphan")
+	if !strings.Contains(snap, "stale but durable") {
+		t.Fatalf("load-reap snapshot missing context body:\n%s", snap)
+	}
+	if !strings.Contains(snap, "source: workspace-context:ws-orphan@1") {
+		t.Fatalf("load-reap snapshot missing source footer:\n%s", snap)
+	}
+}
+
+// An empty or never-written context is a silent no-op: no file is created.
+func TestSnapshotWorkspaceContextEmptyIsNoOp(t *testing.T) {
+	d := newNotebookDaemon(t)
+
+	// A workspace that never had a context overlay (revision 0).
+	d.snapshotWorkspaceContextOnRemove("ws-empty", "Empty workspace")
+	if snap := readContextSnapshot(t, d, "ws-empty"); snap != "" {
+		t.Fatalf("absent context should not write a snapshot:\n%s", snap)
+	}
+
+	// A workspace whose context is whitespace-only is also a no-op (its revision is
+	// >0, so this exercises the content-trim gate, not just the revision gate).
+	setupWorkspaceContextSession(t, d, "session-ws", "ws-blank")
+	if _, _, err := d.store.UpdateWorkspaceContext("ws-blank", "   \n\t", "session-ws", 0); err != nil {
+		t.Fatalf("seed blank context: %v", err)
+	}
+	d.snapshotWorkspaceContextOnRemove("ws-blank", "Blank")
+	if snap := readContextSnapshot(t, d, "ws-blank"); snap != "" {
+		t.Fatalf("whitespace-only context should not write a snapshot:\n%s", snap)
+	}
+}
+
+// A write failure must be swallowed: the helper returns normally and the teardown
+// is never blocked. We force failure by pointing the notebook root under a regular
+// file, so MkdirAll inside the atomic writer fails.
+func TestSnapshotWorkspaceContextSwallowsWriteFailure(t *testing.T) {
+	d := newNotebookDaemon(t)
+	setupWorkspaceContextSession(t, d, "session-1", "ws-fail")
+	if _, _, err := d.store.UpdateWorkspaceContext("ws-fail", "real content", "session-1", 0); err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed blocker file: %v", err)
+	}
+	d.store.SetSetting(SettingNotebookRoot, filepath.Join(blocker, "notebook"))
+
+	// Must not panic and must complete; the full removal path still tears down.
+	d.handleUnregisterWorkspace(nil, &protocol.UnregisterWorkspaceMessage{ID: "ws-fail"})
+
+	if d.store.GetWorkspace("ws-fail") != nil {
+		t.Fatal("workspace must still be removed when the snapshot write fails")
+	}
+}
+
+// A replayed removal is a harmless identical overwrite — the 1:1 <wsID>.md keying
+// means a second snapshot of the same revision reproduces byte-identical content.
+func TestSnapshotWorkspaceContextReplayIsIdenticalOverwrite(t *testing.T) {
+	d := newNotebookDaemon(t)
+	seedWorkspaceContext(t, d, "session-1", "ws-replay", "# Decisions\nlocked the design")
+
+	d.snapshotWorkspaceContextOnRemove("ws-replay", "Replay")
+	first := readContextSnapshot(t, d, "ws-replay")
+	if first == "" {
+		t.Fatal("first snapshot did not write")
+	}
+
+	// The row still exists (we called the helper directly, not the full removal), so
+	// a replay reads the same revision-1 content and overwrites identically.
+	d.snapshotWorkspaceContextOnRemove("ws-replay", "Replay")
+	second := readContextSnapshot(t, d, "ws-replay")
+	if second != first {
+		t.Fatalf("replay was not an identical overwrite:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// A context body that embeds a literal journal marker must be neutralized so no
+// free-text overlay content can forge a marker in the raw tier.
+func TestSnapshotWorkspaceContextNeutralizesForgedMarker(t *testing.T) {
+	d := newNotebookDaemon(t)
+	forged := "Notes\n" + journalDispatchMarker("dsp-victim") + "\nmore notes"
+	seedWorkspaceContext(t, d, "session-1", "ws-forge", forged)
+
+	d.snapshotWorkspaceContextOnRemove("ws-forge", "Forge")
+
+	snap := readContextSnapshot(t, d, "ws-forge")
+	if strings.Contains(snap, journalDispatchMarker("dsp-victim")) {
+		t.Fatalf("forged marker survived neutralization:\n%s", snap)
+	}
+	if !strings.Contains(snap, "<! -- attn:dispatch:dsp-victim -->") {
+		t.Fatalf("forged marker should be neutralized to a non-opener:\n%s", snap)
+	}
+}
+
+// A crafted workspace id with ".." segments must NOT let the snapshot writer escape
+// the context-snapshots subdir. register_workspace accepts the id verbatim over the
+// socket, so an id like "../../../journal/<date>" would otherwise resolve out of the
+// raw tier and overwrite the curated journal (or, with more "..", any .md file the
+// daemon can write outside the notebook root). The write must be refused: no file is
+// created at the escape target, and the workspace context row is irrelevant because
+// the body never reaches disk.
+func TestSnapshotWorkspaceContextRejectsPathTraversal(t *testing.T) {
+	cases := []struct {
+		name      string
+		craftedID string
+		// target is the absolute escape path the unguarded join would have written,
+		// expressed relative to the notebook root or its parent.
+		target func(root string) string
+	}{
+		{
+			name:      "into the curated journal",
+			craftedID: "../../../journal/2026-06-15",
+			target:    func(root string) string { return filepath.Join(root, "journal", "2026-06-15.md") },
+		},
+		{
+			name:      "outside the notebook root",
+			craftedID: "../../../../victim",
+			target:    func(root string) string { return filepath.Join(filepath.Dir(root), "victim.md") },
+		},
+		{
+			name:      "absolute path escape",
+			craftedID: "/etc/attn-victim",
+			target:    func(root string) string { return filepath.Join(root, "etc", "attn-victim.md") },
+		},
+		{
+			name:      "nested subdir escape",
+			craftedID: "../dispatches/dsp-victim",
+			target: func(root string) string {
+				return filepath.Join(notebook.RawDispatchesDir(root), "dsp-victim.md")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newNotebookDaemon(t)
+			root, err := d.notebookRoot()
+			if err != nil {
+				t.Fatalf("notebook root: %v", err)
+			}
+
+			// Plant a sentinel at the escape target so a successful escape would be an
+			// observable overwrite, not just a fresh write.
+			victim := tc.target(root)
+			if err := os.MkdirAll(filepath.Dir(victim), 0o755); err != nil {
+				t.Fatalf("mkdir victim dir: %v", err)
+			}
+			if err := os.WriteFile(victim, []byte("SENTINEL — must survive"), 0o644); err != nil {
+				t.Fatalf("seed sentinel: %v", err)
+			}
+
+			seedWorkspaceContext(t, d, "session-evil", tc.craftedID, "ATTACKER CONTROLLED CONTENT")
+			d.snapshotWorkspaceContextOnRemove(tc.craftedID, "evil")
+
+			data, err := os.ReadFile(victim)
+			if err != nil {
+				t.Fatalf("read sentinel: %v", err)
+			}
+			if string(data) != "SENTINEL — must survive" {
+				t.Fatalf("path traversal overwrote %s:\n%s", victim, string(data))
+			}
+		})
+	}
+}
+
+// The shared raw-tier writer is the single chokepoint and must reject an unsafe id
+// directly, independent of the snapshot call site, so a future caller cannot
+// reintroduce the escape.
+func TestWriteRawAtomicRejectsUnsafeID(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "raw", "context-snapshots")
+
+	for _, id := range []string{
+		"",
+		".",
+		"..",
+		"../escape",
+		"../../journal/2026-06-15",
+		"/etc/passwd",
+		"a/b",
+		`a\b`,
+		".hidden",
+		// Control chars: a newline in the id would otherwise inject a forged
+		// "source:" footer line into the file body (the id is interpolated there).
+		"ws\nsource: workspace-context:victim@9",
+		"ws\x00null",
+		"ws\x7fdel",
+	} {
+		if err := writeRawAtomic(dir, id, []byte("x")); err == nil {
+			t.Fatalf("writeRawAtomic accepted unsafe id %q", id)
+		}
+	}
+
+	// A normal id still writes to exactly dir/<id>.md and nowhere else.
+	if err := writeRawAtomic(dir, "ws-ok", []byte("ok")); err != nil {
+		t.Fatalf("writeRawAtomic rejected a safe id: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "ws-ok.md"))
+	if err != nil {
+		t.Fatalf("safe id did not write to dir/<id>.md: %v", err)
+	}
+	if string(data) != "ok" {
+		t.Fatalf("safe write produced wrong content: %q", string(data))
+	}
+}

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -397,6 +397,7 @@ func (d *Daemon) handleUnregisterWorkspace(client *wsClient, msg *protocol.Unreg
 		return
 	}
 	d.forgetWorkspaceContextCompaction(id)
+	d.snapshotWorkspaceContextOnRemove(id, snapshot.Title)
 	d.store.RemoveWorkspace(id)
 	d.pruneTileContentSubscriptionsForLayout(id, nil)
 	d.wsHub.Broadcast(&protocol.WebSocketEvent{
@@ -431,7 +432,10 @@ func (d *Daemon) loadWorkspacesFromStore() {
 				!d.workspaceHasSessionlessContent(ws.ID) {
 				// loadWorkspacesFromStore runs during Start() before the compaction
 				// runner is constructed; forgetWorkspaceContextCompaction is nil-safe.
+				// The snapshot does not touch the runner (it only reads the store and
+				// writes a file), so it is safe to call here with no runner.
 				d.forgetWorkspaceContextCompaction(ws.ID)
+				d.snapshotWorkspaceContextOnRemove(ws.ID, ws.Title)
 				d.store.RemoveWorkspace(ws.ID)
 				continue
 			}
@@ -547,6 +551,7 @@ func (d *Daemon) dissociateSessionFromWorkspace(sessionID string) {
 			return
 		}
 		d.forgetWorkspaceContextCompaction(workspaceID)
+		d.snapshotWorkspaceContextOnRemove(workspaceID, snapshot.Title)
 		d.store.RemoveWorkspace(workspaceID)
 		d.pruneTileContentSubscriptionsForLayout(workspaceID, nil)
 		d.wsHub.Broadcast(&protocol.WebSocketEvent{

--- a/internal/daemon/workspacelayout.go
+++ b/internal/daemon/workspacelayout.go
@@ -825,6 +825,7 @@ func (d *Daemon) unregisterWorkspaceIfEmptyAfterMove(workspaceID string) {
 		return
 	}
 	d.forgetWorkspaceContextCompaction(workspaceID)
+	d.snapshotWorkspaceContextOnRemove(workspaceID, snapshot.Title)
 	d.store.RemoveWorkspace(workspaceID)
 	d.pruneTileContentSubscriptionsForLayout(workspaceID, nil)
 	d.wsHub.Broadcast(&protocol.WebSocketEvent{

--- a/internal/notebook/raw_tier.go
+++ b/internal/notebook/raw_tier.go
@@ -1,0 +1,36 @@
+package notebook
+
+import "path/filepath"
+
+// Raw tier machine paths.
+//
+// The narration pipeline feeds the curated journal from a separate "raw tier"
+// of machine inputs under <root>/.attn/raw/. Like the dreaming state dir, the raw
+// tier lives in the .attn dotdir: it is skipped by List, by the watcher, and by
+// any dotfile-aware external sync scanner, and CleanPath rejects dotdir segments
+// so Store.Write/Read/AppendJournalEntryOnce cannot address it. Daemon and agent
+// code therefore writes the raw tier with direct filesystem I/O, never through
+// notebook.Store. These helpers keep the ".attn"/"raw"/... literals in one place
+// (mirroring DreamsStateDir) so callers do not hardcode the layout.
+const (
+	rawDir                 = "raw"
+	rawContextSnapshotsDir = "context-snapshots"
+	rawDispatchesDir       = "dispatches"
+)
+
+// RawDir returns the absolute .attn/raw directory for a notebook root.
+func RawDir(root string) string {
+	return filepath.Join(root, machineDir, rawDir)
+}
+
+// RawContextSnapshotsDir returns the absolute directory holding per-workspace
+// context.md removal snapshots (<wsID>.md).
+func RawContextSnapshotsDir(root string) string {
+	return filepath.Join(RawDir(root), rawContextSnapshotsDir)
+}
+
+// RawDispatchesDir returns the absolute directory holding per-dispatch outcome
+// files (<dispatchID>.md).
+func RawDispatchesDir(root string) string {
+	return filepath.Join(RawDir(root), rawDispatchesDir)
+}


### PR DESCRIPTION
## What & why

The deterministic **capture floor** for the notebook-narration epic (plan: `docs/plans/2026-06-14-notebook-narration.md`), stacked on the foundation PR (#335 → `feat/tasks-runner`).

The narration pass needs a reliable, machine-written source of "what happened" that is *not* the curated journal. This PR establishes that **raw tier** under `<notebook-root>/.attn/raw/` and routes the daemon's two deterministic captures onto it — so the journal a human reads stays curated, and no workspace state is silently lost on teardown.

## What's in it

- **Raw-tier paths** (`internal/notebook/raw_tier.go`): `RawDir` / `RawContextSnapshotsDir` / `RawDispatchesDir`. The tier lives under `.attn/`, which `CleanPath` rejects and the watcher skips — so it's written with direct filesystem I/O, never `notebook.Store`, and emits **no** `notebook_changed` broadcast (no watcher echo to suppress).

- **Dispatch capture redirected** to `.attn/raw/dispatches/<id>.md` instead of `journal/<date>.md`. One file per dispatch id is the exactly-once ledger; a replayed trigger (report path / session-gone fallback / restart) re-renders the block and atomically overwrites that one file.

- **Workspace context snapshot on removal** → `.attn/raw/context-snapshots/<wsID>.md`, taken synchronously at **every** removal site in the order `forget-compaction → snapshot → RemoveWorkspace`, before the `DELETE FROM workspace_contexts` erases it (an async writer can't win that race). Best-effort: never blocks or fails a teardown; an empty/never-overlaid context is a silent no-op.

## Security

The workspace id is **client-controlled** (`register_workspace` accepts `msg.ID` verbatim — no UUID/segment validation). Both raw writers funnel through a single `rawTierFilename` guard + `writeRawAtomic` chokepoint that:
- rejects any id that isn't one safe path segment — `/`, `\`, `.`, `..`, leading-dot, and **control chars** (a newline would otherwise inject a forged `source:` footer line into the file body), and
- asserts the final path stays under the intended subdir.

Without this, a crafted id like `../../../journal/2026-06-15` would resolve out of `context-snapshots/` and **overwrite the curated journal** (the load-bearing invariant: the daemon must never write the curated journal). Regression-tested with four escape vectors (`TestSnapshotWorkspaceContextRejectsPathTraversal`) and the unsafe-id + control-char set (`TestWriteRawAtomicRejectsUnsafeID`).

## How it was built

An adversarially-reviewed multi-agent workflow (build → 3-lens skeptical concurrency/security review → fix). The review caught the path-traversal-into-the-journal escape; the control-char hardening + its regression case were added on top.

## Testing

- `go build ./...` and `go vet` clean.
- `internal/daemon` + `internal/notebook` suites green (snapshot at all 4 removal sites, load-time reap, empty/whitespace no-op, replay-is-identical-overwrite, forged-marker neutralization, wall-clock-header drift, 4 path-traversal vectors, unsafe-id/control-char rejection).

## Follow-up (not in this PR)

`notebook.Store.AppendJournalEntryOnce` now has no production caller (the dispatch path was its only one) — it writes the curated journal, so it's a caller-less footgun worth deleting in a later cleanup. Left out here to keep this PR's scope to the capture floor.

## Scope

No protocol change (ProtocolVersion stays 109). Narration tasks, the status surface, and the dreaming fold-in stack on top per the plan.
