### PR TITLE
feat(notebook): PARA/OKF knowledge base + raw capture tier

### DIFF
--- a/internal/notebook/document.go
+++ b/internal/notebook/document.go
@@ -157,8 +157,15 @@ func (d Document) frontmatterString(key string) string {
 	return v
 }
 
-// Kind returns the declared kind ("" if absent or non-string).
-func (d Document) Kind() string { return d.frontmatterString("kind") }
+// Type returns the declared OKF `type` ("" if absent or non-string). For
+// read-compatibility with notes an external tool wrote before the field was
+// renamed, it falls back to a legacy `kind` value; attn always writes `type`.
+func (d Document) Type() string {
+	if t := d.frontmatterString("type"); t != "" {
+		return t
+	}
+	return d.frontmatterString("kind")
+}
 
 // Title returns the declared title ("" if absent).
 func (d Document) Title() string { return d.frontmatterString("title") }

--- a/internal/notebook/document_test.go
+++ b/internal/notebook/document_test.go
@@ -7,9 +7,9 @@ import (
 
 func TestParseRoundTrip(t *testing.T) {
 	tests := []struct {
-		name    string
-		raw     string
-		wantFM  map[string]any
+		name     string
+		raw      string
+		wantFM   map[string]any
 		wantBody string
 	}{
 		{
@@ -20,20 +20,20 @@ func TestParseRoundTrip(t *testing.T) {
 		},
 		{
 			name:     "frontmatter and body",
-			raw:      "---\nkind: memory\ntitle: Foo\n---\n# Foo\n\nbody\n",
-			wantFM:   map[string]any{"kind": "memory", "title": "Foo"},
+			raw:      "---\ntype: note\ntitle: Foo\n---\n# Foo\n\nbody\n",
+			wantFM:   map[string]any{"type": "note", "title": "Foo"},
 			wantBody: "# Foo\n\nbody\n",
 		},
 		{
 			name:     "frontmatter preserves blank line before body",
-			raw:      "---\nkind: memory\n---\n\n# Foo\n",
-			wantFM:   map[string]any{"kind": "memory"},
+			raw:      "---\ntype: note\n---\n\n# Foo\n",
+			wantFM:   map[string]any{"type": "note"},
 			wantBody: "\n# Foo\n",
 		},
 		{
 			name:     "empty body",
-			raw:      "---\nkind: journal\n---\n",
-			wantFM:   map[string]any{"kind": "journal"},
+			raw:      "---\ntype: journal\n---\n",
+			wantFM:   map[string]any{"type": "journal"},
 			wantBody: "",
 		},
 	}
@@ -65,7 +65,7 @@ func TestParseRoundTrip(t *testing.T) {
 // Unknown keys (e.g. written by Obsidian or an external sync tool) must survive
 // a parse + serialize cycle, not be dropped.
 func TestUnknownKeysPreserved(t *testing.T) {
-	raw := "---\nkind: memory\ntitle: T\nobsidian-tags: [a, b]\ncustom: 42\n---\nbody\n"
+	raw := "---\ntype: note\ntitle: T\nobsidian-tags: [a, b]\ncustom: 42\n---\nbody\n"
 	doc, err := Parse([]byte(raw))
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
@@ -86,7 +86,7 @@ func TestUnknownKeysPreserved(t *testing.T) {
 
 // The read/list path must never fail on malformed frontmatter.
 func TestParsePermissiveOnMalformedYAML(t *testing.T) {
-	raw := "---\nkind: memory\n  bad: : indentation\n: nope\n---\nbody\n"
+	raw := "---\ntype: note\n  bad: : indentation\n: nope\n---\nbody\n"
 	if _, err := Parse([]byte(raw)); err == nil {
 		t.Fatal("Parse should report malformed YAML as an error")
 	}
@@ -100,13 +100,27 @@ func TestParsePermissiveOnMalformedYAML(t *testing.T) {
 }
 
 func TestDocumentAccessors(t *testing.T) {
-	doc, _ := Parse([]byte("---\nkind: memory\ntitle: T\nsummary: S\nupdated: 2026-06-13T00:00:00Z\n---\n"))
-	if doc.Kind() != "memory" || doc.Title() != "T" || doc.Summary() != "S" || doc.Updated() != "2026-06-13T00:00:00Z" {
-		t.Fatalf("accessors = (%q,%q,%q,%q)", doc.Kind(), doc.Title(), doc.Summary(), doc.Updated())
+	doc, _ := Parse([]byte("---\ntype: note\ntitle: T\nsummary: S\nupdated: 2026-06-13T00:00:00Z\n---\n"))
+	if doc.Type() != "note" || doc.Title() != "T" || doc.Summary() != "S" || doc.Updated() != "2026-06-13T00:00:00Z" {
+		t.Fatalf("accessors = (%q,%q,%q,%q)", doc.Type(), doc.Title(), doc.Summary(), doc.Updated())
 	}
 	empty := Document{}
-	if empty.Kind() != "" || empty.Title() != "" {
+	if empty.Type() != "" || empty.Title() != "" {
 		t.Fatal("accessors on empty document should return empty strings")
+	}
+}
+
+// Type() falls back to a legacy `kind` field so a note an external tool wrote
+// before the field was renamed still resolves. attn always writes `type`, and a
+// present `type` wins over a stray `kind`.
+func TestTypeReadsLegacyKind(t *testing.T) {
+	legacy, _ := Parse([]byte("---\nkind: memory\n---\n"))
+	if legacy.Type() != "memory" {
+		t.Fatalf("Type() should fall back to legacy kind, got %q", legacy.Type())
+	}
+	both, _ := Parse([]byte("---\ntype: note\nkind: memory\n---\n"))
+	if both.Type() != "note" {
+		t.Fatalf("Type() should prefer type over legacy kind, got %q", both.Type())
 	}
 }
 
@@ -130,13 +144,13 @@ func TestNoClosingFenceIsBody(t *testing.T) {
 // are all preserved. This is the preserve-verbatim round-trip the design
 // requires for Obsidian/sync/user-authored fields.
 func TestParseRoundTripIsByteFaithful(t *testing.T) {
-	raw := "---\nkind: memory\nticket: 007\nver: 1.10\n# a human note\nzeta: last\nalpha: first\n---\n\n# Body\n"
+	raw := "---\ntype: note\nticket: 007\nver: 1.10\n# a human note\nzeta: last\nalpha: first\n---\n\n# Body\n"
 	doc, err := Parse([]byte(raw))
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	if doc.Kind() != "memory" {
-		t.Fatalf("Kind = %q, want memory", doc.Kind())
+	if doc.Type() != "note" {
+		t.Fatalf("Type = %q, want note", doc.Type())
 	}
 	if out := string(doc.Bytes()); out != raw {
 		t.Fatalf("round-trip not byte-faithful:\n got: %q\nwant: %q", out, raw)

--- a/internal/notebook/layout.go
+++ b/internal/notebook/layout.go
@@ -8,25 +8,28 @@ import (
 )
 
 // Reserved layout (OKF-derived). index.md and log.md carry no frontmatter, like
-// OKF's bundle root. The .attn/ dotdir holds machine state (dreaming candidates,
-// locks, run reports) and is never surfaced by List nor touched by a
-// dotfile-skipping external sync scanner.
+// OKF's bundle root. The .attn/ dotdir holds machine state (the durable task
+// runner, raw tier, narrate-cron anchor) and is never surfaced by List nor touched
+// by a dotfile-skipping external sync scanner.
 const (
 	FileIndex = "index.md"
 	FileLog   = "log.md"
 	// FileInbox is the reserved note where "send to chief" messages accumulate.
 	// It is created on the first send (not scaffolded) and lives at the root so
-	// it groups under "Notebook" in the browser, distinct from journal/memory.
+	// it groups under "Notebook" in the browser, distinct from journal/knowledge.
 	FileInbox = "inbox.md"
 
-	DirJournal = "journal"
-	DirMemory  = "memory"
+	DirJournal   = "journal"
+	DirKnowledge = "knowledge"
 
 	machineDir = ".attn"
 )
 
-// memorySubdirs are organizational groupings under memory/ (not kinds).
-var memorySubdirs = []string{"decisions", "gotchas", "domain"}
+// paraSubdirs are the PARA-method groupings under knowledge/ (the directory
+// axis). They are organizational, orthogonal to a note's OKF `type`. Knowledge
+// is nested under projects/ and areas/; resources/ and archive/ hold reference
+// and inactive material respectively.
+var paraSubdirs = []string{"projects", "areas", "resources", "archive"}
 
 // DefaultRoot returns the default notebook root for a profile, derived from the
 // user's home directory. The default profile ("" or "default") maps to
@@ -43,8 +46,8 @@ func DefaultRoot(home, profile string) string {
 }
 
 // CleanPath validates and normalizes a notebook path. The input may be
-// root-absolute ("/memory/foo.md", matching the link convention) or relative
-// ("memory/foo.md"); the result is always a clean, slash-separated relative
+// root-absolute ("/knowledge/areas/foo.md", matching the link convention) or
+// relative ("knowledge/areas/foo.md"); the result is always a clean, slash-separated relative
 // path. It rejects empty paths, the root itself, parent-directory escapes,
 // dotfile/dotdir segments, and any extension other than .md.
 func CleanPath(p string) (string, error) {
@@ -78,19 +81,26 @@ type scaffoldFile struct {
 }
 
 func scaffoldDirs() []string {
-	dirs := []string{DirJournal, DirMemory}
-	for _, sub := range memorySubdirs {
-		dirs = append(dirs, path.Join(DirMemory, sub))
+	dirs := []string{DirJournal, DirKnowledge}
+	for _, sub := range paraSubdirs {
+		dirs = append(dirs, path.Join(DirKnowledge, sub))
 	}
 	return dirs
 }
 
 func scaffoldFiles() []scaffoldFile {
-	return []scaffoldFile{
+	files := []scaffoldFile{
 		{FileIndex, indexTemplate},
 		{FileLog, logTemplate},
-		{path.Join(DirMemory, FileIndex), memoryIndexTemplate},
+		{path.Join(DirKnowledge, FileIndex), knowledgeIndexTemplate},
 	}
+	for _, sub := range paraSubdirs {
+		files = append(files, scaffoldFile{
+			relPath: path.Join(DirKnowledge, sub, FileIndex),
+			content: paraIndexTemplates[sub],
+		})
+	}
+	return files
 }
 
 // ScaffoldPaths returns the notebook-relative paths of the reserved files that
@@ -106,15 +116,17 @@ func ScaffoldPaths() []string {
 
 const indexTemplate = `# Notebook
 
-Durable, profile-wide markdown memory — written by attn on behalf of agents, a
-nightly consolidation pass, and you. It outlives any single workspace.
+A durable, profile-wide markdown bundle — the journal attn writes on your behalf
+and the knowledge base the chief of staff maintains. It outlives any single
+workspace and is yours to read, edit, and sync.
 
-- ` + "`journal/`" + ` — dated, append-only entries (the raw system of record).
-- ` + "`memory/`" + ` — durable distilled notes: decisions, gotchas, domain knowledge.
+- ` + "`journal/`" + ` — dated narrative of what was done, newest entries appended per day.
+- ` + "`knowledge/`" + ` — the PARA-organized knowledge base (projects, areas, resources, archive).
 - ` + "`log.md`" + ` — global change history, newest first.
 
-Kinds: ` + "`journal`" + `, ` + "`memory`" + `. Links are root-absolute markdown, e.g.
-[a decision](/memory/decisions/example.md) — not wikilinks.
+This is one OKF bundle (Open Knowledge Format): every note carries a ` + "`type`" + `
+frontmatter field, and links are root-absolute markdown, e.g.
+[an area note](/knowledge/areas/example.md) — not wikilinks.
 
 <!-- okf_version: 0.1 -->
 `
@@ -124,19 +136,31 @@ const logTemplate = `# Log
 Change history, newest first.
 `
 
-// inboxTemplate seeds inbox.md on the first "send to chief". It has no kind: it
-// is an append-only delivery log, not durable distilled memory.
+// inboxTemplate seeds inbox.md on the first "send to chief". It has no type: it
+// is an append-only delivery log, not durable knowledge.
 const inboxTemplate = `# Chief inbox
 
 Selections sent to the chief of staff from the Notebook, oldest first.
 `
 
-const memoryIndexTemplate = `# Memory
+const knowledgeIndexTemplate = `# Knowledge base
 
-Durable distilled notes. Every note carries resolvable ` + "`sources:`" + ` — there is
-no ungrounded memory.
+The chief of staff's durable knowledge, organized by the PARA method (the
+directory axis) with an OKF ` + "`type`" + ` on every note (the frontmatter axis).
 
-- ` + "`decisions/`" + ` — cross-workspace decisions that outlived a single PR.
-- ` + "`gotchas/`" + ` — repeated surprises worth remembering.
-- ` + "`domain/`" + ` — glossary and business rules.
+- ` + "`projects/`" + ` — bounded efforts with an end (one folder per project/epic).
+- ` + "`areas/`" + ` — ongoing responsibilities and subsystems, with no end.
+- ` + "`resources/`" + ` — reference material worth keeping.
+- ` + "`archive/`" + ` — finished or inactive items, moved here when a project closes.
+
+Every note is grounded — carry resolvable ` + "`sources:`" + ` (journal anchors,
+` + "`dispatch:<id>`" + `, or URLs), never paraphrase alone.
 `
+
+// paraIndexTemplates seeds each PARA directory's reserved index.md.
+var paraIndexTemplates = map[string]string{
+	"projects":  "# Projects\n\nBounded efforts with an end. One folder per project or epic; a\nproject's `index.md` links the workspace that produced it with\n`resource: attn:workspace/<id>`.\n",
+	"areas":     "# Areas\n\nOngoing responsibilities and subsystems, with no end. Durable knowledge\npromoted out of finished projects lands here.\n",
+	"resources": "# Resources\n\nReference material worth keeping across projects and areas.\n",
+	"archive":   "# Archive\n\nFinished or inactive items. A project folder is moved here when its\nworkspace closes.\n",
+}

--- a/internal/notebook/layout_test.go
+++ b/internal/notebook/layout_test.go
@@ -25,21 +25,21 @@ func TestCleanPath(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"memory/decisions/foo.md", "memory/decisions/foo.md", false},
-		{"/memory/decisions/foo.md", "memory/decisions/foo.md", false}, // root-absolute normalized
+		{"knowledge/areas/foo.md", "knowledge/areas/foo.md", false},
+		{"/knowledge/areas/foo.md", "knowledge/areas/foo.md", false}, // root-absolute normalized
 		{"  /index.md  ", "index.md", false},
-		{"memory/./foo.md", "memory/foo.md", false},
+		{"knowledge/./foo.md", "knowledge/foo.md", false},
 		// escapes are neutralized to within the root, never outside
 		{"../../etc/passwd.md", "etc/passwd.md", false},
-		{"memory/../journal/x.md", "journal/x.md", false},
+		{"knowledge/../journal/x.md", "journal/x.md", false},
 		// rejections
 		{"", "", true},
 		{"/", "", true},
-		{"memory/foo.txt", "", true},     // not .md
-		{"memory/foo", "", true},         // no extension
-		{".attn/dreams/x.md", "", true},  // dotdir segment
-		{"memory/.hidden.md", "", true},  // dotfile segment
-		{"memory//foo.md", "memory/foo.md", false}, // doubled slash collapses to a valid path
+		{"knowledge/foo.txt", "", true},                  // not .md
+		{"knowledge/foo", "", true},                      // no extension
+		{".attn/raw/x.md", "", true},                     // dotdir segment
+		{"knowledge/.hidden.md", "", true},               // dotfile segment
+		{"knowledge//foo.md", "knowledge/foo.md", false}, // doubled slash collapses to a valid path
 	}
 	for _, tc := range tests {
 		got, err := CleanPath(tc.in)

--- a/internal/notebook/links.go
+++ b/internal/notebook/links.go
@@ -3,7 +3,7 @@ package notebook
 import "regexp"
 
 // rootAbsoluteLinkRE matches markdown links whose target is a root-absolute
-// notebook path, e.g. [a decision](/memory/decisions/foo.md). External
+// notebook path, e.g. [an area note](/knowledge/areas/foo.md). External
 // (http://…), relative (foo.md), and anchor-only (#section) targets are
 // intentionally not matched: the Notebook linking convention is root-absolute
 // markdown only — no [[wikilinks]] — so the targets resolve without an external

--- a/internal/notebook/links_test.go
+++ b/internal/notebook/links_test.go
@@ -6,15 +6,15 @@ import (
 )
 
 func TestLinks(t *testing.T) {
-	body := `See [the decision](/memory/decisions/foo.md) and
-[a gotcha](/memory/gotchas/bar.md#section) for context.
+	body := `See [the decision](/knowledge/areas/foo.md) and
+[a gotcha](/knowledge/resources/bar.md#section) for context.
 External [link](https://example.com/x.md) and a [relative](foo.md) one are ignored,
-as is an [anchor](#top). The decision is referenced [again](/memory/decisions/foo.md).`
+as is an [anchor](#top). The decision is referenced [again](/knowledge/areas/foo.md).`
 
 	got := Links(body)
 	want := []string{
-		"/memory/decisions/foo.md",
-		"/memory/gotchas/bar.md#section",
+		"/knowledge/areas/foo.md",
+		"/knowledge/resources/bar.md#section",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Links = %#v, want %#v", got, want)

--- a/internal/notebook/narrate_cron_state.go
+++ b/internal/notebook/narrate_cron_state.go
@@ -1,0 +1,84 @@
+package notebook
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Daily-narrate cron machine state.
+//
+// The daily per-workspace narrate pass persists its schedule anchor under
+// <root>/.attn/narrate/ as plain JSON — self-describing and git-diffable. This is
+// MACHINE state, not a notebook document: it lives in the .attn dotdir (skipped by
+// List and by any dotfile-aware external sync scanner) and never goes through
+// Store.Write, whose CleanPath rejects dotdir and non-.md paths.
+//
+// It is its own small state file so the daily narrate's schedule anchor stays
+// decoupled from any other cron bookkeeping; it carries only the nightly schedule
+// anchor.
+//
+// The write reuses the package's atomic temp+rename writer so a crash mid-write
+// never leaves a half-written state file.
+
+const (
+	narrateDir       = "narrate"
+	narrateStateFile = "state.json"
+
+	// narrateCronStateVersion tags persisted state so a future format change can be
+	// detected and migrated rather than silently mis-read.
+	narrateCronStateVersion = 1
+)
+
+// NarrateCronStateDir returns the absolute .attn/narrate directory for a notebook
+// root.
+func NarrateCronStateDir(root string) string {
+	return filepath.Join(root, machineDir, narrateDir)
+}
+
+// NarrateCronState is the persisted schedule anchor for the daily per-workspace
+// narrate cron. It is deliberately tiny: the cron enqueuer
+// (enqueueDueDailyNarrates) is its SOLE writer, so there is no two-writer race on
+// state.json.
+type NarrateCronState struct {
+	Version int `json:"version"`
+	// ScheduledFrom is the anchor the next daily-narrate pass is computed from
+	// (RFC3339, UTC): set to "now" on the first observation (so the first pass
+	// lands at the next scheduled slot, not at daemon startup) and advanced to the
+	// dispatch time after each due fire. A fire is due when
+	// schedule.Next(ScheduledFrom) has passed; because the anchor jumps forward to
+	// the dispatch time, slots missed while the daemon was down collapse into a
+	// single catch-up. See enqueueDueDailyNarrates for the full semantics.
+	ScheduledFrom string `json:"scheduled_from,omitempty"`
+}
+
+// LoadNarrateCronState reads the persisted schedule anchor. A missing file yields
+// the zero value (no pass has been anchored yet), not an error.
+func LoadNarrateCronState(root string) (NarrateCronState, error) {
+	path := filepath.Join(NarrateCronStateDir(root), narrateStateFile)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return NarrateCronState{}, nil
+	}
+	if err != nil {
+		return NarrateCronState{}, err
+	}
+	var state NarrateCronState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return NarrateCronState{}, fmt.Errorf("notebook: parse %s: %w", narrateStateFile, err)
+	}
+	return state, nil
+}
+
+// SaveNarrateCronState writes the schedule anchor atomically, stamping the current
+// format version.
+func SaveNarrateCronState(root string, state NarrateCronState) error {
+	state.Version = narrateCronStateVersion
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeAtomic(filepath.Join(NarrateCronStateDir(root), narrateStateFile), data)
+}

--- a/internal/notebook/narrate_cron_state_test.go
+++ b/internal/notebook/narrate_cron_state_test.go
@@ -1,0 +1,41 @@
+package notebook
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNarrateCronStateRoundTrip(t *testing.T) {
+	root := t.TempDir()
+
+	// Missing file reads as the zero value, not an error.
+	zero, err := LoadNarrateCronState(root)
+	if err != nil {
+		t.Fatalf("load missing: %v", err)
+	}
+	if zero.ScheduledFrom != "" {
+		t.Fatalf("expected zero state, got %+v", zero)
+	}
+
+	if err := SaveNarrateCronState(root, NarrateCronState{
+		ScheduledFrom: "2026-06-14T03:00:00Z",
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := LoadNarrateCronState(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.Version != narrateCronStateVersion {
+		t.Fatalf("expected version stamped to %d, got %d", narrateCronStateVersion, got.Version)
+	}
+	if got.ScheduledFrom != "2026-06-14T03:00:00Z" {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	// The state lives under the .attn narrate dir.
+	if _, err := os.Stat(filepath.Join(NarrateCronStateDir(root), narrateStateFile)); err != nil {
+		t.Fatalf("narrate state file not written: %v", err)
+	}
+}

--- a/internal/notebook/notebook.go
+++ b/internal/notebook/notebook.go
@@ -1,7 +1,7 @@
 // Package notebook implements the Notebook on-disk format and a
-// filesystem-canonical store: a durable, profile-wide markdown memory layer
-// (dated journals + distilled memory notes + cross-workspace decisions) that
-// outlives any single workspace.
+// filesystem-canonical store: a durable, profile-wide markdown layer (dated
+// journals + a PARA-organized knowledge base) that outlives any single
+// workspace.
 //
 // The package is deliberately free of daemon dependencies so the format and the
 // store can be unit-tested in isolation. The daemon wraps a Store, resolves the
@@ -15,7 +15,7 @@
 //   - Plain files, paths-as-identity, root-absolute markdown links (no
 //     wikilinks), machine state under a .attn/ dotdir — so an external markdown
 //     sync tool or Obsidian can point at the root without attn precluding it.
-//   - Permissive reader: never reject a file on unknown kind, extra frontmatter
+//   - Permissive reader: never reject a file on unknown type, extra frontmatter
 //     keys, broken links, or a missing index; preserve unknown keys on
 //     round-trip so fields written by other tools survive.
 package notebook
@@ -27,22 +27,15 @@ import (
 	"fmt"
 )
 
-// Document kinds. The Notebook recognizes exactly two (OKF discipline: one
-// required frontmatter field). The subdirectories under memory/ (decisions,
-// gotchas, domain) are organizational groupings, not kinds.
-const (
-	KindJournal = "journal"
-	KindMemory  = "memory"
-)
+// TypeJournal is the OKF `type` value attn writes onto dated journal notes. It
+// is the one type attn authors itself; every other note's `type` is author- or
+// chief-chosen (OKF leaves the vocabulary open), so the store does not enforce a
+// closed set — it stays a permissive reader/writer.
+const TypeJournal = "journal"
 
 // MaxFileSize bounds a single note so the store stays sync-friendly; journals
 // rotate daily to stay well under it.
 const MaxFileSize = 2 << 20 // 2 MiB
-
-// ValidKind reports whether k is a recognized Notebook kind.
-func ValidKind(k string) bool {
-	return k == KindJournal || k == KindMemory
-}
 
 // Hash returns the canonical content hash used for hash-CAS edits.
 func Hash(content []byte) string {
@@ -53,8 +46,8 @@ func Hash(content []byte) string {
 // Entry is a single note as surfaced by List: enough to render a tree without
 // reading every file's full body.
 type Entry struct {
-	Path    string // notebook-relative, slash-separated, e.g. "memory/decisions/foo.md"
-	Kind    string // "" when the file declares no kind (permissive)
+	Path    string // notebook-relative, slash-separated, e.g. "knowledge/areas/foo.md"
+	Type    string // OKF `type` ("" when the file declares none; permissive)
 	Title   string
 	Summary string
 	Updated string // frontmatter `updated`, else the file mtime (RFC3339)

--- a/internal/notebook/raw_tier.go
+++ b/internal/notebook/raw_tier.go
@@ -1,0 +1,44 @@
+package notebook
+
+import "path/filepath"
+
+// Raw tier machine paths.
+//
+// The narration pipeline feeds the curated journal from a separate "raw tier"
+// of machine inputs under <root>/.attn/raw/. The raw tier lives in the .attn
+// dotdir: it is skipped by List, by the watcher, and by any dotfile-aware external
+// sync scanner, and CleanPath rejects dotdir segments so Store.Write/Read cannot
+// address it. Daemon and agent code therefore writes the raw tier with direct
+// filesystem I/O, never through notebook.Store. These helpers keep the
+// ".attn"/"raw"/... literals in one place so callers do not hardcode the layout.
+const (
+	rawDir                 = "raw"
+	rawContextSnapshotsDir = "context-snapshots"
+	rawDispatchesDir       = "dispatches"
+	rawSessionsDir         = "sessions"
+)
+
+// RawDir returns the absolute .attn/raw directory for a notebook root.
+func RawDir(root string) string {
+	return filepath.Join(root, machineDir, rawDir)
+}
+
+// RawContextSnapshotsDir returns the absolute directory holding per-workspace
+// context.md removal snapshots (<wsID>.md).
+func RawContextSnapshotsDir(root string) string {
+	return filepath.Join(RawDir(root), rawContextSnapshotsDir)
+}
+
+// RawDispatchesDir returns the absolute directory holding per-dispatch outcome
+// files (<dispatchID>.md).
+func RawDispatchesDir(root string) string {
+	return filepath.Join(RawDir(root), rawDispatchesDir)
+}
+
+// RawSessionsDir returns the absolute directory holding per-session digest files
+// (<sessionID>.md), written natively by the summarize_session narration agent and
+// later read by the narrate_workspace agent. Like the other raw-tier subdirs it
+// lives under .attn/raw/ — unreachable through the user-facing notebook APIs.
+func RawSessionsDir(root string) string {
+	return filepath.Join(RawDir(root), rawSessionsDir)
+}

--- a/internal/notebook/store.go
+++ b/internal/notebook/store.go
@@ -108,14 +108,9 @@ func (s *Store) Write(p string, content []byte, baseHash string) (newHash string
 	if int64(len(content)) > MaxFileSize {
 		return "", nil, fmt.Errorf("notebook: content for %q exceeds %d bytes", p, MaxFileSize)
 	}
-	// Reject an explicitly-declared but invalid kind; absent kind is allowed
-	// (permissive). Malformed frontmatter is tolerated here — Write stores
-	// bytes; the read/list path is the permissive consumer.
-	if doc, perr := Parse(content); perr == nil {
-		if k := doc.Kind(); k != "" && !ValidKind(k) {
-			return "", nil, fmt.Errorf("notebook: invalid kind %q (want %q or %q)", k, KindJournal, KindMemory)
-		}
-	}
+	// No type validation: OKF leaves the `type` vocabulary open, so the store is
+	// a permissive writer (it stores bytes) and the read/list path is the
+	// permissive consumer. The guidance, not the store, asks authors for a type.
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -146,7 +141,7 @@ func (s *Store) Write(p string, content []byte, baseHash string) (newHash string
 var journalDateRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
 
 // AppendJournal appends an entry to the dated journal file (journal/<date>.md),
-// creating it with kind:journal frontmatter on first write. Appends are
+// creating it with type:journal frontmatter on first write. Appends are
 // serialized and never conflict. dateISO must be YYYY-MM-DD.
 func (s *Store) AppendJournal(dateISO, entry string) (relPath string, hash string, err error) {
 	if !journalDateRE.MatchString(dateISO) {
@@ -187,7 +182,7 @@ func (s *Store) AppendJournalEntryOnce(dateISO, dedupeMarker, entry string) (rel
 func newJournalDoc(dateISO string) func() Document {
 	return func() Document {
 		return Document{
-			Frontmatter: map[string]any{"kind": KindJournal, "title": dateISO},
+			Frontmatter: map[string]any{"type": TypeJournal, "title": dateISO},
 			Body:        "# " + dateISO + "\n",
 		}
 	}
@@ -269,7 +264,7 @@ const listFrontmatterScanLimit = 64 << 10 // 64 KiB
 
 func (s *Store) List(prefix string) ([]Entry, error) {
 	// A non-empty prefix scopes a subtree on path-segment boundaries (so
-	// "memory/decisions" does NOT match the sibling "memory/decisions-archive").
+	// "knowledge/areas" does NOT match the sibling "knowledge/areas-archive").
 	want := strings.Trim(strings.TrimSpace(prefix), "/")
 	var entries []Entry
 	walkErr := filepath.WalkDir(s.root, func(p string, dirent fs.DirEntry, err error) error {
@@ -319,7 +314,7 @@ func (s *Store) List(prefix string) ([]Entry, error) {
 		}
 		entries = append(entries, Entry{
 			Path:    rel,
-			Kind:    doc.Kind(),
+			Type:    doc.Type(),
 			Title:   doc.Title(),
 			Summary: doc.Summary(),
 			Updated: updated,

--- a/internal/notebook/store_test.go
+++ b/internal/notebook/store_test.go
@@ -18,15 +18,20 @@ func TestEnsureScaffold(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EnsureScaffold: %v", err)
 	}
-	if !reflect.DeepEqual(created, []string{"index.md", "log.md", "memory/index.md"}) {
+	wantFiles := []string{
+		"index.md", "log.md", "knowledge/index.md",
+		"knowledge/projects/index.md", "knowledge/areas/index.md",
+		"knowledge/resources/index.md", "knowledge/archive/index.md",
+	}
+	if !reflect.DeepEqual(created, wantFiles) {
 		t.Fatalf("first EnsureScaffold created = %v, want all reserved files", created)
 	}
-	for _, rel := range []string{"index.md", "log.md", "memory/index.md"} {
+	for _, rel := range wantFiles {
 		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
 			t.Fatalf("scaffold file %s missing: %v", rel, err)
 		}
 	}
-	for _, rel := range []string{"journal", "memory/decisions", "memory/gotchas", "memory/domain"} {
+	for _, rel := range []string{"journal", "knowledge", "knowledge/projects", "knowledge/areas", "knowledge/resources", "knowledge/archive"} {
 		info, err := os.Stat(filepath.Join(root, rel))
 		if err != nil || !info.IsDir() {
 			t.Fatalf("scaffold dir %s missing: %v", rel, err)
@@ -53,44 +58,51 @@ func TestEnsureScaffold(t *testing.T) {
 func TestEnsureScaffoldReturnsPartialWritesOnFailure(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "nb")
 	// Pre-create the full dir layout so EnsureScaffold's MkdirAll calls are no-ops,
-	// then make memory/ read-only so the memory/index.md write (the last reserved
-	// file) fails while index.md and log.md (in the writable root) succeed.
-	for _, d := range []string{"journal", "memory/decisions", "memory/gotchas", "memory/domain"} {
+	// then make knowledge/archive/ read-only so the knowledge/archive/index.md
+	// write (the LAST reserved file) fails while every earlier reserved file
+	// (in writable dirs) succeeds.
+	for _, d := range []string{"journal", "knowledge/projects", "knowledge/areas", "knowledge/resources", "knowledge/archive"} {
 		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
-	mem := filepath.Join(root, "memory")
-	if err := os.Chmod(mem, 0o555); err != nil {
+	archive := filepath.Join(root, "knowledge", "archive")
+	if err := os.Chmod(archive, 0o555); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chmod(mem, 0o755) })
+	t.Cleanup(func() { _ = os.Chmod(archive, 0o755) })
 
 	s := NewStore(root)
 	created, err := s.EnsureScaffold()
 	if err == nil {
-		t.Skip("write into read-only memory/ unexpectedly succeeded (likely running as root)")
+		t.Skip("write into read-only knowledge/archive/ unexpectedly succeeded (likely running as root)")
 	}
 	// The files written before the failure must be returned so the caller can
 	// account for attn's own partial writes (and not later mis-surface them as
-	// external edits), rather than discarding them with the error.
-	if !reflect.DeepEqual(created, []string{"index.md", "log.md"}) {
-		t.Fatalf("partial EnsureScaffold created = %v, want [index.md log.md]", created)
+	// external edits), rather than discarding them with the error. Only the final
+	// reserved file (knowledge/archive/index.md) fails.
+	wantPartial := []string{
+		"index.md", "log.md", "knowledge/index.md",
+		"knowledge/projects/index.md", "knowledge/areas/index.md",
+		"knowledge/resources/index.md",
+	}
+	if !reflect.DeepEqual(created, wantPartial) {
+		t.Fatalf("partial EnsureScaffold created = %v, want %v", created, wantPartial)
 	}
 }
 
 func TestReadNotFound(t *testing.T) {
 	s := NewStore(t.TempDir())
-	if _, _, err := s.Read("memory/missing.md"); !IsNotFound(err) {
+	if _, _, err := s.Read("knowledge/areas/missing.md"); !IsNotFound(err) {
 		t.Fatalf("Read missing = %v, want NotFoundError", err)
 	}
 }
 
 func TestWriteCreateAndConflict(t *testing.T) {
 	s := NewStore(t.TempDir())
-	content := []byte("---\nkind: memory\n---\nhello\n")
+	content := []byte("---\ntype: note\n---\nhello\n")
 
-	hash, conflict, err := s.Write("memory/decisions/foo.md", content, "")
+	hash, conflict, err := s.Write("knowledge/areas/foo.md", content, "")
 	if err != nil || conflict != nil {
 		t.Fatalf("create: err=%v conflict=%v", err, conflict)
 	}
@@ -99,14 +111,14 @@ func TestWriteCreateAndConflict(t *testing.T) {
 	}
 
 	// Create-only against an existing file is a conflict, not an overwrite.
-	_, conflict, err = s.Write("memory/decisions/foo.md", []byte("other"), "")
+	_, conflict, err = s.Write("knowledge/areas/foo.md", []byte("other"), "")
 	if err != nil {
 		t.Fatalf("create-conflict err: %v", err)
 	}
 	if conflict == nil || conflict.CurrentHash != Hash(content) {
 		t.Fatalf("expected create conflict carrying current hash, got %#v", conflict)
 	}
-	got, _, _ := s.Read("memory/decisions/foo.md")
+	got, _, _ := s.Read("knowledge/areas/foo.md")
 	if string(got) != string(content) {
 		t.Fatalf("create-conflict overwrote the file: %q", got)
 	}
@@ -114,15 +126,15 @@ func TestWriteCreateAndConflict(t *testing.T) {
 
 func TestWriteCASEdit(t *testing.T) {
 	s := NewStore(t.TempDir())
-	v1 := []byte("---\nkind: memory\n---\nv1\n")
-	h1, _, err := s.Write("memory/decisions/foo.md", v1, "")
+	v1 := []byte("---\ntype: note\n---\nv1\n")
+	h1, _, err := s.Write("knowledge/areas/foo.md", v1, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Stale base hash => conflict, no write.
-	v2 := []byte("---\nkind: memory\n---\nv2\n")
-	_, conflict, err := s.Write("memory/decisions/foo.md", v2, "deadbeef")
+	v2 := []byte("---\ntype: note\n---\nv2\n")
+	_, conflict, err := s.Write("knowledge/areas/foo.md", v2, "deadbeef")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,25 +143,13 @@ func TestWriteCASEdit(t *testing.T) {
 	}
 
 	// Matching base hash => applies.
-	h2, conflict, err := s.Write("memory/decisions/foo.md", v2, h1)
+	h2, conflict, err := s.Write("knowledge/areas/foo.md", v2, h1)
 	if err != nil || conflict != nil {
 		t.Fatalf("CAS edit: err=%v conflict=%v", err, conflict)
 	}
-	got, gotHash, _ := s.Read("memory/decisions/foo.md")
+	got, gotHash, _ := s.Read("knowledge/areas/foo.md")
 	if string(got) != string(v2) || gotHash != h2 {
 		t.Fatalf("CAS edit did not apply: content=%q hash=%q", got, gotHash)
-	}
-}
-
-func TestWriteRejectsInvalidKind(t *testing.T) {
-	s := NewStore(t.TempDir())
-	_, _, err := s.Write("memory/foo.md", []byte("---\nkind: bogus\n---\nx\n"), "")
-	if err == nil {
-		t.Fatal("Write should reject an explicitly-declared invalid kind")
-	}
-	// Absent kind is permitted.
-	if _, _, err := s.Write("memory/bar.md", []byte("# no frontmatter\n"), ""); err != nil {
-		t.Fatalf("Write without a kind should be allowed: %v", err)
 	}
 }
 
@@ -170,8 +170,8 @@ func TestAppendJournal(t *testing.T) {
 
 	content, _, _ := s.Read(rel)
 	doc := ParsePermissive(content)
-	if doc.Kind() != KindJournal {
-		t.Fatalf("journal kind = %q, want %q", doc.Kind(), KindJournal)
+	if doc.Type() != TypeJournal {
+		t.Fatalf("journal type = %q, want %q", doc.Type(), TypeJournal)
 	}
 	if !strings.Contains(doc.Body, "first entry") || !strings.Contains(doc.Body, "second entry") {
 		t.Fatalf("journal body missing entries:\n%s", doc.Body)
@@ -331,7 +331,7 @@ func TestStoreRejectsSymlinkEscape(t *testing.T) {
 	if _, _, err := s.Read("evil/secret.md"); err == nil {
 		t.Fatal("Read through a symlinked dir should be rejected")
 	}
-	if _, _, err := s.Write("evil/secret.md", []byte("---\nkind: memory\n---\nx\n"), ""); err == nil {
+	if _, _, err := s.Write("evil/secret.md", []byte("---\ntype: note\n---\nx\n"), ""); err == nil {
 		t.Fatal("Write through a symlinked dir should be rejected")
 	}
 	if got, _ := os.ReadFile(secret); string(got) != "TOP SECRET\n" {
@@ -355,7 +355,7 @@ func TestStoreAllowsSymlinkedRoot(t *testing.T) {
 	if _, err := s.EnsureScaffold(); err != nil {
 		t.Fatalf("EnsureScaffold on a symlinked root: %v", err)
 	}
-	if _, _, err := s.Write("memory/foo.md", []byte("---\nkind: memory\n---\nx\n"), ""); err != nil {
+	if _, _, err := s.Write("knowledge/areas/foo.md", []byte("---\ntype: note\n---\nx\n"), ""); err != nil {
 		t.Fatalf("write under a symlinked root should work: %v", err)
 	}
 }
@@ -363,31 +363,31 @@ func TestStoreAllowsSymlinkedRoot(t *testing.T) {
 // The prefix scopes a subtree on path-segment boundaries, not raw substring.
 func TestListPrefixIsPathSegmentBoundary(t *testing.T) {
 	s := NewStore(t.TempDir())
-	body := []byte("---\nkind: memory\n---\nx\n")
-	if _, _, err := s.Write("memory/decisions/foo.md", body, ""); err != nil {
+	body := []byte("---\ntype: note\n---\nx\n")
+	if _, _, err := s.Write("knowledge/areas/foo.md", body, ""); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := s.Write("memory/decisions-archive/bar.md", body, ""); err != nil {
+	if _, _, err := s.Write("knowledge/areas-archive/bar.md", body, ""); err != nil {
 		t.Fatal(err)
 	}
-	entries, err := s.List("memory/decisions")
+	entries, err := s.List("knowledge/areas")
 	if err != nil {
 		t.Fatal(err)
 	}
 	foundFoo, foundArchive := false, false
 	for _, e := range entries {
 		switch e.Path {
-		case "memory/decisions/foo.md":
+		case "knowledge/areas/foo.md":
 			foundFoo = true
-		case "memory/decisions-archive/bar.md":
+		case "knowledge/areas-archive/bar.md":
 			foundArchive = true
 		}
 	}
 	if !foundFoo {
-		t.Fatalf("prefix should include memory/decisions/foo.md; got %+v", entries)
+		t.Fatalf("prefix should include knowledge/areas/foo.md; got %+v", entries)
 	}
 	if foundArchive {
-		t.Fatalf("prefix must NOT leak the sibling memory/decisions-archive/bar.md; got %+v", entries)
+		t.Fatalf("prefix must NOT leak the sibling knowledge/areas-archive/bar.md; got %+v", entries)
 	}
 }
 
@@ -395,15 +395,15 @@ func TestListPrefixIsPathSegmentBoundary(t *testing.T) {
 // and still reports the full size.
 func TestListReadsFrontmatterFromLargeFile(t *testing.T) {
 	s := NewStore(t.TempDir())
-	big := "---\nkind: memory\ntitle: Big\n---\n" + strings.Repeat("x\n", 100<<10) // ~200 KiB body
-	if _, _, err := s.Write("memory/big.md", []byte(big), ""); err != nil {
+	big := "---\ntype: note\ntitle: Big\n---\n" + strings.Repeat("x\n", 100<<10) // ~200 KiB body
+	if _, _, err := s.Write("knowledge/areas/big.md", []byte(big), ""); err != nil {
 		t.Fatal(err)
 	}
-	entries, err := s.List("memory/big.md")
+	entries, err := s.List("knowledge/areas/big.md")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(entries) != 1 || entries[0].Kind != "memory" || entries[0].Title != "Big" {
+	if len(entries) != 1 || entries[0].Type != "note" || entries[0].Title != "Big" {
 		t.Fatalf("List did not extract frontmatter from a large file: %+v", entries)
 	}
 	if entries[0].Size != int64(len(big)) {
@@ -415,7 +415,7 @@ func TestListReadsFrontmatterFromLargeFile(t *testing.T) {
 // key order, ambiguous scalars all survive the next attn append).
 func TestAppendJournalPreservesExistingFrontmatter(t *testing.T) {
 	s := NewStore(t.TempDir())
-	existing := "---\nkind: journal\n# external note\nobsidian_id: 007\nzeta: z\ntitle: jrnl\n---\n# entries\n\nfirst\n"
+	existing := "---\ntype: journal\n# external note\nobsidian_id: 007\nzeta: z\ntitle: jrnl\n---\n# entries\n\nfirst\n"
 	if _, _, err := s.Write("journal/2026-06-13.md", []byte(existing), ""); err != nil {
 		t.Fatal(err)
 	}
@@ -446,14 +446,14 @@ func TestList(t *testing.T) {
 	if _, err := s.EnsureScaffold(); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := s.Write("memory/decisions/foo.md", []byte("---\nkind: memory\ntitle: Foo\nsummary: a decision\n---\nbody\n"), ""); err != nil {
+	if _, _, err := s.Write("knowledge/areas/foo.md", []byte("---\ntype: note\ntitle: Foo\nsummary: a decision\n---\nbody\n"), ""); err != nil {
 		t.Fatal(err)
 	}
 	// Machine state under .attn/ must never be surfaced.
-	if err := os.MkdirAll(filepath.Join(s.Root(), ".attn", "dreams"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(s.Root(), ".attn", "raw"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(s.Root(), ".attn", "dreams", "note.md"), []byte("x"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(s.Root(), ".attn", "raw", "note.md"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -468,21 +468,21 @@ func TestList(t *testing.T) {
 		}
 		paths[e.Path] = e
 	}
-	foo, ok := paths["memory/decisions/foo.md"]
+	foo, ok := paths["knowledge/areas/foo.md"]
 	if !ok {
 		t.Fatalf("List missing the written note; got %v", entries)
 	}
-	if foo.Kind != "memory" || foo.Title != "Foo" || foo.Summary != "a decision" {
+	if foo.Type != "note" || foo.Title != "Foo" || foo.Summary != "a decision" {
 		t.Fatalf("List entry metadata = %+v", foo)
 	}
 
 	// Prefix filters to a subtree.
-	mem, err := s.List("/memory/decisions")
+	mem, err := s.List("/knowledge/areas")
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, e := range mem {
-		if !strings.HasPrefix(e.Path, "memory/decisions") {
+		if !strings.HasPrefix(e.Path, "knowledge/areas") {
 			t.Fatalf("prefixed List returned out-of-subtree entry %q", e.Path)
 		}
 	}
@@ -498,18 +498,18 @@ func TestBacklinks(t *testing.T) {
 	}
 
 	// target is the note we want backlinks for.
-	mustWrite(t, s, "memory/decisions/target.md", "---\nkind: memory\ntitle: Target\n---\nthe decision\n")
+	mustWrite(t, s, "knowledge/areas/target.md", "---\ntype: note\ntitle: Target\n---\nthe decision\n")
 	// linker references target with a trailing #anchor — the anchor must be
 	// ignored when matching.
-	mustWrite(t, s, "memory/decisions/linker.md", "---\nkind: memory\ntitle: Linker\n---\nsee [the call](/memory/decisions/target.md#why) for context\n")
+	mustWrite(t, s, "knowledge/areas/linker.md", "---\ntype: note\ntitle: Linker\n---\nsee [the call](/knowledge/areas/target.md#why) for context\n")
 	// journal references target with a plain root-absolute link.
-	mustWrite(t, s, "journal/2026-06-13.md", "---\nkind: journal\n---\nfollowed [target](/memory/decisions/target.md) today\n")
+	mustWrite(t, s, "journal/2026-06-13.md", "---\ntype: journal\n---\nfollowed [target](/knowledge/areas/target.md) today\n")
 	// unrelated links elsewhere and must not appear.
-	mustWrite(t, s, "memory/gotchas/unrelated.md", "---\nkind: memory\n---\nlinks [elsewhere](/memory/decisions/other.md) only\n")
+	mustWrite(t, s, "knowledge/resources/unrelated.md", "---\ntype: note\n---\nlinks [elsewhere](/knowledge/areas/other.md) only\n")
 	// self-link: target links to itself and must be excluded from its own backlinks.
-	mustWrite(t, s, "memory/decisions/target.md", "---\nkind: memory\ntitle: Target\n---\nthe decision; see [self](/memory/decisions/target.md)\n")
+	mustWrite(t, s, "knowledge/areas/target.md", "---\ntype: note\ntitle: Target\n---\nthe decision; see [self](/knowledge/areas/target.md)\n")
 
-	got, err := s.Backlinks("/memory/decisions/target.md")
+	got, err := s.Backlinks("/knowledge/areas/target.md")
 	if err != nil {
 		t.Fatalf("Backlinks: %v", err)
 	}
@@ -517,25 +517,25 @@ func TestBacklinks(t *testing.T) {
 	for i, e := range got {
 		gotPaths[i] = e.Path
 	}
-	want := []string{"journal/2026-06-13.md", "memory/decisions/linker.md"} // sorted by path
+	want := []string{"journal/2026-06-13.md", "knowledge/areas/linker.md"} // sorted by path
 	if !reflect.DeepEqual(gotPaths, want) {
 		t.Fatalf("Backlinks paths = %v, want %v", gotPaths, want)
 	}
 	// Metadata (title) should ride along so the UI can render a label.
 	for _, e := range got {
-		if e.Path == "memory/decisions/linker.md" && e.Title != "Linker" {
+		if e.Path == "knowledge/areas/linker.md" && e.Title != "Linker" {
 			t.Fatalf("backlink entry lost metadata: %+v", e)
 		}
 	}
 
 	// Dangling-link discovery: a target that does not exist still surfaces its
 	// linkers, so the UI can show what points at a not-yet-created note.
-	dangling, err := s.Backlinks("/memory/decisions/other.md")
+	dangling, err := s.Backlinks("/knowledge/areas/other.md")
 	if err != nil {
 		t.Fatalf("Backlinks(dangling): %v", err)
 	}
-	if len(dangling) != 1 || dangling[0].Path != "memory/gotchas/unrelated.md" {
-		t.Fatalf("dangling Backlinks = %v, want [memory/gotchas/unrelated.md]", dangling)
+	if len(dangling) != 1 || dangling[0].Path != "knowledge/resources/unrelated.md" {
+		t.Fatalf("dangling Backlinks = %v, want [knowledge/resources/unrelated.md]", dangling)
 	}
 
 	// A note nobody links to has no backlinks.
@@ -556,18 +556,18 @@ func TestBacklinksSkipsOversizedExternalFiles(t *testing.T) {
 	}
 
 	// A normal note that links to the target is a real backlink.
-	mustWrite(t, s, "memory/decisions/linker.md", "---\nkind: memory\n---\nsee [the call](/memory/decisions/target.md) here\n")
+	mustWrite(t, s, "knowledge/areas/linker.md", "---\ntype: note\n---\nsee [the call](/knowledge/areas/target.md) here\n")
 
 	// An oversized file (larger than attn ever writes) is synced in externally,
 	// bypassing Write's MaxFileSize guard. It also links to the target, but
 	// Backlinks must not pull its whole body into memory — so it is skipped.
-	big := append([]byte("---\nkind: memory\n---\nlinks [target](/memory/decisions/target.md)\n"), make([]byte, MaxFileSize+1)...)
-	bigPath := filepath.Join(dir, "memory", "decisions", "oversized.md")
+	big := append([]byte("---\ntype: note\n---\nlinks [target](/knowledge/areas/target.md)\n"), make([]byte, MaxFileSize+1)...)
+	bigPath := filepath.Join(dir, "knowledge", "areas", "oversized.md")
 	if err := os.WriteFile(bigPath, big, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := s.Backlinks("/memory/decisions/target.md")
+	got, err := s.Backlinks("/knowledge/areas/target.md")
 	if err != nil {
 		t.Fatalf("Backlinks: %v", err)
 	}
@@ -575,7 +575,7 @@ func TestBacklinksSkipsOversizedExternalFiles(t *testing.T) {
 	for i, e := range got {
 		gotPaths[i] = e.Path
 	}
-	want := []string{"memory/decisions/linker.md"}
+	want := []string{"knowledge/areas/linker.md"}
 	if !reflect.DeepEqual(gotPaths, want) {
 		t.Fatalf("Backlinks skipped/included the wrong files: got %v, want %v", gotPaths, want)
 	}

--- a/internal/notebook/watcher_test.go
+++ b/internal/notebook/watcher_test.go
@@ -61,16 +61,16 @@ func expectNoChange(t *testing.T, ch chan []string) {
 
 func TestWatcherDetectsExternalWrite(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "memory"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, "knowledge"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	_, changes := newTestWatcher(t, root)
 
-	writeFile(t, filepath.Join(root, "memory", "foo.md"), "# foo\n")
+	writeFile(t, filepath.Join(root, "knowledge", "foo.md"), "# foo\n")
 
 	got := waitChange(t, changes)
-	if !reflect.DeepEqual(got, []string{"memory/foo.md"}) {
-		t.Fatalf("change = %v, want [memory/foo.md]", got)
+	if !reflect.DeepEqual(got, []string{"knowledge/foo.md"}) {
+		t.Fatalf("change = %v, want [knowledge/foo.md]", got)
 	}
 }
 
@@ -164,7 +164,7 @@ func TestWatcherCoalescesBurst(t *testing.T) {
 
 func TestWatcherIgnoresDotDirsTempAndNonMarkdown(t *testing.T) {
 	root := t.TempDir()
-	for _, dir := range []string{".attn", "memory"} {
+	for _, dir := range []string{".attn", "knowledge"} {
 		if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -177,7 +177,7 @@ func TestWatcherIgnoresDotDirsTempAndNonMarkdown(t *testing.T) {
 	writeFile(t, filepath.Join(root, ".attn", "locks.md"), "x")
 	writeFile(t, filepath.Join(root, "notes.txt"), "x")
 	writeFile(t, filepath.Join(root, ".hidden.md"), "x")
-	writeFile(t, filepath.Join(root, "memory", "foo.md.tmp.123.456"), "x")
+	writeFile(t, filepath.Join(root, "knowledge", "foo.md.tmp.123.456"), "x")
 
 	expectNoChange(t, changes)
 }
@@ -228,11 +228,11 @@ func TestWatcherWatchesNewSubdir(t *testing.T) {
 
 	// A directory created after the watcher started must be watched so a note
 	// written inside it is still observed.
-	writeFile(t, filepath.Join(root, "memory", "decisions", "x.md"), "# x\n")
+	writeFile(t, filepath.Join(root, "knowledge", "areas", "x.md"), "# x\n")
 
 	got := waitChange(t, changes)
-	if !reflect.DeepEqual(got, []string{"memory/decisions/x.md"}) {
-		t.Fatalf("change = %v, want [memory/decisions/x.md]", got)
+	if !reflect.DeepEqual(got, []string{"knowledge/areas/x.md"}) {
+		t.Fatalf("change = %v, want [knowledge/areas/x.md]", got)
 	}
 }
 


### PR DESCRIPTION
Reframes the notebook library from the fixed `memory/{decisions,gotchas,domain}` model to a **PARA** knowledge base (`projects/areas/resources/archive`, each with its own `index.md`) on a directory axis, plus an open-string **OKF `type`** frontmatter axis. The store is a permissive writer (no `type` validation). Adds the **raw tier** (machine-input floor: per-session summaries + context snapshots) and the narrate-cron state anchor. The read layer stays backward-compatible (`type` falls back to `kind`).
---
**Final-state re-split of the knowledge-base / keeper epic** (supersedes #335–#343, #345). The original stack was split by chronology and carried mid-epic churn; this one is sliced by subsystem from the net diff, so each PR is a clean final-state slice.

Stack: `1 task-engine` · `2 notebook-kb` · `3 agent-native` · `4 store-keeper` · `5 keeper-compaction` · `6 keeper-narration` · `7 keeper-cron` · **`8 integration`** · `9 frontend` · `10 cli/docs`

This is PR **2/10** — base `kb/01-task-engine`. Review per-diff. By design the refactor only activates in #8 (where the keeper is wired and the janitor/dreaming are deleted), so branches 2–9 are not individually `go build`-clean; the merged tip (#10) is build + vet + test green.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. `feat/chifplace`
2. #347
3. **#348** 👈 current
4. #349
5. #350
6. #351
7. #352
8. #353
9. #354
10. #355
11. #356
<!-- stack:links:end -->