### PR TITLE
attn delegate: per-delegation --model and --effort pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-01]
 
+### Added
+- **Pin a delegated agent's model and effort.** `attn delegate` accepts `--model <alias|id>` and `--effort <level>` to launch that one delegation with a specific model and reasoning effort (Claude's native `--effort` levels, Codex's `model_reasoning_effort`), instead of silently inheriting the machine's default. Omit them and nothing changes; agents without a native mechanism (e.g. Copilot) reject the flags up front.
+
 ### Removed
 - **The automated review loop is gone.** The standalone review-loop feature — the SDK-managed iterating loop, its session sidebar bar, `attn review-loop` CLI, and related settings — has been removed. Diff comments, PR reviews, and the workflow engine are unaffected.
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -165,7 +165,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '139';
+export const PROTOCOL_VERSION = '140';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -769,7 +769,9 @@ export interface DelegateMessage {
     brief:             string;
     cmd:               DelegateMessageCmd;
     cwd?:              string;
+    effort?:           string;
     label?:            string;
+    model?:            string;
     placement?:        string;
     source_session_id: string;
     workspace_id?:     string;
@@ -3120,11 +3122,13 @@ export interface SpawnSessionMessage {
     cols:                number;
     copilot_executable?: string;
     cwd:                 string;
+    effort?:             string;
     endpoint_id?:        string;
     executable?:         string;
     id:                  string;
     initial_prompt?:     string;
     label?:              string;
+    model?:              string;
     resume_picker?:      boolean;
     resume_session_id?:  string;
     rows:                number;
@@ -7072,7 +7076,9 @@ const typeMap: any = {
         { json: "brief", js: "brief", typ: "" },
         { json: "cmd", js: "cmd", typ: r("DelegateMessageCmd") },
         { json: "cwd", js: "cwd", typ: u(undefined, "") },
+        { json: "effort", js: "effort", typ: u(undefined, "") },
         { json: "label", js: "label", typ: u(undefined, "") },
+        { json: "model", js: "model", typ: u(undefined, "") },
         { json: "placement", js: "placement", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
@@ -8410,11 +8416,13 @@ const typeMap: any = {
         { json: "cols", js: "cols", typ: 0 },
         { json: "copilot_executable", js: "copilot_executable", typ: u(undefined, "") },
         { json: "cwd", js: "cwd", typ: "" },
+        { json: "effort", js: "effort", typ: u(undefined, "") },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "executable", js: "executable", typ: u(undefined, "") },
         { json: "id", js: "id", typ: "" },
         { json: "initial_prompt", js: "initial_prompt", typ: u(undefined, "") },
         { json: "label", js: "label", typ: u(undefined, "") },
+        { json: "model", js: "model", typ: u(undefined, "") },
         { json: "resume_picker", js: "resume_picker", typ: u(undefined, true) },
         { json: "resume_session_id", js: "resume_session_id", typ: u(undefined, "") },
         { json: "rows", js: "rows", typ: 0 },

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -604,6 +604,12 @@ worktree options:
 
 session options:
   --agent <name>             configured prompt-capable built-in or plugin agent
+  --model <name>             pin the agent's model (alias or full id, e.g.
+                             "opus" or "claude-opus-4-8"; defaults to the
+                             agent's own default)
+  --effort <level>           pin the agent's reasoning effort (claude: low,
+                             medium, high, xhigh, max; codex: minimal, low,
+                             medium, high, xhigh)
   --name <text>              name for the agent and, when a new workspace is
                              created, the workspace (max 16 chars, must be
                              unique; defaults to the directory name)
@@ -1550,6 +1556,8 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 	briefText := fs.String("brief", "", "delegated task brief")
 	briefFile := fs.String("brief-file", "", "file containing the delegated task brief")
 	agentName := fs.String("agent", "", "target agent (defaults to the source session agent)")
+	model := fs.String("model", "", "pin the delegated agent's model (alias or full id)")
+	effort := fs.String("effort", "", "pin the delegated agent's reasoning effort")
 	name := fs.String("name", "", "name for the agent and, when a new workspace is created, the workspace")
 	sourceSessionID := fs.String("source-session", "", "source session id (defaults to ATTN_SESSION_ID)")
 	yolo := fs.Bool("yolo", false, "launch the target agent in yolo mode")
@@ -1616,6 +1624,8 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 		brief:           brief,
 		options: client.DelegateOptions{
 			Agent:        strings.TrimSpace(*agentName),
+			Model:        strings.TrimSpace(*model),
+			Effort:       strings.TrimSpace(*effort),
 			Label:        strings.TrimSpace(*name),
 			Yolo:         *yolo,
 			Placement:    placement,
@@ -2243,8 +2253,11 @@ func runAgentDirectly(requestedAgent string) {
 	// Likewise the worker exports ATTN_AUTO_APPROVE when the auto_approve_enabled
 	// setting is on, so the launched agent starts in its native auto-approve mode.
 	opts.AutoApprove = strings.TrimSpace(os.Getenv("ATTN_AUTO_APPROVE")) == "1"
-	// ATTN_CHIEF_MODEL pins the chief launch's model (chief_model_<agent>).
-	opts.Model = strings.TrimSpace(os.Getenv("ATTN_CHIEF_MODEL"))
+	// ATTN_MODEL pins the launch's model (chief_model_<agent> for chief
+	// launches, delegate --model for delegations); ATTN_EFFORT pins the
+	// reasoning effort (delegate --effort).
+	opts.Model = strings.TrimSpace(os.Getenv("ATTN_MODEL"))
+	opts.Effort = strings.TrimSpace(os.Getenv("ATTN_EFFORT"))
 	if cp, ok := agentdriver.GetConfigOverrideProvider(driver); ok {
 		opts.ConfigOverrides = cp.GenerateConfigOverrides(opts)
 	}

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -518,6 +518,21 @@ func TestParseDelegateArgsNameSetsLabel(t *testing.T) {
 	}
 }
 
+func TestParseDelegateArgsModelAndEffort(t *testing.T) {
+	parsed, err := parseDelegateArgs([]string{
+		"--source-session", "source-session",
+		"--brief", "Investigate this",
+		"--model", " claude-fable-5 ",
+		"--effort", " low ",
+	})
+	if err != nil {
+		t.Fatalf("parseDelegateArgs() error = %v", err)
+	}
+	if parsed.options.Model != "claude-fable-5" || parsed.options.Effort != "low" {
+		t.Fatalf("options model/effort = %q/%q", parsed.options.Model, parsed.options.Effort)
+	}
+}
+
 func TestParseDelegateArgsWorktreeUsesCurrentWorkspace(t *testing.T) {
 	parsed, err := parseDelegateArgs([]string{
 		"--source-session", "source-session",

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -60,6 +60,17 @@ The source agent is used by default. Select another supported agent with:
 Plugin agents work only when they declare delegated initial-prompt support.
 Copilot delegation is currently unsupported.
 
+`--model` and `--effort` pin the delegated agent's model and reasoning effort
+for that delegation only; omitted, the agent uses its own defaults:
+
+    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" \
+      --agent claude --model opus --effort high
+
+`--model` takes an alias or a full model id. `--effort` takes the agent's
+native levels (claude: low, medium, high, xhigh, max; codex: minimal, low,
+medium, high, xhigh). Agents without a native mechanism (e.g. copilot) reject
+these flags.
+
 ## Placement
 
 Before creating a new workspace, check whether an existing one already fits the

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -67,6 +67,8 @@ func (c *Claude) Capabilities() Capabilities {
 		HasInitialPrompt:     true,
 		HasWorkspaceContext:  true,
 		HasSelfMonitor:       true,
+		HasModelPin:          true,
+		HasEffortPin:         true,
 	}
 }
 
@@ -98,6 +100,9 @@ func (c *Claude) BuildCommand(opts SpawnOpts) *exec.Cmd {
 
 	if model := strings.TrimSpace(opts.Model); model != "" {
 		args = append(args, "--model", model)
+	}
+	if effort := strings.TrimSpace(opts.Effort); effort != "" {
+		args = append(args, "--effort", effort)
 	}
 
 	if opts.ResumeSessionID != "" {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -57,6 +57,8 @@ func (c *Codex) Capabilities() Capabilities {
 		HasWorkspaceContext: true,
 		// HasSelfMonitor: false — codex has no live ticket Monitor, so it is
 		// pty-nudged when ticket activity arrives while it is idle.
+		HasModelPin:  true,
+		HasEffortPin: true,
 	}
 }
 
@@ -78,6 +80,11 @@ func (c *Codex) BuildCommand(opts SpawnOpts) *exec.Cmd {
 	args = append(args, "-C", opts.CWD)
 	if model := strings.TrimSpace(opts.Model); model != "" {
 		args = append(args, "--model", model)
+	}
+	if effort := strings.TrimSpace(opts.Effort); effort != "" {
+		// Codex has no dedicated effort flag; model_reasoning_effort is its
+		// native config knob (the -c value is parsed as TOML, hence the quotes).
+		args = append(args, "-c", `model_reasoning_effort="`+effort+`"`)
 	}
 	if opts.YoloMode {
 		args = append(args, "--dangerously-bypass-approvals-and-sandbox")

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -124,6 +124,15 @@ type Capabilities struct {
 	// to pick DeliveryWatch (self-monitor) vs DeliveryNudge (idle pty-nudge). Only
 	// Claude self-monitors today.
 	HasSelfMonitor bool
+
+	// HasModelPin indicates the agent's launch command accepts a per-session
+	// model pin (SpawnOpts.Model). Delegation rejects --model for agents without it.
+	HasModelPin bool
+
+	// HasEffortPin indicates the agent's launch command accepts a per-session
+	// reasoning-effort pin (SpawnOpts.Effort). Delegation rejects --effort for
+	// agents without it.
+	HasEffortPin bool
 }
 
 var capabilityEnvNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9]+`)
@@ -142,6 +151,8 @@ var capabilityEnvNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9]+`)
 //   - ATTN_AGENT_<AGENT>_INITIAL_PROMPT=0|1
 //   - ATTN_AGENT_<AGENT>_WORKSPACE_CONTEXT=0|1
 //   - ATTN_AGENT_<AGENT>_SELF_MONITOR=0|1
+//   - ATTN_AGENT_<AGENT>_MODEL_PIN=0|1
+//   - ATTN_AGENT_<AGENT>_EFFORT_PIN=0|1
 //
 // <AGENT> is uppercased with non-alphanumeric chars replaced by underscores
 // (e.g. "gemini-cli" -> "GEMINI_CLI").
@@ -184,6 +195,12 @@ func EffectiveCapabilities(d Driver) Capabilities {
 	}
 	if v, ok := boolEnv(prefix + "SELF_MONITOR"); ok {
 		caps.HasSelfMonitor = v
+	}
+	if v, ok := boolEnv(prefix + "MODEL_PIN"); ok {
+		caps.HasModelPin = v
+	}
+	if v, ok := boolEnv(prefix + "EFFORT_PIN"); ok {
+		caps.HasEffortPin = v
 	}
 
 	// Consistency: transcript watcher requires transcript support.
@@ -243,8 +260,16 @@ type SpawnOpts struct {
 	// Model, when set, pins the interactive agent's model via --model (an alias
 	// like "opus"/"sonnet" or a full model id). Empty means the agent's own
 	// default. Sourced from the daemon's chief_model_<agent> setting for chief
-	// launches and threaded into the worker via ATTN_CHIEF_MODEL.
+	// launches or a delegation's --model flag, and threaded into the worker via
+	// ATTN_MODEL.
 	Model string
+
+	// Effort, when set, pins the interactive agent's reasoning effort using the
+	// agent's native mechanism (Claude --effort, Codex model_reasoning_effort).
+	// Empty means the agent's own default. Sourced from a delegation's --effort
+	// flag and threaded into the worker via ATTN_EFFORT. Only meaningful for
+	// drivers with HasEffortPin.
+	Effort string
 
 	// Executable is the resolved executable path (from ResolveExecutable).
 	Executable string

--- a/internal/agent/model_effort_test.go
+++ b/internal/agent/model_effort_test.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"slices"
+	"testing"
+)
+
+// The model/effort pins ride SpawnOpts into each driver's launch argv. Claude
+// has native --model/--effort flags; codex takes -m/--model and the
+// model_reasoning_effort config override (quoted so the -c value parses as TOML).
+func TestClaudeBuildCommand_ModelAndEffortPins(t *testing.T) {
+	cmd := (&Claude{}).BuildCommand(SpawnOpts{
+		SessionID:  "sess-1",
+		CWD:        "/tmp/project",
+		Executable: "claude",
+		Model:      "claude-fable-5",
+		Effort:     "low",
+	})
+	if i := slices.Index(cmd.Args, "--model"); i < 0 || cmd.Args[i+1] != "claude-fable-5" {
+		t.Fatalf("args = %#v, want --model claude-fable-5", cmd.Args)
+	}
+	if i := slices.Index(cmd.Args, "--effort"); i < 0 || cmd.Args[i+1] != "low" {
+		t.Fatalf("args = %#v, want --effort low", cmd.Args)
+	}
+}
+
+func TestCodexBuildCommand_ModelAndEffortPins(t *testing.T) {
+	cmd := (&Codex{}).BuildCommand(SpawnOpts{
+		SessionID:  "sess-1",
+		CWD:        "/tmp/project",
+		Executable: "codex",
+		Model:      "gpt-5.2-codex",
+		Effort:     "high",
+	})
+	if i := slices.Index(cmd.Args, "--model"); i < 0 || cmd.Args[i+1] != "gpt-5.2-codex" {
+		t.Fatalf("args = %#v, want --model gpt-5.2-codex", cmd.Args)
+	}
+	found := false
+	for i, arg := range cmd.Args {
+		if arg == "-c" && i+1 < len(cmd.Args) && cmd.Args[i+1] == `model_reasoning_effort="high"` {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("args = %#v, want -c model_reasoning_effort=\"high\"", cmd.Args)
+	}
+}
+
+func TestBuildCommand_NoModelEffortPinsByDefault(t *testing.T) {
+	for _, driver := range []Driver{&Claude{}, &Codex{}} {
+		cmd := driver.BuildCommand(SpawnOpts{
+			SessionID:  "sess-1",
+			CWD:        "/tmp/project",
+			Executable: driver.DefaultExecutable(),
+		})
+		for _, arg := range cmd.Args {
+			if arg == "--model" || arg == "--effort" || arg == `model_reasoning_effort=""` {
+				t.Fatalf("%s args = %#v, want no model/effort flags", driver.Name(), cmd.Args)
+			}
+		}
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -145,6 +145,8 @@ func (c *Client) UpdateTodos(id string, todos []string) error {
 
 type DelegateOptions struct {
 	Agent        string
+	Model        string
+	Effort       string
 	Label        string
 	Yolo         bool
 	Placement    string
@@ -165,6 +167,12 @@ func (c *Client) Delegate(sourceSessionID, brief string, opts DelegateOptions) (
 	}
 	if value := strings.TrimSpace(opts.Agent); value != "" {
 		msg.Agent = protocol.Ptr(value)
+	}
+	if value := strings.TrimSpace(opts.Model); value != "" {
+		msg.Model = protocol.Ptr(value)
+	}
+	if value := strings.TrimSpace(opts.Effort); value != "" {
+		msg.Effort = protocol.Ptr(value)
 	}
 	if value := strings.TrimSpace(opts.Label); value != "" {
 		msg.Label = protocol.Ptr(value)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -360,6 +360,8 @@ func TestClient_Delegate(t *testing.T) {
 	c := New(sockPath)
 	result, err := c.Delegate("source-session", "Investigate the parser", DelegateOptions{
 		Agent:        "codex",
+		Model:        "gpt-5.2-codex",
+		Effort:       "high",
 		Label:        "Parser task",
 		Yolo:         true,
 		Placement:    "new_workspace",
@@ -382,6 +384,9 @@ func TestClient_Delegate(t *testing.T) {
 	}
 	if protocol.Deref(request.Agent) != "codex" || protocol.Deref(request.Label) != "Parser task" {
 		t.Fatalf("Delegate request options = %+v", request)
+	}
+	if protocol.Deref(request.Model) != "gpt-5.2-codex" || protocol.Deref(request.Effort) != "high" {
+		t.Fatalf("Delegate request model/effort = %+v", request)
 	}
 	if !protocol.Deref(request.YoloMode) {
 		t.Fatal("Delegate request did not enable yolo mode")

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -118,6 +118,34 @@ func (d *Daemon) resolveDelegationAgent(sourceAgent string, requested *string) (
 	return driver.Name(), nil
 }
 
+// validateDelegationModelEffort rejects --model / --effort for agents whose
+// launch command cannot apply them, so the pin fails fast at delegate time
+// instead of being silently dropped by the spawned session. Values themselves
+// are passed through (aliases, full ids, and new effort levels stay legal
+// without an allowlist to rot); the agent CLI is the authority on them.
+func (d *Daemon) validateDelegationModelEffort(agent, model, effort string) error {
+	if model == "" && effort == "" {
+		return nil
+	}
+	if pluginDriver, ok := d.ensurePluginRegistry().driver(agent); ok {
+		if model != "" && !pluginDriver.Capabilities["model_pin"] {
+			return fmt.Errorf("agent %q does not support --model", agent)
+		}
+		if effort != "" && !pluginDriver.Capabilities["effort_pin"] {
+			return fmt.Errorf("agent %q does not support --effort", agent)
+		}
+		return nil
+	}
+	caps := agentdriver.EffectiveCapabilities(agentdriver.Get(agent))
+	if model != "" && !caps.HasModelPin {
+		return fmt.Errorf("agent %q does not support --model", agent)
+	}
+	if effort != "" && !caps.HasEffortPin {
+		return fmt.Errorf("agent %q does not support --effort", agent)
+	}
+	return nil
+}
+
 func delegationPlacement(msg *protocol.DelegateMessage) string {
 	placement := strings.TrimSpace(strings.ToLower(protocol.Deref(msg.Placement)))
 	if placement != "" {
@@ -219,6 +247,11 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 	}
 	agent, err := d.resolveDelegationAgent(source.Agent, msg.Agent)
 	if err != nil {
+		return nil, err
+	}
+	model := strings.TrimSpace(protocol.Deref(msg.Model))
+	effort := strings.TrimSpace(strings.ToLower(protocol.Deref(msg.Effort)))
+	if err := d.validateDelegationModelEffort(agent, model, effort); err != nil {
 		return nil, err
 	}
 	// name is the explicit --name, or empty to default to the directory basename
@@ -351,7 +384,7 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 		initialPrompt = delegatedTicketPrompt(brief)
 	}
 	initialPrompt = withLeafIdentity(initialPrompt)
-	d.handleSpawnSession(spawnClient, &protocol.SpawnSessionMessage{
+	spawnMsg := &protocol.SpawnSessionMessage{
 		Cmd:           protocol.CmdSpawnSession,
 		ID:            sessionID,
 		Cwd:           directory,
@@ -362,7 +395,14 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 		Label:         protocol.Ptr(name),
 		YoloMode:      msg.YoloMode,
 		InitialPrompt: protocol.Ptr(initialPrompt),
-	})
+	}
+	if model != "" {
+		spawnMsg.Model = protocol.Ptr(model)
+	}
+	if effort != "" {
+		spawnMsg.Effort = protocol.Ptr(effort)
+	}
+	d.handleSpawnSession(spawnClient, spawnMsg)
 	if _, err := readInternalActionResult(spawnClient); err != nil {
 		d.removeWorkspaceLayoutPaneForSession(sessionID)
 		return nil, d.rollbackDelegation(createdWorkspaceID, createdWorktreePath, fmt.Errorf("spawn delegated session: %w", err))

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -485,6 +485,89 @@ func TestDelegateAcceptsCopilotInitialPrompt(t *testing.T) {
 	}
 }
 
+// --model / --effort ride the delegate request into the spawned session's
+// launch options; effort is normalized to lowercase on the way through.
+func TestDelegateThreadsModelAndEffortIntoSpawn(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Run pinned to a specific model.",
+		Agent:           protocol.Ptr("claude"),
+		Model:           protocol.Ptr("claude-fable-5"),
+		Effort:          protocol.Ptr("Low"),
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	spawn, ok := backend.LastSpawn()
+	if !ok || spawn.ID != result.SessionID {
+		t.Fatalf("last spawn = %+v, want delegated session %s", spawn, result.SessionID)
+	}
+	if spawn.Model != "claude-fable-5" || spawn.Effort != "low" {
+		t.Fatalf("spawn model/effort = %q/%q, want claude-fable-5/low", spawn.Model, spawn.Effort)
+	}
+}
+
+// A delegation without pins must not inherit any: the spawned agent keeps its
+// own defaults (empty model/effort all the way down).
+func TestDelegateWithoutModelEffortLeavesAgentDefaults(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+
+	if _, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Run with agent defaults.",
+		Agent:           protocol.Ptr("claude"),
+	}); err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	spawn, ok := backend.LastSpawn()
+	if !ok || spawn.Model != "" || spawn.Effort != "" {
+		t.Fatalf("spawn model/effort = %q/%q, want both empty", spawn.Model, spawn.Effort)
+	}
+}
+
+// Copilot's launch command applies neither pin, so both flags fail fast at
+// delegate time instead of being silently dropped by the spawned session.
+func TestDelegateRejectsModelEffortForUnsupportedAgent(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+
+	for flag, msg := range map[string]*protocol.DelegateMessage{
+		"--model": {
+			Cmd:             protocol.CmdDelegate,
+			SourceSessionID: sourceSessionID,
+			Brief:           "Pin a model on copilot.",
+			Agent:           protocol.Ptr("copilot"),
+			Model:           protocol.Ptr("gpt-5"),
+		},
+		"--effort": {
+			Cmd:             protocol.CmdDelegate,
+			SourceSessionID: sourceSessionID,
+			Brief:           "Pin effort on copilot.",
+			Agent:           protocol.Ptr("copilot"),
+			Effort:          protocol.Ptr("high"),
+		},
+	} {
+		_, err := d.delegate(msg)
+		if err == nil || !strings.Contains(err.Error(), "does not support "+flag) {
+			t.Fatalf("delegate(%s) error = %v, want unsupported-agent rejection", flag, err)
+		}
+	}
+	if len(backend.spawnOpts) != 1 {
+		t.Fatalf("spawn count = %d, want only source session", len(backend.spawnOpts))
+	}
+}
+
 func TestDelegateRejectsRemoteSourceSession(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -541,7 +541,13 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 
 		WorkflowGuidanceEnabled: parseBooleanSetting(d.store.GetSetting(SettingWorkflowsEnabled)),
 		AutoApprove:             parseBooleanSetting(d.store.GetSetting(SettingAutoApproveEnabled)),
-		Model:                   d.chiefLaunchModel(agent, protocol.Deref(msg.ChiefOfStaff)),
+		Model:                   strings.TrimSpace(protocol.Deref(msg.Model)),
+		Effort:                  strings.TrimSpace(protocol.Deref(msg.Effort)),
+	}
+	if spawnOpts.Model == "" {
+		// No per-spawn pin (delegation); a chief launch falls back to the
+		// chief_model_<agent> setting.
+		spawnOpts.Model = d.chiefLaunchModel(agent, protocol.Deref(msg.ChiefOfStaff))
 	}
 	if existingSession != nil {
 		for _, liveID := range d.ptyBackend.SessionIDs(context.Background()) {

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "139"
+const ProtocolVersion = "140"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -510,8 +510,14 @@ type DelegateMessage struct {
 	// Cwd corresponds to the JSON schema field "cwd".
 	Cwd *string `json:"cwd,omitempty,omitzero"`
 
+	// Effort corresponds to the JSON schema field "effort".
+	Effort *string `json:"effort,omitempty,omitzero"`
+
 	// Label corresponds to the JSON schema field "label".
 	Label *string `json:"label,omitempty,omitzero"`
+
+	// Model corresponds to the JSON schema field "model".
+	Model *string `json:"model,omitempty,omitzero"`
 
 	// Placement corresponds to the JSON schema field "placement".
 	Placement *string `json:"placement,omitempty,omitzero"`
@@ -2919,6 +2925,9 @@ type SpawnSessionMessage struct {
 	// Cwd corresponds to the JSON schema field "cwd".
 	Cwd string `json:"cwd"`
 
+	// Effort corresponds to the JSON schema field "effort".
+	Effort *string `json:"effort,omitempty,omitzero"`
+
 	// EndpointID corresponds to the JSON schema field "endpoint_id".
 	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
 
@@ -2933,6 +2942,9 @@ type SpawnSessionMessage struct {
 
 	// Label corresponds to the JSON schema field "label".
 	Label *string `json:"label,omitempty,omitzero"`
+
+	// Model corresponds to the JSON schema field "model".
+	Model *string `json:"model,omitempty,omitzero"`
 
 	// ResumePicker corresponds to the JSON schema field "resume_picker".
 	ResumePicker *bool `json:"resume_picker,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -510,6 +510,8 @@ model DelegateMessage {
   workspace_id?: string;
   cwd?: string;
   worktree?: DelegateWorktreeRequest;
+  `model`?: string; // Pin the delegated agent's model (alias or full id); empty = agent default
+  effort?: string; // Pin the delegated agent's reasoning effort; empty = agent default
 }
 
 // SetTicketStatusMessage is an agent self-reporting the work state of its own
@@ -1267,6 +1269,8 @@ model SpawnSessionMessage {
   claude_executable?: string;  // Backward compatibility
   codex_executable?: string;   // Backward compatibility
   copilot_executable?: string; // Backward compatibility
+  `model`?: string;            // Pin the launched agent's model; empty = agent default (chief launches fall back to chief_model_<agent>)
+  effort?: string;             // Pin the launched agent's reasoning effort; empty = agent default
 }
 
 model AttachSessionMessage {

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -51,9 +51,16 @@ type SpawnOptions struct {
 	AutoApprove bool
 
 	// Model, when set, pins the launched agent's model via --model. Sourced from
-	// the chief_model_<agent> setting for chief launches; the worker exports it as
-	// ATTN_CHIEF_MODEL. Empty means the agent's own default.
+	// the chief_model_<agent> setting for chief launches or a delegation's
+	// --model flag; the worker exports it as ATTN_MODEL. Empty means the agent's
+	// own default.
 	Model string
+
+	// Effort, when set, pins the launched agent's reasoning effort via its
+	// native mechanism (Claude --effort, Codex model_reasoning_effort). Sourced
+	// from a delegation's --effort flag; the worker exports it as ATTN_EFFORT.
+	// Empty means the agent's own default.
+	Effort string
 }
 
 type AttachInfo struct {

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -483,7 +483,10 @@ func (b *WorkerBackend) Spawn(ctx context.Context, opts SpawnOptions) error {
 		workerEnv = append(workerEnv, "ATTN_AUTO_APPROVE=1")
 	}
 	if model := strings.TrimSpace(opts.Model); model != "" {
-		workerEnv = append(workerEnv, "ATTN_CHIEF_MODEL="+model)
+		workerEnv = append(workerEnv, "ATTN_MODEL="+model)
+	}
+	if effort := strings.TrimSpace(opts.Effort); effort != "" {
+		workerEnv = append(workerEnv, "ATTN_EFFORT="+effort)
 	}
 	if len(opts.LoginShellEnv) > 0 {
 		if envJSON, err := json.Marshal(opts.LoginShellEnv); err == nil {


### PR DESCRIPTION
## What

`attn delegate` accepts optional `--model <alias|full-id>` and `--effort <level>` flags that pin the spawned agent's model and reasoning effort **for that delegation only**. Omitted, nothing changes — the agent keeps its own defaults.

## How

The pins flow through the existing chief-model plumbing, generalized:

- **CLI → client → `DelegateMessage`** — new optional `model`/`effort` fields.
- **Daemon** — `delegate()` validates the pins against the resolved agent's new `HasModelPin`/`HasEffortPin` capabilities (plugins check `model_pin`/`effort_pin` keys) and fails fast — `agent "copilot" does not support --effort` — instead of silently dropping them. The pins ride `SpawnSessionMessage` into `handleSpawnSession`; a per-spawn model takes precedence over the `chief_model_<agent>` setting fallback.
- **Worker env** — `ATTN_MODEL` (renamed from the chief-only `ATTN_CHIEF_MODEL`; the daemon and wrapper ship in the same binary) and new `ATTN_EFFORT` carry the pins into the wrapper.
- **Drivers** — claude appends its native `--model` / `--effort` (low, medium, high, xhigh, max — verified against `claude --help`); codex appends `--model` / `-c model_reasoning_effort="<level>"` (its native config knob, per the Codex config reference).

Model and effort **values** pass through unvalidated by design: aliases, full ids, and future effort levels stay legal without an allowlist that rots. The agent CLI is the authority.

Protocol version 139 → 140 (new message fields). Skill docs (`references/delegation.md`), `delegate --help`, and CHANGELOG updated. No frontend delegate form exists, so this is CLI-only per the brief.

## Verification

Unit tests at every hop: CLI flag parsing, client message construction, daemon threading (backend receives `Model`/`Effort`), unsupported-agent rejection, and driver argv construction for both agents (plus a no-pins default-behavior test). Full `go test ./...` and frontend vitest suites green.

**Live smoke** on an isolated `modelpin` profile (fresh daemon from this branch, headless via wsctl):

- `attn delegate --agent claude --model sonnet --effort low` → spawned process argv contains `--model sonnet --effort low`, worker env has `ATTN_MODEL=sonnet` / `ATTN_EFFORT=low`, and the live session's statusline shows **Sonnet 5** (not the machine default) with the brief answered.
- `attn delegate --agent codex --effort high` → codex argv contains `-c model_reasoning_effort="high"`.
- `attn delegate --agent copilot --effort high` → rejected at delegate time: `agent "copilot" does not support --effort`.

## Notes

- If a delegated session's worker dies and it is later relaunched/resumed (app respawn, ticket Resume), the pin is not re-applied — the pin lives in the spawn request, not the session row. Same lifetime as the brief's initial prompt; called out here for visibility.

https://claude.ai/code/session_01HsGcmp3Y6yrCnzUTKMKBCX