### PR TITLE
fix(tickets): revive crashed ticket to working when its session reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-09]
+
+### Fixed
+- **Reloading a crashed session moves its ticket back to Working automatically.** When a delegated session died mid-run its ticket was stamped Crashed — but bringing the session back to life (reloading the dead pane, resuming the ticket, or the daemon re-adopting a still-live worker after a restart) left the ticket sitting in the Crashed column until you moved it by hand. Reviving the session now flips the ticket back to Working on its own, and crash detection is re-armed so a later genuine crash is still stamped. Intentional closes are still never treated as crashes.
+
+---
+
 ## [2026-07-08]
 
 ### Fixed

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1152,6 +1152,10 @@ func (d *Daemon) reconcileSessionsWithWorkerBackend(ctx context.Context, allowId
 		// stale, and keeping it would misread this session's later genuine crash as
 		// a clean close.
 		d.store.ClearSessionIntentionalClose(sessionID)
+		// By the same token it cannot be crashed: a ticket stamped Crashed (a
+		// startup reap on an earlier boot, a sweep misread) whose owner turns out
+		// to be alive goes back to Working (ticket_revive.go).
+		d.reviveCrashedTicketsForSession(sessionID)
 		if protocol.Deref(existing.Recoverable) {
 			d.store.SetRecoverable(sessionID, false)
 			report.Changed = true
@@ -2154,6 +2158,9 @@ func (d *Daemon) handleRegister(conn net.Conn, msg *protocol.RegisterMessage) {
 	if err := d.store.ClearTicketReconciliationForAssignee(session.ID); err != nil {
 		d.logf("clear ticket reconciliation on register for %s: %v", session.ID, err)
 	}
+	// A crash-stamped ticket whose owner just re-registered is no longer
+	// crashed: move it back to Working (ticket_revive.go).
+	d.reviveCrashedTicketsForSession(session.ID)
 	d.associateSessionWithWorkspace(session.ID, workspaceID)
 	if _, err := d.ensureWorkspaceLayout(workspaceID); err != nil {
 		d.logf("workspace layout bootstrap failed for workspace %s: %v", workspaceID, err)

--- a/internal/daemon/ticket_revive.go
+++ b/internal/daemon/ticket_revive.go
@@ -1,0 +1,63 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/victorarias/attn/internal/store"
+)
+
+// reviveCrashedTicketsForSession is the inverse half of crashTicket
+// (ticket_crash.go): a session stamped Crashed can be brought back to life —
+// the app reloads/respawns the dead pane, a ticket Resume respawns under the
+// same id, the CLI re-registers it, or daemon recovery adopts a still-live
+// worker — and from that moment the board's Crashed column is a lie the agent
+// cannot correct (an agent only reports through in-progress/blocked/... work
+// states; nothing routinely re-reports right after a revival). So the same
+// authority that stamped Crashed un-stamps it: attn moves the ticket back to
+// Working when its owning session revives.
+//
+// Re-arming crash detection falls out of the flip itself: `crashed` is
+// terminal, so a ticket left there is invisible to ActiveTicketsForSession and
+// a second death would never re-stamp it; back in `working` the ticket is on
+// the crash/reconcile seam's radar again. Idempotent — a session with no
+// crashed tickets is a no-op — and safe to run from any revival seam, in any
+// order, any number of times. Callers (all three "session came back to life"
+// seams): handleSpawnSession, handleRegister, and the recovery-adopt path in
+// reconcileSessionsWithWorkerBackend.
+func (d *Daemon) reviveCrashedTicketsForSession(sessionID string) {
+	if d.store == nil {
+		return
+	}
+	tickets, err := d.store.CrashedTicketsForAssignee(sessionID)
+	if err != nil {
+		d.logf("ticket revive: list crashed tickets for %s: %v", sessionID, err)
+		return
+	}
+	if len(tickets) == 0 {
+		return
+	}
+	moved := false
+	for _, ticket := range tickets {
+		if ticket == nil {
+			continue
+		}
+		if _, err := d.store.SetTicketStatus(
+			ticket.ID,
+			store.TicketStatusWorking,
+			store.TicketAuthorAttn,
+			"session was reloaded and is running again",
+			time.Now(),
+		); err != nil {
+			d.logf("ticket revive for %s: %v", sessionID, err)
+			continue
+		}
+		moved = true
+		d.logf("ticket %q revived: session %s is live again", ticket.ID, sessionID)
+		// attn authored the move; notify the chief/participants the work is back on.
+		d.notifyTicketObservers(ticket.ID)
+	}
+	if moved {
+		// Refresh the app's board view: the ticket left the Crashed lane.
+		d.broadcastTicketsUpdated()
+	}
+}

--- a/internal/daemon/ticket_revive_test.go
+++ b/internal/daemon/ticket_revive_test.go
@@ -1,0 +1,167 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// respawnDelegatedSession re-spawns a delegated session under its existing id —
+// the frontend path for reloading a dead pane (and the tail of a ticket Resume).
+func respawnDelegatedSession(t *testing.T, d *Daemon, sessionID string) {
+	t.Helper()
+	session := d.store.Get(sessionID)
+	if session == nil {
+		t.Fatalf("session %s missing before respawn", sessionID)
+	}
+	client := newWorkspaceProtocolTestClient()
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:         protocol.CmdSpawnSession,
+		ID:          sessionID,
+		Cwd:         session.Directory,
+		WorkspaceID: session.WorkspaceID,
+		Agent:       string(session.Agent),
+		Cols:        80,
+		Rows:        24,
+	})
+	expectSpawnResult(t, client, sessionID, true)
+}
+
+// The observed bug (2026-07-08): a delegated session crashes mid-flight — its
+// ticket is stamped Crashed — and the user then reloads the dead pane. The
+// session comes back and works, but the ticket used to sit in Crashed until
+// moved by hand. Reviving the owning session must move the ticket back to
+// Working automatically, authored by attn like the crash stamp itself.
+func TestRespawnOfCrashedSessionRevivesTicketToWorking(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	sessionID := delegateBoundSession(t, d)
+	ticketID := boundTicketID(t, d, sessionID)
+
+	// Spontaneous mid-flight death: the ticket is crash-stamped and terminal.
+	d.store.UpdateState(sessionID, protocol.StateWorking)
+	d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 1})
+	ticket, err := d.store.GetTicket(ticketID)
+	if err != nil || ticket == nil {
+		t.Fatalf("GetTicket after crash: %v, %v", ticket, err)
+	}
+	if ticket.Status != store.TicketStatusCrashed {
+		t.Fatalf("status after crash = %q, want crashed", ticket.Status)
+	}
+
+	// The user reloads the dead pane: same id, frontend-driven respawn.
+	respawnDelegatedSession(t, d, sessionID)
+
+	ticket, err = d.store.GetTicket(ticketID)
+	if err != nil || ticket == nil {
+		t.Fatalf("GetTicket after respawn: %v, %v", ticket, err)
+	}
+	if ticket.Status != store.TicketStatusWorking {
+		t.Fatalf("status after respawn = %q, want working", ticket.Status)
+	}
+	if ticket.ClosedAt != nil {
+		t.Fatal("revived ticket still carries closed_at")
+	}
+
+	events, err := d.store.TicketEventsSince(0)
+	if err != nil {
+		t.Fatalf("TicketEventsSince: %v", err)
+	}
+	var revive *store.TicketEvent
+	for i := range events {
+		if events[i].TicketID == ticketID &&
+			events[i].FromStatus == store.TicketStatusCrashed &&
+			events[i].ToStatus == store.TicketStatusWorking {
+			revive = &events[i]
+		}
+	}
+	if revive == nil {
+		t.Fatalf("no crashed->working event for ticket %q", ticketID)
+	}
+	if revive.Author != store.TicketAuthorAttn {
+		t.Fatalf("revive author = %q, want attn", revive.Author)
+	}
+
+	// Crash detection is re-armed for the revived run: a later genuine
+	// mid-flight death stamps Crashed again.
+	d.store.UpdateState(sessionID, protocol.StateWorking)
+	d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 1})
+	ticket, err = d.store.GetTicket(ticketID)
+	if err != nil || ticket == nil {
+		t.Fatalf("GetTicket after second crash: %v, %v", ticket, err)
+	}
+	if ticket.Status != store.TicketStatusCrashed {
+		t.Fatalf("status after second crash = %q, want crashed (detection re-armed)", ticket.Status)
+	}
+}
+
+// Revival flips ONLY the Crashed column. A respawn under a ticket the agent
+// left in another column (here In Review) must not move it.
+func TestRespawnLeavesNonCrashedTicketAlone(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	sessionID := delegateBoundSession(t, d)
+	ticketID := boundTicketID(t, d, sessionID)
+	callSetTicketStatus(t, d, sessionID, string(protocol.DispatchWorkStateReadyForReview), "PR is up")
+
+	// A clean exit (no crash stamp) followed by a reload of the pane.
+	d.store.UpdateState(sessionID, protocol.StateWaitingInput)
+	d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 0})
+	respawnDelegatedSession(t, d, sessionID)
+
+	ticket, err := d.store.GetTicket(ticketID)
+	if err != nil || ticket == nil {
+		t.Fatalf("GetTicket: %v, %v", ticket, err)
+	}
+	if ticket.Status != store.TicketStatusInReview {
+		t.Fatalf("status = %q, want in_review (revival must not touch other columns)", ticket.Status)
+	}
+}
+
+// Daemon-restart safety: startup recovery adopting a still-live worker for a
+// crash-stamped ticket's session (a reap on an earlier boot stamped it, the
+// worker survived) moves the ticket back to Working — the same durable-vs-
+// in-memory rigor as the intentional-close mark it clears at the same spot.
+func TestRecoveryAdoptRevivesCrashedTicketToWorking(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	sessionID := delegateBoundSession(t, d)
+	ticketID := boundTicketID(t, d, sessionID)
+	session := d.store.Get(sessionID)
+
+	// Crash-stamp via the seam, as a reap would.
+	d.store.UpdateState(sessionID, protocol.StateWorking)
+	d.reconcileTicketsOnSessionEnd(sessionID, protocol.StateWorking)
+	ticket, err := d.store.GetTicket(ticketID)
+	if err != nil || ticket == nil {
+		t.Fatalf("GetTicket after crash: %v, %v", ticket, err)
+	}
+	if ticket.Status != store.TicketStatusCrashed {
+		t.Fatalf("status after crash = %q, want crashed", ticket.Status)
+	}
+
+	// Restart-time recovery finds the worker alive and adopts the session.
+	d.ptyBackend = &fakeWorkerReconcileBackend{
+		liveIDs: []string{sessionID},
+		info: map[string]ptybackend.SessionInfo{
+			sessionID: {
+				SessionID: sessionID,
+				Agent:     string(session.Agent),
+				CWD:       session.Directory,
+				Running:   true,
+				State:     protocol.StateWorking,
+			},
+		},
+	}
+	d.reconcileSessionsWithWorkerBackend(context.Background(), true, time.Time{})
+
+	ticket, err = d.store.GetTicket(ticketID)
+	if err != nil || ticket == nil {
+		t.Fatalf("GetTicket after adopt: %v, %v", ticket, err)
+	}
+	if ticket.Status != store.TicketStatusWorking {
+		t.Fatalf("status after adopt = %q, want working", ticket.Status)
+	}
+}

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -734,6 +734,10 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		if err := d.store.ClearTicketReconciliationForAssignee(session.ID); err != nil {
 			d.logf("clear ticket reconciliation on spawn for %s: %v", session.ID, err)
 		}
+		// A crash-stamped ticket whose owner just respawned (dead-pane reload,
+		// ticket Resume) is no longer crashed: move it back to Working and put it
+		// back on the crash seam's radar (ticket_revive.go).
+		d.reviveCrashedTicketsForSession(session.ID)
 		if !isShell {
 			d.startTranscriptWatcher(session.ID, session.Agent, session.Directory, spawnStartedAt)
 		}

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -43,10 +43,10 @@ const (
 )
 
 // TicketAuthorAttn is the event author attn uses when it writes a transition on a
-// ticket itself rather than on behalf of the user, the chief, or an agent — today
-// only the Crashed status a dead worker could not report. It is an authoring
-// identity, never an observer, so it accrues no cursors and is excluded from
-// nobody's unread feed.
+// ticket itself rather than on behalf of the user, the chief, or an agent — the
+// Crashed status a dead worker could not report, and the crashed→working flip
+// when that worker is revived. It is an authoring identity, never an observer,
+// so it accrues no cursors and is excluded from nobody's unread feed.
 const TicketAuthorAttn = "attn"
 
 // TicketAuthorYou is the identity the human user authors with when acting on a
@@ -426,6 +426,43 @@ func (s *Store) ActiveTicketsForSession(sessionID string) ([]*Ticket, error) {
 		if !ticket.Status.IsTerminal() {
 			tickets = append(tickets, ticket)
 		}
+	}
+	return tickets, rows.Err()
+}
+
+// CrashedTicketsForAssignee returns every non-archived ticket sitting in the
+// Crashed column bound to a session id, newest first — the revival seam
+// (a crashed session respawned/registered/adopted back to live) flips exactly
+// these back to Working. Archived tickets stay archived: the user dismissed
+// them from the board, so a revival must not resurrect them. Activity and
+// attachments are not loaded.
+func (s *Store) CrashedTicketsForAssignee(assignee string) ([]*Ticket, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return nil, nil
+	}
+	assignee = strings.TrimSpace(assignee)
+	if assignee == "" {
+		return nil, nil
+	}
+	rows, err := s.db.Query(
+		ticketSelect+` WHERE assignee = ? AND status = ? AND archived_at = '' ORDER BY created_at DESC, id DESC`,
+		assignee, string(TicketStatusCrashed),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tickets []*Ticket
+	for rows.Next() {
+		ticket, err := scanTicket(rows)
+		if err != nil {
+			return nil, err
+		}
+		tickets = append(tickets, ticket)
 	}
 	return tickets, rows.Err()
 }

--- a/internal/store/tickets_test.go
+++ b/internal/store/tickets_test.go
@@ -579,3 +579,41 @@ func TestTicketResumeSessionID(t *testing.T) {
 		t.Fatalf("unbound resume id = %q, want empty", got)
 	}
 }
+
+// CrashedTicketsForAssignee returns exactly the revivable set: crashed,
+// non-archived, and bound to the given session — nothing in another column,
+// archived, or owned by someone else.
+func TestCrashedTicketsForAssignee(t *testing.T) {
+	s := New()
+	t.Cleanup(func() { _ = s.Close() })
+
+	mk := func(id string, status TicketStatus, assignee string) {
+		t.Helper()
+		if _, err := s.CreateTicket(Ticket{ID: id, Title: id, Status: status, Assignee: assignee}, "chief", ticketBase); err != nil {
+			t.Fatalf("CreateTicket %s: %v", id, err)
+		}
+	}
+	mk("crashed-mine", TicketStatusCrashed, "sess-1")
+	mk("crashed-archived", TicketStatusCrashed, "sess-1")
+	if err := s.ArchiveTicket("crashed-archived", ticketBase); err != nil {
+		t.Fatalf("ArchiveTicket: %v", err)
+	}
+	mk("working-mine", TicketStatusWorking, "sess-1")
+	mk("crashed-other", TicketStatusCrashed, "sess-2")
+
+	got, err := s.CrashedTicketsForAssignee("sess-1")
+	if err != nil {
+		t.Fatalf("CrashedTicketsForAssignee: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "crashed-mine" {
+		ids := make([]string, len(got))
+		for i, tk := range got {
+			ids[i] = tk.ID
+		}
+		t.Fatalf("got %v, want exactly [crashed-mine]", ids)
+	}
+
+	if got, err := s.CrashedTicketsForAssignee(""); err != nil || got != nil {
+		t.Fatalf("empty assignee = %v, %v, want nil, nil", got, err)
+	}
+}


### PR DESCRIPTION
## Summary
- A session stamped Crashed can be brought back to life (dead-pane reload, ticket Resume, CLI re-register, or recovery adopting a still-live worker), but nothing moved its bound ticket out of the terminal Crashed column — Victor had to flip it by hand.
- The same authority that stamps Crashed now un-stamps it: every session-revival seam calls `reviveCrashedTicketsForSession`, which moves the ticket crashed -> working (attn-authored, like the crash stamp) and puts it back on the crash/reconcile seam's radar, so a later genuine crash re-stamps it.
- Archived crashed tickets stay archived (the user dismissed them), and non-crashed columns are never touched.

## Test plan
- [x] `go test ./internal/store ./internal/daemon` (green)
- [x] Live-tested on a throwaway `ATTN_PROFILE` (non-prod)
- [x] CHANGELOG.md updated