### PR TITLE
Fix terminal text selection getting stuck mid-drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Copilot sessions now receive the attn skill.** The bundled attn skill (delegation, tickets, workspace context, notebook, workflow, chief-of-staff guidance) was only ever installed to `~/.claude/skills/attn` and `~/.agents/skills/attn`, so a Copilot-driven session had no way to learn what "chief of staff" or the rest of attn's vocabulary meant. It's now also installed to `~/.copilot/skills/attn`, kept identical to the Claude/Codex copies and pruned of stale files the same way.
+- **Selecting terminal text no longer occasionally gets stuck extending.** A drag-selection relied on the mouse button's release event reaching the terminal to stop, plus a `buttons`-bitmask check as a backstop. If the release happened outside the app's window (alt-tabbing away mid-drag, releasing over a native dialog, a context menu interrupting the gesture) that bitmask could go stale, so the selection kept growing on the next mouse movement even with no button held. Losing window focus or an interrupted pointer gesture now force-finalizes the selection immediately, matching the same safeguard already used for pane drag-and-drop.
 
 ## [2026-07-05]
 

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -2422,6 +2422,27 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       }
     };
 
+    // Finalize a drag that has no real release event to interpret (window
+    // lost focus, or the OS/browser canceled the implicit pointer capture,
+    // e.g. a context menu opening mid-drag). There is no cell to resolve a
+    // click, link, or command-block hit against here, so this only stops the
+    // drag and copies whatever was already selected — it must never leave
+    // selectingRef stuck true.
+    const cancelSelectionDrag = () => {
+      stopSelectionDrag();
+      if (!selectingRef.current) return;
+      selectingRef.current = false;
+      selectionPointerStartRef.current = null;
+      if (!selectionDragThresholdMetRef.current) {
+        selectionRef.current = null;
+        renderSurface(true);
+        return;
+      }
+      const text = textForSelectionRange(selectionRef.current);
+      selectedTextRef.current = text || null;
+      if (text) void writeClipboardText(text);
+    };
+
     // Track an in-progress selection on the document rather than the terminal
     // element. The drag must keep updating and finalize even when the pointer
     // crosses a sibling overlay (e.g. a split divider sitting above the pane
@@ -2433,6 +2454,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         if (!selectingRef.current || !selectionRef.current) return;
         // The button was released without a mouseup we observed (e.g. focus
         // loss while over another window): finalize so we never get stuck.
+        // `buttons` itself can go stale in WebKit (the engine Tauri uses on
+        // macOS) after a release outside the webview, which is exactly why
+        // the blur/pointercancel listeners below exist as a second net that
+        // doesn't depend on this bit being accurate.
         if ((event.buttons & 1) === 0) {
           void finishSelectionDrag(event);
           return;
@@ -2460,11 +2485,29 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       const onUp = (event: MouseEvent) => {
         void finishSelectionDrag(event);
       };
+      // Belt-and-suspenders against a real mouseup never reaching this
+      // listener at all — e.g. the release happens outside the app's window
+      // entirely, or a descendant calls stopPropagation() on the native event
+      // before it bubbles to document. `blur` fires whenever the window loses
+      // focus mid-drag (alt-tab, clicking another app, a native dialog), and
+      // `pointercancel` fires when the browser/OS revokes the implicit
+      // pointer capture (e.g. a context menu opening mid-drag) — the same
+      // pattern already used for pane drags in SessionTerminalWorkspace's
+      // leafDrag.ts. Without this, a swallowed or missed release leaves
+      // selectingRef stuck true and the selection keeps growing on the next
+      // mouse movement, even with no button held.
+      const onCancel = () => {
+        cancelSelectionDrag();
+      };
       document.addEventListener('mousemove', onMove);
       document.addEventListener('mouseup', onUp);
+      window.addEventListener('blur', onCancel);
+      window.addEventListener('pointercancel', onCancel);
       selectionDragCleanupRef.current = () => {
         document.removeEventListener('mousemove', onMove);
         document.removeEventListener('mouseup', onUp);
+        window.removeEventListener('blur', onCancel);
+        window.removeEventListener('pointercancel', onCancel);
       };
     };
 


### PR DESCRIPTION
startSelectionDrag() tracked an in-progress selection via document-level mousemove/mouseup listeners, with a fallback that force-finalizes on the next mousemove if event.buttons no longer reports the button held (to recover from a mouseup that happened outside the app). That buttons bitmask can go stale in WebKit (the engine Tauri uses on macOS) following a release outside the webview, or a real mouseup can be swallowed by a descendant calling stopPropagation() before it bubbles to document. Either way selectingRef stayed stuck true and the selection kept extending on the next pointer movement, even with no button held.

Add window 'blur' and 'pointercancel' listeners as a second, independent safety net, alongside a new cancelSelectionDrag() that finalizes (copies any threshold-crossing selection, or clears an unfinished click-only one) without needing a real MouseEvent to interpret a click/link/block hit against. This mirrors the existing pattern in
SessionTerminalWorkspace/leafDrag.ts, which already uses the same blur/pointercancel combination to guarantee pane-drag cleanup.