### PR TITLE
feat(present): rail anatomy — per-file ± stats, comment chips, pinned Summary row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Added
 - **Present now tracks your review progress and gives you a fuller keyboard model.** Mark a file reviewed with `R`, or just keep moving with `J`/`K` — leaving a file with `J` marks it reviewed automatically, jaunt-style. Progress shows in the file rail (a header count and thin progress bar, plus a checkmark and dimmed styling on reviewed rows) and in a new bottom drive bar with its own progress meter, keyboard hints, and the "Submit review" button (now bound to `S`). Each file's diff header also gets its own Reviewed toggle. The submit dialog lists any files you haven't walked yet as an advisory note — it never blocks submission. Marks are saved locally per round, so they survive a window reload but start fresh on a new round.
+- **Present's file rail is more informative.** Each file row now shows its line change count (`+added`/`−removed`) and a chip with its comment count, when it has any. A new pinned "Summary" row at the top of the rail jumps you back to the round's summary card.
 
 ## [2026-07-07]
 

--- a/app/src/components/PresentRoot/PresentRoot.css
+++ b/app/src/components/PresentRoot/PresentRoot.css
@@ -231,6 +231,24 @@
   border-top: 1px solid var(--color-border-subtle);
 }
 
+.present-root-summary-row {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-weight: 600;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.present-root-summary-row:hover {
+  background: var(--color-border-subtle);
+}
+
+.present-root-summary-row.selected {
+  background: var(--color-accent);
+  color: #fff;
+}
+
 .present-root-file {
   display: flex;
   align-items: center;
@@ -280,6 +298,46 @@
 
 .present-root-file.selected .present-root-file-note-marker {
   color: #fff;
+}
+
+.present-root-file-comment-chip {
+  flex: 0 0 auto;
+  min-width: 15px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--color-accent, #5b8cff);
+  color: #fff;
+  font-size: 10px;
+  line-height: 15px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.present-root-file.selected .present-root-file-comment-chip {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.present-root-file-stats {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  font-family: monospace;
+}
+
+.present-root-file-stats .adds {
+  color: var(--color-diff-add, #3fb950);
+}
+
+.present-root-file-stats .dels {
+  color: var(--color-diff-del, #f85149);
+}
+
+.present-root-file.selected .present-root-file-stats .adds,
+.present-root-file.selected .present-root-file-stats .dels {
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .present-root-file.reviewed:not(.selected) {

--- a/app/src/components/PresentRoot/PresentRoot.test.tsx
+++ b/app/src/components/PresentRoot/PresentRoot.test.tsx
@@ -202,6 +202,17 @@ const roundWithSkip = {
   },
 };
 
+const roundWithStats = {
+  ...round,
+  manifest: {
+    ...round.manifest,
+    files: [
+      { path: 'src/foo.ts', note: 'Core logic', additions: 12, deletions: 3 },
+      { path: 'src/foo.test.ts' },
+    ],
+  },
+};
+
 const presentation = {
   id: 'pres-1',
   created_at: '2026-07-01T00:00:00Z',
@@ -364,6 +375,93 @@ describe('PresentRoot', () => {
     const unnotedItem = screen.getByText('src/foo.test.ts').closest('li');
     expect(notedItem?.querySelector('.present-root-file-note-marker')).not.toBeNull();
     expect(unnotedItem?.querySelector('.present-root-file-note-marker')).toBeNull();
+  });
+
+  it('renders per-file ± stats when the round carries them, and omits them otherwise', async () => {
+    await loadRound({ round: roundWithStats });
+
+    const statted = screen.getByText('src/foo.ts').closest('li');
+    const statsEl = statted?.querySelector('.present-root-file-stats');
+    expect(statsEl).not.toBeNull();
+    expect(statsEl?.querySelector('.adds')?.textContent).toBe('+12');
+    expect(statsEl?.querySelector('.dels')?.textContent).toBe('−3');
+
+    const unstatted = screen.getByText('src/foo.test.ts').closest('li');
+    expect(unstatted?.querySelector('.present-root-file-stats')).toBeNull();
+  });
+
+  it('shows a comment-count chip on rows with submitted comments or drafts, sized to the count', async () => {
+    await loadRound({
+      comments: [
+        {
+          id: 'submitted-1',
+          content: 'from a prior round',
+          filepath: 'src/foo.ts',
+          line_start: 2,
+          line_end: 2,
+          side: 'new',
+          author: 'user',
+          created_at: '2026-07-01T00:00:00Z',
+          round_id: 'round-0',
+        },
+        {
+          id: 'submitted-2',
+          content: 'a second one',
+          filepath: 'src/foo.ts',
+          line_start: 4,
+          line_end: 4,
+          side: 'new',
+          author: 'user',
+          created_at: '2026-07-01T00:00:00Z',
+          round_id: 'round-0',
+        },
+      ],
+    });
+
+    const withComments = screen.getByText('src/foo.ts').closest('li');
+    expect(withComments?.querySelector('.present-root-file-comment-chip')?.textContent).toBe('2');
+
+    const noComments = screen.getByText('src/foo.test.ts').closest('li');
+    expect(noComments?.querySelector('.present-root-file-comment-chip')).toBeNull();
+
+    // A local, not-yet-submitted draft bumps the chip too.
+    await act(async () => {
+      latestTourProps().onAddComment('src/foo.test.ts', 1, 1, 'draft comment');
+    });
+    await waitFor(() => {
+      expect(screen.getByText('src/foo.test.ts').closest('li')?.querySelector('.present-root-file-comment-chip')?.textContent).toBe('1');
+    }, WAIT_OPTS);
+  });
+
+  it('the pinned Summary row scrolls to the top and a file row click still works afterward', async () => {
+    await loadRound();
+
+    await waitFor(() => {
+      expect(screen.getByText('src/foo.ts').closest('li')).toHaveClass('selected');
+    }, WAIT_OPTS);
+
+    const summaryRow = screen.getByTestId('present-root-summary-row');
+    fireEvent.click(summaryRow);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('present-root-summary-row')).toHaveClass('selected');
+    }, WAIT_OPTS);
+    expect(screen.getByText('src/foo.ts').closest('li')).not.toHaveClass('selected');
+
+    const propsAfterSummaryClick = latestTourProps();
+    expect(propsAfterSummaryClick.scrollToPath).toBeNull();
+    expect(propsAfterSummaryClick.scrollNonce).toBeGreaterThan(0);
+    const nonceAfterSummary = propsAfterSummaryClick.scrollNonce;
+
+    fireEvent.click(screen.getByText('src/foo.test.ts'));
+    await waitFor(() => {
+      expect(screen.getByText('src/foo.test.ts').closest('li')).toHaveClass('selected');
+    }, WAIT_OPTS);
+    expect(screen.getByTestId('present-root-summary-row')).not.toHaveClass('selected');
+
+    const propsAfterFileClick = latestTourProps();
+    expect(propsAfterFileClick.scrollToPath).toBe('src/foo.test.ts');
+    expect(propsAfterFileClick.scrollNonce).toBeGreaterThan(nonceAfterSummary ?? 0);
   });
 
   it('fetches every manifest file’s diff up front, exactly once per round', async () => {

--- a/app/src/components/PresentRoot/index.tsx
+++ b/app/src/components/PresentRoot/index.tsx
@@ -138,7 +138,7 @@ export function PresentRoot() {
   // passive activePath update from scrolling can never itself re-trigger a
   // programmatic scroll (which would fight the user's own scroll gesture).
   const [activePath, setActivePath] = useState<string | null>(null);
-  const [scrollRequest, setScrollRequest] = useState<{ path: string; nonce: number } | null>(null);
+  const [scrollRequest, setScrollRequest] = useState<{ path: string | null; nonce: number } | null>(null);
   const scrollNonceRef = useRef(0);
   const [fileDiffs, setFileDiffs] = useState<Record<string, DiffCacheEntry>>({});
   const [driftDismissed, setDriftDismissed] = useState(false);
@@ -156,7 +156,8 @@ export function PresentRoot() {
   const activeRoundKeyRef = useRef<string | null>(null);
   activeRoundKeyRef.current = round ? round.id : null;
 
-  const requestScroll = useCallback((path: string) => {
+  // path=null requests a scroll to the pinned Summary row (stop 0).
+  const requestScroll = useCallback((path: string | null) => {
     scrollNonceRef.current += 1;
     setActivePath(path);
     setScrollRequest({ path, nonce: scrollNonceRef.current });
@@ -356,6 +357,14 @@ export function PresentRoot() {
     () => new Set(allComments.filter((c) => !draftIds.has(c.id)).map((c) => c.id)),
     [allComments, draftIds]
   );
+  // Rail comment chip: submitted comments (unresolved and resolved alike)
+  // plus in-progress drafts, per file.
+  const commentCountByPath = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const c of comments) counts.set(c.filepath, (counts.get(c.filepath) ?? 0) + 1);
+    for (const d of drafts) counts.set(d.filepath, (counts.get(d.filepath) ?? 0) + 1);
+    return counts;
+  }, [comments, drafts]);
   const tourFiles = useMemo<PresentTourFile[]>(
     () =>
       files.map((file) => ({
@@ -541,8 +550,19 @@ export function PresentRoot() {
           </div>
 
           <ol className="present-root-files" ref={railRef}>
+            <li
+              key="__summary__"
+              data-testid="present-root-summary-row"
+              className={`present-root-summary-row ${activePath === null ? 'selected' : ''}`}
+              onClick={() => requestScroll(null)}
+            >
+              <span className="present-root-file-path">Summary</span>
+            </li>
+
             {files.map((file, index) => {
               const isReviewed = reviewed.has(file.path);
+              const commentCount = commentCountByPath.get(file.path) ?? 0;
+              const hasStats = file.additions !== undefined || file.deletions !== undefined;
               return (
                 <li
                   key={file.path}
@@ -553,6 +573,17 @@ export function PresentRoot() {
                   <span className="present-root-file-index">{isReviewed ? '✓' : index + 1}</span>
                   <code className="present-root-file-path">{file.path}</code>
                   {file.note && <span className="present-root-file-note-marker" title="Has a note">●</span>}
+                  {commentCount > 0 && (
+                    <span className="present-root-file-comment-chip" title={`${commentCount} comment${commentCount === 1 ? '' : 's'}`}>
+                      {commentCount}
+                    </span>
+                  )}
+                  {hasStats && (
+                    <span className="present-root-file-stats">
+                      {file.additions !== undefined && <span className="adds">+{file.additions}</span>}
+                      {file.deletions !== undefined && <span className="dels">−{file.deletions}</span>}
+                    </span>
+                  )}
                 </li>
               );
             })}

--- a/app/src/components/PresentTour/index.tsx
+++ b/app/src/components/PresentTour/index.tsx
@@ -88,8 +88,10 @@ export interface PresentTourProps {
    * with `scrollNonce` so re-clicking the same file still re-scrolls. */
   scrollToPath?: string | null;
   scrollNonce?: number;
-  /** Fires with the path nearest the top of the viewport as the user scrolls. */
-  onActivePathChange?: (path: string) => void;
+  /** Fires with the path nearest the top of the viewport as the user scrolls,
+   * or null when the viewport is scrolled to the very top (the summary
+   * region, above the first file). */
+  onActivePathChange?: (path: string | null) => void;
   /** Paths the user has marked reviewed (jaunt-style per-file mark). */
   reviewedPaths: ReadonlySet<string>;
   onToggleReviewed: (path: string) => void;
@@ -523,7 +525,13 @@ export function PresentTour({
   }, []);
 
   // Rail-driven / j-k-driven scroll: nonce forces a re-scroll even to the
-  // same path (e.g. re-pressing j at the last file).
+  // same path (e.g. re-pressing j at the last file). A null scrollToPath
+  // paired with an advanced nonce means "scroll to the summary" (stop 0):
+  // the rail's pinned Summary row has no item id to scroll to, so this
+  // resets the scroller itself to the top instead of asking CodeView to
+  // resolve an item. `scrollNonce` (not scrollToPath) is what distinguishes
+  // "no request yet" (nonce still at its initial 0) from an explicit
+  // scroll-to-summary request, since scrollToPath is null in both cases.
   //
   // This request is itself deliberate user-driven navigation, but it does
   // not fire a native wheel/touch/pointerdown/keydown ON THE SCROLLER (the
@@ -559,18 +567,25 @@ export function PresentTour({
   useEffect(() => {
     const wasSettled = wasSettledRef.current;
     wasSettledRef.current = allSettled;
-    if (!scrollToPath || !allSettled) return;
+    const hasRequest = (scrollNonce ?? 0) > 0;
+    if (!hasRequest || !allSettled) return;
     const handle = handleRef.current;
     if (!handle) return;
     userTookOverRef.current = true;
-    if (!wasSettled) {
-      const raf = requestAnimationFrame(() => {
+    const performScroll = () => {
+      if (scrollToPath) {
         handle.scrollTo({ type: 'item', id: scrollToPath, align: 'start', behavior: 'smooth' });
-      });
+      } else {
+        containerRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+    };
+    if (!wasSettled) {
+      const raf = requestAnimationFrame(performScroll);
       return () => cancelAnimationFrame(raf);
     }
-    handle.scrollTo({ type: 'item', id: scrollToPath, align: 'start', behavior: 'smooth' });
-    // scrollNonce intentionally included so repeat clicks on the same path re-fire.
+    performScroll();
+    // scrollNonce intentionally included so repeat clicks on the same path (or
+    // repeat clicks on Summary) re-fire.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollToPath, scrollNonce, allSettled]);
 
@@ -583,6 +598,12 @@ export function PresentTour({
   const handleScroll = useCallback(
     (scrollTop: number) => {
       if (!onActivePathChange || !containerRef.current) return;
+      // At the very top of the scroller there is nothing above the first
+      // file to have scrolled past — this is the summary region.
+      if (scrollTop <= 0) {
+        onActivePathChange(null);
+        return;
+      }
       const instance = handleRef.current?.getInstance();
       if (!instance) return;
       const containerTop = containerRef.current.getBoundingClientRect().top;
@@ -605,7 +626,6 @@ export function PresentTour({
       }
       const path = bestPath ?? nearestPath;
       if (path) onActivePathChange(path);
-      void scrollTop;
     },
     [onActivePathChange]
   );

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '150';
+export const PROTOCOL_VERSION = '151';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1312,8 +1312,10 @@ export interface Manifest {
 }
 
 export interface FileElement {
-    note?: string;
-    path:  string;
+    additions?: number;
+    deletions?: number;
+    note?:      string;
+    path:       string;
     [property: string]: any;
 }
 
@@ -2429,8 +2431,10 @@ export interface PresentFeedbackResult {
 }
 
 export interface PresentFile {
-    note?: string;
-    path:  string;
+    additions?: number;
+    deletions?: number;
+    note?:      string;
+    path:       string;
     [property: string]: any;
 }
 
@@ -7703,6 +7707,8 @@ const typeMap: any = {
         { json: "title", js: "title", typ: "" },
     ], "any"),
     "FileElement": o([
+        { json: "additions", js: "additions", typ: u(undefined, 0) },
+        { json: "deletions", js: "deletions", typ: u(undefined, 0) },
         { json: "note", js: "note", typ: u(undefined, "") },
         { json: "path", js: "path", typ: "" },
     ], "any"),
@@ -8357,6 +8363,8 @@ const typeMap: any = {
         { json: "submitted", js: "submitted", typ: true },
     ], "any"),
     "PresentFile": o([
+        { json: "additions", js: "additions", typ: u(undefined, 0) },
+        { json: "deletions", js: "deletions", typ: u(undefined, 0) },
         { json: "note", js: "note", typ: u(undefined, "") },
         { json: "path", js: "path", typ: "" },
     ], "any"),

--- a/internal/daemon/present.go
+++ b/internal/daemon/present.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -328,8 +329,73 @@ func (d *Daemon) handleGetPresentationRound(client *wsClient, msg *protocol.GetP
 		result.RepoHeadSHA = protocol.Ptr(strings.TrimSpace(string(headSHA)))
 	}
 
+	// Per-file ± line stats are a progressive enhancement for the rail: a
+	// lookup failure or empty result must never fail the round fetch.
+	if stats := d.presentFileStats(pres.RepoPath, round.BaseSHA, round.HeadSHA); len(stats) > 0 {
+		for i := range result.Round.Manifest.Files {
+			path := result.Round.Manifest.Files[i].Path
+			if s, ok := stats[path]; ok {
+				result.Round.Manifest.Files[i].Additions = protocol.Ptr(s[0])
+				result.Round.Manifest.Files[i].Deletions = protocol.Ptr(s[1])
+			}
+		}
+	}
+
 	result.Success = true
 	d.sendToClient(client, result)
+}
+
+// presentFileStats returns path -> [additions, deletions] for the pinned
+// base..head diff, from `git diff --numstat`. Binary files (numstat "-") are
+// omitted. Rename lines are skipped — the numstat rename encoding
+// ("old => new" or "{old => new}/tail") doesn't cleanly resolve to a single
+// manifest path, and leaving those files stats-less is an accepted
+// limitation. Errors return nil; stats are a progressive enhancement and
+// must never fail a round fetch.
+func (d *Daemon) presentFileStats(repoDir, baseSHA, headSHA string) map[string][2]int {
+	out, err := attngit.Output(attngit.OpDiff, repoDir, "diff", "--numstat", baseSHA+".."+headSHA)
+	if err != nil {
+		return nil
+	}
+	return parsePresentNumstat(string(out))
+}
+
+// parsePresentNumstat parses `git diff --numstat` output into path ->
+// [additions, deletions]. Lines are tab-separated: additions, deletions,
+// path. Binary files report "-" for both counts and are omitted. Rename
+// lines carry a path field containing " => " (optionally with a "{old =>
+// new}" brace segment) and are skipped rather than guessed at.
+func parsePresentNumstat(output string) map[string][2]int {
+	result := make(map[string][2]int)
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		if parts[0] == "-" || parts[1] == "-" {
+			// Binary file: no line stats available.
+			continue
+		}
+		additions, err := strconv.Atoi(parts[0])
+		if err != nil {
+			continue
+		}
+		deletions, err := strconv.Atoi(parts[1])
+		if err != nil {
+			continue
+		}
+		path := parts[2]
+		if strings.Contains(path, " => ") {
+			// Rename line — accepted limitation, see doc comment.
+			continue
+		}
+		result[path] = [2]int{additions, deletions}
+	}
+	return result
 }
 
 // handlePresentSubmitRound hands a round's review back to the authoring

--- a/internal/daemon/present_test.go
+++ b/internal/daemon/present_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -268,5 +269,139 @@ func TestHandleGetPresentationRound_CarriesRepoHeadSHA(t *testing.T) {
 	}
 	if res.RepoHeadSHA == nil || *res.RepoHeadSHA != headSHA {
 		t.Errorf("repo_head_sha = %v, want %q", res.RepoHeadSHA, headSHA)
+	}
+}
+
+// presentStatsTestRepo creates a base commit with a.txt and img.png (a fake
+// binary blob), then a head commit that grows a.txt, adds b.txt, and
+// modifies img.png — so tests can assert numstat-derived additions/deletions
+// per file, including the binary-file omission case.
+func presentStatsTestRepo(t *testing.T) (dir, baseSHA, headSHA string) {
+	t.Helper()
+	dir = t.TempDir()
+	run := func(args ...string) string {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	run("init")
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("line1\nline2\n"), 0o644); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	// A NUL byte marks this blob as binary to git, without needing a real PNG.
+	if err := os.WriteFile(filepath.Join(dir, "img.png"), []byte{0x89, 0x00, 0x50, 0x4e}, 0o644); err != nil {
+		t.Fatalf("write img.png: %v", err)
+	}
+	run("add", "a.txt", "img.png")
+	run("commit", "-m", "base")
+	baseSHA = run("rev-parse", "HEAD")
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("line1\nline2\nline3\nline4\n"), 0o644); err != nil {
+		t.Fatalf("update a.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.txt"), []byte("new file\n"), 0o644); err != nil {
+		t.Fatalf("write b.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "img.png"), []byte{0x89, 0x00, 0x50, 0x4e, 0x01, 0x02}, 0o644); err != nil {
+		t.Fatalf("update img.png: %v", err)
+	}
+	run("add", "a.txt", "b.txt", "img.png")
+	run("commit", "-m", "head")
+	headSHA = run("rev-parse", "HEAD")
+
+	return dir, baseSHA, headSHA
+}
+
+func TestHandleGetPresentationRound_CarriesFileStats(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	repoDir, baseSHA, headSHA := presentStatsTestRepo(t)
+
+	manifestYAML := fmt.Sprintf(
+		"version: 1\nkind: changes\ntitle: %q\nframe:\n  repo: %q\n  base: %q\n  head: %q\nfiles:\n  - path: a.txt\n  - path: b.txt\n  - path: img.png\n",
+		"Stats Change", repoDir, baseSHA, headSHA,
+	)
+
+	opened := callPresentOpen(t, d, &protocol.PresentOpenMessage{
+		Cmd:             protocol.CmdPresentOpen,
+		SourceSessionID: "session-1",
+		ManifestYaml:    manifestYAML,
+	})
+	if !opened.Ok || opened.PresentOpenResult == nil {
+		t.Fatalf("setup present open response = %+v, want ok", opened)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleGetPresentationRound(client, &protocol.GetPresentationRoundMessage{
+		Cmd:            protocol.CmdGetPresentationRound,
+		PresentationID: opened.PresentOpenResult.PresentationID,
+	})
+	var res protocol.GetPresentationRoundResultMessage
+	readTicketResult(t, client.send, &res)
+	if !res.Success || res.Round == nil {
+		t.Fatalf("get_presentation_round = %+v, want success with a round", res)
+	}
+
+	byPath := make(map[string]protocol.PresentFile, len(res.Round.Manifest.Files))
+	for _, f := range res.Round.Manifest.Files {
+		byPath[f.Path] = f
+	}
+
+	aTxt, ok := byPath["a.txt"]
+	if !ok {
+		t.Fatalf("a.txt missing from manifest files: %+v", byPath)
+	}
+	if aTxt.Additions == nil || *aTxt.Additions != 2 || aTxt.Deletions == nil || *aTxt.Deletions != 0 {
+		t.Errorf("a.txt stats = +%v/-%v, want +2/-0", derefIntOrNil(aTxt.Additions), derefIntOrNil(aTxt.Deletions))
+	}
+
+	bTxt, ok := byPath["b.txt"]
+	if !ok {
+		t.Fatalf("b.txt missing from manifest files: %+v", byPath)
+	}
+	if bTxt.Additions == nil || *bTxt.Additions != 1 || bTxt.Deletions == nil || *bTxt.Deletions != 0 {
+		t.Errorf("b.txt stats = +%v/-%v, want +1/-0", derefIntOrNil(bTxt.Additions), derefIntOrNil(bTxt.Deletions))
+	}
+
+	imgPNG, ok := byPath["img.png"]
+	if !ok {
+		t.Fatalf("img.png missing from manifest files: %+v", byPath)
+	}
+	if imgPNG.Additions != nil || imgPNG.Deletions != nil {
+		t.Errorf("img.png (binary) stats = +%v/-%v, want absent", derefIntOrNil(imgPNG.Additions), derefIntOrNil(imgPNG.Deletions))
+	}
+}
+
+func derefIntOrNil(p *int) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return strconv.Itoa(*p)
+}
+
+func TestParsePresentNumstat(t *testing.T) {
+	input := "2\t0\ta.txt\n1\t0\tb.txt\n-\t-\timg.png\n3\t1\told.txt => new.txt\n4\t2\t{old => new}/renamed.txt\n"
+
+	stats := parsePresentNumstat(input)
+
+	if got, want := stats["a.txt"], [2]int{2, 0}; got != want {
+		t.Errorf("a.txt = %v, want %v", got, want)
+	}
+	if got, want := stats["b.txt"], [2]int{1, 0}; got != want {
+		t.Errorf("b.txt = %v, want %v", got, want)
+	}
+	if _, ok := stats["img.png"]; ok {
+		t.Errorf("binary file img.png should be omitted, got %v", stats["img.png"])
+	}
+	if len(stats) != 2 {
+		t.Errorf("expected only 2 non-binary, non-rename entries, got %v", stats)
 	}
 }

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "150"
+const ProtocolVersion = "151"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2117,6 +2117,12 @@ type PresentFeedbackResult struct {
 }
 
 type PresentFile struct {
+	// Additions corresponds to the JSON schema field "additions".
+	Additions *int `json:"additions,omitempty,omitzero"`
+
+	// Deletions corresponds to the JSON schema field "deletions".
+	Deletions *int `json:"deletions,omitempty,omitzero"`
+
 	// Note corresponds to the JSON schema field "note".
 	Note *string `json:"note,omitempty,omitzero"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -163,6 +163,10 @@ model WorkspaceContext {
 model PresentFile {
   path: string;
   note?: string;
+  // Line stats for this file across the round's pinned base..head diff,
+  // from git numstat. Absent when unknown (binary file, or stats lookup failed).
+  additions?: int32;
+  deletions?: int32;
 }
 
 // PresentManifestView is the parsed, daemon-pinned view of a present manifest —


### PR DESCRIPTION
Extends the Present reader's left file rail, jaunt-style: per-file +N/−M line stats sourced daemon-side from `git diff --numstat` over the round's pinned base..head SHAs (exactly consistent with what FileDiff renders); a comment-count chip counting submitted comments + local drafts per file; a pinned Summary row that scrolls the tour back to the summary card and highlights when the tour is scrolled above the first file.

Protocol: PresentFile gains optional `additions`/`deletions`; ProtocolVersion bumped 150 → 151 (all three lockstep spots: constants.go, generated files, useDaemonSocket.ts PROTOCOL_VERSION).

Accepted limitation: binary files and renames are left stats-less (numstat `-` counts and `=>` rename paths are skipped, documented in code).

Testing: Go daemon tests (fixture repo incl. binary-file case + pure numstat parser test incl. both rename forms), jsdom PresentRoot tests (stats render/omit, chip counts, Summary click → scroll-request contract), full frontend suite green, tsc clean. Live-verified in attn-dev: stats match git numstat exactly on a real round, Summary row highlights at scrollTop 0 and yields to file rows on scroll, slice-2 J/K/R progress behavior intact.

https://claude.ai/code/session_01MvgEqMMAkmqJQezpgLNjzQ