### PR TITLE
fix(present): keep Codex waiting for review feedback

### DIFF
--- a/app/scripts/real-app-harness/scenario-present-flow.mjs
+++ b/app/scripts/real-app-harness/scenario-present-flow.mjs
@@ -3,11 +3,11 @@
 /**
  * Real-app scenario: the full "Present" loop in the packaged app.
  *
- * An agent (via the attn CLI, `attn present`) opens a presentation from a
+ * An agent (via the attn CLI, `attn present --wait`) opens a presentation from a
  * manifest -> a notice chip appears in the main window -> clicking the chip
  * opens the second Tauri window (titled "attn — present") -> a reviewer
- * submits a round over the real daemon socket -> the authoring agent reads
- * the feedback back (`attn present feedback --json`).
+ * submits a round over the real daemon socket -> the same blocking CLI call
+ * returns the feedback to the authoring agent.
  *
  * The present window itself carries NO automation bridge, so loop mechanics
  * are asserted via the MAIN-window bridge (present_get_state /
@@ -20,7 +20,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execFileSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import {
   createSessionAndWaitForInitialPane,
   launchFreshAppAndConnect,
@@ -33,7 +33,7 @@ import { MacOSDriver } from './macosDriver.mjs';
 import { createScenarioRunner } from './scenarioRunner.mjs';
 import { buildPresentFixtureRepo } from './presentFixtureRepo.mjs';
 import { getPresentations, getPresentationRound, submitPresentationRound } from './presentDaemon.mjs';
-import { currentHarnessProfile, defaultDaemonPortForProfile } from './harnessProfile.mjs';
+import { currentHarnessProfile, defaultDaemonPortForProfile, socketPathForProfile } from './harnessProfile.mjs';
 
 const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
 // The em dash (U+2014) is load-bearing: it must match the native window title
@@ -67,19 +67,41 @@ function resolveAttnBin() {
   throw new Error('attn binary not found (build ./attn or set ATTN_HARNESS_BIN)');
 }
 
-// Extends scenario-chief-ticket-watch.mjs's makeAttnRunner with a per-call
-// { cwd, extraEnv }: `attn present` reads .present.yml from its cwd and
-// resolves the acting session from ATTN_SESSION_ID (or --session).
-function makeAttnRunner(attnBin, profile) {
-  return function runAttn(args, { cwd, extraEnv } = {}) {
-    const stdout = execFileSync(attnBin, args, {
-      encoding: 'utf8',
-      cwd,
-      env: { ...process.env, ATTN_PROFILE: profile, ...(extraEnv || {}) },
+function startWaitingPresent(attnBin, profile, { cwd, sessionId }) {
+  const child = spawn(attnBin, ['present', '--wait', '--json'], {
+    cwd,
+    env: {
+      ...process.env,
+      ATTN_PROFILE: profile,
+      ATTN_SOCKET_PATH: socketPathForProfile(profile),
+      ATTN_SESSION_ID: sessionId,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+
+  const completion = new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code, signal) => {
+      if (code !== 0) {
+        reject(new Error(`attn present --wait exited with code ${code} signal ${signal}: ${stderr}`));
+        return;
+      }
+      const brace = stdout.indexOf('{');
+      resolve({ stdout, stderr, json: brace >= 0 ? JSON.parse(stdout.slice(brace)) : null });
     });
-    const brace = stdout.indexOf('{');
-    return { stdout, json: brace >= 0 ? JSON.parse(stdout.slice(brace)) : null };
-  };
+  });
+  // A later scenario step awaits the original promise. Attach a rejection
+  // observer now as well so cleanup after an earlier failure cannot produce an
+  // unhandled rejection while the harness is unwinding.
+  completion.catch(() => {});
+
+  return { completion, kill: () => child.kill('SIGTERM') };
 }
 
 async function main() {
@@ -92,13 +114,12 @@ async function main() {
   const runner = createScenarioRunner(options, {
     scenarioId: 'PRESENT-FLOW',
     prefix: 'present-flow',
-    metadata: { focus: 'chip -> present window -> submit round -> feedback CLI' },
+    metadata: { focus: 'waiting CLI -> chip -> present window -> submit round -> synchronous feedback' },
   });
 
   const profile = currentHarnessProfile();
   const port = defaultDaemonPortForProfile(profile);
   const attnBin = resolveAttnBin();
-  const runAttn = makeAttnRunner(attnBin, profile);
 
   const client = new UiAutomationClient({ appPath: options.appPath });
   const observer = new DaemonObserver({ wsUrl: options.wsUrl });
@@ -106,6 +127,7 @@ async function main() {
 
   let sessionId = null;
   let presentationId = null;
+  let waitingPresent = null;
 
   try {
     const { repoDir, baseSha, headSha, notedPath } = await runner.step('build_fixture', async () => {
@@ -133,11 +155,20 @@ async function main() {
     });
     runner.registerCleanup('close_session', () => client.request('close_session', { sessionId }));
 
-    presentationId = await runner.step('open_presentation', async () => {
-      const { stdout } = runAttn(['present'], { cwd: repoDir, extraEnv: { ATTN_SESSION_ID: sessionId } });
-      const match = /attn present feedback (\S+)/.exec(stdout);
-      runner.assert(Boolean(match), 'attn present printed a "feedback will arrive via" line with a presentation id', { stdout });
-      const id = match[1];
+    presentationId = await runner.step('open_presentation_and_wait', async () => {
+      const existingIds = new Set((await getPresentations({ port })).map((p) => p.id));
+      waitingPresent = startWaitingPresent(attnBin, profile, { cwd: repoDir, sessionId });
+      runner.registerCleanup('stop_waiting_present', () => waitingPresent?.kill());
+      const opened = await Promise.race([
+        pollFor(async () => {
+          const presentations = await getPresentations({ port });
+          return presentations.find((p) => !existingIds.has(p.id) && p.session_id === sessionId) || null;
+        }, 'attn present --wait to open a presentation', 30_000),
+        waitingPresent.completion.then(({ stdout, stderr }) => {
+          throw new Error(`attn present --wait returned before review: stdout=${stdout} stderr=${stderr}`);
+        }),
+      ]);
+      const id = opened.id;
       const presentations = await getPresentations({ port });
       runner.assert(
         presentations.some((p) => p.id === id),
@@ -210,10 +241,16 @@ async function main() {
       return roundResult.round.submitted_at;
     });
 
-    await runner.step('read_feedback', async () => {
-      const { json } = runAttn(['present', 'feedback', presentationId, '--json']);
-      runner.assert(json && typeof json.markdown === 'string', 'present feedback --json returned a markdown field', json);
-      runner.assert(json.markdown.includes(REVIEWER_COMMENT), 'feedback markdown includes the reviewer note', json.markdown);
+    await runner.step('waiting_cli_receives_feedback', async () => {
+      const { json, stderr } = await waitingPresent.completion;
+      waitingPresent = null;
+      runner.assert(
+        stderr.includes('waiting for review of round'),
+        'attn present --wait reported that it was synchronously waiting',
+        { stderr },
+      );
+      runner.assert(json && typeof json.markdown === 'string', 'attn present --wait returned a markdown field', json);
+      runner.assert(json.markdown.includes(REVIEWER_COMMENT), 'waiting CLI feedback includes the reviewer note', json.markdown);
     });
 
     const summary = runner.finishSuccess({ sessionId, presentationId, window: presentWindow, submittedAt, baseSha, headSha });
@@ -223,6 +260,7 @@ async function main() {
     console.error(summary.error);
     process.exitCode = 1;
   } finally {
+    waitingPresent?.kill();
     if (sessionId) {
       await client.request('close_session', { sessionId }).catch(() => {});
     }

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -49,9 +49,9 @@ export const scenarioCatalog = [
   },
   {
     id: 'present-flow',
-    label: 'Present flow: chip → window → submit round → feedback CLI',
+    label: 'Present flow: waiting CLI → window → submit round → synchronous feedback',
     command: ['pnpm', 'run', 'real-app:scenario-present-flow'],
-    // Boots the app + a session + two CLI round-trips + a second native
+    // Boots the app + a session + a blocking CLI handback + a second native
     // window; give it headroom like the other heavy scenarios.
     timeoutMs: 240_000,
   },

--- a/docs/alignment/present-codex-synchronous-handback.md
+++ b/docs/alignment/present-codex-synchronous-handback.md
@@ -1,0 +1,30 @@
+# Synchronous Present handback for Codex
+
+## Why
+
+Codex currently ends its turn after opening a Present review, so feedback has
+to wake the session through a nudge. That wake-up is intentionally suppressed
+while the user is watching the session, which makes the normal Present workflow
+stall. Done means Codex keeps the Present command in the foreground and receives
+the review outcome as that command's result.
+
+## Aligned on
+
+- The built-in Present guidance tells Codex to run `attn present --wait` for
+  every round and treat its stdout as the review handback.
+- The packaged-app Present scenario exercises the same synchronous lifecycle:
+  start the waiting CLI, submit the round, then assert that the CLI returns the
+  submitted feedback.
+- Closing a presentation remains a terminal result of the waiting command.
+
+## In scope / deferred
+
+This chunk changes the embedded agent guidance and the existing real-app
+Present harness. It does not change nudge delivery, submission semantics, or
+the optional non-waiting CLI surface used by humans and other integrations.
+
+## Vision
+
+This advances the rounds loop in [the Present vision](../vision/present.md): the
+reviewer hands a round back and the presenting agent can respond in the same
+live workflow.

--- a/internal/agent/attn_skill/references/present.md
+++ b/internal/agent/attn_skill/references/present.md
@@ -400,21 +400,19 @@ don't. Iterate until clean before opening — a broken anchor or a schema
 mistake should never reach the reviewer's screen.
 
 ```bash
-attn present --manifest .present.yml
+attn present --manifest .present.yml --wait
 ```
 
 Validates again, hands the manifest to the daemon, which pins `base`/`head`
 to SHAs and opens the presentation — a banner notice plus a Present window
-chip appear in the app. Prints any warnings, the pinned SHAs, and the exact
-feedback command to run later.
+chip appear in the app. **When you are Codex, always include `--wait` and keep
+this foreground tool call open while the reviewer works.** It blocks
+synchronously until the round is submitted or the presentation is closed,
+then returns the outcome on stdout. Submitted feedback is printed as markdown,
+so use that command result as the review handback and continue the same turn
+from it.
 
-**After opening, end your turn.** Don't poll for a review, don't sit in a
-loop watching for the reviewer. The daemon wakes you when a round is
-submitted: a ticket-bound presentation gets a durable ticket comment; a bare
-session gets a doorbell message typed into the session — but only if the
-session is idle at that exact moment, otherwise it's skipped, not queued.
-So if you were mid-work when a submit could plausibly have landed, don't
-assume silence means "no review yet" — check directly:
+To inspect feedback from an older or non-waiting presentation explicitly:
 
 ```bash
 attn present feedback <presentation-id> [--round <n>] [--json]
@@ -426,7 +424,7 @@ Prints the round's feedback as markdown (defaults to the latest round).
 a new round on the same presentation:
 
 ```bash
-attn present --manifest .present.yml --presentation <presentation-id>
+attn present --manifest .present.yml --presentation <presentation-id> --wait
 ```
 
 Author round N+1 as the **delta** since the last submitted round — what


### PR DESCRIPTION
## Intent / Why

Codex currently ends its turn after opening a Present review and depends on a later nudge to retrieve feedback. That nudge can be suppressed while the user is watching the session, leaving the review loop stalled even though the agent is otherwise available.

This makes the supported Codex workflow synchronous: the Present command stays in the foreground until the reviewer submits or closes the round, then returns that outcome directly to the same turn.

## Summary

- update the embedded Present guidance so Codex always runs each round with `attn present --wait` and continues from the returned result
- reshape the packaged-app Present scenario to keep one CLI child alive from open through submission and assert that the same process receives the feedback
- explicitly target the harness profile socket so an attn-managed shell cannot leak its production socket into the isolated dev run
- document the agreed scope: synchronous Codex handback changes, with nudge delivery left unchanged

## Test plan

- [x] `go test ./cmd/attn/... -run Present -count=1`
- [x] `go test ./internal/daemon/... -run Present -count=1`
- [x] JavaScript syntax checks for the modified real-app harness files
- [x] Build, sign, install, and launch the isolated `attn-dev` app
- [x] Exercise two real Present rounds with foreground `--wait`; both returned their handback synchronously and round two was approved
- [ ] Re-run `real-app:scenario-present-flow` once native Present-window enumeration is working locally. The waiting CLI opened correctly and the daemon logged the Present window loading its diff, but native window enumeration timed out before the scenario could submit.

## Out of scope

Nudge scheduling and delivery semantics are unchanged. Non-Codex callers may continue using the explicit feedback command when they intentionally manage handback themselves.
