### PR TITLE
fix(tickets): nudge every non-approval session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Fixed
 - **Closed sessions no longer leave workspace tiles that reappear in the sidebar.** Closing now removes the pane before announcing the session's departure, stale agent panes cannot be moved into another workspace, and startup repairs any orphan panes left by older runs.
 
+### Changed
+- **Ticket artifacts use attachment language throughout.** `attn ticket attach` now names the durable operation for adding Markdown artifacts to a ticket; its multi-file, optional state/comment, retry-safe receipt, and canonical Notebook behavior are unchanged.
+
 ## [2026-07-10]
 
 ### Added
-- **Durable ticket handovers keep plans alive after the producing agent stops.** `attn ticket handover` copies one or more Markdown files into a visible `tickets/<ticket-id>/` Notebook directory, can change ticket state in the same operation, records a retry-safe handover receipt, and returns the canonical paths. Ticket reads now derive their current artifact list directly from that directory, so ordinary edits, renames, and deletions are reflected without reconciliation. The ticket panel can hand over files, open them in the Notebook editor, copy their paths, rename them, and delete them. Chiefs and delegated agents receive role-specific guidance for continuing work from the same canonical plan.
+- **Durable ticket attachments keep plans alive after the producing agent stops.** `attn ticket attach` copies one or more Markdown files into a visible `tickets/<ticket-id>/` Notebook directory, can change ticket state in the same operation, records a retry-safe attachment receipt, and returns the canonical paths. Ticket reads derive their current artifact list directly from that directory, so ordinary edits, renames, and deletions are reflected without reconciliation. The ticket panel can attach files, open them in the Notebook editor, copy their paths, rename them, and delete them. Chiefs and delegated agents receive role-specific guidance for continuing work from the same canonical plan.
 
 ### Fixed
 - **The Present window's summary card now actually collapses when you scroll the code.** Wheel-scrolling the diff — including wheel gestures over the card itself — folds the summary to a slim strip, which you can also collapse or expand by hand at any time; previously, scrolling never folded it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Closed sessions no longer leave workspace tiles that reappear in the sidebar.** Closing now removes the pane before announcing the session's departure, stale agent panes cannot be moved into another workspace, and startup repairs any orphan panes left by older runs.
+- **Ticket nudges now reach active, new, and unknown sessions too.** Any live chief or delegated agent receives the same bounded ticket nudge unless it is waiting for an approval prompt, where the doorbell could answer on its behalf. Claude's optional inbox watch can still consume an update before the countdown fires.
 
 ### Changed
 - **Ticket artifacts use attachment language throughout.** `attn ticket attach` now names the durable operation for adding Markdown artifacts to a ticket; its multi-file, optional state/comment, retry-safe receipt, and canonical Notebook behavior are unchanged.

--- a/app/scripts/real-app-harness/scenario-chief-ticket-watch.mjs
+++ b/app/scripts/real-app-harness/scenario-chief-ticket-watch.mjs
@@ -2,10 +2,10 @@
 
 /**
  * Real-agent benchmark: does a chief of staff, given the always-on ChiefGuidance
- * system prompt, ACTUALLY delegate, use its runtime's supported ticket wake path,
- * and react proactively when a delegated ticket changes — with no further human
- * prompting? Claude must arm `attn ticket inbox --watch`; Codex must rely on attn's
- * ticket nudge and leave no watcher running.
+ * system prompt, ACTUALLY delegate and react proactively when a delegated ticket
+ * changes — with no further human prompting? A runtime may optionally arm
+ * `attn ticket inbox --watch`, but every non-approval chief shares the same ticket
+ * nudge path when unread activity remains.
  *
  * This is an instruction-following benchmark, not a unit test: it stands up a REAL
  * Claude (or Codex) chief in an isolated packaged app, types a human-sounding
@@ -26,7 +26,8 @@
  *      miss never masquerades as a behavioral failure.
  *   4. Type the human prompt. Observe (no coaching):
  *        - did the chief DELEGATE? (a ticket bound to a NEW worker session appears)
- *        - did Claude ARM THE WATCH, or did Codex leave the nudge path unobstructed?
+ *        - did it optionally arm a watch, or leave unread activity for the shared
+ *          nudge path?
  *      If the chief does the task ITSELF instead of delegating, capture the evidence
  *      and STOP with verdict=did-not-delegate — that is a finding to discuss, not a
  *      thing to auto-correct.
@@ -93,8 +94,7 @@ const CHIEF_MODELS = {
 };
 
 // --no-watch variant: tell the chief to delegate but explicitly NOT arm a watch /
-// Monitor. For Claude this exercises the self-monitor backstop; for Codex it uses
-// the normal nudge path. Both should receive the same bounded PTY doorbell.
+// Monitor. This isolates the shared daemon nudge path for either runtime.
 const NO_WATCH_PROMPTS = {
   claude:
     'hey can you get someone going on a quick CHANGELOG audit? skim the last couple ' +
@@ -438,7 +438,8 @@ async function main() {
     const baselineIds = new Set((baseline.tickets || []).map((tk) => tk.id));
     note(`ticket baseline captured`, { existing: baselineIds.size });
 
-    // 5) Observe: delegation (a NEW ticket bound to a non-chief session) + watch-arming.
+    // 5) Observe: delegation (a NEW ticket bound to a non-chief session) and any
+    // optional watch arming. A watch is evidence, never a prerequisite.
     // No coaching. Snapshot the pane along the way so we can read the chief's reasoning.
     let delegation = null;
     let armedWatch = '';
@@ -506,40 +507,38 @@ async function main() {
 
     workerId = delegation.assignee;
     const ticketId = delegation.id;
-    const expectsWatch = agent === 'claude';
     note(`DELEGATED`, { workerId, ticketId, armedWatch: Boolean(armedWatch) });
     await observer.waitForSession({ id: workerId, timeoutMs: 30_000 }).catch(() => {});
 
     if (noWatch) {
-      // === DAEMON BACKSTOP PATH (--no-watch) ===
-      // The chief was told NOT to arm a Monitor. Verify attn nudges it anyway: an
-      // idle self-monitor with unread ticket activity that no `--watch` drained gets
-      // the deferred PTY doorbell (ticket_notify.go backstop, grace ~8s).
-      const chiefIdle = () => ['idle', 'waiting_input'].includes(chiefState());
+      // === SHARED DAEMON NUDGE PATH (--no-watch) ===
+      // The chief was told NOT to arm a Monitor. Any state except pending approval
+      // can receive the bounded nudge once it is not the selected pane.
+      const chiefEligible = () => chiefState() !== 'pending_approval';
 
-      // 6a) The backstop only fires for an IDLE chief, so wait for its turn to end
-      //     (delegated, reported back, no watch armed) before triggering the event.
-      const wentIdle = await pollFor(() => (chiefIdle() ? true : null), 'chief to finish its turn (no-watch)', 120_000, 1_500);
-      if (!wentIdle) {
-        await dumpPane('06-nowatch-still-working');
-        note(`chief never went idle in the no-watch window`, { finalState: chiefState() });
-        saveEvidence('nowatch-inconclusive-still-working');
-        console.log('\n=== INCONCLUSIVE: chief still working; backstop precondition (idle) never met ===');
+      // 6a) Do not send into an approval prompt, then select the worker so the
+      //     chief's countdown is allowed to run even if it remains active/green.
+      const eligible = await pollFor(() => (chiefEligible() ? true : null), 'chief to leave pending approval (no-watch)', 120_000, 1_500);
+      if (!eligible) {
+        await dumpPane('06-nowatch-pending-approval');
+        note(`chief remained pending approval in the no-watch window`, { finalState: chiefState() });
+        saveEvidence('nowatch-blocked-on-approval');
+        console.log('\n=== INCONCLUSIVE: chief remained at an approval prompt ===');
         return;
       }
       await client.request('select_session', { sessionId: workerId });
-      note(`selected worker so the idle chief's nudge countdown can run`);
+      note(`selected worker so the chief's shared nudge countdown can run`);
       const strayWatch = freshWatchProcesses(baselineWatchPids);
       if (strayWatch) {
-        // The chief armed a watch despite being told not to — the backstop would then
-        // self-suppress, so we can't observe it. Report it as the finding.
+        // The chief armed a watch despite being told not to — it may consume the
+        // event before the countdown, so report the alternate consumer outcome.
         note(`chief ARMED A WATCH despite the no-watch prompt`, { processes: strayWatch.split('\n').length });
       } else {
-        note(`chief is idle with no watch armed — backstop precondition met`);
+        note(`chief is nudge-eligible with no watch armed`);
       }
 
-      // 6b) Now fire the producer event. With the chief idle + unread + no watch, the
-      //     daemon schedules the backstop and doorbells after the grace.
+      // 6b) Now fire the producer event. With unread activity and no watch, the
+      //     daemon schedules the shared countdown and doorbells the chief.
       runAttn(['ticket', 'status', 'ready_for_review', '--comment', 'Audit done — 3 entries flagged, rewrites in the report.', '--session', workerId]);
       note(`worker reported ready_for_review`);
 
@@ -551,55 +550,50 @@ async function main() {
       let nsnap = 0;
       while (Date.now() < nudgeUntil) {
         const text = await dumpPane(`06-nudge-${String(nsnap).padStart(2, '0')}`);
-        if (!nudged && /New ticket activity/i.test(text)) { nudged = text; note(`daemon backstop nudge delivered to chief`); }
+        if (!nudged && /New ticket activity/i.test(text)) { nudged = text; note(`shared daemon nudge delivered to chief`); }
         if (nudged && /ticket inbox|ready[ _]for[ _]review|in review|review the|audit/i.test(text.split('\n').slice(-25).join('\n'))) { reactedNw = text; break; }
         nsnap += 1;
         await delay(3_000);
       }
-      evidence.backstopNudged = Boolean(nudged);
+      evidence.sharedNudgeDelivered = Boolean(nudged);
       evidence.reacted = Boolean(reactedNw);
       evidence.strayWatch = Boolean(strayWatch);
       const finalText = await dumpPane('07-chief-final-nowatch');
 
       const verdict = !nudged
-        ? (strayWatch ? 'nowatch-chief-self-armed-watch' : 'backstop-not-delivered')
-        : (reactedNw ? 'backstop-nudged-and-reacted' : 'backstop-nudged-no-reaction');
+        ? (strayWatch ? 'nowatch-chief-self-armed-watch' : 'shared-nudge-not-delivered')
+        : (reactedNw ? 'shared-nudge-and-reacted' : 'shared-nudge-no-reaction');
       saveEvidence(verdict);
       console.log(`\n=== VERDICT: ${verdict} ===`);
       console.log(`delegated: yes (worker=${workerId} ticket=${ticketId})`);
       console.log(`chief armed its own watch despite no-watch prompt: ${strayWatch ? 'YES' : 'no'}`);
-      console.log(`daemon backstop nudge delivered: ${nudged ? 'YES' : 'no'}`);
+      console.log(`shared daemon nudge delivered: ${nudged ? 'YES' : 'no'}`);
       console.log(`visible reaction to the nudge: ${reactedNw ? 'YES' : 'no'}`);
       console.log('--- chief pane (tail) ---');
       console.log(finalText.split('\n').slice(-45).join('\n'));
       return;
     }
 
-    // The controlled report must land after the chief's delegation turn ends. A
-    // report that arrives while the chief is still working can be discovered by its
-    // own board upkeep, which does not prove either runtime's wake path. Claude must
-    // also have armed its watch before the event; Codex must remain watch-free.
-    const chiefIdle = () => ['idle', 'waiting_input'].includes(chiefState());
+    // The controlled report may land while the chief is active: the shared policy
+    // permits every state except pending approval. Select the worker so a countdown
+    // is not intentionally paused by the user's current pane.
+    const chiefEligible = () => chiefState() !== 'pending_approval';
     const settled = await pollFor(() => {
       if (!armedWatch) armedWatch = freshWatchProcesses(baselineWatchPids);
-      if (!chiefIdle()) return null;
-      if (expectsWatch && !armedWatch) return null;
-      return true;
-    }, 'chief to finish delegation upkeep and arm its runtime wake path', 120_000, 1_500);
+      return chiefEligible() ? true : null;
+    }, 'chief to leave pending approval', 120_000, 1_500);
     if (!settled) {
-      await dumpPane('04-chief-not-settled');
+      await dumpPane('04-chief-pending-approval');
       evidence.armedWatch = armedWatch;
       evidence.chiefState = chiefState();
-      saveEvidence('inconclusive-chief-not-settled');
-      console.log('\n=== INCONCLUSIVE: chief did not settle into its runtime wake path ===');
+      saveEvidence('inconclusive-chief-pending-approval');
+      console.log('\n=== INCONCLUSIVE: chief remained at an approval prompt ===');
       console.log(`chief state: ${chiefState()}`);
       console.log(`armed watch: ${armedWatch ? 'YES' : 'no'}`);
       return;
     }
-    if (!expectsWatch) {
-      await client.request('select_session', { sessionId: workerId });
-      note(`selected worker so the idle Codex chief's nudge countdown can run`);
-    }
+    await client.request('select_session', { sessionId: workerId });
+    note(`selected worker so the chief's shared nudge countdown can run`);
 
     // 6) Drive the worker to report ready_for_review — the real producer path. The
     // chief cannot tell this from the sub-agent finishing on its own.
@@ -607,13 +601,10 @@ async function main() {
     runAttn(['ticket', 'status', 'ready_for_review', '--comment', 'Audit done — 3 entries flagged, rewrites in the report.', '--session', workerId]);
     note(`worker reported ready_for_review`);
 
-    // 7) Observe whether the chief surfaces the update ON ITS OWN. Claude: via its
-    // armed --watch Monitor or the daemon backstop. Codex (not a self-monitor): via
-    // the daemon's direct nudge. Evidence = the chief runs `attn ticket inbox` /
-    // mentions the review without us prompting it again.
-    // Claude arms its watch Monitor after delegating, so its `--watch` process only
-    // appears during this post-delegation window. Codex must not arm one: its unread
-    // event must remain available for the daemon's nudge path.
+    // 7) Observe whether the chief surfaces the update ON ITS OWN. An optional watch
+    // may consume it before the shared countdown rings; otherwise the fixed nudge
+    // must arrive. Evidence = the chief runs `attn ticket inbox` / mentions the
+    // review without us prompting it again.
     const reactUntil = Date.now() + 240_000;
     let reacted = null;
     let nudged = null;
@@ -623,20 +614,20 @@ async function main() {
       const recent = text.split('\n').slice(-35).join('\n');
       if (!nudged && /New ticket activity/i.test(text)) {
         nudged = text;
-        note(`daemon ticket nudge delivered to Codex chief`);
+        note(`shared daemon ticket nudge delivered to chief`);
       }
       const handledUpdate = /ticket inbox|ready[ _]for[ _]review|in review|review the report/i.test(recent);
-      if (!reacted && handledUpdate && (expectsWatch || nudged)) {
+      if (!reacted && handledUpdate && (armedWatch || nudged)) {
         reacted = text;
       }
       if (!armedWatch) {
         const w = freshWatchProcesses(baselineWatchPids);
         if (w) {
           armedWatch = w;
-          note(expectsWatch ? `watch armed (post-delegation)` : `UNEXPECTED watch armed by Codex`, { processes: w.split('\n').length });
+          note(`optional watch armed (post-delegation)`, { processes: w.split('\n').length });
         }
       }
-      if (reacted && (!expectsWatch || armedWatch)) break;
+      if (reacted) break;
       rsnap += 1;
       await delay(3_000);
     }
@@ -645,11 +636,9 @@ async function main() {
     evidence.reacted = Boolean(reacted);
     const finalText = await dumpPane('05-chief-final');
 
-    const verdict = !expectsWatch && armedWatch
-      ? 'codex-armed-watch'
-      : (!expectsWatch && !nudged
-          ? 'codex-not-nudged'
-          : (reacted ? 'delegated-and-reacted' : 'delegated-no-visible-reaction'));
+    const verdict = reacted
+      ? 'delegated-and-reacted'
+      : (armedWatch ? 'watch-no-visible-reaction' : 'shared-nudge-not-delivered');
     saveEvidence(verdict);
     console.log(`\n=== VERDICT: ${evidence.verdict} ===`);
     console.log(`delegated: yes (worker=${workerId} ticket=${ticketId})`);

--- a/app/scripts/real-app-harness/scenario-nudge-trigger.mjs
+++ b/app/scripts/real-app-harness/scenario-nudge-trigger.mjs
@@ -113,8 +113,9 @@ async function readPaneText(client, sessionId) {
 
 // A freshly-booted agent sits at its prompt but is not yet `idle`/`waiting_input`
 // — that state is only reached after a completed turn (boot -> working -> idle).
-// The nudge only arms for an idle session, so drive one trivial turn first. The
-// text and the Enter are sent as SEPARATE writes (a fast burst ending in CR is
+// This scenario uses an idle target to isolate the paused manual-trigger path; the
+// shared nudge policy also permits active, launching, and unknown targets. The text
+// and the Enter are sent as SEPARATE writes (a fast burst ending in CR is
 // treated as a bracketed paste and never submits).
 async function driveAgentToIdle(client, observer, sessionId, note) {
   const pane = await waitForFirstWorkspacePane(client, sessionId, `pane for ${sessionId}`, 20_000);

--- a/app/scripts/real-app-harness/scenario-ticket-delegation-lifecycle.mjs
+++ b/app/scripts/real-app-harness/scenario-ticket-delegation-lifecycle.mjs
@@ -6,7 +6,7 @@
  *
  * Bootstraps a chief-of-staff, delegates a real codex worker (which mints a bound
  * ticket), drives the WORKER side via the agent CLI verbs (`attn ticket
- * status|handover`), then opens and drives the CHIEF side entirely through the
+ * status|attach`), then opens and drives the CHIEF side entirely through the
  * packaged app's TicketDetailPanel via the new `ticket_*` automation actions —
  * which click the real controls, so the panel's own gating runs. Asserts the
  * rendered panel reflects every step (status moves, comment, edited description,
@@ -135,8 +135,8 @@ async function main() {
   });
   const reportPath = path.join(sessionDir, 'report.md');
   const rolloutPath = path.join(sessionDir, 'rollout.md');
-  fs.writeFileSync(reportPath, 'ticket handover report\nsecond line\n', 'utf8');
-  fs.writeFileSync(rolloutPath, 'ticket handover rollout\n', 'utf8');
+  fs.writeFileSync(reportPath, 'ticket attach report\nsecond line\n', 'utf8');
+  fs.writeFileSync(rolloutPath, 'ticket attach rollout\n', 'utf8');
 
   const client = new UiAutomationClient({ appPath: options.appPath });
   const observer = new DaemonObserver({ wsUrl: options.wsUrl });
@@ -186,16 +186,16 @@ async function main() {
 
     // 3) Worker side via the real agent CLI verbs.
     runAttn(['ticket', 'status', 'in_progress', '--session', workerId]);
-    const handoverArgs = ['ticket', 'handover', '--file', reportPath, '--file', rolloutPath, '--state', 'ready_for_review', '--comment', 'Please review the handed-over plan.', '--session', workerId, '--json'];
-    const handover = runAttn(handoverArgs);
-    assert(handover.json?.artifacts?.length === 2, `multi-file handover returned two artifacts (got ${JSON.stringify(handover.json)})`);
-    const retry = runAttn(handoverArgs);
-    assert(retry.json?.deduplicated === true && retry.json?.event_seq === handover.json?.event_seq, `retry returned the existing receipt (got ${JSON.stringify(retry.json)})`);
+    const attachArgs = ['ticket', 'attach', '--file', reportPath, '--file', rolloutPath, '--state', 'ready_for_review', '--comment', 'Please review the handed-over plan.', '--session', workerId, '--json'];
+    const attach = runAttn(attachArgs);
+    assert(attach.json?.artifacts?.length === 2, `multi-file attach returned two artifacts (got ${JSON.stringify(attach.json)})`);
+    const retry = runAttn(attachArgs);
+    assert(retry.json?.deduplicated === true && retry.json?.event_seq === attach.json?.event_seq, `retry returned the existing receipt (got ${JSON.stringify(retry.json)})`);
 
-    const canonicalReport = handover.json.artifacts.find((artifact) => artifact.filename === 'report.md')?.path;
-    const canonicalRollout = handover.json.artifacts.find((artifact) => artifact.filename === 'rollout.md')?.path;
-    assert(canonicalReport && canonicalRollout, 'handover returned canonical report and rollout paths');
-    fs.appendFileSync(canonicalReport, 'updated after handover\n', 'utf8');
+    const canonicalReport = attach.json.artifacts.find((artifact) => artifact.filename === 'report.md')?.path;
+    const canonicalRollout = attach.json.artifacts.find((artifact) => artifact.filename === 'rollout.md')?.path;
+    assert(canonicalReport && canonicalRollout, 'attach returned canonical report and rollout paths');
+    fs.appendFileSync(canonicalReport, 'updated after attach\n', 'utf8');
     const canonicalImplementation = path.join(path.dirname(canonicalRollout), 'implementation.md');
     fs.renameSync(canonicalRollout, canonicalImplementation);
     runAttn(['ticket', 'comment', ticketId, '-m', 'Updated report.md and renamed rollout.md to implementation.md.', '--session', workerId]);
@@ -221,7 +221,7 @@ async function main() {
     );
     assert(
       afterWorker.activity.some((entry) => entry.comment.includes('Please review the handed-over plan')),
-      'handover decision context is in the activity history',
+      'attach decision context is in the activity history',
     );
 
     // 5) Chief side — drive the real panel controls. Each mutation drives the

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -597,7 +597,7 @@ function App() {
     sendTicketChangeStatus,
     sendTicketAddComment,
     sendTicketEditDescription,
-    sendTicketHandover,
+    sendTicketAttach,
     sendTicketResume,
     getPresentations,
     connectionError,
@@ -779,7 +779,7 @@ function App() {
         sendTicketChangeStatus={sendTicketChangeStatus}
         sendTicketAddComment={sendTicketAddComment}
         sendTicketEditDescription={sendTicketEditDescription}
-        sendTicketHandover={sendTicketHandover}
+        sendTicketAttach={sendTicketAttach}
         sendTicketResume={sendTicketResume}
         clearGitStatus={clearGitStatus}
         registerSessionExitHandler={registerSessionExitHandler}
@@ -889,7 +889,7 @@ interface AppContentProps {
   sendTicketChangeStatus: ReturnType<typeof useDaemonSocket>['sendTicketChangeStatus'];
   sendTicketAddComment: ReturnType<typeof useDaemonSocket>['sendTicketAddComment'];
   sendTicketEditDescription: ReturnType<typeof useDaemonSocket>['sendTicketEditDescription'];
-  sendTicketHandover: ReturnType<typeof useDaemonSocket>['sendTicketHandover'];
+  sendTicketAttach: ReturnType<typeof useDaemonSocket>['sendTicketAttach'];
   sendTicketResume: ReturnType<typeof useDaemonSocket>['sendTicketResume'];
   clearGitStatus: () => void;
   registerSessionExitHandler: (handler: ((info: SessionExitInfo) => void) | null) => void;
@@ -993,7 +993,7 @@ sendFetchPRDetails,
   sendTicketChangeStatus,
   sendTicketAddComment,
   sendTicketEditDescription,
-  sendTicketHandover,
+  sendTicketAttach,
   sendTicketResume,
   clearGitStatus,
   registerSessionExitHandler,
@@ -3061,7 +3061,7 @@ sendFetchPRDetails,
     onChangeStatus: sendTicketChangeStatus,
     onAddComment: sendTicketAddComment,
     onEditDescription: sendTicketEditDescription,
-    onHandover: sendTicketHandover,
+    onAttach: sendTicketAttach,
     onRenameArtifact: sendFsRename,
     onDeleteArtifact: sendFsDelete,
     onOpenArtifact: (path: string) => {
@@ -3069,7 +3069,7 @@ sendFetchPRDetails,
       setNotebookOpen(true);
     },
     onResume: handleResumeTicket,
-  }), [fetchTicket, sendTicketChangeStatus, sendTicketAddComment, sendTicketEditDescription, sendTicketHandover, sendFsRename, sendFsDelete, handleResumeTicket]);
+  }), [fetchTicket, sendTicketChangeStatus, sendTicketAddComment, sendTicketEditDescription, sendTicketAttach, sendFsRename, sendFsDelete, handleResumeTicket]);
 
   const isZedEditorConfigured = useMemo(() => {
     const editor = (settings.editor_executable || '').trim().toLowerCase();
@@ -3589,7 +3589,7 @@ sendFetchPRDetails,
                   onChangeStatus={sendTicketChangeStatus}
                   onAddComment={sendTicketAddComment}
                   onEditDescription={sendTicketEditDescription}
-                  onHandover={sendTicketHandover}
+                  onAttach={sendTicketAttach}
                   onRenameArtifact={sendFsRename}
                   onDeleteArtifact={sendFsDelete}
                   onOpenArtifact={(path) => {

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -127,7 +127,7 @@ interface SessionTerminalWorkspaceProps {
     onChangeStatus: (ticketId: string, status: Ticket['status'], comment?: string) => Promise<void>;
     onAddComment: (ticketId: string, comment: string) => Promise<void>;
     onEditDescription: (ticketId: string, description: string) => Promise<void>;
-    onHandover?: (ticketId: string, paths: string[], state?: string, comment?: string) => Promise<unknown>;
+    onAttach?: (ticketId: string, paths: string[], state?: string, comment?: string) => Promise<unknown>;
     onRenameArtifact?: (path: string, newPath: string) => Promise<unknown>;
     onDeleteArtifact?: (path: string) => Promise<unknown>;
     onOpenArtifact?: (path: string) => void;
@@ -913,7 +913,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
                     onChangeStatus={ticketActions.onChangeStatus}
                     onAddComment={ticketActions.onAddComment}
                     onEditDescription={ticketActions.onEditDescription}
-                    onHandover={ticketActions.onHandover}
+                    onAttach={ticketActions.onAttach}
                     onRenameArtifact={ticketActions.onRenameArtifact}
                     onDeleteArtifact={ticketActions.onDeleteArtifact}
                     onOpenArtifact={ticketActions.onOpenArtifact}

--- a/app/src/components/TicketDetailPanel.css
+++ b/app/src/components/TicketDetailPanel.css
@@ -285,7 +285,7 @@
   padding: 4px 6px;
 }
 
-.ticket-handover-form {
+.ticket-attach-form {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -294,7 +294,7 @@
   border-radius: 6px;
 }
 
-.ticket-handover-files {
+.ticket-attach-files {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;

--- a/app/src/components/TicketDetailPanel.test.tsx
+++ b/app/src/components/TicketDetailPanel.test.tsx
@@ -420,24 +420,24 @@ describe('TicketDetailPanel', () => {
   it('hands over selected Markdown files with optional state and comment', async () => {
     vi.mocked(open).mockResolvedValue(['/tmp/design.md', '/tmp/rollout.md']);
     const fetchTicket = vi.fn().mockResolvedValue(makeTicket());
-    const onHandover = vi.fn().mockResolvedValue(undefined);
+    const onAttach = vi.fn().mockResolvedValue(undefined);
     render(
       <TicketDetailPanel
         isOpen
         ticketId="store-migration"
         ticketRow={makeTicket()}
         fetchTicket={fetchTicket}
-        onHandover={onHandover}
+        onAttach={onAttach}
         onClose={() => {}}
       />,
     );
-    await waitFor(() => screen.getByTestId('ticket-choose-handover'));
-    fireEvent.click(screen.getByTestId('ticket-choose-handover'));
-    await waitFor(() => screen.getByTestId('ticket-handover-form'));
+    await waitFor(() => screen.getByTestId('ticket-choose-attach'));
+    fireEvent.click(screen.getByTestId('ticket-choose-attach'));
+    await waitFor(() => screen.getByTestId('ticket-attach-form'));
     fireEvent.change(screen.getByLabelText('Resulting ticket state'), { target: { value: 'ready_for_review' } });
     fireEvent.change(screen.getByPlaceholderText('Decision context (optional)'), { target: { value: 'Chosen approach' } });
-    fireEvent.click(screen.getByTestId('ticket-submit-handover'));
-    await waitFor(() => expect(onHandover).toHaveBeenCalledWith(
+    fireEvent.click(screen.getByTestId('ticket-submit-attach'));
+    await waitFor(() => expect(onAttach).toHaveBeenCalledWith(
       'store-migration',
       ['/tmp/design.md', '/tmp/rollout.md'],
       'ready_for_review',

--- a/app/src/components/TicketDetailPanel.tsx
+++ b/app/src/components/TicketDetailPanel.tsx
@@ -20,7 +20,7 @@ interface TicketDetailPanelProps {
   onChangeStatus?: (ticketId: string, status: Ticket['status'], comment?: string) => Promise<void>;
   onAddComment?: (ticketId: string, comment: string) => Promise<void>;
   onEditDescription?: (ticketId: string, description: string) => Promise<void>;
-  onHandover?: (ticketId: string, paths: string[], state?: string, comment?: string) => Promise<unknown>;
+  onAttach?: (ticketId: string, paths: string[], state?: string, comment?: string) => Promise<unknown>;
   onRenameArtifact?: (path: string, newPath: string) => Promise<unknown>;
   onDeleteArtifact?: (path: string) => Promise<unknown>;
   onOpenArtifact?: (path: string) => void;
@@ -93,7 +93,7 @@ export function TicketDetailPanel({
   onChangeStatus,
   onAddComment,
   onEditDescription,
-  onHandover,
+  onAttach,
   onRenameArtifact,
   onDeleteArtifact,
   onOpenArtifact,
@@ -114,9 +114,9 @@ export function TicketDetailPanel({
   const [commentDraft, setCommentDraft] = useState('');
   const [editingDescription, setEditingDescription] = useState(false);
   const [descriptionDraft, setDescriptionDraft] = useState('');
-  const [handoverFiles, setHandoverFiles] = useState<string[]>([]);
-  const [handoverState, setHandoverState] = useState('');
-  const [handoverComment, setHandoverComment] = useState('');
+  const [attachFiles, setAttachFiles] = useState<string[]>([]);
+  const [attachState, setAttachState] = useState('');
+  const [attachComment, setAttachComment] = useState('');
   const [renamingArtifact, setRenamingArtifact] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState('');
 
@@ -157,9 +157,9 @@ export function TicketDetailPanel({
     setCommentDraft('');
     setEditingDescription(false);
     setDescriptionDraft('');
-    setHandoverFiles([]);
-    setHandoverState('');
-    setHandoverComment('');
+    setAttachFiles([]);
+    setAttachState('');
+    setAttachComment('');
     setRenamingArtifact(null);
     setRenameDraft('');
   }, [ticketId]);
@@ -403,17 +403,17 @@ export function TicketDetailPanel({
           <section className="ticket-detail-section">
             <div className="ticket-section-head">
               <h3 className="ticket-section-label">Artifacts</h3>
-              {onHandover && (
+              {onAttach && (
                 <button
                   type="button"
                   className="ticket-section-action"
-                  data-testid="ticket-choose-handover"
+                  data-testid="ticket-choose-attach"
                   disabled={busyAction !== null}
                   onClick={() => {
                     void open({ multiple: true, filters: [{ name: 'Markdown', extensions: ['md'] }] })
                       .then((selected) => {
                         const paths = Array.isArray(selected) ? selected : selected ? [selected] : [];
-                        if (paths.length > 0) setHandoverFiles(paths);
+                        if (paths.length > 0) setAttachFiles(paths);
                       })
                       .catch((err) => setActionError(err instanceof Error ? err.message : 'Could not choose files'));
                   }}
@@ -422,16 +422,16 @@ export function TicketDetailPanel({
                 </button>
               )}
             </div>
-            {handoverFiles.length > 0 && onHandover && (
-              <div className="ticket-handover-form" data-testid="ticket-handover-form">
-                <div className="ticket-handover-files">
-                  {handoverFiles.map((path) => <span key={path}>{path.split(/[\\/]/).pop()}</span>)}
+            {attachFiles.length > 0 && onAttach && (
+              <div className="ticket-attach-form" data-testid="ticket-attach-form">
+                <div className="ticket-attach-files">
+                  {attachFiles.map((path) => <span key={path}>{path.split(/[\\/]/).pop()}</span>)}
                 </div>
                 <select
                   aria-label="Resulting ticket state"
                   className="ticket-status-select"
-                  value={handoverState}
-                  onChange={(event) => setHandoverState(event.target.value)}
+                  value={attachState}
+                  onChange={(event) => setAttachState(event.target.value)}
                 >
                   <option value="">Keep current state</option>
                   <option value="in_progress">Working</option>
@@ -443,29 +443,29 @@ export function TicketDetailPanel({
                 <textarea
                   className="ticket-comment-input"
                   placeholder="Decision context (optional)"
-                  value={handoverComment}
-                  onChange={(event) => setHandoverComment(event.target.value)}
+                  value={attachComment}
+                  onChange={(event) => setAttachComment(event.target.value)}
                   rows={2}
                 />
                 <div className="ticket-edit-buttons">
                   <button
                     type="button"
                     className="ticket-edit-save"
-                    data-testid="ticket-submit-handover"
+                    data-testid="ticket-submit-attach"
                     disabled={busyAction !== null}
                     onClick={() => {
-                      runAction('handover', async () => {
-                        await onHandover(fullTicket.id, handoverFiles, handoverState || undefined, handoverComment.trim() || undefined);
-                        setHandoverFiles([]);
-                        setHandoverState('');
-                        setHandoverComment('');
+                      runAction('attach', async () => {
+                        await onAttach(fullTicket.id, attachFiles, attachState || undefined, attachComment.trim() || undefined);
+                        setAttachFiles([]);
+                        setAttachState('');
+                        setAttachComment('');
                         await refreshTicket();
                       }).catch(() => {});
                     }}
                   >
-                    {busyAction === 'handover' ? 'Handing over…' : 'Hand over'}
+                    {busyAction === 'attach' ? 'Attaching…' : 'Attach'}
                   </button>
-                  <button type="button" className="ticket-edit-cancel" onClick={() => setHandoverFiles([])}>Cancel</button>
+                  <button type="button" className="ticket-edit-cancel" onClick={() => setAttachFiles([])}>Cancel</button>
                 </div>
               </div>
             )}

--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -2911,14 +2911,14 @@ describe('useDaemonSocket ticket request/result', () => {
     unmount();
   });
 
-  it('sends a multi-file ticket handover and resolves its receipt', async () => {
+  it('sends a multi-file ticket attach and resolves its receipt', async () => {
     const { result, unmount } = renderTicketHook();
     const ws = await waitForOpenSocket();
-    const promise = result.current.sendTicketHandover('tk-1', ['/tmp/design.md', '/tmp/rollout.md'], 'ready_for_review', 'ready');
+    const promise = result.current.sendTicketAttach('tk-1', ['/tmp/design.md', '/tmp/rollout.md'], 'ready_for_review', 'ready');
     await Promise.resolve();
     const sent = lastSent(ws);
     expect(sent).toMatchObject({
-      cmd: 'ticket_handover',
+      cmd: 'ticket_attach',
       ticket_id: 'tk-1',
       state: 'ready_for_review',
       comment: 'ready',
@@ -2928,7 +2928,7 @@ describe('useDaemonSocket ticket request/result', () => {
       ],
     });
     const receipt = { ticket_id: 'tk-1', artifacts: [], fingerprint: 'abc', event_seq: 7, state: 'in_review', deduplicated: false };
-    ws.emit({ event: 'ticket_handover_result', request_id: sent.request_id, success: true, result: receipt });
+    ws.emit({ event: 'ticket_attach_result', request_id: sent.request_id, success: true, result: receipt });
     await expect(promise).resolves.toEqual(receipt);
     unmount();
   });

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -169,7 +169,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '157';
+export const PROTOCOL_VERSION = '158';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -1685,17 +1685,17 @@ export function useDaemonSocket({
             break;
           }
 
-          case 'ticket_handover_result': {
+          case 'ticket_attach_result': {
             const requestId = data.request_id;
             if (typeof requestId !== 'string') break;
-            const key = `ticket_handover:${requestId}`;
+            const key = `ticket_attach:${requestId}`;
             const pending = pendingActionsRef.current.get(key);
             if (!pending) break;
             pendingActionsRef.current.delete(key);
             if (data.success && data.result) {
               pending.resolve(data.result);
             } else {
-              pending.reject(new Error(data.error || 'Ticket handover failed'));
+              pending.reject(new Error(data.error || 'Ticket attach failed'));
             }
             break;
           }
@@ -4041,7 +4041,7 @@ export function useDaemonSocket({
     [sendTicketAction],
   );
 
-  const sendTicketHandover = useCallback((
+  const sendTicketAttach = useCallback((
     ticketId: string,
     paths: string[],
     state?: string,
@@ -4052,11 +4052,11 @@ export function useDaemonSocket({
       reject(new Error('WebSocket not connected'));
       return;
     }
-    const requestId = nextRequestID('ticket_handover');
-    const key = `ticket_handover:${requestId}`;
+    const requestId = nextRequestID('ticket_attach');
+    const key = `ticket_attach:${requestId}`;
     pendingActionsRef.current.set(key, { resolve, reject });
     ws.send(JSON.stringify({
-      cmd: 'ticket_handover',
+      cmd: 'ticket_attach',
       request_id: requestId,
       source_session_id: 'you',
       ticket_id: ticketId,
@@ -4070,7 +4070,7 @@ export function useDaemonSocket({
     setTimeout(() => {
       if (pendingActionsRef.current.has(key)) {
         pendingActionsRef.current.delete(key);
-        reject(new Error('Ticket handover timed out'));
+        reject(new Error('Ticket attach timed out'));
       }
     }, 30000);
   }), [nextRequestID]);
@@ -4901,7 +4901,7 @@ export function useDaemonSocket({
     sendTicketChangeStatus,
     sendTicketAddComment,
     sendTicketEditDescription,
-    sendTicketHandover,
+    sendTicketAttach,
     sendTicketResume,
     sendTaskList,
     sendTaskRetry,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketHandoverFile, TicketHandoverMessage, TicketHandoverResult, TicketHandoverResultMessage, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -238,10 +238,10 @@
 //   const ticketEvent = Convert.toTicketEvent(json);
 //   const ticketEventBundle = Convert.toTicketEventBundle(json);
 //   const ticketEventKind = Convert.toTicketEventKind(json);
-//   const ticketHandoverFile = Convert.toTicketHandoverFile(json);
-//   const ticketHandoverMessage = Convert.toTicketHandoverMessage(json);
-//   const ticketHandoverResult = Convert.toTicketHandoverResult(json);
-//   const ticketHandoverResultMessage = Convert.toTicketHandoverResultMessage(json);
+//   const ticketAttachFile = Convert.toTicketAttachFile(json);
+//   const ticketAttachMessage = Convert.toTicketAttachMessage(json);
+//   const ticketAttachResult = Convert.toTicketAttachResult(json);
+//   const ticketAttachResultMessage = Convert.toTicketAttachResultMessage(json);
 //   const ticketInboxMessage = Convert.toTicketInboxMessage(json);
 //   const ticketInboxResult = Convert.toTicketInboxResult(json);
 //   const ticketListMessage = Convert.toTicketListMessage(json);
@@ -1720,7 +1720,7 @@ export enum TicketStatus {
 
 export enum TicketActivityKind {
     Comment = "comment",
-    Handover = "handover",
+    Attach = "attach",
     StatusChange = "status_change",
 }
 
@@ -2943,7 +2943,7 @@ export interface Response {
     sessions?:                             SessionElement[];
     ticket_comment_result?:                TicketCommentResultObject;
     ticket_create_result?:                 TicketCreateResultObject;
-    ticket_handover_result?:               TicketHandoverResultObject;
+    ticket_attach_result?:               TicketAttachResultObject;
     ticket_inbox_result?:                  TicketInboxResultObject;
     ticket_list_result?:                   TicketListResultObject;
     ticket_show_result?:                   TicketShowResultObject;
@@ -3003,7 +3003,7 @@ export interface TicketCreateResultObject {
     [property: string]: any;
 }
 
-export interface TicketHandoverResultObject {
+export interface TicketAttachResultObject {
     artifacts:    ArtifactElement[];
     deduplicated: boolean;
     event_seq:    number;
@@ -3042,7 +3042,7 @@ export enum TicketEventKind {
     Commented = "commented",
     Created = "created",
     DescriptionEdited = "description_edited",
-    HandoverSubmitted = "handover_submitted",
+    AttachSubmitted = "attach_submitted",
     StatusChanged = "status_changed",
 }
 
@@ -3644,14 +3644,14 @@ export interface TicketEventBundle {
     [property: string]: any;
 }
 
-export interface TicketHandoverFile {
+export interface TicketAttachFile {
     filename:    string;
     source_path: string;
     [property: string]: any;
 }
 
-export interface TicketHandoverMessage {
-    cmd:               TicketHandoverMessageCmd;
+export interface TicketAttachMessage {
+    cmd:               TicketAttachMessageCmd;
     comment?:          string;
     files:             FileObject[];
     request_id?:       string;
@@ -3661,8 +3661,8 @@ export interface TicketHandoverMessage {
     [property: string]: any;
 }
 
-export enum TicketHandoverMessageCmd {
-    TicketHandover = "ticket_handover",
+export enum TicketAttachMessageCmd {
+    TicketAttach = "ticket_attach",
 }
 
 export interface FileObject {
@@ -3671,7 +3671,7 @@ export interface FileObject {
     [property: string]: any;
 }
 
-export interface TicketHandoverResult {
+export interface TicketAttachResult {
     artifacts:    ArtifactElement[];
     deduplicated: boolean;
     event_seq:    number;
@@ -3681,17 +3681,17 @@ export interface TicketHandoverResult {
     [property: string]: any;
 }
 
-export interface TicketHandoverResultMessage {
+export interface TicketAttachResultMessage {
     error?:     string;
-    event:      TicketHandoverResultMessageEvent;
+    event:      TicketAttachResultMessageEvent;
     request_id: string;
-    result?:    TicketHandoverResultObject;
+    result?:    TicketAttachResultObject;
     success:    boolean;
     [property: string]: any;
 }
 
-export enum TicketHandoverResultMessageEvent {
-    TicketHandoverResult = "ticket_handover_result",
+export enum TicketAttachResultMessageEvent {
+    TicketAttachResult = "ticket_attach_result",
 }
 
 export interface TicketInboxMessage {
@@ -6528,36 +6528,36 @@ export class Convert {
         return JSON.stringify(uncast(value, r("TicketEventKind")), null, 2);
     }
 
-    public static toTicketHandoverFile(json: string): TicketHandoverFile {
-        return cast(JSON.parse(json), r("TicketHandoverFile"));
+    public static toTicketAttachFile(json: string): TicketAttachFile {
+        return cast(JSON.parse(json), r("TicketAttachFile"));
     }
 
-    public static ticketHandoverFileToJson(value: TicketHandoverFile): string {
-        return JSON.stringify(uncast(value, r("TicketHandoverFile")), null, 2);
+    public static ticketAttachFileToJson(value: TicketAttachFile): string {
+        return JSON.stringify(uncast(value, r("TicketAttachFile")), null, 2);
     }
 
-    public static toTicketHandoverMessage(json: string): TicketHandoverMessage {
-        return cast(JSON.parse(json), r("TicketHandoverMessage"));
+    public static toTicketAttachMessage(json: string): TicketAttachMessage {
+        return cast(JSON.parse(json), r("TicketAttachMessage"));
     }
 
-    public static ticketHandoverMessageToJson(value: TicketHandoverMessage): string {
-        return JSON.stringify(uncast(value, r("TicketHandoverMessage")), null, 2);
+    public static ticketAttachMessageToJson(value: TicketAttachMessage): string {
+        return JSON.stringify(uncast(value, r("TicketAttachMessage")), null, 2);
     }
 
-    public static toTicketHandoverResult(json: string): TicketHandoverResult {
-        return cast(JSON.parse(json), r("TicketHandoverResult"));
+    public static toTicketAttachResult(json: string): TicketAttachResult {
+        return cast(JSON.parse(json), r("TicketAttachResult"));
     }
 
-    public static ticketHandoverResultToJson(value: TicketHandoverResult): string {
-        return JSON.stringify(uncast(value, r("TicketHandoverResult")), null, 2);
+    public static ticketAttachResultToJson(value: TicketAttachResult): string {
+        return JSON.stringify(uncast(value, r("TicketAttachResult")), null, 2);
     }
 
-    public static toTicketHandoverResultMessage(json: string): TicketHandoverResultMessage {
-        return cast(JSON.parse(json), r("TicketHandoverResultMessage"));
+    public static toTicketAttachResultMessage(json: string): TicketAttachResultMessage {
+        return cast(JSON.parse(json), r("TicketAttachResultMessage"));
     }
 
-    public static ticketHandoverResultMessageToJson(value: TicketHandoverResultMessage): string {
-        return JSON.stringify(uncast(value, r("TicketHandoverResultMessage")), null, 2);
+    public static ticketAttachResultMessageToJson(value: TicketAttachResultMessage): string {
+        return JSON.stringify(uncast(value, r("TicketAttachResultMessage")), null, 2);
     }
 
     public static toTicketInboxMessage(json: string): TicketInboxMessage {
@@ -8893,7 +8893,7 @@ const typeMap: any = {
         { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
         { json: "ticket_comment_result", js: "ticket_comment_result", typ: u(undefined, r("TicketCommentResultObject")) },
         { json: "ticket_create_result", js: "ticket_create_result", typ: u(undefined, r("TicketCreateResultObject")) },
-        { json: "ticket_handover_result", js: "ticket_handover_result", typ: u(undefined, r("TicketHandoverResultObject")) },
+        { json: "ticket_attach_result", js: "ticket_attach_result", typ: u(undefined, r("TicketAttachResultObject")) },
         { json: "ticket_inbox_result", js: "ticket_inbox_result", typ: u(undefined, r("TicketInboxResultObject")) },
         { json: "ticket_list_result", js: "ticket_list_result", typ: u(undefined, r("TicketListResultObject")) },
         { json: "ticket_show_result", js: "ticket_show_result", typ: u(undefined, r("TicketShowResultObject")) },
@@ -8939,7 +8939,7 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: "" },
         { json: "title", js: "title", typ: "" },
     ], "any"),
-    "TicketHandoverResultObject": o([
+    "TicketAttachResultObject": o([
         { json: "artifacts", js: "artifacts", typ: a(r("ArtifactElement")) },
         { json: "deduplicated", js: "deduplicated", typ: true },
         { json: "event_seq", js: "event_seq", typ: 0 },
@@ -9312,12 +9312,12 @@ const typeMap: any = {
         { json: "events", js: "events", typ: a(r("EventElement")) },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
-    "TicketHandoverFile": o([
+    "TicketAttachFile": o([
         { json: "filename", js: "filename", typ: "" },
         { json: "source_path", js: "source_path", typ: "" },
     ], "any"),
-    "TicketHandoverMessage": o([
-        { json: "cmd", js: "cmd", typ: r("TicketHandoverMessageCmd") },
+    "TicketAttachMessage": o([
+        { json: "cmd", js: "cmd", typ: r("TicketAttachMessageCmd") },
         { json: "comment", js: "comment", typ: u(undefined, "") },
         { json: "files", js: "files", typ: a(r("FileObject")) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
@@ -9329,7 +9329,7 @@ const typeMap: any = {
         { json: "filename", js: "filename", typ: "" },
         { json: "source_path", js: "source_path", typ: "" },
     ], "any"),
-    "TicketHandoverResult": o([
+    "TicketAttachResult": o([
         { json: "artifacts", js: "artifacts", typ: a(r("ArtifactElement")) },
         { json: "deduplicated", js: "deduplicated", typ: true },
         { json: "event_seq", js: "event_seq", typ: 0 },
@@ -9337,11 +9337,11 @@ const typeMap: any = {
         { json: "state", js: "state", typ: r("TicketStatus") },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
-    "TicketHandoverResultMessage": o([
+    "TicketAttachResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("TicketHandoverResultMessageEvent") },
+        { json: "event", js: "event", typ: r("TicketAttachResultMessageEvent") },
         { json: "request_id", js: "request_id", typ: "" },
-        { json: "result", js: "result", typ: u(undefined, r("TicketHandoverResultObject")) },
+        { json: "result", js: "result", typ: u(undefined, r("TicketAttachResultObject")) },
         { json: "success", js: "success", typ: true },
     ], "any"),
     "TicketInboxMessage": o([
@@ -10145,7 +10145,7 @@ const typeMap: any = {
     ],
     "TicketActivityKind": [
         "comment",
-        "handover",
+        "attach",
         "status_change",
     ],
     "WorkspaceLayoutPaneKind": [
@@ -10377,7 +10377,7 @@ const typeMap: any = {
         "commented",
         "created",
         "description_edited",
-        "handover_submitted",
+        "attach_submitted",
         "status_changed",
     ],
     "WorkspaceContextMaintenanceAction": [
@@ -10490,11 +10490,11 @@ const typeMap: any = {
     "TicketEditDescriptionMessageCmd": [
         "ticket_edit_description",
     ],
-    "TicketHandoverMessageCmd": [
-        "ticket_handover",
+    "TicketAttachMessageCmd": [
+        "ticket_attach",
     ],
-    "TicketHandoverResultMessageEvent": [
-        "ticket_handover_result",
+    "TicketAttachResultMessageEvent": [
+        "ticket_attach_result",
     ],
     "TicketInboxMessageCmd": [
         "ticket_inbox",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -1389,16 +1389,15 @@ func runTicketInbox(args []string) {
 }
 
 // ticketWatchInterval is how often `attn ticket inbox --watch` polls the consuming
-// inbox. It is the lower bound on push latency for a self-monitoring chief, and it
-// is coupled to the daemon's self-monitor backstop grace
-// (defaultTicketBackstopGrace, 8s): the grace must stay above this interval so a
-// live watch drains its queue before the daemon's backstop doorbell would fire.
+// inbox. A watch may consume unread activity before the daemon's shared nudge
+// countdown fires, but it is not required for delivery.
 const ticketWatchInterval = 3 * time.Second
 
 // runTicketInboxWatch blocks and prints new ticket activity as it lands, so a
-// harness Monitor can wrap it as a true push for a self-monitoring chief. It polls
-// the consuming ticket-inbox: the daemon advances the session's per-ticket cursor
-// on each read, so each event prints exactly once and the client tracks no state.
+// harness Monitor can wrap it as a true push for a chief. Whether a runtime is
+// guided to use it is separate from daemon nudge eligibility. It polls the
+// consuming ticket-inbox: the daemon advances the session's per-ticket cursor on
+// each read, so each event prints exactly once and the client tracks no state.
 // Silent when nothing is new; exits cleanly on SIGINT/SIGTERM (the harness stops
 // the Monitor on session end). A transient daemon error is reported once per outage
 // but does not end the watch. The poll loop lives in watchTicketInbox so it can be

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -648,7 +648,7 @@ func hasHelpFlag(args []string) bool {
 }
 
 // runTicket routes `attn ticket <command>`: `status` (the agent's forward channel
-// onto its own bound ticket), `inbox`, `handover`, `new` (mint a standalone, unbound
+// onto its own bound ticket), `inbox`, `attach`, `new` (mint a standalone, unbound
 // backlog ticket without delegating), and `comment` (post a one-shot note onto any
 // ticket by id).
 func runTicket() {
@@ -682,12 +682,12 @@ func runTicket() {
 			return
 		}
 		runTicketShow(os.Args[3:])
-	case "handover":
+	case "attach":
 		if hasHelpFlag(os.Args[3:]) {
 			writeTicketHelp(os.Stdout)
 			return
 		}
-		runTicketHandover(os.Args[3:])
+		runTicketAttach(os.Args[3:])
 	case "new":
 		if hasHelpFlag(os.Args[3:]) {
 			writeTicketHelp(os.Stdout)
@@ -809,7 +809,7 @@ func (f *stringListFlag) Set(value string) error {
 	return nil
 }
 
-type ticketHandoverArgs struct {
+type ticketAttachArgs struct {
 	Files   []string
 	Ticket  string
 	State   string
@@ -818,15 +818,15 @@ type ticketHandoverArgs struct {
 	JSON    bool
 }
 
-func parseTicketHandoverArgs(args []string) (ticketHandoverArgs, error) {
-	var result ticketHandoverArgs
-	fs := flag.NewFlagSet("ticket handover", flag.ContinueOnError)
+func parseTicketAttachArgs(args []string) (ticketAttachArgs, error) {
+	var result ticketAttachArgs
+	fs := flag.NewFlagSet("ticket attach", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	var files stringListFlag
 	fs.Var(&files, "file", "path to a Markdown artifact (repeatable)")
-	ticketID := fs.String("ticket", "", "hand over to this ticket instead of the session's bound ticket")
+	ticketID := fs.String("ticket", "", "attach to this ticket instead of the session's bound ticket")
 	state := fs.String("state", "", "optional resulting work state")
-	comment := fs.String("comment", "", "optional decision context recorded with the handover")
+	comment := fs.String("comment", "", "optional context recorded with the attachment")
 	session := fs.String("session", "", "session id (defaults to ATTN_SESSION_ID)")
 	jsonOutput := fs.Bool("json", false, "print the result as JSON")
 	if err := fs.Parse(args); err != nil {
@@ -853,46 +853,46 @@ func parseTicketHandoverArgs(args []string) (ticketHandoverArgs, error) {
 	return result, nil
 }
 
-func runTicketHandover(args []string) {
-	parsed, err := parseTicketHandoverArgs(args)
+func runTicketAttach(args []string) {
+	parsed, err := parseTicketAttachArgs(args)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ticket handover: %v\n", err)
+		fmt.Fprintf(os.Stderr, "ticket attach: %v\n", err)
 		writeTicketHelp(os.Stderr)
 		os.Exit(2)
 	}
 	source, err := resolveDispatchSession(parsed.Session)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ticket handover: %v\n", err)
+		fmt.Fprintf(os.Stderr, "ticket attach: %v\n", err)
 		os.Exit(2)
 	}
-	files := make([]protocol.TicketHandoverFile, 0, len(parsed.Files))
+	files := make([]protocol.TicketAttachFile, 0, len(parsed.Files))
 	for _, path := range parsed.Files {
 		absPath, absErr := filepath.Abs(path)
 		if absErr != nil {
-			fmt.Fprintf(os.Stderr, "ticket handover: %v\n", absErr)
+			fmt.Fprintf(os.Stderr, "ticket attach: %v\n", absErr)
 			os.Exit(2)
 		}
 		info, statErr := os.Lstat(absPath)
 		if statErr != nil {
-			fmt.Fprintf(os.Stderr, "ticket handover: %v\n", statErr)
+			fmt.Fprintf(os.Stderr, "ticket attach: %v\n", statErr)
 			os.Exit(1)
 		}
 		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || filepath.Ext(absPath) != ".md" {
-			fmt.Fprintf(os.Stderr, "ticket handover: %q is not a regular Markdown file\n", absPath)
+			fmt.Fprintf(os.Stderr, "ticket attach: %q is not a regular Markdown file\n", absPath)
 			os.Exit(1)
 		}
-		files = append(files, protocol.TicketHandoverFile{SourcePath: absPath, Filename: filepath.Base(absPath)})
+		files = append(files, protocol.TicketAttachFile{SourcePath: absPath, Filename: filepath.Base(absPath)})
 	}
-	result, err := client.New("").HandoverTicket(source, files, parsed.Ticket, parsed.State, parsed.Comment)
+	result, err := client.New("").AttachTicket(source, files, parsed.Ticket, parsed.State, parsed.Comment)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ticket handover: %v\n", err)
+		fmt.Fprintf(os.Stderr, "ticket attach: %v\n", err)
 		os.Exit(1)
 	}
 	if parsed.JSON {
 		printJSON(result)
 		return
 	}
-	fmt.Printf("handed over %d artifact(s) to ticket %s → %s\n", len(result.Artifacts), result.TicketID, result.State)
+	fmt.Printf("attached %d artifact(s) to ticket %s → %s\n", len(result.Artifacts), result.TicketID, result.State)
 	for _, artifact := range result.Artifacts {
 		fmt.Printf("  %s\n", artifact.Path)
 	}
@@ -1529,10 +1529,10 @@ commands:
         print one ticket's full record — description, complete activity thread
         with full bodies, current artifacts; non-consuming, does not touch your inbox
         cursor
-  handover --file <path> [--file <path> ...] [--ticket <id>]
+  attach --file <path> [--file <path> ...] [--ticket <id>]
         [--state <work-state>] [--comment <text>] [--session <id>] [--json]
         copy Markdown artifacts into a ticket's canonical Notebook directory,
-        record one durable handover, and optionally change ticket state
+        record one durable attachment, and optionally change ticket state
   new --title <t> [--description <d>] [--id <slug>] [--session <id>] [--json]
         create an unbound backlog ticket in todo (no agent, no session)
   comment <ticket-id> --message <text> [--session <id>] [--json]

--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -1056,18 +1056,18 @@ func TestParseTicketStatusArgsErrors(t *testing.T) {
 	}
 }
 
-func TestParseTicketHandoverArgs(t *testing.T) {
-	got, err := parseTicketHandoverArgs([]string{"--file", "report.md", "--file", "rollout.md", "--ticket", "tk", "--state", "ready_for_review", "--comment", "for review", "--session", "s1", "--json"})
+func TestParseTicketAttachArgs(t *testing.T) {
+	got, err := parseTicketAttachArgs([]string{"--file", "report.md", "--file", "rollout.md", "--ticket", "tk", "--state", "ready_for_review", "--comment", "for review", "--session", "s1", "--json"})
 	if err != nil {
-		t.Fatalf("parseTicketHandoverArgs: %v", err)
+		t.Fatalf("parseTicketAttachArgs: %v", err)
 	}
-	want := ticketHandoverArgs{Files: []string{"report.md", "rollout.md"}, Ticket: "tk", State: "ready_for_review", Comment: "for review", Session: "s1", JSON: true}
+	want := ticketAttachArgs{Files: []string{"report.md", "rollout.md"}, Ticket: "tk", State: "ready_for_review", Comment: "for review", Session: "s1", JSON: true}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("parseTicketHandoverArgs = %+v, want %+v", got, want)
+		t.Fatalf("parseTicketAttachArgs = %+v, want %+v", got, want)
 	}
 }
 
-func TestParseTicketHandoverArgsErrors(t *testing.T) {
+func TestParseTicketAttachArgsErrors(t *testing.T) {
 	cases := map[string][]string{
 		"missing file":          {"--comment", "hi"},
 		"unexpected positional": {"--file", "a.md", "extra"},
@@ -1075,8 +1075,8 @@ func TestParseTicketHandoverArgsErrors(t *testing.T) {
 	}
 	for name, args := range cases {
 		t.Run(name, func(t *testing.T) {
-			if _, err := parseTicketHandoverArgs(args); err == nil {
-				t.Fatalf("parseTicketHandoverArgs(%v) = nil error, want error", args)
+			if _, err := parseTicketAttachArgs(args); err == nil {
+				t.Fatalf("parseTicketAttachArgs(%v) = nil error, want error", args)
 			}
 		})
 	}

--- a/docs/alignment/nudge-delivery-review-remediation.md
+++ b/docs/alignment/nudge-delivery-review-remediation.md
@@ -1,0 +1,30 @@
+# Nudge delivery review remediation
+
+## Why
+
+Ticket delivery must remain runtime- and role-neutral without risking an
+approval response. Done means every state transition uses the shared
+`pending_approval` safety rule, a countdown cannot append Enter after approval
+begins, and the real-app and direct-doorbell tests prove the intended surface.
+
+## Aligned on
+
+- Plugin-owned sessions are ordinary nudge targets, so their authoritative state
+  reports must reconcile deferred unread activity just like built-in runtimes.
+- The approval boundary applies through the whole doorbell write, not only at
+  countdown-fire time.
+- Optional Claude watching is one valid consumer outcome, never a harness
+  precondition or delivery gate.
+
+## In scope / deferred
+
+In scope: the five review findings on PR #531, their focused tests, and stale
+behavioral wording. Deferred: redesigning nudge UX, countdown timing, or inbox
+semantics beyond what is required to make the existing contract safe and
+observable.
+
+## Vision
+
+Advances [chief delegation awareness](../vision/chief-delegation-awareness.md):
+the daemon provides a bounded doorbell while durable ticket state remains the
+source of truth.

--- a/docs/alignment/ticket-attach-rename.md
+++ b/docs/alignment/ticket-attach-rename.md
@@ -1,0 +1,22 @@
+# Ticket attach rename
+
+## Why
+
+`attach` names the mechanical operation more accurately: copy one or more files into a ticket's canonical artifact directory and record that action. `handover` remains useful language for the broader agent workflow, but should not be the command or protocol vocabulary.
+
+This chunk is done when the current durable artifact operation is consistently named `attach` across the CLI, protocol, daemon, store, UI, tests, changelog, and agent guidance without changing its behavior.
+
+## Aligned on
+
+- Rename the operation to `ticket attach` throughout the active product surface.
+- Preserve multi-file attachment, optional state and comment updates, retry-safe receipts, collision handling, and filesystem-canonical artifact listing.
+- Keep “handover” only where prose describes the broader transfer-of-work workflow.
+- Make this a clean rename with no compatibility alias for `ticket handover`.
+
+## In scope / deferred
+
+This chunk includes the product vocabulary rename, generated protocol types, tests, and live verification in a non-production profile. Changes to artifact formats, allowed file types, or ticket workflow semantics are deferred.
+
+## Vision
+
+This sharpens the artifact mechanics supporting [chief delegation awareness](../vision/chief-delegation-awareness.md) while preserving its durable continuation model.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -143,7 +143,7 @@ The chief delegates a unit of work to a sub-agent, and that work is tracked as a
 The agent reports its own **work state** — in progress, needs input, ready for
 review, completed, or failed — which moves the ticket across the board
 (Todo · Working · Blocked · In Review · Done). Comments, status changes, and
-artifact handovers accumulate on the ticket's activity thread. Current artifacts
+artifact attachments accumulate on the ticket's activity thread. Current artifacts
 are the Markdown files in the ticket's Notebook directory, and the chief watches
 progress from the ticket view and board rather than polling the agent.
 

--- a/docs/plans/2026-06-26-work-tracker.md
+++ b/docs/plans/2026-06-26-work-tracker.md
@@ -256,10 +256,11 @@ each is a meaningful, verifiable chunk.
    tear out anyway. *Test:* store-level — create/read/update, transitions, archival, TTL
    with injected time.
 2. **Event-driven notification core.** Mutations emit events; observers + cursors;
-   the two decoupled handlers (watch-consume / nudge), bundled-by-ticket, dedup,
-   unread. Built against the store, **proven by a simulation harness** (drives
-   producers + both handlers, nudge included; real Monitor arming skippable). *Test:*
-   harness scenarios — emit → consume → unread cursor, dedup, bundle, nudge path.
+   a shared nudge countdown for every non-approval session, bundled-by-ticket,
+   dedup, unread. An optional `ticket inbox --watch` consumes the same queue before
+   the countdown delivers. Built against the store, **proven by a simulation
+   harness**. *Test:* harness scenarios — emit → consume → unread cursor, dedup,
+   bundle, nudge path.
 3. **Delegation ⇄ tickets (live wiring).** Delegating creates/binds a ticket
    (description = prompt); the agent's self-reported status moves the ticket (forward);
    editing the ticket emits events the agent observes (reverse). Wires the event core to
@@ -274,9 +275,9 @@ each is a meaningful, verifiable chunk.
    closed one, bind a bare session.
 5. **Board view.** The session list as status columns with the Todo backlog and
    filters. *Test:* tickets appear in the right columns; backlog persists; filters work.
-6. **Codex nudge path.** `HasSelfMonitor` capability + the idle-nudge handler for
-   non-Claude agents, both chief→agent and agent→chief. *Test:* a codex agent gets
-   nudged on a ticket change and consumes it.
+6. **Shared nudge path.** A non-approval session gets the same ticket nudge whether
+   it is Codex or Claude, chief or delegated agent; `HasSelfMonitor` only controls
+   optional runtime guidance. *Test:* both runtimes receive a nudge and consume it.
 7. **Retire the `dispatch` namespace (completion bar).** Remove every old verb
    (`watch / report / message / inbox / messages / resolve / status / handoff / list`)
    and the mailbox / journal / `Classify` / #397 remnants — once the `ticket` surface

--- a/docs/plans/2026-06-28-delegated-ticket-awareness.md
+++ b/docs/plans/2026-06-28-delegated-ticket-awareness.md
@@ -1,5 +1,11 @@
 # Plan: Close the delegated-ticket awareness gap (chief watch + daemon backstop)
 
+> **Status (2026-07-11): superseded.** This plan records the earlier
+> runtime-aware watch/backstop design. Ticket delivery now uses one shared policy:
+> every session is nudge-eligible except one waiting for approval. Claude's
+> `ticket inbox --watch` remains optional and may consume activity before the
+> shared countdown delivers.
+
 ## Goal
 
 When the chief delegates, it currently goes silent until Victor prompts it: a

--- a/docs/plans/2026-07-01-orphaned-ticket-reconciliation.md
+++ b/docs/plans/2026-07-01-orphaned-ticket-reconciliation.md
@@ -397,9 +397,10 @@ Evidence: last assistant turn (~14:32): "tests pass locally except e2e, which…
 
 Then the existing fan-out: `notifyTicketObservers(ticketID)`
 (ticket_notify.go:34) + `broadcastTicketsUpdated()` (ticket_board.go:72). The
-chief is a participant (it authored `created` at delegation) and self-monitors
-via `attn ticket inbox --watch`; non-self-monitor chiefs get the standard
-countdown doorbell. No new event kind, no new protocol message for delivery.
+chief is a participant (it authored `created` at delegation) and receives the
+standard countdown doorbell whenever it is not waiting for approval. A runtime
+may additionally use `attn ticket inbox --watch` to consume before the countdown
+delivers. No new event kind, no new protocol message for delivery.
 
 Edge worth naming: a ticket with no chief in its participant set (created by
 `attn ticket new` from the user, taken by an agent that later died) may have no

--- a/docs/plans/2026-07-02-chief-guidance-brief-craft.md
+++ b/docs/plans/2026-07-02-chief-guidance-brief-craft.md
@@ -156,9 +156,9 @@ Count net new prose lines against this table when done (`git diff --stat` sanity
       > (a default, not a hard rule — skip it if the user asks; the daemon
       > doorbells you if unread ticket activity sits unwatched).
 
-      The backstop claim is real: `internal/daemon/ticket_notify.go` re-checks
-      after a grace and doorbells a self-monitoring chief whose queue is still
-      unread. While executing, also mark the "Open product question for Victor"
+      The shared countdown claim is real: `internal/daemon/ticket_notify.go`
+      doorbells every non-approval chief unless an optional watch already consumed
+      the queue. While executing, also mark the "Open product question for Victor"
       line in `docs/plans/2026-06-28-delegated-ticket-awareness.md` resolved with
       a pointer to this plan.
 

--- a/docs/plans/2026-07-02-ticket-went-quiet.md
+++ b/docs/plans/2026-07-02-ticket-went-quiet.md
@@ -1,5 +1,10 @@
 # Plan: The went-quiet floor — projection + stopped-without-report event
 
+> **Policy update (2026-07-11):** the nudge policy referenced below is now shared
+> across runtimes and roles: only `pending_approval` blocks delivery. Any future
+> state-hook work should use `isNudgeDeliveryAllowed`, not the removed idle-only
+> gate.
+
 ## Goal
 
 Close the last open mechanism gap in

--- a/docs/plans/2026-07-09-design-artifact-handover.md
+++ b/docs/plans/2026-07-09-design-artifact-handover.md
@@ -35,14 +35,14 @@ state, delegation association, discussion, and handover history.
 - Ticket events and role-owned unread cursors deliver durable activity to the
   chief (`internal/store/ticket_events.go`, `internal/daemon/ticket_read.go`,
   `internal/daemon/ticket_notify.go`).
-- `ticket handover` validates and stages one or more Markdown sources, installs
-  them into the ticket's visible Notebook directory, and commits the handover
+- `ticket attach` validates and stages one or more Markdown sources, installs
+  them into the ticket's visible Notebook directory, and commits the attachment
   event and optional state change as one recoverable operation
-  (`internal/daemon/ticket_handover.go`, `internal/store/tickets.go`).
+  (`internal/daemon/ticket_attach.go`, `internal/store/tickets.go`).
 - Full ticket reads enumerate current files directly from
   `tickets/<ticket-id>/`; the board remains a lightweight summary
   (`internal/daemon/ticket_artifacts.go`, `internal/daemon/ticket_board.go`).
-- Ticket detail supports handover, open, copy-path, rename, and delete actions,
+- Ticket detail supports attach, open, copy-path, rename, and delete actions,
   while `ticket show` exposes the same filesystem-derived paths
   (`app/src/components/TicketDetailPanel.tsx`, `cmd/attn/main.go`).
 - Built-in and plugin-provided agents receive a shared delegated initial prompt
@@ -91,7 +91,7 @@ supplies the current file index.
 ### Hand over one or several files
 
 ```sh
-"$ATTN_WRAPPER_PATH" ticket handover \
+"$ATTN_WRAPPER_PATH" ticket attach \
   --file docs/plans/design.md \
   --file docs/plans/rollout.md \
   --state ready_for_review \
@@ -103,7 +103,7 @@ The command:
 1. resolves the caller's bound ticket, or an explicitly supplied ticket ID;
 2. validates every source before changing the ticket;
 3. copies the files into `<notebook>/tickets/<ticket-id>/`;
-4. records one `handover_submitted` ticket event containing the submitted file
+4. records one `attach_submitted` ticket event containing the submitted file
    names and decision-context comment;
 5. applies the optional state transition;
 6. notifies ticket participants; and
@@ -156,10 +156,10 @@ The stable ticket association lets the chief:
 
 ## Delivery semantics
 
-A successful handover means all submitted files are present at the returned
-paths, the `handover_submitted` event is durable, the requested state is
+A successful attachment means all submitted files are present at the returned
+paths, the `attach_submitted` event is durable, the requested state is
 durable, and the receipt identifies all three. Notification delivery may be
-repeated; ticket reads and the handover receipt remain authoritative.
+repeated; ticket reads and the attachment receipt remain authoritative.
 
 The command uses a deterministic fingerprint of the ticket ID, destination
 names, file contents, requested state, and comment. The event stores that key.
@@ -210,7 +210,7 @@ command examples and detailed operation guidance.
 | Role | Guaranteed guidance | Skill guidance |
 |---|---|---|
 | Chief of staff | Read the ticket's current artifact paths before follow-on work, pass those paths to delegated agents, and expect meaningful changes to be reported on the ticket. | How to inspect handover receipts, open plans, and include canonical paths in delegation briefs. |
-| Chief-tracked delegated agent | Hand over a durable plan with `ticket handover`; after success, treat the returned Notebook paths as canonical and report meaningful edits, renames, or deletions through ticket status or comments. | Multi-file examples, optional state/comment usage, collision handling, and retry behavior. |
+| Chief-tracked delegated agent | Hand over a durable plan with `ticket attach`; after success, treat the returned Notebook paths as canonical and report meaningful edits, renames, or deletions through ticket status or comments. | Multi-file examples, optional state/comment usage, collision handling, and retry behavior. |
 | Plugin-provided delegated agent | The same tracked-agent rule arrives in the universal delegated initial prompt. | Plugins may expose the bundled references when supported. |
 | Ordinary agent | Existing ticket-awareness guidance remains sufficient. | Ticket handover guidance is loaded when the agent is working with a tracked ticket. |
 
@@ -240,9 +240,9 @@ reads.
 
 ## One-PR implementation
 
-- [x] Replace the current file-handoff command and protocol with `ticket handover`,
+- [x] Replace the current file-handoff command and protocol with `ticket attach`,
    including repeatable files, optional state/comment, a structured receipt,
-   and the `handover_submitted` event.
+   and the `attach_submitted` event.
 - [x] Write new handovers to `tickets/<ticket-id>/` and make directory enumeration
    the ticket-read source. Existing attachment data remains untouched.
 - [x] Add deterministic handover fingerprints, staging, locking, rollback, and

--- a/docs/plans/2026-07-09-design-artifact-handover.md
+++ b/docs/plans/2026-07-09-design-artifact-handover.md
@@ -233,10 +233,10 @@ the core behavior available across supported runtimes.
 ## Cross-runtime behavior
 
 Codex, Claude, and plugin-provided interactive agents use the same handover,
-status, comment, and ticket-read protocol. Runtime-specific ticket delivery
-continues to use each runtime's existing capability: Claude may self-monitor,
-while Codex and plugin runtimes respond to nudges and perform one-shot inbox
-reads.
+status, comment, ticket-read, and ticket-nudge protocol. Every live session is
+eligible for the same bounded nudge unless it is waiting for approval; Claude may
+also self-monitor with `ticket inbox --watch`, which can consume unread activity
+before the countdown fires.
 
 ## One-PR implementation
 

--- a/docs/vision/chief-delegation-awareness.md
+++ b/docs/vision/chief-delegation-awareness.md
@@ -55,10 +55,10 @@ not *reach* it is a sensor, not a hand. So the loop closes both ways: the chief,
 and Victor through it, can steer work already in flight — answer a blocker,
 re-brief it, feed it context — by editing the same ticket. And the reverse
 channel must be as ambient as the forward one: a steer to an agent never rots in a
-queue no one watches. A self-monitoring agent learns of it the moment it lands; an
-agent that can't is nudged to check at a sensible moment; and Victor sees the
-pending signal in the sidebar where he already looks — never buried in a dashboard
-he never opens.
+queue no one watches. Any live agent receives the same bounded nudge unless it is
+waiting for approval; an optional watcher can consume its inbox sooner. Victor sees
+the pending signal in the sidebar where he already looks — never buried in a
+dashboard he never opens.
 
 ## The shape: an issue tracker, not a switchboard
 
@@ -91,12 +91,11 @@ How it runs:
 
 ## North-star principles
 
-- **Event-driven where we can; attn-triggered where we can't.** A ticket move emits
-  an event. A self-monitoring agent (Claude) watches the event stream live and drains
-  it the moment it lands; an agent that can't (codex, etc.) gets a fixed doorbell
-  typed into its PTY *only when it is idle*, nudging it to run `attn ticket inbox` — a
-  sensible-moment poke, not a busy-loop timer. The split is a first-class capability
-  (`HasSelfMonitor`), resolved from the driver registry, never guessed.
+- **One safe nudge policy for every runtime.** A ticket move emits an event and arms
+  the same bounded doorbell for every live observer. The only state that suppresses
+  delivery is `pending_approval`, where the doorbell's Enter could approve a prompt.
+  Claude may also watch `attn ticket inbox --watch`; that optional consumer can drain
+  unread activity before the countdown fires, but it does not change eligibility.
 - **The loop runs both ways.** Observing is half a loop; the chief must also steer a
   running agent. Steering is just another authored event on the ticket (comment,
   re-brief, status), delivered by the same layer and read with `attn ticket inbox` —
@@ -139,9 +138,9 @@ How it runs:
 **In scope.** The durable **ticket** model (status, activity thread, artifacts,
 resume); the **board** as the read-only awareness surface the chief reads instead of
 polling; agent self-report via `attn ticket status`; the reverse channel via
-`attn ticket inbox`; the **notification split** (a live watch for self-monitoring
-agents, an idle pty-nudge for the rest) and the per-identity read cursor that tracks
-delivery; and attn-authored **crash** capture so a silent death is still visible.
+`attn ticket inbox`; the shared approval-safe pty-nudge policy (with an optional live
+watch for capable runtimes) and the per-identity read cursor that tracks delivery;
+and attn-authored **crash** capture so a silent death is still visible.
 
 **Non-goals.**
 - *Not Jira.* Linear's restraint — a few fields, and a board that **informs, never
@@ -171,8 +170,9 @@ The work-tracker epic delivered the loop across slices 1–7.
   mid-flight close.
 - [x] **Agent reverse channel** — `attn ticket inbox` consume path; the steering edits
   the chief makes are read here.
-- [x] **Notification split by capability** — `HasSelfMonitor`: Claude watches live;
-  codex is idle-nudged with a fixed doorbell.
+- [x] **Approval-safe notification policy** — every live runtime gets the same
+  bounded nudge unless it is waiting for approval; capable runtimes may additionally
+  watch their inbox live.
 - [x] **Ticket view + resume + artifacts** — the chief edits, comments, and changes
   status from the UI; **resume** reopens a stopped agent on the same ticket (its cwd +
   last agent id); `attn ticket attach` copies one or more Markdown files into the

--- a/docs/vision/chief-delegation-awareness.md
+++ b/docs/vision/chief-delegation-awareness.md
@@ -175,7 +175,7 @@ The work-tracker epic delivered the loop across slices 1–7.
   codex is idle-nudged with a fixed doorbell.
 - [x] **Ticket view + resume + artifacts** — the chief edits, comments, and changes
   status from the UI; **resume** reopens a stopped agent on the same ticket (its cwd +
-  last agent id); `attn ticket handover` copies one or more Markdown files into the
+  last agent id); `attn ticket attach` copies one or more Markdown files into the
   ticket's visible Notebook directory and returns their canonical paths.
 - [x] **The board** — status columns + a Todo backlog + filters (blocked / in review /
   closed today), read-only, live `tickets_updated`.

--- a/internal/agent/attn_skill/references/delegated-agent.md
+++ b/internal/agent/attn_skill/references/delegated-agent.md
@@ -67,7 +67,7 @@ delegation.
 When tracked work produces a plan, design, or other Markdown artifact that must
 outlive this session, hand it over to the ticket:
 
-    "$ATTN_WRAPPER_PATH" ticket handover \
+    "$ATTN_WRAPPER_PATH" ticket attach \
       --file docs/plans/design.md \
       --file docs/plans/rollout.md \
       --state ready_for_review \
@@ -75,7 +75,7 @@ outlive this session, hand it over to the ticket:
 
 `--file` is repeatable. `--state` and `--comment` are optional. The command copies
 the files into the ticket's visible Notebook directory, records one durable
-handover event, and returns the canonical paths. A matching retry returns the same
+attach event, and returns the canonical paths. A matching retry returns the same
 receipt; a same-name file with different bytes is preserved and must be renamed
 before retrying.
 

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -22,10 +22,10 @@ workspace/session, or a collaborator they can steer themselves.
 
 Attn delegation starts another agent with a focused brief; it does not create
 durable parent-child lineage. If you are the chief of staff, attn binds a ticket
-to the delegated session and your system-prompt guidance covers the runtime's
-supported follow-up path: Claude arms a Monitor on `attn ticket inbox --watch`,
-while Codex waits for attn's ticket nudge and then reads `attn ticket inbox`.
-Ordinary delegation needs none of that.
+to the delegated session and your system-prompt guidance covers the follow-up path:
+all runtimes receive the same ticket nudge when activity remains unread; Claude may
+also arm a Monitor on `attn ticket inbox --watch` to consume updates sooner. Ordinary
+delegation needs none of that.
 
 For a chief-tracked delegation that returns a durable plan, read the ticket before
 continuing: `attn ticket show <ticket-id>` lists the Markdown files currently in

--- a/internal/agent/attn_skill/references/tickets.md
+++ b/internal/agent/attn_skill/references/tickets.md
@@ -42,9 +42,9 @@ validates it.
 
 ## Handing over Markdown artifacts
 
-`attn ticket handover` is the durable producer-to-ticket operation:
+`attn ticket attach` is the durable producer-to-ticket operation:
 
-    "$ATTN_WRAPPER_PATH" ticket handover \
+    "$ATTN_WRAPPER_PATH" ticket attach \
       --file docs/plans/design.md \
       --file docs/plans/rollout.md \
       --ticket <ticket-id> \
@@ -53,17 +53,17 @@ validates it.
 
 - Omit `--ticket` to use your own bound ticket; include it to target any known
   ticket, matching `ticket status --ticket` and `ticket comment`.
-- Repeat `--file` to submit several Markdown files in one handover.
+- Repeat `--file` to submit several Markdown files in one attachment.
 - `--state` uses the reporting vocabulary: `in_progress`, `needs_input`,
   `ready_for_review`, `completed`, or `failed`.
 - `--comment` is short decision context. Put the full reasoning in the Markdown.
 - The receipt's Notebook paths are canonical. Current artifacts are whatever
   regular `.md` files exist directly in `tickets/<ticket-id>/` when the ticket is
   read.
-- Retrying an identical handover returns its existing receipt. A destination with
+- Retrying an identical attachment returns its existing receipt. A destination with
   different bytes is never overwritten; choose a new filename and retry.
 
-After handover, edit, rename, or delete the canonical files with ordinary file
+After attaching, edit, rename, or delete the canonical files with ordinary file
 tools. Report meaningful changes on the ticket so participants know to re-read it.
 
 ## Creating a ticket
@@ -113,4 +113,4 @@ inbox (see the delegated-agent reference). These two commands reach **any** tick
   ticket **already assigned to someone else** requires `--confirm`, so you cannot silently
   take over a sibling's active work — without it the command refuses and names the current
   assignee. Taking does not skip the backlog: your first `attn ticket inbox` afterward
-  delivers the ticket's history. The displaced assignee is notified of the handover.
+  delivers the ticket's history. The displaced assignee is notified of the attach.

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -108,8 +108,8 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 		"--source-session <session-id>",
 		"Copilot delegation is currently unsupported",
 		"durable parent-child lineage",
-		"Claude arms a Monitor",
-		"Codex waits for attn's ticket nudge",
+		"all runtimes receive the same ticket nudge",
+		"Claude may",
 	} {
 		if !strings.Contains(delegation, expected) {
 			t.Fatalf("delegation reference missing %q: %q", expected, delegation)

--- a/internal/agent/capabilities_self_monitor_test.go
+++ b/internal/agent/capabilities_self_monitor_test.go
@@ -2,15 +2,13 @@ package agent
 
 import "testing"
 
-// The agent->self-monitor mapping that used to live as a magic string in
-// internal/ticketnotify (HasSelfMonitor("claude")) is now a driver capability.
-// This is its home: only Claude self-monitors today; codex (and the rest, which
-// rely on the zero value) take the idle-nudge path.
+// The agent->self-monitor mapping is a driver capability used for optional chief
+// guidance. It does not change the daemon's shared nudge eligibility.
 func TestCapabilitiesSelfMonitor(t *testing.T) {
 	if !MustGet("claude").Capabilities().HasSelfMonitor {
 		t.Fatal("claude should self-monitor (watch its own ticket stream)")
 	}
 	if MustGet("codex").Capabilities().HasSelfMonitor {
-		t.Fatal("codex should not self-monitor (it is pty-nudged when idle)")
+		t.Fatal("codex should not advertise an optional ticket monitor")
 	}
 }

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -55,8 +55,8 @@ func (c *Codex) Capabilities() Capabilities {
 		HasYolo:             true,
 		HasInitialPrompt:    true,
 		HasWorkspaceContext: true,
-		// HasSelfMonitor: false — codex has no live ticket Monitor, so it is
-		// pty-nudged when ticket activity arrives while it is idle.
+		// HasSelfMonitor: false — Codex has no live ticket Monitor. It still uses
+		// the shared daemon nudge for unread ticket activity.
 		HasModelPin:  true,
 		HasEffortPin: true,
 	}

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -118,11 +118,9 @@ type Capabilities struct {
 	// instructions for using a workspace context checkout.
 	HasWorkspaceContext bool
 
-	// HasSelfMonitor indicates the agent watches its own ticket/event stream via
-	// a live Monitor (true push) rather than needing an idle PTY nudge when ticket
-	// activity arrives. Consumed by the work-tracker notifier (internal/ticketnotify)
-	// to pick DeliveryWatch (self-monitor) vs DeliveryNudge (idle pty-nudge). Only
-	// Claude self-monitors today.
+	// HasSelfMonitor indicates the agent can optionally watch its own ticket/event
+	// stream via a live Monitor. It selects chief guidance only; daemon nudge
+	// eligibility is shared across runtimes. Only Claude supports this today.
 	HasSelfMonitor bool
 
 	// HasModelPin indicates the agent's launch command accepts a per-session

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -241,10 +241,10 @@ func (c *Client) SetTicketStatus(sourceSessionID, workState, comment, ticketID s
 	return resp.TicketStatusResult, nil
 }
 
-// HandoverTicket copies one or more Markdown files into a ticket's canonical
+// AttachTicket copies one or more Markdown files into a ticket's canonical
 // Notebook directory and returns its durable receipt.
-func (c *Client) HandoverTicket(sourceSessionID string, files []protocol.TicketHandoverFile, ticketID, state, comment string) (*protocol.TicketHandoverResult, error) {
-	msg := protocol.TicketHandoverMessage{Cmd: protocol.CmdTicketHandover, SourceSessionID: sourceSessionID, Files: files}
+func (c *Client) AttachTicket(sourceSessionID string, files []protocol.TicketAttachFile, ticketID, state, comment string) (*protocol.TicketAttachResult, error) {
+	msg := protocol.TicketAttachMessage{Cmd: protocol.CmdTicketAttach, SourceSessionID: sourceSessionID, Files: files}
 	if value := strings.TrimSpace(ticketID); value != "" {
 		msg.TicketID = protocol.Ptr(value)
 	}
@@ -259,10 +259,10 @@ func (c *Client) HandoverTicket(sourceSessionID string, files []protocol.TicketH
 	if err != nil {
 		return nil, err
 	}
-	if resp.TicketHandoverResult == nil {
-		return nil, errors.New("daemon returned no ticket handover result")
+	if resp.TicketAttachResult == nil {
+		return nil, errors.New("daemon returned no ticket attach result")
 	}
-	return resp.TicketHandoverResult, nil
+	return resp.TicketAttachResult, nil
 }
 
 // CreateTicket mints a standalone backlog ticket — unbound, starting in todo. The

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -88,8 +88,8 @@ func (d *Daemon) clearChiefOfStaffIfSession(sessionID string) {
 }
 
 // nudgeChiefOfStaff types a bounded prompt into the current chief-of-staff
-// session's PTY, but only when a chief is set and that session is idle or waiting
-// for input — never an agent mid-task. It re-confirms the role right before
+// session's PTY whenever a chief is set and it is not waiting for approval. It
+// re-confirms the role right before
 // typing (the role is a single-holder upsert that another promotion may have
 // moved). Returns true only when the nudge was actually delivered, so callers can
 // report whether the chief was pinged live versus only queued in the inbox.
@@ -105,7 +105,7 @@ func (d *Daemon) nudgeChiefOfStaff(prompt string) bool {
 	if session == nil {
 		return false
 	}
-	if session.State != protocol.SessionStateIdle && session.State != protocol.SessionStateWaitingInput {
+	if !isNudgeDeliveryAllowed(string(session.State)) {
 		return false
 	}
 	if d.chiefOfStaffSessionID() != sessionID {
@@ -228,7 +228,6 @@ func (d *Daemon) handleSetChiefOfStaff(client *wsClient, msg *protocol.SetChiefO
 // ownership and its cursors do not move, copy, or advance.
 func (d *Daemon) retargetChiefTicketDelivery(previousSessionID, newSessionID string) {
 	if previousSessionID != "" {
-		d.cancelTicketBackstop(previousSessionID)
 		d.refreshTicketUnread(previousSessionID)
 	}
 	if newSessionID != "" {

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -9,6 +10,8 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 )
+
+var errDoorbellBlockedByApproval = errors.New("doorbell blocked by pending approval")
 
 const profileRoleChiefOfStaff = "chief_of_staff"
 
@@ -118,15 +121,21 @@ func (d *Daemon) nudgeChiefOfStaff(prompt string) bool {
 	return true
 }
 
-// typeDoorbell types a bounded prompt followed by Enter into a session's PTY. It
-// is the shared primitive behind the chief-of-staff doorbells (notebook
-// activation, inbox nudge): a fixed trigger, never arbitrary streamed content.
+// typeDoorbell types a bounded prompt and its Enter as one PTY write. It serializes
+// that write against authoritative state commits, so a pending_approval report
+// cannot land between the prompt and Enter. It is the shared primitive behind the
+// chief-of-staff doorbells (notebook activation, inbox nudge): a fixed trigger,
+// never arbitrary streamed content.
 func (d *Daemon) typeDoorbell(sessionID, prompt string) error {
-	if err := d.ptyBackend.Input(context.Background(), sessionID, []byte(prompt)); err != nil {
-		return err
+	d.doorbellMu.Lock()
+	defer d.doorbellMu.Unlock()
+	if session := d.store.Get(sessionID); session == nil || !isNudgeDeliveryAllowed(string(session.State)) {
+		return errDoorbellBlockedByApproval
 	}
-	time.Sleep(100 * time.Millisecond)
-	return d.ptyBackend.Input(context.Background(), sessionID, []byte{'\r'})
+	input := make([]byte, 0, len(prompt)+1)
+	input = append(input, prompt...)
+	input = append(input, '\r')
+	return d.ptyBackend.Input(context.Background(), sessionID, input)
 }
 
 // maybeAssignChiefOnSpawn assigns the chief-of-staff role at a session's first

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -31,7 +31,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdRegister:                              commandMetadata(ScopeSession, false, true),
 	protocol.CmdSetTicketStatus:                       commandMetadata(ScopeSession, false, true),
 	protocol.CmdTicketInbox:                           commandMetadata(ScopeSession, false, true),
-	protocol.CmdTicketHandover:                        commandMetadata(ScopeSession, false, true),
+	protocol.CmdTicketAttach:                          commandMetadata(ScopeSession, false, true),
 	protocol.CmdTicketCreate:                          commandMetadata(ScopeSession, false, true),
 	protocol.CmdUnregister:                            commandMetadata(ScopeSession, true, true),
 	protocol.CmdState:                                 commandMetadata(ScopeSession, false, true),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -175,6 +175,10 @@ type Daemon struct {
 	// place a real doorbell happens, and only if no genuine user keystroke landed in
 	// the guard window (the anti-splice guarantee). All maps lazy-init so a
 	// directly-constructed test daemon is nil-safe.
+	// doorbellMu serializes authoritative session-state commits with a complete
+	// doorbell write. This keeps a pending_approval report from interleaving
+	// between the prompt and its trailing Enter.
+	doorbellMu          sync.Mutex
 	nudgeMu             sync.Mutex
 	nudgeCountdowns     map[string]*nudgeCountdown     // presence == a running (unpaused) countdown
 	unreadCache         map[string]bool                // per-session unread ticket activity, for cheap broadcast decoration
@@ -1602,8 +1606,11 @@ func (d *Daemon) handlePTYState(sessionID, state string) {
 	case protocol.StateIdle, protocol.StateScheduled:
 		d.clearLongRunTracking(sessionID)
 	}
-	d.store.UpdateState(sessionID, state)
-	d.store.Touch(sessionID)
+	d.applyStateAndSyncNudge(sessionID, state, func() bool {
+		d.store.UpdateState(sessionID, state)
+		d.store.Touch(sessionID)
+		return true
+	})
 	updated := d.sessionForBroadcast(d.store.Get(sessionID))
 	if updated == nil {
 		return
@@ -1613,7 +1620,6 @@ func (d *Daemon) handlePTYState(sessionID, state string) {
 		Session: updated,
 	})
 	d.recomputeAndBroadcastWorkspaceForSession(sessionID)
-	d.syncNudgeForState(sessionID, state)
 }
 
 // initHTTPServer creates the HTTP server synchronously to avoid race with Stop().
@@ -2186,11 +2192,13 @@ func (d *Daemon) handleState(conn net.Conn, msg *protocol.StateMessage) {
 		// review on the next short resumed turn.
 		d.clearLongRunTracking(msg.ID)
 	}
-	d.store.UpdateState(msg.ID, msg.State)
-	d.store.Touch(msg.ID)
-	// The hook is the authoritative state path for codex/claude, so it must also
-	// reconcile a nudge deferred by an approval prompt.
-	d.syncNudgeForState(msg.ID, msg.State)
+	d.applyStateAndSyncNudge(msg.ID, msg.State, func() bool {
+		d.store.UpdateState(msg.ID, msg.State)
+		d.store.Touch(msg.ID)
+		return true
+	})
+	// The hook is the authoritative state path for Codex and Claude; the shared
+	// state helper also reconciles a nudge deferred by an approval prompt.
 	d.sendOK(conn)
 
 	// Broadcast to WebSocket clients
@@ -2827,8 +2835,10 @@ func (d *Daemon) updateAndBroadcastState(sessionID, state string) {
 	case protocol.StateIdle, protocol.StateScheduled:
 		d.clearLongRunTracking(sessionID)
 	}
-	d.store.UpdateState(sessionID, state)
-	d.syncNudgeForState(sessionID, state)
+	d.applyStateAndSyncNudge(sessionID, state, func() bool {
+		d.store.UpdateState(sessionID, state)
+		return true
+	})
 	// Broadcast to WebSocket clients
 	session := d.sessionForBroadcast(d.store.Get(sessionID))
 	if session != nil {
@@ -2845,14 +2855,15 @@ func (d *Daemon) updateAndBroadcastState(sessionID, state string) {
 // than the current state. Used by classifier to prevent stale results from overwriting
 // newer state updates that arrived during classification.
 func (d *Daemon) updateAndBroadcastStateWithTimestamp(sessionID, state string, updatedAt time.Time) bool {
-	if d.store.UpdateStateWithTimestamp(sessionID, state, updatedAt) {
+	if d.applyStateAndSyncNudge(sessionID, state, func() bool {
+		return d.store.UpdateStateWithTimestamp(sessionID, state, updatedAt)
+	}) {
 		switch state {
 		case protocol.StateWorking:
 			d.markRunStartedIfNeeded(sessionID)
 		case protocol.StateIdle, protocol.StateScheduled:
 			d.clearLongRunTracking(sessionID)
 		}
-		d.syncNudgeForState(sessionID, state)
 		// Broadcast to WebSocket clients
 		session := d.sessionForBroadcast(d.store.Get(sessionID))
 		if session != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -146,7 +146,7 @@ type Daemon struct {
 	// lookup seam: nil in production (reconcileGroundTruth derives the fetcher
 	// from ghRegistry per-host); tests set it to a fake so no network runs.
 	ticketReconcilePRFetch prStateFetcher
-	// ticketArtifactMu serializes handover installation with its durable ticket
+	// ticketArtifactMu serializes attach installation with its durable ticket
 	// receipt so concurrent submissions cannot race on destination names.
 	ticketArtifactMu sync.Mutex
 	// reloadingSessions marks sessions whose agent is being re-spawned in place
@@ -1982,8 +1982,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleTicketSubscribe(conn, msg.(*protocol.TicketSubscribeMessage))
 	case protocol.CmdTicketUnsubscribe:
 		d.handleTicketUnsubscribe(conn, msg.(*protocol.TicketUnsubscribeMessage))
-	case protocol.CmdTicketHandover:
-		d.handleTicketHandover(conn, msg.(*protocol.TicketHandoverMessage))
+	case protocol.CmdTicketAttach:
+		d.handleTicketAttach(conn, msg.(*protocol.TicketAttachMessage))
 	case protocol.CmdTicketCreate:
 		d.handleTicketCreate(conn, msg.(*protocol.TicketCreateMessage))
 	case protocol.CmdTicketComment:

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -169,15 +169,6 @@ type Daemon struct {
 	// stale mark (reload kill that never produced an exit) cannot swallow a real
 	// crash later. Lazily initialized under reloadingMu.
 	reloadKills map[string]time.Time
-	// ticketBackstop debounces the deferred self-monitor doorbell (see
-	// ticket_notify.go): an idle self-monitor with unread ticket activity is
-	// re-checked after a grace delay and doorbelled only if still unread, so a live
-	// `attn ticket inbox --watch` Monitor (which drains within its poll interval)
-	// self-suppresses it. ticketBackstopGrace is 0 in production (=> the default
-	// const) and a test override otherwise.
-	ticketBackstopMu     sync.Mutex
-	ticketBackstopTimers map[string]*time.Timer
-	ticketBackstopGrace  time.Duration
 	// nudge countdown (see nudge_countdown.go): every ticket doorbell arms a
 	// visible per-session countdown instead of injecting immediately. The
 	// currently-selected session's countdown is paused; the timer fire is the only
@@ -1380,7 +1371,6 @@ func (d *Daemon) Stop() {
 	}
 	d.stopInstalledPlugins()
 	d.stopAllTranscriptWatchers()
-	d.stopTicketBackstops()
 	d.stopNudgeCountdowns()
 	if d.ptyBackend != nil {
 		_ = d.ptyBackend.Shutdown(context.Background())
@@ -1623,25 +1613,7 @@ func (d *Daemon) handlePTYState(sessionID, state string) {
 		Session: updated,
 	})
 	d.recomputeAndBroadcastWorkspaceForSession(sessionID)
-	// A non-self-monitoring agent that was busy when a ticket event landed gets its
-	// deferred doorbell the moment it goes idle. Off the read-loop goroutine: the
-	// doorbell write briefly blocks, and a no-unread observer is a quick no-op.
-	if isIdleForNudge(state) {
-		go d.notifyTicketSessionWentIdle(sessionID)
-	}
-	d.cancelNudgeOnLeaveIdle(sessionID, state)
-}
-
-// cancelNudgeOnLeaveIdle cancels a session's pending nudge countdown when its state is
-// no longer idle/waiting — you don't count down to nudge a working agent (the unread
-// marker survives until it reads its inbox). Called from every state-broadcast path so
-// the "armed only while idle" invariant holds regardless of which signal (PTY
-// detector, hook, classifier, transcript) drove the transition; the no-op-when-idle
-// guard makes it safe to call unconditionally.
-func (d *Daemon) cancelNudgeOnLeaveIdle(sessionID, state string) {
-	if !isIdleForNudge(state) {
-		d.cancelNudgeCountdown(sessionID, "left idle")
-	}
+	d.syncNudgeForState(sessionID, state)
 }
 
 // initHTTPServer creates the HTTP server synchronously to avoid race with Stop().
@@ -2216,9 +2188,9 @@ func (d *Daemon) handleState(conn net.Conn, msg *protocol.StateMessage) {
 	}
 	d.store.UpdateState(msg.ID, msg.State)
 	d.store.Touch(msg.ID)
-	// The hook is the authoritative state path for codex/claude, which never flow
-	// through handlePTYState, so the leaving-idle countdown cancel must hook here too.
-	d.cancelNudgeOnLeaveIdle(msg.ID, msg.State)
+	// The hook is the authoritative state path for codex/claude, so it must also
+	// reconcile a nudge deferred by an approval prompt.
+	d.syncNudgeForState(msg.ID, msg.State)
 	d.sendOK(conn)
 
 	// Broadcast to WebSocket clients
@@ -2856,7 +2828,7 @@ func (d *Daemon) updateAndBroadcastState(sessionID, state string) {
 		d.clearLongRunTracking(sessionID)
 	}
 	d.store.UpdateState(sessionID, state)
-	d.cancelNudgeOnLeaveIdle(sessionID, state)
+	d.syncNudgeForState(sessionID, state)
 	// Broadcast to WebSocket clients
 	session := d.sessionForBroadcast(d.store.Get(sessionID))
 	if session != nil {
@@ -2880,7 +2852,7 @@ func (d *Daemon) updateAndBroadcastStateWithTimestamp(sessionID, state string, u
 		case protocol.StateIdle, protocol.StateScheduled:
 			d.clearLongRunTracking(sessionID)
 		}
-		d.cancelNudgeOnLeaveIdle(sessionID, state)
+		d.syncNudgeForState(sessionID, state)
 		// Broadcast to WebSocket clients
 		session := d.sessionForBroadcast(d.store.Get(sessionID))
 		if session != nil {

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -515,7 +515,7 @@ Use the state that matches the outcome when work needs input, is ready, or ends:
     "$ATTN_WRAPPER_PATH" ticket status failed --comment "<terminal failure>"
 
 When the deliverable is a durable plan, design, or other Markdown artifact, hand
-it over with ` + "`" + `"$ATTN_WRAPPER_PATH" ticket handover --file <path>` + "`" + `. Use repeatable
+it over with ` + "`" + `"$ATTN_WRAPPER_PATH" ticket attach --file <path>` + "`" + `. Use repeatable
 ` + "`" + `--file` + "`" + ` flags for multiple artifacts and optionally include ` + "`" + `--state` + "`" + ` and
 ` + "`" + `--comment` + "`" + `. After success, the returned Notebook paths are canonical: keep
 those files current, and report meaningful edits, renames, or deletions through

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -171,7 +171,7 @@ func TestChiefOfStaffDelegateBindsTicketAndPrompt(t *testing.T) {
 	if !strings.Contains(prompt, "ask the user to confirm") {
 		t.Fatalf("tracked initial prompt missing confirm-before-complete guidance = %q", prompt)
 	}
-	for _, expected := range []string{"ticket handover --file", "returned Notebook paths are canonical", "meaningful edits, renames, or deletions"} {
+	for _, expected := range []string{"ticket attach --file", "returned Notebook paths are canonical", "meaningful edits, renames, or deletions"} {
 		if !strings.Contains(prompt, expected) {
 			t.Fatalf("tracked initial prompt missing %q: %q", expected, prompt)
 		}

--- a/internal/daemon/notebook.go
+++ b/internal/daemon/notebook.go
@@ -335,7 +335,8 @@ func chiefInboxNudgePrompt(root string) string {
 
 // sendNotebookToChiefWSResult delivers a Notebook selection to the chief of staff:
 // it appends the selection to the chief inbox note (the daemon is the sole writer)
-// and, when a chief session is live and idle/waiting, fires a bounded PTY nudge.
+// and, when a chief session is live and not waiting for approval, fires a bounded
+// PTY nudge.
 // The inbox delivery is the durable channel; the nudge is best-effort immediacy.
 // The UI never messages the chief directly — it only hands the selection here.
 func (d *Daemon) sendNotebookToChiefWSResult(client *wsClient, requestID, sourcePath, selection string) {

--- a/internal/daemon/notebook.go
+++ b/internal/daemon/notebook.go
@@ -186,7 +186,7 @@ func (d *Daemon) handleNotebookGuide(conn net.Conn, msg *protocol.NotebookGuideM
 	}
 	sessionID := strings.TrimSpace(protocol.Deref(msg.SessionID))
 	sessionIsChief := sessionID != "" && sessionID == d.chiefOfStaffSessionID()
-	hasSelfMonitor := d.ticketDeliveryObserverForSession(sessionID).HasSelfMonitor
+	hasSelfMonitor := d.sessionHasSelfMonitor(sessionID)
 	if sessionIsChief {
 		if _, _, serr := d.ensureNotebookScaffold(); serr != nil {
 			d.logf("notebook guide: ensure scaffold failed: %v", serr)

--- a/internal/daemon/notebook_test.go
+++ b/internal/daemon/notebook_test.go
@@ -752,9 +752,8 @@ func TestNotebookSendToChiefQueuesWithoutLiveChief(t *testing.T) {
 	}
 }
 
-// A busy chief (working/pending) is not interrupted: the inbox delivery happens
-// but the nudge is withheld, mirroring the activation doorbell's state gate.
-func TestNotebookSendToChiefDoesNotNudgeBusyChief(t *testing.T) {
+// A green/working chief receives the same live nudge as any other eligible session.
+func TestNotebookSendToChiefNudgesWorkingChief(t *testing.T) {
 	d := newNotebookDaemon(t)
 	var mu sync.Mutex
 	var inputs []string
@@ -769,14 +768,40 @@ func TestNotebookSendToChiefDoesNotNudgeBusyChief(t *testing.T) {
 
 	var res protocol.NotebookSendToChiefResultMessage
 	readNotebookWSEvent(t, client.send, &res)
+	if !res.Success || res.Result == nil || !res.Result.Nudged {
+		t.Fatalf("send-to-chief result = %+v, want success with working chief nudged", res.Result)
+	}
+	mu.Lock()
+	n := len(inputs)
+	mu.Unlock()
+	if n != 2 {
+		t.Fatalf("PTY inputs = %d, want prompt plus Enter", n)
+	}
+}
+
+func TestNotebookSendToChiefDoesNotNudgePendingApprovalChief(t *testing.T) {
+	d := newNotebookDaemon(t)
+	var mu sync.Mutex
+	var inputs []string
+	d.ptyBackend = recordingBackend(&inputs, &mu)
+	addIdleNotebookSession(d, "chief", protocol.SessionStatePendingApproval)
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, "chief"); err != nil {
+		t.Fatal(err)
+	}
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+
+	d.sendNotebookToChiefWSResult(client, "c3-pending", "/index.md", "wait for approval")
+
+	var res protocol.NotebookSendToChiefResultMessage
+	readNotebookWSEvent(t, client.send, &res)
 	if !res.Success || res.Result == nil || res.Result.Nudged {
-		t.Fatalf("send-to-chief result = %+v, want success not nudged for a busy chief", res.Result)
+		t.Fatalf("send-to-chief result = %+v, want success without a pending-approval nudge", res.Result)
 	}
 	mu.Lock()
 	n := len(inputs)
 	mu.Unlock()
 	if n != 0 {
-		t.Fatalf("PTY inputs = %d, want 0 (never interrupt a working chief)", n)
+		t.Fatalf("PTY inputs = %d, want 0 while approval is pending", n)
 	}
 }
 

--- a/internal/daemon/notebook_test.go
+++ b/internal/daemon/notebook_test.go
@@ -709,14 +709,15 @@ func TestNotebookSendToChiefAppendsAndNudges(t *testing.T) {
 		t.Fatalf("send-to-chief result = %+v, want success inbox.md nudged", res.Result)
 	}
 
-	// Only the bounded doorbell + Enter was typed into the chief PTY — never the
-	// selection content itself (that goes to the inbox note, not the terminal).
+	// Only the bounded doorbell + Enter was typed into the chief PTY as one atomic
+	// write — never the selection content itself (that goes to the inbox note, not
+	// the terminal).
 	mu.Lock()
 	got := append([]string(nil), inputs...)
 	mu.Unlock()
 	wantNudge := chiefInboxNudgePrompt(d.store.GetSetting(SettingNotebookRoot))
-	if len(got) != 2 || got[0] != wantNudge || got[1] != "\r" {
-		t.Fatalf("PTY inputs = %q, want [nudge prompt, \\r]", got)
+	if len(got) != 1 || got[0] != wantNudge+"\r" {
+		t.Fatalf("PTY inputs = %q, want one nudge-prompt-plus-Enter write", got)
 	}
 
 	body := readInboxNote(t, d)
@@ -774,8 +775,8 @@ func TestNotebookSendToChiefNudgesWorkingChief(t *testing.T) {
 	mu.Lock()
 	n := len(inputs)
 	mu.Unlock()
-	if n != 2 {
-		t.Fatalf("PTY inputs = %d, want prompt plus Enter", n)
+	if n != 1 {
+		t.Fatalf("PTY inputs = %d, want one prompt-plus-Enter write", n)
 	}
 }
 

--- a/internal/daemon/nudge_countdown.go
+++ b/internal/daemon/nudge_countdown.go
@@ -8,7 +8,7 @@ import (
 )
 
 // defaultNudgeCountdownWindow is how long an armed ticket nudge waits — visible to
-// the user as a countdown — before the daemon doorbells an idle session. The user
+// the user as a countdown — before the daemon doorbells an eligible session. The user
 // can switch to the session and trigger it early, or let it elapse so attn delivers
 // it. It gates every ticket doorbell so a nudge is never a silent surprise.
 const defaultNudgeCountdownWindow = 30 * time.Second
@@ -173,7 +173,7 @@ func (d *Daemon) stopNudgeCountdowns() {
 }
 
 // nudgeCountdownFire is the deferred delivery. The identity check against the map
-// entry mirrors ticketBackstopFire: a countdown that lost a reschedule/cancel race
+// entry keeps a countdown that lost a reschedule/cancel race from delivering twice:
 // finds a different (or absent) timer and bails, keeping delivery to a single
 // doorbell. The entry is consumed here; deliverNudgeOrReArm decides what to do.
 func (d *Daemon) nudgeCountdownFire(sessionID string, self *time.Timer) {
@@ -202,8 +202,9 @@ func (d *Daemon) deliverNudgeOrReArm(sessionID string) {
 }
 
 // runNudgeDelivery is the fire-time decision, separated so its outcome is a single
-// string the test hook can assert. It doorbells only when the session is still idle,
-// not the active session, still has unread ticket activity, and — the splice guard —
+// string the test hook can assert. It doorbells only when the session is not waiting
+// for approval, is not the active session, still has unread ticket activity, and —
+// the splice guard —
 // has not received a genuine user keystroke within userInputGuardWindow. A keystroke
 // re-arms a fresh countdown rather than dropping the nudge: the user is mid-keystroke,
 // not gone.
@@ -212,8 +213,8 @@ func (d *Daemon) runNudgeDelivery(sessionID string) string {
 		return "noop"
 	}
 	session := d.store.Get(sessionID)
-	if session == nil || !isIdleForNudge(string(session.State)) {
-		return "not-idle"
+	if session == nil || !isNudgeDeliveryAllowed(string(session.State)) {
+		return "blocked"
 	}
 	if d.currentlySelectedSession() == sessionID {
 		// Became the active session during the window; switching away re-arms it.
@@ -244,11 +245,11 @@ func (d *Daemon) runNudgeDelivery(sessionID string) string {
 // updateNudgeSelection pauses the newly selected session's countdown and resumes the
 // previously selected one. Selection drives only this UX; the splice guard above is
 // what protects a second visible tile the user types into. The store read for the
-// idle check is done before taking nudgeMu to keep the lock ordering one-way.
+// approval check is done before taking nudgeMu to keep the lock ordering one-way.
 func (d *Daemon) updateNudgeSelection(oldID, newID string) {
 	resumeOld := false
 	if oldID != "" && oldID != newID && d.store != nil {
-		if s := d.store.Get(oldID); s != nil && isIdleForNudge(string(s.State)) {
+		if s := d.store.Get(oldID); s != nil && isNudgeDeliveryAllowed(string(s.State)) {
 			resumeOld = true
 		}
 	}
@@ -274,7 +275,7 @@ func (d *Daemon) updateNudgeSelection(oldID, newID string) {
 // refreshTicketUnread recomputes a session's unread ticket count and updates the
 // indicator. Called after an inbox consume (handleTicketInbox) and on each notify so
 // the indicator reflects reality for every agent — including self-monitoring Claude,
-// whose own watch drains the queue with no doorbell.
+// whose optional watch can drain the queue before the countdown doorbells.
 func (d *Daemon) refreshTicketUnread(sessionID string) {
 	if d.store == nil {
 		return
@@ -287,18 +288,17 @@ func (d *Daemon) refreshTicketUnread(sessionID string) {
 	d.markTicketUnread(sessionID, unread > 0)
 }
 
-// isExplicitNudgeBlocked reports the one state where a user's explicit click must NOT
-// doorbell: pending_approval. Typing the doorbell prompt + Enter into an approval
-// prompt could answer the approval — an unsafe, hard-to-undo side effect. Every other
-// state honors the click on demand (idle, waiting_input, working, unknown, launching):
-// an explicit click is unambiguous intent, so unlike the automatic countdown (which
-// stays idle-only) the user has chosen to deliver now regardless of the agent's state.
-func isExplicitNudgeBlocked(state string) bool {
-	return state == protocol.StatePendingApproval
+// isNudgeDeliveryAllowed is the sole session-state gate for every doorbell. A
+// pending approval is the only unsafe target because a trailing Enter could answer
+// it. Active, launching, unknown, idle, waiting-input, and scheduled sessions all
+// remain eligible; selection and recent-keypress checks are separate user-safety
+// mechanisms, not state policy.
+func isNudgeDeliveryAllowed(state string) bool {
+	return state != protocol.StatePendingApproval
 }
 
 // handleTriggerNudge is the user clicking the incoming-nudge indicator: deliver the
-// pending doorbell now, on demand, in any state but pending_approval. It is exempt
+// pending doorbell now, on demand, in any nudge-eligible state. It is exempt
 // from the keystroke guard — an explicit click is unambiguous intent — and respects
 // only unread (a click on a stale, already-drained indicator is a harmless no-op).
 func (d *Daemon) handleTriggerNudge(msg *protocol.TriggerNudgeMessage) {
@@ -311,7 +311,7 @@ func (d *Daemon) handleTriggerNudge(msg *protocol.TriggerNudgeMessage) {
 		return
 	}
 	session := d.store.Get(sessionID)
-	if session == nil || isExplicitNudgeBlocked(string(session.State)) {
+	if session == nil || !isNudgeDeliveryAllowed(string(session.State)) {
 		return
 	}
 	unread, err := d.ticketUnreadForSession(sessionID)

--- a/internal/daemon/nudge_countdown_test.go
+++ b/internal/daemon/nudge_countdown_test.go
@@ -47,9 +47,8 @@ func waitForNudge(t *testing.T, inputs func(string) []string, sessionID string) 
 	t.Fatalf("session %s was never doorbelled", sessionID)
 }
 
-// armForTest gives an idle codex agent an unread chief steer, which arms its nudge
-// countdown (codex is a non-self-monitor, so notify resolves to the immediate-nudge
-// path that now arms the countdown). Returns the agent id and inputs accessor.
+// armForTest gives an idle codex agent an unread chief steer, which arms its shared
+// nudge countdown. Returns the agent id and inputs accessor.
 func armForTest(t *testing.T, d *Daemon) (agentID string, inputs func(string) []string) {
 	t.Helper()
 	_, agentID, inputs = delegateForNotify(t, d, "codex")
@@ -139,10 +138,9 @@ func TestNudgeCountdownPausesOnSwitchTo(t *testing.T) {
 	}
 }
 
-// Leaving idle (the agent starts working) cancels the countdown — you don't count
-// down to nudge a working agent. Driven through a non-PTY state-broadcast path, since
-// codex/claude state is hook-owned and never flows through handlePTYState.
-func TestNudgeCountdownCanceledOnLeavingIdle(t *testing.T) {
+// Moving to another eligible state keeps the countdown armed. This covers the hook
+// path used by Codex and Claude, which does not flow through handlePTYState.
+func TestNudgeCountdownSurvivesEligibleStateChange(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour
 	t.Cleanup(d.stopNudgeCountdowns)
@@ -153,14 +151,47 @@ func TestNudgeCountdownCanceledOnLeavingIdle(t *testing.T) {
 
 	d.updateAndBroadcastState(agentID, protocol.StateWorking)
 
-	if currentNudgeTimer(d, agentID) != nil {
-		t.Fatal("countdown survived the agent leaving idle")
+	if currentNudgeTimer(d, agentID) == nil {
+		t.Fatal("countdown was canceled when the agent became active")
 	}
 }
 
-// Draining the inbox clears the indicator and cancels the countdown — the chokepoint
-// a self-monitoring agent's own watch drains through. After draining, nothing is
-// unread, so there is nothing to nudge.
+func TestNudgeCountdownCancelsOnPendingApproval(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Hour
+	t.Cleanup(d.stopNudgeCountdowns)
+	agentID, _ := armForTest(t, d)
+
+	d.updateAndBroadcastState(agentID, protocol.StatePendingApproval)
+
+	if currentNudgeTimer(d, agentID) != nil {
+		t.Fatal("countdown survived a pending approval prompt")
+	}
+}
+
+func TestNudgeDeliveryStatePolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state string
+		want  bool
+	}{
+		{name: "active green", state: protocol.StateWorking, want: true},
+		{name: "new initial", state: protocol.StateLaunching, want: true},
+		{name: "unknown", state: protocol.StateUnknown, want: true},
+		{name: "waiting for input", state: protocol.StateWaitingInput, want: true},
+		{name: "flashing approval", state: protocol.StatePendingApproval, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNudgeDeliveryAllowed(tc.state); got != tc.want {
+				t.Fatalf("isNudgeDeliveryAllowed(%q) = %v, want %v", tc.state, got, tc.want)
+			}
+		})
+	}
+}
+
+// Draining the inbox clears the indicator and cancels the countdown — including when
+// an optional runtime watch is the consumer. After draining, nothing is unread, so
+// there is nothing to nudge.
 func TestNudgeCountdownClearedWhenInboxDrained(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour

--- a/internal/daemon/nudge_countdown_test.go
+++ b/internal/daemon/nudge_countdown_test.go
@@ -20,9 +20,9 @@ func currentNudgeTimer(d *Daemon, sessionID string) *time.Timer {
 }
 
 // fireNudgeNow simulates the countdown timer firing immediately, by invoking the fire
-// callback with the live timer handle — the faithful deterministic path (mirrors the
-// backstop tests' hour-long-grace + fire-by-hand pattern). Tests that use it set an
-// hour-long window override so the real timer never races this hand-fire.
+// callback with the live timer handle — the faithful deterministic path. Tests that
+// use it set an hour-long window override so the real timer never races this
+// hand-fire.
 func fireNudgeNow(t *testing.T, d *Daemon, sessionID string) {
 	t.Helper()
 	timer := currentNudgeTimer(d, sessionID)
@@ -169,6 +169,56 @@ func TestNudgeCountdownCancelsOnPendingApproval(t *testing.T) {
 	}
 }
 
+func TestDoorbellWriteDoesNotInterleaveWithPendingApproval(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	sessionID := "doorbell-state-fence"
+	now := protocol.TimestampNow().String()
+	d.store.Add(&protocol.Session{
+		ID:             sessionID,
+		Label:          "doorbell-state-fence",
+		Agent:          protocol.SessionAgentCodex,
+		Directory:      t.TempDir(),
+		State:          protocol.SessionStateWorking,
+		StateSince:     now,
+		StateUpdatedAt: now,
+		LastSeen:       now,
+	})
+
+	inputStarted := make(chan struct{})
+	releaseInput := make(chan struct{})
+	inputs := make(chan string, 1)
+	d.ptyBackend = &fakeSpawnBackend{onInput: func(_ string, data []byte) {
+		inputs <- string(data)
+		close(inputStarted)
+		<-releaseInput
+	}}
+
+	doorbellDone := make(chan error, 1)
+	go func() { doorbellDone <- d.typeDoorbell(sessionID, ticketNudgePrompt) }()
+	<-inputStarted
+
+	stateDone := make(chan struct{})
+	go func() {
+		d.updateAndBroadcastState(sessionID, protocol.StatePendingApproval)
+		close(stateDone)
+	}()
+	select {
+	case <-stateDone:
+		t.Fatal("pending approval committed while a doorbell input was in flight")
+	case <-time.After(20 * time.Millisecond):
+		// The shared fence holds the state report until the complete input is sent.
+	}
+
+	close(releaseInput)
+	if err := <-doorbellDone; err != nil {
+		t.Fatalf("typeDoorbell() error = %v", err)
+	}
+	<-stateDone
+	if got := <-inputs; got != ticketNudgePrompt+"\r" {
+		t.Fatalf("doorbell input = %q, want one atomic prompt+Enter write", got)
+	}
+}
+
 func TestNudgeDeliveryStatePolicy(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -236,9 +286,9 @@ func TestTriggerNudgeFiresImmediately(t *testing.T) {
 	}
 }
 
-// An explicit click delivers even when the session rests in 'unknown' — codex's common
-// resting state when its turn-end classifier can't find a transcript. The auto
-// countdown stays idle-only, but the user's click is unambiguous intent.
+// An explicit click delivers when the session rests in 'unknown' — Codex's common
+// resting state when its turn-end classifier cannot find a transcript. Unknown is
+// also auto-nudge-eligible; the click simply bypasses the countdown.
 func TestTriggerNudgeDeliversWhenUnknown(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour
@@ -256,8 +306,8 @@ func TestTriggerNudgeDeliversWhenUnknown(t *testing.T) {
 	}
 }
 
-// An explicit click delivers on demand even while the agent is working — the user has
-// chosen to deliver now, and unlike the automatic countdown the click is not idle-gated.
+// An explicit click delivers on demand while the agent is working. Working is also
+// auto-nudge-eligible; the click simply bypasses the countdown.
 func TestTriggerNudgeDeliversWhileWorking(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour

--- a/internal/daemon/plugin_driver.go
+++ b/internal/daemon/plugin_driver.go
@@ -271,7 +271,9 @@ func validatePluginReportCursor(runID string, seq uint64) error {
 
 func (d *Daemon) applyPluginReportedState(params pluginReportStateParams) bool {
 	state := strings.TrimSpace(params.State)
-	if !d.store.ApplyAgentDriverState(params.SessionID, params.RunID, params.Seq, state) {
+	if !d.applyStateAndSyncNudge(params.SessionID, state, func() bool {
+		return d.store.ApplyAgentDriverState(params.SessionID, params.RunID, params.Seq, state)
+	}) {
 		d.logf("plugin state report discarded: session=%s run=%s seq=%d state=%s", params.SessionID, params.RunID, params.Seq, state)
 		return false
 	}

--- a/internal/daemon/plugin_driver_test.go
+++ b/internal/daemon/plugin_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/ptybackend"
@@ -372,6 +373,51 @@ func TestPluginDriverReports_StateStopAndMetadataAreOwnedByRegisteredAgent(t *te
 	})
 	if got := d.store.Get("snipe-report").State; got != protocol.SessionStateWaitingInput {
 		t.Fatalf("state=%q, want waiting_input", got)
+	}
+}
+
+func TestPluginReportedStateFlushesDeferredTicketNudge(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Hour
+	t.Cleanup(d.stopNudgeCountdowns)
+	_, sessionID, inputs := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, sessionID)
+	setSessionAgent(t, d, sessionID, protocol.SessionAgent("snipe"))
+	if !d.store.BeginAgentDriverRun(sessionID, "snipe-plugin", "run-nudge") {
+		t.Fatal("failed to begin plugin driver run")
+	}
+
+	if !d.applyPluginReportedState(pluginReportStateParams{
+		SessionID: sessionID,
+		RunID:     "run-nudge",
+		Seq:       1,
+		State:     protocol.StatePendingApproval,
+	}) {
+		t.Fatal("pending approval plugin report was rejected")
+	}
+	commentOnTicket(t, d, ticketID, "review this update")
+	if currentNudgeTimer(d, sessionID) != nil {
+		t.Fatal("pending approval plugin session armed a countdown")
+	}
+
+	if !d.applyPluginReportedState(pluginReportStateParams{
+		SessionID: sessionID,
+		RunID:     "run-nudge",
+		Seq:       2,
+		State:     protocol.StateWorking,
+	}) {
+		t.Fatal("working plugin report was rejected")
+	}
+	deadline := time.Now().Add(time.Second)
+	for currentNudgeTimer(d, sessionID) == nil && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if currentNudgeTimer(d, sessionID) == nil {
+		t.Fatal("eligible plugin state did not re-arm the deferred nudge")
+	}
+	fireNudgeNow(t, d, sessionID)
+	if !wasNudged(inputs(sessionID)) {
+		t.Fatal("eligible plugin session was not nudged after approval cleared")
 	}
 }
 

--- a/internal/daemon/present.go
+++ b/internal/daemon/present.go
@@ -499,7 +499,8 @@ func parsePresentNumstat(output string) map[string][2]int {
 // agent: it validates and stores the comments, marks the round submitted, and
 // — when handback is set — wakes the authoring agent up, either through a
 // ticket comment (ticket-bound presentations) or a direct doorbell (bare
-// sessions, best-effort: skipped, not queued, if the session is not idle).
+// sessions, best-effort: skipped, not queued, while the session waits for
+// approval).
 func (d *Daemon) handlePresentSubmitRound(client *wsClient, msg *protocol.PresentSubmitRoundMessage) {
 	result := protocol.PresentSubmitRoundResultMessage{
 		Event:   protocol.EventPresentSubmitRoundResult,
@@ -593,11 +594,11 @@ func (d *Daemon) handlePresentSubmitRound(client *wsClient, msg *protocol.Presen
 // handbackPresentationRound wakes the authoring agent once a round has been
 // submitted. Ticket-bound presentations get a durable ticket comment (queued
 // regardless of the session's state); bare sessions get a best-effort direct
-// doorbell that is silently skipped when the session is not idle — chunk-1's
-// accepted limitation, since a bare presentation has no durable inbox to fall
-// back on. verdict is verdict-aware wording: "approved" tells the agent the
-// round was approved (possibly with nits); "feedback" keeps the original
-// "submitted" wording.
+// doorbell that is silently skipped while the session waits for approval — the
+// accepted limitation for a bare presentation, which has no durable inbox to fall
+// back on. verdict is verdict-aware wording: "approved" tells the agent the round
+// was approved (possibly with nits); "feedback" keeps the original "submitted"
+// wording.
 func (d *Daemon) handbackPresentationRound(pres *store.Presentation, seq int, verdict string) {
 	var notice string
 	if verdict == "approved" {

--- a/internal/daemon/present.go
+++ b/internal/daemon/present.go
@@ -617,8 +617,8 @@ func (d *Daemon) handbackPresentationRound(pres *store.Presentation, seq int, ve
 	}
 
 	session := d.store.Get(pres.SessionID)
-	if session == nil || !isIdleForNudge(string(session.State)) || isExplicitNudgeBlocked(string(session.State)) {
-		d.logf("present handback: session %s not idle, skipping doorbell for presentation %s", pres.SessionID, pres.ID)
+	if session == nil || !isNudgeDeliveryAllowed(string(session.State)) {
+		d.logf("present handback: session %s is waiting for approval, skipping doorbell for presentation %s", pres.SessionID, pres.ID)
 		return
 	}
 	if err := d.typeDoorbell(pres.SessionID, "\U0001F4FD "+notice+"."); err != nil {

--- a/internal/daemon/present_test.go
+++ b/internal/daemon/present_test.go
@@ -105,6 +105,41 @@ func TestHandlePresentOpen_HappyPath(t *testing.T) {
 	}
 }
 
+func TestHandbackPresentationRoundNudgesEligibleBareSession(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state string
+		want  bool
+	}{
+		{name: "working", state: protocol.StateWorking, want: true},
+		{name: "launching", state: protocol.StateLaunching, want: true},
+		{name: "unknown", state: protocol.StateUnknown, want: true},
+		{name: "pending approval", state: protocol.StatePendingApproval, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			_, sessionID, inputs := delegateForNotify(t, d, "codex")
+			d.store.UpdateState(sessionID, tc.state)
+			pres, err := d.store.CreatePresentation(sessionID, nil, "Review", "changes", t.TempDir(), time.Now())
+			if err != nil {
+				t.Fatalf("CreatePresentation: %v", err)
+			}
+
+			d.handbackPresentationRound(pres, 1, "approved")
+			gotDoorbell := false
+			for _, input := range inputs(sessionID) {
+				if strings.Contains(input, "attn present feedback") {
+					gotDoorbell = true
+					break
+				}
+			}
+			if gotDoorbell != tc.want {
+				t.Fatalf("handback doorbell = %v, want %v for state %s", gotDoorbell, tc.want, tc.state)
+			}
+		})
+	}
+}
+
 // presentAnnotatedTestRepo creates a one-commit repo with a.txt containing
 // known lines, so tests can author manifests with anchor/line annotations
 // against predictable content.

--- a/internal/daemon/ticket_attach.go
+++ b/internal/daemon/ticket_attach.go
@@ -18,7 +18,7 @@ import (
 	"github.com/victorarias/attn/internal/store"
 )
 
-type stagedHandoverFile struct {
+type stagedAttachFile struct {
 	filename    string
 	stagedPath  string
 	destination string
@@ -26,36 +26,36 @@ type stagedHandoverFile struct {
 	installed   bool
 }
 
-type handoverFingerprintFile struct {
+type attachFingerprintFile struct {
 	Filename string `json:"filename"`
 	Hash     string `json:"hash"`
 }
 
-type handoverFingerprintInput struct {
-	Version  int                       `json:"version"`
-	TicketID string                    `json:"ticket_id"`
-	Files    []handoverFingerprintFile `json:"files"`
-	State    string                    `json:"state,omitempty"`
-	Comment  string                    `json:"comment,omitempty"`
+type attachFingerprintInput struct {
+	Version  int                     `json:"version"`
+	TicketID string                  `json:"ticket_id"`
+	Files    []attachFingerprintFile `json:"files"`
+	State    string                  `json:"state,omitempty"`
+	Comment  string                  `json:"comment,omitempty"`
 }
 
-// handleTicketHandover is the Unix-socket form used by the CLI and agents.
-func (d *Daemon) handleTicketHandover(conn net.Conn, msg *protocol.TicketHandoverMessage) {
-	result, err := d.submitTicketHandover(msg, strings.TrimSpace(msg.SourceSessionID), true)
+// handleTicketAttach is the Unix-socket form used by the CLI and agents.
+func (d *Daemon) handleTicketAttach(conn net.Conn, msg *protocol.TicketAttachMessage) {
+	result, err := d.submitTicketAttach(msg, strings.TrimSpace(msg.SourceSessionID), true)
 	if err != nil {
-		d.sendError(conn, "ticket handover: "+err.Error())
+		d.sendError(conn, "ticket attach: "+err.Error())
 		return
 	}
-	_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, TicketHandoverResult: result})
+	_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, TicketAttachResult: result})
 }
 
-// handleTicketHandoverWS is the in-app form. The human is the audited author and
+// handleTicketAttachWS is the in-app form. The human is the audited author and
 // must name the ticket explicitly.
-func (d *Daemon) handleTicketHandoverWS(client *wsClient, msg *protocol.TicketHandoverMessage) {
+func (d *Daemon) handleTicketAttachWS(client *wsClient, msg *protocol.TicketAttachMessage) {
 	requestID := protocol.Deref(msg.RequestID)
-	result, err := d.submitTicketHandover(msg, store.TicketAuthorYou, false)
-	reply := protocol.TicketHandoverResultMessage{
-		Event:     protocol.EventTicketHandoverResult,
+	result, err := d.submitTicketAttach(msg, store.TicketAuthorYou, false)
+	reply := protocol.TicketAttachResultMessage{
+		Event:     protocol.EventTicketAttachResult,
 		RequestID: requestID,
 		Success:   err == nil,
 		Result:    result,
@@ -66,7 +66,7 @@ func (d *Daemon) handleTicketHandoverWS(client *wsClient, msg *protocol.TicketHa
 	d.sendToClient(client, reply)
 }
 
-func (d *Daemon) submitTicketHandover(msg *protocol.TicketHandoverMessage, author string, resolveBound bool) (*protocol.TicketHandoverResult, error) {
+func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author string, resolveBound bool) (*protocol.TicketAttachResult, error) {
 	if strings.TrimSpace(author) == "" {
 		return nil, errors.New("source_session_id is required")
 	}
@@ -115,31 +115,31 @@ func (d *Daemon) submitTicketHandover(msg *protocol.TicketHandoverMessage, autho
 		return nil, err
 	}
 
-	staged, err := stageTicketHandoverFiles(dir, msg.Files)
+	staged, err := stageTicketAttachFiles(dir, msg.Files)
 	if err != nil {
 		return nil, err
 	}
-	defer removeHandoverStages(staged)
+	defer removeAttachStages(staged)
 
-	fingerprint, detail, err := handoverFingerprint(ticketID, staged, msg.State, comment)
+	fingerprint, detail, err := attachFingerprint(ticketID, staged, msg.State, comment)
 	if err != nil {
 		return nil, err
 	}
-	activityComment := handoverActivityComment(staged, comment)
+	activityComment := attachActivityComment(staged, comment)
 
 	d.ticketArtifactMu.Lock()
 	defer d.ticketArtifactMu.Unlock()
 
-	if err := validateHandoverDestinations(staged); err != nil {
+	if err := validateAttachDestinations(staged); err != nil {
 		return nil, err
 	}
-	if err := installHandoverFiles(staged); err != nil {
-		rollbackInstalledHandoverFiles(staged)
+	if err := installAttachFiles(staged); err != nil {
+		rollbackInstalledAttachFiles(staged)
 		return nil, err
 	}
-	record, err := d.store.SubmitTicketHandover(ticketID, author, fingerprint, detail, activityComment, status, time.Now())
+	record, err := d.store.SubmitTicketAttach(ticketID, author, fingerprint, detail, activityComment, status, time.Now())
 	if err != nil {
-		rollbackInstalledHandoverFiles(staged)
+		rollbackInstalledAttachFiles(staged)
 		return nil, err
 	}
 
@@ -158,7 +158,7 @@ func (d *Daemon) submitTicketHandover(msg *protocol.TicketHandoverMessage, autho
 	d.broadcastNotebookChanged(originAgent, changedPaths...)
 	d.broadcastFsChanged(originAgent, changedPaths...)
 
-	return &protocol.TicketHandoverResult{
+	return &protocol.TicketAttachResult{
 		TicketID:     ticketID,
 		Artifacts:    artifacts,
 		Fingerprint:  fingerprint,
@@ -168,17 +168,17 @@ func (d *Daemon) submitTicketHandover(msg *protocol.TicketHandoverMessage, autho
 	}, nil
 }
 
-func stageTicketHandoverFiles(dir string, files []protocol.TicketHandoverFile) ([]*stagedHandoverFile, error) {
+func stageTicketAttachFiles(dir string, files []protocol.TicketAttachFile) ([]*stagedAttachFile, error) {
 	seen := make(map[string]struct{}, len(files))
-	staged := make([]*stagedHandoverFile, 0, len(files))
+	staged := make([]*stagedAttachFile, 0, len(files))
 	for _, input := range files {
 		filename := filepath.Base(strings.TrimSpace(input.Filename))
 		if filename == "" || filename == "." || filename == ".." || strings.HasPrefix(filename, ".") || filepath.Ext(filename) != ".md" {
-			removeHandoverStages(staged)
+			removeAttachStages(staged)
 			return nil, fmt.Errorf("%q is not a visible Markdown filename", input.Filename)
 		}
 		if _, exists := seen[filename]; exists {
-			removeHandoverStages(staged)
+			removeAttachStages(staged)
 			return nil, fmt.Errorf("duplicate destination filename %q", filename)
 		}
 		seen[filename] = struct{}{}
@@ -186,22 +186,22 @@ func stageTicketHandoverFiles(dir string, files []protocol.TicketHandoverFile) (
 		source := strings.TrimSpace(input.SourcePath)
 		info, err := os.Lstat(source)
 		if err != nil {
-			removeHandoverStages(staged)
+			removeAttachStages(staged)
 			return nil, fmt.Errorf("read %q: %w", source, err)
 		}
 		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
-			removeHandoverStages(staged)
+			removeAttachStages(staged)
 			return nil, fmt.Errorf("%q is not a regular file", source)
 		}
 		in, err := os.Open(source)
 		if err != nil {
-			removeHandoverStages(staged)
+			removeAttachStages(staged)
 			return nil, err
 		}
-		stage, err := os.CreateTemp(dir, ".handover-*")
+		stage, err := os.CreateTemp(dir, ".attach-*")
 		if err != nil {
 			in.Close()
-			removeHandoverStages(staged)
+			removeAttachStages(staged)
 			return nil, err
 		}
 		hasher := sha256.New()
@@ -210,23 +210,23 @@ func stageTicketHandoverFiles(dir string, files []protocol.TicketHandoverFile) (
 		closeStageErr := stage.Close()
 		if copyErr != nil || closeInErr != nil || closeStageErr != nil {
 			_ = os.Remove(stage.Name())
-			removeHandoverStages(staged)
+			removeAttachStages(staged)
 			return nil, errors.Join(copyErr, closeInErr, closeStageErr)
 		}
-		staged = append(staged, &stagedHandoverFile{
+		staged = append(staged, &stagedAttachFile{
 			filename: filename, stagedPath: stage.Name(), destination: filepath.Join(dir, filename), hash: hex.EncodeToString(hasher.Sum(nil)),
 		})
 	}
 	return staged, nil
 }
 
-func handoverFingerprint(ticketID string, files []*stagedHandoverFile, state *protocol.DispatchWorkState, comment string) (string, string, error) {
-	payload := handoverFingerprintInput{Version: 1, TicketID: ticketID, Comment: comment}
+func attachFingerprint(ticketID string, files []*stagedAttachFile, state *protocol.DispatchWorkState, comment string) (string, string, error) {
+	payload := attachFingerprintInput{Version: 1, TicketID: ticketID, Comment: comment}
 	if state != nil {
 		payload.State = string(*state)
 	}
 	for _, file := range files {
-		payload.Files = append(payload.Files, handoverFingerprintFile{Filename: file.filename, Hash: file.hash})
+		payload.Files = append(payload.Files, attachFingerprintFile{Filename: file.filename, Hash: file.hash})
 	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {
@@ -237,7 +237,7 @@ func handoverFingerprint(ticketID string, files []*stagedHandoverFile, state *pr
 	return fingerprint, fingerprint + "\n" + string(encoded), nil
 }
 
-func handoverActivityComment(files []*stagedHandoverFile, comment string) string {
+func attachActivityComment(files []*stagedAttachFile, comment string) string {
 	names := make([]string, 0, len(files))
 	for _, file := range files {
 		names = append(names, file.filename)
@@ -249,7 +249,7 @@ func handoverActivityComment(files []*stagedHandoverFile, comment string) string
 	return text
 }
 
-func validateHandoverDestinations(files []*stagedHandoverFile) error {
+func validateAttachDestinations(files []*stagedAttachFile) error {
 	for _, file := range files {
 		data, err := os.ReadFile(file.destination)
 		if os.IsNotExist(err) {
@@ -266,7 +266,7 @@ func validateHandoverDestinations(files []*stagedHandoverFile) error {
 	return nil
 }
 
-func installHandoverFiles(files []*stagedHandoverFile) error {
+func installAttachFiles(files []*stagedAttachFile) error {
 	for _, file := range files {
 		if _, err := os.Stat(file.destination); err == nil {
 			continue
@@ -298,7 +298,7 @@ func installHandoverFiles(files []*stagedHandoverFile) error {
 	return nil
 }
 
-func rollbackInstalledHandoverFiles(files []*stagedHandoverFile) {
+func rollbackInstalledAttachFiles(files []*stagedAttachFile) {
 	for _, file := range files {
 		if file.installed {
 			data, err := os.ReadFile(file.destination)
@@ -313,7 +313,7 @@ func rollbackInstalledHandoverFiles(files []*stagedHandoverFile) {
 	}
 }
 
-func removeHandoverStages(files []*stagedHandoverFile) {
+func removeAttachStages(files []*stagedAttachFile) {
 	for _, file := range files {
 		if file.stagedPath != "" {
 			_ = os.Remove(file.stagedPath)

--- a/internal/daemon/ticket_attach_test.go
+++ b/internal/daemon/ticket_attach_test.go
@@ -14,34 +14,34 @@ import (
 	"github.com/victorarias/attn/internal/ticketnotify"
 )
 
-func callTicketHandover(t *testing.T, d *Daemon, msg *protocol.TicketHandoverMessage) protocol.Response {
+func callTicketAttach(t *testing.T, d *Daemon, msg *protocol.TicketAttachMessage) protocol.Response {
 	t.Helper()
 	server, client := net.Pipe()
 	defer client.Close()
 	done := make(chan struct{})
 	go func() {
-		d.handleTicketHandover(server, msg)
+		d.handleTicketAttach(server, msg)
 		_ = server.Close()
 		close(done)
 	}()
 	var resp protocol.Response
 	if err := json.NewDecoder(client).Decode(&resp); err != nil {
-		t.Fatalf("decode ticket handover response: %v", err)
+		t.Fatalf("decode ticket attach response: %v", err)
 	}
 	<-done
 	return resp
 }
 
-func handoverSource(t *testing.T, dir, name, content string) protocol.TicketHandoverFile {
+func attachSource(t *testing.T, dir, name, content string) protocol.TicketAttachFile {
 	t.Helper()
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-	return protocol.TicketHandoverFile{SourcePath: path, Filename: name}
+	return protocol.TicketAttachFile{SourcePath: path, Filename: name}
 }
 
-func TestTicketHandoverCopiesMultipleFilesAndChangesState(t *testing.T) {
+func TestTicketAttachCopiesMultipleFilesAndChangesState(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	notebookRoot := t.TempDir()
 	d.store.SetSetting(SettingNotebookRoot, notebookRoot)
@@ -51,20 +51,20 @@ func TestTicketHandoverCopiesMultipleFilesAndChangesState(t *testing.T) {
 	state := protocol.DispatchWorkStateReadyForReview
 	comment := "Storage choice is confirmed."
 
-	resp := callTicketHandover(t, d, &protocol.TicketHandoverMessage{
-		Cmd:             protocol.CmdTicketHandover,
+	resp := callTicketAttach(t, d, &protocol.TicketAttachMessage{
+		Cmd:             protocol.CmdTicketAttach,
 		SourceSessionID: agentID,
-		Files: []protocol.TicketHandoverFile{
-			handoverSource(t, sources, "design.md", "the design"),
-			handoverSource(t, sources, "rollout.md", "the rollout"),
+		Files: []protocol.TicketAttachFile{
+			attachSource(t, sources, "design.md", "the design"),
+			attachSource(t, sources, "rollout.md", "the rollout"),
 		},
 		State:   &state,
 		Comment: &comment,
 	})
-	if !resp.Ok || resp.TicketHandoverResult == nil {
-		t.Fatalf("response = %+v, want handover receipt", resp)
+	if !resp.Ok || resp.TicketAttachResult == nil {
+		t.Fatalf("response = %+v, want attach receipt", resp)
 	}
-	result := resp.TicketHandoverResult
+	result := resp.TicketAttachResult
 	if result.TicketID != ticketID || result.State != protocol.TicketStatusInReview || len(result.Artifacts) != 2 || result.EventSeq == 0 {
 		t.Fatalf("receipt = %+v", result)
 	}
@@ -83,35 +83,35 @@ func TestTicketHandoverCopiesMultipleFilesAndChangesState(t *testing.T) {
 	if ticket.Status != store.TicketStatusInReview {
 		t.Fatalf("ticket status = %s", ticket.Status)
 	}
-	var sawHandover bool
+	var sawAttach bool
 	for _, activity := range ticket.Activity {
-		if activity.Kind == store.TicketActivityHandover {
-			sawHandover = strings.Contains(activity.Comment, "design.md, rollout.md") && strings.Contains(activity.Comment, comment)
+		if activity.Kind == store.TicketActivityAttach {
+			sawAttach = strings.Contains(activity.Comment, "design.md, rollout.md") && strings.Contains(activity.Comment, comment)
 		}
 	}
-	if !sawHandover {
-		t.Fatalf("handover history missing: %+v", ticket.Activity)
+	if !sawAttach {
+		t.Fatalf("attach history missing: %+v", ticket.Activity)
 	}
 }
 
-func TestTicketHandoverRetryReturnsExistingReceipt(t *testing.T) {
+func TestTicketAttachRetryReturnsExistingReceipt(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.store.SetSetting(SettingNotebookRoot, t.TempDir())
 	_, agentID, _ := delegateForNotify(t, d, "codex")
-	source := handoverSource(t, t.TempDir(), "design.md", "same bytes")
-	msg := &protocol.TicketHandoverMessage{Cmd: protocol.CmdTicketHandover, SourceSessionID: agentID, Files: []protocol.TicketHandoverFile{source}}
+	source := attachSource(t, t.TempDir(), "design.md", "same bytes")
+	msg := &protocol.TicketAttachMessage{Cmd: protocol.CmdTicketAttach, SourceSessionID: agentID, Files: []protocol.TicketAttachFile{source}}
 
-	first := callTicketHandover(t, d, msg)
-	second := callTicketHandover(t, d, msg)
-	if !first.Ok || !second.Ok || first.TicketHandoverResult == nil || second.TicketHandoverResult == nil {
+	first := callTicketAttach(t, d, msg)
+	second := callTicketAttach(t, d, msg)
+	if !first.Ok || !second.Ok || first.TicketAttachResult == nil || second.TicketAttachResult == nil {
 		t.Fatalf("responses = %+v / %+v", first, second)
 	}
-	if second.TicketHandoverResult.Fingerprint != first.TicketHandoverResult.Fingerprint || second.TicketHandoverResult.EventSeq != first.TicketHandoverResult.EventSeq || !second.TicketHandoverResult.Deduplicated {
-		t.Fatalf("retry receipt = %+v, first = %+v", second.TicketHandoverResult, first.TicketHandoverResult)
+	if second.TicketAttachResult.Fingerprint != first.TicketAttachResult.Fingerprint || second.TicketAttachResult.EventSeq != first.TicketAttachResult.EventSeq || !second.TicketAttachResult.Deduplicated {
+		t.Fatalf("retry receipt = %+v, first = %+v", second.TicketAttachResult, first.TicketAttachResult)
 	}
 }
 
-func TestTicketHandoverPreservesDifferentExistingArtifact(t *testing.T) {
+func TestTicketAttachPreservesDifferentExistingArtifact(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	root := t.TempDir()
 	d.store.SetSetting(SettingNotebookRoot, root)
@@ -125,8 +125,8 @@ func TestTicketHandoverPreservesDifferentExistingArtifact(t *testing.T) {
 	if err := os.WriteFile(destination, []byte("keep me"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	source := handoverSource(t, t.TempDir(), "design.md", "replacement")
-	resp := callTicketHandover(t, d, &protocol.TicketHandoverMessage{Cmd: protocol.CmdTicketHandover, SourceSessionID: agentID, Files: []protocol.TicketHandoverFile{source}})
+	source := attachSource(t, t.TempDir(), "design.md", "replacement")
+	resp := callTicketAttach(t, d, &protocol.TicketAttachMessage{Cmd: protocol.CmdTicketAttach, SourceSessionID: agentID, Files: []protocol.TicketAttachFile{source}})
 	if resp.Ok || resp.Error == nil || !strings.Contains(*resp.Error, "different contents") {
 		t.Fatalf("response = %+v, want collision error", resp)
 	}
@@ -135,42 +135,42 @@ func TestTicketHandoverPreservesDifferentExistingArtifact(t *testing.T) {
 	}
 }
 
-func TestTicketHandoverSupportsExplicitTicketID(t *testing.T) {
+func TestTicketAttachSupportsExplicitTicketID(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.store.SetSetting(SettingNotebookRoot, t.TempDir())
 	if _, err := d.store.CreateTicket(store.Ticket{ID: "other-ticket", Title: "Other", Status: store.TicketStatusTodo}, "chief", time.Now()); err != nil {
 		t.Fatal(err)
 	}
 	ticketID := "other-ticket"
-	source := handoverSource(t, t.TempDir(), "plan.md", "plan")
-	resp := callTicketHandover(t, d, &protocol.TicketHandoverMessage{Cmd: protocol.CmdTicketHandover, SourceSessionID: "peer", TicketID: &ticketID, Files: []protocol.TicketHandoverFile{source}})
-	if !resp.Ok || resp.TicketHandoverResult == nil || resp.TicketHandoverResult.TicketID != ticketID {
+	source := attachSource(t, t.TempDir(), "plan.md", "plan")
+	resp := callTicketAttach(t, d, &protocol.TicketAttachMessage{Cmd: protocol.CmdTicketAttach, SourceSessionID: "peer", TicketID: &ticketID, Files: []protocol.TicketAttachFile{source}})
+	if !resp.Ok || resp.TicketAttachResult == nil || resp.TicketAttachResult.TicketID != ticketID {
 		t.Fatalf("response = %+v", resp)
 	}
 }
 
-func TestTicketHandoverDispatchesFromWebSocketAsUser(t *testing.T) {
+func TestTicketAttachDispatchesFromWebSocketAsUser(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.store.SetSetting(SettingNotebookRoot, t.TempDir())
 	if _, err := d.store.CreateTicket(store.Ticket{ID: "ui-ticket", Title: "UI", Status: store.TicketStatusWorking}, "chief", time.Now()); err != nil {
 		t.Fatal(err)
 	}
-	source := handoverSource(t, t.TempDir(), "plan.md", "plan")
+	source := attachSource(t, t.TempDir(), "plan.md", "plan")
 	client := newWorkspaceProtocolTestClient()
 	client.setIdentity("test", "protocol-"+protocol.ProtocolVersion, []string{protocol.CapabilityWorkspaceSessions})
-	payload, _ := json.Marshal(protocol.TicketHandoverMessage{
-		Cmd: protocol.CmdTicketHandover, SourceSessionID: store.TicketAuthorYou,
-		TicketID: protocol.Ptr("ui-ticket"), Files: []protocol.TicketHandoverFile{source}, RequestID: protocol.Ptr("h1"),
+	payload, _ := json.Marshal(protocol.TicketAttachMessage{
+		Cmd: protocol.CmdTicketAttach, SourceSessionID: store.TicketAuthorYou,
+		TicketID: protocol.Ptr("ui-ticket"), Files: []protocol.TicketAttachFile{source}, RequestID: protocol.Ptr("h1"),
 	})
 	d.handleClientMessage(client, payload)
-	var result protocol.TicketHandoverResultMessage
+	var result protocol.TicketAttachResultMessage
 	readNotebookWSEvent(t, client.send, &result)
 	if result.RequestID != "h1" || !result.Success || result.Result == nil || result.Result.TicketID != "ui-ticket" {
-		t.Fatalf("websocket handover = %+v", result)
+		t.Fatalf("websocket attach = %+v", result)
 	}
 }
 
-func TestTicketHandoverNotifiesChiefAndBroadcasts(t *testing.T) {
+func TestTicketAttachNotifiesChiefAndBroadcasts(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour
 	t.Cleanup(d.stopNudgeCountdowns)
@@ -185,10 +185,10 @@ func TestTicketHandoverNotifiesChiefAndBroadcasts(t *testing.T) {
 	d.store.UpdateState(chiefID, protocol.StateIdle)
 	d.store.UpdateState(agentID, protocol.StateIdle)
 	latestBroadcast := captureTicketBroadcasts(d)
-	source := handoverSource(t, t.TempDir(), "report.md", "findings")
-	resp := callTicketHandover(t, d, &protocol.TicketHandoverMessage{Cmd: protocol.CmdTicketHandover, SourceSessionID: agentID, Files: []protocol.TicketHandoverFile{source}})
+	source := attachSource(t, t.TempDir(), "report.md", "findings")
+	resp := callTicketAttach(t, d, &protocol.TicketAttachMessage{Cmd: protocol.CmdTicketAttach, SourceSessionID: agentID, Files: []protocol.TicketAttachFile{source}})
 	if !resp.Ok {
-		t.Fatalf("handover failed: %+v", resp)
+		t.Fatalf("attach failed: %+v", resp)
 	}
 	fireNudgeNow(t, d, chiefID)
 	if !wasNudged(inputs(chiefID)) || wasNudged(inputs(agentID)) {

--- a/internal/daemon/ticket_comment_test.go
+++ b/internal/daemon/ticket_comment_test.go
@@ -53,7 +53,6 @@ func callTicketComment(t *testing.T, d *Daemon, sessionID, ticketID, comment str
 // does not exist is a clear error rather than a silently dropped note.
 func TestHandleTicketCommentValidatesTicket(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	t.Cleanup(d.stopTicketBackstops)
 	_, agents, _ := delegateMany(t, d, "codex", "Task Y", "Task X")
 	z, x := agents[0], agents[1]
 	ticketY := boundTicketID(t, d, z)
@@ -80,7 +79,6 @@ func TestHandleTicketCommentValidatesTicket(t *testing.T) {
 func TestAgentCommentDoesNotSubscribeCommenter(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopTicketBackstops)
 	t.Cleanup(d.stopNudgeCountdowns)
 	_, agents, inputs := delegateMany(t, d, "codex", "Task Y", "Task X")
 	z, x := agents[0], agents[1] // z owns ticket Y; x owns its own ticket

--- a/internal/daemon/ticket_list_test.go
+++ b/internal/daemon/ticket_list_test.go
@@ -47,7 +47,6 @@ func ticketsByID(tickets []protocol.Ticket) map[string]protocol.Ticket {
 // each row carrying its description (the brief), not just a bare title.
 func TestHandleTicketListReturnsBoardWithoutSession(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	t.Cleanup(d.stopTicketBackstops)
 	_, agents, _ := delegateMany(t, d, "codex", "Task Y", "Task X")
 	wantY := boundTicketID(t, d, agents[0])
 	wantX := boundTicketID(t, d, agents[1])
@@ -76,7 +75,6 @@ func TestHandleTicketListReturnsBoardWithoutSession(t *testing.T) {
 // only the other — proving the filter reaches the store query, not just the wire.
 func TestHandleTicketListStatusFilter(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	t.Cleanup(d.stopTicketBackstops)
 	_, agents, _ := delegateMany(t, d, "codex", "Task Y", "Task X")
 	reviewing := boundTicketID(t, d, agents[0])
 	working := boundTicketID(t, d, agents[1])

--- a/internal/daemon/ticket_notify.go
+++ b/internal/daemon/ticket_notify.go
@@ -3,15 +3,14 @@ package daemon
 import (
 	"time"
 
-	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 	"github.com/victorarias/attn/internal/ticketnotify"
 )
 
-// ticketNudgePrompt is the fixed doorbell typed into an idle agent that cannot
-// self-monitor: a bounded "go look" trigger, never event content. The agent then
-// reads its own queue with `attn ticket inbox`. This is the doorbell rule — the
-// daemon signals, it never streams the message into the PTY.
+// ticketNudgePrompt is the fixed doorbell typed into a nudge-eligible agent: a
+// bounded "go look" trigger, never event content. The agent then reads its own
+// queue with `attn ticket inbox`. This is the doorbell rule — the daemon signals,
+// it never streams the message into the PTY.
 const ticketNudgePrompt = "📋 New ticket activity — run `attn ticket inbox` to catch up."
 
 // ticketNudger adapts the daemon's doorbell primitive to ticketnotify.Nudger.
@@ -28,10 +27,9 @@ func (n ticketNudger) Nudge(observerID string) error {
 // notifyTicketObservers runs the notification handler for every live session
 // involved with a ticket after an event lands on it. A producer blanket-notifies
 // without caring who caused the event: each observer sees only what it did not
-// author (Notify -> Unread), so the author never notifies itself. Self-monitoring
-// observers (Claude) resolve to DeliveryWatch — nothing injected, their own watch
-// drains it; an idle non-self-monitor (codex) gets the fixed doorbell; a busy one
-// is deferred until it next goes idle (see notifyTicketSessionWentIdle).
+// author (Notify -> Unread), so the author never notifies itself. All runtimes
+// share one delivery policy: only an approval prompt blocks a countdown. An optional
+// `ticket inbox --watch` may consume the unread activity before it rings.
 func (d *Daemon) notifyTicketObservers(ticketID string) {
 	if d.ptyBackend == nil || d.store == nil {
 		return
@@ -59,158 +57,30 @@ func (d *Daemon) notifyTicketObservers(ticketID string) {
 
 // notifyTicketSession runs Notify for one session's observer when it is a live
 // session. A participant that is not a live session — the attn crash author, or a
-// session already gone — is skipped: there is nothing to watch or nudge.
-//
-// DeliveryWatch for an idle session is where the self-monitor backstop hooks in:
-// the synchronous decision injects nothing (a live Monitor is assumed to be
-// draining), but nothing guarantees one is armed, so we schedule a deferred
-// re-check that doorbells only if the queue is still unread past the grace.
+// session already gone — is skipped: there is nothing to nudge.
 func (d *Daemon) notifyTicketSession(sessionID string, now time.Time) {
 	session := d.store.Get(sessionID)
 	if session == nil {
 		return
 	}
 	// Reflect unread ticket activity on the session for the indicator, independent of
-	// the delivery mechanism (nudge / self-monitor watch / deferred-until-idle), so a
-	// working agent and a self-monitoring Claude both surface the unread marker.
+	// the delivery mechanism, so an active agent and an optional watcher both surface
+	// the unread marker.
 	d.refreshTicketUnread(sessionID)
 	observers := d.ticketObserversForSession(sessionID)
-	idle := isIdleForNudge(string(session.State))
-	delivery, err := ticketnotify.NotifyAny(d.store, observers, observers[0], idle, ticketNudger{d}, now)
+	_, err := ticketnotify.NotifyAny(d.store, observers, observers[0], isNudgeDeliveryAllowed(string(session.State)), ticketNudger{d}, now)
 	if err != nil {
 		d.logf("ticket notify: %s: %v", sessionID, err)
+	}
+}
+
+// syncNudgeForState cancels a queued doorbell only while a session is waiting for
+// approval. Leaving that state rechecks unread activity so a previously deferred
+// nudge is armed as soon as it is safe.
+func (d *Daemon) syncNudgeForState(sessionID, state string) {
+	if !isNudgeDeliveryAllowed(state) {
+		d.cancelNudgeCountdown(sessionID, "waiting for approval")
 		return
 	}
-	if delivery == ticketnotify.DeliveryWatch && idle {
-		d.scheduleTicketBackstop(sessionID)
-	}
-}
-
-// defaultTicketBackstopGrace is how long the daemon waits before doorbelling an
-// idle self-monitor that still has unread ticket activity. It must exceed the
-// `attn ticket inbox --watch` poll interval (ticketWatchInterval in cmd/attn, 3s)
-// plus a round-trip margin: a live watch consumes the new event within one
-// interval, so by the grace its queue is drained and the backstop self-suppresses.
-// Keep these two constants in sync — shrinking the watch interval or growing it
-// past this grace reintroduces the redundant-doorbell collision.
-const defaultTicketBackstopGrace = 8 * time.Second
-
-// scheduleTicketBackstop arms (or resets) the per-session deferred re-check. It
-// debounces: a burst of events on a session's tickets collapses to one re-check,
-// always grace after the latest event. The timer carries its own handle so a fire
-// that lost a reschedule race can tell it has been superseded (ticketBackstopFire).
-func (d *Daemon) scheduleTicketBackstop(sessionID string) {
-	grace := d.ticketBackstopGrace
-	if grace <= 0 {
-		grace = defaultTicketBackstopGrace
-	}
-	d.ticketBackstopMu.Lock()
-	defer d.ticketBackstopMu.Unlock()
-	if d.ticketBackstopTimers == nil {
-		d.ticketBackstopTimers = make(map[string]*time.Timer)
-	}
-	if t, ok := d.ticketBackstopTimers[sessionID]; ok {
-		t.Stop()
-	}
-	// The AfterFunc needs its own *Timer to prove identity in ticketBackstopFire, but
-	// that is the value being assigned here. ready is the synchronization edge: the
-	// closure blocks until we publish `timer`, so its read happens-after the write
-	// (no data race) even if a tiny grace fires the timer immediately.
-	ready := make(chan struct{})
-	var timer *time.Timer
-	timer = time.AfterFunc(grace, func() {
-		<-ready
-		d.ticketBackstopFire(sessionID, timer)
-	})
-	d.ticketBackstopTimers[sessionID] = timer
-	close(ready)
-}
-
-// ticketBackstopFire is the deferred re-check. It doorbells the session iff it is
-// still idle and still has unread ticket activity — i.e. no live `--watch` Monitor
-// drained the queue during the grace. A live watch (or the session going busy, or
-// disappearing) leaves nothing to do. This is the only place an idle self-monitor
-// is ever typed into; the synchronous Notify path stays a no-op for it.
-//
-// self is the timer whose expiry triggered this call. If a later event already
-// rescheduled the backstop, the map holds a newer timer, so this stale fire bails
-// (the newer timer will fire) — that identity check is what keeps the debounce to a
-// single doorbell when a fire races a reschedule.
-func (d *Daemon) ticketBackstopFire(sessionID string, self *time.Timer) {
-	d.ticketBackstopMu.Lock()
-	current := d.ticketBackstopTimers[sessionID] == self
-	if current {
-		delete(d.ticketBackstopTimers, sessionID)
-	}
-	d.ticketBackstopMu.Unlock()
-	if current {
-		d.ticketBackstopRecheck(sessionID)
-	}
-}
-
-// ticketBackstopRecheck arms a nudge countdown for the session iff it is still idle
-// and still has unread ticket activity — i.e. no live `--watch` Monitor drained the
-// queue during the grace. A live watch (or the session going busy, or disappearing)
-// leaves nothing to do. This is the self-monitor's entry into the countdown; the
-// synchronous Notify path stays a no-op for it, and the countdown owns the actual
-// doorbell.
-func (d *Daemon) ticketBackstopRecheck(sessionID string) {
-	if d.ptyBackend == nil || d.store == nil {
-		return
-	}
-	session := d.store.Get(sessionID)
-	if session == nil || !isIdleForNudge(string(session.State)) {
-		return
-	}
-	unread, err := d.ticketUnreadForSession(sessionID)
-	if err != nil {
-		d.logf("ticket backstop: %s: %v", sessionID, err)
-		return
-	}
-	if unread == 0 {
-		return
-	}
-	// The self-monitor's own watch did not drain the queue within the grace, so fall
-	// through to the same visible countdown every nudge uses rather than doorbelling
-	// straight into the PTY.
-	d.armNudgeCountdown(sessionID)
-}
-
-// stopTicketBackstops cancels every pending backstop re-check. Daemon.Stop() calls
-// it so no AfterFunc goroutine outlives teardown.
-func (d *Daemon) stopTicketBackstops() {
-	d.ticketBackstopMu.Lock()
-	defer d.ticketBackstopMu.Unlock()
-	for id, t := range d.ticketBackstopTimers {
-		t.Stop()
-		delete(d.ticketBackstopTimers, id)
-	}
-}
-
-// cancelTicketBackstop removes one session's pending self-monitor re-check. Role
-// transfer uses it so a displaced chief cannot receive a stale role doorbell.
-func (d *Daemon) cancelTicketBackstop(sessionID string) {
-	d.ticketBackstopMu.Lock()
-	if timer := d.ticketBackstopTimers[sessionID]; timer != nil {
-		timer.Stop()
-		delete(d.ticketBackstopTimers, sessionID)
-	}
-	d.ticketBackstopMu.Unlock()
-}
-
-// notifyTicketSessionWentIdle flushes a deferred nudge: a non-self-monitor that was
-// busy when an event landed gets its doorbell the moment it goes idle. Called from
-// the state-transition path. A no-op when nothing is unread (so an agent that has
-// already consumed is never re-nudged).
-func (d *Daemon) notifyTicketSessionWentIdle(sessionID string) {
-	if d.ptyBackend == nil || d.store == nil {
-		return
-	}
-	d.notifyTicketSession(sessionID, time.Now())
-}
-
-// isIdleForNudge reports whether a session is at rest enough to receive a doorbell
-// without interrupting work — the same guard the chief doorbell uses.
-func isIdleForNudge(state string) bool {
-	return state == protocol.StateIdle || state == protocol.StateWaitingInput
+	go d.notifyTicketSession(sessionID, time.Now())
 }

--- a/internal/daemon/ticket_notify.go
+++ b/internal/daemon/ticket_notify.go
@@ -84,3 +84,19 @@ func (d *Daemon) syncNudgeForState(sessionID, state string) {
 	}
 	go d.notifyTicketSession(sessionID, time.Now())
 }
+
+// applyStateAndSyncNudge serializes an authoritative session-state write with a
+// complete doorbell input. The lock establishes one order when a session reaches an
+// approval prompt at the same time a countdown wants to send Enter: either the
+// eligible doorbell is fully written first, or the approval state is committed first
+// and the doorbell is suppressed. The follow-up reconciliation runs outside the lock
+// because it may read tickets and arm timers.
+func (d *Daemon) applyStateAndSyncNudge(sessionID, state string, apply func() bool) bool {
+	d.doorbellMu.Lock()
+	applied := apply()
+	d.doorbellMu.Unlock()
+	if applied {
+		d.syncNudgeForState(sessionID, state)
+	}
+	return applied
+}

--- a/internal/daemon/ticket_notify_test.go
+++ b/internal/daemon/ticket_notify_test.go
@@ -47,18 +47,13 @@ func delegateForNotify(t *testing.T, d *Daemon, agent string) (chiefID, agentID 
 	return chiefID, result.SessionID, inputs
 }
 
-// makeSelfMonitor flips a session's stored agent to Claude so it resolves to
-// HasSelfMonitor=true through ticketObserverForSession. The harness delegation
-// source spawns as a shell (the test default), but the production chief of staff is
-// Claude — the only kind of session that takes the DeliveryWatch backstop path. Use
-// this to model the real chief in backstop tests.
-func makeSelfMonitor(t *testing.T, d *Daemon, sessionID string) {
+func setSessionAgent(t *testing.T, d *Daemon, sessionID string, agent protocol.SessionAgent) {
 	t.Helper()
 	s := d.store.Get(sessionID)
 	if s == nil {
-		t.Fatalf("makeSelfMonitor: session %s not found", sessionID)
+		t.Fatalf("setSessionAgent: session %s not found", sessionID)
 	}
-	s.Agent = protocol.SessionAgentClaude
+	s.Agent = agent
 	d.store.Add(s)
 }
 
@@ -113,51 +108,41 @@ func wasNudged(inputs []string) bool {
 	return false
 }
 
-// An idle agent that can't self-monitor (codex) gets the fixed doorbell when an
-// event it did not author is unread — here a chief steer on its ticket. Its own
-// brief is delivered via the spawn prompt and pre-consumed at delegation, so it is
-// never the trigger (see TestDelegatedAgentNotNudgedByOwnDeliveredBrief).
-func TestNotifyNudgesIdleCodexObserver(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Hour // hand-fire the countdown deterministically
-	t.Cleanup(d.stopNudgeCountdowns)
-	_, agentID, inputs := delegateForNotify(t, d, "codex")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateIdle)
-
-	// A chief steer lands on the agent's ticket — an event it did not author.
-	commentOnTicket(t, d, ticketID, "take a look at the failing test")
-
-	// The doorbell is now gated behind a (paused-while-active) countdown; the session
-	// is inactive here, so firing the countdown delivers it.
-	fireNudgeNow(t, d, agentID)
-	if !wasNudged(inputs(agentID)) {
-		t.Fatal("idle codex agent was not nudged about the chief steer on its ticket")
+// Every runtime receives the same nudge for an eligible delegated leaf: active
+// (green), launching (new), and unknown states all arm the visible countdown.
+func TestNotifyNudgesEligibleLeavesAcrossRuntimes(t *testing.T) {
+	states := []struct {
+		name  string
+		state protocol.SessionState
+	}{
+		{name: "active green", state: protocol.SessionStateWorking},
+		{name: "new initial", state: protocol.SessionStateLaunching},
+		{name: "unknown", state: protocol.SessionStateUnknown},
 	}
-}
+	for _, runtime := range []string{"codex", "claude"} {
+		for _, tc := range states {
+			t.Run(runtime+"/"+tc.name, func(t *testing.T) {
+				d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+				d.nudgeWindowOverride = time.Hour
+				t.Cleanup(d.stopNudgeCountdowns)
+				_, agentID, inputs := delegateForNotify(t, d, runtime)
+				ticketID := boundTicketID(t, d, agentID)
+				d.store.UpdateState(agentID, string(tc.state))
 
-// A self-monitoring agent (claude) is never typed into synchronously even with unread
-// activity — its own watch drains the queue (DeliveryWatch), so the doorbell would be
-// a redundant interruption. A real chief steer supplies the unread event (the brief is
-// pre-consumed at delegation, so without a steer there would be nothing to decide on).
-func TestNotifyDoesNotNudgeClaudeObserver(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	t.Cleanup(d.stopTicketBackstops) // idle self-monitor schedules a deferred backstop
-	_, agentID, inputs := delegateForNotify(t, d, "claude")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateIdle)
-
-	commentOnTicket(t, d, ticketID, "one more thing")
-
-	if wasNudged(inputs(agentID)) {
-		t.Fatal("self-monitoring claude agent should not be typed into synchronously")
+				commentOnTicket(t, d, ticketID, "take a look at the failing test")
+				fireNudgeNow(t, d, agentID)
+				if !wasNudged(inputs(agentID)) {
+					t.Fatalf("%s delegated leaf was not nudged", runtime)
+				}
+			})
+		}
 	}
 }
 
 // Full slice-6 roundtrip: a real chief producer (the human commenting on the
 // agent's bound ticket via handleTicketAddComment) drives notifyTicketObservers,
-// which nudges the idle codex agent (DeliveryNudge, because the codex driver's
-// HasSelfMonitor capability is false, resolved through ticketObserverForSession).
+// which nudges the codex agent through the same shared delivery policy as every
+// other runtime.
 // The agent then runs `attn ticket inbox`, consumes the chief's event, and a
 // second inbox is empty because the cursor advanced — proving it consumed, not
 // peeked. No real codex binary or PTY: the fake spawn backend captures the doorbell.
@@ -206,30 +191,32 @@ func TestCodexNudgeRoundtrip(t *testing.T) {
 	}
 }
 
-// A busy codex agent is deferred — no doorbell mid-task — then gets it the moment
-// it goes idle, which is what notifyTicketSessionWentIdle flushes. A real chief steer
-// landing while the agent is busy supplies the unread event.
-func TestNotifyDefersBusyCodexThenFlushesOnIdle(t *testing.T) {
+// Approval prompts are the sole deferral state. Once the prompt clears, unread
+// activity is rechecked and armed even when the agent returns to active/green.
+func TestNotifyDefersPendingApprovalThenFlushesOnWorking(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour
 	t.Cleanup(d.stopNudgeCountdowns)
 	_, agentID, inputs := delegateForNotify(t, d, "codex")
 	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateWorking)
+	d.store.UpdateState(agentID, protocol.StatePendingApproval)
 
-	commentOnTicket(t, d, ticketID, "take a look") // lands mid-task -> deferred, no countdown
+	commentOnTicket(t, d, ticketID, "take a look")
 	if wasNudged(inputs(agentID)) {
-		t.Fatal("busy codex agent was nudged mid-task")
+		t.Fatal("approval-waiting codex agent was nudged")
 	}
 	if currentNudgeTimer(d, agentID) != nil {
-		t.Fatal("busy codex agent armed a countdown mid-task")
+		t.Fatal("approval-waiting codex agent armed a countdown")
 	}
 
-	d.store.UpdateState(agentID, protocol.StateIdle)
-	d.notifyTicketSessionWentIdle(agentID) // settling arms the countdown
+	d.updateAndBroadcastState(agentID, protocol.StateWorking)
+	deadline := time.Now().Add(time.Second)
+	for currentNudgeTimer(d, agentID) == nil && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
 	fireNudgeNow(t, d, agentID)
 	if !wasNudged(inputs(agentID)) {
-		t.Fatal("deferred nudge was not flushed when the agent went idle")
+		t.Fatal("deferred nudge was not flushed when approval cleared")
 	}
 }
 
@@ -240,7 +227,6 @@ func TestNotifyDefersBusyCodexThenFlushesOnIdle(t *testing.T) {
 // that makes "agent A is nudged about ticket C" impossible by construction.
 func TestDelegatedSiblingsNotNudgedByEachOther(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	t.Cleanup(d.stopTicketBackstops)
 	_, agents, inputs := delegateMany(t, d, "codex", "Task A", "Task B", "Task C")
 	a, b, c := agents[0], agents[1], agents[2]
 	for _, id := range agents {
@@ -268,14 +254,13 @@ func TestDelegatedSiblingsNotNudgedByEachOther(t *testing.T) {
 // the assignee at creation, so nothing is unread and no doorbell fires.
 func TestDelegatedAgentNotNudgedByOwnDeliveredBrief(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	t.Cleanup(d.stopTicketBackstops)
 	_, agents, inputs := delegateMany(t, d, "codex", "Task A")
 	a := agents[0]
 	d.store.UpdateState(a, protocol.StateIdle)
 
 	// The agent settles after its initial run; the went-idle path re-runs the notify
 	// decision for it. With the brief consumed at delegation, there is nothing unread.
-	d.notifyTicketSessionWentIdle(a)
+	d.notifyTicketSession(a, time.Now())
 
 	if wasNudged(inputs(a)) {
 		t.Fatal("delegated agent was doorbelled about its own already-delivered brief")
@@ -296,67 +281,32 @@ func commentOnTicket(t *testing.T, d *Daemon, ticketID, comment string) {
 	})
 }
 
-// The self-monitor backstop: an idle self-monitor with unread ticket activity that
-// no live `--watch` Monitor drained gets the doorbell from the deferred re-check —
-// the case the synchronous DeliveryWatch no-op leaves silent, fired here directly.
-//
-// The subject is a delegated Claude agent. It exercises the exact production path
-// the chief takes: ticketObserverForSession -> HasSelfMonitor=true. The backstop is
-// keyed on that capability, not on being the chief, so this also proves the
-// "applies to all agents if Claude didn't use the monitor" intent — the harness
-// chief is a shell (non-self-monitor), so a delegated Claude agent is the faithful
-// self-monitor subject.
-func TestTicketBackstopDoorbellsIdleSelfMonitorWithUnread(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopTicketBackstops)
-	t.Cleanup(d.stopNudgeCountdowns)
-	_, agentID, inputs := delegateForNotify(t, d, "claude")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateWorking) // no schedule during the steer
-	commentOnTicket(t, d, ticketID, "take a look at the failing test")
-	d.store.UpdateState(agentID, protocol.StateIdle)
+// The shared policy also covers chiefs. A report from a delegated agent wakes an
+// active chief regardless of whether the chief runs Codex or Claude.
+func TestTicketNudgesActiveChiefAcrossRuntimes(t *testing.T) {
+	for _, runtime := range []protocol.SessionAgent{protocol.SessionAgentCodex, protocol.SessionAgentClaude} {
+		t.Run(string(runtime), func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+			d.nudgeWindowOverride = time.Hour
+			t.Cleanup(d.stopNudgeCountdowns)
+			chiefID, agentID, inputs := delegateForNotify(t, d, "codex")
+			setSessionAgent(t, d, chiefID, runtime)
+			d.store.UpdateState(chiefID, protocol.StateWorking)
+			d.setSelectedSession(agentID) // preserve the focused-session anti-splice pause
 
-	d.ticketBackstopRecheck(agentID) // arms the countdown
-	fireNudgeNow(t, d, agentID)
-
-	if !wasNudged(inputs(agentID)) {
-		t.Fatal("idle self-monitor with unread was not doorbelled by the backstop")
-	}
-}
-
-// The headline scenario this whole mechanism exists for: the chief of staff
-// delegates, goes idle, and its delegate later reports ready-for-review. The chief
-// is a self-monitor (Claude in production), so the synchronous notify resolves to
-// DeliveryWatch — a no-op that, on its own, leaves the idle chief unaware the work
-// came back (exactly the gap Victor hit). The deferred backstop closes it: the
-// report schedules a re-check that doorbells the still-idle chief after the grace.
-// This drives the full chain — agent reports -> notify -> schedule -> fire ->
-// doorbell — against the real chief subject, with a tiny grace for a fast timer. The
-// agent that authored the report is never doorbelled about its own status change.
-func TestTicketBackstopDoorbellsIdleChiefAfterAgentReports(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.ticketBackstopGrace = 15 * time.Millisecond
-	d.nudgeWindowOverride = 15 * time.Millisecond // backstop -> countdown both fire fast
-	t.Cleanup(d.stopTicketBackstops)
-	t.Cleanup(d.stopNudgeCountdowns)
-	chiefID, agentID, inputs := delegateForNotify(t, d, "claude")
-	makeSelfMonitor(t, d, chiefID)                   // the production chief is Claude; the harness default is shell
-	d.store.UpdateState(chiefID, protocol.StateIdle) // delegated, then went idle waiting
-
-	// The delegate reports ready-for-review: an event the idle chief did not author,
-	// so it is unread for the chief — the signal the chief's DeliveryWatch no-op drops.
-	callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateReadyForReview), "done, please review")
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && !wasNudged(inputs(chiefID)) {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if !wasNudged(inputs(chiefID)) {
-		t.Fatal("idle Claude chief was never doorbelled after its delegate reported back")
-	}
-	if wasNudged(inputs(agentID)) {
-		t.Fatal("the reporting agent was doorbelled about its own status change")
+			callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateReadyForReview), "done, please review")
+			deadline := time.Now().Add(time.Second)
+			for currentNudgeTimer(d, chiefID) == nil && time.Now().Before(deadline) {
+				time.Sleep(time.Millisecond)
+			}
+			fireNudgeNow(t, d, chiefID)
+			if !wasNudged(inputs(chiefID)) {
+				t.Fatalf("active %s chief was not nudged", runtime)
+			}
+			if wasNudged(inputs(agentID)) {
+				t.Fatal("the reporting agent was nudged about its own status change")
+			}
+		})
 	}
 }
 
@@ -367,7 +317,6 @@ func TestTicketBackstopDoorbellsIdleChiefAfterAgentReports(t *testing.T) {
 func TestChiefTicketContinuityAcrossRoleTransfer(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopTicketBackstops)
 	t.Cleanup(d.stopNudgeCountdowns)
 	chiefA, agentID, inputs := delegateForNotify(t, d, "codex")
 	ticketID := boundTicketID(t, d, agentID)
@@ -429,7 +378,6 @@ func TestChiefTicketContinuityAcrossRoleTransfer(t *testing.T) {
 // deduplicated while both cursors advance.
 func TestChiefRoleAndExplicitSubscriptionDeliverOnce(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	t.Cleanup(d.stopTicketBackstops)
 	chiefID, agentID, _ := delegateForNotify(t, d, "codex")
 	ticketID := boundTicketID(t, d, agentID)
 	if resp := callTicketSubscribe(t, d, chiefID, ticketID); !resp.Ok {
@@ -446,70 +394,27 @@ func TestChiefRoleAndExplicitSubscriptionDeliverOnce(t *testing.T) {
 	}
 }
 
-// Composition with A: if a live `--watch` Monitor already drained the inbox (the
-// cursor advanced), the deferred re-check sees nothing unread and self-suppresses,
-// so an actively-watching self-monitor is never double-notified.
-func TestTicketBackstopSuppressedAfterWatchDrains(t *testing.T) {
+// A Claude `ticket inbox --watch` remains a valid optional consumer. It drains the
+// same queue and clears the shared countdown before the doorbell fires.
+func TestTicketWatchDrainClearsSharedCountdown(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	t.Cleanup(d.stopTicketBackstops)
-	_, agentID, inputs := delegateForNotify(t, d, "claude")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateWorking)
-	commentOnTicket(t, d, ticketID, "take a look")
-	d.store.UpdateState(agentID, protocol.StateIdle)
-
-	// Simulate `attn ticket inbox --watch` draining the agent's queue.
-	callTicketInbox(t, d, agentID)
-
-	d.ticketBackstopRecheck(agentID)
-
-	if wasNudged(inputs(agentID)) {
-		t.Fatal("backstop doorbelled a self-monitor whose watch already drained the inbox")
-	}
-}
-
-// A busy self-monitor is never doorbelled by the backstop — it is working, not
-// missing the event. The re-check is a no-op until the session is at rest.
-func TestTicketBackstopSuppressedWhenBusy(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	t.Cleanup(d.stopTicketBackstops)
-	_, agentID, inputs := delegateForNotify(t, d, "claude")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateWorking)
-	commentOnTicket(t, d, ticketID, "take a look") // lands while busy -> no schedule
-
-	d.ticketBackstopRecheck(agentID)
-
-	if wasNudged(inputs(agentID)) {
-		t.Fatal("backstop doorbelled a busy self-monitor")
-	}
-}
-
-// End-to-end scheduling: the synchronous notify for an idle self-monitor schedules
-// the deferred backstop, which fires after the grace and doorbells. Uses a tiny
-// grace override so the timer is fast and deterministic.
-func TestNotifySchedulesBackstopForIdleSelfMonitor(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.ticketBackstopGrace = 15 * time.Millisecond
-	d.nudgeWindowOverride = 15 * time.Millisecond
-	t.Cleanup(d.stopTicketBackstops)
+	d.nudgeWindowOverride = time.Hour
 	t.Cleanup(d.stopNudgeCountdowns)
 	_, agentID, inputs := delegateForNotify(t, d, "claude")
 	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateIdle)
+	d.store.UpdateState(agentID, protocol.StateWorking)
 
-	// A steer lands while the agent is idle: the synchronous notify resolves to
-	// DeliveryWatch and schedules the backstop (grace 15ms).
-	commentOnTicket(t, d, ticketID, "one more thing")
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if wasNudged(inputs(agentID)) {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+	commentOnTicket(t, d, ticketID, "take a look")
+	if currentNudgeTimer(d, agentID) == nil {
+		t.Fatal("shared countdown was not armed for Claude")
 	}
-	t.Fatal("scheduled backstop never doorbelled the idle self-monitor")
+	callTicketInbox(t, d, agentID) // equivalent to the watch's consuming poll
+	if currentNudgeTimer(d, agentID) != nil {
+		t.Fatal("watch drain did not clear the shared countdown")
+	}
+	if wasNudged(inputs(agentID)) {
+		t.Fatal("watch-drained queue was still doorbelled")
+	}
 }
 
 // nudgeCount counts how many doorbells (ticketNudgePrompt inputs) a session got.
@@ -521,121 +426,4 @@ func nudgeCount(inputs []string) int {
 		}
 	}
 	return n
-}
-
-func currentBackstopTimer(d *Daemon, sessionID string) *time.Timer {
-	d.ticketBackstopMu.Lock()
-	defer d.ticketBackstopMu.Unlock()
-	return d.ticketBackstopTimers[sessionID]
-}
-
-// Race regression: a backstop timer that was superseded by a reschedule must NOT
-// doorbell when it later fires — only the current timer does. Without the timer
-// identity guard, the stale fire would both evict the live timer's map entry and
-// doorbell, producing the double-doorbell the deferred design exists to prevent.
-// Driven deterministically with an hour-long grace so no real timer fires; the fire
-// callbacks are invoked by hand with the captured handles.
-func TestTicketBackstopStaleTimerDoesNotDoorbell(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.ticketBackstopGrace = time.Hour
-	d.nudgeWindowOverride = time.Hour // hand-fire the armed countdown too
-	t.Cleanup(d.stopTicketBackstops)
-	t.Cleanup(d.stopNudgeCountdowns)
-	_, agentID, inputs := delegateForNotify(t, d, "claude")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateWorking)
-	commentOnTicket(t, d, ticketID, "take a look") // lands while busy -> no schedule
-	d.store.UpdateState(agentID, protocol.StateIdle)
-
-	d.scheduleTicketBackstop(agentID)
-	stale := currentBackstopTimer(d, agentID)
-	d.scheduleTicketBackstop(agentID) // reschedule supersedes `stale`
-	current := currentBackstopTimer(d, agentID)
-	if stale == nil || current == nil || stale == current {
-		t.Fatalf("reschedule did not replace the timer: stale=%p current=%p", stale, current)
-	}
-
-	d.ticketBackstopFire(agentID, stale) // superseded: must bail, arming nothing
-	if currentNudgeTimer(d, agentID) != nil {
-		t.Fatal("a superseded backstop timer armed a nudge countdown")
-	}
-	if wasNudged(inputs(agentID)) {
-		t.Fatal("a superseded backstop timer doorbelled the session (double-doorbell race)")
-	}
-
-	d.ticketBackstopFire(agentID, current) // current: arms the countdown
-	fireNudgeNow(t, d, agentID)            // which doorbells exactly once
-	if n := nudgeCount(inputs(agentID)); n != 1 {
-		t.Fatalf("current backstop timer doorbelled %d times, want exactly 1", n)
-	}
-}
-
-// Debounce: a burst of events while the agent is idle reschedules the backstop each
-// time, collapsing to exactly ONE pending timer — firing it doorbells once, not once
-// per event. Driven deterministically with an hour-long grace so no real timer fires
-// mid-burst and the single surviving timer is fired by hand: this asserts the
-// debounce invariant (N reschedules -> one timer -> one doorbell) without depending
-// on wall-clock timing. The end-to-end "a scheduled timer actually fires on its own"
-// path is covered by TestNotifySchedulesBackstopForIdleSelfMonitor.
-func TestTicketBackstopDebouncesBurst(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.ticketBackstopGrace = time.Hour
-	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopTicketBackstops)
-	t.Cleanup(d.stopNudgeCountdowns)
-	_, agentID, inputs := delegateForNotify(t, d, "claude")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateIdle)
-
-	commentOnTicket(t, d, ticketID, "take a look") // unread + first schedule
-	for i := 0; i < 3; i++ {
-		d.notifyTicketObservers(ticketID) // each reschedules, replacing the prior timer
-	}
-
-	// The burst left exactly one pending timer and no premature doorbell.
-	if wasNudged(inputs(agentID)) {
-		t.Fatal("burst doorbelled the self-monitor before any grace elapsed")
-	}
-	timer := currentBackstopTimer(d, agentID)
-	if timer == nil {
-		t.Fatal("burst left no pending backstop timer")
-	}
-
-	// Firing that single surviving timer arms one countdown, which doorbells once.
-	d.ticketBackstopFire(agentID, timer)
-	fireNudgeNow(t, d, agentID)
-	if n := nudgeCount(inputs(agentID)); n != 1 {
-		t.Fatalf("burst produced %d doorbells, want exactly 1 (debounced)", n)
-	}
-}
-
-// The went-idle path schedules the backstop: an event that lands while the agent is
-// busy schedules nothing, but when the agent later settles, notifyTicketSessionWentIdle
-// re-runs the decision and arms the backstop, which then fires.
-func TestTicketBackstopScheduledOnWentIdle(t *testing.T) {
-	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	d.ticketBackstopGrace = 20 * time.Millisecond
-	d.nudgeWindowOverride = 20 * time.Millisecond
-	t.Cleanup(d.stopTicketBackstops)
-	t.Cleanup(d.stopNudgeCountdowns)
-	_, agentID, inputs := delegateForNotify(t, d, "claude")
-	ticketID := boundTicketID(t, d, agentID)
-	d.store.UpdateState(agentID, protocol.StateWorking)
-
-	commentOnTicket(t, d, ticketID, "take a look") // lands while busy -> no schedule
-	if currentBackstopTimer(d, agentID) != nil {
-		t.Fatal("backstop scheduled while the agent was busy")
-	}
-
-	d.store.UpdateState(agentID, protocol.StateIdle)
-	d.notifyTicketSessionWentIdle(agentID) // settles -> schedules the backstop
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if wasNudged(inputs(agentID)) {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatal("backstop did not fire after the agent went idle")
 }

--- a/internal/daemon/ticket_read.go
+++ b/internal/daemon/ticket_read.go
@@ -16,31 +16,27 @@ import (
 // session. Every session retains its ordinary session identity. The active chief
 // additionally observes through the durable chief role identity, whose cursor
 // survives role transfers while AuthorID keeps self-authored events excluded. The
-// delivery path comes from the session's agent driver capability
-// (agent.Capabilities.HasSelfMonitor, resolved via the registry): Claude
-// self-monitors and watches; codex and the rest are nudged. An empty/unknown agent
-// resolves to nil → Capabilities{} → false, the safe nudge default.
+// delivery path is shared by all runtimes; an optional runtime `ticket inbox
+// --watch` consumes the same unread queue before a countdown has to ring.
 func (d *Daemon) ticketObserversForSession(sessionID string) []ticketnotify.Observer {
-	agentName := ""
-	if s := d.store.Get(sessionID); s != nil {
-		agentName = s.Agent
-	}
-	selfMonitor := agentdriver.EffectiveCapabilities(agentdriver.Get(agentName)).HasSelfMonitor
-	personal := ticketnotify.Observer{ID: sessionID, AuthorID: sessionID, DeliveryID: sessionID, HasSelfMonitor: selfMonitor}
+	personal := ticketnotify.Observer{ID: sessionID, AuthorID: sessionID, DeliveryID: sessionID}
 	observers := []ticketnotify.Observer{personal}
 	if d.isChiefOfStaffSession(sessionID) {
 		observers = append(observers, ticketnotify.Observer{
-			ID:             store.TicketRoleIdentity(store.TicketRoleChiefOfStaff),
-			AuthorID:       sessionID,
-			DeliveryID:     sessionID,
-			HasSelfMonitor: selfMonitor,
+			ID:         store.TicketRoleIdentity(store.TicketRoleChiefOfStaff),
+			AuthorID:   sessionID,
+			DeliveryID: sessionID,
 		})
 	}
 	return observers
 }
 
-func (d *Daemon) ticketDeliveryObserverForSession(sessionID string) ticketnotify.Observer {
-	return d.ticketObserversForSession(sessionID)[0]
+func (d *Daemon) sessionHasSelfMonitor(sessionID string) bool {
+	agentName := ""
+	if s := d.store.Get(sessionID); s != nil {
+		agentName = s.Agent
+	}
+	return agentdriver.EffectiveCapabilities(agentdriver.Get(agentName)).HasSelfMonitor
 }
 
 func (d *Daemon) ticketUnreadForSession(sessionID string) (int, error) {
@@ -49,9 +45,9 @@ func (d *Daemon) ticketUnreadForSession(sessionID string) (int, error) {
 
 // handleTicketInbox returns the calling session's unread ticket events, bundled by
 // ticket, and advances its per-ticket cursors past them (a consume). This is the
-// agent's read path — what a nudged agent runs to catch up, and what a
-// self-monitoring agent's own watch drains. The observer identity is resolved from
-// the session, so the caller names nothing.
+// agent's read path — what a nudged agent runs to catch up, and what a runtime's
+// optional watch drains. The observer identity is resolved from the session, so the
+// caller names nothing.
 func (d *Daemon) handleTicketInbox(conn net.Conn, msg *protocol.TicketInboxMessage) {
 	sourceSessionID := strings.TrimSpace(msg.SourceSessionID)
 	if sourceSessionID == "" {
@@ -65,7 +61,7 @@ func (d *Daemon) handleTicketInbox(conn net.Conn, msg *protocol.TicketInboxMessa
 	}
 	// The consume advanced this session's cursors, so its unread count just dropped.
 	// Refresh the indicator (and cancel any pending countdown if fully drained) — this
-	// is the chokepoint a self-monitoring agent's own watch drains through.
+	// is the chokepoint a runtime's optional watch drains through.
 	d.refreshTicketUnread(sourceSessionID)
 	result := &protocol.TicketInboxResult{Bundles: ticketEventBundlesToProtocol(bundles)}
 	if lastActive := d.lastUserActivityAt(); !lastActive.IsZero() {

--- a/internal/daemon/ticket_subscribe_test.go
+++ b/internal/daemon/ticket_subscribe_test.go
@@ -53,9 +53,9 @@ func inboxHasTicket(bundles []protocol.TicketEventBundle, ticketID string) bool 
 // ticket, and after unsubscribing it is neither nudged by nor served further events.
 // codex (no self-monitor) is used so the doorbell is observable; the trigger is a
 // chief comment on the ticket, an event the subscriber did not author. The trigger
-// goes through commentOnTicket (synchronous handleTicketAddComment), so the doorbell
-// — typeDoorbell sleeps mid-delivery — completes before the assertion, unlike the
-// net.Pipe-based callSetTicketStatus which would return before the async notify ran.
+// goes through commentOnTicket (synchronous handleTicketAddComment), so the nudge
+// countdown is armed before the assertion, unlike the net.Pipe-based
+// callSetTicketStatus which can return before its async notify runs.
 func TestTicketSubscribeLifecycle(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour

--- a/internal/daemon/ticket_subscribe_test.go
+++ b/internal/daemon/ticket_subscribe_test.go
@@ -59,7 +59,6 @@ func inboxHasTicket(bundles []protocol.TicketEventBundle, ticketID string) bool 
 func TestTicketSubscribeLifecycle(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopTicketBackstops)
 	t.Cleanup(d.stopNudgeCountdowns)
 	_, agents, inputs := delegateMany(t, d, "codex", "Task Y", "Task X")
 	z, x := agents[0], agents[1] // z owns ticket Y; x owns its own ticket
@@ -106,7 +105,6 @@ func TestTicketSubscribeLifecycle(t *testing.T) {
 // idempotent and tolerant of an unknown id.
 func TestTicketSubscribeValidatesTicket(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	t.Cleanup(d.stopTicketBackstops)
 	_, agents, _ := delegateMany(t, d, "codex", "Task Y")
 	x := agents[0]
 

--- a/internal/daemon/ticket_take_test.go
+++ b/internal/daemon/ticket_take_test.go
@@ -39,7 +39,6 @@ func callTicketTake(t *testing.T, d *Daemon, sessionID, ticketID string, confirm
 func TestTicketTakeOverNotifiesPreviousAssignee(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	d.nudgeWindowOverride = time.Hour
-	t.Cleanup(d.stopTicketBackstops)
 	t.Cleanup(d.stopNudgeCountdowns)
 	_, agents, inputs := delegateMany(t, d, "codex", "Task Y", "Task X")
 	z, x := agents[0], agents[1] // z owns ticket Y; x owns its own ticket
@@ -89,7 +88,6 @@ func TestTicketTakeOverNotifiesPreviousAssignee(t *testing.T) {
 // already owned is a harmless no-op; taking an unknown ticket is a clear error.
 func TestTicketTakeUnassignedSelfAndUnknown(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
-	t.Cleanup(d.stopTicketBackstops)
 	_, agents, _ := delegateMany(t, d, "codex", "Task X")
 	x := agents[0]
 

--- a/internal/daemon/ticket_take_test.go
+++ b/internal/daemon/ticket_take_test.go
@@ -32,7 +32,7 @@ func callTicketTake(t *testing.T, d *Daemon, sessionID, ticketID string, confirm
 // Taking over an actively-worked ticket: x cannot take z's ticket without
 // --confirm (the steal guard), takes it with --confirm, and the displaced
 // assignee z — a participant because it reported status while working — is nudged
-// about the handover. The taker's first inbox then delivers the ticket's history
+// about the attach. The taker's first inbox then delivers the ticket's history
 // (take does not advance the cursor). codex agents are used so the doorbell is
 // observable; handleTicketTake notifies synchronously, so the assertion is
 // deterministic.
@@ -74,7 +74,7 @@ func TestTicketTakeOverNotifiesPreviousAssignee(t *testing.T) {
 		t.Fatalf("ticket not reassigned to taker: %+v", tk)
 	}
 
-	// The displaced assignee z is nudged about the handover.
+	// The displaced assignee z is nudged about the attach.
 	fireNudgeNow(t, d, z) // the takeover armed z's countdown
 	if !wasNudged(inputs(z)) {
 		t.Fatal("previous assignee was not nudged about the takeover")

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -920,8 +920,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		go d.handleTicketAddComment(client, msg.(*protocol.TicketAddCommentMessage))
 	case protocol.CmdTicketEditDescription:
 		go d.handleTicketEditDescription(client, msg.(*protocol.TicketEditDescriptionMessage))
-	case protocol.CmdTicketHandover:
-		go d.handleTicketHandoverWS(client, msg.(*protocol.TicketHandoverMessage))
+	case protocol.CmdTicketAttach:
+		go d.handleTicketAttachWS(client, msg.(*protocol.TicketAttachMessage))
 	case protocol.CmdTicketResume:
 		go d.handleTicketResume(client, msg.(*protocol.TicketResumeMessage))
 	case protocol.CmdFsList:

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -126,8 +126,8 @@ func WorkspaceContextSessionStartOutput(path string) string {
 // ChiefGuidance is the system prompt block injected into a chief-of-staff agent.
 // It covers the chief's role (coordinator, not doer), the Notebook as its durable
 // home, delegation rules, and ticket awareness. root is the resolved notebook root
-// (empty disables). hasSelfMonitor selects the runtime's existing ticket-delivery
-// path: self-monitoring agents watch, while the rest wait for attn's PTY nudge.
+// (empty disables). hasSelfMonitor selects whether the runtime may additionally
+// watch its inbox; every runtime remains eligible for the same daemon nudge.
 func ChiefGuidance(root string, hasSelfMonitor bool) string {
 	root = strings.TrimSpace(root)
 	if root == "" {
@@ -136,8 +136,8 @@ func ChiefGuidance(root string, hasSelfMonitor bool) string {
 	ticketWaitingGuidance := "For this runtime, attn's ticket nudges are the supported wake-up mechanism. Do not start `attn ticket inbox --watch`: end your turn after delegating, and when attn nudges you, run `attn ticket inbox` to consume and surface the update."
 	wakeBoundary := "attn nudges you"
 	if hasSelfMonitor {
-		ticketWaitingGuidance = "Right after delegating, arm a harness Monitor running `attn ticket inbox --watch` so a ticket's state-changes push to you the moment they land instead of you polling the board."
-		wakeBoundary = "a watched ticket pushes"
+		ticketWaitingGuidance = "You may arm a harness Monitor running `attn ticket inbox --watch` so ticket state changes push to you instead of polling the board. That monitor complements attn's shared ticket nudge: if activity remains unread, attn still wakes you with the same doorbell as every other runtime."
+		wakeBoundary = "a watched ticket pushes or attn nudges you"
 	}
 	return fmt.Sprintf(`You are the chief of staff. The attn Notebook at %[1]s is your durable, profile-wide home — plain markdown on disk that outlives any single workspace, used in place of a per-workspace shared context. Read it to orient, and maintain it as you work. It is yours to read and edit directly with native file tools (Read/Write/Edit); there is no notebook CLI.
 

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "157"
+const ProtocolVersion = "158"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -50,7 +50,7 @@ const (
 	CmdTicketSubscribe                       = "ticket_subscribe"
 	CmdTicketUnsubscribe                     = "ticket_unsubscribe"
 	CmdTicketTake                            = "ticket_take"
-	CmdTicketHandover                        = "ticket_handover"
+	CmdTicketAttach                          = "ticket_attach"
 	CmdTicketCreate                          = "ticket_create"
 	CmdTicketComment                         = "ticket_comment"
 	CmdGetTicket                             = "get_ticket"
@@ -198,7 +198,7 @@ const (
 	EventTicketsUpdated              = "tickets_updated"
 	EventTicketResult                = "ticket_result"
 	EventTicketActionResult          = "ticket_action_result"
-	EventTicketHandoverResult        = "ticket_handover_result"
+	EventTicketAttachResult          = "ticket_attach_result"
 	EventTicketResumeResult          = "ticket_resume_result"
 	EventGetPresentationsResult      = "get_presentations_result"
 	EventGetPresentationRoundResult  = "get_presentation_round_result"
@@ -423,8 +423,8 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 		}
 		return peek.Cmd, &msg, nil
 
-	case CmdTicketHandover:
-		var msg TicketHandoverMessage
+	case CmdTicketAttach:
+		var msg TicketAttachMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2794,16 +2794,15 @@ type Response struct {
 	// Sessions corresponds to the JSON schema field "sessions".
 	Sessions []Session `json:"sessions,omitempty,omitzero"`
 
+	// TicketAttachResult corresponds to the JSON schema field "ticket_attach_result".
+	TicketAttachResult *TicketAttachResult `json:"ticket_attach_result,omitempty,omitzero"`
+
 	// TicketCommentResult corresponds to the JSON schema field
 	// "ticket_comment_result".
 	TicketCommentResult *TicketCommentResult `json:"ticket_comment_result,omitempty,omitzero"`
 
 	// TicketCreateResult corresponds to the JSON schema field "ticket_create_result".
 	TicketCreateResult *TicketCreateResult `json:"ticket_create_result,omitempty,omitzero"`
-
-	// TicketHandoverResult corresponds to the JSON schema field
-	// "ticket_handover_result".
-	TicketHandoverResult *TicketHandoverResult `json:"ticket_handover_result,omitempty,omitzero"`
 
 	// TicketInboxResult corresponds to the JSON schema field "ticket_inbox_result".
 	TicketInboxResult *TicketInboxResult `json:"ticket_inbox_result,omitempty,omitzero"`
@@ -3414,8 +3413,8 @@ type TicketActivity struct {
 
 type TicketActivityKind string
 
+const TicketActivityKindAttach TicketActivityKind = "attach"
 const TicketActivityKindComment TicketActivityKind = "comment"
-const TicketActivityKindHandover TicketActivityKind = "handover"
 const TicketActivityKindStatusChange TicketActivityKind = "status_change"
 
 type TicketAddCommentMessage struct {
@@ -3441,6 +3440,74 @@ type TicketArtifact struct {
 
 	// Path corresponds to the JSON schema field "path".
 	Path string `json:"path"`
+}
+
+type TicketAttachFile struct {
+	// Filename corresponds to the JSON schema field "filename".
+	Filename string `json:"filename"`
+
+	// SourcePath corresponds to the JSON schema field "source_path".
+	SourcePath string `json:"source_path"`
+}
+
+type TicketAttachMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Comment corresponds to the JSON schema field "comment".
+	Comment *string `json:"comment,omitempty,omitzero"`
+
+	// Files corresponds to the JSON schema field "files".
+	Files []TicketAttachFile `json:"files"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// SourceSessionID corresponds to the JSON schema field "source_session_id".
+	SourceSessionID string `json:"source_session_id"`
+
+	// State corresponds to the JSON schema field "state".
+	State *DispatchWorkState `json:"state,omitempty,omitzero"`
+
+	// TicketID corresponds to the JSON schema field "ticket_id".
+	TicketID *string `json:"ticket_id,omitempty,omitzero"`
+}
+
+type TicketAttachResult struct {
+	// Artifacts corresponds to the JSON schema field "artifacts".
+	Artifacts []TicketArtifact `json:"artifacts"`
+
+	// Deduplicated corresponds to the JSON schema field "deduplicated".
+	Deduplicated bool `json:"deduplicated"`
+
+	// EventSeq corresponds to the JSON schema field "event_seq".
+	EventSeq int `json:"event_seq"`
+
+	// Fingerprint corresponds to the JSON schema field "fingerprint".
+	Fingerprint string `json:"fingerprint"`
+
+	// State corresponds to the JSON schema field "state".
+	State TicketStatus `json:"state"`
+
+	// TicketID corresponds to the JSON schema field "ticket_id".
+	TicketID string `json:"ticket_id"`
+}
+
+type TicketAttachResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Result corresponds to the JSON schema field "result".
+	Result *TicketAttachResult `json:"result,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
 }
 
 type TicketChangeStatusMessage struct {
@@ -3558,79 +3625,11 @@ type TicketEventBundle struct {
 type TicketEventKind string
 
 const TicketEventKindAssigned TicketEventKind = "assigned"
+const TicketEventKindAttachSubmitted TicketEventKind = "attach_submitted"
 const TicketEventKindCommented TicketEventKind = "commented"
 const TicketEventKindCreated TicketEventKind = "created"
 const TicketEventKindDescriptionEdited TicketEventKind = "description_edited"
-const TicketEventKindHandoverSubmitted TicketEventKind = "handover_submitted"
 const TicketEventKindStatusChanged TicketEventKind = "status_changed"
-
-type TicketHandoverFile struct {
-	// Filename corresponds to the JSON schema field "filename".
-	Filename string `json:"filename"`
-
-	// SourcePath corresponds to the JSON schema field "source_path".
-	SourcePath string `json:"source_path"`
-}
-
-type TicketHandoverMessage struct {
-	// Cmd corresponds to the JSON schema field "cmd".
-	Cmd string `json:"cmd"`
-
-	// Comment corresponds to the JSON schema field "comment".
-	Comment *string `json:"comment,omitempty,omitzero"`
-
-	// Files corresponds to the JSON schema field "files".
-	Files []TicketHandoverFile `json:"files"`
-
-	// RequestID corresponds to the JSON schema field "request_id".
-	RequestID *string `json:"request_id,omitempty,omitzero"`
-
-	// SourceSessionID corresponds to the JSON schema field "source_session_id".
-	SourceSessionID string `json:"source_session_id"`
-
-	// State corresponds to the JSON schema field "state".
-	State *DispatchWorkState `json:"state,omitempty,omitzero"`
-
-	// TicketID corresponds to the JSON schema field "ticket_id".
-	TicketID *string `json:"ticket_id,omitempty,omitzero"`
-}
-
-type TicketHandoverResult struct {
-	// Artifacts corresponds to the JSON schema field "artifacts".
-	Artifacts []TicketArtifact `json:"artifacts"`
-
-	// Deduplicated corresponds to the JSON schema field "deduplicated".
-	Deduplicated bool `json:"deduplicated"`
-
-	// EventSeq corresponds to the JSON schema field "event_seq".
-	EventSeq int `json:"event_seq"`
-
-	// Fingerprint corresponds to the JSON schema field "fingerprint".
-	Fingerprint string `json:"fingerprint"`
-
-	// State corresponds to the JSON schema field "state".
-	State TicketStatus `json:"state"`
-
-	// TicketID corresponds to the JSON schema field "ticket_id".
-	TicketID string `json:"ticket_id"`
-}
-
-type TicketHandoverResultMessage struct {
-	// Error corresponds to the JSON schema field "error".
-	Error *string `json:"error,omitempty,omitzero"`
-
-	// Event corresponds to the JSON schema field "event".
-	Event string `json:"event"`
-
-	// RequestID corresponds to the JSON schema field "request_id".
-	RequestID string `json:"request_id"`
-
-	// Result corresponds to the JSON schema field "result".
-	Result *TicketHandoverResult `json:"result,omitempty,omitzero"`
-
-	// Success corresponds to the JSON schema field "success".
-	Success bool `json:"success"`
-}
 
 type TicketInboxMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -276,7 +276,7 @@ enum TicketEventKind {
   commented,
   assigned,
   description_edited,
-  handover_submitted,
+  attach_submitted,
 }
 
 // TicketEvent is one entry in a ticket's append-only event log, as delivered to an
@@ -322,7 +322,7 @@ model TicketInboxResult {
 enum TicketActivityKind {
   status_change,
   comment,
-  handover,
+  attach,
 }
 
 // TicketActivity is one entry in a ticket's history thread, as shown in the detail
@@ -348,7 +348,7 @@ model TicketArtifact {
 }
 
 // Ticket is the wire shape of a durable tracked-work record. `activity` and
-// `artifacts` are the full history thread and current handover files — populated on the
+// `artifacts` are the full history thread and current attach files — populated on the
 // get_ticket full record, and left empty on the list / board feed for cheapness.
 model Ticket {
   id: string;
@@ -819,28 +819,28 @@ model TicketTakeResult {
   previous_assignee: string;
 }
 
-model TicketHandoverFile {
+model TicketAttachFile {
   source_path: string;
   filename: string;
 }
 
-// TicketHandoverMessage copies one or more Markdown artifacts into a ticket's
-// visible Notebook directory and records one durable handover receipt. Without a
+// TicketAttachMessage copies one or more Markdown artifacts into a ticket's
+// visible Notebook directory and records one durable attach receipt. Without a
 // ticket_id the daemon resolves the caller's bound ticket; with one it follows the
 // same permissive by-id authorization as ticket status and comment.
-model TicketHandoverMessage {
-  cmd: "ticket_handover";
+model TicketAttachMessage {
+  cmd: "ticket_attach";
   source_session_id: string;
   ticket_id?: string;
-  files: TicketHandoverFile[];
+  files: TicketAttachFile[];
   state?: DispatchWorkState;
   comment?: string;
   request_id?: string;
 }
 
-// TicketHandoverResult is the durable receipt returned for a new submission and
+// TicketAttachResult is the durable receipt returned for a new submission and
 // for an idempotent retry of the same fingerprint.
-model TicketHandoverResult {
+model TicketAttachResult {
   ticket_id: string;
   artifacts: TicketArtifact[];
   fingerprint: string;
@@ -849,12 +849,12 @@ model TicketHandoverResult {
   deduplicated: boolean;
 }
 
-model TicketHandoverResultMessage {
-  event: "ticket_handover_result";
+model TicketAttachResultMessage {
+  event: "ticket_attach_result";
   request_id: string;
   success: boolean;
   error?: string;
-  result?: TicketHandoverResult;
+  result?: TicketAttachResult;
 }
 
 // GetTicketMessage fetches one ticket's full record — the row plus its activity
@@ -2426,7 +2426,7 @@ model Response {
   ticket_inbox_result?: TicketInboxResult;
   ticket_list_result?: TicketListResult;
   ticket_show_result?: TicketShowResult;
-  ticket_handover_result?: TicketHandoverResult;
+  ticket_attach_result?: TicketAttachResult;
   ticket_create_result?: TicketCreateResult;
   ticket_comment_result?: TicketCommentResult;
   ticket_subscribe_result?: TicketSubscribeResult;
@@ -2893,7 +2893,7 @@ alias DaemonEvent =
   | TicketsUpdatedMessage
   | TicketResultMessage
   | TicketActionResultMessage
-  | TicketHandoverResultMessage
+  | TicketAttachResultMessage
   | TicketResumeResultMessage
   | WorkspaceTileContentMessage
   | BrowserControlResponseMessage

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -643,6 +643,10 @@ CREATE TABLE IF NOT EXISTS ticket_event_cursors (
 				WHERE assigned.ticket_id = t.id AND assigned.kind = 'assigned'
 			);
 	`},
+	{67, "rename ticket artifact handover records to attachments", `
+		UPDATE ticket_activity SET kind = 'attach' WHERE kind = 'handover';
+		UPDATE ticket_events SET kind = 'attach_submitted' WHERE kind = 'handover_submitted';
+	`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -145,6 +145,46 @@ func TestMigrations_Idempotent(t *testing.T) {
 	}
 }
 
+func TestMigration67RenamesTicketArtifactRecords(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "migration-67.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB() error = %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO tickets (id, title, status, created_at, updated_at)
+		VALUES ('artifact-ticket', 'Artifact ticket', 'working', '2026-07-10T00:00:00Z', '2026-07-10T00:00:00Z');
+		INSERT INTO ticket_activity (ticket_id, kind, author, created_at)
+		VALUES ('artifact-ticket', 'handover', 'agent', '2026-07-10T00:00:00Z');
+		INSERT INTO ticket_events (ticket_id, kind, author, detail, created_at)
+		VALUES ('artifact-ticket', 'handover_submitted', 'agent', 'fingerprint', '2026-07-10T00:00:00Z');
+		DELETE FROM schema_migrations WHERE version = 67;
+	`); err != nil {
+		db.Close()
+		t.Fatalf("seed legacy artifact records: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seeded db: %v", err)
+	}
+
+	migrated, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB() migrate error = %v", err)
+	}
+	defer migrated.Close()
+
+	var activityKind, eventKind string
+	if err := migrated.QueryRow(`SELECT kind FROM ticket_activity WHERE ticket_id = 'artifact-ticket'`).Scan(&activityKind); err != nil {
+		t.Fatalf("read migrated activity: %v", err)
+	}
+	if err := migrated.QueryRow(`SELECT kind FROM ticket_events WHERE ticket_id = 'artifact-ticket'`).Scan(&eventKind); err != nil {
+		t.Fatalf("read migrated event: %v", err)
+	}
+	if activityKind != "attach" || eventKind != "attach_submitted" {
+		t.Fatalf("migrated kinds = (%q, %q), want (attach, attach_submitted)", activityKind, eventKind)
+	}
+}
+
 func TestMigration66BackfillsActiveBornAssignedTicketsWithoutCursor(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "migration-66.db")
 	s, err := NewWithDB(dbPath)
@@ -175,7 +215,7 @@ func TestMigration66BackfillsActiveBornAssignedTicketsWithoutCursor(t *testing.T
 	}
 	if _, err := raw.Exec(`
 		DROP TABLE ticket_role_owners;
-		DELETE FROM schema_migrations WHERE version = 66;
+		DELETE FROM schema_migrations WHERE version >= 66;
 	`); err != nil {
 		t.Fatalf("rewind migration 66: %v", err)
 	}

--- a/internal/store/ticket_events.go
+++ b/internal/store/ticket_events.go
@@ -38,11 +38,11 @@ const (
 	// TicketEventDescriptionEdited fires when the brief is edited.
 	TicketEventDescriptionEdited TicketEventKind = "description_edited"
 	// TicketEventAttachmentAdded is retained for historical attachment rows and
-	// events. New handovers use TicketEventHandoverSubmitted.
+	// events. New attachments use TicketEventAttachSubmitted.
 	TicketEventAttachmentAdded TicketEventKind = "attachment_added"
-	// TicketEventHandoverSubmitted fires when one or more artifacts are handed
-	// over. Detail contains the versioned receipt payload.
-	TicketEventHandoverSubmitted TicketEventKind = "handover_submitted"
+	// TicketEventAttachSubmitted fires when one or more artifacts are attached.
+	// Detail contains the versioned receipt payload.
+	TicketEventAttachSubmitted TicketEventKind = "attach_submitted"
 )
 
 // TicketEvent is one entry in the append-only event log. Seq is the global

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -85,9 +85,9 @@ const (
 	TicketActivityStatusChange TicketActivityKind = "status_change"
 	// TicketActivityComment records a freeform note from either side.
 	TicketActivityComment TicketActivityKind = "comment"
-	// TicketActivityHandover records the files and decision context submitted in
-	// one durable ticket handover.
-	TicketActivityHandover TicketActivityKind = "handover"
+	// TicketActivityAttach records the files and decision context submitted in
+	// one durable ticket attach.
+	TicketActivityAttach TicketActivityKind = "attach"
 )
 
 // Ticket is the durable record. Activity and Attachments are populated by
@@ -127,7 +127,7 @@ type TicketActivity struct {
 	CreatedAt  time.Time
 }
 
-// TicketAttachment is a file handed over with the work. Slice 1 stores the
+// TicketAttachment is a file attached to the ticket. Slice 1 stores the
 // record; the file-handling ergonomics (copy-into-store) come with slice 4.
 type TicketAttachment struct {
 	ID        int64
@@ -138,8 +138,8 @@ type TicketAttachment struct {
 	CreatedAt time.Time
 }
 
-// TicketHandoverResult is the durable portion of a handover receipt.
-type TicketHandoverResult struct {
+// TicketAttachResult is the durable portion of an attachment receipt.
+type TicketAttachResult struct {
 	EventSeq     int64
 	Status       TicketStatus
 	Deduplicated bool
@@ -781,7 +781,7 @@ func (s *Store) GetTicketResumeSessionID(assignee string) string {
 	return strings.TrimSpace(resumeSessionID)
 }
 
-// AddTicketAttachment records a handover file on the ticket, bumps updated_at, and
+// AddTicketAttachment records an attached file on the ticket, bumps updated_at, and
 // emits an attachment_added event (Detail = filename) authored by author. Returns
 // the stored attachment (with its assigned id).
 func (s *Store) AddTicketAttachment(att TicketAttachment, author string, now time.Time) (*TicketAttachment, error) {
@@ -832,14 +832,14 @@ func (s *Store) AddTicketAttachment(att TicketAttachment, author string, now tim
 	return &att, nil
 }
 
-// SubmitTicketHandover records one durable handover receipt and optionally moves
+// SubmitTicketAttach records one durable attachment receipt and optionally moves
 // the ticket in the same transaction. The fingerprint prefix in detail makes a
-// lost-response retry discoverable even when a status event followed the handover.
-func (s *Store) SubmitTicketHandover(
+// lost-response retry discoverable even when a status event followed the attach.
+func (s *Store) SubmitTicketAttach(
 	ticketID, author, fingerprint, detail, activityComment string,
 	status *TicketStatus,
 	now time.Time,
-) (*TicketHandoverResult, error) {
+) (*TicketAttachResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -847,7 +847,7 @@ func (s *Store) SubmitTicketHandover(
 		return nil, nil
 	}
 	if strings.TrimSpace(fingerprint) == "" {
-		return nil, errors.New("handover fingerprint required")
+		return nil, errors.New("attach fingerprint required")
 	}
 	if status != nil && !status.IsValid() {
 		return nil, fmt.Errorf("%w: %q", ErrInvalidTicketStatus, *status)
@@ -865,9 +865,9 @@ func (s *Store) SubmitTicketHandover(
 		SELECT seq, to_status FROM ticket_events
 		WHERE ticket_id = ? AND kind = ? AND detail LIKE ?
 		ORDER BY seq DESC LIMIT 1
-	`, ticketID, string(TicketEventHandoverSubmitted), fingerprint+"\n%").Scan(&existingSeq, &existingStatus)
+	`, ticketID, string(TicketEventAttachSubmitted), fingerprint+"\n%").Scan(&existingSeq, &existingStatus)
 	if err == nil {
-		return &TicketHandoverResult{EventSeq: existingSeq, Status: TicketStatus(existingStatus), Deduplicated: true}, nil
+		return &TicketAttachResult{EventSeq: existingSeq, Status: TicketStatus(existingStatus), Deduplicated: true}, nil
 	}
 	if err != sql.ErrNoRows {
 		return nil, err
@@ -886,7 +886,7 @@ func (s *Store) SubmitTicketHandover(
 	if _, err := tx.Exec(`
 		INSERT INTO ticket_activity (ticket_id, kind, author, comment, created_at)
 		VALUES (?, ?, ?, ?, ?)
-	`, ticketID, string(TicketActivityHandover), author, activityComment, formatTicketTime(now)); err != nil {
+	`, ticketID, string(TicketActivityAttach), author, activityComment, formatTicketTime(now)); err != nil {
 		return nil, err
 	}
 	resultStatus := current.Status
@@ -895,7 +895,7 @@ func (s *Store) SubmitTicketHandover(
 	}
 	eventSeq, _, err := appendTicketEventTx(tx, TicketEvent{
 		TicketID: ticketID,
-		Kind:     TicketEventHandoverSubmitted,
+		Kind:     TicketEventAttachSubmitted,
 		Author:   author,
 		Comment:  activityComment,
 		Detail:   detail,
@@ -914,7 +914,7 @@ func (s *Store) SubmitTicketHandover(
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	return &TicketHandoverResult{EventSeq: eventSeq, Status: resultStatus}, nil
+	return &TicketAttachResult{EventSeq: eventSeq, Status: resultStatus}, nil
 }
 
 // ArchiveTicket clears a closed ticket from the active board. Only terminal

--- a/internal/store/tickets_test.go
+++ b/internal/store/tickets_test.go
@@ -233,7 +233,7 @@ func TestTicketAttachments(t *testing.T) {
 	att, err := s.AddTicketAttachment(TicketAttachment{
 		TicketID: "tk",
 		Filename: "results.json",
-		Path:     "/handover/results.json",
+		Path:     "/attach/results.json",
 		Note:     "benchmark output",
 	}, "agent7", t1)
 	if err != nil {
@@ -618,35 +618,35 @@ func TestCrashedTicketsForAssignee(t *testing.T) {
 	}
 }
 
-func TestSubmitTicketHandoverIsAtomicAndIdempotent(t *testing.T) {
+func TestSubmitTicketAttachIsAtomicAndIdempotent(t *testing.T) {
 	s := New()
 	t.Cleanup(func() { _ = s.Close() })
-	if _, err := s.CreateTicket(Ticket{ID: "handover", Title: "Handover", Status: TicketStatusWorking}, "chief", ticketBase); err != nil {
+	if _, err := s.CreateTicket(Ticket{ID: "attach", Title: "Attach", Status: TicketStatusWorking}, "chief", ticketBase); err != nil {
 		t.Fatal(err)
 	}
 	status := TicketStatusInReview
-	first, err := s.SubmitTicketHandover("handover", "agent", "fingerprint", "fingerprint\n{}", "Handed over: plan.md\n\nDecision context", &status, ticketBase.Add(time.Minute))
+	first, err := s.SubmitTicketAttach("attach", "agent", "fingerprint", "fingerprint\n{}", "Handed over: plan.md\n\nDecision context", &status, ticketBase.Add(time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if first.EventSeq == 0 || first.Status != TicketStatusInReview || first.Deduplicated {
 		t.Fatalf("first receipt = %+v", first)
 	}
-	retry, err := s.SubmitTicketHandover("handover", "agent", "fingerprint", "fingerprint\n{}", "Handed over: plan.md\n\nDecision context", &status, ticketBase.Add(2*time.Minute))
+	retry, err := s.SubmitTicketAttach("attach", "agent", "fingerprint", "fingerprint\n{}", "Handed over: plan.md\n\nDecision context", &status, ticketBase.Add(2*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !retry.Deduplicated || retry.EventSeq != first.EventSeq || retry.Status != first.Status {
 		t.Fatalf("retry receipt = %+v, first = %+v", retry, first)
 	}
-	ticket, _ := s.GetTicket("handover")
-	var handovers int
+	ticket, _ := s.GetTicket("attach")
+	var attachments int
 	for _, activity := range ticket.Activity {
-		if activity.Kind == TicketActivityHandover {
-			handovers++
+		if activity.Kind == TicketActivityAttach {
+			attachments++
 		}
 	}
-	if handovers != 1 || ticket.Status != TicketStatusInReview {
-		t.Fatalf("ticket = %+v, handovers=%d", ticket, handovers)
+	if attachments != 1 || ticket.Status != TicketStatusInReview {
+		t.Fatalf("ticket = %+v, attachments=%d", ticket, attachments)
 	}
 }

--- a/internal/ticketnotify/harness_test.go
+++ b/internal/ticketnotify/harness_test.go
@@ -193,11 +193,8 @@ func TestHarnessDedup(t *testing.T) {
 func TestHarnessNudgePath(t *testing.T) {
 	h := newHarness(t)
 
-	// A codex agent can't self-monitor; a Claude agent can. The agent->capability
-	// mapping now lives on the agent driver (internal/agent); here the bool is given
-	// explicitly, which is more honest for this pure package.
-	codex := Observer{ID: "codexbot", HasSelfMonitor: false}
-	claude := Observer{ID: "agent7", HasSelfMonitor: true}
+	codex := Observer{ID: "codexbot"}
+	claude := Observer{ID: "agent7"}
 
 	h.create("alpha", "codexbot", ObserverChief)
 	h.create("beta", "agent7", ObserverChief)
@@ -206,16 +203,16 @@ func TestHarnessNudgePath(t *testing.T) {
 	h.comment("alpha", ObserverChief, "please rebase")
 	h.comment("beta", ObserverChief, "tweak the title")
 
-	// Busy codex: deferred, no nudge yet.
+	// An approval-waiting codex agent is deferred, with no nudge yet.
 	d, err := Notify(h.s, codex, false, h, h.tick())
 	if err != nil || d != DeliveryDeferred {
-		t.Fatalf("busy codex delivery = %v (err %v), want Deferred", d, err)
+		t.Fatalf("approval-waiting codex delivery = %v (err %v), want Deferred", d, err)
 	}
 	if len(h.nudges) != 0 {
-		t.Fatalf("nudges = %v, want none while busy", h.nudges)
+		t.Fatalf("nudges = %v, want none while waiting for approval", h.nudges)
 	}
 
-	// Idle codex: nudged (a fixed trigger carrying only the observer id).
+	// A nudge-eligible codex agent receives the fixed trigger.
 	d, err = Notify(h.s, codex, true, h, h.tick())
 	if err != nil || d != DeliveryNudge {
 		t.Fatalf("idle codex delivery = %v (err %v), want Nudge", d, err)
@@ -224,13 +221,14 @@ func TestHarnessNudgePath(t *testing.T) {
 		t.Fatalf("nudges = %v, want [codexbot]", h.nudges)
 	}
 
-	// Claude agent: its own watch consumes; never nudged.
+	// Claude receives the same nudge. Its optional watch can consume the queue
+	// before a daemon countdown reaches the PTY, but does not change this decision.
 	d, err = Notify(h.s, claude, true, h, h.tick())
-	if err != nil || d != DeliveryWatch {
-		t.Fatalf("claude delivery = %v (err %v), want Watch", d, err)
+	if err != nil || d != DeliveryNudge {
+		t.Fatalf("claude delivery = %v (err %v), want Nudge", d, err)
 	}
-	if len(h.nudges) != 1 {
-		t.Fatalf("nudges = %v, claude must not be nudged", h.nudges)
+	if len(h.nudges) != 2 || h.nudges[1] != "agent7" {
+		t.Fatalf("nudges = %v, want [codexbot agent7]", h.nudges)
 	}
 
 	// After the nudge, the codex agent consumes its own queue and sees the steer.
@@ -252,7 +250,7 @@ func TestHarnessNudgePath(t *testing.T) {
 func TestHarnessAgentScopeAndSelfAuthored(t *testing.T) {
 	h := newHarness(t)
 	chief := ChiefObserver()
-	agent7 := Observer{ID: "agent7", HasSelfMonitor: true}
+	agent7 := Observer{ID: "agent7"}
 
 	h.create("alpha", "agent7", ObserverChief) // assigned to agent7
 	h.create("beta", "agent9", ObserverChief)  // assigned to someone else
@@ -304,7 +302,7 @@ func TestHarnessAgentScopeAndSelfAuthored(t *testing.T) {
 // silently skipped.
 func TestHarnessLateAssignmentDeliversContext(t *testing.T) {
 	h := newHarness(t)
-	agent7 := Observer{ID: "agent7", HasSelfMonitor: true}
+	agent7 := Observer{ID: "agent7"}
 
 	// agent7 has prior work it already consumed — its bookmark on "early" is advanced.
 	h.create("early", "agent7", ObserverChief)
@@ -353,7 +351,7 @@ func TestHarnessLateAssignmentDeliversContext(t *testing.T) {
 // assignee's progress, so the new agent picks up with full context.
 func TestHarnessReassignmentHandsOverHistory(t *testing.T) {
 	h := newHarness(t)
-	agent9 := Observer{ID: "agent9", HasSelfMonitor: true}
+	agent9 := Observer{ID: "agent9"}
 
 	// agent7 works a ticket and reports progress.
 	h.create("handoff", "agent7", ObserverChief)

--- a/internal/ticketnotify/notify.go
+++ b/internal/ticketnotify/notify.go
@@ -1,9 +1,9 @@
 // Package ticketnotify is the event-driven notification core of the work tracker
 // (slice 2 of docs/plans/2026-06-26-work-tracker.md). It is the decoupled layer
 // that sits above the store's append-only event log: every identity has a
-// per-ticket cursor, events past it are unread, and two handlers turn unread
-// events into a notification — a watch-consume for agents that self-monitor
-// (Claude), and an idle pty-nudge for those that can't (codex).
+// per-ticket cursor, events past it are unread, and a shared pty-nudge asks the
+// owning session to consume them. A runtime may also run `ticket inbox --watch`,
+// which simply consumes the same queue before the countdown reaches its doorbell.
 //
 // Every observer reads through one or more identities. Ordinary assignment,
 // authorship, and explicit subscription use session identities. Durable product
@@ -19,7 +19,7 @@
 //	                                an identity's cursor on a ticket are unread
 //	bundle by sender                Consume groups unread events by ticket
 //	hardcoded chief id              observer IDs supplied by the caller
-//	two consumers (watch / nudge)   the two Delivery paths below
+//	watch / nudge race              either may consume; unread is authoritative
 //	never stream content to a PTY   Nudger carries only a fixed trigger
 //
 // It knows nothing about live sessions or real Monitors — it is built against the
@@ -51,18 +51,16 @@ type EventStore interface {
 
 // Observer is one ticket-event view. ID owns the cursor, AuthorID is excluded as
 // self-authored activity, and DeliveryID is the live session to nudge. All three
-// are the session ID for ordinary agents; durable roles split them. HasSelfMonitor
-// selects watch versus nudge delivery.
+// are the session ID for ordinary agents; durable roles split them.
 type Observer struct {
-	ID             string
-	AuthorID       string
-	DeliveryID     string
-	HasSelfMonitor bool
+	ID         string
+	AuthorID   string
+	DeliveryID string
 }
 
 // ChiefObserver returns the harness-only chief observer.
 func ChiefObserver() Observer {
-	return Observer{ID: ObserverChief, AuthorID: ObserverChief, DeliveryID: ObserverChief, HasSelfMonitor: true}
+	return Observer{ID: ObserverChief, AuthorID: ObserverChief, DeliveryID: ObserverChief}
 }
 
 // Bundle is an observer's unread events for a single ticket. Consume returns one
@@ -75,8 +73,8 @@ type Bundle struct {
 
 // Consume returns the observer's unread events, bundled by ticket, and advances
 // the observer's cursor on each of those tickets past everything just delivered.
-// This is the watch-consume handler: a self-monitoring observer calls it when its
-// Monitor fires; a nudged observer calls it after the nudge lands.
+// A runtime may call this from `ticket inbox --watch`; a nudged session calls it
+// after the nudge lands. Both consume the same per-identity queue.
 //
 // Single-consumer-per-observer assumption: Consume reads unread events then writes
 // each touched ticket's cursor as separately-locked store calls, so two Consume
@@ -168,20 +166,16 @@ type Delivery int
 const (
 	// DeliveryNone means there was nothing unread.
 	DeliveryNone Delivery = iota
-	// DeliveryWatch means a self-monitoring observer's own watch will consume it
-	// (true push) — nothing is injected.
-	DeliveryWatch
-	// DeliveryNudge means an idle, non-self-monitoring observer was pty-nudged to
-	// go consume. Only a fixed trigger is sent, never event content.
+	// DeliveryNudge means a nudge-eligible observer was asked to consume. Only a
+	// fixed trigger is sent, never event content.
 	DeliveryNudge
-	// DeliveryDeferred means a non-self-monitoring observer is busy; the nudge
-	// waits until it goes idle.
+	// DeliveryDeferred means the observer is waiting for approval, so a doorbell
+	// could accidentally answer that prompt. A later eligible state rechecks it.
 	DeliveryDeferred
 )
 
-// Nudger delivers a fixed wake trigger to an observer that can't self-monitor. It
-// carries NO event content — only the bounded "go consume your tickets" trigger,
-// mirroring the daemon's doorbell rule (the agent then reads its own queue).
+// Nudger delivers a fixed wake trigger. It carries NO event content — only the
+// bounded "go consume your tickets" trigger, mirroring the daemon's doorbell rule.
 type Nudger interface {
 	Nudge(observerID string) error
 }
@@ -191,17 +185,16 @@ type Nudger interface {
 // triggers the observer to consume:
 //
 //   - nothing unread            -> DeliveryNone
-//   - self-monitors             -> DeliveryWatch (its own watch consumes)
-//   - idle, can't self-monitor  -> DeliveryNudge (fixed trigger; it then consumes)
-//   - busy, can't self-monitor  -> DeliveryDeferred (wait for idle)
-func Notify(es EventStore, obs Observer, idle bool, nudger Nudger, now time.Time) (Delivery, error) {
-	return NotifyAny(es, []Observer{obs}, obs, idle, nudger, now)
+//   - nudge-eligible            -> DeliveryNudge (fixed trigger; it then consumes)
+//   - waiting for approval       -> DeliveryDeferred (recheck after it clears)
+func Notify(es EventStore, obs Observer, nudgeEligible bool, nudger Nudger, now time.Time) (Delivery, error) {
+	return NotifyAny(es, []Observer{obs}, obs, nudgeEligible, nudger, now)
 }
 
 // NotifyAny makes one delivery decision for a session that observes through more
-// than one identity. deliveryObserver supplies the session capability and target;
-// the observed identities only determine whether anything is unread.
-func NotifyAny(es EventStore, observers []Observer, deliveryObserver Observer, idle bool, nudger Nudger, now time.Time) (Delivery, error) {
+// than one identity. deliveryObserver supplies the target; the observed identities
+// only determine whether anything is unread.
+func NotifyAny(es EventStore, observers []Observer, deliveryObserver Observer, nudgeEligible bool, nudger Nudger, now time.Time) (Delivery, error) {
 	unread, err := UnreadAny(es, observers)
 	if err != nil {
 		return DeliveryNone, err
@@ -209,10 +202,7 @@ func NotifyAny(es EventStore, observers []Observer, deliveryObserver Observer, i
 	if unread == 0 {
 		return DeliveryNone, nil
 	}
-	if deliveryObserver.HasSelfMonitor {
-		return DeliveryWatch, nil
-	}
-	if !idle {
+	if !nudgeEligible {
 		return DeliveryDeferred, nil
 	}
 	deliveryID := deliveryObserver.DeliveryID

--- a/internal/ticketnotify/notify_edge_test.go
+++ b/internal/ticketnotify/notify_edge_test.go
@@ -40,7 +40,7 @@ func (e erroringStore) SetTicketCursor(string, string, int64, time.Time) error {
 
 func TestNotifyNudgeError(t *testing.T) {
 	h := newHarness(t)
-	codex := Observer{ID: "codexbot", HasSelfMonitor: false}
+	codex := Observer{ID: "codexbot"}
 	h.create("alpha", "codexbot", ObserverChief)
 	h.comment("alpha", ObserverChief, "steer")
 


### PR DESCRIPTION
## Intent

Ticket activity should reach every session that can safely receive it. Runtime or coordinator role must not decide that; only an approval prompt blocks a doorbell.

## Summary

- Route ticket notifications through one state predicate, so active, launching, and unknown targets receive countdown nudges.
- Apply the same rule to Codex and Claude, chiefs and delegated agents; an optional Claude ticket inbox --watch can still consume activity before delivery.
- Align direct chief and presentation doorbells, guidance, docs, and focused regression coverage with the shared policy.

## Verification

- [x] go test ./internal/ticketnotify
- [x] go test ./internal/daemon
- [x] go test ./internal/hooks ./internal/agent ./cmd/attn
- [x] node --check app/scripts/real-app-harness/scenario-nudge-trigger.mjs
- [x] git diff --check
- [x] Built and exercised the isolated attn-dev.app ticket lifecycle scenario.

## Related

- Stacked on #530.