### PR TITLE
feat(workspace): add pinned workspaces that persist when empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-24]
+
+### Added
+- **Pin workspaces to keep them in the sidebar even when empty.** A workspace can now be toggled pinned/unpinned from the sidebar. A pinned workspace survives its last session closing and daemon restarts — it stays visible and ready for a new agent launch. Existing tile-only and context-based workspace retention continues to work alongside pinning.
+
 ## [2026-06-23]
 
 ### Added

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -465,6 +465,7 @@ function App() {
     sendMuteRepo,
     sendMuteAuthor,
     sendMuteWorkspace,
+    sendPinWorkspace,
     sendPRVisited,
     sendRefreshPRs,
     sendRegisterWorkspace,
@@ -620,6 +621,7 @@ function App() {
         sendMuteRepo={sendMuteRepo}
         sendMuteAuthor={sendMuteAuthor}
         sendMuteWorkspace={sendMuteWorkspace}
+        sendPinWorkspace={sendPinWorkspace}
         sendPRVisited={sendPRVisited}
         sendRefreshPRs={sendRefreshPRs}
         sendRegisterWorkspace={sendRegisterWorkspace}
@@ -735,6 +737,7 @@ interface AppContentProps {
   sendMuteRepo: ReturnType<typeof useDaemonSocket>['sendMuteRepo'];
   sendMuteAuthor: ReturnType<typeof useDaemonSocket>['sendMuteAuthor'];
   sendMuteWorkspace: ReturnType<typeof useDaemonSocket>['sendMuteWorkspace'];
+  sendPinWorkspace: ReturnType<typeof useDaemonSocket>['sendPinWorkspace'];
   sendPRVisited: ReturnType<typeof useDaemonSocket>['sendPRVisited'];
   sendRefreshPRs: ReturnType<typeof useDaemonSocket>['sendRefreshPRs'];
   sendRegisterWorkspace: ReturnType<typeof useDaemonSocket>['sendRegisterWorkspace'];
@@ -844,6 +847,7 @@ function AppContent({
   sendMuteRepo,
   sendMuteAuthor,
   sendMuteWorkspace,
+  sendPinWorkspace,
   sendPRVisited,
   sendRefreshPRs,
   sendRegisterWorkspace,
@@ -3572,6 +3576,7 @@ sendFetchPRDetails,
           mutedExpanded={sidebarMutedExpanded}
           onMutedExpandedChange={setSidebarMutedExpanded}
           onMuteWorkspace={sendMuteWorkspace}
+          onPinWorkspace={sendPinWorkspace}
           onRenameSession={sendRenameSession}
           onRenameWorkspace={sendRenameWorkspace}
           onChangeChiefOfStaff={handleChangeChiefOfStaff}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2465,11 +2465,11 @@ sendFetchPRDetails,
     [daemonWorkspaces, visibleEnrichedSessions],
   );
   const unmutedWorkspaceViews = useMemo(
-    () => workspaceViews.filter((workspace) => !workspace.muted && workspace.sessions.length > 0),
+    () => workspaceViews.filter((workspace) => !workspace.muted && (workspace.pinned || workspace.sessions.length > 0)),
     [workspaceViews],
   );
   const mutedWorkspaceViews = useMemo(
-    () => workspaceViews.filter((workspace) => workspace.muted && workspace.sessions.length > 0),
+    () => workspaceViews.filter((workspace) => workspace.muted && (workspace.pinned || workspace.sessions.length > 0)),
     [workspaceViews],
   );
   const unmutedEnrichedSessions = useMemo(
@@ -2596,7 +2596,7 @@ sendFetchPRDetails,
   }, []);
   const sidebarWorkspaceViews = useMemo(
     () => workspaceViews.filter(
-      (workspace) => !workspace.muted && (workspace.sessions.length > 0 || showSessionlessWorkspaces),
+      (workspace) => !workspace.muted && (workspace.pinned || workspace.sessions.length > 0 || showSessionlessWorkspaces),
     ),
     [workspaceViews, showSessionlessWorkspaces],
   );

--- a/app/src/components/Sidebar.css
+++ b/app/src/components/Sidebar.css
@@ -685,6 +685,14 @@
   color: var(--color-text-primary);
 }
 
+/* Keep the pin button visible and accented when the workspace is pinned,
+   even when the header row is not hovered. */
+.pin-workspace-btn.pinned {
+  opacity: 1;
+  pointer-events: auto;
+  color: var(--color-text-primary);
+}
+
 .session-item:hover .session-actions,
 .session-item:focus-within .session-actions {
   opacity: 1;

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -148,6 +148,7 @@ interface SidebarProps {
   mutedExpanded?: boolean;
   onMutedExpandedChange?: (expanded: boolean) => void;
   onMuteWorkspace?: (workspaceId: string, endpointId?: string) => void;
+  onPinWorkspace?: (workspaceId: string, pinned: boolean) => void;
   onRenameSession?: (sessionId: string, label: string) => Promise<void>;
   onRenameWorkspace?: (workspaceId: string, title: string) => Promise<void>;
   onChangeChiefOfStaff?: (sessionId: string, enabled: boolean) => void;
@@ -344,6 +345,7 @@ export function Sidebar({
   mutedExpanded: mutedExpandedProp,
   onMutedExpandedChange,
   onMuteWorkspace,
+  onPinWorkspace,
   onRenameSession,
   onRenameWorkspace,
   onChangeChiefOfStaff,
@@ -414,7 +416,7 @@ export function Sidebar({
     onMutedExpandedChange?.(v);
   };
 
-  const isWorkspaceVisible = (workspace: SidebarWorkspace) => !isSessionless(workspace) || showSessionless;
+  const isWorkspaceVisible = (workspace: SidebarWorkspace) => workspace.pinned || !isSessionless(workspace) || showSessionless;
   const visibleWorkspaces = workspaces.filter(isWorkspaceVisible);
   const visibleVisualOrder = visualOrder.filter(isWorkspaceVisible);
   const visibleVisualIndexByWorkspaceId = new Map(
@@ -955,8 +957,23 @@ export function Sidebar({
                   </span>
                 )}
                 <span className="session-shortcut">⌘{workspaceIndex + 1}</span>
-                {(onRenameWorkspace || onMuteWorkspace) && (
+                {(onRenameWorkspace || onMuteWorkspace || onPinWorkspace) && (
                   <span className="workspace-actions">
+                    {onPinWorkspace && (
+                      <button
+                        type="button"
+                        className={`workspace-action-btn pin-workspace-btn${workspace.pinned ? ' pinned' : ''}`}
+                        data-testid={`pin-workspace-${workspace.id}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onPinWorkspace(workspace.id, !workspace.pinned);
+                        }}
+                        title={workspace.pinned ? 'Unpin workspace' : 'Pin workspace'}
+                        aria-label={`${workspace.pinned ? 'Unpin' : 'Pin'} workspace ${workspace.title}`}
+                      >
+                        {workspace.pinned ? '\u{1F4CC}' : '\u{1F4CD}'}
+                      </button>
+                    )}
                     {onRenameWorkspace && (
                       <button
                         type="button"

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -3353,6 +3353,16 @@ export function useDaemonSocket({
     }));
   }, []);
 
+  const sendPinWorkspace = useCallback((workspaceId: string, pinned: boolean) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({
+      cmd: 'pin_workspace',
+      workspace_id: workspaceId,
+      pinned,
+    }));
+  }, []);
+
   // Request daemon to refresh PRs from GitHub
   const sendRefreshPRs = useCallback((): Promise<PRActionResult> => {
     return new Promise((resolve, reject) => {
@@ -4874,6 +4884,7 @@ export function useDaemonSocket({
     sendMuteRepo,
     sendMuteAuthor,
     sendMuteWorkspace,
+    sendPinWorkspace,
     sendRefreshPRs,
     sendFetchPRDetails,
     sendClearSessions,

--- a/app/src/store/sessions.test.ts
+++ b/app/src/store/sessions.test.ts
@@ -395,6 +395,7 @@ describe('sessions store', () => {
         directory: '/tmp/workspace',
         status: WorkspaceStatus.Idle,
         muted: false,
+        pinned: false,
         rank: '',
         layout: {
           workspace_id: `workspace-${sessionId}`,
@@ -447,6 +448,7 @@ describe('sessions store', () => {
         directory: '/tmp/workspace',
         status: WorkspaceStatus.Idle,
         muted: false,
+        pinned: false,
         rank: '',
         layout: {
           workspace_id: `workspace-${sessionId}`,
@@ -463,6 +465,7 @@ describe('sessions store', () => {
         directory: '/tmp/unknown',
         status: WorkspaceStatus.Idle,
         muted: false,
+        pinned: false,
         rank: '',
         layout: {
           workspace_id: 'workspace-unknown-session',

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HandoffDispatchMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchMessagesMessage, ListDispatchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookTask, NotebookTaskListMessage, NotebookTaskListResultMessage, NotebookTaskRetryMessage, NotebookTaskRetryResultMessage, NotebookTasksChangedMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReportDispatchMessage, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockPanelMessage, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockPanelMessage, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspacePanelContentGetMessage, WorkspacePanelContentMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HandoffDispatchMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListDispatchMessagesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookTask, NotebookTaskListMessage, NotebookTaskListResultMessage, NotebookTaskRetryMessage, NotebookTaskRetryResultMessage, NotebookTasksChangedMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, ReportDispatchMessage, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const acknowledgeDispatchMessage = Convert.toAcknowledgeDispatchMessage(json);
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
@@ -116,8 +116,8 @@
 //   const installPluginMessage = Convert.toInstallPluginMessage(json);
 //   const killSessionMessage = Convert.toKillSessionMessage(json);
 //   const listBranchesMessage = Convert.toListBranchesMessage(json);
-//   const listDispatchMessagesMessage = Convert.toListDispatchMessagesMessage(json);
 //   const listDispatchesMessage = Convert.toListDispatchesMessage(json);
+//   const listDispatchMessagesMessage = Convert.toListDispatchMessagesMessage(json);
 //   const listEndpointsMessage = Convert.toListEndpointsMessage(json);
 //   const listPluginsMessage = Convert.toListPluginsMessage(json);
 //   const listRemoteBranchesMessage = Convert.toListRemoteBranchesMessage(json);
@@ -155,21 +155,22 @@
 //   const notebookWriteResultMessage = Convert.toNotebookWriteResultMessage(json);
 //   const openBrowserMessage = Convert.toOpenBrowserMessage(json);
 //   const openMarkdownMessage = Convert.toOpenMarkdownMessage(json);
-//   const pR = Convert.toPR(json);
-//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
-//   const pRRole = Convert.toPRRole(json);
-//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
-//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
 //   const pathInspection = Convert.toPathInspection(json);
+//   const pinWorkspaceMessage = Convert.toPinWorkspaceMessage(json);
 //   const pluginActionResultMessage = Convert.toPluginActionResultMessage(json);
 //   const pluginInfo = Convert.toPluginInfo(json);
 //   const pluginIssue = Convert.toPluginIssue(json);
 //   const pluginsUpdatedMessage = Convert.toPluginsUpdatedMessage(json);
+//   const pR = Convert.toPR(json);
+//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
+//   const pRRole = Convert.toPRRole(json);
+//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
+//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
 //   const ptyDesyncMessage = Convert.toPtyDesyncMessage(json);
 //   const ptyInputMessage = Convert.toPtyInputMessage(json);
 //   const ptyOutputMessage = Convert.toPtyOutputMessage(json);
-//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
+//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const queryAuthorsMessage = Convert.toQueryAuthorsMessage(json);
 //   const queryMessage = Convert.toQueryMessage(json);
 //   const queryPRsMessage = Convert.toQueryPRsMessage(json);
@@ -189,8 +190,8 @@
 //   const renameWorkspaceMessage = Convert.toRenameWorkspaceMessage(json);
 //   const replaySegment = Convert.toReplaySegment(json);
 //   const repoInfo = Convert.toRepoInfo(json);
-//   const repoState = Convert.toRepoState(json);
 //   const reportDispatchMessage = Convert.toReportDispatchMessage(json);
+//   const repoState = Convert.toRepoState(json);
 //   const reposUpdatedMessage = Convert.toReposUpdatedMessage(json);
 //   const resolveCommentMessage = Convert.toResolveCommentMessage(json);
 //   const resolveCommentResultMessage = Convert.toResolveCommentResultMessage(json);
@@ -216,18 +217,18 @@
 //   const sessionSelectedMessage = Convert.toSessionSelectedMessage(json);
 //   const sessionState = Convert.toSessionState(json);
 //   const sessionStateChangedMessage = Convert.toSessionStateChangedMessage(json);
+//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const sessionTodosUpdatedMessage = Convert.toSessionTodosUpdatedMessage(json);
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
 //   const sessionVisualizedMessage = Convert.toSessionVisualizedMessage(json);
-//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
 //   const setPluginPriorityMessage = Convert.toSetPluginPriorityMessage(json);
 //   const setReviewLoopIterationLimitMessage = Convert.toSetReviewLoopIterationLimitMessage(json);
 //   const setSessionResumeIDMessage = Convert.toSetSessionResumeIDMessage(json);
 //   const setSettingMessage = Convert.toSetSettingMessage(json);
-//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const settingsUpdatedMessage = Convert.toSettingsUpdatedMessage(json);
+//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const spawnResultMessage = Convert.toSpawnResultMessage(json);
 //   const spawnSessionMessage = Convert.toSpawnSessionMessage(json);
 //   const startReviewLoopMessage = Convert.toStartReviewLoopMessage(json);
@@ -275,7 +276,6 @@
 //   const workspaceLayoutAddSessionPaneMessage = Convert.toWorkspaceLayoutAddSessionPaneMessage(json);
 //   const workspaceLayoutClosePaneMessage = Convert.toWorkspaceLayoutClosePaneMessage(json);
 //   const workspaceLayoutDockEdge = Convert.toWorkspaceLayoutDockEdge(json);
-//   const workspaceLayoutDockPanelMessage = Convert.toWorkspaceLayoutDockPanelMessage(json);
 //   const workspaceLayoutDockTileMessage = Convert.toWorkspaceLayoutDockTileMessage(json);
 //   const workspaceLayoutFocusPaneMessage = Convert.toWorkspaceLayoutFocusPaneMessage(json);
 //   const workspaceLayoutGetMessage = Convert.toWorkspaceLayoutGetMessage(json);
@@ -289,12 +289,9 @@
 //   const workspaceLayoutRenamePaneMessage = Convert.toWorkspaceLayoutRenamePaneMessage(json);
 //   const workspaceLayoutSetSplitRatioMessage = Convert.toWorkspaceLayoutSetSplitRatioMessage(json);
 //   const workspaceLayoutSplitDirection = Convert.toWorkspaceLayoutSplitDirection(json);
-//   const workspaceLayoutUndockPanelMessage = Convert.toWorkspaceLayoutUndockPanelMessage(json);
 //   const workspaceLayoutUndockTileMessage = Convert.toWorkspaceLayoutUndockTileMessage(json);
-//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
-//   const workspacePanelContentGetMessage = Convert.toWorkspacePanelContentGetMessage(json);
-//   const workspacePanelContentMessage = Convert.toWorkspacePanelContentMessage(json);
+//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceRegisteredMessage = Convert.toWorkspaceRegisteredMessage(json);
 //   const workspaceSelectedMessage = Convert.toWorkspaceSelectedMessage(json);
 //   const workspaceStateChangedMessage = Convert.toWorkspaceStateChangedMessage(json);
@@ -1889,6 +1886,7 @@ export interface WorkspaceElement {
     id:        string;
     layout?:   Layout;
     muted:     boolean;
+    pinned:    boolean;
     rank:      string;
     status:    WorkspaceStatus;
     title:     string;
@@ -2013,6 +2011,16 @@ export enum ListBranchesMessageCmd {
     ListBranches = "list_branches",
 }
 
+export interface ListDispatchesMessage {
+    cmd:               ListDispatchesMessageCmd;
+    source_session_id: string;
+    [property: string]: any;
+}
+
+export enum ListDispatchesMessageCmd {
+    ListDispatches = "list_dispatches",
+}
+
 export interface ListDispatchMessagesMessage {
     cmd:               ListDispatchMessagesMessageCmd;
     dispatch_id?:      string;
@@ -2023,16 +2031,6 @@ export interface ListDispatchMessagesMessage {
 
 export enum ListDispatchMessagesMessageCmd {
     ListDispatchMessages = "list_dispatch_messages",
-}
-
-export interface ListDispatchesMessage {
-    cmd:               ListDispatchesMessageCmd;
-    source_session_id: string;
-    [property: string]: any;
-}
-
-export enum ListDispatchesMessageCmd {
-    ListDispatches = "list_dispatches",
 }
 
 export interface ListEndpointsMessage {
@@ -2480,69 +2478,6 @@ export enum OpenMarkdownMessageCmd {
     OpenMarkdown = "open_markdown",
 }
 
-export interface PR {
-    approved_by_me:         boolean;
-    author:                 string;
-    ci_status?:             string;
-    comment_count?:         number;
-    details_fetched:        boolean;
-    details_fetched_at?:    string;
-    has_new_changes:        boolean;
-    head_branch?:           string;
-    head_sha?:              string;
-    heat_state?:            HeatState;
-    host:                   string;
-    id:                     string;
-    last_heat_activity_at?: string;
-    last_polled:            string;
-    last_updated:           string;
-    mergeable?:             boolean;
-    mergeable_state?:       string;
-    muted:                  boolean;
-    number:                 number;
-    reason:                 string;
-    repo:                   string;
-    review_status?:         string;
-    role:                   PRRole;
-    state:                  string;
-    title:                  string;
-    url:                    string;
-    [property: string]: any;
-}
-
-export interface PRActionResultMessage {
-    action:  string;
-    error?:  string;
-    event:   PRActionResultMessageEvent;
-    id:      string;
-    success: boolean;
-    [property: string]: any;
-}
-
-export enum PRActionResultMessageEvent {
-    PRActionResult = "pr_action_result",
-}
-
-export interface PRVisitedMessage {
-    cmd: PRVisitedMessageCmd;
-    id:  string;
-    [property: string]: any;
-}
-
-export enum PRVisitedMessageCmd {
-    PRVisited = "pr_visited",
-}
-
-export interface PRsUpdatedMessage {
-    event: PRsUpdatedMessageEvent;
-    prs?:  PRElement[];
-    [property: string]: any;
-}
-
-export enum PRsUpdatedMessageEvent {
-    PrsUpdated = "prs_updated",
-}
-
 export interface PathInspection {
     exists:        boolean;
     home_path?:    string;
@@ -2551,6 +2486,17 @@ export interface PathInspection {
     repo_root?:    string;
     resolved_path: string;
     [property: string]: any;
+}
+
+export interface PinWorkspaceMessage {
+    cmd:          PinWorkspaceMessageCmd;
+    pinned:       boolean;
+    workspace_id: string;
+    [property: string]: any;
+}
+
+export enum PinWorkspaceMessageCmd {
+    PinWorkspace = "pin_workspace",
 }
 
 export interface PluginActionResultMessage {
@@ -2617,6 +2563,69 @@ export interface PluginElement {
     [property: string]: any;
 }
 
+export interface PR {
+    approved_by_me:         boolean;
+    author:                 string;
+    ci_status?:             string;
+    comment_count?:         number;
+    details_fetched:        boolean;
+    details_fetched_at?:    string;
+    has_new_changes:        boolean;
+    head_branch?:           string;
+    head_sha?:              string;
+    heat_state?:            HeatState;
+    host:                   string;
+    id:                     string;
+    last_heat_activity_at?: string;
+    last_polled:            string;
+    last_updated:           string;
+    mergeable?:             boolean;
+    mergeable_state?:       string;
+    muted:                  boolean;
+    number:                 number;
+    reason:                 string;
+    repo:                   string;
+    review_status?:         string;
+    role:                   PRRole;
+    state:                  string;
+    title:                  string;
+    url:                    string;
+    [property: string]: any;
+}
+
+export interface PRActionResultMessage {
+    action:  string;
+    error?:  string;
+    event:   PRActionResultMessageEvent;
+    id:      string;
+    success: boolean;
+    [property: string]: any;
+}
+
+export enum PRActionResultMessageEvent {
+    PRActionResult = "pr_action_result",
+}
+
+export interface PRsUpdatedMessage {
+    event: PRsUpdatedMessageEvent;
+    prs?:  PRElement[];
+    [property: string]: any;
+}
+
+export enum PRsUpdatedMessageEvent {
+    PrsUpdated = "prs_updated",
+}
+
+export interface PRVisitedMessage {
+    cmd: PRVisitedMessageCmd;
+    id:  string;
+    [property: string]: any;
+}
+
+export enum PRVisitedMessageCmd {
+    PRVisited = "pr_visited",
+}
+
 export interface PtyDesyncMessage {
     event:  PtyDesyncMessageEvent;
     id:     string;
@@ -2652,18 +2661,6 @@ export enum PtyOutputMessageEvent {
     PtyOutput = "pty_output",
 }
 
-export interface PtyResizeMessage {
-    cmd:  PtyResizeMessageCmd;
-    cols: number;
-    id:   string;
-    rows: number;
-    [property: string]: any;
-}
-
-export enum PtyResizeMessageCmd {
-    PtyResize = "pty_resize",
-}
-
 export interface PtyResizedMessage {
     cols:  number;
     event: PtyResizedMessageEvent;
@@ -2674,6 +2671,18 @@ export interface PtyResizedMessage {
 
 export enum PtyResizedMessageEvent {
     PtyResized = "pty_resized",
+}
+
+export interface PtyResizeMessage {
+    cmd:  PtyResizeMessageCmd;
+    cols: number;
+    id:   string;
+    rows: number;
+    [property: string]: any;
+}
+
+export enum PtyResizeMessageCmd {
+    PtyResize = "pty_resize",
 }
 
 export interface QueryAuthorsMessage {
@@ -2887,13 +2896,6 @@ export interface RepoInfo {
     [property: string]: any;
 }
 
-export interface RepoState {
-    collapsed: boolean;
-    muted:     boolean;
-    repo:      string;
-    [property: string]: any;
-}
-
 export interface ReportDispatchMessage {
     cmd:                ReportDispatchMessageCmd;
     report:             string;
@@ -2904,6 +2906,13 @@ export interface ReportDispatchMessage {
 
 export enum ReportDispatchMessageCmd {
     ReportDispatch = "report_dispatch",
+}
+
+export interface RepoState {
+    collapsed: boolean;
+    muted:     boolean;
+    repo:      string;
+    [property: string]: any;
 }
 
 export interface ReposUpdatedMessage {
@@ -3336,6 +3345,16 @@ export enum SessionStateChangedMessageEvent {
     SessionStateChanged = "session_state_changed",
 }
 
+export interface SessionsUpdatedMessage {
+    event:     SessionsUpdatedMessageEvent;
+    sessions?: SessionElement[];
+    [property: string]: any;
+}
+
+export enum SessionsUpdatedMessageEvent {
+    SessionsUpdated = "sessions_updated",
+}
+
 export interface SessionTodosUpdatedMessage {
     event:   SessionTodosUpdatedMessageEvent;
     session: SessionElement;
@@ -3364,16 +3383,6 @@ export interface SessionVisualizedMessage {
 
 export enum SessionVisualizedMessageCmd {
     SessionVisualized = "session_visualized",
-}
-
-export interface SessionsUpdatedMessage {
-    event:     SessionsUpdatedMessageEvent;
-    sessions?: SessionElement[];
-    [property: string]: any;
-}
-
-export enum SessionsUpdatedMessageEvent {
-    SessionsUpdated = "sessions_updated",
 }
 
 export interface SetChiefOfStaffMessage {
@@ -3442,18 +3451,6 @@ export enum SetSettingMessageCmd {
     SetSetting = "set_setting",
 }
 
-export interface SetWorkspaceRankMessage {
-    cmd:                SetWorkspaceRankMessageCmd;
-    next_workspace_id?: string;
-    prev_workspace_id?: string;
-    workspace_id:       string;
-    [property: string]: any;
-}
-
-export enum SetWorkspaceRankMessageCmd {
-    SetWorkspaceRank = "set_workspace_rank",
-}
-
 export interface SettingsUpdatedMessage {
     changed_key?: string;
     error?:       string;
@@ -3465,6 +3462,18 @@ export interface SettingsUpdatedMessage {
 
 export enum SettingsUpdatedMessageEvent {
     SettingsUpdated = "settings_updated",
+}
+
+export interface SetWorkspaceRankMessage {
+    cmd:                SetWorkspaceRankMessageCmd;
+    next_workspace_id?: string;
+    prev_workspace_id?: string;
+    workspace_id:       string;
+    [property: string]: any;
+}
+
+export enum SetWorkspaceRankMessageCmd {
+    SetWorkspaceRank = "set_workspace_rank",
 }
 
 export interface SpawnResultMessage {
@@ -3918,6 +3927,7 @@ export interface Workspace {
     id:        string;
     layout?:   Layout;
     muted:     boolean;
+    pinned:    boolean;
     rank:      string;
     status:    WorkspaceStatus;
     title:     string;
@@ -4118,28 +4128,6 @@ export enum WorkspaceLayoutClosePaneMessageCmd {
     WorkspaceLayoutClosePane = "workspace_layout_close_pane",
 }
 
-export interface WorkspaceLayoutDockPanelMessage {
-    anchor_pane_id: string;
-    cmd:            WorkspaceLayoutDockPanelMessageCmd;
-    edge:           WorkspaceLayoutDockEdge;
-    panel_id:       string;
-    panel_kind:     string;
-    ratio?:         number;
-    workspace_id:   string;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutDockPanelMessageCmd {
-    WorkspaceLayoutDockPanel = "workspace_layout_dock_panel",
-}
-
-export enum WorkspaceLayoutDockEdge {
-    Bottom = "bottom",
-    Left = "left",
-    Right = "right",
-    Top = "top",
-}
-
 export interface WorkspaceLayoutDockTileMessage {
     anchor_pane_id: string;
     cmd:            WorkspaceLayoutDockTileMessageCmd;
@@ -4153,6 +4141,13 @@ export interface WorkspaceLayoutDockTileMessage {
 
 export enum WorkspaceLayoutDockTileMessageCmd {
     WorkspaceLayoutDockTile = "workspace_layout_dock_tile",
+}
+
+export enum WorkspaceLayoutDockEdge {
+    Bottom = "bottom",
+    Left = "left",
+    Right = "right",
+    Top = "top",
 }
 
 export interface WorkspaceLayoutFocusPaneMessage {
@@ -4266,17 +4261,6 @@ export enum WorkspaceLayoutSetSplitRatioMessageCmd {
     WorkspaceLayoutSetSplitRatio = "workspace_layout_set_split_ratio",
 }
 
-export interface WorkspaceLayoutUndockPanelMessage {
-    cmd:          WorkspaceLayoutUndockPanelMessageCmd;
-    panel_id:     string;
-    workspace_id: string;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutUndockPanelMessageCmd {
-    WorkspaceLayoutUndockPanel = "workspace_layout_undock_panel",
-}
-
 export interface WorkspaceLayoutUndockTileMessage {
     cmd:          WorkspaceLayoutUndockTileMessageCmd;
     tile_id:      string;
@@ -4286,6 +4270,16 @@ export interface WorkspaceLayoutUndockTileMessage {
 
 export enum WorkspaceLayoutUndockTileMessageCmd {
     WorkspaceLayoutUndockTile = "workspace_layout_undock_tile",
+}
+
+export interface WorkspaceLayoutUpdatedMessage {
+    event:            WorkspaceLayoutUpdatedMessageEvent;
+    workspace_layout: Layout;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutUpdatedMessageEvent {
+    WorkspaceLayoutUpdated = "workspace_layout_updated",
 }
 
 export interface WorkspaceLayoutUpdateTileMessage {
@@ -4299,42 +4293,6 @@ export interface WorkspaceLayoutUpdateTileMessage {
 
 export enum WorkspaceLayoutUpdateTileMessageCmd {
     WorkspaceLayoutUpdateTile = "workspace_layout_update_tile",
-}
-
-export interface WorkspaceLayoutUpdatedMessage {
-    event:            WorkspaceLayoutUpdatedMessageEvent;
-    workspace_layout: Layout;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutUpdatedMessageEvent {
-    WorkspaceLayoutUpdated = "workspace_layout_updated",
-}
-
-export interface WorkspacePanelContentGetMessage {
-    cmd:          WorkspacePanelContentGetMessageCmd;
-    panel_id:     string;
-    workspace_id: string;
-    [property: string]: any;
-}
-
-export enum WorkspacePanelContentGetMessageCmd {
-    WorkspacePanelContentGet = "workspace_panel_content_get",
-}
-
-export interface WorkspacePanelContentMessage {
-    content:      string;
-    error?:       string;
-    event:        WorkspacePanelContentMessageEvent;
-    panel_id:     string;
-    panel_kind:   string;
-    path:         string;
-    workspace_id: string;
-    [property: string]: any;
-}
-
-export enum WorkspacePanelContentMessageEvent {
-    WorkspacePanelContent = "workspace_panel_content",
 }
 
 export interface WorkspaceRegisteredMessage {
@@ -5356,20 +5314,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("ListBranchesMessage")), null, 2);
     }
 
-    public static toListDispatchMessagesMessage(json: string): ListDispatchMessagesMessage {
-        return cast(JSON.parse(json), r("ListDispatchMessagesMessage"));
-    }
-
-    public static listDispatchMessagesMessageToJson(value: ListDispatchMessagesMessage): string {
-        return JSON.stringify(uncast(value, r("ListDispatchMessagesMessage")), null, 2);
-    }
-
     public static toListDispatchesMessage(json: string): ListDispatchesMessage {
         return cast(JSON.parse(json), r("ListDispatchesMessage"));
     }
 
     public static listDispatchesMessageToJson(value: ListDispatchesMessage): string {
         return JSON.stringify(uncast(value, r("ListDispatchesMessage")), null, 2);
+    }
+
+    public static toListDispatchMessagesMessage(json: string): ListDispatchMessagesMessage {
+        return cast(JSON.parse(json), r("ListDispatchMessagesMessage"));
+    }
+
+    public static listDispatchMessagesMessageToJson(value: ListDispatchMessagesMessage): string {
+        return JSON.stringify(uncast(value, r("ListDispatchMessagesMessage")), null, 2);
     }
 
     public static toListEndpointsMessage(json: string): ListEndpointsMessage {
@@ -5668,52 +5626,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("OpenMarkdownMessage")), null, 2);
     }
 
-    public static toPR(json: string): PR {
-        return cast(JSON.parse(json), r("PR"));
-    }
-
-    public static pRToJson(value: PR): string {
-        return JSON.stringify(uncast(value, r("PR")), null, 2);
-    }
-
-    public static toPRActionResultMessage(json: string): PRActionResultMessage {
-        return cast(JSON.parse(json), r("PRActionResultMessage"));
-    }
-
-    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
-        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
-    }
-
-    public static toPRRole(json: string): PRRole {
-        return cast(JSON.parse(json), r("PRRole"));
-    }
-
-    public static pRRoleToJson(value: PRRole): string {
-        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
-    }
-
-    public static toPRVisitedMessage(json: string): PRVisitedMessage {
-        return cast(JSON.parse(json), r("PRVisitedMessage"));
-    }
-
-    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
-        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
-    }
-
-    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
-        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
-    }
-
-    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
-    }
-
     public static toPathInspection(json: string): PathInspection {
         return cast(JSON.parse(json), r("PathInspection"));
     }
 
     public static pathInspectionToJson(value: PathInspection): string {
         return JSON.stringify(uncast(value, r("PathInspection")), null, 2);
+    }
+
+    public static toPinWorkspaceMessage(json: string): PinWorkspaceMessage {
+        return cast(JSON.parse(json), r("PinWorkspaceMessage"));
+    }
+
+    public static pinWorkspaceMessageToJson(value: PinWorkspaceMessage): string {
+        return JSON.stringify(uncast(value, r("PinWorkspaceMessage")), null, 2);
     }
 
     public static toPluginActionResultMessage(json: string): PluginActionResultMessage {
@@ -5748,6 +5674,46 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PluginsUpdatedMessage")), null, 2);
     }
 
+    public static toPR(json: string): PR {
+        return cast(JSON.parse(json), r("PR"));
+    }
+
+    public static pRToJson(value: PR): string {
+        return JSON.stringify(uncast(value, r("PR")), null, 2);
+    }
+
+    public static toPRActionResultMessage(json: string): PRActionResultMessage {
+        return cast(JSON.parse(json), r("PRActionResultMessage"));
+    }
+
+    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
+        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
+    }
+
+    public static toPRRole(json: string): PRRole {
+        return cast(JSON.parse(json), r("PRRole"));
+    }
+
+    public static pRRoleToJson(value: PRRole): string {
+        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
+    }
+
+    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
+        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
+    }
+
+    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
+    }
+
+    public static toPRVisitedMessage(json: string): PRVisitedMessage {
+        return cast(JSON.parse(json), r("PRVisitedMessage"));
+    }
+
+    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
+        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
+    }
+
     public static toPtyDesyncMessage(json: string): PtyDesyncMessage {
         return cast(JSON.parse(json), r("PtyDesyncMessage"));
     }
@@ -5772,20 +5738,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PtyOutputMessage")), null, 2);
     }
 
-    public static toPtyResizeMessage(json: string): PtyResizeMessage {
-        return cast(JSON.parse(json), r("PtyResizeMessage"));
-    }
-
-    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
-        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
-    }
-
     public static toPtyResizedMessage(json: string): PtyResizedMessage {
         return cast(JSON.parse(json), r("PtyResizedMessage"));
     }
 
     public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
         return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
+    }
+
+    public static toPtyResizeMessage(json: string): PtyResizeMessage {
+        return cast(JSON.parse(json), r("PtyResizeMessage"));
+    }
+
+    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
+        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
     }
 
     public static toQueryAuthorsMessage(json: string): QueryAuthorsMessage {
@@ -5940,20 +5906,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("RepoInfo")), null, 2);
     }
 
-    public static toRepoState(json: string): RepoState {
-        return cast(JSON.parse(json), r("RepoState"));
-    }
-
-    public static repoStateToJson(value: RepoState): string {
-        return JSON.stringify(uncast(value, r("RepoState")), null, 2);
-    }
-
     public static toReportDispatchMessage(json: string): ReportDispatchMessage {
         return cast(JSON.parse(json), r("ReportDispatchMessage"));
     }
 
     public static reportDispatchMessageToJson(value: ReportDispatchMessage): string {
         return JSON.stringify(uncast(value, r("ReportDispatchMessage")), null, 2);
+    }
+
+    public static toRepoState(json: string): RepoState {
+        return cast(JSON.parse(json), r("RepoState"));
+    }
+
+    public static repoStateToJson(value: RepoState): string {
+        return JSON.stringify(uncast(value, r("RepoState")), null, 2);
     }
 
     public static toReposUpdatedMessage(json: string): ReposUpdatedMessage {
@@ -6156,6 +6122,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionStateChangedMessage")), null, 2);
     }
 
+    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
+        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
+    }
+
+    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
+    }
+
     public static toSessionTodosUpdatedMessage(json: string): SessionTodosUpdatedMessage {
         return cast(JSON.parse(json), r("SessionTodosUpdatedMessage"));
     }
@@ -6178,14 +6152,6 @@ export class Convert {
 
     public static sessionVisualizedMessageToJson(value: SessionVisualizedMessage): string {
         return JSON.stringify(uncast(value, r("SessionVisualizedMessage")), null, 2);
-    }
-
-    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
-        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
-    }
-
-    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
     }
 
     public static toSetChiefOfStaffMessage(json: string): SetChiefOfStaffMessage {
@@ -6236,20 +6202,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SetSettingMessage")), null, 2);
     }
 
-    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
-        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
-    }
-
-    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
-        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
-    }
-
     public static toSettingsUpdatedMessage(json: string): SettingsUpdatedMessage {
         return cast(JSON.parse(json), r("SettingsUpdatedMessage"));
     }
 
     public static settingsUpdatedMessageToJson(value: SettingsUpdatedMessage): string {
         return JSON.stringify(uncast(value, r("SettingsUpdatedMessage")), null, 2);
+    }
+
+    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
+        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
+    }
+
+    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
+        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
     }
 
     public static toSpawnResultMessage(json: string): SpawnResultMessage {
@@ -6628,14 +6594,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutDockEdge")), null, 2);
     }
 
-    public static toWorkspaceLayoutDockPanelMessage(json: string): WorkspaceLayoutDockPanelMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutDockPanelMessage"));
-    }
-
-    public static workspaceLayoutDockPanelMessageToJson(value: WorkspaceLayoutDockPanelMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutDockPanelMessage")), null, 2);
-    }
-
     public static toWorkspaceLayoutDockTileMessage(json: string): WorkspaceLayoutDockTileMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutDockTileMessage"));
     }
@@ -6740,28 +6698,12 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutSplitDirection")), null, 2);
     }
 
-    public static toWorkspaceLayoutUndockPanelMessage(json: string): WorkspaceLayoutUndockPanelMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutUndockPanelMessage"));
-    }
-
-    public static workspaceLayoutUndockPanelMessageToJson(value: WorkspaceLayoutUndockPanelMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockPanelMessage")), null, 2);
-    }
-
     public static toWorkspaceLayoutUndockTileMessage(json: string): WorkspaceLayoutUndockTileMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutUndockTileMessage"));
     }
 
     public static workspaceLayoutUndockTileMessageToJson(value: WorkspaceLayoutUndockTileMessage): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockTileMessage")), null, 2);
-    }
-
-    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
-    }
-
-    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
     }
 
     public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
@@ -6772,20 +6714,12 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
     }
 
-    public static toWorkspacePanelContentGetMessage(json: string): WorkspacePanelContentGetMessage {
-        return cast(JSON.parse(json), r("WorkspacePanelContentGetMessage"));
+    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
     }
 
-    public static workspacePanelContentGetMessageToJson(value: WorkspacePanelContentGetMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspacePanelContentGetMessage")), null, 2);
-    }
-
-    public static toWorkspacePanelContentMessage(json: string): WorkspacePanelContentMessage {
-        return cast(JSON.parse(json), r("WorkspacePanelContentMessage"));
-    }
-
-    public static workspacePanelContentMessageToJson(value: WorkspacePanelContentMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspacePanelContentMessage")), null, 2);
+    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
     }
 
     public static toWorkspaceRegisteredMessage(json: string): WorkspaceRegisteredMessage {
@@ -7976,6 +7910,7 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "layout", js: "layout", typ: u(undefined, r("Layout")) },
         { json: "muted", js: "muted", typ: true },
+        { json: "pinned", js: "pinned", typ: true },
         { json: "rank", js: "rank", typ: "" },
         { json: "status", js: "status", typ: r("WorkspaceStatus") },
         { json: "title", js: "title", typ: "" },
@@ -8040,15 +7975,15 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("ListBranchesMessageCmd") },
         { json: "main_repo", js: "main_repo", typ: "" },
     ], "any"),
+    "ListDispatchesMessage": o([
+        { json: "cmd", js: "cmd", typ: r("ListDispatchesMessageCmd") },
+        { json: "source_session_id", js: "source_session_id", typ: "" },
+    ], "any"),
     "ListDispatchMessagesMessage": o([
         { json: "cmd", js: "cmd", typ: r("ListDispatchMessagesMessageCmd") },
         { json: "dispatch_id", js: "dispatch_id", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "unread_only", js: "unread_only", typ: u(undefined, true) },
-    ], "any"),
-    "ListDispatchesMessage": o([
-        { json: "cmd", js: "cmd", typ: r("ListDispatchesMessageCmd") },
-        { json: "source_session_id", js: "source_session_id", typ: "" },
     ], "any"),
     "ListEndpointsMessage": o([
         { json: "cmd", js: "cmd", typ: r("ListEndpointsMessageCmd") },
@@ -8287,49 +8222,6 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
         { json: "session_id", js: "session_id", typ: u(undefined, "") },
     ], "any"),
-    "PR": o([
-        { json: "approved_by_me", js: "approved_by_me", typ: true },
-        { json: "author", js: "author", typ: "" },
-        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
-        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
-        { json: "details_fetched", js: "details_fetched", typ: true },
-        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
-        { json: "has_new_changes", js: "has_new_changes", typ: true },
-        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
-        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
-        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
-        { json: "host", js: "host", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
-        { json: "last_polled", js: "last_polled", typ: "" },
-        { json: "last_updated", js: "last_updated", typ: "" },
-        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
-        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
-        { json: "muted", js: "muted", typ: true },
-        { json: "number", js: "number", typ: 0 },
-        { json: "reason", js: "reason", typ: "" },
-        { json: "repo", js: "repo", typ: "" },
-        { json: "review_status", js: "review_status", typ: u(undefined, "") },
-        { json: "role", js: "role", typ: r("PRRole") },
-        { json: "state", js: "state", typ: "" },
-        { json: "title", js: "title", typ: "" },
-        { json: "url", js: "url", typ: "" },
-    ], "any"),
-    "PRActionResultMessage": o([
-        { json: "action", js: "action", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "success", js: "success", typ: true },
-    ], "any"),
-    "PRVisitedMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
-        { json: "id", js: "id", typ: "" },
-    ], "any"),
-    "PRsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
-        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
-    ], "any"),
     "PathInspection": o([
         { json: "exists", js: "exists", typ: true },
         { json: "home_path", js: "home_path", typ: u(undefined, "") },
@@ -8337,6 +8229,11 @@ const typeMap: any = {
         { json: "is_directory", js: "is_directory", typ: true },
         { json: "repo_root", js: "repo_root", typ: u(undefined, "") },
         { json: "resolved_path", js: "resolved_path", typ: "" },
+    ], "any"),
+    "PinWorkspaceMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PinWorkspaceMessageCmd") },
+        { json: "pinned", js: "pinned", typ: true },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "PluginActionResultMessage": o([
         { json: "action", js: "action", typ: "" },
@@ -8382,6 +8279,49 @@ const typeMap: any = {
         { json: "running", js: "running", typ: true },
         { json: "version", js: "version", typ: "" },
     ], "any"),
+    "PR": o([
+        { json: "approved_by_me", js: "approved_by_me", typ: true },
+        { json: "author", js: "author", typ: "" },
+        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
+        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
+        { json: "details_fetched", js: "details_fetched", typ: true },
+        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
+        { json: "has_new_changes", js: "has_new_changes", typ: true },
+        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
+        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
+        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
+        { json: "host", js: "host", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
+        { json: "last_polled", js: "last_polled", typ: "" },
+        { json: "last_updated", js: "last_updated", typ: "" },
+        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
+        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
+        { json: "muted", js: "muted", typ: true },
+        { json: "number", js: "number", typ: 0 },
+        { json: "reason", js: "reason", typ: "" },
+        { json: "repo", js: "repo", typ: "" },
+        { json: "review_status", js: "review_status", typ: u(undefined, "") },
+        { json: "role", js: "role", typ: r("PRRole") },
+        { json: "state", js: "state", typ: "" },
+        { json: "title", js: "title", typ: "" },
+        { json: "url", js: "url", typ: "" },
+    ], "any"),
+    "PRActionResultMessage": o([
+        { json: "action", js: "action", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "PRsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
+        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
+    ], "any"),
+    "PRVisitedMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
+        { json: "id", js: "id", typ: "" },
+    ], "any"),
     "PtyDesyncMessage": o([
         { json: "event", js: "event", typ: r("PtyDesyncMessageEvent") },
         { json: "id", js: "id", typ: "" },
@@ -8399,15 +8339,15 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "seq", js: "seq", typ: 0 },
     ], "any"),
-    "PtyResizeMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
-        { json: "cols", js: "cols", typ: 0 },
-        { json: "id", js: "id", typ: "" },
-        { json: "rows", js: "rows", typ: 0 },
-    ], "any"),
     "PtyResizedMessage": o([
         { json: "cols", js: "cols", typ: 0 },
         { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "rows", js: "rows", typ: 0 },
+    ], "any"),
+    "PtyResizeMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
+        { json: "cols", js: "cols", typ: 0 },
         { json: "id", js: "id", typ: "" },
         { json: "rows", js: "rows", typ: 0 },
     ], "any"),
@@ -8518,16 +8458,16 @@ const typeMap: any = {
         { json: "repo", js: "repo", typ: "" },
         { json: "worktrees", js: "worktrees", typ: a(r("WorktreeElement")) },
     ], "any"),
-    "RepoState": o([
-        { json: "collapsed", js: "collapsed", typ: true },
-        { json: "muted", js: "muted", typ: true },
-        { json: "repo", js: "repo", typ: "" },
-    ], "any"),
     "ReportDispatchMessage": o([
         { json: "cmd", js: "cmd", typ: r("ReportDispatchMessageCmd") },
         { json: "report", js: "report", typ: "" },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "structured_report", js: "structured_report", typ: u(undefined, r("Report")) },
+    ], "any"),
+    "RepoState": o([
+        { json: "collapsed", js: "collapsed", typ: true },
+        { json: "muted", js: "muted", typ: true },
+        { json: "repo", js: "repo", typ: "" },
     ], "any"),
     "ReposUpdatedMessage": o([
         { json: "event", js: "event", typ: r("ReposUpdatedMessageEvent") },
@@ -8818,6 +8758,10 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("SessionStateChangedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
     ], "any"),
+    "SessionsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
+        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
+    ], "any"),
     "SessionTodosUpdatedMessage": o([
         { json: "event", js: "event", typ: r("SessionTodosUpdatedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
@@ -8829,10 +8773,6 @@ const typeMap: any = {
     "SessionVisualizedMessage": o([
         { json: "cmd", js: "cmd", typ: r("SessionVisualizedMessageCmd") },
         { json: "id", js: "id", typ: "" },
-    ], "any"),
-    "SessionsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
-        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
     ], "any"),
     "SetChiefOfStaffMessage": o([
         { json: "chief_of_staff", js: "chief_of_staff", typ: true },
@@ -8864,18 +8804,18 @@ const typeMap: any = {
         { json: "key", js: "key", typ: "" },
         { json: "value", js: "value", typ: "" },
     ], "any"),
-    "SetWorkspaceRankMessage": o([
-        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
-        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
-        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
     "SettingsUpdatedMessage": o([
         { json: "changed_key", js: "changed_key", typ: u(undefined, "") },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("SettingsUpdatedMessageEvent") },
         { json: "settings", js: "settings", typ: u(undefined, m("any")) },
         { json: "success", js: "success", typ: u(undefined, true) },
+    ], "any"),
+    "SetWorkspaceRankMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
+        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
+        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "SpawnResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
@@ -9166,6 +9106,7 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "layout", js: "layout", typ: u(undefined, r("Layout")) },
         { json: "muted", js: "muted", typ: true },
+        { json: "pinned", js: "pinned", typ: true },
         { json: "rank", js: "rank", typ: "" },
         { json: "status", js: "status", typ: r("WorkspaceStatus") },
         { json: "title", js: "title", typ: "" },
@@ -9279,15 +9220,6 @@ const typeMap: any = {
         { json: "pane_id", js: "pane_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
-    "WorkspaceLayoutDockPanelMessage": o([
-        { json: "anchor_pane_id", js: "anchor_pane_id", typ: "" },
-        { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutDockPanelMessageCmd") },
-        { json: "edge", js: "edge", typ: r("WorkspaceLayoutDockEdge") },
-        { json: "panel_id", js: "panel_id", typ: "" },
-        { json: "panel_kind", js: "panel_kind", typ: "" },
-        { json: "ratio", js: "ratio", typ: u(undefined, 3.14) },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
     "WorkspaceLayoutDockTileMessage": o([
         { json: "anchor_pane_id", js: "anchor_pane_id", typ: "" },
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutDockTileMessageCmd") },
@@ -9358,39 +9290,20 @@ const typeMap: any = {
         { json: "split_id", js: "split_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
-    "WorkspaceLayoutUndockPanelMessage": o([
-        { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUndockPanelMessageCmd") },
-        { json: "panel_id", js: "panel_id", typ: "" },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
     "WorkspaceLayoutUndockTileMessage": o([
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUndockTileMessageCmd") },
         { json: "tile_id", js: "tile_id", typ: "" },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
-    "WorkspaceLayoutUpdateTileMessage": o([
-        { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUpdateTileMessageCmd") },
-        { json: "request_id", js: "request_id", typ: "" },
-        { json: "tile_id", js: "tile_id", typ: "" },
-        { json: "tile_params", js: "tile_params", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "WorkspaceLayoutUpdatedMessage": o([
         { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
         { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
     ], "any"),
-    "WorkspacePanelContentGetMessage": o([
-        { json: "cmd", js: "cmd", typ: r("WorkspacePanelContentGetMessageCmd") },
-        { json: "panel_id", js: "panel_id", typ: "" },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
-    "WorkspacePanelContentMessage": o([
-        { json: "content", js: "content", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("WorkspacePanelContentMessageEvent") },
-        { json: "panel_id", js: "panel_id", typ: "" },
-        { json: "panel_kind", js: "panel_kind", typ: "" },
-        { json: "path", js: "path", typ: "" },
+    "WorkspaceLayoutUpdateTileMessage": o([
+        { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUpdateTileMessageCmd") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "tile_id", js: "tile_id", typ: "" },
+        { json: "tile_params", js: "tile_params", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "WorkspaceRegisteredMessage": o([
@@ -9759,11 +9672,11 @@ const typeMap: any = {
     "ListBranchesMessageCmd": [
         "list_branches",
     ],
-    "ListDispatchMessagesMessageCmd": [
-        "list_dispatch_messages",
-    ],
     "ListDispatchesMessageCmd": [
         "list_dispatches",
+    ],
+    "ListDispatchMessagesMessageCmd": [
+        "list_dispatch_messages",
     ],
     "ListEndpointsMessageCmd": [
         "list_endpoints",
@@ -9858,20 +9771,23 @@ const typeMap: any = {
     "OpenMarkdownMessageCmd": [
         "open_markdown",
     ],
-    "PRActionResultMessageEvent": [
-        "pr_action_result",
-    ],
-    "PRVisitedMessageCmd": [
-        "pr_visited",
-    ],
-    "PRsUpdatedMessageEvent": [
-        "prs_updated",
+    "PinWorkspaceMessageCmd": [
+        "pin_workspace",
     ],
     "PluginActionResultMessageEvent": [
         "plugin_action_result",
     ],
     "PluginsUpdatedMessageEvent": [
         "plugins_updated",
+    ],
+    "PRActionResultMessageEvent": [
+        "pr_action_result",
+    ],
+    "PRsUpdatedMessageEvent": [
+        "prs_updated",
+    ],
+    "PRVisitedMessageCmd": [
+        "pr_visited",
     ],
     "PtyDesyncMessageEvent": [
         "pty_desync",
@@ -9882,11 +9798,11 @@ const typeMap: any = {
     "PtyOutputMessageEvent": [
         "pty_output",
     ],
-    "PtyResizeMessageCmd": [
-        "pty_resize",
-    ],
     "PtyResizedMessageEvent": [
         "pty_resized",
+    ],
+    "PtyResizeMessageCmd": [
+        "pty_resize",
     ],
     "QueryAuthorsMessageCmd": [
         "query_authors",
@@ -10009,6 +9925,9 @@ const typeMap: any = {
     "SessionStateChangedMessageEvent": [
         "session_state_changed",
     ],
+    "SessionsUpdatedMessageEvent": [
+        "sessions_updated",
+    ],
     "SessionTodosUpdatedMessageEvent": [
         "session_todos_updated",
     ],
@@ -10017,9 +9936,6 @@ const typeMap: any = {
     ],
     "SessionVisualizedMessageCmd": [
         "session_visualized",
-    ],
-    "SessionsUpdatedMessageEvent": [
-        "sessions_updated",
     ],
     "SetChiefOfStaffMessageCmd": [
         "set_chief_of_staff",
@@ -10039,11 +9955,11 @@ const typeMap: any = {
     "SetSettingMessageCmd": [
         "set_setting",
     ],
-    "SetWorkspaceRankMessageCmd": [
-        "set_workspace_rank",
-    ],
     "SettingsUpdatedMessageEvent": [
         "settings_updated",
+    ],
+    "SetWorkspaceRankMessageCmd": [
+        "set_workspace_rank",
     ],
     "SpawnResultMessageEvent": [
         "spawn_result",
@@ -10166,17 +10082,14 @@ const typeMap: any = {
     "WorkspaceLayoutClosePaneMessageCmd": [
         "workspace_layout_close_pane",
     ],
-    "WorkspaceLayoutDockPanelMessageCmd": [
-        "workspace_layout_dock_panel",
+    "WorkspaceLayoutDockTileMessageCmd": [
+        "workspace_layout_dock_tile",
     ],
     "WorkspaceLayoutDockEdge": [
         "bottom",
         "left",
         "right",
         "top",
-    ],
-    "WorkspaceLayoutDockTileMessageCmd": [
-        "workspace_layout_dock_tile",
     ],
     "WorkspaceLayoutFocusPaneMessageCmd": [
         "workspace_layout_focus_pane",
@@ -10202,23 +10115,14 @@ const typeMap: any = {
     "WorkspaceLayoutSetSplitRatioMessageCmd": [
         "workspace_layout_set_split_ratio",
     ],
-    "WorkspaceLayoutUndockPanelMessageCmd": [
-        "workspace_layout_undock_panel",
-    ],
     "WorkspaceLayoutUndockTileMessageCmd": [
         "workspace_layout_undock_tile",
-    ],
-    "WorkspaceLayoutUpdateTileMessageCmd": [
-        "workspace_layout_update_tile",
     ],
     "WorkspaceLayoutUpdatedMessageEvent": [
         "workspace_layout_updated",
     ],
-    "WorkspacePanelContentGetMessageCmd": [
-        "workspace_panel_content_get",
-    ],
-    "WorkspacePanelContentMessageEvent": [
-        "workspace_panel_content",
+    "WorkspaceLayoutUpdateTileMessageCmd": [
+        "workspace_layout_update_tile",
     ],
     "WorkspaceRegisteredMessageEvent": [
         "workspace_registered",

--- a/app/src/utils/workspaceViewModels.test.ts
+++ b/app/src/utils/workspaceViewModels.test.ts
@@ -82,6 +82,8 @@ describe('workspaceViewModels', () => {
         directory: '/repo/pending',
         status: 'launching',
         muted: false,
+        pinned: false,
+        rank: undefined,
         endpointId: undefined,
         sessions: [],
         children: [],

--- a/app/src/utils/workspaceViewModels.ts
+++ b/app/src/utils/workspaceViewModels.ts
@@ -22,6 +22,7 @@ export interface WorkspaceViewWorkspace {
   directory: string;
   status?: string;
   muted?: boolean;
+  pinned?: boolean;
   rank?: string;
   endpointId?: string;
   endpoint_id?: string;
@@ -56,6 +57,7 @@ export interface WorkspaceWithSessions<TSession extends WorkspaceViewSession = W
   directory: string;
   status?: string;
   muted?: boolean;
+  pinned?: boolean;
   rank?: string;
   endpointId?: string;
   sessions: TSession[];
@@ -196,6 +198,7 @@ function toWorkspaceViewModel<TSession extends WorkspaceViewSession>(
     directory: workspace.directory,
     status: workspace.status,
     muted: workspace.muted ?? false,
+    pinned: workspace.pinned ?? false,
     rank: workspace.rank,
     endpointId: workspaceEndpointId(workspace) || (sessions[0] ? sessionEndpointId(sessions[0]) : undefined),
     sessions,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1938,6 +1938,13 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 			return
 		}
 		d.sendOK(conn)
+	case protocol.CmdPinWorkspace:
+		m := msg.(*protocol.PinWorkspaceMessage)
+		if _, errMsg := d.setWorkspacePinned(m.WorkspaceID, m.Pinned); errMsg != "" {
+			d.sendError(conn, errMsg)
+			return
+		}
+		d.sendOK(conn)
 	case protocol.CmdCollapseRepo:
 		d.handleCollapseRepo(conn, msg.(*protocol.CollapseRepoMessage))
 	case protocol.CmdQueryRepos:
@@ -2022,7 +2029,7 @@ func (d *Daemon) handleRegister(conn net.Conn, msg *protocol.RegisterMessage) {
 	// first forever. A re-register carries the stored key forward.
 	workspaceRank := d.resolveWorkspaceRank(existingWS)
 	d.store.AddWorkspace(&protocol.Workspace{ID: workspaceID, Title: workspaceTitle, Directory: session.Directory, Status: protocol.WorkspaceStatusLaunching, Rank: workspaceRank})
-	d.workspaces.register(workspaceID, workspaceTitle, session.Directory, workspaceRank, false)
+	d.workspaces.register(workspaceID, workspaceTitle, session.Directory, workspaceRank, false, false)
 	d.store.Add(session)
 	if resumeSessionID := d.consumePendingResumeSessionID(session.ID); resumeSessionID != "" {
 		d.store.SetResumeSessionID(session.ID, resumeSessionID)
@@ -3240,7 +3247,7 @@ func (d *Daemon) handleInjectTestSession(conn net.Conn, msg *protocol.InjectTest
 			Rank:      workspaceRank,
 		})
 	}
-	d.workspaces.register(workspaceID, msg.Session.Label, msg.Session.Directory, workspaceRank, false)
+	d.workspaces.register(workspaceID, msg.Session.Label, msg.Session.Directory, workspaceRank, false, false)
 
 	// Add session directly to store
 	d.store.Add(&msg.Session)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -438,7 +438,7 @@ func TestDaemon_ReseedWorkspaceStatusesAfterRecovery(t *testing.T) {
 	cwd := t.TempDir()
 
 	d.store.AddWorkspace(&protocol.Workspace{ID: workspaceID, Title: "Reseed", Directory: cwd})
-	d.workspaces.register(workspaceID, "Reseed", cwd, "a0", false)
+	d.workspaces.register(workspaceID, "Reseed", cwd, "a0", false, false)
 	nowStr := string(protocol.TimestampNow())
 	d.store.Add(&protocol.Session{
 		ID:             sessionID,
@@ -1149,7 +1149,7 @@ func TestDaemon_PruneSessionsWithoutPTY_RemovesReapedWorkspaceLayout(t *testing.
 		LastSeen:       now,
 		WorkspaceID:    workspaceID,
 	})
-	d.workspaces.register(workspaceID, "Stale", "/tmp/stale", "", false)
+	d.workspaces.register(workspaceID, "Stale", "/tmp/stale", "", false, false)
 	d.workspaces.associateSession(sessionID, workspaceID, sessionID)
 	if err := d.store.SaveWorkspaceLayout(workspacelayout.WorkspaceLayout{
 		WorkspaceID:  workspaceID,
@@ -1204,7 +1204,7 @@ func TestDaemon_PruneSessionsWithoutPTY_KeepsTileOnlyWorkspace(t *testing.T) {
 		LastSeen:       now,
 		WorkspaceID:    workspaceID,
 	})
-	d.workspaces.register(workspaceID, "Stale Tile", "/tmp/stale-tile", "", false)
+	d.workspaces.register(workspaceID, "Stale Tile", "/tmp/stale-tile", "", false, false)
 	d.workspaces.associateSession(sessionID, workspaceID, sessionID)
 	if err := d.store.SaveWorkspaceLayout(workspacelayout.WorkspaceLayout{
 		WorkspaceID:  workspaceID,
@@ -1755,7 +1755,7 @@ func (b *fakeReviewLoopBackend) SetScrollback(sessionID, text string) {
 func addTestWorkspace(d *Daemon, id, directory string) {
 	rank := d.resolveWorkspaceRank(d.store.GetWorkspace(id))
 	d.store.AddWorkspace(&protocol.Workspace{ID: id, Title: id, Directory: directory, Status: protocol.WorkspaceStatusLaunching, Rank: rank})
-	d.workspaces.register(id, id, directory, rank, false)
+	d.workspaces.register(id, id, directory, rank, false, false)
 }
 
 func TestDaemon_HandleSpawnSession_UsesStoredResumeSessionIDForRecoverableClaudeSession(t *testing.T) {

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -923,6 +923,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleMuteAuthorWS(msg.(*protocol.MuteAuthorMessage))
 	case protocol.CmdMuteWorkspace:
 		d.handleMuteWorkspaceWS(client, msg.(*protocol.MuteWorkspaceMessage))
+	case protocol.CmdPinWorkspace:
+		d.handlePinWorkspaceWS(client, msg.(*protocol.PinWorkspaceMessage))
 	case protocol.CmdRefreshPRs:
 		d.handleRefreshPRsWS(client)
 	case protocol.CmdFetchPRDetails:

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -21,6 +21,7 @@ type workspaceEntry struct {
 	directory string
 	status    protocol.WorkspaceStatus
 	muted     bool
+	pinned    bool
 	// rank is the fractional sidebar-order key; the store is the durable
 	// authority. Empty until a workspace is seeded or loaded from store.
 	rank string
@@ -50,7 +51,7 @@ func newWorkspaceRegistry() *workspaceRegistry {
 // from the incoming value when it is empty: a re-register that omits the rank
 // (or the caller passes the stored rank back) leaves a user reorder intact. The
 // caller seeds rank for brand-new workspaces before this runs.
-func (r *workspaceRegistry) register(id, title, directory, rank string, muted bool) (protocol.Workspace, bool) {
+func (r *workspaceRegistry) register(id, title, directory, rank string, muted, pinned bool) (protocol.Workspace, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -66,6 +67,7 @@ func (r *workspaceRegistry) register(id, title, directory, rank string, muted bo
 	entry.title = title
 	entry.directory = directory
 	entry.muted = muted
+	entry.pinned = pinned
 	if rank != "" {
 		entry.rank = rank
 	}
@@ -105,6 +107,17 @@ func (r *workspaceRegistry) setMuted(id string, muted bool) (protocol.Workspace,
 		return protocol.Workspace{}, false
 	}
 	entry.muted = muted
+	return snapshotEntry(entry), true
+}
+
+func (r *workspaceRegistry) setPinned(id string, pinned bool) (protocol.Workspace, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, ok := r.workspaces[id]
+	if !ok {
+		return protocol.Workspace{}, false
+	}
+	entry.pinned = pinned
 	return snapshotEntry(entry), true
 }
 
@@ -266,6 +279,7 @@ func snapshotEntry(e *workspaceEntry) protocol.Workspace {
 		Directory: e.directory,
 		Status:    e.status,
 		Muted:     e.muted,
+		Pinned:    e.pinned,
 		Rank:      e.rank,
 	}
 }
@@ -410,6 +424,7 @@ func (d *Daemon) handleRegisterWorkspace(client *wsClient, msg *protocol.Registe
 	}
 	existing := d.store.GetWorkspace(id)
 	muted := existing != nil && existing.Muted
+	pinned := existing != nil && existing.Pinned
 	// Preserve a user-applied rename across re-registration. A reconnect or
 	// retry can re-register the same workspace id with the old derived title;
 	// the only authoritative way to change a title is the rename_workspace
@@ -419,7 +434,7 @@ func (d *Daemon) handleRegisterWorkspace(client *wsClient, msg *protocol.Registe
 		title = existing.Title
 	}
 	rank := d.resolveWorkspaceRank(existing)
-	snapshot, isNew := d.workspaces.register(id, title, directory, rank, muted)
+	snapshot, isNew := d.workspaces.register(id, title, directory, rank, muted, pinned)
 	d.store.AddWorkspace(&snapshot)
 	// Make workspace directories available in the recent-locations picker.
 	d.store.UpsertRecentLocation(directory)
@@ -489,6 +504,42 @@ func (d *Daemon) setWorkspaceMuted(workspaceID string, muted bool) (protocol.Wor
 	if !ok {
 		_ = d.store.SetWorkspaceMuted(id, current.Muted)
 		return protocol.Workspace{}, "workspace disappeared while updating mute state"
+	}
+	d.wsHub.Broadcast(&protocol.WebSocketEvent{
+		Event:     protocol.EventWorkspaceStateChanged,
+		Workspace: &snapshot,
+	})
+	return snapshot, ""
+}
+
+func (d *Daemon) handlePinWorkspaceWS(client *wsClient, msg *protocol.PinWorkspaceMessage) {
+	if _, errMsg := d.setWorkspacePinned(msg.WorkspaceID, msg.Pinned); errMsg != "" {
+		d.sendCommandError(client, protocol.CmdPinWorkspace, errMsg)
+	}
+}
+
+func (d *Daemon) setWorkspacePinned(workspaceID string, pinned bool) (protocol.Workspace, string) {
+	id := strings.TrimSpace(workspaceID)
+	if id == "" {
+		return protocol.Workspace{}, "missing workspace_id"
+	}
+	if d.workspaces == nil {
+		return protocol.Workspace{}, "workspace registry unavailable"
+	}
+	current, ok := d.workspaces.snapshot(id)
+	if !ok {
+		return protocol.Workspace{}, "workspace not found"
+	}
+	if current.Pinned == pinned {
+		return current, ""
+	}
+	if err := d.store.SetWorkspacePinned(id, pinned); err != nil {
+		return protocol.Workspace{}, "persist workspace pin: " + err.Error()
+	}
+	snapshot, ok := d.workspaces.setPinned(id, pinned)
+	if !ok {
+		_ = d.store.SetWorkspacePinned(id, current.Pinned)
+		return protocol.Workspace{}, "workspace disappeared while updating pin state"
 	}
 	d.wsHub.Broadcast(&protocol.WebSocketEvent{
 		Event:     protocol.EventWorkspaceStateChanged,
@@ -582,6 +633,7 @@ func (d *Daemon) loadWorkspacesFromStore() []string {
 			// content such as docked tiles.
 			_, registered := d.workspaces.snapshot(ws.ID)
 			if !registered &&
+				!ws.Pinned &&
 				!d.workspaceHasPendingSpawn(ws.ID) &&
 				!d.workspaceHasSessionlessContent(ws.ID) {
 				// loadWorkspacesFromStore runs during Start() before the compaction
@@ -598,7 +650,7 @@ func (d *Daemon) loadWorkspacesFromStore() []string {
 				continue
 			}
 		}
-		d.workspaces.register(ws.ID, ws.Title, ws.Directory, ws.Rank, ws.Muted)
+		d.workspaces.register(ws.ID, ws.Title, ws.Directory, ws.Rank, ws.Muted, ws.Pinned)
 	}
 	for _, session := range d.store.List("") {
 		if session == nil {
@@ -691,10 +743,12 @@ func (d *Daemon) dissociateSessionFromWorkspace(sessionID string) {
 		return
 	}
 	if remaining == 0 {
-		// A workspace whose last session leaves normally tears down. Visible
-		// sessionless content keeps it alive. This runs before the session pane
-		// is removed, so a retained tile is still visible in the stored layout.
-		if d.workspaceHasSessionlessContent(workspaceID) {
+		// A workspace whose last session leaves normally tears down. Pinned
+		// workspaces and visible sessionless content keep it alive. This runs
+		// before the session pane is removed, so a retained tile is still
+		// visible in the stored layout.
+		snap, _ := d.workspaces.snapshot(workspaceID)
+		if snap.Pinned || d.workspaceHasSessionlessContent(workspaceID) {
 			updated, changed := d.recomputeWorkspaceStatus(workspaceID)
 			if !changed {
 				updated, _ = d.workspaces.snapshot(workspaceID)

--- a/internal/daemon/workspace_context_test.go
+++ b/internal/daemon/workspace_context_test.go
@@ -18,7 +18,7 @@ func setupWorkspaceContextSession(t *testing.T, d *Daemon, sessionID, workspaceI
 		Title:     workspaceID,
 		Directory: t.TempDir(),
 	})
-	d.workspaces.register(workspaceID, workspaceID, t.TempDir(), "", false)
+	d.workspaces.register(workspaceID, workspaceID, t.TempDir(), "", false, false)
 	now := string(protocol.TimestampNow())
 	d.store.Add(&protocol.Session{
 		ID:             sessionID,

--- a/internal/daemon/workspace_test.go
+++ b/internal/daemon/workspace_test.go
@@ -126,7 +126,7 @@ func TestRollupWorkspaceStatus_PriorityOrdering(t *testing.T) {
 
 func TestWorkspaceRegistry_RegisterUnregister(t *testing.T) {
 	r := newWorkspaceRegistry()
-	snapshot, isNew := r.register("ws1", "Workspace 1", "/repo", "", false)
+	snapshot, isNew := r.register("ws1", "Workspace 1", "/repo", "", false, false)
 	if !isNew {
 		t.Fatal("first register should be new")
 	}
@@ -137,7 +137,7 @@ func TestWorkspaceRegistry_RegisterUnregister(t *testing.T) {
 		t.Fatalf("initial status = %q, want idle", snapshot.Status)
 	}
 
-	_, isNew = r.register("ws1", "Renamed", "/repo", "", false)
+	_, isNew = r.register("ws1", "Renamed", "/repo", "", false, false)
 	if isNew {
 		t.Fatal("second register should not be new")
 	}
@@ -156,8 +156,8 @@ func TestWorkspaceRegistry_RegisterUnregister(t *testing.T) {
 
 func TestWorkspaceRegistry_AssociateAndDissociate(t *testing.T) {
 	r := newWorkspaceRegistry()
-	r.register("ws1", "ws", "/repo", "", false)
-	r.register("ws2", "ws", "/repo", "", false)
+	r.register("ws1", "ws", "/repo", "", false, false)
+	r.register("ws2", "ws", "/repo", "", false, false)
 
 	if !r.associateSession("s1", "ws1", "Session 1") {
 		t.Fatal("associate should succeed")
@@ -226,7 +226,7 @@ func TestDissociateLastSessionUnregistersWorkspace(t *testing.T) {
 
 func TestWorkspaceRegistry_UnregisterCleansSessionLinks(t *testing.T) {
 	r := newWorkspaceRegistry()
-	r.register("ws1", "ws", "/repo", "", false)
+	r.register("ws1", "ws", "/repo", "", false, false)
 	r.associateSession("s1", "ws1", "Session 1")
 	r.associateSession("s2", "ws1", "Session 2")
 
@@ -729,5 +729,122 @@ func TestAssociateSessionWithWorkspace_PersistsToStore(t *testing.T) {
 	got = d.store.Get("s1")
 	if got != nil {
 		t.Fatalf("session should be removed instead of workspace_id being cleared: %+v", got)
+	}
+}
+
+func TestPinnedWorkspaceSurvivesFinalSessionClose(t *testing.T) {
+	d := newDaemonForTest(t)
+	cap := captureBroadcasts(d)
+	now := string(protocol.TimestampNow())
+
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: "ws1", Title: "ws", Directory: "/repo",
+	})
+	d.setWorkspacePinned("ws1", true)
+
+	d.store.Add(&protocol.Session{
+		ID: "s1", Label: "s1", Agent: protocol.SessionAgentCodex, Directory: "/repo",
+		State: protocol.SessionStateIdle, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	d.associateSessionWithWorkspace("s1", "ws1")
+
+	d.dissociateSessionFromWorkspace("s1")
+
+	if _, ok := d.workspaces.snapshot("ws1"); !ok {
+		t.Fatal("pinned workspace was removed after last session departed")
+	}
+
+	events := cap.snapshot()
+	for _, e := range events {
+		if e.Event == protocol.EventWorkspaceUnregistered && e.Workspace != nil && e.Workspace.ID == "ws1" {
+			t.Fatal("pinned workspace emitted workspace_unregistered")
+		}
+	}
+}
+
+func TestUnpinnedWorkspaceRemovedOnFinalSessionClose(t *testing.T) {
+	d := newDaemonForTest(t)
+	now := string(protocol.TimestampNow())
+
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: "ws1", Title: "ws", Directory: "/repo",
+	})
+
+	d.store.Add(&protocol.Session{
+		ID: "s1", Label: "s1", Agent: protocol.SessionAgentCodex, Directory: "/repo",
+		State: protocol.SessionStateIdle, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	d.associateSessionWithWorkspace("s1", "ws1")
+
+	d.dissociateSessionFromWorkspace("s1")
+
+	if _, ok := d.workspaces.snapshot("ws1"); ok {
+		t.Fatal("unpinned workspace should be removed after last session departed")
+	}
+}
+
+func TestPinnedEmptyWorkspaceSurvivesStartupCleanup(t *testing.T) {
+	d := newDaemonForTest(t)
+
+	d.store.AddWorkspace(&protocol.Workspace{
+		ID: "ws-pinned", Title: "Pinned", Directory: "/repo", Pinned: true,
+	})
+	d.store.AddWorkspace(&protocol.Workspace{
+		ID: "ws-unpinned", Title: "Unpinned", Directory: "/repo",
+	})
+
+	reaped := d.loadWorkspacesFromStore()
+
+	if _, ok := d.workspaces.snapshot("ws-pinned"); !ok {
+		t.Fatal("pinned empty workspace was reaped during startup load")
+	}
+	if _, ok := d.workspaces.snapshot("ws-unpinned"); ok {
+		t.Fatal("unpinned empty workspace should be reaped during startup load")
+	}
+
+	found := false
+	for _, id := range reaped {
+		if id == "ws-unpinned" {
+			found = true
+		}
+		if id == "ws-pinned" {
+			t.Fatal("pinned workspace should not be in reaped list")
+		}
+	}
+	if !found {
+		t.Fatal("unpinned workspace should be in reaped list")
+	}
+}
+
+func TestSetWorkspacePinned_PersistsAndBroadcasts(t *testing.T) {
+	d := newDaemonForTest(t)
+	cap := captureBroadcasts(d)
+
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: "ws1", Title: "ws", Directory: "/repo",
+	})
+
+	snap, errMsg := d.setWorkspacePinned("ws1", true)
+	if errMsg != "" {
+		t.Fatalf("setWorkspacePinned: %s", errMsg)
+	}
+	if !snap.Pinned {
+		t.Fatal("snapshot after pin should have Pinned=true")
+	}
+
+	stored := d.store.GetWorkspace("ws1")
+	if stored == nil || !stored.Pinned {
+		t.Fatalf("store should persist pinned state: %+v", stored)
+	}
+
+	events := cap.snapshot()
+	var foundStateChanged bool
+	for _, e := range events {
+		if e.Event == protocol.EventWorkspaceStateChanged && e.Workspace != nil && e.Workspace.ID == "ws1" && e.Workspace.Pinned {
+			foundStateChanged = true
+		}
+	}
+	if !foundStateChanged {
+		t.Fatal("expected workspace_state_changed broadcast with Pinned=true")
 	}
 }

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -82,6 +82,7 @@ const (
 	CmdSessionSelected                       = "session_selected"
 	CmdWorkspaceSelected                     = "workspace_selected"
 	CmdMuteWorkspace                         = "mute_workspace"
+	CmdPinWorkspace                          = "pin_workspace"
 	CmdQueryPRs                              = "query_prs"
 	CmdMutePR                                = "mute_pr"
 	CmdMuteRepo                              = "mute_repo"
@@ -635,6 +636,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		var msg MuteWorkspaceMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdPinWorkspace:
+		var msg PinWorkspaceMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, fmt.Errorf("unmarshal pin_workspace: %w", err)
 		}
 		return peek.Cmd, &msg, nil
 

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2390,6 +2390,17 @@ type PathInspection struct {
 	ResolvedPath string `json:"resolved_path"`
 }
 
+type PinWorkspaceMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Pinned corresponds to the JSON schema field "pinned".
+	Pinned bool `json:"pinned"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID string `json:"workspace_id"`
+}
+
 type PluginActionResultMessage struct {
 	// Action corresponds to the JSON schema field "action".
 	Action string `json:"action"`
@@ -4142,6 +4153,9 @@ type Workspace struct {
 	// Muted corresponds to the JSON schema field "muted".
 	Muted bool `json:"muted"`
 
+	// Pinned corresponds to the JSON schema field "pinned".
+	Pinned bool `json:"pinned"`
+
 	// Rank corresponds to the JSON schema field "rank".
 	Rank string `json:"rank"`
 
@@ -4430,29 +4444,6 @@ const WorkspaceLayoutDockEdgeLeft WorkspaceLayoutDockEdge = "left"
 const WorkspaceLayoutDockEdgeRight WorkspaceLayoutDockEdge = "right"
 const WorkspaceLayoutDockEdgeTop WorkspaceLayoutDockEdge = "top"
 
-type WorkspaceLayoutDockPanelMessage struct {
-	// AnchorPaneID corresponds to the JSON schema field "anchor_pane_id".
-	AnchorPaneID string `json:"anchor_pane_id"`
-
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
-
-	// Edge corresponds to the JSON schema field "edge".
-	Edge WorkspaceLayoutDockEdge `json:"edge"`
-
-	// PanelID corresponds to the JSON schema field "panel_id".
-	PanelID string `json:"panel_id"`
-
-	// PanelKind corresponds to the JSON schema field "panel_kind".
-	PanelKind string `json:"panel_kind"`
-
-	// Ratio corresponds to the JSON schema field "ratio".
-	Ratio *float64 `json:"ratio,omitempty,omitzero"`
-
-	// WorkspaceID corresponds to the JSON schema field "workspace_id".
-	WorkspaceID string `json:"workspace_id"`
-}
-
 type WorkspaceLayoutDockTileMessage struct {
 	// AnchorPaneID corresponds to the JSON schema field "anchor_pane_id".
 	AnchorPaneID string `json:"anchor_pane_id"`
@@ -4638,17 +4629,6 @@ type WorkspaceLayoutSplitDirection string
 const WorkspaceLayoutSplitDirectionHorizontal WorkspaceLayoutSplitDirection = "horizontal"
 const WorkspaceLayoutSplitDirectionVertical WorkspaceLayoutSplitDirection = "vertical"
 
-type WorkspaceLayoutUndockPanelMessage struct {
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
-
-	// PanelID corresponds to the JSON schema field "panel_id".
-	PanelID string `json:"panel_id"`
-
-	// WorkspaceID corresponds to the JSON schema field "workspace_id".
-	WorkspaceID string `json:"workspace_id"`
-}
-
 type WorkspaceLayoutUndockTileMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -4683,40 +4663,6 @@ type WorkspaceLayoutUpdatedMessage struct {
 
 	// WorkspaceLayout corresponds to the JSON schema field "workspace_layout".
 	WorkspaceLayout WorkspaceLayout `json:"workspace_layout"`
-}
-
-type WorkspacePanelContentGetMessage struct {
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
-
-	// PanelID corresponds to the JSON schema field "panel_id".
-	PanelID string `json:"panel_id"`
-
-	// WorkspaceID corresponds to the JSON schema field "workspace_id".
-	WorkspaceID string `json:"workspace_id"`
-}
-
-type WorkspacePanelContentMessage struct {
-	// Content corresponds to the JSON schema field "content".
-	Content string `json:"content"`
-
-	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty,omitzero"`
-
-	// Event corresponds to the JSON schema field "event".
-	Event string `json:"event"`
-
-	// PanelID corresponds to the JSON schema field "panel_id".
-	PanelID string `json:"panel_id"`
-
-	// PanelKind corresponds to the JSON schema field "panel_kind".
-	PanelKind string `json:"panel_kind"`
-
-	// Path corresponds to the JSON schema field "path".
-	Path string `json:"path"`
-
-	// WorkspaceID corresponds to the JSON schema field "workspace_id".
-	WorkspaceID string `json:"workspace_id"`
 }
 
 type WorkspaceRegisteredMessage struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -182,6 +182,7 @@ model Workspace {
   directory: string;
   status: WorkspaceStatus;
   muted: boolean;               // Muting parks the whole workspace out of attention surfaces.
+  pinned: boolean;              // Pinned workspaces persist in the sidebar even when empty.
   rank: string;                 // Fractional-index sort key; default order is opening (creation) order.
   layout?: WorkspaceLayout;
 }
@@ -790,6 +791,12 @@ model MuteWorkspaceMessage {
   cmd: "mute_workspace";
   workspace_id: string;
   endpoint_id?: string;
+}
+
+model PinWorkspaceMessage {
+  cmd: "pin_workspace";
+  workspace_id: string;
+  pinned: boolean;
 }
 
 model QueryPRsMessage {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -456,6 +456,7 @@ CREATE INDEX IF NOT EXISTS idx_workflow_agent_calls_run_id
 	// install — if either build burned 51/52 there, these may need to move higher.
 	{52, "rename workspace context janitor backups to keeper compact backups", ""},
 	{53, "add closed_state to chief of staff dispatches", ""},
+	{54, "add pinned to workspaces", ""},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -616,6 +617,11 @@ func migrateDB(db *sql.DB) error {
 			}
 		} else if m.version == 53 {
 			if err := applyMigration53(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 54 {
+			if err := applyMigration54(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -830,6 +836,28 @@ func applyMigration52(tx *sql.Tx) error {
 		}
 	}
 	return nil
+}
+
+// applyMigration54 adds the pinned column to workspaces, allowing users to pin
+// workspaces so they stay visible at the top of the list. Guarded with
+// tableExists and columnExists for idempotent re-run safety.
+func applyMigration54(tx *sql.Tx) error {
+	exists, err := tableExists(tx, "workspaces")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	hasColumn, err := columnExists(tx, "workspaces", "pinned")
+	if err != nil {
+		return err
+	}
+	if hasColumn {
+		return nil
+	}
+	_, err = tx.Exec(`ALTER TABLE workspaces ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0`)
+	return err
 }
 
 // applyMigration53 adds the closed_state column to chief_of_staff_dispatches,

--- a/internal/store/workspace.go
+++ b/internal/store/workspace.go
@@ -23,12 +23,12 @@ func (s *Store) AddWorkspace(ws *protocol.Workspace) {
 	// the durable authority for ordering and must survive — like title, it is not
 	// re-derived from the incoming struct so a user reorder sticks.
 	if _, err := s.db.Exec(`
-		INSERT INTO workspaces (id, title, directory, muted, created_at, rank)
-		VALUES (?, ?, ?, COALESCE(?, 0), ?, ?)
+		INSERT INTO workspaces (id, title, directory, muted, pinned, created_at, rank)
+		VALUES (?, ?, ?, COALESCE(?, 0), COALESCE(?, 0), ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			title = excluded.title,
 			directory = excluded.directory`,
-		ws.ID, ws.Title, ws.Directory, boolToInt(ws.Muted), createdAt, ws.Rank,
+		ws.ID, ws.Title, ws.Directory, boolToInt(ws.Muted), boolToInt(ws.Pinned), createdAt, ws.Rank,
 	); err != nil {
 		log.Printf("[store] AddWorkspace: failed to upsert workspace %s: %v", ws.ID, err)
 	}
@@ -63,14 +63,15 @@ func (s *Store) GetWorkspace(id string) *protocol.Workspace {
 		return nil
 	}
 	var ws protocol.Workspace
-	var muted int
+	var muted, pinned int
 	err := s.db.QueryRow(`
-		SELECT id, title, directory, muted, rank FROM workspaces WHERE id = ?`, id).
-		Scan(&ws.ID, &ws.Title, &ws.Directory, &muted, &ws.Rank)
+		SELECT id, title, directory, muted, pinned, rank FROM workspaces WHERE id = ?`, id).
+		Scan(&ws.ID, &ws.Title, &ws.Directory, &muted, &pinned, &ws.Rank)
 	if err != nil {
 		return nil
 	}
 	ws.Muted = muted == 1
+	ws.Pinned = pinned == 1
 	return &ws
 }
 
@@ -83,7 +84,7 @@ func (s *Store) ListWorkspaces() []*protocol.Workspace {
 	if s.db == nil {
 		return nil
 	}
-	rows, err := s.db.Query(`SELECT id, title, directory, muted, rank FROM workspaces ORDER BY rank, created_at`)
+	rows, err := s.db.Query(`SELECT id, title, directory, muted, pinned, rank FROM workspaces ORDER BY rank, created_at`)
 	if err != nil {
 		return nil
 	}
@@ -92,11 +93,12 @@ func (s *Store) ListWorkspaces() []*protocol.Workspace {
 	var out []*protocol.Workspace
 	for rows.Next() {
 		var ws protocol.Workspace
-		var muted int
-		if err := rows.Scan(&ws.ID, &ws.Title, &ws.Directory, &muted, &ws.Rank); err != nil {
+		var muted, pinned int
+		if err := rows.Scan(&ws.ID, &ws.Title, &ws.Directory, &muted, &pinned, &ws.Rank); err != nil {
 			continue
 		}
 		ws.Muted = muted == 1
+		ws.Pinned = pinned == 1
 		out = append(out, &ws)
 	}
 	return out
@@ -128,6 +130,28 @@ func (s *Store) SetWorkspaceMuted(id string, muted bool) error {
 		return nil
 	}
 	result, err := s.db.Exec(`UPDATE workspaces SET muted = ? WHERE id = ?`, boolToInt(muted), id)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("workspace not found: %s", id)
+	}
+	return nil
+}
+
+// SetWorkspacePinned writes an explicit workspace pinned state.
+func (s *Store) SetWorkspacePinned(id string, pinned bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	result, err := s.db.Exec(`UPDATE workspaces SET pinned = ? WHERE id = ?`, boolToInt(pinned), id)
 	if err != nil {
 		return err
 	}

--- a/internal/store/workspace_test.go
+++ b/internal/store/workspace_test.go
@@ -130,6 +130,72 @@ func idsOf(list []*protocol.Workspace) []string {
 	return ids
 }
 
+func TestSetWorkspacePinned(t *testing.T) {
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	s.AddWorkspace(&protocol.Workspace{ID: "workspace-1", Title: "Project", Directory: "/tmp/project"})
+
+	if got := s.GetWorkspace("workspace-1"); got == nil || got.Pinned {
+		t.Fatalf("new workspace pinned = true, want false")
+	}
+
+	if err := s.SetWorkspacePinned("workspace-1", true); err != nil {
+		t.Fatalf("SetWorkspacePinned(true): %v", err)
+	}
+	if got := s.GetWorkspace("workspace-1"); got == nil || !got.Pinned {
+		t.Fatalf("workspace after pin = %+v, want pinned", got)
+	}
+
+	if err := s.SetWorkspacePinned("workspace-1", false); err != nil {
+		t.Fatalf("SetWorkspacePinned(false): %v", err)
+	}
+	if got := s.GetWorkspace("workspace-1"); got == nil || got.Pinned {
+		t.Fatalf("workspace after unpin = %+v, want unpinned", got)
+	}
+}
+
+func TestAddWorkspacePinnedField(t *testing.T) {
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	s.AddWorkspace(&protocol.Workspace{ID: "workspace-1", Title: "Pinned", Directory: "/tmp/p", Pinned: true})
+	got := s.GetWorkspace("workspace-1")
+	if got == nil || !got.Pinned {
+		t.Fatalf("workspace with Pinned=true = %+v, want pinned", got)
+	}
+}
+
+func TestListWorkspacesPinnedField(t *testing.T) {
+	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	s.AddWorkspace(&protocol.Workspace{ID: "ws-a", Title: "A", Directory: "/tmp/a"})
+	s.AddWorkspace(&protocol.Workspace{ID: "ws-b", Title: "B", Directory: "/tmp/b", Pinned: true})
+
+	list := s.ListWorkspaces()
+	if len(list) != 2 {
+		t.Fatalf("ListWorkspaces() = %d, want 2", len(list))
+	}
+	for _, ws := range list {
+		if ws.ID == "ws-a" && ws.Pinned {
+			t.Fatalf("ws-a should not be pinned")
+		}
+		if ws.ID == "ws-b" && !ws.Pinned {
+			t.Fatalf("ws-b should be pinned")
+		}
+	}
+}
+
 func TestAssignSessionWorkspaceRefusesEmptyWorkspace(t *testing.T) {
 	s, err := NewWithDB(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {


### PR DESCRIPTION
## Intent

Workspaces disappear from the sidebar the moment their last session closes. For workspaces the user wants to keep around — a project they return to, a delegation target, a context they're building up — this forces them to re-create the workspace each time. Pinned workspaces let the user mark a workspace as persistent so it survives being emptied.

## Summary

- **Migration 54** adds a `pinned INTEGER NOT NULL DEFAULT 0` column to the workspaces table (idempotent, guarded by `columnExists`).
- **Protocol**: `pinned: boolean` field on `Workspace` model; new `pin_workspace` command with `workspace_id` and `pinned` fields.
- **Store**: `AddWorkspace`/`GetWorkspace`/`ListWorkspaces` read and write the pinned column; new `SetWorkspacePinned` method.
- **Daemon retention logic**: `dissociateSessionFromWorkspace` checks `snap.Pinned` before tearing down an empty workspace; `loadWorkspacesFromStore` startup reaper skips pinned workspaces.
- **Daemon command handling**: `handlePinWorkspaceWS`/`setWorkspacePinned` persist + broadcast; wired into both WebSocket and unix socket dispatch.
- **Frontend**: `sendPinWorkspace` in `useDaemonSocket`; pin toggle button in sidebar workspace rows; pinned empty workspaces bypass the sessionless visibility toggle; CSS keeps the pin icon visible when active.
- **Existing behavior preserved**: tile-only retention, muted workspaces, workspace context — all compose cleanly with pinning.

## Test plan

- [x] `TestSetWorkspacePinned` — store round-trip
- [x] `TestAddWorkspacePinnedField` — persisted on insert
- [x] `TestListWorkspacesPinnedField` — returned in list
- [x] `TestPinnedWorkspaceSurvivesFinalSessionClose` — retention on last-session departure
- [x] `TestUnpinnedWorkspaceRemovedOnFinalSessionClose` — existing cleanup preserved
- [x] `TestPinnedEmptyWorkspaceSurvivesStartupCleanup` — retention on daemon restart
- [x] `TestSetWorkspacePinned_PersistsAndBroadcasts` — store + broadcast
- [x] All Go tests pass (`go test ./internal/...`)
- [x] All 1138 frontend tests pass (`pnpm test -- --run`)
- [ ] Manual app QA in dev profile: pin a workspace, close all sessions, verify it stays, restart daemon, verify it persists