### PR TITLE
test(perf): leak-soak retained-RSS slope scenario

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "real-app:bridge-pty-bench": "node scripts/real-app-harness/bridge-pty-bench.mjs",
     "real-app:scenario-perf-baseline": "node scripts/real-app-harness/scenario-perf-baseline.mjs",
     "real-app:scenario-perf-cold-warm": "node scripts/real-app-harness/scenario-perf-cold-warm.mjs",
+    "real-app:scenario-perf-leak-soak": "node scripts/real-app-harness/scenario-perf-leak-soak.mjs",
     "real-app:bridge-cli": "node scripts/real-app-harness/ui-automation-cli.mjs",
     "real-app:scenario-tr201": "node scripts/real-app-harness/scenario-tr201-local-relaunch-existing-split.mjs",
     "real-app:scenario-tr204": "node scripts/real-app-harness/scenario-tr204-local-relaunch-formatting.mjs",

--- a/app/scripts/real-app-harness/rssBaselineVerdict.mjs
+++ b/app/scripts/real-app-harness/rssBaselineVerdict.mjs
@@ -92,3 +92,77 @@ export function buildColdWarmVerdict({ cold, warm, scenarioId, runId, artifactsD
     metrics: { coldRssMb: cold.value, warmRssMb: warm.value },
   };
 }
+
+// Pure: least-squares linear regression of `points` (y) against x = 0..n-1.
+// Standard closed form: slope = (n*sum(x*y) - sum(x)*sum(y)) / (n*sum(x^2) -
+// sum(x)^2). `slope` is rounded to 2 decimals -- it is the leak-soak
+// scenario's headline number (MB of retained RSS growth per cycle).
+export function fitSlope(points) {
+  if (points.length < 2) {
+    throw new Error('fitSlope needs at least 2 points');
+  }
+  const n = points.length;
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+  for (let x = 0; x < n; x += 1) {
+    const y = points[x];
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumXX += x * x;
+  }
+  const denominator = n * sumXX - sumX * sumX;
+  const slope = (n * sumXY - sumX * sumY) / denominator;
+  const intercept = (sumY - slope * sumX) / n;
+  return { slope: Number(slope.toFixed(2)), intercept };
+}
+
+// Pure: builds the ATTN_VERDICT payload for the leak-soak scenario.
+// `retainedByCycle` is the full per-cycle retained-RSS series (including the
+// warmup cycles); `slope` is the pre-fitted (fitSlope) trend over the
+// post-warmup portion -- this function does not fit it itself so the caller
+// can log/record intermediate values (e.g. the machine registry comparison)
+// before building the verdict. Extends the core verdict with `rss` and
+// `metrics`, in parity with buildBaselineVerdict/buildColdWarmVerdict.
+export function buildLeakSoakVerdict({
+  retainedByCycle,
+  warmupCycles,
+  slope,
+  slopeThresholdMb,
+  scenarioId,
+  runId,
+  artifactsDir,
+  summaryPath,
+  durationMs,
+}) {
+  const ok = slope <= slopeThresholdMb;
+  const failureCount = ok ? 0 : 1;
+  let firstFailure = null;
+  if (!ok) {
+    const post = retainedByCycle.slice(warmupCycles);
+    const firstPost = post[0];
+    const lastPost = post[post.length - 1];
+    firstFailure = truncateFirstFailure(
+      `Retained-RSS leak: slope ${slope}MB/cycle over ${retainedByCycle.length - warmupCycles} post-warmup cycles `
+      + `exceeds ${slopeThresholdMb}MB/cycle (retained ${firstPost}->${lastPost}MB)`,
+    );
+  }
+  return {
+    ok,
+    scenarioId,
+    runId,
+    failureCount,
+    firstFailure,
+    artifactsDir,
+    summaryPath,
+    durationMs,
+    rss: { retainedByCycle, warmupCycles, slope, slopeThresholdMb },
+    metrics: {
+      retainedRssSlopeMbPerCycle: slope,
+      firstRetainedMb: retainedByCycle[0],
+      lastRetainedMb: retainedByCycle[retainedByCycle.length - 1],
+    },
+  };
+}

--- a/app/scripts/real-app-harness/rssBaselineVerdict.test.mjs
+++ b/app/scripts/real-app-harness/rssBaselineVerdict.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildBaselineVerdict, buildColdWarmVerdict, evaluateRssBaseline } from './rssBaselineVerdict.mjs';
+import { buildBaselineVerdict, buildColdWarmVerdict, buildLeakSoakVerdict, evaluateRssBaseline, fitSlope } from './rssBaselineVerdict.mjs';
 
 const fingerprint = {
   key: 'abc123def456',
@@ -252,5 +252,106 @@ describe('buildColdWarmVerdict', () => {
     expect(verdict.failureCount).toBe(2);
     expect(verdict.firstFailure.startsWith('Cold RSS regression:')).toBe(true);
     expect(verdict.firstFailure).toContain('900MB');
+  });
+});
+
+describe('fitSlope', () => {
+  it('returns slope 0 for a flat series', () => {
+    const { slope, intercept } = fitSlope([100, 100, 100, 100]);
+
+    expect(slope).toBe(0);
+    expect(intercept).toBeCloseTo(100, 5);
+  });
+
+  it('returns the exact slope for a perfect staircase', () => {
+    const { slope, intercept } = fitSlope([100, 110, 120, 130]);
+
+    expect(slope).toBe(10);
+    expect(intercept).toBeCloseTo(100, 5);
+  });
+
+  it('returns a slope near 0 for a noisy-but-flat series', () => {
+    const { slope } = fitSlope([100, 102, 98, 101, 99, 100]);
+
+    expect(Math.abs(slope)).toBeLessThan(1);
+  });
+
+  it('throws when given fewer than 2 points', () => {
+    expect(() => fitSlope([100])).toThrow('fitSlope needs at least 2 points');
+    expect(() => fitSlope([])).toThrow('fitSlope needs at least 2 points');
+  });
+});
+
+describe('buildLeakSoakVerdict', () => {
+  it('builds a passing verdict when the slope is below the threshold', () => {
+    const retainedByCycle = [500, 501, 500, 500.5, 500.2, 500.8];
+
+    const verdict = buildLeakSoakVerdict({
+      retainedByCycle,
+      warmupCycles: 2,
+      slope: 0.1,
+      slopeThresholdMb: 5,
+      scenarioId: 'perf-leak-soak',
+      runId: 'perf-leak-soak-2026-07-05T00-00-00-000Z',
+      artifactsDir: '/tmp/attn-real-app-harness/perf-leak-soak-run',
+      summaryPath: '/tmp/attn-real-app-harness/perf-leak-soak-run/summary.json',
+      durationMs: 4321,
+    });
+
+    expect(verdict).toEqual({
+      ok: true,
+      scenarioId: 'perf-leak-soak',
+      runId: 'perf-leak-soak-2026-07-05T00-00-00-000Z',
+      failureCount: 0,
+      firstFailure: null,
+      artifactsDir: '/tmp/attn-real-app-harness/perf-leak-soak-run',
+      summaryPath: '/tmp/attn-real-app-harness/perf-leak-soak-run/summary.json',
+      durationMs: 4321,
+      rss: { retainedByCycle, warmupCycles: 2, slope: 0.1, slopeThresholdMb: 5 },
+      metrics: { retainedRssSlopeMbPerCycle: 0.1, firstRetainedMb: 500, lastRetainedMb: 500.8 },
+    });
+  });
+
+  it('builds a failing verdict with a one-line leak message and failureCount 1 when the slope exceeds the threshold', () => {
+    const retainedByCycle = [500, 520, 500, 510, 530, 550];
+
+    const verdict = buildLeakSoakVerdict({
+      retainedByCycle,
+      warmupCycles: 2,
+      slope: 15,
+      slopeThresholdMb: 5,
+      scenarioId: 'perf-leak-soak',
+      runId: 'run-1',
+      artifactsDir: '/tmp/run',
+      summaryPath: '/tmp/run/summary.json',
+      durationMs: 100,
+    });
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failureCount).toBe(1);
+    expect(verdict.firstFailure).toContain('Retained-RSS leak');
+    expect(verdict.firstFailure.length).toBeLessThanOrEqual(300);
+    expect(verdict.firstFailure).toContain('15MB/cycle');
+    expect(verdict.firstFailure).toContain('500->550MB');
+  });
+
+  it('passes when the slope is exactly equal to the threshold (boundary)', () => {
+    const retainedByCycle = [500, 505, 510, 515];
+
+    const verdict = buildLeakSoakVerdict({
+      retainedByCycle,
+      warmupCycles: 1,
+      slope: 5,
+      slopeThresholdMb: 5,
+      scenarioId: 'perf-leak-soak',
+      runId: 'run-1',
+      artifactsDir: '/tmp/run',
+      summaryPath: '/tmp/run/summary.json',
+      durationMs: 100,
+    });
+
+    expect(verdict.ok).toBe(true);
+    expect(verdict.failureCount).toBe(0);
+    expect(verdict.firstFailure).toBeNull();
   });
 });

--- a/app/scripts/real-app-harness/scenario-perf-leak-soak.mjs
+++ b/app/scripts/real-app-harness/scenario-perf-leak-soak.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+
+// Leak-soak RSS scenario.
+//
+// scenario-perf-cold-warm.mjs takes two single-cycle snapshots, each preceded
+// by a full data-dir wipe, so it can compare a reproducible cold footprint
+// against a reproducible warm footprint -- but it can never see a leak that
+// only accumulates WITHIN a single continuous process. This scenario runs N
+// create -> workload -> close cycles inside ONE long-lived app instance (NO
+// wipe between cycles -- the leak only accumulates within a single continuous
+// process), sampling RETAINED RSS after a decay hold each cycle (the LAST
+// sample of a decay window, never the peak -- macOS scavenges freed pages
+// lazily, so only a settled sample reflects what the process is actually
+// holding onto). It then fits the least-squares slope of retained-RSS-vs-cycle
+// across the post-warmup cycles: a flat slope is healthy churn, a positive
+// staircase is a leak.
+//
+// Requires a dedicated non-prod profile app bundle (one-time
+// `make install PROFILE=perf`) and is driven with `ATTN_HARNESS_PROFILE=perf`
+// -- like scenario-perf-cold-warm.mjs, this scenario refuses to run against
+// the dev sibling or prod.
+//
+// Usage:
+//   ATTN_HARNESS_PROFILE=perf pnpm run real-app:scenario-perf-leak-soak -- --cycles 12
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { createRunContext, createSessionAndWaitForInitialPane, emitVerdict, parseCommonArgs, printCommonHelp } from './common.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+import { profileForAppPath, assertProductionRunAllowed } from './harnessProfile.mjs';
+import { getMachineFingerprint, loadBaseline, saveBaseline } from './machineRegistry.mjs';
+import { buildLeakSoakVerdict, evaluateRssBaseline, fitSlope } from './rssBaselineVerdict.mjs';
+import { captureWebKitPids, readLiveDaemonPid, closeSessions, fillAllPanes, sampleWindow, teardownProfileState } from './perfMeasure.mjs';
+
+function parseArgs(argv) {
+  const filtered = argv.filter((arg) => arg !== '--');
+  const passthrough = [];
+  const extras = {
+    cycles: 12,
+    sessions: 6,
+    workloadCmd: 'seq 1 60000',
+    reclaimHoldMs: 8000,
+    perPaneSettleMs: 3000,
+    warmupCycles: 2,
+    slopeThresholdMb: 5,
+    recordBaseline: false,
+  };
+  for (let index = 0; index < filtered.length; index += 1) {
+    const arg = filtered[index];
+    if (arg === '--cycles') extras.cycles = Number(filtered[++index]);
+    else if (arg === '--sessions') extras.sessions = Number(filtered[++index]);
+    else if (arg === '--workload-cmd') extras.workloadCmd = filtered[++index];
+    else if (arg === '--reclaim-hold-ms') extras.reclaimHoldMs = Number(filtered[++index]);
+    else if (arg === '--per-pane-settle-ms') extras.perPaneSettleMs = Number(filtered[++index]);
+    else if (arg === '--warmup-cycles') extras.warmupCycles = Number(filtered[++index]);
+    else if (arg === '--slope-threshold-mb') extras.slopeThresholdMb = Number(filtered[++index]);
+    else if (arg === '--record-baseline') extras.recordBaseline = true;
+    else passthrough.push(arg);
+  }
+  const options = parseCommonArgs(passthrough);
+  return Object.assign(options, extras);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printCommonHelp('scripts/real-app-harness/scenario-perf-leak-soak.mjs');
+    console.log('  --cycles <n>              Create->workload->close cycles to run in one app instance (default: 12)');
+    console.log('  --sessions <n>            Shell sessions to create per cycle (default: 6)');
+    console.log('  --workload-cmd <cmd>      Per-pane workload command run once per pane each cycle');
+    console.log('                            (default: "seq 1 60000")');
+    console.log('  --reclaim-hold-ms <n>     Decay-hold window after closing each cycle\'s sessions, before');
+    console.log('                            sampling the retained RSS for that cycle (default: 8000)');
+    console.log('  --per-pane-settle-ms <n>  Settle time after writing the workload command into each pane');
+    console.log('                            (default: 3000)');
+    console.log('  --warmup-cycles <n>       Leading cycles dropped from the slope fit -- they include');
+    console.log('                            one-time WASM heap growth, not a leak (default: 2)');
+    console.log('  --slope-threshold-mb <n>  Max allowed retained-RSS slope in MB/cycle before the verdict');
+    console.log('                            fails (default: 5)');
+    console.log('  --record-baseline         Overwrite this machine\'s leak-floor baseline with this run\'s');
+    console.log('                            first post-warmup retained RSS instead of comparing against it');
+    console.log('');
+    console.log('Requires a dedicated non-prod profile: run `make install PROFILE=perf` once, then');
+    console.log('drive this scenario with ATTN_HARNESS_PROFILE=perf.');
+    return;
+  }
+
+  const startedAt = Date.now();
+  const profile = profileForAppPath(options.appPath);
+  assertProductionRunAllowed({ appPath: options.appPath, wsUrl: options.wsUrl });
+  if (!profile || profile === 'dev') {
+    throw new Error(
+      'scenario-perf-leak-soak needs a DEDICATED non-prod profile, distinct from the shared dev '
+      + 'sibling -- it runs many cycles inside one long-lived app instance, so it must never be prod '
+      + '(~/.attn) or the dev world (~/.attn-dev) that attn-on-attn iteration depends on. Set '
+      + 'ATTN_HARNESS_PROFILE=perf and run `make install PROFILE=perf` once if you haven\'t already.',
+    );
+  }
+
+  if (options.cycles - options.warmupCycles < 2) {
+    throw new Error(
+      `scenario-perf-leak-soak needs at least 2 post-warmup cycles to fit a slope, but got `
+      + `cycles=${options.cycles} warmupCycles=${options.warmupCycles} (${options.cycles - options.warmupCycles} left)`,
+    );
+  }
+
+  const { runId, runDir, sessionDir } = createRunContext(options, 'perf-leak-soak');
+  const client = new UiAutomationClient({ appPath: options.appPath });
+
+  await teardownProfileState({ client, profile });
+  const webkitBaseline = await captureWebKitPids();
+
+  await client.launchFreshApp();
+  await client.waitForManifest(20_000);
+  await client.waitForReady(20_000);
+  await client.waitForFrontendResponsive(20_000);
+
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  await observer.connect();
+  const retainedByCycle = [];
+  try {
+    const appPid = client.readManifest().pid;
+    const daemonPid = readLiveDaemonPid(profile);
+    if (!daemonPid) {
+      console.warn('[perf] WARNING: no live daemon pid file found; daemon + pty-worker RSS are NOT included in this run');
+    }
+
+    for (let cycle = 0; cycle < options.cycles; cycle += 1) {
+      const sessionIds = [];
+      for (let i = 0; i < options.sessions; i += 1) {
+        const label = `perf-leak-soak-${runId}-c${cycle}-${i}`;
+        const sessionId = await createSessionAndWaitForInitialPane({
+          client,
+          observer,
+          cwd: sessionDir,
+          label,
+          agent: 'shell',
+          sessionWaitMs: 30_000,
+          waitForInitialPaneVisible: true,
+          initialPaneWaitMs: 25_000,
+        });
+        sessionIds.push(sessionId);
+      }
+
+      await fillAllPanes(client, sessionIds, options.workloadCmd, options.perPaneSettleMs);
+      await closeSessions(client, sessionIds);
+
+      // Decay hold: sample repeatedly over the window and keep only the LAST
+      // sample (retained), never the peak -- macOS scavenges freed pages
+      // lazily, so a sample taken right after close would still show the
+      // transient workload spike, not what the process actually retains.
+      const win = await sampleWindow(appPid, daemonPid, webkitBaseline, options.reclaimHoldMs);
+      retainedByCycle.push(win.last.totalRssMb);
+      console.log(`[perf] cycle ${cycle + 1}/${options.cycles}: retained ${win.last.totalRssMb} MB (peak ${win.peak.totalRssMb})`);
+    }
+  } finally {
+    await observer.close();
+  }
+
+  const post = retainedByCycle.slice(options.warmupCycles);
+  const { slope } = fitSlope(post);
+
+  // Registry comparison is an informational trend signal (mirrors cold/warm's
+  // usage of evaluateRssBaseline) -- it is NEVER what gates this scenario's
+  // verdict; the slope-vs-threshold check above is.
+  const fingerprint = getMachineFingerprint();
+  const key = `${fingerprint.key}-leak-floor`;
+  const floorEval = evaluateRssBaseline({
+    totalRssMb: post[0],
+    fingerprint,
+    baseline: loadBaseline(key),
+    tolerancePct: 15,
+    record: options.recordBaseline,
+    recordedAt: new Date().toISOString(),
+  });
+  if (floorEval.baselineToSave) saveBaseline(key, floorEval.baselineToSave);
+
+  if (floorEval.baselineToSave) {
+    console.log(`[perf] recorded leak-floor baseline for machine ${key}: ${post[0]} MB`);
+  } else {
+    console.log(
+      `[perf] compared to leak-floor baseline for machine ${key}: ${floorEval.comparison.value} MB `
+      + `vs ${floorEval.comparison.baseline} MB (${floorEval.comparison.reason}, tolerance ${floorEval.comparison.tolerancePct}%)`,
+    );
+  }
+
+  const verdict = buildLeakSoakVerdict({
+    retainedByCycle,
+    warmupCycles: options.warmupCycles,
+    slope,
+    slopeThresholdMb: options.slopeThresholdMb,
+    scenarioId: 'perf-leak-soak',
+    runId,
+    artifactsDir: runDir,
+    summaryPath: path.join(runDir, 'summary.json'),
+    durationMs: Date.now() - startedAt,
+  });
+
+  const summaryPath = path.join(runDir, 'summary.json');
+  const summary = {
+    ok: verdict.ok,
+    runId,
+    runDir,
+    cycles: options.cycles,
+    sessions: options.sessions,
+    warmupCycles: options.warmupCycles,
+    workloadCmd: options.workloadCmd,
+    slopeThresholdMb: options.slopeThresholdMb,
+    retainedByCycle,
+    postWarmupRetained: post,
+    slope,
+    floorComparison: floorEval.comparison,
+  };
+  fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+
+  console.log(JSON.stringify({ slope, slopeThresholdMb: options.slopeThresholdMb, retainedByCycle, runDir }, null, 2));
+
+  // A slope regression is a trend signal, not a harness error: it surfaces as
+  // verdict.ok:false but never sets a non-zero exit code (only real errors do
+  // that, via main().catch below).
+  emitVerdict(verdict);
+}
+
+main().catch((error) => {
+  console.error('[perf] Failed.');
+  console.error(error instanceof Error ? error.stack || error.message : error);
+  process.exitCode = 1;
+});

--- a/docs/perf-testing.md
+++ b/docs/perf-testing.md
@@ -155,3 +155,57 @@ registry described above. Each compares within `--rss-tolerance-pct` (default
 15%) of its own baseline. As with the single-number baseline, a regression
 sets the verdict's `ok` to `false` but never sets a non-zero exit code — it's
 a trend signal for a human to look at, not a build break.
+
+## Leak soak (retained-RSS slope)
+
+Cold/warm's two snapshots are each taken from a freshly wiped data dir, so
+neither can see a leak that only accumulates *within* one continuous process
+— cycling sessions inside a single long-lived app instance is exactly what a
+real user session looks like over hours of use, and it's the case cold/warm
+cannot observe. `scenario-perf-leak-soak.mjs` runs many create → workload →
+close cycles inside **one** app instance with **no wipe between cycles**, then
+fits the trend across cycles:
+
+- climbing retained RSS across cycles (a "staircase") signals a leak —
+  something from each cycle's sessions/panes/PTYs is not being freed;
+- flat retained RSS across cycles is healthy — the process is reusing the
+  memory it frees each cycle, not accumulating it.
+
+Each cycle samples RSS over a decay-hold window after closing that cycle's
+sessions and keeps only the **last** sample (retained), never the peak —
+macOS scavenges freed pages lazily, so a sample taken right after close would
+still show the workload's transient spike rather than what the process
+actually holds onto afterward. The scenario then fits a least-squares slope
+(`fitSlope` in `rssBaselineVerdict.mjs`) of retained-RSS-vs-cycle-index over
+the post-warmup cycles.
+
+Like cold/warm, this needs the dedicated perf profile (one-time
+`make install PROFILE=perf`) and refuses to run against the dev sibling or
+prod — many cycles inside one instance would otherwise pollute the shared dev
+world.
+
+Run it:
+
+```bash
+ATTN_HARNESS_PROFILE=perf pnpm --dir app run real-app:scenario-perf-leak-soak -- --cycles 12
+```
+
+### Warmup cycles and the slope threshold
+
+The first `--warmup-cycles` (default 2) are dropped from the slope fit: the
+first cycle or two typically show one-time growth (Ghostty WASM heap/atlas
+allocation, lazy daemon/pty-worker initialization) that is not a leak, and
+would otherwise bias the fitted slope upward. `--slope-threshold-mb` (default
+5) is the max allowed MB/cycle growth over the remaining post-warmup cycles
+before the verdict fails; a slope exactly at the threshold passes.
+
+### Registry
+
+The first post-warmup retained-RSS value also self-baselines against this
+machine's own history, stored under `<fingerprint>-leak-floor` in the same
+per-machine registry described above (`--record-baseline` to
+overwrite it). This is an informational trend on the starting floor, not what
+gates the scenario — the slope-vs-threshold check is. As with the other
+scenarios, a slope regression sets the verdict's `ok` to `false` but never
+sets a non-zero exit code — it's a trend signal for a human to look at, not a
+build break.


### PR DESCRIPTION
## What

Adds `scenario-perf-leak-soak` — the last test in the perf starter set (#4). It catches the memory failure users actually feel: RSS that **climbs over a long session and never comes back** (the WASM balloon; any per-operation frontend leak).

The cold/warm scenario (#490) takes two single-cycle snapshots, each from a freshly wiped data dir — so it structurally *cannot* see a leak that only accumulates **within one continuous process**. This scenario does:

- Runs **N create → workload → close cycles inside one long-lived app instance** (no wipe between cycles — cycling sessions in a single running app is what a real multi-hour user session looks like).
- Samples retained RSS after a **decay-hold window** each cycle, keeping the **last** sample (retained), **never the peak** — macOS scavenges freed pages lazily, so a sample right after close still shows the transient workload spike, not what the process actually holds.
- Fits the **least-squares slope** of retained-RSS-vs-cycle over the post-warmup cycles. Flat slope = healthy churn; a positive staircase = leak.

```bash
make install PROFILE=perf                    # one-time
ATTN_HARNESS_PROFILE=perf pnpm --dir app run real-app:scenario-perf-leak-soak -- --cycles 12
```

## Design decisions

- **Self-contained cycle loop, deliberately NOT driven by `run-soak.mjs`.** The strategy doc suggested building on the soak runner, but run-soak spawns a fresh child / relaunches the app between iterations — that resets the process and *erases* the within-process accumulation a leak needs. run-soak stays for flakiness-soaking a whole scenario, orthogonal to this measurement.
- **Warmup cycles dropped from the fit** (`--warmup-cycles`, default 2): the first cycle or two carry one-time WASM heap/atlas growth and lazy daemon/pty-worker init — not a leak — which would bias the slope upward.
- **Generous threshold + decay hold defeat both documented traps:** peak RSS is meaningless (one-way allocator), and a too-tight band on a lazily-scavenged OS reads noise as a false leak. Real data below shows ~30 MB/cycle RSS noise, so the slope-over-many-cycles fit — not any single before/after — is what gives a stable signal.
- **Gate is the slope only.** The first post-warmup retained value also self-baselines under `<fingerprint>-leak-floor` (reusing the merged registry) as an informational trend, but never gates. A slope regression sets `verdict.ok:false` but never a non-zero exit — trend signal, not build break.

New pure helpers `fitSlope` + `buildLeakSoakVerdict` in `rssBaselineVerdict.mjs`, in parity with the baseline/cold-warm builders.

## Verification

Live on the dedicated `perf` profile (Apple M5), 6 cycles:

```
retained: 891.2 / 905.7 / 941.0 / 900.5 / 873.3 / 938.5 MB
post-warmup slope: -3.47 MB/cycle  ->  ok:true
```

- The decay hold works: cycle 5 read retained **873.3 MB below its peak 906.2 MB** — the settled-vs-transient distinction the design requires.
- Leak-floor baseline recorded, verdict contract-shaped, exit 0.
- `rssBaselineVerdict.test.mjs`: **19/19** (12 existing + 7 new: `fitSlope` flat/staircase/noisy/throws, `buildLeakSoakVerdict` pass/fail/boundary).

Refuses prod and the dev sibling (each run cycles heavily inside one instance); needs the dedicated perf profile like cold/warm.

https://claude.ai/code/session_01CZQx8e5SPw2zFhWK4w9yYt