### PR TITLE
feat(fs): frontend fs surface plumbing + lazy FileTree component

### DIFF
--- a/app/src/components/notebook/FileTree.css
+++ b/app/src/components/notebook/FileTree.css
@@ -1,0 +1,85 @@
+/* Lazy filesystem tree. Tracks the app's light/dark mode through the same design
+   tokens the notebook browser uses (--accent, --color-*), so it sits seamlessly in
+   the same pane. Indentation is applied inline per depth (see indent() in the TSX);
+   these rules own only the row chrome. */
+
+.file-tree {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  font-size: 13px;
+}
+
+.file-tree-group {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.file-tree-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 4px 10px 4px 8px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.file-tree-row:hover {
+  background: color-mix(in srgb, var(--color-bg-elevated) 60%, transparent);
+}
+
+.file-tree-file.is-selected {
+  background: var(--color-bg-elevated);
+  border-color: var(--color-border);
+}
+
+.file-tree-chevron {
+  display: inline-block;
+  width: 12px;
+  flex: 0 0 auto;
+  color: var(--color-text-secondary);
+  transition: transform 0.12s ease;
+  transform: rotate(0deg);
+}
+
+.file-tree-chevron.is-open {
+  transform: rotate(90deg);
+}
+
+.file-tree-dir .file-tree-name {
+  font-weight: 550;
+}
+
+.file-tree-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-tree-file.is-selected .file-tree-name {
+  color: var(--accent);
+}
+
+.file-tree-state {
+  list-style: none;
+  padding: 4px 10px;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+}
+
+.file-tree-error {
+  color: var(--color-danger, #e5484d);
+}
+
+.file-tree-empty {
+  font-style: italic;
+  opacity: 0.8;
+}

--- a/app/src/components/notebook/FileTree.test.tsx
+++ b/app/src/components/notebook/FileTree.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FileTree } from './FileTree';
+import type { FsEntry } from '../../hooks/useDaemonSocket';
+
+// A tiny fixture tree: root has a directory (areas/) and a file (index.md); areas/
+// holds one file (foo.md). listDir returns the children for a given directory.
+const TREE: Record<string, FsEntry[]> = {
+  '': [
+    { path: 'areas', name: 'areas', isDir: true, size: 0 },
+    { path: 'index.md', name: 'index.md', isDir: false, size: 10, modified: '2026-06-20T00:00:00Z' },
+  ],
+  areas: [{ path: 'areas/foo.md', name: 'foo.md', isDir: false, size: 5 }],
+};
+
+function makeListDir() {
+  return vi.fn<(path: string) => Promise<FsEntry[]>>().mockImplementation((p) => Promise.resolve(TREE[p] ?? []));
+}
+
+describe('FileTree', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('lists the root on mount and renders its directories and files', async () => {
+    const listDir = makeListDir();
+    render(<FileTree listDir={listDir} selectedPath={null} onSelectFile={vi.fn()} />);
+
+    expect(await screen.findByRole('treeitem', { name: 'areas' })).toBeInTheDocument();
+    expect(screen.getByRole('treeitem', { name: 'index.md' })).toBeInTheDocument();
+    expect(listDir).toHaveBeenCalledWith('');
+    // Shallow: the nested file is not listed until areas/ is expanded.
+    expect(screen.queryByRole('treeitem', { name: 'foo.md' })).not.toBeInTheDocument();
+  });
+
+  it('expands a directory lazily, caches it on collapse/re-expand, and never re-fetches', async () => {
+    const listDir = makeListDir();
+    render(<FileTree listDir={listDir} selectedPath={null} onSelectFile={vi.fn()} />);
+
+    const areas = await screen.findByRole('treeitem', { name: 'areas' });
+    expect(areas).toHaveAttribute('aria-expanded', 'false');
+    expect(listDir).not.toHaveBeenCalledWith('areas');
+
+    // Expand: areas/ is listed and its child appears.
+    fireEvent.click(areas);
+    expect(await screen.findByRole('treeitem', { name: 'foo.md' })).toBeInTheDocument();
+    expect(screen.getByRole('treeitem', { name: 'areas' })).toHaveAttribute('aria-expanded', 'true');
+    expect(listDir).toHaveBeenCalledWith('areas');
+    expect(listDir.mock.calls.filter(([p]) => p === 'areas')).toHaveLength(1);
+
+    // Collapse: the child is hidden.
+    fireEvent.click(screen.getByRole('treeitem', { name: 'areas' }));
+    await waitFor(() => expect(screen.queryByRole('treeitem', { name: 'foo.md' })).not.toBeInTheDocument());
+
+    // Re-expand: served from cache, no second fetch for areas/.
+    fireEvent.click(screen.getByRole('treeitem', { name: 'areas' }));
+    expect(await screen.findByRole('treeitem', { name: 'foo.md' })).toBeInTheDocument();
+    expect(listDir.mock.calls.filter(([p]) => p === 'areas')).toHaveLength(1);
+  });
+
+  it('calls onSelectFile when a file is clicked and marks the selected file', async () => {
+    const listDir = makeListDir();
+    const onSelectFile = vi.fn();
+    const { rerender } = render(
+      <FileTree listDir={listDir} selectedPath={null} onSelectFile={onSelectFile} />,
+    );
+
+    const file = await screen.findByRole('treeitem', { name: 'index.md' });
+    fireEvent.click(file);
+    expect(onSelectFile).toHaveBeenCalledWith('index.md');
+    // Clicking a file never triggers a directory listing.
+    expect(listDir).toHaveBeenCalledTimes(1);
+
+    // When it becomes the selection, it is marked current.
+    rerender(<FileTree listDir={listDir} selectedPath="index.md" onSelectFile={onSelectFile} />);
+    expect(screen.getByRole('treeitem', { name: 'index.md' })).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('re-lists the root and any open directory when the change signal bumps', async () => {
+    const listDir = makeListDir();
+    const { rerender } = render(
+      <FileTree listDir={listDir} selectedPath={null} onSelectFile={vi.fn()} changeSignal={0} />,
+    );
+
+    fireEvent.click(await screen.findByRole('treeitem', { name: 'areas' }));
+    await screen.findByRole('treeitem', { name: 'foo.md' });
+    const rootCalls = listDir.mock.calls.filter(([p]) => p === '').length;
+    const areasCalls = listDir.mock.calls.filter(([p]) => p === 'areas').length;
+
+    // A change signal re-lists the root AND the open directory (preserving expansion).
+    rerender(<FileTree listDir={listDir} selectedPath={null} onSelectFile={vi.fn()} changeSignal={1} />);
+    await waitFor(() => {
+      expect(listDir.mock.calls.filter(([p]) => p === '').length).toBe(rootCalls + 1);
+      expect(listDir.mock.calls.filter(([p]) => p === 'areas').length).toBe(areasCalls + 1);
+    });
+    expect(screen.getByRole('treeitem', { name: 'foo.md' })).toBeInTheDocument();
+  });
+
+  it('surfaces a directory listing error without blanking the tree', async () => {
+    const listDir = vi
+      .fn<(path: string) => Promise<FsEntry[]>>()
+      .mockRejectedValue(new Error('fsdoc: permission denied'));
+    render(<FileTree listDir={listDir} selectedPath={null} onSelectFile={vi.fn()} />);
+
+    expect(await screen.findByText('fsdoc: permission denied')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/notebook/FileTree.tsx
+++ b/app/src/components/notebook/FileTree.tsx
@@ -1,0 +1,221 @@
+// A lazy filesystem tree over the daemon's generic fs surface. It renders the real
+// folder hierarchy under the root: the root's immediate children on mount, and each
+// directory's children only when it is expanded (one fs_list per opened node — the
+// tree never walks the whole disk up front). Files are selectable; directories
+// toggle open/closed. An fs_changed bump re-lists the root and every open directory
+// so external/agent edits surface without losing the user's expansion state.
+//
+// This component is purely presentational over the injected `listDir` — it knows
+// nothing about the websocket — so it is unit-testable with a mock and reusable
+// wherever a filesystem tree is needed (the notebook browser is the first consumer).
+
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+import type { FsEntry } from '../../hooks/useDaemonSocket';
+import './FileTree.css';
+
+interface FileTreeProps {
+  // List one directory's immediate children. '' = the root directory itself.
+  listDir: (path: string) => Promise<FsEntry[]>;
+  // The currently selected FILE path (root-relative), highlighted in the tree.
+  selectedPath: string | null;
+  // A file node was activated (clicked). Directories never call this — they toggle.
+  onSelectFile: (path: string) => void;
+  // Bumped whenever fs content changes, so the tree re-lists its open directories.
+  changeSignal?: number;
+}
+
+// The root directory's key in the children/expanded/loading maps. Kept distinct from
+// any real entry path (entry paths are always non-empty) so the root never collides.
+const ROOT = '';
+
+export function FileTree({ listDir, selectedPath, onSelectFile, changeSignal = 0 }: FileTreeProps) {
+  // Per-directory listing cache (key = directory path, ROOT for the root). Presence
+  // of a key means that directory has been listed at least once.
+  const [children, setChildren] = useState<Map<string, FsEntry[]>>(new Map());
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState<Set<string>>(new Set());
+  const [errors, setErrors] = useState<Map<string, string>>(new Map());
+
+  // Avoid setting state after unmount (a slow list resolving post-close).
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const markLoading = useCallback((dir: string, on: boolean) => {
+    setLoading((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(dir);
+      else next.delete(dir);
+      return next;
+    });
+  }, []);
+
+  // List one directory and fold the result into the caches. Errors are recorded per
+  // directory (so one failed node does not blank the rest); a successful list clears
+  // any prior error for that directory.
+  const loadDir = useCallback(
+    async (dir: string) => {
+      markLoading(dir, true);
+      try {
+        const entries = await listDir(dir);
+        if (!mountedRef.current) return;
+        setChildren((prev) => new Map(prev).set(dir, entries));
+        setErrors((prev) => {
+          if (!prev.has(dir)) return prev;
+          const next = new Map(prev);
+          next.delete(dir);
+          return next;
+        });
+      } catch (err) {
+        if (!mountedRef.current) return;
+        setErrors((prev) =>
+          new Map(prev).set(dir, err instanceof Error ? err.message : 'Could not list this folder'),
+        );
+      } finally {
+        if (mountedRef.current) markLoading(dir, false);
+      }
+    },
+    [listDir, markLoading],
+  );
+
+  // List the root on mount.
+  useEffect(() => {
+    void loadDir(ROOT);
+    // loadDir is stable for a stable listDir; we intentionally list once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadDir]);
+
+  // Re-list the root and every open directory when fs content changes, preserving
+  // expansion. (Skip the initial 0 so this does not double-list on mount.)
+  useEffect(() => {
+    if (changeSignal === 0) return;
+    void loadDir(ROOT);
+    for (const dir of expanded) void loadDir(dir);
+    // expanded is read as a live snapshot; we don't want to re-run when it changes,
+    // only when the change signal bumps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [changeSignal, loadDir]);
+
+  // Toggle a directory open/closed. List it on first open (no cached listing yet);
+  // a re-open reuses the cache. `expanded`/`children` are read from the closure
+  // (both are deps), so the load decision is made outside any setState updater —
+  // updaters must stay pure (StrictMode invokes them twice).
+  const toggleDir = useCallback(
+    (dir: string) => {
+      const isOpen = expanded.has(dir);
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(dir)) next.delete(dir);
+        else next.add(dir);
+        return next;
+      });
+      if (!isOpen && !children.has(dir)) void loadDir(dir);
+    },
+    [expanded, children, loadDir],
+  );
+
+  // Render one directory's entries at the given depth. Recurses into open
+  // subdirectories. Returns null when the directory has not been listed yet.
+  const renderDir = (dir: string, depth: number) => {
+    const entries = children.get(dir);
+    const isLoading = loading.has(dir);
+    const error = errors.get(dir);
+
+    if (error) {
+      return (
+        <li className="file-tree-state file-tree-error" style={indent(depth)} role="treeitem">
+          {error}
+        </li>
+      );
+    }
+    if (entries === undefined) {
+      return isLoading ? (
+        <li className="file-tree-state" style={indent(depth)} role="treeitem">
+          Loading…
+        </li>
+      ) : null;
+    }
+    if (entries.length === 0) {
+      return (
+        <li className="file-tree-state file-tree-empty" style={indent(depth)} role="treeitem">
+          Empty
+        </li>
+      );
+    }
+    return entries.map((entry) =>
+      entry.isDir ? (
+        <li key={entry.path} role="none">
+          <button
+            type="button"
+            role="treeitem"
+            aria-expanded={expanded.has(entry.path)}
+            className="file-tree-row file-tree-dir"
+            style={indent(depth)}
+            onClick={() => toggleDir(entry.path)}
+            title={entry.path}
+          >
+            <span className={`file-tree-chevron${expanded.has(entry.path) ? ' is-open' : ''}`} aria-hidden="true">
+              ▸
+            </span>
+            <span className="file-tree-name">{entry.name}</span>
+          </button>
+          {expanded.has(entry.path) && (
+            <ul role="group" className="file-tree-group">
+              {renderDir(entry.path, depth + 1)}
+            </ul>
+          )}
+        </li>
+      ) : (
+        <li key={entry.path} role="none">
+          <button
+            type="button"
+            role="treeitem"
+            aria-current={entry.path === selectedPath ? 'true' : undefined}
+            className={`file-tree-row file-tree-file${entry.path === selectedPath ? ' is-selected' : ''}`}
+            style={indent(depth)}
+            onClick={() => onSelectFile(entry.path)}
+            title={entry.path}
+          >
+            <span className="file-tree-name">{entry.name}</span>
+          </button>
+        </li>
+      ),
+    );
+  };
+
+  const rootEntries = children.get(ROOT);
+  const rootLoading = loading.has(ROOT);
+  const rootError = errors.get(ROOT);
+
+  return (
+    <ul className="file-tree" role="tree" aria-label="Files">
+      {rootError ? (
+        <li className="file-tree-state file-tree-error" role="treeitem">
+          {rootError}
+        </li>
+      ) : rootEntries === undefined ? (
+        rootLoading ? (
+          <li className="file-tree-state" role="treeitem">
+            Loading…
+          </li>
+        ) : null
+      ) : rootEntries.length === 0 ? (
+        <li className="file-tree-state file-tree-empty" role="treeitem">
+          This folder is empty.
+        </li>
+      ) : (
+        renderDir(ROOT, 0)
+      )}
+    </ul>
+  );
+}
+
+// Indent a row by its depth. Kept as inline padding (not a per-depth class) so the
+// tree nests to any depth without a fixed ladder of CSS rules.
+function indent(depth: number): CSSProperties {
+  return { paddingLeft: `${8 + depth * 14}px` };
+}

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -2905,3 +2905,156 @@ describe('useDaemonSocket workflow runs', () => {
     unmount();
   });
 });
+
+describe('useDaemonSocket fs surface', () => {
+  let originalWebSocket: typeof WebSocket;
+
+  beforeEach(() => {
+    originalWebSocket = globalThis.WebSocket;
+    FakeWebSocket.instances = [];
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+    vi.clearAllMocks();
+  });
+
+  function renderFsHook(extra: Record<string, unknown> = {}) {
+    return renderHook(() =>
+      useDaemonSocket({
+        onSessionsUpdate: vi.fn(),
+        onWorkspacesUpdate: vi.fn(),
+        onPRsUpdate: vi.fn(),
+        onReposUpdate: vi.fn(),
+        onAuthorsUpdate: vi.fn(),
+        wsUrl: 'ws://localhost:9999/ws',
+        ...extra,
+      }),
+    );
+  }
+
+  // The last command the daemon would have received, parsed (request_id correlates
+  // the result event the test then emits).
+  function lastSent(ws: FakeWebSocket): { cmd: string; request_id: string; [k: string]: unknown } {
+    return JSON.parse(ws.sent[ws.sent.length - 1]);
+  }
+
+  it('sends fs_list and resolves entries, converting is_dir to isDir', async () => {
+    const { result, unmount } = renderFsHook();
+    const ws = await waitForOpenSocket();
+
+    const promise = result.current.sendFsList('knowledge');
+    await Promise.resolve();
+    const sent = lastSent(ws);
+    expect(sent.cmd).toBe('fs_list');
+    expect(sent.path).toBe('knowledge');
+
+    ws.emit({
+      event: 'fs_list_result',
+      request_id: sent.request_id,
+      success: true,
+      entries: [
+        { path: 'knowledge/areas', name: 'areas', is_dir: true, size: 0 },
+        { path: 'knowledge/index.md', name: 'index.md', is_dir: false, size: 12, modified: '2026-06-20T00:00:00Z' },
+      ],
+    });
+
+    await expect(promise).resolves.toEqual([
+      { path: 'knowledge/areas', name: 'areas', isDir: true, size: 0, modified: undefined },
+      { path: 'knowledge/index.md', name: 'index.md', isDir: false, size: 12, modified: '2026-06-20T00:00:00Z' },
+    ]);
+    unmount();
+  });
+
+  it('omits path from fs_list when listing the root', async () => {
+    const { result, unmount } = renderFsHook();
+    const ws = await waitForOpenSocket();
+
+    const promise = result.current.sendFsList();
+    await Promise.resolve();
+    const sent = lastSent(ws);
+    expect(sent.cmd).toBe('fs_list');
+    expect('path' in sent).toBe(false);
+
+    ws.emit({ event: 'fs_list_result', request_id: sent.request_id, success: true, entries: [] });
+    await expect(promise).resolves.toEqual([]);
+    unmount();
+  });
+
+  it('resolves fs_read with the file content and hash', async () => {
+    const { result, unmount } = renderFsHook();
+    const ws = await waitForOpenSocket();
+
+    const promise = result.current.sendFsRead('notes/todo.txt');
+    await Promise.resolve();
+    const sent = lastSent(ws);
+    expect(sent).toMatchObject({ cmd: 'fs_read', path: 'notes/todo.txt' });
+
+    ws.emit({
+      event: 'fs_read_result',
+      request_id: sent.request_id,
+      success: true,
+      result: { path: 'notes/todo.txt', content: 'buy milk', hash: 'h1' },
+    });
+    await expect(promise).resolves.toEqual({ path: 'notes/todo.txt', content: 'buy milk', hash: 'h1' });
+    unmount();
+  });
+
+  it('rejects fs_read on a failed result', async () => {
+    const { result, unmount } = renderFsHook();
+    const ws = await waitForOpenSocket();
+
+    const promise = result.current.sendFsRead('gone.txt');
+    await Promise.resolve();
+    const sent = lastSent(ws);
+    ws.emit({ event: 'fs_read_result', request_id: sent.request_id, success: false, error: 'fsdoc: gone.txt not found' });
+
+    await expect(promise).rejects.toThrow(/not found/);
+    unmount();
+  });
+
+  it('resolves fs_write, mapping current_hash to currentHash on a conflict', async () => {
+    const { result, unmount } = renderFsHook();
+    const ws = await waitForOpenSocket();
+
+    // A successful (non-conflict) write.
+    const ok = result.current.sendFsWrite('a.txt', 'v1');
+    await Promise.resolve();
+    let sent = lastSent(ws);
+    expect(sent).toMatchObject({ cmd: 'fs_write', path: 'a.txt', content: 'v1' });
+    expect('base_hash' in sent).toBe(false);
+    ws.emit({
+      event: 'fs_write_result',
+      request_id: sent.request_id,
+      success: true,
+      result: { path: 'a.txt', hash: 'h2', conflict: false },
+    });
+    await expect(ok).resolves.toEqual({ path: 'a.txt', hash: 'h2', conflict: false, currentHash: undefined });
+
+    // A stale-base conflict: still a resolved result, with current_hash mapped.
+    const conflicting = result.current.sendFsWrite('a.txt', 'v2', 'deadbeef');
+    await Promise.resolve();
+    sent = lastSent(ws);
+    expect(sent.base_hash).toBe('deadbeef');
+    ws.emit({
+      event: 'fs_write_result',
+      request_id: sent.request_id,
+      success: true,
+      result: { path: 'a.txt', conflict: true, current_hash: 'h2' },
+    });
+    await expect(conflicting).resolves.toMatchObject({ conflict: true, currentHash: 'h2' });
+    unmount();
+  });
+
+  it('invokes onFsChanged with origin and paths', async () => {
+    const onFsChanged = vi.fn();
+    const { unmount } = renderFsHook({ onFsChanged });
+    const ws = await waitForOpenSocket();
+
+    act(() => {
+      ws.emit({ event: 'fs_changed', origin: 'ui', paths: ['notes/todo.txt'] });
+    });
+    expect(onFsChanged).toHaveBeenCalledWith('ui', ['notes/todo.txt']);
+    unmount();
+  });
+});

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -442,6 +442,35 @@ export interface NotebookSendToChiefResult {
   nudged: boolean;
 }
 
+// One child of a listed directory in the generic filesystem surface (fs_list).
+// isDir distinguishes a subdirectory (expand with another fs_list) from a file
+// (open with fs_read). Mirrors the daemon's protocol.FsEntry (is_dir on the wire).
+export interface FsEntry {
+  path: string;
+  name: string;
+  isDir: boolean;
+  size: number;
+  modified?: string;
+}
+
+// The full bytes of one file plus its content hash (for hash-CAS edits). Mirrors
+// the daemon's protocol.FsReadResult.
+export interface FsReadResult {
+  path: string;
+  content: string;
+  hash: string;
+}
+
+// The outcome of a filesystem hash-CAS save. conflict=true means the file changed
+// on disk since it was loaded, so the write did NOT apply; currentHash is the hash
+// now on disk. Same contract as NotebookWriteResult; mirrors protocol.FsWriteResult.
+export interface FsWriteResult {
+  path: string;
+  hash?: string;
+  conflict: boolean;
+  currentHash?: string;
+}
+
 interface UseDaemonSocketOptions {
   onSessionsUpdate: (sessions: DaemonSession[]) => void;
   // Fired when notebook content changes (any client/agent/external write). paths
@@ -451,6 +480,10 @@ interface UseDaemonSocketOptions {
   // transition: queue/run/retry/fail/done). Carries no payload — an open Tasks
   // panel refetches via notebook_task_list to reflect truth.
   onNotebookTasksChanged?: () => void;
+  // Fired when files under the root change (any client/agent/external write). paths
+  // are root-relative; origin is agent|ui|external. Mirrors onNotebookChanged for
+  // the generic filesystem surface (fs_changed).
+  onFsChanged?: (origin: string, paths: string[]) => void;
   onChiefOfStaffDispatchesUpdate?: (dispatches: ChiefOfStaffDispatch[]) => void;
   onWorkspacesUpdate: (workspaces: DaemonWorkspace[]) => void;
   onPRsUpdate: (prs: DaemonPR[]) => void;
@@ -733,6 +766,7 @@ export function useDaemonSocket({
   onSessionsUpdate,
   onNotebookChanged,
   onNotebookTasksChanged,
+  onFsChanged,
   onChiefOfStaffDispatchesUpdate,
   onWorkspacesUpdate,
   onPRsUpdate,
@@ -763,6 +797,7 @@ export function useDaemonSocket({
     onSessionsUpdate,
     onNotebookChanged,
     onNotebookTasksChanged,
+    onFsChanged,
     onChiefOfStaffDispatchesUpdate,
     onWorkspacesUpdate,
     onPRsUpdate,
@@ -782,6 +817,7 @@ export function useDaemonSocket({
     onSessionsUpdate,
     onNotebookChanged,
     onNotebookTasksChanged,
+    onFsChanged,
     onChiefOfStaffDispatchesUpdate,
     onWorkspacesUpdate,
     onPRsUpdate,
@@ -1477,6 +1513,93 @@ export function useDaemonSocket({
             // reflects the runner's truth (no optimistic mutation here).
             callbacksRef.current.onNotebookTasksChanged?.();
             break;
+
+          case 'fs_changed':
+            callbacksRef.current.onFsChanged?.(
+              typeof data.origin === 'string' ? data.origin : '',
+              Array.isArray(data.paths) ? data.paths : [],
+            );
+            break;
+
+          case 'fs_list_result': {
+            const requestId = data.request_id;
+            if (typeof requestId !== 'string') {
+              break;
+            }
+            const key = `fs_list:${requestId}`;
+            const pending = pendingActionsRef.current.get(key);
+            if (!pending) {
+              break;
+            }
+            pendingActionsRef.current.delete(key);
+            if (data.success) {
+              // Convert the wire's is_dir to the camelCase public FsEntry shape.
+              const rawEntries = (data.entries || []) as Array<{
+                path: string;
+                name: string;
+                is_dir?: boolean;
+                size?: number;
+                modified?: string;
+              }>;
+              pending.resolve(
+                rawEntries.map((e) => ({
+                  path: e.path,
+                  name: e.name,
+                  isDir: !!e.is_dir,
+                  size: typeof e.size === 'number' ? e.size : 0,
+                  modified: e.modified,
+                })),
+              );
+            } else {
+              pending.reject(new Error(data.error || 'Filesystem list failed'));
+            }
+            break;
+          }
+
+          case 'fs_read_result': {
+            const requestId = data.request_id;
+            if (typeof requestId !== 'string') {
+              break;
+            }
+            const key = `fs_read:${requestId}`;
+            const pending = pendingActionsRef.current.get(key);
+            if (!pending) {
+              break;
+            }
+            pendingActionsRef.current.delete(key);
+            if (data.success && data.result) {
+              pending.resolve(data.result);
+            } else {
+              pending.reject(new Error(data.error || 'Filesystem read failed'));
+            }
+            break;
+          }
+
+          case 'fs_write_result': {
+            const requestId = data.request_id;
+            if (typeof requestId !== 'string') {
+              break;
+            }
+            const key = `fs_write:${requestId}`;
+            const pending = pendingActionsRef.current.get(key);
+            if (!pending) {
+              break;
+            }
+            pendingActionsRef.current.delete(key);
+            if (data.success && data.result) {
+              // A conflict is a SUCCESSFUL result the editor reconciles, not a
+              // rejection — only a transport/daemon error rejects.
+              pending.resolve({
+                path: data.result.path,
+                hash: data.result.hash,
+                conflict: !!data.result.conflict,
+                currentHash: data.result.current_hash,
+              });
+            } else {
+              pending.reject(new Error(data.error || 'Filesystem write failed'));
+            }
+            break;
+          }
 
           case 'notebook_list_result':
           case 'notebook_backlinks_result': {
@@ -3893,6 +4016,73 @@ export function useDaemonSocket({
     });
   }, [nextRequestID]);
 
+  // List one directory's immediate children over the generic filesystem surface.
+  // Omit/empty path = the root directory. Shallow: a tree expands lazily, one call
+  // per node.
+  const sendFsList = useCallback((path?: string): Promise<FsEntry[]> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('fs_list');
+      const key = `fs_list:${requestId}`;
+      pendingActionsRef.current.set(key, { resolve, reject });
+      ws.send(JSON.stringify({ cmd: 'fs_list', request_id: requestId, ...(path ? { path } : {}) }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Filesystem list timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
+  // Read one file's full bytes + content hash.
+  const sendFsRead = useCallback((path: string): Promise<FsReadResult> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('fs_read');
+      const key = `fs_read:${requestId}`;
+      pendingActionsRef.current.set(key, { resolve, reject });
+      ws.send(JSON.stringify({ cmd: 'fs_read', request_id: requestId, path }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Filesystem read timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
+  // Save one file via the daemon (hash-CAS). Omit baseHash to create-only; pass the
+  // file's loaded hash to edit. Resolves with the outcome — including a conflict
+  // (resolve, not reject) the editor reconciles; rejects only on a transport error.
+  const sendFsWrite = useCallback((path: string, content: string, baseHash?: string): Promise<FsWriteResult> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('fs_write');
+      const key = `fs_write:${requestId}`;
+      pendingActionsRef.current.set(key, { resolve, reject });
+      ws.send(JSON.stringify({ cmd: 'fs_write', request_id: requestId, path, content, ...(baseHash ? { base_hash: baseHash } : {}) }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Filesystem save timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
   // Get recent locations from daemon
   const sendGetRecentLocations = useCallback((endpointId?: string, limit?: number): Promise<RecentLocationsResult> => {
     return new Promise((resolve, reject) => {
@@ -4636,6 +4826,9 @@ export function useDaemonSocket({
     sendNotebookBacklinks,
     sendNotebookWrite,
     sendNotebookToChief,
+    sendFsList,
+    sendFsRead,
+    sendFsWrite,
     sendGetRecentLocations,
     sendBrowseDirectory,
     sendInspectPath,

--- a/app/test-harness/harnesses/FileTreeHarness.tsx
+++ b/app/test-harness/harnesses/FileTreeHarness.tsx
@@ -1,0 +1,65 @@
+/**
+ * FileTree Test Harness
+ *
+ * Renders the lazy filesystem tree in a real browser against an in-memory fixture
+ * tree, so the lazy expand/collapse, selection highlight, and theming can be
+ * exercised and eyeballed. listDir resolves from the fixture with a small delay so
+ * the "Loading…" state is observable; every call is recorded for assertions.
+ */
+import { useCallback, useEffect, useState } from 'react';
+// Pull in the app's design tokens (--color-*, --accent) so the tree renders with the
+// real theme rather than undefined variables.
+import '../../src/App.css';
+import { FileTree } from '../../src/components/notebook/FileTree';
+import type { FsEntry } from '../../src/hooks/useDaemonSocket';
+import type { HarnessProps } from '../types';
+
+// A small fixture filesystem: a PARA-shaped notebook root with a couple of nested
+// folders and files. listDir returns the immediate children of a directory.
+const TREE: Record<string, FsEntry[]> = {
+  '': [
+    { path: 'areas', name: 'areas', isDir: true, size: 0 },
+    { path: 'resources', name: 'resources', isDir: true, size: 0 },
+    { path: 'index.md', name: 'index.md', isDir: false, size: 128, modified: '2026-06-20T09:00:00Z' },
+    { path: 'README', name: 'README', isDir: false, size: 64 },
+  ],
+  areas: [
+    { path: 'areas/hiring', name: 'hiring', isDir: true, size: 0 },
+    { path: 'areas/roadmap.md', name: 'roadmap.md', isDir: false, size: 240 },
+  ],
+  'areas/hiring': [{ path: 'areas/hiring/pipeline.md', name: 'pipeline.md', isDir: false, size: 96 }],
+  resources: [
+    { path: 'resources/links.md', name: 'links.md', isDir: false, size: 48 },
+    { path: 'resources/diagram.png', name: 'diagram.png', isDir: false, size: 4096 },
+  ],
+};
+
+export function FileTreeHarness({ onReady, setTriggerRerender }: HarnessProps) {
+  const [selectedPath, setSelectedPath] = useState<string | null>('index.md');
+
+  const listDir = useCallback(async (path: string): Promise<FsEntry[]> => {
+    window.__HARNESS__.recordCall('listDir', [path]);
+    // Small delay so the lazy "Loading…" state is visible during expansion.
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    return TREE[path] ?? [];
+  }, []);
+
+  const onSelectFile = useCallback((path: string) => {
+    window.__HARNESS__.recordCall('onSelectFile', [path]);
+    setSelectedPath(path);
+  }, []);
+
+  useEffect(() => {
+    // The app defaults to the dark theme; force it so the harness is deterministic
+    // regardless of the runner's OS color scheme.
+    document.documentElement.setAttribute('data-theme', 'dark');
+    setTriggerRerender(() => {});
+    onReady();
+  }, [onReady, setTriggerRerender]);
+
+  return (
+    <div style={{ width: 320, padding: 12, background: 'var(--color-bg-app)', minHeight: '100vh' }}>
+      <FileTree listDir={listDir} selectedPath={selectedPath} onSelectFile={onSelectFile} />
+    </div>
+  );
+}

--- a/app/test-harness/harnesses/index.ts
+++ b/app/test-harness/harnesses/index.ts
@@ -7,6 +7,7 @@ import type { HarnessProps } from '../types';
 import { DashboardPRsHarness } from './DashboardPRsHarness';
 import { DiffDetailPanelHarness } from './DiffDetailPanelHarness';
 import { DiffViewHarness } from './DiffViewHarness';
+import { FileTreeHarness } from './FileTreeHarness';
 import { GridLayoutControlHarness } from './GridLayoutControlHarness';
 import { GridViewHarness } from './GridViewHarness';
 import { LiveMarkdownEditorHarness } from './LiveMarkdownEditorHarness';
@@ -17,6 +18,7 @@ export const harnesses: Record<string, React.ComponentType<HarnessProps>> = {
   DashboardPRs: DashboardPRsHarness,
   DiffDetailPanel: DiffDetailPanelHarness,
   DiffView: DiffViewHarness,
+  FileTree: FileTreeHarness,
   GridLayoutControl: GridLayoutControlHarness,
   GridView: GridViewHarness,
   LiveMarkdownEditor: LiveMarkdownEditorHarness,


### PR DESCRIPTION
## What

First of two PRs rebuilding the Notebook browser onto the generic filesystem surface (daemon side merged in #366). This PR is the **frontend building blocks**; the NotebookBrowser integration follows in a second PR so each stays small and reviewable.

### `useDaemonSocket`
- `FsEntry` / `FsReadResult` / `FsWriteResult` types mirroring the daemon protocol (`is_dir`/`current_hash` on the wire → camelCase here).
- `sendFsList` / `sendFsRead` / `sendFsWrite` senders using the standard request/result pattern keyed `cmd:requestId`. As with `notebook_write`, a hash-CAS **conflict resolves** (the editor reconciles it) rather than rejecting — only a transport/daemon error rejects.
- `onFsChanged` option wired to the `fs_changed` event.

### `FileTree`
- A lazy folder tree over the fs surface: lists the root on mount and each directory's children **only when expanded** — one `fs_list` per opened node, never a full-disk walk.
- Per-directory listing cache (re-expand reuses it, no refetch), selectable files with `aria-current`, per-node error rows so one failed folder doesn't blank the tree, and an `fs_changed`-driven re-list that preserves expansion state.
- Purely presentational over an injected `listDir` — knows nothing about the websocket — so it's unit-testable with a mock and reusable beyond the notebook.

## Testing
- `FileTree.test.tsx`: lazy-list-on-mount, lazy-expand-fetches-once (+cache on re-expand), file select → `onSelectFile` + selection mark, `changeSignal` re-lists root + open dirs, per-directory error row.
- `useDaemonSocket.test.tsx`: new `fs surface` block — list (`is_dir`→`isDir`), root omits `path`, read resolve/reject, write conflict mapping (`current_hash`→`currentHash`) + `base_hash`, `onFsChanged`.
- Browser harness at `/test-harness/?component=FileTree`.
- Full suite: **1040 passed**, `tsc` clean.

## Not in this PR
- No user-visible change yet — `FileTree` isn't wired into any rendered UI. That (replacing the PARA groups + switching the editor onto `fs_read`/`fs_write`) is PR-2. Hence no CHANGELOG entry here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)