### PR TITLE
refactor(protocol): drop the unused Response.notebook_tasks field

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '113';
+export const PROTOCOL_VERSION = '114';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -2753,7 +2753,6 @@ export interface Response {
     notebook_entries?:                     NotebookEntryElement[];
     notebook_guide?:                       NotebookGuide;
     notebook_read?:                        NotebookReadObject;
-    notebook_tasks?:                       Task[];
     notebook_write?:                       NotebookWriteObject;
     ok:                                    boolean;
     prs?:                                  PRElement[];
@@ -7743,7 +7742,6 @@ const typeMap: any = {
         { json: "notebook_entries", js: "notebook_entries", typ: u(undefined, a(r("NotebookEntryElement"))) },
         { json: "notebook_guide", js: "notebook_guide", typ: u(undefined, r("NotebookGuide")) },
         { json: "notebook_read", js: "notebook_read", typ: u(undefined, r("NotebookReadObject")) },
-        { json: "notebook_tasks", js: "notebook_tasks", typ: u(undefined, a(r("Task"))) },
         { json: "notebook_write", js: "notebook_write", typ: u(undefined, r("NotebookWriteObject")) },
         { json: "ok", js: "ok", typ: true },
         { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "113"
+const ProtocolVersion = "114"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2663,9 +2663,6 @@ type Response struct {
 	// NotebookRead corresponds to the JSON schema field "notebook_read".
 	NotebookRead *NotebookReadResult `json:"notebook_read,omitempty,omitzero"`
 
-	// NotebookTasks corresponds to the JSON schema field "notebook_tasks".
-	NotebookTasks []NotebookTask `json:"notebook_tasks,omitempty,omitzero"`
-
 	// NotebookWrite corresponds to the JSON schema field "notebook_write".
 	NotebookWrite *NotebookWriteResult `json:"notebook_write,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1982,7 +1982,6 @@ model Response {
   notebook_read?: NotebookReadResult;
   notebook_write?: NotebookWriteResult;
   notebook_guide?: NotebookGuideResult;
-  notebook_tasks?: NotebookTask[];
 }
 
 model DelegateResult {


### PR DESCRIPTION
## Drop the unused `Response.notebook_tasks` protocol field (kb/12)

The deferred item from #358. The `Response` envelope carried `notebook_tasks?: NotebookTask[]` — a leftover from the removed `attn notebook tasks` CLI. The task surface is **websocket-only** (`NotebookTaskListResultMessage`), so the field has **no producer or consumer**: no Go or TS code reads `Response.NotebookTasks` (verified by grep across the tree, incl. tests).

Isolated in its own PR (stacked on `kb/11`) because it touches generated code + the version gate — kept out of #358 so that one stayed protocol-neutral and standalone-buildable.

### Change
- Remove `notebook_tasks` from `Response` in `main.tsp`. **Keep** the `NotebookTask` model (used by the WS task panel) and the `notebook_tasks_changed` broadcast.
- `ProtocolVersion` **113 → 114** + frontend `PROTOCOL_VERSION` mirror.
- Regenerated `generated.go` / `generated.ts` (`rm -rf tsp-output` first to avoid the orphaned-json-schema glob trap). Net −3 Go / −2 TS lines, no other schema churn.

### Owner step
`make install` (needs keychain) so the daemon adopts protocol 114 — fold this into the same install the epic already needs for the 113 bump.

### Verification
`go build ./...` · `go vet ./...` · `go test ./internal/protocol` + scoped daemon · full `go test ./internal/daemon` · `tsc --noEmit` · app vitest (950) — all green.

— on behalf of Victor
