### PR TITLE
test(present): packaged-app scenario for the full present loop

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -52,6 +52,7 @@
     "real-app:scenario-notebook-tile-finder": "node scripts/real-app-harness/scenario-notebook-tile-finder.mjs",
     "real-app:scenario-notebook-tile-close": "node scripts/real-app-harness/scenario-notebook-tile-close.mjs",
     "real-app:scenario-autoclose-on-exit": "node scripts/real-app-harness/scenario-autoclose-on-exit.mjs",
+    "real-app:scenario-present-flow": "node scripts/real-app-harness/scenario-present-flow.mjs",
     "real-app:scenario-ticket-lifecycle": "node scripts/real-app-harness/scenario-ticket-delegation-lifecycle.mjs",
     "real-app:scenario-ticket-resume": "node scripts/real-app-harness/scenario-ticket-resume.mjs",
     "real-app:scenario-nudge-trigger": "node scripts/real-app-harness/scenario-nudge-trigger.mjs",

--- a/app/scripts/real-app-harness/InputDriver.swift
+++ b/app/scripts/real-app-harness/InputDriver.swift
@@ -51,7 +51,7 @@ func parseOptions() throws -> Options {
     while index < args.count {
         let arg = args[index]
         switch arg {
-        case "activate", "activate_background", "frontmost", "windowid", "text", "key", "keycode", "click", "right_click", "menu", "window_park", "scroll":
+        case "activate", "activate_background", "frontmost", "windowid", "windowlist", "text", "key", "keycode", "click", "right_click", "menu", "window_park", "scroll":
             options.command = arg
         case "--window-title":
             index += 1
@@ -146,6 +146,7 @@ func parseOptions() throws -> Options {
               InputDriver.swift activate_background [--bundle-id ...]
               InputDriver.swift frontmost
               InputDriver.swift windowid [--bundle-id ...] [--window-title <substring>]
+              InputDriver.swift windowlist [--bundle-id ...]
               InputDriver.swift text --text "hello" [--bundle-id ...] [--prompt-accessibility]
               InputDriver.swift key --key d [--modifiers command,option]
               InputDriver.swift keycode --key-code 36 [--modifiers command]
@@ -175,7 +176,7 @@ func parseOptions() throws -> Options {
     }
 
     guard options.command != nil else {
-        throw DriverError.usage("Missing command. Use activate, activate_background, frontmost, windowid, text, key, keycode, click, or menu.")
+        throw DriverError.usage("Missing command. Use activate, activate_background, frontmost, windowid, windowlist, text, key, keycode, click, or menu.")
     }
 
     return options
@@ -354,6 +355,43 @@ func mainWindowBounds(bundleId: String, titleSubstring: String? = nil) throws ->
 // instead.
 func mainWindowID(bundleId: String, titleSubstring: String? = nil) throws -> CGWindowID {
     try resolveWindow(bundleId: bundleId, titleSubstring: titleSubstring).0
+}
+
+// Enumerate every onscreen window owned by the bundle (not just the largest
+// layer-0 one, unlike mainWindowID). Used by callers that need to find a
+// specific window by title, such as attn's second "present" window.
+//
+// kCGWindowName is only populated when this process has Screen Recording
+// permission; without it the name is empty for every window. That is
+// acceptable here — callers tolerate empty names and fall back to matching by
+// other means (e.g. layer/size).
+func listWindows(bundleId: String) throws -> [[String: Any]] {
+    let pid = try runningPID(bundleId: bundleId)
+    let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+    guard let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+        throw DriverError.eventCreationFailed("Failed to read window list.")
+    }
+
+    return windows
+        .filter { (($0[kCGWindowOwnerPID as String] as? pid_t) ?? -1) == pid }
+        .compactMap { entry -> [String: Any]? in
+            guard let number = entry[kCGWindowNumber as String] as? CGWindowID else {
+                return nil
+            }
+            let name = (entry[kCGWindowName as String] as? String) ?? ""
+            let rect: CGRect = (entry[kCGWindowBounds as String] as? NSDictionary)
+                .flatMap { CGRect(dictionaryRepresentation: $0) } ?? .zero
+            let layer = (entry[kCGWindowLayer as String] as? Int) ?? 0
+            return [
+                "id": Int(number),
+                "name": name,
+                "x": Double(rect.origin.x),
+                "y": Double(rect.origin.y),
+                "width": Double(rect.width),
+                "height": Double(rect.height),
+                "layer": layer,
+            ]
+        }
 }
 
 func modifierFlags(_ modifiers: [String]) -> CGEventFlags {
@@ -730,6 +768,10 @@ do {
     case "windowid":
         let wid = try mainWindowID(bundleId: options.bundleId, titleSubstring: options.windowTitle)
         print(wid)
+    case "windowlist":
+        let windows = try listWindows(bundleId: options.bundleId)
+        let data = try JSONSerialization.data(withJSONObject: windows, options: [])
+        print(String(data: data, encoding: .utf8) ?? "[]")
     case "menu":
         try ensureAccessibility(prompt: options.promptAccessibility)
         try axPressMenuItem(bundleId: options.bundleId, path: options.menuPath)

--- a/app/scripts/real-app-harness/macosDriver.mjs
+++ b/app/scripts/real-app-harness/macosDriver.mjs
@@ -111,6 +111,34 @@ export class MacOSDriver {
     return null;
   }
 
+  // Returns all onscreen windows owned by the driver's bundle, parsed from the
+  // `windowlist` subcommand: Array<{ id, name, x, y, width, height, layer }>.
+  // Returns [] on any failure (never throws), matching mainWindowId()'s
+  // tolerance.
+  async windowList() {
+    try {
+      const value = await this.runInputDriverCapture(['windowlist']);
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
+  // Polls windowList() until a window whose `name` equals `title` appears.
+  // Returns the matching window object, or null on timeout. Requires window
+  // names (Screen Recording permission); callers should treat null as "the
+  // window never opened" and fail loudly rather than guessing.
+  async waitForWindowTitled(title, { timeoutMs = 10_000, pollIntervalMs = 200 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const named = (await this.windowList()).find((w) => w.name === title);
+      if (named) return named;
+      await delay(pollIntervalMs);
+    }
+    return null;
+  }
+
   async typeText(text) {
     await this.runInputDriver(['text', '--text', text, '--prompt-accessibility']);
     await delay(this.actionDelayMs);

--- a/app/scripts/real-app-harness/presentDaemon.mjs
+++ b/app/scripts/real-app-harness/presentDaemon.mjs
@@ -106,14 +106,20 @@ export async function getPresentationRound(presentationId, { port, seq } = {}) {
 }
 
 // Shapes a present_submit_round message. Exported (pure, no socket) so tests
-// can cover payload shaping without a live daemon.
-export function buildSubmitMessage({ roundId, comments = [], handback = true }) {
+// can cover payload shaping without a live daemon. verdict mirrors the
+// daemon's own validation (handlePresentSubmitRound in internal/daemon/present.go):
+// it must be "approved" or "feedback".
+export function buildSubmitMessage({ roundId, comments = [], handback = true, verdict = 'feedback' }) {
   if (!roundId) {
     throw new Error('buildSubmitMessage requires roundId');
+  }
+  if (verdict !== 'approved' && verdict !== 'feedback') {
+    throw new Error(`verdict must be "approved" or "feedback", got ${JSON.stringify(verdict)}`);
   }
   return {
     cmd: 'present_submit_round',
     round_id: roundId,
+    verdict,
     comments: comments.map((comment, index) => {
       if (!comment.filepath) {
         throw new Error(`comments[${index}].filepath is required`);
@@ -135,7 +141,7 @@ export function buildSubmitMessage({ roundId, comments = [], handback = true }) 
 
 // If roundId is omitted, fetches the presentation's latest round first and
 // submits against it.
-export async function submitPresentationRound({ presentationId, roundId, comments = [], handback = true } = {}, { port } = {}) {
+export async function submitPresentationRound({ presentationId, roundId, comments = [], handback = true, verdict = 'feedback' } = {}, { port } = {}) {
   return withDaemonSocket(async (sendAndWait) => {
     let resolvedRoundId = roundId;
     if (!resolvedRoundId) {
@@ -154,7 +160,7 @@ export async function submitPresentationRound({ presentationId, roundId, comment
         throw new Error(`No round found for presentation ${presentationId}`);
       }
     }
-    const submitMessage = buildSubmitMessage({ roundId: resolvedRoundId, comments, handback });
+    const submitMessage = buildSubmitMessage({ roundId: resolvedRoundId, comments, handback, verdict });
     const result = await sendAndWait(submitMessage, 'present_submit_round_result');
     if (!result.success) {
       throw new Error(result.error || `present_submit_round failed for round ${resolvedRoundId}`);

--- a/app/scripts/real-app-harness/presentDaemon.test.mjs
+++ b/app/scripts/real-app-harness/presentDaemon.test.mjs
@@ -16,11 +16,13 @@ describe('buildSubmitMessage', () => {
         { filepath: 'a.go', line_start: 10, line_end: 12, side: 'new', content: 'nit' },
       ],
       handback: true,
+      verdict: 'approved',
     });
 
     expect(message).toEqual({
       cmd: 'present_submit_round',
       round_id: 'round-1',
+      verdict: 'approved',
       comments: [
         { filepath: 'a.go', line_start: 10, line_end: 12, side: 'new', content: 'nit' },
       ],
@@ -28,14 +30,21 @@ describe('buildSubmitMessage', () => {
     });
   });
 
-  it('defaults handback to true and comments to empty', () => {
+  it('defaults handback to true, verdict to feedback, and comments to empty', () => {
     const message = buildSubmitMessage({ roundId: 'round-2' });
     expect(message.handback).toBe(true);
+    expect(message.verdict).toBe('feedback');
     expect(message.comments).toEqual([]);
   });
 
   it('throws without a roundId', () => {
     expect(() => buildSubmitMessage({ comments: [] })).toThrow('requires roundId');
+  });
+
+  it('throws on an invalid verdict', () => {
+    expect(() => buildSubmitMessage({ roundId: 'round-5', verdict: 'lgtm' })).toThrow(
+      'verdict must be "approved" or "feedback"',
+    );
   });
 
   it('throws on an invalid comment side', () => {

--- a/app/scripts/real-app-harness/presentFixtureRepo.mjs
+++ b/app/scripts/real-app-harness/presentFixtureRepo.mjs
@@ -1,0 +1,93 @@
+/**
+ * Builds a throwaway git repository with a committed base->head change and a
+ * `.present.yml` manifest pinning that range, for exercising the Present
+ * window (a second Tauri window titled "attn — present") in the packaged
+ * app.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: 'Attn Harness',
+  GIT_AUTHOR_EMAIL: 'harness@attn.test',
+  GIT_COMMITTER_NAME: 'Attn Harness',
+  GIT_COMMITTER_EMAIL: 'harness@attn.test',
+};
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, {
+    cwd,
+    env: { ...process.env, ...GIT_ENV },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).toString();
+}
+
+function write(repoDir, relPath, contents) {
+  const full = path.join(repoDir, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, contents, 'utf8');
+}
+
+/**
+ * @param {string} rootDir directory under which the fixture repo is created
+ * @returns {{ repoDir: string, manifestPath: string, baseSha: string, headSha: string, notedPath: string }}
+ */
+export function buildPresentFixtureRepo(rootDir) {
+  const repoDir = path.join(rootDir, 'present-fixture');
+  fs.mkdirSync(repoDir, { recursive: true });
+  git(repoDir, 'init', '-q');
+
+  // --- base commit ---------------------------------------------------------
+  write(repoDir, 'greeting.ts', [
+    'export function greet(name: string): string {',
+    '  return `Hello, ${name}!`;',
+    '}',
+    '',
+  ].join('\n'));
+
+  write(repoDir, 'notes.md', [
+    '# Notes',
+    '',
+    'A throwaway project used to exercise the Present window.',
+    '',
+  ].join('\n'));
+
+  git(repoDir, 'add', '-A');
+  git(repoDir, 'commit', '-q', '-m', 'base');
+  const baseSha = git(repoDir, 'rev-parse', 'HEAD').trim();
+
+  // --- head commit -----------------------------------------------------
+  write(repoDir, 'greeting.ts', [
+    'export function greet(name: string): string {',
+    '  // reworked to include a friendlier sign-off',
+    '  return `Hello, ${name}! Welcome aboard.`;',
+    '}',
+    '',
+  ].join('\n'));
+
+  git(repoDir, 'add', '-A');
+  git(repoDir, 'commit', '-q', '-m', 'head: tweak greeting');
+  const headSha = git(repoDir, 'rev-parse', 'HEAD').trim();
+
+  // --- Present manifest ------------------------------------------------
+  const manifestPath = path.join(repoDir, '.present.yml');
+  const manifestYaml = [
+    'version: 1',
+    'kind: changes',
+    'title: Present flow smoke',
+    'frame:',
+    `  repo: ${repoDir}`,
+    `  base: ${baseSha}`,
+    `  head: ${headSha}`,
+    'summary: |',
+    '  Smoke presentation for the packaged-app present-flow scenario.',
+    'files:',
+    '  - path: greeting.ts',
+    '    note: Reworked the greeting.',
+    '',
+  ].join('\n');
+  fs.writeFileSync(manifestPath, manifestYaml, 'utf8');
+
+  return { repoDir, manifestPath, baseSha, headSha, notedPath: 'greeting.ts' };
+}

--- a/app/scripts/real-app-harness/scenario-present-flow.mjs
+++ b/app/scripts/real-app-harness/scenario-present-flow.mjs
@@ -190,6 +190,7 @@ async function main() {
         {
           presentationId,
           handback: true,
+          verdict: 'feedback',
           comments: [{ filepath: notedPath, line_start: 1, line_end: 1, side: 'new', content: REVIEWER_COMMENT }],
         },
         { port },

--- a/app/scripts/real-app-harness/scenario-present-flow.mjs
+++ b/app/scripts/real-app-harness/scenario-present-flow.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+/**
+ * Real-app scenario: the full "Present" loop in the packaged app.
+ *
+ * An agent (via the attn CLI, `attn present`) opens a presentation from a
+ * manifest -> a notice chip appears in the main window -> clicking the chip
+ * opens the second Tauri window (titled "attn — present") -> a reviewer
+ * submits a round over the real daemon socket -> the authoring agent reads
+ * the feedback back (`attn present feedback --json`).
+ *
+ * The present window itself carries NO automation bridge, so loop mechanics
+ * are asserted via the MAIN-window bridge (present_get_state /
+ * present_click_chip), the real daemon socket (presentDaemon.mjs), and native
+ * window enumeration (macosDriver.mjs's waitForWindowTitled), plus a
+ * best-effort screenshot artifact. Diff-pixel rendering inside the present
+ * window is covered by unit tests and manual cold-boot verification, not
+ * here — do not try to read the present window's DOM.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import {
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { MacOSDriver } from './macosDriver.mjs';
+import { createScenarioRunner } from './scenarioRunner.mjs';
+import { buildPresentFixtureRepo } from './presentFixtureRepo.mjs';
+import { getPresentations, getPresentationRound, submitPresentationRound } from './presentDaemon.mjs';
+import { currentHarnessProfile, defaultDaemonPortForProfile } from './harnessProfile.mjs';
+
+const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
+// The em dash (U+2014) is load-bearing: it must match the native window title
+// set in app/src-tauri/src/lib.rs exactly, or waitForWindowTitled never matches.
+const PRESENT_WINDOW_TITLE = 'attn — present';
+const REVIEWER_COMMENT = 'Reviewer note from the present-flow scenario.';
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') args.shift();
+  const options = parseCommonArgs(args);
+  return { options, help: args.includes('--help') || args.includes('-h') };
+}
+
+async function pollFor(fn, description, timeoutMs = 30_000, intervalMs = 250) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await fn();
+    if (last) return last;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for: ${description}. Last value: ${JSON.stringify(last)}`);
+}
+
+function resolveAttnBin() {
+  const candidates = [process.env.ATTN_HARNESS_BIN, path.resolve(HARNESS_DIR, '../../../attn')].filter(Boolean);
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error('attn binary not found (build ./attn or set ATTN_HARNESS_BIN)');
+}
+
+// Extends scenario-chief-ticket-watch.mjs's makeAttnRunner with a per-call
+// { cwd, extraEnv }: `attn present` reads .present.yml from its cwd and
+// resolves the acting session from ATTN_SESSION_ID (or --session).
+function makeAttnRunner(attnBin, profile) {
+  return function runAttn(args, { cwd, extraEnv } = {}) {
+    const stdout = execFileSync(attnBin, args, {
+      encoding: 'utf8',
+      cwd,
+      env: { ...process.env, ATTN_PROFILE: profile, ...(extraEnv || {}) },
+    });
+    const brace = stdout.indexOf('{');
+    return { stdout, json: brace >= 0 ? JSON.parse(stdout.slice(brace)) : null };
+  };
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-present-flow.mjs');
+    return;
+  }
+
+  const runner = createScenarioRunner(options, {
+    scenarioId: 'PRESENT-FLOW',
+    prefix: 'present-flow',
+    metadata: { focus: 'chip -> present window -> submit round -> feedback CLI' },
+  });
+
+  const profile = currentHarnessProfile();
+  const port = defaultDaemonPortForProfile(profile);
+  const attnBin = resolveAttnBin();
+  const runAttn = makeAttnRunner(attnBin, profile);
+
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const driver = new MacOSDriver({ appPath: options.appPath });
+
+  let sessionId = null;
+  let presentationId = null;
+
+  try {
+    const { repoDir, baseSha, headSha, notedPath } = await runner.step('build_fixture', async () => {
+      const fixture = buildPresentFixtureRepo(runner.sessionDir);
+      runner.log('fixture_built', { repoDir: fixture.repoDir, baseSha: fixture.baseSha, headSha: fixture.headSha });
+      return fixture;
+    });
+
+    await runner.step('launch_app', async () => {
+      await launchFreshAppAndConnect(client, observer);
+    });
+
+    sessionId = await runner.step('create_session', async () => {
+      const id = await createSessionAndWaitForInitialPane({
+        client,
+        observer,
+        cwd: repoDir,
+        label: `present-${runner.runId}`,
+        agent: 'shell',
+        waitForInitialPaneVisible: false,
+        sessionWaitMs: 30_000,
+      });
+      await client.request('select_session', { sessionId: id });
+      return id;
+    });
+    runner.registerCleanup('close_session', () => client.request('close_session', { sessionId }));
+
+    presentationId = await runner.step('open_presentation', async () => {
+      const { stdout } = runAttn(['present'], { cwd: repoDir, extraEnv: { ATTN_SESSION_ID: sessionId } });
+      const match = /attn present feedback (\S+)/.exec(stdout);
+      runner.assert(Boolean(match), 'attn present printed a "feedback will arrive via" line with a presentation id', { stdout });
+      const id = match[1];
+      const presentations = await getPresentations({ port });
+      runner.assert(
+        presentations.some((p) => p.id === id),
+        'daemon get_presentations includes the opened presentation',
+        { id, presentations },
+      );
+      return id;
+    });
+
+    await runner.step('assert_chip', async () => {
+      const state = await pollFor(
+        async () => {
+          const s = await client.request('present_get_state');
+          const notice = (s.notices || []).find((n) => n.id === presentationId);
+          const chip = (s.chips || []).find((c) => c.presentationId === presentationId);
+          return notice && chip ? { notice, chip } : null;
+        },
+        `present_get_state to include notice+chip for presentation ${presentationId}`,
+        30_000,
+      );
+      runner.assert(
+        state.notice.title === 'Present flow smoke',
+        `notice title matches the manifest (got ${JSON.stringify(state.notice.title)})`,
+      );
+      runner.assert(
+        state.chip.title === 'Present flow smoke',
+        `chip title matches the manifest (got ${JSON.stringify(state.chip.title)})`,
+      );
+    });
+
+    const presentWindow = await runner.step('open_present_window', async () => {
+      await client.request('present_click_chip', { presentationId });
+      const win = await driver.waitForWindowTitled(PRESENT_WINDOW_TITLE, { timeoutMs: 15_000 });
+      runner.assert(Boolean(win), `present window "${PRESENT_WINDOW_TITLE}" opened`);
+      runner.log('present_window_bounds', win);
+      try {
+        await client.request('capture_native_window_screenshot', {
+          path: path.join(runner.runDir, 'present-window.png'),
+        });
+      } catch (error) {
+        runner.log('present_window_screenshot_skipped', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      return win;
+    });
+
+    const submittedAt = await runner.step('submit_round', async () => {
+      await submitPresentationRound(
+        {
+          presentationId,
+          handback: true,
+          comments: [{ filepath: notedPath, line_start: 1, line_end: 1, side: 'new', content: REVIEWER_COMMENT }],
+        },
+        { port },
+      );
+      const roundResult = await getPresentationRound(presentationId, { port });
+      runner.assert(
+        Boolean(roundResult.round?.submitted_at),
+        'round has a submitted_at timestamp after submit',
+        roundResult.round,
+      );
+      const comments = roundResult.comments || [];
+      runner.assert(
+        comments.some((c) => c.content === REVIEWER_COMMENT && c.side === 'new'),
+        'submitted round comments include the reviewer note on side=new',
+        comments,
+      );
+      return roundResult.round.submitted_at;
+    });
+
+    await runner.step('read_feedback', async () => {
+      const { json } = runAttn(['present', 'feedback', presentationId, '--json']);
+      runner.assert(json && typeof json.markdown === 'string', 'present feedback --json returned a markdown field', json);
+      runner.assert(json.markdown.includes(REVIEWER_COMMENT), 'feedback markdown includes the reviewer note', json.markdown);
+    });
+
+    const summary = runner.finishSuccess({ sessionId, presentationId, window: presentWindow, submittedAt, baseSha, headSha });
+    console.log(JSON.stringify(summary, null, 2));
+  } catch (error) {
+    const summary = runner.finishFailure(error, { sessionId, presentationId });
+    console.error(summary.error);
+    process.exitCode = 1;
+  } finally {
+    if (sessionId) {
+      await client.request('close_session', { sessionId }).catch(() => {});
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close().catch(() => {});
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -48,6 +48,14 @@ export const scenarioCatalog = [
     command: ['pnpm', 'run', 'real-app:scenario-autoclose-on-exit'],
   },
   {
+    id: 'present-flow',
+    label: 'Present flow: chip → window → submit round → feedback CLI',
+    command: ['pnpm', 'run', 'real-app:scenario-present-flow'],
+    // Boots the app + a session + two CLI round-trips + a second native
+    // window; give it headroom like the other heavy scenarios.
+    timeoutMs: 240_000,
+  },
+  {
     id: 'ticket-lifecycle',
     label: 'Ticket lifecycle: chief delegates, worker reports, chief reviews in the panel',
     command: ['pnpm', 'run', 'real-app:scenario-ticket-lifecycle'],

--- a/docs/plans/2026-07-04-present-spine.md
+++ b/docs/plans/2026-07-04-present-spine.md
@@ -129,7 +129,10 @@ Tests:
       head). `get_file_diff` head-ref extension lands here with its daemon
       tests. (Merged: #482.)
 - [x] **PR 4 — packaged evidence + polish.** Real-app scenario for the full
-      loop; live dev-app smoke with a real delegated agent; CHANGELOG entry. (Open: #484 — live-verified, in review.)
+      loop; live dev-app smoke with a real delegated agent; CHANGELOG entry.
+      (Packaged scenario `scenario-present-flow.mjs` — PR #484, rebuilt on
+      main and kept current with the verdict-aware submit protocol from
+      PR #516.)
 
 ## Decisions
 

--- a/docs/plans/2026-07-04-present-spine.md
+++ b/docs/plans/2026-07-04-present-spine.md
@@ -108,28 +108,28 @@ Tests:
 
 ## Implementation Steps
 
-- [ ] **PR 1 — Go spine.** `internal/present` (parse, validate, SHA pinning);
+- [x] **PR 1 — Go spine.** `internal/present` (parse, validate, SHA pinning);
       store tables + migration; protocol messages + version bump; daemon
       handlers (`present_open`, feedback, get/list, submit_round persistence);
       `attn present` / `attn present validate` / `attn present feedback` in
       `cmd/attn`; doorbell-on-submit (ticket activity when bound, bare
-      doorbell otherwise). Tests as mapped.
-- [ ] **PR 2 — window shell.** Rust `open_presentation_window` (build-or-show,
+      doorbell otherwise). Tests as mapped. (Merged: #465.)
+- [x] **PR 2 — window shell.** Rust `open_presentation_window` (build-or-show,
       hide-on-close-request), label-guarded `on_page_load` show,
       `capabilities/present.json` (core:default + clipboard), focus-aware
       `on_menu_event`/`dispatch_native_shortcut` (⌘W on present window hides
       it, never touches main panes); `main.tsx` `?window=present` branch with
       a hello-world `PresentRoot` proving WS + theme; banner notice in main
       window wired to `presentation_added` → open window; banner persists
-      while window hidden (that IS minimize-to-banner).
-- [ ] **PR 3 — the reader.** Ordered file list, pinned-SHA diffs through
+      while window hidden (that IS minimize-to-banner). (Merged: #466.)
+- [x] **PR 3 — the reader.** Ordered file list, pinned-SHA diffs through
       `DiffView`, per-file notes + summary (existing simple markdown renderer;
       no new markdown stack), keyboard nav, inline comment drafts, submit
       dialog with handback toggle, drift banner (round head vs current branch
       head). `get_file_diff` head-ref extension lands here with its daemon
-      tests.
-- [ ] **PR 4 — packaged evidence + polish.** Real-app scenario for the full
-      loop; live dev-app smoke with a real delegated agent; CHANGELOG entry.
+      tests. (Merged: #482.)
+- [x] **PR 4 — packaged evidence + polish.** Real-app scenario for the full
+      loop; live dev-app smoke with a real delegated agent; CHANGELOG entry. (Open: #484 — live-verified, in review.)
 
 ## Decisions
 


### PR DESCRIPTION
Packaged-app scenario for the full **Present** loop (`real-app:scenario-present-flow`, catalog id `present-flow`): fixture repo + manifest → `attn present` CLI opens a presentation → notice chip asserted via the main-window automation bridge → `present_click_chip` opens the second Tauri window (found by its real native title via a new `windowlist` InputDriver subcommand + `waitForWindowTitled`) → reviewer submits a round over the daemon socket → `attn present feedback --json` returns the markdown.

**Rebuilt on current main and modernized for the verdict-era daemon (#516):**
- `presentDaemon.mjs` submit helpers now carry the required `verdict` ("approved" | "feedback", default `feedback`) with daemon-matching validation; unit tests updated (+ invalid-verdict case).
- Kept the still-unmerged `windowlist`/`windowList()`/`waitForWindowTitled()` driver additions; resolved around the `--window-title` support that already landed on main.
- Dropped stale `diff-review` catalog/package.json entries (that scenario was removed with the standalone diff-review panels) and the CHANGELOG hunk (internal harness work).
- Re-verified the scenario's assumptions against main: CLI output line, bridge shapes (`present_get_state`/`present_click_chip`), manifest schema.

**Verified:** `presentDaemon.test.mjs` 7/7 green; `swiftc -parse` clean; and the packaged scenario itself run against a fresh `attn-dev.app` built from this branch — full pass (chip → window "attn — present" → verdict submit → feedback markdown with the reviewer note).

https://claude.ai/code/session_01MvgEqMMAkmqJQezpgLNjzQ
