### PR TITLE
fix(terminal): refit revealed panes whose grid overflows the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Fixed
 - **Changing font size no longer risks blank or misrendered terminals when many panes are open.** Adjusting the terminal font size used to rebuild every open pane's terminal (visible and backgrounded), which under enough open panes could exhaust the app's GPU rendering resources and leave a pane permanently blank or garbled until reopened. Terminals now update in place to the new font size instead of being rebuilt.
 - **Terminals now recover automatically if the app's GPU rendering context is lost.** Previously a pane hit by a GPU context loss showed a permanent error asking you to reopen it; it now rebuilds its renderer in place within a fraction of a second, keeping the session's content and scrollback.
+- **Switching back to a workspace after resizing the window no longer leaves the terminal cut off at the bottom.** If the window shrank while a workspace was in the background, revealing it could land an oversized terminal grid that never corrected itself; the app now detects and fixes this right after the workspace becomes visible.
 
 ## [2026-07-03]
 

--- a/app/package.json
+++ b/app/package.json
@@ -58,6 +58,7 @@
     "real-app:scenario-terminal-block-resize": "node scripts/real-app-harness/scenario-terminal-block-resize.mjs",
     "real-app:scenario-offset-soak": "node scripts/real-app-harness/scenario-offset-soak.mjs",
     "real-app:scenario-webgl-recovery": "node scripts/real-app-harness/scenario-webgl-recovery.mjs",
+    "real-app:scenario-reveal-overflow": "node scripts/real-app-harness/scenario-reveal-overflow.mjs",
     "real-app:serial-matrix": "node scripts/real-app-harness/run-serial-matrix.mjs",
     "e2e": "playwright test",
     "e2e:settings-visual": "playwright test e2e/settings-visual.spec.ts",

--- a/app/scripts/real-app-harness/scenario-reveal-overflow.mjs
+++ b/app/scripts/real-app-harness/scenario-reveal-overflow.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+
+// Packaged-app repro for a reveal-time clip: a hidden workspace's terminal
+// keeps its old, larger grid while the window shrinks around it. When the
+// workspace is revealed again, its model grid (rows x cellHeight) can be
+// taller than the container it renders into, and the reveal refit's late
+// retry historically only fired for too-TINY grids, not too-TALL ones — so
+// the pane stayed clipped indefinitely until something unrelated (e.g. a
+// window nudge) re-triggered a fit.
+//
+// To land workspace A on a genuinely too-tall grid (not just re-measure the
+// same size), this enlarges the window while A is active (confirming A's
+// pane actually grew into the extra height), switches to workspace B, shrinks
+// the window back to its original size while A is hidden, then reveals A and
+// asserts the revealed pane's canvas converges inside its terminal container
+// within a short deadline — the reveal-time backstop's invariant. Every
+// window-height transition is asserted to actually change (never a no-op),
+// so a vacuous run can never report pass.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  assertCommonTargetAllowed,
+  createRunContext,
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { getFrontWindowBounds, setFrontWindowBounds } from './nativeWindowCapture.mjs';
+import {
+  captureSessionArtifacts,
+  sleep,
+  waitForFirstWorkspacePane,
+  waitForPaneAttached,
+  waitForPaneShellReady,
+  waitForPaneVisible,
+} from './scenarioAssertions.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+
+const OVERFLOW_TOLERANCE_PX = 2;
+const WINDOW_ENLARGE_HEIGHT_PX = 250;
+const REVEAL_CONVERGENCE_DEADLINE_MS = 600;
+const REVEAL_CONVERGENCE_POLL_MS = 100;
+const ENLARGE_REFIT_DEADLINE_MS = 5_000;
+// A's container must grow by at least half the enlarge delta to count as
+// proof it actually refit taller, not just noise/rounding.
+const ENLARGE_REFIT_MIN_GROWTH_PX = WINDOW_ENLARGE_HEIGHT_PX / 2;
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') {
+    args.shift();
+  }
+  const options = { ...parseCommonArgs([]) };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--ws-url') options.wsUrl = args[++index];
+    else if (arg === '--app-path') options.appPath = args[++index];
+    else if (arg === '--artifacts-dir' || arg === '--artifacts') options.artifactsDir = args[++index];
+    else if (arg === '--session-root-dir') options.sessionRootDir = args[++index];
+    else if (arg === '--run-against-prod') options.runAgainstProd = true;
+    else if (arg === '--help' || arg === '-h') options.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!options.help) {
+    assertCommonTargetAllowed(options, args);
+  }
+  return {
+    options,
+    help: Boolean(options.help),
+  };
+}
+
+async function createShellWorkspace(client, observer, cwd, label) {
+  fs.mkdirSync(cwd, { recursive: true });
+  const sessionId = await createSessionAndWaitForInitialPane({
+    client,
+    observer,
+    cwd,
+    label,
+    agent: 'shell',
+    waitForInitialPaneVisible: false,
+    sessionWaitMs: 30_000,
+  });
+  const pane = await waitForFirstWorkspacePane(client, sessionId, `initial pane for ${label}`);
+  await client.request('select_session', { sessionId });
+  await waitForPaneVisible(client, sessionId, pane.paneId, 20_000);
+  await waitForPaneAttached(client, sessionId, pane.paneId, 20_000);
+  await waitForPaneShellReady(client, sessionId, pane.paneId, {
+    timeoutMs: 20_000,
+    description: `initial shell pane ready for ${label}`,
+  });
+  return { sessionId, paneId: pane.paneId, label };
+}
+
+function boundsOf(dom, key) {
+  const bounds = dom?.[key]?.bounds;
+  if (!bounds) {
+    return null;
+  }
+  return bounds;
+}
+
+// Measures the active pane's canvas rect against its terminal container rect.
+// Returns null measurements (treated as "not yet clean") when DOM nodes are
+// missing, since a mid-reveal pane can transiently lack them.
+async function measurePane(client, sessionId, paneId) {
+  const state = await client.request('get_pane_state', { sessionId, paneId });
+  const dom = state?.pane?.dom;
+  const canvas = boundsOf(dom, 'canvas');
+  const container = boundsOf(dom, 'terminalContainer');
+  if (!canvas || !container) {
+    return { clean: false, reason: 'missing dom bounds', canvas, container };
+  }
+  const overflowBottom = canvas.y + canvas.height - (container.y + container.height);
+  const overflowRight = canvas.x + canvas.width - (container.x + container.width);
+  const clean = overflowBottom <= OVERFLOW_TOLERANCE_PX && overflowRight <= OVERFLOW_TOLERANCE_PX;
+  return { clean, overflowBottom, overflowRight, canvas, container };
+}
+
+// Polls measurePane every REVEAL_CONVERGENCE_POLL_MS until either a clean
+// read is observed or the deadline elapses, returning the sequence of
+// measurements taken (for evidence) and whether it ever converged.
+async function waitForRevealConvergence(client, sessionId, paneId) {
+  const deadline = Date.now() + REVEAL_CONVERGENCE_DEADLINE_MS;
+  const measurements = [];
+  for (;;) {
+    const measurement = await measurePane(client, sessionId, paneId);
+    measurements.push({ atMs: REVEAL_CONVERGENCE_DEADLINE_MS - (deadline - Date.now()), ...measurement });
+    if (measurement.clean) {
+      return { converged: true, measurements };
+    }
+    if (Date.now() >= deadline) {
+      return { converged: false, measurements };
+    }
+    await sleep(REVEAL_CONVERGENCE_POLL_MS);
+  }
+}
+
+// Polls measurePane until the pane's container has grown to at least
+// minHeight, or throws. Used to prove the pre-shrink enlarge actually landed
+// A on a taller grid — without this, a window resize that the pane never
+// refit to would let the scenario "pass" without exercising anything.
+async function waitForContainerHeightAtLeast(client, sessionId, paneId, minHeight, description, timeoutMs = ENLARGE_REFIT_DEADLINE_MS) {
+  const deadline = Date.now() + timeoutMs;
+  let lastMeasurement = null;
+  for (;;) {
+    lastMeasurement = await measurePane(client, sessionId, paneId);
+    if (lastMeasurement.container && lastMeasurement.container.height >= minHeight) {
+      return lastMeasurement;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for ${description} (wanted container height >= ${minHeight}). Last measurement: ${JSON.stringify(lastMeasurement)}`,
+      );
+    }
+    await sleep(REVEAL_CONVERGENCE_POLL_MS);
+  }
+}
+
+// A window-height transition that turns out to be a no-op (e.g. clamped by
+// the OS, or the harness already parked at the target size) would let this
+// scenario "pass" without ever exercising the bug. Fail loudly instead.
+function assertHeightChanged(beforeHeight, afterHeight, label) {
+  if (beforeHeight === afterHeight) {
+    throw new Error(`${label}: window height did not change (stayed ${beforeHeight}) — scenario would pass vacuously`);
+  }
+}
+
+async function closeWorkspacePanes(client, sessionId) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const workspace = await client.request('get_workspace', { sessionId }).catch(() => null);
+    const pane = workspace?.panes?.[0];
+    if (!pane) {
+      return;
+    }
+    await client.request('close_pane', { sessionId, paneId: pane.paneId }).catch(() => {});
+    await sleep(200);
+  }
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-reveal-overflow.mjs');
+    return;
+  }
+
+  const { runId, runDir, sessionDir } = createRunContext(options, 'reveal-overflow');
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+
+  console.log(`[RealAppHarness] runDir=${runDir}`);
+  console.log(`[RealAppHarness] sessionDir=${sessionDir}`);
+  console.log(`[RealAppHarness] wsUrl=${options.wsUrl}`);
+
+  let workspaceA;
+  let workspaceB;
+
+  try {
+    await launchFreshAppAndConnect(client, observer);
+
+    // Workspace A is created (and selected) alone, so it is unambiguously
+    // the active workspace while we enlarge the window under it.
+    workspaceA = await createShellWorkspace(client, observer, path.join(sessionDir, 'ws-a'), `revealoverflow-${runId}-a`);
+    console.log(`[RealAppHarness] created workspace A: sessionId=${workspaceA.sessionId}`);
+
+    const originalBounds = await getFrontWindowBounds(client.bundleId, { client });
+    const baselineMeasurement = await measurePane(client, workspaceA.sessionId, workspaceA.paneId);
+    const baselineContainerHeight = baselineMeasurement.container?.height ?? 0;
+
+    const enlargedBounds = {
+      x: originalBounds.x,
+      y: originalBounds.y,
+      width: originalBounds.width,
+      height: originalBounds.height + WINDOW_ENLARGE_HEIGHT_PX,
+    };
+    console.log(`[RealAppHarness] enlarging window from height=${originalBounds.height} to height=${enlargedBounds.height} (workspace A active)`);
+    const appliedEnlargedBounds = await setFrontWindowBounds(enlargedBounds, { client });
+    assertHeightChanged(originalBounds.height, appliedEnlargedBounds.height, 'enlarge');
+
+    // Prove A actually refit taller, not just that the window resized.
+    await waitForContainerHeightAtLeast(
+      client,
+      workspaceA.sessionId,
+      workspaceA.paneId,
+      baselineContainerHeight + ENLARGE_REFIT_MIN_GROWTH_PX,
+      'workspace A pane to refit to the enlarged window',
+    );
+    console.log('[RealAppHarness] confirmed workspace A refit to a taller grid at the enlarged window size');
+
+    // Creating workspace B selects it, hiding A while it still holds the
+    // tall grid from the enlarged window.
+    workspaceB = await createShellWorkspace(client, observer, path.join(sessionDir, 'ws-b'), `revealoverflow-${runId}-b`);
+    console.log(`[RealAppHarness] created workspace B: sessionId=${workspaceB.sessionId} (workspace A now hidden)`);
+
+    const shrunkBounds = {
+      x: originalBounds.x,
+      y: originalBounds.y,
+      width: originalBounds.width,
+      height: originalBounds.height,
+    };
+    console.log(`[RealAppHarness] shrinking window back from height=${appliedEnlargedBounds.height} to height=${shrunkBounds.height} (workspace A hidden)`);
+    const appliedShrunkBounds = await setFrontWindowBounds(shrunkBounds, { client });
+    assertHeightChanged(appliedEnlargedBounds.height, appliedShrunkBounds.height, 'shrink');
+
+    // Reveal workspace A while it still holds the too-tall grid from before
+    // the shrink — this is the moment the reveal-time backstop must catch.
+    console.log(`[RealAppHarness] revealing workspace A (sessionId=${workspaceA.sessionId})`);
+    await client.request('select_session', { sessionId: workspaceA.sessionId });
+    await waitForPaneVisible(client, workspaceA.sessionId, workspaceA.paneId, 20_000);
+
+    const { converged, measurements } = await waitForRevealConvergence(client, workspaceA.sessionId, workspaceA.paneId);
+
+    fs.writeFileSync(path.join(runDir, 'measurements.json'), `${JSON.stringify(measurements, null, 2)}\n`, 'utf8');
+
+    if (!converged) {
+      console.error(
+        `[RealAppHarness] VIOLATION: revealed pane did not converge within ${REVEAL_CONVERGENCE_DEADLINE_MS}ms.`,
+      );
+      await captureSessionArtifacts(client, runDir, 'violation', workspaceA.sessionId).catch(() => {});
+      console.error(`[RealAppHarness] Evidence written to ${runDir}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    const summary = {
+      ok: true,
+      runId,
+      convergedAfterMeasurements: measurements.length,
+      originalWindowHeightPx: originalBounds.height,
+      enlargedWindowHeightPx: appliedEnlargedBounds.height,
+      baselineContainerHeightPx: baselineContainerHeight,
+      deadlineMs: REVEAL_CONVERGENCE_DEADLINE_MS,
+    };
+    fs.writeFileSync(path.join(runDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    console.log(`[RealAppHarness] Reveal-overflow scenario passed after ${measurements.length} measurement(s).`);
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    for (const workspace of [workspaceB, workspaceA]) {
+      if (workspace) {
+        await closeWorkspacePanes(client, workspace.sessionId).catch(() => {});
+      }
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -165,6 +165,12 @@ export interface GhosttyTerminalHandle {
   // (a fit() that did not bail). Until then getSize() reports the provisional
   // construction default, which must never claim PTY geometry authority.
   hasMeasuredSize: () => boolean;
+  // True when the model grid is taller or wider than the container it is
+  // rendering into (see geometryOverflowsContainer). A pane can land in this
+  // state on reveal after the window shrank while it was hidden; a caller
+  // that catches it can force a refit rather than leaving the clip in place
+  // indefinitely.
+  overflowsContainer: () => boolean;
   getVisibleContent: () => TerminalVisibleContentSnapshot;
   getVisibleStyleSummary: () => TerminalVisibleStyleSnapshot;
   getBlockState: () => BlockStateSnapshot;
@@ -1641,6 +1647,14 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       getText,
       getSize: () => terminalRef.current ? { cols: terminalRef.current.cols, rows: terminalRef.current.rows } : null,
       hasMeasuredSize: () => hasMeasuredSizeRef.current,
+      overflowsContainer: () => {
+        const model = terminalRef.current;
+        const renderer = rendererRef.current;
+        const container = containerRef.current;
+        if (!model || !renderer || !container) return false;
+        return geometryOverflowsContainer(model.rows, renderer.cellHeight, container.clientHeight)
+          || geometryOverflowsContainer(model.cols, renderer.cellWidth, container.clientWidth);
+      },
       getVisibleContent,
       getVisibleStyleSummary,
       getBlockState,
@@ -1831,6 +1845,8 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           getText,
           getSize: () => ({ cols: terminal.cols, rows: terminal.rows }),
           hasMeasuredSize: () => hasMeasuredSizeRef.current,
+          overflowsContainer: () => geometryOverflowsContainer(terminal.rows, renderer.cellHeight, container.clientHeight)
+            || geometryOverflowsContainer(terminal.cols, renderer.cellWidth, container.clientWidth),
           getVisibleContent,
           getVisibleStyleSummary,
           getBlockState,

--- a/app/src/components/SessionTerminalWorkspace.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace.test.tsx
@@ -62,6 +62,10 @@ const { mockTerminalFit } = vi.hoisted(() => ({
   mockTerminalFit: vi.fn(),
 }));
 
+const { mockTerminalOverflowsContainer } = vi.hoisted(() => ({
+  mockTerminalOverflowsContainer: vi.fn(() => false),
+}));
+
 const { renderedTerminalProps } = vi.hoisted(() => ({
   renderedTerminalProps: new Map<string, any>(),
 }));
@@ -99,6 +103,7 @@ vi.mock('./GhosttyTerminal', () => ({
       getText: vi.fn(() => ''),
       getSize: vi.fn(() => ({ cols: 80, rows: 24 })),
       hasMeasuredSize: vi.fn(() => true),
+      overflowsContainer: mockTerminalOverflowsContainer,
       getVisibleContent: vi.fn(),
       getVisibleStyleSummary: vi.fn(),
       drain: vi.fn(() => Promise.resolve()),
@@ -137,6 +142,7 @@ function createMockTerminal() {
     getText: vi.fn(() => ''),
     getSize: vi.fn(() => ({ cols: 80, rows: 24 })),
     hasMeasuredSize: vi.fn(() => true),
+    overflowsContainer: vi.fn(() => false),
     getVisibleContent: vi.fn(),
     getVisibleStyleSummary: vi.fn(),
     drain: vi.fn(() => Promise.resolve()),
@@ -150,6 +156,7 @@ describe('SessionTerminalWorkspace', () => {
     terminalLifecycleCounts.clear();
     vi.mocked(mockEventRouter.registerBinding).mockClear();
     mockTerminalFit.mockReset();
+    mockTerminalOverflowsContainer.mockReset().mockReturnValue(false);
     mockPtyAttach.mockReset();
     mockPtyDetach.mockReset();
     mockPtyResize.mockReset();
@@ -1202,6 +1209,76 @@ describe('SessionTerminalWorkspace', () => {
 
     expect(mockTerminalFit).toHaveBeenCalledTimes(2);
     expect(mockTerminalFocus).toHaveBeenCalled();
+  });
+
+  it('retries the reveal refit (at both late ticks) while the pane still overflows its container', () => {
+    // Reproduces the reveal-time bug: the window shrank while this pane was
+    // hidden, so on reveal its grid is taller/wider than the container. Unlike
+    // the suspicious-size case, this pane's cols/rows are unremarkable — only
+    // overflowsContainer() reports the problem — so the late retries must
+    // consult it, not just isSuspiciousTerminalSize.
+    vi.useFakeTimers();
+    mockTerminalFit.mockReset();
+    mockTerminalOverflowsContainer.mockReset().mockReturnValue(true);
+
+    render(
+      <SessionTerminalWorkspace
+        workspaceId="workspace-session-1"
+        workspaceSessions={[{ id: "session-1", label: "Session 1", agent: "claude", cwd: "/tmp/repo" }]}
+        workspace={createSingleAgentWorkspace()}
+        activePaneId={SESSION_PANE_ID}
+        fontSize={14}
+        enabled
+        isActiveSession
+        eventRouter={mockEventRouter}
+        onSplitPane={vi.fn()}
+        onClosePane={vi.fn()}
+        onFocusPane={vi.fn()}
+        onNavigateOutOfSession={vi.fn()}
+      />
+    );
+
+    expect(mockTerminalFit).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(75);
+    });
+    expect(mockTerminalFit).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      vi.advanceTimersByTime(325);
+    });
+    expect(mockTerminalFit).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not schedule extra reveal refits once the pane fits its container', () => {
+    vi.useFakeTimers();
+    mockTerminalFit.mockReset();
+    mockTerminalOverflowsContainer.mockReset().mockReturnValue(false);
+
+    render(
+      <SessionTerminalWorkspace
+        workspaceId="workspace-session-1"
+        workspaceSessions={[{ id: "session-1", label: "Session 1", agent: "claude", cwd: "/tmp/repo" }]}
+        workspace={createSingleAgentWorkspace()}
+        activePaneId={SESSION_PANE_ID}
+        fontSize={14}
+        enabled
+        isActiveSession
+        eventRouter={mockEventRouter}
+        onSplitPane={vi.fn()}
+        onClosePane={vi.fn()}
+        onFocusPane={vi.fn()}
+        onNavigateOutOfSession={vi.fn()}
+      />
+    );
+
+    expect(mockTerminalFit).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mockTerminalFit).toHaveBeenCalledTimes(1);
   });
 
   it('attaches the selected session pane runtime on terminal ready', async () => {

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -324,6 +324,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       });
     }, [fitPane, runtimePanes]);
     const getPaneSize = runtime.getPaneSize;
+    const paneOverflowsContainer = runtime.paneOverflowsContainer;
     const splitLayoutActive = workspace.layoutTree?.type === 'split';
     // Show the pane header (which doubles as the drag-to-move handle) whenever the
     // workspace holds more than one leaf — including tiles, so a lone pane sharing
@@ -493,8 +494,11 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
 
     // After relaunch, first-show, or split topology changes, the terminal can briefly keep
     // stale narrow geometry from the previous layout. Re-fitting immediately and then
-    // once more after layout settles preserves restored headers/content width.
-    const refitPanesNowAndIfStillTiny = useCallback((targetPaneIds: string[]) => {
+    // once (or twice) more after layout settles preserves restored headers/content width —
+    // and catches a pane whose grid overflows its container (e.g. the window shrank while
+    // the pane was hidden), which fit()'s reveal path does not retry on its own and would
+    // otherwise stay clipped until something unrelated re-triggers a fit.
+    const refitPanesNowAndIfStillWrong = useCallback((targetPaneIds: string[]) => {
       const paneIdsToFit = Array.from(new Set(targetPaneIds));
       if (paneIdsToFit.length === 0) {
         return undefined;
@@ -504,19 +508,34 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         fitPane(paneId);
       }
 
+      const stillWrong = (paneId: string) => {
+        const size = getPaneSize(paneId);
+        return (size != null && isSuspiciousTerminalSize(size.cols, size.rows)) || paneOverflowsContainer(paneId);
+      };
+
       const lateRefitTimeout = window.setTimeout(() => {
         for (const paneId of paneIdsToFit) {
-          const size = getPaneSize(paneId);
-          if (size && isSuspiciousTerminalSize(size.cols, size.rows)) {
+          if (stillWrong(paneId)) {
             fitPane(paneId);
           }
         }
       }, 75);
 
+      // A second, later check covers slower layout settles the 75ms tick can
+      // miss — cheap insurance for a bug that otherwise persists indefinitely.
+      const secondLateRefitTimeout = window.setTimeout(() => {
+        for (const paneId of paneIdsToFit) {
+          if (stillWrong(paneId)) {
+            fitPane(paneId);
+          }
+        }
+      }, 400);
+
       return () => {
         window.clearTimeout(lateRefitTimeout);
+        window.clearTimeout(secondLateRefitTimeout);
       };
-    }, [fitPane, getPaneSize]);
+    }, [fitPane, getPaneSize, paneOverflowsContainer]);
 
     useLayoutEffect(() => {
       if (!sessionVisible) {
@@ -527,8 +546,8 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
         return;
       }
       sessionVisibleRef.current = true;
-      return refitPanesNowAndIfStillTiny(renderedPaneIds);
-    }, [refitPanesNowAndIfStillTiny, renderedPaneIds, renderedPaneIdsKey, sessionVisible]);
+      return refitPanesNowAndIfStillWrong(renderedPaneIds);
+    }, [refitPanesNowAndIfStillWrong, renderedPaneIds, renderedPaneIdsKey, sessionVisible]);
 
     useLayoutEffect(() => {
       if (!sessionVisible) {
@@ -548,8 +567,8 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
       if (movedPanes.length === 0) {
         return;
       }
-      return refitPanesNowAndIfStillTiny(movedPanes);
-    }, [panePaths, refitPanesNowAndIfStillTiny, sessionVisible, workspaceTopologyKey]);
+      return refitPanesNowAndIfStillWrong(movedPanes);
+    }, [panePaths, refitPanesNowAndIfStillWrong, sessionVisible, workspaceTopologyKey]);
 
     const handleSplit = useCallback((direction: TerminalSplitDirection) => {
       onSplitPane(activePaneId, direction);

--- a/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.test.ts
+++ b/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.test.ts
@@ -32,6 +32,7 @@ function createTerminal(): GhosttyTerminalHandle {
     getText: vi.fn(() => ''),
     getSize: vi.fn(() => ({ cols: 120, rows: 40 })),
     hasMeasuredSize: vi.fn(() => true),
+    overflowsContainer: vi.fn(() => false),
     getVisibleContent: vi.fn() as never,
     getVisibleStyleSummary: vi.fn() as never,
     getBlockState: vi.fn() as never,

--- a/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
+++ b/app/src/components/SessionTerminalWorkspace/useGhosttyPaneRuntime.ts
@@ -49,6 +49,7 @@ export interface GhosttyPaneRuntime {
   scrollPaneToTop: (paneId: string) => boolean;
   getPaneText: (paneId: string) => string;
   getPaneSize: (paneId: string) => { cols: number; rows: number } | null;
+  paneOverflowsContainer: (paneId: string) => boolean;
   getPaneVisibleContent: (paneId: string) => TerminalVisibleContentSnapshot;
   getPaneVisibleStyleSummary: (paneId: string) => TerminalVisibleStyleSnapshot;
   getPaneBlockState: (paneId: string) => BlockStateSnapshot | null;
@@ -383,6 +384,7 @@ export function useGhosttyPaneRuntime(
     scrollPaneToTop: (paneId: string) => get(paneId)?.scrollToTop() ?? false,
     getPaneText: (paneId: string) => get(paneId)?.getText() ?? '',
     getPaneSize: (paneId: string) => get(paneId)?.getSize() ?? null,
+    paneOverflowsContainer: (paneId: string) => get(paneId)?.overflowsContainer() ?? false,
     getPaneVisibleContent: (paneId: string) => get(paneId)?.getVisibleContent() ?? emptyContent(),
     getPaneVisibleStyleSummary: (paneId: string) => get(paneId)?.getVisibleStyleSummary() ?? emptyStyle(),
     getPaneBlockState: (paneId: string) => get(paneId)?.getBlockState() ?? null,


### PR DESCRIPTION
## What

Final PR of the offset-bug stack (on top of #473). The reveal-time refit retry (`refitPanesNowAndIfStillTiny`, now `refitPanesNowAndIfStillWrong`) previously only re-fired when the pane looked suspiciously **tiny**. It now also re-fires when the pane's grid **overflows** its container (too tall / too wide — `overflowsContainer()` on the terminal handle, comparing rows×cellHeight / cols×cellWidth against the container), and retries at two late ticks (75ms and 400ms) to outlast reveal-time layout churn.

## Why

Third evidenced strand of the offset bug, caught live on prod: the window shrank while a workspace was hidden (display:none warm set); on reveal, the fit raced layout and landed a too-tall grid, and **nothing ever re-triggered** — the pane stayed clipped for 40+ minutes. A live experiment proved the mechanism: nudging the window height by 1px healed it instantly, i.e. fit computes correctly whenever it actually runs; the failure is purely a reveal-time race with no backstop.

## Verification

- Unit tests: refit retries at both ticks while the pane still overflows; no extra refits when clean.
- New packaged-app scenario `real-app:scenario-reveal-overflow`: grow the window while workspace A is visible (A refits taller), hide A behind a new workspace, shrink the window back, reveal A — asserts A converges to the container within 600ms. The sequence fails loudly if any window-resize step is a no-op, so the test can't pass vacuously.
- Full-stack seed-2 × 300 soak: 0 persistent violations, 19 transients all self-healed ≤2.4s.
- CHANGELOG entry included in the stack.