### PR TITLE
feat(delegate): non-chief agents confirm before completing a ticket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Run agents unattended, and pin your chief's model.** Settings › Agents adds two controls. **Auto-approve** launches managed agents in their native auto-approve mode so they keep working without stopping at every permission prompt — off by default, and yolo sessions already bypass approvals regardless. **Chief-of-staff model** pins the model a chief-of-staff session launches with, per agent (Claude or Codex); leave it blank to use the agent's own default. Both apply to sessions started afterward.
 
+### Changed
+- **Delegated agents confirm with you before completing a ticket.** A delegated agent now treats closing its ticket as your call: when it believes the work is done it asks you to confirm and waits for your go-ahead before reporting `completed`, instead of closing the ticket on its own. It still reports the other states (in progress, needs input, ready for review, failed) as they happen.
+
 ### Fixed
 - **Delegated agents no longer nudge themselves about their own brief.** A freshly delegated agent already receives its brief when it starts, so it no longer gets a spurious "new ticket activity — check your inbox" prompt about that same brief the moment it goes idle. Agents are now only nudged about genuine new activity on their own ticket (a steer, or a status change they didn't make).
 

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -431,7 +431,12 @@ Use the state that matches the outcome when work needs input, is ready, or ends:
     "$ATTN_WRAPPER_PATH" ticket status completed --comment "<completed outcome>"
     "$ATTN_WRAPPER_PATH" ticket status failed --comment "<terminal failure>"
 
-Continue the assigned work after reporting unless you are blocked or finished.`
+Closing a ticket is the user's call, not yours: when you believe the work is
+done, ask the user to confirm and wait for their go-ahead before you report the
+completed state. Report the other states as they happen.
+
+Continue the assigned work after reporting unless you are blocked or waiting on
+the user.`
 }
 
 func (d *Daemon) handleDelegate(conn net.Conn, msg *protocol.DelegateMessage) {

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -163,6 +163,10 @@ func TestChiefOfStaffDelegateBindsTicketAndPrompt(t *testing.T) {
 		strings.Contains(prompt, "dispatch ") {
 		t.Fatalf("tracked initial prompt = %q", prompt)
 	}
+	// The agent must not close a ticket on its own — completing is gated on the user.
+	if !strings.Contains(prompt, "ask the user to confirm") {
+		t.Fatalf("tracked initial prompt missing confirm-before-complete guidance = %q", prompt)
+	}
 
 	ticket, err := d.store.ActiveTicketForSession(result.SessionID)
 	if err != nil {


### PR DESCRIPTION
## What

A delegated worker now treats closing its ticket as the user's call. The delegated-agent prompt (`delegatedTicketPrompt`) tells it: when it believes the work is done, ask the user to confirm and wait for the go-ahead before reporting `completed` — rather than closing the ticket on its own. The other work states (in progress, needs input, ready for review, failed) are still reported as they happen.

## Why

Agents were marking tickets `completed` autonomously. Completion is the moment a human (or chief) wants to weigh in, so the agent should surface and wait, not self-close.

## Scope

Guidance/prompt change only — no protocol or daemon-behavior change. Test asserts the new guidance is present in the delegated prompt.

https://claude.ai/code/session_01NcbKHZbprd36hdtAdJCZbN