### PR TITLE
feat(harness): machine-parseable ATTN_VERDICT line from runner and serial matrix

### DIFF
--- a/app/scripts/real-app-harness/AGENTS.md
+++ b/app/scripts/real-app-harness/AGENTS.md
@@ -22,6 +22,31 @@ re-derive them. dev/prod are fast-path literals that a drift guard in
 needs `./attn` built (`make dev` / `go build -o ./attn ./cmd/attn`); override the
 binary with `ATTN_HARNESS_BIN`.
 
+## Verdict Line
+
+Every scenario built on `createScenarioRunner` (`scenarioRunner.mjs`), and
+`run-serial-matrix.mjs`, print a single machine-parseable verdict line as the
+last thing they emit on that path, so a driving agent can learn pass/fail
+without spelunking through step logs or JSON summaries.
+
+- Format: `ATTN_VERDICT ` followed by compact (non-pretty-printed) JSON, all on
+  one line. `formatVerdictLine`/`emitVerdict` in `common.mjs` are the only
+  producers — use them instead of hand-rolling the line.
+- Shape: `{ ok, scenarioId, runId, failureCount, firstFailure, artifactsDir, summaryPath, durationMs }`.
+  - `firstFailure` is `null` on success, otherwise the first line of the error
+    message, capped at 300 characters (never multi-line, so it cannot break
+    the one-line contract).
+  - `run-serial-matrix.mjs` emits the same shape with `scenarioId: 'serial-matrix'`,
+    `runId: ''`, `artifactsDir: ''`, and `summaryPath: ''` (it aggregates many
+    runs, each of which already printed its own verdict line).
+- Consumers must take the **last** line starting with `ATTN_VERDICT `, not the
+  first — a scenario's own trace/log output can print other lines afterward
+  in rare cases, but the verdict line itself is written right after the
+  summary/failure JSON file, so it stays reliably last among `ATTN_VERDICT`
+  lines.
+- Out of scope: the older ad-hoc scenarios with hand-rolled `main()` that do
+  not use `createScenarioRunner` do not emit a verdict line.
+
 ## Real-App Parity
 
 - Scenarios must match real app usage. Do not invent command sequences that the app cannot perform.

--- a/app/scripts/real-app-harness/common.mjs
+++ b/app/scripts/real-app-harness/common.mjs
@@ -89,6 +89,20 @@ Options:
 `);
 }
 
+// Contract: a driving agent greps stdout for the LAST line starting with the
+// `ATTN_VERDICT ` prefix and JSON.parses the remainder. Keep the payload on a
+// single line (compact JSON; no pretty-print) and free of embedded newlines so
+// naive line-oriented parsing never splits it.
+export const ATTN_VERDICT_PREFIX = 'ATTN_VERDICT ';
+
+export function formatVerdictLine(verdict) {
+  return `${ATTN_VERDICT_PREFIX}${JSON.stringify(verdict)}`;
+}
+
+export function emitVerdict(verdict) {
+  console.log(formatVerdictLine(verdict));
+}
+
 export function ensureDir(dirPath) {
   fs.mkdirSync(dirPath, { recursive: true });
 }

--- a/app/scripts/real-app-harness/run-serial-matrix.mjs
+++ b/app/scripts/real-app-harness/run-serial-matrix.mjs
@@ -2,6 +2,7 @@
 
 import { spawn } from 'node:child_process';
 import { assertPackagedAppBuildMatchesCurrentSource } from './buildPreflight.mjs';
+import { emitVerdict } from './common.mjs';
 import {
   assertProductionRunAllowed,
   defaultAppPathForProfile,
@@ -324,6 +325,7 @@ function runScenario(scenario, timeoutMs, runAgainstProd) {
 }
 
 async function main() {
+  const matrixStartedAt = Date.now();
   const { help, selected, failFast, timeoutMs, runAgainstProd } = parseArgs(process.argv.slice(2));
   if (help) {
     printHelp();
@@ -372,6 +374,16 @@ async function main() {
     results,
   };
   console.log(`\nSerial matrix summary:\n${JSON.stringify(summary, null, 2)}`);
+  emitVerdict({
+    ok: failed.length === 0,
+    scenarioId: 'serial-matrix',
+    runId: '',
+    failureCount: failed.length,
+    firstFailure: failed.length ? `${failed[0].id} exit ${failed[0].code}` : null,
+    artifactsDir: '',
+    summaryPath: '',
+    durationMs: Date.now() - matrixStartedAt,
+  });
   if (failed.length > 0) {
     process.exitCode = 1;
   }

--- a/app/scripts/real-app-harness/scenarioRunner.mjs
+++ b/app/scripts/real-app-harness/scenarioRunner.mjs
@@ -2,7 +2,25 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { assertPackagedAppBuildMatchesCurrentSource } from './buildPreflight.mjs';
-import { createRunContext } from './common.mjs';
+import { createRunContext, emitVerdict } from './common.mjs';
+
+const FIRST_FAILURE_MAX_LENGTH = 300;
+
+// Collapse to a single line and cap length so the verdict's firstFailure field
+// can never break the one-line ATTN_VERDICT contract regardless of what the
+// underlying error message contains. Exported for direct unit testing (see
+// verdict.test.mjs) — createScenarioRunner itself has filesystem/lock side
+// effects that make it a poor unit-test surface.
+export function summarizeFirstFailure(error) {
+  // Use the raw message (not normalizeError's stack trace) so firstFailure is
+  // the human-readable "what failed", not file/line noise from the stack.
+  const message = error instanceof Error ? error.message : String(error);
+  const firstLine = message.split(/\r?\n/, 1)[0];
+  if (firstLine.length <= FIRST_FAILURE_MAX_LENGTH) {
+    return firstLine;
+  }
+  return firstLine.slice(0, FIRST_FAILURE_MAX_LENGTH);
+}
 
 function writeJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
@@ -117,6 +135,7 @@ export function createScenarioRunner(options, {
   metadata = {},
   preflightLaunchEnv = null,
 } = {}) {
+  const runnerCreatedAt = Date.now();
   assertPackagedAppBuildMatchesCurrentSource({
     appPath: options?.appPath,
     launchEnv: preflightLaunchEnv,
@@ -313,7 +332,18 @@ export function createScenarioRunner(options, {
         assertions,
         ...summary,
       };
-      writeJson(path.join(runDir, 'summary.json'), finalSummary);
+      const summaryPath = path.join(runDir, 'summary.json');
+      writeJson(summaryPath, finalSummary);
+      emitVerdict({
+        ok: true,
+        scenarioId,
+        runId,
+        failureCount: 0,
+        firstFailure: null,
+        artifactsDir: runDir,
+        summaryPath,
+        durationMs: Date.now() - runnerCreatedAt,
+      });
       finalizeRunner();
       return finalSummary;
     },
@@ -331,7 +361,18 @@ export function createScenarioRunner(options, {
         error: normalizeError(error),
         ...summary,
       };
-      writeJson(path.join(runDir, 'failure.json'), finalSummary);
+      const summaryPath = path.join(runDir, 'failure.json');
+      writeJson(summaryPath, finalSummary);
+      emitVerdict({
+        ok: false,
+        scenarioId,
+        runId,
+        failureCount: 1,
+        firstFailure: summarizeFirstFailure(error),
+        artifactsDir: runDir,
+        summaryPath,
+        durationMs: Date.now() - runnerCreatedAt,
+      });
       finalizeRunner();
       return finalSummary;
     },

--- a/app/scripts/real-app-harness/verdict.test.mjs
+++ b/app/scripts/real-app-harness/verdict.test.mjs
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { ATTN_VERDICT_PREFIX, formatVerdictLine } from './common.mjs';
+import { summarizeFirstFailure } from './scenarioRunner.mjs';
+
+const baseVerdict = {
+  ok: true,
+  scenarioId: 'demo-scenario',
+  runId: 'demo-scenario-2026-01-01T00-00-00-000Z',
+  failureCount: 0,
+  firstFailure: null,
+  artifactsDir: '/tmp/attn-real-app-harness/demo-scenario-run',
+  summaryPath: '/tmp/attn-real-app-harness/demo-scenario-run/summary.json',
+  durationMs: 1234,
+};
+
+describe('formatVerdictLine', () => {
+  it('prefixes the line with ATTN_VERDICT and a space', () => {
+    const line = formatVerdictLine(baseVerdict);
+
+    expect(line.startsWith(ATTN_VERDICT_PREFIX)).toBe(true);
+  });
+
+  it('emits compact (non-pretty-printed) JSON after the prefix', () => {
+    const line = formatVerdictLine(baseVerdict);
+    const payload = line.slice(ATTN_VERDICT_PREFIX.length);
+
+    expect(payload).toBe(JSON.stringify(baseVerdict));
+    expect(payload).not.toMatch(/\n/);
+    expect(JSON.parse(payload)).toEqual(baseVerdict);
+  });
+
+  it('preserves every contract key on a failing verdict', () => {
+    const failingVerdict = {
+      ...baseVerdict,
+      ok: false,
+      failureCount: 1,
+      firstFailure: 'assertion failed: expected pane visible',
+    };
+
+    const line = formatVerdictLine(failingVerdict);
+    const parsed = JSON.parse(line.slice(ATTN_VERDICT_PREFIX.length));
+
+    expect(parsed).toEqual(failingVerdict);
+  });
+
+  it('stays a single line even when firstFailure contains embedded newlines', () => {
+    const verdictWithNewlines = {
+      ...baseVerdict,
+      ok: false,
+      failureCount: 1,
+      firstFailure: 'first line of error\nsecond line\nthird line',
+    };
+
+    const line = formatVerdictLine(verdictWithNewlines);
+
+    // JSON.stringify escapes newlines as the two-character sequence `\n`
+    // rather than a literal line break, so the produced line has no raw
+    // newline characters in it — verify that invariant directly rather than
+    // just re-parsing the JSON.
+    expect(line.split('\n')).toHaveLength(1);
+    expect(line).toContain('first line of error\\nsecond line\\nthird line');
+  });
+
+  it('stays a single line even when firstFailure contains embedded quotes', () => {
+    const verdictWithQuotes = {
+      ...baseVerdict,
+      ok: false,
+      failureCount: 1,
+      firstFailure: 'expected "visible" but got "hidden"',
+    };
+
+    const line = formatVerdictLine(verdictWithQuotes);
+    const parsed = JSON.parse(line.slice(ATTN_VERDICT_PREFIX.length));
+
+    expect(line.split('\n')).toHaveLength(1);
+    expect(parsed.firstFailure).toBe('expected "visible" but got "hidden"');
+  });
+});
+
+describe('summarizeFirstFailure', () => {
+  it('keeps a short single-line message intact', () => {
+    const error = new Error('pane not visible');
+
+    expect(summarizeFirstFailure(error)).toBe('pane not visible');
+  });
+
+  it('takes only the first line of a multi-line error message', () => {
+    const error = new Error('assertion failed: pane not visible\n    at step (scenario.mjs:42)');
+
+    expect(summarizeFirstFailure(error)).toBe('assertion failed: pane not visible');
+  });
+
+  it('truncates a message longer than 300 characters to exactly 300', () => {
+    const longMessage = 'x'.repeat(400);
+    const error = new Error(longMessage);
+
+    const result = summarizeFirstFailure(error);
+
+    expect(result).toHaveLength(300);
+    expect(result).toBe('x'.repeat(300));
+  });
+
+  it('handles non-Error values via String()', () => {
+    expect(summarizeFirstFailure('plain string failure')).toBe('plain string failure');
+  });
+});


### PR DESCRIPTION
## What

Every real-app harness scenario built on `createScenarioRunner`, plus `run-serial-matrix.mjs`, now ends stdout with a single machine-parseable line:

```
ATTN_VERDICT {"ok":false,"scenarioId":"tr401-local-window-resize","runId":"...","failureCount":1,"firstFailure":"assertion failed: ...","artifactsDir":"...","summaryPath":".../failure.json","durationMs":48211}
```

A driving agent learns pass/fail, the first failure, and where the artifacts live from one line instead of 3-4 follow-up spelunking round trips per harness iteration. Contract documented in `app/scripts/real-app-harness/AGENTS.md` (consumers take the LAST matching line).

Item 1 of the agent-cost-tooling ticket; the soak runner (item 2) builds on this line as its aggregation input.

## Scope notes

- Older ad-hoc scenarios (hand-rolled `main()`, no shared runner) intentionally don't emit the line — converting them is a separate mechanical change if it proves worth it.
- `firstFailure` is the first line of `error.message`, capped at 300 chars, so the one-line contract can't break.

## Testing

- Unit: `verdict.test.mjs` covers line format, escaping (newlines/quotes), truncation. `pnpm --dir app test`: 1250 passed / 5 pre-existing skips.
- Live-app verification: pending — will run a runner-based packaged-app scenario against a dev install and post the observed verdict line here before merge.

🤖 Generated with Claude Code on behalf of Victor