### PR TITLE
feat(delegate): workspace reuse guidance and --workspace + --worktree support

### DIFF
--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -602,8 +602,8 @@ placement:
   --worktree <branch>        create a worktree for the delegated session
 
 worktree options:
-  combine with --new-workspace to place the worktree in a new workspace
-  --repo <path>              main repository (defaults to the source repository)
+  combine with any placement (current, --workspace, or --new-workspace)
+  --repo <path>              main repository (defaults to the workspace repository)
   --from <ref>               branch or ref to start from
   --worktree-path <path>     override the generated sibling path
 
@@ -1608,8 +1608,8 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 	repo := strings.TrimSpace(*worktreeRepo)
 	startingFrom := strings.TrimSpace(*worktreeStart)
 	customWorktreePath := strings.TrimSpace(*worktreePath)
-	if explicitWorkspace != "" && (*newWorkspace || customCWD != "" || branch != "") {
-		return delegateCLIArgs{}, errors.New("--workspace cannot be combined with --new-workspace, --cwd, or --worktree")
+	if explicitWorkspace != "" && (*newWorkspace || customCWD != "") {
+		return delegateCLIArgs{}, errors.New("--workspace cannot be combined with --new-workspace or --cwd")
 	}
 	if customCWD != "" && branch != "" {
 		return delegateCLIArgs{}, errors.New("--cwd cannot be combined with --worktree")

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -560,7 +560,7 @@ func TestParseDelegateArgsWorktreeUsesExplicitNewWorkspace(t *testing.T) {
 func TestParseDelegateArgsRejectsAmbiguousPlacement(t *testing.T) {
 	for _, args := range [][]string{
 		{"--workspace", "workspace-target", "--new-workspace"},
-		{"--workspace", "workspace-target", "--worktree", "feat/parser"},
+		{"--workspace", "workspace-target", "--cwd", "/some/dir"},
 	} {
 		_, err := parseDelegateArgs(append([]string{
 			"--source-session", "source-session",
@@ -569,6 +569,23 @@ func TestParseDelegateArgsRejectsAmbiguousPlacement(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "--workspace cannot be combined") {
 			t.Fatalf("parseDelegateArgs(%v) error = %v", args, err)
 		}
+	}
+}
+
+func TestParseDelegateArgsAcceptsWorkspaceWithWorktree(t *testing.T) {
+	parsed, err := parseDelegateArgs([]string{
+		"--source-session", "source-session",
+		"--brief", "Work in an existing workspace with a worktree",
+		"--workspace", "workspace-target",
+		"--worktree", "feat/parser",
+	})
+	if err != nil {
+		t.Fatalf("parseDelegateArgs error = %v", err)
+	}
+	if parsed.options.Placement != "existing_workspace" ||
+		parsed.options.WorkspaceID != "workspace-target" ||
+		parsed.options.Worktree != "feat/parser" {
+		t.Fatalf("options = %+v", parsed.options)
 	}
 }
 
@@ -887,7 +904,7 @@ func TestWriteDelegateHelpMentionsPlacementOptions(t *testing.T) {
 		"--workspace <id>",
 		"--cwd <path>",
 		"--worktree <branch>",
-		"combine with --new-workspace to place the worktree in a new workspace",
+		"combine with any placement (current, --workspace, or --new-workspace)",
 		"--agent <name>",
 		"--name <text>",
 	} {

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -76,19 +76,24 @@ When the source session is the chief of staff, delegating into a muted existing
 workspace automatically unmutes it so the new agent is visible in the sidebar.
 Ordinary delegation preserves the workspace's current mute state.
 
-Create an isolated worktree in the current workspace:
+`--worktree` creates an isolated git worktree for branch isolation. It combines
+with any placement:
 
+    # worktree in the current workspace
     "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" \
       --worktree feat/delegated-task
 
-Place the isolated worktree in a separate new workspace:
+    # worktree in an existing workspace
+    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" \
+      --workspace <workspace-id> --worktree feat/delegated-task
 
+    # worktree in a new workspace
     "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" \
       --new-workspace --worktree feat/delegated-task
 
 Worktree options:
 
-- `--repo <path>` chooses the main repository.
+- `--repo <path>` chooses the main repository (defaults to the workspace's repo).
 - `--from <ref>` chooses the starting branch or ref.
 - `--worktree-path <path>` chooses an explicit worktree location.
 

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -46,7 +46,20 @@ Copilot delegation is currently unsupported.
 
 ## Placement
 
-No placement flag adds the delegated session to the current workspace:
+Before creating a new workspace, check whether an existing one already fits the
+work. `attn list` returns a `workspaces` array; each entry has `id`, `title`,
+`directory`, and `pinned`. Pinned workspaces are long-lived domain spaces the
+user keeps around (e.g. code reviews, goalie rotation, triage). When the
+delegated task matches a workspace's domain, place it there with `--workspace`:
+
+    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" --workspace <workspace-id>
+
+When delegating multiple independent items in parallel, route each agent to the
+workspace that fits its domain rather than creating a new workspace per item.
+
+If no existing workspace fits, use one of:
+
+No placement flag — adds the session to the current workspace:
 
     "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file"
 
@@ -57,10 +70,6 @@ Create a separate workspace using the source directory:
 Create a workspace at an existing directory:
 
     "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" --cwd /path/to/project
-
-Join an existing workspace:
-
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" --workspace <workspace-id>
 
 `attn list` marks sessions in hidden workspaces with `workspace_muted: true`.
 When the source session is the chief of staff, delegating into a muted existing

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -47,15 +47,19 @@ Copilot delegation is currently unsupported.
 ## Placement
 
 Before creating a new workspace, check whether an existing one already fits the
-work. `attn list` returns a `workspaces` array; each entry has `id`, `title`,
-`directory`, and `pinned`. Pinned workspaces are long-lived domain spaces the
-user keeps around (e.g. code reviews, goalie rotation, triage). When the
-delegated task matches a workspace's domain, place it there with `--workspace`:
+work. `attn list` returns sessions grouped by `workspace_id`; use the session
+labels, directories, and workspace IDs to identify domain workspaces the user
+already has (e.g. code reviews, goalie rotation, triage). When the delegated
+task matches an existing workspace's domain, place it there with `--workspace`:
 
     "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" --workspace <workspace-id>
 
 When delegating multiple independent items in parallel, route each agent to the
 workspace that fits its domain rather than creating a new workspace per item.
+
+`--workspace` cannot be combined with `--worktree`, `--new-workspace`, or
+`--cwd`. When a task needs both workspace reuse and branch isolation, place it
+in the matching workspace without `--worktree`.
 
 If no existing workspace fits, use one of:
 

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -57,10 +57,6 @@ task matches an existing workspace's domain, place it there with `--workspace`:
 When delegating multiple independent items in parallel, route each agent to the
 workspace that fits its domain rather than creating a new workspace per item.
 
-`--workspace` cannot be combined with `--worktree`, `--new-workspace`, or
-`--cwd`. When a task needs both workspace reuse and branch isolation, place it
-in the matching workspace without `--worktree`.
-
 If no existing workspace fits, use one of:
 
 No placement flag — adds the session to the current workspace:

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -81,7 +81,7 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 		"--workspace <workspace-id>",
 		"--cwd /path/to/project",
 		"--worktree feat/delegated-task",
-		"isolated worktree in the current workspace",
+		"isolated git worktree for branch isolation",
 		"--new-workspace --worktree feat/delegated-task",
 		"--worktree-path <path>",
 		"--source-session <session-id>",

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -77,6 +77,7 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 		"user explicitly asks for delegation",
 		"delegate --brief-file",
 		"--new-workspace",
+		"Before creating a new workspace, check whether an existing one already fits",
 		"--workspace <workspace-id>",
 		"--cwd /path/to/project",
 		"--worktree feat/delegated-task",

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -160,29 +160,29 @@ func (d *Daemon) rollbackDelegation(createdWorkspaceID, createdWorktreePath stri
 	return cause
 }
 
-func (d *Daemon) createDelegationWorktree(sourceDirectory string, request *protocol.DelegateWorktreeRequest) (string, error) {
+func (d *Daemon) createDelegationWorktree(baseDirectory string, request *protocol.DelegateWorktreeRequest) (string, error) {
 	branch := strings.TrimSpace(request.Branch)
 	if branch == "" {
 		return "", fmt.Errorf("worktree branch is required")
 	}
 	repo := strings.TrimSpace(protocol.Deref(request.Repo))
 	if repo == "" {
-		repoRoot, err := git.GetRepoRoot(sourceDirectory)
+		repoRoot, err := git.GetRepoRoot(baseDirectory)
 		if err != nil {
-			return "", fmt.Errorf("source directory is not in a git repository; pass --repo")
+			return "", fmt.Errorf("workspace directory is not in a git repository; pass --repo")
 		}
 		repo = git.ResolveMainRepoPath(repoRoot)
 	}
 	startingFrom := request.StartingFrom
 	if strings.TrimSpace(protocol.Deref(startingFrom)) == "" {
-		sourceRoot, sourceRootErr := git.GetRepoRoot(sourceDirectory)
-		sourceBranch, sourceBranchErr := git.GetBranchInfo(sourceDirectory)
-		if sourceRootErr == nil &&
-			sourceBranchErr == nil &&
-			sourceBranch != nil &&
-			strings.TrimSpace(sourceBranch.Branch) != "" &&
-			git.ResolveMainRepoPath(sourceRoot) == git.ResolveMainRepoPath(repo) {
-			startingFrom = protocol.Ptr(strings.TrimSpace(sourceBranch.Branch))
+		baseRoot, baseRootErr := git.GetRepoRoot(baseDirectory)
+		baseBranch, baseBranchErr := git.GetBranchInfo(baseDirectory)
+		if baseRootErr == nil &&
+			baseBranchErr == nil &&
+			baseBranch != nil &&
+			strings.TrimSpace(baseBranch.Branch) != "" &&
+			git.ResolveMainRepoPath(baseRoot) == git.ResolveMainRepoPath(repo) {
+			startingFrom = protocol.Ptr(strings.TrimSpace(baseBranch.Branch))
 		}
 	}
 	worktreePath, err := d.doCreateWorktree(&protocol.CreateWorktreeMessage{
@@ -245,8 +245,8 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 		}
 		directory = source.Directory
 	case delegationPlacementExisting:
-		if msg.Worktree != nil || strings.TrimSpace(protocol.Deref(msg.Cwd)) != "" {
-			return nil, fmt.Errorf("existing_workspace placement does not accept cwd or worktree")
+		if strings.TrimSpace(protocol.Deref(msg.Cwd)) != "" {
+			return nil, fmt.Errorf("existing_workspace placement does not accept cwd")
 		}
 		workspaceID = strings.TrimSpace(protocol.Deref(msg.WorkspaceID))
 		workspace := d.store.GetWorkspace(workspaceID)
@@ -287,7 +287,7 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 	}
 
 	if msg.Worktree != nil {
-		worktreePath, createErr := d.createDelegationWorktree(source.Directory, msg.Worktree)
+		worktreePath, createErr := d.createDelegationWorktree(directory, msg.Worktree)
 		if createErr != nil {
 			return nil, createErr
 		}

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -1354,23 +1354,62 @@ func TestChiefOfStaffDelegateUnmutesExistingWorkspace(t *testing.T) {
 	}
 }
 
-func TestDelegateRejectsWorktreeInExistingWorkspace(t *testing.T) {
+func TestDelegateCreatesWorktreeInExistingWorkspace(t *testing.T) {
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	runGitDaemon(t, mainRepo, "init")
+	runGitDaemon(t, mainRepo, "commit", "--allow-empty", "-m", "init")
+
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
-	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	_, sourceSessionID, _ := setupDelegationSourceAt(t, d, backend, mainRepo)
+	consumeDelegatedPrompt(t, backend)
 
-	_, err := d.delegate(&protocol.DelegateMessage{
+	targetWorkspaceID := "workspace-target"
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        targetWorkspaceID,
+		Title:     "Target",
+		Directory: mainRepo,
+	})
+
+	worktreePath := filepath.Join(root, "repo--feat-existing-ws")
+	result, err := d.delegate(&protocol.DelegateMessage{
 		Cmd:             protocol.CmdDelegate,
 		SourceSessionID: sourceSessionID,
-		Brief:           "Do not create this unsupported worktree.",
+		Brief:           "Work in a worktree placed in an existing workspace.",
+		Label:           protocol.Ptr("delegated"),
 		Placement:       protocol.Ptr(delegationPlacementExisting),
-		WorkspaceID:     protocol.Ptr("workspace-source"),
+		WorkspaceID:     protocol.Ptr(targetWorkspaceID),
 		Worktree: &protocol.DelegateWorktreeRequest{
-			Branch: "feat/unsupported",
+			Branch: "feat/existing-ws",
+			Path:   protocol.Ptr(worktreePath),
 		},
 	})
-	if err == nil || !strings.Contains(err.Error(), "existing_workspace placement does not accept cwd or worktree") {
+	if err != nil {
 		t.Fatalf("delegate() error = %v", err)
+	}
+	worktreePath = git.CanonicalizePath(worktreePath)
+	if result.Placement != delegationPlacementExisting ||
+		result.WorkspaceID != targetWorkspaceID ||
+		result.Directory != worktreePath ||
+		!protocol.Deref(result.WorktreeCreated) {
+		t.Fatalf("result = %+v", result)
+	}
+	session := d.store.Get(result.SessionID)
+	if session == nil ||
+		session.WorkspaceID != targetWorkspaceID ||
+		session.Directory != worktreePath ||
+		session.Label != "delegated" ||
+		protocol.Deref(session.Branch) != "feat/existing-ws" {
+		t.Fatalf("delegated worktree session = %+v", session)
+	}
+	layout := d.store.GetWorkspaceLayout(targetWorkspaceID)
+	if layout == nil || len(layout.Panes) != 1 {
+		t.Fatalf("target workspace layout = %+v, want one pane", layout)
 	}
 }
 


### PR DESCRIPTION
## Intent

The chief of staff was creating new workspaces for every delegated task even
when a matching pinned/domain workspace already existed. Worse, if the task
needed branch isolation, `--workspace` and `--worktree` couldn't be combined
— so workspace reuse was fundamentally incompatible with worktrees.

## Summary

**Guidance** (`internal/agent/attn_skill/references/delegation.md`):
- Placement section leads with checking `attn list` for existing workspaces
  before creating new ones
- Parallel delegation: route each agent to the matching domain workspace
- Documents `--worktree` with all three placements (current, existing, new)

**Product** — lift `--workspace + --worktree` restriction:
- CLI (`cmd/attn/main.go`): `--workspace` now only rejects `--new-workspace`
  and `--cwd` (not `--worktree`)
- Daemon (`internal/daemon/delegate.go`): `existing_workspace` placement
  accepts worktree requests
- Worktree creation uses the target workspace's directory for repo discovery
  and starting-branch inference (not the source session's)

**Tests**:
- New `TestDelegateCreatesWorktreeInExistingWorkspace` — end-to-end daemon test
- New `TestParseDelegateArgsAcceptsWorkspaceWithWorktree` — CLI parsing test
- Updated rejection tests and help-text assertions
- Skill test asserts workspace-reuse preamble

## Test plan

- [x] `go test ./internal/daemon/ -run TestDelegate` — all pass
- [x] `go test ./cmd/attn/ -run TestParseDelegate` — all pass
- [x] `go test ./internal/agent/ -run TestAttnSkill` — all pass
- [x] `make dev` — dev app built and installed
- [ ] End-to-end: chief delegates with `--workspace <id> --worktree <branch>`
  into an existing pinned workspace (manual in dev app)