### PR TITLE
fix(notebook): stabilize long markdown editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-06-23]
 
 ### Fixed
+- **Long Notebook notes keep their rendered formatting and cursor position while you edit.** Moving the cursor beyond the first few thousand characters no longer turns the rest of a note back into raw Markdown or sends ArrowUp to the properties card. Clicking into the body also leaves the frontmatter card stable; raw YAML appears only when you click the card to edit it.
 - **Chief-of-staff delegations no longer disappear into muted workspaces.** Delegating into an existing muted workspace now brings that workspace back into the sidebar, and `attn list` marks sessions whose workspace is muted so the chief can see that state before choosing a target.
 
 ## [2026-06-22]

--- a/app/e2e/frontmatter-card.spec.ts
+++ b/app/e2e/frontmatter-card.spec.ts
@@ -56,6 +56,18 @@ test.describe('FrontmatterCard', () => {
     await expect(page.locator('.cm-content')).toBeFocused();
   });
 
+  test('opens frontmatter editing from a synthesized semantic click', async ({ page }) => {
+    await page.goto('/test-harness/?component=FrontmatterCard');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    const card = page.getByRole('button', { name: 'Edit note properties' });
+
+    // VoiceOver and other assistive technologies invoke a button action through click
+    // without first emitting the raw pointer or keyboard events.
+    await card.evaluate((el) => (el as HTMLElement).click());
+    await expect(card).toHaveCount(0);
+    await expect(page.locator('.cm-content')).toContainText('type: area');
+  });
+
   test('focusing the body never expands frontmatter under the pointer click', async ({ page }) => {
     await page.goto('/test-harness/?component=FrontmatterCard');
     await page.waitForFunction(() => window.__HARNESS__?.ready === true);

--- a/app/e2e/frontmatter-card.spec.ts
+++ b/app/e2e/frontmatter-card.spec.ts
@@ -70,6 +70,32 @@ test.describe('FrontmatterCard', () => {
     )).toBe(false);
   });
 
+  test('moves the caret out of hidden YAML when frontmatter editing loses focus', async ({ page }) => {
+    await page.goto('/test-harness/?component=FrontmatterCard');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    const content = page.locator('.cm-content');
+
+    await page.locator('.cm-md-frontmatter').click();
+    await expect(content).toContainText('type: area');
+    await content.evaluate((el) => (el as HTMLElement).blur());
+    await expect(page.locator('.cm-md-frontmatter')).toBeVisible();
+
+    // Keyboard-style refocus must type into the visible body, never into the YAML
+    // range now hidden behind the restored card.
+    await content.focus();
+    await page.keyboard.type('VISIBLE_BODY_TOKEN');
+    await page.waitForFunction(() => {
+      const calls = window.__HARNESS__.getCalls('change');
+      return calls.some((call) => String(call[0]).includes('VISIBLE_BODY_TOKEN'));
+    });
+    const changed = await page.evaluate(() => {
+      const calls = window.__HARNESS__.getCalls('change');
+      return String(calls[calls.length - 1][0]);
+    });
+    expect(changed.indexOf('VISIBLE_BODY_TOKEN')).toBeGreaterThan(changed.indexOf('\n---\n'));
+    await expect(page.locator('.cm-md-frontmatter')).toBeVisible();
+  });
+
   test('keeps long markdown rendered and ArrowUp local beyond character 3,000', async ({ page }) => {
     await page.goto('/test-harness/?component=FrontmatterCard&long=1');
     await page.waitForFunction(() => window.__HARNESS__?.ready === true);

--- a/app/e2e/frontmatter-card.spec.ts
+++ b/app/e2e/frontmatter-card.spec.ts
@@ -43,6 +43,19 @@ test.describe('FrontmatterCard', () => {
     await expect(page.locator('.cm-content')).not.toContainText('type: area');
   });
 
+  test('opens frontmatter editing from the keyboard', async ({ page }) => {
+    await page.goto('/test-harness/?component=FrontmatterCard');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    const card = page.getByRole('button', { name: 'Edit note properties' });
+    await card.focus();
+    await expect(card).toBeFocused();
+
+    await page.keyboard.press('Enter');
+    await expect(card).toHaveCount(0);
+    await expect(page.locator('.cm-content')).toContainText('type: area');
+    await expect(page.locator('.cm-content')).toBeFocused();
+  });
+
   test('focusing the body never expands frontmatter under the pointer click', async ({ page }) => {
     await page.goto('/test-harness/?component=FrontmatterCard');
     await page.waitForFunction(() => window.__HARNESS__?.ready === true);

--- a/app/e2e/frontmatter-card.spec.ts
+++ b/app/e2e/frontmatter-card.spec.ts
@@ -43,6 +43,73 @@ test.describe('FrontmatterCard', () => {
     await expect(page.locator('.cm-content')).not.toContainText('type: area');
   });
 
+  test('focusing the body never expands frontmatter under the pointer click', async ({ page }) => {
+    await page.goto('/test-harness/?component=FrontmatterCard');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-md-frontmatter');
+
+    // Record even a transient raw-YAML mount. The old focus-driven gate expanded the
+    // block before CodeMirror placed the body selection, changing geometry mid-click.
+    await page.evaluate(() => {
+      const content = document.querySelector('.cm-content')!;
+      (window as typeof window & { __rawFrontmatterSeen?: boolean }).__rawFrontmatterSeen = false;
+      const observer = new MutationObserver(() => {
+        if (content.textContent?.includes('type: area')) {
+          (window as typeof window & { __rawFrontmatterSeen?: boolean }).__rawFrontmatterSeen = true;
+        }
+      });
+      observer.observe(content, { childList: true, subtree: true, characterData: true });
+    });
+
+    await page.locator('.cm-line', { hasText: 'Context rail' }).click();
+    await page.waitForTimeout(50);
+
+    await expect(page.locator('.cm-md-frontmatter')).toBeVisible();
+    expect(await page.evaluate(
+      () => (window as typeof window & { __rawFrontmatterSeen?: boolean }).__rawFrontmatterSeen,
+    )).toBe(false);
+  });
+
+  test('keeps long markdown rendered and ArrowUp local beyond character 3,000', async ({ page }) => {
+    await page.goto('/test-harness/?component=FrontmatterCard&long=1');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-md-frontmatter');
+
+    const scroller = page.locator('.cm-scroller');
+    const stage2 = page.locator('.cm-line', { hasText: 'Stage 2: Rendered after' });
+    // CodeMirror virtualizes offscreen lines, so scroll the editor before locating
+    // Stage 2 in the DOM rather than asking Playwright to scroll a nonexistent node.
+    // Acknowledge an intermediate scroll first. CM's virtual scroller can otherwise
+    // restore its still-top internal anchor when a raw jump to the end races the first
+    // measure (the same constraint covered by scrollIntoLongNote in the editor specs).
+    await scroller.evaluate((el) => { el.scrollTop = 1800; });
+    await expect(page.locator('.cm-line', { hasText: 'Supporting paragraph 40 ' })).toBeAttached();
+    await expect(stage2).toBeAttached();
+    expect(await scroller.evaluate((el) => el.scrollTop)).toBeGreaterThan(500);
+
+    // Off the active line, the heading marker is hidden even though this heading is
+    // beyond CM's initial 3,000-character parse window.
+    await expect(stage2).not.toContainText('###');
+    await stage2.click();
+
+    // Chromium resolves this deep decorated-line click onto the following blank line.
+    // ArrowUp must move locally onto Stage 2, not jump to the frontmatter atom.
+    await page.keyboard.press('ArrowUp');
+    await expect(stage2).toContainText('###');
+    expect(await scroller.evaluate((el) => el.scrollTop)).toBeGreaterThan(500);
+
+    await page.keyboard.press('ArrowUp');
+    await expect(stage2).not.toContainText('###');
+    expect(await scroller.evaluate((el) => el.scrollTop)).toBeGreaterThan(500);
+
+    // A cursor transaction must not discard decorations for the remaining suffix.
+    const stage3 = page.locator('.cm-line', { hasText: 'Stage 3: Rendering remains stable' });
+    await scroller.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+    await expect(stage3).toBeAttached();
+    await expect(stage3).not.toContainText('###');
+    await expect(page.locator('.cm-line', { hasText: 'Stage complete when:' })).not.toContainText('**');
+  });
+
   test('a frontmatter-only note stays raw (no body line to anchor the cursor)', async ({ page }) => {
     await page.goto('/test-harness/?component=FrontmatterCard&empty=1');
     await page.waitForFunction(() => window.__HARNESS__?.ready === true);

--- a/app/src/components/notebook/frontmatterCard.test.ts
+++ b/app/src/components/notebook/frontmatterCard.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { frontmatterCardDecorations } from './frontmatterCard';
 import { parseFrontmatter } from './frontmatter';
 
-// Pull the card's ranges out of the decoration set so the cursor/focus gate can be
+// Pull the card's ranges out of the decoration set so the explicit-edit gate can be
 // asserted without mounting a view (the widget's toDOM never runs headlessly).
 function ranges(set: DecorationSet): { from: number; to: number; block: boolean }[] {
   const out: { from: number; to: number; block: boolean }[] = [];
@@ -23,20 +23,20 @@ function stateAt(doc: string, cursor: number): EditorState {
 const NOTE = ['---', 'type: area', 'tags: [a, b]', '---', '# Body', 'text'].join('\n');
 
 describe('frontmatterCardDecorations', () => {
-  it('renders a block-replace card over the whole frontmatter range when unfocused', () => {
-    const state = stateAt(NOTE, 0); // selection sits at 0 (inside the block) but unfocused
+  it('renders a block-replace card when property editing is inactive', () => {
+    const state = stateAt(NOTE, 0); // CM's initial selection sits inside the hidden block
     const got = ranges(frontmatterCardDecorations(state, false));
     const fm = parseFrontmatter(NOTE)!;
     expect(got).toEqual([{ from: 0, to: fm.to, block: true }]);
   });
 
-  it('keeps the card when focused but the cursor is in the body', () => {
+  it('keeps the card when edit mode is active but the cursor is in the body', () => {
     const bodyPos = parseFrontmatter(NOTE)!.to + 2; // a few chars into the body
     const got = ranges(frontmatterCardDecorations(stateAt(NOTE, bodyPos), true));
     expect(got).toHaveLength(1);
   });
 
-  it('reveals raw YAML (no card) when focused with the cursor inside the block', () => {
+  it('reveals raw YAML when explicit edit mode is active inside the block', () => {
     const got = ranges(frontmatterCardDecorations(stateAt(NOTE, 6), true)); // inside `type:`
     expect(got).toHaveLength(0);
   });

--- a/app/src/components/notebook/frontmatterCard.ts
+++ b/app/src/components/notebook/frontmatterCard.ts
@@ -1,8 +1,6 @@
 // The in-editor frontmatter card (notebook UI stage 4b, "Option A"). A note's leading
-// `---…---` YAML renders as a compact properties strip in place of the raw block; when
-// the editor is focused and the cursor enters the block, the card yields to the raw
-// YAML so it can be edited — the same reveal model the inline live-preview uses, at
-// block level.
+// `---…---` YAML renders as a compact properties strip in place of the raw block. The
+// card yields to raw YAML only when the user explicitly clicks it to edit properties.
 //
 // The card shows PROPERTIES only (type, summary, tags, sources, dates) — never a
 // title. A note's title is its leading `# H1` (the single canonical title; the keeper
@@ -19,16 +17,25 @@ import { type EditorState, type Extension, RangeSet, StateEffect, StateField } f
 import { Decoration, type DecorationSet, EditorView, WidgetType } from '@codemirror/view';
 import { type Frontmatter, type FrontmatterValue, parseFrontmatter } from './frontmatter';
 
-// Editor focus, carried into state. A StateField can't read `view.hasFocus`, but the
-// card must show when the editor is unfocused even though CM keeps a selection at
-// position 0 (which sits inside the frontmatter block). Without this, a freshly opened
-// note would show raw YAML instead of the card.
-const setFocused = StateEffect.define<boolean>();
+// Raw frontmatter is an explicit editing mode, not a consequence of editor focus.
+// CodeMirror focuses before it places a pointer selection. Tying the card to focus
+// therefore expanded the YAML under an in-flight body click (the stale selection was
+// still at position 0), changing document geometry while CM resolved that click.
+const setEditingFrontmatter = StateEffect.define<boolean>();
 
-const focusedField = StateField.define<boolean>({
+const editingFrontmatterField = StateField.define<boolean>({
   create: () => false,
   update(value, tr) {
-    for (const effect of tr.effects) if (effect.is(setFocused)) value = effect.value;
+    for (const effect of tr.effects) {
+      if (effect.is(setEditingFrontmatter)) value = effect.value;
+    }
+    if (value && tr.selection) {
+      const fm = parseFrontmatter(tr.state.doc.toString());
+      const remainsInside = fm && tr.state.selection.ranges.some(
+        (range) => range.from < fm.to && range.to > fm.from,
+      );
+      if (!remainsInside) value = false;
+    }
     return value;
   },
 });
@@ -139,7 +146,10 @@ class FrontmatterCardWidget extends WidgetType {
     card.addEventListener('mousedown', (event) => {
       event.preventDefault();
       const revealAt = view.state.doc.line(2).from; // line 1 is the opening fence
-      view.dispatch({ selection: { anchor: revealAt } });
+      view.dispatch({
+        selection: { anchor: revealAt },
+        effects: setEditingFrontmatter.of(true),
+      });
       view.focus();
     });
 
@@ -149,15 +159,15 @@ class FrontmatterCardWidget extends WidgetType {
 
 // Pure decoration builder (no view), so the gate is unit-testable headlessly like
 // buildDecorations. Returns the block-replace card, or an empty set when there's no
-// frontmatter or when a focused cursor sits inside the block (reveal raw for editing).
-export function frontmatterCardDecorations(state: EditorState, focused: boolean): DecorationSet {
+// frontmatter or while explicit frontmatter editing is active.
+export function frontmatterCardDecorations(state: EditorState, editing: boolean): DecorationSet {
   const doc = state.doc.toString();
   const fm = parseFrontmatter(doc);
   if (!fm || fm.to <= fm.from) return Decoration.none;
   // Don't swallow the whole document: a note that is ONLY frontmatter has no body line
   // to keep the cursor on, so leave it as raw text.
   if (fm.to >= doc.length) return Decoration.none;
-  if (focused) {
+  if (editing) {
     for (const range of state.selection.ranges) {
       if (range.from < fm.to && range.to > fm.from) return Decoration.none;
     }
@@ -168,26 +178,31 @@ export function frontmatterCardDecorations(state: EditorState, focused: boolean)
 }
 
 const cardField = StateField.define<DecorationSet>({
-  create: (state) => frontmatterCardDecorations(state, state.field(focusedField, false) ?? false),
+  create: (state) => frontmatterCardDecorations(
+    state,
+    state.field(editingFrontmatterField, false) ?? false,
+  ),
   update(value, tr) {
-    // Recompute when the doc, the selection, or focus changes — any of which can flip
-    // the card between shown and revealed.
-    if (tr.docChanged || tr.selection || tr.effects.some((e) => e.is(setFocused))) {
-      return frontmatterCardDecorations(tr.state, tr.state.field(focusedField, false) ?? false);
+    if (
+      tr.docChanged ||
+      tr.selection ||
+      tr.effects.some((effect) => effect.is(setEditingFrontmatter))
+    ) {
+      return frontmatterCardDecorations(
+        tr.state,
+        tr.state.field(editingFrontmatterField, false) ?? false,
+      );
     }
     return value.map(tr.changes);
   },
   provide: (field) => EditorView.decorations.from(field),
 });
 
-// Push focus changes into state so the card field can react to them.
-const focusTracker = EditorView.domEventHandlers({
-  focus: (_event, view) => {
-    view.dispatch({ effects: setFocused.of(true) });
-    return false;
-  },
+// Leaving the editor ends property editing. Ordinary focus does nothing, so a body
+// click cannot temporarily replace the card using CM's stale position-0 selection.
+const blurTracker = EditorView.domEventHandlers({
   blur: (_event, view) => {
-    view.dispatch({ effects: setFocused.of(false) });
+    view.dispatch({ effects: setEditingFrontmatter.of(false) });
     return false;
   },
 });
@@ -248,8 +263,8 @@ const cardTheme = EditorView.baseTheme({
   },
 });
 
-// The extension: focus tracking, the card field, its atomic range, and styles. Order
+// The extension: explicit editing state, the card field, its atomic range, and styles. Order
 // puts the field before the atomic facet, which reads it.
 export function frontmatterCard(): Extension {
-  return [focusedField, cardField, cardAtomic, focusTracker, cardTheme];
+  return [editingFrontmatterField, cardField, cardAtomic, blurTracker, cardTheme];
 }

--- a/app/src/components/notebook/frontmatterCard.ts
+++ b/app/src/components/notebook/frontmatterCard.ts
@@ -81,8 +81,9 @@ class FrontmatterCardWidget extends WidgetType {
     const f = this.fm.fields;
     const card = document.createElement('div');
     card.className = 'cm-md-frontmatter';
-    card.setAttribute('role', 'group');
-    card.setAttribute('aria-label', 'Note properties');
+    card.setAttribute('role', 'button');
+    card.setAttribute('aria-label', 'Edit note properties');
+    card.tabIndex = 0;
 
     // Header row: the type pill and the dates — the card's compact identity line.
     // No title: the note's `# H1` below the card is the title.
@@ -140,17 +141,26 @@ class FrontmatterCardWidget extends WidgetType {
     hint.textContent = 'click to edit';
     card.appendChild(hint);
 
-    // Click reveals the raw YAML for editing: move the cursor just inside the block
-    // (the first YAML line) so the reveal gate fires, and take focus. preventDefault
-    // stops CM from also placing a selection at the click point.
-    card.addEventListener('mousedown', (event) => {
-      event.preventDefault();
+    // Pointer or keyboard activation reveals the raw YAML for editing: move the cursor
+    // just inside the block (the first YAML line) so the reveal gate fires, then hand
+    // focus back to the editor at that visible selection.
+    const reveal = () => {
       const revealAt = view.state.doc.line(2).from; // line 1 is the opening fence
       view.dispatch({
         selection: { anchor: revealAt },
         effects: setEditingFrontmatter.of(true),
       });
       view.focus();
+    };
+    card.addEventListener('mousedown', (event) => {
+      event.preventDefault();
+      reveal();
+    });
+    card.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      event.preventDefault();
+      event.stopPropagation();
+      reveal();
     });
 
     return card;

--- a/app/src/components/notebook/frontmatterCard.ts
+++ b/app/src/components/notebook/frontmatterCard.ts
@@ -153,7 +153,13 @@ class FrontmatterCardWidget extends WidgetType {
       view.focus();
     };
     card.addEventListener('mousedown', (event) => {
+      // Keep CodeMirror from placing a selection around the atomic widget before the
+      // ensuing semantic click activates it.
       event.preventDefault();
+    });
+    card.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
       reveal();
     });
     card.addEventListener('keydown', (event) => {

--- a/app/src/components/notebook/frontmatterCard.ts
+++ b/app/src/components/notebook/frontmatterCard.ts
@@ -202,7 +202,14 @@ const cardField = StateField.define<DecorationSet>({
 // click cannot temporarily replace the card using CM's stale position-0 selection.
 const blurTracker = EditorView.domEventHandlers({
   blur: (_event, view) => {
-    view.dispatch({ effects: setEditingFrontmatter.of(false) });
+    const fm = parseFrontmatter(view.state.doc.toString());
+    const selectionInside = fm && view.state.selection.ranges.some(
+      (range) => range.from < fm.to && range.to > fm.from,
+    );
+    view.dispatch({
+      ...(selectionInside ? { selection: { anchor: fm.to } } : {}),
+      effects: setEditingFrontmatter.of(false),
+    });
     return false;
   },
 });

--- a/app/src/components/notebook/liveMarkdownPreview.test.ts
+++ b/app/src/components/notebook/liveMarkdownPreview.test.ts
@@ -61,6 +61,22 @@ describe('liveMarkdownPreview decorations', () => {
     expect(hideAt(decos, 0, 2)).toBe(true);
   });
 
+  it('decorates syntax beyond CodeMirror\'s initial 3,000-character parse window', () => {
+    const prefix = `${'ordinary paragraph text '.repeat(140)}\n\n`;
+    const heading = '### Stage 2 remains rendered';
+    const doc = `${prefix}${heading}\n\nbody`;
+    const headingFrom = doc.indexOf(heading);
+    expect(headingFrom).toBeGreaterThan(3000);
+
+    const decos = decosFor(doc, doc.length, false);
+    expect(
+      decos.some(
+        (d) => d.class === 'cm-md-h3' && d.from === headingFrom && d.to === headingFrom + heading.length,
+      ),
+    ).toBe(true);
+    expect(hideAt(decos, headingFrom, headingFrom + 4)).toBe(true);
+  });
+
   it('reveals the heading marker when the cursor is on the heading line', () => {
     const doc = '# Title\n\nbody';
     const decos = decosFor(doc, 1); // cursor inside the heading line

--- a/app/src/components/notebook/liveMarkdownPreview.ts
+++ b/app/src/components/notebook/liveMarkdownPreview.ts
@@ -44,6 +44,10 @@ const HEADING_MARK = [1, 2, 3, 4, 5, 6].map((n) => Decoration.mark({ class: `cm-
 const HIDE = Decoration.replace({});
 const CODEFENCE = Decoration.mark({ class: 'cm-md-codefence' });
 const CODEINFO = Decoration.mark({ class: 'cm-md-codeinfo' });
+// Keep nearby layout decorations stable while CM adjusts its viewport after edits.
+// Scanning only the exact viewport let a heading cross the boundary during scroll
+// anchoring, changing its line height and nudging the reader by several pixels.
+const DECORATION_MARGIN = 5000;
 // A line decoration applied to every row of a fenced code block, giving the block a
 // contiguous monospace panel (the fences stay visible but dimmed, so nothing shifts).
 const CODEBLOCK_LINE = Decoration.line({ class: 'cm-md-codeblock' });
@@ -322,16 +326,21 @@ export function liveMarkdownPreview(options: LiveMarkdownOptions = {}): Extensio
       rebuild(view: EditorView) {
         // CodeMirror deliberately parses only the first 3,000 characters on state
         // creation, then advances around the viewport in the background. Restricting
-        // decorations to the logical viewport keeps work bounded, while ensuring through
-        // the viewport prevents a cursor transaction from replacing rendered markdown
-        // with raw text at that initial parse boundary.
-        const upto = view.viewport.to;
+        // decorations to the logical viewport plus a bounded margin keeps work bounded,
+        // while ensuring through that range prevents a cursor transaction from replacing
+        // rendered markdown with raw text at the initial parse boundary. The margin also
+        // keeps line-height decorations stable while CM anchors scroll across edits.
+        const range = {
+          from: Math.max(0, view.viewport.from - DECORATION_MARGIN),
+          to: Math.min(view.state.doc.length, view.viewport.to + DECORATION_MARGIN),
+        };
+        const upto = range.to;
         this.tree = ensureSyntaxTree(view.state, upto, 20) ?? syntaxTree(view.state);
         this.decorations = buildDecorations(
           view.state,
           view.hasFocus,
           this.tree,
-          view.viewport,
+          range,
         );
       }
 

--- a/app/src/components/notebook/liveMarkdownPreview.ts
+++ b/app/src/components/notebook/liveMarkdownPreview.ts
@@ -8,7 +8,7 @@
 // that line reads exactly as the file does on disk. Everything is derived from the
 // Lezer markdown syntax tree, so it tracks the parser rather than re-implementing it.
 
-import { syntaxTree } from '@codemirror/language';
+import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
 import { type EditorState, type Extension, type Range } from '@codemirror/state';
 import {
   Decoration,
@@ -18,6 +18,7 @@ import {
   type ViewUpdate,
   WidgetType,
 } from '@codemirror/view';
+import type { Tree } from '@lezer/common';
 
 export interface LiveMarkdownOptions {
   // Invoked when the user mod-clicks (⌘/Ctrl) a rendered link. Receives the raw href.
@@ -116,15 +117,31 @@ function activeLines(state: EditorState): Set<number> {
 // markdown (nothing "active"), so a freshly-opened note reads like a rendered doc
 // even though CM always keeps a selection at position 0. Once focused, the cursor's
 // line reveals its raw markers for editing.
-export function buildDecorations(state: EditorState, focused = true): DecorationSet {
+interface DecorationRange {
+  from: number;
+  to: number;
+}
+
+export function buildDecorations(
+  state: EditorState,
+  focused = true,
+  parsedTree?: Tree,
+  range?: DecorationRange,
+): DecorationSet {
   const decos: Range<Decoration>[] = [];
   const { doc } = state;
   const active = focused ? activeLines(state) : new Set<number>();
-  const tree = syntaxTree(state);
+  // Headless callers want the complete document. The live ViewPlugin passes an
+  // already-ensured tree plus its logical viewport so cursor motion never reparses an
+  // arbitrarily large note synchronously.
+  const tree = parsedTree ?? ensureSyntaxTree(state, doc.length, 100) ?? syntaxTree(state);
+  const scanRange = range ?? { from: 0, to: doc.length };
 
   const onActiveLine = (pos: number) => active.has(doc.lineAt(pos).number);
 
   tree.iterate({
+    from: scanRange.from,
+    to: scanRange.to,
     enter: (node) => {
       const name = node.name;
 
@@ -294,15 +311,43 @@ export function liveMarkdownPreview(options: LiveMarkdownOptions = {}): Extensio
   const plugin = ViewPlugin.fromClass(
     class {
       decorations: DecorationSet;
+      tree: Tree;
+
       constructor(view: EditorView) {
-        this.decorations = buildDecorations(view.state, view.hasFocus);
+        this.tree = syntaxTree(view.state);
+        this.decorations = Decoration.none;
+        this.rebuild(view);
       }
+
+      rebuild(view: EditorView) {
+        // CodeMirror deliberately parses only the first 3,000 characters on state
+        // creation, then advances around the viewport in the background. Restricting
+        // decorations to the logical viewport keeps work bounded, while ensuring through
+        // the viewport prevents a cursor transaction from replacing rendered markdown
+        // with raw text at that initial parse boundary.
+        const upto = view.viewport.to;
+        this.tree = ensureSyntaxTree(view.state, upto, 20) ?? syntaxTree(view.state);
+        this.decorations = buildDecorations(
+          view.state,
+          view.hasFocus,
+          this.tree,
+          view.viewport,
+        );
+      }
+
       update(update: ViewUpdate) {
+        const currentTree = syntaxTree(update.state);
         // Markers reveal/hide as the cursor moves and as focus changes (an unfocused
-        // editor renders fully clean), so rebuild on selection and focus changes too,
-        // not only document/viewport changes.
-        if (update.docChanged || update.viewportChanged || update.selectionSet || update.focusChanged) {
-          this.decorations = buildDecorations(update.state, update.view.hasFocus);
+        // editor renders fully clean). A parse-only transaction must also rebuild so
+        // newly parsed visible syntax becomes decorated without another user action.
+        if (
+          update.docChanged ||
+          update.viewportChanged ||
+          update.selectionSet ||
+          update.focusChanged ||
+          currentTree !== this.tree
+        ) {
+          this.rebuild(update.view);
         }
       }
     },

--- a/app/test-harness/harnesses/FrontmatterCardHarness.tsx
+++ b/app/test-harness/harnesses/FrontmatterCardHarness.tsx
@@ -9,6 +9,7 @@
  */
 import { useCallback, useEffect, useState } from 'react';
 import '../../src/App.css';
+import '../../src/components/NotebookBrowser.css';
 import { LiveMarkdownEditor } from '../../src/components/notebook/LiveMarkdownEditor';
 import type { HarnessProps } from '../types';
 
@@ -34,9 +35,31 @@ summary: A note that is only properties, with no body.
 ---
 `;
 
+const LONG_SAMPLE = `${SAMPLE}
+## Stage 1: Rendered before the initial parse boundary
+
+${Array.from(
+  { length: 55 },
+  (_, i) => `Supporting paragraph ${i + 1} keeps this realistic long-form notebook document readable.`,
+).join('\n\n')}
+
+### Stage 2: Rendered after the initial parse boundary
+
+**Output:** Markdown after character 3,000 remains rendered when the cursor moves.
+
+### Stage 3: Rendering remains stable
+
+**Stage complete when:** ArrowUp moves one visual line without returning to frontmatter.
+`;
+
 export function FrontmatterCardHarness({ onReady, setTriggerRerender }: HarnessProps) {
   const params = new URLSearchParams(window.location.search);
-  const [value, setValue] = useState(params.get('empty') === '1' ? SAMPLE_NO_BODY : SAMPLE);
+  const initial = params.get('empty') === '1'
+    ? SAMPLE_NO_BODY
+    : params.get('long') === '1'
+      ? LONG_SAMPLE
+      : SAMPLE;
+  const [value, setValue] = useState(initial);
   const [, force] = useState(0);
 
   const handleChange = useCallback((next: string) => {
@@ -52,7 +75,10 @@ export function FrontmatterCardHarness({ onReady, setTriggerRerender }: HarnessP
 
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', padding: 24, background: 'var(--color-bg-app)' }}>
-      <div style={{ flex: 1, minHeight: 0, border: '1px solid var(--color-border)', borderRadius: 8 }}>
+      <div
+        className="notebook-browser-live-editor"
+        style={{ border: '1px solid var(--color-border)', borderRadius: 8 }}
+      >
         <LiveMarkdownEditor value={value} onChange={handleChange} ariaLabel="Note" />
       </div>
     </div>


### PR DESCRIPTION
## Intent / Why

Long Notebook notes could lose rendered Markdown after the first few thousand characters when a click or cursor movement rebuilt preview decorations from CodeMirror's incomplete initial syntax tree. The resulting layout churn could also send ArrowUp back to the frontmatter card. Focusing the note body had a second geometry race: frontmatter briefly expanded from the stale position-0 selection before CodeMirror placed the click.

## Summary

- scope live-preview decoration work to the logical viewport, ensure parsing reaches that viewport, and refresh when background parsing advances so long-note suffixes stay rendered without synchronously parsing the whole document on every keypress
- make raw frontmatter editing explicit to clicks on the properties card, keeping ordinary body focus from changing document geometry mid-click
- add a long-document fixture beyond CodeMirror's 3,000-character initial parse boundary plus unit and browser regressions for rendering, ArrowUp locality, and frontmatter stability
- document the user-visible fix in the changelog

## Test plan

- [x] `make test-frontend` (1,143 tests)
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec playwright test e2e/frontmatter-card.spec.ts e2e/live-markdown-editor.spec.ts` (13 tests)
- [x] `make dev` (signed, installed, and launched the isolated `attn-dev.app`)
- [ ] In a packaged app with native-input Accessibility permission, open a long frontmatter note and confirm ArrowUp stays local; the automated packaged Notebook scenario could not deliver its native shortcut in this environment because the harness process lacks Accessibility permission