### PR TITLE
fix: use persisted chief role for spawn settings on reconnect

### DIFF
--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -544,14 +544,18 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		Model:                   strings.TrimSpace(protocol.Deref(msg.Model)),
 		Effort:                  strings.TrimSpace(protocol.Deref(msg.Effort)),
 	}
+	// The frontend sets chief_of_staff only on initial creation, not on
+	// reconnect/resume spawns after a daemon restart. Fall back to the
+	// persisted profile-roles table so chief settings survive respawns.
+	isChief := protocol.Deref(msg.ChiefOfStaff) || d.isChiefOfStaffSession(msg.ID)
 	if spawnOpts.Model == "" {
 		// No per-spawn pin (delegation); a chief launch falls back to the
 		// chief_model_<agent> setting.
-		spawnOpts.Model = d.chiefLaunchModel(agent, protocol.Deref(msg.ChiefOfStaff))
+		spawnOpts.Model = d.chiefLaunchModel(agent, isChief)
 	}
 	// A chief launch caps its context window (chief_context_window_cap); non-chief
 	// launches stay uncapped so delegated interactive agents are never affected.
-	spawnOpts.ChiefContextWindowCap = d.chiefContextWindowCap(protocol.Deref(msg.ChiefOfStaff))
+	spawnOpts.ChiefContextWindowCap = d.chiefContextWindowCap(isChief)
 	if existingSession != nil {
 		for _, liveID := range d.ptyBackend.SessionIDs(context.Background()) {
 			if liveID != msg.ID {


### PR DESCRIPTION
## Intent

Fixes the chief-of-staff context-window cap (`ATTN_CHIEF_AUTO_COMPACT_WINDOW`) and model override (`chief_model_claude`) being silently dropped on reconnect/resume spawns after a daemon restart.

Tracked in attn ticket `compact-window`.

## Summary

- The frontend-initiated spawn path in `ws_pty.go` read `chief_of_staff` from the WebSocket message, but the frontend only sets that field during initial session creation — not on reconnect/resume spawns. A reconnected chief session was spawned as a plain session with no cap and no model override.
- The reload path (`reload.go`) already handled this correctly by checking the persisted profile-roles table via `isChiefOfStaffSession()`.
- This PR makes the frontend spawn path fall back to the same store lookup: `isChief := protocol.Deref(msg.ChiefOfStaff) || d.isChiefOfStaffSession(msg.ID)`, then uses `isChief` for both the model and context-window cap.

## Test plan

- [x] `go build ./...` — compiles
- [x] `go test ./internal/daemon/` — passes
- [x] Live-app (dev profile): after daemon restart, spawned a chief claude session via WebSocket **without** `chief_of_staff` in the message — worker env confirmed `ATTN_CHIEF_AUTO_COMPACT_WINDOW=100000` (matching `chief_context_window_cap` setting)
- [x] Live-app (dev profile): chief model override confirmed — worker env shows `ATTN_MODEL=sonnet` (matching `chief_model_claude=sonnet` setting)