### PR TITLE
fix(tickets): stop delegated agents self-nudging about their own brief

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Run agents unattended, and pin your chief's model.** Settings › Agents adds two controls. **Auto-approve** launches managed agents in their native auto-approve mode so they keep working without stopping at every permission prompt — off by default, and yolo sessions already bypass approvals regardless. **Chief-of-staff model** pins the model a chief-of-staff session launches with, per agent (Claude or Codex); leave it blank to use the agent's own default. Both apply to sessions started afterward.
 
+### Fixed
+- **Delegated agents no longer nudge themselves about their own brief.** A freshly delegated agent already receives its brief when it starts, so it no longer gets a spurious "new ticket activity — check your inbox" prompt about that same brief the moment it goes idle. Agents are now only nudged about genuine new activity on their own ticket (a steer, or a status change they didn't make).
+
 ## [2026-06-28]
 
 ### Added

--- a/internal/daemon/ticket_notify_test.go
+++ b/internal/daemon/ticket_notify_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -61,6 +62,48 @@ func makeSelfMonitor(t *testing.T, d *Daemon, sessionID string) {
 	d.store.Add(s)
 }
 
+// delegateMany sets up ONE chief of staff and delegates an agent per brief from it,
+// modeling a chief that fanned work out to a batch of siblings. It returns the chief
+// id, the spawned agent ids (brief order), and an accessor for inputs typed into a
+// session's PTY. Like delegateForNotify, the brief is delivered via the spawn prompt
+// file — never Input — so any recorded input is a nudge.
+func delegateMany(t *testing.T, d *Daemon, agent string, briefs ...string) (chiefID string, agentIDs []string, inputs func(string) []string) {
+	t.Helper()
+	backend := &fakeSpawnBackend{}
+	var mu sync.Mutex
+	rec := map[string][]string{}
+	backend.onInput = func(id string, data []byte) {
+		mu.Lock()
+		rec[id] = append(rec[id], string(data))
+		mu.Unlock()
+	}
+	_, chiefID, _ = setupDelegationSource(t, d, backend)
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, chiefID); err != nil {
+		t.Fatalf("set chief role: %v", err)
+	}
+	consumeDelegatedPrompt(t, backend)
+	for i, brief := range briefs {
+		// Distinct labels: same-workspace siblings can't share an auto-derived name.
+		result, err := d.delegate(&protocol.DelegateMessage{
+			Cmd:             protocol.CmdDelegate,
+			SourceSessionID: chiefID,
+			Brief:           brief,
+			Agent:           protocol.Ptr(agent),
+			Label:           protocol.Ptr(fmt.Sprintf("delegate-%d", i)),
+		})
+		if err != nil {
+			t.Fatalf("delegate(%d, %q): %v", i, brief, err)
+		}
+		agentIDs = append(agentIDs, result.SessionID)
+	}
+	inputs = func(id string) []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), rec[id]...)
+	}
+	return chiefID, agentIDs, inputs
+}
+
 func wasNudged(inputs []string) bool {
 	for _, in := range inputs {
 		if strings.Contains(in, ticketNudgePrompt) {
@@ -71,26 +114,27 @@ func wasNudged(inputs []string) bool {
 }
 
 // An idle agent that can't self-monitor (codex) gets the fixed doorbell when an
-// event it did not author is unread (here its own assignment, authored by the
-// chief). The chief, which authored that event, is never nudged about it.
+// event it did not author is unread — here a chief steer on its ticket. Its own
+// brief is delivered via the spawn prompt and pre-consumed at delegation, so it is
+// never the trigger (see TestDelegatedAgentNotNudgedByOwnDeliveredBrief).
 func TestNotifyNudgesIdleCodexObserver(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	chiefID, agentID, inputs := delegateForNotify(t, d, "codex")
+	_, agentID, inputs := delegateForNotify(t, d, "codex")
 	ticketID := boundTicketID(t, d, agentID)
 	d.store.UpdateState(agentID, protocol.StateIdle)
 
-	d.notifyTicketObservers(ticketID)
+	// A chief steer lands on the agent's ticket — an event it did not author.
+	commentOnTicket(t, d, ticketID, "take a look at the failing test")
 
 	if !wasNudged(inputs(agentID)) {
-		t.Fatal("idle codex agent was not nudged about its unread event")
-	}
-	if wasNudged(inputs(chiefID)) {
-		t.Fatal("chief was nudged about an event it authored")
+		t.Fatal("idle codex agent was not nudged about the chief steer on its ticket")
 	}
 }
 
-// A self-monitoring agent (claude) is never typed into — its own watch drains the
-// queue (DeliveryWatch), so the doorbell would be a redundant interruption.
+// A self-monitoring agent (claude) is never typed into synchronously even with unread
+// activity — its own watch drains the queue (DeliveryWatch), so the doorbell would be
+// a redundant interruption. A real chief steer supplies the unread event (the brief is
+// pre-consumed at delegation, so without a steer there would be nothing to decide on).
 func TestNotifyDoesNotNudgeClaudeObserver(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	t.Cleanup(d.stopTicketBackstops) // idle self-monitor schedules a deferred backstop
@@ -98,7 +142,7 @@ func TestNotifyDoesNotNudgeClaudeObserver(t *testing.T) {
 	ticketID := boundTicketID(t, d, agentID)
 	d.store.UpdateState(agentID, protocol.StateIdle)
 
-	d.notifyTicketObservers(ticketID)
+	commentOnTicket(t, d, ticketID, "one more thing")
 
 	if wasNudged(inputs(agentID)) {
 		t.Fatal("self-monitoring claude agent should not be typed into synchronously")
@@ -154,14 +198,15 @@ func TestCodexNudgeRoundtrip(t *testing.T) {
 }
 
 // A busy codex agent is deferred — no doorbell mid-task — then gets it the moment
-// it goes idle, which is what notifyTicketSessionWentIdle flushes.
+// it goes idle, which is what notifyTicketSessionWentIdle flushes. A real chief steer
+// landing while the agent is busy supplies the unread event.
 func TestNotifyDefersBusyCodexThenFlushesOnIdle(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	_, agentID, inputs := delegateForNotify(t, d, "codex")
 	ticketID := boundTicketID(t, d, agentID)
 	d.store.UpdateState(agentID, protocol.StateWorking)
 
-	d.notifyTicketObservers(ticketID)
+	commentOnTicket(t, d, ticketID, "take a look") // lands mid-task -> deferred
 	if wasNudged(inputs(agentID)) {
 		t.Fatal("busy codex agent was nudged mid-task")
 	}
@@ -170,6 +215,55 @@ func TestNotifyDefersBusyCodexThenFlushesOnIdle(t *testing.T) {
 	d.notifyTicketSessionWentIdle(agentID)
 	if !wasNudged(inputs(agentID)) {
 		t.Fatal("deferred nudge was not flushed when the agent went idle")
+	}
+}
+
+// A chief that fans work out to siblings must not cross-wire their doorbells: when
+// one delegate reports a status change, only that ticket's participants (the agent
+// and the chief) are notified — the OTHER delegates are neither assignee nor author
+// on it, so the event never routes to them. This locks the store-level isolation
+// that makes "agent A is nudged about ticket C" impossible by construction.
+func TestDelegatedSiblingsNotNudgedByEachOther(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(d.stopTicketBackstops)
+	_, agents, inputs := delegateMany(t, d, "codex", "Task A", "Task B", "Task C")
+	a, b, c := agents[0], agents[1], agents[2]
+	for _, id := range agents {
+		d.store.UpdateState(id, protocol.StateIdle)
+	}
+
+	// Delegate C reports done — an event on ticket C only.
+	callSetTicketStatus(t, d, c, string(protocol.DispatchWorkStateCompleted), "done")
+
+	if wasNudged(inputs(a)) {
+		t.Fatal("sibling A was nudged by C's status change (cross-ticket leak)")
+	}
+	if wasNudged(inputs(b)) {
+		t.Fatal("sibling B was nudged by C's status change (cross-ticket leak)")
+	}
+}
+
+// The real symptom behind "everyone gets nudged": a delegated agent already has its
+// brief (delivered via the spawn prompt), but the chief-authored `created` event
+// stays unread on the agent's OWN ticket because nothing advances its cursor at
+// delegation. So the moment the agent goes idle, the went-idle flush doorbells it
+// about a brief it already holds. Batch delegation makes the siblings settle around
+// the same time, which reads as "C finishing nudged the whole batch" — but each is
+// only ever self-nudging about its own ticket. The fix marks the brief consumed for
+// the assignee at creation, so nothing is unread and no doorbell fires.
+func TestDelegatedAgentNotNudgedByOwnDeliveredBrief(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(d.stopTicketBackstops)
+	_, agents, inputs := delegateMany(t, d, "codex", "Task A")
+	a := agents[0]
+	d.store.UpdateState(a, protocol.StateIdle)
+
+	// The agent settles after its initial run; the went-idle path re-runs the notify
+	// decision for it. With the brief consumed at delegation, there is nothing unread.
+	d.notifyTicketSessionWentIdle(a)
+
+	if wasNudged(inputs(a)) {
+		t.Fatal("delegated agent was doorbelled about its own already-delivered brief")
 	}
 }
 

--- a/internal/daemon/ticket_read_test.go
+++ b/internal/daemon/ticket_read_test.go
@@ -34,10 +34,11 @@ func callTicketInbox(t *testing.T, d *Daemon, sessionID string) []protocol.Ticke
 	return resp.TicketInboxResult.Bundles
 }
 
-// The inbox is a consume keyed on observer identity: the agent sees the
-// chief-authored events on its ticket (its assignment, later steers) but never its
-// own; the chief sees the agent's reports but never its own; and a second read is
-// empty because the first advanced the cursor.
+// The inbox is a consume keyed on observer identity: a delegated agent's brief is
+// delivered via the spawn prompt and pre-consumed at delegation, so its inbox starts
+// EMPTY rather than echoing the assignment it already holds; it then sees later
+// chief steers but never its own events; the chief sees the agent's reports but never
+// its own; and a second read is empty because the first advanced the cursor.
 func TestTicketInboxConsumesByIdentity(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
@@ -58,16 +59,20 @@ func TestTicketInboxConsumesByIdentity(t *testing.T) {
 	agentSession := result.SessionID
 	ticketID := boundTicketID(t, d, agentSession)
 
-	// Agent's first read: the chief-authored created event (its assignment).
-	bundles := callTicketInbox(t, d, agentSession)
-	if len(bundles) != 1 || bundles[0].TicketID != ticketID {
-		t.Fatalf("agent inbox = %+v, want one bundle for %q", bundles, ticketID)
+	// Agent's first read is empty: the brief was delivered out of band via the spawn
+	// prompt, so the created event is pre-consumed and never re-served as inbox noise.
+	if bundles := callTicketInbox(t, d, agentSession); len(bundles) != 0 {
+		t.Fatalf("agent inbox = %+v, want empty (brief delivered via spawn prompt)", bundles)
 	}
-	if len(bundles[0].Events) != 1 || bundles[0].Events[0].Kind != protocol.TicketEventKind(store.TicketEventCreated) {
-		t.Fatalf("agent inbox events = %+v, want one created event", bundles[0].Events)
+
+	// A later chief steer DOES reach the agent: an event it did not author, unread.
+	commentOnTicket(t, d, ticketID, "one more thing to check")
+	steer := callTicketInbox(t, d, agentSession)
+	if len(steer) != 1 || steer[0].TicketID != ticketID {
+		t.Fatalf("agent inbox after steer = %+v, want one bundle for %q", steer, ticketID)
 	}
-	if bundles[0].Events[0].Author != chiefSessionID {
-		t.Fatalf("created event author = %q, want chief %q", bundles[0].Events[0].Author, chiefSessionID)
+	if len(steer[0].Events) != 1 || steer[0].Events[0].Kind != protocol.TicketEventKind(store.TicketEventCommented) {
+		t.Fatalf("agent inbox events = %+v, want one commented event", steer[0].Events)
 	}
 
 	// Second read: empty — the first consume advanced the agent's cursor.

--- a/internal/store/ticket_events.go
+++ b/internal/store/ticket_events.go
@@ -335,7 +335,21 @@ func (s *Store) SetTicketCursor(identity, ticketID string, cursor int64, now tim
 	if s.db == nil {
 		return nil
 	}
-	_, err := s.db.Exec(`
+	return setTicketCursorTx(s.db, identity, ticketID, cursor, now)
+}
+
+// ticketExecer is the Exec surface shared by *sql.DB and *sql.Tx, so a cursor write
+// can run either standalone or inside an enclosing mutation's transaction (e.g. the
+// delegation create that marks an agent's brief consumed atomically with the ticket).
+type ticketExecer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+// setTicketCursorTx is the monotonic cursor write. It only moves the cursor FORWARD
+// (MAX of stored and proposed), so a stale or overlapping write can never rewind a
+// cursor and resurrect already-consumed events as unread.
+func setTicketCursorTx(ex ticketExecer, identity, ticketID string, cursor int64, now time.Time) error {
+	_, err := ex.Exec(`
 		INSERT INTO ticket_event_cursors (identity, ticket_id, cursor, updated_at)
 		VALUES (?, ?, ?, ?)
 		ON CONFLICT(identity, ticket_id) DO UPDATE SET

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -244,13 +244,31 @@ func (s *Store) CreateTicket(t Ticket, author string, now time.Time) (*Ticket, e
 	); err != nil {
 		return nil, err
 	}
-	if _, _, err := appendTicketEventTx(tx, TicketEvent{
+	createdSeq, _, err := appendTicketEventTx(tx, TicketEvent{
 		TicketID: t.ID,
 		Kind:     TicketEventCreated,
 		Author:   author,
 		ToStatus: t.Status,
-	}, now); err != nil {
+	}, now)
+	if err != nil {
 		return nil, err
+	}
+	// A ticket born WITH an assignee is a chief delegation: the brief was already
+	// handed to that agent out of band via the spawn prompt, so mark the `created`
+	// event consumed for the assignee. Otherwise it lingers unread on the agent's
+	// OWN ticket and doorbells it the moment it goes idle — a self-nudge about a
+	// brief it already holds. A backlog ticket is born unassigned, so a later pickup
+	// still receives the full brief through `attn ticket inbox`.
+	//
+	// This is a DELEGATION policy living in generic store code: it holds only because
+	// delegation is the sole create path that sets an assignee at birth (backlog
+	// create is unbound). A future "create a pre-assigned ticket whose brief SHOULD
+	// arrive via the inbox" would silently lose its brief here — move this guard up to
+	// the delegation caller if that case ever appears.
+	if t.Assignee != "" {
+		if err := setTicketCursorTx(tx, t.Assignee, t.ID, createdSeq, now); err != nil {
+			return nil, err
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

Victor noticed delegated agents getting nudged ("📋 New ticket activity — run `attn ticket inbox`") when they shouldn't. Diagnosis traced two distinct things:

- **The cross-ticket routing leak he suspected does not exist.** The store query scopes an agent strictly to `tickets WHERE assignee = me UNION tickets I authored on`, with self-authored events excluded. A sibling working on ticket A is never a participant of ticket C, so C's completion can't route to A. Proven by `TestDelegatedSiblingsNotNudgedByEachOther`.
- **A real self-nudge bug.** A chief delegation delivers the brief into the agent's PTY as its spawn prompt, but it *also* lands as a chief-authored `created` event on the agent's own ticket — and nothing marked it consumed. So every delegated agent carried one permanently-unread event on its own ticket and got doorbelled about it the moment it went idle (codex immediately, Claude via the 8s backstop): a "check your inbox" pointing at a brief it already holds.

## Fix

In `store.CreateTicket`, a ticket born *with* an assignee (only delegation sets one at birth — backlog tickets are unbound) advances that assignee's cursor past the `created` event in the same transaction. The brief is delivered out of band, so it's never re-served as inbox noise or a doorbell. A backlog ticket picked up later stays unassigned at birth, so its brief still arrives via `attn ticket inbox`.

## Tests

- `TestDelegatedAgentNotNudgedByOwnDeliveredBrief` — red→green repro of the self-nudge.
- `TestDelegatedSiblingsNotNudgedByEachOther` — locks store-level sibling isolation.
- Three existing tests had used the unread brief as their fixture; they now drive a real chief steer instead.
- Full Go suite green.

## Note

The brief-self-nudge fires when each agent goes idle on its own schedule, not causally when a sibling completes. If A/B still appear pinged *at the moment a sibling finishes*, that's the chief's `--watch` Monitor waking it to steer them — expected behavior, separate from this fix.

https://claude.ai/code/session_01NcbKHZbprd36hdtAdJCZbN