### PR TITLE
ci(perf): same-machine A/B benchmark job (benchstat delta, trend-only)

### DIFF
--- a/.github/workflows/bench-ab.yml
+++ b/.github/workflows/bench-ab.yml
@@ -1,0 +1,110 @@
+name: Bench A/B
+
+# Runs the daemon/transcript Go benchmarks on the PR base and PR head,
+# back-to-back on the SAME runner, and diffs them with benchstat. The
+# same-machine delta cancels most shared-runner noise; allocs/op is
+# deterministic regardless. This job is TREND-ONLY: it publishes the delta
+# for a human to read in the run's step summary and does not gate the PR.
+
+on:
+  pull_request:
+    paths:
+      - "internal/daemon/**"
+      - "internal/transcript/**"
+      - "**/*_bench_test.go"
+      - ".github/workflows/bench-ab.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Defined once, reused verbatim for both the head and base runs so the
+  # comparison is apples-to-apples.
+  #   -run '^$'   : skip normal tests (also sidesteps the known pre-existing
+  #                 data race in internal/daemon tests)
+  #   -benchmem   : report B/op and allocs/op alongside ns/op
+  #   -count 6    : enough samples for benchstat to say something meaningful
+  #   no -race    : race instrumentation would distort the perf numbers
+  BENCH_CMD: "go test -run '^$' -bench . -benchmem -count 6 ./internal/daemon/ ./internal/transcript/"
+
+jobs:
+  bench-ab:
+    name: Bench A/B (base vs head)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: Bench PR head
+        run: |
+          echo "Running: $BENCH_CMD"
+          eval "$BENCH_CMD" 2>&1 | tee head.txt || true
+          if [ ! -s head.txt ]; then
+            echo "::warning::head.txt is empty; the benchmark run on HEAD produced no output"
+          fi
+
+      - name: Checkout PR base
+        run: |
+          # Make sure a local origin/main ref exists as a fallback for
+          # workflow_dispatch runs, where there is no PR base SHA.
+          git fetch origin main --quiet || true
+
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          if [ -n "$BASE_SHA" ]; then
+            git checkout "$BASE_SHA"
+          else
+            git checkout origin/main
+          fi
+
+      - name: Bench PR base
+        run: |
+          echo "Running: $BENCH_CMD"
+          eval "$BENCH_CMD" 2>&1 | tee base.txt || true
+          if [ ! -s base.txt ]; then
+            echo "::warning::base.txt is empty; the benchmark run on BASE produced no output"
+          fi
+
+      - name: Compute benchstat delta
+        if: always()
+        run: |
+          benchstat base.txt head.txt | tee delta.txt || true
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo "## Bench A/B (base → head, same runner)"
+            echo '```'
+            cat delta.txt 2>/dev/null || echo "(no delta produced)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-ab-results
+          path: |
+            base.txt
+            head.txt
+            delta.txt
+          if-no-files-found: warn
+
+      # Trend-only: this job never fails a PR on the benchmark delta. If a
+      # prior step recorded a warning (e.g. empty output), that is visible
+      # in the run's annotations and step summary, but does not flip the
+      # job red.
+      - name: Always succeed
+        if: always()
+        run: exit 0


### PR DESCRIPTION
## What

Adds `.github/workflows/bench-ab.yml`: the last piece of the perf-testing
initiative — a same-machine A/B Go-benchmark CI job.

## Why same-machine A/B

`ns/op` from Go benchmarks is too noisy on GitHub's shared runners for an
absolute threshold to mean anything. The fix: run the *same* benchmarks
(`BenchmarkEncodePtyOutput_*` in `internal/daemon`, `BenchmarkExtractLastAssistantTurn*`
in `internal/transcript`) on both the PR base and the PR head, back-to-back
on the *same* runner, then diff with `benchstat`. The same-machine delta
cancels most runner noise. `allocs/op` is deterministic regardless of
machine and is the primary signal to watch.

## Trend-only — never gates

This job **never fails a PR** on the delta. It:
- runs on `pull_request` (path-filtered to `internal/daemon/**`,
  `internal/transcript/**`, and `**/*_bench_test.go`, plus `workflow_dispatch`
  for manual runs)
- checks out HEAD, runs the bench command, writes `head.txt`
- checks out `base.sha` (falls back to `origin/main` for `workflow_dispatch`),
  re-runs the same command, writes `base.txt`
- runs `benchstat base.txt head.txt`, appends the delta to the run's
  `$GITHUB_STEP_SUMMARY` under a `## Bench A/B (base → head, same runner)`
  heading, and uploads `base.txt`/`head.txt`/`delta.txt` as an artifact
- always exits 0 — no threshold check, by design

Bench command (defined once, reused for both checkouts):
```
go test -run '^$' -bench . -benchmem -count 6 ./internal/daemon/ ./internal/transcript/
```
`-run '^$'` skips normal tests (and the known pre-existing data race in
`internal/daemon` tests); no `-race` (would distort perf numbers); `-count 6`
gives benchstat enough samples.

Action versions matched from the repo's existing workflows (`ci.yml`,
`release-preflight.yml`): `actions/checkout@v4`, `actions/setup-go@v5` with
`go-version: "1.22"`, `actions/upload-artifact@v4`. No existing workflow
uses a `concurrency` group or `go-version-file`, so this one doesn't either,
to stay consistent.

`docs/perf-testing.md` (which currently says the CI job is "forthcoming")
does not exist on `main` yet, so no doc update is included here — it lives
only on an unmerged branch.

## Verified locally

- `go test -run '^$' -bench . -benchmem -count 2 ./internal/daemon/ ./internal/transcript/`
  produced `BenchmarkEncodePtyOutput_*` and `BenchmarkExtractLastAssistantTurn*`
  lines with `allocs/op`, as expected.
- `benchstat head.txt head.txt` (self-comparison smoke test) parsed the
  format cleanly and printed a `~ (p=1.000)` delta table.
- YAML structure validated with Ruby's `Psych` (`on:` parses as the boolean
  key `true` under YAML 1.1 — confirmed this is a pre-existing quirk shared
  by every other workflow in the repo, not specific to this file); triggers,
  paths, job name, and all 10 step names round-tripped correctly.

The real proof is the first live run on this PR — the orchestrator will
watch it.

https://claude.ai/code/session_01CZQx8e5SPw2zFhWK4w9yYt