### PR TITLE
fix(tickets): keep chief awareness across session changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-08]
 
 ### Fixed
+- **Your chief keeps every delegated ticket when you switch chief sessions.** Unread ticket activity now belongs to the durable chief-of-staff role instead of the session that happened to create the ticket. The new chief picks up at the same unread position and receives future nudges, while the retired chief stops receiving role notifications. Existing active delegations are carried forward automatically.
 - **Present reader polish.** The keyboard (`K`) now reaches the summary stop from the first file, the summary is the initial stop when a round opens, and jumping to an annotation in a far file no longer under-scrolls on the first press.
 - **Closing a delegated session no longer marks its ticket as Crashed.** Closing an agent's pane (or tearing down its workspace) while the session still looked busy used to be treated like a process death: the bound ticket — often already sitting In Review with finished work — was stamped Crashed. An intentional close now leaves the ticket exactly where the agent last reported it, and the reconciliation verdict still posts, framed as a clean close. The close is also remembered durably, so it is honored even when the reconciliation runs late — after a daemon restart, for example. Genuine unexpected agent deaths are still detected and stamped Crashed exactly as before.
 

--- a/docs/plans/2026-07-08-chief-ticket-continuity.md
+++ b/docs/plans/2026-07-08-chief-ticket-continuity.md
@@ -1,0 +1,69 @@
+# Plan: Chief ticket continuity
+
+## Why / Alignment
+
+The chief-of-staff role is durable even though the session filling it can change. Chief-delegated tickets must therefore keep their unread history and notification ownership across a role transfer. Event authorship remains session-scoped for audit; it must not double as durable participation.
+
+This chunk covers chief-delegated ticket ownership, inbox consumption, event routing, role-transfer nudge cleanup, and upgrade backfill. Ordinary assignment and explicit subscription behavior stay session-scoped. Runtime-specific waiting remains unchanged: Claude may drain `ticket inbox --watch`; Codex relies on nudges and one-shot inbox reads.
+
+## Architecture Map
+
+```text
+Current:
+chief session creates ticket
+  -> created-event authorship implies participation
+    -> session cursor owns unread state
+      -> role transfer loses ticket scope and delivery
+
+Target:
+chief session creates ticket (session remains event author)
+  -> durable ticket role ownership: chief_of_staff
+    -> durable role cursor owns chief unread state
+      -> current profile-role holder resolves as delivery target
+
+Active chief inbox:
+  -> consume personal session identity (assignment / explicit subscription)
+  -> consume durable chief role identity (chief-owned tickets)
+  -> merge and deduplicate events by sequence
+```
+
+## Data Model / Interfaces
+
+```text
+ticket_role_owners(role, ticket_id, created_at)
+  primary key: (role, ticket_id)
+  role: chief_of_staff
+
+ticket_event_cursors(identity, ticket_id, cursor, updated_at)
+  durable chief cursor identity: role:chief_of_staff
+  session identities remain unchanged for ordinary participation
+```
+
+## Boundaries
+
+- The store owns durable role participation and cursor scope.
+- The daemon resolves a durable role observer to the current live session and its runtime delivery capability.
+- Ticket events retain the concrete author session; role-owned creation does not permanently subscribe that session.
+- Role transfer changes delivery only. It never copies or advances a cursor.
+
+## Implementation Steps
+
+- [x] Add durable role ownership storage and migration/backfill for active pre-fix delegated tickets.
+- [x] Create chief-delegated tickets with durable chief ownership.
+- [x] Resolve chief inbox/unread checks across personal and role identities without duplicates.
+- [x] Route role notifications to only the active chief and clean up stale timers on transfer.
+- [x] Add coverage for transfer, cursor continuity, retired-chief silence, ordinary participants, migration, and runtime guidance.
+- [x] Run focused and full relevant tests, live-profile verification, changelog update, review, and PR packaging.
+
+## Decisions
+
+- Do not copy session cursors during transfer: the durable role cursor is the single chief bookmark.
+- Keep role ownership separate from explicit subscriptions so `ticket unsubscribe` cannot remove product-owned chief awareness.
+- Backfill ownership without creating or advancing cursors, preserving every unread event.
+
+## Verification
+
+- Focused continuity and guidance tests pass under the race detector.
+- `go vet` passes for the store, notifier, and daemon packages.
+- The uncached full Go suite passes serially. Parallel full-suite runs exposed an unrelated load-sensitive timeout in the Codex resume mapping test; that test and the full daemon package both pass independently.
+- The signed `attn-dev.app` package passes the real-app ticket lifecycle scenario, and the migrated dev database records the ticket under durable chief role ownership without pre-seeding its role cursor.

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
 )
 
 const profileRoleChiefOfStaff = "chief_of_staff"
@@ -53,11 +54,7 @@ func (d *Daemon) delegatedFromChiefSessionIDs() map[string]bool {
 	if d.store == nil {
 		return nil
 	}
-	chiefSessionID := d.chiefOfStaffSessionID()
-	if chiefSessionID == "" {
-		return nil
-	}
-	return d.store.DelegatedFromChiefSessionIDs(chiefSessionID)
+	return d.store.TicketAssigneesOwnedByRole(store.TicketRoleChiefOfStaff)
 }
 
 // decorateDelegatedFromChief marks a session that was delegated from the chief
@@ -210,6 +207,11 @@ func (d *Daemon) handleSetChiefOfStaff(client *wsClient, msg *protocol.SetChiefO
 		roleChanged = previousSessionID == sessionID
 	}
 	if roleChanged {
+		newChiefSessionID := ""
+		if msg.ChiefOfStaff {
+			newChiefSessionID = sessionID
+		}
+		d.retargetChiefTicketDelivery(previousSessionID, newChiefSessionID)
 		go d.reloadSessionAgent(sessionID)
 		// A role transfer (promote B while A still held it) demotes A via the
 		// single-holder upsert. Reload A too so the displaced chief drops the guidance
@@ -220,6 +222,18 @@ func (d *Daemon) handleSetChiefOfStaff(client *wsClient, msg *protocol.SetChiefO
 		}
 	}
 	d.sendChiefOfStaffResult(client, sessionID, msg.ChiefOfStaff, previousSessionID, nil)
+}
+
+// retargetChiefTicketDelivery moves only the live delivery target. Durable role
+// ownership and its cursors do not move, copy, or advance.
+func (d *Daemon) retargetChiefTicketDelivery(previousSessionID, newSessionID string) {
+	if previousSessionID != "" {
+		d.cancelTicketBackstop(previousSessionID)
+		d.refreshTicketUnread(previousSessionID)
+	}
+	if newSessionID != "" {
+		d.notifyTicketSession(newSessionID, time.Now())
+	}
 }
 
 func (d *Daemon) sendChiefOfStaffResult(

--- a/internal/daemon/delegate_ticket.go
+++ b/internal/daemon/delegate_ticket.go
@@ -33,10 +33,10 @@ func ticketSlug(label string) string {
 // createDelegatedTicket creates and binds the ticket for a chief-delegated session.
 // The brief is the description (the delegation prompt); the session id is the
 // assignee (its observer identity, so assignee == session is the binding); the
-// chief is the author (so the created event reads as "assigned to you" for the
-// agent and is self-authored for the chief). The ticket starts in Working since the
-// agent begins immediately. The slug is derived from the label, with a numeric
-// suffix on collision. Returns the created ticket id.
+// concrete chief session is the event author for audit, while durable chief-role
+// ownership supplies participation and the unread cursor. The ticket starts in
+// Working since the agent begins immediately. The slug is derived from the label,
+// with a numeric suffix on collision. Returns the created ticket id.
 func (d *Daemon) createDelegatedTicket(chiefSessionID string, session *protocol.Session, brief, label, agent string) (string, error) {
 	created, err := d.createTicketWithUniqueSlug(store.Ticket{
 		Title:       label,
@@ -45,7 +45,7 @@ func (d *Daemon) createDelegatedTicket(chiefSessionID string, session *protocol.
 		Assignee:    session.ID,
 		Cwd:         session.Directory,
 		LastAgentID: agent,
-	}, ticketSlug(label), chiefSessionID, time.Now())
+	}, ticketSlug(label), chiefSessionID, store.TicketRoleChiefOfStaff, time.Now())
 	if err != nil {
 		return "", err
 	}
@@ -58,13 +58,19 @@ func (d *Daemon) createDelegatedTicket(chiefSessionID string, session *protocol.
 // CreateTicket error verbatim, or a "could not allocate" exhaustion error. Both
 // createDelegatedTicket (bound, working) and the standalone ticket_create handler
 // (unbound, todo) share this so the auto-suffix behavior is identical.
-func (d *Daemon) createTicketWithUniqueSlug(template store.Ticket, base, author string, now time.Time) (*store.Ticket, error) {
+func (d *Daemon) createTicketWithUniqueSlug(template store.Ticket, base, author, ownerRole string, now time.Time) (*store.Ticket, error) {
 	for attempt := 0; attempt < 50; attempt++ {
 		template.ID = base
 		if attempt > 0 {
 			template.ID = fmt.Sprintf("%s-%d", base, attempt+1)
 		}
-		created, err := d.store.CreateTicket(template, author, now)
+		var created *store.Ticket
+		var err error
+		if ownerRole == "" {
+			created, err = d.store.CreateTicket(template, author, now)
+		} else {
+			created, err = d.store.CreateRoleOwnedTicket(template, author, ownerRole, now)
+		}
 		if err == nil {
 			return created, nil
 		}

--- a/internal/daemon/notebook.go
+++ b/internal/daemon/notebook.go
@@ -186,7 +186,7 @@ func (d *Daemon) handleNotebookGuide(conn net.Conn, msg *protocol.NotebookGuideM
 	}
 	sessionID := strings.TrimSpace(protocol.Deref(msg.SessionID))
 	sessionIsChief := sessionID != "" && sessionID == d.chiefOfStaffSessionID()
-	hasSelfMonitor := d.ticketObserverForSession(sessionID).HasSelfMonitor
+	hasSelfMonitor := d.ticketDeliveryObserverForSession(sessionID).HasSelfMonitor
 	if sessionIsChief {
 		if _, _, serr := d.ensureNotebookScaffold(); serr != nil {
 			d.logf("notebook guide: ensure scaffold failed: %v", serr)

--- a/internal/daemon/nudge_countdown.go
+++ b/internal/daemon/nudge_countdown.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
-	"github.com/victorarias/attn/internal/ticketnotify"
 )
 
 // defaultNudgeCountdownWindow is how long an armed ticket nudge waits — visible to
@@ -220,8 +219,7 @@ func (d *Daemon) runNudgeDelivery(sessionID string) string {
 		// Became the active session during the window; switching away re-arms it.
 		return "active"
 	}
-	obs := d.ticketObserverForSession(sessionID)
-	unread, err := ticketnotify.Unread(d.store, obs)
+	unread, err := d.ticketUnreadForSession(sessionID)
 	if err != nil {
 		d.logf("nudge countdown unread check %s: %v", sessionID, err)
 		return "error"
@@ -281,8 +279,7 @@ func (d *Daemon) refreshTicketUnread(sessionID string) {
 	if d.store == nil {
 		return
 	}
-	obs := d.ticketObserverForSession(sessionID)
-	unread, err := ticketnotify.Unread(d.store, obs)
+	unread, err := d.ticketUnreadForSession(sessionID)
 	if err != nil {
 		d.logf("ticket unread refresh %s: %v", sessionID, err)
 		return
@@ -317,8 +314,7 @@ func (d *Daemon) handleTriggerNudge(msg *protocol.TriggerNudgeMessage) {
 	if session == nil || isExplicitNudgeBlocked(string(session.State)) {
 		return
 	}
-	obs := d.ticketObserverForSession(sessionID)
-	unread, err := ticketnotify.Unread(d.store, obs)
+	unread, err := d.ticketUnreadForSession(sessionID)
 	if err != nil || unread == 0 {
 		// Nothing to deliver; clear a stale indicator rather than doorbell into nothing.
 		d.markTicketUnread(sessionID, false)

--- a/internal/daemon/ticket_attach_test.go
+++ b/internal/daemon/ticket_attach_test.go
@@ -184,7 +184,7 @@ func TestTicketAttachNotifiesChiefAndBroadcasts(t *testing.T) {
 	// agent is about to self-author. That isolates the fan-out: the chief is nudged
 	// solely because of the attachment, and the self-authoring agent is not nudged.
 	for _, id := range []string{chiefID, agentID} {
-		if _, err := ticketnotify.Consume(d.store, d.ticketObserverForSession(id), time.Now()); err != nil {
+		if _, err := ticketnotify.ConsumeAll(d.store, d.ticketObserversForSession(id), time.Now()); err != nil {
 			t.Fatalf("consume inbox for %s: %v", id, err)
 		}
 	}

--- a/internal/daemon/ticket_create.go
+++ b/internal/daemon/ticket_create.go
@@ -59,7 +59,7 @@ func (d *Daemon) handleTicketCreate(conn net.Conn, msg *protocol.TicketCreateMes
 			Title:       title,
 			Description: desc,
 			Status:      store.TicketStatusTodo,
-		}, ticketSlug(title), author, now)
+		}, ticketSlug(title), author, "", now)
 		if err != nil {
 			d.sendError(conn, "ticket new: "+err.Error())
 			return

--- a/internal/daemon/ticket_notify.go
+++ b/internal/daemon/ticket_notify.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
 	"github.com/victorarias/attn/internal/ticketnotify"
 )
 
@@ -41,7 +42,17 @@ func (d *Daemon) notifyTicketObservers(ticketID string) {
 		return
 	}
 	now := time.Now()
-	for _, id := range participants {
+	targets := make(map[string]bool, len(participants))
+	for _, identity := range participants {
+		id := identity
+		if identity == store.TicketRoleIdentity(store.TicketRoleChiefOfStaff) {
+			id = d.chiefOfStaffSessionID()
+		}
+		if id != "" {
+			targets[id] = true
+		}
+	}
+	for id := range targets {
 		d.notifyTicketSession(id, now)
 	}
 }
@@ -63,9 +74,9 @@ func (d *Daemon) notifyTicketSession(sessionID string, now time.Time) {
 	// the delivery mechanism (nudge / self-monitor watch / deferred-until-idle), so a
 	// working agent and a self-monitoring Claude both surface the unread marker.
 	d.refreshTicketUnread(sessionID)
-	obs := d.ticketObserverForSession(sessionID)
+	observers := d.ticketObserversForSession(sessionID)
 	idle := isIdleForNudge(string(session.State))
-	delivery, err := ticketnotify.Notify(d.store, obs, idle, ticketNudger{d}, now)
+	delivery, err := ticketnotify.NotifyAny(d.store, observers, observers[0], idle, ticketNudger{d}, now)
 	if err != nil {
 		d.logf("ticket notify: %s: %v", sessionID, err)
 		return
@@ -151,8 +162,7 @@ func (d *Daemon) ticketBackstopRecheck(sessionID string) {
 	if session == nil || !isIdleForNudge(string(session.State)) {
 		return
 	}
-	obs := d.ticketObserverForSession(sessionID)
-	unread, err := ticketnotify.Unread(d.store, obs)
+	unread, err := d.ticketUnreadForSession(sessionID)
 	if err != nil {
 		d.logf("ticket backstop: %s: %v", sessionID, err)
 		return
@@ -175,6 +185,17 @@ func (d *Daemon) stopTicketBackstops() {
 		t.Stop()
 		delete(d.ticketBackstopTimers, id)
 	}
+}
+
+// cancelTicketBackstop removes one session's pending self-monitor re-check. Role
+// transfer uses it so a displaced chief cannot receive a stale role doorbell.
+func (d *Daemon) cancelTicketBackstop(sessionID string) {
+	d.ticketBackstopMu.Lock()
+	if timer := d.ticketBackstopTimers[sessionID]; timer != nil {
+		timer.Stop()
+		delete(d.ticketBackstopTimers, sessionID)
+	}
+	d.ticketBackstopMu.Unlock()
 }
 
 // notifyTicketSessionWentIdle flushes a deferred nudge: a non-self-monitor that was

--- a/internal/daemon/ticket_notify_test.go
+++ b/internal/daemon/ticket_notify_test.go
@@ -360,6 +360,92 @@ func TestTicketBackstopDoorbellsIdleChiefAfterAgentReports(t *testing.T) {
 	}
 }
 
+// Chief ticket awareness belongs to the role, not the session that happened to
+// delegate. A consumes one report, the role transfers to B, and the next report
+// reaches only B. The role cursor means B receives exactly the post-transfer
+// unread event: nothing A consumed is replayed and nothing new is skipped.
+func TestChiefTicketContinuityAcrossRoleTransfer(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Hour
+	t.Cleanup(d.stopTicketBackstops)
+	t.Cleanup(d.stopNudgeCountdowns)
+	chiefA, agentID, inputs := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, agentID)
+
+	now := string(protocol.TimestampNow())
+	chiefB := "chief-b"
+	d.store.Add(&protocol.Session{
+		ID: chiefB, Label: "replacement chief", Agent: protocol.SessionAgentCodex,
+		Directory: "/tmp/chief-b", WorkspaceID: "workspace-chief-b",
+		State: protocol.SessionStateIdle, StateSince: now, StateUpdatedAt: now, LastSeen: now,
+	})
+	d.store.UpdateState(chiefA, protocol.StateIdle)
+	d.store.UpdateState(agentID, protocol.StateIdle)
+
+	// A consumes the first agent report, advancing the durable role cursor.
+	callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateNeedsInput), "need a decision")
+	first := callTicketInbox(t, d, chiefA)
+	if len(first) != 1 || len(first[0].Events) != 1 ||
+		first[0].Events[0].ToStatus == nil || *first[0].Events[0].ToStatus != protocol.TicketStatusBlocked {
+		t.Fatalf("chief A first inbox = %+v, want only the blocked report", first)
+	}
+	nudgesA := nudgeCount(inputs(chiefA))
+
+	// Transfer the singleton profile role. No cursor copy occurs; only delivery is
+	// retargeted and A's stale role nudge state is cleared.
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, chiefB); err != nil {
+		t.Fatalf("transfer chief role: %v", err)
+	}
+	d.retargetChiefTicketDelivery(chiefA, chiefB)
+
+	callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateReadyForReview), "ready now")
+	deadline := time.Now().Add(time.Second)
+	for currentNudgeTimer(d, chiefB) == nil && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	fireNudgeNow(t, d, chiefB)
+	if !wasNudged(inputs(chiefB)) {
+		t.Fatal("replacement chief was not nudged about unread chief-owned ticket activity")
+	}
+	if got := nudgeCount(inputs(chiefA)); got != nudgesA {
+		t.Fatalf("retired chief received a role nudge after transfer: %d -> %d", nudgesA, got)
+	}
+
+	second := callTicketInbox(t, d, chiefB)
+	if len(second) != 1 || second[0].TicketID != ticketID || len(second[0].Events) != 1 {
+		t.Fatalf("chief B inbox = %+v, want exactly one post-cursor event for %s", second, ticketID)
+	}
+	event := second[0].Events[0]
+	if event.ToStatus == nil || *event.ToStatus != protocol.TicketStatusInReview || event.Author != agentID {
+		t.Fatalf("chief B event = %+v, want agent's in-review report", event)
+	}
+	if again := callTicketInbox(t, d, chiefB); len(again) != 0 {
+		t.Fatalf("chief B second inbox = %+v, want no duplicate activity", again)
+	}
+}
+
+// A chief can still participate personally through the ordinary explicit
+// subscription path. When personal and durable-role scopes overlap, delivery is
+// deduplicated while both cursors advance.
+func TestChiefRoleAndExplicitSubscriptionDeliverOnce(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(d.stopTicketBackstops)
+	chiefID, agentID, _ := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, agentID)
+	if resp := callTicketSubscribe(t, d, chiefID, ticketID); !resp.Ok {
+		t.Fatalf("subscribe response = %+v", resp)
+	}
+
+	callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateReadyForReview), "ready")
+	bundles := callTicketInbox(t, d, chiefID)
+	if len(bundles) != 1 || len(bundles[0].Events) != 1 {
+		t.Fatalf("overlapping role/subscriber inbox = %+v, want one event", bundles)
+	}
+	if again := callTicketInbox(t, d, chiefID); len(again) != 0 {
+		t.Fatalf("overlapping role/subscriber second inbox = %+v, want empty", again)
+	}
+}
+
 // Composition with A: if a live `--watch` Monitor already drained the inbox (the
 // cursor advanced), the deferred re-check sees nothing unread and self-suppresses,
 // so an actively-watching self-monitor is never double-notified.

--- a/internal/daemon/ticket_read.go
+++ b/internal/daemon/ticket_read.go
@@ -12,22 +12,39 @@ import (
 	"github.com/victorarias/attn/internal/ticketnotify"
 )
 
-// ticketObserverForSession builds the notification observer for a session. Identity
-// is uniform: every session — the chief included — observes as its own session id,
-// the same string it authors events with, so involvement (assignee or author) and
-// the self-author exclusion line up. The literal ticketnotify.ObserverChief is only
-// the slice-2 harness placeholder; real wiring keys off the live session. The
+// ticketObserversForSession builds the effective notification identities for a
+// session. Every session retains its ordinary session identity. The active chief
+// additionally observes through the durable chief role identity, whose cursor
+// survives role transfers while AuthorID keeps self-authored events excluded. The
 // delivery path comes from the session's agent driver capability
 // (agent.Capabilities.HasSelfMonitor, resolved via the registry): Claude
 // self-monitors and watches; codex and the rest are nudged. An empty/unknown agent
 // resolves to nil → Capabilities{} → false, the safe nudge default.
-func (d *Daemon) ticketObserverForSession(sessionID string) ticketnotify.Observer {
+func (d *Daemon) ticketObserversForSession(sessionID string) []ticketnotify.Observer {
 	agentName := ""
 	if s := d.store.Get(sessionID); s != nil {
 		agentName = s.Agent
 	}
 	selfMonitor := agentdriver.EffectiveCapabilities(agentdriver.Get(agentName)).HasSelfMonitor
-	return ticketnotify.Observer{ID: sessionID, HasSelfMonitor: selfMonitor}
+	personal := ticketnotify.Observer{ID: sessionID, AuthorID: sessionID, DeliveryID: sessionID, HasSelfMonitor: selfMonitor}
+	observers := []ticketnotify.Observer{personal}
+	if d.isChiefOfStaffSession(sessionID) {
+		observers = append(observers, ticketnotify.Observer{
+			ID:             store.TicketRoleIdentity(store.TicketRoleChiefOfStaff),
+			AuthorID:       sessionID,
+			DeliveryID:     sessionID,
+			HasSelfMonitor: selfMonitor,
+		})
+	}
+	return observers
+}
+
+func (d *Daemon) ticketDeliveryObserverForSession(sessionID string) ticketnotify.Observer {
+	return d.ticketObserversForSession(sessionID)[0]
+}
+
+func (d *Daemon) ticketUnreadForSession(sessionID string) (int, error) {
+	return ticketnotify.UnreadAny(d.store, d.ticketObserversForSession(sessionID))
 }
 
 // handleTicketInbox returns the calling session's unread ticket events, bundled by
@@ -41,8 +58,7 @@ func (d *Daemon) handleTicketInbox(conn net.Conn, msg *protocol.TicketInboxMessa
 		d.sendError(conn, "ticket inbox: source_session_id is required")
 		return
 	}
-	obs := d.ticketObserverForSession(sourceSessionID)
-	bundles, err := ticketnotify.Consume(d.store, obs, time.Now())
+	bundles, err := ticketnotify.ConsumeAll(d.store, d.ticketObserversForSession(sourceSessionID), time.Now())
 	if err != nil {
 		d.sendError(conn, "ticket inbox: "+err.Error())
 		return

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -616,6 +616,33 @@ CREATE TABLE IF NOT EXISTS ticket_event_cursors (
 	`},
 	{64, "add closed_intentionally_at to sessions", "ALTER TABLE sessions ADD COLUMN closed_intentionally_at TEXT NOT NULL DEFAULT ''"},
 	{65, "add verdict to presentation_rounds", ""},
+	// Chief ticket awareness belongs to the durable profile role, not to whichever
+	// session happened to fill it when the ticket was delegated. Existing product
+	// data is safe to identify by its born-assigned shape: delegation is the only
+	// create path that persists an assignee before the created event lands. Do not
+	// seed a cursor here — a backfill must preserve every unread event.
+	{66, "add durable ticket role ownership", `
+		CREATE TABLE IF NOT EXISTS ticket_role_owners (
+			role TEXT NOT NULL,
+			ticket_id TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT '',
+			PRIMARY KEY (role, ticket_id),
+			FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE
+		);
+		CREATE INDEX IF NOT EXISTS idx_ticket_role_owners_ticket
+			ON ticket_role_owners(ticket_id, role);
+		INSERT OR IGNORE INTO ticket_role_owners (role, ticket_id, created_at)
+		SELECT 'chief_of_staff', t.id, t.created_at
+		FROM tickets t
+		JOIN ticket_events e ON e.ticket_id = t.id AND e.kind = 'created'
+		WHERE t.assignee != ''
+			AND t.archived_at = ''
+			AND t.status NOT IN ('done', 'failed', 'crashed')
+			AND NOT EXISTS (
+				SELECT 1 FROM ticket_events assigned
+				WHERE assigned.ticket_id = t.id AND assigned.kind = 'assigned'
+			);
+	`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
 )
@@ -141,6 +142,61 @@ func TestMigrations_Idempotent(t *testing.T) {
 	}
 	if count != len(migrations) {
 		t.Errorf("migration count after reopen = %d, want %d", count, len(migrations))
+	}
+}
+
+func TestMigration66BackfillsActiveBornAssignedTicketsWithoutCursor(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "migration-66.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("open seeded store: %v", err)
+	}
+	now := time.Now().UTC()
+	if _, err := s.CreateTicket(Ticket{
+		ID: "legacy-delegation", Title: "delegated work", Status: TicketStatusWorking, Assignee: "agent-a",
+	}, "chief-a", now); err != nil {
+		t.Fatalf("create legacy delegation: %v", err)
+	}
+	if _, err := s.CreateTicket(Ticket{
+		ID: "ordinary-ticket", Title: "ordinary work", Status: TicketStatusTodo,
+	}, "author", now); err != nil {
+		t.Fatalf("create ordinary ticket: %v", err)
+	}
+	if err := s.AssignTicket("ordinary-ticket", "agent-b", "author", now.Add(time.Minute)); err != nil {
+		t.Fatalf("assign ordinary ticket: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close seeded store: %v", err)
+	}
+
+	raw, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	if _, err := raw.Exec(`
+		DROP TABLE ticket_role_owners;
+		DELETE FROM schema_migrations WHERE version = 66;
+	`); err != nil {
+		t.Fatalf("rewind migration 66: %v", err)
+	}
+	_ = raw.Close()
+
+	migrated, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("reopen migrated store: %v", err)
+	}
+	t.Cleanup(func() { _ = migrated.Close() })
+	owned, err := migrated.IsTicketRoleOwner(TicketRoleChiefOfStaff, "legacy-delegation")
+	if err != nil || !owned {
+		t.Fatalf("legacy delegation role ownership = %v, err %v; want true", owned, err)
+	}
+	ordinaryOwned, err := migrated.IsTicketRoleOwner(TicketRoleChiefOfStaff, "ordinary-ticket")
+	if err != nil || ordinaryOwned {
+		t.Fatalf("ordinary assigned ticket role ownership = %v, err %v; want false", ordinaryOwned, err)
+	}
+	cursor, err := migrated.GetTicketCursor(TicketRoleIdentity(TicketRoleChiefOfStaff), "legacy-delegation")
+	if err != nil || cursor != 0 {
+		t.Fatalf("backfilled role cursor = %d, err %v; want untouched zero", cursor, err)
 	}
 }
 

--- a/internal/store/ticket_events.go
+++ b/internal/store/ticket_events.go
@@ -12,11 +12,11 @@ import (
 // cursors that express "unread". The decoupled notification handlers live in
 // internal/ticketnotify; this file is only the durable substrate.
 //
-// Cursors are keyed by (identity, ticket), not one global cursor per identity:
-// every identity — you, the chief, each agent (the chief is just another agent) —
-// has its own bookmark PER ticket. So a ticket newly assigned to an agent is
-// delivered from the start (it carries the brief and pre-assignment context),
-// and an agent's progress on one ticket never advances its bookmark on another.
+// Cursors are keyed by (identity, ticket), not one global cursor per identity.
+// Session identities own ordinary participation; durable role identities own
+// role-scoped participation. A ticket newly assigned to an agent is delivered
+// from the start, and activity on one ticket never advances another ticket's
+// bookmark.
 //
 // Events are a SUPERSET of the display activity thread (slice 1): activity holds
 // the two human-facing kinds (status_change, comment); the event log carries all
@@ -181,11 +181,11 @@ func (s *Store) TicketEventsSince(cursor int64) ([]TicketEvent, error) {
 }
 
 // UnreadTicketEvents returns, for an identity, every event it has not yet
-// consumed across the tickets it participates in — those currently assigned to it,
-// any it has authored a NON-COMMENT event on, plus any it has explicitly subscribed
-// to — excluding events it authored itself. Each event is compared against the identity's OWN per-(identity, ticket)
-// cursor, so a ticket the identity has never looked at is delivered from the start
-// (the brief and all pre-involvement context). Results are ordered by ticket then seq.
+// consumed across the tickets it participates in — those currently assigned to
+// it, any it has authored a NON-COMMENT event on, any it has explicitly subscribed
+// to, plus tickets owned by the matching durable role identity — excluding events
+// it authored itself. Each event is compared against the identity's OWN
+// per-(identity, ticket) cursor. Results are ordered by ticket then seq.
 //
 // Comment authorship is deliberately NOT a participation source: a one-shot
 // comment on an arbitrary ticket informs that ticket's participants without
@@ -197,10 +197,17 @@ func (s *Store) TicketEventsSince(cursor int64) ([]TicketEvent, error) {
 // per-ticket cursors, and the self-author exclusion together, so a quiet or
 // closed ticket the identity has nothing new on costs only an indexed lookup.
 func (s *Store) UnreadTicketEvents(identity string) ([]TicketEvent, error) {
+	return s.UnreadTicketEventsFor(identity, identity)
+}
+
+// UnreadTicketEventsFor reads cursorIdentity's queue while excluding events by
+// authorIdentity. They differ for a durable role: the cursor belongs to the role,
+// while the current session remains the audited event author.
+func (s *Store) UnreadTicketEventsFor(cursorIdentity, authorIdentity string) ([]TicketEvent, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if s.db == nil || identity == "" {
+	if s.db == nil || cursorIdentity == "" {
 		return nil, nil
 	}
 	rows, err := s.db.Query(`
@@ -213,12 +220,21 @@ func (s *Store) UnreadTicketEvents(identity string) ([]TicketEvent, error) {
 			AND e.ticket_id IN (
 				SELECT id FROM tickets WHERE assignee = ?
 				UNION
-				SELECT DISTINCT ticket_id FROM ticket_events WHERE author = ? AND kind != 'commented'
+				SELECT DISTINCT e2.ticket_id FROM ticket_events e2
+				WHERE e2.author = ? AND e2.kind != 'commented'
+					AND NOT (
+						e2.kind = 'created' AND EXISTS (
+							SELECT 1 FROM ticket_role_owners ro WHERE ro.ticket_id = e2.ticket_id
+						)
+					)
 				UNION
 				SELECT ticket_id FROM ticket_subscriptions WHERE identity = ?
+				UNION
+				SELECT ticket_id FROM ticket_role_owners
+				WHERE ? = ('role:' || role)
 			)
 		ORDER BY e.ticket_id, e.seq ASC
-	`, identity, identity, identity, identity, identity)
+	`, cursorIdentity, authorIdentity, cursorIdentity, cursorIdentity, cursorIdentity, cursorIdentity)
 	if err != nil {
 		return nil, err
 	}
@@ -226,8 +242,9 @@ func (s *Store) UnreadTicketEvents(identity string) ([]TicketEvent, error) {
 }
 
 // TicketParticipants returns the identities involved with a single ticket — its
-// current assignee, everyone who has authored a NON-COMMENT event on it, and
-// everyone subscribed to it. This is the inverse of UnreadTicketEvents (identities-
+// current assignee, everyone who has authored a NON-COMMENT event on it, everyone
+// subscribed to it, and any durable owning role. A role-owned created event's
+// concrete author is audit provenance, not personal participation. This is the inverse of UnreadTicketEvents (identities-
 // for-a-ticket, not tickets-for-an-identity): when an event lands, the notifier
 // reaches exactly these identities, each of which sees only what it did not author.
 // Empty authors/assignees/subscribers are excluded, and comment authorship confers
@@ -243,11 +260,19 @@ func (s *Store) TicketParticipants(ticketID string) ([]string, error) {
 	rows, err := s.db.Query(`
 		SELECT assignee FROM tickets WHERE id = ? AND assignee != ''
 		UNION
-		SELECT DISTINCT author FROM ticket_events WHERE ticket_id = ? AND author != '' AND kind != 'commented'
+		SELECT DISTINCT e.author FROM ticket_events e
+		WHERE e.ticket_id = ? AND e.author != '' AND e.kind != 'commented'
+			AND NOT (
+				e.kind = 'created' AND EXISTS (
+					SELECT 1 FROM ticket_role_owners ro WHERE ro.ticket_id = e.ticket_id
+				)
+			)
 		UNION
 		SELECT identity FROM ticket_subscriptions WHERE ticket_id = ? AND identity != ''
+		UNION
+		SELECT ('role:' || role) FROM ticket_role_owners WHERE ticket_id = ? AND role != ''
 		ORDER BY 1 ASC
-	`, ticketID, ticketID, ticketID)
+	`, ticketID, ticketID, ticketID, ticketID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/ticket_roles.go
+++ b/internal/store/ticket_roles.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+)
+
+const (
+	TicketRoleChiefOfStaff   = "chief_of_staff"
+	ticketRoleIdentityPrefix = "role:"
+)
+
+// TicketRoleIdentity returns the durable notification identity for a profile
+// role. Sessions come and go; cursors keyed by this identity do not.
+func TicketRoleIdentity(role string) string {
+	role = strings.TrimSpace(role)
+	if role == "" {
+		return ""
+	}
+	return ticketRoleIdentityPrefix + role
+}
+
+// IsTicketRoleOwner reports whether role durably owns ticketID.
+func (s *Store) IsTicketRoleOwner(role, ticketID string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return false, nil
+	}
+	var one int
+	err := s.db.QueryRow(`
+		SELECT 1 FROM ticket_role_owners WHERE role = ? AND ticket_id = ?
+	`, strings.TrimSpace(role), strings.TrimSpace(ticketID)).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+// TicketAssigneesOwnedByRole returns current assignees for non-archived tickets
+// owned by role. It powers the delegated-from-chief session decoration without
+// tying that decoration to the current chief session's authorship.
+func (s *Store) TicketAssigneesOwnedByRole(role string) map[string]bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make(map[string]bool)
+	if s.db == nil || strings.TrimSpace(role) == "" {
+		return out
+	}
+	rows, err := s.db.Query(`
+		SELECT DISTINCT t.assignee
+		FROM tickets t
+		JOIN ticket_role_owners o ON o.ticket_id = t.id
+		WHERE o.role = ? AND t.assignee != '' AND t.archived_at = ''
+	`, strings.TrimSpace(role))
+	if err != nil {
+		return out
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var assignee string
+		if err := rows.Scan(&assignee); err == nil && strings.TrimSpace(assignee) != "" {
+			out[strings.TrimSpace(assignee)] = true
+		}
+	}
+	return out
+}

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -189,6 +189,16 @@ func ValidateTicketID(id string) error {
 // The supplied now stamps created_at/updated_at (and closed_at, in the unusual
 // case of creating directly into a terminal status).
 func (s *Store) CreateTicket(t Ticket, author string, now time.Time) (*Ticket, error) {
+	return s.createTicket(t, author, "", now)
+}
+
+// CreateRoleOwnedTicket creates a ticket whose notification ownership belongs to
+// a durable profile role. The concrete author remains on the event for audit.
+func (s *Store) CreateRoleOwnedTicket(t Ticket, author, ownerRole string, now time.Time) (*Ticket, error) {
+	return s.createTicket(t, author, strings.TrimSpace(ownerRole), now)
+}
+
+func (s *Store) createTicket(t Ticket, author, ownerRole string, now time.Time) (*Ticket, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -258,6 +268,14 @@ func (s *Store) CreateTicket(t Ticket, author string, now time.Time) (*Ticket, e
 	}, now)
 	if err != nil {
 		return nil, err
+	}
+	if ownerRole != "" {
+		if _, err := tx.Exec(`
+			INSERT INTO ticket_role_owners (role, ticket_id, created_at)
+			VALUES (?, ?, ?)
+		`, ownerRole, t.ID, formatTicketTime(now)); err != nil {
+			return nil, err
+		}
 	}
 	// A ticket born WITH an assignee is a chief delegation: the brief was already
 	// handed to that agent out of band via the spawn prompt, so mark the `created`
@@ -461,51 +479,6 @@ func (s *Store) ClearTicketReconciliationForAssignee(assignee string) error {
 		assignee,
 	)
 	return err
-}
-
-// DelegatedFromChiefSessionIDs returns the set of session IDs that were
-// delegated from the given chief of staff. A chief-delegated session is the
-// Assignee of a non-archived ticket the chief authored (see
-// daemon.createDelegatedTicket: the chief is the ticket's creator and the
-// session its assignee). Tickets persist for the session's lifetime, so an
-// assigned non-archived ticket authored by the chief is exactly the "delegated
-// from chief" signal. This bulk read lets a single broadcast decorate every
-// session without one query per session. Returns an empty map when chief is
-// unset or the store is db-less.
-func (s *Store) DelegatedFromChiefSessionIDs(chiefSessionID string) map[string]bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	out := make(map[string]bool)
-	chiefSessionID = strings.TrimSpace(chiefSessionID)
-	if s.db == nil || chiefSessionID == "" {
-		return out
-	}
-
-	// The ticket's author lives on its created event (ticket_events kind
-	// "created"), not the tickets row, so join through to scope by chief.
-	rows, err := s.db.Query(`
-		SELECT DISTINCT t.assignee
-		FROM tickets t
-		JOIN ticket_events e
-			ON e.ticket_id = t.id AND e.kind = ? AND e.author = ?
-		WHERE t.assignee != '' AND t.archived_at = ''`,
-		string(TicketEventCreated), chiefSessionID,
-	)
-	if err != nil {
-		return out
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var assignee string
-		if err := rows.Scan(&assignee); err != nil {
-			continue
-		}
-		if sid := strings.TrimSpace(assignee); sid != "" {
-			out[sid] = true
-		}
-	}
-	return out
 }
 
 // SetTicketStatus moves a ticket to a new column and records the change in the

--- a/internal/store/tickets_test.go
+++ b/internal/store/tickets_test.go
@@ -430,24 +430,24 @@ func TestTicketTTLSweep(t *testing.T) {
 	}
 }
 
-func TestDelegatedFromChiefSessionIDs(t *testing.T) {
+func TestTicketAssigneesOwnedByRole(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })
 
-	// No chief / empty arg -> empty set, never the full table.
-	if ids := s.DelegatedFromChiefSessionIDs(""); len(ids) != 0 {
-		t.Fatalf("empty chief = %v, want none", ids)
+	// Empty role -> empty set, never the full table.
+	if ids := s.TicketAssigneesOwnedByRole(""); len(ids) != 0 {
+		t.Fatalf("empty role = %v, want none", ids)
 	}
 
-	// A ticket the chief authored and assigned to a session is the delegated signal.
-	if _, err := s.CreateTicket(Ticket{
+	// Durable role ownership, not the concrete author, is the delegated signal.
+	if _, err := s.CreateRoleOwnedTicket(Ticket{
 		ID:       "delegated",
 		Title:    "do the thing",
 		Assignee: "sess-delegated",
-	}, "chief-1", ticketBase); err != nil {
+	}, "chief-1", TicketRoleChiefOfStaff, ticketBase); err != nil {
 		t.Fatalf("CreateTicket delegated: %v", err)
 	}
-	// A ticket authored by someone else must not leak into the chief's set.
+	// A session-authored ticket without role ownership must not leak into the set.
 	if _, err := s.CreateTicket(Ticket{
 		ID:       "self-authored",
 		Title:    "user work",
@@ -456,7 +456,7 @@ func TestDelegatedFromChiefSessionIDs(t *testing.T) {
 		t.Fatalf("CreateTicket self: %v", err)
 	}
 
-	ids := s.DelegatedFromChiefSessionIDs("chief-1")
+	ids := s.TicketAssigneesOwnedByRole(TicketRoleChiefOfStaff)
 	if !ids["sess-delegated"] {
 		t.Fatalf("delegated session missing from set: %v", ids)
 	}
@@ -470,7 +470,7 @@ func TestDelegatedFromChiefSessionIDs(t *testing.T) {
 	if _, err := s.SetTicketStatus("delegated", TicketStatusDone, "sess-delegated", "shipped", ticketBase.Add(time.Minute)); err != nil {
 		t.Fatalf("SetTicketStatus terminal: %v", err)
 	}
-	if ids := s.DelegatedFromChiefSessionIDs("chief-1"); !ids["sess-delegated"] {
+	if ids := s.TicketAssigneesOwnedByRole(TicketRoleChiefOfStaff); !ids["sess-delegated"] {
 		t.Fatalf("delegated session lost after terminal report: %v", ids)
 	}
 
@@ -478,7 +478,7 @@ func TestDelegatedFromChiefSessionIDs(t *testing.T) {
 	if err := s.ArchiveTicket("delegated", ticketBase.Add(2*time.Minute)); err != nil {
 		t.Fatalf("ArchiveTicket: %v", err)
 	}
-	if ids := s.DelegatedFromChiefSessionIDs("chief-1"); ids["sess-delegated"] {
+	if ids := s.TicketAssigneesOwnedByRole(TicketRoleChiefOfStaff); ids["sess-delegated"] {
 		t.Fatalf("archived ticket still in set: %v", ids)
 	}
 }

--- a/internal/ticketnotify/notify.go
+++ b/internal/ticketnotify/notify.go
@@ -5,14 +5,11 @@
 // events into a notification — a watch-consume for agents that self-monitor
 // (Claude), and an idle pty-nudge for those that can't (codex).
 //
-// Identity is uniform: you, the chief, and each agent are all just identities (the
-// chief is one of the agents). There is no special "sees everything" observer —
-// an identity is involved with a ticket when it is assigned to it or has authored
-// an event on it (the chief authors the created event when it delegates, so it
-// stays aware of its own delegations without a special case). Each identity has
-// its OWN cursor PER ticket, so a ticket newly assigned to an agent arrives with
-// its full history (the brief, prior steers) and an agent's progress on one ticket
-// never skips another it has not looked at yet.
+// Every observer reads through one or more identities. Ordinary assignment,
+// authorship, and explicit subscription use session identities. Durable product
+// roles use role identities, so their per-ticket cursors survive a change in the
+// session filling the role. There is no special "sees everything" observer: each
+// identity sees only tickets in its participation scope.
 //
 // This package re-homes the dispatch gateway's settled mechanics:
 //
@@ -21,7 +18,7 @@
 //	ack = output / consume pending  per-(identity, ticket) cursors: events past
 //	                                an identity's cursor on a ticket are unread
 //	bundle by sender                Consume groups unread events by ticket
-//	hardcoded chief id              ObserverChief, a well-known literal
+//	hardcoded chief id              observer IDs supplied by the caller
 //	two consumers (watch / nudge)   the two Delivery paths below
 //	never stream content to a PTY   Nudger carries only a fixed trigger
 //
@@ -36,11 +33,9 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
-// ObserverChief is the well-known chief identity — the chief is just one of the
-// agents, but its id is fixed (it has no spawned session id) so addressing it
-// needs no lookup. It enjoys no special scope: like any identity it sees events on
-// the tickets it is involved with (the ones it delegated/authored, plus any
-// assigned to it). Slice 3 supplies the real chief session id.
+// ObserverChief is the original simulation-harness identity. Production uses the
+// store's durable role identity plus the current chief session as AuthorID and
+// DeliveryID.
 const ObserverChief = "chief"
 
 // EventStore is the store surface the notifier needs. The real *store.Store
@@ -50,25 +45,24 @@ const ObserverChief = "chief"
 // cursors, and the self-author exclusion into one query; SetTicketCursor advances
 // a single ticket's cursor for an identity.
 type EventStore interface {
-	UnreadTicketEvents(identity string) ([]store.TicketEvent, error)
+	UnreadTicketEventsFor(cursorIdentity, authorIdentity string) ([]store.TicketEvent, error)
 	SetTicketCursor(identity, ticketID string, cursor int64, now time.Time) error
 }
 
-// Observer is a subscriber to ticket events. ID is ObserverChief or an agent's
-// session id. HasSelfMonitor picks the delivery path: a self-monitoring agent's
-// own watch consumes; others are nudged when idle. The caller supplies the bool —
-// this package stays pure and knows nothing about agent types; the daemon reads it
-// from the agent driver's capability (internal/agent.Capabilities.HasSelfMonitor).
+// Observer is one ticket-event view. ID owns the cursor, AuthorID is excluded as
+// self-authored activity, and DeliveryID is the live session to nudge. All three
+// are the session ID for ordinary agents; durable roles split them. HasSelfMonitor
+// selects watch versus nudge delivery.
 type Observer struct {
 	ID             string
+	AuthorID       string
+	DeliveryID     string
 	HasSelfMonitor bool
 }
 
-// ChiefObserver returns the well-known chief observer. Harness/test-only: the live
-// chief is built from its real agent via the daemon, like any other session. The
-// chief is a self-monitoring session here, so it watches rather than is nudged.
+// ChiefObserver returns the harness-only chief observer.
 func ChiefObserver() Observer {
-	return Observer{ID: ObserverChief, HasSelfMonitor: true}
+	return Observer{ID: ObserverChief, AuthorID: ObserverChief, DeliveryID: ObserverChief, HasSelfMonitor: true}
 }
 
 // Bundle is an observer's unread events for a single ticket. Consume returns one
@@ -102,6 +96,39 @@ func Consume(es EventStore, obs Observer, now time.Time) ([]Bundle, error) {
 	return bundles, nil
 }
 
+// ConsumeAll consumes several effective identities and merges their output by
+// event sequence. A chief session uses this for its ordinary session identity and
+// the durable chief role identity; an event in both scopes is delivered once while
+// both cursors advance.
+func ConsumeAll(es EventStore, observers []Observer, now time.Time) ([]Bundle, error) {
+	byTicket := map[string]map[int64]store.TicketEvent{}
+	for _, obs := range observers {
+		bundles, err := Consume(es, obs, now)
+		if err != nil {
+			return nil, err
+		}
+		for _, bundle := range bundles {
+			if byTicket[bundle.TicketID] == nil {
+				byTicket[bundle.TicketID] = map[int64]store.TicketEvent{}
+			}
+			for _, event := range bundle.Events {
+				byTicket[bundle.TicketID][event.Seq] = event
+			}
+		}
+	}
+	merged := make([]Bundle, 0, len(byTicket))
+	for ticketID, events := range byTicket {
+		bundle := Bundle{TicketID: ticketID, Events: make([]store.TicketEvent, 0, len(events))}
+		for _, event := range events {
+			bundle.Events = append(bundle.Events, event)
+		}
+		sort.Slice(bundle.Events, func(i, j int) bool { return bundle.Events[i].Seq < bundle.Events[j].Seq })
+		merged = append(merged, bundle)
+	}
+	sort.Slice(merged, func(i, j int) bool { return merged[i].Events[0].Seq < merged[j].Events[0].Seq })
+	return merged, nil
+}
+
 // Unread counts the observer's unread events without consuming them.
 func Unread(es EventStore, obs Observer) (int, error) {
 	bundles, _, err := pending(es, obs)
@@ -113,6 +140,26 @@ func Unread(es EventStore, obs Observer) (int, error) {
 		n += len(b.Events)
 	}
 	return n, nil
+}
+
+// UnreadAny counts the union only as a delivery predicate. Callers use it to
+// decide whether one session should be notified for any of its effective
+// identities; exact deduplication happens when ConsumeAll returns the events.
+func UnreadAny(es EventStore, observers []Observer) (int, error) {
+	hasUnread := false
+	for _, obs := range observers {
+		n, err := Unread(es, obs)
+		if err != nil {
+			return 0, err
+		}
+		if n > 0 {
+			hasUnread = true
+		}
+	}
+	if hasUnread {
+		return 1, nil
+	}
+	return 0, nil
 }
 
 // Delivery is how the notifier decided to reach an observer about pending events.
@@ -148,20 +195,31 @@ type Nudger interface {
 //   - idle, can't self-monitor  -> DeliveryNudge (fixed trigger; it then consumes)
 //   - busy, can't self-monitor  -> DeliveryDeferred (wait for idle)
 func Notify(es EventStore, obs Observer, idle bool, nudger Nudger, now time.Time) (Delivery, error) {
-	unread, err := Unread(es, obs)
+	return NotifyAny(es, []Observer{obs}, obs, idle, nudger, now)
+}
+
+// NotifyAny makes one delivery decision for a session that observes through more
+// than one identity. deliveryObserver supplies the session capability and target;
+// the observed identities only determine whether anything is unread.
+func NotifyAny(es EventStore, observers []Observer, deliveryObserver Observer, idle bool, nudger Nudger, now time.Time) (Delivery, error) {
+	unread, err := UnreadAny(es, observers)
 	if err != nil {
 		return DeliveryNone, err
 	}
 	if unread == 0 {
 		return DeliveryNone, nil
 	}
-	if obs.HasSelfMonitor {
+	if deliveryObserver.HasSelfMonitor {
 		return DeliveryWatch, nil
 	}
 	if !idle {
 		return DeliveryDeferred, nil
 	}
-	if err := nudger.Nudge(obs.ID); err != nil {
+	deliveryID := deliveryObserver.DeliveryID
+	if deliveryID == "" {
+		deliveryID = deliveryObserver.ID
+	}
+	if err := nudger.Nudge(deliveryID); err != nil {
 		return DeliveryNone, err
 	}
 	return DeliveryNudge, nil
@@ -178,7 +236,11 @@ func Notify(es EventStore, obs Observer, idle bool, nudger Nudger, now time.Time
 // reassignment to it — is delivered from the start, brief and all. Bundles are
 // ordered by their oldest unread event so cross-ticket order stays chronological.
 func pending(es EventStore, obs Observer) (bundles []Bundle, advance map[string]int64, err error) {
-	events, err := es.UnreadTicketEvents(obs.ID)
+	authorID := obs.AuthorID
+	if authorID == "" {
+		authorID = obs.ID
+	}
+	events, err := es.UnreadTicketEventsFor(obs.ID, authorID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/ticketnotify/notify_edge_test.go
+++ b/internal/ticketnotify/notify_edge_test.go
@@ -25,7 +25,7 @@ type erroringStore struct {
 
 var errBoom = errors.New("boom")
 
-func (e erroringStore) UnreadTicketEvents(string) ([]store.TicketEvent, error) {
+func (e erroringStore) UnreadTicketEventsFor(string, string) ([]store.TicketEvent, error) {
 	if e.failUnread {
 		return nil, errBoom
 	}


### PR DESCRIPTION
## Intent / Why

Chief-of-staff ticket awareness was attached to the session that created a delegation. Transferring the chief role therefore left the new chief without the ticket participation or cursor needed to see later reports, while the retired session could remain a notification target. The chief role is durable, so its ticket ownership and unread position need to be durable too.

## Summary

- add durable `ticket_role_owners` records for chief-delegated tickets while retaining concrete session IDs as event authors for audit
- read a chief session through both its ordinary session identity and the durable chief role identity, merging overlapping events once while advancing both relevant cursors
- resolve role notifications to the current chief session and clear stale countdown/backstop state when the role transfers
- keep assignee and explicit-subscriber behavior session-scoped and unchanged
- preserve runtime-specific delivery: self-monitoring agents may drain `ticket inbox --watch`, while other runtimes receive attn nudges and use one-shot inbox reads

## Migration

Migration 66 creates the role-ownership table and backfills active tickets created in the pre-fix born-assigned delegation shape. It does not create, copy, or advance a role cursor, so unread events remain unread across upgrade and handoff. Ordinary tickets assigned after creation are not reclassified.

## Test plan

- [x] Chief A consumes an update, transfers the role to B, and B receives the next unread update plus a nudge
- [x] B receives no skipped or duplicate events, and A receives no further chief-role nudge
- [x] overlapping explicit subscription and chief-role ownership still deliver once
- [x] migration backfills an active legacy delegation without seeding its cursor and leaves ordinary assignment alone
- [x] Claude/Codex runtime-specific waiting guidance remains covered
- [x] `go test -race ./internal/store ./internal/ticketnotify ./internal/daemon -run "Test(Migration66|ChiefTicketContinuity|ChiefRoleAndExplicit|TicketInboxConsumes|TicketSubscribeLifecycle|TicketBackstopSuppressedAfterWatchDrains|NotebookGuideUses)" -count=1`
- [x] `go vet ./internal/store ./internal/ticketnotify ./internal/daemon`
- [x] `go test -p 1 ./... -count=1`
- [x] signed `attn-dev.app` install and packaged-app ticket lifecycle scenario