### PR TITLE
chore(harness): dedup helpers across the agent-cost-tooling stack

### DIFF
--- a/app/scripts/real-app-harness/common.mjs
+++ b/app/scripts/real-app-harness/common.mjs
@@ -95,6 +95,12 @@ Options:
 // naive line-oriented parsing never splits it.
 export const ATTN_VERDICT_PREFIX = 'ATTN_VERDICT ';
 
+// Contract: verdict.firstFailure is capped at this length (see ATTN_VERDICT_PREFIX
+// above) so it can never contain a newline or otherwise break the one-line
+// contract. Shared by every producer of a firstFailure field (scenarioRunner.mjs,
+// rssBaselineVerdict.mjs).
+export const FIRST_FAILURE_MAX_LENGTH = 300;
+
 export function formatVerdictLine(verdict) {
   return `${ATTN_VERDICT_PREFIX}${JSON.stringify(verdict)}`;
 }

--- a/app/scripts/real-app-harness/machineRegistry.mjs
+++ b/app/scripts/real-app-harness/machineRegistry.mjs
@@ -79,6 +79,25 @@ export function saveBaseline(fingerprintKeyValue, baseline, { registryDir = DEFA
   fs.writeFileSync(localPath, `${JSON.stringify(baseline, null, 2)}\n`);
 }
 
+// Saves the baseline (when the evaluation asked for one) and logs the
+// resulting record-or-compare outcome, in the exact `[perf] recorded ...` /
+// `[perf] compared to ...` shape every perf scenario prints after calling
+// evaluateRssBaseline. `label` is an optional word (with its own trailing
+// space, e.g. 'cold ', 'warm ', 'leak-floor ') inserted between "recorded"/
+// "compared to" and "baseline" to distinguish per-phase keys; omit it for a
+// scenario with a single, unqualified baseline.
+export function recordOrCompareBaseline({ evaluation, key, label = '' }) {
+  if (evaluation.baselineToSave) {
+    saveBaseline(key, evaluation.baselineToSave);
+    console.log(`[perf] recorded ${label}baseline for machine ${key}: ${evaluation.comparison.value} MB`);
+  } else {
+    console.log(
+      `[perf] compared to ${label}baseline for machine ${key}: ${evaluation.comparison.value} MB `
+      + `vs ${evaluation.comparison.baseline} MB (${evaluation.comparison.reason}, tolerance ${evaluation.comparison.tolerancePct}%)`,
+    );
+  }
+}
+
 function readJsonIfExists(filePath) {
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));

--- a/app/scripts/real-app-harness/rssBaselineVerdict.mjs
+++ b/app/scripts/real-app-harness/rssBaselineVerdict.mjs
@@ -1,10 +1,5 @@
 import { compareToBaseline } from './machineRegistry.mjs';
-
-// Contract cap shared with scenarioRunner.mjs's summarizeFirstFailure — the
-// ATTN_VERDICT line is single-line and length-bounded, so firstFailure here
-// follows the same rule even though this scenario builds its own verdict by
-// hand instead of going through createScenarioRunner.
-const FIRST_FAILURE_MAX_LENGTH = 300;
+import { FIRST_FAILURE_MAX_LENGTH } from './common.mjs';
 
 function truncateFirstFailure(message) {
   return message.length <= FIRST_FAILURE_MAX_LENGTH ? message : message.slice(0, FIRST_FAILURE_MAX_LENGTH);
@@ -36,6 +31,15 @@ export function evaluateRssBaseline({ totalRssMb, fingerprint, baseline, toleran
   return { ok: comparison.ok, comparison, baselineToSave };
 }
 
+// Private: the 6-key envelope shared by every ATTN_VERDICT builder in this
+// file (buildBaselineVerdict / buildColdWarmVerdict / buildLeakSoakVerdict).
+// Each builder computes its own `ok`/`failureCount`/`firstFailure` (the
+// scenario-specific regression message differs per builder) and attaches its
+// own scenario-specific fields (`rss`/`metrics`) on top of this.
+function buildVerdictEnvelope({ ok, failureCount, firstFailure, scenarioId, runId, artifactsDir, summaryPath, durationMs }) {
+  return { ok, scenarioId, runId, failureCount, firstFailure, artifactsDir, summaryPath, durationMs };
+}
+
 // Pure: builds the ATTN_VERDICT payload for the RSS baseline scenario. Extends
 // the core verdict contract (see common.mjs) with two scenario-specific
 // fields, `rss` and `metrics` — existing verdict consumers only read the core
@@ -50,14 +54,7 @@ export function buildBaselineVerdict({ ok, comparison, scenarioId, runId, artifa
       );
 
   return {
-    ok,
-    scenarioId,
-    runId,
-    failureCount: ok ? 0 : 1,
-    firstFailure,
-    artifactsDir,
-    summaryPath,
-    durationMs,
+    ...buildVerdictEnvelope({ ok, failureCount: ok ? 0 : 1, firstFailure, scenarioId, runId, artifactsDir, summaryPath, durationMs }),
     rss: comparison,
     metrics: { totalRssMb: comparison.value, ...extraMetrics },
   };
@@ -80,14 +77,7 @@ export function buildColdWarmVerdict({ cold, warm, scenarioId, runId, artifactsD
   if (!cold.ok) firstFailure = truncateFirstFailure(regressionLine('Cold', cold));
   else if (!warm.ok) firstFailure = truncateFirstFailure(regressionLine('Warm', warm));
   return {
-    ok,
-    scenarioId,
-    runId,
-    failureCount,
-    firstFailure,
-    artifactsDir,
-    summaryPath,
-    durationMs,
+    ...buildVerdictEnvelope({ ok, failureCount, firstFailure, scenarioId, runId, artifactsDir, summaryPath, durationMs }),
     rss: { cold, warm },
     metrics: { coldRssMb: cold.value, warmRssMb: warm.value },
   };
@@ -150,14 +140,7 @@ export function buildLeakSoakVerdict({
     );
   }
   return {
-    ok,
-    scenarioId,
-    runId,
-    failureCount,
-    firstFailure,
-    artifactsDir,
-    summaryPath,
-    durationMs,
+    ...buildVerdictEnvelope({ ok, failureCount, firstFailure, scenarioId, runId, artifactsDir, summaryPath, durationMs }),
     rss: { retainedByCycle, warmupCycles, slope, slopeThresholdMb },
     metrics: {
       retainedRssSlopeMbPerCycle: slope,

--- a/app/scripts/real-app-harness/scenario-perf-baseline.mjs
+++ b/app/scripts/real-app-harness/scenario-perf-baseline.mjs
@@ -37,7 +37,7 @@ import { DaemonObserver } from './daemonObserver.mjs';
 import { createRunContext, createSessionAndWaitForInitialPane, emitVerdict, parseCommonArgs, printCommonHelp } from './common.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { profileForAppPath, socketPathForProfile } from './harnessProfile.mjs';
-import { getMachineFingerprint, loadBaseline, saveBaseline } from './machineRegistry.mjs';
+import { getMachineFingerprint, loadBaseline, recordOrCompareBaseline } from './machineRegistry.mjs';
 import { buildBaselineVerdict, evaluateRssBaseline } from './rssBaselineVerdict.mjs';
 import { delay, captureWebKitPids, snapshot, classRssMb, sampleWindow, readLiveDaemonPid, stopDaemon, paneIdForSession, closeSessions, fillAllPanes } from './perfMeasure.mjs';
 
@@ -613,15 +613,7 @@ async function main() {
       record: options.recordBaseline,
       recordedAt: new Date().toISOString(),
     });
-    if (rssEvaluation.baselineToSave) {
-      saveBaseline(fingerprint.key, rssEvaluation.baselineToSave);
-      console.log(`[perf] recorded baseline for machine ${fingerprint.key}: ${summary.headline.totalRssMb} MB`);
-    } else {
-      console.log(
-        `[perf] compared to baseline for machine ${fingerprint.key}: ${rssEvaluation.comparison.value} MB `
-        + `vs ${rssEvaluation.comparison.baseline} MB (${rssEvaluation.comparison.reason}, tolerance ${rssEvaluation.comparison.tolerancePct}%)`,
-      );
-    }
+    recordOrCompareBaseline({ evaluation: rssEvaluation, key: fingerprint.key });
     summary.baselineComparison = rssEvaluation.comparison;
   } finally {
     // Close every session we created so they don't persist into the next run.

--- a/app/scripts/real-app-harness/scenario-perf-cold-warm.mjs
+++ b/app/scripts/real-app-harness/scenario-perf-cold-warm.mjs
@@ -28,7 +28,7 @@ import { DaemonObserver } from './daemonObserver.mjs';
 import { createRunContext, createSessionAndWaitForInitialPane, emitVerdict, parseCommonArgs, printCommonHelp } from './common.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { profileForAppPath, assertProductionRunAllowed } from './harnessProfile.mjs';
-import { getMachineFingerprint, loadBaseline, saveBaseline } from './machineRegistry.mjs';
+import { getMachineFingerprint, loadBaseline, recordOrCompareBaseline } from './machineRegistry.mjs';
 import { buildColdWarmVerdict, evaluateRssBaseline } from './rssBaselineVerdict.mjs';
 import { delay, captureWebKitPids, snapshot, classRssMb, readLiveDaemonPid, paneIdForSession, closeSessions, fillAllPanes, teardownProfileState } from './perfMeasure.mjs';
 
@@ -170,25 +170,8 @@ async function main() {
     record: options.recordBaseline,
     recordedAt,
   });
-  if (coldEval.baselineToSave) saveBaseline(coldKey, coldEval.baselineToSave);
-  if (warmEval.baselineToSave) saveBaseline(warmKey, warmEval.baselineToSave);
-
-  if (coldEval.baselineToSave) {
-    console.log(`[perf] recorded cold baseline for machine ${coldKey}: ${coldSnap.totalRssMb} MB`);
-  } else {
-    console.log(
-      `[perf] compared to cold baseline for machine ${coldKey}: ${coldEval.comparison.value} MB `
-      + `vs ${coldEval.comparison.baseline} MB (${coldEval.comparison.reason}, tolerance ${coldEval.comparison.tolerancePct}%)`,
-    );
-  }
-  if (warmEval.baselineToSave) {
-    console.log(`[perf] recorded warm baseline for machine ${warmKey}: ${warmSnap.totalRssMb} MB`);
-  } else {
-    console.log(
-      `[perf] compared to warm baseline for machine ${warmKey}: ${warmEval.comparison.value} MB `
-      + `vs ${warmEval.comparison.baseline} MB (${warmEval.comparison.reason}, tolerance ${warmEval.comparison.tolerancePct}%)`,
-    );
-  }
+  recordOrCompareBaseline({ evaluation: coldEval, key: coldKey, label: 'cold ' });
+  recordOrCompareBaseline({ evaluation: warmEval, key: warmKey, label: 'warm ' });
 
   const summary = {
     ok: coldEval.ok && warmEval.ok,

--- a/app/scripts/real-app-harness/scenario-perf-leak-soak.mjs
+++ b/app/scripts/real-app-harness/scenario-perf-leak-soak.mjs
@@ -29,7 +29,7 @@ import { DaemonObserver } from './daemonObserver.mjs';
 import { createRunContext, createSessionAndWaitForInitialPane, emitVerdict, parseCommonArgs, printCommonHelp } from './common.mjs';
 import { UiAutomationClient } from './uiAutomationClient.mjs';
 import { profileForAppPath, assertProductionRunAllowed } from './harnessProfile.mjs';
-import { getMachineFingerprint, loadBaseline, saveBaseline } from './machineRegistry.mjs';
+import { getMachineFingerprint, loadBaseline, recordOrCompareBaseline } from './machineRegistry.mjs';
 import { buildLeakSoakVerdict, evaluateRssBaseline, fitSlope } from './rssBaselineVerdict.mjs';
 import { captureWebKitPids, readLiveDaemonPid, closeSessions, fillAllPanes, sampleWindow, teardownProfileState } from './perfMeasure.mjs';
 
@@ -174,16 +174,7 @@ async function main() {
     record: options.recordBaseline,
     recordedAt: new Date().toISOString(),
   });
-  if (floorEval.baselineToSave) saveBaseline(key, floorEval.baselineToSave);
-
-  if (floorEval.baselineToSave) {
-    console.log(`[perf] recorded leak-floor baseline for machine ${key}: ${post[0]} MB`);
-  } else {
-    console.log(
-      `[perf] compared to leak-floor baseline for machine ${key}: ${floorEval.comparison.value} MB `
-      + `vs ${floorEval.comparison.baseline} MB (${floorEval.comparison.reason}, tolerance ${floorEval.comparison.tolerancePct}%)`,
-    );
-  }
+  recordOrCompareBaseline({ evaluation: floorEval, key, label: 'leak-floor ' });
 
   const verdict = buildLeakSoakVerdict({
     retainedByCycle,

--- a/app/scripts/real-app-harness/scenarioRunner.mjs
+++ b/app/scripts/real-app-harness/scenarioRunner.mjs
@@ -2,9 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { assertPackagedAppBuildMatchesCurrentSource } from './buildPreflight.mjs';
-import { createRunContext, emitVerdict } from './common.mjs';
-
-const FIRST_FAILURE_MAX_LENGTH = 300;
+import { createRunContext, emitVerdict, FIRST_FAILURE_MAX_LENGTH } from './common.mjs';
 
 // Collapse to a single line and cap length so the verdict's firstFailure field
 // can never break the one-line ATTN_VERDICT contract regardless of what the

--- a/internal/daemon/ticket_reconcile_groundtruth_test.go
+++ b/internal/daemon/ticket_reconcile_groundtruth_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -151,22 +150,6 @@ func TestReconcileGroundTruthLines(t *testing.T) {
 	})
 }
 
-// runGitDaemonTest runs a git command in dir for setting up a test repo with
-// an origin remote — mirrors internal/git's own test helper since this test
-// lives in the daemon package and can't import unexported git test helpers.
-func runGitDaemonTest(t *testing.T, dir string, args ...string) {
-	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
-		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
-	)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git %v failed: %v\n%s", args, err, out)
-	}
-}
-
 // The end-to-end wiring test: a verdict mentioning a PR that the store
 // already knows is merged gets a Ground-truth check line appended to the
 // posted reconciliation comment, without touching the verdict fields
@@ -176,8 +159,8 @@ func TestReconcileGroundTruthAnnotatesMergedPR(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 
 	repoDir := t.TempDir()
-	runGitDaemonTest(t, repoDir, "init")
-	runGitDaemonTest(t, repoDir, "remote", "add", "origin", "git@github.com:victorarias/attn.git")
+	runGitDaemon(t, repoDir, "init")
+	runGitDaemon(t, repoDir, "remote", "add", "origin", "git@github.com:victorarias/attn.git")
 
 	ticketID := "gt-ticket"
 	if _, err := d.store.CreateTicket(store.Ticket{
@@ -245,8 +228,8 @@ func TestReconcileGroundTruthSilentWhenPROpen(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 
 	repoDir := t.TempDir()
-	runGitDaemonTest(t, repoDir, "init")
-	runGitDaemonTest(t, repoDir, "remote", "add", "origin", "git@github.com:victorarias/attn.git")
+	runGitDaemon(t, repoDir, "init")
+	runGitDaemon(t, repoDir, "remote", "add", "origin", "git@github.com:victorarias/attn.git")
 
 	ticketID := "gt-ticket-open"
 	if _, err := d.store.CreateTicket(store.Ticket{
@@ -302,8 +285,8 @@ func runGroundTruthReconcile(t *testing.T, d *Daemon, ticketID, whatsLeft string
 	t.Helper()
 
 	repoDir := t.TempDir()
-	runGitDaemonTest(t, repoDir, "init")
-	runGitDaemonTest(t, repoDir, "remote", "add", "origin", "git@github.com:victorarias/attn.git")
+	runGitDaemon(t, repoDir, "init")
+	runGitDaemon(t, repoDir, "remote", "add", "origin", "git@github.com:victorarias/attn.git")
 
 	if _, err := d.store.CreateTicket(store.Ticket{
 		ID:       ticketID,


### PR DESCRIPTION
Post-merge cleanup surfaced by a `/simplify` review of the whole agent-cost-tooling stack. **Pure dedup — no behavior change:** same test coverage, same emitted `ATTN_VERDICT` JSON, same perf-scenario log strings and saved baseline files.

## Changes
- **daemon test** — drop `runGitDaemonTest`, a byte-identical duplicate of the same-package `runGitDaemon` (`worktree_naming_test.go`); reuse the existing helper and drop the now-unused `os/exec` import.
- **perf harness** — single-source `FIRST_FAILURE_MAX_LENGTH` in `common.mjs` instead of two copies previously kept in sync by comment only.
- **perf harness** — extract one private `buildVerdictEnvelope()` so `buildBaselineVerdict` / `buildColdWarmVerdict` / `buildLeakSoakVerdict` stop repeating the shared 6-key envelope (names/signatures unchanged).
- **perf harness** — extract `recordOrCompareBaseline()` and collapse the four copy-pasted "record-or-compare-and-log" blocks across the three perf scenarios into one call each.

## Not done (reviewed, deliberately skipped)
- Consolidating the two remote-URL parsers in `internal/git/resolve.go` — would change the pre-existing `ResolveRepoDir` parsing path; the split is sound as-is.
- Fanning out the ≤3 GitHub lookups in the reconcile ground-truth check — over-engineering for a capped, infrequent path.
- Pointing the untouched `bridge-perf.mjs` / `bridge-pty-bench.mjs` at the new `perfMeasure.mjs` — correct in spirit but edits files outside this stack's scope.

## Testing
- `go build ./...` + `go test ./internal/daemon -run GroundTruth` — green.
- `vitest run` over the harness suite — 37/37 on the two touched test files; 132 pass / 0 fail across the full harness suite.
- `node --check` clean on all 7 touched `.mjs` files.
- The record-branch value substitution in `recordOrCompareBaseline` was verified: `evaluation.comparison.value` is provably equal to each site's former local (it's the same `totalRssMb` fed into `evaluateRssBaseline`), so the log output is byte-identical.
- No live-app run: the perf **scenario** files have no unit coverage, so their correctness here is by-inspection behavior-preservation (harness scripts, not shipped product); the verdict/registry logic that *is* unit-tested stays green.

https://claude.ai/code/session_01GsJxkhdJJgYYVPd3m5f4xx