### PR TITLE
feat(tickets): slice 3b — agent forward channel (ticket status)

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -172,7 +172,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '123';
+export const PROTOCOL_VERSION = '124';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HandoffDispatchMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchMessagesMessage, ListDispatchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookTask, NotebookTaskListMessage, NotebookTaskListResultMessage, NotebookTaskRetryMessage, NotebookTaskRetryResultMessage, NotebookTasksChangedMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubmitDispatchOutcomeMessage, SubscribeGitStatusMessage, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AcknowledgeDispatchMessage, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, AnswerReviewLoopMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffDispatch, ChiefOfStaffDispatchesUpdatedMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchArtifact, DispatchDecisionRequest, DispatchMessage, DispatchReport, DispatchReportType, DispatchRequestStatus, DispatchVerification, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetDispatchMessage, GetFileDiffMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewLoopRunMessage, GetReviewLoopStateMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HandoffDispatchMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListDispatchesMessage, ListDispatchMessagesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookTask, NotebookTaskListMessage, NotebookTaskListResultMessage, NotebookTaskRetryMessage, NotebookTaskRetryResultMessage, NotebookTasksChangedMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, ReadDispatchMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, ResolveDispatchRequestMessage, Response, ReviewComment, ReviewLoopDecision, ReviewLoopInteraction, ReviewLoopInteractionStatus, ReviewLoopIteration, ReviewLoopIterationStatus, ReviewLoopResultMessage, ReviewLoopRun, ReviewLoopRunStatus, ReviewLoopState, ReviewLoopStatus, ReviewLoopUpdatedMessage, ReviewState, SendDispatchMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetReviewLoopIterationLimitMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StartReviewLoopMessage, StateMessage, StopMessage, StopReviewLoopMessage, SubmitDispatchOutcomeMessage, SubscribeGitStatusMessage, TicketStatus, TicketStatusResult, TodosMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WakeDispatchAgentMessage, WakeDispatchAgentResultMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const acknowledgeDispatchMessage = Convert.toAcknowledgeDispatchMessage(json);
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
@@ -116,8 +116,8 @@
 //   const installPluginMessage = Convert.toInstallPluginMessage(json);
 //   const killSessionMessage = Convert.toKillSessionMessage(json);
 //   const listBranchesMessage = Convert.toListBranchesMessage(json);
-//   const listDispatchMessagesMessage = Convert.toListDispatchMessagesMessage(json);
 //   const listDispatchesMessage = Convert.toListDispatchesMessage(json);
+//   const listDispatchMessagesMessage = Convert.toListDispatchMessagesMessage(json);
 //   const listEndpointsMessage = Convert.toListEndpointsMessage(json);
 //   const listPluginsMessage = Convert.toListPluginsMessage(json);
 //   const listRemoteBranchesMessage = Convert.toListRemoteBranchesMessage(json);
@@ -155,22 +155,22 @@
 //   const notebookWriteResultMessage = Convert.toNotebookWriteResultMessage(json);
 //   const openBrowserMessage = Convert.toOpenBrowserMessage(json);
 //   const openMarkdownMessage = Convert.toOpenMarkdownMessage(json);
-//   const pR = Convert.toPR(json);
-//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
-//   const pRRole = Convert.toPRRole(json);
-//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
-//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
 //   const pathInspection = Convert.toPathInspection(json);
 //   const pinWorkspaceMessage = Convert.toPinWorkspaceMessage(json);
 //   const pluginActionResultMessage = Convert.toPluginActionResultMessage(json);
 //   const pluginInfo = Convert.toPluginInfo(json);
 //   const pluginIssue = Convert.toPluginIssue(json);
 //   const pluginsUpdatedMessage = Convert.toPluginsUpdatedMessage(json);
+//   const pR = Convert.toPR(json);
+//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
+//   const pRRole = Convert.toPRRole(json);
+//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
+//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
 //   const ptyDesyncMessage = Convert.toPtyDesyncMessage(json);
 //   const ptyInputMessage = Convert.toPtyInputMessage(json);
 //   const ptyOutputMessage = Convert.toPtyOutputMessage(json);
-//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
+//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const queryAuthorsMessage = Convert.toQueryAuthorsMessage(json);
 //   const queryMessage = Convert.toQueryMessage(json);
 //   const queryPRsMessage = Convert.toQueryPRsMessage(json);
@@ -216,18 +216,19 @@
 //   const sessionSelectedMessage = Convert.toSessionSelectedMessage(json);
 //   const sessionState = Convert.toSessionState(json);
 //   const sessionStateChangedMessage = Convert.toSessionStateChangedMessage(json);
+//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const sessionTodosUpdatedMessage = Convert.toSessionTodosUpdatedMessage(json);
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
 //   const sessionVisualizedMessage = Convert.toSessionVisualizedMessage(json);
-//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
 //   const setPluginPriorityMessage = Convert.toSetPluginPriorityMessage(json);
 //   const setReviewLoopIterationLimitMessage = Convert.toSetReviewLoopIterationLimitMessage(json);
 //   const setSessionResumeIDMessage = Convert.toSetSessionResumeIDMessage(json);
 //   const setSettingMessage = Convert.toSetSettingMessage(json);
-//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
+//   const setTicketStatusMessage = Convert.toSetTicketStatusMessage(json);
 //   const settingsUpdatedMessage = Convert.toSettingsUpdatedMessage(json);
+//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const spawnResultMessage = Convert.toSpawnResultMessage(json);
 //   const spawnSessionMessage = Convert.toSpawnSessionMessage(json);
 //   const startReviewLoopMessage = Convert.toStartReviewLoopMessage(json);
@@ -236,6 +237,8 @@
 //   const stopReviewLoopMessage = Convert.toStopReviewLoopMessage(json);
 //   const submitDispatchOutcomeMessage = Convert.toSubmitDispatchOutcomeMessage(json);
 //   const subscribeGitStatusMessage = Convert.toSubscribeGitStatusMessage(json);
+//   const ticketStatus = Convert.toTicketStatus(json);
+//   const ticketStatusResult = Convert.toTicketStatusResult(json);
 //   const todosMessage = Convert.toTodosMessage(json);
 //   const unregisterMessage = Convert.toUnregisterMessage(json);
 //   const unregisterWorkspaceMessage = Convert.toUnregisterWorkspaceMessage(json);
@@ -290,8 +293,8 @@
 //   const workspaceLayoutSetSplitRatioMessage = Convert.toWorkspaceLayoutSetSplitRatioMessage(json);
 //   const workspaceLayoutSplitDirection = Convert.toWorkspaceLayoutSplitDirection(json);
 //   const workspaceLayoutUndockTileMessage = Convert.toWorkspaceLayoutUndockTileMessage(json);
-//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
+//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceRegisteredMessage = Convert.toWorkspaceRegisteredMessage(json);
 //   const workspaceSelectedMessage = Convert.toWorkspaceSelectedMessage(json);
 //   const workspaceStateChangedMessage = Convert.toWorkspaceStateChangedMessage(json);
@@ -2011,6 +2014,16 @@ export enum ListBranchesMessageCmd {
     ListBranches = "list_branches",
 }
 
+export interface ListDispatchesMessage {
+    cmd:               ListDispatchesMessageCmd;
+    source_session_id: string;
+    [property: string]: any;
+}
+
+export enum ListDispatchesMessageCmd {
+    ListDispatches = "list_dispatches",
+}
+
 export interface ListDispatchMessagesMessage {
     cmd:               ListDispatchMessagesMessageCmd;
     dispatch_id?:      string;
@@ -2021,16 +2034,6 @@ export interface ListDispatchMessagesMessage {
 
 export enum ListDispatchMessagesMessageCmd {
     ListDispatchMessages = "list_dispatch_messages",
-}
-
-export interface ListDispatchesMessage {
-    cmd:               ListDispatchesMessageCmd;
-    source_session_id: string;
-    [property: string]: any;
-}
-
-export enum ListDispatchesMessageCmd {
-    ListDispatches = "list_dispatches",
 }
 
 export interface ListEndpointsMessage {
@@ -2478,69 +2481,6 @@ export enum OpenMarkdownMessageCmd {
     OpenMarkdown = "open_markdown",
 }
 
-export interface PR {
-    approved_by_me:         boolean;
-    author:                 string;
-    ci_status?:             string;
-    comment_count?:         number;
-    details_fetched:        boolean;
-    details_fetched_at?:    string;
-    has_new_changes:        boolean;
-    head_branch?:           string;
-    head_sha?:              string;
-    heat_state?:            HeatState;
-    host:                   string;
-    id:                     string;
-    last_heat_activity_at?: string;
-    last_polled:            string;
-    last_updated:           string;
-    mergeable?:             boolean;
-    mergeable_state?:       string;
-    muted:                  boolean;
-    number:                 number;
-    reason:                 string;
-    repo:                   string;
-    review_status?:         string;
-    role:                   PRRole;
-    state:                  string;
-    title:                  string;
-    url:                    string;
-    [property: string]: any;
-}
-
-export interface PRActionResultMessage {
-    action:  string;
-    error?:  string;
-    event:   PRActionResultMessageEvent;
-    id:      string;
-    success: boolean;
-    [property: string]: any;
-}
-
-export enum PRActionResultMessageEvent {
-    PRActionResult = "pr_action_result",
-}
-
-export interface PRVisitedMessage {
-    cmd: PRVisitedMessageCmd;
-    id:  string;
-    [property: string]: any;
-}
-
-export enum PRVisitedMessageCmd {
-    PRVisited = "pr_visited",
-}
-
-export interface PRsUpdatedMessage {
-    event: PRsUpdatedMessageEvent;
-    prs?:  PRElement[];
-    [property: string]: any;
-}
-
-export enum PRsUpdatedMessageEvent {
-    PrsUpdated = "prs_updated",
-}
-
 export interface PathInspection {
     exists:        boolean;
     home_path?:    string;
@@ -2626,6 +2566,69 @@ export interface PluginElement {
     [property: string]: any;
 }
 
+export interface PR {
+    approved_by_me:         boolean;
+    author:                 string;
+    ci_status?:             string;
+    comment_count?:         number;
+    details_fetched:        boolean;
+    details_fetched_at?:    string;
+    has_new_changes:        boolean;
+    head_branch?:           string;
+    head_sha?:              string;
+    heat_state?:            HeatState;
+    host:                   string;
+    id:                     string;
+    last_heat_activity_at?: string;
+    last_polled:            string;
+    last_updated:           string;
+    mergeable?:             boolean;
+    mergeable_state?:       string;
+    muted:                  boolean;
+    number:                 number;
+    reason:                 string;
+    repo:                   string;
+    review_status?:         string;
+    role:                   PRRole;
+    state:                  string;
+    title:                  string;
+    url:                    string;
+    [property: string]: any;
+}
+
+export interface PRActionResultMessage {
+    action:  string;
+    error?:  string;
+    event:   PRActionResultMessageEvent;
+    id:      string;
+    success: boolean;
+    [property: string]: any;
+}
+
+export enum PRActionResultMessageEvent {
+    PRActionResult = "pr_action_result",
+}
+
+export interface PRsUpdatedMessage {
+    event: PRsUpdatedMessageEvent;
+    prs?:  PRElement[];
+    [property: string]: any;
+}
+
+export enum PRsUpdatedMessageEvent {
+    PrsUpdated = "prs_updated",
+}
+
+export interface PRVisitedMessage {
+    cmd: PRVisitedMessageCmd;
+    id:  string;
+    [property: string]: any;
+}
+
+export enum PRVisitedMessageCmd {
+    PRVisited = "pr_visited",
+}
+
 export interface PtyDesyncMessage {
     event:  PtyDesyncMessageEvent;
     id:     string;
@@ -2661,18 +2664,6 @@ export enum PtyOutputMessageEvent {
     PtyOutput = "pty_output",
 }
 
-export interface PtyResizeMessage {
-    cmd:  PtyResizeMessageCmd;
-    cols: number;
-    id:   string;
-    rows: number;
-    [property: string]: any;
-}
-
-export enum PtyResizeMessageCmd {
-    PtyResize = "pty_resize",
-}
-
 export interface PtyResizedMessage {
     cols:  number;
     event: PtyResizedMessageEvent;
@@ -2683,6 +2674,18 @@ export interface PtyResizedMessage {
 
 export enum PtyResizedMessageEvent {
     PtyResized = "pty_resized",
+}
+
+export interface PtyResizeMessage {
+    cmd:  PtyResizeMessageCmd;
+    cols: number;
+    id:   string;
+    rows: number;
+    [property: string]: any;
+}
+
+export enum PtyResizeMessageCmd {
+    PtyResize = "pty_resize",
 }
 
 export interface QueryAuthorsMessage {
@@ -2966,6 +2969,7 @@ export interface Response {
     repos?:                                RepoElement[];
     review_loop_run?:                      ReviewLoopRunObject;
     sessions?:                             SessionElement[];
+    ticket_status_result?:                 TicketStatusResultObject;
     workspace_context_maintenance_result?: WorkspaceContextMaintenanceResultObject;
     workspace_context_result?:             WorkspaceContextResultObject;
     workspace_contexts?:                   WorkspaceContextElement[];
@@ -3080,6 +3084,22 @@ export enum ReviewLoopRunStatus {
     Error = "error",
     Running = "running",
     Stopped = "stopped",
+}
+
+export interface TicketStatusResultObject {
+    status:    TicketStatus;
+    ticket_id: string;
+    [property: string]: any;
+}
+
+export enum TicketStatus {
+    Blocked = "blocked",
+    Crashed = "crashed",
+    Done = "done",
+    Failed = "failed",
+    InReview = "in_review",
+    Todo = "todo",
+    Working = "working",
 }
 
 export interface WorkspaceContextMaintenanceResultObject {
@@ -3334,6 +3354,16 @@ export enum SessionStateChangedMessageEvent {
     SessionStateChanged = "session_state_changed",
 }
 
+export interface SessionsUpdatedMessage {
+    event:     SessionsUpdatedMessageEvent;
+    sessions?: SessionElement[];
+    [property: string]: any;
+}
+
+export enum SessionsUpdatedMessageEvent {
+    SessionsUpdated = "sessions_updated",
+}
+
 export interface SessionTodosUpdatedMessage {
     event:   SessionTodosUpdatedMessageEvent;
     session: SessionElement;
@@ -3362,16 +3392,6 @@ export interface SessionVisualizedMessage {
 
 export enum SessionVisualizedMessageCmd {
     SessionVisualized = "session_visualized",
-}
-
-export interface SessionsUpdatedMessage {
-    event:     SessionsUpdatedMessageEvent;
-    sessions?: SessionElement[];
-    [property: string]: any;
-}
-
-export enum SessionsUpdatedMessageEvent {
-    SessionsUpdated = "sessions_updated",
 }
 
 export interface SetChiefOfStaffMessage {
@@ -3440,16 +3460,16 @@ export enum SetSettingMessageCmd {
     SetSetting = "set_setting",
 }
 
-export interface SetWorkspaceRankMessage {
-    cmd:                SetWorkspaceRankMessageCmd;
-    next_workspace_id?: string;
-    prev_workspace_id?: string;
-    workspace_id:       string;
+export interface SetTicketStatusMessage {
+    cmd:               SetTicketStatusMessageCmd;
+    comment?:          string;
+    source_session_id: string;
+    work_state:        DispatchWorkState;
     [property: string]: any;
 }
 
-export enum SetWorkspaceRankMessageCmd {
-    SetWorkspaceRank = "set_workspace_rank",
+export enum SetTicketStatusMessageCmd {
+    SetTicketStatus = "set_ticket_status",
 }
 
 export interface SettingsUpdatedMessage {
@@ -3463,6 +3483,18 @@ export interface SettingsUpdatedMessage {
 
 export enum SettingsUpdatedMessageEvent {
     SettingsUpdated = "settings_updated",
+}
+
+export interface SetWorkspaceRankMessage {
+    cmd:                SetWorkspaceRankMessageCmd;
+    next_workspace_id?: string;
+    prev_workspace_id?: string;
+    workspace_id:       string;
+    [property: string]: any;
+}
+
+export enum SetWorkspaceRankMessageCmd {
+    SetWorkspaceRank = "set_workspace_rank",
 }
 
 export interface SpawnResultMessage {
@@ -3568,6 +3600,12 @@ export interface SubscribeGitStatusMessage {
 
 export enum SubscribeGitStatusMessageCmd {
     SubscribeGitStatus = "subscribe_git_status",
+}
+
+export interface TicketStatusResult {
+    status:    TicketStatus;
+    ticket_id: string;
+    [property: string]: any;
 }
 
 export interface TodosMessage {
@@ -4273,6 +4311,16 @@ export enum WorkspaceLayoutUndockTileMessageCmd {
     WorkspaceLayoutUndockTile = "workspace_layout_undock_tile",
 }
 
+export interface WorkspaceLayoutUpdatedMessage {
+    event:            WorkspaceLayoutUpdatedMessageEvent;
+    workspace_layout: Layout;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutUpdatedMessageEvent {
+    WorkspaceLayoutUpdated = "workspace_layout_updated",
+}
+
 export interface WorkspaceLayoutUpdateTileMessage {
     cmd:          WorkspaceLayoutUpdateTileMessageCmd;
     request_id:   string;
@@ -4284,16 +4332,6 @@ export interface WorkspaceLayoutUpdateTileMessage {
 
 export enum WorkspaceLayoutUpdateTileMessageCmd {
     WorkspaceLayoutUpdateTile = "workspace_layout_update_tile",
-}
-
-export interface WorkspaceLayoutUpdatedMessage {
-    event:            WorkspaceLayoutUpdatedMessageEvent;
-    workspace_layout: Layout;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutUpdatedMessageEvent {
-    WorkspaceLayoutUpdated = "workspace_layout_updated",
 }
 
 export interface WorkspaceRegisteredMessage {
@@ -5315,20 +5353,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("ListBranchesMessage")), null, 2);
     }
 
-    public static toListDispatchMessagesMessage(json: string): ListDispatchMessagesMessage {
-        return cast(JSON.parse(json), r("ListDispatchMessagesMessage"));
-    }
-
-    public static listDispatchMessagesMessageToJson(value: ListDispatchMessagesMessage): string {
-        return JSON.stringify(uncast(value, r("ListDispatchMessagesMessage")), null, 2);
-    }
-
     public static toListDispatchesMessage(json: string): ListDispatchesMessage {
         return cast(JSON.parse(json), r("ListDispatchesMessage"));
     }
 
     public static listDispatchesMessageToJson(value: ListDispatchesMessage): string {
         return JSON.stringify(uncast(value, r("ListDispatchesMessage")), null, 2);
+    }
+
+    public static toListDispatchMessagesMessage(json: string): ListDispatchMessagesMessage {
+        return cast(JSON.parse(json), r("ListDispatchMessagesMessage"));
+    }
+
+    public static listDispatchMessagesMessageToJson(value: ListDispatchMessagesMessage): string {
+        return JSON.stringify(uncast(value, r("ListDispatchMessagesMessage")), null, 2);
     }
 
     public static toListEndpointsMessage(json: string): ListEndpointsMessage {
@@ -5627,46 +5665,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("OpenMarkdownMessage")), null, 2);
     }
 
-    public static toPR(json: string): PR {
-        return cast(JSON.parse(json), r("PR"));
-    }
-
-    public static pRToJson(value: PR): string {
-        return JSON.stringify(uncast(value, r("PR")), null, 2);
-    }
-
-    public static toPRActionResultMessage(json: string): PRActionResultMessage {
-        return cast(JSON.parse(json), r("PRActionResultMessage"));
-    }
-
-    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
-        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
-    }
-
-    public static toPRRole(json: string): PRRole {
-        return cast(JSON.parse(json), r("PRRole"));
-    }
-
-    public static pRRoleToJson(value: PRRole): string {
-        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
-    }
-
-    public static toPRVisitedMessage(json: string): PRVisitedMessage {
-        return cast(JSON.parse(json), r("PRVisitedMessage"));
-    }
-
-    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
-        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
-    }
-
-    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
-        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
-    }
-
-    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
-    }
-
     public static toPathInspection(json: string): PathInspection {
         return cast(JSON.parse(json), r("PathInspection"));
     }
@@ -5715,6 +5713,46 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PluginsUpdatedMessage")), null, 2);
     }
 
+    public static toPR(json: string): PR {
+        return cast(JSON.parse(json), r("PR"));
+    }
+
+    public static pRToJson(value: PR): string {
+        return JSON.stringify(uncast(value, r("PR")), null, 2);
+    }
+
+    public static toPRActionResultMessage(json: string): PRActionResultMessage {
+        return cast(JSON.parse(json), r("PRActionResultMessage"));
+    }
+
+    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
+        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
+    }
+
+    public static toPRRole(json: string): PRRole {
+        return cast(JSON.parse(json), r("PRRole"));
+    }
+
+    public static pRRoleToJson(value: PRRole): string {
+        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
+    }
+
+    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
+        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
+    }
+
+    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
+    }
+
+    public static toPRVisitedMessage(json: string): PRVisitedMessage {
+        return cast(JSON.parse(json), r("PRVisitedMessage"));
+    }
+
+    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
+        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
+    }
+
     public static toPtyDesyncMessage(json: string): PtyDesyncMessage {
         return cast(JSON.parse(json), r("PtyDesyncMessage"));
     }
@@ -5739,20 +5777,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PtyOutputMessage")), null, 2);
     }
 
-    public static toPtyResizeMessage(json: string): PtyResizeMessage {
-        return cast(JSON.parse(json), r("PtyResizeMessage"));
-    }
-
-    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
-        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
-    }
-
     public static toPtyResizedMessage(json: string): PtyResizedMessage {
         return cast(JSON.parse(json), r("PtyResizedMessage"));
     }
 
     public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
         return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
+    }
+
+    public static toPtyResizeMessage(json: string): PtyResizeMessage {
+        return cast(JSON.parse(json), r("PtyResizeMessage"));
+    }
+
+    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
+        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
     }
 
     public static toQueryAuthorsMessage(json: string): QueryAuthorsMessage {
@@ -6115,6 +6153,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionStateChangedMessage")), null, 2);
     }
 
+    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
+        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
+    }
+
+    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
+    }
+
     public static toSessionTodosUpdatedMessage(json: string): SessionTodosUpdatedMessage {
         return cast(JSON.parse(json), r("SessionTodosUpdatedMessage"));
     }
@@ -6137,14 +6183,6 @@ export class Convert {
 
     public static sessionVisualizedMessageToJson(value: SessionVisualizedMessage): string {
         return JSON.stringify(uncast(value, r("SessionVisualizedMessage")), null, 2);
-    }
-
-    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
-        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
-    }
-
-    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
     }
 
     public static toSetChiefOfStaffMessage(json: string): SetChiefOfStaffMessage {
@@ -6195,12 +6233,12 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SetSettingMessage")), null, 2);
     }
 
-    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
-        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
+    public static toSetTicketStatusMessage(json: string): SetTicketStatusMessage {
+        return cast(JSON.parse(json), r("SetTicketStatusMessage"));
     }
 
-    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
-        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
+    public static setTicketStatusMessageToJson(value: SetTicketStatusMessage): string {
+        return JSON.stringify(uncast(value, r("SetTicketStatusMessage")), null, 2);
     }
 
     public static toSettingsUpdatedMessage(json: string): SettingsUpdatedMessage {
@@ -6209,6 +6247,14 @@ export class Convert {
 
     public static settingsUpdatedMessageToJson(value: SettingsUpdatedMessage): string {
         return JSON.stringify(uncast(value, r("SettingsUpdatedMessage")), null, 2);
+    }
+
+    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
+        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
+    }
+
+    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
+        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
     }
 
     public static toSpawnResultMessage(json: string): SpawnResultMessage {
@@ -6273,6 +6319,22 @@ export class Convert {
 
     public static subscribeGitStatusMessageToJson(value: SubscribeGitStatusMessage): string {
         return JSON.stringify(uncast(value, r("SubscribeGitStatusMessage")), null, 2);
+    }
+
+    public static toTicketStatus(json: string): TicketStatus {
+        return cast(JSON.parse(json), r("TicketStatus"));
+    }
+
+    public static ticketStatusToJson(value: TicketStatus): string {
+        return JSON.stringify(uncast(value, r("TicketStatus")), null, 2);
+    }
+
+    public static toTicketStatusResult(json: string): TicketStatusResult {
+        return cast(JSON.parse(json), r("TicketStatusResult"));
+    }
+
+    public static ticketStatusResultToJson(value: TicketStatusResult): string {
+        return JSON.stringify(uncast(value, r("TicketStatusResult")), null, 2);
     }
 
     public static toTodosMessage(json: string): TodosMessage {
@@ -6707,20 +6769,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockTileMessage")), null, 2);
     }
 
-    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
-    }
-
-    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
-    }
-
     public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutUpdatedMessage"));
     }
 
     public static workspaceLayoutUpdatedMessageToJson(value: WorkspaceLayoutUpdatedMessage): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
+    }
+
+    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
+    }
+
+    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
     }
 
     public static toWorkspaceRegisteredMessage(json: string): WorkspaceRegisteredMessage {
@@ -7976,15 +8038,15 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("ListBranchesMessageCmd") },
         { json: "main_repo", js: "main_repo", typ: "" },
     ], "any"),
+    "ListDispatchesMessage": o([
+        { json: "cmd", js: "cmd", typ: r("ListDispatchesMessageCmd") },
+        { json: "source_session_id", js: "source_session_id", typ: "" },
+    ], "any"),
     "ListDispatchMessagesMessage": o([
         { json: "cmd", js: "cmd", typ: r("ListDispatchMessagesMessageCmd") },
         { json: "dispatch_id", js: "dispatch_id", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "unread_only", js: "unread_only", typ: u(undefined, true) },
-    ], "any"),
-    "ListDispatchesMessage": o([
-        { json: "cmd", js: "cmd", typ: r("ListDispatchesMessageCmd") },
-        { json: "source_session_id", js: "source_session_id", typ: "" },
     ], "any"),
     "ListEndpointsMessage": o([
         { json: "cmd", js: "cmd", typ: r("ListEndpointsMessageCmd") },
@@ -8223,49 +8285,6 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
         { json: "session_id", js: "session_id", typ: u(undefined, "") },
     ], "any"),
-    "PR": o([
-        { json: "approved_by_me", js: "approved_by_me", typ: true },
-        { json: "author", js: "author", typ: "" },
-        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
-        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
-        { json: "details_fetched", js: "details_fetched", typ: true },
-        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
-        { json: "has_new_changes", js: "has_new_changes", typ: true },
-        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
-        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
-        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
-        { json: "host", js: "host", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
-        { json: "last_polled", js: "last_polled", typ: "" },
-        { json: "last_updated", js: "last_updated", typ: "" },
-        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
-        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
-        { json: "muted", js: "muted", typ: true },
-        { json: "number", js: "number", typ: 0 },
-        { json: "reason", js: "reason", typ: "" },
-        { json: "repo", js: "repo", typ: "" },
-        { json: "review_status", js: "review_status", typ: u(undefined, "") },
-        { json: "role", js: "role", typ: r("PRRole") },
-        { json: "state", js: "state", typ: "" },
-        { json: "title", js: "title", typ: "" },
-        { json: "url", js: "url", typ: "" },
-    ], "any"),
-    "PRActionResultMessage": o([
-        { json: "action", js: "action", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "success", js: "success", typ: true },
-    ], "any"),
-    "PRVisitedMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
-        { json: "id", js: "id", typ: "" },
-    ], "any"),
-    "PRsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
-        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
-    ], "any"),
     "PathInspection": o([
         { json: "exists", js: "exists", typ: true },
         { json: "home_path", js: "home_path", typ: u(undefined, "") },
@@ -8323,6 +8342,49 @@ const typeMap: any = {
         { json: "running", js: "running", typ: true },
         { json: "version", js: "version", typ: "" },
     ], "any"),
+    "PR": o([
+        { json: "approved_by_me", js: "approved_by_me", typ: true },
+        { json: "author", js: "author", typ: "" },
+        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
+        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
+        { json: "details_fetched", js: "details_fetched", typ: true },
+        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
+        { json: "has_new_changes", js: "has_new_changes", typ: true },
+        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
+        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
+        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
+        { json: "host", js: "host", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
+        { json: "last_polled", js: "last_polled", typ: "" },
+        { json: "last_updated", js: "last_updated", typ: "" },
+        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
+        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
+        { json: "muted", js: "muted", typ: true },
+        { json: "number", js: "number", typ: 0 },
+        { json: "reason", js: "reason", typ: "" },
+        { json: "repo", js: "repo", typ: "" },
+        { json: "review_status", js: "review_status", typ: u(undefined, "") },
+        { json: "role", js: "role", typ: r("PRRole") },
+        { json: "state", js: "state", typ: "" },
+        { json: "title", js: "title", typ: "" },
+        { json: "url", js: "url", typ: "" },
+    ], "any"),
+    "PRActionResultMessage": o([
+        { json: "action", js: "action", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "PRsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
+        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
+    ], "any"),
+    "PRVisitedMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
+        { json: "id", js: "id", typ: "" },
+    ], "any"),
     "PtyDesyncMessage": o([
         { json: "event", js: "event", typ: r("PtyDesyncMessageEvent") },
         { json: "id", js: "id", typ: "" },
@@ -8340,15 +8402,15 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "seq", js: "seq", typ: 0 },
     ], "any"),
-    "PtyResizeMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
-        { json: "cols", js: "cols", typ: 0 },
-        { json: "id", js: "id", typ: "" },
-        { json: "rows", js: "rows", typ: 0 },
-    ], "any"),
     "PtyResizedMessage": o([
         { json: "cols", js: "cols", typ: 0 },
         { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "rows", js: "rows", typ: 0 },
+    ], "any"),
+    "PtyResizeMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
+        { json: "cols", js: "cols", typ: 0 },
         { json: "id", js: "id", typ: "" },
         { json: "rows", js: "rows", typ: 0 },
     ], "any"),
@@ -8503,6 +8565,7 @@ const typeMap: any = {
         { json: "repos", js: "repos", typ: u(undefined, a(r("RepoElement"))) },
         { json: "review_loop_run", js: "review_loop_run", typ: u(undefined, r("ReviewLoopRunObject")) },
         { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
+        { json: "ticket_status_result", js: "ticket_status_result", typ: u(undefined, r("TicketStatusResultObject")) },
         { json: "workspace_context_maintenance_result", js: "workspace_context_maintenance_result", typ: u(undefined, r("WorkspaceContextMaintenanceResultObject")) },
         { json: "workspace_context_result", js: "workspace_context_result", typ: u(undefined, r("WorkspaceContextResultObject")) },
         { json: "workspace_contexts", js: "workspace_contexts", typ: u(undefined, a(r("WorkspaceContextElement"))) },
@@ -8577,6 +8640,10 @@ const typeMap: any = {
         { json: "loop_id", js: "loop_id", typ: "" },
         { json: "question", js: "question", typ: "" },
         { json: "status", js: "status", typ: r("ReviewLoopInteractionStatus") },
+    ], "any"),
+    "TicketStatusResultObject": o([
+        { json: "status", js: "status", typ: r("TicketStatus") },
+        { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
     "WorkspaceContextMaintenanceResultObject": o([
         { json: "action", js: "action", typ: r("WorkspaceContextMaintenanceAction") },
@@ -8754,6 +8821,10 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("SessionStateChangedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
     ], "any"),
+    "SessionsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
+        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
+    ], "any"),
     "SessionTodosUpdatedMessage": o([
         { json: "event", js: "event", typ: r("SessionTodosUpdatedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
@@ -8765,10 +8836,6 @@ const typeMap: any = {
     "SessionVisualizedMessage": o([
         { json: "cmd", js: "cmd", typ: r("SessionVisualizedMessageCmd") },
         { json: "id", js: "id", typ: "" },
-    ], "any"),
-    "SessionsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
-        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
     ], "any"),
     "SetChiefOfStaffMessage": o([
         { json: "chief_of_staff", js: "chief_of_staff", typ: true },
@@ -8800,11 +8867,11 @@ const typeMap: any = {
         { json: "key", js: "key", typ: "" },
         { json: "value", js: "value", typ: "" },
     ], "any"),
-    "SetWorkspaceRankMessage": o([
-        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
-        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
-        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
+    "SetTicketStatusMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SetTicketStatusMessageCmd") },
+        { json: "comment", js: "comment", typ: u(undefined, "") },
+        { json: "source_session_id", js: "source_session_id", typ: "" },
+        { json: "work_state", js: "work_state", typ: r("DispatchWorkState") },
     ], "any"),
     "SettingsUpdatedMessage": o([
         { json: "changed_key", js: "changed_key", typ: u(undefined, "") },
@@ -8812,6 +8879,12 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("SettingsUpdatedMessageEvent") },
         { json: "settings", js: "settings", typ: u(undefined, m("any")) },
         { json: "success", js: "success", typ: u(undefined, true) },
+    ], "any"),
+    "SetWorkspaceRankMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
+        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
+        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "SpawnResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
@@ -8869,6 +8942,10 @@ const typeMap: any = {
     "SubscribeGitStatusMessage": o([
         { json: "cmd", js: "cmd", typ: r("SubscribeGitStatusMessageCmd") },
         { json: "directory", js: "directory", typ: "" },
+    ], "any"),
+    "TicketStatusResult": o([
+        { json: "status", js: "status", typ: r("TicketStatus") },
+        { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
     "TodosMessage": o([
         { json: "cmd", js: "cmd", typ: r("TodosMessageCmd") },
@@ -9297,16 +9374,16 @@ const typeMap: any = {
         { json: "tile_id", js: "tile_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
+    "WorkspaceLayoutUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
+        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
+    ], "any"),
     "WorkspaceLayoutUpdateTileMessage": o([
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUpdateTileMessageCmd") },
         { json: "request_id", js: "request_id", typ: "" },
         { json: "tile_id", js: "tile_id", typ: "" },
         { json: "tile_params", js: "tile_params", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
-    "WorkspaceLayoutUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
-        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
     ], "any"),
     "WorkspaceRegisteredMessage": o([
         { json: "event", js: "event", typ: r("WorkspaceRegisteredMessageEvent") },
@@ -9674,11 +9751,11 @@ const typeMap: any = {
     "ListBranchesMessageCmd": [
         "list_branches",
     ],
-    "ListDispatchMessagesMessageCmd": [
-        "list_dispatch_messages",
-    ],
     "ListDispatchesMessageCmd": [
         "list_dispatches",
+    ],
+    "ListDispatchMessagesMessageCmd": [
+        "list_dispatch_messages",
     ],
     "ListEndpointsMessageCmd": [
         "list_endpoints",
@@ -9773,15 +9850,6 @@ const typeMap: any = {
     "OpenMarkdownMessageCmd": [
         "open_markdown",
     ],
-    "PRActionResultMessageEvent": [
-        "pr_action_result",
-    ],
-    "PRVisitedMessageCmd": [
-        "pr_visited",
-    ],
-    "PRsUpdatedMessageEvent": [
-        "prs_updated",
-    ],
     "PinWorkspaceMessageCmd": [
         "pin_workspace",
     ],
@@ -9790,6 +9858,15 @@ const typeMap: any = {
     ],
     "PluginsUpdatedMessageEvent": [
         "plugins_updated",
+    ],
+    "PRActionResultMessageEvent": [
+        "pr_action_result",
+    ],
+    "PRsUpdatedMessageEvent": [
+        "prs_updated",
+    ],
+    "PRVisitedMessageCmd": [
+        "pr_visited",
     ],
     "PtyDesyncMessageEvent": [
         "pty_desync",
@@ -9800,11 +9877,11 @@ const typeMap: any = {
     "PtyOutputMessageEvent": [
         "pty_output",
     ],
-    "PtyResizeMessageCmd": [
-        "pty_resize",
-    ],
     "PtyResizedMessageEvent": [
         "pty_resized",
+    ],
+    "PtyResizeMessageCmd": [
+        "pty_resize",
     ],
     "QueryAuthorsMessageCmd": [
         "query_authors",
@@ -9891,6 +9968,15 @@ const typeMap: any = {
         "running",
         "stopped",
     ],
+    "TicketStatus": [
+        "blocked",
+        "crashed",
+        "done",
+        "failed",
+        "in_review",
+        "todo",
+        "working",
+    ],
     "WorkspaceContextMaintenanceAction": [
         "compact",
         "rollback",
@@ -9924,6 +10010,9 @@ const typeMap: any = {
     "SessionStateChangedMessageEvent": [
         "session_state_changed",
     ],
+    "SessionsUpdatedMessageEvent": [
+        "sessions_updated",
+    ],
     "SessionTodosUpdatedMessageEvent": [
         "session_todos_updated",
     ],
@@ -9932,9 +10021,6 @@ const typeMap: any = {
     ],
     "SessionVisualizedMessageCmd": [
         "session_visualized",
-    ],
-    "SessionsUpdatedMessageEvent": [
-        "sessions_updated",
     ],
     "SetChiefOfStaffMessageCmd": [
         "set_chief_of_staff",
@@ -9954,11 +10040,14 @@ const typeMap: any = {
     "SetSettingMessageCmd": [
         "set_setting",
     ],
-    "SetWorkspaceRankMessageCmd": [
-        "set_workspace_rank",
+    "SetTicketStatusMessageCmd": [
+        "set_ticket_status",
     ],
     "SettingsUpdatedMessageEvent": [
         "settings_updated",
+    ],
+    "SetWorkspaceRankMessageCmd": [
+        "set_workspace_rank",
     ],
     "SpawnResultMessageEvent": [
         "spawn_result",
@@ -10120,11 +10209,11 @@ const typeMap: any = {
     "WorkspaceLayoutUndockTileMessageCmd": [
         "workspace_layout_undock_tile",
     ],
-    "WorkspaceLayoutUpdateTileMessageCmd": [
-        "workspace_layout_update_tile",
-    ],
     "WorkspaceLayoutUpdatedMessageEvent": [
         "workspace_layout_updated",
+    ],
+    "WorkspaceLayoutUpdateTileMessageCmd": [
+        "workspace_layout_update_tile",
     ],
     "WorkspaceRegisteredMessageEvent": [
         "workspace_registered",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -852,37 +852,71 @@ func runTicket() {
 	}
 }
 
+type ticketStatusArgs struct {
+	WorkState string
+	Session   string
+	Comment   string
+	JSON      bool
+}
+
+// parseTicketStatusArgs reads `ticket status <work-state> [flags]`. Go's flag
+// parser stops at the first positional, so a naive Parse would silently drop any
+// flag written after the work state — exactly the documented form. We interleave
+// instead: parse, peel one positional, repeat, so flags may sit on either side of
+// the state and the single positional is the work state regardless of order.
+func parseTicketStatusArgs(args []string) (ticketStatusArgs, error) {
+	var result ticketStatusArgs
+	fs := flag.NewFlagSet("ticket status", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	session := fs.String("session", "", "session id (defaults to ATTN_SESSION_ID)")
+	comment := fs.String("comment", "", "optional note recorded with the status change")
+	jsonOutput := fs.Bool("json", false, "print the result as JSON")
+
+	var positionals []string
+	rest := args
+	for {
+		if err := fs.Parse(rest); err != nil {
+			return result, err
+		}
+		rest = fs.Args()
+		if len(rest) == 0 {
+			break
+		}
+		positionals = append(positionals, rest[0])
+		rest = rest[1:]
+	}
+	if len(positionals) != 1 {
+		return result, fmt.Errorf("expected exactly one work state argument, got %d", len(positionals))
+	}
+	result.WorkState = positionals[0]
+	result.Session = *session
+	result.Comment = *comment
+	result.JSON = *jsonOutput
+	return result, nil
+}
+
 // runTicketStatus reports the calling agent's work state, moving its bound ticket
 // to the matching column. The work state is the same vocabulary the agent reports
 // to the chief (in_progress, needs_input, ready_for_review, completed, failed);
 // the daemon resolves which ticket from the session and maps the column.
 func runTicketStatus(args []string) {
-	fs := flag.NewFlagSet("ticket status", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	sessionID := fs.String("session", "", "session id (defaults to ATTN_SESSION_ID)")
-	comment := fs.String("comment", "", "optional note recorded with the status change")
-	jsonOutput := fs.Bool("json", false, "print the result as JSON")
-	if err := fs.Parse(args); err != nil {
+	parsed, err := parseTicketStatusArgs(args)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "ticket status: %v\n", err)
-		os.Exit(2)
-	}
-	if fs.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "ticket status: expected exactly one work state argument")
 		writeTicketHelp(os.Stderr)
 		os.Exit(2)
 	}
-	workState := fs.Arg(0)
-	source, err := resolveDispatchSession(*sessionID)
+	source, err := resolveDispatchSession(parsed.Session)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ticket status: %v\n", err)
 		os.Exit(2)
 	}
-	result, err := client.New("").SetTicketStatus(source, workState, *comment)
+	result, err := client.New("").SetTicketStatus(source, parsed.WorkState, parsed.Comment)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ticket status: %v\n", err)
 		os.Exit(1)
 	}
-	if *jsonOutput {
+	if parsed.JSON {
 		printJSON(result)
 		return
 	}

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -253,6 +253,9 @@ func main() {
 	case "dispatch":
 		maybePrintProfileBanner()
 		runDispatch()
+	case "ticket":
+		maybePrintProfileBanner()
+		runTicket()
 	case "workspace":
 		maybePrintProfileBanner()
 		runWorkspace()
@@ -825,6 +828,83 @@ func hasHelpFlag(args []string) bool {
 		}
 	}
 	return false
+}
+
+// runTicket routes `attn ticket <command>`. Today the only verb is `status`, the
+// agent's forward channel onto its own bound ticket; more arrive with the board.
+func runTicket() {
+	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
+		writeTicketHelp(os.Stdout)
+		return
+	}
+	warnIfDaemonVersionMismatch()
+	switch os.Args[2] {
+	case "status":
+		if hasHelpFlag(os.Args[3:]) {
+			writeTicketHelp(os.Stdout)
+			return
+		}
+		runTicketStatus(os.Args[3:])
+	default:
+		fmt.Fprintf(os.Stderr, "ticket: unknown command %q\n", os.Args[2])
+		writeTicketHelp(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+// runTicketStatus reports the calling agent's work state, moving its bound ticket
+// to the matching column. The work state is the same vocabulary the agent reports
+// to the chief (in_progress, needs_input, ready_for_review, completed, failed);
+// the daemon resolves which ticket from the session and maps the column.
+func runTicketStatus(args []string) {
+	fs := flag.NewFlagSet("ticket status", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	sessionID := fs.String("session", "", "session id (defaults to ATTN_SESSION_ID)")
+	comment := fs.String("comment", "", "optional note recorded with the status change")
+	jsonOutput := fs.Bool("json", false, "print the result as JSON")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "ticket status: %v\n", err)
+		os.Exit(2)
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "ticket status: expected exactly one work state argument")
+		writeTicketHelp(os.Stderr)
+		os.Exit(2)
+	}
+	workState := fs.Arg(0)
+	source, err := resolveDispatchSession(*sessionID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ticket status: %v\n", err)
+		os.Exit(2)
+	}
+	result, err := client.New("").SetTicketStatus(source, workState, *comment)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ticket status: %v\n", err)
+		os.Exit(1)
+	}
+	if *jsonOutput {
+		printJSON(result)
+		return
+	}
+	fmt.Printf("ticket %s → %s\n", result.TicketID, result.Status)
+}
+
+func writeTicketHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn ticket <command>
+
+commands:
+  status <work-state> [--session <id>] [--comment <text>] [--json]
+        move this session's bound ticket to the column for the reported state
+
+work states:
+  in_progress       working
+  needs_input       blocked
+  ready_for_review  in review
+  completed         done
+  failed            failed
+
+The session defaults to ATTN_SESSION_ID.
+`)
 }
 
 func writeDispatchOutcomeHelp(w io.Writer, outcome string) {

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -1213,3 +1213,62 @@ func TestNonTerminalStopState(t *testing.T) {
 		})
 	}
 }
+
+// parseTicketStatusArgs must accept flags on either side of the work-state
+// positional. Go's flag parser stops at the first positional, so the regression
+// here is the documented `ticket status <state> --comment ...` form (flags after
+// the state) silently dropping the flags.
+func TestParseTicketStatusArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want ticketStatusArgs
+	}{
+		{
+			name: "flags after state (the documented form)",
+			args: []string{"ready_for_review", "--comment", "ready for a look", "--session", "s1"},
+			want: ticketStatusArgs{WorkState: "ready_for_review", Comment: "ready for a look", Session: "s1"},
+		},
+		{
+			name: "flags before state",
+			args: []string{"--session", "s1", "--comment", "wip", "in_progress"},
+			want: ticketStatusArgs{WorkState: "in_progress", Comment: "wip", Session: "s1"},
+		},
+		{
+			name: "flags around state",
+			args: []string{"--session", "s1", "completed", "--json"},
+			want: ticketStatusArgs{WorkState: "completed", Session: "s1", JSON: true},
+		},
+		{
+			name: "bare state",
+			args: []string{"failed"},
+			want: ticketStatusArgs{WorkState: "failed"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseTicketStatusArgs(tc.args)
+			if err != nil {
+				t.Fatalf("parseTicketStatusArgs(%v): %v", tc.args, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseTicketStatusArgs(%v) = %+v, want %+v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseTicketStatusArgsErrors(t *testing.T) {
+	cases := map[string][]string{
+		"no state":     {"--comment", "hi"},
+		"two states":   {"working", "failed"},
+		"unknown flag": {"working", "--bogus"},
+	}
+	for name, args := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseTicketStatusArgs(args); err == nil {
+				t.Fatalf("parseTicketStatusArgs(%v) = nil error, want error", args)
+			}
+		})
+	}
+}

--- a/docs/plans/2026-06-26-work-tracker-slice3.md
+++ b/docs/plans/2026-06-26-work-tracker-slice3.md
@@ -1,0 +1,58 @@
+# Slice 3 execution plan — Delegation ⇄ tickets (live wiring)
+
+> Detail plan for slice 3 of `2026-06-26-work-tracker.md`. The parent plan is the
+> spec; this records the **sub-split and the implementation decisions**, because
+> slice 3 is large and **removes live production paths** (the dispatch mailbox +
+> report), so the destructive work is gated behind the additive replacements.
+
+## Why split
+
+Slice 3 spans the daemon, hooks, the `dispatch` CLI surface, the protocol (version
+bump + `make generate-types`), and the store, and it **deletes** the mailbox/report
+paths. That is too big for one reviewable PR and the deletions are irreversible. So
+it lands as **stacked, additive-first sub-PRs**, with the removal **last and gated**.
+
+## Decisions (resolved from the parent plan)
+
+- **Binding = `ticket.assignee = the delegated session id`.** The agent's observer
+  identity in `ticketnotify` is its session id (`AgentObserver(sessionID, agent)`), so
+  assignee == identity *is* the binding — no new sessions column or protocol field.
+  A `session → ticket` lookup is `ActiveTicketForSession` (the non-terminal ticket
+  assigned to that session), used by crash detection and the report path. Parent plan:
+  "the ticket binds to it" and "delegated sessions always have a ticket."
+- **Ticket id at delegate time = a slug derived from the label/brief.** The agent
+  isn't running yet, so attn derives the slug and resolves collisions with a numeric
+  suffix (`ErrTicketIDTaken` → retry). (The agent-names-it path applies to
+  agent-created tickets, a later surface.)
+- **Initial status = Working.** Delegation starts the agent immediately, so the
+  ticket is in flight from t0. (Todo is for an un-started backlog item.)
+- **Assignee = the delegated session id.** This is the observer identity in
+  `ticketnotify` (`AgentObserver(sessionID, agent)`), so assignee == identity is what
+  makes the agent observe its own ticket. Display name resolution is a board concern.
+- **Forward report = a ticket-native verb.** Agent reports via
+  `ticket status <id> <status> [--comment]` → `SetTicketStatus`. The dispatch outcome
+  verbs (`update/block/review/complete/fail`) are removed in the gated removal sub-PR.
+  `handoff` is NOT removed here — it becomes `ticket attach` in slice 4.
+- **DispatchWorkState → TicketStatus**: `in_progress→Working`, `needs_input→Blocked`,
+  `ready_for_review→In Review`, `completed→Done`, `failed→Failed`.
+- **Crash is attn-authored.** `handlePTYExit` → `captureDispatchCloseState` →
+  `closedMidFlight`: when a bound ticket is still non-terminal on a mid-flight close,
+  attn writes `SetTicketStatus(Crashed, author="attn")`. The one transition a dead
+  worker can't make itself.
+- **Reverse = ticket events + ticketnotify.** Chief edits a ticket → events →
+  `ticketnotify.Notify` → Claude watch-consume / codex nudge. The
+  `chief_of_staff_dispatch_messages` mailbox is removed in the gated removal sub-PR.
+
+## Sub-PRs (stacked on `tickets/slice-2-events`)
+
+| # | branch | additive? | scope |
+|---|---|---|---|
+| 3a | `tickets/slice-3a-binding` | ✅ additive | delegate creates + binds a ticket (slug, Working, assignee=session) and emits the created event; `ActiveTicketForSession` lookup. No migration/protocol change. |
+| 3b | `tickets/slice-3b-report` | ✅ additive | `ticket status` verb + daemon handler → `SetTicketStatus` on the bound ticket; new protocol command (version bump). |
+| 3c | `tickets/slice-3c-crash` | ✅ additive | wire the crash seam to author `Crashed` on a bound, non-terminal ticket. |
+| 3d | `tickets/slice-3d-observe` | ✅ additive | chief + agent observers on live sessions; ticket events drive `Notify` (Claude watch / codex-nudge stub); end-to-end with a real Claude agent. |
+| 3e | `tickets/slice-3e-remove-dispatch` | ⚠️ **destructive — gated on Victor's confirm** | delete the dispatch mailbox (`message/inbox/messages/read/ack`, store file, handlers, protocol) and the outcome-report verbs, now that tickets cover them. |
+
+CI is main-only, so each PR is verified green locally + figgyster-reviewed. The
+removal sub-PR (3e) is **not** started until the additive replacements are proven and
+Victor signs off on deleting the live paths.

--- a/docs/plans/2026-06-26-work-tracker-slice3.md
+++ b/docs/plans/2026-06-26-work-tracker-slice3.md
@@ -47,8 +47,8 @@ it lands as **stacked, additive-first sub-PRs**, with the removal **last and gat
 
 | # | branch | additive? | scope |
 |---|---|---|---|
-| 3a | `tickets/slice-3a-binding` | ✅ additive | delegate creates + binds a ticket (slug, Working, assignee=session) and emits the created event; `ActiveTicketForSession` lookup. No migration/protocol change. |
-| 3b | `tickets/slice-3b-report` | ✅ additive | `ticket status` verb + daemon handler → `SetTicketStatus` on the bound ticket; new protocol command (version bump). |
+| 3a | `tickets/slice-3a-binding` | ✅ additive | ✅ **merged-ready (#415, figgy-approved)** — delegate creates + binds a ticket (slug, Working, assignee=session) and emits the created event; `ActiveTicketForSession` lookup. No migration/protocol change. |
+| 3b | `tickets/slice-3b-report` | ✅ additive | ✅ **built** — `attn ticket status <work-state>` verb + `handleSetTicketStatus` → `SetTicketStatus` on the session's bound ticket (resolved via `ActiveTicketForSession`, never a caller id); `work_state`→column map; protocol v124. |
 | 3c | `tickets/slice-3c-crash` | ✅ additive | wire the crash seam to author `Crashed` on a bound, non-terminal ticket. |
 | 3d | `tickets/slice-3d-observe` | ✅ additive | chief + agent observers on live sessions; ticket events drive `Notify` (Claude watch / codex-nudge stub); end-to-end with a real Claude agent. |
 | 3e | `tickets/slice-3e-remove-dispatch` | ⚠️ **destructive — gated on Victor's confirm** | delete the dispatch mailbox (`message/inbox/messages/read/ack`, store file, handlers, protocol) and the outcome-report verbs, now that tickets cover them. |

--- a/docs/plans/2026-06-26-work-tracker.md
+++ b/docs/plans/2026-06-26-work-tracker.md
@@ -229,7 +229,7 @@ each is a meaningful, verifiable chunk.
 | # | slice | status |
 |---|---|---|
 | 1 | Ticket store + lifecycle | 🟡 |
-| 2 | Event-driven notification core | ⬜ |
+| 2 | Event-driven notification core | 🟡 |
 | 3 | Delegation ⇄ tickets (live wiring) | ⬜ |
 | 4 | Ticket view + resume + attachments | ⬜ |
 | 5 | Board view | ⬜ |

--- a/docs/plans/2026-06-26-work-tracker.md
+++ b/docs/plans/2026-06-26-work-tracker.md
@@ -147,11 +147,20 @@ knows *nothing* about who's listening:
 - `TicketCreated`, `TicketStatusChanged` (from→to), `TicketCommented`,
   `TicketAssigned`, `TicketDescriptionEdited`, `TicketAttachmentAdded`.
 
-**2. Observers subscribe** to events for tickets they care about:
+**2. Observers subscribe** to events for tickets they care about. Identity is uniform
+— **you, the chief, and each agent are all just identities** (the chief is one of the
+agents). An identity is *involved* with a ticket when it is assigned to it or has
+authored an event on it:
 
-- the **chief** observes events on the tickets it delegated / owns;
+- the **chief** observes events on the tickets it delegated / owns (it authored their
+  `created` event, so it needs no special "sees everything" scope);
 - an **assignee agent** observes events on its ticket that it *didn't author* (the
   chief's comments, status changes, re-briefs).
+
+Each identity keeps its **own cursor per ticket**, not one global cursor. So a ticket
+newly assigned to an agent — or reassigned to it — arrives with its **full history**
+(the brief and prior steers), and an agent's progress on one ticket never advances its
+bookmark on another it hasn't looked at.
 
 **3. Decoupled handlers** turn an event into a notification — adding a channel is adding
 a handler, never touching the mutators:
@@ -169,7 +178,7 @@ The gateway's settled mechanics map onto the event log:
 | gateway mechanic | here |
 |---|---|
 | dedup by content | idempotent events (no double-emitted transition/comment) |
-| ack = output; consume returns pending | **unread** — events since the observer's cursor |
+| ack = output; consume returns pending | **unread** — events past the identity's per-(identity, ticket) cursor |
 | bundle by sender | a consume groups pending events **by ticket** |
 | hardcoded chief id | the chief is a well-known observer (literal constant) |
 | two consumers (watch / nudge) | the two decoupled handlers above |

--- a/docs/plans/2026-06-26-work-tracker.md
+++ b/docs/plans/2026-06-26-work-tracker.md
@@ -239,7 +239,7 @@ each is a meaningful, verifiable chunk.
 |---|---|---|
 | 1 | Ticket store + lifecycle | 🟡 |
 | 2 | Event-driven notification core | 🟡 |
-| 3 | Delegation ⇄ tickets (live wiring) | ⬜ |
+| 3 | Delegation ⇄ tickets (live wiring) | 🟡 (sub-split — see `2026-06-26-work-tracker-slice3.md`) |
 | 4 | Ticket view + resume + attachments | ⬜ |
 | 5 | Board view | ⬜ |
 | 6 | Codex nudge path | ⬜ |

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -374,6 +374,28 @@ func (c *Client) AcknowledgeDispatchMessage(
 	return resp.DispatchMessage, nil
 }
 
+// SetTicketStatus reports the calling agent's work state; the daemon moves the
+// session's bound ticket to the matching column and echoes the resolved id and
+// status back.
+func (c *Client) SetTicketStatus(sourceSessionID, workState, comment string) (*protocol.TicketStatusResult, error) {
+	msg := protocol.SetTicketStatusMessage{
+		Cmd:             protocol.CmdSetTicketStatus,
+		SourceSessionID: sourceSessionID,
+		WorkState:       protocol.DispatchWorkState(workState),
+	}
+	if value := strings.TrimSpace(comment); value != "" {
+		msg.Comment = protocol.Ptr(value)
+	}
+	resp, err := c.send(msg)
+	if err != nil {
+		return nil, err
+	}
+	if resp.TicketStatusResult == nil {
+		return nil, errors.New("daemon returned no ticket status result")
+	}
+	return resp.TicketStatusResult, nil
+}
+
 func (c *Client) CheckoutWorkspaceContext(sourceSessionID string, force bool) (*protocol.WorkspaceContextResult, error) {
 	msg := protocol.WorkspaceContextCheckoutMessage{
 		Cmd:             protocol.CmdWorkspaceContextCheckout,

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -37,6 +37,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdReadDispatchMessage:                   commandMetadata(ScopeSession, false, true),
 	protocol.CmdAcknowledgeDispatchMessage:            commandMetadata(ScopeSession, false, true),
 	protocol.CmdWakeDispatchAgent:                     commandMetadata(ScopeHubLocal, true, true),
+	protocol.CmdSetTicketStatus:                       commandMetadata(ScopeSession, false, true),
 	protocol.CmdUnregister:                            commandMetadata(ScopeSession, true, true),
 	protocol.CmdState:                                 commandMetadata(ScopeSession, false, true),
 	protocol.CmdSetSessionResumeID:                    commandMetadata(ScopeSession, false, true),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1867,6 +1867,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleReadDispatchMessage(conn, msg.(*protocol.ReadDispatchMessage))
 	case protocol.CmdAcknowledgeDispatchMessage:
 		d.handleAcknowledgeDispatchMessage(conn, msg.(*protocol.AcknowledgeDispatchMessage))
+	case protocol.CmdSetTicketStatus:
+		d.handleSetTicketStatus(conn, msg.(*protocol.SetTicketStatusMessage))
 	case protocol.CmdWorkspaceContextCheckout:
 		d.handleWorkspaceContextCheckout(conn, msg.(*protocol.WorkspaceContextCheckoutMessage))
 	case protocol.CmdWorkspaceContextUpdate:

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -394,6 +394,18 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 				fmt.Errorf("make delegated workspace visible: %s", errMsg),
 			)
 		}
+		ticketID, err := d.createDelegatedTicket(chiefSessionID, session, brief, name, agent)
+		if err != nil {
+			_ = d.store.DeleteChiefOfStaffDispatch(dispatch.ID)
+			d.unregisterSession(sessionID, syscall.SIGTERM)
+			d.removeWorkspaceLayoutPaneForSession(sessionID)
+			return nil, d.rollbackDelegation(
+				createdWorkspaceID,
+				createdWorktreePath,
+				fmt.Errorf("create delegated ticket: %w", err),
+			)
+		}
+		d.logf("delegate: bound ticket %q to session %s", ticketID, session.ID)
 	}
 	result := &protocol.DelegateResult{
 		SessionID:   session.ID,

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/store"
 )
 
 func setupDelegationSource(t *testing.T, d *Daemon, backend *fakeSpawnBackend) (string, string, string) {
@@ -780,6 +781,68 @@ func TestStructuredDispatchReportSeparatesRuntimeAndSupportsResolution(t *testin
 		statusResponse.ChiefOfStaffDispatch == nil ||
 		protocol.Deref(statusResponse.ChiefOfStaffDispatch.StructuredReport.Request.Response) != "Use AisNoOperationV1." {
 		t.Fatalf("delegated status response = %+v", statusResponse)
+	}
+}
+
+// Delegating from the chief creates and binds a ticket: the brief is the
+// description, the delegated session is the assignee (its observer identity), the
+// ticket is in-flight (Working), and a created event lands authored by the chief.
+func TestDelegateCreatesAndBindsTicket(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, chiefSessionID, _ := setupDelegationSource(t, d, backend)
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, chiefSessionID); err != nil {
+		t.Fatalf("set chief role: %v", err)
+	}
+	consumeDelegatedPrompt(t, backend)
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: chiefSessionID,
+		Brief:           "Migrate the store to X",
+		Agent:           protocol.Ptr("codex"),
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+
+	ticket, err := d.store.ActiveTicketForSession(result.SessionID)
+	if err != nil {
+		t.Fatalf("ActiveTicketForSession: %v", err)
+	}
+	if ticket == nil {
+		t.Fatal("delegate did not create a ticket bound to the session")
+	}
+	if ticket.Description != "Migrate the store to X" {
+		t.Fatalf("ticket description = %q, want the brief", ticket.Description)
+	}
+	if ticket.Assignee != result.SessionID {
+		t.Fatalf("ticket assignee = %q, want session id %q", ticket.Assignee, result.SessionID)
+	}
+	if ticket.Status != store.TicketStatusWorking {
+		t.Fatalf("ticket status = %q, want working", ticket.Status)
+	}
+	if ticket.Cwd == "" {
+		t.Fatal("ticket cwd not set (needed for resume)")
+	}
+
+	// The created event is authored by the chief, so the agent observes it as its
+	// "assigned to you" signal and the chief never sees its own action.
+	events, err := d.store.TicketEventsSince(0)
+	if err != nil {
+		t.Fatalf("TicketEventsSince: %v", err)
+	}
+	var created *store.TicketEvent
+	for i := range events {
+		if events[i].TicketID == ticket.ID && events[i].Kind == store.TicketEventCreated {
+			created = &events[i]
+		}
+	}
+	if created == nil {
+		t.Fatalf("no created event for ticket %q", ticket.ID)
+	}
+	if created.Author != chiefSessionID {
+		t.Fatalf("created event author = %q, want chief %q", created.Author, chiefSessionID)
 	}
 }
 

--- a/internal/daemon/delegate_ticket.go
+++ b/internal/daemon/delegate_ticket.go
@@ -1,0 +1,65 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// ticketSlugStrip collapses every run of non-slug characters to a single dash.
+var ticketSlugStrip = regexp.MustCompile(`[^a-z0-9]+`)
+
+// ticketSlug derives a human-friendly slug id from a label (e.g. "Migrate store
+// to X" -> "migrate-store-to-x"). Delegation creates the ticket before the agent
+// runs, so attn names it from the label rather than the agent. The result is
+// always a non-empty, bounded slug; collisions are resolved by the caller.
+func ticketSlug(label string) string {
+	s := ticketSlugStrip.ReplaceAllString(strings.ToLower(strings.TrimSpace(label)), "-")
+	s = strings.Trim(s, "-")
+	if len(s) > 60 {
+		s = strings.Trim(s[:60], "-")
+	}
+	if s == "" {
+		s = "ticket"
+	}
+	return s
+}
+
+// createDelegatedTicket creates and binds the ticket for a chief-delegated session.
+// The brief is the description (the delegation prompt); the session id is the
+// assignee (its observer identity, so assignee == session is the binding); the
+// chief is the author (so the created event reads as "assigned to you" for the
+// agent and is self-authored for the chief). The ticket starts in Working since the
+// agent begins immediately. The slug is derived from the label, with a numeric
+// suffix on collision. Returns the created ticket id.
+func (d *Daemon) createDelegatedTicket(chiefSessionID string, session *protocol.Session, brief, label, agent string) (string, error) {
+	base := ticketSlug(label)
+	now := time.Now()
+	for attempt := 0; attempt < 50; attempt++ {
+		id := base
+		if attempt > 0 {
+			id = fmt.Sprintf("%s-%d", base, attempt+1)
+		}
+		_, err := d.store.CreateTicket(store.Ticket{
+			ID:          id,
+			Title:       label,
+			Description: brief,
+			Status:      store.TicketStatusWorking,
+			Assignee:    session.ID,
+			Cwd:         session.Directory,
+			LastAgentID: agent,
+		}, chiefSessionID, now)
+		if err == nil {
+			return id, nil
+		}
+		if !errors.Is(err, store.ErrTicketIDTaken) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("could not allocate a unique ticket id from %q", base)
+}

--- a/internal/daemon/delegate_ticket_test.go
+++ b/internal/daemon/delegate_ticket_test.go
@@ -1,0 +1,42 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+func TestTicketSlug(t *testing.T) {
+	cases := map[string]string{
+		"Migrate store to X": "migrate-store-to-x",
+		"  Trim/These  ":     "trim-these",
+		"already-kebab":      "already-kebab",
+		"":                   "ticket",
+		"!!!":                "ticket",
+	}
+	for in, want := range cases {
+		if got := ticketSlug(in); got != want {
+			t.Errorf("ticketSlug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// When the derived slug is already taken, the next ticket gets a numeric suffix
+// rather than failing the delegation.
+func TestCreateDelegatedTicketCollisionSuffix(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	if _, err := d.store.CreateTicket(store.Ticket{ID: "migrate-store-to-x", Title: "x"}, "chief", time.Now()); err != nil {
+		t.Fatalf("seed ticket: %v", err)
+	}
+	session := &protocol.Session{ID: "sess-1", Directory: "/tmp/x"}
+	id, err := d.createDelegatedTicket("chief", session, "the brief", "Migrate store to X", "codex")
+	if err != nil {
+		t.Fatalf("createDelegatedTicket: %v", err)
+	}
+	if id != "migrate-store-to-x-2" {
+		t.Fatalf("collision id = %q, want migrate-store-to-x-2", id)
+	}
+}

--- a/internal/daemon/ticket_status.go
+++ b/internal/daemon/ticket_status.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// ticketStatusFromWorkState maps the work state an agent reports onto the ticket
+// column its bound ticket should move to. This is the agent's forward channel:
+// the agent describes its own state, attn projects that onto the board. `crashed`
+// and `todo` are intentionally unreachable here — crashed is attn-authored when an
+// agent dies without reporting, and todo is the pre-assignment backlog state.
+func ticketStatusFromWorkState(ws protocol.DispatchWorkState) (store.TicketStatus, bool) {
+	switch ws {
+	case protocol.DispatchWorkStateInProgress:
+		return store.TicketStatusWorking, true
+	case protocol.DispatchWorkStateNeedsInput:
+		return store.TicketStatusBlocked, true
+	case protocol.DispatchWorkStateReadyForReview:
+		return store.TicketStatusInReview, true
+	case protocol.DispatchWorkStateCompleted:
+		return store.TicketStatusDone, true
+	case protocol.DispatchWorkStateFailed:
+		return store.TicketStatusFailed, true
+	default:
+		return "", false
+	}
+}
+
+// handleSetTicketStatus moves the calling agent's bound ticket to the column
+// implied by the work state it reports. The session is the assignee, so the
+// daemon resolves the ticket from the session rather than trusting a
+// caller-supplied id — an agent can only move its own active ticket. The reported
+// status is recorded with the agent as author so the change reads as
+// self-reported on the activity thread.
+func (d *Daemon) handleSetTicketStatus(conn net.Conn, msg *protocol.SetTicketStatusMessage) {
+	sourceSessionID := strings.TrimSpace(msg.SourceSessionID)
+	if sourceSessionID == "" {
+		d.sendError(conn, "ticket status: source_session_id is required")
+		return
+	}
+	status, ok := ticketStatusFromWorkState(msg.WorkState)
+	if !ok {
+		d.sendError(conn, fmt.Sprintf("ticket status: unknown work state %q", msg.WorkState))
+		return
+	}
+	ticket, err := d.store.ActiveTicketForSession(sourceSessionID)
+	if err != nil {
+		d.sendError(conn, "ticket status: "+err.Error())
+		return
+	}
+	if ticket == nil {
+		d.sendError(conn, "ticket status: no active ticket bound to this session")
+		return
+	}
+	comment := ""
+	if msg.Comment != nil {
+		comment = strings.TrimSpace(*msg.Comment)
+	}
+	updated, err := d.store.SetTicketStatus(ticket.ID, status, sourceSessionID, comment, time.Now())
+	if err != nil {
+		d.sendError(conn, "ticket status: "+err.Error())
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(protocol.Response{
+		Ok: true,
+		TicketStatusResult: &protocol.TicketStatusResult{
+			TicketID: updated.ID,
+			Status:   protocol.TicketStatus(updated.Status),
+		},
+	})
+}

--- a/internal/daemon/ticket_status_test.go
+++ b/internal/daemon/ticket_status_test.go
@@ -1,0 +1,177 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// delegateBoundSession runs a real delegation so the returned session has a
+// ticket bound to it (assignee = session, status = working), mirroring the
+// production path the agent's forward channel reports against.
+func delegateBoundSession(t *testing.T, d *Daemon) string {
+	t.Helper()
+	backend := &fakeSpawnBackend{}
+	_, chiefSessionID, _ := setupDelegationSource(t, d, backend)
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, chiefSessionID); err != nil {
+		t.Fatalf("set chief role: %v", err)
+	}
+	consumeDelegatedPrompt(t, backend)
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: chiefSessionID,
+		Brief:           "Migrate the store to X",
+		Agent:           protocol.Ptr("codex"),
+	})
+	if err != nil {
+		t.Fatalf("delegate(): %v", err)
+	}
+	return result.SessionID
+}
+
+func callSetTicketStatus(t *testing.T, d *Daemon, sessionID, workState, comment string) protocol.Response {
+	t.Helper()
+	msg := &protocol.SetTicketStatusMessage{
+		Cmd:             protocol.CmdSetTicketStatus,
+		SourceSessionID: sessionID,
+		WorkState:       protocol.DispatchWorkState(workState),
+	}
+	if comment != "" {
+		msg.Comment = protocol.Ptr(comment)
+	}
+	server, clientConn := net.Pipe()
+	go func() {
+		d.handleSetTicketStatus(server, msg)
+		_ = server.Close()
+	}()
+	var resp protocol.Response
+	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+		t.Fatalf("decode set-ticket-status response: %v", err)
+	}
+	_ = clientConn.Close()
+	return resp
+}
+
+// The agent reporting ready-for-review moves its bound ticket into the In Review
+// column, echoes the resolved id and status, and records the change authored by
+// the agent's own session.
+func TestSetTicketStatusMovesBoundTicket(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	sessionID := delegateBoundSession(t, d)
+
+	resp := callSetTicketStatus(t, d, sessionID, string(protocol.DispatchWorkStateReadyForReview), "ready for a look")
+	if !resp.Ok || resp.TicketStatusResult == nil {
+		t.Fatalf("response = %+v, want ok with ticket status result", resp)
+	}
+	if resp.TicketStatusResult.Status != protocol.TicketStatusInReview {
+		t.Fatalf("result status = %q, want in_review", resp.TicketStatusResult.Status)
+	}
+
+	ticket, err := d.store.GetTicket(resp.TicketStatusResult.TicketID)
+	if err != nil {
+		t.Fatalf("GetTicket: %v", err)
+	}
+	if ticket.Status != store.TicketStatusInReview {
+		t.Fatalf("stored status = %q, want in_review", ticket.Status)
+	}
+
+	events, err := d.store.TicketEventsSince(0)
+	if err != nil {
+		t.Fatalf("TicketEventsSince: %v", err)
+	}
+	var change *store.TicketEvent
+	for i := range events {
+		if events[i].TicketID == ticket.ID && events[i].Kind == store.TicketEventStatusChanged {
+			change = &events[i]
+		}
+	}
+	if change == nil {
+		t.Fatalf("no status-changed event for ticket %q", ticket.ID)
+	}
+	if change.Author != sessionID {
+		t.Fatalf("status-changed author = %q, want agent session %q", change.Author, sessionID)
+	}
+	if change.ToStatus != store.TicketStatusInReview {
+		t.Fatalf("status-changed to = %q, want in_review", change.ToStatus)
+	}
+	if change.Comment != "ready for a look" {
+		t.Fatalf("status-changed comment = %q, want the supplied note", change.Comment)
+	}
+}
+
+// A completed report closes the ticket (terminal Done), after which the session
+// has no active ticket and a further report is rejected.
+func TestSetTicketStatusCompletedClosesTicket(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	sessionID := delegateBoundSession(t, d)
+
+	resp := callSetTicketStatus(t, d, sessionID, string(protocol.DispatchWorkStateCompleted), "")
+	if !resp.Ok || resp.TicketStatusResult == nil || resp.TicketStatusResult.Status != protocol.TicketStatusDone {
+		t.Fatalf("response = %+v, want ok done", resp)
+	}
+	ticket, err := d.store.GetTicket(resp.TicketStatusResult.TicketID)
+	if err != nil {
+		t.Fatalf("GetTicket: %v", err)
+	}
+	if !ticket.Status.IsTerminal() || ticket.ClosedAt == nil {
+		t.Fatalf("ticket = %+v, want terminal with closed_at", ticket)
+	}
+
+	again := callSetTicketStatus(t, d, sessionID, string(protocol.DispatchWorkStateInProgress), "")
+	if again.Ok || again.Error == nil || !strings.Contains(*again.Error, "no active ticket") {
+		t.Fatalf("second report = %+v, want no-active-ticket error", again)
+	}
+}
+
+func TestSetTicketStatusErrors(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	sessionID := delegateBoundSession(t, d)
+
+	cases := []struct {
+		name      string
+		session   string
+		workState string
+		wantErr   string
+	}{
+		{"empty session", "", string(protocol.DispatchWorkStateInProgress), "source_session_id is required"},
+		{"unknown work state", sessionID, "marshmallow", "unknown work state"},
+		{"no bound ticket", "ghost-session", string(protocol.DispatchWorkStateInProgress), "no active ticket"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := callSetTicketStatus(t, d, tc.session, tc.workState, "")
+			if resp.Ok || resp.Error == nil {
+				t.Fatalf("response = %+v, want error", resp)
+			}
+			if !strings.Contains(*resp.Error, tc.wantErr) {
+				t.Fatalf("error = %q, want substring %q", *resp.Error, tc.wantErr)
+			}
+		})
+	}
+}
+
+// The work-state -> ticket-column mapping is the contract the agent reports
+// against; lock every reachable state and reject the unreachable ones.
+func TestTicketStatusFromWorkState(t *testing.T) {
+	want := map[protocol.DispatchWorkState]store.TicketStatus{
+		protocol.DispatchWorkStateInProgress:     store.TicketStatusWorking,
+		protocol.DispatchWorkStateNeedsInput:     store.TicketStatusBlocked,
+		protocol.DispatchWorkStateReadyForReview: store.TicketStatusInReview,
+		protocol.DispatchWorkStateCompleted:      store.TicketStatusDone,
+		protocol.DispatchWorkStateFailed:         store.TicketStatusFailed,
+	}
+	for ws, status := range want {
+		got, ok := ticketStatusFromWorkState(ws)
+		if !ok || got != status {
+			t.Fatalf("ticketStatusFromWorkState(%q) = (%q, %v), want (%q, true)", ws, got, ok, status)
+		}
+	}
+	if _, ok := ticketStatusFromWorkState(protocol.DispatchWorkState("nonsense")); ok {
+		t.Fatal("ticketStatusFromWorkState accepted an unknown work state")
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "123"
+const ProtocolVersion = "124"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -53,6 +53,7 @@ const (
 	CmdReadDispatchMessage                   = "read_dispatch_message"
 	CmdAcknowledgeDispatchMessage            = "acknowledge_dispatch_message"
 	CmdWakeDispatchAgent                     = "wake_dispatch_agent"
+	CmdSetTicketStatus                       = "set_ticket_status"
 	CmdWorkspaceContextCheckout              = "workspace_context_checkout"
 	CmdWorkspaceContextUpdate                = "workspace_context_update"
 	CmdWorkspaceContextStatus                = "workspace_context_status"
@@ -431,6 +432,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdWakeDispatchAgent:
 		var msg WakeDispatchAgentMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdSetTicketStatus:
+		var msg SetTicketStatusMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2880,6 +2880,9 @@ type Response struct {
 	// Sessions corresponds to the JSON schema field "sessions".
 	Sessions []Session `json:"sessions,omitempty,omitzero"`
 
+	// TicketStatusResult corresponds to the JSON schema field "ticket_status_result".
+	TicketStatusResult *TicketStatusResult `json:"ticket_status_result,omitempty,omitzero"`
+
 	// WorkspaceContextMaintenanceResult corresponds to the JSON schema field
 	// "workspace_context_maintenance_result".
 	WorkspaceContextMaintenanceResult *WorkspaceContextMaintenanceResult `json:"workspace_context_maintenance_result,omitempty,omitzero"`
@@ -3435,6 +3438,20 @@ type SetSettingMessage struct {
 	Value string `json:"value"`
 }
 
+type SetTicketStatusMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Comment corresponds to the JSON schema field "comment".
+	Comment *string `json:"comment,omitempty,omitzero"`
+
+	// SourceSessionID corresponds to the JSON schema field "source_session_id".
+	SourceSessionID string `json:"source_session_id"`
+
+	// WorkState corresponds to the JSON schema field "work_state".
+	WorkState DispatchWorkState `json:"work_state"`
+}
+
 type SetWorkspaceRankMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -3604,6 +3621,25 @@ type SubscribeGitStatusMessage struct {
 	// Directory corresponds to the JSON schema field "directory".
 	Directory string `json:"directory"`
 }
+
+type TicketStatus string
+
+const TicketStatusBlocked TicketStatus = "blocked"
+const TicketStatusCrashed TicketStatus = "crashed"
+const TicketStatusDone TicketStatus = "done"
+const TicketStatusFailed TicketStatus = "failed"
+const TicketStatusInReview TicketStatus = "in_review"
+
+type TicketStatusResult struct {
+	// Status corresponds to the JSON schema field "status".
+	Status TicketStatus `json:"status"`
+
+	// TicketID corresponds to the JSON schema field "ticket_id".
+	TicketID string `json:"ticket_id"`
+}
+
+const TicketStatusTodo TicketStatus = "todo"
+const TicketStatusWorking TicketStatus = "working"
 
 type TodosMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -216,6 +216,19 @@ enum DispatchRequestStatus {
   resolved,
 }
 
+// TicketStatus is the column a ticket lives in on the work-tracker board.
+// `crashed` is attn-authored only (an agent that died without reporting); the
+// rest are reachable by the chief or the agent's own self-report.
+enum TicketStatus {
+  todo,
+  working,
+  blocked,
+  in_review,
+  done,
+  failed,
+  crashed,
+}
+
 model DispatchDecisionRequest {
   question: string;
   recommendation?: string;
@@ -612,6 +625,24 @@ model WakeDispatchAgentMessage {
   source_session_id: string;
   dispatch_id: string;
   request_id: string;
+}
+
+// SetTicketStatusMessage is an agent self-reporting the work state of its own
+// bound ticket. The daemon resolves the ticket from the calling session (the
+// assignee) — the agent does not name an id — and maps the reported work state
+// onto a ticket column. `comment` is an optional note recorded on the change.
+model SetTicketStatusMessage {
+  cmd: "set_ticket_status";
+  source_session_id: string;
+  work_state: DispatchWorkState;
+  comment?: string;
+}
+
+// TicketStatusResult echoes the resolved ticket id and the column it now sits in
+// after a status change, so the caller can confirm what moved.
+model TicketStatusResult {
+  ticket_id: string;
+  status: TicketStatus;
 }
 
 model WorkspaceContextCheckoutMessage {
@@ -2179,6 +2210,7 @@ model Response {
   notebook_read?: NotebookReadResult;
   notebook_write?: NotebookWriteResult;
   notebook_guide?: NotebookGuideResult;
+  ticket_status_result?: TicketStatusResult;
 }
 
 model DelegateResult {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -513,9 +513,12 @@ CREATE INDEX IF NOT EXISTS idx_ticket_attachments_ticket
 CREATE INDEX IF NOT EXISTS idx_ticket_events_ticket
     ON ticket_events(ticket_id, seq);
 CREATE TABLE IF NOT EXISTS ticket_event_cursors (
-    observer_id TEXT PRIMARY KEY,
-    cursor      INTEGER NOT NULL DEFAULT 0,
-    updated_at  TEXT NOT NULL DEFAULT ''
+    identity   TEXT NOT NULL,
+    ticket_id  TEXT NOT NULL,
+    cursor     INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (identity, ticket_id),
+    FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE
 );`},
 }
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -498,6 +498,25 @@ CREATE TABLE IF NOT EXISTS ticket_attachments (
 );
 CREATE INDEX IF NOT EXISTS idx_ticket_attachments_ticket
     ON ticket_attachments(ticket_id, id ASC);`},
+	{56, "create ticket event log", `CREATE TABLE IF NOT EXISTS ticket_events (
+    seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticket_id   TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    author      TEXT NOT NULL DEFAULT '',
+    from_status TEXT NOT NULL DEFAULT '',
+    to_status   TEXT NOT NULL DEFAULT '',
+    comment     TEXT NOT NULL DEFAULT '',
+    detail      TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL,
+    FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_ticket_events_ticket
+    ON ticket_events(ticket_id, seq);
+CREATE TABLE IF NOT EXISTS ticket_event_cursors (
+    observer_id TEXT PRIMARY KEY,
+    cursor      INTEGER NOT NULL DEFAULT 0,
+    updated_at  TEXT NOT NULL DEFAULT ''
+);`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.

--- a/internal/store/ticket_events.go
+++ b/internal/store/ticket_events.go
@@ -8,9 +8,15 @@ import (
 // The ticket event log is the notification substrate for the work tracker (slice
 // 2 of docs/plans/2026-06-26-work-tracker.md). It re-homes the dispatch gateway's
 // settled mechanics: an append-only log with idempotent (deduped) events, a global
-// monotonic seq that doubles as the cursor space, and per-observer cursors that
-// express "unread". The decoupled notification handlers live in internal/ticketnotify;
-// this file is only the durable substrate.
+// monotonic seq that doubles as the cursor space, and per-(identity, ticket)
+// cursors that express "unread". The decoupled notification handlers live in
+// internal/ticketnotify; this file is only the durable substrate.
+//
+// Cursors are keyed by (identity, ticket), not one global cursor per identity:
+// every identity — you, the chief, each agent (the chief is just another agent) —
+// has its own bookmark PER ticket. So a ticket newly assigned to an agent is
+// delivered from the start (it carries the brief and pre-assignment context),
+// and an agent's progress on one ticket never advances its bookmark on another.
 //
 // Events are a SUPERSET of the display activity thread (slice 1): activity holds
 // the two human-facing kinds (status_change, comment); the event log carries all
@@ -130,24 +136,11 @@ func appendTicketEventTx(tx *sql.Tx, e TicketEvent, now time.Time) (int64, bool,
 	return seq, true, nil
 }
 
-// TicketEventsSince returns every event with seq greater than the given cursor,
-// in seq (chronological) order. A cursor of 0 returns the whole log.
-func (s *Store) TicketEventsSince(cursor int64) ([]TicketEvent, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	if s.db == nil {
-		return nil, nil
-	}
-	rows, err := s.db.Query(`
-		SELECT seq, ticket_id, kind, author, from_status, to_status, comment, detail, created_at
-		FROM ticket_events WHERE seq > ? ORDER BY seq ASC
-	`, cursor)
-	if err != nil {
-		return nil, err
-	}
+// scanTicketEventRows scans a ticket_events result set whose columns are, in
+// order: seq, ticket_id, kind, author, from_status, to_status, comment, detail,
+// created_at. It closes rows.
+func scanTicketEventRows(rows *sql.Rows) ([]TicketEvent, error) {
 	defer rows.Close()
-
 	var events []TicketEvent
 	for rows.Next() {
 		var (
@@ -168,6 +161,94 @@ func (s *Store) TicketEventsSince(cursor int64) ([]TicketEvent, error) {
 	return events, rows.Err()
 }
 
+// TicketEventsSince returns every event with seq greater than the given cursor,
+// in seq (chronological) order. A cursor of 0 returns the whole log.
+func (s *Store) TicketEventsSince(cursor int64) ([]TicketEvent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT seq, ticket_id, kind, author, from_status, to_status, comment, detail, created_at
+		FROM ticket_events WHERE seq > ? ORDER BY seq ASC
+	`, cursor)
+	if err != nil {
+		return nil, err
+	}
+	return scanTicketEventRows(rows)
+}
+
+// UnreadTicketEvents returns, for an identity, every event it has not yet
+// consumed across the tickets it participates in — those currently assigned to it
+// plus any it has authored an event on — excluding events it authored itself.
+// Each event is compared against the identity's OWN per-(identity, ticket) cursor,
+// so a ticket the identity has never looked at is delivered from the start (the
+// brief and all pre-involvement context). Results are ordered by ticket then seq.
+//
+// This is the consume query: one statement folds the participant set, the
+// per-ticket cursors, and the self-author exclusion together, so a quiet or
+// closed ticket the identity has nothing new on costs only an indexed lookup.
+func (s *Store) UnreadTicketEvents(identity string) ([]TicketEvent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil || identity == "" {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT e.seq, e.ticket_id, e.kind, e.author, e.from_status, e.to_status, e.comment, e.detail, e.created_at
+		FROM ticket_events e
+		LEFT JOIN ticket_event_cursors c
+			ON c.identity = ? AND c.ticket_id = e.ticket_id
+		WHERE e.author != ?
+			AND e.seq > COALESCE(c.cursor, 0)
+			AND e.ticket_id IN (
+				SELECT id FROM tickets WHERE assignee = ?
+				UNION
+				SELECT DISTINCT ticket_id FROM ticket_events WHERE author = ?
+			)
+		ORDER BY e.ticket_id, e.seq ASC
+	`, identity, identity, identity, identity)
+	if err != nil {
+		return nil, err
+	}
+	return scanTicketEventRows(rows)
+}
+
+// InvolvedTicketIDs returns the ids of tickets an identity participates in: those
+// currently assigned to it, plus any it has authored an event on. This is the
+// uniform "which tickets do I care about" rule — the chief is just an identity
+// that authored the created event when it delegated, so it needs no special case.
+func (s *Store) InvolvedTicketIDs(identity string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil || identity == "" {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT id FROM tickets WHERE assignee = ?
+		UNION
+		SELECT DISTINCT ticket_id FROM ticket_events WHERE author = ?
+		ORDER BY 1 ASC
+	`, identity, identity)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // LatestTicketEventSeq returns the highest event seq, or 0 when the log is empty.
 func (s *Store) LatestTicketEventSeq() (int64, error) {
 	s.mu.RLock()
@@ -186,9 +267,11 @@ func (s *Store) LatestTicketEventSeq() (int64, error) {
 	return seq.Int64, nil
 }
 
-// GetObserverCursor returns an observer's cursor — the seq through which it has
-// consumed. A never-seen observer starts at 0 (everything is unread).
-func (s *Store) GetObserverCursor(observerID string) (int64, error) {
+// GetTicketCursor returns an identity's cursor on a single ticket — the seq
+// through which it has consumed that ticket's events. An identity that has never
+// looked at the ticket starts at 0 (everything on it is unread), which is what
+// delivers a freshly-assigned ticket's full history.
+func (s *Store) GetTicketCursor(identity, ticketID string) (int64, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -196,7 +279,7 @@ func (s *Store) GetObserverCursor(observerID string) (int64, error) {
 		return 0, nil
 	}
 	var cursor int64
-	err := s.db.QueryRow(`SELECT cursor FROM ticket_event_cursors WHERE observer_id = ?`, observerID).Scan(&cursor)
+	err := s.db.QueryRow(`SELECT cursor FROM ticket_event_cursors WHERE identity = ? AND ticket_id = ?`, identity, ticketID).Scan(&cursor)
 	if err == sql.ErrNoRows {
 		return 0, nil
 	}
@@ -206,8 +289,8 @@ func (s *Store) GetObserverCursor(observerID string) (int64, error) {
 	return cursor, nil
 }
 
-// SetObserverCursor advances (upserts) an observer's cursor.
-func (s *Store) SetObserverCursor(observerID string, cursor int64, now time.Time) error {
+// SetTicketCursor advances (upserts) an identity's cursor on a single ticket.
+func (s *Store) SetTicketCursor(identity, ticketID string, cursor int64, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -215,9 +298,9 @@ func (s *Store) SetObserverCursor(observerID string, cursor int64, now time.Time
 		return nil
 	}
 	_, err := s.db.Exec(`
-		INSERT INTO ticket_event_cursors (observer_id, cursor, updated_at)
-		VALUES (?, ?, ?)
-		ON CONFLICT(observer_id) DO UPDATE SET cursor = excluded.cursor, updated_at = excluded.updated_at
-	`, observerID, cursor, formatTicketTime(now))
+		INSERT INTO ticket_event_cursors (identity, ticket_id, cursor, updated_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(identity, ticket_id) DO UPDATE SET cursor = excluded.cursor, updated_at = excluded.updated_at
+	`, identity, ticketID, cursor, formatTicketTime(now))
 	return err
 }

--- a/internal/store/ticket_events.go
+++ b/internal/store/ticket_events.go
@@ -289,7 +289,11 @@ func (s *Store) GetTicketCursor(identity, ticketID string) (int64, error) {
 	return cursor, nil
 }
 
-// SetTicketCursor advances (upserts) an identity's cursor on a single ticket.
+// SetTicketCursor advances an identity's cursor on a single ticket. The write is
+// monotonic: it only ever moves the cursor FORWARD (MAX of the stored and proposed
+// seq). A cursor named "consumed through here" must never rewind, so a stale or
+// overlapping consume that writes a lower seq cannot resurrect already-consumed
+// events as unread or double-deliver them.
 func (s *Store) SetTicketCursor(identity, ticketID string, cursor int64, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -300,7 +304,9 @@ func (s *Store) SetTicketCursor(identity, ticketID string, cursor int64, now tim
 	_, err := s.db.Exec(`
 		INSERT INTO ticket_event_cursors (identity, ticket_id, cursor, updated_at)
 		VALUES (?, ?, ?, ?)
-		ON CONFLICT(identity, ticket_id) DO UPDATE SET cursor = excluded.cursor, updated_at = excluded.updated_at
+		ON CONFLICT(identity, ticket_id) DO UPDATE SET
+			cursor = MAX(cursor, excluded.cursor),
+			updated_at = excluded.updated_at
 	`, identity, ticketID, cursor, formatTicketTime(now))
 	return err
 }

--- a/internal/store/ticket_events.go
+++ b/internal/store/ticket_events.go
@@ -1,0 +1,223 @@
+package store
+
+import (
+	"database/sql"
+	"time"
+)
+
+// The ticket event log is the notification substrate for the work tracker (slice
+// 2 of docs/plans/2026-06-26-work-tracker.md). It re-homes the dispatch gateway's
+// settled mechanics: an append-only log with idempotent (deduped) events, a global
+// monotonic seq that doubles as the cursor space, and per-observer cursors that
+// express "unread". The decoupled notification handlers live in internal/ticketnotify;
+// this file is only the durable substrate.
+//
+// Events are a SUPERSET of the display activity thread (slice 1): activity holds
+// the two human-facing kinds (status_change, comment); the event log carries all
+// six domain events the chief observes. Mutators append events transactionally —
+// they emit, but know nothing about who listens.
+
+// TicketEventKind is a domain event on a ticket.
+type TicketEventKind string
+
+const (
+	// TicketEventCreated fires when a ticket is created.
+	TicketEventCreated TicketEventKind = "created"
+	// TicketEventStatusChanged fires when a ticket moves column (from -> to).
+	TicketEventStatusChanged TicketEventKind = "status_changed"
+	// TicketEventCommented fires on a freeform comment.
+	TicketEventCommented TicketEventKind = "commented"
+	// TicketEventAssigned fires when the assignee changes (Detail = new assignee).
+	TicketEventAssigned TicketEventKind = "assigned"
+	// TicketEventDescriptionEdited fires when the brief is edited.
+	TicketEventDescriptionEdited TicketEventKind = "description_edited"
+	// TicketEventAttachmentAdded fires when a file is attached (Detail = filename).
+	TicketEventAttachmentAdded TicketEventKind = "attachment_added"
+)
+
+// TicketEvent is one entry in the append-only event log. Seq is the global
+// monotonic id (the cursor space). The payload columns are kind-specific:
+// FromStatus/ToStatus for status changes, Comment for notes, Detail for the
+// kind's salient value (new assignee, filename).
+type TicketEvent struct {
+	Seq        int64
+	TicketID   string
+	Kind       TicketEventKind
+	Author     string
+	FromStatus TicketStatus
+	ToStatus   TicketStatus
+	Comment    string
+	Detail     string
+	CreatedAt  time.Time
+}
+
+// signature is the dedup key: two events with the same signature on the same
+// ticket back-to-back are the same logical event (a retry), so only the first is
+// appended.
+func (e TicketEvent) signature() string {
+	return string(e.Kind) + "\x00" + string(e.FromStatus) + "\x00" + string(e.ToStatus) +
+		"\x00" + e.Comment + "\x00" + e.Detail + "\x00" + e.Author
+}
+
+// AppendTicketEvent appends an event to the log, deduped against the ticket's
+// most recent event. It returns the event's seq and whether a new row was written
+// (false when deduped). Most callers append within a mutator's transaction via
+// appendTicketEventTx; this is the standalone entry point.
+func (s *Store) AppendTicketEvent(e TicketEvent, now time.Time) (int64, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return 0, false, nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, false, err
+	}
+	defer tx.Rollback()
+
+	seq, appended, err := appendTicketEventTx(tx, e, now)
+	if err != nil {
+		return 0, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, false, err
+	}
+	return seq, appended, nil
+}
+
+// appendTicketEventTx is the transactional core, shared by ticket mutators so the
+// event lands atomically with the mutation that produced it.
+func appendTicketEventTx(tx *sql.Tx, e TicketEvent, now time.Time) (int64, bool, error) {
+	var (
+		lastSeq                                    int64
+		lk, lfrom, lto, lcomment, ldetail, lauthor string
+	)
+	err := tx.QueryRow(`
+		SELECT seq, kind, from_status, to_status, comment, detail, author
+		FROM ticket_events WHERE ticket_id = ? ORDER BY seq DESC LIMIT 1
+	`, e.TicketID).Scan(&lastSeq, &lk, &lfrom, &lto, &lcomment, &ldetail, &lauthor)
+	switch err {
+	case nil:
+		prev := TicketEvent{
+			Kind:       TicketEventKind(lk),
+			FromStatus: TicketStatus(lfrom),
+			ToStatus:   TicketStatus(lto),
+			Comment:    lcomment,
+			Detail:     ldetail,
+			Author:     lauthor,
+		}
+		if prev.signature() == e.signature() {
+			return lastSeq, false, nil // idempotent: identical to the previous event
+		}
+	case sql.ErrNoRows:
+		// first event for this ticket
+	default:
+		return 0, false, err
+	}
+
+	res, err := tx.Exec(`
+		INSERT INTO ticket_events (ticket_id, kind, author, from_status, to_status, comment, detail, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, e.TicketID, string(e.Kind), e.Author, string(e.FromStatus), string(e.ToStatus), e.Comment, e.Detail, formatTicketTime(now))
+	if err != nil {
+		return 0, false, err
+	}
+	seq, err := res.LastInsertId()
+	if err != nil {
+		return 0, false, err
+	}
+	return seq, true, nil
+}
+
+// TicketEventsSince returns every event with seq greater than the given cursor,
+// in seq (chronological) order. A cursor of 0 returns the whole log.
+func (s *Store) TicketEventsSince(cursor int64) ([]TicketEvent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.Query(`
+		SELECT seq, ticket_id, kind, author, from_status, to_status, comment, detail, created_at
+		FROM ticket_events WHERE seq > ? ORDER BY seq ASC
+	`, cursor)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var events []TicketEvent
+	for rows.Next() {
+		var (
+			e         TicketEvent
+			kind      string
+			from, to  string
+			createdAt string
+		)
+		if err := rows.Scan(&e.Seq, &e.TicketID, &kind, &e.Author, &from, &to, &e.Comment, &e.Detail, &createdAt); err != nil {
+			return nil, err
+		}
+		e.Kind = TicketEventKind(kind)
+		e.FromStatus = TicketStatus(from)
+		e.ToStatus = TicketStatus(to)
+		e.CreatedAt = parseTicketTime(createdAt)
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}
+
+// LatestTicketEventSeq returns the highest event seq, or 0 when the log is empty.
+func (s *Store) LatestTicketEventSeq() (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return 0, nil
+	}
+	var seq sql.NullInt64
+	if err := s.db.QueryRow(`SELECT MAX(seq) FROM ticket_events`).Scan(&seq); err != nil {
+		return 0, err
+	}
+	if !seq.Valid {
+		return 0, nil
+	}
+	return seq.Int64, nil
+}
+
+// GetObserverCursor returns an observer's cursor — the seq through which it has
+// consumed. A never-seen observer starts at 0 (everything is unread).
+func (s *Store) GetObserverCursor(observerID string) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return 0, nil
+	}
+	var cursor int64
+	err := s.db.QueryRow(`SELECT cursor FROM ticket_event_cursors WHERE observer_id = ?`, observerID).Scan(&cursor)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return cursor, nil
+}
+
+// SetObserverCursor advances (upserts) an observer's cursor.
+func (s *Store) SetObserverCursor(observerID string, cursor int64, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO ticket_event_cursors (observer_id, cursor, updated_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(observer_id) DO UPDATE SET cursor = excluded.cursor, updated_at = excluded.updated_at
+	`, observerID, cursor, formatTicketTime(now))
+	return err
+}

--- a/internal/store/ticket_events_test.go
+++ b/internal/store/ticket_events_test.go
@@ -124,6 +124,36 @@ func TestTicketEventDedupSemantics(t *testing.T) {
 	}
 }
 
+// A cursor only ever moves forward. A stale or overlapping consume that writes a
+// lower seq must not rewind it — otherwise already-consumed events resurface as
+// unread (double-delivery). Writing 3 then a stale 2 must leave it at 3.
+func TestTicketCursorMonotonic(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	if err := s.SetTicketCursor("agent7", "tk", 3, eventBase); err != nil {
+		t.Fatalf("SetTicketCursor 3: %v", err)
+	}
+	// A stale writer tries to move it backwards.
+	if err := s.SetTicketCursor("agent7", "tk", 2, eventBase.Add(time.Minute)); err != nil {
+		t.Fatalf("SetTicketCursor 2: %v", err)
+	}
+	if got, _ := s.GetTicketCursor("agent7", "tk"); got != 3 {
+		t.Fatalf("cursor after stale write = %d, want 3 (no rewind)", got)
+	}
+	// A genuine forward write still advances.
+	if err := s.SetTicketCursor("agent7", "tk", 5, eventBase.Add(2*time.Minute)); err != nil {
+		t.Fatalf("SetTicketCursor 5: %v", err)
+	}
+	if got, _ := s.GetTicketCursor("agent7", "tk"); got != 5 {
+		t.Fatalf("cursor after forward write = %d, want 5", got)
+	}
+	// Cursors are scoped per (identity, ticket) — another identity is independent.
+	if got, _ := s.GetTicketCursor("agent9", "tk"); got != 0 {
+		t.Fatalf("unrelated identity cursor = %d, want 0", got)
+	}
+}
+
 // The event log and per-(identity, ticket) cursors survive a daemon restart.
 func TestTicketEventCursorPersistence(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "attn.db")

--- a/internal/store/ticket_events_test.go
+++ b/internal/store/ticket_events_test.go
@@ -124,7 +124,7 @@ func TestTicketEventDedupSemantics(t *testing.T) {
 	}
 }
 
-// The event log and observer cursors survive a daemon restart.
+// The event log and per-(identity, ticket) cursors survive a daemon restart.
 func TestTicketEventCursorPersistence(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "attn.db")
 	s, err := NewWithDB(dbPath)
@@ -141,8 +141,8 @@ func TestTicketEventCursorPersistence(t *testing.T) {
 	if err != nil || latest == 0 {
 		t.Fatalf("LatestTicketEventSeq = %d (err %v), want > 0", latest, err)
 	}
-	if err := s.SetObserverCursor("chief", latest, eventBase.Add(2*time.Minute)); err != nil {
-		t.Fatalf("SetObserverCursor: %v", err)
+	if err := s.SetTicketCursor("chief", "tk", latest, eventBase.Add(2*time.Minute)); err != nil {
+		t.Fatalf("SetTicketCursor: %v", err)
 	}
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -158,7 +158,7 @@ func TestTicketEventCursorPersistence(t *testing.T) {
 	if err != nil || len(events) != 2 {
 		t.Fatalf("events after reopen = %d (err %v), want 2", len(events), err)
 	}
-	cursor, err := reopened.GetObserverCursor("chief")
+	cursor, err := reopened.GetTicketCursor("chief", "tk")
 	if err != nil || cursor != latest {
 		t.Fatalf("cursor after reopen = %d (err %v), want %d", cursor, err, latest)
 	}

--- a/internal/store/ticket_events_test.go
+++ b/internal/store/ticket_events_test.go
@@ -1,0 +1,172 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+var eventBase = time.Date(2026, 6, 26, 9, 0, 0, 0, time.UTC)
+
+// kindsOf counts events per kind for a ticket.
+func kindsOf(t *testing.T, s *Store, ticketID string) map[TicketEventKind]int {
+	t.Helper()
+	events, err := s.TicketEventsSince(0)
+	if err != nil {
+		t.Fatalf("TicketEventsSince: %v", err)
+	}
+	counts := map[TicketEventKind]int{}
+	for _, e := range events {
+		if e.TicketID == ticketID {
+			counts[e.Kind]++
+		}
+	}
+	return counts
+}
+
+// Every mutator emits exactly one domain event, with the right kind / author /
+// detail. This pins emission for all six kinds — three of which the notification
+// harness never drives.
+func TestTicketEventEmissionAllKinds(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	tick := eventBase
+	next := func() time.Time { tick = tick.Add(time.Minute); return tick }
+
+	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, "chief", next()); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+	if _, err := s.SetTicketStatus("tk", TicketStatusWorking, "agent7", "", next()); err != nil {
+		t.Fatalf("SetTicketStatus: %v", err)
+	}
+	if _, err := s.AddTicketComment("tk", "agent7", "a note", next()); err != nil {
+		t.Fatalf("AddTicketComment: %v", err)
+	}
+	if err := s.AssignTicket("tk", "agent9", "chief", next()); err != nil {
+		t.Fatalf("AssignTicket: %v", err)
+	}
+	if err := s.EditTicketDescription("tk", "new brief", "chief", next()); err != nil {
+		t.Fatalf("EditTicketDescription: %v", err)
+	}
+	if _, err := s.AddTicketAttachment(TicketAttachment{TicketID: "tk", Filename: "out.txt"}, "agent9", next()); err != nil {
+		t.Fatalf("AddTicketAttachment: %v", err)
+	}
+
+	counts := kindsOf(t, s, "tk")
+	for _, k := range []TicketEventKind{
+		TicketEventCreated, TicketEventStatusChanged, TicketEventCommented,
+		TicketEventAssigned, TicketEventDescriptionEdited, TicketEventAttachmentAdded,
+	} {
+		if counts[k] != 1 {
+			t.Fatalf("event kind %q count = %d, want 1 (all: %+v)", k, counts[k], counts)
+		}
+	}
+
+	// Detail is set on the kinds that carry a salient value.
+	events, _ := s.TicketEventsSince(0)
+	byKind := map[TicketEventKind]TicketEvent{}
+	for _, e := range events {
+		byKind[e.Kind] = e
+	}
+	if byKind[TicketEventAssigned].Detail != "agent9" {
+		t.Fatalf("assigned Detail = %q, want agent9", byKind[TicketEventAssigned].Detail)
+	}
+	if byKind[TicketEventDescriptionEdited].Detail != "new brief" {
+		t.Fatalf("description_edited Detail = %q, want the new brief", byKind[TicketEventDescriptionEdited].Detail)
+	}
+	if byKind[TicketEventAttachmentAdded].Detail != "out.txt" {
+		t.Fatalf("attachment_added Detail = %q, want out.txt", byKind[TicketEventAttachmentAdded].Detail)
+	}
+}
+
+// Dedup is "vs the ticket's PREVIOUS event" only. A re-brief with distinct text is
+// kept (the slice-2 fix); an (A, B, A) sequence keeps all three; a true
+// back-to-back repeat is dropped.
+func TestTicketEventDedupSemantics(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	tick := eventBase
+	next := func() time.Time { tick = tick.Add(time.Minute); return tick }
+
+	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, "chief", next()); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+
+	// Distinct re-briefs are all kept (regression guard for the dedup-drops-rebrief bug).
+	for _, d := range []string{"brief one", "brief two", "brief three"} {
+		if err := s.EditTicketDescription("tk", d, "chief", next()); err != nil {
+			t.Fatalf("EditTicketDescription %q: %v", d, err)
+		}
+	}
+	if got := kindsOf(t, s, "tk")[TicketEventDescriptionEdited]; got != 3 {
+		t.Fatalf("description_edited events = %d, want 3 distinct re-briefs kept", got)
+	}
+
+	// (A, B, A) on comments — dedup is only vs the immediately-previous event, so
+	// the second A is NOT deduped.
+	for _, c := range []string{"A", "B", "A"} {
+		if _, err := s.AddTicketComment("tk", "agent7", c, next()); err != nil {
+			t.Fatalf("AddTicketComment %q: %v", c, err)
+		}
+	}
+	if got := kindsOf(t, s, "tk")[TicketEventCommented]; got != 3 {
+		t.Fatalf("comment events after A,B,A = %d, want 3", got)
+	}
+
+	// A true back-to-back repeat (another A right after A) IS deduped.
+	if _, err := s.AddTicketComment("tk", "agent7", "A", next()); err != nil {
+		t.Fatalf("AddTicketComment repeat: %v", err)
+	}
+	if got := kindsOf(t, s, "tk")[TicketEventCommented]; got != 3 {
+		t.Fatalf("comment events after repeat A = %d, want still 3 (deduped)", got)
+	}
+}
+
+// The event log and observer cursors survive a daemon restart.
+func TestTicketEventCursorPersistence(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB: %v", err)
+	}
+	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, "chief", eventBase); err != nil {
+		t.Fatalf("CreateTicket: %v", err)
+	}
+	if _, err := s.SetTicketStatus("tk", TicketStatusWorking, "agent7", "on it", eventBase.Add(time.Minute)); err != nil {
+		t.Fatalf("SetTicketStatus: %v", err)
+	}
+	latest, err := s.LatestTicketEventSeq()
+	if err != nil || latest == 0 {
+		t.Fatalf("LatestTicketEventSeq = %d (err %v), want > 0", latest, err)
+	}
+	if err := s.SetObserverCursor("chief", latest, eventBase.Add(2*time.Minute)); err != nil {
+		t.Fatalf("SetObserverCursor: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+
+	events, err := reopened.TicketEventsSince(0)
+	if err != nil || len(events) != 2 {
+		t.Fatalf("events after reopen = %d (err %v), want 2", len(events), err)
+	}
+	cursor, err := reopened.GetObserverCursor("chief")
+	if err != nil || cursor != latest {
+		t.Fatalf("cursor after reopen = %d (err %v), want %d", cursor, err, latest)
+	}
+	// AUTOINCREMENT seq keeps climbing after restart — no reuse.
+	if _, err := reopened.AddTicketComment("tk", "agent7", "more", eventBase.Add(3*time.Minute)); err != nil {
+		t.Fatalf("AddTicketComment after reopen: %v", err)
+	}
+	if next, _ := reopened.LatestTicketEventSeq(); next <= latest {
+		t.Fatalf("seq after reopen = %d, want > %d (monotonic)", next, latest)
+	}
+}

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -572,8 +572,9 @@ func (s *Store) ArchiveTicket(id string, now time.Time) error {
 }
 
 // SweepExpiredTickets hard-deletes terminal tickets whose closed_at is older than
-// now-ttl, cascading to their activity and attachments. Open tickets (a durable
-// backlog) are never swept. Returns the number of tickets removed. The caller
+// now-ttl, cascading to their activity, attachments, events, and event cursors.
+// Open tickets (a durable backlog) are never swept. Returns the number of tickets
+// removed. The caller
 // passes now and the TTL (production: time.Now() and 30 days); tests inject both.
 func (s *Store) SweepExpiredTickets(now time.Time, ttl time.Duration) (int, error) {
 	s.mu.Lock()
@@ -601,6 +602,9 @@ func (s *Store) SweepExpiredTickets(now time.Time, ttl time.Duration) (int, erro
 		return 0, err
 	}
 	if _, err := tx.Exec(`DELETE FROM ticket_events WHERE ticket_id IN (SELECT id FROM tickets WHERE `+expired+`)`, cutoff); err != nil {
+		return 0, err
+	}
+	if _, err := tx.Exec(`DELETE FROM ticket_event_cursors WHERE ticket_id IN (SELECT id FROM tickets WHERE `+expired+`)`, cutoff); err != nil {
 		return 0, err
 	}
 	res, err := tx.Exec(`DELETE FROM tickets WHERE `+expired, cutoff)

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -313,6 +313,36 @@ func (s *Store) ListTickets(filter TicketListFilter) ([]*Ticket, error) {
 	return tickets, rows.Err()
 }
 
+// ActiveTicketForSession returns the non-terminal ticket currently assigned to a
+// session — the delegated work it is running — or nil if none. The delegated
+// session's id is the ticket's assignee, so assignee == session is the session ->
+// ticket binding (used by the report path and crash detection). Activity and
+// attachments are not loaded.
+func (s *Store) ActiveTicketForSession(sessionID string) (*Ticket, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil || sessionID == "" {
+		return nil, nil
+	}
+	rows, err := s.db.Query(ticketSelect+` WHERE assignee = ? ORDER BY created_at DESC, id DESC`, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		ticket, err := scanTicket(rows)
+		if err != nil {
+			return nil, err
+		}
+		if !ticket.Status.IsTerminal() {
+			return ticket, nil
+		}
+	}
+	return nil, rows.Err()
+}
+
 // SetTicketStatus moves a ticket to a new column and records the change in the
 // activity thread (from -> to, with an optional comment). Transitions are
 // permissive. Entering a terminal status stamps closed_at; leaving one clears it

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -443,12 +443,16 @@ func (s *Store) AddTicketComment(id, author, comment string, now time.Time) (*Ti
 }
 
 // EditTicketDescription replaces the ticket's brief, bumps updated_at, and emits a
-// description_edited event authored by author.
+// description_edited event authored by author. Detail carries the new brief so the
+// event is self-describing AND so the dedup signature distinguishes one re-brief
+// from another — without it, two consecutive edits would look identical and the
+// second (a real re-brief / steer) would be silently deduped away.
 func (s *Store) EditTicketDescription(id, description, author string, now time.Time) error {
 	return s.updateTicketFieldWithEvent(id, "description", description, TicketEvent{
 		TicketID: id,
 		Kind:     TicketEventDescriptionEdited,
 		Author:   author,
+		Detail:   description,
 	}, now)
 }
 

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -166,9 +166,10 @@ func ValidateTicketID(id string) error {
 
 // CreateTicket inserts a new ticket. The id is an agent-chosen memorable slug; on
 // collision it fails with ErrTicketIDTaken and actionable guidance. An empty
-// status defaults to Todo. The supplied now stamps created_at/updated_at (and
-// closed_at, in the unusual case of creating directly into a terminal status).
-func (s *Store) CreateTicket(t Ticket, now time.Time) (*Ticket, error) {
+// status defaults to Todo. author records who created it (for the emitted event).
+// The supplied now stamps created_at/updated_at (and closed_at, in the unusual
+// case of creating directly into a terminal status).
+func (s *Store) CreateTicket(t Ticket, author string, now time.Time) (*Ticket, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -227,6 +228,14 @@ func (s *Store) CreateTicket(t Ticket, now time.Time) (*Ticket, error) {
 		t.ProjectID, formatTicketTime(now), formatTicketTime(now),
 		formatTicketTimePtr(t.ClosedAt), formatTicketTimePtr(t.ArchivedAt),
 	); err != nil {
+		return nil, err
+	}
+	if _, _, err := appendTicketEventTx(tx, TicketEvent{
+		TicketID: t.ID,
+		Kind:     TicketEventCreated,
+		Author:   author,
+		ToStatus: t.Status,
+	}, now); err != nil {
 		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -361,6 +370,16 @@ func (s *Store) SetTicketStatus(id string, to TicketStatus, author, comment stri
 	`, id, string(TicketActivityStatusChange), author, string(from), string(to), comment, formatTicketTime(now)); err != nil {
 		return nil, err
 	}
+	if _, _, err := appendTicketEventTx(tx, TicketEvent{
+		TicketID:   id,
+		Kind:       TicketEventStatusChanged,
+		Author:     author,
+		FromStatus: from,
+		ToStatus:   to,
+		Comment:    comment,
+	}, now); err != nil {
+		return nil, err
+	}
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
@@ -402,6 +421,14 @@ func (s *Store) AddTicketComment(id, author, comment string, now time.Time) (*Ti
 	if err != nil {
 		return nil, err
 	}
+	if _, _, err := appendTicketEventTx(tx, TicketEvent{
+		TicketID: id,
+		Kind:     TicketEventCommented,
+		Author:   author,
+		Comment:  comment,
+	}, now); err != nil {
+		return nil, err
+	}
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
@@ -415,14 +442,25 @@ func (s *Store) AddTicketComment(id, author, comment string, now time.Time) (*Ti
 	}, nil
 }
 
-// EditTicketDescription replaces the ticket's brief and bumps updated_at.
-func (s *Store) EditTicketDescription(id, description string, now time.Time) error {
-	return s.updateTicketField(id, "description", description, now)
+// EditTicketDescription replaces the ticket's brief, bumps updated_at, and emits a
+// description_edited event authored by author.
+func (s *Store) EditTicketDescription(id, description, author string, now time.Time) error {
+	return s.updateTicketFieldWithEvent(id, "description", description, TicketEvent{
+		TicketID: id,
+		Kind:     TicketEventDescriptionEdited,
+		Author:   author,
+	}, now)
 }
 
-// AssignTicket sets (or clears, with "") the assignee and bumps updated_at.
-func (s *Store) AssignTicket(id, assignee string, now time.Time) error {
-	return s.updateTicketField(id, "assignee", assignee, now)
+// AssignTicket sets (or clears, with "") the assignee, bumps updated_at, and emits
+// an assigned event (Detail = the new assignee) authored by author.
+func (s *Store) AssignTicket(id, assignee, author string, now time.Time) error {
+	return s.updateTicketFieldWithEvent(id, "assignee", assignee, TicketEvent{
+		TicketID: id,
+		Kind:     TicketEventAssigned,
+		Author:   author,
+		Detail:   assignee,
+	}, now)
 }
 
 // SetTicketSession records the last session's working dir and agent id, which the
@@ -443,9 +481,10 @@ func (s *Store) SetTicketSession(id, cwd, lastAgentID string, now time.Time) err
 	return ticketUpdateResult(res, id)
 }
 
-// AddTicketAttachment records a handover file on the ticket and bumps updated_at.
-// Returns the stored attachment (with its assigned id).
-func (s *Store) AddTicketAttachment(att TicketAttachment, now time.Time) (*TicketAttachment, error) {
+// AddTicketAttachment records a handover file on the ticket, bumps updated_at, and
+// emits an attachment_added event (Detail = filename) authored by author. Returns
+// the stored attachment (with its assigned id).
+func (s *Store) AddTicketAttachment(att TicketAttachment, author string, now time.Time) (*TicketAttachment, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -475,6 +514,14 @@ func (s *Store) AddTicketAttachment(att TicketAttachment, now time.Time) (*Ticke
 	}
 	attachmentID, err := res.LastInsertId()
 	if err != nil {
+		return nil, err
+	}
+	if _, _, err := appendTicketEventTx(tx, TicketEvent{
+		TicketID: att.TicketID,
+		Kind:     TicketEventAttachmentAdded,
+		Author:   author,
+		Detail:   att.Filename,
+	}, now); err != nil {
 		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -549,6 +596,9 @@ func (s *Store) SweepExpiredTickets(now time.Time, ttl time.Duration) (int, erro
 	if _, err := tx.Exec(`DELETE FROM ticket_attachments WHERE ticket_id IN (SELECT id FROM tickets WHERE `+expired+`)`, cutoff); err != nil {
 		return 0, err
 	}
+	if _, err := tx.Exec(`DELETE FROM ticket_events WHERE ticket_id IN (SELECT id FROM tickets WHERE `+expired+`)`, cutoff); err != nil {
+		return 0, err
+	}
 	res, err := tx.Exec(`DELETE FROM tickets WHERE `+expired, cutoff)
 	if err != nil {
 		return 0, err
@@ -570,23 +620,35 @@ const ticketSelect = `
 		project_id, created_at, updated_at, closed_at, archived_at
 	FROM tickets`
 
-// updateTicketField sets a single text column plus updated_at. column is a
-// trusted internal literal, never caller input.
-func (s *Store) updateTicketField(id, column, value string, now time.Time) error {
+// updateTicketFieldWithEvent sets a single text column plus updated_at and emits
+// evt, atomically. column is a trusted internal literal, never caller input.
+func (s *Store) updateTicketFieldWithEvent(id, column, value string, evt TicketEvent, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.db == nil {
 		return nil
 	}
-	res, err := s.db.Exec(
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.Exec(
 		`UPDATE tickets SET `+column+` = ?, updated_at = ? WHERE id = ?`,
 		value, formatTicketTime(now), id,
 	)
 	if err != nil {
 		return err
 	}
-	return ticketUpdateResult(res, id)
+	if err := ticketUpdateResult(res, id); err != nil {
+		return err
+	}
+	if _, _, err := appendTicketEventTx(tx, evt, now); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // touchTicketTx bumps updated_at within a transaction, returning ErrTicketNotFound

--- a/internal/store/tickets_test.go
+++ b/internal/store/tickets_test.go
@@ -31,7 +31,7 @@ func TestTicketCRUDRoundTrip(t *testing.T) {
 		Assignee:    "agent7",
 		Cwd:         "/tmp/project",
 		LastAgentID: "agent7",
-	}, ticketBase)
+	}, "chief", ticketBase)
 	if err != nil {
 		t.Fatalf("CreateTicket: %v", err)
 	}
@@ -70,13 +70,13 @@ func TestTicketValidation(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })
 
-	if _, err := s.CreateTicket(Ticket{ID: "Has Spaces", Title: "x"}, ticketBase); !errors.Is(err, ErrInvalidTicketID) {
+	if _, err := s.CreateTicket(Ticket{ID: "Has Spaces", Title: "x"}, "you", ticketBase); !errors.Is(err, ErrInvalidTicketID) {
 		t.Fatalf("invalid id err = %v, want ErrInvalidTicketID", err)
 	}
-	if _, err := s.CreateTicket(Ticket{ID: "no-title"}, ticketBase); !errors.Is(err, ErrTicketTitleRequired) {
+	if _, err := s.CreateTicket(Ticket{ID: "no-title"}, "you", ticketBase); !errors.Is(err, ErrTicketTitleRequired) {
 		t.Fatalf("missing title err = %v, want ErrTicketTitleRequired", err)
 	}
-	if _, err := s.CreateTicket(Ticket{ID: "bad-status", Title: "x", Status: "weird"}, ticketBase); !errors.Is(err, ErrInvalidTicketStatus) {
+	if _, err := s.CreateTicket(Ticket{ID: "bad-status", Title: "x", Status: "weird"}, "you", ticketBase); !errors.Is(err, ErrInvalidTicketStatus) {
 		t.Fatalf("bad status err = %v, want ErrInvalidTicketStatus", err)
 	}
 }
@@ -85,10 +85,10 @@ func TestTicketIDCollision(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })
 
-	if _, err := s.CreateTicket(Ticket{ID: "dup", Title: "first"}, ticketBase); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "dup", Title: "first"}, "you", ticketBase); err != nil {
 		t.Fatalf("first CreateTicket: %v", err)
 	}
-	_, err := s.CreateTicket(Ticket{ID: "dup", Title: "second"}, ticketBase)
+	_, err := s.CreateTicket(Ticket{ID: "dup", Title: "second"}, "you", ticketBase)
 	if !errors.Is(err, ErrTicketIDTaken) {
 		t.Fatalf("collision err = %v, want ErrTicketIDTaken", err)
 	}
@@ -107,7 +107,7 @@ func TestTicketStatusTransitions(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })
 
-	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, ticketBase); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, "you", ticketBase); err != nil {
 		t.Fatalf("CreateTicket: %v", err)
 	}
 
@@ -171,7 +171,7 @@ func TestTicketCommentsAndEdits(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })
 
-	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, ticketBase); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, "you", ticketBase); err != nil {
 		t.Fatalf("CreateTicket: %v", err)
 	}
 
@@ -183,10 +183,10 @@ func TestTicketCommentsAndEdits(t *testing.T) {
 	if _, err := s.AddTicketComment("tk", "agent7", "almost there", t2); err != nil {
 		t.Fatalf("AddTicketComment: %v", err)
 	}
-	if err := s.EditTicketDescription("tk", "Revised brief.", t2); err != nil {
+	if err := s.EditTicketDescription("tk", "Revised brief.", "you", t2); err != nil {
 		t.Fatalf("EditTicketDescription: %v", err)
 	}
-	if err := s.AssignTicket("tk", "agent9", t2); err != nil {
+	if err := s.AssignTicket("tk", "agent9", "you", t2); err != nil {
 		t.Fatalf("AssignTicket: %v", err)
 	}
 	if err := s.SetTicketSession("tk", "/repo", "agent9", t2); err != nil {
@@ -214,7 +214,7 @@ func TestTicketCommentsAndEdits(t *testing.T) {
 	}
 
 	// Edits / comments on a missing ticket fail rather than orphan.
-	if err := s.EditTicketDescription("ghost", "x", t2); !errors.Is(err, ErrTicketNotFound) {
+	if err := s.EditTicketDescription("ghost", "x", "you", t2); !errors.Is(err, ErrTicketNotFound) {
 		t.Fatalf("edit missing = %v, want ErrTicketNotFound", err)
 	}
 	if _, err := s.AddTicketComment("ghost", "", "x", t2); !errors.Is(err, ErrTicketNotFound) {
@@ -226,7 +226,7 @@ func TestTicketAttachments(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })
 
-	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, ticketBase); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "tk", Title: "work"}, "you", ticketBase); err != nil {
 		t.Fatalf("CreateTicket: %v", err)
 	}
 	t1 := ticketBase.Add(1 * time.Minute)
@@ -235,7 +235,7 @@ func TestTicketAttachments(t *testing.T) {
 		Filename: "results.json",
 		Path:     "/handover/results.json",
 		Note:     "benchmark output",
-	}, t1)
+	}, "agent7", t1)
 	if err != nil {
 		t.Fatalf("AddTicketAttachment: %v", err)
 	}
@@ -258,10 +258,10 @@ func TestTicketAttachments(t *testing.T) {
 	}
 
 	// A filename is required; a missing ticket is rejected.
-	if _, err := s.AddTicketAttachment(TicketAttachment{TicketID: "tk"}, t1); err == nil {
+	if _, err := s.AddTicketAttachment(TicketAttachment{TicketID: "tk"}, "agent7", t1); err == nil {
 		t.Fatal("AddTicketAttachment with no filename: want error")
 	}
-	if _, err := s.AddTicketAttachment(TicketAttachment{TicketID: "ghost", Filename: "x"}, t1); !errors.Is(err, ErrTicketNotFound) {
+	if _, err := s.AddTicketAttachment(TicketAttachment{TicketID: "ghost", Filename: "x"}, "agent7", t1); !errors.Is(err, ErrTicketNotFound) {
 		t.Fatalf("attach to missing = %v, want ErrTicketNotFound", err)
 	}
 }
@@ -271,13 +271,13 @@ func TestTicketListAndArchive(t *testing.T) {
 	t.Cleanup(func() { _ = s.Close() })
 
 	// Three tickets across columns.
-	if _, err := s.CreateTicket(Ticket{ID: "backlog", Title: "later"}, ticketBase); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "backlog", Title: "later"}, "you", ticketBase); err != nil {
 		t.Fatalf("create backlog: %v", err)
 	}
-	if _, err := s.CreateTicket(Ticket{ID: "active", Title: "now", Status: TicketStatusWorking}, ticketBase.Add(time.Minute)); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "active", Title: "now", Status: TicketStatusWorking}, "you", ticketBase.Add(time.Minute)); err != nil {
 		t.Fatalf("create active: %v", err)
 	}
-	if _, err := s.CreateTicket(Ticket{ID: "shipped", Title: "old", Status: TicketStatusDone}, ticketBase.Add(2*time.Minute)); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "shipped", Title: "old", Status: TicketStatusDone}, "you", ticketBase.Add(2*time.Minute)); err != nil {
 		t.Fatalf("create shipped: %v", err)
 	}
 
@@ -377,22 +377,22 @@ func TestTicketTTLSweep(t *testing.T) {
 	now := ticketBase
 
 	// An open backlog ticket — never swept.
-	if _, err := s.CreateTicket(Ticket{ID: "open", Title: "live"}, now.Add(-90*24*time.Hour)); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "open", Title: "live"}, "you", now.Add(-90*24*time.Hour)); err != nil {
 		t.Fatalf("create open: %v", err)
 	}
 	// A recently-closed ticket — within TTL, kept.
-	if _, err := s.CreateTicket(Ticket{ID: "recent", Title: "recent", Status: TicketStatusDone}, now.Add(-5*24*time.Hour)); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "recent", Title: "recent", Status: TicketStatusDone}, "you", now.Add(-5*24*time.Hour)); err != nil {
 		t.Fatalf("create recent: %v", err)
 	}
 	// A long-closed ticket with activity + an attachment — swept, cascading.
-	if _, err := s.CreateTicket(Ticket{ID: "stale", Title: "stale"}, now.Add(-100*24*time.Hour)); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "stale", Title: "stale"}, "you", now.Add(-100*24*time.Hour)); err != nil {
 		t.Fatalf("create stale: %v", err)
 	}
 	closedAt := now.Add(-60 * 24 * time.Hour)
 	if _, err := s.SetTicketStatus("stale", TicketStatusDone, "agent7", "done long ago", closedAt); err != nil {
 		t.Fatalf("close stale: %v", err)
 	}
-	if _, err := s.AddTicketAttachment(TicketAttachment{TicketID: "stale", Filename: "old.txt"}, closedAt); err != nil {
+	if _, err := s.AddTicketAttachment(TicketAttachment{TicketID: "stale", Filename: "old.txt"}, "agent7", closedAt); err != nil {
 		t.Fatalf("attach stale: %v", err)
 	}
 
@@ -415,15 +415,18 @@ func TestTicketTTLSweep(t *testing.T) {
 	}
 
 	// Cascade: the swept ticket's activity + attachment rows are gone too.
-	var orphanActivity, orphanAttachments int
+	var orphanActivity, orphanAttachments, orphanEvents int
 	if err := s.db.QueryRow(`SELECT COUNT(*) FROM ticket_activity WHERE ticket_id = 'stale'`).Scan(&orphanActivity); err != nil {
 		t.Fatalf("count orphan activity: %v", err)
 	}
 	if err := s.db.QueryRow(`SELECT COUNT(*) FROM ticket_attachments WHERE ticket_id = 'stale'`).Scan(&orphanAttachments); err != nil {
 		t.Fatalf("count orphan attachments: %v", err)
 	}
-	if orphanActivity != 0 || orphanAttachments != 0 {
-		t.Fatalf("cascade leak: %d activity, %d attachments left", orphanActivity, orphanAttachments)
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM ticket_events WHERE ticket_id = 'stale'`).Scan(&orphanEvents); err != nil {
+		t.Fatalf("count orphan events: %v", err)
+	}
+	if orphanActivity != 0 || orphanAttachments != 0 || orphanEvents != 0 {
+		t.Fatalf("cascade leak: %d activity, %d attachments, %d events left", orphanActivity, orphanAttachments, orphanEvents)
 	}
 }
 
@@ -433,7 +436,7 @@ func TestTicketPersistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewWithDB: %v", err)
 	}
-	if _, err := s.CreateTicket(Ticket{ID: "persist", Title: "survives restart"}, ticketBase); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "persist", Title: "survives restart"}, "you", ticketBase); err != nil {
 		t.Fatalf("CreateTicket: %v", err)
 	}
 	if _, err := s.SetTicketStatus("persist", TicketStatusInReview, "agent7", "ready", ticketBase.Add(time.Minute)); err != nil {

--- a/internal/store/tickets_test.go
+++ b/internal/store/tickets_test.go
@@ -333,7 +333,7 @@ func TestArchivedTicketReopenedBecomesVisible(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })
 
-	if _, err := s.CreateTicket(Ticket{ID: "zombie", Title: "shipped", Status: TicketStatusDone}, ticketBase); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "zombie", Title: "shipped", Status: TicketStatusDone}, "you", ticketBase); err != nil {
 		t.Fatalf("create: %v", err)
 	}
 	if err := s.ArchiveTicket("zombie", ticketBase.Add(time.Minute)); err != nil {

--- a/internal/ticketnotify/harness_test.go
+++ b/internal/ticketnotify/harness_test.go
@@ -1,0 +1,301 @@
+package ticketnotify
+
+import (
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/store"
+)
+
+// The simulation harness drives the real store as the event producer and exercises
+// both notification handlers (watch-consume + nudge) without any live session or
+// real Monitor. It proves the slice-2 mechanics end to end: emit -> consume ->
+// unread cursor, dedup, bundle-by-ticket, the nudge path, and self-authored
+// exclusion.
+
+// harness wires a real store to a recording Nudger. It also satisfies Nudger, so
+// the nudge path is observable. Note the Nudger contract takes only an observer id
+// — there is structurally no channel for event content, which is the
+// never-stream-content-to-a-PTY rule, enforced by shape.
+type harness struct {
+	t      *testing.T
+	s      *store.Store
+	now    time.Time
+	nudges []string
+}
+
+func newHarness(t *testing.T) *harness {
+	s := store.New()
+	t.Cleanup(func() { _ = s.Close() })
+	return &harness{t: t, s: s, now: time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)}
+}
+
+// tick advances and returns the harness clock, so each emit has a distinct stamp.
+func (h *harness) tick() time.Time {
+	h.now = h.now.Add(time.Minute)
+	return h.now
+}
+
+func (h *harness) Nudge(observerID string) error {
+	h.nudges = append(h.nudges, observerID)
+	return nil
+}
+
+func hasComment(events []store.TicketEvent, comment string) bool {
+	for _, e := range events {
+		if e.Comment == comment {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *harness) create(id, assignee, author string) {
+	h.t.Helper()
+	if _, err := h.s.CreateTicket(store.Ticket{ID: id, Title: id, Assignee: assignee}, author, h.tick()); err != nil {
+		h.t.Fatalf("create %s: %v", id, err)
+	}
+}
+
+func (h *harness) status(id string, to store.TicketStatus, author, comment string) {
+	h.t.Helper()
+	if _, err := h.s.SetTicketStatus(id, to, author, comment, h.tick()); err != nil {
+		h.t.Fatalf("status %s: %v", id, err)
+	}
+}
+
+func (h *harness) comment(id, author, comment string) {
+	h.t.Helper()
+	if _, err := h.s.AddTicketComment(id, author, comment, h.tick()); err != nil {
+		h.t.Fatalf("comment %s: %v", id, err)
+	}
+}
+
+func TestHarnessEmitConsumeCursor(t *testing.T) {
+	h := newHarness(t)
+	chief := ChiefObserver()
+
+	// Chief delegates a ticket; the agent picks it up and reports.
+	h.create("alpha", "agent7", ObserverChief)
+	h.status("alpha", store.TicketStatusWorking, "agent7", "on it")
+
+	// Chief consumes: it sees the agent's status move, but NOT its own created event.
+	bundles, err := Consume(h.s, chief, h.tick())
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if len(bundles) != 1 || bundles[0].TicketID != "alpha" {
+		t.Fatalf("bundles = %+v, want one for alpha", bundles)
+	}
+	if len(bundles[0].Events) != 1 || bundles[0].Events[0].Kind != store.TicketEventStatusChanged {
+		t.Fatalf("events = %+v, want one status_changed", bundles[0].Events)
+	}
+	if a := bundles[0].Events[0].Author; a == ObserverChief {
+		t.Fatalf("chief consumed its own event (author=%s)", a)
+	}
+
+	// The cursor advanced: a second consume is empty.
+	if n, err := Unread(h.s, chief); err != nil || n != 0 {
+		t.Fatalf("unread after consume = %d (err %v), want 0", n, err)
+	}
+	again, err := Consume(h.s, chief, h.tick())
+	if err != nil || len(again) != 0 {
+		t.Fatalf("second Consume = %+v (err %v), want empty", again, err)
+	}
+
+	// A fresh event becomes unread; the next consume returns only that one.
+	h.status("alpha", store.TicketStatusInReview, "agent7", "ready for review")
+	if n, _ := Unread(h.s, chief); n != 1 {
+		t.Fatalf("unread after new event = %d, want 1", n)
+	}
+	final, _ := Consume(h.s, chief, h.tick())
+	if len(final) != 1 || final[0].Events[0].ToStatus != store.TicketStatusInReview {
+		t.Fatalf("final consume = %+v, want one in_review", final)
+	}
+}
+
+func TestHarnessBundleByTicket(t *testing.T) {
+	h := newHarness(t)
+	chief := ChiefObserver()
+
+	h.create("alpha", "agent7", ObserverChief)
+	h.create("beta", "agent9", ObserverChief)
+
+	// Interleave events across the two tickets; consume should group by ticket.
+	h.status("alpha", store.TicketStatusWorking, "agent7", "")
+	h.status("beta", store.TicketStatusWorking, "agent9", "")
+	h.comment("alpha", "agent7", "halfway")
+
+	bundles, err := Consume(h.s, chief, h.tick())
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if len(bundles) != 2 {
+		t.Fatalf("bundles = %d, want 2 (one per ticket)", len(bundles))
+	}
+	// First-seen ticket order: alpha's status moved first.
+	if bundles[0].TicketID != "alpha" || bundles[1].TicketID != "beta" {
+		t.Fatalf("bundle order = %s,%s, want alpha,beta", bundles[0].TicketID, bundles[1].TicketID)
+	}
+	if len(bundles[0].Events) != 2 { // status + comment, grouped
+		t.Fatalf("alpha events = %d, want 2", len(bundles[0].Events))
+	}
+	if len(bundles[1].Events) != 1 {
+		t.Fatalf("beta events = %d, want 1", len(bundles[1].Events))
+	}
+}
+
+func TestHarnessDedup(t *testing.T) {
+	h := newHarness(t)
+	chief := ChiefObserver()
+
+	h.create("alpha", "agent7", ObserverChief)
+	// The same comment twice in a row is one logical event (a retry) — deduped.
+	h.comment("alpha", "agent7", "ping")
+	h.comment("alpha", "agent7", "ping")
+
+	events, err := h.s.TicketEventsSince(0)
+	if err != nil {
+		t.Fatalf("TicketEventsSince: %v", err)
+	}
+	commentEvents := 0
+	for _, e := range events {
+		if e.Kind == store.TicketEventCommented {
+			commentEvents++
+		}
+	}
+	if commentEvents != 1 {
+		t.Fatalf("comment events = %d, want 1 (deduped)", commentEvents)
+	}
+
+	// Idempotent at the append boundary too: a re-append returns appended=false.
+	if _, appended, err := h.s.AppendTicketEvent(store.TicketEvent{
+		TicketID: "alpha", Kind: store.TicketEventCommented, Author: "agent7", Comment: "ping",
+	}, h.tick()); err != nil || appended {
+		t.Fatalf("re-append appended=%v (err %v), want false", appended, err)
+	}
+
+	// The chief still sees a single comment.
+	bundles, _ := Consume(h.s, chief, h.tick())
+	got := 0
+	for _, b := range bundles {
+		for _, e := range b.Events {
+			if e.Kind == store.TicketEventCommented {
+				got++
+			}
+		}
+	}
+	if got != 1 {
+		t.Fatalf("chief saw %d comments, want 1", got)
+	}
+}
+
+func TestHarnessNudgePath(t *testing.T) {
+	h := newHarness(t)
+
+	// A codex agent can't self-monitor; a Claude agent can.
+	codex := AgentObserver("codexbot", "codex")
+	claude := AgentObserver("agent7", "claude")
+	if codex.HasSelfMonitor {
+		t.Fatal("codex should not self-monitor")
+	}
+	if !claude.HasSelfMonitor {
+		t.Fatal("claude should self-monitor")
+	}
+
+	h.create("alpha", "codexbot", ObserverChief)
+	h.create("beta", "agent7", ObserverChief)
+
+	// The chief steers each agent (reverse channel).
+	h.comment("alpha", ObserverChief, "please rebase")
+	h.comment("beta", ObserverChief, "tweak the title")
+
+	// Busy codex: deferred, no nudge yet.
+	d, err := Notify(h.s, codex, false, h, h.tick())
+	if err != nil || d != DeliveryDeferred {
+		t.Fatalf("busy codex delivery = %v (err %v), want Deferred", d, err)
+	}
+	if len(h.nudges) != 0 {
+		t.Fatalf("nudges = %v, want none while busy", h.nudges)
+	}
+
+	// Idle codex: nudged (a fixed trigger carrying only the observer id).
+	d, err = Notify(h.s, codex, true, h, h.tick())
+	if err != nil || d != DeliveryNudge {
+		t.Fatalf("idle codex delivery = %v (err %v), want Nudge", d, err)
+	}
+	if len(h.nudges) != 1 || h.nudges[0] != "codexbot" {
+		t.Fatalf("nudges = %v, want [codexbot]", h.nudges)
+	}
+
+	// Claude agent: its own watch consumes; never nudged.
+	d, err = Notify(h.s, claude, true, h, h.tick())
+	if err != nil || d != DeliveryWatch {
+		t.Fatalf("claude delivery = %v (err %v), want Watch", d, err)
+	}
+	if len(h.nudges) != 1 {
+		t.Fatalf("nudges = %v, claude must not be nudged", h.nudges)
+	}
+
+	// After the nudge, the codex agent consumes its own queue and sees the steer.
+	// (It also sees the chief-authored "created" event — the "assigned to you"
+	// signal — but never beta, which belongs to another agent.)
+	bundles, _ := Consume(h.s, codex, h.tick())
+	if len(bundles) != 1 || bundles[0].TicketID != "alpha" {
+		t.Fatalf("codex consume = %+v, want only alpha", bundles)
+	}
+	if !hasComment(bundles[0].Events, "please rebase") {
+		t.Fatalf("codex did not see the rebase steer: %+v", bundles[0].Events)
+	}
+	// Nothing left unread once consumed; a re-notify is quiet.
+	if d, _ := Notify(h.s, codex, true, h, h.tick()); d != DeliveryNone {
+		t.Fatalf("re-notify after consume = %v, want None", d)
+	}
+}
+
+func TestHarnessAgentScopeAndSelfAuthored(t *testing.T) {
+	h := newHarness(t)
+	chief := ChiefObserver()
+	agent7 := AgentObserver("agent7", "claude")
+
+	h.create("alpha", "agent7", ObserverChief) // assigned to agent7
+	h.create("beta", "agent9", ObserverChief)  // assigned to someone else
+
+	// agent7 acts on its own ticket; the chief comments on it; an event lands on beta.
+	h.status("alpha", store.TicketStatusWorking, "agent7", "starting")
+	h.comment("alpha", ObserverChief, "one note")
+	h.status("beta", store.TicketStatusWorking, "agent9", "starting")
+
+	// agent7 observes only alpha, and not the event it authored itself.
+	bundles, err := Consume(h.s, agent7, h.tick())
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if len(bundles) != 1 || bundles[0].TicketID != "alpha" {
+		t.Fatalf("agent7 bundles = %+v, want only alpha (never beta)", bundles)
+	}
+	for _, e := range bundles[0].Events {
+		if e.Author == "agent7" {
+			t.Fatalf("agent7 saw its own event: %+v", e)
+		}
+	}
+	// It sees the chief's steer; it never sees its own "starting" status move.
+	if !hasComment(bundles[0].Events, "one note") {
+		t.Fatalf("agent7 missing the chief's note: %+v", bundles[0].Events)
+	}
+
+	// The chief, by contrast, observes every ticket's events (minus its own note).
+	chiefBundles, _ := Consume(h.s, chief, h.tick())
+	tickets := map[string]bool{}
+	for _, b := range chiefBundles {
+		tickets[b.TicketID] = true
+		for _, e := range b.Events {
+			if e.Author == ObserverChief {
+				t.Fatalf("chief saw its own event: %+v", e)
+			}
+		}
+	}
+	if !tickets["alpha"] || !tickets["beta"] {
+		t.Fatalf("chief tickets = %v, want both alpha and beta", tickets)
+	}
+}

--- a/internal/ticketnotify/harness_test.go
+++ b/internal/ticketnotify/harness_test.go
@@ -284,7 +284,9 @@ func TestHarnessAgentScopeAndSelfAuthored(t *testing.T) {
 		t.Fatalf("agent7 missing the chief's note: %+v", bundles[0].Events)
 	}
 
-	// The chief, by contrast, observes every ticket's events (minus its own note).
+	// The chief, having delegated both, observes events on both (minus its own note)
+	// — not via a special "sees everything" scope, but because it authored the
+	// created event on each.
 	chiefBundles, _ := Consume(h.s, chief, h.tick())
 	tickets := map[string]bool{}
 	for _, b := range chiefBundles {
@@ -297,5 +299,90 @@ func TestHarnessAgentScopeAndSelfAuthored(t *testing.T) {
 	}
 	if !tickets["alpha"] || !tickets["beta"] {
 		t.Fatalf("chief tickets = %v, want both alpha and beta", tickets)
+	}
+}
+
+// Per-ticket cursors fix the lost-briefing bug: an agent that already advanced its
+// bookmark on OTHER tickets still receives a ticket's full pre-assignment history
+// when it is assigned that ticket later. With one global cursor this context was
+// silently skipped.
+func TestHarnessLateAssignmentDeliversContext(t *testing.T) {
+	h := newHarness(t)
+	agent7 := AgentObserver("agent7", "claude")
+
+	// agent7 has prior work it already consumed — its bookmark on "early" is advanced.
+	h.create("early", "agent7", ObserverChief)
+	h.status("early", store.TicketStatusWorking, "agent7", "on early")
+	if _, err := Consume(h.s, agent7, h.tick()); err != nil {
+		t.Fatalf("consume early: %v", err)
+	}
+
+	// Meanwhile the chief opens a ticket agent7 is NOT yet on, and briefs it.
+	h.create("late", "", ObserverChief) // unassigned at first
+	h.comment("late", ObserverChief, "pre-assignment brief")
+
+	// agent7 isn't involved with "late" yet — nothing new for it.
+	if n, err := Unread(h.s, agent7); err != nil || n != 0 {
+		t.Fatalf("unread before assignment = %d (err %v), want 0", n, err)
+	}
+
+	// The chief assigns "late" to agent7. agent7's per-ticket bookmark on "late" is
+	// still 0, so it receives the ticket's FULL history, brief included.
+	if err := h.s.AssignTicket("late", "agent7", ObserverChief, h.tick()); err != nil {
+		t.Fatalf("AssignTicket: %v", err)
+	}
+	bundles, err := Consume(h.s, agent7, h.tick())
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if len(bundles) != 1 || bundles[0].TicketID != "late" {
+		t.Fatalf("bundles = %+v, want only late", bundles)
+	}
+	if !hasComment(bundles[0].Events, "pre-assignment brief") {
+		t.Fatalf("late did not deliver its pre-assignment brief: %+v", bundles[0].Events)
+	}
+	sawCreated := false
+	for _, e := range bundles[0].Events {
+		if e.Kind == store.TicketEventCreated {
+			sawCreated = true
+		}
+	}
+	if !sawCreated {
+		t.Fatalf("late did not deliver its created event: %+v", bundles[0].Events)
+	}
+}
+
+// Reassignment hands the new assignee the whole thread: because its per-ticket
+// cursor starts at 0, a mid-flight handoff delivers the brief and the prior
+// assignee's progress, so the new agent picks up with full context.
+func TestHarnessReassignmentHandsOverHistory(t *testing.T) {
+	h := newHarness(t)
+	agent9 := AgentObserver("agent9", "claude")
+
+	// agent7 works a ticket and reports progress.
+	h.create("handoff", "agent7", ObserverChief)
+	h.status("handoff", store.TicketStatusWorking, "agent7", "did the first half")
+
+	// The chief reassigns it to agent9 mid-flight.
+	if err := h.s.AssignTicket("handoff", "agent9", ObserverChief, h.tick()); err != nil {
+		t.Fatalf("AssignTicket: %v", err)
+	}
+
+	bundles, err := Consume(h.s, agent9, h.tick())
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if len(bundles) != 1 || bundles[0].TicketID != "handoff" {
+		t.Fatalf("bundles = %+v, want only handoff", bundles)
+	}
+	kinds := map[store.TicketEventKind]bool{}
+	for _, e := range bundles[0].Events {
+		kinds[e.Kind] = true
+	}
+	if !kinds[store.TicketEventCreated] || !kinds[store.TicketEventStatusChanged] {
+		t.Fatalf("agent9 did not inherit the full thread: %+v", bundles[0].Events)
+	}
+	if !hasComment(bundles[0].Events, "did the first half") {
+		t.Fatalf("agent9 missing the prior progress note: %+v", bundles[0].Events)
 	}
 }

--- a/internal/ticketnotify/notify.go
+++ b/internal/ticketnotify/notify.go
@@ -78,6 +78,12 @@ type Bundle struct {
 // should see), bundled by ticket, and advances the cursor past everything
 // examined. This is the watch-consume handler: a self-monitoring observer calls it
 // when its Monitor fires; a nudged observer calls it after the nudge lands.
+//
+// Single-consumer-per-observer assumption: Consume reads the cursor, reads events,
+// then writes the cursor as three separately-locked store calls, so two Consume
+// calls racing for the SAME observer can double-deliver. In practice an observer is
+// one session with one Monitor, so its consumes are serialized. Slice 3 makes this
+// atomic if real concurrency appears.
 func Consume(es EventStore, obs Observer, now time.Time) ([]Bundle, error) {
 	matched, newCursor, err := pending(es, obs)
 	if err != nil {
@@ -155,8 +161,20 @@ func Notify(es EventStore, obs Observer, idle bool, nudger Nudger, now time.Time
 // events are never re-scanned. An observer never sees events it authored.
 //
 // Scope: the chief observes every ticket; an agent observes only tickets currently
-// assigned to it. (Slice 3 narrows the chief to tickets it delegated/owns once
-// delegation exists.)
+// assigned to it.
+//
+// KNOWN LIMITATION — agent scope is preliminary (resolved in slice 3's live wiring).
+// A single global cursor per observer does not compose cleanly with the per-agent
+// "current assignee" filter, and reassignment is genuinely undecided:
+//   - an agent's cursor advances past events on tickets not (yet) assigned to it, so
+//     a ticket assigned to it AFTER it has consumed loses its pre-assignment context
+//     (the created event / brief);
+//   - conversely a brand-new assignee, whose cursor sits below a ticket's history,
+//     would see the prior assignee's events.
+//
+// The chief observer (global scope) is unaffected and correct. Slice 3 decides the
+// agent audience model — emit-time audience snapshot or per-(observer,ticket)
+// cursors — when real delegation exists to pin the desired semantics.
 func pending(es EventStore, obs Observer) (matched []store.TicketEvent, newCursor int64, err error) {
 	cursor, err := es.GetObserverCursor(obs.ID)
 	if err != nil {

--- a/internal/ticketnotify/notify.go
+++ b/internal/ticketnotify/notify.go
@@ -1,16 +1,26 @@
 // Package ticketnotify is the event-driven notification core of the work tracker
 // (slice 2 of docs/plans/2026-06-26-work-tracker.md). It is the decoupled layer
-// that sits above the store's append-only event log: observers subscribe, their
-// cursors express "unread", and two handlers turn pending events into a
-// notification — a watch-consume for agents that self-monitor (Claude), and an
-// idle pty-nudge for those that can't (codex).
+// that sits above the store's append-only event log: every identity has a
+// per-ticket cursor, events past it are unread, and two handlers turn unread
+// events into a notification — a watch-consume for agents that self-monitor
+// (Claude), and an idle pty-nudge for those that can't (codex).
+//
+// Identity is uniform: you, the chief, and each agent are all just identities (the
+// chief is one of the agents). There is no special "sees everything" observer —
+// an identity is involved with a ticket when it is assigned to it or has authored
+// an event on it (the chief authors the created event when it delegates, so it
+// stays aware of its own delegations without a special case). Each identity has
+// its OWN cursor PER ticket, so a ticket newly assigned to an agent arrives with
+// its full history (the brief, prior steers) and an agent's progress on one ticket
+// never skips another it has not looked at yet.
 //
 // This package re-homes the dispatch gateway's settled mechanics:
 //
 //	gateway                         here
 //	------------------------------  -----------------------------------------
-//	ack = output / consume pending  cursor: events since the observer's cursor
-//	bundle by sender                Consume groups pending events by ticket
+//	ack = output / consume pending  per-(identity, ticket) cursors: events past
+//	                                an identity's cursor on a ticket are unread
+//	bundle by sender                Consume groups unread events by ticket
 //	hardcoded chief id              ObserverChief, a well-known literal
 //	two consumers (watch / nudge)   the two Delivery paths below
 //	never stream content to a PTY   Nudger carries only a fixed trigger
@@ -20,24 +30,29 @@
 package ticketnotify
 
 import (
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/victorarias/attn/internal/store"
 )
 
-// ObserverChief is the well-known chief observer — the awareness layer that
-// observes every ticket. Re-homes the gateway's hardcoded chief id as a literal,
-// so addressing it needs no lookup.
+// ObserverChief is the well-known chief identity — the chief is just one of the
+// agents, but its id is fixed (it has no spawned session id) so addressing it
+// needs no lookup. It enjoys no special scope: like any identity it sees events on
+// the tickets it is involved with (the ones it delegated/authored, plus any
+// assigned to it). Slice 3 supplies the real chief session id.
 const ObserverChief = "chief"
 
 // EventStore is the store surface the notifier needs. The real *store.Store
 // satisfies it; the harness uses the real store, so there is no mock to drift.
+//
+// UnreadTicketEvents folds the participant set, the per-(identity, ticket)
+// cursors, and the self-author exclusion into one query; SetTicketCursor advances
+// a single ticket's cursor for an identity.
 type EventStore interface {
-	TicketEventsSince(cursor int64) ([]store.TicketEvent, error)
-	GetObserverCursor(observerID string) (int64, error)
-	SetObserverCursor(observerID string, cursor int64, now time.Time) error
-	GetTicket(id string) (*store.Ticket, error)
+	UnreadTicketEvents(identity string) ([]store.TicketEvent, error)
+	SetTicketCursor(identity, ticketID string, cursor int64, now time.Time) error
 }
 
 // Observer is a subscriber to ticket events. ID is ObserverChief or an agent's
@@ -66,42 +81,48 @@ func HasSelfMonitor(agent string) bool {
 	return strings.EqualFold(strings.TrimSpace(agent), "claude")
 }
 
-// Bundle is an observer's pending events for a single ticket. Consume returns one
-// Bundle per ticket, in first-seen order — the gateway's "bundle by sender",
-// re-homed to "bundle by ticket".
+// Bundle is an observer's unread events for a single ticket. Consume returns one
+// Bundle per ticket, in oldest-activity-first order — the gateway's "bundle by
+// sender", re-homed to "bundle by ticket".
 type Bundle struct {
 	TicketID string
 	Events   []store.TicketEvent
 }
 
-// Consume returns the observer's unread events (those after its cursor that it
-// should see), bundled by ticket, and advances the cursor past everything
-// examined. This is the watch-consume handler: a self-monitoring observer calls it
-// when its Monitor fires; a nudged observer calls it after the nudge lands.
+// Consume returns the observer's unread events, bundled by ticket, and advances
+// the observer's cursor on each of those tickets past everything just delivered.
+// This is the watch-consume handler: a self-monitoring observer calls it when its
+// Monitor fires; a nudged observer calls it after the nudge lands.
 //
-// Single-consumer-per-observer assumption: Consume reads the cursor, reads events,
-// then writes the cursor as three separately-locked store calls, so two Consume
+// Single-consumer-per-observer assumption: Consume reads unread events then writes
+// each touched ticket's cursor as separately-locked store calls, so two Consume
 // calls racing for the SAME observer can double-deliver. In practice an observer is
 // one session with one Monitor, so its consumes are serialized. Slice 3 makes this
 // atomic if real concurrency appears.
 func Consume(es EventStore, obs Observer, now time.Time) ([]Bundle, error) {
-	matched, newCursor, err := pending(es, obs)
+	bundles, advance, err := pending(es, obs)
 	if err != nil {
 		return nil, err
 	}
-	if err := es.SetObserverCursor(obs.ID, newCursor, now); err != nil {
-		return nil, err
+	for ticketID, seq := range advance {
+		if err := es.SetTicketCursor(obs.ID, ticketID, seq, now); err != nil {
+			return nil, err
+		}
 	}
-	return bundleByTicket(matched), nil
+	return bundles, nil
 }
 
-// Unread counts the observer's pending events without consuming them.
+// Unread counts the observer's unread events without consuming them.
 func Unread(es EventStore, obs Observer) (int, error) {
-	matched, _, err := pending(es, obs)
+	bundles, _, err := pending(es, obs)
 	if err != nil {
 		return 0, err
 	}
-	return len(matched), nil
+	n := 0
+	for _, b := range bundles {
+		n += len(b.Events)
+	}
+	return n, nil
 }
 
 // Delivery is how the notifier decided to reach an observer about pending events.
@@ -156,74 +177,23 @@ func Notify(es EventStore, obs Observer, idle bool, nudger Nudger, now time.Time
 	return DeliveryNudge, nil
 }
 
-// pending returns the observer's unread, relevant events and the cursor to advance
-// to. The cursor advances past every event examined (matched or not), so unrelated
-// events are never re-scanned. An observer never sees events it authored.
+// pending returns the observer's unread events, already bundled by ticket, and the
+// per-ticket cursor each bundle's ticket should advance to. The store's
+// UnreadTicketEvents has already applied the scope (tickets the identity is
+// assigned to or has authored an event on), the per-(identity, ticket) cursors, and
+// the self-author exclusion — so this only groups and orders the result.
 //
-// Scope: the chief observes every ticket; an agent observes only tickets currently
-// assigned to it.
-//
-// KNOWN LIMITATION — agent scope is preliminary (resolved in slice 3's live wiring).
-// A single global cursor per observer does not compose cleanly with the per-agent
-// "current assignee" filter, and reassignment is genuinely undecided:
-//   - an agent's cursor advances past events on tickets not (yet) assigned to it, so
-//     a ticket assigned to it AFTER it has consumed loses its pre-assignment context
-//     (the created event / brief);
-//   - conversely a brand-new assignee, whose cursor sits below a ticket's history,
-//     would see the prior assignee's events.
-//
-// The chief observer (global scope) is unaffected and correct. Slice 3 decides the
-// agent audience model — emit-time audience snapshot or per-(observer,ticket)
-// cursors — when real delegation exists to pin the desired semantics.
-func pending(es EventStore, obs Observer) (matched []store.TicketEvent, newCursor int64, err error) {
-	cursor, err := es.GetObserverCursor(obs.ID)
+// Because each ticket is compared against the identity's own cursor on THAT ticket
+// (default 0), a ticket the identity has never looked at — a fresh assignment, or a
+// reassignment to it — is delivered from the start, brief and all. Bundles are
+// ordered by their oldest unread event so cross-ticket order stays chronological.
+func pending(es EventStore, obs Observer) (bundles []Bundle, advance map[string]int64, err error) {
+	events, err := es.UnreadTicketEvents(obs.ID)
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, err
 	}
-	events, err := es.TicketEventsSince(cursor)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	newCursor = cursor
-	assigneeOf := map[string]string{}
-	for _, e := range events {
-		if e.Seq > newCursor {
-			newCursor = e.Seq
-		}
-		if e.Author == obs.ID {
-			continue // never notify an observer of its own action
-		}
-		if obs.ID == ObserverChief {
-			matched = append(matched, e)
-			continue
-		}
-		assignee, ok := assigneeOf[e.TicketID]
-		if !ok {
-			ticket, err := es.GetTicket(e.TicketID)
-			if err != nil {
-				return nil, 0, err
-			}
-			if ticket != nil {
-				assignee = ticket.Assignee
-			}
-			assigneeOf[e.TicketID] = assignee
-		}
-		if assignee == obs.ID {
-			matched = append(matched, e)
-		}
-	}
-	return matched, newCursor, nil
-}
-
-// bundleByTicket groups events by ticket, preserving first-seen ticket order and
-// per-ticket event order.
-func bundleByTicket(events []store.TicketEvent) []Bundle {
-	if len(events) == 0 {
-		return nil
-	}
+	advance = map[string]int64{}
 	index := map[string]int{}
-	var bundles []Bundle
 	for _, e := range events {
 		i, ok := index[e.TicketID]
 		if !ok {
@@ -232,6 +202,12 @@ func bundleByTicket(events []store.TicketEvent) []Bundle {
 			bundles = append(bundles, Bundle{TicketID: e.TicketID})
 		}
 		bundles[i].Events = append(bundles[i].Events, e)
+		if e.Seq > advance[e.TicketID] {
+			advance[e.TicketID] = e.Seq
+		}
 	}
-	return bundles
+	sort.SliceStable(bundles, func(i, j int) bool {
+		return bundles[i].Events[0].Seq < bundles[j].Events[0].Seq
+	})
+	return bundles, advance, nil
 }

--- a/internal/ticketnotify/notify.go
+++ b/internal/ticketnotify/notify.go
@@ -1,0 +1,219 @@
+// Package ticketnotify is the event-driven notification core of the work tracker
+// (slice 2 of docs/plans/2026-06-26-work-tracker.md). It is the decoupled layer
+// that sits above the store's append-only event log: observers subscribe, their
+// cursors express "unread", and two handlers turn pending events into a
+// notification — a watch-consume for agents that self-monitor (Claude), and an
+// idle pty-nudge for those that can't (codex).
+//
+// This package re-homes the dispatch gateway's settled mechanics:
+//
+//	gateway                         here
+//	------------------------------  -----------------------------------------
+//	ack = output / consume pending  cursor: events since the observer's cursor
+//	bundle by sender                Consume groups pending events by ticket
+//	hardcoded chief id              ObserverChief, a well-known literal
+//	two consumers (watch / nudge)   the two Delivery paths below
+//	never stream content to a PTY   Nudger carries only a fixed trigger
+//
+// It knows nothing about live sessions or real Monitors — it is built against the
+// store and proven by a simulation harness. Slice 3 wires it to real sessions.
+package ticketnotify
+
+import (
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/store"
+)
+
+// ObserverChief is the well-known chief observer — the awareness layer that
+// observes every ticket. Re-homes the gateway's hardcoded chief id as a literal,
+// so addressing it needs no lookup.
+const ObserverChief = "chief"
+
+// EventStore is the store surface the notifier needs. The real *store.Store
+// satisfies it; the harness uses the real store, so there is no mock to drift.
+type EventStore interface {
+	TicketEventsSince(cursor int64) ([]store.TicketEvent, error)
+	GetObserverCursor(observerID string) (int64, error)
+	SetObserverCursor(observerID string, cursor int64, now time.Time) error
+	GetTicket(id string) (*store.Ticket, error)
+}
+
+// Observer is a subscriber to ticket events. ID is ObserverChief or an agent's
+// session id. HasSelfMonitor picks the delivery path: a self-monitoring agent's
+// own watch consumes; others are nudged when idle.
+type Observer struct {
+	ID             string
+	HasSelfMonitor bool
+}
+
+// ChiefObserver returns the well-known chief observer. The chief is a Claude
+// session, so it self-monitors.
+func ChiefObserver() Observer {
+	return Observer{ID: ObserverChief, HasSelfMonitor: true}
+}
+
+// AgentObserver returns an observer for a delegated agent session.
+func AgentObserver(sessionID, agent string) Observer {
+	return Observer{ID: sessionID, HasSelfMonitor: HasSelfMonitor(agent)}
+}
+
+// HasSelfMonitor reports whether an agent can watch its own events (true push via
+// a Monitor) or must be polled/nudged. Only Claude self-monitors today; codex and
+// the rest fall back to the idle nudge — matching the vision's split.
+func HasSelfMonitor(agent string) bool {
+	return strings.EqualFold(strings.TrimSpace(agent), "claude")
+}
+
+// Bundle is an observer's pending events for a single ticket. Consume returns one
+// Bundle per ticket, in first-seen order — the gateway's "bundle by sender",
+// re-homed to "bundle by ticket".
+type Bundle struct {
+	TicketID string
+	Events   []store.TicketEvent
+}
+
+// Consume returns the observer's unread events (those after its cursor that it
+// should see), bundled by ticket, and advances the cursor past everything
+// examined. This is the watch-consume handler: a self-monitoring observer calls it
+// when its Monitor fires; a nudged observer calls it after the nudge lands.
+func Consume(es EventStore, obs Observer, now time.Time) ([]Bundle, error) {
+	matched, newCursor, err := pending(es, obs)
+	if err != nil {
+		return nil, err
+	}
+	if err := es.SetObserverCursor(obs.ID, newCursor, now); err != nil {
+		return nil, err
+	}
+	return bundleByTicket(matched), nil
+}
+
+// Unread counts the observer's pending events without consuming them.
+func Unread(es EventStore, obs Observer) (int, error) {
+	matched, _, err := pending(es, obs)
+	if err != nil {
+		return 0, err
+	}
+	return len(matched), nil
+}
+
+// Delivery is how the notifier decided to reach an observer about pending events.
+type Delivery int
+
+const (
+	// DeliveryNone means there was nothing unread.
+	DeliveryNone Delivery = iota
+	// DeliveryWatch means a self-monitoring observer's own watch will consume it
+	// (true push) — nothing is injected.
+	DeliveryWatch
+	// DeliveryNudge means an idle, non-self-monitoring observer was pty-nudged to
+	// go consume. Only a fixed trigger is sent, never event content.
+	DeliveryNudge
+	// DeliveryDeferred means a non-self-monitoring observer is busy; the nudge
+	// waits until it goes idle.
+	DeliveryDeferred
+)
+
+// Nudger delivers a fixed wake trigger to an observer that can't self-monitor. It
+// carries NO event content — only the bounded "go consume your tickets" trigger,
+// mirroring the daemon's doorbell rule (the agent then reads its own queue).
+type Nudger interface {
+	Nudge(observerID string) error
+}
+
+// Notify decides how to deliver an observer's pending events and, for the nudge
+// path, fires the Nudger. It does not consume (advance the cursor) — delivery only
+// triggers the observer to consume:
+//
+//   - nothing unread            -> DeliveryNone
+//   - self-monitors             -> DeliveryWatch (its own watch consumes)
+//   - idle, can't self-monitor  -> DeliveryNudge (fixed trigger; it then consumes)
+//   - busy, can't self-monitor  -> DeliveryDeferred (wait for idle)
+func Notify(es EventStore, obs Observer, idle bool, nudger Nudger, now time.Time) (Delivery, error) {
+	unread, err := Unread(es, obs)
+	if err != nil {
+		return DeliveryNone, err
+	}
+	if unread == 0 {
+		return DeliveryNone, nil
+	}
+	if obs.HasSelfMonitor {
+		return DeliveryWatch, nil
+	}
+	if !idle {
+		return DeliveryDeferred, nil
+	}
+	if err := nudger.Nudge(obs.ID); err != nil {
+		return DeliveryNone, err
+	}
+	return DeliveryNudge, nil
+}
+
+// pending returns the observer's unread, relevant events and the cursor to advance
+// to. The cursor advances past every event examined (matched or not), so unrelated
+// events are never re-scanned. An observer never sees events it authored.
+//
+// Scope: the chief observes every ticket; an agent observes only tickets currently
+// assigned to it. (Slice 3 narrows the chief to tickets it delegated/owns once
+// delegation exists.)
+func pending(es EventStore, obs Observer) (matched []store.TicketEvent, newCursor int64, err error) {
+	cursor, err := es.GetObserverCursor(obs.ID)
+	if err != nil {
+		return nil, 0, err
+	}
+	events, err := es.TicketEventsSince(cursor)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	newCursor = cursor
+	assigneeOf := map[string]string{}
+	for _, e := range events {
+		if e.Seq > newCursor {
+			newCursor = e.Seq
+		}
+		if e.Author == obs.ID {
+			continue // never notify an observer of its own action
+		}
+		if obs.ID == ObserverChief {
+			matched = append(matched, e)
+			continue
+		}
+		assignee, ok := assigneeOf[e.TicketID]
+		if !ok {
+			ticket, err := es.GetTicket(e.TicketID)
+			if err != nil {
+				return nil, 0, err
+			}
+			if ticket != nil {
+				assignee = ticket.Assignee
+			}
+			assigneeOf[e.TicketID] = assignee
+		}
+		if assignee == obs.ID {
+			matched = append(matched, e)
+		}
+	}
+	return matched, newCursor, nil
+}
+
+// bundleByTicket groups events by ticket, preserving first-seen ticket order and
+// per-ticket event order.
+func bundleByTicket(events []store.TicketEvent) []Bundle {
+	if len(events) == 0 {
+		return nil
+	}
+	index := map[string]int{}
+	var bundles []Bundle
+	for _, e := range events {
+		i, ok := index[e.TicketID]
+		if !ok {
+			i = len(bundles)
+			index[e.TicketID] = i
+			bundles = append(bundles, Bundle{TicketID: e.TicketID})
+		}
+		bundles[i].Events = append(bundles[i].Events, e)
+	}
+	return bundles
+}

--- a/internal/ticketnotify/notify_edge_test.go
+++ b/internal/ticketnotify/notify_edge_test.go
@@ -16,28 +16,27 @@ type failingNudger struct{ called bool }
 func (n *failingNudger) Nudge(string) error { n.called = true; return errors.New("pty gone") }
 
 // erroringStore is an EventStore that fails on a chosen method, to exercise error
-// propagation through Consume / Unread / Notify.
+// propagation through Consume / Unread / Notify. UnreadTicketEvents returns one
+// unread event (when not failing) so Consume reaches the cursor-write path.
 type erroringStore struct {
-	failSince  bool
-	failCursor bool
+	failUnread bool
+	failSet    bool
 }
 
 var errBoom = errors.New("boom")
 
-func (e erroringStore) TicketEventsSince(int64) ([]store.TicketEvent, error) {
-	if e.failSince {
+func (e erroringStore) UnreadTicketEvents(string) ([]store.TicketEvent, error) {
+	if e.failUnread {
 		return nil, errBoom
 	}
 	return []store.TicketEvent{{Seq: 1, TicketID: "tk", Kind: store.TicketEventCommented, Author: "agent7"}}, nil
 }
-func (e erroringStore) GetObserverCursor(string) (int64, error) {
-	if e.failCursor {
-		return 0, errBoom
+func (e erroringStore) SetTicketCursor(string, string, int64, time.Time) error {
+	if e.failSet {
+		return errBoom
 	}
-	return 0, nil
+	return nil
 }
-func (e erroringStore) SetObserverCursor(string, int64, time.Time) error { return nil }
-func (e erroringStore) GetTicket(string) (*store.Ticket, error)          { return nil, nil }
 
 func TestNotifyNudgeError(t *testing.T) {
 	h := newHarness(t)
@@ -62,13 +61,18 @@ func TestNotifyAndConsumePropagateStoreErrors(t *testing.T) {
 	obs := ChiefObserver()
 	now := edgeBase
 
-	if _, err := Consume(erroringStore{failSince: true}, obs, now); !errors.Is(err, errBoom) {
-		t.Fatalf("Consume error = %v, want boom", err)
+	if _, err := Consume(erroringStore{failUnread: true}, obs, now); !errors.Is(err, errBoom) {
+		t.Fatalf("Consume(failUnread) error = %v, want boom", err)
 	}
-	if _, err := Unread(erroringStore{failCursor: true}, obs); !errors.Is(err, errBoom) {
+	// failSet exercises the cursor-write path: pending returns an unread event, so
+	// Consume reaches SetTicketCursor, which errors.
+	if _, err := Consume(erroringStore{failSet: true}, obs, now); !errors.Is(err, errBoom) {
+		t.Fatalf("Consume(failSet) error = %v, want boom", err)
+	}
+	if _, err := Unread(erroringStore{failUnread: true}, obs); !errors.Is(err, errBoom) {
 		t.Fatalf("Unread error = %v, want boom", err)
 	}
-	if _, err := Notify(erroringStore{failSince: true}, obs, true, &failingNudger{}, now); !errors.Is(err, errBoom) {
+	if _, err := Notify(erroringStore{failUnread: true}, obs, true, &failingNudger{}, now); !errors.Is(err, errBoom) {
 		t.Fatalf("Notify error = %v, want boom", err)
 	}
 }

--- a/internal/ticketnotify/notify_edge_test.go
+++ b/internal/ticketnotify/notify_edge_test.go
@@ -1,0 +1,134 @@
+package ticketnotify
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/store"
+)
+
+var edgeBase = time.Date(2026, 6, 26, 8, 0, 0, 0, time.UTC)
+
+// failingNudger reports a nudge attempt and fails.
+type failingNudger struct{ called bool }
+
+func (n *failingNudger) Nudge(string) error { n.called = true; return errors.New("pty gone") }
+
+// erroringStore is an EventStore that fails on a chosen method, to exercise error
+// propagation through Consume / Unread / Notify.
+type erroringStore struct {
+	failSince  bool
+	failCursor bool
+}
+
+var errBoom = errors.New("boom")
+
+func (e erroringStore) TicketEventsSince(int64) ([]store.TicketEvent, error) {
+	if e.failSince {
+		return nil, errBoom
+	}
+	return []store.TicketEvent{{Seq: 1, TicketID: "tk", Kind: store.TicketEventCommented, Author: "agent7"}}, nil
+}
+func (e erroringStore) GetObserverCursor(string) (int64, error) {
+	if e.failCursor {
+		return 0, errBoom
+	}
+	return 0, nil
+}
+func (e erroringStore) SetObserverCursor(string, int64, time.Time) error { return nil }
+func (e erroringStore) GetTicket(string) (*store.Ticket, error)          { return nil, nil }
+
+func TestNotifyNudgeError(t *testing.T) {
+	h := newHarness(t)
+	codex := AgentObserver("codexbot", "codex")
+	h.create("alpha", "codexbot", ObserverChief)
+	h.comment("alpha", ObserverChief, "steer")
+
+	n := &failingNudger{}
+	d, err := Notify(h.s, codex, true, n, h.tick())
+	if !n.called {
+		t.Fatal("nudger was not called")
+	}
+	if err == nil {
+		t.Fatal("Notify swallowed the nudge error")
+	}
+	if d != DeliveryNone {
+		t.Fatalf("delivery on nudge failure = %v, want None", d)
+	}
+}
+
+func TestNotifyAndConsumePropagateStoreErrors(t *testing.T) {
+	obs := ChiefObserver()
+	now := edgeBase
+
+	if _, err := Consume(erroringStore{failSince: true}, obs, now); !errors.Is(err, errBoom) {
+		t.Fatalf("Consume error = %v, want boom", err)
+	}
+	if _, err := Unread(erroringStore{failCursor: true}, obs); !errors.Is(err, errBoom) {
+		t.Fatalf("Unread error = %v, want boom", err)
+	}
+	if _, err := Notify(erroringStore{failSince: true}, obs, true, &failingNudger{}, now); !errors.Is(err, errBoom) {
+		t.Fatalf("Notify error = %v, want boom", err)
+	}
+}
+
+func TestConsumeEmptyStore(t *testing.T) {
+	h := newHarness(t)
+	chief := ChiefObserver()
+
+	bundles, err := Consume(h.s, chief, h.tick())
+	if err != nil || bundles != nil {
+		t.Fatalf("empty Consume = %+v (err %v), want nil", bundles, err)
+	}
+	if n, err := Unread(h.s, chief); err != nil || n != 0 {
+		t.Fatalf("empty Unread = %d (err %v), want 0", n, err)
+	}
+	d, err := Notify(h.s, chief, true, h, h.tick())
+	if err != nil || d != DeliveryNone {
+		t.Fatalf("empty Notify = %v (err %v), want None", d, err)
+	}
+	if len(h.nudges) != 0 {
+		t.Fatalf("nudges on empty store = %v, want none", h.nudges)
+	}
+}
+
+// The chief consumes the three event kinds the main harness never drives:
+// assigned, description_edited, attachment_added (authored by an agent, so the
+// chief — which excludes its own events — observes them).
+func TestConsumeOtherEventKinds(t *testing.T) {
+	h := newHarness(t)
+	chief := ChiefObserver()
+
+	h.create("alpha", "agent7", ObserverChief)
+	if err := h.s.AssignTicket("alpha", "agent9", "agent7", h.tick()); err != nil {
+		t.Fatalf("AssignTicket: %v", err)
+	}
+	if err := h.s.EditTicketDescription("alpha", "tighter brief", "agent7", h.tick()); err != nil {
+		t.Fatalf("EditTicketDescription: %v", err)
+	}
+	if _, err := h.s.AddTicketAttachment(store.TicketAttachment{TicketID: "alpha", Filename: "diff.patch"}, "agent7", h.tick()); err != nil {
+		t.Fatalf("AddTicketAttachment: %v", err)
+	}
+
+	bundles, err := Consume(h.s, chief, h.tick())
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if len(bundles) != 1 || bundles[0].TicketID != "alpha" {
+		t.Fatalf("bundles = %+v, want one for alpha", bundles)
+	}
+	seen := map[store.TicketEventKind]string{}
+	for _, e := range bundles[0].Events {
+		seen[e.Kind] = e.Detail
+	}
+	if seen[store.TicketEventAssigned] != "agent9" {
+		t.Fatalf("assigned not consumed with detail: %+v", seen)
+	}
+	if seen[store.TicketEventDescriptionEdited] != "tighter brief" {
+		t.Fatalf("description_edited not consumed with detail: %+v", seen)
+	}
+	if seen[store.TicketEventAttachmentAdded] != "diff.patch" {
+		t.Fatalf("attachment_added not consumed with detail: %+v", seen)
+	}
+}


### PR DESCRIPTION
Part of the **Tickets** work tracker (umbrella #412, plan `docs/plans/2026-06-26-work-tracker-slice3.md`). Stacked on #415 (slice 3a).

## What

Adds `attn ticket status <work-state>` — the agent's **forward channel** onto its own bound ticket. This is the awareness spine working in the agent→board direction: the agent self-reports its work state, attn projects that onto the board column. No content is ever streamed into a PTY.

- **`set_ticket_status` protocol command** (version bump 123→124). The agent never names a ticket id; the daemon resolves the bound ticket from the calling session (the assignee) via `ActiveTicketForSession`, so a session can only ever move *its own* active ticket.
- **work-state → column map** (`ticketStatusFromWorkState`): `in_progress→working`, `needs_input→blocked`, `ready_for_review→in_review`, `completed→done`, `failed→failed`. `crashed`/`todo` are intentionally unreachable here (crashed is attn-authored; todo is pre-assignment). The map lives in one place so slices 3c/3d/3e can reuse it.
- Status changes are recorded with the **agent's own session as author** on the activity thread + as a `status_changed` ticket event.

## Scope (additive only)

The dispatch report verbs (`dispatch update/block/review/complete/fail`) still exist and still work. The agent prompt is rewired to use tickets in **3d**, and the dispatch report/mailbox paths are removed in the **gated** **3e** (Victor's sign-off). 3b just adds the mechanism + proves it.

## Tests

- `TestSetTicketStatusMovesBoundTicket` — real delegation → `ready_for_review` → ticket in In Review, result echoed, change authored by the agent session with the comment.
- `TestSetTicketStatusCompletedClosesTicket` — `completed` closes the ticket (terminal + `closed_at`); a follow-up report is rejected (no active ticket).
- `TestSetTicketStatusErrors` — empty session / unknown work state / no bound ticket.
- `TestTicketStatusFromWorkState` — locks all five mappings + rejects unknown.

## Verification

`go build ./...`, full `go test ./internal/daemon` (incl. new tests), `internal/protocol|client|store|ticketnotify` suites, and frontend `tsc --noEmit` all green. CI is main-only, so verified locally + figgyster per PR.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #412
2. #413
3. #414
4. #415
5. **#416** 👈 current
6. #417
7. #418
8. #419
9. #420
10. #421
11. #422
12. #423
13. #424
<!-- stack:links:end -->