### PR TITLE
feat(notebook): fold dreaming harvest onto the durable task runner

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -232,11 +232,9 @@ type Daemon struct {
 	) (agentdriver.HeadlessTaskResult, error)
 	narrationNowOverride func() time.Time
 
-	// Dreaming scheduler (notebook consolidation janitor). dreamMu guards the
-	// single-flight dreamRunning guard; dreamSchedulerInterval overrides the tick
-	// cadence in tests (zero = default).
-	dreamMu                sync.Mutex
-	dreamRunning           bool
+	// Notebook cron enqueuer. dreamSchedulerInterval overrides the tick cadence in
+	// tests (zero = default). The harvest itself runs on the durable runner (kind
+	// harvest_dream), so there is no in-daemon single-flight guard here.
 	dreamSchedulerInterval time.Duration
 }
 
@@ -720,12 +718,14 @@ func (d *Daemon) Start() error {
 	// Start branch monitoring
 	go d.monitorBranches()
 
-	// Start the dreaming consolidation scheduler (clears orphaned run locks, then
-	// runs the nightly harvest when due). Off unless notebook.dreaming.enabled.
-	go d.startDreamingScheduler(d.done)
-
-	// Construct + start the durable compaction runner (kind "compact_context").
+	// Construct + start the durable compaction runner (kinds compact_context,
+	// summarize_session, narrate_workspace, harvest_dream).
 	d.startCompactRunner()
+
+	// Start the notebook cron enqueuer (enqueues the nightly dream harvest onto the
+	// durable runner when due; off unless notebook.dreaming.enabled). Launched AFTER
+	// startCompactRunner so harvest_dream is registered before the first tick fires.
+	go d.startNotebookCronEnqueuer(d.done)
 
 	d.signalStarted()
 	startSucceeded = true

--- a/internal/daemon/notebook_dreaming.go
+++ b/internal/daemon/notebook_dreaming.go
@@ -16,15 +16,16 @@ import (
 //
 // This file implements the deterministic, LLM-free harvest and the inspection
 // commands that surface it (`attn notebook dream status` / `--dry-run`). It scans
-// the three v1 sources — dated journals, canonical workspace-context snapshots,
-// and closed chief-of-staff dispatches — into deduplicated candidates ordered by
-// durability signal (recurrence across distinct contexts).
+// the two surviving v1 sources — dated journals and closed chief-of-staff
+// dispatches — into deduplicated candidates ordered by durability signal
+// (recurrence across distinct contexts). (Workspace-context re-read, the former
+// source-2, was removed once narration took ownership of distilling context.md
+// into the journal.)
 //
-// Harvest here is preview-only: it never writes candidates.json, never advances a
-// cursor, and never touches durable memory. Persistence, the nightly scheduler,
-// and the gated LLM promote pass arrive in the follow-up dreaming PR; keeping
-// this phase side-effect-free makes the harvest model observable and reviewable
-// before anything runs autonomously.
+// The harvest functions here are read-only previews: they never write
+// candidates.json and never touch durable memory. Persistence is the harvest_dream
+// executor's job (harvestDreamExecutor, on the durable runner), dispatched nightly
+// by the cron enqueuer; the gated LLM promote pass arrives in the follow-up PR.
 
 // topDreamCandidates bounds how many candidates `dream status` returns inline.
 const topDreamCandidates = 10
@@ -33,23 +34,11 @@ const topDreamCandidates = 10
 // returns, so a large notebook can't produce an unbounded response.
 const maxDreamRunCandidates = 200
 
-// harvestDreamCandidates scans all three v1 sources into a fresh merged candidate
-// set. It is read-only: callers decide what to do with the result. Failure to read
-// any single source is logged and skipped — a partial harvest is more useful than
-// none, and the preview is advisory.
-func (d *Daemon) harvestDreamCandidates() (*notebook.DreamCandidateSet, error) {
-	set := notebook.NewDreamCandidateSet()
-	if err := d.harvestInto(set); err != nil {
-		return nil, err
-	}
-	return set, nil
-}
-
 // dreamHarvestUnion loads the persisted candidate set and merges a fresh harvest
 // into it, returning the union and how many candidates were already persisted
 // before the harvest. This is exactly what the next scheduled run would persist,
 // so status and dry-run preview the real accumulated state — not just what one
-// in-the-moment scan happens to see. It never writes; runDreamHarvest persists.
+// in-the-moment scan happens to see. It never writes; harvestDreamExecutor persists.
 func (d *Daemon) dreamHarvestUnion() (set *notebook.DreamCandidateSet, persisted int, err error) {
 	root, err := d.notebookRoot()
 	if err != nil {
@@ -67,8 +56,13 @@ func (d *Daemon) dreamHarvestUnion() (set *notebook.DreamCandidateSet, persisted
 	return set, persisted, nil
 }
 
-// harvestInto scans all three v1 sources into the supplied set, merging with
-// whatever it already holds (re-adding a known source ref is idempotent).
+// harvestInto scans the v1 sources into the supplied set, merging with whatever
+// it already holds (re-adding a known source ref is idempotent).
+//
+// Source 2 (workspace-context Decisions/Constraints re-read) was removed when
+// narration took ownership of distilling context.md into the journal: the journal
+// is now the single durable system of record harvest reads from, so re-reading
+// workspace context would double-count what narration already wrote.
 func (d *Daemon) harvestInto(set *notebook.DreamCandidateSet) error {
 	store, err := d.notebookStoreFor()
 	if err != nil {
@@ -100,19 +94,8 @@ func (d *Daemon) harvestInto(set *notebook.DreamCandidateSet) error {
 		}
 	}
 
-	// 2. Workspace-context snapshots: durable Decisions/Constraints per workspace.
+	// 3. Closed dispatches: a dispatch is closed when its target session is gone.
 	if d.store != nil {
-		contexts, cerr := d.store.ListWorkspaceContexts()
-		if cerr != nil {
-			d.logf("dreaming harvest: list workspace contexts: %v", cerr)
-		}
-		for _, wc := range contexts {
-			for _, sig := range extractContextSignals(wc.WorkspaceID, wc.Content, wc.UpdatedAt) {
-				set.Add(sig)
-			}
-		}
-
-		// 3. Closed dispatches: a dispatch is closed when its target session is gone.
 		for _, disp := range d.store.ListChiefOfStaffDispatches("") {
 			if disp == nil || d.store.Get(disp.SessionID) != nil {
 				continue
@@ -124,78 +107,6 @@ func (d *Daemon) harvestInto(set *notebook.DreamCandidateSet) error {
 	}
 
 	return nil
-}
-
-// contextDurableHeadings are the workspace-context sections whose bullets are
-// durable enough to harvest. Area/Current Picture/Threads are working state;
-// Decisions and Constraints are the facts meant to outlive a workspace.
-var contextDurableHeadings = map[string]bool{
-	"## decisions":   true,
-	"## constraints": true,
-}
-
-// extractContextSignals harvests each Decisions/Constraints bullet from a
-// canonical workspace-context snapshot. The workspace is both the source ref and
-// the distinct-context label, so a decision echoed across several workspaces
-// reads as recurring.
-func extractContextSignals(workspaceID, content, updatedAt string) []notebook.DreamSignal {
-	ref := "context:" + workspaceID
-	ctx := "workspace:" + workspaceID
-	var out []notebook.DreamSignal
-	for _, bullet := range collectBulletsUnderHeadings(content, contextDurableHeadings) {
-		out = append(out, notebook.DreamSignal{
-			Source:    notebook.SignalSourceContext,
-			Text:      bullet,
-			SourceRef: ref,
-			Context:   ctx,
-			Seen:      updatedAt,
-		})
-	}
-	return out
-}
-
-// collectBulletsUnderHeadings returns the list bullets (with their continuation
-// lines) that appear under any of the target "## " headings. A heading toggles
-// the active section; a blank line or new bullet ends the current bullet; any
-// new heading ends the section.
-func collectBulletsUnderHeadings(content string, headings map[string]bool) []string {
-	var bullets []string
-	var cur []string
-	inSection := false
-	flush := func() {
-		if len(cur) > 0 {
-			bullets = append(bullets, strings.Join(cur, "\n"))
-			cur = nil
-		}
-	}
-	for line := range strings.SplitSeq(content, "\n") {
-		trimmed := strings.TrimSpace(line)
-		switch {
-		case strings.HasPrefix(trimmed, "## "):
-			flush()
-			inSection = headings[strings.ToLower(trimmed)]
-			continue
-		case strings.HasPrefix(trimmed, "# "):
-			flush()
-			inSection = false
-			continue
-		}
-		if !inSection {
-			continue
-		}
-		if trimmed == "" {
-			flush()
-			continue
-		}
-		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
-			flush()
-			cur = append(cur, trimmed)
-		} else if len(cur) > 0 {
-			cur = append(cur, trimmed) // continuation of the current bullet
-		}
-	}
-	flush()
-	return bullets
 }
 
 // dispatchSignals harvests the durable outcome of a closed dispatch: its

--- a/internal/daemon/notebook_dreaming_scheduler.go
+++ b/internal/daemon/notebook_dreaming_scheduler.go
@@ -1,40 +1,75 @@
 package daemon
 
 import (
-	"errors"
+	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
 	"github.com/victorarias/attn/internal/notebook"
+	"github.com/victorarias/attn/internal/tasks"
 )
 
-// Dreaming scheduler — phase B1 (deterministic, no LLM).
+// Dreaming cron enqueuer — phase B1 (deterministic, no LLM).
 //
-// This file makes the dreaming pass RUN on a schedule and remember what it saw
-// across daemon restarts. A timezone-aware cron drives a nightly harvest that
-// merges into the persisted candidate set under .attn/dreams/; the LLM promote
-// pass that turns candidates into durable memory arrives in the follow-up PR.
+// This file makes the dreaming harvest RUN on a schedule and remember what it saw
+// across daemon restarts. A timezone-aware cron decides, each tick, whether a
+// nightly harvest is due; when it is, the enqueuer enqueues a single
+// harvest_dream task onto the durable runner (internal/tasks). The runner owns
+// execution, single-flight (its single worker), retry/backoff, and crash
+// recovery (orphan-running reset on start) — so the enqueuer is a thin
+// schedule-and-dispatch loop with no run machinery of its own.
 //
-// Lifecycle mirrors the workspace-context janitor: a single-flight guard so two
-// runs never overlap, a filesystem lock for crash auditability, and startup
-// recovery that clears a lock orphaned by a crashed run. The scheduler is a
-// ticker loop that asks, each tick, whether a run is due — granularity of a
-// minute is ample for a daily janitor and keeps catch-up logic trivial.
+// The harvest merges into the persisted candidate set under .attn/dreams/; the
+// LLM promote pass that turns candidates into durable memory arrives in the
+// follow-up PR. The cron tick granularity of a minute is ample for a daily
+// janitor and keeps catch-up logic trivial.
+
+// harvestDreamKind is the runner task kind for the nightly dream harvest. Its
+// subject is the notebook root string (harvest_dream:<root>); the task store's
+// sanitizeID turns the slashed root into a safe single filename component.
+const harvestDreamKind = "harvest_dream"
 
 const (
 	// defaultDreamingFrequency runs the pass nightly at 03:00 in the configured
 	// timezone — quiet hours, after a day's journals and dispatches have landed.
 	defaultDreamingFrequency = "0 3 * * *"
 
-	// defaultDreamSchedulerInterval is how often the scheduler checks whether a
-	// run is due. A daily janitor does not need finer granularity.
+	// defaultDreamSchedulerInterval is how often the enqueuer checks whether a
+	// harvest is due. A daily janitor does not need finer granularity.
 	defaultDreamSchedulerInterval = time.Minute
 )
 
-// errDreamRunning signals that a dreaming run is already in progress; the
-// scheduler treats it as a benign skip rather than an error to log loudly.
-var errDreamRunning = errors.New("dreaming pass already running")
+// harvestDreamExecutor merges a fresh harvest into the persisted candidate set
+// and saves it. It runs on the durable runner (single worker = single-flight, so
+// no bespoke guard or lock is needed) and is the SOLE writer of candidates.json;
+// it deliberately does NOT touch DreamRunState (the cron enqueuer owns that, so
+// state.json has exactly one writer). This phase writes only machine state under
+// .attn/dreams/ — no durable memory and no LLM (that is the promote phase).
+//
+// No CommitGuard: SaveDreamCandidates is an atomic temp+rename, ctx-free write,
+// so a Cancel/timeout cannot tear it (the same property the janitor's ctx-free
+// commit relies on). The ctx is therefore unused.
+func (d *Daemon) harvestDreamExecutor(_ context.Context, _ *tasks.Task) error {
+	root, err := d.notebookRoot()
+	if err != nil {
+		return fmt.Errorf("dreaming harvest: resolve root: %w", err)
+	}
+	if strings.TrimSpace(root) == "" {
+		return fmt.Errorf("dreaming harvest: empty notebook root")
+	}
+	set, persisted, err := d.dreamHarvestUnion()
+	if err != nil {
+		return fmt.Errorf("dreaming harvest: union: %w", err)
+	}
+	candidates := set.Candidates()
+	if err := notebook.SaveDreamCandidates(root, candidates); err != nil {
+		return fmt.Errorf("dreaming harvest: save candidates: %w", err)
+	}
+	d.logf("dreaming: harvested %d candidates (%d new) into %s", len(candidates), len(candidates)-persisted, root)
+	return nil
+}
 
 // dreamingEnabled reports whether the notebook.dreaming.enabled gate is on.
 func (d *Daemon) dreamingEnabled() bool {
@@ -97,24 +132,16 @@ func parseDreamTime(s string) (time.Time, bool) {
 	return time.Time{}, false
 }
 
-// startDreamingScheduler clears any orphaned lock from a crashed run, then blocks
-// running the scheduler tick loop until done is closed. Intended to be launched in
-// its own goroutine from Start.
+// startNotebookCronEnqueuer blocks running the notebook cron tick loop until done
+// is closed. Intended to be launched in its own goroutine from Start, AFTER
+// startCompactRunner so the harvest_dream executor is registered before the first
+// tick can enqueue.
 //
 // Shutdown is by done alone (close(d.done) in Stop), like the daemon's other
-// d.done-driven loops; there is no explicit join. A harvest in flight when done
-// closes is not waited for, which is safe: state writes are atomic (temp+rename)
-// and a lock left by an abrupt stop is reclaimed by ClearOrphanDreamLocks on the
-// next start — the same crash path the lock is designed around.
-func (d *Daemon) startDreamingScheduler(done <-chan struct{}) {
-	if root, err := d.notebookRoot(); err == nil {
-		if n, err := notebook.ClearOrphanDreamLocks(root); err != nil {
-			d.logf("dreaming scheduler: clear orphan locks: %v", err)
-		} else if n > 0 {
-			d.logf("dreaming scheduler: cleared %d orphan dream lock(s)", n)
-		}
-	}
-
+// d.done-driven loops; there is no explicit join. The enqueuer holds no run
+// machinery — it only dispatches onto the durable runner, which owns single-flight
+// and crash recovery — so there is nothing to drain on stop.
+func (d *Daemon) startNotebookCronEnqueuer(done <-chan struct{}) {
 	interval := d.dreamSchedulerInterval
 	if interval <= 0 {
 		interval = defaultDreamSchedulerInterval
@@ -126,31 +153,41 @@ func (d *Daemon) startDreamingScheduler(done <-chan struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
-			d.dreamSchedulerTick(time.Now())
+			d.notebookCronTick(time.Now())
 		}
 	}
 }
 
-// dreamSchedulerTick runs at most one harvest per tick, when the schedule says a
-// run is due. It is the unit-testable core of the scheduler: tests drive it with
-// synthetic times instead of waiting on a real ticker.
+// notebookCronTick is the per-tick fan-out of the single notebook cron. Today it
+// enqueues only the due nightly dream harvest; the daily per-workspace narrate
+// lands here in the follow-up PR.
+func (d *Daemon) notebookCronTick(now time.Time) {
+	d.enqueueDueDreamHarvest(now)
+	// TODO(daily-narrate): also enqueue per-active-workspace narrate here.
+}
+
+// enqueueDueDreamHarvest decides, from the timezone-aware cron and the persisted
+// anchor, whether a harvest is due now; when it is, it advances the anchor and
+// records the dispatch time on a SINGLE state write, then enqueues the
+// harvest_dream task. The runner owns the actual harvest (execution, single-flight,
+// retry, crash recovery).
 //
 // Anchoring: the very FIRST observation with no persisted anchor records "now" and
 // returns, so enabling dreaming never fires an immediate harvest on daemon startup
-// — the first real run lands at the next scheduled slot. After that a run is due
-// once schedule.Next(anchor) has passed; the run advances the anchor to its
-// completion time.
+// — the first real dispatch lands at the next scheduled slot. After that a fire is
+// due once schedule.Next(anchor) has passed; the dispatch advances the anchor to
+// "now".
 //
 // Catch-up semantics: several scheduled slots missed while the daemon was down (a
-// sleeping laptop) collapse into a SINGLE catch-up run on the next tick — not one
-// run per missed slot — because the anchor jumps forward to the run time. Two
+// sleeping laptop) collapse into a SINGLE catch-up enqueue on the next tick — not
+// one per missed slot — because the anchor jumps forward to the dispatch time. Two
 // nuances follow from anchoring on wall-clock time, both deliberate and benign for
 // this harvest-only phase (it writes idempotent machine state, no LLM): a wake
-// shortly BEFORE the day's slot runs the catch-up and then that slot when it
-// arrives; and re-enabling after a long disable performs one catch-up run (the
+// shortly BEFORE the day's slot enqueues the catch-up and then that slot when it
+// arrives; and re-enabling after a long disable performs one catch-up enqueue (the
 // persisted anchor is stale), unlike a first-ever enable. The promote phase will
 // revisit whether either warrants suppression before attaching an LLM pass.
-func (d *Daemon) dreamSchedulerTick(now time.Time) {
+func (d *Daemon) enqueueDueDreamHarvest(now time.Time) {
 	if !d.dreamingEnabled() {
 		return
 	}
@@ -164,6 +201,14 @@ func (d *Daemon) dreamSchedulerTick(now time.Time) {
 		d.logf("dreaming scheduler: resolve root: %v", err)
 		return
 	}
+
+	// Resolve the runner BEFORE touching state, so a missing/disabled runner never
+	// advances the anchor (which would silently skip the day with no work done).
+	runner := d.compactRunnerRef()
+	if runner == nil || runner.Disabled() {
+		return
+	}
+
 	state, err := notebook.LoadDreamRunState(root)
 	if err != nil {
 		d.logf("dreaming scheduler: load state: %v", err)
@@ -172,8 +217,8 @@ func (d *Daemon) dreamSchedulerTick(now time.Time) {
 
 	anchor, ok := parseDreamTime(state.ScheduledFrom)
 	if !ok {
-		// First enable (or a corrupt anchor): anchor at now so the first run lands
-		// at the next scheduled slot instead of immediately.
+		// First enable (or a corrupt anchor): anchor at now so the first dispatch
+		// lands at the next scheduled slot instead of immediately.
 		state.ScheduledFrom = now.UTC().Format(time.RFC3339)
 		if err := notebook.SaveDreamRunState(root, state); err != nil {
 			d.logf("dreaming scheduler: anchor schedule: %v", err)
@@ -193,56 +238,17 @@ func (d *Daemon) dreamSchedulerTick(now time.Time) {
 	if next.After(now) {
 		return // not due yet
 	}
-	if _, err := d.runDreamHarvest(now); err != nil && !errors.Is(err, errDreamRunning) {
-		d.logf("dreaming scheduler: run: %v", err)
-	}
-}
 
-// runDreamHarvest performs one scheduled harvest: under a single-writer guard and
-// filesystem lock, it merges a fresh harvest into the persisted candidate set,
-// saves it, and advances the schedule anchor. This phase writes only machine state
-// under .attn/dreams/ — no durable memory and no LLM (that is the promote phase).
-func (d *Daemon) runDreamHarvest(now time.Time) (*notebook.DreamRunState, error) {
-	d.dreamMu.Lock()
-	if d.dreamRunning {
-		d.dreamMu.Unlock()
-		return nil, errDreamRunning
-	}
-	d.dreamRunning = true
-	d.dreamMu.Unlock()
-	defer func() {
-		d.dreamMu.Lock()
-		d.dreamRunning = false
-		d.dreamMu.Unlock()
-	}()
-
-	root, err := d.notebookRoot()
-	if err != nil {
-		return nil, err
-	}
-	release, err := notebook.AcquireDreamLock(root)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = release() }()
-
-	set, persisted, err := d.dreamHarvestUnion()
-	if err != nil {
-		return nil, err
-	}
-	candidates := set.Candidates()
-	if err := notebook.SaveDreamCandidates(root, candidates); err != nil {
-		return nil, err
-	}
-	state := notebook.DreamRunState{
-		ScheduledFrom:         now.UTC().Format(time.RFC3339),
-		LastRunAt:             now.UTC().Format(time.RFC3339),
-		LastRunNewCandidates:  len(candidates) - persisted,
-		LastRunCandidateCount: len(candidates),
-	}
+	// Due: anchor-FIRST ordering. Advance the anchor and record the dispatch time on
+	// ONE state write, THEN enqueue. If the rare Enqueue fails, the advanced anchor
+	// skips one day rather than re-firing every tick; the idempotent harvest union
+	// makes a skipped day benign (tomorrow's run picks up everything).
+	state.ScheduledFrom = now.UTC().Format(time.RFC3339)
+	state.LastRunAt = now.UTC().Format(time.RFC3339)
 	if err := notebook.SaveDreamRunState(root, state); err != nil {
-		return nil, err
+		d.logf("dreaming scheduler: advance anchor: %v", err)
 	}
-	d.logf("dreaming: harvested %d candidates (%d new) into %s", len(candidates), len(candidates)-persisted, root)
-	return &state, nil
+	if _, err := runner.Enqueue(harvestDreamKind, root, tasks.EnqueueOptions{ZeroDebounce: true}); err != nil {
+		d.logf("dreaming: enqueue harvest: %v", err)
+	}
 }

--- a/internal/daemon/notebook_dreaming_scheduler_test.go
+++ b/internal/daemon/notebook_dreaming_scheduler_test.go
@@ -1,11 +1,12 @@
 package daemon
 
 import (
-	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/victorarias/attn/internal/notebook"
+	"github.com/victorarias/attn/internal/tasks"
 )
 
 func mustTime(t *testing.T, s string) time.Time {
@@ -34,51 +35,89 @@ func dreamRoot(t *testing.T, d *Daemon) string {
 	return root
 }
 
-// A disabled scheduler tick is fully inert: it neither anchors the schedule nor
-// harvests, so turning dreaming off leaves no machine state behind.
-func TestDreamSchedulerTickDisabledIsInert(t *testing.T) {
+// installDreamHarvestRunner wires a started durable runner with the harvest_dream
+// executor onto the daemon (the enqueuer's required dispatch target). The runner's
+// OWN tasks dir is a throwaway temp dir; it deliberately does NOT touch
+// SettingNotebookRoot, which newNotebookDaemon already set and the test's seeded
+// journals/DreamRunState depend on (both the executor and the enqueuer resolve the
+// notebook root via d.notebookRoot()). A fast poll interval avoids real-time waits.
+func installDreamHarvestRunner(t *testing.T, d *Daemon) *tasks.Runner {
+	t.Helper()
+	runner := tasks.New(tasks.Options{
+		Root:         filepath.Join(t.TempDir(), "tasks"),
+		Log:          func(string, ...interface{}) {},
+		PollInterval: 2 * time.Millisecond,
+	})
+	if err := runner.Register(harvestDreamKind, d.harvestDreamExecutor); err != nil {
+		t.Fatalf("register harvest_dream: %v", err)
+	}
+	if err := runner.Start(); err != nil {
+		t.Fatalf("start runner: %v", err)
+	}
+	t.Cleanup(runner.Stop)
+	d.compactRunner = runner
+	return runner
+}
+
+// dreamTaskEnqueued reports whether the harvest_dream:<root> task exists on the
+// runner (i.e. the enqueuer dispatched it on a due fire).
+func dreamTaskEnqueued(t *testing.T, runner *tasks.Runner, root string) bool {
+	t.Helper()
+	task, err := runner.Get(tasks.TaskID(harvestDreamKind, root))
+	if err != nil {
+		t.Fatalf("get harvest_dream task: %v", err)
+	}
+	return task != nil
+}
+
+// A disabled enqueuer tick is fully inert: it neither anchors the schedule nor
+// enqueues, so turning dreaming off leaves no machine state and no task behind.
+func TestEnqueueDueDreamHarvestDisabledIsInert(t *testing.T) {
 	d := newNotebookDaemon(t)
+	runner := installDreamHarvestRunner(t, d)
 	appendDreamJournal(t, d, "2026-06-10", "A durable fact that would harvest if enabled.")
-
-	d.dreamSchedulerTick(mustTime(t, "2026-06-14T12:00:00Z"))
-
 	root := dreamRoot(t, d)
+
+	d.enqueueDueDreamHarvest(mustTime(t, "2026-06-14T12:00:00Z"))
+
 	state, _ := notebook.LoadDreamRunState(root)
 	if state.ScheduledFrom != "" || state.LastRunAt != "" {
 		t.Fatalf("disabled tick wrote run state: %+v", state)
 	}
-	if cands, _ := notebook.LoadDreamCandidates(root); len(cands) != 0 {
-		t.Fatalf("disabled tick persisted %d candidates", len(cands))
+	if dreamTaskEnqueued(t, runner, root) {
+		t.Fatal("disabled tick enqueued a harvest_dream task")
 	}
 }
 
-// The first tick after enabling anchors the schedule at "now" and does NOT run —
-// so enabling dreaming never triggers an immediate harvest on daemon startup; the
-// first real run lands at the next scheduled slot.
-func TestDreamSchedulerTickFirstEnableAnchorsWithoutRunning(t *testing.T) {
+// The first tick after enabling anchors the schedule at "now" and does NOT
+// enqueue — so enabling dreaming never triggers an immediate harvest on daemon
+// startup; the first real dispatch lands at the next scheduled slot.
+func TestEnqueueDueDreamHarvestFirstEnableAnchorsWithoutRunning(t *testing.T) {
 	d := newNotebookDaemon(t)
+	runner := installDreamHarvestRunner(t, d)
 	enableDreaming(t, d)
 	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
-
-	d.dreamSchedulerTick(mustTime(t, "2026-06-14T12:00:00Z"))
-
 	root := dreamRoot(t, d)
+
+	d.enqueueDueDreamHarvest(mustTime(t, "2026-06-14T12:00:00Z"))
+
 	state, _ := notebook.LoadDreamRunState(root)
 	if state.ScheduledFrom == "" {
 		t.Fatal("first enable should anchor the schedule")
 	}
 	if state.LastRunAt != "" {
-		t.Fatalf("first enable must not run; got LastRunAt=%q", state.LastRunAt)
+		t.Fatalf("first enable must not dispatch; got LastRunAt=%q", state.LastRunAt)
 	}
-	if cands, _ := notebook.LoadDreamCandidates(root); len(cands) != 0 {
-		t.Fatalf("first enable persisted %d candidates", len(cands))
+	if dreamTaskEnqueued(t, runner, root) {
+		t.Fatal("first enable enqueued a harvest_dream task")
 	}
 }
 
-// An anchored schedule whose next slot is still in the future does not run, and
-// leaves the anchor untouched.
-func TestDreamSchedulerTickNotDue(t *testing.T) {
+// An anchored schedule whose next slot is still in the future does not enqueue,
+// and leaves the anchor untouched.
+func TestEnqueueDueDreamHarvestNotDue(t *testing.T) {
 	d := newNotebookDaemon(t)
+	runner := installDreamHarvestRunner(t, d)
 	enableDreaming(t, d)
 	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
 	root := dreamRoot(t, d)
@@ -88,23 +127,27 @@ func TestDreamSchedulerTickNotDue(t *testing.T) {
 		t.Fatalf("seed state: %v", err)
 	}
 
-	d.dreamSchedulerTick(mustTime(t, "2026-06-14T05:00:00Z"))
+	d.enqueueDueDreamHarvest(mustTime(t, "2026-06-14T05:00:00Z"))
 
 	state, _ := notebook.LoadDreamRunState(root)
 	if state.LastRunAt != "" {
-		t.Fatalf("not-due tick ran: %+v", state)
+		t.Fatalf("not-due tick dispatched: %+v", state)
 	}
 	if state.ScheduledFrom != "2026-06-14T04:00:00Z" {
 		t.Fatalf("not-due tick mutated the anchor: %q", state.ScheduledFrom)
 	}
+	if dreamTaskEnqueued(t, runner, root) {
+		t.Fatal("not-due tick enqueued a harvest_dream task")
+	}
 }
 
-// A due schedule runs once, persisting the harvested candidates and advancing the
-// anchor; a second tick the same day does NOT run again — proving a laptop that
-// slept past several nightly slots catches up with exactly one run, not one per
-// missed slot.
-func TestDreamSchedulerTickDueRunsOnceWithCatchUp(t *testing.T) {
+// A due schedule dispatches once, enqueuing the harvest_dream task and advancing
+// the anchor; a second tick the same day does NOT enqueue again — proving a laptop
+// that slept past several nightly slots catches up with exactly one dispatch, not
+// one per missed slot.
+func TestEnqueueDueDreamHarvestDueRunsOnceWithCatchUp(t *testing.T) {
 	d := newNotebookDaemon(t)
+	runner := installDreamHarvestRunner(t, d)
 	enableDreaming(t, d)
 	appendDreamJournal(t, d, "2026-06-10", "A durable fact worth consolidating.")
 	root := dreamRoot(t, d)
@@ -115,109 +158,81 @@ func TestDreamSchedulerTickDueRunsOnceWithCatchUp(t *testing.T) {
 	}
 
 	now := mustTime(t, "2026-06-14T12:00:00Z")
-	d.dreamSchedulerTick(now)
+	d.enqueueDueDreamHarvest(now)
 
 	state, _ := notebook.LoadDreamRunState(root)
 	if state.LastRunAt == "" {
-		t.Fatal("due tick should have run")
+		t.Fatal("due tick should have dispatched (LastRunAt set)")
 	}
 	firstRun := state.LastRunAt
-	cands, _ := notebook.LoadDreamCandidates(root)
-	if len(cands) == 0 {
-		t.Fatal("due run should persist harvested candidates")
-	}
-	if state.LastRunCandidateCount != len(cands) {
-		t.Fatalf("run state count %d != persisted %d", state.LastRunCandidateCount, len(cands))
+	if !dreamTaskEnqueued(t, runner, root) {
+		t.Fatal("due tick should enqueue the harvest_dream task")
 	}
 
-	// One minute later the next slot is tomorrow's 03:00 → not due → no second run.
-	d.dreamSchedulerTick(now.Add(time.Minute))
+	// One minute later the next slot is tomorrow's 03:00 → not due → no second
+	// dispatch (LastRunAt unchanged).
+	d.enqueueDueDreamHarvest(now.Add(time.Minute))
 	state2, _ := notebook.LoadDreamRunState(root)
 	if state2.LastRunAt != firstRun {
 		t.Fatalf("catch-up fired twice: first=%q second=%q", firstRun, state2.LastRunAt)
 	}
 }
 
-// runDreamHarvest merges a fresh harvest into the persisted set: a re-run picks up
-// only genuinely new facts (idempotent on already-seen sources) and reports the
-// new-candidate delta.
-func TestRunDreamHarvestMergesPersisted(t *testing.T) {
+// harvestDreamExecutor merges a fresh harvest into the persisted set: a re-run
+// picks up only genuinely new facts (idempotent on already-seen sources). Running
+// the executor twice with one new journal fact between runs grows the persisted
+// candidate set by exactly that one fact.
+func TestHarvestDreamExecutorMergesPersisted(t *testing.T) {
 	d := newNotebookDaemon(t)
 	enableDreaming(t, d)
 	appendDreamJournal(t, d, "2026-06-10", "First durable fact about the harvest.")
-
-	first, err := d.runDreamHarvest(mustTime(t, "2026-06-14T03:00:00Z"))
-	if err != nil {
-		t.Fatalf("first run: %v", err)
-	}
-	if first.LastRunNewCandidates == 0 || first.LastRunCandidateCount != first.LastRunNewCandidates {
-		t.Fatalf("first run should be all-new: %+v", first)
-	}
-
-	// Add one genuinely new fact, then re-run: only the new one counts as new, and
-	// the total grows by exactly that (the prior fact is not double-counted).
-	appendDreamJournal(t, d, "2026-06-11", "Second durable fact, distinct from the first.")
-	second, err := d.runDreamHarvest(mustTime(t, "2026-06-15T03:00:00Z"))
-	if err != nil {
-		t.Fatalf("second run: %v", err)
-	}
-	if second.LastRunCandidateCount != first.LastRunCandidateCount+1 {
-		t.Fatalf("second run total = %d, want %d (one new fact merged)", second.LastRunCandidateCount, first.LastRunCandidateCount+1)
-	}
-	if second.LastRunNewCandidates != 1 {
-		t.Fatalf("second run new = %d, want exactly 1", second.LastRunNewCandidates)
-	}
-}
-
-// A run in progress (the in-memory single-flight guard) refuses a concurrent run.
-func TestRunDreamHarvestSingleFlight(t *testing.T) {
-	d := newNotebookDaemon(t)
-	enableDreaming(t, d)
-	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
-
-	d.dreamMu.Lock()
-	d.dreamRunning = true
-	d.dreamMu.Unlock()
-
-	if _, err := d.runDreamHarvest(mustTime(t, "2026-06-14T03:00:00Z")); !errors.Is(err, errDreamRunning) {
-		t.Fatalf("expected errDreamRunning, got %v", err)
-	}
-}
-
-// The filesystem lock blocks a run while held; clearing an orphaned lock (startup
-// recovery) unblocks the next run.
-func TestRunDreamHarvestFileLockAndRecovery(t *testing.T) {
-	d := newNotebookDaemon(t)
-	enableDreaming(t, d)
-	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
 	root := dreamRoot(t, d)
 
-	// Simulate a crashed run that left its lock behind (never released).
-	if _, err := notebook.AcquireDreamLock(root); err != nil {
-		t.Fatalf("seed orphan lock: %v", err)
+	if err := d.harvestDreamExecutor(t.Context(), nil); err != nil {
+		t.Fatalf("first run: %v", err)
 	}
-	if _, err := d.runDreamHarvest(mustTime(t, "2026-06-14T03:00:00Z")); err == nil {
-		t.Fatal("run should fail while the lock is held")
+	first, err := notebook.LoadDreamCandidates(root)
+	if err != nil {
+		t.Fatalf("load after first run: %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("first run should persist harvested candidates")
 	}
 
-	cleared, err := notebook.ClearOrphanDreamLocks(root)
-	if err != nil || cleared != 1 {
-		t.Fatalf("orphan recovery: cleared=%d err=%v", cleared, err)
+	// Add one genuinely new fact, then re-run: only the new one is added, and the
+	// total grows by exactly one (the prior fact is not double-counted).
+	appendDreamJournal(t, d, "2026-06-11", "Second durable fact, distinct from the first.")
+	if err := d.harvestDreamExecutor(t.Context(), nil); err != nil {
+		t.Fatalf("second run: %v", err)
 	}
-	if _, err := d.runDreamHarvest(mustTime(t, "2026-06-14T03:05:00Z")); err != nil {
-		t.Fatalf("run should succeed after recovery: %v", err)
+	second, err := notebook.LoadDreamCandidates(root)
+	if err != nil {
+		t.Fatalf("load after second run: %v", err)
+	}
+	if len(second) != len(first)+1 {
+		t.Fatalf("second run total = %d, want %d (one new fact merged)", len(second), len(first)+1)
 	}
 }
 
 // dreamStatus surfaces the schedule, timezone, last/next run, and persisted count
-// once a run has happened.
+// once a harvest has persisted candidates and the enqueuer has recorded a fire.
 func TestDreamStatusSurfacesSchedule(t *testing.T) {
 	d := newNotebookDaemon(t)
+	installDreamHarvestRunner(t, d)
 	enableDreaming(t, d)
 	appendDreamJournal(t, d, "2026-06-10", "A durable fact worth consolidating.")
+	root := dreamRoot(t, d)
 
-	if _, err := d.runDreamHarvest(mustTime(t, "2026-06-14T03:00:00Z")); err != nil {
-		t.Fatalf("run: %v", err)
+	// Record a fire at the 03:00 anchor (the enqueuer's state write) and persist the
+	// harvested candidates (the executor's write) — the two halves of one due fire.
+	if err := notebook.SaveDreamRunState(root, notebook.DreamRunState{
+		ScheduledFrom: "2026-06-14T03:00:00Z",
+		LastRunAt:     "2026-06-14T03:00:00Z",
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	if err := d.harvestDreamExecutor(t.Context(), nil); err != nil {
+		t.Fatalf("harvest: %v", err)
 	}
 
 	res, err := d.dreamStatus()
@@ -233,14 +248,14 @@ func TestDreamStatusSurfacesSchedule(t *testing.T) {
 	if res.LastRunAt == nil || res.NextRunAt == nil {
 		t.Fatalf("expected last/next run set: last=%v next=%v", res.LastRunAt, res.NextRunAt)
 	}
-	// The run anchored at 2026-06-14T03:00:00Z; the next "0 3 * * *" UTC slot is the
+	// The fire anchored at 2026-06-14T03:00:00Z; the next "0 3 * * *" UTC slot is the
 	// following day. Asserting the exact value pins that next_run is computed from
 	// the persisted anchor (and timezone), not merely non-nil.
 	if *res.NextRunAt != "2026-06-15T03:00:00Z" {
 		t.Fatalf("next_run = %q, want 2026-06-15T03:00:00Z", *res.NextRunAt)
 	}
 	if res.PersistedCount == 0 {
-		t.Fatal("expected persisted candidates after a run")
+		t.Fatal("expected persisted candidates after a harvest")
 	}
 }
 
@@ -271,10 +286,10 @@ func TestDreamStatusNextRunBeforeFirstRun(t *testing.T) {
 }
 
 // The configured timezone genuinely flips the due decision: the same anchor and
-// "now" produce opposite verdicts under different zones. A scheduler that dropped
+// "now" produce opposite verdicts under different zones. An enqueuer that dropped
 // the timezone conversion (computing everything in one fixed zone) would fail at
 // least one direction of this table.
-func TestDreamSchedulerTickTimezoneAffectsDueDecision(t *testing.T) {
+func TestEnqueueDueDreamHarvestTimezoneAffectsDueDecision(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		tz      string
@@ -293,6 +308,7 @@ func TestDreamSchedulerTickTimezoneAffectsDueDecision(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			d := newNotebookDaemon(t)
+			runner := installDreamHarvestRunner(t, d)
 			d.store.SetSetting(SettingNotebookDreamingEnabled, "true")
 			d.store.SetSetting(SettingNotebookDreamingTimezone, tc.tz)
 			appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
@@ -301,11 +317,15 @@ func TestDreamSchedulerTickTimezoneAffectsDueDecision(t *testing.T) {
 				t.Fatalf("seed state: %v", err)
 			}
 
-			d.dreamSchedulerTick(mustTime(t, tc.now))
+			d.enqueueDueDreamHarvest(mustTime(t, tc.now))
 
 			state, _ := notebook.LoadDreamRunState(root)
-			if ran := state.LastRunAt != ""; ran != tc.wantRun {
+			ran := state.LastRunAt != ""
+			if ran != tc.wantRun {
 				t.Fatalf("tz=%s anchor=%s now=%s: ran=%v want=%v", tc.tz, tc.anchor, tc.now, ran, tc.wantRun)
+			}
+			if got := dreamTaskEnqueued(t, runner, root); got != tc.wantRun {
+				t.Fatalf("tz=%s: task enqueued=%v want=%v", tc.tz, got, tc.wantRun)
 			}
 		})
 	}
@@ -313,10 +333,11 @@ func TestDreamSchedulerTickTimezoneAffectsDueDecision(t *testing.T) {
 
 // A frequency that never occurs (validation normally rejects it, but an older
 // daemon could have persisted one) must be treated as never-due, not always-due —
-// otherwise every tick would re-harvest. Set the raw setting directly to bypass
-// validation, then tick twice and assert nothing ran.
-func TestDreamSchedulerUnsatisfiableFrequencyDoesNotRun(t *testing.T) {
+// otherwise every tick would re-enqueue. Set the raw setting directly to bypass
+// validation, then tick twice and assert nothing fired.
+func TestEnqueueDueDreamHarvestUnsatisfiableFrequencyDoesNotRun(t *testing.T) {
 	d := newNotebookDaemon(t)
+	runner := installDreamHarvestRunner(t, d)
 	enableDreaming(t, d)
 	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
 	d.store.SetSetting(SettingNotebookDreamingFrequency, "0 0 30 2 *") // Feb 30 — never occurs
@@ -325,20 +346,24 @@ func TestDreamSchedulerUnsatisfiableFrequencyDoesNotRun(t *testing.T) {
 		t.Fatalf("seed state: %v", err)
 	}
 
-	d.dreamSchedulerTick(mustTime(t, "2026-06-14T12:00:00Z"))
-	d.dreamSchedulerTick(mustTime(t, "2026-06-14T12:01:00Z"))
+	d.enqueueDueDreamHarvest(mustTime(t, "2026-06-14T12:00:00Z"))
+	d.enqueueDueDreamHarvest(mustTime(t, "2026-06-14T12:01:00Z"))
 
 	if state, _ := notebook.LoadDreamRunState(root); state.LastRunAt != "" {
-		t.Fatalf("an unsatisfiable frequency must never be due, but a run happened: %+v", state)
+		t.Fatalf("an unsatisfiable frequency must never be due, but a fire happened: %+v", state)
+	}
+	if dreamTaskEnqueued(t, runner, root) {
+		t.Fatal("an unsatisfiable frequency must never enqueue a harvest_dream task")
 	}
 }
 
 // Documented catch-up nuance: when the daemon wakes shortly BEFORE the day's slot
-// after missing several nights, the missed slots collapse into one catch-up run
-// now, and the day's own slot then runs when it arrives. Two runs, by design — this
-// pins that behavior so it cannot regress silently in either direction.
-func TestDreamSchedulerCatchUpBeforeSlotAlsoRunsTheSlot(t *testing.T) {
+// after missing several nights, the missed slots collapse into one catch-up fire
+// now, and the day's own slot then fires when it arrives. Two fires, by design —
+// this pins that behavior so it cannot regress silently in either direction.
+func TestEnqueueDueDreamHarvestCatchUpBeforeSlotAlsoRunsTheSlot(t *testing.T) {
 	d := newNotebookDaemon(t)
+	installDreamHarvestRunner(t, d)
 	enableDreaming(t, d) // UTC
 	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
 	root := dreamRoot(t, d)
@@ -346,40 +371,42 @@ func TestDreamSchedulerCatchUpBeforeSlotAlsoRunsTheSlot(t *testing.T) {
 		t.Fatalf("seed state: %v", err)
 	}
 
-	// 02:00, before today's 03:00 slot: one catch-up run for the missed nights.
-	d.dreamSchedulerTick(mustTime(t, "2026-06-14T02:00:00Z"))
+	// 02:00, before today's 03:00 slot: one catch-up fire for the missed nights.
+	d.enqueueDueDreamHarvest(mustTime(t, "2026-06-14T02:00:00Z"))
 	s1, _ := notebook.LoadDreamRunState(root)
 	if s1.LastRunAt == "" {
-		t.Fatal("missed nights should trigger a catch-up run")
+		t.Fatal("missed nights should trigger a catch-up fire")
 	}
 	catchUp := s1.LastRunAt
 
 	// 02:30, still before the slot: anchor advanced to 02:00 → not due again.
-	d.dreamSchedulerTick(mustTime(t, "2026-06-14T02:30:00Z"))
+	d.enqueueDueDreamHarvest(mustTime(t, "2026-06-14T02:30:00Z"))
 	s2, _ := notebook.LoadDreamRunState(root)
 	if s2.LastRunAt != catchUp {
 		t.Fatalf("catch-up must not repeat before the slot: %q -> %q", catchUp, s2.LastRunAt)
 	}
 
-	// 03:00:30, today's scheduled slot arrives → the documented second run.
-	d.dreamSchedulerTick(mustTime(t, "2026-06-14T03:00:30Z"))
+	// 03:00:30, today's scheduled slot arrives → the documented second fire.
+	d.enqueueDueDreamHarvest(mustTime(t, "2026-06-14T03:00:30Z"))
 	s3, _ := notebook.LoadDreamRunState(root)
 	if s3.LastRunAt == catchUp {
-		t.Fatal("today's scheduled slot should run after the pre-slot catch-up")
+		t.Fatal("today's scheduled slot should fire after the pre-slot catch-up")
 	}
 
-	// 03:01:30, no further runs today.
-	d.dreamSchedulerTick(mustTime(t, "2026-06-14T03:01:30Z"))
+	// 03:01:30, no further fires today.
+	d.enqueueDueDreamHarvest(mustTime(t, "2026-06-14T03:01:30Z"))
 	s4, _ := notebook.LoadDreamRunState(root)
 	if s4.LastRunAt != s3.LastRunAt {
-		t.Fatalf("the slot run must not repeat: %q -> %q", s3.LastRunAt, s4.LastRunAt)
+		t.Fatalf("the slot fire must not repeat: %q -> %q", s3.LastRunAt, s4.LastRunAt)
 	}
 }
 
-// The scheduler goroutine actually ticks at its configured interval (exercising
-// dreamSchedulerInterval) and returns promptly when its done channel closes.
-func TestDreamSchedulerGoroutineRunsAndStops(t *testing.T) {
+// The cron enqueuer goroutine actually ticks at its configured interval
+// (exercising dreamSchedulerInterval) and returns promptly when its done channel
+// closes; a due tick records a fire (LastRunAt set).
+func TestNotebookCronEnqueuerGoroutineRunsAndStops(t *testing.T) {
 	d := newNotebookDaemon(t)
+	installDreamHarvestRunner(t, d)
 	enableDreaming(t, d)
 	appendDreamJournal(t, d, "2026-06-10", "A durable fact.")
 	root := dreamRoot(t, d)
@@ -394,7 +421,7 @@ func TestDreamSchedulerGoroutineRunsAndStops(t *testing.T) {
 
 	done := make(chan struct{})
 	stopped := make(chan struct{})
-	go func() { d.startDreamingScheduler(done); close(stopped) }()
+	go func() { d.startNotebookCronEnqueuer(done); close(stopped) }()
 
 	deadline := time.Now().Add(2 * time.Second)
 	for {
@@ -402,7 +429,7 @@ func TestDreamSchedulerGoroutineRunsAndStops(t *testing.T) {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatal("scheduler goroutine did not run within timeout")
+			t.Fatal("enqueuer goroutine did not fire within timeout")
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
@@ -411,7 +438,7 @@ func TestDreamSchedulerGoroutineRunsAndStops(t *testing.T) {
 	select {
 	case <-stopped:
 	case <-time.After(2 * time.Second):
-		t.Fatal("scheduler goroutine did not stop after done closed")
+		t.Fatal("enqueuer goroutine did not stop after done closed")
 	}
 }
 

--- a/internal/daemon/notebook_dreaming_test.go
+++ b/internal/daemon/notebook_dreaming_test.go
@@ -43,16 +43,20 @@ func findCandidate(cands []protocol.NotebookDreamCandidate, substr string) *prot
 	return nil
 }
 
-// Harvest pulls from all three v1 sources, merges a fact echoed across two
-// workspace contexts into one recurring candidate, and excludes a dispatch whose
-// target session is still live (only closed dispatches are durable).
+// Harvest pulls from the surviving v1 sources — journals (source-1) and closed
+// chief dispatches (source-3) — and excludes a dispatch whose target session is
+// still live (only closed dispatches are durable). Source-2 (workspace-context
+// re-read) was removed once narration took ownership of distilling context.md into
+// the journal, so a workspace context set here must NOT surface as a candidate.
 func TestHarvestDreamCandidatesAcrossSources(t *testing.T) {
 	d := newNotebookDaemon(t)
 
-	appendDreamJournal(t, d, "2026-06-10", "The harvest pass scans journals, context snapshots, and closed dispatches.")
+	appendDreamJournal(t, d, "2026-06-10", "The harvest pass scans journals and closed dispatches.")
 
-	const sharedDecision = "Daemon owns every notebook write through one in-process store."
-	ctxTemplate := "# Workspace Context\n\n## Area\nfoo\n\n## Decisions\n- " + sharedDecision + "\n"
+	// Workspace context is no longer a harvest source: setting one must contribute
+	// nothing (narration distills it into the journal instead).
+	const droppedDecision = "Daemon owns every notebook write through one in-process store."
+	ctxTemplate := "# Workspace Context\n\n## Area\nfoo\n\n## Decisions\n- " + droppedDecision + "\n"
 	setWorkspaceContext(t, d, "ws-a", ctxTemplate)
 	setWorkspaceContext(t, d, "ws-b", ctxTemplate+"- A second decision only in ws-b about hash-CAS edits.\n")
 
@@ -82,30 +86,17 @@ func TestHarvestDreamCandidatesAcrossSources(t *testing.T) {
 		t.Fatal("dreamRun must be preview-only (applied=false)")
 	}
 
-	// The shared decision recurs across both workspaces.
-	shared := findCandidate(res.Candidates, sharedDecision)
-	if shared == nil {
-		t.Fatalf("shared decision not harvested; candidates = %+v", res.Candidates)
-	}
-	if shared.Occurrences != 2 || len(shared.Contexts) != 2 {
-		t.Fatalf("shared decision occurrences=%d contexts=%d, want 2/2", shared.Occurrences, len(shared.Contexts))
-	}
-	if shared.Source != notebook.SignalSourceContext {
-		t.Fatalf("shared decision source = %q, want context", shared.Source)
+	// The journal block (source-1) is harvested.
+	if findCandidate(res.Candidates, "The harvest pass scans journals") == nil {
+		t.Fatalf("journal block not harvested; candidates = %+v", res.Candidates)
 	}
 
-	// Exactly one candidate recurs across multiple contexts (the shared decision);
-	// the journal block, ws-b's second decision, and the dispatch summary are each
-	// single-context. This pins the ">1" multi-context threshold that the user-
-	// facing "N across multiple contexts" count and the promote-phase gate rest on.
-	if res.MultiContextCount != 1 {
-		t.Fatalf("multi-context count = %d, want exactly 1 (only the shared decision recurs); candidates = %+v", res.MultiContextCount, res.Candidates)
-	}
-	if res.CandidateCount <= 1 {
-		t.Fatalf("candidate count = %d, want several so the multi-context subset is meaningful", res.CandidateCount)
+	// Workspace-context decisions (former source-2) are NOT harvested anymore.
+	if findCandidate(res.Candidates, droppedDecision) != nil {
+		t.Fatalf("workspace context must not be harvested (source-2 removed); candidates = %+v", res.Candidates)
 	}
 
-	// The closed dispatch's summary is harvested; the live one is not.
+	// The closed dispatch's summary (source-3) is harvested; the live one is not.
 	if findCandidate(res.Candidates, "Shipped the in-app markdown editor") == nil {
 		t.Fatal("closed dispatch summary should be harvested")
 	}
@@ -113,45 +104,18 @@ func TestHarvestDreamCandidatesAcrossSources(t *testing.T) {
 		t.Fatal("a dispatch whose target session is still live must not be harvested")
 	}
 
-	// All three sources contributed.
+	// Only the journal and dispatch sources contribute now — no context source.
 	srcs := map[string]bool{}
 	for _, sc := range res.SourceCounts {
 		srcs[sc.Source] = true
 	}
-	for _, want := range []string{notebook.SignalSourceJournal, notebook.SignalSourceContext, notebook.SignalSourceDispatch} {
+	for _, want := range []string{notebook.SignalSourceJournal, notebook.SignalSourceDispatch} {
 		if !srcs[want] {
 			t.Fatalf("source %q missing from counts %+v", want, res.SourceCounts)
 		}
 	}
-}
-
-// extractContextSignals harvests only the Decisions/Constraints sections (working
-// state like Area is ignored) and joins a wrapped bullet's continuation lines.
-func TestExtractContextSignals(t *testing.T) {
-	content := "# Workspace Context\n\n" +
-		"## Area\nThis is working context, not durable memory.\n\n" +
-		"## Decisions\n- A decision that wraps\n  onto a second line.\n- A second decision.\n\n" +
-		"## Constraints\n- A hard constraint.\n\n" +
-		"## Threads\n- Not harvested.\n"
-
-	sigs := extractContextSignals("ws-1", content, "2026-06-13T00:00:00Z")
-	if len(sigs) != 3 {
-		t.Fatalf("signals = %d, want 3 (2 decisions + 1 constraint): %+v", len(sigs), sigs)
-	}
-	var joined bool
-	for _, s := range sigs {
-		if s.SourceRef != "context:ws-1" || s.Context != "workspace:ws-1" {
-			t.Fatalf("signal grounding = ref %q ctx %q, want context:ws-1 / workspace:ws-1", s.SourceRef, s.Context)
-		}
-		if strings.Contains(s.Text, "wraps") && strings.Contains(s.Text, "second line") {
-			joined = true
-		}
-		if strings.Contains(s.Text, "Not harvested") || strings.Contains(s.Text, "working context") {
-			t.Fatalf("harvested a non-durable section: %q", s.Text)
-		}
-	}
-	if !joined {
-		t.Fatal("a wrapped bullet's continuation line should be joined into one signal")
+	if srcs[notebook.SignalSourceContext] {
+		t.Fatalf("context source must not appear in harvest (source-2 removed); counts %+v", res.SourceCounts)
 	}
 }
 

--- a/internal/daemon/workspace_context_janitor.go
+++ b/internal/daemon/workspace_context_janitor.go
@@ -177,6 +177,12 @@ func (d *Daemon) startCompactRunner() {
 		); err != nil {
 			d.logf("notebook narration: register narrate_workspace: %v", err)
 		}
+		// Dreaming's nightly harvest folds onto the same runner. The default 5-min
+		// timeout is ample for the harvest's file I/O; the cron enqueuer
+		// (startNotebookCronEnqueuer) dispatches the harvest_dream task when due.
+		if err := runner.Register(harvestDreamKind, d.harvestDreamExecutor); err != nil {
+			d.logf("dreaming: register harvest_dream: %v", err)
+		}
 	}
 	d.setCompactRunner(runner)
 	_ = runner.Start()

--- a/internal/notebook/dreams_state.go
+++ b/internal/notebook/dreams_state.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 )
 
 // Dreaming machine state.
@@ -20,8 +19,7 @@ import (
 //	candidates.json  — the accumulated harvest candidate set (grows monotonically;
 //	                   harvest only ever merges, never prunes — compaction is a
 //	                   separate, deferred op)
-//	state.json       — run bookkeeping: the schedule anchor + last-run summary
-//	locks/dream.lock — single-writer lock held for the duration of a run
+//	state.json       — run bookkeeping: the schedule anchor + last-dispatch time
 //	runs/            — reserved for the promote phase's dated run reports
 //
 // All writes reuse the package's atomic temp+rename writer so a crash mid-write
@@ -31,8 +29,6 @@ const (
 	dreamsDir            = "dreams"
 	dreamsCandidatesFile = "candidates.json"
 	dreamsStateFile      = "state.json"
-	dreamsLocksDir       = "locks"
-	dreamsLockFile       = "dream.lock"
 
 	// dreamStateVersion tags persisted state so a future format change can be
 	// detected and migrated rather than silently mis-read.
@@ -46,24 +42,25 @@ func DreamsStateDir(root string) string {
 
 // DreamRunState is the persisted run bookkeeping for the dreaming pass. It is
 // deliberately small and separate from candidates.json so the (potentially large)
-// candidate list and the tiny run metadata are written independently.
+// candidate list and the tiny run metadata are written independently. The cron
+// enqueuer (enqueueDueDreamHarvest) is its SOLE writer: the harvest executor that
+// runs async on the durable runner does NOT touch this file, so there is no
+// two-writer race on state.json.
 type DreamRunState struct {
 	Version int `json:"version"`
 	// ScheduledFrom is the anchor the next run is computed from (RFC3339, UTC):
 	// set to "now" on the first enable (so the first run lands at the next
-	// scheduled slot, not at daemon startup) and advanced to the run time after
-	// each completed run. A run is due when schedule.Next(ScheduledFrom) has passed;
-	// because the anchor jumps forward to the run time, slots missed while the
-	// daemon was down collapse into a single catch-up run. See dreamSchedulerTick
-	// for the full catch-up semantics (and its two deliberate wall-clock nuances).
+	// scheduled slot, not at daemon startup) and advanced to the dispatch time
+	// after each due fire. A fire is due when schedule.Next(ScheduledFrom) has
+	// passed; because the anchor jumps forward to the dispatch time, slots missed
+	// while the daemon was down collapse into a single catch-up enqueue. See
+	// enqueueDueDreamHarvest for the full catch-up semantics (and its two
+	// deliberate wall-clock nuances).
 	ScheduledFrom string `json:"scheduled_from,omitempty"`
-	// LastRunAt is when the last harvest run completed (RFC3339, UTC; display).
+	// LastRunAt is when the daily harvest was last DISPATCHED by the cron enqueuer
+	// (the harvest itself runs async on the durable runner moments later) —
+	// RFC3339, UTC; display.
 	LastRunAt string `json:"last_run_at,omitempty"`
-	// LastRunNewCandidates is how many candidates that run added that were not
-	// already persisted.
-	LastRunNewCandidates int `json:"last_run_new_candidates"`
-	// LastRunCandidateCount is the total persisted candidate count after that run.
-	LastRunCandidateCount int `json:"last_run_candidate_count"`
 }
 
 // LoadDreamCandidates reads the persisted candidate set. A missing file is not an
@@ -123,72 +120,4 @@ func SaveDreamRunState(root string, state DreamRunState) error {
 		return err
 	}
 	return writeAtomic(filepath.Join(DreamsStateDir(root), dreamsStateFile), data)
-}
-
-// dreamLockInfo records who holds the dream lock, for crash auditability.
-type dreamLockInfo struct {
-	PID      int    `json:"pid"`
-	Acquired string `json:"acquired"`
-}
-
-// AcquireDreamLock takes the single-writer dream lock by creating
-// locks/dream.lock exclusively. It returns a release func that removes the lock;
-// release is idempotent. If the lock already exists the call fails — the caller
-// must treat that as "a run is already in progress" (startup orphan recovery
-// clears a lock left behind by a crashed run).
-func AcquireDreamLock(root string) (release func() error, err error) {
-	dir := filepath.Join(DreamsStateDir(root), dreamsLocksDir)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, err
-	}
-	lockPath := filepath.Join(dir, dreamsLockFile)
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
-	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return nil, fmt.Errorf("notebook: dream lock already held at %s", lockPath)
-		}
-		return nil, err
-	}
-	info, _ := json.Marshal(dreamLockInfo{PID: os.Getpid(), Acquired: time.Now().UTC().Format(time.RFC3339)})
-	_, _ = f.Write(info)
-	_ = f.Close()
-
-	released := false
-	return func() error {
-		if released {
-			return nil
-		}
-		released = true
-		return os.Remove(lockPath)
-	}, nil
-}
-
-// ClearOrphanDreamLocks removes any lock files left under locks/. For every
-// supported configuration this is safe: the daemon is a process singleton (the PID
-// lock kills any prior daemon on startup) and the notebook root is per-profile (the
-// default root is profile-namespaced), so a lock present at startup is necessarily
-// orphaned by a crashed run. The one way to defeat this is unsupported — pointing
-// two profiles' daemons at one EXPLICIT notebook.root, where startup recovery could
-// clear the other daemon's live lock. The lock records its holder PID for auditing
-// if that ever needs hardening into a liveness check. Returns how many lock files
-// were removed; a missing locks dir is not an error.
-func ClearOrphanDreamLocks(root string) (int, error) {
-	dir := filepath.Join(DreamsStateDir(root), dreamsLocksDir)
-	entries, err := os.ReadDir(dir)
-	if errors.Is(err, os.ErrNotExist) {
-		return 0, nil
-	}
-	if err != nil {
-		return 0, err
-	}
-	cleared := 0
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		if err := os.Remove(filepath.Join(dir, e.Name())); err == nil {
-			cleared++
-		}
-	}
-	return cleared, nil
 }

--- a/internal/notebook/dreams_state_test.go
+++ b/internal/notebook/dreams_state_test.go
@@ -51,10 +51,8 @@ func TestDreamRunStateRoundTrip(t *testing.T) {
 	}
 
 	if err := SaveDreamRunState(root, DreamRunState{
-		ScheduledFrom:         "2026-06-14T03:00:00Z",
-		LastRunAt:             "2026-06-14T03:00:00Z",
-		LastRunNewCandidates:  3,
-		LastRunCandidateCount: 10,
+		ScheduledFrom: "2026-06-14T03:00:00Z",
+		LastRunAt:     "2026-06-14T03:00:00Z",
 	}); err != nil {
 		t.Fatalf("save: %v", err)
 	}
@@ -65,65 +63,9 @@ func TestDreamRunStateRoundTrip(t *testing.T) {
 	if got.Version != dreamStateVersion {
 		t.Fatalf("expected version stamped to %d, got %d", dreamStateVersion, got.Version)
 	}
-	if got.LastRunCandidateCount != 10 || got.LastRunNewCandidates != 3 {
+	if got.ScheduledFrom != "2026-06-14T03:00:00Z" || got.LastRunAt != "2026-06-14T03:00:00Z" {
 		t.Fatalf("round-trip mismatch: %+v", got)
 	}
-}
-
-func TestDreamLockSingleFlightAndRecovery(t *testing.T) {
-	root := t.TempDir()
-
-	release, err := AcquireDreamLock(root)
-	if err != nil {
-		t.Fatalf("first acquire: %v", err)
-	}
-
-	// A second acquire while held must fail (single writer).
-	if _, err := AcquireDreamLock(root); err == nil {
-		t.Fatal("expected second acquire to fail while lock is held")
-	}
-
-	if err := release(); err != nil {
-		t.Fatalf("release: %v", err)
-	}
-	// Release is idempotent.
-	if err := release(); err != nil {
-		t.Fatalf("second release should be a no-op: %v", err)
-	}
-
-	// After release the lock is free again.
-	release2, err := AcquireDreamLock(root)
-	if err != nil {
-		t.Fatalf("re-acquire after release: %v", err)
-	}
-	_ = release2()
-}
-
-func TestClearOrphanDreamLocks(t *testing.T) {
-	root := t.TempDir()
-
-	// No locks dir yet → nothing to clear, no error.
-	if n, err := ClearOrphanDreamLocks(root); err != nil || n != 0 {
-		t.Fatalf("clear empty: n=%d err=%v", n, err)
-	}
-
-	// A lock left behind by a crashed run is orphaned: clear it, then the lock is
-	// re-acquirable (proving recovery unblocks the next scheduled run).
-	if _, err := AcquireDreamLock(root); err != nil {
-		t.Fatalf("acquire (simulating crash that never released): %v", err)
-	}
-	if _, err := AcquireDreamLock(root); err == nil {
-		t.Fatal("sanity: lock should still be held before recovery")
-	}
-	n, err := ClearOrphanDreamLocks(root)
-	if err != nil || n != 1 {
-		t.Fatalf("clear orphan: n=%d err=%v", n, err)
-	}
-	release, err := AcquireDreamLock(root)
-	if err != nil {
-		t.Fatalf("acquire after recovery: %v", err)
-	}
-	_ = release()
 }
 
 func TestLoadDreamCandidateSetMergesIdempotently(t *testing.T) {


### PR DESCRIPTION
Stacked on #338 (`feat/notebook-narration-transcript`). Part of the notebook-narration epic — the **DR6 dreaming fold-in** half of PR-4, peeled out under the plan's Open-5 permitted split because it is pure-Go (no protocol/frontend) and fully verifiable without a packaged-app install.

## What

Dreaming's nightly harvest stops running on its own bespoke scheduler and instead runs as a `harvest_dream` task on the **existing durable runner** (`internal/tasks`). A single cron *enqueuer* decides when a harvest is due and dispatches the task; the runner owns execution, single-flight, retry/backoff, and crash recovery. This reaches the plan's **"one runner, zero special-case schedulers"** end state for harvest, and the harvest gains durable retry it never had (a failed harvest now backs off and re-runs instead of being lost).

## Design

- **`harvest_dream` executor** — sole writer of `candidates.json`; runs `dreamHarvestUnion` + `SaveDreamCandidates`. No `CommitGuard` because that write is an atomic, ctx-free temp+rename (a Cancel/timeout can't tear it).
- **Single cron enqueuer** (`startNotebookCronEnqueuer` → `notebookCronTick` → `enqueueDueDreamHarvest`) — keeps the timezone-aware cron + anchor/catch-up math verbatim, but on a due fire it **enqueues** rather than running inline. It is the **sole writer of `DreamRunState`** (anchor + dispatch time), so `state.json` has exactly one writer and the async executor never races it. **Anchor-first ordering**: a due fire advances the anchor *before* enqueuing, so a rare enqueue failure skips one (idempotent) day rather than re-firing every tick.
- **Deletions** (all subsumed by the runner): `startDreamingScheduler`/`dreamSchedulerTick`/`runDreamHarvest`, the in-daemon single-flight guard (`dreamMu`/`dreamRunning`), and the now-redundant `.attn/dreams/` filesystem lock (`AcquireDreamLock`/`ClearOrphanDreamLocks`/`dreamLockInfo`). Also the superseded **harvest source-2** (workspace-context Decisions/Constraints re-read) — narration now owns distilling `context.md` into the journal, so re-reading it would double-count; journals (source-1) and closed dispatches (source-3) are unchanged. Dropped `DreamRunState`'s per-run candidate-count fields (nothing surfaced them). Removed the already-dead `harvestDreamCandidates` helper.
- **Registration ordering**: `harvest_dream` registers in `startCompactRunner`; the enqueuer goroutine now launches *after* `startCompactRunner` so the kind is registered before the first tick can dispatch.

## Not in this PR (deliberately deferred)

- **Daily per-workspace narrate** (the other half of the plan's "single cron enqueuer"). The narrate executor currently treats "nothing new to add" as a *failure* (→ backoff → dead), so a daily idle-pass would spam failed runs. Making it well-behaved needs executor success-semantics surgery + an activity gate with new tracking state (plan Open-4) — genuine new design, so it gets its own PR. The extension point is marked `// TODO(daily-narrate)` in `notebookCronTick`.
- **DR5 status surface** (protocol bump 109→110 + Tasks panel) — needs `make install` + visual verification.

## Tests / verification (local)

- `go build ./...`, `go vet` — clean.
- `internal/notebook`, `internal/tasks`, and `internal/daemon` (Dream/Harvest/Narrate/Summarize/Compact/Janitor/Stop) — green.
- Scoped `-race` on the enqueuer-goroutine × runner-worker interaction and `internal/tasks` — clean (scoped with `-run` to dodge the known unrelated `TestGitStatusScheduler` data race).
- The cron due-math tests (first-enable, not-due, catch-up-once, timezone table, unsatisfiable, catch-up-before-slot) are preserved 1:1 and now *additionally* assert the `harvest_dream` task was/wasn't enqueued. Added a real executor idempotency test (union grows by exactly one new fact) and a positive *absence* test that workspace-context no longer harvests.

No `CHANGELOG.md` entry: internal refactor of an off-by-default, preview-only experimental subsystem; user-visible nightly-harvest behavior is unchanged.

🤖 Built via an ultracode workflow (build → 3-lens adversarial review → fix), then independently verified.