### PR TITLE
docs: Present — vision and chunk-1 plan (jaunt-in-attn design)

### DIFF
--- a/docs/plans/2026-07-02-pr-tour-port.md
+++ b/docs/plans/2026-07-02-pr-tour-port.md
@@ -1,5 +1,11 @@
 # Plan: PR tours in attn (jaunt port) — direction plan
 
+> **SUPERSEDED (2026-07-04)** by [docs/vision/present.md](../vision/present.md).
+> The design pivoted: instead of overlaying a tour on the existing diff panel,
+> **Present** replaces that panel with an agent-triggered presentation surface
+> (own window, rounds, doc annotation, teaching). The jaunt inventory below
+> remains accurate and useful; the decisions and slices do not govern anything.
+
 ## Goal
 
 Port jaunt into attn: a delegated agent authors a **guided PR tour** — an ordered

--- a/docs/plans/2026-07-04-present-spine.md
+++ b/docs/plans/2026-07-04-present-spine.md
@@ -1,0 +1,167 @@
+# Plan: Present — chunk 1, the spine + window (thin end-to-end)
+
+## Why / Alignment
+
+First chunk of [docs/vision/present.md](../vision/present.md), agreed with
+Victor 2026-07-04: one vertical slice proving the whole loop — an agent runs
+`attn present`, a banner notice lands in the main window, clicking it opens the
+presentation in **its own OS window** (second display capable), Victor reads a
+level-0/1 change presentation (explicit frame, reading order, diffs), comments
+inline, hands the round back; the agent gets a doorbell and reads structured
+feedback via CLI. Feedback loop is **in** this chunk (the loop is the product).
+Guidance stays at level 0–1 (order + per-file notes; no line annotations, no
+mermaid). The old ⌘⇧E diff panel is untouched until the vision's demolition
+rock. Grounded: Tauri multi-window is viable (mechanism A below); the daemon
+already supports multiple WS clients cleanly.
+
+## Data Model / Interfaces
+
+Manifest v0 (`.present.yml` or any path; parsed by `internal/present`):
+
+```yaml
+version: 1
+kind: changes            # only "changes" in chunk 1; "doc" is a later chunk
+title: Nudge countdown fixes
+frame:
+  repo: /abs/worktree    # CLI defaults from cwd but always records absolute
+  base: origin/main      # refs, resolved AND PINNED to SHAs at trigger time
+  head: HEAD
+summary: >               # optional markdown, rendered simply
+files:                   # optional = level 0; present = level 1 reading order
+  - path: internal/daemon/nudge.go
+    note: optional one-paragraph note rendered above the diff
+skip:
+  - app/src/types/generated.ts   # rendered last, dimmed
+```
+
+Store (new tables, next free migration version — check `MAX(version)` in real
+DBs first, per the burned-versions gotcha):
+
+```sql
+presentations:         id, session_id, ticket_id NULL, title, kind,
+                       repo_path, status(open|closed), created_at
+presentation_rounds:   id, presentation_id, seq, manifest_yaml,
+                       base_sha, head_sha, created_at, submitted_at NULL
+presentation_comments: id, round_id, filepath, line_start, line_end,
+                       side(new|old), content, author(user), created_at
+```
+
+Protocol (pattern #1: main.tsp → `rm -rf tsp-output` → `make generate-types` →
+constants → ProtocolVersion bump; tsc-check for the quicktype enum-merge trap):
+
+```text
+unix socket (agent CLI):
+  present_open     {manifest_path | inline manifest, session from ATTN_SESSION_ID}
+                   -> creates presentation + round 1 (or round N+1 via --presentation)
+  present_feedback {presentation_id, round?} -> structured markdown of comments
+websocket (app):
+  evt  presentation_added / presentation_updated   (row + latest round summary)
+  cmd  get_presentations, get_presentation_round   (manifest struct + pinned SHAs)
+  cmd  present_submit_round {round_id, comments[], handback: bool} -> *_result
+  diff content: get_file_diff extended with pinned base_sha/head_sha
+                (FileDiff today diffs base..worktree; add explicit head ref)
+```
+
+## Architecture Map
+
+```text
+agent (delegated session, worktree)
+  -> attn present --manifest .present.yml        [cmd/attn, parse+pin via internal/present]
+    -> unix socket present_open -> daemon: store insert + broadcast presentation_added
+main window (App.tsx)
+  -> banner notice (nudge-strip pattern) "▶ <title> — <session>"
+    -> click -> invoke open_presentation_window(id)          [new Rust cmd]
+present window (label "present", WebviewWindowBuilder,
+                url index.html?window=present&presentation=<id>)
+  -> main.tsx branches on ?window=present -> <PresentRoot/>  [slim root, NOT App.tsx]
+    -> own useDaemonSocket (client_hello workspace_sessions; no browser-host token)
+    -> get_presentation_round -> ordered file list (files -> others -> skip dimmed)
+    -> per file: get_file_diff at pinned SHAs -> DiffView (@pierre/diffs)
+    -> j/k nav, gutter comment -> local drafts -> submit dialog
+    -> present_submit_round {comments, handback}
+daemon on submit
+  -> store comments; ticket-bound: ticket activity + existing nudge machinery
+     else: typeDoorbell(session, fixed "run attn present feedback <id>" prompt)
+agent -> attn present feedback <id> -> quoted, file:line-structured markdown
+
+Tests:
+  internal/present golden manifests (valid + every rejection)
+  daemon handler tests beside ws_review/ticket patterns; store migration test
+  PresentRoot unit tests w/ createMockDaemon pattern
+  packaged: real-app scenario (fixture repo: present -> banner -> window ->
+            comment -> submit -> feedback CLI round-trips) — single-tenant
+```
+
+## Boundaries
+
+- `internal/present` owns manifest parse/validate/pinning. Pure file+git →
+  struct; no store, no daemon imports.
+- Daemon translates and stores; it never resolves file content at ingest — the
+  reader fetches diffs live at the round's pinned SHAs (pin = refs, drift =
+  banner; no content snapshots).
+- `PresentRoot` never imports `App.tsx` — no deep-link listeners, no
+  UI-automation bridge, no browser-host token (Rust `TrustedMainWebview` gate
+  already denies it), theme consumed read-only.
+- The presentation window coordinates with main via the daemon WS, not Tauri
+  events (avoids capability wiring; both windows are ordinary WS clients).
+- Old diff panel and `(repo_path, branch)` review store: untouched this chunk.
+
+## Implementation Steps
+
+- [ ] **PR 1 — Go spine.** `internal/present` (parse, validate, SHA pinning);
+      store tables + migration; protocol messages + version bump; daemon
+      handlers (`present_open`, feedback, get/list, submit_round persistence);
+      `attn present` / `attn present validate` / `attn present feedback` in
+      `cmd/attn`; doorbell-on-submit (ticket activity when bound, bare
+      doorbell otherwise). Tests as mapped.
+- [ ] **PR 2 — window shell.** Rust `open_presentation_window` (build-or-show,
+      hide-on-close-request), label-guarded `on_page_load` show,
+      `capabilities/present.json` (core:default + clipboard), focus-aware
+      `on_menu_event`/`dispatch_native_shortcut` (⌘W on present window hides
+      it, never touches main panes); `main.tsx` `?window=present` branch with
+      a hello-world `PresentRoot` proving WS + theme; banner notice in main
+      window wired to `presentation_added` → open window; banner persists
+      while window hidden (that IS minimize-to-banner).
+- [ ] **PR 3 — the reader.** Ordered file list, pinned-SHA diffs through
+      `DiffView`, per-file notes + summary (existing simple markdown renderer;
+      no new markdown stack), keyboard nav, inline comment drafts, submit
+      dialog with handback toggle, drift banner (round head vs current branch
+      head). `get_file_diff` head-ref extension lands here with its daemon
+      tests.
+- [ ] **PR 4 — packaged evidence + polish.** Real-app scenario for the full
+      loop; live dev-app smoke with a real delegated agent; CHANGELOG entry.
+
+## Decisions
+
+- **Fresh presentation-scoped storage**, not the `(repo_path, branch)` reviews
+  key — the vision retires that identity; migrating old rows buys nothing.
+- **Explicit `side` column** on comments instead of inheriting the
+  negative-`line_end` encoding from ReviewComment — fresh schema, no hack.
+- **Pin = SHAs, content fetched live** at those SHAs; drift is a visible
+  banner. No per-round content snapshots (vision: rounds pin, never freeze).
+- **Single HTML entry + `?window=present`** (grounded mechanism A) over a
+  separate Vite entry — maximal component sharing; `test-harness` precedent
+  exists if a split becomes worth it.
+- **Separate capability file** for the `present` label; `default.json` stays
+  `["main"]` (a browser-host test pins it, and the child-webview security
+  invariant depends on it).
+- **Round N+1 = re-run `attn present --presentation <id>`** with re-pinned
+  SHAs — no separate "update" verb to learn.
+
+## Open Questions
+
+- Doorbell copy + whether a submitted round should also flip a bound ticket to
+  a state the chief narrates (leaning: ticket activity only, no status write).
+- Banner stacking when several presentations are open at once (chunk 1: newest
+  wins, count badge; revisit with real use).
+- Presentation close/archive lifecycle (chunk 1: `status=closed` on
+  handback-with-no-reopen is deferred; instances just accumulate).
+
+## Follow-ups
+
+- Level ≥2 guidance (line annotations, threads, tour summary card) — next
+  chunk, brings the jaunt authoring-skill port with it.
+- Document (`kind: doc`) reader + annotation; shared markdown renderer paying
+  the ticket-board debt.
+- Changes-since-round view; gates; pull; `/teach`; ⌘⇧E demolition — per the
+  vision's big rocks.

--- a/docs/vision/present.md
+++ b/docs/vision/present.md
@@ -1,0 +1,134 @@
+# Vision: Present — the agent's document channel
+
+> Supersedes [docs/plans/2026-07-02-pr-tour-port.md](../plans/2026-07-02-pr-tour-port.md)
+> (the jaunt port direction plan). That plan overlaid a tour on the existing diff
+> panel; this vision replaces the panel and broadens the primitive. jaunt
+> (`victorarias/jaunt`) and plannotator (`backnotprop/plannotator`) are the two
+> donor products — jaunt for the pedagogy, plannotator for the annotation
+> vocabulary — but Present is neither's port.
+
+## End state (the why)
+
+An agent finishes a change, or reaches a plan worth vetting, or uncovers
+something worth explaining — and **presents** it. A quiet notice lands in attn's
+top banner. One click opens the presentation in its own window: throw it on the
+second display while agents keep running in the main one. The document is laid
+out the way its author would walk you through it — summary first, reading order
+chosen, every consequential line carrying the *why* that the content alone can't
+show — rendered richly: prose, highlighted code, diagrams, tables. You read
+keyboard-first. Where you push back, you annotate — the feedback pins to the
+exact text or line, quoted, structured. You hand the round back; the agent gets
+its doorbell, reads your notes through the CLI, revises, presents round two —
+and round two opens on *what changed since round one*.
+
+The same surface reviews a branch diff, gates a plan before the agent builds,
+walks you through an unfamiliar subsystem, or teaches you something the agent
+learned. Presenting is the agent's **document channel** — the terminal stays the
+conversation channel, and walls of terminal text stop being how agents show
+work.
+
+Why it matters: attn's whole model is many agents, one Victor. Reading and
+judging agent output is the bottleneck — and the trust ceiling. A
+cognition-friendly, pedagogic presentation surface raises both. The automated
+review-loop failed because it removed the human; Present succeeds by centering
+him.
+
+## North-star principles
+
+- **Human-centric, always.** Agents author and present; the human reads and
+  decides. No headless review loops, ever — that is the review-loop's grave, and
+  we don't dig it up.
+- **The presenter carries the frame.** Every presentation states its content
+  explicitly — repo, base, head, doc paths. Nothing is inferred from "the active
+  session"; the frame ambiguity that broke the old diff panel cannot exist here.
+- **Pedagogy over inventory.** Teach, don't list. Reading order, pinned whys,
+  contested decisions pre-empted (jaunt's voice). Multi-modal by default —
+  prose, code, diagrams, structure. Cognition-friendly UI/UX is a non-negotiable,
+  not polish.
+- **Zero friction.** Banner → reading in under a second. Keyboard-first
+  traversal. Progress durable. No port dances, no browser tabs, no blocked
+  agent processes.
+- **Rounds are the unit of trust.** A presentation advances in rounds; each
+  round pins its content (SHAs for diffs, content hash for docs). Drift is
+  visible — "the branch is N commits ahead of this round" — never silent.
+  What-changed-since-last-round is first-class.
+- **Feedback is structured and quoted.** Annotations pin to content and quote
+  it, so the agent never resolves anchors. They flow back as data through the
+  CLI; the doorbell says *go look* — content is never streamed into a PTY.
+- **Guidance and response scale independently.** Guidance: just show it →
+  reading order → notes → full annotated tour. Response: FYI → annotations →
+  gate (approve/deny) → iterating rounds. Every combination is legitimate;
+  every level is useful; cost scales with stakes.
+- **One spine, many uses.** Change review, plan gating, explainers, teaching —
+  one instance model, one window, one feedback path. A new use is a new
+  manifest shape, not a new subsystem.
+
+## Scope & non-goals
+
+**In scope:** the presentation instance (agent-triggered, several per session,
+bound to session/ticket); the manifest (evolved-from-jaunt YAML — content refs,
+guidance, response mode); the banner → own-window surface (minimize back to
+banner); readers for changes (diff) and documents (rendered markdown);
+annotation and comment machinery with structured vocabulary; rounds with
+pinning and drift; the agent CLI + doorbell loop; authoring skills (jaunt's
+discipline, ported); a shared markdown renderer that also pays the ticket-board
+rendering debt; pull ("give me a tour of this"), gates, and teaching (`/teach`)
+as the surface matures; eventual removal of the ⌘⇧E diff panel, which this
+replaces.
+
+**Non-goals:** posting to GitHub/GitLab (feedback belongs to the agent loop);
+chat inside the presentation (conversation stays in the session terminal);
+headless agent-to-agent review; jaunt web-app compatibility for the manifest;
+mobile/remote rendering of the presentation window in v1.
+
+## Big rocks (the arc)
+
+- [ ] **Spine** — presentation instance + rounds domain model, manifest schema,
+      protocol, store, `attn present` CLI, doorbell semantics. Retires the
+      `(repo_path, branch)` review identity.
+- [ ] **Window shell** — banner notice → dedicated OS window, minimize back;
+      keyboard-first player chrome. (Tauri multi-window: ground pass first.)
+- [ ] **Change reader** — guided diff at levels 0–1 (explicit frame + reading
+      order + skip), replaces ⌘⇧E for daily review; inline comments; handback.
+- [ ] **Full tour guidance** — per-file notes, line-pinned annotations and
+      threads, summary card; authoring skill ported from jaunt.
+- [ ] **Document reader** — rendered markdown presentation + annotation
+      (select/pinpoint, quoted anchors — plannotator parity where it earns it).
+- [ ] **Rounds & drift** — pinned SHAs/hashes, drift banner,
+      changes-since-round view.
+- [ ] **Rendering palette** — shared markdown renderer (ticket board pays off
+      its debt here), syntax highlighting, mermaid, callouts; more as needed.
+- [ ] **Feedback vocabulary** — quick labels with agent-facing tips,
+      delete-this, looks-good; suggested-code later.
+- [ ] **Gates** — presentations that block: plan-mode interception, rounds that
+      require approval.
+- [ ] **Pull** — request a presentation of any diff/doc on demand,
+      reviewer-side generated.
+- [ ] **Teaching** — `/teach`: agent-authored lessons on the same surface.
+- [ ] **HTML artifacts** — sandboxed rendering + annotation; last, and may
+      dissolve if markdown + diagrams cover the need.
+- [ ] **Demolition** — remove the old diff panel and its review UX once Present
+      covers daily review.
+
+## Open questions
+
+Known unknowns:
+
+- Manifest schema: how far it drifts from jaunt v1, and how levels/modes are
+  expressed without schema sprawl.
+- Fate of existing `ReviewComment` rows and viewed-marks data — migrate into
+  presentation instances or start clean.
+- Gate ↔ `pending_approval` interplay: is a gated presentation a session state,
+  a ticket state, or its own thing?
+- How the board/chief surface presentations (a ticket's rounds, "waiting on
+  your review" visibility) without the board gating anything.
+- Where plannotator remains in the toolkit (non-attn contexts, external repos).
+
+Blindspots — run a `ground` blindspot pass before their first chunk:
+
+- **Tauri multi-window**: second WebviewWindow lifecycle, WS client sharing vs
+  separate connection, state sync, shortcut routing, menu accelerators.
+- **Markdown annotation anchoring** inside attn's own renderer (plannotator's
+  dual-anchor approach is documented prior art, but attn renders its own DOM).
+- **Teaching mode**: what a lesson artifact is, whether lessons persist, how
+  `/teach` fits the notebook/knowledge-base world.


### PR DESCRIPTION
## What

Design docs only — no code. Output of the jaunt-in-attn design session with Victor.

- **`docs/vision/present.md`** — north star for **Present**, the agent's document channel: agent-triggered presentations (change diffs or rendered markdown) arriving via a top-banner notice into their own OS window; guidance levels (show → order → notes → full tour) independent of response mode (FYI → annotations → gate → rounds); SHA-pinned rounds with visible drift; structured, quoted feedback returning through the CLI + doorbell. Human-centric always — the review-loop's failure mode is named as a standing principle. Replaces (eventually) the ⌘⇧E diff panel.
- **`docs/plans/2026-07-04-present-spine.md`** — chunk 1: the spine + own-window thin end-to-end slice, a four-PR train (Go spine + CLI + doorbell → Tauri second window + banner → level-0/1 change reader with inline comments → packaged evidence). Written against a completed multi-window grounding pass (mechanism, capabilities, menu routing, multi-client WS all verified).
- **`docs/plans/2026-07-02-pr-tour-port.md`** — marked SUPERSEDED by the vision (the design pivoted from overlaying a tour on the existing diff panel to replacing it); its jaunt inventory remains accurate reference material.

## Lineage

jaunt donates the pedagogy (authoring voice, tours, rounds); plannotator donates the annotation vocabulary (quoted anchors, quick labels, gates). Present is neither's port — it's attn-native: durable instances bound to sessions/tickets, non-blocking agents, doorbell handback.

---
*PR opened by Claude on behalf of Victor.*