### PR TITLE
feat(reconcile): log when ground-truth annotation hits a cap

### DIFF
--- a/internal/daemon/ticket_reconcile_groundtruth.go
+++ b/internal/daemon/ticket_reconcile_groundtruth.go
@@ -57,6 +57,17 @@ type prStateFetcher func(repo string, number int) (state string, merged bool, ti
 // rather than a real PR reference.
 const groundTruthMaxPRNumber = 100000
 
+// groundTruthCaps records which best-effort limits the ground-truth
+// cross-check hit while building annotation lines. It drives a single debug
+// log line in reconcileGroundTruth; it never changes what gets annotated.
+type groundTruthCaps struct {
+	lineCap   bool // groundTruthMaxLines reached
+	lookupCap bool // groundTruthMaxLookups reached
+	timeout   bool // lookup budget (ctx) expired
+}
+
+func (c groundTruthCaps) any() bool { return c.lineCap || c.lookupCap || c.timeout }
+
 var (
 	prHashRefPattern   = regexp.MustCompile(`#(\d+)`)
 	prWordRefPattern   = regexp.MustCompile(`(?i)\bPR\s+(\d+)\b`)
@@ -132,9 +143,9 @@ var groundTruthTerminalStates = map[string]bool{
 // isn't tracked at all, produce no line — silence is the default; this only
 // fires when attn positively knows the referenced PR is finished. Capped at
 // groundTruthMaxLines lines.
-func reconcileGroundTruthLines(refs []int, repoSlug string, prs []*protocol.PR) []string {
+func reconcileGroundTruthLines(refs []int, repoSlug string, prs []*protocol.PR) (lines []string, lineCap bool) {
 	if repoSlug == "" || len(prs) == 0 || len(refs) == 0 {
-		return nil
+		return nil, false
 	}
 
 	byNumber := make(map[int]*protocol.PR, len(prs))
@@ -145,9 +156,9 @@ func reconcileGroundTruthLines(refs []int, repoSlug string, prs []*protocol.PR) 
 		byNumber[pr.Number] = pr
 	}
 
-	var lines []string
 	for _, n := range refs {
 		if len(lines) >= groundTruthMaxLines {
+			lineCap = true
 			break
 		}
 		pr, ok := byNumber[n]
@@ -159,7 +170,7 @@ func reconcileGroundTruthLines(refs []int, repoSlug string, prs []*protocol.PR) 
 		}
 		lines = append(lines, groundTruthLine(n, pr.State, pr.Title))
 	}
-	return lines
+	return lines, lineCap
 }
 
 func groundTruthLine(number int, state, title string) string {
@@ -174,21 +185,26 @@ func groundTruthLine(number int, state, title string) string {
 // can also mean "never tracked", so each candidate gets one definitive
 // lookup, capped at groundTruthMaxLookups. Merged or closed results produce a
 // line; open results, lookup errors, or a nil fetcher produce silence.
-func groundTruthUntrackedLines(ctx context.Context, refs []int, tracked map[int]bool, repoSlug string, fetch prStateFetcher) []string {
+func groundTruthUntrackedLines(ctx context.Context, refs []int, tracked map[int]bool, repoSlug string, fetch prStateFetcher) (lines []string, caps groundTruthCaps) {
 	if fetch == nil || repoSlug == "" || len(refs) == 0 {
-		return nil
+		return nil, groundTruthCaps{}
 	}
 
-	var lines []string
 	lookups := 0
 	for _, n := range refs {
 		if tracked[n] {
 			continue // tracked rows are the deterministic leg's business
 		}
-		if lookups >= groundTruthMaxLookups || len(lines) >= groundTruthMaxLines {
+		if len(lines) >= groundTruthMaxLines {
+			caps.lineCap = true
+			break
+		}
+		if lookups >= groundTruthMaxLookups {
+			caps.lookupCap = true
 			break
 		}
 		if ctx.Err() != nil {
+			caps.timeout = true
 			break // overall lookup budget spent
 		}
 		lookups++
@@ -203,7 +219,7 @@ func groundTruthUntrackedLines(ctx context.Context, refs []int, tracked map[int]
 			lines = append(lines, groundTruthLine(n, "closed", title))
 		}
 	}
-	return lines
+	return lines, caps
 }
 
 // fetchPRStateCtx runs fetch under ctx: github.Client has no context plumbing
@@ -250,7 +266,7 @@ func (d *Daemon) reconcileGroundTruth(ctx context.Context, verdict *ticketReconc
 	}
 
 	prs := d.store.ListPRsByRepo(repoSlug)
-	lines := reconcileGroundTruthLines(refs, repoSlug, prs)
+	lines, trackedLineCap := reconcileGroundTruthLines(refs, repoSlug, prs)
 
 	tracked := make(map[int]bool, len(prs))
 	for _, pr := range prs {
@@ -267,10 +283,19 @@ func (d *Daemon) reconcileGroundTruth(ctx context.Context, verdict *ticketReconc
 	}
 	lookupCtx, cancel := context.WithTimeout(ctx, groundTruthLookupTimeout)
 	defer cancel()
-	lines = append(lines, groundTruthUntrackedLines(lookupCtx, refs, tracked, repoSlug, fetch)...)
+	untracked, caps := groundTruthUntrackedLines(lookupCtx, refs, tracked, repoSlug, fetch)
+	lines = append(lines, untracked...)
+	if trackedLineCap {
+		caps.lineCap = true
+	}
 
 	if len(lines) > groundTruthMaxLines {
 		lines = lines[:groundTruthMaxLines]
+		caps.lineCap = true
+	}
+	if caps.any() {
+		d.logf("ticket reconcile ground-truth %s: annotation cap reached (lineCap=%t lookupCap=%t timeout=%t; refs=%d lines=%d)",
+			repoSlug, caps.lineCap, caps.lookupCap, caps.timeout, len(refs), len(lines))
 	}
 	return lines
 }

--- a/internal/daemon/ticket_reconcile_groundtruth_test.go
+++ b/internal/daemon/ticket_reconcile_groundtruth_test.go
@@ -95,7 +95,7 @@ func TestReconcileGroundTruthLines(t *testing.T) {
 	}
 
 	t.Run("merged PR is annotated", func(t *testing.T) {
-		lines := reconcileGroundTruthLines([]int{462}, "victorarias/attn", prs)
+		lines, _ := reconcileGroundTruthLines([]int{462}, "victorarias/attn", prs)
 		if len(lines) != 1 {
 			t.Fatalf("lines = %v, want 1", lines)
 		}
@@ -105,34 +105,34 @@ func TestReconcileGroundTruthLines(t *testing.T) {
 	})
 
 	t.Run("closed PR is annotated", func(t *testing.T) {
-		lines := reconcileGroundTruthLines([]int{470}, "victorarias/attn", prs)
+		lines, _ := reconcileGroundTruthLines([]int{470}, "victorarias/attn", prs)
 		if len(lines) != 1 || !strings.Contains(lines[0], "PR #470 is closed") {
 			t.Fatalf("lines = %v, want one closed annotation", lines)
 		}
 	})
 
 	t.Run("open PR is silent", func(t *testing.T) {
-		lines := reconcileGroundTruthLines([]int{480}, "victorarias/attn", prs)
+		lines, _ := reconcileGroundTruthLines([]int{480}, "victorarias/attn", prs)
 		if len(lines) != 0 {
 			t.Fatalf("lines = %v, want none (open PR)", lines)
 		}
 	})
 
 	t.Run("untracked PR number is silent", func(t *testing.T) {
-		lines := reconcileGroundTruthLines([]int{999}, "victorarias/attn", prs)
+		lines, _ := reconcileGroundTruthLines([]int{999}, "victorarias/attn", prs)
 		if len(lines) != 0 {
 			t.Fatalf("lines = %v, want none (untracked)", lines)
 		}
 	})
 
 	t.Run("empty repo slug yields nil", func(t *testing.T) {
-		if lines := reconcileGroundTruthLines([]int{462}, "", prs); lines != nil {
+		if lines, _ := reconcileGroundTruthLines([]int{462}, "", prs); lines != nil {
 			t.Fatalf("lines = %v, want nil", lines)
 		}
 	})
 
 	t.Run("empty pr list yields nil", func(t *testing.T) {
-		if lines := reconcileGroundTruthLines([]int{462}, "victorarias/attn", nil); lines != nil {
+		if lines, _ := reconcileGroundTruthLines([]int{462}, "victorarias/attn", nil); lines != nil {
 			t.Fatalf("lines = %v, want nil", lines)
 		}
 	})
@@ -144,9 +144,12 @@ func TestReconcileGroundTruthLines(t *testing.T) {
 			manyPRs = append(manyPRs, groundTruthTestPR(i, "merged", "t"))
 			refs = append(refs, i)
 		}
-		lines := reconcileGroundTruthLines(refs, "victorarias/attn", manyPRs)
+		lines, lineCap := reconcileGroundTruthLines(refs, "victorarias/attn", manyPRs)
 		if len(lines) != groundTruthMaxLines {
 			t.Fatalf("lines = %d, want %d (cap)", len(lines), groundTruthMaxLines)
+		}
+		if !lineCap {
+			t.Fatalf("lineCap = false, want true when %d refs exceed the %d-line cap", len(refs), groundTruthMaxLines)
 		}
 	})
 }
@@ -430,12 +433,15 @@ func TestGroundTruthUntrackedLinesCapsLookups(t *testing.T) {
 	}
 
 	refs := []int{1, 2, 3, 4, 5, 6}
-	lines := groundTruthUntrackedLines(context.Background(), refs, nil, "victorarias/attn", fetch)
+	lines, caps := groundTruthUntrackedLines(context.Background(), refs, nil, "victorarias/attn", fetch)
 	if calls != groundTruthMaxLookups {
 		t.Fatalf("fetch calls = %d, want %d (cap)", calls, groundTruthMaxLookups)
 	}
 	if len(lines) != groundTruthMaxLookups {
 		t.Fatalf("lines = %d, want %d", len(lines), groundTruthMaxLookups)
+	}
+	if !caps.lookupCap {
+		t.Fatalf("caps.lookupCap = false, want true after hitting the lookup cap")
 	}
 }
 
@@ -447,7 +453,7 @@ func TestGroundTruthUntrackedLinesSkipsTrackedRefs(t *testing.T) {
 		return "closed", true, "t", nil
 	}
 
-	lines := groundTruthUntrackedLines(context.Background(), []int{1, 2, 3},
+	lines, _ := groundTruthUntrackedLines(context.Background(), []int{1, 2, 3},
 		map[int]bool{1: true, 2: true}, "victorarias/attn", fetch)
 	if calls != 1 {
 		t.Fatalf("fetch calls = %d, want 1 (only the untracked ref)", calls)
@@ -467,10 +473,14 @@ func TestGroundTruthUntrackedLinesRespectsContext(t *testing.T) {
 		calls++
 		return "closed", true, "t", nil
 	}
-	if lines := groundTruthUntrackedLines(ctx, []int{1, 2}, nil, "victorarias/attn", fetch); len(lines) != 0 {
+	lines, caps := groundTruthUntrackedLines(ctx, []int{1, 2}, nil, "victorarias/attn", fetch)
+	if len(lines) != 0 {
 		t.Fatalf("lines = %v, want none under cancelled ctx", lines)
 	}
 	if calls != 0 {
 		t.Fatalf("fetch calls = %d, want 0 under cancelled ctx", calls)
+	}
+	if !caps.timeout {
+		t.Fatalf("caps.timeout = false, want true under cancelled ctx")
 	}
 }


### PR DESCRIPTION
The reconcile **ground-truth** cross-check (the annotate-only "Ground-truth check" lines added in #483) silently `break`/`continue`s on every limit it hits: the 5-line annotation cap (`groundTruthMaxLines`), the 3-lookup GitHub cap (`groundTruthMaxLookups`), and the 10s lookup timeout (`groundTruthLookupTimeout`). That silence made the caps invisible in practice — no signal for whether they ever needed tuning.

## What this does
- Adds a small `groundTruthCaps{lineCap, lookupCap, timeout}` threaded out of `reconcileGroundTruthLines` and `groundTruthUntrackedLines`.
- Splits the previously-combined break condition so each cap is attributed to the right flag (same stop points and priority, no behavior change).
- Emits **one** `d.logf` breadcrumb from `(*Daemon).reconcileGroundTruth` when any cap fires, tagged with repo slug, ref count, and line count.

The **annotation itself is unchanged** — same lines appended, same silence-on-failure. This only adds a debug log line so the caps can be tweaked later.

## Testing
- `go build ./...` clean; `gofmt -l` clean.
- `go test ./internal/daemon -run GroundTruth -count=1` — all pass, including 3 new assertions that `lineCap` / `lookupCap` / `timeout` are set when their limit is reached.
- No live-app run: internal-only debug logging on the reconcile path, pure control-flow attribution + one `d.logf`, fully covered by unit tests. Internal instrumentation, so no CHANGELOG entry and no protocol change.

https://claude.ai/code/session_01GsJxkhdJJgYYVPd3m5f4xx