### PR TITLE
Per-agent chief-of-staff reasoning-effort override (+ settings bridge actions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-04]
+
+### Added
+- **Pin the chief-of-staff's reasoning effort, per agent.** Settings → Agents → "Chief-of-staff model & effort" now has an effort selector next to each agent's model override (Claude: low, medium, high, xhigh, max; Codex: minimal, low, medium, high, xhigh). Leave it on "Agent default" to use the agent's own default. Only chief-of-staff launches are affected — regular sessions are unaffected.
+
 ## [2026-07-03]
 
 ### Added

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '../test/utils';
+import { act, fireEvent, render, screen, waitFor } from '../test/utils';
 import { SettingsModal } from './SettingsModal';
+import { getSettingsAutomationHandle } from './settingsAutomation';
 
 describe('SettingsModal', () => {
   it('closes on escape', async () => {
@@ -899,6 +900,35 @@ describe('SettingsModal chief settings', () => {
     expect(onSetSetting).toHaveBeenCalledWith('chief_model_codex', '');
   });
 
+  it('renders a chief-effort select per supported agent and commits on change', async () => {
+    const onSetSetting = renderModal({});
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const claudeEffort = await screen.findByTestId('settings-chief-effort-claude');
+    expect(screen.getByTestId('settings-chief-effort-codex')).toBeInTheDocument();
+    expect(screen.queryByTestId('settings-chief-effort-copilot')).toBeNull();
+
+    fireEvent.change(claudeEffort, { target: { value: 'high' } });
+    expect(onSetSetting).toHaveBeenCalledWith('chief_effort_claude', 'high');
+  });
+
+  it('shows a saved chief-effort override', async () => {
+    renderModal({ chief_effort_codex: 'xhigh' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    const codexEffort = await screen.findByTestId('settings-chief-effort-codex');
+    expect(codexEffort).toHaveValue('xhigh');
+  });
+
+  it('keeps an agent visible when only its chief-effort override is saved', async () => {
+    // codex is unavailable but has a saved effort override, so it should still show
+    // (mirrors the chief-model re-inclusion rule).
+    renderModal({ codex_available: 'false', chief_effort_codex: 'low' });
+    fireEvent.click(screen.getByTestId('settings-nav-agents'));
+
+    expect(await screen.findByTestId('settings-chief-effort-codex')).toHaveValue('low');
+  });
+
   it('shows the effective context-window caps and defaults to 128000 when unset', async () => {
     renderModal({ chief_context_window_cap: '120000', headless_context_window_cap: '90000' });
     fireEvent.click(screen.getByTestId('settings-nav-agents'));
@@ -1034,5 +1064,118 @@ describe('SettingsModal font size', () => {
 
     fireEvent.click(screen.getByText('Match app', { selector: 'button' }));
     expect(onMatchApp).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SettingsModal automation handle', () => {
+  function renderModal(overrides: Record<string, unknown> = {}) {
+    return render(
+      <SettingsModal
+        isOpen
+        onClose={vi.fn()}
+        mutedRepos={[]}
+        githubHosts={[]}
+        onUnmuteRepo={vi.fn()}
+        mutedAuthors={[]}
+        onUnmuteAuthor={vi.fn()}
+        settings={{}}
+        endpoints={[]}
+        plugins={[]}
+        pluginIssues={[]}
+        onAddEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onUpdateEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onRemoveEndpoint={vi.fn().mockResolvedValue({ success: true })}
+        onSetEndpointRemoteWeb={vi.fn().mockResolvedValue({ success: true })}
+        onListPlugins={vi.fn().mockResolvedValue({ plugins: [], issues: [] })}
+        onInstallPlugin={vi.fn().mockResolvedValue({ success: true })}
+        onRemovePlugin={vi.fn().mockResolvedValue({ success: true })}
+        onSetPluginPriority={vi.fn().mockResolvedValue({ success: true })}
+        onSetSetting={vi.fn()}
+        themePreference="system"
+        onSetTheme={vi.fn()}
+        {...overrides}
+      />,
+    );
+  }
+
+  it('registers the handle while mounted and clears it on unmount', async () => {
+    const { unmount } = renderModal();
+    await screen.findByText('Mobile Web Client');
+
+    expect(getSettingsAutomationHandle()).not.toBeNull();
+
+    unmount();
+    expect(getSettingsAutomationHandle()).toBeNull();
+  });
+
+  it('reports open state, active section, and search text through getState', async () => {
+    renderModal();
+    await screen.findByText('Mobile Web Client');
+
+    expect(getSettingsAutomationHandle()?.getState()).toEqual({
+      open: true,
+      activeSection: 'connectivity',
+      search: '',
+    });
+
+    fireEvent.change(screen.getByLabelText('Search settings'), { target: { value: 'theme' } });
+    fireEvent.click(screen.getByTestId('settings-nav-general'));
+
+    expect(getSettingsAutomationHandle()?.getState()).toEqual({
+      open: true,
+      activeSection: 'general',
+      search: 'theme',
+    });
+  });
+
+  it('reports open: false when the modal is closed', async () => {
+    renderModal({ isOpen: false });
+
+    expect(getSettingsAutomationHandle()?.getState()).toEqual({
+      open: false,
+      activeSection: 'connectivity',
+      search: '',
+    });
+  });
+
+  it('selectSection switches the rendered section the same way a nav click does', async () => {
+    renderModal();
+    await screen.findByText('Mobile Web Client');
+
+    act(() => {
+      getSettingsAutomationHandle()?.selectSection('agents');
+    });
+
+    expect(await screen.findByTestId('settings-section-agents')).toBeInTheDocument();
+    expect(getSettingsAutomationHandle()?.getState().activeSection).toBe('agents');
+  });
+
+  // Regression test: SettingsModal re-registers a fresh handle on every render
+  // (its registration effect depends on selectedSection), so a handle
+  // reference captured *before* calling selectSection closes over the
+  // pre-selection state. A caller (like the bridge's settings_select_section
+  // case) must re-read through getSettingsAutomationHandle() after the
+  // section switch settles, not reuse the handle it already had.
+  it('a handle captured before selectSection reports stale state; re-reading the module getter reports fresh state', async () => {
+    renderModal();
+    await screen.findByText('Mobile Web Client');
+
+    const capturedHandle = getSettingsAutomationHandle();
+    act(() => {
+      capturedHandle?.selectSection('agents');
+    });
+    await screen.findByTestId('settings-section-agents');
+
+    expect(capturedHandle?.getState().activeSection).toBe('connectivity');
+    expect(getSettingsAutomationHandle()?.getState().activeSection).toBe('agents');
+  });
+
+  it('selectSection throws a clear error for an unknown section id', async () => {
+    renderModal();
+    await screen.findByText('Mobile Web Client');
+
+    expect(() => getSettingsAutomationHandle()?.selectSection('nonexistent')).toThrow(
+      /unknown settings section "nonexistent"/,
+    );
   });
 });

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 // app/src/components/SettingsModal.tsx
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { Fragment, useState, useCallback, useEffect, useMemo } from 'react';
 import { useEscapeStack } from '../hooks/useEscapeStack';
 import { open } from '@tauri-apps/plugin-dialog';
 import {
@@ -11,6 +11,10 @@ import {
   PluginListResult,
 } from '../hooks/useDaemonSocket';
 import { BackgroundTasksSettings } from './BackgroundTasksSettings';
+import {
+  assertValidSettingsSectionID,
+  setSettingsAutomationHandle,
+} from './settingsAutomation';
 import { normalizeSessionAgent, type SessionAgent } from '../types/sessionAgent';
 import type { ThemePreference } from '../hooks/useTheme';
 import {
@@ -86,6 +90,13 @@ type SettingsSectionID = 'general' | 'connectivity' | 'plugins' | 'agents' | 're
 // Fallback shown when the daemon has not yet sent a normalized value; the daemon
 // mirrors this default (agent.DefaultContextWindowCap) for both context-window caps.
 const DEFAULT_CONTEXT_WINDOW_CAP = 128000;
+
+// Reasoning-effort levels the chief_effort_<agent> setting accepts, per agent. Blank
+// (agent default) is added separately as the select's first option.
+const CHIEF_EFFORT_LEVELS: Partial<Record<SessionAgent, string[]>> = {
+  claude: ['low', 'medium', 'high', 'xhigh', 'max'],
+  codex: ['minimal', 'low', 'medium', 'high', 'xhigh'],
+};
 
 interface SettingsNavItem {
   id: SettingsSectionID;
@@ -169,6 +180,9 @@ export function SettingsModal({
   // Per-agent chief-of-staff model override (chief_model_<agent>), edited locally
   // and committed on blur like the executable paths. Blank => the agent default.
   const [chiefModels, setChiefModels] = useState<Record<SessionAgent, string>>({});
+  // Per-agent chief-of-staff reasoning-effort override (chief_effort_<agent>). A
+  // <select>, so it commits immediately on change rather than on blur.
+  const [chiefEfforts, setChiefEfforts] = useState<Record<SessionAgent, string>>({});
   const [editorExecutable, setEditorExecutable] = useState(settings.editor_executable || '');
   const [defaultAgent, setDefaultAgent] = useState<SessionAgent>('claude');
   const [reviewerModel, setReviewerModel] = useState(settings.reviewer_model || '');
@@ -255,15 +269,19 @@ export function SettingsModal({
     () => orderedAgentList.filter((agent) => ['codex', 'claude', 'copilot'].includes(agent)),
     [orderedAgentList],
   );
-  // Agents whose chief launch honors a --model override (claude, codex). Installed
-  // agents only, plus any agent that already has a saved override so its row stays
-  // visible even if it became unavailable — mirrors keeperAgents re-inclusion.
-  const chiefModelAgentList = useMemo(() => {
+  // Agents whose chief launch honors a --model/--effort override (claude, codex).
+  // Installed agents only, plus any agent that already has a saved model OR effort
+  // override so its row stays visible even if it became unavailable — mirrors
+  // keeperAgents re-inclusion.
+  const chiefOverrideAgentList = useMemo(() => {
     const list = orderedAgentList.filter((agent) => (
       ['codex', 'claude'].includes(agent) && isAgentAvailable(agentAvailability, agent)
     ));
     for (const agent of ['claude', 'codex'] as const) {
-      if (!list.includes(agent) && (settings[`chief_model_${agent}`] || '').trim() !== '') {
+      if (!list.includes(agent) && (
+        (settings[`chief_model_${agent}`] || '').trim() !== ''
+        || (settings[`chief_effort_${agent}`] || '').trim() !== ''
+      )) {
         list.push(agent);
       }
     }
@@ -271,11 +289,18 @@ export function SettingsModal({
   }, [orderedAgentList, agentAvailability, settings]);
   const actualChiefModels = useMemo(() => {
     const out = {} as Record<SessionAgent, string>;
-    for (const agent of chiefModelAgentList) {
+    for (const agent of chiefOverrideAgentList) {
       out[agent] = settings[`chief_model_${agent}`] || '';
     }
     return out;
-  }, [settings, chiefModelAgentList]);
+  }, [settings, chiefOverrideAgentList]);
+  const actualChiefEfforts = useMemo(() => {
+    const out = {} as Record<SessionAgent, string>;
+    for (const agent of chiefOverrideAgentList) {
+      out[agent] = settings[`chief_effort_${agent}`] || '';
+    }
+    return out;
+  }, [settings, chiefOverrideAgentList]);
   // Agents eligible to run any keeper duty: installed, headless-task capable, and one
   // of claude/codex. Any agent already configured on a duty is kept in the list even
   // if it has since become unavailable, so its row still shows the saved selection.
@@ -321,6 +346,7 @@ export function SettingsModal({
     setNotebookRoot(actualNotebookRoot);
     setAgentExecutables(actualAgentExecutables);
     setChiefModels(actualChiefModels);
+    setChiefEfforts(actualChiefEfforts);
     setEditorExecutable(actualEditorExecutable);
     setDefaultAgent(resolvedDefaultAgent);
     setReviewerModel(actualReviewerModel);
@@ -341,9 +367,28 @@ export function SettingsModal({
     setPluginSourcePath('');
     setPluginError(null);
     setPluginActionName(null);
-  }, [isOpen, actualProjectsDir, actualNotebookRoot, actualAgentExecutables, actualChiefModels, actualEditorExecutable, resolvedDefaultAgent, actualReviewerModel, actualChiefContextCap, actualHeadlessContextCap, actualKeeperConfigs, keeperAgents]);
+  }, [isOpen, actualProjectsDir, actualNotebookRoot, actualAgentExecutables, actualChiefModels, actualChiefEfforts, actualEditorExecutable, resolvedDefaultAgent, actualReviewerModel, actualChiefContextCap, actualHeadlessContextCap, actualKeeperConfigs, keeperAgents]);
 
   useEscapeStack(onClose, isOpen);
+
+  // Publish a read/select handle for the UI automation bridge (testing only).
+  // Registered for the component's whole lifetime (not just while open) so the
+  // bridge can always read `open: false` through it rather than falling back
+  // to the module's inactive-state default.
+  useEffect(() => {
+    setSettingsAutomationHandle({
+      getState: () => ({
+        open: isOpen,
+        activeSection: selectedSection,
+        search: settingsSearch,
+      }),
+      selectSection: (sectionId) => {
+        assertValidSettingsSectionID(sectionId);
+        setSelectedSection(sectionId);
+      },
+    });
+    return () => setSettingsAutomationHandle(null);
+  }, [isOpen, selectedSection, settingsSearch]);
 
   const handleBrowse = useCallback(async () => {
     const selected = await open({
@@ -436,6 +481,12 @@ export function SettingsModal({
       onSetSetting(`chief_model_${agent}`, nextValue);
     }
   }, [actualChiefModels, chiefModels, onSetSetting]);
+
+  // A <select>, so change commits immediately rather than waiting for blur.
+  const handleChiefEffortChange = useCallback((agent: SessionAgent, value: string) => {
+    setChiefEfforts((prev) => ({ ...prev, [agent]: value }));
+    onSetSetting(`chief_effort_${agent}`, value);
+  }, [onSetSetting]);
 
   const handleToggleAutoApprove = useCallback(() => {
     onSetSetting('auto_approve_enabled', autoApproveEnabled ? 'false' : 'true');
@@ -1843,43 +1894,63 @@ export function SettingsModal({
       <section className="settings-block">
         <div className="settings-block-intro">
           <div className="settings-kicker">Agents</div>
-          <h3>Chief-of-staff model</h3>
+          <h3>Chief-of-staff model &amp; effort</h3>
           <p className="settings-description">
-            Pins the model a chief-of-staff session launches with, per agent. Leave blank
-            to use the agent's own default. Only applies to chief launches — regular
-            sessions are unaffected.
+            Pins the model and reasoning effort a chief-of-staff session launches with,
+            per agent. Leave blank to use the agent's own default. Only applies to chief
+            launches — regular sessions are unaffected.
           </p>
         </div>
         <div className="settings-block-body">
-          {chiefModelAgentList.length === 0 ? (
-            <div className="settings-warning">No installed agent supports a model override.</div>
+          {chiefOverrideAgentList.length === 0 ? (
+            <div className="settings-warning">No installed agent supports a model or effort override.</div>
           ) : (
-            <div className="settings-field-grid">
-              {chiefModelAgentList.map((agent) => {
+            <div className="settings-field-grid two-column">
+              {chiefOverrideAgentList.map((agent) => {
                 const inputId = `settings-chief-model-${agent}`;
+                const effortId = `settings-chief-effort-${agent}`;
                 const value = chiefModels[agent] || '';
+                const effortValue = chiefEfforts[agent] || '';
+                const effortLevels = CHIEF_EFFORT_LEVELS[agent] || [];
                 return (
-                  <div className="settings-field" key={agent}>
-                    <label className="settings-label" htmlFor={inputId}>{agentLabel(agent)}</label>
-                    <input
-                      id={inputId}
-                      data-testid={inputId}
-                      type="text"
-                      value={value}
-                      onChange={(e) => handleChiefModelChange(agent, e.target.value)}
-                      onBlur={() => commitChiefModel(agent)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          commitChiefModel(agent);
-                        }
-                      }}
-                      placeholder={agent === 'claude' ? 'opus — blank for default' : 'gpt-5.4 — blank for default'}
-                      className="settings-input"
-                      autoCapitalize="none"
-                      autoCorrect="off"
-                      spellCheck={false}
-                    />
-                  </div>
+                  <Fragment key={agent}>
+                    <div className="settings-field">
+                      <label className="settings-label" htmlFor={inputId}>{agentLabel(agent)}</label>
+                      <input
+                        id={inputId}
+                        data-testid={inputId}
+                        type="text"
+                        value={value}
+                        onChange={(e) => handleChiefModelChange(agent, e.target.value)}
+                        onBlur={() => commitChiefModel(agent)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            commitChiefModel(agent);
+                          }
+                        }}
+                        placeholder={agent === 'claude' ? 'opus — blank for default' : 'gpt-5.4 — blank for default'}
+                        className="settings-input"
+                        autoCapitalize="none"
+                        autoCorrect="off"
+                        spellCheck={false}
+                      />
+                    </div>
+                    <div className="settings-field">
+                      <label className="settings-label" htmlFor={effortId}>{agentLabel(agent)} effort</label>
+                      <select
+                        id={effortId}
+                        data-testid={effortId}
+                        className="settings-input"
+                        value={effortValue}
+                        onChange={(e) => handleChiefEffortChange(agent, e.target.value)}
+                      >
+                        <option value="">Agent default</option>
+                        {effortLevels.map((level) => (
+                          <option key={level} value={level}>{level}</option>
+                        ))}
+                      </select>
+                    </div>
+                  </Fragment>
                 );
               })}
             </div>

--- a/app/src/components/settingsAutomation.ts
+++ b/app/src/components/settingsAutomation.ts
@@ -1,0 +1,59 @@
+// A tiny module-level registry so the UI automation bridge can introspect and
+// drive the Settings modal without a reference into the conditionally-mounted
+// SettingsModal. SettingsModal publishes a handle while it's mounted and
+// clears it on unmount; the bridge reads through getSettingsAutomationHandle().
+// This is a test affordance only — it exposes read state and section
+// selection, reusing the same code path as a real nav-item click.
+
+const SETTINGS_SECTION_IDS = [
+  'general',
+  'connectivity',
+  'plugins',
+  'agents',
+  'review',
+  'hygiene',
+  'backgroundTasks',
+] as const;
+
+export type SettingsAutomationSectionID = (typeof SETTINGS_SECTION_IDS)[number];
+
+export interface SettingsAutomationState {
+  open: boolean;
+  activeSection: string;
+  search: string;
+}
+
+export interface SettingsAutomationHandle {
+  getState(): SettingsAutomationState;
+  selectSection(sectionId: string): void;
+}
+
+let handle: SettingsAutomationHandle | null = null;
+
+export function setSettingsAutomationHandle(next: SettingsAutomationHandle | null): void {
+  handle = next;
+}
+
+export function getSettingsAutomationHandle(): SettingsAutomationHandle | null {
+  return handle;
+}
+
+// State when the settings modal isn't mounted/open — so callers get a stable
+// shape either way.
+export const INACTIVE_SETTINGS_STATE: SettingsAutomationState = {
+  open: false,
+  activeSection: '',
+  search: '',
+};
+
+// Validates a raw sectionId against the real SettingsSectionID union, throwing
+// a clear, actionable error for an unknown id.
+export function assertValidSettingsSectionID(
+  sectionId: string,
+): asserts sectionId is SettingsAutomationSectionID {
+  if (!(SETTINGS_SECTION_IDS as readonly string[]).includes(sectionId)) {
+    throw new Error(
+      `unknown settings section "${sectionId}"; valid ids: ${SETTINGS_SECTION_IDS.join(', ')}`,
+    );
+  }
+}

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -8,6 +8,7 @@ import type { SessionAgent } from '../types/sessionAgent';
 import type { TerminalSplitDirection } from '../types/workspace';
 import { SHORTCUTS, type ShortcutId, type Combo, isChord, resolveBinding } from '../shortcuts';
 import { getGridAutomationHandle, INACTIVE_GRID_STATE } from '../components/grid/gridAutomation';
+import { getSettingsAutomationHandle, INACTIVE_SETTINGS_STATE } from '../components/settingsAutomation';
 import { getTerminalPerfSnapshot } from '../utils/terminalPerf';
 import { readWarmWorkspaceLimit } from '../utils/terminalVirtualization';
 import { getReviewPerfSnapshot } from '../utils/reviewPerf';
@@ -1620,6 +1621,21 @@ export function useUiAutomationBridge({
         const sent = handle.sendText(text);
         await settleUi();
         return { sent, zoomedId: handle.getState().zoomedId };
+      }
+      case 'settings_get_state':
+        return getSettingsAutomationHandle()?.getState() ?? INACTIVE_SETTINGS_STATE;
+      case 'settings_select_section': {
+        const sectionId = typeof payload.sectionId === 'string' ? payload.sectionId : null;
+        if (!sectionId) throw new Error('settings_select_section requires sectionId');
+        const handle = getSettingsAutomationHandle();
+        if (!handle || !handle.getState().open) throw new Error('settings modal is not open');
+        handle.selectSection(sectionId);
+        await settleUi(2);
+        // Re-read through the module getter rather than the captured handle:
+        // SettingsModal re-registers a fresh handle on each render (its
+        // useEffect depends on selectedSection), so the captured handle's
+        // getState still closes over the pre-selection section.
+        return getSettingsAutomationHandle()?.getState() ?? INACTIVE_SETTINGS_STATE;
       }
       case 'capture_screenshot_data':
         return captureDomScreenshotData(

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -4208,6 +4208,8 @@ func TestDaemon_SettingsValidation(t *testing.T) {
 		{"empty headless context cap uses default", "headless_context_window_cap", "", false},
 		{"valid headless context cap", "headless_context_window_cap", "200000", false},
 		{"headless context cap below min", "headless_context_window_cap", "1", true},
+		{"valid chief_effort_claude", "chief_effort_claude", "high", false},
+		{"empty chief_effort_claude", "chief_effort_claude", "", false},
 	}
 
 	for _, tt := range tests {
@@ -4244,6 +4246,28 @@ func TestDaemon_ContextWindowCapResolutionAndGating(t *testing.T) {
 	d.store.SetSetting(SettingChiefContextWindowCap, "160000")
 	if got := d.chiefContextWindowCap(true); got != 160000 {
 		t.Fatalf("chief cap = %d, want 160000", got)
+	}
+}
+
+func TestDaemon_ChiefLaunchEffort(t *testing.T) {
+	d := &Daemon{store: store.New()}
+
+	// chiefLaunchEffort: "" for non-chief regardless of setting; "" for a
+	// chief with no setting; the configured value for a chief that set one.
+	d.store.SetSetting(SettingChiefEffortPrefix+"claude", "high")
+	if got := d.chiefLaunchEffort("claude", false); got != "" {
+		t.Fatalf("non-chief effort = %q, want \"\"", got)
+	}
+	if got := d.chiefLaunchEffort("codex", true); got != "" {
+		t.Fatalf("chief effort with no setting = %q, want \"\"", got)
+	}
+	if got := d.chiefLaunchEffort("claude", true); got != "high" {
+		t.Fatalf("chief effort = %q, want %q", got, "high")
+	}
+
+	// Agent name is normalized (trimmed and lowercased) before the setting lookup.
+	if got := d.chiefLaunchEffort(" Claude ", true); got != "high" {
+		t.Fatalf("chief effort with unnormalized agent = %q, want %q", got, "high")
 	}
 }
 

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -553,6 +553,11 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		// chief_model_<agent> setting.
 		spawnOpts.Model = d.chiefLaunchModel(agent, isChief)
 	}
+	if spawnOpts.Effort == "" {
+		// No per-spawn pin (delegation); a chief launch falls back to the
+		// chief_effort_<agent> setting.
+		spawnOpts.Effort = d.chiefLaunchEffort(agent, isChief)
+	}
 	// A chief launch caps its context window (chief_context_window_cap); non-chief
 	// launches stay uncapped so delegated interactive agents are never affected.
 	spawnOpts.ChiefContextWindowCap = d.chiefContextWindowCap(isChief)

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -49,6 +49,12 @@ const (
 	// chief-of-staff launch uses, passed through as --model. Empty/unset => the
 	// agent's own default model. Only consulted for chief launches.
 	SettingChiefModelPrefix = "chief_model_"
+	// SettingChiefEffortPrefix + agent (e.g. "chief_effort_claude") pins the
+	// reasoning effort a chief-of-staff launch uses, passed through as the
+	// agent's native effort mechanism (Claude --effort, Codex
+	// model_reasoning_effort). Empty/unset => the agent's own default. Only
+	// consulted for chief launches.
+	SettingChiefEffortPrefix = "chief_effort_"
 	// SettingNotebookRoot overrides the notebook's filesystem root. Empty =>
 	// the profile-derived default (~/attn-notebook[-profile]).
 	SettingNotebookRoot = "notebook.root"
@@ -298,6 +304,17 @@ func (d *Daemon) chiefLaunchModel(agent string, chief bool) string {
 	return strings.TrimSpace(d.store.GetSetting(SettingChiefModelPrefix + strings.ToLower(strings.TrimSpace(agent))))
 }
 
+// chiefLaunchEffort returns the configured reasoning effort for a
+// chief-of-staff launch of the given agent (from chief_effort_<agent>), or
+// "" — the agent's own default — when this is not a chief launch or no
+// effort is configured.
+func (d *Daemon) chiefLaunchEffort(agent string, chief bool) string {
+	if !chief {
+		return ""
+	}
+	return strings.TrimSpace(d.store.GetSetting(SettingChiefEffortPrefix + strings.ToLower(strings.TrimSpace(agent))))
+}
+
 // chiefContextWindowCap returns the effective context-window token cap for a
 // chief-of-staff launch, or 0 (no cap) when this is not a chief launch. Mirrors
 // chiefLaunchModel: the policy (what the cap is, and that only the chief gets
@@ -365,6 +382,12 @@ func (d *Daemon) validateSetting(key, value string) error {
 		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingChiefModelPrefix) {
 			// Model names/aliases are free-form (like the reviewer_model
 			// setting); accept any value and let the agent reject bad ones.
+			return nil
+		}
+		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(key)), SettingChiefEffortPrefix) {
+			// Effort levels are agent-native (claude: low/medium/high/xhigh/max,
+			// codex: minimal/low/medium/high/xhigh); accept any value and let
+			// the agent reject bad ones. The UI constrains input.
 			return nil
 		}
 		if _, ok := isAgentExecutableSettingKey(key); ok {


### PR DESCRIPTION
## Summary

- **`chief_effort_<agent>` setting** — the effort analog of `chief_model_<agent>`. A chief-of-staff launch with no per-spawn pin falls back to it; delegation `--effort` pins (PR #448) still win. Passed through the agent's native mechanism (Claude `--effort`, Codex `model_reasoning_effort`). No protocol change: settings ride the generic key/value map and the spawn message already carries `effort`.
- **Settings UI** — the "Chief-of-staff model" section becomes "Chief-of-staff model & effort", with a per-agent effort `<select>` (Claude: low/medium/high/xhigh/max; Codex: minimal/low/medium/high/xhigh; first option "Agent default") committing immediately on change. The keep-row-visible rule now fires on either saved override.
- **Harness: `settings_get_state` / `settings_select_section` bridge actions** — the Settings modal was not drivable by the UI-automation bridge (openable only), which blocked live verification of specific sections. SettingsModal now publishes a module-level automation handle (same pattern as grid automation); `settings_select_section` reuses the exact nav-click code path and re-reads the handle after settling (the modal re-registers it every render, so a captured handle reports pre-selection state — covered by a regression test).

## Testing

- `go test ./internal/daemon` (full package) — new `TestDaemon_ChiefLaunchEffort` + validator cases.
- `pnpm exec vitest run src/components/SettingsModal.test.tsx` — 44 tests incl. 3 effort-UI tests and 6 automation-handle tests; `tsc --noEmit` clean.
- **Live on the dev profile**: set `chief_effort_claude=high` over the daemon WS and spawned a chief session — the real claude process launched with `--effort high`; non-chief spawns unaffected. Drove the packaged app via the new bridge actions: opened Settings, selected the Agents section, DOM-screenshot confirmed the new effort selects render; unknown section ids are rejected with the valid-id list.