### PR TITLE
feat(settings): UI for auto-approve + per-agent chief model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-29]
+
+### Added
+- **Run agents unattended, and pin your chief's model.** Settings › Agents adds two controls. **Auto-approve** launches managed agents in their native auto-approve mode so they keep working without stopping at every permission prompt — off by default, and yolo sessions already bypass approvals regardless. **Chief-of-staff model** pins the model a chief-of-staff session launches with, per agent (Claude or Codex); leave it blank to use the agent's own default. Both apply to sessions started afterward.
+
 ## [2026-06-28]
 
 ### Added

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -855,3 +855,97 @@ describe('SettingsModal keeper', () => {
     expect(onSetSetting).toHaveBeenCalledWith('notebook.narrate_workspace', '');
   });
 });
+
+describe('SettingsModal chief settings', () => {
+  function renderModal(
+    settings: Record<string, string>,
+    onSetSetting = vi.fn(),
+  ) {
+    render(
+      <SettingsModal
+        isOpen
+        onClose={vi.fn()}
+        mutedRepos={[]}
+        githubHosts={[]}
+        onUnmuteRepo={vi.fn()}
+        mutedAuthors={[]}
+        onUnmuteAuthor={vi.fn()}
+        settings={{
+          claude_available: 'true',
+          codex_available: 'true',
+          ...settings,
+        }}
+        endpoints={[]}
+        plugins={[]}
+        pluginIssues={[]}
+        onAddEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onUpdateEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onRemoveEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onSetEndpointRemoteWeb={vi.fn().mockResolvedValue({ success: true })}
+        onListPlugins={vi.fn().mockResolvedValue({ plugins: [], issues: [] })}
+        onInstallPlugin={vi.fn().mockResolvedValue({ success: true })}
+        onRemovePlugin={vi.fn().mockResolvedValue({ success: true })}
+        onSetPluginPriority={vi.fn().mockResolvedValue({ success: true })}
+        onSetSetting={onSetSetting}
+        themePreference="system"
+        onSetTheme={vi.fn()}
+      />,
+    );
+    return onSetSetting;
+  }
+
+  it('enables auto-approve when off', async () => {
+    const onSetSetting = renderModal({ auto_approve_enabled: 'false' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const toggle = await screen.findByTestId('settings-auto-approve-toggle');
+    expect(toggle).toHaveTextContent('Enable');
+    fireEvent.click(toggle);
+    expect(onSetSetting).toHaveBeenCalledWith('auto_approve_enabled', 'true');
+  });
+
+  it('disables auto-approve when on', async () => {
+    const onSetSetting = renderModal({ auto_approve_enabled: 'true' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const toggle = await screen.findByTestId('settings-auto-approve-toggle');
+    expect(toggle).toHaveTextContent('Disable');
+    fireEvent.click(toggle);
+    expect(onSetSetting).toHaveBeenCalledWith('auto_approve_enabled', 'false');
+  });
+
+  it('renders a chief-model input per supported agent and commits a typed model on blur', async () => {
+    const onSetSetting = renderModal({});
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    // claude and codex each get a row; copilot does not (its launch ignores --model).
+    const claudeInput = await screen.findByTestId('settings-chief-model-claude');
+    expect(screen.getByTestId('settings-chief-model-codex')).toBeInTheDocument();
+    expect(screen.queryByTestId('settings-chief-model-copilot')).toBeNull();
+
+    fireEvent.change(claudeInput, { target: { value: 'opus' } });
+    fireEvent.blur(claudeInput);
+    expect(onSetSetting).toHaveBeenCalledWith('chief_model_claude', 'opus');
+  });
+
+  it('does not write when a chief-model input blurs unchanged', async () => {
+    const onSetSetting = renderModal({ chief_model_claude: 'opus' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const claudeInput = await screen.findByTestId('settings-chief-model-claude');
+    expect(claudeInput).toHaveValue('opus');
+    fireEvent.blur(claudeInput);
+    expect(onSetSetting).not.toHaveBeenCalledWith('chief_model_claude', expect.anything());
+  });
+
+  it('clears a chief-model override back to the agent default', async () => {
+    const onSetSetting = renderModal({ chief_model_codex: 'gpt-5.4' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const codexInput = await screen.findByTestId('settings-chief-model-codex');
+    expect(codexInput).toHaveValue('gpt-5.4');
+    fireEvent.change(codexInput, { target: { value: '' } });
+    fireEvent.blur(codexInput);
+    expect(onSetSetting).toHaveBeenCalledWith('chief_model_codex', '');
+  });
+});

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -138,6 +138,9 @@ export function SettingsModal({
   const [projectsDir, setProjectsDir] = useState(settings.projects_directory || '');
   const [notebookRoot, setNotebookRoot] = useState(settings['notebook.root'] || '');
   const [agentExecutables, setAgentExecutables] = useState<Record<SessionAgent, string>>({});
+  // Per-agent chief-of-staff model override (chief_model_<agent>), edited locally
+  // and committed on blur like the executable paths. Blank => the agent default.
+  const [chiefModels, setChiefModels] = useState<Record<SessionAgent, string>>({});
   const [editorExecutable, setEditorExecutable] = useState(settings.editor_executable || '');
   const [defaultAgent, setDefaultAgent] = useState<SessionAgent>('claude');
   const [reviewLoopPresets, setReviewLoopPresets] = useState<ReviewLoopPreset[]>([]);
@@ -181,6 +184,7 @@ export function SettingsModal({
   const effectiveNotebookRoot = settings['notebook.root.effective'] || '';
   const tailscaleEnabled = (settings.tailscale_enabled || 'false') === 'true';
   const workflowsEnabled = (settings.workflows_enabled || 'false') === 'true';
+  const autoApproveEnabled = (settings.auto_approve_enabled || 'false') === 'true';
   const tailscaleStatus = settings.tailscale_status || 'disabled';
   const tailscaleURL = settings.tailscale_url || '';
   const tailscaleDomain = settings.tailscale_domain || '';
@@ -223,6 +227,27 @@ export function SettingsModal({
     () => orderedAgentList.filter((agent) => ['codex', 'claude', 'copilot'].includes(agent)),
     [orderedAgentList],
   );
+  // Agents whose chief launch honors a --model override (claude, codex). Installed
+  // agents only, plus any agent that already has a saved override so its row stays
+  // visible even if it became unavailable — mirrors keeperAgents re-inclusion.
+  const chiefModelAgentList = useMemo(() => {
+    const list = orderedAgentList.filter((agent) => (
+      ['codex', 'claude'].includes(agent) && isAgentAvailable(agentAvailability, agent)
+    ));
+    for (const agent of ['claude', 'codex'] as const) {
+      if (!list.includes(agent) && (settings[`chief_model_${agent}`] || '').trim() !== '') {
+        list.push(agent);
+      }
+    }
+    return list;
+  }, [orderedAgentList, agentAvailability, settings]);
+  const actualChiefModels = useMemo(() => {
+    const out = {} as Record<SessionAgent, string>;
+    for (const agent of chiefModelAgentList) {
+      out[agent] = settings[`chief_model_${agent}`] || '';
+    }
+    return out;
+  }, [settings, chiefModelAgentList]);
   // Agents eligible to run any keeper duty: installed, headless-task capable, and one
   // of claude/codex. Any agent already configured on a duty is kept in the list even
   // if it has since become unavailable, so its row still shows the saved selection.
@@ -267,6 +292,7 @@ export function SettingsModal({
     setProjectsDir(actualProjectsDir);
     setNotebookRoot(actualNotebookRoot);
     setAgentExecutables(actualAgentExecutables);
+    setChiefModels(actualChiefModels);
     setEditorExecutable(actualEditorExecutable);
     setDefaultAgent(resolvedDefaultAgent);
     setReviewLoopPresets(actualReviewLoopPresets);
@@ -291,7 +317,7 @@ export function SettingsModal({
     setPluginSourcePath('');
     setPluginError(null);
     setPluginActionName(null);
-  }, [isOpen, actualProjectsDir, actualNotebookRoot, actualAgentExecutables, actualEditorExecutable, resolvedDefaultAgent, actualReviewLoopPresets, actualReviewLoopModel, actualReviewerModel, actualKeeperConfigs, keeperAgents]);
+  }, [isOpen, actualProjectsDir, actualNotebookRoot, actualAgentExecutables, actualChiefModels, actualEditorExecutable, resolvedDefaultAgent, actualReviewLoopPresets, actualReviewLoopModel, actualReviewerModel, actualKeeperConfigs, keeperAgents]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -392,6 +418,22 @@ export function SettingsModal({
       onSetSetting(`${agent}_executable`, nextValue);
     }
   }, [actualAgentExecutables, agentExecutables, onSetSetting]);
+
+  const handleChiefModelChange = useCallback((agent: SessionAgent, value: string) => {
+    setChiefModels((prev) => ({ ...prev, [agent]: value }));
+  }, []);
+
+  const commitChiefModel = useCallback((agent: SessionAgent) => {
+    const nextValue = (chiefModels[agent] || '').trim();
+    const currentValue = (actualChiefModels[agent] || '').trim();
+    if (nextValue !== currentValue) {
+      onSetSetting(`chief_model_${agent}`, nextValue);
+    }
+  }, [actualChiefModels, chiefModels, onSetSetting]);
+
+  const handleToggleAutoApprove = useCallback(() => {
+    onSetSetting('auto_approve_enabled', autoApproveEnabled ? 'false' : 'true');
+  }, [autoApproveEnabled, onSetSetting]);
 
   const handleEditorChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setEditorExecutable(e.target.value);
@@ -793,8 +835,8 @@ export function SettingsModal({
           label: 'Executables and defaults',
           title: 'Agent runtime',
           description: 'Agent executable paths, defaults, context maintenance, capabilities, and PTY runtime mode.',
-          count: orderedAgentList.length + 4,
-          keywords: 'agents executables claude codex cursor default capabilities pty backend editor context keeper compact model',
+          count: orderedAgentList.length + 6,
+          keywords: 'agents executables claude codex cursor default capabilities pty backend editor context keeper compact model workflows auto-approve unattended chief',
         },
       ],
     },
@@ -1704,6 +1746,85 @@ export function SettingsModal({
               {workflowsEnabled ? 'Disable' : 'Enable'}
             </button>
           </div>
+        </div>
+      </section>
+
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Agents</div>
+          <h3>Auto-approve</h3>
+          <p className="settings-description">
+            Launches managed agents in their native auto-approve mode (Claude
+            "--permission-mode auto", Codex auto-review) so they can run unattended
+            without stopping at every permission gate. Off by default.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          <div className="settings-row-card">
+            <div>
+              <p className="settings-row-title">Run agents unattended</p>
+              <p className="settings-row-copy">
+                While off, agents pause for approval on sensitive actions. Yolo sessions
+                already bypass approvals and ignore this setting. Changing it only affects
+                sessions launched afterward.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="settings-action"
+              data-testid="settings-auto-approve-toggle"
+              onClick={handleToggleAutoApprove}
+            >
+              {autoApproveEnabled ? 'Disable' : 'Enable'}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section className="settings-block">
+        <div className="settings-block-intro">
+          <div className="settings-kicker">Agents</div>
+          <h3>Chief-of-staff model</h3>
+          <p className="settings-description">
+            Pins the model a chief-of-staff session launches with, per agent. Leave blank
+            to use the agent's own default. Only applies to chief launches — regular
+            sessions are unaffected.
+          </p>
+        </div>
+        <div className="settings-block-body">
+          {chiefModelAgentList.length === 0 ? (
+            <div className="settings-warning">No installed agent supports a model override.</div>
+          ) : (
+            <div className="settings-field-grid">
+              {chiefModelAgentList.map((agent) => {
+                const inputId = `settings-chief-model-${agent}`;
+                const value = chiefModels[agent] || '';
+                return (
+                  <div className="settings-field" key={agent}>
+                    <label className="settings-label" htmlFor={inputId}>{agentLabel(agent)}</label>
+                    <input
+                      id={inputId}
+                      data-testid={inputId}
+                      type="text"
+                      value={value}
+                      onChange={(e) => handleChiefModelChange(agent, e.target.value)}
+                      onBlur={() => commitChiefModel(agent)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          commitChiefModel(agent);
+                        }
+                      }}
+                      placeholder={agent === 'claude' ? 'opus — blank for default' : 'gpt-5.4 — blank for default'}
+                      className="settings-input"
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      spellCheck={false}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       </section>
 

--- a/docs/plans/2026-06-28-delegated-ticket-awareness.md
+++ b/docs/plans/2026-06-28-delegated-ticket-awareness.md
@@ -277,13 +277,13 @@ so the env hop is what runs). Both default off/empty; yolo overrides auto-approv
   run unattended without stalling on approval gates. Env hop `ATTN_AUTO_APPROVE`.
   - [x] setting + validation (ws_settings.go); ws_pty + reload read; worker.go env; cmd/attn read; SpawnOpts field; claude `--permission-mode auto`; codex `approval_policy`+`approvals_reviewer`
   - [x] codex combo confirmed vs [official docs](https://developers.openai.com/codex/concepts/sandboxing/auto-review): `approvals_reviewer = "auto_review"` requires `approval_policy = "on-request"` (or a granular interactive policy) — exactly the pairing we wire; it routes escalations to a reviewer agent (the reviewer can still deny). Keys are NOT surfaced in `codex --help`/`review --help`/`doctor`, so CLI introspection can't find them — trust the docs (`approval_policy` is separately visible via `codex doctor` → "approval policy OnRequest"). Benchmark: codex ran unattended through the scenario; the reviewer didn't visibly fire in panes (nothing needed approval under the sandbox) — expected, config is correct.
-  - [ ] SettingsModal UI toggle + unit tests
+  - [x] SettingsModal UI toggle + unit tests (Settings › Agents › Auto-approve; mirrors the workflows toggle)
 - **`chief_model_<agent>`** (per-agent string, chief-gated) → `--model <alias>` (e.g.
   `opus`). Empty = agent default. Env hop `ATTN_CHIEF_MODEL`; read only for chief
   launches (`chiefLaunchModel`).
   - [x] setting + validation; ws_pty chief-gated read; worker.go env; cmd/attn read; SpawnOpts field; claude + codex `--model`
-  - [ ] SettingsModal UI toggle (per-agent) + unit tests
-- [ ] **CHANGELOG** entry covering both new settings
+  - [x] SettingsModal UI (per-agent text input, claude+codex only, commit-on-blur, blank=default) + unit tests. Free-form text input over a preset dropdown: the backend is explicitly free-form, and a Default/preset/Custom select hits a snap-back trap (Default and empty-Custom both map to ""). Mirrors the per-agent executable-path inputs.
+- [x] **CHANGELOG** entry covering both new settings (2026-06-29)
 - Real-app gotcha: the source-fingerprint guard compares the app bundle's baked
   fingerprint (`get_state.appBuild`) against the working tree, so Go/frontend edits
   need a full `make install PROFILE=uat`; harness scripts are excluded (edit + re-run


### PR DESCRIPTION
## What

Surfaces the two benchmark-support daemon settings shipped in #436 in **Settings › Agents**. Until now they were wired through the daemon but had no UI — reachable only by poking daemon settings directly. This is the deferred SettingsModal slice from the [delegated-ticket-awareness plan](docs/plans/2026-06-28-delegated-ticket-awareness.md) (lines 280/285/286).

- **Auto-approve** — a global toggle that mirrors the existing Workflows toggle exactly. Launches managed agents in their native auto-approve mode (Claude `--permission-mode auto`, Codex auto-review) so they run unattended without stopping at every permission gate. Off by default; yolo sessions already bypass approvals and ignore it.
- **Chief-of-staff model** — a per-agent text input for `chief_model_<agent>`, shown for **claude and codex only** (the drivers whose `BuildCommand` honors `opts.Model`; copilot ignores it). Committed on blur, blank = the agent's own default. Only affects chief launches.

## Design notes

- **Free-form text input, not a preset dropdown.** The backend validation is explicitly free-form ("accept any value and let the agent reject bad ones"). A Default/preset/Custom `<select>` walks into a snap-back trap — "Default" and "Custom-before-typing" both correspond to an empty model string, so the select can't be derived from the committed value without extra local mode state. A plain per-agent input (mirroring the existing executable-path inputs) is faithful to the free-form backend, sidesteps the trap, and dodges stale curated aliases.
- **No protocol change / no version bump** — settings ride the generic `Record<string>` map; the daemon already normalizes and ships these keys.
- Availability-gated like the rest of the modal, with saved-value re-inclusion (a configured agent stays visible even if it becomes unavailable — mirrors `keeperAgents`).
- Bumps the Agents nav badge (`+4` → `+6`) for the two new blocks.

## Verification

- `tsc --noEmit` clean.
- Full vitest suite green (1210 tests), including 5 new `SettingsModal chief settings` cases: both toggle directions for auto-approve; chief-model renders per supported agent (and **not** copilot); commit-on-blur of a typed model; no spurious write when unchanged; clear-back-to-default.
- Desktop `settings-visual` Playwright e2e renders both new sections in a real browser; confirmed the chief-model section shows only claude + codex while copilot is available elsewhere in the modal.

https://claude.ai/code/session_01NcbKHZbprd36hdtAdJCZbN