### PR TITLE
feat(tickets): formalize self-monitor as an agent capability (slice 6)

### DIFF
--- a/docs/plans/2026-06-26-work-tracker.md
+++ b/docs/plans/2026-06-26-work-tracker.md
@@ -242,7 +242,7 @@ each is a meaningful, verifiable chunk.
 | 3 | Delegation ⇄ tickets (live wiring) | ✅ (sub-split — see `2026-06-26-work-tracker-slice3.md`) |
 | 4 | Ticket view + resume + attachments | ✅ (sub-split — see `2026-06-26-work-tracker-slice4.md`) |
 | 5 | Board view | ✅ (status columns + Todo backlog + filters; read-only awareness surface, opened from ⌘K) |
-| 6 | Codex nudge path | ⬜ |
+| 6 | Codex nudge path | ✅ (self-monitor formalized as an `agent.Capabilities` flag; daemon resolves it from the driver registry; pure `ticketnotify` + end-to-end codex-nudge roundtrip test) |
 | 7 | Retire the `dispatch` namespace | ⬜ |
 | 8 | Export ticket state (CLI) — *post-merge, lands on `main`* | ⬜ |
 

--- a/internal/agent/capabilities_self_monitor_test.go
+++ b/internal/agent/capabilities_self_monitor_test.go
@@ -1,0 +1,16 @@
+package agent
+
+import "testing"
+
+// The agent->self-monitor mapping that used to live as a magic string in
+// internal/ticketnotify (HasSelfMonitor("claude")) is now a driver capability.
+// This is its home: only Claude self-monitors today; codex (and the rest, which
+// rely on the zero value) take the idle-nudge path.
+func TestCapabilitiesSelfMonitor(t *testing.T) {
+	if !MustGet("claude").Capabilities().HasSelfMonitor {
+		t.Fatal("claude should self-monitor (watch its own ticket stream)")
+	}
+	if MustGet("codex").Capabilities().HasSelfMonitor {
+		t.Fatal("codex should not self-monitor (it is pty-nudged when idle)")
+	}
+}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -65,6 +65,7 @@ func (c *Claude) Capabilities() Capabilities {
 		HasYolo:              true,
 		HasInitialPrompt:     true,
 		HasWorkspaceContext:  true,
+		HasSelfMonitor:       true,
 	}
 }
 

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -55,6 +55,8 @@ func (c *Codex) Capabilities() Capabilities {
 		HasYolo:             true,
 		HasInitialPrompt:    true,
 		HasWorkspaceContext: true,
+		// HasSelfMonitor: false — codex has no live ticket Monitor, so it is
+		// pty-nudged when ticket activity arrives while it is idle.
 	}
 }
 

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -117,6 +117,13 @@ type Capabilities struct {
 	// HasWorkspaceContext indicates attn can give the agent hidden launch
 	// instructions for using a workspace context checkout.
 	HasWorkspaceContext bool
+
+	// HasSelfMonitor indicates the agent watches its own ticket/event stream via
+	// a live Monitor (true push) rather than needing an idle PTY nudge when ticket
+	// activity arrives. Consumed by the work-tracker notifier (internal/ticketnotify)
+	// to pick DeliveryWatch (self-monitor) vs DeliveryNudge (idle pty-nudge). Only
+	// Claude self-monitors today.
+	HasSelfMonitor bool
 }
 
 var capabilityEnvNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9]+`)
@@ -134,6 +141,7 @@ var capabilityEnvNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9]+`)
 //   - ATTN_AGENT_<AGENT>_YOLO=0|1
 //   - ATTN_AGENT_<AGENT>_INITIAL_PROMPT=0|1
 //   - ATTN_AGENT_<AGENT>_WORKSPACE_CONTEXT=0|1
+//   - ATTN_AGENT_<AGENT>_SELF_MONITOR=0|1
 //
 // <AGENT> is uppercased with non-alphanumeric chars replaced by underscores
 // (e.g. "gemini-cli" -> "GEMINI_CLI").
@@ -173,6 +181,9 @@ func EffectiveCapabilities(d Driver) Capabilities {
 	}
 	if v, ok := boolEnv(prefix + "WORKSPACE_CONTEXT"); ok {
 		caps.HasWorkspaceContext = v
+	}
+	if v, ok := boolEnv(prefix + "SELF_MONITOR"); ok {
+		caps.HasSelfMonitor = v
 	}
 
 	// Consistency: transcript watcher requires transcript support.

--- a/internal/daemon/ticket_notify_test.go
+++ b/internal/daemon/ticket_notify_test.go
@@ -88,6 +88,54 @@ func TestNotifyDoesNotNudgeClaudeObserver(t *testing.T) {
 	}
 }
 
+// Full slice-6 roundtrip: a real chief producer (the human commenting on the
+// agent's bound ticket via handleTicketAddComment) drives notifyTicketObservers,
+// which nudges the idle codex agent (DeliveryNudge, because the codex driver's
+// HasSelfMonitor capability is false, resolved through ticketObserverForSession).
+// The agent then runs `attn ticket inbox`, consumes the chief's event, and a
+// second inbox is empty because the cursor advanced — proving it consumed, not
+// peeked. No real codex binary or PTY: the fake spawn backend captures the doorbell.
+func TestCodexNudgeRoundtrip(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	_, agentID, inputs := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, agentID)
+	d.store.UpdateState(agentID, protocol.StateIdle)
+
+	// Drive a REAL chief→agent producer: the human comments on the codex agent's
+	// ticket, authored as "you" — an event the agent did not author, so it is unread.
+	client := &wsClient{send: make(chan outboundMessage, 8)}
+	d.handleTicketAddComment(client, &protocol.TicketAddCommentMessage{
+		Cmd:      protocol.CmdTicketAddComment,
+		TicketID: ticketID,
+		Comment:  "please take a look at the failing test",
+	})
+
+	// 1) The idle codex agent was nudged by the chief's comment on its ticket.
+	if !wasNudged(inputs(agentID)) {
+		t.Fatal("idle codex agent was not nudged on chief ticket comment")
+	}
+
+	// 2) Consume side: the agent's inbox carries the chief's comment on its ticket.
+	bundles := callTicketInbox(t, d, agentID)
+	if len(bundles) == 0 {
+		t.Fatal("codex inbox returned no bundles after nudge")
+	}
+	found := false
+	for _, b := range bundles {
+		if b.TicketID == ticketID && len(b.Events) > 0 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("inbox missing chief event on ticket %s: %+v", ticketID, bundles)
+	}
+
+	// 3) Cursor advanced: a second consume is empty (consumed, not peeked).
+	if again := callTicketInbox(t, d, agentID); len(again) != 0 {
+		t.Fatalf("second inbox not empty, cursor did not advance: %+v", again)
+	}
+}
+
 // A busy codex agent is deferred — no doorbell mid-task — then gets it the moment
 // it goes idle, which is what notifyTicketSessionWentIdle flushes.
 func TestNotifyDefersBusyCodexThenFlushesOnIdle(t *testing.T) {

--- a/internal/daemon/ticket_read.go
+++ b/internal/daemon/ticket_read.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 	"github.com/victorarias/attn/internal/ticketnotify"
@@ -15,14 +16,18 @@ import (
 // is uniform: every session — the chief included — observes as its own session id,
 // the same string it authors events with, so involvement (assignee or author) and
 // the self-author exclusion line up. The literal ticketnotify.ObserverChief is only
-// the slice-2 harness placeholder; real wiring keys off the live session. The agent
-// decides the delivery path (Claude self-monitors; codex is nudged).
+// the slice-2 harness placeholder; real wiring keys off the live session. The
+// delivery path comes from the session's agent driver capability
+// (agent.Capabilities.HasSelfMonitor, resolved via the registry): Claude
+// self-monitors and watches; codex and the rest are nudged. An empty/unknown agent
+// resolves to nil → Capabilities{} → false, the safe nudge default.
 func (d *Daemon) ticketObserverForSession(sessionID string) ticketnotify.Observer {
-	agent := ""
+	agentName := ""
 	if s := d.store.Get(sessionID); s != nil {
-		agent = s.Agent
+		agentName = s.Agent
 	}
-	return ticketnotify.AgentObserver(sessionID, agent)
+	selfMonitor := agentdriver.EffectiveCapabilities(agentdriver.Get(agentName)).HasSelfMonitor
+	return ticketnotify.Observer{ID: sessionID, HasSelfMonitor: selfMonitor}
 }
 
 // handleTicketInbox returns the calling session's unread ticket events, bundled by

--- a/internal/ticketnotify/harness_test.go
+++ b/internal/ticketnotify/harness_test.go
@@ -193,15 +193,11 @@ func TestHarnessDedup(t *testing.T) {
 func TestHarnessNudgePath(t *testing.T) {
 	h := newHarness(t)
 
-	// A codex agent can't self-monitor; a Claude agent can.
-	codex := AgentObserver("codexbot", "codex")
-	claude := AgentObserver("agent7", "claude")
-	if codex.HasSelfMonitor {
-		t.Fatal("codex should not self-monitor")
-	}
-	if !claude.HasSelfMonitor {
-		t.Fatal("claude should self-monitor")
-	}
+	// A codex agent can't self-monitor; a Claude agent can. The agent->capability
+	// mapping now lives on the agent driver (internal/agent); here the bool is given
+	// explicitly, which is more honest for this pure package.
+	codex := Observer{ID: "codexbot", HasSelfMonitor: false}
+	claude := Observer{ID: "agent7", HasSelfMonitor: true}
 
 	h.create("alpha", "codexbot", ObserverChief)
 	h.create("beta", "agent7", ObserverChief)
@@ -256,7 +252,7 @@ func TestHarnessNudgePath(t *testing.T) {
 func TestHarnessAgentScopeAndSelfAuthored(t *testing.T) {
 	h := newHarness(t)
 	chief := ChiefObserver()
-	agent7 := AgentObserver("agent7", "claude")
+	agent7 := Observer{ID: "agent7", HasSelfMonitor: true}
 
 	h.create("alpha", "agent7", ObserverChief) // assigned to agent7
 	h.create("beta", "agent9", ObserverChief)  // assigned to someone else
@@ -308,7 +304,7 @@ func TestHarnessAgentScopeAndSelfAuthored(t *testing.T) {
 // silently skipped.
 func TestHarnessLateAssignmentDeliversContext(t *testing.T) {
 	h := newHarness(t)
-	agent7 := AgentObserver("agent7", "claude")
+	agent7 := Observer{ID: "agent7", HasSelfMonitor: true}
 
 	// agent7 has prior work it already consumed — its bookmark on "early" is advanced.
 	h.create("early", "agent7", ObserverChief)
@@ -357,7 +353,7 @@ func TestHarnessLateAssignmentDeliversContext(t *testing.T) {
 // assignee's progress, so the new agent picks up with full context.
 func TestHarnessReassignmentHandsOverHistory(t *testing.T) {
 	h := newHarness(t)
-	agent9 := AgentObserver("agent9", "claude")
+	agent9 := Observer{ID: "agent9", HasSelfMonitor: true}
 
 	// agent7 works a ticket and reports progress.
 	h.create("handoff", "agent7", ObserverChief)

--- a/internal/ticketnotify/notify.go
+++ b/internal/ticketnotify/notify.go
@@ -31,7 +31,6 @@ package ticketnotify
 
 import (
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/victorarias/attn/internal/store"
@@ -57,28 +56,19 @@ type EventStore interface {
 
 // Observer is a subscriber to ticket events. ID is ObserverChief or an agent's
 // session id. HasSelfMonitor picks the delivery path: a self-monitoring agent's
-// own watch consumes; others are nudged when idle.
+// own watch consumes; others are nudged when idle. The caller supplies the bool —
+// this package stays pure and knows nothing about agent types; the daemon reads it
+// from the agent driver's capability (internal/agent.Capabilities.HasSelfMonitor).
 type Observer struct {
 	ID             string
 	HasSelfMonitor bool
 }
 
-// ChiefObserver returns the well-known chief observer. The chief is a Claude
-// session, so it self-monitors.
+// ChiefObserver returns the well-known chief observer. Harness/test-only: the live
+// chief is built from its real agent via the daemon, like any other session. The
+// chief is a self-monitoring session here, so it watches rather than is nudged.
 func ChiefObserver() Observer {
 	return Observer{ID: ObserverChief, HasSelfMonitor: true}
-}
-
-// AgentObserver returns an observer for a delegated agent session.
-func AgentObserver(sessionID, agent string) Observer {
-	return Observer{ID: sessionID, HasSelfMonitor: HasSelfMonitor(agent)}
-}
-
-// HasSelfMonitor reports whether an agent can watch its own events (true push via
-// a Monitor) or must be polled/nudged. Only Claude self-monitors today; codex and
-// the rest fall back to the idle nudge — matching the vision's split.
-func HasSelfMonitor(agent string) bool {
-	return strings.EqualFold(strings.TrimSpace(agent), "claude")
 }
 
 // Bundle is an observer's unread events for a single ticket. Consume returns one

--- a/internal/ticketnotify/notify_edge_test.go
+++ b/internal/ticketnotify/notify_edge_test.go
@@ -40,7 +40,7 @@ func (e erroringStore) SetTicketCursor(string, string, int64, time.Time) error {
 
 func TestNotifyNudgeError(t *testing.T) {
 	h := newHarness(t)
-	codex := AgentObserver("codexbot", "codex")
+	codex := Observer{ID: "codexbot", HasSelfMonitor: false}
 	h.create("alpha", "codexbot", ObserverChief)
 	h.comment("alpha", ObserverChief, "steer")
 


### PR DESCRIPTION
## Slice 6 — Codex nudge path

The nudge engine itself shipped in slices 3d/4c (idle non-Claude agents get a fixed-trigger PTY doorbell on ticket activity; Claude self-monitors via its live watch). This slice closes the two genuine gaps the plan called for: **formalizing the self-monitor decision** and **an end-to-end roundtrip test**.

### What changed

**The self-monitor decision now lives where agent capabilities live.** It used to be a magic string buried in the *pure* `ticketnotify` package — `HasSelfMonitor(agent)` matching `"claude"`. That's agent-type knowledge `ticketnotify` shouldn't own. It moves to a `HasSelfMonitor bool` on `internal/agent.Capabilities` (alongside `HasHooks`, `HasResume`, …), set `true` only in `Claude.Capabilities()`; codex and the rest take the zero-value `false` → idle nudge.

- **Daemon resolves it from the registry.** `ticketObserverForSession` now reads `agent.EffectiveCapabilities(agent.Get(name)).HasSelfMonitor` and builds the `ticketnotify.Observer` directly. Unknown/empty agent → `EffectiveCapabilities(nil)` → `Capabilities{}` → `false`, the safe nudge default. The daemon already imports `internal/agent`, so **no new import cycle**.
- **`ticketnotify` stays pure.** Retired `AgentObserver` + `HasSelfMonitor(string)` (the magic string and its only wrapper), dropped the now-unused `strings` import. `Observer{ID, HasSelfMonitor bool}`, `Notify`/`Consume`, and the harness-only `ChiefObserver` are untouched.
- **Env-override parity:** `ATTN_AGENT_<AGENT>_SELF_MONITOR=0|1`, matching every other capability field.

**Net runtime behavior is byte-identical** (claude → `DeliveryWatch`, codex → `DeliveryNudge`). Only the capability's *home* changes — and it becomes discoverable on the driver instead of hidden in a string compare.

### Tests
- `TestCapabilitiesSelfMonitor` (internal/agent) — pins the agent→bool mapping in its new home (claude true, codex false).
- `TestCodexNudgeRoundtrip` (internal/daemon) — the slice's end-to-end coverage: a **real chief→agent producer** (human comments on the idle codex agent's bound ticket via `handleTicketAddComment`) fires `notifyTicketObservers` → the codex agent is nudged (`DeliveryNudge`, capability resolved through `ticketObserverForSession`) → it consumes the event via the inbox path → a second inbox is empty, proving the cursor advanced (consumed, not peeked). No real codex binary or PTY — the fake spawn backend captures the doorbell.
- Existing `ticketnotify` harness tests now construct observers with explicit `HasSelfMonitor` bools — more honest for a pure package.

### Notes
- No protocol change / no `ProtocolVersion` bump — the capability is internal Go, not on the wire.
- No CHANGELOG entry — internal refactor of where the capability lives + test; the user-visible nudge behavior already shipped.
- Built with the ultracode workflow (design panel → judge → implement → verify → adversarial review, mixed opus/sonnet). `go build ./...` clean; `internal/agent`, `internal/ticketnotify`, `internal/daemon` ticket/notify tests green. Reviewers returned ship / fix-then-ship (the one finding — stage the untracked agent test — is included here).

Part of the tickets work-tracker epic (`docs/plans/2026-06-26-work-tracker.md`). Targets `feat/tickets`.