### PR TITLE
refactor: post-review cleanup — dedup, dead code, comment fixes

### DIFF
--- a/app/src/components/NotebookBrowser.tsx
+++ b/app/src/components/NotebookBrowser.tsx
@@ -378,20 +378,13 @@ export function NotebookBrowser({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [changeSignal]);
 
-  // Fetch tasks when the Tasks section is opened (and the browser is open). A bump
-  // of taskChangeSignal while it's open refetches via the effect below.
+  // Fetch tasks while the Tasks section is open (and the browser is open): once on
+  // open, and again whenever a notebook_tasks_changed broadcast bumps taskChangeSignal
+  // so runner transitions show without reopening the section.
   useEffect(() => {
     if (!isOpen || !tasksOpen) return;
     void refreshTasks();
-  }, [isOpen, tasksOpen, refreshTasks]);
-
-  // Live refresh: a notebook_tasks_changed broadcast refetches the task list while
-  // the section is open so runner transitions show without reopening it.
-  useEffect(() => {
-    if (!isOpen || !tasksOpen || taskChangeSignal === 0) return;
-    void refreshTasks();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [taskChangeSignal]);
+  }, [isOpen, tasksOpen, refreshTasks, taskChangeSignal]);
 
   // Drop the staleness token when the browser closes so an in-flight tasks fetch
   // can't stamp rows onto a reopened panel.
@@ -871,13 +864,14 @@ const TASK_TERMINAL_STATES = new Set(['done', 'dead']);
 
 // formatNextAttempt renders an RFC3339 next_attempt_at as a short relative phrase
 // ("in 2m", "5s ago", "now"). Returns '' for an unparseable/zero timestamp so the
-// row can omit it. now is injectable for deterministic tests.
-function formatNextAttempt(iso: string, now: number = Date.now()): string {
+// row can omit it.
+function formatNextAttempt(iso: string): string {
   if (!iso) return '';
   const t = Date.parse(iso);
   if (Number.isNaN(t)) return '';
   // The runner stamps a zero time (year <= 1) when there is no scheduled attempt.
   if (new Date(t).getUTCFullYear() <= 1) return '';
+  const now = Date.now();
   const deltaSec = Math.round((t - now) / 1000);
   const abs = Math.abs(deltaSec);
   if (abs < 5) return 'now';

--- a/internal/agent/headless_test.go
+++ b/internal/agent/headless_test.go
@@ -256,22 +256,14 @@ func TestCodexHeadlessArgsWidensWritableRootsAdditively(t *testing.T) {
 			Prompt:             "narrate",
 			ExtraWritableRoots: []string{"/notebook/root", "  ", "/notebook/raw"},
 		})
+		// Both writable roots map to --add-dir, plus the base sandbox + feature locks + prompt.
+		assertContainsAll(t, "codex narrate args", args,
+			"--add-dir\x00/notebook/root", "--add-dir\x00/notebook/raw",
+			"workspace-write", "features.apps=false", "narrate")
 		joined := strings.Join(args, "\x00")
-		if !strings.Contains(joined, "--add-dir\x00/notebook/root") {
-			t.Fatalf("missing --add-dir for notebook root:\n%v", args)
-		}
-		if !strings.Contains(joined, "--add-dir\x00/notebook/raw") {
-			t.Fatalf("missing --add-dir for raw root:\n%v", args)
-		}
 		// The blank entry is skipped.
 		if strings.Count(joined, "--add-dir") != 2 {
 			t.Fatalf("expected exactly 2 --add-dir entries, got:\n%v", args)
-		}
-		// Still the base sandbox + feature locks + prompt.
-		for _, want := range []string{"workspace-write", "features.apps=false", "narrate"} {
-			if !strings.Contains(joined, want) {
-				t.Fatalf("missing base arg %q:\n%v", want, args)
-			}
 		}
 		// --add-dir must precede the feature locks and the prompt.
 		addDirIdx := strings.Index(joined, "--add-dir")
@@ -284,9 +276,7 @@ func TestCodexHeadlessArgsWidensWritableRootsAdditively(t *testing.T) {
 
 	t.Run("keeper compaction adds nothing", func(t *testing.T) {
 		args := codexHeadlessArgs(HeadlessTaskRequest{Model: "gpt-test", Prompt: "compact"})
-		if strings.Contains(strings.Join(args, "\x00"), "--add-dir") {
-			t.Fatalf("keeper compaction (no ExtraWritableRoots) unexpectedly added --add-dir:\n%v", args)
-		}
+		assertContainsNone(t, "codex compaction args", args, "--add-dir")
 	})
 }
 
@@ -301,16 +291,8 @@ func TestClaudeHeadlessArgsIgnoreWritableRoots(t *testing.T) {
 		AllowedTools:       []string{"Read", "Write", "Edit", "Grep", "Glob", "Bash"},
 		ExtraWritableRoots: []string{"/notebook/root"},
 	})
-	joined := strings.Join(withRoots, "\x00")
-	if strings.Contains(joined, "--add-dir") || strings.Contains(joined, "/notebook/root") {
-		t.Fatalf("Claude args leaked ExtraWritableRoots:\n%v", withRoots)
-	}
-	if !strings.Contains(joined, "Read,Write,Edit,Grep,Glob,Bash") {
-		t.Fatalf("Claude args dropped the explicit Bash-inclusive allow-list:\n%v", withRoots)
-	}
-	for _, want := range []string{"--permission-mode", "dontAsk", "claude-test", "narrate"} {
-		if !strings.Contains(joined, want) {
-			t.Fatalf("Claude args missing %q:\n%v", want, withRoots)
-		}
-	}
+	assertContainsNone(t, "claude args", withRoots, "--add-dir", "/notebook/root")
+	assertContainsAll(t, "claude args", withRoots,
+		"Read,Write,Edit,Grep,Glob,Bash",
+		"--permission-mode", "dontAsk", "claude-test", "narrate")
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -232,11 +232,6 @@ type Daemon struct {
 	) (agentdriver.HeadlessTaskResult, error)
 	narrationNowOverride func() time.Time
 
-	// Notebook cron enqueuer. notebookCronInterval overrides the tick cadence in
-	// tests (zero = default). The enqueued work runs on the durable runner, so there
-	// is no in-daemon single-flight guard here.
-	notebookCronInterval time.Duration
-
 	// Daily-narrate activity gate. notebookNarrateActivity is the in-memory set of
 	// workspace ids that saw real activity (a session end or a content-changing
 	// context write) since the last daily-narrate cron fire. It is best-effort and
@@ -585,7 +580,7 @@ func (d *Daemon) Start() error {
 	if d.pluginProcesses == nil {
 		d.pluginProcesses = newPluginProcessRegistry()
 	}
-	d.loadWorkspacesFromStore()
+	reapedWorkspaceIDs := d.loadWorkspacesFromStore()
 	if d.daemonInstanceID == "" {
 		instanceID, err := ensureDaemonInstanceID(d.dataRoot)
 		if err != nil {
@@ -736,6 +731,15 @@ func (d *Daemon) Start() error {
 	// Construct + start the durable compaction runner (kinds compact_context,
 	// summarize_session, narrate_workspace).
 	d.startCompactRunner()
+
+	// Now that the runner exists, enqueue the deferred removal-boundary retrospectives
+	// for any workspaces reaped during startup reconciliation. loadWorkspacesFromStore
+	// ran before startCompactRunner, so enqueuing inline there would have been a
+	// nil-runner no-op; deferring to here gives a startup-reaped workspace its final
+	// narrate, matching the live removal paths.
+	for _, wsID := range reapedWorkspaceIDs {
+		d.enqueueFinalNarrateWorkspace(wsID)
+	}
 
 	// Start the notebook cron enqueuer (enqueues the nightly daily-narrate backstop
 	// onto the durable runner when due). Launched AFTER startCompactRunner so the

--- a/internal/daemon/notebook_cron.go
+++ b/internal/daemon/notebook_cron.go
@@ -42,32 +42,17 @@ const (
 // migrateNotebookCronSettingKeys performs the one-time rename of the persisted
 // notebook.dreaming.{frequency,timezone} settings to notebook.cron.* (the schedule
 // outlived the removed dreaming feature) and reaps the orphaned
-// notebook.dreaming.enabled gate (which has no successor). Like
-// migrateKeeperCompactSettingKey it runs at daemon start — and therefore again after
-// every app rebuild, since the daemon survives rebuilds — so it MUST be idempotent.
-// It copies each renamed legacy value forward only when the legacy key holds a
-// non-empty value AND the new key is still empty, so a re-run never clobbers a value
-// set under the new key, then deletes the stale legacy row so the migration is a
-// true no-op on the next boot. This is a plain settings-value copy, NOT a schema
-// migration.
+// notebook.dreaming.enabled gate (which has no successor). Each rename uses
+// renameSettingKey for the idempotent copy-forward-then-reap contract; it runs at
+// daemon start (and thus again after every app rebuild, since the daemon survives
+// them), so it MUST stay idempotent. This is a plain settings-value copy, NOT a
+// schema migration.
 func (d *Daemon) migrateNotebookCronSettingKeys() {
 	if d.store == nil {
 		return
 	}
-	for _, m := range []struct{ legacy, current string }{
-		{legacyNotebookDreamingFrequencyKey, SettingNotebookCronFrequency},
-		{legacyNotebookDreamingTimezoneKey, SettingNotebookCronTimezone},
-	} {
-		legacy := d.store.GetSetting(m.legacy)
-		if strings.TrimSpace(legacy) == "" {
-			continue // nothing to migrate (or already migrated + cleaned up)
-		}
-		if strings.TrimSpace(d.store.GetSetting(m.current)) == "" {
-			d.store.SetSetting(m.current, legacy)
-			d.logf("migrated setting %q -> %q", m.legacy, m.current)
-		}
-		d.store.DeleteSetting(m.legacy)
-	}
+	d.renameSettingKey(legacyNotebookDreamingFrequencyKey, SettingNotebookCronFrequency)
+	d.renameSettingKey(legacyNotebookDreamingTimezoneKey, SettingNotebookCronTimezone)
 	// The enabled gate has no cron equivalent — just drop any stale row so it stops
 	// being broadcast in the settings map. DeleteSetting is a no-op when absent.
 	d.store.DeleteSetting(legacyNotebookDreamingEnabledKey)
@@ -136,11 +121,7 @@ func parseNotebookCronTime(s string) (time.Time, bool) {
 // machinery — it only dispatches onto the durable runner, which owns single-flight
 // and crash recovery — so there is nothing to drain on stop.
 func (d *Daemon) startNotebookCronEnqueuer(done <-chan struct{}) {
-	interval := d.notebookCronInterval
-	if interval <= 0 {
-		interval = defaultNotebookCronInterval
-	}
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(defaultNotebookCronInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/internal/daemon/notebook_narration.go
+++ b/internal/daemon/notebook_narration.go
@@ -255,14 +255,17 @@ func notebookSessionDigestPath(root, workspaceID, sessionID string) (string, err
 	if err != nil {
 		return "", fmt.Errorf("unsafe session id: %w", err)
 	}
-	bucket := notebookSoloSessionBucket
-	if workspaceID != "" {
-		bucket, err = rawTierSegment(workspaceID)
-		if err != nil {
-			return "", fmt.Errorf("unsafe workspace id: %w", err)
-		}
+	if workspaceID == "" {
+		return filepath.Join(notebook.RawSessionsDir(root), notebookSoloSessionBucket, name), nil
 	}
-	return filepath.Join(notebook.RawSessionsDir(root), bucket, name), nil
+	// Non-solo sessions land in the same per-workspace bucket the narrate pass reads;
+	// notebookWorkspaceSessionsDir is the single source of that bucket path (and it
+	// already returns the identical "unsafe workspace id" error, so pass it through).
+	dir, err := notebookWorkspaceSessionsDir(root, workspaceID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, name), nil
 }
 
 // notebookWorkspaceSessionsDir is the per-workspace digest subdir the narrate pass
@@ -668,9 +671,10 @@ func (d *Daemon) enqueueDailyNarrateWorkspace(workspaceID string) {
 // eligible — the workspace is gone, so this is the last chance to write its
 // retrospective. It must be called AFTER the context snapshot is taken and the
 // workspace row is removed, so the executor derives IS_REMOVAL_PASS=true and the
-// snapshot is on disk for the narrate pass to read. Nil/Disabled-guarded, so the
-// startup-reconciliation removal site (which runs before the runner exists) is a
-// safe no-op.
+// snapshot is on disk for the narrate pass to read. Nil/Disabled-guarded: a caller
+// that runs before startCompactRunner constructs the runner is a safe no-op, which
+// is why the startup-reconciliation reaper defers its enqueue to Start (after the
+// runner exists) rather than calling this inline.
 func (d *Daemon) enqueueFinalNarrateWorkspace(workspaceID string) {
 	workspaceID = strings.TrimSpace(workspaceID)
 	if workspaceID == "" {

--- a/internal/daemon/notebook_narration_config.go
+++ b/internal/daemon/notebook_narration_config.go
@@ -49,9 +49,8 @@ func narrationTierDefault(kind string) (agent, model string) {
 	switch kind {
 	case notebookSummarizeSessionKind:
 		return notebookSummarizeDefaultAgent, notebookSummarizeDefaultModel
-	case notebookNarrateWorkspaceKind:
-		return notebookNarrateDefaultAgent, notebookNarrateDefaultModel
 	default:
+		// notebookNarrateWorkspaceKind (and any future narrate kind) uses the strong tier.
 		return notebookNarrateDefaultAgent, notebookNarrateDefaultModel
 	}
 }

--- a/internal/daemon/notebook_narration_test.go
+++ b/internal/daemon/notebook_narration_test.go
@@ -720,9 +720,10 @@ func blockingExecution(t *testing.T) func(context.Context, agentdriver.HeadlessT
 
 // --- path-traversal guard (the load-bearing security property) ---
 
-// journalDirHasUnexpectedFiles fails the test if anything other than the allowed
-// files appears under <root>/journal/, so a path-traversal write that escaped the
-// raw tier into the curated journal dir is caught.
+// assertJournalUntouched fails the test if ANY entry appears under <root>/journal/
+// (the curated journal must stay empty in these raw-tier traversal tests), so a
+// path-traversal write that escaped the raw tier into the journal dir is caught. An
+// absent journal dir is fine — nothing escaped into it.
 func assertJournalUntouched(t *testing.T, root string) {
 	t.Helper()
 	journalDir := filepath.Join(root, notebook.DirJournal)

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -362,6 +362,29 @@ func (d *Daemon) toggleWorkspaceMute(workspaceID string) (protocol.Workspace, st
 	return snapshot, ""
 }
 
+// tearDownRemovedWorkspace runs the shared removal sequence for a workspace whose
+// registry entry was just unregistered. The caller owns the unregister + !removed
+// guard and any site-specific rationale, and passes the resulting snapshot. It drops
+// any pending compaction, snapshots context.md into the raw tier (the synchronous
+// data-safety floor, before the row delete), deletes the store row, enqueues the
+// zero-debounce final retrospective narrate (which derives IS_REMOVAL_PASS=true now
+// that the row is gone), prunes the workspace's tile-content subscriptions, and
+// broadcasts workspace_unregistered. The startup-reconciliation reaper deliberately
+// does NOT use this helper: it runs before the runner exists and omits the prune +
+// broadcast.
+func (d *Daemon) tearDownRemovedWorkspace(snapshot protocol.Workspace) {
+	id := snapshot.ID
+	d.forgetWorkspaceContextCompaction(id)
+	d.snapshotWorkspaceContextOnRemove(id, snapshot.Title)
+	d.store.RemoveWorkspace(id)
+	d.enqueueFinalNarrateWorkspace(id)
+	d.pruneTileContentSubscriptionsForLayout(id, nil)
+	d.wsHub.Broadcast(&protocol.WebSocketEvent{
+		Event:     protocol.EventWorkspaceUnregistered,
+		Workspace: &snapshot,
+	})
+}
+
 // handleUnregisterWorkspace closes the workspace AND every session that
 // belongs to it. Sessions get a graceful SIGTERM through unregisterSession
 // (same path as the unix-socket "unregister" command), so transcripts flush
@@ -396,18 +419,9 @@ func (d *Daemon) handleUnregisterWorkspace(client *wsClient, msg *protocol.Unreg
 	if !removed {
 		return
 	}
-	d.forgetWorkspaceContextCompaction(id)
-	d.snapshotWorkspaceContextOnRemove(id, snapshot.Title)
-	d.store.RemoveWorkspace(id)
-	// Removal boundary: the workspace row is now gone, so the final narrate run
-	// derives IS_REMOVAL_PASS=true and writes the retrospective from the snapshot +
-	// digests. ZeroDebounce overrides any pending active-day pass.
-	d.enqueueFinalNarrateWorkspace(id)
-	d.pruneTileContentSubscriptionsForLayout(id, nil)
-	d.wsHub.Broadcast(&protocol.WebSocketEvent{
-		Event:     protocol.EventWorkspaceUnregistered,
-		Workspace: &snapshot,
-	})
+	// Explicit unregister (workspace closed along with its sessions): tear down and
+	// write the removal-boundary retrospective.
+	d.tearDownRemovedWorkspace(snapshot)
 }
 
 // loadWorkspacesFromStore rebuilds the in-memory registry from SQLite at
@@ -415,10 +429,11 @@ func (d *Daemon) handleUnregisterWorkspace(client *wsClient, msg *protocol.Unreg
 // associateSession has somewhere to land), then walk persisted sessions and
 // re-bind those that have a workspace_id. Status is recomputed last from the
 // loaded session states.
-func (d *Daemon) loadWorkspacesFromStore() {
+func (d *Daemon) loadWorkspacesFromStore() []string {
 	if d.workspaces == nil {
 		d.workspaces = newWorkspaceRegistry()
 	}
+	var reaped []string
 	for _, ws := range d.store.ListWorkspaces() {
 		if ws == nil {
 			continue
@@ -435,18 +450,16 @@ func (d *Daemon) loadWorkspacesFromStore() {
 				!d.workspaceHasPendingSpawn(ws.ID) &&
 				!d.workspaceHasSessionlessContent(ws.ID) {
 				// loadWorkspacesFromStore runs during Start() before the compaction
-				// runner is constructed; forgetWorkspaceContextCompaction is nil-safe.
-				// The snapshot does not touch the runner (it only reads the store and
-				// writes a file), so it is safe to call here with no runner.
+				// runner is constructed; forgetWorkspaceContextCompaction is nil-safe
+				// and the snapshot only reads the store and writes a file, so both are
+				// safe here with no runner. The final-narrate enqueue, however, needs
+				// the runner, so we DEFER it: collect the reaped id and return it for
+				// Start to enqueue once startCompactRunner has run, so a startup-reaped
+				// workspace still gets its removal-boundary retrospective.
 				d.forgetWorkspaceContextCompaction(ws.ID)
 				d.snapshotWorkspaceContextOnRemove(ws.ID, ws.Title)
 				d.store.RemoveWorkspace(ws.ID)
-				// Final-narrate enqueue is a nil-safe no-op here: load runs before
-				// startCompactRunner constructs the runner. A workspace reaped at
-				// startup (no live sessions across a restart) gets no retrospective —
-				// acceptable, since the live removal paths own the common case and the
-				// snapshot above still preserves its context for a future manual read.
-				d.enqueueFinalNarrateWorkspace(ws.ID)
+				reaped = append(reaped, ws.ID)
 				continue
 			}
 		}
@@ -465,6 +478,7 @@ func (d *Daemon) loadWorkspacesFromStore() {
 	for _, ws := range d.workspaces.list() {
 		d.recomputeWorkspaceStatus(ws.ID)
 	}
+	return reaped
 }
 
 func (d *Daemon) workspaceHasPendingSpawn(workspaceID string) bool {
@@ -560,16 +574,9 @@ func (d *Daemon) dissociateSessionFromWorkspace(sessionID string) {
 		if !removed {
 			return
 		}
-		d.forgetWorkspaceContextCompaction(workspaceID)
-		d.snapshotWorkspaceContextOnRemove(workspaceID, snapshot.Title)
-		d.store.RemoveWorkspace(workspaceID)
-		// Removal boundary (last session left): final retrospective narrate.
-		d.enqueueFinalNarrateWorkspace(workspaceID)
-		d.pruneTileContentSubscriptionsForLayout(workspaceID, nil)
-		d.wsHub.Broadcast(&protocol.WebSocketEvent{
-			Event:     protocol.EventWorkspaceUnregistered,
-			Workspace: &snapshot,
-		})
+		// Natural last-session departure (the common path): tear down and write the
+		// removal-boundary retrospective.
+		d.tearDownRemovedWorkspace(snapshot)
 		return
 	}
 	updated, changed := d.recomputeWorkspaceStatus(workspaceID)

--- a/internal/daemon/workspace_keeper.go
+++ b/internal/daemon/workspace_keeper.go
@@ -111,32 +111,35 @@ func (d *Daemon) keeperCompactConfig() (keeperCompactConfig, error) {
 // agent/model forward to SettingKeeperCompact. Never read it anywhere else.
 const legacyKeeperCompactSettingKey = "workspace_context_janitor"
 
-// migrateKeeperCompactSettingKey performs the one-time rename of the persisted
-// "workspace_context_janitor" setting to "workspace_keeper_compact"
-// (SettingKeeperCompact). It runs at daemon start — and therefore again after
-// every app rebuild, since the daemon survives rebuilds — so it MUST be
-// idempotent. It copies the legacy value forward only when the legacy key holds
-// a non-empty value AND the new key is still empty, so a re-run never clobbers a
-// value the user has since set under the new key. After copying it deletes the
-// stale legacy row so the migration is a true no-op on the next boot (and the
-// dead key never appears in the broadcast settings map). This is a plain
-// settings-value copy, NOT a schema migration — it is unrelated to
-// schema_migrations.
-func (d *Daemon) migrateKeeperCompactSettingKey() {
+// renameSettingKey performs a one-time settings-value rename: it copies the legacy
+// key's value forward to current ONLY when legacy is non-empty AND current is still
+// empty (so a re-run never clobbers a value the user has since set under the new
+// key), then deletes the stale legacy row so the migration is a true no-op on the
+// next boot (and the dead key never appears in the broadcast settings map). It is
+// nil-store-safe and idempotent — required because the daemon runs these renames at
+// every start, including after each app rebuild. This is a plain settings-value
+// copy, NOT a schema migration; it is unrelated to schema_migrations.
+func (d *Daemon) renameSettingKey(legacy, current string) {
 	if d.store == nil {
 		return
 	}
-	legacy := d.store.GetSetting(legacyKeeperCompactSettingKey)
-	if strings.TrimSpace(legacy) == "" {
+	value := d.store.GetSetting(legacy)
+	if strings.TrimSpace(value) == "" {
 		return // nothing to migrate (or already migrated + cleaned up)
 	}
-	if strings.TrimSpace(d.store.GetSetting(SettingKeeperCompact)) == "" {
+	if strings.TrimSpace(d.store.GetSetting(current)) == "" {
 		// Carry the raw legacy value forward to preserve it exactly.
-		d.store.SetSetting(SettingKeeperCompact, legacy)
-		d.logf("migrated setting %q -> %q", legacyKeeperCompactSettingKey, SettingKeeperCompact)
+		d.store.SetSetting(current, value)
+		d.logf("migrated setting %q -> %q", legacy, current)
 	}
-	// Drop the stale row so the migration is a true no-op on the next boot.
-	d.store.DeleteSetting(legacyKeeperCompactSettingKey)
+	d.store.DeleteSetting(legacy)
+}
+
+// migrateKeeperCompactSettingKey performs the one-time rename of the persisted
+// "workspace_context_janitor" setting to SettingKeeperCompact. See renameSettingKey
+// for the idempotent copy-forward-then-reap contract.
+func (d *Daemon) migrateKeeperCompactSettingKey() {
+	d.renameSettingKey(legacyKeeperCompactSettingKey, SettingKeeperCompact)
 }
 
 // compactContextKind is the runner task kind for workspace-context compaction.
@@ -371,7 +374,11 @@ func (d *Daemon) applyWorkspaceContextCompaction(
 		AgentModel:     protocol.Ptr(config.Model),
 	}
 	if changed {
-		d.refreshCleanWorkspaceContextCheckouts(updated)
+		// Existing checkout files are agent-owned working copies; we deliberately do
+		// NOT rewrite them. Replacing one could discard a write from an editor still
+		// holding the old inode open. Their prior metadata makes them stale against
+		// the new canonical revision, so the normal refresh/conflict workflow
+		// preserves both clean and modified local state.
 		d.broadcastWorkspaceContextChanged(updated)
 	}
 	if execution.ResolvedExecutable != "" {
@@ -575,14 +582,6 @@ func markdownSectionContent(lines []string, heading string) string {
 	return strings.Join(content, "\n")
 }
 
-func (d *Daemon) refreshCleanWorkspaceContextCheckouts(canonical *protocol.WorkspaceContext) {
-	// Existing checkout files are agent-owned working copies. Replacing one can
-	// discard a write from an editor that still holds the old inode open. Leave
-	// all checkouts untouched; their prior metadata makes them stale against the
-	// new canonical revision, so the normal refresh/conflict workflow preserves
-	// both clean and modified local state.
-}
-
 func (d *Daemon) broadcastWorkspaceContextChanged(canonical *protocol.WorkspaceContext) {
 	d.broadcastMessage(protocol.WorkspaceContextChangedMessage{
 		Event:              protocol.EventWorkspaceContextChanged,
@@ -639,7 +638,9 @@ func (d *Daemon) rollbackWorkspaceContextForSession(
 	if err != nil {
 		return nil, err
 	}
-	d.refreshCleanWorkspaceContextCheckouts(updated)
+	// Checkouts are agent-owned; we deliberately leave them untouched (see the note
+	// in the compact path) so the normal refresh/conflict workflow reconciles them
+	// against the restored revision rather than risking a lost local write.
 	d.broadcastWorkspaceContextChanged(updated)
 	return &protocol.WorkspaceContextMaintenanceResult{
 		Action:         protocol.WorkspaceContextMaintenanceActionRollback,

--- a/internal/daemon/workspacelayout.go
+++ b/internal/daemon/workspacelayout.go
@@ -824,16 +824,9 @@ func (d *Daemon) unregisterWorkspaceIfEmptyAfterMove(workspaceID string) {
 	if !removed {
 		return
 	}
-	d.forgetWorkspaceContextCompaction(workspaceID)
-	d.snapshotWorkspaceContextOnRemove(workspaceID, snapshot.Title)
-	d.store.RemoveWorkspace(workspaceID)
-	// Removal boundary (layout teardown): final retrospective narrate.
-	d.enqueueFinalNarrateWorkspace(workspaceID)
-	d.pruneTileContentSubscriptionsForLayout(workspaceID, nil)
-	d.wsHub.Broadcast(&protocol.WebSocketEvent{
-		Event:     protocol.EventWorkspaceUnregistered,
-		Workspace: &snapshot,
-	})
+	// Layout teardown (last visible pane/tile removed): tear down and write the
+	// removal-boundary retrospective.
+	d.tearDownRemovedWorkspace(snapshot)
 }
 
 func (d *Daemon) recomputeAndBroadcastWorkspace(workspaceID string) {

--- a/internal/tasks/commit_guard.go
+++ b/internal/tasks/commit_guard.go
@@ -24,7 +24,7 @@ import "sync"
 // of the contract ("cancel a not-yet-committing run cleanly"); a true return is
 // the (b) branch ("an already-committing run finishes its write untorn").
 //
-// The runner drives the coordination via tryFence / committed; an executor only
+// The runner drives the coordination via tryFence; an executor only
 // ever touches Enter/Leave.
 type CommitGuard struct {
 	mu         sync.Mutex

--- a/internal/tasks/runner.go
+++ b/internal/tasks/runner.go
@@ -9,8 +9,8 @@ import (
 	"time"
 )
 
-// Tuning defaults. Kept as package vars (not consts) so a kind config or a test
-// can override them through Options without changing the source.
+// Tuning defaults. Each is overridable per-runner through the matching Options
+// field (a zero value falls back to the default, resolved in New).
 const (
 	// DefaultMaxAttempts is the attempt cap: a task that has failed this many
 	// times goes dead instead of auto-requeuing.
@@ -447,15 +447,21 @@ func (r *Runner) Cancel(id string) {
 		r.mu.Unlock()
 		return
 	}
-	// Only cancel the context if the run has not yet entered its commit fence.
-	// If it is already committing, leave the context alone and just wait — the
-	// blocks-until-exit contract finishes an in-progress durable write untorn.
+	r.fenceAndWait(run)
+}
+
+// fenceAndWait performs the shared cancel-and-block core for Cancel and cancelActive.
+// The CALLER must hold r.mu and pass the currently-running run (non-nil); fenceAndWait
+// RELEASES r.mu before it blocks on the done channel. It cancels the run's context
+// only if the run has not yet entered its commit fence — if the run is already
+// committing, it leaves the context alone and just waits, so the blocks-until-exit
+// contract finishes an in-progress durable write untorn.
+func (r *Runner) fenceAndWait(run *activeRun) {
 	if run.guard.tryFence() {
 		run.cancel()
 	}
 	done := run.done
 	r.mu.Unlock()
-
 	<-done
 }
 
@@ -829,12 +835,7 @@ func (r *Runner) cancelActive() {
 		r.mu.Unlock()
 		return
 	}
-	if run.guard.tryFence() {
-		run.cancel()
-	}
-	done := run.done
-	r.mu.Unlock()
-	<-done
+	r.fenceAndWait(run)
 }
 
 // --- helpers ---------------------------------------------------------------


### PR DESCRIPTION
## Post-review cleanup (kb/11)

Applies the maintainability-review recommendations over the notebook/keeper epic's net diff. **Net −33 lines, no protocol/version change.** Stacked on `kb/10`; builds standalone on the tip, so it's fully Figgy-reviewable. The 10 approved slices (#347–#356) are left byte-identical.

### Plan-check on dead code (the load-bearing step)

Before deleting anything, each dead/no-op item was cross-referenced against `docs/plans/2026-06-14-notebook-narration.md` and `docs/plans/2026-06-18-knowledge-base.md`. Four were genuine cruft / already-planned removal; **one was a planned behavior left unwired** and is now completed rather than deleted:

- **`notebookCronInterval`** — a test-only seam never assigned anywhere; tests inject `now` into the tick directly, and the plan never wanted a tunable production cadence. Removed.
- **`refreshCleanWorkspaceContextCheckouts`** — an empty no-op documenting the *deliberate* decision not to rewrite agent-owned checkouts (confirmed by both plans). Removed; rationale relocated to the call sites.
- **startup-reaper final narrate (finding #3)** — plan §4 wants every removal path, including startup reconciliation, to enqueue a final retrospective, but the call was a guaranteed nil-runner no-op (load runs ~150 lines before `startCompactRunner`). **Now wired:** `loadWorkspacesFromStore` returns the reaped ids; `Start` enqueues them after the runner exists, matching the live removal paths (which already narrate post-removal from snapshot + transcripts).

### Dedup
- `tearDownRemovedWorkspace` — the byte-identical 6-statement teardown at the three live removal sites (`workspace.go` ×2, `workspacelayout.go`). The startup reaper deliberately stays separate (omits prune + broadcast).
- `Runner.fenceAndWait` — shared by `Cancel` and `cancelActive`, in the caller-holds-`mu` form (no `mu` drop/re-take, so the commit-fence / blocks-until-exit contract is preserved).
- `renameSettingKey` — shared by the keeper-compact and notebook-cron settings renames (exact copy-forward + log format preserved).
- `notebookSessionDigestPath` now reuses `notebookWorkspaceSessionsDir` for the per-workspace bucket.

### Comments / micro-simplify
runner tuning-defaults comment · CommitGuard `committed` ref · `narrationTierDefault` redundant case · `formatNextAttempt` dead `now` param · NotebookBrowser two-effects → one (drops eslint-disable) · headless_test helper reuse · `assertJournalUntouched` doc.

### Deferred (not in this PR)
- `Response.notebook_tasks` field removal — leftover from the removed `attn notebook tasks` CLI. Needs a `ProtocolVersion` bump + `make generate-types` + `make install`; kept out so this PR stays protocol-neutral. Batch it with the post-merge `make install`.

### Verification
`go build ./...` · `go vet ./...` · `go test ./internal/{tasks,agent,daemon}` (full daemon suite, 123s) · app vitest (950) · `tsc --noEmit` — all green.

— on behalf of Victor
