### PR TITLE
feat(notebook): single live-preview editor (read + type in one surface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-06-20]
 
+### Changed
+- **Read and edit Notebook notes in one place — the Edit mode is gone.** Opening a note now shows it as rendered markdown you can type straight into, the way Obsidian's live preview works: headings, **bold**, *italic*, `inline code`, and links render as you read, and the raw markdown of the line your cursor is on reveals itself so you can edit it. There's no more View/Edit toggle, and your changes save automatically (no Save button) — you still get a heads-up if the note changed on disk underneath you, and notes stay plain `.md` files.
+
 ### Added
 - **Choose where your Notebook folder lives.** Settings → General now has a Notebook Folder picker, so you can point attn's durable Notebook — your dated journals and knowledge base — at any folder you own instead of the default `~/attn-notebook` (separate per profile). Browse to a folder or type a path, and the picker shows where the Notebook currently resolves to; leave it blank to fall back to the default. attn starts using the new folder right away — your existing notes aren't moved, so move or sync the folder yourself if you want the current contents to come along.
 - **Configure the keeper's background work — and switch it off with one toggle.** Settings → Agents now has a single Keeper section that gathers all of the keeper's background duties: session summaries, journal narration, and workspace-context compaction. Each duty has its own agent and model picker (with recommended defaults — Haiku for summaries, Sonnet for narration), so you can dial cost and quality per duty. A new **Background tasks** master switch at the top turns every keeper duty on or off together; while it's off the keeper queues and runs no background work, though your picks stay saved, and turning it off won't interrupt a run already in flight.

--- a/app/e2e/live-markdown-editor.spec.ts
+++ b/app/e2e/live-markdown-editor.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+
+// The notebook's single read-and-type surface (CodeMirror live preview), rendered
+// in isolation by the component harness in a real browser — CM cannot mount under
+// happy-dom, so this is where its rendering and interactions are verified.
+// Screenshots are captured so the live preview can be eyeballed.
+
+test.describe('LiveMarkdownEditor (live preview)', () => {
+  test('renders markdown inline, hides syntax off the cursor line, and reveals it on it', async ({ page }) => {
+    await page.goto('/test-harness/?component=LiveMarkdownEditor');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-content');
+
+    // Headings are sized via the live-preview decorations.
+    await expect(page.locator('.cm-md-h1').first()).toBeVisible();
+    await expect(page.locator('.cm-md-h2').first()).toBeVisible();
+    // Inline styling renders (bold / italic / code / link).
+    await expect(page.locator('.cm-md-strong').first()).toBeVisible();
+    await expect(page.locator('.cm-md-em').first()).toBeVisible();
+    await expect(page.locator('.cm-md-code').first()).toBeVisible();
+    const link = page.locator('.cm-md-link').first();
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('data-href', '/knowledge/areas/foo.md');
+
+    // The heading's leading "# " is hidden while the cursor is elsewhere: the first
+    // rendered line reads "Notebook heading", not "# Notebook heading".
+    const firstLine = page.locator('.cm-line').first();
+    await expect(firstLine).toContainText('Notebook heading');
+    await expect(firstLine).not.toContainText('#');
+    await page.screenshot({ path: 'test-results/live-editor-preview.png' });
+
+    // Click into the heading line — its raw "# " marker is revealed for editing
+    // (Obsidian's active-line behavior).
+    await firstLine.click();
+    await expect(firstLine).toContainText('#');
+    await page.screenshot({ path: 'test-results/live-editor-active-line.png' });
+  });
+
+  test('typing edits the document and reports changes', async ({ page }) => {
+    await page.goto('/test-harness/?component=LiveMarkdownEditor&empty=1');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-content');
+
+    await page.locator('.cm-content').click();
+    await page.keyboard.type('# Fresh note', { delay: 8 });
+
+    // The change is reported with the new document text, and renders as a heading.
+    await page.waitForFunction(() => window.__HARNESS__.getCalls('change').length > 0);
+    const last = await page.evaluate(() => {
+      const calls = window.__HARNESS__.getCalls('change');
+      return calls[calls.length - 1][0] as string;
+    });
+    expect(last).toBe('# Fresh note');
+    await expect(page.locator('.cm-md-h1').first()).toBeVisible();
+  });
+
+  test('mod-click on a wiki link reports the href to follow', async ({ page }) => {
+    await page.goto('/test-harness/?component=LiveMarkdownEditor');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-md-link');
+
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.locator('.cm-md-link').first().click({ modifiers: [modifier] });
+
+    const calls = await page.evaluate(() => window.__HARNESS__.getCalls('followLink'));
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe('/knowledge/areas/foo.md');
+  });
+
+  test('selecting text reports a non-empty selection', async ({ page }) => {
+    await page.goto('/test-harness/?component=LiveMarkdownEditor');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-content');
+
+    // Select the whole first line (the heading text).
+    await page.locator('.cm-line').first().click();
+    await page.keyboard.press('Home');
+    await page.keyboard.press('Shift+End');
+
+    await page.waitForFunction(() => {
+      const calls = window.__HARNESS__.getCalls('selectionChange');
+      const last = calls[calls.length - 1]?.[0] as { text?: string } | null;
+      return !!last && typeof last.text === 'string' && last.text.length > 0;
+    });
+    const last = await page.evaluate(() => {
+      const calls = window.__HARNESS__.getCalls('selectionChange');
+      return calls[calls.length - 1][0] as { text: string; top: number; left: number };
+    });
+    expect(last.text).toContain('Notebook heading');
+  });
+});

--- a/app/e2e/live-markdown-editor.spec.ts
+++ b/app/e2e/live-markdown-editor.spec.ts
@@ -36,6 +36,23 @@ test.describe('LiveMarkdownEditor (live preview)', () => {
     await page.screenshot({ path: 'test-results/live-editor-active-line.png' });
   });
 
+  test('renders a visible caret in the app theme (not CodeMirror\'s default black)', async ({ page }) => {
+    // Regression: basicSetup's drawSelection hides the native caret and draws its own
+    // .cm-cursor, whose default border is solid black — invisible on the dark pane.
+    // Our editorTheme must paint it the app's text color (a CM theme without {dark}
+    // otherwise inherits the light base default).
+    await page.goto('/test-harness/?component=LiveMarkdownEditor');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.locator('.cm-content').click(); // focus → the cursor layer renders
+
+    const cursor = page.locator('.cm-cursor').first();
+    await cursor.waitFor();
+    const borderColor = await cursor.evaluate((el) => getComputedStyle(el).borderLeftColor);
+    // The bug was a black caret; ours uses --color-text-primary (dark theme #e8e8e8).
+    expect(borderColor).not.toBe('rgb(0, 0, 0)');
+    expect(borderColor).toBe('rgb(232, 232, 232)');
+  });
+
   test('typing edits the document and reports changes', async ({ page }) => {
     await page.goto('/test-harness/?component=LiveMarkdownEditor&empty=1');
     await page.waitForFunction(() => window.__HARNESS__?.ready === true);

--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+
+// The full notebook modal (sidebar + single live-editor document pane), rendered by
+// the component harness with mocked daemon functions in a real browser. Verifies the
+// redesigned layout end-to-end and that the always-live editor autosaves — no
+// view/edit toggle. Screenshots capture the assembled UI.
+
+test.describe('NotebookBrowser (single live surface)', () => {
+  test('opens a note into a live editor with no view/edit toggle and autosaves edits', async ({ page }) => {
+    await page.goto('/test-harness/?component=NotebookBrowser');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+
+    // The sidebar lists notes and the preferred note opens into the live editor.
+    await expect(page.getByText('Foo decision')).toBeVisible();
+    await expect(page.getByRole('heading', { level: 2, name: 'Knowledge index' })).toBeVisible();
+    await page.waitForSelector('.cm-content');
+    // Rendered inline (heading sized), not a textarea of raw markdown.
+    await expect(page.locator('.cm-md-h1').first()).toBeVisible();
+    // There is no mode toggle — the surface is always editable.
+    await expect(page.getByRole('button', { name: 'Edit' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Save' })).toHaveCount(0);
+    // Backlinks render in their strip.
+    await expect(page.getByRole('heading', { name: /Linked from/ })).toBeVisible();
+    await page.screenshot({ path: 'test-results/notebook-browser-open.png' });
+
+    // Type at the end of the document; the debounced autosave persists via hash-CAS.
+    await page.locator('.cm-content').click();
+    await page.keyboard.press('Control+End');
+    await page.keyboard.type(' Extra words.', { delay: 8 });
+
+    await page.waitForFunction(() => window.__HARNESS__.getCalls('writeNotebook').length > 0, null, {
+      timeout: 4000,
+    });
+    const writes = await page.evaluate(() => window.__HARNESS__.getCalls('writeNotebook'));
+    const last = writes[writes.length - 1] as [string, string, string | undefined];
+    expect(last[0]).toBe('knowledge/index.md');
+    expect(last[1]).toContain('Extra words.');
+    expect(last[2]).toBe('h1'); // saved against the loaded hash
+    // The live save indicator reflects the persisted state.
+    await expect(page.getByText('Saved')).toBeVisible();
+    await page.screenshot({ path: 'test-results/notebook-browser-saved.png' });
+  });
+
+  test('navigates to another note when a sidebar item is clicked', async ({ page }) => {
+    await page.goto('/test-harness/?component=NotebookBrowser');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.getByRole('heading', { level: 2, name: 'Knowledge index' }).waitFor();
+
+    await page.getByRole('button', { name: /Foo decision/ }).click();
+    await expect(page.getByRole('heading', { level: 2, name: 'Foo decision' })).toBeVisible();
+  });
+});

--- a/app/package.json
+++ b/app/package.json
@@ -58,6 +58,12 @@
     "e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.43.1",
+    "@lezer/common": "^1.5.2",
+    "@lezer/markdown": "^1.6.4",
     "@pierre/diffs": "^1.2.7",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-clipboard-manager": "^2",
@@ -66,6 +72,7 @@
     "@tauri-apps/plugin-fs": "^2.5.0",
     "@tauri-apps/plugin-opener": "^2",
     "@testing-library/dom": "^10.4.1",
+    "@uiw/react-codemirror": "^4.25.10",
     "focus-trap-react": "^11.0.4",
     "ghostty-web": "0.4.0",
     "html-to-image": "^1.11.13",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -8,6 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@codemirror/lang-markdown':
+        specifier: ^6.5.0
+        version: 6.5.0
+      '@codemirror/language':
+        specifier: ^6.12.3
+        version: 6.12.3
+      '@codemirror/state':
+        specifier: ^6.6.0
+        version: 6.6.0
+      '@codemirror/view':
+        specifier: ^6.43.1
+        version: 6.43.1
+      '@lezer/common':
+        specifier: ^1.5.2
+        version: 1.5.2
+      '@lezer/markdown':
+        specifier: ^1.6.4
+        version: 1.6.4
       '@pierre/diffs':
         specifier: ^1.2.7
         version: 1.2.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -32,6 +50,9 @@ importers:
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
+      '@uiw/react-codemirror':
+        specifier: ^4.25.10
+        version: 4.25.10(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.1)(codemirror@6.0.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       focus-trap-react:
         specifier: ^11.0.4
         version: 11.0.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -202,6 +223,42 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/search@6.7.1':
+    resolution: {integrity: sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+
+  '@codemirror/view@6.43.1':
+    resolution: {integrity: sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -374,6 +431,30 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.6.4':
+    resolution: {integrity: sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@pierre/diffs@1.2.7':
     resolution: {integrity: sha512-YrHmFZLDtiLZ4DkiVqMDUFqTFIct3ML3t20nMp0UeuiUtqrmRcenYVxPb4IafiNkhZZURhCiwcs89tVb/HrSDA==}
@@ -723,6 +804,28 @@ packages:
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.10':
+    resolution: {integrity: sha512-P3vytLlpE62KYSWrMUnwDCv2lvaQDuDZzyj03mHntuHo5bSl34fRZpjTY3kQTPGuXHxkGSYpoPFFj+hMTqaaMQ==}
+    peerDependencies:
+      '@codemirror/autocomplete': '>=6.0.0'
+      '@codemirror/commands': '>=6.0.0'
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/lint': '>=6.0.0'
+      '@codemirror/search': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+
+  '@uiw/react-codemirror@4.25.10':
+    resolution: {integrity: sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w==}
+    peerDependencies:
+      '@babel/runtime': '>=7.11.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/theme-one-dark': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+      codemirror: '>=6.0.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
@@ -815,11 +918,17 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -1283,6 +1392,9 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -1424,6 +1536,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -1596,6 +1711,99 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.6.4
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      crelt: 1.0.6
+
+  '@codemirror/search@6.7.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/highlight': 1.2.3
+
+  '@codemirror/view@6.43.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -1692,6 +1900,41 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.6.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@pierre/diffs@1.2.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -1989,6 +2232,33 @@ snapshots:
 
   '@types/whatwg-mimetype@3.0.2': {}
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.10(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.1
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+
+  '@uiw/react-codemirror@4.25.10(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.1)(codemirror@6.0.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@codemirror/commands': 6.10.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.43.1
+      '@uiw/codemirror-extensions-basic-setup': 4.25.10(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)
+      codemirror: 6.0.2
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    transitivePeerDependencies:
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@4.7.0(vite@7.2.6(@types/node@20.19.26))':
@@ -2080,9 +2350,21 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.1
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+
   comma-separated-tokens@2.0.3: {}
 
   convert-source-map@2.0.0: {}
+
+  crelt@1.0.6: {}
 
   css.escape@1.5.1: {}
 
@@ -2815,6 +3097,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  style-mod@4.1.3: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -2942,6 +3226,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  w3c-keyname@2.2.8: {}
 
   whatwg-mimetype@3.0.0: {}
 

--- a/app/src/components/NotebookBrowser.css
+++ b/app/src/components/NotebookBrowser.css
@@ -213,10 +213,13 @@
 
 .notebook-browser-document {
   min-width: 0;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .notebook-browser-document-meta {
+  flex: none;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -249,24 +252,10 @@
   flex-shrink: 0;
 }
 
-.notebook-browser-saved {
+.notebook-browser-save-status {
   font-size: 12px;
-  color: var(--accent);
-}
-
-.notebook-browser-edit-btn {
-  padding: 6px 14px;
-  font-size: 13px;
-  color: var(--color-text-secondary);
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--color-border);
-  border-radius: 7px;
-  cursor: pointer;
-}
-
-.notebook-browser-edit-btn:hover {
-  color: var(--color-text-primary);
-  border-color: var(--accent);
+  color: var(--color-text-muted);
+  white-space: nowrap;
 }
 
 .notebook-browser-chief-status {
@@ -306,30 +295,38 @@
   cursor: default;
 }
 
-/* Editor */
-.notebook-browser-editor {
+/* Live editor surface — read and type in one. The pane scrolls inside the editor
+   (CM owns its scroller); the meta header and backlinks strip stay fixed. */
+.notebook-browser-live {
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 22px clamp(28px, 6vw, 90px) 28px;
+  padding: 18px clamp(28px, 6vw, 90px) 0;
 }
 
-.notebook-browser-editor-area {
-  width: 100%;
-  min-height: 320px;
-  resize: vertical;
-  padding: 16px;
-  color: var(--color-text-primary);
-  background: var(--color-bg-app);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  font: 13px/1.6 ui-monospace, 'SFMono-Regular', monospace;
-  tab-size: 2;
+.notebook-browser-live-editor {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
-.notebook-browser-editor-area:focus {
-  outline: none;
-  border-color: var(--accent);
+/* The @uiw/react-codemirror wrapper and the CM editor both fill the flex cell so
+   the editor owns the vertical scroll (CM keeps the cursor in view as you type). */
+.notebook-browser-live-editor > * {
+  flex: 1;
+  min-height: 0;
+}
+
+.notebook-browser-live-editor .cm-editor {
+  height: 100%;
+}
+
+.notebook-browser-live-editor .cm-scroller {
+  overflow: auto;
 }
 
 .notebook-browser-editor-conflict {
@@ -351,8 +348,7 @@
   flex-shrink: 0;
 }
 
-.notebook-browser-editor-conflict-actions button,
-.notebook-browser-editor-actions button {
+.notebook-browser-editor-conflict-actions button {
   padding: 6px 14px;
   font-size: 13px;
   color: var(--color-text-secondary);
@@ -362,29 +358,11 @@
   cursor: pointer;
 }
 
-.notebook-browser-editor-conflict-actions button:hover:not(:disabled),
-.notebook-browser-editor-actions button:hover:not(:disabled) {
+.notebook-browser-editor-conflict-actions button:hover:not(:disabled) {
   color: var(--color-text-primary);
   border-color: var(--accent);
 }
 
-.notebook-browser-editor-actions {
-  display: flex;
-  gap: 8px;
-}
-
-.notebook-browser-editor-save {
-  color: var(--color-bg-app) !important;
-  background: var(--accent) !important;
-  border-color: var(--accent) !important;
-  font-weight: 600;
-}
-
-.notebook-browser-editor-save:hover:not(:disabled) {
-  filter: brightness(1.08);
-}
-
-.notebook-browser-editor-actions button:disabled,
 .notebook-browser-editor-conflict-actions button:disabled {
   opacity: 0.55;
   cursor: default;
@@ -396,86 +374,14 @@
   color: var(--color-danger, #e5484d);
 }
 
-.notebook-browser-markdown {
-  max-width: 900px;
-  padding: 30px clamp(28px, 6vw, 90px) 24px;
-  color: var(--color-text-secondary);
-  font-size: 14px;
-  line-height: 1.65;
-}
-
-.notebook-browser-markdown h1,
-.notebook-browser-markdown h2,
-.notebook-browser-markdown h3 {
-  color: var(--color-text-primary);
-  letter-spacing: -0.02em;
-}
-
-.notebook-browser-markdown h1 { margin: 0 0 24px; font-size: 28px; }
-
-.notebook-browser-markdown h2 {
-  margin: 34px 0 12px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--color-border-subtle);
-  font-size: 18px;
-}
-
-.notebook-browser-markdown h3 { margin: 24px 0 8px; font-size: 15px; }
-
-.notebook-browser-markdown p,
-.notebook-browser-markdown ul,
-.notebook-browser-markdown ol,
-.notebook-browser-markdown pre,
-.notebook-browser-markdown blockquote {
-  margin: 0 0 16px;
-}
-
-.notebook-browser-markdown ul,
-.notebook-browser-markdown ol { padding-left: 22px; }
-
-.notebook-browser-markdown code {
-  padding: 2px 5px;
-  color: color-mix(in srgb, var(--accent) 75%, var(--color-text-primary));
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: 4px;
-  font: 0.9em/1.4 ui-monospace, 'SFMono-Regular', monospace;
-}
-
-.notebook-browser-markdown pre {
-  overflow-x: auto;
-  padding: 14px;
-  background: var(--color-bg-app);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-}
-
-.notebook-browser-markdown pre code {
-  padding: 0;
-  color: var(--color-text-secondary);
-  background: transparent;
-  border: 0;
-}
-
-.notebook-browser-markdown blockquote {
-  padding-left: 14px;
-  color: var(--color-text-tertiary);
-  border-left: 3px solid var(--accent);
-}
-
-.notebook-browser-markdown a { color: var(--accent); }
-
-/* An in-notebook link reads as a wiki cross-reference. */
-.notebook-browser-markdown a.notebook-link {
-  color: color-mix(in srgb, var(--accent) 88%, var(--color-text-primary));
-  text-decoration-style: dotted;
-  text-underline-offset: 2px;
-}
-
+/* Backlinks sit in a fixed strip at the foot of the document pane (stage 3 moves
+   them to the right context rail). It scrolls on its own if there are many. */
 .notebook-browser-backlinks {
-  max-width: 900px;
-  margin: 0 clamp(28px, 6vw, 90px) 70px;
-  padding-top: 18px;
+  flex: none;
+  max-height: 132px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 14px clamp(28px, 6vw, 90px) 18px;
   border-top: 1px solid var(--color-border-subtle);
 }
 

--- a/app/src/components/NotebookBrowser.test.tsx
+++ b/app/src/components/NotebookBrowser.test.tsx
@@ -329,7 +329,7 @@ describe('NotebookBrowser', () => {
   });
 
   it('flushes an unsaved buffer when navigating away before autosave fires', async () => {
-    const { props, writeNotebook } = makeProps();
+    const { props, writeNotebook, readNotebook } = makeProps();
     render(<NotebookBrowser {...props} />);
     await waitForNoteLoaded();
 
@@ -337,8 +337,73 @@ describe('NotebookBrowser', () => {
     fireEvent.change(editor(), { target: { value: '# quick edit\n' } });
     fireEvent.click(screen.getByRole('button', { name: /Foo decision/ }));
 
-    // The outgoing buffer is flushed against its loaded hash, so the edit isn't lost.
+    // The outgoing buffer is flushed against its loaded hash, so the edit isn't lost,
+    // and (the flush having succeeded) the navigation lands on the new note.
     await waitFor(() => expect(writeNotebook).toHaveBeenCalledWith('knowledge/index.md', '# quick edit\n', 'h1'));
+    await waitFor(() => expect(readNotebook).toHaveBeenCalledWith('knowledge/areas/foo.md'));
+    expect(await screen.findByRole('heading', { level: 2, name: 'Foo decision' })).toBeInTheDocument();
+  });
+
+  it('aborts navigation and surfaces the conflict when the navigate flush conflicts', async () => {
+    const { props, writeNotebook, readNotebook } = makeProps();
+    // The flush triggered by navigating away conflicts (the note changed on disk).
+    writeNotebook.mockResolvedValueOnce({ path: 'knowledge/index.md', conflict: true, currentHash: 'hX' });
+    render(<NotebookBrowser {...props} />);
+    await waitForNoteLoaded();
+
+    // Type, then navigate away before the autosave fires; the flush hits the conflict.
+    fireEvent.change(editor(), { target: { value: '# mine\n' } });
+    fireEvent.click(screen.getByRole('button', { name: /Foo decision/ }));
+
+    // The flush wrote against the loaded hash and came back conflicted, so the
+    // navigation is abandoned: we stay on the current note, the conflict banner shows,
+    // and the buffer is intact — the edit is NOT lost behind a silent navigation.
+    await waitFor(() => expect(writeNotebook).toHaveBeenCalledWith('knowledge/index.md', '# mine\n', 'h1'));
+    expect(await screen.findByText(/changed on disk/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Knowledge index' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 2, name: 'Foo decision' })).not.toBeInTheDocument();
+    expect(editor().value).toBe('# mine\n');
+    expect(readNotebook).not.toHaveBeenCalledWith('knowledge/areas/foo.md');
+  });
+
+  it('does not stamp a stale reload-from-disk onto a note navigated to mid-reload', async () => {
+    const { props, writeNotebook, readNotebook } = makeProps();
+    // Autosave conflicts (so the "Reload from disk" affordance appears); the later
+    // navigate flush then succeeds, superseding the in-flight reload.
+    writeNotebook
+      .mockResolvedValueOnce({ path: 'knowledge/index.md', conflict: true, currentHash: 'hX' })
+      .mockResolvedValueOnce({ path: 'knowledge/index.md', hash: 'h2', conflict: false });
+    // Defer the SECOND read of index (the reload) so navigation can outrun it.
+    let indexReads = 0;
+    let resolveReload: (r: NotebookReadResult) => void = () => {};
+    readNotebook.mockImplementation((path) => {
+      if (path === 'knowledge/index.md') {
+        indexReads += 1;
+        if (indexReads === 2) return new Promise<NotebookReadResult>((resolve) => { resolveReload = resolve; });
+      }
+      return Promise.resolve({ path, content: `# ${path}\n\nbody`, hash: 'h1' });
+    });
+    render(<NotebookBrowser {...props} />);
+    await waitForNoteLoaded();
+
+    // Edit → the debounced autosave conflicts → the reconcile banner appears.
+    fireEvent.change(editor(), { target: { value: '# mine\n' } });
+    expect(await screen.findByText(/changed on disk/i, undefined, { timeout: 2500 })).toBeInTheDocument();
+
+    // Start a reload from disk (its read is deferred), then navigate away before it
+    // resolves; the navigate flush succeeds and lands us on the new note.
+    fireEvent.click(screen.getByRole('button', { name: 'Reload from disk' }));
+    fireEvent.click(screen.getByRole('button', { name: /Foo decision/ }));
+    await screen.findByRole('heading', { level: 2, name: 'Foo decision' });
+    await waitFor(() => expect(editor().value).toContain('# knowledge/areas/foo.md'));
+
+    // The stale reload of index now resolves — it must NOT stamp its content over the
+    // note the user navigated to.
+    await act(async () => {
+      resolveReload({ path: 'knowledge/index.md', content: '# reloaded index\n', hash: 'hX' });
+    });
+    expect(editor().value).not.toContain('# reloaded index');
+    expect(editor().value).toContain('# knowledge/areas/foo.md');
   });
 
   it('keeps the buffer when a change signal arrives with unsaved edits (no clobber)', async () => {

--- a/app/src/components/NotebookBrowser.test.tsx
+++ b/app/src/components/NotebookBrowser.test.tsx
@@ -3,6 +3,43 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NotebookBrowser, parseNotebookHref } from './NotebookBrowser';
 import type { NotebookEntry, NotebookReadResult, NotebookSendToChiefResult, NotebookTask, NotebookWriteResult } from '../hooks/useDaemonSocket';
 
+// The live editor is CodeMirror-backed, which cannot mount under happy-dom (its
+// async measure pass throws). The real editing experience (live preview, typing,
+// link-follow, selection) is covered by the Playwright harness; here we mock the
+// editor to a controlled textarea and expose its callbacks so these tests can drive
+// the surrounding orchestration (autosave, conflict, flush, navigation guards).
+const editorMock = vi.hoisted(() => ({
+  current: null as null | {
+    onFollowLink?: (href: string) => void;
+    onSelectionChange?: (sel: { text: string; top: number; left: number } | null) => void;
+  },
+}));
+
+vi.mock('./notebook/LiveMarkdownEditor', () => ({
+  LiveMarkdownEditor: ({
+    value,
+    onChange,
+    onFollowLink,
+    onSelectionChange,
+    ariaLabel,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    onFollowLink?: (href: string) => void;
+    onSelectionChange?: (sel: { text: string; top: number; left: number } | null) => void;
+    ariaLabel?: string;
+  }) => {
+    editorMock.current = { onFollowLink, onSelectionChange };
+    return (
+      <textarea
+        aria-label={ariaLabel ?? 'Note'}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    );
+  },
+}));
+
 const ENTRIES: NotebookEntry[] = [
   { path: 'knowledge/index.md', type: 'note', title: 'Knowledge index', size: 10 },
   { path: 'journal/2026-06-13.md', type: 'journal', title: '2026-06-13', size: 20 },
@@ -76,20 +113,19 @@ function makeProps(overrides: Partial<React.ComponentProps<typeof NotebookBrowse
   };
 }
 
-// mockSelection stubs window.getSelection so a mouseup on the rendered markdown
-// behaves as if `text` is highlighted (empty/whitespace = collapsed selection).
-function mockSelection(text: string) {
-  const rect = { top: 40, left: 60, width: 120, height: 18 } as DOMRect;
-  const sel = {
-    toString: () => text,
-    rangeCount: text.trim() ? 1 : 0,
-    getRangeAt: () => ({ getBoundingClientRect: () => rect }),
-  } as unknown as Selection;
-  return vi.spyOn(window, 'getSelection').mockReturnValue(sel);
+// The single live editor surface (mocked to a textarea).
+function editor() {
+  return screen.getByRole('textbox', { name: 'Note' }) as HTMLTextAreaElement;
+}
+
+// Wait for the preferred note (knowledge/index.md) to load into the editor.
+async function waitForNoteLoaded() {
+  await waitFor(() => expect(editor().value).toContain('# knowledge/index.md'));
 }
 
 describe('NotebookBrowser', () => {
   afterEach(() => {
+    editorMock.current = null;
     vi.restoreAllMocks();
   });
 
@@ -104,16 +140,17 @@ describe('NotebookBrowser', () => {
     render(<NotebookBrowser {...props} />);
 
     // The sidebar lists every note, grouped. ('Foo decision' is unique to the
-    // sidebar; 'Knowledge index' also appears as the open note's title.)
+    // sidebar; the open note's title shows in the document header instead.)
     expect(await screen.findByText('Foo decision')).toBeInTheDocument();
     expect(screen.getByText('knowledge/areas/foo.md')).toBeInTheDocument();
     expect(listNotebook).toHaveBeenCalledTimes(1);
 
-    // knowledge/index.md is the preferred first selection and is read + rendered.
+    // knowledge/index.md is the preferred first selection and is read + loaded.
     await waitFor(() => expect(readNotebook).toHaveBeenCalledWith('knowledge/index.md'));
     expect(backlinksNotebook).toHaveBeenCalledWith('knowledge/index.md');
-    // The rendered note body (h1 from the markdown content).
-    expect(await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' })).toBeInTheDocument();
+    // The document header shows the note's title, and its content loads into the editor.
+    expect(await screen.findByRole('heading', { level: 2, name: 'Knowledge index' })).toBeInTheDocument();
+    await waitForNoteLoaded();
     // The backlink entry is shown.
     expect(await screen.findByRole('button', { name: '2026-06-13' })).toBeInTheDocument();
   });
@@ -137,12 +174,13 @@ describe('NotebookBrowser', () => {
     }
   });
 
-  it('navigates when an in-notebook link is clicked', async () => {
+  it('navigates when an in-notebook link is followed', async () => {
     const { props, readNotebook } = makeProps();
     render(<NotebookBrowser {...props} />);
+    await screen.findByRole('heading', { level: 2, name: 'Knowledge index' });
 
-    const link = await screen.findByRole('link', { name: 'the decision' });
-    fireEvent.click(link);
+    // The editor reports a mod-click on an in-notebook link via onFollowLink.
+    act(() => editorMock.current!.onFollowLink!('/knowledge/areas/foo.md'));
 
     await waitFor(() => expect(readNotebook).toHaveBeenCalledWith('knowledge/areas/foo.md'));
   });
@@ -150,6 +188,7 @@ describe('NotebookBrowser', () => {
   it('navigates when a backlink is clicked', async () => {
     const { props, readNotebook } = makeProps();
     render(<NotebookBrowser {...props} />);
+    await screen.findByRole('heading', { level: 2, name: 'Knowledge index' });
 
     const backlink = await screen.findByRole('button', { name: '2026-06-13' });
     fireEvent.click(backlink);
@@ -184,21 +223,21 @@ describe('NotebookBrowser', () => {
     listNotebook.mockResolvedValueOnce(ENTRIES);
     const { rerender } = render(<NotebookBrowser {...props} />);
 
-    // The preferred note opens and renders.
-    expect(await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' })).toBeInTheDocument();
+    // The preferred note opens and shows its title.
+    expect(await screen.findByRole('heading', { level: 2, name: 'Knowledge index' })).toBeInTheDocument();
 
     rerender(<NotebookBrowser {...props} changeSignal={1} />);
 
-    // The deleted note's stale content is gone; the document returns to empty.
+    // The deleted note is gone; the document returns to the empty state.
     expect(await screen.findByText('Nothing selected')).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { level: 1, name: 'knowledge/index.md' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 2, name: 'Knowledge index' })).not.toBeInTheDocument();
   });
 
   it('keeps the open note when a change-signal refresh fails transiently', async () => {
     const { props, listNotebook } = makeProps();
     const { rerender } = render(<NotebookBrowser {...props} />);
 
-    expect(await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Knowledge index' })).toBeInTheDocument();
 
     // The initial open succeeded; the refresh triggered by the change signal now
     // rejects (a transient WS hiccup, not a deletion).
@@ -208,7 +247,7 @@ describe('NotebookBrowser', () => {
     // A failed refresh must NOT be mistaken for an empty/deleted tree: the open
     // note stays put and the document does not fall back to the empty state.
     await waitFor(() => expect(listNotebook.mock.calls.length).toBeGreaterThan(1));
-    expect(screen.getByRole('heading', { level: 1, name: 'knowledge/index.md' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Knowledge index' })).toBeInTheDocument();
     expect(screen.queryByText('Nothing selected')).not.toBeInTheDocument();
   });
 
@@ -240,69 +279,74 @@ describe('NotebookBrowser', () => {
     expect(screen.getByText('Foo decision')).toBeInTheDocument();
   });
 
-  it('edits and saves a note via hash-CAS, then returns to the rendered view', async () => {
+  it('autosaves an edited note via hash-CAS and shows a Saved indicator', async () => {
     const { props, writeNotebook } = makeProps();
     render(<NotebookBrowser {...props} />);
+    await waitForNoteLoaded();
 
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' });
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    // Type into the single live surface — there is no edit mode to enter.
+    fireEvent.change(editor(), { target: { value: '# edited\n' } });
 
-    const textarea = await screen.findByRole('textbox', { name: 'Edit note' });
-    fireEvent.change(textarea, { target: { value: '# edited\n' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-    // Saved against the hash the note was loaded with (h1).
-    await waitFor(() => expect(writeNotebook).toHaveBeenCalledWith('knowledge/index.md', '# edited\n', 'h1'));
-    // The editor closes, the rendered view shows the new content, and a Saved
-    // indicator appears.
-    expect(await screen.findByRole('heading', { level: 1, name: 'edited' })).toBeInTheDocument();
-    expect(screen.getByText('Saved')).toBeInTheDocument();
-    expect(screen.queryByRole('textbox', { name: 'Edit note' })).not.toBeInTheDocument();
+    // The debounced autosave persists against the loaded hash (h1); no Save button.
+    await waitFor(
+      () => expect(writeNotebook).toHaveBeenCalledWith('knowledge/index.md', '# edited\n', 'h1'),
+      { timeout: 2000 },
+    );
+    expect(await screen.findByText('Saved')).toBeInTheDocument();
   });
 
-  it('surfaces a save conflict and lets the user overwrite the on-disk version', async () => {
+  it('there is no view/edit toggle — the surface is always editable', async () => {
+    const { props } = makeProps();
+    render(<NotebookBrowser {...props} />);
+    await waitForNoteLoaded();
+
+    // The editor is present and editable on open; no Edit/Save/Cancel controls exist.
+    expect(editor()).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+  });
+
+  it('surfaces an autosave conflict and lets the user overwrite the on-disk version', async () => {
     const { props, writeNotebook } = makeProps();
-    // First save conflicts (note changed on disk); the overwrite then succeeds.
+    // First autosave conflicts (note changed on disk); the overwrite then succeeds.
     writeNotebook
       .mockResolvedValueOnce({ path: 'knowledge/index.md', conflict: true, currentHash: 'hX' })
       .mockResolvedValueOnce({ path: 'knowledge/index.md', hash: 'h3', conflict: false });
     render(<NotebookBrowser {...props} />);
+    await waitForNoteLoaded();
 
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' });
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Edit note' }), { target: { value: '# mine\n' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.change(editor(), { target: { value: '# mine\n' } });
 
-    // The conflict is surfaced and the editor stays open with the draft intact.
+    // The conflict is surfaced and the buffer is intact.
     expect(await screen.findByText(/changed on disk/i)).toBeInTheDocument();
-    expect((screen.getByRole('textbox', { name: 'Edit note' }) as HTMLTextAreaElement).value).toBe('# mine\n');
+    expect(editor().value).toBe('# mine\n');
 
-    // Overwrite saves the draft against the current on-disk hash.
+    // Overwrite saves the buffer against the current on-disk hash.
     fireEvent.click(screen.getByRole('button', { name: 'Overwrite anyway' }));
     await waitFor(() => expect(writeNotebook).toHaveBeenLastCalledWith('knowledge/index.md', '# mine\n', 'hX'));
-    await waitFor(() => expect(screen.queryByRole('textbox', { name: 'Edit note' })).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText(/changed on disk/i)).not.toBeInTheDocument());
   });
 
-  it('discards the draft on cancel without saving', async () => {
+  it('flushes an unsaved buffer when navigating away before autosave fires', async () => {
     const { props, writeNotebook } = makeProps();
     render(<NotebookBrowser {...props} />);
+    await waitForNoteLoaded();
 
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' });
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Edit note' }), { target: { value: 'junk' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    // Type, then immediately navigate away (faster than the 700ms autosave debounce).
+    fireEvent.change(editor(), { target: { value: '# quick edit\n' } });
+    fireEvent.click(screen.getByRole('button', { name: /Foo decision/ }));
 
-    expect(await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' })).toBeInTheDocument();
-    expect(writeNotebook).not.toHaveBeenCalled();
+    // The outgoing buffer is flushed against its loaded hash, so the edit isn't lost.
+    await waitFor(() => expect(writeNotebook).toHaveBeenCalledWith('knowledge/index.md', '# quick edit\n', 'h1'));
   });
 
-  it('keeps the draft when a change signal arrives mid-edit (no clobber)', async () => {
+  it('keeps the buffer when a change signal arrives with unsaved edits (no clobber)', async () => {
     const { props, readNotebook, listNotebook } = makeProps();
     const { rerender } = render(<NotebookBrowser {...props} />);
+    await waitForNoteLoaded();
 
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' });
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Edit note' }), { target: { value: '# my draft\n' } });
+    fireEvent.change(editor(), { target: { value: '# my draft\n' } });
 
     const listBefore = listNotebook.mock.calls.length;
     const readsBefore = readNotebook.mock.calls.length;
@@ -310,71 +354,63 @@ describe('NotebookBrowser', () => {
 
     // The change-signal effect runs (tree refreshed)...
     await waitFor(() => expect(listNotebook.mock.calls.length).toBeGreaterThan(listBefore));
-    // ...but the open note is NOT reloaded under the editor, and the draft survives.
-    expect((screen.getByRole('textbox', { name: 'Edit note' }) as HTMLTextAreaElement).value).toBe('# my draft\n');
+    // ...but the open note is NOT reloaded under the buffer, and the edit survives.
+    expect(editor().value).toBe('# my draft\n');
     expect(readNotebook.mock.calls.length).toBe(readsBefore);
   });
 
-  it('does not stamp a mid-save result onto a note the user navigated to', async () => {
+  it('does not stamp a mid-autosave result onto a note the user navigated to', async () => {
     const { props, writeNotebook } = makeProps();
-    // Defer the write so the user can navigate before it resolves.
+    // Defer the first write so the user can navigate before it resolves.
     let resolveWrite: (r: NotebookWriteResult) => void = () => {};
     writeNotebook.mockImplementationOnce(
       () => new Promise<NotebookWriteResult>((resolve) => { resolveWrite = resolve; }),
     );
     render(<NotebookBrowser {...props} />);
+    await waitForNoteLoaded();
 
-    // Edit note A (knowledge/index.md) and click Save; the write is now in flight.
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' });
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Edit note' }), { target: { value: '# A edited\n' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-    await waitFor(() => expect(writeNotebook).toHaveBeenCalledWith('knowledge/index.md', '# A edited\n', 'h1'));
+    // Edit note A (knowledge/index.md); its autosave is now in flight.
+    fireEvent.change(editor(), { target: { value: '# A edited\n' } });
+    await waitFor(
+      () => expect(writeNotebook).toHaveBeenCalledWith('knowledge/index.md', '# A edited\n', 'h1'),
+      { timeout: 2000 },
+    );
 
-    // Navigate to note B (foo.md) before A's save resolves. B loads and renders.
+    // Navigate to note B (foo.md) before A's save resolves. B loads.
     fireEvent.click(screen.getByRole('button', { name: /Foo decision/ }));
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/areas/foo.md' });
+    await screen.findByRole('heading', { level: 2, name: 'Foo decision' });
+    await waitFor(() => expect(editor().value).toContain('# knowledge/areas/foo.md'));
 
-    // A's stale save now resolves. It must NOT overwrite B's pane (no A body under
-    // B, no spurious "Saved" badge) — the save targeted A's bytes correctly, but
-    // its result no longer applies to what's on screen.
+    // A's stale save resolves. It must NOT overwrite B's pane (no A body under B,
+    // no spurious "Saved") — the save targeted A's bytes, but no longer applies.
     await act(async () => {
       resolveWrite({ path: 'knowledge/index.md', hash: 'h2', conflict: false });
     });
 
-    expect(screen.getByRole('heading', { level: 1, name: 'knowledge/areas/foo.md' })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { level: 1, name: 'A edited' })).not.toBeInTheDocument();
+    expect(editor().value).not.toContain('# A edited');
     expect(screen.queryByText('Saved')).not.toBeInTheDocument();
   });
 
-  it('auto-dismisses the Saved badge after a successful save', async () => {
-    // Real timers throughout: the editor-open path (loadNote -> setNote -> the
-    // textarea) does not settle under fake timers, so opening the editor and saving
-    // must run on real timers (the adjacent "stale save" test relies on the same).
-    // The auto-dismiss is a real-time behavior, so we wait it out with a bounded
-    // waitFor rather than advancing a fake clock.
+  it('auto-dismisses the Saved indicator after a successful autosave', async () => {
     const { props } = makeProps();
     render(<NotebookBrowser {...props} />);
+    await waitForNoteLoaded();
 
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' });
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    fireEvent.change(await screen.findByRole('textbox', { name: 'Edit note' }), { target: { value: '# edited\n' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.change(editor(), { target: { value: '# edited\n' } });
 
-    // The badge appears on save success...
+    // The indicator appears on save success...
     expect(await screen.findByText('Saved')).toBeInTheDocument();
     // ...and clears itself rather than lingering while the user keeps reading.
     await waitFor(() => expect(screen.queryByText('Saved')).not.toBeInTheDocument(), { timeout: 4000 });
   }, 10000);
 
-  it('sends a highlighted selection to the chief and shows the outcome', async () => {
+  it('sends an editor selection to the chief and shows the outcome', async () => {
     const { props, sendToChief } = makeProps();
-    const { container } = render(<NotebookBrowser {...props} />);
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' });
+    render(<NotebookBrowser {...props} />);
+    await screen.findByRole('heading', { level: 2, name: 'Knowledge index' });
 
-    // Highlight text in the rendered note; the floating action appears.
-    mockSelection('a key decision');
-    fireEvent.mouseUp(container.querySelector('.notebook-browser-markdown') as HTMLElement);
+    // The editor reports a non-empty selection; the floating action appears.
+    act(() => editorMock.current!.onSelectionChange!({ text: 'a key decision', top: 40, left: 60 }));
     fireEvent.click(await screen.findByRole('button', { name: 'Send to chief' }));
 
     // The selection + its source note go to the daemon, and the outcome is shown.
@@ -384,13 +420,12 @@ describe('NotebookBrowser', () => {
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Send to chief' })).not.toBeInTheDocument());
   });
 
-  it('shows no send-to-chief action for an empty selection', async () => {
+  it('shows no send-to-chief action for a collapsed selection', async () => {
     const { props, sendToChief } = makeProps();
-    const { container } = render(<NotebookBrowser {...props} />);
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' });
+    render(<NotebookBrowser {...props} />);
+    await screen.findByRole('heading', { level: 2, name: 'Knowledge index' });
 
-    mockSelection('   '); // whitespace only
-    fireEvent.mouseUp(container.querySelector('.notebook-browser-markdown') as HTMLElement);
+    act(() => editorMock.current!.onSelectionChange!(null));
 
     expect(screen.queryByRole('button', { name: 'Send to chief' })).not.toBeInTheDocument();
     expect(sendToChief).not.toHaveBeenCalled();
@@ -399,11 +434,10 @@ describe('NotebookBrowser', () => {
   it('surfaces an error when sending to the chief fails', async () => {
     const { props, sendToChief } = makeProps();
     sendToChief.mockRejectedValueOnce(new Error('no chief reachable'));
-    const { container } = render(<NotebookBrowser {...props} />);
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' });
+    render(<NotebookBrowser {...props} />);
+    await screen.findByRole('heading', { level: 2, name: 'Knowledge index' });
 
-    mockSelection('something');
-    fireEvent.mouseUp(container.querySelector('.notebook-browser-markdown') as HTMLElement);
+    act(() => editorMock.current!.onSelectionChange!({ text: 'something', top: 40, left: 60 }));
     fireEvent.click(await screen.findByRole('button', { name: 'Send to chief' }));
 
     expect(await screen.findByText('no chief reachable')).toBeInTheDocument();
@@ -416,18 +450,17 @@ describe('NotebookBrowser', () => {
     sendToChief.mockImplementationOnce(
       () => new Promise<NotebookSendToChiefResult>((resolve) => { resolveSend = resolve; }),
     );
-    const { container } = render(<NotebookBrowser {...props} />);
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/index.md' });
+    render(<NotebookBrowser {...props} />);
+    await screen.findByRole('heading', { level: 2, name: 'Knowledge index' });
 
-    // Highlight + send from note A; the send is now in flight.
-    mockSelection('from A');
-    fireEvent.mouseUp(container.querySelector('.notebook-browser-markdown') as HTMLElement);
+    // Select + send from note A; the send is now in flight.
+    act(() => editorMock.current!.onSelectionChange!({ text: 'from A', top: 40, left: 60 }));
     fireEvent.click(await screen.findByRole('button', { name: 'Send to chief' }));
     await waitFor(() => expect(sendToChief).toHaveBeenCalledWith('from A', 'knowledge/index.md'));
 
-    // Navigate to note B before A's send resolves; B loads and renders.
+    // Navigate to note B before A's send resolves; B loads.
     fireEvent.click(screen.getByRole('button', { name: /Foo decision/ }));
-    await screen.findByRole('heading', { level: 1, name: 'knowledge/areas/foo.md' });
+    await screen.findByRole('heading', { level: 2, name: 'Foo decision' });
 
     // A's stale send resolves — its outcome must NOT flash on note B.
     await act(async () => {

--- a/app/src/components/NotebookBrowser.tsx
+++ b/app/src/components/NotebookBrowser.tsx
@@ -1,9 +1,8 @@
-import { createElement, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import FocusTrap from 'focus-trap-react';
-import ReactMarkdown, { type Components } from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 import type { NotebookEntry, NotebookReadResult, NotebookSendToChiefResult, NotebookTask, NotebookWriteResult } from '../hooks/useDaemonSocket';
 import { useEscapeStack } from '../hooks/useEscapeStack';
+import { LiveMarkdownEditor, type LiveSelection } from './notebook/LiveMarkdownEditor';
 import './NotebookBrowser.css';
 
 interface NotebookBrowserProps {
@@ -36,6 +35,11 @@ interface NotebookBrowserProps {
 // The note shown first when the browser opens with nothing selected, in order of
 // preference. knowledge/index.md is the distilled map an agent is told to read.
 const PREFERRED_FIRST = ['knowledge/index.md', 'index.md'];
+
+// How long the buffer must be idle before an autosave fires. Short enough that
+// edits persist promptly, long enough to coalesce a burst of keystrokes into one
+// write (and one origin=ui broadcast).
+const AUTOSAVE_DELAY_MS = 700;
 
 export function NotebookBrowser({
   isOpen,
@@ -79,6 +83,11 @@ export function NotebookBrowser({
   // a slow response from a superseded navigation is dropped. (A render-synced ref
   // can't do this — it only updates on commit, after the await may have resolved.)
   const loadSeqRef = useRef(0);
+  // Persists the outgoing note's unsaved buffer when navigation/close happens before
+  // the debounced autosave fires. Assigned below (after the editing refs exist) and
+  // invoked here via a ref so loadNote/clearSelection don't depend on declaration
+  // order. A no-op until assigned.
+  const flushSaveRef = useRef<() => void>(() => {});
   // The dialog container is the deliberate initial focus target so keyboard/AT
   // users land inside the modal (engaging the focus trap) without auto-selecting
   // the Close button. Tab from here moves to the first interactive control.
@@ -147,6 +156,9 @@ export function NotebookBrowser({
   }, [retryTask]);
 
   const loadNote = useCallback(async (path: string) => {
+    // Persist any unsaved buffer on the note we're leaving before we replace it
+    // (covers an edit made in the <debounce window of the autosave timer).
+    flushSaveRef.current();
     const seq = ++loadSeqRef.current;
     setSelectedPath(path);
     setNoteLoading(true);
@@ -166,8 +178,12 @@ export function NotebookBrowser({
     if (loadSeqRef.current !== seq) return;
     if (readResult.status === 'fulfilled') {
       setNote(readResult.value);
+      // Seed the live editor buffer from disk; a fresh load is never dirty.
+      setDraft(readResult.value.content);
+      lastFlushedRef.current = null;
     } else {
       setNote(null);
+      setDraft('');
       setNoteError(readResult.reason instanceof Error ? readResult.reason.message : 'Could not read this note');
     }
     setBacklinks(backlinkResult.status === 'fulfilled' ? backlinkResult.value : []);
@@ -178,96 +194,104 @@ export function NotebookBrowser({
   // Bumping loadSeqRef invalidates any in-flight loadNote so a response that
   // resolves after this clear cannot resurrect the just-cleared note's content.
   const clearSelection = useCallback(() => {
+    flushSaveRef.current();
     loadSeqRef.current += 1;
     setSelectedPath(null);
     setNote(null);
+    setDraft('');
     setNoteError(null);
     setNoteLoading(false);
     setBacklinks([]);
   }, []);
 
-  // --- Editing ---
-  const [editing, setEditing] = useState(false);
+  // --- Editing (single live surface; no view/edit toggle) ---
+  // `draft` is the live editor buffer; `note` holds the value last synced from disk
+  // (its content + hash). The note is "dirty" when draft diverges from note.content;
+  // dirty edits autosave (debounced) via hash-CAS against note.hash.
   const [draft, setDraft] = useState('');
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  // Set when the on-disk note changed since the editor loaded it; carries the
-  // current on-disk hash so the user can choose to overwrite it.
+  // Set when an autosave's hash-CAS rejected because the note changed on disk since
+  // it was loaded; carries the current on-disk hash so the user can overwrite it.
   const [conflict, setConflict] = useState<{ currentHash?: string } | null>(null);
   const [justSaved, setJustSaved] = useState(false);
-  // The hash the draft is edited against, captured on entering edit mode and held
-  // independently of live `note` updates so an external change during editing is
-  // detected as a save-time conflict rather than silently overwritten.
-  const editBaseHashRef = useRef('');
-  // Lets the live-refresh effect see "are we editing?" without re-subscribing.
-  const editingRef = useRef(false);
-  editingRef.current = editing;
+  // Refs let the navigation/close flush and the live-refresh guard read the latest
+  // draft / synced note / dirty state without re-subscribing every effect to them.
+  const draftRef = useRef('');
+  draftRef.current = draft;
+  const noteRef = useRef<NotebookReadResult | null>(null);
+  noteRef.current = note;
+  // Dirty = the buffer diverges from the last synced content. Gates autosave and the
+  // live-refresh reload (an unsaved buffer must not be clobbered by a disk reload).
+  const dirty = note ? draft !== note.content : false;
+  const dirtyRef = useRef(false);
+  dirtyRef.current = dirty;
+  // The content last flushed on navigate/close, so a follow-up flush doesn't re-write
+  // identical bytes (e.g. close right after navigating away from the same edit).
+  const lastFlushedRef = useRef<string | null>(null);
 
   // --- Send to chief ---
-  // The current rendered-markdown selection and where to float its action button
-  // (viewport coords from the selection rect). Cleared on navigation/scroll/edit.
-  const [chiefSel, setChiefSel] = useState<{ text: string; top: number; left: number } | null>(null);
+  // The current editor selection and where to float its action button (viewport
+  // coords from the selection start). Cleared on navigation/scroll/collapse.
+  const [chiefSel, setChiefSel] = useState<LiveSelection | null>(null);
   const [sendingToChief, setSendingToChief] = useState(false);
   // A transient outcome line ("Added to chief's inbox" / an error), auto-dismissed.
   const [chiefStatus, setChiefStatus] = useState<{ text: string; error: boolean } | null>(null);
 
-  const startEditing = useCallback(() => {
-    if (!note) return;
-    setDraft(note.content);
-    editBaseHashRef.current = note.hash;
-    setConflict(null);
-    setSaveError(null);
-    setJustSaved(false);
-    // The rendered article (and its selection) is replaced by the textarea, so
-    // drop any floating "Send to chief" button left over from the view.
-    setChiefSel(null);
-    setEditing(true);
-  }, [note]);
+  // Persist the outgoing note's unsaved buffer when navigation/close pre-empts the
+  // debounced autosave. Reassigned every render so it closes over the current refs;
+  // fire-and-forget (the view has already moved on) and best-effort (a flush-time
+  // conflict is dropped rather than surfaced on a note no longer shown).
+  flushSaveRef.current = () => {
+    const path = selectedPathRef.current;
+    const current = noteRef.current;
+    if (!path || !current) return;
+    const content = draftRef.current;
+    if (content === current.content) return;        // in sync — nothing to flush
+    if (content === lastFlushedRef.current) return; // these bytes already flushed
+    lastFlushedRef.current = content;
+    void writeNotebook(path, content, current.hash || undefined).catch(() => {});
+  };
 
-  const cancelEditing = useCallback(() => {
-    setEditing(false);
-    setConflict(null);
-    setSaveError(null);
-  }, []);
-
-  // Save the draft against baseHash (hash-CAS). An empty baseHash is a create-only
-  // write — used to recreate a note that was deleted on disk while being edited.
-  const saveDraft = useCallback(async (baseHash: string) => {
+  // Save `content` against `baseHash` (hash-CAS). An empty baseHash is a create-only
+  // write — used to recreate a note deleted on disk while it was being edited.
+  const saveDraft = useCallback(async (baseHash: string, content: string) => {
     const path = selectedPathRef.current;
     if (!path) return;
     // Freeze the load token so a navigation that happens while this save is in
-    // flight can be detected when it resolves (mirrors loadNote's staleness
-    // guard; loadNote/clearSelection both bump loadSeqRef, saveDraft does not).
+    // flight can be detected when it resolves (mirrors loadNote's staleness guard;
+    // loadNote/clearSelection both bump loadSeqRef, saveDraft does not).
     const seq = loadSeqRef.current;
     setSaving(true);
     setSaveError(null);
     try {
-      const res = await writeNotebook(path, draft, baseHash || undefined);
-      // The write to `path` completed correctly against its own bytes, but if the
-      // user navigated away (or cleared the selection) while it was in flight, the
-      // result now applies to a note that is no longer shown. Bail before stamping
-      // this note's content/conflict/status onto the now-selected note.
+      const res = await writeNotebook(path, content, baseHash || undefined);
+      // The write to `path` completed against its own bytes, but if the user
+      // navigated away (or cleared the selection) while it was in flight, the result
+      // now applies to a note no longer shown. Bail before stamping this note's
+      // content/conflict/status onto the now-selected note.
       if (loadSeqRef.current !== seq || selectedPathRef.current !== path) return;
       if (res.conflict) {
         // The note diverged on disk; let the user reconcile rather than clobber.
         setConflict({ currentHash: res.currentHash });
         return;
       }
-      // Saved: reflect the new content+hash locally and leave edit mode. The
-      // origin=ui broadcast also refreshes the view, so this is just immediacy.
+      // Saved: advance the synced base to the bytes just written. If the user kept
+      // typing during the save, draft is now ahead of `content` → still dirty → the
+      // autosave effect fires again. The origin=ui broadcast also refreshes.
       setConflict(null);
-      setNote({ path, content: draft, hash: res.hash ?? '' });
-      editBaseHashRef.current = res.hash ?? '';
-      setEditing(false);
+      setNote({ path, content, hash: res.hash ?? '' });
+      lastFlushedRef.current = null;
       setJustSaved(true);
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : 'Could not save this note');
     } finally {
       setSaving(false);
     }
-  }, [draft, writeNotebook]);
+  }, [writeNotebook]);
 
-  // Discard the draft and load the current on-disk version into the editor.
+  // Discard the local buffer and reload the current on-disk version (the conflict
+  // reconcile "reload from disk" path).
   const reloadFromDisk = useCallback(async () => {
     const path = selectedPathRef.current;
     if (!path) return;
@@ -275,26 +299,13 @@ export function NotebookBrowser({
     setSaveError(null);
     try {
       const fresh = await readNotebook(path);
-      setDraft(fresh.content);
-      editBaseHashRef.current = fresh.hash;
       setNote(fresh);
+      setDraft(fresh.content);
+      lastFlushedRef.current = null;
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : 'Could not reload this note');
     }
   }, [readNotebook]);
-
-  // Capture the rendered-markdown selection on mouseup so the "Send to chief"
-  // button can float over it. An empty/collapsed selection clears the button.
-  const captureSelection = useCallback(() => {
-    const sel = window.getSelection();
-    const text = sel ? sel.toString().trim() : '';
-    if (!text || !sel || sel.rangeCount === 0) {
-      setChiefSel(null);
-      return;
-    }
-    const rect = sel.getRangeAt(0).getBoundingClientRect();
-    setChiefSel({ text, top: rect.top, left: rect.left + rect.width / 2 });
-  }, []);
 
   // Hand the captured selection to the daemon for the chief of staff. The daemon
   // appends it to the chief inbox note and best-effort nudges a live chief; the
@@ -360,10 +371,10 @@ export function NotebookBrowser({
       // A failed refresh (null) is NOT an empty notebook: leave the open note
       // alone rather than mistaking a transient WS hiccup for a deletion.
       if (cancelled || next === null) return;
-      // While the user is editing, refresh the tree but never reload or clear the
-      // open note — that would clobber the draft or yank the editor away. On-disk
-      // divergence is surfaced as a save-time conflict instead.
-      if (editingRef.current) return;
+      // With unsaved edits, refresh the tree but never reload or clear the open
+      // note — that would clobber the buffer. On-disk divergence surfaces as a
+      // save-time conflict instead. (A clean buffer reloads to pick up the change.)
+      if (dirtyRef.current) return;
       const current = selectedPathRef.current;
       if (current && next.some((e) => e.path === current)) {
         void loadNote(current);
@@ -394,17 +405,38 @@ export function NotebookBrowser({
     setTasksLoading(false);
   }, [isOpen]);
 
-  // Navigating to another note discards any in-progress edit and clears its
-  // status. Keyed on selectedPath, so it fires on navigation but not on a
-  // same-note live reload (which keeps selectedPath unchanged).
+  // Navigating to another note clears the previous note's edit status. Keyed on
+  // selectedPath, so it fires on navigation but not on a same-note live reload
+  // (which keeps selectedPath unchanged).
   useEffect(() => {
-    setEditing(false);
     setConflict(null);
     setSaveError(null);
     setJustSaved(false);
     setChiefSel(null);
     setChiefStatus(null);
   }, [selectedPath]);
+
+  // Debounced autosave: once the buffer diverges from the synced note, persist it
+  // via hash-CAS against note.hash after a short idle. Gated off while a note is
+  // loading (the buffer is being re-seeded), while a save is already in flight, and
+  // while a conflict is unresolved (the user must reconcile first). Every dep change
+  // clears the pending timer, so navigation can't leave a stale write scheduled.
+  useEffect(() => {
+    if (!note || noteLoading || saving || conflict) return;
+    if (draft === note.content) return; // in sync — nothing to save
+    const timer = window.setTimeout(() => {
+      void saveDraft(note.hash, draft);
+    }, AUTOSAVE_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [draft, note, noteLoading, saving, conflict, saveDraft]);
+
+  // Flush an unsaved buffer when the browser closes (or unmounts) so edits made in
+  // the last <debounce window aren't lost. flushSaveRef is a no-op when not dirty.
+  useEffect(() => {
+    if (isOpen) return;
+    flushSaveRef.current();
+  }, [isOpen]);
+  useEffect(() => () => flushSaveRef.current(), []);
 
   // The "Send to chief" outcome line is a transient confirmation; auto-dismiss it
   // (errors linger a little longer than the success acknowledgement).
@@ -441,14 +473,37 @@ export function NotebookBrowser({
   }, [justSaved]);
 
   const grouped = useMemo(() => groupEntries(entries), [entries]);
-  const markdownComponents = useMemo(
-    () => notebookMarkdownComponents((path) => void loadNote(path)),
-    [loadNote],
-  );
+
+  // Mod-click on a rendered link: in-notebook .md targets navigate; external
+  // targets open in the browser; fragments are ignored (no in-editor anchor jump).
+  const handleFollowLink = useCallback((href: string) => {
+    const target = parseNotebookHref(href);
+    if (target.kind === 'note' && target.path) {
+      void loadNote(target.path);
+    } else if (target.kind === 'external' && target.href) {
+      window.open(target.href, '_blank', 'noreferrer');
+    }
+  }, [loadNote]);
+
+  // The editor reports its current selection (or null when collapsed); float the
+  // "Send to chief" action over it.
+  const handleSelectionChange = useCallback((selection: LiveSelection | null) => {
+    setChiefSel(selection);
+  }, []);
 
   if (!isOpen) return null;
 
   const selectedEntry = entries.find((e) => e.path === selectedPath) || null;
+  // A single live save indicator (the error itself is surfaced by its own banner).
+  const saveStatus = saveError
+    ? null
+    : saving
+      ? 'Saving…'
+      : dirty
+        ? 'Unsaved…'
+        : justSaved
+          ? 'Saved'
+          : null;
 
   return (
     <div className="notebook-browser-shell">
@@ -600,7 +655,7 @@ export function NotebookBrowser({
                       <p>{note.path}</p>
                     </div>
                     <div className="notebook-browser-document-actions">
-                      {!editing && chiefStatus && (
+                      {chiefStatus && (
                         <span
                           className={`notebook-browser-chief-status${chiefStatus.error ? ' is-error' : ''}`}
                           role="status"
@@ -608,85 +663,58 @@ export function NotebookBrowser({
                           {chiefStatus.text}
                         </span>
                       )}
-                      {!editing && justSaved && (
-                        <span className="notebook-browser-saved" role="status">Saved</span>
-                      )}
-                      {!editing && (
-                        <button type="button" className="notebook-browser-edit-btn" onClick={startEditing}>
-                          Edit
-                        </button>
+                      {saveStatus && (
+                        <span className="notebook-browser-save-status" role="status">{saveStatus}</span>
                       )}
                     </div>
                   </div>
-                  {editing ? (
-                    <div className="notebook-browser-editor">
-                      <textarea
-                        className="notebook-browser-editor-area"
-                        aria-label="Edit note"
-                        value={draft}
-                        onChange={(event) => setDraft(event.target.value)}
-                        spellCheck={false}
-                        autoFocus
-                      />
-                      {conflict && (
-                        <div className="notebook-browser-editor-conflict" role="alert">
-                          <span>
-                            {conflict.currentHash
-                              ? 'This note changed on disk since you opened it.'
-                              : 'This note was deleted on disk since you opened it.'}
-                          </span>
-                          <div className="notebook-browser-editor-conflict-actions">
-                            <button type="button" onClick={() => void reloadFromDisk()} disabled={saving}>
-                              Reload from disk
-                            </button>
-                            <button type="button" onClick={() => void saveDraft(conflict.currentHash ?? '')} disabled={saving}>
-                              Overwrite anyway
-                            </button>
-                          </div>
+                  <div className="notebook-browser-live">
+                    {conflict && (
+                      <div className="notebook-browser-editor-conflict" role="alert">
+                        <span>
+                          {conflict.currentHash
+                            ? 'This note changed on disk since you opened it.'
+                            : 'This note was deleted on disk since you opened it.'}
+                        </span>
+                        <div className="notebook-browser-editor-conflict-actions">
+                          <button type="button" onClick={() => void reloadFromDisk()} disabled={saving}>
+                            Reload from disk
+                          </button>
+                          <button type="button" onClick={() => void saveDraft(conflict.currentHash ?? '', draft)} disabled={saving}>
+                            Overwrite anyway
+                          </button>
                         </div>
-                      )}
-                      {saveError && (
-                        <p className="notebook-browser-editor-error" role="alert">{saveError}</p>
-                      )}
-                      <div className="notebook-browser-editor-actions">
-                        <button
-                          type="button"
-                          className="notebook-browser-editor-save"
-                          onClick={() => void saveDraft(editBaseHashRef.current)}
-                          disabled={saving}
-                        >
-                          {saving ? 'Saving…' : 'Save'}
-                        </button>
-                        <button type="button" onClick={cancelEditing} disabled={saving}>
-                          Cancel
-                        </button>
                       </div>
+                    )}
+                    {saveError && (
+                      <p className="notebook-browser-editor-error" role="alert">{saveError}</p>
+                    )}
+                    <div className="notebook-browser-live-editor">
+                      <LiveMarkdownEditor
+                        value={draft}
+                        onChange={setDraft}
+                        onFollowLink={handleFollowLink}
+                        onSelectionChange={handleSelectionChange}
+                        ariaLabel="Note"
+                      />
                     </div>
-                  ) : (
-                    <>
-                      <article className="notebook-browser-markdown" onMouseUp={captureSelection}>
-                        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
-                          {note.content || '_This note is empty._'}
-                        </ReactMarkdown>
-                      </article>
-                      <section className="notebook-browser-backlinks" aria-label="Backlinks">
-                        <h3>Linked from {backlinks.length > 0 ? `(${backlinks.length})` : ''}</h3>
-                        {backlinks.length === 0 ? (
-                          <p className="notebook-browser-backlinks-empty">No other note links here.</p>
-                        ) : (
-                          <ul>
-                            {backlinks.map((entry) => (
-                              <li key={entry.path}>
-                                <button type="button" onClick={() => void loadNote(entry.path)} title={entry.path}>
-                                  {entry.title || basename(entry.path)}
-                                </button>
-                              </li>
-                            ))}
-                          </ul>
-                        )}
-                      </section>
-                    </>
-                  )}
+                  </div>
+                  <section className="notebook-browser-backlinks" aria-label="Backlinks">
+                    <h3>Linked from {backlinks.length > 0 ? `(${backlinks.length})` : ''}</h3>
+                    {backlinks.length === 0 ? (
+                      <p className="notebook-browser-backlinks-empty">No other note links here.</p>
+                    ) : (
+                      <ul>
+                        {backlinks.map((entry) => (
+                          <li key={entry.path}>
+                            <button type="button" onClick={() => void loadNote(entry.path)} title={entry.path}>
+                              {entry.title || basename(entry.path)}
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </section>
                 </>
               )}
               {!noteLoading && !noteError && !note && (
@@ -789,69 +817,6 @@ export function parseNotebookHref(href: string): NotebookHref {
     }
   }
   return { kind: 'external', href: trimmed };
-}
-
-// notebookMarkdownComponents renders headings with slug ids (so #anchors resolve)
-// and routes link clicks: in-notebook links navigate via onNavigate, external
-// links open in a new tab, fragments scroll.
-function notebookMarkdownComponents(onNavigate: (path: string) => void): Components {
-  const slugCounts = new Map<string, number>();
-  const heading = (level: number) => ({ children }: { children?: ReactNode }) => {
-    const base = slug(textOf(children));
-    const count = slugCounts.get(base) ?? 0;
-    slugCounts.set(base, count + 1);
-    const id = count === 0 ? base : `${base}-${count}`;
-    return createElement(`h${level}`, { id }, children);
-  };
-  return {
-    h1: heading(1),
-    h2: heading(2),
-    h3: heading(3),
-    h4: heading(4),
-    h5: heading(5),
-    h6: heading(6),
-    a({ href, children }) {
-      if (!href) return <span>{children}</span>;
-      const target = parseNotebookHref(href);
-      if (target.kind === 'note' && target.path) {
-        const path = target.path;
-        return (
-          <a
-            href={href}
-            className="notebook-link"
-            title={`/${path}`}
-            onClick={(event) => {
-              event.preventDefault();
-              onNavigate(path);
-            }}
-          >
-            {children}
-          </a>
-        );
-      }
-      if (target.kind === 'fragment') {
-        return <a href={href}>{children}</a>;
-      }
-      return (
-        <a href={href} target="_blank" rel="noreferrer">{children}</a>
-      );
-    },
-  };
-}
-
-function textOf(node: ReactNode): string {
-  if (node == null || typeof node === 'boolean') return '';
-  if (typeof node === 'string' || typeof node === 'number') return String(node);
-  if (Array.isArray(node)) return node.map(textOf).join('');
-  if (typeof node === 'object' && 'props' in node) {
-    const props = (node as { props?: { children?: ReactNode } }).props;
-    return textOf(props?.children);
-  }
-  return '';
-}
-
-function slug(text: string): string {
-  return text.toLowerCase().trim().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-');
 }
 
 function basename(path: string): string {

--- a/app/src/components/NotebookBrowser.tsx
+++ b/app/src/components/NotebookBrowser.tsx
@@ -41,6 +41,11 @@ const PREFERRED_FIRST = ['knowledge/index.md', 'index.md'];
 // write (and one origin=ui broadcast).
 const AUTOSAVE_DELAY_MS = 700;
 
+// Outcome of persisting the buffer. On-demand callers (navigate/close) MUST react
+// to 'conflict'/'error' — a CAS conflict cannot be silently dropped, or the user's
+// edits vanish behind a navigation/close without the banner ever showing.
+type PersistOutcome = 'saved' | 'conflict' | 'error' | 'noop';
+
 export function NotebookBrowser({
   isOpen,
   onClose,
@@ -83,17 +88,30 @@ export function NotebookBrowser({
   // a slow response from a superseded navigation is dropped. (A render-synced ref
   // can't do this — it only updates on commit, after the await may have resolved.)
   const loadSeqRef = useRef(0);
-  // Persists the outgoing note's unsaved buffer when navigation/close happens before
-  // the debounced autosave fires. Assigned below (after the editing refs exist) and
-  // invoked here via a ref so loadNote/clearSelection don't depend on declaration
-  // order. A no-op until assigned.
-  const flushSaveRef = useRef<() => void>(() => {});
+  // Persists the outgoing note's unsaved buffer before a navigation/close replaces or
+  // hides it — surfacing a CAS conflict rather than dropping it. Assigned below (after
+  // the editing state/refs exist) and invoked via a ref so loadNote — declared above
+  // the editing block — doesn't depend on declaration order. A no-op until assigned.
+  const persistRef = useRef<() => Promise<PersistOutcome>>(async () => 'noop');
   // The dialog container is the deliberate initial focus target so keyboard/AT
   // users land inside the modal (engaging the focus trap) without auto-selecting
   // the Close button. Tab from here moves to the first interactive control.
   const dialogRef = useRef<HTMLDivElement>(null);
 
-  useEscapeStack(onClose, isOpen);
+  // Closing with unsaved edits persists them first; if that write conflicts (or
+  // errors) we keep the modal open so the conflict banner can be reconciled, rather
+  // than losing the buffer behind the close. dirtyRef short-circuits the clean case
+  // to an immediate close (no write, no await).
+  const requestClose = useCallback(async () => {
+    if (dirtyRef.current) {
+      const outcome = await persistRef.current();
+      if (outcome === 'conflict' || outcome === 'error') return;
+    }
+    onClose();
+  }, [onClose]);
+  const handleEscape = useCallback(() => void requestClose(), [requestClose]);
+
+  useEscapeStack(handleEscape, isOpen);
 
   // Returns the fetched entries, or null if the fetch FAILED (distinct from an
   // empty notebook). Callers must not treat a failed refresh as "the notebook is
@@ -157,8 +175,14 @@ export function NotebookBrowser({
 
   const loadNote = useCallback(async (path: string) => {
     // Persist any unsaved buffer on the note we're leaving before we replace it
-    // (covers an edit made in the <debounce window of the autosave timer).
-    flushSaveRef.current();
+    // (covers an edit made in the <debounce window of the autosave timer). If that
+    // write conflicts (the note changed on disk) we ABORT the navigation and stay
+    // put so the conflict banner can be reconciled — navigating away would discard
+    // the buffer and the user's edits would vanish silently.
+    if (dirtyRef.current && selectedPathRef.current && selectedPathRef.current !== path) {
+      const outcome = await persistRef.current();
+      if (outcome === 'conflict' || outcome === 'error') return;
+    }
     const seq = ++loadSeqRef.current;
     setSelectedPath(path);
     setNoteLoading(true);
@@ -180,7 +204,6 @@ export function NotebookBrowser({
       setNote(readResult.value);
       // Seed the live editor buffer from disk; a fresh load is never dirty.
       setDraft(readResult.value.content);
-      lastFlushedRef.current = null;
     } else {
       setNote(null);
       setDraft('');
@@ -194,7 +217,6 @@ export function NotebookBrowser({
   // Bumping loadSeqRef invalidates any in-flight loadNote so a response that
   // resolves after this clear cannot resurrect the just-cleared note's content.
   const clearSelection = useCallback(() => {
-    flushSaveRef.current();
     loadSeqRef.current += 1;
     setSelectedPath(null);
     setNote(null);
@@ -215,7 +237,7 @@ export function NotebookBrowser({
   // it was loaded; carries the current on-disk hash so the user can overwrite it.
   const [conflict, setConflict] = useState<{ currentHash?: string } | null>(null);
   const [justSaved, setJustSaved] = useState(false);
-  // Refs let the navigation/close flush and the live-refresh guard read the latest
+  // Refs let the navigation/close persist and the live-refresh guard read the latest
   // draft / synced note / dirty state without re-subscribing every effect to them.
   const draftRef = useRef('');
   draftRef.current = draft;
@@ -226,9 +248,6 @@ export function NotebookBrowser({
   const dirty = note ? draft !== note.content : false;
   const dirtyRef = useRef(false);
   dirtyRef.current = dirty;
-  // The content last flushed on navigate/close, so a follow-up flush doesn't re-write
-  // identical bytes (e.g. close right after navigating away from the same edit).
-  const lastFlushedRef = useRef<string | null>(null);
 
   // --- Send to chief ---
   // The current editor selection and where to float its action button (viewport
@@ -238,71 +257,82 @@ export function NotebookBrowser({
   // A transient outcome line ("Added to chief's inbox" / an error), auto-dismissed.
   const [chiefStatus, setChiefStatus] = useState<{ text: string; error: boolean } | null>(null);
 
-  // Persist the outgoing note's unsaved buffer when navigation/close pre-empts the
-  // debounced autosave. Reassigned every render so it closes over the current refs;
-  // fire-and-forget (the view has already moved on) and best-effort (a flush-time
-  // conflict is dropped rather than surfaced on a note no longer shown).
-  flushSaveRef.current = () => {
+  // Core write: persist `content` against `baseHash` (hash-CAS) and reconcile the
+  // result. Returns the outcome so on-demand callers (navigate/close) can react —
+  // a 'conflict'/'error' must NOT be silently dropped. An empty baseHash is a
+  // create-only write, used to recreate a note deleted on disk while it was edited.
+  const writeBuffer = useCallback(async (baseHash: string, content: string): Promise<PersistOutcome> => {
     const path = selectedPathRef.current;
-    const current = noteRef.current;
-    if (!path || !current) return;
-    const content = draftRef.current;
-    if (content === current.content) return;        // in sync — nothing to flush
-    if (content === lastFlushedRef.current) return; // these bytes already flushed
-    lastFlushedRef.current = content;
-    void writeNotebook(path, content, current.hash || undefined).catch(() => {});
-  };
-
-  // Save `content` against `baseHash` (hash-CAS). An empty baseHash is a create-only
-  // write — used to recreate a note deleted on disk while it was being edited.
-  const saveDraft = useCallback(async (baseHash: string, content: string) => {
-    const path = selectedPathRef.current;
-    if (!path) return;
-    // Freeze the load token so a navigation that happens while this save is in
-    // flight can be detected when it resolves (mirrors loadNote's staleness guard;
-    // loadNote/clearSelection both bump loadSeqRef, saveDraft does not).
+    if (!path) return 'noop';
+    // Freeze the load token so a navigation that lands while this write is in flight
+    // is detected on resolve (mirrors loadNote's staleness guard; loadNote/
+    // clearSelection bump loadSeqRef, writeBuffer does not). The bytes still reach
+    // disk either way — we just don't stamp this note's result onto whatever note is
+    // now shown. The OUTCOME still returns so the caller can react.
     const seq = loadSeqRef.current;
     setSaving(true);
     setSaveError(null);
     try {
       const res = await writeNotebook(path, content, baseHash || undefined);
-      // The write to `path` completed against its own bytes, but if the user
-      // navigated away (or cleared the selection) while it was in flight, the result
-      // now applies to a note no longer shown. Bail before stamping this note's
-      // content/conflict/status onto the now-selected note.
-      if (loadSeqRef.current !== seq || selectedPathRef.current !== path) return;
+      const superseded = loadSeqRef.current !== seq || selectedPathRef.current !== path;
       if (res.conflict) {
         // The note diverged on disk; let the user reconcile rather than clobber.
-        setConflict({ currentHash: res.currentHash });
-        return;
+        // (Only surface it if this note is still shown — see `superseded`.)
+        if (!superseded) setConflict({ currentHash: res.currentHash });
+        return 'conflict';
       }
-      // Saved: advance the synced base to the bytes just written. If the user kept
-      // typing during the save, draft is now ahead of `content` → still dirty → the
-      // autosave effect fires again. The origin=ui broadcast also refreshes.
-      setConflict(null);
-      setNote({ path, content, hash: res.hash ?? '' });
-      lastFlushedRef.current = null;
-      setJustSaved(true);
+      if (!superseded) {
+        // Saved: advance the synced base to the bytes just written. If the user kept
+        // typing during the save, draft is now ahead of `content` → still dirty → the
+        // autosave effect fires again. The origin=ui broadcast also refreshes.
+        setConflict(null);
+        setNote({ path, content, hash: res.hash ?? '' });
+        setJustSaved(true);
+      }
+      return 'saved';
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : 'Could not save this note');
+      if (loadSeqRef.current === seq && selectedPathRef.current === path) {
+        setSaveError(err instanceof Error ? err.message : 'Could not save this note');
+      }
+      return 'error';
     } finally {
       setSaving(false);
     }
   }, [writeNotebook]);
+
+  // Persist the current dirty buffer against its synced base. Drives the debounced
+  // autosave and — crucially — the navigate/close flush, so an outgoing edit that
+  // conflicts surfaces the banner (and blocks the navigation/close) instead of being
+  // dropped. A no-op when the buffer is in sync. Reads refs, so it stays stable.
+  const persist = useCallback(async (): Promise<PersistOutcome> => {
+    const current = noteRef.current;
+    if (!current) return 'noop';
+    const content = draftRef.current;
+    if (content === current.content) return 'noop'; // in sync — nothing to persist
+    return writeBuffer(current.hash, content);
+  }, [writeBuffer]);
+  // Indirection so loadNote/requestClose (declared above the editing block) can invoke
+  // the latest persist without a forward declaration.
+  persistRef.current = persist;
 
   // Discard the local buffer and reload the current on-disk version (the conflict
   // reconcile "reload from disk" path).
   const reloadFromDisk = useCallback(async () => {
     const path = selectedPathRef.current;
     if (!path) return;
+    // Freeze the load token so a navigation that lands while this read is in flight
+    // is detected on resolve (mirrors loadNote/writeBuffer). Without it, a slow reload
+    // of note A could stamp A's content/hash onto note B after the user moved on.
+    const seq = loadSeqRef.current;
     setConflict(null);
     setSaveError(null);
     try {
       const fresh = await readNotebook(path);
+      if (loadSeqRef.current !== seq || selectedPathRef.current !== path) return;
       setNote(fresh);
       setDraft(fresh.content);
-      lastFlushedRef.current = null;
     } catch (err) {
+      if (loadSeqRef.current !== seq || selectedPathRef.current !== path) return;
       setSaveError(err instanceof Error ? err.message : 'Could not reload this note');
     }
   }, [readNotebook]);
@@ -313,7 +343,7 @@ export function NotebookBrowser({
   const sendSelectionToChief = useCallback(async () => {
     if (!chiefSel) return;
     const path = selectedPathRef.current ?? undefined;
-    // Freeze the load token (as saveDraft does) so an outcome that resolves after
+    // Freeze the load token (as writeBuffer does) so an outcome that resolves after
     // the user navigated away doesn't flash on the now-selected note.
     const seq = loadSeqRef.current;
     setSendingToChief(true);
@@ -425,18 +455,10 @@ export function NotebookBrowser({
     if (!note || noteLoading || saving || conflict) return;
     if (draft === note.content) return; // in sync — nothing to save
     const timer = window.setTimeout(() => {
-      void saveDraft(note.hash, draft);
+      void persist();
     }, AUTOSAVE_DELAY_MS);
     return () => window.clearTimeout(timer);
-  }, [draft, note, noteLoading, saving, conflict, saveDraft]);
-
-  // Flush an unsaved buffer when the browser closes (or unmounts) so edits made in
-  // the last <debounce window aren't lost. flushSaveRef is a no-op when not dirty.
-  useEffect(() => {
-    if (isOpen) return;
-    flushSaveRef.current();
-  }, [isOpen]);
-  useEffect(() => () => flushSaveRef.current(), []);
+  }, [draft, note, noteLoading, saving, conflict, persist]);
 
   // The "Send to chief" outcome line is a transient confirmation; auto-dismiss it
   // (errors linger a little longer than the success acknowledgement).
@@ -517,7 +539,7 @@ export function NotebookBrowser({
                 <h1 id="notebook-browser-title">Notebook</h1>
               </div>
             </div>
-            <button type="button" className="notebook-browser-close" onClick={onClose}>
+            <button type="button" className="notebook-browser-close" onClick={() => void requestClose()}>
               <span>Close</span><kbd>esc</kbd>
             </button>
           </header>
@@ -680,7 +702,7 @@ export function NotebookBrowser({
                           <button type="button" onClick={() => void reloadFromDisk()} disabled={saving}>
                             Reload from disk
                           </button>
-                          <button type="button" onClick={() => void saveDraft(conflict.currentHash ?? '', draft)} disabled={saving}>
+                          <button type="button" onClick={() => void writeBuffer(conflict.currentHash ?? '', draft)} disabled={saving}>
                             Overwrite anyway
                           </button>
                         </div>

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -102,6 +102,10 @@ export function LiveMarkdownEditor({
       autoFocus={autoFocus}
       height="100%"
       aria-label={ariaLabel}
+      // Skip @uiw/react-codemirror's built-in theme (default "light" paints a white
+      // background). Our editorTheme keeps the surface transparent so it inherits the
+      // app's dark document pane and tracks light/dark via CSS variables.
+      theme="none"
       basicSetup={{
         lineNumbers: false,
         foldGutter: false,

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -1,0 +1,123 @@
+// A single read-and-type markdown surface: CodeMirror 6 with the live-preview
+// decorations from liveMarkdownPreview. There is no view/edit toggle — the document
+// always renders inline and is always editable, with raw markdown revealed on the
+// cursor's line. The parent owns persistence (hash-CAS autosave); this component only
+// emits value changes, link follows, and the current selection (for "send to chief").
+
+import { useMemo } from 'react';
+import CodeMirror from '@uiw/react-codemirror';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { EditorView, type ViewUpdate } from '@codemirror/view';
+import { liveMarkdownPreview } from './liveMarkdownPreview';
+
+export interface LiveSelection {
+  text: string;
+  // Viewport coordinates of the selection start, for floating UI.
+  top: number;
+  left: number;
+}
+
+interface LiveMarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  onFollowLink?: (href: string) => void;
+  onSelectionChange?: (selection: LiveSelection | null) => void;
+  ariaLabel?: string;
+  autoFocus?: boolean;
+}
+
+// Match the surrounding document pane: transparent background, inherit the app's
+// theme colors via CSS variables so it tracks light/dark without a CM theme swap.
+const editorTheme = EditorView.theme({
+  '&': {
+    height: '100%',
+    backgroundColor: 'transparent',
+    color: 'var(--color-text-secondary, inherit)',
+    fontSize: '14px',
+  },
+  '.cm-content': {
+    fontFamily:
+      "ui-serif, Georgia, 'Times New Roman', var(--font-sans, system-ui), serif",
+    lineHeight: '1.65',
+    padding: '4px 0 80px',
+    caretColor: 'var(--color-accent, #7c9cff)',
+  },
+  '.cm-scroller': { overflow: 'auto' },
+  '&.cm-focused': { outline: 'none' },
+  '.cm-line': { padding: '0 2px' },
+  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground': {
+    backgroundColor: 'var(--color-accent-soft, rgba(124,156,255,0.22))',
+  },
+});
+
+export function LiveMarkdownEditor({
+  value,
+  onChange,
+  onFollowLink,
+  onSelectionChange,
+  ariaLabel,
+  autoFocus,
+}: LiveMarkdownEditorProps) {
+  const extensions = useMemo(
+    () => [
+      markdown({ base: markdownLanguage }),
+      EditorView.lineWrapping,
+      liveMarkdownPreview({ onFollowLink }),
+      editorTheme,
+    ],
+    [onFollowLink],
+  );
+
+  const handleUpdate = useMemo(
+    () =>
+      (update: ViewUpdate) => {
+        if (!onSelectionChange) return;
+        if (!update.selectionSet && !update.docChanged && !update.focusChanged) return;
+        const range = update.state.selection.main;
+        if (range.empty) {
+          onSelectionChange(null);
+          return;
+        }
+        const text = update.state.sliceDoc(range.from, range.to).trim();
+        if (!text) {
+          onSelectionChange(null);
+          return;
+        }
+        const coords = update.view.coordsAtPos(range.from);
+        if (!coords) {
+          onSelectionChange(null);
+          return;
+        }
+        onSelectionChange({ text, top: coords.top, left: (coords.left + coords.right) / 2 });
+      },
+    [onSelectionChange],
+  );
+
+  return (
+    <CodeMirror
+      value={value}
+      onChange={onChange}
+      onUpdate={handleUpdate}
+      extensions={extensions}
+      autoFocus={autoFocus}
+      height="100%"
+      aria-label={ariaLabel}
+      basicSetup={{
+        lineNumbers: false,
+        foldGutter: false,
+        highlightActiveLine: false,
+        highlightActiveLineGutter: false,
+        highlightSelectionMatches: false,
+        bracketMatching: false,
+        closeBrackets: false,
+        autocompletion: false,
+        searchKeymap: false,
+        lintKeymap: false,
+        // The default highlight style underlines headings and colors prose, fighting
+        // the live-preview decorations that own how rendered markdown looks. Disable
+        // it so this component's theme/decorations are the single source of styling.
+        syntaxHighlighting: false,
+      }}
+    />
+  );
+}

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -26,13 +26,19 @@ interface LiveMarkdownEditorProps {
   autoFocus?: boolean;
 }
 
-// Match the surrounding document pane: transparent background, inherit the app's
-// theme colors via CSS variables so it tracks light/dark without a CM theme swap.
+// Themed entirely through the app's CSS variables so it tracks the app's light/dark
+// mode automatically — no CodeMirror dark/light flag to keep in sync. The catch:
+// CodeMirror's *base* theme styles the cursor/selection/caret from `&light`/`&dark`
+// rules that only activate when a theme sets the `darkTheme` facet (which we don't,
+// on purpose — the CSS variables already track the mode). So a complete app theme
+// must OWN every surface CM would otherwise pick a light-biased default for:
+// background, foreground, the cursor, and the selection. Get this wrong and you get
+// a black caret / lavender selection on a dark pane.
 const editorTheme = EditorView.theme({
   '&': {
     height: '100%',
     backgroundColor: 'transparent',
-    color: 'var(--color-text-secondary, inherit)',
+    color: 'var(--color-text-primary, inherit)',
     fontSize: '14px',
   },
   '.cm-content': {
@@ -40,13 +46,24 @@ const editorTheme = EditorView.theme({
       "ui-serif, Georgia, 'Times New Roman', var(--font-sans, system-ui), serif",
     lineHeight: '1.65',
     padding: '4px 0 80px',
-    caretColor: 'var(--color-accent, #7c9cff)',
   },
   '.cm-scroller': { overflow: 'auto' },
   '&.cm-focused': { outline: 'none' },
   '.cm-line': { padding: '0 2px' },
-  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground': {
-    backgroundColor: 'var(--color-accent-soft, rgba(124,156,255,0.22))',
+  // basicSetup's drawSelection hides the native caret (`caret-color: transparent`)
+  // and renders its OWN `.cm-cursor` element, so the caret color is that element's
+  // left border — NOT `.cm-content { caretColor }`. This selector is deep enough to
+  // outrank CM's base `&light/&dark .cm-cursor` rule (theme beats baseTheme on a
+  // specificity tie), so the app's text color wins in both themes.
+  '.cm-cursorLayer .cm-cursor, .cm-dropCursor': {
+    borderLeftColor: 'var(--color-text-primary, #e8e8e8)',
+    borderLeftWidth: '2px',
+  },
+  // CM's base focused-selection rule is highly specific (`&dark.cm-focused > … >
+  // .cm-selectionLayer .cm-selectionBackground`), more than a theme can match, so
+  // !important is the clean way to assert the app accent over it in both themes.
+  '.cm-selectionLayer .cm-selectionBackground': {
+    backgroundColor: 'color-mix(in srgb, var(--accent, #ff6b35) 30%, transparent) !important',
   },
 });
 

--- a/app/src/components/notebook/liveMarkdownPreview.test.ts
+++ b/app/src/components/notebook/liveMarkdownPreview.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { buildDecorations } from './liveMarkdownPreview';
+
+// buildDecorations works off an EditorState (no view), so the live-preview logic is
+// testable headlessly — CodeMirror's view can't mount under happy-dom, but a state
+// needs no DOM. Each test builds a state with the cursor placed deliberately, since
+// the cursor's line reveals its raw markers (the Obsidian active-line behavior).
+interface Deco {
+  from: number;
+  to: number;
+  class?: string;
+  attributes?: Record<string, string>;
+}
+
+function decosFor(doc: string, cursor: number, focused = true): Deco[] {
+  const state = EditorState.create({
+    doc,
+    selection: { anchor: cursor },
+    extensions: [markdown({ base: markdownLanguage })],
+  });
+  const out: Deco[] = [];
+  const iter = buildDecorations(state, focused).iter();
+  while (iter.value) {
+    const spec = iter.value.spec as { class?: string; attributes?: Record<string, string> };
+    out.push({ from: iter.from, to: iter.to, class: spec.class, attributes: spec.attributes });
+    iter.next();
+  }
+  return out;
+}
+
+// A hide decoration is a replace with no class (Decoration.replace({})).
+const isHide = (d: Deco) => d.class === undefined;
+const hasClass = (decos: Deco[], cls: string) => decos.some((d) => d.class === cls);
+const hideAt = (decos: Deco[], from: number, to: number) =>
+  decos.some((d) => isHide(d) && d.from === from && d.to === to);
+
+describe('liveMarkdownPreview decorations', () => {
+  it('sizes a heading and hides its leading "# " off the active line', () => {
+    const doc = '# Title\n\nbody';
+    const decos = decosFor(doc, doc.length); // cursor on the "body" line
+
+    // The whole heading line (0..7) is sized.
+    expect(decos.some((d) => d.class === 'cm-md-h1' && d.from === 0 && d.to === 7)).toBe(true);
+    // The "# " marker (including the trailing space) is hidden.
+    expect(hideAt(decos, 0, 2)).toBe(true);
+  });
+
+  it('reveals the heading marker when the cursor is on the heading line', () => {
+    const doc = '# Title\n\nbody';
+    const decos = decosFor(doc, 1); // cursor inside the heading line
+
+    // Sizing persists on the active line...
+    expect(hasClass(decos, 'cm-md-h1')).toBe(true);
+    // ...but the raw "# " marker is shown (not hidden) so it can be edited.
+    expect(hideAt(decos, 0, 2)).toBe(false);
+  });
+
+  it('hides all markers when the editor is unfocused, even on the cursor line', () => {
+    const doc = '# Title\n\nbody';
+    // Cursor on the heading line, but unfocused → renders fully clean (a freshly
+    // opened note reads like rendered markdown until the user clicks in).
+    const decos = decosFor(doc, 1, false);
+
+    expect(hasClass(decos, 'cm-md-h1')).toBe(true); // still sized
+    expect(hideAt(decos, 0, 2)).toBe(true); // "# " hidden despite the cursor
+  });
+
+  it('styles bold / italic / code / strikethrough and hides their markers off the active line', () => {
+    const doc = 'x **b** *i* `c` ~~s~~\nsecond';
+    const decos = decosFor(doc, doc.length); // cursor on the second line
+
+    expect(hasClass(decos, 'cm-md-strong')).toBe(true);
+    expect(hasClass(decos, 'cm-md-em')).toBe(true);
+    expect(hasClass(decos, 'cm-md-code')).toBe(true);
+    expect(hasClass(decos, 'cm-md-strike')).toBe(true);
+    // The surrounding **, *, `, ~~ markers are hidden.
+    expect(decos.filter(isHide).length).toBeGreaterThan(0);
+  });
+
+  it('reveals inline markers when the cursor is on their line', () => {
+    const doc = 'x **b** *i*\nsecond';
+    const decos = decosFor(doc, 3); // cursor inside the styled first line
+
+    // The styling still applies, but no markers are hidden on the active line.
+    expect(hasClass(decos, 'cm-md-strong')).toBe(true);
+    expect(decos.filter(isHide).length).toBe(0);
+  });
+
+  it('renders a link as its text, carrying the href, and hides the URL/brackets', () => {
+    const doc = 'see [the note](/knowledge/areas/foo.md) here\nsecond';
+    const decos = decosFor(doc, doc.length); // cursor on the second line
+
+    const link = decos.find((d) => d.class === 'cm-md-link');
+    expect(link).toBeDefined();
+    expect(link?.attributes?.['data-href']).toBe('/knowledge/areas/foo.md');
+    // The "](...)" tail and brackets are hidden, leaving just the link text.
+    expect(decos.filter(isHide).length).toBeGreaterThan(0);
+  });
+
+  it('does not hide the ``` fence of a fenced code block as inline code', () => {
+    const doc = '```\ncode\n```\n\nbody';
+    const decos = decosFor(doc, doc.length); // cursor on "body", away from the fence
+
+    // Fenced code is not inline code: no cm-md-code styling is applied to the fence,
+    // and the backtick fence rows are not treated as inline-code markers to hide.
+    expect(hasClass(decos, 'cm-md-code')).toBe(false);
+  });
+});

--- a/app/src/components/notebook/liveMarkdownPreview.ts
+++ b/app/src/components/notebook/liveMarkdownPreview.ts
@@ -169,7 +169,7 @@ const baseTheme = EditorView.baseTheme({
     borderRadius: '4px',
     background: 'var(--color-bg-elevated, rgba(127,127,127,0.16))',
   },
-  '.cm-md-link': { color: 'var(--color-accent, #7c9cff)', cursor: 'pointer' },
+  '.cm-md-link': { color: 'var(--accent, #ff6b35)', cursor: 'pointer' },
 });
 
 export function liveMarkdownPreview(options: LiveMarkdownOptions = {}): Extension {

--- a/app/src/components/notebook/liveMarkdownPreview.ts
+++ b/app/src/components/notebook/liveMarkdownPreview.ts
@@ -1,0 +1,209 @@
+// Live-preview decorations for CodeMirror 6 — the Obsidian-style "read and type in
+// the same surface" behavior. The document stays raw, canonical markdown (the
+// external-sync invariant); these decorations only change how it RENDERS:
+//   - heading lines are sized and their leading `#`s hidden
+//   - **bold**, *italic*, `code`, ~~strike~~ render styled with their markers hidden
+//   - [text](url) shows just the text, mod-click follows the link
+// On the line the cursor is on, the raw markers are REVEALED so you can edit them —
+// that line reads exactly as the file does on disk. Everything is derived from the
+// Lezer markdown syntax tree, so it tracks the parser rather than re-implementing it.
+
+import { syntaxTree } from '@codemirror/language';
+import { type EditorState, type Extension, type Range } from '@codemirror/state';
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+} from '@codemirror/view';
+
+export interface LiveMarkdownOptions {
+  // Invoked when the user mod-clicks (⌘/Ctrl) a rendered link. Receives the raw href.
+  onFollowLink?: (href: string) => void;
+}
+
+const HEADING_LEVEL: Record<string, number> = {
+  ATXHeading1: 1,
+  ATXHeading2: 2,
+  ATXHeading3: 3,
+  ATXHeading4: 4,
+  ATXHeading5: 5,
+  ATXHeading6: 6,
+};
+
+// Mark decorations (styling). Replace decorations (hide a marker range) are created
+// inline because they carry no shared identity.
+const STRONG = Decoration.mark({ class: 'cm-md-strong' });
+const EMPHASIS = Decoration.mark({ class: 'cm-md-em' });
+const INLINE_CODE = Decoration.mark({ class: 'cm-md-code' });
+const STRIKE = Decoration.mark({ class: 'cm-md-strike' });
+const HEADING_MARK = [1, 2, 3, 4, 5, 6].map((n) => Decoration.mark({ class: `cm-md-h${n}` }));
+const HIDE = Decoration.replace({});
+
+function linkMark(href: string): Decoration {
+  return Decoration.mark({
+    class: 'cm-md-link',
+    attributes: { 'data-href': href },
+  });
+}
+
+// Build the set of line numbers any selection range touches. A node rendered on one
+// of these lines keeps its raw markers visible (the active-line reveal). Derived
+// from the EditorState (not a view) so the decoration logic is unit-testable
+// headlessly — building a state needs no DOM, mounting a view does.
+function activeLines(state: EditorState): Set<number> {
+  const lines = new Set<number>();
+  for (const range of state.selection.ranges) {
+    const first = state.doc.lineAt(range.from).number;
+    const last = state.doc.lineAt(range.to).number;
+    for (let n = first; n <= last; n += 1) lines.add(n);
+  }
+  return lines;
+}
+
+// `focused` gates the active-line reveal: an unfocused editor renders as fully clean
+// markdown (nothing "active"), so a freshly-opened note reads like a rendered doc
+// even though CM always keeps a selection at position 0. Once focused, the cursor's
+// line reveals its raw markers for editing.
+export function buildDecorations(state: EditorState, focused = true): DecorationSet {
+  const decos: Range<Decoration>[] = [];
+  const { doc } = state;
+  const active = focused ? activeLines(state) : new Set<number>();
+  const tree = syntaxTree(state);
+
+  const onActiveLine = (pos: number) => active.has(doc.lineAt(pos).number);
+
+  tree.iterate({
+    enter: (node) => {
+      const name = node.name;
+
+      // ---- block: ATX headings ----
+      const level = HEADING_LEVEL[name];
+      if (level) {
+        // Size the whole heading line; sizing persists even on the active line.
+        decos.push(HEADING_MARK[level - 1].range(node.from, node.to));
+        return;
+      }
+
+      // ---- inline styling spans ----
+      if (name === 'StrongEmphasis') {
+        decos.push(STRONG.range(node.from, node.to));
+        return;
+      }
+      if (name === 'Emphasis') {
+        decos.push(EMPHASIS.range(node.from, node.to));
+        return;
+      }
+      if (name === 'InlineCode') {
+        decos.push(INLINE_CODE.range(node.from, node.to));
+        return;
+      }
+      if (name === 'Strikethrough') {
+        decos.push(STRIKE.range(node.from, node.to));
+        return;
+      }
+      if (name === 'Link') {
+        const url = node.node.getChild('URL');
+        const href = url ? doc.sliceString(url.from, url.to) : '';
+        if (href) decos.push(linkMark(href).range(node.from, node.to));
+        return;
+      }
+
+      // ---- markers we hide off the active line ----
+      if (name === 'HeaderMark') {
+        // Only ATX leading `#`s (a Setext underline is also a HeaderMark — leave it).
+        if (doc.sliceString(node.from, node.from + 1) !== '#') return;
+        if (onActiveLine(node.from)) return;
+        // Swallow the single space after the `#`s so the title sits flush.
+        let to = node.to;
+        if (doc.sliceString(to, to + 1) === ' ') to += 1;
+        decos.push(HIDE.range(node.from, to));
+        return;
+      }
+      if (name === 'EmphasisMark') {
+        if (!onActiveLine(node.from)) decos.push(HIDE.range(node.from, node.to));
+        return;
+      }
+      if (name === 'StrikethroughMark') {
+        if (!onActiveLine(node.from)) decos.push(HIDE.range(node.from, node.to));
+        return;
+      }
+      if (name === 'CodeMark') {
+        // Inline-code backticks only — never the ``` fences of a code block.
+        if (node.node.parent?.name !== 'InlineCode') return;
+        if (!onActiveLine(node.from)) decos.push(HIDE.range(node.from, node.to));
+        return;
+      }
+      if (name === 'LinkMark') {
+        if (!onActiveLine(node.from)) decos.push(HIDE.range(node.from, node.to));
+        return;
+      }
+      if (name === 'URL') {
+        // The (url) tail of a [text](url) link — hidden; bare/autolink URLs stay.
+        if (node.node.parent?.name !== 'Link') return;
+        if (!onActiveLine(node.from)) decos.push(HIDE.range(node.from, node.to));
+      }
+    },
+  });
+
+  // CM requires decorations sorted by position (and side); let Decoration.set sort.
+  return Decoration.set(decos, true);
+}
+
+const baseTheme = EditorView.baseTheme({
+  '.cm-md-h1': { fontSize: '1.7em', fontWeight: '650', lineHeight: '1.3' },
+  '.cm-md-h2': { fontSize: '1.4em', fontWeight: '630', lineHeight: '1.3' },
+  '.cm-md-h3': { fontSize: '1.2em', fontWeight: '600' },
+  '.cm-md-h4': { fontSize: '1.08em', fontWeight: '600' },
+  '.cm-md-h5': { fontSize: '1em', fontWeight: '600' },
+  '.cm-md-h6': { fontSize: '1em', fontWeight: '600', opacity: '0.85' },
+  '.cm-md-strong': { fontWeight: '700' },
+  '.cm-md-em': { fontStyle: 'italic' },
+  '.cm-md-strike': { textDecoration: 'line-through', opacity: '0.75' },
+  '.cm-md-code': {
+    fontFamily:
+      "ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+    fontSize: '0.92em',
+    padding: '0.5px 4px',
+    borderRadius: '4px',
+    background: 'var(--color-bg-elevated, rgba(127,127,127,0.16))',
+  },
+  '.cm-md-link': { color: 'var(--color-accent, #7c9cff)', cursor: 'pointer' },
+});
+
+export function liveMarkdownPreview(options: LiveMarkdownOptions = {}): Extension {
+  const plugin = ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+      constructor(view: EditorView) {
+        this.decorations = buildDecorations(view.state, view.hasFocus);
+      }
+      update(update: ViewUpdate) {
+        // Markers reveal/hide as the cursor moves and as focus changes (an unfocused
+        // editor renders fully clean), so rebuild on selection and focus changes too,
+        // not only document/viewport changes.
+        if (update.docChanged || update.viewportChanged || update.selectionSet || update.focusChanged) {
+          this.decorations = buildDecorations(update.state, update.view.hasFocus);
+        }
+      }
+    },
+    { decorations: (v) => v.decorations },
+  );
+
+  const followLinks = EditorView.domEventHandlers({
+    mousedown: (event, view) => {
+      if (!(event.metaKey || event.ctrlKey)) return false;
+      const target = (event.target as HTMLElement | null)?.closest('.cm-md-link');
+      const href = target?.getAttribute('data-href');
+      if (!href) return false;
+      event.preventDefault();
+      options.onFollowLink?.(href);
+      // Drop the selection CM would otherwise place at the click point.
+      view.dispatch({ selection: { anchor: view.state.selection.main.head } });
+      return true;
+    },
+  });
+
+  return [plugin, baseTheme, followLinks];
+}

--- a/app/test-harness/harnesses/LiveMarkdownEditorHarness.tsx
+++ b/app/test-harness/harnesses/LiveMarkdownEditorHarness.tsx
@@ -7,6 +7,10 @@
  * every change, and link-follow / selection callbacks are recorded too.
  */
 import { useCallback, useEffect, useState } from 'react';
+// Pull in the app's design tokens so the transparent editor renders over the real
+// dark pane (otherwise it sits on the browser's default white page, which is exactly
+// the kind of theme mismatch this editor is supposed to avoid).
+import '../../src/App.css';
 import { LiveMarkdownEditor, type LiveSelection } from '../../src/components/notebook/LiveMarkdownEditor';
 import type { HarnessProps } from '../types';
 
@@ -40,13 +44,14 @@ export function LiveMarkdownEditorHarness({ onReady, setTriggerRerender }: Harne
   }, []);
 
   useEffect(() => {
+    document.documentElement.setAttribute('data-theme', 'dark');
     setTriggerRerender(() => force((n) => n + 1));
     onReady();
   }, [onReady, setTriggerRerender]);
 
   return (
-    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', padding: 24 }}>
-      <div style={{ flex: 1, minHeight: 0, border: '1px solid #2a2a30', borderRadius: 8 }}>
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', padding: 24, background: 'var(--color-bg-app)' }}>
+      <div style={{ flex: 1, minHeight: 0, border: '1px solid var(--color-border)', borderRadius: 8 }}>
         <LiveMarkdownEditor
           value={value}
           onChange={handleChange}

--- a/app/test-harness/harnesses/LiveMarkdownEditorHarness.tsx
+++ b/app/test-harness/harnesses/LiveMarkdownEditorHarness.tsx
@@ -1,0 +1,60 @@
+/**
+ * LiveMarkdownEditor Test Harness
+ *
+ * Renders the CodeMirror-backed live-preview editor in a real browser (CM can't
+ * mount under happy-dom), so its rendering and interactions can be exercised and
+ * eyeballed. Exposes window.__HARNESS__ controls: the current value is recorded on
+ * every change, and link-follow / selection callbacks are recorded too.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { LiveMarkdownEditor, type LiveSelection } from '../../src/components/notebook/LiveMarkdownEditor';
+import type { HarnessProps } from '../types';
+
+const SAMPLE = `# Notebook heading
+
+A paragraph with **bold**, *italic*, \`inline code\`, and a
+[wiki link](/knowledge/areas/foo.md) to another note.
+
+## Second heading
+
+- a list item
+- another item
+`;
+
+export function LiveMarkdownEditorHarness({ onReady, setTriggerRerender }: HarnessProps) {
+  const params = new URLSearchParams(window.location.search);
+  const [value, setValue] = useState(params.get('empty') === '1' ? '' : SAMPLE);
+  const [, force] = useState(0);
+
+  const handleChange = useCallback((next: string) => {
+    window.__HARNESS__.recordCall('change', [next]);
+    setValue(next);
+  }, []);
+
+  const handleFollowLink = useCallback((href: string) => {
+    window.__HARNESS__.recordCall('followLink', [href]);
+  }, []);
+
+  const handleSelectionChange = useCallback((selection: LiveSelection | null) => {
+    window.__HARNESS__.recordCall('selectionChange', [selection]);
+  }, []);
+
+  useEffect(() => {
+    setTriggerRerender(() => force((n) => n + 1));
+    onReady();
+  }, [onReady, setTriggerRerender]);
+
+  return (
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', padding: 24 }}>
+      <div style={{ flex: 1, minHeight: 0, border: '1px solid #2a2a30', borderRadius: 8 }}>
+        <LiveMarkdownEditor
+          value={value}
+          onChange={handleChange}
+          onFollowLink={handleFollowLink}
+          onSelectionChange={handleSelectionChange}
+          ariaLabel="Note"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/test-harness/harnesses/NotebookBrowserHarness.tsx
+++ b/app/test-harness/harnesses/NotebookBrowserHarness.tsx
@@ -1,0 +1,78 @@
+/**
+ * NotebookBrowser Test Harness
+ *
+ * Renders the whole notebook modal (sidebar + single live-editor document pane)
+ * with mocked daemon functions, in a real browser, so the redesigned layout and the
+ * CodeMirror live editor can be exercised and eyeballed together. Edits are recorded
+ * via the writeNotebook mock so the autosave path is observable.
+ */
+import { useCallback, useEffect } from 'react';
+import { NotebookBrowser } from '../../src/components/NotebookBrowser';
+import type {
+  NotebookEntry,
+  NotebookReadResult,
+  NotebookSendToChiefResult,
+  NotebookTask,
+  NotebookWriteResult,
+} from '../../src/hooks/useDaemonSocket';
+import type { HarnessProps } from '../types';
+
+const ENTRIES: NotebookEntry[] = [
+  { path: 'knowledge/index.md', type: 'note', title: 'Knowledge index', size: 10 },
+  { path: 'journal/2026-06-20.md', type: 'journal', title: '2026-06-20', size: 20 },
+  { path: 'knowledge/areas/foo.md', type: 'note', title: 'Foo decision', size: 30 },
+];
+
+const CONTENT: Record<string, string> = {
+  'knowledge/index.md': `# Knowledge index
+
+The distilled map of the notebook. A paragraph with **bold**, *italic*,
+\`inline code\`, and a [wiki link](/knowledge/areas/foo.md) to another note.
+
+## Sections
+
+- areas — long-lived responsibilities
+- resources — reference material
+`,
+};
+
+export function NotebookBrowserHarness({ onReady, setTriggerRerender }: HarnessProps) {
+  const listNotebook = useCallback(async () => ENTRIES, []);
+  const readNotebook = useCallback(async (path: string): Promise<NotebookReadResult> => {
+    return { path, content: CONTENT[path] ?? `# ${path}\n\nSample note body.`, hash: 'h1' };
+  }, []);
+  const backlinksNotebook = useCallback(async (): Promise<NotebookEntry[]> => [
+    { path: 'journal/2026-06-20.md', type: 'journal', title: '2026-06-20', size: 20 },
+  ], []);
+  const writeNotebook = useCallback(async (path: string, content: string, baseHash?: string): Promise<NotebookWriteResult> => {
+    window.__HARNESS__.recordCall('writeNotebook', [path, content, baseHash]);
+    return { path, hash: 'h2', conflict: false };
+  }, []);
+  const sendToChief = useCallback(async (selection: string, sourcePath?: string): Promise<NotebookSendToChiefResult> => {
+    window.__HARNESS__.recordCall('sendToChief', [selection, sourcePath]);
+    return { path: 'inbox.md', nudged: false };
+  }, []);
+  const listTasks = useCallback(async (): Promise<NotebookTask[]> => [], []);
+  const retryTask = useCallback(async (): Promise<NotebookTask | null> => null, []);
+
+  useEffect(() => {
+    setTriggerRerender(() => {});
+    onReady();
+  }, [onReady, setTriggerRerender]);
+
+  return (
+    <NotebookBrowser
+      isOpen
+      onClose={() => window.__HARNESS__.recordCall('close', [])}
+      listNotebook={listNotebook}
+      readNotebook={readNotebook}
+      backlinksNotebook={backlinksNotebook}
+      writeNotebook={writeNotebook}
+      sendToChief={sendToChief}
+      changeSignal={0}
+      listTasks={listTasks}
+      retryTask={retryTask}
+      taskChangeSignal={0}
+    />
+  );
+}

--- a/app/test-harness/harnesses/NotebookBrowserHarness.tsx
+++ b/app/test-harness/harnesses/NotebookBrowserHarness.tsx
@@ -7,6 +7,10 @@
  * via the writeNotebook mock so the autosave path is observable.
  */
 import { useCallback, useEffect } from 'react';
+// Pull in the app's design tokens (--color-*, --accent) so the harness renders with
+// the real theme — without this the editor/modal fall back to undefined variables and
+// the screenshot isn't color-representative.
+import '../../src/App.css';
 import { NotebookBrowser } from '../../src/components/NotebookBrowser';
 import type {
   NotebookEntry,
@@ -56,6 +60,9 @@ export function NotebookBrowserHarness({ onReady, setTriggerRerender }: HarnessP
   const retryTask = useCallback(async (): Promise<NotebookTask | null> => null, []);
 
   useEffect(() => {
+    // The app defaults to the dark theme (useTheme DEFAULT_PREFERENCE); force it here
+    // so the harness is deterministic regardless of the runner's OS color scheme.
+    document.documentElement.setAttribute('data-theme', 'dark');
     setTriggerRerender(() => {});
     onReady();
   }, [onReady, setTriggerRerender]);

--- a/app/test-harness/harnesses/index.ts
+++ b/app/test-harness/harnesses/index.ts
@@ -9,6 +9,8 @@ import { DiffDetailPanelHarness } from './DiffDetailPanelHarness';
 import { DiffViewHarness } from './DiffViewHarness';
 import { GridLayoutControlHarness } from './GridLayoutControlHarness';
 import { GridViewHarness } from './GridViewHarness';
+import { LiveMarkdownEditorHarness } from './LiveMarkdownEditorHarness';
+import { NotebookBrowserHarness } from './NotebookBrowserHarness';
 import { SessionReviewLoopBarHarness } from './SessionReviewLoopBarHarness';
 
 export const harnesses: Record<string, React.ComponentType<HarnessProps>> = {
@@ -17,5 +19,7 @@ export const harnesses: Record<string, React.ComponentType<HarnessProps>> = {
   DiffView: DiffViewHarness,
   GridLayoutControl: GridLayoutControlHarness,
   GridView: GridViewHarness,
+  LiveMarkdownEditor: LiveMarkdownEditorHarness,
+  NotebookBrowser: NotebookBrowserHarness,
   SessionReviewLoopBar: SessionReviewLoopBarHarness,
 };

--- a/docs/plans/2026-06-20-notebook-ui-gap.md
+++ b/docs/plans/2026-06-20-notebook-ui-gap.md
@@ -1,0 +1,173 @@
+# Notebook UI — Prototype vs. Shipped: Gap Map
+
+Status: analysis (pre-plan). Maps every material difference between the **target**
+prototype and the **currently shipped** notebook UI, so a rebuild can be scoped.
+
+**Target (prototype):** `docs/prototypes/kb-markdown-ui.html` — self-contained
+interactive mock. Open in a browser to see it rendered.
+
+**Shipped (current):**
+- `app/src/components/NotebookBrowser.tsx` (+ `NotebookBrowser.css`) — the whole UI
+- mounted as a fullscreen **modal** from `App.tsx` (`notebookOpen`), opened via the
+  action-menu item "Browse the Notebook"
+- daemon surface: `notebook_list` / `notebook_read` / `notebook_backlinks` /
+  `notebook_write` / `notebook_to_chief` / `notebook_task_list` / `notebook_task_retry`
+  (all in `app/src/hooks/useDaemonSocket.ts`)
+
+**Plan reference:** `docs/plans/2026-06-13-notebook.md` → `## Markdown UI
+(Obsidian-style)` (line 356) specified the prototype's design; only a trimmed
+subset shipped.
+
+---
+
+## TL;DR — the shape is wrong, not just the details
+
+The prototype is a **panel-based, three-pane knowledge workspace** with two display
+modes (a pane that lives *inside the workspace grid beside agent terminals*, and a
+wide fullscreen view), a **file tree**, and a **right context rail** (outline +
+backlinks). What shipped is a **single fullscreen modal** with a **two-column**
+layout: a **flat category list** on the left and a markdown view/edit pane on the
+right, with backlinks tacked onto the bottom of the document. There is **no right
+rail, no tree, no outline, no tile mode, no collapsible panes, no frontmatter card,
+and no selection menu** — so it reads as a different product, which matches the "this
+is NOTHING like I wanted" reaction.
+
+The good news: the **majority of the gaps are frontend-only** — the daemon already
+serves the data (full note list with paths, backlinks, content+hash, type). The one
+genuinely large, architectural piece is **tile mode** (notebook as a workspace pane).
+
+---
+
+## Gap table
+
+Verdict: **Missing** (not built), **Partial** (built but reduced), **Different**
+(built differently). Build column: **FE** = frontend-only (daemon already serves what
+is needed), **FE+proto** = needs a small protocol/daemon addition, **Big** =
+architectural.
+
+| # | Dimension | Prototype (target) | Shipped (current) | Verdict | Build |
+|---|-----------|--------------------|-------------------|---------|-------|
+| 1 | Display modes | Tile (in workspace grid, beside terminals) **and** Fullscreen, segmented toggle, file preserved across toggle | Single fullscreen **modal** only | **Missing** (tile) / **Different** (fullscreen=modal) | **Big** (tile) / FE (full) |
+| 2 | Overall layout | **Three panes**: tree │ note │ context, + footer spanning all | **Two columns**: list │ document | **Different** | FE |
+| 3 | Left pane | **File tree**: nested folders, chevrons, expand/collapse | **Flat list** bucketed into 7 fixed category groups, no nesting | **Different** | FE |
+| 4 | Left-pane item | icon + **kind dot** (journal=amber / memory=blue / plain) + name | 3px type **marker bar** + title + path | **Partial** | FE |
+| 5 | Right pane | **Context rail**: Outline + Backlinks, each collapsible | **None** | **Missing** | FE |
+| 6 | Outline (TOC) | jump-to-heading list (h1/h2/h3 indented) | **None** (heading slug ids exist, unused for TOC) | **Missing** | FE |
+| 7 | Backlinks | In the **right rail**, card per source: mono path + context snippet | `<section>` at **bottom of document**, title-only buttons | **Different** | FE |
+| 8 | Frontmatter | **Frontmatter card**: title, summary, tag chips, sources (internal/external), created/updated meta | Raw content rendered through markdown; only title/path in header | **Missing** | FE (+proto optional) |
+| 9 | Broken links | In-notebook link to a missing note flagged red with ⚠ | Not detected; click just navigates (daemon 404s) | **Missing** | FE |
+| 10 | View / Edit | Per-note **View/Edit** segmented toggle in note header | "Edit" button → textarea editor (same capability, different control) | **Partial** | FE |
+| 11 | Editor + conflict | textarea + Save/Cancel + save-status (ok/conflict) | textarea + Save/Cancel + conflict reconcile ("reload" / "overwrite") | **Shipped** (parity ✓) | — |
+| 12 | Collapsible panes | Edge **rails** (‹ ›) fold tree/context; manual in full, auto in tile | Only the **Tasks** section collapses; panes never fold | **Missing** | FE |
+| 13 | Width responsiveness | Tile responds to **its own width** (ResizeObserver): wide→3-pane, medium→tree+note (right auto-folds), narrow→**file-picker**+note (tree folds), short→trimmed chrome; live mode indicator | Only a window media query at 760px shrinks the left column | **Missing** | FE |
+| 14 | Selection → chief | Floating **"Send to chief"** button **+ context menu** (Send to chief ⌘⏎ / **New memory note from selection** / **Copy link**) | Floating "Send to chief" button **only** | **Partial** | FE (+proto for new-note path) |
+| 15 | Confirmations | **Toast** stack (bottom-right) with snippet, accent/warm variants | Transient inline status badge in the doc header | **Different** | FE |
+| 16 | Top chrome | Persistent **top bar**: brand glyph, mode segmented control, **chief: active** pulse, help | Modal header: logo + "Notebook" + Close (esc) | **Different** | FE (+signal for chief status) |
+| 17 | Footer | KB footer spanning panes: "saved to the attn vault" + "N notes" path status | None | **Missing** | FE |
+| 18 | Tasks panel | Not in the KB (prototype only mocks terminals); background work is just terminal output | **Tasks** runner panel (collapsible) in the left pane: state badges, attempts, next-attempt, retry, errors | **Shipped beyond proto** (keep; decide placement) | — |
+| 19 | Kind / type system | journal vs memory vs plain, expressed as dots + header **badge pill** | `entry.type` drives only the marker bar color | **Partial** | FE |
+| 20 | Visual language | Obsidian-ish: tree gradient panels, fm card, chips, mono paths, density differs tile vs full | attn settings-style panels; flat groups; single density | **Different** | FE |
+
+---
+
+## What this means for effort
+
+**Frontend-only (daemon already serves the data):** items 2–10, 12, 13, 15, 17, 19,
+20. This is the bulk of the redesign. The daemon's `notebook_list` returns every
+note's full path (build the **tree** client-side by splitting paths), `notebook_read`
+returns content+hash (parse the **frontmatter** block and headings for the **card**
+and **outline** client-side), `notebook_backlinks` already feeds the **right-rail
+backlinks**, and the full note list lets us flag **broken links** by cross-reference.
+None of these need a protocol bump.
+
+**Small protocol/daemon additions (optional, for cleanliness):**
+- Item 8: a structured `frontmatter` object on `NotebookReadResult` (the daemon
+  already parses title/type, so it has the YAML) — avoids re-parsing client-side. Not
+  required; frontend can parse it.
+- Item 14: "New memory note from selection" needs a target path/name; `notebook_write`
+  to a new path already exists, so this is mostly a frontend new-note flow.
+- Item 16: a "chief active" signal for the pulse indicator (if not already broadcast).
+
+**The one big rock — item 1, tile mode:** rendering the notebook as a **pane type
+inside the workspace layout** (beside agent terminals, with the existing split/resize
+machinery and its own width-responsiveness) is architectural. It touches the
+workspace pane/layout system (`SessionTerminalWorkspace/`, the layout model) and
+likely needs layout **persistence** for the new pane type. This is the piece that
+makes the notebook "live where you work" instead of being a modal you pop open. It is
+separable from the fullscreen redesign and should probably be its own phase.
+
+**Already at/above parity (keep):** editor + hash-CAS conflict reconcile (item 11),
+live `notebook_changed` refresh, and the **Tasks runner panel** (item 18) — which the
+prototype never had. Decide whether Tasks stays in the left pane, moves to the right
+rail as a third section, or becomes its own surface.
+
+---
+
+## Hard requirement: one mode (read + type together)
+
+The current **View/Edit toggle is removed**. There is a single surface that is both
+readable (rendered markdown) and directly typeable — no "switch to edit". The chosen
+editing model (Live Preview vs WYSIWYG vs highlighted source) is the one open
+decision below; everything else in the order is independent of it. The notebook's
+files must stay plain canonical `.md` (external-sync invariant in
+`2026-06-13-notebook.md`), so the editor's source of truth stays raw markdown.
+
+## Staged rebuild order — verifiable at every stage
+
+Each stage is a small PR that leaves the app working and is **manually verifiable in
+the running app on its own**. We transform the existing component in place (no
+big-bang rewrite), so there is always something to open and check. Order is by
+dependency + "address the loudest wrongness first", not by the prototype's phasing.
+
+1. **One mode: read + type together.** ✅ **Done.** Replaced the view/edit split with
+   a single CodeMirror 6 live-preview surface (`notebook/LiveMarkdownEditor.tsx` +
+   `notebook/liveMarkdownPreview.ts`) in the *current* layout; deleted the View/Edit
+   toggle and the rendered/textarea split; edits now **autosave** (debounced, with a
+   navigate/close flush) over the same hash-CAS + conflict reconcile, and a selection
+   feeds the existing "Send to chief". Headings, bold/italic/code/strike, and links
+   render inline with markers hidden off the cursor line; an unfocused editor reads
+   fully clean. *Deferred to stage 4 polish:* list bullets/checkboxes and fenced-code
+   styling (raw `- ` / ``` still show). CM can't mount under happy-dom, so editor
+   behavior is covered by Playwright harnesses (`e2e/live-markdown-editor.spec.ts`,
+   `e2e/notebook-browser.spec.ts`); the decoration logic has a headless `EditorState`
+   unit test, and the surrounding orchestration is unit-tested with the editor mocked.
+   *Verify:* open a note → it renders **and** you can click anywhere and type → edits
+   persist; there is no mode toggle.
+2. **Left becomes a file tree.** Replace the flat category list with a nested folder
+   tree (expand/collapse) + kind dots.
+   *Verify:* folders nest and fold; clicking a file opens it; dots reflect kind.
+3. **Three-pane shell + right context rail.** Add the third pane; move backlinks into
+   it; add an **outline** (jump-to-heading).
+   *Verify:* outline lists the note's headings and scrolls to them on click;
+   backlinks now live in the rail; three columns render.
+4. **Frontmatter card + broken-link flags + markdown polish.**
+   *Verify:* a card shows title/summary/tags/sources/meta; an in-notebook link to a
+   missing note is flagged.
+5. **Collapsible rails + width responsiveness + footer + top-bar chrome.**
+   *Verify:* fold the tree/rail via the edge rails; narrow the window → panes fold and
+   the file-picker fallback appears; brand/mode/chief chrome + footer are present.
+6. **Selection menu + toasts.**
+   *Verify:* select text → menu (Send to chief / New note / Copy link) → a toast
+   confirms.
+7. **Tile mode (the one architectural piece).** Notebook as a workspace pane beside
+   terminals + tile/full toggle.
+   *Verify:* open the notebook as a pane inside a workspace; resize it; toggle to
+   fullscreen.
+
+Tasks runner panel (item 18) stays through all stages; it gets a final home in stage
+3 or 5 (left pane vs right-rail third section) — decide when the rail exists.
+
+## The one decision that shapes the build — DECIDED
+
+**Editing model for stage 1: Live Preview (Obsidian-style).** Type raw markdown,
+rendered inline as you go; raw syntax reveals only on the cursor's line. Source of
+truth stays plain `.md` (honors the external-sync invariant). Implementation:
+CodeMirror 6 with markdown language support + live-preview decorations (hide syntax
+markers off the active line, size headings, style bold/italic/code, make links
+clickable, render list bullets/checkboxes). Rejected: WYSIWYG (lossy `.md`
+round-trip) and highlighted-source-only (not "rendered reading").
+
+Lower-stakes decisions, defaultable as we go: fullscreen stays a modal vs becomes a
+real app view (lean: real view); frontmatter parsed client-side vs a new read-result
+field (lean: client-side); tree derived client-side from paths vs daemon-returned
+(lean: client-side — no protocol change).


### PR DESCRIPTION
## Stage 1 of the notebook UI rebuild

Toward the panel-based prototype (`docs/prototypes/kb-markdown-ui.html`); gap map in `docs/plans/2026-06-20-notebook-ui-gap.md`. Each stage is a small PR that's manually verifiable on its own.

**This stage: one mode — read and type in the same surface.** The notebook's View/Edit toggle and the rendered-markdown/textarea split are gone. A note now opens into a single CodeMirror 6 **live-preview** editor:

- Markdown renders inline as you read — headings sized, **bold**/*italic*/`code`/~~strike~~ styled, links shown as text — with the raw syntax markers hidden.
- The line your cursor is on reveals its raw markdown so you can edit it (Obsidian behavior). An **unfocused** editor renders fully clean.
- ⌘/Ctrl-click a wiki link to follow it; selecting text floats the existing **Send to chief** action.
- Edits **autosave** (debounced, plus a flush when you navigate away or close) over the same hash-CAS write + on-disk **conflict reconcile** as before. No Save button, no Cancel.
- Notes stay plain canonical `.md` (the source of truth is raw markdown), honoring the external-sync invariant.

Layout is otherwise unchanged (sidebar + document pane); backlinks moved to a foot strip for now (stage 3 relocates them to a right rail).

### Verify
Open a note → it renders **and** you can click anywhere and type → edits persist; there is no mode toggle.

### Testing
CodeMirror can't mount under happy-dom, so coverage is layered:
- **Headless unit** (`liveMarkdownPreview.test.ts`): decoration logic over an `EditorState` (heading sizing, marker hide/reveal by active line + focus, link href).
- **Unit, editor mocked** (`NotebookBrowser.test.tsx`): autosave/flush/conflict/navigation/selection orchestration.
- **Playwright harnesses** (real browser): `live-markdown-editor.spec.ts` (live preview render, typing, mod-click follow, selection) and `notebook-browser.spec.ts` (full modal, no toggle, autosave). Screenshots attached in `test-results/`.

All 1025 unit tests + the new e2e specs pass; `tsc` clean.

### Deferred (stage 4 polish)
List bullets/checkboxes and fenced-code styling still show raw (`- `, ```` ``` ````).

🤖 Opened by Claude on behalf of Victor.