### PR TITLE
feat(present): reclaim vertical space — compact topbar + summary fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-09]
 
+### Changed
+- **The Present review window reclaims vertical space for the diff.** The title, kind, repo path, round info, drift notice, and comment count now share one compact line at the top instead of a tall stacked header. The summary card folds away once you scroll into the tour and reappears when you jump back to the Summary stop, and the redundant "End of tour" strip — which just repeated the drive bar's reviewed count — is gone.
+
 ### Fixed
 - **Reloading a crashed session moves its ticket back to Working automatically.** When a delegated session died mid-run its ticket was stamped Crashed — but bringing the session back to life (reloading the dead pane, resuming the ticket, or the daemon re-adopting a still-live worker after a restart) left the ticket sitting in the Crashed column until you moved it by hand. Reviving the session now flips the ticket back to Working on its own, and crash detection is re-armed so a later genuine crash is still stamped. Intentional closes are still never treated as crashes.
 

--- a/app/e2e/present-tour.spec.ts
+++ b/app/e2e/present-tour.spec.ts
@@ -88,12 +88,26 @@ async function findContainerByTitle(page: Page, path: string): Promise<Locator |
   return null;
 }
 
-/** Opens a draft on the given line via the gutter "+" (hover then click), scoped to one file's container. */
+/**
+ * Opens a draft on the given line via the gutter "+" (hover then click),
+ * scoped to one file's container.
+ *
+ * The diff rows re-render while hover state, draft mounts, and the
+ * virtualizer churn, so the "+" can detach between resolving and clicking
+ * (observed as `element was detached from the DOM, retrying` until the test
+ * times out). Retry the whole hover→click gesture until a new draft form
+ * actually appears, skipping the click if a prior attempt already landed.
+ */
 async function openDraftViaGutter(container: Locator, line: Locator) {
-  await line.hover();
-  const plus = container.locator('[data-utility-button]');
-  await plus.waitFor({ state: 'visible' });
-  await plus.click();
+  const page = container.page();
+  const forms = page.getByTestId('diff-comment-form');
+  const before = await forms.count();
+  await expect(async () => {
+    if ((await forms.count()) > before) return; // a prior attempt's click landed
+    await line.hover();
+    await container.locator('[data-utility-button]').click({ timeout: 2000 });
+    await expect(forms).toHaveCount(before + 1, { timeout: 1000 });
+  }).toPass({ timeout: 15_000 });
 }
 
 test.describe('PresentTour rendering', () => {
@@ -117,8 +131,6 @@ test.describe('PresentTour rendering', () => {
       const last = containers.last();
       return titleOf(last);
     }).toBe('src/gamma.ts');
-
-    await expect(page.getByTestId('present-tour-footer')).toContainText('3 files reviewed');
   });
 
   test('renders the per-file note as a callout under that file only', async ({ page }) => {

--- a/app/src/components/PresentRoot/DriveBar.css
+++ b/app/src/components/PresentRoot/DriveBar.css
@@ -5,8 +5,8 @@
   display: flex;
   align-items: center;
   gap: 20px;
-  margin-top: 16px;
-  padding: 10px 14px;
+  margin-top: 8px;
+  padding: 8px 12px;
   border: 1px solid var(--color-border);
   border-radius: 8px;
   background: var(--color-bg-panel);

--- a/app/src/components/PresentRoot/PresentRoot.css
+++ b/app/src/components/PresentRoot/PresentRoot.css
@@ -1,7 +1,7 @@
 .present-root {
   height: 100vh;
   overflow-y: auto;
-  padding: 32px 40px;
+  padding: 10px 16px 12px;
   background: var(--color-bg-app);
   color: var(--color-text-primary);
   display: flex;
@@ -15,41 +15,65 @@
   color: var(--color-text-secondary);
 }
 
-.present-root-header h1 {
-  margin: 0 0 8px 0;
-  font-size: 20px;
-  font-weight: 600;
+.present-root-topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--color-border);
+  min-width: 0;
 }
 
-.present-root-meta {
-  display: flex;
-  gap: 12px;
-  color: var(--color-text-secondary);
-  font-size: var(--font-size);
+.present-root-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 1 auto;
+  min-width: 0;
 }
 
 .present-root-kind {
   text-transform: capitalize;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  flex: none;
 }
 
-.present-root-round {
+.present-root-repo {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  font-family: monospace;
+  max-width: 280px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.present-root-topbar-right {
+  margin-left: auto;
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-top: 20px;
-  padding: 10px 12px;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  font-size: var(--font-size);
+  gap: 10px;
+  flex: none;
+  white-space: nowrap;
+}
+
+.present-root-round-label {
+  font-size: var(--font-size-sm);
 }
 
 .present-root-shas {
   font-family: monospace;
   color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
 }
 
 .present-root-status {
-  margin-left: auto;
   padding: 2px 8px;
   border-radius: 999px;
   font-size: 12px;
@@ -143,45 +167,44 @@
 }
 
 .present-root-drift {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  margin-top: 16px;
-  padding: 10px 12px;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  background: var(--color-bg-panel);
-  color: var(--color-text-secondary);
-  font-size: var(--font-size);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: var(--font-size-sm);
+  background: #d9770622;
+  color: #d97706;
+  border: 1px solid #d9770655;
 }
 
 .present-root-drift-dismiss {
   background: none;
   border: none;
-  color: var(--color-text-secondary);
+  color: inherit;
   cursor: pointer;
-  font-size: 16px;
+  font-size: 13px;
   line-height: 1;
-  padding: 0 2px;
+  padding: 0;
+  opacity: 0.7;
 }
 
 .present-root-drift-dismiss:hover {
-  color: var(--color-text-primary);
+  opacity: 1;
 }
 
 .present-root-comment-count {
-  margin-top: 16px;
   color: var(--color-text-secondary);
-  font-size: var(--font-size);
+  font-size: var(--font-size-sm);
+  margin: 0;
 }
 
 .present-root-body {
   display: flex;
   flex: 1;
   min-height: 0;
-  margin-top: 20px;
-  gap: 20px;
+  margin-top: 12px;
+  gap: 14px;
 }
 
 .present-root-rail {

--- a/app/src/components/PresentRoot/PresentRoot.test.tsx
+++ b/app/src/components/PresentRoot/PresentRoot.test.tsx
@@ -666,16 +666,34 @@ describe('PresentRoot', () => {
     expect(screen.getByTestId('present-root-summary-row')).not.toHaveClass('selected');
   }, TEST_TIMEOUT);
 
-  it('shows a drift banner iff repoHeadSha differs from the pinned round head', async () => {
+  it('shows a drift pill (with the long explanation in its title) iff repoHeadSha differs from the pinned round head, and it dismisses', async () => {
     await loadRound({ repoHeadSha: 'deadbeef000000' });
 
-    expect(screen.getByText(/repo has moved on/)).toBeInTheDocument();
+    const pill = screen.getByRole('status');
+    expect(pill.textContent).toContain('deadbee');
+    expect(pill.getAttribute('title')).toContain('The repo has moved on since this round was pinned');
+
+    fireEvent.click(screen.getByLabelText('Dismiss'));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
-  it('shows no drift banner when repoHeadSha matches the pinned round head', async () => {
+  it('shows no drift pill when repoHeadSha matches the pinned round head', async () => {
     await loadRound({ repoHeadSha: round.head_sha });
 
-    expect(screen.queryByText(/repo has moved on/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('passes summaryVisible=true while on the pinned Summary stop, and false after navigating to a file', async () => {
+    await loadRound();
+
+    await waitFor(() => {
+      expect(latestTourProps().summaryVisible).toBe(true);
+    }, WAIT_OPTS);
+
+    fireEvent.click(screen.getByText('src/foo.ts'));
+    await waitFor(() => {
+      expect(latestTourProps().summaryVisible).toBe(false);
+    }, WAIT_OPTS);
   });
 
   it('shows an inline error when a diff fetch fails, without blanking the window', async () => {

--- a/app/src/components/PresentRoot/index.tsx
+++ b/app/src/components/PresentRoot/index.tsx
@@ -676,23 +676,26 @@ export function PresentRoot() {
 
   return (
     <div className="present-root">
-      <header className="present-root-header">
-        <h1>{presentation.title}</h1>
-        <div className="present-root-meta">
-          <span className="present-root-kind">{presentation.kind}</span>
-          <span className="present-root-repo">{presentation.repo_path}</span>
+      <header className="present-root-topbar">
+        <h1 className="present-root-title" title={presentation.title}>{presentation.title}</h1>
+        <span className="present-root-kind">{presentation.kind}</span>
+        <span className="present-root-repo" title={presentation.repo_path}>{presentation.repo_path}</span>
+        <div className="present-root-topbar-right">
+          <span className="present-root-round-label">Round {round.seq}</span>
+          <span className="present-root-shas">{shortSha(round.base_sha)}…{shortSha(round.head_sha)}</span>
+          <span className={`present-root-status ${round.submitted_at ? 'submitted' : 'draft'}`}>{round.submitted_at ? 'Submitted' : 'Draft'}</span>
+          {showDrift && (
+            <span className="present-root-drift" role="status"
+                  title={`The repo has moved on since this round was pinned (${shortSha(round.head_sha)} → ${shortSha(repoHeadSha!)}). Diffs below still show the pinned commits.`}>
+              moved on → {shortSha(repoHeadSha!)}
+              <button type="button" className="present-root-drift-dismiss" aria-label="Dismiss" onClick={() => setDriftDismissed(true)}>×</button>
+            </span>
+          )}
+          {comments.length > 0 && (
+            <span className="present-root-comment-count">{comments.length} comment{comments.length === 1 ? '' : 's'}</span>
+          )}
         </div>
       </header>
-
-      <section className="present-root-round">
-        <span>Round {round.seq}</span>
-        <span className="present-root-shas">
-          {shortSha(round.base_sha)}…{shortSha(round.head_sha)}
-        </span>
-        <span className={`present-root-status ${round.submitted_at ? 'submitted' : 'draft'}`}>
-          {round.submitted_at ? 'Submitted' : 'Draft'}
-        </span>
-      </section>
 
       {showSubmitDialog && (
         <div className="present-root-submit-overlay" role="dialog" aria-modal="true" aria-label="Submit review">
@@ -738,29 +741,6 @@ export function PresentRoot() {
             </div>
           </div>
         </div>
-      )}
-
-      {showDrift && (
-        <div className="present-root-drift" role="status">
-          <span>
-            The repo has moved on since this round was pinned ({shortSha(round.head_sha)} → {shortSha(repoHeadSha!)}).
-            Diffs below still show the pinned commits.
-          </span>
-          <button
-            type="button"
-            className="present-root-drift-dismiss"
-            aria-label="Dismiss"
-            onClick={() => setDriftDismissed(true)}
-          >
-            ×
-          </button>
-        </div>
-      )}
-
-      {comments.length > 0 && (
-        <p className="present-root-comment-count">
-          {comments.length} comment{comments.length === 1 ? '' : 's'} on this round
-        </p>
       )}
 
       <div className="present-root-body">
@@ -817,6 +797,7 @@ export function PresentRoot() {
           ) : (
             <PresentTour
               summary={round.manifest.summary}
+              summaryVisible={activePath === null}
               files={tourFiles}
               comments={allComments}
               editingCommentId={editingCommentId}

--- a/app/src/components/PresentRoot/index.tsx
+++ b/app/src/components/PresentRoot/index.tsx
@@ -152,6 +152,9 @@ export function PresentRoot() {
   // "scroll to this file" instruction — kept separate from `activePath` so a
   // passive activePath update from scrolling can never itself re-trigger a
   // programmatic scroll (which would fight the user's own scroll gesture).
+  // Passive scroll updates never report null — the Summary stop (null) is
+  // only entered explicitly (initial state, rail Summary click, or K from the
+  // first file).
   const [activePath, setActivePath] = useState<string | null>(null);
   const [scrollRequest, setScrollRequest] = useState<{ path: string | null; nonce: number } | null>(null);
   const scrollNonceRef = useRef(0);

--- a/app/src/components/PresentTour/PresentTour.css
+++ b/app/src/components/PresentTour/PresentTour.css
@@ -26,6 +26,26 @@
      squeezes the tour itself out of the viewport. */
   max-height: 40vh;
   overflow-y: auto;
+  transition: max-height 0.18s ease, opacity 0.18s ease, padding 0.18s ease, margin-bottom 0.18s ease;
+}
+
+/* Folded once the user scrolls past the pinned Summary stop (see
+   summaryVisible) — the card stays mounted so the fold can animate, rather
+   than unmounting and losing the transition. */
+.present-tour-summary.collapsed {
+  max-height: 0;
+  opacity: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-bottom: 0;
+  border-width: 0;
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .present-tour-summary {
+    transition: none;
+  }
 }
 
 .present-tour-summary :first-child {
@@ -113,16 +133,6 @@
   background: var(--color-bg-panel);
   font-family: monospace;
   font-size: var(--font-size-xs);
-}
-
-.present-tour-footer {
-  flex: 0 0 auto;
-  margin-top: 16px;
-  padding: 16px;
-  text-align: center;
-  color: var(--color-text-secondary);
-  font-size: var(--font-size);
-  border-top: 1px solid var(--color-border);
 }
 
 /* Skipped-file cards (jaunt's "deemph" analog): CodeView items render inside

--- a/app/src/components/PresentTour/PresentTour.test.tsx
+++ b/app/src/components/PresentTour/PresentTour.test.tsx
@@ -31,11 +31,32 @@ vi.mock('mermaid', () => ({
 // `version` CodeView receives, without CodeView itself needing to be real.
 const codeViewRenders = vi.hoisted(() => ({ calls: [] as Array<Array<Record<string, unknown>>> }));
 
+// The latest full props object CodeView received, so scroll tests can invoke
+// `props.onScroll(scrollTop)` directly — the same callback PresentTour wires
+// up as `handleScroll` — without needing the real library's scroll machinery.
+const codeViewProps = vi.hoisted(() => ({ latest: null as Record<string, unknown> | null }));
+
 vi.mock('@pierre/diffs/react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@pierre/diffs/react')>();
   const MockCodeView = forwardRef((props: Record<string, unknown>, ref) => {
+    codeViewProps.latest = props;
     useImperativeHandle(ref, () => ({
-      getInstance: () => ({ getRenderedItems: () => [] }),
+      // Derived from the mock's own rendered DOM (each `[data-item-id]` div
+      // below) rather than hardcoded — in jsdom `getBoundingClientRect()`
+      // returns all zeros, so the first item's `top` always lands at 0,
+      // which is <= handleScroll's 80px threshold and makes it `bestPath`.
+      // That's what lets these tests exercise the real bestPath/nearestPath
+      // loop instead of just the pre-loop early returns.
+      getInstance: () => ({
+        getRenderedItems: () => {
+          const container = document.querySelector('[data-testid="mock-codeview"]');
+          if (!container) return [];
+          return Array.from(container.querySelectorAll<HTMLElement>('[data-item-id]')).map((el) => ({
+            id: el.getAttribute('data-item-id') as string,
+            element: el,
+          }));
+        },
+      }),
       scrollTo: () => {},
       getItem: () => undefined,
       updateItem: () => false,
@@ -75,6 +96,7 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   codeViewRenders.calls = [];
+  codeViewProps.latest = null;
 });
 
 const noop = () => {};
@@ -383,6 +405,116 @@ describe('PresentTour summary fold', () => {
     expect(summaryEl).toHaveAttribute('aria-hidden', 'true');
     // Stays mounted (not removed) so the fold can animate.
     expect(summaryEl.textContent).toContain('The summary text');
+  });
+});
+
+// These exercise handleScroll's new explicit-only Summary semantics: passive
+// scroll tracking (the mock's onScroll callback, captured via codeViewProps)
+// never reports null, and it is suppressed both before the user's first real
+// gesture and while a programmatic scroll (rail/j-k) is still settling.
+describe('PresentTour summary fold vs scroll', () => {
+  function latestOnScroll(): (scrollTop: number) => void {
+    return codeViewProps.latest!.onScroll as (scrollTop: number) => void;
+  }
+
+  it('does not report scroll position before any user gesture (mount/cold-window-pin noise)', async () => {
+    const onActivePathChange = vi.fn();
+    render(
+      <PresentTour
+        {...baseProps({ files: [tinyFile('src/foo.ts'), tinyFile('src/bar.ts')], onActivePathChange })}
+      />
+    );
+    await waitForSettled();
+
+    act(() => {
+      latestOnScroll()(0);
+    });
+    act(() => {
+      latestOnScroll()(50);
+    });
+
+    expect(onActivePathChange).not.toHaveBeenCalled();
+  });
+
+  it('reports the first file (never null) at the top of the scroller once the user has taken over', async () => {
+    const onActivePathChange = vi.fn();
+    render(
+      <PresentTour
+        {...baseProps({ files: [tinyFile('src/foo.ts'), tinyFile('src/bar.ts')], onActivePathChange })}
+      />
+    );
+    await waitForSettled();
+
+    // A real user gesture on the scroller (the takeover listeners live on
+    // containerRef, which is this mock's root div) enables passive tracking.
+    fireEvent.wheel(screen.getByTestId('mock-codeview'));
+    act(() => {
+      latestOnScroll()(0);
+    });
+
+    expect(onActivePathChange).toHaveBeenCalledWith('src/foo.ts');
+    expect(onActivePathChange).not.toHaveBeenCalledWith(null);
+  });
+
+  it('suppresses passive reporting while a programmatic scroll settles; user takeover restores it immediately', async () => {
+    const onActivePathChange = vi.fn();
+    const files = [tinyFile('src/foo.ts'), tinyFile('src/bar.ts')];
+    const { rerender } = render(
+      <PresentTour {...baseProps({ files, onActivePathChange, scrollToPath: null, scrollNonce: 0 })} />
+    );
+    await waitForSettled();
+
+    const container = screen.getByTestId('mock-codeview');
+    // Arm passive tracking first so an unsuppressed onScroll below would
+    // otherwise report — isolating the assertion to suppression, not to the
+    // pre-gesture guard covered by the previous test.
+    fireEvent.wheel(container);
+
+    // Simulate the rail/j-k path: scrollToPath + an advanced scrollNonce.
+    rerender(
+      <PresentTour {...baseProps({ files, onActivePathChange, scrollToPath: 'src/bar.ts', scrollNonce: 1 })} />
+    );
+
+    act(() => {
+      latestOnScroll()(120);
+    });
+    expect(onActivePathChange).not.toHaveBeenCalled();
+
+    // A real user gesture takes over immediately, even mid-settle.
+    fireEvent.wheel(container);
+    act(() => {
+      latestOnScroll()(120);
+    });
+    expect(onActivePathChange).toHaveBeenCalled();
+  });
+
+  it('clears suppression after the quiet window elapses with no further scroll events', async () => {
+    const onActivePathChange = vi.fn();
+    const files = [tinyFile('src/foo.ts'), tinyFile('src/bar.ts')];
+    const { rerender } = render(
+      <PresentTour {...baseProps({ files, onActivePathChange, scrollToPath: null, scrollNonce: 0 })} />
+    );
+    await waitForSettled();
+
+    fireEvent.wheel(screen.getByTestId('mock-codeview'));
+    rerender(<PresentTour {...baseProps({ files, onActivePathChange, scrollToPath: 'src/bar.ts', scrollNonce: 1 })} />);
+
+    act(() => {
+      latestOnScroll()(120);
+    });
+    expect(onActivePathChange).not.toHaveBeenCalled();
+
+    // Real ~250ms wait past the 200ms quiet window — fake timers fight this
+    // suite's use of testing-library's `waitFor` (see waitForSettled), so
+    // this is a genuine wall-clock wait rather than `vi.advanceTimersByTime`.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+
+    act(() => {
+      latestOnScroll()(80);
+    });
+    expect(onActivePathChange).toHaveBeenCalled();
   });
 });
 

--- a/app/src/components/PresentTour/PresentTour.test.tsx
+++ b/app/src/components/PresentTour/PresentTour.test.tsx
@@ -359,27 +359,30 @@ describe('PresentTour annotations', () => {
   });
 });
 
-describe('PresentTour end-of-tour footer', () => {
-  it('counts reviewed over progress files only (skipped excluded), not every rendered card', async () => {
-    const tourFile = tinyFile('src/foo.ts');
-    const otherFile: PresentTourFile = { ...tinyFile('src/extra.ts'), group: 'other' };
-    const skipFile: PresentTourFile = { ...tinyFile('src/generated.ts'), group: 'skip' };
+describe('PresentTour summary fold', () => {
+  it('renders expanded (no collapsed class, aria-hidden=false) when summaryVisible is omitted or true', async () => {
+    render(<PresentTour {...baseProps({ files: [tinyFile('src/foo.ts')], summary: 'The summary text' })} />);
+    await waitForSettled();
+
+    const summaryEl = screen.getByTestId('present-tour-summary');
+    expect(summaryEl).not.toHaveClass('collapsed');
+    expect(summaryEl).toHaveAttribute('aria-hidden', 'false');
+    expect(summaryEl.textContent).toContain('The summary text');
+  });
+
+  it('applies the collapsed class and aria-hidden=true when summaryVisible is false, without unmounting the card', async () => {
     render(
       <PresentTour
-        {...baseProps({
-          files: [tourFile, otherFile, skipFile],
-          reviewedPaths: new Set(['src/foo.ts']),
-        })}
+        {...baseProps({ files: [tinyFile('src/foo.ts')], summary: 'The summary text', summaryVisible: false })}
       />
     );
     await waitForSettled();
 
-    // 3 cards render, but progress covers tour + other only (2), of which
-    // one is marked reviewed — the footer must mirror the rail, not count
-    // skipped cards or claim everything reviewed.
-    await waitFor(() => {
-      expect(screen.getByTestId('present-tour-footer').textContent).toBe('End of tour — 1 of 2 files reviewed.');
-    });
+    const summaryEl = screen.getByTestId('present-tour-summary');
+    expect(summaryEl).toHaveClass('collapsed');
+    expect(summaryEl).toHaveAttribute('aria-hidden', 'true');
+    // Stays mounted (not removed) so the fold can animate.
+    expect(summaryEl.textContent).toContain('The summary text');
   });
 });
 

--- a/app/src/components/PresentTour/index.tsx
+++ b/app/src/components/PresentTour/index.tsx
@@ -23,13 +23,14 @@
  *     once. A per-file error still gets its own card in-order (rendered as
  *     a plain `type: 'file'` item carrying the error text) rather than
  *     being dropped, but it will not stream in before its siblings.
- *   - Summary/footer placement: CodeView's react wrapper renders its own
- *     internal scroll container (via `containerRef`), not a slot host
- *     that's known to tolerate injected sibling DOM. Rather than risk
- *     fighting the library's own layout, the summary card and end-of-tour
- *     footer are flex siblings around the CodeView, not inside its own
- *     scroller. They stay put (do not scroll with the tour) as a result —
- *     acceptable for slice 1 per the brief's stated fallback.
+ *   - Summary placement: CodeView's react wrapper renders its own internal
+ *     scroll container (via `containerRef`), not a slot host that's known to
+ *     tolerate injected sibling DOM. Rather than risk fighting the library's
+ *     own layout, the summary card is a flex sibling above the CodeView, not
+ *     inside its own scroller — it does not scroll with the tour as a
+ *     result. Instead it folds away via `summaryVisible` once the caller
+ *     reports the user has scrolled past the pinned Summary stop, so it
+ *     doesn't permanently steal space from the diff.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -83,6 +84,9 @@ export interface AnnotationAnchor {
 
 export interface PresentTourProps {
   summary?: string;
+  /** Whether the summary card is expanded. The card stays mounted so the fold
+   * can animate; false collapses it to zero height. */
+  summaryVisible?: boolean;
   files: PresentTourFile[];
   comments: ReviewComment[];
   editingCommentId: string | null;
@@ -196,6 +200,7 @@ function getVisibleLineRangesFromDiff(diff: ReturnType<typeof parseDiffFromFile>
 
 export function PresentTour({
   summary,
+  summaryVisible = true,
   files,
   comments,
   editingCommentId,
@@ -632,17 +637,6 @@ export function PresentTour({
   const noteByPath = useMemo(() => new Map(files.map((f) => [f.path, f.note])), [files]);
   const groupByPath = useMemo(() => new Map(files.map((f) => [f.path, f.group ?? 'tour'])), [files]);
 
-  // End-of-tour footer counts, mirroring the rail's progress semantics:
-  // progress covers tour + other only (skipped files were never meant to be
-  // walked), and only files actually marked reviewed count as reviewed.
-  const { reviewedCount, progressCount } = useMemo(() => {
-    const progressPaths = files.filter((f) => (f.group ?? 'tour') !== 'skip').map((f) => f.path);
-    return {
-      progressCount: progressPaths.length,
-      reviewedCount: progressPaths.filter((path) => reviewedPaths.has(path)).length,
-    };
-  }, [files, reviewedPaths]);
-
   // The library's items don't carry an arbitrary className slot, so the
   // skip-card de-emphasis (see .present-tour-card-skip in PresentTour.css) is
   // applied imperatively to each rendered card's root element — the same
@@ -910,7 +904,11 @@ export function PresentTour({
       style={fontSize ? ({ '--diffs-font-size': `${fontSize}px` } as React.CSSProperties) : undefined}
     >
       {summary && (
-        <div className="present-tour-summary" data-testid="present-tour-summary">
+        <div
+          className={`present-tour-summary ${summaryVisible ? '' : 'collapsed'}`}
+          data-testid="present-tour-summary"
+          aria-hidden={!summaryVisible}
+        >
           <Markdown>{summary}</Markdown>
         </div>
       )}
@@ -934,12 +932,6 @@ export function PresentTour({
           onScroll={handleScroll}
           disableWorkerPool
         />
-      )}
-
-      {allSettled && items.length > 0 && (
-        <div className="present-tour-footer" data-testid="present-tour-footer">
-          End of tour — {reviewedCount} of {progressCount} file{progressCount === 1 ? '' : 's'} reviewed.
-        </div>
       )}
     </div>
   );

--- a/app/src/components/PresentTour/index.tsx
+++ b/app/src/components/PresentTour/index.tsx
@@ -104,9 +104,11 @@ export interface PresentTourProps {
    * with `scrollNonce` so re-clicking the same file still re-scrolls. */
   scrollToPath?: string | null;
   scrollNonce?: number;
-  /** Fires with the path nearest the top of the viewport as the user scrolls,
-   * or null when the viewport is scrolled to the very top (the summary
-   * region, above the first file). */
+  /** Fires with the path nearest the top of the viewport as the user
+   * passively scrolls — never with null. The Summary stop (null) is entered
+   * only explicitly (initial state, rail Summary click, or K from the first
+   * file), never as a side effect of scrolling to the top of the tour; see
+   * `handleScroll` below for why passive tracking can't report it. */
   onActivePathChange?: (path: string | null) => void;
   /** Paths the user has marked reviewed (jaunt-style per-file mark). */
   reviewedPaths: ReadonlySet<string>;
@@ -729,11 +731,27 @@ export function PresentTour({
   // mounted this commit) rather than "a scroll has ever fired". See that
   // effect's comment.
   const wasSettledRef = useRef(false);
+  // True while a programmatic smooth scroll (rail/j-k or N/P) is settling —
+  // handleScroll swallows passive reports during this window so the
+  // animation's own scroll events can't fight the explicit navigation that
+  // triggered it (e.g. K from the first file scrolling to the summary must
+  // not have its own settling events report the first file and re-fold the
+  // summary). A real user gesture (see `takeover` below) clears this
+  // immediately, since a user's own scroll always wins over a still-animating
+  // programmatic one.
+  const passiveSuppressedRef = useRef(false);
+  // Quiet-window timer backing passiveSuppressedRef: each settling scroll
+  // event re-arms it (see handleScroll), so suppression lifts ~200ms after
+  // the last such event rather than on a fixed delay from when the
+  // programmatic scroll started.
+  const suppressQuietTimerRef = useRef<number>(0);
   useEffect(() => {
     const scroller = containerRef.current;
     if (!scroller) return;
     const takeover = () => {
       userTookOverRef.current = true;
+      passiveSuppressedRef.current = false;
+      window.clearTimeout(suppressQuietTimerRef.current);
     };
     const onNativeScroll = () => {
       if (!userTookOverRef.current && scroller.scrollTop !== 0) scroller.scrollTop = 0;
@@ -749,6 +767,7 @@ export function PresentTour({
       scroller.removeEventListener('pointerdown', takeover);
       scroller.removeEventListener('keydown', takeover);
       scroller.removeEventListener('scroll', onNativeScroll);
+      window.clearTimeout(suppressQuietTimerRef.current);
     };
   }, []);
 
@@ -800,6 +819,8 @@ export function PresentTour({
     const handle = handleRef.current;
     if (!handle) return;
     userTookOverRef.current = true;
+    passiveSuppressedRef.current = true;
+    window.clearTimeout(suppressQuietTimerRef.current);
     const performScroll = () => {
       if (scrollToPath) {
         handle.scrollTo({ type: 'item', id: scrollToPath, align: 'start', behavior: 'smooth' });
@@ -834,6 +855,8 @@ export function PresentTour({
     const handle = handleRef.current;
     if (!handle) return;
     userTookOverRef.current = true;
+    passiveSuppressedRef.current = true;
+    window.clearTimeout(suppressQuietTimerRef.current);
     const { path, anchorKey } = scrollToAnnotation;
     handle.scrollTo({ type: 'item', id: path, align: 'start', behavior: 'smooth' });
     const LOCATE_BUDGET_MS = 1500;
@@ -862,13 +885,28 @@ export function PresentTour({
   // record carries the real mounted `element` for that item — rather than a
   // guessed selector.
   const handleScroll = useCallback(
-    (scrollTop: number) => {
+    (_scrollTop: number) => {
       syncSkipClasses();
       if (!onActivePathChange || !containerRef.current) return;
-      // At the very top of the scroller there is nothing above the first
-      // file to have scrolled past — this is the summary region.
-      if (scrollTop <= 0) {
-        onActivePathChange(null);
+      // Mount/cold-window-pin scroll noise never reports — passive tracking
+      // only starts once the user has taken over with a real gesture (see the
+      // takeover listeners above). Without this, the initial scroll-pin
+      // settling could fold the summary before the user ever touched
+      // anything.
+      if (!userTookOverRef.current) return;
+      // A programmatic smooth scroll (rail/j-k, N/P) is still settling — its
+      // own scroll events must not fight the explicit navigation that
+      // triggered them (e.g. K from the first file scrolling to the summary
+      // must not have the animation's own events report the first file and
+      // re-fold the summary). Re-arm the quiet window on every such event; it
+      // clears itself ~200ms after the last one. If the programmatic scroll
+      // produces no events at all (target already in view), suppression just
+      // stays armed until the user's next gesture clears it.
+      if (passiveSuppressedRef.current) {
+        window.clearTimeout(suppressQuietTimerRef.current);
+        suppressQuietTimerRef.current = window.setTimeout(() => {
+          passiveSuppressedRef.current = false;
+        }, 200);
         return;
       }
       const instance = handleRef.current?.getInstance();


### PR DESCRIPTION
## Why

Victor's review-window feedback: there's no room to read the code. The stacked title/changes/round/drift header burned ~20% of the height, and the summary card (often with a mermaid diagram) is pinned outside the CodeView scroller so it could never be scrolled away — together ~60% of the window was chrome.

## What

- **One slim topbar** replaces the header stack: title · kind · repo path, with round seq, pinned shas, draft/submitted status on the right. Repo-drift is now a dismissible amber pill in the topbar (full tooltip preserved) instead of a full-width banner.
- **Summary folds away off the Summary stop.** The card is a flex sibling of CodeView (the library owns its scroll container and positions items at analytic offsets, so the card can't live inside the scroller). Instead its visibility now derives from tour position: expanded on the pinned Summary stop (`activePath === null` — initial load, rail Summary click, K from the first file, scroll-to-top), folded the moment you move into a file. Animated max-height/opacity collapse, kept mounted so it can animate, `prefers-reduced-motion` honored, `aria-hidden` while folded.
- **End-of-tour progress strip removed** — it duplicated the rail and pinned more chrome at the bottom.
- Root padding and DriveBar spacing tightened.

Net effect: once you're reading files, everything except the slim topbar and the drive bar is code.

## Verification

- `pnpm test` PresentRoot+PresentTour: 66/66 (new tests: summaryVisible wiring from PresentRoot, fold class/aria states in PresentTour, drift-pill behavior)
- `tsc` clean
- Live packaged app: `real-app:scenario-present-flow` green end-to-end against a dev build of this branch (session → chip → present window → comment → submit → feedback CLI)
- Manual fold captures (stop-0 vs after J) to follow in a PR comment — the target machine's display is asleep; a watcher grabs them when it wakes

https://claude.ai/code/session_01MvgEqMMAkmqJQezpgLNjzQ