### PR TITLE
Self-report trigger loop — chief↔delegated-agent awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-06-23]
 
+### Added
+- **Self-report finishing or getting stuck with one flag — no JSON.** A delegated agent can now declare a terminal or blocked outcome directly: `attn dispatch report --done` / `--review` / `--failed` / `--blocked`. `--blocked` takes `--question`, `--recommendation`, and `--consequence` to put a concrete decision in front of the chief. A plain `--message` with no flag is a silent note that does not wake the chief. The full `--coordination-file` JSON envelope stays as an escape hatch.
+- **See pending chief mail without opening the dashboard.** A delegated agent that has unread mail from its chief now shows an amber envelope badge in the sidebar (and a small dot on the collapsed rail), plus an overlay on the agent's own terminal. Clicking the overlay prompts that agent to check its inbox.
+
+### Changed
+- **A chief's `dispatch watch` fires only on what an agent reports, not on its process state.** Watching a delegation no longer reacts to the agent's runtime status, so a turn-boundary rest is never misread as "ended" and stopping with an empty report is no longer a false "waiting" blocker. The watch wakes the chief only when the agent self-reports done, ready-for-review, failed, or blocked. Trade-off: an agent that ends without filing a report now leaves its watch quietly waiting rather than emitting a neutral "ended" — silence is neither success nor failure.
+
 ### Fixed
 - **Long Notebook notes keep their rendered formatting and cursor position while you edit.** Moving the cursor beyond the first few thousand characters no longer turns the rest of a note back into raw Markdown or sends ArrowUp to the properties card. Clicking into the body also leaves the frontmatter card stable; raw YAML appears only when you click the card to edit it.
 - **Chief-of-staff delegations no longer disappear into muted workspaces.** Delegating into an existing muted workspace now brings that workspace back into the sidebar, and `attn list` marks sessions whose workspace is muted so the chief can see that state before choosing a target.

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -26,6 +26,7 @@ import { SessionCreationProgress, type SessionCreationPhase } from './components
 import { RightDock } from './components/RightDock';
 import { SessionTerminalWorkspace } from './components/SessionTerminalWorkspace';
 import type { DockTarget } from './components/SessionTerminalWorkspace/dockTarget';
+import type { PendingAgentMail } from './components/OnAgentMailOverlay';
 import { SettingsModal } from './components/SettingsModal';
 import { ShortcutsModal } from './components/ShortcutsModal';
 import { ShortcutEditorModal } from './components/ShortcutEditorModal';
@@ -1067,7 +1068,7 @@ sendFetchPRDetails,
   const [workspaceContextsError, setWorkspaceContextsError] = useState<string | null>(null);
   const [workspaceContexts, setWorkspaceContexts] = useState<Awaited<ReturnType<typeof sendListWorkspaceContexts>>>([]);
   const whatsNew = useWhatsNew();
-  const { repoStates, authorStates } = useDaemonStore();
+  const { repoStates, authorStates, chiefOfStaffDispatches } = useDaemonStore();
   const mutedRepos = useMemo(() =>
     repoStates.filter(r => r.muted).map(r => r.repo),
     [repoStates],
@@ -1216,6 +1217,21 @@ sendFetchPRDetails,
     [daemonEndpoints],
   );
 
+  // Unread chief→agent mail per session, derived from the dispatch list already in
+  // the store (each ChiefOfStaffDispatch carries unread_message_count keyed by its
+  // session_id) — no extra protocol surface. Drives the sidebar pending-mail badge.
+  const dispatchesWithMail = chiefOfStaffDispatches ?? [];
+  const unreadMailBySessionId = new Map<string, number>();
+  for (const dispatch of dispatchesWithMail) {
+    const count = dispatch.unread_message_count ?? 0;
+    if (count > 0) {
+      unreadMailBySessionId.set(
+        dispatch.session_id,
+        (unreadMailBySessionId.get(dispatch.session_id) ?? 0) + count,
+      );
+    }
+  }
+
   const enrichedLocalSessions = sessions.map((s) => {
     const daemonSession = daemonSessions.find((ds) => ds.id === s.id);
     const rawState = daemonSession?.state ?? s.state;
@@ -1240,10 +1256,33 @@ sendFetchPRDetails,
       reviewLoopStatus: reviewLoop?.status,
       chiefOfStaff: daemonSession?.chief_of_staff ?? false,
       delegatedFromChief: daemonSession?.delegated_from_chief ?? false,
+      unreadMailCount: unreadMailBySessionId.get(s.id) ?? 0,
     };
   });
 
   const visibleEnrichedSessions = filterSessionsRepresentedInWorkspaceLayouts(daemonWorkspaces, enrichedLocalSessions);
+
+  // Per-session pending mail for the on-agent overlay: the unread count plus the
+  // dispatch/chief routing the wake doorbell needs, and whether the agent is in a
+  // pokeable state (mirrors the dashboard's canWake gate).
+  const pendingMailBySessionId = new Map<string, PendingAgentMail>();
+  for (const dispatch of dispatchesWithMail) {
+    const count = dispatch.unread_message_count ?? 0;
+    if (count <= 0) continue;
+    const session = enrichedLocalSessions.find((entry) => entry.id === dispatch.session_id);
+    const wakeable = Boolean(
+      session
+      && !session.endpointName
+      && (session.state === 'idle' || session.state === 'waiting_input'),
+    );
+    const existing = pendingMailBySessionId.get(dispatch.session_id);
+    pendingMailBySessionId.set(dispatch.session_id, {
+      unreadCount: (existing?.unreadCount ?? 0) + count,
+      dispatchId: existing?.dispatchId ?? dispatch.id,
+      chiefSessionId: existing?.chiefSessionId ?? dispatch.chief_session_id,
+      wakeable: existing ? existing.wakeable || wakeable : wakeable,
+    });
+  }
 
   // The Notebook top-bar chief pulse: undefined when no chief-of-staff session exists
   // (indicator hidden), else true while it is working. Derived locally from sessions
@@ -3650,6 +3689,8 @@ sendFetchPRDetails,
                     isSessionViewVisible={view === 'session'}
                     terminalsLive={terminalsLive}
                     eventRouter={paneRuntimeEventRouter}
+                    pendingMailBySessionId={pendingMailBySessionId}
+                    onWakeDispatch={sendWakeDispatchAgent}
                     onSplitPane={(targetPaneId, direction) => {
                       void createSplitSession('shell', direction, targetPaneId);
                     }}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1262,9 +1262,15 @@ sendFetchPRDetails,
 
   const visibleEnrichedSessions = filterSessionsRepresentedInWorkspaceLayouts(daemonWorkspaces, enrichedLocalSessions);
 
+  // The currently active chief-of-staff session, if any. Used both for the Notebook
+  // top-bar pulse below and for the on-agent overlay's wake gate (a wake routes
+  // through this chief, so it must be the one that owns the dispatch).
+  const notebookChiefSession = enrichedLocalSessions.find((session) => session.chiefOfStaff);
+
   // Per-session pending mail for the on-agent overlay: the unread count plus the
   // dispatch/chief routing the wake doorbell needs, and whether the agent is in a
-  // pokeable state (mirrors the dashboard's canWake gate).
+  // pokeable state (mirrors the dashboard's canWake gate, including that the
+  // dispatch's chief is the currently active chief session).
   const pendingMailBySessionId = new Map<string, PendingAgentMail>();
   for (const dispatch of dispatchesWithMail) {
     const count = dispatch.unread_message_count ?? 0;
@@ -1273,7 +1279,8 @@ sendFetchPRDetails,
     const wakeable = Boolean(
       session
       && !session.endpointName
-      && (session.state === 'idle' || session.state === 'waiting_input'),
+      && (session.state === 'idle' || session.state === 'waiting_input')
+      && notebookChiefSession?.id === dispatch.chief_session_id,
     );
     const existing = pendingMailBySessionId.get(dispatch.session_id);
     pendingMailBySessionId.set(dispatch.session_id, {
@@ -1285,9 +1292,8 @@ sendFetchPRDetails,
   }
 
   // The Notebook top-bar chief pulse: undefined when no chief-of-staff session exists
-  // (indicator hidden), else true while it is working. Derived locally from sessions
-  // already in hand — no extra socket call or threaded daemon function.
-  const notebookChiefSession = enrichedLocalSessions.find((session) => session.chiefOfStaff);
+  // (indicator hidden), else true while it is working. Reuses notebookChiefSession
+  // derived above — no extra socket call or threaded daemon function.
   const notebookChiefActive = notebookChiefSession ? notebookChiefSession.state === 'working' : undefined;
 
   const {

--- a/app/src/components/OnAgentMailOverlay.css
+++ b/app/src/components/OnAgentMailOverlay.css
@@ -1,0 +1,48 @@
+/* Overlay layer over an agent pane. The container is click-through (pointer-events:
+   none) so it never intercepts terminal input or focus; only the chip opts back in.
+   Positioned top-right, clear of the pane header drag handle. */
+.on-agent-mail-overlay {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  pointer-events: none;
+}
+
+.on-agent-mail-chip {
+  pointer-events: auto;
+  align-items: center;
+  background: rgba(240, 173, 78, 0.9);
+  border: none;
+  border-radius: 999px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+  color: #1b1b1b;
+  cursor: pointer;
+  display: inline-flex;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  font-weight: 700;
+  gap: 4px;
+  height: 22px;
+  line-height: 1;
+  padding: 0 9px;
+}
+
+.on-agent-mail-chip:disabled {
+  cursor: default;
+  background: rgba(240, 173, 78, 0.55);
+}
+
+.on-agent-mail-error {
+  pointer-events: auto;
+  background: rgba(20, 20, 20, 0.9);
+  border-radius: 6px;
+  color: #f7c08a;
+  font-size: 11px;
+  max-width: 220px;
+  padding: 3px 6px;
+}

--- a/app/src/components/OnAgentMailOverlay.css
+++ b/app/src/components/OnAgentMailOverlay.css
@@ -13,6 +13,13 @@
   pointer-events: none;
 }
 
+/* When the pane header is shown (multi-leaf workspaces), it carries a
+   hover-revealed rename button pinned at the same top-right corner. Drop the
+   overlay below the header so the interactive chip never occludes that button. */
+.workspace-pane[data-header-shown] .on-agent-mail-overlay {
+  top: 34px;
+}
+
 .on-agent-mail-chip {
   pointer-events: auto;
   align-items: center;

--- a/app/src/components/OnAgentMailOverlay.test.tsx
+++ b/app/src/components/OnAgentMailOverlay.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { OnAgentMailOverlay, type PendingAgentMail } from './OnAgentMailOverlay';
+
+const mail = (overrides: Partial<PendingAgentMail> = {}): PendingAgentMail => ({
+  unreadCount: 2,
+  dispatchId: 'dispatch-1',
+  chiefSessionId: 'chief-1',
+  wakeable: true,
+  ...overrides,
+});
+
+describe('OnAgentMailOverlay', () => {
+  it('renders nothing when there is no unread mail', () => {
+    const { container } = render(<OnAgentMailOverlay mail={mail({ unreadCount: 0 })} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('fires the wake doorbell with the dispatch chief + id on click when wakeable', async () => {
+    const onWake = vi.fn().mockResolvedValue(undefined);
+    render(<OnAgentMailOverlay mail={mail()} onWake={onWake} />);
+    await userEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(onWake).toHaveBeenCalledWith('chief-1', 'dispatch-1'));
+  });
+
+  it('shows the count but stays non-interactive when not wakeable', async () => {
+    const onWake = vi.fn().mockResolvedValue(undefined);
+    render(<OnAgentMailOverlay mail={mail({ wakeable: false })} onWake={onWake} />);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent('2');
+    await userEvent.click(button);
+    expect(onWake).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a wake failure without crashing', async () => {
+    const onWake = vi.fn().mockRejectedValue(new Error('agent is busy'));
+    render(<OnAgentMailOverlay mail={mail()} onWake={onWake} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(await screen.findByText('agent is busy')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/OnAgentMailOverlay.tsx
+++ b/app/src/components/OnAgentMailOverlay.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import './OnAgentMailOverlay.css';
+
+export interface PendingAgentMail {
+  unreadCount: number;
+  dispatchId: string;
+  chiefSessionId: string;
+  // wakeable mirrors the dashboard's canWake gate: a local, non-endpoint agent
+  // that is idle/waiting with unread mail and a chief that can poke it.
+  wakeable: boolean;
+}
+
+interface OnAgentMailOverlayProps {
+  mail: PendingAgentMail;
+  onWake?: (chiefSessionId: string, dispatchId: string) => Promise<void>;
+}
+
+// A top-right overlay on an agent pane that has unread chief mail — the attended
+// reverse-channel affordance for when a human is driving this agent. Clicking it
+// fires the inbox doorbell (a read trigger; message content never enters the PTY).
+// It is a sibling visual layer over the terminal: the container is pointer-events:
+// none and only the chip is interactive, so it never steals focus from the PTY or
+// interferes with fit/resize (Terminal Focus Ownership / PTY geometry rules).
+export function OnAgentMailOverlay({ mail, onWake }: OnAgentMailOverlayProps) {
+  const [waking, setWaking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (mail.unreadCount <= 0) return null;
+
+  const interactive = mail.wakeable && Boolean(onWake);
+  const countLabel = `${mail.unreadCount} unread message${mail.unreadCount === 1 ? '' : 's'} from chief`;
+
+  const wake = async () => {
+    if (!interactive || !onWake || waking) return;
+    setWaking(true);
+    setError(null);
+    try {
+      await onWake(mail.chiefSessionId, mail.dispatchId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not wake agent');
+    } finally {
+      setWaking(false);
+    }
+  };
+
+  return (
+    <div className="on-agent-mail-overlay" data-testid="on-agent-mail-overlay">
+      <button
+        type="button"
+        className="on-agent-mail-chip"
+        disabled={!interactive || waking}
+        title={interactive ? `${countLabel} — click to prompt an inbox check` : countLabel}
+        aria-label={countLabel}
+        // Keep the pane's mousedown (focus/drag) from firing under the chip.
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          event.stopPropagation();
+          void wake();
+        }}
+      >
+        <span aria-hidden="true">✉</span>
+        <span>{waking ? 'Waking…' : mail.unreadCount}</span>
+      </button>
+      {error && <span className="on-agent-mail-error">{error}</span>}
+    </div>
+  );
+}

--- a/app/src/components/PendingMailBadge.css
+++ b/app/src/components/PendingMailBadge.css
@@ -1,0 +1,32 @@
+/* Unread chief→agent mail chip. A warm amber sets it apart from the chief's blue
+   family (chief / delegated-from-chief badges) so "you have mail" reads at a
+   glance and never blends into the lineage badges. */
+.pending-mail-badge {
+  align-items: center;
+  background: rgba(240, 173, 78, 0.16);
+  border: 1px solid rgba(240, 173, 78, 0.4);
+  border-radius: 999px;
+  color: #f0ad4e;
+  display: inline-flex;
+  flex-shrink: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 700;
+  gap: 3px;
+  height: 18px;
+  justify-content: center;
+  line-height: 1;
+  min-width: 18px;
+  padding: 0 5px;
+}
+
+.pending-mail-badge.compact {
+  min-width: 8px;
+  height: 8px;
+  padding: 0;
+  border-radius: 999px;
+}
+
+.pending-mail-badge.compact > span {
+  display: none;
+}

--- a/app/src/components/PendingMailBadge.test.tsx
+++ b/app/src/components/PendingMailBadge.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PendingMailBadge } from './PendingMailBadge';
+
+describe('PendingMailBadge', () => {
+  it('renders the count with an accessible name when there is unread mail', () => {
+    render(<PendingMailBadge count={3} />);
+    const badge = screen.getByLabelText('3 unread messages from chief');
+    expect(badge).toHaveClass('pending-mail-badge');
+    expect(badge).toHaveTextContent('3');
+  });
+
+  it('singularizes the label for one message', () => {
+    render(<PendingMailBadge count={1} />);
+    expect(screen.getByLabelText('1 unread message from chief')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there is no unread mail', () => {
+    const { container } = render(<PendingMailBadge count={0} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('hides the numeric label in compact mode', () => {
+    render(<PendingMailBadge count={2} compact />);
+    const badge = screen.getByLabelText('2 unread messages from chief');
+    expect(badge).toHaveClass('compact');
+  });
+});

--- a/app/src/components/PendingMailBadge.tsx
+++ b/app/src/components/PendingMailBadge.tsx
@@ -1,0 +1,25 @@
+import './PendingMailBadge.css';
+
+interface PendingMailBadgeProps {
+  count: number;
+  // compact renders the icon-only dot variant for the collapsed rail.
+  compact?: boolean;
+}
+
+// A per-session chip flagging unread chief→agent mail, so a human sees pending
+// mail in the sidebar where they already look — no dashboard trip required. It is
+// the reverse-channel sibling of the chief / delegated-from-chief badges.
+export function PendingMailBadge({ count, compact = false }: PendingMailBadgeProps) {
+  if (count <= 0) return null;
+  const label = `${count} unread message${count === 1 ? '' : 's'} from chief`;
+  return (
+    <span
+      className={`pending-mail-badge ${compact ? 'compact' : ''}`.trim()}
+      title={label}
+      aria-label={label}
+    >
+      <span aria-hidden="true">✉</span>
+      {!compact && <span>{count}</span>}
+    </span>
+  );
+}

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { GhosttyTerminal, type BlockStateSnapshot, type GhosttyTerminalHandle } from '../GhosttyTerminal';
+import { OnAgentMailOverlay, type PendingAgentMail } from '../OnAgentMailOverlay';
 import { RenamePopover } from '../RenamePopover';
 import { useShortcut } from '../../shortcuts';
 import {
@@ -116,6 +117,10 @@ interface SessionTerminalWorkspaceProps {
   // instead. The terminal rehydrates from daemon replay when it remounts.
   terminalsLive?: boolean;
   eventRouter: PaneRuntimeEventRouter;
+  // Unread chief→agent mail per session, driving the on-agent overlay. Absent when
+  // there is no pending mail anywhere.
+  pendingMailBySessionId?: Map<string, PendingAgentMail>;
+  onWakeDispatch?: (chiefSessionId: string, dispatchId: string) => Promise<void>;
   onSplitPane: (targetPaneId: string, direction: TerminalSplitDirection) => void;
   onClosePane: (paneId: string) => void;
   onFocusPane: (paneId: string) => void;
@@ -158,6 +163,8 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
     isSessionViewVisible = true,
     terminalsLive = true,
     eventRouter,
+    pendingMailBySessionId,
+    onWakeDispatch,
     onSplitPane,
     onClosePane,
     onFocusPane,
@@ -702,6 +709,10 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
             data-pane-path={path}
             style={frameStyle}
           >
+            {(() => {
+              const mail = pendingMailBySessionId?.get(agentPane.sessionId);
+              return mail ? <OnAgentMailOverlay mail={mail} onWake={onWakeDispatch} /> : null;
+            })()}
             <div
               className={`workspace-pane-header ${showPaneHeader ? 'workspace-pane-header--draggable' : 'workspace-pane-header-hidden'}`.trim()}
               aria-hidden={showPaneHeader ? undefined : true}
@@ -824,6 +835,8 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       resolvedTheme,
       runtime,
       showPaneHeader,
+      pendingMailBySessionId,
+      onWakeDispatch,
     ]);
 
     const focusModeTitle = useMemo(() => {

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -707,6 +707,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
             data-pane-id={agentPane.id}
             data-pane-kind="agent"
             data-pane-path={path}
+            data-header-shown={showPaneHeader ? '' : undefined}
             style={frameStyle}
           >
             {(() => {

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -1166,6 +1166,15 @@
   border: none;
 }
 
+/* Unread chief→agent mail in a collapsed-rail workspace. Pinned bottom-right so it
+   never collides with the top-right attention dot, in the pending-mail amber. */
+.mini-badge.mail {
+  top: auto;
+  bottom: 4px;
+  right: 4px;
+  background: #f0ad4e;
+}
+
 @keyframes flash-pending {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.3; }

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { RenamePopover } from './RenamePopover';
 import { ChiefOfStaffBadge } from './ChiefOfStaffBadge';
 import { DelegatedFromChiefBadge } from './DelegatedFromChiefBadge';
+import { PendingMailBadge } from './PendingMailBadge';
 import { SessionActionsPopover } from './SessionActionsPopover';
 import { GridLayoutControl } from './grid/GridLayoutControl';
 import type { GridLayout } from './grid/gridLayout';
@@ -29,6 +30,7 @@ interface LocalSession {
   reviewLoopStatus?: string;
   chiefOfStaff?: boolean;
   delegatedFromChief?: boolean;
+  unreadMailCount?: number;
 }
 
 type SidebarWorkspace = WorkspaceWithSessions<LocalSession>;
@@ -806,6 +808,9 @@ export function Sidebar({
               {workspace.sessions.some((session) => isAttentionSessionState(session.state)) && (
                 <span className={`mini-badge ${workspace.status === 'pending_approval' ? 'pending' : ''} ${workspace.status === 'unknown' ? 'unknown' : ''}`} />
               )}
+              {workspace.sessions.some((session) => (session.unreadMailCount ?? 0) > 0) && (
+                <span className="mini-badge mail" title="An agent here has unread chief mail" />
+              )}
             </button>
           ))}
           <button className="icon-btn" onClick={onNewSession} title="New Session (⌘N)">
@@ -1030,6 +1035,7 @@ export function Sidebar({
                     )}
                     {session.chiefOfStaff && <ChiefOfStaffBadge />}
                     {session.delegatedFromChief && <DelegatedFromChiefBadge />}
+                    {session.unreadMailCount ? <PendingMailBadge count={session.unreadMailCount} /> : null}
                     {reviewLoopIndicator(session.reviewLoopStatus) && (
                       <span
                         className={`session-loop-indicator session-loop-indicator--${session.reviewLoopStatus}`}
@@ -1179,6 +1185,7 @@ export function Sidebar({
                           <span className="session-label">{session.label}</span>
                           {session.chiefOfStaff && <ChiefOfStaffBadge />}
                           {session.delegatedFromChief && <DelegatedFromChiefBadge />}
+                          {session.unreadMailCount ? <PendingMailBadge count={session.unreadMailCount} /> : null}
                           {session.endpointName && (
                             <span className={`session-endpoint-badge status-${session.endpointStatus || 'connected'}`}>
                               {session.endpointName}

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -913,6 +913,14 @@ func parseDispatchReportArgs(args []string) (string, string, *protocol.DispatchR
 			return "", "", nil, errors.New("--question, --recommendation, and --consequence require --blocked")
 		}
 	}
+	// --recommendation/--consequence only travel attached to a decision Request,
+	// which is built only when --question is present. Without --question they would
+	// be silently dropped (a daemon-valid blocker with the agent's reasoning lost),
+	// so reject the combination explicitly instead of losing the data.
+	if (strings.TrimSpace(*recommendation) != "" || strings.TrimSpace(*consequence) != "") &&
+		strings.TrimSpace(*question) == "" {
+		return "", "", nil, errors.New("--recommendation and --consequence require --question")
+	}
 
 	var structuredReport *protocol.DispatchReport
 	switch {

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -738,8 +738,11 @@ commands:
   list [--session <id>]                          list work dispatched by this chief
   watch <dispatch-id> [--session <id>]           stream meaningful events until terminal
         [--interval <dur>]
-  report (--message <text> | --file <path>)     report progress from a dispatched agent
-         [--coordination-file <json>]
+  report (--done | --failed | --review | --blocked)   self-report a terminal/blocked
+         [--message <text> | --file <path>]           outcome (the watch trigger). --blocked
+         [--question <text>] [--recommendation <text>] [--consequence <text>]
+         [--coordination-file <json>]                 takes an optional decision for the chief.
+                                                      A bare --message is a silent note.
   handoff --file <path> --to <notebook-path>    write a large artifact into the notebook and
          [--message <text>] [--coordination-file <json>]   report a reference back to the chief
   status [--session <id>]                        show this delegated session's report and response
@@ -852,9 +855,19 @@ func parseDispatchReportArgs(args []string) (string, string, *protocol.DispatchR
 	fs := flag.NewFlagSet("dispatch report", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	sessionID := fs.String("session", "", "session id (defaults to ATTN_SESSION_ID)")
-	message := fs.String("message", "", "concise progress or completion update")
-	reportFile := fs.String("file", "", "file containing a progress or completion update")
-	coordinationFile := fs.String("coordination-file", "", "JSON file containing structured coordination fields")
+	message := fs.String("message", "", "concise terminal/blocked update")
+	reportFile := fs.String("file", "", "file containing the update")
+	coordinationFile := fs.String("coordination-file", "", "JSON file with a full structured report (escape hatch)")
+	// Convenience state flags — the reliable self-report affordance. Exactly one of
+	// these (or none) declares the terminal/blocked outcome the watch triggers on,
+	// so an agent never has to hand-author coordination JSON for the common cases.
+	done := fs.Bool("done", false, "self-report a successful completion (terminal)")
+	failed := fs.Bool("failed", false, "self-report a failure (terminal)")
+	review := fs.Bool("review", false, "self-report ready for review (terminal)")
+	blocked := fs.Bool("blocked", false, "self-report blocked, needs the chief (interim)")
+	question := fs.String("question", "", "the decision the chief must make (with --blocked)")
+	recommendation := fs.String("recommendation", "", "your recommended answer (with --blocked)")
+	consequence := fs.String("consequence", "", "what is at stake / why it matters (with --blocked)")
 	if err := fs.Parse(args); err != nil {
 		return "", "", nil, err
 	}
@@ -879,12 +892,39 @@ func parseDispatchReportArgs(args []string) (string, string, *protocol.DispatchR
 		}
 		report = strings.TrimSpace(string(content))
 	}
-	if report == "" {
-		return "", "", nil, errors.New("--message or --file is required")
+
+	stateFlags := 0
+	for _, on := range []bool{*done, *failed, *review, *blocked} {
+		if on {
+			stateFlags++
+		}
 	}
+	if stateFlags > 1 {
+		return "", "", nil, errors.New("pass only one of --done, --failed, --review, --blocked")
+	}
+	coordPath := strings.TrimSpace(*coordinationFile)
+	if stateFlags == 1 && coordPath != "" {
+		return "", "", nil, errors.New("pass a state flag (--done/--failed/--review/--blocked) or --coordination-file, not both")
+	}
+	if !*blocked {
+		if strings.TrimSpace(*question) != "" ||
+			strings.TrimSpace(*recommendation) != "" ||
+			strings.TrimSpace(*consequence) != "" {
+			return "", "", nil, errors.New("--question, --recommendation, and --consequence require --blocked")
+		}
+	}
+
 	var structuredReport *protocol.DispatchReport
-	if path := strings.TrimSpace(*coordinationFile); path != "" {
-		content, err := os.ReadFile(path)
+	switch {
+	case stateFlags == 1:
+		report, structuredReport = dispatchReportFromState(
+			report, *done, *failed, *review,
+			strings.TrimSpace(*question),
+			strings.TrimSpace(*recommendation),
+			strings.TrimSpace(*consequence),
+		)
+	case coordPath != "":
+		content, err := os.ReadFile(coordPath)
 		if err != nil {
 			return "", "", nil, fmt.Errorf("read coordination file: %w", err)
 		}
@@ -894,7 +934,60 @@ func parseDispatchReportArgs(args []string) (string, string, *protocol.DispatchR
 		}
 		structuredReport = &parsed
 	}
+
+	if report == "" {
+		return "", "", nil, errors.New("--message or --file is required (or pass a state flag)")
+	}
 	return source, report, structuredReport, nil
+}
+
+// dispatchReportFromState synthesizes the structured report for a convenience
+// state flag, reusing the freeform message as the structured summary. When no
+// message was given it falls back to a sensible default so the freeform report
+// (which the daemon requires non-empty) and the structured summary are both set.
+func dispatchReportFromState(message string, done, failed, review bool, question, recommendation, consequence string) (string, *protocol.DispatchReport) {
+	r := &protocol.DispatchReport{}
+	defaultMsg := ""
+	switch {
+	case done:
+		r.WorkState = protocol.DispatchWorkStateCompleted
+		r.ReportType = protocol.DispatchReportTypeCompletion
+		defaultMsg = "Completed."
+	case failed:
+		r.WorkState = protocol.DispatchWorkStateFailed
+		r.ReportType = protocol.DispatchReportTypeFailure
+		defaultMsg = "Failed."
+	case review:
+		r.WorkState = protocol.DispatchWorkStateReadyForReview
+		r.ReportType = protocol.DispatchReportTypeHandoff
+		defaultMsg = "Ready for review."
+	default: // blocked
+		r.WorkState = protocol.DispatchWorkStateNeedsInput
+		r.ReportType = protocol.DispatchReportTypeBlocker
+		defaultMsg = "Blocked — needs the chief."
+		if question != "" {
+			if message == "" {
+				defaultMsg = question
+			}
+			req := &protocol.DispatchDecisionRequest{
+				Question:          question,
+				ExpectedResponder: "chief",
+				Status:            protocol.DispatchRequestStatusPending,
+			}
+			if recommendation != "" {
+				req.Recommendation = protocol.Ptr(recommendation)
+			}
+			if consequence != "" {
+				req.Consequence = protocol.Ptr(consequence)
+			}
+			r.Request = req
+		}
+	}
+	if message == "" {
+		message = defaultMsg
+	}
+	r.Summary = message
+	return message, r
 }
 
 // parseDispatchHandoffArgs parses `dispatch handoff` flags. The artifact file is

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -751,6 +751,23 @@ func TestParseDispatchReportArgsRejectsDecisionFlagsWithoutBlocked(t *testing.T)
 	}
 }
 
+func TestParseDispatchReportArgsRejectsDecisionContextWithoutQuestion(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "worker-1")
+	// --recommendation/--consequence only travel attached to a decision Request,
+	// which is built only when --question is present. Omitting --question would
+	// silently drop them into a daemon-valid blocker, so it must error instead.
+	if _, _, _, err := parseDispatchReportArgs([]string{
+		"--blocked", "--recommendation", "SQLite",
+	}); err == nil || !strings.Contains(err.Error(), "require --question") {
+		t.Fatalf("recommendation without --question error = %v", err)
+	}
+	if _, _, _, err := parseDispatchReportArgs([]string{
+		"--blocked", "--consequence", "a migration later",
+	}); err == nil || !strings.Contains(err.Error(), "require --question") {
+		t.Fatalf("consequence without --question error = %v", err)
+	}
+}
+
 func TestParseDispatchReportArgsBareMessageHasNoStructuredReport(t *testing.T) {
 	t.Setenv("ATTN_SESSION_ID", "worker-1")
 	// A freeform progress note carries no structured report, so the watch stays

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -660,6 +660,111 @@ func TestParseDispatchReportArgsReadsCoordinationFile(t *testing.T) {
 	}
 }
 
+func TestParseDispatchReportArgsDoneFlagSynthesizesCompletion(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "worker-1")
+	_, report, structured, err := parseDispatchReportArgs([]string{"--done", "--message", "shipped it"})
+	if err != nil {
+		t.Fatalf("parseDispatchReportArgs() error = %v", err)
+	}
+	if report != "shipped it" {
+		t.Fatalf("report = %q", report)
+	}
+	if structured == nil ||
+		structured.WorkState != protocol.DispatchWorkStateCompleted ||
+		structured.ReportType != protocol.DispatchReportTypeCompletion ||
+		structured.Summary != "shipped it" {
+		t.Fatalf("structured = %+v", structured)
+	}
+}
+
+func TestParseDispatchReportArgsStateFlagAloneSynthesizesMessage(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "worker-1")
+	// A bare state flag with no --message must still produce a non-empty freeform
+	// report (the daemon requires it) and a non-empty structured summary.
+	_, report, structured, err := parseDispatchReportArgs([]string{"--failed"})
+	if err != nil {
+		t.Fatalf("parseDispatchReportArgs() error = %v", err)
+	}
+	if report == "" || structured == nil || structured.Summary == "" {
+		t.Fatalf("report = %q, structured = %+v", report, structured)
+	}
+	if structured.WorkState != protocol.DispatchWorkStateFailed ||
+		structured.ReportType != protocol.DispatchReportTypeFailure {
+		t.Fatalf("structured = %+v", structured)
+	}
+}
+
+func TestParseDispatchReportArgsBlockedWithQuestionBuildsRequest(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "worker-1")
+	_, _, structured, err := parseDispatchReportArgs([]string{
+		"--blocked",
+		"--question", "Postgres or SQLite for the cache?",
+		"--recommendation", "SQLite",
+		"--consequence", "wrong pick means a migration later",
+	})
+	if err != nil {
+		t.Fatalf("parseDispatchReportArgs() error = %v", err)
+	}
+	if structured == nil ||
+		structured.WorkState != protocol.DispatchWorkStateNeedsInput ||
+		structured.ReportType != protocol.DispatchReportTypeBlocker ||
+		structured.Request == nil {
+		t.Fatalf("structured = %+v", structured)
+	}
+	req := structured.Request
+	if req.Question != "Postgres or SQLite for the cache?" ||
+		req.ExpectedResponder != "chief" ||
+		req.Status != protocol.DispatchRequestStatusPending {
+		t.Fatalf("request = %+v", req)
+	}
+	if req.Recommendation == nil || *req.Recommendation != "SQLite" {
+		t.Fatalf("recommendation = %v", req.Recommendation)
+	}
+	if req.Consequence == nil || *req.Consequence != "wrong pick means a migration later" {
+		t.Fatalf("consequence = %v", req.Consequence)
+	}
+}
+
+func TestParseDispatchReportArgsRejectsConflictingStateFlags(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "worker-1")
+	if _, _, _, err := parseDispatchReportArgs([]string{"--done", "--failed"}); err == nil ||
+		!strings.Contains(err.Error(), "only one of --done") {
+		t.Fatalf("conflicting state flags error = %v", err)
+	}
+}
+
+func TestParseDispatchReportArgsRejectsStateFlagWithCoordinationFile(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "worker-1")
+	if _, _, _, err := parseDispatchReportArgs([]string{
+		"--done", "--coordination-file", "/tmp/whatever.json",
+	}); err == nil || !strings.Contains(err.Error(), "not both") {
+		t.Fatalf("state flag + coordination-file error = %v", err)
+	}
+}
+
+func TestParseDispatchReportArgsRejectsDecisionFlagsWithoutBlocked(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "worker-1")
+	if _, _, _, err := parseDispatchReportArgs([]string{
+		"--done", "--question", "really?",
+	}); err == nil || !strings.Contains(err.Error(), "require --blocked") {
+		t.Fatalf("decision flag without --blocked error = %v", err)
+	}
+}
+
+func TestParseDispatchReportArgsBareMessageHasNoStructuredReport(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "worker-1")
+	// A freeform progress note carries no structured report, so the watch stays
+	// silent on it — "never report progress" is enforced by the trigger, not by
+	// forbidding the note.
+	_, report, structured, err := parseDispatchReportArgs([]string{"--message", "halfway there"})
+	if err != nil {
+		t.Fatalf("parseDispatchReportArgs() error = %v", err)
+	}
+	if report != "halfway there" || structured != nil {
+		t.Fatalf("report = %q, structured = %+v", report, structured)
+	}
+}
+
 func TestParseDispatchResolveArgsReadsResponseFile(t *testing.T) {
 	t.Setenv("ATTN_SESSION_ID", "chief-1")
 	path := filepath.Join(t.TempDir(), "response.md")

--- a/docs/plans/2026-06-23-self-report-trigger-loop.md
+++ b/docs/plans/2026-06-23-self-report-trigger-loop.md
@@ -176,7 +176,8 @@ timeout→escalate; any daemon-push / stop-hook / state auto-inference.
 - [x] Step 3 — launch prompt + guidance (chief-of-staff.md, delegation.md).
 - [x] Step 4 — reverse ambient UI (PendingMailBadge + OnAgentMailOverlay).
 - [x] Step 5 — changelog + progress.
-- [ ] Adversarial review + CI green + figgyster.
+- [x] Adversarial review — 15-agent fan-out; fixed every confirmed finding (see below).
+- [ ] CI green + figgyster.
 
 ## Outcome notes
 - **No ProtocolVersion bump.** Every change reuses existing protocol surfaces
@@ -189,3 +190,26 @@ timeout→escalate; any daemon-push / stop-hook / state auto-inference.
 - **Accepted gap (documented):** removing the closed/idle/waiting_input fallbacks
   means an agent that ends without a terminal self-report leaves a quiet, non-exiting
   watch (silence ≠ success). The deferred watch-timeout→escalate is the backstop.
+- **Adversarial review fixes (2026-06-23).** A 15-agent review of the change found
+  five confirmed issues, all fixed in-PR:
+  - **(HIGH) Resolved decision re-fired the blocker.** `dispatch resolve` flips only
+    `Request.Status`, leaving `work_state=needs_input`, so `Classify` re-emitted a
+    `[blocker]` (reason `needs_input`) after the chief answered — a store-state
+    transition triggering a wake, the exact noise class this PR kills. Fixed: a
+    present-but-resolved `Request` is authoritative and silent (`KindNone`); the
+    `needs_input` branch now fires only when no `Request` is attached (preserving
+    `--blocked` without `--question`). Guarded by a `classify_test` case on the real
+    post-resolve shape + a `watch_test` for the full pending→resolve→done flow.
+  - **(MEDIUM) Test masked the above.** `classify_test` exercised a `WorkState=InProgress`
+    resolved-request shape the system never produces; corrected to the real
+    `needs_input`/blocker shape.
+  - **(MEDIUM) Silent data loss in the CLI.** `dispatch report --blocked --recommendation/
+    --consequence` without `--question` built no `Request`, dropping the agent's
+    reasoning into a daemon-valid blocker. Now an explicit error.
+  - **(HIGH, docs) Reverse-channel claim was wrong.** `chief-of-staff.md` said the
+    chief's `dispatch watch` fires on the agent reacting to mail; it only classifies
+    self-reports. Reworded: the reverse channel is the agent's own inbox watch,
+    surfaced via ack state + ambient UI.
+  - **(LOW) Two UI gaps.** The on-agent overlay's wake gate now also requires the
+    dispatch's chief to be the active chief (mirrors `Dashboard.canWake`); the mail
+    chip drops below a shown pane header so it no longer occludes the rename button.

--- a/docs/plans/2026-06-23-self-report-trigger-loop.md
+++ b/docs/plans/2026-06-23-self-report-trigger-loop.md
@@ -171,9 +171,21 @@ timeout→escalate; any daemon-push / stop-hook / state auto-inference.
 ## Progress
 - [x] Understand — 6-reader subsystem map (watch, state, self-report, mailbox, UI, guidance).
 - [x] Design — decisions above; implementation map filled.
-- [ ] Step 1 — forward trigger (Classify).
-- [ ] Step 2 — self-report affordance (CLI flags).
-- [ ] Step 3 — launch prompt + guidance.
-- [ ] Step 4 — reverse ambient UI (badge + overlay).
-- [ ] Step 5 — changelog + progress.
+- [x] Step 1 — forward trigger (Classify): removed daemon-state steps 4/7/8.
+- [x] Step 2 — self-report affordance (CLI flags --done/--failed/--review/--blocked).
+- [x] Step 3 — launch prompt + guidance (chief-of-staff.md, delegation.md).
+- [x] Step 4 — reverse ambient UI (PendingMailBadge + OnAgentMailOverlay).
+- [x] Step 5 — changelog + progress.
 - [ ] Adversarial review + CI green + figgyster.
+
+## Outcome notes
+- **No ProtocolVersion bump.** Every change reuses existing protocol surfaces
+  (DispatchReport enums, unread_message_count, wake_dispatch_agent). Verified.
+- **"watching ≠ working" dissolved via the quiet watch — no explicit state code.**
+  The state-inference reader confirmed an armed loop reads `working` only via the
+  Stop `background_tasks=running` payload or the live animated-status-frame PTY
+  detector; a quiet watch produces neither and settles to idle on its own. Guidance
+  makes the watch quiet by construction.
+- **Accepted gap (documented):** removing the closed/idle/waiting_input fallbacks
+  means an agent that ends without a terminal self-report leaves a quiet, non-exiting
+  watch (silence ≠ success). The deferred watch-timeout→escalate is the backstop.

--- a/docs/plans/2026-06-23-self-report-trigger-loop.md
+++ b/docs/plans/2026-06-23-self-report-trigger-loop.md
@@ -87,4 +87,93 @@ badge), and sharpens the **signal definition** — trigger = self-report + mailb
 NOT daemon state.
 
 ## Implementation map
-_Stub — hand to plan-doc-write to decompose into PR-sized steps with sequencing._
+
+> Status: design decided 2026-06-23 (Understand phase complete — 6-reader subsystem
+> map). One PR, committed in logical steps. **No ProtocolVersion bump** — every change
+> reuses existing protocol surfaces.
+
+### Design decisions (grounded in this doc's model)
+1. **Forward trigger = remove daemon-state from `dispatch.Classify`.** Steps 1-3
+   (done/failed/review) and 5-6 (decision-request / needs_input) are *already*
+   self-report-keyed — keep them. Delete steps **4 (status=closed→ended), 7
+   (status=idle→ended), 8 (status=waiting_input→blocker)** — these are the
+   daemon-state inference that flickers and misfires. The #399 "empty report at
+   waiting_input" bug *is* step 8. After removal the watch fires **only** on a
+   self-reported terminal (done/failed/review) or blocked (decision-request /
+   needs_input / blocker). No opt-in `--peek` flag: on-demand state peeking already
+   exists via `dispatch status` / `dispatch list`.
+2. **Accepted gap (per Deferred): a watch on an agent that closes/crashes _without_ a
+   terminal self-report now hangs silently.** This is correct under the model —
+   silence ≠ success, and a quiet hung watch does NOT peg the chief green (see #5).
+   The happy path is unaffected: a well-behaved agent files `--done`/`--failed`/
+   `--review` and the watch exits on that *self-report* (steps 1-3), before/around
+   close. The deferred **watch-timeout→escalate-to-Victor** is the future backstop.
+   Mitigated now by the reliable self-report affordance (#3) + mandatory-terminal
+   guidance (#6). The `dispatch_gone`/`not_found` neutral-terminal (record actually
+   deleted from the list) stays — that's definitive record removal, not state flicker.
+3. **Self-report affordance = convenience flags on `dispatch report`** that synthesize
+   the structured `DispatchReport` over the *existing* `ReportDispatchEnvelope` (no
+   protocol change; the enums already exist): `--done` (work_state=completed,
+   report_type=completion), `--failed` (failed/failure), `--review` (ready_for_review,
+   report_type=handoff), `--blocked` (needs_input, report_type=blocker) with optional
+   `--question`/`--recommendation`/`--consequence` → a pending `DispatchDecisionRequest`.
+   `--message`/`--file` supply the human summary (synthesized if a state flag is given
+   alone). Mutually exclusive with `--coordination-file` (power-user escape hatch
+   stays). Net effect: a freeform `--message` with no state flag is a **silent note**
+   (stored, visible on-demand, classifies as `KindNone`) — "never report progress" is
+   enforced by the trigger, not by forbidding notes.
+4. **Reverse trigger = the agent self-monitors its own inbox** (a quiet `Monitor` on
+   `dispatch inbox --unread`, reusing the existing command — dogfooded by this very
+   agent). This is **guidance**, not new daemon code: the agent's own watch fires on
+   the mailbox item, no manual wake. The daemon **auto-doorbell** (push on send) is the
+   *codex* fallback and is **deferred**. The existing manual "Wake agent" button /
+   `wake_dispatch_agent` stays as the attended path the on-agent overlay click fires.
+5. **"watching ≠ working" needs no code.** Confirmed by the state-inference reader: an
+   armed loop reads `working` only via (a) Stop payload `background_tasks` status=running
+   or (b) the live PTY animated-status-frame detector. A **quiet** watch produces
+   neither at rest, so it settles to idle (~6s, via the PTY detector emitting idle off
+   the settled prompt). Only a *noisy* watch that re-prompts pegs green. We make the
+   watch quiet by construction (guidance) → the busy-look dissolves. No state-inference
+   patch in this PR.
+6. **Guidance has one authoritative home: the bundled skill** at
+   `internal/agent/attn_skill/references/` (Go-embedded, installed to `~/.claude` and
+   `~/.agents`; never hand-edit the installed copies). `~/exo/AGENTS.md` is the chief
+   *persona* doc — no delegation mechanics — and is **not** touched. No `~/exo` skill
+   mirror exists.
+
+### Steps (PR-sized, sequenced)
+1. **Forward trigger (Go core).** `internal/dispatch/classify.go`: remove steps 4/7/8,
+   rewrite the package doc to the self-report-only model. Rewrite the affected
+   `classify_test.go` / `watch_test.go` cases (closed/idle/waiting_input). Prune the
+   now-dead `defaultSummary` reasons in `watch.go`. _Self-contained; merges green alone._
+2. **Self-report affordance (CLI).** `cmd/attn/main.go` `parseDispatchReportArgs`: add
+   the state flags + synthesis, update `writeDispatchHelp`. Tests in `main_test.go`.
+   No client/daemon signature change (reuses `ReportDispatchEnvelope`).
+3. **Launch prompt + guidance.** Rewrite `chiefOfStaffDispatchPrompt`
+   (`chief_of_staff_dispatch.go`) and `references/chief-of-staff.md` +
+   `references/delegation.md`: chief arms one `dispatch watch`; agent self-reports
+   only at terminal/blocked via the flags and arms a quiet inbox watch; chief
+   response-discipline (don't watch process state / don't spelunk / escalate-unless-
+   sure). Reconcile `delegation.md:18` ("does not require you to monitor").
+4. **Reverse ambient UI (frontend).** `PendingMailBadge` next to
+   `DelegatedFromChiefBadge` in `Sidebar.tsx` (active + muted + collapsed rail);
+   derive per-session unread in `App.tsx` `enrichedLocalSessions` from
+   `chiefOfStaffDispatches`; on-agent top-right overlay in
+   `SessionTerminalWorkspace/index.tsx` `renderPaneSurface` (pointer-events scoped —
+   respect Focus Ownership / PTY geometry), click → `sendWakeDispatchAgent`. Frontend
+   tests. Uses existing `unread_message_count` — no protocol change.
+5. **Changelog + plan-doc progress.** One user-facing `CHANGELOG.md` entry.
+
+### Out of this PR (per Deferred)
+Codex idle auto-wake / daemon auto-doorbell; crash-without-report handling; watch
+timeout→escalate; any daemon-push / stop-hook / state auto-inference.
+
+## Progress
+- [x] Understand — 6-reader subsystem map (watch, state, self-report, mailbox, UI, guidance).
+- [x] Design — decisions above; implementation map filled.
+- [ ] Step 1 — forward trigger (Classify).
+- [ ] Step 2 — self-report affordance (CLI flags).
+- [ ] Step 3 — launch prompt + guidance.
+- [ ] Step 4 — reverse ambient UI (badge + overlay).
+- [ ] Step 5 — changelog + progress.
+- [ ] Adversarial review + CI green + figgyster.

--- a/docs/plans/2026-06-23-self-report-trigger-loop.md
+++ b/docs/plans/2026-06-23-self-report-trigger-loop.md
@@ -1,0 +1,90 @@
+# Self-report trigger loop — chief↔delegated-agent awareness
+
+> Status: alignment captured 2026-06-23 (v1, iterable). Implementation map below is
+> a stub — hand to plan-doc-write before building.
+
+## Why / Alignment
+
+**Intent.** The chief should be *aware* of its delegated agents and able to *steer*
+them — bidirectional comms — **without babysitting**. Today's PR #399 delegation
+drowned the chief in noise because it watched the wrong thing: process/daemon state,
+which flickers (working↔waiting_input) and misfires "ended" on a turn-boundary rest.
+The fix is to trigger only on meaningful, **self-reported** signals.
+
+**The model (aligned 2026-06-23):**
+- The delegated agent **self-reports only at terminal or blocked** — never progress,
+  never process state. No hooks, no daemon-state inference, no auto-capture —
+  self-report only.
+- The chief **arms one watch per delegation** — intentionally. The watch *is* the
+  bidirectional channel; it's the point of the vision. Watching is correct; *what* it
+  watched was the bug.
+- **The trigger mechanism fires on exactly two things:** (forward) the agent's
+  self-reported terminal/blocked, and (reverse) **mailbox items** (chief→agent
+  messages). Both first-class. Nothing else triggers.
+- Between triggers: **silence.** The chief does not watch process/daemon state by
+  default — on-demand only if it chooses to.
+- **The loop:** agent self-reports blocked → chief's watch fires (carrying the
+  report) → chief sends a mailbox item (steer) → the agent's watch fires on that
+  mailbox item → agent reads & acts. No manual wake. This is what finally retires the
+  clunky pull-based mailbox.
+- **The chief's response discipline (on a `blocked` report):** the chief does *not*
+  reflexively auto-reply to unblock. It steers back only when it is **sure** of the
+  answer or the decision is **low-consequence**; otherwise it **escalates to Victor
+  and waits**. The chief usually lacks the full context, and a confident-but-wrong
+  steer is worse than waiting. Auto-reply is the exception, not the default.
+- **Ambient UI:** an on-agent overlay + a sidebar pending-mail badge surface mailbox
+  items visually, so a human sees pending mail without opening the dashboard.
+
+## Aligned on
+- Watch the **self-report**, not the process state.
+- Altitude: **guidance + the minimal attn watch fix** — the trigger fires on
+  self-report + mailbox items, not daemon state.
+- Direction: build the **full bidirectional loop** this chunk.
+- Reverse scope: core loop **+ ambient UI** (on-agent overlay + sidebar badge).
+- **Mailbox items are part of the trigger mechanism** — first-class, alongside
+  self-reports.
+
+## In scope (this chunk)
+- attn: the watch/trigger fires on **self-reported terminal/blocked + mailbox items**
+  (replaces daemon-state keying — the source of today's misfires).
+- attn: a reliable agent **self-report affordance** for terminal/blocked (verify what
+  exists today; build the gap — today's agent sat at `waiting_input` with an empty
+  report).
+- attn: **reverse delivery** — a mailbox item triggers the recipient agent's watch
+  (no manual wake) + ambient UI (on-agent overlay + sidebar pending-mail badge).
+- Guidance:
+  - chief delegation instructions — arm the watch, and how.
+  - agent brief convention — self-report only at terminal/blocked; arm a watch that
+    fires on mailbox items.
+  - chief behavior — don't watch process state, don't spelunk transcripts, don't
+    narrate intermediate ticks; re-engage on the trigger. On a `blocked` report,
+    only auto-steer when **sure or low-consequence** — otherwise escalate to Victor
+    and wait.
+
+## Deferred
+- Non-Claude (codex) idle **auto-wake** — the unattended reverse fallback.
+- **Crash-without-report gap:** an agent that dies without self-reporting → chief sees
+  silence ("still working"). Accepted for now (chief peeks on-demand); re-decide
+  later. This is what doneness-on-close (#397) addressed — deprioritized under
+  self-report-only, not free.
+- daemon-push re-invocation, stop-hooks, any auto-inference of state — explicitly
+  rejected for now.
+- **Watch timeout on long idle (follow-up PR):** the chief-side `watch` may time out
+  if the agent is idle a very long time with no self-report — a backstop for the
+  crash-without-report gap above. Careful framing: the timeout **escalates to Victor**
+  (surfaces "this agent went quiet"); it does NOT trigger the chief to auto-poke the
+  agent. Pairs with the response discipline — silence is escalated, not auto-resolved.
+
+## Related / dependency
+- **"watching ≠ working"** (chief *displayed* state): an armed watch must not display
+  the chief as busy, or this model reintroduces the busy-look. In-flight investigation
+  (dispatch 76e5d022) + the chief-state rock. Gating-adjacent.
+
+## Vision
+[chief-delegation-awareness](../vision/chief-delegation-awareness.md). Advances:
+forward-observe (self-report watch), reverse-steer (mailbox trigger + overlay +
+badge), and sharpens the **signal definition** — trigger = self-report + mailbox,
+NOT daemon state.
+
+## Implementation map
+_Stub — hand to plan-doc-write to decompose into PR-sized steps with sequencing._

--- a/internal/agent/attn_skill/references/chief-of-staff.md
+++ b/internal/agent/attn_skill/references/chief-of-staff.md
@@ -31,11 +31,14 @@ exactly one per dispatch, right after delegating:
     "$ATTN_WRAPPER_PATH" dispatch watch <id>
 
 It blocks and prints one line per *meaningful* event, then exits when the work
-reaches a terminal state. It fires on exactly two things: the agent's
-self-reported terminal/blocked outcome (forward), and the agent reacting to your
-mail (reverse) — nothing from runtime state. Run it as a quiet background watch
-(for a Claude chief, a Monitor) so it stays silent between events: an armed watch
-must not make you look busy, and you must not narrate intermediate ticks.
+reaches a terminal state. This watch fires on one thing: the agent's self-reported
+terminal or blocked outcome (the forward channel) — nothing from runtime state.
+The reverse channel — your mail reaching the agent — is a *separate* watch running
+in the agent's own process, not this one; you track its progress through
+acknowledgement state in `dispatch messages` and the ambient pending-mail UI, not
+through `dispatch watch`. Run this watch as a quiet background watch (for a Claude
+chief, a Monitor) so it stays silent between events: an armed watch must not make
+you look busy, and you must not narrate intermediate ticks.
 
 Do NOT watch the agent's process/daemon status, and do NOT spelunk its
 transcript. Runtime state flickers and is not a signal; re-engage only when the

--- a/internal/agent/attn_skill/references/chief-of-staff.md
+++ b/internal/agent/attn_skill/references/chief-of-staff.md
@@ -23,20 +23,44 @@ Review your dispatched work with:
 
     "$ATTN_WRAPPER_PATH" dispatch list
 
-Runtime status and delegated work state are separate. Use the target session's
-live status plus the latest report and its structured `work_state`, `next_actor`,
-`next_action`, actionable request, artifact, and verification to decide whether
-to wait, inspect its work, answer a blocker, or give the user a summary.
+### Arm one watch per delegation
 
-Resolve the dispatch's one active decision request with:
+The watch is how you stay aware of a delegation without babysitting it. Arm
+exactly one per dispatch, right after delegating:
+
+    "$ATTN_WRAPPER_PATH" dispatch watch <id>
+
+It blocks and prints one line per *meaningful* event, then exits when the work
+reaches a terminal state. It fires on exactly two things: the agent's
+self-reported terminal/blocked outcome (forward), and the agent reacting to your
+mail (reverse) — nothing from runtime state. Run it as a quiet background watch
+(for a Claude chief, a Monitor) so it stays silent between events: an armed watch
+must not make you look busy, and you must not narrate intermediate ticks.
+
+Do NOT watch the agent's process/daemon status, and do NOT spelunk its
+transcript. Runtime state flickers and is not a signal; re-engage only when the
+watch fires. To peek at a delegation's live state on demand, use `dispatch list`
+or `dispatch status` — a deliberate peek, not a standing watch.
+
+### Respond with discipline
+
+When a watch fires with a blocked event, do NOT reflexively answer to unblock the
+agent. You usually lack the full context, and a confident-but-wrong steer is worse
+than waiting. Steer back only when you are SURE of the answer or the decision is
+low-consequence. Otherwise escalate to Victor and wait — surface the blocker (the
+question, the agent's recommendation, what is at stake) and let him decide.
+
+Answer a dispatch's one active decision request with:
 
     "$ATTN_WRAPPER_PATH" dispatch resolve \
       --dispatch <id> \
       --response "Use AisNoOperationV1." \
       --link "https://external-system.example/decision"
 
-The response is stored on the dispatch and becomes available to the delegated
-agent through `dispatch status`.
+The response is stored on the dispatch and reaches the delegated agent through
+`dispatch status`.
+
+### Steer a running agent (the reverse channel)
 
 Send durable instructions to a delegated agent with:
 
@@ -44,9 +68,11 @@ Send durable instructions to a delegated agent with:
       --dispatch <id> \
       --message "Rebase onto main, rerun the focused tests, and report conflicts."
 
-Messages are mailbox entries, not terminal input. Do not assume a working agent
-has seen one immediately. The dashboard shows unread mail and lets the user
-explicitly wake an idle agent with a fixed inbox-check prompt.
+Mail is durable and acknowledgement-tracked. A delegated Claude agent watches its
+own inbox, so a new message reaches it without a manual wake. attn also surfaces
+pending mail ambiently — a per-session sidebar badge and an on-agent overlay — so
+you (or Victor) see unread mail without opening a dashboard. The message content
+never streams into the agent's terminal; it triggers a read of the durable mailbox.
 
 Inspect sent messages, including read and acknowledgement state, with:
 
@@ -60,20 +86,21 @@ working agents just to request status.
 
 ## As a Dispatched Agent
 
-If the initial task says the work is tracked, report when you:
+If the initial task says the work is tracked, SELF-REPORT ONLY AT A TERMINAL OR
+BLOCKED POINT — never progress, never status. Prefer silence between those points.
 
-- reach a meaningful milestone
-- need input or are blocked
-- finish the requested work
+Declare the outcome with one flag — it is the chief's trigger:
 
-Keep a short report concrete: outcome, evidence, and next action.
+    "$ATTN_WRAPPER_PATH" dispatch report --done    --message "<what landed>"
+    "$ATTN_WRAPPER_PATH" dispatch report --review  --message "<what to review>"
+    "$ATTN_WRAPPER_PATH" dispatch report --failed  --message "<what went wrong>"
+    "$ATTN_WRAPPER_PATH" dispatch report --blocked \
+      --question "<the decision the chief must make>" \
+      --recommendation "<your pick>" --consequence "<what is at stake>"
 
-    "$ATTN_WRAPPER_PATH" dispatch report --message \
-      "Implemented the parser and tests pass. Next: review the error wording."
-
-For a longer report, write it to a file and submit the file:
-
-    "$ATTN_WRAPPER_PATH" dispatch report --file /tmp/dispatch-report.md
+Keep the message concrete: outcome, evidence, next action. For a long update, use
+`--file <path>`. A bare `dispatch report --message "<text>"` with no state flag is
+a silent note — stored and visible on demand, but it does not wake the chief.
 
 A report is a small payload. When you build a large durable artifact — a report, a
 design doc, findings, often built with the user — write it into the Notebook and
@@ -87,10 +114,34 @@ report the reference instead of inlining it:
 `--to` is the Notebook path the chief (or user) designated; the daemon writes the
 artifact there and the reference travels back in your report. If no destination was
 designated and the artifact warrants one, ask the chief in a report rather than
-inventing a location. Add `--coordination-file <json>` to a terminal handoff just as
-you would to a report.
+inventing a location. Add a state flag (or `--coordination-file <json>`) to a
+terminal handoff just as you would to a report.
 
-For actionable coordination, keep the narrative and attach a JSON envelope:
+### Watch your inbox
+
+Arm a quiet watch on your inbox so the chief's steering reaches you without a
+manual wake. If your agent supports background watches (for a Claude agent, a
+Monitor), watch:
+
+    "$ATTN_WRAPPER_PATH" dispatch inbox --unread
+
+Keep it quiet — it should emit only when there is new mail. When mail arrives,
+read it, act on it, then acknowledge:
+
+    "$ATTN_WRAPPER_PATH" dispatch read --message-id <id>
+    "$ATTN_WRAPPER_PATH" dispatch ack \
+      --message-id <id> \
+      --message "Rebased cleanly; focused tests pass."
+
+After requesting a decision, read the durable chief response with:
+
+    "$ATTN_WRAPPER_PATH" dispatch status
+
+### Full structured reports (escape hatch)
+
+The state flags cover the common cases. For a report that needs the full
+coordination envelope — remaining scope, constraints, artifact identity, and
+verification evidence — keep the narrative and attach a JSON envelope:
 
 ```json
 {
@@ -129,24 +180,6 @@ Submit it with:
       --message "Core implementation is ready; event emission needs a decision." \
       --coordination-file /tmp/dispatch-coordination.json
 
-After requesting a decision, read the durable chief response with:
-
-    "$ATTN_WRAPPER_PATH" dispatch status
-
-Before reporting completion or entering a waiting state, check unread mail:
-
-    "$ATTN_WRAPPER_PATH" dispatch inbox --unread
-
-For each message, mark it read when you start handling it:
-
-    "$ATTN_WRAPPER_PATH" dispatch read --message-id <id>
-
-After acting on it, acknowledge it, optionally with a concise result:
-
-    "$ATTN_WRAPPER_PATH" dispatch ack \
-      --message-id <id> \
-      --message "Rebased cleanly; focused tests pass."
-
-Reporting does not stop or transfer your session. Continue working unless the
-task is blocked or complete. Do not use dispatch reporting for ordinary,
-untracked delegation.
+Reporting does not stop or transfer your session. Continue working after a blocked
+report unless you are truly stuck; stop only when finished.
+Do not use dispatch reporting for ordinary, untracked delegation.

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -15,7 +15,12 @@ when the user explicitly asks for delegation, an interactive agent, a separate
 workspace/session, or a collaborator they can steer themselves.
 
 Attn delegation starts another agent with a focused brief; it does not create
-durable parent-child lineage or require you to monitor the new agent.
+durable parent-child lineage. When you hold the chief-of-staff role the delegation
+is tracked, and you arm exactly one quiet watch on it so you stay aware without
+babysitting — see the chief-of-staff reference for the watch, the reverse mailbox
+channel, and the response discipline. The brief should tell the agent it is
+tracked: self-report only at a terminal or blocked point, and watch its own inbox
+for your steering.
 
 ## Brief Workflow
 

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -49,9 +49,12 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 	chiefOfStaff := readSkillFile(t, skillDir, "references/chief-of-staff.md")
 	for _, expected := range []string{
 		"dispatch list",
-		"dispatch report --message",
-		"dispatch report --file",
-		"latest report",
+		"dispatch watch <id>",
+		"dispatch report --done",
+		"dispatch report --blocked",
+		"escalate to Victor",
+		"Watch your inbox",
+		"without a manual wake",
 		"visible, full interactive",
 		"default to native subagents",
 		"not proof that the work is correct",

--- a/internal/daemon/chief_of_staff_dispatch.go
+++ b/internal/daemon/chief_of_staff_dispatch.go
@@ -24,30 +24,39 @@ func chiefOfStaffDispatchPrompt(brief string) string {
 	return strings.TrimSpace(brief) + `
 
 ---
-This task is tracked by the chief of staff in attn.
-Send a concise update when you reach a meaningful milestone, need input, or finish:
+This task is tracked by the chief of staff in attn. Two rules keep the chief aware
+of you and able to steer you, without babysitting:
 
-    "$ATTN_WRAPPER_PATH" dispatch report --message "<update>"
+1. SELF-REPORT ONLY AT A TERMINAL OR BLOCKED POINT — never progress, never status.
+   One flag declares the outcome; it is the chief's trigger:
 
-For a longer update, write it to a file and use ` + "`--file <path>`" + `.
-When work is blocked, ready for review, completed, or failed, attach structured
-coordination fields with ` + "`--coordination-file <json>`" + `.
+       "$ATTN_WRAPPER_PATH" dispatch report --done    --message "<what landed>"
+       "$ATTN_WRAPPER_PATH" dispatch report --review  --message "<what to review>"
+       "$ATTN_WRAPPER_PATH" dispatch report --failed  --message "<what went wrong>"
+       "$ATTN_WRAPPER_PATH" dispatch report --blocked --question "<the decision>" \
+           --recommendation "<your pick>" --consequence "<what is at stake>"
 
-attn has a Notebook — a durable, profile-wide markdown store. A dispatch report is a
-small payload; when you produce a large durable artifact (a report, design doc, or
-findings — often built with the user), hand it into the Notebook instead of inlining
-it, and the reference goes back to the chief:
+   A bare ` + "`--message`" + ` with no flag is a silent note (no trigger) — prefer
+   silence between terminal/blocked points. Use ` + "`--file <path>`" + ` for a long update.
+
+2. ARM A QUIET WATCH ON YOUR INBOX so the chief can steer you without a manual
+   wake. If your agent supports background watches (e.g. Claude's Monitor), watch
+
+       "$ATTN_WRAPPER_PATH" dispatch inbox --unread
+
+   and when mail arrives, read it, act, then ` + "`dispatch ack --message-id <id>`" + `.
+   Keep the watch quiet — it should emit only when there is new mail.
+
+A large durable artifact (report, design doc, findings) goes into the Notebook, not
+inline — hand it off and report just the reference:
 
     "$ATTN_WRAPPER_PATH" dispatch handoff --file <artifact> --to <notebook-path> --message "<update>"
 
 Write to the Notebook path the chief or user designated. If none was designated and
 the artifact warrants one, ask the chief in a report rather than inventing a location.
 
-Use ` + "`dispatch status`" + ` to read a chief's durable response to a decision request.
-Before reporting completion or waiting for more work, run
-` + "`dispatch inbox --unread`" + `, read pending messages, and acknowledge each
-one after acting on it.
-Continue the assigned work after reporting unless you are blocked or finished.`
+Use ` + "`dispatch status`" + ` to read the chief's durable response to a decision.
+Continue working after a blocked report unless you are truly stuck; stop when finished.`
 }
 
 func (d *Daemon) newChiefOfStaffDispatch(

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -158,7 +158,8 @@ func TestChiefOfStaffDelegateCreatesTrackedDispatch(t *testing.T) {
 		t.Fatalf("delegate result = %+v, want dispatch id", result)
 	}
 	if !strings.Contains(prompt, "Investigate the tracked task.") ||
-		!strings.Contains(prompt, "dispatch report --message") {
+		!strings.Contains(prompt, "dispatch report --done") ||
+		!strings.Contains(prompt, "SELF-REPORT ONLY AT A TERMINAL OR BLOCKED POINT") {
 		t.Fatalf("tracked initial prompt = %q", prompt)
 	}
 

--- a/internal/dispatch/classify.go
+++ b/internal/dispatch/classify.go
@@ -29,10 +29,18 @@
 //  1. report work_state=failed OR report_type=failure       -> Failed  (terminal, exit 1)
 //  2. report work_state=completed OR report_type=completion  -> Done    (terminal, exit 0)
 //  3. report work_state=ready_for_review                     -> Review  (terminal, exit 0)
-//  4. report has a pending decision Request                  -> Blocker (interim)
-//  5. report work_state=needs_input OR report_type=blocker   -> Blocker (interim)
-//  6. everything else (no report, a progress report, or any  -> None    (no emit)
-//     runtime status whatsoever)
+//  4. report has a PENDING decision Request                  -> Blocker (interim)
+//  5. report work_state=needs_input OR report_type=blocker,  -> Blocker (interim)
+//     and no decision Request is attached
+//  6. everything else: no report, a progress report, OR a    -> None    (no emit)
+//     report whose decision Request was already RESOLVED
+//
+// Step 6's resolved-Request case matters: when the chief answers a blocker via
+// `dispatch resolve`, the store flips only the Request status to resolved and
+// leaves work_state=needs_input untouched. That is a store-state transition, not
+// a fresh self-report, so it must stay silent — otherwise the watch would re-fire
+// the very blocker the chief just answered. A still-pending Request (step 4)
+// outranks the needs_input check; a resolved Request suppresses it (step 6).
 //
 // Step 6 is the crux of *noise* suppression. A bare freeform `dispatch report
 // --message` (a progress note) carries no structured terminal/blocked claim, so
@@ -133,22 +141,28 @@ func Classify(d protocol.ChiefOfStaffDispatch) Event {
 		return Event{KindReview, true, 0, "ready_for_review", summary, nextAction}
 	}
 
-	// 4-5. Explicit BLOCKED self-report (interim — a watch keeps running through
-	// it so the chief can steer and the loop continues).
-	if req := r.Request; req != nil && req.Status == protocol.DispatchRequestStatusPending {
-		s := summary
-		if q := trim(req.Question); q != "" {
-			s = q
+	// 4-6. Explicit BLOCKED self-report (interim — a watch keeps running through
+	// it so the chief can steer and the loop continues). A decision Request is
+	// authoritative when present: pending fires the blocker; resolved is silent —
+	// the chief already answered, and the resolve is a store-state transition (not
+	// a fresh self-report), so re-firing it off the still-needs_input work_state
+	// would wake the chief about the blocker it just cleared.
+	if req := r.Request; req != nil {
+		if req.Status == protocol.DispatchRequestStatusPending {
+			s := summary
+			if q := trim(req.Question); q != "" {
+				s = q
+			}
+			return Event{KindBlocker, false, 0, "decision_request", s, nextAction}
 		}
-		return Event{KindBlocker, false, 0, "decision_request", s, nextAction}
+		return Event{Kind: KindNone}
 	}
 	if r.WorkState == protocol.DispatchWorkStateNeedsInput ||
 		r.ReportType == protocol.DispatchReportTypeBlocker {
 		return Event{KindBlocker, false, 0, "needs_input", summary, nextAction}
 	}
 
-	// 6. A progress / in_progress report (or a resolved request) is a silent note,
-	// not a trigger.
+	// 6. A progress / in_progress report is a silent note, not a trigger.
 	return Event{Kind: KindNone}
 }
 

--- a/internal/dispatch/classify.go
+++ b/internal/dispatch/classify.go
@@ -9,66 +9,60 @@
 //
 // # The signal definition
 //
-// A dispatch carries two independent state dimensions, both projected onto
-// protocol.ChiefOfStaffDispatch when it is read:
+// The trigger fires on the agent's SELF-REPORT and nothing else. A dispatch's
+// runtime/daemon Status (working / waiting_input / idle / pending_approval /
+// "closed" …) is deliberately NOT a trigger: it flickers (working↔waiting_input
+// on a turn boundary) and misfires "ended" on a routine rest, which is exactly
+// the noise this classifier exists to suppress. The chief peeks at runtime state
+// on demand via `dispatch status` / `dispatch list`; the watch only fires on
+// meaningful, agent-declared events.
 //
-//   - Status: the delegated session's projected runtime state — launching,
-//     working, pending_approval, waiting_input, idle, scheduled, unknown — or
-//     the sentinel "closed" once the session is gone. This comes from attn's
-//     PTY/stop classifier.
-//   - StructuredReport: the coordination envelope the delegated agent explicitly
-//     files via `attn dispatch report --coordination-file` (work_state,
-//     report_type, an optional decision Request, summary, next_action).
+// The only input Classify keys on is the StructuredReport — the coordination
+// envelope the delegated agent explicitly files via `attn dispatch report`
+// (`--done` / `--failed` / `--review` / `--blocked`, or `--coordination-file`):
+// work_state, report_type, an optional decision Request, summary, next_action.
+// Doneness, failure, review, and blocked are CLAIMED by the agent, never inferred.
 //
-// Doneness and failure are claimed by the agent, not inferred. Only an explicit
-// structured report yields Done or Failed; the runtime Status governs liveness
-// and the interim/neutral states.
-//
-// Classify maps those two dimensions onto exactly the events the vision says are
-// worth a chief notification, and nothing else. In priority order:
+// Classify maps the report onto exactly the events worth a chief notification, in
+// priority order:
 //
 //  1. report work_state=failed OR report_type=failure       -> Failed  (terminal, exit 1)
 //  2. report work_state=completed OR report_type=completion  -> Done    (terminal, exit 0)
 //  3. report work_state=ready_for_review                     -> Review  (terminal, exit 0)
-//  4. status=closed, no explicit terminal outcome            -> Ended   (terminal, exit 0)
-//  5. report has a pending decision Request                  -> Blocker (interim)
-//  6. report work_state=needs_input OR report_type=blocker   -> Blocker (interim)
-//  7. status=idle, no explicit outcome                       -> Ended   (terminal, exit 0)
-//  8. status=waiting_input                                   -> Blocker (interim)
-//  9. everything else                                        -> None    (no emit)
+//  4. report has a pending decision Request                  -> Blocker (interim)
+//  5. report work_state=needs_input OR report_type=blocker   -> Blocker (interim)
+//  6. everything else (no report, a progress report, or any  -> None    (no emit)
+//     runtime status whatsoever)
 //
-// Step 9 is the crux of *noise* suppression: it swallows routine tool-permission
-// prompts (status=pending_approval), plus working/launching/scheduled/unknown. A
-// routine "approve this tool call" is NOT a decision worth waking the chief for,
-// and it is cleanly distinguishable from a genuine decision-request: the former
-// is the runtime status pending_approval; the latter is an explicit structured
-// Request / needs_input declaration (steps 5-6). The two come from different data
-// sources, so the exclusion is expressible from existing state.
+// Step 6 is the crux of *noise* suppression. A bare freeform `dispatch report
+// --message` (a progress note) carries no structured terminal/blocked claim, so
+// it classifies as None: it is a silent, on-demand-readable note, never a wake.
+// Routine tool-permission prompts (runtime status pending_approval) are likewise
+// not a trigger — only an explicit structured Request / needs_input declaration
+// (steps 4-5) is. A genuine decision-request and a routine approval prompt thus
+// classify differently from the same runtime moment, because the trigger reads
+// the report, not the status.
 //
-// The agent's explicit terminal declarations — Failed, Done, and Review (steps
-// 1-3) — are authoritative over runtime liveness: a report of completion,
-// failure, or ready_for_review stands even once the session has closed, so a
-// review handoff filed just before the agent exits is never lost. They sit ahead
-// of the closed check (step 4) for exactly that reason.
-//
-// Silence implies NEITHER success nor failure. A dispatch that ends WITHOUT an
-// explicit terminal report — its session simply closes (step 4), or the agent
-// stops at idle without reporting (step 7) — is the neutral terminal kind Ended:
-// it emits and exits (so a watch never hangs and every terminal state is
-// covered), but it asserts no outcome. This is why the closed check (step 4) sits
-// ahead of the *interim* report states (steps 5-6): those are non-terminal, so
-// once the session is gone a stale needs_input is not a live blocker — a dead
-// session must resolve to a neutral terminal instead of hanging on it. Review
-// does not have that problem because it is itself terminal, which is why it can
-// stay authoritative above the closed check.
+// All five emitting events are self-reported, so there is no liveness race to
+// arbitrate: a completion / failure / review / blocked claim stands on its own
+// regardless of whether the session has since gone idle or closed. The cost is
+// the deliberate, accepted gap: an agent that ends WITHOUT a terminal self-report
+// (a crash, or simply forgetting) produces silence — a watch on it does not exit
+// on its own. Silence implies neither success nor failure; the backstop for a
+// genuinely stuck/dead agent is a chief-side watch timeout that escalates to the
+// user (a deferred follow-up), NOT daemon-state inference here. The one non-report
+// terminal the watch still honors is an actually-deleted dispatch RECORD (handled
+// in the watch loop as dispatch_gone / not_found), which is definitive removal,
+// not runtime-state flicker.
 package dispatch
 
 import "github.com/victorarias/attn/internal/protocol"
 
 // SessionClosedStatus is the sentinel ChiefOfStaffDispatch.Status value the
-// daemon projects once the delegated session is gone. The daemon's decorate path
-// is the producer; this package is the consumer, so the literal lives here as
-// the single source of truth.
+// daemon projects once the delegated session is gone. It is a DISPLAY status only
+// (shown in `dispatch status` / `list`); Classify deliberately does not key on it,
+// because runtime state is not a trigger. The literal lives in this package as the
+// single source of truth shared with the daemon's decorate path (the producer).
 const SessionClosedStatus = "closed"
 
 // EventKind is the category of a meaningful dispatch event.
@@ -86,9 +80,9 @@ const (
 	// KindReview is a reviewable deliverable handed back for the chief to look
 	// at. Terminal — the agent considers its push done.
 	KindReview EventKind = "review"
-	// KindEnded is a neutral terminal: the dispatch ended without an explicit
-	// outcome (its session closed, or it stopped at idle without reporting). It
-	// implies neither success nor failure — drill into the narrative to know.
+	// KindEnded is a neutral terminal used only when the dispatch RECORD itself is
+	// gone (explicitly deleted, or never existed) — see the watch loop. It implies
+	// neither success nor failure and is never produced from runtime/daemon state.
 	KindEnded EventKind = "ended"
 	// KindFailed is a failure the agent explicitly declared.
 	KindFailed EventKind = "failed"
@@ -116,62 +110,46 @@ type Event struct {
 // Classify maps a dispatch snapshot to its signal Event. It is a pure function
 // of the snapshot — the single source of truth described in the package doc.
 func Classify(d protocol.ChiefOfStaffDispatch) Event {
+	// The trigger keys ONLY on the agent's self-report. With no structured report
+	// there is nothing the agent has declared, so there is nothing to wake the
+	// chief for — runtime/daemon Status is never a trigger (see the package doc).
+	r := d.StructuredReport
+	if r == nil {
+		return Event{Kind: KindNone}
+	}
+
 	summary := dispatchSummary(d)
 	nextAction := trim(deref(structuredNextAction(d)))
 
-	// 1-3. Explicit TERMINAL outcome the agent declared — authoritative even if the
-	// session has since closed (a completed-, failed-, or ready_for_review-then-
-	// closed dispatch keeps that outcome). All three are terminal, so keeping them
-	// ahead of the closed check cannot hang a watch; it only preserves the handoff
-	// a report filed just before the agent exits would otherwise lose to the race.
-	if r := d.StructuredReport; r != nil {
-		switch {
-		case r.WorkState == protocol.DispatchWorkStateFailed ||
-			r.ReportType == protocol.DispatchReportTypeFailure:
-			return Event{KindFailed, true, 1, "reported_failure", summary, nextAction}
-		case r.WorkState == protocol.DispatchWorkStateCompleted ||
-			r.ReportType == protocol.DispatchReportTypeCompletion:
-			return Event{KindDone, true, 0, "reported_completion", summary, nextAction}
-		case r.WorkState == protocol.DispatchWorkStateReadyForReview:
-			return Event{KindReview, true, 0, "ready_for_review", summary, nextAction}
-		}
+	// 1-3. Explicit TERMINAL outcome the agent declared.
+	switch {
+	case r.WorkState == protocol.DispatchWorkStateFailed ||
+		r.ReportType == protocol.DispatchReportTypeFailure:
+		return Event{KindFailed, true, 1, "reported_failure", summary, nextAction}
+	case r.WorkState == protocol.DispatchWorkStateCompleted ||
+		r.ReportType == protocol.DispatchReportTypeCompletion:
+		return Event{KindDone, true, 0, "reported_completion", summary, nextAction}
+	case r.WorkState == protocol.DispatchWorkStateReadyForReview:
+		return Event{KindReview, true, 0, "ready_for_review", summary, nextAction}
 	}
 
-	// 4. Session gone with no explicit terminal outcome → neutral terminal.
-	// Checked BEFORE the interim report states (steps 5-6) so a dead session never
-	// hangs (a stale needs_input is not a live blocker once the agent is gone) and
-	// is never read as success or failure.
-	if d.Status == SessionClosedStatus {
-		return Event{KindEnded, true, 0, "session_closed", summary, nextAction}
+	// 4-5. Explicit BLOCKED self-report (interim — a watch keeps running through
+	// it so the chief can steer and the loop continues).
+	if req := r.Request; req != nil && req.Status == protocol.DispatchRequestStatusPending {
+		s := summary
+		if q := trim(req.Question); q != "" {
+			s = q
+		}
+		return Event{KindBlocker, false, 0, "decision_request", s, nextAction}
+	}
+	if r.WorkState == protocol.DispatchWorkStateNeedsInput ||
+		r.ReportType == protocol.DispatchReportTypeBlocker {
+		return Event{KindBlocker, false, 0, "needs_input", summary, nextAction}
 	}
 
-	// 5-6. Live, explicit INTERIM (non-terminal) report states.
-	if r := d.StructuredReport; r != nil {
-		if req := r.Request; req != nil && req.Status == protocol.DispatchRequestStatusPending {
-			s := summary
-			if q := trim(req.Question); q != "" {
-				s = q
-			}
-			return Event{KindBlocker, false, 0, "decision_request", s, nextAction}
-		}
-		if r.WorkState == protocol.DispatchWorkStateNeedsInput ||
-			r.ReportType == protocol.DispatchReportTypeBlocker {
-			return Event{KindBlocker, false, 0, "needs_input", summary, nextAction}
-		}
-	}
-
-	// 7-9. Live runtime resting states with no actionable report. idle is a stop
-	// without a structured outcome, so it is neutral Ended too — attn does not
-	// claim a success the agent never declared.
-	switch d.Status {
-	case string(protocol.SessionStateIdle):
-		return Event{KindEnded, true, 0, "session_idle", summary, nextAction}
-	case string(protocol.SessionStateWaitingInput):
-		return Event{KindBlocker, false, 0, "awaiting_input", summary, nextAction}
-	default:
-		// working, launching, pending_approval (the exclusion), scheduled, unknown.
-		return Event{Kind: KindNone}
-	}
+	// 6. A progress / in_progress report (or a resolved request) is a silent note,
+	// not a trigger.
+	return Event{Kind: KindNone}
 }
 
 // IsTerminalReport reports whether a structured report represents a finished

--- a/internal/dispatch/classify_test.go
+++ b/internal/dispatch/classify_test.go
@@ -45,31 +45,31 @@ func TestClassify(t *testing.T) {
 		wantReason   string
 	}{
 		// --- explicit completion → done (the agent SAID it finished) ---
+		// The runtime status is irrelevant: the trigger keys on the report alone.
 		{"reported completion", "working", report(protocol.DispatchWorkStateCompleted, protocol.DispatchReportTypeCompletion), KindDone, true, 0, "reported_completion"},
 		{"completion type only", "working", report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeCompletion), KindDone, true, 0, "reported_completion"},
-		{"completed then closed = done (report wins over close)", SessionClosedStatus, report(protocol.DispatchWorkStateCompleted, protocol.DispatchReportTypeCompletion), KindDone, true, 0, "reported_completion"},
+		{"completed stands even once closed", SessionClosedStatus, report(protocol.DispatchWorkStateCompleted, protocol.DispatchReportTypeCompletion), KindDone, true, 0, "reported_completion"},
 		{"ready for review = terminal handoff", "working", report(protocol.DispatchWorkStateReadyForReview, protocol.DispatchReportTypeProgress), KindReview, true, 0, "ready_for_review"},
-		// An explicit ready_for_review is a TERMINAL outcome and stays authoritative
-		// over a closed session, exactly like completion/failure — the review handoff
-		// must survive the agent filing it and exiting before the watcher's next poll.
-		{"ready_for_review then closed = review (report wins over close)", SessionClosedStatus, report(protocol.DispatchWorkStateReadyForReview, protocol.DispatchReportTypeProgress), KindReview, true, 0, "ready_for_review"},
+		{"ready_for_review stands even once closed", SessionClosedStatus, report(protocol.DispatchWorkStateReadyForReview, protocol.DispatchReportTypeProgress), KindReview, true, 0, "ready_for_review"},
 
-		// --- silence implies neither success nor failure → neutral Ended ---
-		{"idle without report = ended (not done)", string(protocol.SessionStateIdle), nil, KindEnded, true, 0, "session_idle"},
-		{"idle after progress report = ended", string(protocol.SessionStateIdle), report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeProgress), KindEnded, true, 0, "session_idle"},
-		{"session closed without report = ended (not failed)", SessionClosedStatus, nil, KindEnded, true, 0, "session_closed"},
-		{"session closed after progress report = ended", SessionClosedStatus, report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeProgress), KindEnded, true, 0, "session_closed"},
-		// A dead session beats a stale INTERIM (non-terminal) report — never hang,
-		// never mislabel. (A TERMINAL report like ready_for_review wins over close
-		// instead; see the explicit case above.)
-		{"needs_input then closed = ended (no hang)", SessionClosedStatus, report(protocol.DispatchWorkStateNeedsInput, protocol.DispatchReportTypeProgress), KindEnded, true, 0, "session_closed"},
-		{"decision request then closed = ended", SessionClosedStatus, pendingRequest, KindEnded, true, 0, "session_closed"},
+		// --- no self-report → silence, regardless of runtime status. Runtime state
+		// (idle / closed / waiting_input / working / …) is NEVER a trigger now. ---
+		{"idle without report = silent", string(protocol.SessionStateIdle), nil, KindNone, false, 0, ""},
+		{"idle after progress report = silent", string(protocol.SessionStateIdle), report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeProgress), KindNone, false, 0, ""},
+		{"session closed without report = silent", SessionClosedStatus, nil, KindNone, false, 0, ""},
+		{"session closed after progress report = silent", SessionClosedStatus, report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeProgress), KindNone, false, 0, ""},
+		{"waiting_input without report = silent (the #399 misfire, now killed)", string(protocol.SessionStateWaitingInput), nil, KindNone, false, 0, ""},
+
+		// --- a self-reported blocker stands even once the session is gone. The
+		// dispatch hangs on it (accepted crash-while-blocked gap); only an explicit
+		// terminal report or a deleted record ends the watch. ---
+		{"needs_input stands even once closed", SessionClosedStatus, report(protocol.DispatchWorkStateNeedsInput, protocol.DispatchReportTypeProgress), KindBlocker, false, 0, "needs_input"},
+		{"decision request stands even once closed", SessionClosedStatus, pendingRequest, KindBlocker, false, 0, "decision_request"},
 
 		// --- genuine blocker / decision-request (interim, live) ---
 		{"pending decision request", "waiting_input", pendingRequest, KindBlocker, false, 0, "decision_request"},
 		{"needs_input work state", "working", report(protocol.DispatchWorkStateNeedsInput, protocol.DispatchReportTypeProgress), KindBlocker, false, 0, "needs_input"},
 		{"blocker report type", "working", report(protocol.DispatchWorkStateInProgress, protocol.DispatchReportTypeBlocker), KindBlocker, false, 0, "needs_input"},
-		{"waiting_input without report", string(protocol.SessionStateWaitingInput), nil, KindBlocker, false, 0, "awaiting_input"},
 
 		// --- explicit failure → failed (the agent SAID it failed) ---
 		{"reported failure", "working", report(protocol.DispatchWorkStateFailed, protocol.DispatchReportTypeFailure), KindFailed, true, 1, "reported_failure"},
@@ -86,7 +86,7 @@ func TestClassify(t *testing.T) {
 		{"unknown (do not cry wolf)", string(protocol.SessionStateUnknown), nil, KindNone, false, 0, ""},
 
 		// --- a resolved request is no longer a blocker ---
-		{"resolved request falls through to status", "working", resolvedRequest, KindNone, false, 0, ""},
+		{"resolved request is silent", "working", resolvedRequest, KindNone, false, 0, ""},
 	}
 
 	for _, tt := range tests {
@@ -136,6 +136,8 @@ func TestClassify_ApprovalExclusionIsExpressible(t *testing.T) {
 }
 
 func TestClassify_SummaryPrefersConciseThenReportThenLatest(t *testing.T) {
+	// dispatchSummary is consulted only for an emitting (self-reported) event, so
+	// every case carries a terminal report; only the summary SOURCE varies.
 	d := protocol.ChiefOfStaffDispatch{
 		Status:         string(protocol.SessionStateIdle),
 		ConciseSummary: ptr("concise wins"),
@@ -154,7 +156,9 @@ func TestClassify_SummaryPrefersConciseThenReportThenLatest(t *testing.T) {
 		t.Errorf("summary = %q, want report summary", got)
 	}
 
-	d.StructuredReport = nil
+	// No concise summary and an empty structured summary → fall back to the
+	// freeform latest report.
+	d.StructuredReport.Summary = ""
 	if got := Classify(d).Summary; got != "freeform loses" {
 		t.Errorf("summary = %q, want latest report", got)
 	}

--- a/internal/dispatch/classify_test.go
+++ b/internal/dispatch/classify_test.go
@@ -24,9 +24,16 @@ func TestClassify(t *testing.T) {
 			ExpectedResponder: "chief",
 		},
 	}
+	// The exact shape the system produces after a chief resolves a blocked
+	// decision: `dispatch report --blocked --question` synthesizes
+	// WorkState=NeedsInput + ReportType=Blocker + a pending Request, and
+	// `dispatch resolve` flips ONLY Request.Status to resolved — work_state and
+	// report_type are left untouched. Classify must read the resolved Request as
+	// authoritative and stay silent; the earlier InProgress fixture dodged the
+	// needs_input branch and masked a re-fire bug.
 	resolvedRequest := &protocol.DispatchReport{
-		WorkState:  protocol.DispatchWorkStateInProgress,
-		ReportType: protocol.DispatchReportTypeProgress,
+		WorkState:  protocol.DispatchWorkStateNeedsInput,
+		ReportType: protocol.DispatchReportTypeBlocker,
 		Summary:    "mid-flight",
 		Request: &protocol.DispatchDecisionRequest{
 			Status:            protocol.DispatchRequestStatusResolved,
@@ -85,8 +92,14 @@ func TestClassify(t *testing.T) {
 		{"scheduled (will auto-resume)", string(protocol.SessionStateScheduled), nil, KindNone, false, 0, ""},
 		{"unknown (do not cry wolf)", string(protocol.SessionStateUnknown), nil, KindNone, false, 0, ""},
 
-		// --- a resolved request is no longer a blocker ---
+		// --- a resolved request is no longer a blocker: the chief answered, and the
+		// resolve (a store-state flip, not a self-report) must not re-fire even though
+		// work_state still reads needs_input. This is the real post-`dispatch resolve`
+		// shape; a present-but-resolved Request suppresses the needs_input branch. ---
 		{"resolved request is silent", "working", resolvedRequest, KindNone, false, 0, ""},
+		// A genuine needs_input/blocker with NO decision Request (e.g. `--blocked`
+		// without `--question`) still emits — only an attached Request gates it.
+		{"needs_input without a request still emits", "working", report(protocol.DispatchWorkStateNeedsInput, protocol.DispatchReportTypeBlocker), KindBlocker, false, 0, "needs_input"},
 	}
 
 	for _, tt := range tests {

--- a/internal/dispatch/watch.go
+++ b/internal/dispatch/watch.go
@@ -166,12 +166,6 @@ func formatAbortLine(dispatchID string, err error) string {
 
 func defaultSummary(reason string) string {
 	switch reason {
-	case "session_closed":
-		return "session ended without a structured report"
-	case "session_idle":
-		return "agent stopped without a structured report"
-	case "awaiting_input":
-		return "agent is waiting for direction (no report filed)"
 	case "dispatch_gone":
 		return "dispatch record is no longer present"
 	case "not_found":

--- a/internal/dispatch/watch_test.go
+++ b/internal/dispatch/watch_test.go
@@ -94,21 +94,31 @@ func TestRunWatch_StaysSilentThenExitsOnRoutineApproval(t *testing.T) {
 	}
 }
 
-func TestRunWatch_SessionCloseIsNeutralEndedExitZero(t *testing.T) {
-	// Silence is not failure: a session that closes without a structured report
-	// is the neutral [ended], exit 0 — it emits and exits (never hangs), but
-	// asserts no outcome.
+func TestRunWatch_SessionCloseWithoutReportStaysSilent(t *testing.T) {
+	// Runtime state is not a trigger: a session that closes WITHOUT a terminal
+	// self-report emits nothing and the watch keeps running (the accepted
+	// crash-without-report gap; a deferred chief-side watch-timeout is the backstop).
+	// A real terminal report — even filed just before close — still ends it cleanly.
 	closed := &protocol.ChiefOfStaffDispatch{ID: "d1", Label: "badge", Status: SessionClosedStatus}
+	doneAtClose := &protocol.ChiefOfStaffDispatch{
+		ID: "d1", Label: "badge", Status: SessionClosedStatus,
+		StructuredReport: &protocol.DispatchReport{
+			WorkState: protocol.DispatchWorkStateCompleted,
+			Summary:   "done and green",
+		},
+	}
 	code, out, _ := runWatchScript(t, []fetchStep{
 		{working(), true, nil},
 		{closed, true, nil},
+		{closed, true, nil}, // still silent — close is not a signal
+		{doneAtClose, true, nil},
 	})
 	if code != 0 {
-		t.Errorf("exit = %d, want 0 — close-without-report is neutral, not failure", code)
+		t.Errorf("exit = %d, want 0", code)
 	}
 	lines := nonEmptyLines(out)
-	if len(lines) != 1 || !strings.HasPrefix(lines[0], "[ended]") {
-		t.Fatalf("want a single [ended] line, got: %q", out)
+	if len(lines) != 1 || !strings.HasPrefix(lines[0], "[done]") {
+		t.Fatalf("close-without-report must be silent; only the [done] report emits. got: %q", out)
 	}
 }
 
@@ -134,32 +144,43 @@ func TestRunWatch_ExplicitFailureExitsNonZero(t *testing.T) {
 	}
 }
 
-func TestRunWatch_DeadSessionWithStaleBlockerDoesNotHang(t *testing.T) {
-	// A needs_input report on a session that then closes must resolve to a
-	// neutral terminal — not stay a (non-terminal) blocker and hang forever.
-	stuck := &protocol.ChiefOfStaffDispatch{
+func TestRunWatch_SelfReportedBlockerStandsEvenWhenClosed(t *testing.T) {
+	// A self-reported blocker is keyed on the report, not runtime state, so it stays
+	// a (non-terminal) blocker even once the session shows closed — the watch keeps
+	// running through it. Only a terminal report (or a deleted record) ends it.
+	blocked := &protocol.ChiefOfStaffDispatch{
 		ID: "d1", Label: "badge", Status: SessionClosedStatus,
 		StructuredReport: &protocol.DispatchReport{
 			WorkState: protocol.DispatchWorkStateNeedsInput,
 			Summary:   "was waiting on a decision",
 		},
 	}
+	done := &protocol.ChiefOfStaffDispatch{
+		ID: "d1", Label: "badge", Status: SessionClosedStatus,
+		StructuredReport: &protocol.DispatchReport{
+			WorkState: protocol.DispatchWorkStateCompleted,
+			Summary:   "resolved and finished",
+		},
+	}
 	code, out, _ := runWatchScript(t, []fetchStep{
-		{stuck, true, nil},
+		{blocked, true, nil},
+		{blocked, true, nil}, // same blocker: deduped, silent, still running
+		{done, true, nil},
 	})
 	if code != 0 {
 		t.Errorf("exit = %d, want 0", code)
 	}
-	if !strings.HasPrefix(strings.TrimSpace(out), "[ended]") {
-		t.Fatalf("dead session with a stale blocker must end neutrally, got: %q", out)
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 || !strings.HasPrefix(lines[0], "[blocker]") || !strings.HasPrefix(lines[1], "[done]") {
+		t.Fatalf("want [blocker] then [done], got: %q", out)
 	}
 }
 
 func TestRunWatch_ReadyForReviewSurvivesSessionClose(t *testing.T) {
-	// The race figgyster flagged: the agent files work_state=ready_for_review and
-	// the session closes before the next poll, so the snapshot carries BOTH a
-	// closed Status and the structured review report. The explicit review handoff
-	// must win over the close — [review], exit 0 — not collapse to neutral [ended].
+	// The agent files work_state=ready_for_review and the session closes before the
+	// next poll, so the snapshot carries BOTH a closed Status and the structured
+	// review report. The trigger keys on the report, not runtime state, so the
+	// review handoff stands — [review], exit 0 — regardless of the close.
 	reviewing := &protocol.ChiefOfStaffDispatch{
 		ID: "d1", Label: "badge", Status: SessionClosedStatus,
 		StructuredReport: &protocol.DispatchReport{

--- a/internal/dispatch/watch_test.go
+++ b/internal/dispatch/watch_test.go
@@ -235,6 +235,56 @@ func TestRunWatch_BlockerEmitsButDoesNotExitThenCompletes(t *testing.T) {
 	}
 }
 
+func TestRunWatch_ResolvedDecisionDoesNotRefireBlocker(t *testing.T) {
+	// The core reverse-channel flow: the agent files a decision request (pending),
+	// the chief resolves it. `dispatch resolve` flips ONLY Request.Status to
+	// resolved and leaves work_state=needs_input — so the post-resolve snapshot is
+	// {WorkState: NeedsInput, Request.Status: Resolved}. The resolve is a
+	// store-state transition, not a fresh self-report, so it must NOT surface a
+	// second [blocker] to the chief who just answered. Only the agent's later
+	// completion ends the watch.
+	pending := &protocol.ChiefOfStaffDispatch{
+		ID: "d1", Label: "badge", Status: "waiting_input",
+		StructuredReport: &protocol.DispatchReport{
+			WorkState: protocol.DispatchWorkStateNeedsInput,
+			Summary:   "need a decision",
+			Request: &protocol.DispatchDecisionRequest{
+				Status:            protocol.DispatchRequestStatusPending,
+				Question:          "flag or not?",
+				ExpectedResponder: "chief",
+			},
+		},
+	}
+	resolved := &protocol.ChiefOfStaffDispatch{
+		ID: "d1", Label: "badge", Status: "working",
+		StructuredReport: &protocol.DispatchReport{
+			WorkState: protocol.DispatchWorkStateNeedsInput, // resolve leaves this as-is
+			Summary:   "need a decision",
+			Request: &protocol.DispatchDecisionRequest{
+				Status:            protocol.DispatchRequestStatusResolved,
+				Question:          "flag or not?",
+				ExpectedResponder: "chief",
+			},
+		},
+	}
+	code, out, _ := runWatchScript(t, []fetchStep{
+		{pending, true, nil},  // emits [blocker], keeps watching
+		{resolved, true, nil}, // chief answered → silent, NOT a second blocker
+		{resolved, true, nil}, // still silent
+		{completed(), true, nil},
+	})
+	if code != 0 {
+		t.Errorf("exit = %d, want 0", code)
+	}
+	lines := nonEmptyLines(out)
+	if len(lines) != 2 {
+		t.Fatalf("want exactly 2 lines (one [blocker], then [done]); a resolved request must not re-fire. got %d: %q", len(lines), out)
+	}
+	if !strings.HasPrefix(lines[0], "[blocker]") || !strings.HasPrefix(lines[1], "[done]") {
+		t.Fatalf("want [blocker] then [done], got: %q", out)
+	}
+}
+
 func TestRunWatch_AlreadyTerminalOnFirstPollEmitsAndExits(t *testing.T) {
 	code, out, calls := runWatchScript(t, []fetchStep{
 		{completed(), true, nil},


### PR DESCRIPTION
## Self-report trigger loop — chief↔delegated-agent awareness

Builds the aligned chunk of the chief-in-the-loop vision (plan:
`docs/plans/2026-06-23-self-report-trigger-loop.md`, cherry-picked here so merging
lands it on main). The chief stays *aware* of its delegations and can *steer* them
— bidirectionally — **without babysitting**.

### The model
The trigger fires on exactly two things and is silent otherwise:
- **forward** — the agent's self-reported terminal/blocked outcome;
- **reverse** — a mailbox item, delivered via the agent's own quiet inbox watch.

Daemon/runtime state is no longer a trigger — that flicker was the source of the
#399 misfires.

### What's in this PR
- **Forward trigger** (`internal/dispatch/classify.go`): removed the daemon-state
  steps (closed/idle/waiting_input). The watch now fires only on a self-reported
  `done`/`failed`/`review` (terminal) or `decision-request`/`needs_input`/`blocker`
  (interim). The #399 "empty report at waiting_input → false blocker" misfire is gone.
- **Self-report affordance** (`cmd/attn dispatch report`): first-class
  `--done` / `--failed` / `--review` / `--blocked` (with `--question` /
  `--recommendation` / `--consequence`) flags that synthesize the structured report
  over the existing envelope — no more hand-written coordination JSON for the common
  cases. A bare `--message` is a silent note (no trigger). `--coordination-file`
  stays as the escape hatch.
- **Reverse ambient UI** (`app/`): a sidebar pending-mail badge (+ collapsed-rail
  dot) and an on-agent terminal overlay, both driven by the existing
  `unread_message_count`. The overlay is pointer-events-scoped so it never steals
  PTY focus. Clicking it fires the existing wake doorbell.
- **Guidance** (`internal/agent/attn_skill/references/`): the launch prompt and skill
  references teach the chief to arm one quiet watch, self-report only at
  terminal/blocked, watch the inbox for steering, and escalate-unless-sure. Single
  authoritative home (the bundled skill); `~/exo` persona doc untouched.

### Notable decisions
- **No `ProtocolVersion` bump** — everything reuses existing protocol surfaces.
- **"watching ≠ working" dissolved via the quiet watch** — no state-inference code.
  A quiet (event-only) watch produces neither a running `background_tasks` entry at
  Stop nor an animated PTY frame, so it settles to idle on its own.
- **Accepted gap** (per the plan's Deferred): an agent that ends *without* a terminal
  self-report leaves a quiet, non-exiting watch (silence ≠ success). The deferred
  watch-timeout→escalate is the backstop; codex auto-wake is also deferred.

### Testing
- Go: `go test ./...` green (full suite).
- Frontend: `pnpm test` green (1151 tests, incl. new PendingMailBadge / OnAgentMailOverlay specs).

🤖 Authored by an attn-delegated agent on behalf of Victor.
