### PR TITLE
fix(cli): show pinned empty workspaces in list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-26]
+
+### Fixed
+- **`attn list` now shows pinned workspaces even when they are empty.** The command returns workspace snapshots alongside live sessions, so chief-of-staff agents can see a pinned workspace's ID, name, directory, and pinned state before delegating into it instead of creating a duplicate workspace.
+
 ## [2026-06-24]
 
 ### Added

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -172,7 +172,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '122';
+export const PROTOCOL_VERSION = '123';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -2969,6 +2969,7 @@ export interface Response {
     workspace_context_maintenance_result?: WorkspaceContextMaintenanceResultObject;
     workspace_context_result?:             WorkspaceContextResultObject;
     workspace_contexts?:                   WorkspaceContextElement[];
+    workspaces?:                           WorkspaceElement[];
     [property: string]: any;
 }
 
@@ -8505,6 +8506,7 @@ const typeMap: any = {
         { json: "workspace_context_maintenance_result", js: "workspace_context_maintenance_result", typ: u(undefined, r("WorkspaceContextMaintenanceResultObject")) },
         { json: "workspace_context_result", js: "workspace_context_result", typ: u(undefined, r("WorkspaceContextResultObject")) },
         { json: "workspace_contexts", js: "workspace_contexts", typ: u(undefined, a(r("WorkspaceContextElement"))) },
+        { json: "workspaces", js: "workspaces", typ: u(undefined, a(r("WorkspaceElement"))) },
     ], "any"),
     "DispatchMessageObject": o([
         { json: "acknowledged_at", js: "acknowledged_at", typ: u(undefined, "") },

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -514,15 +514,15 @@ func runWSRelay() {
 func runList() {
 	warnIfDaemonVersionMismatch()
 	c := client.New("")
-	sessions, err := c.Query("")
+	result, err := c.List("")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(sessions); err != nil {
-		fmt.Fprintf(os.Stderr, "error encoding sessions: %v\n", err)
+	if err := enc.Encode(result); err != nil {
+		fmt.Fprintf(os.Stderr, "error encoding list: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -564,7 +564,7 @@ commands:
   browser <command>                 open and control the in-app browser
   review-loop <command>             manage an autonomous review loop
   workflow <command>                run, inspect, and resume durable workflows
-  list                              list sessions
+  list                              list sessions and workspaces
   daemon <command>                  manage the daemon
   profile <status|resolve|list>     show / resolve the active profile's resources
   profile-env <profile|--unset>     print shell commands for selecting a profile

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -23,6 +23,11 @@ type Client struct {
 	socketPath string
 }
 
+type ListResult struct {
+	Sessions   []protocol.Session   `json:"sessions"`
+	Workspaces []protocol.Workspace `json:"workspaces"`
+}
+
 // New creates a new client
 func New(socketPath string) *Client {
 	if socketPath == "" {
@@ -448,8 +453,7 @@ func (c *Client) NotebookGuide(sessionID string) (*protocol.NotebookGuideResult,
 	return resp.NotebookGuide, nil
 }
 
-// Query returns sessions matching the filter
-func (c *Client) Query(filter string) ([]protocol.Session, error) {
+func (c *Client) queryResponse(filter string) (*protocol.Response, error) {
 	var filterPtr *string
 	if filter != "" {
 		filterPtr = &filter
@@ -462,7 +466,36 @@ func (c *Client) Query(filter string) ([]protocol.Session, error) {
 	if err != nil {
 		return nil, err
 	}
+	return resp, nil
+}
+
+// Query returns sessions matching the filter.
+func (c *Client) Query(filter string) ([]protocol.Session, error) {
+	resp, err := c.queryResponse(filter)
+	if err != nil {
+		return nil, err
+	}
 	return resp.Sessions, nil
+}
+
+// List returns the decorated sessions and workspace snapshots used by `attn list`.
+func (c *Client) List(filter string) (*ListResult, error) {
+	resp, err := c.queryResponse(filter)
+	if err != nil {
+		return nil, err
+	}
+	sessions := resp.Sessions
+	if sessions == nil {
+		sessions = []protocol.Session{}
+	}
+	workspaces := resp.Workspaces
+	if workspaces == nil {
+		workspaces = []protocol.Workspace{}
+	}
+	return &ListResult{
+		Sessions:   sessions,
+		Workspaces: workspaces,
+	}, nil
 }
 
 // Heartbeat sends a heartbeat for a session

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -269,6 +269,55 @@ func TestClient_Query(t *testing.T) {
 	}
 }
 
+func TestClient_ListIncludesWorkspaces(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "attn-client-")
+	if err != nil {
+		t.Fatalf("MkdirTemp error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	sockPath := filepath.Join(tmpDir, "test.sock")
+
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen error: %v", err)
+	}
+	defer listener.Close()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 4096)
+		conn.Read(buf)
+
+		resp := protocol.Response{
+			Ok: true,
+			Sessions: []protocol.Session{
+				{ID: "1", Label: "one", State: protocol.SessionStateWaitingInput},
+			},
+			Workspaces: []protocol.Workspace{
+				{ID: "workspace-empty", Title: "Empty", Directory: "/repo", Status: protocol.WorkspaceStatusIdle, Pinned: true},
+			},
+		}
+		json.NewEncoder(conn).Encode(resp)
+	}()
+
+	c := New(sockPath)
+	result, err := c.List("")
+	if err != nil {
+		t.Fatalf("List error: %v", err)
+	}
+	if len(result.Sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(result.Sessions))
+	}
+	if len(result.Workspaces) != 1 || result.Workspaces[0].ID != "workspace-empty" || !result.Workspaces[0].Pinned {
+		t.Fatalf("workspaces = %+v, want pinned empty workspace", result.Workspaces)
+	}
+}
+
 func TestClient_Delegate(t *testing.T) {
 	tmpDir := t.TempDir()
 	sockPath := filepath.Join(tmpDir, "test.sock")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2784,7 +2784,7 @@ func (d *Daemon) handleQuery(conn net.Conn, msg *protocol.QueryMessage) {
 	resp := protocol.Response{
 		Ok:         true,
 		Sessions:   d.sessionsForBroadcast(sessions),
-		Workspaces: d.listWorkspaces(),
+		Workspaces: d.listLocalWorkspaces(),
 	}
 	json.NewEncoder(conn).Encode(resp)
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2782,8 +2782,9 @@ func (d *Daemon) handleTodos(conn net.Conn, msg *protocol.TodosMessage) {
 func (d *Daemon) handleQuery(conn net.Conn, msg *protocol.QueryMessage) {
 	sessions := d.store.List(protocol.Deref(msg.Filter))
 	resp := protocol.Response{
-		Ok:       true,
-		Sessions: d.sessionsForBroadcast(sessions),
+		Ok:         true,
+		Sessions:   d.sessionsForBroadcast(sessions),
+		Workspaces: d.listWorkspaces(),
 	}
 	json.NewEncoder(conn).Encode(resp)
 }

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -1312,6 +1312,41 @@ func TestDelegateTargetsExistingWorkspace(t *testing.T) {
 	}
 }
 
+func TestDelegateTargetsPinnedEmptyWorkspace(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+	targetDir := t.TempDir()
+	targetWorkspaceID := "workspace-empty-pinned"
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        targetWorkspaceID,
+		Title:     "Empty pinned",
+		Directory: targetDir,
+	})
+	if _, errMsg := d.setWorkspacePinned(targetWorkspaceID, true); errMsg != "" {
+		t.Fatalf("pin target workspace: %s", errMsg)
+	}
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Reuse the empty pinned workspace.",
+		Placement:       protocol.Ptr(delegationPlacementExisting),
+		WorkspaceID:     protocol.Ptr(targetWorkspaceID),
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	if result.WorkspaceID != targetWorkspaceID || result.Directory != targetDir {
+		t.Fatalf("result = %+v", result)
+	}
+	if sessions := d.store.SessionsInWorkspace(targetWorkspaceID); len(sessions) != 1 || sessions[0] != result.SessionID {
+		t.Fatalf("target workspace sessions = %v, want delegated session %s", sessions, result.SessionID)
+	}
+}
+
 func TestChiefOfStaffDelegateUnmutesExistingWorkspace(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}

--- a/internal/daemon/workspace.go
+++ b/internal/daemon/workspace.go
@@ -688,8 +688,9 @@ func (d *Daemon) workspaceHasSessionlessContent(workspaceID string) bool {
 	return d.workspaceLayoutHasTiles(workspaceID)
 }
 
-// listWorkspaces returns a snapshot of the current workspaces for InitialState.
-func (d *Daemon) listWorkspaces() []protocol.Workspace {
+// listLocalWorkspaces returns a snapshot of the local workspaces that can be
+// targeted by local CLI operations such as `attn delegate --workspace`.
+func (d *Daemon) listLocalWorkspaces() []protocol.Workspace {
 	if d.workspaces == nil {
 		return nil
 	}
@@ -700,6 +701,13 @@ func (d *Daemon) listWorkspaces() []protocol.Workspace {
 			workspaces[i].Layout = layout
 		}
 	}
+	return workspaces
+}
+
+// listWorkspaces returns a snapshot of the current local and remote workspaces
+// for app InitialState.
+func (d *Daemon) listWorkspaces() []protocol.Workspace {
+	workspaces := d.listLocalWorkspaces()
 	if d.hubManager != nil {
 		workspaces = append(workspaces, d.hubManager.RemoteWorkspaces()...)
 	}

--- a/internal/daemon/workspace_test.go
+++ b/internal/daemon/workspace_test.go
@@ -816,6 +816,41 @@ func TestPinnedEmptyWorkspaceSurvivesStartupCleanup(t *testing.T) {
 	}
 }
 
+func TestQueryIncludesPinnedEmptyWorkspace(t *testing.T) {
+	d := newDaemonForTest(t)
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        "ws-pinned",
+		Title:     "Pinned",
+		Directory: "/repo",
+	})
+	if _, errMsg := d.setWorkspacePinned("ws-pinned", true); errMsg != "" {
+		t.Fatalf("pin workspace: %s", errMsg)
+	}
+
+	server, client := net.Pipe()
+	defer client.Close()
+	go func() {
+		defer server.Close()
+		d.handleQuery(server, &protocol.QueryMessage{Cmd: protocol.CmdQuery})
+	}()
+
+	var resp protocol.Response
+	if err := json.NewDecoder(client).Decode(&resp); err != nil {
+		t.Fatalf("decode query response: %v", err)
+	}
+	if len(resp.Sessions) != 0 {
+		t.Fatalf("sessions = %d, want none", len(resp.Sessions))
+	}
+	if len(resp.Workspaces) != 1 {
+		t.Fatalf("workspaces = %d, want pinned empty workspace", len(resp.Workspaces))
+	}
+	got := resp.Workspaces[0]
+	if got.ID != "ws-pinned" || !got.Pinned || got.Status != protocol.WorkspaceStatusIdle {
+		t.Fatalf("workspace = %+v, want pinned idle ws-pinned", got)
+	}
+}
+
 func TestSetWorkspacePinned_PersistsAndBroadcasts(t *testing.T) {
 	d := newDaemonForTest(t)
 	cap := captureBroadcasts(d)

--- a/internal/daemon/workspace_test.go
+++ b/internal/daemon/workspace_test.go
@@ -510,7 +510,7 @@ func TestSessionForBroadcast_PreservesPersistedWorkspaceIDDuringRegistryRecovery
 	}
 }
 
-func TestListWorkspaces_IncludesRegistered(t *testing.T) {
+func TestListLocalWorkspaces_IncludesRegistered(t *testing.T) {
 	d := newDaemonForTest(t)
 	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
 		Cmd: protocol.CmdRegisterWorkspace, ID: "ws1", Title: "A", Directory: "/a",
@@ -519,7 +519,7 @@ func TestListWorkspaces_IncludesRegistered(t *testing.T) {
 		Cmd: protocol.CmdRegisterWorkspace, ID: "ws2", Title: "B", Directory: "/b",
 	})
 
-	list := d.listWorkspaces()
+	list := d.listLocalWorkspaces()
 	if len(list) != 2 {
 		t.Fatalf("expected 2 workspaces, got %d (%+v)", len(list), list)
 	}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "122"
+const ProtocolVersion = "123"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2890,6 +2890,9 @@ type Response struct {
 
 	// WorkspaceContexts corresponds to the JSON schema field "workspace_contexts".
 	WorkspaceContexts []WorkspaceContext `json:"workspace_contexts,omitempty,omitzero"`
+
+	// Workspaces corresponds to the JSON schema field "workspaces".
+	Workspaces []Workspace `json:"workspaces,omitempty,omitzero"`
 }
 
 type ReviewComment struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -2170,6 +2170,7 @@ model Response {
   dispatch_message?: DispatchMessage;
   dispatch_messages?: DispatchMessage[];
   sessions?: Session[];
+  workspaces?: Workspace[];
   prs?: PR[];
   repos?: RepoState[];
   authors?: AuthorState[];


### PR DESCRIPTION
## Intent / Why

Victor expects chief-of-staff agents to use `attn list` when choosing where to place new delegations. Pinned workspaces are meant to remain reusable even when their last session is gone, but the CLI only returned live sessions, so an empty pinned workspace had no visible ID or context. Agents could not discover the workspace and would create duplicates instead of reusing it.

## Summary

- Include workspace snapshots in daemon query responses so CLI consumers can see pinned empty workspaces, not just sessions.
- Add `Client.List` for `attn list` while keeping `Client.Query` session-only for existing callers.
- Update `attn list` to print `{ "sessions": [...], "workspaces": [...] }`, exposing workspace ID, title, directory, status, muted, pinned, rank, and layout when present.
- Regenerate protocol types and bump the protocol version to force daemon/client agreement.
- Cover both discovery and reuse: pinned empty workspaces appear in query/list output, and delegation into a pinned empty workspace succeeds.

## Test plan

- [x] `go test ./internal/client ./internal/daemon -run 'TestClient_(Query|ListIncludesWorkspaces)$|Test(QueryIncludesPinnedEmptyWorkspace|DelegateTargetsPinnedEmptyWorkspace|PinnedEmptyWorkspaceSurvivesStartupCleanup|PinnedWorkspaceSurvivesFinalSessionClose)$'`
- [x] `go test ./cmd/attn ./internal/client ./internal/daemon -run '^$'`
- [x] `pnpm --dir app exec tsc --noEmit`
- [x] `git diff --check`

## Out of scope

- No live `~/.attn` workspace data was mutated for verification.
- No chief-of-staff prompt guidance was changed; the product surface now exposes the workspace directly.
