### PR TITLE
feat(reconcile): run ticket reconciliation as a durable task kind (PR3)

### DIFF
--- a/docs/plans/2026-07-02-bg-task-notifications.md
+++ b/docs/plans/2026-07-02-bg-task-notifications.md
@@ -215,13 +215,62 @@ Isolate this in its own PR so the invariant change is reviewed alone.
       `runner.Stop()`/`cancelAll` is NOT reachable in prod (nothing calls
       `Daemon.Stop()` outside the test harness — the daemon is killed and relies on
       orphan recovery), so that path stays covered by `TestStopDrainsConcurrentInFlightRuns`.
-- [ ] **PR3 — Reconcile → `reconcile` task kind.** *Land after PR #454 merges;
+- [x] **PR3 — Reconcile → `reconcile` task kind.** *Land after PR #454 merges;
       rebase over main and build on its classifier body — do not port the old
       one.* Register the executor (body = classifier incl. drop-rule/🩺 comment);
       enqueue on session-end and from the sweep (sweep enqueues, no longer runs
-      inline); per-kind cap 2; delete the bespoke goroutine + semaphore + sweep
-      ticker and `maybeRepairAbandonedReconcileClaim` (runner orphan-recovery
-      replaces it); likely retire the `reconciled_at` column. Backend + tests.
+      inline); per-kind cap 2; delete the semaphore + the bespoke `go
+      d.runTicketReconciliation` goroutines + `maybeRepairAbandonedReconcileClaim`
+      (runner orphan-recovery replaces it). Backend + tests.
+
+      **Refinement vs the original plan (settled during implementation):**
+      - **Keep `reconciled_at`, do NOT retire it.** It is not merely an internal
+        claim flag — non-terminal + `reconciled_at` set drives the *user-visible
+        orphan badge* on the board (`app/src/utils/ticketOrphan.ts`,
+        `ticket_board.go` projection, `main.tsp`). Retiring it is a
+        protocol/frontend change, out of scope for a backend-only PR3.
+      - **`ClaimTicketReconciliation` stays the trigger gate; only the inline
+        `go` becomes an `Enqueue`.** Session-end still claims (set-if-unset), which
+        (a) lights the badge immediately, exactly as today, and (b) dedupes the
+        handlePTYExit+dropSessionRecord double-fire so the FIRST fire — the one
+        with the session row still present, hence the freshest inputs — wins and
+        the loser exits. On a winning claim it enqueues `reconcile:<ticketID>`
+        (inputs serialized into `Task.Meta`) instead of spawning a goroutine. The
+        executor runs the classifier + drop-rule + 🩺 comment; it does NOT stamp
+        `reconciled_at` (the claim already did).
+      - **The durable task record is the sweep's dedup ledger.** The sweep enqueues
+        only when `runner.Get("reconcile:<id>") == nil`. That both replaces the old
+        `reconciled_at`-gated skip AND recovers the one gap the claim-then-enqueue
+        split opens: a daemon death after the claim but before the enqueue persists
+        leaves `reconciled_at` set with no task — the sweep sees no task and
+        enqueues a real reconciliation (what the old maybeRepair pass hand-rolled a
+        generic note for). The sweep still claims (badge) before it enqueues.
+      - **maybeRepair deleted:** its "verdict never ran" role is now covered by the
+        durable task (queued/running survives restart; orphan-recovery re-runs a
+        run that died mid-flight) and by the sweep's task-existence enqueue.
+      - **Accepted micro-windows (both negligible, both strictly better than
+        today):** (1) a daemon kill in the microseconds between the executor's
+        `AddTicketComment` committing and the runner marking the task done → next
+        boot's orphan-recovery re-runs and posts one duplicate 🩺 comment (today's
+        equivalent crash produces *no* verdict at all). (2) a reassign + new-session
+        death whose seam is *also* lost to a crash won't be swept if a done
+        `reconcile:<id>` task from the prior cycle still exists — vanishingly rare,
+        and the common reassign+redeath is handled by the session-end seam
+        (coalesces onto the record with fresh inputs).
+
+      Backend + tests only — no protocol/frontend change. Deletes the bespoke
+      semaphore, the two `go d.runTicketReconciliation` goroutines, and
+      `maybeRepairAbandonedReconcileClaim`; drops the runner's notebook-root enable
+      gate (enabled whenever the store exists). `go test ./internal/{daemon,tasks,
+      store}` green; tasks race-clean. **Live-app smoke** (throwaway profile, real
+      daemon from the branch, fast sweep/grace env): inserted an orphaned
+      dead-owner ticket → the sweep discovered it after grace, claimed
+      (`reconciled_at` stamped = orphan badge), enqueued `reconcile:<id>` onto the
+      SQLite-backed runner, and the registered executor deserialized its Meta
+      inputs and posted the attn-authored 🩺 note (no-transcript path, no real
+      `claude` spawn); the task reached `done` (attempts=1, one-shot). Repeated
+      sweep passes left exactly one comment / one task / an unchanged badge — the
+      durable task record is the "already handled" ledger.
 - [ ] **PR4 — Notifications + Tasks-in-Settings (backend + frontend).** One PR:
       - *Backend:* `notifications` table (migration {62}) + store methods;
         protocol (`notification_list` / `notification_mark_read` /
@@ -274,9 +323,12 @@ last so reconcile failures (PR3) flow through the notifications it introduces.
   recovery. The **sweep stays** but for its *other* job: discovering orphaned
   tickets (a session that ended without firing the seam) and **enqueuing** a
   `reconcile:<ticketID>` task instead of running the classifier inline. Task
-  coalescing (one task per ticket) replaces the claim's dedup role; the 🩺 comment
-  is the durable "already handled" ledger — so PR3 can likely retire the
-  `reconciled_at` column too (settle during PR3).
+  the durable *task record* (not a comment scan) is the sweep's "already handled"
+  ledger — it enqueues only when no `reconcile:<ticketID>` task exists yet.
+  **Settled during PR3:** the `reconciled_at` column is **kept** (not retired) —
+  it drives the user-visible orphan badge — and `ClaimTicketReconciliation` stays
+  the trigger-time gate (badge + session-end double-fire dedup), so only the
+  inline goroutine became a durable `Enqueue`. See the PR3 refinement note above.
 - **Notification retention — unbounded for v1.** No cap/prune. Revisit only if
   growth becomes a real problem (listed under Follow-ups).
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -130,14 +130,15 @@ type Daemon struct {
 	// a capped headless classifier judges the dead transcript against the brief.
 	// ticketReconcileExec is the classifier spawn — New() wires the real claude
 	// headless run; it stays nil on test daemons so unit tests never shell out
-	// (the runner logs and skips). ticketReconcileDone is a test observation hook
-	// fired after a claim's verdict (or failure note) lands. ticketOrphanFirstSeen
-	// is the sweep's grace tracker (ticket id -> first pass that saw the owner
-	// dead); in-memory by design — a restart merely restarts the grace clock.
-	// All lazy/nil-safe under ticketReconcileMu.
+	// (the executor logs and skips). ticketReconcileDone is a test observation hook
+	// fired when a reconcile task run reaches any terminal outcome. Concurrency is
+	// no longer a bespoke semaphore here — the durable runner bounds it per-kind
+	// (reconcileKind at ticketReconcileConcurrency). ticketOrphanFirstSeen is the
+	// sweep's grace tracker (ticket id -> first pass that saw the owner dead);
+	// in-memory by design — a restart merely restarts the grace clock. All
+	// lazy/nil-safe under ticketReconcileMu.
 	ticketReconcileMu     sync.Mutex
 	ticketReconcileExec   func(ctx context.Context, in ticketReconcileInputs) (agentdriver.HeadlessTaskResult, error)
-	ticketReconcileSem    chan struct{}
 	ticketReconcileDone   func(ticketID string)
 	ticketOrphanFirstSeen map[string]time.Time
 	// reloadingSessions marks sessions whose agent is being re-spawned in place

--- a/internal/daemon/ticket_reconcile.go
+++ b/internal/daemon/ticket_reconcile.go
@@ -14,6 +14,7 @@ import (
 	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/tasks"
 )
 
 // Orphaned-ticket reconciliation (docs/plans/2026-07-01-orphaned-ticket-
@@ -44,9 +45,23 @@ const (
 	ticketReconcileFailureDetailHead = 300
 	ticketReconcileFailureDetailTail = 700
 
+	// reconcileKind is the durable-runner task kind for orphaned-ticket
+	// reconciliation. Subject is the ticket id, so TaskID("reconcile", ticketID)
+	// coalesces every trigger for one ticket onto a single record.
+	reconcileKind = "reconcile"
+
+	// reconcileInputsMetaKey stashes the JSON-encoded ticketReconcileInputs on the
+	// task record (Task.Meta). The classifier inputs are captured at ENQUEUE time
+	// because the owning session row is deleted moments after the death seam; the
+	// executor, which may run much later, reads them back from here and never
+	// re-reads the (gone) session.
+	reconcileInputsMetaKey = "reconcile_inputs"
+
 	// ticketReconcileConcurrency bounds simultaneous classifier processes: a
 	// workspace teardown can kill several delegated sessions at once, and without
-	// a cap that is N parallel sonnet runs.
+	// a cap that is N parallel sonnet runs. It is the reconcile executor's per-kind
+	// MaxConcurrent in the durable runner (which now owns the cap the bespoke
+	// semaphore used to enforce).
 	ticketReconcileConcurrency = 2
 
 	// Sweep cadence. The grace period must comfortably exceed the classifier
@@ -94,6 +109,33 @@ type ticketReconcileInputs struct {
 	Agent          string
 	TranscriptPath string
 	CloseContext   string // human framing: how the session ended, for prompt + comment
+}
+
+// reconcileInputsToMeta encodes the captured inputs into a Task.Meta map for the
+// durable record. ticketReconcileInputs is all strings, so json.Marshal cannot
+// fail; a defensive nil return degrades to "no inputs" (the executor then logs
+// and retires the task rather than panicking).
+func reconcileInputsToMeta(in ticketReconcileInputs) map[string]string {
+	data, err := json.Marshal(in)
+	if err != nil {
+		return nil
+	}
+	return map[string]string{reconcileInputsMetaKey: string(data)}
+}
+
+// reconcileInputsFromMeta decodes the inputs the enqueue stashed. A missing or
+// undecodable blob is an error the executor treats as terminal (the task cannot
+// be run, and retrying would never fix a garbled record).
+func reconcileInputsFromMeta(meta map[string]string) (ticketReconcileInputs, error) {
+	var in ticketReconcileInputs
+	raw, ok := meta[reconcileInputsMetaKey]
+	if !ok {
+		return in, fmt.Errorf("reconcile task missing %q meta", reconcileInputsMetaKey)
+	}
+	if err := json.Unmarshal([]byte(raw), &in); err != nil {
+		return in, fmt.Errorf("decode reconcile inputs: %w", err)
+	}
+	return in, nil
 }
 
 // ticketReconcileVerdict is the classifier's structured output.
@@ -175,8 +217,13 @@ func ticketReconcileGrace() time.Duration {
 // reconcileTicketsOnSessionEnd is the single ticket seam for a dying session,
 // fed the pre-clobber runtime state. Called from handlePTYExit (process death)
 // and dropSessionRecord (user close / reap / teardown backstop) — a user close
-// fires both, so everything downstream of the claim is double-fire-safe: the
-// claim is a set-if-unset and the loser exits.
+// fires both, so the claim (a set-if-unset) dedupes: the first fire claims and
+// enqueues a durable reconcile task with the freshest inputs (the session row is
+// still present), and the loser exits. The claim also lights the board's orphan
+// badge immediately (reconciled_at). Enqueue replaces the old inline goroutine so
+// a daemon restart between here and the classifier run no longer loses the work —
+// the task survives in the profile DB, and the runner's cap-2 dispatch (not a
+// bespoke semaphore) bounds concurrent classifier processes.
 func (d *Daemon) reconcileTicketsOnSessionEnd(sessionID, state string) {
 	if d.store == nil {
 		return
@@ -192,6 +239,12 @@ func (d *Daemon) reconcileTicketsOnSessionEnd(sessionID, state string) {
 	// The session row is still present at both call sites; capture what the
 	// classifier needs NOW (dropSessionRecord deletes the row right after).
 	session := d.store.Get(sessionID)
+	// The reconcile ENQUEUE needs a durable runner, but the crash stamp does not —
+	// crashTicket must run regardless so a mid-flight death is always marked. When
+	// the runner is unavailable (not expected in production, where the store is
+	// always present), the periodic sweep rediscovers the still-orphaned ticket and
+	// enqueues once the runner is up.
+	runner := d.compactRunnerRef()
 
 	for _, ticket := range tickets {
 		if ticket == nil {
@@ -206,6 +259,9 @@ func (d *Daemon) reconcileTicketsOnSessionEnd(sessionID, state string) {
 				continue
 			}
 			statusAtClaim = store.TicketStatusCrashed
+		}
+		if runner == nil || runner.Disabled() {
+			continue // crash stamp applied above; the sweep backstops the reconcile
 		}
 		claimed, err := d.store.ClaimTicketReconciliation(ticket.ID, time.Now())
 		if err != nil {
@@ -233,7 +289,12 @@ func (d *Daemon) reconcileTicketsOnSessionEnd(sessionID, state string) {
 			TranscriptPath: d.resolveReconcileTranscript(agentID, sessionID, cwd, anchor, ticket.Assignee),
 			CloseContext:   d.reconcileCloseContext(sessionID, state, ticket.Status),
 		}
-		go d.runTicketReconciliation(in)
+		if _, err := runner.Enqueue(reconcileKind, ticket.ID, tasks.EnqueueOptions{
+			ZeroDebounce: true,
+			Meta:         reconcileInputsToMeta(in),
+		}); err != nil {
+			d.logf("ticket reconcile: enqueue %s: %v", ticket.ID, err)
+		}
 	}
 }
 
@@ -293,55 +354,57 @@ func (d *Daemon) resolveReconcileTranscript(agentID, sessionID, cwd string, anch
 
 // --- the classifier run ---
 
-func (d *Daemon) ticketReconcileSemaphore() chan struct{} {
-	d.ticketReconcileMu.Lock()
-	defer d.ticketReconcileMu.Unlock()
-	if d.ticketReconcileSem == nil {
-		d.ticketReconcileSem = make(chan struct{}, ticketReconcileConcurrency)
+// reconcileTaskExecutor is the durable-runner ExecutorFunc for the reconcile
+// kind. It reads the classifier inputs captured at enqueue time (the session row
+// is long gone by run time), runs the headless classifier under the runner-owned
+// timeout ctx, and drives the reconciliation to its durable end: a verdict
+// comment, a rule-7 failure comment, or a logged drop (status moved during the
+// run — someone acted, the verdict is stale). The board's orphan badge
+// (reconciled_at) was already stamped at enqueue time by the claim.
+//
+// Return contract: nil in every case where the reconciliation reached a
+// conclusion (verdict posted, failure note posted, dropped, or inputs
+// unrecoverable) — a reconcile is one-shot, exactly as the inline version was,
+// so a classifier error becomes a posted failure note, not a runner retry. The
+// ONLY retryable error is a failure to POST the comment (a transient store
+// error): the verdict must eventually land, so the runner backs off and re-runs.
+func (d *Daemon) reconcileTaskExecutor(ctx context.Context, task *tasks.Task) error {
+	if d.ticketReconcileDone != nil {
+		// Test observation hook: fire once the run reaches any terminal outcome.
+		defer d.ticketReconcileDone(task.Subject)
 	}
-	return d.ticketReconcileSem
-}
-
-// runTicketReconciliation runs one claimed reconciliation to its durable end: a
-// verdict comment, a rule-7 failure comment, or a logged drop (status moved
-// during the run — someone acted, the verdict is stale). It runs in its own
-// goroutine and must not touch the session (dead) or block the exit path.
-func (d *Daemon) runTicketReconciliation(in ticketReconcileInputs) {
+	in, err := reconcileInputsFromMeta(task.Meta)
+	if err != nil {
+		// A record with no/garbled inputs can never be run into health; log and
+		// retire it (nil) so it doesn't hot-loop the dispatch queue.
+		d.logf("ticket reconcile %s: %v", task.Subject, err)
+		return nil
+	}
 	execFn := d.ticketReconcileExec
 	if execFn == nil {
-		// Test daemons: the claim stands (provenance) but no classifier runs and
-		// no comment lands. Production always wires the real exec in New().
+		// Test daemons without a wired classifier: the claim stands (provenance),
+		// but no classifier runs and no comment lands. Production always wires the
+		// real exec in New().
 		d.logf("ticket reconcile %s: classifier not configured; skipping", in.TicketID)
-		return
+		return nil
 	}
-	sem := d.ticketReconcileSemaphore()
-	sem <- struct{}{}
-	defer func() { <-sem }()
-	defer func() {
-		if d.ticketReconcileDone != nil {
-			d.ticketReconcileDone(in.TicketID)
-		}
-	}()
-
-	ctx, cancel := context.WithTimeout(context.Background(), ticketReconcileTimeout())
-	defer cancel()
 
 	var verdict *ticketReconcileVerdict
 	failReason := ""
 	if strings.TrimSpace(in.TranscriptPath) == "" {
 		failReason = "could not locate the dead session's transcript"
 	} else {
-		result, err := execFn(ctx, in)
+		result, runErr := execFn(ctx, in)
 		if result.TotalCostUSD > 0 || result.NumTurns > 0 {
 			d.logf("ticket reconcile %s: classifier spent $%.4f over %d turns", in.TicketID, result.TotalCostUSD, result.NumTurns)
 		}
 		switch {
-		case err != nil:
+		case runErr != nil:
 			// The comment carries the raw cause, not just the keyword bucket:
 			// err summarizes (bucket + exit status), FailureOutput is the child's
 			// actual output tail — without it a failure is undiagnosable (the
 			// 2026-07-02 first fire surfaced only "keeper tools failed").
-			failReason = "classifier run failed: " + err.Error()
+			failReason = "classifier run failed: " + runErr.Error()
 			if raw := strings.TrimSpace(result.FailureOutput); raw != "" {
 				failReason += "\nClassifier output:\n" + truncateMiddleString(raw,
 					ticketReconcileFailureDetailHead, ticketReconcileFailureDetailTail)
@@ -369,23 +432,25 @@ func (d *Daemon) runTicketReconciliation(in ticketReconcileInputs) {
 	ticket, err := d.store.GetTicket(in.TicketID)
 	if err != nil || ticket == nil {
 		d.logf("ticket reconcile %s: ticket gone before verdict landed", in.TicketID)
-		return
+		return nil
 	}
 	if ticket.Status != in.StatusAtClaim {
 		d.logf("ticket reconcile %s: dropped verdict — status moved %s -> %s during classification",
 			in.TicketID, in.StatusAtClaim, ticket.Status)
-		return
+		return nil
 	}
 
 	comment := renderTicketReconcileComment(in, verdict, failReason)
 	if _, err := d.store.AddTicketComment(in.TicketID, store.TicketAuthorAttn, comment, time.Now()); err != nil {
-		d.logf("ticket reconcile %s: post verdict comment: %v", in.TicketID, err)
-		return
+		// The only retryable path: the verdict must land, so ask the runner to back
+		// off and re-run rather than silently dropping the reconciliation.
+		return fmt.Errorf("post reconcile verdict comment: %w", err)
 	}
 	// The comment notifies participants (the chief is one via the created event);
 	// attn itself is an authoring identity, never an observer.
 	d.notifyTicketObservers(in.TicketID)
 	d.broadcastTicketsUpdated()
+	return nil
 }
 
 // truncateMiddleString keeps the first head and last tail bytes of s, marking
@@ -488,10 +553,11 @@ Report via structured output:
 
 // runTicketReconcileSweep is the periodic backstop for what the session-end
 // seam structurally cannot cover: tickets orphaned before the feature shipped,
-// a daemon death mid-seam (row removed, flag unclaimed), and claims whose
-// verdict never landed (daemon death mid-run). No initial pass at boot —
-// startup recovery's reap routes dead-worker sessions through the seam itself;
-// the first tick lands after that churn settles.
+// and a daemon death mid-seam (the session-end claim landed but the enqueue did
+// not, so no reconcile task exists). No initial pass at boot — startup recovery's
+// reap routes dead-worker sessions through the seam itself; the first tick lands
+// after that churn settles. A daemon death mid-RUN no longer needs the sweep: the
+// durable task survives and the runner's orphan-recovery re-runs it.
 func (d *Daemon) runTicketReconcileSweep() {
 	ticker := time.NewTicker(ticketReconcileSweepInterval())
 	defer ticker.Stop()
@@ -509,6 +575,10 @@ func (d *Daemon) ticketReconcileSweepPass(now time.Time) {
 	if d.store == nil {
 		return
 	}
+	runner := d.compactRunnerRef()
+	if runner == nil || runner.Disabled() {
+		return // no durable runner to enqueue onto; nothing the sweep can do
+	}
 	tickets, err := d.store.ListTickets(store.TicketListFilter{})
 	if err != nil {
 		d.logf("ticket reconcile sweep: list tickets: %v", err)
@@ -524,10 +594,6 @@ func (d *Daemon) ticketReconcileSweepPass(now time.Time) {
 		if assignee == "" || assignee == store.TicketAuthorYou {
 			continue
 		}
-		if ticket.ReconciledAt != nil {
-			d.maybeRepairAbandonedReconcileClaim(ticket, now)
-			continue
-		}
 		if ticket.Status.IsTerminal() {
 			d.clearOrphanFirstSeen(ticket.ID)
 			continue
@@ -536,23 +602,34 @@ func (d *Daemon) ticketReconcileSweepPass(now time.Time) {
 			d.clearOrphanFirstSeen(ticket.ID)
 			continue
 		}
+		// The durable task record is the "already triggered" ledger: if one exists
+		// for this ticket (in any state), the session-end seam or a prior sweep
+		// already enqueued it and the runner owns it from here — including
+		// re-running one whose daemon died mid-flight. Only a ticket with NO task is
+		// a genuine sweep discovery (pre-feature orphan, or a seam whose claim
+		// landed but whose enqueue was lost to a crash — the abandoned-claim case
+		// the old maybeRepair pass covered, now recovered by enqueuing for real).
+		if existing, err := runner.Get(tasks.TaskID(reconcileKind, ticket.ID)); err != nil {
+			d.logf("ticket reconcile sweep: lookup task for %s: %v", ticket.ID, err)
+			continue
+		} else if existing != nil {
+			d.clearOrphanFirstSeen(ticket.ID)
+			continue
+		}
 		firstSeen := d.orphanFirstSeen(ticket.ID, now)
 		if now.Sub(firstSeen) < ticketReconcileGrace() {
 			continue
 		}
 		if claims >= ticketReconcileSweepClaimCap {
-			continue // next pass picks it up; repair checks above still ran
-		}
-		claimed, err := d.store.ClaimTicketReconciliation(ticket.ID, now)
-		if err != nil {
-			d.logf("ticket reconcile sweep: claim %s: %v", ticket.ID, err)
-			continue
-		}
-		if !claimed {
-			continue
+			continue // next pass picks it up
 		}
 		claims++
 		d.clearOrphanFirstSeen(ticket.ID)
+		// Light the board's orphan badge now (set-if-unset; a no-op if an abandoned
+		// session-end claim already set it), then enqueue the durable task.
+		if _, err := d.store.ClaimTicketReconciliation(ticket.ID, now); err != nil {
+			d.logf("ticket reconcile sweep: claim %s: %v", ticket.ID, err)
+		}
 
 		// The session row may still exist (exited-in-place) or be long gone; use
 		// the freshest source available for each input.
@@ -574,7 +651,12 @@ func (d *Daemon) ticketReconcileSweepPass(now time.Time) {
 			CloseContext: fmt.Sprintf(
 				"found orphaned by the periodic sweep (owning session dead) while the ticket was %s", ticket.Status),
 		}
-		go d.runTicketReconciliation(in)
+		if _, err := runner.Enqueue(reconcileKind, ticket.ID, tasks.EnqueueOptions{
+			ZeroDebounce: true,
+			Meta:         reconcileInputsToMeta(in),
+		}); err != nil {
+			d.logf("ticket reconcile sweep: enqueue %s: %v", ticket.ID, err)
+		}
 	}
 }
 
@@ -630,45 +712,4 @@ func (d *Daemon) clearOrphanFirstSeen(ticketID string) {
 	d.ticketReconcileMu.Lock()
 	defer d.ticketReconcileMu.Unlock()
 	delete(d.ticketOrphanFirstSeen, ticketID)
-}
-
-// maybeRepairAbandonedReconcileClaim closes the claim/comment atomicity gap:
-// the claim and the verdict comment are separate writes, so a daemon death
-// between them leaves a claimed ticket with no verdict — which would otherwise
-// vanish silently, violating rule 7 (reconciliation failure must surface).
-// Repair posts the failure note when a claim is old, no reconciliation comment
-// ever landed, and NOTHING else happened since the claim (any later activity
-// means someone acted — a deliberate verdict drop, a reassign, a human move —
-// and a late failure note would be noise).
-func (d *Daemon) maybeRepairAbandonedReconcileClaim(ticket *store.Ticket, now time.Time) {
-	if ticket.ReconciledAt == nil || now.Sub(*ticket.ReconciledAt) < ticketReconcileGrace() {
-		return
-	}
-	// A settled ticket (done/failed by someone's hand) needs no failure note;
-	// crashed is attn's own stamp, so its abandoned claims still deserve repair.
-	if ticket.Status.IsTerminal() && ticket.Status != store.TicketStatusCrashed {
-		return
-	}
-	full, err := d.store.GetTicket(ticket.ID)
-	if err != nil || full == nil {
-		return
-	}
-	for _, a := range full.Activity {
-		if a.Kind == store.TicketActivityComment && a.Author == store.TicketAuthorAttn &&
-			strings.HasPrefix(a.Comment, ticketReconcileCommentPrefix) {
-			return // a verdict (or failure note) landed; nothing to repair
-		}
-		if a.CreatedAt.After(*full.ReconciledAt) {
-			return // post-claim activity: someone acted, a late note is noise
-		}
-	}
-	comment := fmt.Sprintf("%s could not determine the outcome — needs a human look.\nReason: the reconciliation run was interrupted before a verdict landed (daemon restart?).",
-		ticketReconcileCommentPrefix)
-	if _, err := d.store.AddTicketComment(ticket.ID, store.TicketAuthorAttn, comment, now); err != nil {
-		d.logf("ticket reconcile repair %s: %v", ticket.ID, err)
-		return
-	}
-	d.logf("ticket reconcile repair %s: posted failure note for an abandoned claim", ticket.ID)
-	d.notifyTicketObservers(ticket.ID)
-	d.broadcastTicketsUpdated()
 }

--- a/internal/daemon/ticket_reconcile_test.go
+++ b/internal/daemon/ticket_reconcile_test.go
@@ -12,7 +12,44 @@ import (
 	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/tasks"
 )
+
+// installReconcileRunner builds and starts a durable runner with only the
+// reconcile executor registered, then publishes it on the daemon — so the
+// session-end seam and the sweep have a live runner to Enqueue onto. A tiny poll
+// interval avoids real-time waits. Callers arm the classifier + done hook (see
+// armReconcileObserver) before triggering.
+func installReconcileRunner(t *testing.T, d *Daemon) {
+	t.Helper()
+	runner := tasks.New(tasks.Options{
+		Root:         filepath.Join(t.TempDir(), "tasks"),
+		Log:          func(string, ...interface{}) {},
+		PollInterval: 2 * time.Millisecond,
+	})
+	if err := runner.RegisterWith(reconcileKind, d.reconcileTaskExecutor, tasks.ExecutorConfig{
+		Timeout:       ticketReconcileTimeout(),
+		MaxConcurrent: ticketReconcileConcurrency,
+	}); err != nil {
+		t.Fatalf("register reconcile: %v", err)
+	}
+	if err := runner.Start(); err != nil {
+		t.Fatalf("start runner: %v", err)
+	}
+	t.Cleanup(runner.Stop)
+	d.compactRunner = runner
+}
+
+// reconcileTask wraps captured inputs into the durable record the executor reads,
+// so a test can drive reconcileTaskExecutor directly without a running runner.
+func reconcileTask(in ticketReconcileInputs) *tasks.Task {
+	return &tasks.Task{
+		ID:      tasks.TaskID(reconcileKind, in.TicketID),
+		Kind:    reconcileKind,
+		Subject: in.TicketID,
+		Meta:    reconcileInputsToMeta(in),
+	}
+}
 
 // reconcileComments returns the attn-authored reconciliation comments (verdict
 // or failure notes) on a ticket, oldest first.
@@ -73,6 +110,7 @@ func TestReconcileSeamNeutralEndPostsFailureNote(t *testing.T) {
 	sessionID := delegateBoundSession(t, d)
 	ticketID := boundTicketID(t, d, sessionID)
 	done, calls := armReconcileObserver(d, agentdriver.HeadlessTaskResult{}, nil)
+	installReconcileRunner(t, d)
 
 	d.reconcileTicketsOnSessionEnd(sessionID, protocol.StateIdle)
 	waitReconcileDone(t, done)
@@ -106,6 +144,7 @@ func TestReconcileSeamMidFlightStampsCrashedAndClaims(t *testing.T) {
 	sessionID := delegateBoundSession(t, d)
 	ticketID := boundTicketID(t, d, sessionID)
 	done, _ := armReconcileObserver(d, agentdriver.HeadlessTaskResult{}, nil)
+	installReconcileRunner(t, d)
 
 	d.reconcileTicketsOnSessionEnd(sessionID, protocol.StateWorking)
 	waitReconcileDone(t, done)
@@ -132,9 +171,12 @@ func TestReconcileSeamDoubleFireSingleClaim(t *testing.T) {
 	sessionID := delegateBoundSession(t, d)
 	ticketID := boundTicketID(t, d, sessionID)
 	done, _ := armReconcileObserver(d, agentdriver.HeadlessTaskResult{}, nil)
+	installReconcileRunner(t, d)
 
 	d.reconcileTicketsOnSessionEnd(sessionID, protocol.StateIdle)
 	waitReconcileDone(t, done)
+	// The second fire's claim fails (set-if-unset), so it never enqueues a second
+	// task — exactly one verdict lands.
 	d.reconcileTicketsOnSessionEnd(sessionID, protocol.StateIdle)
 
 	if comments := reconcileComments(t, d, ticketID); len(comments) != 1 {
@@ -153,9 +195,6 @@ func TestRunTicketReconciliationPostsVerdict(t *testing.T) {
 	if err := os.WriteFile(transcript, []byte("{}\n"), 0o600); err != nil {
 		t.Fatalf("write transcript: %v", err)
 	}
-	if claimed, err := d.store.ClaimTicketReconciliation(ticketID, time.Now()); err != nil || !claimed {
-		t.Fatalf("claim: %v, %v", claimed, err)
-	}
 	var seen ticketReconcileInputs
 	d.ticketReconcileExec = func(ctx context.Context, in ticketReconcileInputs) (agentdriver.HeadlessTaskResult, error) {
 		seen = in
@@ -166,7 +205,7 @@ func TestRunTicketReconciliationPostsVerdict(t *testing.T) {
 		}, nil
 	}
 
-	d.runTicketReconciliation(ticketReconcileInputs{
+	if err := d.reconcileTaskExecutor(context.Background(), reconcileTask(ticketReconcileInputs{
 		TicketID:       ticketID,
 		Title:          "Migrate the store to X",
 		Brief:          "Move the store onto the new backend.",
@@ -175,7 +214,9 @@ func TestRunTicketReconciliationPostsVerdict(t *testing.T) {
 		Agent:          "codex",
 		TranscriptPath: transcript,
 		CloseContext:   "the session was closed (user close or teardown) while the ticket was working",
-	})
+	})); err != nil {
+		t.Fatalf("reconcileTaskExecutor: %v", err)
+	}
 
 	comments := reconcileComments(t, d, ticketID)
 	if len(comments) != 1 {
@@ -220,13 +261,15 @@ func TestRunTicketReconciliationDropsVerdictWhenStatusMoved(t *testing.T) {
 		}, nil
 	}
 
-	d.runTicketReconciliation(ticketReconcileInputs{
+	if err := d.reconcileTaskExecutor(context.Background(), reconcileTask(ticketReconcileInputs{
 		TicketID:       ticketID,
 		StatusAtClaim:  store.TicketStatusWorking,
 		SessionID:      sessionID,
 		Agent:          "codex",
 		TranscriptPath: transcript,
-	})
+	})); err != nil {
+		t.Fatalf("reconcileTaskExecutor: %v", err)
+	}
 
 	if comments := reconcileComments(t, d, ticketID); len(comments) != 0 {
 		t.Fatalf("reconcile comments = %d, want 0 (verdict dropped after status move)", len(comments))
@@ -254,13 +297,15 @@ func TestRunTicketReconciliationExecErrorPostsFailureNote(t *testing.T) {
 		}, errors.New("headless agent MCP tool server failed: exit status 1")
 	}
 
-	d.runTicketReconciliation(ticketReconcileInputs{
+	if err := d.reconcileTaskExecutor(context.Background(), reconcileTask(ticketReconcileInputs{
 		TicketID:       ticketID,
 		StatusAtClaim:  store.TicketStatusWorking,
 		SessionID:      sessionID,
 		Agent:          "claude",
 		TranscriptPath: transcript,
-	})
+	})); err != nil {
+		t.Fatalf("reconcileTaskExecutor: %v", err)
+	}
 
 	comments := reconcileComments(t, d, ticketID)
 	if len(comments) != 1 {
@@ -285,11 +330,12 @@ func TestRunTicketReconciliationExecErrorPostsFailureNote(t *testing.T) {
 	}
 }
 
-// The sweep claims a dead-owner ticket only after the grace period, then runs
-// the same reconciliation path.
+// The sweep claims a dead-owner ticket only after the grace period, then enqueues
+// the durable reconcile task, which runs the same reconciliation path.
 func TestSweepClaimsDeadOwnerAfterGrace(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	done, _ := armReconcileObserver(d, agentdriver.HeadlessTaskResult{}, nil)
+	installReconcileRunner(t, d)
 	// No session row for the assignee: the owner is dead (rows are deleted on close).
 	if _, err := d.store.CreateTicket(store.Ticket{
 		ID: "orphaned", Title: "t", Assignee: "sess-dead", Status: store.TicketStatusInReview,
@@ -321,6 +367,7 @@ func TestSweepClaimsDeadOwnerAfterGrace(t *testing.T) {
 func TestSweepSkipsLiveHumanAndUnassigned(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	armReconcileObserver(d, agentdriver.HeadlessTaskResult{}, nil)
+	installReconcileRunner(t, d)
 
 	// A session row without a backend runtime reads as live (CLI/remote sessions
 	// have no daemon PTY; their death-hook is the unregister path).
@@ -345,54 +392,67 @@ func TestSweepSkipsLiveHumanAndUnassigned(t *testing.T) {
 	}
 }
 
-// A claim whose verdict never landed (daemon died mid-run) is repaired with the
-// rule-7 failure note — but only when nothing else happened since the claim.
-func TestSweepRepairsAbandonedClaim(t *testing.T) {
+// An abandoned session-end claim — reconciled_at stamped but the daemon died
+// before the durable task was enqueued — is recovered by the sweep. With no
+// reconcile task on record, the sweep re-enqueues after grace and the executor
+// posts a REAL verdict/failure note. This replaces the old bespoke
+// maybeRepairAbandonedReconcileClaim pass (and its generic "interrupted before a
+// verdict landed" note) with a genuine reconciliation run.
+func TestSweepRecoversAbandonedClaim(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	armReconcileObserver(d, agentdriver.HeadlessTaskResult{}, nil)
+	done, _ := armReconcileObserver(d, agentdriver.HeadlessTaskResult{}, nil)
+	installReconcileRunner(t, d)
 	past := time.Now().Add(-time.Hour)
 	if _, err := d.store.CreateTicket(store.Ticket{
 		ID: "abandoned", Title: "t", Assignee: "sess-dead", Status: store.TicketStatusWorking,
 	}, "chief", past); err != nil {
 		t.Fatalf("CreateTicket: %v", err)
 	}
+	// The crash gap: the seam claimed (badge stamped) but the enqueue never landed,
+	// so no reconcile task exists.
 	if claimed, err := d.store.ClaimTicketReconciliation("abandoned", past); err != nil || !claimed {
 		t.Fatalf("claim: %v, %v", claimed, err)
 	}
 
-	d.ticketReconcileSweepPass(time.Now())
-
-	comments := reconcileComments(t, d, "abandoned")
-	if len(comments) != 1 || !strings.Contains(comments[0], "interrupted before a verdict landed") {
-		t.Fatalf("repair comments = %v, want one interrupted-note", comments)
+	t0 := time.Now()
+	d.ticketReconcileSweepPass(t0) // first sight: grace not elapsed, no enqueue yet
+	if comments := reconcileComments(t, d, "abandoned"); len(comments) != 0 {
+		t.Fatalf("reconciled before grace elapsed: %v", comments)
 	}
-	// Idempotent: the marker comment suppresses a second repair.
-	d.ticketReconcileSweepPass(time.Now())
-	if comments := reconcileComments(t, d, "abandoned"); len(comments) != 1 {
-		t.Fatalf("repair comments after second pass = %d, want 1", len(comments))
+	d.ticketReconcileSweepPass(t0.Add(ticketReconcileGrace() + time.Minute))
+	waitReconcileDone(t, done)
+
+	// A real reconciliation ran (no transcript resolvable ⇒ the rule-7 failure
+	// note), not the old generic interrupted-claim string.
+	comments := reconcileComments(t, d, "abandoned")
+	if len(comments) != 1 || !strings.Contains(comments[0], "could not locate") {
+		t.Fatalf("recovered comments = %v, want one could-not-locate failure note", comments)
 	}
 }
 
-// Post-claim activity (someone acted: a deliberate verdict drop, a human move)
-// suppresses the repair note — a late failure note would be noise.
-func TestSweepRepairSkipsWhenActedUpon(t *testing.T) {
+// Once a reconcile task exists for a ticket (the seam or a prior sweep enqueued
+// it), the sweep leaves it to the runner and never enqueues a duplicate — the
+// durable task record is the "already triggered" ledger.
+func TestSweepSkipsTicketWithExistingTask(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	past := time.Now().Add(-time.Hour)
+	installReconcileRunner(t, d)
+	now := time.Now()
 	if _, err := d.store.CreateTicket(store.Ticket{
-		ID: "acted", Title: "t", Assignee: "sess-dead", Status: store.TicketStatusWorking,
-	}, "chief", past); err != nil {
+		ID: "already", Title: "t", Assignee: "sess-dead", Status: store.TicketStatusWorking,
+	}, "chief", now.Add(-time.Hour)); err != nil {
 		t.Fatalf("CreateTicket: %v", err)
 	}
-	if claimed, err := d.store.ClaimTicketReconciliation("acted", past); err != nil || !claimed {
-		t.Fatalf("claim: %v, %v", claimed, err)
-	}
-	if _, err := d.store.AddTicketComment("acted", "chief", "taking a look", time.Now().Add(-30*time.Minute)); err != nil {
-		t.Fatalf("AddTicketComment: %v", err)
+	// A terminal reconcile task already on record stands in for "already handled".
+	runner := d.compactRunnerRef()
+	if _, err := runner.Enqueue(reconcileKind, "already", tasks.EnqueueOptions{
+		Meta: reconcileInputsToMeta(ticketReconcileInputs{TicketID: "already"}),
+	}); err != nil {
+		t.Fatalf("seed reconcile task: %v", err)
 	}
 
-	d.ticketReconcileSweepPass(time.Now())
-
-	if comments := reconcileComments(t, d, "acted"); len(comments) != 0 {
-		t.Fatalf("repair comments = %v, want none (post-claim activity)", comments)
+	// Even well past grace, the sweep must not re-claim: a task exists.
+	d.ticketReconcileSweepPass(now.Add(ticketReconcileGrace() + time.Hour))
+	if got := reconciledAt(t, d, "already"); got != nil {
+		t.Fatalf("sweep re-claimed a ticket with an existing task (%v)", got)
 	}
 }

--- a/internal/daemon/workspace_keeper.go
+++ b/internal/daemon/workspace_keeper.go
@@ -212,13 +212,15 @@ func (d *Daemon) startCompactRunner() {
 	if root != "" {
 		d.migrateLegacyTasksToSQLite(root)
 	}
-	// Tasks now persist in the profile SQLite DB via the injected store, not under
-	// the notebook root. PR1 keeps the runner's enable gate keyed on the notebook
-	// root to preserve today's behavior (no root ⇒ disabled ⇒ inline compaction
-	// fallback); a later slice drops that gate once reconcile — which needs no
-	// notebook — becomes a task kind (docs/plans/2026-07-02-bg-task-notifications.md).
+	// Tasks persist in the profile SQLite DB via the injected store, NOT under the
+	// notebook root — so the runner's enable gate is keyed only on the store now,
+	// not on a resolvable notebook root. That gate-drop is what lets the reconcile
+	// kind (which must run for any dead session, notebook or not) become an
+	// ordinary task (docs/plans/2026-07-02-bg-task-notifications.md). The
+	// notebook-scoped executors (compact_context, summarize_session,
+	// narrate_workspace) keep their own no-op-when-no-notebook guards.
 	opts := tasks.Options{Log: d.logf}
-	if root != "" && d.store != nil {
+	if d.store != nil {
 		opts.Store = d.newSQLTaskStore()
 	}
 	// Build and register on a LOCAL pointer, then publish it once under the write
@@ -250,6 +252,21 @@ func (d *Daemon) startCompactRunner() {
 			notebookNarrateWorkspaceTimeout,
 		); err != nil {
 			d.logf("notebook narration: register narrate_workspace: %v", err)
+		}
+		// Orphaned-ticket reconciliation joins the same durable runner as a task
+		// kind. It runs regardless of notebook config and is the one kind that wants
+		// real concurrency: a workspace teardown can kill several delegated sessions
+		// at once, so cap it at ticketReconcileConcurrency classifier subprocesses
+		// (the per-kind bound the runner now owns, replacing the old semaphore).
+		if err := runner.RegisterWith(
+			reconcileKind,
+			d.reconcileTaskExecutor,
+			tasks.ExecutorConfig{
+				Timeout:       ticketReconcileTimeout(),
+				MaxConcurrent: ticketReconcileConcurrency,
+			},
+		); err != nil {
+			d.logf("ticket reconcile: register reconcile: %v", err)
 		}
 	}
 	// Surface lifecycle transitions to any open task panel. OnChange may fire


### PR DESCRIPTION
## What

PR3 of the background-task errors initiative (`docs/plans/2026-07-02-bg-task-notifications.md`). Folds the orphaned-ticket **reconcile classifier** onto the durable task runner as a `reconcile` task kind, so there is one task substrate and one crash-recovery story. Backend + tests only — **no protocol/frontend change**.

Builds on PR1 (tasks → SQLite, #455) and PR2 (bounded per-kind concurrency, #456).

## The change

- **New `reconcileTaskExecutor`** (per-kind cap 2): reads the classifier inputs captured at enqueue time from `Task.Meta` (the owning session row is deleted moments after the death seam, so the async run can never re-read it), runs the headless classifier under the runner-owned timeout, applies the drop rule, and posts the 🩺 verdict/failure comment. One-shot — a classifier error is a posted failure note, not a runner retry; the only retryable path is a failed comment-post.
- **Session-end seam + periodic sweep now `Enqueue`** instead of spawning a goroutine. `ClaimTicketReconciliation` stays the trigger-time gate: it lights the board's orphan badge immediately and dedupes the `handlePTYExit`+`dropSessionRecord` double-fire (the fresher-inputs fire wins). The **sweep dedupes on the durable task record** (enqueue only when no `reconcile:<id>` task exists), which also recovers a claim whose enqueue was lost to a crash.
- **Deletes** the `ticketReconcileSem` semaphore (the runner owns per-kind concurrency) and `maybeRepairAbandonedReconcileClaim` (runner orphan-recovery re-runs a mid-flight death; the sweep re-enqueues an abandoned claim — and posts a *real* verdict instead of the old generic "interrupted" note).
- **Drops the runner's notebook-root enable gate**: the runner is enabled whenever the store exists, so reconcile runs regardless of notebook config. The notebook-scoped executors (compact/summarize/narrate) keep their own no-op-when-no-notebook guards.

## Decision: `reconciled_at` is kept, not retired

The plan speculated PR3 could retire the `reconciled_at` column. It can't cheaply: non-terminal + `reconciled_at` set drives the **user-visible orphan badge** on the board (`ticketOrphan.ts`, `ticket_board.go`, `main.tsp`). Retiring it is a protocol/frontend change, out of scope here. So the column stays; the *durable task record* (not the column) becomes the dedup + crash-recovery mechanism. See the PR3 refinement note in the plan for the full reasoning and the two accepted micro-windows.

## Testing

- `go test ./internal/{daemon,tasks,store}` green; `tasks` race-clean. Reconcile/sweep/crash suites updated (seam + sweep tests now drive a real started runner; the two maybeRepair tests are replaced by task-based recovery + task-existence-dedup tests).
- **Live-app smoke** (throwaway profile, real daemon built from the branch, fast sweep/grace env): inserted an orphaned dead-owner ticket → the sweep discovered it after grace, claimed (`reconciled_at` stamped = badge), enqueued `reconcile:<id>` onto the SQLite-backed runner, and the registered executor deserialized its Meta inputs and posted the attn-authored 🩺 note (no-transcript path, no real `claude` spawn); task reached `done` (attempts=1, one-shot). Repeated sweep passes left exactly one comment / one task / an unchanged badge — the task record is the "already handled" ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)