### PR TITLE
fix(terminal): keep small panes' last rows on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-27]
+
+### Fixed
+- **A terminal's last rows no longer get cut off outside the window.** Under some conditions — most often after splitting a workspace into several stacked panes, or making the window short — the bottom one or two lines of a terminal could render past the edge of its pane and stay there: invisible, and impossible to scroll into view, until you restarted the app or cycled away and back to the workspace. A safeguard meant to ignore transient/garbage size measurements was also rejecting legitimately small panes, leaving the terminal larger than the space it had. It now keeps the terminal sized to its pane so every row stays on screen (the same fix covers the right-most columns being clipped in very narrow side-by-side splits).
+
 ## [2026-06-26]
 
 ### Fixed

--- a/app/src/components/GhosttyTerminal.resizePolicy.test.ts
+++ b/app/src/components/GhosttyTerminal.resizePolicy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   fitRequiresTerminalResize,
+  fitShouldBailAsSuspicious,
   geometryOverflowsContainer,
   isWorkspaceResizeDragActive,
   liveResizeConflictsWithQueuedReplay,
@@ -65,6 +66,42 @@ describe('geometryOverflowsContainer', () => {
     expect(geometryOverflowsContainer(27, 21, 0)).toBe(false);
     expect(geometryOverflowsContainer(0, 21, 540)).toBe(false);
     expect(geometryOverflowsContainer(27, 0, 540)).toBe(false);
+  });
+});
+
+describe('fitShouldBailAsSuspicious', () => {
+  // cellWidth 9, cellHeight 21 throughout, matching the captured incident.
+  // Args: (paneKind, dims, modelCols, modelRows, cellWidth, cellHeight, clientWidth, clientHeight).
+  it('does NOT bail when a small fit is required to stop the bottom-row clip', () => {
+    // The bug: a deep stacked split fits ~7 rows (rows<=10 => "suspicious"), but
+    // the live model is stranded at 13 rows, overflowing the 147px container. The
+    // small fit MUST apply — refusing it leaves the model taller than the pane and
+    // the last rows clip below the overflow:hidden edge.
+    expect(fitShouldBailAsSuspicious('agent', { cols: 73, rows: 7 }, 73, 13, 9, 21, 720, 147)).toBe(false);
+  });
+
+  it('does NOT bail when a small fit is required to stop the right-column clip', () => {
+    // The width analog: a narrow side-by-side split fits ~16 cols (cols<=20 =>
+    // "suspicious"), but the model is stranded at 40 cols overflowing the 150px
+    // container width. Height fits, so only the width check catches this.
+    expect(fitShouldBailAsSuspicious('agent', { cols: 16, rows: 40 }, 40, 40, 9, 21, 150, 840)).toBe(false);
+  });
+
+  it('bails on a suspicious fit when the model does not overflow (transient measurement)', () => {
+    // Pre-layout / first-show: container not yet measured (client ~0), so the
+    // model cannot overflow it. The tiny dims are garbage and must be suppressed.
+    expect(fitShouldBailAsSuspicious('agent', { cols: 2, rows: 1 }, 13, 13, 9, 21, 0, 0)).toBe(true);
+    // A settled, comfortably-sized container with a transient tiny fit also bails.
+    expect(fitShouldBailAsSuspicious('agent', { cols: 4, rows: 2 }, 24, 24, 9, 21, 720, 540)).toBe(true);
+  });
+
+  it('never bails for non-agent panes (utility terminals manage their own size)', () => {
+    expect(fitShouldBailAsSuspicious('utility', { cols: 2, rows: 1 }, 24, 24, 9, 21, 720, 540)).toBe(false);
+    expect(fitShouldBailAsSuspicious(undefined, { cols: 2, rows: 1 }, 24, 24, 9, 21, 720, 540)).toBe(false);
+  });
+
+  it('never bails when the floored fit is a normal usable size', () => {
+    expect(fitShouldBailAsSuspicious('agent', { cols: 120, rows: 40 }, 120, 40, 9, 21, 1080, 840)).toBe(false);
   });
 });
 

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -284,6 +284,44 @@ export function geometryOverflowsContainer(
   return rows * cellHeight > clientHeight + 1;
 }
 
+// Whether fit() should SUPPRESS applying `dims` because they look like a
+// transient/garbage measurement (taken before layout settles on relaunch,
+// first-show, or a split topology change) rather than a real container.
+//
+// The guard only fires for agent panes whose floored size is "suspicious"
+// (MIN_USABLE_TERMINAL_*). But a genuinely small container — a deep stacked
+// split, a narrow side-by-side split, or a short window — yields a legitimately
+// small grid. Refusing it would leave the model LARGER than the container, so the
+// overflowing edge (the bottom row(s) for a short pane, or the right column(s)
+// for a narrow one) renders past the overflow:hidden viewport edge and cannot be
+// scrolled into view. So when the live model already overflows the measured
+// container in either axis, the small fit is required (a correctly sized small
+// terminal beats a clipped one) and we do NOT bail. A not-yet-laid-out container
+// (clientWidth/clientHeight ~0) never registers as overflowing (see
+// geometryOverflowsContainer), so the transient case still bails.
+export function fitShouldBailAsSuspicious(
+  paneKind: string | undefined,
+  dims: TerminalDimensions,
+  modelCols: number,
+  modelRows: number,
+  cellWidth: number,
+  cellHeight: number,
+  clientWidth: number,
+  clientHeight: number,
+): boolean {
+  if (paneKind !== 'agent') {
+    return false;
+  }
+  if (!isSuspiciousTerminalSize(dims.cols, dims.rows)) {
+    return false;
+  }
+  // geometryOverflowsContainer is axis-agnostic (count * cellSize > client + 1);
+  // apply it to height (rows) and width (cols) so a narrow split is covered too.
+  const overflows = geometryOverflowsContainer(modelRows, cellHeight, clientHeight)
+    || geometryOverflowsContainer(modelCols, cellWidth, clientWidth);
+  return !overflows;
+}
+
 // Geometry the queued (not yet applied) historical replay will end at.
 // `resizes` counts replay resize operations still on the write chain.
 export interface PendingReplayGeometry extends TerminalDimensions {
@@ -1488,7 +1526,16 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         return;
       }
       const dims = renderer.fitDimensions(container.clientWidth, container.clientHeight);
-      if (runtimeMetaRef.current?.paneKind === 'agent' && isSuspiciousTerminalSize(dims.cols, dims.rows)) {
+      if (fitShouldBailAsSuspicious(
+        runtimeMetaRef.current?.paneKind,
+        dims,
+        terminalRef.current?.cols ?? 0,
+        terminalRef.current?.rows ?? 0,
+        renderer.cellWidth,
+        renderer.cellHeight,
+        container.clientWidth,
+        container.clientHeight,
+      )) {
         noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'suspiciousSize', toCols: dims.cols, toRows: dims.rows });
         return;
       }
@@ -1614,6 +1661,8 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         registerRenderProbe(diagKeyRef.current, () => {
           const model = terminalRef.current;
           if (!model) return null;
+          const activeRenderer = rendererRef.current;
+          const activeContainer = containerRef.current;
           return {
             cols: model.cols,
             rows: model.rows,
@@ -1623,6 +1672,16 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             // Mirrors renderSurface's inactive-session bail: a pane that is
             // not allowed to paint must not be judged blank by the watchdog.
             active: runtimeMetaRef.current ? runtimeMetaRef.current.isActiveSession : true,
+            // Geometry for the bottom-clip detector / on-demand dump. Reads the
+            // container live (forces a layout), so only the low-frequency sweep
+            // and the manual dump call this — never the per-frame paint path.
+            session: runtimeMetaRef.current?.sessionId ?? undefined,
+            isActivePane: runtimeMetaRef.current?.isActivePane ?? null,
+            hasMeasuredSize: hasMeasuredSizeRef.current,
+            cellWidth: activeRenderer?.cellWidth ?? null,
+            cellHeight: activeRenderer?.cellHeight ?? null,
+            clientWidth: activeContainer?.clientWidth ?? null,
+            clientHeight: activeContainer?.clientHeight ?? null,
           };
         });
         inputRef.current = new InputHandler(

--- a/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.test.ts
+++ b/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.test.ts
@@ -542,7 +542,13 @@ describe('useGhosttyPaneRuntime', () => {
     });
   });
 
-  it('does not send transient unusable session-pane sizes to the PTY', async () => {
+  it('forwards a genuinely small fit so the PTY matches a deep split (no bottom clip)', async () => {
+    // GhosttyTerminal.fit() is the geometry authority: it already suppresses
+    // transient/garbage measurements and deliberately emits a small grid when a
+    // pane is legitimately short (a deep stacked split, or a short window). The
+    // runtime must NOT re-apply the MIN_USABLE "suspicious" threshold here —
+    // dropping a real small fit strands the PTY taller than the pane and clips
+    // the bottom rows below the overflow:hidden edge.
     const { result } = renderHook(() => useGhosttyPaneRuntime([
       {
         paneId: 'pane-session',
@@ -565,7 +571,28 @@ describe('useGhosttyPaneRuntime', () => {
       result.current.handleTerminalResize('pane-session-2')(10, 6);
     });
 
-    expect(mockPtyResize).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'runtime-1', cols: 10, rows: 6 }));
-    expect(mockPtyResize).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'runtime-2', cols: 10, rows: 6 }));
+    expect(mockPtyResize).toHaveBeenCalledWith(expect.objectContaining({ id: 'runtime-1', cols: 10, rows: 6 }));
+    expect(mockPtyResize).toHaveBeenCalledWith(expect.objectContaining({ id: 'runtime-2', cols: 10, rows: 6 }));
+  });
+
+  it('drops a degenerate (zero/negative/non-finite) fit', async () => {
+    const { result } = renderHook(() => useGhosttyPaneRuntime([
+      {
+        paneId: 'pane-session',
+        runtimeId: 'runtime-1',
+        paneKind: 'agent',
+      },
+    ], 'pane-session', router, { current: true }));
+    const terminal = createTerminal();
+
+    await act(async () => {
+      await result.current.handleTerminalReady('pane-session')(terminal);
+      result.current.handleTerminalResize('pane-session')(80, 0);
+      result.current.handleTerminalResize('pane-session')(0, 24);
+      result.current.handleTerminalResize('pane-session')(-1, 24);
+      result.current.handleTerminalResize('pane-session')(Number.NaN, 24);
+    });
+
+    expect(mockPtyResize).not.toHaveBeenCalled();
   });
 });

--- a/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
+++ b/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { ptyAttach, ptyDetach, ptyResize, ptyWrite, type PtyEventPayload } from '../../pty/bridge';
 import { formatExitNotice } from '../../pty/exitNotice';
-import { isSuspiciousTerminalSize } from '../../utils/terminalDebug';
 import { recordFocus } from '../../utils/terminalDiagnosticsLog';
 import type { PaneRuntimeEventRouter } from './paneRuntimeEventRouter';
 import type { BlockStateSnapshot, GhosttyTerminalHandle } from '../GhosttyTerminal';
@@ -331,7 +330,14 @@ export function useGhosttyPaneRuntime(
     if (!isActiveSessionRef.current) return;
     const pane = paneFor(paneId);
     if (!pane) return;
-    if (isSuspiciousTerminalSize(cols, rows)) return;
+    // GhosttyTerminal.fit() is the geometry authority: it measures the real,
+    // settled container and suppresses transient/degenerate measurements itself,
+    // and deliberately emits a small grid for a genuinely small pane (a deep
+    // stacked split, or a short window) so the bottom rows are not clipped.
+    // Re-applying the MIN_USABLE "suspicious" threshold here dropped those
+    // legitimate small fits and stranded the PTY taller than the pane. Guard only
+    // against a non-sensical size.
+    if (!Number.isFinite(cols) || !Number.isFinite(rows) || cols < 1 || rows < 1) return;
     const reason = options?.reason ?? 'ghostty_fit';
     if (!readyRuntimesRef.current.has(pane.runtimeId)) {
       pendingResizeRef.current.set(pane.runtimeId, { cols, rows, reason });

--- a/app/src/utils/terminalDiagnosticsLog.test.ts
+++ b/app/src/utils/terminalDiagnosticsLog.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { noteResize, recordDiag, recordPaint, registerRenderProbe } from './terminalDiagnosticsLog';
+import {
+  dumpTerminalGeometry,
+  noteResize,
+  recordDiag,
+  recordPaint,
+  registerRenderProbe,
+  type RenderProbe,
+} from './terminalDiagnosticsLog';
 
 function ringEventsFor(pane: string) {
   return (window.__ATTN_TERMINAL_DIAG_DUMP?.() ?? []).filter((event) => event.pane === pane);
@@ -134,5 +141,95 @@ describe('blank-after-resize watchdog', () => {
     const events = ringEventsFor(pane);
     expect(events.filter((event) => event.kind === 'incident')).toHaveLength(0);
     expect(events.some((event) => event.kind === 'watchdog' && event.skipped === 'inactive')).toBe(true);
+  });
+});
+
+describe('bottom-clip detector', () => {
+  beforeEach(() => {
+    window.localStorage.setItem('attn:terminal-diagnostics', '1');
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const probeWith = (over: Partial<RenderProbe>): RenderProbe => ({
+    cols: 80,
+    rows: 24,
+    modelPrintable: 100,
+    lastPaintAt: Date.now(),
+    lastPaintQuads: 100,
+    active: true,
+    ...over,
+  });
+
+  it('flags an active pane whose grid is one row taller than its container', () => {
+    const pane = 'pane-clip-overflow';
+    // floor(540/21)=25 rows fit, but the daemon left the model at 26 → 6px spill.
+    const unregister = registerRenderProbe(pane, () => probeWith({
+      rows: 26, cellHeight: 21, clientHeight: 540, cellWidth: 9, clientWidth: 720,
+      session: 's-clip', isActivePane: true, hasMeasuredSize: true,
+    }));
+    vi.advanceTimersByTime(1600);
+    unregister();
+
+    const incidents = ringEventsFor(pane).filter((event) => event.kind === 'incident');
+    expect(incidents).toHaveLength(1);
+    expect(incidents[0]?.reason).toBe('bottom_clip');
+    expect(incidents[0]?.flooredRows).toBe(25);
+    expect(incidents[0]?.extraRows).toBe(1);
+    expect(incidents[0]?.overflowPx).toBe(6);
+  });
+
+  it('does not flag a grid that fits within the container', () => {
+    const pane = 'pane-clip-fits';
+    const unregister = registerRenderProbe(pane, () => probeWith({
+      rows: 25, cellHeight: 21, clientHeight: 540,
+    }));
+    vi.advanceTimersByTime(1600);
+    unregister();
+    expect(ringEventsFor(pane).filter((event) => event.kind === 'incident')).toHaveLength(0);
+  });
+
+  it('does not flag an inactive pane even when its grid overflows', () => {
+    const pane = 'pane-clip-inactive';
+    const unregister = registerRenderProbe(pane, () => probeWith({
+      active: false, rows: 26, cellHeight: 21, clientHeight: 540,
+    }));
+    vi.advanceTimersByTime(1600);
+    unregister();
+    expect(ringEventsFor(pane).filter((event) => event.kind === 'incident')).toHaveLength(0);
+  });
+
+  it('reports the clip once, then a resolution when it clears', () => {
+    const pane = 'pane-clip-resolve';
+    let rows = 26;
+    const unregister = registerRenderProbe(pane, () => probeWith({
+      rows, cellHeight: 21, clientHeight: 540,
+    }));
+    vi.advanceTimersByTime(1600); // onset
+    vi.advanceTimersByTime(1600); // still clipping → edge-triggered, no repeat
+    rows = 25; // a refit floored it back
+    vi.advanceTimersByTime(1600); // resolution
+    unregister();
+
+    const reasons = ringEventsFor(pane)
+      .filter((event) => event.kind === 'incident')
+      .map((event) => event.reason);
+    expect(reasons).toEqual(['bottom_clip', 'bottom_clip_resolved']);
+  });
+
+  it('dumpTerminalGeometry computes overflow and floored dims per pane', () => {
+    const pane = 'pane-clip-dump';
+    const unregister = registerRenderProbe(pane, () => probeWith({
+      rows: 26, cols: 80, cellHeight: 21, cellWidth: 9, clientHeight: 540, clientWidth: 720,
+    }));
+    const snapshot = dumpTerminalGeometry().find((entry) => entry.pane === pane);
+    unregister();
+
+    expect(snapshot).toMatchObject({
+      rows: 26, flooredRows: 25, flooredCols: 80, overflowPx: 6, clipping: true,
+    });
   });
 });

--- a/app/src/utils/terminalDiagnosticsLog.ts
+++ b/app/src/utils/terminalDiagnosticsLog.ts
@@ -13,12 +13,20 @@
 //     if the model holds content but the surface drew ~nothing, it writes an
 //     INCIDENT record (with ring context) to a separate file. That captures the
 //     blank automatically, so the user only has to keep using the app.
+//   - A second sweep (the bottom-clip detector) periodically checks each active
+//     pane for a grid that is taller than its container — the "last line cut off
+//     at the bottom of the window" bug. It records a `bottom_clip` incident (with
+//     ring context) when the clip appears and a `bottom_clip_resolved` marker
+//     when it clears, so the trigger sequence is captured in the wild.
 //   - Disk writes are async/non-blocking and size-capped, so they never perturb
 //     the render timing we are trying to diagnose.
 //
 // Read the results from:
 //   $APPLOCALDATA/debug/terminal-diagnostics.jsonl   (lifecycle stream)
-//   $APPLOCALDATA/debug/terminal-incidents.jsonl      (auto-captured blanks)
+//   $APPLOCALDATA/debug/terminal-incidents.jsonl      (auto-captured blanks + bottom clips)
+//
+// Dump every mounted pane's live geometry on demand (DevTools console):
+//   window.__ATTN_TERMINAL_GEOMETRY()
 //
 // Disable at runtime with localStorage['attn:terminal-diagnostics']='0'.
 import { isTauri } from '@tauri-apps/api/core';
@@ -42,6 +50,14 @@ const WATCHDOG_DELAYS_MS = [1200, 3500];
 // Do not emit more than one incident per pane within this window (avoids spam
 // while a pane stays blank across several repaint attempts).
 const INCIDENT_COOLDOWN_MS = 8000;
+// Bottom-clip detector: how often to sweep active panes for a rendered grid
+// taller than its container (the last row(s) clipped below the viewport). Low
+// frequency — the clip persists until a remount, so a slow sweep still catches
+// it, and the cost is one layout read per active pane per tick.
+const BOTTOM_CLIP_SWEEP_MS = 1500;
+// Pixel slack mirroring geometryOverflowsContainer: ignore sub-pixel container
+// heights so we only act on a genuine extra row.
+const BOTTOM_CLIP_SLACK_PX = 1;
 
 export type DiagKind =
   | 'pane_mount'
@@ -91,6 +107,33 @@ export interface RenderProbe {
   // "blank" is meaningless — it will paint on activation via the model's
   // accumulated dirty flag.
   active: boolean;
+  // Geometry for the bottom-clip detector / on-demand dump. Optional so other
+  // probe producers and tests keep compiling; `null` means "not measured yet".
+  session?: string;
+  isActivePane?: boolean | null;
+  hasMeasuredSize?: boolean;
+  cellWidth?: number | null;
+  cellHeight?: number | null;
+  clientWidth?: number | null;
+  clientHeight?: number | null;
+}
+
+export interface TerminalGeometrySnapshot {
+  pane: string;
+  session?: string;
+  active: boolean;
+  isActivePane: boolean | null;
+  hasMeasuredSize: boolean | null;
+  cols: number;
+  rows: number;
+  cellWidth: number | null;
+  cellHeight: number | null;
+  clientWidth: number | null;
+  clientHeight: number | null;
+  flooredCols: number | null;
+  flooredRows: number | null;
+  overflowPx: number | null;
+  clipping: boolean;
 }
 
 interface PaneHealth {
@@ -111,6 +154,8 @@ declare global {
     __ATTN_TERMINAL_DIAG_DUMP?: () => DiagEvent[];
     __ATTN_TERMINAL_DIAG_FILES?: { lifecycle: string; incidents: string };
     __ATTN_TERMINAL_DIAG_ENABLE?: (enabled: boolean) => void;
+    // On-demand: dump every mounted pane's live geometry (and persist a snapshot).
+    __ATTN_TERMINAL_GEOMETRY?: () => TerminalGeometrySnapshot[];
     // Back-compat alias used by the split-blank e2e repro spec.
     __ATTN_RENDER_TRACE?: unknown[];
     __ATTN_RENDER_TRACE_ON?: boolean;
@@ -123,6 +168,10 @@ let ringWrapped = false;
 const paneHealth = new Map<string, PaneHealth>();
 const renderProbes = new Map<string, () => RenderProbe | null>();
 const watchdogTimers = new Map<string, ReturnType<typeof setTimeout>[]>();
+// Per-pane "currently clipping at the bottom" flag so the detector reports the
+// clip's onset (and its resolution) once, not on every sweep tick.
+const clipState = new Map<string, boolean>();
+let clipSweepTimer: ReturnType<typeof setInterval> | null = null;
 
 let lifecycleBytes = 0;
 let incidentBytes = 0;
@@ -173,6 +222,9 @@ function ensureGlobals() {
         // ignore
       }
     };
+  }
+  if (!window.__ATTN_TERMINAL_GEOMETRY) {
+    window.__ATTN_TERMINAL_GEOMETRY = dumpTerminalGeometry;
   }
 }
 
@@ -365,8 +417,11 @@ export function recordPaint(sample: PaintSample): void {
 
 export function registerRenderProbe(pane: string, probe: () => RenderProbe | null): () => void {
   renderProbes.set(pane, probe);
+  ensureClipSweep();
   return () => {
     renderProbes.delete(pane);
+    clipState.delete(pane);
+    stopClipSweepIfIdle();
   };
 }
 
@@ -481,10 +536,176 @@ function maybeFlushIncident(pane: string, reason: string, detail: Record<string,
   enqueueWrite('incident', `${JSON.stringify(record)}\n`);
 }
 
+// --- Bottom-clip detector --------------------------------------------------
+// `fit()` floors rows so it can never overflow, but the daemon's authoritative
+// geometry is applied unfloored and the floor-correction (`fit()`) bails while
+// a pane is inactive — so a pane can end up one or two rows taller than its
+// container with no container resize to re-fire the ResizeObserver, clipping the
+// bottom line below the viewport. This sweep notices that state on any active
+// pane and captures it with full ring context (the resize trail that led there).
+
+function bottomClipOverflowPx(probe: RenderProbe): number | null {
+  const cellHeight = probe.cellHeight ?? 0;
+  const clientHeight = probe.clientHeight ?? 0;
+  if (cellHeight <= 0 || clientHeight <= 0 || probe.rows <= 0) {
+    return null;
+  }
+  return probe.rows * cellHeight - clientHeight;
+}
+
+function recordBottomClipIncident(pane: string, detail: Record<string, unknown>): void {
+  const now = Date.now();
+  const session = typeof detail.session === 'string' ? detail.session : undefined;
+  const marker: DiagEvent = { at: now, kind: 'incident', pane, session, reason: 'bottom_clip', ...detail };
+  pushRing(marker);
+  enqueueWrite('lifecycle', `${JSON.stringify(marker)}\n`);
+  // Full record carries the surrounding ring context (resizes, paints, layout)
+  // that produced the clip — the whole point of capturing it in the wild.
+  const record = {
+    at: now,
+    kind: 'incident',
+    pane,
+    session,
+    reason: 'bottom_clip',
+    detail,
+    context: ringSnapshot().slice(-INCIDENT_CONTEXT_EVENTS),
+  };
+  enqueueWrite('incident', `${JSON.stringify(record)}\n`);
+}
+
+function sweepBottomClip(): void {
+  if (typeof window === 'undefined' || !isEnabled()) {
+    return;
+  }
+  for (const [pane, probeFn] of renderProbes) {
+    let probe: RenderProbe | null = null;
+    try {
+      probe = probeFn();
+    } catch {
+      probe = null;
+    }
+    const wasClipping = clipState.get(pane) ?? false;
+    // Only judge active (visible) panes. An inactive pane legitimately holds the
+    // daemon's geometry until it re-fits on activation, and its container is
+    // display:none (height 0). Clear the flag so a later activation that still
+    // clips re-reports the onset.
+    if (!probe || !probe.active) {
+      if (wasClipping) clipState.set(pane, false);
+      continue;
+    }
+    const overflowPx = bottomClipOverflowPx(probe);
+    if (overflowPx == null) {
+      continue;
+    }
+    const clipping = overflowPx > BOTTOM_CLIP_SLACK_PX;
+    if (clipping === wasClipping) {
+      continue;
+    }
+    clipState.set(pane, clipping);
+    const cellHeight = probe.cellHeight ?? 0;
+    const clientHeight = probe.clientHeight ?? 0;
+    const flooredRows = cellHeight > 0 ? Math.floor(clientHeight / cellHeight) : 0;
+    if (clipping) {
+      recordBottomClipIncident(pane, {
+        rows: probe.rows,
+        cols: probe.cols,
+        flooredRows,
+        extraRows: probe.rows - flooredRows,
+        overflowPx: Math.round(overflowPx),
+        cellHeight,
+        cellWidth: probe.cellWidth ?? null,
+        clientHeight,
+        clientWidth: probe.clientWidth ?? null,
+        hasMeasuredSize: probe.hasMeasuredSize ?? null,
+        isActivePane: probe.isActivePane ?? null,
+        session: probe.session,
+        dpr: window.devicePixelRatio,
+        winInnerWidth: window.innerWidth,
+        winInnerHeight: window.innerHeight,
+      });
+    } else {
+      // The clip cleared (a remount, a window resize that re-fit, or an
+      // activation refit). Record what fixed it so the trail is self-describing.
+      recordDiag({
+        kind: 'incident',
+        pane,
+        session: probe.session,
+        reason: 'bottom_clip_resolved',
+        rows: probe.rows,
+        cols: probe.cols,
+        flooredRows,
+        overflowPx: Math.round(overflowPx),
+        cellHeight,
+        clientHeight,
+      });
+    }
+  }
+}
+
+function ensureClipSweep(): void {
+  if (typeof window === 'undefined' || clipSweepTimer != null) {
+    return;
+  }
+  clipSweepTimer = setInterval(sweepBottomClip, BOTTOM_CLIP_SWEEP_MS);
+}
+
+function stopClipSweepIfIdle(): void {
+  if (clipSweepTimer != null && renderProbes.size === 0) {
+    clearInterval(clipSweepTimer);
+    clipSweepTimer = null;
+  }
+}
+
+// On-demand: snapshot every mounted pane's live geometry, persist it, and (in a
+// console) table it. Useful to inspect the moment the clip is on screen.
+export function dumpTerminalGeometry(): TerminalGeometrySnapshot[] {
+  const snapshots: TerminalGeometrySnapshot[] = [];
+  for (const [pane, probeFn] of renderProbes) {
+    let probe: RenderProbe | null = null;
+    try {
+      probe = probeFn();
+    } catch {
+      probe = null;
+    }
+    if (!probe) {
+      continue;
+    }
+    const cellHeight = probe.cellHeight ?? null;
+    const cellWidth = probe.cellWidth ?? null;
+    const clientHeight = probe.clientHeight ?? null;
+    const clientWidth = probe.clientWidth ?? null;
+    const overflowPx = cellHeight && clientHeight ? probe.rows * cellHeight - clientHeight : null;
+    snapshots.push({
+      pane,
+      session: probe.session,
+      active: probe.active,
+      isActivePane: probe.isActivePane ?? null,
+      hasMeasuredSize: probe.hasMeasuredSize ?? null,
+      cols: probe.cols,
+      rows: probe.rows,
+      cellWidth,
+      cellHeight,
+      clientWidth,
+      clientHeight,
+      flooredCols: cellWidth && clientWidth ? Math.floor(clientWidth / cellWidth) : null,
+      flooredRows: cellHeight && clientHeight ? Math.floor(clientHeight / cellHeight) : null,
+      overflowPx: overflowPx == null ? null : Math.round(overflowPx),
+      clipping: overflowPx != null && overflowPx > BOTTOM_CLIP_SLACK_PX,
+    });
+  }
+  enqueueWrite('incident', `${JSON.stringify({ at: Date.now(), kind: 'geometry_dump', snapshots })}\n`);
+  if (typeof console !== 'undefined' && typeof console.table === 'function') {
+    console.table(snapshots);
+  }
+  return snapshots;
+}
+
 export function disposePaneDiagnostics(pane: string): void {
   clearWatchdog(pane);
   paneHealth.delete(pane);
   renderProbes.delete(pane);
+  clipState.delete(pane);
+  stopClipSweepIfIdle();
 }
 
 ensureGlobals();


### PR DESCRIPTION
## The bug

Under some conditions the **bottom one or two rows of a terminal render outside the pane** — invisible, and unscrollable. It clears on app restart or by cycling the workspace through the warm-set LRU. Non-deterministic, so it felt random.

## Root cause

`isSuspiciousTerminalSize` (`cols <= 20 || rows <= 10`, `terminalDebug.ts`) was used as a **hard gate** in two places:

- `GhosttyTerminal.fit()` — refused to apply the measured size
- `useGhosttyPaneRuntime.handleTerminalResize()` — dropped the resize before it reached the daemon

The guard exists to ignore transient/garbage measurements taken before layout settles. But a **legitimately small** pane (deep stacked splits, a narrow side-by-side split, or a short window) produces a small grid too. Rejecting it left the Ghostty model/canvas at the previous, **larger** size while the container shrank. The wrapper is `overflow:hidden`, so the extra rows paint past the edge and can't be scrolled into view. It only bites once a pane crosses the ≤10-rows / ≤20-cols line — hence the randomness — and a fresh measure (restart / LRU reload) lands on a non-suspicious size and "fixes" it.

## The fix

- **`fitShouldBailAsSuspicious()`** — `fit()` now bails on a suspicious size **only when the model does not already overflow the container**, checked on both axes via the axis-agnostic `geometryOverflowsContainer`. A not-yet-laid-out container (client ≈ 0) can't overflow, so transient garbage is still suppressed; a real small pane gets its corrective fit. Covers the reported bottom-row clip *and* the symmetric right-column clip for very narrow splits.
- **`handleTerminalResize()`** — relaxed to reject only degenerate sizes (`< 1` / non-finite) so the corrective small resize reaches the daemon.
- **Silent detector** (`terminalDiagnosticsLog.ts`) — edge-triggered, records a `bottom_clip` incident to the on-disk diagnostics log when an active pane's canvas overflows its container. It caught this bug in the wild; kept as a prod regression net.

## Verification

A/B against a rebuilt **buggy** binary, driving a full-screen TUI (marks its last row, repaints on `SIGWINCH`) in a 4-pane stacked layout, same ~197px pane:

| build | rows the model uses | container fits | canvas overflow | last row |
|---|---|---|---|---|
| buggy | 11 | ~8 | **+62px** | clipped (rows 9–11 gone) |
| fixed | 8 | ~8 | **−1px** | visible at the pane edge |

Screenshots confirmed the buggy build shows `TOP rows=11` then cuts off before the `BOTTOM` marker, while the fixed build shows `TOP rows=8` … `BOTTOM row=8 <<< MUST BE VISIBLE >>>` at the pane edge.

- Frontend unit suite: **1154 pass**, `tsc` clean
- New regression tests: `fitShouldBailAsSuspicious` (both axes), relaxed `handleTerminalResize`, the bottom-clip detector
