### PR TITLE
feat(present): collapsible summary card + fix dead passive-scroll fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Durable ticket handovers keep plans alive after the producing agent stops.** `attn ticket handover` copies one or more Markdown files into a visible `tickets/<ticket-id>/` Notebook directory, can change ticket state in the same operation, records a retry-safe handover receipt, and returns the canonical paths. Ticket reads now derive their current artifact list directly from that directory, so ordinary edits, renames, and deletions are reflected without reconciliation. The ticket panel can hand over files, open them in the Notebook editor, copy their paths, rename them, and delete them. Chiefs and delegated agents receive role-specific guidance for continuing work from the same canonical plan.
 
+### Fixed
+- **The Present window's summary card now actually collapses when you scroll the code.** Wheel-scrolling the diff — including wheel gestures over the card itself — folds the summary to a slim strip, which you can also collapse or expand by hand at any time; previously, scrolling never folded it.
+
 ---
 
 ## [2026-07-09]

--- a/app/e2e/present-tour.spec.ts
+++ b/app/e2e/present-tour.spec.ts
@@ -382,6 +382,37 @@ test.describe('PresentTour draft and comment gutter interactions', () => {
   });
 });
 
+test.describe('PresentTour summary fold', () => {
+  // Browser-level regression for the listener-never-attached bug: the harness's
+  // `deferred=1` + `settleDiffs()` mode reproduces the live app's loading ->
+  // settled transition (diffs arrive async over the daemon WS), which is
+  // exactly the case unit tests and the default harness mode (diffs
+  // pre-loaded) never exercised.
+  test('wheel-scrolling the diff folds the summary card; the toggle re-expands it', async ({ page }) => {
+    await page.goto('/test-harness/?component=PresentTour&seed=0&deferred=1');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+
+    const summary = page.locator('.present-tour-summary');
+    await expect(summary).toBeVisible();
+    await expect(summary).not.toHaveClass(/collapsed/);
+
+    await page.evaluate(() => (window.__HARNESS__ as unknown as { settleDiffs: () => void }).settleDiffs());
+    await page.waitForSelector('diffs-container');
+    await page.locator('diffs-container [data-line-number-content]').first().waitFor();
+
+    await expect(async () => {
+      const box = await page.locator('.present-tour-scroller').boundingBox();
+      if (!box) throw new Error('scroller not laid out yet');
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.wheel(0, 400);
+      await expect(summary).toHaveClass(/collapsed/, { timeout: 1000 });
+    }).toPass({ timeout: 15_000 });
+
+    await page.getByTestId('present-tour-summary-toggle').click();
+    await expect(summary).not.toHaveClass(/collapsed/);
+  });
+});
+
 test.describe('PresentTour deferred-load scroll replay', () => {
   test('a scroll request issued while still loading is replayed once files settle', async ({ page }) => {
     // `&deferred=1` starts every file `{loading: true}` (no `<diffs-container>`

--- a/app/e2e/present-tour.spec.ts
+++ b/app/e2e/present-tour.spec.ts
@@ -110,6 +110,23 @@ async function openDraftViaGutter(container: Locator, line: Locator) {
   }).toPass({ timeout: 15_000 });
 }
 
+/**
+ * Collapses the summary card up front so its scroll-triggered fold (an
+ * ~0.18s height animation that shifts the whole scroller and churns the
+ * virtualizer) can't fire mid-gesture in specs whose subject is draft/form
+ * behavior, not the fold. The fold itself is covered by its own spec.
+ */
+async function collapseSummaryFirst(page: Page) {
+  const summary = page.locator('.present-tour-summary');
+  if ((await summary.count()) === 0) return;
+  await page.getByTestId('present-tour-summary-toggle').click();
+  await expect(summary).toHaveClass(/collapsed/);
+  // The class flips immediately, but the body's height transition
+  // (max-height 0.18s) still runs after — settle it too so the scroller's
+  // layout has fully stopped moving before any gesture below.
+  await expect(page.getByTestId('present-tour-summary-body')).toHaveCSS('max-height', '0px');
+}
+
 test.describe('PresentTour rendering', () => {
   test('renders every manifest file as a card inside one scroller, in reading order', async ({ page }) => {
     await openHarness(page, UNSEEDED);
@@ -255,6 +272,7 @@ test.describe('PresentTour rail-driven scroll', () => {
 test.describe('PresentTour multiple simultaneous drafts across files', () => {
   test('opening a draft on one file and one on another keeps both open independently', async ({ page }) => {
     await openHarness(page, UNSEEDED);
+    await collapseSummaryFirst(page);
 
     const alphaContainer = fileContainers(page).first();
     const alphaLine = alphaContainer.locator('[data-line-index][data-column-number]').nth(4);
@@ -303,6 +321,7 @@ test.describe('PresentTour multiple simultaneous drafts across files', () => {
 
   test('Escape closes the most-recently-opened draft first, across files', async ({ page }) => {
     await openHarness(page, UNSEEDED);
+    await collapseSummaryFirst(page);
 
     const alphaContainer = fileContainers(page).first();
     const alphaLine = alphaContainer.locator('[data-line-index][data-column-number]').nth(4);
@@ -339,6 +358,7 @@ test.describe('PresentTour multiple simultaneous drafts across files', () => {
 test.describe('PresentTour draft and comment gutter interactions', () => {
   test('gutter "+" on a specific line opens a draft form anchored to that line', async ({ page }) => {
     await openHarness(page, UNSEEDED);
+    await collapseSummaryFirst(page);
 
     const alphaContainer = fileContainers(page).first();
     const line = alphaContainer.locator('[data-line-index][data-column-number]').nth(3);
@@ -364,6 +384,7 @@ test.describe('PresentTour draft and comment gutter interactions', () => {
   test('a seeded comment can be edited and deleted', async ({ page }) => {
     // seed=1 (default): harness seeds one comment on src/alpha.ts.
     await openHarness(page, '/test-harness/?component=PresentTour');
+    await collapseSummaryFirst(page);
 
     const thread = page.getByTestId('diff-comment-thread');
     await expect(thread).toContainText('Seeded comment on alpha');

--- a/app/src/components/PresentRoot/PresentRoot.test.tsx
+++ b/app/src/components/PresentRoot/PresentRoot.test.tsx
@@ -21,7 +21,7 @@ import type { PresentationRound } from '../../types/generated';
 // production logic covered separately in PresentTour.test.tsx; this mock only
 // needs to exercise PresentRoot's N/P hop-state wiring.
 vi.mock('../PresentTour', () => ({
-  PresentTour: vi.fn(({ summary, files, comments, annotationCommentIds, onAnnotationAnchorsChange, reviewedPaths, onToggleReviewed }: PresentTourProps) => {
+  PresentTour: vi.fn(({ summary, summaryVisible, onSummaryVisibleChange, files, comments, annotationCommentIds, onAnnotationAnchorsChange, reviewedPaths, onToggleReviewed }: PresentTourProps) => {
     useEffect(() => {
       if (!onAnnotationAnchorsChange) return;
       // One anchor per (filepath, line_start) group, not per thread entry —
@@ -41,6 +41,10 @@ vi.mock('../PresentTour', () => ({
     return (
       <div data-testid="present-tour">
         {summary && <div data-testid="present-tour-summary">{summary}</div>}
+        <span data-testid="present-tour-summary-visible">{String(summaryVisible)}</span>
+        <button type="button" onClick={() => onSummaryVisibleChange?.(!summaryVisible)}>
+          toggle-summary-visible
+        </button>
         {files.map((f) => (
           <div key={f.path} data-testid={`tour-file-${f.path}`}>
             {f.note && <div className="note">{f.note}</div>}
@@ -693,6 +697,38 @@ describe('PresentRoot', () => {
     fireEvent.click(screen.getByText('src/foo.ts'));
     await waitFor(() => {
       expect(latestTourProps().summaryVisible).toBe(false);
+    }, WAIT_OPTS);
+  });
+
+  it('restores summaryVisible=true when the rail Summary row is clicked after navigating away', async () => {
+    await loadRound();
+
+    fireEvent.click(screen.getByText('src/foo.ts'));
+    await waitFor(() => {
+      expect(latestTourProps().summaryVisible).toBe(false);
+    }, WAIT_OPTS);
+
+    fireEvent.click(screen.getByTestId('present-root-summary-row'));
+    await waitFor(() => {
+      expect(latestTourProps().summaryVisible).toBe(true);
+    }, WAIT_OPTS);
+  });
+
+  it('flips summaryVisible via onSummaryVisibleChange (manual toggle) while still on the Summary stop', async () => {
+    await loadRound();
+
+    await waitFor(() => {
+      expect(latestTourProps().summaryVisible).toBe(true);
+    }, WAIT_OPTS);
+
+    fireEvent.click(screen.getByText('toggle-summary-visible'));
+    await waitFor(() => {
+      expect(latestTourProps().summaryVisible).toBe(false);
+    }, WAIT_OPTS);
+
+    fireEvent.click(screen.getByText('toggle-summary-visible'));
+    await waitFor(() => {
+      expect(latestTourProps().summaryVisible).toBe(true);
     }, WAIT_OPTS);
   });
 

--- a/app/src/components/PresentRoot/index.tsx
+++ b/app/src/components/PresentRoot/index.tsx
@@ -158,6 +158,14 @@ export function PresentRoot() {
   const [activePath, setActivePath] = useState<string | null>(null);
   const [scrollRequest, setScrollRequest] = useState<{ path: string | null; nonce: number } | null>(null);
   const scrollNonceRef = useRef(0);
+  // Owned separately from activePath so a manual toggle (click, overscroll
+  // wheel) can win independently of navigation, while still folding
+  // automatically on any arrival at a file stop. See the effect below and
+  // `requestScroll`'s null-path branch for the two ways this un-collapses.
+  const [summaryCollapsed, setSummaryCollapsed] = useState(false);
+  useEffect(() => {
+    if (activePath !== null) setSummaryCollapsed(true);
+  }, [activePath]);
   const [fileDiffs, setFileDiffs] = useState<Record<string, DiffCacheEntry>>({});
   const [driftDismissed, setDriftDismissed] = useState(false);
   const [drafts, setDrafts] = useState<Draft[]>([]);
@@ -174,11 +182,14 @@ export function PresentRoot() {
   const activeRoundKeyRef = useRef<string | null>(null);
   activeRoundKeyRef.current = round ? round.id : null;
 
-  // path=null requests a scroll to the pinned Summary row (stop 0).
+  // path=null requests a scroll to the pinned Summary row (stop 0), and also
+  // re-expands the summary card — an explicit return to the Summary stop
+  // should always show it, even if it was manually collapsed earlier.
   const requestScroll = useCallback((path: string | null) => {
     scrollNonceRef.current += 1;
     setActivePath(path);
     setScrollRequest({ path, nonce: scrollNonceRef.current });
+    if (path === null) setSummaryCollapsed(false);
   }, []);
 
   // Fires once, unconditionally, regardless of load/error state below — the
@@ -800,7 +811,8 @@ export function PresentRoot() {
           ) : (
             <PresentTour
               summary={round.manifest.summary}
-              summaryVisible={activePath === null}
+              summaryVisible={!summaryCollapsed}
+              onSummaryVisibleChange={(visible) => setSummaryCollapsed(!visible)}
               files={tourFiles}
               comments={allComments}
               editingCommentId={editingCommentId}

--- a/app/src/components/PresentTour/PresentTour.css
+++ b/app/src/components/PresentTour/PresentTour.css
@@ -16,43 +16,76 @@
 .present-tour-summary {
   flex: 0 0 auto;
   margin-bottom: 16px;
-  padding: 14px 16px;
   border: 1px solid var(--color-border);
   border-radius: 6px;
   background: var(--color-bg-panel);
   color: var(--color-text-primary);
+}
+
+/* The always-visible strip: folding hides only the body below, so the card
+   can still be expanded again once collapsed. */
+.present-tour-summary-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 16px;
+  border: none;
+  background: none;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.present-tour-summary-toggle:focus-visible {
+  outline: 2px solid var(--color-accent, #5b8cff);
+  outline-offset: -2px;
+}
+
+.present-tour-summary-chevron {
+  display: inline-block;
+  transition: transform 0.18s ease;
+}
+
+.present-tour-summary-chevron.is-open {
+  transform: rotate(90deg);
+}
+
+.present-tour-summary-body {
+  color: var(--color-text-primary);
   line-height: 1.6;
+  padding: 0 16px 14px;
   /* A summary can now hold a mermaid diagram; without a cap a tall one
      squeezes the tour itself out of the viewport. */
   max-height: 40vh;
   overflow-y: auto;
-  transition: max-height 0.18s ease, opacity 0.18s ease, padding 0.18s ease, margin-bottom 0.18s ease;
+  transition: max-height 0.18s ease, opacity 0.18s ease, padding 0.18s ease;
 }
 
-/* Folded once the user scrolls past the pinned Summary stop (see
-   summaryVisible) — the card stays mounted so the fold can animate, rather
-   than unmounting and losing the transition. */
-.present-tour-summary.collapsed {
+/* Folded on scroll-away or manual toggle (see onSummaryVisibleChange) — the
+   body stays mounted so the fold can animate, rather than unmounting and
+   losing the transition. The strip itself (toggle button) stays visible. */
+.present-tour-summary.collapsed .present-tour-summary-body {
   max-height: 0;
   opacity: 0;
   padding-top: 0;
   padding-bottom: 0;
-  margin-bottom: 0;
-  border-width: 0;
   overflow: hidden;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .present-tour-summary {
+  .present-tour-summary-body,
+  .present-tour-summary-chevron {
     transition: none;
   }
 }
 
-.present-tour-summary :first-child {
+.present-tour-summary-body :first-child {
   margin-top: 0;
 }
 
-.present-tour-summary :last-child {
+.present-tour-summary-body :last-child {
   margin-bottom: 0;
 }
 

--- a/app/src/components/PresentTour/PresentTour.test.tsx
+++ b/app/src/components/PresentTour/PresentTour.test.tsx
@@ -382,17 +382,20 @@ describe('PresentTour annotations', () => {
 });
 
 describe('PresentTour summary fold', () => {
-  it('renders expanded (no collapsed class, aria-hidden=false) when summaryVisible is omitted or true', async () => {
+  it('renders expanded (no collapsed class, body aria-hidden=false) when summaryVisible is omitted or true', async () => {
     render(<PresentTour {...baseProps({ files: [tinyFile('src/foo.ts')], summary: 'The summary text' })} />);
     await waitForSettled();
 
     const summaryEl = screen.getByTestId('present-tour-summary');
     expect(summaryEl).not.toHaveClass('collapsed');
-    expect(summaryEl).toHaveAttribute('aria-hidden', 'false');
-    expect(summaryEl.textContent).toContain('The summary text');
+    const bodyEl = screen.getByTestId('present-tour-summary-body');
+    expect(bodyEl).toHaveAttribute('aria-hidden', 'false');
+    expect(bodyEl.textContent).toContain('The summary text');
+    // The toggle stays present and clickable while expanded.
+    expect(screen.getByTestId('present-tour-summary-toggle')).toBeEnabled();
   });
 
-  it('applies the collapsed class and aria-hidden=true when summaryVisible is false, without unmounting the card', async () => {
+  it('applies the collapsed class and body aria-hidden=true when summaryVisible is false, without unmounting the card', async () => {
     render(
       <PresentTour
         {...baseProps({ files: [tinyFile('src/foo.ts')], summary: 'The summary text', summaryVisible: false })}
@@ -402,9 +405,125 @@ describe('PresentTour summary fold', () => {
 
     const summaryEl = screen.getByTestId('present-tour-summary');
     expect(summaryEl).toHaveClass('collapsed');
-    expect(summaryEl).toHaveAttribute('aria-hidden', 'true');
+    const bodyEl = screen.getByTestId('present-tour-summary-body');
+    expect(bodyEl).toHaveAttribute('aria-hidden', 'true');
     // Stays mounted (not removed) so the fold can animate.
-    expect(summaryEl.textContent).toContain('The summary text');
+    expect(bodyEl.textContent).toContain('The summary text');
+    // The toggle stays present and clickable while collapsed.
+    expect(screen.getByTestId('present-tour-summary-toggle')).toBeEnabled();
+  });
+
+  it('clicking the toggle calls onSummaryVisibleChange with the opposite of summaryVisible', async () => {
+    const onSummaryVisibleChange = vi.fn();
+    const { rerender } = render(
+      <PresentTour
+        {...baseProps({
+          files: [tinyFile('src/foo.ts')],
+          summary: 'The summary text',
+          summaryVisible: true,
+          onSummaryVisibleChange,
+        })}
+      />
+    );
+    await waitForSettled();
+
+    fireEvent.click(screen.getByTestId('present-tour-summary-toggle'));
+    expect(onSummaryVisibleChange).toHaveBeenCalledWith(false);
+
+    onSummaryVisibleChange.mockClear();
+    rerender(
+      <PresentTour
+        {...baseProps({
+          files: [tinyFile('src/foo.ts')],
+          summary: 'The summary text',
+          summaryVisible: false,
+          onSummaryVisibleChange,
+        })}
+      />
+    );
+    fireEvent.click(screen.getByTestId('present-tour-summary-toggle'));
+    expect(onSummaryVisibleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('wheel-down over an at-bottom (no further scroll) card body collapses; wheel-up does not', async () => {
+    const onSummaryVisibleChange = vi.fn();
+    render(
+      <PresentTour
+        {...baseProps({
+          files: [tinyFile('src/foo.ts')],
+          summary: 'The summary text',
+          summaryVisible: true,
+          onSummaryVisibleChange,
+        })}
+      />
+    );
+    await waitForSettled();
+
+    const summaryEl = screen.getByTestId('present-tour-summary');
+    // jsdom gives every element zero geometry (scrollTop/clientHeight/
+    // scrollHeight all 0), so scrollTop + clientHeight >= scrollHeight holds
+    // by default — this exercises the "no more content to scroll" case
+    // without needing to fake non-zero geometry.
+    fireEvent.wheel(summaryEl, { deltaY: -50 });
+    expect(onSummaryVisibleChange).not.toHaveBeenCalled();
+
+    fireEvent.wheel(summaryEl, { deltaY: 50 });
+    expect(onSummaryVisibleChange).toHaveBeenCalledWith(false);
+  });
+
+  it('wheel-down does not collapse while the card body still has content to scroll', async () => {
+    const onSummaryVisibleChange = vi.fn();
+    render(
+      <PresentTour
+        {...baseProps({
+          files: [tinyFile('src/foo.ts')],
+          summary: 'The summary text',
+          summaryVisible: true,
+          onSummaryVisibleChange,
+        })}
+      />
+    );
+    await waitForSettled();
+
+    const body = screen.getByTestId('present-tour-summary-body');
+    Object.defineProperty(body, 'scrollHeight', { value: 800, configurable: true });
+    Object.defineProperty(body, 'clientHeight', { value: 200, configurable: true });
+    Object.defineProperty(body, 'scrollTop', { value: 0, configurable: true });
+
+    fireEvent.wheel(screen.getByTestId('present-tour-summary'), { deltaY: 50 });
+    expect(onSummaryVisibleChange).not.toHaveBeenCalled();
+  });
+});
+
+// Regression test for the root-cause bug: the takeover/cold-window-pin
+// listener effect used to have `[]` deps, so it ran once against
+// `containerRef.current === null` while the first render's `allSettled` was
+// still false (diffs load async over the daemon WS in the live app) and then
+// never ran again once CodeView actually mounted. Passive scroll tracking
+// never armed, `handleScroll` returned early forever, and neither the
+// summary fold nor the cold-window scroll pin ever worked outside tests
+// (which, unlike the live app, feed pre-loaded diffs so `allSettled` is true
+// on the very first render). This must fail on the pre-fix `[]` deps and
+// pass once the effect depends on `allSettled`.
+describe('PresentTour listener re-attach on deferred load (regression)', () => {
+  it('arms passive scroll tracking once CodeView mounts after starting in the loading state', async () => {
+    const onActivePathChange = vi.fn();
+    const loadingFile: PresentTourFile = { path: 'src/foo.ts', diff: { loading: true } };
+    const { rerender } = render(
+      <PresentTour {...baseProps({ files: [loadingFile], onActivePathChange })} />
+    );
+
+    expect(screen.getByText('Loading tour…')).toBeInTheDocument();
+
+    rerender(<PresentTour {...baseProps({ files: [tinyFile('src/foo.ts')], onActivePathChange })} />);
+    await waitForSettled();
+
+    fireEvent.wheel(screen.getByTestId('mock-codeview'));
+    act(() => {
+      (codeViewProps.latest!.onScroll as (scrollTop: number) => void)(0);
+    });
+
+    expect(onActivePathChange).toHaveBeenCalledWith('src/foo.ts');
   });
 });
 

--- a/app/src/components/PresentTour/index.tsx
+++ b/app/src/components/PresentTour/index.tsx
@@ -87,6 +87,11 @@ export interface PresentTourProps {
   /** Whether the summary card is expanded. The card stays mounted so the fold
    * can animate; false collapses it to zero height. */
   summaryVisible?: boolean;
+  /** Fires when the user asks to change the summary's expanded state — the
+   * manual toggle button, or the overscroll-to-collapse wheel gesture over
+   * the card (see `handleSummaryWheel`). The caller owns the actual
+   * `summaryVisible` state; this component never flips it itself. */
+  onSummaryVisibleChange?: (visible: boolean) => void;
   files: PresentTourFile[];
   comments: ReviewComment[];
   editingCommentId: string | null;
@@ -203,6 +208,7 @@ function getVisibleLineRangesFromDiff(diff: ReturnType<typeof parseDiffFromFile>
 export function PresentTour({
   summary,
   summaryVisible = true,
+  onSummaryVisibleChange,
   files,
   comments,
   editingCommentId,
@@ -229,6 +235,23 @@ export function PresentTour({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const handleRef = useRef<CodeViewHandle<AnnotationMeta> | null>(null);
   const suppressSelectionEndRef = useRef(false);
+  // The summary card is a flex sibling above the CodeView scroller (see the
+  // module doc), so a wheel gesture with the cursor over the card never
+  // reaches the takeover/scroll listeners below — without this, wheeling
+  // over the card was a dead zone that neither scrolled the tour nor folded
+  // the summary. Wheel-down over the card collapses it, but only once the
+  // card's own internal scroll (see `.present-tour-summary-body`'s
+  // `overflow-y: auto`) is exhausted, so a tall summary can still be read.
+  const summaryBodyRef = useRef<HTMLDivElement>(null);
+  const handleSummaryWheel = useCallback(
+    (e: React.WheelEvent) => {
+      if (!summaryVisible || e.deltaY <= 0) return;
+      const body = summaryBodyRef.current;
+      if (body && body.scrollTop + body.clientHeight < body.scrollHeight - 1) return; // still has content to scroll
+      onSummaryVisibleChange?.(false);
+    },
+    [summaryVisible, onSummaryVisibleChange]
+  );
   // Populated as a side effect of the items useMemo below (document order:
   // files order, then rendered line within a file) and read back out by the
   // annotation-anchors effect further down — same "mutate a ref inside the
@@ -745,6 +768,17 @@ export function PresentTour({
   // the last such event rather than on a fixed delay from when the
   // programmatic scroll started.
   const suppressQuietTimerRef = useRef<number>(0);
+  // Must attach once CodeView actually mounts, not just on this component's
+  // own mount: diffs load async over the daemon WS, so on first render
+  // `allSettled` is often still false, the "Loading tour…" branch renders
+  // instead of CodeView, and `containerRef.current` is null — an empty dep
+  // array would run this effect exactly once against that null ref and never
+  // again, permanently disarming the takeover/cold-window-pin listeners (the
+  // summary card would then never fold, since passive scroll reports never
+  // arm `userTookOverRef`). `allSettled` in the deps re-runs the effect the
+  // moment CodeView mounts; the cleanup also re-runs if diffs ever reload
+  // (allSettled true -> false -> true), which is correct since the container
+  // itself may have been swapped out during the loading branch.
   useEffect(() => {
     const scroller = containerRef.current;
     if (!scroller) return;
@@ -769,7 +803,7 @@ export function PresentTour({
       scroller.removeEventListener('scroll', onNativeScroll);
       window.clearTimeout(suppressQuietTimerRef.current);
     };
-  }, []);
+  }, [allSettled]);
 
   // Rail-driven / j-k-driven scroll: nonce forces a re-scroll even to the
   // same path (e.g. re-pressing j at the last file). A null scrollToPath
@@ -945,9 +979,28 @@ export function PresentTour({
         <div
           className={`present-tour-summary ${summaryVisible ? '' : 'collapsed'}`}
           data-testid="present-tour-summary"
-          aria-hidden={!summaryVisible}
+          onWheel={handleSummaryWheel}
         >
-          <Markdown>{summary}</Markdown>
+          <button
+            type="button"
+            className="present-tour-summary-toggle"
+            data-testid="present-tour-summary-toggle"
+            aria-expanded={summaryVisible}
+            onClick={() => onSummaryVisibleChange?.(!summaryVisible)}
+          >
+            <span className={`present-tour-summary-chevron${summaryVisible ? ' is-open' : ''}`} aria-hidden="true">
+              ▸
+            </span>
+            Summary
+          </button>
+          <div
+            className="present-tour-summary-body"
+            data-testid="present-tour-summary-body"
+            aria-hidden={!summaryVisible}
+            ref={summaryBodyRef}
+          >
+            <Markdown>{summary}</Markdown>
+          </div>
         </div>
       )}
 

--- a/app/test-harness/harnesses/PresentTourHarness.tsx
+++ b/app/test-harness/harnesses/PresentTourHarness.tsx
@@ -117,6 +117,13 @@ export function PresentTourHarness({ onReady }: HarnessProps) {
   const [scrollNonce, setScrollNonce] = useState(0);
   const [activePath, setActivePath] = useState<string | null>(null);
   const [reviewedPaths, setReviewedPaths] = useState<Set<string>>(new Set());
+  // Mirrors PresentRoot's summary-collapse wiring so e2e can exercise the
+  // fold: any arrival at a file stop collapses it, a manual toggle wins
+  // otherwise.
+  const [summaryCollapsed, setSummaryCollapsed] = useState(false);
+  useEffect(() => {
+    if (activePath !== null) setSummaryCollapsed(true);
+  }, [activePath]);
   // When `deferred=1`, files start loading (mirroring PresentRoot's fetch pass)
   // so tests can exercise scroll requests issued before CodeView mounts, then
   // call `settleDiffs()` to supply content and let the tour finish loading.
@@ -224,6 +231,8 @@ export function PresentTourHarness({ onReady }: HarnessProps) {
           summary={`## Harness summary
 
 Three files, reading order alpha -> beta -> gamma.`}
+          summaryVisible={!summaryCollapsed}
+          onSummaryVisibleChange={(visible) => setSummaryCollapsed(!visible)}
           files={files}
           comments={comments}
           editingCommentId={editingCommentId}


### PR DESCRIPTION
## Why

Victor: the summary/diagram card still eats 30–40% of the present window's vertical space and scrolling doesn't fold it — it needs to be collapsible, and to auto-collapse (animated) when you start scrolling the files.

Investigating live showed the #525 fold-on-scroll was **never working in the packaged app**: the takeover/cold-window-pin listener effect has `[]` deps, but on first render diffs are still loading over the WS, CodeView isn't mounted, and `containerRef.current` is null — the effect bails and never re-runs. Passive scroll never arms `userTookOverRef`, so `handleScroll` returns early forever: no fold, no rail tracking, and the cold-window scroll pin was dead too. Unit tests and the e2e harness feed pre-loaded diffs (`allSettled` true on first render), which is why CI stayed green.

## What

- **Fix:** the listener effect now depends on `allSettled`, attaching the moment CodeView mounts (and re-attaching if diffs reload).
- **Disclosure card:** the summary keeps a slim always-visible "Summary" strip with a chevron; the body folds. Click toggles it manually.
- **Dead zone removed:** wheel-down with the cursor over the card collapses it once the card's own inner scroll is exhausted (tall summaries stay readable).
- Navigation semantics unchanged: arriving at any file stop collapses; rail-Summary / K-to-top expands; manual toggle wins until the next navigation.

## Verification

- Unit: 75/75 (PresentTour + PresentRoot), including a regression test for the loading→settled listener attach — **flip-checked**: it fails with the old `[]` deps.
- E2E: 14/14 `present-tour.spec.ts`, including a new browser-level fold spec that uses the harness's `deferred=1` mode to reproduce the live loading transition, real `mouse.wheel`, and the toggle click.
- Live packaged app (attn-dev rebuilt from this branch, synthetic CGEvent wheel): wheel over the code folds the card and moves the rail highlight; K back to top re-expands; wheel over the card collapses it. Screenshots in the session log.
- `tsc --noEmit` clean.