### PR TITLE
feat(tickets): slice 1 — ticket store + lifecycle

### DIFF
--- a/docs/plans/2026-06-26-work-tracker.md
+++ b/docs/plans/2026-06-26-work-tracker.md
@@ -228,7 +228,7 @@ each is a meaningful, verifiable chunk.
 
 | # | slice | status |
 |---|---|---|
-| 1 | Ticket store + lifecycle | ⬜ |
+| 1 | Ticket store + lifecycle | 🟡 |
 | 2 | Event-driven notification core | ⬜ |
 | 3 | Delegation ⇄ tickets (live wiring) | ⬜ |
 | 4 | Ticket view + resume + attachments | ⬜ |
@@ -237,10 +237,14 @@ each is a meaningful, verifiable chunk.
 | 7 | Retire the `dispatch` namespace | ⬜ |
 | 8 | Export ticket state (CLI) — *post-merge, lands on `main`* | ⬜ |
 
-1. **Ticket store + lifecycle.** The `tickets` + `activity` + `attachments` tables, the
-   status enum (incl. Todo / Crashed), human-friendly ids, CRUD + status transitions,
-   and the archive / 30-day-TTL sweep. Evolves `chief_of_staff_dispatches`. *Test:*
-   store-level — create/read/update, transitions, archival, TTL with injected time.
+1. **Ticket store + lifecycle.** Fresh `tickets` / `ticket_activity` /
+   `ticket_attachments` tables (migration 55), the status enum (incl. Todo / Crashed),
+   human-friendly slug ids (uniqueness check + collision guidance), CRUD + permissive
+   status transitions, and the archive / 30-day-TTL sweep. Store-local row types (the
+   wire shape comes later). The old `chief_of_staff_dispatches` table is left untouched
+   and dies with its namespace in slice 7 — a fresh table is cleaner than evolving one we
+   tear out anyway. *Test:* store-level — create/read/update, transitions, archival, TTL
+   with injected time.
 2. **Event-driven notification core.** Mutations emit events; observers + cursors;
    the two decoupled handlers (watch-consume / nudge), bundled-by-ticket, dedup,
    unread. Built against the store, **proven by a simulation harness** (drives

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -457,6 +457,47 @@ CREATE INDEX IF NOT EXISTS idx_workflow_agent_calls_run_id
 	{52, "rename workspace context janitor backups to keeper compact backups", ""},
 	{53, "add closed_state to chief of staff dispatches", ""},
 	{54, "add pinned to workspaces", ""},
+	{55, "create ticket tables", `CREATE TABLE IF NOT EXISTS tickets (
+    id            TEXT PRIMARY KEY,
+    title         TEXT NOT NULL,
+    description   TEXT NOT NULL DEFAULT '',
+    status        TEXT NOT NULL,
+    assignee      TEXT NOT NULL DEFAULT '',
+    cwd           TEXT NOT NULL DEFAULT '',
+    last_agent_id TEXT NOT NULL DEFAULT '',
+    project_id    TEXT NOT NULL DEFAULT '',
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL,
+    closed_at     TEXT NOT NULL DEFAULT '',
+    archived_at   TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_tickets_status ON tickets(status);
+CREATE INDEX IF NOT EXISTS idx_tickets_archived_closed
+    ON tickets(archived_at, closed_at);
+CREATE TABLE IF NOT EXISTS ticket_activity (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticket_id   TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    author      TEXT NOT NULL DEFAULT '',
+    from_status TEXT NOT NULL DEFAULT '',
+    to_status   TEXT NOT NULL DEFAULT '',
+    comment     TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL,
+    FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_ticket_activity_ticket
+    ON ticket_activity(ticket_id, id ASC);
+CREATE TABLE IF NOT EXISTS ticket_attachments (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticket_id   TEXT NOT NULL,
+    filename    TEXT NOT NULL,
+    path        TEXT NOT NULL DEFAULT '',
+    note        TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL,
+    FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_ticket_attachments_ticket
+    ON ticket_attachments(ticket_id, id ASC);`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -1,0 +1,713 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Tickets are the durable unit of tracked work in attn — independent of any
+// session. This file is the store layer for slice 1 of the work tracker (see
+// docs/plans/2026-06-26-work-tracker.md): the schema, CRUD, status transitions,
+// and the archive / TTL lifecycle. Notification events (slice 2) and the live
+// session wiring (slice 3+) layer on top of these primitives; nothing here knows
+// about observers or sessions.
+//
+// Following the workflow_runs convention, the row types are store-local (NOT
+// protocol/generated types) — the protocol/wire shape is owned by a later slice.
+
+// TicketStatus is the column a ticket sits in. The board informs, it never gates:
+// transitions are permissive (any status may move to any other). The only thing a
+// status drives is lifecycle — the terminal statuses age out via the TTL sweep.
+type TicketStatus string
+
+const (
+	// TicketStatusTodo is the backlog: created, not started.
+	TicketStatusTodo TicketStatus = "todo"
+	// TicketStatusWorking is actively being worked.
+	TicketStatusWorking TicketStatus = "working"
+	// TicketStatusBlocked is paused, owing the chief a reply.
+	TicketStatusBlocked TicketStatus = "blocked"
+	// TicketStatusInReview is done, awaiting a look/approval.
+	TicketStatusInReview TicketStatus = "in_review"
+	// TicketStatusDone is closed, worked.
+	TicketStatusDone TicketStatus = "done"
+	// TicketStatusFailed is finished, didn't work.
+	TicketStatusFailed TicketStatus = "failed"
+	// TicketStatusCrashed is died without reporting — the one transition attn
+	// itself writes, since a dead worker can't.
+	TicketStatusCrashed TicketStatus = "crashed"
+)
+
+// IsValid reports whether st is a known status.
+func (st TicketStatus) IsValid() bool {
+	switch st {
+	case TicketStatusTodo, TicketStatusWorking, TicketStatusBlocked,
+		TicketStatusInReview, TicketStatusDone, TicketStatusFailed, TicketStatusCrashed:
+		return true
+	}
+	return false
+}
+
+// IsTerminal reports whether st is a settled-and-done status. Terminal tickets
+// carry a closed_at timestamp and are the only ones the TTL sweep removes.
+func (st TicketStatus) IsTerminal() bool {
+	switch st {
+	case TicketStatusDone, TicketStatusFailed, TicketStatusCrashed:
+		return true
+	}
+	return false
+}
+
+// TicketActivityKind is the type of a history entry. Per the model there are
+// exactly two: a status change (the ticket moved column, optionally with a note)
+// and a freeform comment. What used to be a dispatch "report" is just a status
+// change with a comment.
+type TicketActivityKind string
+
+const (
+	// TicketActivityStatusChange records a column move (from -> to), optionally
+	// with an accompanying comment.
+	TicketActivityStatusChange TicketActivityKind = "status_change"
+	// TicketActivityComment records a freeform note from either side.
+	TicketActivityComment TicketActivityKind = "comment"
+)
+
+// Ticket is the durable record. Activity and Attachments are populated by
+// GetTicket; list operations leave them nil for cheapness.
+type Ticket struct {
+	ID          string
+	Title       string
+	Description string
+	Status      TicketStatus
+	Assignee    string // agent id, "you", or "" when unassigned
+	Cwd         string // last session's working dir (for resume)
+	LastAgentID string // last session's agent id (for resume)
+	ProjectID   string // future grouping; "" when ungrouped
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	ClosedAt    *time.Time // set on entering a terminal status; drives the TTL
+	ArchivedAt  *time.Time // set when manually cleared from the board
+
+	Activity    []TicketActivity   // populated by GetTicket
+	Attachments []TicketAttachment // populated by GetTicket
+}
+
+// TicketActivity is one entry in a ticket's history thread.
+type TicketActivity struct {
+	ID         int64
+	TicketID   string
+	Kind       TicketActivityKind
+	Author     string       // who authored it ("you", a chief, an agent id)
+	FromStatus TicketStatus // status_change only
+	ToStatus   TicketStatus // status_change only
+	Comment    string       // freeform note (may accompany a status change)
+	CreatedAt  time.Time
+}
+
+// TicketAttachment is a file handed over with the work. Slice 1 stores the
+// record; the file-handling ergonomics (copy-into-store) come with slice 4.
+type TicketAttachment struct {
+	ID        int64
+	TicketID  string
+	Filename  string
+	Path      string
+	Note      string
+	CreatedAt time.Time
+}
+
+// TicketListFilter narrows ListTickets. The zero value lists every non-archived
+// ticket, newest first.
+type TicketListFilter struct {
+	Status          TicketStatus // "" matches any status
+	IncludeArchived bool         // false hides archived tickets (the default board)
+}
+
+// Ticket lifecycle errors. Callers match these with errors.Is; the error string
+// is also surfaced to agents, so it carries the actionable guidance directly.
+var (
+	// ErrTicketIDTaken means a ticket already exists with that slug.
+	ErrTicketIDTaken = errors.New("ticket id already in use")
+	// ErrTicketNotFound means no ticket exists with that id.
+	ErrTicketNotFound = errors.New("ticket not found")
+	// ErrInvalidTicketID means the slug isn't a well-formed handle.
+	ErrInvalidTicketID = errors.New("invalid ticket id")
+	// ErrInvalidTicketStatus means the status isn't one of the known columns.
+	ErrInvalidTicketStatus = errors.New("invalid ticket status")
+	// ErrTicketTitleRequired means a ticket was created without a title.
+	ErrTicketTitleRequired = errors.New("ticket title required")
+	// ErrTicketNotClosed means an open ticket can't be archived — open tickets
+	// are durable and never leave the board until they settle.
+	ErrTicketNotClosed = errors.New("ticket is not closed")
+)
+
+// ticketIDPattern is a human-friendly slug: lowercase alphanumerics and hyphens,
+// starting with an alphanumeric. Speakable, typeable, distinctive.
+var ticketIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// ticketScanner abstracts *sql.Row and *sql.Rows so one scan func serves both.
+type ticketScanner interface {
+	Scan(dest ...any) error
+}
+
+// ValidateTicketID reports whether id is a well-formed slug.
+func ValidateTicketID(id string) error {
+	if id == "" {
+		return fmt.Errorf("%w: id is empty", ErrInvalidTicketID)
+	}
+	if !ticketIDPattern.MatchString(id) {
+		return fmt.Errorf("%w: %q must be lowercase letters, digits, and hyphens (e.g. store-migration)", ErrInvalidTicketID, id)
+	}
+	return nil
+}
+
+// CreateTicket inserts a new ticket. The id is an agent-chosen memorable slug; on
+// collision it fails with ErrTicketIDTaken and actionable guidance. An empty
+// status defaults to Todo. The supplied now stamps created_at/updated_at (and
+// closed_at, in the unusual case of creating directly into a terminal status).
+func (s *Store) CreateTicket(t Ticket, now time.Time) (*Ticket, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+
+	t.ID = strings.TrimSpace(t.ID)
+	if err := ValidateTicketID(t.ID); err != nil {
+		return nil, err
+	}
+	t.Title = strings.TrimSpace(t.Title)
+	if t.Title == "" {
+		return nil, ErrTicketTitleRequired
+	}
+	if t.Status == "" {
+		t.Status = TicketStatusTodo
+	}
+	if !t.Status.IsValid() {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidTicketStatus, t.Status)
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	var exists int
+	switch err := tx.QueryRow(`SELECT 1 FROM tickets WHERE id = ?`, t.ID).Scan(&exists); err {
+	case nil:
+		return nil, fmt.Errorf("%w: %q is already taken — pick a new name, or append a number (e.g. %q)", ErrTicketIDTaken, t.ID, t.ID+"-2")
+	case sql.ErrNoRows:
+		// free to use
+	default:
+		return nil, err
+	}
+
+	t.CreatedAt = now
+	t.UpdatedAt = now
+	if t.Status.IsTerminal() {
+		closed := now
+		t.ClosedAt = &closed
+	} else {
+		t.ClosedAt = nil
+	}
+	t.ArchivedAt = nil
+
+	if _, err := tx.Exec(`
+		INSERT INTO tickets (
+			id, title, description, status, assignee, cwd, last_agent_id,
+			project_id, created_at, updated_at, closed_at, archived_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		t.ID, t.Title, t.Description, string(t.Status), t.Assignee, t.Cwd, t.LastAgentID,
+		t.ProjectID, formatTicketTime(now), formatTicketTime(now),
+		formatTicketTimePtr(t.ClosedAt), formatTicketTimePtr(t.ArchivedAt),
+	); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// GetTicket returns a ticket with its full activity thread and attachments, or
+// (nil, nil) if it doesn't exist.
+func (s *Store) GetTicket(id string) (*Ticket, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+
+	ticket, err := scanTicket(s.db.QueryRow(ticketSelect+` WHERE id = ?`, id))
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if ticket.Activity, err = s.ticketActivity(id); err != nil {
+		return nil, err
+	}
+	if ticket.Attachments, err = s.ticketAttachments(id); err != nil {
+		return nil, err
+	}
+	return ticket, nil
+}
+
+// ListTickets returns tickets matching the filter, newest first. Activity and
+// attachments are not loaded (use GetTicket for the full record).
+func (s *Store) ListTickets(filter TicketListFilter) ([]*Ticket, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+
+	where := []string{}
+	args := []any{}
+	if !filter.IncludeArchived {
+		where = append(where, `archived_at = ''`)
+	}
+	if filter.Status != "" {
+		where = append(where, `status = ?`)
+		args = append(args, string(filter.Status))
+	}
+	query := ticketSelect
+	if len(where) > 0 {
+		query += ` WHERE ` + strings.Join(where, ` AND `)
+	}
+	query += ` ORDER BY created_at DESC, id DESC`
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tickets []*Ticket
+	for rows.Next() {
+		ticket, err := scanTicket(rows)
+		if err != nil {
+			return nil, err
+		}
+		tickets = append(tickets, ticket)
+	}
+	return tickets, rows.Err()
+}
+
+// SetTicketStatus moves a ticket to a new column and records the change in the
+// activity thread (from -> to, with an optional comment). Transitions are
+// permissive. Entering a terminal status stamps closed_at; leaving one clears it
+// so reopened work becomes durable again. Returns the updated ticket row.
+func (s *Store) SetTicketStatus(id string, to TicketStatus, author, comment string, now time.Time) (*Ticket, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	if !to.IsValid() {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidTicketStatus, to)
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	current, err := scanTicket(tx.QueryRow(ticketSelect+` WHERE id = ?`, id))
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("%w: %q", ErrTicketNotFound, id)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	from := current.Status
+	closedAt := current.ClosedAt
+	switch {
+	case to.IsTerminal() && !from.IsTerminal():
+		closed := now
+		closedAt = &closed
+	case !to.IsTerminal():
+		closedAt = nil
+	}
+
+	if _, err := tx.Exec(`
+		UPDATE tickets SET status = ?, updated_at = ?, closed_at = ? WHERE id = ?
+	`, string(to), formatTicketTime(now), formatTicketTimePtr(closedAt), id); err != nil {
+		return nil, err
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO ticket_activity (ticket_id, kind, author, from_status, to_status, comment, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, id, string(TicketActivityStatusChange), author, string(from), string(to), comment, formatTicketTime(now)); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	current.Status = to
+	current.ClosedAt = closedAt
+	current.UpdatedAt = now
+	return current, nil
+}
+
+// AddTicketComment appends a freeform comment to the activity thread and bumps
+// the ticket's updated_at. Returns the new activity entry.
+func (s *Store) AddTicketComment(id, author, comment string, now time.Time) (*TicketActivity, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	if err := touchTicketTx(tx, id, now); err != nil {
+		return nil, err
+	}
+	res, err := tx.Exec(`
+		INSERT INTO ticket_activity (ticket_id, kind, author, comment, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, id, string(TicketActivityComment), author, comment, formatTicketTime(now))
+	if err != nil {
+		return nil, err
+	}
+	activityID, err := res.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return &TicketActivity{
+		ID:        activityID,
+		TicketID:  id,
+		Kind:      TicketActivityComment,
+		Author:    author,
+		Comment:   comment,
+		CreatedAt: now,
+	}, nil
+}
+
+// EditTicketDescription replaces the ticket's brief and bumps updated_at.
+func (s *Store) EditTicketDescription(id, description string, now time.Time) error {
+	return s.updateTicketField(id, "description", description, now)
+}
+
+// AssignTicket sets (or clears, with "") the assignee and bumps updated_at.
+func (s *Store) AssignTicket(id, assignee string, now time.Time) error {
+	return s.updateTicketField(id, "assignee", assignee, now)
+}
+
+// SetTicketSession records the last session's working dir and agent id, which the
+// Resume affordance (slice 4) reloads from.
+func (s *Store) SetTicketSession(id, cwd, lastAgentID string, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	res, err := s.db.Exec(`
+		UPDATE tickets SET cwd = ?, last_agent_id = ?, updated_at = ? WHERE id = ?
+	`, cwd, lastAgentID, formatTicketTime(now), id)
+	if err != nil {
+		return err
+	}
+	return ticketUpdateResult(res, id)
+}
+
+// AddTicketAttachment records a handover file on the ticket and bumps updated_at.
+// Returns the stored attachment (with its assigned id).
+func (s *Store) AddTicketAttachment(att TicketAttachment, now time.Time) (*TicketAttachment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	att.Filename = strings.TrimSpace(att.Filename)
+	if att.Filename == "" {
+		return nil, errors.New("attachment filename required")
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	if err := touchTicketTx(tx, att.TicketID, now); err != nil {
+		return nil, err
+	}
+	res, err := tx.Exec(`
+		INSERT INTO ticket_attachments (ticket_id, filename, path, note, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, att.TicketID, att.Filename, att.Path, att.Note, formatTicketTime(now))
+	if err != nil {
+		return nil, err
+	}
+	attachmentID, err := res.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	att.ID = attachmentID
+	att.CreatedAt = now
+	return &att, nil
+}
+
+// ArchiveTicket clears a closed ticket from the active board. Only terminal
+// tickets may be archived — open tickets are durable and stay until they settle.
+func (s *Store) ArchiveTicket(id string, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	current, err := scanTicket(tx.QueryRow(ticketSelect+` WHERE id = ?`, id))
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("%w: %q", ErrTicketNotFound, id)
+	}
+	if err != nil {
+		return err
+	}
+	if !current.Status.IsTerminal() {
+		return fmt.Errorf("%w: %q is %s", ErrTicketNotClosed, id, current.Status)
+	}
+
+	if _, err := tx.Exec(`
+		UPDATE tickets SET archived_at = ?, updated_at = ? WHERE id = ?
+	`, formatTicketTime(now), formatTicketTime(now), id); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// SweepExpiredTickets hard-deletes terminal tickets whose closed_at is older than
+// now-ttl, cascading to their activity and attachments. Open tickets (a durable
+// backlog) are never swept. Returns the number of tickets removed. The caller
+// passes now and the TTL (production: time.Now() and 30 days); tests inject both.
+func (s *Store) SweepExpiredTickets(now time.Time, ttl time.Duration) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return 0, nil
+	}
+
+	cutoff := formatTicketTime(now.Add(-ttl))
+	// closed_at is a fixed-width RFC3339 UTC string, so a lexical compare is a
+	// chronological compare.
+	const expired = `status IN ('done','failed','crashed') AND closed_at != '' AND closed_at < ?`
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(`DELETE FROM ticket_activity WHERE ticket_id IN (SELECT id FROM tickets WHERE `+expired+`)`, cutoff); err != nil {
+		return 0, err
+	}
+	if _, err := tx.Exec(`DELETE FROM ticket_attachments WHERE ticket_id IN (SELECT id FROM tickets WHERE `+expired+`)`, cutoff); err != nil {
+		return 0, err
+	}
+	res, err := tx.Exec(`DELETE FROM tickets WHERE `+expired, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
+// --- internal helpers ---
+
+const ticketSelect = `
+	SELECT id, title, description, status, assignee, cwd, last_agent_id,
+		project_id, created_at, updated_at, closed_at, archived_at
+	FROM tickets`
+
+// updateTicketField sets a single text column plus updated_at. column is a
+// trusted internal literal, never caller input.
+func (s *Store) updateTicketField(id, column, value string, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	res, err := s.db.Exec(
+		`UPDATE tickets SET `+column+` = ?, updated_at = ? WHERE id = ?`,
+		value, formatTicketTime(now), id,
+	)
+	if err != nil {
+		return err
+	}
+	return ticketUpdateResult(res, id)
+}
+
+// touchTicketTx bumps updated_at within a transaction, returning ErrTicketNotFound
+// when the ticket is absent (so an activity/attachment can't orphan onto nothing).
+func touchTicketTx(tx *sql.Tx, id string, now time.Time) error {
+	res, err := tx.Exec(`UPDATE tickets SET updated_at = ? WHERE id = ?`, formatTicketTime(now), id)
+	if err != nil {
+		return err
+	}
+	return ticketUpdateResult(res, id)
+}
+
+func ticketUpdateResult(res sql.Result, id string) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("%w: %q", ErrTicketNotFound, id)
+	}
+	return nil
+}
+
+func (s *Store) ticketActivity(ticketID string) ([]TicketActivity, error) {
+	rows, err := s.db.Query(`
+		SELECT id, ticket_id, kind, author, from_status, to_status, comment, created_at
+		FROM ticket_activity WHERE ticket_id = ? ORDER BY id ASC
+	`, ticketID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var activity []TicketActivity
+	for rows.Next() {
+		var (
+			a         TicketActivity
+			kind      string
+			from, to  string
+			createdAt string
+		)
+		if err := rows.Scan(&a.ID, &a.TicketID, &kind, &a.Author, &from, &to, &a.Comment, &createdAt); err != nil {
+			return nil, err
+		}
+		a.Kind = TicketActivityKind(kind)
+		a.FromStatus = TicketStatus(from)
+		a.ToStatus = TicketStatus(to)
+		a.CreatedAt = parseTicketTime(createdAt)
+		activity = append(activity, a)
+	}
+	return activity, rows.Err()
+}
+
+func (s *Store) ticketAttachments(ticketID string) ([]TicketAttachment, error) {
+	rows, err := s.db.Query(`
+		SELECT id, ticket_id, filename, path, note, created_at
+		FROM ticket_attachments WHERE ticket_id = ? ORDER BY id ASC
+	`, ticketID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var attachments []TicketAttachment
+	for rows.Next() {
+		var (
+			att       TicketAttachment
+			createdAt string
+		)
+		if err := rows.Scan(&att.ID, &att.TicketID, &att.Filename, &att.Path, &att.Note, &createdAt); err != nil {
+			return nil, err
+		}
+		att.CreatedAt = parseTicketTime(createdAt)
+		attachments = append(attachments, att)
+	}
+	return attachments, rows.Err()
+}
+
+func scanTicket(scanner ticketScanner) (*Ticket, error) {
+	var (
+		t          Ticket
+		status     string
+		createdAt  string
+		updatedAt  string
+		closedAt   string
+		archivedAt string
+	)
+	if err := scanner.Scan(
+		&t.ID, &t.Title, &t.Description, &status, &t.Assignee, &t.Cwd, &t.LastAgentID,
+		&t.ProjectID, &createdAt, &updatedAt, &closedAt, &archivedAt,
+	); err != nil {
+		return nil, err
+	}
+	t.Status = TicketStatus(status)
+	t.CreatedAt = parseTicketTime(createdAt)
+	t.UpdatedAt = parseTicketTime(updatedAt)
+	if closedAt != "" {
+		ts := parseTicketTime(closedAt)
+		t.ClosedAt = &ts
+	}
+	if archivedAt != "" {
+		ts := parseTicketTime(archivedAt)
+		t.ArchivedAt = &ts
+	}
+	return &t, nil
+}
+
+// formatTicketTime renders a timestamp as a fixed-width RFC3339 UTC string, so
+// stored timestamps sort lexically (which the TTL sweep relies on).
+func formatTicketTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
+func formatTicketTimePtr(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return formatTicketTime(*t)
+}
+
+// parseTicketTime is the inverse of formatTicketTime; an unparseable value yields
+// the zero time rather than an error, since timestamps are store-written.
+func parseTicketTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -307,7 +307,9 @@ func (s *Store) ListTickets(filter TicketListFilter) ([]*Ticket, error) {
 // SetTicketStatus moves a ticket to a new column and records the change in the
 // activity thread (from -> to, with an optional comment). Transitions are
 // permissive. Entering a terminal status stamps closed_at; leaving one clears it
-// so reopened work becomes durable again. Returns the updated ticket row.
+// AND un-archives the ticket — reopening to an open status makes it durable and
+// visible on the board again, never a hidden zombie immune to the TTL sweep.
+// Returns the updated ticket row.
 func (s *Store) SetTicketStatus(id string, to TicketStatus, author, comment string, now time.Time) (*Ticket, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -335,17 +337,22 @@ func (s *Store) SetTicketStatus(id string, to TicketStatus, author, comment stri
 
 	from := current.Status
 	closedAt := current.ClosedAt
+	archivedAt := current.ArchivedAt
 	switch {
 	case to.IsTerminal() && !from.IsTerminal():
 		closed := now
 		closedAt = &closed
 	case !to.IsTerminal():
+		// Reopening to an open status: clear closed_at AND un-archive, so the
+		// ticket returns to the durable, visible, sweepable board. Otherwise an
+		// archived-then-reopened ticket becomes an invisible zombie.
 		closedAt = nil
+		archivedAt = nil
 	}
 
 	if _, err := tx.Exec(`
-		UPDATE tickets SET status = ?, updated_at = ?, closed_at = ? WHERE id = ?
-	`, string(to), formatTicketTime(now), formatTicketTimePtr(closedAt), id); err != nil {
+		UPDATE tickets SET status = ?, updated_at = ?, closed_at = ?, archived_at = ? WHERE id = ?
+	`, string(to), formatTicketTime(now), formatTicketTimePtr(closedAt), formatTicketTimePtr(archivedAt), id); err != nil {
 		return nil, err
 	}
 	if _, err := tx.Exec(`
@@ -360,6 +367,7 @@ func (s *Store) SetTicketStatus(id string, to TicketStatus, author, comment stri
 
 	current.Status = to
 	current.ClosedAt = closedAt
+	current.ArchivedAt = archivedAt
 	current.UpdatedAt = now
 	return current, nil
 }

--- a/internal/store/tickets_test.go
+++ b/internal/store/tickets_test.go
@@ -1,0 +1,419 @@
+package store
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ticketBase is a fixed clock for deterministic, injected-time tests.
+var ticketBase = time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC)
+
+func TestTicketCRUDRoundTrip(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Migration smoke: the ticket tables migration is part of the latest chain.
+	var maxVersion int
+	if err := s.db.QueryRow(`SELECT MAX(version) FROM schema_migrations`).Scan(&maxVersion); err != nil {
+		t.Fatalf("read schema_migrations: %v", err)
+	}
+	if maxVersion != latestSchemaVersion() {
+		t.Fatalf("schema version = %d, want %d", maxVersion, latestSchemaVersion())
+	}
+
+	created, err := s.CreateTicket(Ticket{
+		ID:          "store-migration",
+		Title:       "Migrate store to X",
+		Description: "Move the store onto the new backend.",
+		Assignee:    "agent7",
+		Cwd:         "/tmp/project",
+		LastAgentID: "agent7",
+	}, ticketBase)
+	if err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+	if created.Status != TicketStatusTodo {
+		t.Fatalf("default status = %q, want todo", created.Status)
+	}
+	if created.ClosedAt != nil {
+		t.Fatalf("ClosedAt = %v, want nil for a fresh todo", created.ClosedAt)
+	}
+
+	got, err := s.GetTicket("store-migration")
+	if err != nil {
+		t.Fatalf("GetTicket: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetTicket = nil, want ticket")
+	}
+	if got.Title != "Migrate store to X" || got.Description != "Move the store onto the new backend." {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	if got.Assignee != "agent7" || got.Cwd != "/tmp/project" || got.LastAgentID != "agent7" {
+		t.Fatalf("round-trip mismatch on session fields: %+v", got)
+	}
+	if !got.CreatedAt.Equal(ticketBase) || !got.UpdatedAt.Equal(ticketBase) {
+		t.Fatalf("timestamps = created %v / updated %v, want %v", got.CreatedAt, got.UpdatedAt, ticketBase)
+	}
+
+	// Missing ticket reads as (nil, nil).
+	missing, err := s.GetTicket("nope")
+	if err != nil || missing != nil {
+		t.Fatalf("GetTicket(missing) = %v, %v; want nil, nil", missing, err)
+	}
+}
+
+func TestTicketValidation(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if _, err := s.CreateTicket(Ticket{ID: "Has Spaces", Title: "x"}, ticketBase); !errors.Is(err, ErrInvalidTicketID) {
+		t.Fatalf("invalid id err = %v, want ErrInvalidTicketID", err)
+	}
+	if _, err := s.CreateTicket(Ticket{ID: "no-title"}, ticketBase); !errors.Is(err, ErrTicketTitleRequired) {
+		t.Fatalf("missing title err = %v, want ErrTicketTitleRequired", err)
+	}
+	if _, err := s.CreateTicket(Ticket{ID: "bad-status", Title: "x", Status: "weird"}, ticketBase); !errors.Is(err, ErrInvalidTicketStatus) {
+		t.Fatalf("bad status err = %v, want ErrInvalidTicketStatus", err)
+	}
+}
+
+func TestTicketIDCollision(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if _, err := s.CreateTicket(Ticket{ID: "dup", Title: "first"}, ticketBase); err != nil {
+		t.Fatalf("first CreateTicket: %v", err)
+	}
+	_, err := s.CreateTicket(Ticket{ID: "dup", Title: "second"}, ticketBase)
+	if !errors.Is(err, ErrTicketIDTaken) {
+		t.Fatalf("collision err = %v, want ErrTicketIDTaken", err)
+	}
+	// The message guides the agent to a fix.
+	if msg := err.Error(); !strings.Contains(msg, "pick a new name") || !strings.Contains(msg, "dup-2") {
+		t.Fatalf("collision message lacks guidance: %q", msg)
+	}
+	// The original ticket is untouched.
+	got, _ := s.GetTicket("dup")
+	if got == nil || got.Title != "first" {
+		t.Fatalf("original overwritten: %+v", got)
+	}
+}
+
+func TestTicketStatusTransitions(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, ticketBase); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+
+	t1 := ticketBase.Add(1 * time.Minute)
+	if _, err := s.SetTicketStatus("tk", TicketStatusWorking, "agent7", "picking it up", t1); err != nil {
+		t.Fatalf("SetTicketStatus working: %v", err)
+	}
+
+	// Into a terminal status stamps closed_at.
+	t2 := ticketBase.Add(2 * time.Minute)
+	got, err := s.SetTicketStatus("tk", TicketStatusDone, "agent7", "shipped", t2)
+	if err != nil {
+		t.Fatalf("SetTicketStatus done: %v", err)
+	}
+	if got.ClosedAt == nil || !got.ClosedAt.Equal(t2) {
+		t.Fatalf("ClosedAt = %v, want %v", got.ClosedAt, t2)
+	}
+
+	// Reopening clears closed_at — durable again.
+	t3 := ticketBase.Add(3 * time.Minute)
+	got, err = s.SetTicketStatus("tk", TicketStatusWorking, "you", "more to do", t3)
+	if err != nil {
+		t.Fatalf("SetTicketStatus reopen: %v", err)
+	}
+	if got.ClosedAt != nil {
+		t.Fatalf("ClosedAt = %v, want nil after reopen", got.ClosedAt)
+	}
+
+	// The activity thread captured every move, in order, with from/to + comment.
+	full, err := s.GetTicket("tk")
+	if err != nil {
+		t.Fatalf("GetTicket: %v", err)
+	}
+	if len(full.Activity) != 3 {
+		t.Fatalf("activity len = %d, want 3", len(full.Activity))
+	}
+	wantFrom := []TicketStatus{TicketStatusTodo, TicketStatusWorking, TicketStatusDone}
+	wantTo := []TicketStatus{TicketStatusWorking, TicketStatusDone, TicketStatusWorking}
+	for i, a := range full.Activity {
+		if a.Kind != TicketActivityStatusChange {
+			t.Fatalf("activity[%d].Kind = %q, want status_change", i, a.Kind)
+		}
+		if a.FromStatus != wantFrom[i] || a.ToStatus != wantTo[i] {
+			t.Fatalf("activity[%d] = %s->%s, want %s->%s", i, a.FromStatus, a.ToStatus, wantFrom[i], wantTo[i])
+		}
+	}
+	if full.Activity[1].Comment != "shipped" {
+		t.Fatalf("done comment = %q, want shipped", full.Activity[1].Comment)
+	}
+
+	// Unknown ticket / invalid status are errors.
+	if _, err := s.SetTicketStatus("ghost", TicketStatusDone, "", "", t3); !errors.Is(err, ErrTicketNotFound) {
+		t.Fatalf("status on missing = %v, want ErrTicketNotFound", err)
+	}
+	if _, err := s.SetTicketStatus("tk", "bogus", "", "", t3); !errors.Is(err, ErrInvalidTicketStatus) {
+		t.Fatalf("bad status = %v, want ErrInvalidTicketStatus", err)
+	}
+}
+
+func TestTicketCommentsAndEdits(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, ticketBase); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+
+	t1 := ticketBase.Add(1 * time.Minute)
+	if _, err := s.AddTicketComment("tk", "you", "any update?", t1); err != nil {
+		t.Fatalf("AddTicketComment: %v", err)
+	}
+	t2 := ticketBase.Add(2 * time.Minute)
+	if _, err := s.AddTicketComment("tk", "agent7", "almost there", t2); err != nil {
+		t.Fatalf("AddTicketComment: %v", err)
+	}
+	if err := s.EditTicketDescription("tk", "Revised brief.", t2); err != nil {
+		t.Fatalf("EditTicketDescription: %v", err)
+	}
+	if err := s.AssignTicket("tk", "agent9", t2); err != nil {
+		t.Fatalf("AssignTicket: %v", err)
+	}
+	if err := s.SetTicketSession("tk", "/repo", "agent9", t2); err != nil {
+		t.Fatalf("SetTicketSession: %v", err)
+	}
+
+	got, err := s.GetTicket("tk")
+	if err != nil {
+		t.Fatalf("GetTicket: %v", err)
+	}
+	if got.Description != "Revised brief." || got.Assignee != "agent9" || got.Cwd != "/repo" || got.LastAgentID != "agent9" {
+		t.Fatalf("edits not applied: %+v", got)
+	}
+	if !got.UpdatedAt.Equal(t2) {
+		t.Fatalf("UpdatedAt = %v, want %v (bumped by edits)", got.UpdatedAt, t2)
+	}
+	if len(got.Activity) != 2 {
+		t.Fatalf("activity len = %d, want 2 comments", len(got.Activity))
+	}
+	if got.Activity[0].Kind != TicketActivityComment || got.Activity[0].Comment != "any update?" {
+		t.Fatalf("activity[0] = %+v, want first comment", got.Activity[0])
+	}
+	if got.Activity[1].Author != "agent7" {
+		t.Fatalf("activity[1].Author = %q, want agent7", got.Activity[1].Author)
+	}
+
+	// Edits / comments on a missing ticket fail rather than orphan.
+	if err := s.EditTicketDescription("ghost", "x", t2); !errors.Is(err, ErrTicketNotFound) {
+		t.Fatalf("edit missing = %v, want ErrTicketNotFound", err)
+	}
+	if _, err := s.AddTicketComment("ghost", "", "x", t2); !errors.Is(err, ErrTicketNotFound) {
+		t.Fatalf("comment missing = %v, want ErrTicketNotFound", err)
+	}
+}
+
+func TestTicketAttachments(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, ticketBase); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+	t1 := ticketBase.Add(1 * time.Minute)
+	att, err := s.AddTicketAttachment(TicketAttachment{
+		TicketID: "tk",
+		Filename: "results.json",
+		Path:     "/handover/results.json",
+		Note:     "benchmark output",
+	}, t1)
+	if err != nil {
+		t.Fatalf("AddTicketAttachment: %v", err)
+	}
+	if att.ID == 0 {
+		t.Fatal("attachment id = 0, want assigned id")
+	}
+
+	got, err := s.GetTicket("tk")
+	if err != nil {
+		t.Fatalf("GetTicket: %v", err)
+	}
+	if len(got.Attachments) != 1 {
+		t.Fatalf("attachments len = %d, want 1", len(got.Attachments))
+	}
+	if got.Attachments[0].Filename != "results.json" || got.Attachments[0].Note != "benchmark output" {
+		t.Fatalf("attachment round-trip = %+v", got.Attachments[0])
+	}
+	if !got.UpdatedAt.Equal(t1) {
+		t.Fatalf("UpdatedAt = %v, want %v (bumped by attach)", got.UpdatedAt, t1)
+	}
+
+	// A filename is required; a missing ticket is rejected.
+	if _, err := s.AddTicketAttachment(TicketAttachment{TicketID: "tk"}, t1); err == nil {
+		t.Fatal("AddTicketAttachment with no filename: want error")
+	}
+	if _, err := s.AddTicketAttachment(TicketAttachment{TicketID: "ghost", Filename: "x"}, t1); !errors.Is(err, ErrTicketNotFound) {
+		t.Fatalf("attach to missing = %v, want ErrTicketNotFound", err)
+	}
+}
+
+func TestTicketListAndArchive(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Three tickets across columns.
+	if _, err := s.CreateTicket(Ticket{ID: "backlog", Title: "later"}, ticketBase); err != nil {
+		t.Fatalf("create backlog: %v", err)
+	}
+	if _, err := s.CreateTicket(Ticket{ID: "active", Title: "now", Status: TicketStatusWorking}, ticketBase.Add(time.Minute)); err != nil {
+		t.Fatalf("create active: %v", err)
+	}
+	if _, err := s.CreateTicket(Ticket{ID: "shipped", Title: "old", Status: TicketStatusDone}, ticketBase.Add(2*time.Minute)); err != nil {
+		t.Fatalf("create shipped: %v", err)
+	}
+
+	all, err := s.ListTickets(TicketListFilter{})
+	if err != nil {
+		t.Fatalf("ListTickets: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("list len = %d, want 3", len(all))
+	}
+	// Newest first.
+	if all[0].ID != "shipped" || all[2].ID != "backlog" {
+		t.Fatalf("ordering = %s..%s, want shipped..backlog", all[0].ID, all[2].ID)
+	}
+
+	// Status filter.
+	working, err := s.ListTickets(TicketListFilter{Status: TicketStatusWorking})
+	if err != nil {
+		t.Fatalf("ListTickets(working): %v", err)
+	}
+	if len(working) != 1 || working[0].ID != "active" {
+		t.Fatalf("working filter = %+v, want [active]", working)
+	}
+
+	// Archiving an open ticket is refused.
+	if err := s.ArchiveTicket("active", ticketBase.Add(3*time.Minute)); !errors.Is(err, ErrTicketNotClosed) {
+		t.Fatalf("archive open = %v, want ErrTicketNotClosed", err)
+	}
+	// Archiving a closed ticket clears it from the default board.
+	if err := s.ArchiveTicket("shipped", ticketBase.Add(3*time.Minute)); err != nil {
+		t.Fatalf("ArchiveTicket: %v", err)
+	}
+	board, err := s.ListTickets(TicketListFilter{})
+	if err != nil {
+		t.Fatalf("ListTickets after archive: %v", err)
+	}
+	if len(board) != 2 {
+		t.Fatalf("board len = %d, want 2 (archived hidden)", len(board))
+	}
+	withArchived, err := s.ListTickets(TicketListFilter{IncludeArchived: true})
+	if err != nil {
+		t.Fatalf("ListTickets(IncludeArchived): %v", err)
+	}
+	if len(withArchived) != 3 {
+		t.Fatalf("IncludeArchived len = %d, want 3", len(withArchived))
+	}
+}
+
+func TestTicketTTLSweep(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	const ttl = 30 * 24 * time.Hour
+	now := ticketBase
+
+	// An open backlog ticket — never swept.
+	if _, err := s.CreateTicket(Ticket{ID: "open", Title: "live"}, now.Add(-90*24*time.Hour)); err != nil {
+		t.Fatalf("create open: %v", err)
+	}
+	// A recently-closed ticket — within TTL, kept.
+	if _, err := s.CreateTicket(Ticket{ID: "recent", Title: "recent", Status: TicketStatusDone}, now.Add(-5*24*time.Hour)); err != nil {
+		t.Fatalf("create recent: %v", err)
+	}
+	// A long-closed ticket with activity + an attachment — swept, cascading.
+	if _, err := s.CreateTicket(Ticket{ID: "stale", Title: "stale"}, now.Add(-100*24*time.Hour)); err != nil {
+		t.Fatalf("create stale: %v", err)
+	}
+	closedAt := now.Add(-60 * 24 * time.Hour)
+	if _, err := s.SetTicketStatus("stale", TicketStatusDone, "agent7", "done long ago", closedAt); err != nil {
+		t.Fatalf("close stale: %v", err)
+	}
+	if _, err := s.AddTicketAttachment(TicketAttachment{TicketID: "stale", Filename: "old.txt"}, closedAt); err != nil {
+		t.Fatalf("attach stale: %v", err)
+	}
+
+	removed, err := s.SweepExpiredTickets(now, ttl)
+	if err != nil {
+		t.Fatalf("SweepExpiredTickets: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1 (only stale)", removed)
+	}
+
+	if gone, _ := s.GetTicket("stale"); gone != nil {
+		t.Fatal("stale ticket survived the sweep")
+	}
+	if kept, _ := s.GetTicket("recent"); kept == nil {
+		t.Fatal("recent ticket was swept early")
+	}
+	if kept, _ := s.GetTicket("open"); kept == nil {
+		t.Fatal("open backlog ticket was swept")
+	}
+
+	// Cascade: the swept ticket's activity + attachment rows are gone too.
+	var orphanActivity, orphanAttachments int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM ticket_activity WHERE ticket_id = 'stale'`).Scan(&orphanActivity); err != nil {
+		t.Fatalf("count orphan activity: %v", err)
+	}
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM ticket_attachments WHERE ticket_id = 'stale'`).Scan(&orphanAttachments); err != nil {
+		t.Fatalf("count orphan attachments: %v", err)
+	}
+	if orphanActivity != 0 || orphanAttachments != 0 {
+		t.Fatalf("cascade leak: %d activity, %d attachments left", orphanActivity, orphanAttachments)
+	}
+}
+
+func TestTicketPersistence(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB: %v", err)
+	}
+	if _, err := s.CreateTicket(Ticket{ID: "persist", Title: "survives restart"}, ticketBase); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+	if _, err := s.SetTicketStatus("persist", TicketStatusInReview, "agent7", "ready", ticketBase.Add(time.Minute)); err != nil {
+		t.Fatalf("SetTicketStatus: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+
+	got, err := reopened.GetTicket("persist")
+	if err != nil {
+		t.Fatalf("GetTicket after reopen: %v", err)
+	}
+	if got == nil || got.Status != TicketStatusInReview {
+		t.Fatalf("persisted ticket = %+v, want in_review", got)
+	}
+	if len(got.Activity) != 1 || got.Activity[0].ToStatus != TicketStatusInReview {
+		t.Fatalf("persisted activity = %+v", got.Activity)
+	}
+}

--- a/internal/store/tickets_test.go
+++ b/internal/store/tickets_test.go
@@ -326,6 +326,49 @@ func TestTicketListAndArchive(t *testing.T) {
 	}
 }
 
+// Reopening an archived ticket un-archives it: a closed+archived ticket moved back
+// to an open status must return to the default board and shed its archived_at, not
+// linger as an invisible zombie immune to the TTL sweep.
+func TestArchivedTicketReopenedBecomesVisible(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if _, err := s.CreateTicket(Ticket{ID: "zombie", Title: "shipped", Status: TicketStatusDone}, ticketBase); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := s.ArchiveTicket("zombie", ticketBase.Add(time.Minute)); err != nil {
+		t.Fatalf("ArchiveTicket: %v", err)
+	}
+	// Archived: hidden from the default board.
+	if board, err := s.ListTickets(TicketListFilter{}); err != nil || len(board) != 0 {
+		t.Fatalf("board after archive = %d (err %v), want 0", len(board), err)
+	}
+
+	// Reopen it to an open status.
+	reopened, err := s.SetTicketStatus("zombie", TicketStatusWorking, "you", "back to it", ticketBase.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("SetTicketStatus: %v", err)
+	}
+	if reopened.ArchivedAt != nil {
+		t.Fatalf("reopened ArchivedAt = %v, want nil (un-archived)", reopened.ArchivedAt)
+	}
+	if reopened.ClosedAt != nil {
+		t.Fatalf("reopened ClosedAt = %v, want nil", reopened.ClosedAt)
+	}
+
+	// It is visible on the default board again.
+	board, err := s.ListTickets(TicketListFilter{})
+	if err != nil {
+		t.Fatalf("ListTickets: %v", err)
+	}
+	if len(board) != 1 || board[0].ID != "zombie" {
+		t.Fatalf("board after reopen = %+v, want [zombie]", board)
+	}
+	if board[0].ArchivedAt != nil {
+		t.Fatalf("persisted ArchivedAt = %v, want nil", board[0].ArchivedAt)
+	}
+}
+
 func TestTicketTTLSweep(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })


### PR DESCRIPTION
## Slice 1 — Ticket store + lifecycle

First implementation slice of the work tracker (plan: `docs/plans/2026-06-26-work-tracker.md`). **Base: `feat/tickets`** — lands on the integration branch, not `main`.

Pure store layer. No protocol/IPC/CLI/frontend surface yet (those are slices 3–5), so nothing user-visible changes — this is the foundation the rest builds on.

### What's here

- **Migration 55** — fresh `tickets`, `ticket_activity`, `ticket_attachments` tables. (Verified real DBs top out at 52/54, so 55 is clear of the burned-version trap.)
- **`TicketStatus`** enum — `todo / working / blocked / in_review / done / failed / crashed`, with `IsValid` / `IsTerminal`. Transitions are **permissive** — the board informs, it never gates.
- **Slug ids** — `ValidateTicketID` + a uniqueness check whose collision error tells the agent to *pick a new name or append a number* (e.g. `store-migration-2`), matching the locked design.
- **CRUD + activity** — `CreateTicket`, `GetTicket` (loads the full activity thread + attachments), `ListTickets` (board filter, archived hidden by default). Status changes and comments are recorded as one unified **activity thread** (`status_change` + `comment` — no separate "report"). Plus description / assignee / session / attachment mutators.
- **Lifecycle** — `closed_at` is stamped on entering a terminal status and cleared on reopen (so reopened work is durable again); it drives `SweepExpiredTickets(now, ttl)`, which hard-deletes terminal tickets past the 30-day TTL and **cascades** to their activity + attachments. Open tickets (the backlog) never age out. `ArchiveTicket` clears a *closed* ticket from the board and refuses open ones.

### Design notes

- **Fresh table, not an evolve.** The plan originally said "evolves `chief_of_staff_dispatches`"; I went fresh-table instead (plan prose updated to match). The schema is materially different, and slice 7 retires the whole `dispatch` namespace anyway — a fresh table lets the old one die cleanly with its namespace rather than slice 1 half-converting it and slice 7 half-dismantling it. The old table is left fully functional through slices 1–6.
- **Store-local row types** (`store.Ticket` etc.), following the `workflow_runs` convention — the wire shape is owned by a later slice.
- **Injected time.** Mutators take an explicit `now time.Time` (idiomatic here — the codebase already passes timestamps in) so every lifecycle test, including the TTL sweep, is deterministic. Timestamps are stored as fixed-width RFC3339 UTC, so the sweep's `closed_at` comparison is a clean lexical compare.

### Tests

`internal/store/tickets_test.go`, all store-level: CRUD round-trip + migration smoke, validation, id collision (incl. the guidance message), permissive transitions + `closed_at` lifecycle, comments/edits bumping `updated_at`, attachments, list + archive board semantics, the **TTL sweep with injected time** (cascade verified, open + recent tickets untouched), and persistence across a DB reopen.

Per the plan's Rule of play, this PR flips slice 1 to 🟡.

🤖 Opened by Claude on behalf of Victor.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #412
2. **#413** 👈 current
3. #414
4. #415
5. #416
6. #417
7. #418
8. #419
9. #420
10. #421
11. #422
12. #423
13. #424
<!-- stack:links:end -->