### PR TITLE
feat(agent): native-tools headless task mode

### DIFF
--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -83,13 +82,13 @@ func (c *Claude) BuildCommand(opts SpawnOpts) *exec.Cmd {
 	}
 	// A chief-of-staff launch (NotebookRoot set) gets Notebook guidance instead
 	// of the workspace-context checkout guidance. Every other workspace agent gets
-	// its workspace-context guidance plus the universal journaling directive, so
-	// the work-journal captures notable work across the whole workspace — not only
-	// the chief and delegated dispatches.
+	// its workspace-context guidance. Non-chief agents are NOT nudged to journal:
+	// the keeper narrates each workspace's own work into the journal, and the chief
+	// journals the cross-workspace layer.
 	if guidance := hooks.NotebookGuidance(opts.NotebookRoot); guidance != "" {
 		args = append(args, "--append-system-prompt", guidance)
 	} else if guidance := hooks.WorkspaceContextGuidance(opts.WorkspaceContextPath); guidance != "" {
-		args = append(args, "--append-system-prompt", guidance+"\n\n"+hooks.JournalingDirective())
+		args = append(args, "--append-system-prompt", guidance)
 	}
 
 	if opts.ResumeSessionID != "" {
@@ -122,41 +121,37 @@ func (c *Claude) BuildEnv(opts SpawnOpts) []string {
 	return env
 }
 
+// claudeNativeDefaultTools is the file-tool allow-list used when a native-tools
+// headless task does not specify AllowedTools. Bash is intentionally omitted:
+// the keeper's compaction duty only needs to read/write/edit files, and Grep/Glob cover
+// navigation, so the surface stays minimal.
+var claudeNativeDefaultTools = []string{"Read", "Write", "Edit", "Grep", "Glob"}
+
 func (c *Claude) RunHeadlessTask(ctx context.Context, request HeadlessTaskRequest) (HeadlessTaskResult, error) {
-	serverName := strings.TrimSpace(request.MCPServerName)
-	if serverName == "" {
-		serverName = "attn_context"
+	return runHeadlessCommand(ctx, request.Executable, claudeHeadlessArgs(request), request.WorkDir, "claude")
+}
+
+// claudeHeadlessArgs builds the native-tools arg set: the agent gets its own
+// file tools and writes into cmd.Dir (the scratch WorkDir). Only the allow-list
+// and permission mode let it read/write its cwd unprompted.
+func claudeHeadlessArgs(request HeadlessTaskRequest) []string {
+	tools := request.AllowedTools
+	if len(tools) == 0 {
+		tools = claudeNativeDefaultTools
 	}
-	config, err := json.Marshal(map[string]any{
-		"mcpServers": map[string]any{
-			serverName: map[string]any{
-				"type":    "stdio",
-				"command": request.MCPServerCommand,
-				"args":    request.MCPServerArgs,
-			},
-		},
-	})
-	if err != nil {
-		return HeadlessTaskResult{}, fmt.Errorf("encode MCP config: %w", err)
-	}
-	toolPrefix := "mcp__" + serverName + "__"
-	tools := toolPrefix + "read_context," + toolPrefix + "replace_context"
 	args := []string{"--print"}
 	args = append(args, claudeHeadlessIsolationArgs()...)
 	args = append(args,
 		"--model", strings.TrimSpace(request.Model),
 		"--no-session-persistence",
-		"--strict-mcp-config",
-		"--mcp-config", string(config),
 		"--disable-slash-commands",
 		"--no-chrome",
-		"--tools", tools,
-		"--allowedTools", tools,
+		"--allowedTools", strings.Join(tools, ","),
 		"--permission-mode", "dontAsk",
 		"--output-format", "json",
 		request.Prompt,
 	)
-	return runHeadlessCommand(ctx, request.Executable, args, request.WorkDir, "claude")
+	return args
 }
 
 func (c *Claude) HeadlessTaskAvailability() (bool, string) {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -2,9 +2,7 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
-	"strconv"
 	"strings"
 	"time"
 
@@ -107,23 +105,14 @@ func (c *Codex) PrepareLaunch(opts SpawnOpts) error {
 }
 
 func (c *Codex) RunHeadlessTask(ctx context.Context, request HeadlessTaskRequest) (HeadlessTaskResult, error) {
-	serverName := strings.TrimSpace(request.MCPServerName)
-	if serverName == "" {
-		serverName = "attn_context"
-	}
-	args := []string{
-		"exec",
-		"--json",
-		"--ephemeral",
-		"--ignore-user-config",
-		"--ignore-rules",
-		"--strict-config",
-		"--skip-git-repo-check",
-		"--sandbox", "read-only",
-		"-m", strings.TrimSpace(request.Model),
-		"-c", `approval_policy="never"`,
-		"-c", "features.shell_tool=false",
-		"-c", "features.unified_exec=false",
+	return runHeadlessCommand(ctx, request.Executable, codexHeadlessArgs(request), request.WorkDir, "codex")
+}
+
+// codexFeatureLocks are the non-file feature locks. They keep the agent surface
+// minimal (no apps/hooks/plugins/browser/etc.) and are independent of the
+// file/exec tooling enabled by the workspace-write sandbox.
+func codexFeatureLocks() []string {
+	return []string{
 		"-c", "features.apps=false",
 		"-c", "features.hooks=false",
 		"-c", "features.plugins=false",
@@ -138,22 +127,43 @@ func (c *Codex) RunHeadlessTask(ctx context.Context, request HeadlessTaskRequest
 		"-c", "features.standalone_web_search=false",
 		"-c", "features.tool_suggest=false",
 		"-c", "features.workspace_dependencies=false",
-		"-c", fmt.Sprintf("mcp_servers.%s.command=%s", serverName, strconv.Quote(request.MCPServerCommand)),
-		"-c", fmt.Sprintf("mcp_servers.%s.args=%s", serverName, tomlStringArray(request.MCPServerArgs)),
-		"-c", fmt.Sprintf("mcp_servers.%s.required=true", serverName),
-		"-c", fmt.Sprintf("mcp_servers.%s.enabled_tools=%s", serverName, tomlStringArray([]string{"read_context", "replace_context"})),
-		"-c", fmt.Sprintf(`mcp_servers.%s.default_tools_approval_mode="approve"`, serverName),
-		request.Prompt,
 	}
-	return runHeadlessCommand(ctx, request.Executable, args, request.WorkDir, "codex")
 }
 
-func tomlStringArray(values []string) string {
-	quoted := make([]string, 0, len(values))
-	for _, value := range values {
-		quoted = append(quoted, strconv.Quote(value))
+// codexHeadlessArgs builds the native-tools arg set: a workspace-write sandbox
+// makes cwd (the scratch WorkDir via cmd.Dir) writable, and Codex's default
+// file/exec tooling is active. approval_policy="never" keeps writes autonomous
+// and the run non-interactive.
+func codexHeadlessArgs(request HeadlessTaskRequest) []string {
+	args := []string{
+		"exec",
+		"--json",
+		"--ephemeral",
+		"--ignore-user-config",
+		"--ignore-rules",
+		"--strict-config",
+		"--skip-git-repo-check",
+		"--sandbox", "workspace-write",
+		"-m", strings.TrimSpace(request.Model),
+		"-c", `approval_policy="never"`,
 	}
-	return "[" + strings.Join(quoted, ",") + "]"
+	// Widen the workspace-write sandbox's writable set beyond the scratch WorkDir
+	// for tasks that must write outside cwd (e.g. the notebook narrate pass writing the
+	// curated journal under the notebook root). `--add-dir` is the codex exec flag
+	// for "additional directories that should be writable alongside the primary
+	// workspace"; reads stay unrestricted under workspace-write, so this is
+	// write-only widening. Empty (the keeper's compaction duty) appends nothing,
+	// preserving the scratch-tempdir-only behavior.
+	for _, root := range request.ExtraWritableRoots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		args = append(args, "--add-dir", root)
+	}
+	args = append(args, codexFeatureLocks()...)
+	args = append(args, request.Prompt)
+	return args
 }
 
 // --- ConfigOverrideProvider ---

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -263,17 +263,40 @@ type ConfigOverrideProvider interface {
 	GenerateConfigOverrides(opts SpawnOpts) []string
 }
 
-// HeadlessTaskRequest describes a daemon-owned non-interactive task. The
-// provider must expose only the supplied MCP server and must not create an
-// interactive attn session.
+// HeadlessTaskRequest describes a daemon-owned non-interactive task. The task
+// must not create an interactive attn session. The agent runs in native-tools
+// mode: it gets its OWN file tools and a writable working dir (WorkDir). The
+// daemon writes inputs into WorkDir and reads the agent's output file back;
+// validation + commit stay daemon-owned.
 type HeadlessTaskRequest struct {
-	Executable       string
-	Model            string
-	Prompt           string
-	WorkDir          string
-	MCPServerName    string
-	MCPServerCommand string
-	MCPServerArgs    []string
+	Executable string
+	Model      string
+	Prompt     string
+	WorkDir    string
+
+	// AllowedTools optionally overrides the default native tool set
+	// (Claude: Read,Write,Edit,Grep,Glob). Empty => provider default. (Codex
+	// ignores this field; its native tooling comes from the workspace-write
+	// sandbox defaults, not a CLI list.)
+	AllowedTools []string
+
+	// ExtraWritableRoots optionally widens the set of directories the agent may
+	// WRITE to, beyond the scratch WorkDir. The notebook narration tasks use this
+	// so a headless agent can write the curated journal / raw tier under the
+	// notebook root (which lives outside the scratch tempdir).
+	//
+	// Provider behavior:
+	//   - Claude: IGNORED. Claude headless runs with --permission-mode dontAsk,
+	//     which is NOT filesystem-sandboxed — it can already write anywhere the OS
+	//     user can, given absolute paths. No widening is needed or applied.
+	//   - Codex: each root is passed as `--add-dir <root>` so the
+	//     workspace-write sandbox (which otherwise confines writes to the cwd
+	//     WorkDir) also permits writes under these roots. Reads are unrestricted
+	//     under workspace-write, so transcript dirs need no widening.
+	//
+	// Empty (the keeper's compaction case) leaves both providers' existing
+	// scratch-only behavior unchanged.
+	ExtraWritableRoots []string
 }
 
 type HeadlessTaskResult struct {

--- a/internal/agent/headless.go
+++ b/internal/agent/headless.go
@@ -128,7 +128,7 @@ func classifyHeadlessFailure(output string) string {
 	case strings.Contains(lower, "mcp"),
 		strings.Contains(lower, "tool server"),
 		strings.Contains(lower, "server failed"):
-		return "headless agent janitor tools failed"
+		return "headless agent keeper tools failed"
 	default:
 		return "headless agent process failed"
 	}

--- a/internal/agent/headless_native_test.go
+++ b/internal/agent/headless_native_test.go
@@ -1,0 +1,117 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func joinArgs(args []string) string {
+	return strings.Join(args, "\x00")
+}
+
+func assertContainsAll(t *testing.T, label string, args []string, wants ...string) {
+	t.Helper()
+	joined := joinArgs(args)
+	for _, want := range wants {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("%s missing %q:\n%v", label, want, args)
+		}
+	}
+}
+
+func assertContainsNone(t *testing.T, label string, args []string, forbidden ...string) {
+	t.Helper()
+	joined := joinArgs(args)
+	for _, bad := range forbidden {
+		if strings.Contains(joined, bad) {
+			t.Fatalf("%s unexpectedly contained %q:\n%v", label, bad, args)
+		}
+	}
+}
+
+func TestClaudeHeadlessArgsUsesFileToolsAndDropsMCPPin(t *testing.T) {
+	for _, name := range []string{
+		"ANTHROPIC_API_KEY",
+		"CLAUDE_CODE_USE_BEDROCK",
+		"CLAUDE_CODE_USE_VERTEX",
+		"CLAUDE_CODE_USE_FOUNDRY",
+	} {
+		t.Setenv(name, "")
+	}
+	args := claudeHeadlessArgs(HeadlessTaskRequest{
+		Model:   "claude-test",
+		Prompt:  "compact the context file",
+		WorkDir: "/tmp/scratch",
+	})
+
+	// Native file tools + unprompted-write permission.
+	assertContainsAll(t, "Claude native args", args,
+		"--print",
+		"--setting-sources",
+		"--no-session-persistence",
+		"--disable-slash-commands",
+		"--no-chrome",
+		"--allowedTools",
+		"Read,Write,Edit,Grep,Glob",
+		"--permission-mode",
+		"dontAsk",
+		"--output-format",
+		"json",
+		"claude-test",
+		"compact the context file",
+	)
+	// The MCP keeper compaction pin must be gone.
+	assertContainsNone(t, "Claude native args", args,
+		"--strict-mcp-config",
+		"--mcp-config",
+		"--tools",
+		"mcp__attn_context__read_context,mcp__attn_context__replace_context",
+	)
+}
+
+func TestClaudeHeadlessArgsHonorsAllowedToolsOverride(t *testing.T) {
+	args := claudeHeadlessArgs(HeadlessTaskRequest{
+		Model:        "claude-test",
+		Prompt:       "compact",
+		AllowedTools: []string{"Read", "Write"},
+	})
+	assertContainsAll(t, "Claude native override args", args, "--allowedTools", "Read,Write")
+	assertContainsNone(t, "Claude native override args", args, "Read,Write,Edit,Grep,Glob")
+}
+
+func TestCodexHeadlessArgsUsesWorkspaceWriteAndDropsMCPPin(t *testing.T) {
+	args := codexHeadlessArgs(HeadlessTaskRequest{
+		Model:   "gpt-test",
+		Prompt:  "compact the context file",
+		WorkDir: "/tmp/scratch",
+	})
+
+	assertContainsAll(t, "Codex native args", args,
+		"exec",
+		"--json",
+		"--ephemeral",
+		"--ignore-user-config",
+		"--ignore-rules",
+		"--strict-config",
+		"--skip-git-repo-check",
+		"--sandbox",
+		"workspace-write",
+		`approval_policy="never"`,
+		// non-file feature locks stay.
+		"features.apps=false",
+		"features.browser_use=false",
+		"features.standalone_web_search=false",
+		"gpt-test",
+		"compact the context file",
+	)
+	// Read-only sandbox, file/exec disables, and the MCP pin must all be gone.
+	assertContainsNone(t, "Codex native args", args,
+		"read-only",
+		"features.shell_tool=false",
+		"features.unified_exec=false",
+		"mcp_servers.attn_context.command",
+		"mcp_servers.attn_context.required=true",
+		`mcp_servers.attn_context.enabled_tools=["read_context","replace_context"]`,
+		`mcp_servers.attn_context.default_tools_approval_mode="approve"`,
+	)
+}

--- a/internal/agent/headless_test.go
+++ b/internal/agent/headless_test.go
@@ -27,13 +27,10 @@ func shellSingleQuote(value string) string {
 func TestCodexRunHeadlessTaskScopesToolsAndConfiguration(t *testing.T) {
 	executable, logPath := writeHeadlessArgsRecorder(t)
 	_, err := (&Codex{}).RunHeadlessTask(context.Background(), HeadlessTaskRequest{
-		Executable:       executable,
-		Model:            "gpt-test",
-		Prompt:           "compact",
-		WorkDir:          t.TempDir(),
-		MCPServerName:    "attn_context",
-		MCPServerCommand: "/tmp/attn",
-		MCPServerArgs:    []string{"_workspace-context-janitor-mcp", "--source-file", "/tmp/source"},
+		Executable: executable,
+		Model:      "gpt-test",
+		Prompt:     "compact",
+		WorkDir:    t.TempDir(),
 	})
 	if err != nil {
 		t.Fatalf("RunHeadlessTask error: %v", err)
@@ -49,10 +46,9 @@ func TestCodexRunHeadlessTaskScopesToolsAndConfiguration(t *testing.T) {
 		"--ignore-user-config",
 		"--ignore-rules",
 		"--strict-config",
-		"read-only",
+		"--skip-git-repo-check",
+		"workspace-write",
 		`approval_policy="never"`,
-		"features.shell_tool=false",
-		"features.unified_exec=false",
 		"features.apps=false",
 		"features.hooks=false",
 		"features.plugins=false",
@@ -60,15 +56,25 @@ func TestCodexRunHeadlessTaskScopesToolsAndConfiguration(t *testing.T) {
 		"features.memories=false",
 		"features.multi_agent=false",
 		"features.standalone_web_search=false",
-		"mcp_servers.attn_context.command=\"/tmp/attn\"",
-		"mcp_servers.attn_context.required=true",
-		`mcp_servers.attn_context.enabled_tools=["read_context","replace_context"]`,
-		`mcp_servers.attn_context.default_tools_approval_mode="approve"`,
 		"gpt-test",
 		"compact",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("Codex args missing %q:\n%s", want, got)
+		}
+	}
+	// The constrained-MCP read-only sandbox and read_context/replace_context pin
+	// must be gone: native mode gives Codex its own file tools.
+	for _, forbidden := range []string{
+		"read-only",
+		"features.shell_tool=false",
+		"features.unified_exec=false",
+		"mcp_servers.attn_context",
+		"read_context",
+		"replace_context",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("Codex args unexpectedly contained %q:\n%s", forbidden, got)
 		}
 	}
 }
@@ -84,13 +90,10 @@ func TestClaudeRunHeadlessTaskExcludesNonManagedSettingsWithoutExplicitAuthentic
 	}
 	executable, logPath := writeHeadlessArgsRecorder(t)
 	_, err := (&Claude{}).RunHeadlessTask(context.Background(), HeadlessTaskRequest{
-		Executable:       executable,
-		Model:            "claude-test",
-		Prompt:           "compact",
-		WorkDir:          t.TempDir(),
-		MCPServerName:    "attn_context",
-		MCPServerCommand: "/tmp/attn",
-		MCPServerArgs:    []string{"_workspace-context-janitor-mcp", "--candidate-file", "/tmp/candidate"},
+		Executable: executable,
+		Model:      "claude-test",
+		Prompt:     "compact",
+		WorkDir:    t.TempDir(),
 	})
 	if err != nil {
 		t.Fatalf("RunHeadlessTask error: %v", err)
@@ -104,13 +107,12 @@ func TestClaudeRunHeadlessTaskExcludesNonManagedSettingsWithoutExplicitAuthentic
 		"--print",
 		"--setting-sources",
 		"--no-session-persistence",
-		"--strict-mcp-config",
 		"--disable-slash-commands",
 		"--no-chrome",
-		"--tools",
-		"mcp__attn_context__read_context,mcp__attn_context__replace_context",
 		"--allowedTools",
-		"mcp__attn_context__read_context,mcp__attn_context__replace_context",
+		"Read,Write,Edit,Grep,Glob",
+		"--permission-mode",
+		"dontAsk",
 		"claude-test",
 		"compact",
 	} {
@@ -121,11 +123,17 @@ func TestClaudeRunHeadlessTaskExcludesNonManagedSettingsWithoutExplicitAuthentic
 	if !strings.Contains(got, "--setting-sources\n\n--model") {
 		t.Fatalf("Claude args did not pass an empty setting source list:\n%s", got)
 	}
-	if strings.Contains(got, "--safe-mode") {
-		t.Fatalf("Claude args unexpectedly contained --safe-mode, which disables explicit MCP servers:\n%s", got)
-	}
-	if strings.Contains(got, "--bare") {
-		t.Fatalf("Claude managed-auth args unexpectedly contained --bare:\n%s", got)
+	// The constrained-MCP pin must be gone in native mode.
+	for _, forbidden := range []string{
+		"--strict-mcp-config",
+		"--mcp-config",
+		"--tools",
+		"mcp__attn_context__read_context,mcp__attn_context__replace_context",
+		"--bare",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("Claude managed-auth args unexpectedly contained %q:\n%s", forbidden, got)
+		}
 	}
 }
 
@@ -133,13 +141,10 @@ func TestClaudeRunHeadlessTaskUsesBareModeWithExplicitAuthentication(t *testing.
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	executable, logPath := writeHeadlessArgsRecorder(t)
 	_, err := (&Claude{}).RunHeadlessTask(context.Background(), HeadlessTaskRequest{
-		Executable:       executable,
-		Model:            "claude-test",
-		Prompt:           "compact",
-		WorkDir:          t.TempDir(),
-		MCPServerName:    "attn_context",
-		MCPServerCommand: "/tmp/attn",
-		MCPServerArgs:    []string{"_workspace-context-janitor-mcp"},
+		Executable: executable,
+		Model:      "claude-test",
+		Prompt:     "compact",
+		WorkDir:    t.TempDir(),
 	})
 	if err != nil {
 		t.Fatalf("RunHeadlessTask error: %v", err)
@@ -236,5 +241,76 @@ func TestClaudeHeadlessTaskAvailabilitySupportsManagedAuthentication(t *testing.
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	if got := claudeHeadlessIsolationArgs(); len(got) != 1 || got[0] != "--bare" {
 		t.Fatalf("isolation args = %#v, want --bare", got)
+	}
+}
+
+// TestCodexHeadlessArgsWidensWritableRootsAdditively proves the notebook narrate pass's
+// ExtraWritableRoots map to `--add-dir <root>` entries (so the workspace-write
+// sandbox also permits writes under the notebook root), placed AFTER the base
+// sandbox args and BEFORE the prompt, without disturbing the feature locks. The
+// keeper compaction duty's empty ExtraWritableRoots must add no --add-dir (regression guard).
+func TestCodexHeadlessArgsWidensWritableRootsAdditively(t *testing.T) {
+	t.Run("narration widens", func(t *testing.T) {
+		args := codexHeadlessArgs(HeadlessTaskRequest{
+			Model:              "gpt-test",
+			Prompt:             "narrate",
+			ExtraWritableRoots: []string{"/notebook/root", "  ", "/notebook/raw"},
+		})
+		joined := strings.Join(args, "\x00")
+		if !strings.Contains(joined, "--add-dir\x00/notebook/root") {
+			t.Fatalf("missing --add-dir for notebook root:\n%v", args)
+		}
+		if !strings.Contains(joined, "--add-dir\x00/notebook/raw") {
+			t.Fatalf("missing --add-dir for raw root:\n%v", args)
+		}
+		// The blank entry is skipped.
+		if strings.Count(joined, "--add-dir") != 2 {
+			t.Fatalf("expected exactly 2 --add-dir entries, got:\n%v", args)
+		}
+		// Still the base sandbox + feature locks + prompt.
+		for _, want := range []string{"workspace-write", "features.apps=false", "narrate"} {
+			if !strings.Contains(joined, want) {
+				t.Fatalf("missing base arg %q:\n%v", want, args)
+			}
+		}
+		// --add-dir must precede the feature locks and the prompt.
+		addDirIdx := strings.Index(joined, "--add-dir")
+		lockIdx := strings.Index(joined, "features.apps=false")
+		promptIdx := strings.LastIndex(joined, "narrate")
+		if !(addDirIdx < lockIdx && lockIdx < promptIdx) {
+			t.Fatalf("arg ordering wrong (add-dir=%d lock=%d prompt=%d):\n%v", addDirIdx, lockIdx, promptIdx, args)
+		}
+	})
+
+	t.Run("keeper compaction adds nothing", func(t *testing.T) {
+		args := codexHeadlessArgs(HeadlessTaskRequest{Model: "gpt-test", Prompt: "compact"})
+		if strings.Contains(strings.Join(args, "\x00"), "--add-dir") {
+			t.Fatalf("keeper compaction (no ExtraWritableRoots) unexpectedly added --add-dir:\n%v", args)
+		}
+	})
+}
+
+// TestClaudeHeadlessArgsIgnoreWritableRoots proves Claude never gains an --add-dir
+// (or any sandbox-widening flag) from ExtraWritableRoots: dontAsk is not
+// filesystem-sandboxed, so the field is a no-op for Claude. The allow-list and the
+// model/prompt are unchanged whether or not the roots are present.
+func TestClaudeHeadlessArgsIgnoreWritableRoots(t *testing.T) {
+	withRoots := claudeHeadlessArgs(HeadlessTaskRequest{
+		Model:              "claude-test",
+		Prompt:             "narrate",
+		AllowedTools:       []string{"Read", "Write", "Edit", "Grep", "Glob", "Bash"},
+		ExtraWritableRoots: []string{"/notebook/root"},
+	})
+	joined := strings.Join(withRoots, "\x00")
+	if strings.Contains(joined, "--add-dir") || strings.Contains(joined, "/notebook/root") {
+		t.Fatalf("Claude args leaked ExtraWritableRoots:\n%v", withRoots)
+	}
+	if !strings.Contains(joined, "Read,Write,Edit,Grep,Glob,Bash") {
+		t.Fatalf("Claude args dropped the explicit Bash-inclusive allow-list:\n%v", withRoots)
+	}
+	for _, want := range []string{"--permission-mode", "dontAsk", "claude-test", "narrate"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("Claude args missing %q:\n%v", want, withRoots)
+		}
 	}
 }

--- a/internal/agent/yolo_test.go
+++ b/internal/agent/yolo_test.go
@@ -77,16 +77,15 @@ func TestClaudeBuildCommand_AppendsWorkspaceContextSystemPrompt(t *testing.T) {
 	if flagIndex == -1 || flagIndex+1 >= len(cmd.Args) {
 		t.Fatalf("args = %#v, want --append-system-prompt with guidance", cmd.Args)
 	}
-	// A non-chief workspace agent gets its workspace-context guidance AND the
-	// universal journaling directive composed into one system-prompt value. Pin the
-	// exact composition (not just co-presence) so a dropped separator or a directive
-	// injected as a separate arg is caught.
-	want := hooks.WorkspaceContextGuidance("/tmp/context.md") + "\n\n" + hooks.JournalingDirective()
+	// A non-chief workspace agent gets ONLY its workspace-context guidance as the
+	// system-prompt value — no journaling directive is appended. Pin the exact value
+	// so a re-introduced directive (composed or as a separate arg) is caught.
+	want := hooks.WorkspaceContextGuidance("/tmp/context.md")
 	if cmd.Args[flagIndex+1] != want {
-		t.Fatalf("system prompt = %q, want exact guidance+directive composition", cmd.Args[flagIndex+1])
+		t.Fatalf("system prompt = %q, want exactly the workspace-context guidance", cmd.Args[flagIndex+1])
 	}
 	// The same launch sets the suppression marker, so the SessionStart fallback does
-	// not re-emit (and duplicate) the directive on resume/compact.
+	// not re-emit the guidance on resume/compact.
 	if !slices.Contains((&Claude{}).BuildEnv(opts), "ATTN_WORKSPACE_CONTEXT_GUIDANCE=append_system_prompt") {
 		t.Fatal("non-chief launch must set ATTN_WORKSPACE_CONTEXT_GUIDANCE so the SessionStart fallback is suppressed")
 	}
@@ -162,9 +161,9 @@ func TestCodexConfigOverrides_NotebookGuidanceTakesPrecedence(t *testing.T) {
 	}
 }
 
-// A non-chief Codex launch carries its workspace-context guidance plus the
-// universal journaling directive in a SINGLE developer_instructions override.
-func TestCodexConfigOverrides_NonChiefIncludesJournalingDirective(t *testing.T) {
+// A non-chief Codex launch carries ONLY its workspace-context guidance in a
+// single developer_instructions override — no journaling directive is appended.
+func TestCodexConfigOverrides_NonChiefOmitsJournalingDirective(t *testing.T) {
 	overrides := (&Codex{}).GenerateConfigOverrides(SpawnOpts{
 		SessionID:            "sess-1",
 		WorkspaceContextPath: "/tmp/context.md",
@@ -175,16 +174,16 @@ func TestCodexConfigOverrides_NonChiefIncludesJournalingDirective(t *testing.T) 
 			devInstr = append(devInstr, o)
 		}
 	}
-	// Exactly one developer_instructions entry — guidance and directive must share
-	// it, not arrive as a second entry that the parser would let the first clobber.
+	// Exactly one developer_instructions entry, carrying the workspace-context guidance.
 	if len(devInstr) != 1 {
 		t.Fatalf("want exactly one developer_instructions override, got %d: %q", len(devInstr), overrides)
 	}
 	if !strings.Contains(devInstr[0], "/tmp/context.md") {
 		t.Fatalf("developer_instructions should carry workspace-context guidance: %q", devInstr[0])
 	}
-	if !strings.Contains(devInstr[0], "notable moments, not routine steps") {
-		t.Fatalf("developer_instructions should append the journaling directive: %q", devInstr[0])
+	// The journaling directive must NOT be appended for non-chief agents.
+	if strings.Contains(devInstr[0], "notable moments, not routine steps") {
+		t.Fatalf("non-chief developer_instructions must not append the journaling directive: %q", devInstr[0])
 	}
 }
 


### PR DESCRIPTION
`RunHeadlessTask` hands a headless Claude/Codex agent its **own native file tools** in a writable scratch dir (Claude `--allowedTools`+`dontAsk`; Codex `--sandbox workspace-write`+`--add-dir`), replacing the constrained `read_context`/`replace_context` MCP path. Adds `ExtraWritableRoots` for the narrator's journal writes. (The MCP toolserver itself is deleted in #10 with its only caller, the CLI.)
---
**Final-state re-split of the knowledge-base / keeper epic** (supersedes #335–#343, #345). The original stack was split by chronology and carried mid-epic churn; this one is sliced by subsystem from the net diff, so each PR is a clean final-state slice.

Stack: `1 task-engine` · `2 notebook-kb` · `3 agent-native` · `4 store-keeper` · `5 keeper-compaction` · `6 keeper-narration` · `7 keeper-cron` · **`8 integration`** · `9 frontend` · `10 cli/docs`

This is PR **3/10** — base `kb/02-notebook-knowledge-base`. Review per-diff. By design the refactor only activates in #8 (where the keeper is wired and the janitor/dreaming are deleted), so branches 2–9 are not individually `go build`-clean; the merged tip (#10) is build + vet + test green.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. `feat/chifplace`
2. #347
3. #348
4. **#349** 👈 current
5. #350
6. #351
7. #352
8. #353
9. #354
10. #355
11. #356
<!-- stack:links:end -->