### PR TITLE
feat(tasks): bounded per-kind concurrency in the durable runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,19 @@ pnpm run e2e
 - Diagnose root cause before fixing symptoms.
 - Do not remove requested functionality without explicit approval.
 
+## Live-App Testing Is Required
+
+Automated tests are necessary but not sufficient. Every PR must be exercised in the **live app** (a running daemon/app built from the branch) before it is called done or merged, with exactly two exemptions:
+
+- the change is **trivial** (e.g. a comment, a doc, a rename, a log-string tweak), or
+- the change is one you have **extremely high confidence** in without a live-app test, and you can say concretely why (for example: a pure, well-isolated function fully covered by unit tests, with no daemon-process, protocol, timing, or UI surface).
+
+A large automated suite — even a race-clean concurrency suite — is not by itself one of these exemptions. If the change touches the daemon process lifecycle, protocol, PTY, background runners, or any UI, it needs live-app verification.
+
+Use a **non-prod** profile for this (the `dev` sibling or a throwaway `ATTN_PROFILE`) — that is pre-authorized; never smoke on prod. See [Iterating On Attn Itself](#iterating-on-attn-itself-attn-on-attn-testing) and [docs/profiles.md](docs/profiles.md).
+
+If a PR needs live-app verification and you **cannot** run it (no ability to build/install/run a non-prod profile in this environment), **stop and ask the user for guidance** — do not merge on automated tests alone. State plainly in the PR and to the user what was and was not verified live.
+
 ## Packaged-App Harness
 
 - Real packaged-app scenarios are single-tenant. Never run them in parallel.

--- a/docs/plans/2026-07-02-bg-task-notifications.md
+++ b/docs/plans/2026-07-02-bg-task-notifications.md
@@ -189,9 +189,23 @@ Isolate this in its own PR so the invariant change is reviewed alone.
       imported 1 legacy task(s)`, unparseable file dropped, dir retired to
       `.migrated`); the live SQLite-backed runner executed 3 real `narrate_workspace`
       tasks to `done`. Source dev DB untouched; profile torn down.
-- [ ] **PR2 — Runner bounded per-kind concurrency.** Executors concurrent, record
-      mutations serialized; default cap 1. Preserve every invariant above.
-      Backend + tests (race-clean).
+      **Merged** 2026-07-02 as PR #455 (merge commit `335f5e8d`): figgyster APPROVED
+      on head, CI green. A follow-up commit gofmt-aligned `scanTaskRow`'s var block.
+- [x] **PR2 — Runner bounded per-kind concurrency.** Replaced the single
+      run-one-at-a-time worker with a dispatch loop that claims every eligible task
+      whose kind is under its per-kind concurrency cap and launches each as its own
+      goroutine. `executor` gained a `limit`; new `ExecutorConfig{Timeout,
+      MaxConcurrent}` + `RegisterWith` (default cap 1 ⇒ a kind stays serialized with
+      itself, different kinds now run in parallel; reconcile will use 2). Runner
+      state: `run *activeRun` → `runs map[id]*activeRun` + `inflight map[kind]int`,
+      both under `mu`; a claimed slot is reserved under `mu` then persisted under
+      `ioMu` (ioMu stays the outer lock, no store I/O under `mu`). `Stop` reordered
+      for detached runs: close done → wait loop exit → `cancelAll` (fence + join
+      every in-flight run). All prior invariants preserved (commit fence, Requeued
+      coalescing, backoff/dead, orphan recovery, single-instance lock,
+      Cancel-blocks-until-terminal-record). No protocol/frontend change. Tests:
+      cross-kind concurrency, per-kind cap serialization, configured cap 2, Stop
+      drains multiple in-flight; existing suite + new ones race-clean at `-count=10`.
 - [ ] **PR3 — Reconcile → `reconcile` task kind.** *Land after PR #454 merges;
       rebase over main and build on its classifier body — do not port the old
       one.* Register the executor (body = classifier incl. drop-rule/🩺 comment);

--- a/docs/plans/2026-07-02-bg-task-notifications.md
+++ b/docs/plans/2026-07-02-bg-task-notifications.md
@@ -206,6 +206,15 @@ Isolate this in its own PR so the invariant change is reviewed alone.
       Cancel-blocks-until-terminal-record). No protocol/frontend change. Tests:
       cross-kind concurrency, per-kind cap serialization, configured cap 2, Stop
       drains multiple in-flight; existing suite + new ones race-clean at `-count=10`.
+      **Live-app smoke** (throwaway profile, daemon built from the branch): fresh DB
+      migrated to {61}; the live dispatch loop ran seeded `compact_context` (ws-A/ws-B)
+      + `summarize_session` tasks — cross-kind ran concurrently, the two same-kind
+      compacts serialized (next_attempt_at ~2ms apart, cap 1); both terminal paths
+      (failed+backoff, done) persisted; a seeded `running` orphan was recovered
+      (stale runner lock reclaimed) → re-dispatched → done on next boot. Graceful
+      `runner.Stop()`/`cancelAll` is NOT reachable in prod (nothing calls
+      `Daemon.Stop()` outside the test harness — the daemon is killed and relies on
+      orphan recovery), so that path stays covered by `TestStopDrainsConcurrentInFlightRuns`.
 - [ ] **PR3 — Reconcile → `reconcile` task kind.** *Land after PR #454 merges;
       rebase over main and build on its classifier body — do not port the old
       one.* Register the executor (body = classifier incl. drop-rule/🩺 comment);

--- a/internal/daemon/notebook_tasks.go
+++ b/internal/daemon/notebook_tasks.go
@@ -104,9 +104,10 @@ func (d *Daemon) sendNotebookTaskRetryWSResult(client *wsClient, requestID, task
 
 // broadcastNotebookTasksChanged announces that a task lifecycle transition
 // occurred so an open task panel re-lists. It is wired to the runner's OnChange
-// callback (see startCompactRunner). broadcastMessage -> wsHub.BroadcastValue is
-// non-blocking (a full broadcast channel drops the message), so this is safe to
-// invoke synchronously from the runner's single worker goroutine.
+// callback (see startCompactRunner). It builds a fresh message and does a
+// non-blocking broadcastMessage -> wsHub.BroadcastValue (a full broadcast channel
+// drops the message), holding no shared state, so it is safe to invoke
+// CONCURRENTLY from the runner's dispatch goroutine and its in-flight runs.
 func (d *Daemon) broadcastNotebookTasksChanged() {
 	d.broadcastMessage(protocol.NotebookTasksChangedMessage{
 		Event: protocol.EventNotebookTasksChanged,

--- a/internal/daemon/workspace_keeper.go
+++ b/internal/daemon/workspace_keeper.go
@@ -252,11 +252,12 @@ func (d *Daemon) startCompactRunner() {
 			d.logf("notebook narration: register narrate_workspace: %v", err)
 		}
 	}
-	// Surface lifecycle transitions to any open task panel. OnChange fires
-	// SYNCHRONOUSLY inside the runner's single worker goroutine, so the callback
-	// must be cheap and non-blocking: broadcastNotebookTasksChanged ->
-	// broadcastMessage -> wsHub.BroadcastValue uses a non-blocking send that drops
-	// on a full broadcast channel, so it can never stall the worker.
+	// Surface lifecycle transitions to any open task panel. OnChange may fire
+	// CONCURRENTLY from the runner's dispatch goroutine and its in-flight runs, so
+	// the callback must be cheap, non-blocking, and concurrency-safe:
+	// broadcastNotebookTasksChanged -> broadcastMessage -> wsHub.BroadcastValue
+	// builds a fresh message and uses a non-blocking send that drops on a full
+	// broadcast channel, so it can never stall a run.
 	runner.OnChange(func() { d.broadcastNotebookTasksChanged() })
 	d.setCompactRunner(runner)
 	_ = runner.Start()

--- a/internal/tasks/concurrency_test.go
+++ b/internal/tasks/concurrency_test.go
@@ -1,0 +1,225 @@
+package tasks
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// recvWithin reads one value from ch or fails after 3s. Used to observe an
+// executor entering (a channel sync point, never a sleep).
+func recvWithin(t *testing.T, what string, ch <-chan string) string {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+		return ""
+	}
+}
+
+// assertNoRecv asserts nothing arrives on ch within a short window — the negative
+// side of a concurrency-cap assertion (a still-blocked run must NOT have entered).
+func assertNoRecv(t *testing.T, what string, ch <-chan string) {
+	t.Helper()
+	select {
+	case v := <-ch:
+		t.Fatalf("%s: unexpected entry %q — the concurrency cap did not hold", what, v)
+	case <-time.After(60 * time.Millisecond):
+	}
+}
+
+// TestDifferentKindsRunConcurrently proves the whole point of the change: two
+// DIFFERENT kinds run at the same time. Each executor parks on a shared release
+// gate; both must enter before either is released. Under the old single-worker
+// design the second kind could never enter while the first was parked, so this
+// test would time out.
+func TestDifferentKindsRunConcurrently(t *testing.T) {
+	clock := newFakeClock()
+	r := testRunner(t, clock)
+
+	enteredA := make(chan string, 1)
+	enteredB := make(chan string, 1)
+	release := make(chan struct{})
+	_ = r.Register("A", func(_ context.Context, task *Task) error {
+		enteredA <- task.Subject
+		<-release
+		return nil
+	})
+	_ = r.Register("B", func(_ context.Context, task *Task) error {
+		enteredB <- task.Subject
+		<-release
+		return nil
+	})
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer r.Stop()
+
+	if _, err := r.Enqueue("A", "s", EnqueueOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Enqueue("B", "s", EnqueueOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// BOTH must be running at once (neither released yet).
+	recvWithin(t, "kind A to enter", enteredA)
+	recvWithin(t, "kind B to enter (concurrently with A)", enteredB)
+
+	close(release)
+	waitFor(t, "both kinds to reach done", func() bool {
+		a, _ := r.Get(TaskID("A", "s"))
+		b, _ := r.Get(TaskID("B", "s"))
+		return a != nil && a.State == StateDone && b != nil && b.State == StateDone
+	})
+}
+
+// TestPerKindCapSerializesSameKind proves the default cap of 1 keeps a kind
+// serialized with itself: two subjects of the same kind never run at once. The
+// first parks; the second must not enter until the first finishes.
+func TestPerKindCapSerializesSameKind(t *testing.T) {
+	clock := newFakeClock()
+	r := testRunner(t, clock)
+
+	entered := make(chan string, 8)
+	release := make(chan struct{})
+	_ = r.Register("K", func(_ context.Context, task *Task) error {
+		entered <- task.Subject
+		<-release
+		return nil
+	})
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer r.Stop()
+
+	if _, err := r.Enqueue("K", "s1", EnqueueOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Enqueue("K", "s2", EnqueueOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Exactly one run enters; the other is cap-blocked while the first is parked.
+	first := recvWithin(t, "the first same-kind run to enter", entered)
+	assertNoRecv(t, "a second same-kind run started while the first was still running", entered)
+
+	// Release the first; only now may the second run.
+	close(release)
+	second := recvWithin(t, "the second same-kind run to enter after the first finished", entered)
+	if first == second {
+		t.Fatalf("both entries were the same subject %q; expected the two distinct subjects", first)
+	}
+	waitFor(t, "both same-kind subjects to reach done", func() bool {
+		a, _ := r.Get(TaskID("K", "s1"))
+		b, _ := r.Get(TaskID("K", "s2"))
+		return a != nil && a.State == StateDone && b != nil && b.State == StateDone
+	})
+}
+
+// TestPerKindCapAllowsConfiguredConcurrency proves RegisterWith(MaxConcurrent: 2)
+// lets exactly two runs of that kind proceed at once while a third waits for a
+// freed slot. This is the shape PR3's reconcile kind uses.
+func TestPerKindCapAllowsConfiguredConcurrency(t *testing.T) {
+	clock := newFakeClock()
+	r := testRunner(t, clock)
+
+	entered := make(chan string, 8)
+	release := make(chan struct{})
+	if err := r.RegisterWith("K", func(_ context.Context, task *Task) error {
+		entered <- task.Subject
+		<-release
+		return nil
+	}, ExecutorConfig{MaxConcurrent: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer r.Stop()
+
+	for _, s := range []string{"s1", "s2", "s3"} {
+		if _, err := r.Enqueue("K", s, EnqueueOptions{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Two run concurrently (cap 2); the third is held back.
+	recvWithin(t, "the first run to enter", entered)
+	recvWithin(t, "the second run to enter (concurrently, cap 2)", entered)
+	assertNoRecv(t, "a third run started while two of the same kind were already running", entered)
+
+	// Free the two slots; the third now runs.
+	close(release)
+	recvWithin(t, "the third run to enter after a slot freed", entered)
+	waitFor(t, "all three subjects to reach done", func() bool {
+		for _, s := range []string{"s1", "s2", "s3"} {
+			task, _ := r.Get(TaskID("K", s))
+			if task == nil || task.State != StateDone {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// TestStopDrainsConcurrentInFlightRuns proves Stop cancels and joins EVERY
+// in-flight run, not just one. Two different kinds are parked on ctx.Done(); Stop
+// must return only after both goroutines have exited.
+func TestStopDrainsConcurrentInFlightRuns(t *testing.T) {
+	clock := newFakeClock()
+	r := testRunner(t, clock)
+
+	enteredA := make(chan string, 1)
+	enteredB := make(chan string, 1)
+	exited := make(chan string, 2)
+	_ = r.Register("A", func(ctx context.Context, task *Task) error {
+		enteredA <- task.Subject
+		<-ctx.Done() // Stop must cancel us
+		exited <- task.Kind
+		return ctx.Err()
+	})
+	_ = r.Register("B", func(ctx context.Context, task *Task) error {
+		enteredB <- task.Subject
+		<-ctx.Done()
+		exited <- task.Kind
+		return ctx.Err()
+	})
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Enqueue("A", "s", EnqueueOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Enqueue("B", "s", EnqueueOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	recvWithin(t, "kind A to enter", enteredA)
+	recvWithin(t, "kind B to enter", enteredB)
+
+	stopped := make(chan struct{})
+	go func() {
+		r.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Stop did not return after cancelling both in-flight runs")
+	}
+	// Both run goroutines must have observed their cancellation and exited.
+	got := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case kind := <-exited:
+			got[kind] = true
+		case <-time.After(time.Second):
+			t.Fatalf("only %d of 2 in-flight runs exited on Stop", len(got))
+		}
+	}
+	if !got["A"] || !got["B"] {
+		t.Fatalf("Stop did not drain both kinds; exited=%v", got)
+	}
+}

--- a/internal/tasks/lock.go
+++ b/internal/tasks/lock.go
@@ -11,12 +11,14 @@ import (
 )
 
 // ErrAlreadyRunning is returned by Start when another live Runner already owns
-// the lock dir. The orphan-recovery and single-worker guarantees assume at most
-// one live worker per store: two workers would both claim the same record, both
+// the lock dir. The orphan-recovery and single-instance guarantees assume at most
+// one live Runner per store: two Runners would both claim the same record, both
 // save StateRunning (atomic rename = last-writer-wins, no torn file), and both
 // invoke the executor concurrently — double-applying the durable write (e.g.
-// double compaction). The CommitGuard is a per-process in-memory latch with no
-// cross-process coordination, so nothing else can fence that.
+// double compaction). Per-kind concurrency bounds parallelism WITHIN one Runner;
+// it does nothing across processes. The CommitGuard is likewise a per-process
+// in-memory latch with no cross-process coordination, so nothing else can fence
+// that.
 var ErrAlreadyRunning = errors.New("tasks: another runner already owns this store")
 
 // lockFileName is the single-instance ownership marker inside the lock dir.

--- a/internal/tasks/runner.go
+++ b/internal/tasks/runner.go
@@ -23,9 +23,9 @@ const (
 	// wraps around every invocation. Keeper compaction uses 5 minutes; a kind can
 	// override it via RegisterWithTimeout.
 	DefaultExecutorTimeout = 5 * time.Minute
-	// defaultPollInterval is how often the worker wakes to re-scan the queue for a
-	// task whose NextAttemptAt has arrived. The single worker is level-triggered,
-	// so this only bounds scheduling latency for time-gated requeues.
+	// defaultPollInterval is how often the dispatch loop wakes to re-scan the queue
+	// for a task whose NextAttemptAt has arrived. The loop is level-triggered, so
+	// this only bounds scheduling latency for time-gated requeues.
 	defaultPollInterval = time.Second
 )
 
@@ -46,10 +46,28 @@ var ErrUnknownKind = errors.New("tasks: no executor registered for kind")
 // internal/daemon/workspace_keeper.go.
 type ExecutorFunc func(ctx context.Context, task *Task) error
 
-// executor pairs a registered ExecutorFunc with its per-kind timeout.
+// executor pairs a registered ExecutorFunc with its per-kind timeout and
+// concurrency cap.
 type executor struct {
 	fn      ExecutorFunc
 	timeout time.Duration
+	// limit is the max number of tasks OF THIS KIND that may run at once. It is
+	// always >= 1 after registration (a zero MaxConcurrent resolves to 1), so a
+	// kind is serialized with itself by default while different kinds run in
+	// parallel.
+	limit int
+}
+
+// ExecutorConfig tunes a registered executor. The zero value is the default:
+// DefaultExecutorTimeout and a per-kind concurrency cap of 1.
+type ExecutorConfig struct {
+	// Timeout is the per-invocation context.WithTimeout the runner wraps around
+	// every call to this executor. Zero ⇒ DefaultExecutorTimeout.
+	Timeout time.Duration
+	// MaxConcurrent bounds how many tasks of this kind may run simultaneously.
+	// Zero ⇒ 1 (a kind serialized with itself, the pre-concurrency default);
+	// different kinds always run in parallel regardless. The reconcile kind uses 2.
+	MaxConcurrent int
 }
 
 // EnqueueOptions tunes a single Enqueue call.
@@ -96,7 +114,11 @@ type Options struct {
 	BackoffCap  time.Duration
 }
 
-// Runner is the durable, single-worker task runner.
+// Runner is the durable task runner. A single dispatch loop selects eligible
+// tasks and launches each as its own goroutine, bounded by a per-kind
+// concurrency cap (default 1): a kind is serialized with itself while different
+// kinds run in parallel. Every record read-modify-write still funnels through
+// ioMu, so persistence stays serialized even though executors run concurrently.
 type Runner struct {
 	store    Store
 	log      LogFunc
@@ -109,26 +131,35 @@ type Runner struct {
 	backoffCap   time.Duration
 
 	// onChange, if set, fires after every lifecycle transition (for the status
-	// broadcast). It runs synchronously inside the worker, so it must be cheap and
-	// non-blocking; the daemon's wiring just emits a websocket event.
+	// broadcast). It may be called CONCURRENTLY — from the dispatch goroutine, from
+	// each in-flight run's finish(), and from Enqueue/Retry/Remove on arbitrary
+	// daemon goroutines — so it must be cheap, non-blocking, and safe to invoke from
+	// multiple goroutines; the daemon's wiring just emits a websocket event.
 	onChange func()
 
 	mu        sync.Mutex
 	executors map[string]executor
 	started   bool
 
-	// ioMu serializes every read-modify-write cycle on a task record. The single
-	// worker plus arbitrary daemon goroutines calling Enqueue/Retry all mutate the
-	// same on-disk records; without this a concurrent Enqueue and a worker state
-	// write would lost-update each other. It is a coarse store-level lock — correct
-	// and cheap because record I/O is fast and contention is low. It is ALWAYS
-	// acquired without holding mu (and the executor never runs while it is held),
-	// so there is no lock-ordering hazard with mu.
+	// ioMu serializes every read-modify-write cycle on a task record. The dispatch
+	// loop, the in-flight run goroutines' finish(), and arbitrary daemon goroutines
+	// calling Enqueue/Retry all mutate the same records; without this a concurrent
+	// Enqueue and a claim/finish write would lost-update each other. It is a coarse
+	// store-level lock — correct and cheap because record I/O is fast and
+	// contention is low. When both locks are needed, ioMu is ALWAYS the outer lock:
+	// it is acquired without holding mu (dispatch takes ioMu, then briefly mu to
+	// reserve a slot), so there is no lock-ordering hazard with mu.
 	ioMu sync.Mutex
 
-	// run is the state of the currently-running task (nil when idle). Cancel reads
-	// it under mu to coordinate the commit fence and the blocks-until-exit wait.
-	run *activeRun
+	// runs holds every in-flight run keyed by task id (the single-worker design had
+	// one *activeRun). Cancel(id) fences and waits on its entry; Stop drains them
+	// all. Guarded by mu.
+	runs map[string]*activeRun
+
+	// inflight counts currently-running tasks per kind. dispatch reads it to enforce
+	// each kind's concurrency cap; it is bumped when a run is claimed and dropped
+	// when the run goroutine exits. Guarded by mu.
+	inflight map[string]int
 
 	// wake nudges the worker to re-scan the queue immediately after an Enqueue or
 	// Retry, rather than waiting for the next poll tick. Buffered depth 1 so a
@@ -143,11 +174,12 @@ type Runner struct {
 	lockPath string
 }
 
-// activeRun tracks the in-flight task so Cancel can fence its commit and block
+// activeRun tracks one in-flight task so Cancel can fence its commit and block
 // until its goroutine exits. Ported from the keeper compaction cancel/done/committing
 // fields (workspace_keeper.go).
 type activeRun struct {
 	id     string
+	kind   string // so the run goroutine can drop its per-kind in-flight slot on exit
 	cancel context.CancelFunc
 	guard  *CommitGuard
 	done   chan struct{} // closed when the run goroutine has fully exited
@@ -172,6 +204,8 @@ func New(opts Options) *Runner {
 		log:          log,
 		now:          utcNow,
 		executors:    make(map[string]executor),
+		runs:         make(map[string]*activeRun),
+		inflight:     make(map[string]int),
 		pollInterval: nonZeroDuration(opts.PollInterval, defaultPollInterval),
 		maxAttempts:  nonZeroInt(opts.MaxAttempts, DefaultMaxAttempts),
 		backoffBase:  nonZeroDuration(opts.BackoffBase, DefaultBackoffBase),
@@ -202,15 +236,23 @@ func (r *Runner) OnChange(fn func()) {
 	r.mu.Unlock()
 }
 
-// Register wires an executor for a kind with the default per-kind timeout.
+// Register wires an executor for a kind with the default per-kind timeout and a
+// concurrency cap of 1.
 func (r *Runner) Register(kind string, fn ExecutorFunc) error {
-	return r.RegisterWithTimeout(kind, fn, DefaultExecutorTimeout)
+	return r.RegisterWith(kind, fn, ExecutorConfig{})
 }
 
 // RegisterWithTimeout wires an executor for a kind with an explicit timeout (the
-// runner wraps every invocation in context.WithTimeout of this duration). It is
-// an error to register the same kind twice or to pass a nil fn.
+// runner wraps every invocation in context.WithTimeout of this duration) and a
+// concurrency cap of 1.
 func (r *Runner) RegisterWithTimeout(kind string, fn ExecutorFunc, timeout time.Duration) error {
+	return r.RegisterWith(kind, fn, ExecutorConfig{Timeout: timeout})
+}
+
+// RegisterWith wires an executor for a kind with an explicit timeout and per-kind
+// concurrency cap (see ExecutorConfig). It is an error to register the same kind
+// twice or to pass a nil fn.
+func (r *Runner) RegisterWith(kind string, fn ExecutorFunc, cfg ExecutorConfig) error {
 	if r.disabled {
 		return ErrDisabled
 	}
@@ -220,20 +262,25 @@ func (r *Runner) RegisterWithTimeout(kind string, fn ExecutorFunc, timeout time.
 	if kind == "" {
 		return errors.New("tasks: kind must not be empty")
 	}
+	timeout := cfg.Timeout
 	if timeout <= 0 {
 		timeout = DefaultExecutorTimeout
+	}
+	limit := cfg.MaxConcurrent
+	if limit <= 0 {
+		limit = 1
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.executors[kind]; exists {
 		return fmt.Errorf("tasks: kind already registered: %s", kind)
 	}
-	r.executors[kind] = executor{fn: fn, timeout: timeout}
+	r.executors[kind] = executor{fn: fn, timeout: timeout, limit: limit}
 	return nil
 }
 
 // Start recovers orphaned running tasks (reset to queued) and launches the single
-// worker goroutine. It is safe (no-op) on a disabled runner. Calling Start twice
+// dispatch goroutine. It is safe (no-op) on a disabled runner. Calling Start twice
 // is an error.
 func (r *Runner) Start() error {
 	if r.disabled {
@@ -280,10 +327,10 @@ func (r *Runner) Start() error {
 	return nil
 }
 
-// Stop signals the worker to exit and blocks until it has. A Stop concurrent with
-// an in-flight executor lets that executor finish (the worker checks done only
-// between tasks); callers that need a specific task aborted use Cancel first. Safe
-// to call on a disabled or never-started runner.
+// Stop signals the dispatch loop to exit, then cancels and drains every in-flight
+// run. cancelAll honors each commit fence, so an already-committing run still
+// finishes its durable write untorn. Safe to call on a disabled or never-started
+// runner.
 func (r *Runner) Stop() {
 	r.mu.Lock()
 	if !r.started {
@@ -300,15 +347,17 @@ func (r *Runner) Stop() {
 	r.lockPath = ""
 	r.mu.Unlock()
 
-	// Cancel any in-flight run so Stop does not block on a long executor; this
-	// respects the commit fence (an already-committing run still finishes).
-	r.cancelActive()
-
+	// Order matters in the concurrent model: runs are detached goroutines the
+	// dispatch loop does not join. First stop the loop launching MORE runs
+	// (close done, wait for the loop to exit), THEN cancel and join everything
+	// still in flight. Doing it in this order guarantees no new run can appear
+	// while cancelAll drains, so it terminates.
 	close(done)
 	<-exit
+	r.cancelAll()
 
-	// Release single-instance ownership only after the worker has fully exited, so
-	// no other Runner can claim the root while ours is still draining.
+	// Release single-instance ownership only after every run has exited, so no
+	// other Runner can claim the store while ours is still draining.
 	r.store.ReleaseLock(lockPath)
 }
 
@@ -450,8 +499,8 @@ func (r *Runner) Cancel(id string) {
 		return
 	}
 	r.mu.Lock()
-	run := r.run
-	if run == nil || run.id != id {
+	run := r.runs[id]
+	if run == nil {
 		r.mu.Unlock()
 		return
 	}
@@ -527,32 +576,34 @@ func (r *Runner) Get(id string) (*Task, error) {
 	return r.store.Load(id)
 }
 
-// --- worker loop -----------------------------------------------------------
+// --- dispatch loop ---------------------------------------------------------
 
-// loop is the single worker goroutine. It is level-triggered: each pass picks the
-// one eligible task (if any), runs it, then waits for the next nudge or poll tick.
-// There is no worker pool — serialization is the whole point (it removes the need
-// for a per-task lock).
+// loop is the single dispatch goroutine. It is level-triggered: each pass claims
+// and launches every currently-eligible task whose kind has a free concurrency
+// slot (each as its own goroutine), draining until a pass can place nothing more,
+// then waits for the next nudge or poll tick. Executors run concurrently; the loop
+// itself never blocks on one.
 func (r *Runner) loop() {
 	defer close(r.exit)
 	ticker := time.NewTicker(r.pollInterval)
 	defer ticker.Stop()
 	for {
-		// Drain all currently-eligible work before sleeping, so a burst of enqueues
-		// does not stall behind the poll interval.
+		// Drain: keep dispatching until a pass launches nothing (queue empty or
+		// every eligible kind saturated), so a burst of enqueues does not stall
+		// behind the poll interval.
 		for {
-			ran, err := r.runNext()
-			if err != nil {
-				r.log("tasks: worker pass: %v", err)
-				break
-			}
-			if !ran {
-				break
-			}
 			select {
 			case <-r.done:
 				return
 			default:
+			}
+			progressed, err := r.dispatch()
+			if err != nil {
+				r.log("tasks: dispatch pass: %v", err)
+				break
+			}
+			if !progressed {
+				break
 			}
 		}
 		select {
@@ -564,13 +615,22 @@ func (r *Runner) loop() {
 	}
 }
 
-// runNext selects the single most-eligible task and runs it. It reports whether a
-// task ran (so the caller can keep draining). A task is eligible when it is queued
-// (or a failed task past its NextAttemptAt with attempts under the cap) and its
-// NextAttemptAt has arrived. Selection runs under ioMu so a concurrent Enqueue/
-// Retry cannot make the chosen record stale before the run is claimed.
-func (r *Runner) runNext() (bool, error) {
+// dispatch claims every currently-eligible task whose kind is under its per-kind
+// concurrency cap and launches each in its own goroutine. It reports whether it
+// made progress (launched a run, or failed an unknown-kind task in place) so the
+// loop keeps draining until a pass can place nothing more. Selection order is
+// earliest NextAttemptAt, then oldest CreatedAt, so under cap pressure the
+// longest-waiting work claims the freed slot first.
+//
+// The store read and every per-task claim write run under ioMu, so a concurrent
+// Enqueue/Retry cannot make a chosen record stale between selection and claim.
+// The per-kind in-flight accounting and the active-run registry live under mu,
+// which is only ever taken WHILE holding ioMu (never the reverse) — preserving the
+// ioMu-outer lock order. Executors are launched only AFTER both locks are released,
+// so an executor never runs while the runner holds a lock.
+func (r *Runner) dispatch() (progressed bool, err error) {
 	r.ioMu.Lock()
+
 	now := r.now()
 	all, err := r.store.List()
 	if err != nil {
@@ -578,54 +638,87 @@ func (r *Runner) runNext() (bool, error) {
 		return false, err
 	}
 
-	var pick *Task
+	// Collect eligible tasks, earliest-scheduled first (ties: oldest created).
+	eligible := make([]*Task, 0, len(all))
 	for _, t := range all {
-		if !r.eligible(t, now) {
+		if r.eligible(t, now) {
+			eligible = append(eligible, t)
+		}
+	}
+	sort.SliceStable(eligible, func(i, j int) bool {
+		if eligible[i].NextAttemptAt.Equal(eligible[j].NextAttemptAt) {
+			return eligible[i].CreatedAt.Before(eligible[j].CreatedAt)
+		}
+		return eligible[i].NextAttemptAt.Before(eligible[j].NextAttemptAt)
+	})
+
+	type launchSpec struct {
+		task *Task
+		exec executor
+		ctx  context.Context
+		run  *activeRun
+	}
+	var launch []launchSpec
+	failedUnknown := false
+
+	for _, t := range eligible {
+		// Decide + reserve under mu: the executor registry and in-flight counts both
+		// live there. Reserving the slot before persisting the claim keeps a later
+		// candidate of the same kind in this very pass from over-committing the cap.
+		r.mu.Lock()
+		exec, ok := r.executors[t.Kind]
+		if !ok {
+			r.mu.Unlock()
+			// No executor for this kind (e.g. a stale record from an old build). Fail
+			// it in place so it surfaces rather than being re-selected every pass.
+			r.recordFailureLocked(t, fmt.Errorf("%w: %s", ErrUnknownKind, t.Kind))
+			failedUnknown = true
 			continue
 		}
-		// Earliest NextAttemptAt wins; ties broken by oldest CreatedAt for fairness.
-		if pick == nil ||
-			t.NextAttemptAt.Before(pick.NextAttemptAt) ||
-			(t.NextAttemptAt.Equal(pick.NextAttemptAt) && t.CreatedAt.Before(pick.CreatedAt)) {
-			pick = t
+		if r.inflight[t.Kind] >= exec.limit {
+			r.mu.Unlock()
+			continue // this kind is saturated; a finishing run will re-nudge us
 		}
-	}
-	if pick == nil {
-		r.ioMu.Unlock()
-		return false, nil
+		ctx, cancel := context.WithCancel(context.Background())
+		run := &activeRun{
+			id:     t.ID,
+			kind:   t.Kind,
+			cancel: cancel,
+			guard:  &CommitGuard{},
+			done:   make(chan struct{}),
+		}
+		r.inflight[t.Kind]++
+		r.runs[t.ID] = run
+		r.mu.Unlock()
+
+		// Persist the claim (state running) under ioMu — NOT under mu, which must
+		// never wrap store I/O.
+		t.State = StateRunning
+		t.Attempts++
+		t.Requeued = false
+		t.UpdatedAt = now
+		if err := r.store.Save(t); err != nil {
+			r.log("tasks: persist running state for %s: %v", t.ID, err)
+			// Roll the reservation back so the per-kind slot is not leaked forever.
+			r.mu.Lock()
+			delete(r.runs, t.ID)
+			r.inflight[t.Kind]--
+			r.mu.Unlock()
+			cancel()
+			continue
+		}
+		launch = append(launch, launchSpec{task: t, exec: exec, ctx: ctx, run: run})
 	}
 
-	// Claim the task: mark it running and persist while still holding ioMu, so the
-	// claim is atomic against Enqueue/Retry. We then release ioMu and run the
-	// executor unlocked (it may take minutes; holding ioMu would block enqueues
-	// and status reads). Concurrency past this point is handled by the commit
-	// fence and the Requeued flag, not by ioMu.
-	r.mu.Lock()
-	exec, ok := r.executors[pick.Kind]
-	r.mu.Unlock()
-	if !ok {
-		// No executor for this kind (e.g. a stale record from an old build). Fail it
-		// in place so it surfaces rather than spinning the worker.
-		r.recordFailureLocked(pick, fmt.Errorf("%w: %s", ErrUnknownKind, pick.Kind))
-		r.ioMu.Unlock()
-		r.notifyChange()
-		return true, nil
-	}
-
-	pick.State = StateRunning
-	pick.Attempts++
-	pick.Requeued = false
-	pick.UpdatedAt = now
-	if err := r.store.Save(pick); err != nil {
-		r.ioMu.Unlock()
-		r.log("tasks: persist running state for %s: %v", pick.ID, err)
-		return false, nil
-	}
 	r.ioMu.Unlock()
-	r.notifyChange()
 
-	r.execute(pick, exec)
-	return true, nil
+	if failedUnknown || len(launch) > 0 {
+		r.notifyChange()
+	}
+	for _, ls := range launch {
+		go r.execute(ls.task, ls.exec, ls.ctx, ls.run)
+	}
+	return failedUnknown || len(launch) > 0, nil
 }
 
 // eligible reports whether a task may run now. Auto-requeue of a failed task is
@@ -647,21 +740,20 @@ func (r *Runner) eligible(t *Task, now time.Time) bool {
 
 // execute runs one already-claimed task (state == running on disk) through its
 // executor inside a runner-owned timeout, then records the outcome (done /
-// requeued / failed-with-backoff / dead) under ioMu. The executor's CommitGuard
-// fences its durable write against a concurrent Cancel AND against the
-// runner-owned timeout: once the executor has entered its commit, neither Cancel
-// nor the deadline cancels the context, so the single durable write is never
-// torn. This mirrors keeper compaction, whose commit (ApplyKeeperCompactResult)
-// is ctx-free and therefore timeout-immune by construction.
-func (r *Runner) execute(t *Task, exec executor) {
-	// Use WithCancel (not WithTimeout) so the deadline is enforced by a timer we
-	// can route through the commit fence: a timeout that arrives mid-commit must
-	// not cancel the context, exactly like a Cancel that arrives mid-commit.
-	ctx, cancel := context.WithCancel(context.Background())
-	guard := &CommitGuard{}
-	runDone := make(chan struct{})
+// requeued / failed-with-backoff / dead) under ioMu. The ctx, cancel, guard, and
+// activeRun are all built by dispatch at claim time and the run is already
+// registered in r.runs, so a Cancel arriving before this goroutine is scheduled
+// still finds and fences it. The executor's CommitGuard fences its durable write
+// against a concurrent Cancel AND against the runner-owned timeout: once the
+// executor has entered its commit, neither Cancel nor the deadline cancels the
+// context, so the single durable write is never torn. This mirrors keeper
+// compaction, whose commit (ApplyKeeperCompactResult) is ctx-free and therefore
+// timeout-immune by construction.
+func (r *Runner) execute(t *Task, exec executor, ctx context.Context, run *activeRun) {
+	guard := run.guard
+	cancel := run.cancel
 
-	// timeoutFired stops the deadline timer once the run has exited so it cannot
+	// timeoutStop stops the deadline timer once the run has exited so it cannot
 	// fire (and consult the guard) after teardown.
 	timeoutStop := make(chan struct{})
 	timer := time.NewTimer(exec.timeout)
@@ -671,17 +763,13 @@ func (r *Runner) execute(t *Task, exec executor) {
 		case <-timer.C:
 			// The deadline elapsed. Honor the commit fence: if the executor is
 			// already committing, do NOT cancel — let the durable write finish
-			// untorn (the worker still blocks on the executor returning).
+			// untorn (this goroutine still waits for the executor to return).
 			if guard.tryFence() {
 				cancel()
 			}
 		case <-timeoutStop:
 		}
 	}()
-
-	r.mu.Lock()
-	r.run = &activeRun{id: t.ID, cancel: cancel, guard: guard, done: runDone}
-	r.mu.Unlock()
 
 	// Attach the guard so the executor body can fence its durable write.
 	taskForExec := t.clone()
@@ -706,13 +794,17 @@ func (r *Runner) execute(t *Task, exec executor) {
 	// durable ApplyKeeperCompactResult has settled.
 	r.finish(t.ID, runErr)
 
-	// Tear down the active-run registration and signal exit. From here, a Cancel
-	// that was already blocked on run.done unblocks; a Cancel arriving after this
-	// finds r.run == nil (or a different run) and returns immediately.
+	// Deregister the run and free its per-kind slot, THEN signal exit. From here, a
+	// Cancel that was already blocked on run.done unblocks; a Cancel arriving after
+	// this finds no entry for the id and returns immediately.
 	r.mu.Lock()
-	r.run = nil
+	delete(r.runs, run.id)
+	r.inflight[run.kind]--
 	r.mu.Unlock()
-	close(runDone)
+	close(run.done)
+
+	// A freed slot may admit a queued task of a now-uncapped kind; re-dispatch.
+	r.nudge()
 }
 
 // finish records the terminal outcome of a run. It re-loads the record under ioMu
@@ -834,16 +926,25 @@ func (r *Runner) backoff(attempt int) time.Duration {
 	return d
 }
 
-// cancelActive cancels the in-flight run (if any), honoring the commit fence and
-// blocking until it exits. Used by Stop.
-func (r *Runner) cancelActive() {
+// cancelAll cancels every in-flight run (honoring each commit fence) and blocks
+// until they have all exited. Used by Stop AFTER the dispatch loop has exited, so
+// no new run can be registered while it drains. It snapshots r.runs under mu and
+// then fences+waits without holding mu: a run that finishes between the snapshot
+// and the fence closes its done channel (tryFence on a settled guard is a safe
+// no-op) so <-run.done returns immediately.
+func (r *Runner) cancelAll() {
 	r.mu.Lock()
-	run := r.run
-	if run == nil {
-		r.mu.Unlock()
-		return
+	runs := make([]*activeRun, 0, len(r.runs))
+	for _, run := range r.runs {
+		runs = append(runs, run)
 	}
-	r.fenceAndWait(run)
+	r.mu.Unlock()
+	for _, run := range runs {
+		if run.guard.tryFence() {
+			run.cancel()
+		}
+		<-run.done
+	}
 }
 
 // --- helpers ---------------------------------------------------------------

--- a/internal/tasks/store.go
+++ b/internal/tasks/store.go
@@ -16,9 +16,10 @@ import (
 // os.ReadDir filtered by State. Production now injects a SQLite-backed Store from
 // the daemon instead (docs/plans/2026-07-02-bg-task-notifications.md); this file
 // impl backs the package's own tests and the daemon's one-time JSON->SQLite import
-// of any pre-existing on-disk records. The single worker serializes all writes, so
-// no per-task lock is needed; the only durability guarantee this store owns is
-// atomic temp+rename so a crash mid-write never leaves a half-written record.
+// of any pre-existing on-disk records. The runner funnels every write through one
+// store-level lock, so no per-task lock is needed; the only durability guarantee
+// this store owns is atomic temp+rename so a crash mid-write never leaves a
+// half-written record.
 
 const (
 	machineDir = ".attn"

--- a/internal/tasks/task.go
+++ b/internal/tasks/task.go
@@ -1,19 +1,26 @@
-// Package tasks is a general, file-backed, durable task runner.
+// Package tasks is a general, durable task runner.
 //
-// It runs short, retryable units of work (compaction, summarization, narration)
-// out of a single worker goroutine, persisting one atomic-JSON file per task so a
-// daemon crash never loses a pending or in-flight task. It is intentionally
-// daemon-agnostic: it accepts a notebook root dir and a LogFunc at construction
-// and MUST NOT import internal/daemon (the daemon imports this package, so the
-// reverse would be an import cycle).
+// It runs short, retryable units of work (compaction, summarization, narration),
+// persisting each task through a pluggable Store (the daemon injects a
+// SQLite-backed one; a file-backed store backs this package's tests) so a daemon
+// crash never loses a pending or in-flight task. It is intentionally
+// daemon-agnostic: it accepts a Store (or a notebook root dir) and a LogFunc at
+// construction and MUST NOT import internal/daemon (the daemon imports this
+// package, so the reverse would be an import cycle).
+//
+// A single dispatch goroutine selects eligible tasks and launches each as its own
+// goroutine, bounded by a per-kind concurrency cap (default 1): a kind is
+// serialized with itself while different kinds run in parallel. Every record
+// read-modify-write still funnels through one store-level lock, so persistence
+// stays serialized even though executors run concurrently — which is why no
+// per-task lock is needed.
 //
 // The cancel-blocks-until-exit + commit-fence contract is ported from
 // internal/daemon/workspace_keeper.go.
 //
 // What this package is NOT: there are no priorities, no DAG, no cron generality,
-// no worker pool, no SQLite, no per-task lock file, and no heartbeat beyond the
-// runner-owned context.WithTimeout around each executor invocation. The single
-// worker serializes everything, so a per-task lock is unnecessary.
+// no unbounded worker pool, and no heartbeat beyond the runner-owned
+// context.WithTimeout around each executor invocation.
 package tasks
 
 import (


### PR DESCRIPTION
## What

PR2 of the background-task notifications initiative (plan: `docs/plans/2026-07-02-bg-task-notifications.md`). Grows the durable task runner from a single run-one-at-a-time worker into a dispatch loop with **bounded per-kind concurrency**.

Different kinds now run in parallel; a kind stays serialized with itself at the default cap of 1 (behavior-preserving for each individual kind). PR3 will register the reconcile kind with cap 2.

## How

- **`executor` gains a `limit`**; new `ExecutorConfig{Timeout, MaxConcurrent}` + `RegisterWith`. `Register`/`RegisterWithTimeout` delegate with the default cap of 1.
- **Runner state:** `run *activeRun` → `runs map[id]*activeRun` + `inflight map[kind]int`, both guarded by `mu`. A per-kind slot is reserved under `mu`, then the claim (state=running) is persisted under `ioMu`. `ioMu` stays the outer lock and no store I/O ever runs under `mu`.
- **`dispatch`** claims every eligible task whose kind has a free slot (earliest-scheduled first) and launches each as its own goroutine; the loop drains until a pass can place nothing more, then sleeps on nudge/tick. A finishing run frees its slot and re-nudges.
- **`Stop`** reordered for detached runs: close done → wait for the loop to exit → `cancelAll` (fence + join every in-flight run, honoring each commit fence).

## Invariants preserved

Commit fence, `Requeued` coalescing, capped-exponential backoff/dead, orphan recovery, single-instance lock, and Cancel-blocks-until-the-terminal-record-is-written. No protocol or frontend change.

## Tests

New: cross-kind concurrency, per-kind cap serialization, configured cap 2, and `Stop` draining multiple in-flight runs. Existing suite + new tests **race-clean at `-count=10`**; full `go build ./...`, `go vet`, and daemon task/keeper/narration tests green.

🤖 Opened by Claude on behalf of Victor.