### PR TITLE
feat(notebook): width-driven auto-fold for the tile surface (stage 7, PR 3)

### DIFF
--- a/app/src/components/NotebookSurface.tsx
+++ b/app/src/components/NotebookSurface.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import FocusTrap from 'focus-trap-react';
 import type { FsEntry, FsExistsResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult, NotebookTask } from '../hooks/useDaemonSocket';
 import { useEscapeStack } from '../hooks/useEscapeStack';
+import { useTileAutoFold } from '../hooks/useTileAutoFold';
 import { FileTree } from './notebook/FileTree';
 import { fileKind, isBinaryPath, isMarkdownPath } from './notebook/fileKind';
 import { parseFrontmatter } from './notebook/frontmatter';
@@ -147,6 +148,10 @@ export function NotebookSurface({
   // users land inside the modal (engaging the focus trap) without auto-selecting
   // the Close button. Tab from here moves to the first interactive control.
   const dialogRef = useRef<HTMLDivElement>(null);
+  // The body container, observed by the tile's responsive auto-fold. Its width is
+  // independent of how the inner panes fold, so folding can't shrink the observed
+  // box and oscillate.
+  const bodyRef = useRef<HTMLDivElement>(null);
   // Imperative handle to the live editor, so the context rail's outline can scroll
   // the editor to a heading (navigation that originates outside the editor).
   const editorRef = useRef<LiveMarkdownEditorHandle>(null);
@@ -161,9 +166,12 @@ export function NotebookSurface({
   // to 0 width but stay mounted (CodeMirror/scroll state survives).
   const [treeOverride, setTreeOverride] = useState<boolean | null>(null);
   const [railOverride, setRailOverride] = useState<boolean | null>(null);
-  const autoFold = false;
-  const treeFolded = treeOverride === null ? autoFold : treeOverride;
-  const railFolded = railOverride === null ? autoFold : railOverride;
+  // The auto side of the fold seam. A modal folds nothing automatically (manual
+  // only, unchanged); a tile folds its rail then its tree as it narrows. A manual
+  // override still wins (`override ?? auto`), so this only changes what auto means.
+  const { treeAutoFold, railAutoFold } = useTileAutoFold(bodyRef, variant === 'tile');
+  const treeFolded = treeOverride === null ? treeAutoFold : treeOverride;
+  const railFolded = railOverride === null ? railAutoFold : railOverride;
   // The kind/type pill in the note header: a markdown note's frontmatter `type`
   // (defaulting to "note"), or "text" for a plain-text file. Parsed off the loaded
   // content (not the live draft) so it doesn't churn on every keystroke. Self-
@@ -698,6 +706,7 @@ export function NotebookSurface({
 
   const body = (
     <div
+      ref={bodyRef}
       className={`notebook-browser-body${showRail ? ' has-rail' : ''}${treeFolded ? ' tree-folded' : ''}${showRail && railFolded ? ' rail-folded' : ''}`}
     >
       {/* `inert` while folded removes the whole pane from the tab order and the

--- a/app/src/hooks/useTileAutoFold.test.ts
+++ b/app/src/hooks/useTileAutoFold.test.ts
@@ -1,0 +1,85 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { foldsForWidth, RAIL_FOLD_BELOW, TREE_FOLD_BELOW, useTileAutoFold } from './useTileAutoFold';
+
+// A div whose clientWidth we control (happy-dom does no layout, so it's 0 otherwise).
+function elementOfWidth(width: number): HTMLElement {
+  const el = document.createElement('div');
+  Object.defineProperty(el, 'clientWidth', { value: width, configurable: true });
+  return el;
+}
+
+// Capture the latest ResizeObserver callback so a test can drive a resize.
+let resizeCallback: ResizeObserverCallback | null = null;
+class MockResizeObserver {
+  constructor(cb: ResizeObserverCallback) { resizeCallback = cb; }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+function emitWidth(width: number) {
+  act(() => {
+    resizeCallback?.([{ contentRect: { width } } as ResizeObserverEntry], {} as ResizeObserver);
+  });
+}
+
+const RealResizeObserver = globalThis.ResizeObserver;
+beforeEach(() => {
+  resizeCallback = null;
+  globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+});
+afterEach(() => {
+  globalThis.ResizeObserver = RealResizeObserver;
+});
+
+describe('foldsForWidth', () => {
+  it('folds nothing at a wide width', () => {
+    expect(foldsForWidth(RAIL_FOLD_BELOW)).toEqual({ treeAutoFold: false, railAutoFold: false });
+    expect(foldsForWidth(1200)).toEqual({ treeAutoFold: false, railAutoFold: false });
+  });
+
+  it('folds the rail first as it narrows past the wide threshold', () => {
+    expect(foldsForWidth(RAIL_FOLD_BELOW - 1)).toEqual({ treeAutoFold: false, railAutoFold: true });
+    expect(foldsForWidth(TREE_FOLD_BELOW)).toEqual({ treeAutoFold: false, railAutoFold: true });
+  });
+
+  it('folds both rail and tree once narrow', () => {
+    expect(foldsForWidth(TREE_FOLD_BELOW - 1)).toEqual({ treeAutoFold: true, railAutoFold: true });
+    expect(foldsForWidth(320)).toEqual({ treeAutoFold: true, railAutoFold: true });
+  });
+
+  it('treats a non-positive (unmeasured) width as fold-nothing, so a tile never flashes collapsed', () => {
+    expect(foldsForWidth(0)).toEqual({ treeAutoFold: false, railAutoFold: false });
+    expect(foldsForWidth(-10)).toEqual({ treeAutoFold: false, railAutoFold: false });
+  });
+});
+
+describe('useTileAutoFold', () => {
+  it('stays at the manual-only baseline when disabled (the modal), never observing', () => {
+    const ref = { current: elementOfWidth(320) };
+    const { result } = renderHook(() => useTileAutoFold(ref, false));
+    expect(result.current).toEqual({ treeAutoFold: false, railAutoFold: false });
+    expect(resizeCallback).toBeNull();
+  });
+
+  it('measures synchronously on mount so a narrow tile is folded on the first frame', () => {
+    const ref = { current: elementOfWidth(TREE_FOLD_BELOW - 50) };
+    const { result } = renderHook(() => useTileAutoFold(ref, true));
+    expect(result.current).toEqual({ treeAutoFold: true, railAutoFold: true });
+  });
+
+  it('refolds across breakpoints as the observed width changes', () => {
+    const ref = { current: elementOfWidth(1200) };
+    const { result } = renderHook(() => useTileAutoFold(ref, true));
+    expect(result.current).toEqual({ treeAutoFold: false, railAutoFold: false });
+
+    emitWidth(RAIL_FOLD_BELOW - 100); // medium: rail folds, tree stays
+    expect(result.current).toEqual({ treeAutoFold: false, railAutoFold: true });
+
+    emitWidth(TREE_FOLD_BELOW - 100); // narrow: both fold
+    expect(result.current).toEqual({ treeAutoFold: true, railAutoFold: true });
+
+    emitWidth(1100); // back to wide: both unfold
+    expect(result.current).toEqual({ treeAutoFold: false, railAutoFold: false });
+  });
+});

--- a/app/src/hooks/useTileAutoFold.ts
+++ b/app/src/hooks/useTileAutoFold.ts
@@ -1,0 +1,77 @@
+import { useLayoutEffect, useState, type RefObject } from 'react';
+
+// Width thresholds (px) for the responsive fold ladder of a notebook tile. A tile
+// can be narrow (docked beside terminals) or wide (a near-fullscreen pane), so it
+// sheds its side panes as it shrinks: the context rail folds first, then the file
+// tree, leaving the document pane with the most room.
+//
+//   width >= RAIL_FOLD_BELOW           → tree + document + rail   (wide)
+//   TREE_FOLD_BELOW <= width < RAIL... → tree + document         (medium; rail folds)
+//   width <  TREE_FOLD_BELOW           → document only           (narrow; both fold)
+export const RAIL_FOLD_BELOW = 900;
+export const TREE_FOLD_BELOW = 620;
+
+export interface TileAutoFold {
+  treeAutoFold: boolean;
+  railAutoFold: boolean;
+}
+
+// foldsForWidth is the pure breakpoint decision, split out so the ladder is unit
+// testable without a live ResizeObserver. A non-positive width is "not measured
+// yet" — fold nothing, so a tile never flashes collapsed before its first real
+// measurement.
+export function foldsForWidth(width: number): TileAutoFold {
+  if (width <= 0) return { treeAutoFold: false, railAutoFold: false };
+  return {
+    railAutoFold: width < RAIL_FOLD_BELOW,
+    treeAutoFold: width < TREE_FOLD_BELOW,
+  };
+}
+
+// useTileAutoFold drives a notebook surface's automatic edge-rail folds from the
+// observed width of `ref` (the surface body). It feeds the fold seam's auto side
+// (`folded = override ?? auto`), so a manual fold still wins; this only changes what
+// "auto" resolves to.
+//
+// `enabled` gates the whole thing: the modal passes false and always gets
+// {false,false} (its folds are manual-only, unchanged), so only a tile observes.
+// The initial measurement runs in a layout effect — synchronously before paint — so
+// a tile that mounts already-narrow renders folded on the first frame instead of
+// flashing open then snapping shut.
+export function useTileAutoFold(ref: RefObject<HTMLElement | null>, enabled: boolean): TileAutoFold {
+  const [folds, setFolds] = useState<TileAutoFold>({ treeAutoFold: false, railAutoFold: false });
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      // Keep a disabled surface (the modal) at its manual-only baseline.
+      setFolds({ treeAutoFold: false, railAutoFold: false });
+      return;
+    }
+    const el = ref.current;
+    if (!el) return;
+
+    // Apply a width immediately (before paint) and on every resize. We observe the
+    // body CONTAINER, whose width is independent of how its inner panes fold, so
+    // folding can't shrink the observed box and oscillate.
+    const apply = (width: number) => {
+      setFolds((prev) => {
+        const next = foldsForWidth(width);
+        return prev.treeAutoFold === next.treeAutoFold && prev.railAutoFold === next.railAutoFold
+          ? prev
+          : next;
+      });
+    };
+    apply(el.clientWidth);
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        apply(entry.contentRect.width);
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref, enabled]);
+
+  return folds;
+}


### PR DESCRIPTION
Stage 7 (Notebook tile mode), PR 3 of the ladder. Builds on the PR2 \`NotebookSurface\` extraction. Design doc: \`docs/plans/2026-06-21-notebook-stage7-tile-mode.md\`.

## What
Add **\`useTileAutoFold\`** — a ResizeObserver hook that drives the fold seam's *auto* side from the surface body's width. As a notebook tile narrows it sheds side panes:

| width | layout |
|---|---|
| ≥ 900px | tree + document + rail |
| 620–899px | tree + document (rail auto-folds) |
| < 620px | document only (both fold) |

A manual fold still wins (`folded = override ?? auto`); this only changes what "auto" resolves to.

## Safety / correctness
- The **modal passes `enabled=false`** and keeps `{false,false}` (manual-only folds, unchanged) — only a tile observes. The modal is untouched.
- The **initial measurement runs in a layout effect** (synchronously before paint), so a tile that mounts already-narrow renders folded on the first frame instead of flashing open then snapping shut.
- We observe the body **container**, whose width is independent of how its inner panes fold, so folding can't shrink the observed box and oscillate.

## Tests
- `foldsForWidth` pure breakpoint ladder + the hook wiring (sync mount measure, resize refold across breakpoints, disabled baseline) — **7 unit tests**.
- `NotebookBrowser` suite still green (modal `{false,false}` path).
- `tsc` clean.

No CHANGELOG: the tile isn't rendered until a later PR, so no user-visible change yet. The responsive folding gets its integration coverage + manual verification when the tile first mounts (PR mounting `WorkspaceDockTile`).

---
🤖 Opened by Claude on behalf of Victor.