### PR TITLE
feat(tasks): persist the durable task runner in SQLite (PR1/4)

### DIFF
--- a/docs/plans/2026-07-02-bg-task-notifications.md
+++ b/docs/plans/2026-07-02-bg-task-notifications.md
@@ -1,0 +1,268 @@
+# Plan: Background-task errors → Notifications + Tasks-in-Settings
+
+## Goal
+
+Background/headless work (the keeper's compaction, session summaries, workspace
+narration, and the orphaned-ticket reconcile classifier) fails too quietly. Its
+errors are parked on the **notebook screen** — the wrong home, and one the user
+rarely opens. Move that visibility to a new **global, daemon-level Notifications
+surface** with read/unread state and a click-through error dialog, and give the
+tasks themselves a management home in **Settings**. Along the way, converge the
+one-off reconcile scheduler onto the durable task runner so there is a single
+task substrate and a single error producer.
+
+## Scope
+
+**In:**
+- Migrate the durable task runner's persistence from per-file JSON
+  (`<notebookRoot>/.attn/tasks/*.json`) to a **SQLite table** in the profile DB
+  (`~/.attn[-profile]/attn.db`); convert existing tasks once.
+- Grow the runner from a strict single worker to **bounded, per-kind
+  concurrency** (executors run concurrently; record mutations stay serialized).
+- Fold the **reconcile classifier** (`internal/daemon/ticket_reconcile.go`) into
+  the runner as a `reconcile` task kind.
+- New **Notifications** concept: SQLite table, protocol (list / mark-read /
+  broadcast + unread count), sidebar button with an unread counter, click →
+  detail dialog (what was being done + error text + Retry). Producer = a task
+  reaching terminal `dead`.
+- **Tasks UI in Settings**; remove the Tasks panel from the notebook screen.
+
+**Out:**
+- The **workflow engine** (`internal/workflow`, `WorkflowRun*`) — a separate
+  system, not a background task. Untouched.
+- The **session-keyed attention/color system** (`isAttentionSessionState`,
+  sidebar state dots, AttentionDrawer). Background tasks aren't tied to a session
+  or workspace, so they get their own surface, not the eye-drawing machinery.
+- The concurrent `fix/reconcile-classifier` work is now **PR #454** (In Review,
+  +194/−22): the classifier runs with `--strict-mcp-config` and rule-7 comments
+  carry the real bounded error text. It makes the classifier's *error text*
+  better; that flows into whatever we build here. **PR3 must land after #454
+  merges — rebase over main and build on its classifier body, do not port the old
+  one.** No coordination needed beyond that ordering; PR1/PR2 are unaffected.
+
+## Key insight — storage migration is load-bearing, not just cleanup
+
+The runner is **disabled when there is no notebook root** (`Runner.Disabled()`)
+*because its storage lives under that root*. The reconcile classifier, by
+contrast, must run for any dead session regardless of notebook config — which is
+exactly why it was built as a bespoke goroutine instead of a task kind.
+
+Moving task storage to the **global profile DB** (PR1) dissolves that coupling:
+the runner no longer needs a notebook root to persist, so the "disabled without
+root" gate can drop, and reconcile can become an ordinary task kind (PR3).
+Executors that genuinely need a notebook (compaction/narration) keep their own
+internal no-op-when-no-root guards, which they already have. So PR1 is a
+prerequisite for the reconcile convergence, not independent cleanup.
+
+## Architecture Map
+
+```text
+Current:
+  keeper/narration enqueue ─┐
+                            ├─> compactRunner (tasks.Runner, single worker)
+  notebook_task_list  ──────┘     └─> internal/tasks/store.go  (JSON files under
+                                        <notebookRoot>/.attn/tasks/*.json)
+                                  └─> LastError/state=dead ──> NotebookTask proto
+                                        └─> NotebookSurface Tasks panel (notebook screen)
+
+  reconcileTicketsOnSessionEnd / sweep (5-min ticker)
+    └─> own goroutine + semaphore(2) + reconciled_at claim + repair pass
+        └─> execTicketReconcileClassifier (headless claude -p)
+            └─> 🩺 ticket comment  (the one good error surface today)
+
+Target:
+  keeper/narration enqueue ──┐
+  reconcile enqueue ─────────┤─> Runner (bounded per-kind concurrency)
+  (session-end + sweep)      │     └─> internal/tasks Store SEAM
+                             │           └─> store.Tasks* (SQLite `tasks` table, global DB)
+                             │     └─> OnTerminalFailure(task) ──> Daemon
+                             │           └─> renderTaskDescription(kind,subject)
+                             │           └─> store.AddNotification(...)
+                             │           └─> broadcast notifications_updated{unread_count}
+  reconcile executor still posts its 🩺 ticket comment (unchanged output)
+
+Frontend:
+  Sidebar tool button [🔔 badge=unread] ──> Notifications panel (list, read/unread)
+                                              └─> click row ──> Notification dialog
+                                                    (body="what was being done"
+                                                     + error text + Retry ──> task_retry)
+  SettingsModal ──> "Background Tasks" section (state/attempts/next/last_error/Retry)
+  NotebookSurface Tasks panel ──> DELETED
+```
+
+## Data Model / Interfaces
+
+```go
+// New SQLite `tasks` table (migration {61}) — mirrors internal/tasks.Task.
+// Meta stays a JSON blob and is NEVER projected to the frontend (internal fs paths).
+tasks( id TEXT PK, kind TEXT, subject TEXT, state TEXT, attempts INT,
+       next_attempt_at TEXT, last_error TEXT, meta_json TEXT,
+       created_at TEXT, updated_at TEXT )
+
+// Persistence seam so runner logic is unchanged; only the backend swaps.
+// internal/tasks/store.go's file store becomes one impl; a SQLite-backed impl
+// (thin adapter over internal/store) becomes the production one.
+type Store interface {
+    List() ([]*Task, error)
+    Get(id string) (*Task, error)
+    Save(t *Task) error
+    Delete(id string) error
+}
+
+// New `notifications` table (migration {62}). read_at NULL == unread.
+notifications( id TEXT PK, kind TEXT, title TEXT, body TEXT, detail TEXT,
+               source_kind TEXT, source_id TEXT, created_at TEXT, read_at TEXT NULL )
+```
+
+```ts
+// Protocol (TypeSpec main.tsp → generate-types → constants.go; bump ProtocolVersion).
+// Rename NotebookTask* -> Task* (the "notebook" prefix is a lie once tasks live in
+// Settings and include reconcile).
+task_list            -> task_list_result { tasks: Task[] }
+task_retry {id}      -> task_retry_result { task? }
+tasks_changed        (broadcast, payload-free)      // existing, renamed
+
+notification_list          -> notification_list_result { notifications: Notification[] }
+notification_mark_read {id|all} -> notification_mark_read_result { unread_count }
+notifications_updated       (broadcast) { unread_count }   // drives the sidebar badge
+
+type Notification = {
+  id: string; kind: string;          // "task_failed" (extensible)
+  title: string;                     // "Workspace narration failed"
+  body: string;                      // "what was being done" (rendered from kind+subject)
+  detail: string;                    // full error text (task.last_error)
+  source_kind: string;               // "task"
+  source_id: string;                 // task id — Retry deep-links here
+  created_at: string; read_at?: string;
+}
+```
+
+## Boundaries
+
+- **`internal/tasks` Runner** owns lifecycle/retry/concurrency; knows nothing of
+  notifications or tickets. It exposes `OnTerminalFailure(func(*Task))`; the
+  daemon translates.
+- **Daemon** owns kind→semantics: `renderTaskDescription(kind, subject)` for the
+  human "what was being done" line, and the reconcile executor body (claim,
+  drop-rule, 🩺 comment). It registers the runner callbacks and writes
+  notifications.
+- **`internal/store`** owns both new tables; the `tasks` SQLite impl is an
+  adapter so `internal/tasks` need not import daemon/store types directly (keep
+  the seam thin — pass a `Store` into `tasks.New`).
+- **Frontend** never sees task `Meta`. The notifications badge reads only
+  `unread_count` from the broadcast; the list/dialog fetch on open.
+
+## The concurrency change (the one risky invariant)
+
+Today "single worker" is load-bearing: it removes the need for per-task locks and
+underpins orphan-`running` recovery ("one worker per root"). Reconcile wants 2
+concurrent classifier subprocesses. Target design:
+
+- Separate **executor concurrency** from **record-mutation serialization**: the
+  worker may dispatch up to `N(kind)` executor bodies concurrently, but every
+  state transition still happens under the runner mutex.
+- **Per-kind cap**, default 1 (keeper/narration stay effectively serial);
+  `reconcile` = 2.
+- Behaviors that MUST survive (verify each): orphan-`running` recovery on start,
+  subject-derived coalescing + zero-debounce override, per-executor
+  `context.WithTimeout`, `Cancel` blocks until exit, single-instance ownership
+  lock, no lost/half-written records.
+
+Isolate this in its own PR so the invariant change is reviewed alone.
+
+## Implementation Steps (sliced for ~1k-line PRs)
+
+- [x] **PR1 — Tasks persistence → SQLite.** Added `tasks` table (migration {61};
+      real DBs verified at MAX(version)=60 first). Introduced the `tasks.Store`
+      seam (exported interface + `FileStore` wrapper over the untouched file store);
+      SQLite adapter (`internal/daemon/task_store.go`) mapping `Task`↔`store.TaskRecord`;
+      single-instance lock extracted to shared dir-lock helpers and relocated to the
+      profile data dir; import-once conversion from `.attn/tasks/*.json` (drops
+      unparseable, retires the dir). `startCompactRunner` injects the SQLite store.
+      Behavior-preserving: the enable gate stays keyed on the notebook root in PR1
+      (the gate-drop moves to PR3 with reconcile). No protocol change. Tests:
+      store CRUD/recover, adapter round-trip + runner-through-SQLite end-to-end,
+      import-once migration. `go test` green for tasks/store/daemon; tasks race-clean.
+      **Real-app smoke** (throwaway profile seeded with a copy of the real v60 dev
+      DB): migration {61} applied cleanly (v60→v61, tasks table created, 20 tickets
+      intact); daemon startup ran the import-once conversion (`tasks migrate:
+      imported 1 legacy task(s)`, unparseable file dropped, dir retired to
+      `.migrated`); the live SQLite-backed runner executed 3 real `narrate_workspace`
+      tasks to `done`. Source dev DB untouched; profile torn down.
+- [ ] **PR2 — Runner bounded per-kind concurrency.** Executors concurrent, record
+      mutations serialized; default cap 1. Preserve every invariant above.
+      Backend + tests (race-clean).
+- [ ] **PR3 — Reconcile → `reconcile` task kind.** *Land after PR #454 merges;
+      rebase over main and build on its classifier body — do not port the old
+      one.* Register the executor (body = classifier incl. drop-rule/🩺 comment);
+      enqueue on session-end and from the sweep (sweep enqueues, no longer runs
+      inline); per-kind cap 2; delete the bespoke goroutine + semaphore + sweep
+      ticker and `maybeRepairAbandonedReconcileClaim` (runner orphan-recovery
+      replaces it); likely retire the `reconciled_at` column. Backend + tests.
+- [ ] **PR4 — Notifications + Tasks-in-Settings (backend + frontend).** One PR:
+      - *Backend:* `notifications` table (migration {62}) + store methods;
+        protocol (`notification_list` / `notification_mark_read` /
+        `notifications_updated` + unread count; rename `NotebookTask*` → `Task*`;
+        bump version); daemon `OnTerminalFailure` → `renderTaskDescription` →
+        `AddNotification` → broadcast.
+      - *Frontend:* sidebar tool button reusing `SidebarAction.badge`
+        (`sidebar-tool-badge`, caps at 9+); notifications list panel (read/unread
+        rows); detail dialog (body + error + Retry via `task_retry`); mark-read on
+        open; "Background Tasks" section in `SettingsModal.tsx`
+        (state/attempts/next/last_error/Retry); delete the `NotebookSurface` Tasks
+        panel + wiring.
+
+      This one is larger than the ~1k target; if it runs long, split the frontend
+      (sidebar/dialog vs Settings section) as the natural seam.
+
+Dependency order: PR1 → PR2 → PR3 → PR4. PR4's producer needs only PR1, but lands
+last so reconcile failures (PR3) flow through the notifications it introduces.
+
+## Decisions
+
+- **SQLite over JSON (reversal).** Supersedes `docs/plans/2026-06-14-notebook-narration.md`'s
+  "no SQLite" call. Its reason — a burned migration counter meant a new table
+  would be silently skipped — is obsolete: migrations now flow to `{60}` (the
+  ticket tables `{55}`–`{60}` landed after that plan). Read/unread + a global feed
+  want a table anyway. Still re-verify real-DB `MAX(version)` before numbering.
+- **Notify on terminal `dead`, not first `failed`.** `failed` auto-retries and may
+  self-heal; a notification per transient blip is noise. `dead` = retries
+  exhausted = actionable. Live `failed`/retrying state stays visible in the
+  Settings Tasks UI for anyone who looks.
+- **Bounded per-kind concurrency, not a worker pool.** Keeps record mutations
+  serialized under the existing mutex (preserving the "no per-task lock"
+  simplicity and orphan-recovery), while letting reconcile run 2 at once.
+- **Reconcile keeps its 🩺 ticket comment.** That path is good and ticket-scoped;
+  the notification is an *additional*, global signal, not a replacement.
+- **Global, not session/workspace-scoped.** Notifications live in the profile DB
+  and the sidebar chrome, deliberately outside the attention/color system.
+
+## Resolved (were open questions)
+
+- **Existing-task conversion — import-once, drop unparseable.** On first boot
+  after upgrade, read `.attn/tasks/*.json` into the table and retire the dir. A
+  file that fails to parse is dropped (logged), never a startup blocker.
+- **Reconcile crash-recovery — runner replaces the bespoke repair; keep the sweep
+  as the discovery/enqueue source.** Today reconcile has two nets for "daemon
+  crashed mid-reconcile, ticket stuck claimed-but-unhandled": the 5-min sweep and
+  `maybeRepairAbandonedReconcileClaim`. The runner already ships that net —
+  orphan-`running` recovery re-runs a task whose process died mid-execution — so
+  in PR3 we **delete `maybeRepairAbandonedReconcileClaim`** and lean on runner
+  recovery. The **sweep stays** but for its *other* job: discovering orphaned
+  tickets (a session that ended without firing the seam) and **enqueuing** a
+  `reconcile:<ticketID>` task instead of running the classifier inline. Task
+  coalescing (one task per ticket) replaces the claim's dedup role; the 🩺 comment
+  is the durable "already handled" ledger — so PR3 can likely retire the
+  `reconciled_at` column too (settle during PR3).
+- **Notification retention — unbounded for v1.** No cap/prune. Revisit only if
+  growth becomes a real problem (listed under Follow-ups).
+
+## Follow-ups
+
+- Extend notification `kind` beyond `task_failed` (the "other things in the
+  future" Victor flagged) — e.g. long-run-finished, update-available.
+- Consider a notification for reconcile *verdicts* (not just failures) once the
+  surface exists.
+- Optional macOS-native notification when the window is unfocused (currently the
+  app is accessory-mode with the dock tile hidden — larger, deferred).
+- Notification retention (cap/prune) if the unbounded table ever grows painfully.

--- a/internal/daemon/task_store.go
+++ b/internal/daemon/task_store.go
@@ -1,0 +1,158 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/tasks"
+)
+
+// sqlTaskStore satisfies the tasks.Store seam.
+var _ tasks.Store = (*sqlTaskStore)(nil)
+
+// sqlTaskStore adapts the profile SQLite store to the tasks.Store seam so the
+// durable task runner persists its records in ~/.attn[-profile]/attn.db instead of
+// one JSON file per task under the notebook root. It lives in the daemon (which
+// imports both internal/tasks and internal/store) so neither of those packages
+// depends on the other. See docs/plans/2026-07-02-bg-task-notifications.md.
+//
+// The single-instance lock stays a file lock — relocated from the notebook tasks
+// dir to the profile data dir (one runner per profile, matching one daemon per
+// profile) — reusing the shared dir-lock helpers.
+type sqlTaskStore struct {
+	store   *store.Store
+	lockDir string
+	log     tasks.LogFunc
+}
+
+// newSQLTaskStore builds the adapter over the daemon's store, locking under the
+// profile data dir.
+func (d *Daemon) newSQLTaskStore() *sqlTaskStore {
+	return &sqlTaskStore{store: d.store, lockDir: config.DataDir(), log: d.logf}
+}
+
+// Init is a no-op: migration {61} creates the tasks table when the DB opens.
+func (a *sqlTaskStore) Init() error { return nil }
+
+func (a *sqlTaskStore) AcquireLock() (string, error) { return tasks.AcquireDirLock(a.lockDir, a.log) }
+func (a *sqlTaskStore) ReleaseLock(token string)     { tasks.ReleaseDirLock(token, a.log) }
+
+func (a *sqlTaskStore) RecoverOrphans(now time.Time) (int, error) {
+	return a.store.RecoverRunningTasks(now)
+}
+
+func (a *sqlTaskStore) Load(id string) (*tasks.Task, error) {
+	rec, ok, err := a.store.GetTask(id)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	return recordToTask(*rec), nil
+}
+
+func (a *sqlTaskStore) Save(t *tasks.Task) error {
+	return a.store.UpsertTask(taskToRecord(t))
+}
+
+func (a *sqlTaskStore) Delete(id string) error { return a.store.DeleteTask(id) }
+
+func (a *sqlTaskStore) List() ([]*tasks.Task, error) {
+	recs, err := a.store.ListTasks()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*tasks.Task, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToTask(rec))
+	}
+	return out, nil
+}
+
+// taskToRecord maps a runner task to its store row. Meta is carried opaquely as a
+// JSON blob; the store never interprets it. CommitGuard is per-run and never
+// persisted.
+func taskToRecord(t *tasks.Task) store.TaskRecord {
+	meta := ""
+	if len(t.Meta) > 0 {
+		if b, err := json.Marshal(t.Meta); err == nil {
+			meta = string(b)
+		}
+	}
+	return store.TaskRecord{
+		ID:            t.ID,
+		Kind:          t.Kind,
+		Subject:       t.Subject,
+		State:         string(t.State),
+		Attempts:      t.Attempts,
+		NextAttemptAt: t.NextAttemptAt,
+		LastError:     t.LastError,
+		MetaJSON:      meta,
+		Requeued:      t.Requeued,
+		CreatedAt:     t.CreatedAt,
+		UpdatedAt:     t.UpdatedAt,
+	}
+}
+
+func recordToTask(rec store.TaskRecord) *tasks.Task {
+	var meta map[string]string
+	if strings.TrimSpace(rec.MetaJSON) != "" {
+		_ = json.Unmarshal([]byte(rec.MetaJSON), &meta)
+	}
+	return &tasks.Task{
+		ID:            rec.ID,
+		Kind:          rec.Kind,
+		Subject:       rec.Subject,
+		State:         tasks.State(rec.State),
+		Attempts:      rec.Attempts,
+		NextAttemptAt: rec.NextAttemptAt,
+		LastError:     rec.LastError,
+		Meta:          meta,
+		Requeued:      rec.Requeued,
+		CreatedAt:     rec.CreatedAt,
+		UpdatedAt:     rec.UpdatedAt,
+	}
+}
+
+// migrateLegacyTasksToSQLite imports any pre-existing on-disk JSON task records
+// (the old <root>/.attn/tasks/*.json format) into the SQLite tasks table exactly
+// once, then retires the directory so it never re-imports. Unparseable records are
+// dropped — the file store's List already skips and logs them. Best-effort: a
+// failure never blocks the runner from starting, and Save is an idempotent upsert
+// so a partial run re-converges on the next boot.
+func (d *Daemon) migrateLegacyTasksToSQLite(root string) {
+	dir := filepath.Join(root, ".attn", "tasks")
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return // nothing to migrate
+	}
+	legacy, err := tasks.NewFileStore(root, d.logf).List()
+	if err != nil {
+		d.logf("tasks migrate: list legacy records: %v", err)
+		return
+	}
+	adapter := d.newSQLTaskStore()
+	migrated := 0
+	for _, t := range legacy {
+		if err := adapter.Save(t); err != nil {
+			d.logf("tasks migrate: import %s: %v", t.ID, err)
+			continue
+		}
+		migrated++
+	}
+	// Retire the dir so we never re-import. Clear any stale prior .migrated first so
+	// the rename can't fail on a leftover.
+	retired := dir + ".migrated"
+	_ = os.RemoveAll(retired)
+	if err := os.Rename(dir, retired); err != nil {
+		d.logf("tasks migrate: retire legacy dir: %v", err)
+	}
+	if migrated > 0 {
+		d.logf("tasks migrate: imported %d legacy task(s) into sqlite", migrated)
+	}
+}

--- a/internal/daemon/task_store_test.go
+++ b/internal/daemon/task_store_test.go
@@ -1,0 +1,167 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/tasks"
+)
+
+// newTestSQLTaskStore builds the adapter over an in-memory store with a hermetic
+// lock dir (t.TempDir) so tests never touch the real profile data dir.
+func newTestSQLTaskStore(t *testing.T) (*store.Store, *sqlTaskStore) {
+	t.Helper()
+	st := store.New()
+	return st, &sqlTaskStore{store: st, lockDir: t.TempDir(), log: func(string, ...interface{}) {}}
+}
+
+// TestSQLTaskStore_RunnerEndToEnd drives a real Runner backed by the SQLite
+// adapter: a registered executor runs the enqueued task to completion and the
+// record is durably reflected in the DB.
+func TestSQLTaskStore_RunnerEndToEnd(t *testing.T) {
+	st, adapter := newTestSQLTaskStore(t)
+	runner := tasks.New(tasks.Options{
+		Store:        adapter,
+		PollInterval: 2 * time.Millisecond,
+		Log:          func(string, ...interface{}) {},
+	})
+	ran := make(chan string, 1)
+	if err := runner.Register("compact_context", func(_ context.Context, task *tasks.Task) error {
+		ran <- task.Subject
+		return nil
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := runner.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer runner.Stop()
+
+	if _, err := runner.Enqueue("compact_context", "ws-1", tasks.EnqueueOptions{}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	select {
+	case got := <-ran:
+		if got != "ws-1" {
+			t.Fatalf("executor ran for %q, want ws-1", got)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("executor never ran")
+	}
+
+	// The terminal record is persisted in the DB, addressable by its runner id.
+	id := tasks.TaskID("compact_context", "ws-1")
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		rec, ok, err := st.GetTask(id)
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if ok && rec.State == string(tasks.StateDone) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task did not reach done in the DB (ok=%v rec=%+v)", ok, rec)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestSQLTaskStore_MetaRoundTrip checks the Task<->TaskRecord mapping preserves
+// the kind-specific Meta bag through a Save/Load cycle.
+func TestSQLTaskStore_MetaRoundTrip(t *testing.T) {
+	_, adapter := newTestSQLTaskStore(t)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	orig := &tasks.Task{
+		ID:            "summarize_session:s-1",
+		Kind:          "summarize_session",
+		Subject:       "s-1",
+		State:         tasks.StateFailed,
+		Attempts:      2,
+		NextAttemptAt: now.Add(time.Minute),
+		LastError:     "agent run failed",
+		Meta:          map[string]string{"transcript": "/tmp/x.jsonl", "workspace": "ws-9"},
+		Requeued:      true,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := adapter.Save(orig); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := adapter.Load(orig.ID)
+	if err != nil || got == nil {
+		t.Fatalf("load: got=%v err=%v", got, err)
+	}
+	if got.Kind != orig.Kind || got.State != orig.State || got.Attempts != orig.Attempts ||
+		got.LastError != orig.LastError || !got.Requeued {
+		t.Fatalf("scalar mismatch: %+v", got)
+	}
+	if len(got.Meta) != 2 || got.Meta["transcript"] != "/tmp/x.jsonl" || got.Meta["workspace"] != "ws-9" {
+		t.Fatalf("meta not preserved: %+v", got.Meta)
+	}
+	if !got.NextAttemptAt.Equal(orig.NextAttemptAt) {
+		t.Fatalf("next_attempt_at: got %v want %v", got.NextAttemptAt, orig.NextAttemptAt)
+	}
+
+	// Load of a missing id is (nil, nil), not an error — the coalesced re-enqueue
+	// contract.
+	miss, err := adapter.Load("nope:x")
+	if err != nil || miss != nil {
+		t.Fatalf("load miss: got=%v err=%v", miss, err)
+	}
+}
+
+// TestMigrateLegacyTasksToSQLite imports the pre-SQLite on-disk JSON records into
+// the DB exactly once, drops an unparseable file, and retires the directory.
+func TestMigrateLegacyTasksToSQLite(t *testing.T) {
+	st := store.New()
+	d := &Daemon{store: st}
+	root := t.TempDir()
+
+	// Seed two legacy records via the file store (the real on-disk format).
+	fs := tasks.NewFileStore(root, nil)
+	for _, task := range []*tasks.Task{
+		{ID: "compact_context:ws-a", Kind: "compact_context", Subject: "ws-a", State: tasks.StateQueued},
+		{ID: "narrate_workspace:ws-b", Kind: "narrate_workspace", Subject: "ws-b", State: tasks.StateDead, LastError: "boom"},
+	} {
+		if err := fs.Save(task); err != nil {
+			t.Fatalf("seed legacy %s: %v", task.ID, err)
+		}
+	}
+	// An unparseable file must be dropped, not fatal.
+	legacyDir := filepath.Join(root, ".attn", "tasks")
+	if err := os.WriteFile(filepath.Join(legacyDir, "corrupt.json"), []byte("{ not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d.migrateLegacyTasksToSQLite(root)
+
+	all, err := st.ListTasks()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 imported tasks, got %d (%+v)", len(all), all)
+	}
+	if _, ok, _ := st.GetTask("narrate_workspace:ws-b"); !ok {
+		t.Fatalf("dead task not imported")
+	}
+	// The legacy dir is retired so a re-run does not re-import.
+	if _, err := os.Stat(legacyDir); !os.IsNotExist(err) {
+		t.Fatalf("legacy dir not retired (stat err=%v)", err)
+	}
+	if _, err := os.Stat(legacyDir + ".migrated"); err != nil {
+		t.Fatalf("expected .migrated dir: %v", err)
+	}
+
+	// Idempotent: a second run with no dir is a no-op and does not error/duplicate.
+	d.migrateLegacyTasksToSQLite(root)
+	all2, _ := st.ListTasks()
+	if len(all2) != 2 {
+		t.Fatalf("re-run changed task count: %d", len(all2))
+	}
+}

--- a/internal/daemon/workspace_keeper.go
+++ b/internal/daemon/workspace_keeper.go
@@ -207,11 +207,25 @@ func (d *Daemon) setCompactRunner(runner *tasks.Runner) {
 // Cancel/Enqueue callsites can call d.compactRunner unconditionally.
 func (d *Daemon) startCompactRunner() {
 	root, _ := d.notebookRoot()
+	// One-time import of any legacy on-disk JSON task records (the pre-SQLite
+	// <root>/.attn/tasks/*.json format) into the profile DB.
+	if root != "" {
+		d.migrateLegacyTasksToSQLite(root)
+	}
+	// Tasks now persist in the profile SQLite DB via the injected store, not under
+	// the notebook root. PR1 keeps the runner's enable gate keyed on the notebook
+	// root to preserve today's behavior (no root ⇒ disabled ⇒ inline compaction
+	// fallback); a later slice drops that gate once reconcile — which needs no
+	// notebook — becomes a task kind (docs/plans/2026-07-02-bg-task-notifications.md).
+	opts := tasks.Options{Log: d.logf}
+	if root != "" && d.store != nil {
+		opts.Store = d.newSQLTaskStore()
+	}
 	// Build and register on a LOCAL pointer, then publish it once under the write
 	// lock. Registering on the local (not the published field) keeps a concurrent
 	// reader from ever observing a half-registered runner, and the single
 	// setCompactRunner swap is what Stop()/enqueue/forget synchronize against.
-	runner := tasks.New(tasks.Options{Root: root, Log: d.logf})
+	runner := tasks.New(opts)
 	if !runner.Disabled() {
 		if err := runner.RegisterWithTimeout(
 			compactContextKind,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -551,6 +551,21 @@ CREATE TABLE IF NOT EXISTS ticket_event_cursors (
 	// reconciliation, not agent self-report) and the set-if-unset dedupe lock
 	// between the death-hook and the sweep backstop.
 	{60, "add reconciled_at to tickets", "ALTER TABLE tickets ADD COLUMN reconciled_at TEXT NOT NULL DEFAULT ''"},
+	// The durable task runner (internal/tasks) persists its records here instead of
+	// one JSON file per task under the notebook root. See docs/plans/2026-07-02-bg-task-notifications.md.
+	{61, "create tasks table", `CREATE TABLE IF NOT EXISTS tasks (
+		id TEXT PRIMARY KEY,
+		kind TEXT NOT NULL,
+		subject TEXT NOT NULL,
+		state TEXT NOT NULL,
+		attempts INTEGER NOT NULL DEFAULT 0,
+		next_attempt_at TEXT NOT NULL,
+		last_error TEXT NOT NULL DEFAULT '',
+		meta_json TEXT NOT NULL DEFAULT '',
+		requeued INTEGER NOT NULL DEFAULT 0,
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	)`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -1,0 +1,189 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// This is the SQLite persistence for the durable task runner (internal/tasks).
+// The runner used to keep one atomic-JSON file per task under the notebook root;
+// it now persists here in the profile DB so background work no longer depends on a
+// notebook root and so future surfaces (notifications) can query it. See
+// docs/plans/2026-07-02-bg-task-notifications.md.
+//
+// Following the tickets/workflow_runs convention, TaskRecord is a store-local row
+// type — NOT the internal/tasks.Task type. The daemon owns the mapping between the
+// two, which keeps this package a leaf (internal/store imports neither
+// internal/tasks nor internal/daemon).
+
+// taskTimeFormat is the on-disk timestamp encoding. RFC3339Nano preserves the
+// sub-second precision the runner's backoff/coalescing timing relies on.
+const taskTimeFormat = time.RFC3339Nano
+
+// TaskRecord is one durable task-runner record. Meta is carried opaquely as a
+// JSON blob (MetaJSON) because the store never interprets it — only the executor
+// that stashed it does.
+type TaskRecord struct {
+	ID            string
+	Kind          string
+	Subject       string
+	State         string
+	Attempts      int
+	NextAttemptAt time.Time
+	LastError     string
+	MetaJSON      string
+	Requeued      bool
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+// UpsertTask inserts or fully replaces a task row by id. The runner addresses a
+// record only by its stable id (kind:subject), so a re-enqueue overwrites the same
+// row — the same coalescing the file store got from same-filename overwrite.
+func (s *Store) UpsertTask(rec TaskRecord) error {
+	if s.db == nil {
+		return fmt.Errorf("store: no database")
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO tasks (id, kind, subject, state, attempts, next_attempt_at, last_error, meta_json, requeued, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET
+		   kind=excluded.kind,
+		   subject=excluded.subject,
+		   state=excluded.state,
+		   attempts=excluded.attempts,
+		   next_attempt_at=excluded.next_attempt_at,
+		   last_error=excluded.last_error,
+		   meta_json=excluded.meta_json,
+		   requeued=excluded.requeued,
+		   created_at=excluded.created_at,
+		   updated_at=excluded.updated_at`,
+		rec.ID, rec.Kind, rec.Subject, rec.State, rec.Attempts,
+		rec.NextAttemptAt.UTC().Format(taskTimeFormat), rec.LastError, rec.MetaJSON,
+		boolToInt(rec.Requeued),
+		rec.CreatedAt.UTC().Format(taskTimeFormat), rec.UpdatedAt.UTC().Format(taskTimeFormat),
+	)
+	if err != nil {
+		return fmt.Errorf("store: upsert task %s: %w", rec.ID, err)
+	}
+	return nil
+}
+
+// GetTask returns the row for id. The bool is false (with a nil record and nil
+// error) when no such row exists — the runner's coalesced re-enqueue must tell
+// "no record yet" apart from a read error.
+func (s *Store) GetTask(id string) (*TaskRecord, bool, error) {
+	if s.db == nil {
+		return nil, false, fmt.Errorf("store: no database")
+	}
+	row := s.db.QueryRow(
+		`SELECT id, kind, subject, state, attempts, next_attempt_at, last_error, meta_json, requeued, created_at, updated_at
+		 FROM tasks WHERE id = ?`, id)
+	rec, err := scanTaskRow(row)
+	if err == sql.ErrNoRows {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("store: get task %s: %w", id, err)
+	}
+	return rec, true, nil
+}
+
+// DeleteTask removes a task row. A missing row is not an error (already gone).
+func (s *Store) DeleteTask(id string) error {
+	if s.db == nil {
+		return fmt.Errorf("store: no database")
+	}
+	if _, err := s.db.Exec(`DELETE FROM tasks WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("store: delete task %s: %w", id, err)
+	}
+	return nil
+}
+
+// ListTasks returns every task row, newest-updated first (the contract the task
+// status surface documents).
+func (s *Store) ListTasks() ([]TaskRecord, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("store: no database")
+	}
+	rows, err := s.db.Query(
+		`SELECT id, kind, subject, state, attempts, next_attempt_at, last_error, meta_json, requeued, created_at, updated_at
+		 FROM tasks ORDER BY updated_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("store: list tasks: %w", err)
+	}
+	defer rows.Close()
+	var out []TaskRecord
+	for rows.Next() {
+		rec, err := scanTaskRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("store: scan task: %w", err)
+		}
+		out = append(out, *rec)
+	}
+	return out, rows.Err()
+}
+
+// RecoverRunningTasks resets any task left in "running" back to "queued" with
+// next_attempt_at = now, returning how many were recovered. A row in "running" at
+// startup means a crash interrupted that task mid-run, so it is re-eligible
+// immediately (the same recovery the file store did by rewriting each record).
+func (s *Store) RecoverRunningTasks(now time.Time) (int, error) {
+	if s.db == nil {
+		return 0, fmt.Errorf("store: no database")
+	}
+	ts := now.UTC().Format(taskTimeFormat)
+	res, err := s.db.Exec(
+		`UPDATE tasks SET state='queued', next_attempt_at=?, updated_at=? WHERE state='running'`, ts, ts)
+	if err != nil {
+		return 0, fmt.Errorf("store: recover running tasks: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
+// rowScanner is satisfied by both *sql.Row and *sql.Rows so scanTaskRow serves
+// GetTask and ListTasks.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanTaskRow(sc rowScanner) (*TaskRecord, error) {
+	var (
+		rec               TaskRecord
+		nextStr, createdStr, updatedStr string
+		requeued          int
+	)
+	if err := sc.Scan(&rec.ID, &rec.Kind, &rec.Subject, &rec.State, &rec.Attempts,
+		&nextStr, &rec.LastError, &rec.MetaJSON, &requeued, &createdStr, &updatedStr); err != nil {
+		return nil, err
+	}
+	rec.Requeued = requeued != 0
+	rec.NextAttemptAt = parseTaskTime(nextStr)
+	rec.CreatedAt = parseTaskTime(createdStr)
+	rec.UpdatedAt = parseTaskTime(updatedStr)
+	return &rec, nil
+}
+
+// boolToInt lives in store.go (shared across this package).
+
+// parseTaskTime decodes a stored timestamp, tolerating the plain RFC3339 form as
+// well as RFC3339Nano. A blank/garbage value yields the zero time rather than an
+// error — a task with an unreadable timestamp is still a real record and the
+// runner treats a zero NextAttemptAt as "eligible now".
+func parseTaskTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(taskTimeFormat, s); err == nil {
+		return t.UTC()
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC()
+	}
+	return time.Time{}
+}

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -154,9 +154,9 @@ type rowScanner interface {
 
 func scanTaskRow(sc rowScanner) (*TaskRecord, error) {
 	var (
-		rec               TaskRecord
+		rec                             TaskRecord
 		nextStr, createdStr, updatedStr string
-		requeued          int
+		requeued                        int
 	)
 	if err := sc.Scan(&rec.ID, &rec.Kind, &rec.Subject, &rec.State, &rec.Attempts,
 		&nextStr, &rec.LastError, &rec.MetaJSON, &requeued, &createdStr, &updatedStr); err != nil {

--- a/internal/store/tasks_test.go
+++ b/internal/store/tasks_test.go
@@ -1,0 +1,148 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTasks_UpsertGetDelete(t *testing.T) {
+	s := New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	rec := TaskRecord{
+		ID:            "compact_context:ws-1",
+		Kind:          "compact_context",
+		Subject:       "ws-1",
+		State:         "queued",
+		Attempts:      2,
+		NextAttemptAt: now.Add(30 * time.Second),
+		LastError:     "boom",
+		MetaJSON:      `{"transcript":"/tmp/x.jsonl"}`,
+		Requeued:      true,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := s.UpsertTask(rec); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, ok, err := s.GetTask(rec.ID)
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if got.Kind != rec.Kind || got.Subject != rec.Subject || got.State != rec.State {
+		t.Fatalf("core fields mismatch: %+v", got)
+	}
+	if got.Attempts != 2 || got.LastError != "boom" || got.MetaJSON != rec.MetaJSON || !got.Requeued {
+		t.Fatalf("scalar fields mismatch: %+v", got)
+	}
+	if !got.NextAttemptAt.Equal(rec.NextAttemptAt) {
+		t.Fatalf("next_attempt_at not preserved: got %v want %v", got.NextAttemptAt, rec.NextAttemptAt)
+	}
+
+	// Upsert again with new state — same id must overwrite, not duplicate.
+	rec.State = "running"
+	rec.Attempts = 3
+	if err := s.UpsertTask(rec); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	got, ok, _ = s.GetTask(rec.ID)
+	if !ok || got.State != "running" || got.Attempts != 3 {
+		t.Fatalf("overwrite failed: %+v", got)
+	}
+	all, err := s.ListTasks()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 row after re-upsert, got %d", len(all))
+	}
+
+	if err := s.DeleteTask(rec.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, ok, _ := s.GetTask(rec.ID); ok {
+		t.Fatalf("row still present after delete")
+	}
+	// Deleting a missing row is not an error.
+	if err := s.DeleteTask("nope"); err != nil {
+		t.Fatalf("delete missing: %v", err)
+	}
+}
+
+func TestTasks_GetMissing(t *testing.T) {
+	s := New()
+	rec, ok, err := s.GetTask("absent")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok || rec != nil {
+		t.Fatalf("expected miss, got ok=%v rec=%v", ok, rec)
+	}
+}
+
+func TestTasks_ListNewestUpdatedFirst(t *testing.T) {
+	s := New()
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	mk := func(id string, updated time.Time) TaskRecord {
+		return TaskRecord{ID: id, Kind: "k", Subject: id, State: "queued",
+			NextAttemptAt: base, CreatedAt: base, UpdatedAt: updated}
+	}
+	if err := s.UpsertTask(mk("a", base.Add(1*time.Second))); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpsertTask(mk("b", base.Add(3*time.Second))); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpsertTask(mk("c", base.Add(2*time.Second))); err != nil {
+		t.Fatal(err)
+	}
+	all, err := s.ListTasks()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	order := []string{all[0].ID, all[1].ID, all[2].ID}
+	want := []string{"b", "c", "a"}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("order = %v, want %v", order, want)
+		}
+	}
+}
+
+func TestTasks_RecoverRunningTasks(t *testing.T) {
+	s := New()
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	mk := func(id, state string) TaskRecord {
+		return TaskRecord{ID: id, Kind: "k", Subject: id, State: state,
+			NextAttemptAt: base.Add(time.Hour), CreatedAt: base, UpdatedAt: base}
+	}
+	for _, r := range []TaskRecord{mk("run-1", "running"), mk("run-2", "running"), mk("q", "queued"), mk("d", "done")} {
+		if err := s.UpsertTask(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	recoverAt := base.Add(5 * time.Minute)
+	n, err := s.RecoverRunningTasks(recoverAt)
+	if err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("recovered %d, want 2", n)
+	}
+	for _, id := range []string{"run-1", "run-2"} {
+		got, _, _ := s.GetTask(id)
+		if got.State != "queued" {
+			t.Fatalf("%s state=%s, want queued", id, got.State)
+		}
+		if !got.NextAttemptAt.Equal(recoverAt) {
+			t.Fatalf("%s next_attempt_at=%v, want %v", id, got.NextAttemptAt, recoverAt)
+		}
+	}
+	// Non-running rows are untouched.
+	if got, _, _ := s.GetTask("q"); got.State != "queued" || !got.NextAttemptAt.Equal(base.Add(time.Hour)) {
+		t.Fatalf("queued row was disturbed: %+v", got)
+	}
+	if got, _, _ := s.GetTask("d"); got.State != "done" {
+		t.Fatalf("done row was disturbed: %+v", got)
+	}
+}

--- a/internal/tasks/lock.go
+++ b/internal/tasks/lock.go
@@ -11,28 +11,34 @@ import (
 )
 
 // ErrAlreadyRunning is returned by Start when another live Runner already owns
-// the tasks dir for this root. The orphan-recovery and single-worker guarantees
-// assume at most one live worker per root: two workers would both claim the same
-// record, both save StateRunning (atomic rename = last-writer-wins, no torn
-// file), and both invoke the executor concurrently — double-applying the durable
-// write (e.g. double compaction). The CommitGuard is a per-process in-memory
-// latch with no cross-process coordination, so nothing else can fence that.
-var ErrAlreadyRunning = errors.New("tasks: another runner already owns this notebook root")
+// the lock dir. The orphan-recovery and single-worker guarantees assume at most
+// one live worker per store: two workers would both claim the same record, both
+// save StateRunning (atomic rename = last-writer-wins, no torn file), and both
+// invoke the executor concurrently — double-applying the durable write (e.g.
+// double compaction). The CommitGuard is a per-process in-memory latch with no
+// cross-process coordination, so nothing else can fence that.
+var ErrAlreadyRunning = errors.New("tasks: another runner already owns this store")
 
-// lockFileName is the single-instance ownership marker under the tasks dir.
+// lockFileName is the single-instance ownership marker inside the lock dir.
 const lockFileName = ".runner.lock"
 
-// acquireLock takes exclusive ownership of the tasks dir for this process by
-// creating <tasksDir>/.runner.lock with O_EXCL. If the file already exists it
-// either belongs to a live process (refuse with ErrAlreadyRunning) or to a
-// crashed one (stale ⇒ steal it). The PID inside lets a restart after a crash
-// reclaim the lock instead of wedging forever. Returns the path of the acquired
-// lock so the caller can release it on Stop.
-func (s *store) acquireLock() (string, error) {
-	if err := s.init(); err != nil {
+// AcquireDirLock takes exclusive single-instance ownership for this process by
+// creating <dir>/.runner.lock with O_EXCL. If the file already exists it either
+// belongs to a live process (refuse with ErrAlreadyRunning) or to a crashed one
+// (stale ⇒ steal it). The PID inside lets a restart after a crash reclaim the lock
+// instead of wedging forever. Returns the acquired lock path for ReleaseDirLock.
+//
+// It is a free function so both the file store (locking under the notebook tasks
+// dir) and the daemon's SQLite adapter (locking under the profile data dir) share
+// one implementation.
+func AcquireDirLock(dir string, log LogFunc) (string, error) {
+	if log == nil {
+		log = func(string, ...interface{}) {}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
-	path := filepath.Join(stateDir(s.root), lockFileName)
+	path := filepath.Join(dir, lockFileName)
 	for {
 		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 		if err == nil {
@@ -50,7 +56,7 @@ func (s *store) acquireLock() (string, error) {
 			return "", err
 		}
 		// The lock exists. Decide whether it is live (refuse) or stale (steal).
-		if pid, alive := s.lockHolderAlive(path); alive {
+		if pid, alive := lockHolderAlive(path); alive {
 			return "", fmt.Errorf("%w (held by pid %d)", ErrAlreadyRunning, pid)
 		}
 		// Stale lock from a crashed process: remove it and retry the O_EXCL create.
@@ -58,15 +64,40 @@ func (s *store) acquireLock() (string, error) {
 		if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
 			return "", rmErr
 		}
-		s.log("tasks: reclaimed stale runner lock at %s", path)
+		log("tasks: reclaimed stale runner lock at %s", path)
 	}
 }
+
+// ReleaseDirLock removes the lock file if it still belongs to this process. It is
+// best-effort: a failure to remove is logged, not returned, because Stop must not
+// block shutdown on a lock-file cleanup error.
+func ReleaseDirLock(path string, log LogFunc) {
+	if path == "" {
+		return
+	}
+	if log == nil {
+		log = func(string, ...interface{}) {}
+	}
+	if pid, _ := lockHolderAlive(path); pid != 0 && pid != os.Getpid() {
+		// Another process re-acquired the lock after we crashed/stalled; do not
+		// delete its marker.
+		return
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log("tasks: release runner lock %s: %v", path, err)
+	}
+}
+
+// acquireLock / releaseLock keep the file store's method shape, delegating to the
+// shared dir-lock helpers. The file store locks under its own .attn/tasks dir.
+func (s *store) acquireLock() (string, error) { return AcquireDirLock(stateDir(s.root), s.log) }
+func (s *store) releaseLock(path string)      { ReleaseDirLock(path, s.log) }
 
 // lockHolderAlive reports the PID recorded in the lock file and whether that
 // process is still alive. An unreadable/garbage lock is treated as stale (alive
 // false) so a corrupt marker can never wedge startup permanently. A lock with no
 // readable PID is also treated as stale.
-func (s *store) lockHolderAlive(path string) (pid int, alive bool) {
+func lockHolderAlive(path string) (pid int, alive bool) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0, false
@@ -81,23 +112,6 @@ func (s *store) lockHolderAlive(path string) (pid int, alive bool) {
 		return pid, true
 	}
 	return pid, processAlive(pid)
-}
-
-// releaseLock removes the lock file if it still belongs to this process. It is
-// best-effort: a failure to remove is logged, not returned, because Stop must not
-// block shutdown on a lock-file cleanup error.
-func (s *store) releaseLock(path string) {
-	if path == "" {
-		return
-	}
-	if pid, _ := s.lockHolderAlive(path); pid != 0 && pid != os.Getpid() {
-		// Another process re-acquired the lock after we crashed/stalled; do not
-		// delete its marker.
-		return
-	}
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		s.log("tasks: release runner lock %s: %v", path, err)
-	}
 }
 
 // processAlive reports whether a process with the given pid currently exists.

--- a/internal/tasks/runner.go
+++ b/internal/tasks/runner.go
@@ -74,7 +74,12 @@ type EnqueueOptions struct {
 
 // Options configures a Runner at construction.
 type Options struct {
-	// Root is the notebook root dir. Empty/whitespace ⇒ the runner is disabled.
+	// Store injects the persistence backend. When set it takes precedence over Root
+	// and the runner is enabled. Production passes a SQLite-backed Store; tests and
+	// the legacy on-disk path leave it nil and use Root.
+	Store Store
+	// Root is the notebook root dir. Used only when Store is nil: a non-empty root
+	// selects the file-backed FileStore; empty/whitespace ⇒ the runner is disabled.
 	Root string
 	// Log receives runtime log lines. A nil Log is replaced with a no-op.
 	Log LogFunc
@@ -91,9 +96,9 @@ type Options struct {
 	BackoffCap  time.Duration
 }
 
-// Runner is the durable, file-backed, single-worker task runner.
+// Runner is the durable, single-worker task runner.
 type Runner struct {
-	store    *store
+	store    Store
 	log      LogFunc
 	now      func() time.Time
 	disabled bool
@@ -173,13 +178,16 @@ func New(opts Options) *Runner {
 		backoffCap:   nonZeroDuration(opts.BackoffCap, DefaultBackoffCap),
 		wake:         make(chan struct{}, 1),
 	}
-	if root := trimRoot(opts.Root); root == "" {
+	if opts.Store != nil {
+		r.store = opts.Store
+		return r
+	}
+	root := trimRoot(opts.Root)
+	if root == "" {
 		r.disabled = true
 		return r
-	} else {
-		r.store = newStore(root)
-		r.store.log = log
 	}
+	r.store = NewFileStore(root, log)
 	return r
 }
 
@@ -236,7 +244,7 @@ func (r *Runner) Start() error {
 		r.mu.Unlock()
 		return errors.New("tasks: runner already started")
 	}
-	if err := r.store.init(); err != nil {
+	if err := r.store.Init(); err != nil {
 		r.mu.Unlock()
 		return fmt.Errorf("tasks: init store: %w", err)
 	}
@@ -244,7 +252,7 @@ func (r *Runner) Start() error {
 	// second live Runner on the same root would double-execute every task (its own
 	// worker, its own in-memory CommitGuard). Acquiring the lock fails fast with
 	// ErrAlreadyRunning rather than silently double-applying durable writes.
-	lockPath, err := r.store.acquireLock()
+	lockPath, err := r.store.AcquireLock()
 	if err != nil {
 		r.mu.Unlock()
 		return err
@@ -260,7 +268,7 @@ func (r *Runner) Start() error {
 	// clobbered by recovery's stale in-memory copy (lost update). It runs before
 	// the worker launches, so contention here is nil.
 	r.ioMu.Lock()
-	n, err := r.store.recoverOrphans(r.now())
+	n, err := r.store.RecoverOrphans(r.now())
 	r.ioMu.Unlock()
 	if err != nil {
 		r.log("tasks: recover orphan running tasks: %v", err)
@@ -301,7 +309,7 @@ func (r *Runner) Stop() {
 
 	// Release single-instance ownership only after the worker has fully exited, so
 	// no other Runner can claim the root while ours is still draining.
-	r.store.releaseLock(lockPath)
+	r.store.ReleaseLock(lockPath)
 }
 
 // Enqueue (re-)persists a task for kind+subject, coalescing onto the same record.
@@ -336,7 +344,7 @@ func (r *Runner) Enqueue(kind, subject string, opts EnqueueOptions) (*Task, erro
 	r.ioMu.Lock()
 	defer r.ioMu.Unlock()
 
-	existing, err := r.store.load(id)
+	existing, err := r.store.Load(id)
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +395,7 @@ func (r *Runner) Enqueue(kind, subject string, opts EnqueueOptions) (*Task, erro
 		task.Meta = cloneStringMap(opts.Meta)
 	}
 
-	if err := r.store.save(task); err != nil {
+	if err := r.store.Save(task); err != nil {
 		return nil, err
 	}
 	r.notifyChange()
@@ -406,7 +414,7 @@ func (r *Runner) Retry(id string) (*Task, error) {
 	r.ioMu.Lock()
 	defer r.ioMu.Unlock()
 
-	existing, err := r.store.load(id)
+	existing, err := r.store.Load(id)
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +431,7 @@ func (r *Runner) Retry(id string) (*Task, error) {
 	existing.Requeued = false
 	existing.NextAttemptAt = now
 	existing.UpdatedAt = now
-	if err := r.store.save(existing); err != nil {
+	if err := r.store.Save(existing); err != nil {
 		return nil, err
 	}
 	r.notifyChange()
@@ -486,7 +494,7 @@ func (r *Runner) Remove(id string) {
 	}
 	r.Cancel(id)
 	r.ioMu.Lock()
-	err := r.store.delete(id)
+	err := r.store.Delete(id)
 	r.ioMu.Unlock()
 	if err != nil {
 		r.log("tasks: remove %s: %v", id, err)
@@ -501,7 +509,7 @@ func (r *Runner) List() ([]*Task, error) {
 	if r.disabled {
 		return nil, nil
 	}
-	all, err := r.store.list()
+	all, err := r.store.List()
 	if err != nil {
 		return nil, err
 	}
@@ -516,7 +524,7 @@ func (r *Runner) Get(id string) (*Task, error) {
 	if r.disabled {
 		return nil, nil
 	}
-	return r.store.load(id)
+	return r.store.Load(id)
 }
 
 // --- worker loop -----------------------------------------------------------
@@ -564,7 +572,7 @@ func (r *Runner) loop() {
 func (r *Runner) runNext() (bool, error) {
 	r.ioMu.Lock()
 	now := r.now()
-	all, err := r.store.list()
+	all, err := r.store.List()
 	if err != nil {
 		r.ioMu.Unlock()
 		return false, err
@@ -608,7 +616,7 @@ func (r *Runner) runNext() (bool, error) {
 	pick.Attempts++
 	pick.Requeued = false
 	pick.UpdatedAt = now
-	if err := r.store.save(pick); err != nil {
+	if err := r.store.Save(pick); err != nil {
 		r.ioMu.Unlock()
 		r.log("tasks: persist running state for %s: %v", pick.ID, err)
 		return false, nil
@@ -714,7 +722,7 @@ func (r *Runner) execute(t *Task, exec executor) {
 func (r *Runner) finish(id string, runErr error) {
 	r.ioMu.Lock()
 
-	cur, err := r.store.load(id)
+	cur, err := r.store.Load(id)
 	if err != nil {
 		r.ioMu.Unlock()
 		r.log("tasks: reload %s before finish: %v", id, err)
@@ -744,7 +752,7 @@ func (r *Runner) finish(id string, runErr error) {
 			cur.Attempts = 0
 			cur.LastError = runErr.Error()
 			cur.UpdatedAt = now
-			if err := r.store.save(cur); err != nil {
+			if err := r.store.Save(cur); err != nil {
 				r.ioMu.Unlock()
 				r.log("tasks: persist requeued-after-failure state for %s: %v", id, err)
 				return
@@ -768,7 +776,7 @@ func (r *Runner) finish(id string, runErr error) {
 		} else {
 			cur.State = StateDone
 		}
-		if err := r.store.save(cur); err != nil {
+		if err := r.store.Save(cur); err != nil {
 			r.ioMu.Unlock()
 			r.log("tasks: persist done state for %s: %v", id, err)
 			return
@@ -798,7 +806,7 @@ func (r *Runner) recordFailureLocked(t *Task, cause error) {
 		r.log("tasks: %s failed (attempt %d/%d), retry at %s: %v",
 			t.ID, t.Attempts, r.maxAttempts, t.NextAttemptAt.Format(time.RFC3339), cause)
 	}
-	if err := r.store.save(t); err != nil {
+	if err := r.store.Save(t); err != nil {
 		r.log("tasks: persist failure state for %s: %v", t.ID, err)
 	}
 }

--- a/internal/tasks/runner_test.go
+++ b/internal/tasks/runner_test.go
@@ -49,6 +49,18 @@ func testRunner(t *testing.T, clock *fakeClock) *Runner {
 	return r
 }
 
+// storeRoot returns the on-disk root behind a file-backed runner. The runner's
+// store is the Store interface now, so the on-disk assertions reach the concrete
+// FileStore through this helper.
+func storeRoot(t *testing.T, r *Runner) string {
+	t.Helper()
+	fs, ok := r.store.(*FileStore)
+	if !ok {
+		t.Fatalf("runner is not file-backed (%T)", r.store)
+	}
+	return fs.s.root
+}
+
 // waitFor polls cond until it is true or the deadline elapses. It is used ONLY to
 // observe the worker's eventual durable state (the worker runs in its own
 // goroutine on a short ticker); ordering guarantees in the cancel/commit tests use
@@ -132,7 +144,7 @@ func TestDerivedIDEnqueueIsIdempotent(t *testing.T) {
 		t.Fatalf("derived id: got %q want %q", all[0].ID, id)
 	}
 	// Exactly one file on disk.
-	files, _ := os.ReadDir(stateDir(r.store.root))
+	files, _ := os.ReadDir(stateDir(storeRoot(t, r)))
 	jsonCount := 0
 	for _, f := range files {
 		if filepath.Ext(f.Name()) == ".json" {
@@ -805,7 +817,7 @@ func TestRetryOnDeadTask(t *testing.T) {
 		CreatedAt:     clock.now(),
 		UpdatedAt:     clock.now(),
 	}
-	if err := r.store.save(dead); err != nil {
+	if err := r.store.Save(dead); err != nil {
 		t.Fatal(err)
 	}
 	got, err := r.Retry(dead.ID)
@@ -1203,10 +1215,10 @@ func TestPoisonRecordDoesNotWedgeWorker(t *testing.T) {
 	// Place a corrupt record that sorts BEFORE the valid one (ReadDir is sorted),
 	// so list() visits it first. The old code returned on the parse error and the
 	// worker never reached the valid task.
-	if err := r.store.init(); err != nil {
+	if err := r.store.Init(); err != nil {
 		t.Fatal(err)
 	}
-	poison := filepath.Join(stateDir(r.store.root), "aaa_corrupt.json")
+	poison := filepath.Join(stateDir(storeRoot(t, r)), "aaa_corrupt.json")
 	if err := os.WriteFile(poison, []byte("{ this is not valid json"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tasks/store.go
+++ b/internal/tasks/store.go
@@ -11,12 +11,14 @@ import (
 	"time"
 )
 
-// The task store is one atomic-JSON file per task under <root>/.attn/tasks/. The
-// "queue" is os.ReadDir filtered by State — there is no index file and no SQLite
-// table (the burned-migration gotcha means a new table would be silently skipped
-// on real DBs). The single worker serializes all writes, so no per-task lock is
-// needed; the only durability guarantee the store owns is atomic temp+rename so a
-// crash mid-write never leaves a half-written record.
+// This is the FILE-backed implementation of the Store seam (see FileStore below):
+// one atomic-JSON file per task under <root>/.attn/tasks/, with the "queue" being
+// os.ReadDir filtered by State. Production now injects a SQLite-backed Store from
+// the daemon instead (docs/plans/2026-07-02-bg-task-notifications.md); this file
+// impl backs the package's own tests and the daemon's one-time JSON->SQLite import
+// of any pre-existing on-disk records. The single worker serializes all writes, so
+// no per-task lock is needed; the only durability guarantee this store owns is
+// atomic temp+rename so a crash mid-write never leaves a half-written record.
 
 const (
 	machineDir = ".attn"
@@ -198,6 +200,60 @@ func (s *store) recoverOrphans(now time.Time) (int, error) {
 	}
 	return recovered, nil
 }
+
+// Store is the persistence + single-instance-lock seam the Runner sits on. The
+// file-backed FileStore below is the default and backs this package's own tests;
+// the daemon injects a SQLite-backed implementation via Options.Store so tasks
+// persist in the profile DB (not under the notebook root). Keeping the seam here
+// (not importing internal/store) preserves this package as a leaf.
+type Store interface {
+	// Init prepares the store (the file store creates its tasks dir; a DB store is
+	// a no-op — migrations create the table).
+	Init() error
+	// AcquireLock takes exclusive single-instance ownership, returning an opaque
+	// token for ReleaseLock. Returns ErrAlreadyRunning if another live process
+	// already holds it.
+	AcquireLock() (string, error)
+	// ReleaseLock releases a token from AcquireLock. Best-effort; never blocks Stop.
+	ReleaseLock(token string)
+	// RecoverOrphans resets any task left in StateRunning back to StateQueued
+	// (NextAttemptAt = now) and returns how many were recovered.
+	RecoverOrphans(now time.Time) (int, error)
+	// Load returns the record for id, or (nil, nil) when there is none.
+	Load(id string) (*Task, error)
+	// Save persists a record (create or overwrite by id).
+	Save(t *Task) error
+	// Delete removes a record by id; a missing record is not an error.
+	Delete(id string) error
+	// List returns every persisted record.
+	List() ([]*Task, error)
+}
+
+// FileStore is the file-backed Store: one atomic-JSON file per task under
+// <root>/.attn/tasks/. It wraps this package's internal file store so both the
+// Runner and the daemon's one-time JSON->SQLite import reach it through the Store
+// interface.
+type FileStore struct{ s *store }
+
+// NewFileStore builds a file-backed Store rooted at root. A nil log is a no-op.
+func NewFileStore(root string, log LogFunc) *FileStore {
+	s := newStore(root)
+	if log != nil {
+		s.log = log
+	}
+	return &FileStore{s: s}
+}
+
+func (f *FileStore) Init() error                  { return f.s.init() }
+func (f *FileStore) AcquireLock() (string, error) { return f.s.acquireLock() }
+func (f *FileStore) ReleaseLock(token string)     { f.s.releaseLock(token) }
+func (f *FileStore) RecoverOrphans(now time.Time) (int, error) {
+	return f.s.recoverOrphans(now)
+}
+func (f *FileStore) Load(id string) (*Task, error) { return f.s.load(id) }
+func (f *FileStore) Save(t *Task) error            { return f.s.save(t) }
+func (f *FileStore) Delete(id string) error        { return f.s.delete(id) }
+func (f *FileStore) List() ([]*Task, error)        { return f.s.list() }
 
 // writeAtomic mirrors notebook.writeAtomic: write to a unique temp file, then
 // rename over the target so a reader never observes a half-written record.


### PR DESCRIPTION
First slice of the **background-task notifications** initiative (plan: `docs/plans/2026-07-02-bg-task-notifications.md`). Moves the durable task runner off one-JSON-file-per-task under the notebook root and onto a SQLite table in the profile DB.

## Why
Storage under the notebook root is why the runner is *disabled without a notebook root*. Putting tasks in the global DB dissolves that coupling — which is what later lets the reconcile classifier become an ordinary task kind (PR3) — and gives the coming notifications surface a queryable store. (The narration plans original "no SQLite" call was a defensive workaround for a burned-migration hazard that no longer applies; migrations flow cleanly to `{60}` today.)

## What
- **migration `{61}`**: `tasks` table
- **store**: `TaskRecord` + CRUD / recover-running (`internal/store/tasks.go`)
- **tasks**: a `Store` seam — an exported interface with a `FileStore` wrapper over the *untouched* file store, so the battle-tested store and its identity tests are undisturbed; the runner now takes an injected `Store`
- **daemon**: SQLite adapter mapping `Task`↔`store.TaskRecord` (`internal/daemon/task_store.go`); the single-instance lock is extracted to shared dir-lock helpers and relocated from the notebook tasks dir to the profile data dir; a one-time import of any legacy on-disk records (drops unparseable, retires the dir); `startCompactRunner` injects the store

## Scope / safety
- **Behavior-preserving**: the runners enable gate stays keyed on the notebook root in this PR — dropping it belongs in PR3 with reconcile, where narrations real root-dependence gets handled.
- **No protocol change** (the `NotebookTask` projection is unchanged), so no version bump and no changelog entry (internal refactor).

## Verification
- `go test ./internal/tasks ./internal/store ./internal/daemon` green; `internal/tasks` `-race` clean; full build.
- **Real-app smoke** on a throwaway profile seeded with a copy of the real v60 dev DB: migration `{61}` applied cleanly (v60→v61, table created, 20 tickets intact); daemon startup ran the import-once conversion (`tasks migrate: imported 1 legacy task(s)`, unparseable dropped, dir retired); the live SQLite-backed runner executed 3 real `narrate_workspace` tasks to `done`. Source dev DB untouched.

_Opened by Claude on behalf of Victor._