### PR TITLE
fix: keep a delegated agent a leaf, not a re-delegating chief

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-06-30]
+
+### Fixed
+- **A delegated agent stays focused on its own task instead of handing it off again.** A delegated agent could misread attn's guidance as a license to delegate onward — spinning up a *third* agent for one of its own subtasks, in a session you weren't watching. Now every delegated session is told up front that it's a worker, not a coordinator: it does the assigned work itself and uses its own internal helpers for subtasks, only creating a new visible attn agent if you explicitly ask it to. (attn also now cleans up stale guidance files from older installs that could keep teaching the old behavior.)
+
 ## [2026-06-29]
 
 ### Added

--- a/docs/plans/2026-06-30-delegated-leaf-not-chief.md
+++ b/docs/plans/2026-06-30-delegated-leaf-not-chief.md
@@ -1,0 +1,208 @@
+# Plan: stop a delegated (non-chief) agent from re-delegating
+
+Ticket: `delegated-agents-not-chief`. **Implemented.** Two instruments: a
+**delegate-time leaf line** (code, closes the zero-signal leaf) and a **skill
+role front-door + installer orphan-pruning fix** (prose + code, closes the
+read-the-skill misread). See "What actually shipped" below.
+
+## The bug
+
+A delegated agent delegated its own task onward to a third agent. It had read
+the attn skill and applied the "delegate if you're the chief" framing to itself.
+Nothing told it that it is a *leaf*, not the chief.
+
+## Root cause: an inference gap, not disobedience
+
+The agent did not ignore a rule — it lacked the information to know the rule
+applied to it. attn marks the **chief** with a concrete, passive, startup-time
+signal; it marked a **leaf** with nothing analogous.
+
+| Role | Passive env signal | Initial-prompt framing | System prompt | Active query (`attn list --json`) |
+|---|---|---|---|---|
+| Chief of staff | **`ATTN_CHIEF_GUIDANCE`** present | n/a | "You are the chief of staff…" (`ChiefGuidance`, `hooks.go:130`) | `chief_of_staff: true` |
+| Tracked leaf (delegated *by chief*) | none | ticket-report contract appended (`delegate.go:418-440`) | non-chief `AgentInstructions` | `delegated_from_chief: true` |
+| Ordinary session | none | none | non-chief `AgentInstructions` | both absent |
+| **Leaf delegated by a non-chief** (the bug) | **none** | **none — raw brief** | **non-chief `AgentInstructions`** | **both absent — identical to ordinary** |
+
+The chief is *positively* marked. A leaf was defined only by the *absence* of
+the chief markers — an absence it shares with every ordinary top-level session.
+The skill's chief-vs-leaf distinction therefore rested on the agent
+**inferring** a role for which no positive signal was plumbed to it.
+
+### The actual mechanism behind the reported incident — a stale install, not a live design defect
+
+Initial analysis (this plan's first draft) diagnosed the misread as caused by a
+file `references/chief-of-staff.md` that bundled the chief's delegate license
+with leaf reporting guidance, and was reachable by a tracked leaf via its own
+load-trigger text. That file is real — but **it does not exist in the skill's
+canonical source** (`internal/agent/attn_skill/`). It was deliberately deleted
+at commit `b1fad9b0` ("feat(tickets): chief watch + daemon backstop for
+delegated-ticket awareness"), as part of an earlier, intentional refactor that
+moved the chief's delegation license into the always-on, Go-injected system
+prompt (`hooks.ChiefGuidance`) and left `delegated-agent.md` as the leaf-only
+home — already tested against carrying chief content back
+(`attn_skill_test.go`'s `chiefOrLegacy` checks).
+
+The copy of `chief-of-staff.md` actually read during this investigation came
+from `~/.claude/skills/attn/references/` — an **installed**, not source,
+location. `installAttnSkill` (`internal/agent/attn_skill.go`) only ever
+writes/overwrites files present in the current embed; it never deleted files
+that fell out of the bundle. So a reference retired from source in late June
+survived indefinitely on an already-installed machine, fully able to keep
+teaching a delegated leaf the old, no-longer-current "use the normal `attn
+delegate` workflow" framing. **This — an orphaned installed file, not a gap in
+the current skill's design — is the direct, concrete mechanism of the reported
+incident.** Fixed by adding orphan-pruning to the installer (below).
+
+### Two misread vectors — they needed different instruments
+
+- **(a) The read-the-skill misread.** A *chief-delegated* (tracked) leaf opens
+  stale chief-only content (the orphaned `chief-of-staff.md`) and bleeds the
+  chief's delegate license onto itself. Closed by installer pruning (removes the
+  stale file) plus a role front-door in `SKILL.md` as defense-in-depth, so even a
+  leaf reading delegation content for an unrelated reason sees the role gate
+  before anything else.
+- **(b) The zero-signal leaf.** A *non-chief-delegated* leaf has no env marker,
+  no prompt framing, and no load-trigger pointing it at any leaf reference. It
+  may never open the skill at all (the lazy-load-miss flagged in
+  `docs/plans/2026-06-28-delegated-ticket-awareness.md`). Prose alone cannot
+  reach it — only a spawn-time signal does. Closed by the delegate-time leaf
+  line, injected into *every* delegation's initial prompt.
+
+## What actually shipped
+
+### 1. Delegate-time leaf line (`internal/daemon/delegate.go`)
+
+`withLeafIdentity` prepends a terse identity preamble to every delegated
+agent's initial prompt — tracked or not, chief-delegated or not. Composes with
+the existing `delegatedTicketPrompt` ticket-report contract for tracked leaves
+(identity line + report contract + brief) and is the only signal for a
+non-chief delegation (identity line + brief). Tests updated:
+`TestDelegateSpawnsAgentInSourceWorkspaceWithBrief`,
+`TestDelegateAcceptsCopilotInitialPrompt` (both previously asserted the prompt
+equaled the raw brief; now assert it contains the leaf line + the brief).
+
+### 2. Installer orphan-pruning (`internal/agent/attn_skill.go`)
+
+`installAttnSkill` now collects the set of paths the current embed expects and
+calls `pruneOrphanedSkillFiles` to remove anything under the installed skill
+dir that isn't in that set. This is the actual fix for the reported incident's
+mechanism: a retired reference can no longer survive a future install. Covered
+by `TestEnsureAttnClaudeSkillInstalledPrunesOrphanedFiles`, which seeds a
+leftover `chief-of-staff.md` and an orphaned subdirectory and asserts both are
+gone after install. Verified live: rebuilt and installed `attn-dev.app`
+(`make dev`), confirmed the real `~/.claude/skills/attn/references/
+chief-of-staff.md` (Victor's own machine, dated 2026-06-28) was removed by the
+next settings-driven install pass.
+
+### 3. Skill role front-door (`internal/agent/attn_skill/SKILL.md`)
+
+Added a "Confirm Your Role First" section ahead of the Capability Index — the
+first thing any agent that loads the skill sees, regardless of why it loaded
+it. States the three roles (chief / delegated leaf / ordinary session) and what
+delegation means for each, before any capability-routing happens. The
+`assertAttnSkillTree` byte-budget test (`len(index) > 3000`) that previously
+held `SKILL.md` to ~2930/3000 bytes was removed (Victor's call: "that test
+should must go") — it left no room for genuinely load-bearing content; the file
+is now governed by reviewer judgment instead, same as any other reference.
+
+### 4. `delegated-agent.md` — the leaf's home, restructured
+
+Split into two sections reflecting what's actually true at runtime: "You Are A
+Leaf, Not A Coordinator" (universal — applies to every delegated leaf, carries
+the positive identity rule) and "If Your Work Is Tracked, Report Your State"
+(conditional — only chief-tracked leaves get the ticket-report contract). Load
+trigger broadened from "your task says your work is tracked" to "you are a
+delegated leaf" (matches the now-universal delegate-time line).
+
+### 5. `delegation.md` — pointer to the role check
+
+Replaced the self-applicable "while you continue coordinating the wider task"
+framing (read naturally by a leaf as describing itself) with a one-line pointer
+back to `SKILL.md`'s role check and an explicit "if that might be you, read
+`delegated-agent.md` first" redirect.
+
+### Not done (re-scoped after the chief-of-staff.md finding)
+
+The first draft of this plan also proposed moving `notebook.md`'s "As Chief Of
+Staff" coda into a (to-be-recreated) `chief-of-staff.md`, and giving
+`chief-of-staff.md` a dedicated home for board-reading altitude. Both are
+**dropped**: recreating `chief-of-staff.md` would undo the deliberate
+commit-`b1fad9b0` refactor that moved chief identity into the always-on system
+prompt specifically so it doesn't depend on a skill-file load. `notebook.md`'s
+coda is real but minor (journaling altitude, not a delegation-license grant —
+not part of this bug's mechanism) and is left as a follow-up, not bundled into
+this fix.
+
+## One leaf definition, shared in spirit between code and prose
+
+The delegate-time preamble (terse, runtime) and `delegated-agent.md`'s "You Are
+A Leaf" section (fuller, with the why) say the same thing in different
+registers — both: you are a leaf, not a coordinator; do the work here; native
+subagents for your own subtasks, not `attn delegate`; delegate again only if
+the user steering *this* session explicitly asks.
+
+## Decisions — consequences of being "too strong" (why we do NOT just ban delegation)
+
+The leverage is in the *signal*, not the *imperative*.
+
+1. **Strength can't substitute for signal.** Every prose rule is "if you are a
+   leaf, don't X" — and the antecedent is exactly what the agent cannot
+   observe. Hardening the consequent ("don't" → "NEVER") does nothing about an
+   uncertain antecedent: the model still over-applies (muzzles non-leaves) or
+   under-applies (the original bug). Louder consequent + fuzzy antecedent =
+   **more variance, not less.** Make the antecedent observable (the
+   delegate-time line + pruning a stale file that misrepresented it), then the
+   consequent can stay calm.
+2. **The blast-radius trap — named so we don't do it.** The tempting cheap fix
+   is to move `delegationBoundary` into always-on `AgentInstructions`
+   (`hooks.go:103`). Don't: that path also feeds *every ordinary top-level
+   session*, which legitimately delegates on user request. A leaf rule there
+   muzzles ordinary sessions — the exact false-positive radius of conditioning
+   on the absence-signal. The signal must live where the leaf is *known*
+   (`delegate.go`).
+3. **A hard tool-level block is the most "too strong" lever — avoid it.**
+   Making `attn delegate` refuse from a delegated session moves policy into the
+   tool where it can't see user intent, breaks the legitimate "user steering a
+   delegated agent asks for a worker" case, is un-overridable by prose, and
+   reintroduces parent-child lineage attn deliberately omits. If anything at
+   the tool level, a soft confirm — never a refusal. Not built.
+4. **Keep the consequent calm: "don't self-offload," not "never delegate."** A
+   delegated agent IS a full steerable session; if its present user asks for a
+   visible worker, it should comply. Default to native subagents for *your
+   own* subtasks; delegate only on an explicit ask from the user in this
+   session. Both `delegated-agent.md` and the delegate-time line say this
+   explicitly, not a blanket prohibition.
+5. **Prompt bloat dilutes the skill.** Repeating a heavy guard across surfaces
+   burns attention budget and trains the model to skim past skill absolutes.
+   Landed in three places only: the front-door, the one leaf rule, the
+   delegate-time line — not the four-plus surfaces the first draft considered.
+
+## Verification
+
+- `go build ./...`, `go vet ./...` clean.
+- `go test ./internal/agent/...` (incl. `TestEnsureAttnClaudeSkillInstalled`,
+  the new `TestEnsureAttnClaudeSkillInstalledPrunesOrphanedFiles`,
+  `TestEnsureAttnCodexSkillInstalled`, `TestAttnSkillInstallsAreIdentical`) —
+  green.
+- `go test ./internal/daemon/...` delegation tests (`TestDelegate*`,
+  `TestChiefOfStaffDelegate*`, `TestOrdinaryDelegation*`,
+  `TestDelegatedFromChief*`) — green.
+- `go test ./internal/hooks/...` — green (untouched, confirms no regression).
+- `gofmt -l` clean on all edited files.
+- Live: `make dev` rebuild + install; confirmed the real installed skill at
+  `~/.claude/skills/attn` picked up the new `SKILL.md`/`delegated-agent.md`
+  content and the stale `chief-of-staff.md` orphan was pruned.
+
+## Open / Follow-ups
+
+- **Assignment is still blocked.** Taking this ticket needs the prod daemon
+  updated (`make install-daemon`) — the running prod daemon predates `ticket
+  take` (rejects `ticket_take`/`ticket_list`). Gated on Victor's approval; not
+  worked around via a direct DB write.
+- `ATTN_DELEGATED` env / `presence` surfacing of `delegated_from_chief` — a
+  nice-to-have observable-antecedent path, not built.
+- `notebook.md`'s "As Chief Of Staff" coda is a minor, separate IA smell
+  (journaling altitude duplicated with `hooks.ChiefGuidance`) — not part of
+  this bug's mechanism, left untouched.
+- A hard tool-level re-delegation guard was deliberately not built (Decision 3).

--- a/internal/agent/attn_skill.go
+++ b/internal/agent/attn_skill.go
@@ -13,13 +13,15 @@ import (
 var attnSkillFiles embed.FS
 
 func installAttnSkill(skillDir string) error {
-	return fs.WalkDir(attnSkillFiles, "attn_skill", func(path string, entry fs.DirEntry, walkErr error) error {
+	expected := map[string]bool{}
+	err := fs.WalkDir(attnSkillFiles, "attn_skill", func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
 		relative := strings.TrimPrefix(path, "attn_skill")
 		relative = strings.TrimPrefix(relative, "/")
 		target := filepath.Join(skillDir, filepath.FromSlash(relative))
+		expected[target] = true
 		if entry.IsDir() {
 			if err := os.MkdirAll(target, 0o755); err != nil {
 				return fmt.Errorf("create attn skill directory %s: %w", target, err)
@@ -38,6 +40,42 @@ func installAttnSkill(skillDir string) error {
 		}
 		if err := os.WriteFile(target, content, 0o644); err != nil {
 			return fmt.Errorf("write attn skill file %s: %w", target, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return pruneOrphanedSkillFiles(skillDir, expected)
+}
+
+// pruneOrphanedSkillFiles removes files and directories under skillDir that are
+// no longer part of the bundled skill — e.g. a reference retired in a later
+// version. installAttnSkill only ever writes/overwrites files present in the
+// current embed, so without this an installed skill accumulates stale content
+// forever: a retired reference stays loadable by name and can directly
+// contradict the current skill's guidance (this is how a leftover
+// chief-of-staff.md, removed from the source tree, kept teaching a delegated
+// leaf that it could re-delegate like the chief).
+func pruneOrphanedSkillFiles(skillDir string, expected map[string]bool) error {
+	return filepath.WalkDir(skillDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		if expected[path] {
+			return nil
+		}
+		if entry.IsDir() {
+			if err := os.RemoveAll(path); err != nil {
+				return fmt.Errorf("remove orphaned attn skill directory %s: %w", path, err)
+			}
+			return fs.SkipDir
+		}
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("remove orphaned attn skill file %s: %w", path, err)
 		}
 		return nil
 	})

--- a/internal/agent/attn_skill/SKILL.md
+++ b/internal/agent/attn_skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attn
-description: "Drive attn from an agent: spawn a visible interactive agent the user can inspect and steer, run durable resumable multi-agent workflows, maintain shared workspace context, journal as chief of staff, run review loops, open markdown, or control attn's persistent in-app browser. Use when the user explicitly asks for an attn session, delegation, workflow, review loop, browser, or to show a markdown explainer or doc in the app, or when you are attn's chief of staff. Not for private research, verification, or parallel reasoning you synthesize yourself — use native subagents for those."
+description: "Drive attn from an agent: spawn a visible interactive agent the user can inspect and steer, run durable resumable multi-agent workflows, maintain shared workspace context, journal, run review loops, open markdown, or control attn's persistent in-app browser. Use when the user explicitly asks for an attn session, delegation, creating a new ticket, workflow, review loop, browser, or to show a markdown explainer or doc in the app, or when you are attn's chief of staff. Not for private research, verification, or parallel reasoning you synthesize yourself — use native subagents for those."
 ---
 
 # attn
@@ -20,12 +20,32 @@ Inside attn, prefer `"$ATTN_WRAPPER_PATH"` for every command. Fall back to
 If a command reports an unknown subcommand or shows another tool's help, check
 `attn --version` and `which -a attn`, then use `ATTN_WRAPPER_PATH`.
 
+## Confirm Your Role First
+
+A delegated leaf re-delegating its own assigned work — mistaking itself for the
+chief — is this skill's most common failure. Check which you are before reading
+anything about delegation:
+
+- **Chief of staff**, if your system prompt says so: it already carries your
+  full delegation, ticket, and Notebook guidance. Use native subagents for your
+  own research and synthesis.
+- **A delegated leaf**, if your initial task opens with a line identifying you
+  as a delegated attn session: do the work here. Native subagents for your own
+  subtasks; `attn delegate` again only if the user steering *this* session
+  explicitly asks. See [references/delegated-agent.md](references/delegated-agent.md).
+- **Otherwise, an ordinary session:** `attn delegate` only when the user
+  explicitly asks for a visible, steerable agent.
+
+A ticket-tracked task is still a leaf task — being tracked means the chief is
+*watching* your ticket, not that you inherited the chief's delegation license.
+
 ## Capability Index
 
-- **Create a visible interactive agent the user can steer:** read
-  [references/delegation.md](references/delegation.md).
-- **Report your work state as a delegated agent whose work is tracked (tickets):**
-  read [references/delegated-agent.md](references/delegated-agent.md).
+- **Create a visible interactive agent the user can steer** (per the role check
+  above): read [references/delegation.md](references/delegation.md).
+- **You are a delegated leaf — confirm what you may do, and report your work
+  state if it's tracked:** read
+  [references/delegated-agent.md](references/delegated-agent.md).
 - **Write a good ticket, or create a backlog ticket without delegating (`ticket new`):** read [references/tickets.md](references/tickets.md).
 - **Read or update shared workspace context:** read
   [references/workspace-context.md](references/workspace-context.md).
@@ -40,8 +60,6 @@ If a command reports an unknown subcommand or shows another tool's help, check
   [references/markdown.md](references/markdown.md).
 - **Operate attn's persistent browser tile:** read
   [references/browser.md](references/browser.md).
-- **Write, review, or improve a system prompt, agent guidance, or skill
-  instruction:** load the `prompting` skill before starting.
 
 Load more than one reference only when the task actually combines capabilities.
 

--- a/internal/agent/attn_skill/references/delegated-agent.md
+++ b/internal/agent/attn_skill/references/delegated-agent.md
@@ -1,12 +1,26 @@
-# Delegated-Agent Ticket Reporting
+# Delegated-Agent Guidance
 
-Load this reference when your initial task says your work is tracked — the chief
-of staff delegated it to you and is following a ticket bound to your session.
+Load this reference when you are a delegated leaf — your initial task opens
+with a line identifying you as a delegated attn session.
 
-When the chief delegates, attn opens a ticket bound to your session (you are its
-assignee) and starts it in the working column. You self-report your work state,
-which moves the ticket across the board so the chief can follow your progress
-without interrupting you to ask. Report when you:
+## You Are A Leaf, Not A Coordinator
+
+Do the assigned work in this session. For your own subtasks — research,
+verification, or parallel exploration you alone will synthesize — use native
+subagents (your Task/Agent tools), not `attn delegate`. Delegating offloads
+your assigned work into a session the user who delegated you isn't watching,
+which defeats the point of being delegated to in the first place. Spawn a
+visible attn agent only if the user steering *this* session explicitly asks for
+one — that user can still ask for a worker; the rule is against self-offloading
+your own assignment, not against delegation altogether.
+
+## If Your Work Is Tracked, Report Your State
+
+If the chief of staff delegated this and is following a ticket bound to your
+session, self-report your work state so the ticket moves across the board and
+the chief can follow your progress without interrupting you to ask. When the
+chief delegates, attn opens that ticket (you are its assignee) and starts it in
+the working column. Report when you:
 
 - reach a meaningful milestone
 - need input or are blocked

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -1,8 +1,14 @@
 # Delegation
 
+This file is mechanics. It assumes you already confirmed in SKILL.md's role
+check that delegating is yours to do right now — the chief of staff, or an
+ordinary session the user is steering directly. A delegated leaf re-delegating
+its own assigned work onward is the bug this skill exists to prevent; if that
+might be you, read [delegated-agent.md](delegated-agent.md) first.
+
 Attn delegation creates a visible, full interactive agent session for the user.
 Use it when the user wants another agent they can inspect, converse with, and
-steer directly while you continue coordinating the wider task.
+steer directly.
 
 Do not use attn delegation as an internal parallel-reasoning mechanism. For
 research, adversarial analysis, verification, or other work that you alone will
@@ -34,6 +40,11 @@ The brief should let the delegated agent start immediately. Include:
 2. relevant paths, decisions, or evidence
 3. constraints and explicit non-goals
 4. the expected deliverable or stopping condition
+
+A delegation brief *is* a ticket's description, so the fuller craft in
+[tickets.md](tickets.md) applies here too — write the objective as a stop
+condition, give a verification contract, and let the shape bend by deliverable
+type.
 
 Use `--brief <text>` only for short, simple tasks.
 

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -36,13 +36,14 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 		"references/markdown.md",
 		"references/browser.md",
 		"Load more than one reference only when",
+		// the role front-door: a delegated leaf must learn, before reading
+		// anything about delegation, that being tracked is not being the chief.
+		"Confirm Your Role First",
+		"delegated leaf",
 	} {
 		if !strings.Contains(index, expected) {
 			t.Fatalf("skill index missing %q: %q", expected, index)
 		}
-	}
-	if len(index) > 3000 {
-		t.Fatalf("skill index is %d bytes, want a concise routing index", len(index))
 	}
 	if strings.Contains(index, "browser command find_element") {
 		t.Fatalf("skill index contains capability details that belong in a reference: %q", index)
@@ -50,6 +51,8 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 
 	delegatedAgent := readSkillFile(t, skillDir, "references/delegated-agent.md")
 	for _, expected := range []string{
+		"You Are A Leaf, Not A Coordinator",
+		"not `attn delegate`",
 		"ticket status in_progress",
 		"ticket status needs_input",
 		"ticket status ready_for_review",
@@ -191,6 +194,42 @@ func TestEnsureAttnClaudeSkillInstalled(t *testing.T) {
 	}
 
 	assertAttnSkillTree(t, filepath.Join(home, ".claude", "skills", "attn"))
+}
+
+// TestEnsureAttnClaudeSkillInstalledPrunesOrphanedFiles guards against the
+// actual mechanism behind a reported incident: a reference retired from the
+// skill source (chief-of-staff.md) survived indefinitely on an installed
+// machine because the installer only ever wrote/overwrote known files and
+// never deleted files that fell out of the bundle. A stale reference can
+// directly contradict the current skill's guidance, so install must prune.
+func TestEnsureAttnClaudeSkillInstalledPrunesOrphanedFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	skillDir := filepath.Join(home, ".claude", "skills", "attn")
+	if err := os.MkdirAll(filepath.Join(skillDir, "references"), 0o755); err != nil {
+		t.Fatalf("seed skill dir: %v", err)
+	}
+	orphanFile := filepath.Join(skillDir, "references", "chief-of-staff.md")
+	if err := os.WriteFile(orphanFile, []byte("stale, retired guidance"), 0o644); err != nil {
+		t.Fatalf("seed orphaned reference: %v", err)
+	}
+	orphanDir := filepath.Join(skillDir, "references", "retired-subdir")
+	if err := os.MkdirAll(orphanDir, 0o755); err != nil {
+		t.Fatalf("seed orphaned directory: %v", err)
+	}
+
+	if err := ensureAttnClaudeSkillInstalled(); err != nil {
+		t.Fatalf("ensureAttnClaudeSkillInstalled() error = %v", err)
+	}
+
+	if _, err := os.Stat(orphanFile); !os.IsNotExist(err) {
+		t.Fatalf("orphaned reference file was not pruned: stat err = %v", err)
+	}
+	if _, err := os.Stat(orphanDir); !os.IsNotExist(err) {
+		t.Fatalf("orphaned reference directory was not pruned: stat err = %v", err)
+	}
+	assertAttnSkillTree(t, skillDir)
 }
 
 func TestEnsureAttnCodexSkillInstalled(t *testing.T) {

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -350,6 +350,7 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 	if trackedByChief {
 		initialPrompt = delegatedTicketPrompt(brief)
 	}
+	initialPrompt = withLeafIdentity(initialPrompt)
 	d.handleSpawnSession(spawnClient, &protocol.SpawnSessionMessage{
 		Cmd:           protocol.CmdSpawnSession,
 		ID:            sessionID,
@@ -408,6 +409,28 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 		result.Branch = protocol.Ptr(strings.TrimSpace(*session.Branch))
 	}
 	return result, nil
+}
+
+// leafIdentityPreamble is prepended to every delegated agent's initial prompt.
+// attn marks a chief of staff with a passive, positive signal (an env var and a
+// system-prompt block); a delegated leaf gets nothing analogous — it is defined
+// only by the absence of those chief markers, an absence it shares with every
+// ordinary top-level session. Without this line, a leaf delegated by a non-chief
+// session is byte-identical to an ordinary session and has no way to learn it is
+// a leaf, so it can misapply chief-only guidance (like the delegation license) to
+// itself. See docs/plans/2026-06-30-delegated-leaf-not-chief.md.
+const leafIdentityPreamble = "You are a delegated attn session — a leaf, not a " +
+	"coordinator. Do the work below in this session. For your own subtasks, use " +
+	"native subagents (your Task/Agent tools), not `attn delegate` — delegating " +
+	"offloads your assigned work into a session the user who delegated you isn't " +
+	"watching. Spawn a visible attn agent only if the user steering this session " +
+	"explicitly asks for one."
+
+// withLeafIdentity prefixes a delegated agent's composed initial prompt with the
+// leaf identity line, applied uniformly whether or not the delegation is tracked
+// by the chief of staff.
+func withLeafIdentity(prompt string) string {
+	return leafIdentityPreamble + "\n\n---\n\n" + strings.TrimSpace(prompt)
 }
 
 // delegatedTicketPrompt augments a chief-delegated agent's brief with the

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -103,7 +103,11 @@ func TestDelegateSpawnsAgentInSourceWorkspaceWithBrief(t *testing.T) {
 	if result.WorkspaceID != workspaceID || result.Directory != cwd {
 		t.Fatalf("result = %+v, want workspace=%s directory=%s", result, workspaceID, cwd)
 	}
-	if prompt != "Investigate the delegated task." {
+	// Every delegated agent's initial prompt is prefixed with the leaf identity
+	// line so a non-chief-delegated leaf — which gets no ticket-report contract —
+	// still has a positive signal that it is a leaf, not a coordinator.
+	if !strings.Contains(prompt, "a leaf, not a coordinator") ||
+		!strings.Contains(prompt, "Investigate the delegated task.") {
 		t.Fatalf("initial prompt = %q", prompt)
 	}
 	if promptPath == "" {
@@ -467,7 +471,8 @@ func TestDelegateAcceptsCopilotInitialPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("delegate() error = %v, want copilot delegation to succeed", err)
 	}
-	if prompt != "Use Copilot for this delegated task." {
+	if !strings.Contains(prompt, "a leaf, not a coordinator") ||
+		!strings.Contains(prompt, "Use Copilot for this delegated task.") {
 		t.Fatalf("delegated initial prompt = %q", prompt)
 	}
 	session := d.store.Get(result.SessionID)


### PR DESCRIPTION
## The bug

A delegated agent delegated its own task onward to a third agent — it read attn's skill, applied the "delegate if you're the chief" framing to itself, and spun up a worker in a session the delegating user wasn't watching. Nothing told it that it is a *leaf*, not the chief.

## Root cause: an inference gap, plus a stale install

attn marks the **chief** with a concrete positive signal (`ATTN_CHIEF_GUIDANCE` env + an always-on system-prompt block). It marked a **leaf** with *nothing analogous* — for a non-chief delegation the initial prompt was the raw brief, byte-identical to an ordinary top-level session. The chief-vs-leaf distinction therefore rested on the agent *inferring* a role for which no positive signal was plumbed to it.

The concrete mechanism behind the actual incident was an **orphaned installed file**: `references/chief-of-staff.md` was retired from the source tree weeks ago (chief identity moved into the always-on system prompt), but `installAttnSkill` only ever wrote/overwrote files in the current embed and never deleted ones that fell out of the bundle — so the retired reference survived on an already-installed machine and kept teaching the old "delegate like the chief" framing.

## What shipped

1. **Delegate-time leaf line** (`internal/daemon/delegate.go`) — a terse leaf-identity preamble is prepended to *every* delegated agent's initial prompt (tracked or not, chief-delegated or not). It composes with the existing ticket-report contract and is the only role signal that reaches a leaf which never opens the skill.
2. **Installer orphan-pruning** (`internal/agent/attn_skill.go`) — `pruneOrphanedSkillFiles` removes anything under the installed skill dir that isn't in the current embed, so a retired reference can no longer outlive a later install. This is the direct fix for the incident's mechanism.
3. **Skill role front-door** (`SKILL.md`) — a "Confirm Your Role First" section ahead of the capability index, with a checkable observable for each of chief / delegated leaf / ordinary, so any agent that loads the skill self-classifies before reading anything about delegation.
4. **`delegated-agent.md` restructure** — split into "You Are A Leaf, Not A Coordinator" (universal) and "If Your Work Is Tracked, Report Your State" (conditional).
5. **`delegation.md`** — defers to the role check up front, and points a brief-writer at `tickets.md`'s fuller brief craft (a delegation brief *is* a ticket description). Also drops a dangling cross-reference to a non-shipped local skill.

## On not being "too strong"

The leverage is in the *signal*, not the *imperative*. Hardening prose ("don't" → "NEVER") does nothing about an antecedent the agent can't observe — it just adds variance (muzzles legitimate delegators or under-applies to leaves). A delegated agent is a full steerable session; if *its* user asks for a worker it should comply. So the consequent stays calm ("don't self-offload," not "never delegate") and the fix makes the antecedent observable instead. A hard tool-level block was deliberately not built — it can't see user intent and breaks the legitimate "user steering a delegated agent asks for a worker" case. Full reasoning in `docs/plans/2026-06-30-delegated-leaf-not-chief.md`.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test ./internal/agent/...` — incl. new `TestEnsureAttnClaudeSkillInstalledPrunesOrphanedFiles` (seeds a leftover `chief-of-staff.md` + orphan subdir, asserts both pruned).
- `go test ./internal/daemon/ -run 'TestDelegate|TestChiefOfStaffDelegate|TestOrdinaryDelegation|TestDelegatedFromChief'` — green.

Reviewable in three slices: the delegate-time line, the skill/installer change, and docs.

https://claude.ai/code/session_01NcbKHZbprd36hdtAdJCZbN