### PR TITLE
fix(worktree): default new worktrees to origin/<default branch>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **The Notebook header tells you more at a glance.** A small "chief" indicator lights up while your chief-of-staff agent is working, and each note's title now carries a kind badge (note or journal).
 - **Broken Notebook links are flagged as you write.** When a note links to another note that doesn't exist — a typo in the path, or a note you haven't created yet — the link now shows in red with a ⚠ instead of looking like a working link. Links to real notes stay normal, and external links (http/https, email) are never flagged. If an agent or you create the missing note, its links clear their flag once the Notebook refreshes.
 
+### Changed
+- **New worktrees start from the latest origin/main by default.** When you create a worktree in the new-session dialog, "Start from origin/&lt;default branch&gt;" is now the pre-selected, leading choice — so your new branch is cut from a freshly-fetched upstream main, not from whatever branch the source location happened to be sitting on (which could be days stale). You can still pick "Start from &lt;current branch&gt;" to branch off your in-progress work. A repo with no matching remote branch falls back to the current checkout instead of failing.
+
 ### Fixed
 - **A finished session now ends cleanly instead of looking like a crash.** When a session is stopped, closed, or wraps up its work, attn tears it down with a normal termination signal — but the terminal used to report that as a bare `[Process exited with code 143]`, which reads like something broke. Expected endings (a clean exit, or a normal stop/close) now show a calm `[Session ended]`. Genuine failures — a non-zero exit code, or a crash/force-kill — still show the exit code so real problems stay visible.
 

--- a/app/src/components/LocationPicker.test.tsx
+++ b/app/src/components/LocationPicker.test.tsx
@@ -589,6 +589,9 @@ describe('LocationPicker', () => {
 
     fireEvent.click(screen.getByTestId('repo-option-2'));
     fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'feat-more' } });
+    // Worktrees now default to origin/<defaultBranch>; opt into the selected
+    // worktree's current branch to exercise that path.
+    fireEvent.click(screen.getByTestId('repo-new-worktree-start-current'));
     fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
 
     await waitFor(() => {

--- a/app/src/components/NewSessionDialog/RepoOptions.test.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.test.tsx
@@ -281,6 +281,56 @@ describe('RepoOptions', () => {
     });
   });
 
+  it('defaults a new worktree to origin/<defaultBranch>', async () => {
+    const onCreateWorktree = vi.fn(async () => {});
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo--feature"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={onCreateWorktree}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('repo-option-2'));
+    fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'feature-2' } });
+
+    expect(screen.getByTestId('repo-new-worktree-start-default')).toBeChecked();
+    expect(screen.getByTestId('repo-new-worktree-start-current')).not.toBeChecked();
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+    await waitFor(() => expect(onCreateWorktree).toHaveBeenCalledWith('feature-2', 'origin/main'));
+  });
+
+  it('starts from the selected destination branch when "current" is chosen', async () => {
+    const onCreateWorktree = vi.fn(async () => {});
+    render(
+      <RepoOptions
+        repoInfo={repoInfo}
+        selectedPath="/tmp/repo--feature"
+        onSelectedPathChange={vi.fn()}
+        onSelectMainRepo={vi.fn()}
+        onSelectWorktree={vi.fn()}
+        onCreateWorktree={onCreateWorktree}
+        onRefresh={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('repo-option-2'));
+    fireEvent.change(screen.getByTestId('repo-new-worktree-input'), { target: { value: 'feature-2' } });
+    fireEvent.click(screen.getByTestId('repo-new-worktree-start-current'));
+
+    fireEvent.keyDown(screen.getByTestId('repo-options'), { key: 'Enter' });
+
+    await waitFor(() => expect(onCreateWorktree).toHaveBeenCalledWith('feature-2', 'feature'));
+  });
+
   it('shows row-local progress while deleting a worktree', async () => {
     const deleteGate = deferred<void>();
     const onDeleteWorktree = vi.fn(() => deleteGate.promise);

--- a/app/src/components/NewSessionDialog/RepoOptions.tsx
+++ b/app/src/components/NewSessionDialog/RepoOptions.tsx
@@ -128,7 +128,11 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
   const [focusIndex, setFocusIndex] = useState(committedDestinationIndex);
   const [showNewWorktree, setShowNewWorktree] = useState(false);
   const [newWorktreeName, setNewWorktreeName] = useState('');
-  const [startingBranch, setStartingBranch] = useState<'current' | 'default'>('current');
+  // Default to origin/<defaultBranch> so a new worktree starts fresh from the
+  // latest upstream main (fetched first daemon-side), not from whatever local
+  // branch the selected destination happens to be sitting on — which can be
+  // arbitrarily stale. Users can still opt into "current" via the radio/Tab.
+  const [startingBranch, setStartingBranch] = useState<'current' | 'default'>('default');
   const [pendingDeletePath, setPendingDeletePath] = useState<string | null>(null);
   const [deleteFailure, setDeleteFailure] = useState<DeleteFailure | null>(null);
   const [creatingWorktree, setCreatingWorktree] = useState(false);
@@ -528,17 +532,6 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
                 />
               </div>
               <div className="new-worktree-radio-row">
-                <label className={startingBranch === 'current' ? 'selected' : ''}>
-                  <input
-                    type="radio"
-                    name="startingBranch"
-                    value="current"
-                    data-testid="repo-new-worktree-start-current"
-                    checked={startingBranch === 'current'}
-                    onChange={() => setStartingBranch('current')}
-                  />
-                  Start from {selectedDestination?.branch || repoInfo.currentBranch}
-                </label>
                 <label className={startingBranch === 'default' ? 'selected' : ''}>
                   <input
                     type="radio"
@@ -549,6 +542,17 @@ export const RepoOptions: React.FC<RepoOptionsProps> = ({
                     onChange={() => setStartingBranch('default')}
                   />
                   Start from origin/{repoInfo.defaultBranch}
+                </label>
+                <label className={startingBranch === 'current' ? 'selected' : ''}>
+                  <input
+                    type="radio"
+                    name="startingBranch"
+                    value="current"
+                    data-testid="repo-new-worktree-start-current"
+                    checked={startingBranch === 'current'}
+                    onChange={() => setStartingBranch('current')}
+                  />
+                  Start from {selectedDestination?.branch || repoInfo.currentBranch}
                 </label>
               </div>
               <div className={`new-worktree-hint ${creatingWorktree ? 'operation-running' : ''}`}>

--- a/internal/daemon/worktree.go
+++ b/internal/daemon/worktree.go
@@ -134,6 +134,14 @@ func (d *Daemon) doCreateWorktree(msg *protocol.CreateWorktreeMessage) (string, 
 			}
 		}
 	}
+	// If the requested start ref can't be resolved (e.g. "origin/main" in a repo
+	// with no matching remote branch), fall back to the repo's current HEAD so
+	// creation succeeds instead of erroring on an unknown ref. The fetch above
+	// has already run, so a resolvable remote ref is up to date by this point.
+	if startingFrom != "" && !git.RefExists(mainRepo, startingFrom) {
+		d.logf("Worktree start ref %q not resolvable in %s; falling back to current HEAD", startingFrom, mainRepo)
+		startingFrom = ""
+	}
 	var createErr error
 	if startingFrom != "" {
 		createErr = git.CreateWorktreeFromPoint(mainRepo, msg.Branch, path, startingFrom)

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -195,6 +195,18 @@ func ListRemotes(repoDir string) ([]string, error) {
 	return remotes, nil
 }
 
+// RefExists reports whether ref resolves to a commit in repoDir (e.g. a local
+// branch, a remote-tracking ref like "origin/main", or a SHA). Used to decide
+// whether a requested worktree start point is usable before handing it to
+// `git worktree add`, which errors hard on an unknown ref.
+func RefExists(repoDir, ref string) bool {
+	resolvedDir, err := ResolveRepoDir(repoDir)
+	if err != nil {
+		return false
+	}
+	return runGitNoOutput(OpMetadata, resolvedDir, "rev-parse", "--verify", "--quiet", ref+"^{commit}") == nil
+}
+
 // FetchRemoteBranch fetches a single branch from a remote.
 // remote should be e.g. "origin", branch should be e.g. "main".
 func FetchRemoteBranch(repoDir, remote, branch string) error {

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -58,6 +58,27 @@ func TestCheckoutRemoteBranch(t *testing.T) {
 	}
 }
 
+func TestRefExists(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "commit", "--allow-empty", "-m", "init")
+
+	cases := []struct {
+		ref  string
+		want bool
+	}{
+		{"HEAD", true},
+		{"main", true},
+		{"origin/main", false}, // no remote configured
+		{"does-not-exist", false},
+	}
+	for _, tc := range cases {
+		if got := RefExists(dir, tc.ref); got != tc.want {
+			t.Errorf("RefExists(%q) = %v, want %v", tc.ref, got, tc.want)
+		}
+	}
+}
+
 func TestGetCurrentBranchEmptyRepo(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init", "-b", "main")


### PR DESCRIPTION
## Problem
Creating a worktree from the new-session dialog could produce a **stale** branch. A worktree opened "to start fresh" came out based on a 6-day-old commit (`test/test`'s tip) rather than the latest `main`.

Root cause is **not** a broken fetch — I verified the `origin/main` path fetches correctly end-to-end (git 2.54): `git fetch origin main` moves `refs/remotes/origin/main`, then `git worktree add … origin/main` lands on the fresh tip (control without the fetch lands stale, so the fetch is load-bearing).

The footgun was the **default**: `RepoOptions` defaulted `startingBranch` to `'current'`, which branches off `selectedDestination?.branch` — the *local* branch the chosen destination happens to be on. For a worktree-of-a-worktree that can be arbitrarily stale.

## Change
- **Frontend** (`RepoOptions.tsx`): default flipped `'current'` → `'default'` (origin/&lt;defaultBranch&gt;) and the two radios reordered so the now-default option leads. "Start from &lt;current&gt;" is still one click/Tab away.
- **Daemon** (`worktree.go`): after the fetch, if the requested start ref can't be resolved (e.g. `origin/main` in a repo with no matching remote branch), fall back to the current HEAD instead of erroring on `git worktree add`. Fixes a latent hard-failure the new default would otherwise expose.
- **git** (`branch.go`): new `RefExists` helper.

## Tests
- `RepoOptions.test.tsx`: default is `origin/main`; choosing "current" passes the destination branch.
- `LocationPicker.test.tsx`: updated the "from selected worktree branch" test to opt into "current" (no longer the default).
- `branch_test.go`: `TestRefExists`.
- Frontend suite green (1098 passed); `internal/git` + daemon worktree tests pass.

## Note
The radio reorder is cosmetic-equivalent — the radio-row CSS is order-independent (column flex; `.selected`/`:hover` only).