### PR TITLE
feat(present): multiple simultaneous comment drafts + pin diff scroll until user input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-07]
 
+### Added
+- **Comment boxes in Present are now GitHub-style.** Multiple comments can now be open at once: the hover "+" button keeps working while a draft is open, each comment saves or cancels independently, and Escape closes the most recently opened box first.
+
 ### Fixed
+- **The Present window now opens scrolled to the top.** A freshly opened diff no longer arrives scrolled away from the beginning, and the first click won't jump and misplace a comment — the diff stays anchored until you scroll it.
 - **Copilot sessions now receive the attn skill.** The bundled attn skill (delegation, tickets, workspace context, notebook, workflow, chief-of-staff guidance) was only ever installed to `~/.claude/skills/attn` and `~/.agents/skills/attn`, so a Copilot-driven session had no way to learn what "chief of staff" or the rest of attn's vocabulary meant. It's now also installed to `~/.copilot/skills/attn`, kept identical to the Claude/Codex copies and pruned of stale files the same way.
 - **Selecting terminal text no longer occasionally gets stuck extending.** A drag-selection relied on the mouse button's release event reaching the terminal to stop, plus a `buttons`-bitmask check as a backstop. If the release happened outside the app's window (alt-tabbing away mid-drag, releasing over a native dialog, a context menu interrupting the gesture) that bitmask could go stale, so the selection kept growing on the next mouse movement even with no button held. Losing window focus or an interrupted pointer gesture now force-finalizes the selection immediately, matching the same safeguard already used for pane drag-and-drop.
 

--- a/app/e2e/diff-view-comment-interactions.spec.ts
+++ b/app/e2e/diff-view-comment-interactions.spec.ts
@@ -84,13 +84,55 @@ async function realScrollTop(page: Page): Promise<number> {
   });
 }
 
+function calls(page: Page, name: string) {
+  return page.evaluate((n) => window.__HARNESS__.getCalls(n), name);
+}
+
+/**
+ * Scrolls the diff via a REAL wheel event, not a programmatic `scrollBy`.
+ * DiffView pins `.diff-view-scroller` to the top until real user input
+ * arrives (see the takeover-tracking effect in DiffView.tsx) — a JS-driven
+ * scroll here would be silently snapped back to 0 before any of these tests
+ * got to assert anything, since it doesn't count as "the user took over".
+ */
 async function scrollDown(page: Page, amount: number) {
-  await page.evaluate((amt) => {
-    const scroller = document.querySelector('.diff-view-scroller') as HTMLElement | null;
-    scroller?.scrollBy(0, amt);
-  }, amount);
+  const box = await page.locator('.diff-view-scroller').boundingBox();
+  if (box) {
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  }
+  await page.mouse.wheel(0, amount);
   // Let the virtualizer's rAF-driven render loop settle before reading scrollTop.
   await page.waitForTimeout(150);
+}
+
+/**
+ * Returns the line number of the row currently hosting the gutter utility "+"
+ * (the `[data-gutter-utility-slot]` container the library appends into a
+ * line's number cell), or null if the "+" isn't shown anywhere.
+ *
+ * `[data-gutter-utility-slot]` lives inside `diffs-container`'s OPEN shadow
+ * root (appended by InteractionManager.showUtilityOnLine into the hovered
+ * line's number element). Playwright's locator engine pierces open shadow
+ * roots to FIND the node, but a plain `page.evaluate(() =>
+ * document.querySelector(...))` does not — that returned null. Locating via
+ * `page.locator` first, then running `.evaluate()` on the resolved handle
+ * (which operates on the real DOM node and can freely walk `parentElement`
+ * regardless of shadow boundaries), is the fix.
+ *
+ * Module-scoped (rather than local to one describe block) so both the
+ * single-draft hover-death regression test and the multi-draft tests below
+ * can share it.
+ */
+async function gutterUtilityLineNumber(page: Page): Promise<number | null> {
+  const slot = page.locator('diffs-container [data-gutter-utility-slot]');
+  if ((await slot.count()) === 0) return null;
+  return slot.first().evaluate((el) => {
+    const numberCell = el.parentElement;
+    const raw =
+      numberCell?.getAttribute('data-column-number') ??
+      numberCell?.closest('[data-column-number]')?.getAttribute('data-column-number');
+    return raw != null ? Number(raw) : null;
+  });
 }
 
 test.describe('DiffView scroll preservation', () => {
@@ -252,33 +294,53 @@ test.describe('DiffView scroll preservation', () => {
   });
 });
 
-test.describe('DiffView gutter hover follows pointer', () => {
+test.describe('DiffView pins scroll to the top until the user takes over', () => {
   /**
-   * Returns the line number of the row currently hosting the gutter utility
-   * "+" (the `[data-gutter-utility-slot]` container the library appends into
-   * a line's number cell), or null if the "+" isn't shown anywhere.
-   *
-   * `[data-gutter-utility-slot]` lives inside `diffs-container`'s OPEN shadow
-   * root (appended by InteractionManager.showUtilityOnLine into the hovered
-   * line's number element). Playwright's locator engine pierces open shadow
-   * roots to FIND the node, but a plain `page.evaluate(() =>
-   * document.querySelector(...))` does not — that returned null. Locating via
-   * `page.locator` first, then running `.evaluate()` on the resolved handle
-   * (which operates on the real DOM node and can freely walk `parentElement`
-   * regardless of shadow boundaries), is the fix.
+   * Root-cause fix for the scroll-jump bugs above: on a cold present-window
+   * load, @pierre/diffs' Virtualizer can scroll `.diff-view-scroller`
+   * autonomously from garbage geometry before the user ever touches the
+   * page. DiffView now pins the scroller to 0 until real user input (wheel,
+   * touch, pointerdown, or a key press) arrives on it. This test simulates
+   * the library's own autonomous scroll with a programmatic scrollTop write
+   * (indistinguishable, from DiffView's point of view, from the library
+   * fixing up its own anchor) and expects it snapped back to the top.
    */
-  async function gutterUtilityLineNumber(page: Page): Promise<number | null> {
-    const slot = page.locator('diffs-container [data-gutter-utility-slot]');
-    if ((await slot.count()) === 0) return null;
-    return slot.first().evaluate((el) => {
-      const numberCell = el.parentElement;
-      const raw =
-        numberCell?.getAttribute('data-column-number') ??
-        numberCell?.closest('[data-column-number]')?.getAttribute('data-column-number');
-      return raw != null ? Number(raw) : null;
-    });
-  }
+  test('a programmatic scroll before any user input snaps back to the top', async ({ page }) => {
+    await openLargeDiff(page);
 
+    await page.evaluate(() => {
+      const scroller = document.querySelector('.diff-view-scroller') as HTMLElement | null;
+      if (scroller) scroller.scrollTop = 500;
+    });
+
+    await expect.poll(() => realScrollTop(page)).toBe(0);
+  });
+
+  /**
+   * Once the user has scrolled for real, the pin must disarm permanently —
+   * including for later scroll changes that are themselves programmatic
+   * (e.g. the library's own virtualization bookkeeping), not just the wheel
+   * event that armed it.
+   */
+  test('a real wheel scroll arms takeover, and later scroll changes are no longer pinned', async ({ page }) => {
+    await openLargeDiff(page);
+
+    await scrollDown(page, 300);
+    const afterWheel = await realScrollTop(page);
+    expect(afterWheel, 'the real wheel scroll itself must not be pinned').toBeGreaterThan(0);
+
+    await page.evaluate(() => {
+      const scroller = document.querySelector('.diff-view-scroller') as HTMLElement | null;
+      if (scroller) scroller.scrollTop = 500;
+    });
+    await page.waitForTimeout(150);
+
+    const after = await realScrollTop(page);
+    expect(after, 'takeover must stick for later scroll changes too').toBe(500);
+  });
+});
+
+test.describe('DiffView gutter hover follows pointer', () => {
   /**
    * BUG REPRO (known RED): after adding a comment via the gutter "+" on line
    * A, hovering a different visible line B should move the "+" to B. Against
@@ -336,5 +398,154 @@ test.describe('DiffView gutter hover follows pointer', () => {
     // (or wherever the committed selection landed) instead of following the
     // pointer to line B.
     expect(pinnedLine).toBe(numberB);
+  });
+});
+
+test.describe('DiffView multiple simultaneous drafts', () => {
+  /** Opens a draft on the given line via the gutter "+" (hover then click). */
+  async function openDraftViaGutter(page: Page, line: Locator) {
+    await line.hover();
+    const plus = page.locator('diffs-container [data-utility-button]');
+    await plus.waitFor({ state: 'visible' });
+    await plus.click();
+  }
+
+  /**
+   * Two visible rows to anchor two independent drafts on, deliberately BOTH on
+   * the additions side (context rows nth(6)/nth(7), lines 5 and 6) rather than
+   * mixing in a change-deletion row like nth(3) (line 4, deletions side).
+   * DiffView's `lineAnnotations` sorts open-form groups by `${side}:${line}`
+   * anchor key, and string comparison puts "additions:5" before "deletions:4"
+   * (side prefix wins over the numeric line) — a deletions/additions pair
+   * would NOT sort in the ascending order these tests' `forms.nth(0)` /
+   * `forms.nth(1)` indexing assumes. Same-side, ascending lines keep anchor-key
+   * order and array order in step.
+   */
+  function twoSameSideLines(page: Page): [Locator, Locator] {
+    const lineLocators = page.locator('diffs-container [data-line-index][data-column-number]');
+    return [lineLocators.nth(6), lineLocators.nth(7)];
+  }
+
+  /**
+   * GitHub-style multi-comment authoring: with a draft box open on one line,
+   * the hover "+" must keep following the pointer to OTHER lines (not just
+   * after a draft closes, which is what the single-draft regression test
+   * above already covers), and clicking it there opens an independent second
+   * box rather than overwriting the first.
+   */
+  test('hover "+" keeps following the pointer while a draft is open on another line', async ({ page }) => {
+    await openHarness(page, UNSEEDED);
+
+    const [lineA, lineB] = twoSameSideLines(page);
+    const numberB = Number(await lineB.getAttribute('data-column-number'));
+
+    await openDraftViaGutter(page, lineA);
+    await expect(page.getByTestId('diff-comment-form')).toBeVisible(); // draft A open, not saved
+
+    await lineB.hover();
+    await page.waitForTimeout(150); // let InteractionManager's pointer handlers react
+    await expect.poll(() => gutterUtilityLineNumber(page)).toBe(numberB);
+  });
+
+  test('clicking "+" on another line while a draft is open opens a second, independent draft box', async ({ page }) => {
+    await openHarness(page, UNSEEDED);
+
+    const [lineA, lineB] = twoSameSideLines(page);
+    const forms = page.getByTestId('diff-comment-form');
+
+    await openDraftViaGutter(page, lineA);
+    await expect(forms).toHaveCount(1);
+    await forms.nth(0).locator('textarea').fill('Comment A');
+
+    await openDraftViaGutter(page, lineB);
+    await expect(forms).toHaveCount(2);
+
+    // Both boxes coexist, each keeping its own typed text.
+    await expect(forms.nth(0).locator('textarea')).toHaveValue('Comment A');
+    await forms.nth(1).locator('textarea').fill('Comment B');
+    await expect(forms.nth(0).locator('textarea')).toHaveValue('Comment A');
+    await expect(forms.nth(1).locator('textarea')).toHaveValue('Comment B');
+  });
+
+  test('clicking an anchor that already has an open draft is a no-op, not an overwrite', async ({ page }) => {
+    await openHarness(page, UNSEEDED);
+
+    const lineA = page.locator('diffs-container [data-line-index][data-column-number]').nth(3);
+    await openDraftViaGutter(page, lineA);
+    const forms = page.getByTestId('diff-comment-form');
+    await expect(forms).toHaveCount(1);
+    await forms.nth(0).locator('textarea').fill('Do not lose this');
+
+    // Re-click the number cell on the same line: same anchor, must not
+    // duplicate the box or wipe its text.
+    await lineA.click();
+    await expect(forms).toHaveCount(1);
+    await expect(forms.nth(0).locator('textarea')).toHaveValue('Do not lose this');
+  });
+
+  test('saves two open drafts independently, each with its own line args', async ({ page }) => {
+    await openHarness(page, UNSEEDED);
+
+    const [lineA, lineB] = twoSameSideLines(page);
+    const forms = page.getByTestId('diff-comment-form');
+
+    await openDraftViaGutter(page, lineA);
+    await forms.nth(0).locator('textarea').fill('Comment A');
+    await openDraftViaGutter(page, lineB);
+    await expect(forms).toHaveCount(2);
+    await forms.nth(1).locator('textarea').fill('Comment B');
+
+    await forms.nth(0).locator('.save-btn').click();
+    await expect.poll(() => calls(page, 'addComment')).toHaveLength(1);
+    // The other box survives, untouched, while the first is gone.
+    await expect(forms).toHaveCount(1);
+    await expect(forms.nth(0).locator('textarea')).toHaveValue('Comment B');
+
+    await forms.nth(0).locator('.save-btn').click();
+    await expect.poll(() => calls(page, 'addComment')).toHaveLength(2);
+    await expect(forms).toHaveCount(0);
+
+    const added = (await calls(page, 'addComment')) as Array<[number, number, string]>;
+    const byContent = Object.fromEntries(added.map(([start, end, content]) => [content, [start, end]]));
+    expect(byContent['Comment A'][0]).toBe(byContent['Comment A'][1]); // single-line, additions side
+    expect(byContent['Comment B'][0]).toBe(byContent['Comment B'][1]);
+    expect(byContent['Comment A'][0]).not.toBe(byContent['Comment B'][0]); // distinct anchors
+  });
+
+  test('canceling one draft box leaves the other intact', async ({ page }) => {
+    await openHarness(page, UNSEEDED);
+
+    const [lineA, lineB] = twoSameSideLines(page);
+    const forms = page.getByTestId('diff-comment-form');
+
+    await openDraftViaGutter(page, lineA);
+    await forms.nth(0).locator('textarea').fill('Keep me');
+    await openDraftViaGutter(page, lineB);
+    await forms.nth(1).locator('textarea').fill('Cancel me');
+
+    await forms.nth(1).locator('.cancel-btn').click();
+    await expect(forms).toHaveCount(1);
+    await expect(forms.nth(0).locator('textarea')).toHaveValue('Keep me');
+    expect(await calls(page, 'addComment')).toHaveLength(0);
+  });
+
+  test('Escape closes the most-recently-opened draft first', async ({ page }) => {
+    await openHarness(page, UNSEEDED);
+
+    const [lineA, lineB] = twoSameSideLines(page);
+    const forms = page.getByTestId('diff-comment-form');
+
+    await openDraftViaGutter(page, lineA);
+    await forms.nth(0).locator('textarea').fill('Opened first');
+    await openDraftViaGutter(page, lineB);
+    await forms.nth(1).locator('textarea').fill('Opened second');
+    await expect(forms).toHaveCount(2);
+
+    await page.keyboard.press('Escape');
+    await expect(forms).toHaveCount(1);
+    await expect(forms.nth(0).locator('textarea')).toHaveValue('Opened first');
+
+    await page.keyboard.press('Escape');
+    await expect(forms).toHaveCount(0);
   });
 });

--- a/app/src/components/DiffView.tsx
+++ b/app/src/components/DiffView.tsx
@@ -50,6 +50,8 @@ interface AnnotationMeta {
   lineNumber: number;
   comments: ReviewComment[];
   draft: boolean;
+  /** `${side}:${startLine}` — looks up this group's own draft in `draftsByFile`. */
+  anchorKey: string;
 }
 
 type DraftState = {
@@ -58,6 +60,15 @@ type DraftState = {
   end: number;
   content: string;
 };
+
+/** Draft anchor key: a (side, start line) pair identifies one open comment box. */
+function anchorKeyOf(side: AnnotationSide, start: number): string {
+  return `${side}:${start}`;
+}
+
+/** Stable empty-record reference so `draftsByFile[name] ?? EMPTY_DRAFTS` doesn't
+ * allocate a fresh object identity for files with no open drafts. */
+const EMPTY_DRAFTS: Record<string, DraftState> = {};
 
 export interface DiffViewProps {
   original: string;
@@ -146,19 +157,91 @@ export function DiffView({
   // that one selection-end instead of letting it also open a second draft.
   const suppressSelectionEndRef = useRef(false);
 
-  const [draftsByFile, setDraftsByFile] = useState<Record<string, DraftState>>({});
+  // On a cold present-window load, this diff can first render inside a hidden
+  // or throttled webview. @pierre/diffs' Virtualizer captures its scroll
+  // anchor against unmeasured row geometry during that throttled window, then
+  // autonomously scrolls `.diff-view-scroller` to garbage positions (observed
+  // in the wild: scrollTo 8792 -> clamp 8265 -> 5565) before the user has
+  // touched the page at all. The first real click then forces a re-measure
+  // that remaps content under that now-stale scrollTop, producing a visible
+  // jump and a click that resolves against the wrong row entirely. Warm loads
+  // never exhibit this — the library only mis-measures against a
+  // hidden/throttled layout.
+  //
+  // Pin the scroller to the top until the user deliberately scrolls it
+  // themselves; once real input arrives, get out of the way for good. Empty
+  // dep array: this arms once per DiffView mount and must NOT re-arm on file
+  // switch or diffKey change, or a mid-review file switch would yank the
+  // viewport back to the top.
+  useEffect(() => {
+    const scroller = wrapperRef.current?.querySelector<HTMLElement>('.diff-view-scroller');
+    if (!scroller) return;
+    let userTookOver = false;
+    const takeover = () => {
+      userTookOver = true;
+    };
+    const onScroll = () => {
+      if (!userTookOver && scroller.scrollTop !== 0) scroller.scrollTop = 0;
+    };
+    scroller.addEventListener('wheel', takeover, { passive: true });
+    scroller.addEventListener('touchstart', takeover, { passive: true });
+    scroller.addEventListener('pointerdown', takeover, { passive: true });
+    scroller.addEventListener('keydown', takeover);
+    scroller.addEventListener('scroll', onScroll);
+    return () => {
+      scroller.removeEventListener('wheel', takeover);
+      scroller.removeEventListener('touchstart', takeover);
+      scroller.removeEventListener('pointerdown', takeover);
+      scroller.removeEventListener('keydown', takeover);
+      scroller.removeEventListener('scroll', onScroll);
+    };
+  }, []);
+
+  // Per-anchor draft storage: multiple comment boxes can be open at once in the
+  // same file, each keyed by the (side, start line) it's anchored to. Object key
+  // insertion order is preserved for these string keys, which the escape-stack
+  // handler below relies on to find the most-recently-opened draft.
+  const [draftsByFile, setDraftsByFile] = useState<Record<string, Record<string, DraftState>>>({});
   // Comments that cannot render inline are collapsed by default.
   const [staleExpanded, setStaleExpanded] = useState(false);
 
   const name = filePath ?? 'file.txt';
-  const draft = draftsByFile[name] ?? null;
+  const draftsForFile = draftsByFile[name] ?? EMPTY_DRAFTS;
+  const draftKeys = useMemo(() => Object.keys(draftsForFile), [draftsForFile]);
 
-  const setDraftForCurrentFile = useCallback(
-    (next: DraftState | null) => {
+  // Opens a new draft box at (side, start..end). No-op if a draft is already
+  // open at that exact anchor — clicking an anchor that already has an open box
+  // should neither duplicate it nor wipe its typed text.
+  const openDraft = useCallback(
+    (side: AnnotationSide, start: number, end: number) => {
+      const key = anchorKeyOf(side, start);
       setDraftsByFile((current) => {
-        if (next) return { ...current, [name]: next };
-        const { [name]: _removed, ...rest } = current;
-        return rest;
+        const forFile = current[name] ?? EMPTY_DRAFTS;
+        if (forFile[key]) return current;
+        return { ...current, [name]: { ...forFile, [key]: { side, start, end, content: '' } } };
+      });
+    },
+    [name]
+  );
+
+  const updateDraftContent = useCallback(
+    (key: string, content: string) => {
+      setDraftsByFile((current) => {
+        const forFile = current[name];
+        if (!forFile?.[key]) return current;
+        return { ...current, [name]: { ...forFile, [key]: { ...forFile[key], content } } };
+      });
+    },
+    [name]
+  );
+
+  const closeDraft = useCallback(
+    (key: string) => {
+      setDraftsByFile((current) => {
+        const forFile = current[name];
+        if (!forFile || !(key in forFile)) return current;
+        const { [key]: _removed, ...rest } = forFile;
+        return { ...current, [name]: rest };
       });
     },
     [name]
@@ -170,7 +253,7 @@ export function DiffView({
     () => editingCommentId != null && comments.some((c) => c.id === editingCommentId),
     [editingCommentId, comments]
   );
-  const formOpen = draft !== null || editingHere;
+  const formOpen = draftKeys.length > 0 || editingHere;
 
   // Freeze the diff content while a comment form is open. @pierre/diffs binds a
   // rendered instance to its first file and won't swap the target in place
@@ -231,18 +314,22 @@ export function DiffView({
     [name, shownOriginal, shownModified]
   );
 
-  // Controlled selection. Without this, the library runs uncontrolled and
-  // commits an internal selectedRange on the first gutter-"+" click or
-  // drag-driven draft; InteractionManager then keeps re-anchoring the hover
-  // "+" to that stale range on every pointer move instead of following the
-  // mouse (see InteractionManager.placeUtilityFromSelection). Reflecting our
-  // own draft state here — and clearing to null once it's closed — keeps the
-  // library's selection in sync with ours and lets the "+" resume tracking
-  // the pointer as soon as there's nothing selected.
-  const selectedLines = useMemo<SelectedLineRange | null>(() => {
-    if (draft) return { side: draft.side, start: draft.start, end: draft.end };
-    return null;
-  }, [draft]);
+  // Controlled selection — ALWAYS null. Passing the `selectedLines` prop at all
+  // (rather than omitting it) is what keeps @pierre/diffs out of uncontrolled
+  // mode; if the prop is omitted the library commits its own internal
+  // selectedRange on the first gutter-"+" click or drag-driven draft, and
+  // InteractionManager then keeps re-anchoring the hover "+" to that stale
+  // range on every pointer move instead of following the mouse (see
+  // InteractionManager.placeUtilityFromSelection). This file used to reflect
+  // the single open draft's range back into this prop to keep the library's
+  // selection "in sync" with ours — but with multiple simultaneous drafts
+  // there is no longer one range to reflect, and pinning to any one of them
+  // would resume the hover-death bug on every OTHER draft's lines. A draft's
+  // anchor is fully communicated by the inline comment box rendered at that
+  // (side, line) via lineAnnotations/renderAnnotation, so this prop has
+  // nothing to carry — always-null keeps the library controlled while
+  // leaving its hover "+" free to follow the pointer everywhere.
+  const selectedLines: SelectedLineRange | null = null;
 
   // The library forces a full re-render whenever the options object changes by
   // value (function identities included), so keep callbacks stable and memoize
@@ -252,7 +339,7 @@ export function DiffView({
     if (!normalized) return;
     const { side, start, end } = normalized;
     suppressSelectionEndRef.current = true;
-    setDraftForCurrentFile({ side, start, end, content: '' });
+    openDraft(side, start, end);
   });
 
   // `enableLineSelection` requires a click to land on the number column to
@@ -272,7 +359,7 @@ export function DiffView({
     const normalized = normalizeRange(range);
     if (!normalized) return;
     const { side, start, end } = normalized;
-    setDraftForCurrentFile({ side, start, end, content: '' });
+    openDraft(side, start, end);
   });
 
   const options = useMemo<FileDiffOptions<AnnotationMeta>>(() => ({
@@ -296,30 +383,30 @@ export function DiffView({
     onGutterUtilityClick: handleGutterUtilityClick,
   }), [diffStyle, expandUnchanged, resolvedTheme, handleLineSelectionEnd, handleGutterUtilityClick]);
 
-  // Group saved comments + the optional draft into one annotation per
+  // Group saved comments + any open drafts into one annotation per
   // (side, anchor line). The library slots annotations by `side`+`lineNumber`,
-  // so collisions must be merged into a single thread.
+  // so collisions must be merged into a single thread — a draft can land on
+  // the same anchor as an existing comment thread, or on its own empty one.
   const lineAnnotations = useMemo<DiffLineAnnotation<AnnotationMeta>[]>(() => {
     const groups = new Map<string, AnnotationMeta>();
-    const keyOf = (side: AnnotationSide, line: number) => `${side}:${line}`;
 
     for (const comment of anchoredComments) {
       const side: AnnotationSide = isOriginalSideComment(comment) ? 'deletions' : 'additions';
       const line = comment.line_start;
-      const key = keyOf(side, line);
+      const key = anchorKeyOf(side, line);
       let group = groups.get(key);
       if (!group) {
-        group = { side, lineNumber: line, comments: [], draft: false };
+        group = { side, lineNumber: line, comments: [], draft: false, anchorKey: key };
         groups.set(key, group);
       }
       group.comments.push(comment);
     }
 
-    if (draft) {
-      const key = keyOf(draft.side, draft.start);
+    for (const key of draftKeys) {
+      const d = draftsForFile[key];
       let group = groups.get(key);
       if (!group) {
-        group = { side: draft.side, lineNumber: draft.start, comments: [], draft: true };
+        group = { side: d.side, lineNumber: d.start, comments: [], draft: true, anchorKey: key };
         groups.set(key, group);
       } else {
         group.draft = true;
@@ -329,46 +416,41 @@ export function DiffView({
     // The library keys annotation slots by array index (renderDiffChildren maps
     // with the index as the React key), so an annotation's index must stay stable
     // or React remounts its subtree — which would wipe an in-progress draft/edit
-    // form (its typed text and focus). Keep the annotation(s) with an open form at
-    // the front so that comments arriving or leaving in the background only ever
-    // shift the trailing, form-less threads. Visual placement is unaffected: the
-    // library positions each thread by its `slot` (side+line), not array order.
+    // form (its typed text and focus). Keep ALL annotations hosting an open form
+    // (any open draft, or the comment being edited) at the front, in a stable
+    // order among themselves (sorted by anchor key so their relative order never
+    // depends on Map iteration or comment arrival order), so that comments
+    // arriving or leaving in the background only ever shift the trailing,
+    // form-less threads. Visual placement is unaffected: the library positions
+    // each thread by its `slot` (side+line), not array order.
     const all = Array.from(groups.values());
     const hasOpenForm = (g: AnnotationMeta) =>
       g.draft || g.comments.some((c) => c.id === editingCommentId);
-    const active = all.filter(hasOpenForm);
+    const active = all.filter(hasOpenForm).sort((a, b) => a.anchorKey.localeCompare(b.anchorKey));
     const rest = all.filter((g) => !hasOpenForm(g));
     return [...active, ...rest].map((meta) => ({
       side: meta.side,
       lineNumber: meta.lineNumber,
       metadata: meta,
     }));
-  }, [anchoredComments, draft, editingCommentId]);
+  }, [anchoredComments, draftKeys, draftsForFile, editingCommentId]);
 
   const handleSaveDraft = useCallback(
-    async (content: string) => {
-      if (!draft) return;
-      const lineStart = draft.start;
-      const lineEnd = draft.side === 'deletions' ? -draft.end : draft.end;
+    async (key: string, content: string) => {
+      const d = draftsForFile[key];
+      if (!d) return;
+      const lineStart = d.start;
+      const lineEnd = d.side === 'deletions' ? -d.end : d.end;
       try {
         await onAddComment(lineStart, lineEnd, content);
-        setDraftForCurrentFile(null);
+        closeDraft(key);
       } catch {
         // The parent owns user-visible error reporting; keep the draft intact so
         // the user can retry without losing typed text.
       }
     },
-    [draft, onAddComment, setDraftForCurrentFile]
+    [draftsForFile, onAddComment, closeDraft]
   );
-
-  const handleDraftContentChange = useCallback(
-    (content: string) => {
-      setDraftForCurrentFile(draft ? { ...draft, content } : null);
-    },
-    [draft, setDraftForCurrentFile]
-  );
-
-  const handleCancelDraft = useCallback(() => setDraftForCurrentFile(null), [setDraftForCurrentFile]);
 
   const handleSendComment = useCallback(
     (comment: ReviewComment) => {
@@ -381,17 +463,29 @@ export function DiffView({
   const renderAnnotation = useCallback(
     (annotation: DiffLineAnnotation<AnnotationMeta>) => {
       const meta = annotation.metadata;
+      const key = meta.anchorKey;
       return (
         <DiffCommentThread
+          // Keyed by anchor, not just positioned by array index: the "front"
+          // slot a given index hosts can switch which anchor it represents
+          // between renders (e.g. draft A at index 0 closes, sliding draft B
+          // from index 1 into index 0). Without this key React reconciles
+          // that as "the same DiffCommentThread, new props" and reuses the
+          // mounted CommentForm instance — whose `value` state is seeded
+          // once from `initialValue` — leaving B's box showing A's stale
+          // typed text. The key forces a remount whenever the anchor at a
+          // slot actually changes, while leaving it stable (untouched
+          // state/focus) across renders where the same anchor stays put.
+          key={key}
           comments={meta.comments}
           draft={meta.draft}
           editingCommentId={editingCommentId}
           readOnlyCommentIds={readOnlyCommentIds}
           showSendToClaude={!!onSendToClaude && !!filePath}
-          draftContent={meta.draft ? draft?.content : undefined}
-          onDraftContentChange={meta.draft ? handleDraftContentChange : undefined}
-          onSaveDraft={handleSaveDraft}
-          onCancelDraft={handleCancelDraft}
+          draftContent={meta.draft ? draftsForFile[key]?.content : undefined}
+          onDraftContentChange={meta.draft ? (content) => updateDraftContent(key, content) : undefined}
+          onSaveDraft={(content) => handleSaveDraft(key, content)}
+          onCancelDraft={() => closeDraft(key)}
           onStartEdit={onStartEdit}
           onEditComment={onEditComment}
           onCancelEdit={onCancelEdit}
@@ -406,9 +500,10 @@ export function DiffView({
       readOnlyCommentIds,
       onSendToClaude,
       filePath,
+      draftsForFile,
+      updateDraftContent,
       handleSaveDraft,
-      handleDraftContentChange,
-      handleCancelDraft,
+      closeDraft,
       onStartEdit,
       onEditComment,
       onCancelEdit,
@@ -418,8 +513,15 @@ export function DiffView({
     ]
   );
 
-  // Escape closes the draft form before the panel (LIFO).
-  useEscapeStack(handleCancelDraft, draft !== null);
+  // Escape closes the most-recently-opened draft first (LIFO among drafts),
+  // before falling through to the panel's own escape handling. Object key
+  // insertion order (preserved for these string keys) doubles as open order,
+  // so the last key is the most recently opened still-open draft.
+  const handleEscapeDraft = useCallback(() => {
+    if (draftKeys.length === 0) return;
+    closeDraft(draftKeys[draftKeys.length - 1]);
+  }, [draftKeys, closeDraft]);
+  useEscapeStack(handleEscapeDraft, draftKeys.length > 0);
   useEscapeStack(onCancelEdit, editingCommentId !== null);
 
   return (


### PR DESCRIPTION
## Summary
- Multi-draft commenting in the present reader's `DiffView` (GitHub-style): per-anchor draft map keyed `${side}:${start}`, the hover "+" keeps following the pointer while boxes are open (controlled selection now always null — anchors are communicated via `lineAnnotations`/`renderAnnotation` instead), threads keyed by anchor key so the library's index-keyed annotation slots can't leak one draft's text into another, Escape closes the most-recently-opened draft first, and save/cancel is isolated per anchor.
- Cold-load scroll fix: `@pierre/diffs`' `Virtualizer` scroll-anchoring (`scrollFix`) captures its anchor against unmeasured row geometry during the throttled first render of a fresh Present webview and autonomously scrolls the pane to the bottom (instrumented live: `scrollTo 8792 → clamp 8265 → 5565`). The first click then remaps rows under a stale `scrollTop`, producing a visible jump and anchoring the comment on the wrong (nonexistent) line. `DiffView` now pins the scroller to top until real user input (wheel/touch/pointer/key) and then disarms permanently.

## Test plan
- [x] 6 new multi-draft e2e tests + 2 scroll-pin tests
- [x] The three previously-red scroll-jump repro tests now pass exactly
- [x] Full suite green: `tsc`, 1337 vitest tests, 164 e2e tests
- [x] Live-app verified on the `dev` profile with native CGEvents input — 4/4 cold-relaunch runs open at top and place the draft on the clicked line
- [x] Victor's manual pass
- Note: the e2e `scrollDown` helper now uses a real mouse wheel because programmatic scrolls are (correctly) indistinguishable from the library's autonomous scrolls and get pinned.