### PR TITLE
feat(tickets): slice 5 — board view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Added
 - **Open and act on a delegated agent's ticket from the app.** Delegated work now has a ticket you can open from its session: see its description, status, full history, and attachments, all updating live as the work moves. From the ticket you can change its status, add a comment, or re-brief the agent — each notifies the agent — and **resume** a stopped session to pick the work back up where it left off. Agents can hand a file to their ticket with `attn ticket attach --file <path>`, and it shows up in the ticket's attachments.
+- **See all your tickets on a board, grouped by status.** A new **ticket board** — open it from the ⌘K command menu — lays out every active ticket in columns (Todo · Working · Blocked · In Review · Done) so you can see at a glance where delegated work stands. Each card shows the title, id, who's on it, and when it last moved; click one to open its full detail. Filter to just what's **blocked**, **in review**, or **closed today**, and finished-bad work (failed or crashed) collects in a Closed lane under Done. The board updates live as agents report progress.
 
 ## [2026-06-26]
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -15,6 +15,7 @@ import { ChiefOfStaffTransferPrompt } from './components/ChiefOfStaffTransferPro
 import { ChangesPanel } from './components/ChangesPanel';
 import { DiffDetailPanel } from './components/DiffDetailPanel';
 import { TicketDetailPanel } from './components/TicketDetailPanel';
+import { TicketBoardPanel } from './components/TicketBoardPanel';
 import { SessionReviewLoopBar } from './components/SessionReviewLoopBar';
 import { WorkflowRunView } from './components/WorkflowRunView';
 import {
@@ -132,6 +133,16 @@ function KeyboardActionIcon() {
     <svg viewBox="0 0 24 24" aria-hidden="true">
       <rect x="3" y="6" width="18" height="12" rx="2" />
       <path d="M7 10h.01M11 10h.01M15 10h.01M8 13.5h8" />
+    </svg>
+  );
+}
+
+function BoardActionIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <rect x="4" y="4" width="4.5" height="16" rx="1" />
+      <rect x="9.75" y="4" width="4.5" height="11" rx="1" />
+      <rect x="15.5" y="4" width="4.5" height="14" rx="1" />
     </svg>
   );
 }
@@ -1311,7 +1322,7 @@ sendFetchPRDetails,
     void connect();
   }, [connect]);
 
-  type DockPanelId = 'diff' | 'reviewLoop' | 'workflowRun' | 'attention' | 'diffDetail' | 'ticketDetail';
+  type DockPanelId = 'diff' | 'reviewLoop' | 'workflowRun' | 'attention' | 'diffDetail' | 'ticketDetail' | 'board';
 
   // Muted section expansion (controlled by Dashboard click)
   const [sidebarMutedExpanded, setSidebarMutedExpanded] = useState(false);
@@ -1329,6 +1340,7 @@ sendFetchPRDetails,
         attention: false,
         diffDetail: false,
         ticketDetail: false,
+        board: false,
     },
     stack: ['diff'],
   });
@@ -1713,6 +1725,7 @@ sendFetchPRDetails,
   const attentionPanelOpen = openDockPanels.attention;
   const diffDetailPanelOpen = openDockPanels.diffDetail;
   const ticketDetailPanelOpen = openDockPanels.ticketDetail;
+  const boardPanelOpen = openDockPanels.board;
   const changesPanelVisible = view === 'session' && diffPanelOpen && Boolean(activeRepoDaemonSession?.directory);
   const blockingOverlayOpen = locationPickerOpen
     || whatsNew.isOpen
@@ -1818,6 +1831,14 @@ sendFetchPRDetails,
       icon: <AttentionActionIcon />,
       shortcut: [shortcutTokens('dock.attention')],
       run: () => openDockPanel('attention'),
+    },
+    {
+      id: 'tickets-board',
+      title: 'Open ticket board',
+      description: 'Tickets grouped by status',
+      keywords: ['ticket', 'board', 'kanban', 'tickets'],
+      icon: <BoardActionIcon />,
+      run: () => openDockPanel('board'),
     },
     {
       id: 'customize-shortcuts',
@@ -3933,6 +3954,20 @@ sendFetchPRDetails,
                   onEditDescription={sendTicketEditDescription}
                   onResume={handleResumeTicket}
                   onClose={handleCloseTicketDetail}
+                />
+              ),
+            },
+            {
+              id: 'board',
+              isOpen: boardPanelOpen,
+              width: 'clamp(560px, 52vw, 880px)',
+              className: 'dock-panel dock-panel--board',
+              children: (
+                <TicketBoardPanel
+                  isOpen={boardPanelOpen}
+                  tickets={tickets}
+                  onOpenTicket={handleOpenTicketDetail}
+                  onClose={() => closeDockPanel('board')}
                 />
               ),
             },

--- a/app/src/components/TicketBoardPanel.css
+++ b/app/src/components/TicketBoardPanel.css
@@ -1,0 +1,398 @@
+/* TicketBoardPanel.css — token-only; no invented hex (only documented #ef4444 fallback
+   for the undefined --color-error token used by the sibling TicketDetailPanel.css).
+   Rhymes with TicketDetailPanel.css: 6px radii, 999px pill badges, uppercase
+   letterspaced labels, mono ids. cursor-blink is the EXISTING keyframes in App.css
+   (.no-sessions::before) — do not redefine it here. */
+
+.tb-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--color-bg-panel);
+  color: var(--color-text-primary);
+}
+
+.tb-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tb-title {
+  margin: 0;
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+/* filter bar — pill toggles in the badge language */
+.tb-filters {
+  display: flex;
+  gap: 6px;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  flex-wrap: wrap;
+}
+
+.tb-filter {
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-button);
+  color: var(--color-text-tertiary);
+  border-radius: 999px;
+  padding: 3px 12px;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.tb-filter:hover {
+  border-color: var(--color-border-hover);
+  color: var(--color-text-secondary);
+}
+
+.tb-filter[aria-checked='true'] {
+  border-color: var(--accent);
+  color: var(--color-text-primary);
+  background: var(--accent-glow);
+}
+
+.tb-filter:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* board track — horizontal scroll when narrow */
+.tb-board {
+  flex: 1;
+  display: flex;
+  gap: 12px;
+  padding: 16px 20px 20px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 0;
+}
+
+.tb-column {
+  flex: 0 0 clamp(220px, 40vw, 248px);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--color-bg-app);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.tb-col-head {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 9px 11px;
+  background: var(--color-bg-panel);
+  border-bottom: 1px solid var(--color-border-subtle);
+  border-top: 2px solid var(--tb-tint, var(--color-border-hover));
+}
+
+.tb-col-label {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--tb-label, var(--color-text-tertiary));
+}
+
+.tb-count {
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+  background: color-mix(in srgb, var(--tb-tint, var(--color-border-hover)) 14%, transparent);
+  border-radius: 999px;
+  padding: 1px 7px;
+  min-width: 18px;
+  text-align: center;
+}
+
+.tb-col-body {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--tb-col-bg, transparent);
+}
+
+/* per-status tint vars set on .tb-column AND .tb-card via [data-status].
+   Only DEFINED tokens (or the documented #ef4444 fallback) — never bare
+   --color-accent / --color-error, which are undefined in App.css. */
+.tb-column[data-status='todo'],
+.tb-card[data-status='todo'] {
+  --tb-rule: var(--color-border-hover);
+  --tb-tint: var(--color-border-hover);
+}
+
+.tb-column[data-status='working'],
+.tb-card[data-status='working'] {
+  --tb-rule: var(--accent);
+  --tb-tint: var(--accent);
+  --tb-label: var(--accent);
+}
+
+.tb-column[data-status='blocked'],
+.tb-card[data-status='blocked'] {
+  --tb-rule: var(--color-error, #ef4444);
+  --tb-tint: color-mix(in srgb, var(--color-error, #ef4444) 70%, var(--accent) 30%);
+}
+
+.tb-column[data-status='in_review'],
+.tb-card[data-status='in_review'] {
+  --tb-rule: var(--color-text-secondary);
+  --tb-tint: color-mix(in srgb, var(--accent) 45%, var(--color-text-tertiary));
+}
+
+.tb-column[data-status='done'] {
+  --tb-rule: var(--color-text-muted);
+  --tb-tint: var(--color-text-muted);
+  --tb-label: var(--color-text-muted);
+  --tb-col-bg: var(--color-bg-app);
+}
+
+.tb-card[data-status='done'] {
+  --tb-rule: var(--color-text-muted);
+}
+
+.tb-card[data-status='failed'],
+.tb-card[data-status='crashed'] {
+  --tb-rule: var(--color-error, #ef4444);
+}
+
+/* card */
+.tb-card {
+  position: relative;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 9px 11px 9px 13px;
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--tb-rule, var(--color-border-hover));
+  border-radius: 6px;
+  background: var(--color-bg-elevated);
+  color: inherit;
+  font: inherit;
+  transition: transform 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.tb-card:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--tb-rule, var(--color-border-hover)) 60%, var(--color-border-hover));
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--tb-rule, var(--color-border-hover)) 12%, transparent);
+}
+
+.tb-card:active {
+  transform: none;
+}
+
+.tb-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.tb-card-title {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.tb-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+  min-width: 0;
+}
+
+.tb-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--tb-rule, var(--color-border-hover));
+  flex: 0 0 auto;
+}
+
+.tb-card-id {
+  font-family: var(--font-mono, monospace);
+  color: var(--color-text-dimmed);
+  flex: 0 0 auto;
+}
+
+.tb-when {
+  margin-left: auto;
+  color: var(--color-text-dimmed);
+  flex: 0 0 auto;
+}
+
+.tb-card-assignee {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* working/blocked at-rest heartbeat */
+.tb-pulse {
+  position: absolute;
+  left: 0;
+  top: 7px;
+  bottom: 7px;
+  width: 2px;
+  border-radius: 2px;
+  background: var(--tb-rule, var(--color-border-hover));
+  opacity: 0.45;
+}
+
+/* closed (terminal-bad) sub-lane inside Done */
+.tb-closed-divider {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-dimmed);
+  padding: 6px 2px 2px;
+  border-top: 1px solid color-mix(in srgb, var(--color-error, #ef4444) 30%, transparent);
+  margin-top: 4px;
+}
+
+.tb-card[data-terminal='bad'] .tb-card-title {
+  color: var(--color-text-secondary);
+}
+
+.tb-card[data-closed-today='true'] {
+  opacity: 0.62;
+}
+
+.tb-card[data-closed-today='true'] .tb-card-title {
+  text-decoration: line-through;
+  text-decoration-color: color-mix(in srgb, var(--color-text-dimmed) 70%, transparent);
+}
+
+/* empty states */
+.tb-col-empty {
+  margin: auto;
+  font-size: var(--font-size-xs);
+  font-style: italic;
+  color: var(--color-text-dimmed);
+  text-align: center;
+  padding: 16px 8px;
+}
+
+.tb-board-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  text-align: center;
+  padding: 24px;
+}
+
+.tb-board-empty::before {
+  content: '>';
+  font-family: var(--font-mono, monospace);
+  font-size: 28px;
+  color: var(--color-text-dimmed);
+  animation: cursor-blink 1s steps(1) infinite;
+}
+
+.tb-show-all {
+  all: unset;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  text-decoration: underline;
+  font-size: var(--font-size-xs);
+}
+
+.tb-show-all:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* entrance — gated behind reduced-motion */
+@media (prefers-reduced-motion: no-preference) {
+  .tb-column {
+    animation: tb-rise 220ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation-delay: calc(var(--col-i, 0) * 60ms);
+  }
+
+  .tb-card {
+    animation: tb-rise 220ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation-delay: calc(var(--card-i, 0) * 28ms + 120ms);
+  }
+
+  .tb-card[data-active='true'] .tb-pulse {
+    animation: tb-pulse 1.8s ease-in-out infinite;
+  }
+
+  @keyframes tb-rise {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  @keyframes tb-pulse {
+    0%,
+    100% {
+      opacity: 0.4;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tb-column,
+  .tb-card {
+    animation: none;
+  }
+
+  .tb-card {
+    transition: none;
+  }
+
+  .tb-card:hover {
+    transform: none;
+  }
+
+  .tb-pulse,
+  .tb-board-empty::before {
+    animation: none;
+  }
+}

--- a/app/src/components/TicketBoardPanel.test.tsx
+++ b/app/src/components/TicketBoardPanel.test.tsx
@@ -1,0 +1,347 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '../test/utils';
+import {
+  TicketBoardPanel,
+  relativeTime,
+  isSameLocalDay,
+  applyFilter,
+  groupTicketsByColumn,
+  STATUS_COLUMNS,
+} from './TicketBoardPanel';
+import type { Ticket } from '../hooks/useDaemonSocket';
+import { TicketStatus } from '../types/generated';
+
+function makeTicket(overrides: Partial<Ticket> = {}): Ticket {
+  return {
+    id: 'tk-1',
+    title: 'A ticket',
+    description: '',
+    status: TicketStatus.Todo,
+    assignee: 'sess-1',
+    cwd: '/repo',
+    last_agent_id: 'codex',
+    project_id: '',
+    created_at: '2026-06-27T10:00:00Z',
+    updated_at: '2026-06-27T10:05:00Z',
+    activity: [],
+    attachments: [],
+    ...overrides,
+  };
+}
+
+/** Find the column <section> for a given status. */
+function column(status: string): HTMLElement {
+  const sections = screen.getAllByTestId('ticket-board-column');
+  const found = sections.find((s) => s.getAttribute('data-status') === status);
+  if (!found) throw new Error(`no column for status ${status}`);
+  return found;
+}
+
+describe('relativeTime', () => {
+  const now = new Date('2026-06-27T12:00:00Z');
+  it('formats seconds, minutes, hours, yesterday, days', () => {
+    expect(relativeTime('2026-06-27T11:59:30Z', now)).toBe('30s');
+    expect(relativeTime('2026-06-27T11:30:00Z', now)).toBe('30m');
+    expect(relativeTime('2026-06-27T09:00:00Z', now)).toBe('3h');
+    expect(relativeTime('2026-06-26T10:00:00Z', now)).toBe('yesterday');
+    expect(relativeTime('2026-06-24T12:00:00Z', now)).toBe('3d');
+  });
+  it('floors sub-second to 1s and returns empty for garbage', () => {
+    expect(relativeTime('2026-06-27T12:00:00Z', now)).toBe('1s');
+    expect(relativeTime('not-a-date', now)).toBe('');
+  });
+});
+
+describe('isSameLocalDay', () => {
+  const now = new Date('2026-06-27T12:00:00Z');
+  it('matches same local day, rejects other days and missing values', () => {
+    // Noon UTC matches `now` (also noon UTC) in every timezone — avoids a
+    // local-date flip that an early-UTC fixture would cause west of UTC.
+    expect(isSameLocalDay('2026-06-27T12:00:00Z', now)).toBe(true);
+    expect(isSameLocalDay('2026-06-25T12:00:00Z', now)).toBe(false);
+    expect(isSameLocalDay(undefined, now)).toBe(false);
+    expect(isSameLocalDay('garbage', now)).toBe(false);
+  });
+});
+
+describe('applyFilter', () => {
+  const now = new Date('2026-06-27T12:00:00Z');
+  const tickets = [
+    makeTicket({ id: 'a', status: TicketStatus.Working }),
+    makeTicket({ id: 'b', status: TicketStatus.Blocked }),
+    makeTicket({ id: 'c', status: TicketStatus.InReview }),
+    makeTicket({ id: 'd', status: TicketStatus.Done, closed_at: '2026-06-27T11:00:00Z' }),
+    makeTicket({ id: 'e', status: TicketStatus.Done, closed_at: '2026-06-20T08:00:00Z' }),
+  ];
+
+  it('all keeps everything', () => {
+    expect(applyFilter(tickets, 'all', now).map((t) => t.id)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+  it('blocked / in_review narrow to status', () => {
+    expect(applyFilter(tickets, 'blocked', now).map((t) => t.id)).toEqual(['b']);
+    expect(applyFilter(tickets, 'in_review', now).map((t) => t.id)).toEqual(['c']);
+  });
+  it('closed_today keeps only tickets closed within today (by closed_at, not updated_at)', () => {
+    expect(applyFilter(tickets, 'closed_today', now).map((t) => t.id)).toEqual(['d']);
+  });
+});
+
+describe('groupTicketsByColumn', () => {
+  it('buckets each status into its flow column preserving order', () => {
+    const newer = makeTicket({ id: 'w-new', status: TicketStatus.Working, created_at: '2026-06-27T11:00:00Z' });
+    const older = makeTicket({ id: 'w-old', status: TicketStatus.Working, created_at: '2026-06-27T09:00:00Z' });
+    const cols = groupTicketsByColumn([newer, older, makeTicket({ id: 't', status: TicketStatus.Todo })]);
+    const working = cols.find((c) => c.status === 'working')!;
+    expect(working.cards.map((t) => t.id)).toEqual(['w-new', 'w-old']); // incoming (created_at desc) order preserved
+    const todo = cols.find((c) => c.status === 'todo')!;
+    expect(todo.cards.map((t) => t.id)).toEqual(['t']);
+  });
+
+  it('folds failed/crashed into the Done column terminalBad lane, not their own column', () => {
+    const cols = groupTicketsByColumn([
+      makeTicket({ id: 'd1', status: TicketStatus.Done }),
+      makeTicket({ id: 'f1', status: TicketStatus.Failed }),
+      makeTicket({ id: 'c1', status: TicketStatus.Crashed }),
+    ]);
+    // Only the five flow columns exist.
+    expect(cols.map((c) => c.status)).toEqual(['todo', 'working', 'blocked', 'in_review', 'done']);
+    const done = cols.find((c) => c.status === 'done')!;
+    expect(done.cards.map((t) => t.id)).toEqual(['d1']);
+    expect(done.terminalBad.map((t) => t.id)).toEqual(['f1', 'c1']);
+  });
+});
+
+describe('TicketBoardPanel', () => {
+  const baseProps = {
+    isOpen: true as const,
+    onOpenTicket: () => {},
+    onClose: () => {},
+  };
+
+  it('renders a column for each flow status with the correct label', () => {
+    render(<TicketBoardPanel {...baseProps} tickets={[makeTicket()]} />);
+    for (const col of STATUS_COLUMNS) {
+      const section = column(col.status);
+      expect(within(section).getByText(col.label)).toBeTruthy();
+    }
+    // no extra columns for failed/crashed
+    expect(screen.getAllByTestId('ticket-board-column')).toHaveLength(5);
+  });
+
+  it('groups a working ticket into Working and not Todo', () => {
+    render(
+      <TicketBoardPanel
+        {...baseProps}
+        tickets={[makeTicket({ id: 'w', status: TicketStatus.Working, title: 'Run it' })]}
+      />,
+    );
+    expect(within(column('working')).getByText('Run it')).toBeTruthy();
+    expect(within(column('todo')).queryByText('Run it')).toBeNull();
+  });
+
+  it('per-column header count reflects the cards shown', () => {
+    render(
+      <TicketBoardPanel
+        {...baseProps}
+        tickets={[
+          makeTicket({ id: 'w1', status: TicketStatus.Working }),
+          makeTicket({ id: 'w2', status: TicketStatus.Working }),
+          makeTicket({ id: 'w3', status: TicketStatus.Working }),
+        ]}
+      />,
+    );
+    expect(within(column('working')).getByTestId('ticket-board-count').textContent).toBe('3');
+    expect(within(column('todo')).getByTestId('ticket-board-count').textContent).toBe('0');
+  });
+
+  it('renders terminal-bad cards under a Closed divider in the Done column with data-terminal=bad', () => {
+    render(
+      <TicketBoardPanel
+        {...baseProps}
+        tickets={[
+          makeTicket({ id: 'd1', status: TicketStatus.Done }),
+          makeTicket({ id: 'f1', status: TicketStatus.Failed }),
+        ]}
+      />,
+    );
+    const done = column('done');
+    expect(within(done).getByTestId('ticket-board-closed-divider')).toBeTruthy();
+    const bad = within(done)
+      .getAllByTestId('ticket-board-card')
+      .find((c) => c.getAttribute('data-ticket-id') === 'f1')!;
+    expect(bad.getAttribute('data-terminal')).toBe('bad');
+  });
+
+  it('shows a split "done · bad" count when terminal-bad exist, single number otherwise', () => {
+    const { rerender } = render(
+      <TicketBoardPanel
+        {...baseProps}
+        tickets={[
+          makeTicket({ id: 'd1', status: TicketStatus.Done }),
+          makeTicket({ id: 'd2', status: TicketStatus.Done }),
+          makeTicket({ id: 'f1', status: TicketStatus.Failed }),
+        ]}
+      />,
+    );
+    expect(within(column('done')).getByTestId('ticket-board-count').textContent).toBe('2 · 1');
+
+    rerender(<TicketBoardPanel {...baseProps} tickets={[makeTicket({ id: 'd1', status: TicketStatus.Done })]} />);
+    expect(within(column('done')).getByTestId('ticket-board-count').textContent).toBe('1');
+  });
+
+  it('preserves incoming (created_at desc) card order within a column', () => {
+    render(
+      <TicketBoardPanel
+        {...baseProps}
+        tickets={[
+          makeTicket({ id: 'newer', status: TicketStatus.Todo, created_at: '2026-06-27T11:00:00Z' }),
+          makeTicket({ id: 'older', status: TicketStatus.Todo, created_at: '2026-06-27T09:00:00Z' }),
+        ]}
+      />,
+    );
+    const ids = within(column('todo'))
+      .getAllByTestId('ticket-board-card')
+      .map((c) => c.getAttribute('data-ticket-id'));
+    expect(ids).toEqual(['newer', 'older']);
+  });
+
+  it('clicking a card calls onOpenTicket exactly once with the ticket id', () => {
+    const onOpenTicket = vi.fn();
+    render(
+      <TicketBoardPanel
+        {...baseProps}
+        onOpenTicket={onOpenTicket}
+        tickets={[makeTicket({ id: 'tk-42', status: TicketStatus.Todo })]}
+      />,
+    );
+    const card = within(column('todo')).getByTestId('ticket-board-card');
+    fireEvent.click(card);
+    expect(onOpenTicket).toHaveBeenCalledTimes(1);
+    expect(onOpenTicket).toHaveBeenCalledWith('tk-42');
+  });
+
+  it('cards are <button type=button> with a descriptive aria-label', () => {
+    render(
+      <TicketBoardPanel
+        {...baseProps}
+        tickets={[makeTicket({ id: 'tk-1', title: 'Wire it up', status: TicketStatus.InReview, assignee: 'sess-9' })]}
+      />,
+    );
+    const card = within(column('in_review')).getByTestId('ticket-board-card');
+    expect(card.tagName).toBe('BUTTON');
+    expect(card.getAttribute('type')).toBe('button');
+    const label = card.getAttribute('aria-label') ?? '';
+    expect(label).toContain('Wire it up');
+    expect(label).toContain('In review');
+    expect(label).toContain('sess-9');
+    expect(label).toContain('Open detail');
+  });
+
+  it('aria-label says "unassigned" when there is no assignee', () => {
+    render(
+      <TicketBoardPanel
+        {...baseProps}
+        tickets={[makeTicket({ id: 'tk-1', status: TicketStatus.Todo, assignee: '' })]}
+      />,
+    );
+    const card = within(column('todo')).getByTestId('ticket-board-card');
+    expect(card.getAttribute('aria-label')).toContain('unassigned');
+  });
+
+  it('filter "Blocked" narrows to blocked and empties the other columns (count 0)', () => {
+    render(
+      <TicketBoardPanel
+        {...baseProps}
+        tickets={[
+          makeTicket({ id: 'b1', status: TicketStatus.Blocked }),
+          makeTicket({ id: 'w1', status: TicketStatus.Working }),
+          makeTicket({ id: 't1', status: TicketStatus.Todo }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('ticket-board-filter-blocked'));
+    expect(within(column('blocked')).getByTestId('ticket-board-count').textContent).toBe('1');
+    expect(within(column('working')).getByTestId('ticket-board-count').textContent).toBe('0');
+    expect(within(column('working')).getByTestId('ticket-board-column-empty')).toBeTruthy();
+    expect(within(column('todo')).getByTestId('ticket-board-count').textContent).toBe('0');
+  });
+
+  it('filter "In review" hides terminal-bad cards (no Closed sub-lane)', () => {
+    render(
+      <TicketBoardPanel
+        {...baseProps}
+        tickets={[
+          makeTicket({ id: 'r1', status: TicketStatus.InReview }),
+          makeTicket({ id: 'f1', status: TicketStatus.Failed }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('ticket-board-filter-in_review'));
+    expect(within(column('in_review')).getByTestId('ticket-board-count').textContent).toBe('1');
+    expect(screen.queryByTestId('ticket-board-closed-divider')).toBeNull();
+  });
+
+  it('the active filter pill carries aria-checked and only one is checked at a time', () => {
+    render(<TicketBoardPanel {...baseProps} tickets={[makeTicket()]} />);
+    const all = screen.getByTestId('ticket-board-filter-all');
+    const blocked = screen.getByTestId('ticket-board-filter-blocked');
+    expect(all.getAttribute('aria-checked')).toBe('true');
+    expect(blocked.getAttribute('aria-checked')).toBe('false');
+    fireEvent.click(blocked);
+    expect(all.getAttribute('aria-checked')).toBe('false');
+    expect(blocked.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('empty board renders the placeholder message and no columns', () => {
+    render(<TicketBoardPanel {...baseProps} tickets={[]} />);
+    expect(screen.getByTestId('ticket-board-empty').textContent).toContain(
+      'No tickets yet — delegate work to populate the board.',
+    );
+    expect(screen.queryByTestId('ticket-board')).toBeNull();
+  });
+
+  it('filter matches nothing but tickets exist: shows the no-match state and "Show all" restores the board', () => {
+    render(
+      <TicketBoardPanel
+        {...baseProps}
+        tickets={[makeTicket({ id: 'open', status: TicketStatus.Working, closed_at: undefined })]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('ticket-board-filter-closed_today'));
+    expect(screen.getByTestId('ticket-board-no-match')).toBeTruthy();
+    expect(screen.queryByTestId('ticket-board-empty')).toBeNull(); // distinct from truly-empty
+
+    fireEvent.click(screen.getByTestId('ticket-board-show-all'));
+    expect(screen.getByTestId('ticket-board')).toBeTruthy();
+    expect(within(column('working')).getByTestId('ticket-board-count').textContent).toBe('1');
+  });
+
+  it('a column with zero matching cards keeps its header and shows a quiet placeholder', () => {
+    render(<TicketBoardPanel {...baseProps} tickets={[makeTicket({ status: TicketStatus.Working })]} />);
+    const todo = column('todo');
+    expect(within(todo).getByText('Todo')).toBeTruthy();
+    expect(within(todo).getByTestId('ticket-board-count').textContent).toBe('0');
+    expect(within(todo).getByTestId('ticket-board-column-empty')).toBeTruthy();
+  });
+
+  it('mounts read-only with only the four contract props (no mutation handlers)', () => {
+    const { container } = render(
+      <TicketBoardPanel isOpen tickets={[makeTicket()]} onOpenTicket={() => {}} onClose={() => {}} />,
+    );
+    expect(container.querySelector('[data-testid="ticket-board-panel"]')).toBeTruthy();
+  });
+
+  it('isOpen=false renders nothing', () => {
+    const { container } = render(
+      <TicketBoardPanel isOpen={false} tickets={[makeTicket()]} onOpenTicket={() => {}} onClose={() => {}} />,
+    );
+    expect(container.querySelector('[data-testid="ticket-board-panel"]')).toBeNull();
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<TicketBoardPanel {...baseProps} onClose={onClose} tickets={[makeTicket()]} />);
+    fireEvent.click(screen.getByLabelText('Close board'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/TicketBoardPanel.tsx
+++ b/app/src/components/TicketBoardPanel.tsx
@@ -1,0 +1,290 @@
+import { useMemo, useState } from 'react';
+import type { Ticket } from '../hooks/useDaemonSocket';
+import { TicketStatus } from '../types/generated';
+import './TicketBoardPanel.css';
+
+export type BoardFilter = 'all' | 'blocked' | 'in_review' | 'closed_today';
+
+type TicketStatusValue = Ticket['status'];
+
+/** Statuses that own a flow column (terminal-bad statuses do not — they fold into Done). */
+type FlowStatus =
+  | TicketStatus.Todo
+  | TicketStatus.Working
+  | TicketStatus.Blocked
+  | TicketStatus.InReview
+  | TicketStatus.Done;
+
+/**
+ * Single source of truth for the flow columns and their order. Reordering or
+ * relabeling a column is a one-line edit here. Terminal-bad statuses (failed,
+ * crashed) deliberately have NO column — they fold into the Done column as a
+ * "Closed" sub-lane (see groupTicketsByColumn / the Done render branch).
+ */
+export const STATUS_COLUMNS: ReadonlyArray<{
+  status: FlowStatus;
+  label: string;
+  empty: string;
+}> = [
+  { status: TicketStatus.Todo, label: 'Todo', empty: 'Nothing here' },
+  { status: TicketStatus.Working, label: 'Working', empty: 'Nothing here' },
+  { status: TicketStatus.Blocked, label: 'Blocked', empty: 'None blocked' },
+  { status: TicketStatus.InReview, label: 'In review', empty: 'Nothing in review' },
+  { status: TicketStatus.Done, label: 'Done', empty: 'Nothing here' },
+];
+
+/** Statuses that fold into the Done column's CLOSED sub-lane. */
+export const TERMINAL_BAD_STATUSES: ReadonlyArray<TicketStatusValue> = [
+  TicketStatus.Failed,
+  TicketStatus.Crashed,
+];
+
+export const STATUS_LABEL: Record<TicketStatusValue, string> = {
+  [TicketStatus.Todo]: 'Todo',
+  [TicketStatus.Working]: 'Working',
+  [TicketStatus.Blocked]: 'Blocked',
+  [TicketStatus.InReview]: 'In review',
+  [TicketStatus.Done]: 'Done',
+  [TicketStatus.Failed]: 'Failed',
+  [TicketStatus.Crashed]: 'Crashed',
+};
+
+export const FILTERS: ReadonlyArray<{ id: BoardFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'blocked', label: 'Blocked' },
+  { id: 'in_review', label: 'In review' },
+  { id: 'closed_today', label: 'Closed today' },
+];
+
+/** True when `iso` falls on the same local calendar day as `now`. */
+export function isSameLocalDay(iso: string | undefined, now: Date = new Date()): boolean {
+  if (!iso) return false;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return false;
+  return (
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  );
+}
+
+/**
+ * Compact, deterministic relative time. `now` is injectable for tests.
+ * now/Ns/Nm/Nh/yesterday/Nd.
+ */
+export function relativeTime(iso: string, now: Date = new Date()): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return '';
+  const seconds = Math.max(0, (now.getTime() - t) / 1000);
+  if (seconds < 60) return `${Math.floor(seconds) || 1}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  if (seconds < 172800) return 'yesterday';
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+/** Narrow the ticket set per the active filter BEFORE bucketing, so per-column counts reflect what is shown. */
+export function applyFilter(tickets: Ticket[], filter: BoardFilter, now: Date = new Date()): Ticket[] {
+  return (tickets ?? []).filter((t) => {
+    if (filter === 'blocked') return t.status === 'blocked';
+    if (filter === 'in_review') return t.status === 'in_review';
+    if (filter === 'closed_today') return isSameLocalDay(t.closed_at, now);
+    return true;
+  });
+}
+
+export interface BoardColumnData {
+  status: (typeof STATUS_COLUMNS)[number]['status'];
+  label: string;
+  empty: string;
+  /** Cards for this column's own status, preserving incoming order (created_at desc). */
+  cards: Ticket[];
+  /** Only populated for the Done column: terminal-bad tickets in the CLOSED sub-lane. */
+  terminalBad: Ticket[];
+}
+
+/**
+ * Bucket already-filtered tickets into the flow columns. Terminal-bad tickets
+ * are attached to the Done column's `terminalBad` lane rather than getting a
+ * column of their own. Pure and side-effect free.
+ */
+export function groupTicketsByColumn(visible: Ticket[]): BoardColumnData[] {
+  const terminalBad = visible.filter((t) => TERMINAL_BAD_STATUSES.includes(t.status));
+  return STATUS_COLUMNS.map((col) => ({
+    status: col.status,
+    label: col.label,
+    empty: col.empty,
+    cards: visible.filter((t) => t.status === col.status),
+    terminalBad: col.status === 'done' ? terminalBad : [],
+  }));
+}
+
+export interface TicketBoardPanelProps {
+  isOpen: boolean;
+  /** useDaemonStore().tickets — non-archived, created_at desc. Read-only. */
+  tickets: Ticket[];
+  /** App.tsx: setSelectedTicketId(id) + openDockPanel('ticketDetail'). */
+  onOpenTicket: (ticketId: string) => void;
+  /** closeDockPanel('board'). */
+  onClose: () => void;
+}
+
+export function TicketBoardPanel({ isOpen, tickets = [], onOpenTicket, onClose }: TicketBoardPanelProps) {
+  const [filter, setFilter] = useState<BoardFilter>('all');
+
+  const visible = useMemo(() => applyFilter(tickets, filter), [tickets, filter]);
+  const columns = useMemo(() => groupTicketsByColumn(visible), [visible]);
+
+  if (!isOpen) return null;
+
+  const boardEmpty = tickets.length === 0; // truly empty, filter-independent
+  const noMatch = !boardEmpty && visible.length === 0; // filter matched nothing
+
+  return (
+    <div className="tb-panel" data-testid="ticket-board-panel">
+      <div className="tb-header">
+        <h2 className="tb-title">Board</h2>
+        <button
+          type="button"
+          className="ticket-detail-close"
+          onClick={onClose}
+          aria-label="Close board"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="tb-filters" role="radiogroup" aria-label="Filter tickets">
+        {FILTERS.map((f) => (
+          <button
+            key={f.id}
+            type="button"
+            role="radio"
+            aria-checked={filter === f.id}
+            className="tb-filter"
+            data-testid={`ticket-board-filter-${f.id}`}
+            onClick={() => setFilter(f.id)}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {boardEmpty ? (
+        <div className="tb-board-empty" data-testid="ticket-board-empty">
+          No tickets yet — delegate work to populate the board.
+        </div>
+      ) : noMatch ? (
+        <div className="tb-board-empty" data-testid="ticket-board-no-match">
+          No tickets match this filter.
+          <button
+            type="button"
+            className="tb-show-all"
+            data-testid="ticket-board-show-all"
+            onClick={() => setFilter('all')}
+          >
+            Show all
+          </button>
+        </div>
+      ) : (
+        <div className="tb-board" data-testid="ticket-board">
+          {columns.map((col, colI) => {
+            const badCount = col.terminalBad.length;
+            const headCount =
+              col.status === 'done' && badCount > 0
+                ? `${col.cards.length} · ${badCount}`
+                : `${col.cards.length}`;
+            const showColEmpty = col.cards.length === 0 && badCount === 0;
+            return (
+              <section
+                key={col.status}
+                className="tb-column"
+                data-testid="ticket-board-column"
+                data-status={col.status}
+                style={{ ['--col-i' as string]: colI }}
+                aria-label={`${col.label} (${col.cards.length + badCount})`}
+              >
+                <header className="tb-col-head">
+                  <span className="tb-col-label">{col.label}</span>
+                  <span className="tb-count" data-testid="ticket-board-count">
+                    {headCount}
+                  </span>
+                </header>
+                <div className="tb-col-body">
+                  {showColEmpty ? (
+                    <p className="tb-col-empty" data-testid="ticket-board-column-empty">
+                      {col.empty}
+                    </p>
+                  ) : (
+                    <>
+                      {col.cards.map((t, i) => (
+                        <BoardCard key={t.id} ticket={t} index={i} onOpen={onOpenTicket} />
+                      ))}
+                      {col.status === 'done' && badCount > 0 && (
+                        <>
+                          <div className="tb-closed-divider" data-testid="ticket-board-closed-divider">
+                            Closed
+                          </div>
+                          {col.terminalBad.map((t, i) => (
+                            <BoardCard
+                              key={t.id}
+                              ticket={t}
+                              index={col.cards.length + i}
+                              onOpen={onOpenTicket}
+                              terminalBad
+                            />
+                          ))}
+                        </>
+                      )}
+                    </>
+                  )}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface BoardCardProps {
+  ticket: Ticket;
+  index: number;
+  onOpen: (ticketId: string) => void;
+  terminalBad?: boolean;
+}
+
+function BoardCard({ ticket, index, onOpen, terminalBad }: BoardCardProps) {
+  const when = relativeTime(ticket.updated_at);
+  const active = ticket.status === 'working' || ticket.status === 'blocked';
+  const closedToday = isSameLocalDay(ticket.closed_at);
+  return (
+    <button
+      type="button"
+      className="tb-card"
+      data-testid="ticket-board-card"
+      data-ticket-id={ticket.id}
+      data-status={ticket.status}
+      data-terminal={terminalBad ? 'bad' : undefined}
+      data-active={active ? 'true' : undefined}
+      data-closed-today={closedToday ? 'true' : undefined}
+      style={{ ['--card-i' as string]: Math.min(index, 7) }}
+      onClick={() => onOpen(ticket.id)}
+      aria-label={`${ticket.title}, ${STATUS_LABEL[ticket.status] ?? ticket.status}, ${
+        ticket.assignee || 'unassigned'
+      }, updated ${when}. Open detail.`}
+    >
+      {active && <span className="tb-pulse" aria-hidden="true" />}
+      <span className="tb-card-title">{ticket.title}</span>
+      <span className="tb-card-meta">
+        <span className="tb-dot" aria-hidden="true" />
+        <span className="tb-card-id">{ticket.id}</span>
+        <span className="tb-when" title={new Date(ticket.updated_at).toLocaleString()}>
+          {when}
+        </span>
+      </span>
+      {ticket.assignee && <span className="tb-card-assignee">@{ticket.assignee}</span>}
+    </button>
+  );
+}

--- a/docs/plans/2026-06-26-work-tracker.md
+++ b/docs/plans/2026-06-26-work-tracker.md
@@ -237,11 +237,11 @@ each is a meaningful, verifiable chunk.
 
 | # | slice | status |
 |---|---|---|
-| 1 | Ticket store + lifecycle | 🟡 |
-| 2 | Event-driven notification core | 🟡 |
-| 3 | Delegation ⇄ tickets (live wiring) | 🟡 (sub-split — see `2026-06-26-work-tracker-slice3.md`) |
-| 4 | Ticket view + resume + attachments | ⬜ |
-| 5 | Board view | ⬜ |
+| 1 | Ticket store + lifecycle | ✅ |
+| 2 | Event-driven notification core | ✅ |
+| 3 | Delegation ⇄ tickets (live wiring) | ✅ (sub-split — see `2026-06-26-work-tracker-slice3.md`) |
+| 4 | Ticket view + resume + attachments | ✅ (sub-split — see `2026-06-26-work-tracker-slice4.md`) |
+| 5 | Board view | ✅ (status columns + Todo backlog + filters; read-only awareness surface, opened from ⌘K) |
 | 6 | Codex nudge path | ⬜ |
 | 7 | Retire the `dispatch` namespace | ⬜ |
 | 8 | Export ticket state (CLI) — *post-merge, lands on `main`* | ⬜ |


### PR DESCRIPTION
## Slice 5 — Board view

Grows the proto-board into a real **status-column board**: a new read-only right-dock panel (open from **⌘K → "Open ticket board"**) that groups the chief's tickets into flow columns and lets you filter at a glance.

Closes slice 5 of `docs/plans/2026-06-26-work-tracker.md`.

### What it does
- **Five flow columns** — Todo · Working · Blocked · In Review · Done — mapping the status enum to spatial position, with the **Todo backlog** included and live per-column counts.
- **Terminal-bad** work (`failed` / `crashed`) folds into a **Closed sub-lane under Done** (Done count shows `done · bad` when present) — visible but distinct, keeping the scan to five columns.
- **Filters:** All · Blocked · In Review · **Closed today** (by `closed_at`, local day). A distinct "no tickets match" state with a *Show all* reset, separate from the truly-empty board.
- **Cards** show title, mono id, assignee, status accent, and relative time; the whole card is a `<button>` that opens the existing **TicketDetailPanel** (the Dashboard "View ticket" path). Working/Blocked cards carry a quiet at-rest heartbeat; closed-today cards get a struck/dimmed treatment.

### Design
Built with `/frontend-design` polish, cohesive with attn's dark terminal aesthetic and `TicketDetailPanel`: **token-only** colors (light/dark safe), status-tinted sticky column headers, hover lift + colored shadow, focus-visible rings, a blinking `>` empty state reusing the app's `cursor-blink`, and full `prefers-reduced-motion` handling. Authored via a multi-agent design→judge→implement→verify→review workflow (mixed opus/sonnet).

### Scope / spine
- **Frontend-only.** Reads the existing `tickets` store (`initial_state` + `tickets_updated` broadcast). **No daemon command, no protocol change, no `ProtocolVersion` bump.**
- **Awareness, not autonomy** — the board *informs*, never *gates*: no drag-to-mutate; status changes stay in the detail panel or are self-reported by agents. The panel takes only `{ isOpen, tickets, onOpenTicket, onClose }` (no mutation handlers).

### Tests
- 26 new unit tests (grouping, per-column counts, each filter, terminal-bad lane, a11y labels, empty / no-match states).
- Full suite green locally: **`tsc` clean, 1195 tests pass.**

### Note (out of scope — flagged for follow-up)
This work surfaced a **pre-existing bug**: `TicketDetailPanel.css` references bare `var(--color-error)` / `var(--color-accent)`, but those tokens **aren't defined in `App.css`** — so the detail panel's blocked/failed/working status colors are silently no-ops in the real app. The board defends against it (uses `var(--color-error, #ef4444)` with a fallback). A small follow-up should define `--color-accent` / `--color-error` in `App.css` (and drop the board's fallbacks).