### PR TITLE
feat(present): the reader — pinned diffs, notes, inline comments, submit round-trip

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1149,6 +1149,12 @@ Object.defineProperty(window, "__ATTN_NATIVE_DIALOGS", {
             }
             // Show window as soon as page content is loaded (loading screen visible)
             let _ = webview.window().show();
+            // The present window opens from an explicit user action (chip click) and
+            // must take focus: an unfocused, hidden-at-creation WKWebView can leave
+            // requestAnimationFrame parked (blank diff pane) until first focus.
+            if webview.window().label() == PRESENT_WINDOW_LABEL {
+                let _ = webview.window().set_focus();
+            }
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/app/src/components/DiffCommentThread.test.tsx
+++ b/app/src/components/DiffCommentThread.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DiffCommentThread } from './DiffCommentThread';
+import type { ReviewComment } from '../types/generated';
+
+function makeComment(overrides: Partial<ReviewComment> = {}): ReviewComment {
+  return {
+    id: 'comment-1',
+    content: 'a comment',
+    filepath: 'src/foo.ts',
+    line_start: 1,
+    line_end: 1,
+    author: 'user',
+    resolved: false,
+    created_at: '2026-07-01T00:00:00Z',
+    review_id: 'round-1',
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+describe('DiffCommentThread', () => {
+  it('hides Edit/Resolve/Delete for a comment id in readOnlyCommentIds', () => {
+    render(
+      <DiffCommentThread
+        comments={[makeComment({ id: 'read-only-1' })]}
+        draft={false}
+        editingCommentId={null}
+        readOnlyCommentIds={new Set(['read-only-1'])}
+        showSendToClaude={false}
+        onSaveDraft={noop}
+        onCancelDraft={noop}
+        onStartEdit={noop}
+        onEditComment={noop}
+        onCancelEdit={noop}
+        onResolveComment={noop}
+        onDeleteComment={noop}
+        onSendComment={noop}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Resolve' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('shows Edit/Resolve/Delete for a comment id not in readOnlyCommentIds', () => {
+    render(
+      <DiffCommentThread
+        comments={[makeComment({ id: 'editable-1' })]}
+        draft={false}
+        editingCommentId={null}
+        readOnlyCommentIds={new Set(['some-other-id'])}
+        showSendToClaude={false}
+        onSaveDraft={noop}
+        onCancelDraft={noop}
+        onStartEdit={noop}
+        onEditComment={noop}
+        onCancelEdit={noop}
+        onResolveComment={noop}
+        onDeleteComment={noop}
+        onSendComment={noop}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resolve' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('defaults to showing all actions when readOnlyCommentIds is undefined', () => {
+    render(
+      <DiffCommentThread
+        comments={[makeComment()]}
+        draft={false}
+        editingCommentId={null}
+        showSendToClaude={false}
+        onSaveDraft={noop}
+        onCancelDraft={noop}
+        onStartEdit={noop}
+        onEditComment={noop}
+        onCancelEdit={noop}
+        onResolveComment={noop}
+        onDeleteComment={noop}
+        onSendComment={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resolve' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+});

--- a/app/src/components/DiffCommentThread.tsx
+++ b/app/src/components/DiffCommentThread.tsx
@@ -87,6 +87,8 @@ export interface DiffCommentThreadProps {
   draft: boolean;
   /** Id of the comment currently being edited, if any. */
   editingCommentId: string | null;
+  /** Comment ids to render without Edit/Resolve/Delete actions (e.g. already-submitted comments in a read-only view). */
+  readOnlyCommentIds?: Set<string>;
   /** Whether the per-comment "Send to CC" action is available. */
   showSendToClaude: boolean;
   draftContent?: string;
@@ -105,6 +107,7 @@ export function DiffCommentThread({
   comments,
   draft,
   editingCommentId,
+  readOnlyCommentIds,
   showSendToClaude,
   draftContent = '',
   onDraftContentChange,
@@ -122,6 +125,7 @@ export function DiffCommentThread({
       {comments.map((comment) => {
         const isEditing = editingCommentId === comment.id;
         const isAgent = comment.author === 'agent';
+        const isReadOnly = readOnlyCommentIds?.has(comment.id) ?? false;
         return (
           <div
             key={comment.id}
@@ -147,17 +151,23 @@ export function DiffCommentThread({
                     )}
                   </div>
                   <div className="diff-comment-actions">
-                    <button className="edit-btn" onClick={() => onStartEdit(comment.id)}>Edit</button>
+                    {!isReadOnly && (
+                      <button className="edit-btn" onClick={() => onStartEdit(comment.id)}>Edit</button>
+                    )}
                     {showSendToClaude && (
                       <button className="send-btn" onClick={() => onSendComment(comment)}>Send to CC</button>
                     )}
-                    <button
-                      className="resolve-btn"
-                      onClick={() => onResolveComment(comment.id, !comment.resolved)}
-                    >
-                      {comment.resolved ? 'Unresolve' : 'Resolve'}
-                    </button>
-                    <button className="delete-btn" onClick={() => onDeleteComment(comment.id)}>Delete</button>
+                    {!isReadOnly && (
+                      <button
+                        className="resolve-btn"
+                        onClick={() => onResolveComment(comment.id, !comment.resolved)}
+                      >
+                        {comment.resolved ? 'Unresolve' : 'Resolve'}
+                      </button>
+                    )}
+                    {!isReadOnly && (
+                      <button className="delete-btn" onClick={() => onDeleteComment(comment.id)}>Delete</button>
+                    )}
                   </div>
                 </div>
                 <CommentBody content={comment.content} />

--- a/app/src/components/DiffView.tsx
+++ b/app/src/components/DiffView.tsx
@@ -69,6 +69,8 @@ export interface DiffViewProps {
   filePath?: string;
   comments: ReviewComment[];
   editingCommentId: string | null;
+  /** Comment ids to render without Edit/Resolve/Delete actions (already-submitted, non-draft comments). */
+  readOnlyCommentIds?: Set<string>;
   resolvedTheme?: ResolvedTheme;
   diffStyle: 'unified' | 'split';
   /** false = hunks (collapse unchanged), true = full file. */
@@ -129,6 +131,7 @@ export function DiffView({
   filePath,
   comments,
   editingCommentId,
+  readOnlyCommentIds,
   resolvedTheme = 'dark',
   diffStyle,
   expandUnchanged,
@@ -386,6 +389,7 @@ export function DiffView({
           comments={meta.comments}
           draft={meta.draft}
           editingCommentId={editingCommentId}
+          readOnlyCommentIds={readOnlyCommentIds}
           showSendToClaude={!!onSendToClaude && !!filePath}
           draftContent={meta.draft ? draft?.content : undefined}
           onDraftContentChange={meta.draft ? handleDraftContentChange : undefined}
@@ -402,6 +406,7 @@ export function DiffView({
     },
     [
       editingCommentId,
+      readOnlyCommentIds,
       onSendToClaude,
       filePath,
       handleSaveDraft,
@@ -486,6 +491,7 @@ export function DiffView({
                 comments={staleComments}
                 draft={false}
                 editingCommentId={editingCommentId}
+                readOnlyCommentIds={readOnlyCommentIds}
                 showSendToClaude={!!onSendToClaude && !!filePath}
                 onSaveDraft={noop}
                 onCancelDraft={noop}

--- a/app/src/components/PresentRoot/PresentRoot.css
+++ b/app/src/components/PresentRoot/PresentRoot.css
@@ -66,6 +66,89 @@
   color: #d97706;
 }
 
+.present-root-submit-button {
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: var(--font-size);
+  cursor: pointer;
+}
+
+.present-root-submit-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.present-root-submit-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 100;
+}
+
+.present-root-submit-dialog {
+  background: var(--color-bg-panel);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 20px 24px;
+  min-width: 320px;
+  max-width: 420px;
+}
+
+.present-root-submit-dialog h2 {
+  margin: 0 0 8px 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.present-root-submit-dialog p {
+  margin: 0 0 12px 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size);
+}
+
+.present-root-submit-handback {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size);
+  margin-bottom: 12px;
+  cursor: pointer;
+}
+
+.present-root-submit-error {
+  color: var(--color-error, #dc2626);
+  font-size: var(--font-size);
+  margin-bottom: 12px;
+}
+
+.present-root-submit-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.present-root-submit-actions button {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-app);
+  color: var(--color-text-primary);
+  font-size: var(--font-size);
+  cursor: pointer;
+}
+
+.present-root-submit-actions button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 .present-root-drift {
   display: flex;
   align-items: flex-start;

--- a/app/src/components/PresentRoot/PresentRoot.css
+++ b/app/src/components/PresentRoot/PresentRoot.css
@@ -4,6 +4,8 @@
   padding: 32px 40px;
   background: var(--color-bg-app);
   color: var(--color-text-primary);
+  display: flex;
+  flex-direction: column;
 }
 
 .present-root-message {
@@ -64,29 +66,46 @@
   color: #d97706;
 }
 
+.present-root-drift {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-panel);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size);
+}
+
+.present-root-drift-dismiss {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.present-root-drift-dismiss:hover {
+  color: var(--color-text-primary);
+}
+
 .present-root-summary {
   margin-top: 16px;
   color: var(--color-text-secondary);
+  line-height: 1.6;
 }
 
-.present-root-files {
-  margin-top: 16px;
-  padding-left: 20px;
+.present-root-summary :first-child {
+  margin-top: 0;
 }
 
-.present-root-file {
-  margin-bottom: 10px;
-}
-
-.present-root-file code {
-  font-family: monospace;
-  font-size: var(--font-size);
-}
-
-.present-root-file-note {
-  margin: 4px 0 0 0;
-  color: var(--color-text-secondary);
-  font-size: var(--font-size);
+.present-root-summary :last-child {
+  margin-bottom: 0;
 }
 
 .present-root-comment-count {
@@ -95,11 +114,129 @@
   font-size: var(--font-size);
 }
 
-.present-root-footer {
-  margin-top: 32px;
-  padding-top: 16px;
-  border-top: 1px solid var(--color-border);
+.present-root-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  margin-top: 20px;
+  gap: 20px;
+}
+
+.present-root-files {
+  flex: 0 0 260px;
+  overflow-y: auto;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-panel);
+}
+
+.present-root-file {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.present-root-file:last-child {
+  border-bottom: none;
+}
+
+.present-root-file:hover {
+  background: var(--color-border-subtle);
+}
+
+.present-root-file.selected {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.present-root-file-index {
   color: var(--color-text-secondary);
+  font-size: 12px;
+  min-width: 18px;
+  text-align: right;
+}
+
+.present-root-file.selected .present-root-file-index {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.present-root-file-path {
+  font-family: monospace;
   font-size: var(--font-size);
-  font-style: italic;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.present-root-file-note-marker {
+  color: var(--color-accent);
+  font-size: 10px;
+}
+
+.present-root-file.selected .present-root-file-note-marker {
+  color: #fff;
+}
+
+.present-root-skip-divider {
+  padding: 8px 12px 4px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary);
+  border-top: 1px solid var(--color-border);
+  margin-top: 4px;
+}
+
+.present-root-file-skipped {
+  cursor: default;
+  color: var(--color-text-secondary);
+  opacity: 0.6;
+}
+
+.present-root-file-skipped:hover {
+  background: none;
+}
+
+.present-root-diff-pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.present-root-file-note-banner {
+  margin-bottom: 12px;
+  padding: 10px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-panel);
+  color: var(--color-text-primary);
+  line-height: 1.6;
+  font-size: var(--font-size);
+}
+
+.present-root-file-note-banner :first-child {
+  margin-top: 0;
+}
+
+.present-root-file-note-banner :last-child {
+  margin-bottom: 0;
+}
+
+.present-root-diff-placeholder {
+  color: var(--color-text-secondary);
+  padding: 24px;
+}
+
+.present-root-diff-error {
+  color: var(--color-error, #dc2626);
+  padding: 24px;
 }

--- a/app/src/components/PresentRoot/PresentRoot.test.tsx
+++ b/app/src/components/PresentRoot/PresentRoot.test.tsx
@@ -1,12 +1,16 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isTauri } from '@tauri-apps/api/core';
 import { PresentRoot } from './index';
+import { DiffView } from '../DiffView';
+import type { DiffViewProps } from '../DiffView';
 
 // DiffView renders the @pierre/diffs custom element (shadow DOM + Shiki),
 // which jsdom cannot exercise. These tests cover the reader's data flow
-// (file selection, fetching pinned diffs, keyboard nav), not diff rendering
-// internals — mirrors the DiffDetailPanel.test.tsx idiom.
+// (file selection, fetching pinned diffs, keyboard nav, comment drafts), not
+// diff rendering internals — mirrors the DiffDetailPanel.test.tsx idiom. The
+// mock captures its full props so tests can invoke onAddComment etc.
+// directly and assert on the comments PresentRoot passes down.
 vi.mock('../DiffView', () => ({
   DiffView: vi.fn(({ original, modified }) => (
     <div data-testid="diff-view">
@@ -15,6 +19,13 @@ vi.mock('../DiffView', () => ({
     </div>
   )),
 }));
+
+function latestDiffViewProps(): DiffViewProps {
+  const calls = vi.mocked(DiffView).mock.calls;
+  const props = calls[calls.length - 1]?.[0];
+  if (!props) throw new Error('DiffView has not been rendered yet');
+  return props as unknown as DiffViewProps;
+}
 
 // PresentRoot owns its own useDaemonSocket connection (it is a standalone
 // Tauri window, not a component fed daemon functions via props), so
@@ -64,6 +75,12 @@ class FakeWebSocket {
 // waits can be slower than testing-library's 1000ms default, independent of
 // this component's own logic.
 const WAIT_OPTS = { timeout: 5000 };
+
+// Tests that chain several sequential waitFor calls can, in aggregate, exceed
+// vitest's 5000ms default per-test timeout under full-suite contention even
+// though each individual waitFor stays within WAIT_OPTS. Applied as the third
+// `it(...)` argument on those multi-step tests.
+const TEST_TIMEOUT = 15000;
 
 async function waitForOpenSocket(): Promise<FakeWebSocket> {
   await waitFor(() => {
@@ -195,6 +212,13 @@ describe('PresentRoot', () => {
   });
 
   afterEach(() => {
+    // Unmount explicitly, while setTimeout is still our tracked wrapper: the
+    // socket's onclose-triggered reconnect scheduling runs during unmount, and
+    // needs to land in pendingTimeouts below rather than escape as a real,
+    // untracked 1000ms timer that later fires mid a subsequent test and
+    // injects a stray FakeWebSocket instance (this is what made "moves the
+    // selection..."/other later tests intermittently see the wrong socket).
+    cleanup();
     for (const timeoutId of pendingTimeouts) {
       originalClearTimeout(timeoutId);
     }
@@ -366,7 +390,7 @@ describe('PresentRoot', () => {
     await waitFor(() => {
       expect(screen.getByText('src/foo.ts').closest('li')).toHaveClass('selected');
     }, WAIT_OPTS);
-  });
+  }, TEST_TIMEOUT);
 
   it('shows a drift banner iff repoHeadSha differs from the pinned round head', async () => {
     await loadRound({ repoHeadSha: 'deadbeef000000' });
@@ -412,4 +436,175 @@ describe('PresentRoot', () => {
     expect(screen.getByText('src/vendor.ts')).toBeInTheDocument();
     expect(screen.getByText('src/generated.ts').closest('li')).toHaveClass('present-root-file-skipped');
   });
+
+  async function loadRoundWithDiff(): Promise<FakeWebSocket> {
+    const ws = await loadRound();
+    act(() => {
+      ws.emit({
+        event: 'file_diff_result',
+        success: true,
+        path: 'src/foo.ts',
+        original: 'old content',
+        modified: 'new content',
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-view')).toBeInTheDocument();
+    }, WAIT_OPTS);
+    return ws;
+  }
+
+  it('surfaces a locally-added draft in the comments passed to DiffView', async () => {
+    await loadRoundWithDiff();
+
+    await act(async () => {
+      await latestDiffViewProps().onAddComment(3, 5, 'looks off');
+    });
+
+    await waitFor(() => {
+      const comments = latestDiffViewProps().comments;
+      expect(comments).toHaveLength(1);
+      expect(comments[0]).toMatchObject({ line_start: 3, line_end: 5, content: 'looks off' });
+    }, WAIT_OPTS);
+  }, TEST_TIMEOUT);
+
+  it('round-trips an old-side (negative line_end) draft through the signed convention', async () => {
+    await loadRoundWithDiff();
+
+    await act(async () => {
+      await latestDiffViewProps().onAddComment(10, -12, 'stale comment');
+    });
+
+    await waitFor(() => {
+      const comments = latestDiffViewProps().comments;
+      const draft = comments.find((c) => c.content === 'stale comment');
+      expect(draft).toMatchObject({ line_start: 10, line_end: -12 });
+    }, WAIT_OPTS);
+  }, TEST_TIMEOUT);
+
+  it('sends the correct wire shape when submitting drafts', async () => {
+    const ws = await loadRoundWithDiff();
+
+    await act(async () => {
+      await latestDiffViewProps().onAddComment(3, 5, 'new-side comment');
+    });
+    await act(async () => {
+      await latestDiffViewProps().onAddComment(10, -12, 'old-side comment');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Submit review/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      const sent = ws.sent.map((entry) => JSON.parse(entry));
+      const req = sent.find((m) => m.cmd === 'present_submit_round');
+      expect(req).toBeDefined();
+      expect(req.round_id).toBe('round-1');
+      expect(req.handback).toBe(true);
+      expect(req.comments).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            filepath: 'src/foo.ts',
+            line_start: 3,
+            line_end: 5,
+            side: 'new',
+            content: 'new-side comment',
+          }),
+          expect.objectContaining({
+            filepath: 'src/foo.ts',
+            line_start: 10,
+            line_end: 12,
+            side: 'old',
+            content: 'old-side comment',
+          }),
+        ])
+      );
+    }, WAIT_OPTS);
+  }, TEST_TIMEOUT);
+
+  it('clears drafts and refetches the round after a successful submit', async () => {
+    const ws = await loadRoundWithDiff();
+
+    await act(async () => {
+      await latestDiffViewProps().onAddComment(3, 5, 'looks off');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Submit review/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(ws.sent.map((e) => JSON.parse(e)).some((m) => m.cmd === 'present_submit_round')).toBe(true);
+    }, WAIT_OPTS);
+
+    act(() => {
+      ws.emit({ event: 'present_submit_round_result', success: true, round_id: 'round-1' });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    }, WAIT_OPTS);
+    expect(screen.getByText('Submit review')).toBeInTheDocument();
+
+    // A successful submit bumps refreshSignal, which re-fetches the round.
+    await waitFor(() => {
+      const sent = ws.sent.map((entry) => JSON.parse(entry));
+      const refetches = sent.filter((m) => m.cmd === 'get_presentation_round');
+      expect(refetches.length).toBeGreaterThanOrEqual(2);
+    }, WAIT_OPTS);
+  }, TEST_TIMEOUT);
+
+  it('keeps drafts and shows an inline error when submit fails', async () => {
+    const ws = await loadRoundWithDiff();
+
+    await act(async () => {
+      await latestDiffViewProps().onAddComment(3, 5, 'looks off');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Submit review/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(ws.sent.map((e) => JSON.parse(e)).some((m) => m.cmd === 'present_submit_round')).toBe(true);
+    }, WAIT_OPTS);
+
+    act(() => {
+      ws.emit({ event: 'present_submit_round_result', success: false, error: 'daemon unreachable' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('daemon unreachable')).toBeInTheDocument();
+    }, WAIT_OPTS);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(latestDiffViewProps().comments.some((c) => c.content === 'looks off')).toBe(true);
+  }, TEST_TIMEOUT);
+
+  it('keeps drafts made on one file when switching to another and back', async () => {
+    const ws = await loadRoundWithDiff();
+
+    await act(async () => {
+      await latestDiffViewProps().onAddComment(3, 5, 'on foo.ts');
+    });
+    await waitFor(() => {
+      expect(latestDiffViewProps().comments.some((c) => c.content === 'on foo.ts')).toBe(true);
+    }, WAIT_OPTS);
+
+    fireEvent.click(screen.getByText('src/foo.test.ts'));
+    act(() => {
+      ws.emit({
+        event: 'file_diff_result',
+        success: true,
+        path: 'src/foo.test.ts',
+        original: 'test old',
+        modified: 'test new',
+      });
+    });
+    await waitFor(() => {
+      expect(latestDiffViewProps().comments.some((c) => c.content === 'on foo.ts')).toBe(false);
+    }, WAIT_OPTS);
+
+    fireEvent.click(screen.getByText('src/foo.ts'));
+    await waitFor(() => {
+      expect(latestDiffViewProps().comments.some((c) => c.content === 'on foo.ts')).toBe(true);
+    }, WAIT_OPTS);
+  }, TEST_TIMEOUT);
 });

--- a/app/src/components/PresentRoot/PresentRoot.test.tsx
+++ b/app/src/components/PresentRoot/PresentRoot.test.tsx
@@ -1,7 +1,20 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isTauri } from '@tauri-apps/api/core';
 import { PresentRoot } from './index';
+
+// DiffView renders the @pierre/diffs custom element (shadow DOM + Shiki),
+// which jsdom cannot exercise. These tests cover the reader's data flow
+// (file selection, fetching pinned diffs, keyboard nav), not diff rendering
+// internals — mirrors the DiffDetailPanel.test.tsx idiom.
+vi.mock('../DiffView', () => ({
+  DiffView: vi.fn(({ original, modified }) => (
+    <div data-testid="diff-view">
+      <div className="original">{original}</div>
+      <div className="modified">{modified}</div>
+    </div>
+  )),
+}));
 
 // PresentRoot owns its own useDaemonSocket connection (it is a standalone
 // Tauri window, not a component fed daemon functions via props), so
@@ -47,19 +60,60 @@ class FakeWebSocket {
   }
 }
 
+// A generous timeout: under full-suite parallel load these real-timer/microtask
+// waits can be slower than testing-library's 1000ms default, independent of
+// this component's own logic.
+const WAIT_OPTS = { timeout: 5000 };
+
 async function waitForOpenSocket(): Promise<FakeWebSocket> {
   await waitFor(() => {
     expect(FakeWebSocket.instances.length).toBeGreaterThan(0);
-  });
+  }, WAIT_OPTS);
   const ws = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
   await waitFor(() => {
     expect(ws.readyState).toBe(FakeWebSocket.OPEN);
-  });
+  }, WAIT_OPTS);
   return ws;
 }
 
 function setSearch(search: string) {
   window.history.replaceState({}, '', `/?${search}`);
+}
+
+/** Renders PresentRoot and drives it through a loaded round, returning the socket for further interaction. */
+async function loadRound(options?: {
+  round?: typeof round;
+  repoHeadSha?: string;
+}): Promise<FakeWebSocket> {
+  setSearch('window=present&presentation=pres-1');
+  render(<PresentRoot />);
+
+  const ws = await waitForOpenSocket();
+  act(() => {
+    ws.emit({ event: 'initial_state' });
+  });
+
+  await waitFor(() => {
+    const sent = ws.sent.map((entry) => JSON.parse(entry));
+    expect(sent.some((m) => m.cmd === 'get_presentation_round' && m.presentation_id === 'pres-1')).toBe(true);
+  }, WAIT_OPTS);
+
+  act(() => {
+    ws.emit({
+      event: 'get_presentation_round_result',
+      success: true,
+      presentation,
+      round: options?.round ?? round,
+      comments: [],
+      ...(options?.repoHeadSha !== undefined && { repo_head_sha: options.repoHeadSha }),
+    });
+  });
+
+  await waitFor(() => {
+    expect(screen.getByText('My presentation')).toBeInTheDocument();
+  }, WAIT_OPTS);
+
+  return ws;
 }
 
 const round = {
@@ -76,7 +130,15 @@ const round = {
       { path: 'src/foo.ts', note: 'Core logic' },
       { path: 'src/foo.test.ts' },
     ],
-    skip: [],
+    skip: [] as string[],
+  },
+};
+
+const roundWithSkip = {
+  ...round,
+  manifest: {
+    ...round.manifest,
+    skip: ['src/generated.ts', 'src/vendor.ts'],
   },
 };
 
@@ -94,12 +156,36 @@ const presentation = {
 
 describe('PresentRoot', () => {
   let originalWebSocket: typeof WebSocket;
+  let originalSetTimeout: typeof globalThis.setTimeout;
+  let originalClearTimeout: typeof globalThis.clearTimeout;
+  let pendingTimeouts: Set<ReturnType<typeof globalThis.setTimeout>>;
 
   beforeEach(() => {
     originalWebSocket = globalThis.WebSocket;
     FakeWebSocket.instances = [];
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
     vi.mocked(isTauri).mockReturnValue(true);
+
+    // Track every setTimeout (including useDaemonSocket's reconnect backoff)
+    // so afterEach can kill stragglers before the next test's FakeWebSocket
+    // gets polluted by a reconnect firing mid-test — mirrors
+    // useDaemonSocket.test.tsx's timer-tracking idiom.
+    originalSetTimeout = globalThis.setTimeout;
+    originalClearTimeout = globalThis.clearTimeout;
+    pendingTimeouts = new Set();
+    globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      let timeoutId: ReturnType<typeof globalThis.setTimeout>;
+      timeoutId = originalSetTimeout((...callbackArgs: unknown[]) => {
+        pendingTimeouts.delete(timeoutId);
+        if (typeof handler === 'function') handler(...callbackArgs);
+      }, timeout, ...args);
+      pendingTimeouts.add(timeoutId);
+      return timeoutId;
+    }) as typeof globalThis.setTimeout;
+    globalThis.clearTimeout = ((timeoutId?: ReturnType<typeof globalThis.setTimeout>) => {
+      if (timeoutId !== undefined) pendingTimeouts.delete(timeoutId);
+      return originalClearTimeout(timeoutId);
+    }) as typeof globalThis.clearTimeout;
 
     // Mirrors the static #loading-screen div in index.html that every window
     // boots behind until React takes over.
@@ -109,6 +195,12 @@ describe('PresentRoot', () => {
   });
 
   afterEach(() => {
+    for (const timeoutId of pendingTimeouts) {
+      originalClearTimeout(timeoutId);
+    }
+    pendingTimeouts.clear();
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
     globalThis.WebSocket = originalWebSocket;
     document.getElementById('loading-screen')?.remove();
     vi.clearAllMocks();
@@ -191,5 +283,133 @@ describe('PresentRoot', () => {
     await waitFor(() => {
       expect(screen.getByText('No presentation specified.')).toBeInTheDocument();
     });
+  });
+
+  it('renders the file list in manifest order with a note marker', async () => {
+    await loadRound();
+
+    const paths = screen.getAllByText(/^src\//).map((el) => el.textContent);
+    expect(paths).toEqual(['src/foo.ts', 'src/foo.test.ts']);
+
+    const notedItem = screen.getByText('src/foo.ts').closest('li');
+    const unnotedItem = screen.getByText('src/foo.test.ts').closest('li');
+    expect(notedItem?.querySelector('.present-root-file-note-marker')).not.toBeNull();
+    expect(unnotedItem?.querySelector('.present-root-file-note-marker')).toBeNull();
+  });
+
+  it('fetches the pinned diff for the initially selected file and shows its note banner', async () => {
+    const ws = await loadRound();
+
+    await waitFor(() => {
+      const sent = ws.sent.map((entry) => JSON.parse(entry));
+      const req = sent.find((m) => m.cmd === 'get_file_diff');
+      expect(req).toMatchObject({
+        directory: '/repo/path',
+        path: 'src/foo.ts',
+        base_ref: 'a1b2c3d4e5f6',
+        head_ref: '00112233445566',
+      });
+    }, WAIT_OPTS);
+
+    expect(screen.getByText('Core logic')).toBeInTheDocument();
+
+    act(() => {
+      ws.emit({
+        event: 'file_diff_result',
+        success: true,
+        path: 'src/foo.ts',
+        original: 'old content',
+        modified: 'new content',
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-view')).toBeInTheDocument();
+    }, WAIT_OPTS);
+    expect(screen.getByText('old content')).toBeInTheDocument();
+    expect(screen.getByText('new content')).toBeInTheDocument();
+  });
+
+  it('fetches the pinned diff for a clicked file', async () => {
+    const ws = await loadRound();
+
+    await waitFor(() => {
+      const sent = ws.sent.map((entry) => JSON.parse(entry));
+      expect(sent.some((m) => m.cmd === 'get_file_diff' && m.path === 'src/foo.ts')).toBe(true);
+    }, WAIT_OPTS);
+
+    fireEvent.click(screen.getByText('src/foo.test.ts'));
+
+    await waitFor(() => {
+      const sent = ws.sent.map((entry) => JSON.parse(entry));
+      const req = sent.find((m) => m.cmd === 'get_file_diff' && m.path === 'src/foo.test.ts');
+      expect(req).toMatchObject({
+        base_ref: 'a1b2c3d4e5f6',
+        head_ref: '00112233445566',
+      });
+    }, WAIT_OPTS);
+  });
+
+  it('moves the selection with j/k keyboard shortcuts', async () => {
+    await loadRound();
+
+    await waitFor(() => {
+      expect(screen.getByText('src/foo.ts').closest('li')).toHaveClass('selected');
+    }, WAIT_OPTS);
+
+    fireEvent.keyDown(window, { key: 'j' });
+    await waitFor(() => {
+      expect(screen.getByText('src/foo.test.ts').closest('li')).toHaveClass('selected');
+    }, WAIT_OPTS);
+
+    fireEvent.keyDown(window, { key: 'k' });
+    await waitFor(() => {
+      expect(screen.getByText('src/foo.ts').closest('li')).toHaveClass('selected');
+    }, WAIT_OPTS);
+  });
+
+  it('shows a drift banner iff repoHeadSha differs from the pinned round head', async () => {
+    await loadRound({ repoHeadSha: 'deadbeef000000' });
+
+    expect(screen.getByText(/repo has moved on/)).toBeInTheDocument();
+  });
+
+  it('shows no drift banner when repoHeadSha matches the pinned round head', async () => {
+    await loadRound({ repoHeadSha: round.head_sha });
+
+    expect(screen.queryByText(/repo has moved on/)).not.toBeInTheDocument();
+  });
+
+  it('shows an inline error when the diff fetch fails, without blanking the window', async () => {
+    const ws = await loadRound();
+
+    await waitFor(() => {
+      const sent = ws.sent.map((entry) => JSON.parse(entry));
+      expect(sent.some((m) => m.cmd === 'get_file_diff')).toBe(true);
+    }, WAIT_OPTS);
+
+    act(() => {
+      ws.emit({
+        event: 'file_diff_result',
+        success: false,
+        path: 'src/foo.ts',
+        error: 'git show failed',
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('git show failed')).toBeInTheDocument();
+    }, WAIT_OPTS);
+    // The window itself stays rendered — not replaced by a full-page error.
+    expect(screen.getByText('My presentation')).toBeInTheDocument();
+  });
+
+  it('lists skipped files dimmed and non-clickable under a Skipped divider', async () => {
+    await loadRound({ round: roundWithSkip });
+
+    expect(screen.getByText('Skipped')).toBeInTheDocument();
+    expect(screen.getByText('src/generated.ts')).toBeInTheDocument();
+    expect(screen.getByText('src/vendor.ts')).toBeInTheDocument();
+    expect(screen.getByText('src/generated.ts').closest('li')).toHaveClass('present-root-file-skipped');
   });
 });

--- a/app/src/components/PresentRoot/PresentRoot.test.tsx
+++ b/app/src/components/PresentRoot/PresentRoot.test.tsx
@@ -1,6 +1,5 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { isTauri } from '@tauri-apps/api/core';
 import { PresentRoot } from './index';
 import { DiffView } from '../DiffView';
 import type { DiffViewProps } from '../DiffView';
@@ -101,6 +100,7 @@ function setSearch(search: string) {
 async function loadRound(options?: {
   round?: typeof round;
   repoHeadSha?: string;
+  comments?: Array<Record<string, unknown>>;
 }): Promise<FakeWebSocket> {
   setSearch('window=present&presentation=pres-1');
   render(<PresentRoot />);
@@ -121,7 +121,7 @@ async function loadRound(options?: {
       success: true,
       presentation,
       round: options?.round ?? round,
-      comments: [],
+      comments: options?.comments ?? [],
       ...(options?.repoHeadSha !== undefined && { repo_head_sha: options.repoHeadSha }),
     });
   });
@@ -181,7 +181,6 @@ describe('PresentRoot', () => {
     originalWebSocket = globalThis.WebSocket;
     FakeWebSocket.instances = [];
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
-    vi.mocked(isTauri).mockReturnValue(true);
 
     // Track every setTimeout (including useDaemonSocket's reconnect backoff)
     // so afterEach can kill stragglers before the next test's FakeWebSocket
@@ -437,8 +436,10 @@ describe('PresentRoot', () => {
     expect(screen.getByText('src/generated.ts').closest('li')).toHaveClass('present-root-file-skipped');
   });
 
-  async function loadRoundWithDiff(): Promise<FakeWebSocket> {
-    const ws = await loadRound();
+  async function loadRoundWithDiff(options?: {
+    comments?: Array<Record<string, unknown>>;
+  }): Promise<FakeWebSocket> {
+    const ws = await loadRound({ comments: options?.comments });
     act(() => {
       ws.emit({
         event: 'file_diff_result',
@@ -465,6 +466,40 @@ describe('PresentRoot', () => {
       const comments = latestDiffViewProps().comments;
       expect(comments).toHaveLength(1);
       expect(comments[0]).toMatchObject({ line_start: 3, line_end: 5, content: 'looks off' });
+    }, WAIT_OPTS);
+  }, TEST_TIMEOUT);
+
+  it('marks submitted comments read-only in DiffView while leaving drafts editable', async () => {
+    await loadRoundWithDiff({
+      comments: [
+        {
+          id: 'submitted-1',
+          content: 'from a prior round',
+          filepath: 'src/foo.ts',
+          line_start: 2,
+          line_end: 2,
+          side: 'new',
+          author: 'user',
+          created_at: '2026-07-01T00:00:00Z',
+          round_id: 'round-0',
+        },
+      ],
+    });
+
+    await act(async () => {
+      await latestDiffViewProps().onAddComment(3, 5, 'looks off');
+    });
+
+    await waitFor(() => {
+      const props = latestDiffViewProps();
+      const comments = props.comments;
+      expect(comments.some((c) => c.id === 'submitted-1')).toBe(true);
+      expect(comments.some((c) => c.content === 'looks off')).toBe(true);
+
+      const readOnlyIds = props.readOnlyCommentIds;
+      expect(readOnlyIds?.has('submitted-1')).toBe(true);
+      const draftComment = comments.find((c) => c.content === 'looks off');
+      expect(readOnlyIds?.has(draftComment!.id)).toBe(false);
     }, WAIT_OPTS);
   }, TEST_TIMEOUT);
 

--- a/app/src/components/PresentRoot/index.tsx
+++ b/app/src/components/PresentRoot/index.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { useDaemonSocket } from '../../hooks/useDaemonSocket';
-import type { Presentation, PresentationRound, PresentationComment } from '../../types/generated';
+import { DiffView } from '../DiffView';
+import type { Presentation, PresentationRound, PresentationComment, FileObject } from '../../types/generated';
 import { hideBootSplash } from '../../utils/bootSplash';
 import '../../App.css';
 import './PresentRoot.css';
@@ -28,6 +31,19 @@ function applyThemeAttribute(preference: string | undefined) {
 // PresentRoot only cares about presentation/round data and theme settings.
 function noop() {}
 
+interface DiffCacheEntry {
+  loading: boolean;
+  original?: string;
+  modified?: string;
+  error?: string;
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable;
+}
+
 export function PresentRoot() {
   const presentationId = useMemo(
     () => new URLSearchParams(window.location.search).get('presentation'),
@@ -37,9 +53,24 @@ export function PresentRoot() {
   const [presentation, setPresentation] = useState<Presentation | null>(null);
   const [round, setRound] = useState<PresentationRound | null>(null);
   const [comments, setComments] = useState<PresentationComment[]>([]);
+  const [repoHeadSha, setRepoHeadSha] = useState<string | undefined>(undefined);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [daemonSettings, setDaemonSettings] = useState<Record<string, string>>({});
   const [refreshSignal, setRefreshSignal] = useState(0);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [diffState, setDiffState] = useState<DiffCacheEntry | null>(null);
+  const [driftDismissed, setDriftDismissed] = useState(false);
+
+  // Cache of fetched diffs, keyed by `${round.id}:${path}`, valid for the
+  // lifetime of the loaded round. A fresh round (new refreshSignal) gets a
+  // fresh cache automatically because the key includes round.id.
+  const diffCacheRef = useRef<Map<string, DiffCacheEntry>>(new Map());
+  const railRef = useRef<HTMLOListElement>(null);
+  // Kept in sync with selectedPath so the diff-fetch effect below can check
+  // "is this response still for the current selection" without nesting a
+  // setState call inside a setSelectedPath updater (updaters must stay pure).
+  const selectedPathRef = useRef<string | null>(null);
+  selectedPathRef.current = selectedPath;
 
   // Fires once, unconditionally, regardless of load/error state below — the
   // splash must come down even if the presentation id is missing or the
@@ -48,7 +79,7 @@ export function PresentRoot() {
     hideBootSplash();
   }, []);
 
-  const { hasReceivedInitialState, connectionError, getPresentationRound } = useDaemonSocket({
+  const { hasReceivedInitialState, connectionError, getPresentationRound, sendGetFileDiff } = useDaemonSocket({
     onSessionsUpdate: noop,
     onWorkspacesUpdate: noop,
     onPRsUpdate: noop,
@@ -75,12 +106,19 @@ export function PresentRoot() {
 
     let cancelled = false;
     getPresentationRound(presentationId)
-      .then(({ presentation: p, round: r, comments: c }) => {
+      .then(({ presentation: p, round: r, comments: c, repoHeadSha: h }) => {
         if (cancelled) return;
         setPresentation(p);
         setRound(r);
         setComments(c);
+        setRepoHeadSha(h);
         setLoadError(null);
+        setDriftDismissed(false);
+        diffCacheRef.current = new Map();
+        setSelectedPath((current) => {
+          if (current && r.manifest.files.some((f) => f.path === current)) return current;
+          return r.manifest.files[0]?.path ?? null;
+        });
       })
       .catch((err) => {
         if (cancelled) return;
@@ -92,6 +130,87 @@ export function PresentRoot() {
       cancelled = true;
     };
   }, [presentationId, hasReceivedInitialState, getPresentationRound, refreshSignal]);
+
+  // Fetch (or serve from cache) the diff for the selected file, pinned to the
+  // round's base/head SHAs. Guards against a stale response for a
+  // previously-selected file clobbering the currently-selected one.
+  useEffect(() => {
+    if (!presentation || !round || !selectedPath) {
+      setDiffState(null);
+      return;
+    }
+
+    const cacheKey = `${round.id}:${selectedPath}`;
+    const cached = diffCacheRef.current.get(cacheKey);
+    if (cached) {
+      setDiffState(cached);
+      return;
+    }
+
+    const loadingEntry: DiffCacheEntry = { loading: true };
+    diffCacheRef.current.set(cacheKey, loadingEntry);
+    setDiffState(loadingEntry);
+
+    const requestedPath = selectedPath;
+    const requestedRoundId = round.id;
+    sendGetFileDiff(presentation.repo_path, requestedPath, {
+      baseRef: round.base_sha,
+      headRef: round.head_sha,
+    })
+      .then((result) => {
+        const entry: DiffCacheEntry = result.success
+          ? { loading: false, original: result.original, modified: result.modified }
+          : { loading: false, error: result.error || 'Failed to load diff.' };
+        diffCacheRef.current.set(`${requestedRoundId}:${requestedPath}`, entry);
+        if (selectedPathRef.current === requestedPath) {
+          setDiffState(entry);
+        }
+      })
+      .catch((err) => {
+        const entry: DiffCacheEntry = {
+          loading: false,
+          error: err instanceof Error ? err.message : 'Failed to load diff.',
+        };
+        diffCacheRef.current.set(`${requestedRoundId}:${requestedPath}`, entry);
+        if (selectedPathRef.current === requestedPath) {
+          setDiffState(entry);
+        }
+      });
+    // round.id/base_sha/head_sha are stable for the loaded round's lifetime;
+    // presentation.repo_path likewise. sendGetFileDiff is a stable callback.
+  }, [presentation, round, selectedPath, sendGetFileDiff]);
+
+  const files: FileObject[] = round?.manifest.files ?? [];
+
+  const moveSelection = useCallback((delta: number) => {
+    setSelectedPath((current) => {
+      if (files.length === 0) return current;
+      const index = current ? files.findIndex((f) => f.path === current) : -1;
+      const nextIndex = index === -1 ? 0 : Math.max(0, Math.min(files.length - 1, index + delta));
+      return files[nextIndex]?.path ?? current;
+    });
+  }, [files]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (isTypingTarget(e.target)) return;
+      if (e.key === 'j' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        moveSelection(1);
+      } else if (e.key === 'k' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        moveSelection(-1);
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [moveSelection]);
+
+  useEffect(() => {
+    if (!selectedPath || !railRef.current) return;
+    const el = railRef.current.querySelector<HTMLElement>(`[data-path="${CSS.escape(selectedPath)}"]`);
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [selectedPath]);
 
   if (connectionError) {
     return (
@@ -117,6 +236,9 @@ export function PresentRoot() {
     );
   }
 
+  const selectedFile = files.find((f) => f.path === selectedPath) ?? null;
+  const showDrift = !!repoHeadSha && repoHeadSha !== round.head_sha && !driftDismissed;
+
   return (
     <div className="present-root">
       <header className="present-root-header">
@@ -137,18 +259,28 @@ export function PresentRoot() {
         </span>
       </section>
 
-      {round.manifest.summary && (
-        <p className="present-root-summary">{round.manifest.summary}</p>
+      {showDrift && (
+        <div className="present-root-drift" role="status">
+          <span>
+            The repo has moved on since this round was pinned ({shortSha(round.head_sha)} → {shortSha(repoHeadSha!)}).
+            Diffs below still show the pinned commits.
+          </span>
+          <button
+            type="button"
+            className="present-root-drift-dismiss"
+            aria-label="Dismiss"
+            onClick={() => setDriftDismissed(true)}
+          >
+            ×
+          </button>
+        </div>
       )}
 
-      <ol className="present-root-files">
-        {round.manifest.files.map((file) => (
-          <li key={file.path} className="present-root-file">
-            <code>{file.path}</code>
-            {file.note && <p className="present-root-file-note">{file.note}</p>}
-          </li>
-        ))}
-      </ol>
+      {round.manifest.summary && (
+        <div className="present-root-summary">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{round.manifest.summary}</ReactMarkdown>
+        </div>
+      )}
 
       {comments.length > 0 && (
         <p className="present-root-comment-count">
@@ -156,7 +288,74 @@ export function PresentRoot() {
         </p>
       )}
 
-      <footer className="present-root-footer">Reader coming soon.</footer>
+      <div className="present-root-body">
+        <ol className="present-root-files" ref={railRef}>
+          {files.map((file, index) => (
+            <li
+              key={file.path}
+              data-path={file.path}
+              className={`present-root-file ${file.path === selectedPath ? 'selected' : ''}`}
+              onClick={() => setSelectedPath(file.path)}
+            >
+              <span className="present-root-file-index">{index + 1}</span>
+              <code className="present-root-file-path">{file.path}</code>
+              {file.note && <span className="present-root-file-note-marker" title="Has a note">●</span>}
+            </li>
+          ))}
+
+          {round.manifest.skip.length > 0 && (
+            <>
+              <li className="present-root-skip-divider">Skipped</li>
+              {round.manifest.skip.map((path) => (
+                <li key={path} className="present-root-file present-root-file-skipped">
+                  <code className="present-root-file-path">{path}</code>
+                </li>
+              ))}
+            </>
+          )}
+        </ol>
+
+        <main className="present-root-diff-pane">
+          {!selectedFile ? (
+            <div className="present-root-diff-placeholder">No files in this round.</div>
+          ) : (
+            <>
+              {selectedFile.note && (
+                <div className="present-root-file-note-banner">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{selectedFile.note}</ReactMarkdown>
+                </div>
+              )}
+
+              {diffState?.loading && (
+                <div className="present-root-diff-placeholder">Loading diff…</div>
+              )}
+
+              {diffState?.error && (
+                <div className="present-root-diff-error">{diffState.error}</div>
+              )}
+
+              {!diffState?.loading && !diffState?.error && diffState?.original !== undefined && diffState?.modified !== undefined && (
+                // comments wired in the next chunk
+                <DiffView
+                  original={diffState.original}
+                  modified={diffState.modified}
+                  filePath={selectedFile.path}
+                  comments={[]}
+                  editingCommentId={null}
+                  diffStyle="unified"
+                  expandUnchanged={false}
+                  onAddComment={noop}
+                  onEditComment={noop}
+                  onStartEdit={noop}
+                  onCancelEdit={noop}
+                  onResolveComment={noop}
+                  onDeleteComment={noop}
+                />
+              )}
+            </>
+          )}
+        </main>
+      </div>
     </div>
   );
 }

--- a/app/src/components/PresentRoot/index.tsx
+++ b/app/src/components/PresentRoot/index.tsx
@@ -385,6 +385,12 @@ export function PresentRoot() {
         ...drafts.filter((d) => d.filepath === selectedFile.path).map(draftToReviewComment),
       ]
     : [];
+  // Submitted comments (author is the round's owner or agent, not a local
+  // draft) render read-only in the reader — only the user's own in-progress
+  // drafts are editable/resolvable/deletable here.
+  const readOnlyCommentIds = new Set(
+    selectedFileComments.filter((c) => !draftIds.has(c.id)).map((c) => c.id)
+  );
 
   return (
     <div className="present-root">
@@ -527,6 +533,7 @@ export function PresentRoot() {
                   filePath={selectedFile.path}
                   comments={selectedFileComments}
                   editingCommentId={editingCommentId}
+                  readOnlyCommentIds={readOnlyCommentIds}
                   diffStyle="unified"
                   expandUnchanged={false}
                   onAddComment={handleAddComment}

--- a/app/src/components/PresentRoot/index.tsx
+++ b/app/src/components/PresentRoot/index.tsx
@@ -3,7 +3,14 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useDaemonSocket } from '../../hooks/useDaemonSocket';
 import { DiffView } from '../DiffView';
-import type { Presentation, PresentationRound, PresentationComment, FileObject } from '../../types/generated';
+import type {
+  Presentation,
+  PresentationRound,
+  PresentationComment,
+  FileObject,
+  ReviewComment,
+  PresentCommentInput,
+} from '../../types/generated';
 import { hideBootSplash } from '../../utils/bootSplash';
 import '../../App.css';
 import './PresentRoot.css';
@@ -44,6 +51,66 @@ function isTypingTarget(target: EventTarget | null): boolean {
   return tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable;
 }
 
+// A locally-held, not-yet-submitted comment. line_start/line_end are always
+// positive here (unlike ReviewComment's signed line_end); `side` carries the
+// old/new distinction explicitly, matching the wire shape so submission is a
+// direct field copy.
+interface Draft {
+  id: string;
+  filepath: string;
+  line_start: number;
+  line_end: number;
+  side: 'new' | 'old';
+  content: string;
+}
+
+// Protocol convention (see app/src/utils/reviewComment.ts and DiffView.tsx):
+// a comment anchors at line_start; a NEGATIVE line_end encodes the
+// original/deleted side, with abs(line_end) giving the actual end line.
+function draftToReviewComment(draft: Draft): ReviewComment {
+  return {
+    id: draft.id,
+    content: draft.content,
+    filepath: draft.filepath,
+    line_start: draft.line_start,
+    line_end: draft.side === 'old' ? -draft.line_end : draft.line_end,
+    author: 'user',
+    resolved: false,
+    created_at: '',
+    review_id: '',
+  };
+}
+
+// Inverse of the sign convention above, applied to DiffView's onAddComment
+// callback args (which already arrive pre-encoded the same way).
+function draftFromAddComment(filepath: string, lineStart: number, lineEnd: number, content: string, id: string): Draft {
+  return {
+    id,
+    filepath,
+    line_start: lineStart,
+    line_end: Math.abs(lineEnd),
+    side: lineEnd < 0 ? 'old' : 'new',
+    content,
+  };
+}
+
+// PresentationComment (already-submitted, wire shape) uses an explicit
+// side string with positive line_end rather than DiffView's signed
+// convention, so it needs its own mapper into ReviewComment.
+function submittedToReviewComment(comment: PresentationComment): ReviewComment {
+  return {
+    id: comment.id,
+    content: comment.content,
+    filepath: comment.filepath,
+    line_start: comment.line_start,
+    line_end: comment.side === 'old' ? -comment.line_end : comment.line_end,
+    author: comment.author,
+    resolved: false,
+    created_at: comment.created_at,
+    review_id: comment.round_id,
+  };
+}
+
 export function PresentRoot() {
   const presentationId = useMemo(
     () => new URLSearchParams(window.location.search).get('presentation'),
@@ -60,6 +127,13 @@ export function PresentRoot() {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [diffState, setDiffState] = useState<DiffCacheEntry | null>(null);
   const [driftDismissed, setDriftDismissed] = useState(false);
+  const [drafts, setDrafts] = useState<Draft[]>([]);
+  const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
+  const [showSubmitDialog, setShowSubmitDialog] = useState(false);
+  const [handback, setHandback] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const draftIdCounterRef = useRef(0);
 
   // Cache of fetched diffs, keyed by `${round.id}:${path}`, valid for the
   // lifetime of the loaded round. A fresh round (new refreshSignal) gets a
@@ -79,7 +153,13 @@ export function PresentRoot() {
     hideBootSplash();
   }, []);
 
-  const { hasReceivedInitialState, connectionError, getPresentationRound, sendGetFileDiff } = useDaemonSocket({
+  const {
+    hasReceivedInitialState,
+    connectionError,
+    getPresentationRound,
+    sendGetFileDiff,
+    submitPresentationRound,
+  } = useDaemonSocket({
     onSessionsUpdate: noop,
     onWorkspacesUpdate: noop,
     onPRsUpdate: noop,
@@ -212,6 +292,67 @@ export function PresentRoot() {
     el?.scrollIntoView({ block: 'nearest' });
   }, [selectedPath]);
 
+  // An in-progress edit is scoped to whichever file's diff is showing it;
+  // switching files should not leave a stale editingCommentId pointing at a
+  // comment that's no longer rendered.
+  useEffect(() => {
+    setEditingCommentId(null);
+  }, [selectedPath]);
+
+  const draftIds = useMemo(() => new Set(drafts.map((d) => d.id)), [drafts]);
+
+  const handleAddComment = useCallback((lineStart: number, lineEnd: number, content: string) => {
+    if (!selectedPath) return;
+    const id = `draft-${draftIdCounterRef.current++}`;
+    setDrafts((prev) => [...prev, draftFromAddComment(selectedPath, lineStart, lineEnd, content, id)]);
+  }, [selectedPath]);
+
+  const handleStartEdit = useCallback((id: string) => {
+    if (draftIds.has(id)) setEditingCommentId(id);
+  }, [draftIds]);
+
+  const handleEditComment = useCallback((id: string, content: string) => {
+    if (!draftIds.has(id)) return;
+    setDrafts((prev) => prev.map((d) => (d.id === id ? { ...d, content } : d)));
+    setEditingCommentId(null);
+  }, [draftIds]);
+
+  const handleCancelEdit = useCallback(() => {
+    setEditingCommentId(null);
+  }, []);
+
+  const handleDeleteComment = useCallback((id: string) => {
+    if (!draftIds.has(id)) return;
+    setDrafts((prev) => prev.filter((d) => d.id !== id));
+  }, [draftIds]);
+
+  // Drafts have no resolved state in this chunk, and submitted comments are
+  // read-only here, so resolving is a no-op either way.
+  const handleResolveComment = useCallback(() => {}, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (!round) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const comments: PresentCommentInput[] = drafts.map((d) => ({
+        filepath: d.filepath,
+        line_start: d.line_start,
+        line_end: d.line_end,
+        side: d.side,
+        content: d.content,
+      }));
+      await submitPresentationRound({ roundId: round.id, comments, handback });
+      setDrafts([]);
+      setShowSubmitDialog(false);
+      setRefreshSignal((n) => n + 1);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Failed to submit review.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [round, drafts, handback, submitPresentationRound]);
+
   if (connectionError) {
     return (
       <div className="present-root present-root-message">
@@ -238,6 +379,12 @@ export function PresentRoot() {
 
   const selectedFile = files.find((f) => f.path === selectedPath) ?? null;
   const showDrift = !!repoHeadSha && repoHeadSha !== round.head_sha && !driftDismissed;
+  const selectedFileComments: ReviewComment[] = selectedFile
+    ? [
+        ...comments.filter((c) => c.filepath === selectedFile.path).map(submittedToReviewComment),
+        ...drafts.filter((d) => d.filepath === selectedFile.path).map(draftToReviewComment),
+      ]
+    : [];
 
   return (
     <div className="present-root">
@@ -257,7 +404,46 @@ export function PresentRoot() {
         <span className={`present-root-status ${round.submitted_at ? 'submitted' : 'draft'}`}>
           {round.submitted_at ? 'Submitted' : 'Draft'}
         </span>
+        <button
+          type="button"
+          className="present-root-submit-button"
+          onClick={() => {
+            setSubmitError(null);
+            setShowSubmitDialog(true);
+          }}
+          disabled={submitting}
+        >
+          {drafts.length > 0 ? `Submit review (${drafts.length})` : 'Submit review'}
+        </button>
       </section>
+
+      {showSubmitDialog && (
+        <div className="present-root-submit-overlay" role="dialog" aria-modal="true" aria-label="Submit review">
+          <div className="present-root-submit-dialog">
+            <h2>Submit review</h2>
+            <p>
+              {drafts.length} comment{drafts.length === 1 ? '' : 's'}
+            </p>
+            <label className="present-root-submit-handback">
+              <input
+                type="checkbox"
+                checked={handback}
+                onChange={(e) => setHandback(e.target.checked)}
+              />
+              Hand back to agent
+            </label>
+            {submitError && <div className="present-root-submit-error">{submitError}</div>}
+            <div className="present-root-submit-actions">
+              <button type="button" onClick={() => setShowSubmitDialog(false)} disabled={submitting}>
+                Cancel
+              </button>
+              <button type="button" onClick={handleSubmit} disabled={submitting}>
+                {submitting ? 'Submitting…' : 'Submit'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {showDrift && (
         <div className="present-root-drift" role="status">
@@ -335,21 +521,20 @@ export function PresentRoot() {
               )}
 
               {!diffState?.loading && !diffState?.error && diffState?.original !== undefined && diffState?.modified !== undefined && (
-                // comments wired in the next chunk
                 <DiffView
                   original={diffState.original}
                   modified={diffState.modified}
                   filePath={selectedFile.path}
-                  comments={[]}
-                  editingCommentId={null}
+                  comments={selectedFileComments}
+                  editingCommentId={editingCommentId}
                   diffStyle="unified"
                   expandUnchanged={false}
-                  onAddComment={noop}
-                  onEditComment={noop}
-                  onStartEdit={noop}
-                  onCancelEdit={noop}
-                  onResolveComment={noop}
-                  onDeleteComment={noop}
+                  onAddComment={handleAddComment}
+                  onEditComment={handleEditComment}
+                  onStartEdit={handleStartEdit}
+                  onCancelEdit={handleCancelEdit}
+                  onResolveComment={handleResolveComment}
+                  onDeleteComment={handleDeleteComment}
                 />
               )}
             </>

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -24,6 +24,7 @@ import type {
   Presentation,
   PresentationRound,
   PresentationComment,
+  PresentCommentInput,
   PRRole,
   HeatState,
 } from '../types/generated';
@@ -169,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '144';
+export const PROTOCOL_VERSION = '145';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -2322,9 +2323,27 @@ export function useDaemonSocket({
             if (pending) {
               pendingActionsRef.current.delete('get_presentation_round');
               if (data.success) {
-                pending.resolve({ presentation: data.presentation, round: data.round, comments: data.comments || [] });
+                pending.resolve({
+                  presentation: data.presentation,
+                  round: data.round,
+                  comments: data.comments || [],
+                  repoHeadSha: data.repo_head_sha,
+                });
               } else {
                 pending.reject(new Error(data.error || 'Failed to load presentation round'));
+              }
+            }
+            break;
+          }
+
+          case 'present_submit_round_result': {
+            const pending = pendingActionsRef.current.get('present_submit_round');
+            if (pending) {
+              pendingActionsRef.current.delete('present_submit_round');
+              if (data.success) {
+                pending.resolve({ roundId: data.round_id });
+              } else {
+                pending.reject(new Error(data.error || 'Failed to submit presentation round'));
               }
             }
             break;
@@ -4591,11 +4610,13 @@ export function useDaemonSocket({
   }, []);
 
   // Get file diff
-  // Options: staged (deprecated), baseRef (for PR-like branch diffs)
+  // Options: staged (deprecated), baseRef (for PR-like branch diffs), headRef
+  // (pins the modified side to a commit instead of the working tree — used by
+  // the presentation reader for base_sha->head_sha diffs)
   const sendGetFileDiff = useCallback((
     directory: string,
     path: string,
-    options?: { staged?: boolean; baseRef?: string }
+    options?: { staged?: boolean; baseRef?: string; headRef?: string }
   ): Promise<FileDiffResult> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
@@ -4614,6 +4635,7 @@ export function useDaemonSocket({
         path,
         ...(options?.staged !== undefined && { staged: options.staged }),
         ...(options?.baseRef && { base_ref: options.baseRef }),
+        ...(options?.headRef && { head_ref: options.headRef }),
       }));
 
       setTimeout(() => {
@@ -4950,7 +4972,7 @@ export function useDaemonSocket({
   const getPresentationRound = useCallback((
     presentationId: string,
     seq?: number,
-  ): Promise<{ presentation: Presentation; round: PresentationRound; comments: PresentationComment[] }> => {
+  ): Promise<{ presentation: Presentation; round: PresentationRound; comments: PresentationComment[]; repoHeadSha?: string }> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -4971,6 +4993,38 @@ export function useDaemonSocket({
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
           reject(new Error('Get presentation round timed out'));
+        }
+      }, 30000);
+    });
+  }, []);
+
+  // Hand a round's review back to the authoring agent (presentation reader).
+  const submitPresentationRound = useCallback((input: {
+    roundId: string;
+    comments: PresentCommentInput[];
+    handback: boolean;
+  }): Promise<{ roundId: string }> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+
+      const key = 'present_submit_round';
+      pendingActionsRef.current.set(key, { resolve, reject });
+
+      ws.send(JSON.stringify({
+        cmd: 'present_submit_round',
+        round_id: input.roundId,
+        comments: input.comments,
+        handback: input.handback,
+      }));
+
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Submit presentation round timed out'));
         }
       }, 30000);
     });
@@ -5087,5 +5141,6 @@ export function useDaemonSocket({
     sendGetComments,
     getPresentations,
     getPresentationRound,
+    submitPresentationRound,
   };
 }

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1368,6 +1368,7 @@ export interface GetFileDiffMessage {
     base_ref?: string;
     cmd:       GetFileDiffMessageCmd;
     directory: string;
+    head_ref?: string;
     path:      string;
     staged?:   boolean;
     [property: string]: any;
@@ -1389,12 +1390,13 @@ export enum GetPresentationRoundMessageCmd {
 }
 
 export interface GetPresentationRoundResultMessage {
-    comments?:     CommentElement[];
-    error?:        string;
-    event:         GetPresentationRoundResultMessageEvent;
-    presentation?: PresentationElement;
-    round?:        Round;
-    success:       boolean;
+    comments?:      CommentElement[];
+    error?:         string;
+    event:          GetPresentationRoundResultMessageEvent;
+    presentation?:  PresentationElement;
+    repo_head_sha?: string;
+    round?:         Round;
+    success:        boolean;
     [property: string]: any;
 }
 
@@ -7987,6 +7989,7 @@ const typeMap: any = {
         { json: "base_ref", js: "base_ref", typ: u(undefined, "") },
         { json: "cmd", js: "cmd", typ: r("GetFileDiffMessageCmd") },
         { json: "directory", js: "directory", typ: "" },
+        { json: "head_ref", js: "head_ref", typ: u(undefined, "") },
         { json: "path", js: "path", typ: "" },
         { json: "staged", js: "staged", typ: u(undefined, true) },
     ], "any"),
@@ -8000,6 +8003,7 @@ const typeMap: any = {
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("GetPresentationRoundResultMessageEvent") },
         { json: "presentation", js: "presentation", typ: u(undefined, r("PresentationElement")) },
+        { json: "repo_head_sha", js: "repo_head_sha", typ: u(undefined, "") },
         { json: "round", js: "round", typ: u(undefined, r("Round")) },
         { json: "success", js: "success", typ: true },
     ], "any"),

--- a/internal/daemon/git_coordinator.go
+++ b/internal/daemon/git_coordinator.go
@@ -61,6 +61,7 @@ type fileDiffCacheKey struct {
 	directory string
 	path      string
 	baseRef   string
+	headRef   string
 	staged    bool
 }
 
@@ -218,8 +219,8 @@ func (c *gitCoordinator) finishBranchDiffRefresh(key branchDiffCacheKey, refresh
 	close(refresh.done)
 }
 
-func (c *gitCoordinator) FileDiff(directory, path, baseRef string, staged bool) (fileDiffContent, error) {
-	key := fileDiffCacheKey{directory: directory, path: path, baseRef: baseRef, staged: staged}
+func (c *gitCoordinator) FileDiff(directory, path, baseRef, headRef string, staged bool) (fileDiffContent, error) {
+	key := fileDiffCacheKey{directory: directory, path: path, baseRef: baseRef, headRef: headRef, staged: staged}
 
 	c.mu.Lock()
 	if refresh, ok := c.fileDiffActive[key]; ok {
@@ -233,7 +234,7 @@ func (c *gitCoordinator) FileDiff(directory, path, baseRef string, staged bool) 
 	c.fileDiffActive[key] = refresh
 	c.mu.Unlock()
 
-	refresh.content, refresh.err = readFileDiffForDaemon(directory, path, baseRef, staged)
+	refresh.content, refresh.err = readFileDiffForDaemon(directory, path, baseRef, headRef, staged)
 
 	c.mu.Lock()
 	if c.fileDiffActive[key] == refresh {
@@ -245,12 +246,24 @@ func (c *gitCoordinator) FileDiff(directory, path, baseRef string, staged bool) 
 	return refresh.content, refresh.err
 }
 
-func readFileDiff(directory, path, baseRef string, staged bool) (fileDiffContent, error) {
+func readFileDiff(directory, path, baseRef, headRef string, staged bool) (fileDiffContent, error) {
 	content := fileDiffContent{}
 
 	origOutput, origErr := attngit.Output(attngit.OpDiff, directory, "show", baseRef+":"+path)
 	if origErr == nil {
 		content.original = string(origOutput)
+	}
+
+	// When head_ref is set (presentation reader diffs), the modified side is
+	// pinned to that ref instead of the working tree, and staged is ignored.
+	if headRef != "" {
+		headOutput, err := attngit.Output(attngit.OpDiff, directory, "show", headRef+":"+path)
+		if err != nil {
+			content.modified = ""
+			return content, nil
+		}
+		content.modified = string(headOutput)
+		return content, nil
 	}
 
 	if staged {

--- a/internal/daemon/gitstatus_test.go
+++ b/internal/daemon/gitstatus_test.go
@@ -3,6 +3,10 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -10,6 +14,86 @@ import (
 	attngit "github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/protocol"
 )
+
+// fileDiffTestRepo creates a real git repo with two commits touching path:
+// the first commit does not create path at all, the second adds it with
+// content v1, and a third commit updates it to v2 — so tests can pin a
+// base_ref/head_ref pair and a ref where the file doesn't exist yet.
+func fileDiffTestRepo(t *testing.T, path, v1, v2 string) (dir, shaEmpty, shaV1, shaV2 string) {
+	t.Helper()
+	dir = t.TempDir()
+	run := func(args ...string) string {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	run("init")
+	run("commit", "--allow-empty", "-m", "init")
+	shaEmpty = run("rev-parse", "HEAD")
+
+	fullPath := filepath.Join(dir, path)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(fullPath, []byte(v1), 0o644); err != nil {
+		t.Fatalf("write v1: %v", err)
+	}
+	run("add", path)
+	run("commit", "-m", "add "+path)
+	shaV1 = run("rev-parse", "HEAD")
+
+	if err := os.WriteFile(fullPath, []byte(v2), 0o644); err != nil {
+		t.Fatalf("write v2: %v", err)
+	}
+	run("add", path)
+	run("commit", "-m", "update "+path)
+	shaV2 = run("rev-parse", "HEAD")
+
+	return dir, shaEmpty, shaV1, shaV2
+}
+
+func TestReadFileDiff_PinnedHeadRefIgnoresWorkingTree(t *testing.T) {
+	dir, _, shaV1, shaV2 := fileDiffTestRepo(t, "src/file.ts", "v1", "v2")
+
+	// Dirty the working tree; a pinned head_ref diff must ignore this.
+	if err := os.WriteFile(filepath.Join(dir, "src/file.ts"), []byte("dirty"), 0o644); err != nil {
+		t.Fatalf("dirty working tree: %v", err)
+	}
+
+	content, err := readFileDiff(dir, "src/file.ts", shaV1, shaV2, false)
+	if err != nil {
+		t.Fatalf("readFileDiff: %v", err)
+	}
+	if content.original != "v1" {
+		t.Errorf("original = %q, want %q", content.original, "v1")
+	}
+	if content.modified != "v2" {
+		t.Errorf("modified = %q, want %q (working tree should be ignored)", content.modified, "v2")
+	}
+}
+
+func TestReadFileDiff_HeadRefFileDoesNotExist(t *testing.T) {
+	dir, shaEmpty, _, _ := fileDiffTestRepo(t, "src/file.ts", "v1", "v2")
+
+	content, err := readFileDiff(dir, "src/file.ts", shaEmpty, shaEmpty, false)
+	if err != nil {
+		t.Fatalf("readFileDiff: %v", err)
+	}
+	if content.original != "" {
+		t.Errorf("original = %q, want empty (file absent at base_ref)", content.original)
+	}
+	if content.modified != "" {
+		t.Errorf("modified = %q, want empty (file absent at head_ref)", content.modified)
+	}
+}
 
 func TestParseGitStatusPorcelain(t *testing.T) {
 	// Porcelain v1 format: XY PATH or XY ORIG -> PATH for renames
@@ -500,7 +584,7 @@ func TestGitCoordinatorSharesInFlightFileDiff(t *testing.T) {
 	var calls atomic.Int32
 	started := make(chan struct{})
 	release := make(chan struct{})
-	readFileDiffForDaemon = func(_, _, _ string, _ bool) (fileDiffContent, error) {
+	readFileDiffForDaemon = func(_, _, _, _ string, _ bool) (fileDiffContent, error) {
 		call := calls.Add(1)
 		if call == 1 {
 			close(started)
@@ -516,7 +600,7 @@ func TestGitCoordinatorSharesInFlightFileDiff(t *testing.T) {
 	results := make(chan fileDiffContent, 2)
 	for i := 0; i < 2; i++ {
 		go func() {
-			content, err := d.coordinator().FileDiff("/repo", "src/file.ts", "HEAD", false)
+			content, err := d.coordinator().FileDiff("/repo", "src/file.ts", "HEAD", "", false)
 			if err != nil {
 				t.Errorf("FileDiff failed: %v", err)
 			}

--- a/internal/daemon/present.go
+++ b/internal/daemon/present.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	attngit "github.com/victorarias/attn/internal/git"
 	"github.com/victorarias/attn/internal/present"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
@@ -319,6 +320,14 @@ func (d *Daemon) handleGetPresentationRound(client *wsClient, msg *protocol.GetP
 	for i, c := range comments {
 		result.Comments[i] = commentToProto(c)
 	}
+
+	// Best-effort drift signal: the repo may have moved on since the round
+	// was pinned. A rev-parse failure (repo gone, etc.) is non-fatal — just
+	// omit the field.
+	if headSHA, err := attngit.Output(attngit.OpMetadata, pres.RepoPath, "rev-parse", "HEAD"); err == nil {
+		result.RepoHeadSHA = protocol.Ptr(strings.TrimSpace(string(headSHA)))
+	}
+
 	result.Success = true
 	d.sendToClient(client, result)
 }

--- a/internal/daemon/present_test.go
+++ b/internal/daemon/present_test.go
@@ -242,3 +242,31 @@ func TestHandlePresentSubmitRound_DoubleSubmitRejected(t *testing.T) {
 		t.Fatalf("second submit of an already-submitted round returned success: %+v", second)
 	}
 }
+
+func TestHandleGetPresentationRound_CarriesRepoHeadSHA(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	repoDir, headSHA := presentTestRepo(t)
+
+	opened := callPresentOpen(t, d, &protocol.PresentOpenMessage{
+		Cmd:             protocol.CmdPresentOpen,
+		SourceSessionID: "session-1",
+		ManifestYaml:    presentManifestYAML("My Change", repoDir),
+	})
+	if !opened.Ok || opened.PresentOpenResult == nil {
+		t.Fatalf("setup present open response = %+v, want ok", opened)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleGetPresentationRound(client, &protocol.GetPresentationRoundMessage{
+		Cmd:            protocol.CmdGetPresentationRound,
+		PresentationID: opened.PresentOpenResult.PresentationID,
+	})
+	var res protocol.GetPresentationRoundResultMessage
+	readTicketResult(t, client.send, &res)
+	if !res.Success {
+		t.Fatalf("get_presentation_round = %+v, want success", res)
+	}
+	if res.RepoHeadSHA == nil || *res.RepoHeadSHA != headSHA {
+		t.Errorf("repo_head_sha = %v, want %q", res.RepoHeadSHA, headSHA)
+	}
+}

--- a/internal/daemon/ws_git.go
+++ b/internal/daemon/ws_git.go
@@ -190,8 +190,13 @@ func (d *Daemon) handleGetFileDiff(client *wsClient, msg *protocol.GetFileDiffMe
 		baseRef = *msg.BaseRef
 	}
 
+	headRef := ""
+	if msg.HeadRef != nil {
+		headRef = *msg.HeadRef
+	}
+
 	staged := msg.Staged != nil && *msg.Staged
-	content, err := d.coordinator().FileDiff(msg.Directory, msg.Path, baseRef, staged)
+	content, err := d.coordinator().FileDiff(msg.Directory, msg.Path, baseRef, headRef, staged)
 	if err != nil {
 		result.Error = protocol.Ptr("Failed to read file diff: " + err.Error())
 		d.sendToClient(client, result)

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "144"
+const ProtocolVersion = "145"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1099,6 +1099,9 @@ type GetFileDiffMessage struct {
 	// Directory corresponds to the JSON schema field "directory".
 	Directory string `json:"directory"`
 
+	// HeadRef corresponds to the JSON schema field "head_ref".
+	HeadRef *string `json:"head_ref,omitempty,omitzero"`
+
 	// Path corresponds to the JSON schema field "path".
 	Path string `json:"path"`
 
@@ -1129,6 +1132,9 @@ type GetPresentationRoundResultMessage struct {
 
 	// Presentation corresponds to the JSON schema field "presentation".
 	Presentation *Presentation `json:"presentation,omitempty,omitzero"`
+
+	// RepoHeadSHA corresponds to the JSON schema field "repo_head_sha".
+	RepoHeadSHA *string `json:"repo_head_sha,omitempty,omitzero"`
 
 	// Round corresponds to the JSON schema field "round".
 	Round *PresentationRound `json:"round,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1273,6 +1273,7 @@ model GetFileDiffMessage {
   path: string;
   staged?: boolean;  // DEPRECATED: If true, show staged diff instead of working tree
   base_ref?: string; // If provided, compare against this ref instead of HEAD (for PR-like diffs)
+  head_ref?: string; // If set, the modified side is pinned to `git show <head_ref>:<path>` instead of the working tree (used by the presentation reader for base_sha->head_sha diffs)
 }
 
 // Branch diff file info for PR-like review
@@ -1826,6 +1827,7 @@ model GetPresentationRoundResultMessage {
   presentation?: Presentation;
   round?: PresentationRound;
   comments?: PresentationComment[];
+  repo_head_sha?: string; // Current `git rev-parse HEAD` of the presentation's repo_path at query time, for drift detection; omitted if the rev-parse fails (e.g. repo gone)
 }
 
 // PresentCommentInput is a reviewer comment as submitted from the app, before


### PR DESCRIPTION
PR 3 of the Present spine (plan: docs/plans/2026-07-04-present-spine.md, vision: docs/vision/present.md). Builds on #465 (Go spine) and #466 (window shell + chip + harness tooling).

## What this delivers

The present window is now a working level-0/1 change reader:

- **Ordered file rail** from the round manifest, with per-file note markers, skip section, and j/k + arrow keyboard navigation.
- **Pinned-SHA diffs** through the shared DiffView — `get_file_diff` gained an optional head ref so diffs render the round's pinned commits, not the moving worktree.
- **Markdown summary and per-file notes** (react-markdown + GFM).
- **Drift banner** when the repo head moves past the round's pinned head; diffs stay pinned, banner is dismissable.
- **Inline comment drafts** on diff lines (both sides, using the signed line_end convention adapted to an explicit `side` on the wire), edit/delete for drafts, drafts survive file switches.
- **Submit review dialog** with handback toggle → `present_submit_round`; success clears drafts and refetches; the round header flips to Submitted.
- **Submitted comments render read-only** — new opt-in `readOnlyCommentIds` prop on DiffView/DiffCommentThread hides Edit/Resolve/Delete per comment; default preserves main-window behavior exactly.
- **Fix: blank diff pane on cold-created window.** A present window created hidden and shown without focus (e.g. display asleep/occluded) left WKWebView's rAF clock parked forever — the Virtualizer never painted. The window now takes focus on its page-load show (mirrors the reuse path; correct UX for an explicit chip click anyway).
- (An fs-capability grant for debug instrumentation was initially included, then dropped after review: `present_capability_has_a_minimal_permission_surface` deliberately keeps this window's permission surface minimal, and the instrumentation pattern is temporary-by-definition. The debugging recipe is a local, uncommitted capability edit while instrumenting.)

## Verification

- Unit: 134 files / 1291 tests green (19 PresentRoot tests incl. wire-shape round-trips for the signed-side adapters; 3 new DiffCommentThread tests); `tsc --noEmit` clean; `go build ./...` + store/daemon present tests green.
- Live (dev profile, packaged app): cold-boot repro of the blank-diff bug before/after fix (instrumented rAF layout probes: absent pre-fix, fire post-fix after display wake); j/k navigation; note banner; drift banner with correct SHAs after a new head commit; `present_submit_round` over the real daemon socket with a comment on the old/new side, round `submitted_at` + comment persisted, and the open window live-updating to Submitted with the comment anchored inline and rendered read-only.

## Follow-ups (deliberate)

- "Submit review" stays enabled on an already-submitted round (daemon rejects re-submit); agents open new rounds so this state is transient — will pick up with PR 4 polish if worth it.
- PR 4: packaged-app scenario for the full present flow + CHANGELOG entry.
