### PR TITLE
feat(daemon): daily-cron narrate backstop

### DIFF
--- a/internal/daemon/notebook_cron.go
+++ b/internal/daemon/notebook_cron.go
@@ -1,0 +1,270 @@
+package daemon
+
+import (
+	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/victorarias/attn/internal/notebook"
+)
+
+// Notebook cron enqueuer.
+//
+// A single per-minute, timezone-aware cron tick drives the notebook's scheduled
+// background work. The tick is a thin schedule-and-dispatch loop: it decides what
+// is due and enqueues onto the durable runner (internal/tasks), which owns
+// execution, single-flight, retry/backoff, and crash recovery. Today it dispatches
+// the daily per-workspace narrate backstop (enqueueDueDailyNarrates). The minute
+// granularity is ample for a nightly pass and keeps catch-up logic trivial.
+
+const (
+	// defaultNotebookCronFrequency is the nightly slot (03:00 in the configured
+	// timezone — quiet hours, after a day's journals and dispatches have landed)
+	// the notebook cron fires on by default.
+	defaultNotebookCronFrequency = "0 3 * * *"
+
+	// defaultNotebookCronInterval is how often the cron checks whether work is
+	// due. A daily pass does not need finer granularity.
+	defaultNotebookCronInterval = time.Minute
+)
+
+// legacyNotebookDreaming*Key are the pre-rename persisted settings keys.
+// frequency/timezone are retained ONLY so migrateNotebookCronSettingKeys can copy a
+// user's configured schedule forward to the notebook.cron.* keys; the enabled gate
+// has no cron successor (it died with the dreaming feature) and is only reaped.
+// Never read any of these anywhere else.
+const (
+	legacyNotebookDreamingFrequencyKey = "notebook.dreaming.frequency"
+	legacyNotebookDreamingTimezoneKey  = "notebook.dreaming.timezone"
+	legacyNotebookDreamingEnabledKey   = "notebook.dreaming.enabled"
+)
+
+// migrateNotebookCronSettingKeys performs the one-time rename of the persisted
+// notebook.dreaming.{frequency,timezone} settings to notebook.cron.* (the schedule
+// outlived the removed dreaming feature) and reaps the orphaned
+// notebook.dreaming.enabled gate (which has no successor). Like
+// migrateKeeperCompactSettingKey it runs at daemon start — and therefore again after
+// every app rebuild, since the daemon survives rebuilds — so it MUST be idempotent.
+// It copies each renamed legacy value forward only when the legacy key holds a
+// non-empty value AND the new key is still empty, so a re-run never clobbers a value
+// set under the new key, then deletes the stale legacy row so the migration is a
+// true no-op on the next boot. This is a plain settings-value copy, NOT a schema
+// migration.
+func (d *Daemon) migrateNotebookCronSettingKeys() {
+	if d.store == nil {
+		return
+	}
+	for _, m := range []struct{ legacy, current string }{
+		{legacyNotebookDreamingFrequencyKey, SettingNotebookCronFrequency},
+		{legacyNotebookDreamingTimezoneKey, SettingNotebookCronTimezone},
+	} {
+		legacy := d.store.GetSetting(m.legacy)
+		if strings.TrimSpace(legacy) == "" {
+			continue // nothing to migrate (or already migrated + cleaned up)
+		}
+		if strings.TrimSpace(d.store.GetSetting(m.current)) == "" {
+			d.store.SetSetting(m.current, legacy)
+			d.logf("migrated setting %q -> %q", m.legacy, m.current)
+		}
+		d.store.DeleteSetting(m.legacy)
+	}
+	// The enabled gate has no cron equivalent — just drop any stale row so it stops
+	// being broadcast in the settings map. DeleteSetting is a no-op when absent.
+	d.store.DeleteSetting(legacyNotebookDreamingEnabledKey)
+}
+
+// notebookCronFrequency returns the configured cron frequency or the default.
+func (d *Daemon) notebookCronFrequency() string {
+	if d.store != nil {
+		if f := strings.TrimSpace(d.store.GetSetting(SettingNotebookCronFrequency)); f != "" {
+			return f
+		}
+	}
+	return defaultNotebookCronFrequency
+}
+
+// notebookCronSchedule parses the configured frequency into a cron schedule, also
+// returning the raw expression for display/logging.
+func (d *Daemon) notebookCronSchedule() (cron.Schedule, string, error) {
+	raw := d.notebookCronFrequency()
+	sched, err := cron.ParseStandard(raw)
+	if err != nil {
+		return nil, raw, err
+	}
+	return sched, raw, nil
+}
+
+// notebookCronLocation returns the configured IANA timezone, falling back to the
+// machine's local time when unset or unparseable (so a bad setting degrades to a
+// sensible default rather than disabling the scheduler).
+func (d *Daemon) notebookCronLocation() *time.Location {
+	if d.store == nil {
+		return time.Local
+	}
+	tz := strings.TrimSpace(d.store.GetSetting(SettingNotebookCronTimezone))
+	if tz == "" {
+		return time.Local
+	}
+	if loc, err := time.LoadLocation(tz); err == nil {
+		return loc
+	}
+	d.logf("notebook cron: invalid timezone %q, using local time", tz)
+	return time.Local
+}
+
+// parseNotebookCronTime parses a persisted RFC3339 timestamp.
+func parseNotebookCronTime(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// startNotebookCronEnqueuer blocks running the notebook cron tick loop until done
+// is closed. Intended to be launched in its own goroutine from Start, AFTER
+// startCompactRunner so the narrate executor is registered before the first tick
+// can enqueue.
+//
+// Shutdown is by done alone (close(d.done) in Stop), like the daemon's other
+// d.done-driven loops; there is no explicit join. The enqueuer holds no run
+// machinery — it only dispatches onto the durable runner, which owns single-flight
+// and crash recovery — so there is nothing to drain on stop.
+func (d *Daemon) startNotebookCronEnqueuer(done <-chan struct{}) {
+	interval := d.notebookCronInterval
+	if interval <= 0 {
+		interval = defaultNotebookCronInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			d.notebookCronTick(time.Now())
+		}
+	}
+}
+
+// notebookCronTick is the per-tick fan-out of the single notebook cron. It enqueues
+// a per-active-workspace narrate for long-lived (never-removed) workspaces on the
+// nightly slot.
+func (d *Daemon) notebookCronTick(now time.Time) {
+	d.enqueueDueDailyNarrates(now)
+}
+
+// enqueueDueDailyNarrates decides, from the timezone-aware cron and the persisted
+// NarrateCronState anchor, whether the daily per-workspace narrate pass is due now;
+// when it is, it advances the anchor on a SINGLE state write, then drains the
+// activity set and enqueues a coalesced narrate_workspace for each STILL-LIVE
+// workspace that saw activity since the last fire. This is the backstop for the
+// never-removed long-lived workspace, which gets no session-end narrate on a day it
+// had no session stop.
+//
+// The daily narrate fires on the shared notebook-maintenance nightly slot defined by
+// the notebook cron schedule/timezone SETTINGS; a dedicated split can come later.
+// Narration is always on (no enabled gate), so this fires on its own anchor; that is
+// why it uses a SEPARATE state file (NarrateCronState).
+//
+// Activity gate: only workspaces that saw a session end or a content-changing context
+// write since the last fire are in the set, so idle workspaces are skipped and never
+// burn a strong-tier pass. A removed workspace in the set is skipped too — its
+// removal-boundary final retrospective already ran. An empty set still advances the
+// anchor (consumes the day's slot) and enqueues nothing.
+//
+// Anchoring + catch-up: a first observation with no anchor records "now" and returns
+// (so enabling never fires immediately at startup); a fire advances the anchor to
+// "now" on one write BEFORE draining, so a rare enqueue failure skips one idempotent
+// day rather than re-firing every tick, and missed slots collapse into a single
+// catch-up.
+func (d *Daemon) enqueueDueDailyNarrates(now time.Time) {
+	sched, raw, err := d.notebookCronSchedule()
+	if err != nil {
+		d.logf("daily narrate: invalid frequency %q: %v", raw, err)
+		return
+	}
+	root, err := d.notebookRoot()
+	if err != nil {
+		d.logf("daily narrate: resolve root: %v", err)
+		return
+	}
+
+	// Resolve the runner BEFORE touching state, so a missing/disabled runner never
+	// advances the anchor (which would silently skip the day with no work done).
+	runner := d.compactRunnerRef()
+	if runner == nil || runner.Disabled() {
+		return
+	}
+
+	state, err := notebook.LoadNarrateCronState(root)
+	if err != nil {
+		d.logf("daily narrate: load state: %v", err)
+		return
+	}
+
+	anchor, ok := parseNotebookCronTime(state.ScheduledFrom)
+	if !ok {
+		// First observation (or a corrupt anchor): anchor at now so the first pass
+		// lands at the next scheduled slot instead of immediately at startup.
+		state.ScheduledFrom = now.UTC().Format(time.RFC3339)
+		if err := notebook.SaveNarrateCronState(root, state); err != nil {
+			d.logf("daily narrate: anchor schedule: %v", err)
+		}
+		return
+	}
+
+	loc := d.notebookCronLocation()
+	next := sched.Next(anchor.In(loc))
+	if next.IsZero() {
+		// An unsatisfiable schedule has no next occurrence. Validation rejects these,
+		// but a value persisted by an older daemon could slip through — treat it as
+		// never-due rather than always-due (which would re-narrate every tick).
+		d.logf("daily narrate: frequency %q never occurs; skipping", raw)
+		return
+	}
+	if next.After(now) {
+		return // not due yet
+	}
+
+	// Due: anchor-FIRST ordering. Advance the anchor on ONE state write, THEN drain
+	// and enqueue. If a rare enqueue fails, the advanced anchor skips one day rather
+	// than re-firing every tick; the daily narrate is idempotent (the next trigger
+	// re-narrates), so a skipped day is benign.
+	state.ScheduledFrom = now.UTC().Format(time.RFC3339)
+	if err := notebook.SaveNarrateCronState(root, state); err != nil {
+		d.logf("daily narrate: advance anchor: %v", err)
+	}
+
+	for _, workspaceID := range d.drainNotebookNarrateActivity() {
+		if d.store.GetWorkspace(workspaceID) == nil {
+			// Removed since it was marked active: its removal-boundary final
+			// retrospective already ran. Skip it.
+			continue
+		}
+		d.enqueueDailyNarrateWorkspace(workspaceID)
+	}
+}
+
+// drainNotebookNarrateActivity atomically snapshots and clears the daily-narrate
+// activity set (swapping in a fresh map under the mutex), returning the workspace ids
+// that saw activity since the last fire. Clearing on drain is what makes a later
+// no-activity day enqueue nothing.
+func (d *Daemon) drainNotebookNarrateActivity() []string {
+	d.notebookNarrateActivityMu.Lock()
+	defer d.notebookNarrateActivityMu.Unlock()
+	if len(d.notebookNarrateActivity) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(d.notebookNarrateActivity))
+	for id := range d.notebookNarrateActivity {
+		ids = append(ids, id)
+	}
+	d.notebookNarrateActivity = make(map[string]struct{})
+	return ids
+}

--- a/internal/daemon/notebook_cron_test.go
+++ b/internal/daemon/notebook_cron_test.go
@@ -1,0 +1,145 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", s, err)
+	}
+	return parsed
+}
+
+func TestNotebookCronLocation(t *testing.T) {
+	d := newNotebookDaemon(t)
+	if got := d.notebookCronLocation(); got != time.Local {
+		t.Fatalf("default location = %v, want local", got)
+	}
+	d.store.SetSetting(SettingNotebookCronTimezone, "America/New_York")
+	if got := d.notebookCronLocation(); got.String() != "America/New_York" {
+		t.Fatalf("configured location = %v, want America/New_York", got)
+	}
+	d.store.SetSetting(SettingNotebookCronTimezone, "Not/ARealZone")
+	if got := d.notebookCronLocation(); got != time.Local {
+		t.Fatalf("invalid location should fall back to local, got %v", got)
+	}
+}
+
+func TestValidateNotebookCronSettings(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"empty frequency ok", "", false},
+		{"valid cron", "0 3 * * *", false},
+		{"valid every-minute cron", "* * * * *", false},
+		{"descriptor ok", "@daily", false},
+		{"garbage cron", "not a cron", true},
+		{"too few fields", "0 3 * *", true},
+		{"impossible date (Feb 30) rejected", "0 0 30 2 *", true},
+		{"embedded CRON_TZ rejected", "CRON_TZ=Asia/Tokyo 0 3 * * *", true},
+		{"embedded TZ rejected", "TZ=Asia/Tokyo 0 3 * * *", true},
+	} {
+		t.Run("frequency/"+tc.name, func(t *testing.T) {
+			if err := validateNotebookCronFrequency(tc.value); (err != nil) != tc.wantErr {
+				t.Fatalf("validate %q err=%v wantErr=%v", tc.value, err, tc.wantErr)
+			}
+		})
+	}
+	for _, tc := range []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"empty tz ok", "", false},
+		{"valid IANA", "America/New_York", false},
+		{"utc", "UTC", false},
+		{"garbage tz", "Not/ARealZone", true},
+	} {
+		t.Run("timezone/"+tc.name, func(t *testing.T) {
+			if err := validateNotebookCronTimezone(tc.value); (err != nil) != tc.wantErr {
+				t.Fatalf("validate %q err=%v wantErr=%v", tc.value, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestMigrateNotebookCronSettingKeys covers the one-time rename of the persisted
+// notebook.dreaming.{frequency,timezone} settings to notebook.cron.*: configured
+// legacy values are carried forward, the legacy rows are dropped, and the migration
+// is idempotent — a re-run never clobbers a value set under the new key.
+func TestMigrateNotebookCronSettingKeys(t *testing.T) {
+	t.Run("copies both legacy values forward and drops the legacy rows", func(t *testing.T) {
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+		d.store.SetSetting(legacyNotebookDreamingFrequencyKey, "0 5 * * *")
+		d.store.SetSetting(legacyNotebookDreamingTimezoneKey, "America/New_York")
+
+		d.migrateNotebookCronSettingKeys()
+
+		if got := d.store.GetSetting(SettingNotebookCronFrequency); got != "0 5 * * *" {
+			t.Fatalf("frequency new key = %q, want %q", got, "0 5 * * *")
+		}
+		if got := d.store.GetSetting(SettingNotebookCronTimezone); got != "America/New_York" {
+			t.Fatalf("timezone new key = %q, want %q", got, "America/New_York")
+		}
+		if got := d.store.GetSetting(legacyNotebookDreamingFrequencyKey); got != "" {
+			t.Fatalf("legacy frequency key still present: %q", got)
+		}
+		if got := d.store.GetSetting(legacyNotebookDreamingTimezoneKey); got != "" {
+			t.Fatalf("legacy timezone key still present: %q", got)
+		}
+	})
+
+	t.Run("idempotent: re-run is a no-op and never clobbers a user-set new value", func(t *testing.T) {
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+		d.store.SetSetting(legacyNotebookDreamingFrequencyKey, "0 5 * * *")
+
+		d.migrateNotebookCronSettingKeys()
+
+		// User reconfigures under the new key, and (defensively) a stale legacy row reappears.
+		d.store.SetSetting(SettingNotebookCronFrequency, "30 2 * * *")
+		d.store.SetSetting(legacyNotebookDreamingFrequencyKey, "0 5 * * *")
+
+		d.migrateNotebookCronSettingKeys()
+
+		if got := d.store.GetSetting(SettingNotebookCronFrequency); got != "30 2 * * *" {
+			t.Fatalf("new key was clobbered: got %q, want %q", got, "30 2 * * *")
+		}
+		if got := d.store.GetSetting(legacyNotebookDreamingFrequencyKey); got != "" {
+			t.Fatalf("legacy key still present after re-run: %q", got)
+		}
+	})
+
+	t.Run("no legacy values: nothing to migrate", func(t *testing.T) {
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+		d.migrateNotebookCronSettingKeys()
+
+		if got := d.store.GetSetting(SettingNotebookCronFrequency); got != "" {
+			t.Fatalf("frequency new key unexpectedly set: %q", got)
+		}
+		if got := d.store.GetSetting(SettingNotebookCronTimezone); got != "" {
+			t.Fatalf("timezone new key unexpectedly set: %q", got)
+		}
+	})
+
+	t.Run("reaps the orphaned enabled gate (no cron successor)", func(t *testing.T) {
+		d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+		d.store.SetSetting(legacyNotebookDreamingEnabledKey, "true")
+
+		d.migrateNotebookCronSettingKeys()
+
+		if got := d.store.GetSetting(legacyNotebookDreamingEnabledKey); got != "" {
+			t.Fatalf("stale enabled gate not reaped: %q", got)
+		}
+		if _, ok := d.store.GetAllSettings()[legacyNotebookDreamingEnabledKey]; ok {
+			t.Fatal("reaped enabled gate still appears in GetAllSettings")
+		}
+	})
+}

--- a/internal/daemon/notebook_daily_narrate_test.go
+++ b/internal/daemon/notebook_daily_narrate_test.go
@@ -1,0 +1,351 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/notebook"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/tasks"
+)
+
+// pinUTCSlot configures the daily-narrate cron to use the shared nightly slot in a
+// fixed UTC timezone, so schedule math in tests is independent of the machine's local
+// time. The frequency default ("0 3 * * *") is used; only the timezone is pinned.
+func pinUTCSlot(t *testing.T, d *Daemon) {
+	t.Helper()
+	d.store.SetSetting(SettingNotebookCronTimezone, "UTC")
+}
+
+// --- enqueueDueDailyNarrates cron due-math ---
+
+// The first tick anchors the schedule at "now" and does NOT enqueue, so daemon
+// startup never fires an immediate daily narrate; the first real pass lands at the
+// next scheduled slot. NOTE: the daily narrate has no enabled gate and uses its own
+// state file.
+func TestEnqueueDueDailyNarratesFirstObservationAnchorsWithoutFiring(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	root := installNotebookNarrationRunner(t, d)
+	pinUTCSlot(t, d)
+	d.markNotebookWorkspaceActivity("ws-A")
+
+	d.enqueueDueDailyNarrates(mustTime(t, "2026-06-14T12:00:00Z"))
+
+	state, _ := notebook.LoadNarrateCronState(root)
+	if state.ScheduledFrom == "" {
+		t.Fatal("first observation should anchor the schedule")
+	}
+	if taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
+		t.Fatal("first observation enqueued a narrate before the first scheduled slot")
+	}
+	// The activity set must NOT be drained when the cron only anchors (no fire).
+	if got := d.drainNotebookNarrateActivity(); len(got) != 1 || got[0] != "ws-A" {
+		t.Fatalf("first observation drained the activity set: %v", got)
+	}
+}
+
+// An anchored schedule whose next slot is still in the future does not enqueue, and
+// leaves the anchor untouched.
+func TestEnqueueDueDailyNarratesNotDueLeavesAnchor(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	root := installNotebookNarrationRunner(t, d)
+	pinUTCSlot(t, d)
+	d.markNotebookWorkspaceActivity("ws-A")
+
+	// Anchor at 04:00 UTC; the next "0 3 * * *" slot is the following day 03:00.
+	if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-14T04:00:00Z"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	d.enqueueDueDailyNarrates(mustTime(t, "2026-06-14T05:00:00Z"))
+
+	state, _ := notebook.LoadNarrateCronState(root)
+	if state.ScheduledFrom != "2026-06-14T04:00:00Z" {
+		t.Fatalf("not-due tick mutated the anchor: %q", state.ScheduledFrom)
+	}
+	if taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
+		t.Fatal("not-due tick enqueued a narrate")
+	}
+}
+
+// A due schedule fires once: it enqueues narrate_workspace for the active workspace
+// (with the daily Meta flag set) and advances the anchor; a second tick the same day
+// does NOT re-fire, and — because the set was cleared on the first fire — a later due
+// day with no new activity enqueues nothing.
+func TestEnqueueDueDailyNarratesDueFiresOnceAndClearsActivity(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	root := installNotebookNarrationRunner(t, d)
+	pinUTCSlot(t, d)
+	// Live workspace row so the drain does not skip it as removed.
+	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-A", Title: "ws-A", Directory: t.TempDir()})
+	d.markNotebookWorkspaceActivity("ws-A")
+	// Block the narrate so the enqueued record stays observable.
+	d.narrateWorkspaceExecution = blockingExecution(t)
+
+	// Anchor a day back so 2026-06-14T03:00 is the due slot.
+	if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-13T03:00:00Z"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	now := mustTime(t, "2026-06-14T12:00:00Z")
+	d.enqueueDueDailyNarrates(now)
+
+	state, _ := notebook.LoadNarrateCronState(root)
+	if state.ScheduledFrom != now.UTC().Format(time.RFC3339) {
+		t.Fatalf("due fire did not advance the anchor to now: %q", state.ScheduledFrom)
+	}
+	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
+		t.Fatal("due fire did not enqueue narrate_workspace for the active workspace")
+	}
+	task, err := d.compactRunner.Get(tasks.TaskID(notebookNarrateWorkspaceKind, "ws-A"))
+	if err != nil || task == nil {
+		t.Fatalf("get narrate task: %v", err)
+	}
+	if task.Meta[notebookNarrateMetaDailyPass] != "1" {
+		t.Fatalf("daily narrate task missing the daily-pass Meta flag: %+v", task.Meta)
+	}
+
+	// The activity set was cleared on the fire, so a later due day with no new
+	// activity advances the anchor but enqueues nothing new.
+	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-B", Title: "ws-B", Directory: t.TempDir()})
+	d.enqueueDueDailyNarrates(mustTime(t, "2026-06-15T12:00:00Z"))
+	if taskExists(t, d, notebookNarrateWorkspaceKind, "ws-B") {
+		t.Fatal("a later due day with no new activity enqueued a narrate")
+	}
+}
+
+// The gate is exact: only workspaces in the activity set are narrated. A due fire
+// narrates the active ws-A and NOT the idle ws-B.
+func TestEnqueueDueDailyNarratesGatesOnActivity(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	root := installNotebookNarrationRunner(t, d)
+	pinUTCSlot(t, d)
+	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-A", Title: "ws-A", Directory: t.TempDir()})
+	d.store.AddWorkspace(&protocol.Workspace{ID: "ws-B", Title: "ws-B", Directory: t.TempDir()})
+	d.narrateWorkspaceExecution = blockingExecution(t)
+
+	// Only ws-A saw activity. ws-B is idle.
+	d.markNotebookWorkspaceActivity("ws-A")
+
+	if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-13T03:00:00Z"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	d.enqueueDueDailyNarrates(mustTime(t, "2026-06-14T12:00:00Z"))
+
+	if !taskExists(t, d, notebookNarrateWorkspaceKind, "ws-A") {
+		t.Fatal("active workspace ws-A was not narrated")
+	}
+	// Give the worker a beat; ws-B must never get a task.
+	time.Sleep(20 * time.Millisecond)
+	task, err := d.compactRunner.Get(tasks.TaskID(notebookNarrateWorkspaceKind, "ws-B"))
+	if err != nil {
+		t.Fatalf("get ws-B narrate: %v", err)
+	}
+	if task != nil {
+		t.Fatalf("idle workspace ws-B was unexpectedly narrated: %+v", task)
+	}
+}
+
+// A workspace in the activity set whose row was removed before the fire is skipped:
+// its removal-boundary final retrospective already ran. The anchor still advances.
+func TestEnqueueDueDailyNarratesSkipsRemovedWorkspace(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	root := installNotebookNarrationRunner(t, d)
+	pinUTCSlot(t, d)
+	d.narrateWorkspaceExecution = blockingExecution(t)
+	// ws-gone was active but its row is gone (no AddWorkspace).
+	d.markNotebookWorkspaceActivity("ws-gone")
+
+	if err := notebook.SaveNarrateCronState(root, notebook.NarrateCronState{ScheduledFrom: "2026-06-13T03:00:00Z"}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	now := mustTime(t, "2026-06-14T12:00:00Z")
+	d.enqueueDueDailyNarrates(now)
+
+	state, _ := notebook.LoadNarrateCronState(root)
+	if state.ScheduledFrom != now.UTC().Format(time.RFC3339) {
+		t.Fatalf("anchor did not advance on a fire that skipped a removed workspace: %q", state.ScheduledFrom)
+	}
+	time.Sleep(20 * time.Millisecond)
+	task, err := d.compactRunner.Get(tasks.TaskID(notebookNarrateWorkspaceKind, "ws-gone"))
+	if err != nil {
+		t.Fatalf("get ws-gone narrate: %v", err)
+	}
+	if task != nil {
+		t.Fatalf("removed workspace was narrated by the daily cron: %+v", task)
+	}
+}
+
+// --- activity hooks ---
+
+// A session Stop marks its workspace active (the handleStop path), so the daily cron
+// will narrate it.
+func TestHandleStopMarksWorkspaceActivity(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+	installNotebookNarrationRunner(t, d)
+	d.summarizeSessionExecution = blockingExecution(t)
+	d.narrateWorkspaceExecution = blockingExecution(t)
+
+	d.handleStop(drainingConn(t), &protocol.StopMessage{ID: "session-1"})
+
+	got := d.drainNotebookNarrateActivity()
+	if len(got) != 1 || got[0] != "ws-1" {
+		t.Fatalf("stop did not mark ws-1 active: %v", got)
+	}
+}
+
+// A content-CHANGING context update marks the workspace active; a no-op update
+// (changed == false) does NOT — driven through the real updateWorkspaceContext
+// handler so the hook is exercised at the genuine chokepoint.
+func TestContextWriteMarksActivityOnlyWhenChanged(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "workspace-1")
+
+	checkout, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{SourceSessionID: "session-1"})
+	if err != nil {
+		t.Fatalf("checkout: %v", err)
+	}
+
+	// A no-op update (nothing edited) does NOT mark activity.
+	if _, changed, err := d.updateWorkspaceContext(&protocol.WorkspaceContextUpdateMessage{SourceSessionID: "session-1"}); err != nil || changed {
+		t.Fatalf("expected no-op update (changed=false), got changed=%v err=%v", changed, err)
+	}
+	if got := d.drainNotebookNarrateActivity(); len(got) != 0 {
+		t.Fatalf("a no-op context update marked activity: %v", got)
+	}
+
+	// A real edit -> changed -> marks activity.
+	if err := os.WriteFile(checkout.Path, []byte("# Real shared goal\n"), 0o600); err != nil {
+		t.Fatalf("edit checkout: %v", err)
+	}
+	if _, changed, err := d.updateWorkspaceContext(&protocol.WorkspaceContextUpdateMessage{SourceSessionID: "session-1"}); err != nil || !changed {
+		t.Fatalf("expected changing update (changed=true), got changed=%v err=%v", changed, err)
+	}
+	got := d.drainNotebookNarrateActivity()
+	if len(got) != 1 || got[0] != "workspace-1" {
+		t.Fatalf("a content-changing context update did not mark workspace-1 active: %v", got)
+	}
+}
+
+// --- executor relaxation (daily pass success semantics) ---
+
+// A daily-flagged narrate whose agent leaves the block UNCHANGED goes DONE (not
+// failed): a daily refresh that finds nothing new is a clean no-op.
+func TestNarrateWorkspaceDailyPassUnchangedIsDone(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+	root := installNotebookNarrationRunner(t, d)
+	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+
+	journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+	if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
+		t.Fatalf("mkdir journal: %v", err)
+	}
+	prior := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nalready narrated today\n\nsource: workspace:ws-1\n"
+	if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
+		t.Fatalf("seed prior entry: %v", err)
+	}
+
+	// Daily-pass agent no-ops: leaves the block exactly as-is.
+	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		return agentdriver.HeadlessTaskResult{Diagnostics: "nothing new"}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookNarrateWorkspaceKind, "ws-1", tasks.EnqueueOptions{
+		Meta: map[string]string{notebookNarrateMetaDailyPass: "1"},
+	}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", tasks.StateDone)
+}
+
+// A daily-flagged narrate whose agent writes NO entry at all goes DONE (not failed):
+// an absent block on a daily refresh is also a clean no-op.
+func TestNarrateWorkspaceDailyPassAbsentIsDone(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+	installNotebookNarrationRunner(t, d)
+	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+
+	// Daily-pass agent writes nothing.
+	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		return agentdriver.HeadlessTaskResult{Diagnostics: "no entry"}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookNarrateWorkspaceKind, "ws-1", tasks.EnqueueOptions{
+		Meta: map[string]string{notebookNarrateMetaDailyPass: "1"},
+	}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForTaskState(t, d, notebookNarrateWorkspaceKind, "ws-1", tasks.StateDone)
+}
+
+// A daily-flagged REMOVAL pass keeps STRICT gating: an unchanged/absent block still
+// FAILS, because the removal retrospective must actually be written.
+func TestNarrateWorkspaceDailyFlagRemovalPassStillStrict(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	// No workspace row for ws-removed -> IS_REMOVAL_PASS derived true; the daily flag
+	// must not relax a removal pass.
+	root := installNotebookNarrationRunner(t, d)
+	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+
+	journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+	if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
+		t.Fatalf("mkdir journal: %v", err)
+	}
+	prior := "## ws-removed — 2026-06-15\n<!-- attn:wsnarr:ws-removed -->\n\nprior\n\nsource: workspace:ws-removed\n"
+	if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
+		t.Fatalf("seed prior entry: %v", err)
+	}
+
+	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
+	}
+
+	if _, err := d.compactRunner.Enqueue(notebookNarrateWorkspaceKind, "ws-removed", tasks.EnqueueOptions{
+		Meta: map[string]string{notebookNarrateMetaDailyPass: "1"},
+	}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	task := waitForNonDoneFailure(t, d, notebookNarrateWorkspaceKind, "ws-removed")
+	if task.State == tasks.StateDone {
+		t.Fatal("daily flag wrongly relaxed a removal pass to done")
+	}
+}
+
+// A NON-flagged routine (session-end) pass with an unchanged block still FAILS —
+// unchanged behavior, preserving the retry-until-the-digest-lands property.
+func TestNarrateWorkspaceRoutinePassUnchangedStillFails(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	setupWorkspaceContextSession(t, d, "session-1", "ws-1")
+	root := installNotebookNarrationRunner(t, d)
+	d.narrationNowOverride = func() time.Time { return time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) }
+
+	journal := filepath.Join(root, notebook.DirJournal, "2026-06-15.md")
+	if err := os.MkdirAll(filepath.Dir(journal), 0o755); err != nil {
+		t.Fatalf("mkdir journal: %v", err)
+	}
+	prior := "## ws-1 — 2026-06-15\n<!-- attn:wsnarr:ws-1 -->\n\nactive-day entry\n\nsource: workspace:ws-1\n"
+	if err := os.WriteFile(journal, []byte(prior), 0o644); err != nil {
+		t.Fatalf("seed prior entry: %v", err)
+	}
+
+	d.narrateWorkspaceExecution = func(context.Context, agentdriver.HeadlessTaskProvider, agentdriver.HeadlessTaskRequest) (agentdriver.HeadlessTaskResult, error) {
+		return agentdriver.HeadlessTaskResult{Diagnostics: "no-op"}, nil
+	}
+
+	// No daily Meta flag -> strict gating.
+	if _, err := d.compactRunner.Enqueue(notebookNarrateWorkspaceKind, "ws-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	task := waitForNonDoneFailure(t, d, notebookNarrateWorkspaceKind, "ws-1")
+	if !strings.Contains(task.LastError, "unchanged") {
+		t.Fatalf("routine pass last error = %q, want unchanged rejection", task.LastError)
+	}
+}


### PR DESCRIPTION
The nightly per-workspace narrate backstop on the durable runner: a single cron enqueuer with a **relaxed daily-pass gate** (absent or unchanged journal block = clean done) plus an in-memory **activity gate** so only drained, still-live workspaces are narrated. Session-end and removal passes stay strict. Separate `NarrateCronState` anchor (shares only cadence/timezone settings). Dormant until #8.
---
**Final-state re-split of the knowledge-base / keeper epic** (supersedes #335–#343, #345). The original stack was split by chronology and carried mid-epic churn; this one is sliced by subsystem from the net diff, so each PR is a clean final-state slice.

Stack: `1 task-engine` · `2 notebook-kb` · `3 agent-native` · `4 store-keeper` · `5 keeper-compaction` · `6 keeper-narration` · `7 keeper-cron` · **`8 integration`** · `9 frontend` · `10 cli/docs`

This is PR **7/10** — base `kb/06-keeper-narration`. Review per-diff. By design the refactor only activates in #8 (where the keeper is wired and the janitor/dreaming are deleted), so branches 2–9 are not individually `go build`-clean; the merged tip (#10) is build + vet + test green.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. `feat/chifplace`
2. #347
3. #348
4. #349
5. #350
6. #351
7. #352
8. **#353** 👈 current
9. #354
10. #355
11. #356
<!-- stack:links:end -->