### PR TITLE
test(perf): cold vs warm RSS from a dedicated clean perf profile

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,7 @@
     "real-app:bridge-perf": "node scripts/real-app-harness/bridge-perf.mjs",
     "real-app:bridge-pty-bench": "node scripts/real-app-harness/bridge-pty-bench.mjs",
     "real-app:scenario-perf-baseline": "node scripts/real-app-harness/scenario-perf-baseline.mjs",
+    "real-app:scenario-perf-cold-warm": "node scripts/real-app-harness/scenario-perf-cold-warm.mjs",
     "real-app:bridge-cli": "node scripts/real-app-harness/ui-automation-cli.mjs",
     "real-app:scenario-tr201": "node scripts/real-app-harness/scenario-tr201-local-relaunch-existing-split.mjs",
     "real-app:scenario-tr204": "node scripts/real-app-harness/scenario-tr204-local-relaunch-formatting.mjs",

--- a/app/scripts/real-app-harness/perfMeasure.mjs
+++ b/app/scripts/real-app-harness/perfMeasure.mjs
@@ -1,0 +1,226 @@
+// Shared measurement + lifecycle primitives for the perf scenarios
+// (scenario-perf-baseline.mjs, scenario-perf-cold-warm.mjs). Side-effect-free:
+// importing this module runs nothing.
+
+import fs from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { daemonPidFilePathForProfile, dataDirForProfile } from './harnessProfile.mjs';
+
+const execFileAsync = promisify(execFile);
+export const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function readProcessTable() {
+  const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,%cpu=,rss=,comm=,command=']);
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(\d+)\s+([\d.]+)\s+(\d+)\s+(\S+)\s+(.*)$/);
+      if (!match) return null;
+      return {
+        pid: Number(match[1]),
+        ppid: Number(match[2]),
+        cpuPct: Number(match[3]),
+        rssKb: Number(match[4]),
+        comm: match[5],
+        command: match[6],
+      };
+    })
+    .filter(Boolean);
+}
+
+export function collectDescendantPids(processes, rootPid) {
+  const childrenByParent = new Map();
+  for (const proc of processes) {
+    const siblings = childrenByParent.get(proc.ppid) || [];
+    siblings.push(proc.pid);
+    childrenByParent.set(proc.ppid, siblings);
+  }
+  const visited = new Set([rootPid]);
+  const queue = [rootPid];
+  while (queue.length > 0) {
+    const pid = queue.shift();
+    for (const childPid of childrenByParent.get(pid) || []) {
+      if (visited.has(childPid)) continue;
+      visited.add(childPid);
+      queue.push(childPid);
+    }
+  }
+  return visited;
+}
+
+// WebKit content/GPU/networking processes are reparented to launchd, so they
+// are NOT descendants of the app pid and must be matched by command.
+export function isRelevantWebKitProcess(proc) {
+  return proc.command.includes('com.apple.WebKit.WebContent')
+    || proc.command.includes('com.apple.WebKit.Networking')
+    || proc.command.includes('com.apple.WebKit.GPU');
+}
+
+export async function captureWebKitPids() {
+  const table = await readProcessTable();
+  return new Set(table.filter(isRelevantWebKitProcess).map((proc) => proc.pid));
+}
+
+export function classify(proc) {
+  const command = proc.command;
+  if (command.includes('pty-worker')) return 'pty_worker';
+  if (command.includes('attn daemon')) return 'daemon';
+  if (command.includes('/Contents/MacOS/app')) return 'app';
+  if (command.includes('com.apple.WebKit.WebContent')) return 'webkit_webcontent';
+  if (command.includes('com.apple.WebKit.Networking')) return 'webkit_networking';
+  if (command.includes('com.apple.WebKit.GPU')) return 'webkit_gpu';
+  // Login shell spawned inside each pty-worker (the session's own workload, not
+  // attn overhead). Track it separately so per-session attn cost stays clear.
+  if (/\/(fish|zsh|bash|dash|tcsh|ksh)( |$)|\/sh( |$)/.test(command)) return 'shell';
+  return proc.comm;
+}
+
+// Snapshot the RSS of the dev app tree: descendants of the app pid (WebKit) plus
+// descendants of the daemon pid (one pty-worker per session) plus any explicitly
+// known pids. Targeting these specific roots isolates the dev tree from a
+// possibly-running prod daemon (both share the `attn daemon` command string).
+export async function snapshot(appPid, daemonPid, webkitBaseline = new Set(), extraPids = []) {
+  const table = await readProcessTable();
+  const pidSet = new Set();
+  for (const pid of collectDescendantPids(table, appPid)) pidSet.add(pid);
+  if (daemonPid) for (const pid of collectDescendantPids(table, daemonPid)) pidSet.add(pid);
+  // Attribute any WebKit process that appeared after the pre-launch baseline to
+  // this app (they reparent to launchd, so a tree walk misses them). This is
+  // where the WS-1 atlas canvas + GPU texture memory lives.
+  for (const proc of table) {
+    if (isRelevantWebKitProcess(proc) && !webkitBaseline.has(proc.pid)) pidSet.add(proc.pid);
+  }
+  for (const pid of extraPids) pidSet.add(pid);
+
+  const procs = table.filter((proc) => pidSet.has(proc.pid));
+  const byClass = {};
+  let totalRssKb = 0;
+  for (const proc of procs) {
+    const label = classify(proc);
+    const entry = byClass[label] || { count: 0, rssKb: 0, rssMaxKb: 0, pids: [] };
+    entry.count += 1;
+    entry.rssKb += proc.rssKb;
+    entry.rssMaxKb = Math.max(entry.rssMaxKb, proc.rssKb);
+    entry.pids.push({ pid: proc.pid, rssKb: proc.rssKb });
+    byClass[label] = entry;
+    totalRssKb += proc.rssKb;
+  }
+  return {
+    totalRssMb: Number((totalRssKb / 1024).toFixed(1)),
+    procCount: procs.length,
+    byClass: Object.fromEntries(
+      Object.entries(byClass).map(([label, entry]) => [label, {
+        count: entry.count,
+        rssMb: Number((entry.rssKb / 1024).toFixed(1)),
+        rssMaxMb: Number((entry.rssMaxKb / 1024).toFixed(1)),
+        pids: entry.pids,
+      }]),
+    ),
+  };
+}
+
+export function classRssMb(snap, label) {
+  return snap?.byClass?.[label]?.rssMb ?? 0;
+}
+
+// Sample RSS repeatedly over a window and return the peak (by total RSS) and the
+// last sample. Used to catch the transient/retained spike from heavy output.
+export async function sampleWindow(appPid, daemonPid, webkitBaseline, windowMs, intervalMs = 1000) {
+  const samples = [];
+  const deadline = Date.now() + windowMs;
+  while (Date.now() < deadline) {
+    samples.push(await snapshot(appPid, daemonPid, webkitBaseline));
+    await delay(intervalMs);
+  }
+  if (samples.length === 0) samples.push(await snapshot(appPid, daemonPid, webkitBaseline));
+  const peak = samples.reduce((best, current) => (current.totalRssMb > best.totalRssMb ? current : best), samples[0]);
+  return { peak, last: samples[samples.length - 1], count: samples.length };
+}
+
+// Read the authoritative daemon pid from the profile's pid file, returning it
+// only if that process is still alive. This is pprof-independent: it is how the
+// default (non-ATTN_PPROF) baseline still attributes daemon + pty-worker RSS,
+// since the detached daemon and its workers are not descendants of the app pid.
+export function readLiveDaemonPid(profile) {
+  let pid = null;
+  try {
+    pid = Number(fs.readFileSync(daemonPidFilePathForProfile(profile), 'utf8').trim());
+  } catch {
+    return null;
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  try { process.kill(pid, 0); } catch { return null; } // stale pid file
+  return pid;
+}
+
+// Stop the detached daemon for the given profile via its pid file. Only ever
+// touches ~/.attn-<profile> (or ~/.attn for prod), never another profile's.
+export async function stopDaemon(profile) {
+  const pid = readLiveDaemonPid(profile);
+  if (pid == null) return null;
+  try { process.kill(pid, 'SIGTERM'); } catch { return null; }
+  for (let i = 0; i < 50; i += 1) {
+    try { process.kill(pid, 0); } catch { return pid; }
+    await delay(200);
+  }
+  try { process.kill(pid, 'SIGKILL'); } catch {}
+  return pid;
+}
+
+// Tear a NON-PROD profile down to empty on-disk state: quit its app (so the app
+// cannot auto-respawn the daemon after we kill it), stop the detached daemon,
+// then wipe its data dir (SQLite store, pid file, socket, worker logs). Does NOT
+// relaunch — the caller captures a WebKit-pid baseline (captureWebKitPids) after
+// teardown and before launchFreshApp, exactly like scenario-perf-baseline does.
+// Hard-refuses prod: wiping ~/.attn would destroy the user's real data.
+export async function teardownProfileState({ client, profile, wipe = true }) {
+  if (!profile || profile === 'default') {
+    throw new Error(`teardownProfileState refuses an empty/prod profile (got ${JSON.stringify(profile)})`);
+  }
+  const dataDir = dataDirForProfile(profile);
+  if (dataDir === dataDirForProfile('')) {
+    throw new Error(`teardownProfileState refuses to wipe the prod data dir ${dataDir}`);
+  }
+  await client.quitApp();
+  await stopDaemon(profile);
+  if (wipe) {
+    try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch {}
+  }
+}
+
+export async function paneIdForSession(client, sessionId) {
+  const ws = await client.request('get_workspace', { sessionId }, { timeoutMs: 10_000 });
+  return ws.activePaneId || ws.panes?.[0]?.paneId || null;
+}
+
+// Close sessions through the automation bridge (the daemon-level close). The
+// observer's WS `unregister` is rejected without the workspace_sessions
+// capability, so close_session is the supported cleanup path.
+export async function closeSessions(client, ids) {
+  for (const sessionId of ids) {
+    await client.request('close_session', { sessionId }, { timeoutMs: 15_000 }).catch(() => {});
+  }
+}
+
+// Run `cmd` in every pane, one at a time, to grow each Ghostty WASM heap + atlas
+// so the warm-set sweep measures realistic (used) idle panes rather than the
+// empty floor. Sequential with a per-pane settle to avoid overrunning the
+// websocket's 256-message buffer (see AGENTS.md) by flooding all panes at once.
+export async function fillAllPanes(client, sessionIds, cmd, perPaneSettleMs) {
+  let filled = 0;
+  for (const sessionId of sessionIds) {
+    const paneId = await paneIdForSession(client, sessionId);
+    if (!paneId) {
+      console.warn(`[perf] fill: no pane for session ${sessionId}`);
+      continue;
+    }
+    await client.request('write_pane', { sessionId, paneId, text: cmd }, { timeoutMs: 30_000 })
+      .catch((error) => console.warn(`[perf] fill write_pane ${sessionId} failed: ${error.message}`));
+    filled += 1;
+    await delay(perPaneSettleMs);
+  }
+  console.log(`[perf] filled ${filled}/${sessionIds.length} panes with \`${cmd}\``);
+}

--- a/app/scripts/real-app-harness/rssBaselineVerdict.mjs
+++ b/app/scripts/real-app-harness/rssBaselineVerdict.mjs
@@ -62,3 +62,33 @@ export function buildBaselineVerdict({ ok, comparison, scenarioId, runId, artifa
     metrics: { totalRssMb: comparison.value, ...extraMetrics },
   };
 }
+
+// Pure: builds the single ATTN_VERDICT payload for the cold/warm RSS scenario.
+// `cold` and `warm` are `comparison` objects (the shape evaluateRssBaseline /
+// compareToBaseline returns: { ok, value, baseline, deltaPct, tolerancePct, reason }).
+// ok is the AND of both phases; failureCount counts the regressing phases;
+// firstFailure names the first regressor (cold before warm), capped like the
+// core contract. Extends the core verdict with `rss: { cold, warm }` and
+// `metrics: { coldRssMb, warmRssMb }` (parity with buildBaselineVerdict's
+// extension, for the leak-soak consumer).
+export function buildColdWarmVerdict({ cold, warm, scenarioId, runId, artifactsDir, summaryPath, durationMs }) {
+  const ok = cold.ok && warm.ok;
+  const failureCount = (cold.ok ? 0 : 1) + (warm.ok ? 0 : 1);
+  const regressionLine = (label, c) =>
+    `${label} RSS regression: ${c.value}MB vs baseline ${c.baseline}MB (+${c.deltaPct}%, tolerance ${c.tolerancePct}%)`;
+  let firstFailure = null;
+  if (!cold.ok) firstFailure = truncateFirstFailure(regressionLine('Cold', cold));
+  else if (!warm.ok) firstFailure = truncateFirstFailure(regressionLine('Warm', warm));
+  return {
+    ok,
+    scenarioId,
+    runId,
+    failureCount,
+    firstFailure,
+    artifactsDir,
+    summaryPath,
+    durationMs,
+    rss: { cold, warm },
+    metrics: { coldRssMb: cold.value, warmRssMb: warm.value },
+  };
+}

--- a/app/scripts/real-app-harness/rssBaselineVerdict.test.mjs
+++ b/app/scripts/real-app-harness/rssBaselineVerdict.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildBaselineVerdict, evaluateRssBaseline } from './rssBaselineVerdict.mjs';
+import { buildBaselineVerdict, buildColdWarmVerdict, evaluateRssBaseline } from './rssBaselineVerdict.mjs';
 
 const fingerprint = {
   key: 'abc123def456',
@@ -159,5 +159,98 @@ describe('buildBaselineVerdict', () => {
     });
 
     expect(verdict.metrics).toEqual({ totalRssMb: 500, retainedMb: 12.3 });
+  });
+});
+
+describe('buildColdWarmVerdict', () => {
+  const okComparison = (value) => ({ ok: true, value, baseline: value - 10, deltaPct: 1.4, tolerancePct: 15, reason: 'within-band' });
+  const regressingComparison = (value) => ({ ok: false, value, baseline: 700, deltaPct: 28.6, tolerancePct: 15, reason: 'regression' });
+
+  it('builds a passing verdict when both phases are within band', () => {
+    const cold = okComparison(720);
+    const warm = okComparison(910);
+
+    const verdict = buildColdWarmVerdict({
+      cold,
+      warm,
+      scenarioId: 'perf-cold-warm',
+      runId: 'perf-cold-warm-2026-07-05T00-00-00-000Z',
+      artifactsDir: '/tmp/attn-real-app-harness/perf-cold-warm-run',
+      summaryPath: '/tmp/attn-real-app-harness/perf-cold-warm-run/summary.json',
+      durationMs: 4321,
+    });
+
+    expect(verdict.ok).toBe(true);
+    expect(verdict.failureCount).toBe(0);
+    expect(verdict.firstFailure).toBeNull();
+    expect(verdict.metrics).toEqual({ coldRssMb: 720, warmRssMb: 910 });
+    expect(verdict.rss).toEqual({ cold, warm });
+    expect(verdict.scenarioId).toBe('perf-cold-warm');
+    expect(verdict.runId).toBe('perf-cold-warm-2026-07-05T00-00-00-000Z');
+    expect(verdict.artifactsDir).toBe('/tmp/attn-real-app-harness/perf-cold-warm-run');
+    expect(verdict.summaryPath).toBe('/tmp/attn-real-app-harness/perf-cold-warm-run/summary.json');
+    expect(verdict.durationMs).toBe(4321);
+  });
+
+  it('fails with the cold regression line when only cold regresses', () => {
+    const cold = regressingComparison(900);
+    const warm = okComparison(910);
+
+    const verdict = buildColdWarmVerdict({
+      cold,
+      warm,
+      scenarioId: 'perf-cold-warm',
+      runId: 'run-1',
+      artifactsDir: '/tmp/run',
+      summaryPath: '/tmp/run/summary.json',
+      durationMs: 100,
+    });
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failureCount).toBe(1);
+    expect(verdict.firstFailure.startsWith('Cold RSS regression:')).toBe(true);
+    expect(verdict.firstFailure).toContain('900MB');
+    expect(verdict.firstFailure).toContain('700MB');
+    expect(verdict.firstFailure).toContain('28.6%');
+    expect(verdict.firstFailure).toContain('tolerance 15%');
+  });
+
+  it('fails with the warm regression line when only warm regresses', () => {
+    const cold = okComparison(720);
+    const warm = regressingComparison(900);
+
+    const verdict = buildColdWarmVerdict({
+      cold,
+      warm,
+      scenarioId: 'perf-cold-warm',
+      runId: 'run-1',
+      artifactsDir: '/tmp/run',
+      summaryPath: '/tmp/run/summary.json',
+      durationMs: 100,
+    });
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failureCount).toBe(1);
+    expect(verdict.firstFailure.startsWith('Warm RSS regression:')).toBe(true);
+  });
+
+  it('reports both failures but names cold first when both regress', () => {
+    const cold = regressingComparison(900);
+    const warm = regressingComparison(950);
+
+    const verdict = buildColdWarmVerdict({
+      cold,
+      warm,
+      scenarioId: 'perf-cold-warm',
+      runId: 'run-1',
+      artifactsDir: '/tmp/run',
+      summaryPath: '/tmp/run/summary.json',
+      durationMs: 100,
+    });
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failureCount).toBe(2);
+    expect(verdict.firstFailure.startsWith('Cold RSS regression:')).toBe(true);
+    expect(verdict.firstFailure).toContain('900MB');
   });
 });

--- a/app/scripts/real-app-harness/scenario-perf-baseline.mjs
+++ b/app/scripts/real-app-harness/scenario-perf-baseline.mjs
@@ -32,17 +32,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import http from 'node:http';
-import { execFile, spawn } from 'node:child_process';
-import { promisify } from 'node:util';
+import { spawn } from 'node:child_process';
 import { DaemonObserver } from './daemonObserver.mjs';
 import { createRunContext, createSessionAndWaitForInitialPane, emitVerdict, parseCommonArgs, printCommonHelp } from './common.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
-import { daemonPidFilePathForProfile, profileForAppPath, socketPathForProfile } from './harnessProfile.mjs';
+import { profileForAppPath, socketPathForProfile } from './harnessProfile.mjs';
 import { getMachineFingerprint, loadBaseline, saveBaseline } from './machineRegistry.mjs';
 import { buildBaselineVerdict, evaluateRssBaseline } from './rssBaselineVerdict.mjs';
-
-const execFileAsync = promisify(execFile);
-const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+import { delay, captureWebKitPids, snapshot, classRssMb, sampleWindow, readLiveDaemonPid, stopDaemon, paneIdForSession, closeSessions, fillAllPanes } from './perfMeasure.mjs';
 
 function parseArgs(argv) {
   const filtered = argv.filter((arg) => arg !== '--');
@@ -129,179 +126,6 @@ function httpGetToFile(port, urlPath, outPath, timeoutMs = 60_000) {
   });
 }
 
-async function readProcessTable() {
-  const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,%cpu=,rss=,comm=,command=']);
-  return stdout
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const match = line.match(/^(\d+)\s+(\d+)\s+([\d.]+)\s+(\d+)\s+(\S+)\s+(.*)$/);
-      if (!match) return null;
-      return {
-        pid: Number(match[1]),
-        ppid: Number(match[2]),
-        cpuPct: Number(match[3]),
-        rssKb: Number(match[4]),
-        comm: match[5],
-        command: match[6],
-      };
-    })
-    .filter(Boolean);
-}
-
-function collectDescendantPids(processes, rootPid) {
-  const childrenByParent = new Map();
-  for (const proc of processes) {
-    const siblings = childrenByParent.get(proc.ppid) || [];
-    siblings.push(proc.pid);
-    childrenByParent.set(proc.ppid, siblings);
-  }
-  const visited = new Set([rootPid]);
-  const queue = [rootPid];
-  while (queue.length > 0) {
-    const pid = queue.shift();
-    for (const childPid of childrenByParent.get(pid) || []) {
-      if (visited.has(childPid)) continue;
-      visited.add(childPid);
-      queue.push(childPid);
-    }
-  }
-  return visited;
-}
-
-// WebKit content/GPU/networking processes are reparented to launchd, so they
-// are NOT descendants of the app pid and must be matched by command.
-function isRelevantWebKitProcess(proc) {
-  return proc.command.includes('com.apple.WebKit.WebContent')
-    || proc.command.includes('com.apple.WebKit.Networking')
-    || proc.command.includes('com.apple.WebKit.GPU');
-}
-
-async function captureWebKitPids() {
-  const table = await readProcessTable();
-  return new Set(table.filter(isRelevantWebKitProcess).map((proc) => proc.pid));
-}
-
-function classify(proc) {
-  const command = proc.command;
-  if (command.includes('pty-worker')) return 'pty_worker';
-  if (command.includes('attn daemon')) return 'daemon';
-  if (command.includes('/Contents/MacOS/app')) return 'app';
-  if (command.includes('com.apple.WebKit.WebContent')) return 'webkit_webcontent';
-  if (command.includes('com.apple.WebKit.Networking')) return 'webkit_networking';
-  if (command.includes('com.apple.WebKit.GPU')) return 'webkit_gpu';
-  // Login shell spawned inside each pty-worker (the session's own workload, not
-  // attn overhead). Track it separately so per-session attn cost stays clear.
-  if (/\/(fish|zsh|bash|dash|tcsh|ksh)( |$)|\/sh( |$)/.test(command)) return 'shell';
-  return proc.comm;
-}
-
-// Snapshot the RSS of the dev app tree: descendants of the app pid (WebKit) plus
-// descendants of the daemon pid (one pty-worker per session) plus any explicitly
-// known pids. Targeting these specific roots isolates the dev tree from a
-// possibly-running prod daemon (both share the `attn daemon` command string).
-async function snapshot(appPid, daemonPid, webkitBaseline = new Set(), extraPids = []) {
-  const table = await readProcessTable();
-  const pidSet = new Set();
-  for (const pid of collectDescendantPids(table, appPid)) pidSet.add(pid);
-  if (daemonPid) for (const pid of collectDescendantPids(table, daemonPid)) pidSet.add(pid);
-  // Attribute any WebKit process that appeared after the pre-launch baseline to
-  // this app (they reparent to launchd, so a tree walk misses them). This is
-  // where the WS-1 atlas canvas + GPU texture memory lives.
-  for (const proc of table) {
-    if (isRelevantWebKitProcess(proc) && !webkitBaseline.has(proc.pid)) pidSet.add(proc.pid);
-  }
-  for (const pid of extraPids) pidSet.add(pid);
-
-  const procs = table.filter((proc) => pidSet.has(proc.pid));
-  const byClass = {};
-  let totalRssKb = 0;
-  for (const proc of procs) {
-    const label = classify(proc);
-    const entry = byClass[label] || { count: 0, rssKb: 0, rssMaxKb: 0, pids: [] };
-    entry.count += 1;
-    entry.rssKb += proc.rssKb;
-    entry.rssMaxKb = Math.max(entry.rssMaxKb, proc.rssKb);
-    entry.pids.push({ pid: proc.pid, rssKb: proc.rssKb });
-    byClass[label] = entry;
-    totalRssKb += proc.rssKb;
-  }
-  return {
-    totalRssMb: Number((totalRssKb / 1024).toFixed(1)),
-    procCount: procs.length,
-    byClass: Object.fromEntries(
-      Object.entries(byClass).map(([label, entry]) => [label, {
-        count: entry.count,
-        rssMb: Number((entry.rssKb / 1024).toFixed(1)),
-        rssMaxMb: Number((entry.rssMaxKb / 1024).toFixed(1)),
-        pids: entry.pids,
-      }]),
-    ),
-  };
-}
-
-function classRssMb(snap, label) {
-  return snap?.byClass?.[label]?.rssMb ?? 0;
-}
-
-// Sample RSS repeatedly over a window and return the peak (by total RSS) and the
-// last sample. Used to catch the transient/retained spike from heavy output.
-async function sampleWindow(appPid, daemonPid, webkitBaseline, windowMs, intervalMs = 1000) {
-  const samples = [];
-  const deadline = Date.now() + windowMs;
-  while (Date.now() < deadline) {
-    samples.push(await snapshot(appPid, daemonPid, webkitBaseline));
-    await delay(intervalMs);
-  }
-  if (samples.length === 0) samples.push(await snapshot(appPid, daemonPid, webkitBaseline));
-  const peak = samples.reduce((best, current) => (current.totalRssMb > best.totalRssMb ? current : best), samples[0]);
-  return { peak, last: samples[samples.length - 1], count: samples.length };
-}
-
-// Read the authoritative daemon pid from the profile's pid file, returning it
-// only if that process is still alive. This is pprof-independent: it is how the
-// default (non-ATTN_PPROF) baseline still attributes daemon + pty-worker RSS,
-// since the detached daemon and its workers are not descendants of the app pid.
-function readLiveDaemonPid(profile) {
-  let pid = null;
-  try {
-    pid = Number(fs.readFileSync(daemonPidFilePathForProfile(profile), 'utf8').trim());
-  } catch {
-    return null;
-  }
-  if (!Number.isInteger(pid) || pid <= 0) return null;
-  try { process.kill(pid, 0); } catch { return null; } // stale pid file
-  return pid;
-}
-
-async function stopDevDaemon() {
-  // Only ever touches the dev profile pid file (~/.attn-dev), never prod (~/.attn).
-  const pid = readLiveDaemonPid('dev');
-  if (pid == null) return null;
-  try { process.kill(pid, 'SIGTERM'); } catch { return null; }
-  for (let i = 0; i < 50; i += 1) {
-    try { process.kill(pid, 0); } catch { return pid; }
-    await delay(200);
-  }
-  try { process.kill(pid, 'SIGKILL'); } catch {}
-  return pid;
-}
-
-async function paneIdForSession(client, sessionId) {
-  const ws = await client.request('get_workspace', { sessionId }, { timeoutMs: 10_000 });
-  return ws.activePaneId || ws.panes?.[0]?.paneId || null;
-}
-
-// Close sessions through the automation bridge (the daemon-level close). The
-// observer's WS `unregister` is rejected without the workspace_sessions
-// capability, so close_session is the supported cleanup path.
-async function closeSessions(client, ids) {
-  for (const sessionId of ids) {
-    await client.request('close_session', { sessionId }, { timeoutMs: 15_000 }).catch(() => {});
-  }
-}
-
 async function waitForSessionsGone(observer, predicate, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -354,26 +178,6 @@ function reportSessionState(bin, socketPath, sessionId, state) {
     child.on('close', () => resolve());
     child.on('error', () => resolve());
   });
-}
-
-// Run `cmd` in every pane, one at a time, to grow each Ghostty WASM heap + atlas
-// so the warm-set sweep measures realistic (used) idle panes rather than the
-// empty floor. Sequential with a per-pane settle to avoid overrunning the
-// websocket's 256-message buffer (see AGENTS.md) by flooding all panes at once.
-async function fillAllPanes(client, sessionIds, cmd, perPaneSettleMs) {
-  let filled = 0;
-  for (const sessionId of sessionIds) {
-    const paneId = await paneIdForSession(client, sessionId);
-    if (!paneId) {
-      console.warn(`[perf] fill: no pane for session ${sessionId}`);
-      continue;
-    }
-    await client.request('write_pane', { sessionId, paneId, text: cmd }, { timeoutMs: 30_000 })
-      .catch((error) => console.warn(`[perf] fill write_pane ${sessionId} failed: ${error.message}`));
-    filled += 1;
-    await delay(perPaneSettleMs);
-  }
-  console.log(`[perf] filled ${filled}/${sessionIds.length} panes with \`${cmd}\``);
 }
 
 async function markSessionsIdle(client, options, sessionIds) {
@@ -471,7 +275,7 @@ async function main() {
 
   try {
     if (port && options.restartDaemon) {
-      const killed = await stopDevDaemon();
+      const killed = await stopDaemon('dev');
       console.log(`[perf] stopped dev daemon pid=${killed ?? 'none'} so a fresh one inherits ATTN_PPROF=${port}`);
     }
 

--- a/app/scripts/real-app-harness/scenario-perf-cold-warm.mjs
+++ b/app/scripts/real-app-harness/scenario-perf-cold-warm.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+// Cold vs warm RSS scenario.
+//
+// scenario-perf-baseline.mjs's single RSS number self-baselines against its
+// OWN prior history: a freshly launched app and one that has cycled sessions
+// for a while land at very different footprints, so its headline number is
+// not reproducible run-to-run on the same machine. This scenario captures TWO
+// reproducible numbers instead, each preceded by a full data-dir wipe so
+// neither depends on prior app history:
+//
+//   cold = fresh app + N sessions, measured right after settle (no history)
+//   warm = fresh app + N sessions + a bounded per-pane warmup burst (grows the
+//          Ghostty WASM heaps/atlas), then settle -- the worked-then-idle
+//          footprint
+//
+// Requires a dedicated non-prod profile app bundle (one-time
+// `make install PROFILE=perf`) and is driven with `ATTN_HARNESS_PROFILE=perf`
+// -- wiping ~/.attn-dev or (far worse) ~/.attn between phases is not
+// acceptable, so this scenario refuses to run against the dev sibling or prod.
+//
+// Usage:
+//   ATTN_HARNESS_PROFILE=perf pnpm run real-app:scenario-perf-cold-warm -- --sessions 8
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { createRunContext, createSessionAndWaitForInitialPane, emitVerdict, parseCommonArgs, printCommonHelp } from './common.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { profileForAppPath, assertProductionRunAllowed } from './harnessProfile.mjs';
+import { getMachineFingerprint, loadBaseline, saveBaseline } from './machineRegistry.mjs';
+import { buildColdWarmVerdict, evaluateRssBaseline } from './rssBaselineVerdict.mjs';
+import { delay, captureWebKitPids, snapshot, classRssMb, readLiveDaemonPid, paneIdForSession, closeSessions, fillAllPanes, teardownProfileState } from './perfMeasure.mjs';
+
+function parseArgs(argv) {
+  const filtered = argv.filter((arg) => arg !== '--');
+  const passthrough = [];
+  const extras = {
+    sessions: 8,
+    settleMs: 4000,
+    warmupCmd: 'seq 1 60000',
+    warmupSettleMs: 3000,
+    rssTolerancePct: 15,
+    recordBaseline: false,
+  };
+  for (let index = 0; index < filtered.length; index += 1) {
+    const arg = filtered[index];
+    if (arg === '--sessions') extras.sessions = Number(filtered[++index]);
+    else if (arg === '--settle-ms') extras.settleMs = Number(filtered[++index]);
+    else if (arg === '--warmup-cmd') extras.warmupCmd = filtered[++index];
+    else if (arg === '--warmup-settle-ms') extras.warmupSettleMs = Number(filtered[++index]);
+    else if (arg === '--rss-tolerance-pct') extras.rssTolerancePct = Number(filtered[++index]);
+    else if (arg === '--record-baseline') extras.recordBaseline = true;
+    else passthrough.push(arg);
+  }
+  const options = parseCommonArgs(passthrough);
+  return Object.assign(options, extras);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printCommonHelp('scripts/real-app-harness/scenario-perf-cold-warm.mjs');
+    console.log('  --sessions <n>            Shell sessions to create per phase (default: 8)');
+    console.log('  --settle-ms <n>           Settle time before each snapshot (default: 4000)');
+    console.log('  --warmup-cmd <cmd>        Per-pane warmup command for the warm phase, run once');
+    console.log('                            per pane to grow its Ghostty WASM heap (default: "seq 1 60000")');
+    console.log('  --warmup-settle-ms <n>    Settle time after the warmup burst, before the warm');
+    console.log('                            snapshot (default: 3000)');
+    console.log('  --rss-tolerance-pct <n>   Allowed growth over each phase\'s per-machine baseline');
+    console.log('                            before the verdict fails (default: 15)');
+    console.log('  --record-baseline         Overwrite both the cold and warm per-machine baselines');
+    console.log('                            with this run\'s RSS instead of comparing against them');
+    console.log('');
+    console.log('Requires a dedicated non-prod profile: run `make install PROFILE=perf` once, then');
+    console.log('drive this scenario with ATTN_HARNESS_PROFILE=perf.');
+    return;
+  }
+
+  const startedAt = Date.now();
+  const profile = profileForAppPath(options.appPath);
+  assertProductionRunAllowed({ appPath: options.appPath, wsUrl: options.wsUrl });
+  if (!profile || profile === 'dev') {
+    throw new Error(
+      'scenario-perf-cold-warm needs a DEDICATED non-prod profile, distinct from the shared dev '
+      + 'sibling -- each phase wipes its data dir, so it must never be prod (~/.attn) or the dev '
+      + 'world (~/.attn-dev) that attn-on-attn iteration depends on. Set ATTN_HARNESS_PROFILE=perf '
+      + 'and run `make install PROFILE=perf` once if you haven\'t already.',
+    );
+  }
+
+  const { runId, runDir, sessionDir } = createRunContext(options, 'perf-cold-warm');
+  const client = new UiAutomationClient({ appPath: options.appPath });
+
+  async function runPhase({ warmup }) {
+    await teardownProfileState({ client, profile });
+    const webkitBaseline = await captureWebKitPids();
+
+    await client.launchFreshApp();
+    await client.waitForManifest(20_000);
+    await client.waitForReady(20_000);
+    await client.waitForFrontendResponsive(20_000);
+
+    const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+    await observer.connect();
+    try {
+      const appPid = client.readManifest().pid;
+      const daemonPid = readLiveDaemonPid(profile);
+      if (!daemonPid) {
+        console.warn('[perf] WARNING: no live daemon pid file found; daemon + pty-worker RSS are NOT included in this phase');
+      }
+
+      const sessionIds = [];
+      for (let i = 0; i < options.sessions; i += 1) {
+        const label = `perf-cold-warm-${runId}-${i}`;
+        const sessionId = await createSessionAndWaitForInitialPane({
+          client,
+          observer,
+          cwd: sessionDir,
+          label,
+          agent: 'shell',
+          sessionWaitMs: 30_000,
+          waitForInitialPaneVisible: true,
+          initialPaneWaitMs: 25_000,
+        });
+        sessionIds.push(sessionId);
+        console.log(`[perf] created session ${i + 1}/${options.sessions} (${sessionId})`);
+      }
+
+      await delay(options.settleMs);
+
+      if (warmup) {
+        await fillAllPanes(client, sessionIds, options.warmupCmd, options.warmupSettleMs);
+        await delay(options.settleMs);
+      }
+
+      const snap = await snapshot(appPid, daemonPid, webkitBaseline);
+      console.log(`[perf] ${warmup ? 'WARM' : 'COLD'} @ ${options.sessions} sessions: ${snap.totalRssMb} MB (${snap.procCount} procs)`);
+
+      await closeSessions(client, sessionIds);
+      return snap;
+    } finally {
+      await observer.close();
+    }
+  }
+
+  const coldSnap = await runPhase({ warmup: false });
+  const warmSnap = await runPhase({ warmup: true });
+
+  // Compare each phase against its own key in the per-machine registry (see
+  // machineRegistry.mjs). Never affects the process exit code -- a regression
+  // is a trend signal, not a harness error.
+  const fingerprint = getMachineFingerprint();
+  const recordedAt = new Date().toISOString();
+  const coldKey = `${fingerprint.key}-cold`;
+  const warmKey = `${fingerprint.key}-warm`;
+  const coldEval = evaluateRssBaseline({
+    totalRssMb: coldSnap.totalRssMb,
+    fingerprint,
+    baseline: loadBaseline(coldKey),
+    tolerancePct: options.rssTolerancePct,
+    record: options.recordBaseline,
+    recordedAt,
+  });
+  const warmEval = evaluateRssBaseline({
+    totalRssMb: warmSnap.totalRssMb,
+    fingerprint,
+    baseline: loadBaseline(warmKey),
+    tolerancePct: options.rssTolerancePct,
+    record: options.recordBaseline,
+    recordedAt,
+  });
+  if (coldEval.baselineToSave) saveBaseline(coldKey, coldEval.baselineToSave);
+  if (warmEval.baselineToSave) saveBaseline(warmKey, warmEval.baselineToSave);
+
+  if (coldEval.baselineToSave) {
+    console.log(`[perf] recorded cold baseline for machine ${coldKey}: ${coldSnap.totalRssMb} MB`);
+  } else {
+    console.log(
+      `[perf] compared to cold baseline for machine ${coldKey}: ${coldEval.comparison.value} MB `
+      + `vs ${coldEval.comparison.baseline} MB (${coldEval.comparison.reason}, tolerance ${coldEval.comparison.tolerancePct}%)`,
+    );
+  }
+  if (warmEval.baselineToSave) {
+    console.log(`[perf] recorded warm baseline for machine ${warmKey}: ${warmSnap.totalRssMb} MB`);
+  } else {
+    console.log(
+      `[perf] compared to warm baseline for machine ${warmKey}: ${warmEval.comparison.value} MB `
+      + `vs ${warmEval.comparison.baseline} MB (${warmEval.comparison.reason}, tolerance ${warmEval.comparison.tolerancePct}%)`,
+    );
+  }
+
+  const summary = {
+    ok: coldEval.ok && warmEval.ok,
+    runId,
+    runDir,
+    sessions: options.sessions,
+    warmupCmd: options.warmupCmd,
+    cold: { totalRssMb: coldSnap.totalRssMb, byClass: coldSnap.byClass },
+    warm: { totalRssMb: warmSnap.totalRssMb, byClass: warmSnap.byClass },
+    coldComparison: coldEval.comparison,
+    warmComparison: warmEval.comparison,
+    headline: {
+      coldRssMb: coldSnap.totalRssMb,
+      warmRssMb: warmSnap.totalRssMb,
+      deltaMb: Number((warmSnap.totalRssMb - coldSnap.totalRssMb).toFixed(1)),
+    },
+  };
+  const summaryPath = path.join(runDir, 'summary.json');
+  fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+
+  console.log(JSON.stringify({ headline: summary.headline, coldByClass: coldSnap.byClass, warmByClass: warmSnap.byClass, runDir }, null, 2));
+
+  // A regression against either phase's machine baseline is a trend signal,
+  // not a harness error: it surfaces as verdict.ok:false but never sets a
+  // non-zero exit code (only real errors do that, via main().catch below).
+  emitVerdict(buildColdWarmVerdict({
+    cold: coldEval.comparison,
+    warm: warmEval.comparison,
+    scenarioId: 'perf-cold-warm',
+    runId,
+    artifactsDir: runDir,
+    summaryPath,
+    durationMs: Date.now() - startedAt,
+  }));
+}
+
+main().catch((error) => {
+  console.error('[perf] Failed.');
+  console.error(error instanceof Error ? error.stack || error.message : error);
+  process.exitCode = 1;
+});

--- a/docs/perf-testing.md
+++ b/docs/perf-testing.md
@@ -114,3 +114,44 @@ trend to investigate, not a build break.
 the headline number (per-process-class RSS, worker count, optional warm-set
 sweep, optional real-output peak/retained RSS) plus `baselineComparison`, the
 same object as the verdict's `rss` field.
+
+## Cold vs warm RSS (dedicated perf profile)
+
+`scenario-perf-baseline.mjs`'s single RSS number depends on the app's own
+history: a freshly launched app and one that has cycled sessions for a while
+land at very different footprints, so that headline number isn't reproducible
+run-to-run on the same machine. `scenario-perf-cold-warm.mjs` instead captures
+two numbers, each measured from a wiped data dir, so both ARE reproducible:
+
+- **Cold**: fresh app + N sessions, measured immediately after settle (no
+  history).
+- **Warm**: fresh app + N sessions + a per-pane warmup burst (grows the
+  Ghostty WASM heaps/atlas), then settle — the worked-then-idle footprint.
+
+Each phase wipes the profile's data dir before it runs, so this scenario needs
+its own dedicated non-prod profile: run `make install PROFILE=perf` once to
+build `~/Applications/attn-perf.app` (its own bundle id, data dir, and port),
+then drive the scenario with `ATTN_HARNESS_PROFILE=perf`. Runs are sequential —
+the packaged app is single-tenant, same as every other real-app scenario.
+
+Run it:
+
+```bash
+ATTN_HARNESS_PROFILE=perf pnpm --dir app run real-app:scenario-perf-cold-warm -- --sessions 8
+```
+
+Record or update the machine baseline the same way as the single-number
+baseline:
+
+```bash
+ATTN_HARNESS_PROFILE=perf pnpm --dir app run real-app:scenario-perf-cold-warm -- --sessions 8 --record-baseline
+```
+
+### Registry
+
+Cold and warm each self-baseline independently, stored under separate keys
+(`<fingerprint>-cold` and `<fingerprint>-warm`) in the same per-machine
+registry described above. Each compares within `--rss-tolerance-pct` (default
+15%) of its own baseline. As with the single-number baseline, a regression
+sets the verdict's `ok` to `false` but never sets a non-zero exit code — it's
+a trend signal for a human to look at, not a build break.


### PR DESCRIPTION
## What

Adds `scenario-perf-cold-warm` — two **reproducible** RSS numbers for the packaged app, replacing the history-dependent single number from `scenario-perf-baseline`.

`scenario-perf-baseline`'s headline self-baselines against its *own prior history*: a freshly launched app and one that has cycled sessions land at very different footprints, so the number is not reproducible run-to-run on the same machine. Measured here: **1162 MB** (history-polluted, its empty floor was already 675 MB from the still-running app) vs **776 MB** clean.

The new scenario captures two numbers, **each preceded by a full data-dir wipe** so neither depends on prior app history:

| phase | what it measures |
|-------|------------------|
| **cold** | fresh app + N sessions, measured right after settle (no history) |
| **warm** | fresh app + N sessions + a bounded per-pane warmup burst, then settle — the worked-then-idle footprint (grows the Ghostty WASM heaps/atlas) |

## Dedicated perf profile

Each phase wipes its data dir, so the scenario **refuses prod (`~/.attn`) and the dev sibling (`~/.attn-dev`)** — it needs a dedicated profile:

```bash
make install PROFILE=perf                       # one-time
ATTN_HARNESS_PROFILE=perf pnpm --dir app run real-app:scenario-perf-cold-warm -- --sessions 8
```

Each phase compares against its own per-machine registry key (`<fingerprint>-cold` / `-warm`, reusing the merged registry from #487). A regression is a **trend signal, never a non-zero exit** — only real errors fail the process.

## Shared primitives

The measurement + lifecycle helpers (process table, `snapshot`, `sampleWindow`, daemon pid, session fill/close) are extracted verbatim into `perfMeasure.mjs` so both scenarios share one copy. `scenario-perf-baseline` becomes a behavior-preserving re-point onto the module (`stopDevDaemon` → `stopDaemon('dev')`). `buildColdWarmVerdict` builds the single `ATTN_VERDICT` for both phases (cold before warm on `firstFailure`).

## Verification

Live on the dedicated `perf` profile (Apple M5, 32GB):

- **cold 776.2 MB / warm 842.8 MB (+66.6)** — both self-baselined into the registry under distinct `-cold`/`-warm` keys; verdict `ok:true`, contract-shaped.
- `scenario-perf-baseline` runs **clean on the same fresh build** (`ok:true`, exit 0), exercising the full extracted surface (`sampleWindow`, `readProcessTable`, `classify`, …) — proving the extraction changed no behavior.
- `rssBaselineVerdict.test.mjs`: 12/12 pass (added 4 `buildColdWarmVerdict` cases).

https://claude.ai/code/session_01CZQx8e5SPw2zFhWK4w9yYt