### PR TITLE
feat(tickets): attn ticket show — full activity thread over the agent socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-05]
+
+### Added
+- **`attn ticket show <ticket-id>` for agents.** Agents can now pull a ticket's full record over the socket — description, the complete activity thread (status changes, comments, verdicts) with full bodies, and attachments — the same detail the app's ticket panel shows, but non-consuming: unlike `ticket inbox`, it never advances any session's unread cursor, so it can be re-read any time.
+
 ## [2026-07-04]
 
 ### Added

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '144';
+export const PROTOCOL_VERSION = '145';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '145';
+export const PROTOCOL_VERSION = '146';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewState, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketAttachment, TicketAttachMessage, TicketAttachResult, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddCommentMessage, AddCommentResultMessage, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchDiffFile, BranchDiffFilesResultMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteCommentMessage, DeleteCommentResultMessage, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetBranchDiffFilesMessage, GetCommentsMessage, GetCommentsResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetReviewStateMessage, GetReviewStateResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkFileViewedMessage, MarkFileViewedResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, ResolveCommentMessage, ResolveCommentResultMessage, Response, ReviewComment, ReviewState, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketAttachment, TicketAttachMessage, TicketAttachResult, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateCommentMessage, UpdateCommentResultMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addCommentMessage = Convert.toAddCommentMessage(json);
 //   const addCommentResultMessage = Convert.toAddCommentResultMessage(json);
@@ -250,6 +250,8 @@
 //   const ticketListMessage = Convert.toTicketListMessage(json);
 //   const ticketListResult = Convert.toTicketListResult(json);
 //   const ticketResultMessage = Convert.toTicketResultMessage(json);
+//   const ticketShowMessage = Convert.toTicketShowMessage(json);
+//   const ticketShowResult = Convert.toTicketShowResult(json);
 //   const ticketStatus = Convert.toTicketStatus(json);
 //   const ticketStatusResult = Convert.toTicketStatusResult(json);
 //   const ticketSubscribeMessage = Convert.toTicketSubscribeMessage(json);
@@ -3012,6 +3014,7 @@ export interface Response {
     ticket_create_result?:                 TicketCreateResultObject;
     ticket_inbox_result?:                  TicketInboxResultObject;
     ticket_list_result?:                   TicketListResultObject;
+    ticket_show_result?:                   TicketShowResultObject;
     ticket_status_result?:                 TicketStatusResultObject;
     ticket_subscribe_result?:              TicketSubscribeResultObject;
     ticket_take_result?:                   TicketTakeResultObject;
@@ -3099,6 +3102,11 @@ export enum TicketEventKind {
 
 export interface TicketListResultObject {
     tickets: TicketElement[];
+    [property: string]: any;
+}
+
+export interface TicketShowResultObject {
+    ticket: TicketElement;
     [property: string]: any;
 }
 
@@ -3761,6 +3769,22 @@ export interface TicketResultMessage {
 
 export enum TicketResultMessageEvent {
     TicketResult = "ticket_result",
+}
+
+export interface TicketShowMessage {
+    cmd:                TicketShowMessageCmd;
+    source_session_id?: string;
+    ticket_id:          string;
+    [property: string]: any;
+}
+
+export enum TicketShowMessageCmd {
+    TicketShow = "ticket_show",
+}
+
+export interface TicketShowResult {
+    ticket: TicketElement;
+    [property: string]: any;
 }
 
 export interface TicketStatusResult {
@@ -6628,6 +6652,22 @@ export class Convert {
         return JSON.stringify(uncast(value, r("TicketResultMessage")), null, 2);
     }
 
+    public static toTicketShowMessage(json: string): TicketShowMessage {
+        return cast(JSON.parse(json), r("TicketShowMessage"));
+    }
+
+    public static ticketShowMessageToJson(value: TicketShowMessage): string {
+        return JSON.stringify(uncast(value, r("TicketShowMessage")), null, 2);
+    }
+
+    public static toTicketShowResult(json: string): TicketShowResult {
+        return cast(JSON.parse(json), r("TicketShowResult"));
+    }
+
+    public static ticketShowResultToJson(value: TicketShowResult): string {
+        return JSON.stringify(uncast(value, r("TicketShowResult")), null, 2);
+    }
+
     public static toTicketStatus(json: string): TicketStatus {
         return cast(JSON.parse(json), r("TicketStatus"));
     }
@@ -8938,6 +8978,7 @@ const typeMap: any = {
         { json: "ticket_create_result", js: "ticket_create_result", typ: u(undefined, r("TicketCreateResultObject")) },
         { json: "ticket_inbox_result", js: "ticket_inbox_result", typ: u(undefined, r("TicketInboxResultObject")) },
         { json: "ticket_list_result", js: "ticket_list_result", typ: u(undefined, r("TicketListResultObject")) },
+        { json: "ticket_show_result", js: "ticket_show_result", typ: u(undefined, r("TicketShowResultObject")) },
         { json: "ticket_status_result", js: "ticket_status_result", typ: u(undefined, r("TicketStatusResultObject")) },
         { json: "ticket_subscribe_result", js: "ticket_subscribe_result", typ: u(undefined, r("TicketSubscribeResultObject")) },
         { json: "ticket_take_result", js: "ticket_take_result", typ: u(undefined, r("TicketTakeResultObject")) },
@@ -8996,6 +9037,9 @@ const typeMap: any = {
     ], "any"),
     "TicketListResultObject": o([
         { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
+    ], "any"),
+    "TicketShowResultObject": o([
+        { json: "ticket", js: "ticket", typ: r("TicketElement") },
     ], "any"),
     "TicketStatusResultObject": o([
         { json: "status", js: "status", typ: r("TicketStatus") },
@@ -9378,6 +9422,14 @@ const typeMap: any = {
         { json: "request_id", js: "request_id", typ: "" },
         { json: "success", js: "success", typ: true },
         { json: "ticket", js: "ticket", typ: u(undefined, r("TicketElement")) },
+    ], "any"),
+    "TicketShowMessage": o([
+        { json: "cmd", js: "cmd", typ: r("TicketShowMessageCmd") },
+        { json: "source_session_id", js: "source_session_id", typ: u(undefined, "") },
+        { json: "ticket_id", js: "ticket_id", typ: "" },
+    ], "any"),
+    "TicketShowResult": o([
+        { json: "ticket", js: "ticket", typ: r("TicketElement") },
     ], "any"),
     "TicketStatusResult": o([
         { json: "status", js: "status", typ: r("TicketStatus") },
@@ -10521,6 +10573,9 @@ const typeMap: any = {
     ],
     "TicketResultMessageEvent": [
         "ticket_result",
+    ],
+    "TicketShowMessageCmd": [
+        "ticket_show",
     ],
     "TicketSubscribeMessageCmd": [
         "ticket_subscribe",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -662,6 +662,12 @@ func runTicket() {
 			return
 		}
 		runTicketList(os.Args[3:])
+	case "show":
+		if hasHelpFlag(os.Args[3:]) {
+			writeTicketHelp(os.Stdout)
+			return
+		}
+		runTicketShow(os.Args[3:])
 	case "attach":
 		if hasHelpFlag(os.Args[3:]) {
 			writeTicketHelp(os.Stdout)
@@ -1033,6 +1039,83 @@ func printTicketBoard(tickets []protocol.Ticket) {
 	}
 }
 
+// runTicketShow prints one ticket's full record — metadata, description, and the
+// complete activity thread with full bodies (comments, status changes, verdicts)
+// plus attachments. It is a non-consuming read: it never touches any session's
+// inbox cursor, so unlike `ticket inbox` it can be re-read at will. Like `ticket
+// list` it works without a session (a global read by id), so the session is
+// resolved best-effort — flag then ATTN_SESSION_ID — and passed along even if
+// empty rather than erroring via resolveDispatchSession.
+func runTicketShow(args []string) {
+	parsed, err := parseTicketIDArgs("ticket show", args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ticket show: %v\n", err)
+		writeTicketHelp(os.Stderr)
+		os.Exit(2)
+	}
+	source := strings.TrimSpace(parsed.Session)
+	if source == "" {
+		source = strings.TrimSpace(os.Getenv("ATTN_SESSION_ID"))
+	}
+	ticket, err := client.New("").ShowTicket(source, parsed.TicketID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ticket show: %v\n", err)
+		os.Exit(1)
+	}
+	if parsed.JSON {
+		printJSON(ticket)
+		return
+	}
+	fprintTicketShow(os.Stdout, ticket)
+}
+
+// fprintTicketShow renders one ticket's full record in the same visual style as
+// fprintTicketInbox's activity lines — header block, full description, complete
+// activity thread with full bodies (no truncation), then attachments.
+func fprintTicketShow(w io.Writer, t *protocol.Ticket) {
+	if t == nil {
+		fmt.Fprintln(w, "ticket not found")
+		return
+	}
+	assignee := t.Assignee
+	if strings.TrimSpace(assignee) == "" {
+		assignee = "-"
+	}
+	fmt.Fprintf(w, "%s\t%s\t%s\t%s → %s\n", t.ID, t.Status, assignee, t.CreatedAt, t.UpdatedAt)
+	fmt.Fprintln(w, t.Title)
+	if strings.TrimSpace(t.Description) != "" {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, t.Description)
+	}
+	fmt.Fprintln(w)
+	if len(t.Activity) == 0 {
+		fmt.Fprintln(w, "no activity")
+	} else {
+		fmt.Fprintln(w, "activity:")
+		for _, e := range t.Activity {
+			line := fmt.Sprintf("  [%s] %s by %s", e.CreatedAt, e.Kind, e.Author)
+			if e.FromStatus != nil && e.ToStatus != nil {
+				line += fmt.Sprintf(" (%s → %s)", *e.FromStatus, *e.ToStatus)
+			}
+			fmt.Fprintln(w, line)
+			if e.Comment != nil && *e.Comment != "" {
+				fmt.Fprintf(w, "    %s\n", *e.Comment)
+			}
+		}
+	}
+	if len(t.Attachments) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "attachments:")
+		for _, a := range t.Attachments {
+			line := fmt.Sprintf("  %s (%s)", a.Filename, a.Path)
+			if a.Note != nil && *a.Note != "" {
+				line += fmt.Sprintf(" — %s", *a.Note)
+			}
+			fmt.Fprintln(w, line)
+		}
+	}
+}
+
 // runTicketComment posts a one-shot comment from the calling session onto any
 // ticket by id — the agent-to-agent note channel. Commenting informs the ticket's
 // participants but does not subscribe the caller, so it is a way to chime in
@@ -1375,6 +1458,10 @@ commands:
   list [--status <col>] [--all] [--json]
         read the board: every ticket (id, column, assignee, title), newest first;
         --json includes each ticket's description. No session required.
+  show <ticket-id> [--session <id>] [--json]
+        print one ticket's full record — description, complete activity thread
+        with full bodies, attachments; non-consuming, does not touch your inbox
+        cursor
   attach --file <path> [--note <text>] [--session <id>] [--json]
         copy a file onto this session's bound ticket as an attachment
   new --title <t> [--description <d>] [--id <slug>] [--session <id>] [--json]

--- a/cmd/attn/ticket_show_test.go
+++ b/cmd/attn/ticket_show_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// fprintTicketShow must never truncate a comment body — that is the whole point
+// of `ticket show` over the consuming `ticket inbox` read. This exercises a
+// long multi-line comment plus a status-transition activity line and checks
+// both render verbatim.
+func TestFprintTicketShowFullBodyNoTruncation(t *testing.T) {
+	longComment := strings.Repeat("this is a long verdict line. ", 20) + "\nsecond line\nthird line: the conclusion"
+	from := protocol.TicketStatusWorking
+	to := protocol.TicketStatusInReview
+	ticket := &protocol.Ticket{
+		ID:          "store-migration",
+		Title:       "Migrate the store",
+		Description: "Move to X",
+		Status:      protocol.TicketStatusInReview,
+		Assignee:    "sess-1",
+		CreatedAt:   "2026-07-01T00:00:00Z",
+		UpdatedAt:   "2026-07-02T00:00:00Z",
+		Activity: []protocol.TicketActivity{
+			{
+				ID:         1,
+				Kind:       protocol.TicketActivityKind("status_change"),
+				Author:     "sess-1",
+				CreatedAt:  "2026-07-01T00:01:00Z",
+				FromStatus: &from,
+				ToStatus:   &to,
+			},
+			{
+				ID:        2,
+				Kind:      protocol.TicketActivityKind("comment"),
+				Author:    "chief-1",
+				CreatedAt: "2026-07-01T00:02:00Z",
+				Comment:   &longComment,
+			},
+		},
+		Attachments: []protocol.TicketAttachment{
+			{Filename: "report.md", Path: "/repo/report.md"},
+		},
+	}
+
+	var buf bytes.Buffer
+	fprintTicketShow(&buf, ticket)
+	out := buf.String()
+
+	if !strings.Contains(out, longComment) {
+		t.Fatalf("comment body was not rendered verbatim; out:\n%s", out)
+	}
+	if !strings.Contains(out, "working → in_review") {
+		t.Fatalf("status transition not rendered; out:\n%s", out)
+	}
+	if !strings.Contains(out, "Move to X") {
+		t.Fatalf("description not rendered; out:\n%s", out)
+	}
+	if !strings.Contains(out, "report.md") {
+		t.Fatalf("attachment not rendered; out:\n%s", out)
+	}
+}
+
+// An empty-activity ticket (freshly created, unbound) should render sanely
+// with no attachments/activity noise instead of blowing up.
+func TestFprintTicketShowEmptyActivity(t *testing.T) {
+	ticket := &protocol.Ticket{
+		ID:        "fresh-ticket",
+		Title:     "A fresh backlog item",
+		Status:    protocol.TicketStatusTodo,
+		CreatedAt: "2026-07-01T00:00:00Z",
+		UpdatedAt: "2026-07-01T00:00:00Z",
+	}
+
+	var buf bytes.Buffer
+	fprintTicketShow(&buf, ticket)
+	out := buf.String()
+
+	if !strings.Contains(out, "no activity") {
+		t.Fatalf("expected 'no activity' for empty thread; out:\n%s", out)
+	}
+	if !strings.Contains(out, "fresh-ticket") || !strings.Contains(out, "A fresh backlog item") {
+		t.Fatalf("expected header with id/title; out:\n%s", out)
+	}
+	if strings.Contains(out, "attachments:") {
+		t.Fatalf("should not print attachments section when there are none; out:\n%s", out)
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -390,6 +390,26 @@ func (c *Client) TicketList(sourceSessionID, status string, includeArchived bool
 	return resp.TicketListResult.Tickets, nil
 }
 
+// ShowTicket reads one ticket's full record — metadata, description, and the
+// complete activity thread (full bodies) plus attachments. It is a non-consuming
+// read (unlike TicketInbox, it never advances the calling session's unread
+// cursor) and, like TicketList, a global read: sourceSessionID is passed for
+// command-shape uniformity but the daemon does not use it.
+func (c *Client) ShowTicket(sourceSessionID, ticketID string) (*protocol.Ticket, error) {
+	msg := protocol.TicketShowMessage{Cmd: protocol.CmdTicketShow, TicketID: ticketID}
+	if sourceSessionID != "" {
+		msg.SourceSessionID = &sourceSessionID
+	}
+	resp, err := c.send(msg)
+	if err != nil {
+		return nil, err
+	}
+	if resp.TicketShowResult == nil {
+		return nil, errors.New("daemon returned no ticket show result")
+	}
+	return &resp.TicketShowResult.Ticket, nil
+}
+
 // SubscribeTicket opts the calling session into a ticket's notifications. The
 // session becomes a participant (nudged about activity, the ticket delivered in its
 // inbox) without advancing its cursor, so its first inbox after this delivers the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1925,6 +1925,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleTicketInbox(conn, msg.(*protocol.TicketInboxMessage))
 	case protocol.CmdTicketList:
 		d.handleTicketList(conn, msg.(*protocol.TicketListMessage))
+	case protocol.CmdTicketShow:
+		d.handleTicketShow(conn, msg.(*protocol.TicketShowMessage))
 	case protocol.CmdTicketSubscribe:
 		d.handleTicketSubscribe(conn, msg.(*protocol.TicketSubscribeMessage))
 	case protocol.CmdTicketUnsubscribe:

--- a/internal/daemon/ticket_board.go
+++ b/internal/daemon/ticket_board.go
@@ -66,6 +66,34 @@ func (d *Daemon) handleTicketList(conn net.Conn, msg *protocol.TicketListMessage
 	})
 }
 
+// handleTicketShow is the agent's non-consuming full-record read: one ticket's
+// metadata, description, and complete activity thread (full bodies) plus
+// attachments, the same shape sendGetTicketWSResult serves the app. Unlike
+// ticket_inbox, it never advances the calling session's unread cursor, so an
+// agent can re-read it at will. Like ticket_list it is NOT identity-scoped, so
+// source_session_id is accepted but unused.
+func (d *Daemon) handleTicketShow(conn net.Conn, msg *protocol.TicketShowMessage) {
+	ticketID := strings.TrimSpace(msg.TicketID)
+	if ticketID == "" {
+		d.sendError(conn, "ticket show: ticket_id is required")
+		return
+	}
+	ticket, err := d.store.GetTicket(ticketID)
+	if err != nil {
+		d.sendError(conn, "ticket show: "+err.Error())
+		return
+	}
+	if ticket == nil {
+		d.sendError(conn, "ticket show: ticket not found: "+ticketID)
+		return
+	}
+	full := ticketToProtocol(ticket)
+	_ = json.NewEncoder(conn).Encode(protocol.Response{
+		Ok:               true,
+		TicketShowResult: &protocol.TicketShowResult{Ticket: full},
+	})
+}
+
 // broadcastTicketsUpdated re-pushes the whole non-archived board to every client.
 // Run it after any producer that mutates a ticket (create, status, crash, and the
 // chief edits to come).

--- a/internal/daemon/ticket_show_test.go
+++ b/internal/daemon/ticket_show_test.go
@@ -1,0 +1,108 @@
+package daemon
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// callTicketShow drives the agent-socket handler synchronously and returns the
+// decoded response. handleTicketShow has no async side effects, so a plain
+// syncConn suffices.
+func callTicketShow(t *testing.T, d *Daemon, ticketID string) protocol.Response {
+	t.Helper()
+	conn := &syncConn{}
+	d.handleTicketShow(conn, &protocol.TicketShowMessage{Cmd: protocol.CmdTicketShow, TicketID: ticketID})
+	var resp protocol.Response
+	if err := json.Unmarshal(conn.buf.Bytes(), &resp); err != nil {
+		t.Fatalf("decode ticket-show response: %v", err)
+	}
+	return resp
+}
+
+// ticket_show is the agent-socket counterpart of the app's get_ticket: a
+// non-consuming full-record read (description + complete activity thread with
+// full bodies + attachments) for a ticket with 2+ activity events, including a
+// long multi-line comment. Nothing here should be truncated.
+func TestHandleTicketShowReturnsFullRecord(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	now := time.Now()
+	if _, err := d.store.CreateTicket(store.Ticket{
+		ID:          "store-migration",
+		Title:       "Migrate the store",
+		Description: "Move to X",
+		Status:      store.TicketStatusWorking,
+		Assignee:    "sess-1",
+		Cwd:         "/repo",
+		LastAgentID: "codex",
+	}, "chief-1", now); err != nil {
+		t.Fatalf("create ticket: %v", err)
+	}
+	if _, err := d.store.SetTicketStatus("store-migration", store.TicketStatusInReview, "sess-1", "ready for a look", now.Add(time.Minute)); err != nil {
+		t.Fatalf("set status: %v", err)
+	}
+	longComment := "line one of the verdict\nline two with more detail\nline three: the conclusion"
+	if _, err := d.store.AddTicketComment("store-migration", "chief-1", longComment, now.Add(2*time.Minute)); err != nil {
+		t.Fatalf("add comment: %v", err)
+	}
+	if _, err := d.store.AddTicketAttachment(store.TicketAttachment{
+		TicketID: "store-migration",
+		Filename: "report.md",
+		Path:     "/repo/report.md",
+		Note:     "the findings",
+	}, "sess-1", now.Add(3*time.Minute)); err != nil {
+		t.Fatalf("add attachment: %v", err)
+	}
+
+	resp := callTicketShow(t, d, "store-migration")
+	if !resp.Ok || resp.TicketShowResult == nil {
+		t.Fatalf("ticket show response = %+v, want ok with result", resp)
+	}
+	tk := resp.TicketShowResult.Ticket
+	if tk.ID != "store-migration" || tk.Description != "Move to X" {
+		t.Fatalf("ticket id/description = %q/%q", tk.ID, tk.Description)
+	}
+	if len(tk.Activity) < 2 {
+		t.Fatalf("activity = %+v, want at least 2 events", tk.Activity)
+	}
+
+	var sawStatusChange, sawComment bool
+	for _, a := range tk.Activity {
+		switch a.Kind {
+		case protocol.TicketActivityKind(store.TicketActivityStatusChange):
+			sawStatusChange = true
+		case protocol.TicketActivityKind(store.TicketActivityComment):
+			sawComment = true
+			if a.Comment == nil || *a.Comment != longComment {
+				t.Fatalf("comment body = %v, want full multi-line body intact", a.Comment)
+			}
+		}
+	}
+	if !sawStatusChange || !sawComment {
+		t.Fatalf("activity kinds: statusChange=%v comment=%v (activity=%+v)", sawStatusChange, sawComment, tk.Activity)
+	}
+	if len(tk.Attachments) != 1 || tk.Attachments[0].Filename != "report.md" {
+		t.Fatalf("attachments = %+v", tk.Attachments)
+	}
+}
+
+// An unknown id fails with Ok:false and an error, not a panic — the same
+// contract as the app's get_ticket over websocket.
+func TestHandleTicketShowUnknownIDFails(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	resp := callTicketShow(t, d, "nope")
+	if resp.Ok {
+		t.Fatalf("ticket show response = %+v, want Ok:false for unknown id", resp)
+	}
+	if resp.Error == nil || !strings.Contains(*resp.Error, "not found") {
+		t.Fatalf("ticket show error = %v, want a not-found error", resp.Error)
+	}
+	if resp.TicketShowResult != nil {
+		t.Fatalf("failure response carried a result: %+v", resp.TicketShowResult)
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "144"
+const ProtocolVersion = "145"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -46,6 +46,7 @@ const (
 	CmdSetTicketStatus                       = "set_ticket_status"
 	CmdTicketInbox                           = "ticket_inbox"
 	CmdTicketList                            = "ticket_list"
+	CmdTicketShow                            = "ticket_show"
 	CmdTicketSubscribe                       = "ticket_subscribe"
 	CmdTicketUnsubscribe                     = "ticket_unsubscribe"
 	CmdTicketTake                            = "ticket_take"
@@ -395,6 +396,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdTicketList:
 		var msg TicketListMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdTicketShow:
+		var msg TicketShowMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "145"
+const ProtocolVersion = "146"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2847,6 +2847,9 @@ type Response struct {
 	// TicketListResult corresponds to the JSON schema field "ticket_list_result".
 	TicketListResult *TicketListResult `json:"ticket_list_result,omitempty,omitzero"`
 
+	// TicketShowResult corresponds to the JSON schema field "ticket_show_result".
+	TicketShowResult *TicketShowResult `json:"ticket_show_result,omitempty,omitzero"`
+
 	// TicketStatusResult corresponds to the JSON schema field "ticket_status_result".
 	TicketStatusResult *TicketStatusResult `json:"ticket_status_result,omitempty,omitzero"`
 
@@ -3685,6 +3688,22 @@ type TicketResultMessage struct {
 
 	// Ticket corresponds to the JSON schema field "ticket".
 	Ticket *Ticket `json:"ticket,omitempty,omitzero"`
+}
+
+type TicketShowMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// SourceSessionID corresponds to the JSON schema field "source_session_id".
+	SourceSessionID *string `json:"source_session_id,omitempty,omitzero"`
+
+	// TicketID corresponds to the JSON schema field "ticket_id".
+	TicketID string `json:"ticket_id"`
+}
+
+type TicketShowResult struct {
+	// Ticket corresponds to the JSON schema field "ticket".
+	Ticket Ticket `json:"ticket"`
 }
 
 type TicketStatus string

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -702,6 +702,25 @@ model TicketListResult {
   tickets: Ticket[];
 }
 
+// TicketShowMessage reads one ticket's full record — metadata, description, and the
+// complete activity thread (with full bodies) plus attachments — pulled over the
+// agent socket instead of pushed as a tickets_updated broadcast. Unlike ticket_inbox
+// this is non-consuming: it never advances the calling session's unread cursor, so
+// it can be re-read at will. Like ticket_list it is NOT identity-scoped — a global
+// read of a ticket by id, so source_session_id is optional and unused, present only
+// for command-shape uniformity.
+model TicketShowMessage {
+  cmd: "ticket_show";
+  source_session_id?: string;
+  ticket_id: string;
+}
+
+// TicketShowResult is the full ticket record — the same shape the app's get_ticket
+// serves, with Activity and Attachments populated.
+model TicketShowResult {
+  ticket: Ticket;
+}
+
 // TicketSubscribeMessage opts the calling session into a ticket's notifications —
 // an explicit, opt-in standing interest in a ticket it is not assigned to. The
 // daemon records the subscription authored by the session (identity = session), so
@@ -2376,6 +2395,7 @@ model Response {
   ticket_status_result?: TicketStatusResult;
   ticket_inbox_result?: TicketInboxResult;
   ticket_list_result?: TicketListResult;
+  ticket_show_result?: TicketShowResult;
   ticket_attach_result?: TicketAttachResult;
   ticket_create_result?: TicketCreateResult;
   ticket_comment_result?: TicketCommentResult;


### PR DESCRIPTION
Part of ticket **agent-cost-tools** (scope-extension item 7): agents could never re-read a ticket's discussion — `ticket inbox` is a consuming cursor read, `ticket list` carries no activity. The app's panel has `get_ticket` over WS; this gives agents the same full-detail pull over the unix socket.

## What

- New agent-socket command `ticket_show` (`TicketShowMessage`/`TicketShowResult` in TypeSpec + generated types): a **non-consuming** full-record read — metadata, description, complete activity thread with full bodies (comments, status changes, verdicts), attachments. Never touches any session's inbox cursor. Like `ticket_list`, not identity-scoped.
- Daemon handler reuses the exact path `get_ticket` serves the app (`store.GetTicket` + `ticketToProtocol`); unknown id → `Ok:false` "not found".
- `attn ticket show <ticket-id> [--session <id>] [--json]` — human output renders the full thread in the inbox style with **no truncation**; `--json` prints the full wire ticket.
- `ProtocolVersion` 144 → 145, bumped in both lockstep spots (constants.go + useDaemonSocket.ts).

## Testing

- Daemon test: full record round-trip with status change + long multi-line comment + attachment, all bodies intact; unknown-id failure contract.
- Printer test: long multi-line comment renders verbatim; empty-activity ticket renders sanely.
- `go build ./...`, scoped Go tests, `tsc --noEmit` all green.
- Live: throwaway `ATTN_PROFILE` daemon built from this branch — created a ticket, added a multi-line comment, verified `ticket show` (human + `--json`) returns the full body and the unknown-id case errors cleanly; profile cleaned after.

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Victor

Co-Authored-By: Claude <noreply@anthropic.com>