### PR TITLE
feat(delegate): --cwd composes with --worktree; auto-truncate derived names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-05]
 
+### Added
+- **Delegate: `--cwd` and `--worktree` now compose.** `attn delegate --cwd <dir> --worktree <branch>` creates a worktree of the repo at `<dir>` and places the new workspace there, instead of being rejected. Over-long auto-derived names (e.g. from a worktree folder like `attn--feat-some-long-branch`) are now truncated instead of failing the delegation; an explicit `--name` that is too long still errors as before.
+
 ### Fixed
 - **Reloading an agent no longer crashes its ticket.** Reloading a delegated agent's session (session actions → Reload) used to look like a process death to the daemon: the bound ticket was stamped Crashed and a pointless reconciliation verdict was posted against a perfectly healthy session. A reload is now a recognized lifecycle transition — the ticket stays in its column and no reconciliation runs. Real crashes are still detected exactly as before.
 - **Reload no longer races the pane teardown.** The reload's own kill could be mistaken for the agent quitting cleanly, closing the pane (and its workspace) out from under the respawn and failing the reload with "unknown workspace". The session now stays put for the whole kill → respawn window.

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -608,7 +608,8 @@ placement:
   --worktree <branch>        create a worktree for the delegated session
 
 worktree options:
-  combine with any placement (current, --workspace, or --new-workspace)
+  combine with any placement (current, --workspace, or --new-workspace);
+  combining with --cwd creates a worktree of the repo at that directory
   --repo <path>              main repository (defaults to the workspace repository)
   --from <ref>               branch or ref to start from
   --worktree-path <path>     override the generated sibling path
@@ -1820,9 +1821,6 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 	customWorktreePath := strings.TrimSpace(*worktreePath)
 	if explicitWorkspace != "" && (*newWorkspace || customCWD != "") {
 		return delegateCLIArgs{}, errors.New("--workspace cannot be combined with --new-workspace or --cwd")
-	}
-	if customCWD != "" && branch != "" {
-		return delegateCLIArgs{}, errors.New("--cwd cannot be combined with --worktree")
 	}
 	if branch == "" && (repo != "" || startingFrom != "" || customWorktreePath != "") {
 		return delegateCLIArgs{}, errors.New("--repo, --from, and --worktree-path require --worktree")

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -604,6 +604,23 @@ func TestParseDelegateArgsAcceptsWorkspaceWithWorktree(t *testing.T) {
 	}
 }
 
+func TestParseDelegateArgsAcceptsCwdWithWorktree(t *testing.T) {
+	parsed, err := parseDelegateArgs([]string{
+		"--source-session", "source-session",
+		"--brief", "Work in a worktree of the repo at this directory",
+		"--cwd", "/some/repo",
+		"--worktree", "feat/parser",
+	})
+	if err != nil {
+		t.Fatalf("parseDelegateArgs() error = %v", err)
+	}
+	if parsed.options.Placement != "new_workspace" ||
+		parsed.options.CWD != "/some/repo" ||
+		parsed.options.Worktree != "feat/parser" {
+		t.Fatalf("options = %+v", parsed.options)
+	}
+}
+
 func TestWriteHelpMentionsPresenceAndOpen(t *testing.T) {
 	var output bytes.Buffer
 	writeHelp(&output)

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -118,6 +118,10 @@ with any placement:
     "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" \
       --new-workspace --worktree feat/delegated-task
 
+    # worktree of the repo at an existing directory
+    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" \
+      --cwd /path/to/project --worktree feat/delegated-task
+
 Worktree options:
 
 - `--repo <path>` chooses the main repository (defaults to the workspace's repo).

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -94,6 +94,21 @@ func (d *Daemon) validateDelegationName(name string, creatingWorkspace bool, tar
 	return nil
 }
 
+// truncateDelegationName shortens a directory-basename-derived name to fit
+// maxDelegationNameRunes. Unlike an explicit --name (which must fail loudly so
+// the caller learns the limit), a derived default should just fit — a worktree
+// checkout like "attn--feat-some-long-branch" always exceeds 16 runes, and
+// erroring there would make --worktree unusable without also passing --name.
+// Trailing "-", "_", ".", and whitespace are trimmed off the cut so the result
+// reads cleanly (e.g. "attn--feat-agent" rather than "attn--feat-agent-").
+func truncateDelegationName(name string) string {
+	runes := []rune(name)
+	if len(runes) <= maxDelegationNameRunes {
+		return name
+	}
+	return strings.TrimRight(string(runes[:maxDelegationNameRunes]), "-_. \t")
+}
+
 func (d *Daemon) resolveDelegationAgent(sourceAgent string, requested *string) (string, error) {
 	agent := strings.TrimSpace(strings.ToLower(protocol.Deref(requested)))
 	if agent == "" {
@@ -292,10 +307,15 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 			return nil, fmt.Errorf("new_workspace placement does not accept workspace_id")
 		}
 		directory = strings.TrimSpace(protocol.Deref(msg.Cwd))
-		if msg.Worktree != nil {
-			if directory != "" {
-				return nil, fmt.Errorf("new_workspace placement cannot combine cwd and worktree")
+		if directory != "" && msg.Worktree != nil {
+			// --cwd + --worktree compose: the worktree's repo and starting ref are
+			// inferred from this base directory below (createDelegationWorktree),
+			// and the workspace ends up placed at the created worktree path.
+			validatedCwd, cwdErr := validateDelegationDirectory(directory)
+			if cwdErr != nil {
+				return nil, cwdErr
 			}
+			directory = validatedCwd
 		}
 		if directory == "" {
 			directory = source.Directory
@@ -346,7 +366,7 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 	// validate the final name. Only a worktree may exist at this point, so a
 	// validation failure rolls it back (no workspace/pane/session yet).
 	if name == "" {
-		name = filepath.Base(directory)
+		name = truncateDelegationName(filepath.Base(directory))
 		if err := d.validateDelegationName(name, creatingWorkspace, sessionNameWorkspaceID); err != nil {
 			return nil, d.rollbackDelegation("", createdWorktreePath, err)
 		}

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -851,7 +851,7 @@ func TestDelegateRejectsDuplicateSessionNameInWorkspace(t *testing.T) {
 	}
 }
 
-func TestDelegateRejectsLongWorktreeDefaultNameAndRollsBack(t *testing.T) {
+func TestDelegateTruncatesLongWorktreeDefaultName(t *testing.T) {
 	root := t.TempDir()
 	mainRepo := filepath.Join(root, "repo")
 	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
@@ -866,7 +866,10 @@ func TestDelegateRejectsLongWorktreeDefaultNameAndRollsBack(t *testing.T) {
 	consumeDelegatedPrompt(t, backend)
 	worktreePath := filepath.Join(root, "repo--feat-delegated-long")
 
-	_, err := d.delegate(&protocol.DelegateMessage{
+	// No --name; the worktree folder basename ("repo--feat-delegated-long", 26
+	// runes) exceeds maxDelegationNameRunes. A derived name is truncated instead
+	// of rejected, so the delegation succeeds with a shortened, clean name.
+	result, err := d.delegate(&protocol.DelegateMessage{
 		Cmd:             protocol.CmdDelegate,
 		SourceSessionID: sourceSessionID,
 		Brief:           "No --name; the worktree folder is too long.",
@@ -877,14 +880,46 @@ func TestDelegateRejectsLongWorktreeDefaultNameAndRollsBack(t *testing.T) {
 			Path:   protocol.Ptr(worktreePath),
 		},
 	})
-	if err == nil || !strings.Contains(err.Error(), "too long") {
-		t.Fatalf("delegate() error = %v, want a name-too-long error", err)
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
 	}
-	if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
-		t.Fatalf("worktree still exists after rollback: %v", statErr)
+	wantName := "repo--feat-deleg"
+	if len([]rune(wantName)) > maxDelegationNameRunes {
+		t.Fatalf("test setup bug: wantName %q exceeds max", wantName)
 	}
-	if workspaces := d.store.ListWorkspaces(); len(workspaces) != 1 {
-		t.Fatalf("workspaces = %+v, want only the source workspace", workspaces)
+	workspace := d.store.GetWorkspace(result.WorkspaceID)
+	if workspace == nil || workspace.Title != wantName {
+		t.Fatalf("delegated workspace = %+v, want title %q", workspace, wantName)
+	}
+	session := d.store.Get(result.SessionID)
+	if session == nil || session.Label != wantName {
+		t.Fatalf("delegated session = %+v, want label %q", session, wantName)
+	}
+}
+
+func TestTruncateDelegationName(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"within limit is unchanged", "myproj", "myproj"},
+		{"exactly at limit is unchanged", strings.Repeat("a", 16), strings.Repeat("a", 16)},
+		{"cuts to the rune limit", "attn--feat-agent-cost-tooling", "attn--feat-agent"},
+		{"trims a trailing dash after the cut", strings.Repeat("a", 15) + "-more-stuff", strings.Repeat("a", 15)},
+		{"trims trailing punctuation and whitespace", "twelve chars.   more", "twelve chars"},
+		{"multi-byte runes counted as one", strings.Repeat("é", 20), strings.Repeat("é", 16)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateDelegationName(tc.input)
+			if got != tc.want {
+				t.Fatalf("truncateDelegationName(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+			if len([]rune(got)) > maxDelegationNameRunes {
+				t.Fatalf("truncateDelegationName(%q) = %q exceeds max runes", tc.input, got)
+			}
+		})
 	}
 }
 
@@ -1336,5 +1371,126 @@ func TestDelegateRollsBackNewWorkspaceAndWorktreeWhenSpawnFails(t *testing.T) {
 		if workspace != nil && workspace.Directory == worktreePath {
 			t.Fatalf("delegated workspace still exists after rollback: %+v", workspace)
 		}
+	}
+}
+
+// TestDelegateComposesCwdAndWorktree covers the new_workspace placement with
+// both --cwd and --worktree set: the worktree's repo and starting ref are
+// inferred from the cwd (not the source session's directory), and the new
+// workspace ends up placed at the created worktree path, not the cwd itself.
+func TestDelegateComposesCwdAndWorktree(t *testing.T) {
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	runGitDaemon(t, mainRepo, "init")
+	runGitDaemon(t, mainRepo, "commit", "--allow-empty", "-m", "init")
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	// Source session lives elsewhere so a correct implementation must infer
+	// the worktree's repo/starting-ref from --cwd, not from the source.
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+	worktreePath := filepath.Join(root, "repo--feat-cwd-compose")
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Compose --cwd with --worktree.",
+		Placement:       protocol.Ptr(delegationPlacementNew),
+		Label:           protocol.Ptr("composed"),
+		Cwd:             protocol.Ptr(mainRepo),
+		Worktree: &protocol.DelegateWorktreeRequest{
+			Branch: "feat/cwd-compose",
+			Path:   protocol.Ptr(worktreePath),
+		},
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	worktreePath = git.CanonicalizePath(worktreePath)
+	if result.Placement != delegationPlacementNew ||
+		result.Directory != worktreePath ||
+		!protocol.Deref(result.WorktreeCreated) {
+		t.Fatalf("result = %+v, want directory %q", result, worktreePath)
+	}
+	workspace := d.store.GetWorkspace(result.WorkspaceID)
+	if workspace == nil || workspace.Directory != worktreePath {
+		t.Fatalf("delegated workspace = %+v, want directory %q", workspace, worktreePath)
+	}
+	session := d.store.Get(result.SessionID)
+	if session == nil ||
+		session.Directory != worktreePath ||
+		protocol.Deref(session.Branch) != "feat/cwd-compose" {
+		t.Fatalf("delegated session = %+v", session)
+	}
+	if info, err := os.Stat(worktreePath); err != nil || !info.IsDir() {
+		t.Fatalf("worktree path stat = %v, info = %+v", err, info)
+	}
+}
+
+// TestDelegateComposedCwdWorktreeRequiresRepoWhenNotAGitRepo covers the
+// failure mode: a --cwd that is not itself a git repository, combined with
+// --worktree and no --repo, must still surface the existing "pass --repo"
+// error rather than silently falling back to the source session's repo.
+func TestDelegateComposedCwdWorktreeRequiresRepoWhenNotAGitRepo(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+	notARepo := t.TempDir()
+
+	_, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "cwd is not a git repo and no --repo is given.",
+		Placement:       protocol.Ptr(delegationPlacementNew),
+		Cwd:             protocol.Ptr(notARepo),
+		Worktree: &protocol.DelegateWorktreeRequest{
+			Branch: "feat/no-repo",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not in a git repository; pass --repo") {
+		t.Fatalf("delegate() error = %v, want a not-a-git-repository error", err)
+	}
+}
+
+// TestDelegateTruncatesLongDirectoryDefaultName covers the plain (no
+// worktree) new_workspace case: a directory whose basename exceeds
+// maxDelegationNameRunes, with no explicit --name, gets a truncated name
+// instead of a rejected delegation.
+func TestDelegateTruncatesLongDirectoryDefaultName(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+	targetDir := filepath.Join(t.TempDir(), "a-very-long-directory-name-indeed")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "No --name; the directory basename is too long.",
+		Placement:       protocol.Ptr(delegationPlacementNew),
+		Cwd:             protocol.Ptr(targetDir),
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	wantName := "a-very-long-dire"
+	if len([]rune(wantName)) > maxDelegationNameRunes {
+		t.Fatalf("test setup bug: wantName %q exceeds max", wantName)
+	}
+	workspace := d.store.GetWorkspace(result.WorkspaceID)
+	if workspace == nil || workspace.Title != wantName {
+		t.Fatalf("delegated workspace = %+v, want title %q", workspace, wantName)
+	}
+	session := d.store.Get(result.SessionID)
+	if session == nil || session.Label != wantName {
+		t.Fatalf("delegated session = %+v, want label %q", session, wantName)
 	}
 }


### PR DESCRIPTION
Item 10 of the agent-cost-tools ticket: two delegate CLI ergonomics fixes.

## What

- **`--cwd` + `--worktree` now compose.** `attn delegate --cwd <dir> --worktree <branch>` creates a worktree of the repo at `<dir>` and places the new workspace there. Previously both the CLI and the daemon rejected the combination outright. The daemon mechanics already supported it — `createDelegationWorktree` infers repo and starting ref from the base directory — so this removes the two guards and validates the cwd up front.
- **Over-long derived names truncate instead of erroring.** A worktree checkout basename like `attn--feat-some-long-branch` always exceeds the 16-rune session-name limit, which made `--worktree` unusable without also passing `--name`. Derived defaults are now cut to 16 runes with trailing `-_. ` trimmed. An explicit `--name` that is too long still fails loudly, as before.

## Testing

- New daemon tests: composition end-to-end (repo/ref inferred from cwd, workspace placed at worktree path), non-repo cwd still surfaces the "pass --repo" error, truncation for both the worktree and plain-directory derived-name paths, plus a `truncateDelegationName` table test (rune counting, trailing-punctuation trim).
- CLI parse test for `--cwd` + `--worktree`.
- **Live-verified on a throwaway profile** (`ATTN_PROFILE=prhsmoke`, daemon built from this branch): `attn delegate --cwd /tmp/.../a-very-long-repository-name-for-truncation --worktree feat/compose-smoke` created the sibling worktree, placed the new workspace at it (`worktree_created: true`, branch correct in `git worktree list`), and derived the label `a-very-long-repo` (exactly 16 runes, cleanly trimmed).

https://claude.ai/code/session_01GsJxkhdJJgYYVPd3m5f4xx