### PR TITLE
feat(cli): attn vision-check — single tool-less LLM call over an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-04]
 
 ### Added
+- **`attn vision-check <image> <question>` CLI command.** Answers a question about a screenshot or image with a single, tool-less LLM call, so an agent can ask about an image without pulling it into its own context.
 - **Pin the chief-of-staff's reasoning effort, per agent.** Settings → Agents → "Chief-of-staff model & effort" now has an effort selector next to each agent's model override (Claude: low, medium, high, xhigh, max; Codex: minimal, low, medium, high, xhigh). Leave it on "Agent default" to use the agent's own default. Only chief-of-staff launches are affected — regular sessions are unaffected.
 
 ## [2026-07-03]

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -252,6 +252,10 @@ func main() {
 	case "ticket":
 		maybePrintProfileBanner()
 		runTicket()
+	case "vision-check":
+		// No banner: output must stay pure (stdout = answer only, or a single
+		// --json line) for machine consumption by the calling agent.
+		runVisionCheck()
 	case "present":
 		maybePrintProfileBanner()
 		runPresent()
@@ -566,6 +570,7 @@ commands:
   workflow <command>                run, inspect, and resume durable workflows
   list                              list sessions and workspaces
   present <command>                 open a review presentation and read feedback
+  vision-check <image> <question>   answer a question about an image (single LLM call)
   daemon <command>                  manage the daemon
   profile <status|resolve|list>     show / resolve the active profile's resources
   profile-env <profile|--unset>     print shell commands for selecting a profile

--- a/cmd/attn/vision_check.go
+++ b/cmd/attn/vision_check.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// maxVisionCheckBase64Bytes bounds the size of the base64-encoded image payload
+// sent to the claude CLI. Past this size, prompt captures with --crop/--max-dim
+// are a better fix than raising the limit.
+const maxVisionCheckBase64Bytes = 4_500_000
+
+// visionCheckResult is the parsed shape of the final `result` stream-json event
+// emitted by `claude -p --output-format stream-json`.
+type visionCheckResult struct {
+	Result      string  `json:"result"`
+	Subtype     string  `json:"subtype"`
+	IsError     bool    `json:"is_error"`
+	TotalCostUS float64 `json:"total_cost_usd"`
+	NumTurns    int     `json:"num_turns"`
+}
+
+// visionCheckJSONOutput is the --json stdout shape.
+type visionCheckJSONOutput struct {
+	Answer   string  `json:"answer"`
+	Model    string  `json:"model"`
+	CostUSD  float64 `json:"cost_usd"`
+	NumTurns int     `json:"num_turns"`
+	IsError  bool    `json:"is_error"`
+}
+
+// mediaTypeForPath maps an image file extension to its MIME media type, as
+// required by the claude CLI's image content block.
+func mediaTypeForPath(path string) (string, error) {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png":
+		return "image/png", nil
+	case ".jpg", ".jpeg":
+		return "image/jpeg", nil
+	case ".gif":
+		return "image/gif", nil
+	case ".webp":
+		return "image/webp", nil
+	default:
+		return "", fmt.Errorf("unsupported image extension %q (supported: .png, .jpg, .jpeg, .gif, .webp)", filepath.Ext(path))
+	}
+}
+
+// buildVisionCheckMessage builds the single stream-json stdin line sent to
+// `claude -p --input-format stream-json`: one user message with a text block
+// (the question) followed by an image block (base64-encoded).
+func buildVisionCheckMessage(question, mediaType, base64Data string) (string, error) {
+	msg := map[string]interface{}{
+		"type": "user",
+		"message": map[string]interface{}{
+			"role": "user",
+			"content": []map[string]interface{}{
+				{
+					"type": "text",
+					"text": question,
+				},
+				{
+					"type": "image",
+					"source": map[string]interface{}{
+						"type":       "base64",
+						"media_type": mediaType,
+						"data":       base64Data,
+					},
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// parseVisionCheckResult scans claude's stream-json stdout for the last line
+// whose "type" is "result" and decodes it. Lines are read via a bufio.Reader
+// (not bufio.Scanner) because assistant/tool lines carrying large payloads can
+// exceed Scanner's default token size.
+func parseVisionCheckResult(stdout string) (*visionCheckResult, error) {
+	reader := bufio.NewReader(strings.NewReader(stdout))
+	var last *visionCheckResult
+	for {
+		line, readErr := reader.ReadString('\n')
+		line = strings.TrimSpace(line)
+		if line != "" {
+			var envelope struct {
+				Type string `json:"type"`
+			}
+			if err := json.Unmarshal([]byte(line), &envelope); err == nil && envelope.Type == "result" {
+				var r visionCheckResult
+				if err := json.Unmarshal([]byte(line), &r); err == nil {
+					last = &r
+				}
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return nil, readErr
+		}
+	}
+	if last == nil {
+		return nil, fmt.Errorf("no result event found in claude output")
+	}
+	return last, nil
+}
+
+// resolveClaudeBinary locates the claude CLI, checking PATH first and then a
+// couple of common install locations that may not be on PATH for a
+// non-interactive shell.
+func resolveClaudeBinary() (string, error) {
+	if p, err := exec.LookPath("claude"); err == nil {
+		return p, nil
+	}
+	home, _ := os.UserHomeDir()
+	if home != "" {
+		for _, candidate := range []string{
+			filepath.Join(home, ".npm-global", "bin", "claude"),
+			filepath.Join(home, ".local", "bin", "claude"),
+		} {
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				return candidate, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("claude CLI not found on PATH, ~/.npm-global/bin, or ~/.local/bin")
+}
+
+func parseVisionCheckArgs(args []string) (image, question, model string, timeout time.Duration, jsonOut bool, err error) {
+	fs := flag.NewFlagSet("vision-check", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	modelFlag := fs.String("model", "sonnet", "model to use for the vision check")
+	timeoutFlag := fs.Duration("timeout", 120*time.Second, "timeout for the claude CLI call")
+	jsonFlag := fs.Bool("json", false, "print a single compact JSON line instead of the bare answer")
+
+	positionals, perr := parseInterspersedFlagArgs(fs, args)
+	if perr != nil {
+		return "", "", "", 0, false, perr
+	}
+	if len(positionals) < 2 {
+		return "", "", "", 0, false, fmt.Errorf("usage: attn vision-check <image> <question> [--model sonnet] [--timeout 120s] [--json]")
+	}
+	if len(positionals) > 2 {
+		return "", "", "", 0, false, fmt.Errorf("unexpected extra arguments: %v", positionals[2:])
+	}
+	return positionals[0], positionals[1], *modelFlag, *timeoutFlag, *jsonFlag, nil
+}
+
+// runVisionCheck implements `attn vision-check <image> <question>`: a single
+// tool-less LLM call that answers a question about an image without putting
+// the image itself into the calling agent's context.
+func runVisionCheck() {
+	imagePath, question, model, timeout, jsonOut, err := parseVisionCheckArgs(os.Args[2:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "vision-check: %v\n", err)
+		os.Exit(2)
+	}
+
+	mediaType, err := mediaTypeForPath(imagePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "vision-check: %v\n", err)
+		os.Exit(1)
+	}
+
+	data, err := os.ReadFile(imagePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "vision-check: read %s: %v\n", imagePath, err)
+		os.Exit(1)
+	}
+	encoded := base64.StdEncoding.EncodeToString(data)
+	if len(encoded) > maxVisionCheckBase64Bytes {
+		fmt.Fprintf(os.Stderr, "vision-check: encoded image is %d bytes, over the %d limit; capture with --crop/--max-dim first\n", len(encoded), maxVisionCheckBase64Bytes)
+		os.Exit(1)
+	}
+
+	stdinLine, err := buildVisionCheckMessage(question, mediaType, encoded)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "vision-check: build message: %v\n", err)
+		os.Exit(1)
+	}
+
+	claudeBin, err := resolveClaudeBinary()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "vision-check: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, claudeBin,
+		"-p",
+		"--input-format", "stream-json",
+		"--output-format", "stream-json",
+		"--verbose",
+		"--model", model,
+		"--max-turns", "1",
+		"--strict-mcp-config",
+		"--setting-sources", "",
+		"--allowedTools", "",
+	)
+	cmd.Stdin = strings.NewReader(stdinLine + "\n")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+	result, parseErr := parseVisionCheckResult(stdout.String())
+	if parseErr != nil {
+		if runErr != nil {
+			fmt.Fprintf(os.Stderr, "vision-check: claude CLI failed: %v\n%s\n", runErr, stderr.String())
+		} else {
+			fmt.Fprintf(os.Stderr, "vision-check: %v\n%s\n", parseErr, stderr.String())
+		}
+		os.Exit(1)
+	}
+
+	if result.IsError || result.Subtype != "success" {
+		fmt.Fprintln(os.Stderr, result.Result)
+		os.Exit(1)
+	}
+
+	if jsonOut {
+		out := visionCheckJSONOutput{
+			Answer:   result.Result,
+			Model:    model,
+			CostUSD:  result.TotalCostUS,
+			NumTurns: result.NumTurns,
+			IsError:  result.IsError,
+		}
+		b, err := json.Marshal(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "vision-check: encode json: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(b))
+	} else {
+		fmt.Println(result.Result)
+		fmt.Fprintf(os.Stderr, "vision-check: model=%s cost_usd=%.4f turns=%d\n", model, result.TotalCostUS, result.NumTurns)
+	}
+}

--- a/cmd/attn/vision_check_test.go
+++ b/cmd/attn/vision_check_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestMediaTypeForPath(t *testing.T) {
+	cases := map[string]string{
+		"screenshot.png":  "image/png",
+		"photo.jpg":       "image/jpeg",
+		"photo.jpeg":      "image/jpeg",
+		"PHOTO.JPG":       "image/jpeg",
+		"anim.gif":        "image/gif",
+		"pic.webp":        "image/webp",
+		"/abs/path/x.PNG": "image/png",
+	}
+	for path, want := range cases {
+		got, err := mediaTypeForPath(path)
+		if err != nil {
+			t.Errorf("mediaTypeForPath(%q) unexpected error: %v", path, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("mediaTypeForPath(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+func TestMediaTypeForPathUnsupported(t *testing.T) {
+	for _, path := range []string{"file.bmp", "file", "file.txt", "file.tiff"} {
+		if _, err := mediaTypeForPath(path); err == nil {
+			t.Errorf("mediaTypeForPath(%q) expected error, got nil", path)
+		}
+	}
+}
+
+func TestBuildVisionCheckMessage(t *testing.T) {
+	line, err := buildVisionCheckMessage("what color is the button?", "image/png", "QUJD")
+	if err != nil {
+		t.Fatalf("buildVisionCheckMessage error: %v", err)
+	}
+	if strings.Contains(line, "\n") {
+		t.Fatalf("buildVisionCheckMessage must return a single line, got: %q", line)
+	}
+
+	var decoded struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string `json:"role"`
+			Content []struct {
+				Type   string `json:"type"`
+				Text   string `json:"text,omitempty"`
+				Source struct {
+					Type      string `json:"type"`
+					MediaType string `json:"media_type"`
+					Data      string `json:"data"`
+				} `json:"source,omitempty"`
+			} `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+		t.Fatalf("failed to unmarshal built message: %v", err)
+	}
+	if decoded.Type != "user" {
+		t.Errorf("type = %q, want %q", decoded.Type, "user")
+	}
+	if decoded.Message.Role != "user" {
+		t.Errorf("message.role = %q, want %q", decoded.Message.Role, "user")
+	}
+	if len(decoded.Message.Content) != 2 {
+		t.Fatalf("content blocks = %d, want 2", len(decoded.Message.Content))
+	}
+	if decoded.Message.Content[0].Type != "text" || decoded.Message.Content[0].Text != "what color is the button?" {
+		t.Errorf("content[0] = %+v", decoded.Message.Content[0])
+	}
+	img := decoded.Message.Content[1]
+	if img.Type != "image" || img.Source.Type != "base64" || img.Source.MediaType != "image/png" || img.Source.Data != "QUJD" {
+		t.Errorf("content[1] = %+v", img)
+	}
+}
+
+func TestParseVisionCheckResultLastEventWins(t *testing.T) {
+	stdout := strings.Join([]string{
+		`{"type":"system","subtype":"init","session_id":"abc"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"looking..."}]}}`,
+		`{"type":"result","subtype":"success","is_error":false,"result":"first (should be overridden)","total_cost_usd":0.01,"num_turns":1}`,
+		`{"type":"result","subtype":"success","is_error":false,"result":"the button is blue","total_cost_usd":0.0234,"num_turns":1}`,
+	}, "\n")
+
+	r, err := parseVisionCheckResult(stdout)
+	if err != nil {
+		t.Fatalf("parseVisionCheckResult error: %v", err)
+	}
+	if r.Result != "the button is blue" {
+		t.Errorf("Result = %q, want the last result event's text", r.Result)
+	}
+	if r.IsError {
+		t.Errorf("IsError = true, want false")
+	}
+	if r.NumTurns != 1 {
+		t.Errorf("NumTurns = %d, want 1", r.NumTurns)
+	}
+	if r.TotalCostUS != 0.0234 {
+		t.Errorf("TotalCostUS = %v, want 0.0234", r.TotalCostUS)
+	}
+}
+
+func TestParseVisionCheckResultIsErrorPassthrough(t *testing.T) {
+	stdout := `{"type":"result","subtype":"error_max_turns","is_error":true,"result":"hit max turns"}`
+	r, err := parseVisionCheckResult(stdout)
+	if err != nil {
+		t.Fatalf("parseVisionCheckResult error: %v", err)
+	}
+	if !r.IsError {
+		t.Errorf("IsError = false, want true")
+	}
+	if r.Subtype != "error_max_turns" {
+		t.Errorf("Subtype = %q, want error_max_turns", r.Subtype)
+	}
+}
+
+func TestParseVisionCheckResultMissingResultEvent(t *testing.T) {
+	stdout := strings.Join([]string{
+		`{"type":"system","subtype":"init"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[]}}`,
+	}, "\n")
+	if _, err := parseVisionCheckResult(stdout); err == nil {
+		t.Fatal("expected error when no result event is present, got nil")
+	}
+}
+
+func TestParseVisionCheckResultHugeLine(t *testing.T) {
+	// Simulate an assistant line far larger than bufio.Scanner's default
+	// 64KB token limit, to prove the reader doesn't choke on it.
+	huge := strings.Repeat("x", 300*1024)
+	stdout := strings.Join([]string{
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"` + huge + `"}]}}`,
+		`{"type":"result","subtype":"success","is_error":false,"result":"ok","total_cost_usd":0.1,"num_turns":1}`,
+	}, "\n")
+	r, err := parseVisionCheckResult(stdout)
+	if err != nil {
+		t.Fatalf("parseVisionCheckResult error with huge line: %v", err)
+	}
+	if r.Result != "ok" {
+		t.Errorf("Result = %q, want ok", r.Result)
+	}
+}
+
+func TestParseVisionCheckArgs(t *testing.T) {
+	image, question, model, timeout, jsonOut, err := parseVisionCheckArgs([]string{"shot.png", "what does this say?"})
+	if err != nil {
+		t.Fatalf("parseVisionCheckArgs error: %v", err)
+	}
+	if image != "shot.png" || question != "what does this say?" {
+		t.Errorf("got image=%q question=%q", image, question)
+	}
+	if model != "sonnet" {
+		t.Errorf("default model = %q, want sonnet", model)
+	}
+	if timeout.Seconds() != 120 {
+		t.Errorf("default timeout = %v, want 120s", timeout)
+	}
+	if jsonOut {
+		t.Errorf("default json = true, want false")
+	}
+}
+
+func TestParseVisionCheckArgsMissingPositional(t *testing.T) {
+	if _, _, _, _, _, err := parseVisionCheckArgs([]string{"shot.png"}); err == nil {
+		t.Fatal("expected error for missing question argument")
+	}
+}


### PR DESCRIPTION
## What

`attn vision-check <image> "<question>"` answers a question about a screenshot with ONE tool-less `claude` call (`--input-format stream-json` with a base64 image block, `--max-turns 1`, `--strict-mcp-config --setting-sources "" --allowedTools ""`), so the image never enters the driving agent's context. Default model **sonnet**, overridable via `--model`; `--json` emits a single machine-readable line with answer + cost.

Item 5 of the agent-cost-tooling ticket.

## Design notes

- The stream-json image-input path was spike-validated against the real CLI before implementation; the CLI's final `result` event supplies answer, `total_cost_usd`, and `num_turns`.
- Default mode prints the bare answer on stdout and a one-line `model/cost/turns` summary on stderr, keeping stdout pipe-clean. No profile banner for the same reason.
- Base64 payloads over ~4.5MB error with a hint to capture via `--crop`/`--max-dim` (PR #468) instead.

## Testing

- Unit: media-type mapping, message shape, last-result-wins stream parsing incl. a 300KB line (Scanner token-limit case), arg parsing. `go build ./...` + `go test ./cmd/attn/...` green.
- Live-verified against the real `claude` CLI with a generated solid-red PNG:
  - default mode → `red` / `vision-check: model=haiku cost_usd=0.0262 turns=1`, exit 0
  - `--json` → `{"answer":"Red.","model":"haiku","cost_usd":0.0181,"num_turns":1,"is_error":false}`

🤖 Generated with Claude Code on behalf of Victor