### PR TITLE
feat(diagnostics): DOM-truth clip detection, fit-bail logging, offset soak scenario

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -56,6 +56,7 @@
     "real-app:scenario-terminal-block-copy": "node scripts/real-app-harness/scenario-terminal-block-copy.mjs",
     "real-app:scenario-terminal-context-menu": "node scripts/real-app-harness/scenario-terminal-context-menu.mjs",
     "real-app:scenario-terminal-block-resize": "node scripts/real-app-harness/scenario-terminal-block-resize.mjs",
+    "real-app:scenario-offset-soak": "node scripts/real-app-harness/scenario-offset-soak.mjs",
     "real-app:serial-matrix": "node scripts/real-app-harness/run-serial-matrix.mjs",
     "e2e": "playwright test",
     "e2e:settings-visual": "playwright test e2e/settings-visual.spec.ts",

--- a/app/scripts/real-app-harness/scenario-offset-soak.mjs
+++ b/app/scripts/real-app-harness/scenario-offset-soak.mjs
@@ -311,7 +311,8 @@ async function main() {
   let maxOverflowSeen = 0;
   let transientCount = 0;
   const transientSteps = [];
-  const TRANSIENT_RECHECK_DELAY_MS = 1_500;
+  const TRANSIENT_RECHECK_POLL_MS = 750;
+  const TRANSIENT_RECHECK_DEADLINE_MS = 4_500;
 
   console.log(`[RealAppHarness] runDir=${runDir}`);
   console.log(`[RealAppHarness] sessionDir=${sessionDir}`);
@@ -543,22 +544,37 @@ async function main() {
       );
 
       if (violations.length > 0) {
-        // Production incidents show transient clips that self-heal within
-        // ~1s (a RAF self-heal path exists). Don't fail on the first sighting
-        // — wait and re-measure the same workspace before deciding whether
-        // this is the persistent bug (survives until remount) or a transient
-        // one we should log and keep soaking past.
-        console.warn(`[RealAppHarness] suspect clip at step ${step}, rechecking after ${TRANSIENT_RECHECK_DELAY_MS}ms...`);
-        await delay(TRANSIENT_RECHECK_DELAY_MS);
-        const confirm = await measureActiveWorkspacePanes(client, activeWorkspace.sessionId);
+        // Production incidents show transient clips that self-heal, but the
+        // attach-replay storm on a cold workspace reactivation can run ~1s
+        // BEFORE the self-heal even starts, so a single fixed-delay recheck
+        // can land mid-churn and misclassify a transient as persistent. Poll
+        // every 750ms up to a 4.5s deadline; the first clean re-measure wins
+        // (record how long healing took), and only fail if every poll through
+        // the deadline stays dirty.
+        console.warn(`[RealAppHarness] suspect clip at step ${step}, polling every ${TRANSIENT_RECHECK_POLL_MS}ms up to ${TRANSIENT_RECHECK_DEADLINE_MS}ms...`);
+        const suspectAt = Date.now();
+        const rechecks = [];
+        let healed = null;
+        let elapsedMs = 0;
+        while (elapsedMs < TRANSIENT_RECHECK_DEADLINE_MS) {
+          await delay(TRANSIENT_RECHECK_POLL_MS);
+          elapsedMs = Date.now() - suspectAt;
+          const recheck = await measureActiveWorkspacePanes(client, activeWorkspace.sessionId);
+          rechecks.push({ elapsedMs, violations: recheck.violations, measurements: recheck.measurements });
+          if (recheck.violations.length === 0) {
+            healed = { elapsedMs, measurements: recheck.measurements };
+            break;
+          }
+        }
 
-        if (confirm.violations.length === 0) {
+        if (healed) {
           transientCount += 1;
           transientSteps.push(step);
           traceEntry.transient = true;
+          traceEntry.healMs = healed.elapsedMs;
           traceEntry.firstMeasurements = measurements;
-          traceEntry.confirmMeasurements = confirm.measurements;
-          console.warn(`[RealAppHarness] TRANSIENT clip at step ${step}, self-healed`);
+          traceEntry.confirmMeasurements = healed.measurements;
+          console.warn(`[RealAppHarness] TRANSIENT clip at step ${step}, self-healed after ${healed.elapsedMs}ms`);
           continue;
         }
 
@@ -573,7 +589,7 @@ async function main() {
               params,
               activeWorkspaceIndex: activeIndex,
               first: { violations, measurements },
-              confirm: { violations: confirm.violations, measurements: confirm.measurements },
+              rechecks,
             },
             null,
             2,
@@ -593,7 +609,8 @@ async function main() {
           'utf8',
         );
         await captureSessionArtifacts(client, runDir, 'violation', activeWorkspace.sessionId).catch(() => {});
-        for (const violation of confirm.violations) {
+        const lastRecheck = rechecks[rechecks.length - 1];
+        for (const violation of lastRecheck.violations) {
           const paneText = await client.request('read_pane_text', {
             sessionId: activeWorkspace.sessionId,
             paneId: violation.paneId,

--- a/app/scripts/real-app-harness/scenario-offset-soak.mjs
+++ b/app/scripts/real-app-harness/scenario-offset-soak.mjs
@@ -1,0 +1,646 @@
+#!/usr/bin/env node
+
+// Randomized soak repro for a hard-to-reproduce bug: a terminal pane's
+// rendered canvas ends up offset/clipped at the bottom (or side) of its
+// pane, persisting until remount. Suspected triggers: switching among 4+
+// workspaces (warm-set virtualization churn), font-size (UI scale) changes
+// made while other workspaces are hidden, window resizes, splitting/closing
+// panes (a real prod incident clipped in a narrow 292px-wide split), and
+// re-activating a cold workspace mid-attach-replay (the replay storm resizes
+// the canvas dozens of times over ~1s before settling — bouncing away and
+// back interrupts that window).
+//
+// This drives the real packaged dev app through a seeded, weighted random
+// walk of those actions and asserts, after every step, that the active
+// workspace's canvas DOM rect sits inside its terminal container's rect.
+// First violation stops the run, dumps evidence, and exits non-zero.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  assertCommonTargetAllowed,
+  createRunContext,
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { getFrontWindowBounds, setFrontWindowBounds } from './nativeWindowCapture.mjs';
+import {
+  captureSessionArtifacts,
+  waitForPaneAttached,
+  waitForPaneShellReady,
+  waitForPaneText,
+  waitForPaneVisible,
+  waitForSessionWorkspace,
+} from './scenarioAssertions.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+
+const OVERFLOW_TOLERANCE_PX = 2;
+const FONT_SCALE_MIN = 0.7;
+const FONT_SCALE_MAX = 1.5;
+const FONT_SCALE_STEP = 0.1;
+const MAX_PANES_PER_WORKSPACE = 4;
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') {
+    args.shift();
+  }
+  const options = {
+    ...parseCommonArgs([]),
+    iterations: 150,
+    workspaceCount: 6,
+    seed: 1,
+    warmLimit: 3,
+    settleMs: 400,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--ws-url') options.wsUrl = args[++index];
+    else if (arg === '--app-path') options.appPath = args[++index];
+    else if (arg === '--artifacts-dir' || arg === '--artifacts') options.artifactsDir = args[++index];
+    else if (arg === '--session-root-dir') options.sessionRootDir = args[++index];
+    else if (arg === '--iterations') options.iterations = Number.parseInt(args[++index], 10);
+    else if (arg === '--workspaces') options.workspaceCount = Number.parseInt(args[++index], 10);
+    else if (arg === '--seed') options.seed = Number.parseInt(args[++index], 10);
+    else if (arg === '--warm-limit') options.warmLimit = Number.parseInt(args[++index], 10);
+    else if (arg === '--settle-ms') options.settleMs = Number.parseInt(args[++index], 10);
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
+    else if (arg === '--help' || arg === '-h') options.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!options.help) {
+    assertCommonTargetAllowed(options, args);
+  }
+  return {
+    options,
+    help: Boolean(options.help),
+  };
+}
+
+// Deterministic PRNG (mulberry32) so a given --seed always drives the same
+// action sequence.
+function mulberry32(seed) {
+  let state = seed >>> 0;
+  return function next() {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pickInt(rand, min, max) {
+  return min + Math.floor(rand() * (max - min + 1));
+}
+
+function pickFrom(rand, list) {
+  return list[Math.floor(rand() * list.length) % list.length];
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fullScreenTuiCommand(markerLabel) {
+  // Enters the alternate screen, redraws TOP/BOTTOM markers (with live
+  // cols/rows) on every SIGWINCH, then idles. Painted content at the exact
+  // bottom row makes bottom-clipping visually real, and the readout exposes
+  // stale PTY size after a resize.
+  //
+  // markerLabel must be short (e.g. "s0") — the run's long, timestamped
+  // session label does not fit some narrow panes, and a wrapped marker line
+  // both scrolls the TOP row off-screen and garbles the BOTTOM row. Each
+  // line is also truncated to the live terminal width (`printf '%.*s'`) so a
+  // future narrow pane can never wrap, regardless of label length.
+  return (
+    `bash -c 'r(){ c=$(tput cols); l=$(tput lines); clear; ` +
+    `top="TOP ${markerLabel} cols=$c rows=$l"; ` +
+    `bot="BOTTOM ${markerLabel} cols=$c rows=$l"; ` +
+    `printf "%.*s" "$((c-1))" "$top"; ` +
+    `tput cup $((l-1)) 0; ` +
+    `printf "%.*s" "$((c-1))" "$bot"; }; ` +
+    `trap r WINCH; tput smcup; r; while :; do sleep 0.2; done'`
+  );
+}
+
+async function createTuiWorkspace(client, observer, cwd, sessionLabel, markerLabel) {
+  fs.mkdirSync(cwd, { recursive: true });
+  const sessionId = await createSessionAndWaitForInitialPane({
+    client,
+    observer,
+    cwd,
+    label: sessionLabel,
+    agent: 'shell',
+    waitForInitialPaneVisible: false,
+    sessionWaitMs: 30_000,
+  });
+  const workspace = await waitForSessionWorkspace(
+    client,
+    sessionId,
+    (ws) => (ws?.panes || []).length === 1 && ws.panes[0].runtimeId,
+    `initial pane for ${sessionLabel}`,
+  );
+  const pane = workspace.panes[0];
+  await client.request('select_session', { sessionId });
+  await waitForPaneVisible(client, sessionId, pane.paneId, 20_000);
+  await waitForPaneAttached(client, sessionId, pane.paneId, 20_000);
+  await waitForPaneShellReady(client, sessionId, pane.paneId, {
+    timeoutMs: 20_000,
+    description: `initial shell pane ready for ${sessionLabel}`,
+  });
+  await client.request('write_pane', { sessionId, paneId: pane.paneId, text: fullScreenTuiCommand(markerLabel) });
+  await waitForPaneText(
+    client,
+    sessionId,
+    pane.paneId,
+    (text) => text.includes(`TOP ${markerLabel}`) && text.includes(`BOTTOM ${markerLabel}`),
+    `full-screen TUI painted for ${sessionLabel}`,
+    20_000,
+  );
+  return {
+    sessionId,
+    workspaceId: workspace.workspaceId,
+    label: sessionLabel,
+    // Bookkeeping for the panes we've injected the full-screen TUI into, so
+    // split/close_split actions know what exists and can hand out unique
+    // marker labels. measureActiveWorkspacePanes does NOT read this — it
+    // always re-fetches live panes from get_workspace — this is only for
+    // action selection and marker-label bookkeeping.
+    panes: [{ paneId: pane.paneId, markerLabel }],
+    nextPaneMarker: 1,
+  };
+}
+
+// Waits for a new pane to appear in the workspace, regardless of pane kind.
+// scenarioAssertions.mjs's waitForNewShellPane filters to kind === 'shell',
+// but these workspaces' panes are kind 'agent' (agent shell wrapper), so
+// that filter never matches here and the wait times out even though the
+// split succeeded. Mirror its resolution logic (prefer the workspace's
+// activePaneId if it's new, else the first new pane) without the kind filter.
+async function waitForNewPane(client, sessionId, existingPaneIds, description, timeoutMs = 20_000) {
+  const workspace = await waitForSessionWorkspace(
+    client,
+    sessionId,
+    (ws) => (ws?.panes || []).some((pane) => !existingPaneIds.has(pane.paneId)),
+    description,
+    timeoutMs,
+  );
+  const newPanes = (workspace.panes || []).filter((pane) => !existingPaneIds.has(pane.paneId));
+  return newPanes.find((pane) => pane.paneId === workspace.activePaneId) || newPanes[0];
+}
+
+// Writes the same full-screen TUI marker script into a freshly split pane
+// and waits for it to paint, mirroring what createTuiWorkspace does for a
+// workspace's initial pane.
+async function seedTuiIntoPane(client, sessionId, paneId, markerLabel, description) {
+  await client.request('write_pane', { sessionId, paneId, text: fullScreenTuiCommand(markerLabel) });
+  await waitForPaneText(
+    client,
+    sessionId,
+    paneId,
+    (text) => text.includes(`TOP ${markerLabel}`) && text.includes(`BOTTOM ${markerLabel}`),
+    description,
+    20_000,
+  );
+}
+
+async function closeWorkspacePanes(client, sessionId) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const workspace = await client.request('get_workspace', { sessionId }).catch(() => null);
+    const pane = workspace?.panes?.[0];
+    if (!pane) {
+      return;
+    }
+    await client.request('close_pane', { sessionId, paneId: pane.paneId }).catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+async function closeExistingSessions(client, sessionRootDir) {
+  const initial = await client.request('get_state');
+  const harnessSessions = (initial.sessions || []).filter((session) => session.cwd?.startsWith(sessionRootDir));
+  for (const session of harnessSessions) {
+    await closeWorkspacePanes(client, session.id).catch(() => {});
+  }
+}
+
+function boundsOf(dom, key) {
+  const bounds = dom?.[key]?.bounds;
+  if (!bounds) {
+    return null;
+  }
+  return bounds;
+}
+
+// Checks every pane of the active workspace's canvas against its terminal
+// container. Returns a list of per-pane measurements plus any violations
+// (missing DOM nodes count as a violation too — that is itself evidence of
+// a broken render, not something to silently skip).
+async function measureActiveWorkspacePanes(client, sessionId) {
+  const workspace = await client.request('get_workspace', { sessionId });
+  const measurements = [];
+  const violations = [];
+  for (const pane of workspace.panes || []) {
+    const state = await client.request('get_pane_state', { sessionId, paneId: pane.paneId });
+    const dom = state?.pane?.dom;
+    const canvas = boundsOf(dom, 'canvas');
+    const container = boundsOf(dom, 'terminalContainer');
+    if (!canvas || !container) {
+      violations.push({
+        paneId: pane.paneId,
+        reason: 'missing dom bounds',
+        canvas,
+        container,
+      });
+      continue;
+    }
+    const domOffsetTop = canvas.y - container.y;
+    const domOverflowBottom = canvas.y + canvas.height - (container.y + container.height);
+    const domOverflowRight = canvas.x + canvas.width - (container.x + container.width);
+    const measurement = {
+      paneId: pane.paneId,
+      canvas,
+      container,
+      domOffsetTop,
+      domOverflowBottom,
+      domOverflowRight,
+    };
+    measurements.push(measurement);
+    if (
+      domOverflowBottom > OVERFLOW_TOLERANCE_PX ||
+      domOffsetTop > OVERFLOW_TOLERANCE_PX ||
+      domOverflowRight > OVERFLOW_TOLERANCE_PX
+    ) {
+      violations.push({ ...measurement, reason: 'canvas rect escapes terminal container rect' });
+    }
+  }
+  return { measurements, violations };
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-offset-soak.mjs');
+    console.log(`Additional options:
+  --iterations <n>     Number of random action steps to run (default: 150)
+  --workspaces <n>     Number of shell workspaces to create (default: 6)
+  --seed <n>           PRNG seed for deterministic action sequence (default: 1)
+  --warm-limit <n>     Warm workspace virtualization limit (default: 3)
+  --settle-ms <n>      Settle delay before each post-step assertion (default: 400)
+`);
+    return;
+  }
+  if (!Number.isInteger(options.iterations) || options.iterations <= 0) {
+    throw new Error(`--iterations must be a positive integer, got: ${options.iterations}`);
+  }
+  if (!Number.isInteger(options.workspaceCount) || options.workspaceCount < 2) {
+    throw new Error(`--workspaces must be an integer >= 2, got: ${options.workspaceCount}`);
+  }
+
+  const { runId, runDir, sessionDir } = createRunContext(options, 'offset-soak');
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const rand = mulberry32(options.seed);
+
+  const workspaces = [];
+  const trace = [];
+  let maxOverflowSeen = 0;
+  let transientCount = 0;
+  const transientSteps = [];
+  const TRANSIENT_RECHECK_DELAY_MS = 1_500;
+
+  console.log(`[RealAppHarness] runDir=${runDir}`);
+  console.log(`[RealAppHarness] sessionDir=${sessionDir}`);
+  console.log(`[RealAppHarness] wsUrl=${options.wsUrl}`);
+  console.log(`[RealAppHarness] seed=${options.seed} iterations=${options.iterations} workspaces=${options.workspaceCount} warmLimit=${options.warmLimit}`);
+
+  try {
+    process.env.ATTN_HARNESS_PARK_VISIBLE_PX ??= '0';
+    await launchFreshAppAndConnect(client, observer);
+    await closeExistingSessions(client, options.sessionRootDir);
+
+    await client.request('set_warm_workspace_limit', { limit: options.warmLimit }).catch((error) => {
+      console.warn(`[RealAppHarness] set_warm_workspace_limit failed: ${error.message}`);
+    });
+
+    for (let index = 0; index < options.workspaceCount; index += 1) {
+      const sessionLabel = `offsetsoak-${runId}-${index}`;
+      const markerLabel = `s${index}`; // short: must fit inside any pane width without wrapping
+      const workspace = await createTuiWorkspace(client, observer, path.join(sessionDir, `ws${index}`), sessionLabel, markerLabel);
+      workspaces.push(workspace);
+      console.log(`[RealAppHarness] created workspace ${index}: sessionId=${workspace.sessionId} workspaceId=${workspace.workspaceId} marker=${markerLabel}`);
+    }
+
+    let activeIndex = workspaces.length - 1; // last created workspace is selected
+
+    // Recency of activation, oldest-first: index 0 is the workspace least
+    // recently made active, i.e. the one most likely evicted from the warm
+    // set and coldest on next re-activation. Setup activated workspaces in
+    // creation order, so that's the initial recency order too.
+    const recency = workspaces.map((_, index) => index);
+    const markActive = (index) => {
+      const position = recency.indexOf(index);
+      if (position !== -1) {
+        recency.splice(position, 1);
+      }
+      recency.push(index);
+    };
+
+    const switchTo = async (index) => {
+      const target = workspaces[index];
+      await client.request('select_session', { sessionId: target.sessionId });
+      activeIndex = index;
+      markActive(index);
+    };
+
+    const otherIndex = (excludeIndex) => {
+      let candidate = excludeIndex;
+      while (candidate === excludeIndex) {
+        candidate = pickInt(rand, 0, workspaces.length - 1);
+      }
+      return candidate;
+    };
+
+    // The coldest OTHER workspace: the least-recently-active entry in
+    // `recency` that isn't excludeIndex.
+    const leastRecentlyActiveIndex = (excludeIndex) => {
+      for (const index of recency) {
+        if (index !== excludeIndex) {
+          return index;
+        }
+      }
+      return excludeIndex;
+    };
+
+    let windowBounds = await getFrontWindowBounds(client.bundleId, { client }).catch(() => null);
+    let fontScaleSteps = 0; // relative to default 1.0, in FONT_SCALE_STEP units
+
+    for (let step = 1; step <= options.iterations; step += 1) {
+      const roll = rand();
+      let action;
+      const params = {};
+
+      // Weighted action distribution: switch 35%, font_scale 20%,
+      // window_resize 15%, rapid_double_switch 5%, bounce_switch 10%,
+      // split 10%, close_split 5%.
+      if (roll < 0.35) {
+        action = 'switch';
+        params.switchToIndex = otherIndex(activeIndex);
+        await switchTo(params.switchToIndex);
+      } else if (roll < 0.55) {
+        action = 'font_scale';
+        const doReset = rand() < 0.15;
+        if (doReset) {
+          params.shortcut = 'ui.resetFontSize';
+          fontScaleSteps = 0;
+        } else {
+          const increase = rand() < 0.5;
+          const atMax = fontScaleSteps >= Math.round((FONT_SCALE_MAX - 1) / FONT_SCALE_STEP);
+          const atMin = fontScaleSteps <= -Math.round((1 - FONT_SCALE_MIN) / FONT_SCALE_STEP);
+          const goUp = increase && !atMax ? true : (!increase && !atMin ? false : !atMax);
+          params.shortcut = goUp ? 'ui.increaseFontSize' : 'ui.decreaseFontSize';
+          fontScaleSteps += goUp ? 1 : -1;
+        }
+        await client.request('dispatch_shortcut', { shortcutId: params.shortcut });
+        params.switchToIndex = otherIndex(activeIndex);
+        await switchTo(params.switchToIndex);
+      } else if (roll < 0.70) {
+        action = 'window_resize';
+        if (!windowBounds) {
+          windowBounds = await getFrontWindowBounds(client.bundleId, { client });
+        }
+        const deltaW = pickInt(rand, 20, 80) * pickFrom(rand, [1, -1]);
+        const deltaH = pickInt(rand, 20, 80) * pickFrom(rand, [1, -1]);
+        const nextBounds = {
+          x: windowBounds.x,
+          y: windowBounds.y,
+          width: Math.max(900, Math.min(2200, windowBounds.width + deltaW)),
+          height: Math.max(600, Math.min(1400, windowBounds.height + deltaH)),
+        };
+        params.fromBounds = windowBounds;
+        params.toBounds = nextBounds;
+        windowBounds = await setFrontWindowBounds(nextBounds, { client });
+        params.switchToIndex = otherIndex(activeIndex);
+        await switchTo(params.switchToIndex);
+      } else if (roll < 0.75) {
+        action = 'rapid_double_switch';
+        const first = otherIndex(activeIndex);
+        const second = otherIndex(first);
+        params.first = first;
+        params.second = second;
+        await switchTo(first);
+        await switchTo(second);
+      } else if (roll < 0.85) {
+        // Best persistent-bug candidate: re-activate the coldest workspace
+        // (most likely evicted from the warm set), interrupt its attach
+        // replay storm (dozens of resizeLocal events over ~1s before it
+        // settles) with an away-and-back bounce, then land back on it so the
+        // usual post-step measurement checks it mid-settle.
+        action = 'bounce_switch';
+        const coldTarget = leastRecentlyActiveIndex(activeIndex);
+        params.coldTargetIndex = coldTarget;
+        await switchTo(coldTarget);
+
+        const delay1Ms = pickInt(rand, 100, 600);
+        params.delay1Ms = delay1Ms;
+        await delay(delay1Ms);
+
+        const bounceAwayIndex = otherIndex(coldTarget);
+        params.bounceAwayIndex = bounceAwayIndex;
+        await switchTo(bounceAwayIndex);
+
+        const delay2Ms = pickInt(rand, 100, 600);
+        params.delay2Ms = delay2Ms;
+        await delay(delay2Ms);
+
+        await switchTo(coldTarget);
+      } else if (roll < 0.95) {
+        action = 'split';
+        const activeWorkspace = workspaces[activeIndex];
+        const workspaceState = await client.request('get_workspace', { sessionId: activeWorkspace.sessionId });
+        const existingPanes = workspaceState.panes || [];
+        if (existingPanes.length >= MAX_PANES_PER_WORKSPACE) {
+          action = 'split_fallback_switch';
+          params.reason = `pane cap reached (${existingPanes.length}/${MAX_PANES_PER_WORKSPACE})`;
+          params.switchToIndex = otherIndex(activeIndex);
+          await switchTo(params.switchToIndex);
+        } else {
+          const direction = pickFrom(rand, ['vertical', 'horizontal']);
+          params.direction = direction;
+          const existingPaneIds = new Set(existingPanes.map((pane) => pane.paneId));
+          await client.request('split_pane', { sessionId: activeWorkspace.sessionId, direction });
+          const newPane = await waitForNewPane(
+            client,
+            activeWorkspace.sessionId,
+            existingPaneIds,
+            `new split pane for ${activeWorkspace.label}`,
+            20_000,
+          );
+          await waitForPaneVisible(client, activeWorkspace.sessionId, newPane.paneId, 20_000);
+          await waitForPaneAttached(client, activeWorkspace.sessionId, newPane.paneId, 20_000);
+          await waitForPaneShellReady(client, activeWorkspace.sessionId, newPane.paneId, {
+            timeoutMs: 20_000,
+            description: `split pane ready for ${activeWorkspace.label}`,
+          });
+          const markerLabel = `s${activeIndex}p${activeWorkspace.nextPaneMarker}`;
+          activeWorkspace.nextPaneMarker += 1;
+          await seedTuiIntoPane(
+            client,
+            activeWorkspace.sessionId,
+            newPane.paneId,
+            markerLabel,
+            `full-screen TUI painted for split pane ${markerLabel}`,
+          );
+          activeWorkspace.panes.push({ paneId: newPane.paneId, markerLabel });
+          params.paneId = newPane.paneId;
+          params.markerLabel = markerLabel;
+        }
+      } else {
+        action = 'close_split';
+        const activeWorkspace = workspaces[activeIndex];
+        const workspaceState = await client.request('get_workspace', { sessionId: activeWorkspace.sessionId });
+        const existingPanes = workspaceState.panes || [];
+        if (existingPanes.length <= 1) {
+          action = 'close_split_fallback_switch';
+          params.reason = 'workspace has only one pane';
+          params.switchToIndex = otherIndex(activeIndex);
+          await switchTo(params.switchToIndex);
+        } else {
+          // Never close the first pane — pick uniformly among the rest.
+          const closeIndex = 1 + pickInt(rand, 0, existingPanes.length - 2);
+          const paneToClose = existingPanes[closeIndex];
+          params.paneId = paneToClose.paneId;
+          await client.request('close_pane', { sessionId: activeWorkspace.sessionId, paneId: paneToClose.paneId });
+          activeWorkspace.panes = activeWorkspace.panes.filter((pane) => pane.paneId !== paneToClose.paneId);
+        }
+      }
+
+      await delay(options.settleMs);
+
+      const activeWorkspace = workspaces[activeIndex];
+      const { measurements, violations } = await measureActiveWorkspacePanes(client, activeWorkspace.sessionId);
+      const stepMaxOverflow = measurements.reduce(
+        (max, measurement) => Math.max(max, measurement.domOffsetTop, measurement.domOverflowBottom, measurement.domOverflowRight),
+        0,
+      );
+      maxOverflowSeen = Math.max(maxOverflowSeen, stepMaxOverflow);
+
+      const traceEntry = {
+        step,
+        action,
+        params,
+        activeWorkspaceIndex: activeIndex,
+        activeSessionId: activeWorkspace.sessionId,
+        maxOverflowPx: stepMaxOverflow,
+      };
+      trace.push(traceEntry);
+      console.log(
+        `[RealAppHarness] step=${step} action=${action} active=${activeIndex} maxOverflowPx=${stepMaxOverflow.toFixed(1)}`,
+      );
+
+      if (violations.length > 0) {
+        // Production incidents show transient clips that self-heal within
+        // ~1s (a RAF self-heal path exists). Don't fail on the first sighting
+        // — wait and re-measure the same workspace before deciding whether
+        // this is the persistent bug (survives until remount) or a transient
+        // one we should log and keep soaking past.
+        console.warn(`[RealAppHarness] suspect clip at step ${step}, rechecking after ${TRANSIENT_RECHECK_DELAY_MS}ms...`);
+        await delay(TRANSIENT_RECHECK_DELAY_MS);
+        const confirm = await measureActiveWorkspacePanes(client, activeWorkspace.sessionId);
+
+        if (confirm.violations.length === 0) {
+          transientCount += 1;
+          transientSteps.push(step);
+          traceEntry.transient = true;
+          traceEntry.firstMeasurements = measurements;
+          traceEntry.confirmMeasurements = confirm.measurements;
+          console.warn(`[RealAppHarness] TRANSIENT clip at step ${step}, self-healed`);
+          continue;
+        }
+
+        console.error(`[RealAppHarness] VIOLATION at step ${step}: canvas escaped its terminal container.`);
+        fs.writeFileSync(path.join(runDir, 'trace.json'), `${JSON.stringify(trace, null, 2)}\n`, 'utf8');
+        fs.writeFileSync(
+          path.join(runDir, 'violation.json'),
+          `${JSON.stringify(
+            {
+              step,
+              action,
+              params,
+              activeWorkspaceIndex: activeIndex,
+              first: { violations, measurements },
+              confirm: { violations: confirm.violations, measurements: confirm.measurements },
+            },
+            null,
+            2,
+          )}\n`,
+          'utf8',
+        );
+        const workspace = await client.request('get_workspace', { sessionId: activeWorkspace.sessionId }).catch(() => null);
+        const allPaneStates = {};
+        for (const pane of workspace?.panes || []) {
+          allPaneStates[pane.paneId] = await client
+            .request('get_pane_state', { sessionId: activeWorkspace.sessionId, paneId: pane.paneId })
+            .catch((error) => ({ error: error instanceof Error ? error.message : String(error) }));
+        }
+        fs.writeFileSync(
+          path.join(runDir, 'violation-pane-states.json'),
+          `${JSON.stringify(allPaneStates, null, 2)}\n`,
+          'utf8',
+        );
+        await captureSessionArtifacts(client, runDir, 'violation', activeWorkspace.sessionId).catch(() => {});
+        for (const violation of confirm.violations) {
+          const paneText = await client.request('read_pane_text', {
+            sessionId: activeWorkspace.sessionId,
+            paneId: violation.paneId,
+          }).catch((error) => ({ error: error instanceof Error ? error.message : String(error) }));
+          fs.writeFileSync(
+            path.join(runDir, `violation-pane-${violation.paneId}-text.json`),
+            `${JSON.stringify(paneText, null, 2)}\n`,
+            'utf8',
+          );
+        }
+
+        const historyTail = trace.slice(-15);
+        console.error('[RealAppHarness] Last 15 steps before violation:');
+        for (const entry of historyTail) {
+          console.error(`  step=${entry.step} action=${entry.action} active=${entry.activeWorkspaceIndex} maxOverflowPx=${entry.maxOverflowPx.toFixed(1)}${entry.transient ? ' (transient)' : ''}`);
+        }
+        console.error(`[RealAppHarness] seed=${options.seed} failing step=${step}. Evidence written to ${runDir}`);
+        process.exitCode = 1;
+        return;
+      }
+    }
+
+    fs.writeFileSync(path.join(runDir, 'trace.json'), `${JSON.stringify(trace, null, 2)}\n`, 'utf8');
+    const summary = {
+      ok: true,
+      runId,
+      seed: options.seed,
+      iterations: options.iterations,
+      workspaceCount: options.workspaceCount,
+      warmLimit: options.warmLimit,
+      maxOverflowPxSeen: maxOverflowSeen,
+      transientCount,
+      transientSteps,
+    };
+    fs.writeFileSync(path.join(runDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    console.log(`[RealAppHarness] Offset soak passed: ${options.iterations} steps, no persistent violation, maxOverflowPxSeen=${maxOverflowSeen.toFixed(1)}, transientCount=${transientCount}.`);
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    for (const workspace of workspaces.reverse()) {
+      await closeWorkspacePanes(client, workspace.sessionId).catch(() => {});
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -1465,18 +1465,31 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const applyFitDimensions = useCallback((dims: TerminalDimensions) => {
       const terminal = terminalRef.current;
       const renderer = rendererRef.current;
-      if (!terminal || !renderer) return;
+      if (!terminal || !renderer) {
+        // A dead model/renderer left this bail silent before, which is exactly
+        // when the trace matters most — log it defensively (meta may not exist yet).
+        noteResize(diagKeyRef.current, {
+          session: runtimeMetaRef.current?.sessionId ?? undefined,
+          paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
+          source: 'fit',
+          bail: renderer ? 'noModel' : 'noRenderer',
+        });
+        return;
+      }
       // Inactive session wrappers use display:none. Resizing the Ghostty
       // model from that hidden geometry discards an idle alternate-screen
       // frame before the session becomes visible again.
       const paneKind = runtimeMetaRef.current?.paneKind ?? undefined;
       const session = runtimeMetaRef.current?.sessionId ?? undefined;
+      const fitContainer = containerRef.current;
+      const cw = fitContainer?.clientWidth;
+      const ch = fitContainer?.clientHeight;
       if (runtimeMetaRef.current && !runtimeMetaRef.current.isActiveSession) {
-        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'inactiveSession' });
+        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'inactiveSession', cw, ch });
         return;
       }
       if (!fitRequiresTerminalResize({ cols: terminal.cols, rows: terminal.rows }, dims)) {
-        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'sameSize', toCols: dims.cols, toRows: dims.rows });
+        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'sameSize', toCols: dims.cols, toRows: dims.rows, cw, ch, fromCols: terminal.cols, fromRows: terminal.rows });
         renderSurface(false);
         return;
       }
@@ -1485,7 +1498,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       // is not a conflict — skip it and let the replay land there (the PTY
       // is already that size, so there is nothing to notify either).
       if (liveResizeConflictsWithQueuedReplay(pendingReplayGeometryRef.current, dims) === 'skip') {
-        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'replayPending', toCols: dims.cols, toRows: dims.rows });
+        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'replayPending', toCols: dims.cols, toRows: dims.rows, cw, ch, fromCols: terminal.cols, fromRows: terminal.rows });
         renderSurface(false);
         return;
       }
@@ -1518,11 +1531,22 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const fit = useCallback(() => {
       const container = containerRef.current;
       const renderer = rendererRef.current;
-      if (!container || !renderer) return;
+      if (!container || !renderer) {
+        // A dead renderer/unmounted container left this bail silent before,
+        // which is exactly when the trace matters most — log it defensively
+        // (meta may not exist yet).
+        noteResize(diagKeyRef.current, {
+          session: runtimeMetaRef.current?.sessionId ?? undefined,
+          paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
+          source: 'fit',
+          bail: renderer ? 'noContainer' : 'noRenderer',
+        });
+        return;
+      }
       const paneKind = runtimeMetaRef.current?.paneKind ?? undefined;
       const session = runtimeMetaRef.current?.sessionId ?? undefined;
       if (runtimeMetaRef.current && !runtimeMetaRef.current.isActiveSession) {
-        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'inactiveSession' });
+        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'inactiveSession', cw: container.clientWidth, ch: container.clientHeight });
         return;
       }
       const dims = renderer.fitDimensions(container.clientWidth, container.clientHeight);
@@ -1536,7 +1560,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         container.clientWidth,
         container.clientHeight,
       )) {
-        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'suspiciousSize', toCols: dims.cols, toRows: dims.rows });
+        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'suspiciousSize', toCols: dims.cols, toRows: dims.rows, cw: container.clientWidth, ch: container.clientHeight });
         return;
       }
       // The size is now backed by a real container measurement: attaches may
@@ -1663,6 +1687,9 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           if (!model) return null;
           const activeRenderer = rendererRef.current;
           const activeContainer = containerRef.current;
+          const activeCanvas = canvasRef.current;
+          const containerRect = activeContainer?.getBoundingClientRect() ?? null;
+          const canvasRect = activeCanvas?.getBoundingClientRect() ?? null;
           return {
             cols: model.cols,
             rows: model.rows,
@@ -1673,8 +1700,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             // not allowed to paint must not be judged blank by the watchdog.
             active: runtimeMetaRef.current ? runtimeMetaRef.current.isActiveSession : true,
             // Geometry for the bottom-clip detector / on-demand dump. Reads the
-            // container live (forces a layout), so only the low-frequency sweep
-            // and the manual dump call this — never the per-frame paint path.
+            // container/canvas live (forces a layout via getBoundingClientRect),
+            // so only the low-frequency sweep and the manual dump call this —
+            // never the per-frame paint path. The rects are DOM truth: they
+            // catch a canvas offset or mis-sized within its container even
+            // when the model's own row*cellHeight arithmetic looks clean.
             session: runtimeMetaRef.current?.sessionId ?? undefined,
             isActivePane: runtimeMetaRef.current?.isActivePane ?? null,
             hasMeasuredSize: hasMeasuredSizeRef.current,
@@ -1682,6 +1712,17 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             cellHeight: activeRenderer?.cellHeight ?? null,
             clientWidth: activeContainer?.clientWidth ?? null,
             clientHeight: activeContainer?.clientHeight ?? null,
+            containerTop: containerRect?.top ?? null,
+            containerBottom: containerRect?.bottom ?? null,
+            containerLeft: containerRect?.left ?? null,
+            containerRight: containerRect?.right ?? null,
+            canvasTop: canvasRect?.top ?? null,
+            canvasBottom: canvasRect?.bottom ?? null,
+            canvasLeft: canvasRect?.left ?? null,
+            canvasRight: canvasRect?.right ?? null,
+            canvasCssHeight: canvasRect?.height ?? null,
+            canvasPixelWidth: activeCanvas?.width ?? null,
+            canvasPixelHeight: activeCanvas?.height ?? null,
           };
         });
         inputRef.current = new InputHandler(

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -10,6 +10,7 @@ import { SHORTCUTS, type ShortcutId, type Combo, isChord, resolveBinding } from 
 import { getGridAutomationHandle, INACTIVE_GRID_STATE } from '../components/grid/gridAutomation';
 import { getTerminalPerfSnapshot } from '../utils/terminalPerf';
 import { readWarmWorkspaceLimit } from '../utils/terminalVirtualization';
+import { dumpTerminalGeometry } from '../utils/terminalDiagnosticsLog';
 import { getReviewPerfSnapshot } from '../utils/reviewPerf';
 import { clearPtyPerfSnapshot, getPtyPerfSnapshot, recordPtyDecode, recordWsJsonParse } from '../utils/ptyPerf';
 import { buildSessionRenderHealth } from '../utils/renderHealth';
@@ -1790,6 +1791,14 @@ export function useUiAutomationBridge({
         const limit = readWarmWorkspaceLimit();
         const virtualizedPanes = document.querySelectorAll('[data-testid^="pane-virtualized-"]').length;
         return { limit, virtualizedPanes };
+      }
+      case 'dump_terminal_geometry': {
+        // Same-moment app-side read of every mounted pane's model grid, cell
+        // metrics, clientWidth/Height, and DOM-truth canvas rects — avoids the
+        // cross-clock ambiguity of comparing a harness screenshot's timestamp
+        // against a separately-read disk dump.
+        const snapshots = dumpTerminalGeometry();
+        return { snapshots };
       }
       case 'reload_session': {
         if (!reloadSession) {

--- a/app/src/utils/terminalDiagnosticsLog.test.ts
+++ b/app/src/utils/terminalDiagnosticsLog.test.ts
@@ -232,4 +232,97 @@ describe('bottom-clip detector', () => {
       rows: 26, flooredRows: 25, flooredCols: 80, overflowPx: 6, clipping: true,
     });
   });
+
+  it('flags DOM-truth bottom overflow even when the model math is clean', () => {
+    const pane = 'pane-clip-dom-overflow';
+    // Model math is clean (rows*cellHeight == clientHeight), but the real
+    // canvas rect spills 5px past the container's bottom edge.
+    const unregister = registerRenderProbe(pane, () => probeWith({
+      rows: 25, cellHeight: 21, clientHeight: 525,
+      containerTop: 0, containerBottom: 525, canvasTop: 0, canvasBottom: 530,
+    }));
+    vi.advanceTimersByTime(1600);
+    unregister();
+
+    const incidents = ringEventsFor(pane).filter((event) => event.kind === 'incident');
+    expect(incidents).toHaveLength(1);
+    expect(incidents[0]?.reason).toBe('bottom_clip');
+    expect(incidents[0]?.trigger).toEqual(['dom_overflow']);
+    expect(incidents[0]?.domOverflowPx).toBe(5);
+    expect(incidents[0]?.domOffsetTopPx).toBe(0);
+  });
+
+  it('flags a DOM-truth top offset even when the model math is clean', () => {
+    const pane = 'pane-clip-dom-offset';
+    const unregister = registerRenderProbe(pane, () => probeWith({
+      rows: 25, cellHeight: 21, clientHeight: 525,
+      containerTop: 0, containerBottom: 525, canvasTop: 4, canvasBottom: 525,
+    }));
+    vi.advanceTimersByTime(1600);
+    unregister();
+
+    const incidents = ringEventsFor(pane).filter((event) => event.kind === 'incident');
+    expect(incidents).toHaveLength(1);
+    expect(incidents[0]?.reason).toBe('bottom_clip');
+    expect(incidents[0]?.trigger).toEqual(['dom_offset']);
+    expect(incidents[0]?.domOffsetTopPx).toBe(4);
+    expect(incidents[0]?.domOverflowPx).toBe(0);
+  });
+
+  it('stays clean and resolves a previously-clipping pane when all three signals agree', () => {
+    const pane = 'pane-clip-all-clean-then-resolve';
+    let clipping = true;
+    const unregister = registerRenderProbe(pane, () => (clipping
+      ? probeWith({
+        rows: 26, cellHeight: 21, clientHeight: 540,
+        containerTop: 0, containerBottom: 540, canvasTop: 0, canvasBottom: 546,
+      })
+      : probeWith({
+        rows: 25, cellHeight: 21, clientHeight: 525,
+        containerTop: 0, containerBottom: 525, canvasTop: 0, canvasBottom: 525,
+      })));
+    vi.advanceTimersByTime(1600); // onset (model + dom overflow agree)
+    clipping = false;
+    vi.advanceTimersByTime(1600); // all three signals clean → resolution
+    unregister();
+
+    const reasons = ringEventsFor(pane)
+      .filter((event) => event.kind === 'incident')
+      .map((event) => event.reason);
+    expect(reasons).toEqual(['bottom_clip', 'bottom_clip_resolved']);
+  });
+
+  it('flags a right-edge-only overflow that the bottom-only signals miss', () => {
+    const pane = 'pane-clip-right-overflow';
+    // Bottom is clean (even slightly under, i.e. negative overflow), but the
+    // canvas spills 7px past the container's right edge — the field repro
+    // this detector was blind to before the right/left signals were added.
+    const unregister = registerRenderProbe(pane, () => probeWith({
+      rows: 25, cellHeight: 21, clientHeight: 525,
+      containerTop: 0, containerBottom: 525, canvasTop: 0, canvasBottom: 525,
+      containerLeft: 0, containerRight: 720, canvasLeft: 0, canvasRight: 727,
+    }));
+    vi.advanceTimersByTime(1600);
+    unregister();
+
+    const incidents = ringEventsFor(pane).filter((event) => event.kind === 'incident');
+    expect(incidents).toHaveLength(1);
+    expect(incidents[0]?.reason).toBe('bottom_clip');
+    expect(incidents[0]?.trigger).toEqual(['dom_overflow_right']);
+    expect(incidents[0]?.domOverflowRightPx).toBe(7);
+    expect(incidents[0]?.domOffsetLeftPx).toBe(0);
+  });
+
+  it('stays clean when left/right rects agree with the container', () => {
+    const pane = 'pane-clip-lr-clean';
+    const unregister = registerRenderProbe(pane, () => probeWith({
+      rows: 25, cellHeight: 21, clientHeight: 525,
+      containerTop: 0, containerBottom: 525, canvasTop: 0, canvasBottom: 525,
+      containerLeft: 0, containerRight: 720, canvasLeft: 0, canvasRight: 720,
+    }));
+    vi.advanceTimersByTime(1600);
+    unregister();
+
+    expect(ringEventsFor(pane).filter((event) => event.kind === 'incident')).toHaveLength(0);
+  });
 });

--- a/app/src/utils/terminalDiagnosticsLog.ts
+++ b/app/src/utils/terminalDiagnosticsLog.ts
@@ -116,6 +116,20 @@ export interface RenderProbe {
   cellHeight?: number | null;
   clientWidth?: number | null;
   clientHeight?: number | null;
+  // DOM-truth rects, so the detector can also catch a canvas that disagrees
+  // with the model (offset within its container, or a size mismatch) rather
+  // than only judging the model's own arithmetic.
+  containerTop?: number | null;
+  containerBottom?: number | null;
+  containerLeft?: number | null;
+  containerRight?: number | null;
+  canvasTop?: number | null;
+  canvasBottom?: number | null;
+  canvasLeft?: number | null;
+  canvasRight?: number | null;
+  canvasCssHeight?: number | null;
+  canvasPixelWidth?: number | null;
+  canvasPixelHeight?: number | null;
 }
 
 export interface TerminalGeometrySnapshot {
@@ -133,6 +147,13 @@ export interface TerminalGeometrySnapshot {
   flooredCols: number | null;
   flooredRows: number | null;
   overflowPx: number | null;
+  domOverflowPx: number | null;
+  domOffsetTopPx: number | null;
+  domOverflowRightPx: number | null;
+  domOffsetLeftPx: number | null;
+  canvasCssHeight: number | null;
+  canvasPixelWidth: number | null;
+  canvasPixelHeight: number | null;
   clipping: boolean;
 }
 
@@ -427,7 +448,7 @@ export function registerRenderProbe(pane: string, probe: () => RenderProbe | nul
 
 export function noteResize(
   pane: string,
-  info: { session?: string; source: string; fromCols?: number; fromRows?: number; toCols?: number; toRows?: number; bail?: string; noop?: boolean; paneKind?: string; historicalReplay?: boolean },
+  info: { session?: string; source: string; fromCols?: number; fromRows?: number; toCols?: number; toRows?: number; bail?: string; noop?: boolean; paneKind?: string; historicalReplay?: boolean; cw?: number; ch?: number },
 ): void {
   recordDiag({ kind: 'resize', pane, ...info });
   // A WebGL canvas only clears its drawing buffer when its pixel dimensions
@@ -553,6 +574,37 @@ function bottomClipOverflowPx(probe: RenderProbe): number | null {
   return probe.rows * cellHeight - clientHeight;
 }
 
+// DOM-truth signals: computed straight from getBoundingClientRect(), so they
+// catch a canvas that is offset or mis-sized within its container even when
+// the model's own row*cellHeight arithmetic looks clean.
+function domOverflowPx(probe: RenderProbe): number | null {
+  if (probe.canvasBottom == null || probe.containerBottom == null) {
+    return null;
+  }
+  return probe.canvasBottom - probe.containerBottom;
+}
+
+function domOffsetTopPx(probe: RenderProbe): number | null {
+  if (probe.canvasTop == null || probe.containerTop == null) {
+    return null;
+  }
+  return probe.canvasTop - probe.containerTop;
+}
+
+function domOverflowRightPx(probe: RenderProbe): number | null {
+  if (probe.canvasRight == null || probe.containerRight == null) {
+    return null;
+  }
+  return probe.canvasRight - probe.containerRight;
+}
+
+function domOffsetLeftPx(probe: RenderProbe): number | null {
+  if (probe.canvasLeft == null || probe.containerLeft == null) {
+    return null;
+  }
+  return probe.canvasLeft - probe.containerLeft;
+}
+
 function recordBottomClipIncident(pane: string, detail: Record<string, unknown>): void {
   const now = Date.now();
   const session = typeof detail.session === 'string' ? detail.session : undefined;
@@ -594,10 +646,23 @@ function sweepBottomClip(): void {
       continue;
     }
     const overflowPx = bottomClipOverflowPx(probe);
-    if (overflowPx == null) {
+    const domOverflow = domOverflowPx(probe);
+    const domOffset = domOffsetTopPx(probe);
+    const domOverflowRight = domOverflowRightPx(probe);
+    const domOffsetLeft = domOffsetLeftPx(probe);
+    if (
+      overflowPx == null && domOverflow == null && domOffset == null
+      && domOverflowRight == null && domOffsetLeft == null
+    ) {
       continue;
     }
-    const clipping = overflowPx > BOTTOM_CLIP_SLACK_PX;
+    const trigger: string[] = [];
+    if (overflowPx != null && overflowPx > BOTTOM_CLIP_SLACK_PX) trigger.push('model');
+    if (domOverflow != null && domOverflow > BOTTOM_CLIP_SLACK_PX) trigger.push('dom_overflow');
+    if (domOffset != null && domOffset > BOTTOM_CLIP_SLACK_PX) trigger.push('dom_offset');
+    if (domOverflowRight != null && domOverflowRight > BOTTOM_CLIP_SLACK_PX) trigger.push('dom_overflow_right');
+    if (domOffsetLeft != null && domOffsetLeft > BOTTOM_CLIP_SLACK_PX) trigger.push('dom_offset_left');
+    const clipping = trigger.length > 0;
     if (clipping === wasClipping) {
       continue;
     }
@@ -611,14 +676,22 @@ function sweepBottomClip(): void {
         cols: probe.cols,
         flooredRows,
         extraRows: probe.rows - flooredRows,
-        overflowPx: Math.round(overflowPx),
+        overflowPx: overflowPx == null ? null : Math.round(overflowPx),
+        domOverflowPx: domOverflow == null ? null : Math.round(domOverflow),
+        domOffsetTopPx: domOffset == null ? null : Math.round(domOffset),
+        domOverflowRightPx: domOverflowRight == null ? null : Math.round(domOverflowRight),
+        domOffsetLeftPx: domOffsetLeft == null ? null : Math.round(domOffsetLeft),
         cellHeight,
         cellWidth: probe.cellWidth ?? null,
         clientHeight,
         clientWidth: probe.clientWidth ?? null,
+        canvasCssHeight: probe.canvasCssHeight == null ? null : Math.round(probe.canvasCssHeight),
+        canvasPixelWidth: probe.canvasPixelWidth ?? null,
+        canvasPixelHeight: probe.canvasPixelHeight ?? null,
         hasMeasuredSize: probe.hasMeasuredSize ?? null,
         isActivePane: probe.isActivePane ?? null,
         session: probe.session,
+        trigger,
         dpr: window.devicePixelRatio,
         winInnerWidth: window.innerWidth,
         winInnerHeight: window.innerHeight,
@@ -634,7 +707,11 @@ function sweepBottomClip(): void {
         rows: probe.rows,
         cols: probe.cols,
         flooredRows,
-        overflowPx: Math.round(overflowPx),
+        overflowPx: overflowPx == null ? null : Math.round(overflowPx),
+        domOverflowPx: domOverflow == null ? null : Math.round(domOverflow),
+        domOffsetTopPx: domOffset == null ? null : Math.round(domOffset),
+        domOverflowRightPx: domOverflowRight == null ? null : Math.round(domOverflowRight),
+        domOffsetLeftPx: domOffsetLeft == null ? null : Math.round(domOffsetLeft),
         cellHeight,
         clientHeight,
       });
@@ -675,6 +752,10 @@ export function dumpTerminalGeometry(): TerminalGeometrySnapshot[] {
     const clientHeight = probe.clientHeight ?? null;
     const clientWidth = probe.clientWidth ?? null;
     const overflowPx = cellHeight && clientHeight ? probe.rows * cellHeight - clientHeight : null;
+    const domOverflow = domOverflowPx(probe);
+    const domOffset = domOffsetTopPx(probe);
+    const domOverflowRight = domOverflowRightPx(probe);
+    const domOffsetLeft = domOffsetLeftPx(probe);
     snapshots.push({
       pane,
       session: probe.session,
@@ -690,7 +771,18 @@ export function dumpTerminalGeometry(): TerminalGeometrySnapshot[] {
       flooredCols: cellWidth && clientWidth ? Math.floor(clientWidth / cellWidth) : null,
       flooredRows: cellHeight && clientHeight ? Math.floor(clientHeight / cellHeight) : null,
       overflowPx: overflowPx == null ? null : Math.round(overflowPx),
-      clipping: overflowPx != null && overflowPx > BOTTOM_CLIP_SLACK_PX,
+      domOverflowPx: domOverflow == null ? null : Math.round(domOverflow),
+      domOffsetTopPx: domOffset == null ? null : Math.round(domOffset),
+      domOverflowRightPx: domOverflowRight == null ? null : Math.round(domOverflowRight),
+      domOffsetLeftPx: domOffsetLeft == null ? null : Math.round(domOffsetLeft),
+      canvasCssHeight: probe.canvasCssHeight == null ? null : Math.round(probe.canvasCssHeight),
+      canvasPixelWidth: probe.canvasPixelWidth ?? null,
+      canvasPixelHeight: probe.canvasPixelHeight ?? null,
+      clipping: (overflowPx != null && overflowPx > BOTTOM_CLIP_SLACK_PX)
+        || (domOverflow != null && domOverflow > BOTTOM_CLIP_SLACK_PX)
+        || (domOffset != null && domOffset > BOTTOM_CLIP_SLACK_PX)
+        || (domOverflowRight != null && domOverflowRight > BOTTOM_CLIP_SLACK_PX)
+        || (domOffsetLeft != null && domOffsetLeft > BOTTOM_CLIP_SLACK_PX),
     });
   }
   enqueueWrite('incident', `${JSON.stringify({ at: Date.now(), kind: 'geometry_dump', snapshots })}\n`);


### PR DESCRIPTION
## What

Diagnostics + reproduction tooling for the long-standing "terminal gets offset / bottom cut off, remount fixes it" bug. First PR of a 4-PR stack (this one → remetric → recover → reveal).

- **DOM-truth clip detector**: incidents in `terminal-incidents.jsonl` now compare the canvas rect against the container rect directly, with a `trigger` array (`model`, `dom_overflow`, `dom_overflow_right`, `dom_overflow_left`, `dom_offset`). Previously right-edge-only overflows were invisible to the detector.
- **Fit-bail logging**: `fit()` bail-outs (no renderer, same size, suspicious size) are now logged with container `cw/ch` — a silent `fit()` no-op on a dead renderer cost hours of diagnosis.
- **Offset soak scenario** (`real-app:scenario-offset-soak`): seeded, weighted random walk over the packaged app — workspace switches, font scaling, window resizes, rapid double-switches, splits/close-splits — measuring every pane's canvas-vs-container geometry after each step. Suspect clips are polled every 750ms up to 4.5s: first clean re-measure classifies it a transient (with `healMs`); persistent failures dump full evidence (violation.json with all recheck rounds, pane states, native screenshot, diagnostics tail).

## Why

The bug was effectively unreproducible by hand. The soak makes it deterministic: on main, `--seed 2 --iterations 300` fails with a persistent violation at step 291 (WebGL context exhaustion after font-size rebuild storms — fixed in the next PRs in the stack). The transient-poll window is calibrated from measured attach-replay churn: replay storms can outlast 1.5s (observed heals up to 2.4s), so a single fixed recheck misclassifies transients as persistent.

## Verification

- Detector confirmed live in the packaged app (29 incidents in a soak run, including 4 right-edge-only clips previously invisible).
- Full seed-2 × 300 soak run against the complete stack: 0 persistent violations, 19 transients (max heal 2430ms).
- Diagnostics are dev-instrumentation (JSONL on disk, per AGENTS.md frontend-instrumentation pattern); no user-facing behavior change, no CHANGELOG entry.