### PR TITLE
feat(sidebar): badge sessions delegated from the chief of staff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-06-22]
 
 ### Added
-- **See which sessions your chief of staff started.** Sessions the chief of staff delegated now carry a small "↳ chief" badge in the sidebar, right where the chief's own badge sits — so at a glance you can tell the agents the chief spun up from the ones you started yourself. Only delegations that came from the chief get the badge; a plain hand-off between two regular sessions doesn't, and the chief's own badge is unchanged.
+- **See which sessions your chief of staff started.** Sessions the chief of staff delegated now carry a small "↳" marker in the sidebar, next to where the chief's own badge sits — so at a glance you can tell the agents the chief spun up from the ones you started yourself. Only delegations that came from the chief get it; a plain hand-off between two regular sessions doesn't.
+
+### Changed
+- **The chief of staff is now blue.** The chief-of-staff badge (in the sidebar and the dashboard) and its related controls — the "Make chief of staff" action and the transfer confirmation — moved from the app's orange accent to a distinct blue, giving the chief its own identity and setting the new delegated-from-chief marker (which shares that blue) apart from everything else.
 
 ## [2026-06-21]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-22]
+
+### Added
+- **See which sessions your chief of staff started.** Sessions the chief of staff delegated now carry a small "↳ chief" badge in the sidebar, right where the chief's own badge sits — so at a glance you can tell the agents the chief spun up from the ones you started yourself. Only delegations that came from the chief get the badge; a plain hand-off between two regular sessions doesn't, and the chief's own badge is unchanged.
+
 ## [2026-06-21]
 
 ### Fixed

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1239,6 +1239,7 @@ sendFetchPRDetails,
       recoverable: daemonSession?.recoverable ?? false,
       reviewLoopStatus: reviewLoop?.status,
       chiefOfStaff: daemonSession?.chief_of_staff ?? false,
+      delegatedFromChief: daemonSession?.delegated_from_chief ?? false,
     };
   });
 

--- a/app/src/components/ChiefOfStaffBadge.css
+++ b/app/src/components/ChiefOfStaffBadge.css
@@ -1,9 +1,9 @@
 .chief-of-staff-badge {
   align-items: center;
-  background: rgba(255, 107, 53, 0.1);
-  border: 1px solid rgba(255, 107, 53, 0.32);
+  background: rgba(88, 166, 255, 0.12);
+  border: 1px solid rgba(88, 166, 255, 0.36);
   border-radius: 4px;
-  color: #ff8b61;
+  color: #79b8ff;
   display: inline-flex;
   flex-shrink: 0;
   font-family: 'JetBrains Mono', monospace;

--- a/app/src/components/ChiefOfStaffTransferPrompt.css
+++ b/app/src/components/ChiefOfStaffTransferPrompt.css
@@ -67,12 +67,12 @@
 }
 
 .chief-transfer-actions .confirm {
-  background: rgba(255, 107, 53, 0.14);
-  border-color: rgba(255, 107, 53, 0.35);
-  color: #ff8b61;
+  background: rgba(88, 166, 255, 0.14);
+  border-color: rgba(88, 166, 255, 0.35);
+  color: #79b8ff;
 }
 
 .chief-transfer-actions button:focus-visible {
-  outline: 2px solid rgba(255, 107, 53, 0.6);
+  outline: 2px solid rgba(88, 166, 255, 0.6);
   outline-offset: 2px;
 }

--- a/app/src/components/DelegatedFromChiefBadge.css
+++ b/app/src/components/DelegatedFromChiefBadge.css
@@ -1,29 +1,20 @@
-/* Visually analogous to the chief-of-staff badge (same orange family, same
-   dimensions and glyph-then-label structure) but outline-only and a touch
-   muted, so a session delegated FROM the chief reads as related to — yet
-   distinct from — the chief session's own filled badge. */
+/* A session delegated FROM the chief carries a small icon-only "↳" chip in the
+   chief's blue family — the shared blue reads as "spawned from the chief", while
+   the tiny icon (vs the chief's worded "⌁ CHIEF" badge) keeps the two distinct. */
 .delegated-from-chief-badge {
   align-items: center;
-  background: transparent;
-  border: 1px solid rgba(255, 107, 53, 0.28);
-  border-radius: 4px;
-  color: #e6a07e;
+  background: rgba(88, 166, 255, 0.14);
+  border: 1px solid rgba(88, 166, 255, 0.34);
+  border-radius: 999px;
+  color: #79b8ff;
   display: inline-flex;
   flex-shrink: 0;
   font-family: 'JetBrains Mono', monospace;
-  font-size: var(--font-size-xs);
-  font-weight: 600;
-  gap: 3px;
-  letter-spacing: 0.06em;
-  line-height: 1;
-  padding: 3px 5px;
-  text-transform: uppercase;
-}
-
-.delegated-from-chief-badge.compact {
-  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
   height: 18px;
   justify-content: center;
+  line-height: 1;
   min-width: 18px;
-  padding: 0 5px;
+  padding: 0;
 }

--- a/app/src/components/DelegatedFromChiefBadge.css
+++ b/app/src/components/DelegatedFromChiefBadge.css
@@ -1,0 +1,29 @@
+/* Visually analogous to the chief-of-staff badge (same orange family, same
+   dimensions and glyph-then-label structure) but outline-only and a touch
+   muted, so a session delegated FROM the chief reads as related to — yet
+   distinct from — the chief session's own filled badge. */
+.delegated-from-chief-badge {
+  align-items: center;
+  background: transparent;
+  border: 1px solid rgba(255, 107, 53, 0.28);
+  border-radius: 4px;
+  color: #e6a07e;
+  display: inline-flex;
+  flex-shrink: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  gap: 3px;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  padding: 3px 5px;
+  text-transform: uppercase;
+}
+
+.delegated-from-chief-badge.compact {
+  border-radius: 999px;
+  height: 18px;
+  justify-content: center;
+  min-width: 18px;
+  padding: 0 5px;
+}

--- a/app/src/components/DelegatedFromChiefBadge.test.tsx
+++ b/app/src/components/DelegatedFromChiefBadge.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { DelegatedFromChiefBadge } from './DelegatedFromChiefBadge';
+
+describe('DelegatedFromChiefBadge', () => {
+  it('renders the label and an accessible name by default', () => {
+    render(<DelegatedFromChiefBadge />);
+    const badge = screen.getByLabelText('Delegated from chief of staff');
+    expect(badge).toHaveTextContent('chief');
+    expect(badge).toHaveClass('delegated-from-chief-badge');
+    expect(badge).not.toHaveClass('compact');
+  });
+
+  it('hides the text label and adds the compact class in compact mode', () => {
+    render(<DelegatedFromChiefBadge compact />);
+    const badge = screen.getByLabelText('Delegated from chief of staff');
+    expect(badge).toHaveClass('compact');
+    expect(badge).not.toHaveTextContent('chief');
+  });
+});

--- a/app/src/components/DelegatedFromChiefBadge.test.tsx
+++ b/app/src/components/DelegatedFromChiefBadge.test.tsx
@@ -3,18 +3,12 @@ import { describe, it, expect } from 'vitest';
 import { DelegatedFromChiefBadge } from './DelegatedFromChiefBadge';
 
 describe('DelegatedFromChiefBadge', () => {
-  it('renders the label and an accessible name by default', () => {
+  it('renders an icon-only chip with an accessible name and no text label', () => {
     render(<DelegatedFromChiefBadge />);
     const badge = screen.getByLabelText('Delegated from chief of staff');
-    expect(badge).toHaveTextContent('chief');
     expect(badge).toHaveClass('delegated-from-chief-badge');
-    expect(badge).not.toHaveClass('compact');
-  });
-
-  it('hides the text label and adds the compact class in compact mode', () => {
-    render(<DelegatedFromChiefBadge compact />);
-    const badge = screen.getByLabelText('Delegated from chief of staff');
-    expect(badge).toHaveClass('compact');
-    expect(badge).not.toHaveTextContent('chief');
+    // Icon-only: the "↳" glyph is present but no worded label like "chief".
+    expect(badge).toHaveTextContent('↳');
+    expect(badge.textContent).not.toMatch(/chief/i);
   });
 });

--- a/app/src/components/DelegatedFromChiefBadge.tsx
+++ b/app/src/components/DelegatedFromChiefBadge.tsx
@@ -1,0 +1,18 @@
+import './DelegatedFromChiefBadge.css';
+
+interface DelegatedFromChiefBadgeProps {
+  compact?: boolean;
+}
+
+export function DelegatedFromChiefBadge({ compact = false }: DelegatedFromChiefBadgeProps) {
+  return (
+    <span
+      className={`delegated-from-chief-badge ${compact ? 'compact' : ''}`}
+      title="Delegated from chief of staff"
+      aria-label="Delegated from chief of staff"
+    >
+      <span aria-hidden="true">↳</span>
+      {!compact && <span>chief</span>}
+    </span>
+  );
+}

--- a/app/src/components/DelegatedFromChiefBadge.tsx
+++ b/app/src/components/DelegatedFromChiefBadge.tsx
@@ -1,18 +1,13 @@
 import './DelegatedFromChiefBadge.css';
 
-interface DelegatedFromChiefBadgeProps {
-  compact?: boolean;
-}
-
-export function DelegatedFromChiefBadge({ compact = false }: DelegatedFromChiefBadgeProps) {
+export function DelegatedFromChiefBadge() {
   return (
     <span
-      className={`delegated-from-chief-badge ${compact ? 'compact' : ''}`}
+      className="delegated-from-chief-badge"
       title="Delegated from chief of staff"
       aria-label="Delegated from chief of staff"
     >
       <span aria-hidden="true">↳</span>
-      {!compact && <span>chief</span>}
     </span>
   );
 }

--- a/app/src/components/SessionActionsPopover.css
+++ b/app/src/components/SessionActionsPopover.css
@@ -41,7 +41,7 @@
 }
 
 .session-actions-popover .chief-of-staff-action {
-  color: #ff8b61;
+  color: #79b8ff;
 }
 
 .session-actions-divider {

--- a/app/src/components/Sidebar.test.tsx
+++ b/app/src/components/Sidebar.test.tsx
@@ -29,6 +29,7 @@ interface TestSession {
   recoverable?: boolean;
   reviewLoopStatus?: string;
   chiefOfStaff?: boolean;
+  delegatedFromChief?: boolean;
 }
 
 function buildSidebarData(sessions: TestSession[]) {
@@ -429,6 +430,24 @@ describe('Sidebar', () => {
     );
 
     expect(screen.getByLabelText('Review loop running')).toBeInTheDocument();
+  });
+
+  it('shows the delegated-from-chief badge only on sessions delegated from the chief', () => {
+    const sessions: TestSession[] = [
+      { id: 's1', label: 'delegated', state: 'working', agent: 'claude', delegatedFromChief: true },
+      { id: 's2', label: 'self-started', state: 'working', agent: 'claude' },
+    ];
+    render(
+      <Sidebar
+        {...baseProps}
+        {...buildSidebarData(sessions)}
+      />
+    );
+
+    const badges = screen.getAllByLabelText('Delegated from chief of staff');
+    expect(badges).toHaveLength(1);
+    expect(screen.getByTestId('sidebar-session-s1')).toContainElement(badges[0]);
+    expect(screen.getByTestId('sidebar-session-s2')).not.toContainElement(badges[0]);
   });
 
   it('renders workspace shortcuts in workspace visual order', () => {

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent, 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { RenamePopover } from './RenamePopover';
 import { ChiefOfStaffBadge } from './ChiefOfStaffBadge';
+import { DelegatedFromChiefBadge } from './DelegatedFromChiefBadge';
 import { SessionActionsPopover } from './SessionActionsPopover';
 import { GridLayoutControl } from './grid/GridLayoutControl';
 import type { GridLayout } from './grid/gridLayout';
@@ -27,6 +28,7 @@ interface LocalSession {
   recoverable?: boolean;
   reviewLoopStatus?: string;
   chiefOfStaff?: boolean;
+  delegatedFromChief?: boolean;
 }
 
 type SidebarWorkspace = WorkspaceWithSessions<LocalSession>;
@@ -1027,6 +1029,7 @@ export function Sidebar({
                       <span className="session-recoverable">recoverable</span>
                     )}
                     {session.chiefOfStaff && <ChiefOfStaffBadge />}
+                    {session.delegatedFromChief && <DelegatedFromChiefBadge />}
                     {reviewLoopIndicator(session.reviewLoopStatus) && (
                       <span
                         className={`session-loop-indicator session-loop-indicator--${session.reviewLoopStatus}`}
@@ -1175,6 +1178,7 @@ export function Sidebar({
                           <StateIndicator state={session.state} size="md" seed={session.id} />
                           <span className="session-label">{session.label}</span>
                           {session.chiefOfStaff && <ChiefOfStaffBadge />}
+                          {session.delegatedFromChief && <DelegatedFromChiefBadge />}
                           {session.endpointName && (
                             <span className={`session-endpoint-badge status-${session.endpointStatus || 'connected'}`}>
                               {session.endpointName}

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -172,7 +172,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '117';
+export const PROTOCOL_VERSION = '118';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -497,6 +497,7 @@ export interface SessionElement {
     agent:                        string;
     branch?:                      string;
     chief_of_staff?:              boolean;
+    delegated_from_chief?:        boolean;
     directory:                    string;
     endpoint_id?:                 string;
     id:                           string;
@@ -3252,6 +3253,7 @@ export interface Session {
     agent:                        string;
     branch?:                      string;
     chief_of_staff?:              boolean;
+    delegated_from_chief?:        boolean;
     directory:                    string;
     endpoint_id?:                 string;
     id:                           string;
@@ -7023,6 +7025,7 @@ const typeMap: any = {
         { json: "agent", js: "agent", typ: "" },
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
+        { json: "delegated_from_chief", js: "delegated_from_chief", typ: u(undefined, true) },
         { json: "directory", js: "directory", typ: "" },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "id", js: "id", typ: "" },
@@ -8654,6 +8657,7 @@ const typeMap: any = {
         { json: "agent", js: "agent", typ: "" },
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "chief_of_staff", js: "chief_of_staff", typ: u(undefined, true) },
+        { json: "delegated_from_chief", js: "delegated_from_chief", typ: u(undefined, true) },
         { json: "directory", js: "directory", typ: "" },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "id", js: "id", typ: "" },

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -46,6 +46,30 @@ func (d *Daemon) decorateChiefOfStaffWithSessionID(session *protocol.Session, ch
 	session.ChiefOfStaff = nil
 }
 
+// delegatedFromChiefSessionIDs returns the set of session IDs that the chief of
+// staff delegated, so a single broadcast can decorate every session without one
+// store lookup per session.
+func (d *Daemon) delegatedFromChiefSessionIDs() map[string]bool {
+	if d.store == nil {
+		return nil
+	}
+	return d.store.DelegatedFromChiefSessionIDs()
+}
+
+// decorateDelegatedFromChief marks a session that was delegated from the chief
+// of staff. Mirrors decorateChiefOfStaffWithSessionID: the field is set only
+// when true and cleared otherwise so it round-trips as an omitted boolean.
+func (d *Daemon) decorateDelegatedFromChief(session *protocol.Session, delegatedFromChief map[string]bool) {
+	if session == nil {
+		return
+	}
+	if delegatedFromChief[session.ID] {
+		session.DelegatedFromChief = protocol.Ptr(true)
+		return
+	}
+	session.DelegatedFromChief = nil
+}
+
 func (d *Daemon) sessionExists(sessionID string) bool {
 	if d.store != nil && d.store.Get(sessionID) != nil {
 		return true

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2599,12 +2599,17 @@ func cloneSession(session *protocol.Session) *protocol.Session {
 }
 
 func (d *Daemon) sessionForBroadcast(session *protocol.Session) *protocol.Session {
-	return d.sessionForBroadcastWithChiefOfStaff(session, d.chiefOfStaffSessionID())
+	return d.sessionForBroadcastWithChiefOfStaff(
+		session,
+		d.chiefOfStaffSessionID(),
+		d.delegatedFromChiefSessionIDs(),
+	)
 }
 
 func (d *Daemon) sessionForBroadcastWithChiefOfStaff(
 	session *protocol.Session,
 	chiefOfStaffSessionID string,
+	delegatedFromChief map[string]bool,
 ) *protocol.Session {
 	clone := cloneSession(session)
 	if clone == nil {
@@ -2616,6 +2621,7 @@ func (d *Daemon) sessionForBroadcastWithChiefOfStaff(
 		clone.NeedsReviewAfterLongRun = nil
 	}
 	d.decorateChiefOfStaffWithSessionID(clone, chiefOfStaffSessionID)
+	d.decorateDelegatedFromChief(clone, delegatedFromChief)
 	d.decorateSessionWithWorkspace(clone)
 	return clone
 }
@@ -2625,9 +2631,10 @@ func (d *Daemon) sessionsForBroadcast(sessions []*protocol.Session) []protocol.S
 		return nil
 	}
 	chiefOfStaffSessionID := d.chiefOfStaffSessionID()
+	delegatedFromChief := d.delegatedFromChiefSessionIDs()
 	out := make([]protocol.Session, 0, len(sessions))
 	for _, session := range sessions {
-		if decorated := d.sessionForBroadcastWithChiefOfStaff(session, chiefOfStaffSessionID); decorated != nil {
+		if decorated := d.sessionForBroadcastWithChiefOfStaff(session, chiefOfStaffSessionID, delegatedFromChief); decorated != nil {
 			out = append(out, *decorated)
 		}
 	}

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -182,6 +182,87 @@ func TestChiefOfStaffDelegateCreatesTrackedDispatch(t *testing.T) {
 	}
 }
 
+func TestDelegatedFromChiefDecoratesBroadcastSession(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, sourceSessionID); err != nil {
+		t.Fatalf("set chief role: %v", err)
+	}
+	consumeDelegatedPrompt(t, backend)
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Investigate the tracked task.",
+		Agent:           protocol.Ptr("codex"),
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+
+	// Exercise the same list-broadcast path the sidebar receives.
+	var delegated, chief *protocol.Session
+	for _, session := range d.sessionsForBroadcast(d.store.List("")) {
+		session := session
+		switch session.ID {
+		case result.SessionID:
+			delegated = &session
+		case sourceSessionID:
+			chief = &session
+		}
+	}
+
+	if delegated == nil {
+		t.Fatal("delegated session missing from broadcast")
+	}
+	if !protocol.Deref(delegated.DelegatedFromChief) {
+		t.Fatalf("delegated session = %+v, want delegated_from_chief=true", delegated)
+	}
+	if protocol.Deref(delegated.ChiefOfStaff) {
+		t.Fatalf("delegated session should not be the chief itself: %+v", delegated)
+	}
+
+	if chief == nil {
+		t.Fatal("chief session missing from broadcast")
+	}
+	if !protocol.Deref(chief.ChiefOfStaff) {
+		t.Fatalf("chief session = %+v, want chief_of_staff=true", chief)
+	}
+	if protocol.Deref(chief.DelegatedFromChief) {
+		t.Fatalf("chief session should not carry delegated_from_chief: %+v", chief)
+	}
+}
+
+func TestOrdinaryDelegationDoesNotDecorateDelegatedFromChief(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	// No chief role is set, so this is a plain session-to-session delegation.
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Plain delegated task.",
+		Agent:           protocol.Ptr("codex"),
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	if result.DispatchID != nil {
+		t.Fatalf("ordinary delegation should not create a dispatch: %+v", result)
+	}
+
+	delegated := d.sessionForBroadcast(d.store.Get(result.SessionID))
+	if delegated == nil {
+		t.Fatal("delegated session missing")
+	}
+	if protocol.Deref(delegated.DelegatedFromChief) {
+		t.Fatalf("ordinary delegated session should not carry delegated_from_chief: %+v", delegated)
+	}
+}
+
 func TestDispatchReportUpdatesTrackedRecord(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "117"
+const ProtocolVersion = "118"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -3216,6 +3216,9 @@ type Session struct {
 	// ChiefOfStaff corresponds to the JSON schema field "chief_of_staff".
 	ChiefOfStaff *bool `json:"chief_of_staff,omitempty,omitzero"`
 
+	// DelegatedFromChief corresponds to the JSON schema field "delegated_from_chief".
+	DelegatedFromChief *bool `json:"delegated_from_chief,omitempty,omitzero"`
+
 	// Directory corresponds to the JSON schema field "directory".
 	Directory string `json:"directory"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -169,6 +169,7 @@ model Session {
   needs_review_after_long_run?: boolean; // True when a 5m+ run finished and awaits user visualization
   recoverable?: boolean;        // True when session can be recovered after daemon restart (agent has resumable conversation)
   chief_of_staff?: boolean;     // True when this session holds the profile-wide coordinator role
+  delegated_from_chief?: boolean; // True when this session was delegated from the chief of staff (has a chief dispatch)
   todos?: string[];             // Optional: can be empty/absent
   last_seen: string;            // ISO timestamp, always set
 }

--- a/internal/store/chief_of_staff_dispatches.go
+++ b/internal/store/chief_of_staff_dispatches.go
@@ -176,6 +176,44 @@ func (s *Store) GetChiefOfStaffDispatchBySession(sessionID string) *protocol.Chi
 	return scanChiefOfStaffDispatch(row)
 }
 
+// DelegatedFromChiefSessionIDs returns the set of session IDs that were
+// delegated from the chief of staff. A chief-of-staff dispatch is created only
+// when a session is delegated and its source session is the current chief (see
+// daemon.delegate's trackedByChief), and dispatch records are retained for the
+// session's lifetime, so a dispatch's existence is exactly the "delegated from
+// chief" signal. This bulk read lets a single broadcast decorate every session
+// without one query per session.
+func (s *Store) DelegatedFromChiefSessionIDs() map[string]bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make(map[string]bool)
+	if s.db == nil {
+		for _, dispatch := range s.chiefDispatches {
+			if sid := strings.TrimSpace(dispatch.SessionID); sid != "" {
+				out[sid] = true
+			}
+		}
+		return out
+	}
+
+	rows, err := s.db.Query("SELECT session_id FROM chief_of_staff_dispatches")
+	if err != nil {
+		return out
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var sessionID string
+		if err := rows.Scan(&sessionID); err != nil {
+			continue
+		}
+		if sid := strings.TrimSpace(sessionID); sid != "" {
+			out[sid] = true
+		}
+	}
+	return out
+}
+
 func (s *Store) GetChiefOfStaffDispatch(id string) *protocol.ChiefOfStaffDispatch {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/store/chief_of_staff_dispatches_test.go
+++ b/internal/store/chief_of_staff_dispatches_test.go
@@ -52,6 +52,44 @@ func TestChiefOfStaffDispatchLifecycle(t *testing.T) {
 	}
 }
 
+func TestDelegatedFromChiefSessionIDs(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if ids := s.DelegatedFromChiefSessionIDs(); len(ids) != 0 {
+		t.Fatalf("empty store delegated set = %+v", ids)
+	}
+
+	now := string(protocol.TimestampNow())
+	add := func(id, sessionID string) {
+		t.Helper()
+		if err := s.AddChiefOfStaffDispatch(&protocol.ChiefOfStaffDispatch{
+			ID:             id,
+			ChiefSessionID: "chief-1",
+			SessionID:      sessionID,
+			WorkspaceID:    "workspace-1",
+			Brief:          "brief",
+			Label:          "label",
+			Agent:          "codex",
+			Directory:      "/tmp/project",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}); err != nil {
+			t.Fatalf("add dispatch %s: %v", id, err)
+		}
+	}
+	add("dispatch-1", "worker-1")
+	add("dispatch-2", "worker-2")
+
+	ids := s.DelegatedFromChiefSessionIDs()
+	if len(ids) != 2 || !ids["worker-1"] || !ids["worker-2"] {
+		t.Fatalf("delegated set = %+v", ids)
+	}
+	if ids["never-delegated"] {
+		t.Fatalf("unexpected non-delegated session in set: %+v", ids)
+	}
+}
+
 func TestChiefOfStaffDispatchMessageLifecycle(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "attn.db")
 	s, err := NewWithDB(dbPath)


### PR DESCRIPTION
## What

Sessions the chief of staff spun up via `attn delegate` now carry a small **`↳`** marker in the left sidebar — right where the chief's own badge sits — so at a glance you can tell the agents the chief started from the ones you started yourself.

![Delegated-from-chief sidebar badge](https://raw.githubusercontent.com/victorarias/attn/assets/pr-screenshots/docs/screenshots/delegated-from-chief-badge.png)

- **chief** session → its **`⌁ CHIEF`** badge — now **blue**
- **delegated-from-chief** session (`UI verific…`) → the **new blue icon-only `↳`** chip
- a normal, self-started session (`my-own-session`) → **no badge**

### A note on the colors

The first cut gave the delegated badge an orange `↳ chief` pill, which sat right next to the chief's own orange `⌁ CHIEF` pill and read as nearly the same thing. To pull them apart while keeping them related, this PR:

- shrinks the delegated badge to an **icon-only blue `↳` chip** (no word), and
- moves the **chief of staff to its own blue identity** across every chief surface: the badge (sidebar + dashboard), the **"Make chief of staff"** menu action, and the **chief-transfer confirmation** prompt.

Net: chief = a blue worded pill, delegated = a small blue icon chip in the same family, plain sessions unchanged.

## Signal I rendered on (and the data decision)

I did **not** add a new persisted column — the signal already exists end-to-end:

- The daemon creates a `chief_of_staff_dispatches` row **only** when a session is delegated and its **source session is the current chief** (`delegate.go`'s `trackedByChief := chiefSessionID == sourceSessionID`).
- That row is keyed **unique by the delegated `session_id`** and is **never deleted** (retained as history).

So a dispatch's existence *is* the "delegated from chief" truth, frozen at delegation time. A plain session-to-session delegation creates no dispatch, so it never gets the badge — which is exactly the requirement (chief-origin only).

I surface this as a **derived** `Session.delegated_from_chief` boolean, decorated onto the broadcast session exactly like the existing `chief_of_staff` field — no migration, no schema churn:

- **protocol**: add `Session.delegated_from_chief`; bump `ProtocolVersion` 117 → 118
- **store**: `DelegatedFromChiefSessionIDs()` — one bulk read of delegated session ids
- **daemon**: `decorateDelegatedFromChief`, precomputed once per broadcast and threaded through `sessionsForBroadcast` (no per-session query), mirroring `chief_of_staff`
- **frontend**: `DelegatedFromChiefBadge` (icon-only blue `↳` chip) rendered at both sidebar session-row sites and enriched in `App.tsx`; the chief badge and its sibling controls recolor to the shared blue

## Tests

- **store**: `TestDelegatedFromChiefSessionIDs`
- **daemon**: `TestDelegatedFromChiefDecoratesBroadcastSession` (chief-delegated → badge true, chief's own session → no badge) and `TestOrdinaryDelegationDoesNotDecorateDelegatedFromChief`
- **frontend**: `DelegatedFromChiefBadge.test.tsx` (icon-only, no worded label) + a Sidebar render test (badge appears on the delegated row only)
- full frontend suite, `go vet`, and `tsc` all green

## Manual verification

Built `attn-dev`, created a chief-of-staff session, delegated a session from it, and added a normal session in the same workspace. The screenshot above is the **real dev-app sidebar**: blue chief badge, the delegated session's new blue `↳` chip, and no badge on the normal session.

## Scope

Additive UI + the minimal data plumbing to support it, plus the chief recolor — not a refactor. No behavior change for non-delegated sessions; the only appearance change to existing surfaces is the chief's accent color (orange → blue).
