### PR TITLE
feat(daemon): keeper compaction + raw-tier capture floor

### DIFF
--- a/internal/daemon/notebook_dispatch_journal.go
+++ b/internal/daemon/notebook_dispatch_journal.go
@@ -9,27 +9,35 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// Auto-journaling of chief-of-staff dispatch outcomes.
+// Deterministic capture of chief-of-staff dispatch outcomes to the raw tier.
 //
 // A dispatch is delegated agent work, and its terminal report (completed/failed)
 // — or, as a fallback, its session simply ending — is exactly the "what was
 // decided / built / failed" signal the durable work-journal exists to capture.
 // This file renders that already-structured DispatchReport into a human-readable
-// journal block and appends it to the daily journal:
+// block and writes it to the notebook's raw tier
+// (.attn/raw/dispatches/<dispatchID>.md), where the later narration pass reads it.
+// It deliberately does NOT write the curated journal — the journal stays curated.
 //
 //   - deterministic: the daemon renders structured fields, no LLM is involved;
-//   - idempotent: a hidden per-dispatch marker means the terminal-report path, the
-//     session-gone fallback, and a daemon restart together write exactly one block;
-//   - grounded by construction: every block cites source: dispatch:<id>.
+//   - exactly-once: one file per dispatch id; a replay atomically overwrites that
+//     one file, so the report path, the session-gone fallback, and a daemon restart
+//     together leave exactly one entry. The overwrite is byte-identical when the
+//     dispatch carries a server ReportedAt; when it does not (a worker that ended
+//     with no structured report), the "## HH:MM" header is stamped from the wall
+//     clock at render time, so two replays in different minutes overwrite with an
+//     equivalent — not byte-identical — block. Still one file, one marker;
+//   - grounded by construction: every block cites source: dispatch:<id> and carries
+//     a hidden attn:dispatch:<id> marker.
 //
-// This is the capture half of the notebook-as-work-journal: reliable, low-noise
-// entries land without any agent having to remember to journal. LLM curation of
-// these raw entries is a separate, later pass.
+// This is the deterministic capture floor of the notebook-as-work-journal:
+// reliable, low-noise entries land without any agent having to remember to journal.
+// LLM curation of these raw entries is a separate, later pass.
 
-// journalDispatchMarker is the stable, hidden per-dispatch dedupe marker embedded
-// in each auto-journaled block. It is an HTML comment so it renders invisibly in a
-// markdown viewer while keeping the journal file self-describing — dedup needs no
-// separate ledger and survives a daemon restart.
+// journalDispatchMarker is the stable, hidden per-dispatch marker embedded in each
+// rendered block. It is an HTML comment so it renders invisibly in a markdown
+// viewer while keeping the raw dispatch file self-describing — the marker is the
+// greppable ledger the narration pass keys off, and it survives a daemon restart.
 func journalDispatchMarker(dispatchID string) string {
 	return fmt.Sprintf("<!-- attn:dispatch:%s -->", strings.TrimSpace(dispatchID))
 }
@@ -44,68 +52,84 @@ func isTerminalDispatchReport(report *protocol.DispatchReport) bool {
 			report.WorkState == protocol.DispatchWorkStateFailed)
 }
 
-// journalDispatchOutcome renders a dispatch's outcome into the daily journal,
-// exactly once. It is best-effort and safe to call from any dispatch-end path: a
-// missing/unconfigured notebook, an empty dispatch, or an already-journaled
-// dispatch is a silent no-op. Capture must never disrupt the dispatch lifecycle,
-// so every failure is logged and swallowed.
+// journalDispatchOutcome captures a dispatch's outcome to the raw tier, exactly
+// once. It is best-effort and safe to call from any dispatch-end path: a
+// missing/unconfigured notebook or an empty dispatch is a silent no-op. Capture
+// must never disrupt the dispatch lifecycle, so every failure is logged and
+// swallowed.
 //
-// Best-effort has one accepted edge: if the write itself cannot land — an
-// unwritable notebook root, or a day's journal that has reached notebook.MaxFileSize
-// — the entry is logged and dropped, and since the marker was never written the
-// later removal-path retry re-fails identically. So "exactly once" degrades to "at
-// most once" precisely when the journal cannot be written at all. Given a block is
-// a few KiB and fields are clamped, hitting the daily ceiling needs an implausible
-// per-day dispatch volume; we accept that over carrying an overflow-spill mechanism.
+// The destination is the raw tier (.attn/raw/dispatches/<dispatchID>.md), not the
+// curated journal: one file per dispatch, keyed 1:1 on the dispatch id. Existence
+// of that file plus the attn:dispatch:<id> marker embedded in the rendered block
+// is the exactly-once ledger, so a replayed trigger (report path, session-gone
+// fallback, restart) re-renders the block and atomically overwrites that one file —
+// harmless. The re-rendered block is byte-identical when the dispatch has a server
+// ReportedAt; without one, its wall-clock header can drift across minutes, so the
+// overwrite is equivalent rather than byte-identical (still one file, one marker).
+// If the write cannot land (an unwritable notebook
+// root), the entry is logged and dropped; a later removal-path retry re-attempts
+// the same write, so "exactly once" degrades to "at most once" only while the raw
+// tier itself is unwritable.
 func (d *Daemon) journalDispatchOutcome(dispatch *protocol.ChiefOfStaffDispatch) {
 	if dispatch == nil {
 		return
 	}
-	dateISO, block, ok := renderDispatchJournalEntry(dispatch, time.Now())
+	_, block, ok := renderDispatchJournalEntry(dispatch, time.Now())
 	if !ok {
 		return // nothing meaningful to record
 	}
-	store, err := d.notebookStoreFor()
+	// Redirect the deterministic dispatch capture to the raw tier
+	// (.attn/raw/dispatches/<dispatchID>.md) instead of the curated journal, so the
+	// curated journal/<date>.md never accumulates machine-raw blocks. The raw tier
+	// lives under .attn/, which CleanPath rejects and the watcher skips, so this is
+	// written with direct filesystem I/O (not notebook.Store) and emits no
+	// notebook_changed broadcast — there is no watcher echo to suppress.
+	//
+	// One file per dispatch: its existence + the attn:dispatch:<id> marker already
+	// embedded in `block` is the exactly-once ledger, so the prior in-file
+	// marker-scan dedup (AppendJournalEntryOnce) is no longer needed here. A
+	// replayed trigger re-renders the identical block and atomically overwrites the
+	// identical file — harmless.
+	root, err := d.notebookRoot()
 	if err != nil {
-		d.logf("dispatch auto-journal: store unavailable: %v", err)
+		d.logf("dispatch auto-journal %s: notebook root unavailable: %v", dispatch.ID, err)
 		return
 	}
-	rel, written, hash, err := store.AppendJournalEntryOnce(dateISO, journalDispatchMarker(dispatch.ID), block)
-	if err != nil {
+	if strings.TrimSpace(root) == "" {
+		return // notebook disabled — silent no-op
+	}
+	if err := writeRawAtomic(notebook.RawDispatchesDir(root), dispatch.ID, []byte(block)); err != nil {
 		d.logf("dispatch auto-journal %s: %v", dispatch.ID, err)
 		return
 	}
-	if !written {
-		return // already journaled — idempotent
-	}
-	// Suppress the watcher echo and surface the write like the CLI append path does.
-	d.noteNotebookSelfWrite(notebook.SelfWrite{Rel: rel, Hash: hash})
-	d.broadcastNotebookChanged(originAgent, rel)
 }
 
-// journalDispatchOnSessionGone journals the outcome of a dispatch whose target
+// journalDispatchOnSessionGone captures the outcome of a dispatch whose target
 // session is being removed — the reliability backstop for a worker that ended
-// without a terminal report. It always attempts the write and lets the journal
-// file's per-dispatch marker (checked under the notebook store lock in
-// AppendJournalEntryOnce) be the sole dedup authority. That keying-off-the-file,
-// not off store state, is deliberate:
+// without a terminal report. It always attempts the write; the per-dispatch raw
+// file (one file per dispatch id) is the exactly-once ledger. Keying off the file
+// rather than off store state is deliberate:
 //
-//   - it no-ops when the report path already journaled (marker present);
 //   - it RECOVERS a dispatch whose report-path write failed transiently — the
 //     store still holds the terminal report at removal time, so the recovered
 //     entry is the rich completed/failed block, not a degraded one. (Keying the
 //     skip off the store's terminal-state instead would strand that dispatch
-//     unjournaled forever, since the marker was never written.)
+//     uncaptured forever, since the file was never written.)
+//   - a replay (report path already captured) re-renders the block and atomically
+//     overwrites that one file — harmless (byte-identical with a server ReportedAt;
+//     with only the wall-clock fallback the header can drift across minutes, so the
+//     overwrite is equivalent rather than byte-identical).
 //
 // Non-dispatch sessions resolve to no dispatch and are ignored.
 //
 // One narrow, accepted race remains: if a teardown reads this dispatch in the
 // sub-millisecond window after a terminal report is rendered but before it commits
-// to the store, AND the teardown's append wins the marker before the report path's,
-// the journal records the lower-fidelity "(ended)" block. Exactly-once still holds
-// (the marker admits a single entry); only the fidelity of that one entry degrades,
-// and only in that window. Closing it fully would require cross-subsystem per-
-// dispatch locking — not worth it for a best-effort capture.
+// to the store, the teardown may write the lower-fidelity "(ended)" block and the
+// report path may then overwrite it with the rich block (or vice versa). Either
+// way the single per-dispatch file holds exactly one entry; only the fidelity of
+// that one entry can briefly differ, and only in that window. Closing it fully
+// would require cross-subsystem per-dispatch locking — not worth it for a
+// best-effort capture.
 func (d *Daemon) journalDispatchOnSessionGone(sessionID string) {
 	dispatch := d.store.GetChiefOfStaffDispatchBySession(strings.TrimSpace(sessionID))
 	if dispatch == nil {
@@ -202,6 +226,27 @@ func renderDispatchJournalEntry(dispatch *protocol.ChiefOfStaffDispatch, now tim
 // is unaffected.
 func neutralizeJournalMarkers(s string) string {
 	return strings.ReplaceAll(s, "<!--", "<! --")
+}
+
+// dispatchDecisionText renders a resolved decision request as a single durable
+// line ("Decision: <question> → <answer>"). An unanswered request carries no
+// durable outcome yet, so it is skipped.
+func dispatchDecisionText(req *protocol.DispatchDecisionRequest) string {
+	if req == nil {
+		return ""
+	}
+	question := strings.TrimSpace(req.Question)
+	answer := ""
+	if req.Response != nil {
+		answer = strings.TrimSpace(*req.Response)
+	}
+	if answer == "" && req.Recommendation != nil {
+		answer = strings.TrimSpace(*req.Recommendation)
+	}
+	if question == "" || answer == "" {
+		return ""
+	}
+	return fmt.Sprintf("Decision: %s → %s", question, answer)
 }
 
 // dispatchVerificationLine condenses verification evidence into one scannable line

--- a/internal/daemon/notebook_dispatch_journal_test.go
+++ b/internal/daemon/notebook_dispatch_journal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/victorarias/attn/internal/notebook"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -28,18 +29,74 @@ func readJournalFile(t *testing.T, d *Daemon, dateISO string) string {
 	return string(data)
 }
 
-// waitForJournal polls the dated journal until it contains substr — the journal
-// write on the dispatch-report path is a side effect that runs after the socket
-// response is sent, so socket-level tests assert it eventually, not synchronously.
-func waitForJournal(t *testing.T, d *Daemon, dateISO, substr string) string {
+// readRawDispatchFile returns the per-dispatch raw-tier file
+// (.attn/raw/dispatches/<dispatchID>.md), or "" if it does not exist. Dispatch
+// outcomes now land here, redirected out of the curated journal.
+func readRawDispatchFile(t *testing.T, d *Daemon, dispatchID string) string {
+	t.Helper()
+	root, err := d.notebookRoot()
+	if err != nil {
+		t.Fatalf("notebook root: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(notebook.RawDispatchesDir(root), dispatchID+".md"))
+	if errors.Is(err, os.ErrNotExist) {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("read raw dispatch %s: %v", dispatchID, err)
+	}
+	return string(data)
+}
+
+// waitForRawDispatch polls the per-dispatch raw file until it contains substr —
+// the redirect on the dispatch-report path is a side effect that runs after the
+// socket response is sent, so socket-level tests assert it eventually.
+func waitForRawDispatch(t *testing.T, d *Daemon, dispatchID, substr string) string {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		if body := readJournalFile(t, d, dateISO); strings.Contains(body, substr) {
+		if body := readRawDispatchFile(t, d, dispatchID); strings.Contains(body, substr) {
 			return body
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("journal %s never contained %q:\n%s", dateISO, substr, readJournalFile(t, d, dateISO))
+			t.Fatalf("raw dispatch %s never contained %q:\n%s", dispatchID, substr, readRawDispatchFile(t, d, dispatchID))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// waitForRawDispatchesQuiescent polls until the dispatches dir holds exactly the
+// expected settled .md files with no in-flight atomic-writer temp (.tmp.) sibling.
+// The report-path capture runs as a post-response side effect, so a socket-level
+// idempotency check must wait for the in-flight overwrite to settle — otherwise a
+// lingering temp file races t.TempDir() cleanup.
+func waitForRawDispatchesQuiescent(t *testing.T, d *Daemon, wantMD int) {
+	t.Helper()
+	root, err := d.notebookRoot()
+	if err != nil {
+		t.Fatalf("notebook root: %v", err)
+	}
+	dir := notebook.RawDispatchesDir(root)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		entries, err := os.ReadDir(dir)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatalf("read dispatches dir: %v", err)
+		}
+		md, temp := 0, 0
+		for _, e := range entries {
+			switch {
+			case strings.Contains(e.Name(), ".tmp."):
+				temp++
+			case strings.HasSuffix(e.Name(), ".md"):
+				md++
+			}
+		}
+		if temp == 0 && md == wantMD {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("dispatches dir not quiescent: md=%d (want %d) temp=%d", md, wantMD, temp)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -228,12 +285,16 @@ func TestRemoveReapedSessionJournalsOnce(t *testing.T) {
 
 	d.removeReapedSession("worker-reap")
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-reap")
 	if !strings.Contains(body, "Made progress before the worker was reaped.") {
-		t.Fatalf("reaped dispatch was not journaled:\n%s", body)
+		t.Fatalf("reaped dispatch was not captured:\n%s", body)
 	}
 	if n := strings.Count(body, "<!-- attn:dispatch:dsp-reap -->"); n != 1 {
-		t.Fatalf("reaped dispatch journaled %d times, want 1:\n%s", n, body)
+		t.Fatalf("reaped dispatch captured %d markers, want 1:\n%s", n, body)
+	}
+	// The redirect keeps the raw block OUT of the curated journal.
+	if j := readJournalFile(t, d, "2026-06-14"); strings.Contains(j, "dsp-reap") {
+		t.Fatalf("dispatch block leaked into the curated journal:\n%s", j)
 	}
 }
 
@@ -258,19 +319,21 @@ func TestJournalDispatchOnSessionGoneRecoversTerminal(t *testing.T) {
 		t.Fatalf("add dispatch: %v", err)
 	}
 
-	// No prior journal write exists (marker absent) — the fallback recovers it.
+	// No prior raw file exists — the fallback recovers it.
 	d.journalDispatchOnSessionGone("worker-term")
-	d.journalDispatchOnSessionGone("worker-term") // idempotent: marker now present
+	d.journalDispatchOnSessionGone("worker-term") // idempotent: identical overwrite
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-term")
 	if !strings.Contains(body, "(completed)") || !strings.Contains(body, "Finished cleanly.") {
 		t.Fatalf("recovered entry should be the rich completed block, not degraded:\n%s", body)
 	}
 	if strings.Contains(body, "(ended)") {
 		t.Fatalf("recovered entry must not use the degraded (ended) label:\n%s", body)
 	}
+	// The 1:1 <dispatchID>.md keying means a replay is an identical overwrite, so the
+	// single file holds exactly one marker regardless of how many times it is called.
 	if n := strings.Count(body, "<!-- attn:dispatch:dsp-term -->"); n != 1 {
-		t.Fatalf("terminal dispatch recovered %d times, want 1:\n%s", n, body)
+		t.Fatalf("terminal dispatch recovered %d markers, want 1:\n%s", n, body)
 	}
 }
 
@@ -293,12 +356,66 @@ func TestJournalDispatchOutcomeIdempotent(t *testing.T) {
 	d.journalDispatchOutcome(dispatch)
 	d.journalDispatchOutcome(dispatch)
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-once")
 	if n := strings.Count(body, "<!-- attn:dispatch:dsp-once -->"); n != 1 {
-		t.Fatalf("dispatch journaled %d times, want 1:\n%s", n, body)
+		t.Fatalf("dispatch captured %d markers, want 1:\n%s", n, body)
 	}
 	if !strings.Contains(body, "source: dispatch:dsp-once") {
 		t.Fatalf("entry not grounded:\n%s", body)
+	}
+}
+
+// A replay of a dispatch that carries a server ReportedAt re-renders a
+// byte-identical block, but a dispatch WITHOUT a ReportedAt stamps its "## HH:MM"
+// header from the wall clock at render time, so two replays in different minutes
+// produce an equivalent — not byte-identical — block. The exactly-once ledger still
+// holds (one file, one marker); only the header timestamp can drift. This pins the
+// softened "equivalent, not byte-identical" claim in the package comments.
+func TestRenderDispatchJournalEntryWallClockHeaderDrifts(t *testing.T) {
+	withReportedAt := &protocol.ChiefOfStaffDispatch{
+		ID:         "dsp-stamped",
+		Label:      "stamped",
+		ReportedAt: protocol.Ptr("2026-06-15T10:30:00Z"),
+		StructuredReport: &protocol.DispatchReport{
+			ReportType: protocol.DispatchReportTypeCompletion,
+			WorkState:  protocol.DispatchWorkStateCompleted,
+			Summary:    "done",
+		},
+	}
+	noReportedAt := &protocol.ChiefOfStaffDispatch{
+		ID:           "dsp-bare",
+		Label:        "bare",
+		LatestReport: protocol.Ptr("ended without a structured report"),
+		// ReportedAt deliberately absent -> wall-clock fallback for the header.
+	}
+
+	t1 := time.Date(2026, 6, 15, 10, 30, 0, 0, time.UTC)
+	t2 := time.Date(2026, 6, 15, 10, 31, 0, 0, time.UTC)
+
+	// With a server ReportedAt the render ignores the passed clock entirely, so the
+	// block is byte-identical across replays.
+	if _, a, _ := renderDispatchJournalEntry(withReportedAt, t1); true {
+		if _, b, _ := renderDispatchJournalEntry(withReportedAt, t2); a != b {
+			t.Fatalf("ReportedAt dispatch should render identically across clocks:\n%s\n---\n%s", a, b)
+		}
+	}
+
+	// Without one the header tracks the wall clock, so the two blocks differ — but
+	// only in the header line; the body and the dedup marker are unchanged.
+	_, first, ok1 := renderDispatchJournalEntry(noReportedAt, t1)
+	_, second, ok2 := renderDispatchJournalEntry(noReportedAt, t2)
+	if !ok1 || !ok2 {
+		t.Fatal("bare dispatch should still be renderable")
+	}
+	if first == second {
+		t.Fatalf("wall-clock header should drift across minutes:\n%s", first)
+	}
+	if !strings.Contains(first, "## 10:30 —") || !strings.Contains(second, "## 10:31 —") {
+		t.Fatalf("headers not stamped from the passed clock:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	marker := "<!-- attn:dispatch:dsp-bare -->"
+	if !strings.Contains(first, marker) || !strings.Contains(second, marker) {
+		t.Fatalf("dedup marker missing despite header drift")
 	}
 }
 
@@ -326,17 +443,21 @@ func TestReportDispatchAutoJournals(t *testing.T) {
 	}
 	sendNotebookCmd(t, d, report)
 
-	today := time.Now().Format("2006-01-02")
-	body := waitForJournal(t, d, today, "Wired the auto-journal into the report path.")
+	body := waitForRawDispatch(t, d, "dsp-int", "Wired the auto-journal into the report path.")
 	if !strings.Contains(body, "source: dispatch:dsp-int") {
 		t.Fatalf("entry not grounded:\n%s", body)
 	}
+	// The redirect keeps the raw block OUT of the curated journal.
+	if j := readJournalFile(t, d, time.Now().Format("2006-01-02")); strings.Contains(j, "dsp-int") {
+		t.Fatalf("dispatch block leaked into the curated journal:\n%s", j)
+	}
 
-	// A second identical report must not double-write.
+	// A second identical report is a harmless identical overwrite — one file, one marker.
 	sendNotebookCmd(t, d, report)
-	body = waitForJournal(t, d, today, "<!-- attn:dispatch:dsp-int -->")
+	waitForRawDispatchesQuiescent(t, d, 1) // the in-flight overwrite settled; still one file
+	body = readRawDispatchFile(t, d, "dsp-int")
 	if n := strings.Count(body, "<!-- attn:dispatch:dsp-int -->"); n != 1 {
-		t.Fatalf("dispatch journaled %d times after re-report, want 1:\n%s", n, body)
+		t.Fatalf("dispatch captured %d markers after re-report, want 1:\n%s", n, body)
 	}
 }
 
@@ -365,8 +486,8 @@ func TestReportDispatchNonTerminalDoesNotJournal(t *testing.T) {
 
 	// Give any (incorrect) async write a chance to land before asserting absence.
 	time.Sleep(50 * time.Millisecond)
-	if body := readJournalFile(t, d, time.Now().Format("2006-01-02")); strings.Contains(body, "dsp-mid") {
-		t.Fatalf("non-terminal report should not journal:\n%s", body)
+	if body := readRawDispatchFile(t, d, "dsp-mid"); body != "" {
+		t.Fatalf("non-terminal report should not capture a dispatch file:\n%s", body)
 	}
 }
 
@@ -384,16 +505,15 @@ func TestJournalDispatchOnSessionGoneFallback(t *testing.T) {
 	}
 
 	d.journalDispatchOnSessionGone("worker-gone")
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-gone")
 	if !strings.Contains(body, "Got partway before the session closed.") || !strings.Contains(body, "(ended)") {
-		t.Fatalf("session-gone fallback did not journal:\n%s", body)
+		t.Fatalf("session-gone fallback did not capture:\n%s", body)
 	}
 
-	// A session that is not a tracked dispatch is a silent no-op.
-	before := body
+	// A session that is not a tracked dispatch is a silent no-op — it writes no file.
 	d.journalDispatchOnSessionGone("not-a-dispatch")
-	if after := readJournalFile(t, d, "2026-06-14"); after != before {
-		t.Fatalf("non-dispatch session changed the journal:\nbefore:\n%s\nafter:\n%s", before, after)
+	if after := readRawDispatchFile(t, d, "dsp-gone"); after != body {
+		t.Fatalf("non-dispatch session changed the captured file:\nbefore:\n%s\nafter:\n%s", body, after)
 	}
 }
 
@@ -415,9 +535,9 @@ func TestUnregisterSessionJournals(t *testing.T) {
 
 	d.unregisterSession("worker-close", syscall.SIGTERM)
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-close")
 	if !strings.Contains(body, "Worked until the pane was closed.") {
-		t.Fatalf("orderly-close path did not journal:\n%s", body)
+		t.Fatalf("orderly-close path did not capture:\n%s", body)
 	}
 	if d.store.Get("worker-close") != nil {
 		t.Fatal("session record should be removed after unregister")
@@ -441,9 +561,9 @@ func TestCleanupDeletedWorktreeSessionsJournals(t *testing.T) {
 	// addIdleNotebookSession sets Directory to "/tmp/<id>"; match it.
 	d.cleanupDeletedWorktreeSessions("/tmp/worker-wt")
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-wt")
 	if !strings.Contains(body, "Ran inside a worktree that was deleted.") {
-		t.Fatalf("worktree-cleanup path did not journal:\n%s", body)
+		t.Fatalf("worktree-cleanup path did not capture:\n%s", body)
 	}
 	if d.store.Get("worker-wt") != nil {
 		t.Fatal("session record should be removed after worktree cleanup")
@@ -467,9 +587,9 @@ func TestClearAllSessionsJournals(t *testing.T) {
 
 	d.clearAllSessions()
 
-	body := readJournalFile(t, d, "2026-06-14")
+	body := readRawDispatchFile(t, d, "dsp-clear")
 	if !strings.Contains(body, "Was mid-run when sessions were cleared.") {
-		t.Fatalf("clear-all path did not journal:\n%s", body)
+		t.Fatalf("clear-all path did not capture:\n%s", body)
 	}
 	if d.store.Get("worker-clear") != nil {
 		t.Fatal("session record should be removed after clear-all")
@@ -505,8 +625,11 @@ func TestDropSessionRecordSwallowsJournalFailure(t *testing.T) {
 }
 
 // A free-text field that contains a literal dispatch marker must not be able to
-// poison another dispatch's dedup. The renderer neutralizes HTML-comment openers in
-// the body, so dispatch B's real entry still writes even after A embedded B's marker.
+// forge another dispatch's marker. With the raw-tier redirect each dispatch is a
+// distinct 1:1 file, so A cannot suppress B's separate file; what the neutralize
+// guarantee still protects is that A's OWN file never contains a genuine
+// (un-neutralized) copy of B's marker that a marker-scanner could mistake for B's
+// real entry.
 func TestForgedMarkerDoesNotPoisonDedup(t *testing.T) {
 	d := newNotebookDaemon(t)
 
@@ -521,7 +644,7 @@ func TestForgedMarkerDoesNotPoisonDedup(t *testing.T) {
 			Summary:    "Embedding " + journalDispatchMarker("dsp-B") + " in my summary.",
 		},
 	})
-	// B's real entry must still land — its marker was not pre-written by A.
+	// B's real entry lands in its own file regardless.
 	d.journalDispatchOutcome(&protocol.ChiefOfStaffDispatch{
 		ID:         "dsp-B",
 		Label:      "Victim",
@@ -533,13 +656,21 @@ func TestForgedMarkerDoesNotPoisonDedup(t *testing.T) {
 		},
 	})
 
-	body := readJournalFile(t, d, "2026-06-14")
-	if !strings.Contains(body, "B's genuine outcome.") {
-		t.Fatalf("dispatch B was suppressed by a forged marker in A:\n%s", body)
+	bBody := readRawDispatchFile(t, d, "dsp-B")
+	if !strings.Contains(bBody, "B's genuine outcome.") {
+		t.Fatalf("dispatch B's own file is missing its outcome:\n%s", bBody)
 	}
-	// B's real marker appears exactly once (A's embedded copy was neutralized).
-	if n := strings.Count(body, journalDispatchMarker("dsp-B")); n != 1 {
-		t.Fatalf("B's marker count = %d, want 1 (A's copy should be neutralized):\n%s", n, body)
+	if n := strings.Count(bBody, journalDispatchMarker("dsp-B")); n != 1 {
+		t.Fatalf("B's file marker count = %d, want 1:\n%s", n, bBody)
+	}
+	// A's file embedded B's marker text in free prose; it must have been neutralized
+	// so A's file holds ZERO genuine B markers.
+	aBody := readRawDispatchFile(t, d, "dsp-A")
+	if n := strings.Count(aBody, journalDispatchMarker("dsp-B")); n != 0 {
+		t.Fatalf("A's file holds %d genuine B markers, want 0 (the forged copy must be neutralized):\n%s", n, aBody)
+	}
+	if !strings.Contains(aBody, "<! -- attn:dispatch:dsp-B -->") {
+		t.Fatalf("A's forged marker should be neutralized to a non-opener:\n%s", aBody)
 	}
 }
 

--- a/internal/daemon/notebook_raw_tier.go
+++ b/internal/daemon/notebook_raw_tier.go
@@ -1,0 +1,180 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/notebook"
+)
+
+// The raw tier is the deterministic capture floor for the notebook narration
+// pipeline. It holds machine inputs the narrate pass later consumes, under
+// <notebook.root>/.attn/raw/ — physically unreachable through the user-facing
+// notebook APIs (CleanPath rejects dotdir segments) and skipped by the watcher,
+// so raw writes emit no external-edit broadcast. Two deterministic daemon writes
+// land here and SHARE this one atomic writer + the one neutralizeJournalMarkers
+// step so they are built, reviewed, and tested together:
+//
+//   - context-snapshots/<wsID>.md — the synchronous context.md snapshot taken at
+//     every workspace-removal site, BEFORE store.RemoveWorkspace runs its
+//     DELETE FROM workspace_contexts (an async writer cannot win that race).
+//   - dispatches/<dispatchID>.md  — the redirected dispatch outcome capture (see
+//     notebook_dispatch_journal.go).
+//
+// They cannot collide: distinct per-item files under distinct subdirs, distinct
+// exactly-once ledgers (file existence + a source footer / marker), and both
+// bodies pass through neutralizeJournalMarkers so no free-text field can forge a
+// journal marker.
+
+// rawTierFilename turns a raw-tier item id (a workspace id or dispatch id) into a
+// single safe "<id>.md" filename, or errors if the id cannot be a single path
+// segment. This is the load-bearing guard that keeps a CLIENT-CONTROLLED id (the
+// workspace id from register_workspace is accepted verbatim over the socket, with
+// no UUID/segment validation) from escaping its raw-tier subdir: filepath.Join
+// cleans ".." segments, so an unvalidated id like "../../../journal/2026-06-15"
+// would resolve OUT of context-snapshots/ and overwrite the curated journal (or,
+// with enough "..", any .md file the daemon can write outside the notebook root).
+// The raw tier is supposed to be physically unreachable through the user-facing
+// notebook APIs, and the daemon must never write the curated journal; an id that
+// is not a plain filename violates both, so we reject it rather than join it.
+//
+// Dispatch ids are server UUIDs and never trip this, but routing both writers
+// through the same guard keeps the invariant in one place instead of resting on a
+// per-call-site property a future caller could quietly break.
+func rawTierFilename(id string) (string, error) {
+	return rawTierName(id, ".md")
+}
+
+// rawTierSegment validates a raw-tier id as a single safe path *segment* (no
+// extension), for callers that need a directory name rather than a "<id>.md"
+// file — e.g. partitioning the per-session digest dir by workspace id
+// (RawSessionsDir/<wsID>/). It applies the same containment guard as
+// rawTierFilename so a crafted id (workspace id from register_workspace is
+// accepted verbatim over the socket) can never climb out of the raw tier.
+func rawTierSegment(id string) (string, error) {
+	return rawTierName(id, "")
+}
+
+// rawTierName is the shared single-safe-segment guard. It trims, rejects path
+// separators / dotdir / control characters, optionally appends an extension, and
+// asserts the result round-trips through filepath.Base/Clean so an escaping id
+// cannot slip through. suffix is "" for a bare directory segment or ".md" for a
+// raw-tier file.
+func rawTierName(id, suffix string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("raw-tier id is empty")
+	}
+	if strings.ContainsAny(id, `/\`) || id == "." || id == ".." || strings.HasPrefix(id, ".") {
+		return "", fmt.Errorf("raw-tier id %q is not a single safe path segment", id)
+	}
+	// Reject control characters (newlines especially): an id is interpolated into
+	// the file's plaintext "source:" footer, so a newline would let it inject a
+	// forged grounding line, and a control char has no place in a filename anyway.
+	for _, r := range id {
+		if r < 0x20 || r == 0x7f {
+			return "", fmt.Errorf("raw-tier id %q contains a control character", id)
+		}
+	}
+	name := id + suffix
+	// Belt-and-suspenders: a Clean of the bare name must be the name itself (no
+	// separator, no dotdir reintroduced). filepath.Base of an escaping id would not
+	// round-trip to it.
+	if filepath.Base(name) != name || name != filepath.Clean(name) {
+		return "", fmt.Errorf("raw-tier id %q does not produce a safe filename", id)
+	}
+	return name, nil
+}
+
+// writeRawAtomic writes content to a raw-tier file built from dir + a validated
+// "<id>.md" filename, via a temp+rename so a reader never observes a half-written
+// file, MkdirAll'ing the parent first so a write never fails on a missing raw-tier
+// subdir. It mirrors notebook.writeAtomic / tasks.writeAtomic (no fsync, matching
+// the repo idiom). This is the one writer both deterministic raw-tier writes use,
+// and the single chokepoint that validates the id: callers pass the raw id and the
+// intended subdir, and the path is only ever dir/<safe-name> — never a join that
+// ".." could climb out of. A second containment assertion verifies the final path
+// stays under dir even if rawTierFilename is ever weakened.
+func writeRawAtomic(dir, id string, content []byte) error {
+	name, err := rawTierFilename(id)
+	if err != nil {
+		return err
+	}
+	absPath := filepath.Join(dir, name)
+	cleanDir := filepath.Clean(dir)
+	if filepath.Dir(absPath) != cleanDir {
+		return fmt.Errorf("raw-tier write for %q escapes %q", id, dir)
+	}
+	if err := os.MkdirAll(cleanDir, 0o755); err != nil {
+		return err
+	}
+	tmp := fmt.Sprintf("%s.tmp.%d.%d", absPath, os.Getpid(), time.Now().UnixNano())
+	if err := os.WriteFile(tmp, content, 0o644); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, absPath); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// snapshotWorkspaceContextOnRemove synchronously captures a workspace's
+// context.md overlay into the raw tier before the workspace row (and its
+// context.md) is deleted. It is the deterministic data-safety floor: context.md
+// is erased by store.RemoveWorkspace's DELETE FROM workspace_contexts, which an
+// async writer cannot win, so this MUST run at every removal site AFTER the
+// keeper compaction cancel/forget (commit-fence: no in-flight keeper compaction
+// write is still racing the context row) and BEFORE store.RemoveWorkspace.
+//
+// Best-effort: it never returns an error and never blocks or fails a teardown.
+// Every failure — read error, unresolvable/unconfigured notebook root, write
+// error — is logged and swallowed. An empty or revision-0 context (a workspace
+// that never had an overlay) is a silent no-op.
+//
+// The file is keyed 1:1 on the workspace id, so a replayed removal is a harmless
+// identical overwrite; existence of <wsID>.md plus the
+// "source: workspace-context:<id>@<revision>" footer is the exactly-once ledger
+// (no HTML-comment dedup marker is needed). title is used only for logging — the
+// file is keyed on id, so a blank title never breaks the write or the ledger.
+func (d *Daemon) snapshotWorkspaceContextOnRemove(id, title string) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return
+	}
+
+	canonical, err := d.store.GetWorkspaceContext(id)
+	if err != nil {
+		d.logf("context snapshot %s (%s): read context: %v", id, title, err)
+		return
+	}
+	if strings.TrimSpace(canonical.Content) == "" || canonical.Revision == 0 {
+		return // no overlay to preserve — silent no-op
+	}
+
+	root, err := d.notebookRoot()
+	if err != nil {
+		d.logf("context snapshot %s (%s): notebook root unavailable: %v", id, title, err)
+		return
+	}
+	if strings.TrimSpace(root) == "" {
+		return // notebook disabled — silent no-op
+	}
+
+	// Neutralize the verbatim overlay BEFORE appending the genuine source footer,
+	// so no free-text field in the body can forge a journal marker while the real
+	// footer stays intact (same pattern renderDispatchJournalEntry uses).
+	var doc strings.Builder
+	doc.WriteString(neutralizeJournalMarkers(canonical.Content))
+	fmt.Fprintf(&doc, "\nsource: workspace-context:%s@%d\n", id, canonical.Revision)
+
+	dir := notebook.RawContextSnapshotsDir(root)
+	if err := writeRawAtomic(dir, id, []byte(doc.String())); err != nil {
+		d.logf("context snapshot %s (%s): write under %s: %v", id, title, dir, err)
+		return
+	}
+}

--- a/internal/daemon/notebook_raw_tier_test.go
+++ b/internal/daemon/notebook_raw_tier_test.go
@@ -1,0 +1,321 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/notebook"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// readContextSnapshot returns the raw-tier context snapshot for a workspace
+// (.attn/raw/context-snapshots/<wsID>.md), or "" if it does not exist.
+func readContextSnapshot(t *testing.T, d *Daemon, wsID string) string {
+	t.Helper()
+	root, err := d.notebookRoot()
+	if err != nil {
+		t.Fatalf("notebook root: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(notebook.RawContextSnapshotsDir(root), wsID+".md"))
+	if errors.Is(err, os.ErrNotExist) {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("read context snapshot %s: %v", wsID, err)
+	}
+	return string(data)
+}
+
+// seedWorkspaceContext registers a workspace+session and seeds a revision-1
+// shared context with body, returning the daemon ready for a removal-site call.
+func seedWorkspaceContext(t *testing.T, d *Daemon, sessionID, workspaceID, body string) {
+	t.Helper()
+	setupWorkspaceContextSession(t, d, sessionID, workspaceID)
+	if _, _, err := d.store.UpdateWorkspaceContext(workspaceID, body, sessionID, 0); err != nil {
+		t.Fatalf("seed workspace context: %v", err)
+	}
+}
+
+// The snapshot must land at every removal site, BEFORE the workspace_contexts row
+// is deleted, with the source footer keyed on id@revision.
+func TestSnapshotWorkspaceContextAtRemovalSites(t *testing.T) {
+	cases := []struct {
+		name   string
+		wsID   string
+		remove func(d *Daemon, sessionID, workspaceID string)
+	}{
+		{
+			name: "handleUnregisterWorkspace",
+			wsID: "ws-unreg",
+			remove: func(d *Daemon, _, workspaceID string) {
+				d.handleUnregisterWorkspace(nil, &protocol.UnregisterWorkspaceMessage{ID: workspaceID})
+			},
+		},
+		{
+			name: "dissociateSessionFromWorkspace",
+			wsID: "ws-dissoc",
+			remove: func(d *Daemon, sessionID, _ string) {
+				d.dissociateSessionFromWorkspace(sessionID)
+			},
+		},
+		{
+			name: "unregisterWorkspaceIfEmptyAfterMove",
+			wsID: "ws-move",
+			remove: func(d *Daemon, sessionID, workspaceID string) {
+				// The session must be gone for the workspace to be considered empty.
+				d.workspaces.dissociateSession(sessionID)
+				d.store.Remove(sessionID)
+				d.unregisterWorkspaceIfEmptyAfterMove(workspaceID)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newNotebookDaemon(t)
+			seedWorkspaceContext(t, d, "session-1", tc.wsID, "# Decisions\nchose hash-CAS")
+
+			tc.remove(d, "session-1", tc.wsID)
+
+			// The row is gone (the removal completed) ...
+			if d.store.HasWorkspaceContext(tc.wsID) {
+				t.Fatal("workspace context row survived removal")
+			}
+			// ... yet the snapshot captured the body before the delete.
+			snap := readContextSnapshot(t, d, tc.wsID)
+			if !strings.Contains(snap, "chose hash-CAS") {
+				t.Fatalf("snapshot missing context body:\n%s", snap)
+			}
+			if !strings.Contains(snap, "source: workspace-context:"+tc.wsID+"@1") {
+				t.Fatalf("snapshot missing/incorrect source footer:\n%s", snap)
+			}
+		})
+	}
+}
+
+// The startup-reconciliation reap (loadWorkspacesFromStore) is the fourth removal
+// site. It runs before the compaction runner exists (compactRunner nil), and the
+// snapshot must still land — it does not touch the runner.
+func TestSnapshotWorkspaceContextAtLoadTimeReap(t *testing.T) {
+	d := newNotebookDaemon(t)
+	// Mimic production: an orphaned workspace row + context with no live session,
+	// reaped during Start() before startCompactRunner runs.
+	d.compactRunner = nil
+	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-orphan", Title: "orphan", Directory: "/repo/orphan"})
+	if _, _, err := d.store.UpdateWorkspaceContext("ws-orphan", "# Old context\nstale but durable", "s-orphan", 0); err != nil {
+		t.Fatalf("seed orphan context: %v", err)
+	}
+
+	d.workspaces = newWorkspaceRegistry()
+	d.loadWorkspacesFromStore() // must not panic with a nil runner
+
+	if d.store.GetWorkspace("ws-orphan") != nil {
+		t.Fatal("orphan workspace survived load reap")
+	}
+	snap := readContextSnapshot(t, d, "ws-orphan")
+	if !strings.Contains(snap, "stale but durable") {
+		t.Fatalf("load-reap snapshot missing context body:\n%s", snap)
+	}
+	if !strings.Contains(snap, "source: workspace-context:ws-orphan@1") {
+		t.Fatalf("load-reap snapshot missing source footer:\n%s", snap)
+	}
+}
+
+// An empty or never-written context is a silent no-op: no file is created.
+func TestSnapshotWorkspaceContextEmptyIsNoOp(t *testing.T) {
+	d := newNotebookDaemon(t)
+
+	// A workspace that never had a context overlay (revision 0).
+	d.snapshotWorkspaceContextOnRemove("ws-empty", "Empty workspace")
+	if snap := readContextSnapshot(t, d, "ws-empty"); snap != "" {
+		t.Fatalf("absent context should not write a snapshot:\n%s", snap)
+	}
+
+	// A workspace whose context is whitespace-only is also a no-op (its revision is
+	// >0, so this exercises the content-trim gate, not just the revision gate).
+	setupWorkspaceContextSession(t, d, "session-ws", "ws-blank")
+	if _, _, err := d.store.UpdateWorkspaceContext("ws-blank", "   \n\t", "session-ws", 0); err != nil {
+		t.Fatalf("seed blank context: %v", err)
+	}
+	d.snapshotWorkspaceContextOnRemove("ws-blank", "Blank")
+	if snap := readContextSnapshot(t, d, "ws-blank"); snap != "" {
+		t.Fatalf("whitespace-only context should not write a snapshot:\n%s", snap)
+	}
+}
+
+// A write failure must be swallowed: the helper returns normally and the teardown
+// is never blocked. We force failure by pointing the notebook root under a regular
+// file, so MkdirAll inside the atomic writer fails.
+func TestSnapshotWorkspaceContextSwallowsWriteFailure(t *testing.T) {
+	d := newNotebookDaemon(t)
+	setupWorkspaceContextSession(t, d, "session-1", "ws-fail")
+	if _, _, err := d.store.UpdateWorkspaceContext("ws-fail", "real content", "session-1", 0); err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed blocker file: %v", err)
+	}
+	d.store.SetSetting(SettingNotebookRoot, filepath.Join(blocker, "notebook"))
+
+	// Must not panic and must complete; the full removal path still tears down.
+	d.handleUnregisterWorkspace(nil, &protocol.UnregisterWorkspaceMessage{ID: "ws-fail"})
+
+	if d.store.GetWorkspace("ws-fail") != nil {
+		t.Fatal("workspace must still be removed when the snapshot write fails")
+	}
+}
+
+// A replayed removal is a harmless identical overwrite — the 1:1 <wsID>.md keying
+// means a second snapshot of the same revision reproduces byte-identical content.
+func TestSnapshotWorkspaceContextReplayIsIdenticalOverwrite(t *testing.T) {
+	d := newNotebookDaemon(t)
+	seedWorkspaceContext(t, d, "session-1", "ws-replay", "# Decisions\nlocked the design")
+
+	d.snapshotWorkspaceContextOnRemove("ws-replay", "Replay")
+	first := readContextSnapshot(t, d, "ws-replay")
+	if first == "" {
+		t.Fatal("first snapshot did not write")
+	}
+
+	// The row still exists (we called the helper directly, not the full removal), so
+	// a replay reads the same revision-1 content and overwrites identically.
+	d.snapshotWorkspaceContextOnRemove("ws-replay", "Replay")
+	second := readContextSnapshot(t, d, "ws-replay")
+	if second != first {
+		t.Fatalf("replay was not an identical overwrite:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// A context body that embeds a literal journal marker must be neutralized so no
+// free-text overlay content can forge a marker in the raw tier.
+func TestSnapshotWorkspaceContextNeutralizesForgedMarker(t *testing.T) {
+	d := newNotebookDaemon(t)
+	forged := "Notes\n" + journalDispatchMarker("dsp-victim") + "\nmore notes"
+	seedWorkspaceContext(t, d, "session-1", "ws-forge", forged)
+
+	d.snapshotWorkspaceContextOnRemove("ws-forge", "Forge")
+
+	snap := readContextSnapshot(t, d, "ws-forge")
+	if strings.Contains(snap, journalDispatchMarker("dsp-victim")) {
+		t.Fatalf("forged marker survived neutralization:\n%s", snap)
+	}
+	if !strings.Contains(snap, "<! -- attn:dispatch:dsp-victim -->") {
+		t.Fatalf("forged marker should be neutralized to a non-opener:\n%s", snap)
+	}
+}
+
+// A crafted workspace id with ".." segments must NOT let the snapshot writer escape
+// the context-snapshots subdir. register_workspace accepts the id verbatim over the
+// socket, so an id like "../../../journal/<date>" would otherwise resolve out of the
+// raw tier and overwrite the curated journal (or, with more "..", any .md file the
+// daemon can write outside the notebook root). The write must be refused: no file is
+// created at the escape target, and the workspace context row is irrelevant because
+// the body never reaches disk.
+func TestSnapshotWorkspaceContextRejectsPathTraversal(t *testing.T) {
+	cases := []struct {
+		name      string
+		craftedID string
+		// target is the absolute escape path the unguarded join would have written,
+		// expressed relative to the notebook root or its parent.
+		target func(root string) string
+	}{
+		{
+			name:      "into the curated journal",
+			craftedID: "../../../journal/2026-06-15",
+			target:    func(root string) string { return filepath.Join(root, "journal", "2026-06-15.md") },
+		},
+		{
+			name:      "outside the notebook root",
+			craftedID: "../../../../victim",
+			target:    func(root string) string { return filepath.Join(filepath.Dir(root), "victim.md") },
+		},
+		{
+			name:      "absolute path escape",
+			craftedID: "/etc/attn-victim",
+			target:    func(root string) string { return filepath.Join(root, "etc", "attn-victim.md") },
+		},
+		{
+			name:      "nested subdir escape",
+			craftedID: "../dispatches/dsp-victim",
+			target: func(root string) string {
+				return filepath.Join(notebook.RawDispatchesDir(root), "dsp-victim.md")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newNotebookDaemon(t)
+			root, err := d.notebookRoot()
+			if err != nil {
+				t.Fatalf("notebook root: %v", err)
+			}
+
+			// Plant a sentinel at the escape target so a successful escape would be an
+			// observable overwrite, not just a fresh write.
+			victim := tc.target(root)
+			if err := os.MkdirAll(filepath.Dir(victim), 0o755); err != nil {
+				t.Fatalf("mkdir victim dir: %v", err)
+			}
+			if err := os.WriteFile(victim, []byte("SENTINEL — must survive"), 0o644); err != nil {
+				t.Fatalf("seed sentinel: %v", err)
+			}
+
+			seedWorkspaceContext(t, d, "session-evil", tc.craftedID, "ATTACKER CONTROLLED CONTENT")
+			d.snapshotWorkspaceContextOnRemove(tc.craftedID, "evil")
+
+			data, err := os.ReadFile(victim)
+			if err != nil {
+				t.Fatalf("read sentinel: %v", err)
+			}
+			if string(data) != "SENTINEL — must survive" {
+				t.Fatalf("path traversal overwrote %s:\n%s", victim, string(data))
+			}
+		})
+	}
+}
+
+// The shared raw-tier writer is the single chokepoint and must reject an unsafe id
+// directly, independent of the snapshot call site, so a future caller cannot
+// reintroduce the escape.
+func TestWriteRawAtomicRejectsUnsafeID(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "raw", "context-snapshots")
+
+	for _, id := range []string{
+		"",
+		".",
+		"..",
+		"../escape",
+		"../../journal/2026-06-15",
+		"/etc/passwd",
+		"a/b",
+		`a\b`,
+		".hidden",
+		// Control chars: a newline in the id would otherwise inject a forged
+		// "source:" footer line into the file body (the id is interpolated there).
+		"ws\nsource: workspace-context:victim@9",
+		"ws\x00null",
+		"ws\x7fdel",
+	} {
+		if err := writeRawAtomic(dir, id, []byte("x")); err == nil {
+			t.Fatalf("writeRawAtomic accepted unsafe id %q", id)
+		}
+	}
+
+	// A normal id still writes to exactly dir/<id>.md and nowhere else.
+	if err := writeRawAtomic(dir, "ws-ok", []byte("ok")); err != nil {
+		t.Fatalf("writeRawAtomic rejected a safe id: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "ws-ok.md"))
+	if err != nil {
+		t.Fatalf("safe id did not write to dir/<id>.md: %v", err)
+	}
+	if string(data) != "ok" {
+		t.Fatalf("safe write produced wrong content: %q", string(data))
+	}
+}

--- a/internal/daemon/workspace_keeper.go
+++ b/internal/daemon/workspace_keeper.go
@@ -1,0 +1,651 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/tasks"
+)
+
+const (
+	// keeperCompactUpdater is the updated_by_session_id sentinel written when the
+	// keeper's compaction duty rewrites a workspace context. It is a PERSISTED
+	// identifier (stored in workspace_contexts.updated_by_session_id and
+	// string-matched in the frontend navigator); migration 51 realigns existing
+	// rows from the old "attn-janitor" value to this one.
+	keeperCompactUpdater          = "attn-keeper"
+	defaultKeeperCompactThreshold = 12 * 1024
+	defaultKeeperCompactDebounce  = 10 * time.Minute
+	defaultKeeperCompactTimeout   = 5 * time.Minute
+)
+
+type keeperCompactConfig struct {
+	Agent string `json:"agent"`
+	Model string `json:"model"`
+}
+
+type keeperCompactExecution struct {
+	Candidate          string
+	ResolvedExecutable string
+	Diagnostics        string
+}
+
+func parseKeeperCompactConfig(raw string) (keeperCompactConfig, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return keeperCompactConfig{}, nil
+	}
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var config keeperCompactConfig
+	if err := decoder.Decode(&config); err != nil {
+		return keeperCompactConfig{}, fmt.Errorf("invalid keeper compact configuration: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return keeperCompactConfig{}, fmt.Errorf("invalid keeper compact configuration: %w", err)
+	}
+	config.Agent = strings.TrimSpace(strings.ToLower(config.Agent))
+	config.Model = strings.TrimSpace(config.Model)
+	if config.Agent == "" || config.Model == "" {
+		return keeperCompactConfig{}, errors.New("keeper compact requires both agent and model")
+	}
+	driver := agentdriver.Get(config.Agent)
+	if driver == nil {
+		return keeperCompactConfig{}, fmt.Errorf("keeper compact agent is not installed: %s", config.Agent)
+	}
+	if _, ok := driver.(agentdriver.HeadlessTaskProvider); !ok {
+		return keeperCompactConfig{}, fmt.Errorf("agent %s does not support headless tasks", config.Agent)
+	}
+	if available, reason := agentdriver.HeadlessTaskAvailability(driver); !available {
+		return keeperCompactConfig{}, fmt.Errorf("agent %s cannot run headless tasks: %s", config.Agent, reason)
+	}
+	return config, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); errors.Is(err, io.EOF) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	return errors.New("unexpected trailing JSON")
+}
+
+func (d *Daemon) validateKeeperCompactSetting(raw string) error {
+	config, err := parseKeeperCompactConfig(raw)
+	if err != nil || config.Agent == "" {
+		return err
+	}
+	driver := agentdriver.Get(config.Agent)
+	configured := ""
+	if d.store != nil {
+		configured = d.store.GetSetting(canonicalExecutableSettingKey(config.Agent))
+	}
+	executable := driver.ResolveExecutable(configured)
+	if _, err := exec.LookPath(executable); err != nil {
+		return fmt.Errorf("keeper compact executable for %s was not found: %w", config.Agent, err)
+	}
+	return nil
+}
+
+func (d *Daemon) keeperCompactConfig() (keeperCompactConfig, error) {
+	if d.store == nil {
+		return keeperCompactConfig{}, errors.New("keeper compact settings unavailable")
+	}
+	return parseKeeperCompactConfig(d.store.GetSetting(SettingKeeperCompact))
+}
+
+// legacyKeeperCompactSettingKey is the pre-rename persisted settings key. It is
+// retained ONLY so migrateKeeperCompactSettingKey can copy a user's configured
+// agent/model forward to SettingKeeperCompact. Never read it anywhere else.
+const legacyKeeperCompactSettingKey = "workspace_context_janitor"
+
+// migrateKeeperCompactSettingKey performs the one-time rename of the persisted
+// "workspace_context_janitor" setting to "workspace_keeper_compact"
+// (SettingKeeperCompact). It runs at daemon start — and therefore again after
+// every app rebuild, since the daemon survives rebuilds — so it MUST be
+// idempotent. It copies the legacy value forward only when the legacy key holds
+// a non-empty value AND the new key is still empty, so a re-run never clobbers a
+// value the user has since set under the new key. After copying it deletes the
+// stale legacy row so the migration is a true no-op on the next boot (and the
+// dead key never appears in the broadcast settings map). This is a plain
+// settings-value copy, NOT a schema migration — it is unrelated to
+// schema_migrations.
+func (d *Daemon) migrateKeeperCompactSettingKey() {
+	if d.store == nil {
+		return
+	}
+	legacy := d.store.GetSetting(legacyKeeperCompactSettingKey)
+	if strings.TrimSpace(legacy) == "" {
+		return // nothing to migrate (or already migrated + cleaned up)
+	}
+	if strings.TrimSpace(d.store.GetSetting(SettingKeeperCompact)) == "" {
+		// Carry the raw legacy value forward to preserve it exactly.
+		d.store.SetSetting(SettingKeeperCompact, legacy)
+		d.logf("migrated setting %q -> %q", legacyKeeperCompactSettingKey, SettingKeeperCompact)
+	}
+	// Drop the stale row so the migration is a true no-op on the next boot.
+	d.store.DeleteSetting(legacyKeeperCompactSettingKey)
+}
+
+// compactContextKind is the runner task kind for workspace-context compaction.
+const compactContextKind = "compact_context"
+
+// forgetWorkspaceContextCompaction drops any in-flight or pending compaction for a
+// workspace AND deletes its task record. It is the single nil-safe entry point:
+// the runner is constructed late in Start() (startCompactRunner, after the
+// websocket server is already accepting connections), so every teardown callsite —
+// including the ones reachable over the websocket before the runner exists — must
+// route through here rather than dereferencing d.compactRunner directly. Remove
+// (not Cancel) is used so a removed workspace leaves no orphan compact_context
+// record behind: Cancel alone is a no-op for a queued task and never deletes the
+// record.
+func (d *Daemon) forgetWorkspaceContextCompaction(workspaceID string) {
+	runner := d.compactRunnerRef()
+	if runner == nil {
+		return
+	}
+	runner.Remove(tasks.TaskID(compactContextKind, workspaceID))
+}
+
+// compactRunnerRef reads the compaction/narration runner pointer under the
+// read lock, so a concurrent startCompactRunner pointer swap is race-free. It
+// returns the same value the field holds (possibly nil before startCompactRunner
+// runs, possibly a disabled runner when no notebook root resolves) — callers keep
+// their existing nil/Disabled guards.
+func (d *Daemon) compactRunnerRef() *tasks.Runner {
+	d.compactRunnerMu.RLock()
+	defer d.compactRunnerMu.RUnlock()
+	return d.compactRunner
+}
+
+// setCompactRunner publishes a freshly built runner under the write lock. Only
+// startCompactRunner calls it; everything else reads via compactRunnerRef.
+func (d *Daemon) setCompactRunner(runner *tasks.Runner) {
+	d.compactRunnerMu.Lock()
+	d.compactRunner = runner
+	d.compactRunnerMu.Unlock()
+}
+
+// startCompactRunner constructs and starts the durable compaction runner. The
+// runner root is the notebook root; when it cannot be resolved the runner is
+// disabled and the daemon degrades to the inline fallback (see
+// enqueueWorkspaceContextCompaction). New always returns a non-nil value, so the
+// Cancel/Enqueue callsites can call d.compactRunner unconditionally.
+func (d *Daemon) startCompactRunner() {
+	root, _ := d.notebookRoot()
+	// Build and register on a LOCAL pointer, then publish it once under the write
+	// lock. Registering on the local (not the published field) keeps a concurrent
+	// reader from ever observing a half-registered runner, and the single
+	// setCompactRunner swap is what Stop()/enqueue/forget synchronize against.
+	runner := tasks.New(tasks.Options{Root: root, Log: d.logf})
+	if !runner.Disabled() {
+		if err := runner.RegisterWithTimeout(
+			compactContextKind,
+			d.compactContextExecutor,
+			d.keeperCompactTimeoutDuration(),
+		); err != nil {
+			d.logf("keeper compact: register compact_context: %v", err)
+		}
+		// Notebook narration shares the same durable runner (same root, same
+		// disabled-when-no-root gate). Both narration executors run native-tools
+		// agents and verify a written file rather than committing a read-back.
+		if err := runner.RegisterWithTimeout(
+			notebookSummarizeSessionKind,
+			d.summarizeSessionExecutor,
+			notebookSummarizeSessionTimeout,
+		); err != nil {
+			d.logf("notebook narration: register summarize_session: %v", err)
+		}
+		if err := runner.RegisterWithTimeout(
+			notebookNarrateWorkspaceKind,
+			d.narrateWorkspaceExecutor,
+			notebookNarrateWorkspaceTimeout,
+		); err != nil {
+			d.logf("notebook narration: register narrate_workspace: %v", err)
+		}
+	}
+	// Surface lifecycle transitions to any open task panel. OnChange fires
+	// SYNCHRONOUSLY inside the runner's single worker goroutine, so the callback
+	// must be cheap and non-blocking: broadcastNotebookTasksChanged ->
+	// broadcastMessage -> wsHub.BroadcastValue uses a non-blocking send that drops
+	// on a full broadcast channel, so it can never stall the worker.
+	runner.OnChange(func() { d.broadcastNotebookTasksChanged() })
+	d.setCompactRunner(runner)
+	_ = runner.Start()
+}
+
+// enqueueWorkspaceContextCompaction is THE trigger callsite. It carries the
+// size-threshold gate, the non-empty-workspaceID guard, and the loaded-config
+// guard that used to live in the pre-runner scheduler. When the runner is
+// enabled it coalesces a debounced compaction onto the per-workspace task;
+// otherwise (no notebook root) it runs the compaction inline/synchronously so
+// compaction still happens.
+func (d *Daemon) enqueueWorkspaceContextCompaction(canonical *protocol.WorkspaceContext) {
+	if canonical == nil || strings.TrimSpace(canonical.WorkspaceID) == "" {
+		return
+	}
+	config, err := d.keeperCompactConfig()
+	if err != nil {
+		d.logf("keeper compact: configuration: %v", err)
+		return
+	}
+	if config.Agent == "" {
+		return
+	}
+	if len([]byte(canonical.Content)) <= d.keeperCompactSizeThreshold() {
+		return
+	}
+	runner := d.compactRunnerRef()
+	if runner == nil || runner.Disabled() {
+		// Inline fallback: no durable queue, no debounce, no retry. Compaction
+		// still happens, synchronously, on the trigger.
+		// runWorkspaceContextCompactionInline applies the per-run timeout.
+		if _, err := d.runWorkspaceContextCompactionInline(context.Background(), config, canonical); err != nil {
+			d.logf("keeper compact: inline compact %s: %v", canonical.WorkspaceID, err)
+		}
+		return
+	}
+	if _, err := runner.Enqueue(compactContextKind, canonical.WorkspaceID, tasks.EnqueueOptions{
+		Debounce: d.keeperCompactDebounceDuration(),
+	}); err != nil {
+		d.logf("keeper compact: enqueue %s: %v", canonical.WorkspaceID, err)
+	}
+}
+
+// compactContextExecutor is the runner-registered ExecutorFunc for
+// compact_context. The runner supplies the timeout context and the per-run
+// CommitGuard; this body loads the current context, re-checks the size threshold
+// (the doc may have shrunk during the debounce window), runs the agentic
+// compaction, validates, and commits under the guard.
+func (d *Daemon) compactContextExecutor(ctx context.Context, task *tasks.Task) error {
+	workspaceID := task.Subject
+	config, err := d.keeperCompactConfig()
+	if err != nil {
+		return err
+	}
+	if config.Agent == "" {
+		return errors.New("keeper compact is disabled")
+	}
+	canonical, err := d.store.GetWorkspaceContext(workspaceID)
+	if err != nil {
+		return err
+	}
+	// Re-check the size gate after the debounce: a doc edited down below the
+	// threshold should not burn an LLM pass. No-op success.
+	if len([]byte(canonical.Content)) <= d.keeperCompactSizeThreshold() {
+		return nil
+	}
+	_, err = d.applyWorkspaceContextCompaction(ctx, config, canonical, task.CommitGuard)
+	return err
+}
+
+// runWorkspaceContextCompactionInline runs execute+validate+apply synchronously
+// without the durable queue. It is used by the disabled-runner fallback and by
+// the manual `attn workspace context compact` command, which must return a
+// result synchronously. It uses a throwaway CommitGuard (no concurrent Cancel
+// fences an inline run, but the apply path is shared so it must take a guard).
+//
+// It applies the same per-run timeout the runner-driven path gets from
+// RegisterWithTimeout, so a hung/runaway agent cannot block an inline run (the
+// disabled-runner fallback) or the synchronous manual-command IPC response
+// indefinitely. This is the SOLE timeout boundary for both inline callers.
+func (d *Daemon) runWorkspaceContextCompactionInline(
+	ctx context.Context,
+	config keeperCompactConfig,
+	canonical *protocol.WorkspaceContext,
+) (*protocol.WorkspaceContextMaintenanceResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, d.keeperCompactTimeoutDuration())
+	defer cancel()
+	return d.applyWorkspaceContextCompaction(ctx, config, canonical, &tasks.CommitGuard{})
+}
+
+// applyWorkspaceContextCompaction is the single execute+validate+apply helper
+// shared by the runner executor, the inline fallback, and the manual command.
+// It runs the agentic compaction, validates the candidate, then commits under
+// the supplied CommitGuard so a concurrent Cancel either fences the run cleanly
+// before the durable write or waits for it to finish untorn.
+func (d *Daemon) applyWorkspaceContextCompaction(
+	ctx context.Context,
+	config keeperCompactConfig,
+	canonical *protocol.WorkspaceContext,
+	guard *tasks.CommitGuard,
+) (*protocol.WorkspaceContextMaintenanceResult, error) {
+	if canonical == nil || strings.TrimSpace(canonical.WorkspaceID) == "" {
+		return nil, errors.New("workspace context is required")
+	}
+	execute := d.executeKeeperCompact
+	if d.workspaceContextCompactionExecution != nil {
+		execute = d.workspaceContextCompactionExecution
+	}
+	execution, err := execute(ctx, config, canonical)
+	if err != nil {
+		return nil, err
+	}
+	candidate := execution.Candidate
+	if err := validateKeeperCompactCandidate(canonical.Content, candidate); err != nil {
+		return nil, err
+	}
+
+	// Enter the commit fence BEFORE the test hook. Once admitted, a concurrent
+	// Cancel must wait for the durable write to finish untorn; the test hook then
+	// blocks inside the admitted commit so a test can prove the fence holds. If a
+	// Cancel already fired before Enter, skip the durable write entirely.
+	if !guard.Enter() {
+		return nil, context.Canceled
+	}
+	defer guard.Leave()
+	if d.workspaceContextBeforeKeeperApply != nil {
+		d.workspaceContextBeforeKeeperApply()
+	}
+
+	updated, changed, err := d.store.ApplyKeeperCompactResult(
+		canonical.WorkspaceID,
+		candidate,
+		keeperCompactUpdater,
+		canonical.Revision,
+		config.Agent,
+		config.Model,
+	)
+	if err != nil {
+		return nil, err
+	}
+	result := &protocol.WorkspaceContextMaintenanceResult{
+		Action:         protocol.WorkspaceContextMaintenanceActionCompact,
+		WorkspaceID:    canonical.WorkspaceID,
+		SourceRevision: canonical.Revision,
+		ResultRevision: updated.Revision,
+		Changed:        changed,
+		Agent:          protocol.Ptr(config.Agent),
+		AgentModel:     protocol.Ptr(config.Model),
+	}
+	if changed {
+		d.refreshCleanWorkspaceContextCheckouts(updated)
+		d.broadcastWorkspaceContextChanged(updated)
+	}
+	if execution.ResolvedExecutable != "" {
+		d.logf(
+			"keeper compact: workspace=%s agent=%s model=%s executable=%s changed=%t diagnostics=%s",
+			canonical.WorkspaceID,
+			config.Agent,
+			config.Model,
+			execution.ResolvedExecutable,
+			changed,
+			execution.Diagnostics,
+		)
+	}
+	return result, nil
+}
+
+func (d *Daemon) keeperCompactSizeThreshold() int {
+	if d.keeperCompactThreshold > 0 {
+		return d.keeperCompactThreshold
+	}
+	return defaultKeeperCompactThreshold
+}
+
+func (d *Daemon) keeperCompactDebounceDuration() time.Duration {
+	if d.keeperCompactDebounce > 0 {
+		return d.keeperCompactDebounce
+	}
+	return defaultKeeperCompactDebounce
+}
+
+func (d *Daemon) keeperCompactTimeoutDuration() time.Duration {
+	if d.keeperCompactTimeout > 0 {
+		return d.keeperCompactTimeout
+	}
+	return defaultKeeperCompactTimeout
+}
+
+func (d *Daemon) executeKeeperCompact(
+	ctx context.Context,
+	config keeperCompactConfig,
+	canonical *protocol.WorkspaceContext,
+) (keeperCompactExecution, error) {
+	driver := agentdriver.Get(config.Agent)
+	if driver == nil {
+		return keeperCompactExecution{}, fmt.Errorf("keeper compact agent not found: %s", config.Agent)
+	}
+	provider, ok := driver.(agentdriver.HeadlessTaskProvider)
+	if !ok {
+		return keeperCompactExecution{}, fmt.Errorf("agent %s does not support headless tasks", config.Agent)
+	}
+	configured := d.store.GetSetting(canonicalExecutableSettingKey(config.Agent))
+	resolvedExecutable := driver.ResolveExecutable(configured)
+	executablePath, err := exec.LookPath(resolvedExecutable)
+	if err != nil {
+		return keeperCompactExecution{}, fmt.Errorf("resolve %s executable: %w", config.Agent, err)
+	}
+	tempDir, err := os.MkdirTemp("", "attn-keeper-compact-*")
+	if err != nil {
+		return keeperCompactExecution{}, fmt.Errorf("create keeper compact workspace: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	sourcePath := filepath.Join(tempDir, "source.md")
+	candidatePath := filepath.Join(tempDir, "candidate.md")
+	if err := os.WriteFile(sourcePath, []byte(canonical.Content), 0o600); err != nil {
+		return keeperCompactExecution{}, fmt.Errorf("write keeper compact source: %w", err)
+	}
+	// Native-tools mode: the agent gets its own file tools and a writable scratch
+	// dir (WorkDir). It reads the source and writes the candidate itself; the
+	// daemon reads the candidate back and owns validation + commit.
+	request := agentdriver.HeadlessTaskRequest{
+		Executable: executablePath,
+		Model:      config.Model,
+		Prompt:     fmt.Sprintf(keeperCompactPrompt, sourcePath, candidatePath),
+		WorkDir:    tempDir,
+	}
+	result, err := provider.RunHeadlessTask(ctx, request)
+	if err != nil {
+		return keeperCompactExecution{
+			ResolvedExecutable: executablePath,
+			Diagnostics:        result.Diagnostics,
+		}, err
+	}
+	candidate, err := os.ReadFile(candidatePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return keeperCompactExecution{
+			ResolvedExecutable: executablePath,
+			Diagnostics:        result.Diagnostics,
+		}, errors.New("keeper compact completed without replacing the context")
+	} else if err != nil {
+		return keeperCompactExecution{}, fmt.Errorf("read keeper compact candidate: %w", err)
+	}
+	return keeperCompactExecution{
+		Candidate:          string(candidate),
+		ResolvedExecutable: executablePath,
+		Diagnostics:        result.Diagnostics,
+	}, nil
+}
+
+// keeperCompactPrompt is a format string: the two %s are the absolute
+// source path (to read) and candidate path (to write). Absolute paths are robust
+// regardless of how the agent resolves cwd, and both providers' file tools accept
+// absolute paths inside the writable workspace.
+const keeperCompactPrompt = `Compact the workspace context file without changing its meaning.
+
+Read the file at %s. Write the complete compacted result to %s. Do not modify any other file. Write the candidate file exactly once with the full result; do not leave it empty.
+
+Preserve:
+- Area and all current truths
+- unresolved open edges
+- decisions and constraints
+- source links and useful timeline turning points
+
+You may shorten prose, deduplicate facts, and merge overlapping Threads. Remove stale or superseded material only when the document itself establishes that it is stale or superseded.
+
+Do not add facts, dates, chronology, causality, ownership, thread structure, or conclusions. If uncertain, preserve the content. A byte-identical copy is valid.
+
+The result must contain exactly one "# Workspace Context" heading, a non-empty "## Area", and a non-empty "## Current Picture".`
+
+func validateKeeperCompactCandidate(source, candidate string) error {
+	if len([]byte(candidate)) > len([]byte(source)) {
+		return fmt.Errorf("keeper compact candidate grew from %d to %d bytes", len([]byte(source)), len([]byte(candidate)))
+	}
+	lines := splitMarkdownLines(candidate)
+	if firstNonEmptyLine(lines) != "# Workspace Context" {
+		return errors.New(`keeper compact candidate must start with "# Workspace Context"`)
+	}
+	if countExactLine(lines, "# Workspace Context") != 1 {
+		return errors.New(`keeper compact candidate must contain exactly one "# Workspace Context" heading`)
+	}
+	if countTopLevelHeadings(lines) != 1 {
+		return errors.New("keeper compact candidate must contain exactly one top-level heading")
+	}
+	for _, heading := range []string{"## Area", "## Current Picture"} {
+		if countExactLine(lines, heading) != 1 {
+			return fmt.Errorf("keeper compact candidate must contain exactly one %q heading", heading)
+		}
+		if strings.TrimSpace(markdownSectionContent(lines, heading)) == "" {
+			return fmt.Errorf("keeper compact candidate section %q is empty", heading)
+		}
+	}
+	return nil
+}
+
+func splitMarkdownLines(content string) []string {
+	raw := strings.Split(content, "\n")
+	lines := make([]string, 0, len(raw))
+	for _, line := range raw {
+		lines = append(lines, strings.TrimSpace(line))
+	}
+	return lines
+}
+
+func firstNonEmptyLine(lines []string) string {
+	for _, line := range lines {
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+func countExactLine(lines []string, want string) int {
+	count := 0
+	for _, line := range lines {
+		if line == want {
+			count++
+		}
+	}
+	return count
+}
+
+func countTopLevelHeadings(lines []string) int {
+	count := 0
+	for _, line := range lines {
+		if strings.HasPrefix(line, "# ") {
+			count++
+		}
+	}
+	return count
+}
+
+func markdownSectionContent(lines []string, heading string) string {
+	start := -1
+	for index, line := range lines {
+		if line == heading {
+			start = index + 1
+			break
+		}
+	}
+	if start < 0 {
+		return ""
+	}
+	var content []string
+	for _, line := range lines[start:] {
+		if strings.HasPrefix(line, "## ") {
+			break
+		}
+		content = append(content, line)
+	}
+	return strings.Join(content, "\n")
+}
+
+func (d *Daemon) refreshCleanWorkspaceContextCheckouts(canonical *protocol.WorkspaceContext) {
+	// Existing checkout files are agent-owned working copies. Replacing one can
+	// discard a write from an editor that still holds the old inode open. Leave
+	// all checkouts untouched; their prior metadata makes them stale against the
+	// new canonical revision, so the normal refresh/conflict workflow preserves
+	// both clean and modified local state.
+}
+
+func (d *Daemon) broadcastWorkspaceContextChanged(canonical *protocol.WorkspaceContext) {
+	d.broadcastMessage(protocol.WorkspaceContextChangedMessage{
+		Event:              protocol.EventWorkspaceContextChanged,
+		WorkspaceID:        canonical.WorkspaceID,
+		Revision:           canonical.Revision,
+		UpdatedBySessionID: canonical.UpdatedBySessionID,
+		UpdatedAt:          canonical.UpdatedAt,
+	})
+}
+
+func (d *Daemon) compactWorkspaceContextForSession(
+	ctx context.Context,
+	sourceSessionID string,
+) (*protocol.WorkspaceContextMaintenanceResult, error) {
+	session, err := d.resolveWorkspaceContextSource(sourceSessionID)
+	if err != nil {
+		return nil, err
+	}
+	canonical, err := d.store.GetWorkspaceContext(session.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(canonical.Content) == "" {
+		return nil, errors.New("workspace context is empty")
+	}
+	config, err := d.keeperCompactConfig()
+	if err != nil {
+		return nil, err
+	}
+	if config.Agent == "" {
+		return nil, errors.New("keeper compact is disabled")
+	}
+	// Drop any pending/in-flight debounced run so the manual command is
+	// authoritative, then run the inline execute+validate+apply path synchronously
+	// so the command can return a result to the user. Remove cancels any in-flight
+	// run (blocking until it exits) and deletes a pending record, so a queued run
+	// cannot fire again after the manual one and double-compact.
+	d.forgetWorkspaceContextCompaction(session.WorkspaceID)
+	return d.runWorkspaceContextCompactionInline(ctx, config, canonical)
+}
+
+func (d *Daemon) rollbackWorkspaceContextForSession(
+	sourceSessionID string,
+) (*protocol.WorkspaceContextMaintenanceResult, error) {
+	session, err := d.resolveWorkspaceContextSource(sourceSessionID)
+	if err != nil {
+		return nil, err
+	}
+	current, err := d.store.GetWorkspaceContext(session.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := d.store.RestoreKeeperCompactBackup(session.WorkspaceID, session.ID)
+	if err != nil {
+		return nil, err
+	}
+	d.refreshCleanWorkspaceContextCheckouts(updated)
+	d.broadcastWorkspaceContextChanged(updated)
+	return &protocol.WorkspaceContextMaintenanceResult{
+		Action:         protocol.WorkspaceContextMaintenanceActionRollback,
+		WorkspaceID:    session.WorkspaceID,
+		SourceRevision: current.Revision,
+		ResultRevision: updated.Revision,
+		Changed:        true,
+	}, nil
+}

--- a/internal/daemon/workspace_keeper_test.go
+++ b/internal/daemon/workspace_keeper_test.go
@@ -1,0 +1,794 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/tasks"
+)
+
+const (
+	keeperSource = `# Workspace Context
+
+## Area
+
+Workspace context product work and operational use.
+
+## Current Picture
+
+The current document is longer than it needs to be, but its facts remain useful.
+
+## Threads
+
+### Context model
+- Now: The area-map format is being implemented.
+`
+	keeperCandidate = `# Workspace Context
+
+## Area
+
+Workspace context product work and use.
+
+## Current Picture
+
+The area-map format is being implemented.
+`
+)
+
+// installTestCompactRunner replaces the daemon's default disabled runner with an
+// enabled one over a temp root, registers the real compact_context executor (so
+// the executor's load/threshold/validate/commit-under-CommitGuard logic runs for
+// real), and starts the worker. The fake compaction execution is injected via
+// d.workspaceContextCompactionExecution so no real LLM is spawned. A fast poll
+// interval avoids real-time waits.
+func installTestCompactRunner(t *testing.T, d *Daemon) {
+	t.Helper()
+	runner := tasks.New(tasks.Options{
+		Root:         t.TempDir(),
+		Log:          func(string, ...interface{}) {},
+		PollInterval: 2 * time.Millisecond,
+	})
+	if err := runner.RegisterWithTimeout(
+		compactContextKind,
+		d.compactContextExecutor,
+		d.keeperCompactTimeoutDuration(),
+	); err != nil {
+		t.Fatalf("register compact_context: %v", err)
+	}
+	if err := runner.Start(); err != nil {
+		t.Fatalf("start runner: %v", err)
+	}
+	t.Cleanup(runner.Stop)
+	d.compactRunner = runner
+}
+
+func fakeCompaction(candidate string) func(
+	context.Context, keeperCompactConfig, *protocol.WorkspaceContext,
+) (keeperCompactExecution, error) {
+	return func(
+		context.Context, keeperCompactConfig, *protocol.WorkspaceContext,
+	) (keeperCompactExecution, error) {
+		return keeperCompactExecution{Candidate: candidate}, nil
+	}
+}
+
+func TestParseKeeperCompactConfig(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		config, err := parseKeeperCompactConfig("")
+		if err != nil || config.Agent != "" || config.Model != "" {
+			t.Fatalf("config = %+v, err = %v", config, err)
+		}
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		config, err := parseKeeperCompactConfig(`{"agent":"CODEX","model":"gpt-test"}`)
+		if err != nil {
+			t.Fatalf("parse config: %v", err)
+		}
+		if config.Agent != "codex" || config.Model != "gpt-test" {
+			t.Fatalf("config = %+v", config)
+		}
+	})
+
+	for name, raw := range map[string]string{
+		"missing model": `{"agent":"codex"}`,
+		"unknown field": `{"agent":"codex","model":"gpt-test","fallback":"claude"}`,
+		"unknown agent": `{"agent":"missing","model":"test"}`,
+		"trailing json": `{"agent":"codex","model":"gpt-test"} {}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseKeeperCompactConfig(raw); err == nil {
+				t.Fatalf("parseKeeperCompactConfig(%q) succeeded", raw)
+			}
+		})
+	}
+}
+
+func TestValidateKeeperCompactCandidate(t *testing.T) {
+	if err := validateKeeperCompactCandidate(keeperSource, keeperCandidate); err != nil {
+		t.Fatalf("valid candidate rejected: %v", err)
+	}
+	if err := validateKeeperCompactCandidate(keeperSource, keeperSource); err != nil {
+		t.Fatalf("identical candidate rejected: %v", err)
+	}
+	legacy := "# Goal\n\nDo the work.\n"
+	if err := validateKeeperCompactCandidate(legacy, legacy); err == nil {
+		t.Fatal("identical legacy candidate unexpectedly accepted")
+	}
+
+	for name, candidate := range map[string]string{
+		"growth": keeperSource + "\nMore content that makes the result larger.\n",
+		"wrong top heading": `# Context
+
+## Area
+Area.
+
+## Current Picture
+Current.
+`,
+		"missing area": `# Workspace Context
+
+## Current Picture
+Current.
+`,
+		"empty current picture": `# Workspace Context
+
+## Area
+Area.
+
+## Current Picture
+`,
+		"duplicate area": `# Workspace Context
+
+## Area
+Area.
+
+## Area
+Another area.
+
+## Current Picture
+Current.
+`,
+		"extra top heading": `# Workspace Context
+
+## Area
+Area.
+
+## Current Picture
+Current.
+
+# Appendix
+Other.
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateKeeperCompactCandidate(keeperSource, candidate); err == nil {
+				t.Fatalf("candidate unexpectedly accepted:\n%s", candidate)
+			}
+		})
+	}
+}
+
+// TestWorkspaceContextCompactionAppliesAndLeavesExistingCheckoutsStale exercises
+// the shared execute+validate+apply path (inline) end to end: the canonical is
+// compacted, both checkouts are left untouched (clean stays stale, modified keeps
+// its local edit), a backup is written, and rollback restores the source.
+func TestWorkspaceContextCompactionAppliesAndLeavesExistingCheckoutsStale(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-clean", "workspace-1")
+	setupWorkspaceContextSession(t, d, "session-modified", "workspace-1")
+	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+
+	canonical, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-clean", 0)
+	if err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+	clean, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{SourceSessionID: "session-clean"})
+	if err != nil {
+		t.Fatalf("checkout clean session: %v", err)
+	}
+	modified, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{SourceSessionID: "session-modified"})
+	if err != nil {
+		t.Fatalf("checkout modified session: %v", err)
+	}
+	localEdit := keeperSource + "\nLocal unsaved fact.\n"
+	if err := os.WriteFile(modified.Path, []byte(localEdit), 0o600); err != nil {
+		t.Fatalf("edit modified checkout: %v", err)
+	}
+	d.workspaceContextCompactionExecution = fakeCompaction(keeperCandidate)
+	config, err := d.keeperCompactConfig()
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	result, err := d.runWorkspaceContextCompactionInline(context.Background(), config, canonical)
+	if err != nil {
+		t.Fatalf("run compaction: %v", err)
+	}
+	if !result.Changed || result.SourceRevision != 1 || result.ResultRevision != 2 ||
+		protocol.Deref(result.Agent) != "codex" || protocol.Deref(result.AgentModel) != "gpt-test" {
+		t.Fatalf("result = %+v", result)
+	}
+	current, err := d.store.GetWorkspaceContext("workspace-1")
+	if err != nil {
+		t.Fatalf("get compacted context: %v", err)
+	}
+	if current.Content != keeperCandidate || current.UpdatedBySessionID != keeperCompactUpdater {
+		t.Fatalf("current = %+v", current)
+	}
+	cleanContent, err := os.ReadFile(clean.Path)
+	if err != nil {
+		t.Fatalf("read clean checkout: %v", err)
+	}
+	if string(cleanContent) != keeperSource {
+		t.Fatalf("clean checkout was rewritten: %q", cleanContent)
+	}
+	cleanStatus, err := d.workspaceContextStatus(&protocol.WorkspaceContextStatusMessage{SourceSessionID: "session-clean"})
+	if err != nil {
+		t.Fatalf("clean status: %v", err)
+	}
+	if cleanStatus.Modified || !cleanStatus.Stale ||
+		cleanStatus.Revision != 1 || cleanStatus.CanonicalRevision != 2 {
+		t.Fatalf("clean status = %+v", cleanStatus)
+	}
+	modifiedContent, err := os.ReadFile(modified.Path)
+	if err != nil {
+		t.Fatalf("read modified checkout: %v", err)
+	}
+	if string(modifiedContent) != localEdit {
+		t.Fatalf("modified checkout was overwritten: %q", modifiedContent)
+	}
+	modifiedStatus, err := d.workspaceContextStatus(&protocol.WorkspaceContextStatusMessage{SourceSessionID: "session-modified"})
+	if err != nil {
+		t.Fatalf("modified status: %v", err)
+	}
+	if !modifiedStatus.Modified || !modifiedStatus.Stale ||
+		modifiedStatus.Revision != 1 || modifiedStatus.CanonicalRevision != 2 {
+		t.Fatalf("modified status = %+v", modifiedStatus)
+	}
+	backup, err := d.store.GetKeeperCompactBackup("workspace-1")
+	if err != nil {
+		t.Fatalf("get backup: %v", err)
+	}
+	if backup.SourceContent != keeperSource || backup.SourceRevision != 1 || backup.ResultRevision != 2 {
+		t.Fatalf("backup = %+v", backup)
+	}
+
+	rollback, err := d.rollbackWorkspaceContextForSession("session-clean")
+	if err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if rollback.Action != "rollback" || !rollback.Changed || rollback.ResultRevision != 3 {
+		t.Fatalf("rollback result = %+v", rollback)
+	}
+	current, err = d.store.GetWorkspaceContext("workspace-1")
+	if err != nil {
+		t.Fatalf("get restored context: %v", err)
+	}
+	if current.Content != keeperSource || current.UpdatedBySessionID != "session-clean" {
+		t.Fatalf("restored context = %+v", current)
+	}
+}
+
+// TestManualWorkspaceContextCompactionCancelsPendingRun proves the manual command
+// drops a pending debounced runner task and returns a result synchronously.
+func TestManualWorkspaceContextCompactionCancelsPendingRun(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+	d.keeperCompactThreshold = 1
+	d.keeperCompactDebounce = time.Hour
+	installTestCompactRunner(t, d)
+	d.workspaceContextCompactionExecution = fakeCompaction(keeperCandidate)
+
+	if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+	// Enqueue a far-future debounced task that must be cancelled by the manual run.
+	if _, err := d.compactRunner.Enqueue(compactContextKind, "workspace-1", tasks.EnqueueOptions{Debounce: time.Hour}); err != nil {
+		t.Fatalf("enqueue pending: %v", err)
+	}
+
+	result, err := d.compactWorkspaceContextForSession(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("manual compaction: %v", err)
+	}
+	if !result.Changed || result.ResultRevision != 2 {
+		t.Fatalf("manual result = %+v", result)
+	}
+	pending, err := d.compactRunner.Get(tasks.TaskID(compactContextKind, "workspace-1"))
+	if err != nil {
+		t.Fatalf("get pending: %v", err)
+	}
+	// Cancel does not delete the record, but the manual run committed revision 2;
+	// the pending record stays queued for the far-future debounce and must not have
+	// run (it would conflict on the stale revision). The deterministic seam here is
+	// that the manual command returned a committed result synchronously.
+	if pending != nil && pending.State == tasks.StateRunning {
+		t.Fatalf("pending task still running after manual cancel: %+v", pending)
+	}
+}
+
+// TestWorkspaceContextCompactionRejectsStaleRevision proves the revision-guarded
+// apply rejects a candidate built from a now-stale source revision.
+func TestWorkspaceContextCompactionRejectsStaleRevision(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+	canonical, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0)
+	if err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+	later := keeperSource + "\nA later verified edit.\n"
+	d.workspaceContextCompactionExecution = func(
+		context.Context, keeperCompactConfig, *protocol.WorkspaceContext,
+	) (keeperCompactExecution, error) {
+		if _, _, updateErr := d.store.UpdateWorkspaceContext("workspace-1", later, "session-1", 1); updateErr != nil {
+			return keeperCompactExecution{}, updateErr
+		}
+		return keeperCompactExecution{Candidate: keeperCandidate}, nil
+	}
+	config, err := d.keeperCompactConfig()
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	if _, err := d.runWorkspaceContextCompactionInline(context.Background(), config, canonical); !errors.Is(err, store.ErrWorkspaceContextConflict) {
+		t.Fatalf("run error = %v, want revision conflict", err)
+	}
+	current, err := d.store.GetWorkspaceContext("workspace-1")
+	if err != nil {
+		t.Fatalf("get current context: %v", err)
+	}
+	if current.Content != later || current.Revision != 2 {
+		t.Fatalf("current context = %+v", current)
+	}
+	if _, err := d.store.GetKeeperCompactBackup("workspace-1"); !errors.Is(err, store.ErrKeeperCompactBackupNotFound) {
+		t.Fatalf("backup error = %v, want not found", err)
+	}
+}
+
+// TestCompactRunnerTimeoutAndCancellationProtectContext proves the runner-owned
+// timeout and a runner.Cancel both abort a stuck compaction without writing the
+// context.
+func TestCompactRunnerTimeoutAndCancellationProtectContext(t *testing.T) {
+	for name, stop := range map[string]func(*Daemon){
+		"timeout":      func(d *Daemon) {},
+		"cancellation": func(d *Daemon) { d.compactRunner.Cancel(tasks.TaskID(compactContextKind, "workspace-1")) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+			d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+			d.keeperCompactThreshold = 1
+			if name == "timeout" {
+				d.keeperCompactTimeout = 20 * time.Millisecond
+			} else {
+				d.keeperCompactTimeout = time.Second
+			}
+			started := make(chan struct{})
+			d.workspaceContextCompactionExecution = func(
+				ctx context.Context, _ keeperCompactConfig, _ *protocol.WorkspaceContext,
+			) (keeperCompactExecution, error) {
+				close(started)
+				<-ctx.Done()
+				return keeperCompactExecution{}, ctx.Err()
+			}
+			installTestCompactRunner(t, d)
+			if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
+				t.Fatalf("seed context: %v", err)
+			}
+			if _, err := d.compactRunner.Enqueue(compactContextKind, "workspace-1", tasks.EnqueueOptions{}); err != nil {
+				t.Fatalf("enqueue: %v", err)
+			}
+			<-started
+			stop(d)
+			deadline := time.Now().Add(2 * time.Second)
+			for {
+				current, err := d.store.GetWorkspaceContext("workspace-1")
+				if err != nil {
+					t.Fatalf("get current context: %v", err)
+				}
+				if current.Content != keeperSource || current.Revision != 1 {
+					t.Fatalf("context changed after aborted run: %+v", current)
+				}
+				task, err := d.compactRunner.Get(tasks.TaskID(compactContextKind, "workspace-1"))
+				if err != nil {
+					t.Fatalf("get task: %v", err)
+				}
+				if task != nil && task.State != tasks.StateRunning {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("compaction run did not stop")
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+		})
+	}
+}
+
+// TestCompactRunnerCancellationWaitsForAdmittedCommit proves the CommitGuard
+// fence: a Cancel that arrives after the executor has entered its commit waits
+// for the durable write to finish untorn.
+func TestCompactRunnerCancellationWaitsForAdmittedCommit(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+	d.keeperCompactThreshold = 1
+	d.workspaceContextCompactionExecution = fakeCompaction(keeperCandidate)
+	commitStarted := make(chan struct{})
+	releaseCommit := make(chan struct{})
+	d.workspaceContextBeforeKeeperApply = func() {
+		close(commitStarted)
+		<-releaseCommit
+	}
+	installTestCompactRunner(t, d)
+	if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+	if _, err := d.compactRunner.Enqueue(compactContextKind, "workspace-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	<-commitStarted
+
+	cancelDone := make(chan struct{})
+	go func() {
+		d.compactRunner.Cancel(tasks.TaskID(compactContextKind, "workspace-1"))
+		close(cancelDone)
+	}()
+	select {
+	case <-cancelDone:
+		t.Fatal("cancellation returned before the admitted commit finished")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseCommit)
+	select {
+	case <-cancelDone:
+	case <-time.After(time.Second):
+		t.Fatal("cancellation did not return after commit completion")
+	}
+	current, err := d.store.GetWorkspaceContext("workspace-1")
+	if err != nil {
+		t.Fatalf("get current context: %v", err)
+	}
+	if current.Content != keeperCandidate || current.Revision != 2 {
+		t.Fatalf("admitted commit was not applied: %+v", current)
+	}
+}
+
+// TestWorkspaceDeletionCancelsCompactionBeforeRemovingContext proves the
+// cancel-then-remove ordering: dissociateSessionFromWorkspace cancels the
+// in-flight compaction (blocking until it exits) before removing the workspace
+// row, so no torn compaction can write a deleted workspace's context.
+func TestWorkspaceDeletionCancelsCompactionBeforeRemovingContext(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+	d.keeperCompactThreshold = 1
+	started := make(chan struct{})
+	d.workspaceContextCompactionExecution = func(
+		ctx context.Context, _ keeperCompactConfig, _ *protocol.WorkspaceContext,
+	) (keeperCompactExecution, error) {
+		close(started)
+		<-ctx.Done()
+		return keeperCompactExecution{}, ctx.Err()
+	}
+	installTestCompactRunner(t, d)
+	if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+	if _, err := d.compactRunner.Enqueue(compactContextKind, "workspace-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	<-started
+
+	d.dissociateSessionFromWorkspace("session-1")
+	if d.store.GetWorkspace("workspace-1") != nil || d.store.HasWorkspaceContext("workspace-1") {
+		t.Fatal("workspace deletion returned before removing the workspace context")
+	}
+	if _, err := d.store.GetKeeperCompactBackup("workspace-1"); !errors.Is(err, store.ErrKeeperCompactBackupNotFound) {
+		t.Fatalf("backup error = %v, want not found", err)
+	}
+}
+
+// TestWorkspaceContextCompactionEnqueuesOnThresholdViaTrigger proves the
+// context-write trigger enqueues a coalesced compaction once the doc crosses the
+// size threshold, and that the runner runs it to a committed revision.
+func TestWorkspaceContextCompactionEnqueuesOnThresholdViaTrigger(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+	d.keeperCompactThreshold = 1
+	d.keeperCompactDebounce = 5 * time.Millisecond
+	calls := make(chan struct{}, 1)
+	d.workspaceContextCompactionExecution = func(
+		context.Context, keeperCompactConfig, *protocol.WorkspaceContext,
+	) (keeperCompactExecution, error) {
+		select {
+		case calls <- struct{}{}:
+		default:
+		}
+		return keeperCompactExecution{Candidate: keeperCandidate}, nil
+	}
+	installTestCompactRunner(t, d)
+
+	checkout, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{SourceSessionID: "session-1"})
+	if err != nil {
+		t.Fatalf("checkout context: %v", err)
+	}
+	if err := os.WriteFile(checkout.Path, []byte(keeperSource), 0o600); err != nil {
+		t.Fatalf("edit context: %v", err)
+	}
+	if _, changed, err := d.updateWorkspaceContext(&protocol.WorkspaceContextUpdateMessage{SourceSessionID: "session-1"}); err != nil || !changed {
+		t.Fatalf("publish context: changed=%v err=%v", changed, err)
+	}
+
+	select {
+	case <-calls:
+	case <-time.After(time.Second):
+		t.Fatal("trigger did not enqueue a compaction")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		current, getErr := d.store.GetWorkspaceContext("workspace-1")
+		if getErr != nil {
+			t.Fatalf("get current context: %v", getErr)
+		}
+		if current.Revision == 2 {
+			if current.Content != keeperCandidate {
+				t.Fatalf("compacted content = %q", current.Content)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("context revision = %d, want 2", current.Revision)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestWorkspaceContextCompactionInlineFallbackWhenRunnerDisabled proves that with
+// a disabled runner (no notebook root) the trigger compacts inline/synchronously
+// so compaction still happens.
+func TestWorkspaceContextCompactionInlineFallbackWhenRunnerDisabled(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+	d.keeperCompactThreshold = 1
+	// NewForTesting installs a disabled runner; keep it.
+	if !d.compactRunner.Disabled() {
+		t.Fatal("expected disabled runner in test")
+	}
+	d.workspaceContextCompactionExecution = fakeCompaction(keeperCandidate)
+
+	if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+	canonical, err := d.store.GetWorkspaceContext("workspace-1")
+	if err != nil {
+		t.Fatalf("get canonical: %v", err)
+	}
+	// The trigger runs the inline fallback synchronously.
+	d.enqueueWorkspaceContextCompaction(canonical)
+
+	current, err := d.store.GetWorkspaceContext("workspace-1")
+	if err != nil {
+		t.Fatalf("get current context: %v", err)
+	}
+	if current.Revision != 2 || current.Content != keeperCandidate {
+		t.Fatalf("inline fallback did not compact: %+v", current)
+	}
+}
+
+// TestWorkspaceContextCompactionReChecksThresholdAfterDebounce proves the run-time
+// size re-check: a doc edited below the threshold during the debounce window is a
+// no-op success (no LLM pass, no revision bump).
+func TestWorkspaceContextCompactionReChecksThresholdAfterDebounce(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+	// Threshold far above the seeded doc size so the run-time re-check no-ops.
+	d.keeperCompactThreshold = 1 << 20
+	executed := false
+	d.workspaceContextCompactionExecution = func(
+		context.Context, keeperCompactConfig, *protocol.WorkspaceContext,
+	) (keeperCompactExecution, error) {
+		executed = true
+		return keeperCompactExecution{Candidate: keeperCandidate}, nil
+	}
+	installTestCompactRunner(t, d)
+	if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+	// Enqueue directly (the trigger would gate it, but a pre-debounce enqueue may
+	// have outlived a shrink); the executor must re-check and no-op.
+	if _, err := d.compactRunner.Enqueue(compactContextKind, "workspace-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		task, err := d.compactRunner.Get(tasks.TaskID(compactContextKind, "workspace-1"))
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task != nil && task.State == tasks.StateDone {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task did not finish: %+v", task)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if executed {
+		t.Fatal("executor ran despite the doc being below the size threshold")
+	}
+	current, err := d.store.GetWorkspaceContext("workspace-1")
+	if err != nil {
+		t.Fatalf("get current context: %v", err)
+	}
+	if current.Revision != 1 {
+		t.Fatalf("context was modified by a below-threshold run: %+v", current)
+	}
+}
+
+// TestWorkspaceTeardownDoesNotPanicBeforeCompactRunnerExists proves the runtime
+// teardown sites tolerate a nil compactRunner. Production New() leaves
+// compactRunner nil until startCompactRunner() runs late in Start(), but the
+// websocket server already accepts connections by then, so an UnregisterWorkspace
+// / session-close / move-out arriving in that window reaches these sites with a
+// nil runner. An unconditional d.compactRunner.Cancel(...) would nil-deref on the
+// first line of Runner.Cancel (it reads r.disabled) and crash the daemon.
+func TestWorkspaceTeardownDoesNotPanicBeforeCompactRunnerExists(t *testing.T) {
+	t.Run("dissociateSessionFromWorkspace", func(t *testing.T) {
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+		setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+		// Mimic production New(): the runner is not constructed yet.
+		d.compactRunner = nil
+
+		d.dissociateSessionFromWorkspace("session-1")
+
+		if d.store.GetWorkspace("workspace-1") != nil {
+			t.Fatal("workspace was not removed after dissociation")
+		}
+	})
+
+	t.Run("handleUnregisterWorkspace", func(t *testing.T) {
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+		setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+		d.compactRunner = nil
+
+		d.handleUnregisterWorkspace(nil, &protocol.UnregisterWorkspaceMessage{ID: "workspace-1"})
+
+		if d.store.GetWorkspace("workspace-1") != nil {
+			t.Fatal("workspace was not removed after unregister")
+		}
+	})
+
+	t.Run("unregisterWorkspaceIfEmptyAfterMove", func(t *testing.T) {
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+		setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+		// The session must be gone for the workspace to be considered empty.
+		d.workspaces.dissociateSession("session-1")
+		d.store.Remove("session-1")
+		d.compactRunner = nil
+
+		d.unregisterWorkspaceIfEmptyAfterMove("workspace-1")
+
+		if d.store.GetWorkspace("workspace-1") != nil {
+			t.Fatal("empty workspace was not removed after move-out")
+		}
+	})
+}
+
+// TestManualWorkspaceContextCompactionAppliesTimeout proves the manual command
+// path (compactWorkspaceContextForSession -> runWorkspaceContextCompactionInline)
+// bounds the agent run with the configured per-run timeout. The original code
+// funneled every run through a WithTimeout wrapper; the inline manual path must
+// keep that bound so a hung/runaway agent cannot block the synchronous IPC
+// response indefinitely.
+func TestManualWorkspaceContextCompactionAppliesTimeout(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+	d.store.SetSetting(SettingKeeperCompact, `{"agent":"codex","model":"gpt-test"}`)
+	d.keeperCompactThreshold = 1
+	d.keeperCompactTimeout = 20 * time.Millisecond
+
+	gotDeadline := make(chan bool, 1)
+	d.workspaceContextCompactionExecution = func(
+		ctx context.Context, _ keeperCompactConfig, _ *protocol.WorkspaceContext,
+	) (keeperCompactExecution, error) {
+		_, hasDeadline := ctx.Deadline()
+		gotDeadline <- hasDeadline
+		// A runaway agent: block until the context aborts. With a deadline the
+		// manual command returns promptly; without one it would hang here forever.
+		<-ctx.Done()
+		return keeperCompactExecution{}, ctx.Err()
+	}
+	if _, _, err := d.store.UpdateWorkspaceContext("workspace-1", keeperSource, "session-1", 0); err != nil {
+		t.Fatalf("seed context: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := d.compactWorkspaceContextForSession(context.Background(), "session-1")
+		done <- err
+	}()
+
+	select {
+	case hasDeadline := <-gotDeadline:
+		if !hasDeadline {
+			t.Fatal("manual compaction executor ctx has NO deadline")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("manual compaction executor was not invoked")
+	}
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("manual compaction error = %v, want context deadline exceeded", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("manual compaction did not abort within the configured timeout")
+	}
+}
+
+// TestMigrateKeeperCompactSettingKey covers the one-time rename of the persisted
+// "workspace_context_janitor" setting to SettingKeeperCompact: a configured
+// legacy value is carried forward, the legacy row is dropped, and the migration
+// is idempotent — a re-run never clobbers a value the user set under the new key.
+func TestMigrateKeeperCompactSettingKey(t *testing.T) {
+	t.Run("copies legacy value forward and drops the legacy row", func(t *testing.T) {
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+		const value = `{"agent":"codex","model":"gpt-test"}`
+		d.store.SetSetting(legacyKeeperCompactSettingKey, value)
+
+		d.migrateKeeperCompactSettingKey()
+
+		if got := d.store.GetSetting(SettingKeeperCompact); got != value {
+			t.Fatalf("new key = %q, want %q", got, value)
+		}
+		if got := d.store.GetSetting(legacyKeeperCompactSettingKey); got != "" {
+			t.Fatalf("legacy key still present: %q", got)
+		}
+		if _, ok := d.store.GetAllSettings()[legacyKeeperCompactSettingKey]; ok {
+			t.Fatal("legacy key still appears in GetAllSettings")
+		}
+	})
+
+	t.Run("idempotent: re-run is a no-op and never clobbers a user-set new value", func(t *testing.T) {
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+		d.store.SetSetting(legacyKeeperCompactSettingKey, `{"agent":"codex","model":"old"}`)
+
+		d.migrateKeeperCompactSettingKey()
+
+		// User reconfigures under the new key, and (defensively) a stale legacy row reappears.
+		const userValue = `{"agent":"claude","model":"new"}`
+		d.store.SetSetting(SettingKeeperCompact, userValue)
+		d.store.SetSetting(legacyKeeperCompactSettingKey, `{"agent":"codex","model":"old"}`)
+
+		d.migrateKeeperCompactSettingKey()
+
+		if got := d.store.GetSetting(SettingKeeperCompact); got != userValue {
+			t.Fatalf("new key was clobbered: got %q, want %q", got, userValue)
+		}
+		if got := d.store.GetSetting(legacyKeeperCompactSettingKey); got != "" {
+			t.Fatalf("legacy key still present after re-run: %q", got)
+		}
+	})
+
+	t.Run("no legacy value: nothing to migrate", func(t *testing.T) {
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+		d.migrateKeeperCompactSettingKey()
+
+		if got := d.store.GetSetting(SettingKeeperCompact); got != "" {
+			t.Fatalf("new key unexpectedly set: %q", got)
+		}
+	})
+}


### PR DESCRIPTION
Adds the keeper's **tidy** duty (`workspace_keeper.go`: `compact_context` on the durable runner — agentic via native tools; the daemon keeps temp-in/candidate-out + validate + revision-guarded commit under CommitGuard) and the deterministic **capture floor** (`notebook_raw_tier.go`: the synchronous `context.md` snapshot at every removal path, funnelled through one path-segment guard so a client-controlled id can't escape the raw dir). Dispatch outcomes are redirected to `.attn/raw/dispatches/`. Code is dormant until #8 wires it.
---
**Final-state re-split of the knowledge-base / keeper epic** (supersedes #335–#343, #345). The original stack was split by chronology and carried mid-epic churn; this one is sliced by subsystem from the net diff, so each PR is a clean final-state slice.

Stack: `1 task-engine` · `2 notebook-kb` · `3 agent-native` · `4 store-keeper` · `5 keeper-compaction` · `6 keeper-narration` · `7 keeper-cron` · **`8 integration`** · `9 frontend` · `10 cli/docs`

This is PR **5/10** — base `kb/04-store-keeper-migration`. Review per-diff. By design the refactor only activates in #8 (where the keeper is wired and the janitor/dreaming are deleted), so branches 2–9 are not individually `go build`-clean; the merged tip (#10) is build + vet + test green.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. `feat/chifplace`
2. #347
3. #348
4. #349
5. #350
6. **#351** 👈 current
7. #352
8. #353
9. #354
10. #355
11. #356
<!-- stack:links:end -->