### PR TITLE
fix(tickets): make the ticket comment box submittable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-02]
+
+### Fixed
+- **You can post comments from the ticket detail panel again.** The panel's comment box had no usable way to submit — the "Add comment" button was rendered in an undefined accent color that painted it invisibly against the panel, and there was no keyboard shortcut — so a comment typed in the app couldn't be posted (only the `attn ticket comment` CLI worked). The button is now visible, and **⌘Return** (Ctrl+Return off-mac) posts the comment without leaving the field; plain Enter still adds a newline. The button stays disabled until you've typed something and while a post is in flight, clears on success, and shows an error if the post fails. The same missing accent/error colors also left ticket status accents and error text uncolored throughout the panel; those now render as intended.
+
 ## [2026-07-01]
 
 ### Added

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -12,6 +12,15 @@
   --accent: #ff6b35;
   --accent-glow: rgba(255, 107, 53, 0.15);
 
+  /* Functional accent + status colors. Theme-invariant, so defined once here in
+     :root and inherited by every theme block below (which only override the
+     neutral grays). Several components reference these as var(--color-accent,
+     #5b8cff) / var(--color-error, #ef4444); defining them makes the bare
+     references (e.g. the ticket comment submit button, the crashed badge, the
+     action-error text) render instead of collapsing to an invisible no-op. */
+  --color-accent: #5b8cff;
+  --color-error: #ef4444;
+
   color-scheme: dark;
 
   /* Theme colors (dark defaults) */

--- a/app/src/components/TicketDetailPanel.test.tsx
+++ b/app/src/components/TicketDetailPanel.test.tsx
@@ -206,6 +206,111 @@ describe('TicketDetailPanel', () => {
     await waitFor(() => expect(input.value).toBe(''));
   });
 
+  it('submits a comment with ⌘Return and with Ctrl+Return, clearing the draft', async () => {
+    for (const modifier of ['metaKey', 'ctrlKey'] as const) {
+      const fetchTicket = vi.fn().mockResolvedValue(makeTicket());
+      const onAddComment = vi.fn().mockResolvedValue(undefined);
+      const { unmount } = render(
+        <TicketDetailPanel
+          isOpen
+          ticketId="store-migration"
+          ticketRow={makeTicket()}
+          fetchTicket={fetchTicket}
+          onAddComment={onAddComment}
+          onClose={() => {}}
+        />,
+      );
+      await waitFor(() => screen.getByTestId('ticket-comment-input'));
+
+      const input = screen.getByTestId('ticket-comment-input') as HTMLTextAreaElement;
+      fireEvent.change(input, { target: { value: 'ship it' } });
+      fireEvent.keyDown(input, { key: 'Enter', [modifier]: true });
+
+      expect(onAddComment).toHaveBeenCalledWith('store-migration', 'ship it');
+      await waitFor(() => expect(input.value).toBe(''));
+      unmount();
+    }
+  });
+
+  it('does not submit on a plain Enter (newline, not send)', async () => {
+    const fetchTicket = vi.fn().mockResolvedValue(makeTicket());
+    const onAddComment = vi.fn().mockResolvedValue(undefined);
+    render(
+      <TicketDetailPanel
+        isOpen
+        ticketId="store-migration"
+        ticketRow={makeTicket()}
+        fetchTicket={fetchTicket}
+        onAddComment={onAddComment}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByTestId('ticket-comment-input'));
+
+    const input = screen.getByTestId('ticket-comment-input') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'a line' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onAddComment).not.toHaveBeenCalled();
+  });
+
+  it('keeps the submit button disabled until the draft has non-whitespace text', async () => {
+    const fetchTicket = vi.fn().mockResolvedValue(makeTicket());
+    const onAddComment = vi.fn().mockResolvedValue(undefined);
+    render(
+      <TicketDetailPanel
+        isOpen
+        ticketId="store-migration"
+        ticketRow={makeTicket()}
+        fetchTicket={fetchTicket}
+        onAddComment={onAddComment}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByTestId('ticket-comment-input'));
+
+    const input = screen.getByTestId('ticket-comment-input') as HTMLTextAreaElement;
+    const button = screen.getByTestId('ticket-add-comment') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+
+    // Whitespace only stays disabled, and the shortcut is a no-op on it.
+    fireEvent.change(input, { target: { value: '   ' } });
+    expect(button.disabled).toBe(true);
+    fireEvent.keyDown(input, { key: 'Enter', metaKey: true });
+    expect(onAddComment).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: 'real text' } });
+    expect(button.disabled).toBe(false);
+  });
+
+  it('disables the submit button and relabels it while the post is in flight', async () => {
+    const fetchTicket = vi.fn().mockResolvedValue(makeTicket());
+    // A never-resolving post keeps the action pending so the busy UI is observable.
+    const onAddComment = vi.fn().mockReturnValue(new Promise<void>(() => {}));
+    render(
+      <TicketDetailPanel
+        isOpen
+        ticketId="store-migration"
+        ticketRow={makeTicket()}
+        fetchTicket={fetchTicket}
+        onAddComment={onAddComment}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByTestId('ticket-comment-input'));
+
+    const input = screen.getByTestId('ticket-comment-input') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'hang on' } });
+    fireEvent.click(screen.getByTestId('ticket-add-comment'));
+
+    const button = screen.getByTestId('ticket-add-comment') as HTMLButtonElement;
+    await waitFor(() => expect(button.disabled).toBe(true));
+    expect(button.textContent).toBe('Adding…');
+    // A second shortcut press must not fire another post while one is pending.
+    fireEvent.keyDown(input, { key: 'Enter', metaKey: true });
+    expect(onAddComment).toHaveBeenCalledTimes(1);
+  });
+
   it('edits the description through the edit toggle', async () => {
     const fetchTicket = vi.fn().mockResolvedValue(makeTicket());
     const onEditDescription = vi.fn().mockResolvedValue(undefined);

--- a/app/src/components/TicketDetailPanel.tsx
+++ b/app/src/components/TicketDetailPanel.tsx
@@ -171,6 +171,18 @@ export function TicketDetailPanel({
   // button is live before the full record loads.
   const canResume = Boolean(onResume && ticketId && header?.cwd && header?.last_agent_id);
 
+  // Post the current comment draft. Shared by the form's submit button and the
+  // textarea's ⌘/Ctrl+Return shortcut so both paths trim, guard against an empty
+  // draft or an in-flight action, clear on success, and surface errors identically.
+  const submitComment = () => {
+    if (!onAddComment || !fullTicket) return;
+    const text = commentDraft.trim();
+    if (!text || busyAction !== null) return;
+    runAction('comment', () => onAddComment(fullTicket.id, text))
+      .then(() => setCommentDraft(''))
+      .catch(() => {});
+  };
+
   return (
     <div className="ticket-detail-panel" data-testid="ticket-detail-panel">
       <div className="ticket-detail-header">
@@ -331,19 +343,23 @@ export function TicketDetailPanel({
                 className="ticket-comment-form"
                 onSubmit={(event) => {
                   event.preventDefault();
-                  const text = commentDraft.trim();
-                  if (!text) return;
-                  runAction('comment', () => onAddComment(fullTicket.id, text))
-                    .then(() => setCommentDraft(''))
-                    .catch(() => {});
+                  submitComment();
                 }}
               >
                 <textarea
                   className="ticket-comment-input"
                   data-testid="ticket-comment-input"
-                  placeholder="Add a comment…"
+                  placeholder="Add a comment… (⌘⏎ to send)"
                   value={commentDraft}
                   onChange={(event) => setCommentDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    // ⌘Return (mac) / Ctrl+Return (elsewhere) submits without
+                    // leaving the field; plain Enter still inserts a newline.
+                    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+                      event.preventDefault();
+                      submitComment();
+                    }
+                  }}
                   rows={2}
                 />
                 <button


### PR DESCRIPTION
## Problem

Victor (2026-07-02): *"The ticket UI comment box has no 'add' button, nor does it support cmd+return, so it's impossible to add comments from it."*

Reproduced in the dev app. Two root causes:

1. **The "Add comment" button was invisible.** It's styled with `background: var(--color-accent)` / `color: var(--color-bg-panel)`, but `--color-accent` was **never defined** anywhere in `App.css`. With the token undefined, the background/border collapse to transparent and the text takes the panel background color → the button paints dark-on-dark. It was in the DOM and correctly wired to the `ticket_add_comment` route (the same `store.AddTicketComment` path as `attn ticket comment`), just unseeable. `--color-error` was undefined too, leaving the crashed badge and action-error text uncolored.
2. **No keyboard shortcut** — the textarea had no key handler at all.

## Fix

- **Define the missing tokens** `--color-accent: #5b8cff` and `--color-error: #ef4444` in `App.css :root`. These are the exact values 11+ sites already reference as `var(--token, fallback)`, so anything using the fallback is unchanged; the bare `var(--token)` references (this button, `.ticket-status-*`, the error text) now render as intended. Theme-invariant, so one `:root` definition cascades to all theme blocks with zero regression.
- **Add ⌘Return / Ctrl+Return** to the comment textarea, sharing a single `submitComment` with the button (trim, disabled-when-empty + in-flight guards, clear-on-success, error surfacing). Plain Enter still inserts a newline. Placeholder hints `(⌘⏎ to send)`.

Reuses the existing comment route — no new plumbing.

## Verification

- **Vitest** (all green, 1225 total): new coverage for ⌘/Ctrl+Return submit, plain-Enter no-op, disabled-until-non-empty (+ shortcut no-op on whitespace), and the in-flight disable/relabel guard.
- **Manual e2e in the dev app** on a real ticket: the button now renders as a visible blue "Add comment" button (before the fix an app-owned screenshot had **0** colorful pixels — invisible; after, the button is clearly blue). Posting via the button lands the comment in the ticket activity, confirmed by a fresh `GetTicket` after close+reopen (defeats optimistic render / broadcast lag).

<sub>Opened by Claude on behalf of Victor.</sub>