### PR TITLE
fix: treat agent reload as a lifecycle transition, not a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-05]
+
+### Fixed
+- **Reloading an agent no longer crashes its ticket.** Reloading a delegated agent's session (session actions → Reload) used to look like a process death to the daemon: the bound ticket was stamped Crashed and a pointless reconciliation verdict was posted against a perfectly healthy session. A reload is now a recognized lifecycle transition — the ticket stays in its column and no reconciliation runs. Real crashes are still detected exactly as before.
+- **Reload no longer races the pane teardown.** The reload's own kill could be mistaken for the agent quitting cleanly, closing the pane (and its workspace) out from under the respawn and failing the reload with "unknown workspace". The session now stays put for the whole kill → respawn window.
+
 ## [2026-07-04]
 
 ### Added

--- a/app/scripts/real-app-harness/scenario-reload-not-crash.mjs
+++ b/app/scripts/real-app-harness/scenario-reload-not-crash.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+
+/**
+ * Real-app scenario: reloading an agent is a lifecycle transition, not a crash.
+ *
+ * Regression coverage for the 2026-07-04 incident: reloading a delegated agent
+ * (session actions -> Reload = frontend ptyKill + ptySpawn of the same id) made
+ * the daemon treat the worker exit as a mid-flight death — the bound ticket was
+ * stamped Crashed and a reconcile classifier task was enqueued against a healthy
+ * session. The fix threads reload:true through kill_session so handlePTYExit
+ * skips exactly the ticket seam for that one exit.
+ *
+ * The scenario proves BOTH sides of the seam in the packaged app:
+ *
+ *   1. boot a real codex agent, bind a ticket to it (`ticket take` + status),
+ *   2. put it mid-turn (state=working) and reload it via the real UI path
+ *      (reload_session bridge action -> reloadSession -> kill_session reload:true),
+ *      then assert: ticket NOT crashed, no reconcile task minted, agent respawned,
+ *   3. boot a SECOND agent (claude) with its own ticket, put it mid-turn, and
+ *      SIGKILL its pty-worker for real, then assert: that ticket IS crashed and
+ *      a reconcile task exists — the reload carve-out did not widen into a
+ *      crash-detection hole, and the first session's reload mark did not leak
+ *      across sessions. (A separate session because the resumed codex
+ *      conversation cannot run another real turn in this environment — the
+ *      crash seam itself is per-exit and identical for first or respawned
+ *      workers.)
+ *
+ * Prereqs: `codex` and `claude` on PATH; a built `./attn` (or
+ * ATTN_HARNESS_BIN); a non-prod profile install with the automation layer
+ * (defaults to the dev sibling).
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import {
+  createRunContext,
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { waitForFirstWorkspacePane } from './scenarioAssertions.mjs';
+import { ensureClaudePromptReadyViaPty, ensureCodexPromptReadyViaPty, preTrustClaudeFolder } from './scenarioAgents.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { currentHarnessProfile } from './harnessProfile.mjs';
+
+const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs(args);
+  return { options, help: args.includes('--help') || args.includes('-h') };
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function pollFor(fn, description, timeoutMs = 30_000, intervalMs = 250) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await fn();
+    if (last) return last;
+    await delay(intervalMs);
+  }
+  throw new Error(`Timed out waiting for: ${description}. Last value: ${JSON.stringify(last)}`);
+}
+
+function resolveAttnBin() {
+  const candidates = [process.env.ATTN_HARNESS_BIN, path.resolve(HARNESS_DIR, '../../../attn')].filter(Boolean);
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error('attn binary not found (build ./attn or set ATTN_HARNESS_BIN)');
+}
+
+function makeAttnRunner(attnBin, profile) {
+  return function runAttn(args) {
+    const stdout = execFileSync(attnBin, args, {
+      encoding: 'utf8',
+      env: { ...process.env, ATTN_PROFILE: profile },
+    }).trim();
+    // The profile banner goes to stderr, so --json stdout is pure JSON
+    // (object or array depending on the command).
+    const json = stdout.startsWith('{') || stdout.startsWith('[') ? JSON.parse(stdout) : null;
+    return { stdout, json };
+  };
+}
+
+// The bound ticket's current status, from the CLI's list (authoritative store
+// read; no dependency on broadcast timing).
+function ticketStatus(runAttn, ticketId) {
+  const { json } = runAttn(['ticket', 'list', '--all', '--json']);
+  const tickets = Array.isArray(json) ? json : [];
+  const ticket = tickets.find((t) => t.id === ticketId);
+  return ticket?.status || null;
+}
+
+// Reconcile tasks minted for the ticket, straight from the profile DB's durable
+// task table (TaskID = "reconcile:<ticketId>").
+function reconcileTaskCount(profile, ticketId) {
+  const dbPath = path.join(os.homedir(), `.attn-${profile}`, 'attn.db');
+  const out = execFileSync('sqlite3', [dbPath, `SELECT COUNT(*) FROM tasks WHERE kind='reconcile' AND subject='${ticketId}';`], { encoding: 'utf8' });
+  return Number(out.trim());
+}
+
+// The pty-worker process for a session (worker backend runs one `attn pty-worker
+// --session-id <id>` per session).
+function workerPid(sessionId) {
+  try {
+    const out = execFileSync('pgrep', ['-f', `pty-worker.*--session-id ${sessionId}`], { encoding: 'utf8' });
+    const pids = out.trim().split('\n').filter(Boolean).map(Number);
+    return pids[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+// Submit a prompt that keeps the agent busy for a while, and wait until the
+// daemon says the session is working — the crash seam only differs from the
+// clean-rest path for mid-flight states. Retries the submit: right after a
+// reload the resumed codex TUI can look prompt-ready (stale replayed pane
+// text) while still swallowing input.
+async function driveAgentToWorking(client, observer, sessionId, note) {
+  const pane = await waitForFirstWorkspacePane(client, sessionId, `pane for ${sessionId}`, 20_000);
+  const prompt = 'Count from 1 to 40, one number per line, then say done. Do not use tools.';
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    await client.request('write_pane', { sessionId, paneId: pane.paneId, text: prompt, submit: false });
+    await delay(1_200);
+    await client.request('write_pane', { sessionId, paneId: pane.paneId, text: '\r', submit: false });
+    try {
+      await pollFor(
+        () => (observer.getSession(sessionId)?.state === 'working' ? true : null),
+        `${sessionId} to start working (attempt ${attempt})`,
+        12_000,
+        300,
+      );
+      note(`agent is mid-turn (working) after attempt ${attempt}`);
+      return;
+    } catch (error) {
+      if (attempt === 3) throw error;
+      note(`submit attempt ${attempt} did not reach working; retrying`);
+      await delay(3_000);
+    }
+  }
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-reload-not-crash.mjs');
+    return;
+  }
+
+  const profile = currentHarnessProfile();
+  if (!profile) {
+    throw new Error('the reload-not-crash scenario does not run against production; set ATTN_PROFILE / ATTN_HARNESS_PROFILE to a named profile');
+  }
+  const attnBin = resolveAttnBin();
+  const runAttn = makeAttnRunner(attnBin, profile);
+
+  const { runId, runDir, sessionDir } = createRunContext(options, 'reload-not-crash');
+
+  const repoDir = path.join(sessionDir, 'target-repo');
+  fs.mkdirSync(repoDir, { recursive: true });
+  execFileSync('git', ['init', '-q'], { cwd: repoDir });
+  execFileSync('git', ['commit', '-q', '--allow-empty', '-m', 'init'], {
+    cwd: repoDir,
+    env: { ...process.env, GIT_AUTHOR_NAME: 'attn', GIT_AUTHOR_EMAIL: 'attn@local', GIT_COMMITTER_NAME: 'attn', GIT_COMMITTER_EMAIL: 'attn@local' },
+  });
+
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  let sessionId = null;
+  let crashSessionId = null;
+  const evidence = { runId, profile, steps: [] };
+  const note = (m, extra) => { console.log(`[reload-not-crash] ${m}`); evidence.steps.push({ t: Date.now(), m, ...(extra || {}) }); };
+  const saveEvidence = (verdict) => {
+    evidence.verdict = verdict;
+    fs.writeFileSync(path.join(runDir, 'summary.json'), `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+  };
+
+  console.log(`[reload-not-crash] profile=${profile} runDir=${runDir} repo=${repoDir}`);
+
+  try {
+    await launchFreshAppAndConnect(client, observer);
+
+    // 1) Boot a real codex agent and bind a ticket to it.
+    sessionId = await createSessionAndWaitForInitialPane({
+      client,
+      observer,
+      cwd: repoDir,
+      label: `reload-target-${runId.slice(-6)}`,
+      agent: 'codex',
+      sessionWaitMs: 30_000,
+      promptReadyFn: ensureCodexPromptReadyViaPty,
+      promptReadyTimeoutMs: 90_000,
+    });
+    await client.request('select_session', { sessionId });
+    note('target agent ready', { sessionId });
+
+    const created = runAttn(['ticket', 'new', '--title', `Reload fixture ${runId.slice(-6)}`, '--session', sessionId, '--json']);
+    const ticketId = created.json?.ticket_id;
+    assert(typeof ticketId === 'string' && ticketId.length > 0, `ticket new returned an id (got ${JSON.stringify(created.json)})`);
+    runAttn(['ticket', 'take', ticketId, '--session', sessionId, '--confirm']);
+    // Take assigns but does not change the column; report working like a real
+    // agent would — the incident's ticket was in Working when the reload hit.
+    runAttn(['ticket', 'status', 'in_progress', '--session', sessionId, '--comment', 'harness: starting work']);
+    const statusAfterTake = ticketStatus(runAttn, ticketId);
+    assert(statusAfterTake === 'working', `ticket bound and working after take (got ${statusAfterTake})`);
+    note('ticket bound to agent', { ticketId, status: statusAfterTake });
+
+    // 2) Reload mid-turn: the ticket must stay put and no reconcile task minted.
+    await driveAgentToWorking(client, observer, sessionId, note);
+    await client.request('reload_session', { sessionId }, { timeoutMs: 45_000 });
+    note('reload_session completed');
+    await pollFor(() => (workerPid(sessionId) ? true : null), 'respawned pty-worker after reload', 20_000, 300);
+    // Give any (buggy) crash/reconcile write a moment to land before asserting.
+    await delay(2_000);
+
+    const statusAfterReload = ticketStatus(runAttn, ticketId);
+    assert(statusAfterReload === 'working', `ticket unchanged after reload (got ${statusAfterReload})`);
+    const tasksAfterReload = reconcileTaskCount(profile, ticketId);
+    assert(tasksAfterReload === 0, `no reconcile task after reload (got ${tasksAfterReload})`);
+    note('reload left the ticket alone', { statusAfterReload, tasksAfterReload });
+
+    // 3) Real crash, on a fresh second session: SIGKILL its worker mid-turn.
+    //    The crash stamp and the reconcile enqueue must both still fire.
+    //    Claude here, not codex: a killed claude fires no Stop hook, so the
+    //    daemon still sees the session mid-flight when the worker death lands
+    //    (codex turns in this environment can end instantly and settle idle
+    //    before crash detection runs, hiding the seam under test).
+    preTrustClaudeFolder(repoDir);
+    crashSessionId = await createSessionAndWaitForInitialPane({
+      client,
+      observer,
+      cwd: repoDir,
+      label: `crash-target-${runId.slice(-6)}`,
+      agent: 'claude',
+      sessionWaitMs: 30_000,
+      promptReadyFn: ensureClaudePromptReadyViaPty,
+      promptReadyTimeoutMs: 90_000,
+    });
+    await client.request('select_session', { sessionId: crashSessionId });
+    const crashCreated = runAttn(['ticket', 'new', '--title', `Crash fixture ${runId.slice(-6)}`, '--session', crashSessionId, '--json']);
+    const crashTicketId = crashCreated.json?.ticket_id;
+    assert(crashTicketId, 'crash-leg ticket created');
+    runAttn(['ticket', 'take', crashTicketId, '--session', crashSessionId, '--confirm']);
+    runAttn(['ticket', 'status', 'in_progress', '--session', crashSessionId, '--comment', 'harness: starting work']);
+    note('crash-leg ticket bound', { crashTicketId });
+
+    await driveAgentToWorking(client, observer, crashSessionId, note);
+    const pid = workerPid(crashSessionId);
+    assert(pid, `found pty-worker pid for ${crashSessionId}`);
+    process.kill(pid, 'SIGKILL');
+    note('killed pty-worker', { pid });
+
+    // A SIGKILLed worker does NOT produce an immediate PTY exit: the daemon's
+    // worker-backend poller retries the dead socket and only forces the exit
+    // after "unreachable for 30s". The crash stamp lands after that window, so
+    // poll well past it.
+    const crashed = await pollFor(
+      () => (ticketStatus(runAttn, crashTicketId) === 'crashed' ? true : null),
+      `ticket ${crashTicketId} to be stamped crashed after a real worker death`,
+      90_000,
+      500,
+    );
+    assert(crashed, 'ticket crashed after real kill');
+    const tasksAfterCrash = reconcileTaskCount(profile, crashTicketId);
+    assert(tasksAfterCrash === 1, `reconcile task minted for the real crash (got ${tasksAfterCrash})`);
+    // And the reload-leg ticket must STILL be untouched.
+    const reloadTicketFinal = ticketStatus(runAttn, ticketId);
+    assert(reloadTicketFinal === 'working', `reload-leg ticket still working at the end (got ${reloadTicketFinal})`);
+    note('real crash still detected; reload ticket untouched', { tasksAfterCrash, reloadTicketFinal });
+
+    saveEvidence('pass');
+    console.log(`[reload-not-crash] PASS runDir=${runDir}`);
+  } catch (error) {
+    if (sessionId) {
+      try {
+        const pane = await waitForFirstWorkspacePane(client, sessionId, 'pane for failure dump', 5_000);
+        const text = await client.request('read_pane_text', { sessionId, paneId: pane.paneId });
+        evidence.failurePaneText = (text?.text || '').slice(-2000);
+        console.error(`[reload-not-crash] pane at failure:\n${evidence.failurePaneText}`);
+      } catch { /* best effort */ }
+    }
+    saveEvidence(`fail: ${error?.message || error}`);
+    console.error(`[reload-not-crash] FAIL: ${error?.stack || error}`);
+    process.exitCode = 1;
+  } finally {
+    if (sessionId) await client.request('close_session', { sessionId }).catch(() => {});
+    if (crashSessionId) await client.request('close_session', { sessionId: crashSessionId }).catch(() => {});
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+await main();

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -41,7 +41,7 @@ import { DaemonProvider } from './contexts/DaemonContext';
 import { NotebookSurfaceProvider } from './contexts/NotebookSurfaceContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 import { KeybindingsProvider, useKeybindings } from './contexts/KeybindingsContext';
-import { useSessionStore, type Session, type TerminalWorkspaceState } from './store/sessions';
+import { useSessionStore, isSessionReloading, type Session, type TerminalWorkspaceState } from './store/sessions';
 import {
   computeWarmWorkspaceIds,
   DEFAULT_WARM_WORKSPACE_LIMIT,
@@ -2301,6 +2301,12 @@ sendFetchPRDetails,
   // explicit closes) keep the pane open so the error and exit code stay visible.
   const handleSessionProcessExit = useCallback((info: SessionExitInfo) => {
     if (info.exitCode !== 0 || info.signal) {
+      return;
+    }
+    // A reload's kill can surface as a clean exit (code 0, no signal); the same
+    // id is about to respawn in place, so closing the pane here would tear the
+    // workspace down under the pending spawn ("unknown workspace").
+    if (isSessionReloading(info.id)) {
       return;
     }
     handleRequestCloseSession(info.id);

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -166,7 +166,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '143';
+export const PROTOCOL_VERSION = '144';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -2921,7 +2921,7 @@ export function useDaemonSocket({
     });
   }, [reconcileAttachedRuntimeGeometry, sendAttachSessionWithRetry, sendPtyResize]);
 
-  const sendKillSession = useCallback((id: string, signal?: string): Promise<void> => {
+  const sendKillSession = useCallback((id: string, signal?: string, options?: { reload?: boolean }): Promise<void> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -2935,7 +2935,14 @@ export function useDaemonSocket({
         reject,
       });
 
-      ws.send(JSON.stringify({ cmd: 'kill_session', id, ...(signal && { signal }) }));
+      ws.send(JSON.stringify({
+        cmd: 'kill_session',
+        id,
+        ...(signal && { signal }),
+        // Tells the daemon this kill is the first half of a reload (the same id
+        // respawns right after), so the exit is not treated as a crash.
+        ...(options?.reload && { reload: true }),
+      }));
 
       // Wait for session_exited to avoid kill/spawn races during reload.
       setTimeout(() => {
@@ -3267,9 +3274,9 @@ export function useDaemonSocket({
       detach: async (id: string) => {
         sendDetachSession(id);
       },
-      kill: async (id: string) => {
+      kill: async (id: string, options?: { reload?: boolean }) => {
         sendDetachSession(id);
-        await sendKillSession(id);
+        await sendKillSession(id, undefined, options);
       },
     });
 

--- a/app/src/pty/bridge.ts
+++ b/app/src/pty/bridge.ts
@@ -67,7 +67,7 @@ export interface PtyBackend {
   write: (id: string, data: string, source?: string) => Promise<void>;
   resize: (id: string, cols: number, rows: number, reason?: string) => Promise<void>;
   detach: (id: string) => Promise<void>;
-  kill: (id: string) => Promise<void>;
+  kill: (id: string, options?: { reload?: boolean }) => Promise<void>;
 }
 
 const listeners = new Set<PtyEventHandler>();
@@ -203,7 +203,7 @@ export async function ptyDetach(request: { id: string }) {
   await backend.detach(request.id);
 }
 
-export async function ptyKill(request: { id: string }) {
+export async function ptyKill(request: { id: string; reload?: boolean }) {
   if (mockEnabled()) {
     if (!mockSessions.has(request.id)) {
       return;
@@ -215,5 +215,5 @@ export async function ptyKill(request: { id: string }) {
   if (!backend) {
     throw new Error('PTY backend is not configured');
   }
-  await backend.kill(request.id);
+  await backend.kill(request.id, request.reload ? { reload: true } : undefined);
 }

--- a/app/src/store/sessions.test.ts
+++ b/app/src/store/sessions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { useSessionStore } from './sessions';
+import { useSessionStore, isSessionReloading } from './sessions';
 import { WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceStatus } from '../types/generated';
 
 const { mockPtySpawn, mockPtyKill } = vi.hoisted(() => ({
@@ -491,7 +491,9 @@ describe('sessions store', () => {
 
     await useSessionStore.getState().reloadSession('sess-remote', { cols: 120, rows: 40 });
 
-    expect(mockPtyKill).toHaveBeenCalledWith({ id: 'sess-remote' });
+    // reload:true is the daemon's signal that this kill is a lifecycle
+    // transition, not a crash — bound tickets must stay put.
+    expect(mockPtyKill).toHaveBeenCalledWith({ id: 'sess-remote', reload: true });
     expect(mockPtySpawn).toHaveBeenCalledWith({
       args: expect.objectContaining({
         id: 'sess-remote',
@@ -503,5 +505,34 @@ describe('sessions store', () => {
         yolo_mode: true,
       }),
     });
+  });
+
+  it('marks the session as reloading for the whole kill→respawn window', async () => {
+    await useSessionStore.getState().createSession('Local', '/srv/repo', 'sess-reload', 'codex', undefined, false, 'workspace-sess-reload');
+
+    // The reload kill surfaces a session_exited that can look like a clean
+    // voluntary quit; the guard must be up while ptyKill resolves so the
+    // auto-close-on-clean-exit handler leaves the pane alone.
+    let duringKill = false;
+    mockPtyKill.mockImplementation(async () => {
+      duringKill = isSessionReloading('sess-reload');
+    });
+
+    expect(isSessionReloading('sess-reload')).toBe(false);
+    await useSessionStore.getState().reloadSession('sess-reload', { cols: 120, rows: 40 });
+
+    expect(duringKill).toBe(true);
+    expect(isSessionReloading('sess-reload')).toBe(false);
+  });
+
+  it('clears the reloading mark even when the respawn fails', async () => {
+    await useSessionStore.getState().createSession('Local', '/srv/repo', 'sess-reload-fail', 'codex', undefined, false, 'workspace-sess-reload-fail');
+    mockPtySpawn.mockRejectedValueOnce(new Error('spawn failed'));
+
+    await expect(
+      useSessionStore.getState().reloadSession('sess-reload-fail', { cols: 120, rows: 40 }),
+    ).rejects.toThrow('spawn failed');
+
+    expect(isSessionReloading('sess-reload-fail')).toBe(false);
   });
 });

--- a/app/src/store/sessions.ts
+++ b/app/src/store/sessions.ts
@@ -13,6 +13,17 @@ import {
 
 export type { TerminalWorkspaceState };
 
+// Sessions whose runtime is being reloaded in place (kill → respawn of the same
+// id). The kill's exit event can look like a clean voluntary quit (code 0, no
+// signal), which would trip the auto-close-on-clean-exit path in App.tsx and
+// tear down the pane/workspace out from under the pending respawn. Consumers
+// (the session-exit handler) check this before treating an exit as end-of-life.
+const reloadingSessionIds = new Set<string>();
+
+export function isSessionReloading(id: string): boolean {
+  return reloadingSessionIds.has(id);
+}
+
 export interface Session {
   id: string;
   label: string;
@@ -297,8 +308,11 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       rows = 24;
     }
 
+    reloadingSessionIds.add(id);
     try {
-      await ptyKill({ id });
+      // reload:true tells the daemon this kill is a lifecycle transition (the
+      // same id respawns just below), not a crash — bound tickets stay put.
+      await ptyKill({ id, reload: true });
     } catch (e) {
       console.warn('[Session] Reload kill failed, continuing to respawn:', e);
     }
@@ -334,6 +348,8 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     } catch (e) {
       console.error('[Session] Reload spawn failed:', e);
       throw e;
+    } finally {
+      reloadingSessionIds.delete(id);
     }
   },
 

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1808,6 +1808,7 @@ export enum InstallPluginMessageCmd {
 export interface KillSessionMessage {
     cmd:     KillSessionMessageCmd;
     id:      string;
+    reload?: boolean;
     signal?: string;
     [property: string]: any;
 }
@@ -7820,6 +7821,7 @@ const typeMap: any = {
     "KillSessionMessage": o([
         { json: "cmd", js: "cmd", typ: r("KillSessionMessageCmd") },
         { json: "id", js: "id", typ: "" },
+        { json: "reload", js: "reload", typ: u(undefined, true) },
         { json: "signal", js: "signal", typ: u(undefined, "") },
     ], "any"),
     "ListBranchesMessage": o([

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -152,6 +152,15 @@ type Daemon struct {
 	// cannot interleave and tear each other's respawn down. Lazily initialized.
 	reloadLocksMu sync.Mutex
 	reloadLocks   map[string]*sync.Mutex
+	// reloadKills marks sessions whose next process exit was caused by a
+	// client-initiated reload (kill_session with reload:true, followed by a
+	// spawn_session of the same id). Unlike reloadingSessions it suppresses ONLY
+	// the ticket crash/reconcile seam in handlePTYExit — the rest of exit
+	// processing (backend remove, idle clobber, session_exited broadcast) must
+	// still run because the client's reload flow depends on it. Timestamped so a
+	// stale mark (reload kill that never produced an exit) cannot swallow a real
+	// crash later. Lazily initialized under reloadingMu.
+	reloadKills map[string]time.Time
 	// ticketBackstop debounces the deferred self-monitor doorbell (see
 	// ticket_notify.go): an idle self-monitor with unread ticket activity is
 	// re-checked after a grace delay and doorbelled only if still unread, so a live
@@ -1422,7 +1431,14 @@ func (d *Daemon) handlePTYExit(info ptybackend.ExitInfo) {
 		// just below erases whether the agent was mid-flight (a crash or kill) or at
 		// a clean rest when its process exited — the signal that decides between the
 		// Crashed stamp and the orphaned-ticket classifier (ticket_reconcile.go).
-		d.reconcileTicketsOnSessionEnd(info.ID, string(session.State))
+		// A client-initiated reload (kill_session reload:true + respawn of the same
+		// id) is a lifecycle transition, not a death: skip ONLY the ticket seam and
+		// let the rest of exit processing run — the reload flow depends on it.
+		if d.consumeReloadKill(info.ID) {
+			d.logf("skipping ticket reconcile for %s: exit is a user reload, runtime respawns in place", info.ID)
+		} else {
+			d.reconcileTicketsOnSessionEnd(info.ID, string(session.State))
+		}
 		d.store.Touch(info.ID)
 		d.store.UpdateState(info.ID, protocol.StateIdle)
 		updated := d.sessionForBroadcast(d.store.Get(info.ID))

--- a/internal/daemon/reload.go
+++ b/internal/daemon/reload.go
@@ -47,6 +47,39 @@ func (d *Daemon) clearReloading(sessionID string) {
 	delete(d.reloadingSessions, sessionID)
 }
 
+// reloadKillMarkTTL bounds how long a reload-kill mark stays consumable. The
+// backend's Kill returns only after the child exits, so the exit event lands
+// within moments of the mark; the TTL only exists so a mark whose exit never
+// arrived cannot suppress the crash seam for an unrelated death much later.
+const reloadKillMarkTTL = 15 * time.Second
+
+// markReloadKill records that sessionID's next exit is the kill half of a
+// client-initiated reload (kill_session with reload:true). Must be called
+// before the backend Kill so the mark beats the async exit event.
+func (d *Daemon) markReloadKill(sessionID string) {
+	d.reloadingMu.Lock()
+	defer d.reloadingMu.Unlock()
+	if d.reloadKills == nil {
+		d.reloadKills = make(map[string]time.Time)
+	}
+	d.reloadKills[sessionID] = time.Now()
+}
+
+// consumeReloadKill atomically reports whether sessionID's exit was caused by a
+// client reload and clears the mark. One-shot: exactly the reload-killed
+// worker's exit skips the ticket seam; any later exit of the respawned session
+// is judged normally.
+func (d *Daemon) consumeReloadKill(sessionID string) bool {
+	d.reloadingMu.Lock()
+	defer d.reloadingMu.Unlock()
+	markedAt, ok := d.reloadKills[sessionID]
+	if !ok {
+		return false
+	}
+	delete(d.reloadKills, sessionID)
+	return time.Since(markedAt) <= reloadKillMarkTTL
+}
+
 // reloadLockFor returns the per-session mutex that serializes reloadSessionAgent's
 // kill→remove→spawn composite. Without it, two concurrent reloads of the same
 // session (a double-toggle, or a role transfer reloading both chiefs) interleave

--- a/internal/daemon/ticket_crash_test.go
+++ b/internal/daemon/ticket_crash_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/store"
 )
 
@@ -97,6 +98,78 @@ func TestCaptureTicketCrashStateNoopAfterTerminalReport(t *testing.T) {
 	}
 	if ticket.Status != store.TicketStatusDone {
 		t.Fatalf("status = %q, want done (report wins over crash)", ticket.Status)
+	}
+}
+
+// A user reload (kill_session reload:true + respawn of the same id) is a
+// lifecycle transition, not a death: exactly the reload-killed exit skips the
+// crash/reconcile seam, and a later real exit of the respawned worker is judged
+// normally again (the mark is one-shot).
+func TestHandlePTYExitReloadKillSkipsTicketSeam(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	sessionID := delegateBoundSession(t, d)
+	ticketID := boundTicketID(t, d, sessionID)
+	d.store.UpdateState(sessionID, protocol.StateWorking)
+
+	d.markReloadKill(sessionID)
+	d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 0})
+
+	ticket, err := d.store.GetTicket(ticketID)
+	if err != nil {
+		t.Fatalf("GetTicket: %v", err)
+	}
+	if ticket.Status != store.TicketStatusWorking {
+		t.Fatalf("status after reload exit = %q, want unchanged working", ticket.Status)
+	}
+
+	// The respawned worker dying for real must still crash the ticket.
+	d.store.UpdateState(sessionID, protocol.StateWorking)
+	d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 1})
+
+	ticket, err = d.store.GetTicket(ticketID)
+	if err != nil {
+		t.Fatalf("GetTicket: %v", err)
+	}
+	if ticket.Status != store.TicketStatusCrashed {
+		t.Fatalf("status after real exit = %q, want crashed", ticket.Status)
+	}
+}
+
+// An expired reload mark must not swallow a real crash: consume reports false
+// past the TTL, and the mark is cleared either way.
+func TestConsumeReloadKillExpiresAndIsOneShot(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+
+	d.markReloadKill("fresh")
+	if !d.consumeReloadKill("fresh") {
+		t.Fatal("fresh mark not consumable")
+	}
+	if d.consumeReloadKill("fresh") {
+		t.Fatal("mark consumable twice, want one-shot")
+	}
+
+	d.markReloadKill("stale")
+	d.reloadingMu.Lock()
+	d.reloadKills["stale"] = time.Now().Add(-reloadKillMarkTTL - time.Second)
+	d.reloadingMu.Unlock()
+	if d.consumeReloadKill("stale") {
+		t.Fatal("expired mark consumed as valid")
+	}
+}
+
+// The reload flag survives the wire: a kill_session JSON payload with
+// reload:true decodes into KillSessionMessage.Reload.
+func TestKillSessionMessageDecodesReloadFlag(t *testing.T) {
+	_, msg, err := protocol.ParseMessage([]byte(`{"cmd":"kill_session","id":"s1","reload":true}`))
+	if err != nil {
+		t.Fatalf("ParseMessage: %v", err)
+	}
+	kill, ok := msg.(*protocol.KillSessionMessage)
+	if !ok {
+		t.Fatalf("parsed type = %T, want *KillSessionMessage", msg)
+	}
+	if !protocol.Deref(kill.Reload) {
+		t.Fatal("reload flag lost in decode")
 	}
 }
 

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -1082,6 +1082,12 @@ func parseSignal(name string) syscall.Signal {
 func (d *Daemon) handleKillSession(client *wsClient, msg *protocol.KillSessionMessage) {
 	d.detachSession(client, msg.ID)
 	sig := parseSignal(protocol.Deref(msg.Signal))
+	if protocol.Deref(msg.Reload) {
+		// This kill is the first half of a client reload (same id respawns right
+		// after). Mark before Kill so the exit event — which can fire the instant
+		// Kill returns — reads as a lifecycle transition, not a crash.
+		d.markReloadKill(msg.ID)
+	}
 	err := d.ptyBackend.Kill(context.Background(), msg.ID, sig)
 	if err == nil || errors.Is(err, pty.ErrSessionNotFound) {
 		// Production backends return from Kill only once the child has exited.

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "143"
+const ProtocolVersion = "144"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1481,6 +1481,9 @@ type KillSessionMessage struct {
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
 
+	// Reload corresponds to the JSON schema field "reload".
+	Reload *bool `json:"reload,omitempty,omitzero"`
+
 	// Signal corresponds to the JSON schema field "signal".
 	Signal *string `json:"signal,omitempty,omitzero"`
 }

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1332,6 +1332,11 @@ model KillSessionMessage {
   cmd: "kill_session";
   id: string;
   signal?: string; // "SIGTERM", "SIGINT", ...
+  // True when this kill is the first half of a user-initiated reload (the client
+  // respawns the same session id right after). The daemon then treats the
+  // resulting process exit as a lifecycle transition, not a death: bound tickets
+  // are not crash-stamped and no reconcile is enqueued.
+  reload?: boolean;
 }
 
 model WorkspaceLayoutGetMessage {


### PR DESCRIPTION
## Problem

Reloading a delegated agent (session actions → Reload) made the daemon treat the worker exit as a crash: the bound ticket flipped to **Crashed** ("agent process ended mid-flight without reporting") and a spurious reconcile classifier run fired against a healthy session. Incident: 2026-07-04 21:55:44Z, ticket `jaunt-in-attn`, session `15822cd0`.

## Root cause

The frontend's reload is `kill_session` + `spawn_session` of the same id. The daemon's `handlePTYExit` had no way to distinguish that deliberate kill from an unexpected process death, so `reconcileTicketsOnSessionEnd` stamped the ticket crashed and enqueued the reconcile classifier.

## Fix

- Protocol: `reload?: boolean` on `kill_session` (ProtocolVersion 143 → 144, all three lockstep spots).
- Daemon: `handleKillSession` marks the session as a reload kill (one-shot mark, 15s TTL); `handlePTYExit` consumes it and skips **only** `reconcileTicketsOnSessionEnd` — backend removal, state handling, and the `session_exited` broadcast are untouched, so the carve-out is exactly one seam wide and true crashes keep today's behavior.
- Frontend: `reloadSession` sends `reload: true` on the kill.

## Second bug (same family, found during live verification)

The reload kill's exit surfaces as a clean voluntary quit (code 0, no signal), which tripped App.tsx's auto-close-on-clean-exit: the pane was closed, the now-empty workspace removed, and the respawn then failed daemon-side with `unknown workspace`. `reloadSession` now marks the session as reloading for the whole kill→respawn window and the exit handler skips auto-close for it.

## Verification

- Unit: 3 new daemon tests (`internal/daemon/ticket_crash_test.go`) covering reload-skip, true-crash unchanged, and mark TTL/one-shot; 2 new frontend tests for the reloading-mark window (incl. spawn-failure cleanup). Full frontend suite + tsc green; `go build ./...` + daemon tests green.
- **Live (packaged dev app)** via new `scenario-reload-not-crash.mjs`, both legs in one PASS run:
  - mid-turn reload → ticket stayed `working`, 0 reconcile tasks, daemon logged `skipping ticket reconcile … exit is a user reload, runtime respawns in place`, worker respawned;
  - real SIGKILL of a second session's pty-worker mid-turn → ticket stamped `crashed … ended mid-flight (working)`, exactly 1 reconcile task; the reload-leg ticket remained untouched (no cross-session mark leak).

Note: the crash-leg scenario polls 90s because a SIGKILLed worker is only detected via the worker-backend poller's "unreachable for 30s; forcing exit" backstop.

Possible overlap heads-up: the agent-cost-tools session touches reconcile *verdict content*; this PR only changes the *trigger* (`reconcileTicketsOnSessionEnd` call site in `handlePTYExit`).