### PR TITLE
feat(notebook): Notebook folder picker in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-20]
+
+### Added
+- **Choose where your Notebook folder lives.** Settings → General now has a Notebook Folder picker, so you can point attn's durable Notebook — your dated journals and knowledge base — at any folder you own instead of the default `~/attn-notebook` (separate per profile). Browse to a folder or type a path, and the picker shows where the Notebook currently resolves to; leave it blank to fall back to the default. attn starts using the new folder right away — your existing notes aren't moved, so move or sync the folder yourself if you want the current contents to come along.
+
 ## [2026-06-19]
 
 ### Added

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -662,3 +662,81 @@ describe('SettingsModal review loop prompts', () => {
     expect(screen.getByTestId('settings-context-keeper-model-custom')).toHaveValue('gpt-custom');
   });
 });
+
+describe('SettingsModal notebook folder', () => {
+  function renderModal(
+    settings: Record<string, string>,
+    onSetSetting = vi.fn(),
+  ) {
+    render(
+      <SettingsModal
+        isOpen
+        onClose={vi.fn()}
+        mutedRepos={[]}
+        githubHosts={[]}
+        onUnmuteRepo={vi.fn()}
+        mutedAuthors={[]}
+        onUnmuteAuthor={vi.fn()}
+        settings={settings}
+        endpoints={[]}
+        plugins={[]}
+        pluginIssues={[]}
+        onAddEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onUpdateEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onRemoveEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onSetEndpointRemoteWeb={vi.fn().mockResolvedValue({ success: true })}
+        onListPlugins={vi.fn().mockResolvedValue({ plugins: [], issues: [] })}
+        onInstallPlugin={vi.fn().mockResolvedValue({ success: true })}
+        onRemovePlugin={vi.fn().mockResolvedValue({ success: true })}
+        onSetPluginPriority={vi.fn().mockResolvedValue({ success: true })}
+        onSetSetting={onSetSetting}
+        themePreference="system"
+        onSetTheme={vi.fn()}
+      />,
+    );
+    return onSetSetting;
+  }
+
+  it('shows the override value and the daemon-resolved effective folder', async () => {
+    renderModal({
+      'notebook.root': '~/my-notes',
+      'notebook.root.effective': '/Users/me/my-notes',
+    });
+
+    fireEvent.click(screen.getByTestId('settings-nav-general'));
+    const input = await screen.findByTestId('settings-notebook-root-input');
+    expect(input).toHaveValue('~/my-notes');
+    expect(screen.getByTestId('settings-notebook-root-effective')).toHaveTextContent(
+      'Currently: /Users/me/my-notes',
+    );
+  });
+
+  it('falls back to the effective default as placeholder when no override is set', async () => {
+    renderModal({ 'notebook.root.effective': '/Users/me/attn-notebook' });
+
+    fireEvent.click(screen.getByTestId('settings-nav-general'));
+    const input = await screen.findByTestId('settings-notebook-root-input');
+    expect(input).toHaveValue('');
+    expect(input).toHaveAttribute('placeholder', '/Users/me/attn-notebook');
+  });
+
+  it('persists a new folder on blur and an empty value to restore the default', async () => {
+    const onSetSetting = renderModal({
+      'notebook.root': '~/my-notes',
+      'notebook.root.effective': '/Users/me/my-notes',
+    });
+
+    fireEvent.click(screen.getByTestId('settings-nav-general'));
+    const input = await screen.findByTestId('settings-notebook-root-input');
+
+    fireEvent.change(input, { target: { value: '/Users/me/elsewhere' } });
+    fireEvent.blur(input);
+    expect(onSetSetting).toHaveBeenCalledWith('notebook.root', '/Users/me/elsewhere');
+
+    // Clearing the override commits an empty value, which the daemon resolves
+    // back to the per-profile default.
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+    expect(onSetSetting).toHaveBeenCalledWith('notebook.root', '');
+  });
+});

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -106,6 +106,7 @@ export function SettingsModal({
   onSetTheme,
 }: SettingsModalProps) {
   const [projectsDir, setProjectsDir] = useState(settings.projects_directory || '');
+  const [notebookRoot, setNotebookRoot] = useState(settings['notebook.root'] || '');
   const [agentExecutables, setAgentExecutables] = useState<Record<SessionAgent, string>>({});
   const [editorExecutable, setEditorExecutable] = useState(settings.editor_executable || '');
   const [defaultAgent, setDefaultAgent] = useState<SessionAgent>('claude');
@@ -142,6 +143,10 @@ export function SettingsModal({
 
   // Sync with settings when modal opens
   const actualProjectsDir = settings.projects_directory || '';
+  // notebook.root is the user override (blank => default); notebook.root.effective is
+  // the daemon-resolved absolute folder the notebook actually lives in right now.
+  const actualNotebookRoot = settings['notebook.root'] || '';
+  const effectiveNotebookRoot = settings['notebook.root.effective'] || '';
   const tailscaleEnabled = (settings.tailscale_enabled || 'false') === 'true';
   const workflowsEnabled = (settings.workflows_enabled || 'false') === 'true';
   const tailscaleStatus = settings.tailscale_status || 'disabled';
@@ -227,6 +232,7 @@ export function SettingsModal({
   useEffect(() => {
     if (!isOpen) return;
     setProjectsDir(actualProjectsDir);
+    setNotebookRoot(actualNotebookRoot);
     setAgentExecutables(actualAgentExecutables);
     setEditorExecutable(actualEditorExecutable);
     setDefaultAgent(resolvedDefaultAgent);
@@ -249,7 +255,7 @@ export function SettingsModal({
     setPluginSourcePath('');
     setPluginError(null);
     setPluginActionName(null);
-  }, [isOpen, actualProjectsDir, actualAgentExecutables, actualEditorExecutable, resolvedDefaultAgent, actualReviewLoopPresets, actualReviewLoopModel, actualReviewerModel, actualWorkspaceContextKeeper]);
+  }, [isOpen, actualProjectsDir, actualNotebookRoot, actualAgentExecutables, actualEditorExecutable, resolvedDefaultAgent, actualReviewLoopPresets, actualReviewLoopModel, actualReviewerModel, actualWorkspaceContextKeeper]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -308,6 +314,36 @@ export function SettingsModal({
       }
     }
   }, [projectsDir, actualProjectsDir, onSetSetting]);
+
+  const handleBrowseNotebookRoot = useCallback(async () => {
+    const selected = await open({
+      directory: true,
+      multiple: false,
+      title: 'Select Notebook Folder',
+    });
+    if (selected && typeof selected === 'string') {
+      setNotebookRoot(selected);
+      onSetSetting('notebook.root', selected);
+    }
+  }, [onSetSetting]);
+
+  const handleNotebookRootChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setNotebookRoot(e.target.value);
+  }, []);
+
+  // Blank commits as an empty override, which the daemon resolves back to the
+  // per-profile default (~/attn-notebook).
+  const commitNotebookRoot = useCallback(() => {
+    if (notebookRoot !== actualNotebookRoot) {
+      onSetSetting('notebook.root', notebookRoot);
+    }
+  }, [notebookRoot, actualNotebookRoot, onSetSetting]);
+
+  const handleNotebookRootKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      commitNotebookRoot();
+    }
+  }, [commitNotebookRoot]);
 
   const handleExecutableChange = useCallback((agent: SessionAgent, value: string) => {
     setAgentExecutables((prev) => ({ ...prev, [agent]: value }));
@@ -655,10 +691,10 @@ export function SettingsModal({
         {
           id: 'general',
           label: 'Appearance and projects',
-          title: 'Appearance and project roots',
-          description: 'Theme selection and the directory attn uses when opening repositories and worktrees.',
-          count: 2,
-          keywords: 'theme appearance dark light system projects directory worktrees roots',
+          title: 'Appearance, project roots, and Notebook',
+          description: 'Theme selection, the directory attn uses when opening repositories and worktrees, and where your Notebook lives.',
+          count: 3,
+          keywords: 'theme appearance dark light system projects directory worktrees roots notebook folder knowledge base journal location',
         },
       ],
     },
@@ -886,6 +922,44 @@ export function SettingsModal({
               Browse
             </button>
           </div>
+        </div>
+      </section>
+
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Notebook</div>
+          <h3>Notebook Folder</h3>
+          <p className="settings-description">
+            Where attn keeps your durable Notebook — dated journals and the knowledge base — as plain
+            markdown you own. Leave blank to use the default (<code>~/attn-notebook</code>, separate per
+            profile). Changing this points attn at the new folder; your existing notes are not moved, so
+            move or sync the folder yourself if you want the current contents to come along.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          <div className="settings-inline-form projects-dir-input">
+            <input
+              data-testid="settings-notebook-root-input"
+              type="text"
+              value={notebookRoot}
+              onChange={handleNotebookRootChange}
+              onBlur={commitNotebookRoot}
+              onKeyDown={handleNotebookRootKeyDown}
+              placeholder={effectiveNotebookRoot || '~/attn-notebook'}
+              className="settings-input"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+            <button className="settings-action" onClick={handleBrowseNotebookRoot}>
+              Browse
+            </button>
+          </div>
+          {effectiveNotebookRoot && (
+            <p className="settings-description" data-testid="settings-notebook-root-effective">
+              Currently: <code>{effectiveNotebookRoot}</code>
+            </p>
+          )}
         </div>
       </section>
     </>

--- a/internal/daemon/notebook_test.go
+++ b/internal/daemon/notebook_test.go
@@ -696,6 +696,37 @@ func TestValidateNotebookRoot(t *testing.T) {
 	}
 }
 
+// The settings payload must surface the daemon-resolved notebook root under the
+// read-only notebook.root.effective key so the UI can show where the notebook
+// lives even when the override is blank. The key is computed, not stored, and
+// must never be accepted by set_setting.
+func TestNotebookRootEffectiveSurfacedReadOnly(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+	custom := t.TempDir()
+	d.store.SetSetting(SettingNotebookRoot, custom)
+	settings := d.settingsWithAgentAvailability()
+	if got := settings[SettingNotebookRootEffective]; got != custom {
+		t.Fatalf("notebook.root.effective = %v, want resolved root %q", got, custom)
+	}
+
+	// Blank override still resolves to (and surfaces) the profile default.
+	d.store.SetSetting(SettingNotebookRoot, "")
+	resolved, err := d.notebookRoot()
+	if err != nil {
+		t.Fatalf("notebookRoot: %v", err)
+	}
+	settings = d.settingsWithAgentAvailability()
+	if got := settings[SettingNotebookRootEffective]; got != resolved {
+		t.Fatalf("notebook.root.effective with default = %v, want %q", got, resolved)
+	}
+
+	// The computed key is read-only: set_setting must reject it.
+	if err := d.validateSetting(SettingNotebookRootEffective, "/tmp/whatever"); err == nil {
+		t.Fatal("notebook.root.effective must not be settable")
+	}
+}
+
 // readInboxNote returns the inbox note body for assertions.
 func readInboxNote(t *testing.T, d *Daemon) string {
 	t.Helper()

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -44,6 +44,11 @@ const (
 	// SettingNotebookRoot overrides the notebook's filesystem root. Empty =>
 	// the profile-derived default (~/attn-notebook[-profile]).
 	SettingNotebookRoot = "notebook.root"
+	// SettingNotebookRootEffective is a READ-ONLY, daemon-computed key surfaced in
+	// the settings payload (never stored, never accepted by set_setting): the
+	// absolute folder the notebook currently resolves to, so the UI can show where
+	// the notebook lives even when SettingNotebookRoot is blank (the default).
+	SettingNotebookRootEffective = "notebook.root.effective"
 	// SettingNotebookCronFrequency is the 5-field cron expression for the
 	// notebook's nightly maintenance slot (currently the daily-narrate backstop).
 	// Empty => the default ("0 3 * * *").
@@ -201,6 +206,9 @@ func (d *Daemon) settingsWithAgentAvailability() map[string]interface{} {
 		settings[SettingCopilotAvailable] = settings[availabilitySettingKey(string(protocol.SessionAgentCopilot))]
 	}
 	settings[SettingPTYBackendMode] = d.ptyBackendMode()
+	if root, err := d.notebookRoot(); err == nil {
+		settings[SettingNotebookRootEffective] = root
+	}
 	settings[SettingTailscaleEnabled] = strconv.FormatBool(parseBooleanSetting(stored[SettingTailscaleEnabled]))
 	settings[SettingWorkflowsEnabled] = strconv.FormatBool(parseBooleanSetting(stored[SettingWorkflowsEnabled]))
 


### PR DESCRIPTION
## What

Adds a **Notebook Folder** picker under Settings → General so you can relocate attn's durable Notebook (dated journals + knowledge base) from the app.

## Why

PR #360 introduced the `notebook.root` setting with full backend support — `validateNotebookRoot` (absolute path, `~/` expansion, refuses paths inside `~/.attn`), and live re-pointing (`notebookStoreFor()` rebuilds the store and `ensureNotebookWatcher()` follows the new root). But the slice shipped **backend-only**: no UI to set it and no changelog line, so an app user couldn't actually change the folder. This closes that gap.

## Changes

- **SettingsModal**: a Notebook Folder block under General, mirroring the existing Projects Directory picker (text input + Browse via Tauri `open`), wired to `notebook.root`. Blank commits an empty override, which the daemon resolves back to the per-profile default.
- **Daemon**: surfaces a read-only `notebook.root.effective` in the settings payload (computed, never stored, rejected by `set_setting`) so the picker shows where the Notebook currently resolves to even when the override is blank.
- **CHANGELOG**: entry for the relocatable Notebook folder.

## Behavior decision

Changing the folder **re-points** attn at the new location (matches the daemon's existing lazy-rebuild behavior); existing notes are **not** moved. The UI says so — move/sync the folder yourself if you want the current contents to come along. (Move/copy-on-change could be a follow-up.)

## Verification

- `go build ./...`, `go vet`, targeted daemon tests green (`TestNotebookRootEffectiveSurfacedReadOnly`, `TestValidateNotebookRoot`, `TestNotebookRootResolution`, `TestNotebookWatcherFollowsRootChange`).
- Frontend: 17 `SettingsModal` tests pass incl. 3 new ones — render shows override + effective folder, placeholder falls back to the effective default, persist-on-blur and clear-to-default both call `onSetSetting('notebook.root', …)`.
- `tsc` clean. Dev app (`make dev`) rebuilt + reinstalled.

Verified via the rendering tests (which exercise the exact DOM path nav→General→input→effective→persist/clear) rather than a pixel screenshot — the block reuses the Projects Directory CSS classes verbatim. No protocol bump: `notebook.root.effective` is an additive key on the open settings map and degrades gracefully against an old daemon/app.