### PR TITLE
refactor(store): keeper rename + migration 51

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -396,6 +396,10 @@ var migrations = []migration{
 		);
 	`},
 	{48, "drop label from recent_locations", "ALTER TABLE recent_locations DROP COLUMN label"},
+	// Versions 49 and 50 are BURNED on real prod/dev DBs (pre-release builds recorded
+	// them with no matching source migration), so the keeper rename lands at 51 — the
+	// first version above every observed MAX(version). See applyMigration51.
+	{51, "rename workspace context janitor backups to keeper compact backups", ""},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -544,6 +548,11 @@ func migrateDB(db *sql.DB) error {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
+		} else if m.version == 51 {
+			if err := applyMigration51(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
 		} else {
 			if _, err := tx.Exec(m.sql); err != nil {
 				tx.Rollback()
@@ -661,6 +670,57 @@ func applyMigration48(tx *sql.Tx) error {
 	}
 	_, err = tx.Exec("ALTER TABLE recent_locations DROP COLUMN label")
 	return err
+}
+
+// applyMigration51 retires the last "janitor" identifiers from the live schema:
+// it renames the keeper's compaction-backup table and realigns the persisted
+// context-updater sentinel. Guarded so it is idempotent and safe on every DB
+// shape, including a migration rewind that re-runs migration 47's
+// CREATE-IF-NOT-EXISTS after the rename already happened:
+//   - only the legacy table exists (normal upgrade): rename it, preserving data.
+//   - both exist (47 recreated an empty legacy table beside the authoritative
+//     keeper-named one): drop the spurious legacy duplicate.
+//   - only the keeper-named table exists (already migrated): no-op.
+//
+// The UPDATE rewrites historical rows the keeper stamped before this rename.
+func applyMigration51(tx *sql.Tx) error {
+	oldExists, err := tableExists(tx, "workspace_context_janitor_backups")
+	if err != nil {
+		return err
+	}
+	newExists, err := tableExists(tx, "workspace_keeper_compact_backups")
+	if err != nil {
+		return err
+	}
+	switch {
+	case oldExists && !newExists:
+		if _, err := tx.Exec(`ALTER TABLE workspace_context_janitor_backups RENAME TO workspace_keeper_compact_backups`); err != nil {
+			return err
+		}
+	case oldExists && newExists:
+		if _, err := tx.Exec(`DROP TABLE workspace_context_janitor_backups`); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(
+		`UPDATE workspace_contexts SET updated_by_session_id = 'attn-keeper' WHERE updated_by_session_id = 'attn-janitor'`,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+// tableExists reports whether a table of the given name exists in the schema.
+func tableExists(tx *sql.Tx, name string) (bool, error) {
+	var got string
+	err := tx.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, name).Scan(&got)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func applyMigration28(tx *sql.Tx) error {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -4,7 +4,22 @@ import (
 	"database/sql"
 	"path/filepath"
 	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
 )
+
+// latestSchemaVersion is the highest version in the migrations slice. It is NOT
+// the same as len(migrations): versions 49 and 50 are burned (see sqlite.go), so
+// there is a gap and the max version exceeds the migration count.
+func latestSchemaVersion() int {
+	max := 0
+	for _, m := range migrations {
+		if m.version > max {
+			max = m.version
+		}
+	}
+	return max
+}
 
 func TestOpenDB_CreatesSchema(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -17,7 +32,7 @@ func TestOpenDB_CreatesSchema(t *testing.T) {
 	defer db.Close()
 
 	// Verify tables exist by querying them
-	tables := []string{"sessions", "prs", "repos", "review_loop_runs", "review_loop_iterations", "review_loop_interactions", "workspace_contexts", "workspace_context_janitor_backups", "profile_roles", "chief_of_staff_dispatches", "chief_of_staff_dispatch_messages"}
+	tables := []string{"sessions", "prs", "repos", "review_loop_runs", "review_loop_iterations", "review_loop_interactions", "workspace_contexts", "workspace_keeper_compact_backups", "profile_roles", "chief_of_staff_dispatches", "chief_of_staff_dispatch_messages"}
 	for _, table := range tables {
 		var count int
 		err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&count)
@@ -85,8 +100,8 @@ func TestMigrations_AppliedOnNewDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSchemaVersion() error = %v", err)
 	}
-	if version != len(migrations) {
-		t.Errorf("schema version = %d, want %d", version, len(migrations))
+	if version != latestSchemaVersion() {
+		t.Errorf("schema version = %d, want %d", version, latestSchemaVersion())
 	}
 
 	// Verify all migrations recorded
@@ -401,8 +416,8 @@ func TestMigration20_IdempotentWhenHostColumnAlreadyExists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSchemaVersion() error = %v", err)
 	}
-	if version != len(migrations) {
-		t.Fatalf("schema version = %d, want %d", version, len(migrations))
+	if version != latestSchemaVersion() {
+		t.Fatalf("schema version = %d, want %d", version, latestSchemaVersion())
 	}
 
 	// Unique index from migration 20 should exist.
@@ -463,8 +478,8 @@ func TestMigration21_IdempotentWhenAgentColumnAlreadyExists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSchemaVersion() error = %v", err)
 	}
-	if version != len(migrations) {
-		t.Fatalf("schema version = %d, want %d", version, len(migrations))
+	if version != latestSchemaVersion() {
+		t.Fatalf("schema version = %d, want %d", version, latestSchemaVersion())
 	}
 
 	var count int
@@ -510,8 +525,8 @@ func TestMigration31_IdempotentWhenEndpointIDColumnAlreadyExists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSchemaVersion() error = %v", err)
 	}
-	if version != len(migrations) {
-		t.Fatalf("schema version = %d, want %d", version, len(migrations))
+	if version != latestSchemaVersion() {
+		t.Fatalf("schema version = %d, want %d", version, latestSchemaVersion())
 	}
 
 	var count int
@@ -521,4 +536,77 @@ func TestMigration31_IdempotentWhenEndpointIDColumnAlreadyExists(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("migration 31 marker count = %d, want 1", count)
 	}
+}
+
+// TestMigration51RenamesKeeperBackupsAndRealignsSentinel proves the keeper rename
+// migration actually transforms a LEGACY DB: it renames the janitor-named backup
+// table to the keeper-named one and rewrites the persisted 'attn-janitor' sentinel
+// to 'attn-keeper' on existing workspace_contexts rows. (The fresh-DB happy path is
+// already covered by the table-existence test; this exercises the legacy data path.)
+func TestMigration51RenamesKeeperBackupsAndRealignsSentinel(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	// Seed a context row, then roll the DB back to a pre-51 shape: plant the legacy
+	// 'attn-janitor' sentinel, drop the keeper-named table, recreate the legacy
+	// janitor-named one, and unrecord migration 51 so migrateDB re-applies it.
+	s.AddWorkspace(&protocol.Workspace{ID: "workspace-1", Title: "W", Directory: t.TempDir()})
+	if _, _, err := s.UpdateWorkspaceContext("workspace-1", "ctx", "session-1", 0); err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+	if _, err := s.db.Exec(`UPDATE workspace_contexts SET updated_by_session_id = 'attn-janitor' WHERE workspace_id = 'workspace-1'`); err != nil {
+		t.Fatalf("plant legacy sentinel: %v", err)
+	}
+	if _, err := s.db.Exec(`DROP TABLE workspace_keeper_compact_backups`); err != nil {
+		t.Fatalf("drop keeper table: %v", err)
+	}
+	if _, err := s.db.Exec(`CREATE TABLE workspace_context_janitor_backups (
+		workspace_id TEXT PRIMARY KEY,
+		source_revision INTEGER NOT NULL,
+		source_content TEXT NOT NULL,
+		result_revision INTEGER NOT NULL,
+		agent TEXT NOT NULL,
+		model TEXT NOT NULL,
+		created_at TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("recreate legacy table: %v", err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version = 51`); err != nil {
+		t.Fatalf("unrecord migration 51: %v", err)
+	}
+
+	if err := migrateDB(s.db); err != nil {
+		t.Fatalf("migrateDB error: %v", err)
+	}
+
+	if !tableExistsForTest(t, s.db, "workspace_keeper_compact_backups") {
+		t.Fatal("workspace_keeper_compact_backups missing after migration 51")
+	}
+	if tableExistsForTest(t, s.db, "workspace_context_janitor_backups") {
+		t.Fatal("legacy workspace_context_janitor_backups still present after migration 51")
+	}
+	var updater string
+	if err := s.db.QueryRow(`SELECT updated_by_session_id FROM workspace_contexts WHERE workspace_id = 'workspace-1'`).Scan(&updater); err != nil {
+		t.Fatalf("read sentinel: %v", err)
+	}
+	if updater != "attn-keeper" {
+		t.Fatalf("sentinel = %q, want attn-keeper", updater)
+	}
+}
+
+func tableExistsForTest(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+	var got string
+	err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, name).Scan(&got)
+	if err == sql.ErrNoRows {
+		return false
+	}
+	if err != nil {
+		t.Fatalf("tableExists(%s): %v", name, err)
+	}
+	return got == name
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1549,6 +1549,20 @@ func (s *Store) SetSetting(key, value string) {
 		key, value)
 }
 
+// DeleteSetting removes a setting row. No-op if the key is absent or the store
+// has no live DB. Used by one-time settings-key migrations to drop the stale
+// row after copying its value to the renamed key.
+func (s *Store) DeleteSetting(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return
+	}
+
+	s.execLog(`DELETE FROM settings WHERE key = ?`, key)
+}
+
 // GetAllSettings returns all settings as a map
 func (s *Store) GetAllSettings() map[string]string {
 	s.mu.RLock()

--- a/internal/store/workspace.go
+++ b/internal/store/workspace.go
@@ -43,7 +43,7 @@ func (s *Store) RemoveWorkspace(id string) {
 	}
 	_, _ = s.db.Exec(`DELETE FROM workspace_layout_panes WHERE workspace_id = ?`, id)
 	_, _ = s.db.Exec(`DELETE FROM workspace_layouts WHERE workspace_id = ?`, id)
-	_, _ = s.db.Exec(`DELETE FROM workspace_context_janitor_backups WHERE workspace_id = ?`, id)
+	_, _ = s.db.Exec(`DELETE FROM workspace_keeper_compact_backups WHERE workspace_id = ?`, id)
 	_, _ = s.db.Exec(`DELETE FROM workspace_contexts WHERE workspace_id = ?`, id)
 	if _, err := s.db.Exec(`DELETE FROM workspaces WHERE id = ?`, id); err != nil {
 		log.Printf("[store] RemoveWorkspace: failed to delete workspace %s: %v", id, err)

--- a/internal/store/workspace_context.go
+++ b/internal/store/workspace_context.go
@@ -10,9 +10,13 @@ import (
 )
 
 var ErrWorkspaceContextConflict = errors.New("workspace context revision conflict")
-var ErrWorkspaceContextJanitorBackupNotFound = errors.New("workspace context janitor backup not found")
+var ErrKeeperCompactBackupNotFound = errors.New("keeper compact backup not found")
 
-type WorkspaceContextJanitorBackup struct {
+// KeeperCompactBackup is the source snapshot captured before the keeper's
+// compaction duty rewrites a workspace context, used for direct rollback. It is
+// stored in the workspace_keeper_compact_backups table (renamed off the retired
+// "janitor" persona by migration 51).
+type KeeperCompactBackup struct {
 	WorkspaceID    string
 	SourceRevision int
 	SourceContent  string
@@ -175,9 +179,9 @@ func (s *Store) HasWorkspaceContext(workspaceID string) bool {
 	return s.db.QueryRow(`SELECT 1 FROM workspace_contexts WHERE workspace_id = ?`, workspaceID).Scan(&exists) == nil
 }
 
-// ApplyWorkspaceContextJanitorResult atomically stores the compacted context
+// ApplyKeeperCompactResult atomically stores the compacted context
 // and the source snapshot needed for direct rollback.
-func (s *Store) ApplyWorkspaceContextJanitorResult(
+func (s *Store) ApplyKeeperCompactResult(
 	workspaceID string,
 	content string,
 	updatedBySessionID string,
@@ -193,7 +197,7 @@ func (s *Store) ApplyWorkspaceContextJanitorResult(
 	}
 	tx, err := s.db.Begin()
 	if err != nil {
-		return nil, false, fmt.Errorf("begin workspace context janitor update: %w", err)
+		return nil, false, fmt.Errorf("begin keeper compact update: %w", err)
 	}
 	defer tx.Rollback()
 
@@ -214,7 +218,7 @@ func (s *Store) ApplyWorkspaceContextJanitorResult(
 	}
 	if current.Content == content {
 		if err := tx.Commit(); err != nil {
-			return nil, false, fmt.Errorf("commit unchanged workspace context janitor update: %w", err)
+			return nil, false, fmt.Errorf("commit unchanged keeper compact update: %w", err)
 		}
 		return current, false, nil
 	}
@@ -231,7 +235,7 @@ func (s *Store) ApplyWorkspaceContextJanitorResult(
 		return nil, false, err
 	}
 	if _, err := tx.Exec(`
-		INSERT INTO workspace_context_janitor_backups
+		INSERT INTO workspace_keeper_compact_backups
 			(workspace_id, source_revision, source_content, result_revision, agent, model, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(workspace_id) DO UPDATE SET
@@ -249,25 +253,25 @@ func (s *Store) ApplyWorkspaceContextJanitorResult(
 		model,
 		now,
 	); err != nil {
-		return nil, false, fmt.Errorf("store workspace context janitor backup %s: %w", workspaceID, err)
+		return nil, false, fmt.Errorf("store keeper compact backup %s: %w", workspaceID, err)
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, false, fmt.Errorf("commit workspace context janitor update: %w", err)
+		return nil, false, fmt.Errorf("commit keeper compact update: %w", err)
 	}
 	return updated, true, nil
 }
 
-func (s *Store) GetWorkspaceContextJanitorBackup(workspaceID string) (*WorkspaceContextJanitorBackup, error) {
+func (s *Store) GetKeeperCompactBackup(workspaceID string) (*KeeperCompactBackup, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.db == nil {
-		return nil, ErrWorkspaceContextJanitorBackupNotFound
+		return nil, ErrKeeperCompactBackupNotFound
 	}
-	var backup WorkspaceContextJanitorBackup
+	var backup KeeperCompactBackup
 	err := s.db.QueryRow(`
 		SELECT workspace_id, source_revision, source_content, result_revision,
 			agent, model, created_at
-		FROM workspace_context_janitor_backups
+		FROM workspace_keeper_compact_backups
 		WHERE workspace_id = ?`,
 		workspaceID,
 	).Scan(
@@ -280,17 +284,17 @@ func (s *Store) GetWorkspaceContextJanitorBackup(workspaceID string) (*Workspace
 		&backup.CreatedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrWorkspaceContextJanitorBackupNotFound
+		return nil, ErrKeeperCompactBackupNotFound
 	}
 	if err != nil {
-		return nil, fmt.Errorf("get workspace context janitor backup %s: %w", workspaceID, err)
+		return nil, fmt.Errorf("get keeper compact backup %s: %w", workspaceID, err)
 	}
 	return &backup, nil
 }
 
-// RestoreWorkspaceContextJanitorBackup restores only when the compacted
+// RestoreKeeperCompactBackup restores only when the compacted
 // revision is still canonical, so later user edits are never overwritten.
-func (s *Store) RestoreWorkspaceContextJanitorBackup(
+func (s *Store) RestoreKeeperCompactBackup(
 	workspaceID string,
 	updatedBySessionID string,
 ) (*protocol.WorkspaceContext, error) {
@@ -301,15 +305,15 @@ func (s *Store) RestoreWorkspaceContextJanitorBackup(
 	}
 	tx, err := s.db.Begin()
 	if err != nil {
-		return nil, fmt.Errorf("begin workspace context janitor rollback: %w", err)
+		return nil, fmt.Errorf("begin keeper compact rollback: %w", err)
 	}
 	defer tx.Rollback()
 
-	var backup WorkspaceContextJanitorBackup
+	var backup KeeperCompactBackup
 	err = tx.QueryRow(`
 		SELECT workspace_id, source_revision, source_content, result_revision,
 			agent, model, created_at
-		FROM workspace_context_janitor_backups
+		FROM workspace_keeper_compact_backups
 		WHERE workspace_id = ?`,
 		workspaceID,
 	).Scan(
@@ -322,10 +326,10 @@ func (s *Store) RestoreWorkspaceContextJanitorBackup(
 		&backup.CreatedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrWorkspaceContextJanitorBackupNotFound
+		return nil, ErrKeeperCompactBackupNotFound
 	}
 	if err != nil {
-		return nil, fmt.Errorf("read workspace context janitor backup %s: %w", workspaceID, err)
+		return nil, fmt.Errorf("read keeper compact backup %s: %w", workspaceID, err)
 	}
 	current, err := readWorkspaceContextTx(tx, workspaceID)
 	if err != nil {
@@ -345,7 +349,7 @@ func (s *Store) RestoreWorkspaceContextJanitorBackup(
 		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit workspace context janitor rollback: %w", err)
+		return nil, fmt.Errorf("commit keeper compact rollback: %w", err)
 	}
 	return updated, nil
 }
@@ -400,6 +404,6 @@ func (s *Store) RemoveWorkspaceContext(workspaceID string) {
 	if s.db == nil {
 		return
 	}
-	_, _ = s.db.Exec(`DELETE FROM workspace_context_janitor_backups WHERE workspace_id = ?`, workspaceID)
+	_, _ = s.db.Exec(`DELETE FROM workspace_keeper_compact_backups WHERE workspace_id = ?`, workspaceID)
 	_, _ = s.db.Exec(`DELETE FROM workspace_contexts WHERE workspace_id = ?`, workspaceID)
 }

--- a/internal/store/workspace_context_test.go
+++ b/internal/store/workspace_context_test.go
@@ -130,21 +130,21 @@ func TestRemoveWorkspaceRemovesContext(t *testing.T) {
 	if _, _, err := s.UpdateWorkspaceContext("workspace-1", "context", "session-1", 0); err != nil {
 		t.Fatalf("UpdateWorkspaceContext error: %v", err)
 	}
-	if _, _, err := s.ApplyWorkspaceContextJanitorResult(
-		"workspace-1", "compacted", "attn-janitor", 1, "codex", "gpt-test",
+	if _, _, err := s.ApplyKeeperCompactResult(
+		"workspace-1", "compacted", "attn-keeper", 1, "codex", "gpt-test",
 	); err != nil {
-		t.Fatalf("ApplyWorkspaceContextJanitorResult error: %v", err)
+		t.Fatalf("ApplyKeeperCompactResult error: %v", err)
 	}
 	s.RemoveWorkspace("workspace-1")
 	if s.HasWorkspaceContext("workspace-1") {
 		t.Fatal("workspace context survived explicit workspace removal")
 	}
-	if _, err := s.GetWorkspaceContextJanitorBackup("workspace-1"); !errors.Is(err, ErrWorkspaceContextJanitorBackupNotFound) {
+	if _, err := s.GetKeeperCompactBackup("workspace-1"); !errors.Is(err, ErrKeeperCompactBackupNotFound) {
 		t.Fatalf("backup error = %v, want not found", err)
 	}
 }
 
-func TestWorkspaceContextJanitorApplyAndRollback(t *testing.T) {
+func TestKeeperCompactApplyAndRollback(t *testing.T) {
 	s := New()
 	s.AddWorkspace(&protocol.Workspace{ID: "workspace-1", Title: "Workspace", Directory: t.TempDir()})
 	source := "# Workspace Context\n\n## Area\n\nShared work.\n\n## Current Picture\n\nA longer current picture.\n"
@@ -153,58 +153,58 @@ func TestWorkspaceContextJanitorApplyAndRollback(t *testing.T) {
 		t.Fatalf("seed context: %v", err)
 	}
 
-	updated, changed, err := s.ApplyWorkspaceContextJanitorResult(
+	updated, changed, err := s.ApplyKeeperCompactResult(
 		"workspace-1",
 		compacted,
-		"attn-janitor",
+		"attn-keeper",
 		1,
 		"codex",
 		"gpt-test",
 	)
 	if err != nil {
-		t.Fatalf("ApplyWorkspaceContextJanitorResult error: %v", err)
+		t.Fatalf("ApplyKeeperCompactResult error: %v", err)
 	}
-	if !changed || updated.Revision != 2 || updated.UpdatedBySessionID != "attn-janitor" {
+	if !changed || updated.Revision != 2 || updated.UpdatedBySessionID != "attn-keeper" {
 		t.Fatalf("updated = %+v, changed=%v", updated, changed)
 	}
-	backup, err := s.GetWorkspaceContextJanitorBackup("workspace-1")
+	backup, err := s.GetKeeperCompactBackup("workspace-1")
 	if err != nil {
-		t.Fatalf("GetWorkspaceContextJanitorBackup error: %v", err)
+		t.Fatalf("GetKeeperCompactBackup error: %v", err)
 	}
 	if backup.SourceRevision != 1 || backup.SourceContent != source ||
 		backup.ResultRevision != 2 || backup.Agent != "codex" || backup.Model != "gpt-test" {
 		t.Fatalf("backup = %+v", backup)
 	}
 
-	restored, err := s.RestoreWorkspaceContextJanitorBackup("workspace-1", "session-1")
+	restored, err := s.RestoreKeeperCompactBackup("workspace-1", "session-1")
 	if err != nil {
-		t.Fatalf("RestoreWorkspaceContextJanitorBackup error: %v", err)
+		t.Fatalf("RestoreKeeperCompactBackup error: %v", err)
 	}
 	if restored.Content != source || restored.Revision != 3 || restored.UpdatedBySessionID != "session-1" {
 		t.Fatalf("restored = %+v", restored)
 	}
 }
 
-func TestWorkspaceContextJanitorRollbackRejectsLaterEdit(t *testing.T) {
+func TestKeeperCompactRollbackRejectsLaterEdit(t *testing.T) {
 	s := New()
 	s.AddWorkspace(&protocol.Workspace{ID: "workspace-1", Title: "Workspace", Directory: t.TempDir()})
 	if _, _, err := s.UpdateWorkspaceContext("workspace-1", "source", "session-1", 0); err != nil {
 		t.Fatalf("seed context: %v", err)
 	}
-	if _, _, err := s.ApplyWorkspaceContextJanitorResult(
-		"workspace-1", "compacted", "attn-janitor", 1, "claude", "claude-test",
+	if _, _, err := s.ApplyKeeperCompactResult(
+		"workspace-1", "compacted", "attn-keeper", 1, "claude", "claude-test",
 	); err != nil {
 		t.Fatalf("compact context: %v", err)
 	}
 	if _, _, err := s.UpdateWorkspaceContext("workspace-1", "later edit", "session-2", 2); err != nil {
 		t.Fatalf("later edit: %v", err)
 	}
-	if _, err := s.RestoreWorkspaceContextJanitorBackup("workspace-1", "session-1"); !errors.Is(err, ErrWorkspaceContextConflict) {
+	if _, err := s.RestoreKeeperCompactBackup("workspace-1", "session-1"); !errors.Is(err, ErrWorkspaceContextConflict) {
 		t.Fatalf("rollback error = %v, want conflict", err)
 	}
 }
 
-func TestWorkspaceContextJanitorBackupSurvivesReopen(t *testing.T) {
+func TestKeeperCompactBackupSurvivesReopen(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	s, err := NewWithDB(dbPath)
 	if err != nil {
@@ -216,8 +216,8 @@ func TestWorkspaceContextJanitorBackupSurvivesReopen(t *testing.T) {
 	if _, _, err := s.UpdateWorkspaceContext("workspace-1", source, "session-1", 0); err != nil {
 		t.Fatalf("seed context: %v", err)
 	}
-	if _, _, err := s.ApplyWorkspaceContextJanitorResult(
-		"workspace-1", compacted, "attn-janitor", 1, "claude", "sonnet",
+	if _, _, err := s.ApplyKeeperCompactResult(
+		"workspace-1", compacted, "attn-keeper", 1, "claude", "sonnet",
 	); err != nil {
 		t.Fatalf("compact context: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestWorkspaceContextJanitorBackupSurvivesReopen(t *testing.T) {
 		t.Fatalf("reopen store: %v", err)
 	}
 	defer reopened.Close()
-	backup, err := reopened.GetWorkspaceContextJanitorBackup("workspace-1")
+	backup, err := reopened.GetKeeperCompactBackup("workspace-1")
 	if err != nil {
 		t.Fatalf("get reopened backup: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestWorkspaceContextJanitorBackupSurvivesReopen(t *testing.T) {
 		backup.Agent != "claude" || backup.Model != "sonnet" {
 		t.Fatalf("backup = %+v", backup)
 	}
-	restored, err := reopened.RestoreWorkspaceContextJanitorBackup("workspace-1", "session-1")
+	restored, err := reopened.RestoreKeeperCompactBackup("workspace-1", "session-1")
 	if err != nil {
 		t.Fatalf("restore reopened backup: %v", err)
 	}


### PR DESCRIPTION
Renames the persisted janitor surfaces to the **keeper** vocabulary. Migration **51** renames `workspace_context_janitor_backups` → `workspace_keeper_compact_backups` and realigns the `attn-janitor` updater sentinel → `attn-keeper` on existing rows (idempotent across a migration rewind). Lands at 51 (not 49) because 49/50 are burned on real prod/dev DBs. Adds the `DeleteSetting` helper used by the settings-key migration.
---
**Final-state re-split of the knowledge-base / keeper epic** (supersedes #335–#343, #345). The original stack was split by chronology and carried mid-epic churn; this one is sliced by subsystem from the net diff, so each PR is a clean final-state slice.

Stack: `1 task-engine` · `2 notebook-kb` · `3 agent-native` · `4 store-keeper` · `5 keeper-compaction` · `6 keeper-narration` · `7 keeper-cron` · **`8 integration`** · `9 frontend` · `10 cli/docs`

This is PR **4/10** — base `kb/03-agent-native-tools`. Review per-diff. By design the refactor only activates in #8 (where the keeper is wired and the janitor/dreaming are deleted), so branches 2–9 are not individually `go build`-clean; the merged tip (#10) is build + vet + test green.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. `feat/chifplace`
2. #347
3. #348
4. #349
5. **#350** 👈 current
6. #351
7. #352
8. #353
9. #354
10. #355
11. #356
<!-- stack:links:end -->