### PR TITLE
feat(harness): crop/scale options for native window capture

### DIFF
--- a/app/scripts/real-app-harness/AGENTS.md
+++ b/app/scripts/real-app-harness/AGENTS.md
@@ -29,6 +29,16 @@ binary with `ATTN_HARNESS_BIN`.
 - If these scenarios pass while users can reproduce workspace/session errors in the packaged app, treat that as a test design bug.
 - Real-app commands target the dev sibling (or the active `ATTN_PROFILE`) by default. Production runs must pass `--run-against-prod`; never bypass the shared production-target guard.
 
+## Screenshot Crop / Scale
+
+`captureFrontWindowScreenshot` (and `capture-app-screenshot.mjs`'s `--crop`/`--max-dim`
+flags) can crop to a window-relative region and downscale the PNG at capture time via
+`sips -Z`, so an agent that actually looks at the image pays far fewer tokens. `--crop`
+accepts `x,y,WxH` (e.g. `0,0,800x600`) or the all-comma `x,y,w,h` form; a crop is clamped
+to the window's bounds and only throws if it does not overlap the window at all. Prefer
+these over capturing full-resolution, full-window screenshots when only a sub-region
+matters for the assertion.
+
 ## Workspace Sessions
 
 - A visible pane is a session pane. Do not model durable non-session terminals.

--- a/app/scripts/real-app-harness/capture-app-screenshot.mjs
+++ b/app/scripts/real-app-harness/capture-app-screenshot.mjs
@@ -10,14 +10,53 @@ Options:
   --path <file>      Save a native macOS window screenshot to an explicit path
   --launch           Launch the selected packaged app before capturing
   --fresh-launch     Quit and relaunch the selected packaged app before capturing
+  --crop x,y,WxH     Crop to a window-relative region (also accepts x,y,w,h)
+  --max-dim N        Downscale the PNG in place if its larger side exceeds N px
   --run-against-prod Explicitly allow targeting the production app
   --help, -h         Show this help
 
 Examples:
   node scripts/real-app-harness/capture-app-screenshot.mjs
   node scripts/real-app-harness/capture-app-screenshot.mjs --path /tmp/attn.png
+  node scripts/real-app-harness/capture-app-screenshot.mjs --crop 0,0,800x600 --max-dim 1024
   make app-screenshot SCREENSHOT_PATH=/tmp/attn.png
 `);
+}
+
+// Parses a crop spec string into a window-relative {x, y, width, height} rect.
+// Accepts "x,y,WxH" (e.g. "0,0,800x600") and the all-comma form "x,y,w,h".
+export function parseCropSpec(str) {
+  if (typeof str !== 'string' || str.trim() === '') {
+    throw new Error(`Invalid --crop value: ${JSON.stringify(str)}`);
+  }
+
+  const parts = str.split(',').map((value) => value.trim());
+  let x;
+  let y;
+  let width;
+  let height;
+
+  if (parts.length === 3) {
+    const [xPart, yPart, sizePart] = parts;
+    const sizeMatch = /^(\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)$/.exec(sizePart || '');
+    if (!sizeMatch) {
+      throw new Error(`Invalid --crop value: ${JSON.stringify(str)}`);
+    }
+    x = Number(xPart);
+    y = Number(yPart);
+    width = Number(sizeMatch[1]);
+    height = Number(sizeMatch[2]);
+  } else if (parts.length === 4) {
+    [x, y, width, height] = parts.map(Number);
+  } else {
+    throw new Error(`Invalid --crop value: ${JSON.stringify(str)}`);
+  }
+
+  if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) {
+    throw new Error(`Invalid --crop value: ${JSON.stringify(str)}`);
+  }
+
+  return { x, y, width, height };
 }
 
 async function main() {
@@ -25,6 +64,8 @@ async function main() {
   let launch = false;
   let freshLaunch = false;
   let outputPath = '';
+  let crop = null;
+  let maxDim = null;
 
   while (args.length > 0) {
     const arg = args.shift();
@@ -47,6 +88,22 @@ async function main() {
       }
       continue;
     }
+    if (arg === '--crop') {
+      const value = args.shift() || '';
+      if (!value) {
+        throw new Error('--crop requires a value');
+      }
+      crop = parseCropSpec(value);
+      continue;
+    }
+    if (arg === '--max-dim') {
+      const value = args.shift() || '';
+      if (!value || !/^\d+$/.test(value)) {
+        throw new Error('--max-dim requires a positive integer value');
+      }
+      maxDim = Number.parseInt(value, 10);
+      continue;
+    }
     if (arg === '--help' || arg === '-h') {
       printHelp();
       return;
@@ -65,7 +122,7 @@ async function main() {
   await client.waitForFrontendResponsive(20_000);
 
   const targetPath = outputPath || '/tmp/attn-app-window.png';
-  const result = await captureFrontWindowScreenshot(targetPath, { client });
+  const result = await captureFrontWindowScreenshot(targetPath, { client, crop, maxDim });
   console.log(JSON.stringify(result, null, 2));
 }
 

--- a/app/scripts/real-app-harness/nativeWindowCapture.mjs
+++ b/app/scripts/real-app-harness/nativeWindowCapture.mjs
@@ -222,23 +222,90 @@ export async function setFrontWindowBounds(targetBounds, options = {}) {
   );
 }
 
+// Resolves the absolute screencapture rect for a window, optionally cropped
+// to a window-relative sub-rect. `crop` coordinates are relative to the
+// window's top-left corner. The crop is clamped to the window's bounds; a
+// crop rect that does not overlap the window at all throws.
+export function resolveCaptureRect(windowBounds, crop = null) {
+  if (!windowBounds) {
+    throw new Error('resolveCaptureRect requires windowBounds');
+  }
+  if (!crop) {
+    return {
+      x: windowBounds.x,
+      y: windowBounds.y,
+      width: windowBounds.width,
+      height: windowBounds.height,
+    };
+  }
+
+  const cropX = Number(crop.x);
+  const cropY = Number(crop.y);
+  const cropWidth = Number(crop.width);
+  const cropHeight = Number(crop.height);
+  if (![cropX, cropY, cropWidth, cropHeight].every(Number.isFinite) || cropWidth <= 0 || cropHeight <= 0) {
+    throw new Error(`Invalid crop rect: ${JSON.stringify(crop)}`);
+  }
+
+  const windowRight = windowBounds.width;
+  const windowBottom = windowBounds.height;
+  const cropRight = cropX + cropWidth;
+  const cropBottom = cropY + cropHeight;
+
+  const clampedLeft = Math.max(0, Math.min(cropX, windowRight));
+  const clampedTop = Math.max(0, Math.min(cropY, windowBottom));
+  const clampedRight = Math.max(0, Math.min(cropRight, windowRight));
+  const clampedBottom = Math.max(0, Math.min(cropBottom, windowBottom));
+
+  const clampedWidth = clampedRight - clampedLeft;
+  const clampedHeight = clampedBottom - clampedTop;
+
+  if (clampedWidth <= 0 || clampedHeight <= 0) {
+    throw new Error(
+      `Crop rect ${JSON.stringify(crop)} does not overlap window bounds ${JSON.stringify(windowBounds)}`,
+    );
+  }
+
+  return {
+    x: windowBounds.x + clampedLeft,
+    y: windowBounds.y + clampedTop,
+    width: clampedWidth,
+    height: clampedHeight,
+  };
+}
+
 export async function captureFrontWindowScreenshot(outputPath, options = {}) {
   const bundleId = options.bundleId || options.client?.bundleId || bundleIdentifierForProfile();
   assertProductionRunAllowed({ bundleId });
   const bounds = await getFrontWindowBounds(bundleId, options);
+  const captureRect = resolveCaptureRect(bounds, options.crop || null);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   await execFileAsync('/usr/sbin/screencapture', [
     '-x',
     '-R',
-    `${bounds.x},${bounds.y},${bounds.width},${bounds.height}`,
+    `${captureRect.x},${captureRect.y},${captureRect.width},${captureRect.height}`,
     outputPath,
   ], {
     timeout: 10_000,
   });
+
+  if (options.maxDim !== undefined && options.maxDim !== null) {
+    const maxDim = options.maxDim;
+    if (!Number.isInteger(maxDim) || maxDim <= 0) {
+      throw new Error(`Invalid maxDim: ${JSON.stringify(options.maxDim)}`);
+    }
+    if (Math.max(captureRect.width, captureRect.height) > maxDim) {
+      await execFileAsync('/usr/bin/sips', ['-Z', String(maxDim), outputPath], {
+        timeout: 10_000,
+      });
+    }
+  }
+
   return {
     source: 'native_window',
     bundleId,
     bounds,
+    captureRect,
     path: outputPath,
   };
 }

--- a/app/scripts/real-app-harness/nativeWindowCapture.mjs
+++ b/app/scripts/real-app-harness/nativeWindowCapture.mjs
@@ -274,6 +274,31 @@ export function resolveCaptureRect(windowBounds, crop = null) {
   };
 }
 
+// Parses `sips -g pixelWidth -g pixelHeight <path>` output into pixel
+// dimensions. Sips prints the file path on the first line, then one
+// "  pixelWidth: N" / "  pixelHeight: N" line per queried property.
+export function parseSipsPixelDimensions(stdout) {
+  const text = String(stdout || '');
+  const widthMatch = /pixelWidth:\s*(\d+)/.exec(text);
+  const heightMatch = /pixelHeight:\s*(\d+)/.exec(text);
+  if (!widthMatch || !heightMatch) {
+    throw new Error(`Failed to parse sips pixel dimensions from output: ${stdout}`);
+  }
+  return {
+    width: Number.parseInt(widthMatch[1], 10),
+    height: Number.parseInt(heightMatch[1], 10),
+  };
+}
+
+async function readPngPixelDimensions(filePath) {
+  const { stdout } = await execFileAsync(
+    '/usr/bin/sips',
+    ['-g', 'pixelWidth', '-g', 'pixelHeight', filePath],
+    { timeout: 10_000 },
+  );
+  return parseSipsPixelDimensions(stdout);
+}
+
 export async function captureFrontWindowScreenshot(outputPath, options = {}) {
   const bundleId = options.bundleId || options.client?.bundleId || bundleIdentifierForProfile();
   assertProductionRunAllowed({ bundleId });
@@ -289,15 +314,20 @@ export async function captureFrontWindowScreenshot(outputPath, options = {}) {
     timeout: 10_000,
   });
 
+  let pixelDimensions = null;
   if (options.maxDim !== undefined && options.maxDim !== null) {
     const maxDim = options.maxDim;
     if (!Number.isInteger(maxDim) || maxDim <= 0) {
       throw new Error(`Invalid maxDim: ${JSON.stringify(options.maxDim)}`);
     }
-    if (Math.max(captureRect.width, captureRect.height) > maxDim) {
+    // captureRect is in logical points; on Retina displays screencapture
+    // writes the PNG at 2x pixels, so gate on the file's actual dimensions.
+    pixelDimensions = await readPngPixelDimensions(outputPath);
+    if (Math.max(pixelDimensions.width, pixelDimensions.height) > maxDim) {
       await execFileAsync('/usr/bin/sips', ['-Z', String(maxDim), outputPath], {
         timeout: 10_000,
       });
+      pixelDimensions = await readPngPixelDimensions(outputPath);
     }
   }
 
@@ -306,6 +336,7 @@ export async function captureFrontWindowScreenshot(outputPath, options = {}) {
     bundleId,
     bounds,
     captureRect,
+    ...(pixelDimensions ? { pixelDimensions } : {}),
     path: outputPath,
   };
 }

--- a/app/scripts/real-app-harness/nativeWindowCapture.test.mjs
+++ b/app/scripts/real-app-harness/nativeWindowCapture.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveCaptureRect } from './nativeWindowCapture.mjs';
+import { parseSipsPixelDimensions, resolveCaptureRect } from './nativeWindowCapture.mjs';
 import { parseCropSpec } from './capture-app-screenshot.mjs';
 
 describe('resolveCaptureRect', () => {
@@ -80,5 +80,33 @@ describe('parseCropSpec', () => {
     expect(() => parseCropSpec('0,0,0x0')).toThrow(/Invalid --crop value/);
     expect(() => parseCropSpec('0,0,800xabc')).toThrow(/Invalid --crop value/);
     expect(() => parseCropSpec('')).toThrow(/Invalid --crop value/);
+  });
+});
+
+describe('parseSipsPixelDimensions', () => {
+  it('parses realistic sips -g pixelWidth -g pixelHeight output', () => {
+    const stdout = `/tmp/attn-app-window.png
+  pixelWidth: 3200
+  pixelHeight: 2400
+`;
+    expect(parseSipsPixelDimensions(stdout)).toEqual({ width: 3200, height: 2400 });
+  });
+
+  it('parses output regardless of property order', () => {
+    const stdout = `/tmp/shot.png
+  pixelHeight: 100
+  pixelWidth: 200
+`;
+    expect(parseSipsPixelDimensions(stdout)).toEqual({ width: 200, height: 100 });
+  });
+
+  it('throws on garbage output', () => {
+    expect(() => parseSipsPixelDimensions('sips: error')).toThrow(
+      /Failed to parse sips pixel dimensions/,
+    );
+    expect(() => parseSipsPixelDimensions('')).toThrow(/Failed to parse sips pixel dimensions/);
+    expect(() => parseSipsPixelDimensions('  pixelWidth: 3200\n')).toThrow(
+      /Failed to parse sips pixel dimensions/,
+    );
   });
 });

--- a/app/scripts/real-app-harness/nativeWindowCapture.test.mjs
+++ b/app/scripts/real-app-harness/nativeWindowCapture.test.mjs
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCaptureRect } from './nativeWindowCapture.mjs';
+import { parseCropSpec } from './capture-app-screenshot.mjs';
+
+describe('resolveCaptureRect', () => {
+  const windowBounds = { x: 100, y: 200, width: 800, height: 600 };
+
+  it('returns the full window rect when no crop is given', () => {
+    expect(resolveCaptureRect(windowBounds, null)).toEqual({
+      x: 100,
+      y: 200,
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it('offsets a fully-contained crop by the window origin', () => {
+    expect(resolveCaptureRect(windowBounds, { x: 10, y: 20, width: 300, height: 150 })).toEqual({
+      x: 110,
+      y: 220,
+      width: 300,
+      height: 150,
+    });
+  });
+
+  it('clamps a crop that spills past the right/bottom edge', () => {
+    expect(resolveCaptureRect(windowBounds, { x: 700, y: 500, width: 300, height: 300 })).toEqual({
+      x: 800,
+      y: 700,
+      width: 100,
+      height: 100,
+    });
+  });
+
+  it('clamps a crop that starts before the window origin', () => {
+    expect(resolveCaptureRect(windowBounds, { x: -50, y: -50, width: 100, height: 100 })).toEqual({
+      x: 100,
+      y: 200,
+      width: 50,
+      height: 50,
+    });
+  });
+
+  it('throws when the crop rect does not overlap the window at all', () => {
+    expect(() =>
+      resolveCaptureRect(windowBounds, { x: 1000, y: 1000, width: 50, height: 50 }),
+    ).toThrow(/does not overlap/);
+  });
+
+  it('throws on a non-finite or non-positive crop rect', () => {
+    expect(() => resolveCaptureRect(windowBounds, { x: 0, y: 0, width: 0, height: 10 })).toThrow(
+      /Invalid crop rect/,
+    );
+    expect(() =>
+      resolveCaptureRect(windowBounds, { x: 'a', y: 0, width: 10, height: 10 }),
+    ).toThrow(/Invalid crop rect/);
+  });
+
+  it('throws when windowBounds is missing', () => {
+    expect(() => resolveCaptureRect(null, null)).toThrow('resolveCaptureRect requires windowBounds');
+  });
+});
+
+describe('parseCropSpec', () => {
+  it('parses the "x,y,WxH" form', () => {
+    expect(parseCropSpec('0,0,800x600')).toEqual({ x: 0, y: 0, width: 800, height: 600 });
+  });
+
+  it('parses the "x,y,w,h" all-comma form', () => {
+    expect(parseCropSpec('10,20,300,150')).toEqual({ x: 10, y: 20, width: 300, height: 150 });
+  });
+
+  it('parses negative offsets', () => {
+    expect(parseCropSpec('-10,-20,300x150')).toEqual({ x: -10, y: -20, width: 300, height: 150 });
+  });
+
+  it('rejects garbage input', () => {
+    expect(() => parseCropSpec('not-a-crop')).toThrow(/Invalid --crop value/);
+    expect(() => parseCropSpec('0,0')).toThrow(/Invalid --crop value/);
+    expect(() => parseCropSpec('0,0,0x0')).toThrow(/Invalid --crop value/);
+    expect(() => parseCropSpec('0,0,800xabc')).toThrow(/Invalid --crop value/);
+    expect(() => parseCropSpec('')).toThrow(/Invalid --crop value/);
+  });
+});


### PR DESCRIPTION
## What

`captureFrontWindowScreenshot` (and the `capture-app-screenshot.mjs` CLI) can now crop to a window-relative region (`--crop x,y,WxH` or `x,y,w,h`) and downscale in place (`--max-dim N`, via `sips -Z`), so when a driving agent does look at a screenshot it pays ~4× fewer image tokens.

Item 6 of the agent-cost-tooling ticket.

## Notes

- Crop rects are clamped to the window; only a fully-non-overlapping crop throws.
- `--max-dim` gates on the PNG's **actual pixel dimensions** (measured via `sips -g`), not logical points — on Retina the file is 2× the capture rect, and gating on points would make the flag a no-op.
- Default behavior with neither flag is unchanged (same `screencapture` invocation, no `sips` calls); the result object gains an additive `captureRect` (+ `pixelDimensions` when measured).
- An `attn shot` Go-side helper was descoped: the harness flags cover the workflow, and scenarios/agents already reach capture through these scripts.

## Testing

- Unit: `nativeWindowCapture.test.mjs` — `resolveCaptureRect` offset/clamp/no-overlap, `parseCropSpec` both forms + garbage, `parseSipsPixelDimensions`. Harness suite: 57 passed / 5 pre-existing skips.
- Live-app verification: pending — will capture against a dev install with and without `--crop`/`--max-dim` and post measured file dimensions here before merge.

🤖 Generated with Claude Code on behalf of Victor