### PR TITLE
fix(terminal): auto-recover WebGL renderer on context loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Changing font size no longer risks blank or misrendered terminals when many panes are open.** Adjusting the terminal font size used to rebuild every open pane's terminal (visible and backgrounded), which under enough open panes could exhaust the app's GPU rendering resources and leave a pane permanently blank or garbled until reopened. Terminals now update in place to the new font size instead of being rebuilt.
+- **Terminals now recover automatically if the app's GPU rendering context is lost.** Previously a pane hit by a GPU context loss showed a permanent error asking you to reopen it; it now rebuilds its renderer in place within a fraction of a second, keeping the session's content and scrollback.
 
 ## [2026-07-03]
 

--- a/app/package.json
+++ b/app/package.json
@@ -57,6 +57,7 @@
     "real-app:scenario-terminal-context-menu": "node scripts/real-app-harness/scenario-terminal-context-menu.mjs",
     "real-app:scenario-terminal-block-resize": "node scripts/real-app-harness/scenario-terminal-block-resize.mjs",
     "real-app:scenario-offset-soak": "node scripts/real-app-harness/scenario-offset-soak.mjs",
+    "real-app:scenario-webgl-recovery": "node scripts/real-app-harness/scenario-webgl-recovery.mjs",
     "real-app:serial-matrix": "node scripts/real-app-harness/run-serial-matrix.mjs",
     "e2e": "playwright test",
     "e2e:settings-visual": "playwright test e2e/settings-visual.spec.ts",

--- a/app/scripts/real-app-harness/scenario-webgl-recovery.mjs
+++ b/app/scripts/real-app-harness/scenario-webgl-recovery.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+// Packaged-app scenario for the WebGL context-loss auto-recovery fix
+// (GhosttyTerminal's rendererEpoch backoff): forces the active pane's WebGL
+// context to be lost via the lose_webgl_context bridge action, then asserts
+// the full recovery lifecycle actually happens end to end — not just that
+// the right diagnostics events were logged, but that the rebuilt renderer
+// paints live output again and the pane's error overlay never shows.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  assertCommonTargetAllowed,
+  createRunContext,
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { currentHarnessProfile, resolveHarnessResources } from './harnessProfile.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import {
+  captureSessionArtifacts,
+  sleep,
+  waitForFirstWorkspacePane,
+  waitForPaneAttached,
+  waitForPaneShellReady,
+  waitForPaneText,
+  waitForPaneVisible,
+} from './scenarioAssertions.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+
+const OVERFLOW_TOLERANCE_PX = 2;
+const RECOVERY_TIMEOUT_MS = 10_000;
+const RECOVERY_OUTCOMES = ['contextLost', 'scheduled', 'recovered'];
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = { ...parseCommonArgs([]) };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--ws-url') options.wsUrl = args[++index];
+    else if (arg === '--app-path') options.appPath = args[++index];
+    else if (arg === '--artifacts-dir' || arg === '--artifacts') options.artifactsDir = args[++index];
+    else if (arg === '--session-root-dir') options.sessionRootDir = args[++index];
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
+    else if (arg === '--help' || arg === '-h') options.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!options.help) assertCommonTargetAllowed(options, args);
+  return { options, help: Boolean(options.help) };
+}
+
+// Same on-disk location terminalDiagnosticsLog.ts writes to (see
+// $APPLOCALDATA/debug/terminal-diagnostics.jsonl), derived the same way
+// harnessProfile.mjs's manifestPathForProfile derives the automation manifest
+// path — both live under the profile's bundle's Application Support dir.
+function terminalDiagnosticsLogPath(profile) {
+  return path.join(
+    os.homedir(),
+    'Library',
+    'Application Support',
+    resolveHarnessResources(profile).bundleId,
+    'debug',
+    'terminal-diagnostics.jsonl',
+  );
+}
+
+function readRecoveryEvents(logPath, paneId) {
+  if (!fs.existsSync(logPath)) return [];
+  const events = [];
+  for (const line of fs.readFileSync(logPath, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (entry.kind === 'recovery' && entry.pane === paneId) events.push(entry);
+  }
+  return events;
+}
+
+function tailLog(logPath, lines = 40) {
+  if (!fs.existsSync(logPath)) return '(log file does not exist)';
+  return fs.readFileSync(logPath, 'utf8').trim().split('\n').slice(-lines).join('\n');
+}
+
+// Polls the diagnostics log for `outcomes` to appear, in order, among this
+// pane's recovery records (not necessarily contiguous — other lifecycle
+// events interleave). Returns the matched records for the summary.
+async function waitForRecoverySequence(logPath, paneId, outcomes, timeoutMs) {
+  const startedAt = Date.now();
+  let seen = [];
+  while (Date.now() - startedAt < timeoutMs) {
+    seen = readRecoveryEvents(logPath, paneId);
+    let cursor = 0;
+    for (const event of seen) {
+      if (event.outcome === outcomes[cursor]) cursor += 1;
+      if (cursor === outcomes.length) return seen;
+    }
+    await sleep(300);
+  }
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for recovery sequence [${outcomes.join(' -> ')}] for pane ${paneId}.\n`
+    + `Recovery events seen: ${JSON.stringify(seen, null, 2)}\nLog tail:\n${tailLog(logPath)}`,
+  );
+}
+
+function measurePane(state) {
+  const canvas = state?.pane?.dom?.canvas?.bounds;
+  const container = state?.pane?.dom?.terminalContainer?.bounds;
+  if (!canvas || !container) {
+    throw new Error(`Pane state missing canvas/container DOM bounds:\n${JSON.stringify(state, null, 2)}`);
+  }
+  const overflowBottom = canvas.y + canvas.height - (container.y + container.height);
+  const overflowRight = canvas.x + canvas.width - (container.x + container.width);
+  const offsetTop = canvas.y - container.y;
+  if (
+    overflowBottom > OVERFLOW_TOLERANCE_PX
+    || overflowRight > OVERFLOW_TOLERANCE_PX
+    || offsetTop > OVERFLOW_TOLERANCE_PX
+  ) {
+    throw new Error(
+      `Canvas rect escapes its terminal container: overflowBottom=${overflowBottom.toFixed(1)} `
+      + `overflowRight=${overflowRight.toFixed(1)} offsetTop=${offsetTop.toFixed(1)}\n${JSON.stringify({ canvas, container }, null, 2)}`,
+    );
+  }
+  return { canvas, container, overflowBottom, overflowRight, offsetTop };
+}
+
+async function writeMarkerAndWait(client, sessionId, paneId, marker) {
+  await client.request('write_pane', { sessionId, paneId, text: `echo ${marker}`, submit: true });
+  await waitForPaneText(
+    client,
+    sessionId,
+    paneId,
+    (text) => text.includes(marker),
+    `pane ${paneId} painted marker ${marker}`,
+    15_000,
+  );
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-webgl-recovery.mjs');
+    return;
+  }
+
+  const { runId, runDir, sessionDir } = createRunContext(options, 'webgl-recovery');
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const logPath = terminalDiagnosticsLogPath(currentHarnessProfile());
+  const sessionLabel = `webgl-recovery-${runId}`;
+  // Markers must survive as a single unwrapped line on narrow panes (~50 cols
+  // in split layouts), so keep them short — uniqueness within this run's
+  // paneId is all the log filter needs, not the full runId.
+  const markerSuffix = runId.slice(-6);
+
+  console.log(`[RealAppHarness] runDir=${runDir}`);
+  console.log(`[RealAppHarness] sessionDir=${sessionDir}`);
+  console.log(`[RealAppHarness] wsUrl=${options.wsUrl}`);
+  console.log(`[RealAppHarness] diagnosticsLog=${logPath}`);
+
+  let sessionId = null;
+  try {
+    await launchFreshAppAndConnect(client, observer);
+
+    sessionId = await createSessionAndWaitForInitialPane({
+      client,
+      observer,
+      cwd: sessionDir,
+      label: sessionLabel,
+      agent: 'shell',
+      waitForInitialPaneVisible: false,
+      sessionWaitMs: 30_000,
+    });
+    const pane = await waitForFirstWorkspacePane(client, sessionId, 'initial workspace pane', 20_000);
+    const paneId = pane.paneId;
+    await waitForPaneVisible(client, sessionId, paneId, 20_000);
+    await waitForPaneAttached(client, sessionId, paneId, 20_000);
+    await waitForPaneShellReady(client, sessionId, paneId, {
+      timeoutMs: 20_000,
+      description: 'initial shell pane ready',
+    });
+    await writeMarkerAndWait(client, sessionId, paneId, `PRE_${markerSuffix}`);
+
+    const preLossState = await client.request('get_pane_state', { sessionId, paneId });
+    measurePane(preLossState);
+    console.log(`[RealAppHarness] pre-loss pane geometry sane for pane ${paneId}`);
+
+    await client.request('lose_webgl_context', {});
+    console.log('[RealAppHarness] lose_webgl_context requested');
+
+    const recoveryEvents = await waitForRecoverySequence(logPath, paneId, RECOVERY_OUTCOMES, RECOVERY_TIMEOUT_MS);
+    console.log(`[RealAppHarness] recovery sequence observed: ${recoveryEvents.map((event) => event.outcome).join(' -> ')}`);
+
+    await writeMarkerAndWait(client, sessionId, paneId, `POST_${markerSuffix}`);
+    console.log('[RealAppHarness] rebuilt renderer painted a fresh marker');
+
+    const postRecoveryState = await client.request('get_pane_state', { sessionId, paneId });
+    measurePane(postRecoveryState);
+    if (postRecoveryState?.pane?.dom?.errorVisible) {
+      throw new Error(`Pane still shows its error overlay after recovery:\n${JSON.stringify(postRecoveryState.pane.dom, null, 2)}`);
+    }
+    console.log('[RealAppHarness] post-recovery pane geometry sane, no error overlay');
+
+    const summary = {
+      ok: true,
+      runId,
+      sessionId,
+      paneId,
+      recoveryEvents,
+    };
+    fs.writeFileSync(path.join(runDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    console.log('[RealAppHarness] WebGL recovery scenario passed.');
+    console.log(JSON.stringify(summary, null, 2));
+  } catch (error) {
+    console.error('[RealAppHarness] WebGL recovery scenario failed.');
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    if (sessionId) {
+      await captureSessionArtifacts(client, runDir, 'failure', sessionId).catch(() => {});
+    }
+    fs.writeFileSync(path.join(runDir, 'diagnostics-log-tail.txt'), tailLog(logPath, 200), 'utf8');
+    process.exitCode = 1;
+  } finally {
+    if (sessionId) {
+      await client.request('close_session', { sessionId }).catch(() => {});
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/src/components/GhosttyTerminal.recovery.test.ts
+++ b/app/src/components/GhosttyTerminal.recovery.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { recoveryDelayMs } from './GhosttyTerminal';
+
+describe('recoveryDelayMs (WebGL context-loss recovery backoff)', () => {
+  it('escalates delays across the first three attempts', () => {
+    expect(recoveryDelayMs(1)).toBe(250);
+    expect(recoveryDelayMs(2)).toBe(1500);
+    expect(recoveryDelayMs(3)).toBe(5000);
+  });
+
+  it('gives up (null) once the schedule is exhausted', () => {
+    expect(recoveryDelayMs(4)).toBeNull();
+    expect(recoveryDelayMs(5)).toBeNull();
+    expect(recoveryDelayMs(100)).toBeNull();
+  });
+});

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -82,6 +82,7 @@ import { recordTerminalLinkHitTestEvent } from '../utils/terminalLinkHitTestLog'
 import {
   recordDiag,
   recordPaint,
+  noteRecovery,
   noteResize,
   registerRenderProbe,
   disposePaneDiagnostics,
@@ -344,6 +345,17 @@ export function liveResizeConflictsWithQueuedReplay(
   return fitRequiresTerminalResize(pendingReplay, target) ? 'cancel' : 'skip';
 }
 
+// Backoff schedule for WebGL renderer-recovery retries (context loss or a
+// failed construction): `attempt` is 1-indexed (the first retry is attempt 1).
+// Returns the delay before that attempt, or null once attempts are exhausted
+// and the pane should fall back to the "reopen the pane" error state — PR B
+// already removed most of the context-pool pressure that caused losses, so a
+// handful of short, escalating retries covers the rare remaining cases
+// without spinning forever on a genuinely dead GPU/context.
+export function recoveryDelayMs(attempt: number): number | null {
+  const schedule = [250, 1500, 5000];
+  return schedule[attempt - 1] ?? null;
+}
 
 function wordRangeAtColumn(line: string, col: number): { startCol: number; endCol: number } | null {
   const isWordCharacter = (character: string | undefined) => Boolean(character && /[\w-]/.test(character));
@@ -537,6 +549,17 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     const runtimeMetaRef = useRef(runtimeLogMeta);
     const debugNameRef = useRef(debugName);
     const diagKeyRef = useRef<string>(runtimeLogMeta?.paneId ?? runtimeLogMeta?.sessionId ?? debugName);
+    // Bumping this remounts the <canvas> (keyed by it below), forcing a fresh
+    // getContext('webgl2') — the only way off a lost context, since a canvas
+    // keeps returning the same (dead) context object from getContext() for
+    // its own lifetime. See the recovery effect for why this beats setError.
+    const [rendererEpoch, setRendererEpoch] = useState(0);
+    // Recovery attempt counter (reset to 0 once a construction succeeds) and
+    // the pending retry timer, if any. Refs, not state: they must be readable
+    // synchronously inside the mount effect's own cleanup/scheduling without
+    // triggering a render.
+    const recoveryAttemptRef = useRef(0);
+    const recoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [linkCursorActive, setLinkCursorActive] = useState(false);
     const [findUi, setFindUi] = useState({ open: false, matchCount: 0, focusedIndex: -1, scanning: false, caseSensitive: false });
@@ -1631,6 +1654,33 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       const canvas = canvasRef.current;
       if (!container || !canvas) return;
       const perfId = `ghostty-${debugNameRef.current}`;
+      // Schedules the next WebGL-recovery attempt (a lost context or a failed
+      // renderer construction land here) with escalating backoff. A pending
+      // timer is never doubled: a context-lost event and a construction
+      // failure could otherwise both fire for the same dead renderer.
+      const scheduleRecovery = () => {
+        if (recoveryTimerRef.current !== null) return;
+        recoveryAttemptRef.current += 1;
+        const attempt = recoveryAttemptRef.current;
+        const delay = recoveryDelayMs(attempt);
+        const session = runtimeMetaRef.current?.sessionId ?? undefined;
+        const paneKind = runtimeMetaRef.current?.paneKind ?? undefined;
+        if (delay === null) {
+          noteRecovery(diagKeyRef.current, { session, paneKind, attempt, outcome: 'giveUp' });
+          setError('Ghostty WebGL context lost. Reopen the pane to rebuild the renderer.');
+          return;
+        }
+        noteRecovery(diagKeyRef.current, { session, paneKind, attempt, outcome: 'scheduled', delayMs: delay });
+        recoveryTimerRef.current = setTimeout(() => {
+          recoveryTimerRef.current = null;
+          // A stale timer must not resurrect a pane that has since unmounted
+          // (or been torn down for an unrelated reason, e.g. this same effect
+          // already cleaned up) — cleanup below also cancels this outright,
+          // this is a second line of defense.
+          if (!active) return;
+          setRendererEpoch((value) => value + 1);
+        }, delay);
+      };
       void Ghostty.load(ghosttyWasmUrl).then((ghostty) => {
         if (!active) return;
         const theme = getTerminalTheme(resolvedTheme);
@@ -1677,6 +1727,16 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         });
         terminalRef.current = terminal;
         rendererRef.current = renderer;
+        if (recoveryAttemptRef.current > 0) {
+          noteRecovery(diagKeyRef.current, {
+            session: runtimeMetaRef.current?.sessionId ?? undefined,
+            paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
+            attempt: recoveryAttemptRef.current,
+            outcome: 'recovered',
+          });
+        }
+        recoveryAttemptRef.current = 0;
+        setError(null);
         // The bundled Nerd Font may not be loaded yet, so the first glyphs that
         // need it rasterize blank. Once it loads, drop the stale glyph cache and
         // repaint so terminal icons (eza --icons, powerline, devicons) appear.
@@ -1777,11 +1837,27 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           drain: () => writeChainRef.current,
         });
       }).catch((reason) => {
-        if (active) setError(String(reason));
+        if (!active) return;
+        noteRecovery(diagKeyRef.current, {
+          session: runtimeMetaRef.current?.sessionId ?? undefined,
+          paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
+          attempt: recoveryAttemptRef.current,
+          outcome: 'constructFailed',
+          error: String(reason),
+        });
+        scheduleRecovery();
       });
       const handleContextLost = (event: Event) => {
         event.preventDefault();
-        setError('Ghostty WebGL context lost. Reopen the pane to rebuild the renderer.');
+        if (!active) return;
+        noteRecovery(diagKeyRef.current, {
+          session: runtimeMetaRef.current?.sessionId ?? undefined,
+          paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
+          attempt: recoveryAttemptRef.current,
+          outcome: 'contextLost',
+        });
+        setError(null);
+        scheduleRecovery();
       };
       canvas.addEventListener('webglcontextlost', handleContextLost);
       const unregister = registerTerminalPerfGetter(perfId, () => {
@@ -1821,6 +1897,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       });
       return () => {
         active = false;
+        if (recoveryTimerRef.current !== null) {
+          clearTimeout(recoveryTimerRef.current);
+          recoveryTimerRef.current = null;
+        }
         recordDiag({
           kind: 'pane_unmount',
           pane: diagKeyRef.current,
@@ -1846,14 +1926,36 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         inputRef.current = null;
         rendererRef.current = null;
         terminalRef.current = null;
+        // Release THIS canvas's GL context deterministically the moment it is
+        // discarded for good, instead of waiting on non-deterministic GC —
+        // browsers cap the number of simultaneously-live WebGL contexts
+        // (WKWebView's cap is low), and a lingering lost/dead context can
+        // starve new panes until the engine forcibly evicts the oldest one
+        // (a frozen pane or a hard UI freeze elsewhere). "Discarded for good"
+        // means canvasRef.current no longer points at this exact node: either
+        // the whole pane is unmounting (canvasRef.current is now null) or a
+        // rendererEpoch bump just replaced it with a fresh keyed <canvas>
+        // (context-loss recovery). A same-canvas rebuild (theme change reuses
+        // this node) must NOT hit this branch — losing it there would hand
+        // the very renderer just constructed a dead context, since a canvas
+        // keeps returning the same context object from getContext() for its
+        // own lifetime. This is the single owner of canvas-context release;
+        // there is no separate unmount-only effect for it.
+        if (canvasRef.current !== canvas) {
+          canvas.getContext('webgl2')?.getExtension('WEBGL_lose_context')?.loseContext();
+        }
       };
     // Ghostty cells contain their resolved default RGB values, so theme
     // changes require a fresh model. The pane runtime rehydrates this model
     // from verified replay without sending historical replies to the live PTY.
+    // rendererEpoch is a dependency for the same reason: a bump (scheduled by
+    // scheduleRecovery above after a lost context or a failed construction)
+    // must rebuild the model/renderer, and keying the <canvas> on it (see the
+    // JSX below) forces a fresh element and therefore a fresh getContext().
     // fontSize is intentionally NOT a dependency: see the font-size effect
     // below for why a size change must re-metric the existing renderer in
     // place instead of rebuilding the model/renderer for every mounted pane.
-    }, [cancelScheduledOutputRender, clearSynchronizedOutputRenderTimer, fit, getText, getVisibleContent, getVisibleStyleSummary, openFind, renderSurface, resizeLocal, resolvedTheme, write]);
+    }, [cancelScheduledOutputRender, clearSynchronizedOutputRenderTimer, fit, getText, getVisibleContent, getVisibleStyleSummary, openFind, renderSurface, rendererEpoch, resizeLocal, resolvedTheme, write]);
 
     // React to a font-size change without tearing down the WASM model or the
     // WebGL renderer. Rebuilding on every font-size change (the previous
@@ -1879,27 +1981,6 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       fit();
       renderSurface(true);
     }, [fontSize]);
-
-    // Release this pane's WebGL2 context when the pane unmounts. Browsers cap the
-    // number of simultaneously-live WebGL contexts (WKWebView's cap is low), and
-    // attn keeps every workspace's panes mounted, so a closed or remounted pane
-    // whose context lingers until non-deterministic GC can starve new panes — the
-    // engine then forcibly loses the oldest context, which surfaces as a frozen
-    // pane or a hard UI freeze when opening a new agent/terminal. loseContext()
-    // reclaims the context deterministically at unmount.
-    //
-    // This lives in its own unmount-only effect (empty deps) on purpose: the init
-    // effect above reuses this same <canvas> when fontSize/theme change, and a
-    // canvas keeps returning the *same* context object from getContext() even
-    // after it is lost. Losing it in the per-init cleanup would hand the rebuilt
-    // renderer a dead context. Capturing the canvas here closes over the element
-    // so the cleanup is order-independent of the init effect's teardown.
-    useEffect(() => {
-      const canvas = canvasRef.current;
-      return () => {
-        canvas?.getContext('webgl2')?.getExtension('WEBGL_lose_context')?.loseContext();
-      };
-    }, []);
 
     const cellFromPointer = (event: React.MouseEvent | React.WheelEvent | MouseEvent) => {
       const renderer = rendererRef.current;
@@ -2707,7 +2788,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           }
         }}
       >
-        <canvas ref={canvasRef} />
+        {/* Keyed on rendererEpoch: a context-loss recovery bumps the epoch to force
+            a fresh DOM node (and therefore a fresh getContext('webgl2')) — a canvas
+            keeps returning the same dead context object for its own lifetime. */}
+        <canvas ref={canvasRef} key={rendererEpoch} />
         {error && <div className="ghostty-terminal-error">{error}</div>}
       </div>
       {findUi.open && (

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -794,6 +794,21 @@ function dispatchShortcutEvent(shortcutId: ShortcutId) {
   dispatchCombo(binding);
 }
 
+// Finds the WebGL canvas of the pane currently visible on screen — the one
+// workspace root marked visible, and within it the pane its own
+// data-active-pane-id names. Used by the lose_webgl_context harness action to
+// verify context-loss recovery without needing a sessionId/paneId round trip.
+function findActivePaneCanvas(): HTMLCanvasElement | null {
+  const workspace = document.querySelector('[data-session-terminal-workspace][data-session-visible="1"]');
+  const activePaneId = workspace?.getAttribute('data-active-pane-id');
+  if (!workspace || !activePaneId) {
+    return null;
+  }
+  const paneElement = workspace.querySelector(`[data-pane-id="${activePaneId}"]`);
+  const canvas = paneElement?.querySelector('canvas');
+  return canvas instanceof HTMLCanvasElement ? canvas : null;
+}
+
 function clickPaneElement(sessionId: string, paneId: string) {
   const element = document.querySelector(
     `[data-pane-session-id="${sessionId}"][data-pane-id="${paneId}"]`
@@ -1820,6 +1835,22 @@ export function useUiAutomationBridge({
         // against a separately-read disk dump.
         const snapshots = dumpTerminalGeometry();
         return { snapshots };
+      }
+      case 'lose_webgl_context': {
+        // Deliberately kills the active pane's WebGL context so the packaged
+        // app harness can verify GhosttyTerminal's context-loss auto-recovery
+        // (epoch rebuild + backoff) end to end, without needing a real GPU
+        // fault to reproduce it.
+        const canvas = findActivePaneCanvas();
+        if (!canvas) {
+          throw new Error('No active pane canvas found');
+        }
+        const extension = canvas.getContext('webgl2')?.getExtension('WEBGL_lose_context');
+        if (!extension) {
+          throw new Error('WEBGL_lose_context extension is unavailable on the active pane canvas');
+        }
+        extension.loseContext();
+        return { ok: true };
       }
       case 'reload_session': {
         if (!reloadSession) {

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -346,6 +346,11 @@ function collectPaneDomMetrics(paneElement: Element | null) {
     terminalContainer: elementMetrics(terminalContainer),
     terminalSurface: elementMetrics(terminalSurface),
     canvas: elementMetrics(canvas),
+    // GhosttyTerminal renders this when it gives up rebuilding the renderer
+    // (see the WebGL context-loss recovery give-up path) — exposed so the
+    // packaged-app harness can assert recovery actually cleared it, not just
+    // that the diagnostics log said so.
+    errorVisible: paneElement.querySelector('.ghostty-terminal-error') != null,
   };
 }
 

--- a/app/src/utils/terminalDiagnosticsLog.test.ts
+++ b/app/src/utils/terminalDiagnosticsLog.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   dumpTerminalGeometry,
+  noteRecovery,
   noteResize,
   recordDiag,
   recordPaint,
@@ -66,6 +67,23 @@ describe('paint anomaly detection', () => {
     recordPaint({ ...baseSample, pane, modelPrintable: 500, quads: null });
 
     expect(ringEventsFor(pane).filter((event) => event.kind === 'incident')).toHaveLength(0);
+  });
+});
+
+describe('noteRecovery', () => {
+  beforeEach(() => {
+    window.localStorage.setItem('attn:terminal-diagnostics', '1');
+  });
+
+  it('records the recovery lifecycle as lifecycle events, in order', () => {
+    const pane = 'pane-recovery';
+    noteRecovery(pane, { attempt: 1, outcome: 'contextLost' });
+    noteRecovery(pane, { attempt: 1, outcome: 'scheduled', delayMs: 250 });
+    noteRecovery(pane, { attempt: 1, outcome: 'recovered' });
+
+    const events = ringEventsFor(pane).filter((event) => event.kind === 'recovery');
+    expect(events.map((event) => event.outcome)).toEqual(['contextLost', 'scheduled', 'recovered']);
+    expect(events[1]?.delayMs).toBe(250);
   });
 });
 

--- a/app/src/utils/terminalDiagnosticsLog.ts
+++ b/app/src/utils/terminalDiagnosticsLog.ts
@@ -71,7 +71,8 @@ export type DiagKind =
   | 'attach'
   | 'desync'
   | 'watchdog'
-  | 'incident';
+  | 'incident'
+  | 'recovery';
 
 export interface DiagEvent {
   at: number;
@@ -94,6 +95,7 @@ const LIFECYCLE_KINDS = new Set<DiagKind>([
   'desync',
   'watchdog',
   'incident',
+  'recovery',
 ]);
 
 export interface RenderProbe {
@@ -475,6 +477,24 @@ export function noteResize(
   if (info.paneKind === 'agent') {
     armWatchdog(pane, info.session);
   }
+}
+
+// WebGL context-loss recovery lifecycle: a lost context or a failed renderer
+// construction schedules an epoch-rebuild retry with backoff (see
+// GhosttyTerminal's rendererEpoch effect); this makes that retry sequence
+// traceable after the fact instead of only visible as a silently-fixed pane.
+export function noteRecovery(
+  pane: string,
+  info: {
+    session?: string;
+    paneKind?: string;
+    attempt: number;
+    outcome: 'contextLost' | 'constructFailed' | 'scheduled' | 'recovered' | 'giveUp';
+    delayMs?: number;
+    error?: string;
+  },
+): void {
+  recordDiag({ kind: 'recovery', pane, ...info });
 }
 
 function armWatchdog(pane: string, session?: string) {


### PR DESCRIPTION
## What

Third PR of the offset-bug stack (on top of #472). When a pane's WebGL context is lost or renderer construction fails, the pane now auto-recovers instead of dead-ending in a "reopen the pane" error:

- `webglcontextlost` → `preventDefault()`, clear the error overlay, schedule a rebuild.
- Rebuild uses a fresh canvas (`key={rendererEpoch}`) + fresh renderer + refit; the WASM model (scrollback, grid) survives untouched.
- Backoff schedule 250ms → 1.5s → 5s (pure, unit-tested `recoveryDelayMs`); after three failed attempts it gives up into the original error overlay.
- Mount-effect cleanup is the single owner of GL release (explicit `WEBGL_lose_context.loseContext()` on the orphaned canvas), so recovery can't leak contexts.
- Every stage is logged to diagnostics (`recovery` kind: contextLost/constructFailed/scheduled/recovered/giveUp).

## Why

PR #472 removes the main source of context exhaustion, but context loss remains possible (GPU resets, memory pressure, pool contention from other WebViews). Today that leaves a permanently dead pane — the exact user-visible symptom — when a transparent sub-second rebuild fixes it.

## Verification

- Unit tests for the backoff helper.
- New packaged-app scenario `real-app:scenario-webgl-recovery`: forces context loss via a `lose_webgl_context` bridge action on the active pane, then asserts the diagnostics sequence contextLost→scheduled→recovered, that fresh output paints afterwards, geometry is sane, and no error overlay is shown. Observed recovery in **269ms** in the packaged app.
- Full-stack seed-2 × 300 soak: 0 persistent violations.