### PR TITLE
feat(daemon): keeper journal narration

### DIFF
--- a/internal/daemon/notebook_narration.go
+++ b/internal/daemon/notebook_narration.go
@@ -1,0 +1,701 @@
+package daemon
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/notebook"
+	"github.com/victorarias/attn/internal/tasks"
+)
+
+// Notebook narration: two headless agent tasks that turn raw session work into a
+// curated daily work-journal.
+//
+//   - summarize_session (cheap tier): per-session. Reads ONE session transcript and
+//     writes a faithful digest to the raw tier, partitioned by workspace
+//     (RawSessionsDir/<wsID>/<sessionID>.md). Pure machine input for the narrate duty;
+//     high frequency, so it runs on the cheap model.
+//   - narrate_workspace (strong tier): per-workspace, coalesced. Reads the workspace's
+//     digests + context snapshot + dispatch outcomes and writes/refreshes the curated
+//     journal entry for today (journal/<today>.md). The load-bearing product surface.
+//
+// Both are NATIVE-TOOLS tasks: the agent uses its own file tools and writes the
+// target file itself. Unlike the keeper's compaction duty (which reads a candidate
+// back and commits it under a CommitGuard), THE FILE IS THE LEDGER here — the
+// executor's success gate is "did the agent write the target file?" (digest exists /
+// journal contains the workspace marker), not a daemon read-back-and-commit. This is
+// deliberate: the journal is shared and concurrently written by sibling narrate passes and
+// the human, so the daemon must not own a serialize-and-overwrite commit; the agents'
+// native read-before-write CAS is the concurrency control (see the prompt briefs).
+//
+// CONCURRENCY CAVEAT (Codex-backed narrate): Claude's Write/Edit enforce read-before-write
+// staleness rejection, which the shared-journal story depends on. Codex's apply-patch
+// CAS is UNVERIFIED for the installed version, so Claude is the built-in default for
+// both tiers (see notebook_narration_config.go). Codex is NOT hard-gated out — a user
+// may configure it — but a concurrent Codex narrate could in principle clobber a
+// sibling's same-day entry if its patch tooling does not detect the on-disk change.
+
+const (
+	// notebookSummarizeSessionTimeout bounds one per-session digest run. Reading and
+	// summarizing a single transcript is cheap; a few minutes is ample headroom.
+	notebookSummarizeSessionTimeout = 4 * time.Minute
+	// notebookNarrateWorkspaceTimeout bounds one curated-journal run. The narrate pass
+	// reads many digests + prior entries and writes prose on the strong model, so it
+	// gets a wider budget than the per-session digest.
+	notebookNarrateWorkspaceTimeout = 8 * time.Minute
+	// notebookNarrationDebounce coalesces the burst of session stops in an active
+	// workspace into a single narrate pass (and collapses a chatty session's repeated
+	// stops into one digest run). The removal-boundary final narrate overrides this
+	// with ZeroDebounce.
+	notebookNarrationDebounce = 2 * time.Minute
+	// notebookSummarizeMetaTranscript and notebookSummarizeMetaWorkspace are the
+	// task.Meta keys carrying the summarize_session run's inputs onto the durable
+	// record at enqueue time (handleStop), where BOTH the session row and the
+	// workspace row still exist. They MUST be carried because the debounced run
+	// fires AFTER a single-session-workspace teardown has deleted both rows, so the
+	// executor can no longer re-derive the transcript path or the workspace bucket
+	// from a live row. The transcript file itself survives under ~/.claude/~/.codex.
+	notebookSummarizeMetaTranscript = "transcript"
+	notebookSummarizeMetaWorkspace  = "workspace"
+	// notebookNarrateMetaDailyPass marks a narrate_workspace task enqueued by the
+	// daily-narrate cron (the long-lived-workspace backstop) rather than by
+	// session-end or the removal boundary. It relaxes the executor's success gate so
+	// a no-op daily refresh (nothing new to narrate) is a CLEAN DONE instead of a
+	// retried failure (see narrateWorkspaceExecutor's dailyPass branch). Session-end
+	// and removal passes carry no daily flag and keep strict "must have written"
+	// gating.
+	notebookNarrateMetaDailyPass = "daily_pass"
+	// notebookSoloSessionBucket is the RawSessionsDir subdir holding digests for
+	// solo (non-workspace) sessions. It is a reserved name (leading underscore) so
+	// it can never collide with a real workspace id bucket, and rawTierSegment
+	// rejects any workspace id that begins with "." — workspace ids are not allowed
+	// to start with "_" either way in practice, but the underscore keeps the bucket
+	// visually distinct from a workspace dir.
+	notebookSoloSessionBucket = "_solo"
+)
+
+// notebookNarrationAllowedTools is the native tool set both narration agents get.
+// Unlike the keeper's compaction duty (file tools only), the narrate duty may run read-only shell to
+// grep large transcripts and locate prior journal markers, so Bash is included
+// (the briefs explicitly tell them to use Read/Grep/Bash). Claude consumes this as
+// --allowedTools; Codex ignores it (its tooling comes from the workspace-write
+// sandbox), so the Codex-backed narrate's writability is governed by ExtraWritableRoots.
+var notebookNarrationAllowedTools = []string{"Read", "Write", "Edit", "Grep", "Glob", "Bash"}
+
+// --- summarize_session ---
+
+// summarizeSessionExecutor is the runner-registered ExecutorFunc for
+// summarize_session. task.Subject is the session id. It resolves the transcript path
+// and the workspace bucket PREFERRING the inputs carried on task.Meta (stashed at
+// enqueue time, where both the session row and the workspace row still existed) and
+// falling back to the live session row — so the run stays correct after a
+// single-session-workspace teardown has deleted both rows (the transcript file
+// itself survives under ~/.claude/~/.codex). It assembles the digest prompt with
+// absolute paths, runs the agent, and verifies the digest file was (re)written. The
+// written digest is the only success evidence (the file is the ledger): a run that
+// returns without writing it is an error so the runner backs off and retries. On
+// success, if the workspace has since been removed it re-enqueues the retrospective
+// narrate so the late digest lands in it (see the re-narrate hook below).
+func (d *Daemon) summarizeSessionExecutor(ctx context.Context, task *tasks.Task) error {
+	sessionID := strings.TrimSpace(task.Subject)
+	if sessionID == "" {
+		return errors.New("summarize_session requires a session id")
+	}
+
+	root, err := d.notebookRoot()
+	if err != nil {
+		return fmt.Errorf("summarize_session: notebook root: %w", err)
+	}
+	if strings.TrimSpace(root) == "" {
+		return errors.New("summarize_session: notebook is disabled")
+	}
+
+	config, err := d.notebookNarrationConfigFor(notebookSummarizeSessionKind)
+	if err != nil {
+		return err
+	}
+	provider, executablePath, err := d.resolveNotebookNarrationExecutable(config)
+	if err != nil {
+		return err
+	}
+
+	// Resolve the transcript path and workspace id, PREFERRING the inputs carried on
+	// the task (stashed at enqueue time, where both the session row and workspace row
+	// still existed) and falling back to the live session row. The carried inputs are
+	// what make this run correct AFTER a single-session-workspace teardown: by the
+	// time the debounced run fires both rows are gone, but the transcript file
+	// survives on disk and the carried workspace id still routes the digest to the
+	// right per-workspace bucket. The fallback covers a manually-enqueued/legacy task
+	// (no Meta) whose row still exists.
+	carriedTranscript := strings.TrimSpace(task.Meta[notebookSummarizeMetaTranscript])
+	carriedWorkspace := strings.TrimSpace(task.Meta[notebookSummarizeMetaWorkspace])
+	_, hasCarriedWorkspace := task.Meta[notebookSummarizeMetaWorkspace]
+
+	session := d.store.Get(sessionID)
+	if session == nil && carriedTranscript == "" {
+		// No row AND nothing carried: the session is genuinely gone with no transcript
+		// to summarize. That is a no-op success, not a failure (nothing to retry).
+		d.logf("summarize_session: session %s no longer present and no carried transcript, skipping", sessionID)
+		return nil
+	}
+
+	transcriptPath := carriedTranscript
+	if transcriptPath == "" {
+		transcriptPath = d.resolveTranscriptPathForSession(session, "")
+	}
+
+	// Workspace id for the per-session digest bucket: prefer the carried id (which
+	// survives the row deletion) and fall back to the live row's. The carried id is
+	// empty for a genuinely solo session, which keeps the digest in the _solo bucket.
+	workspaceID := carriedWorkspace
+	if !hasCarriedWorkspace && session != nil {
+		workspaceID = strings.TrimSpace(session.WorkspaceID)
+	}
+
+	// Partition the per-session digest dir by the session's workspace so the
+	// narrate pass for a workspace reads ONLY its own members' digests, not a flat
+	// dir holding every workspace's (and every solo session's) digest. The bucket
+	// survives workspace removal on disk, so the removal-pass narrate still finds the
+	// scoped digests. Both segments route through the raw-tier guard so a crafted
+	// session/workspace id cannot escape the raw tier and steer the agent's native
+	// Write at the curated journal (the hole the base raw-floor PR closed for the
+	// daemon's own snapshot write). The carried wsID is just as client-controlled as
+	// the row's was, so it is guarded identically.
+	digestPath, err := notebookSessionDigestPath(root, workspaceID, sessionID)
+	if err != nil {
+		return fmt.Errorf("summarize_session: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(digestPath), 0o755); err != nil {
+		return fmt.Errorf("summarize_session: create raw sessions dir: %w", err)
+	}
+
+	workDir, err := os.MkdirTemp("", "attn-summarize-session-*")
+	if err != nil {
+		return fmt.Errorf("summarize_session: create scratch dir: %w", err)
+	}
+	defer os.RemoveAll(workDir)
+
+	// Snapshot the digest's pre-run identity so the success gate can require the run
+	// to have actually (re)written it. A coalesced re-run (Enqueue resets a done
+	// record back to queued) on a session whose digest already exists must not be
+	// reported done just because the PRIOR run's file is still there — a no-op agent
+	// would otherwise silently leave a stale digest while reporting success.
+	before := fileFingerprintOf(digestPath)
+
+	request := agentdriver.HeadlessTaskRequest{
+		Executable:   executablePath,
+		Model:        config.Model,
+		Prompt:       buildSummarizeSessionPrompt(transcriptPath, sessionID, digestPath),
+		WorkDir:      workDir,
+		AllowedTools: notebookNarrationAllowedTools,
+		// The digest lives under the notebook raw tier, outside the scratch WorkDir,
+		// so a Codex-backed narrate needs that dir made writable (Claude ignores this).
+		ExtraWritableRoots: []string{filepath.Dir(digestPath)},
+	}
+
+	run := d.summarizeSessionExecution
+	if run == nil {
+		run = func(ctx context.Context, p agentdriver.HeadlessTaskProvider, r agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			return p.RunHeadlessTask(ctx, r)
+		}
+	}
+	result, err := run(ctx, provider, request)
+	if err != nil {
+		return fmt.Errorf("summarize_session: run agent: %w (%s)", err, result.Diagnostics)
+	}
+
+	// The file is the ledger: a run that returned without (re)writing the digest
+	// failed, regardless of what the agent claimed. Require the digest to exist AND
+	// to have changed since the pre-run snapshot, so a no-op run over a prior run's
+	// stale digest is a failure (requeued with backoff), not a false done.
+	after := fileFingerprintOf(digestPath)
+	if !after.exists {
+		return fmt.Errorf("summarize_session: agent did not write digest %s (%s)", digestPath, result.Diagnostics)
+	}
+	if before.exists && after.equal(before) {
+		return fmt.Errorf("summarize_session: agent left digest %s unchanged (%s)", digestPath, result.Diagnostics)
+	}
+	d.logf("summarize_session: session=%s agent=%s model=%s digest=%s", sessionID, config.Agent, config.Model, digestPath)
+
+	// Re-narrate hook (closes the removal/debounce timing gap). On a
+	// single-session-workspace teardown the removal-boundary final narrate already
+	// ran almost immediately (zero debounce) over an EMPTY digest bucket, because
+	// this summarize was still debounced. Now that the grounded digest exists, the
+	// removal retrospective is stale (built from the context snapshot alone). If we
+	// know a non-empty workspace id AND its row is gone (the workspace was removed),
+	// re-enqueue a zero-debounce narrate so the retrospective is rewritten WITH the
+	// final session's work — the narrate freshness-guard makes it actually rewrite
+	// the block (the body changes). Only on removal: an active workspace's pending
+	// narrate already covers a fresh digest, and re-narrating it would burn an extra
+	// strong-tier run. LOOP-SAFETY: narrate completion never enqueues summarize, so
+	// there is no cycle; multiple member summaries coalesce to one narrate per wsID.
+	if workspaceID != "" && d.store.GetWorkspace(workspaceID) == nil {
+		d.logf("summarize_session: workspace %s removed, re-narrating retrospective with fresh digest", workspaceID)
+		d.enqueueFinalNarrateWorkspace(workspaceID)
+	}
+	return nil
+}
+
+// notebookSessionDigestPath builds the absolute path of a session's raw digest,
+// partitioned by the session's workspace so a workspace's narrate pass reads only
+// its own members' digests. A workspace session lands at
+// RawSessionsDir/<wsID>/<sessionID>.md; a solo session (no workspace) lands at
+// RawSessionsDir/<soloBucket>/<sessionID>.md. Both id segments route through the
+// raw-tier guard, so a crafted session or workspace id is rejected (a hard error)
+// rather than allowed to climb out of the raw tier via filepath.Join's "..".
+func notebookSessionDigestPath(root, workspaceID, sessionID string) (string, error) {
+	name, err := rawTierFilename(sessionID)
+	if err != nil {
+		return "", fmt.Errorf("unsafe session id: %w", err)
+	}
+	bucket := notebookSoloSessionBucket
+	if workspaceID != "" {
+		bucket, err = rawTierSegment(workspaceID)
+		if err != nil {
+			return "", fmt.Errorf("unsafe workspace id: %w", err)
+		}
+	}
+	return filepath.Join(notebook.RawSessionsDir(root), bucket, name), nil
+}
+
+// notebookWorkspaceSessionsDir is the per-workspace digest subdir the narrate pass
+// hands the narrate pass as RAW_SESSIONS_DIR, so it reads only this workspace's member
+// digests. It mirrors the bucket notebookSessionDigestPath writes to.
+func notebookWorkspaceSessionsDir(root, workspaceID string) (string, error) {
+	bucket, err := rawTierSegment(workspaceID)
+	if err != nil {
+		return "", fmt.Errorf("unsafe workspace id: %w", err)
+	}
+	return filepath.Join(notebook.RawSessionsDir(root), bucket), nil
+}
+
+// --- narrate_workspace ---
+
+// narrateWorkspaceExecutor is the runner-registered ExecutorFunc for
+// narrate_workspace. task.Subject is the workspace id. It derives IS_REMOVAL_PASS
+// at RUN TIME from whether the workspace row still exists (an absent row means the
+// workspace was removed and this is the final retrospective pass), gathers the
+// narrate duty's inputs, runs the agent, and verifies the journal now carries this
+// workspace's marker for today (the file is the ledger).
+func (d *Daemon) narrateWorkspaceExecutor(ctx context.Context, task *tasks.Task) error {
+	workspaceID := strings.TrimSpace(task.Subject)
+	if workspaceID == "" {
+		return errors.New("narrate_workspace requires a workspace id")
+	}
+
+	root, err := d.notebookRoot()
+	if err != nil {
+		return fmt.Errorf("narrate_workspace: notebook root: %w", err)
+	}
+	if strings.TrimSpace(root) == "" {
+		return errors.New("narrate_workspace: notebook is disabled")
+	}
+
+	config, err := d.notebookNarrationConfigFor(notebookNarrateWorkspaceKind)
+	if err != nil {
+		return err
+	}
+	provider, executablePath, err := d.resolveNotebookNarrationExecutable(config)
+	if err != nil {
+		return err
+	}
+
+	inputs, err := d.gatherNarrateWorkspaceInputs(root, workspaceID)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(inputs.JournalDir, 0o755); err != nil {
+		return fmt.Errorf("narrate_workspace: create journal dir: %w", err)
+	}
+	// MkdirAll the per-workspace sessions bucket so the narrate agent's "Read every digest
+	// in RAW_SESSIONS_DIR" step does not fault on a missing dir when no member ever
+	// summarized (e.g. a workspace removed before any session stopped).
+	if err := os.MkdirAll(inputs.RawSessionsDir, 0o755); err != nil {
+		return fmt.Errorf("narrate_workspace: create raw sessions dir: %w", err)
+	}
+
+	// Snapshot this workspace's marker block before the run so the success gate can
+	// require it to have actually changed. Without this a coalesced re-run (the
+	// removal-boundary final narrate firing after an active-day narrate already
+	// wrote today's marker) would be falsely marked done off the PRIOR run's block,
+	// silently dropping the removal retrospective even when this run's agent wrote
+	// nothing for the workspace.
+	before, err := workspaceNarrationBlock(inputs.JournalPath, workspaceID)
+	if err != nil {
+		return fmt.Errorf("narrate_workspace: read journal: %w", err)
+	}
+
+	workDir, err := os.MkdirTemp("", "attn-narrate-workspace-*")
+	if err != nil {
+		return fmt.Errorf("narrate_workspace: create scratch dir: %w", err)
+	}
+	defer os.RemoveAll(workDir)
+
+	request := agentdriver.HeadlessTaskRequest{
+		Executable:   executablePath,
+		Model:        config.Model,
+		Prompt:       buildNarrateWorkspacePrompt(inputs),
+		WorkDir:      workDir,
+		AllowedTools: notebookNarrationAllowedTools,
+		// The journal and raw tier live under the notebook root, outside the scratch
+		// WorkDir; widen the Codex sandbox to the whole root so it can read the raw
+		// inputs and write the curated journal (Claude ignores this — dontAsk is not
+		// sandboxed). Reads are unrestricted under workspace-write, but transcript
+		// dirs live under $HOME outside the root, so we add the root for the write.
+		ExtraWritableRoots: []string{root},
+	}
+
+	run := d.narrateWorkspaceExecution
+	if run == nil {
+		run = func(ctx context.Context, p agentdriver.HeadlessTaskProvider, r agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+			return p.RunHeadlessTask(ctx, r)
+		}
+	}
+	result, err := run(ctx, provider, request)
+	if err != nil {
+		return fmt.Errorf("narrate_workspace: run agent: %w (%s)", err, result.Diagnostics)
+	}
+
+	// The file is the ledger: success means today's journal now carries THIS
+	// workspace's entry block (delimited by `<!-- attn:wsnarr:<wsID> -->`) AND that
+	// block changed since the pre-run snapshot. Requiring a change (not mere
+	// presence) means a coalesced re-run whose agent no-ops over a prior run's block
+	// fails and is retried, instead of being falsely marked done off stale content.
+	after, err := workspaceNarrationBlock(inputs.JournalPath, workspaceID)
+	if err != nil {
+		return fmt.Errorf("narrate_workspace: verify journal: %w", err)
+	}
+
+	// dailyPass relaxes the success gate for the daily-cron backstop ONLY. A daily
+	// refresh legitimately finds nothing new — the workspace was already narrated
+	// today, or only old material is on disk — and forcing a write would spam the
+	// runner's backoff straight to dead. The raw material persists, so a no-op daily
+	// pass loses nothing: the next trigger re-narrates. So when this is a daily pass
+	// (and NOT a removal pass), "agent left the block absent" and "agent left the
+	// block unchanged" are both a CLEAN DONE. Removal passes (the full retrospective)
+	// and session-end routine passes (no daily flag) keep STRICT gating, which
+	// preserves the retry-until-the-digest-lands property they depend on.
+	dailyPass := !inputs.IsRemovalPass && strings.TrimSpace(task.Meta[notebookNarrateMetaDailyPass]) == "1"
+
+	if !after.present {
+		if dailyPass {
+			d.logf("narrate_workspace: daily pass for %s found nothing new to narrate (no entry written); clean no-op", workspaceID)
+			return nil
+		}
+		return fmt.Errorf("narrate_workspace: agent did not write %s entry to %s (%s)", workspaceNarrationMarker(workspaceID), inputs.JournalPath, result.Diagnostics)
+	}
+	if before.present && after.body == before.body {
+		if dailyPass {
+			d.logf("narrate_workspace: daily pass for %s left the entry unchanged (nothing new to narrate); clean no-op", workspaceID)
+			return nil
+		}
+		return fmt.Errorf("narrate_workspace: agent left %s entry in %s unchanged (%s)", workspaceNarrationMarker(workspaceID), inputs.JournalPath, result.Diagnostics)
+	}
+	d.logf(
+		"narrate_workspace: workspace=%s agent=%s model=%s removal=%t journal=%s",
+		workspaceID, config.Agent, config.Model, inputs.IsRemovalPass, inputs.JournalPath,
+	)
+	return nil
+}
+
+// gatherNarrateWorkspaceInputs assembles the absolute-path inputs the narrate
+// agent needs. IS_REMOVAL_PASS is derived from workspace-row absence (the removal
+// boundary deleted the row before this run); WORKSPACE_TITLE falls back to the
+// removal snapshot or the id when the row is gone. TRANSCRIPT_PATHS are the live
+// member sessions' transcripts (best-effort — they may be gone after removal, which
+// is fine: the digests are the durable record and the brief only consults
+// transcripts to chase a divergence).
+func (d *Daemon) gatherNarrateWorkspaceInputs(root, workspaceID string) (narrateWorkspacePromptInputs, error) {
+	today := d.narrationToday()
+
+	// Build the context-snapshot READ path through the same guard the WRITER
+	// (snapshotWorkspaceContextOnRemove -> writeRawAtomic -> rawTierFilename) uses,
+	// so the read path can never address a different file than the write path and a
+	// crafted workspace id is rejected (failing the run) instead of pointing the
+	// narrate agent's "read CONTEXT_SNAPSHOT_PATH first" step at an attacker-chosen file.
+	snapshotName, err := rawTierFilename(workspaceID)
+	if err != nil {
+		return narrateWorkspacePromptInputs{}, fmt.Errorf("narrate_workspace: unsafe workspace id: %w", err)
+	}
+	// Per-workspace digest bucket — the narrate pass reads ONLY this workspace's member
+	// digests, not a flat dir holding every workspace's and every solo session's.
+	sessionsDir, err := notebookWorkspaceSessionsDir(root, workspaceID)
+	if err != nil {
+		return narrateWorkspacePromptInputs{}, fmt.Errorf("narrate_workspace: %w", err)
+	}
+
+	inputs := narrateWorkspacePromptInputs{
+		WorkspaceID:         workspaceID,
+		ContextSnapshotPath: filepath.Join(notebook.RawContextSnapshotsDir(root), snapshotName),
+		RawSessionsDir:      sessionsDir,
+		RawDispatchesDir:    notebook.RawDispatchesDir(root),
+		JournalDir:          filepath.Join(root, notebook.DirJournal),
+		JournalPath:         filepath.Join(root, notebook.DirJournal, today+".md"),
+		KnowledgeDir:        filepath.Join(root, notebook.DirKnowledge),
+	}
+
+	ws := d.store.GetWorkspace(workspaceID)
+	inputs.IsRemovalPass = ws == nil
+	if ws != nil {
+		inputs.WorkspaceTitle = strings.TrimSpace(ws.Title)
+	}
+	if inputs.WorkspaceTitle == "" {
+		inputs.WorkspaceTitle = workspaceID
+	}
+
+	// Collect the transcripts of sessions still associated with this workspace. On a
+	// removal pass the member rows are gone, so this is typically empty — expected.
+	for _, session := range d.store.List("") {
+		if session == nil || session.WorkspaceID != workspaceID {
+			continue
+		}
+		if path := strings.TrimSpace(d.resolveTranscriptPathForSession(session, "")); path != "" {
+			inputs.TranscriptPaths = append(inputs.TranscriptPaths, path)
+		}
+	}
+
+	return inputs, nil
+}
+
+// narrationToday returns today's date in YYYY-MM-DD for the journal filename. The
+// narrationNowOverride test hook pins the clock so date-boundary behavior is
+// deterministic.
+func (d *Daemon) narrationToday() string {
+	now := time.Now
+	if d.narrationNowOverride != nil {
+		now = d.narrationNowOverride
+	}
+	return now().Format("2006-01-02")
+}
+
+// workspaceNarrationMarker is the FULL hidden HTML-comment marker line the narrate agent
+// writes to delimit (and dedup) this workspace's entry in a day's journal file. It
+// MUST match the exact line the prompt brief tells the agent to write
+// (`<!-- attn:wsnarr:<wsID> -->`). The full delimited form is load-bearing for the
+// success ledger: the bare `attn:wsnarr:ws-1` substring is also contained in
+// `<!-- attn:wsnarr:ws-10 -->`, so a prefix-related sibling's entry would falsely
+// verify ws-1's run. Matching the delimited line removes that collision.
+func workspaceNarrationMarker(workspaceID string) string {
+	return fmt.Sprintf("<!-- attn:wsnarr:%s -->", strings.TrimSpace(workspaceID))
+}
+
+// workspaceNarrationEntry is the pre/post-run snapshot of a workspace's marker
+// block in a day's journal, used as the freshness ledger for a narrate run.
+type workspaceNarrationEntry struct {
+	present bool   // the workspace's marker line is in the file
+	body    string // the entry block from the marker line to the next "## "/EOF
+}
+
+// workspaceNarrationBlock reads the journal at path and returns this workspace's
+// entry block: whether its marker line is present and, if so, the text from the
+// marker line through the line just before the next workspace's "## " header (or
+// end of file). A missing file is not an error (the agent simply wrote nothing):
+// it reports an absent entry. The body is scoped to the workspace's own marker so
+// the freshness check ignores a concurrent sibling's edit elsewhere in the file.
+func workspaceNarrationBlock(path, workspaceID string) (workspaceNarrationEntry, error) {
+	content, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return workspaceNarrationEntry{}, nil
+	}
+	if err != nil {
+		return workspaceNarrationEntry{}, err
+	}
+	marker := workspaceNarrationMarker(workspaceID)
+	lines := strings.Split(string(content), "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == marker {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return workspaceNarrationEntry{}, nil
+	}
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "## ") {
+			end = i
+			break
+		}
+	}
+	return workspaceNarrationEntry{present: true, body: strings.Join(lines[start:end], "\n")}, nil
+}
+
+// fileFingerprint captures a file's identity for the digest freshness ledger: its
+// existence and a content hash. A run that left a digest byte-identical to its
+// pre-run state is treated as a no-op (not a success), so a coalesced re-run whose
+// agent did nothing is retried rather than recorded as a false done. Content (not
+// mtime) so a same-second rewrite of identical size can never read as fresh, and a
+// no-op is never missed by coarse filesystem mtime granularity.
+type fileFingerprint struct {
+	exists bool
+	hash   [sha256.Size]byte
+}
+
+func (f fileFingerprint) equal(other fileFingerprint) bool {
+	return f.exists && other.exists && f.hash == other.hash
+}
+
+func fileFingerprintOf(path string) fileFingerprint {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fileFingerprint{}
+	}
+	return fileFingerprint{exists: true, hash: sha256.Sum256(content)}
+}
+
+// --- triggers ---
+
+// enqueueSummarizeSession queues a per-session digest run. It is enqueued on every
+// session Stop (the cheap tier), coalesced per session so a chatty session does not
+// pile up runs. Nil/Disabled-guarded so it is safe before the runner is constructed
+// and when the notebook root cannot resolve.
+//
+// The transcript path and workspace id are STASHED on the task (via Meta) at enqueue
+// time, where both the session row and the workspace row still exist. They are
+// carried because the debounced run fires AFTER a single-session-workspace teardown
+// has deleted both rows: without the carried inputs the executor would resolve an
+// empty workspace id and write the digest to the _solo bucket (wrong) or find no row
+// at all and no-op, so the removal retrospective's per-workspace dir never sees the
+// final session's grounded digest. The transcript file itself survives on disk, so
+// summarize remains runnable post-removal. wsID is empty for a genuinely solo
+// session, which keeps the digest in the _solo bucket exactly as before.
+func (d *Daemon) enqueueSummarizeSession(sessionID, transcriptPath, workspaceID string) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return
+	}
+	runner := d.compactRunnerRef()
+	if runner == nil || runner.Disabled() {
+		return
+	}
+	meta := map[string]string{
+		notebookSummarizeMetaTranscript: strings.TrimSpace(transcriptPath),
+		notebookSummarizeMetaWorkspace:  strings.TrimSpace(workspaceID),
+	}
+	if _, err := runner.Enqueue(notebookSummarizeSessionKind, sessionID, tasks.EnqueueOptions{
+		Debounce: notebookNarrationDebounce,
+		Meta:     meta,
+	}); err != nil {
+		d.logf("summarize_session: enqueue %s: %v", sessionID, err)
+	}
+}
+
+// enqueueNarrateWorkspace queues a coalesced curated-journal run for a live
+// workspace. The debounce collapses the burst of session stops in an active
+// workspace into a single narrate pass. Nil/Disabled-guarded.
+func (d *Daemon) enqueueNarrateWorkspace(workspaceID string) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return
+	}
+	runner := d.compactRunnerRef()
+	if runner == nil || runner.Disabled() {
+		return
+	}
+	if _, err := runner.Enqueue(notebookNarrateWorkspaceKind, workspaceID, tasks.EnqueueOptions{
+		Debounce: notebookNarrationDebounce,
+	}); err != nil {
+		d.logf("narrate_workspace: enqueue %s: %v", workspaceID, err)
+	}
+}
+
+// markNotebookWorkspaceActivity records that a workspace saw real activity (a
+// session end or a content-changing context write) since the last daily-narrate
+// cron fire. It feeds the daily-narrate activity gate: the cron drains this set and
+// only narrates workspaces that appear in it, so idle long-lived workspaces never
+// burn a strong-tier pass. The set is in-memory, best-effort, and lazily initialized
+// under the mutex (so the Daemon constructor needs no edit); an empty id is ignored.
+func (d *Daemon) markNotebookWorkspaceActivity(workspaceID string) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return
+	}
+	d.notebookNarrateActivityMu.Lock()
+	defer d.notebookNarrateActivityMu.Unlock()
+	if d.notebookNarrateActivity == nil {
+		d.notebookNarrateActivity = make(map[string]struct{})
+	}
+	d.notebookNarrateActivity[workspaceID] = struct{}{}
+}
+
+// enqueueDailyNarrateWorkspace queues the daily-cron per-workspace narrate for a
+// live, active workspace. It mirrors enqueueNarrateWorkspace (nil/Disabled guard,
+// notebookNarrationDebounce so it coalesces with any concurrent session-end narrate)
+// but stamps notebookNarrateMetaDailyPass so the executor's success gate relaxes for
+// a no-op daily refresh (see narrateWorkspaceExecutor). Nil/Disabled-guarded.
+//
+// Known coalescing edge (low severity, self-healing): if a session-end narrate and
+// this daily narrate land on the same narrate_workspace:<ws> task within the debounce
+// window — i.e. a session stops within notebookNarrationDebounce of the nightly slot —
+// the merged record ends up daily-flagged in BOTH enqueue orderings (the runner's Meta
+// is REPLACE-on-non-nil / leave-on-nil, so daily's flag either wins by replacing or
+// survives because session-end carries no Meta). The coalesced run then takes the
+// relaxed gate, so a no-op is marked DONE rather than retried. This only matters if
+// the agent ALSO no-ops on a real session-end digest (a transient flake — real work
+// always writes), and even then nothing is lost: the raw digest persists and the next
+// trigger re-narrates. Closing it fully would require flipping the executor default to
+// relaxed (a sticky "strict-wins" marker), trading this rare timing edge for a less
+// safe default on the primary session-end path; not worth it.
+func (d *Daemon) enqueueDailyNarrateWorkspace(workspaceID string) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return
+	}
+	runner := d.compactRunnerRef()
+	if runner == nil || runner.Disabled() {
+		return
+	}
+	if _, err := runner.Enqueue(notebookNarrateWorkspaceKind, workspaceID, tasks.EnqueueOptions{
+		Debounce: notebookNarrationDebounce,
+		Meta:     map[string]string{notebookNarrateMetaDailyPass: "1"},
+	}); err != nil {
+		d.logf("narrate_workspace: enqueue daily %s: %v", workspaceID, err)
+	}
+}
+
+// enqueueFinalNarrateWorkspace queues the removal-boundary final narrate with a
+// zero debounce so it overrides any pending active-day debounce and runs as soon as
+// eligible — the workspace is gone, so this is the last chance to write its
+// retrospective. It must be called AFTER the context snapshot is taken and the
+// workspace row is removed, so the executor derives IS_REMOVAL_PASS=true and the
+// snapshot is on disk for the narrate pass to read. Nil/Disabled-guarded, so the
+// startup-reconciliation removal site (which runs before the runner exists) is a
+// safe no-op.
+func (d *Daemon) enqueueFinalNarrateWorkspace(workspaceID string) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return
+	}
+	runner := d.compactRunnerRef()
+	if runner == nil || runner.Disabled() {
+		return
+	}
+	if _, err := runner.Enqueue(notebookNarrateWorkspaceKind, workspaceID, tasks.EnqueueOptions{
+		ZeroDebounce: true,
+	}); err != nil {
+		d.logf("narrate_workspace: enqueue final %s: %v", workspaceID, err)
+	}
+}
+
+// resolveStopWorkspaceID returns the workspace id for a stopped session, read from
+// the PERSISTED store row (not the in-memory registry). The registry can race a
+// concurrent dissociate-on-close, but the persisted workspace_id survives until the
+// session row itself is removed, so it is the authoritative trigger source for
+// "which workspace did this stop belong to".
+func (d *Daemon) resolveStopWorkspaceID(sessionID string) string {
+	session := d.store.Get(sessionID)
+	if session == nil {
+		return ""
+	}
+	return strings.TrimSpace(session.WorkspaceID)
+}

--- a/internal/daemon/notebook_narration_config.go
+++ b/internal/daemon/notebook_narration_config.go
@@ -1,0 +1,161 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+)
+
+// Narration task kinds (runner executor selectors). They live on d.compactRunner
+// alongside compactContextKind ("compact_context").
+const (
+	notebookSummarizeSessionKind = "summarize_session"
+	notebookNarrateWorkspaceKind = "narrate_workspace"
+)
+
+// Tier-default model ids. Narration ALWAYS runs (unlike the keeper's compaction
+// duty, which disables on a blank setting): when a setting is unset/blank we fall back to a
+// built-in default so session-end and removal-boundary narration work out of the
+// box. Claude is the default agent for BOTH tiers because its native
+// Write/Edit enforce read-before-write CAS, which the shared-journal concurrency
+// story depends on (Codex apply-patch CAS is unverified for the installed
+// version — see notebook_narration.go).
+//
+//   - cheap (summarize_session): Claude Haiku — per-session, high-frequency, only
+//     produces raw input the narrate pass re-reads.
+//   - strong (narrate_workspace): Claude Sonnet — writes the curated journal, the
+//     load-bearing product surface where quality is the point.
+const (
+	notebookSummarizeDefaultAgent = "claude"
+	notebookSummarizeDefaultModel = "claude-haiku-4-5"
+	notebookNarrateDefaultAgent   = "claude"
+	notebookNarrateDefaultModel   = "claude-sonnet-4-6"
+)
+
+// notebookNarrationConfig is the resolved {agent, model} for a narration kind. It
+// is never "disabled": parseNotebookNarrationConfig substitutes the tier default
+// for a blank setting, so Agent/Model are always populated for a valid config.
+type notebookNarrationConfig struct {
+	Agent string `json:"agent"`
+	Model string `json:"model"`
+}
+
+// narrationTierDefault returns the built-in {agent, model} for a narration kind.
+func narrationTierDefault(kind string) (agent, model string) {
+	switch kind {
+	case notebookSummarizeSessionKind:
+		return notebookSummarizeDefaultAgent, notebookSummarizeDefaultModel
+	case notebookNarrateWorkspaceKind:
+		return notebookNarrateDefaultAgent, notebookNarrateDefaultModel
+	default:
+		return notebookNarrateDefaultAgent, notebookNarrateDefaultModel
+	}
+}
+
+// parseNotebookNarrationConfig parses a narration setting value (the same JSON
+// shape the keeper's compaction duty validates: {"agent":"claude"|"codex","model":"<id>"}) and
+// resolves the provider, validating at config/enqueue time so a misconfigured
+// agent/model fails fast into failed->dead with a surfaced last_error rather than
+// hanging an executor mid-run. Unlike parseKeeperCompactConfig, a BLANK
+// value yields the tier DEFAULT (narration is always-on), not a disabled config.
+// A non-blank value must specify both agent and model.
+func parseNotebookNarrationConfig(kind, raw string) (notebookNarrationConfig, error) {
+	raw = strings.TrimSpace(raw)
+	var config notebookNarrationConfig
+	if raw == "" {
+		config.Agent, config.Model = narrationTierDefault(kind)
+	} else {
+		decoder := json.NewDecoder(strings.NewReader(raw))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&config); err != nil {
+			return notebookNarrationConfig{}, fmt.Errorf("invalid %s configuration: %w", kind, err)
+		}
+		if err := ensureJSONEOF(decoder); err != nil {
+			return notebookNarrationConfig{}, fmt.Errorf("invalid %s configuration: %w", kind, err)
+		}
+		config.Agent = strings.TrimSpace(strings.ToLower(config.Agent))
+		config.Model = strings.TrimSpace(config.Model)
+		if config.Agent == "" || config.Model == "" {
+			return notebookNarrationConfig{}, fmt.Errorf("%s requires both agent and model", kind)
+		}
+	}
+
+	driver := agentdriver.Get(config.Agent)
+	if driver == nil {
+		return notebookNarrationConfig{}, fmt.Errorf("%s agent is not installed: %s", kind, config.Agent)
+	}
+	if _, ok := driver.(agentdriver.HeadlessTaskProvider); !ok {
+		return notebookNarrationConfig{}, fmt.Errorf("agent %s does not support headless tasks", config.Agent)
+	}
+	if available, reason := agentdriver.HeadlessTaskAvailability(driver); !available {
+		return notebookNarrationConfig{}, fmt.Errorf("agent %s cannot run headless tasks: %s", config.Agent, reason)
+	}
+	return config, nil
+}
+
+// validateNotebookNarrationSetting is the set-setting validator: it parses the
+// value and additionally resolves the executable on PATH, so a bad agent/model/
+// executable is rejected at config time rather than failing an enqueued task.
+func (d *Daemon) validateNotebookNarrationSetting(kind, raw string) error {
+	config, err := parseNotebookNarrationConfig(kind, raw)
+	if err != nil {
+		return err
+	}
+	driver := agentdriver.Get(config.Agent)
+	configured := ""
+	if d.store != nil {
+		configured = d.store.GetSetting(canonicalExecutableSettingKey(config.Agent))
+	}
+	executable := driver.ResolveExecutable(configured)
+	if _, err := exec.LookPath(executable); err != nil {
+		return fmt.Errorf("%s executable for %s was not found: %w", kind, config.Agent, err)
+	}
+	return nil
+}
+
+// notebookNarrationConfigFor loads the resolved config for a narration kind from
+// settings, applying the tier default when unset. Returns an error (and never a
+// blank config) when the configured agent/model is invalid — the caller fails the
+// task so the misconfiguration surfaces.
+func (d *Daemon) notebookNarrationConfigFor(kind string) (notebookNarrationConfig, error) {
+	if d.store == nil {
+		return notebookNarrationConfig{}, errors.New("notebook narration settings unavailable")
+	}
+	settingKey := ""
+	switch kind {
+	case notebookSummarizeSessionKind:
+		settingKey = SettingNotebookSummarizeSession
+	case notebookNarrateWorkspaceKind:
+		settingKey = SettingNotebookNarrateWorkspace
+	default:
+		return notebookNarrationConfig{}, fmt.Errorf("unknown narration kind: %s", kind)
+	}
+	return parseNotebookNarrationConfig(kind, d.store.GetSetting(settingKey))
+}
+
+// resolveNotebookNarrationExecutable resolves the agent's executable path on PATH
+// for a parsed narration config, mirroring executeKeeperCompact's
+// provider resolution. Returns the HeadlessTaskProvider and the absolute path.
+func (d *Daemon) resolveNotebookNarrationExecutable(
+	config notebookNarrationConfig,
+) (agentdriver.HeadlessTaskProvider, string, error) {
+	driver := agentdriver.Get(config.Agent)
+	if driver == nil {
+		return nil, "", fmt.Errorf("narration agent not found: %s", config.Agent)
+	}
+	provider, ok := driver.(agentdriver.HeadlessTaskProvider)
+	if !ok {
+		return nil, "", fmt.Errorf("agent %s does not support headless tasks", config.Agent)
+	}
+	configured := d.store.GetSetting(canonicalExecutableSettingKey(config.Agent))
+	resolvedExecutable := driver.ResolveExecutable(configured)
+	executablePath, err := exec.LookPath(resolvedExecutable)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve %s executable: %w", config.Agent, err)
+	}
+	return provider, executablePath, nil
+}

--- a/internal/daemon/notebook_narration_prompts.go
+++ b/internal/daemon/notebook_narration_prompts.go
@@ -1,0 +1,414 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The two narration prompts are the load-bearing intelligence of the pipeline.
+// They are embedded VERBATIM from docs/plans/2026-06-14-notebook-narration.md
+// section 8 (the fenced text blocks) — do NOT paraphrase the briefs. Each brief
+// ends by referring to inputs/outputs "given to you below this brief"; the
+// builder funcs append the concrete absolute INPUT/OUTPUT path block at run time.
+
+// summarizeSessionPromptBrief is prompt 8A (summarize_session, cheap tier),
+// verbatim. The absolute TRANSCRIPT_PATH / SESSION_ID / RAW_DIGEST_PATH block is
+// appended by buildSummarizeSessionPrompt.
+const summarizeSessionPromptBrief = `You are the attn keeper, performing your session-summary duty. Your job is to read
+ONE agent session's transcript and write a faithful, compact digest of it to attn's
+raw tier. This digest is your own machine input — later, in your stronger narrate
+duty, you read many of these digests to write the user's curated work-journal. You
+are not writing the journal here; you are giving your narrate duty clean,
+trustworthy raw material. Be accurate over fluent. A wrong digest poisons the journal.
+
+INPUTS (absolute paths, given to you below this brief):
+- TRANSCRIPT_PATH: the session transcript file to read.
+- SESSION_ID: the attn session id for this transcript.
+- RAW_DIGEST_PATH: the exact file you must write your digest to.
+
+Use your own file tools (Read, Grep, Bash) for everything. Do not call any attn
+command or MCP server.
+
+== LOCATING THE TRANSCRIPT ==
+
+TRANSCRIPT_PATH is authoritative — read that file. It is one of:
+
+- A Claude transcript: ~/.claude/projects/<cwd-slug>/<sessionId>.jsonl — JSON Lines,
+  one JSON object per line, each with a "type" field ("user", "assistant",
+  "system", "file-history-snapshot", "mode", …). Assistant/user message content is
+  under .message.content, which is either a string or an array of typed blocks
+  ("text", "tool_use", "tool_result").
+- A Codex transcript: ~/.codex/sessions/YYYY/MM/DD/rollout-<timestamp>-<uuid>.jsonl —
+  also JSON Lines; user/assistant turns and tool calls/outputs are interleaved as
+  typed records.
+
+If TRANSCRIPT_PATH does not exist or is empty (the session may have left no usable
+transcript), do NOT invent content. Write a digest whose body is exactly the line
+` + "`No readable transcript for this session.`" + ` under the headers below, with the
+source footer, and stop. A missing transcript is a fact, not a failure.
+
+Large transcripts: if the file is big, Grep for turn boundaries and tool records
+instead of reading it whole. You need the shape of the work, not every token.
+
+== EPISTEMIC TIERING (the core rule — do not violate it) ==
+
+A transcript mixes three kinds of statements with very different trust. Keep them
+separate and never launder a lower tier into a higher one.
+
+1. TOOL RESULTS = mechanical ground truth. The actual stdout/exit code of a build,
+   test, lint, git, or file operation is what really happened. A passing test suite,
+   a clean ` + "`go build`" + `, a successful commit, a file that was actually written — these
+   are facts. Prefer them above everything. When you state an outcome, ground it in
+   the tool result that proves it.
+
+2. USER TURNS = intent and authority. What the user asked for is the goal. The
+   user's acceptance, correction, or rejection OUTRANKS the agent's own
+   self-assessment. If the agent declared "done" but the user replied "that's wrong"
+   / "still broken" / "revert that" / asked for a redo, the work was NOT done —
+   record it as corrected or rejected, and say what the correction was. A user
+   "thanks, ship it" is real acceptance; record it as such.
+
+3. AGENT PROSE = a claim, never a fact. The agent saying "I fixed it", "all tests
+   pass", "this is complete", "successfully implemented" is an ASSERTION. It becomes
+   fact only when a tool result or user acceptance backs it. If the agent claims
+   success but no tool result confirms it (or a tool result contradicts it), record
+   it as CLAIMED, not done — e.g. "agent reported the fix complete; not confirmed by
+   tests" or "agent claimed passing tests but the last ` + "`go test`" + ` shown failed."
+
+When tiers conflict, the order of authority is: tool result ≈ user acceptance >
+agent prose. Surface the conflict rather than resolving it silently in the agent's
+favor.
+
+== WHAT TO EXTRACT ==
+
+Read the session and capture:
+- The user's actual request(s) and goal for this session — in their terms.
+- What was actually done, grounded in tool results: code/files changed, commands
+  run and their real outcomes, commits/PRs, tests/builds and whether they truly
+  passed.
+- Decisions made and the reasoning, especially any the user ratified or overrode.
+- Dead-ends and course-corrections: approaches tried and ABANDONED, and what
+  replaced them. These matter — your narrate duty uses them to tell the real story.
+- What FAILED or remains broken/unverified (claimed-but-unconfirmed belongs here).
+- What is left unresolved or handed off (next steps the session did not finish).
+
+Keep it faithful and compact. This is raw input, not the final journal — do not
+editorialize, do not praise, do not pad. Omit routine play-by-play (file reads,
+navigation, trivial edits) unless it carries a decision or an outcome. Never
+include secrets, credentials, tokens, or full file dumps.
+
+== OUTPUT FORMAT (exact, greppable headers) ==
+
+Write Markdown with these headers, in this order. Omit a section only if it has no
+content (never write a placeholder like "N/A"); always keep "## Requested" and
+"## Done".
+
+    # Session Digest
+
+    source: session:<SESSION_ID>
+    transcript: <TRANSCRIPT_PATH>
+
+    ## Requested
+    <what the user asked for / the session goal, in their terms>
+
+    ## Done
+    <what actually happened, grounded in tool results — each claim traceable to a
+    real outcome; mark agent-only claims as "claimed, unconfirmed">
+
+    ## Decisions
+    <decisions made and why; note which the user ratified or overrode>
+
+    ## Dead-ends
+    <approaches tried and abandoned, and what replaced them>
+
+    ## Failed / Unverified
+    <what failed, is still broken, or was claimed but not confirmed by a tool result
+    or the user>
+
+    ## Unresolved
+    <what is left open / handed off / not finished>
+
+Tier discipline shows up in the prose: write "tests passed (` + "`go test ./...`" + ` clean)"
+when a tool result proves it; write "agent reported tests passing; not shown" when
+only prose asserts it. Keep the whole digest tight — a scannable note, not a
+transcript.
+
+== WRITE MECHANICS ==
+
+Write your finished digest to RAW_DIGEST_PATH using your Write tool. The parent
+directory already exists.
+
+CONCURRENCY / STALENESS: your Write tool requires a prior Read of a file before
+overwriting it and will REJECT a write if the file changed on disk since you last
+read it. If a write is rejected as stale: re-read RAW_DIGEST_PATH, reconcile (a
+prior run of you may have written a digest for this same session — your job is one
+correct current digest for this SESSION_ID, so it is fine to replace stale content
+with your fresh, faithful version), and write again. Do not append duplicate
+digests; this file holds exactly one digest for this session. The written file is
+the only evidence that you succeeded — make sure the write lands.`
+
+// narrateWorkspacePromptBrief is prompt 8B (narrate_workspace, strong tier). The
+// session-narration text is verbatim from docs/plans/2026-06-14-notebook-narration.md
+// section 8; the removal-pass knowledge-base archive step is added from
+// docs/plans/2026-06-18-knowledge-base.md (PR3) and is the source of truth for its
+// exact wording. The absolute INPUT/OUTPUT path block (WORKSPACE_TITLE, WORKSPACE_ID,
+// CONTEXT_SNAPSHOT_PATH, RAW_SESSIONS_DIR, RAW_DISPATCHES_DIR, TRANSCRIPT_PATHS,
+// JOURNAL_PATH, JOURNAL_DIR, KNOWLEDGE_DIR, IS_REMOVAL_PASS) is appended by
+// buildNarrateWorkspacePrompt.
+const narrateWorkspacePromptBrief = `You are the attn keeper, narrating this workspace's work into the journal. The
+Notebook is a durable HUMAN work-journal: the user's lasting record of what they
+decided, built, fought, shipped, and learned while driving agents — read back later
+for recall and for performance reviews. You write the CURATED narrative. You are the
+only agent (besides the human) who narrates a workspace into the journal, so the
+quality bar is the product: write what a sharp engineer would want to reread about
+their own week, not a changelog.
+
+You are narrating ONE workspace. Use your own file tools (Read, Write, Edit, Grep,
+Bash) for everything. Do not call any attn command or MCP server.
+
+INPUTS (absolute paths, given to you below this brief):
+- WORKSPACE_TITLE: the human name of the workspace.
+- WORKSPACE_ID: its stable id.
+- CONTEXT_SNAPSHOT_PATH: the workspace's context.md editorial overlay — the agents'
+  and user's own running notes (Decisions / Constraints / Current Picture). On the
+  removal pass this is the final snapshot. THIS IS SALIENCE, NOT TRUTH (see below).
+- RAW_SESSIONS_DIR: directory of per-session digests for this workspace's sessions
+  (files named <sessionId>.md). Read these.
+- RAW_DISPATCHES_DIR: directory of per-dispatch outcome files for terminal
+  chief-of-staff dispatches (may be empty). Read these for delegated-work outcomes.
+- TRANSCRIPT_PATHS: absolute paths to the underlying session transcripts, available
+  if you need to verify a claim or resolve a divergence at the source.
+- JOURNAL_PATH: today's curated journal file — journal/<today>.md — the file you
+  write to.
+- JOURNAL_DIR: the directory of dated journal files (journal/<date>.md), so you can
+  read your own prior entries across days.
+- KNOWLEDGE_DIR: the Notebook's knowledge-base root (knowledge/), holding the PARA
+  subtree projects/ areas/ resources/ archive/. You touch it ONLY on a removal pass,
+  to file this workspace's project folder away (see ARCHIVE THE WORKSPACE'S PROJECT
+  FOLDER below). On an active-day pass, ignore it entirely.
+- IS_REMOVAL_PASS: true if this is the workspace's final removal-day narration (the
+  full retrospective), false for a routine active-day pass.
+
+== READ BEFORE YOU WRITE (build enough context for the next step of the story) ==
+
+1. Read CONTEXT_SNAPSHOT_PATH first — it is the fastest signal of what the people in
+   this workspace thought was important: the decisions they recorded, the
+   constraints they set, the current picture. LEAD WITH IT for salience: it tells
+   you where to point your attention.
+
+2. Read every digest in RAW_SESSIONS_DIR and every file in RAW_DISPATCHES_DIR. These
+   are the grounded raw record (each digest already separates tool-result truth from
+   agent claims; respect that tiering — do not promote a "claimed, unconfirmed"
+   item to a shipped fact).
+
+3. Read your OWN prior journal entries for this workspace. Find them by their
+   greppable headers (see format): grep JOURNAL_DIR for the workspace marker
+   ` + "`<!-- attn:wsnarr:<WORKSPACE_ID> -->`" + ` and read the dated entries you wrote on
+   earlier days. Read back across previous days until you have enough continuity to
+   tell the NEXT step of the story without repeating what you already told — the
+   journal is a continuing narrative, not independent daily dumps. Do not re-litigate
+   a decision you already recorded; advance it.
+   If the grep finds NO prior entry for this WORKSPACE_ID (this is the first pass, or
+   a short-lived workspace removed before any daily pass ran), there is no prior
+   history to continue — write a self-contained entry from the raw inputs alone. On a
+   removal pass with no prior entries, the retrospective IS the whole story told once,
+   not a continuation; build it entirely from CONTEXT_SNAPSHOT_PATH + the digests +
+   the dispatch outcomes. Never block or skip the write because prior history is
+   missing — missing history is the common short-workspace case, not an error.
+
+4. Only open TRANSCRIPT_PATHS when you need to verify a specific claim or chase a
+   divergence to its source. You do not need to read them all.
+
+== SALIENCE vs GROUND TRUTH (the editorial discipline) ==
+
+context.md is the editorial OVERLAY — it tells you what people CARED about, which is
+where to aim. But it is ephemeral, sometimes aspirational, and sometimes wrong. The
+session digests and dispatch outcomes (grounded in tool results) are the TRUTH. Your
+craft is to reconcile the two and SURFACE THE DIVERGENCE, because the gaps are the
+most valuable thing in a work-journal:
+
+- CLAIMED-BUT-ABANDONED: context.md (or an agent) says an approach was the plan, but
+  the digests show it was tried and dropped for something else. Tell that story — the
+  dead-end and the pivot is exactly what a perf-review reader wants.
+- DID-BUT-NEVER-MENTIONED: the digests show real shipped work (a fix, a refactor, a
+  hard debugging win confirmed by tool results) that context.md never recorded.
+  Surface it — silent wins are the ones people forget at review time.
+- CLAIMED-DONE-BUT-NOT-CONFIRMED: prose declared victory but no tool result or user
+  acceptance backs it. Do not record it as shipped. Record it honestly ("believed
+  fixed; not yet verified") or omit it.
+
+Never let agent prose launder into journal fact. When the overlay and the grounded
+record disagree, the grounded record wins and the disagreement itself is worth a line.
+
+== THE CURATION BAR ==
+
+This is a human performance-review journal, not a log. Be ruthlessly selective:
+
+- Keep: the singular important decisions and WHY; the real fights and how they
+  resolved; what actually shipped and why it mattered; hard-won fixes and root
+  causes; meaningful failures and what was learned; notable course-corrections.
+- Cut: routine steps, file-by-file edits, tool churn, restated requests, anything a
+  tool already does mechanically. If a sentence would not help the user remember or
+  evaluate the work months later, delete it.
+- Voice: factual, specific, a little narrative. Name the decision and the trade-off.
+  Prefer "chose file-backed JSON tasks over a SQLite table to avoid a burned
+  migration version, accepting weaker query ability" over "made good progress on the
+  task runner." Ground claims; prefer tool-result-backed outcomes over assertions.
+
+A quiet day produces a SHORT entry, or refreshes the existing one with little
+change. Do not manufacture narrative to fill space.
+
+== CROSS-DAY RULES (strict) ==
+
+- You may ONLY write to JOURNAL_PATH (today's file). You may NEVER edit a prior
+  day's journal file — earlier days are immutable history. Read them for continuity;
+  do not touch them.
+- SAME DAY: if today's file already contains your entry for this workspace (its
+  marker is present), REFRESH it in place — rewrite your own dated entry to reflect
+  the fuller picture as of now. Do not append a second entry for the same workspace
+  on the same day.
+- ACROSS DAYS: each active day produces a fresh dated entry in that day's file,
+  advancing the story from where the prior days left off.
+- REMOVAL PASS (IS_REMOVAL_PASS = true): write the FULL RETROSPECTIVE for the
+  workspace into today's file — the arc from start to finish: what it set out to do,
+  the key decisions and fights, what shipped, what was abandoned and why, what was
+  left unfinished, and the honest outcome. This is the entry the user will reread to
+  understand the whole effort, so it is the most important one. It still goes only in
+  today's file, refreshing today's entry if one already exists.
+
+== OUTPUT FORMAT (exact, greppable headers) ==
+
+Each workspace entry in a day's file is a self-contained block delimited by a hidden
+HTML-comment marker so you (and future passes) can find and rewrite exactly your own
+entry. The marker renders invisibly in a Markdown viewer.
+
+    ## <WORKSPACE_TITLE> — <YYYY-MM-DD>
+    <!-- attn:wsnarr:<WORKSPACE_ID> -->
+
+    <the curated narrative prose: tight paragraphs and/or bullets covering the
+    important decisions, fights, shipped work, dead-ends, and what's unresolved —
+    selected per the curation bar above. On a removal pass, this is the full
+    retrospective. Lead with what matters most.>
+
+    source: workspace:<WORKSPACE_ID>
+
+Use the date that JOURNAL_PATH is named for in the header. Keep the marker line
+EXACTLY as shown (it is the dedup/locate key — one entry per workspace per day).
+Within the prose you may use sub-bullets, but do not introduce other ` + "`<!-- ... -->`" + `
+markers and do not reuse another workspace's marker.
+
+Place a new entry by appending it to the file (creating the file if absent). When
+refreshing your existing same-day entry, replace the block that runs from your
+` + "`## <title> — <date>`" + ` header through the line just before the next workspace's
+` + "`## `" + ` header (or end of file), so you rewrite only your own entry and leave other
+workspaces' entries untouched.
+
+== WRITE MECHANICS ==
+
+Write to JOURNAL_PATH with your Write/Edit tools.
+
+CONCURRENCY / STALENESS: the journal is shared — other workspaces' keepers and the
+human may write the same day's file concurrently. Your Write/Edit tools require a
+prior Read and will REJECT a write if the file changed on disk since you read it.
+When a write is rejected as stale:
+  1. Re-read JOURNAL_PATH.
+  2. Re-locate your workspace's marker. If your entry now exists (a concurrent or
+     prior write landed it), refresh THAT block in place; if not, append a fresh one.
+  3. Preserve every OTHER workspace's entry and any human-written content verbatim —
+     never drop or reorder content you did not author.
+  4. Write again. Retry until it lands.
+
+Operate only inside your own marker block. The journal is the only durable surface
+and prior days are immutable — a careless overwrite erases the user's real history,
+so when in doubt, read again and write less.
+
+== ARCHIVE THE WORKSPACE'S PROJECT FOLDER (removal pass only) ==
+
+This step runs ONLY when IS_REMOVAL_PASS = true, and ONLY after the retrospective
+above has been written. It is a mechanical tidy-up of the knowledge base, not a
+narration task — on an active-day pass, skip it entirely and do not touch
+KNOWLEDGE_DIR.
+
+A finished workspace may have a knowledge-base project folder under
+KNOWLEDGE_DIR/projects/ whose index.md frontmatter links it back to this workspace
+with the line ` + "`resource: attn:workspace/<WORKSPACE_ID>`" + `. The workspace is now gone,
+so that project is over — file it under archive/:
+
+1. Find the link with a LITERAL, WHOLE-LINE match — treat WORKSPACE_ID as a fixed
+   string, never a pattern, and require the entire frontmatter line to equal the link:
+       grep -lFx 'resource: attn:workspace/<WORKSPACE_ID>' KNOWLEDGE_DIR/projects/*/index.md
+   (-F keeps any regex/glob characters in the id inert; -x forces a whole-line match,
+   so a longer id like ` + "`auth-v2`" + ` can never match a removed ` + "`auth`" + `, and a line that
+   merely contains the id is not a match.) If nothing matches — or the glob matches no
+   files — there is no linked project: do nothing and stop. A workspace with no project
+   folder is the common case, not an error; a near-but-inexact line (extra characters
+   before or after the id, a quoted or commented value) is NOT a match, so do nothing
+   rather than guess.
+2. If exactly one project folder matches, move that whole folder to
+   KNOWLEDGE_DIR/archive/<same-folder-name>/ (e.g. ` + "`mv`" + ` via Bash). If a folder of
+   that name already exists under archive/, do NOT overwrite it — instead move the
+   folder to ` + "`<same-folder-name> (removed <date>)`" + `, where <date> is the YYYY-MM-DD
+   that JOURNAL_PATH is named for, so no archived history is clobbered.
+3. Do not edit the project's contents, rename the notes inside it, or touch any
+   other project. Promoting durable knowledge up into areas/ is the chief's
+   judgment call, not yours — you only file the closed project away.
+
+This is reversible bookkeeping: the folder still exists, just under archive/. If the
+match is ambiguous (more than one candidate folder, or you are unsure of the
+WORKSPACE_ID), do nothing and leave the knowledge base untouched rather than risk a
+wrong move.`
+
+// buildSummarizeSessionPrompt assembles the full positional prompt for the
+// summarize_session agent: the verbatim brief followed by the concrete absolute
+// INPUT/OUTPUT path block the brief promises is "given to you below this brief".
+func buildSummarizeSessionPrompt(transcriptPath, sessionID, rawDigestPath string) string {
+	var b strings.Builder
+	b.WriteString(summarizeSessionPromptBrief)
+	b.WriteString("\n\n== INPUTS / OUTPUT (absolute paths for this run) ==\n\n")
+	fmt.Fprintf(&b, "TRANSCRIPT_PATH: %s\n", transcriptPath)
+	fmt.Fprintf(&b, "SESSION_ID: %s\n", sessionID)
+	fmt.Fprintf(&b, "RAW_DIGEST_PATH: %s\n", rawDigestPath)
+	return b.String()
+}
+
+// narrateWorkspacePromptInputs carries the concrete run-time values appended below
+// the narrate brief.
+type narrateWorkspacePromptInputs struct {
+	WorkspaceTitle      string
+	WorkspaceID         string
+	ContextSnapshotPath string
+	RawSessionsDir      string
+	RawDispatchesDir    string
+	TranscriptPaths     []string
+	JournalPath         string
+	JournalDir          string
+	KnowledgeDir        string
+	IsRemovalPass       bool
+}
+
+// buildNarrateWorkspacePrompt assembles the full positional prompt for the
+// narrate_workspace agent: the verbatim brief followed by the concrete absolute
+// INPUT/OUTPUT path block and the run-time IS_REMOVAL_PASS flag.
+func buildNarrateWorkspacePrompt(in narrateWorkspacePromptInputs) string {
+	var b strings.Builder
+	b.WriteString(narrateWorkspacePromptBrief)
+	b.WriteString("\n\n== INPUTS / OUTPUT (absolute paths for this run) ==\n\n")
+	fmt.Fprintf(&b, "WORKSPACE_TITLE: %s\n", in.WorkspaceTitle)
+	fmt.Fprintf(&b, "WORKSPACE_ID: %s\n", in.WorkspaceID)
+	fmt.Fprintf(&b, "CONTEXT_SNAPSHOT_PATH: %s\n", in.ContextSnapshotPath)
+	fmt.Fprintf(&b, "RAW_SESSIONS_DIR: %s\n", in.RawSessionsDir)
+	fmt.Fprintf(&b, "RAW_DISPATCHES_DIR: %s\n", in.RawDispatchesDir)
+	if len(in.TranscriptPaths) == 0 {
+		b.WriteString("TRANSCRIPT_PATHS: (none resolved)\n")
+	} else {
+		fmt.Fprintf(&b, "TRANSCRIPT_PATHS:\n")
+		for _, p := range in.TranscriptPaths {
+			fmt.Fprintf(&b, "- %s\n", p)
+		}
+	}
+	fmt.Fprintf(&b, "JOURNAL_PATH: %s\n", in.JournalPath)
+	fmt.Fprintf(&b, "JOURNAL_DIR: %s\n", in.JournalDir)
+	fmt.Fprintf(&b, "KNOWLEDGE_DIR: %s\n", in.KnowledgeDir)
+	fmt.Fprintf(&b, "IS_REMOVAL_PASS: %t\n", in.IsRemovalPass)
+	return b.String()
+}

--- a/internal/daemon/notebook_narration_test.go
+++ b/internal/daemon/notebook_narration_test.go
@@ -1,0 +1,997 @@
+package daemon
+
+import (
+	"context"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/notebook"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/tasks"
+)
+
+// drainingConn returns a net.Conn whose writes are silently consumed, so
+// d.sendOK(conn) inside handleStop does not block or nil-deref in a test that only
+// cares about the narration-trigger side effects.
+func drainingConn(t *testing.T) net.Conn {
+	t.Helper()
+	client, server := net.Pipe()
+	go io.Copy(io.Discard, server)
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+	return client
+}
+
+// --- config ---
+
+func TestParseNotebookNarrationConfig(t *testing.T) {
+	t.Run("blank uses summarize tier default", func(t *testing.T) {
+		config, err := parseNotebookNarrationConfig(notebookSummarizeSessionKind, "")
+		if err != nil {
+			t.Fatalf("parse blank: %v", err)
+		}
+		if config.Agent != notebookSummarizeDefaultAgent || config.Model != notebookSummarizeDefaultModel {
+			t.Fatalf("config = %+v, want summarize default", config)
+		}
+	})
+
+	t.Run("blank uses narrate tier default", func(t *testing.T) {
+		config, err := parseNotebookNarrationConfig(notebookNarrateWorkspaceKind, "   ")
+		if err != nil {
+			t.Fatalf("parse blank: %v", err)
+		}
+		if config.Agent != notebookNarrateDefaultAgent || config.Model != notebookNarrateDefaultModel {
+			t.Fatalf("config = %+v, want narrate default", config)
+		}
+	})
+
+	t.Run("explicit value parses and lowercases agent", func(t *testing.T) {
+		config, err := parseNotebookNarrationConfig(notebookNarrateWorkspaceKind, `{"agent":"CLAUDE","model":"claude-opus-test"}`)
+		if err != nil {
+			t.Fatalf("parse explicit: %v", err)
+		}
+		if config.Agent != "claude" || config.Model != "claude-opus-test" {
+			t.Fatalf("config = %+v", config)
+		}
+	})
+
+	for name, raw := range map[string]string{
+		"missing model": `{"agent":"claude"}`,
+		"missing agent": `{"model":"claude-test"}`,
+		"unknown field": `{"agent":"claude","model":"claude-test","tier":"strong"}`,
+		"unknown agent": `{"agent":"missing","model":"x"}`,
+		"trailing json": `{"agent":"claude","model":"claude-test"} {}`,
+	} {
+		t.Run("invalid: "+name, func(t *testing.T) {
+			if _, err := parseNotebookNarrationConfig(notebookSummarizeSessionKind, raw); err == nil {
+				t.Fatalf("parseNotebookNarrationConfig(%q) succeeded", raw)
+			}
+		})
+	}
+}
+
+func TestNotebookNarrationConfigForAppliesDefaultsAndSettings(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+	// Unset -> tier defaults for both kinds.
+	summarize, err := d.notebookNarrationConfigFor(notebookSummarizeSessionKind)
+	if err != nil {
+		t.Fatalf("summarize default: %v", err)
+	}
+	if summarize.Model != notebookSummarizeDefaultModel {
+		t.Fatalf("summarize default model = %q", summarize.Model)
+	}
+	narrate, err := d.notebookNarrationConfigFor(notebookNarrateWorkspaceKind)
+	if err != nil {
+		t.Fatalf("narrate default: %v", err)
+	}
+	if narrate.Model != notebookNarrateDefaultModel {
+		t.Fatalf("narrate default model = %q", narrate.Model)
+	}
+
+	// A configured override is honored.
+	d.store.SetSetting(SettingNotebookNarrateWorkspace, `{"agent":"claude","model":"claude-custom"}`)
+	narrate, err = d.notebookNarrationConfigFor(notebookNarrateWorkspaceKind)
+	if err != nil {
+		t.Fatalf("narrate override: %v", err)
+	}
+	if narrate.Model != "claude-custom" {
+		t.Fatalf("narrate override model = %q", narrate.Model)
+	}
+}
+
+// --- prompt builders ---
+
+func TestBuildSummarizeSessionPromptEmbedsBriefAndPaths(t *testing.T) {
+	prompt := buildSummarizeSessionPrompt("/t/transcript.jsonl", "session-xyz", "/raw/sessions/session-xyz.md")
+	if !strings.Contains(prompt, "You are the attn keeper, performing your session-summary duty.") {
+		t.Fatal("summarize prompt dropped the verbatim brief")
+	}
+	for _, want := range []string{
+		"TRANSCRIPT_PATH: /t/transcript.jsonl",
+		"SESSION_ID: session-xyz",
+		"RAW_DIGEST_PATH: /raw/sessions/session-xyz.md",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("summarize prompt missing %q", want)
+		}
+	}
+}
+
+func TestBuildNarrateWorkspacePromptEmbedsBriefPathsAndRemovalFlag(t *testing.T) {
+	prompt := buildNarrateWorkspacePrompt(narrateWorkspacePromptInputs{
+		WorkspaceTitle:      "Chifplace",
+		WorkspaceID:         "ws-1",
+		ContextSnapshotPath: "/raw/context-snapshots/ws-1.md",
+		RawSessionsDir:      "/raw/sessions",
+		RawDispatchesDir:    "/raw/dispatches",
+		TranscriptPaths:     []string{"/t/a.jsonl", "/t/b.jsonl"},
+		JournalPath:         "/nb/journal/2026-06-15.md",
+		JournalDir:          "/nb/journal",
+		KnowledgeDir:        "/nb/knowledge",
+		IsRemovalPass:       true,
+	})
+	if !strings.Contains(prompt, "You are the attn keeper, narrating this workspace's work into the journal.") {
+		t.Fatal("narrate prompt dropped the verbatim brief")
+	}
+	for _, want := range []string{
+		"WORKSPACE_TITLE: Chifplace",
+		"WORKSPACE_ID: ws-1",
+		"CONTEXT_SNAPSHOT_PATH: /raw/context-snapshots/ws-1.md",
+		"RAW_SESSIONS_DIR: /raw/sessions",
+		"RAW_DISPATCHES_DIR: /raw/dispatches",
+		"- /t/a.jsonl",
+		"- /t/b.jsonl",
+		"JOURNAL_PATH: /nb/journal/2026-06-15.md",
+		"JOURNAL_DIR: /nb/journal",
+		"KNOWLEDGE_DIR: /nb/knowledge",
+		"IS_REMOVAL_PASS: true",
+		// The removal-pass knowledge-base archive step and its workspace-link hook.
+		"ARCHIVE THE WORKSPACE'S PROJECT FOLDER (removal pass only)",
+		"resource: attn:workspace/<WORKSPACE_ID>",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("narrate prompt missing %q", want)
+		}
+	}
+
+	// No transcripts renders the explicit "(none resolved)" line and IS_REMOVAL_PASS=false.
+	active := buildNarrateWorkspacePrompt(narrateWorkspacePromptInputs{WorkspaceID: "ws-2"})
+	if !strings.Contains(active, "TRANSCRIPT_PATHS: (none resolved)") {
+		t.Fatal("narrate prompt missing the empty-transcripts line")
+	}
+	if !strings.Contains(active, "IS_REMOVAL_PASS: false") {
+		t.Fatal("narrate prompt missing IS_REMOVAL_PASS: false")
+	}
+}
+
+// --- executor test rig ---
+
+// installNotebookNarrationRunner enables the daemon's runner over a temp root and
+// registers BOTH narration executors (real bodies), so the executors' resolve-
+// inputs / verify-ledger logic runs for real. The agent spawn itself is replaced
+// per-test via d.summarizeSessionExecution / d.narrateWorkspaceExecution. A fast
+// poll interval avoids real-time waits. Returns the notebook root.
+func installNotebookNarrationRunner(t *testing.T, d *Daemon) string {
+	t.Helper()
+	root := t.TempDir()
+	d.store.SetSetting(SettingNotebookRoot, root)
+	d.store.SetSetting(canonicalExecutableSettingKey("claude"), writeFakeAgentExecutable(t))
+
+	runner := tasks.New(tasks.Options{
+		Root:         filepath.Join(t.TempDir(), "tasks"),
+		Log:          func(string, ...interface{}) {},
+		PollInterval: 2 * time.Millisecond,
+	})
+	if err := runner.RegisterWithTimeout(notebookSummarizeSessionKind, d.summarizeSessionExecutor, notebookSummarizeSessionTimeout); err != nil {
+		t.Fatalf("register summarize_session: %v", err)
+	}
+	if err := runner.RegisterWithTimeout(notebookNarrateWorkspaceKind, d.narrateWorkspaceExecutor, notebookNarrateWorkspaceTimeout); err != nil {
+		t.Fatalf("register narrate_workspace: %v", err)
+	}
+	if err := runner.Start(); err != nil {
+		t.Fatalf("start runner: %v", err)
+	}
+	t.Cleanup(runner.Stop)
+	d.compactRunner = runner
+	return root
+}
+
+// writeFakeAgentExecutable writes an executable no-op script and returns its path,
+// so resolveNotebookNarrationExecutable's exec.LookPath succeeds without a real
+// claude/codex on PATH. The script is never actually invoked: the daemon-level
+// execution hook replaces RunHeadlessTask.
+func writeFakeAgentExecutable(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-agent")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake agent: %v", err)
+	}
+	return path
+}
+
+func waitForTaskState(t *testing.T, d *Daemon, kind, subject string, want tasks.State) *tasks.Task {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		task, err := d.compactRunner.Get(tasks.TaskID(kind, subject))
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task != nil && task.State == want {
+			return task
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task %s:%s did not reach %s (last=%+v)", kind, subject, want, task)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// --- summarize_session executor ---
+
+func TestSummarizeSessionExecutorVerifiesDigestLedger(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID: "session-1", Label: "session-1", Agent: protocol.SessionAgentClaude,
+		Directory: t.TempDir(), State: protocol.SessionStateIdle,
+		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	root := installNotebookNarrationRunner(t, d)
+
+	// A solo session (no workspace) lands its digest under the reserved _solo bucket.
+	soloBucket := filepath.Join(notebook.RawSessionsDir(root), notebookSoloSessionBucket)
+	digest := filepath.Join(soloBucket, "session-1.md")
+
+	// The fake agent writes the digest where the prompt told it to: success.
+	d.summarizeSessionExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		if err := os.WriteFile(digest, []byte("# Session Digest\n"), 0o644); err != nil {
+			t.Fatalf("fake write digest: %v", err)
+		}
+		// The prompt points the agent at the per-workspace bucket path.
+		if !strings.Contains(req.Prompt, "RAW_DIGEST_PATH: "+digest) {
+			t.Fatalf("prompt RAW_DIGEST_PATH not the bucketed path:\n%s", req.Prompt)
+		}
+		// The request widens to the digest's bucket dir for a Codex-backed narrate.
+		if len(req.ExtraWritableRoots) != 1 || req.ExtraWritableRoots[0] != soloBucket {
+			t.Fatalf("ExtraWritableRoots = %v, want [%s]", req.ExtraWritableRoots, soloBucket)
+		}
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookSummarizeSessionKind, "session-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", tasks.StateDone)
+
+	if _, err := os.Stat(digest); err != nil {
+		t.Fatalf("digest not written: %v", err)
+	}
+}
+
+func TestSummarizeSessionExecutorFailsWhenDigestMissing(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID: "session-1", Label: "session-1", Agent: protocol.SessionAgentClaude,
+		Directory: t.TempDir(), State: protocol.SessionStateIdle,
+		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	installNotebookNarrationRunner(t, d)
+
+	// The agent "succeeds" but writes nothing: the file is the ledger, so the run
+	// must fail (it goes failed/requeued, never done on the first attempt).
+	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		return agentdriver.HeadlessTaskResult{Diagnostics: "claimed done"}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookSummarizeSessionKind, "session-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	task := waitForNonDoneFailure(t, d, notebookSummarizeSessionKind, "session-1")
+	if !strings.Contains(task.LastError, "did not write digest") {
+		t.Fatalf("last error = %q, want digest-missing", task.LastError)
+	}
+}
+
+func TestSummarizeSessionExecutorSkipsRemovedSession(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	installNotebookNarrationRunner(t, d)
+
+	executed := false
+	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		executed = true
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	// No session row exists -> the executor no-ops successfully (nothing to retry).
+	if _, err := d.compactRunner.Enqueue(notebookSummarizeSessionKind, "gone-session", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookSummarizeSessionKind, "gone-session", tasks.StateDone)
+	if executed {
+		t.Fatal("executor ran the agent for a removed session")
+	}
+}
+
+// TestSummarizeSessionExecutorUsesCarriedMetaWhenRowGone is the core fix: after a
+// single-session-workspace teardown deletes BOTH the session row and the workspace
+// row, the debounced summarize must still write the digest to the workspace's bucket
+// (RawSessionsDir/<wsID>/<sid>.md), NOT the _solo bucket — using the transcript path
+// and workspace id carried on the task, since neither row exists to re-derive from.
+func TestSummarizeSessionExecutorUsesCarriedMetaWhenRowGone(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	root := installNotebookNarrationRunner(t, d)
+	// NO session row and NO workspace row: the teardown already removed both. Block
+	// any narrate the re-narrate hook enqueues so it cannot race to done/fail.
+	d.narrateWorkspaceExecution = blockingExecution(t)
+
+	carriedTranscript := filepath.Join(t.TempDir(), "final-turn.jsonl")
+	if err := os.WriteFile(carriedTranscript, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("seed transcript: %v", err)
+	}
+	wsBucket := filepath.Join(notebook.RawSessionsDir(root), "ws-gone")
+	digest := filepath.Join(wsBucket, "session-1.md")
+	soloDigest := filepath.Join(notebook.RawSessionsDir(root), notebookSoloSessionBucket, "session-1.md")
+
+	d.summarizeSessionExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		// The carried transcript (not a re-derived one) flows into the prompt.
+		if !strings.Contains(req.Prompt, "TRANSCRIPT_PATH: "+carriedTranscript) {
+			t.Fatalf("prompt did not use carried transcript path:\n%s", req.Prompt)
+		}
+		// The carried workspace id routes the digest to the workspace bucket.
+		if !strings.Contains(req.Prompt, "RAW_DIGEST_PATH: "+digest) {
+			t.Fatalf("digest not routed to workspace bucket:\n%s", req.Prompt)
+		}
+		if err := os.WriteFile(digest, []byte("# Final session digest\n"), 0o644); err != nil {
+			t.Fatalf("fake write digest: %v", err)
+		}
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookSummarizeSessionKind, "session-1", tasks.EnqueueOptions{
+		Meta: map[string]string{
+			notebookSummarizeMetaTranscript: carriedTranscript,
+			notebookSummarizeMetaWorkspace:  "ws-gone",
+		},
+	}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", tasks.StateDone)
+
+	if _, err := os.Stat(digest); err != nil {
+		t.Fatalf("digest not written to workspace bucket: %v", err)
+	}
+	if _, err := os.Stat(soloDigest); err == nil {
+		t.Fatal("digest leaked into the _solo bucket instead of the workspace bucket")
+	}
+}
+
+// TestSummarizeSessionReNarratesWhenWorkspaceRemoved proves the timing-gap hook: a
+// successful digest write for a session whose workspace ROW IS GONE re-enqueues a
+// zero-debounce narrate_workspace so the removal retrospective is rewritten with the
+// now-available digest.
+func TestSummarizeSessionReNarratesWhenWorkspaceRemoved(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	root := installNotebookNarrationRunner(t, d)
+	// Block narrate so the re-enqueued record stays observable instead of running.
+	d.narrateWorkspaceExecution = blockingExecution(t)
+
+	carriedTranscript := filepath.Join(t.TempDir(), "turn.jsonl")
+	if err := os.WriteFile(carriedTranscript, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("seed transcript: %v", err)
+	}
+	digest := filepath.Join(notebook.RawSessionsDir(root), "ws-gone", "session-1.md")
+	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		if err := os.WriteFile(digest, []byte("# digest\n"), 0o644); err != nil {
+			t.Fatalf("fake write digest: %v", err)
+		}
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	// No workspace row for ws-gone, both rows gone -> the hook should re-narrate.
+	if _, err := d.compactRunner.Enqueue(notebookSummarizeSessionKind, "session-1", tasks.EnqueueOptions{
+		Meta: map[string]string{
+			notebookSummarizeMetaTranscript: carriedTranscript,
+			notebookSummarizeMetaWorkspace:  "ws-gone",
+		},
+	}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", tasks.StateDone)
+
+	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-gone") {
+		t.Fatal("digest success for a removed workspace did not re-enqueue a narrate")
+	}
+}
+
+// TestSummarizeSessionDoesNotReNarrateWhenWorkspacePresent proves the hook is scoped
+// to removal: a successful digest for a session whose workspace row STILL EXISTS must
+// NOT burn an extra strong-tier narrate (the active workspace's pending narrate
+// already covers the fresh digest).
+func TestSummarizeSessionDoesNotReNarrateWhenWorkspacePresent(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "ws-live")
+	root := installNotebookNarrationRunner(t, d)
+	d.narrateWorkspaceExecution = blockingExecution(t)
+
+	digest := filepath.Join(notebook.RawSessionsDir(root), "ws-live", "session-1.md")
+	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		if err := os.WriteFile(digest, []byte("# digest\n"), 0o644); err != nil {
+			t.Fatalf("fake write digest: %v", err)
+		}
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookSummarizeSessionKind, "session-1", tasks.EnqueueOptions{
+		Meta: map[string]string{notebookSummarizeMetaWorkspace: "ws-live"},
+	}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookSummarizeSessionKind, "session-1", tasks.StateDone)
+
+	// The workspace is alive -> no re-narrate. Give the worker a beat; the narrate
+	// record must never appear.
+	time.Sleep(20 * time.Millisecond)
+	task, err := d.compactRunner.Get(tasks.TaskID(notebookNarrateWorkspaceKind, "ws-live"))
+	if err != nil {
+		t.Fatalf("get narrate: %v", err)
+	}
+	if task != nil {
+		t.Fatalf("live workspace unexpectedly got a re-narrate task: %+v", task)
+	}
+}
+
+// --- narrate_workspace executor ---
+
+func TestNarrateWorkspaceExecutorActiveDayVerifiesMarker(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+	root := installNotebookNarrationRunner(t, d)
+	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+
+	d.narrateWorkspaceExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		// Active day -> the live workspace row exists -> IS_REMOVAL_PASS false.
+		if !strings.Contains(req.Prompt, "IS_REMOVAL_PASS: false") {
+			t.Fatalf("expected active-day prompt, got removal flag set")
+		}
+		// The Codex sandbox widens to the whole notebook root.
+		if len(req.ExtraWritableRoots) != 1 || req.ExtraWritableRoots[0] != root {
+			t.Fatalf("ExtraWritableRoots = %v, want [%s]", req.ExtraWritableRoots, root)
+		}
+		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+		body := "## Chifplace — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nDid work.\n"
+		if err := os.WriteFile(journal, []byte(body), 0o644); err != nil {
+			t.Fatalf("fake write journal: %v", err)
+		}
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookNarrateWorkspaceKind, "ws-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", tasks.StateDone)
+
+	journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+	content, err := os.ReadFile(journal)
+	if err != nil {
+		t.Fatalf("read journal: %v", err)
+	}
+	if !strings.Contains(string(content), "attn:wsnarr:ws-1") {
+		t.Fatalf("journal missing workspace marker:\n%s", content)
+	}
+}
+
+func TestNarrateWorkspaceExecutorRemovalPassDerivesFlagFromAbsentRow(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	root := installNotebookNarrationRunner(t, d)
+	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+	// No workspace row for ws-removed -> IS_REMOVAL_PASS must be derived true.
+
+	var sawRemoval bool
+	d.narrateWorkspaceExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		sawRemoval = strings.Contains(req.Prompt, "IS_REMOVAL_PASS: true")
+		// Title falls back to the id when the row is gone.
+		if !strings.Contains(req.Prompt, "WORKSPACE_TITLE: ws-removed") {
+			t.Fatalf("removal prompt did not fall back title to id:\n%s", req.Prompt)
+		}
+		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+		body := "## ws-removed — 2026-06-15\n<!-- attn:wsnarr:ws-removed -->\n\nRetrospective.\n"
+		if err := os.WriteFile(journal, []byte(body), 0o644); err != nil {
+			t.Fatalf("fake write journal: %v", err)
+		}
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookNarrateWorkspaceKind, "ws-removed", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-removed", tasks.StateDone)
+	if !sawRemoval {
+		t.Fatal("removal pass did not derive IS_REMOVAL_PASS=true from absent workspace row")
+	}
+}
+
+func TestNarrateWorkspaceExecutorFailsWhenMarkerMissing(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+	root := installNotebookNarrationRunner(t, d)
+	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+
+	// Agent writes the day's file but NOT this workspace's marker -> ledger says no.
+	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+		if err := os.WriteFile(journal, []byte("## Other — 2026-06-15\n<!-- attn:wsnarr:other-ws -->\n"), 0o644); err != nil {
+			t.Fatalf("fake write journal: %v", err)
+		}
+		return agentdriver.HeadlessTaskResult{Diagnostics: "wrote wrong marker"}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookNarrateWorkspaceKind, "ws-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	task := waitForNonDoneFailure(t, d, notebookNarrateWorkspaceKind, "ws-1")
+	if !strings.Contains(task.LastError, "did not write") {
+		t.Fatalf("last error = %q, want marker-missing", task.LastError)
+	}
+}
+
+// waitForNonDoneFailure waits until a task has recorded a failure (LastError set
+// and not done). The runner auto-requeues failed tasks, so the task may cycle
+// failed->queued->running; we only assert it recorded the failure at least once.
+func waitForNonDoneFailure(t *testing.T, d *Daemon, kind, subject string) *tasks.Task {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		task, err := d.compactRunner.Get(tasks.TaskID(kind, subject))
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task != nil && task.LastError != "" && task.State != tasks.StateDone {
+			return task
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task %s:%s never recorded a failure (last=%+v)", kind, subject, task)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// --- triggers ---
+
+// TestHandleStopEnqueuesNarrationForWorkspaceSession proves a Stop on a workspace
+// session enqueues BOTH a per-session digest and a coalesced workspace narrate.
+func TestHandleStopEnqueuesNarrationForWorkspaceSession(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+	installNotebookNarrationRunner(t, d)
+	// Block both executors so the enqueued records stay observable.
+	d.summarizeSessionExecution = blockingExecution(t)
+	d.narrateWorkspaceExecution = blockingExecution(t)
+
+	d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "session-1"})
+
+	if !taskExists(t, d, notebookSummarizeSessionKind, "session-1") {
+		t.Fatal("stop did not enqueue summarize_session")
+	}
+	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-1") {
+		t.Fatal("stop did not enqueue narrate_workspace for the live workspace")
+	}
+}
+
+// TestHandleStopEnqueuesOnlyDigestForSoloSession proves a Stop on a session with no
+// workspace enqueues the digest but no workspace narrate.
+func TestHandleStopEnqueuesOnlyDigestForSoloSession(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID: "solo", Label: "solo", Agent: protocol.SessionAgentClaude,
+		Directory: t.TempDir(), State: protocol.SessionStateIdle,
+		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	installNotebookNarrationRunner(t, d)
+	d.summarizeSessionExecution = blockingExecution(t)
+
+	d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "solo"})
+
+	if !taskExists(t, d, notebookSummarizeSessionKind, "solo") {
+		t.Fatal("stop did not enqueue summarize_session for solo session")
+	}
+	// No workspace -> no narrate task at all.
+	task, err := d.compactRunner.Get(tasks.TaskID(notebookNarrateWorkspaceKind, ""))
+	if err != nil {
+		t.Fatalf("get narrate: %v", err)
+	}
+	if task != nil {
+		t.Fatalf("solo session unexpectedly enqueued a narrate task: %+v", task)
+	}
+}
+
+// TestHandleStopStashesTranscriptAndWorkspaceInMeta proves the Stop trigger carries
+// the transcript path and the workspace id onto the summarize task's Meta, where both
+// the session row and the workspace row still exist — so the debounced run can still
+// resolve them after a teardown deletes both rows.
+func TestHandleStopStashesTranscriptAndWorkspaceInMeta(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+	installNotebookNarrationRunner(t, d)
+	// Block both executors so the enqueued summarize record stays observable.
+	d.summarizeSessionExecution = blockingExecution(t)
+	d.narrateWorkspaceExecution = blockingExecution(t)
+
+	transcript := filepath.Join(t.TempDir(), "turn.jsonl")
+	if err := os.WriteFile(transcript, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("seed transcript: %v", err)
+	}
+
+	d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "session-1", TranscriptPath: transcript})
+
+	if !taskExists(t, d, notebookSummarizeSessionKind, "session-1") {
+		t.Fatal("stop did not enqueue summarize_session")
+	}
+	task, err := d.compactRunner.Get(tasks.TaskID(notebookSummarizeSessionKind, "session-1"))
+	if err != nil || task == nil {
+		t.Fatalf("get summarize task: %v", err)
+	}
+	if task.Meta[notebookSummarizeMetaTranscript] != transcript {
+		t.Fatalf("summarize Meta transcript = %q, want %q", task.Meta[notebookSummarizeMetaTranscript], transcript)
+	}
+	if task.Meta[notebookSummarizeMetaWorkspace] != "ws-1" {
+		t.Fatalf("summarize Meta workspace = %q, want ws-1", task.Meta[notebookSummarizeMetaWorkspace])
+	}
+}
+
+// TestWorkspaceRemovalEnqueuesFinalNarrateWithZeroDebounce proves the removal
+// boundary enqueues the final retrospective narrate that overrides a pending
+// active-day debounce (ZeroDebounce -> NextAttemptAt is not pushed forward).
+func TestWorkspaceRemovalEnqueuesFinalNarrate(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+	installNotebookNarrationRunner(t, d)
+	d.narrateWorkspaceExecution = blockingExecution(t)
+
+	// Pre-seed a far-future debounced active-day narrate.
+	if _, err := d.compactRunner.Enqueue(notebookNarrateWorkspaceKind, "ws-1", tasks.EnqueueOptions{Debounce: time.Hour}); err != nil {
+		t.Fatalf("seed pending narrate: %v", err)
+	}
+	before, err := d.compactRunner.Get(tasks.TaskID(notebookNarrateWorkspaceKind, "ws-1"))
+	if err != nil || before == nil {
+		t.Fatalf("get seeded task: %v", err)
+	}
+
+	// Remove the workspace (the app's UnregisterWorkspace path).
+	d.handleUnregisterWorkspace(nil, &protocol.UnregisterWorkspaceMessage{ID: "ws-1"})
+
+	if d.store.GetWorkspace("ws-1") != nil {
+		t.Fatal("workspace not removed")
+	}
+	after, err := d.compactRunner.Get(tasks.TaskID(notebookNarrateWorkspaceKind, "ws-1"))
+	if err != nil || after == nil {
+		t.Fatalf("get final task: %v", err)
+	}
+	// ZeroDebounce overrode the hour-long debounce: the final attempt is no later
+	// than the seeded one (in practice much sooner / now).
+	if after.NextAttemptAt.After(before.NextAttemptAt) {
+		t.Fatalf("final narrate did not override the pending debounce: before=%s after=%s",
+			before.NextAttemptAt, after.NextAttemptAt)
+	}
+}
+
+// TestNarrationTriggersAreNilSafeBeforeRunner proves the Stop and removal triggers
+// tolerate a nil compactRunner (the window before startCompactRunner runs).
+func TestNarrationTriggersAreNilSafeBeforeRunner(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+	d.compactRunner = nil // mimic production before startCompactRunner
+
+	// Neither must panic.
+	d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "session-1"})
+	d.handleUnregisterWorkspace(nil, &protocol.UnregisterWorkspaceMessage{ID: "ws-1"})
+
+	if d.store.GetWorkspace("ws-1") != nil {
+		t.Fatal("workspace not removed after nil-runner unregister")
+	}
+}
+
+// blockingExecution returns an execution hook that blocks until the test ends, so
+// an enqueued task that the worker picks up stays observable as running rather than
+// racing to done/failed before the assertion reads it.
+func blockingExecution(t *testing.T) func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+	t.Helper()
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	return func(ctx context.Context, _ agentdriver.HeadlessTaskProvider, _ agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return agentdriver.HeadlessTaskResult{}, ctx.Err()
+	}
+}
+
+// --- path-traversal guard (the load-bearing security property) ---
+
+// journalDirHasUnexpectedFiles fails the test if anything other than the allowed
+// files appears under <root>/journal/, so a path-traversal write that escaped the
+// raw tier into the curated journal dir is caught.
+func assertJournalUntouched(t *testing.T, root string) {
+	t.Helper()
+	journalDir := filepath.Join(root, notebook.DirJournal)
+	entries, err := os.ReadDir(journalDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return // no journal dir at all -> nothing escaped into it
+		}
+		t.Fatalf("read journal dir: %v", err)
+	}
+	for _, e := range entries {
+		t.Fatalf("journal dir unexpectedly contains %q — a write escaped the raw tier", e.Name())
+	}
+}
+
+// TestSummarizeSessionExecutorRejectsTraversalSessionID proves a crafted session id
+// that filepath.Clean would resolve into the curated journal is rejected before the
+// agent runs, and nothing lands under the journal dir. The base raw-floor PR added
+// rawTierFilename precisely for this; this is the missing load-bearing test.
+func TestSummarizeSessionExecutorRejectsTraversalSessionID(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	now := string(protocol.TimestampNow())
+	craftedID := "../../../journal/2026-06-15"
+	d.store.Add(&protocol.Session{
+		ID: craftedID, Label: craftedID, Agent: protocol.SessionAgentClaude,
+		Directory: t.TempDir(), State: protocol.SessionStateIdle,
+		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	root := installNotebookNarrationRunner(t, d)
+
+	ran := false
+	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		ran = true
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookSummarizeSessionKind, craftedID, tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	task := waitForNonDoneFailure(t, d, notebookSummarizeSessionKind, craftedID)
+	if !strings.Contains(task.LastError, "unsafe session id") {
+		t.Fatalf("last error = %q, want unsafe-session-id rejection", task.LastError)
+	}
+	if ran {
+		t.Fatal("executor spawned the agent for a traversal session id")
+	}
+	assertJournalUntouched(t, root)
+}
+
+// TestNarrateWorkspaceExecutorRejectsTraversalWorkspaceID proves a crafted workspace
+// id is rejected (so the narrate pass is never handed a CONTEXT_SNAPSHOT_PATH/journal
+// read target that climbed out of the raw tier) and nothing lands under the journal.
+func TestNarrateWorkspaceExecutorRejectsTraversalWorkspaceID(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	root := installNotebookNarrationRunner(t, d)
+	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+
+	craftedID := "../../../journal/2026-06-15"
+	ran := false
+	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		ran = true
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookNarrateWorkspaceKind, craftedID, tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	task := waitForNonDoneFailure(t, d, notebookNarrateWorkspaceKind, craftedID)
+	if !strings.Contains(task.LastError, "unsafe workspace id") {
+		t.Fatalf("last error = %q, want unsafe-workspace-id rejection", task.LastError)
+	}
+	if ran {
+		t.Fatal("executor spawned the agent for a traversal workspace id")
+	}
+	assertJournalUntouched(t, root)
+}
+
+// --- ledger freshness (no false done off a prior run's file) ---
+
+// TestSummarizeSessionExecutorRequiresFreshDigest proves a coalesced re-run whose
+// agent leaves the prior digest byte-identical is treated as a failure, not a false
+// done — otherwise a stale digest (missing the new turns) would report success.
+func TestSummarizeSessionExecutorRequiresFreshDigest(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{
+		ID: "session-1", Label: "session-1", Agent: protocol.SessionAgentClaude,
+		Directory: t.TempDir(), State: protocol.SessionStateIdle,
+		StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	root := installNotebookNarrationRunner(t, d)
+
+	digest := filepath.Join(notebook.RawSessionsDir(root), notebookSoloSessionBucket, "session-1.md")
+	if err := os.MkdirAll(filepath.Dir(digest), 0o755); err != nil {
+		t.Fatalf("mkdir bucket: %v", err)
+	}
+	if err := os.WriteFile(digest, []byte("# Session Digest\n\nprior run\n"), 0o644); err != nil {
+		t.Fatalf("seed prior digest: %v", err)
+	}
+
+	// Agent no-ops: leaves the prior digest exactly as-is.
+	d.summarizeSessionExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookSummarizeSessionKind, "session-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	task := waitForNonDoneFailure(t, d, notebookSummarizeSessionKind, "session-1")
+	if !strings.Contains(task.LastError, "unchanged") {
+		t.Fatalf("last error = %q, want unchanged-digest rejection", task.LastError)
+	}
+}
+
+// TestNarrateWorkspaceExecutorRequiresFreshEntry proves the removal retrospective
+// is not silently dropped when an active-day entry already exists: a re-run whose
+// agent leaves this workspace's marker block byte-identical fails (and is retried),
+// instead of being marked done off the prior block.
+func TestNarrateWorkspaceExecutorRequiresFreshEntry(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	root := installNotebookNarrationRunner(t, d)
+	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+
+	journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+	if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
+		t.Fatalf("mkdir journal: %v", err)
+	}
+	prior := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nactive-day entry\n\nsource: workspace:ws-1\n"
+	if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
+		t.Fatalf("seed prior entry: %v", err)
+	}
+
+	// Removal-pass agent no-ops: leaves the active-day block exactly as-is.
+	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookNarrateWorkspaceKind, "ws-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	task := waitForNonDoneFailure(t, d, notebookNarrateWorkspaceKind, "ws-1")
+	if !strings.Contains(task.LastError, "unchanged") {
+		t.Fatalf("last error = %q, want unchanged-entry rejection", task.LastError)
+	}
+}
+
+// --- marker prefix collision (sibling whose id is a prefix) ---
+
+// TestWorkspaceNarrationBlockNoPrefixCollision proves ws-1's success ledger is not
+// satisfied by ws-10's entry. A bare-substring match would falsely verify ws-1 off
+// `<!-- attn:wsnarr:ws-10 -->`; the full delimited marker line does not.
+func TestWorkspaceNarrationBlockNoPrefixCollision(t *testing.T) {
+	dir := t.TempDir()
+	journal := filepath.Join(dir, "2026-06-15.md")
+	// Only ws-10 has an entry. ws-1 is a prefix of ws-10.
+	body := "## ws-10 — 2026-06-15\n<!-- attn:wsnarr:ws-10 -->\n\nsibling entry\n\nsource: workspace:ws-10\n"
+	if err := os.WriteFile(journal, []byte(body), 0o644); err != nil {
+		t.Fatalf("write journal: %v", err)
+	}
+
+	got, err := workspaceNarrationBlock(journal, "ws-1")
+	if err != nil {
+		t.Fatalf("workspaceNarrationBlock: %v", err)
+	}
+	if got.present {
+		t.Fatal("ws-1 ledger falsely verified off ws-10's entry (prefix collision)")
+	}
+
+	// ws-10 itself is correctly found.
+	got, err = workspaceNarrationBlock(journal, "ws-10")
+	if err != nil {
+		t.Fatalf("workspaceNarrationBlock ws-10: %v", err)
+	}
+	if !got.present || !strings.Contains(got.body, "sibling entry") {
+		t.Fatalf("ws-10 ledger did not find its own entry: %+v", got)
+	}
+}
+
+// --- per-workspace digest scoping (no cross-workspace contamination) ---
+
+// TestNarrateWorkspaceScopesSessionsToWorkspace proves each narrate pass is handed
+// only its OWN workspace's digest bucket, so one workspace's journal entry cannot be
+// contaminated with a sibling's (or a solo session's) digests.
+func TestNarrateWorkspaceScopesSessionsToWorkspace(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-a", "ws-1")
+	root := installNotebookNarrationRunner(t, d)
+	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+
+	wantDir, err := notebookWorkspaceSessionsDir(root, "ws-1")
+	if err != nil {
+		t.Fatalf("workspace sessions dir: %v", err)
+	}
+	if wantDir == notebook.RawSessionsDir(root) {
+		t.Fatal("per-workspace dir collapsed to the shared flat sessions dir")
+	}
+
+	d.narrateWorkspaceExecution = func(_ context.Context, _ agentdriver.HeadlessTaskProvider, req agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		if !strings.Contains(req.Prompt, "RAW_SESSIONS_DIR: "+wantDir) {
+			t.Fatalf("narrate prompt RAW_SESSIONS_DIR not scoped to ws-1:\n%s", req.Prompt)
+		}
+		journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+		body := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nwork.\n"
+		if err := os.WriteFile(journal, []byte(body), 0o644); err != nil {
+			t.Fatalf("fake write journal: %v", err)
+		}
+		return agentdriver.HeadlessTaskResult{}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookNarrateWorkspaceKind, "ws-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", tasks.StateDone)
+}
+
+// --- config-time validation (fail fast, not mid-run hang) ---
+
+// TestDaemon_ValidatesNotebookNarrationAgentAndExecutable mirrors the keeper compaction
+// validate test: a valid config passes, a missing configured executable is rejected
+// at config time, a blank value validates (tier default), and invalid JSON is
+// rejected through the handler-facing validateSetting route — for BOTH narration
+// keys.
+func TestDaemon_ValidatesNotebookNarrationAgentAndExecutable(t *testing.T) {
+	tempDir := t.TempDir()
+	executable := filepath.Join(tempDir, "custom-claude")
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", tempDir)
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.store.SetSetting(canonicalExecutableSettingKey("claude"), "custom-claude")
+
+	for _, key := range []string{SettingNotebookSummarizeSession, SettingNotebookNarrateWorkspace} {
+		// Blank validates (tier default), but the default agent must still resolve.
+		if err := d.validateSetting(key, ""); err != nil {
+			t.Fatalf("%s: blank rejected: %v", key, err)
+		}
+		// Explicit valid config passes.
+		if err := d.validateSetting(key, `{"agent":"claude","model":"m"}`); err != nil {
+			t.Fatalf("%s: valid config rejected: %v", key, err)
+		}
+		// Invalid JSON is rejected through the handler route.
+		if err := d.validateSetting(key, `{"agent":"claude"`); err == nil {
+			t.Fatalf("%s: invalid JSON accepted", key)
+		}
+	}
+
+	// A missing configured executable is rejected at config time.
+	d.store.SetSetting(canonicalExecutableSettingKey("claude"), "missing-claude")
+	if err := d.validateSetting(SettingNotebookNarrateWorkspace, `{"agent":"claude","model":"m"}`); err == nil {
+		t.Fatal("narrate setting accepted a missing configured executable")
+	}
+}
+
+func taskExists(t *testing.T, d *Daemon, kind, subject string) bool {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		task, err := d.compactRunner.Get(tasks.TaskID(kind, subject))
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task != nil {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
The two agentic narration tasks: `summarize_session` (cheap tier → per-session raw digest) and `narrate_workspace` (strong tier → curated `journal/<date>.md`), both carrying verbatim mechanics+expectations prompts. The removal pass writes a full retrospective and then **archives the workspace's `knowledge/projects/<slug>/` folder** to `archive/`, matched by a literal whole-line grep (`grep -Fx`) on the `resource: attn:workspace/<id>` marker so a short id can't substring-match a longer live workspace. Dormant until #8.
---
**Final-state re-split of the knowledge-base / keeper epic** (supersedes #335–#343, #345). The original stack was split by chronology and carried mid-epic churn; this one is sliced by subsystem from the net diff, so each PR is a clean final-state slice.

Stack: `1 task-engine` · `2 notebook-kb` · `3 agent-native` · `4 store-keeper` · `5 keeper-compaction` · `6 keeper-narration` · `7 keeper-cron` · **`8 integration`** · `9 frontend` · `10 cli/docs`

This is PR **6/10** — base `kb/05-keeper-compaction-capture`. Review per-diff. By design the refactor only activates in #8 (where the keeper is wired and the janitor/dreaming are deleted), so branches 2–9 are not individually `go build`-clean; the merged tip (#10) is build + vet + test green.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. `feat/chifplace`
2. #347
3. #348
4. #349
5. #350
6. #351
7. **#352** 👈 current
8. #353
9. #354
10. #355
11. #356
<!-- stack:links:end -->