### PR TITLE
Add chief of staff support for copilot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ app/src-tauri/binaries/
 
 # Generated per-profile Tauri config overlays (see scripts/build-app-profile.sh)
 app/src-tauri/*.gen.conf.json
+
+# Local env files
+**/.npmrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-06-23]
 
+### Added
+- **The chief of staff can now delegate to GitHub Copilot.** Copilot joins Claude and Codex as a delegation target: the chief spins up a Copilot session with the brief, and the agent starts in an interactive session that runs the brief and stays open for follow-up steering. Ordinary (non-delegated) Copilot sessions are unaffected.
+
 ### Fixed
 - **Long Notebook notes keep their rendered formatting and cursor position while you edit.** Moving the cursor beyond the first few thousand characters no longer turns the rest of a note back into raw Markdown or sends ArrowUp to the properties card. Clicking into the body also leaves the frontmatter card stable; raw YAML appears only when you click the card to edit it.
 - **Chief-of-staff delegations no longer disappear into muted workspaces.** Delegating into an existing muted workspace now brings that workspace back into the sidebar, and `attn list` marks sessions whose workspace is muted so the chief can see that state before choosing a target.

--- a/docs/plans/2026-06-08-chief-of-staff.md
+++ b/docs/plans/2026-06-08-chief-of-staff.md
@@ -170,8 +170,12 @@ ChiefOfStaffDispatch {
   attached to the agent that created them and remain visible as history.
 - Placement defaults to the current workspace. `--new-workspace`, `--cwd`, and
   `--worktree` opt into a new workspace; `--workspace` targets an existing one.
-- Copilot is excluded from delegation for now; ordinary Copilot sessions remain
-  supported.
+- ~~Copilot is excluded from delegation for now; ordinary Copilot sessions remain
+  supported.~~ **Superseded (PR #399):** Copilot now supports initial-prompt
+  delegation. It declares the `initial_prompt` capability and launches with
+  `copilot --interactive <brief>`, which starts an interactive session that
+  auto-executes the brief and stays alive for steering (the same persistent-session
+  model as claude/codex). Ordinary Copilot sessions remain supported.
 
 ## Follow-ups
 

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -55,8 +55,15 @@ func (c *Copilot) BuildCommand(opts SpawnOpts) *exec.Cmd {
 	if opts.YoloMode {
 		args = append(args, "--yolo")
 	}
+	// Copilot's -i/--interactive starts an interactive session that auto-executes
+	// the prompt and stays alive for steering — the model attn delegation needs,
+	// matching how claude/codex keep an interactive session after their initial
+	// prompt. Do NOT use -p/--prompt: that runs non-interactively and exits after
+	// completion, which would tear the delegated session down immediately.
+	// Verified against copilot CLI v1.0.63 (`copilot --help`; example
+	// `copilot -i "Fix the bug in main.js"`).
 	if strings.TrimSpace(opts.InitialPrompt) != "" {
-		args = append(args, "-i", opts.InitialPrompt)
+		args = append(args, "--interactive", opts.InitialPrompt)
 	}
 	return exec.Command(opts.Executable, args...)
 }

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/victorarias/attn/internal/classifier"
@@ -40,6 +41,7 @@ func (c *Copilot) Capabilities() Capabilities {
 		HasStateDetector:     true,
 		HasResume:            true,
 		HasYolo:              true,
+		HasInitialPrompt:     true,
 	}
 }
 
@@ -52,6 +54,9 @@ func (c *Copilot) BuildCommand(opts SpawnOpts) *exec.Cmd {
 	}
 	if opts.YoloMode {
 		args = append(args, "--yolo")
+	}
+	if strings.TrimSpace(opts.InitialPrompt) != "" {
+		args = append(args, "-i", opts.InitialPrompt)
 	}
 	return exec.Command(opts.Executable, args...)
 }

--- a/internal/agent/yolo_test.go
+++ b/internal/agent/yolo_test.go
@@ -210,7 +210,7 @@ func TestBuildCommand_AppendsInitialPromptAfterOptionTerminator(t *testing.T) {
 
 func TestCopilotSupportsInitialPrompt(t *testing.T) {
 	if !(&Copilot{}).Capabilities().HasInitialPrompt {
-		t.Fatal("expected Copilot to support initial prompts via -i flag")
+		t.Fatal("expected Copilot to support initial prompts via --interactive flag")
 	}
 }
 
@@ -223,12 +223,12 @@ func TestCopilotBuildCommandInitialPrompt(t *testing.T) {
 	args := cmd.Args[1:] // skip executable
 	found := false
 	for i, a := range args {
-		if a == "-i" && i+1 < len(args) && args[i+1] == "fix the bug" {
+		if a == "--interactive" && i+1 < len(args) && args[i+1] == "fix the bug" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected -i flag with prompt in args, got: %v", args)
+		t.Fatalf("expected --interactive flag with prompt in args, got: %v", args)
 	}
 }

--- a/internal/agent/yolo_test.go
+++ b/internal/agent/yolo_test.go
@@ -208,8 +208,27 @@ func TestBuildCommand_AppendsInitialPromptAfterOptionTerminator(t *testing.T) {
 	}
 }
 
-func TestCopilotDoesNotSupportInitialPrompt(t *testing.T) {
-	if (&Copilot{}).Capabilities().HasInitialPrompt {
-		t.Fatal("expected Copilot delegation support to remain disabled")
+func TestCopilotSupportsInitialPrompt(t *testing.T) {
+	if !(&Copilot{}).Capabilities().HasInitialPrompt {
+		t.Fatal("expected Copilot to support initial prompts via -i flag")
+	}
+}
+
+func TestCopilotBuildCommandInitialPrompt(t *testing.T) {
+	c := &Copilot{}
+	cmd := c.BuildCommand(SpawnOpts{
+		Executable:    "copilot",
+		InitialPrompt: "fix the bug",
+	})
+	args := cmd.Args[1:] // skip executable
+	found := false
+	for i, a := range args {
+		if a == "-i" && i+1 < len(args) && args[i+1] == "fix the bug" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected -i flag with prompt in args, got: %v", args)
 	}
 }

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -804,23 +804,49 @@ func TestDelegateRollsBackPaneWhenSpawnFails(t *testing.T) {
 	}
 }
 
-func TestDelegateRejectsCopilotInitialPrompt(t *testing.T) {
+// Copilot now supports initial-prompt delegation (it auto-executes the brief via
+// `copilot --interactive`), so delegating to it must succeed and spawn a tracked
+// session carrying the brief — the inverse of the old "rejects" assertion this
+// replaces.
+func TestDelegateAcceptsCopilotInitialPrompt(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
-	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	workspaceID, sourceSessionID, _ := setupDelegationSource(t, d, backend)
 
-	_, err := d.delegate(&protocol.DelegateMessage{
+	var prompt string
+	backend.onSpawn = func(opts ptybackend.SpawnOptions) {
+		if opts.ID == sourceSessionID || opts.InitialPromptFile == "" {
+			return
+		}
+		content, err := os.ReadFile(opts.InitialPromptFile)
+		if err != nil {
+			t.Fatalf("read initial prompt: %v", err)
+		}
+		prompt = string(content)
+		if err := os.Remove(opts.InitialPromptFile); err != nil {
+			t.Fatalf("remove initial prompt: %v", err)
+		}
+	}
+
+	result, err := d.delegate(&protocol.DelegateMessage{
 		Cmd:             protocol.CmdDelegate,
 		SourceSessionID: sourceSessionID,
 		Brief:           "Use Copilot for this delegated task.",
 		Agent:           protocol.Ptr("copilot"),
 	})
-	if err == nil || !strings.Contains(err.Error(), "does not support initial prompts") {
-		t.Fatalf("delegate() error = %v, want unsupported initial prompt error", err)
+	if err != nil {
+		t.Fatalf("delegate() error = %v, want copilot delegation to succeed", err)
 	}
-	layout := d.store.GetWorkspaceLayout("workspace-source")
-	if layout == nil || len(layout.Panes) != 1 || layout.Panes[0].SessionID != sourceSessionID {
-		t.Fatalf("workspace layout after rejection = %+v", layout)
+	if prompt != "Use Copilot for this delegated task." {
+		t.Fatalf("delegated initial prompt = %q", prompt)
+	}
+	session := d.store.Get(result.SessionID)
+	if session == nil || session.WorkspaceID != workspaceID || session.Agent != protocol.SessionAgentCopilot {
+		t.Fatalf("delegated session = %+v, want copilot session in %s", session, workspaceID)
+	}
+	layout := d.store.GetWorkspaceLayout(workspaceID)
+	if layout == nil || len(layout.Panes) != 2 {
+		t.Fatalf("workspace layout = %+v, want source + delegated panes", layout)
 	}
 }
 


### PR DESCRIPTION
## Summary

Enables chief-of-staff delegation to **GitHub Copilot**. Copilot now declares the
`initial_prompt` capability and launches with `copilot --interactive <brief>`,
joining Claude and Codex as a delegation target. Ordinary (non-delegated) Copilot
sessions are unaffected.

## Flag decision: `--interactive` (NOT `-p`/`--prompt`) — with evidence

An offline review flagged the original `-i` as likely wrong, because the **online**
GitHub docs ([cli-programmatic-reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-programmatic-reference))
only document `-p`/`--prompt` and omit `-i` entirely. I installed and checked the
**actual** CLI to settle it:

`copilot --help` (CLI **v1.0.63**, `brew install copilot-cli`):

```
-i, --interactive <prompt>   Start interactive mode and automatically execute this prompt
-p, --prompt <text>          Execute a prompt in non-interactive mode (exits after completion)
```

Documented example: `$ copilot -i "Fix the bug in main.js"`. Parse-validated against
the binary: `copilot --interactive` and `copilot --yolo --interactive` both error only
with `option '-i, --interactive <prompt>' argument missing` (flag + `--yolo` combo
accepted), versus `unknown option` for a bogus flag.

**Conclusion:** `-i`/`--interactive` is the **correct** flag. It starts a *persistent
interactive* session that auto-runs the brief and stays alive for steering — the exact
model attn delegation uses for Claude/Codex. `-p`/`--prompt` would be **wrong**: it runs
non-interactively and exits after completion, which would tear the delegated session down
immediately. So the original author's flag choice was right; I switched it to the long
form `--interactive` for clarity and documented the evidence inline in `copilot.go`.

**Runtime-validation status (honest):** the flag and its `--yolo` combination were
verified against the live binary's parser. A full end-to-end delegated Copilot run (an
interactive session auto-executing a brief through attn's PTY) was **not** exercised —
that needs an authenticated Copilot session. CI only unit-tests argument construction.

## Test reconciliation

- **`internal/daemon`** — replaced the inherited `TestDelegateRejectsCopilotInitialPrompt`
  (which asserted copilot delegation must error — the behavior this PR reverses, and the
  exact blocker figgyster flagged) with **`TestDelegateAcceptsCopilotInitialPrompt`**,
  asserting delegation now succeeds and spawns a tracked Copilot session carrying the brief.
- **`internal/agent`** — `TestCopilotBuildCommandInitialPrompt` now asserts `--interactive`;
  `TestCopilotSupportsInitialPrompt` message updated.
- Full `go test ./...` and `make test` are green (1791 tests, 10 env-gated skips).

## Housekeeping

- Marked the superseded *"Copilot excluded from delegation"* decision in
  `docs/plans/2026-06-08-chief-of-staff.md` (kept the rationale).
- Added a user-facing changelog entry.

## Rebase

Branch was rebased onto latest `main` before this work; `origin/chief-copilot` now
fast-forwards.
