### PR TITLE
fix(reconcile): judge dead sessions from a deterministic transcript slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Notifications when background work fails.** attn now has a notifications feed — the bell in the sidebar, with an unread count — that tells you when a background task gives up after exhausting its retries (context compaction, session summaries, workspace narration, or ticket reconciliation). Open a notification to read what was running and the underlying error, and retry it right there. Notifications persist across restarts and are marked read as you view them (with a "Mark all read").
 - **Background tasks moved to Settings.** The durable task runner's list — every queued, running, failed, or dead background task with its attempt count, next attempt, last error, and a Retry — now lives in its own **Settings → Background Tasks** section. It used to hang off the Notebook's sidebar, but these tasks are a global concern, not a notebook one, so the Notebook's Tasks section is gone.
 
+### Fixed
+- **Orphaned-ticket reconciliation no longer fails on large transcripts.** The background classifier that judges a dead session's work now builds its verdict from a small, deterministically extracted slice of the conversation (the original request, any re-scoping, and the agent's last status turns) inlined into a single cheap model call, instead of agentically reading the whole transcript file. A multi-megabyte transcript used to blow the run's budget cap and post a misleading failure note; now it costs the same as any other.
+
 ## [2026-07-02]
 
 ### Added

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -336,9 +336,15 @@ func buildClaudeHeadlessArgs(request HeadlessTaskRequest) ([]string, error) {
 // the agent gets its own file tools and writes into cmd.Dir (the scratch
 // WorkDir). Only the allow-list and permission mode let it read/write its cwd
 // unprompted.
+//
+// DisableTools is the one exception: it skips the claudeNativeDefaultTools
+// fallback entirely and emits an empty --allowedTools, so the run gets no
+// tools at all (a pure single-shot completion). Without this special case, an
+// empty AllowedTools alone would silently re-enable the native defaults —
+// exactly the trap DisableTools exists to avoid.
 func claudeHeadlessArgs(request HeadlessTaskRequest) []string {
 	tools := request.AllowedTools
-	if len(tools) == 0 {
+	if len(tools) == 0 && !request.DisableTools {
 		tools = claudeNativeDefaultTools
 	}
 	args := []string{"--print"}

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -386,6 +386,15 @@ type HeadlessTaskRequest struct {
 	// (the keeper/notebook tasks), which wires no MCP server.
 	AllowedTools []string
 
+	// DisableTools, when true, runs the native-tools headless path with NO
+	// tools at all — a pure single-shot completion. This overrides
+	// AllowedTools entirely: an empty AllowedTools alone still falls back to
+	// the provider's native default tool set, so DisableTools is the explicit
+	// way to get a truly tool-less run. Empty/false is byte-for-byte identical
+	// to today's behavior. Used by the ticket reconciliation classifier, which
+	// judges a pre-extracted transcript slice with no need to touch disk.
+	DisableTools bool
+
 	// ExtraWritableRoots optionally widens the set of directories the agent may
 	// WRITE to, beyond the scratch WorkDir. The notebook narration tasks use this
 	// so a headless agent can write the curated journal / raw tier under the

--- a/internal/daemon/ticket_reconcile.go
+++ b/internal/daemon/ticket_reconcile.go
@@ -15,16 +15,19 @@ import (
 	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/store"
 	"github.com/victorarias/attn/internal/tasks"
+	"github.com/victorarias/attn/internal/transcript"
 )
 
 // Orphaned-ticket reconciliation (docs/plans/2026-07-01-orphaned-ticket-
 // reconciliation.md). Invariant: no non-terminal ticket without a live owning
 // session. When an owning session ends, this seam judges every bound
 // non-terminal ticket: mid-flight deaths keep the Crashed stamp
-// (ticket_crash.go), and — for all deaths — a capped headless `claude -p`
-// classifier reads the dead session's transcript against the ticket's brief and
-// posts a structured verdict as an attn-authored comment. The classifier never
-// moves the column; the chief and the board badge present, Victor decides.
+// (ticket_crash.go), and — for all deaths — the dead session's transcript is
+// deterministically pre-sliced (internal/transcript) and inlined into a single
+// tool-less, capped headless `claude -p` completion that judges it against the
+// ticket's brief and posts a structured verdict as an attn-authored comment.
+// The classifier never moves the column; the chief and the board badge
+// present, Victor decides.
 
 const (
 	// ticketReconcileCommentPrefix marks every reconciliation comment (verdict or
@@ -32,9 +35,16 @@ const (
 	// whose verdict never landed.
 	ticketReconcileCommentPrefix = "🩺 Reconciliation"
 
-	defaultTicketReconcileModel        = "sonnet"
-	defaultTicketReconcileMaxTurns     = 15
-	defaultTicketReconcileMaxBudgetUSD = "0.50"
+	defaultTicketReconcileModel = "haiku"
+	// The transcript is now deterministically pre-sliced and inlined, so the
+	// classifier is a single tool-less completion — it cannot loop on tools and
+	// cannot balloon on transcript size. These caps are a pure runaway backstop
+	// with real headroom, NOT the primary control: an observed haiku run costs
+	// ~$0.07 over ~2 model turns, so 4 turns / $0.20 leaves comfortable margin
+	// while still catching a true runaway well below the old $0.50 a big
+	// transcript used to blow.
+	defaultTicketReconcileMaxTurns     = 4
+	defaultTicketReconcileMaxBudgetUSD = "0.20"
 	defaultTicketReconcileTimeout      = 5 * time.Minute
 
 	// ticketReconcileFailureDetail{Head,Tail} bound the raw classifier output
@@ -489,9 +499,19 @@ func renderTicketReconcileComment(in ticketReconcileInputs, verdict *ticketRecon
 // Claude Code headless, regardless of which CLI the judged agent ran — a
 // transcript is just a file, and Claude Code is the one agent CLI with
 // enforceable turn/dollar caps (--max-turns / --max-budget-usd) and
-// schema-enforced output (--json-schema). Read-only tools; the caps are a
-// runaway backstop, the prompt's early-exit instruction is the primary control.
+// schema-enforced output (--json-schema). The transcript is deterministically
+// pre-sliced (internal/transcript) and inlined into the prompt, so the run
+// needs no tools at all; the caps remain a runaway backstop, not the primary
+// control.
 func (d *Daemon) execTicketReconcileClassifier(ctx context.Context, in ticketReconcileInputs) (agentdriver.HeadlessTaskResult, error) {
+	slice, err := transcript.ExtractConversationSlice(in.TranscriptPath, transcript.DefaultSliceOptions())
+	if err != nil {
+		return agentdriver.HeadlessTaskResult{}, fmt.Errorf("read transcript: %w", err)
+	}
+	if slice.Empty() {
+		return agentdriver.HeadlessTaskResult{}, errors.New("transcript had no readable conversation turns")
+	}
+
 	driver := agentdriver.Get("claude")
 	if driver == nil {
 		return agentdriver.HeadlessTaskResult{}, errors.New("claude driver unavailable")
@@ -514,9 +534,10 @@ func (d *Daemon) execTicketReconcileClassifier(ctx context.Context, in ticketRec
 	request := agentdriver.HeadlessTaskRequest{
 		Executable:   executablePath,
 		Model:        ticketReconcileModel(),
-		Prompt:       buildTicketReconcilePrompt(in),
+		Prompt:       buildTicketReconcilePrompt(in, slice),
 		WorkDir:      tempDir,
-		AllowedTools: []string{"Read", "Grep", "Glob"},
+		AllowedTools: nil,
+		DisableTools: true,
 		MaxTurns:     ticketReconcileMaxTurns(),
 		MaxBudgetUSD: ticketReconcileMaxBudgetUSD(),
 		OutputSchema: json.RawMessage(ticketReconcileVerdictSchema),
@@ -524,29 +545,30 @@ func (d *Daemon) execTicketReconcileClassifier(ctx context.Context, in ticketRec
 	return provider.RunHeadlessTask(ctx, request)
 }
 
-func buildTicketReconcilePrompt(in ticketReconcileInputs) string {
+func buildTicketReconcilePrompt(in ticketReconcileInputs, slice transcript.ConversationSlice) string {
 	return fmt.Sprintf(`A delegated agent session ended without driving its ticket to a terminal state. Judge the dead session's work against the ticket's brief and render a verdict.
 
+You have no tools; do not attempt to read files -- judge only from the conversation slice below.
+
 Ticket: %s — %s
-Ticket brief (the definition of done):
+Ticket brief (the definition of done), as filed:
 %s
 
 Ticket column at session end: %s
 How the session ended: %s
-Transcript file (%s agent): %s
 
-Read the transcript with the Read tool. Read backwards from the tail in chunks (check the file size first, then use offset/limit). Stop as soon as you can support a verdict — but judge against the BRIEF above, never the final messages alone: an agent can sound finished while the brief is half-done.
+Stop as soon as you can support a verdict — but judge against the BRIEF above, never the final messages alone: an agent can sound finished while the brief is half-done.
 
-The brief is the starting definition of done, not the final one: the user can re-scope the work mid-session. If the transcript shows the user explicitly authorizing, narrowing, or extending the scope, judge against that latest explicit agreement — work the user approved in-session is in scope even where the original brief's wording says otherwise.
+The brief is the starting definition of done, not the final one: the user can re-scope the work mid-session. If the conversation slice shows the user explicitly authorizing, narrowing, or extending the scope, judge against that latest explicit agreement — work the user approved in-session is in scope even where the original brief's wording says otherwise. The slice's first human turn is often the more detailed real instruction (the delegation prompt) — read it alongside the filed brief above; they can differ and both matter.
 
-Claude transcripts are JSONL message lines; Codex rollout transcripts are JSONL response items. Either way, extract what the agent actually did and what remains.
+%s
 
 Report via structured output:
 - assessment: done | partial | interrupted | blocked_unreported
 - confidence: high | medium | low
 - whats_left: one line; empty string when assessment is done
 - evidence: which turn(s) support the verdict — position/timestamp plus a short quote`,
-		in.TicketID, in.Title, in.Brief, in.StatusAtClaim, in.CloseContext, in.Agent, in.TranscriptPath)
+		in.TicketID, in.Title, in.Brief, in.StatusAtClaim, in.CloseContext, slice.Render())
 }
 
 // --- the sweep backstop ---

--- a/internal/daemon/ticket_reconcile_test.go
+++ b/internal/daemon/ticket_reconcile_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 	"github.com/victorarias/attn/internal/tasks"
+	"github.com/victorarias/attn/internal/transcript"
 )
 
 // installReconcileRunner builds and starts a durable runner with only the
@@ -454,5 +455,55 @@ func TestSweepSkipsTicketWithExistingTask(t *testing.T) {
 	d.ticketReconcileSweepPass(now.Add(ticketReconcileGrace() + time.Hour))
 	if got := reconciledAt(t, d, "already"); got != nil {
 		t.Fatalf("sweep re-claimed a ticket with an existing task (%v)", got)
+	}
+}
+
+// The prompt must inline the deterministic transcript slice (not a
+// Read-the-transcript instruction) alongside the filed ticket brief.
+func TestBuildTicketReconcilePromptInlinesSlice(t *testing.T) {
+	dir := t.TempDir()
+	transcriptPath := filepath.Join(dir, "transcript.jsonl")
+	lines := []string{
+		`{"type":"user","origin":{"kind":"human"},"message":{"content":"delegated: wire up the widget"}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"widget wired, opening PR"}]}}`,
+	}
+	if err := os.WriteFile(transcriptPath, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write fixture transcript: %v", err)
+	}
+
+	slice, err := transcript.ExtractConversationSlice(transcriptPath, transcript.DefaultSliceOptions())
+	if err != nil {
+		t.Fatalf("ExtractConversationSlice: %v", err)
+	}
+	if slice.Empty() {
+		t.Fatalf("fixture slice unexpectedly empty")
+	}
+
+	in := ticketReconcileInputs{
+		TicketID:       "tkt-1",
+		Title:          "Wire up the widget",
+		Brief:          "the filed ticket brief text",
+		StatusAtClaim:  store.TicketStatusWorking,
+		Agent:          "claude",
+		TranscriptPath: transcriptPath,
+		CloseContext:   "the agent process exited on its own",
+	}
+
+	prompt := buildTicketReconcilePrompt(in, slice)
+
+	if !strings.Contains(prompt, "widget wired, opening PR") {
+		t.Errorf("prompt missing inlined slice turn content:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "TICKET BRIEF") {
+		t.Errorf("prompt missing slice heading:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, in.Brief) {
+		t.Errorf("prompt missing filed ticket brief:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "Read the transcript") {
+		t.Errorf("prompt still instructs reading the transcript:\n%s", prompt)
+	}
+	if strings.Contains(prompt, in.TranscriptPath) {
+		t.Errorf("prompt still leaks the transcript path:\n%s", prompt)
 	}
 }

--- a/internal/transcript/slice.go
+++ b/internal/transcript/slice.go
@@ -1,0 +1,267 @@
+package transcript
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ConversationSlice is a small, classification-ready reduction of a (possibly
+// huge) agent transcript: the human's original request, any later corrections,
+// the most recent compaction summary (Claude only), and the agent's most
+// recent status turns. It intentionally carries no tool-call/activity trace.
+type ConversationSlice struct {
+	Brief      string   // first genuine human turn (the delegation prompt), capped
+	Rescoping  []string // later genuine human turns (corrections / scope changes), capped, oldest->newest
+	Summary    string   // most recent compaction summary text, if any (Claude), capped
+	AgentTurns []string // last N agent text turns, capped, oldest->newest
+	HumanCount int      // total genuine human turns seen (pre-cap)
+	AgentCount int      // total agent text turns seen (pre-cap)
+}
+
+// Empty reports whether no human/agent text or compaction summary was found.
+func (s ConversationSlice) Empty() bool {
+	return s.Brief == "" && len(s.Rescoping) == 0 && s.Summary == "" && len(s.AgentTurns) == 0
+}
+
+// Render renders the slice as a labeled prompt block, omitting empty sections.
+func (s ConversationSlice) Render() string {
+	var sections []string
+	if s.Brief != "" {
+		sections = append(sections, "## TICKET BRIEF (first human turn)\n"+s.Brief)
+	}
+	if len(s.Rescoping) > 0 {
+		sections = append(sections, "## LATER HUMAN TURNS (re-scoping)\n"+strings.Join(s.Rescoping, "\n---\n"))
+	}
+	if s.Summary != "" {
+		sections = append(sections, "## COMPACTION SUMMARY (most recent)\n"+s.Summary)
+	}
+	if len(s.AgentTurns) > 0 {
+		sections = append(sections, "## AGENT'S LAST STATUS TURNS\n"+strings.Join(s.AgentTurns, "\n---\n"))
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+// SliceOptions bounds how much of a transcript ExtractConversationSlice keeps.
+// Any field that is <= 0 falls back to the DefaultSliceOptions value.
+type SliceOptions struct {
+	MaxRescopingTurns int // most recent human turns AFTER the brief (default 4)
+	MaxAgentTurns     int // most recent agent text turns (default 6)
+	TurnCharCap       int // per-turn char cap for brief/rescoping/agent (default 3000)
+	SummaryCharCap    int // larger cap for the compaction summary (default 12000)
+}
+
+// DefaultSliceOptions returns the default SliceOptions.
+func DefaultSliceOptions() SliceOptions {
+	return SliceOptions{
+		MaxRescopingTurns: 4,
+		MaxAgentTurns:     6,
+		TurnCharCap:       3000,
+		SummaryCharCap:    12000,
+	}
+}
+
+func resolveSliceOptions(opts SliceOptions) SliceOptions {
+	def := DefaultSliceOptions()
+	if opts.MaxRescopingTurns <= 0 {
+		opts.MaxRescopingTurns = def.MaxRescopingTurns
+	}
+	if opts.MaxAgentTurns <= 0 {
+		opts.MaxAgentTurns = def.MaxAgentTurns
+	}
+	if opts.TurnCharCap <= 0 {
+		opts.TurnCharCap = def.TurnCharCap
+	}
+	if opts.SummaryCharCap <= 0 {
+		opts.SummaryCharCap = def.SummaryCharCap
+	}
+	return opts
+}
+
+// sliceLineOrigin captures the Claude "origin" field used to distinguish
+// genuine human turns from injected/tool-authored user-role content.
+type sliceLineOrigin struct {
+	Kind string `json:"kind"`
+}
+
+// sliceLine is a superset shape covering the Claude, Codex, and Copilot line
+// formats. Unknown fields are ignored by encoding/json, so a single unmarshal
+// is enough to try all three shapes for every line.
+type sliceLine struct {
+	// Claude
+	Type             string           `json:"type"`
+	IsCompactSummary bool             `json:"isCompactSummary"`
+	Origin           *sliceLineOrigin `json:"origin"`
+	Message          struct {
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+
+	// Codex (event_msg envelope only; response_item is intentionally ignored
+	// here so the same turn is not double-counted)
+	Payload json.RawMessage `json:"payload"`
+
+	// Copilot
+	Data struct {
+		Content string `json:"content"`
+	} `json:"data"`
+}
+
+// sliceBuilder accumulates a bounded ConversationSlice over a single
+// streaming pass. It never retains more than a small, capped amount of text
+// regardless of transcript size.
+type sliceBuilder struct {
+	opts SliceOptions
+
+	haveFirst     bool
+	firstHuman    string
+	lastHumanText string
+	tailHuman     []string // bounded tail of human turns after the first
+
+	lastSummary string
+
+	tailAgent []string // bounded tail of agent turns
+
+	humanCount int
+	agentCount int
+}
+
+func (b *sliceBuilder) addHuman(text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	if text == b.lastHumanText {
+		// consecutive duplicate (e.g. a resent Codex user_message) - do not
+		// double-count or double-store it.
+		return
+	}
+	b.lastHumanText = text
+	b.humanCount++
+
+	if !b.haveFirst {
+		b.firstHuman = text
+		b.haveFirst = true
+		return
+	}
+
+	b.tailHuman = append(b.tailHuman, text)
+	if len(b.tailHuman) > b.opts.MaxRescopingTurns {
+		b.tailHuman = b.tailHuman[len(b.tailHuman)-b.opts.MaxRescopingTurns:]
+	}
+}
+
+func (b *sliceBuilder) addAgent(text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	b.agentCount++
+
+	b.tailAgent = append(b.tailAgent, text)
+	if len(b.tailAgent) > b.opts.MaxAgentTurns {
+		b.tailAgent = b.tailAgent[len(b.tailAgent)-b.opts.MaxAgentTurns:]
+	}
+}
+
+func (b *sliceBuilder) setSummary(text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	b.lastSummary = text
+}
+
+func (b *sliceBuilder) processLine(line []byte) {
+	var e sliceLine
+	if err := json.Unmarshal(line, &e); err != nil {
+		return
+	}
+
+	switch e.Type {
+	case "user":
+		if e.IsCompactSummary {
+			b.setSummary(extractTextContent(e.Message.Content))
+			return
+		}
+		if e.Origin == nil || e.Origin.Kind == "human" {
+			b.addHuman(extractTextContent(e.Message.Content))
+		}
+		return
+	case "assistant":
+		b.addAgent(extractTextContent(e.Message.Content))
+		return
+	case "event_msg":
+		var payload codexEventMessage
+		if err := json.Unmarshal(e.Payload, &payload); err != nil {
+			return
+		}
+		switch payload.Type {
+		case "user_message":
+			b.addHuman(payload.Message)
+		case "agent_message":
+			b.addAgent(payload.Message)
+		}
+		return
+	case "user.message":
+		b.addHuman(e.Data.Content)
+		return
+	case "assistant.message":
+		b.addAgent(e.Data.Content)
+		return
+	}
+}
+
+func capText(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if n > 0 && len(s) > n {
+		return s[:n] + fmt.Sprintf("\n...[truncated, %d chars total]", len(s))
+	}
+	return s
+}
+
+func capTexts(items []string, n int) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]string, len(items))
+	for i, s := range items {
+		out[i] = capText(s, n)
+	}
+	return out
+}
+
+func (b *sliceBuilder) toSlice(opts SliceOptions) ConversationSlice {
+	return ConversationSlice{
+		Brief:      capText(b.firstHuman, opts.TurnCharCap),
+		Rescoping:  capTexts(b.tailHuman, opts.TurnCharCap),
+		Summary:    capText(b.lastSummary, opts.SummaryCharCap),
+		AgentTurns: capTexts(b.tailAgent, opts.TurnCharCap),
+		HumanCount: b.humanCount,
+		AgentCount: b.agentCount,
+	}
+}
+
+// ExtractConversationSlice reads a JSONL transcript (Claude, Codex, or
+// Copilot shaped) in a single streaming pass and reduces it to a small,
+// bounded ConversationSlice suitable for downstream classification. Memory
+// use is bounded regardless of transcript size or line length. Only a
+// file-open/IO error returns a non-nil error; malformed or unrecognized
+// lines are skipped silently.
+func ExtractConversationSlice(path string, opts SliceOptions) (ConversationSlice, error) {
+	opts = resolveSliceOptions(opts)
+
+	file, err := os.Open(path)
+	if err != nil {
+		return ConversationSlice{}, err
+	}
+	defer file.Close()
+
+	b := &sliceBuilder{opts: opts}
+
+	if err := readJSONLLines(file, b.processLine); err != nil {
+		return ConversationSlice{}, err
+	}
+
+	return b.toSlice(opts), nil
+}

--- a/internal/transcript/slice_test.go
+++ b/internal/transcript/slice_test.go
@@ -1,0 +1,308 @@
+package transcript
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeJSONL(t *testing.T, lines ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestExtractConversationSlice_Claude(t *testing.T) {
+	lines := []string{
+		`{"type":"session_meta","cwd":"/tmp"}`,
+		`{"type":"user","origin":{"kind":"human"},"message":{"content":"fix the reconcile classifier budget bug"}}`,
+		`{"type":"user","message":{"content":[{"type":"tool_result","text":"some tool output"}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"looking into it"}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"found the root cause"}]}}`,
+		`{"type":"user","isCompactSummary":true,"message":{"content":"summary: investigated X, did Y"}}`,
+		`{"type":"user","origin":{"kind":"human"},"message":{"content":"also handle codex transcripts"}}`,
+		`{"type":"user","origin":{"kind":"human"},"message":{"content":"and copilot too"}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"handling codex now"}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"done, opening PR"}]}}`,
+	}
+	path := writeJSONL(t, lines...)
+
+	got, err := ExtractConversationSlice(path, DefaultSliceOptions())
+	if err != nil {
+		t.Fatalf("ExtractConversationSlice: %v", err)
+	}
+
+	if got.Brief != "fix the reconcile classifier budget bug" {
+		t.Errorf("Brief = %q", got.Brief)
+	}
+	wantRescoping := []string{"also handle codex transcripts", "and copilot too"}
+	if len(got.Rescoping) != len(wantRescoping) {
+		t.Fatalf("Rescoping = %v, want %v", got.Rescoping, wantRescoping)
+	}
+	for i, w := range wantRescoping {
+		if got.Rescoping[i] != w {
+			t.Errorf("Rescoping[%d] = %q, want %q", i, got.Rescoping[i], w)
+		}
+	}
+	if got.Summary != "summary: investigated X, did Y" {
+		t.Errorf("Summary = %q", got.Summary)
+	}
+	wantAgent := []string{
+		"looking into it",
+		"found the root cause",
+		"handling codex now",
+		"done, opening PR",
+	}
+	if len(got.AgentTurns) != len(wantAgent) {
+		t.Fatalf("AgentTurns = %v, want %v", got.AgentTurns, wantAgent)
+	}
+	for i, w := range wantAgent {
+		if got.AgentTurns[i] != w {
+			t.Errorf("AgentTurns[%d] = %q, want %q", i, got.AgentTurns[i], w)
+		}
+	}
+	if got.HumanCount != 3 {
+		t.Errorf("HumanCount = %d, want 3 (tool_result-only line must be dropped)", got.HumanCount)
+	}
+	if got.AgentCount != 4 {
+		t.Errorf("AgentCount = %d, want 4", got.AgentCount)
+	}
+}
+
+func TestExtractConversationSlice_ClaudeAgentTailCap(t *testing.T) {
+	opts := DefaultSliceOptions()
+	opts.MaxAgentTurns = 2
+	lines := []string{
+		`{"type":"user","origin":{"kind":"human"},"message":{"content":"brief"}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"a1"}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"a2"}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"a3"}]}}`,
+	}
+	path := writeJSONL(t, lines...)
+
+	got, err := ExtractConversationSlice(path, opts)
+	if err != nil {
+		t.Fatalf("ExtractConversationSlice: %v", err)
+	}
+	want := []string{"a2", "a3"}
+	if len(got.AgentTurns) != len(want) {
+		t.Fatalf("AgentTurns = %v, want %v", got.AgentTurns, want)
+	}
+	for i, w := range want {
+		if got.AgentTurns[i] != w {
+			t.Errorf("AgentTurns[%d] = %q, want %q", i, got.AgentTurns[i], w)
+		}
+	}
+	if got.AgentCount != 3 {
+		t.Errorf("AgentCount = %d, want 3 (pre-cap total)", got.AgentCount)
+	}
+}
+
+func TestExtractConversationSlice_Codex(t *testing.T) {
+	lines := []string{
+		`{"type":"event_msg","payload":{"type":"user_message","message":"please fix the bug"}}`,
+		// consecutive duplicate user_message (e.g. a client retry) must be deduped
+		`{"type":"event_msg","payload":{"type":"user_message","message":"please fix the bug"}}`,
+		`{"type":"event_msg","payload":{"type":"agent_message","message":"on it"}}`,
+		// response_item echo of the same user turn must NOT be double-counted
+		`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"please fix the bug"}]}}`,
+		`{"type":"event_msg","payload":{"type":"user_message","message":"actually also check the tests"}}`,
+	}
+	path := writeJSONL(t, lines...)
+
+	got, err := ExtractConversationSlice(path, DefaultSliceOptions())
+	if err != nil {
+		t.Fatalf("ExtractConversationSlice: %v", err)
+	}
+
+	if got.Brief != "please fix the bug" {
+		t.Errorf("Brief = %q", got.Brief)
+	}
+	wantRescoping := []string{"actually also check the tests"}
+	if len(got.Rescoping) != len(wantRescoping) || got.Rescoping[0] != wantRescoping[0] {
+		t.Errorf("Rescoping = %v, want %v", got.Rescoping, wantRescoping)
+	}
+	// the consecutive duplicate "please fix the bug" user_message is deduped,
+	// and the response_item echo is ignored entirely, so HumanCount is 2, not 4.
+	if got.HumanCount != 2 {
+		t.Errorf("HumanCount = %d, want 2 (consecutive dup deduped, response_item ignored)", got.HumanCount)
+	}
+	if got.AgentCount != 1 {
+		t.Errorf("AgentCount = %d, want 1", got.AgentCount)
+	}
+	if len(got.AgentTurns) != 1 || got.AgentTurns[0] != "on it" {
+		t.Errorf("AgentTurns = %v", got.AgentTurns)
+	}
+}
+
+func TestExtractConversationSlice_Copilot(t *testing.T) {
+	lines := []string{
+		`{"type":"user.message","data":{"content":"please refactor this module"}}`,
+		`{"type":"assistant.message","data":{"content":"refactored, running tests"}}`,
+	}
+	path := writeJSONL(t, lines...)
+
+	got, err := ExtractConversationSlice(path, DefaultSliceOptions())
+	if err != nil {
+		t.Fatalf("ExtractConversationSlice: %v", err)
+	}
+	if got.Brief != "please refactor this module" {
+		t.Errorf("Brief = %q", got.Brief)
+	}
+	if len(got.AgentTurns) != 1 || got.AgentTurns[0] != "refactored, running tests" {
+		t.Errorf("AgentTurns = %v", got.AgentTurns)
+	}
+	if got.HumanCount != 1 || got.AgentCount != 1 {
+		t.Errorf("HumanCount=%d AgentCount=%d, want 1/1", got.HumanCount, got.AgentCount)
+	}
+}
+
+func TestExtractConversationSlice_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("write empty fixture: %v", err)
+	}
+
+	got, err := ExtractConversationSlice(path, DefaultSliceOptions())
+	if err != nil {
+		t.Fatalf("ExtractConversationSlice: %v", err)
+	}
+	if !got.Empty() {
+		t.Errorf("expected Empty() == true for empty file, got %+v", got)
+	}
+}
+
+func TestExtractConversationSlice_MetadataOnly(t *testing.T) {
+	path := writeJSONL(t, `{"type":"session_meta","cwd":"/tmp","other":"stuff"}`)
+
+	got, err := ExtractConversationSlice(path, DefaultSliceOptions())
+	if err != nil {
+		t.Fatalf("ExtractConversationSlice: %v", err)
+	}
+	if !got.Empty() {
+		t.Errorf("expected Empty() == true for metadata-only file, got %+v", got)
+	}
+}
+
+func TestExtractConversationSlice_MissingPath(t *testing.T) {
+	_, err := ExtractConversationSlice("/nonexistent/path/does-not-exist.jsonl", DefaultSliceOptions())
+	if err == nil {
+		t.Fatal("expected non-nil error for missing path")
+	}
+}
+
+func TestExtractConversationSlice_Caps(t *testing.T) {
+	opts := DefaultSliceOptions()
+	opts.TurnCharCap = 20
+	opts.SummaryCharCap = 200
+
+	longHuman := strings.Repeat("x", 50)
+	// Longer than TurnCharCap (20) but shorter than SummaryCharCap (200): must
+	// NOT be truncated, proving the larger summary cap is honored.
+	longSummary := strings.Repeat("y", 100)
+
+	lines := []string{
+		`{"type":"user","origin":{"kind":"human"},"message":{"content":"` + longHuman + `"}}`,
+		`{"type":"user","isCompactSummary":true,"message":{"content":"` + longSummary + `"}}`,
+	}
+	path := writeJSONL(t, lines...)
+
+	got, err := ExtractConversationSlice(path, opts)
+	if err != nil {
+		t.Fatalf("ExtractConversationSlice: %v", err)
+	}
+
+	if !strings.HasPrefix(got.Brief, strings.Repeat("x", 20)) || !strings.Contains(got.Brief, "truncated, 50 chars total") {
+		t.Errorf("Brief not truncated as expected: %q", got.Brief)
+	}
+	if got.Summary != longSummary {
+		t.Errorf("Summary should not be truncated (len %d < SummaryCharCap %d), got %q", len(longSummary), opts.SummaryCharCap, got.Summary)
+	}
+}
+
+func TestExtractConversationSlice_HugeLine(t *testing.T) {
+	// ~2MB single line that must not break the streaming pass.
+	hugeText := strings.Repeat("z", 2*1024*1024)
+	hugeLine := `{"type":"assistant","message":{"content":[{"type":"text","text":"` + hugeText + `"}]}}`
+	normalHuman := `{"type":"user","origin":{"kind":"human"},"message":{"content":"a normal turn"}}`
+
+	path := writeJSONL(t, hugeLine, normalHuman)
+
+	got, err := ExtractConversationSlice(path, DefaultSliceOptions())
+	if err != nil {
+		t.Fatalf("ExtractConversationSlice: %v", err)
+	}
+	if got.Brief != "a normal turn" {
+		t.Errorf("Brief = %q, want %q", got.Brief, "a normal turn")
+	}
+	if got.AgentCount != 1 {
+		t.Errorf("AgentCount = %d, want 1", got.AgentCount)
+	}
+	if len(got.AgentTurns) != 1 {
+		t.Fatalf("AgentTurns = %v, want 1 entry", got.AgentTurns)
+	}
+	// Default TurnCharCap (3000) truncates the huge agent turn.
+	if !strings.Contains(got.AgentTurns[0], "truncated") {
+		t.Errorf("expected huge agent turn to be truncated")
+	}
+}
+
+func TestConversationSlice_Render(t *testing.T) {
+	s := ConversationSlice{
+		Brief:      "the brief",
+		Rescoping:  []string{"scope 1", "scope 2"},
+		Summary:    "the summary",
+		AgentTurns: []string{"agent 1", "agent 2"},
+	}
+	got := s.Render()
+
+	wantSections := []string{
+		"## TICKET BRIEF (first human turn)\nthe brief",
+		"## LATER HUMAN TURNS (re-scoping)\nscope 1\n---\nscope 2",
+		"## COMPACTION SUMMARY (most recent)\nthe summary",
+		"## AGENT'S LAST STATUS TURNS\nagent 1\n---\nagent 2",
+	}
+	want := strings.Join(wantSections, "\n\n")
+	if got != want {
+		t.Errorf("Render() =\n%s\nwant:\n%s", got, want)
+	}
+	if s.Empty() {
+		t.Error("expected populated slice to report Empty() == false")
+	}
+}
+
+func TestConversationSlice_RenderOmitsEmptySections(t *testing.T) {
+	s := ConversationSlice{
+		Brief:      "only the brief",
+		AgentTurns: []string{"only an agent turn"},
+	}
+	got := s.Render()
+
+	if strings.Contains(got, "LATER HUMAN TURNS") {
+		t.Errorf("expected no rescoping section, got:\n%s", got)
+	}
+	if strings.Contains(got, "COMPACTION SUMMARY") {
+		t.Errorf("expected no summary section, got:\n%s", got)
+	}
+	want := "## TICKET BRIEF (first human turn)\nonly the brief\n\n## AGENT'S LAST STATUS TURNS\nonly an agent turn"
+	if got != want {
+		t.Errorf("Render() =\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestConversationSlice_EmptyStruct(t *testing.T) {
+	var s ConversationSlice
+	if !s.Empty() {
+		t.Error("expected zero-value ConversationSlice to be Empty()")
+	}
+	if s.Render() != "" {
+		t.Errorf("expected empty Render(), got %q", s.Render())
+	}
+}


### PR DESCRIPTION
## Problem

On 2026-07-03 the orphaned-ticket reconciliation classifier failed every run: it spawned `claude -p` with `Read/Grep/Glob` and told it to read the dead session's transcript agentically. On a real **4.68MB** transcript that blew the `$0.50` budget cap, exited 1, and posted a **mislabeled** failure note.

## Fix

Replace the agentic read with a **deterministic, streaming extractor** and a **single tool-less Haiku completion**:

- **`internal/transcript/slice.go`** — `ExtractConversationSlice` reduces any Claude/Codex/Copilot transcript, in one streaming pass with bounded memory, to a small slice: the delegation prompt (first human turn), later **re-scoping** human turns, the most recent compaction summary (Claude), and the agent's last status turns. Text-only, no activity trace.
- **`internal/agent`** — `HeadlessTaskRequest.DisableTools` for a genuinely tool-less run. (An empty `AllowedTools` alone still falls back to the native default tool set — the trap this flag exists to avoid.)
- **`internal/daemon/ticket_reconcile.go`** — extract + inline the slice into the prompt, keeping **both** the filed ticket brief and the slice's delegation prompt (they can differ; the delegation prompt is often the more detailed real instruction). Default model → `haiku`; bail cheaply on an empty slice. Caps loosened to a pure runaway backstop (**4 turns / $0.20**) now that input is bounded by construction.

Because the input is bounded, the run can neither loop on tools nor balloon on transcript size — the failure mode is structurally gone.

## Validation (on the real transcript that originally failed)

Ran the **real production `execTicketReconcileClassifier`** against the 4.68MB transcript:

| model | verdict | cost | latency | caught the mid-session re-scope? |
|---|---|---|---|---|
| **haiku** (default) | `done` / high | **$0.073** | 23s | ✅ |
| sonnet (env) | `done` / medium | $0.254 | 42s | ✅ |

Both correctly recognized that the task was re-scoped mid-session (*"i want u to implement the plan in this pr"*) and judged against the delivered implementation, not the filed doc-only brief. haiku is the decisive, correct, 3.5× cheaper default. Reductions: Claude 4.68MB→18.5KB (253×), Codex 3.77MB→1.9KB (2006×).

- extractor: 12 unit tests (Claude/Codex/Copilot, empty, metadata-only, missing, caps, 2MB line, render); all green.
- daemon: existing reconcile tests unchanged & green (they swap the exec, bypassing extraction) + a new `TestBuildTicketReconcilePromptInlinesSlice`.
- `go build ./...`, `go vet`, `gofmt` clean.

## Live-app verification — please read

Per AGENTS.md this touches a daemon background runner. The **only new runtime behavior** (the extractor + the tool-less `claude -p` subprocess with `--allowedTools ""`, haiku, the inlined slice) was exercised **live against the real 4.68MB transcript through the real `execTicketReconcileClassifier`** (table above) — including confirming `--allowedTools ""` runs tool-less cleanly. The surrounding plumbing (seam → claim → durable runner → executor → comment → sweep) is **unchanged** by this PR and covered by the existing passing tests. A full fresh-session seam→comment run in the live app would only exercise that unchanged plumbing against a *small* transcript; injecting the large orphan transcript into a live sweep isn't reachable via the CLI. Happy to run that dev-app smoke too if you'd like it before merge.

## Notes

- Go-only change; the required Tauri/Frontend checks will skip via path filters (merge needs `--admin`).
- Follow-up ticket filed to migrate the stop-time classifier off `claude-agent-sdk-go` and drop the dep (`migrate-stop-time-classifier-off-claude-agent-sdk-go-drop-th`) — the only remaining SDK user, kept out of this PR to stay focused.
