### PR TITLE
feat(dispatch): surface a crash/kill-on-close as a dispatch failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-06-23]
 
+### Changed
+- **A delegated agent that crashes or is killed mid-work now surfaces as a failure to its chief.** When a chief-of-staff dispatch's session ends, attn now tells a clean stop from a real crash: a session cut off while it was still working, starting up, or waiting on a tool approval is reported as a failure (`[failed]`), while a session that closed from a settled rest — or one attn couldn't classify — stays the neutral "ended" introduced with `dispatch watch`. attn still never claims a success the agent didn't report; this only makes a genuine crash visible instead of letting it look like an uneventful end.
+
 ### Fixed
 - **Long Notebook notes keep their rendered formatting and cursor position while you edit.** Moving the cursor beyond the first few thousand characters no longer turns the rest of a note back into raw Markdown or sends ArrowUp to the properties card. Clicking into the body also leaves the frontmatter card stable; raw YAML appears only when you click the card to edit it.
 - **Chief-of-staff delegations no longer disappear into muted workspaces.** Delegating into an existing muted workspace now brings that workspace back into the sidebar, and `attn list` marks sessions whose workspace is muted so the chief can see that state before choosing a target.

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -172,7 +172,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '120';
+export const PROTOCOL_VERSION = '121';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -684,6 +684,7 @@ export interface ChiefOfStaffDispatch {
     branch?:               string;
     brief:                 string;
     chief_session_id:      string;
+    closed_state?:         string;
     concise_summary?:      string;
     created_at:            string;
     directory:             string;
@@ -782,6 +783,7 @@ export interface ChiefOfStaffDispatchElement {
     branch?:               string;
     brief:                 string;
     chief_session_id:      string;
+    closed_state?:         string;
     concise_summary?:      string;
     created_at:            string;
     directory:             string;
@@ -7252,6 +7254,7 @@ const typeMap: any = {
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "brief", js: "brief", typ: "" },
         { json: "chief_session_id", js: "chief_session_id", typ: "" },
+        { json: "closed_state", js: "closed_state", typ: u(undefined, "") },
         { json: "concise_summary", js: "concise_summary", typ: u(undefined, "") },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "directory", js: "directory", typ: "" },
@@ -7317,6 +7320,7 @@ const typeMap: any = {
         { json: "branch", js: "branch", typ: u(undefined, "") },
         { json: "brief", js: "brief", typ: "" },
         { json: "chief_session_id", js: "chief_session_id", typ: "" },
+        { json: "closed_state", js: "closed_state", typ: u(undefined, "") },
         { json: "concise_summary", js: "concise_summary", typ: u(undefined, "") },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "directory", js: "directory", typ: "" },

--- a/docs/vision/chief-delegation-awareness.md
+++ b/docs/vision/chief-delegation-awareness.md
@@ -98,14 +98,19 @@ Coarse and expected to evolve — not a task tracker.
   failure; excludes routine approvals; covers crash states). In flight: PR #394
   (shared classifier in `internal/dispatch`, reuses `list_dispatches`, no new
   protocol surface) — ready to merge.
-- [ ] **Reliable doneness-on-close** — today a session that finishes *without*
-  filing a structured terminal report classifies as `failed` (the safe
-  silence≠success default), so a real success can surface as a false `[failed]`
-  once its session closes — and the *same* work reads `done` while idle but
-  `failed` once closed. Fix doneness at the source: the daemon infers completion
-  on a clean close, or agents reliably file a terminal report, so the signal
-  isn't a false alarm. Surfaced by the #394 alignment review; also closes the
-  re-arming open question below.
+- [x] **Reliable doneness-on-close** — a close without a structured terminal
+  report is now the neutral terminal `ended` (silence is neither success nor
+  failure), so an unreported success no longer cries a false `[failed]`. attn does
+  *not* infer completion on a clean close — doneness stays agent-claimed, never
+  guessed. The one close it *does* assert is a crash: the daemon captures the
+  delegated session's last attn-classified state the moment its process exits
+  (before the idle-clobber/removal erases it) and surfaces a close that was cut
+  off mid-flight — `working` / `launching` / `pending_approval` — as `failed`,
+  while a clean rest (`idle` / `waiting_input`) or an unconfirmed close (`unknown`
+  / unstamped) stays neutral `ended`. So a real crash is visible, a real success
+  is never overwritten, and the safe direction (never a false `done`) holds. The
+  neutral `ended` landed with the #394 alignment; crash-visibility-on-close
+  followed. Also resolves the re-arming caveat below.
 - [ ] **Delegation-time injection** — at delegation, attn instructs the chief to
   arm a persistent, non-blocking Monitor on the new dispatch. Scoped to the
   dispatch id, self-retiring on terminal, default-on but overridable.
@@ -157,9 +162,10 @@ Coarse and expected to evolve — not a task tracker.
   truth.)
 - **Re-arming across sessions.** If the chief compacts or restarts while a
   monitor is armed, how is the watch re-established from journal / dispatch
-  state so a thread isn't silently dropped? (Related: re-arming a watch on an
-  already-finished, already-closed agent reads `failed` for success until
-  *reliable doneness-on-close* lands.)
+  state so a thread isn't silently dropped? (The old failure mode here — re-arming
+  a watch on an already-finished, already-closed agent reading `failed` for a
+  success — is resolved: a clean close now reads neutral `ended`, and only a real
+  mid-flight crash reads `failed`. See *reliable doneness-on-close* above.)
 - **Idle-nudge reliability.** Does the pty "go check" nudge for non-Claude
   chiefs land reliably (idle detection, injection timing), or do some agents
   still need a self-driven timer as backstop?

--- a/internal/daemon/chief_of_staff_dispatch.go
+++ b/internal/daemon/chief_of_staff_dispatch.go
@@ -88,6 +88,9 @@ func (d *Daemon) decorateChiefOfStaffDispatch(dispatch *protocol.ChiefOfStaffDis
 	if dispatch.ReportedAt != nil {
 		decorated.ReportedAt = protocol.Ptr(protocol.Deref(dispatch.ReportedAt))
 	}
+	if dispatch.ClosedState != nil {
+		decorated.ClosedState = protocol.Ptr(protocol.Deref(dispatch.ClosedState))
+	}
 	decorated.StructuredReport = cloneDispatchReportForDisplay(dispatch.StructuredReport)
 	if decorated.StructuredReport != nil {
 		summary := strings.TrimSpace(decorated.StructuredReport.Summary)
@@ -109,7 +112,16 @@ func (d *Daemon) decorateChiefOfStaffDispatch(dispatch *protocol.ChiefOfStaffDis
 	} else {
 		d.logf("chief dispatch %s unread count: %v", dispatch.ID, err)
 	}
-	if session := d.store.Get(dispatch.SessionID); session != nil {
+	// A captured close-state means the delegated process has ended — even if a
+	// stale, idle-clobbered session record still lingers in the store (handlePTYExit
+	// forces idle on any exit without removing the record). Project the terminal
+	// "closed" status, carrying the captured close-state, so a crash/cut-off is
+	// classified the moment the process dies, not only once the record is finally
+	// removed. A live, unclosed dispatch falls through to its real runtime state.
+	if strings.TrimSpace(protocol.Deref(decorated.ClosedState)) != "" {
+		decorated.Status = closedDispatchStatus
+		decorated.StatusSince = ""
+	} else if session := d.store.Get(dispatch.SessionID); session != nil {
 		decorated.Status = string(session.State)
 		decorated.StatusSince = session.StateSince
 	} else {
@@ -117,6 +129,30 @@ func (d *Daemon) decorateChiefOfStaffDispatch(dispatch *protocol.ChiefOfStaffDis
 		decorated.StatusSince = ""
 	}
 	return &decorated
+}
+
+// captureDispatchCloseState records the delegated session's last attn-classified
+// runtime state onto its dispatch the first time the session is observed ending —
+// before handlePTYExit's idle-clobber or the store removal erases it. That state
+// is the signal Classify uses to tell a clean stop (idle / waiting_input) from a
+// real crash or kill mid-flight (working / launching / pending_approval), so a
+// cut-off close surfaces as a failure instead of a neutral end. First-writer-wins
+// in the store keeps the pre-clobber exit authoritative over any later teardown
+// read. A no-op for non-dispatch sessions; broadcasts only when a dispatch row was
+// actually stamped, so the dashboard reflects the new terminal classification at
+// once rather than at the next poll.
+func (d *Daemon) captureDispatchCloseState(sessionID, state string) {
+	if strings.TrimSpace(state) == "" {
+		return
+	}
+	_, changed, err := d.store.SetChiefOfStaffDispatchClosedStateBySession(sessionID, state)
+	if err != nil {
+		d.logf("capture dispatch close-state for %s: %v", sessionID, err)
+		return
+	}
+	if changed {
+		d.broadcastChiefOfStaffDispatchesUpdated()
+	}
 }
 
 func (d *Daemon) validateDispatchChief(dispatchID, chiefSessionID string) (*protocol.ChiefOfStaffDispatch, error) {

--- a/internal/daemon/chief_of_staff_dispatch_close_test.go
+++ b/internal/daemon/chief_of_staff_dispatch_close_test.go
@@ -1,0 +1,141 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/victorarias/attn/internal/dispatch"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
+)
+
+// addDispatchSession registers a delegated session in the given runtime state plus
+// the chief-of-staff dispatch tracking it, the shape a real delegated worker has
+// just before its process ends.
+func addDispatchSession(t *testing.T, d *Daemon, sessionID, dispatchID string, state protocol.SessionState) {
+	t.Helper()
+	addIdleNotebookSession(d, sessionID, state)
+	if err := d.store.AddChiefOfStaffDispatch(&protocol.ChiefOfStaffDispatch{
+		ID: dispatchID, ChiefSessionID: "chief", SessionID: sessionID, WorkspaceID: "ws",
+		Label: "Task", Agent: "claude", CreatedAt: "2026-06-22", UpdatedAt: "2026-06-22",
+	}); err != nil {
+		t.Fatalf("add dispatch: %v", err)
+	}
+}
+
+// classifyDispatch reads the durable dispatch for a session, decorates it exactly
+// as the watch/status paths do, and runs the shared signal classifier — the full
+// chain a chief sees.
+func classifyDispatch(t *testing.T, d *Daemon, sessionID string) (*protocol.ChiefOfStaffDispatch, dispatch.Event) {
+	t.Helper()
+	rec := d.store.GetChiefOfStaffDispatchBySession(sessionID)
+	if rec == nil {
+		t.Fatalf("no dispatch for session %s", sessionID)
+	}
+	decorated := d.decorateChiefOfStaffDispatch(rec)
+	return decorated, dispatch.Classify(*decorated)
+}
+
+// A worker killed mid-work must read as a failure, not a neutral end. handlePTYExit
+// captures the pre-clobber "working" state before forcing the lingering session to
+// idle; the decorated dispatch then projects a closed status carrying that
+// close-state, so the classifier surfaces a real crash instead of crying nothing.
+func TestDispatchCloseStateCrashSurfacesAsFailed(t *testing.T) {
+	d := newNotebookDaemon(t)
+	addDispatchSession(t, d, "worker-1", "dsp-1", protocol.SessionStateWorking)
+
+	d.handlePTYExit(ptybackend.ExitInfo{ID: "worker-1", ExitCode: 137, Signal: "SIGKILL"})
+
+	rec := d.store.GetChiefOfStaffDispatchBySession("worker-1")
+	if rec == nil || protocol.Deref(rec.ClosedState) != string(protocol.SessionStateWorking) {
+		t.Fatalf("captured close-state = %+v", rec)
+	}
+	// The session record lingers (idle-clobbered), yet the dispatch must read closed.
+	if got := d.store.Get("worker-1"); got == nil || got.State != protocol.SessionStateIdle {
+		t.Fatalf("lingering session state = %+v, want idle-clobbered", got)
+	}
+	decorated, ev := classifyDispatch(t, d, "worker-1")
+	if decorated.Status != dispatch.SessionClosedStatus {
+		t.Fatalf("decorated status = %q, want closed", decorated.Status)
+	}
+	if ev.Kind != dispatch.KindFailed || ev.Reason != "session_crashed" {
+		t.Fatalf("classify = %+v, want failed/session_crashed", ev)
+	}
+}
+
+// A worker that closed from a clean idle rest must stay neutral Ended: attn does
+// not infer a success the agent never declared, and a clean stop is not a crash.
+func TestDispatchCloseStateCleanCloseStaysNeutral(t *testing.T) {
+	d := newNotebookDaemon(t)
+	addDispatchSession(t, d, "worker-1", "dsp-1", protocol.SessionStateIdle)
+
+	d.handlePTYExit(ptybackend.ExitInfo{ID: "worker-1", ExitCode: 0})
+
+	rec := d.store.GetChiefOfStaffDispatchBySession("worker-1")
+	if protocol.Deref(rec.ClosedState) != string(protocol.SessionStateIdle) {
+		t.Fatalf("captured close-state = %q, want idle", protocol.Deref(rec.ClosedState))
+	}
+	_, ev := classifyDispatch(t, d, "worker-1")
+	if ev.Kind != dispatch.KindEnded || ev.Reason != "session_closed" {
+		t.Fatalf("classify = %+v, want ended/session_closed", ev)
+	}
+}
+
+// The real crash sequence: the process exits (handlePTYExit captures the true
+// mid-flight state and clobbers to idle), and only later is the record removed
+// (dropSessionRecord, whose backstop read would see the clobbered idle).
+// First-writer-wins must keep the genuine "working" close-state through both.
+func TestDispatchCloseStateFirstWriterWinsAcrossExitThenRemoval(t *testing.T) {
+	d := newNotebookDaemon(t)
+	addDispatchSession(t, d, "worker-1", "dsp-1", protocol.SessionStateWorking)
+
+	d.handlePTYExit(ptybackend.ExitInfo{ID: "worker-1", ExitCode: 1})
+	d.dropSessionRecord("worker-1")
+
+	rec := d.store.GetChiefOfStaffDispatchBySession("worker-1")
+	if rec == nil || protocol.Deref(rec.ClosedState) != string(protocol.SessionStateWorking) {
+		t.Fatalf("close-state after exit+removal = %+v", rec)
+	}
+	if d.store.Get("worker-1") != nil {
+		t.Fatal("session record was not removed")
+	}
+	_, ev := classifyDispatch(t, d, "worker-1")
+	if ev.Kind != dispatch.KindFailed {
+		t.Fatalf("classify = %+v, want failed", ev)
+	}
+}
+
+// A removal path that bypasses handlePTYExit entirely (reaped on restart, liveness
+// sweep, worktree teardown) must still capture the last state via the
+// dropSessionRecord backstop, so a crash that never emitted an exit event is not
+// silently lost.
+func TestDispatchCloseStateDropBackstopCaptures(t *testing.T) {
+	d := newNotebookDaemon(t)
+	addDispatchSession(t, d, "worker-1", "dsp-1", protocol.SessionStateWorking)
+
+	d.dropSessionRecord("worker-1")
+
+	rec := d.store.GetChiefOfStaffDispatchBySession("worker-1")
+	if rec == nil || protocol.Deref(rec.ClosedState) != string(protocol.SessionStateWorking) {
+		t.Fatalf("backstop close-state = %+v", rec)
+	}
+	if d.store.Get("worker-1") != nil {
+		t.Fatal("session record was not removed")
+	}
+	_, ev := classifyDispatch(t, d, "worker-1")
+	if ev.Kind != dispatch.KindFailed {
+		t.Fatalf("classify = %+v, want failed", ev)
+	}
+}
+
+// A non-dispatch session ending is a silent no-op: capture must not invent a
+// dispatch or error when the closing session was never delegated.
+func TestDispatchCloseStateIgnoresNonDispatchSession(t *testing.T) {
+	d := newNotebookDaemon(t)
+	addIdleNotebookSession(d, "plain-1", protocol.SessionStateWorking)
+
+	d.handlePTYExit(ptybackend.ExitInfo{ID: "plain-1", ExitCode: 0})
+
+	if rec := d.store.GetChiefOfStaffDispatchBySession("plain-1"); rec != nil {
+		t.Fatalf("non-dispatch session produced a dispatch: %+v", rec)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1366,6 +1366,11 @@ func (d *Daemon) handlePTYExit(info ptybackend.ExitInfo) {
 	}
 
 	if session := d.store.Get(info.ID); session != nil {
+		// Capture the pre-clobber state for any chief dispatch on this session: the
+		// idle-clobber just below erases whether the agent was mid-flight (a crash or
+		// kill) or at a clean rest when its process exited — the signal the dispatch
+		// classifier needs to surface a cut-off close as a failure.
+		d.captureDispatchCloseState(info.ID, string(session.State))
 		d.store.Touch(info.ID)
 		d.store.UpdateState(info.ID, protocol.StateIdle)
 		updated := d.sessionForBroadcast(d.store.Get(info.ID))
@@ -1472,6 +1477,13 @@ func (d *Daemon) removeReapedSession(sessionID string) {
 // capture is idempotent (a prior terminal-report write wins via the per-dispatch
 // marker) and a no-op for non-dispatch sessions.
 func (d *Daemon) dropSessionRecord(sessionID string) {
+	// Backstop the close-state capture for removal paths that bypass handlePTYExit
+	// (reaped on restart, liveness sweep, or torn down with a worktree). First-
+	// writer-wins means a real pre-clobber exit capture already on the dispatch wins
+	// over this later read, which would otherwise only see the clobbered idle.
+	if session := d.store.Get(sessionID); session != nil {
+		d.captureDispatchCloseState(sessionID, string(session.State))
+	}
 	d.journalDispatchOnSessionGone(sessionID)
 	d.store.Remove(sessionID)
 }

--- a/internal/dispatch/classify.go
+++ b/internal/dispatch/classify.go
@@ -30,7 +30,10 @@
 //  1. report work_state=failed OR report_type=failure       -> Failed  (terminal, exit 1)
 //  2. report work_state=completed OR report_type=completion  -> Done    (terminal, exit 0)
 //  3. report work_state=ready_for_review                     -> Review  (terminal, exit 0)
-//  4. status=closed, no explicit terminal outcome            -> Ended   (terminal, exit 0)
+//  4. status=closed, no explicit terminal outcome:
+//     cut off mid-flight (close-state working/launching/pending_approval)
+//     -> Failed  (terminal, exit 1)
+//     else (clean rest idle/waiting_input, or unconfirmed) -> Ended   (terminal, exit 0)
 //  5. report has a pending decision Request                  -> Blocker (interim)
 //  6. report work_state=needs_input OR report_type=blocker   -> Blocker (interim)
 //  7. status=idle, no explicit outcome                       -> Ended   (terminal, exit 0)
@@ -61,6 +64,17 @@
 // session must resolve to a neutral terminal instead of hanging on it. Review
 // does not have that problem because it is itself terminal, which is why it can
 // stay authoritative above the closed check.
+//
+// The one exception to silent-close-is-neutral is a CRASH: when a session closes
+// while the agent was still cut off mid-flight (its captured close-state is
+// working, launching, or pending_approval), step 4 surfaces Failed instead of
+// Ended. This is not inferring failure from silence — it is positive evidence
+// that the agent's process died before it could reach a resting point or file a
+// report. The safe direction is preserved: a clean stop (idle / waiting_input) or
+// an unconfirmed close (unknown / unstamped) is still neutral Ended, so attn
+// never asserts a failure it cannot evidence, just as it never asserts an
+// unearned success. The close-state is captured by the daemon the moment the
+// process exits — see captureDispatchCloseState — and rides on ClosedState.
 package dispatch
 
 import "github.com/victorarias/attn/internal/protocol"
@@ -137,11 +151,20 @@ func Classify(d protocol.ChiefOfStaffDispatch) Event {
 		}
 	}
 
-	// 4. Session gone with no explicit terminal outcome → neutral terminal.
-	// Checked BEFORE the interim report states (steps 5-6) so a dead session never
-	// hangs (a stale needs_input is not a live blocker once the agent is gone) and
-	// is never read as success or failure.
+	// 4. Session gone with no explicit terminal outcome. Checked BEFORE the interim
+	// report states (steps 5-6) so a dead session never hangs (a stale needs_input is
+	// not a live blocker once the agent is gone). By default a silent close is the
+	// neutral terminal Ended — silence is neither success nor failure. But when the
+	// daemon captured a close-state showing the agent was cut off mid-flight (still
+	// working, launching, or awaiting a tool approval when its process died), that is
+	// a real crash/kill: surface it as a failure so a killed agent is visible, not
+	// quietly neutral. A clean rest (idle / waiting_input) or an unconfirmed close
+	// (unknown / unstamped) stays neutral — attn never asserts a failure it cannot
+	// evidence, exactly as it never asserts an unearned success.
 	if d.Status == SessionClosedStatus {
+		if closedMidFlight(d.ClosedState) {
+			return Event{KindFailed, true, 1, "session_crashed", summary, nextAction}
+		}
 		return Event{KindEnded, true, 0, "session_closed", summary, nextAction}
 	}
 
@@ -171,6 +194,25 @@ func Classify(d protocol.ChiefOfStaffDispatch) Event {
 	default:
 		// working, launching, pending_approval (the exclusion), scheduled, unknown.
 		return Event{Kind: KindNone}
+	}
+}
+
+// closedMidFlight reports whether a closed dispatch's captured ClosedState shows
+// the agent was cut off mid-flight — still working, launching, or awaiting a tool
+// approval — rather than at a settled rest (idle / waiting_input) or an
+// unconfirmed close (unknown, or unstamped: nil/empty). It is the positive-
+// evidence test that turns a real crash/kill into a visible failure while leaving
+// every clean or ambiguous close neutral. The unstamped case returning false
+// preserves the prior behavior (a silent close is Ended) for legacy records and
+// any removal path that never captured a state.
+func closedMidFlight(closedState *string) bool {
+	switch protocol.SessionState(trim(deref(closedState))) {
+	case protocol.SessionStateWorking,
+		protocol.SessionStateLaunching,
+		protocol.SessionStatePendingApproval:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/dispatch/classify_test.go
+++ b/internal/dispatch/classify_test.go
@@ -38,6 +38,7 @@ func TestClassify(t *testing.T) {
 	tests := []struct {
 		name         string
 		status       string
+		closedState  string
 		report       *protocol.DispatchReport
 		wantKind     EventKind
 		wantTerminal bool
@@ -45,53 +46,81 @@ func TestClassify(t *testing.T) {
 		wantReason   string
 	}{
 		// --- explicit completion → done (the agent SAID it finished) ---
-		{"reported completion", "working", report(protocol.DispatchWorkStateCompleted, protocol.DispatchReportTypeCompletion), KindDone, true, 0, "reported_completion"},
-		{"completion type only", "working", report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeCompletion), KindDone, true, 0, "reported_completion"},
-		{"completed then closed = done (report wins over close)", SessionClosedStatus, report(protocol.DispatchWorkStateCompleted, protocol.DispatchReportTypeCompletion), KindDone, true, 0, "reported_completion"},
-		{"ready for review = terminal handoff", "working", report(protocol.DispatchWorkStateReadyForReview, protocol.DispatchReportTypeProgress), KindReview, true, 0, "ready_for_review"},
+		{"reported completion", "working", "", report(protocol.DispatchWorkStateCompleted, protocol.DispatchReportTypeCompletion), KindDone, true, 0, "reported_completion"},
+		{"completion type only", "working", "", report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeCompletion), KindDone, true, 0, "reported_completion"},
+		{"completed then closed = done (report wins over close)", SessionClosedStatus, "", report(protocol.DispatchWorkStateCompleted, protocol.DispatchReportTypeCompletion), KindDone, true, 0, "reported_completion"},
+		// A terminal report stays authoritative even when the close-state shows the
+		// process was still mid-flight: an agent that files completion and is then
+		// killed milliseconds later (close-state working) is Done, not a crash.
+		{"completed then crash-closed = done (report beats crash close-state)", SessionClosedStatus, string(protocol.SessionStateWorking), report(protocol.DispatchWorkStateCompleted, protocol.DispatchReportTypeCompletion), KindDone, true, 0, "reported_completion"},
+		{"ready for review = terminal handoff", "working", "", report(protocol.DispatchWorkStateReadyForReview, protocol.DispatchReportTypeProgress), KindReview, true, 0, "ready_for_review"},
 		// An explicit ready_for_review is a TERMINAL outcome and stays authoritative
 		// over a closed session, exactly like completion/failure — the review handoff
 		// must survive the agent filing it and exiting before the watcher's next poll.
-		{"ready_for_review then closed = review (report wins over close)", SessionClosedStatus, report(protocol.DispatchWorkStateReadyForReview, protocol.DispatchReportTypeProgress), KindReview, true, 0, "ready_for_review"},
+		{"ready_for_review then closed = review (report wins over close)", SessionClosedStatus, "", report(protocol.DispatchWorkStateReadyForReview, protocol.DispatchReportTypeProgress), KindReview, true, 0, "ready_for_review"},
+		{"ready_for_review then crash-closed = review (report beats crash close-state)", SessionClosedStatus, string(protocol.SessionStatePendingApproval), report(protocol.DispatchWorkStateReadyForReview, protocol.DispatchReportTypeProgress), KindReview, true, 0, "ready_for_review"},
 
 		// --- silence implies neither success nor failure → neutral Ended ---
-		{"idle without report = ended (not done)", string(protocol.SessionStateIdle), nil, KindEnded, true, 0, "session_idle"},
-		{"idle after progress report = ended", string(protocol.SessionStateIdle), report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeProgress), KindEnded, true, 0, "session_idle"},
-		{"session closed without report = ended (not failed)", SessionClosedStatus, nil, KindEnded, true, 0, "session_closed"},
-		{"session closed after progress report = ended", SessionClosedStatus, report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeProgress), KindEnded, true, 0, "session_closed"},
+		{"idle without report = ended (not done)", string(protocol.SessionStateIdle), "", nil, KindEnded, true, 0, "session_idle"},
+		{"idle after progress report = ended", string(protocol.SessionStateIdle), "", report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeProgress), KindEnded, true, 0, "session_idle"},
+		// An unstamped close (no captured close-state — a legacy record or a removal
+		// path that never observed a state) stays neutral Ended, preserving the prior
+		// behavior: silence is not failure.
+		{"session closed unstamped = ended (not failed)", SessionClosedStatus, "", nil, KindEnded, true, 0, "session_closed"},
+		{"session closed after progress report = ended", SessionClosedStatus, "", report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeProgress), KindEnded, true, 0, "session_closed"},
 		// A dead session beats a stale INTERIM (non-terminal) report — never hang,
 		// never mislabel. (A TERMINAL report like ready_for_review wins over close
 		// instead; see the explicit case above.)
-		{"needs_input then closed = ended (no hang)", SessionClosedStatus, report(protocol.DispatchWorkStateNeedsInput, protocol.DispatchReportTypeProgress), KindEnded, true, 0, "session_closed"},
-		{"decision request then closed = ended", SessionClosedStatus, pendingRequest, KindEnded, true, 0, "session_closed"},
+		{"needs_input then closed = ended (no hang)", SessionClosedStatus, "", report(protocol.DispatchWorkStateNeedsInput, protocol.DispatchReportTypeProgress), KindEnded, true, 0, "session_closed"},
+		{"decision request then closed = ended", SessionClosedStatus, "", pendingRequest, KindEnded, true, 0, "session_closed"},
+
+		// --- clean / unconfirmed close-states stay neutral Ended (no over-claim) ---
+		// The agent reached a settled rest, or attn could not confirm how it ended,
+		// so a silent close asserts nothing — exactly the prior behavior.
+		{"closed from idle = ended (clean rest)", SessionClosedStatus, string(protocol.SessionStateIdle), nil, KindEnded, true, 0, "session_closed"},
+		{"closed from waiting_input = ended (clean rest)", SessionClosedStatus, string(protocol.SessionStateWaitingInput), nil, KindEnded, true, 0, "session_closed"},
+		{"closed from unknown = ended (unconfirmed)", SessionClosedStatus, string(protocol.SessionStateUnknown), nil, KindEnded, true, 0, "session_closed"},
+		{"closed from scheduled = ended (will auto-resume, not a crash)", SessionClosedStatus, string(protocol.SessionStateScheduled), nil, KindEnded, true, 0, "session_closed"},
+
+		// --- crash / cut-off close-states surface as Failed (real, evidenced) ---
+		// The process died while the agent was still mid-flight: a visible failure,
+		// not a quiet neutral end. This is the inverse of crying wolf — a killed agent
+		// is surfaced; a clean one is not.
+		{"closed mid-work = failed (crash visible)", SessionClosedStatus, string(protocol.SessionStateWorking), nil, KindFailed, true, 1, "session_crashed"},
+		{"closed mid-launch = failed (cut off before running)", SessionClosedStatus, string(protocol.SessionStateLaunching), nil, KindFailed, true, 1, "session_crashed"},
+		{"closed mid-tool-approval = failed (cut off awaiting approval)", SessionClosedStatus, string(protocol.SessionStatePendingApproval), nil, KindFailed, true, 1, "session_crashed"},
+		{"closed mid-work after progress report = failed", SessionClosedStatus, string(protocol.SessionStateWorking), report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeProgress), KindFailed, true, 1, "session_crashed"},
 
 		// --- genuine blocker / decision-request (interim, live) ---
-		{"pending decision request", "waiting_input", pendingRequest, KindBlocker, false, 0, "decision_request"},
-		{"needs_input work state", "working", report(protocol.DispatchWorkStateNeedsInput, protocol.DispatchReportTypeProgress), KindBlocker, false, 0, "needs_input"},
-		{"blocker report type", "working", report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeBlocker), KindBlocker, false, 0, "needs_input"},
-		{"waiting_input without report", string(protocol.SessionStateWaitingInput), nil, KindBlocker, false, 0, "awaiting_input"},
+		{"pending decision request", "waiting_input", "", pendingRequest, KindBlocker, false, 0, "decision_request"},
+		{"needs_input work state", "working", "", report(protocol.DispatchWorkStateNeedsInput, protocol.DispatchReportTypeProgress), KindBlocker, false, 0, "needs_input"},
+		{"blocker report type", "working", "", report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeBlocker), KindBlocker, false, 0, "needs_input"},
+		{"waiting_input without report", string(protocol.SessionStateWaitingInput), "", nil, KindBlocker, false, 0, "awaiting_input"},
 
 		// --- explicit failure → failed (the agent SAID it failed) ---
-		{"reported failure", "working", report(protocol.DispatchWorkStateFailed, protocol.DispatchReportTypeFailure), KindFailed, true, 1, "reported_failure"},
-		{"failure type only", "working", report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeFailure), KindFailed, true, 1, "reported_failure"},
+		{"reported failure", "working", "", report(protocol.DispatchWorkStateFailed, protocol.DispatchReportTypeFailure), KindFailed, true, 1, "reported_failure"},
+		{"failure type only", "working", "", report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeFailure), KindFailed, true, 1, "reported_failure"},
 
 		// --- the exclusion: routine tool-permission prompt (category MUST NOT emit) ---
-		{"pending_approval is routine, no emit", string(protocol.SessionStatePendingApproval), nil, KindNone, false, 0, ""},
-		{"pending_approval with stale progress report", string(protocol.SessionStatePendingApproval), report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeProgress), KindNone, false, 0, ""},
+		{"pending_approval is routine, no emit", string(protocol.SessionStatePendingApproval), "", nil, KindNone, false, 0, ""},
+		{"pending_approval with stale progress report", string(protocol.SessionStatePendingApproval), "", report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeProgress), KindNone, false, 0, ""},
 
 		// --- other routine runtime states, no emit ---
-		{"working", string(protocol.SessionStateWorking), nil, KindNone, false, 0, ""},
-		{"launching", string(protocol.SessionStateLaunching), nil, KindNone, false, 0, ""},
-		{"scheduled (will auto-resume)", string(protocol.SessionStateScheduled), nil, KindNone, false, 0, ""},
-		{"unknown (do not cry wolf)", string(protocol.SessionStateUnknown), nil, KindNone, false, 0, ""},
+		{"working", string(protocol.SessionStateWorking), "", nil, KindNone, false, 0, ""},
+		{"launching", string(protocol.SessionStateLaunching), "", nil, KindNone, false, 0, ""},
+		{"scheduled (will auto-resume)", string(protocol.SessionStateScheduled), "", nil, KindNone, false, 0, ""},
+		{"unknown (do not cry wolf)", string(protocol.SessionStateUnknown), "", nil, KindNone, false, 0, ""},
 
 		// --- a resolved request is no longer a blocker ---
-		{"resolved request falls through to status", "working", resolvedRequest, KindNone, false, 0, ""},
+		{"resolved request falls through to status", "working", "", resolvedRequest, KindNone, false, 0, ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := protocol.ChiefOfStaffDispatch{Status: tt.status, StructuredReport: tt.report}
+			if tt.closedState != "" {
+				d.ClosedState = ptr(tt.closedState)
+			}
 			got := Classify(d)
 			if got.Kind != tt.wantKind {
 				t.Errorf("kind = %q, want %q", got.Kind, tt.wantKind)

--- a/internal/dispatch/watch.go
+++ b/internal/dispatch/watch.go
@@ -166,6 +166,8 @@ func formatAbortLine(dispatchID string, err error) string {
 
 func defaultSummary(reason string) string {
 	switch reason {
+	case "session_crashed":
+		return "session was cut off mid-run without a structured report (crashed or killed)"
 	case "session_closed":
 		return "session ended without a structured report"
 	case "session_idle":

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "120"
+const ProtocolVersion = "121"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -410,6 +410,9 @@ type ChiefOfStaffDispatch struct {
 	// ChiefSessionID corresponds to the JSON schema field "chief_session_id".
 	ChiefSessionID string `json:"chief_session_id"`
 
+	// ClosedState corresponds to the JSON schema field "closed_state".
+	ClosedState *string `json:"closed_state,omitempty,omitzero"`
+
 	// ConciseSummary corresponds to the JSON schema field "concise_summary".
 	ConciseSummary *string `json:"concise_summary,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -283,6 +283,13 @@ model ChiefOfStaffDispatch {
   branch?: string;
   status: string;
   status_since: string;
+  // closed_state is the delegated session's last attn-classified runtime state,
+  // captured once when the session ends (before the idle-clobber/removal erases
+  // it). Empty until the session closes. It lets the signal classifier tell a
+  // clean stop (idle / waiting_input) from a real crash or kill mid-flight
+  // (working / launching / pending_approval), so a cut-off close surfaces as a
+  // failure instead of a neutral end.
+  closed_state?: string;
   latest_report?: string;
   structured_report?: DispatchReport;
   concise_summary?: string;

--- a/internal/store/chief_of_staff_dispatches.go
+++ b/internal/store/chief_of_staff_dispatches.go
@@ -10,6 +10,18 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
+// chiefDispatchSelect is the canonical column list + source for reading a chief
+// dispatch row. Every read shares it so the SELECT column order can never drift
+// from scanChiefOfStaffDispatch's scan order — the fan-out trap when adding a
+// column. closed_state is last; the INSERT omits it and relies on the column
+// DEFAULT ” because it is only ever populated by the close-state capture, never
+// at creation.
+const chiefDispatchSelect = `
+	SELECT id, chief_session_id, session_id, workspace_id, brief, label, agent,
+		directory, branch, latest_report, structured_report_json, reported_at,
+		created_at, updated_at, closed_state
+	FROM chief_of_staff_dispatches`
+
 func cloneChiefOfStaffDispatch(dispatch *protocol.ChiefOfStaffDispatch) *protocol.ChiefOfStaffDispatch {
 	if dispatch == nil {
 		return nil
@@ -30,6 +42,9 @@ func cloneChiefOfStaffDispatch(dispatch *protocol.ChiefOfStaffDispatch) *protoco
 	}
 	if dispatch.Actionable != nil {
 		cloned.Actionable = protocol.Ptr(protocol.Deref(dispatch.Actionable))
+	}
+	if dispatch.ClosedState != nil {
+		cloned.ClosedState = protocol.Ptr(protocol.Deref(dispatch.ClosedState))
 	}
 	return &cloned
 }
@@ -165,14 +180,7 @@ func (s *Store) GetChiefOfStaffDispatchBySession(sessionID string) *protocol.Chi
 		return nil
 	}
 
-	row := s.db.QueryRow(`
-		SELECT id, chief_session_id, session_id, workspace_id, brief, label, agent,
-			directory, branch, latest_report, structured_report_json, reported_at,
-			created_at, updated_at
-		FROM chief_of_staff_dispatches
-		WHERE session_id = ?`,
-		sessionID,
-	)
+	row := s.db.QueryRow(chiefDispatchSelect+` WHERE session_id = ?`, sessionID)
 	return scanChiefOfStaffDispatch(row)
 }
 
@@ -225,14 +233,7 @@ func (s *Store) GetChiefOfStaffDispatch(id string) *protocol.ChiefOfStaffDispatc
 	if s.db == nil {
 		return cloneChiefOfStaffDispatch(s.chiefDispatches[id])
 	}
-	row := s.db.QueryRow(`
-		SELECT id, chief_session_id, session_id, workspace_id, brief, label, agent,
-			directory, branch, latest_report, structured_report_json, reported_at,
-			created_at, updated_at
-		FROM chief_of_staff_dispatches
-		WHERE id = ?`,
-		id,
-	)
+	row := s.db.QueryRow(chiefDispatchSelect+` WHERE id = ?`, id)
 	return scanChiefOfStaffDispatch(row)
 }
 
@@ -258,11 +259,7 @@ func (s *Store) ListChiefOfStaffDispatches(chiefSessionID string) []*protocol.Ch
 		return result
 	}
 
-	query := `
-		SELECT id, chief_session_id, session_id, workspace_id, brief, label, agent,
-			directory, branch, latest_report, structured_report_json, reported_at,
-			created_at, updated_at
-		FROM chief_of_staff_dispatches`
+	query := chiefDispatchSelect
 	var (
 		rows *sql.Rows
 		err  error
@@ -360,19 +357,70 @@ func (s *Store) UpdateChiefOfStaffDispatchReportEnvelope(
 		return nil, fmt.Errorf("session %s is not a tracked dispatch", sessionID)
 	}
 
-	row := s.db.QueryRow(`
-		SELECT id, chief_session_id, session_id, workspace_id, brief, label, agent,
-			directory, branch, latest_report, structured_report_json, reported_at,
-			created_at, updated_at
-		FROM chief_of_staff_dispatches
-		WHERE session_id = ?`,
-		sessionID,
-	)
+	row := s.db.QueryRow(chiefDispatchSelect+` WHERE session_id = ?`, sessionID)
 	dispatch := scanChiefOfStaffDispatch(row)
 	if dispatch == nil {
 		return nil, fmt.Errorf("updated dispatch for session %s could not be read", sessionID)
 	}
 	return dispatch, nil
+}
+
+// SetChiefOfStaffDispatchClosedStateBySession records, exactly once, the last
+// attn-classified runtime state of a delegated session onto its dispatch as
+// closed_state. It is first-writer-wins: the update matches only a row whose
+// closed_state is still empty, so the earliest observation of the session ending
+// (the pre-clobber PTY exit) sticks and a later teardown read cannot overwrite the
+// true close-state with the clobbered idle. It returns changed=true only when a
+// row was actually stamped; changed=false with no error is the normal no-op when
+// the session is not a tracked dispatch, or its close-state was already recorded.
+func (s *Store) SetChiefOfStaffDispatchClosedStateBySession(sessionID, closedState string) (*protocol.ChiefOfStaffDispatch, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sessionID = strings.TrimSpace(sessionID)
+	closedState = strings.TrimSpace(closedState)
+	if sessionID == "" {
+		return nil, false, fmt.Errorf("source session id cannot be empty")
+	}
+	if closedState == "" {
+		return nil, false, fmt.Errorf("closed state cannot be empty")
+	}
+
+	if s.db == nil {
+		for id, dispatch := range s.chiefDispatches {
+			if dispatch.SessionID != sessionID {
+				continue
+			}
+			if strings.TrimSpace(protocol.Deref(dispatch.ClosedState)) != "" {
+				return nil, false, nil // already recorded; first writer wins
+			}
+			updated := cloneChiefOfStaffDispatch(dispatch)
+			updated.ClosedState = protocol.Ptr(closedState)
+			s.chiefDispatches[id] = updated
+			return cloneChiefOfStaffDispatch(updated), true, nil
+		}
+		return nil, false, nil // not a tracked dispatch
+	}
+
+	result, err := s.db.Exec(`
+		UPDATE chief_of_staff_dispatches
+		SET closed_state = ?
+		WHERE session_id = ? AND closed_state = ''`,
+		closedState,
+		sessionID,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("set dispatch closed_state: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return nil, false, fmt.Errorf("read dispatch closed_state update result: %w", err)
+	}
+	if rows == 0 {
+		return nil, false, nil // not a tracked dispatch, or already recorded
+	}
+	row := s.db.QueryRow(chiefDispatchSelect+` WHERE session_id = ?`, sessionID)
+	return scanChiefOfStaffDispatch(row), true, nil
 }
 
 func (s *Store) ResolveChiefOfStaffDispatchRequest(
@@ -399,14 +447,7 @@ func (s *Store) ResolveChiefOfStaffDispatchRequest(
 	if s.db == nil {
 		dispatch = cloneChiefOfStaffDispatch(s.chiefDispatches[dispatchID])
 	} else {
-		row := s.db.QueryRow(`
-			SELECT id, chief_session_id, session_id, workspace_id, brief, label, agent,
-				directory, branch, latest_report, structured_report_json, reported_at,
-				created_at, updated_at
-			FROM chief_of_staff_dispatches
-			WHERE id = ?`,
-			dispatchID,
-		)
+		row := s.db.QueryRow(chiefDispatchSelect+` WHERE id = ?`, dispatchID)
 		dispatch = scanChiefOfStaffDispatch(row)
 	}
 	if dispatch == nil {
@@ -459,8 +500,8 @@ type dispatchScanner interface {
 
 func scanChiefOfStaffDispatch(scanner dispatchScanner) *protocol.ChiefOfStaffDispatch {
 	var (
-		dispatch                                               protocol.ChiefOfStaffDispatch
-		branch, latestReport, structuredReportJSON, reportedAt sql.NullString
+		dispatch                                                            protocol.ChiefOfStaffDispatch
+		branch, latestReport, structuredReportJSON, reportedAt, closedState sql.NullString
 	)
 	if err := scanner.Scan(
 		&dispatch.ID,
@@ -477,6 +518,7 @@ func scanChiefOfStaffDispatch(scanner dispatchScanner) *protocol.ChiefOfStaffDis
 		&reportedAt,
 		&dispatch.CreatedAt,
 		&dispatch.UpdatedAt,
+		&closedState,
 	); err != nil {
 		return nil
 	}
@@ -491,6 +533,9 @@ func scanChiefOfStaffDispatch(scanner dispatchScanner) *protocol.ChiefOfStaffDis
 	}
 	if reportedAt.Valid && reportedAt.String != "" {
 		dispatch.ReportedAt = protocol.Ptr(reportedAt.String)
+	}
+	if closedState.Valid && closedState.String != "" {
+		dispatch.ClosedState = protocol.Ptr(closedState.String)
 	}
 	return &dispatch
 }

--- a/internal/store/chief_of_staff_dispatches_test.go
+++ b/internal/store/chief_of_staff_dispatches_test.go
@@ -303,3 +303,113 @@ func TestChiefOfStaffStructuredReportPersistsAndResolves(t *testing.T) {
 		t.Fatal("resolve with wrong chief succeeded")
 	}
 }
+
+func TestChiefOfStaffDispatchClosedStateCapture(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	now := string(protocol.TimestampNow())
+	dispatch := &protocol.ChiefOfStaffDispatch{
+		ID:             "dispatch-close",
+		ChiefSessionID: "chief-1",
+		SessionID:      "worker-1",
+		WorkspaceID:    "workspace-1",
+		Brief:          "Do the work.",
+		Label:          "Work",
+		Agent:          "codex",
+		Directory:      "/tmp/project",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := s.AddChiefOfStaffDispatch(dispatch); err != nil {
+		t.Fatalf("add dispatch: %v", err)
+	}
+
+	// A fresh dispatch has no captured close-state.
+	if got := s.GetChiefOfStaffDispatchBySession("worker-1"); got == nil || got.ClosedState != nil {
+		t.Fatalf("fresh dispatch close-state = %+v", got)
+	}
+
+	// An untracked session is a silent no-op (changed=false, no error) — most
+	// session exits are not dispatches.
+	if _, changed, err := s.SetChiefOfStaffDispatchClosedStateBySession("not-a-worker", "working"); err != nil || changed {
+		t.Fatalf("untracked set: changed=%v err=%v", changed, err)
+	}
+
+	// Empty inputs are rejected.
+	if _, _, err := s.SetChiefOfStaffDispatchClosedStateBySession("", "working"); err == nil {
+		t.Fatal("empty session id accepted")
+	}
+	if _, _, err := s.SetChiefOfStaffDispatchClosedStateBySession("worker-1", "  "); err == nil {
+		t.Fatal("empty close-state accepted")
+	}
+
+	// The first capture wins and is recorded.
+	updated, changed, err := s.SetChiefOfStaffDispatchClosedStateBySession("worker-1", "working")
+	if err != nil || !changed {
+		t.Fatalf("first capture: changed=%v err=%v", changed, err)
+	}
+	if protocol.Deref(updated.ClosedState) != "working" {
+		t.Fatalf("first capture close-state = %+v", updated.ClosedState)
+	}
+
+	// A later capture must NOT overwrite (first-writer-wins): a teardown read that
+	// sees the clobbered idle cannot erase the true mid-flight close-state.
+	again, changed, err := s.SetChiefOfStaffDispatchClosedStateBySession("worker-1", "idle")
+	if err != nil {
+		t.Fatalf("second capture err: %v", err)
+	}
+	if changed || again != nil {
+		t.Fatalf("second capture overwrote: changed=%v dispatch=%+v", changed, again)
+	}
+	if got := s.GetChiefOfStaffDispatchBySession("worker-1"); protocol.Deref(got.ClosedState) != "working" {
+		t.Fatalf("close-state after second capture = %+v", got.ClosedState)
+	}
+
+	// The close-state survives a reopen (durable across a daemon restart).
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	s, err = NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if got := s.GetChiefOfStaffDispatchBySession("worker-1"); got == nil || protocol.Deref(got.ClosedState) != "working" {
+		t.Fatalf("persisted close-state = %+v", got)
+	}
+}
+
+func TestChiefOfStaffDispatchClosedStateInMemory(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	now := string(protocol.TimestampNow())
+	if err := s.AddChiefOfStaffDispatch(&protocol.ChiefOfStaffDispatch{
+		ID:             "d1",
+		ChiefSessionID: "chief",
+		SessionID:      "w1",
+		WorkspaceID:    "ws",
+		Brief:          "b",
+		Label:          "l",
+		Agent:          "codex",
+		Directory:      "/tmp",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	if _, changed, err := s.SetChiefOfStaffDispatchClosedStateBySession("w1", "pending_approval"); err != nil || !changed {
+		t.Fatalf("first capture: changed=%v err=%v", changed, err)
+	}
+	if _, changed, _ := s.SetChiefOfStaffDispatchClosedStateBySession("w1", "idle"); changed {
+		t.Fatal("in-memory close-state overwrite happened (must be first-writer-wins)")
+	}
+	if got := s.GetChiefOfStaffDispatchBySession("w1"); protocol.Deref(got.ClosedState) != "pending_approval" {
+		t.Fatalf("in-memory close-state = %+v", got.ClosedState)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -455,6 +455,7 @@ CREATE INDEX IF NOT EXISTS idx_workflow_agent_calls_run_id
 	// phantom 51 or 52. NOTE: confirm MAX(version) on the real prod/dev DBs before
 	// install — if either build burned 51/52 there, these may need to move higher.
 	{52, "rename workspace context janitor backups to keeper compact backups", ""},
+	{53, "add closed_state to chief of staff dispatches", ""},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -610,6 +611,11 @@ func migrateDB(db *sql.DB) error {
 			}
 		} else if m.version == 52 {
 			if err := applyMigration52(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 53 {
+			if err := applyMigration53(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -824,6 +830,31 @@ func applyMigration52(tx *sql.Tx) error {
 		}
 	}
 	return nil
+}
+
+// applyMigration53 adds the closed_state column to chief_of_staff_dispatches,
+// recording a delegated session's last attn-classified runtime state at close so
+// the dispatch signal classifier can tell a clean stop (idle / waiting_input)
+// from a crash or kill mid-flight (working / launching / pending_approval). It is
+// guarded with tableExists (a partial-schema test DB may seed only some tables)
+// and columnExists (idempotent re-run safety).
+func applyMigration53(tx *sql.Tx) error {
+	exists, err := tableExists(tx, "chief_of_staff_dispatches")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	hasColumn, err := columnExists(tx, "chief_of_staff_dispatches", "closed_state")
+	if err != nil {
+		return err
+	}
+	if hasColumn {
+		return nil
+	}
+	_, err = tx.Exec(`ALTER TABLE chief_of_staff_dispatches ADD COLUMN closed_state TEXT NOT NULL DEFAULT ''`)
+	return err
 }
 
 // tableExists reports whether a table of the given name exists in the schema.

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -715,7 +715,10 @@ func TestMigration52RenamesKeeperBackupsAndRealignsSentinel(t *testing.T) {
 
 	// Seed a context row, then roll the DB back to a pre-52 shape: plant the legacy
 	// 'attn-janitor' sentinel, drop the keeper-named table, recreate the legacy
-	// janitor-named one, and unrecord migration 52 so migrateDB re-applies it.
+	// janitor-named one, and unrecord migration 52 (and everything after it) so
+	// migrateDB re-applies it. getCurrentVersion is MAX-based, so a higher recorded
+	// version (53+) would otherwise gate 52's re-run out; the later migrations are
+	// idempotent and simply re-run as no-ops.
 	s.AddWorkspace(&protocol.Workspace{ID: "workspace-1", Title: "W", Directory: t.TempDir()})
 	if _, _, err := s.UpdateWorkspaceContext("workspace-1", "ctx", "session-1", 0); err != nil {
 		t.Fatalf("seed context: %v", err)
@@ -737,7 +740,7 @@ func TestMigration52RenamesKeeperBackupsAndRealignsSentinel(t *testing.T) {
 	)`); err != nil {
 		t.Fatalf("recreate legacy table: %v", err)
 	}
-	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version = 52`); err != nil {
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 52`); err != nil {
 		t.Fatalf("unrecord migration 52: %v", err)
 	}
 
@@ -757,6 +760,57 @@ func TestMigration52RenamesKeeperBackupsAndRealignsSentinel(t *testing.T) {
 	}
 	if updater != "attn-keeper" {
 		t.Fatalf("sentinel = %q, want attn-keeper", updater)
+	}
+}
+
+func TestMigration53AddsClosedStateColumnIdempotently(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	hasClosedState := func() bool {
+		rows, err := s.db.Query(`PRAGMA table_info(chief_of_staff_dispatches)`)
+		if err != nil {
+			t.Fatalf("table_info: %v", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var (
+				cid     int
+				name    string
+				colType string
+				notNull int
+				dflt    sql.NullString
+				pk      int
+			)
+			if err := rows.Scan(&cid, &name, &colType, &notNull, &dflt, &pk); err != nil {
+				t.Fatalf("scan table_info: %v", err)
+			}
+			if name == "closed_state" {
+				return true
+			}
+		}
+		return false
+	}
+
+	// A fresh DB has the column from migration 53.
+	if !hasClosedState() {
+		t.Fatal("closed_state column missing after migrations")
+	}
+
+	// Re-applying migration 53 over an existing column must be a no-op (the
+	// columnExists guard), not a duplicate-column error. Unrecord 53 and re-migrate.
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 53`); err != nil {
+		t.Fatalf("unrecord migration 53: %v", err)
+	}
+	if err := migrateDB(s.db); err != nil {
+		t.Fatalf("re-run migrateDB after unrecording 53: %v", err)
+	}
+	if !hasClosedState() {
+		t.Fatal("closed_state column missing after idempotent re-run")
 	}
 }
 


### PR DESCRIPTION
## Why

PR #394 made a chief-of-staff dispatch that closes **without** a structured terminal report the neutral terminal `ended` — *silence is neither success nor failure* — which killed the old false `[failed]` for an unreported success. But that left a real gap: a genuine **crash/kill** mid-work now reads as the same quiet `ended` as a clean stop. A killed agent looks uneventful, which trains the chief to ignore the signal from the other direction.

This is **Option B (crash visibility)**, chosen by Victor over inferring success on a clean close: keep `ended` neutral for clean/unconfirmed closes (never claim an unearned success), but surface a *real* cut-off as a failure.

## What

- **Capture the close-state at the source.** The daemon records the delegated session's last attn-classified runtime state the moment its process exits — in `handlePTYExit` *before* the idle-clobber, with a backstop in `dropSessionRecord` for removal paths that bypass it (reap on restart, liveness sweep, worktree teardown). First-writer-wins keeps the true pre-clobber state authoritative over a later teardown read that would only see the clobbered `idle`. Persisted as a new durable `closed_state` on the dispatch (survives daemon restart).
- **Classify it.** The shared `internal/dispatch.Classify` (single source of truth) surfaces a close cut off mid-flight — `working` / `launching` / `pending_approval` — as `failed` (`session_crashed`), while a clean rest (`idle` / `waiting_input`) or an unconfirmed close (`unknown` / unstamped) stays neutral `ended`. Agent-declared `done` / `failed` / `review` reports remain authoritative over any close-state.
- **Make it immediate.** The decorate path projects the terminal `closed` status as soon as a close-state is stamped, so a crash is classified at process-exit time even while the idle-clobbered session record still lingers in the store.

The safe direction is preserved: attn never asserts a failure it can't evidence, and never a `done` it wasn't told. An unstamped/legacy close behaves exactly as before (`ended`).

## Tests

- `internal/dispatch` — classifier table extended with the full close-state matrix (crash states → failed; clean/unconfirmed → ended; terminal reports beat a crash close-state).
- `internal/store` — `closed_state` first-writer-wins, in-memory + SQLite paths, durability across reopen; migration 53 added + idempotent.
- `internal/daemon` — end-to-end through real `handlePTYExit` / `dropSessionRecord` → decorate → `Classify`: crash visible, clean close neutral, first-writer-wins across exit-then-removal, drop backstop, non-dispatch no-op.

Verified: `gofmt`, `go vet`, `go test ./internal/{dispatch,store,daemon,protocol} ./cmd/attn`, frontend `tsc --noEmit`. Protocol `119 → 120` (new `closed_state` field; frontend version bumped in lockstep).

## Notes
- Base is `main` (#394 already merged).
- Vision doc `docs/vision/chief-delegation-awareness.md` updated: the *Reliable doneness-on-close* big rock now reflects the implemented design, and the re-arming caveat is marked resolved.