### PR TITLE
feat(fs): generic filesystem daemon surface (fs_list/read/write + fs_changed)

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -172,7 +172,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '115';
+export const PROTOCOL_VERSION = '116';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListDispatchMessagesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookTask, NotebookTaskListMessage, NotebookTaskListResultMessage, NotebookTaskRetryMessage, NotebookTaskRetryResultMessage, NotebookTasksChangedMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, ReportDispatchMessage, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSEntry, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListDispatchMessagesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookTask, NotebookTaskListMessage, NotebookTaskListResultMessage, NotebookTaskRetryMessage, NotebookTaskRetryResultMessage, NotebookTasksChangedMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, ReportDispatchMessage, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const acknowledgeDispatchMessage = Convert.toAcknowledgeDispatchMessage(json);
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
@@ -67,6 +67,16 @@
 //   const fetchRemotesMessage = Convert.toFetchRemotesMessage(json);
 //   const fetchRemotesResultMessage = Convert.toFetchRemotesResultMessage(json);
 //   const fileDiffResultMessage = Convert.toFileDiffResultMessage(json);
+//   const fSChangedMessage = Convert.toFSChangedMessage(json);
+//   const fSEntry = Convert.toFSEntry(json);
+//   const fSListMessage = Convert.toFSListMessage(json);
+//   const fSListResultMessage = Convert.toFSListResultMessage(json);
+//   const fSReadMessage = Convert.toFSReadMessage(json);
+//   const fSReadResult = Convert.toFSReadResult(json);
+//   const fSReadResultMessage = Convert.toFSReadResultMessage(json);
+//   const fSWriteMessage = Convert.toFSWriteMessage(json);
+//   const fSWriteResult = Convert.toFSWriteResult(json);
+//   const fSWriteResultMessage = Convert.toFSWriteResultMessage(json);
 //   const getBranchDiffFilesMessage = Convert.toGetBranchDiffFilesMessage(json);
 //   const getCommentsMessage = Convert.toGetCommentsMessage(json);
 //   const getCommentsResultMessage = Convert.toGetCommentsResultMessage(json);
@@ -1306,6 +1316,139 @@ export interface FileDiffResultMessage {
 
 export enum FileDiffResultMessageEvent {
     FileDiffResult = "file_diff_result",
+}
+
+export interface FSChangedMessage {
+    event:  FSChangedMessageEvent;
+    origin: string;
+    paths:  string[];
+    [property: string]: any;
+}
+
+export enum FSChangedMessageEvent {
+    FSChanged = "fs_changed",
+}
+
+export interface FSEntry {
+    is_dir:    boolean;
+    modified?: string;
+    name:      string;
+    path:      string;
+    size:      number;
+    [property: string]: any;
+}
+
+export interface FSListMessage {
+    cmd:         FSListMessageCmd;
+    path?:       string;
+    request_id?: string;
+    [property: string]: any;
+}
+
+export enum FSListMessageCmd {
+    FSList = "fs_list",
+}
+
+export interface FSListResultMessage {
+    entries?:   EntryObject[];
+    error?:     string;
+    event:      FSListResultMessageEvent;
+    request_id: string;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export interface EntryObject {
+    is_dir:    boolean;
+    modified?: string;
+    name:      string;
+    path:      string;
+    size:      number;
+    [property: string]: any;
+}
+
+export enum FSListResultMessageEvent {
+    FSListResult = "fs_list_result",
+}
+
+export interface FSReadMessage {
+    cmd:         FSReadMessageCmd;
+    path:        string;
+    request_id?: string;
+    [property: string]: any;
+}
+
+export enum FSReadMessageCmd {
+    FSRead = "fs_read",
+}
+
+export interface FSReadResult {
+    content: string;
+    hash:    string;
+    path:    string;
+    [property: string]: any;
+}
+
+export interface FSReadResultMessage {
+    error?:     string;
+    event:      FSReadResultMessageEvent;
+    request_id: string;
+    result?:    FSReadResultMessageResult;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum FSReadResultMessageEvent {
+    FSReadResult = "fs_read_result",
+}
+
+export interface FSReadResultMessageResult {
+    content: string;
+    hash:    string;
+    path:    string;
+    [property: string]: any;
+}
+
+export interface FSWriteMessage {
+    base_hash?:  string;
+    cmd:         FSWriteMessageCmd;
+    content:     string;
+    path:        string;
+    request_id?: string;
+    [property: string]: any;
+}
+
+export enum FSWriteMessageCmd {
+    FSWrite = "fs_write",
+}
+
+export interface FSWriteResult {
+    conflict:      boolean;
+    current_hash?: string;
+    hash?:         string;
+    path:          string;
+    [property: string]: any;
+}
+
+export interface FSWriteResultMessage {
+    error?:     string;
+    event:      FSWriteResultMessageEvent;
+    request_id: string;
+    result?:    FSWriteResultMessageResult;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum FSWriteResultMessageEvent {
+    FSWriteResult = "fs_write_result",
+}
+
+export interface FSWriteResultMessageResult {
+    conflict:      boolean;
+    current_hash?: string;
+    hash?:         string;
+    path:          string;
+    [property: string]: any;
 }
 
 export interface GetBranchDiffFilesMessage {
@@ -4705,6 +4848,86 @@ export class Convert {
         return JSON.stringify(uncast(value, r("FileDiffResultMessage")), null, 2);
     }
 
+    public static toFSChangedMessage(json: string): FSChangedMessage {
+        return cast(JSON.parse(json), r("FSChangedMessage"));
+    }
+
+    public static fSChangedMessageToJson(value: FSChangedMessage): string {
+        return JSON.stringify(uncast(value, r("FSChangedMessage")), null, 2);
+    }
+
+    public static toFSEntry(json: string): FSEntry {
+        return cast(JSON.parse(json), r("FSEntry"));
+    }
+
+    public static fSEntryToJson(value: FSEntry): string {
+        return JSON.stringify(uncast(value, r("FSEntry")), null, 2);
+    }
+
+    public static toFSListMessage(json: string): FSListMessage {
+        return cast(JSON.parse(json), r("FSListMessage"));
+    }
+
+    public static fSListMessageToJson(value: FSListMessage): string {
+        return JSON.stringify(uncast(value, r("FSListMessage")), null, 2);
+    }
+
+    public static toFSListResultMessage(json: string): FSListResultMessage {
+        return cast(JSON.parse(json), r("FSListResultMessage"));
+    }
+
+    public static fSListResultMessageToJson(value: FSListResultMessage): string {
+        return JSON.stringify(uncast(value, r("FSListResultMessage")), null, 2);
+    }
+
+    public static toFSReadMessage(json: string): FSReadMessage {
+        return cast(JSON.parse(json), r("FSReadMessage"));
+    }
+
+    public static fSReadMessageToJson(value: FSReadMessage): string {
+        return JSON.stringify(uncast(value, r("FSReadMessage")), null, 2);
+    }
+
+    public static toFSReadResult(json: string): FSReadResult {
+        return cast(JSON.parse(json), r("FSReadResult"));
+    }
+
+    public static fSReadResultToJson(value: FSReadResult): string {
+        return JSON.stringify(uncast(value, r("FSReadResult")), null, 2);
+    }
+
+    public static toFSReadResultMessage(json: string): FSReadResultMessage {
+        return cast(JSON.parse(json), r("FSReadResultMessage"));
+    }
+
+    public static fSReadResultMessageToJson(value: FSReadResultMessage): string {
+        return JSON.stringify(uncast(value, r("FSReadResultMessage")), null, 2);
+    }
+
+    public static toFSWriteMessage(json: string): FSWriteMessage {
+        return cast(JSON.parse(json), r("FSWriteMessage"));
+    }
+
+    public static fSWriteMessageToJson(value: FSWriteMessage): string {
+        return JSON.stringify(uncast(value, r("FSWriteMessage")), null, 2);
+    }
+
+    public static toFSWriteResult(json: string): FSWriteResult {
+        return cast(JSON.parse(json), r("FSWriteResult"));
+    }
+
+    public static fSWriteResultToJson(value: FSWriteResult): string {
+        return JSON.stringify(uncast(value, r("FSWriteResult")), null, 2);
+    }
+
+    public static toFSWriteResultMessage(json: string): FSWriteResultMessage {
+        return cast(JSON.parse(json), r("FSWriteResultMessage"));
+    }
+
+    public static fSWriteResultMessageToJson(value: FSWriteResultMessage): string {
+        return JSON.stringify(uncast(value, r("FSWriteResultMessage")), null, 2);
+    }
+
     public static toGetBranchDiffFilesMessage(json: string): GetBranchDiffFilesMessage {
         return cast(JSON.parse(json), r("GetBranchDiffFilesMessage"));
     }
@@ -7248,6 +7471,85 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
         { json: "success", js: "success", typ: true },
     ], "any"),
+    "FSChangedMessage": o([
+        { json: "event", js: "event", typ: r("FSChangedMessageEvent") },
+        { json: "origin", js: "origin", typ: "" },
+        { json: "paths", js: "paths", typ: a("") },
+    ], "any"),
+    "FSEntry": o([
+        { json: "is_dir", js: "is_dir", typ: true },
+        { json: "modified", js: "modified", typ: u(undefined, "") },
+        { json: "name", js: "name", typ: "" },
+        { json: "path", js: "path", typ: "" },
+        { json: "size", js: "size", typ: 0 },
+    ], "any"),
+    "FSListMessage": o([
+        { json: "cmd", js: "cmd", typ: r("FSListMessageCmd") },
+        { json: "path", js: "path", typ: u(undefined, "") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "FSListResultMessage": o([
+        { json: "entries", js: "entries", typ: u(undefined, a(r("EntryObject"))) },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("FSListResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "EntryObject": o([
+        { json: "is_dir", js: "is_dir", typ: true },
+        { json: "modified", js: "modified", typ: u(undefined, "") },
+        { json: "name", js: "name", typ: "" },
+        { json: "path", js: "path", typ: "" },
+        { json: "size", js: "size", typ: 0 },
+    ], "any"),
+    "FSReadMessage": o([
+        { json: "cmd", js: "cmd", typ: r("FSReadMessageCmd") },
+        { json: "path", js: "path", typ: "" },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "FSReadResult": o([
+        { json: "content", js: "content", typ: "" },
+        { json: "hash", js: "hash", typ: "" },
+        { json: "path", js: "path", typ: "" },
+    ], "any"),
+    "FSReadResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("FSReadResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "result", js: "result", typ: u(undefined, r("FSReadResultMessageResult")) },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "FSReadResultMessageResult": o([
+        { json: "content", js: "content", typ: "" },
+        { json: "hash", js: "hash", typ: "" },
+        { json: "path", js: "path", typ: "" },
+    ], "any"),
+    "FSWriteMessage": o([
+        { json: "base_hash", js: "base_hash", typ: u(undefined, "") },
+        { json: "cmd", js: "cmd", typ: r("FSWriteMessageCmd") },
+        { json: "content", js: "content", typ: "" },
+        { json: "path", js: "path", typ: "" },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "FSWriteResult": o([
+        { json: "conflict", js: "conflict", typ: true },
+        { json: "current_hash", js: "current_hash", typ: u(undefined, "") },
+        { json: "hash", js: "hash", typ: u(undefined, "") },
+        { json: "path", js: "path", typ: "" },
+    ], "any"),
+    "FSWriteResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("FSWriteResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "result", js: "result", typ: u(undefined, r("FSWriteResultMessageResult")) },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "FSWriteResultMessageResult": o([
+        { json: "conflict", js: "conflict", typ: true },
+        { json: "current_hash", js: "current_hash", typ: u(undefined, "") },
+        { json: "hash", js: "hash", typ: u(undefined, "") },
+        { json: "path", js: "path", typ: "" },
+    ], "any"),
     "GetBranchDiffFilesMessage": o([
         { json: "base_ref", js: "base_ref", typ: u(undefined, "") },
         { json: "cmd", js: "cmd", typ: r("GetBranchDiffFilesMessageCmd") },
@@ -9081,6 +9383,27 @@ const typeMap: any = {
     ],
     "FileDiffResultMessageEvent": [
         "file_diff_result",
+    ],
+    "FSChangedMessageEvent": [
+        "fs_changed",
+    ],
+    "FSListMessageCmd": [
+        "fs_list",
+    ],
+    "FSListResultMessageEvent": [
+        "fs_list_result",
+    ],
+    "FSReadMessageCmd": [
+        "fs_read",
+    ],
+    "FSReadResultMessageEvent": [
+        "fs_read_result",
+    ],
+    "FSWriteMessageCmd": [
+        "fs_write",
+    ],
+    "FSWriteResultMessageEvent": [
+        "fs_write_result",
     ],
     "GetBranchDiffFilesMessageCmd": [
         "get_branch_diff_files",

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -24,6 +24,7 @@ import (
 	"github.com/victorarias/attn/internal/classifier"
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/diag"
+	"github.com/victorarias/attn/internal/fsdoc"
 	"github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/github"
 	"github.com/victorarias/attn/internal/hub"
@@ -141,17 +142,22 @@ type Daemon struct {
 	notebookWatcherMu   sync.Mutex
 	notebookWatcher     *notebook.Watcher
 	notebookWatchedRoot string
-	pendingInitialWS    map[*wsClient]struct{}
-	startedOnce         sync.Once
-	startedCh           chan struct{}
-	tailscale           *tailscaleRuntime
-	plugins             *pluginRegistry
-	pluginProcesses     *pluginProcessRegistry
-	pluginDriverMu      sync.Mutex
-	pluginLaunching     map[string]pluginSessionLaunch
-	pluginReports       map[string][]pendingPluginReport
-	pluginExits         map[string]ptybackend.ExitInfo
-	pluginDir           string
+	// fsStore is the generic filesystem view over the SAME root as the notebook
+	// (notebook.root). It is the raw layer beneath the curated notebook surface;
+	// both share the one root watcher started by ensureNotebookWatcher.
+	fsMu             sync.Mutex
+	fsStore          *fsdoc.Store
+	pendingInitialWS map[*wsClient]struct{}
+	startedOnce      sync.Once
+	startedCh        chan struct{}
+	tailscale        *tailscaleRuntime
+	plugins          *pluginRegistry
+	pluginProcesses  *pluginProcessRegistry
+	pluginDriverMu   sync.Mutex
+	pluginLaunching  map[string]pluginSessionLaunch
+	pluginReports    map[string][]pendingPluginReport
+	pluginExits      map[string]ptybackend.ExitInfo
+	pluginDir        string
 
 	worktreePluginCallTimeout         time.Duration
 	worktreeCreateProviderCallTimeout time.Duration

--- a/internal/daemon/fs.go
+++ b/internal/daemon/fs.go
@@ -1,0 +1,153 @@
+package daemon
+
+import (
+	"github.com/victorarias/attn/internal/fsdoc"
+	"github.com/victorarias/attn/internal/notebook"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// fsStoreFor returns the daemon's single generic filesystem Store for the active
+// root. The root is the SAME one the notebook uses (notebook.root): fsdoc is the
+// raw layer beneath the curated notebook surface. The Store is cached and reused
+// so writes serialize through one in-process writer, and rebuilt only when the
+// resolved root changes. As with the notebook, every fs operation lazily ensures
+// the one shared root watcher is running (so fs_changed fires for external edits).
+func (d *Daemon) fsStoreFor() (*fsdoc.Store, error) {
+	root, err := d.notebookRoot()
+	if err != nil {
+		return nil, err
+	}
+	d.fsMu.Lock()
+	if d.fsStore == nil || d.fsStore.Root() != root {
+		d.fsStore = fsdoc.NewStore(root)
+	}
+	store := d.fsStore
+	d.fsMu.Unlock()
+	d.ensureNotebookWatcher(root)
+	return store, nil
+}
+
+// broadcastFsChanged announces a filesystem change to all websocket clients.
+// origin is agent|ui|external, the same vocabulary as notebook_changed.
+func (d *Daemon) broadcastFsChanged(origin string, paths ...string) {
+	d.broadcastMessage(protocol.FsChangedMessage{
+		Event:  protocol.EventFsChanged,
+		Paths:  paths,
+		Origin: origin,
+	})
+}
+
+// sendFsListWSResult lists one directory's immediate children and replies with an
+// fs_list_result event correlated by requestID.
+func (d *Daemon) sendFsListWSResult(client *wsClient, requestID, path string) {
+	var entries []protocol.FsEntry
+	store, err := d.fsStoreFor()
+	if err == nil {
+		var list []fsdoc.Entry
+		if list, err = store.List(path); err == nil {
+			entries = fsEntriesToProtocol(list)
+		}
+	}
+	msg := protocol.FsListResultMessage{
+		Event:     protocol.EventFsListResult,
+		RequestID: requestID,
+		Success:   err == nil,
+		Entries:   entries,
+	}
+	if err != nil {
+		msg.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, msg)
+}
+
+// sendFsReadWSResult reads one file and replies with an fs_read_result event
+// correlated by requestID.
+func (d *Daemon) sendFsReadWSResult(client *wsClient, requestID, path string) {
+	var result *protocol.FsReadResult
+	store, err := d.fsStoreFor()
+	if err == nil {
+		var content []byte
+		var hash string
+		if content, hash, err = store.Read(path); err == nil {
+			result = &protocol.FsReadResult{Path: path, Content: string(content), Hash: hash}
+		}
+	}
+	msg := protocol.FsReadResultMessage{
+		Event:     protocol.EventFsReadResult,
+		RequestID: requestID,
+		Success:   err == nil,
+		Result:    result,
+	}
+	if err != nil {
+		msg.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, msg)
+}
+
+// sendFsWriteWSResult performs a hash-CAS write and replies with an
+// fs_write_result event correlated by requestID. A conflict (the file changed on
+// disk since the editor loaded it) is a successful result carrying conflict=true
+// for the UI to reconcile, not an error. On a successful write it records the
+// path as a self-write (so the shared watcher does not echo it as external) and
+// broadcasts fs_changed(origin=ui).
+func (d *Daemon) sendFsWriteWSResult(client *wsClient, requestID, path, content, baseHash string) {
+	var result *protocol.FsWriteResult
+	store, err := d.fsStoreFor()
+	if err == nil {
+		// Normalize the path to the canonical form fs_list/fs_changed key on, so the
+		// echoed result.path and the broadcast match it (not the raw leading-slash
+		// input). A path that fails to normalize still reaches Write, which returns
+		// the precise error.
+		changed := path
+		if rel, cerr := fsdoc.CleanPath(path); cerr == nil {
+			changed = rel
+		}
+		var hash string
+		var conflict *fsdoc.Conflict
+		if hash, conflict, err = store.Write(path, []byte(content), baseHash); err == nil {
+			result = &protocol.FsWriteResult{Path: changed}
+			if conflict != nil {
+				result.Conflict = true
+				if conflict.CurrentHash != "" {
+					result.CurrentHash = protocol.Ptr(conflict.CurrentHash)
+				}
+			} else {
+				result.Hash = protocol.Ptr(hash)
+				// Content-aware self-write so the shared watcher does not surface this
+				// UI edit as an external one. NoteSelfWrite keys on the notebook's
+				// CleanPath, so it only registers a .md path — which is exactly the set
+				// the watcher can report today; a non-.md write fires no watcher event,
+				// so there is nothing to suppress for it either way.
+				d.noteNotebookSelfWrite(notebook.SelfWrite{Rel: changed, Hash: hash})
+				d.broadcastFsChanged(originUI, changed)
+			}
+		}
+	}
+	msg := protocol.FsWriteResultMessage{
+		Event:     protocol.EventFsWriteResult,
+		RequestID: requestID,
+		Success:   err == nil,
+		Result:    result,
+	}
+	if err != nil {
+		msg.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, msg)
+}
+
+// fsEntriesToProtocol converts store entries to their protocol shape.
+func fsEntriesToProtocol(entries []fsdoc.Entry) []protocol.FsEntry {
+	out := make([]protocol.FsEntry, len(entries))
+	for i, e := range entries {
+		out[i] = protocol.FsEntry{
+			Path:  e.Path,
+			Name:  e.Name,
+			IsDir: e.IsDir,
+			Size:  int(e.Size),
+		}
+		if e.Modified != "" {
+			out[i].Modified = protocol.Ptr(e.Modified)
+		}
+	}
+	return out
+}

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -1,0 +1,246 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// newFsDaemon returns a test daemon whose root (notebook.root, shared by the fs
+// surface) points at an isolated temp dir.
+func newFsDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.store.SetSetting(SettingNotebookRoot, t.TempDir())
+	return d
+}
+
+// fsWriteCAS performs a hash-CAS fs_write over the WS path and returns the decoded
+// result event (a successful result may carry conflict=true). Uses a throwaway
+// client; the origin=ui broadcast goes to the hub, not this client.
+func fsWriteCAS(t *testing.T, d *Daemon, path, content, baseHash string) protocol.FsWriteResultMessage {
+	t.Helper()
+	client := &wsClient{send: make(chan outboundMessage, 8)}
+	d.sendFsWriteWSResult(client, "setup-fs-write", path, content, baseHash)
+	var res protocol.FsWriteResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	return res
+}
+
+// listFs lists one directory over the WS fs path and returns the entries.
+func listFs(t *testing.T, d *Daemon, dir string) []protocol.FsEntry {
+	t.Helper()
+	client := &wsClient{send: make(chan outboundMessage, 8)}
+	d.sendFsListWSResult(client, "setup-fs-list", dir)
+	var res protocol.FsListResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if !res.Success {
+		t.Fatalf("fs list(%q) failed: %v", dir, res.Error)
+	}
+	return res.Entries
+}
+
+// waitForFsChange returns the paths of the first fs_changed broadcast matching the
+// given origin, ignoring other events (notebook_changed, other origins).
+func waitForFsChange(t *testing.T, ch chan outboundMessage, origin string) []string {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case msg := <-ch:
+			var ev protocol.FsChangedMessage
+			if err := json.Unmarshal(msg.payload, &ev); err != nil {
+				continue
+			}
+			if ev.Event == protocol.EventFsChanged && ev.Origin == origin {
+				return ev.Paths
+			}
+		case <-deadline:
+			t.Fatalf("no fs_changed with origin %q was broadcast", origin)
+			return nil
+		}
+	}
+}
+
+// The fs surface writes, lists, and reads arbitrary files (not just .md) over the
+// WS path, round-tripping content and the hash used for hash-CAS edits.
+func TestFsWriteListReadWSResults(t *testing.T) {
+	d := newFsDaemon(t)
+
+	create := fsWriteCAS(t, d, "notes/todo.txt", "buy milk", "")
+	if create.Event != protocol.EventFsWriteResult || !create.Success ||
+		create.Result == nil || create.Result.Conflict || create.Result.Hash == nil {
+		t.Fatalf("create result = %+v", create.Result)
+	}
+	hash := *create.Result.Hash
+
+	// List the root: the notes/ directory shows up (is_dir), not the file inside it
+	// (shallow).
+	rootEntries := listFs(t, d, "")
+	if len(rootEntries) != 1 || rootEntries[0].Name != "notes" || !rootEntries[0].IsDir {
+		t.Fatalf("root list = %+v, want a single notes/ directory", rootEntries)
+	}
+
+	// List notes/: the file shows up with its byte size and a non-empty mtime.
+	sub := listFs(t, d, "notes")
+	if len(sub) != 1 || sub[0].Path != "notes/todo.txt" || sub[0].IsDir ||
+		sub[0].Size != int(len("buy milk")) || sub[0].Modified == nil {
+		t.Fatalf("notes list = %+v", sub)
+	}
+
+	// Read the file: content + the same hash the write returned.
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsReadWSResult(client, "r1", "notes/todo.txt")
+	var read protocol.FsReadResultMessage
+	readNotebookWSEvent(t, client.send, &read)
+	if read.Event != protocol.EventFsReadResult || read.RequestID != "r1" || !read.Success ||
+		read.Result == nil || read.Result.Content != "buy milk" || read.Result.Hash != hash {
+		t.Fatalf("read result = %+v", read.Result)
+	}
+
+	// A missing file is a failed result, not a panic or empty success.
+	d.sendFsReadWSResult(client, "r2", "nope.txt")
+	var missing protocol.FsReadResultMessage
+	readNotebookWSEvent(t, client.send, &missing)
+	if missing.RequestID != "r2" || missing.Success || missing.Error == nil {
+		t.Fatalf("missing read result = %+v, want failure with error", missing)
+	}
+}
+
+// fs_write is hash-CAS: a stale base hash comes back as a successful result
+// carrying conflict=true (for the UI to reconcile), and a matching base applies.
+func TestFsWriteWSResultSaveAndConflict(t *testing.T) {
+	d := newFsDaemon(t)
+
+	create := fsWriteCAS(t, d, "a.txt", "v1", "")
+	if create.Result == nil || create.Result.Hash == nil {
+		t.Fatalf("create = %+v", create.Result)
+	}
+	h1 := *create.Result.Hash
+
+	stale := fsWriteCAS(t, d, "a.txt", "v2", "deadbeef")
+	if !stale.Success || stale.Result == nil || !stale.Result.Conflict ||
+		stale.Result.CurrentHash == nil || *stale.Result.CurrentHash != h1 {
+		t.Fatalf("stale write = %+v, want conflict with current hash %q", stale.Result, h1)
+	}
+
+	ok := fsWriteCAS(t, d, "a.txt", "v2", h1)
+	if !ok.Success || ok.Result == nil || ok.Result.Conflict || ok.Result.Hash == nil {
+		t.Fatalf("CAS edit = %+v", ok.Result)
+	}
+}
+
+// The fs reads/writes must dispatch correctly through handleClientMessage — the
+// real frontend path — not only when the WS-result handlers are called directly.
+// This covers the request_id/path/content/base_hash extraction in the websocket
+// switch (a swapped Deref would compile and ship).
+func TestFsDispatchThroughClientMessage(t *testing.T) {
+	d := newFsDaemon(t)
+	client := newWorkspaceProtocolTestClient()
+	client.setIdentity("test", "protocol-"+protocol.ProtocolVersion, []string{protocol.CapabilityWorkspaceSessions})
+
+	d.handleClientMessage(client, []byte(`{"cmd":"fs_write","request_id":"w1","path":"docs/readme.md","content":"# hi\n"}`))
+	var write protocol.FsWriteResultMessage
+	readNotebookWSEvent(t, client.send, &write)
+	if write.Event != protocol.EventFsWriteResult || write.RequestID != "w1" || !write.Success ||
+		write.Result == nil || write.Result.Conflict || write.Result.Hash == nil {
+		t.Fatalf("write dispatch = %+v", write)
+	}
+
+	// fs_list with request_id AND path set: a swapped Deref would put the path in
+	// request_id (and vice versa), so assert both correlation and scoping.
+	d.handleClientMessage(client, []byte(`{"cmd":"fs_list","request_id":"l1","path":"docs"}`))
+	var list protocol.FsListResultMessage
+	readNotebookWSEvent(t, client.send, &list)
+	if list.RequestID != "l1" || !list.Success || len(list.Entries) != 1 ||
+		list.Entries[0].Path != "docs/readme.md" {
+		t.Fatalf("list dispatch = %+v", list)
+	}
+
+	d.handleClientMessage(client, []byte(`{"cmd":"fs_read","request_id":"r1","path":"docs/readme.md"}`))
+	var read protocol.FsReadResultMessage
+	readNotebookWSEvent(t, client.send, &read)
+	if read.RequestID != "r1" || !read.Success || read.Result == nil || read.Result.Content != "# hi\n" {
+		t.Fatalf("read dispatch = %+v", read.Result)
+	}
+}
+
+// fs_write broadcasts fs_changed(origin=ui) with the written path, so an open fs
+// view refreshes after an in-app save. (A non-.md path is used so the watcher does
+// not also fire — this isolates the direct ui broadcast.)
+func TestFsWriteBroadcastsUiChange(t *testing.T) {
+	d := newFsDaemon(t)
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	writer := &wsClient{send: make(chan outboundMessage, 8)}
+	d.sendFsWriteWSResult(writer, "w1", "notes/todo.txt", "hello", "")
+	var res protocol.FsWriteResultMessage
+	readNotebookWSEvent(t, writer.send, &res)
+	if !res.Success || res.Result == nil || res.Result.Conflict {
+		t.Fatalf("write = %+v", res.Result)
+	}
+
+	got := waitForFsChange(t, hubClient.send, originUI)
+	if !slices.Contains(got, "notes/todo.txt") {
+		t.Fatalf("ui fs_changed = %v, want notes/todo.txt", got)
+	}
+}
+
+// A write whose path arrives root-absolute (leading slash) echoes and broadcasts
+// the normalized root-relative path — the form fs_list returns — so the UI never
+// has to reconcile two spellings of the same file.
+func TestFsWriteNormalizesEchoedPath(t *testing.T) {
+	d := newFsDaemon(t)
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	res := fsWriteCAS(t, d, "/notes/todo.md", "x", "")
+	if res.Result == nil || res.Result.Path != "notes/todo.md" {
+		t.Fatalf("write result path = %+v, want normalized notes/todo.md", res.Result)
+	}
+	got := waitForFsChange(t, hubClient.send, originUI)
+	if !slices.Contains(got, "notes/todo.md") || slices.Contains(got, "/notes/todo.md") {
+		t.Fatalf("ui fs_changed = %v, want normalized notes/todo.md", got)
+	}
+}
+
+// An external .md edit on disk surfaces as fs_changed(origin=external), while the
+// fs surface's own write is suppressed (self-write) and does not echo as external.
+// (The shared watcher only surfaces .md today, so this uses .md files.)
+func TestFsChangedExternalEditNotSelfWrite(t *testing.T) {
+	d := newFsDaemon(t)
+	root := d.store.GetSetting(SettingNotebookRoot)
+	client := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[client] = true
+	go d.wsHub.run()
+
+	// Touch the fs surface so the lazy shared watcher starts, then let it settle.
+	listFs(t, d, "")
+	time.Sleep(80 * time.Millisecond)
+
+	// An fs_write records a self-write before it lands, so the watcher must not
+	// report it as external.
+	if res := fsWriteCAS(t, d, "own.md", "attn wrote this", ""); !res.Success || res.Result == nil || res.Result.Conflict {
+		t.Fatalf("own write = %+v", res.Result)
+	}
+	// An edit straight to disk (bypassing the daemon) must surface as external.
+	if err := os.WriteFile(filepath.Join(root, "ext.md"), []byte("edited externally"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ext := waitForFsChange(t, client.send, originExternal)
+	if !slices.Contains(ext, "ext.md") {
+		t.Fatalf("external fs_changed %v missing ext.md", ext)
+	}
+	if slices.Contains(ext, "own.md") {
+		t.Fatalf("external fs_changed %v wrongly included attn's own write own.md", ext)
+	}
+}

--- a/internal/daemon/notebook.go
+++ b/internal/daemon/notebook.go
@@ -79,7 +79,11 @@ func (d *Daemon) ensureNotebookWatcher(root string) {
 		d.notebookWatchedRoot = ""
 	}
 	w, err := notebook.NewWatcher(root, notebook.DefaultWatchDebounce, func(paths []string) {
+		// One filesystem, two surfaces over it: external edits feed both the curated
+		// notebook view and the raw fs view. (The watcher only surfaces .md paths
+		// today, so fs_changed inherits that limit until the watcher is generalized.)
 		d.broadcastNotebookChanged(originExternal, paths...)
+		d.broadcastFsChanged(originExternal, paths...)
 	})
 	if err != nil {
 		d.logf("notebook watcher: failed to watch %s: %v", root, err)

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -899,6 +899,15 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 	case protocol.CmdNotebookTaskRetry:
 		nbTaskRetry := msg.(*protocol.NotebookTaskRetryMessage)
 		go d.sendNotebookTaskRetryWSResult(client, protocol.Deref(nbTaskRetry.RequestID), nbTaskRetry.TaskID)
+	case protocol.CmdFsList:
+		fsList := msg.(*protocol.FsListMessage)
+		go d.sendFsListWSResult(client, protocol.Deref(fsList.RequestID), protocol.Deref(fsList.Path))
+	case protocol.CmdFsRead:
+		fsRead := msg.(*protocol.FsReadMessage)
+		go d.sendFsReadWSResult(client, protocol.Deref(fsRead.RequestID), fsRead.Path)
+	case protocol.CmdFsWrite:
+		fsWrite := msg.(*protocol.FsWriteMessage)
+		go d.sendFsWriteWSResult(client, protocol.Deref(fsWrite.RequestID), fsWrite.Path, fsWrite.Content, protocol.Deref(fsWrite.BaseHash))
 	case protocol.CmdApprovePR:
 		d.handleApprovePRWS(client, msg.(*protocol.ApprovePRMessage))
 	case protocol.CmdMergePR:

--- a/internal/fsdoc/store.go
+++ b/internal/fsdoc/store.go
@@ -1,0 +1,281 @@
+// Package fsdoc is a generic filesystem view over a single root directory — the
+// raw layer beneath the curated notebook. Where internal/notebook is markdown-
+// and PARA-aware (frontmatter, links, a reserved layout), fsdoc is deliberately
+// structure-blind: it lists, reads, and writes arbitrary files and directories
+// exactly as they sit on disk, so a UI can render the real folder tree over any
+// content. It shares the notebook's root (the notebook.root setting) and reuses
+// the notebook's vetted symlink-containment guard and content hash, so both
+// surfaces agree on what "inside the root" and "the bytes' hash" mean.
+package fsdoc
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/victorarias/attn/internal/notebook"
+)
+
+// MaxFileSize bounds a single fs_write so a runaway write cannot balloon the
+// root. It mirrors notebook.MaxFileSize: the same root, the same sync-friendly
+// goal. (Reads are not yet size-capped — that lands with the non-text handling.)
+const MaxFileSize = 2 << 20 // 2 MiB
+
+// Store is the generic filesystem store for one root directory. Writes serialize
+// under mu and apply atomically (temp file + rename); reads take no lock. It is
+// the single in-process writer for fs-originated mutations under this root.
+type Store struct {
+	root string
+	mu   sync.Mutex
+}
+
+// NewStore returns a Store rooted at the given absolute directory. The directory
+// need not exist yet. The root is cleaned so containment checks compare against a
+// canonical path (a trailing slash would otherwise break the prefix test in abs).
+func NewStore(root string) *Store {
+	if root != "" {
+		root = filepath.Clean(root)
+	}
+	return &Store{root: root}
+}
+
+// Root returns the absolute root directory.
+func (s *Store) Root() string { return s.root }
+
+// Entry is one immediate child of a listed directory: enough to render a tree
+// node and decide whether to expand it (is_dir) or open it.
+type Entry struct {
+	Path     string // root-relative, slash-separated, e.g. "knowledge/areas/foo.md"
+	Name     string // the base name, e.g. "foo.md"
+	IsDir    bool
+	Size     int64  // file byte size; 0 for a directory
+	Modified string // file mtime (RFC3339); "" for a directory
+}
+
+// Conflict reports that a hash-CAS write did not apply because the on-disk
+// content no longer matches the base the caller read. CurrentHash is the hash now
+// on disk ("" when the target file is gone).
+type Conflict struct {
+	CurrentHash string
+}
+
+// NotFoundError is returned when a requested path does not exist.
+type NotFoundError struct{ Path string }
+
+func (e *NotFoundError) Error() string { return fmt.Sprintf("fsdoc: %s not found", e.Path) }
+
+// IsNotFound reports whether err is a NotFoundError.
+func IsNotFound(err error) bool {
+	var nf *NotFoundError
+	return errors.As(err, &nf)
+}
+
+// List returns the immediate children of dir (root-relative; "" = the root
+// itself), files and subdirectories alike, sorted directories-first then by name.
+// It is SHALLOW by design: a tree UI calls it once per expanded node. Dot-entries
+// (.attn, .git, dotfiles) are hidden, and a child that resolves outside the root
+// via a symlink is skipped rather than exposed. A missing root yields an empty
+// list (it may not be created yet); a missing non-root directory yields a
+// NotFoundError; a path that is a file, not a directory, is an error.
+func (s *Store) List(dir string) ([]Entry, error) {
+	rel, err := cleanRel(dir, true)
+	if err != nil {
+		return nil, err
+	}
+	abs, err := s.abs(rel)
+	if err != nil {
+		return nil, err
+	}
+	info, statErr := os.Stat(abs)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			if rel == "" {
+				return []Entry{}, nil // root not created yet => empty
+			}
+			return nil, &NotFoundError{Path: dir}
+		}
+		return nil, statErr
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("fsdoc: %q is not a directory", dir)
+	}
+	dirents, err := os.ReadDir(abs)
+	if err != nil {
+		return nil, err
+	}
+	var entries []Entry
+	for _, dirent := range dirents {
+		name := dirent.Name()
+		if strings.HasPrefix(name, ".") {
+			continue // hide .attn/, .git/, and any dotfile
+		}
+		childAbs := filepath.Join(abs, name)
+		// The root is externally syncable, so a child can be a symlink pointing
+		// outside it. Read/Write defend via abs; List must too, or it would expose
+		// an outside file's name and size over the websocket. Skip such an entry.
+		if notebook.EnsureWithinResolvedRoot(s.root, childAbs) != nil {
+			continue
+		}
+		childInfo, ierr := dirent.Info()
+		if ierr != nil {
+			continue // vanished mid-scan
+		}
+		childRel := name
+		if rel != "" {
+			childRel = rel + "/" + name
+		}
+		e := Entry{Path: childRel, Name: name, IsDir: childInfo.IsDir()}
+		if !childInfo.IsDir() {
+			e.Size = childInfo.Size()
+			e.Modified = childInfo.ModTime().UTC().Format(time.RFC3339)
+		}
+		entries = append(entries, e)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].IsDir != entries[j].IsDir {
+			return entries[i].IsDir // directories first, then files
+		}
+		return entries[i].Name < entries[j].Name
+	})
+	return entries, nil
+}
+
+// Read returns the raw bytes of a file and their content hash. A missing file
+// yields a *NotFoundError.
+func (s *Store) Read(p string) (content []byte, hash string, err error) {
+	rel, err := cleanRel(p, false)
+	if err != nil {
+		return nil, "", err
+	}
+	abs, err := s.abs(rel)
+	if err != nil {
+		return nil, "", err
+	}
+	content, err = os.ReadFile(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, "", &NotFoundError{Path: p}
+		}
+		return nil, "", err
+	}
+	return content, notebook.Hash(content), nil
+}
+
+// Write creates or edits a file with the same hash-CAS contract as the notebook.
+// An empty baseHash means create-only: it fails with a Conflict if the file
+// already exists. A non-empty baseHash is a hash-CAS edit: it applies only if the
+// on-disk hash still matches, else returns a Conflict carrying the current hash.
+// On success it returns the new hash and a nil Conflict. Parent directories are
+// created as needed.
+func (s *Store) Write(p string, content []byte, baseHash string) (newHash string, conflict *Conflict, err error) {
+	rel, err := cleanRel(p, false)
+	if err != nil {
+		return "", nil, err
+	}
+	abs, err := s.abs(rel)
+	if err != nil {
+		return "", nil, err
+	}
+	if int64(len(content)) > MaxFileSize {
+		return "", nil, fmt.Errorf("fsdoc: content for %q exceeds %d bytes", p, MaxFileSize)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, statErr := os.ReadFile(abs)
+	exists := statErr == nil
+	if statErr != nil && !os.IsNotExist(statErr) {
+		return "", nil, statErr
+	}
+	if baseHash == "" {
+		if exists {
+			return "", &Conflict{CurrentHash: notebook.Hash(existing)}, nil
+		}
+	} else {
+		if !exists {
+			return "", &Conflict{CurrentHash: ""}, nil
+		}
+		if cur := notebook.Hash(existing); cur != baseHash {
+			return "", &Conflict{CurrentHash: cur}, nil
+		}
+	}
+	if err := writeAtomic(abs, content); err != nil {
+		return "", nil, err
+	}
+	return notebook.Hash(content), nil, nil
+}
+
+// CleanPath normalizes a file path (root-absolute or relative) to its clean,
+// slash-separated root-relative form — the same form List returns — or errors if
+// it escapes the root or names the root itself. The daemon uses it to echo and
+// broadcast a write's path in the canonical form, so result/event paths match
+// what fs_list keys on (mirroring notebook.CleanPath, but without the .md rule).
+func CleanPath(p string) (string, error) { return cleanRel(p, false) }
+
+// cleanRel validates and normalizes p to a clean, slash-separated path relative
+// to the root. The input may be root-absolute ("/knowledge/foo.md") or relative;
+// ".." is neutralized to within the root. Unlike notebook.CleanPath it imposes NO
+// extension restriction (fsdoc serves any file). allowRoot permits the empty/root
+// path (List uses it for the root directory); Read/Write reject it because they
+// need a file. Dotfile/dotdir segments and empty segments are rejected.
+func cleanRel(p string, allowRoot bool) (string, error) {
+	trimmed := strings.TrimSpace(p)
+	rel := strings.TrimPrefix(path.Clean("/"+strings.TrimPrefix(trimmed, "/")), "/")
+	if rel == "" || rel == "." {
+		if allowRoot {
+			return "", nil
+		}
+		return "", fmt.Errorf("fsdoc: %q is the root, not a file", p)
+	}
+	for seg := range strings.SplitSeq(rel, "/") {
+		if seg == "" {
+			return "", fmt.Errorf("fsdoc: %q has an empty path segment", p)
+		}
+		if strings.HasPrefix(seg, ".") {
+			return "", fmt.Errorf("fsdoc: %q has a dotfile/dotdir segment", p)
+		}
+	}
+	return rel, nil
+}
+
+// abs resolves a cleaned root-relative path to an absolute filesystem path,
+// rejecting any escape outside the root — lexical (defense in depth atop
+// cleanRel) and via symlinks inside the root that point elsewhere. rel == ""
+// resolves to the root itself (for List).
+func (s *Store) abs(rel string) (string, error) {
+	abs := filepath.Join(s.root, filepath.FromSlash(rel))
+	if abs != s.root && !strings.HasPrefix(abs, s.root+string(filepath.Separator)) {
+		return "", fmt.Errorf("fsdoc: %q escapes the root", rel)
+	}
+	if err := notebook.EnsureWithinResolvedRoot(s.root, abs); err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+// writeAtomic writes content to absPath atomically: it creates parent
+// directories, writes a uniquely-named temp file in the same directory, then
+// renames it into place. The temp file is removed on any error. (A focused copy
+// of the notebook's identical helper; both keep the same atomic-write semantics.)
+func writeAtomic(absPath string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return err
+	}
+	tmp := fmt.Sprintf("%s.tmp.%d.%d", absPath, os.Getpid(), time.Now().UnixNano())
+	if err := os.WriteFile(tmp, content, 0o644); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, absPath); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/internal/fsdoc/store_test.go
+++ b/internal/fsdoc/store_test.go
@@ -1,0 +1,220 @@
+package fsdoc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/victorarias/attn/internal/notebook"
+)
+
+func write(t *testing.T, abs, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// List is shallow (immediate children only), sorts directories before files, and
+// hides dot-entries. File entries carry size and mtime; directory entries do not.
+func TestListShallowSortedAndFiltered(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "b.md"), "bb")
+	write(t, filepath.Join(root, "a.txt"), "aaa")
+	write(t, filepath.Join(root, "knowledge", "deep.md"), "deep") // creates the dir
+	write(t, filepath.Join(root, ".hidden"), "x")                 // dotfile, skipped
+	if err := os.MkdirAll(filepath.Join(root, ".attn"), 0o755); err != nil {
+		t.Fatal(err) // dotdir, skipped
+	}
+
+	s := NewStore(root)
+	entries, err := s.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name)
+	}
+	// knowledge/ (dir) first, then files a.txt, b.md; no dot-entries; not recursive
+	// (deep.md is not surfaced).
+	want := []string{"knowledge", "a.txt", "b.md"}
+	if len(names) != len(want) {
+		t.Fatalf("list names = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("list names = %v, want %v", names, want)
+		}
+	}
+	for _, e := range entries {
+		switch e.Name {
+		case "knowledge":
+			if !e.IsDir || e.Path != "knowledge" || e.Size != 0 || e.Modified != "" {
+				t.Fatalf("dir entry = %+v", e)
+			}
+		case "a.txt":
+			if e.IsDir || e.Path != "a.txt" || e.Size != 3 || e.Modified == "" {
+				t.Fatalf("file entry = %+v", e)
+			}
+		}
+	}
+}
+
+// Listing a subdirectory scopes to that directory's immediate children, with
+// root-relative paths.
+func TestListSubdirectory(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "knowledge", "areas", "foo.md"), "x")
+	write(t, filepath.Join(root, "knowledge", "index.md"), "y")
+
+	s := NewStore(root)
+	entries, err := s.List("knowledge")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 || entries[0].Path != "knowledge/areas" || !entries[0].IsDir ||
+		entries[1].Path != "knowledge/index.md" || entries[1].IsDir {
+		t.Fatalf("subdir list = %+v", entries)
+	}
+}
+
+func TestListMissingRootIsEmpty(t *testing.T) {
+	s := NewStore(filepath.Join(t.TempDir(), "does-not-exist-yet"))
+	entries, err := s.List("")
+	if err != nil {
+		t.Fatalf("missing root List error = %v, want nil", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("missing root List = %+v, want empty", entries)
+	}
+}
+
+func TestListMissingSubdirIsNotFound(t *testing.T) {
+	s := NewStore(t.TempDir())
+	_, err := s.List("nope")
+	if !IsNotFound(err) {
+		t.Fatalf("List(missing subdir) err = %v, want NotFound", err)
+	}
+}
+
+func TestListFileIsError(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "a.md"), "x")
+	s := NewStore(root)
+	if _, err := s.List("a.md"); err == nil || IsNotFound(err) {
+		t.Fatalf("List(file) err = %v, want a not-a-directory error", err)
+	}
+}
+
+func TestReadReturnsContentAndHash(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "a.txt"), "hello")
+	s := NewStore(root)
+	content, hash, err := s.Read("a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "hello" || hash != notebook.Hash([]byte("hello")) {
+		t.Fatalf("read = %q hash %q", content, hash)
+	}
+}
+
+func TestReadMissingIsNotFound(t *testing.T) {
+	s := NewStore(t.TempDir())
+	if _, _, err := s.Read("gone.md"); !IsNotFound(err) {
+		t.Fatalf("Read(missing) err = %v, want NotFound", err)
+	}
+}
+
+// Write creates, refuses to clobber on create-only, applies a matching hash-CAS
+// edit, and reports a conflict (with the current hash) on a stale base.
+func TestWriteCreateEditAndConflict(t *testing.T) {
+	root := t.TempDir()
+	s := NewStore(root)
+
+	h1, conflict, err := s.Write("dir/a.txt", []byte("v1"), "")
+	if err != nil || conflict != nil || h1 != notebook.Hash([]byte("v1")) {
+		t.Fatalf("create = %q conflict %+v err %v", h1, conflict, err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(root, "dir", "a.txt")); string(got) != "v1" {
+		t.Fatalf("on-disk = %q after create", got)
+	}
+
+	// Create-only against an existing file => conflict carrying the current hash.
+	_, conflict, err = s.Write("dir/a.txt", []byte("v2"), "")
+	if err != nil || conflict == nil || conflict.CurrentHash != h1 {
+		t.Fatalf("create-only over existing = conflict %+v err %v", conflict, err)
+	}
+
+	// Stale base hash => conflict, no write.
+	_, conflict, err = s.Write("dir/a.txt", []byte("v2"), "deadbeef")
+	if err != nil || conflict == nil || conflict.CurrentHash != h1 {
+		t.Fatalf("stale CAS = conflict %+v err %v", conflict, err)
+	}
+
+	// Correct base hash => the edit applies.
+	h2, conflict, err := s.Write("dir/a.txt", []byte("v2"), h1)
+	if err != nil || conflict != nil || h2 != notebook.Hash([]byte("v2")) {
+		t.Fatalf("CAS edit = %q conflict %+v err %v", h2, conflict, err)
+	}
+}
+
+// A hash-CAS edit of a file that does not exist is a conflict with an empty
+// current hash (not a create), so the editor learns the file vanished.
+func TestWriteCASMissingIsConflict(t *testing.T) {
+	s := NewStore(t.TempDir())
+	_, conflict, err := s.Write("gone.txt", []byte("x"), "somehash")
+	if err != nil || conflict == nil || conflict.CurrentHash != "" {
+		t.Fatalf("CAS over missing = conflict %+v err %v", conflict, err)
+	}
+}
+
+func TestWriteRejectsOversizeContent(t *testing.T) {
+	s := NewStore(t.TempDir())
+	if _, _, err := s.Write("big.bin", make([]byte, MaxFileSize+1), ""); err == nil {
+		t.Fatal("oversize Write err = nil, want rejection")
+	}
+}
+
+// Lexical escapes (.. above the root) are rejected by every operation.
+func TestPathEscapesRejected(t *testing.T) {
+	s := NewStore(t.TempDir())
+	for _, p := range []string{"../outside.txt", "/../../etc/passwd", "a/../../b.txt"} {
+		if _, _, err := s.Read(p); err == nil {
+			t.Fatalf("Read(%q) err = nil, want escape rejection", p)
+		}
+	}
+}
+
+// A symlink inside the root that points outside it is skipped by List and
+// rejected by Read — the same containment the notebook enforces, reused here.
+func TestSymlinkEscapeContained(t *testing.T) {
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	write(t, secret, "top secret")
+
+	root := t.TempDir()
+	write(t, filepath.Join(root, "normal.txt"), "ok")
+	link := filepath.Join(root, "leak.txt")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	s := NewStore(root)
+	entries, err := s.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name == "leak.txt" {
+			t.Fatalf("List surfaced an escaping symlink: %+v", e)
+		}
+	}
+	if _, _, err := s.Read("leak.txt"); err == nil {
+		t.Fatal("Read followed an escaping symlink")
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "115"
+const ProtocolVersion = "116"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -66,6 +66,9 @@ const (
 	CmdNotebookSendToChief                   = "notebook_send_to_chief"
 	CmdNotebookTaskList                      = "notebook_task_list"
 	CmdNotebookTaskRetry                     = "notebook_task_retry"
+	CmdFsList                                = "fs_list"
+	CmdFsRead                                = "fs_read"
+	CmdFsWrite                               = "fs_write"
 	CmdUnregister                            = "unregister"
 	CmdState                                 = "state"
 	CmdSetSessionResumeID                    = "set_session_resume_id"
@@ -199,6 +202,10 @@ const (
 	EventNotebookTaskListResult        = "notebook_task_list_result"
 	EventNotebookTaskRetryResult       = "notebook_task_retry_result"
 	EventNotebookTasksChanged          = "notebook_tasks_changed"
+	EventFsListResult                  = "fs_list_result"
+	EventFsReadResult                  = "fs_read_result"
+	EventFsWriteResult                 = "fs_write_result"
+	EventFsChanged                     = "fs_changed"
 	EventPRsUpdated                    = "prs_updated"
 	EventReposUpdated                  = "repos_updated"
 	EventAuthorsUpdated                = "authors_updated"
@@ -511,6 +518,27 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdNotebookTaskRetry:
 		var msg NotebookTaskRetryMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdFsList:
+		var msg FsListMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdFsRead:
+		var msg FsReadMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdFsWrite:
+		var msg FsWriteMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1090,6 +1090,149 @@ type FileDiffResultMessage struct {
 	Success bool `json:"success"`
 }
 
+type FsChangedMessage struct {
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Origin corresponds to the JSON schema field "origin".
+	Origin string `json:"origin"`
+
+	// Paths corresponds to the JSON schema field "paths".
+	Paths []string `json:"paths"`
+}
+
+type FsEntry struct {
+	// IsDir corresponds to the JSON schema field "is_dir".
+	IsDir bool `json:"is_dir"`
+
+	// Modified corresponds to the JSON schema field "modified".
+	Modified *string `json:"modified,omitempty,omitzero"`
+
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+
+	// Size corresponds to the JSON schema field "size".
+	Size int `json:"size"`
+}
+
+type FsListMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path *string `json:"path,omitempty,omitzero"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type FsListResultMessage struct {
+	// Entries corresponds to the JSON schema field "entries".
+	Entries []FsEntry `json:"entries,omitempty,omitzero"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
+type FsReadMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type FsReadResult struct {
+	// Content corresponds to the JSON schema field "content".
+	Content string `json:"content"`
+
+	// Hash corresponds to the JSON schema field "hash".
+	Hash string `json:"hash"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+}
+
+type FsReadResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Result corresponds to the JSON schema field "result".
+	Result *FsReadResult `json:"result,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
+type FsWriteMessage struct {
+	// BaseHash corresponds to the JSON schema field "base_hash".
+	BaseHash *string `json:"base_hash,omitempty,omitzero"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Content corresponds to the JSON schema field "content".
+	Content string `json:"content"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type FsWriteResult struct {
+	// Conflict corresponds to the JSON schema field "conflict".
+	Conflict bool `json:"conflict"`
+
+	// CurrentHash corresponds to the JSON schema field "current_hash".
+	CurrentHash *string `json:"current_hash,omitempty,omitzero"`
+
+	// Hash corresponds to the JSON schema field "hash".
+	Hash *string `json:"hash,omitempty,omitzero"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+}
+
+type FsWriteResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Result corresponds to the JSON schema field "result".
+	Result *FsWriteResult `json:"result,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type GetBranchDiffFilesMessage struct {
 	// BaseRef corresponds to the JSON schema field "base_ref".
 	BaseRef *string `json:"base_ref,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -689,6 +689,38 @@ model NotebookTaskRetryMessage {
   task_id: string;
 }
 
+// ============================================================================
+// Generic filesystem surface (fs_*). A plain view over the configurable root
+// (the notebook.root setting): list a directory, read a file, write a file with
+// the same hash-CAS contract as notebook_write. Unlike the notebook_* commands
+// this is NOT .md-aware or PARA-aware — it surfaces every file and directory as
+// it is on disk, so the UI can render a real folder tree over arbitrary content.
+// The notebook_* surface remains the curated, markdown-only view of the same
+// root; fs_* is the raw filesystem underneath it.
+// ============================================================================
+
+// List the immediate children (files and subdirectories) of one directory under
+// the root. SHALLOW by design: a tree UI expands lazily, one readdir per node.
+model FsListMessage {
+  cmd: "fs_list";
+  path?: string; // omitted/"" = the root directory itself
+  request_id?: string; // set by the WS frontend to correlate the result event
+}
+
+model FsReadMessage {
+  cmd: "fs_read";
+  path: string;
+  request_id?: string; // set by the WS frontend to correlate the result event
+}
+
+model FsWriteMessage {
+  cmd: "fs_write";
+  path: string;
+  content: string;
+  base_hash?: string; // omitted = create-only; present = hash-CAS edit
+  request_id?: string; // set by the WS frontend to correlate the result event
+}
+
 model DelegateWorktreeRequest {
   repo?: string;
   branch: string;
@@ -2276,6 +2308,72 @@ model NotebookTaskRetryResultMessage {
 // task panel re-lists. Fired from the runner's OnChange callback.
 model NotebookTasksChangedMessage {
   event: "notebook_tasks_changed";
+}
+
+// ---- Generic filesystem surface results (fs_*) ----
+
+// One child of a listed directory. is_dir distinguishes a subdirectory (which the
+// UI expands with another fs_list) from a file (which fs_read opens). size is the
+// byte size for a file (0 for a directory). modified is the file mtime (RFC3339).
+model FsEntry {
+  path: string; // root-relative, slash-separated, e.g. "knowledge/areas/foo.md"
+  name: string; // the base name, e.g. "foo.md"
+  is_dir: boolean;
+  size: int32;
+  modified?: string;
+}
+
+model FsReadResult {
+  path: string;
+  content: string;
+  hash: string;
+}
+
+// Result of fs_write. When conflict is true the write did not apply; current_hash
+// is the hash now on disk (empty if the target is gone). Same contract as
+// NotebookWriteResult.
+model FsWriteResult {
+  path: string;
+  hash?: string;
+  conflict: boolean;
+  current_hash?: string;
+}
+
+model FsListResultMessage {
+  event: "fs_list_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  entries?: FsEntry[];
+}
+
+model FsReadResultMessage {
+  event: "fs_read_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  result?: FsReadResult;
+}
+
+// Result of fs_write (hash-CAS). A conflict is a successful response the UI
+// reconciles, carried in result.conflict — not a transport error.
+model FsWriteResultMessage {
+  event: "fs_write_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  result?: FsWriteResult;
+}
+
+// Broadcast when files under the root change. origin is agent|ui|external, the
+// same vocabulary as notebook_changed. NOTE: today this rides the notebook
+// watcher, which only surfaces .md paths, so a non-.md external edit does not yet
+// emit fs_changed; generalizing the watcher to all files lands with the non-text
+// editor work.
+model FsChangedMessage {
+  event: "fs_changed";
+  paths: string[];
+  origin: string;
 }
 
 model WorkspaceContextResultMessage {


### PR DESCRIPTION
## What

Slice A of the **fs-based notebook pivot**: a generic filesystem daemon surface that the redesigned notebook UI will render a real folder tree over. This PR is **daemon-side only** (Go + protocol) — no UI yet.

Adds a raw filesystem view over the **same configurable root** as the notebook (the already-live `notebook.root` setting), exposed on the websocket:

- `fs_list` — shallow, one directory's immediate children (files + subdirs), directories-first. A tree UI expands lazily, one `readdir` per node.
- `fs_read` — any file's bytes + content hash.
- `fs_write` — create / hash-CAS edit, the **same conflict-reconcile contract as `notebook_write`**.
- `fs_changed` — broadcast on changes (origin `agent|ui|external`).

Unlike `notebook_*`, this surface is **structure-blind**: no `.md`/PARA/frontmatter awareness — it surfaces every file and directory exactly as it sits on disk. The curated notebook view stays; `fs_*` is the raw layer beneath it.

## Design notes

- **`internal/fsdoc`** reuses the notebook's vetted `EnsureWithinResolvedRoot` symlink-containment guard and `Hash` — no duplicated security logic. It defines its own generic path cleaner (no `.md` restriction).
- **One filesystem, one watcher.** The single shared root watcher (started lazily by the notebook path) now feeds *both* `notebook_changed` and `fs_changed`. `fs_write` records a self-write (so its own edit isn't echoed as external) and broadcasts `fs_changed(ui)` — mirroring `notebook_write`. It also normalizes the echoed/broadcast path so result/event paths match what `fs_list` returns.
- **Known limit (documented in code):** the watcher only surfaces `.md` paths today (`notebook.CleanPath` gates it), so a non-`.md` external edit doesn't yet emit `fs_changed`. Generalizing the watcher to all files lands with the non-text editor work.
- `ProtocolVersion` 115 → 116 (+ matching frontend constant).

## Testing

- `internal/fsdoc`: shallow list / dirs-first / dotfile-hiding, missing-root-empty, missing-subdir-NotFound, file-as-dir error, read+hash, create/CAS/conflict, oversize rejection, lexical-escape + symlink-escape containment.
- `internal/daemon`: full WS round-trip via `handleClientMessage` with literal frontend JSON (the real dispatch path) for list/read/write + conflict; `fs_changed(ui)` broadcast; path normalization; and external-edit-surfaces-while-self-write-suppressed against a real `fsnotify` watcher.
- Go `build ./...`, `vet`, `gofmt`, and `tsc --noEmit` all clean.

Verification is at the integration level (handlers driven through the real dispatch path); live UI verification comes in the follow-up slice when there's something to see.