### PR TITLE
feat(dispatch): replace reports with typed outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Changed
 - **Delegated agents and their workspaces now get real, readable names.** `attn delegate` takes `--name` (replacing `--label`); it names the agent and, when the delegation creates a new workspace, the workspace too — so a delegated workspace shows a human name in the sidebar instead of its worktree folder. Omit `--name` to default to the directory name. Names are capped at 16 characters and must be unique (a workspace name across all workspaces, a session name within its workspace); when a name is too long or already taken — including a too-long worktree-folder default — the command fails with a clear message telling you to pass `--name`.
+- **Delegated agents now report explicit outcomes instead of assembling coordination JSON.** The new `attn dispatch update`, `block`, `review`, `complete`, and `fail` commands capture the work state directly, keep concise summaries separate from optional detailed reports, check unread chief messages before handoffs, and return a short confirmation instead of echoing the entire assignment. Notebook handoffs likewise require an explicit `--review` or `--complete` outcome.
+
+### Removed
+- **Removed `attn dispatch report` and `--coordination-file`.** Raw coordination envelopes and unstructured reports are no longer accepted; every delegated-agent update now has a typed outcome.
 
 ## [2026-06-23]
 

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ clean:
 
 # Type generation pipeline: TypeSpec -> JSON Schema -> go-jsonschema/quicktype
 generate-types:
+	rm -rf internal/protocol/schema/tsp-output/json-schema
 	cd internal/protocol/schema && pnpm exec tsp compile .
 	$(HOME)/go/bin/go-jsonschema -p protocol --only-models --tags json --resolve-extension json \
 		--capitalization ID --capitalization URL --capitalization SHA --capitalization PR --capitalization CI \

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -172,7 +172,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '121';
+export const PROTOCOL_VERSION = '122';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HandoffDispatchMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListDispatchMessagesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookTask, NotebookTaskListMessage, NotebookTaskListResultMessage, NotebookTaskRetryMessage, NotebookTaskRetryResultMessage, NotebookTasksChangedMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, ReportDispatchMessage, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HandoffDispatchMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchMessagesMessage, ListDispatchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookTask, NotebookTaskListMessage, NotebookTaskListResultMessage, NotebookTaskRetryMessage, NotebookTaskRetryResultMessage, NotebookTasksChangedMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubmitDispatchOutcomeMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const acknowledgeDispatchMessage = Convert.toAcknowledgeDispatchMessage(json);
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
@@ -116,8 +116,8 @@
 //   const installPluginMessage = Convert.toInstallPluginMessage(json);
 //   const killSessionMessage = Convert.toKillSessionMessage(json);
 //   const listBranchesMessage = Convert.toListBranchesMessage(json);
-//   const listDispatchesMessage = Convert.toListDispatchesMessage(json);
 //   const listDispatchMessagesMessage = Convert.toListDispatchMessagesMessage(json);
+//   const listDispatchesMessage = Convert.toListDispatchesMessage(json);
 //   const listEndpointsMessage = Convert.toListEndpointsMessage(json);
 //   const listPluginsMessage = Convert.toListPluginsMessage(json);
 //   const listRemoteBranchesMessage = Convert.toListRemoteBranchesMessage(json);
@@ -155,22 +155,22 @@
 //   const notebookWriteResultMessage = Convert.toNotebookWriteResultMessage(json);
 //   const openBrowserMessage = Convert.toOpenBrowserMessage(json);
 //   const openMarkdownMessage = Convert.toOpenMarkdownMessage(json);
+//   const pR = Convert.toPR(json);
+//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
+//   const pRRole = Convert.toPRRole(json);
+//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
+//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
 //   const pathInspection = Convert.toPathInspection(json);
 //   const pinWorkspaceMessage = Convert.toPinWorkspaceMessage(json);
 //   const pluginActionResultMessage = Convert.toPluginActionResultMessage(json);
 //   const pluginInfo = Convert.toPluginInfo(json);
 //   const pluginIssue = Convert.toPluginIssue(json);
 //   const pluginsUpdatedMessage = Convert.toPluginsUpdatedMessage(json);
-//   const pR = Convert.toPR(json);
-//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
-//   const pRRole = Convert.toPRRole(json);
-//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
-//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
 //   const ptyDesyncMessage = Convert.toPtyDesyncMessage(json);
 //   const ptyInputMessage = Convert.toPtyInputMessage(json);
 //   const ptyOutputMessage = Convert.toPtyOutputMessage(json);
-//   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
 //   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
+//   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
 //   const queryAuthorsMessage = Convert.toQueryAuthorsMessage(json);
 //   const queryMessage = Convert.toQueryMessage(json);
 //   const queryPRsMessage = Convert.toQueryPRsMessage(json);
@@ -190,7 +190,6 @@
 //   const renameWorkspaceMessage = Convert.toRenameWorkspaceMessage(json);
 //   const replaySegment = Convert.toReplaySegment(json);
 //   const repoInfo = Convert.toRepoInfo(json);
-//   const reportDispatchMessage = Convert.toReportDispatchMessage(json);
 //   const repoState = Convert.toRepoState(json);
 //   const reposUpdatedMessage = Convert.toReposUpdatedMessage(json);
 //   const resolveCommentMessage = Convert.toResolveCommentMessage(json);
@@ -217,24 +216,25 @@
 //   const sessionSelectedMessage = Convert.toSessionSelectedMessage(json);
 //   const sessionState = Convert.toSessionState(json);
 //   const sessionStateChangedMessage = Convert.toSessionStateChangedMessage(json);
-//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const sessionTodosUpdatedMessage = Convert.toSessionTodosUpdatedMessage(json);
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
 //   const sessionVisualizedMessage = Convert.toSessionVisualizedMessage(json);
+//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
 //   const setPluginPriorityMessage = Convert.toSetPluginPriorityMessage(json);
 //   const setReviewLoopIterationLimitMessage = Convert.toSetReviewLoopIterationLimitMessage(json);
 //   const setSessionResumeIDMessage = Convert.toSetSessionResumeIDMessage(json);
 //   const setSettingMessage = Convert.toSetSettingMessage(json);
-//   const settingsUpdatedMessage = Convert.toSettingsUpdatedMessage(json);
 //   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
+//   const settingsUpdatedMessage = Convert.toSettingsUpdatedMessage(json);
 //   const spawnResultMessage = Convert.toSpawnResultMessage(json);
 //   const spawnSessionMessage = Convert.toSpawnSessionMessage(json);
 //   const startReviewLoopMessage = Convert.toStartReviewLoopMessage(json);
 //   const stateMessage = Convert.toStateMessage(json);
 //   const stopMessage = Convert.toStopMessage(json);
 //   const stopReviewLoopMessage = Convert.toStopReviewLoopMessage(json);
+//   const submitDispatchOutcomeMessage = Convert.toSubmitDispatchOutcomeMessage(json);
 //   const subscribeGitStatusMessage = Convert.toSubscribeGitStatusMessage(json);
 //   const todosMessage = Convert.toTodosMessage(json);
 //   const unregisterMessage = Convert.toUnregisterMessage(json);
@@ -290,8 +290,8 @@
 //   const workspaceLayoutSetSplitRatioMessage = Convert.toWorkspaceLayoutSetSplitRatioMessage(json);
 //   const workspaceLayoutSplitDirection = Convert.toWorkspaceLayoutSplitDirection(json);
 //   const workspaceLayoutUndockTileMessage = Convert.toWorkspaceLayoutUndockTileMessage(json);
-//   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
 //   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
+//   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
 //   const workspaceRegisteredMessage = Convert.toWorkspaceRegisteredMessage(json);
 //   const workspaceSelectedMessage = Convert.toWorkspaceSelectedMessage(json);
 //   const workspaceStateChangedMessage = Convert.toWorkspaceStateChangedMessage(json);
@@ -1823,12 +1823,12 @@ export interface StagedElement {
 }
 
 export interface HandoffDispatchMessage {
-    cmd:                HandoffDispatchMessageCmd;
-    content:            string;
-    report?:            string;
-    source_session_id:  string;
-    structured_report?: Report;
-    to:                 string;
+    cmd:               HandoffDispatchMessageCmd;
+    content:           string;
+    report?:           string;
+    source_session_id: string;
+    structured_report: Report;
+    to:                string;
     [property: string]: any;
 }
 
@@ -2011,16 +2011,6 @@ export enum ListBranchesMessageCmd {
     ListBranches = "list_branches",
 }
 
-export interface ListDispatchesMessage {
-    cmd:               ListDispatchesMessageCmd;
-    source_session_id: string;
-    [property: string]: any;
-}
-
-export enum ListDispatchesMessageCmd {
-    ListDispatches = "list_dispatches",
-}
-
 export interface ListDispatchMessagesMessage {
     cmd:               ListDispatchMessagesMessageCmd;
     dispatch_id?:      string;
@@ -2031,6 +2021,16 @@ export interface ListDispatchMessagesMessage {
 
 export enum ListDispatchMessagesMessageCmd {
     ListDispatchMessages = "list_dispatch_messages",
+}
+
+export interface ListDispatchesMessage {
+    cmd:               ListDispatchesMessageCmd;
+    source_session_id: string;
+    [property: string]: any;
+}
+
+export enum ListDispatchesMessageCmd {
+    ListDispatches = "list_dispatches",
 }
 
 export interface ListEndpointsMessage {
@@ -2478,6 +2478,69 @@ export enum OpenMarkdownMessageCmd {
     OpenMarkdown = "open_markdown",
 }
 
+export interface PR {
+    approved_by_me:         boolean;
+    author:                 string;
+    ci_status?:             string;
+    comment_count?:         number;
+    details_fetched:        boolean;
+    details_fetched_at?:    string;
+    has_new_changes:        boolean;
+    head_branch?:           string;
+    head_sha?:              string;
+    heat_state?:            HeatState;
+    host:                   string;
+    id:                     string;
+    last_heat_activity_at?: string;
+    last_polled:            string;
+    last_updated:           string;
+    mergeable?:             boolean;
+    mergeable_state?:       string;
+    muted:                  boolean;
+    number:                 number;
+    reason:                 string;
+    repo:                   string;
+    review_status?:         string;
+    role:                   PRRole;
+    state:                  string;
+    title:                  string;
+    url:                    string;
+    [property: string]: any;
+}
+
+export interface PRActionResultMessage {
+    action:  string;
+    error?:  string;
+    event:   PRActionResultMessageEvent;
+    id:      string;
+    success: boolean;
+    [property: string]: any;
+}
+
+export enum PRActionResultMessageEvent {
+    PRActionResult = "pr_action_result",
+}
+
+export interface PRVisitedMessage {
+    cmd: PRVisitedMessageCmd;
+    id:  string;
+    [property: string]: any;
+}
+
+export enum PRVisitedMessageCmd {
+    PRVisited = "pr_visited",
+}
+
+export interface PRsUpdatedMessage {
+    event: PRsUpdatedMessageEvent;
+    prs?:  PRElement[];
+    [property: string]: any;
+}
+
+export enum PRsUpdatedMessageEvent {
+    PrsUpdated = "prs_updated",
+}
+
 export interface PathInspection {
     exists:        boolean;
     home_path?:    string;
@@ -2563,69 +2626,6 @@ export interface PluginElement {
     [property: string]: any;
 }
 
-export interface PR {
-    approved_by_me:         boolean;
-    author:                 string;
-    ci_status?:             string;
-    comment_count?:         number;
-    details_fetched:        boolean;
-    details_fetched_at?:    string;
-    has_new_changes:        boolean;
-    head_branch?:           string;
-    head_sha?:              string;
-    heat_state?:            HeatState;
-    host:                   string;
-    id:                     string;
-    last_heat_activity_at?: string;
-    last_polled:            string;
-    last_updated:           string;
-    mergeable?:             boolean;
-    mergeable_state?:       string;
-    muted:                  boolean;
-    number:                 number;
-    reason:                 string;
-    repo:                   string;
-    review_status?:         string;
-    role:                   PRRole;
-    state:                  string;
-    title:                  string;
-    url:                    string;
-    [property: string]: any;
-}
-
-export interface PRActionResultMessage {
-    action:  string;
-    error?:  string;
-    event:   PRActionResultMessageEvent;
-    id:      string;
-    success: boolean;
-    [property: string]: any;
-}
-
-export enum PRActionResultMessageEvent {
-    PRActionResult = "pr_action_result",
-}
-
-export interface PRsUpdatedMessage {
-    event: PRsUpdatedMessageEvent;
-    prs?:  PRElement[];
-    [property: string]: any;
-}
-
-export enum PRsUpdatedMessageEvent {
-    PrsUpdated = "prs_updated",
-}
-
-export interface PRVisitedMessage {
-    cmd: PRVisitedMessageCmd;
-    id:  string;
-    [property: string]: any;
-}
-
-export enum PRVisitedMessageCmd {
-    PRVisited = "pr_visited",
-}
-
 export interface PtyDesyncMessage {
     event:  PtyDesyncMessageEvent;
     id:     string;
@@ -2661,18 +2661,6 @@ export enum PtyOutputMessageEvent {
     PtyOutput = "pty_output",
 }
 
-export interface PtyResizedMessage {
-    cols:  number;
-    event: PtyResizedMessageEvent;
-    id:    string;
-    rows:  number;
-    [property: string]: any;
-}
-
-export enum PtyResizedMessageEvent {
-    PtyResized = "pty_resized",
-}
-
 export interface PtyResizeMessage {
     cmd:  PtyResizeMessageCmd;
     cols: number;
@@ -2683,6 +2671,18 @@ export interface PtyResizeMessage {
 
 export enum PtyResizeMessageCmd {
     PtyResize = "pty_resize",
+}
+
+export interface PtyResizedMessage {
+    cols:  number;
+    event: PtyResizedMessageEvent;
+    id:    string;
+    rows:  number;
+    [property: string]: any;
+}
+
+export enum PtyResizedMessageEvent {
+    PtyResized = "pty_resized",
 }
 
 export interface QueryAuthorsMessage {
@@ -2894,18 +2894,6 @@ export interface RepoInfo {
     repo:                string;
     worktrees:           WorktreeElement[];
     [property: string]: any;
-}
-
-export interface ReportDispatchMessage {
-    cmd:                ReportDispatchMessageCmd;
-    report:             string;
-    source_session_id:  string;
-    structured_report?: Report;
-    [property: string]: any;
-}
-
-export enum ReportDispatchMessageCmd {
-    ReportDispatch = "report_dispatch",
 }
 
 export interface RepoState {
@@ -3345,16 +3333,6 @@ export enum SessionStateChangedMessageEvent {
     SessionStateChanged = "session_state_changed",
 }
 
-export interface SessionsUpdatedMessage {
-    event:     SessionsUpdatedMessageEvent;
-    sessions?: SessionElement[];
-    [property: string]: any;
-}
-
-export enum SessionsUpdatedMessageEvent {
-    SessionsUpdated = "sessions_updated",
-}
-
 export interface SessionTodosUpdatedMessage {
     event:   SessionTodosUpdatedMessageEvent;
     session: SessionElement;
@@ -3383,6 +3361,16 @@ export interface SessionVisualizedMessage {
 
 export enum SessionVisualizedMessageCmd {
     SessionVisualized = "session_visualized",
+}
+
+export interface SessionsUpdatedMessage {
+    event:     SessionsUpdatedMessageEvent;
+    sessions?: SessionElement[];
+    [property: string]: any;
+}
+
+export enum SessionsUpdatedMessageEvent {
+    SessionsUpdated = "sessions_updated",
 }
 
 export interface SetChiefOfStaffMessage {
@@ -3451,6 +3439,18 @@ export enum SetSettingMessageCmd {
     SetSetting = "set_setting",
 }
 
+export interface SetWorkspaceRankMessage {
+    cmd:                SetWorkspaceRankMessageCmd;
+    next_workspace_id?: string;
+    prev_workspace_id?: string;
+    workspace_id:       string;
+    [property: string]: any;
+}
+
+export enum SetWorkspaceRankMessageCmd {
+    SetWorkspaceRank = "set_workspace_rank",
+}
+
 export interface SettingsUpdatedMessage {
     changed_key?: string;
     error?:       string;
@@ -3462,18 +3462,6 @@ export interface SettingsUpdatedMessage {
 
 export enum SettingsUpdatedMessageEvent {
     SettingsUpdated = "settings_updated",
-}
-
-export interface SetWorkspaceRankMessage {
-    cmd:                SetWorkspaceRankMessageCmd;
-    next_workspace_id?: string;
-    prev_workspace_id?: string;
-    workspace_id:       string;
-    [property: string]: any;
-}
-
-export enum SetWorkspaceRankMessageCmd {
-    SetWorkspaceRank = "set_workspace_rank",
 }
 
 export interface SpawnResultMessage {
@@ -3557,6 +3545,18 @@ export interface StopReviewLoopMessage {
 
 export enum StopReviewLoopMessageCmd {
     StopReviewLoop = "stop_review_loop",
+}
+
+export interface SubmitDispatchOutcomeMessage {
+    cmd:               SubmitDispatchOutcomeMessageCmd;
+    report:            string;
+    source_session_id: string;
+    structured_report: Report;
+    [property: string]: any;
+}
+
+export enum SubmitDispatchOutcomeMessageCmd {
+    SubmitDispatchOutcome = "submit_dispatch_outcome",
 }
 
 export interface SubscribeGitStatusMessage {
@@ -4272,16 +4272,6 @@ export enum WorkspaceLayoutUndockTileMessageCmd {
     WorkspaceLayoutUndockTile = "workspace_layout_undock_tile",
 }
 
-export interface WorkspaceLayoutUpdatedMessage {
-    event:            WorkspaceLayoutUpdatedMessageEvent;
-    workspace_layout: Layout;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutUpdatedMessageEvent {
-    WorkspaceLayoutUpdated = "workspace_layout_updated",
-}
-
 export interface WorkspaceLayoutUpdateTileMessage {
     cmd:          WorkspaceLayoutUpdateTileMessageCmd;
     request_id:   string;
@@ -4293,6 +4283,16 @@ export interface WorkspaceLayoutUpdateTileMessage {
 
 export enum WorkspaceLayoutUpdateTileMessageCmd {
     WorkspaceLayoutUpdateTile = "workspace_layout_update_tile",
+}
+
+export interface WorkspaceLayoutUpdatedMessage {
+    event:            WorkspaceLayoutUpdatedMessageEvent;
+    workspace_layout: Layout;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutUpdatedMessageEvent {
+    WorkspaceLayoutUpdated = "workspace_layout_updated",
 }
 
 export interface WorkspaceRegisteredMessage {
@@ -5314,20 +5314,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("ListBranchesMessage")), null, 2);
     }
 
-    public static toListDispatchesMessage(json: string): ListDispatchesMessage {
-        return cast(JSON.parse(json), r("ListDispatchesMessage"));
-    }
-
-    public static listDispatchesMessageToJson(value: ListDispatchesMessage): string {
-        return JSON.stringify(uncast(value, r("ListDispatchesMessage")), null, 2);
-    }
-
     public static toListDispatchMessagesMessage(json: string): ListDispatchMessagesMessage {
         return cast(JSON.parse(json), r("ListDispatchMessagesMessage"));
     }
 
     public static listDispatchMessagesMessageToJson(value: ListDispatchMessagesMessage): string {
         return JSON.stringify(uncast(value, r("ListDispatchMessagesMessage")), null, 2);
+    }
+
+    public static toListDispatchesMessage(json: string): ListDispatchesMessage {
+        return cast(JSON.parse(json), r("ListDispatchesMessage"));
+    }
+
+    public static listDispatchesMessageToJson(value: ListDispatchesMessage): string {
+        return JSON.stringify(uncast(value, r("ListDispatchesMessage")), null, 2);
     }
 
     public static toListEndpointsMessage(json: string): ListEndpointsMessage {
@@ -5626,6 +5626,46 @@ export class Convert {
         return JSON.stringify(uncast(value, r("OpenMarkdownMessage")), null, 2);
     }
 
+    public static toPR(json: string): PR {
+        return cast(JSON.parse(json), r("PR"));
+    }
+
+    public static pRToJson(value: PR): string {
+        return JSON.stringify(uncast(value, r("PR")), null, 2);
+    }
+
+    public static toPRActionResultMessage(json: string): PRActionResultMessage {
+        return cast(JSON.parse(json), r("PRActionResultMessage"));
+    }
+
+    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
+        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
+    }
+
+    public static toPRRole(json: string): PRRole {
+        return cast(JSON.parse(json), r("PRRole"));
+    }
+
+    public static pRRoleToJson(value: PRRole): string {
+        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
+    }
+
+    public static toPRVisitedMessage(json: string): PRVisitedMessage {
+        return cast(JSON.parse(json), r("PRVisitedMessage"));
+    }
+
+    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
+        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
+    }
+
+    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
+        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
+    }
+
+    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
+    }
+
     public static toPathInspection(json: string): PathInspection {
         return cast(JSON.parse(json), r("PathInspection"));
     }
@@ -5674,46 +5714,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PluginsUpdatedMessage")), null, 2);
     }
 
-    public static toPR(json: string): PR {
-        return cast(JSON.parse(json), r("PR"));
-    }
-
-    public static pRToJson(value: PR): string {
-        return JSON.stringify(uncast(value, r("PR")), null, 2);
-    }
-
-    public static toPRActionResultMessage(json: string): PRActionResultMessage {
-        return cast(JSON.parse(json), r("PRActionResultMessage"));
-    }
-
-    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
-        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
-    }
-
-    public static toPRRole(json: string): PRRole {
-        return cast(JSON.parse(json), r("PRRole"));
-    }
-
-    public static pRRoleToJson(value: PRRole): string {
-        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
-    }
-
-    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
-        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
-    }
-
-    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
-    }
-
-    public static toPRVisitedMessage(json: string): PRVisitedMessage {
-        return cast(JSON.parse(json), r("PRVisitedMessage"));
-    }
-
-    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
-        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
-    }
-
     public static toPtyDesyncMessage(json: string): PtyDesyncMessage {
         return cast(JSON.parse(json), r("PtyDesyncMessage"));
     }
@@ -5738,20 +5738,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PtyOutputMessage")), null, 2);
     }
 
-    public static toPtyResizedMessage(json: string): PtyResizedMessage {
-        return cast(JSON.parse(json), r("PtyResizedMessage"));
-    }
-
-    public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
-        return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
-    }
-
     public static toPtyResizeMessage(json: string): PtyResizeMessage {
         return cast(JSON.parse(json), r("PtyResizeMessage"));
     }
 
     public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
         return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
+    }
+
+    public static toPtyResizedMessage(json: string): PtyResizedMessage {
+        return cast(JSON.parse(json), r("PtyResizedMessage"));
+    }
+
+    public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
+        return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
     }
 
     public static toQueryAuthorsMessage(json: string): QueryAuthorsMessage {
@@ -5904,14 +5904,6 @@ export class Convert {
 
     public static repoInfoToJson(value: RepoInfo): string {
         return JSON.stringify(uncast(value, r("RepoInfo")), null, 2);
-    }
-
-    public static toReportDispatchMessage(json: string): ReportDispatchMessage {
-        return cast(JSON.parse(json), r("ReportDispatchMessage"));
-    }
-
-    public static reportDispatchMessageToJson(value: ReportDispatchMessage): string {
-        return JSON.stringify(uncast(value, r("ReportDispatchMessage")), null, 2);
     }
 
     public static toRepoState(json: string): RepoState {
@@ -6122,14 +6114,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionStateChangedMessage")), null, 2);
     }
 
-    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
-        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
-    }
-
-    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
-    }
-
     public static toSessionTodosUpdatedMessage(json: string): SessionTodosUpdatedMessage {
         return cast(JSON.parse(json), r("SessionTodosUpdatedMessage"));
     }
@@ -6152,6 +6136,14 @@ export class Convert {
 
     public static sessionVisualizedMessageToJson(value: SessionVisualizedMessage): string {
         return JSON.stringify(uncast(value, r("SessionVisualizedMessage")), null, 2);
+    }
+
+    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
+        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
+    }
+
+    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
     }
 
     public static toSetChiefOfStaffMessage(json: string): SetChiefOfStaffMessage {
@@ -6202,20 +6194,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SetSettingMessage")), null, 2);
     }
 
-    public static toSettingsUpdatedMessage(json: string): SettingsUpdatedMessage {
-        return cast(JSON.parse(json), r("SettingsUpdatedMessage"));
-    }
-
-    public static settingsUpdatedMessageToJson(value: SettingsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("SettingsUpdatedMessage")), null, 2);
-    }
-
     public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
         return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
     }
 
     public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
         return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
+    }
+
+    public static toSettingsUpdatedMessage(json: string): SettingsUpdatedMessage {
+        return cast(JSON.parse(json), r("SettingsUpdatedMessage"));
+    }
+
+    public static settingsUpdatedMessageToJson(value: SettingsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("SettingsUpdatedMessage")), null, 2);
     }
 
     public static toSpawnResultMessage(json: string): SpawnResultMessage {
@@ -6264,6 +6256,14 @@ export class Convert {
 
     public static stopReviewLoopMessageToJson(value: StopReviewLoopMessage): string {
         return JSON.stringify(uncast(value, r("StopReviewLoopMessage")), null, 2);
+    }
+
+    public static toSubmitDispatchOutcomeMessage(json: string): SubmitDispatchOutcomeMessage {
+        return cast(JSON.parse(json), r("SubmitDispatchOutcomeMessage"));
+    }
+
+    public static submitDispatchOutcomeMessageToJson(value: SubmitDispatchOutcomeMessage): string {
+        return JSON.stringify(uncast(value, r("SubmitDispatchOutcomeMessage")), null, 2);
     }
 
     public static toSubscribeGitStatusMessage(json: string): SubscribeGitStatusMessage {
@@ -6706,20 +6706,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockTileMessage")), null, 2);
     }
 
-    public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutUpdatedMessage"));
-    }
-
-    public static workspaceLayoutUpdatedMessageToJson(value: WorkspaceLayoutUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
-    }
-
     public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
     }
 
     public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
+    }
+
+    public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutUpdatedMessage"));
+    }
+
+    public static workspaceLayoutUpdatedMessageToJson(value: WorkspaceLayoutUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
     }
 
     public static toWorkspaceRegisteredMessage(json: string): WorkspaceRegisteredMessage {
@@ -7873,7 +7873,7 @@ const typeMap: any = {
         { json: "content", js: "content", typ: "" },
         { json: "report", js: "report", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
-        { json: "structured_report", js: "structured_report", typ: u(undefined, r("Report")) },
+        { json: "structured_report", js: "structured_report", typ: r("Report") },
         { json: "to", js: "to", typ: "" },
     ], "any"),
     "HeartbeatMessage": o([
@@ -7975,15 +7975,15 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("ListBranchesMessageCmd") },
         { json: "main_repo", js: "main_repo", typ: "" },
     ], "any"),
-    "ListDispatchesMessage": o([
-        { json: "cmd", js: "cmd", typ: r("ListDispatchesMessageCmd") },
-        { json: "source_session_id", js: "source_session_id", typ: "" },
-    ], "any"),
     "ListDispatchMessagesMessage": o([
         { json: "cmd", js: "cmd", typ: r("ListDispatchMessagesMessageCmd") },
         { json: "dispatch_id", js: "dispatch_id", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "unread_only", js: "unread_only", typ: u(undefined, true) },
+    ], "any"),
+    "ListDispatchesMessage": o([
+        { json: "cmd", js: "cmd", typ: r("ListDispatchesMessageCmd") },
+        { json: "source_session_id", js: "source_session_id", typ: "" },
     ], "any"),
     "ListEndpointsMessage": o([
         { json: "cmd", js: "cmd", typ: r("ListEndpointsMessageCmd") },
@@ -8222,6 +8222,49 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
         { json: "session_id", js: "session_id", typ: u(undefined, "") },
     ], "any"),
+    "PR": o([
+        { json: "approved_by_me", js: "approved_by_me", typ: true },
+        { json: "author", js: "author", typ: "" },
+        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
+        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
+        { json: "details_fetched", js: "details_fetched", typ: true },
+        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
+        { json: "has_new_changes", js: "has_new_changes", typ: true },
+        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
+        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
+        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
+        { json: "host", js: "host", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
+        { json: "last_polled", js: "last_polled", typ: "" },
+        { json: "last_updated", js: "last_updated", typ: "" },
+        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
+        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
+        { json: "muted", js: "muted", typ: true },
+        { json: "number", js: "number", typ: 0 },
+        { json: "reason", js: "reason", typ: "" },
+        { json: "repo", js: "repo", typ: "" },
+        { json: "review_status", js: "review_status", typ: u(undefined, "") },
+        { json: "role", js: "role", typ: r("PRRole") },
+        { json: "state", js: "state", typ: "" },
+        { json: "title", js: "title", typ: "" },
+        { json: "url", js: "url", typ: "" },
+    ], "any"),
+    "PRActionResultMessage": o([
+        { json: "action", js: "action", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "PRVisitedMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
+        { json: "id", js: "id", typ: "" },
+    ], "any"),
+    "PRsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
+        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
+    ], "any"),
     "PathInspection": o([
         { json: "exists", js: "exists", typ: true },
         { json: "home_path", js: "home_path", typ: u(undefined, "") },
@@ -8279,49 +8322,6 @@ const typeMap: any = {
         { json: "running", js: "running", typ: true },
         { json: "version", js: "version", typ: "" },
     ], "any"),
-    "PR": o([
-        { json: "approved_by_me", js: "approved_by_me", typ: true },
-        { json: "author", js: "author", typ: "" },
-        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
-        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
-        { json: "details_fetched", js: "details_fetched", typ: true },
-        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
-        { json: "has_new_changes", js: "has_new_changes", typ: true },
-        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
-        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
-        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
-        { json: "host", js: "host", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
-        { json: "last_polled", js: "last_polled", typ: "" },
-        { json: "last_updated", js: "last_updated", typ: "" },
-        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
-        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
-        { json: "muted", js: "muted", typ: true },
-        { json: "number", js: "number", typ: 0 },
-        { json: "reason", js: "reason", typ: "" },
-        { json: "repo", js: "repo", typ: "" },
-        { json: "review_status", js: "review_status", typ: u(undefined, "") },
-        { json: "role", js: "role", typ: r("PRRole") },
-        { json: "state", js: "state", typ: "" },
-        { json: "title", js: "title", typ: "" },
-        { json: "url", js: "url", typ: "" },
-    ], "any"),
-    "PRActionResultMessage": o([
-        { json: "action", js: "action", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "success", js: "success", typ: true },
-    ], "any"),
-    "PRsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
-        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
-    ], "any"),
-    "PRVisitedMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
-        { json: "id", js: "id", typ: "" },
-    ], "any"),
     "PtyDesyncMessage": o([
         { json: "event", js: "event", typ: r("PtyDesyncMessageEvent") },
         { json: "id", js: "id", typ: "" },
@@ -8339,15 +8339,15 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "seq", js: "seq", typ: 0 },
     ], "any"),
-    "PtyResizedMessage": o([
-        { json: "cols", js: "cols", typ: 0 },
-        { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "rows", js: "rows", typ: 0 },
-    ], "any"),
     "PtyResizeMessage": o([
         { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
         { json: "cols", js: "cols", typ: 0 },
+        { json: "id", js: "id", typ: "" },
+        { json: "rows", js: "rows", typ: 0 },
+    ], "any"),
+    "PtyResizedMessage": o([
+        { json: "cols", js: "cols", typ: 0 },
+        { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
         { json: "id", js: "id", typ: "" },
         { json: "rows", js: "rows", typ: 0 },
     ], "any"),
@@ -8457,12 +8457,6 @@ const typeMap: any = {
         { json: "fetched_at", js: "fetched_at", typ: u(undefined, "") },
         { json: "repo", js: "repo", typ: "" },
         { json: "worktrees", js: "worktrees", typ: a(r("WorktreeElement")) },
-    ], "any"),
-    "ReportDispatchMessage": o([
-        { json: "cmd", js: "cmd", typ: r("ReportDispatchMessageCmd") },
-        { json: "report", js: "report", typ: "" },
-        { json: "source_session_id", js: "source_session_id", typ: "" },
-        { json: "structured_report", js: "structured_report", typ: u(undefined, r("Report")) },
     ], "any"),
     "RepoState": o([
         { json: "collapsed", js: "collapsed", typ: true },
@@ -8758,10 +8752,6 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("SessionStateChangedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
     ], "any"),
-    "SessionsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
-        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
-    ], "any"),
     "SessionTodosUpdatedMessage": o([
         { json: "event", js: "event", typ: r("SessionTodosUpdatedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
@@ -8773,6 +8763,10 @@ const typeMap: any = {
     "SessionVisualizedMessage": o([
         { json: "cmd", js: "cmd", typ: r("SessionVisualizedMessageCmd") },
         { json: "id", js: "id", typ: "" },
+    ], "any"),
+    "SessionsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
+        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
     ], "any"),
     "SetChiefOfStaffMessage": o([
         { json: "chief_of_staff", js: "chief_of_staff", typ: true },
@@ -8804,18 +8798,18 @@ const typeMap: any = {
         { json: "key", js: "key", typ: "" },
         { json: "value", js: "value", typ: "" },
     ], "any"),
+    "SetWorkspaceRankMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
+        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
+        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
     "SettingsUpdatedMessage": o([
         { json: "changed_key", js: "changed_key", typ: u(undefined, "") },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("SettingsUpdatedMessageEvent") },
         { json: "settings", js: "settings", typ: u(undefined, m("any")) },
         { json: "success", js: "success", typ: u(undefined, true) },
-    ], "any"),
-    "SetWorkspaceRankMessage": o([
-        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
-        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
-        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "SpawnResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
@@ -8863,6 +8857,12 @@ const typeMap: any = {
     "StopReviewLoopMessage": o([
         { json: "cmd", js: "cmd", typ: r("StopReviewLoopMessageCmd") },
         { json: "session_id", js: "session_id", typ: "" },
+    ], "any"),
+    "SubmitDispatchOutcomeMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SubmitDispatchOutcomeMessageCmd") },
+        { json: "report", js: "report", typ: "" },
+        { json: "source_session_id", js: "source_session_id", typ: "" },
+        { json: "structured_report", js: "structured_report", typ: r("Report") },
     ], "any"),
     "SubscribeGitStatusMessage": o([
         { json: "cmd", js: "cmd", typ: r("SubscribeGitStatusMessageCmd") },
@@ -9295,16 +9295,16 @@ const typeMap: any = {
         { json: "tile_id", js: "tile_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
-    "WorkspaceLayoutUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
-        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
-    ], "any"),
     "WorkspaceLayoutUpdateTileMessage": o([
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUpdateTileMessageCmd") },
         { json: "request_id", js: "request_id", typ: "" },
         { json: "tile_id", js: "tile_id", typ: "" },
         { json: "tile_params", js: "tile_params", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
+    "WorkspaceLayoutUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
+        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
     ], "any"),
     "WorkspaceRegisteredMessage": o([
         { json: "event", js: "event", typ: r("WorkspaceRegisteredMessageEvent") },
@@ -9672,11 +9672,11 @@ const typeMap: any = {
     "ListBranchesMessageCmd": [
         "list_branches",
     ],
-    "ListDispatchesMessageCmd": [
-        "list_dispatches",
-    ],
     "ListDispatchMessagesMessageCmd": [
         "list_dispatch_messages",
+    ],
+    "ListDispatchesMessageCmd": [
+        "list_dispatches",
     ],
     "ListEndpointsMessageCmd": [
         "list_endpoints",
@@ -9771,6 +9771,15 @@ const typeMap: any = {
     "OpenMarkdownMessageCmd": [
         "open_markdown",
     ],
+    "PRActionResultMessageEvent": [
+        "pr_action_result",
+    ],
+    "PRVisitedMessageCmd": [
+        "pr_visited",
+    ],
+    "PRsUpdatedMessageEvent": [
+        "prs_updated",
+    ],
     "PinWorkspaceMessageCmd": [
         "pin_workspace",
     ],
@@ -9779,15 +9788,6 @@ const typeMap: any = {
     ],
     "PluginsUpdatedMessageEvent": [
         "plugins_updated",
-    ],
-    "PRActionResultMessageEvent": [
-        "pr_action_result",
-    ],
-    "PRsUpdatedMessageEvent": [
-        "prs_updated",
-    ],
-    "PRVisitedMessageCmd": [
-        "pr_visited",
     ],
     "PtyDesyncMessageEvent": [
         "pty_desync",
@@ -9798,11 +9798,11 @@ const typeMap: any = {
     "PtyOutputMessageEvent": [
         "pty_output",
     ],
-    "PtyResizedMessageEvent": [
-        "pty_resized",
-    ],
     "PtyResizeMessageCmd": [
         "pty_resize",
+    ],
+    "PtyResizedMessageEvent": [
+        "pty_resized",
     ],
     "QueryAuthorsMessageCmd": [
         "query_authors",
@@ -9851,9 +9851,6 @@ const typeMap: any = {
     ],
     "RenameWorkspaceMessageCmd": [
         "rename_workspace",
-    ],
-    "ReportDispatchMessageCmd": [
-        "report_dispatch",
     ],
     "ReposUpdatedMessageEvent": [
         "repos_updated",
@@ -9925,9 +9922,6 @@ const typeMap: any = {
     "SessionStateChangedMessageEvent": [
         "session_state_changed",
     ],
-    "SessionsUpdatedMessageEvent": [
-        "sessions_updated",
-    ],
     "SessionTodosUpdatedMessageEvent": [
         "session_todos_updated",
     ],
@@ -9936,6 +9930,9 @@ const typeMap: any = {
     ],
     "SessionVisualizedMessageCmd": [
         "session_visualized",
+    ],
+    "SessionsUpdatedMessageEvent": [
+        "sessions_updated",
     ],
     "SetChiefOfStaffMessageCmd": [
         "set_chief_of_staff",
@@ -9955,11 +9952,11 @@ const typeMap: any = {
     "SetSettingMessageCmd": [
         "set_setting",
     ],
-    "SettingsUpdatedMessageEvent": [
-        "settings_updated",
-    ],
     "SetWorkspaceRankMessageCmd": [
         "set_workspace_rank",
+    ],
+    "SettingsUpdatedMessageEvent": [
+        "settings_updated",
     ],
     "SpawnResultMessageEvent": [
         "spawn_result",
@@ -9978,6 +9975,9 @@ const typeMap: any = {
     ],
     "StopReviewLoopMessageCmd": [
         "stop_review_loop",
+    ],
+    "SubmitDispatchOutcomeMessageCmd": [
+        "submit_dispatch_outcome",
     ],
     "SubscribeGitStatusMessageCmd": [
         "subscribe_git_status",
@@ -10118,11 +10118,11 @@ const typeMap: any = {
     "WorkspaceLayoutUndockTileMessageCmd": [
         "workspace_layout_undock_tile",
     ],
-    "WorkspaceLayoutUpdatedMessageEvent": [
-        "workspace_layout_updated",
-    ],
     "WorkspaceLayoutUpdateTileMessageCmd": [
         "workspace_layout_update_tile",
+    ],
+    "WorkspaceLayoutUpdatedMessageEvent": [
+        "workspace_layout_updated",
     ],
     "WorkspaceRegisteredMessageEvent": [
         "workspace_registered",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -638,30 +638,57 @@ func runDispatch() {
 		printJSON(dispatches)
 	case "watch":
 		runDispatchWatch(os.Args[3:])
-	case "report":
-		sourceSessionID, report, structuredReport, err := parseDispatchReportArgs(os.Args[3:])
+	case "update", "block", "review", "complete", "fail":
+		outcome := os.Args[2]
+		if hasHelpFlag(os.Args[3:]) {
+			writeDispatchOutcomeHelp(os.Stdout, outcome)
+			return
+		}
+		parsed, err := parseDispatchOutcomeArgs(outcome, os.Args[3:])
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "dispatch report: %v\n", err)
+			fmt.Fprintf(os.Stderr, "dispatch %s: %v\n", outcome, err)
 			os.Exit(2)
 		}
-		dispatch, err := client.New("").ReportDispatchEnvelope(sourceSessionID, report, structuredReport)
+		c := client.New("")
+		if outcome != "update" {
+			if err := ensureDispatchInboxClear(c, parsed.SourceSessionID); err != nil {
+				fmt.Fprintf(os.Stderr, "dispatch %s: %v\n", outcome, err)
+				os.Exit(2)
+			}
+		}
+		dispatch, err := c.SubmitDispatchOutcome(parsed.SourceSessionID, parsed.Report, parsed.StructuredReport)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "dispatch report: %v\n", err)
+			fmt.Fprintf(os.Stderr, "dispatch %s: %v\n", outcome, err)
 			os.Exit(1)
 		}
-		printJSON(dispatch)
+		printDispatchOutcomeResult(outcome, parsed.JSON, dispatch)
 	case "handoff":
-		sourceSessionID, to, content, message, structuredReport, err := parseDispatchHandoffArgs(os.Args[3:])
+		if hasHelpFlag(os.Args[3:]) {
+			writeDispatchHandoffHelp(os.Stdout)
+			return
+		}
+		parsed, err := parseDispatchHandoffArgs(os.Args[3:])
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "dispatch handoff: %v\n", err)
 			os.Exit(2)
 		}
-		dispatch, err := client.New("").HandoffDispatch(sourceSessionID, to, content, message, structuredReport)
+		c := client.New("")
+		if err := ensureDispatchInboxClear(c, parsed.SourceSessionID); err != nil {
+			fmt.Fprintf(os.Stderr, "dispatch handoff: %v\n", err)
+			os.Exit(2)
+		}
+		dispatch, err := c.HandoffDispatch(
+			parsed.SourceSessionID,
+			parsed.To,
+			parsed.Content,
+			parsed.Report,
+			parsed.StructuredReport,
+		)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "dispatch handoff: %v\n", err)
 			os.Exit(1)
 		}
-		printJSON(dispatch)
+		printDispatchOutcomeResult("handoff", parsed.JSON, dispatch)
 	case "status":
 		sourceSessionID, err := parseDispatchSourceSession(os.Args[3:])
 		if err != nil {
@@ -765,23 +792,128 @@ commands:
   list [--session <id>]                          list work dispatched by this chief
   watch <dispatch-id> [--session <id>]           stream meaningful events until terminal
         [--interval <dur>]
-  report (--message <text> | --file <path>)     report progress from a dispatched agent
-         [--coordination-file <json>]
-  handoff --file <path> --to <notebook-path>    write a large artifact into the notebook and
-         [--message <text>] [--coordination-file <json>]   report a reference back to the chief
+  update --summary <text>                        report meaningful progress
+  block --summary <text> --question <text>       request input before work can continue
+  review --summary <text>                        hand work back for review
+  complete --summary <text>                      report successful completion
+  fail --summary <text>                          report terminal failure
+  handoff --file <path> --to <notebook-path>     hand off a durable artifact
+          --summary <text> (--review | --complete)
   status [--session <id>]                        show this delegated session's report and response
   resolve --dispatch <id>                        answer the active decision request
           (--response <text> | --file <path>) [--link <url>] [--session <id>]
-	  message --dispatch <id>                        send durable mail to a delegated agent
-	          (--message <text> | --file <path>) [--session <id>]
-	  messages --dispatch <id> [--session <id>]      list sent mail and acknowledgement state
-	  inbox [--unread] [--session <id>]              list this delegated agent's mail
+  message --dispatch <id>                        send durable mail to a delegated agent
+          (--message <text> | --file <path>) [--session <id>]
+  messages --dispatch <id> [--session <id>]      list sent mail and acknowledgement state
+  inbox [--unread] [--session <id>]              list this delegated agent's mail
   read --message-id <id> [--session <id>]        mark one message read
   ack --message-id <id>                          acknowledge one message
       [--message <text> | --file <path>] [--session <id>]
 
 The session defaults to ATTN_SESSION_ID.
+
+Outcome commands accept --details <text> or --details-file <path>, plus
+--next-actor, --next-action, repeated --remaining-scope and --constraint,
+and --json. Run attn dispatch <outcome> --help for exact usage.
 `)
+}
+
+func hasHelpFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+func writeDispatchOutcomeHelp(w io.Writer, outcome string) {
+	usage := "attn dispatch " + outcome + " --summary <text> [options]"
+	if outcome == "block" {
+		usage = "attn dispatch block --summary <text> --question <text> [options]"
+	}
+	fmt.Fprintf(w, `usage: %s
+
+options:
+  --summary <text>            concise outcome shown to the chief (required)
+  --details <text>            detailed report text
+  --details-file <path>       read detailed report text from a file
+  --next-actor <text>         who acts next
+  --next-action <text>        what happens next
+  --remaining-scope <text>    remaining item (repeatable)
+  --constraint <text>         constraint (repeatable)
+  --session <id>              session id (defaults to ATTN_SESSION_ID)
+  --json                      print the full dispatch as JSON
+`, usage)
+	if outcome == "block" {
+		fmt.Fprint(w, `  --question <text>           decision or input required (required)
+  --recommendation <text>     recommended response
+  --consequence <text>        effect of leaving the request unresolved
+  --expected-responder <text> who should answer (default: chief)
+`)
+	}
+}
+
+func writeDispatchHandoffHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn dispatch handoff --file <path> --to <notebook-path>
+       --summary <text> (--review | --complete) [options]
+
+options:
+  --file <path>               artifact to write into the Notebook (required)
+  --to <notebook-path>        chief-designated Notebook destination (required)
+  --summary <text>            concise outcome shown to the chief (required)
+  --review                    hand the artifact back for review
+  --complete                  hand off the artifact as completed work
+  --details <text>            note accompanying the artifact reference
+  --details-file <path>       read the note from a file
+  --next-actor <text>         who acts next
+  --next-action <text>        what happens next
+  --remaining-scope <text>    remaining item (repeatable)
+  --constraint <text>         constraint (repeatable)
+  --session <id>              session id (defaults to ATTN_SESSION_ID)
+  --json                      print the full dispatch as JSON
+`)
+}
+
+func ensureDispatchInboxClear(c *client.Client, sourceSessionID string) error {
+	messages, err := c.ListDispatchMessages(sourceSessionID, "", true)
+	if err != nil {
+		return fmt.Errorf("check unread inbox: %w", err)
+	}
+	if len(messages) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%d unread chief message(s); run `attn dispatch inbox --unread`, handle them, then acknowledge each before reporting this outcome",
+		len(messages),
+	)
+}
+
+func printDispatchOutcomeResult(
+	outcome string,
+	jsonOutput bool,
+	dispatch *protocol.ChiefOfStaffDispatch,
+) {
+	if jsonOutput {
+		printJSON(dispatch)
+		return
+	}
+	summary := ""
+	if dispatch != nil && dispatch.StructuredReport != nil {
+		summary = strings.TrimSpace(dispatch.StructuredReport.Summary)
+	}
+	if summary == "" {
+		summary = "Outcome recorded"
+	}
+	dispatchID := ""
+	if dispatch != nil {
+		dispatchID = strings.TrimSpace(dispatch.ID)
+	}
+	if dispatchID == "" {
+		fmt.Printf("Reported %s to the chief: %s\n", outcome, summary)
+		return
+	}
+	fmt.Printf("Reported %s to the chief (%s): %s\n", outcome, dispatchID, summary)
 }
 
 func parseDispatchSourceSession(args []string) (string, error) {
@@ -875,109 +1007,249 @@ func parseDispatchWatchArgs(args []string) (string, string, time.Duration, error
 	return source, dispatchID, *interval, nil
 }
 
-func parseDispatchReportArgs(args []string) (string, string, *protocol.DispatchReport, error) {
-	fs := flag.NewFlagSet("dispatch report", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	sessionID := fs.String("session", "", "session id (defaults to ATTN_SESSION_ID)")
-	message := fs.String("message", "", "concise progress or completion update")
-	reportFile := fs.String("file", "", "file containing a progress or completion update")
-	coordinationFile := fs.String("coordination-file", "", "JSON file containing structured coordination fields")
-	if err := fs.Parse(args); err != nil {
-		return "", "", nil, err
-	}
-	if fs.NArg() != 0 {
-		return "", "", nil, fmt.Errorf("unexpected arguments: %v", fs.Args())
-	}
-	source := strings.TrimSpace(*sessionID)
-	if source == "" {
-		source = strings.TrimSpace(os.Getenv("ATTN_SESSION_ID"))
-	}
-	if source == "" {
-		return "", "", nil, errors.New("no session; run inside attn or pass --session")
-	}
-	if strings.TrimSpace(*message) != "" && strings.TrimSpace(*reportFile) != "" {
-		return "", "", nil, errors.New("pass only one of --message or --file")
-	}
-	report := strings.TrimSpace(*message)
-	if path := strings.TrimSpace(*reportFile); path != "" {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return "", "", nil, fmt.Errorf("read report file: %w", err)
-		}
-		report = strings.TrimSpace(string(content))
-	}
-	if report == "" {
-		return "", "", nil, errors.New("--message or --file is required")
-	}
-	var structuredReport *protocol.DispatchReport
-	if path := strings.TrimSpace(*coordinationFile); path != "" {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return "", "", nil, fmt.Errorf("read coordination file: %w", err)
-		}
-		var parsed protocol.DispatchReport
-		if err := json.Unmarshal(content, &parsed); err != nil {
-			return "", "", nil, fmt.Errorf("parse coordination file: %w", err)
-		}
-		structuredReport = &parsed
-	}
-	return source, report, structuredReport, nil
+type stringListFlag []string
+
+func (values *stringListFlag) String() string {
+	return strings.Join(*values, ", ")
 }
 
-// parseDispatchHandoffArgs parses `dispatch handoff` flags. The artifact file is
-// read here (like a coordination file) and its bytes are sent verbatim — the
-// notebook note keeps the artifact exactly as built. --to and --file are required;
-// the chief (or user) designates --to, so there is no default destination.
-func parseDispatchHandoffArgs(args []string) (string, string, string, string, *protocol.DispatchReport, error) {
+func (values *stringListFlag) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("value cannot be empty")
+	}
+	*values = append(*values, value)
+	return nil
+}
+
+type dispatchOutcomeArgs struct {
+	SourceSessionID  string
+	Report           string
+	StructuredReport protocol.DispatchReport
+	JSON             bool
+}
+
+func parseDispatchOutcomeArgs(outcome string, args []string) (dispatchOutcomeArgs, error) {
+	var result dispatchOutcomeArgs
+	fs := flag.NewFlagSet("dispatch "+outcome, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionID := fs.String("session", "", "session id (defaults to ATTN_SESSION_ID)")
+	summary := fs.String("summary", "", "concise outcome shown to the chief")
+	details := fs.String("details", "", "optional detailed report text")
+	detailsFile := fs.String("details-file", "", "file containing optional detailed report text")
+	nextActor := fs.String("next-actor", "", "who acts next")
+	nextAction := fs.String("next-action", "", "what happens next")
+	jsonOutput := fs.Bool("json", false, "print the full dispatch as JSON")
+	var remainingScope stringListFlag
+	var constraints stringListFlag
+	fs.Var(&remainingScope, "remaining-scope", "remaining item (repeatable)")
+	fs.Var(&constraints, "constraint", "constraint (repeatable)")
+
+	var question, recommendation, consequence, expectedResponder *string
+	if outcome == "block" {
+		question = fs.String("question", "", "decision or input required")
+		recommendation = fs.String("recommendation", "", "recommended response")
+		consequence = fs.String("consequence", "", "effect of leaving the request unresolved")
+		expectedResponder = fs.String("expected-responder", "chief", "who should answer")
+	}
+	if err := fs.Parse(args); err != nil {
+		return result, err
+	}
+	if fs.NArg() != 0 {
+		return result, fmt.Errorf("unexpected arguments: %v", fs.Args())
+	}
+
+	source, err := resolveDispatchSession(*sessionID)
+	if err != nil {
+		return result, err
+	}
+	resolvedSummary := strings.TrimSpace(*summary)
+	if resolvedSummary == "" {
+		return result, errors.New("--summary is required")
+	}
+	report, err := readDispatchDetails(*details, *detailsFile)
+	if err != nil {
+		return result, err
+	}
+	if report == "" {
+		report = resolvedSummary
+	}
+
+	reportType, workState, ok := dispatchOutcomeTypes(outcome)
+	if !ok {
+		return result, fmt.Errorf("unknown outcome %q", outcome)
+	}
+	structured := protocol.DispatchReport{
+		ReportType:     reportType,
+		Summary:        resolvedSummary,
+		WorkState:      workState,
+		RemainingScope: remainingScope,
+		Constraints:    constraints,
+	}
+	if value := strings.TrimSpace(*nextActor); value != "" {
+		structured.NextActor = protocol.Ptr(value)
+	}
+	if value := strings.TrimSpace(*nextAction); value != "" {
+		structured.NextAction = protocol.Ptr(value)
+	}
+	if outcome == "block" {
+		resolvedQuestion := strings.TrimSpace(*question)
+		if resolvedQuestion == "" {
+			return result, errors.New("--question is required")
+		}
+		responder := strings.TrimSpace(*expectedResponder)
+		if responder == "" {
+			return result, errors.New("--expected-responder cannot be empty")
+		}
+		request := &protocol.DispatchDecisionRequest{
+			Question:          resolvedQuestion,
+			ExpectedResponder: responder,
+			Status:            protocol.DispatchRequestStatusPending,
+		}
+		if value := strings.TrimSpace(*recommendation); value != "" {
+			request.Recommendation = protocol.Ptr(value)
+		}
+		if value := strings.TrimSpace(*consequence); value != "" {
+			request.Consequence = protocol.Ptr(value)
+		}
+		structured.Request = request
+	}
+
+	result.SourceSessionID = source
+	result.Report = report
+	result.StructuredReport = structured
+	result.JSON = *jsonOutput
+	return result, nil
+}
+
+func dispatchOutcomeTypes(outcome string) (protocol.DispatchReportType, protocol.DispatchWorkState, bool) {
+	switch outcome {
+	case "update":
+		return protocol.DispatchReportTypeProgress, protocol.DispatchWorkStateInProgress, true
+	case "block":
+		return protocol.DispatchReportTypeBlocker, protocol.DispatchWorkStateNeedsInput, true
+	case "review":
+		return protocol.DispatchReportTypeHandoff, protocol.DispatchWorkStateReadyForReview, true
+	case "complete":
+		return protocol.DispatchReportTypeCompletion, protocol.DispatchWorkStateCompleted, true
+	case "fail":
+		return protocol.DispatchReportTypeFailure, protocol.DispatchWorkStateFailed, true
+	default:
+		return "", "", false
+	}
+}
+
+type dispatchHandoffArgs struct {
+	SourceSessionID  string
+	To               string
+	Content          string
+	Report           string
+	StructuredReport protocol.DispatchReport
+	JSON             bool
+}
+
+// parseDispatchHandoffArgs reads the artifact verbatim and creates a typed
+// review or completion outcome. The chief or user must designate the Notebook
+// destination; handoff never invents one.
+func parseDispatchHandoffArgs(args []string) (dispatchHandoffArgs, error) {
+	var result dispatchHandoffArgs
 	fs := flag.NewFlagSet("dispatch handoff", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	sessionID := fs.String("session", "", "session id (defaults to ATTN_SESSION_ID)")
 	file := fs.String("file", "", "file containing the artifact to write into the notebook")
 	to := fs.String("to", "", "destination notebook path (root-relative, .md) the chief designated")
-	message := fs.String("message", "", "optional note to accompany the reference in the report")
-	coordinationFile := fs.String("coordination-file", "", "JSON file containing structured coordination fields")
+	summary := fs.String("summary", "", "concise outcome shown to the chief")
+	details := fs.String("details", "", "optional note accompanying the artifact reference")
+	detailsFile := fs.String("details-file", "", "file containing the optional note")
+	nextActor := fs.String("next-actor", "", "who acts next")
+	nextAction := fs.String("next-action", "", "what happens next")
+	review := fs.Bool("review", false, "hand the artifact back for review")
+	complete := fs.Bool("complete", false, "hand off the artifact as completed work")
+	jsonOutput := fs.Bool("json", false, "print the full dispatch as JSON")
+	var remainingScope stringListFlag
+	var constraints stringListFlag
+	fs.Var(&remainingScope, "remaining-scope", "remaining item (repeatable)")
+	fs.Var(&constraints, "constraint", "constraint (repeatable)")
 	if err := fs.Parse(args); err != nil {
-		return "", "", "", "", nil, err
+		return result, err
 	}
 	if fs.NArg() != 0 {
-		return "", "", "", "", nil, fmt.Errorf("unexpected arguments: %v", fs.Args())
+		return result, fmt.Errorf("unexpected arguments: %v", fs.Args())
 	}
-	source := strings.TrimSpace(*sessionID)
-	if source == "" {
-		source = strings.TrimSpace(os.Getenv("ATTN_SESSION_ID"))
-	}
-	if source == "" {
-		return "", "", "", "", nil, errors.New("no session; run inside attn or pass --session")
+	source, err := resolveDispatchSession(*sessionID)
+	if err != nil {
+		return result, err
 	}
 	dest := strings.TrimSpace(*to)
 	if dest == "" {
-		return "", "", "", "", nil, errors.New("--to is required (the chief designates the notebook destination)")
+		return result, errors.New("--to is required (the chief designates the notebook destination)")
 	}
 	path := strings.TrimSpace(*file)
 	if path == "" {
-		return "", "", "", "", nil, errors.New("--file is required")
+		return result, errors.New("--file is required")
 	}
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		return "", "", "", "", nil, fmt.Errorf("read artifact file: %w", err)
+		return result, fmt.Errorf("read artifact file: %w", err)
 	}
 	content := string(raw)
 	if strings.TrimSpace(content) == "" {
-		return "", "", "", "", nil, errors.New("artifact file is empty")
+		return result, errors.New("artifact file is empty")
 	}
-	var structuredReport *protocol.DispatchReport
-	if p := strings.TrimSpace(*coordinationFile); p != "" {
-		data, readErr := os.ReadFile(p)
-		if readErr != nil {
-			return "", "", "", "", nil, fmt.Errorf("read coordination file: %w", readErr)
-		}
-		var parsed protocol.DispatchReport
-		if jsonErr := json.Unmarshal(data, &parsed); jsonErr != nil {
-			return "", "", "", "", nil, fmt.Errorf("parse coordination file: %w", jsonErr)
-		}
-		structuredReport = &parsed
+	resolvedSummary := strings.TrimSpace(*summary)
+	if resolvedSummary == "" {
+		return result, errors.New("--summary is required")
 	}
-	return source, dest, content, strings.TrimSpace(*message), structuredReport, nil
+	if *review == *complete {
+		return result, errors.New("pass exactly one of --review or --complete")
+	}
+	report, err := readDispatchDetails(*details, *detailsFile)
+	if err != nil {
+		return result, err
+	}
+	if report == "" {
+		report = resolvedSummary
+	}
+	workState := protocol.DispatchWorkStateReadyForReview
+	if *complete {
+		workState = protocol.DispatchWorkStateCompleted
+	}
+	structured := protocol.DispatchReport{
+		ReportType:     protocol.DispatchReportTypeHandoff,
+		Summary:        resolvedSummary,
+		WorkState:      workState,
+		RemainingScope: remainingScope,
+		Constraints:    constraints,
+	}
+	if value := strings.TrimSpace(*nextActor); value != "" {
+		structured.NextActor = protocol.Ptr(value)
+	}
+	if value := strings.TrimSpace(*nextAction); value != "" {
+		structured.NextAction = protocol.Ptr(value)
+	}
+	result.SourceSessionID = source
+	result.To = dest
+	result.Content = content
+	result.Report = report
+	result.StructuredReport = structured
+	result.JSON = *jsonOutput
+	return result, nil
+}
+
+func readDispatchDetails(details, path string) (string, error) {
+	details = strings.TrimSpace(details)
+	path = strings.TrimSpace(path)
+	if details != "" && path != "" {
+		return "", errors.New("pass only one of --details or --details-file")
+	}
+	if path == "" {
+		return details, nil
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read details file: %w", err)
+	}
+	return strings.TrimSpace(string(content)), nil
 }
 
 func parseDispatchResolveArgs(args []string) (string, string, string, string, error) {

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -572,44 +572,123 @@ func TestParseDelegateArgsRejectsAmbiguousPlacement(t *testing.T) {
 	}
 }
 
-func TestParseDispatchReportArgsReadsFile(t *testing.T) {
+func TestParseDispatchOutcomeArgsBuildsTypedCompletion(t *testing.T) {
 	t.Setenv("ATTN_SESSION_ID", "worker-1")
 	path := filepath.Join(t.TempDir(), "report.md")
 	if err := os.WriteFile(path, []byte("Implemented the fix.\nTests pass.\n"), 0o600); err != nil {
 		t.Fatalf("write report: %v", err)
 	}
-	sessionID, report, structuredReport, err := parseDispatchReportArgs([]string{"--file", path})
+	parsed, err := parseDispatchOutcomeArgs("complete", []string{
+		"--summary", "Parser implemented",
+		"--details-file", path,
+		"--next-actor", "chief",
+		"--next-action", "Review the result",
+		"--constraint", "no push",
+	})
 	if err != nil {
-		t.Fatalf("parseDispatchReportArgs() error = %v", err)
+		t.Fatalf("parseDispatchOutcomeArgs() error = %v", err)
 	}
-	if sessionID != "worker-1" || report != "Implemented the fix.\nTests pass." || structuredReport != nil {
-		t.Fatalf("dispatch report = (%q, %q, %+v)", sessionID, report, structuredReport)
+	if parsed.SourceSessionID != "worker-1" || parsed.Report != "Implemented the fix.\nTests pass." {
+		t.Fatalf("dispatch outcome = %+v", parsed)
+	}
+	structured := parsed.StructuredReport
+	if structured.ReportType != protocol.DispatchReportTypeCompletion ||
+		structured.WorkState != protocol.DispatchWorkStateCompleted ||
+		structured.Summary != "Parser implemented" ||
+		protocol.Deref(structured.NextActor) != "chief" ||
+		protocol.Deref(structured.NextAction) != "Review the result" ||
+		len(structured.Constraints) != 1 || structured.Constraints[0] != "no push" {
+		t.Fatalf("structured outcome = %+v", structured)
 	}
 }
 
-func TestParseDispatchHandoffArgsReadsArtifact(t *testing.T) {
+func TestDispatchOutcomeTypes(t *testing.T) {
+	tests := []struct {
+		outcome    string
+		reportType protocol.DispatchReportType
+		workState  protocol.DispatchWorkState
+	}{
+		{"update", protocol.DispatchReportTypeProgress, protocol.DispatchWorkStateInProgress},
+		{"block", protocol.DispatchReportTypeBlocker, protocol.DispatchWorkStateNeedsInput},
+		{"review", protocol.DispatchReportTypeHandoff, protocol.DispatchWorkStateReadyForReview},
+		{"complete", protocol.DispatchReportTypeCompletion, protocol.DispatchWorkStateCompleted},
+		{"fail", protocol.DispatchReportTypeFailure, protocol.DispatchWorkStateFailed},
+	}
+	for _, test := range tests {
+		t.Run(test.outcome, func(t *testing.T) {
+			reportType, workState, ok := dispatchOutcomeTypes(test.outcome)
+			if !ok || reportType != test.reportType || workState != test.workState {
+				t.Fatalf("dispatchOutcomeTypes(%q) = (%q, %q, %v)", test.outcome, reportType, workState, ok)
+			}
+		})
+	}
+}
+
+func TestParseDispatchBlockRequiresQuestionAndBuildsRequest(t *testing.T) {
+	t.Setenv("ATTN_SESSION_ID", "worker-1")
+	if _, err := parseDispatchOutcomeArgs("block", []string{"--summary", "Need input"}); err == nil ||
+		!strings.Contains(err.Error(), "--question is required") {
+		t.Fatalf("missing question error = %v", err)
+	}
+	parsed, err := parseDispatchOutcomeArgs("block", []string{
+		"--summary", "Need the event contract",
+		"--question", "Which event should be emitted?",
+		"--recommendation", "Use AisNoOperationV1",
+		"--consequence", "Emission remains blocked",
+	})
+	if err != nil {
+		t.Fatalf("parseDispatchOutcomeArgs() error = %v", err)
+	}
+	structured := parsed.StructuredReport
+	if structured.ReportType != protocol.DispatchReportTypeBlocker ||
+		structured.WorkState != protocol.DispatchWorkStateNeedsInput ||
+		structured.Request == nil ||
+		structured.Request.Question != "Which event should be emitted?" ||
+		structured.Request.ExpectedResponder != "chief" ||
+		protocol.Deref(structured.Request.Recommendation) != "Use AisNoOperationV1" {
+		t.Fatalf("block outcome = %+v", structured)
+	}
+}
+
+func TestParseDispatchOutcomeArgsRejectsLegacyCoordinationFile(t *testing.T) {
+	_, err := parseDispatchOutcomeArgs("complete", []string{
+		"--session", "worker-1",
+		"--summary", "Done",
+		"--coordination-file", "/tmp/coordination.json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "flag provided but not defined") {
+		t.Fatalf("legacy coordination error = %v", err)
+	}
+}
+
+func TestParseDispatchHandoffArgsReadsArtifactAndBuildsReview(t *testing.T) {
 	t.Setenv("ATTN_SESSION_ID", "worker-1")
 	path := filepath.Join(t.TempDir(), "artifact.md")
 	artifact := "# Findings\n\nThe long report.\n"
 	if err := os.WriteFile(path, []byte(artifact), 0o600); err != nil {
 		t.Fatalf("write artifact: %v", err)
 	}
-	sessionID, to, content, message, structured, err := parseDispatchHandoffArgs([]string{
+	parsed, err := parseDispatchHandoffArgs([]string{
 		"--file", path,
 		"--to", "projects/audit/findings.md",
-		"--message", "Audit done.",
+		"--summary", "Audit ready",
+		"--details", "Review the access findings.",
+		"--review",
 	})
 	if err != nil {
 		t.Fatalf("parseDispatchHandoffArgs() error = %v", err)
 	}
-	if sessionID != "worker-1" || to != "projects/audit/findings.md" || message != "Audit done." {
-		t.Fatalf("handoff = (%q, %q, %q)", sessionID, to, message)
+	if parsed.SourceSessionID != "worker-1" || parsed.To != "projects/audit/findings.md" ||
+		parsed.Report != "Review the access findings." {
+		t.Fatalf("handoff = %+v", parsed)
 	}
-	if content != artifact { // the artifact is sent verbatim, not trimmed
-		t.Fatalf("artifact not verbatim: %q", content)
+	if parsed.Content != artifact { // the artifact is sent verbatim, not trimmed
+		t.Fatalf("artifact not verbatim: %q", parsed.Content)
 	}
-	if structured != nil {
-		t.Fatalf("unexpected structured report: %+v", structured)
+	if parsed.StructuredReport.ReportType != protocol.DispatchReportTypeHandoff ||
+		parsed.StructuredReport.WorkState != protocol.DispatchWorkStateReadyForReview ||
+		parsed.StructuredReport.Summary != "Audit ready" {
+		t.Fatalf("structured handoff = %+v", parsed.StructuredReport)
 	}
 }
 
@@ -619,58 +698,29 @@ func TestParseDispatchHandoffArgsRequiresToAndFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte("body"), 0o600); err != nil {
 		t.Fatalf("write artifact: %v", err)
 	}
-	if _, _, _, _, _, err := parseDispatchHandoffArgs([]string{"--file", path}); err == nil ||
+	if _, err := parseDispatchHandoffArgs([]string{"--file", path}); err == nil ||
 		!strings.Contains(err.Error(), "--to is required") {
 		t.Fatalf("missing --to error = %v", err)
 	}
-	if _, _, _, _, _, err := parseDispatchHandoffArgs([]string{"--to", "projects/x.md"}); err == nil ||
+	if _, err := parseDispatchHandoffArgs([]string{"--to", "projects/x.md"}); err == nil ||
 		!strings.Contains(err.Error(), "--file is required") {
 		t.Fatalf("missing --file error = %v", err)
 	}
 }
 
-func TestParseDispatchReportArgsRejectsAmbiguousContent(t *testing.T) {
-	_, _, _, err := parseDispatchReportArgs([]string{
-		"--session", "worker-1",
-		"--message", "done",
-		"--file", "/tmp/report.md",
-	})
-	if err == nil || !strings.Contains(err.Error(), "only one of --message or --file") {
-		t.Fatalf("parseDispatchReportArgs() error = %v", err)
-	}
-}
-
-func TestParseDispatchReportArgsReadsCoordinationFile(t *testing.T) {
+func TestParseDispatchHandoffRequiresExplicitOutcome(t *testing.T) {
 	t.Setenv("ATTN_SESSION_ID", "worker-1")
-	path := filepath.Join(t.TempDir(), "coordination.json")
-	if err := os.WriteFile(path, []byte(`{
-		"report_type": "blocker",
-		"summary": "Core implementation ready locally",
-		"work_state": "needs_input",
-		"next_actor": "team",
-		"request": {
-			"question": "Which event contract should be used?",
-			"expected_responder": "team",
-			"status": "pending"
-		}
-	}`), 0o600); err != nil {
-		t.Fatalf("write coordination file: %v", err)
+	path := filepath.Join(t.TempDir(), "artifact.md")
+	if err := os.WriteFile(path, []byte("artifact"), 0o600); err != nil {
+		t.Fatalf("write artifact: %v", err)
 	}
-	sessionID, report, structured, err := parseDispatchReportArgs([]string{
-		"--message", "Waiting for the event contract decision.",
-		"--coordination-file", path,
+	_, err := parseDispatchHandoffArgs([]string{
+		"--file", path,
+		"--to", "projects/audit/findings.md",
+		"--summary", "Audit ready",
 	})
-	if err != nil {
-		t.Fatalf("parseDispatchReportArgs() error = %v", err)
-	}
-	if sessionID != "worker-1" || report != "Waiting for the event contract decision." {
-		t.Fatalf("dispatch report = (%q, %q)", sessionID, report)
-	}
-	if structured == nil ||
-		structured.ReportType != protocol.DispatchReportTypeBlocker ||
-		structured.WorkState != protocol.DispatchWorkStateNeedsInput ||
-		structured.Request == nil {
-		t.Fatalf("structured report = %+v", structured)
+	if err == nil || !strings.Contains(err.Error(), "exactly one of --review or --complete") {
+		t.Fatalf("missing handoff outcome error = %v", err)
 	}
 }
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -136,11 +136,11 @@ The chief is **keeper-aware**: because the keeper already narrates each workspac
 own work into the journal, the chief does not duplicate per-workspace play-by-play.
 It writes the cross-workspace layer the keeper cannot see.
 
-## Dispatch / dispatch report
+## Dispatch / dispatch outcome
 
 The chief delegates a unit of work to a sub-agent — a **dispatch**. The sub-agent
-reports its outcome back to the chief as a structured **dispatch report** (a summary
-plus a decision). A terminal dispatch report is captured deterministically into the
+reports back through a typed **dispatch outcome** (an update, blocker, review handoff,
+completion, or failure). A terminal dispatch outcome is captured deterministically into the
 raw tier (`.attn/raw/dispatches/<id>.md`) and persisted in SQLite. The keeper reads
 those raw dispatch outcomes and weaves the terminal ones into the workspace
 narrative; the chief may also reference them in its cross-workspace journaling.

--- a/internal/agent/attn_skill/references/chief-of-staff.md
+++ b/internal/agent/attn_skill/references/chief-of-staff.md
@@ -66,14 +66,35 @@ If the initial task says the work is tracked, report when you:
 - need input or are blocked
 - finish the requested work
 
-Keep a short report concrete: outcome, evidence, and next action.
+Use the command matching the current outcome. Keep the summary concrete: outcome,
+evidence, and next action.
 
-    "$ATTN_WRAPPER_PATH" dispatch report --message \
+    "$ATTN_WRAPPER_PATH" dispatch update --summary \
       "Implemented the parser and tests pass. Next: review the error wording."
 
-For a longer report, write it to a file and submit the file:
+When work needs input, is ready for review, completes, or fails, use the matching
+typed command:
 
-    "$ATTN_WRAPPER_PATH" dispatch report --file /tmp/dispatch-report.md
+    "$ATTN_WRAPPER_PATH" dispatch block \
+      --summary "Core implementation is ready locally" \
+      --question "Which event contract should be used?" \
+      --recommendation "Use AisNoOperationV1" \
+      --consequence "Event emission remains blocked"
+
+    "$ATTN_WRAPPER_PATH" dispatch review \
+      --summary "Parser implementation is ready for review"
+
+    "$ATTN_WRAPPER_PATH" dispatch complete \
+      --summary "Parser implemented and focused tests pass"
+
+    "$ATTN_WRAPPER_PATH" dispatch fail \
+      --summary "Implementation cannot continue because the required API was removed"
+
+Add `--details <text>` or `--details-file <path>` when the chief needs a longer
+report. Use `--next-actor`, `--next-action`, repeated `--remaining-scope`, and
+repeated `--constraint` to make the handoff explicit. Outcome commands print one
+confirmation line by default; add `--json` only when the full dispatch record is
+needed.
 
 A report is a small payload. When you build a large durable artifact — a report, a
 design doc, findings, often built with the user — write it into the Notebook and
@@ -82,52 +103,14 @@ report the reference instead of inlining it:
     "$ATTN_WRAPPER_PATH" dispatch handoff \
       --file /tmp/auth-audit.md \
       --to projects/auth-audit/findings.md \
-      --message "Auth audit complete; full findings in the Notebook."
+      --summary "Auth audit is ready for review" \
+      --review
 
 `--to` is the Notebook path the chief (or user) designated; the daemon writes the
 artifact there and the reference travels back in your report. If no destination was
-designated and the artifact warrants one, ask the chief in a report rather than
-inventing a location. Add `--coordination-file <json>` to a terminal handoff just as
-you would to a report.
-
-For actionable coordination, keep the narrative and attach a JSON envelope:
-
-```json
-{
-  "report_type": "blocker",
-  "summary": "Core freshness gate implemented locally",
-  "work_state": "needs_input",
-  "next_actor": "team",
-  "next_action": "Decide the AisNoOperationV1 event contract",
-  "remaining_scope": ["Emit the event", "Add the integration test"],
-  "constraints": ["uncommitted", "no push", "no PR"],
-  "request": {
-    "question": "Should the worker emit AisNoOperationV1?",
-    "recommendation": "Use AisNoOperationV1",
-    "consequence": "Event emission remains blocked",
-    "expected_responder": "team",
-    "status": "pending"
-  },
-  "artifact": {
-    "identity": "dirty:<stable-status-hash>",
-    "branch": "feat/example",
-    "dirty": true
-  },
-  "verification": [{
-    "actor": "agent",
-    "target": "go test ./internal/feature",
-    "result": "passed",
-    "timestamp": "2026-06-09T18:00:00Z",
-    "artifact_identity": "dirty:<stable-status-hash>"
-  }]
-}
-```
-
-Submit it with:
-
-    "$ATTN_WRAPPER_PATH" dispatch report \
-      --message "Core implementation is ready; event emission needs a decision." \
-      --coordination-file /tmp/dispatch-coordination.json
+designated and the artifact warrants one, ask the chief with `dispatch block`
+rather than inventing a location. Pass exactly one of `--review` or `--complete`
+so the handoff has an explicit work state.
 
 After requesting a decision, read the durable chief response with:
 
@@ -148,5 +131,5 @@ After acting on it, acknowledge it, optionally with a concise result:
       --message "Rebased cleanly; focused tests pass."
 
 Reporting does not stop or transfer your session. Continue working unless the
-task is blocked or complete. Do not use dispatch reporting for ordinary,
+task is blocked or complete. Do not use dispatch outcome commands for ordinary,
 untracked delegation.

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -49,17 +49,24 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 	chiefOfStaff := readSkillFile(t, skillDir, "references/chief-of-staff.md")
 	for _, expected := range []string{
 		"dispatch list",
-		"dispatch report --message",
-		"dispatch report --file",
+		"dispatch update --summary",
+		"dispatch block",
+		"dispatch review",
+		"dispatch complete",
+		"dispatch fail",
 		"latest report",
 		"visible, full interactive",
 		"default to native subagents",
 		"not proof that the work is correct",
-		"Do not use dispatch reporting for ordinary",
+		"Do not use dispatch outcome commands for ordinary",
 	} {
 		if !strings.Contains(chiefOfStaff, expected) {
 			t.Fatalf("chief of staff reference missing %q: %q", expected, chiefOfStaff)
 		}
+	}
+	if strings.Contains(chiefOfStaff, "coordination-file") ||
+		strings.Contains(chiefOfStaff, "dispatch report --") {
+		t.Fatalf("chief of staff reference retains legacy reporting UX: %q", chiefOfStaff)
 	}
 
 	delegation := readSkillFile(t, skillDir, "references/delegation.md")

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -211,16 +211,12 @@ func (c *Client) ListDispatches(sourceSessionID string) ([]protocol.ChiefOfStaff
 	return resp.ChiefOfStaffDispatches, nil
 }
 
-func (c *Client) ReportDispatch(sourceSessionID, report string) (*protocol.ChiefOfStaffDispatch, error) {
-	return c.ReportDispatchEnvelope(sourceSessionID, report, nil)
-}
-
-func (c *Client) ReportDispatchEnvelope(
+func (c *Client) SubmitDispatchOutcome(
 	sourceSessionID, report string,
-	structuredReport *protocol.DispatchReport,
+	structuredReport protocol.DispatchReport,
 ) (*protocol.ChiefOfStaffDispatch, error) {
-	resp, err := c.send(protocol.ReportDispatchMessage{
-		Cmd:              protocol.CmdReportDispatch,
+	resp, err := c.send(protocol.SubmitDispatchOutcomeMessage{
+		Cmd:              protocol.CmdSubmitDispatchOutcome,
 		SourceSessionID:  sourceSessionID,
 		Report:           report,
 		StructuredReport: structuredReport,
@@ -235,11 +231,10 @@ func (c *Client) ReportDispatchEnvelope(
 }
 
 // HandoffDispatch writes a dispatched agent's artifact into the Notebook at `to`
-// and records a dispatch report referencing it. report and structuredReport are
-// optional extra coordination, identical in meaning to ReportDispatchEnvelope's.
+// and records a typed dispatch outcome referencing it.
 func (c *Client) HandoffDispatch(
 	sourceSessionID, to, content, report string,
-	structuredReport *protocol.DispatchReport,
+	structuredReport protocol.DispatchReport,
 ) (*protocol.ChiefOfStaffDispatch, error) {
 	msg := protocol.HandoffDispatchMessage{
 		Cmd:              protocol.CmdHandoffDispatch,

--- a/internal/daemon/chief_of_staff_dispatch.go
+++ b/internal/daemon/chief_of_staff_dispatch.go
@@ -25,23 +25,30 @@ func chiefOfStaffDispatchPrompt(brief string) string {
 
 ---
 This task is tracked by the chief of staff in attn.
-Send a concise update when you reach a meaningful milestone, need input, or finish:
+Report meaningful progress with:
 
-    "$ATTN_WRAPPER_PATH" dispatch report --message "<update>"
+    "$ATTN_WRAPPER_PATH" dispatch update --summary "<progress and next action>"
 
-For a longer update, write it to a file and use ` + "`--file <path>`" + `.
-When work is blocked, ready for review, completed, or failed, attach structured
-coordination fields with ` + "`--coordination-file <json>`" + `.
+Use the command that matches the outcome when work needs input or reaches a handoff:
 
-attn has a Notebook — a durable, profile-wide markdown store. A dispatch report is a
+    "$ATTN_WRAPPER_PATH" dispatch block --summary "<blocker>" --question "<needed decision>"
+    "$ATTN_WRAPPER_PATH" dispatch review --summary "<what is ready>"
+    "$ATTN_WRAPPER_PATH" dispatch complete --summary "<completed outcome>"
+    "$ATTN_WRAPPER_PATH" dispatch fail --summary "<terminal failure>"
+
+Add ` + "`--details <text>`" + ` or ` + "`--details-file <path>`" + ` when the chief needs more than the
+concise summary. Add ` + "`--next-actor`" + ` and ` + "`--next-action`" + ` when responsibility moves.
+
+attn has a Notebook — a durable, profile-wide markdown store. A dispatch outcome is a
 small payload; when you produce a large durable artifact (a report, design doc, or
 findings — often built with the user), hand it into the Notebook instead of inlining
 it, and the reference goes back to the chief:
 
-    "$ATTN_WRAPPER_PATH" dispatch handoff --file <artifact> --to <notebook-path> --message "<update>"
+    "$ATTN_WRAPPER_PATH" dispatch handoff --file <artifact> --to <notebook-path> \
+      --summary "<outcome>" --review
 
 Write to the Notebook path the chief or user designated. If none was designated and
-the artifact warrants one, ask the chief in a report rather than inventing a location.
+the artifact warrants one, ask the chief with ` + "`dispatch block`" + ` rather than inventing a location.
 
 Use ` + "`dispatch status`" + ` to read a chief's durable response to a decision request.
 Before reporting completion or waiting for more work, run
@@ -292,28 +299,28 @@ func (d *Daemon) handleListDispatches(conn net.Conn, msg *protocol.ListDispatche
 	})
 }
 
-func (d *Daemon) handleReportDispatch(conn net.Conn, msg *protocol.ReportDispatchMessage) {
+func (d *Daemon) handleSubmitDispatchOutcome(conn net.Conn, msg *protocol.SubmitDispatchOutcomeMessage) {
 	sourceSessionID := strings.TrimSpace(msg.SourceSessionID)
 	report := strings.TrimSpace(msg.Report)
 	if sourceSessionID == "" {
-		d.sendError(conn, "dispatch report: source_session_id is required")
+		d.sendError(conn, "dispatch outcome: source_session_id is required")
 		return
 	}
 	if report == "" {
-		d.sendError(conn, "dispatch report: report is required")
+		d.sendError(conn, "dispatch outcome: report is required")
 		return
 	}
-	if err := validateDispatchReport(msg.StructuredReport); err != nil {
-		d.sendError(conn, "dispatch report: "+err.Error())
+	if err := validateDispatchReport(&msg.StructuredReport); err != nil {
+		d.sendError(conn, "dispatch outcome: "+err.Error())
 		return
 	}
-	dispatch, err := d.store.UpdateChiefOfStaffDispatchReportEnvelope(
+	dispatch, err := d.store.UpdateChiefOfStaffDispatchOutcome(
 		sourceSessionID,
 		report,
 		msg.StructuredReport,
 	)
 	if err != nil {
-		d.sendError(conn, "dispatch report: "+err.Error())
+		d.sendError(conn, "dispatch outcome: "+err.Error())
 		return
 	}
 	// Capture finished delegated work in the durable journal BEFORE acking the
@@ -324,7 +331,7 @@ func (d *Daemon) handleReportDispatch(conn net.Conn, msg *protocol.ReportDispatc
 	// observable to the caller — when the response returns the per-dispatch file is
 	// on disk — so a socket-level test never races t.TempDir() cleanup against a
 	// still-pending post-response write.
-	if isTerminalDispatchReport(msg.StructuredReport) {
+	if isTerminalDispatchReport(&msg.StructuredReport) {
 		d.journalDispatchOutcome(dispatch)
 	}
 	decorated := d.decorateChiefOfStaffDispatch(dispatch)
@@ -336,8 +343,8 @@ func (d *Daemon) handleReportDispatch(conn net.Conn, msg *protocol.ReportDispatc
 }
 
 // handleHandoffDispatch writes a dispatched agent's large artifact into the
-// Notebook at the chief-designated path, then records a normal dispatch report
-// whose message embeds the resolved reference. A dispatch report is a small
+// Notebook at the chief-designated path, then records a typed dispatch outcome
+// whose message embeds the resolved reference. A dispatch outcome is a small
 // payload; the Notebook carries the bulky artifact the agent built (often with the
 // user), and the report hands the chief a reference it can act on, move, or
 // promote. The Notebook write happens before the report is recorded, so a report
@@ -357,7 +364,7 @@ func (d *Daemon) handleHandoffDispatch(conn net.Conn, msg *protocol.HandoffDispa
 		d.sendError(conn, "dispatch handoff: content is required")
 		return
 	}
-	if err := validateDispatchReport(msg.StructuredReport); err != nil {
+	if err := validateDispatchReport(&msg.StructuredReport); err != nil {
 		d.sendError(conn, "dispatch handoff: "+err.Error())
 		return
 	}
@@ -388,7 +395,7 @@ func (d *Daemon) handleHandoffDispatch(conn net.Conn, msg *protocol.HandoffDispa
 	d.broadcastNotebookChanged(originAgent, rel)
 
 	report := composeHandoffReport(strings.TrimSpace(protocol.Deref(msg.Report)), rel)
-	dispatch, err := d.store.UpdateChiefOfStaffDispatchReportEnvelope(
+	dispatch, err := d.store.UpdateChiefOfStaffDispatchOutcome(
 		sourceSessionID,
 		report,
 		msg.StructuredReport,
@@ -397,7 +404,7 @@ func (d *Daemon) handleHandoffDispatch(conn net.Conn, msg *protocol.HandoffDispa
 		d.sendError(conn, "dispatch handoff: "+err.Error())
 		return
 	}
-	if isTerminalDispatchReport(msg.StructuredReport) {
+	if isTerminalDispatchReport(&msg.StructuredReport) {
 		d.journalDispatchOutcome(dispatch)
 	}
 	decorated := d.decorateChiefOfStaffDispatch(dispatch)
@@ -408,7 +415,7 @@ func (d *Daemon) handleHandoffDispatch(conn net.Conn, msg *protocol.HandoffDispa
 	d.broadcastChiefOfStaffDispatchesUpdated()
 }
 
-// composeHandoffReport builds the dispatch report message for a handoff: the
+// composeHandoffReport builds the outcome details for a handoff: the
 // agent's optional note (or a neutral default) followed by a resolvable
 // root-absolute reference to the artifact the daemon just wrote. The reference is
 // composed server-side so it always points at the real written path.

--- a/internal/daemon/chief_of_staff_dispatch.go
+++ b/internal/daemon/chief_of_staff_dispatch.go
@@ -262,6 +262,25 @@ func validateDispatchReport(report *protocol.DispatchReport) error {
 	return nil
 }
 
+func validateHandoffDispatchReport(report *protocol.DispatchReport) error {
+	if err := validateDispatchReport(report); err != nil {
+		return err
+	}
+	if report.ReportType != protocol.DispatchReportTypeHandoff {
+		return fmt.Errorf("report_type must be %q", protocol.DispatchReportTypeHandoff)
+	}
+	switch report.WorkState {
+	case protocol.DispatchWorkStateReadyForReview, protocol.DispatchWorkStateCompleted:
+		return nil
+	default:
+		return fmt.Errorf(
+			"work_state must be %q or %q",
+			protocol.DispatchWorkStateReadyForReview,
+			protocol.DispatchWorkStateCompleted,
+		)
+	}
+}
+
 func (d *Daemon) chiefOfStaffDispatches(chiefSessionID string) []protocol.ChiefOfStaffDispatch {
 	records := d.store.ListChiefOfStaffDispatches(chiefSessionID)
 	result := make([]protocol.ChiefOfStaffDispatch, 0, len(records))
@@ -364,7 +383,7 @@ func (d *Daemon) handleHandoffDispatch(conn net.Conn, msg *protocol.HandoffDispa
 		d.sendError(conn, "dispatch handoff: content is required")
 		return
 	}
-	if err := validateDispatchReport(&msg.StructuredReport); err != nil {
+	if err := validateHandoffDispatchReport(&msg.StructuredReport); err != nil {
 		d.sendError(conn, "dispatch handoff: "+err.Error())
 		return
 	}

--- a/internal/daemon/chief_of_staff_handoff_test.go
+++ b/internal/daemon/chief_of_staff_handoff_test.go
@@ -52,6 +52,14 @@ func addHandoffDispatch(t *testing.T, d *Daemon, sessionID, dispatchID string) {
 	}
 }
 
+func handoffReviewOutcome(summary string) protocol.DispatchReport {
+	return protocol.DispatchReport{
+		ReportType: protocol.DispatchReportTypeHandoff,
+		WorkState:  protocol.DispatchWorkStateReadyForReview,
+		Summary:    summary,
+	}
+}
+
 // The happy path: a tracked dispatch hands an artifact into the Notebook; the bytes
 // land verbatim at the designated path and the report carries a resolvable
 // root-absolute reference alongside the agent's note.
@@ -61,11 +69,12 @@ func TestHandoffDispatchWritesArtifactAndReferences(t *testing.T) {
 
 	artifact := "# Findings\n\nA long report the agent built with the user.\n"
 	resp := callHandoff(t, d, &protocol.HandoffDispatchMessage{
-		Cmd:             protocol.CmdHandoffDispatch,
-		SourceSessionID: "worker-1",
-		To:              "projects/audit/findings.md",
-		Content:         artifact,
-		Report:          protocol.Ptr("Audit complete."),
+		Cmd:              protocol.CmdHandoffDispatch,
+		SourceSessionID:  "worker-1",
+		To:               "projects/audit/findings.md",
+		Content:          artifact,
+		Report:           protocol.Ptr("Audit complete."),
+		StructuredReport: handoffReviewOutcome("Audit complete."),
 	})
 	if !resp.Ok || resp.ChiefOfStaffDispatch == nil {
 		t.Fatalf("handoff response = %+v", resp)
@@ -91,10 +100,11 @@ func TestHandoffDispatchDefaultNoteAndPathNormalization(t *testing.T) {
 	addHandoffDispatch(t, d, "worker-2", "dsp-2")
 
 	resp := callHandoff(t, d, &protocol.HandoffDispatchMessage{
-		Cmd:             protocol.CmdHandoffDispatch,
-		SourceSessionID: "worker-2",
-		To:              "/areas/notes.md", // leading slash is accepted and normalized away
-		Content:         "body",
+		Cmd:              protocol.CmdHandoffDispatch,
+		SourceSessionID:  "worker-2",
+		To:               "/areas/notes.md", // leading slash is accepted and normalized away
+		Content:          "body",
+		StructuredReport: handoffReviewOutcome("Notes ready for review."),
 	})
 	if !resp.Ok {
 		t.Fatalf("handoff response = %+v", resp)
@@ -116,6 +126,7 @@ func TestHandoffDispatchOverwritesOnRehandoff(t *testing.T) {
 	first := callHandoff(t, d, &protocol.HandoffDispatchMessage{
 		Cmd: protocol.CmdHandoffDispatch, SourceSessionID: "worker-3",
 		To: "projects/x/report.md", Content: "v1",
+		StructuredReport: handoffReviewOutcome("First version ready."),
 	})
 	if !first.Ok {
 		t.Fatalf("first handoff = %+v", first)
@@ -123,6 +134,7 @@ func TestHandoffDispatchOverwritesOnRehandoff(t *testing.T) {
 	second := callHandoff(t, d, &protocol.HandoffDispatchMessage{
 		Cmd: protocol.CmdHandoffDispatch, SourceSessionID: "worker-3",
 		To: "projects/x/report.md", Content: "v2",
+		StructuredReport: handoffReviewOutcome("Second version ready."),
 	})
 	if !second.Ok {
 		t.Fatalf("re-handoff should overwrite, got %+v", second)
@@ -141,6 +153,7 @@ func TestHandoffDispatchRejectsNonDispatchSession(t *testing.T) {
 	resp := callHandoff(t, d, &protocol.HandoffDispatchMessage{
 		Cmd: protocol.CmdHandoffDispatch, SourceSessionID: "rando",
 		To: "projects/x/report.md", Content: "body",
+		StructuredReport: handoffReviewOutcome("Artifact ready."),
 	})
 	if resp.Ok {
 		t.Fatalf("expected rejection, got ok response")
@@ -161,6 +174,7 @@ func TestHandoffDispatchRejectsBadDestination(t *testing.T) {
 		resp := callHandoff(t, d, &protocol.HandoffDispatchMessage{
 			Cmd: protocol.CmdHandoffDispatch, SourceSessionID: "worker-4",
 			To: dest, Content: "body",
+			StructuredReport: handoffReviewOutcome("Artifact ready."),
 		})
 		if resp.Ok {
 			t.Fatalf("dest %q should be rejected", dest)
@@ -171,6 +185,7 @@ func TestHandoffDispatchRejectsBadDestination(t *testing.T) {
 	resp := callHandoff(t, d, &protocol.HandoffDispatchMessage{
 		Cmd: protocol.CmdHandoffDispatch, SourceSessionID: "worker-4",
 		To: "../escape.md", Content: "body",
+		StructuredReport: handoffReviewOutcome("Artifact ready."),
 	})
 	if !resp.Ok {
 		t.Fatalf("parent escape should be contained, got %+v", resp)
@@ -186,6 +201,7 @@ func TestHandoffDispatchRejectsEmptyContent(t *testing.T) {
 	resp := callHandoff(t, d, &protocol.HandoffDispatchMessage{
 		Cmd: protocol.CmdHandoffDispatch, SourceSessionID: "worker-5",
 		To: "projects/x/report.md", Content: "   \n",
+		StructuredReport: handoffReviewOutcome("Artifact ready."),
 	})
 	if resp.Ok || resp.Error == nil || !strings.Contains(*resp.Error, "content is required") {
 		t.Fatalf("expected content-required error, got ok=%v err=%v", resp.Ok, resp.Error)
@@ -199,11 +215,12 @@ func TestHandoffDispatchFullSocketPath(t *testing.T) {
 	addHandoffDispatch(t, d, "worker-sock", "dsp-sock")
 
 	resp := sendNotebookCmd(t, d, protocol.HandoffDispatchMessage{
-		Cmd:             protocol.CmdHandoffDispatch,
-		SourceSessionID: "worker-sock",
-		To:              "projects/sock/report.md",
-		Content:         "wired",
-		Report:          protocol.Ptr("Routed."),
+		Cmd:              protocol.CmdHandoffDispatch,
+		SourceSessionID:  "worker-sock",
+		To:               "projects/sock/report.md",
+		Content:          "wired",
+		Report:           protocol.Ptr("Routed."),
+		StructuredReport: handoffReviewOutcome("Routed."),
 	})
 	if resp.ChiefOfStaffDispatch == nil {
 		t.Fatalf("socket handoff returned no dispatch: %+v", resp)
@@ -226,7 +243,7 @@ func TestHandoffDispatchTerminalAlsoJournals(t *testing.T) {
 		Cmd: protocol.CmdHandoffDispatch, SourceSessionID: "worker-6",
 		To: "projects/audit/final.md", Content: "# Final\n",
 		Report: protocol.Ptr("Done."),
-		StructuredReport: &protocol.DispatchReport{
+		StructuredReport: protocol.DispatchReport{
 			ReportType: protocol.DispatchReportTypeCompletion,
 			WorkState:  protocol.DispatchWorkStateCompleted,
 			Summary:    "Audit finished; findings handed off.",

--- a/internal/daemon/chief_of_staff_handoff_test.go
+++ b/internal/daemon/chief_of_staff_handoff_test.go
@@ -208,6 +208,54 @@ func TestHandoffDispatchRejectsEmptyContent(t *testing.T) {
 	}
 }
 
+func TestHandoffDispatchRejectsInvalidOutcomeBeforeNotebookWrite(t *testing.T) {
+	tests := []struct {
+		name    string
+		outcome protocol.DispatchReport
+		wantErr string
+	}{
+		{
+			name: "non-handoff report type",
+			outcome: protocol.DispatchReport{
+				ReportType: protocol.DispatchReportTypeProgress,
+				WorkState:  protocol.DispatchWorkStateReadyForReview,
+				Summary:    "Artifact ready.",
+			},
+			wantErr: "report_type must be",
+		},
+		{
+			name: "non-terminal work state",
+			outcome: protocol.DispatchReport{
+				ReportType: protocol.DispatchReportTypeHandoff,
+				WorkState:  protocol.DispatchWorkStateInProgress,
+				Summary:    "Artifact still in progress.",
+			},
+			wantErr: "work_state must be",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := newNotebookDaemon(t)
+			addHandoffDispatch(t, d, "worker-invalid", "dsp-invalid")
+			resp := callHandoff(t, d, &protocol.HandoffDispatchMessage{
+				Cmd:              protocol.CmdHandoffDispatch,
+				SourceSessionID:  "worker-invalid",
+				To:               "projects/audit/invalid.md",
+				Content:          "must not be written",
+				StructuredReport: test.outcome,
+			})
+			if resp.Ok || resp.Error == nil || !strings.Contains(*resp.Error, test.wantErr) {
+				t.Fatalf("invalid handoff outcome = %+v", resp)
+			}
+			root := d.store.GetSetting(SettingNotebookRoot)
+			if _, err := os.Stat(filepath.Join(root, "projects/audit/invalid.md")); !os.IsNotExist(err) {
+				t.Fatalf("invalid handoff wrote Notebook artifact: %v", err)
+			}
+		})
+	}
+}
+
 // The full unix-socket path (ParseMessage decode -> daemon route -> handler) wires
 // the new command end to end, not just the handler in isolation.
 func TestHandoffDispatchFullSocketPath(t *testing.T) {
@@ -244,7 +292,7 @@ func TestHandoffDispatchTerminalAlsoJournals(t *testing.T) {
 		To: "projects/audit/final.md", Content: "# Final\n",
 		Report: protocol.Ptr("Done."),
 		StructuredReport: protocol.DispatchReport{
-			ReportType: protocol.DispatchReportTypeCompletion,
+			ReportType: protocol.DispatchReportTypeHandoff,
 			WorkState:  protocol.DispatchWorkStateCompleted,
 			Summary:    "Audit finished; findings handed off.",
 		},

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -30,7 +30,7 @@ func commandMetadata(scope CommandScope, blocksDuringRecovery bool, log bool) Co
 var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdRegister:                              commandMetadata(ScopeSession, false, true),
 	protocol.CmdListDispatches:                        commandMetadata(ScopeHubLocal, false, true),
-	protocol.CmdReportDispatch:                        commandMetadata(ScopeSession, false, true),
+	protocol.CmdSubmitDispatchOutcome:                 commandMetadata(ScopeSession, false, true),
 	protocol.CmdHandoffDispatch:                       commandMetadata(ScopeSession, false, true),
 	protocol.CmdSendDispatchMessage:                   commandMetadata(ScopeHubLocal, false, true),
 	protocol.CmdListDispatchMessages:                  commandMetadata(ScopeSession, false, true),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1851,8 +1851,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleDelegate(conn, msg.(*protocol.DelegateMessage))
 	case protocol.CmdListDispatches:
 		d.handleListDispatches(conn, msg.(*protocol.ListDispatchesMessage))
-	case protocol.CmdReportDispatch:
-		d.handleReportDispatch(conn, msg.(*protocol.ReportDispatchMessage))
+	case protocol.CmdSubmitDispatchOutcome:
+		d.handleSubmitDispatchOutcome(conn, msg.(*protocol.SubmitDispatchOutcomeMessage))
 	case protocol.CmdHandoffDispatch:
 		d.handleHandoffDispatch(conn, msg.(*protocol.HandoffDispatchMessage))
 	case protocol.CmdGetDispatch:

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -158,7 +158,9 @@ func TestChiefOfStaffDelegateCreatesTrackedDispatch(t *testing.T) {
 		t.Fatalf("delegate result = %+v, want dispatch id", result)
 	}
 	if !strings.Contains(prompt, "Investigate the tracked task.") ||
-		!strings.Contains(prompt, "dispatch report --message") {
+		!strings.Contains(prompt, "dispatch update --summary") ||
+		!strings.Contains(prompt, "dispatch complete --summary") ||
+		strings.Contains(prompt, "coordination-file") {
 		t.Fatalf("tracked initial prompt = %q", prompt)
 	}
 
@@ -234,10 +236,15 @@ func TestChiefOfStaffDelegationPreservesCoordinationIdentityAcrossPlacements(t *
 
 			reportServer, reportClient := net.Pipe()
 			go func() {
-				d.handleReportDispatch(reportServer, &protocol.ReportDispatchMessage{
-					Cmd:             protocol.CmdReportDispatch,
+				d.handleSubmitDispatchOutcome(reportServer, &protocol.SubmitDispatchOutcomeMessage{
+					Cmd:             protocol.CmdSubmitDispatchOutcome,
 					SourceSessionID: spawn.ID,
 					Report:          "Placement identity verified.",
+					StructuredReport: protocol.DispatchReport{
+						ReportType: protocol.DispatchReportTypeProgress,
+						WorkState:  protocol.DispatchWorkStateInProgress,
+						Summary:    "Placement identity verified.",
+					},
 				})
 				_ = reportServer.Close()
 			}()
@@ -377,7 +384,7 @@ func TestOrdinaryDelegationDoesNotDecorateDelegatedFromChief(t *testing.T) {
 	}
 }
 
-func TestDispatchReportUpdatesTrackedRecord(t *testing.T) {
+func TestSubmitDispatchOutcomeUpdatesTrackedRecord(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
 	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
@@ -398,10 +405,15 @@ func TestDispatchReportUpdatesTrackedRecord(t *testing.T) {
 	server, client := net.Pipe()
 	defer client.Close()
 	go func() {
-		d.handleReportDispatch(server, &protocol.ReportDispatchMessage{
-			Cmd:             protocol.CmdReportDispatch,
+		d.handleSubmitDispatchOutcome(server, &protocol.SubmitDispatchOutcomeMessage{
+			Cmd:             protocol.CmdSubmitDispatchOutcome,
 			SourceSessionID: result.SessionID,
 			Report:          "Implementation complete; focused tests pass.",
+			StructuredReport: protocol.DispatchReport{
+				ReportType: protocol.DispatchReportTypeCompletion,
+				WorkState:  protocol.DispatchWorkStateCompleted,
+				Summary:    "Implementation complete; focused tests pass.",
+			},
 		})
 		_ = server.Close()
 	}()
@@ -682,11 +694,11 @@ func TestStructuredDispatchReportSeparatesRuntimeAndSupportsResolution(t *testin
 	server, client := net.Pipe()
 	reportDone := make(chan struct{})
 	go func() {
-		d.handleReportDispatch(server, &protocol.ReportDispatchMessage{
-			Cmd:              protocol.CmdReportDispatch,
+		d.handleSubmitDispatchOutcome(server, &protocol.SubmitDispatchOutcomeMessage{
+			Cmd:              protocol.CmdSubmitDispatchOutcome,
 			SourceSessionID:  result.SessionID,
 			Report:           "Core implementation ready; decision required.",
-			StructuredReport: report,
+			StructuredReport: *report,
 		})
 		_ = server.Close()
 		close(reportDone)

--- a/internal/daemon/notebook_dispatch_journal_test.go
+++ b/internal/daemon/notebook_dispatch_journal_test.go
@@ -423,7 +423,7 @@ func TestRenderDispatchJournalEntryWallClockHeaderDrifts(t *testing.T) {
 
 // The full report path: reporting a completed dispatch over the socket lands a
 // single grounded journal block, and re-reporting it does not duplicate it.
-func TestReportDispatchAutoJournals(t *testing.T) {
+func TestSubmitDispatchOutcomeAutoJournals(t *testing.T) {
 	d := newNotebookDaemon(t)
 	addIdleNotebookSession(d, "worker-1", protocol.SessionStateWorking)
 	if err := d.store.AddChiefOfStaffDispatch(&protocol.ChiefOfStaffDispatch{
@@ -433,11 +433,11 @@ func TestReportDispatchAutoJournals(t *testing.T) {
 		t.Fatalf("add dispatch: %v", err)
 	}
 
-	report := protocol.ReportDispatchMessage{
-		Cmd:             protocol.CmdReportDispatch,
+	report := protocol.SubmitDispatchOutcomeMessage{
+		Cmd:             protocol.CmdSubmitDispatchOutcome,
 		SourceSessionID: "worker-1",
 		Report:          "done",
-		StructuredReport: &protocol.DispatchReport{
+		StructuredReport: protocol.DispatchReport{
 			ReportType: protocol.DispatchReportTypeCompletion,
 			WorkState:  protocol.DispatchWorkStateCompleted,
 			Summary:    "Wired the auto-journal into the report path.",
@@ -465,7 +465,7 @@ func TestReportDispatchAutoJournals(t *testing.T) {
 
 // A non-terminal report (needs_input) is NOT journaled by the report path — only
 // finished dispatches become durable entries.
-func TestReportDispatchNonTerminalDoesNotJournal(t *testing.T) {
+func TestSubmitDispatchOutcomeNonTerminalDoesNotJournal(t *testing.T) {
 	d := newNotebookDaemon(t)
 	addIdleNotebookSession(d, "worker-3", protocol.SessionStateWorking)
 	if err := d.store.AddChiefOfStaffDispatch(&protocol.ChiefOfStaffDispatch{
@@ -475,11 +475,11 @@ func TestReportDispatchNonTerminalDoesNotJournal(t *testing.T) {
 		t.Fatalf("add dispatch: %v", err)
 	}
 
-	sendNotebookCmd(t, d, protocol.ReportDispatchMessage{
-		Cmd:             protocol.CmdReportDispatch,
+	sendNotebookCmd(t, d, protocol.SubmitDispatchOutcomeMessage{
+		Cmd:             protocol.CmdSubmitDispatchOutcome,
 		SourceSessionID: "worker-3",
 		Report:          "progress",
-		StructuredReport: &protocol.DispatchReport{
+		StructuredReport: protocol.DispatchReport{
 			ReportType: protocol.DispatchReportTypeProgress,
 			WorkState:  protocol.DispatchWorkStateInProgress,
 			Summary:    "Still working.",

--- a/internal/dispatch/classify.go
+++ b/internal/dispatch/classify.go
@@ -17,8 +17,8 @@
 //     the sentinel "closed" once the session is gone. This comes from attn's
 //     PTY/stop classifier.
 //   - StructuredReport: the coordination envelope the delegated agent explicitly
-//     files via `attn dispatch report --coordination-file` (work_state,
-//     report_type, an optional decision Request, summary, next_action).
+//     outcome commands such as `attn dispatch complete` and `dispatch block`
+//     (work_state, report_type, an optional decision Request, summary, next_action).
 //
 // Doneness and failure are claimed by the agent, not inferred. Only an explicit
 // structured report yields Done or Failed; the runtime Status governs liveness

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "121"
+const ProtocolVersion = "122"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -44,7 +44,7 @@ const (
 	CmdRegister                              = "register"
 	CmdDelegate                              = "delegate"
 	CmdListDispatches                        = "list_dispatches"
-	CmdReportDispatch                        = "report_dispatch"
+	CmdSubmitDispatchOutcome                 = "submit_dispatch_outcome"
 	CmdHandoffDispatch                       = "handoff_dispatch"
 	CmdGetDispatch                           = "get_dispatch"
 	CmdResolveDispatchRequest                = "resolve_dispatch_request"
@@ -373,8 +373,8 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		}
 		return peek.Cmd, &msg, nil
 
-	case CmdReportDispatch:
-		var msg ReportDispatchMessage
+	case CmdSubmitDispatchOutcome:
+		var msg SubmitDispatchOutcomeMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1626,7 +1626,7 @@ type HandoffDispatchMessage struct {
 	SourceSessionID string `json:"source_session_id"`
 
 	// StructuredReport corresponds to the JSON schema field "structured_report".
-	StructuredReport *DispatchReport `json:"structured_report,omitempty,omitzero"`
+	StructuredReport DispatchReport `json:"structured_report"`
 
 	// To corresponds to the JSON schema field "to".
 	To string `json:"to"`
@@ -2779,20 +2779,6 @@ type RepoState struct {
 	Repo string `json:"repo"`
 }
 
-type ReportDispatchMessage struct {
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
-
-	// Report corresponds to the JSON schema field "report".
-	Report string `json:"report"`
-
-	// SourceSessionID corresponds to the JSON schema field "source_session_id".
-	SourceSessionID string `json:"source_session_id"`
-
-	// StructuredReport corresponds to the JSON schema field "structured_report".
-	StructuredReport *DispatchReport `json:"structured_report,omitempty,omitzero"`
-}
-
 type ReposUpdatedMessage struct {
 	// Event corresponds to the JSON schema field "event".
 	Event string `json:"event"`
@@ -3592,6 +3578,20 @@ type StopReviewLoopMessage struct {
 
 	// SessionID corresponds to the JSON schema field "session_id".
 	SessionID string `json:"session_id"`
+}
+
+type SubmitDispatchOutcomeMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Report corresponds to the JSON schema field "report".
+	Report string `json:"report"`
+
+	// SourceSessionID corresponds to the JSON schema field "source_session_id".
+	SourceSessionID string `json:"source_session_id"`
+
+	// StructuredReport corresponds to the JSON schema field "structured_report".
+	StructuredReport DispatchReport `json:"structured_report"`
 }
 
 type SubscribeGitStatusMessage struct {

--- a/internal/protocol/parse_test.go
+++ b/internal/protocol/parse_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -157,7 +158,7 @@ func TestParseDispatchCommands(t *testing.T) {
 	}
 
 	cmd, data, err = ParseMessage([]byte(`{
-		"cmd":"report_dispatch",
+		"cmd":"submit_dispatch_outcome",
 		"source_session_id":"worker-1",
 		"report":"waiting for a decision",
 		"structured_report":{
@@ -168,13 +169,12 @@ func TestParseDispatchCommands(t *testing.T) {
 		}
 	}`))
 	if err != nil {
-		t.Fatalf("ParseMessage(report_dispatch) error = %v", err)
+		t.Fatalf("ParseMessage(submit_dispatch_outcome) error = %v", err)
 	}
-	report := data.(*ReportDispatchMessage)
-	if cmd != CmdReportDispatch ||
+	report := data.(*SubmitDispatchOutcomeMessage)
+	if cmd != CmdSubmitDispatchOutcome ||
 		report.SourceSessionID != "worker-1" ||
 		report.Report != "waiting for a decision" ||
-		report.StructuredReport == nil ||
 		report.StructuredReport.WorkState != DispatchWorkStateNeedsInput {
 		t.Fatalf("report dispatch = %q %+v", cmd, report)
 	}
@@ -202,6 +202,17 @@ func TestParseDispatchCommands(t *testing.T) {
 		resolution.DispatchID != "dispatch-1" ||
 		resolution.Response != "Use V1." {
 		t.Fatalf("resolve dispatch request = %q %+v", cmd, resolution)
+	}
+}
+
+func TestParseMessageRejectsRemovedReportDispatchCommand(t *testing.T) {
+	_, _, err := ParseMessage([]byte(`{
+		"cmd":"report_dispatch",
+		"source_session_id":"worker-1",
+		"report":"done"
+	}`))
+	if err == nil || !strings.Contains(err.Error(), "unknown command") {
+		t.Fatalf("removed report_dispatch error = %v", err)
 	}
 }
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -544,27 +544,27 @@ model ListDispatchesMessage {
   source_session_id: string;
 }
 
-model ReportDispatchMessage {
-  cmd: "report_dispatch";
+model SubmitDispatchOutcomeMessage {
+  cmd: "submit_dispatch_outcome";
   source_session_id: string;
   report: string;
-  structured_report?: DispatchReport;
+  structured_report: DispatchReport;
 }
 
 // Hand a large artifact built by a dispatched agent into the Notebook and report
 // the reference back to the chief. `to` is a root-relative Notebook path the chief
 // (or user) designated; `content` is the artifact bytes the daemon writes there.
-// The daemon records a normal dispatch report whose message embeds the resolved
+// The daemon records a typed dispatch outcome whose message embeds the resolved
 // reference, so the handoff flows through the same report/capture path — there is
-// no separate structured artifact field. report/structured_report are optional
-// extra coordination, identical in meaning to ReportDispatchMessage's.
+// no separate structured artifact field. `report` is optional detail;
+// `structured_report` is the required typed outcome.
 model HandoffDispatchMessage {
   cmd: "handoff_dispatch";
   source_session_id: string;
   to: string;
   content: string;
   report?: string;
-  structured_report?: DispatchReport;
+  structured_report: DispatchReport;
 }
 
 model GetDispatchMessage {

--- a/internal/store/chief_of_staff_dispatches.go
+++ b/internal/store/chief_of_staff_dispatches.go
@@ -283,13 +283,9 @@ func (s *Store) ListChiefOfStaffDispatches(chiefSessionID string) []*protocol.Ch
 	return result
 }
 
-func (s *Store) UpdateChiefOfStaffDispatchReport(sessionID, report string) (*protocol.ChiefOfStaffDispatch, error) {
-	return s.UpdateChiefOfStaffDispatchReportEnvelope(sessionID, report, nil)
-}
-
-func (s *Store) UpdateChiefOfStaffDispatchReportEnvelope(
+func (s *Store) UpdateChiefOfStaffDispatchOutcome(
 	sessionID, report string,
-	structuredReport *protocol.DispatchReport,
+	structuredReport protocol.DispatchReport,
 ) (*protocol.ChiefOfStaffDispatch, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -303,20 +299,18 @@ func (s *Store) UpdateChiefOfStaffDispatchReportEnvelope(
 		return nil, fmt.Errorf("report cannot be empty")
 	}
 	now := string(protocol.TimestampNow())
-	structuredReport = cloneDispatchReport(structuredReport)
-	if structuredReport != nil {
-		structuredReport.ReportedAt = now
-		artifactIdentity := ""
-		if structuredReport.Artifact != nil {
-			artifactIdentity = strings.TrimSpace(structuredReport.Artifact.Identity)
-		}
-		for i := range structuredReport.Verification {
-			current := artifactIdentity != "" &&
-				strings.TrimSpace(structuredReport.Verification[i].ArtifactIdentity) == artifactIdentity
-			structuredReport.Verification[i].Current = protocol.Ptr(current)
-		}
+	storedOutcome := cloneDispatchReport(&structuredReport)
+	storedOutcome.ReportedAt = now
+	artifactIdentity := ""
+	if storedOutcome.Artifact != nil {
+		artifactIdentity = strings.TrimSpace(storedOutcome.Artifact.Identity)
 	}
-	structuredReportJSON, err := encodeDispatchReport(structuredReport)
+	for i := range storedOutcome.Verification {
+		current := artifactIdentity != "" &&
+			strings.TrimSpace(storedOutcome.Verification[i].ArtifactIdentity) == artifactIdentity
+		storedOutcome.Verification[i].Current = protocol.Ptr(current)
+	}
+	structuredReportJSON, err := encodeDispatchReport(storedOutcome)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +321,7 @@ func (s *Store) UpdateChiefOfStaffDispatchReportEnvelope(
 			}
 			updated := cloneChiefOfStaffDispatch(dispatch)
 			updated.LatestReport = protocol.Ptr(report)
-			updated.StructuredReport = structuredReport
+			updated.StructuredReport = storedOutcome
 			updated.ReportedAt = protocol.Ptr(now)
 			updated.UpdatedAt = now
 			s.chiefDispatches[id] = updated
@@ -347,11 +341,11 @@ func (s *Store) UpdateChiefOfStaffDispatchReportEnvelope(
 		sessionID,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("update dispatch report: %w", err)
+		return nil, fmt.Errorf("update dispatch outcome: %w", err)
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return nil, fmt.Errorf("read dispatch report update result: %w", err)
+		return nil, fmt.Errorf("read dispatch outcome update result: %w", err)
 	}
 	if rows == 0 {
 		return nil, fmt.Errorf("session %s is not a tracked dispatch", sessionID)

--- a/internal/store/chief_of_staff_dispatches_test.go
+++ b/internal/store/chief_of_staff_dispatches_test.go
@@ -36,7 +36,11 @@ func TestChiefOfStaffDispatchLifecycle(t *testing.T) {
 		t.Fatalf("other chief dispatches = %+v", other)
 	}
 
-	updated, err := s.UpdateChiefOfStaffDispatchReport("worker-1", "Root cause found.")
+	updated, err := s.UpdateChiefOfStaffDispatchOutcome("worker-1", "Root cause found.", protocol.DispatchReport{
+		ReportType: protocol.DispatchReportTypeProgress,
+		WorkState:  protocol.DispatchWorkStateInProgress,
+		Summary:    "Root cause found.",
+	})
 	if err != nil {
 		t.Fatalf("update report: %v", err)
 	}
@@ -244,10 +248,10 @@ func TestChiefOfStaffStructuredReportPersistsAndResolves(t *testing.T) {
 			},
 		},
 	}
-	updated, err := s.UpdateChiefOfStaffDispatchReportEnvelope(
+	updated, err := s.UpdateChiefOfStaffDispatchOutcome(
 		"worker-1",
 		"Core implementation is ready; event emission needs a decision.",
-		report,
+		*report,
 	)
 	if err != nil {
 		t.Fatalf("update structured report: %v", err)


### PR DESCRIPTION
## Intent / Why

Delegated agents currently have to construct raw coordination JSON to report terminal work states. That interface is difficult to discover and fails late when an agent invents or misremembers the schema, leaving the chief with an incomplete or unstructured update.

This change makes the work outcome the CLI operation itself. It deliberately replaces the old reporting interface instead of retaining a compatibility path that preserves the same failure mode.

## Summary

- replace `attn dispatch report` with explicit `update`, `block`, `review`, `complete`, and `fail` commands
- keep concise summaries separate from optional details, next ownership, remaining scope, constraints, and blocker decision requests
- require Notebook handoffs to declare `--review` or `--complete`
- check unread chief messages before waiting or terminal outcomes and print a concise success acknowledgement by default
- replace the `report_dispatch` wire command with required typed `submit_dispatch_outcome` payloads and bump the protocol to 122
- update generated types, delegated-agent guidance, glossary, tests, and changelog; remove raw coordination-file support

## Test plan

- [x] `go test -count=1 ./cmd/attn ./internal/protocol ./internal/store ./internal/dispatch ./internal/agent`
- [x] `go test -count=1 ./internal/daemon`
- [x] `pnpm --dir app test` (1,143 tests)
- [x] `pnpm --dir app run build`
- [x] Build and install isolated `attn-dev.app` with `make dev`
- [x] Verify packaged dev CLI exposes the new commands and rejects `dispatch report`
- [x] Codex autoreview: no accepted/actionable findings