### PR TITLE
fix(terminal): stop the last line clipping at the bottom of the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-06-21]
 
+### Fixed
+- **The last line of a terminal is no longer cut off at the bottom of the window.** When a session's terminal was sized one row taller than the window could actually show — for example after the window's height landed on an awkward boundary, or when the session was opened at a size different from where its grid was last set — the bottom line (your prompt, or attn's `auto mode on` status line) got clipped at the window edge. The terminal now re-asserts a row count that fits the visible area, so the last line stays fully on screen at any window size.
+
 ### Added
 - **Broken Notebook links are flagged as you write.** When a note links to another note that doesn't exist — a typo in the path, or a note you haven't created yet — the link now shows in red with a ⚠ instead of looking like a working link. Links to real notes stay normal, and external links (http/https, email) are never flagged. If an agent or you create the missing note, its links clear their flag once the Notebook refreshes.
 

--- a/app/src/components/GhosttyTerminal.resizePolicy.test.ts
+++ b/app/src/components/GhosttyTerminal.resizePolicy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   fitRequiresTerminalResize,
+  geometryOverflowsContainer,
   isWorkspaceResizeDragActive,
   liveResizeConflictsWithQueuedReplay,
 } from './GhosttyTerminal';
@@ -35,6 +36,35 @@ describe('GhosttyTerminal resize policy', () => {
       { cols: 120, rows: 40 },
       { cols: 121, rows: 40 },
     )).toBe(true);
+  });
+});
+
+describe('geometryOverflowsContainer', () => {
+  // The clipped-bottom-row bug: the daemon left the PTY one row taller than this
+  // window fits, so the canvas spilled below the viewport. cellHeight 21.
+  it('flags a grid one row taller than the container (the bug)', () => {
+    // window fits floor(540/21)=25 rows, but the model is 26.
+    expect(geometryOverflowsContainer(26, 21, 540)).toBe(true);
+  });
+
+  it('does not flag a grid that fits, including the floor() remainder gap', () => {
+    // 25 rows * 21 = 525 <= 540 (a harmless 15px gap below the last row).
+    expect(geometryOverflowsContainer(25, 21, 540)).toBe(false);
+    // Exact fit.
+    expect(geometryOverflowsContainer(25, 21, 525)).toBe(false);
+  });
+
+  it('tolerates a 1px sub-pixel container height without a spurious refit', () => {
+    // 27 * 21 = 567; a 566px container is within the 1px slack.
+    expect(geometryOverflowsContainer(27, 21, 566)).toBe(false);
+    // Two px short is a genuine overflow.
+    expect(geometryOverflowsContainer(27, 21, 565)).toBe(true);
+  });
+
+  it('never flags degenerate/zero dimensions (pre-measure, hidden pane)', () => {
+    expect(geometryOverflowsContainer(27, 21, 0)).toBe(false);
+    expect(geometryOverflowsContainer(0, 21, 540)).toBe(false);
+    expect(geometryOverflowsContainer(27, 0, 540)).toBe(false);
   });
 });
 

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -261,6 +261,29 @@ export function fitRequiresTerminalResize(
   return current.cols !== next.cols || current.rows !== next.rows;
 }
 
+// True when a grid of `rows` rows of `cellHeight` px is taller than the
+// container that displays it — i.e. the rendered canvas would spill below the
+// visible viewport and the bottom row(s) would be clipped.
+//
+// `fit()` derives rows from `Math.floor(clientHeight / cellHeight)`, so it can
+// never overflow. But the daemon's authoritative PTY geometry (delivered via
+// `resizeLocal`, source `pty_resized`) is NOT bounded by this client's window:
+// when another client — or a prior, taller layout — left the PTY one row taller
+// than this window fits, the canvas ends up taller than the container and the
+// last line is cut at the window edge. Detecting that lets the active client
+// re-assert its own (floored) geometry. A 1px slack absorbs sub-pixel
+// fractional container heights so we only act on a genuine extra row.
+export function geometryOverflowsContainer(
+  rows: number,
+  cellHeight: number,
+  clientHeight: number,
+): boolean {
+  if (rows <= 0 || cellHeight <= 0 || clientHeight <= 0) {
+    return false;
+  }
+  return rows * cellHeight > clientHeight + 1;
+}
+
 // Geometry the queued (not yet applied) historical replay will end at.
 // `resizes` counts replay resize operations still on the write chain.
 export interface PendingReplayGeometry extends TerminalDimensions {
@@ -449,6 +472,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // Used to detect that a generation bump actually discarded history.
     const pendingReplayOpsRef = useRef(0);
     const fitResizeCoalescerRef = useRef<ResizeCoalescer | null>(null);
+    // `fit` is defined far below; resizeLocal needs to re-assert local geometry
+    // when the daemon's PTY size overflows this window, so reach it via a ref.
+    const fitRef = useRef<() => void>(() => undefined);
+    const overflowRefitRafRef = useRef<number | null>(null);
     const applyFitDimensionsRef = useRef<(dimensions: TerminalDimensions) => void>(() => undefined);
     const osc52StateRef = useRef<Osc52State>({ pending: '' });
     const synchronizedOutputStateRef = useRef<SynchronizedOutputState>({ active: false, pending: '' });
@@ -1373,6 +1400,26 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         });
         if (!options?.historicalReplay) {
           renderSurface(true);
+          // The daemon's authoritative PTY rows are not bounded by this
+          // client's window. If they leave the canvas taller than the
+          // container (another client, or a prior taller layout, set the PTY
+          // one row too tall), the bottom line is clipped at the window edge.
+          // Re-assert this client's own floored geometry. `fit()` bails when
+          // inactive / mid-replay, so this never fights the geometry authority;
+          // it only corrects a live overflow the active client can actually see.
+          const container = containerRef.current;
+          if (
+            container
+            && geometryOverflowsContainer(rows, renderer.cellHeight, container.clientHeight)
+          ) {
+            if (overflowRefitRafRef.current !== null) {
+              cancelAnimationFrame(overflowRefitRafRef.current);
+            }
+            overflowRefitRafRef.current = requestAnimationFrame(() => {
+              overflowRefitRafRef.current = null;
+              fitRef.current();
+            });
+          }
         }
       });
     }, [enqueueOperation, reconcileBlocksAfterResize, renderSurface]);
@@ -1455,6 +1502,8 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       }
       fitResizeCoalescerRef.current.submit(dims, isWorkspaceResizeDragActive(container));
     }, []);
+
+    fitRef.current = fit;
 
     useImperativeHandle(ref, () => ({
       fit,
@@ -1676,6 +1725,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         });
         disposePaneDiagnostics(diagKeyRef.current);
         observer?.disconnect();
+        if (overflowRefitRafRef.current !== null) {
+          cancelAnimationFrame(overflowRefitRafRef.current);
+          overflowRefitRafRef.current = null;
+        }
         canvas.removeEventListener('webglcontextlost', handleContextLost);
         unregister();
         clearSynchronizedOutputRenderTimer();


### PR DESCRIPTION
A terminal could end up sized one row taller than the window can show, so
the bottom line (the shell prompt, or attn's "auto mode on" status line)
was clipped at the window edge — visible whenever content filled the
session to the bottom.

fit() derives rows from Math.floor(clientHeight / cellHeight), so it can
never overflow the container. But the daemon's authoritative PTY geometry
arrives via resizeLocal (source pty_resized) and is NOT bounded by this
client's window: when another client, or a prior taller layout, left the
PTY one row too tall for the current window, the canvas rendered taller
than the visible area and the last row spilled past the window edge. With
no container resize to fire the ResizeObserver, fit() never re-ran, so the
overflow persisted.

Add geometryOverflowsContainer() and, after a live (non-replay)
resizeLocal that overflows the container, schedule a corrective fit() so
the active client re-asserts its own floored geometry (and re-notifies the
daemon). fit() still bails when inactive or mid-replay, so this never
fights the geometry-authority model in rule #7 — it only corrects a live
overflow the active client can actually see. A 1px slack avoids spurious
refits from sub-pixel container heights.

Verified in the dev app: confirmed the overflow with pixel measurements
(canvas bottom below the window), and the last line stays fully visible
after the fix. Unit tests cover the overflow predicate; full terminal
test suite green.
