### PR TITLE
docs: implementation plans for the architecture-review deepening candidates

### DIFF
--- a/docs/plans/2026-07-02-architecture-review-open-candidates.md
+++ b/docs/plans/2026-07-02-architecture-review-open-candidates.md
@@ -1,0 +1,150 @@
+# Plan: Architecture review — open candidates needing a design conversation
+
+Companion to the six implementation plans from the 2026-07-01 architecture
+review. These five candidates have real friction but a wrong-by-default risk:
+each has at least one design fork only Victor can call. This plan captures the
+friction (so it isn't lost with the temp-dir review report), what to
+investigate up front, and the specific questions to settle — so each grilling
+conversation starts from evidence, not from scratch.
+
+**Exit criterion per candidate**: a decision recorded here (and, where the
+reason is load-bearing for future reviews, in `docs/decisions/`), then either a
+dedicated plan doc like the other six, or an explicit drop.
+
+Line references as of `80c62f6b` — re-anchor by symbol.
+
+## 1. Give the keeper a module
+
+**Friction.** `docs/glossary.md` defines the keeper as one persona with two
+causally-coupled duties ("prune *because* the story is preserved"), but the code
+has no keeper type: ~30 methods and 8 loose fields on `Daemon` across
+`workspace_keeper.go` (682 L), `notebook_narration.go` (749 L),
+`notebook_narration_config.go`, `notebook_narration_prompts.go`, with a naming
+schism (`keeperCompact*` vs `notebookNarrate*`). The preserve-then-prune
+invariant is expressible nowhere.
+
+**Investigate before discussing.**
+- [ ] Inventory the daemon dependencies of the 30 methods (store, tasks runner,
+      agent driver, notebook paths, settings) to see whether a clean
+      `internal/keeper` package is feasible or whether it stays a daemon-side
+      type first.
+- [ ] Sketch the module's interface twice (package vs daemon-owned struct) and
+      compare on locality and import cycles.
+
+**Questions for Victor.**
+- Package (`internal/keeper`) or daemon-internal type as the first step?
+- Should the preserve-then-prune invariant become *enforced* (compact refuses to
+  run unless narration for that span succeeded) or stay best-effort with the raw
+  tier as the floor? Enforcement changes failure behavior — that's a product
+  call, not a refactor.
+
+## 2. Command registry instead of the two mega-switches
+
+**Friction.** Dispatch is 105 WS arms (`websocket.go:819-1092`) + 48 socket arms
+(`daemon.go:1858-2003`) + 181 type assertions with zero behavior; commands exist
+twice per transport (paired `handleXxx`/`handleXxxWS`), and
+`newInternalWSClient` (`delegate.go:31-49`) has the socket path impersonating a
+WS client and unmarshalling its own output. Unknown commands drop silently.
+
+**Investigate before discussing.**
+- [ ] Prototype `register[T](cmd, handler)` + a `responder` seam
+      (`connResponder`/`wsResponder`) on ONE command cluster (e.g. the PR
+      actions) to measure the real boilerplate delta and find where the
+      pre-switch cross-cutting (capability gate ~833, recovery gate ~842,
+      selection capture, remote routing) resists tabling.
+- [ ] Decide what the registry does on unknown cmd (error event vs log) — today's
+      silent default is arguably a bug.
+
+**Questions for Victor.**
+- Worth the churn now, or sequence strictly after the test harness plan lands
+  (recommended: harness first — it's the regression net proving dispatch
+  equivalence arm-by-arm)?
+- Unknown-command behavior: silent (status quo) or explicit error reply?
+
+## 3. One truth for sessions in the app
+
+**Friction.** A session's truth lives in ~5 places: socket refs
+(`useDaemonSocket.ts:785-791`) → 17 `on*Update` callbacks (wired
+`App.tsx:558-580`) → `useDaemonStore` + App-local `useState`
+(`daemonWorkspaces:324`) → `useSessionStore.syncFromDaemonSessions`
+(`App.tsx:1120`) → `enrichedLocalSessions` re-merge — drilled through a
+103-member `AppContentProps` (702-807). Stale-state bugs have five candidate
+homes (a documented past example: the laggy ticket-panel refresh).
+
+**Investigate before discussing.**
+- [ ] Map which of the 5 copies each consumer actually reads (grep the imports
+      of the two zustand stores + the props) — the migration order falls out of
+      that map.
+- [ ] Check what `enrichedLocalSessions` adds beyond daemon data (local-only
+      fields?) — those need a home in the normalized store.
+
+**Questions for Victor.**
+- Target: one normalized zustand store + `useDaemon()` context, or keep two
+  stores (daemon-mirror + local-ui) with a single sync point?
+- Appetite: this is the largest frontend program of the set; do we stage it per
+  entity (sessions → workspaces → PRs/tickets) or per consumer?
+
+## 4. Terminal invariants: from AGENTS.md prose to modules
+
+**Friction.** Focus ownership (AGENTS.md #6) and geometry/replay authority
+(AGENTS.md #7) are enforced only by comments across ≥5 files (`App.tsx:1698,1896`,
+`SessionTerminalWorkspace/index.tsx:466-487`,
+`GhosttyTerminal.tsx:139-171,2317-2356`, `useGhosttyPaneRuntime.ts:162`,
+`terminalQueryResponses.ts:30-43`, `pty/session.go:864-899`), with zero
+automated tests — AGENTS.md itself admits the focus spec was removed and never
+replaced. The 20-method `GhosttyTerminalHandle` pushes replay-vs-live
+correctness onto callers via option flags.
+
+**Investigate before discussing.**
+- [ ] Enumerate every focus write (the review counted `focus` refs: 37 App / 45
+      STW / 41 GhosttyTerminal / 10 GridView) and classify which are the
+      *decision* (who should own focus) vs the *mechanism* (calling
+      `.focus()`) — only the decision moves into a `focusOwner` resolver.
+- [ ] Draft the intent-level handle (`applyLiveOutput` / `applyReplay` /
+      `requestFit`) against the current call sites to confirm nothing needs the
+      raw flags.
+
+**Questions for Victor.**
+- Is a pure `focusOwner` resolver + packaged-app spec enough, or do we also want
+  the handle narrowing in the same effort? (The handle work is riskier — it
+  touches the reattach-hang history.)
+- Any appetite for a Go-side `GeometryAuthority` type, or is the daemon half
+  fine as-is with just a contract test?
+
+## 5. One attach payload across the PTY seam + ReplayPlanner
+
+**Friction.** The attach payload is defined three times (~18 fields:
+`pty/manager.go:74`, `ptybackend/backend.go:59`, `ptyworker/protocol.go:111`)
+with four hand-written copy functions (`embedded.go:108`, `runtime.go:37`,
+`worker.go:645,981`); the 125-line replay-tail selection tree lives in the
+daemon (`ws_pty.go:210-335`) one seam away from the ring invariants it
+preserves; and startup recovery forks on a `RecoverableRuntime` type-assert that
+really means "am I on the worker backend?" (`daemon.go:908,1190`).
+
+**Investigate before discussing.**
+- [ ] Determine whether the wire struct (`ptyworker/protocol.go`) can share the
+      `pty` type directly (JSON tags, stability across worker RPC versions —
+      note RPC compat is never tested across a real version gap,
+      `protocol.go:5-21`) or needs codegen.
+- [ ] Sketch `pty.ReplayPlanner`'s interface and check the worker path can serve
+      it without new RPC methods.
+
+**Questions for Victor.**
+- Shared type vs codegen for the wire payload (shared type couples worker RPC
+  stability to `internal/pty` — acceptable?).
+- Fold the `Recover`-unification in here or treat it as its own small PR?
+
+## Decisions
+
+- These five stay investigation-first because each has a fork where the cheap
+  option changes behavior (keeper enforcement, unknown-command reply, handle
+  narrowing, RPC coupling) — encoding a guess into an implementation plan would
+  hand a weaker model a coin-flip.
+
+## Follow-ups
+
+- Also parked from the review's small list: deriving `ProtocolVersion` from a
+  schema hash (formatting-churn question), `transcript.Extract*` options
+  collapse, hub `EndpointIDFor(kind, id)` unification, shared WebGL atlas/glyph
+  core between `GhosttyWebGlRenderer` and `UnifiedGridRenderer`, and a worker
+  RPC version-skew contract test.

--- a/docs/plans/2026-07-02-daemon-test-harness.md
+++ b/docs/plans/2026-07-02-daemon-test-harness.md
@@ -1,0 +1,144 @@
+# Plan: Test the daemon through its production seam
+
+From the 2026-07-01 architecture review. Line references are as of commit
+`80c62f6b` — re-anchor by symbol name.
+
+## Goal
+
+The dominant daemon test pattern bypasses the production interface: construct a
+partial `Daemon` (or `NewForTesting`), fabricate a `&wsClient{send: make(chan
+outboundMessage, N)}`, call `d.handleClientMessage(client, data)` directly, and
+read `client.send`. Consequences:
+
+- The pre-dispatch logic in `handleWS`/`handleClientMessage` (capability gate
+  ~websocket.go:833, recovery gate ~842, selection capture, remote routing) is
+  untested on the common path.
+- Tests must **guess how many broadcasts a command emits** to size the channel
+  (buffers of 4/8/64 across ~40 sites) or the handler deadlocks — implementation
+  choreography leaking into every test.
+- The documented harness (`testharness.go`: `TestHarnessBuilder`,
+  `FakeClassifier`, `BroadcastRecorder`) is used by exactly one file, and six
+  bespoke PTY-backend fakes (daemon_test.go ~586/618/644/1555/1617,
+  reload_test.go ~37) re-implement the 9-method `ptybackend.Backend` by hand.
+
+Deepen the harness so tests cross the same seam production traffic does:
+`send(cmd) → events`. The interface is the test surface. This is also the safety
+net the other daemon refactor plans (session-state door, command registry) need.
+
+## Architecture Map
+
+```text
+Current (dominant):
+test -> &wsClient{send: chan(guess)} -> d.handleClientMessage(...)  // gates skipped
+test -> d.handleXxxWS(client, msg)                                  // dispatch skipped
+
+Already exists (used by ~10 tests, e.g. the web-client smoke test ~daemon_test.go:3905):
+real daemon Start() -> httpServer (ATTN_WS_PORT / d.httpServer ~daemon.go:1581)
+  -> websocket.Dial("ws://127.0.0.1:<port>/ws") -> writeWS / waitForDaemonWebSocketEvent
+
+Target (one harness, built FROM the existing pieces):
+h := NewTestHarness(t)            // TestHarnessBuilder grows: real WS server on :0,
+                                  // FakeClassifier, BroadcastRecorder, fake PTY backend
+c := h.ConnectWS(t)               // real dial, real accept/read/dispatch path
+c.Send(map[string]any{"cmd": ...})
+evt := c.WaitFor(t, timeout, func(evt) bool)   // no channel sizing, ever
+h.PTY.EmitOutput(sessionID, "...")             // scriptable in-memory backend
+```
+
+## Data Model / Interfaces
+
+```go
+// testharness.go additions
+type TestHarness struct {           // existing fields stay
+    ...
+    PTY *FakePTYBackend             // replaces the six bespoke fakes
+}
+func (h *TestHarness) StartWS(t *testing.T) (port int)   // httpServer on 127.0.0.1:0
+func (h *TestHarness) ConnectWS(t *testing.T) *WSTestClient
+
+type WSTestClient struct{ ... }     // wraps the existing writeWS/waitFor helpers
+func (c *WSTestClient) Send(t *testing.T, msg map[string]any)
+func (c *WSTestClient) WaitFor(t *testing.T, d time.Duration, match func(map[string]any) bool) map[string]any
+func (c *WSTestClient) Hello(t *testing.T)  // sendWorkspaceClientHello equivalent
+
+// ptybackend (or a testing sub-package): one scriptable fake implementing Backend
+type FakePTYBackend struct{ ... }   // Spawn/Attach/Input/Resize/Kill/Remove/SessionIDs/Recover/Shutdown
+func (f *FakePTYBackend) EmitOutput(sessionID string, data []byte)  // drives subscribers
+func (f *FakePTYBackend) EmitExit(sessionID string, code int)
+func (f *FakePTYBackend) Inputs(sessionID string) [][]byte          // assertions
+```
+
+The generalized helpers already exist as free functions in `daemon_test.go`
+(`writeWS`, `waitForDaemonWebSocketEvent`, `sendWorkspaceClientHello`,
+`waitForPtyOutputContaining`) — move them into `testharness.go` and make the
+smoke test the first consumer.
+
+## Boundaries
+
+- The harness owns: daemon construction (via the builder — one construction
+  path, not per-test struct literals), server lifecycle (`t.Cleanup` shutdown),
+  WS client plumbing, and the fake PTY backend.
+- Tests own: commands sent, events asserted, fake-backend scripting. Tests must
+  not size channels, construct `wsClient`, or call `handle*` methods directly.
+- `FakePTYBackend` implements `ptybackend.Backend` exactly — if it needs a
+  method the interface lacks, that is a finding, not a reason to type-assert.
+
+## Implementation Steps
+
+- [ ] PR 1 — harness core. Extend `TestHarnessBuilder`/`TestHarness` with
+      `StartWS`/`ConnectWS`/`WSTestClient` (move + generalize the existing
+      helpers). Port the web-client smoke test and 2-3 representative
+      fake-`wsClient` tests (pick ones asserting broadcasts, e.g. a PR-action
+      and a state-change test) to prove the shape. Builder gains
+      `WithPTYBackend(b ptybackend.Backend)`.
+- [ ] PR 2 — `FakePTYBackend`. Implement the scriptable fake; replace the six
+      bespoke fakes with it (each keeps its test-specific scripting inline).
+- [ ] PR 3+ — migration by adjacency, not big-bang: whenever a test file is
+      touched for any reason, its tests move to the harness. New daemon tests
+      MUST use the harness (add one line to AGENTS.md's testing notes saying so).
+- [ ] Retire-or-adopt check: after PR 1-2, `TestHarness` is the single documented
+      daemon test API; delete any builder options nothing uses.
+
+## Decisions
+
+- Build on the existing real-dial path rather than an in-memory
+  `net.Pipe`-based transport: the HTTP server on `127.0.0.1:0` is already proven
+  by ~10 tests, needs no new seam in production code, and tests the real
+  accept/read loop. Speed is acceptable (these are integration-grade tests).
+- No big-bang migration of `daemon_test.go` (5,840 lines): the two patterns
+  coexist; the harness must win by being easier to use.
+- The fake backend lives where daemon tests can import it without an import
+  cycle — `ptybackend` (exported, `testing`-tagged file) preferred so
+  `ptybackend`'s own tests can reuse it.
+
+## Verification
+
+```bash
+go build ./...
+go test ./internal/daemon -count=1        # no whole-package -race (known
+                                          # TestGitStatusScheduler race; use -run to scope)
+go test ./internal/ptybackend -count=1
+go vet ./internal/daemon
+```
+
+Structural asserts (end state of PR 2):
+
+- Ported tests contain no `&wsClient{` literals:
+  `grep -c '&wsClient{' internal/daemon/daemon_test.go` strictly decreases per
+  migration PR; new test files -> 0.
+- `grep -rn 'ptybackend.Backend' internal/daemon/*_test.go` shows only
+  `FakePTYBackend` (no bespoke struct fakes).
+
+Behaviors that must survive / be newly covered:
+
+1. Every ported test keeps its original assertions — port, don't weaken.
+2. New coverage that was impossible before: a test that an unknown `cmd` is
+   handled per the default arm; a test that the recovery gate rejects commands
+   pre-recovery; a test that a slow client hitting the 256-message buffer
+   behaves as documented (AGENTS.md Communication section).
+3. Harness startup/shutdown leak-free under `go test -count=5` (t.Cleanup order).
+
+## Follow-ups
+
+- Once the command-registry candidate (review card #5) lands, the harness is the
+  regression net proving dispatch equivalence arm-by-arm.

--- a/docs/plans/2026-07-02-frontend-request-seam.md
+++ b/docs/plans/2026-07-02-frontend-request-seam.md
@@ -1,0 +1,140 @@
+# Plan: One request seam for the app's socket
+
+From the 2026-07-01 architecture review. Line references are as of commit
+`80c62f6b` — re-anchor by symbol name.
+
+## Goal
+
+`app/src/hooks/useDaemonSocket.ts` (4,871 lines) hand-rolls the same
+request/result correlation 58 times: `new Promise` → build a string key →
+`pendingActionsRef.current.set(key, {resolve, reject})` → `ws.send` →
+`setTimeout(30s, reject)` — plus a matching `case '*_result'` arm in the 84-case
+`onmessage` switch that looks the key up and settles it. Key formats are
+invented per action and have already collided once (`sendCreateWorktree` vs
+`sendCreateWorktreeFromBranch`, documented as a gotcha in `app/CLAUDE.md`).
+
+Deepen the correlation into one module. Each `send*` becomes ~3 lines; the
+result routing becomes a declarative table; the key-collision bug class dies.
+
+**Behavior-preserving**: same commands on the wire, same timeout semantics, same
+rejection on disconnect.
+
+## Architecture Map
+
+```text
+Current (x58):
+sendPRAction (~3223)
+  new Promise -> key = `${id}:${action}` -> pendingActionsRef.set -> ws.send -> setTimeout(30s)
+onmessage switch (~1195-2600)
+  case 'pr_action_result': rebuild key -> get/delete pending -> resolve/reject
+onclose (~910, ~990): iterate pendingActionsRef, reject all ("connection lost")
+
+Target:
+requests = createRequestCorrelator({ send: ws.send })     // app/src/pty|utils/requestCorrelator.ts
+sendPRAction = (action, id, method) =>
+  requests.request({ cmd: `${action}_pr`, id, method }, { key: `pr:${id}:${action}` })
+
+onmessage: RESULT_ROUTES lookup FIRST, then the (shrinking) switch for
+           broadcast/store events
+RESULT_ROUTES: Record<event, { key(data), settle(data) -> {ok} | {err} }>
+onclose: requests.rejectAll('connection lost')
+```
+
+## Data Model / Interfaces
+
+```ts
+// requestCorrelator.ts — a plain module, no React. Unit-test in isolation.
+type Settled<T> = { ok: T } | { err: string };
+
+function createRequestCorrelator(deps: { send(msg: object): boolean }) {
+  const pending = new Map<string, { resolve; reject; timer }>();
+  return {
+    // key must be unique per in-flight request; helper for sequenced keys:
+    nextKey(prefix: string): string,               // `${prefix}:${seq++}`
+    request<T>(msg: object, opts: { key: string; timeoutMs?: number }): Promise<T>,
+    settle(key: string, result: Settled<unknown>): boolean,  // false = no pending entry
+    rejectAll(reason: string): void,
+  };
+}
+
+// result routing — data, not code:
+const RESULT_ROUTES: Record<string, (data: any) => { key: string; result: Settled<any> }>
+```
+
+Keys get a per-command prefix (`pr:`, `worktree:`, `snapshot:` …) plus the
+existing identifying fields; where today's key can collide, use `nextKey` and
+echo the request id through the daemon's existing `request_id` fields (several
+commands already carry one — e.g. `workspaceActionKey` ~600).
+
+## Boundaries
+
+- The correlator owns: pending map, key uniqueness discipline, timeouts,
+  reject-on-disconnect. It knows nothing about React, WebSocket lifecycle, or
+  event shapes.
+- `RESULT_ROUTES` owns: event-name → key + success/error extraction. It must not
+  touch stores or component state — result events that ALSO update a store keep
+  that store update in the switch (route first, then fall through if needed).
+- `useDaemonSocket` keeps: socket lifecycle, reconnect/backoff, broadcast-event
+  handling. Its returned functions become thin `requests.request(...)` calls.
+
+## Implementation Steps
+
+- [ ] PR 1: add `requestCorrelator.ts` + unit tests (resolve, reject-on-error
+      result, timeout fires and cleans up, rejectAll, duplicate-key request is a
+      programmer error — throw). Wire it into `useDaemonSocket`; migrate the
+      canonical `sendPRAction` + `pr_action_result` as the proof, leaving
+      everything else untouched. Update the "Async Pattern Guide" comment
+      (~727-760) to describe the new one-liner recipe.
+- [ ] PR 2..N: migrate the remaining ~57 promise-based senders in clusters
+      (PRs/repo, worktrees, workspace actions, fs/notebook, screen snapshots,
+      tickets…), one PR per cluster, deleting each matching switch arm as its
+      route lands in `RESULT_ROUTES`. Keep each PR under ~400 lines of diff.
+- [ ] Final PR: assert the end state (greps below), update `app/CLAUDE.md`
+      gotchas #1/#2 — the 4-step ritual and the key-collision warning should be
+      replaced by "add a route + a 3-line sender".
+
+## Decisions
+
+- The correlator is a plain module, not a hook: no re-render coupling, trivially
+  unit-testable, and `useDaemonSocket` already holds it in a ref.
+- Fire-and-forget senders (the optimistic pattern in the guide comment) are NOT
+  converted — that's a UX decision per action, out of scope.
+- Do not batch-migrate all 58 in one PR: the per-cluster slicing keeps each diff
+  reviewable and bisectable.
+
+## Verification
+
+Per PR:
+
+```bash
+cd app
+pnpm test                      # useDaemonSocket.test.tsx (2,893 lines) is the net —
+                               # it drives behavior via MockWebSocket frames and
+                               # must stay green with MINIMAL edits (only where a
+                               # test asserted an internal key format)
+pnpm run typecheck 2>/dev/null || pnpm exec tsc --noEmit
+```
+
+End-state structural asserts:
+
+```bash
+grep -c 'new Promise' app/src/hooks/useDaemonSocket.ts          # -> ~1 (socket open) or 0
+grep -c 'pendingActionsRef' app/src/hooks/useDaemonSocket.ts    # -> 0 (ref replaced by correlator)
+```
+
+Behaviors that must survive:
+
+1. 30s default timeout, same rejection message semantics callers display.
+2. All in-flight requests reject on socket close/reconnect (today's onclose
+   sweep at ~910/~990).
+3. Result events that also feed stores (e.g. list-shaped results) still update
+   those stores.
+4. Manual: `make dev` (or `pnpm run dev`), then approve/merge a PR from the PR
+   panel, create + delete a worktree from the UI, and open a notebook file —
+   loading states resolve, errors surface as toasts, nothing hangs.
+
+## Follow-ups
+
+- The 17 `on*Update` callbacks / five-sources-of-truth problem (review card #7:
+  one normalized store + `useDaemon()` context) builds on this but is its own
+  design conversation — do not fold it in here.

--- a/docs/plans/2026-07-02-session-state-door.md
+++ b/docs/plans/2026-07-02-session-state-door.md
@@ -1,0 +1,185 @@
+# Plan: One door for session state (`applyState`)
+
+From the 2026-07-01 architecture review (top recommendation). Line references are
+as of commit `80c62f6b` — always re-anchor by symbol name, not line number.
+
+## Goal
+
+Session state writes are smeared across four copy-pasted choreographies plus five
+raw `store.UpdateState` calls, each applying a *different subset* of guards and
+side effects. The stale-classifier guard (`UpdateStateWithTimestamp`) is a
+convention with exactly one caller, documented as AGENTS.md Critical Pattern #3
+instead of being enforced by an interface.
+
+Deepen this into one module: every session state transition goes through a single
+`applyState` door that owns the guards, side effects, and broadcast. A bug fixed
+there is fixed for every writer. AGENTS.md #3 stops being tribal knowledge.
+
+**This is a behavior-preserving refactor.** No state transition, guard, or
+broadcast may change observably. The per-source differences below are the spec.
+
+## Architecture Map
+
+```text
+Current (4 choreographies + 5 raw writes, all converging on store.UpdateState):
+
+hook/socket path      -> handleState (daemon.go ~2104)
+                           markRunStartedIfNeeded/clearLongRunTracking
+                           store.UpdateState + store.Touch
+                           cancelNudgeOnLeaveIdle, sendOK
+                           broadcast + recomputeAndBroadcastWorkspaceForSession
+PTY detector          -> handlePTYState (daemon.go ~1513)
+                           guard: GetAgentDriverRun + pluginDriverReportsState
+                           guard: agentdriver.ShouldApplyPTYState
+                           same as above + go notifyTicketSessionWentIdle (on idle)
+classifier            -> updateAndBroadcastStateWithTimestamp (daemon.go ~2775)
+                           store.UpdateStateWithTimestamp (CAS)  <- the ONLY guarded door
+transcript watcher    -> updateAndBroadcastState (daemon.go ~2750)
+                           same but NO store.Touch
+startup recovery      -> raw store.UpdateState (daemon.go ~844, ~1121, ~1132, ~1167)
+session exit          -> raw store.UpdateState (daemon.go ~1398) + Touch + broadcast
+
+Target:
+
+every writer
+  -> d.applyState(sessionID, state, stateChangeOpts{...})   // one module: session_state.go
+       -> guards (per opts)
+       -> run-tracking side effects
+       -> store write (always timestamp-CAS)
+       -> nudge cancel, ticket doorbell (per opts)
+       -> broadcast + workspace recompute (per opts)
+grep proof: store.UpdateState( appears ONLY inside session_state.go
+```
+
+## Data Model / Interfaces
+
+New file `internal/daemon/session_state.go`:
+
+```go
+// stateChangeOpts encodes the (small, deliberate) differences between writers.
+// The defaults reproduce updateAndBroadcastState. Every field maps 1:1 to a
+// behavior in the Current tree above — do not invent new combinations.
+type stateChangeOpts struct {
+    observedAt   time.Time // zero => time.Now(); classifier passes its captured start time
+    touch        bool      // hook, PTY, session-exit paths set true
+    broadcast    bool      // default true; some recovery writes set false
+    ticketNudge  bool      // PTY path only: go notifyTicketSessionWentIdle on idle
+}
+
+// applyState is the ONLY place allowed to call store.UpdateState*.
+// Returns false when the CAS rejects a stale write.
+func (d *Daemon) applyState(sessionID, state string, opts stateChangeOpts) bool
+```
+
+Store side: `UpdateState(id, state)` becomes a thin wrapper over
+`UpdateStateWithTimestamp(id, state, time.Now())` (a fresh timestamp always wins,
+so current callers keep identical behavior), then delete the wrapper once the
+daemon only calls the timestamped method through `applyState`.
+
+The PTY-specific guards (`GetAgentDriverRun`/`pluginDriverReportsState`,
+`ShouldApplyPTYState`) stay in `handlePTYState` *before* the `applyState` call —
+they are about whether the PTY observation is trustworthy, not about how a state
+write happens. `handlePTYState` shrinks to guards + one `applyState` call.
+
+## Boundaries
+
+- `session_state.go` owns: run tracking (`markRunStartedIfNeeded`,
+  `clearLongRunTracking`), the store write, `cancelNudgeOnLeaveIdle`, the ticket
+  doorbell dispatch, the `EventSessionStateChanged` broadcast, and
+  `recomputeAndBroadcastWorkspaceForSession`.
+- Callers own: source-specific guards (PTY trust checks), transport replies
+  (`sendOK` stays in `handleState`), and *when* to capture `observedAt`
+  (classifier captures before slow work — keep `classificationStartTime` at the
+  top of `classifySessionState`).
+- Nothing outside `session_state.go` may call `d.store.UpdateState` or
+  `d.store.UpdateStateWithTimestamp`. Reads (`store.Get`) are unrestricted.
+- Hook-authoritative states must survive: do not weaken `ShouldApplyPTYState`
+  (see AGENTS.md; the per-agent policy seam in `internal/agent/daemon_policy.go`
+  is correct and stays).
+
+## Implementation Steps
+
+- [ ] PR 1 — the door. Add `session_state.go` with `applyState` + `stateChangeOpts`.
+      Rewrite the four choreographies as calls into it (`handleState`,
+      `handlePTYState`, `updateAndBroadcastState`,
+      `updateAndBroadcastStateWithTimestamp` — keep the last two as one-line
+      deprecated wrappers if that shrinks the diff, then inline them in PR 2).
+      Add table-driven tests for `applyState` itself: per-source option sets ×
+      (fresh timestamp, stale timestamp) asserting store state, broadcast
+      emission (use `BroadcastRecorder` from `testharness.go`), touch, and
+      nudge-cancel calls.
+- [ ] PR 2 — fold the stragglers. Convert the five raw sites (recovery writes at
+      daemon.go ~844/~1121/~1132/~1167 — keep `broadcast:false` to match today;
+      session-exit at ~1398 with `touch:true`) and the transcript-watcher calls.
+      Delete the wrapper methods. Add the structural guard: a test asserting
+      `store.UpdateState` has no non-test callers outside `session_state.go`.
+      While folding, grep the whole daemon package for other writers you may
+      have missed (`grep -rn 'store\.UpdateState' internal/daemon`) — fold every
+      hit, don't leave stragglers.
+- [ ] PR 3 — shrink AGENTS.md #3. Replace the "Classifier Timestamp Protection"
+      pattern text with two sentences pointing at `applyState` as the invariant
+      owner.
+- [ ] Optional PR 4 — `stopdecision`. Extract the non-LLM parts of
+      `classifySessionState` (pending-todo fast path, capability gates,
+      empty-message → idle, parse-error → unknown) into a pure
+      `Decide(session, transcriptText, classifier) (state, ok)` module so the
+      WAITING/DONE decision is unit-testable without driving the 110-line daemon
+      method.
+
+## Decisions
+
+- Store keeps ONE write method (timestamped CAS); "un-guarded" callers pass a
+  fresh `time.Now()`, which is semantically identical to today's unguarded write.
+  Rejected: keeping two store methods — that is exactly the two-doors bug source.
+- The recovery-path writes keep their no-broadcast behavior (`broadcast:false`)
+  rather than being "fixed" to broadcast: startup reconcile runs before clients
+  attach and batch-reports via its own path. Do not change it in this refactor.
+- `sendOK`/transport replies stay out of `applyState` — the door is
+  transport-agnostic.
+
+## Verification
+
+Run after each PR:
+
+```bash
+go build ./...
+go test ./internal/daemon -run 'TestSessionStateDoor|State|Classif|Nudge|Recover|Reconcile' -count=1
+go test ./internal/daemon -count=1          # full package; do NOT use -race on the
+                                            # whole package (known pre-existing race
+                                            # in TestGitStatusScheduler; scope -race
+                                            # with -run if you need it)
+go test ./internal/store ./internal/classifier ./internal/transcript -count=1
+```
+
+Structural asserts (all must hold when PR 2 lands):
+
+```bash
+# the door is the only writer:
+grep -rn 'store\.UpdateState' internal/daemon --include='*.go' | grep -v _test | grep -v session_state.go
+# -> no output
+# the old choreographies are gone:
+grep -rn 'updateAndBroadcastState' internal/daemon --include='*.go' | grep -v _test
+# -> no output
+```
+
+Behaviors that must survive (spot-check via existing tests + manual `make dev`):
+
+1. Stale classifier result never overwrites a fresher state (existing
+   classifier tests must stay green unmodified — if one needs editing, the
+   refactor changed behavior).
+2. PTY detector still refuses to clobber hook-authoritative states
+   (`ShouldApplyPTYState` tests unmodified).
+3. Ticket doorbell still fires when a PTY-observed session goes idle, and only
+   on that path.
+4. Nudge countdown still cancels on leaving idle for hook AND PTY paths.
+5. Long-run tracking: `working` starts a run; `idle`/`scheduled` clears it, on
+   every path that did so before.
+6. Manual: `make dev`, run a Claude session, confirm the sidebar state flow
+   launching → working → waiting_input/idle behaves normally, and approval
+   (pending_approval) still clears.
+
+## Follow-ups
+
+- The store change-event candidate (see
+  `2026-07-02-store-single-implementation.md` follow-ups) generalizes this
+  one-door pattern to all entities; `applyState` becomes its first client.

--- a/docs/plans/2026-07-02-small-deepenings.md
+++ b/docs/plans/2026-07-02-small-deepenings.md
@@ -1,0 +1,117 @@
+# Plan: Small deepenings (dead code, duplicated primitives, migration dispatch)
+
+From the 2026-07-01 architecture review — the bounded wins that don't warrant
+their own plan. Each item is independent; land them as separate small PRs (or
+batch A+B, which are trivial). Line references as of `80c62f6b` — re-anchor by
+symbol name.
+
+## A. Delete the dead journal writers
+
+`internal/notebook/store.go` `AppendJournal` (~153) and
+`AppendJournalEntryOnce` (~173) have **zero production callers** — verify first:
+
+```bash
+grep -rn 'AppendJournal' --include='*.go' internal/ cmd/ | grep -v _test | grep -v 'internal/notebook/store.go'
+# must print nothing; if it prints something, STOP — the premise changed
+```
+
+Their doc comments describe dispatch-outcome wiring that doesn't exist. The
+journal is agent-written by design (the keeper's narrate duty writes via a
+headless agent; see `internal/daemon/notebook_narration.go` ~472 and
+`docs/glossary.md`).
+
+- [ ] Delete both methods + their tests in `internal/notebook/store_test.go`
+      (~159-422 region; delete only the tests for these two methods).
+- [ ] Keep `AppendInbox` — it has a live caller (`internal/daemon/notebook.go` ~352).
+- [ ] Add one sentence to the `notebook` package doc: the journal is written by
+      agents through the daemon's narration path, not through a store API.
+
+Verify: `go build ./... && go test ./internal/notebook -count=1`.
+
+## B. One `writeAtomic`
+
+Three verbatim copies: `internal/notebook/store.go`,
+`internal/fsdoc/store.go` (~290, self-described as "a focused copy"),
+`internal/tasks/store.go` (~204).
+
+- [ ] Create `internal/atomicfile` with the one function (same signature as the
+      existing copies; keep the tmp-file + rename semantics EXACTLY — atomic
+      rename is what makes editor/agent concurrent access safe).
+- [ ] Point all three stores at it; delete the copies.
+
+Verify:
+
+```bash
+go test ./internal/notebook ./internal/fsdoc ./internal/tasks -count=1
+grep -rn 'func writeAtomic' internal/ --include='*.go' | grep -v atomicfile   # -> no output
+```
+
+## C. Migration versions live once
+
+`internal/store/sqlite.go`: the `migrations` slice (~100, 59 entries) pairs with
+a ~20-branch `else if m.version == N` dispatch chain (~599-720). A complex
+migration needs its number to agree in three places; the slice's `sql` field is
+dead (`"SELECT 1"`, `""`) for chain-dispatched versions. Burned-version scar
+tissue (33, 49/50/51/52 — see comments ~450-456) makes renumbering forbidden.
+
+Target shape:
+
+```go
+type migration struct {
+    version int
+    name    string
+    sql     string                 // simple migrations
+    apply   func(tx *sql.Tx) error // complex migrations; wins over sql when set
+}
+// runner: one loop —
+// if m.apply != nil { m.apply(tx) } else if m.sql != "" { tx.Exec(m.sql) }
+```
+
+- [ ] Add the `apply` field; convert each dispatch-chain branch into the
+      corresponding slice entry's `apply` (move the body of `applyMigrationN`
+      into a named func referenced from the entry).
+- [ ] Delete the version if/else chain entirely.
+- [ ] Do NOT renumber, merge, or "clean up" any migration, including the burned
+      ones — empty/`SELECT 1` entries stay as entries (with their comments).
+      The `49 || 50` merged branch becomes two entries pointing at the same
+      `apply` func.
+
+Verify (this one deserves care — it touches every future DB):
+
+```bash
+go test ./internal/store/... -count=1        # migration + legacy tests must pass unmodified
+# fresh-DB smoke: create a store on a temp path and confirm schema version:
+go test ./internal/store -run 'Migrat|Legacy|Schema' -v -count=1
+```
+
+And on a real dev profile: `make dev`, confirm the dev daemon starts cleanly and
+`~/.attn-dev/attn.db` reports the same `MAX(version)` in `schema_migrations` as
+before the change (`sqlite3 ~/.attn-dev/attn.db 'select max(version) from schema_migrations'`).
+
+## D. Sweep the retired "janitor" vocabulary
+
+`internal/agent/driver.go` comments (~311, 315, 326, 370, 375, 378) still
+narrate the headless contract in terms of "the janitor", a persona
+`docs/glossary.md` retired in favor of **the keeper**. Persisted values already
+migrated (`workspace_keeper.go` ~26/131).
+
+- [ ] s/janitor/keeper/ in those comments (comments only — no identifiers, no
+      persisted strings; the migration code that references the OLD
+      `attn-janitor` value must keep referencing it, that's its job).
+
+Verify: `grep -rn 'janitor' internal/ --include='*.go' | grep -v _test` — the
+remaining hits should only be the persisted-value migration in
+`workspace_keeper.go` and its test.
+
+## Decisions
+
+- Deliberately excluded from this plan: deriving `ProtocolVersion` from a schema
+  hash (needs a design pass — hash-of-generated-file churns on formatting), and
+  the `transcript.Extract*` options-struct collapse (touch it when next in that
+  package). Both stay on the review's list.
+
+## Verification (whole plan)
+
+```bash
+make test          # after each item lands
+```

--- a/docs/plans/2026-07-02-store-single-implementation.md
+++ b/docs/plans/2026-07-02-store-single-implementation.md
@@ -1,0 +1,112 @@
+# Plan: Store single implementation (delete the map fallback)
+
+From the 2026-07-01 architecture review. Line references are as of commit
+`80c62f6b` — re-anchor by symbol name.
+
+## Goal
+
+`internal/store` carries a complete second implementation: 116
+`if s.db == nil` branches across 10 files switch between SQLite bodies and a
+parallel map-based store (`sessions`, `agentMetadata`, `profileRoles`,
+`workspaces`, `recentLocations`, `agentDriverRuns` fields). The map path only
+executes when `OpenDB(":memory:")` fails inside `New()` (`store.go` ~41) — i.e.
+when SQLite itself is broken, which no test exercises and production never hits
+(`store.New()` already IS the in-memory SQLite store; the daemon's
+"persistence degraded" fallback at `daemon.go` ~454 calls `New()`, not the maps).
+
+Delete the parallel universe. Every method keeps one body. This is a deletion
+that concentrates nothing elsewhere — the textbook pass of the deletion test.
+
+**Behavior-preserving**: no caller sees a different result. Only the
+never-executed branch dies.
+
+## Architecture Map
+
+```text
+Current:
+store.New() -> OpenDB(":memory:") ok?  -> Store{db}          (every real run)
+                                  fail? -> Store{maps...}     (dead: needs broken SQLite)
+each method: if s.db == nil { map body } else { SQLite body }   x116
+
+Target:
+store.New() -> OpenDB(":memory:") ok?  -> Store{db}
+                                  fail? -> panic("attn: cannot open in-memory sqlite: <err>")
+each method: one SQLite body
+
+Unchanged:
+daemon.New: NewWithDB(dbPath) fail -> store.New() + persistence-degraded warning
+```
+
+Panic is correct here: `:memory:` failing means the compiled-in SQLite driver is
+broken — the binary cannot function, and limping along with a silently
+non-persistent half-store is worse than a clear crash at startup.
+
+## Boundaries
+
+- `New() *Store` keeps its signature (callers: `testharness.go`, several daemon
+  tests, `daemon.go` fallback, `NewForTesting`/`NewWithGitHubClient`). Do not
+  change it to return an error — that fans out to every test for zero value.
+- `NewWithDB` / `NewWithPersistence` / `OpenDB` are untouched.
+- Migrations (`sqlite.go`) are untouched by this plan.
+
+## Implementation Steps
+
+- [ ] Single PR (mechanical, large-but-boring diff is expected and fine):
+  - [ ] In `New()` (`store.go` ~41): replace the map-construction fallback with
+        `panic(fmt.Sprintf("attn: cannot open in-memory sqlite: %v", err))`.
+  - [ ] Delete the map fields from the `Store` struct (`sessions`,
+        `agentDriverRuns`, `agentMetadata`, `profileRoles`, `workspaces`,
+        `recentLocations`) and any now-unused mutexes that existed only for them.
+        Keep fields that the SQLite path also uses — check each field's readers
+        before deleting (`grep -n '<field>' internal/store/*.go`).
+  - [ ] For each of the 116 `if s.db == nil` branches: delete the map arm, keep
+        the SQLite arm, unindent. Work file by file; after each file run
+        `go build ./internal/store && go test ./internal/store -count=1`.
+  - [ ] Delete map-only helpers that lose their last caller (compiler +
+        `go vet` will name them; also run a final
+        `grep -rn 'sessions\[' internal/store` style sweep per deleted field).
+  - [ ] Fix the AGENTS.md architecture snapshot line "`internal/store`:
+        SQLite-backed state with in-memory cache" → "SQLite-backed state
+        (`:memory:` when no DB path)". It was never a cache.
+
+## Decisions
+
+- Panic over error-return in `New()`: keeps ~15 call sites unchanged; the
+  failure mode is "binary is broken", not a runtime condition to handle.
+- Role interfaces (`SessionStore`, `TicketStore`, …) and store change events are
+  deliberately NOT in this plan — they need the design conversation from the
+  review's grilling loop. This plan is the mechanical, unambiguous slice.
+
+## Verification
+
+```bash
+go build ./...
+go test ./internal/store/... -count=1
+go test ./internal/daemon -count=1     # no -race on the whole package (known
+                                       # TestGitStatusScheduler race; scope with -run)
+make test                              # full Go suite
+```
+
+Structural asserts (must hold at the end):
+
+```bash
+grep -rc 'if s.db == nil' internal/store/*.go | awk -F: '{s+=$2} END {print s}'   # -> 0
+grep -n 'sessions\s*map\[string\]\*protocol.Session' internal/store/store.go      # -> no output
+```
+
+Behaviors that must survive:
+
+1. `store.New()` still yields a fully working store for every test that uses it
+   (the whole daemon test suite is the regression net).
+2. Daemon persistence-degraded startup: `NewWithDB` failure still produces a
+   working in-memory store + `warnPersistenceDegraded` warning (there are
+   existing tests around startup warnings — they must stay green unmodified).
+3. Clone-on-read semantics: `Get` still returns copies, never internal pointers
+   (existing tests cover this; don't touch `cloneSession`).
+
+## Follow-ups
+
+- Role interfaces at point of use (the `ticketnotify` 2-method `EventStore` is
+  the exemplar) — do after this lands; the surface is easier to see with one body.
+- Typed change events from the store + a single daemon broadcast pump (replaces
+  ~40 `broadcast*` helpers). Needs design; see the review's store card.

--- a/docs/plans/2026-07-02-worktree-module.md
+++ b/docs/plans/2026-07-02-worktree-module.md
@@ -1,0 +1,154 @@
+# Plan: One worktree module, hooks inside
+
+From the 2026-07-01 architecture review. Line references are as of commit
+`80c62f6b` — re-anchor by symbol name.
+
+## Goal
+
+Worktree lifecycle orchestration exists twice, and the copies have diverged in a
+way that matters:
+
+- **Daemon path** (`internal/daemon/worktree.go` `doCreateWorktree` ~100,
+  `doDeleteWorktree` ~247): dispatches the `worktree.before_create` /
+  `worktree.create` provider / `worktree.after_create` plugin surfaces
+  (`plugin_worktree.go`), registers the worktree in the store
+  (`registerCreatedWorktree`), and broadcasts.
+- **Workflow driver path** (`internal/workflow/driveragent.go` `runIsolated`
+  ~236): calls `git.GenerateWorktreePath` + `git.CreateWorktree` +
+  `git.DeleteWorktree` directly. It runs in the **CLI process** (the goja engine
+  lives in `cmd/attn/workflow.go`), where the daemon's plugin registry does not
+  exist — so workflow-isolated worktrees **silently skip every worktree plugin
+  provider** and are invisible to the daemon's worktree bookkeeping.
+
+Meanwhile `internal/git/worktree.go` ~50-105 accumulated five shallow
+`CreateWorktree*` variants (one per call-site preference) — interface as wide as
+the implementation.
+
+Deepen: one `worktree` module owning spec → hooks → create → cleanup, with the
+plugin chain injected as a seam. The daemon and the delegation path become
+callers of one implementation; the workflow driver stops bypassing hooks.
+
+## Architecture Map
+
+```text
+Current:
+daemon doCreateWorktree ─> before_create hooks ─> create provider | git.CreateWorktree*
+                        ─> registerCreatedWorktree ─> after_create hooks ─> broadcast
+delegate.go ────────────> d.doCreateWorktree (OK: gets hooks)
+workflow driveragent ───> git.CreateWorktree directly        LEAK: no hooks, no bookkeeping
+                          (CLI process — cannot reach the daemon's plugin registry in-process)
+
+Target:
+internal/worktree (new package)
+  Create(spec Spec, hooks Hooks) (Handle, error)     // path gen + create, hooks around it
+  Handle.Cleanup(force bool) error                   // delete + branch prune
+daemon  ─> worktree.Create(spec, pluginHooks{d})     // adapter over plugin_worktree.go dispatch
+workflow driver ─> daemon over the existing unix socket (client call) ─> same door
+                   (fail-closed if the daemon is unreachable — matches today's
+                    fail-closed CreateWorktree error contract in runIsolated)
+```
+
+## Data Model / Interfaces
+
+```go
+// internal/worktree
+type Spec struct {
+    MainRepo     string
+    Branch       string
+    StartingFrom string // "" => the package's default (origin/main resolution)
+    RequestedPath string // "" => GenerateWorktreePath
+}
+
+type Hooks interface {           // the seam; two real adapters justify it:
+    BeforeCreate(Spec) error     //   daemon: plugin surface dispatch
+    Create(Spec) (path string, handled bool, err error)  // provider may take over creation
+    AfterCreate(Spec, path string) error
+}                                //   tests: recording fake
+type NoHooks struct{}            // explicit no-op adapter for hookless contexts
+
+type Handle struct { Repo, Path, Branch string }
+func Create(spec Spec, hooks Hooks) (Handle, error)
+func (h Handle) Cleanup(force bool) error   // absorbs DeleteWorktree + DeleteBranch
+```
+
+The five `git.CreateWorktree*` variants collapse into `Create` honoring
+`Spec.StartingFrom`/`Spec.RequestedPath`; `internal/git` keeps only the thin
+`git worktree add` execution the module calls.
+
+## Boundaries
+
+- `internal/worktree` owns path generation, creation, hook ordering, and cleanup.
+  It must not import `internal/daemon` or know what a plugin is — it sees `Hooks`.
+- The daemon owns the plugin-backed `Hooks` adapter and store
+  registration/broadcast (registration stays daemon-side; it is bookkeeping, not
+  creation).
+- The workflow driver must not shell out to git for worktrees once stage 2 lands;
+  it asks the daemon. Its cleanliness-based keep/delete policy
+  (`runIsolated`: keep dirty worktrees, delete clean ones) stays in the driver —
+  that is workflow policy, not worktree mechanics.
+
+## Implementation Steps
+
+- [ ] Stage 1 (pure refactor, no behavior change): create `internal/worktree`,
+      move orchestration out of `doCreateWorktree`/`doDeleteWorktree` into it,
+      implement the daemon's plugin `Hooks` adapter, collapse the
+      `git.CreateWorktree*` variants (update `delegate.go` and remaining callers).
+      The workflow driver keeps calling git directly in this stage (now via
+      `worktree.Create(spec, worktree.NoHooks{})` so the divergence is at least
+      explicit and greppable).
+- [ ] Stage 2 (closes the leak — **gated on the open question below**): add a
+      socket command (or extend `CmdCreateWorktree` with an `ephemeral` flag —
+      protocol change: follow AGENTS.md Critical Pattern #1, bump
+      `ProtocolVersion`), add the matching `internal/client` method, and switch
+      `driverAgent.runIsolated` to create/cleanup through the daemon.
+      Fail-closed when the daemon is unreachable.
+- [ ] Update the review-era AGENTS.md notes if any mention the bypass.
+
+## Decisions
+
+- Hooks as an injected interface rather than moving plugin dispatch into the
+  module: the plugin registry is daemon-process state; the module must stay
+  usable from tests and (stage 1) the CLI process. Two adapters (plugin-backed,
+  recording fake) make the seam real.
+- Worktree store registration stays out of the module — it is daemon bookkeeping
+  with its own broadcast lifecycle.
+
+## Open Questions
+
+- Stage 2: should workflow-isolated worktrees be *registered* daemon-side (they
+  become visible in the worktrees UI, possibly noisy for N parallel agents) or
+  created through an `ephemeral` mode that runs hooks but skips
+  registration/broadcast? Decide with Victor before implementing stage 2.
+
+## Verification
+
+```bash
+go build ./...
+go test ./internal/worktree ./internal/git ./internal/workflow -count=1
+go test ./internal/daemon -run 'Worktree|Delegate|Plugin' -count=1
+```
+
+Structural asserts after stage 1:
+
+```bash
+grep -rn 'git\.CreateWorktree' internal/ --include='*.go' | grep -v _test | grep -v 'internal/worktree/'
+# -> no output (all creation goes through the module)
+```
+
+Behavior checks:
+
+1. Existing daemon worktree tests (`plugin_worktree_test.go`,
+   `worktree`-related cases in `daemon_test.go`) stay green **unmodified** in
+   stage 1 — they are the spec for hook ordering and provider-takeover behavior.
+2. Delegation still creates worktrees with hooks (existing `delegate_test.go`).
+3. Workflow isolation tests (`internal/workflow`) stay green in stage 1; stage 2
+   adds a test asserting the driver's create path dispatches hooks (fake daemon
+   or recording Hooks).
+4. Manual (stage 2): `make dev`, run a workflow with `isolation: 'worktree'`,
+   confirm worktree creation/cleanup works and hook logs appear in
+   `~/.attn-dev/daemon.log` (`worktree hook plugin=… status=completed`).
+
+## Follow-ups
+
+- `doDeleteWorktree`'s provider-error classification could move into the module
+  once stage 1 proves the shape.


### PR DESCRIPTION
## What

Six plan docs in `docs/plans/`, one per deepening candidate from the 2026-07-01 architecture review that I'd stake on now:

| Plan | Review card | Shape |
|---|---|---|
| `2026-07-02-session-state-door.md` | #1 (top recommendation) | one `applyState` door for all session-state writes; store timestamp-CAS; optional `stopdecision` extraction |
| `2026-07-02-store-single-implementation.md` | #2 (first slice) | delete the 116-branch `if s.db == nil` parallel map store; one SQLite body |
| `2026-07-02-worktree-module.md` | #4 | one worktree module with the plugin chain injected; closes the workflow-driver hook bypass (stage 2 gated on one open question) |
| `2026-07-02-frontend-request-seam.md` | #6 | one request correlator + declarative result routing replacing 58 copy-pasted promise blocks |
| `2026-07-02-daemon-test-harness.md` | #10 | `send(cmd) → events` harness over the real WS path + one scriptable fake PTY backend |
| `2026-07-02-small-deepenings.md` | small wins | dead `AppendJournal*` deletion, shared `writeAtomic`, migration `apply func` dispatch, janitor→keeper comment sweep |

Candidates that need the grilling conversation first (keeper module, command registry, frontend one-source-of-truth, terminal-invariant modules, PTY payload/ReplayPlanner) are captured in a seventh doc, `2026-07-02-architecture-review-open-candidates.md`: condensed friction with anchors, what to investigate up front, and the questions to settle — investigation-first, not implementation plans.

## Written for a weaker implementing model

Each plan carries: exact symbols with line anchors (as of `80c62f6b`, with a re-anchor-by-symbol instruction), current/target architecture trees, explicit boundaries and do-nots, steps sliced into small PRs, a "behaviors that must survive" list, and runnable verification — both tests and structural greps that prove the old pattern is gone (e.g. `grep -c 'if s.db == nil' internal/store/*.go` → 0). Known traps are called out inline (no whole-package `-race` on `internal/daemon`, burned migration versions, protocol-version bump rules).

## Verification claims were checked

Every load-bearing count/claim in the plans was verified against the working tree before writing (dual-mode branch count, zero `AppendJournal` production callers, the workflow `git.CreateWorktree` bypass, single `UpdateStateWithTimestamp` caller, switch-arm counts, promise-block counts).

Docs-only change; no changelog entry.

https://claude.ai/code/session_014UfxainTytzQ5QAypPeWRp
