### PR TITLE
feat(delegate): name the agent and its workspace with --name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Pin workspaces to keep them in the sidebar even when empty.** A workspace can now be toggled pinned/unpinned from the sidebar. A pinned workspace survives its last session closing and daemon restarts — it stays visible and ready for a new agent launch. Existing tile-only and context-based workspace retention continues to work alongside pinning.
 
+### Changed
+- **Delegated agents and their workspaces now get real, readable names.** `attn delegate` takes `--name` (replacing `--label`); it names the agent and, when the delegation creates a new workspace, the workspace too — so a delegated workspace shows a human name in the sidebar instead of its worktree folder. Omit `--name` to default to the directory name. Names are capped at 16 characters and must be unique (a workspace name across all workspaces, a session name within its workspace); when a name is too long or already taken — including a too-long worktree-folder default — the command fails with a clear message telling you to pass `--name`.
+
 ## [2026-06-23]
 
 ### Added

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -609,7 +609,9 @@ worktree options:
 
 session options:
   --agent <name>             configured prompt-capable built-in or plugin agent
-  --label <text>             session label
+  --name <text>              name for the agent and, when a new workspace is
+                             created, the workspace (max 16 chars, must be
+                             unique; defaults to the directory name)
   --source-session <id>      source session (defaults to ATTN_SESSION_ID)
   --yolo                     bypass agent approval prompts
 `)
@@ -1290,7 +1292,7 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 	briefText := fs.String("brief", "", "delegated task brief")
 	briefFile := fs.String("brief-file", "", "file containing the delegated task brief")
 	agentName := fs.String("agent", "", "target agent (defaults to the source session agent)")
-	label := fs.String("label", "", "target session label")
+	name := fs.String("name", "", "name for the agent and, when a new workspace is created, the workspace")
 	sourceSessionID := fs.String("source-session", "", "source session id (defaults to ATTN_SESSION_ID)")
 	yolo := fs.Bool("yolo", false, "launch the target agent in yolo mode")
 	newWorkspace := fs.Bool("new-workspace", false, "create a new workspace for the delegated agent")
@@ -1356,7 +1358,7 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 		brief:           brief,
 		options: client.DelegateOptions{
 			Agent:        strings.TrimSpace(*agentName),
-			Label:        strings.TrimSpace(*label),
+			Label:        strings.TrimSpace(*name),
 			Yolo:         *yolo,
 			Placement:    placement,
 			WorkspaceID:  explicitWorkspace,

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -504,6 +504,20 @@ func TestParseDelegateArgsDefaultsToCurrentWorkspace(t *testing.T) {
 	}
 }
 
+func TestParseDelegateArgsNameSetsLabel(t *testing.T) {
+	parsed, err := parseDelegateArgs([]string{
+		"--source-session", "source-session",
+		"--brief", "Investigate this",
+		"--name", "  launcher  ",
+	})
+	if err != nil {
+		t.Fatalf("parseDelegateArgs() error = %v", err)
+	}
+	if parsed.options.Label != "launcher" {
+		t.Fatalf("options.Label = %q, want %q", parsed.options.Label, "launcher")
+	}
+}
+
 func TestParseDelegateArgsWorktreeUsesCurrentWorkspace(t *testing.T) {
 	parsed, err := parseDelegateArgs([]string{
 		"--source-session", "source-session",
@@ -825,10 +839,14 @@ func TestWriteDelegateHelpMentionsPlacementOptions(t *testing.T) {
 		"--worktree <branch>",
 		"combine with --new-workspace to place the worktree in a new workspace",
 		"--agent <name>",
+		"--name <text>",
 	} {
 		if !strings.Contains(text, expected) {
 			t.Fatalf("delegate help missing %q: %q", expected, text)
 		}
+	}
+	if strings.Contains(text, "--label") {
+		t.Fatalf("delegate help still mentions removed --label flag: %q", text)
 	}
 }
 

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -48,17 +48,50 @@ func readInternalActionResult(client *wsClient) (internalActionResult, error) {
 	}
 }
 
-func delegationLabel(brief string) string {
-	line := strings.TrimSpace(strings.SplitN(brief, "\n", 2)[0])
-	if line == "" {
-		return "Delegated task"
+// maxDelegationNameRunes bounds a delegated session/workspace display name.
+// Names are short, human, and glanceable in the sidebar; longer strings (e.g. a
+// worktree folder like "attn--feat-some-long-branch") are rejected so the caller
+// supplies a real name with --name.
+const maxDelegationNameRunes = 16
+
+// validateDelegationName enforces the naming rules for a resolved delegation
+// name (whether it came from --name or the directory-basename default):
+//
+//   - non-empty and at most maxDelegationNameRunes runes
+//   - when a new workspace is being created, unique across workspace titles
+//   - unique among the session labels already in the target workspace
+//
+// targetWorkspaceID is the workspace whose sessions are checked for a clash; it
+// is empty when a brand-new (and therefore empty) workspace is being created.
+func (d *Daemon) validateDelegationName(name string, creatingWorkspace bool, targetWorkspaceID string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("a name is required; pass --name")
 	}
-	const maxRunes = 64
-	runes := []rune(line)
-	if len(runes) > maxRunes {
-		line = string(runes[:maxRunes-3]) + "..."
+	if name == "." || name == string(filepath.Separator) {
+		// A directory-basename default can degenerate to "." or "/" for an odd
+		// directory; those are not usable names, so ask for an explicit one.
+		return fmt.Errorf("%q is not a usable name; pass --name", name)
 	}
-	return line
+	if len([]rune(name)) > maxDelegationNameRunes {
+		return fmt.Errorf("name %q is too long (max %d characters); pass a shorter --name", name, maxDelegationNameRunes)
+	}
+	if creatingWorkspace {
+		for _, ws := range d.store.ListWorkspaces() {
+			if strings.EqualFold(strings.TrimSpace(ws.Title), name) {
+				return fmt.Errorf("workspace name %q is already in use; pass a unique --name", name)
+			}
+		}
+	}
+	if targetWorkspaceID != "" {
+		for _, sessionID := range d.store.SessionsInWorkspace(targetWorkspaceID) {
+			existing := d.store.Get(sessionID)
+			if existing != nil && strings.EqualFold(strings.TrimSpace(existing.Label), name) {
+				return fmt.Errorf("session name %q is already used in this workspace; pass a unique --name", name)
+			}
+		}
+	}
+	return nil
 }
 
 func (d *Daemon) resolveDelegationAgent(sourceAgent string, requested *string) (string, error) {
@@ -188,10 +221,9 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 	if err != nil {
 		return nil, err
 	}
-	label := strings.TrimSpace(protocol.Deref(msg.Label))
-	if label == "" {
-		label = delegationLabel(brief)
-	}
+	// name is the explicit --name, or empty to default to the directory basename
+	// once the directory is finalized below.
+	name := strings.TrimSpace(protocol.Deref(msg.Label))
 	sessionID := uuid.NewString()
 	chiefSessionID := d.chiefOfStaffSessionID()
 	trackedByChief := chiefSessionID == sourceSessionID
@@ -239,6 +271,21 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 		return nil, fmt.Errorf("unsupported placement %q", placement)
 	}
 
+	// Naming scope: a new workspace must take a globally-unique name; a session
+	// must be unique among the sessions already in its target workspace (empty
+	// for a brand-new workspace). Validate an explicit --name now, before any
+	// side effects, so a bad name fails fast without creating a worktree.
+	creatingWorkspace := placement == delegationPlacementNew
+	sessionNameWorkspaceID := ""
+	if !creatingWorkspace {
+		sessionNameWorkspaceID = workspaceID
+	}
+	if name != "" {
+		if err := d.validateDelegationName(name, creatingWorkspace, sessionNameWorkspaceID); err != nil {
+			return nil, err
+		}
+	}
+
 	if msg.Worktree != nil {
 		worktreePath, createErr := d.createDelegationWorktree(source.Directory, msg.Worktree)
 		if createErr != nil {
@@ -252,21 +299,32 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 		directory = validatedDirectory
 	}
 
+	// Finalize a new workspace's directory before resolving the name so a
+	// directory-basename default reflects the real directory.
 	if placement == delegationPlacementNew {
 		validatedDirectory, directoryErr := validateDelegationDirectory(directory)
 		if directoryErr != nil {
 			return nil, d.rollbackDelegation("", createdWorktreePath, directoryErr)
 		}
 		directory = validatedDirectory
-		workspaceID = "workspace-" + sessionID
-		workspaceTitle := filepath.Base(directory)
-		if workspaceTitle == "." || workspaceTitle == string(filepath.Separator) || workspaceTitle == "" {
-			workspaceTitle = label
+	}
+
+	// Default the name to the directory basename when --name was not given, then
+	// validate the final name. Only a worktree may exist at this point, so a
+	// validation failure rolls it back (no workspace/pane/session yet).
+	if name == "" {
+		name = filepath.Base(directory)
+		if err := d.validateDelegationName(name, creatingWorkspace, sessionNameWorkspaceID); err != nil {
+			return nil, d.rollbackDelegation("", createdWorktreePath, err)
 		}
+	}
+
+	if placement == delegationPlacementNew {
+		workspaceID = "workspace-" + sessionID
 		d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
 			Cmd:       protocol.CmdRegisterWorkspace,
 			ID:        workspaceID,
-			Title:     workspaceTitle,
+			Title:     name,
 			Directory: directory,
 		})
 		if d.store.GetWorkspace(workspaceID) == nil {
@@ -281,7 +339,7 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 		WorkspaceID: workspaceID,
 		PaneID:      protocol.Ptr(paneID),
 		SessionID:   sessionID,
-		Title:       protocol.Ptr(label),
+		Title:       protocol.Ptr(name),
 	})
 	if _, err := readInternalActionResult(paneClient); err != nil {
 		return nil, d.rollbackDelegation(createdWorkspaceID, createdWorktreePath, fmt.Errorf("create delegated pane: %w", err))
@@ -300,7 +358,7 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 		Agent:         agent,
 		Cols:          80,
 		Rows:          24,
-		Label:         protocol.Ptr(label),
+		Label:         protocol.Ptr(name),
 		YoloMode:      msg.YoloMode,
 		InitialPrompt: protocol.Ptr(initialPrompt),
 	})
@@ -316,7 +374,7 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 	}
 	var dispatch *protocol.ChiefOfStaffDispatch
 	if trackedByChief {
-		dispatch = d.newChiefOfStaffDispatch(chiefSessionID, session, workspaceID, brief, label, agent)
+		dispatch = d.newChiefOfStaffDispatch(chiefSessionID, session, workspaceID, brief, name, agent)
 		if err := d.store.AddChiefOfStaffDispatch(dispatch); err != nil {
 			d.unregisterSession(sessionID, syscall.SIGTERM)
 			d.removeWorkspaceLayoutPaneForSession(sessionID)

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -995,6 +995,276 @@ func TestDelegateCreatesNewWorkspaceAtCustomDirectory(t *testing.T) {
 	}
 }
 
+func TestDelegateNamesNewWorkspaceAndSessionFromExplicitName(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+	targetDir := t.TempDir()
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Name everything from --name.",
+		Placement:       protocol.Ptr(delegationPlacementNew),
+		Cwd:             protocol.Ptr(targetDir),
+		Label:           protocol.Ptr("launcher"),
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	if workspace := d.store.GetWorkspace(result.WorkspaceID); workspace == nil || workspace.Title != "launcher" {
+		t.Fatalf("delegated workspace = %+v, want title %q", workspace, "launcher")
+	}
+	if session := d.store.Get(result.SessionID); session == nil || session.Label != "launcher" {
+		t.Fatalf("delegated session = %+v, want label %q", session, "launcher")
+	}
+	layout := d.store.GetWorkspaceLayout(result.WorkspaceID)
+	if layout == nil || len(layout.Panes) != 1 || layout.Panes[0].Title != "launcher" {
+		t.Fatalf("delegated layout = %+v, want one pane titled %q", layout, "launcher")
+	}
+}
+
+func TestDelegateDefaultsNameToDirectoryBasename(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+	targetDir := filepath.Join(t.TempDir(), "myproj")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Default the name to the folder.",
+		Placement:       protocol.Ptr(delegationPlacementNew),
+		Cwd:             protocol.Ptr(targetDir),
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	if workspace := d.store.GetWorkspace(result.WorkspaceID); workspace == nil || workspace.Title != "myproj" {
+		t.Fatalf("delegated workspace = %+v, want title %q", workspace, "myproj")
+	}
+	if session := d.store.Get(result.SessionID); session == nil || session.Label != "myproj" {
+		t.Fatalf("delegated session = %+v, want label %q", session, "myproj")
+	}
+}
+
+func TestDelegateRejectsNameTooLong(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+	targetDir := t.TempDir()
+
+	_, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Name is too long.",
+		Placement:       protocol.Ptr(delegationPlacementNew),
+		Cwd:             protocol.Ptr(targetDir),
+		Label:           protocol.Ptr("this-name-is-way-too-long"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "too long") {
+		t.Fatalf("delegate() error = %v, want a name-too-long error", err)
+	}
+	if workspaces := d.store.ListWorkspaces(); len(workspaces) != 1 {
+		t.Fatalf("workspaces = %+v, want only the source workspace", workspaces)
+	}
+}
+
+func TestDelegateRejectsDuplicateWorkspaceName(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        "workspace-taken",
+		Title:     "taken",
+		Directory: t.TempDir(),
+	})
+
+	_, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Reuse a workspace name.",
+		Placement:       protocol.Ptr(delegationPlacementNew),
+		Cwd:             protocol.Ptr(t.TempDir()),
+		Label:           protocol.Ptr("taken"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "already in use") {
+		t.Fatalf("delegate() error = %v, want a duplicate-workspace error", err)
+	}
+}
+
+func TestDelegateRejectsDuplicateSessionNameInWorkspace(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+	targetDir := t.TempDir()
+
+	first, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "First agent.",
+		Placement:       protocol.Ptr(delegationPlacementNew),
+		Cwd:             protocol.Ptr(targetDir),
+		Label:           protocol.Ptr("alpha"),
+	})
+	if err != nil {
+		t.Fatalf("first delegate() error = %v", err)
+	}
+
+	_, err = d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Second agent, same name, same workspace.",
+		Placement:       protocol.Ptr(delegationPlacementExisting),
+		WorkspaceID:     protocol.Ptr(first.WorkspaceID),
+		Label:           protocol.Ptr("alpha"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "already used in this workspace") {
+		t.Fatalf("second delegate() error = %v, want a duplicate-session error", err)
+	}
+}
+
+func TestDelegateRejectsLongWorktreeDefaultNameAndRollsBack(t *testing.T) {
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	runGitDaemon(t, mainRepo, "init")
+	runGitDaemon(t, mainRepo, "commit", "--allow-empty", "-m", "init")
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSourceAt(t, d, backend, mainRepo)
+	consumeDelegatedPrompt(t, backend)
+	worktreePath := filepath.Join(root, "repo--feat-delegated-long")
+
+	_, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "No --name; the worktree folder is too long.",
+		Placement:       protocol.Ptr(delegationPlacementNew),
+		Worktree: &protocol.DelegateWorktreeRequest{
+			Repo:   protocol.Ptr(mainRepo),
+			Branch: "feat/delegated-long",
+			Path:   protocol.Ptr(worktreePath),
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "too long") {
+		t.Fatalf("delegate() error = %v, want a name-too-long error", err)
+	}
+	if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
+		t.Fatalf("worktree still exists after rollback: %v", statErr)
+	}
+	if workspaces := d.store.ListWorkspaces(); len(workspaces) != 1 {
+		t.Fatalf("workspaces = %+v, want only the source workspace", workspaces)
+	}
+}
+
+func TestValidateDelegationName(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: "ws-taken", Title: "Taken", Directory: t.TempDir(),
+	})
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: "ws-busy", Title: "Busy WS", Directory: t.TempDir(),
+	})
+	d.store.Add(&protocol.Session{ID: "sess-busy", Label: "Busy", WorkspaceID: "ws-busy", Directory: t.TempDir()})
+
+	cases := []struct {
+		name              string
+		input             string
+		creatingWorkspace bool
+		targetWorkspaceID string
+		wantErr           string // substring; "" means expect success
+	}{
+		{"sixteen ASCII accepted", strings.Repeat("a", 16), false, "", ""},
+		{"seventeen ASCII rejected", strings.Repeat("a", 17), false, "", "too long"},
+		{"sixteen runes accepted", strings.Repeat("é", 16), false, "", ""},           // 16 runes, 32 bytes
+		{"seventeen runes rejected", strings.Repeat("é", 17), false, "", "too long"}, // 17 runes
+		{"blank rejected", "   ", false, "", "a name is required"},
+		{"dot rejected", ".", false, "", "not a usable name"},
+		{"separator rejected", string(filepath.Separator), false, "", "not a usable name"},
+		{"workspace duplicate is case-insensitive", "taken", true, "", "already in use"},
+		{"fresh workspace name accepted", "fresh", true, "", ""},
+		{"session duplicate is case-insensitive", "busy", false, "ws-busy", "already used in this workspace"},
+		{"distinct session name accepted", "other", false, "ws-busy", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := d.validateDelegationName(tc.input, tc.creatingWorkspace, tc.targetWorkspaceID)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateDelegationName(%q) = %v, want nil", tc.input, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validateDelegationName(%q) = %v, want error containing %q", tc.input, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDelegateRejectsDuplicateWorkspaceNameFromDefault(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: "ws-existing", Title: "myproj", Directory: t.TempDir(),
+	})
+	// No --name: the directory basename defaults to "myproj", which collides
+	// with the existing workspace title. The default path must still validate.
+	targetDir := filepath.Join(t.TempDir(), "myproj")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+
+	_, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Default name collides with an existing workspace.",
+		Placement:       protocol.Ptr(delegationPlacementNew),
+		Cwd:             protocol.Ptr(targetDir),
+	})
+	if err == nil || !strings.Contains(err.Error(), "already in use") {
+		t.Fatalf("delegate() error = %v, want a duplicate-workspace error from the default-name path", err)
+	}
+}
+
+func TestDelegateRejectsNameMatchingSourceSession(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+
+	source := d.store.Get(sourceSessionID)
+	if source == nil || strings.TrimSpace(source.Label) == "" {
+		t.Fatalf("source session has no label: %+v", source)
+	}
+	// Delegating into the current workspace with the source session's own label
+	// (different case) must be rejected as a within-workspace duplicate.
+	_, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Clash with the pre-existing source session name.",
+		Label:           protocol.Ptr(strings.ToLower(source.Label)),
+	})
+	if err == nil || !strings.Contains(err.Error(), "already used in this workspace") {
+		t.Fatalf("delegate() error = %v, want a duplicate-session error", err)
+	}
+}
+
 func TestDelegateTargetsExistingWorkspace(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
@@ -1111,6 +1381,7 @@ func TestDelegateCreatesWorktreeInSourceWorkspace(t *testing.T) {
 		Cmd:             protocol.CmdDelegate,
 		SourceSessionID: sourceSessionID,
 		Brief:           "Implement this in an isolated branch in this workspace.",
+		Label:           protocol.Ptr("delegated"),
 		Worktree: &protocol.DelegateWorktreeRequest{
 			Repo:   protocol.Ptr(mainRepo),
 			Branch: "feat/delegated-current",
@@ -1134,6 +1405,7 @@ func TestDelegateCreatesWorktreeInSourceWorkspace(t *testing.T) {
 	if session == nil ||
 		session.WorkspaceID != sourceWorkspaceID ||
 		session.Directory != worktreePath ||
+		session.Label != "delegated" ||
 		protocol.Deref(session.Branch) != "feat/delegated-current" {
 		t.Fatalf("delegated worktree session = %+v", session)
 	}
@@ -1163,6 +1435,7 @@ func TestDelegateCreatesWorktreeAndNewWorkspace(t *testing.T) {
 		SourceSessionID: sourceSessionID,
 		Brief:           "Implement this in an isolated branch.",
 		Placement:       protocol.Ptr(delegationPlacementNew),
+		Label:           protocol.Ptr("delegated"),
 		Worktree: &protocol.DelegateWorktreeRequest{
 			Repo:   protocol.Ptr(mainRepo),
 			Branch: "feat/delegated",
@@ -1181,6 +1454,10 @@ func TestDelegateCreatesWorktreeAndNewWorkspace(t *testing.T) {
 	}
 	if workspaces := d.store.ListWorkspaces(); len(workspaces) != 2 {
 		t.Fatalf("workspaces = %+v, want source and delegated workspaces", workspaces)
+	}
+	delegatedWorkspace := d.store.GetWorkspace(result.WorkspaceID)
+	if delegatedWorkspace == nil || delegatedWorkspace.Title != "delegated" {
+		t.Fatalf("delegated workspace = %+v, want title %q", delegatedWorkspace, "delegated")
 	}
 	if info, err := os.Stat(worktreePath); err != nil || !info.IsDir() {
 		t.Fatalf("worktree path stat = %v, info = %+v", err, info)
@@ -1210,6 +1487,7 @@ func TestDelegateRollsBackCurrentWorkspaceWorktreeWhenSpawnFails(t *testing.T) {
 		Cmd:             protocol.CmdDelegate,
 		SourceSessionID: sourceSessionID,
 		Brief:           "This spawn should roll back in the source workspace.",
+		Label:           protocol.Ptr("rollback"),
 		Worktree: &protocol.DelegateWorktreeRequest{
 			Repo:   protocol.Ptr(mainRepo),
 			Branch: "feat/current-rollback",
@@ -1250,6 +1528,7 @@ func TestDelegateRollsBackNewWorkspaceAndWorktreeWhenSpawnFails(t *testing.T) {
 		SourceSessionID: sourceSessionID,
 		Brief:           "This spawn should roll back.",
 		Placement:       protocol.Ptr(delegationPlacementNew),
+		Label:           protocol.Ptr("rollback"),
 		Worktree: &protocol.DelegateWorktreeRequest{
 			Repo:   protocol.Ptr(mainRepo),
 			Branch: "feat/rollback",


### PR DESCRIPTION
## What

`attn delegate` now takes **`--name`** (replacing `--label`). The resolved name names the delegated **agent/session** and, when the delegation creates a **new workspace**, the workspace too — so a delegated workspace shows a human name in the sidebar instead of its worktree-folder slug.

Previously `--label` named only the session + pane, and a new workspace was titled from the directory basename (e.g. `attn--feat-launch-naming`), never from the label.

## Behavior

- **Optional**, defaults to the target directory's basename when omitted (a short folder like `attn` / `attn--foo` is accepted as-is).
- **Validated** (whether explicit or defaulted):
  - length ≤ **16 runes**;
  - **workspace name** unique across all workspaces (when creating one);
  - **session name** unique within its target workspace.
  - Errors say why (too long / duplicate workspace / duplicate session / missing) and to pass `--name`.
- **Fail-fast**: an explicit `--name` is validated before any side effects; a too-long/duplicate *defaulted* name (e.g. a long worktree folder) is caught after the directory is finalized and **rolls back** a created worktree.
- No slug/uuid pattern rejection (`--` and short sluggy names are fine). The protocol wire field stays `label` to avoid a version bump; only the flag/semantics are `name`.

Names are display-only and mutable (rename later in the app); the uuid stays the real key. Scope is the `attn delegate` CLI path; the in-app launcher is unchanged.

## Tests

New daemon tests: explicit name → both session+workspace; basename default; name-too-long; duplicate workspace; duplicate session-in-workspace; long-worktree-default rollback; a direct `validateDelegationName` table test (16/17-rune boundary in ASCII + multibyte, degenerate `.`/`/`, case-insensitive workspace + session uniqueness); duplicate-workspace via the **default** path; clash with the source session's own label. CLI parse + help tests updated. The two worktree rollback tests now pass a valid `--name` so they still exercise spawn-failure rollback. Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)