### PR TITLE
Install attn skill for Copilot sessions too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-07]
+
+### Fixed
+- **Copilot sessions now receive the attn skill.** The bundled attn skill (delegation, tickets, workspace context, notebook, workflow, chief-of-staff guidance) was only ever installed to `~/.claude/skills/attn` and `~/.agents/skills/attn`, so a Copilot-driven session had no way to learn what "chief of staff" or the rest of attn's vocabulary meant. It's now also installed to `~/.copilot/skills/attn`, kept identical to the Claude/Codex copies and pruned of stale files the same way.
+
 ## [2026-07-05]
 
 ### Removed

--- a/internal/agent/attn_skill.go
+++ b/internal/agent/attn_skill.go
@@ -97,10 +97,22 @@ func ensureAttnCodexSkillInstalled() error {
 	return installAttnSkill(filepath.Join(homeDir, ".agents", "skills", "attn"))
 }
 
+func ensureAttnCopilotSkillInstalled() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory for Copilot skills: %w", err)
+	}
+	return installAttnSkill(filepath.Join(homeDir, ".copilot", "skills", "attn"))
+}
+
 func EnsureClaudeSkillInstalled() error {
 	return ensureAttnClaudeSkillInstalled()
 }
 
 func EnsureCodexSkillInstalled() error {
 	return ensureAttnCodexSkillInstalled()
+}
+
+func EnsureCopilotSkillInstalled() error {
+	return ensureAttnCopilotSkillInstalled()
 }

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -229,6 +229,44 @@ func TestEnsureAttnCodexSkillInstalled(t *testing.T) {
 	assertAttnSkillTree(t, filepath.Join(home, ".agents", "skills", "attn"))
 }
 
+func TestEnsureAttnCopilotSkillInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := ensureAttnCopilotSkillInstalled(); err != nil {
+		t.Fatalf("ensureAttnCopilotSkillInstalled() error = %v", err)
+	}
+
+	assertAttnSkillTree(t, filepath.Join(home, ".copilot", "skills", "attn"))
+}
+
+// TestEnsureAttnCopilotSkillInstalledPrunesOrphanedFiles mirrors the Claude
+// orphan-pruning guard: a stale reference retired from the bundle must not
+// survive on disk and keep teaching outdated guidance (e.g. a leftover
+// chief-of-staff.md telling a delegated leaf it can re-delegate).
+func TestEnsureAttnCopilotSkillInstalledPrunesOrphanedFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	skillDir := filepath.Join(home, ".copilot", "skills", "attn")
+	if err := os.MkdirAll(filepath.Join(skillDir, "references"), 0o755); err != nil {
+		t.Fatalf("seed skill dir: %v", err)
+	}
+	orphanFile := filepath.Join(skillDir, "references", "chief-of-staff.md")
+	if err := os.WriteFile(orphanFile, []byte("stale, retired guidance"), 0o644); err != nil {
+		t.Fatalf("seed orphaned reference: %v", err)
+	}
+
+	if err := ensureAttnCopilotSkillInstalled(); err != nil {
+		t.Fatalf("ensureAttnCopilotSkillInstalled() error = %v", err)
+	}
+
+	if _, err := os.Stat(orphanFile); !os.IsNotExist(err) {
+		t.Fatalf("orphaned reference file was not pruned: stat err = %v", err)
+	}
+	assertAttnSkillTree(t, skillDir)
+}
+
 func TestAttnSkillInstallsAreIdentical(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -239,9 +277,13 @@ func TestAttnSkillInstallsAreIdentical(t *testing.T) {
 	if err := ensureAttnCodexSkillInstalled(); err != nil {
 		t.Fatalf("ensureAttnCodexSkillInstalled() error = %v", err)
 	}
+	if err := ensureAttnCopilotSkillInstalled(); err != nil {
+		t.Fatalf("ensureAttnCopilotSkillInstalled() error = %v", err)
+	}
 
 	claudeDir := filepath.Join(home, ".claude", "skills", "attn")
 	codexDir := filepath.Join(home, ".agents", "skills", "attn")
+	copilotDir := filepath.Join(home, ".copilot", "skills", "attn")
 	for _, relative := range []string{
 		"SKILL.md",
 		"references/delegation.md",
@@ -254,8 +296,12 @@ func TestAttnSkillInstallsAreIdentical(t *testing.T) {
 	} {
 		claudeContent := readSkillFile(t, claudeDir, relative)
 		codexContent := readSkillFile(t, codexDir, relative)
+		copilotContent := readSkillFile(t, copilotDir, relative)
 		if claudeContent != codexContent {
 			t.Fatalf("%s differs between Claude and Codex installs", relative)
+		}
+		if claudeContent != copilotContent {
+			t.Fatalf("%s differs between Claude and Copilot installs", relative)
 		}
 	}
 }

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -210,6 +210,10 @@ func (d *Daemon) settingsWithAgentAvailability() map[string]interface{} {
 				if err := agentdriver.EnsureCodexSkillInstalled(); err != nil {
 					d.logf("failed to ensure Codex attn skill: %v", err)
 				}
+			case string(protocol.SessionAgentCopilot):
+				if err := agentdriver.EnsureCopilotSkillInstalled(); err != nil {
+					d.logf("failed to ensure Copilot attn skill: %v", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
The attn skill (delegation, tickets, workspace context, notebook, workflow, and chief-of-staff guidance) was only ever installed to ~/.claude/skills/attn and ~/.agents/skills/attn. Copilot-driven sessions never received it, so they had no way to learn what "chief of staff" or attn's other vocabulary meant.

Add ensureAttnCopilotSkillInstalled(), writing to
~/.copilot/skills/attn (the directory the Copilot CLI already reads skills from), and wire it into settingsWithAgentAvailability's per-agent switch alongside Claude and Codex. Extend the install tests to cover Copilot: identical tree assertion, orphan pruning, and inclusion in the cross-agent identical-install check.