### PR TITLE
fix(delegation): preserve tracked session identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Chief-of-staff delegations no longer disappear into muted workspaces.** Delegating into an existing muted workspace now brings that workspace back into the sidebar, and `attn list` marks sessions whose workspace is muted so the chief can see that state before choosing a target.
+- **Delegated Codex agents keep their attn identity when working in child directories.** An agent launched in a shared parent directory could lose its session ID and attn wrapper path after running tools from a branch-specific child worktree, so tracked reports, inbox access, and workspace-context publication failed with "no session." Managed Codex launches now preserve the correct session routing across tool working directories and workspace placement modes.
 
 ## [2026-06-22]
 

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -89,6 +89,9 @@ func (c *Codex) BuildEnv(opts SpawnOpts) []string {
 		"ATTN_SESSION_ID=" + opts.SessionID,
 		"ATTN_AGENT=codex",
 	}
+	if wrapper := strings.TrimSpace(opts.WrapperPath); wrapper != "" {
+		env = append(env, "ATTN_WRAPPER_PATH="+wrapper)
+	}
 	if strings.TrimSpace(opts.NotebookRoot) != "" {
 		// A chief launch injected Notebook guidance at launch; mark it so the
 		// SessionStart hook does not also emit workspace-context guidance.

--- a/internal/agent/yolo_test.go
+++ b/internal/agent/yolo_test.go
@@ -180,10 +180,14 @@ func TestCodexConfigOverrides_NonChiefOmitsJournalingDirective(t *testing.T) {
 func TestCodexBuildEnvMarksNotebookGuidance(t *testing.T) {
 	env := (&Codex{}).BuildEnv(SpawnOpts{
 		SessionID:    "sess-1",
+		WrapperPath:  "/Applications/attn-dev.app/Contents/MacOS/attn",
 		NotebookRoot: "/home/u/attn-notebook",
 	})
 	if !slices.Contains(env, "ATTN_NOTEBOOK_GUIDANCE=developer_instructions") {
 		t.Fatalf("env = %#v, want notebook guidance marker", env)
+	}
+	if !slices.Contains(env, "ATTN_WRAPPER_PATH=/Applications/attn-dev.app/Contents/MacOS/attn") {
+		t.Fatalf("env = %#v, want explicit wrapper path", env)
 	}
 }
 

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -182,6 +182,120 @@ func TestChiefOfStaffDelegateCreatesTrackedDispatch(t *testing.T) {
 	}
 }
 
+func TestChiefOfStaffDelegationPreservesCoordinationIdentityAcrossPlacements(t *testing.T) {
+	for _, placement := range []string{
+		delegationPlacementCurrent,
+		delegationPlacementNew,
+		delegationPlacementExisting,
+	} {
+		t.Run(placement, func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			backend := &fakeSpawnBackend{}
+			_, chiefSessionID, _ := setupDelegationSource(t, d, backend)
+			if err := d.store.SetProfileRole(profileRoleChiefOfStaff, chiefSessionID); err != nil {
+				t.Fatalf("set chief role: %v", err)
+			}
+			consumeDelegatedPrompt(t, backend)
+
+			msg := &protocol.DelegateMessage{
+				Cmd:             protocol.CmdDelegate,
+				SourceSessionID: chiefSessionID,
+				Brief:           "Exercise tracked coordination identity.",
+				Agent:           protocol.Ptr("codex"),
+				Placement:       protocol.Ptr(placement),
+			}
+			switch placement {
+			case delegationPlacementNew:
+				msg.Cwd = protocol.Ptr(t.TempDir())
+			case delegationPlacementExisting:
+				targetDirectory := t.TempDir()
+				msg.WorkspaceID = protocol.Ptr("workspace-target")
+				d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+					Cmd:       protocol.CmdRegisterWorkspace,
+					ID:        protocol.Deref(msg.WorkspaceID),
+					Title:     "Target",
+					Directory: targetDirectory,
+				})
+			}
+
+			result, err := d.delegate(msg)
+			if err != nil {
+				t.Fatalf("delegate() error = %v", err)
+			}
+			spawn, ok := backend.LastSpawn()
+			if !ok || spawn.ID != result.SessionID || spawn.CWD != result.Directory {
+				t.Fatalf("spawn = %+v, result = %+v", spawn, result)
+			}
+			dispatch := d.store.GetChiefOfStaffDispatchBySession(spawn.ID)
+			if dispatch == nil || dispatch.ID != protocol.Deref(result.DispatchID) ||
+				dispatch.WorkspaceID != result.WorkspaceID {
+				t.Fatalf("dispatch = %+v, result = %+v", dispatch, result)
+			}
+
+			reportServer, reportClient := net.Pipe()
+			go func() {
+				d.handleReportDispatch(reportServer, &protocol.ReportDispatchMessage{
+					Cmd:             protocol.CmdReportDispatch,
+					SourceSessionID: spawn.ID,
+					Report:          "Placement identity verified.",
+				})
+				_ = reportServer.Close()
+			}()
+			var reportResponse protocol.Response
+			if err := json.NewDecoder(reportClient).Decode(&reportResponse); err != nil {
+				t.Fatalf("decode report response: %v", err)
+			}
+			_ = reportClient.Close()
+			if !reportResponse.Ok || reportResponse.ChiefOfStaffDispatch == nil ||
+				reportResponse.ChiefOfStaffDispatch.SessionID != spawn.ID {
+				t.Fatalf("report response = %+v", reportResponse)
+			}
+
+			inboxServer, inboxClient := net.Pipe()
+			go func() {
+				d.handleListDispatchMessages(inboxServer, &protocol.ListDispatchMessagesMessage{
+					Cmd:             protocol.CmdListDispatchMessages,
+					SourceSessionID: spawn.ID,
+					UnreadOnly:      protocol.Ptr(true),
+				})
+				_ = inboxServer.Close()
+			}()
+			var inboxResponse protocol.Response
+			if err := json.NewDecoder(inboxClient).Decode(&inboxResponse); err != nil {
+				t.Fatalf("decode inbox response: %v", err)
+			}
+			_ = inboxClient.Close()
+			if !inboxResponse.Ok {
+				t.Fatalf("inbox response = %+v", inboxResponse)
+			}
+
+			checkout, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{
+				SourceSessionID: spawn.ID,
+			})
+			if err != nil {
+				t.Fatalf("checkout workspace context: %v", err)
+			}
+			if checkout.SessionID != spawn.ID || checkout.WorkspaceID != result.WorkspaceID {
+				t.Fatalf("checkout = %+v, spawn = %+v, result = %+v", checkout, spawn, result)
+			}
+			if err := os.WriteFile(checkout.Path, []byte("# Workspace Context\n\n## Area\nDelegation identity.\n\n## Current Picture\nCoordination is routed by the delegated session.\n"), 0o600); err != nil {
+				t.Fatalf("edit workspace context: %v", err)
+			}
+			updated, changed, err := d.updateWorkspaceContext(&protocol.WorkspaceContextUpdateMessage{
+				SourceSessionID: spawn.ID,
+			})
+			if err != nil || !changed || updated.SessionID != spawn.ID ||
+				updated.WorkspaceID != result.WorkspaceID {
+				t.Fatalf("workspace context update = %+v, changed=%v, err=%v", updated, changed, err)
+			}
+			canonical, err := d.store.GetWorkspaceContext(result.WorkspaceID)
+			if err != nil || canonical.UpdatedBySessionID != spawn.ID {
+				t.Fatalf("canonical workspace context = %+v, err=%v", canonical, err)
+			}
+		})
+	}
+}
+
 func TestDelegatedFromChiefDecoratesBroadcastSession(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -14,8 +14,6 @@ import (
 // attn has always owned the resize-reflow value for its embedded renderer:
 // xterm needed it disabled, while Ghostty correctly renders the enabled redraw.
 func GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath, workspaceContextPath, notebookRoot string, injectWorkflow bool) []string {
-	_ = sessionID  // Commands read ATTN_SESSION_ID from the Codex process env.
-	_ = socketPath // Hook commands inherit ATTN_SOCKET_PATH from the Codex process env.
 	wrapper := strings.TrimSpace(wrapperPath)
 	if wrapper == "" {
 		wrapper = "attn"
@@ -47,6 +45,13 @@ func GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath, workspaceC
 	stop := command("_hook-stop")
 
 	overrides := []string{
+		// Codex's shell environment policy is applied independently for each tool
+		// working directory. Values inherited by the top-level Codex process can
+		// therefore disappear when an agent runs a tool from a child worktree.
+		// Pin attn's routing identity in the per-launch policy so hooks and agent
+		// commands keep targeting this session regardless of tool cwd.
+		"shell_environment_policy.set.ATTN_SESSION_ID=" + strconv.Quote(strings.TrimSpace(sessionID)),
+		"shell_environment_policy.set.ATTN_WRAPPER_PATH=" + strconv.Quote(wrapper),
 		"features.hooks=true",
 		// Ghostty renders Codex's SIGWINCH redraw correctly, and enabling
 		// reflow prevents resized inline UIs from leaving stale headers.
@@ -65,6 +70,11 @@ func GenerateCodexConfigOverrides(sessionID, socketPath, wrapperPath, workspaceC
 		"hooks.PreToolUse=" + group("*", preToolUse),
 		"hooks.PostToolUse=" + group("*", postToolUse),
 		"hooks.Stop=" + group("", stop),
+	}
+	if socket := strings.TrimSpace(socketPath); socket != "" {
+		overrides = append(overrides,
+			"shell_environment_policy.set.ATTN_SOCKET_PATH="+strconv.Quote(socket),
+		)
 	}
 	// A chief-of-staff launch (notebookRoot set) gets Notebook guidance instead
 	// of the workspace-context checkout guidance. Every other workspace agent gets

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -119,6 +119,15 @@ func TestGenerateHooks_DefaultsWrapperToAttn(t *testing.T) {
 func TestGenerateCodexConfigOverrides_UsesStableEnvBasedCommands(t *testing.T) {
 	overrides := GenerateCodexConfigOverrides("session-1", "/tmp/attn.sock", "/tmp/attn", "/tmp/context.md", "", false)
 	joined := strings.Join(overrides, "\n")
+	for _, expected := range []string{
+		`shell_environment_policy.set.ATTN_SESSION_ID="session-1"`,
+		`shell_environment_policy.set.ATTN_WRAPPER_PATH="/tmp/attn"`,
+		`shell_environment_policy.set.ATTN_SOCKET_PATH="/tmp/attn.sock"`,
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("codex overrides missing stable tool environment %q: %q", expected, joined)
+		}
+	}
 
 	if !strings.Contains(joined, "hooks.SessionStart=") {
 		t.Fatal("codex overrides should include SessionStart hook")
@@ -129,11 +138,9 @@ func TestGenerateCodexConfigOverrides_UsesStableEnvBasedCommands(t *testing.T) {
 	if !strings.Contains(joined, "startup|resume|clear|compact") {
 		t.Fatal("codex SessionStart hook should run after context resets")
 	}
-	if strings.Contains(joined, "session-1") {
-		t.Fatal("codex hook commands should not embed per-session attn ids")
-	}
-	if strings.Contains(joined, "/tmp/attn.sock") {
-		t.Fatal("codex hook commands should not embed per-session socket paths")
+	if strings.Contains(joined, "_hook-session-start session-1") ||
+		strings.Contains(joined, "_hook-state working session-1") {
+		t.Fatal("codex hook commands should read identity from their stable environment")
 	}
 	if !strings.Contains(joined, "features.hooks=true") {
 		t.Fatal("codex overrides should enable hooks for attn-managed sessions")
@@ -154,6 +161,17 @@ func TestGenerateCodexConfigOverrides_UsesStableEnvBasedCommands(t *testing.T) {
 	if !strings.Contains(joined, "developer_instructions=") ||
 		!strings.Contains(joined, "/tmp/context.md") {
 		t.Fatal("codex overrides should inject workspace context as developer instructions")
+	}
+}
+
+func TestGenerateCodexConfigOverrides_OmitsEmptySocketButKeepsSessionIdentity(t *testing.T) {
+	overrides := strings.Join(GenerateCodexConfigOverrides("session-2", "", "", "", "", false), "\n")
+	if !strings.Contains(overrides, `shell_environment_policy.set.ATTN_SESSION_ID="session-2"`) ||
+		!strings.Contains(overrides, `shell_environment_policy.set.ATTN_WRAPPER_PATH="attn"`) {
+		t.Fatalf("codex overrides dropped required attn identity: %q", overrides)
+	}
+	if strings.Contains(overrides, "ATTN_SOCKET_PATH") {
+		t.Fatalf("codex overrides should omit an empty socket path: %q", overrides)
 	}
 }
 


### PR DESCRIPTION
## Intent / Why

Chief-of-staff agents delegated into a shared parent directory could not report progress after switching tool execution into their branch-specific child worktrees. `ATTN_WRAPPER_PATH` and the session identity disappeared, so `dispatch report`, `dispatch inbox --unread`, and workspace-context publication all failed with `no session` even though attn had persisted the sessions and their dispatch associations correctly.

## Root cause

attn supplied its routing variables to the top-level Codex process, but Codex applies `shell_environment_policy` independently to tool commands. With the user's `inherit = "core"` policy, a tool command whose working directory differed from the session launch directory did not inherit `ATTN_SESSION_ID`, `ATTN_WRAPPER_PATH`, or `ATTN_SOCKET_PATH`.

Both observed placement paths converged on the correct daemon spawn path; the failure happened afterward when each agent ran tools from a child worktree.

## Summary

- Pin the launch-specific session ID, wrapper path, and socket path in Codex's per-launch shell environment policy so tool commands retain the correct attn identity across working directories.
- Pass the wrapper path explicitly in the top-level Codex environment instead of relying only on inherited PTY state.
- Cover all placement modes—current workspace, new workspace via `--cwd`, and existing workspace via `--workspace`—and verify the delegated identity can report, read its unread inbox, and publish workspace context.
- Document the user-visible fix in the changelog.

## Test plan

- [x] `go test ./internal/hooks ./internal/agent`
- [x] Focused delegation, dispatch, inbox, and workspace-context daemon tests
- [x] `go test -short ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `make dev` (signed isolated dev app build/install)

## Out of scope

Delegation placement semantics are unchanged. This only makes the existing session identity and profile-specific routing survive Codex tool working-directory changes.
