### PR TITLE
feat(attn-skill): add prompting pointer to capability index

### DIFF
--- a/internal/agent/attn_skill/SKILL.md
+++ b/internal/agent/attn_skill/SKILL.md
@@ -40,6 +40,8 @@ If a command reports an unknown subcommand or shows another tool's help, check
   [references/markdown.md](references/markdown.md).
 - **Operate attn's persistent browser tile:** read
   [references/browser.md](references/browser.md).
+- **Write, review, or improve a system prompt, agent guidance, or skill
+  instruction:** load the `prompting` skill before starting.
 
 Load more than one reference only when the task actually combines capabilities.
 


### PR DESCRIPTION
## Summary

Adds a capability index entry to the attn skill pointing at the `prompting` skill for any work that involves writing, reviewing, or improving a system prompt, agent guidance, or skill instruction.

Previously the chief had no signal to load the prompting skill when working on prompt design — it would load the chief-of-staff reference but skip prompting even when the task was explicitly about improving injected guidance.

## Test plan

- [ ] Trigger a chief session to improve a system prompt and confirm it loads the `prompting` skill before starting