### PR TITLE
fix(app): clean "Session ended" instead of "[Process exited with code 143]"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Broken Notebook links are flagged as you write.** When a note links to another note that doesn't exist — a typo in the path, or a note you haven't created yet — the link now shows in red with a ⚠ instead of looking like a working link. Links to real notes stay normal, and external links (http/https, email) are never flagged. If an agent or you create the missing note, its links clear their flag once the Notebook refreshes.
 
+### Fixed
+- **A finished session now ends cleanly instead of looking like a crash.** When a session is stopped, closed, or wraps up its work, attn tears it down with a normal termination signal — but the terminal used to report that as a bare `[Process exited with code 143]`, which reads like something broke. Expected endings (a clean exit, or a normal stop/close) now show a calm `[Session ended]`. Genuine failures — a non-zero exit code, or a crash/force-kill — still show the exit code so real problems stay visible.
+
 ## [2026-06-20]
 
 ### Changed

--- a/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
+++ b/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { ptyAttach, ptyDetach, ptyResize, ptyWrite, type PtyEventPayload } from '../../pty/bridge';
+import { formatExitNotice } from '../../pty/exitNotice';
 import { isSuspiciousTerminalSize } from '../../utils/terminalDebug';
 import { recordFocus } from '../../utils/terminalDiagnosticsLog';
 import type { PaneRuntimeEventRouter } from './paneRuntimeEventRouter';
@@ -141,7 +142,7 @@ export function useGhosttyPaneRuntime(
         terminal.reset();
         break;
       case 'exit':
-        void terminal.write(`\r\n[Process exited with code ${event.code}]\r\n`);
+        void terminal.write(`\r\n${formatExitNotice(event.code, event.signal)}\r\n`);
         break;
       case 'error':
         void terminal.write(`\r\n[Error: ${event.error}]\r\n`);

--- a/app/src/pty/exitNotice.test.ts
+++ b/app/src/pty/exitNotice.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { formatExitNotice } from './exitNotice';
+
+describe('formatExitNotice', () => {
+  it('treats a clean exit (code 0, no signal) as a session end', () => {
+    expect(formatExitNotice(0)).toBe('[Session ended]');
+  });
+
+  it('treats SIGTERM (143) — attn\'s normal teardown signal — as a session end, not a crash', () => {
+    // This is the regression case: a completed dispatch torn down with SIGTERM
+    // used to surface as the scary "[Process exited with code 143]".
+    expect(formatExitNotice(143)).toBe('[Session ended]');
+  });
+
+  it('treats SIGINT (130) and SIGHUP (129) as a session end', () => {
+    expect(formatExitNotice(130)).toBe('[Session ended]');
+    expect(formatExitNotice(129)).toBe('[Session ended]');
+  });
+
+  it('honors an explicit graceful signal name regardless of code', () => {
+    expect(formatExitNotice(143, 'SIGTERM')).toBe('[Session ended]');
+    expect(formatExitNotice(0, 'SIGTERM')).toBe('[Session ended]');
+    expect(formatExitNotice(1, 'sigterm')).toBe('[Session ended]');
+    expect(formatExitNotice(1, 'term')).toBe('[Session ended]');
+  });
+
+  it('keeps the raw exit code for a non-zero application exit', () => {
+    expect(formatExitNotice(1)).toBe('[Process exited with code 1]');
+    expect(formatExitNotice(2)).toBe('[Process exited with code 2]');
+  });
+
+  it('keeps the raw exit code for genuine crash/force-kill signals', () => {
+    expect(formatExitNotice(137)).toBe('[Process exited with code 137]'); // SIGKILL / OOM
+    expect(formatExitNotice(139)).toBe('[Process exited with code 139]'); // SIGSEGV
+    expect(formatExitNotice(134)).toBe('[Process exited with code 134]'); // SIGABRT
+  });
+
+  it('reports a non-zero code even at code 0 when a crash signal is attached', () => {
+    expect(formatExitNotice(0, 'SIGKILL')).toBe('[Process exited with code 0]');
+  });
+});

--- a/app/src/pty/exitNotice.ts
+++ b/app/src/pty/exitNotice.ts
@@ -1,0 +1,43 @@
+// Human-facing terminal notice for a PTY process exit.
+//
+// The attn daemon tears sessions down with SIGTERM (exit code 143) on normal
+// completion, stop, and pane-close — see `terminateSession`/`unregisterSession`
+// in `internal/daemon`. Rendering that as a bare "[Process exited with code 143]"
+// reads like a crash, even though the task finished and its work persisted.
+//
+// So we present *expected* terminations — a clean exit, or a teardown signal
+// (SIGTERM/SIGINT/SIGHUP) — as a calm "Session ended", and reserve the raw
+// exit-code notice for genuinely abnormal exits: a non-zero application exit
+// code, an out-of-memory/force kill (SIGKILL → 137), or a crash
+// (SIGSEGV → 139, SIGABRT → 134).
+
+// 128 + N is the conventional shell encoding for "terminated by signal N".
+const SIGNAL_BY_CODE: Record<number, string> = {
+  129: 'SIGHUP',
+  130: 'SIGINT',
+  143: 'SIGTERM',
+};
+
+// Signals that represent an expected, orderly shutdown rather than a fault.
+const GRACEFUL_SIGNALS = new Set(['SIGHUP', 'SIGINT', 'SIGTERM']);
+
+function normalizeSignal(code: number, signal?: string): string | undefined {
+  const trimmed = signal?.trim();
+  if (trimmed) {
+    const upper = trimmed.toUpperCase();
+    return upper.startsWith('SIG') ? upper : `SIG${upper}`;
+  }
+  return SIGNAL_BY_CODE[code];
+}
+
+// Returns the line written into the terminal when a session's process exits.
+export function formatExitNotice(code: number, signal?: string): string {
+  if (code === 0 && !signal?.trim()) {
+    return '[Session ended]';
+  }
+  const sig = normalizeSignal(code, signal);
+  if (sig && GRACEFUL_SIGNALS.has(sig)) {
+    return '[Session ended]';
+  }
+  return `[Process exited with code ${code}]`;
+}


### PR DESCRIPTION
## Why

A finished/stopped session is torn down with **SIGTERM** (exit code 143) — see `terminateSession`/`unregisterSession` in `internal/daemon`. The terminal rendered that teardown as a bare `[Process exited with code 143]`, which reads like a crash even though the task completed and its work persisted.

This was surfaced by a real dispatch: an evaluation session finished, called `dispatch report` with a final DONE, saved its result to prod — and the pane showed nothing but `[Process exited with code 143]`.

## What

- New pure helper `app/src/pty/exitNotice.ts` — `formatExitNotice(code, signal)`.
- Wired into the terminal exit-render path in `useGhosttyPaneRuntime.ts` (one line).
- New unit tests `app/src/pty/exitNotice.test.ts`.

### Behavior (before → after)

| exit | before | after |
|------|--------|-------|
| code 0 | `[Process exited with code 0]` | `[Session ended]` |
| 143 (SIGTERM — attn teardown) | `[Process exited with code 143]` | `[Session ended]` |
| 130 / 129 (SIGINT / SIGHUP) | `[Process exited with code N]` | `[Session ended]` |
| 1, 2 (app error) | unchanged | `[Process exited with code N]` |
| 137 / 139 / 134 (SIGKILL / SEGV / ABRT) | unchanged | `[Process exited with code N]` |

SIGTERM is attn's own normal-teardown signal, so 143 is graceful by design. Crash/force-kill signals and non-zero app codes still show the raw code so real failures stay visible.

### Deliberately out of scope

`App.tsx` `handleSessionProcessExit` still auto-closes only on `code 0 && !signal`; a 143 exit keeps the pane open so the final output stays readable. Only the **message wording** changed — the smallest safe fix for the reported complaint.

## Verification

- New `exitNotice` tests: 7/7 pass.
- Full frontend suite: **113 files / 1062 tests** pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
