### PR TITLE
fix(notebook): close the focused tile on ⌘W, not the terminal beside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-06-21]
 
 ### Fixed
+- **`⌘W` in a docked Notebook tile now closes the Notebook, not the terminal beside it.** When a Notebook tile sat next to a terminal pane, pressing `⌘W` while reading or editing a note closed the previously-focused terminal pane (ending that session) instead of the note you were looking at. `⌘W` now closes the focused tile.
 - **The last line of a terminal is no longer cut off at the bottom of the window.** When a session's terminal was sized one row taller than the window could actually show — for example after the window's height landed on an awkward boundary, or when the session was opened at a size different from where its grid was last set — the bottom line (your prompt, or attn's `auto mode on` status line) got clipped at the window edge. The terminal now re-asserts a row count that fits the visible area, so the last line stays fully on screen at any window size.
 
 ### Added

--- a/app/package.json
+++ b/app/package.json
@@ -48,6 +48,7 @@
     "real-app:scenario-workspace-close-one-session-keeps-selection": "node scripts/real-app-harness/scenario-workspace-close-one-session-keeps-selection.mjs",
     "real-app:scenario-tile-only-workspace-select": "node scripts/real-app-harness/scenario-tile-only-workspace-select.mjs",
     "real-app:scenario-notebook-tile-finder": "node scripts/real-app-harness/scenario-notebook-tile-finder.mjs",
+    "real-app:scenario-notebook-tile-close": "node scripts/real-app-harness/scenario-notebook-tile-close.mjs",
     "real-app:scenario-autoclose-on-exit": "node scripts/real-app-harness/scenario-autoclose-on-exit.mjs",
     "real-app:scenario-diff-review": "node scripts/real-app-harness/scenario-diff-review.mjs",
     "real-app:scenario-terminal-block-copy": "node scripts/real-app-harness/scenario-terminal-block-copy.mjs",

--- a/app/scripts/real-app-harness/scenario-notebook-tile-close.mjs
+++ b/app/scripts/real-app-harness/scenario-notebook-tile-close.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+// Cmd+W from inside a docked notebook tile, in the packaged app. In the packaged
+// app the native "Close Pane" menu item claims ⌘W and dispatches session.close —
+// NOT the DOM terminal.close path browser e2e exercises — so a focus-aware close
+// has to live in the session.close handler too. The reported bug: with a notebook
+// tile docked beside a terminal, ⌘W while focus is in the tile closed the terminal
+// pane (ending that session) instead of the note you were looking at.
+//
+// This scenario docks a notebook tile with the REAL native ⌘⌥N, dismisses its
+// auto-finder so focus rests inside the tile (the "reading a note" state), then
+// presses the REAL native ⌘W and asserts the tile is undocked while the terminal
+// pane/session survives. Browser e2e can't cover this — Playwright never hits the
+// native menu that turns ⌘W into session.close.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  createRunContext,
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { MacOSDriver } from './macosDriver.mjs';
+import {
+  waitForFirstWorkspacePane,
+  waitForPaneShellReady,
+  waitForPaneVisible,
+} from './scenarioAssertions.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') {
+    args.shift();
+  }
+  return {
+    options: parseCommonArgs(args),
+    help: args.includes('--help') || args.includes('-h'),
+  };
+}
+
+const FINDER_SELECTOR = '.notebook-finder';
+
+async function finderPresent(client) {
+  return client
+    .request('capture_screenshot_data', { selector: FINDER_SELECTOR })
+    .then(() => true)
+    .catch(() => false);
+}
+
+async function waitForFinder(client, present, description, timeoutMs = 10_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if ((await finderPresent(client)) === present) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  throw new Error(`Timed out waiting for finder to be ${present ? 'present' : 'absent'}: ${description}`);
+}
+
+async function waitForWorkspaceUi(client, workspaceId, predicate, description, timeoutMs = 20_000) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await client.request('get_workspace_ui_state', { workspaceId }).catch((error) => ({ error: String(error) }));
+    if (predicate(last)) {
+      return last;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`Timed out waiting for ${description}. Last workspace UI state:\n${JSON.stringify(last, null, 2)}`);
+}
+
+async function closeWorkspacePanes(client, sessionId) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const workspace = await client.request('get_workspace', { sessionId }).catch(() => null);
+    const pane = workspace?.panes?.[0];
+    if (!pane) {
+      return;
+    }
+    await client.request('close_pane', { sessionId, paneId: pane.paneId }).catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+async function closeExistingSessions(client, sessionRootDir) {
+  const initial = await client.request('get_state');
+  const harnessSessions = (initial.sessions || []).filter((session) => session.cwd?.startsWith(sessionRootDir));
+  for (const session of harnessSessions) {
+    await closeWorkspacePanes(client, session.id).catch(() => {});
+  }
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-notebook-tile-close.mjs');
+    return;
+  }
+
+  const { runId, runDir, sessionDir } = createRunContext(options, 'notebook-tile-close');
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const driver = new MacOSDriver({ appPath: options.appPath });
+  let sessionId = null;
+
+  console.log(`[RealAppHarness] runDir=${runDir}`);
+  console.log(`[RealAppHarness] sessionDir=${sessionDir}`);
+  console.log(`[RealAppHarness] wsUrl=${options.wsUrl}`);
+
+  try {
+    process.env.ATTN_HARNESS_PARK_VISIBLE_PX ??= '0';
+    await launchFreshAppAndConnect(client, observer);
+    await closeExistingSessions(client, options.sessionRootDir);
+
+    // 1. A normal shell workspace to dock the notebook tile into.
+    const cwd = path.join(sessionDir, 'close-ws');
+    fs.mkdirSync(cwd, { recursive: true });
+    sessionId = await createSessionAndWaitForInitialPane({
+      client,
+      observer,
+      cwd,
+      label: `notebook-close-${runId}`,
+      agent: 'shell',
+      waitForInitialPaneVisible: false,
+      sessionWaitMs: 30_000,
+    });
+    const pane = await waitForFirstWorkspacePane(client, sessionId, 'initial workspace pane');
+    await client.request('select_session', { sessionId });
+    await waitForPaneVisible(client, sessionId, pane.paneId, 20_000);
+    await waitForPaneShellReady(client, sessionId, pane.paneId, {
+      timeoutMs: 20_000,
+      description: 'shell prompt ready',
+    });
+
+    const workspace = await client.request('get_workspace', { sessionId });
+    const workspaceId = workspace.workspaceId;
+    if (!workspaceId) {
+      throw new Error(`Could not resolve workspace id for session ${sessionId}: ${JSON.stringify(workspace)}`);
+    }
+    const terminalPaneId = pane.paneId;
+
+    // 2. Dock a notebook tile via the REAL native ⌘⌥N (notebook.openTile).
+    await driver.activateApp();
+    await driver.pressKey('n', { command: true, option: true });
+    const docked = await waitForWorkspaceUi(
+      client,
+      workspaceId,
+      (state) => Array.isArray(state?.tileIds) && state.tileIds.length === 1,
+      'native Cmd+Opt+N to dock a fresh notebook tile',
+      15_000,
+    );
+    const tileId = docked.tileIds[0];
+    console.log(`[RealAppHarness] docked notebook tile=${tileId}`);
+
+    // 3. A fresh tile auto-opens its finder; dismiss it with Esc so focus rests on
+    //    the tile itself (the "reading a note" state) rather than the finder input.
+    //    Esc closing the finder also proves focus is inside the tile, not stolen by
+    //    the terminal on dock.
+    await waitForFinder(client, true, 'fresh notebook tile auto-opens its finder');
+    await driver.activateApp();
+    await driver.pressKey('Escape');
+    await waitForFinder(client, false, 'Esc dismisses the finder, leaving focus in the tile');
+
+    // 4. The REAL native ⌘W. In the packaged app this fires the native "Close Pane"
+    //    menu item → session.close. With focus inside the notebook tile it must
+    //    UNDOCK THE TILE, leaving the terminal pane/session untouched.
+    await driver.activateApp();
+    await driver.pressKey('w', { command: true });
+
+    const afterClose = await waitForWorkspaceUi(
+      client,
+      workspaceId,
+      (state) => Array.isArray(state?.tileIds) && state.tileIds.length === 0,
+      'native Cmd+W to undock the focused notebook tile',
+      15_000,
+    );
+
+    // The terminal pane (and its session) must survive — the whole point of the fix.
+    const workspaceAfter = await client.request('get_workspace', { sessionId });
+    const panesAfter = workspaceAfter?.panes ?? [];
+    const terminalSurvived = panesAfter.some((p) => p.paneId === terminalPaneId);
+    if (!terminalSurvived) {
+      throw new Error(
+        `Cmd+W in the notebook tile closed the terminal pane instead of the tile. `
+        + `Expected pane ${terminalPaneId} to survive; panes after = ${JSON.stringify(panesAfter)}`,
+      );
+    }
+    const state = await client.request('get_state');
+    const sessionSurvived = (state.sessions || []).some((s) => s.id === sessionId);
+    if (!sessionSurvived) {
+      throw new Error(`Cmd+W in the notebook tile ended session ${sessionId} instead of closing the tile.`);
+    }
+
+    const summary = {
+      ok: true,
+      runId,
+      workspaceId,
+      tileId,
+      terminalPaneId,
+      tileIdsAfter: afterClose.tileIds,
+      panesAfter: panesAfter.map((p) => p.paneId),
+    };
+    fs.writeFileSync(path.join(runDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    console.log('[RealAppHarness] Notebook tile Cmd+W close (native menu → session.close → undock tile) passed.');
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    if (sessionId) {
+      await closeWorkspacePanes(client, sessionId).catch(() => {});
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2884,6 +2884,20 @@ sendFetchPRDetails,
   }, [handleNextWorkspace, handlePrevWorkspace]);
 
   const handleCloseCurrentSessionShortcut = useCallback(() => {
+    // Cmd+W closes the focused leaf. In the packaged app the native "Close Pane"
+    // menu item claims Cmd+W and dispatches session.close (this handler), so when
+    // focus is inside a docked tile — e.g. a notebook tile beside a terminal — we
+    // must close THAT tile here, not the active session's terminal pane. Without
+    // this, Cmd+W while reading a note kills the previously-focused terminal/session.
+    // (Native browser tiles are handled natively before session.close ever fires.)
+    const focused = document.activeElement;
+    const tileEl = focused instanceof HTMLElement ? focused.closest('[data-pane-kind="tile"]') : null;
+    const tileId = tileEl?.getAttribute('data-pane-id');
+    if (tileId && activeWorkspaceId) {
+      handleCloseTile(activeWorkspaceId, tileId);
+      return;
+    }
+
     if (!activeSessionId) {
       return;
     }
@@ -2900,7 +2914,7 @@ sendFetchPRDetails,
     }
 
     handleRequestCloseSession(activeSessionId);
-  }, [activeSessionId, getActivePaneIdForSession, handleClosePane, handleRequestCloseSession, sessions]);
+  }, [activeSessionId, activeWorkspaceId, getActivePaneIdForSession, handleCloseTile, handleClosePane, handleRequestCloseSession, sessions]);
 
   const handleReloadSession = useCallback((id: string) => {
     const session = sessions.find((entry) => entry.id === id);

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { SessionTerminalWorkspace } from './index';
+import { createPaneRuntimeEventRouterController } from './paneRuntimeEventRouter';
+import { tileContentKey, type TerminalWorkspaceState } from '../../types/workspace';
+
+// The terminal surface pulls in the Ghostty WASM model; stub it so the import
+// graph stays light in jsdom (this spec only cares about Cmd+W routing).
+vi.mock('../GhosttyTerminal', async () => {
+  const React = await import('react');
+  return {
+    GhosttyTerminal: React.forwardRef(function MockTerminal() {
+      return null;
+    }),
+  };
+});
+
+// A split workspace: one terminal pane beside a docked markdown tile. This is the
+// shape that produces the reported bug — the tile lives inside
+// .session-terminal-workspace, so its Cmd+W is dispatched as terminal.close.
+function paneAndTileWorkspace(): TerminalWorkspaceState {
+  return {
+    agents: [{ id: 'pane-term', runtimeId: 'rt-1', sessionId: 'sess-1', title: 'shell' }],
+    layoutTree: {
+      type: 'split',
+      splitId: 'split-1',
+      direction: 'vertical',
+      ratio: 0.6,
+      children: [
+        { type: 'pane', paneId: 'pane-term' },
+        { type: 'tile', tileId: 'tile-notes', tileKind: 'markdown', tileParams: '/tmp/project/NOTES.md' },
+      ],
+    },
+  };
+}
+
+function renderSplit(overrides: { onClosePane?: () => void; onUndockTile?: (tileId: string) => void } = {}) {
+  const onClosePane = overrides.onClosePane ?? vi.fn();
+  const onUndockTile = overrides.onUndockTile ?? vi.fn();
+  const utils = render(
+    <SessionTerminalWorkspace
+      workspaceId="workspace-split"
+      workspaceSessions={[{ id: 'sess-1', label: 'shell', agent: 'shell', cwd: '/tmp/project' }]}
+      workspace={paneAndTileWorkspace()}
+      activePaneId="pane-term"
+      fontSize={13}
+      enabled
+      isActiveSession
+      eventRouter={createPaneRuntimeEventRouterController()}
+      onSplitPane={vi.fn()}
+      onClosePane={onClosePane}
+      onFocusPane={vi.fn()}
+      onNavigateOutOfSession={vi.fn()}
+      onUndockTile={onUndockTile}
+      tileContents={{
+        [tileContentKey('workspace-split', 'tile-notes')]: {
+          path: '/tmp/project/NOTES.md',
+          content: '# Project notes',
+        },
+      }}
+      onRequestTileContent={vi.fn()}
+    />,
+  );
+  return { ...utils, onClosePane, onUndockTile };
+}
+
+describe('SessionTerminalWorkspace Cmd+W closes the focused leaf', () => {
+  // Regression: Cmd+W from inside a docked notebook tile used to close the
+  // previously-active terminal pane (activePaneId still pointed at it), killing
+  // the wrong leaf. It must undock the focused tile instead.
+  it('undocks the focused tile instead of closing the active terminal pane', () => {
+    const { container, onClosePane, onUndockTile } = renderSplit();
+
+    const tile = container.querySelector('[data-pane-kind="tile"]');
+    expect(tile?.getAttribute('data-pane-id')).toBe('tile-notes');
+    const tileBody = tile?.querySelector('.workspace-dock-tile-body') as HTMLElement;
+    expect(tileBody).toBeTruthy();
+    tileBody.focus();
+
+    fireEvent.keyDown(tileBody, { key: 'w', metaKey: true });
+
+    expect(onUndockTile).toHaveBeenCalledTimes(1);
+    expect(onUndockTile).toHaveBeenCalledWith('tile-notes');
+    expect(onClosePane).not.toHaveBeenCalled();
+  });
+
+  // The terminal-pane path is unchanged: Cmd+W with focus on a terminal pane
+  // closes that pane (activePaneId), never the tile.
+  it('closes the active terminal pane when focus is not inside a tile', () => {
+    const { container, onClosePane, onUndockTile } = renderSplit();
+
+    const pane = container.querySelector('[data-pane-kind="agent"]') as HTMLElement;
+    expect(pane?.getAttribute('data-pane-id')).toBe('pane-term');
+
+    fireEvent.keyDown(pane, { key: 'w', metaKey: true });
+
+    expect(onClosePane).toHaveBeenCalledTimes(1);
+    expect(onClosePane).toHaveBeenCalledWith('pane-term');
+    expect(onUndockTile).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -546,9 +546,24 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       onClosePane(paneId);
     }, [onClosePane]);
 
-    const handleCloseActivePane = useCallback(() => {
+    // Cmd+W closes the focused leaf. A docked tile (e.g. a notebook tile beside a
+    // terminal) lives inside .session-terminal-workspace, so the global dispatcher
+    // routes its Cmd+W to terminal.close — but the tile is not a terminal pane and
+    // `activePaneId` still points at the terminal that was last focused. Without the
+    // tile check below, Cmd+W from inside the notebook would kill that previous pane
+    // (the reported bug). When focus is inside a tile, undock THAT tile instead.
+    const handleCloseFocusedLeaf = useCallback(() => {
+      const focused = document.activeElement;
+      const tileEl = focused instanceof HTMLElement
+        ? focused.closest('[data-pane-kind="tile"]')
+        : null;
+      const tileId = tileEl?.getAttribute('data-pane-id');
+      if (tileId) {
+        onUndockTile?.(tileId);
+        return;
+      }
       handleClosePane(activePaneId);
-    }, [activePaneId, handleClosePane]);
+    }, [activePaneId, handleClosePane, onUndockTile]);
 
     const toggleMaximizeActivePane = useCallback(() => {
       setZoomedPaneId(null);
@@ -599,7 +614,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     useShortcut('terminal.splitHorizontal', () => { handleSplit('horizontal'); }, sessionVisible);
     useShortcut('terminal.toggleZoom', toggleZoomActivePane, sessionVisible);
     useShortcut('terminal.toggleMaximize', toggleMaximizeActivePane, sessionVisible);
-    useShortcut('terminal.close', handleCloseActivePane, sessionVisible && splitLayoutActive);
+    useShortcut('terminal.close', handleCloseFocusedLeaf, sessionVisible && splitLayoutActive);
     useShortcut('terminal.focusLeft', () => handleMovePane('left'), sessionVisible);
     useShortcut('terminal.focusRight', () => handleMovePane('right'), sessionVisible);
     useShortcut('terminal.focusUp', () => handleMovePane('up'), sessionVisible);


### PR DESCRIPTION
## Problem
With a Notebook tile docked next to a terminal, pressing **⌘W** while reading or editing a note closed the *previously-focused terminal pane* (ending that session) instead of the note you were looking at.

## Root cause
A docked tile lives inside `.session-terminal-workspace`, so the ⌘W close handlers treated it as a pane-close and closed `activePaneId` — the last-focused terminal pane — regardless of focus being in the tile.

The subtle part: **⌘W takes two different routes**, so both close handlers had to be fixed:
- **dev / browser / e2e:** DOM dispatcher → `terminal.close` (`handleCloseFocusedLeaf` in `SessionTerminalWorkspace`)
- **packaged app:** the native "Close Pane" menu item claims ⌘W and dispatches `session.close` (`handleCloseCurrentSessionShortcut` in `App.tsx`). The native menu swallows the key, so the DOM `terminal.close` never runs there — fixing only it would pass every test yet stay broken in the real app.

## Fix
Both handlers now detect a focused tile via `document.activeElement.closest('[data-pane-kind="tile"]')` (tiles carry `data-pane-kind="tile"` + `data-pane-id`; terminal panes are `data-pane-kind="agent"`) and **undock that tile** instead of closing the terminal pane.

## Tests / verification
- New unit test (2 cases) for the DOM `terminal.close` path.
- New packaged-app scenario `real-app:scenario-notebook-tile-close` exercising the **real native ⌘W** → undock (needs Accessibility, like the sibling finder scenario).
- Full frontend suite green (1137 passed); `tsc` clean.
- Verified in the **real running dev app** over the automation channel: docked a notebook tile beside a terminal, confirmed focus in the tile, fired ⌘W → tile undocked, terminal pane + session both survived. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)