### PR TITLE
feat(notebook): flag broken in-notebook links (stage 4c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-21]
+
+### Added
+- **Broken Notebook links are flagged as you write.** When a note links to another note that doesn't exist — a typo in the path, or a note you haven't created yet — the link now shows in red with a ⚠ instead of looking like a working link. Links to real notes stay normal, and external links (http/https, email) are never flagged. If an agent or you create the missing note, its links clear their flag once the Notebook refreshes.
+
 ## [2026-06-20]
 
 ### Changed

--- a/app/e2e/broken-links.spec.ts
+++ b/app/e2e/broken-links.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+// Broken-link flagging in the live editor, rendered in a real browser by its dedicated
+// harness (CM cannot mount under happy-dom, and the headless unit tests cannot cover
+// the async existence-check → StateEffect → repaint path). The harness stubs
+// `existsFile` to report any path containing "missing" as absent.
+
+test.describe('LiveMarkdownEditor broken links', () => {
+  test('flags a link to a missing note, leaves real and external links alone', async ({ page }) => {
+    await page.goto('/test-harness/?component=BrokenLinks');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-content');
+
+    // The missing-note link picks up the broken decoration once its async check
+    // resolves and forces a repaint.
+    const broken = page.locator('.cm-md-link-broken');
+    await expect(broken).toHaveCount(1);
+    await expect(broken).toContainText('ghost');
+
+    // The link to a real note is a normal link, never flagged broken.
+    const real = page.locator('.cm-md-link', { hasText: 'real' });
+    await expect(real).toBeVisible();
+    await expect(real).not.toHaveClass(/cm-md-link-broken/);
+
+    // The broken flag is red, distinct from the accent a working link uses.
+    const color = await broken.evaluate((el) => getComputedStyle(el).color);
+    const realColor = await real.evaluate((el) => getComputedStyle(el).color);
+    expect(color).not.toBe(realColor);
+
+    // The existence check ran for the in-notebook links but NEVER for the external one.
+    const checked = await page.evaluate(() => window.__HARNESS__.getCalls('existsFile').map((c) => c[0]));
+    expect(checked).toContain('/knowledge/areas/missing.md');
+    expect(checked).toContain('/knowledge/areas/real.md');
+    expect(checked.some((p: string) => p.includes('example.com'))).toBe(false);
+
+    await page.screenshot({ path: 'test-results/broken-links.png' });
+  });
+
+  test('checks and flags a newly-added broken link when the document changes', async ({ page }) => {
+    await page.goto('/test-harness/?component=BrokenLinks');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-content');
+    await expect(page.locator('.cm-md-link-broken')).toHaveCount(1);
+
+    // Add a second link to a missing note: the docChanged rebuild discovers the new
+    // path, checks it, and flags it once the check resolves.
+    await page.getByTestId('add-missing-link').click();
+    await expect(page.locator('.cm-md-link-broken')).toHaveCount(2);
+
+    const checked = await page.evaluate(() => window.__HARNESS__.getCalls('existsFile').map((c) => c[0]));
+    expect(checked).toContain('/knowledge/areas/missing-extra.md');
+  });
+});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -485,6 +485,7 @@ function App() {
     sendFsList,
     sendFsRead,
     sendFsWrite,
+    sendFsExists,
     sendNotebookTaskList,
     sendNotebookTaskRetry,
     sendNotebookBacklinks,
@@ -637,6 +638,7 @@ function App() {
         sendFsList={sendFsList}
         sendFsRead={sendFsRead}
         sendFsWrite={sendFsWrite}
+        sendFsExists={sendFsExists}
         sendNotebookTaskList={sendNotebookTaskList}
         sendNotebookTaskRetry={sendNotebookTaskRetry}
         sendNotebookBacklinks={sendNotebookBacklinks}
@@ -749,6 +751,7 @@ interface AppContentProps {
   sendFsList: ReturnType<typeof useDaemonSocket>['sendFsList'];
   sendFsRead: ReturnType<typeof useDaemonSocket>['sendFsRead'];
   sendFsWrite: ReturnType<typeof useDaemonSocket>['sendFsWrite'];
+  sendFsExists: ReturnType<typeof useDaemonSocket>['sendFsExists'];
   sendNotebookTaskList: ReturnType<typeof useDaemonSocket>['sendNotebookTaskList'];
   sendNotebookTaskRetry: ReturnType<typeof useDaemonSocket>['sendNotebookTaskRetry'];
   sendNotebookBacklinks: ReturnType<typeof useDaemonSocket>['sendNotebookBacklinks'];
@@ -855,6 +858,7 @@ function AppContent({
   sendFsList,
   sendFsRead,
   sendFsWrite,
+  sendFsExists,
   sendNotebookTaskList,
   sendNotebookTaskRetry,
   sendNotebookBacklinks,
@@ -3795,6 +3799,7 @@ sendFetchPRDetails,
         listDir={sendFsList}
         readFile={sendFsRead}
         writeFile={sendFsWrite}
+        existsFile={sendFsExists}
         backlinksNotebook={sendNotebookBacklinks}
         sendToChief={sendNotebookToChief}
         changeSignal={fsChangeSignal}

--- a/app/src/components/NotebookBrowser.test.tsx
+++ b/app/src/components/NotebookBrowser.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NotebookBrowser, parseNotebookHref } from './NotebookBrowser';
-import type { FsEntry, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult, NotebookTask } from '../hooks/useDaemonSocket';
+import type { FsEntry, FsExistsResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult, NotebookTask } from '../hooks/useDaemonSocket';
 
 // The live editor is CodeMirror-backed, which cannot mount under happy-dom (its
 // async measure pass throws). The real editing experience (live preview, typing,
@@ -106,6 +106,9 @@ function makeProps(overrides: Partial<React.ComponentProps<typeof NotebookBrowse
   const writeFile = vi
     .fn<(path: string, content: string, baseHash?: string) => Promise<FsWriteResult>>()
     .mockImplementation((path) => Promise.resolve({ path, hash: 'h2', conflict: false }));
+  const existsFile = vi
+    .fn<(path: string) => Promise<FsExistsResult>>()
+    .mockImplementation((path) => Promise.resolve({ path, exists: true }));
   const sendToChief = vi
     .fn<(selection: string, sourcePath?: string) => Promise<NotebookSendToChiefResult>>()
     .mockResolvedValue({ path: 'inbox.md', nudged: false });
@@ -121,6 +124,7 @@ function makeProps(overrides: Partial<React.ComponentProps<typeof NotebookBrowse
       readFile,
       backlinksNotebook,
       writeFile,
+      existsFile,
       sendToChief,
       changeSignal: 0,
       listTasks,
@@ -132,6 +136,7 @@ function makeProps(overrides: Partial<React.ComponentProps<typeof NotebookBrowse
     readFile,
     backlinksNotebook,
     writeFile,
+    existsFile,
     sendToChief,
     listTasks,
     retryTask,

--- a/app/src/components/NotebookBrowser.tsx
+++ b/app/src/components/NotebookBrowser.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import FocusTrap from 'focus-trap-react';
-import type { FsEntry, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult, NotebookTask } from '../hooks/useDaemonSocket';
+import type { FsEntry, FsExistsResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult, NotebookTask } from '../hooks/useDaemonSocket';
 import { useEscapeStack } from '../hooks/useEscapeStack';
 import { FileTree } from './notebook/FileTree';
 import { fileKind, isBinaryPath, isMarkdownPath } from './notebook/fileKind';
@@ -19,6 +19,9 @@ interface NotebookBrowserProps {
   // Save an edited file (hash-CAS). Omit baseHash to create-only; pass the file's
   // loaded hash to edit. Resolves with the outcome, including a conflict to reconcile.
   writeFile: (path: string, content: string, baseHash?: string) => Promise<FsWriteResult>;
+  // Check whether an in-notebook link target exists (no read), to flag broken links
+  // in the editor. Only consulted for markdown notes.
+  existsFile: (path: string) => Promise<FsExistsResult>;
   // Backlinks ("Linked from") for a markdown note. Notebook-specific (walks .md link
   // graphs), so it is only consulted for .md files.
   backlinksNotebook: (path: string) => Promise<NotebookEntry[]>;
@@ -63,6 +66,7 @@ export function NotebookBrowser({
   listDir,
   readFile,
   writeFile,
+  existsFile,
   backlinksNotebook,
   sendToChief,
   changeSignal = 0,
@@ -781,6 +785,8 @@ export function NotebookBrowser({
                           onChange={setDraft}
                           onFollowLink={handleFollowLink}
                           onSelectionChange={handleSelectionChange}
+                          existsFile={existsFile}
+                          revalidateSignal={changeSignal}
                           ariaLabel="Note"
                         />
                       ) : (

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -4,10 +4,11 @@
 // cursor's line. The parent owns persistence (hash-CAS autosave); this component only
 // emits value changes, link follows, and the current selection (for "send to chief").
 
-import { forwardRef, useImperativeHandle, useMemo, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { EditorView, type ViewUpdate } from '@codemirror/view';
+import { brokenLinks, revalidateBrokenLinks, type ExistsCheck } from './brokenLinks';
 import { frontmatterCard } from './frontmatterCard';
 import { liveMarkdownPreview } from './liveMarkdownPreview';
 
@@ -33,6 +34,13 @@ interface LiveMarkdownEditorProps {
   onChange: (value: string) => void;
   onFollowLink?: (href: string) => void;
   onSelectionChange?: (selection: LiveSelection | null) => void;
+  // Check whether an in-notebook link target exists, to flag broken links. Omit to
+  // disable the flagging (e.g. the test harness, which has no daemon).
+  existsFile?: (path: string) => Promise<ExistsCheck>;
+  // Bumped whenever the notebook changed on disk; clears the broken-link cache's
+  // "missing" verdicts so a link to a just-created note re-checks. (A change counter,
+  // not data — only its identity change matters.)
+  revalidateSignal?: number;
   ariaLabel?: string;
   autoFocus?: boolean;
 }
@@ -83,6 +91,8 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
   onChange,
   onFollowLink,
   onSelectionChange,
+  existsFile,
+  revalidateSignal,
   ariaLabel,
   autoFocus,
 }, ref) {
@@ -109,10 +119,23 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
       EditorView.lineWrapping,
       frontmatterCard(),
       liveMarkdownPreview({ onFollowLink }),
+      brokenLinks({ existsFile }),
       editorTheme,
     ],
-    [onFollowLink],
+    [onFollowLink, existsFile],
   );
+
+  // When the notebook changed on disk, ask the broken-link checker to re-verify any
+  // links it had flagged missing — a just-created target should clear its flag. The
+  // initial mount is skipped (nothing cached yet); only later bumps revalidate.
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    cmRef.current?.view?.dispatch({ effects: revalidateBrokenLinks.of(null) });
+  }, [revalidateSignal]);
 
   const handleUpdate = useMemo(
     () =>

--- a/app/src/components/notebook/brokenLinks.test.ts
+++ b/app/src/components/notebook/brokenLinks.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { brokenLinkDecorations, notebookLinkPath, notebookLinkPaths } from './brokenLinks';
+
+// The pure helpers work off an EditorState (no view, no daemon), so the broken-link
+// logic is testable headlessly — the async existence cache lives in the plugin, but
+// "which paths to check" and "which links to flag" are pure over the parsed state.
+function stateOf(doc: string): EditorState {
+  return EditorState.create({ doc, extensions: [markdown({ base: markdownLanguage })] });
+}
+
+interface Mark {
+  from: number;
+  to: number;
+  class?: string;
+}
+
+function marksFor(doc: string, missing: (path: string) => boolean): Mark[] {
+  const out: Mark[] = [];
+  const iter = brokenLinkDecorations(stateOf(doc), missing).iter();
+  while (iter.value) {
+    out.push({ from: iter.from, to: iter.to, class: (iter.value.spec as { class?: string }).class });
+    iter.next();
+  }
+  return out;
+}
+
+describe('notebookLinkPath', () => {
+  it('resolves a root-absolute note link to its path', () => {
+    expect(notebookLinkPath('/knowledge/areas/foo.md')).toBe('/knowledge/areas/foo.md');
+  });
+
+  it('resolves a bare (relative) note link unchanged', () => {
+    expect(notebookLinkPath('knowledge/areas/foo.md')).toBe('knowledge/areas/foo.md');
+  });
+
+  it('drops the #fragment and ?query tail (they address within a note)', () => {
+    expect(notebookLinkPath('/knowledge/foo.md#section')).toBe('/knowledge/foo.md');
+    expect(notebookLinkPath('/knowledge/foo.md?v=2')).toBe('/knowledge/foo.md');
+  });
+
+  it('never flags an external URL', () => {
+    expect(notebookLinkPath('http://example.com')).toBeNull();
+    expect(notebookLinkPath('https://example.com/x')).toBeNull();
+    expect(notebookLinkPath('mailto:a@b.com')).toBeNull();
+    expect(notebookLinkPath('file:///etc/hosts')).toBeNull();
+    expect(notebookLinkPath('//cdn.example.com/x')).toBeNull();
+  });
+
+  it('never flags a pure in-document anchor or an empty href', () => {
+    expect(notebookLinkPath('#section')).toBeNull();
+    expect(notebookLinkPath('')).toBeNull();
+    expect(notebookLinkPath('   ')).toBeNull();
+  });
+});
+
+describe('notebookLinkPaths', () => {
+  it('collects only the in-notebook link paths, deduped', () => {
+    const doc = [
+      'See [a](/knowledge/a.md) and [b](https://x.com) and [c](/knowledge/c.md).',
+      'Also [again](/knowledge/a.md) and the [top](#intro).',
+    ].join('\n');
+    expect(notebookLinkPaths(stateOf(doc)).sort()).toEqual(['/knowledge/a.md', '/knowledge/c.md']);
+  });
+
+  it('returns nothing for a document with no in-notebook links', () => {
+    expect(notebookLinkPaths(stateOf('Just [external](https://x.com) here.'))).toEqual([]);
+  });
+});
+
+describe('brokenLinkDecorations', () => {
+  it('flags exactly the links whose target is reported missing', () => {
+    const doc = 'See [gone](/knowledge/gone.md) and [here](/knowledge/here.md).';
+    const missing = (p: string) => p === '/knowledge/gone.md';
+    const marks = marksFor(doc, missing);
+    expect(marks).toHaveLength(1);
+    expect(marks[0].class).toBe('cm-md-link-broken');
+    // The mark spans the whole [text](url) link, not just its text.
+    expect(doc.slice(marks[0].from, marks[0].to)).toBe('[gone](/knowledge/gone.md)');
+  });
+
+  it('flags nothing when every target exists (the predicate reports none missing)', () => {
+    const doc = 'See [a](/knowledge/a.md) and [b](/knowledge/b.md).';
+    expect(marksFor(doc, () => false)).toHaveLength(0);
+  });
+
+  it('never flags an external link even if the predicate would match its raw href', () => {
+    const doc = 'Read [docs](https://example.com/x).';
+    // notebookLinkPath returns null for the URL, so the predicate is never consulted.
+    expect(marksFor(doc, () => true)).toHaveLength(0);
+  });
+});

--- a/app/src/components/notebook/brokenLinks.ts
+++ b/app/src/components/notebook/brokenLinks.ts
@@ -1,0 +1,190 @@
+// Broken-link flags for the live markdown editor. An in-notebook link whose target
+// note does not exist is flagged red with a ⚠, so a typo or a not-yet-created note
+// is visible while you write — matching the prototype's `a.broken` affordance.
+//
+// Existence is checked asynchronously against the daemon (fs_exists), so this lives
+// in its own ViewPlugin rather than the sync `liveMarkdownPreview.buildDecorations`:
+// a result that arrives later forces a rebuild via a refresh effect, and a per-
+// editor cache means each path is checked once, not on every keystroke. External
+// links (http:, mailto:, …) and in-document anchors (#section) are never flagged.
+
+import { syntaxTree } from '@codemirror/language';
+import { type EditorState, type Extension, type Range, StateEffect } from '@codemirror/state';
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+} from '@codemirror/view';
+
+// The outcome of an existence check — the shape of the daemon's FsExistsResult,
+// declared structurally so this module does not depend on the socket hook.
+export interface ExistsCheck {
+  path: string;
+  exists: boolean;
+}
+
+export interface BrokenLinkOptions {
+  // Check whether an in-notebook path exists, without reading it. Resolves with
+  // { exists }. A rejection (transport/daemon error, or a path the daemon refuses
+  // to resolve) leaves the link UNFLAGGED — a link is only ever flagged broken on a
+  // conclusive "does not exist", never on an inconclusive check.
+  existsFile?: (path: string) => Promise<ExistsCheck>;
+}
+
+// Fired when an async existence check resolves: rebuild so a now-known result paints.
+const refreshBrokenLinks = StateEffect.define<null>();
+
+// Fired by the editor when the notebook changed on disk (an agent/external write):
+// drop the cached "missing" verdicts so a link to a just-created note re-checks.
+// "Exists" verdicts are kept — a note rarely vanishes mid-session, and keeping them
+// avoids re-checking every link on the user's own autosave (which also fires this).
+export const revalidateBrokenLinks = StateEffect.define<null>();
+
+const BROKEN = Decoration.mark({
+  class: 'cm-md-link-broken',
+  attributes: { title: 'Link target not found in the notebook' },
+});
+
+// Resolve a link href to the notebook path whose existence decides whether it is
+// broken, or null when the href is not an in-notebook note reference (and so must
+// never be flagged): an external URL (has a scheme like http:/mailto:), a protocol-
+// relative URL, a pure in-document anchor (#section), or empty. The `#fragment` and
+// `?query` tails are dropped — they address a spot within a note, not a file. Both
+// root-absolute (`/knowledge/x.md`) and bare (`knowledge/x.md`) forms resolve the
+// same, mirroring the daemon's root-relative path handling.
+export function notebookLinkPath(href: string): string | null {
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('#')) return null; // in-document anchor
+  if (trimmed.startsWith('//')) return null; // protocol-relative URL
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null; // http:, mailto:, file:, …
+  const path = trimmed.split('#')[0].split('?')[0].trim();
+  return path || null;
+}
+
+// The distinct in-notebook link paths in the document — the set whose existence
+// decides broken-ness. Pure over the parsed state (no view, no daemon) so the
+// plugin's "what do I need to check" logic is unit-testable headlessly.
+export function notebookLinkPaths(state: EditorState): string[] {
+  const seen = new Set<string>();
+  syntaxTree(state).iterate({
+    enter: (node) => {
+      if (node.name !== 'Link') return;
+      const url = node.node.getChild('URL');
+      const href = url ? state.doc.sliceString(url.from, url.to) : '';
+      const path = notebookLinkPath(href);
+      if (path) seen.add(path);
+    },
+  });
+  return [...seen];
+}
+
+// The broken-link marks for the document: a red ⚠ flag over every Link whose target
+// path `missing` reports absent. Pure over the parsed state and a verdict predicate
+// (the plugin backs `missing` with its existence cache), mirroring the headless
+// shape of liveMarkdownPreview.buildDecorations and frontmatterCardDecorations.
+export function brokenLinkDecorations(
+  state: EditorState,
+  missing: (path: string) => boolean,
+): DecorationSet {
+  const decos: Range<Decoration>[] = [];
+  syntaxTree(state).iterate({
+    enter: (node) => {
+      if (node.name !== 'Link') return;
+      const url = node.node.getChild('URL');
+      const href = url ? state.doc.sliceString(url.from, url.to) : '';
+      const path = notebookLinkPath(href);
+      if (path && missing(path)) decos.push(BROKEN.range(node.from, node.to));
+    },
+  });
+  return Decoration.set(decos, true);
+}
+
+export function brokenLinks(options: BrokenLinkOptions = {}): Extension {
+  const { existsFile } = options;
+
+  const plugin = ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+      // path -> exists. A path is checked at most once until a revalidate clears it.
+      private readonly cache = new Map<string, boolean>();
+      // paths with an in-flight check, so concurrent rebuilds don't double-request.
+      private readonly pending = new Set<string>();
+
+      constructor(view: EditorView) {
+        this.decorations = this.build(view);
+      }
+
+      update(update: ViewUpdate) {
+        let revalidated = false;
+        let refreshed = false;
+        for (const tr of update.transactions) {
+          for (const effect of tr.effects) {
+            if (effect.is(revalidateBrokenLinks)) revalidated = true;
+            if (effect.is(refreshBrokenLinks)) refreshed = true;
+          }
+        }
+        if (revalidated) {
+          for (const [path, exists] of this.cache) {
+            if (!exists) this.cache.delete(path);
+          }
+        }
+        if (update.docChanged || update.viewportChanged || refreshed || revalidated) {
+          this.decorations = this.build(update.view);
+        }
+      }
+
+      private build(view: EditorView): DecorationSet {
+        if (!existsFile) return Decoration.none;
+        const paths = notebookLinkPaths(view.state);
+        const toCheck = paths.filter((p) => !this.cache.has(p) && !this.pending.has(p));
+        if (toCheck.length) this.scheduleChecks(view, toCheck);
+        return brokenLinkDecorations(view.state, (p) => this.cache.get(p) === false);
+      }
+
+      private scheduleChecks(view: EditorView, paths: string[]) {
+        if (!existsFile) return;
+        for (const path of paths) {
+          if (this.pending.has(path) || this.cache.has(path)) continue;
+          this.pending.add(path);
+          existsFile(path)
+            .then((res) => {
+              this.cache.set(path, !!res.exists);
+            })
+            .catch(() => {
+              // Inconclusive: record "exists" so an unreachable/invalid check never
+              // paints a false broken flag. A later revalidate will retry it.
+              this.cache.set(path, true);
+            })
+            .finally(() => {
+              this.pending.delete(path);
+              // Repaint with the new verdict. Guard the disposed-view race: a
+              // navigation or unmount can land between request and resolve.
+              if (view.dom.isConnected) {
+                view.dispatch({ effects: refreshBrokenLinks.of(null) });
+              }
+            });
+        }
+      }
+    },
+    { decorations: (v) => v.decorations },
+  );
+
+  const theme = EditorView.baseTheme({
+    // Red, dashed-underlined, with a trailing ⚠ — the prototype's `a.broken`. The
+    // !important on color outranks the overlapping `.cm-md-link` accent (both are
+    // single-class marks wrapping the same range, so specificity alone is a tie).
+    '.cm-md-link-broken': {
+      color: 'var(--color-danger, #e5534b) !important',
+      borderBottom: '1px dashed color-mix(in srgb, var(--color-danger, #e5534b) 50%, transparent)',
+    },
+    '.cm-md-link-broken::after': {
+      content: '" ⚠"',
+      fontSize: '10px',
+    },
+  });
+
+  return [plugin, theme];
+}

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -172,7 +172,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '116';
+export const PROTOCOL_VERSION = '117';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -469,6 +469,14 @@ export interface FsWriteResult {
   hash?: string;
   conflict: boolean;
   currentHash?: string;
+}
+
+// Whether a path exists under the notebook root, without reading it. Used to flag
+// an in-notebook markdown link whose target note is missing. Mirrors the daemon's
+// protocol.FsExistsResult.
+export interface FsExistsResult {
+  path: string;
+  exists: boolean;
 }
 
 interface UseDaemonSocketOptions {
@@ -1597,6 +1605,28 @@ export function useDaemonSocket({
               });
             } else {
               pending.reject(new Error(data.error || 'Filesystem write failed'));
+            }
+            break;
+          }
+
+          case 'fs_exists_result': {
+            const requestId = data.request_id;
+            if (typeof requestId !== 'string') {
+              break;
+            }
+            const key = `fs_exists:${requestId}`;
+            const pending = pendingActionsRef.current.get(key);
+            if (!pending) {
+              break;
+            }
+            pendingActionsRef.current.delete(key);
+            if (data.success && data.result) {
+              pending.resolve({
+                path: data.result.path,
+                exists: !!data.result.exists,
+              });
+            } else {
+              pending.reject(new Error(data.error || 'Filesystem exists check failed'));
             }
             break;
           }
@@ -4083,6 +4113,29 @@ export function useDaemonSocket({
     });
   }, [nextRequestID]);
 
+  // Check whether a path exists under the notebook root, without reading it. Used
+  // to flag in-notebook markdown links whose target note is missing. Rejects on a
+  // transport/daemon error (the caller leaves the link unflagged in that case).
+  const sendFsExists = useCallback((path: string): Promise<FsExistsResult> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('fs_exists');
+      const key = `fs_exists:${requestId}`;
+      pendingActionsRef.current.set(key, { resolve, reject });
+      ws.send(JSON.stringify({ cmd: 'fs_exists', request_id: requestId, path }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Filesystem exists check timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
   // Get recent locations from daemon
   const sendGetRecentLocations = useCallback((endpointId?: string, limit?: number): Promise<RecentLocationsResult> => {
     return new Promise((resolve, reject) => {
@@ -4829,6 +4882,7 @@ export function useDaemonSocket({
     sendFsList,
     sendFsRead,
     sendFsWrite,
+    sendFsExists,
     sendGetRecentLocations,
     sendBrowseDirectory,
     sendInspectPath,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSEntry, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListDispatchMessagesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookTask, NotebookTaskListMessage, NotebookTaskListResultMessage, NotebookTaskRetryMessage, NotebookTaskRetryResultMessage, NotebookTasksChangedMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, ReportDispatchMessage, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListDispatchMessagesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookTask, NotebookTaskListMessage, NotebookTaskListResultMessage, NotebookTaskRetryMessage, NotebookTaskRetryResultMessage, NotebookTasksChangedMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, ReportDispatchMessage, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const acknowledgeDispatchMessage = Convert.toAcknowledgeDispatchMessage(json);
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
@@ -69,6 +69,9 @@
 //   const fileDiffResultMessage = Convert.toFileDiffResultMessage(json);
 //   const fSChangedMessage = Convert.toFSChangedMessage(json);
 //   const fSEntry = Convert.toFSEntry(json);
+//   const fSExistsMessage = Convert.toFSExistsMessage(json);
+//   const fSExistsResult = Convert.toFSExistsResult(json);
+//   const fSExistsResultMessage = Convert.toFSExistsResultMessage(json);
 //   const fSListMessage = Convert.toFSListMessage(json);
 //   const fSListResultMessage = Convert.toFSListResultMessage(json);
 //   const fSReadMessage = Convert.toFSReadMessage(json);
@@ -1335,6 +1338,42 @@ export interface FSEntry {
     name:      string;
     path:      string;
     size:      number;
+    [property: string]: any;
+}
+
+export interface FSExistsMessage {
+    cmd:         FSExistsMessageCmd;
+    path:        string;
+    request_id?: string;
+    [property: string]: any;
+}
+
+export enum FSExistsMessageCmd {
+    FSExists = "fs_exists",
+}
+
+export interface FSExistsResult {
+    exists: boolean;
+    path:   string;
+    [property: string]: any;
+}
+
+export interface FSExistsResultMessage {
+    error?:     string;
+    event:      FSExistsResultMessageEvent;
+    request_id: string;
+    result?:    FSExistsResultMessageResult;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum FSExistsResultMessageEvent {
+    FSExistsResult = "fs_exists_result",
+}
+
+export interface FSExistsResultMessageResult {
+    exists: boolean;
+    path:   string;
     [property: string]: any;
 }
 
@@ -4864,6 +4903,30 @@ export class Convert {
         return JSON.stringify(uncast(value, r("FSEntry")), null, 2);
     }
 
+    public static toFSExistsMessage(json: string): FSExistsMessage {
+        return cast(JSON.parse(json), r("FSExistsMessage"));
+    }
+
+    public static fSExistsMessageToJson(value: FSExistsMessage): string {
+        return JSON.stringify(uncast(value, r("FSExistsMessage")), null, 2);
+    }
+
+    public static toFSExistsResult(json: string): FSExistsResult {
+        return cast(JSON.parse(json), r("FSExistsResult"));
+    }
+
+    public static fSExistsResultToJson(value: FSExistsResult): string {
+        return JSON.stringify(uncast(value, r("FSExistsResult")), null, 2);
+    }
+
+    public static toFSExistsResultMessage(json: string): FSExistsResultMessage {
+        return cast(JSON.parse(json), r("FSExistsResultMessage"));
+    }
+
+    public static fSExistsResultMessageToJson(value: FSExistsResultMessage): string {
+        return JSON.stringify(uncast(value, r("FSExistsResultMessage")), null, 2);
+    }
+
     public static toFSListMessage(json: string): FSListMessage {
         return cast(JSON.parse(json), r("FSListMessage"));
     }
@@ -7483,6 +7546,26 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
         { json: "size", js: "size", typ: 0 },
     ], "any"),
+    "FSExistsMessage": o([
+        { json: "cmd", js: "cmd", typ: r("FSExistsMessageCmd") },
+        { json: "path", js: "path", typ: "" },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "FSExistsResult": o([
+        { json: "exists", js: "exists", typ: true },
+        { json: "path", js: "path", typ: "" },
+    ], "any"),
+    "FSExistsResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("FSExistsResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "result", js: "result", typ: u(undefined, r("FSExistsResultMessageResult")) },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "FSExistsResultMessageResult": o([
+        { json: "exists", js: "exists", typ: true },
+        { json: "path", js: "path", typ: "" },
+    ], "any"),
     "FSListMessage": o([
         { json: "cmd", js: "cmd", typ: r("FSListMessageCmd") },
         { json: "path", js: "path", typ: u(undefined, "") },
@@ -9386,6 +9469,12 @@ const typeMap: any = {
     ],
     "FSChangedMessageEvent": [
         "fs_changed",
+    ],
+    "FSExistsMessageCmd": [
+        "fs_exists",
+    ],
+    "FSExistsResultMessageEvent": [
+        "fs_exists_result",
     ],
     "FSListMessageCmd": [
         "fs_list",

--- a/app/test-harness/harnesses/BrokenLinksHarness.tsx
+++ b/app/test-harness/harnesses/BrokenLinksHarness.tsx
@@ -1,0 +1,69 @@
+/**
+ * BrokenLinks Test Harness
+ *
+ * Renders the live-preview editor in a real browser with an `existsFile` stub, so the
+ * broken-link flagging — which depends on async existence checks resolving and forcing
+ * a CodeMirror repaint — can be exercised end to end (happy-dom can't mount CM, and the
+ * headless unit tests can't cover the async StateEffect repaint path). Dedicated to
+ * broken links so it doesn't collide with the shared LiveMarkdownEditor harness.
+ *
+ * The stub treats any path containing "missing" as absent and everything else as
+ * present, and records each checked path on window.__HARNESS__.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import '../../src/App.css';
+import { LiveMarkdownEditor } from '../../src/components/notebook/LiveMarkdownEditor';
+import type { HarnessProps } from '../types';
+
+const SAMPLE = `# Broken link demo
+
+A link to a real note: [real](/knowledge/areas/real.md).
+
+A link to a missing note: [ghost](/knowledge/areas/missing.md).
+
+An external link, never flagged: [site](https://example.com).
+`;
+
+export function BrokenLinksHarness({ onReady, setTriggerRerender }: HarnessProps) {
+  const [value, setValue] = useState(SAMPLE);
+  const [, force] = useState(0);
+
+  const handleChange = useCallback((next: string) => {
+    window.__HARNESS__.recordCall('change', [next]);
+    setValue(next);
+  }, []);
+
+  const existsFile = useCallback(async (path: string) => {
+    window.__HARNESS__.recordCall('existsFile', [path]);
+    return { path, exists: !path.includes('missing') };
+  }, []);
+
+  // Append a second link to a missing note, so a test can prove a freshly-typed
+  // broken link is checked and flagged after the document changes (the docChanged
+  // re-check path), without fragile in-editor caret manipulation.
+  const addMissingLink = useCallback(() => {
+    setValue((v) => `${v}\nAnother dead one: [extra](/knowledge/areas/missing-extra.md).\n`);
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    setTriggerRerender(() => force((n) => n + 1));
+    onReady();
+  }, [onReady, setTriggerRerender]);
+
+  return (
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', padding: 24, background: 'var(--color-bg-app)' }}>
+      <button type="button" data-testid="add-missing-link" onClick={addMissingLink} style={{ marginBottom: 12 }}>
+        Add missing link
+      </button>
+      <div style={{ flex: 1, minHeight: 0, border: '1px solid var(--color-border)', borderRadius: 8 }}>
+        <LiveMarkdownEditor
+          value={value}
+          onChange={handleChange}
+          existsFile={existsFile}
+          ariaLabel="Note"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/test-harness/harnesses/index.ts
+++ b/app/test-harness/harnesses/index.ts
@@ -4,6 +4,7 @@
  * Register all component harnesses here for the test harness router.
  */
 import type { HarnessProps } from '../types';
+import { BrokenLinksHarness } from './BrokenLinksHarness';
 import { DashboardPRsHarness } from './DashboardPRsHarness';
 import { DiffDetailPanelHarness } from './DiffDetailPanelHarness';
 import { DiffViewHarness } from './DiffViewHarness';
@@ -16,6 +17,7 @@ import { NotebookBrowserHarness } from './NotebookBrowserHarness';
 import { SessionReviewLoopBarHarness } from './SessionReviewLoopBarHarness';
 
 export const harnesses: Record<string, React.ComponentType<HarnessProps>> = {
+  BrokenLinks: BrokenLinksHarness,
   DashboardPRs: DashboardPRsHarness,
   DiffDetailPanel: DiffDetailPanelHarness,
   DiffView: DiffViewHarness,

--- a/internal/daemon/fs.go
+++ b/internal/daemon/fs.go
@@ -135,6 +135,32 @@ func (d *Daemon) sendFsWriteWSResult(client *wsClient, requestID, path, content,
 	d.sendToClient(client, msg)
 }
 
+// sendFsExistsWSResult reports whether a path exists under the root and replies
+// with an fs_exists_result event correlated by requestID. It does not read the
+// file — the frontend uses it to flag an in-notebook link whose target note is
+// missing. A path that fails to validate (escapes the root, dotfile) is an error
+// the frontend treats as "unknown, leave the link unflagged", not as "missing".
+func (d *Daemon) sendFsExistsWSResult(client *wsClient, requestID, path string) {
+	var result *protocol.FsExistsResult
+	store, err := d.fsStoreFor()
+	if err == nil {
+		var exists bool
+		if exists, err = store.Exists(path); err == nil {
+			result = &protocol.FsExistsResult{Path: path, Exists: exists}
+		}
+	}
+	msg := protocol.FsExistsResultMessage{
+		Event:     protocol.EventFsExistsResult,
+		RequestID: requestID,
+		Success:   err == nil,
+		Result:    result,
+	}
+	if err != nil {
+		msg.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, msg)
+}
+
 // fsEntriesToProtocol converts store entries to their protocol shape.
 func fsEntriesToProtocol(entries []fsdoc.Entry) []protocol.FsEntry {
 	out := make([]protocol.FsEntry, len(entries))

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -45,6 +45,16 @@ func listFs(t *testing.T, d *Daemon, dir string) []protocol.FsEntry {
 	return res.Entries
 }
 
+// fsExists checks one path over the WS fs path and returns the decoded result event.
+func fsExists(t *testing.T, d *Daemon, path string) protocol.FsExistsResultMessage {
+	t.Helper()
+	client := &wsClient{send: make(chan outboundMessage, 8)}
+	d.sendFsExistsWSResult(client, "setup-fs-exists", path)
+	var res protocol.FsExistsResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	return res
+}
+
 // waitForFsChange returns the paths of the first fs_changed broadcast matching the
 // given origin, ignoring other events (notebook_changed, other origins).
 func waitForFsChange(t *testing.T, ch chan outboundMessage, origin string) []string {
@@ -112,6 +122,32 @@ func TestFsWriteListReadWSResults(t *testing.T) {
 	}
 }
 
+// fs_exists answers presence without reading: a present file is exists=true, a
+// genuinely absent path is a successful exists=false (the broken-link signal), and a
+// path the rules reject (a dotfile) is a failed result the UI leaves unflagged.
+func TestFsExistsWSResults(t *testing.T) {
+	d := newFsDaemon(t)
+	if c := fsWriteCAS(t, d, "knowledge/areas/foo.md", "x", ""); !c.Success || c.Result == nil {
+		t.Fatalf("seed write = %+v", c.Result)
+	}
+
+	present := fsExists(t, d, "/knowledge/areas/foo.md")
+	if present.Event != protocol.EventFsExistsResult || present.RequestID != "setup-fs-exists" ||
+		!present.Success || present.Result == nil || !present.Result.Exists {
+		t.Fatalf("exists(present) = %+v", present)
+	}
+
+	absent := fsExists(t, d, "/knowledge/areas/missing.md")
+	if !absent.Success || absent.Result == nil || absent.Result.Exists {
+		t.Fatalf("exists(absent) = %+v, want a successful exists=false", absent)
+	}
+
+	bad := fsExists(t, d, ".secret")
+	if bad.Success || bad.Error == nil {
+		t.Fatalf("exists(dotfile) = %+v, want a failed result with error", bad)
+	}
+}
+
 // fs_write is hash-CAS: a stale base hash comes back as a successful result
 // carrying conflict=true (for the UI to reconcile), and a matching base applies.
 func TestFsWriteWSResultSaveAndConflict(t *testing.T) {
@@ -167,6 +203,16 @@ func TestFsDispatchThroughClientMessage(t *testing.T) {
 	readNotebookWSEvent(t, client.send, &read)
 	if read.RequestID != "r1" || !read.Success || read.Result == nil || read.Result.Content != "# hi\n" {
 		t.Fatalf("read dispatch = %+v", read.Result)
+	}
+
+	// fs_exists with request_id AND path set: assert both correlation and that the
+	// just-written note resolves as present (a swapped Deref would misroute either).
+	d.handleClientMessage(client, []byte(`{"cmd":"fs_exists","request_id":"e1","path":"docs/readme.md"}`))
+	var exists protocol.FsExistsResultMessage
+	readNotebookWSEvent(t, client.send, &exists)
+	if exists.RequestID != "e1" || !exists.Success || exists.Result == nil ||
+		exists.Result.Path != "docs/readme.md" || !exists.Result.Exists {
+		t.Fatalf("exists dispatch = %+v", exists)
 	}
 }
 

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -908,6 +908,9 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 	case protocol.CmdFsWrite:
 		fsWrite := msg.(*protocol.FsWriteMessage)
 		go d.sendFsWriteWSResult(client, protocol.Deref(fsWrite.RequestID), fsWrite.Path, fsWrite.Content, protocol.Deref(fsWrite.BaseHash))
+	case protocol.CmdFsExists:
+		fsExists := msg.(*protocol.FsExistsMessage)
+		go d.sendFsExistsWSResult(client, protocol.Deref(fsExists.RequestID), fsExists.Path)
 	case protocol.CmdApprovePR:
 		d.handleApprovePRWS(client, msg.(*protocol.ApprovePRMessage))
 	case protocol.CmdMergePR:

--- a/internal/fsdoc/store.go
+++ b/internal/fsdoc/store.go
@@ -212,6 +212,29 @@ func (s *Store) Write(p string, content []byte, baseHash string) (newHash string
 	return notebook.Hash(content), nil, nil
 }
 
+// Exists reports whether a path exists under the root (file or directory),
+// without reading it. Used to flag in-notebook markdown links that point at a
+// missing note. A path that escapes the root or is otherwise invalid returns an
+// error, so the caller leaves such a link unflagged rather than guessing; only a
+// genuine "not there" returns (false, nil).
+func (s *Store) Exists(p string) (bool, error) {
+	rel, err := cleanRel(p, false)
+	if err != nil {
+		return false, err
+	}
+	abs, err := s.abs(rel)
+	if err != nil {
+		return false, err
+	}
+	if _, err := os.Stat(abs); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // CleanPath normalizes a file path (root-absolute or relative) to its clean,
 // slash-separated root-relative form — the same form List returns — or errors if
 // it escapes the root or names the root itself. The daemon uses it to echo and

--- a/internal/fsdoc/store_test.go
+++ b/internal/fsdoc/store_test.go
@@ -180,6 +180,46 @@ func TestWriteRejectsOversizeContent(t *testing.T) {
 	}
 }
 
+// Exists reports presence without reading: true for a real file or directory,
+// false for a genuinely absent path (no error — that's the "broken link" signal).
+func TestExists(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "knowledge", "areas", "foo.md"), "x")
+	s := NewStore(root)
+
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{"knowledge/areas/foo.md", true},  // a real file
+		{"/knowledge/areas/foo.md", true}, // root-absolute form resolves the same
+		{"knowledge/areas", true},         // a directory exists too
+		{"knowledge/areas/missing.md", false},
+		{"nope/at/all.md", false},
+	} {
+		got, err := s.Exists(tc.path)
+		if err != nil {
+			t.Fatalf("Exists(%q) err = %v", tc.path, err)
+		}
+		if got != tc.want {
+			t.Fatalf("Exists(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// A path the rules reject outright (the root itself, or a dotfile/dotdir segment)
+// is an error, not a false — the caller leaves such a link unflagged rather than
+// calling it broken. (A `..` escape is not an error: cleanRel clamps it back inside
+// the root, where it is simply checked for existence like any other path.)
+func TestExistsInvalidPathErrors(t *testing.T) {
+	s := NewStore(t.TempDir())
+	for _, p := range []string{"", ".secret", "dir/.git/config"} {
+		if _, err := s.Exists(p); err == nil {
+			t.Fatalf("Exists(%q) err = nil, want an error", p)
+		}
+	}
+}
+
 // Lexical escapes (.. above the root) are rejected by every operation.
 func TestPathEscapesRejected(t *testing.T) {
 	s := NewStore(t.TempDir())

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "116"
+const ProtocolVersion = "117"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -69,6 +69,7 @@ const (
 	CmdFsList                                = "fs_list"
 	CmdFsRead                                = "fs_read"
 	CmdFsWrite                               = "fs_write"
+	CmdFsExists                              = "fs_exists"
 	CmdUnregister                            = "unregister"
 	CmdState                                 = "state"
 	CmdSetSessionResumeID                    = "set_session_resume_id"
@@ -205,6 +206,7 @@ const (
 	EventFsListResult                  = "fs_list_result"
 	EventFsReadResult                  = "fs_read_result"
 	EventFsWriteResult                 = "fs_write_result"
+	EventFsExistsResult                = "fs_exists_result"
 	EventFsChanged                     = "fs_changed"
 	EventPRsUpdated                    = "prs_updated"
 	EventReposUpdated                  = "repos_updated"
@@ -539,6 +541,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdFsWrite:
 		var msg FsWriteMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdFsExists:
+		var msg FsExistsMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1118,6 +1118,42 @@ type FsEntry struct {
 	Size int `json:"size"`
 }
 
+type FsExistsMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type FsExistsResult struct {
+	// Exists corresponds to the JSON schema field "exists".
+	Exists bool `json:"exists"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+}
+
+type FsExistsResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Result corresponds to the JSON schema field "result".
+	Result *FsExistsResult `json:"result,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type FsListMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -721,6 +721,14 @@ model FsWriteMessage {
   request_id?: string; // set by the WS frontend to correlate the result event
 }
 
+// Check whether a path exists under the root, without reading it. Used to flag
+// in-notebook markdown links that point at a missing note.
+model FsExistsMessage {
+  cmd: "fs_exists";
+  path: string;
+  request_id?: string; // set by the WS frontend to correlate the result event
+}
+
 model DelegateWorktreeRequest {
   repo?: string;
   branch: string;
@@ -2363,6 +2371,19 @@ model FsWriteResultMessage {
   success: boolean;
   error?: string;
   result?: FsWriteResult;
+}
+
+model FsExistsResult {
+  path: string;
+  exists: boolean;
+}
+
+model FsExistsResultMessage {
+  event: "fs_exists_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  result?: FsExistsResult;
 }
 
 // Broadcast when files under the root change. origin is agent|ui|external, the


### PR DESCRIPTION
## What

Stage **4c** of the Notebook UI rebuild (`docs/plans/2026-06-20-notebook-ui-gap.md`, gap item 9): an in-notebook markdown link whose target note doesn't exist is now flagged **red with a ⚠** in the live editor. Real-note links stay normal; external links (`http`/`https`/`mailto:`/…) and in-document anchors (`#section`) are never flagged.

![broken-links](https://github.com/victorarias/attn/blob/main/app/test-results/broken-links.png)
*(`ghost` → broken: dashed red underline + ⚠; `real` and `site` → normal links.)*

## How

**Daemon — a new `fs_exists` primitive** (the existing fs surface had no "does this path exist, without reading it" check):
- `fsdoc.Store.Exists(path)` — presence without a read; an invalid/escaping path is an *error* (left unflagged), only a genuine absence is `false`.
- `sendFsExistsWSResult` handler + websocket dispatch case.
- `ProtocolVersion` 116 → 117 (new command/event; TypeSpec + generated types regenerated).

**Frontend — a dedicated `brokenLinks` CodeMirror extension** (kept out of the sync `liveMarkdownPreview` so existence checks stay async and the preview stays headless-testable):
- per-editor existence cache + pending set; `buildDecorations` stays sync, the async check forces a repaint via a refresh `StateEffect`.
- a `revalidate` effect (driven off the notebook's `fs_changed` signal) drops cached **missing** verdicts so a just-created target clears its flag — without re-checking everything on every autosave.
- threaded `existsFile` through `App.tsx` → `NotebookBrowser` → `LiveMarkdownEditor` (extension is inert when `existsFile` is absent, e.g. the shared harness).

## Testing

- **Go unit** — `fsdoc.Exists` (present file/dir, absent → `false`, invalid → error).
- **Go integration** — `fs_exists` WS round-trip + dispatch through `handleClientMessage`.
- **TS unit (headless)** — link-path classification (external/anchor/fragment) + decoration placement over a parsed `EditorState`.
- **Playwright** — a dedicated `BrokenLinks` harness/spec: live async flag appears for the missing link, real/external links untouched, `existsFile` queried only for in-notebook links, and a newly-typed broken link gets checked + flagged on doc change. Shared editor + notebook-browser specs still green (extension inert without `existsFile`).

🤖 Opened by Claude on behalf of Victor.