### PR TITLE
fix(tasks): stop the durable task worker hot-looping on stale orphan records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Choose where your Notebook folder lives.** Settings → General now has a Notebook Folder picker, so you can point attn's durable Notebook — your dated journals and knowledge base — at any folder you own instead of the default `~/attn-notebook` (separate per profile). Browse to a folder or type a path, and the picker shows where the Notebook currently resolves to; leave it blank to fall back to the default. attn starts using the new folder right away — your existing notes aren't moved, so move or sync the folder yourself if you want the current contents to come along.
 
+### Fixed
+- **Background work (journal entries, summaries, context compaction) no longer stalls behind a stuck task.** A leftover task record from an earlier version of attn could be picked up by the background worker but never completed, so it was re-run on a tight endless loop — spiking CPU, flooding logs, and starving every other queued job behind it. attn now ignores these stale, unrunnable records so the queue drains and your journal and summary jobs run again.
+
 ## [2026-06-19]
 
 ### Added

--- a/internal/tasks/store.go
+++ b/internal/tasks/store.go
@@ -153,9 +153,23 @@ func (s *store) list() ([]*Task, error) {
 			s.log("tasks: skipping undecodable record %s: %v", e.Name(), err)
 			continue
 		}
-		if t != nil {
-			out = append(out, t)
+		if t == nil {
+			continue
 		}
+		// Defense symmetric with load(): the store addresses a record ONLY by its
+		// canonical taskFilename(id) name, so a task file named anything else is
+		// unreachable — save/delete/load by id all target taskFilename(id), never
+		// this file. The dangerous case is a leftover from the old lossy
+		// rune-replacement naming (pre-hex): list() would return it, runNext would
+		// claim it and persist the claim to the CANONICAL file, leaving the
+		// orphan's own file untouched and still queued — so it is re-selected every
+		// cycle. Because its NextAttemptAt is in the past it wins selection forever,
+		// a hot loop that also starves the real, canonically-named tasks. Skip it.
+		if e.Name() != taskFilename(t.ID)+".json" {
+			s.log("tasks: ignoring non-canonical record %s (stored id %q)", e.Name(), t.ID)
+			continue
+		}
+		out = append(out, t)
 	}
 	return out, nil
 }

--- a/internal/tasks/store_identity_test.go
+++ b/internal/tasks/store_identity_test.go
@@ -1,6 +1,10 @@
 package tasks
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 // TestTaskFilenamesAreInjective is a regression test for a storage-identity bug:
 // the original filename scheme replaced "/", ":", and ".." with "_", so two
@@ -66,5 +70,47 @@ func TestLoadRejectsMismatchedRecord(t *testing.T) {
 	}
 	if got != nil {
 		t.Fatalf("expected nil for a mismatched record, got %+v", got)
+	}
+}
+
+// TestListIgnoresNonCanonicalRecord is a regression test for a hot-loop bug. The
+// original lossy naming scheme wrote "kind:subject" as "kind__subject"; after the
+// switch to hex(id), those old files linger in the tasks dir with names that are
+// NOT taskFilename(id), so the store can never write back to them. list() used to
+// return such a record anyway: the worker would claim it (state=running persisted
+// to the CANONICAL file, leaving the orphan's own file untouched and still
+// queued), so the orphan was re-selected every poll — an infinite loop, observed
+// in prod as thousands of identical "skipping" log lines, that also starved the
+// real canonically-named tasks. list() must skip any record whose filename is not
+// its canonical encoding.
+func TestListIgnoresNonCanonicalRecord(t *testing.T) {
+	root := t.TempDir()
+	s := newStore(root)
+
+	// A real, canonically-named task (s.save writes to taskFilename(id).json).
+	if err := s.save(&Task{ID: "summarize_session:real", Kind: "summarize_session", Subject: "real", State: StateQueued}); err != nil {
+		t.Fatalf("save canonical: %v", err)
+	}
+
+	// An orphan from the pre-hex scheme dropped straight into the dir under a
+	// non-canonical name the store can never address by id.
+	orphanName := "summarize_session__orphan.json"
+	if orphanName == taskFilename("summarize_session:orphan")+".json" {
+		t.Fatal("test bug: orphan name is actually canonical")
+	}
+	orphan := []byte(`{"id":"summarize_session:orphan","kind":"summarize_session","subject":"orphan","state":"queued"}`)
+	if err := os.WriteFile(filepath.Join(stateDir(root), orphanName), orphan, 0o644); err != nil {
+		t.Fatalf("seed orphan: %v", err)
+	}
+
+	got, err := s.list()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("list returned %d records, want 1 (the orphan must be skipped): %+v", len(got), got)
+	}
+	if got[0].ID != "summarize_session:real" {
+		t.Fatalf("surviving record id = %q, want the canonical summarize_session:real", got[0].ID)
 	}
 }


### PR DESCRIPTION
## Symptom

The durable task engine (journal narration, session summaries, context compaction) got **stuck**. The prod daemon log was flooded with the *same line, same second*, thousands of times:

```
summarize_session: session attn-codex-e2e no longer present and no carried transcript, skipping
```

— a hot CPU loop that also starved every real queued task behind it.

## Root cause

The task store addresses every record by its canonical `taskFilename(id)` name (`hex(id).json`). An earlier **lossy naming scheme** wrote `kind:subject` as `kind__subject.json`; after the switch to hex, those old files linger in `<notebook>/.attn/tasks/` and are **unaddressable** — the store can never `save`/`delete`/`load` them by id.

`load()` already guards against this (id-mismatch → "no record"), but **`list()` did not**. So:

1. `list()` returned the orphan as a live `queued` task.
2. Its `NextAttemptAt` is in the past (Jun 17), so `runNext()` selected it over the real Jun-20 tasks (earliest-NextAttemptAt wins).
3. The claim (`state=running`) was persisted to the **canonical** file; the orphan's own file was never touched → still `queued`.
4. `runNext` returned "a task ran", so the drain loop never went idle → re-selected the same orphan forever.

## Fix

`list()` now skips any record whose filename isn't its canonical encoding — symmetric with `load()`'s existing guard. Orphans become inert; the canonical record (if any) is unaffected, and the queue drains normally.

One-file-per-task already isolates bad records; this extends that to "unaddressable" records, not just undecodable ones.

## Remediation already applied to the affected machine

The 7 orphan files on the prod notebook root (all old `__`-named records for **test/synthetic** sessions — `attn-codex-e2e`, `claude-session`, `sess-1`, `test-session`) were moved out of `~/attn-notebook/.attn/tasks/` to a backup dir. The running daemon stopped looping immediately and resumed draining real tasks (verified: `queued`/`done`/`running` mix, real `summarize_session` agent runs in the log, no more flood). The dev root had none.

No new orphans are created going forward — the current code only ever writes hex names — so this guard is for records that already exist on disk.

## Verification

- New regression test `TestListIgnoresNonCanonicalRecord` (an orphan file is excluded from `list()`).
- `go build ./...`, `go vet ./internal/tasks/`, and 136 task/daemon tests (`Task|Notebook|Compact|Narrat|Runner`) green.

## Follow-up (not in this PR)

Optional self-heal: a startup sweep that *deletes* provably-orphaned (parses-as-Task, non-canonical-name) files so they don't linger on disk. Skipping already neutralizes them; deletion is tidiness with slightly more blast radius, so left out of this minimal fix.