### PR TITLE
test(notebook): de-flake the live-markdown scroll e2e

### DIFF
--- a/app/e2e/live-markdown-editor.spec.ts
+++ b/app/e2e/live-markdown-editor.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 // Editing controls the LiveMarkdownEditor harness exposes for the scroll tests below.
 declare global {
@@ -8,6 +8,24 @@ declare global {
       swapValue: (next: string) => void;
     };
   }
+}
+
+// Scroll well down into the long note and wait for CodeMirror to ACKNOWLEDGE the scroll
+// before returning the settled scrollTop. This gate matters: CM doesn't react to a raw
+// `scrollTop =` write until its scroll listener fires a measure that moves its internal
+// scroll anchor. Acting before that measure races CM — and a full-document swap that
+// finds the anchor still pinned at the top has nothing to snap *from*, so it leaves the
+// viewport where it was instead of jumping to the top. (That race flaked the contrast
+// test below on slow CI: scrollTop stuck at ~608 where it expected < 50.) CM virtualizes,
+// so a deep below-the-fold line is rendered into the DOM only once that scroll measure
+// has run — making "paragraph 25 is attached" a deterministic "CM has settled" signal.
+async function scrollIntoLongNote(page: Page): Promise<number> {
+  const scroller = page.locator('.cm-scroller');
+  await scroller.evaluate((el) => { el.scrollTop = 600; });
+  await expect(
+    page.locator('.cm-line', { hasText: 'Paragraph line number 25 of the long note' }),
+  ).toBeAttached();
+  return scroller.evaluate((el) => el.scrollTop);
 }
 
 // The notebook's single read-and-type surface (CodeMirror live preview), rendered
@@ -127,9 +145,8 @@ test.describe('LiveMarkdownEditor (live preview)', () => {
     await page.waitForSelector('.cm-content');
 
     const scroller = page.locator('.cm-scroller');
-    // Scroll well down into the long note.
-    await scroller.evaluate((el) => { el.scrollTop = 600; });
-    const before = await scroller.evaluate((el) => el.scrollTop);
+    // Scroll well down into the long note, and wait for CM to settle there first.
+    const before = await scrollIntoLongNote(page);
     expect(before).toBeGreaterThan(400);
 
     // An agent rewrites a line near the END of the note (below the fold). Applied as a
@@ -148,8 +165,11 @@ test.describe('LiveMarkdownEditor (live preview)', () => {
       return !!last && last.includes('EDITED BY AGENT');
     });
     // ... and the scroller did NOT jump (allow a couple px for re-measure rounding).
-    const after = await scroller.evaluate((el) => el.scrollTop);
-    expect(Math.abs(after - before)).toBeLessThanOrEqual(4);
+    // Poll the settled offset rather than reading once, so a transient re-measure can't
+    // flip the result; a real regression that snaps to the top stays ~600px off and fails.
+    await expect
+      .poll(() => scroller.evaluate((el, b) => Math.abs(el.scrollTop - b), before))
+      .toBeLessThanOrEqual(4);
   });
 
   test('contrast: a full value swap snaps the scroller to the top (the bug the fix avoids)', async ({ page }) => {
@@ -161,8 +181,11 @@ test.describe('LiveMarkdownEditor (live preview)', () => {
     await page.waitForSelector('.cm-content');
 
     const scroller = page.locator('.cm-scroller');
-    await scroller.evaluate((el) => { el.scrollTop = 600; });
-    expect(await scroller.evaluate((el) => el.scrollTop)).toBeGreaterThan(400);
+    // Wait for CM to settle at the scrolled position before swapping — otherwise the
+    // full-document swap races CM's scroll measure and may not snap to the top (see
+    // scrollIntoLongNote). The snap below is what we're proving, so the precondition
+    // has to be deterministic.
+    expect(await scrollIntoLongNote(page)).toBeGreaterThan(400);
 
     await page.evaluate(() => {
       const doc = Array.from({ length: 80 }, (_, i) => `Paragraph line number ${i + 1} of the long note.`);


### PR DESCRIPTION
## Problem

A Playwright e2e in `app/e2e/live-markdown-editor.spec.ts` is flaky and currently **red on `main`** (it slipped through when #390 merged past it).

**Note on which test:** the task brief pointed at the *minimal-edit* test (line 119), but the [CI logs for the failing run](https://github.com/victorarias/attn/actions/runs/27916984795) show that test **passed** — the one that actually **failed** is its sibling, **"contrast: a full value swap snaps the scroller to the top"** (line 155):

```
> 177 |  await expect.poll(() => scroller.evaluate((el) => el.scrollTop)).toBeLessThan(50);
Expected: < 50
Received:   608
```

## Root cause (verified, not assumed)

The contrast test sets `.cm-scroller` `scrollTop = 600`, immediately swaps the whole document (the react-codemirror full-`value` replace), then asserts the viewport snapped to the top.

CodeMirror reacts to a raw `scrollTop =` write only **after** its scroll listener fires a measure that moves its internal scroll **anchor**. When the full-document swap races ahead of that measure (likely on a slow CI runner), CM's anchor is still pinned at the top, so the full replace has nothing to snap *from* and leaves the viewport at ~608.

I reproduced the **exact** CI value (`608`) locally by running the scroll-then-swap in a single tick (so CM never processes the scroll first) — and again under CDP CPU throttling.

The minimal-edit sibling never flaked because a below-the-fold edit preserves scroll *either way*, so it tolerated the same race — which is why it stayed green on CI.

## Fix (test-only — no product change)

- Add a `scrollIntoLongNote()` helper that scrolls down and then **waits for CM to acknowledge the scroll** before acting. CM virtualizes, so a deep below-the-fold line (`"Paragraph line number 25 …"`) is attached to the DOM only after the scroll measure has run — a deterministic "CM has settled" signal.
- Use it in **both** scroll tests so their precondition is deterministic.
- In the minimal-edit test, **poll the settled offset** (`expect.poll`) instead of reading `scrollTop` once.

**Intent preserved** — the tests still fail on a real regression: the swap must reach `< 50`, and the minimal edit must stay within `4px` of the scrolled position (a snap-to-top lands ~600px off).

No editor/scroll product code was touched; this is the documented CM-virtualization behavior, not a product bug.

## Verification

- Reproduced the exact CI failure (`608`) with the old code under CPU throttling.
- Fixed spec: **60/60** green on both scroll tests at **40× CPU throttle** (CI-like slowness), and **320/320** unthrottled (`--repeat-each=40`, full file).