### PR TITLE
feat(present): review progress, keyboard model, and DriveBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-08]
+
+### Added
+- **Present now tracks your review progress and gives you a fuller keyboard model.** Mark a file reviewed with `R`, or just keep moving with `J`/`K` — leaving a file with `J` marks it reviewed automatically, jaunt-style. Progress shows in the file rail (a header count and thin progress bar, plus a checkmark and dimmed styling on reviewed rows) and in a new bottom drive bar with its own progress meter, keyboard hints, and the "Submit review" button (now bound to `S`). Each file's diff header also gets its own Reviewed toggle. The submit dialog lists any files you haven't walked yet as an advisory note — it never blocks submission. Marks are saved locally per round, so they survive a window reload but start fresh on a new round.
+
 ## [2026-07-07]
 
 ### Changed

--- a/app/e2e/present-tour.spec.ts
+++ b/app/e2e/present-tour.spec.ts
@@ -128,6 +128,48 @@ test.describe('PresentTour rendering', () => {
   });
 });
 
+test.describe('PresentTour reviewed toggle', () => {
+  // Real-browser coverage for the slice-1 "controlled items only re-render on
+  // a version bump" trap (see the module doc), applied to the reviewed
+  // indicator: it's rendered via `renderHeaderPrefix`, a callback-based slot
+  // rather than a field baked into `items`, so this proves the indicator
+  // updates live without relying on jsdom (which can't mount the real
+  // `@pierre/diffs` CodeView at all — see PresentRoot.test.tsx's mock note).
+  test('clicking the header Reviewed toggle flips state and calls back to the parent', async ({ page }) => {
+    await openHarness(page, UNSEEDED);
+
+    const alpha = await findContainerByTitle(page, 'src/alpha.ts');
+    expect(alpha).not.toBeNull();
+    const toggle = alpha!.locator('.present-tour-reviewed-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).not.toHaveClass(/is-reviewed/);
+
+    await toggle.click();
+
+    await expect(toggle).toHaveClass(/is-reviewed/);
+    expect(await page.evaluate(() => window.__HARNESS__.getReviewedPaths())).toEqual(['src/alpha.ts']);
+
+    // Click again to un-mark, confirming the version-bump path handles both
+    // directions, not just the initial flip.
+    await toggle.click();
+    await expect(toggle).not.toHaveClass(/is-reviewed/);
+    expect(await page.evaluate(() => window.__HARNESS__.getReviewedPaths())).toEqual([]);
+  });
+
+  test('reviewed state is independent per file', async ({ page }) => {
+    await openHarness(page, UNSEEDED);
+
+    const alpha = await findContainerByTitle(page, 'src/alpha.ts');
+    await alpha!.locator('.present-tour-reviewed-toggle').click();
+
+    await page.evaluate(() => window.__HARNESS__.scrollToFile('src/beta.ts'));
+    const beta = await findContainerByTitle(page, 'src/beta.ts');
+    await expect(beta!.locator('.present-tour-reviewed-toggle')).not.toHaveClass(/is-reviewed/);
+
+    expect(await page.evaluate(() => window.__HARNESS__.getReviewedPaths())).toEqual(['src/alpha.ts']);
+  });
+});
+
 test.describe('PresentTour scroll pin', () => {
   test('a programmatic scroll before any user input snaps back to the top', async ({ page }) => {
     await openHarness(page, UNSEEDED);

--- a/app/src/components/PresentRoot/DriveBar.css
+++ b/app/src/components/PresentRoot/DriveBar.css
@@ -1,0 +1,87 @@
+/* app/src/components/PresentRoot/DriveBar.css */
+
+.present-drive-bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-top: 16px;
+  padding: 10px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-panel);
+}
+
+.present-drive-bar-progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 0 0 240px;
+}
+
+.present-drive-bar-progress-track {
+  flex: 1;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--color-border-subtle);
+  overflow: hidden;
+}
+
+.present-drive-bar-progress-fill {
+  height: 100%;
+  background: var(--color-accent, #5b8cff);
+  transition: width 0.15s ease-out;
+}
+
+.present-drive-bar-progress-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.present-drive-bar-hints {
+  flex: 1;
+  display: flex;
+  gap: 16px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  min-width: 0;
+}
+
+.present-drive-bar kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-app);
+  color: var(--color-text-primary);
+  font-family: monospace;
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+}
+
+.present-drive-bar-submit {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--color-accent, #5b8cff);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: var(--font-size);
+  cursor: pointer;
+}
+
+.present-drive-bar-submit:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.present-drive-bar-submit kbd {
+  border-color: rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}

--- a/app/src/components/PresentRoot/DriveBar.tsx
+++ b/app/src/components/PresentRoot/DriveBar.tsx
@@ -1,0 +1,51 @@
+// app/src/components/PresentRoot/DriveBar.tsx
+// Fixed bottom strip for the Present reader: review-progress on the left,
+// keyboard hints in the middle, and the "Submit review" action on the right.
+// Jaunt-style "drive bar" — always visible, independent of scroll position.
+import './DriveBar.css';
+
+export interface DriveBarProps {
+  reviewedCount: number;
+  totalCount: number;
+  draftCount: number;
+  submitting: boolean;
+  onSubmit: () => void;
+}
+
+export function DriveBar({ reviewedCount, totalCount, draftCount, submitting, onSubmit }: DriveBarProps) {
+  const pct = totalCount > 0 ? Math.round((reviewedCount / totalCount) * 100) : 0;
+
+  return (
+    <div className="present-drive-bar" data-testid="present-drive-bar">
+      <div className="present-drive-bar-progress">
+        <div className="present-drive-bar-progress-track">
+          <div className="present-drive-bar-progress-fill" style={{ width: `${pct}%` }} />
+        </div>
+        <span className="present-drive-bar-progress-label">
+          {reviewedCount} of {totalCount} reviewed
+        </span>
+      </div>
+
+      <div className="present-drive-bar-hints">
+        <span>
+          <kbd>J</kbd>/<kbd>K</kbd> next/prev
+        </span>
+        <span>
+          <kbd>R</kbd> reviewed
+        </span>
+      </div>
+
+      <button
+        type="button"
+        className="present-drive-bar-submit"
+        onClick={onSubmit}
+        disabled={submitting}
+      >
+        {draftCount > 0 ? `Submit review (${draftCount})` : 'Submit review'}
+        <kbd>S</kbd>
+      </button>
+    </div>
+  );
+}
+
+export default DriveBar;

--- a/app/src/components/PresentRoot/PresentRoot.css
+++ b/app/src/components/PresentRoot/PresentRoot.css
@@ -66,21 +66,6 @@
   color: #d97706;
 }
 
-.present-root-submit-button {
-  background: var(--color-accent);
-  color: #fff;
-  border: none;
-  border-radius: 6px;
-  padding: 6px 12px;
-  font-size: var(--font-size);
-  cursor: pointer;
-}
-
-.present-root-submit-button:disabled {
-  opacity: 0.6;
-  cursor: default;
-}
-
 .present-root-submit-overlay {
   position: fixed;
   inset: 0;
@@ -111,6 +96,12 @@
   margin: 0 0 12px 0;
   color: var(--color-text-secondary);
   font-size: var(--font-size);
+}
+
+.present-root-submit-coverage {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  font-style: italic;
 }
 
 .present-root-submit-error {
@@ -182,15 +173,62 @@
   gap: 20px;
 }
 
-.present-root-files {
+.present-root-rail {
   flex: 0 0 260px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-panel);
+  overflow: hidden;
+}
+
+.present-root-rail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px 6px;
+  flex: 0 0 auto;
+}
+
+.present-root-rail-title {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.present-root-rail-count {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.present-root-rail-progress-track {
+  flex: 0 0 auto;
+  height: 3px;
+  margin: 0 12px 8px;
+  border-radius: 999px;
+  background: var(--color-border-subtle);
+  overflow: hidden;
+}
+
+.present-root-rail-progress-fill {
+  height: 100%;
+  background: var(--color-accent, #5b8cff);
+  transition: width 0.15s ease-out;
+}
+
+.present-root-files {
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 0;
   margin: 0;
   list-style: none;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  background: var(--color-bg-panel);
+  border-top: 1px solid var(--color-border-subtle);
 }
 
 .present-root-file {
@@ -241,6 +279,23 @@
 }
 
 .present-root-file.selected .present-root-file-note-marker {
+  color: #fff;
+}
+
+.present-root-file.reviewed:not(.selected) {
+  color: var(--color-text-secondary);
+}
+
+.present-root-file.reviewed:not(.selected) .present-root-file-path {
+  opacity: 0.7;
+}
+
+.present-root-file.reviewed .present-root-file-index {
+  color: var(--color-accent, #5b8cff);
+  font-weight: 600;
+}
+
+.present-root-file.reviewed.selected .present-root-file-index {
   color: #fff;
 }
 

--- a/app/src/components/PresentRoot/PresentRoot.test.tsx
+++ b/app/src/components/PresentRoot/PresentRoot.test.tsx
@@ -13,7 +13,7 @@ import type { PresentTourProps } from '../PresentTour';
 // mock captures its full props so tests can invoke onAddComment etc. directly
 // and assert on what PresentRoot passes down.
 vi.mock('../PresentTour', () => ({
-  PresentTour: vi.fn(({ summary, files }: PresentTourProps) => (
+  PresentTour: vi.fn(({ summary, files, reviewedPaths, onToggleReviewed }: PresentTourProps) => (
     <div data-testid="present-tour">
       {summary && <div data-testid="present-tour-summary">{summary}</div>}
       {files.map((f) => (
@@ -23,6 +23,10 @@ vi.mock('../PresentTour', () => ({
           {f.diff.error && <span className="error">{f.diff.error}</span>}
           {f.diff.original !== undefined && <div className="original">{f.diff.original}</div>}
           {f.diff.modified !== undefined && <div className="modified">{f.diff.modified}</div>}
+          <span className="reviewed-state">{reviewedPaths.has(f.path) ? 'reviewed' : 'unreviewed'}</span>
+          <button type="button" onClick={() => onToggleReviewed(f.path)}>
+            toggle-reviewed-{f.path}
+          </button>
         </div>
       ))}
     </div>
@@ -247,6 +251,9 @@ describe('PresentRoot', () => {
     const loadingScreen = document.createElement('div');
     loadingScreen.id = 'loading-screen';
     document.body.appendChild(loadingScreen);
+
+    // usePresentReviewedMarks persists to localStorage; isolate every test.
+    window.localStorage.clear();
   });
 
   afterEach(() => {
@@ -759,4 +766,130 @@ describe('PresentRoot', () => {
       expect(screen.getByTestId('tour-file-src/foo.ts').textContent).toContain('FRESH round-2 original');
     }, WAIT_OPTS);
   }, TEST_TIMEOUT);
+
+  describe('review progress + keyboard model', () => {
+    it('toggling reviewed from the tour updates the rail count and row styling', async () => {
+      await loadRound();
+
+      expect(screen.getByTestId('present-root-rail-count').textContent).toBe('0/2');
+
+      fireEvent.click(screen.getByText('toggle-reviewed-src/foo.ts'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('present-root-rail-count').textContent).toBe('1/2');
+      }, WAIT_OPTS);
+      expect(screen.getByText('src/foo.ts').closest('li')).toHaveClass('reviewed');
+      expect(screen.getByTestId('tour-file-src/foo.ts').querySelector('.reviewed-state')?.textContent).toBe(
+        'reviewed'
+      );
+    });
+
+    it('r toggles reviewed on the active file', async () => {
+      await loadRound();
+
+      fireEvent.keyDown(window, { key: 'r' });
+      await waitFor(() => {
+        expect(screen.getByTestId('present-root-rail-count').textContent).toBe('1/2');
+      }, WAIT_OPTS);
+      expect(screen.getByText('src/foo.ts').closest('li')).toHaveClass('reviewed');
+
+      fireEvent.keyDown(window, { key: 'r' });
+      await waitFor(() => {
+        expect(screen.getByTestId('present-root-rail-count').textContent).toBe('0/2');
+      }, WAIT_OPTS);
+    });
+
+    it('j marks the file being left as reviewed (auto-mark-on-leave), k never marks', async () => {
+      await loadRound();
+
+      expect(screen.getByTestId('present-root-rail-count').textContent).toBe('0/2');
+
+      fireEvent.keyDown(window, { key: 'j' });
+      await waitFor(() => {
+        expect(screen.getByText('src/foo.test.ts').closest('li')).toHaveClass('selected');
+      }, WAIT_OPTS);
+      // Leaving src/foo.ts via j marks it reviewed; arriving at src/foo.test.ts does not.
+      expect(screen.getByTestId('present-root-rail-count').textContent).toBe('1/2');
+      expect(screen.getByText('src/foo.ts').closest('li')).toHaveClass('reviewed');
+      expect(screen.getByText('src/foo.test.ts').closest('li')).not.toHaveClass('reviewed');
+
+      fireEvent.keyDown(window, { key: 'k' });
+      await waitFor(() => {
+        expect(screen.getByText('src/foo.ts').closest('li')).toHaveClass('selected');
+      }, WAIT_OPTS);
+      // k never marks anything, and the earlier j-mark on foo.ts persists.
+      expect(screen.getByTestId('present-root-rail-count').textContent).toBe('1/2');
+    });
+
+    it('does not intercept single-letter shortcuts while typing in a comment textarea', async () => {
+      await loadRound();
+
+      const input = document.createElement('textarea');
+      document.body.appendChild(input);
+      input.focus();
+
+      fireEvent.keyDown(input, { key: 'r' });
+      fireEvent.keyDown(input, { key: 'j' });
+      fireEvent.keyDown(input, { key: 's' });
+
+      // Nothing moved, nothing got marked, and the submit dialog never opened.
+      expect(screen.getByText('src/foo.ts').closest('li')).toHaveClass('selected');
+      expect(screen.getByTestId('present-root-rail-count').textContent).toBe('0/2');
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      document.body.removeChild(input);
+    });
+
+    it('s opens the submit dialog', async () => {
+      await loadRound();
+
+      fireEvent.keyDown(window, { key: 's' });
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      }, WAIT_OPTS);
+    });
+
+    it('shows an advisory, non-blocking coverage line in the submit dialog for unreviewed files', async () => {
+      await loadRound();
+
+      fireEvent.click(screen.getByText('toggle-reviewed-src/foo.ts'));
+      await waitFor(() => {
+        expect(screen.getByTestId('present-root-rail-count').textContent).toBe('1/2');
+      }, WAIT_OPTS);
+
+      fireEvent.click(screen.getByRole('button', { name: /Submit review/ }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('present-root-submit-coverage').textContent).toContain('src/foo.test.ts');
+      }, WAIT_OPTS);
+      // Submit stays enabled — coverage is advisory only, never a gate.
+      expect(screen.getByRole('button', { name: 'Submit' })).not.toBeDisabled();
+    });
+
+    it('shows no coverage line once every file is reviewed', async () => {
+      await loadRound();
+
+      fireEvent.click(screen.getByText('toggle-reviewed-src/foo.ts'));
+      fireEvent.click(screen.getByText('toggle-reviewed-src/foo.test.ts'));
+      await waitFor(() => {
+        expect(screen.getByTestId('present-root-rail-count').textContent).toBe('2/2');
+      }, WAIT_OPTS);
+
+      fireEvent.click(screen.getByRole('button', { name: /Submit review/ }));
+
+      expect(screen.queryByTestId('present-root-submit-coverage')).not.toBeInTheDocument();
+    });
+
+    it('persists reviewed marks in localStorage scoped to the presentation and round', async () => {
+      await loadRound();
+
+      fireEvent.click(screen.getByText('toggle-reviewed-src/foo.ts'));
+      await waitFor(() => {
+        expect(screen.getByTestId('present-root-rail-count').textContent).toBe('1/2');
+      }, WAIT_OPTS);
+
+      const raw = window.localStorage.getItem('attn.present.reviewed.pres-1.round-1');
+      expect(JSON.parse(raw!)).toEqual(['src/foo.ts']);
+    });
+  });
 });

--- a/app/src/components/PresentRoot/index.tsx
+++ b/app/src/components/PresentRoot/index.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { useDaemonSocket } from '../../hooks/useDaemonSocket';
 import { usePresentAutomationBridge } from '../../hooks/usePresentAutomationBridge';
+import { usePresentReviewedMarks } from '../../hooks/usePresentReviewedMarks';
 import { PresentTour, type PresentTourFile } from '../PresentTour';
+import { DriveBar } from './DriveBar';
 import type {
   Presentation,
   PresentationRound,
@@ -283,6 +285,13 @@ export function PresentRoot() {
   }, [presentation, round, sendGetFileDiff]);
 
   const files = round?.manifest.files ?? [];
+  const filePaths = useMemo(() => files.map((f) => f.path), [files]);
+
+  const { reviewed, toggleReviewed, markReviewed } = usePresentReviewedMarks(
+    presentationId,
+    round?.id ?? null,
+    filePaths
+  );
 
   const moveSelection = useCallback((delta: number) => {
     if (files.length === 0) return;
@@ -295,17 +304,32 @@ export function PresentRoot() {
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       if (isTypingTarget(e.target)) return;
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
       if (e.key === 'j' || e.key === 'ArrowDown') {
         e.preventDefault();
+        // Auto-mark-on-leave (jaunt semantics): advancing past a file marks
+        // the one being left as reviewed. Visiting a file alone (arriving,
+        // scrolling past it passively) never marks it.
+        if (activePath) markReviewed(activePath);
         moveSelection(1);
       } else if (e.key === 'k' || e.key === 'ArrowUp') {
         e.preventDefault();
         moveSelection(-1);
+      } else if (e.key === 'r') {
+        e.preventDefault();
+        if (activePath) toggleReviewed(activePath);
+      } else if (e.key === 's') {
+        e.preventDefault();
+        setShowSubmitDialog((current) => {
+          if (current) return current;
+          setSubmitError(null);
+          return true;
+        });
       }
     }
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [moveSelection]);
+  }, [moveSelection, activePath, markReviewed, toggleReviewed]);
 
   useEffect(() => {
     if (!activePath || !railRef.current) return;
@@ -424,6 +448,15 @@ export function PresentRoot() {
 
   const showDrift = !!repoHeadSha && repoHeadSha !== round.head_sha && !driftDismissed;
 
+  // Advisory-only coverage line for the submit dialog: never blocks
+  // submission, just tells the user what the tour didn't see them mark.
+  const unreviewedPaths = filePaths.filter((p) => !reviewed.has(p));
+  const COVERAGE_PREVIEW_COUNT = 5;
+  const unreviewedCoverageText =
+    unreviewedPaths.length > COVERAGE_PREVIEW_COUNT
+      ? `${unreviewedPaths.slice(0, COVERAGE_PREVIEW_COUNT).join(', ')}, and ${unreviewedPaths.length - COVERAGE_PREVIEW_COUNT} more`
+      : unreviewedPaths.join(', ');
+
   return (
     <div className="present-root">
       <header className="present-root-header">
@@ -442,17 +475,6 @@ export function PresentRoot() {
         <span className={`present-root-status ${round.submitted_at ? 'submitted' : 'draft'}`}>
           {round.submitted_at ? 'Submitted' : 'Draft'}
         </span>
-        <button
-          type="button"
-          className="present-root-submit-button"
-          onClick={() => {
-            setSubmitError(null);
-            setShowSubmitDialog(true);
-          }}
-          disabled={submitting}
-        >
-          {drafts.length > 0 ? `Submit review (${drafts.length})` : 'Submit review'}
-        </button>
       </section>
 
       {showSubmitDialog && (
@@ -462,6 +484,11 @@ export function PresentRoot() {
             <p>
               {drafts.length} comment{drafts.length === 1 ? '' : 's'}
             </p>
+            {unreviewedPaths.length > 0 && (
+              <p className="present-root-submit-coverage" data-testid="present-root-submit-coverage">
+                Not yet walked: {unreviewedCoverageText}
+              </p>
+            )}
             {submitError && <div className="present-root-submit-error">{submitError}</div>}
             <div className="present-root-submit-actions">
               <button type="button" onClick={() => setShowSubmitDialog(false)} disabled={submitting}>
@@ -499,31 +526,49 @@ export function PresentRoot() {
       )}
 
       <div className="present-root-body">
-        <ol className="present-root-files" ref={railRef}>
-          {files.map((file, index) => (
-            <li
-              key={file.path}
-              data-path={file.path}
-              className={`present-root-file ${file.path === activePath ? 'selected' : ''}`}
-              onClick={() => requestScroll(file.path)}
-            >
-              <span className="present-root-file-index">{index + 1}</span>
-              <code className="present-root-file-path">{file.path}</code>
-              {file.note && <span className="present-root-file-note-marker" title="Has a note">●</span>}
-            </li>
-          ))}
+        <div className="present-root-rail">
+          <div className="present-root-rail-header">
+            <span className="present-root-rail-title">Files</span>
+            <span className="present-root-rail-count" data-testid="present-root-rail-count">
+              {reviewed.size}/{files.length}
+            </span>
+          </div>
+          <div className="present-root-rail-progress-track">
+            <div
+              className="present-root-rail-progress-fill"
+              style={{ width: `${files.length > 0 ? (reviewed.size / files.length) * 100 : 0}%` }}
+            />
+          </div>
 
-          {round.manifest.skip.length > 0 && (
-            <>
-              <li className="present-root-skip-divider">Skipped</li>
-              {round.manifest.skip.map((path) => (
-                <li key={path} className="present-root-file present-root-file-skipped">
-                  <code className="present-root-file-path">{path}</code>
+          <ol className="present-root-files" ref={railRef}>
+            {files.map((file, index) => {
+              const isReviewed = reviewed.has(file.path);
+              return (
+                <li
+                  key={file.path}
+                  data-path={file.path}
+                  className={`present-root-file ${file.path === activePath ? 'selected' : ''} ${isReviewed ? 'reviewed' : ''}`}
+                  onClick={() => requestScroll(file.path)}
+                >
+                  <span className="present-root-file-index">{isReviewed ? '✓' : index + 1}</span>
+                  <code className="present-root-file-path">{file.path}</code>
+                  {file.note && <span className="present-root-file-note-marker" title="Has a note">●</span>}
                 </li>
-              ))}
-            </>
-          )}
-        </ol>
+              );
+            })}
+
+            {round.manifest.skip.length > 0 && (
+              <>
+                <li className="present-root-skip-divider">Skipped</li>
+                {round.manifest.skip.map((path) => (
+                  <li key={path} className="present-root-file present-root-file-skipped">
+                    <code className="present-root-file-path">{path}</code>
+                  </li>
+                ))}
+              </>
+            )}
+          </ol>
+        </div>
 
         <main className="present-root-diff-pane">
           {files.length === 0 ? (
@@ -544,10 +589,23 @@ export function PresentRoot() {
               scrollToPath={scrollRequest?.path ?? null}
               scrollNonce={scrollRequest?.nonce ?? 0}
               onActivePathChange={setActivePath}
+              reviewedPaths={reviewed}
+              onToggleReviewed={toggleReviewed}
             />
           )}
         </main>
       </div>
+
+      <DriveBar
+        reviewedCount={reviewed.size}
+        totalCount={files.length}
+        draftCount={drafts.length}
+        submitting={submitting}
+        onSubmit={() => {
+          setSubmitError(null);
+          setShowSubmitDialog(true);
+        }}
+      />
     </div>
   );
 }

--- a/app/src/components/PresentTour/PresentTour.css
+++ b/app/src/components/PresentTour/PresentTour.css
@@ -61,6 +61,43 @@
   margin-bottom: 0;
 }
 
+.present-tour-reviewed-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  margin-right: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg-app);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.present-tour-reviewed-toggle:hover {
+  color: var(--color-text-primary);
+}
+
+.present-tour-reviewed-toggle.is-reviewed {
+  border-color: var(--color-accent, #5b8cff);
+  color: var(--color-accent, #5b8cff);
+}
+
+.present-tour-reviewed-check {
+  font-size: var(--font-size-sm);
+  line-height: 1;
+}
+
+.present-tour-reviewed-toggle kbd {
+  padding: 0 4px;
+  border-radius: 3px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-panel);
+  font-family: monospace;
+  font-size: var(--font-size-xs);
+}
+
 .present-tour-footer {
   flex: 0 0 auto;
   margin-top: 16px;

--- a/app/src/components/PresentTour/index.tsx
+++ b/app/src/components/PresentTour/index.tsx
@@ -90,6 +90,9 @@ export interface PresentTourProps {
   scrollNonce?: number;
   /** Fires with the path nearest the top of the viewport as the user scrolls. */
   onActivePathChange?: (path: string) => void;
+  /** Paths the user has marked reviewed (jaunt-style per-file mark). */
+  reviewedPaths: ReadonlySet<string>;
+  onToggleReviewed: (path: string) => void;
 }
 
 // Metadata carried on each native line annotation, generalized from DiffView's
@@ -151,6 +154,8 @@ export function PresentTour({
   scrollToPath,
   scrollNonce,
   onActivePathChange,
+  reviewedPaths,
+  onToggleReviewed,
 }: PresentTourProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const handleRef = useRef<CodeViewHandle<AnnotationMeta> | null>(null);
@@ -396,8 +401,13 @@ export function PresentTour({
     });
     // frozenRef is a ref (mutated in-place above); its contents are captured
     // deliberately as part of this computation and don't need to be a dep.
+    // reviewedPaths is included purely to force a `version` bump on every
+    // reviewed toggle — same reasoning as editingCommentId above: CodeView's
+    // controlled items only re-render on a version bump (see module doc), and
+    // the reviewed indicator is otherwise rendered through renderHeaderPrefix,
+    // which this codebase has not proven re-renders on its own without one.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allSettled, files, commentsByFile, draftsByFile, drafts, formOpenByFile, editingCommentId]);
+  }, [allSettled, files, commentsByFile, draftsByFile, drafts, formOpenByFile, editingCommentId, reviewedPaths]);
 
   const handleGutterUtilityClick = useStableCallback(
     (range: SelectedLineRange, context: { item: CodeViewItem<AnnotationMeta> }) => {
@@ -436,6 +446,28 @@ export function PresentTour({
       );
     },
     [noteByPath]
+  );
+
+  const renderHeaderPrefix = useCallback(
+    (item: CodeViewItem<AnnotationMeta>) => {
+      const isReviewed = reviewedPaths.has(item.id);
+      return (
+        <button
+          type="button"
+          className={`present-tour-reviewed-toggle ${isReviewed ? 'is-reviewed' : ''}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleReviewed(item.id);
+          }}
+          title={isReviewed ? 'Mark as not reviewed' : 'Mark as reviewed'}
+        >
+          <span className="present-tour-reviewed-check">{isReviewed ? '✓' : '○'}</span>
+          <span className="present-tour-reviewed-label">{isReviewed ? 'Reviewed' : 'Mark reviewed'}</span>
+          <kbd>R</kbd>
+        </button>
+      );
+    },
+    [reviewedPaths, onToggleReviewed]
   );
 
   const options = useMemo<CodeViewOptions<AnnotationMeta>>(
@@ -605,6 +637,7 @@ export function PresentTour({
           selectedLines={selectedLines}
           renderAnnotation={renderAnnotation}
           renderHeaderMetadata={renderHeaderMetadata}
+          renderHeaderPrefix={renderHeaderPrefix}
           onScroll={handleScroll}
           disableWorkerPool
         />

--- a/app/src/hooks/usePresentReviewedMarks.test.ts
+++ b/app/src/hooks/usePresentReviewedMarks.test.ts
@@ -1,0 +1,88 @@
+// app/src/hooks/usePresentReviewedMarks.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { usePresentReviewedMarks } from './usePresentReviewedMarks';
+
+describe('usePresentReviewedMarks', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('starts empty when nothing is persisted', () => {
+    const { result } = renderHook(() => usePresentReviewedMarks('pres-1', 'round-1', ['a.ts', 'b.ts']));
+    expect(result.current.reviewed.size).toBe(0);
+  });
+
+  it('toggleReviewed adds then removes a path', () => {
+    const { result } = renderHook(() => usePresentReviewedMarks('pres-1', 'round-1', ['a.ts', 'b.ts']));
+
+    act(() => result.current.toggleReviewed('a.ts'));
+    expect(result.current.reviewed.has('a.ts')).toBe(true);
+
+    act(() => result.current.toggleReviewed('a.ts'));
+    expect(result.current.reviewed.has('a.ts')).toBe(false);
+  });
+
+  it('markReviewed is idempotent', () => {
+    const { result } = renderHook(() => usePresentReviewedMarks('pres-1', 'round-1', ['a.ts', 'b.ts']));
+
+    act(() => result.current.markReviewed('a.ts'));
+    act(() => result.current.markReviewed('a.ts'));
+    expect(Array.from(result.current.reviewed)).toEqual(['a.ts']);
+  });
+
+  it('persists marks across a remount for the same (presentation, round)', () => {
+    const first = renderHook(() => usePresentReviewedMarks('pres-1', 'round-1', ['a.ts', 'b.ts']));
+    act(() => first.result.current.markReviewed('a.ts'));
+    first.unmount();
+
+    const second = renderHook(() => usePresentReviewedMarks('pres-1', 'round-1', ['a.ts', 'b.ts']));
+    expect(second.result.current.reviewed.has('a.ts')).toBe(true);
+  });
+
+  it('isolates marks between different rounds of the same presentation', () => {
+    const round1 = renderHook(() => usePresentReviewedMarks('pres-1', 'round-1', ['a.ts']));
+    act(() => round1.result.current.markReviewed('a.ts'));
+
+    const round2 = renderHook(() => usePresentReviewedMarks('pres-1', 'round-2', ['a.ts']));
+    expect(round2.result.current.reviewed.size).toBe(0);
+  });
+
+  it('isolates marks between different presentations', () => {
+    const presA = renderHook(() => usePresentReviewedMarks('pres-a', 'round-1', ['a.ts']));
+    act(() => presA.result.current.markReviewed('a.ts'));
+
+    const presB = renderHook(() => usePresentReviewedMarks('pres-b', 'round-1', ['a.ts']));
+    expect(presB.result.current.reviewed.size).toBe(0);
+  });
+
+  it('prunes marks for paths no longer in the manifest and writes the pruned set back', () => {
+    const first = renderHook(({ paths }) => usePresentReviewedMarks('pres-1', 'round-1', paths), {
+      initialProps: { paths: ['a.ts', 'b.ts'] },
+    });
+    act(() => {
+      first.result.current.markReviewed('a.ts');
+      first.result.current.markReviewed('b.ts');
+    });
+    first.unmount();
+
+    // Manifest shrinks to just b.ts (e.g. round was reloaded with a narrower
+    // file list) — a.ts's stale mark should be dropped, not resurrected.
+    const second = renderHook(() => usePresentReviewedMarks('pres-1', 'round-1', ['b.ts']));
+    expect(Array.from(second.result.current.reviewed)).toEqual(['b.ts']);
+
+    const raw = window.localStorage.getItem('attn.present.reviewed.pres-1.round-1');
+    expect(JSON.parse(raw!)).toEqual(['b.ts']);
+  });
+
+  it('null ids yield an empty set and no-op mutations', () => {
+    const { result } = renderHook(() => usePresentReviewedMarks(null, null, ['a.ts']));
+    expect(result.current.reviewed.size).toBe(0);
+
+    act(() => result.current.toggleReviewed('a.ts'));
+    expect(result.current.reviewed.size).toBe(0);
+
+    act(() => result.current.markReviewed('a.ts'));
+    expect(result.current.reviewed.size).toBe(0);
+  });
+});

--- a/app/src/hooks/usePresentReviewedMarks.ts
+++ b/app/src/hooks/usePresentReviewedMarks.ts
@@ -1,0 +1,104 @@
+// app/src/hooks/usePresentReviewedMarks.ts
+// Per-(presentation, round) "reviewed" marks for the Present reader, jaunt
+// style. Persisted in localStorage so a mark survives a window reload but
+// stays scoped to the exact round it was made against — a NEW round id
+// starts with a fresh, empty key. That is the intended mid-round-vs-new-round
+// semantic: reviewing round 1 doesn't pre-mark anything in round 2, since the
+// diff content underneath a path can have changed entirely. Marks are not
+// cleared on submit here — submit-time semantics belong to a later slice.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+function storageKey(presentationId: string, roundId: string): string {
+  return `attn.present.reviewed.${presentationId}.${roundId}`;
+}
+
+function readMarks(key: string): Set<string> {
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((p): p is string => typeof p === 'string'));
+  } catch (err) {
+    console.warn('[usePresentReviewedMarks] Failed to read marks:', err);
+    return new Set();
+  }
+}
+
+function writeMarks(key: string, marks: Set<string>): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(Array.from(marks)));
+  } catch (err) {
+    console.warn('[usePresentReviewedMarks] Failed to persist marks:', err);
+  }
+}
+
+export interface PresentReviewedMarksControls {
+  reviewed: ReadonlySet<string>;
+  toggleReviewed(path: string): void;
+  /** Idempotent — used by the J-advance auto-mark-on-leave behavior. */
+  markReviewed(path: string): void;
+}
+
+export function usePresentReviewedMarks(
+  presentationId: string | null,
+  roundId: string | null,
+  filePaths: string[]
+): PresentReviewedMarksControls {
+  const key = presentationId && roundId ? storageKey(presentationId, roundId) : null;
+  const [reviewed, setReviewed] = useState<Set<string>>(new Set());
+
+  // filePaths is a fresh array identity most renders; only its content should
+  // drive the pruning effect below.
+  const filePathsKey = filePaths.join('\0');
+  const filePathsRef = useRef(filePaths);
+  filePathsRef.current = filePaths;
+
+  // Load on mount / whenever the (presentation, round) identity changes, then
+  // prune any path no longer in the current manifest and write the pruned
+  // set back so the persisted key never drifts from the live file list.
+  useEffect(() => {
+    if (!key) {
+      setReviewed(new Set());
+      return;
+    }
+    const loaded = readMarks(key);
+    const validPaths = new Set(filePathsRef.current);
+    const pruned = new Set(Array.from(loaded).filter((p) => validPaths.has(p)));
+    if (pruned.size !== loaded.size) writeMarks(key, pruned);
+    setReviewed(pruned);
+    // filePathsKey (not filePaths) is the real dependency — see above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, filePathsKey]);
+
+  const toggleReviewed = useCallback(
+    (path: string) => {
+      if (!key) return;
+      setReviewed((current) => {
+        const next = new Set(current);
+        if (next.has(path)) next.delete(path);
+        else next.add(path);
+        writeMarks(key, next);
+        return next;
+      });
+    },
+    [key]
+  );
+
+  const markReviewed = useCallback(
+    (path: string) => {
+      if (!key) return;
+      setReviewed((current) => {
+        if (current.has(path)) return current;
+        const next = new Set(current);
+        next.add(path);
+        writeMarks(key, next);
+        return next;
+      });
+    },
+    [key]
+  );
+
+  return useMemo(() => ({ reviewed, toggleReviewed, markReviewed }), [reviewed, toggleReviewed, markReviewed]);
+}

--- a/app/test-harness/harnesses/PresentTourHarness.tsx
+++ b/app/test-harness/harnesses/PresentTourHarness.tsx
@@ -116,6 +116,7 @@ export function PresentTourHarness({ onReady }: HarnessProps) {
   const [scrollToPath, setScrollToPath] = useState<string | null>(null);
   const [scrollNonce, setScrollNonce] = useState(0);
   const [activePath, setActivePath] = useState<string | null>(null);
+  const [reviewedPaths, setReviewedPaths] = useState<Set<string>>(new Set());
   // When `deferred=1`, files start loading (mirroring PresentRoot's fetch pass)
   // so tests can exercise scroll requests issued before CodeView mounts, then
   // call `settleDiffs()` to supply content and let the tour finish loading.
@@ -175,6 +176,16 @@ export function PresentTourHarness({ onReady }: HarnessProps) {
     setActivePath(path);
   }, []);
 
+  const onToggleReviewed = useCallback((path: string) => {
+    window.__HARNESS__.recordCall('toggleReviewed', [path]);
+    setReviewedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
   useEffect(() => {
     const timer = setTimeout(() => onReady(), 400);
     return () => clearTimeout(timer);
@@ -191,7 +202,8 @@ export function PresentTourHarness({ onReady }: HarnessProps) {
     };
     api.getActivePath = () => activePath;
     api.settleDiffs = () => setDiffsSettled(true);
-  }, [activePath, failNextAddRef]);
+    api.getReviewedPaths = () => Array.from(reviewedPaths);
+  }, [activePath, failNextAddRef, reviewedPaths]);
 
   const files = FILES.map((f) => ({
     path: f.path,
@@ -225,6 +237,8 @@ Three files, reading order alpha -> beta -> gamma.`}
           onSendToClaude={onSendToClaude}
           scrollToPath={scrollToPath}
           scrollNonce={scrollNonce}
+          reviewedPaths={reviewedPaths}
+          onToggleReviewed={onToggleReviewed}
           onActivePathChange={onActivePathChange}
         />
       </div>


### PR DESCRIPTION
## Summary

Slice 2 of the Present reader UX plan (docs/plans/2026-07-07-present-ux-gap.md), frontend-only (no Go, no protocol changes):

- Per-round review progress marks: press `R` to toggle a file reviewed, `J` auto-marks the current file reviewed on leave
- New keyboard model for navigating the review: `J`/`K` to move between files, `R` to toggle reviewed, `S` for the submit dialog
- New `DriveBar` component surfacing the keyboard model and current position
- Rail header now shows review progress for the round
- Submit dialog shows an advisory coverage line (e.g. "3 of 5 files reviewed") — advisory only, does not block submission
- `usePresentReviewedMarks` persists marks to localStorage, keyed per round, so progress survives a window reload

## Verification

- Automated: `PresentRoot.test.tsx` and `usePresentReviewedMarks.test.ts` cover the new hook and keyboard/marking behavior; `present-tour.spec.ts` e2e coverage extended
- Live-verified in attn-dev by the orchestrating session: `R`/`J`/`K`/`S` keyboard semantics, the CodeView version-bump render path, and localStorage persistence across a window reload — all confirmed with screenshots

## Note for reviewers

`usePresentReviewedMarks.ts` uses `'\0'` as the memo-key join separator deliberately — it's collision-proof for file paths that contain spaces.