### PR TITLE
perf(harness): RSS-baseline verdict + per-machine registry comparison

### DIFF
--- a/app/scripts/real-app-harness/rssBaselineVerdict.mjs
+++ b/app/scripts/real-app-harness/rssBaselineVerdict.mjs
@@ -1,0 +1,57 @@
+import { compareToBaseline } from './machineRegistry.mjs';
+
+// Contract cap shared with scenarioRunner.mjs's summarizeFirstFailure — the
+// ATTN_VERDICT line is single-line and length-bounded, so firstFailure here
+// follows the same rule even though this scenario builds its own verdict by
+// hand instead of going through createScenarioRunner.
+const FIRST_FAILURE_MAX_LENGTH = 300;
+
+function truncateFirstFailure(message) {
+  return message.length <= FIRST_FAILURE_MAX_LENGTH ? message : message.slice(0, FIRST_FAILURE_MAX_LENGTH);
+}
+
+// Pure: decides whether this run's RSS is within tolerance of the per-machine
+// baseline, and whether a new baseline should be written. No fs/Date/process
+// access so it stays directly unit-testable — the caller resolves the
+// baseline (machineRegistry.loadBaseline), performs the write
+// (machineRegistry.saveBaseline), and supplies `recordedAt`.
+//
+// A baseline is (re)recorded when there isn't one yet (first run on a
+// machine always self-baselines) or when the caller explicitly asked to via
+// `record` (re-baselining after an intentional regression/improvement).
+export function evaluateRssBaseline({ totalRssMb, fingerprint, baseline, tolerancePct = 15, record = false, recordedAt }) {
+  const comparison = compareToBaseline(totalRssMb, baseline?.metrics?.totalRssMb ?? null, { tolerancePct });
+  const shouldRecord = record === true || baseline == null;
+  const baselineToSave = shouldRecord
+    ? { fingerprint, metrics: { totalRssMb }, recordedAt }
+    : null;
+
+  return { ok: comparison.ok, comparison, baselineToSave };
+}
+
+// Pure: builds the ATTN_VERDICT payload for the RSS baseline scenario. Extends
+// the core verdict contract (see common.mjs) with two scenario-specific
+// fields, `rss` and `metrics` — existing verdict consumers only read the core
+// fields, and this extension is documented for the leak-soak scenario that
+// will read `rss`/`metrics` off this same shape.
+export function buildBaselineVerdict({ ok, comparison, scenarioId, runId, artifactsDir, summaryPath, durationMs, extraMetrics = {} }) {
+  const firstFailure = ok
+    ? null
+    : truncateFirstFailure(
+        `RSS regression: ${comparison.value}MB vs baseline ${comparison.baseline}MB `
+        + `(+${comparison.deltaPct}%, tolerance ${comparison.tolerancePct}%)`,
+      );
+
+  return {
+    ok,
+    scenarioId,
+    runId,
+    failureCount: ok ? 0 : 1,
+    firstFailure,
+    artifactsDir,
+    summaryPath,
+    durationMs,
+    rss: comparison,
+    metrics: { totalRssMb: comparison.value, ...extraMetrics },
+  };
+}

--- a/app/scripts/real-app-harness/rssBaselineVerdict.mjs
+++ b/app/scripts/real-app-harness/rssBaselineVerdict.mjs
@@ -18,10 +18,17 @@ function truncateFirstFailure(message) {
 //
 // A baseline is (re)recorded when there isn't one yet (first run on a
 // machine always self-baselines) or when the caller explicitly asked to via
-// `record` (re-baselining after an intentional regression/improvement).
+// `record` (re-baselining after an intentional regression/improvement). An
+// explicit re-record is a pass by construction: this run DEFINES the new
+// baseline, so it can never be a regression against the value it replaces —
+// comparing it against the old baseline (and possibly failing) would defeat
+// the point of asking to re-baseline.
 export function evaluateRssBaseline({ totalRssMb, fingerprint, baseline, tolerancePct = 15, record = false, recordedAt }) {
-  const comparison = compareToBaseline(totalRssMb, baseline?.metrics?.totalRssMb ?? null, { tolerancePct });
-  const shouldRecord = record === true || baseline == null;
+  const hasBaseline = baseline?.metrics?.totalRssMb != null;
+  const comparison = record === true
+    ? { ok: true, value: totalRssMb, baseline: null, deltaPct: null, tolerancePct, reason: 'recorded' }
+    : compareToBaseline(totalRssMb, hasBaseline ? baseline.metrics.totalRssMb : null, { tolerancePct });
+  const shouldRecord = record === true || !hasBaseline;
   const baselineToSave = shouldRecord
     ? { fingerprint, metrics: { totalRssMb }, recordedAt }
     : null;

--- a/app/scripts/real-app-harness/rssBaselineVerdict.test.mjs
+++ b/app/scripts/real-app-harness/rssBaselineVerdict.test.mjs
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { buildBaselineVerdict, evaluateRssBaseline } from './rssBaselineVerdict.mjs';
+
+const fingerprint = {
+  key: 'abc123def456',
+  arch: 'arm64',
+  platform: 'darwin',
+  osRelease: '24.5.0',
+  hwModel: 'Mac15,6',
+  cpuBrand: 'Apple M3 Pro',
+  cpuCount: 12,
+  totalMemGb: 36,
+};
+
+describe('evaluateRssBaseline', () => {
+  it('is ok with a fresh baseline to save when there is no existing baseline', () => {
+    const result = evaluateRssBaseline({
+      totalRssMb: 500,
+      fingerprint,
+      baseline: null,
+      recordedAt: '2026-07-05T00:00:00.000Z',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.comparison.reason).toBe('no-baseline');
+    expect(result.baselineToSave).toEqual({
+      fingerprint,
+      metrics: { totalRssMb: 500 },
+      recordedAt: '2026-07-05T00:00:00.000Z',
+    });
+  });
+
+  it('is ok with nothing to save when within tolerance of an existing baseline', () => {
+    const baseline = { fingerprint, metrics: { totalRssMb: 500 }, recordedAt: '2026-07-01T00:00:00.000Z' };
+
+    const result = evaluateRssBaseline({
+      totalRssMb: 520,
+      fingerprint,
+      baseline,
+      tolerancePct: 15,
+      recordedAt: '2026-07-05T00:00:00.000Z',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.comparison.reason).toBe('within-band');
+    expect(result.baselineToSave).toBeNull();
+  });
+
+  it('fails with reason regression when beyond tolerance of an existing baseline', () => {
+    const baseline = { fingerprint, metrics: { totalRssMb: 500 }, recordedAt: '2026-07-01T00:00:00.000Z' };
+
+    const result = evaluateRssBaseline({
+      totalRssMb: 700,
+      fingerprint,
+      baseline,
+      tolerancePct: 15,
+      recordedAt: '2026-07-05T00:00:00.000Z',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.comparison.reason).toBe('regression');
+    expect(result.baselineToSave).toBeNull();
+  });
+
+  it('forces a re-record when record is true even with an existing baseline', () => {
+    const baseline = { fingerprint, metrics: { totalRssMb: 500 }, recordedAt: '2026-07-01T00:00:00.000Z' };
+
+    const result = evaluateRssBaseline({
+      totalRssMb: 520,
+      fingerprint,
+      baseline,
+      record: true,
+      recordedAt: '2026-07-05T00:00:00.000Z',
+    });
+
+    expect(result.baselineToSave).toEqual({
+      fingerprint,
+      metrics: { totalRssMb: 520 },
+      recordedAt: '2026-07-05T00:00:00.000Z',
+    });
+  });
+
+  it('passes recordedAt through into baselineToSave unchanged', () => {
+    const result = evaluateRssBaseline({
+      totalRssMb: 500,
+      fingerprint,
+      baseline: null,
+      recordedAt: '2099-01-01T12:34:56.000Z',
+    });
+
+    expect(result.baselineToSave.recordedAt).toBe('2099-01-01T12:34:56.000Z');
+  });
+});
+
+describe('buildBaselineVerdict', () => {
+  it('builds a passing verdict with firstFailure null and the rss/metrics extensions attached', () => {
+    const comparison = { ok: true, value: 500, baseline: null, deltaPct: null, tolerancePct: 15, reason: 'no-baseline' };
+
+    const verdict = buildBaselineVerdict({
+      ok: true,
+      comparison,
+      scenarioId: 'perf-baseline',
+      runId: 'perf-baseline-2026-07-05T00-00-00-000Z',
+      artifactsDir: '/tmp/attn-real-app-harness/perf-baseline-run',
+      summaryPath: '/tmp/attn-real-app-harness/perf-baseline-run/summary.json',
+      durationMs: 4321,
+    });
+
+    expect(verdict).toEqual({
+      ok: true,
+      scenarioId: 'perf-baseline',
+      runId: 'perf-baseline-2026-07-05T00-00-00-000Z',
+      failureCount: 0,
+      firstFailure: null,
+      artifactsDir: '/tmp/attn-real-app-harness/perf-baseline-run',
+      summaryPath: '/tmp/attn-real-app-harness/perf-baseline-run/summary.json',
+      durationMs: 4321,
+      rss: comparison,
+      metrics: { totalRssMb: 500 },
+    });
+  });
+
+  it('builds a failing verdict with a one-line regression message and failureCount 1', () => {
+    const comparison = { ok: false, value: 700, baseline: 500, deltaPct: 40, tolerancePct: 15, reason: 'regression' };
+
+    const verdict = buildBaselineVerdict({
+      ok: false,
+      comparison,
+      scenarioId: 'perf-baseline',
+      runId: 'perf-baseline-2026-07-05T00-00-00-000Z',
+      artifactsDir: '/tmp/attn-real-app-harness/perf-baseline-run',
+      summaryPath: '/tmp/attn-real-app-harness/perf-baseline-run/summary.json',
+      durationMs: 4321,
+    });
+
+    expect(verdict.failureCount).toBe(1);
+    expect(verdict.firstFailure).toBe('RSS regression: 700MB vs baseline 500MB (+40%, tolerance 15%)');
+    expect(verdict.firstFailure.split('\n')).toHaveLength(1);
+  });
+
+  it('merges extraMetrics into metrics alongside totalRssMb', () => {
+    const comparison = { ok: true, value: 500, baseline: 480, deltaPct: 4.2, tolerancePct: 15, reason: 'within-band' };
+
+    const verdict = buildBaselineVerdict({
+      ok: true,
+      comparison,
+      scenarioId: 'perf-baseline',
+      runId: 'run-1',
+      artifactsDir: '/tmp/run',
+      summaryPath: '/tmp/run/summary.json',
+      durationMs: 100,
+      extraMetrics: { retainedMb: 12.3 },
+    });
+
+    expect(verdict.metrics).toEqual({ totalRssMb: 500, retainedMb: 12.3 });
+  });
+});

--- a/app/scripts/real-app-harness/rssBaselineVerdict.test.mjs
+++ b/app/scripts/real-app-harness/rssBaselineVerdict.test.mjs
@@ -62,11 +62,14 @@ describe('evaluateRssBaseline', () => {
     expect(result.baselineToSave).toBeNull();
   });
 
-  it('forces a re-record when record is true even with an existing baseline', () => {
+  it('forces a re-record when record is true even with an existing baseline, and passes by construction', () => {
+    // This is the figgyster-reproduced bug: an explicit re-record must never
+    // be evaluated against the baseline it is about to replace, even when the
+    // new value would have been a regression against the old one.
     const baseline = { fingerprint, metrics: { totalRssMb: 500 }, recordedAt: '2026-07-01T00:00:00.000Z' };
 
     const result = evaluateRssBaseline({
-      totalRssMb: 520,
+      totalRssMb: 700,
       fingerprint,
       baseline,
       record: true,
@@ -75,9 +78,12 @@ describe('evaluateRssBaseline', () => {
 
     expect(result.baselineToSave).toEqual({
       fingerprint,
-      metrics: { totalRssMb: 520 },
+      metrics: { totalRssMb: 700 },
       recordedAt: '2026-07-05T00:00:00.000Z',
     });
+    expect(result.ok).toBe(true);
+    expect(result.comparison.reason).toBe('recorded');
+    expect(result.comparison.baseline).toBeNull();
   });
 
   it('passes recordedAt through into baselineToSave unchanged', () => {

--- a/app/scripts/real-app-harness/scenario-perf-baseline.mjs
+++ b/app/scripts/real-app-harness/scenario-perf-baseline.mjs
@@ -35,9 +35,11 @@ import http from 'node:http';
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { DaemonObserver } from './daemonObserver.mjs';
-import { createRunContext, createSessionAndWaitForInitialPane, parseCommonArgs, printCommonHelp } from './common.mjs';
+import { createRunContext, createSessionAndWaitForInitialPane, emitVerdict, parseCommonArgs, printCommonHelp } from './common.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { daemonPidFilePathForProfile, profileForAppPath, socketPathForProfile } from './harnessProfile.mjs';
+import { getMachineFingerprint, loadBaseline, saveBaseline } from './machineRegistry.mjs';
+import { buildBaselineVerdict, evaluateRssBaseline } from './rssBaselineVerdict.mjs';
 
 const execFileAsync = promisify(execFile);
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -60,6 +62,8 @@ function parseArgs(argv) {
     fillSettleMs: 3000,
     reclaimHoldMs: 0,
     reclaimHoldIntervalMs: 15000,
+    rssTolerancePct: 15,
+    recordBaseline: false,
   };
   for (let index = 0; index < filtered.length; index += 1) {
     const arg = filtered[index];
@@ -77,6 +81,8 @@ function parseArgs(argv) {
     else if (arg === '--fill-settle-ms') extras.fillSettleMs = Number(filtered[++index]);
     else if (arg === '--reclaim-hold-ms') extras.reclaimHoldMs = Number(filtered[++index]);
     else if (arg === '--reclaim-hold-interval-ms') extras.reclaimHoldIntervalMs = Number(filtered[++index]);
+    else if (arg === '--rss-tolerance-pct') extras.rssTolerancePct = Number(filtered[++index]);
+    else if (arg === '--record-baseline') extras.recordBaseline = true;
     else passthrough.push(arg);
   }
   const options = parseCommonArgs(passthrough);
@@ -420,11 +426,16 @@ async function main() {
     console.log('                      curve -- distinguishes soft-but-delayed from hard. Pair with');
     console.log('                      --fill-cmd + --warm <low>.');
     console.log('  --reclaim-hold-interval-ms <n>  Sample interval during the hold (default: 15000)');
+    console.log('  --rss-tolerance-pct <n>  Allowed growth over the per-machine baseline before the');
+    console.log('                      verdict fails (default: 15)');
+    console.log('  --record-baseline   Overwrite the per-machine baseline with this run\'s RSS instead');
+    console.log('                      of comparing against it');
     console.log('');
     console.log('Set ATTN_PPROF=<port> to also capture /debug/vars + heap/CPU pprof.');
     return;
   }
 
+  const startedAt = Date.now();
   const port = pprofPort();
   const { runId, runDir, sessionDir } = createRunContext(options, 'perf-baseline');
   const client = new UiAutomationClient({ appPath: options.appPath });
@@ -434,6 +445,9 @@ async function main() {
   // Warm-workspace limit captured before the sweep perturbs it, restored in the
   // finally so this run does not leak its last swept value into localStorage.
   let initialWarmLimit = null;
+  // Populated once the headline RSS is compared against the machine registry
+  // (below); read again after the finally block to emit the ATTN_VERDICT line.
+  let rssEvaluation = null;
 
   const summary = {
     ok: false,
@@ -779,6 +793,32 @@ async function main() {
         perLivePaneWebContentMb: paneSpan > 0 ? Number(((most.webContentRssMb - least.webContentRssMb) / paneSpan).toFixed(1)) : null,
       };
     }
+
+    // Compare this run's headline RSS against the per-machine registry (see
+    // machineRegistry.mjs) and record what the verdict line below reports.
+    // This never affects summary.ok / the process exit code -- an RSS
+    // regression is a trend signal for a driving agent to notice, not a
+    // harness error.
+    const fingerprint = getMachineFingerprint();
+    const baseline = loadBaseline(fingerprint.key);
+    rssEvaluation = evaluateRssBaseline({
+      totalRssMb: summary.headline.totalRssMb,
+      fingerprint,
+      baseline,
+      tolerancePct: options.rssTolerancePct,
+      record: options.recordBaseline,
+      recordedAt: new Date().toISOString(),
+    });
+    if (rssEvaluation.baselineToSave) {
+      saveBaseline(fingerprint.key, rssEvaluation.baselineToSave);
+      console.log(`[perf] recorded baseline for machine ${fingerprint.key}: ${summary.headline.totalRssMb} MB`);
+    } else {
+      console.log(
+        `[perf] compared to baseline for machine ${fingerprint.key}: ${rssEvaluation.comparison.value} MB `
+        + `vs ${rssEvaluation.comparison.baseline} MB (${rssEvaluation.comparison.reason}, tolerance ${rssEvaluation.comparison.tolerancePct}%)`,
+      );
+    }
+    summary.baselineComparison = rssEvaluation.comparison;
   } finally {
     // Close every session we created so they don't persist into the next run.
     await closeSessions(client, sessionIds);
@@ -810,6 +850,25 @@ async function main() {
   }
 
   console.log(JSON.stringify({ headline: summary.headline, reclaimHold: summary.reclaimHold, idleByClass: summary.snapshots.idle?.byClass, profiles: summary.profiles, runDir }, null, 2));
+
+  // A regression against the machine baseline is a trend signal, not a
+  // harness error: it surfaces as verdict.ok:false but never sets a non-zero
+  // exit code (see the try/finally above -- only real errors do that, via
+  // main().catch below).
+  if (rssEvaluation) {
+    emitVerdict(buildBaselineVerdict({
+      ok: rssEvaluation.ok,
+      comparison: rssEvaluation.comparison,
+      scenarioId: 'perf-baseline',
+      runId,
+      artifactsDir: runDir,
+      summaryPath: path.join(runDir, 'summary.json'),
+      durationMs: Date.now() - startedAt,
+      extraMetrics: summary.headline?.realOutput?.retainedMb != null
+        ? { retainedMb: summary.headline.realOutput.retainedMb }
+        : {},
+    }));
+  }
 }
 
 main().catch((error) => {

--- a/docs/perf-testing.md
+++ b/docs/perf-testing.md
@@ -67,10 +67,13 @@ from someone else's laptop:
 - **Re-recording**: pass `--record-baseline` to overwrite the stored baseline
   with this run's number — use this after an intentional change to the memory
   footprint (a real fix or a deliberate trade-off), not to silence a
-  regression you haven't understood.
+  regression you haven't understood. This run's verdict always passes
+  (`ok:true`, `reason:'recorded'`): the run *defines* the new baseline, so it
+  is never evaluated against — and can never regress against — the number it
+  is replacing.
 
 Local per-machine baselines live in `~/.attn-perf-registry/<fingerprint>.json`
-(gitignored — every dev's cache is their own). A small set of known reference
+(outside the repo — every dev's cache is their own). A small set of known reference
 machines can also have a baseline **committed** to
 `app/scripts/real-app-harness/perf-baselines.json`; a committed entry for a
 given fingerprint always wins over the local cache, so it's the way to pin a
@@ -101,10 +104,11 @@ Shape:
 `scenarioId`, `runId`, `failureCount`, `firstFailure`, `artifactsDir`,
 `summaryPath`, `durationMs` — the same shape every `createScenarioRunner`
 scenario emits). `rss.reason` is one of `no-baseline` (first run on this
-machine), `within-band` (pass), or `regression` (fail). A regression **does
-not** set a non-zero process exit code by itself — only a genuine harness
-error does that — so treat `verdict.ok:false` here as a trend to investigate,
-not a build break.
+machine, pass), `within-band` (pass), `regression` (fail), or `recorded`
+(`--record-baseline` established/overwrote the baseline this run — always a
+pass). A regression **does not** set a non-zero process exit code by itself —
+only a genuine harness error does that — so treat `verdict.ok:false` here as a
+trend to investigate, not a build break.
 
 `summary.json` under the run's artifacts directory has the full detail behind
 the headline number (per-process-class RSS, worker count, optional warm-set

--- a/docs/perf-testing.md
+++ b/docs/perf-testing.md
@@ -1,0 +1,112 @@
+# Performance testing
+
+This is the practical runbook for attn's performance-test suite. It covers how
+to run each layer and how to read the result. For the *why* behind this shape
+(trend-only, no hard gates, per-machine registry instead of a single "Victor's
+number"), see the strategy doc:
+[`docs/plans/2026-07-05-performance-test-strategy.md`](plans/2026-07-05-performance-test-strategy.md).
+
+## Philosophy: trend-only, no hard gates (for now)
+
+Nothing here fails a PR on a perf number. Every layer records a metric and
+prints a machine-parseable verdict; a human (or a future promote-to-gate PR)
+reads the trend. This sidesteps flaky-perf-CI at the cost of relying on
+someone actually looking. The one exception in spirit: `allocs/op` from the Go
+benchmarks is deterministic enough that it's the primary signal to watch, and
+the most likely candidate to graduate to a real gate later.
+
+## Go micro-benches (CPU/allocs)
+
+Targeted `go test -bench` benchmarks for hot paths — currently the PTY
+datapath (`internal/daemon`) and the transcript parser (`internal/transcript`).
+Run them locally:
+
+```bash
+go test -run '^$' -bench . -benchmem ./internal/daemon/ ./internal/transcript/
+```
+
+- `-run '^$'` skips regular tests so only benchmarks run.
+- `-benchmem` adds `allocs/op` and `B/op` alongside `ns/op`.
+- `allocs/op` is the primary trend: it's deterministic regardless of machine
+  noise, unlike `ns/op` on a shared runner.
+- `ns/op` is noisy cross-machine but consistent on the *same* machine, which is
+  why CI (forthcoming) runs `main` and the PR head back-to-back on the same
+  runner and diffs the two with `benchstat` instead of comparing against a
+  fixed number.
+
+A CI job that runs this same-machine A/B automatically is a later PR — not
+built yet.
+
+## Real-app RSS baseline (macro memory)
+
+`scenario-perf-baseline.mjs` drives a packaged dev-app install to a fixed
+number of shell sessions and measures the resident-memory footprint of the
+whole attn tree (app + WebKit + daemon + pty-workers). It requires a running
+dev install (`make dev`) since it's a packaged-app scenario — see
+[`app/scripts/real-app-harness/CLAUDE.md`](../app/scripts/real-app-harness/CLAUDE.md)
+for the harness's profile/single-tenant rules.
+
+Run it:
+
+```bash
+pnpm --dir app run real-app:scenario-perf-baseline -- --sessions 8 --stream 2
+```
+
+### Self-baselining per machine
+
+Every machine is fingerprinted (`hw.model` + CPU brand + core count + RAM +
+OS major + arch — see `app/scripts/real-app-harness/machineRegistry.mjs`) and
+compared against *that machine's own* recorded baseline, not a fixed number
+from someone else's laptop:
+
+- **First run on a machine**: there's no baseline yet, so the run always
+  passes and records one.
+- **Later runs**: the headline total RSS is compared to the stored baseline.
+  Growth beyond `--rss-tolerance-pct` (default 15%) fails the verdict; an
+  improvement (RSS below baseline) always passes.
+- **Re-recording**: pass `--record-baseline` to overwrite the stored baseline
+  with this run's number — use this after an intentional change to the memory
+  footprint (a real fix or a deliberate trade-off), not to silence a
+  regression you haven't understood.
+
+Local per-machine baselines live in `~/.attn-perf-registry/<fingerprint>.json`
+(gitignored — every dev's cache is their own). A small set of known reference
+machines can also have a baseline **committed** to
+`app/scripts/real-app-harness/perf-baselines.json`; a committed entry for a
+given fingerprint always wins over the local cache, so it's the way to pin a
+canonical number for review.
+
+### Reading the verdict
+
+The scenario prints one `ATTN_VERDICT ` line (compact JSON) as the last thing
+it emits on success. Take the **last** such line if there's more than one.
+Shape:
+
+```json
+{
+  "ok": true,
+  "scenarioId": "perf-baseline",
+  "runId": "perf-baseline-...",
+  "failureCount": 0,
+  "firstFailure": null,
+  "artifactsDir": "...",
+  "summaryPath": ".../summary.json",
+  "durationMs": 12345,
+  "rss": { "ok": true, "value": 512.3, "baseline": 498.1, "deltaPct": 2.9, "tolerancePct": 15, "reason": "within-band" },
+  "metrics": { "totalRssMb": 512.3 }
+}
+```
+
+`rss` and `metrics` are extensions on top of the core verdict contract (`ok`,
+`scenarioId`, `runId`, `failureCount`, `firstFailure`, `artifactsDir`,
+`summaryPath`, `durationMs` — the same shape every `createScenarioRunner`
+scenario emits). `rss.reason` is one of `no-baseline` (first run on this
+machine), `within-band` (pass), or `regression` (fail). A regression **does
+not** set a non-zero process exit code by itself — only a genuine harness
+error does that — so treat `verdict.ok:false` here as a trend to investigate,
+not a build break.
+
+`summary.json` under the run's artifacts directory has the full detail behind
+the headline number (per-process-class RSS, worker count, optional warm-set
+sweep, optional real-output peak/retained RSS) plus `baselineComparison`, the
+same object as the verdict's `rss` field.


### PR DESCRIPTION
## Summary
- `scenario-perf-baseline.mjs` now compares its headline RSS against the per-machine baseline registry (`machineRegistry.mjs`, merged in #487) and emits an `ATTN_VERDICT` line, so a driving agent can read pass/fail without spelunking through `summary.json`.
- First run on a machine self-baselines; `--record-baseline` forces a re-record; `--rss-tolerance-pct` tunes the allowed growth band (default 15%).
- A regression surfaces as `verdict.ok:false` but never flips the process exit code — it's a trend signal, not a harness error (matches the "trends only, no hard gates" decision in `docs/plans/2026-07-05-performance-test-strategy.md`).
- New pure helpers `evaluateRssBaseline`/`buildBaselineVerdict` in `rssBaselineVerdict.mjs`, unit tested.
- New `docs/perf-testing.md` runbook covering the Go micro-benches and this RSS baseline.

Originally stacked on #487 (per-machine timings registry); #487 merged to `main` while this was in flight, so this now targets `main` directly (rebased, same single commit).

This PR is harness-only (script + docs + unit tests). **Live-app verification is pending** — I have not run the packaged-app scenario myself; that verification will be done separately before merge, per this repo's live-app-testing policy.

## Test plan
- [x] `pnpm exec vitest run scripts/real-app-harness/rssBaselineVerdict.test.mjs` — 8/8 pass
- [x] `node --check` on all 3 touched/new `.mjs` files — clean
- [ ] Live-app run of `pnpm --dir app run real-app:scenario-perf-baseline` on a dev install (pending)

https://claude.ai/code/session_01CZQx8e5SPw2zFhWK4w9yYt