### PR TITLE
fix(workspaces): remove orphan agent panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-11]
+
+### Fixed
+- **Closed sessions no longer leave workspace tiles that reappear in the sidebar.** Closing now removes the pane before announcing the session's departure, stale agent panes cannot be moved into another workspace, and startup repairs any orphan panes left by older runs.
+
 ## [2026-07-10]
 
 ### Added

--- a/docs/alignment/orphan-agent-pane-lifecycle.md
+++ b/docs/alignment/orphan-agent-pane-lifecycle.md
@@ -1,0 +1,16 @@
+# Orphan agent pane lifecycle
+
+## Why
+
+Closing an agent must remove both the session and its workspace pane as one coherent lifecycle transition. Done means a closed pane cannot remain visible, be moved into another workspace, or reappear during later sidebar reconciliation.
+
+## Aligned on
+
+- Persist the pane-free layout before unregistering the session, so every later event observes the new authoritative layout.
+- Reject cross-workspace moves of agent panes whose backing session no longer exists.
+- Reconcile persisted agent panes against session records at startup, removing historical orphans while preserving docked tiles and valid pending spawns.
+- Cover the close, move, and startup-repair paths with regression tests.
+
+## In scope / deferred
+
+This chunk fixes the daemon lifecycle invariant, repairs existing persisted violations on startup, and updates the user-facing changelog. Broader workspace/sidebar redesign is deferred.

--- a/internal/daemon/workspace_moveleaf_protocol_test.go
+++ b/internal/daemon/workspace_moveleaf_protocol_test.go
@@ -289,6 +289,41 @@ func TestMoveLeafToNewWorkspaceCreatesWorkspace(t *testing.T) {
 	}
 }
 
+func TestMoveLeafToNewWorkspaceRejectsOrphanAgentPane(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &fakeSpawnBackend{}
+	client := newWorkspaceProtocolTestClient()
+	workspaceID := "ws-orphan"
+	cwd := t.TempDir()
+
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd: protocol.CmdRegisterWorkspace, ID: workspaceID, Title: "Orphan", Directory: cwd,
+	})
+	d.handleWorkspaceLayoutAddSessionPane(client, &protocol.WorkspaceLayoutAddSessionPaneMessage{
+		Cmd: protocol.CmdWorkspaceLayoutAddSessionPane, WorkspaceID: workspaceID,
+		PaneID: protocol.Ptr("pane-orphan"), SessionID: "session-gone", Title: protocol.Ptr("gone"),
+	})
+	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutAddSessionPane, workspaceID, "pane-orphan", true)
+	snapshot := d.store.GetWorkspaceLayout(workspaceID)
+	snapshot.Panes[0].Status = workspacelayout.PaneStatusReady
+	if err := d.store.SaveWorkspaceLayout(*snapshot); err != nil {
+		t.Fatalf("mark orphan pane ready: %v", err)
+	}
+	workspaceCount := len(d.store.ListWorkspaces())
+
+	d.handleWorkspaceLayoutMoveLeafToNewWorkspace(client, &protocol.WorkspaceLayoutMoveLeafToNewWorkspaceMessage{
+		Cmd: protocol.CmdWorkspaceLayoutMoveLeafToNewWorkspace, SourceWorkspaceID: workspaceID, LeafID: "pane-orphan",
+	})
+	expectMoveToNewWorkspaceResult(t, client, workspaceID, "pane-orphan", false)
+
+	if got := len(d.store.ListWorkspaces()); got != workspaceCount {
+		t.Fatalf("workspace count = %d, want %d after rejected orphan move", got, workspaceCount)
+	}
+	if source := d.store.GetWorkspaceLayout(workspaceID); source == nil || !workspacelayout.HasPane(source.Layout, "pane-orphan") {
+		t.Fatalf("rejected move changed source layout: %+v", source)
+	}
+}
+
 func TestMoveLeafToNewWorkspaceTearsDownEmptySource(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.ptyBackend = &fakeSpawnBackend{}

--- a/internal/daemon/workspace_session_protocol_test.go
+++ b/internal/daemon/workspace_session_protocol_test.go
@@ -155,7 +155,7 @@ func TestWorkspaceSessionProtocolShellSpawnsIdleNotWorking(t *testing.T) {
 	}
 }
 
-func TestWorkspaceLayoutClosePaneKeepsLayoutUntilSessionUnregistered(t *testing.T) {
+func TestWorkspaceLayoutClosePanePersistsRemovalBeforeSessionUnregistered(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	client := newWorkspaceProtocolTestClient()
 	workspaceID := "workspace-close-order"
@@ -168,11 +168,11 @@ func TestWorkspaceLayoutClosePaneKeepsLayoutUntilSessionUnregistered(t *testing.
 		if session := d.store.Get(sessionID); session == nil {
 			t.Fatalf("session %s was removed before pty kill", sessionID)
 		}
-		if snapshot := d.store.GetWorkspaceLayout(workspaceID); snapshot == nil {
-			t.Fatalf("workspace layout %s was removed while session %s still existed", workspaceID, sessionID)
+		if snapshot := d.store.GetWorkspaceLayout(workspaceID); snapshot != nil {
+			t.Fatalf("workspace layout still referenced session %s when pty kill began: %+v", sessionID, snapshot)
 		}
-		if _, _, ok := d.store.FindWorkspaceLayoutPaneBySessionID(sessionID); !ok {
-			t.Fatalf("workspace pane mapping for session %s was removed before pty kill", sessionID)
+		if _, _, ok := d.store.FindWorkspaceLayoutPaneBySessionID(sessionID); ok {
+			t.Fatalf("workspace pane mapping for session %s still existed when pty kill began", sessionID)
 		}
 	}
 	d.ptyBackend = backend
@@ -217,6 +217,45 @@ func TestWorkspaceLayoutClosePaneKeepsLayoutUntilSessionUnregistered(t *testing.
 	}
 	if workspace := d.store.GetWorkspace(workspaceID); workspace != nil {
 		t.Fatalf("workspace still exists after closing its only session pane: %+v", workspace)
+	}
+}
+
+func TestWorkspaceLayoutStartupReconcileRemovesOrphanButKeepsPendingSpawn(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &fakeSpawnBackend{}
+	client := newWorkspaceProtocolTestClient()
+	cwd := t.TempDir()
+
+	for _, fixture := range []struct {
+		workspaceID string
+		sessionID   string
+		status      workspacelayout.PaneStatus
+	}{
+		{workspaceID: "workspace-orphan", sessionID: "session-gone", status: workspacelayout.PaneStatusReady},
+		{workspaceID: "workspace-pending", sessionID: "session-pending", status: workspacelayout.PaneStatusSpawning},
+	} {
+		d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+			Cmd: protocol.CmdRegisterWorkspace, ID: fixture.workspaceID, Title: fixture.workspaceID, Directory: cwd,
+		})
+		d.handleWorkspaceLayoutAddSessionPane(client, &protocol.WorkspaceLayoutAddSessionPaneMessage{
+			Cmd: protocol.CmdWorkspaceLayoutAddSessionPane, WorkspaceID: fixture.workspaceID,
+			PaneID: protocol.Ptr("pane-" + fixture.sessionID), SessionID: fixture.sessionID,
+		})
+		expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutAddSessionPane, fixture.workspaceID, "pane-"+fixture.sessionID, true)
+		snapshot := d.store.GetWorkspaceLayout(fixture.workspaceID)
+		snapshot.Panes[0].Status = fixture.status
+		if err := d.store.SaveWorkspaceLayout(*snapshot); err != nil {
+			t.Fatalf("save %s fixture: %v", fixture.workspaceID, err)
+		}
+	}
+
+	d.reconcileWorkspaceLayoutsWithPTYBackend(context.Background())
+
+	if orphan := d.store.GetWorkspaceLayout("workspace-orphan"); orphan != nil {
+		t.Fatalf("orphan layout survived startup reconciliation: %+v", orphan)
+	}
+	if pending := d.store.GetWorkspaceLayout("workspace-pending"); pending == nil || !workspacelayout.HasPane(pending.Layout, "pane-session-pending") {
+		t.Fatalf("valid pending spawn was removed: %+v", pending)
 	}
 }
 

--- a/internal/daemon/workspacelayout.go
+++ b/internal/daemon/workspacelayout.go
@@ -866,6 +866,12 @@ func (d *Daemon) moveLeafToWorkspace(sourceWorkspaceID, targetWorkspaceID, leafI
 		}
 	}
 	if movedPane != nil {
+		if strings.TrimSpace(movedPane.SessionID) == "" {
+			return "", fmt.Errorf("agent pane has no backing session: %s", leafID)
+		}
+		if d.store.Get(movedPane.SessionID) == nil && movedPane.Status != workspacelayout.PaneStatusSpawning {
+			return "", fmt.Errorf("agent pane session no longer exists: %s", movedPane.SessionID)
+		}
 		for _, pane := range target.Panes {
 			if pane.SessionID != "" && pane.SessionID == movedPane.SessionID {
 				return "", fmt.Errorf("target workspace already has session: %s", movedPane.SessionID)
@@ -1121,6 +1127,18 @@ func (d *Daemon) handleWorkspaceLayoutClosePane(client *wsClient, msg *protocol.
 	snapshot.Layout = layout
 	snapshot.Panes = nextPanes
 	normalized := workspacelayout.NormalizeWorkspaceLayout(*snapshot)
+	layoutEmpty := workspacelayout.LayoutEmpty(normalized.Layout)
+
+	// Commit the pane removal before terminating and unregistering the session.
+	// Session teardown broadcasts immediately and may also decide whether the
+	// workspace survives; every observer of those events must therefore see the
+	// pane-free layout rather than a stale agent leaf.
+	if layoutEmpty {
+		d.store.RemoveWorkspaceLayout(msg.WorkspaceID)
+	} else if err := d.store.SaveWorkspaceLayout(normalized); err != nil {
+		d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutClosePane, msg.WorkspaceID, protocol.Ptr(msg.PaneID), err)
+		return
+	}
 
 	if strings.TrimSpace(sessionID) != "" {
 		if session := d.unregisterSession(sessionID, syscall.SIGTERM); session != nil {
@@ -1132,17 +1150,6 @@ func (d *Daemon) handleWorkspaceLayoutClosePane(client *wsClient, msg *protocol.
 		}
 	}
 
-	// A workspace dies only when its last leaf is gone. A tile left behind
-	// keeps the workspace (now sessionless) and its layout alive.
-	layoutEmpty := workspacelayout.LayoutEmpty(normalized.Layout)
-	if layoutEmpty {
-		d.store.RemoveWorkspaceLayout(msg.WorkspaceID)
-	} else {
-		if err := d.store.SaveWorkspaceLayout(normalized); err != nil {
-			d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutClosePane, msg.WorkspaceID, protocol.Ptr(msg.PaneID), err)
-			return
-		}
-	}
 	d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutClosePane, msg.WorkspaceID, protocol.Ptr(msg.PaneID), nil)
 
 	if layoutEmpty {
@@ -1214,9 +1221,14 @@ func (d *Daemon) reconcileWorkspaceLayoutsWithPTYBackend(ctx context.Context) {
 		nextPanes := make([]workspacelayout.Pane, 0, len(snapshot.Panes))
 		changed := false
 		for _, pane := range snapshot.Panes {
-			if pane.Kind == workspacelayout.PaneKindAgent && strings.TrimSpace(pane.SessionID) != "" {
+			sessionID := strings.TrimSpace(pane.SessionID)
+			if pane.Kind == workspacelayout.PaneKindAgent && sessionID != "" &&
+				(d.store.Get(sessionID) != nil || pane.Status == workspacelayout.PaneStatusSpawning) {
 				nextPanes = append(nextPanes, pane)
 				continue
+			}
+			if pane.Kind == workspacelayout.PaneKindAgent {
+				snapshot.Layout, _ = workspacelayout.Remove(snapshot.Layout, pane.PaneID)
 			}
 			changed = true
 		}
@@ -1224,7 +1236,9 @@ func (d *Daemon) reconcileWorkspaceLayoutsWithPTYBackend(ctx context.Context) {
 		if changed {
 			snapshot.Panes = nextPanes
 			normalized := workspacelayout.NormalizeWorkspaceLayout(*snapshot)
-			if err := d.store.SaveWorkspaceLayout(normalized); err != nil {
+			if workspacelayout.LayoutEmpty(normalized.Layout) {
+				d.store.RemoveWorkspaceLayout(workspace.ID)
+			} else if err := d.store.SaveWorkspaceLayout(normalized); err != nil {
 				d.logf("workspace layout reconcile save failed for session %s: %v", workspace.ID, err)
 			}
 			continue


### PR DESCRIPTION
## Intent / Why

Closing `json-inc-fable` terminated its agent but left an agent pane referencing the deleted session. Moving that stale pane created a sessionless workspace that repeatedly appeared and disappeared in the sidebar as session and workspace state reconciled.

This change makes session removal and pane removal one coherent lifecycle transition, and repairs orphan panes left by older runs.

## Summary

- persist the pane-free workspace layout before terminating or unregistering its session, so later events cannot replay the closed pane
- reject cross-workspace moves of ready agent panes whose backing session no longer exists
- remove historical orphan agent panes during startup reconciliation while preserving legitimate pending spawns and docked tiles
- add regression coverage for close ordering, stale-pane moves, and startup repair
- document the lifecycle invariant and user-visible fix

## Test plan

- [x] `go test ./internal/daemon`
- [x] `pnpm --dir app test` — 1,426 passed, 5 skipped
- [x] `pnpm --dir app run real-app:scenario-workspace-close-one-session-keeps-selection` against the packaged `attn-dev` app
- [x] `git diff --check`

## Out of scope

- Production data cleanup before this build is installed; startup reconciliation performs that repair when the updated daemon starts.
- Broader workspace/sidebar redesign.