### PR TITLE
fix(terminal): remetric renderer on font-size change instead of rebuilding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Pin the chief-of-staff's reasoning effort, per agent.** Settings → Agents → "Chief-of-staff model & effort" now has an effort selector next to each agent's model override (Claude: low, medium, high, xhigh, max; Codex: minimal, low, medium, high, xhigh). Leave it on "Agent default" to use the agent's own default. Only chief-of-staff launches are affected — regular sessions are unaffected.
 
+### Fixed
+- **Changing font size no longer risks blank or misrendered terminals when many panes are open.** Adjusting the terminal font size used to rebuild every open pane's terminal (visible and backgrounded), which under enough open panes could exhaust the app's GPU rendering resources and leave a pane permanently blank or garbled until reopened. Terminals now update in place to the new font size instead of being rebuilt.
+
 ## [2026-07-03]
 
 ### Added

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -546,6 +546,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const filterQueryRef = useRef('');
     const filterInputRef = useRef<HTMLInputElement>(null);
     const filterRescanTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Read by the mount effect at construction time without being a dependency
+    // of it — see the font-size effect below for why font changes must not
+    // rebuild the model/renderer.
+    const fontSizeRef = useRef(fontSize);
 
     onInputRef.current = onInput;
     onReadyRef.current = onReady;
@@ -554,6 +558,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     runtimeMetaRef.current = runtimeLogMeta;
     debugNameRef.current = debugName;
     cwdRef.current = cwd;
+    fontSizeRef.current = fontSize;
     // Stable diagnostics key for the per-pane watchdog/probe registries. paneId
     // is stable for a pane's life and correlates with daemon/workspace logs;
     // debugName can change (its agent/title segment is reassigned on relabel).
@@ -1665,7 +1670,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           cols: initialSize.cols,
           rows: initialSize.rows,
         });
-        const renderer = new WebGlTerminalRenderer(canvas, fontSize, FONT_FAMILY, {
+        const renderer = new WebGlTerminalRenderer(canvas, fontSizeRef.current, FONT_FAMILY, {
           background: theme.background,
           foreground: theme.foreground,
           cursor: theme.cursor,
@@ -1675,7 +1680,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         // The bundled Nerd Font may not be loaded yet, so the first glyphs that
         // need it rasterize blank. Once it loads, drop the stale glyph cache and
         // repaint so terminal icons (eza --icons, powerline, devicons) appear.
-        void ensureTerminalIconFont(fontSize).then(() => {
+        void ensureTerminalIconFont(fontSizeRef.current).then(() => {
           if (!active || rendererRef.current !== renderer) return;
           renderer.invalidateGlyphCache();
           renderSurface(true);
@@ -1845,7 +1850,35 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // Ghostty cells contain their resolved default RGB values, so theme
     // changes require a fresh model. The pane runtime rehydrates this model
     // from verified replay without sending historical replies to the live PTY.
-    }, [cancelScheduledOutputRender, clearSynchronizedOutputRenderTimer, fit, fontSize, getText, getVisibleContent, getVisibleStyleSummary, openFind, renderSurface, resizeLocal, resolvedTheme, write]);
+    // fontSize is intentionally NOT a dependency: see the font-size effect
+    // below for why a size change must re-metric the existing renderer in
+    // place instead of rebuilding the model/renderer for every mounted pane.
+    }, [cancelScheduledOutputRender, clearSynchronizedOutputRenderTimer, fit, getText, getVisibleContent, getVisibleStyleSummary, openFind, renderSurface, resizeLocal, resolvedTheme, write]);
+
+    // React to a font-size change without tearing down the WASM model or the
+    // WebGL renderer. Rebuilding on every font-size change (the previous
+    // behavior, when fontSize was in the mount effect's deps) tears down and
+    // reconstructs EVERY mounted pane (active + warm hidden), pressuring
+    // WKWebView's small live-WebGL-context pool badly enough to lose/fail
+    // contexts and permanently break panes — and it left hidden panes' canvases
+    // sized for the old font, since a hidden pane's fit() bails and never
+    // re-measures until revealed. Re-metricing in place avoids both: it costs
+    // one glyph-atlas invalidation instead of a full rebuild, and resize()
+    // re-asserts canvas geometry immediately even for panes that won't fit()
+    // again until they're shown.
+    useEffect(() => {
+      const renderer = rendererRef.current;
+      if (!renderer) return;
+      renderer.setFontSize(fontSize);
+      renderer.resize(modelSizeRef.current.cols, modelSizeRef.current.rows);
+      void ensureTerminalIconFont(fontSize).then(() => {
+        if (rendererRef.current !== renderer) return;
+        renderer.invalidateGlyphCache();
+        renderSurface(true);
+      });
+      fit();
+      renderSurface(true);
+    }, [fontSize]);
 
     // Release this pane's WebGL2 context when the pane unmounts. Browsers cap the
     // number of simultaneously-live WebGL contexts (WKWebView's cap is low), and

--- a/app/src/components/GhosttyWebGlRenderer.test.ts
+++ b/app/src/components/GhosttyWebGlRenderer.test.ts
@@ -109,7 +109,12 @@ function makeRecordingContext() {
     // simulate a color-font raster (e.g. emoji) vs the default transparent one.
     nextPixel: null as null | { r: number; g: number; b: number; a: number },
     measureText(text: string) {
-      return { width: text.length * 8 };
+      // Scale with the current font's px size (default 14) so tests can exercise
+      // cellWidth recomputation on a font-size change; existing 14px-fixture
+      // tests are unaffected since the factor is 1 at the default size.
+      const sizeMatch = /^(\d+(?:\.\d+)?)px/.exec(this.font);
+      const size = sizeMatch ? Number.parseFloat(sizeMatch[1]) : 14;
+      return { width: text.length * 8 * (size / 14) };
     },
     clearRect() {},
     fillRect() {},
@@ -325,6 +330,63 @@ describe('WebGlTerminalRenderer glyph cache invalidation', () => {
     renderer.invalidateGlyphCache();
     renderer.getGlyph('', 0);
     expect(atlasContext.fillTextCalls.length).toBe(afterFirst + 1);
+  });
+});
+
+// setFontSize() must re-metric an existing renderer in place (no rebuild) so a
+// font-size change doesn't tear down every mounted pane's WASM model/WebGL
+// context. document.createElement is re-mocked around the call because
+// setFontSize creates its own metrics canvas, just like the constructor does.
+describe('WebGlTerminalRenderer.setFontSize', () => {
+  function withMockedCanvas<T>(fn: () => T): T {
+    const realCreate = document.createElement.bind(document);
+    const spy = vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+      if (tag === 'canvas') return makeFakeCanvas();
+      return realCreate(tag);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any);
+    try {
+      return fn();
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  it('grows cell metrics for a larger font size and invalidates the glyph cache', () => {
+    const { renderer, atlasContext } = makeRenderer(14, 'monospace');
+    const smallWidth = renderer.cellWidth;
+    const smallHeight = renderer.cellHeight;
+    const smallBaseline = renderer.baseline;
+
+    renderer.getGlyph('A', 0);
+    const rasterizedBeforeResize = atlasContext.fillTextCalls.length;
+    renderer.getGlyph('A', 0);
+    expect(atlasContext.fillTextCalls.length).toBe(rasterizedBeforeResize); // served from cache
+
+    withMockedCanvas(() => renderer.setFontSize(28));
+
+    expect(renderer.cellWidth).toBeGreaterThan(smallWidth);
+    expect(renderer.cellHeight).toBeGreaterThan(smallHeight);
+    expect(renderer.baseline).toBeGreaterThan(smallBaseline);
+
+    // The pre-resize glyph must not be served from a stale cache at the new size.
+    renderer.getGlyph('A', 0);
+    expect(atlasContext.fillTextCalls.length).toBe(rasterizedBeforeResize + 1);
+  });
+
+  it('resizes the canvas to the new cell metrics even when cols/rows are unchanged', () => {
+    const { renderer } = makeRenderer(14, 'monospace');
+    const canvas = renderer.canvas as ReturnType<typeof makeFakeCanvas>;
+    renderer.resize(80, 24);
+    const widthBefore = canvas.width;
+    const heightBefore = canvas.height;
+
+    withMockedCanvas(() => renderer.setFontSize(28));
+    // Same grid dimensions as before the font-size change.
+    renderer.resize(80, 24);
+
+    expect(canvas.width).toBeGreaterThan(widthBefore);
+    expect(canvas.height).toBeGreaterThan(heightBefore);
   });
 });
 

--- a/app/src/components/GhosttyWebGlRenderer.ts
+++ b/app/src/components/GhosttyWebGlRenderer.ts
@@ -226,8 +226,8 @@ function createProgram(gl: WebGL2RenderingContext): WebGLProgram {
 }
 
 export class WebGlTerminalRenderer {
-  readonly cellWidth: number;
-  readonly cellHeight: number;
+  cellWidth: number;
+  cellHeight: number;
 
   private readonly canvas: HTMLCanvasElement;
   private readonly gl: WebGL2RenderingContext;
@@ -238,8 +238,8 @@ export class WebGlTerminalRenderer {
   private readonly atlasContext: CanvasRenderingContext2D;
   private readonly glyphs = new Map<string, AtlasGlyph>();
   private readonly dpr: number;
-  private readonly baseline: number;
-  private readonly fontSize: number;
+  private baseline: number;
+  private fontSize: number;
   private readonly fontFamily: string;
   private readonly theme: RendererTheme;
   private atlasSize = INITIAL_ATLAS_SIZE;
@@ -256,6 +256,14 @@ export class WebGlTerminalRenderer {
   private retryingAtlasFrame = false;
   private cols = 0;
   private rows = 0;
+  // Set by setFontSize() so the next resize() call re-sizes the canvas even
+  // when cols/rows are unchanged. Cell metrics can change independently of
+  // grid dimensions (a font-size change with no container resize), and
+  // resize()'s cols/rows guard alone would otherwise skip it, leaving the
+  // canvas sized for the old font — invisible on the active pane (fit()
+  // recomputes cols/rows too, so it rarely hits this path) but permanent on
+  // hidden panes, which never fit() until revealed.
+  private metricsDirty = false;
 
   constructor(canvas: HTMLCanvasElement, fontSize: number, fontFamily: string, theme: RendererTheme) {
     this.canvas = canvas;
@@ -327,9 +335,10 @@ export class WebGlTerminalRenderer {
   }
 
   resize(cols: number, rows: number): void {
-    if (cols === this.cols && rows === this.rows) {
+    if (cols === this.cols && rows === this.rows && !this.metricsDirty) {
       return;
     }
+    this.metricsDirty = false;
     this.cols = cols;
     this.rows = rows;
     this.canvas.width = Math.ceil(cols * this.cellWidth * this.dpr);
@@ -519,6 +528,29 @@ export class WebGlTerminalRenderer {
   // caller is responsible for forcing a redraw afterwards.
   invalidateGlyphCache(): void {
     this.reseedAtlas();
+  }
+
+  // Re-metric this renderer for a new font size in place, instead of tearing
+  // down and reconstructing the WASM model + WebGL context on every font-size
+  // change. WKWebView has a small pool of live WebGL contexts; rebuilding every
+  // mounted pane (active + warm hidden) on a font change pressures that pool
+  // and can permanently break panes with a lost/failed context. This does not
+  // touch canvas sizing — the caller re-asserts cols/rows via resize() so
+  // hidden panes' canvases stay consistent with the model without needing a
+  // container measurement.
+  setFontSize(fontSize: number): void {
+    this.fontSize = fontSize;
+    const metricsCanvas = document.createElement('canvas');
+    const metricsContext = metricsCanvas.getContext('2d');
+    if (!metricsContext) {
+      throw new Error('Unable to measure terminal font');
+    }
+    metricsContext.font = `${fontSize}px ${this.fontFamily}`;
+    this.cellWidth = Math.max(1, Math.ceil(metricsContext.measureText('M').width));
+    this.cellHeight = Math.max(1, Math.ceil(fontSize * 1.45));
+    this.baseline = Math.ceil(fontSize * 1.1);
+    this.metricsDirty = true;
+    this.invalidateGlyphCache();
   }
 
   private configureAttribute(name: string, size: number, stride: number, offset: number): void {


### PR DESCRIPTION
## What

Second PR of the offset-bug stack (on top of #471). Font-size changes no longer tear down and rebuild the WASM model + WebGL renderer of every mounted pane; the existing renderer re-derives its cell metrics (`setFontSize()` + a `metricsDirty` flag so the next `resize()` re-sizes the canvas even when the grid dimensions are unchanged).

## Why

This is the root cause of the **persistent** offset: a font-size change rebuilt N renderers at once (fontSize was in the mount-effect deps), and rebuild storms combined with warm-set churn exhaust WKWebView's small WebGL context pool. Construction then fails (or a live context is lost), the pane's `fit()` silently no-ops with no renderer, and the canvas keeps its old-font geometry forever — offset/clipped until remount. Remetric-in-place removes the context churn entirely.

## Verification

- Unit tests for the remetric path.
- Soak: on the base branch, seed-2 × 300 fails deterministically with a persistent violation at step 291. With this PR: **0 persistent violations** (18 transients), font-related incidents down from dozens to 2. Re-confirmed at the full-stack tip: 0 persistent / 19 transients.
- CHANGELOG entry included.