### PR TITLE
feat(plugin): add OpenCode server-backed driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-11]
 
+### Added
+- **OpenCode can now run as an installable attn agent.** The server-backed `attn-opencode` plugin launches an interactive OpenCode TUI inside attn, using OpenCode's configured defaults for ordinary sessions and an authenticated local server for delegated prompts. It retains the native session for resume and keeps attn’s working/idle state in sync. Delegations can pin the OpenCode provider/model and the contract-tested `low` or `max` variant, including isolated concurrent runs.
+
 ### Fixed
 - **Closed sessions no longer leave workspace tiles that reappear in the sidebar.** Closing now removes the pane before announcing the session's departure, stale agent panes cannot be moved into another workspace, and startup repairs any orphan panes left by older runs.
 

--- a/docs/plans/2026-04-16-plugin-system.md
+++ b/docs/plans/2026-04-16-plugin-system.md
@@ -66,7 +66,7 @@ These were proposed in conversation but not explicitly confirmed:
 5. **SDK shape and timing.** User pushed back on designing SDK top-down. **Revised approach: the first real plugins are written against raw JSON-RPC first. After the provider path proved out, extract a small SDK from those patterns; let richer plugin surfaces wait until their concrete implementations exist.** The protocol must still stay ergonomic enough to consume without a wrapper.
 6. **Manifest format.** Probably TOML — minimal, human-readable, Bun ecosystem-neutral. Alternatives: JSON, YAML. Not confirmed.
 7. **Install sources.** Settings accepts a pasted Git repository URL or local directory. The CLI currently keeps `--path <dir>` for local development; a Git-source CLI form is deferred until it has a concrete use case.
-8. **API versioning discipline.** Proposed: strict `attn_api_version: 1` refuses to load on mismatch. Additive protocol changes don't bump version. Not confirmed.
+8. **API versioning discipline.** Installed plugin manifests and the socket hello use a strict, matching `attn_api_version`. Version 2 introduced optional delegated `model` and `effort` fields on the driver launch request, so daemon and plugin agree on the expanded driver contract before launch. A wire-shape change must bump this version and update every bundled manifest/client; the daemon-client protocol version changes separately only when its own WebSocket schema changes.
 9. **Socket coexistence.** Existing one-message-per-connection hook protocol (claude hooks, whatever remains of the old pi plan's pattern) must keep working. Proposed: detect JSON-RPC handshake by first-message shape and switch the connection's mode. Not confirmed.
 10. **JSON-RPC framing.** Proposed: newline-delimited JSON. Alternative: LSP-style Content-Length headers. Unix socket + JSON makes newline-delimited the simpler choice.
 
@@ -185,7 +185,7 @@ Extend the daemon's existing unix socket handler to recognize a JSON-RPC 2.0 han
 ```json
 → {"jsonrpc":"2.0","id":1,"method":"hello","params":{
     "name":"example-driver","version":"0.1.0",
-    "attn_api_version":1}}
+    "attn_api_version":2}}
 ← {"jsonrpc":"2.0","id":1,"result":{"ok":true}}
 ```
 
@@ -238,7 +238,7 @@ Manifest (`attn-plugin.toml` at repo root):
 ```toml
 name = "example-driver"
 version = "0.1.0"
-attn_api_version = 1
+attn_api_version = 2
 description = "Example external coding agent driver for attn"
 
 [plugin]

--- a/docs/plans/2026-07-11-opencode-plugin-pr1-defaults-revision.md
+++ b/docs/plans/2026-07-11-opencode-plugin-pr1-defaults-revision.md
@@ -1,0 +1,32 @@
+# OpenCode default-launch revision
+
+## Decision
+
+Plain, promptless OpenCode sessions no longer require attn to provide a model
+or effort pin. Attn launches the normal OpenCode TUI and OpenCode applies its
+own configured defaults. The server-backed adapter subscribes to that run's
+authenticated event stream and records the native session when normal TUI input
+creates it.
+
+Delegated staged prompts and explicit model/effort requests retain the original
+server-side creation flow. That path is the only one that needs an attn-provided
+model/variant, because it must bind the staged prompt to a selected native
+session deterministically.
+
+## Evidence
+
+The `attn-dev` live app launched an unpinned session with no model, effort, or
+initial prompt. OpenCode rendered its own GLM 5.2/max default. A normal PTY
+prompt returned `OPENCODE_DEFAULT_LIVE_OK`; the plugin persisted the resulting
+native ID, model, and variant and attn reported `idle`. An explicit subsequent
+resume reopened that same visible conversation.
+
+The TUI home route has no native session before the first prompt, so attn keeps
+the run `launching` during that interval. It must not adopt a historical entry
+from OpenCode's global session list.
+
+## Verification
+
+- `bun test` in `plugins/attn-opencode`: 11 tests, 40 assertions.
+- Non-production `attn-dev` live launch, terminal steering, identity capture,
+  idle report, and resume. Production was not touched.

--- a/docs/plans/2026-07-11-opencode-plugin-pr1-final-hardening.md
+++ b/docs/plans/2026-07-11-opencode-plugin-pr1-final-hardening.md
@@ -1,0 +1,37 @@
+# OpenCode PR 1 final hardening
+
+## Durable changes
+
+- Interactive metadata now distinguishes an OpenCode-selected default from a
+  delegated pin. `pinned: false` resumes the same native session without
+  enforcing an observed model or variant; legacy metadata without the marker is
+  treated as pinned for safety.
+- Every launch failure after `driver.spawn` starts receives
+  `driver.session_closed`, so private run credentials, prompts, and launch
+  files are removed even when the PTY or durable attn run cannot be created.
+- Health, initial SSE readiness, native-session setup, and event callbacks have
+  bounded requests. A setup failure aborts the event stream before its ordered
+  `unknown` report.
+- A transient established OpenCode SSE failure reconnects. Three consecutive
+  established-stream failures or three failed reconnection setups instead
+  degrade the run to `unknown`, avoiding an endless healthy-but-unmonitored
+  loop.
+
+## Evidence
+
+- `bun test` in `plugins/attn-opencode`: 18 tests, 49 assertions.
+- Final isolated `attn-dev` run: API-v2 plugin discovered after daemon restart;
+  ordinary OpenCode TUI showed GLM 5.2/max, returned
+  `OPENCODE_FINAL_LIVE_V6_OK`, and attn reached `idle`.
+- Final interactive close/resume reused the same visible native conversation
+  and persisted `pinned: false`, GLM model, `max`, and `resume: true`.
+- Two independent native adversarial reviewers made final clean passes after
+  their actionable findings were fixed. The previously requested external
+  review service remains unavailable because platform policy blocks the local
+  diff transfer.
+
+## Scope
+
+This does not add generic installed-plugin supervision, semantic
+`waiting_input`, chief/workspace context parity, more effort mappings, or any
+production installation.

--- a/docs/plans/2026-07-11-opencode-plugin-pr1-implementation.md
+++ b/docs/plans/2026-07-11-opencode-plugin-pr1-implementation.md
@@ -1,0 +1,181 @@
+# OpenCode plugin PR 1 implementation
+
+## Why / Alignment
+
+An ordinary Cmd+T OpenCode session should behave like Claude or Codex: attn
+launches the OpenCode TUI and OpenCode chooses its configured model, variant,
+and first native session. The server-backed plugin observes that session and
+persists its native identity once OpenCode creates it. A resume is unavailable
+until that identity exists.
+
+Delegated or otherwise pinned launches remain explicit: a staged prompt or a
+model/effort pin causes the plugin to create and select the native session
+through OpenCode's authenticated server API, preserving the prompt-to-pin
+binding proved by the spike. This chunk changes only that launch-mode boundary;
+it does not add a generic model picker, change OpenCode configuration, or
+broaden effort mappings.
+
+## Goal
+
+Deliver the first installable, server-backed OpenCode driver for attn: delegated
+sessions pin an OpenCode provider/model and verified effort variant, attn owns the
+PTY lifecycle, and the plugin uses authenticated loopback HTTP/SSE for native
+OpenCode session identity and state reporting.
+
+## Runtime map
+
+```text
+plain Cmd+T
+  -> attn-owned PTY -> opencode TUI uses its own defaults
+  -> authenticated SSE observes OpenCode's first session.created
+  -> plugin persists native identity and translates its lifecycle
+
+delegated --agent opencode --model provider/model --effort low|max
+  -> daemon resolves the installed driver capability and forwards pins
+    -> attn-opencode driver.spawn / driver.resume (plugin JSON-RPC API v2)
+      -> private run registry: password, staged prompt, launch config, sequence
+      -> attn-owned PTY launches launcher.ts -> OpenCode loopback server + TUI
+      -> authenticated HTTP/SSE
+           health -> subscribe /event -> create or validate native session
+           -> /tui/select-session -> /prompt_async (fresh runs)
+           -> busy/retry => working; explicit idle => idle
+```
+
+The plugin process and its registry are rooted beside the daemon socket. This
+makes an app-managed profile restart discover the plugins installed for that
+profile even when the restarted process does not inherit `ATTN_PROFILE`.
+
+## Contract and ownership
+
+```ts
+// daemon -> external driver
+type DriverSpawnParams = {
+  session_id: string
+  run_id: string
+  model?: string       // resolved delegated pin
+  effort?: string      // resolved delegated pin
+  initial_prompt?: string
+  metadata?: unknown   // opaque native OpenCode identity on resume
+}
+
+// persisted by attn as opaque driver metadata
+type OpenCodeMetadata = {
+  schema: 1
+  opencode_session_id: string
+  opencode_version: "1.17.16" | "1.17.18"
+  pinned?: boolean  // false means model/variant are observed, not constraints
+  model?: string      // present for pinned or observable default selections
+  variant?: string
+}
+```
+
+- attn owns PTY launch/input/output, resize/replay, session and run identity,
+  durable attn state, and process exit.
+- `attn-opencode` owns only server startup coordination, per-run private files,
+  OpenCode HTTP/SSE translation, native-session metadata, and ordered reports.
+- A status record absent from `/session/status` is unobserved, never idle.
+- Native session creation uses OpenCode's `{ providerID, id, variant }` shape;
+  `prompt_async` uses `{ model: { providerID, modelID }, variant }`.
+- The plugin only binds an unpinned interactive launch after its isolated
+  OpenCode server emits `session.created`; it never guesses a resume ID before
+  that event.
+
+## Implemented
+
+- [x] Added external-driver `model_pin` and `effort_pin` capabilities and passed
+  resolved model/effort through spawn and resume requests.
+- [x] Bumped the external plugin manifest/hello API to v2 and updated bundled
+  manifests and SDK client.
+- [x] Added installable `plugins/attn-opencode` with authenticated HTTP/SSE,
+  native identity resume, atomic private registry files, bounded port retry,
+  cleanup, version gating, and degraded health.
+- [x] Added deterministic adapter coverage for authentication, request shapes,
+  first-status absence, report ordering, resume validation, cleanup, failure,
+  retry, and concurrent isolation.
+- [x] Added daemon coverage for forwarding and capability-gating model/effort.
+- [x] Verified the complete behavior in the isolated `attn-dev` profile with
+  OpenCode 1.17.18 and `spotify-glm/zai-org/GLM-5.2-FP8` at `max` and `low`.
+- [x] Let unpinned, promptless Cmd+T launches use OpenCode defaults and bind the
+  first native session created on that run's private server.
+- [x] Completed two independent native adversarial reviews and fixed their
+  lifecycle, cleanup, and cancellation findings. The requested external review
+  remains unavailable because platform policy blocks local-diff transfer.
+
+## Decisions and deviations
+
+- The external plugin wire API is v2. The app/daemon TypeSpec already carried
+  delegated model and effort fields, so this does **not** change the public
+  WebSocket schema or `ProtocolVersion`; it changes the separate daemon-plugin
+  request shape and must fail closed against v1 plugins.
+- Live OpenCode 1.17.18 schema inspection found that `prompt_async` has a
+  different model field name from session creation. The adapter translates at
+  the HTTP edge and the fake server rejects the previous invalid shape.
+- Plugin discovery is derived from the daemon socket root, preserving an
+  explicit `ATTN_PLUGIN_DIR` override. This was required for profile restarts
+  observed during the non-production smoke test.
+- Model and effort pins are optional driver inputs, not universal OpenCode
+  launch requirements. They remain mandatory whenever the plugin receives a
+  staged prompt, because server-side creation is what binds that prompt to the
+  delegated model and effort variant without depending on TUI picker state.
+- Live verification showed a plain OpenCode TUI home route has no native session
+  before its first prompt. The plugin therefore remains `launching` in that
+  interval and binds the `session.created` SSE event triggered by normal PTY
+  input, rather than trying to adopt an unrelated historical session returned
+  by the server's global session list.
+- Native metadata records whether a model/variant is a delegated constraint or
+  merely an observed interactive default. Interactive resume selects the same
+  native session without rejecting a model that the user later changed in the
+  TUI; older metadata without this marker remains conservatively pinned.
+- Every HTTP and SSE setup step has a bounded request deadline. A failed setup
+  aborts its established SSE stream before reporting `unknown`, so late events
+  cannot overwrite degraded state. Any daemon-side failure after a driver run
+  starts sends `driver.session_closed` and removes the plugin's private record.
+- A normal OpenCode idle SSE stream may end independently of the native TUI.
+  The plugin reconnects after an established-stream interruption, but reports
+  degraded `unknown` after three consecutive established-stream failures or
+  three failed reconnect setups. This preserves state monitoring without
+  treating a transient stream reset as a completed run.
+- Semantic `waiting_input`, generic installed-plugin supervision, chief/workspace
+  guidance parity, production installation, and broader effort mappings remain
+  out of scope for PR 1.
+
+## Verification evidence
+
+- `bun test` in `plugins/attn-opencode`: 18 tests, 49 assertions, including
+  hanging health, SSE readiness, transient and repeated established-stream
+  failures, post-subscription setup timeout, and stream cancellation cases.
+- `go test ./internal/daemon -run 'TestPluginDirForSocketUsesSocketRuntimeRoot|TestDaemon_StartInstalledPlugins|TestPluginDriver|TestDelegate'`.
+- `"$(go env GOBIN)/gotestsum" --format testdox -- ./...`.
+- `make test-frontend`: 146 files, 1,431 tests.
+- `make check-types`; generated Go and TypeScript files unchanged.
+- `attn-dev` live proof: discovered the v2 plugin; completed distinct `max` and
+  `low` GLM requests in separate loopback servers; showed both prompts and
+  responses in the OpenCode TUI; observed steering `working` then `idle`;
+  closed and resumed the same native session/model/variant; and confirmed the
+  current run registry record was removed on close. No production app was
+  built, installed, restarted, or used.
+- `attn-dev` default-mode proof: an unpinned, promptless `spawn_session`
+  launched the OpenCode TUI without a model or effort field; OpenCode displayed
+  its own GLM 5.2/max default, a normal PTY prompt returned
+  `OPENCODE_DEFAULT_LIVE_OK`, and the plugin persisted the resulting native ID,
+  model, and variant before reporting `idle`. An explicit subsequent resume
+  opened that same native session and visible conversation.
+- Two independent native adversarial reviews: one found and verified fixes for
+  observed-default metadata provenance, bounded HTTP/SSE setup, post-failure
+  SSE cancellation, and launch cleanup; the other independently re-checked the
+  daemon rollback path and found it clean. A final targeted pass found that
+  repeated post-ready SSE failures needed their own bound; the fixed controlled
+  adapter regression and both final reviewer checks are clean.
+- Final exact-source `attn-dev` proof: the restarted dev daemon discovered the
+  installed API-v2 plugin, a promptless OpenCode TUI visibly used its own GLM
+  5.2/max default, returned `OPENCODE_FINAL_LIVE_V6_OK`, and attn reported
+  that session idle. The preceding close/resume proof reopened the same native
+  conversation with `pinned: false`, the observed GLM model/`max` variant, and
+  `resume: true` in the private registry. No production app was used.
+
+## Follow-ups
+
+- Add mappings for more OpenCode effort variants only after adapter and live-app
+  evidence for each mapping.
+- Consider generic installed-plugin supervision separately; it is deliberately
+  not part of this driver slice.

--- a/docs/plans/2026-07-11-opencode-plugin-pr1-review-status.md
+++ b/docs/plans/2026-07-11-opencode-plugin-pr1-review-status.md
@@ -1,0 +1,20 @@
+# OpenCode PR 1 review status
+
+The implementation revision is attached to ticket `opencode-design` as
+`2026-07-11-opencode-plugin-pr1-implementation.md`.
+
+All requested automated checks and isolated `attn-dev` behavior were completed.
+The required externally hosted Codex structured review was attempted after
+Victor explicitly approved the local-diff transfer, but platform policy blocked
+the review service from receiving the repository diff. It produced no finding
+or clean result.
+
+As the user-directed safe alternative, two independent native adversarial
+reviews inspected the local diff. Their actionable findings on launch rollback,
+metadata provenance, bounded setup requests, and SSE cleanup were fixed and
+regression tested. A final runtime pass found the reconnect bound did not cover
+repeated post-ready stream failures; it is now bounded by a controlled adapter
+test. Both final follow-up results were clean.
+
+The ticket is ready for Victor's human review. No production app was used, and
+the branch remains unmerged.

--- a/examples/plugins/worktree-deps-hook/attn-plugin.toml
+++ b/examples/plugins/worktree-deps-hook/attn-plugin.toml
@@ -1,6 +1,6 @@
 name = "worktree-deps-hook"
 version = "0.1.0"
-attn_api_version = 1
+attn_api_version = 2
 description = "Example worktree after-create hook that installs JavaScript dependencies"
 
 [plugin]

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -544,7 +544,7 @@ func New(socketPath string) *Daemon {
 		tailscale:          newTailscaleRuntime(),
 		plugins:            newPluginRegistry(),
 		pluginProcesses:    newPluginProcessRegistry(),
-		pluginDir:          config.PluginDir(),
+		pluginDir:          pluginDirForSocket(socketPath),
 		workspaces:         newWorkspaceRegistry(),
 	}
 	// Production wiring for the orphaned-ticket reconciliation classifier. Test
@@ -582,6 +582,7 @@ func NewForTesting(socketPath string) *Daemon {
 		tailscale:          newTailscaleRuntime(),
 		plugins:            newPluginRegistry(),
 		pluginProcesses:    newPluginProcessRegistry(),
+		pluginDir:          pluginDirForSocket(socketPath),
 		workspaces:         newWorkspaceRegistry(),
 		workflowDirty:      make(map[string]bool),
 		workflowEngineConn: make(map[string]workflowEngineSink),
@@ -625,6 +626,7 @@ func NewWithGitHubClient(socketPath string, ghClient github.GitHubClient) *Daemo
 		tailscale:          newTailscaleRuntime(),
 		plugins:            newPluginRegistry(),
 		pluginProcesses:    newPluginProcessRegistry(),
+		pluginDir:          pluginDirForSocket(socketPath),
 		workspaces:         newWorkspaceRegistry(),
 		workflowDirty:      make(map[string]bool),
 		workflowEngineConn: make(map[string]workflowEngineSink),

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -518,6 +518,53 @@ func TestDelegateThreadsModelAndEffortIntoSpawn(t *testing.T) {
 	}
 }
 
+func TestDelegateThreadsModelAndEffortIntoPluginDriver(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	client, done := startPluginPipe(t, d, "fixture-plugin", nil)
+	defer func() {
+		_ = client.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, client, "fixture", map[string]bool{
+		"initial_prompt": true,
+		"model_pin":      true,
+		"effort_pin":     true,
+	})
+
+	requestDone := make(chan struct{})
+	go func() {
+		defer close(requestDone)
+		request := decodeJSONRPCMessage(t, client)
+		if request.Method != "driver.spawn" {
+			t.Errorf("method=%q, want driver.spawn", request.Method)
+			return
+		}
+		var got pluginDriverSpawnParams
+		if err := json.Unmarshal(request.Params, &got); err != nil {
+			t.Errorf("decode plugin spawn params: %v", err)
+			return
+		}
+		if got.Model != "spotify-glm/zai-org/GLM-5.2-FP8" || got.Effort != "low" {
+			t.Errorf("plugin spawn pins=%q/%q, want selected model/low", got.Model, got.Effort)
+		}
+		respondPluginRequest(t, client, request, pluginDriverSpawnResult{Argv: []string{"fixture"}})
+	}()
+
+	if _, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Use the selected OpenCode variant.",
+		Agent:           protocol.Ptr("fixture"),
+		Model:           protocol.Ptr("spotify-glm/zai-org/GLM-5.2-FP8"),
+		Effort:          protocol.Ptr("LOW"),
+	}); err != nil {
+		t.Fatalf("delegate() error=%v", err)
+	}
+	<-requestDone
+}
+
 // A delegation without pins must not inherit any: the spawned agent keeps its
 // own defaults (empty model/effort all the way down).
 func TestDelegateWithoutModelEffortLeavesAgentDefaults(t *testing.T) {

--- a/internal/daemon/plugin_driver.go
+++ b/internal/daemon/plugin_driver.go
@@ -37,6 +37,8 @@ type pluginDriverSpawnParams struct {
 	CWD           string          `json:"cwd"`
 	Label         string          `json:"label,omitempty"`
 	Yolo          bool            `json:"yolo,omitempty"`
+	Model         string          `json:"model,omitempty"`
+	Effort        string          `json:"effort,omitempty"`
 	InitialPrompt string          `json:"initial_prompt,omitempty"`
 	Metadata      json.RawMessage `json:"metadata,omitempty"`
 }
@@ -160,6 +162,8 @@ func validatePluginDriverCapabilities(values map[string]bool) (map[string]bool, 
 		"classifier":       {},
 		"state_reporting":  {},
 		"pending_approval": {},
+		"model_pin":        {},
+		"effort_pin":       {},
 	}
 	out := make(map[string]bool, len(values))
 	for name, enabled := range values {
@@ -182,6 +186,7 @@ func (d *Daemon) handlePluginDriverMethod(plugin *pluginConnection, msg jsonRPCM
 		if err := d.ensurePluginRegistry().registerDriver(plugin, params); err != nil {
 			return nil, true, err
 		}
+		d.logf("plugin driver registered plugin=%s agent=%s", plugin.name, normalizePluginAgent(params.Agent))
 		d.broadcastSettings("")
 		return pluginDriverRegisterResult{OK: true}, true, nil
 	case "session.report_state":
@@ -395,6 +400,23 @@ func (d *Daemon) finishPluginSessionLaunch(sessionID string, success bool) *ptyb
 	return nil
 }
 
+// abortPluginSessionLaunch closes plugin-owned resources created by a successful
+// driver.spawn/driver.resume response when attn fails before a durable active
+// run exists. In particular, a driver may already have staged a prompt or
+// credential before PTY spawn or session persistence fails.
+func (d *Daemon) abortPluginSessionLaunch(sessionID, reason string) {
+	d.pluginDriverMu.Lock()
+	launch, ok := d.pluginLaunching[sessionID]
+	delete(d.pluginReports, sessionID)
+	delete(d.pluginExits, sessionID)
+	delete(d.pluginLaunching, sessionID)
+	d.pluginDriverMu.Unlock()
+	if !ok {
+		return
+	}
+	d.notifyPluginDriverSessionClosed(launch.PluginName, sessionID, launch.RunID, reason, nil, "")
+}
+
 func (r pendingPluginReport) runID() string {
 	switch {
 	case r.State != nil:
@@ -417,14 +439,18 @@ func (d *Daemon) closePluginDriverSession(sessionID, reason string, exitCode *in
 	if run.RunID == "" {
 		return
 	}
-	plugin := d.ensurePluginRegistry().get(run.PluginName)
+	d.notifyPluginDriverSessionClosed(run.PluginName, sessionID, run.RunID, reason, exitCode, signal)
+}
+
+func (d *Daemon) notifyPluginDriverSessionClosed(pluginName, sessionID, runID, reason string, exitCode *int, signal string) {
+	plugin := d.ensurePluginRegistry().get(pluginName)
 	if plugin == nil {
-		d.logf("plugin session close notification dropped: plugin=%s session=%s run=%s owner disconnected", run.PluginName, sessionID, run.RunID)
+		d.logf("plugin session close notification dropped: plugin=%s session=%s run=%s owner disconnected", pluginName, sessionID, runID)
 		return
 	}
 	params := pluginDriverSessionClosedParams{
 		SessionID: sessionID,
-		RunID:     run.RunID,
+		RunID:     runID,
 		Reason:    strings.TrimSpace(reason),
 		ExitCode:  exitCode,
 		Signal:    strings.TrimSpace(signal),
@@ -434,7 +460,7 @@ func (d *Daemon) closePluginDriverSession(sessionID, reason string, exitCode *in
 		defer cancel()
 		var result pluginDriverSessionClosedResult
 		if err := plugin.request(ctx, "driver.session_closed", params, &result); err != nil {
-			d.logf("plugin session close notification failed: plugin=%s session=%s run=%s err=%v", run.PluginName, sessionID, run.RunID, err)
+			d.logf("plugin session close notification failed: plugin=%s session=%s run=%s err=%v", pluginName, sessionID, runID, err)
 		}
 	}()
 }
@@ -442,6 +468,12 @@ func (d *Daemon) closePluginDriverSession(sessionID, reason string, exitCode *in
 func (d *Daemon) resolvePluginDriverLaunch(reg pluginDriverRegistration, params pluginDriverSpawnParams, resume bool) (pluginDriverSpawnResult, error) {
 	if params.Yolo && !reg.Capabilities["yolo"] {
 		return pluginDriverSpawnResult{}, fmt.Errorf("agent %q does not support yolo launches", reg.Agent)
+	}
+	if params.Model != "" && !reg.Capabilities["model_pin"] {
+		return pluginDriverSpawnResult{}, fmt.Errorf("agent %q does not support model pins", reg.Agent)
+	}
+	if params.Effort != "" && !reg.Capabilities["effort_pin"] {
+		return pluginDriverSpawnResult{}, fmt.Errorf("agent %q does not support effort pins", reg.Agent)
 	}
 	if resume && !reg.Capabilities["resume"] {
 		return pluginDriverSpawnResult{}, fmt.Errorf("agent %q does not support resume", reg.Agent)

--- a/internal/daemon/plugin_driver_e2e_test.go
+++ b/internal/daemon/plugin_driver_e2e_test.go
@@ -128,13 +128,13 @@ func TestPluginDriverEndToEnd_InstalledProcessLaunchReportAndResumeThroughWorker
 		return asString(event["event"]) == protocol.EventWorkspaceRegistered
 	})
 
-	assertPluginFixtureStateTransitions(t, spawnFixtureSession(t, ws, sessionID, workspaceID, tmpDir, true, ""))
+	assertPluginFixtureStateTransitions(t, spawnFixtureSession(t, ws, sessionID, workspaceID, tmpDir, true, "", "spotify-glm/zai-org/GLM-5.2-FP8", "max"))
 	assertPluginFixtureReports(t, d, sessionID, "driver.spawn-native")
 	attachAndAssertPluginPTY(t, ws, sessionID, "driver.spawn", fixtureCWD)
 	triggerAndAssertPluginFixtureStateTransitions(t, ws, sessionID, fixtureStateTrigger)
 
 	records := waitForPluginFixtureRecords(t, fixtureLog, 1)
-	if records[0].Method != "driver.spawn" || !records[0].Params.Yolo {
+	if records[0].Method != "driver.spawn" || !records[0].Params.Yolo || records[0].Params.Model != "spotify-glm/zai-org/GLM-5.2-FP8" || records[0].Params.Effort != "max" {
 		t.Fatalf("first plugin request=%+v, want yolo driver.spawn", records[0])
 	}
 
@@ -147,13 +147,13 @@ func TestPluginDriverEndToEnd_InstalledProcessLaunchReportAndResumeThroughWorker
 		session := d.store.Get(sessionID)
 		return session != nil && session.State == protocol.SessionStateIdle
 	}, "initial PTY exit to settle before resume")
-	assertPluginFixtureStateTransitions(t, spawnFixtureSession(t, ws, sessionID, workspaceID, tmpDir, false, sessionID))
+	assertPluginFixtureStateTransitions(t, spawnFixtureSession(t, ws, sessionID, workspaceID, tmpDir, false, sessionID, "spotify-glm/zai-org/GLM-5.2-FP8", "max"))
 	assertPluginFixtureReports(t, d, sessionID, "driver.resume-native")
 	attachAndAssertPluginPTY(t, ws, sessionID, "driver.resume", fixtureCWD)
 
 	records = waitForPluginFixtureRecords(t, fixtureLog, 2)
 	resume := records[1]
-	if resume.Method != "driver.resume" {
+	if resume.Method != "driver.resume" || resume.Params.Model != "spotify-glm/zai-org/GLM-5.2-FP8" || resume.Params.Effort != "max" {
 		t.Fatalf("second plugin method=%q, want driver.resume", resume.Method)
 	}
 	if string(resume.Params.Metadata) != `{"native_id":"driver.spawn-native"}` {
@@ -184,7 +184,7 @@ func terminatePluginFixturePTY(t *testing.T, d *Daemon, sessionID string) {
 	}
 }
 
-func spawnFixtureSession(t *testing.T, ws *websocket.Conn, sessionID, workspaceID, cwd string, yolo bool, resumeID string) []string {
+func spawnFixtureSession(t *testing.T, ws *websocket.Conn, sessionID, workspaceID, cwd string, yolo bool, resumeID, model, effort string) []string {
 	t.Helper()
 	message := map[string]interface{}{
 		"cmd":          protocol.CmdSpawnSession,
@@ -195,6 +195,8 @@ func spawnFixtureSession(t *testing.T, ws *websocket.Conn, sessionID, workspaceI
 		"cols":         80,
 		"rows":         24,
 		"yolo_mode":    yolo,
+		"model":        model,
+		"effort":       effort,
 	}
 	if resumeID != "" {
 		message["resume_session_id"] = resumeID
@@ -403,6 +405,8 @@ func TestPluginDriverFixtureProcess(t *testing.T) {
 		"resume":          true,
 		"yolo":            true,
 		"state_reporting": true,
+		"model_pin":       true,
+		"effort_pin":      true,
 	})
 	if err := os.WriteFile(os.Getenv("ATTN_DRIVER_FIXTURE_READY"), []byte("ready"), 0o644); err != nil {
 		t.Fatalf("write fixture ready marker: %v", err)

--- a/internal/daemon/plugin_driver_test.go
+++ b/internal/daemon/plugin_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -21,8 +22,10 @@ func TestPluginDriverRegister_PublishesDynamicAgentSettings(t *testing.T) {
 	}()
 
 	registerTestPluginDriver(t, client, "snipe", map[string]bool{
-		"resume": true,
-		"yolo":   true,
+		"resume":     true,
+		"yolo":       true,
+		"model_pin":  true,
+		"effort_pin": true,
 	})
 
 	settings := d.settingsWithAgentAvailability()
@@ -31,6 +34,9 @@ func TestPluginDriverRegister_PublishesDynamicAgentSettings(t *testing.T) {
 	}
 	if got := settings["snipe_cap_resume"]; got != "true" {
 		t.Fatalf("snipe_cap_resume=%v, want true", got)
+	}
+	if got := settings["snipe_cap_model_pin"]; got != "true" {
+		t.Fatalf("snipe_cap_model_pin=%v, want true", got)
 	}
 	if err := d.validateNewSessionAgent("snipe"); err != nil {
 		t.Fatalf("validateNewSessionAgent(snipe) error=%v", err)
@@ -46,7 +52,7 @@ func TestHandleSpawnSession_PluginDriverLaunchesReturnedCommand(t *testing.T) {
 		_ = client.Close()
 		<-done
 	}()
-	registerTestPluginDriver(t, client, "snipe", map[string]bool{"yolo": true})
+	registerTestPluginDriver(t, client, "snipe", map[string]bool{"yolo": true, "model_pin": true, "effort_pin": true})
 
 	requestDone := make(chan struct{})
 	go func() {
@@ -61,8 +67,8 @@ func TestHandleSpawnSession_PluginDriverLaunchesReturnedCommand(t *testing.T) {
 			t.Errorf("decode spawn params: %v", err)
 			return
 		}
-		if params.SessionID != "snipe-session" || !params.Yolo {
-			t.Errorf("spawn params=%+v, want session id and yolo request", params)
+		if params.SessionID != "snipe-session" || !params.Yolo || params.Model != "gpt-5" || params.Effort != "low" {
+			t.Errorf("spawn params=%+v, want session id, yolo, model, and effort request", params)
 			return
 		}
 		if params.RunID == "" {
@@ -86,6 +92,8 @@ func TestHandleSpawnSession_PluginDriverLaunchesReturnedCommand(t *testing.T) {
 		Cols:        80,
 		Rows:        24,
 		YoloMode:    protocol.Ptr(true),
+		Model:       protocol.Ptr("gpt-5"),
+		Effort:      protocol.Ptr("low"),
 	})
 	<-requestDone
 
@@ -107,6 +115,69 @@ func TestHandleSpawnSession_PluginDriverLaunchesReturnedCommand(t *testing.T) {
 	}
 	if session := d.store.Get("snipe-session"); session.State != protocol.SessionStateWorking {
 		t.Fatalf("stored session state=%q, want working for driver without state_reporting", session.State)
+	}
+}
+
+func TestResolvePluginDriverLaunch_RejectsUnsupportedPins(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	reg := pluginDriverRegistration{Agent: "snipe", Capabilities: map[string]bool{}}
+	for _, params := range []pluginDriverSpawnParams{{Model: "gpt-5"}, {Effort: "low"}} {
+		_, err := d.resolvePluginDriverLaunch(reg, params, false)
+		if err == nil || !strings.Contains(err.Error(), "does not support") {
+			t.Fatalf("resolvePluginDriverLaunch(%+v) error=%v, want pin capability error", params, err)
+		}
+	}
+}
+
+func TestHandleSpawnSession_PluginDriverClosesRunWhenPTYSpawnFails(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &failingSpawnBackend{err: errors.New("pty spawn failed")}
+	client, done := startPluginPipe(t, d, "snipe-plugin", nil)
+	defer func() {
+		_ = client.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, client, "snipe", map[string]bool{})
+
+	closed := make(chan pluginDriverSessionClosedParams, 1)
+	go func() {
+		request := decodeJSONRPCMessage(t, client)
+		if request.Method != "driver.spawn" {
+			t.Errorf("method=%q, want driver.spawn", request.Method)
+			return
+		}
+		respondPluginRequest(t, client, request, pluginDriverSpawnResult{Argv: []string{"snipe"}})
+		request = decodeJSONRPCMessage(t, client)
+		if request.Method != "driver.session_closed" {
+			t.Errorf("method=%q, want driver.session_closed", request.Method)
+			return
+		}
+		var params pluginDriverSessionClosedParams
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			t.Errorf("decode session_closed params: %v", err)
+			return
+		}
+		respondPluginRequest(t, client, request, pluginDriverSessionClosedResult{OK: true})
+		closed <- params
+	}()
+
+	addTestWorkspace(d, "workspace-snipe-failed-spawn", t.TempDir())
+	ws := &wsClient{send: make(chan outboundMessage, 2), attachedStreams: make(map[string]ptybackend.Stream)}
+	d.handleSpawnSession(ws, &protocol.SpawnSessionMessage{
+		ID:          "snipe-failed-spawn",
+		Cwd:         t.TempDir(),
+		WorkspaceID: "workspace-snipe-failed-spawn",
+		Agent:       "snipe",
+		Cols:        80,
+		Rows:        24,
+	})
+
+	params := <-closed
+	if params.SessionID != "snipe-failed-spawn" || params.RunID == "" || params.Reason != "launch_failed" {
+		t.Fatalf("session_closed params=%+v, want failed launch cleanup", params)
+	}
+	if session := d.store.Get("snipe-failed-spawn"); session != nil {
+		t.Fatalf("stored session=%+v after failed PTY spawn, want none", session)
 	}
 }
 

--- a/internal/daemon/plugin_rpc.go
+++ b/internal/daemon/plugin_rpc.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-const pluginAPIVersion = 1
+const pluginAPIVersion = 2
 const pluginHealthMethod = "attn.health"
 const pluginHealthInterval = 15 * time.Second
 const pluginHealthTimeout = 2 * time.Second

--- a/internal/daemon/plugin_runtime.go
+++ b/internal/daemon/plugin_runtime.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -18,6 +19,17 @@ type pluginManifestIssue = plugins.ManifestIssue
 
 func discoverPluginManifests(pluginDir string) ([]pluginManifest, []pluginManifestIssue) {
 	return plugins.Discover(pluginDir)
+}
+
+// pluginDirForSocket keeps plugin discovery in the same runtime root as the
+// daemon socket. App-managed daemon restarts route by socket path, so relying
+// only on an inherited ATTN_PROFILE can otherwise make a profile daemon start
+// against the default profile's plugins after a restart.
+func pluginDirForSocket(socketPath string) string {
+	if override := strings.TrimSpace(os.Getenv("ATTN_PLUGIN_DIR")); override != "" {
+		return override
+	}
+	return filepath.Join(filepath.Dir(socketPath), "plugins")
 }
 
 func loadPluginManifest(path string) (pluginManifest, error) {
@@ -90,6 +102,7 @@ func (d *Daemon) ensurePluginProcessRegistry() *pluginProcessRegistry {
 
 func (d *Daemon) startInstalledPlugins() {
 	manifests, issues := discoverPluginManifests(d.pluginDir)
+	d.logf("plugin discovery dir=%s manifests=%d issues=%d", d.pluginDir, len(manifests), len(issues))
 	for _, issue := range issues {
 		d.logf("plugin manifest skipped: %v", issue)
 	}

--- a/internal/daemon/plugin_runtime_test.go
+++ b/internal/daemon/plugin_runtime_test.go
@@ -9,6 +9,19 @@ import (
 	"time"
 )
 
+func TestPluginDirForSocketUsesSocketRuntimeRoot(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "profile", "attn.sock")
+	if got, want := pluginDirForSocket(socketPath), filepath.Join(filepath.Dir(socketPath), "plugins"); got != want {
+		t.Fatalf("pluginDirForSocket() = %q, want %q", got, want)
+	}
+
+	override := filepath.Join(t.TempDir(), "custom-plugins")
+	t.Setenv("ATTN_PLUGIN_DIR", override)
+	if got := pluginDirForSocket(socketPath); got != override {
+		t.Fatalf("pluginDirForSocket() with override = %q, want %q", got, override)
+	}
+}
+
 func TestDiscoverPluginManifests_LoadsValidInstalledPlugins(t *testing.T) {
 	pluginDir := filepath.Join(t.TempDir(), "plugins")
 	writeTestPluginManifest(t, pluginDir, "worktree-provider")
@@ -37,7 +50,7 @@ func TestDiscoverPluginManifests_ReportsInvalidManifest(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(badDir, pluginManifestName), []byte(`
 name = "bad-plugin"
 version = "0.1.0"
-attn_api_version = 1
+attn_api_version = 2
 `), 0o644); err != nil {
 		t.Fatalf("write bad manifest: %v", err)
 	}
@@ -64,7 +77,7 @@ func TestDiscoverPluginManifests_AllowsRuntimeOnlyManifestNames(t *testing.T) {
 	manifest := []byte(`
 name = "manual/provider"
 version = "0.1.0"
-attn_api_version = 1
+attn_api_version = 2
 
 [plugin]
 entrypoint = "src/index.ts"
@@ -184,7 +197,7 @@ func writeTestPluginManifest(t *testing.T, pluginDir, name string) {
 	manifest := []byte(`
 name = "` + name + `"
 version = "0.1.0"
-attn_api_version = 1
+attn_api_version = 2
 
 [plugin]
 entrypoint = "src/index.ts"

--- a/internal/daemon/ws_plugins_test.go
+++ b/internal/daemon/ws_plugins_test.go
@@ -90,7 +90,7 @@ mkdir -p "$5/src"
 cat > "$5/attn-plugin.toml" <<'EOF'
 name = "attn-snipe"
 version = "0.1.0"
-attn_api_version = 1
+attn_api_version = 2
 
 [plugin]
 entrypoint = "src/index.ts"

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -595,6 +595,8 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 			CWD:           cwd,
 			Label:         label,
 			Yolo:          protocol.Deref(msg.YoloMode),
+			Model:         spawnOpts.Model,
+			Effort:        spawnOpts.Effort,
 			InitialPrompt: initialPrompt,
 		}
 		if metadata := strings.TrimSpace(d.store.GetAgentMetadata(msg.ID)); metadata != "" && json.Valid([]byte(metadata)) {
@@ -608,7 +610,7 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		}
 		commandEnv, err := pluginCommandEnv(result.Env)
 		if err != nil {
-			d.finishPluginSessionLaunch(msg.ID, false)
+			d.abortPluginSessionLaunch(msg.ID, "launch_failed")
 			d.sendSpawnFailure(client, msg.ID, err)
 			return
 		}
@@ -625,7 +627,7 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 
 	if err := d.ptyBackend.Spawn(context.Background(), spawnOpts); err != nil {
 		if hasPluginDriver {
-			d.finishPluginSessionLaunch(msg.ID, false)
+			d.abortPluginSessionLaunch(msg.ID, "launch_failed")
 		}
 		if chiefAssigned {
 			d.clearChiefOfStaffIfSession(msg.ID)
@@ -696,7 +698,7 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		}
 		if err := d.store.AddChecked(session); err != nil {
 			if hasPluginDriver {
-				d.finishPluginSessionLaunch(msg.ID, false)
+				d.abortPluginSessionLaunch(msg.ID, "launch_failed")
 			}
 			if chiefAssigned {
 				d.clearChiefOfStaffIfSession(msg.ID)
@@ -714,8 +716,24 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 			return
 		}
 		if hasPluginDriver && !d.store.BeginAgentDriverRun(session.ID, pluginDriver.PluginName, pluginRunID) {
-			d.finishPluginSessionLaunch(msg.ID, false)
-			d.logf("failed to initialize plugin driver run cursor: session=%s", session.ID)
+			d.abortPluginSessionLaunch(msg.ID, "launch_failed")
+			if chiefAssigned {
+				d.clearChiefOfStaffIfSession(msg.ID)
+			}
+			killErr := d.ptyBackend.Kill(context.Background(), msg.ID, syscall.SIGTERM)
+			removeErr := d.ptyBackend.Remove(context.Background(), msg.ID)
+			if existingSession == nil {
+				d.store.Remove(session.ID)
+			}
+			cursorErr := fmt.Errorf("initialize plugin driver run cursor")
+			if killErr != nil {
+				cursorErr = fmt.Errorf("%w; kill spawned runtime: %v", cursorErr, killErr)
+			}
+			if removeErr != nil {
+				cursorErr = fmt.Errorf("%w; remove spawned runtime: %v", cursorErr, removeErr)
+			}
+			d.sendSpawnFailure(client, msg.ID, cursorErr)
+			return
 		}
 		if persistResumeID := agentdriver.SpawnResumeSessionID(
 			driver,

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	APIVersion   = 1
+	APIVersion   = 2
 	ManifestName = "attn-plugin.toml"
 )
 

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -87,7 +87,7 @@ mkdir -p "$5/src"
 cat > "$5/attn-plugin.toml" <<'EOF'
 name = "attn-snipe"
 version = "0.1.0"
-attn_api_version = 1
+attn_api_version = 2
 
 [plugin]
 entrypoint = "src/index.ts"
@@ -235,7 +235,7 @@ func TestLoadManifestRejectsEntrypointTraversal(t *testing.T) {
 	manifest := []byte(`
 name = "worktree-provider"
 version = "0.1.0"
-attn_api_version = 1
+attn_api_version = 2
 
 [plugin]
 entrypoint = "../outside.ts"
@@ -259,7 +259,7 @@ func writeTestPlugin(t *testing.T, root, name string) {
 	manifest := []byte(`
 name = "` + name + `"
 version = "0.1.0"
-attn_api_version = 1
+attn_api_version = 2
 
 [plugin]
 entrypoint = "src/index.ts"

--- a/plugins/attn-opencode/README.md
+++ b/plugins/attn-opencode/README.md
@@ -1,0 +1,35 @@
+# attn OpenCode plugin
+
+This installable plugin runs an OpenCode TUI in an attn-owned PTY while the
+plugin uses OpenCode's loopback HTTP/SSE server to create and monitor the
+linked native session. It requires OpenCode `1.17.16` or `1.17.18`; versions
+outside that contract-tested set stay visible as an unhealthy plugin and do not
+register the `opencode` agent.
+
+Install it into a non-production attn profile while developing:
+
+```sh
+attn plugin install --path /path/to/attn/plugins/attn-opencode
+```
+
+Restart that profile's daemon after installation. The plugin resolves
+`ATTN_OPENCODE_EXECUTABLE` first, then `opencode` from the daemon's login-shell
+`PATH`.
+
+An ordinary promptless OpenCode session launches the TUI with OpenCode's own
+model and variant defaults. The plugin observes the native session OpenCode
+creates and persists its identity for resume. Delegated OpenCode sessions
+require an explicit `--model provider/model` and one of the contract-tested
+effort pins: `--effort low` or `--effort max`. The plugin sends those pins to
+OpenCode's server as `{ providerID, id, variant }`, so its staged prompt is
+bound to the selected native session. Other effort labels remain intentionally
+unsupported until they have the same adapter and live-app evidence.
+
+Each run gets a separate loopback port and random Basic-auth password. The
+password and staged prompt live in private files under the active profile's
+attn data directory (`plugins/attn-opencode/`), are never included in metadata
+or argv, and are deleted when attn reports that the PTY run has closed.
+
+The first slice reports OpenCode `busy` and `retry` as `working`, and explicit
+`idle` as `idle`. It intentionally does not infer `waiting_input` from an idle
+event.

--- a/plugins/attn-opencode/attn-plugin.toml
+++ b/plugins/attn-opencode/attn-plugin.toml
@@ -1,0 +1,7 @@
+name = "attn-opencode"
+version = "0.1.0"
+attn_api_version = 2
+description = "Server-backed OpenCode driver for attn"
+
+[plugin]
+entrypoint = "src/index.ts"

--- a/plugins/attn-opencode/package.json
+++ b/plugins/attn-opencode/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "attn-opencode",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "bun test"
+  }
+}

--- a/plugins/attn-opencode/src/attn-rpc.ts
+++ b/plugins/attn-opencode/src/attn-rpc.ts
@@ -1,0 +1,154 @@
+import { createConnection, type Socket } from "node:net";
+import { pluginAPIVersion } from "./types";
+
+type JSONRPCID = number | string;
+
+type JSONRPCRequest = {
+  jsonrpc: "2.0";
+  id: JSONRPCID;
+  method: string;
+  params?: unknown;
+};
+
+type JSONRPCResponse = {
+  jsonrpc: "2.0";
+  id: JSONRPCID;
+  result?: unknown;
+  error?: { code: number; message: string };
+};
+
+type Pending = {
+  resolve: (result: unknown) => void;
+  reject: (error: Error) => void;
+};
+
+export type RPCHandler = (params: unknown) => Promise<unknown> | unknown;
+
+export class AttnRPCClient {
+  private socket?: Socket;
+  private buffer = "";
+  private nextID = 1;
+  private readonly pending = new Map<string, Pending>();
+  private readonly handlers = new Map<string, RPCHandler>();
+
+  constructor(
+    private readonly options: {
+      socketPath: string;
+      name: string;
+      version: string;
+    },
+  ) {}
+
+  handle(method: string, handler: RPCHandler): void {
+    if (this.socket) {
+      throw new Error("register RPC handlers before connecting");
+    }
+    this.handlers.set(method, handler);
+  }
+
+  async connect(): Promise<void> {
+    if (this.socket) return;
+    const socket = await new Promise<Socket>((resolve, reject) => {
+      const candidate = createConnection({ path: this.options.socketPath });
+      candidate.once("error", reject);
+      candidate.once("connect", () => {
+        candidate.off("error", reject);
+        resolve(candidate);
+      });
+    });
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => this.consume(chunk));
+    socket.on("error", (error) => this.failPending(error));
+    socket.on("close", () => {
+      this.socket = undefined;
+      this.failPending(new Error("attn plugin socket closed"));
+    });
+    this.socket = socket;
+
+    try {
+      const result = await this.request<{ ok: boolean }>("hello", {
+        name: this.options.name,
+        version: this.options.version,
+        attn_api_version: pluginAPIVersion,
+      });
+      if (!result.ok) throw new Error("attn rejected plugin hello");
+    } catch (error) {
+      this.close();
+      throw error;
+    }
+  }
+
+  close(): void {
+    this.socket?.destroy();
+    this.socket = undefined;
+    this.failPending(new Error("attn plugin client closed"));
+  }
+
+  request<TResult = unknown>(method: string, params?: unknown): Promise<TResult> {
+    const id = this.nextID++;
+    const result = new Promise<TResult>((resolve, reject) => {
+      this.pending.set(String(id), { resolve: (value) => resolve(value as TResult), reject });
+    });
+    try {
+      this.send({ jsonrpc: "2.0", id, method, params });
+    } catch (error) {
+      this.pending.delete(String(id));
+      throw error;
+    }
+    return result;
+  }
+
+  private consume(chunk: string): void {
+    this.buffer += chunk;
+    for (;;) {
+      const end = this.buffer.indexOf("\n");
+      if (end < 0) return;
+      const line = this.buffer.slice(0, end).trim();
+      this.buffer = this.buffer.slice(end + 1);
+      if (line === "") continue;
+      this.route(JSON.parse(line) as JSONRPCRequest | JSONRPCResponse);
+    }
+  }
+
+  private route(message: JSONRPCRequest | JSONRPCResponse): void {
+    if ("method" in message) {
+      void this.respond(message);
+      return;
+    }
+    const pending = this.pending.get(String(message.id));
+    if (!pending) return;
+    this.pending.delete(String(message.id));
+    if (message.error) {
+      pending.reject(new Error(message.error.message));
+      return;
+    }
+    pending.resolve(message.result);
+  }
+
+  private async respond(request: JSONRPCRequest): Promise<void> {
+    const handler = this.handlers.get(request.method);
+    if (!handler) {
+      this.sendError(request.id, -32601, `unknown method ${request.method}`);
+      return;
+    }
+    try {
+      this.send({ jsonrpc: "2.0", id: request.id, result: await handler(request.params) });
+    } catch (error) {
+      this.sendError(request.id, -32603, error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  private send(message: JSONRPCRequest | JSONRPCResponse): void {
+    if (!this.socket) throw new Error("attn plugin socket is not connected");
+    this.socket.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private sendError(id: JSONRPCID, code: number, message: string): void {
+    this.send({ jsonrpc: "2.0", id, error: { code, message } });
+  }
+
+  private failPending(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+}

--- a/plugins/attn-opencode/src/driver.ts
+++ b/plugins/attn-opencode/src/driver.ts
@@ -1,0 +1,573 @@
+import { createServer } from "node:net";
+import { join } from "node:path";
+import { type EventSubscription, OpenCodeHTTP, parseModelPin, sessionModel, sessionModelMatches, variantForEffort } from "./opencode-http";
+import { RunRegistry } from "./run-registry";
+import {
+  type DriverSpawnParams,
+  type DriverSpawnResult,
+  type LaunchConfig,
+  type OpenCodeMetadata,
+  type OpenCodeModel,
+  type Report,
+  type RunRecord,
+  type SessionClosedParams,
+  supportedOpenCodeVersions,
+} from "./types";
+
+const startupDeadlineMs = 20_000;
+const reconnectDelayMs = 250;
+const healthRequestTimeoutMs = 2_000;
+const eventReconnectAttempts = 3;
+
+export type AttnReporter = {
+  request<T = unknown>(method: string, params?: unknown): Promise<T>;
+};
+
+type CommandResult = { exitCode: number; stdout: string; stderr: string };
+
+export type OpenCodeDriverOptions = {
+  rpc: AttnReporter;
+  registry: RunRegistry;
+  executable?: string;
+  runCommand?: (argv: string[]) => Promise<CommandResult>;
+  allocatePort?: () => Promise<number>;
+  http?: (port: number, password: string) => OpenCodeHTTP;
+  startupDeadline?: number;
+  reconnectDelay?: number;
+  healthRequestTimeout?: number;
+};
+
+type Availability =
+  | { ok: true; executable: string; version: string }
+  | { ok: false; message: string };
+
+type LaunchSelection = {
+  mode: "interactive" | "pinned";
+  model?: OpenCodeModel;
+  modelText?: string;
+  variant?: string;
+  nativeSessionID?: string;
+};
+
+type NativeBinding = {
+  record: RunRecord;
+  nativeID?: string;
+  mode: LaunchSelection["mode"];
+};
+
+export class OpenCodeDriver {
+  private readonly executable: string;
+  private readonly runCommand: (argv: string[]) => Promise<CommandResult>;
+  private readonly allocatePort: () => Promise<number>;
+  private readonly http: (port: number, password: string) => OpenCodeHTTP;
+  private readonly startupDeadline: number;
+  private readonly reconnectDelay: number;
+  private readonly healthRequestTimeout: number;
+  private availability: Availability = { ok: false, message: "OpenCode has not been checked" };
+  private readonly monitors = new Map<string, AbortController>();
+  private readonly reportQueues = new Map<string, Promise<void>>();
+  private readonly degraded = new Map<string, string>();
+
+  constructor(private readonly options: OpenCodeDriverOptions) {
+    this.executable = options.executable?.trim() || process.env.ATTN_OPENCODE_EXECUTABLE?.trim() || "opencode";
+    this.runCommand = options.runCommand ?? runCommand;
+    this.allocatePort = options.allocatePort ?? allocateLoopbackPort;
+    this.http = options.http ?? ((port, password) => new OpenCodeHTTP({ port, password }));
+    this.startupDeadline = options.startupDeadline ?? startupDeadlineMs;
+    this.reconnectDelay = options.reconnectDelay ?? reconnectDelayMs;
+    this.healthRequestTimeout = options.healthRequestTimeout ?? healthRequestTimeoutMs;
+  }
+
+  async initialize(): Promise<void> {
+    await this.options.registry.initialize();
+    await this.options.registry.pruneDead(async (record) => {
+      try {
+        const config = await this.options.registry.readLaunchConfig(record);
+        const password = await this.options.registry.password(record);
+        await this.healthWithin(this.http(config.port, password));
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    await this.refreshAvailability();
+    if (this.availability.ok) {
+      await this.options.rpc.request("driver.register", {
+        agent: "opencode",
+        capabilities: {
+          resume: true,
+          yolo: true,
+          initial_prompt: true,
+          state_reporting: true,
+          model_pin: true,
+          effort_pin: true,
+        },
+      });
+    }
+  }
+
+  health(): { ok: boolean; message: string } {
+    if (!this.availability.ok) return { ok: false, message: this.availability.message };
+    if (this.degraded.size > 0) {
+      return { ok: false, message: [...this.degraded.values()].join("; ") };
+    }
+    return { ok: true, message: `OpenCode ${this.availability.version} is ready` };
+  }
+
+  async spawn(params: DriverSpawnParams): Promise<DriverSpawnResult> {
+    return this.launch(params, false);
+  }
+
+  async resume(params: DriverSpawnParams): Promise<DriverSpawnResult> {
+    return this.launch(params, true);
+  }
+
+  async sessionClosed(params: SessionClosedParams): Promise<{ ok: true }> {
+    const controller = this.monitors.get(params.run_id);
+    controller?.abort();
+    this.monitors.delete(params.run_id);
+    this.reportQueues.delete(params.run_id);
+    this.degraded.delete(params.run_id);
+    await this.options.registry.cleanup(params.run_id);
+    return { ok: true };
+  }
+
+  private async launch(params: DriverSpawnParams, resume: boolean): Promise<DriverSpawnResult> {
+    const availability = await this.requireAvailability();
+    const selection = resume ? this.resumeSelection(params, availability.version) : this.freshSelection(params);
+    const port = await this.allocatePort();
+    let record: RunRecord | undefined;
+    try {
+      record = await this.options.registry.create({
+        schema: 1,
+        attn_session_id: requireText(params.session_id, "session_id"),
+        run_id: requireText(params.run_id, "run_id"),
+        next_seq: 1,
+        port,
+        opencode_session_id: selection.nativeSessionID,
+        opencode_version: availability.version,
+        pinned: selection.mode === "pinned",
+        model: selection.modelText,
+        variant: selection.model?.variant ?? selection.variant,
+        resume,
+        created_at: new Date().toISOString(),
+      }, params.initial_prompt ?? "");
+      const launchConfig: LaunchConfig = {
+        schema: 1,
+        run_id: record.run_id,
+        executable: availability.executable,
+        cwd: params.cwd,
+        password_ref: record.password_ref,
+        port,
+        yolo: params.yolo === true,
+        resume_session_id: selection.nativeSessionID,
+      };
+      await this.options.registry.writeLaunchConfig(record, launchConfig);
+      const controller = new AbortController();
+      this.monitors.set(record.run_id, controller);
+      void this.monitor(record, selection, controller.signal);
+      return {
+        argv: [process.execPath, "run", join(import.meta.dir, "launcher.ts"), record.launch_config_ref],
+        cwd: params.cwd,
+      };
+    } catch (error) {
+      if (record) await this.options.registry.cleanup(record.run_id);
+      throw error;
+    }
+  }
+
+  private freshSelection(params: DriverSpawnParams): LaunchSelection {
+    const modelText = params.model?.trim() ?? "";
+    const effort = params.effort?.trim() ?? "";
+    const stagedPrompt = params.initial_prompt?.trim() ?? "";
+    if (!modelText && !effort && !stagedPrompt) return { mode: "interactive" };
+    if (!modelText) throw new Error("OpenCode staged prompts require a delegated model pin");
+    if (!effort) throw new Error("OpenCode pinned launches require an explicit effort pin");
+    return {
+      mode: "pinned",
+      modelText,
+      model: { ...parseModelPin(modelText), variant: variantForEffort(effort) },
+    };
+  }
+
+  private resumeSelection(params: DriverSpawnParams, version: string): LaunchSelection {
+    if (params.metadata === undefined || params.metadata === null || params.metadata === "") {
+      // An interactive TUI has no native identity until its first normal user
+      // prompt. A recovery attempt in that window must relaunch a fresh TUI,
+      // not advertise a resume target that the plugin cannot name.
+      return this.freshSelection(params);
+    }
+    const metadata = parseMetadata(params.metadata);
+    const pinned = metadata.pinned ?? Boolean(metadata.model && metadata.variant);
+    if (metadata.opencode_version !== version) {
+      throw new Error(`OpenCode resume requires version ${metadata.opencode_version}, found ${version}`);
+    }
+    if (params.model && (!pinned || !metadata.model || params.model !== metadata.model)) {
+      throw new Error("OpenCode resume model pin does not match the persisted native session");
+    }
+    if (params.effort && (!pinned || !metadata.variant || variantForEffort(params.effort) !== metadata.variant)) {
+      throw new Error("OpenCode resume effort pin does not match the persisted native session");
+    }
+    const model = pinned && metadata.model && metadata.variant
+      ? { ...parseModelPin(metadata.model), variant: metadata.variant }
+      : undefined;
+    return {
+      mode: pinned ? "pinned" : "interactive",
+      model,
+      modelText: metadata.model,
+      variant: metadata.variant,
+      nativeSessionID: metadata.opencode_session_id,
+    };
+  }
+
+  private async monitor(initialRecord: RunRecord, selection: LaunchSelection, signal: AbortSignal): Promise<void> {
+    const binding: NativeBinding = {
+      record: initialRecord,
+      nativeID: initialRecord.opencode_session_id,
+      mode: selection.mode,
+    };
+    const eventController = new AbortController();
+    const abortEventsForSession = () => eventController.abort(signal.reason);
+    if (signal.aborted) {
+      abortEventsForSession();
+    } else {
+      signal.addEventListener("abort", abortEventsForSession, { once: true });
+    }
+    let subscription: EventSubscription | undefined;
+    try {
+      const client = await this.waitForHealthyServer(binding.record, signal);
+      if (signal.aborted) return;
+
+      subscription = client.subscribe((event) => this.handleEvent(client, binding, event, eventController.signal), eventController.signal);
+      const setup = this.requestDeadline(signal);
+      try {
+        await this.awaitSubscriptionReady(subscription, setup.signal);
+
+        if (binding.nativeID) {
+          const nativeSession = await client.getSession(binding.nativeID, setup.signal);
+          if (selection.model && !sessionModelMatches(nativeSession, selection.model)) {
+            throw new Error("persisted OpenCode session model or variant no longer matches the delegated pins");
+          }
+          await this.reconcileStatus(binding.record, client, binding.nativeID, setup.signal);
+          await client.selectSession(binding.nativeID, setup.signal);
+        } else if (selection.mode === "pinned") {
+          const model = selection.model!;
+          const nativeID = await client.createSession(model, setup.signal);
+          binding.nativeID = nativeID;
+          binding.record = await this.options.registry.update(binding.record.run_id, { opencode_session_id: nativeID });
+          await this.enqueueReport(binding.record, {
+            kind: "metadata",
+            metadata: {
+              schema: 1,
+              opencode_session_id: nativeID,
+              opencode_version: binding.record.opencode_version,
+              pinned: true,
+              model: binding.record.model,
+              variant: binding.record.variant,
+            },
+          });
+          // A just-submitted prompt can be absent from /session/status until its
+          // first explicit lifecycle event. Reconciliation therefore never infers
+          // idle from absence.
+          await this.reconcileStatus(binding.record, client, nativeID, setup.signal);
+          await client.selectSession(nativeID, setup.signal);
+          const prompt = await this.options.registry.prompt(binding.record);
+          if (prompt !== "") await client.promptAsync(nativeID, prompt, model, setup.signal);
+        }
+      } finally {
+        setup.dispose();
+      }
+
+      let establishedStreamFailures = 0;
+      for (;;) {
+        const activeSubscription = subscription;
+        if (!activeSubscription) return;
+        try {
+          await activeSubscription.done;
+          establishedStreamFailures = 0;
+        } catch (error) {
+          // OpenCode can close an otherwise healthy idle SSE stream. Reconnect
+          // before degrading the run. Repeated established-stream failures are
+          // terminal even when each replacement reached SSE readiness.
+          if (signal.aborted) return;
+          establishedStreamFailures += 1;
+          if (establishedStreamFailures >= eventReconnectAttempts) throw error;
+        }
+        if (signal.aborted) return;
+        let reconnectError: unknown;
+        for (let attempt = 0; attempt < eventReconnectAttempts; attempt += 1) {
+          await sleep(this.reconnectDelay, signal);
+          if (signal.aborted) return;
+          subscription = client.subscribe((event) => this.handleEvent(client, binding, event, eventController.signal), eventController.signal);
+          const setup = this.requestDeadline(signal);
+          try {
+            await this.awaitSubscriptionReady(subscription, setup.signal);
+            await this.reconcileStatus(binding.record, client, binding.nativeID, setup.signal);
+            reconnectError = undefined;
+            break;
+          } catch (error) {
+            subscription.abort();
+            if (signal.aborted) return;
+            reconnectError = error;
+          } finally {
+            setup.dispose();
+          }
+        }
+        if (reconnectError) throw reconnectError;
+      }
+    } catch (error) {
+      if (signal.aborted) return;
+      // Setup failures are terminal for this run. Stop the event stream before
+      // reporting degraded state so a late SSE event cannot overwrite it.
+      eventController.abort(error);
+      subscription?.abort();
+      const message = `OpenCode run ${initialRecord.attn_session_id} is degraded: ${safeError(error)}`;
+      this.degraded.set(initialRecord.run_id, message);
+      try {
+        await this.enqueueReport(binding.record, { kind: "state", state: "unknown" });
+      } catch {
+        // The run's failure is already visible through plugin health. Do not let
+        // a disconnected daemon turn error handling into an unhandled rejection.
+      }
+    } finally {
+      signal.removeEventListener("abort", abortEventsForSession);
+      eventController.abort();
+    }
+  }
+
+  private async waitForHealthyServer(record: RunRecord, signal: AbortSignal): Promise<OpenCodeHTTP> {
+    const deadline = Date.now() + this.startupDeadline;
+    let lastError: unknown = new Error("OpenCode server did not start");
+    while (Date.now() < deadline && !signal.aborted) {
+      try {
+        const config = await this.options.registry.readLaunchConfig(record);
+        if (config.port !== record.port) record = await this.options.registry.update(record.run_id, { port: config.port });
+        const password = await this.options.registry.password(record);
+        const client = this.http(record.port, password);
+        const health = await this.healthWithin(client, signal, deadline - Date.now());
+        if (health.version !== record.opencode_version || !supportedOpenCodeVersions.has(health.version)) {
+          throw new Error(`OpenCode server version ${health.version} is not the verified ${record.opencode_version}`);
+        }
+        return client;
+      } catch (error) {
+        lastError = error;
+        await sleep(this.reconnectDelay, signal);
+      }
+    }
+    throw lastError;
+  }
+
+  private async reconcileStatus(record: RunRecord, client: OpenCodeHTTP, nativeID: string | undefined, signal?: AbortSignal): Promise<void> {
+    if (!nativeID) return;
+    const status = await client.statusFor(nativeID, signal);
+    if (status === "busy" || status === "retry") {
+      await this.enqueueReport(record, { kind: "state", state: "working" });
+    } else if (status === "idle") {
+      await this.enqueueReport(record, { kind: "stop", verdict: "idle" });
+    }
+  }
+
+  private async handleEvent(client: OpenCodeHTTP, binding: NativeBinding, event: { type: string; sessionID?: string; status?: string }, parentSignal: AbortSignal): Promise<void> {
+    if (parentSignal.aborted) return;
+    if (!binding.nativeID && binding.mode === "interactive" && event.type === "session.created" && event.sessionID) {
+      const request = this.requestDeadline(parentSignal);
+      let nativeSession: unknown;
+      try {
+        nativeSession = await client.getSession(event.sessionID, request.signal);
+      } finally {
+        request.dispose();
+      }
+      if (parentSignal.aborted) return;
+      const selectedModel = sessionModel(nativeSession);
+      binding.nativeID = event.sessionID;
+      binding.record = await this.options.registry.update(binding.record.run_id, {
+        opencode_session_id: event.sessionID,
+        pinned: false,
+        model: selectedModel ? `${selectedModel.providerID}/${selectedModel.id}` : undefined,
+        variant: selectedModel?.variant,
+      });
+      await this.enqueueReport(binding.record, {
+        kind: "metadata",
+        metadata: {
+          schema: 1,
+          opencode_session_id: event.sessionID,
+          opencode_version: binding.record.opencode_version,
+          pinned: false,
+          ...(selectedModel ? { model: `${selectedModel.providerID}/${selectedModel.id}`, variant: selectedModel.variant } : {}),
+        },
+      });
+      const statusRequest = this.requestDeadline(parentSignal);
+      try {
+        await this.reconcileStatus(binding.record, client, binding.nativeID, statusRequest.signal);
+      } finally {
+        statusRequest.dispose();
+      }
+    }
+    if (parentSignal.aborted || !binding.nativeID || event.sessionID !== binding.nativeID) return;
+    const record = binding.record;
+    if (event.type === "session.status") {
+      if (event.status === "busy" || event.status === "retry") {
+        await this.enqueueReport(record, { kind: "state", state: "working" });
+      } else if (event.status === "idle") {
+        await this.enqueueReport(record, { kind: "stop", verdict: "idle" });
+      }
+    } else if (event.type === "session.idle") {
+      await this.enqueueReport(record, { kind: "stop", verdict: "idle" });
+    } else if (event.type === "session.error") {
+      await this.enqueueReport(record, { kind: "state", state: "unknown" });
+    }
+  }
+
+  private enqueueReport(record: RunRecord, report: Report): Promise<void> {
+    const previous = this.reportQueues.get(record.run_id) ?? Promise.resolve();
+    const next = previous.then(() => this.sendReport(record, report));
+    this.reportQueues.set(record.run_id, next.catch(() => undefined));
+    return next;
+  }
+
+  private async healthWithin(client: OpenCodeHTTP, parentSignal?: AbortSignal, limit = this.healthRequestTimeout): Promise<{ version: string }> {
+    const request = this.requestDeadline(parentSignal, limit);
+    try {
+      return await client.health(request.signal);
+    } finally {
+      request.dispose();
+    }
+  }
+
+  private requestDeadline(parentSignal?: AbortSignal, limit = this.healthRequestTimeout): { signal: AbortSignal; dispose: () => void } {
+    if (limit <= 0) throw new Error("OpenCode server request deadline elapsed");
+    const controller = new AbortController();
+    const abortForParent = () => controller.abort(parentSignal?.reason);
+    if (parentSignal?.aborted) {
+      abortForParent();
+    } else {
+      parentSignal?.addEventListener("abort", abortForParent, { once: true });
+    }
+    const timer = setTimeout(() => controller.abort(), Math.min(limit, this.healthRequestTimeout));
+    return {
+      signal: controller.signal,
+      dispose: () => {
+        clearTimeout(timer);
+        parentSignal?.removeEventListener("abort", abortForParent);
+      },
+    };
+  }
+
+  private async awaitSubscriptionReady(subscription: { ready: Promise<void>; abort: () => void }, signal: AbortSignal): Promise<void> {
+    if (signal.aborted) {
+      subscription.abort();
+      throw new Error("OpenCode event subscription deadline elapsed");
+    }
+    await new Promise<void>((resolve, reject) => {
+      const abort = () => {
+        subscription.abort();
+        reject(new Error("OpenCode event subscription deadline elapsed"));
+      };
+      signal.addEventListener("abort", abort, { once: true });
+      subscription.ready.then(
+        () => {
+          signal.removeEventListener("abort", abort);
+          resolve();
+        },
+        (error) => {
+          signal.removeEventListener("abort", abort);
+          reject(error);
+        },
+      );
+    });
+  }
+
+  private async sendReport(record: RunRecord, report: Report): Promise<void> {
+    const seq = await this.options.registry.reserveSequence(record.run_id);
+    const base = { session_id: record.attn_session_id, run_id: record.run_id, seq };
+    switch (report.kind) {
+      case "metadata":
+        await this.options.rpc.request("session.report_metadata", { ...base, metadata: report.metadata });
+        return;
+      case "state":
+        await this.options.rpc.request("session.report_state", { ...base, state: report.state });
+        return;
+      case "stop":
+        await this.options.rpc.request("session.report_stop", { ...base, verdict: report.verdict });
+        return;
+    }
+  }
+
+  private async refreshAvailability(): Promise<void> {
+    try {
+      const result = await this.runCommand([this.executable, "--version"]);
+      const version = result.stdout.trim().replace(/^v/, "");
+      if (result.exitCode !== 0) throw new Error(result.stderr.trim() || `exit ${result.exitCode}`);
+      if (!supportedOpenCodeVersions.has(version)) {
+        throw new Error(`version ${version || "(empty)"} is unsupported; verified versions: ${[...supportedOpenCodeVersions].join(", ")}`);
+      }
+      this.availability = { ok: true, executable: this.executable, version };
+    } catch (error) {
+      this.availability = { ok: false, message: `OpenCode executable ${this.executable} is unavailable: ${safeError(error)}` };
+    }
+  }
+
+  private async requireAvailability(): Promise<Extract<Availability, { ok: true }>> {
+    await this.refreshAvailability();
+    if (!this.availability.ok) throw new Error(this.availability.message);
+    return this.availability;
+  }
+}
+
+async function runCommand(argv: string[]): Promise<CommandResult> {
+  const child = Bun.spawn(argv, { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+async function allocateLoopbackPort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("failed to reserve loopback port")));
+        return;
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+function parseMetadata(value: unknown): OpenCodeMetadata {
+  const metadata = typeof value === "string" ? JSON.parse(value) : value;
+  if (!metadata || typeof metadata !== "object") throw new Error("OpenCode resume requires persisted metadata");
+  const result = metadata as Partial<OpenCodeMetadata>;
+  if (result.schema !== 1 || !result.opencode_session_id || !result.opencode_version ||
+    (result.pinned !== undefined && typeof result.pinned !== "boolean") ||
+    (result.model !== undefined && typeof result.model !== "string") ||
+    (result.variant !== undefined && typeof result.variant !== "string")) {
+    throw new Error("OpenCode resume metadata is incomplete");
+  }
+  return result as OpenCodeMetadata;
+}
+
+function requireText(value: string | undefined, label: string): string {
+  const normalized = value?.trim() ?? "";
+  if (!normalized) throw new Error(`${label} is required`);
+  return normalized;
+}
+
+function safeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, ms);
+    signal.addEventListener("abort", () => {
+      clearTimeout(timeout);
+      resolve();
+    }, { once: true });
+  });
+}

--- a/plugins/attn-opencode/src/index.ts
+++ b/plugins/attn-opencode/src/index.ts
@@ -1,0 +1,26 @@
+import { AttnRPCClient } from "./attn-rpc";
+import { OpenCodeDriver } from "./driver";
+import { RunRegistry, runtimeRootFromSocket } from "./run-registry";
+import type { DriverSpawnParams, SessionClosedParams } from "./types";
+
+const socketPath = requiredEnvironment("ATTN_SOCKET_PATH");
+const pluginName = requiredEnvironment("ATTN_PLUGIN_NAME");
+const rpc = new AttnRPCClient({ socketPath, name: pluginName, version: "0.1.0" });
+const driver = new OpenCodeDriver({
+  rpc,
+  registry: new RunRegistry(runtimeRootFromSocket(socketPath)),
+});
+
+rpc.handle("attn.health", () => driver.health());
+rpc.handle("driver.spawn", (params) => driver.spawn(params as DriverSpawnParams));
+rpc.handle("driver.resume", (params) => driver.resume(params as DriverSpawnParams));
+rpc.handle("driver.session_closed", (params) => driver.sessionClosed(params as SessionClosedParams));
+
+await rpc.connect();
+await driver.initialize();
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}

--- a/plugins/attn-opencode/src/launcher.ts
+++ b/plugins/attn-opencode/src/launcher.ts
@@ -1,0 +1,84 @@
+import { createServer } from "node:net";
+import { chmod, open, readFile, rename, rm } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+import type { LaunchConfig } from "./types";
+
+const maxPortAttempts = 3;
+
+if (import.meta.main) {
+  const configPath = process.argv[2];
+  if (!configPath) throw new Error("attn-opencode launcher requires a run config path");
+  process.exitCode = await launch(configPath);
+}
+
+export async function launch(path: string): Promise<number> {
+  let config = await readConfig(path);
+  for (let attempt = 1; attempt <= maxPortAttempts; attempt += 1) {
+    const password = (await readFile(config.password_ref, "utf8")).trim();
+    const args = [config.executable, "--hostname", "127.0.0.1", "--port", String(config.port)];
+    if (config.resume_session_id) args.push("--session", config.resume_session_id);
+    if (config.yolo) args.push("--yolo");
+    const child = Bun.spawn(args, {
+      cwd: config.cwd,
+      env: { ...process.env, OPENCODE_SERVER_PASSWORD: password },
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "pipe",
+    });
+    const [display, collect] = child.stderr.tee();
+    void display.pipeTo(new WritableStream({
+      write(chunk) {
+        process.stderr.write(chunk);
+      },
+    }));
+    const stderr = await new Response(collect).text();
+    const status = await child.exited;
+    if (attempt === maxPortAttempts || !addressInUse(stderr)) return status;
+    config = { ...config, port: await allocateLoopbackPort() };
+    await writeConfig(path, config);
+  }
+  return 1;
+}
+
+async function readConfig(path: string): Promise<LaunchConfig> {
+  const parsed = JSON.parse(await readFile(path, "utf8")) as LaunchConfig;
+  if (parsed.schema !== 1 || !parsed.executable || !parsed.cwd || !parsed.password_ref || !Number.isSafeInteger(parsed.port)) {
+    throw new Error("invalid attn-opencode run config");
+  }
+  return parsed;
+}
+
+async function writeConfig(path: string, config: LaunchConfig): Promise<void> {
+  const temp = join(dirname(path), `.${basename(path)}.${randomBytes(8).toString("hex")}.tmp`);
+  const file = await open(temp, "w", 0o600);
+  try {
+    await file.writeFile(`${JSON.stringify(config)}\n`, "utf8");
+    await file.sync();
+  } finally {
+    await file.close();
+  }
+  await chmod(temp, 0o600);
+  await rename(temp, path);
+  await chmod(path, 0o600);
+  await rm(temp, { force: true });
+}
+
+async function allocateLoopbackPort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("failed to reserve loopback port")));
+        return;
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+function addressInUse(stderr: string): boolean {
+  return /EADDRINUSE|address already in use|address in use/i.test(stderr);
+}

--- a/plugins/attn-opencode/src/opencode-http.ts
+++ b/plugins/attn-opencode/src/opencode-http.ts
@@ -1,0 +1,262 @@
+import type { OpenCodeModel } from "./types";
+
+export type ServerEvent = {
+  type: string;
+  sessionID?: string;
+  status?: string;
+};
+
+export type EventSubscription = {
+  ready: Promise<void>;
+  done: Promise<void>;
+  abort: () => void;
+};
+
+export type OpenCodeHTTPOptions = {
+  port: number;
+  password: string;
+  fetch?: typeof fetch;
+};
+
+export class OpenCodeHTTP {
+  private readonly origin: string;
+  private readonly authorization: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: OpenCodeHTTPOptions) {
+    this.origin = `http://127.0.0.1:${options.port}`;
+    this.authorization = `Basic ${Buffer.from(`opencode:${options.password}`).toString("base64")}`;
+    this.fetchImpl = options.fetch ?? fetch;
+  }
+
+  async health(signal?: AbortSignal): Promise<{ version: string }> {
+    const body = await this.request<{ healthy?: boolean; version?: string }>("/global/health", { signal });
+    if (!body.healthy || typeof body.version !== "string") throw new Error("OpenCode health response was invalid");
+    return { version: body.version };
+  }
+
+  async createSession(model: OpenCodeModel, signal?: AbortSignal): Promise<string> {
+    const body = await this.request<{ id?: string }>("/session", {
+      method: "POST",
+      body: { model },
+      signal,
+    });
+    if (!body.id) throw new Error("OpenCode did not return a native session id");
+    return body.id;
+  }
+
+  async getSession(sessionID: string, signal?: AbortSignal): Promise<unknown> {
+    return this.request(`/session/${encodeURIComponent(sessionID)}`, { signal });
+  }
+
+  async selectSession(sessionID: string, signal?: AbortSignal): Promise<void> {
+    await this.request("/tui/select-session", { method: "POST", body: { sessionID }, signal });
+  }
+
+  async promptAsync(sessionID: string, prompt: string, model: OpenCodeModel, signal?: AbortSignal): Promise<void> {
+    await this.request(`/session/${encodeURIComponent(sessionID)}/prompt_async`, {
+      method: "POST",
+      // OpenCode uses different model shapes for native session creation and
+      // prompt submission. Keep the translation at this HTTP boundary so the
+      // rest of the driver continues to preserve one native-session identity.
+      body: {
+        parts: [{ type: "text", text: prompt }],
+        model: { providerID: model.providerID, modelID: model.id },
+        variant: model.variant,
+      },
+      signal,
+    });
+  }
+
+  async statusFor(sessionID: string, signal?: AbortSignal): Promise<string | undefined> {
+    const body = await this.request<unknown>("/session/status", { signal });
+    return extractStatus(body, sessionID);
+  }
+
+  subscribe(onEvent: (event: ServerEvent) => Promise<void> | void, parentSignal?: AbortSignal): EventSubscription {
+    const controller = new AbortController();
+    const abortForParent = () => controller.abort(parentSignal?.reason);
+    if (parentSignal?.aborted) {
+      abortForParent();
+    } else {
+      parentSignal?.addEventListener("abort", abortForParent, { once: true });
+    }
+    let markReady: () => void = () => {};
+    let markFailed: (error: Error) => void = () => {};
+    const ready = new Promise<void>((resolve, reject) => {
+      markReady = resolve;
+      markFailed = reject;
+    });
+    const done = this.consumeEvents(controller.signal, onEvent, markReady).catch((error) => {
+      markFailed(error instanceof Error ? error : new Error(String(error)));
+      throw error;
+    }).finally(() => parentSignal?.removeEventListener("abort", abortForParent));
+    // A startup failure rejects `ready` before the monitor has reached its
+    // `await done`; mark the rejection handled here while still returning the
+    // original promise for normal reconnect handling.
+    void done.catch(() => undefined);
+    return {
+      ready,
+      done,
+      abort: () => {
+        parentSignal?.removeEventListener("abort", abortForParent);
+        controller.abort();
+      },
+    };
+  }
+
+  private async consumeEvents(
+    signal: AbortSignal,
+    onEvent: (event: ServerEvent) => Promise<void> | void,
+    markReady: () => void,
+  ): Promise<void> {
+    const response = await this.fetchImpl(`${this.origin}/event`, {
+      headers: this.headers(),
+      signal,
+    });
+    if (!response.ok) throw new Error(`OpenCode event stream: HTTP ${response.status}`);
+    if (!response.body) throw new Error("OpenCode event stream had no body");
+    markReady();
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let eventName = "";
+    let data: string[] = [];
+    const flush = async () => {
+      if (data.length === 0) return;
+      const parsed = normalizeEvent(eventName, data.join("\n"));
+      eventName = "";
+      data = [];
+      if (parsed) await onEvent(parsed);
+    };
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        for (;;) {
+          const newline = buffer.indexOf("\n");
+          if (newline < 0) break;
+          const line = buffer.slice(0, newline).replace(/\r$/, "");
+          buffer = buffer.slice(newline + 1);
+          if (line === "") {
+            await flush();
+          } else if (line.startsWith("event:")) {
+            eventName = line.slice("event:".length).trim();
+          } else if (line.startsWith("data:")) {
+            data.push(line.slice("data:".length).trimStart());
+          }
+        }
+      }
+      await flush();
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private async request<T = unknown>(path: string, init: { method?: string; body?: unknown; signal?: AbortSignal } = {}): Promise<T> {
+    const response = await this.fetchImpl(`${this.origin}${path}`, {
+      method: init.method ?? "GET",
+      headers: {
+        ...this.headers(),
+        ...(init.body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+      signal: init.signal,
+    });
+    if (!response.ok) throw new Error(`OpenCode ${path}: HTTP ${response.status}`);
+    if (response.status === 204) return undefined as T;
+    return (await response.json()) as T;
+  }
+
+  private headers(): HeadersInit {
+    return { authorization: this.authorization };
+  }
+}
+
+export function parseModelPin(value: string): Omit<OpenCodeModel, "variant"> {
+  const slash = value.indexOf("/");
+  if (slash <= 0 || slash === value.length - 1) {
+    throw new Error("OpenCode model pin must use provider/model form");
+  }
+  return { providerID: value.slice(0, slash), id: value.slice(slash + 1) };
+}
+
+export function variantForEffort(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) throw new Error("OpenCode requires an explicit effort pin to select a variant");
+  const variants: Record<string, string> = {
+    low: "low",
+    max: "max",
+  };
+  const variant = variants[normalized];
+  if (!variant) throw new Error(`OpenCode effort ${JSON.stringify(value)} has no verified variant mapping`);
+  return variant;
+}
+
+export function sessionModelMatches(value: unknown, model: OpenCodeModel): boolean {
+  const selected = sessionModel(value);
+  return selected?.providerID === model.providerID &&
+    selected.id === model.id &&
+    selected.variant === model.variant;
+}
+
+export function sessionModel(value: unknown): OpenCodeModel | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const session = value as Record<string, unknown>;
+  const selected = asObject(session.model) ?? asObject(asObject(session.info)?.model);
+  const providerID = asString(selected?.providerID);
+  const id = asString(selected?.id) ?? asString(selected?.modelID);
+  const variant = asString(selected?.variant);
+  if (!providerID || !id || !variant) return undefined;
+  return { providerID, id, variant };
+}
+
+function normalizeEvent(eventName: string, raw: string): ServerEvent | undefined {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  const root = asObject(data);
+  const properties = asObject(root?.properties) ?? root;
+  const type = eventName || asString(root?.type) || asString(root?.event);
+  if (!type) return undefined;
+  const statusValue = properties?.status;
+  const status = typeof statusValue === "string" ? statusValue : asString(asObject(statusValue)?.type);
+  return { type, sessionID: sessionIDFrom(properties) ?? sessionIDFrom(root), status };
+}
+
+function extractStatus(body: unknown, sessionID: string): string | undefined {
+  const root = asObject(body);
+  const candidates: unknown[] = [
+    root?.[sessionID],
+    asObject(root?.sessions)?.[sessionID],
+    Array.isArray(body) ? body.find((entry) => sessionIDFrom(asObject(entry)) === sessionID) : undefined,
+    Array.isArray(root?.sessions) ? root.sessions.find((entry) => sessionIDFrom(asObject(entry)) === sessionID) : undefined,
+  ];
+  for (const candidate of candidates) {
+    const object = asObject(candidate);
+    const statusValue = object?.status ?? candidate;
+    if (typeof statusValue === "string") return statusValue;
+    const nested = asObject(statusValue);
+    if (typeof nested?.type === "string") return nested.type;
+  }
+  return undefined;
+}
+
+function sessionIDFrom(value: Record<string, unknown> | undefined): string | undefined {
+  if (!value) return undefined;
+  return asString(value.sessionID) ?? asString(value.session_id) ?? asString(value.id) ?? asString(asObject(value.session)?.id) ?? asString(asObject(value.info)?.id);
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}

--- a/plugins/attn-opencode/src/run-registry.ts
+++ b/plugins/attn-opencode/src/run-registry.ts
@@ -1,0 +1,189 @@
+import { randomBytes } from "node:crypto";
+import { chmod, mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import type { LaunchConfig, RunRecord } from "./types";
+
+const directoryMode = 0o700;
+const fileMode = 0o600;
+
+type RegistryContents = {
+  schema: 1;
+  runs: Record<string, RunRecord>;
+};
+
+export function runtimeRootFromSocket(socketPath: string): string {
+  return join(dirname(socketPath), "plugins", "attn-opencode");
+}
+
+export class RunRegistry {
+  private readonly registryPath: string;
+  private readonly secretsDir: string;
+  private readonly promptsDir: string;
+  private readonly launchDir: string;
+  private runs = new Map<string, RunRecord>();
+  private work = Promise.resolve();
+
+  constructor(readonly root: string) {
+    this.registryPath = join(root, "runs.json");
+    this.secretsDir = join(root, "secrets");
+    this.promptsDir = join(root, "prompts");
+    this.launchDir = join(root, "launch");
+  }
+
+  async initialize(): Promise<void> {
+    await this.withLock(async () => {
+      for (const path of [this.root, this.secretsDir, this.promptsDir, this.launchDir]) {
+        await ensurePrivateDirectory(path);
+      }
+      try {
+        const parsed = JSON.parse(await readFile(this.registryPath, "utf8")) as RegistryContents;
+        if (parsed.schema !== 1 || !parsed.runs || typeof parsed.runs !== "object") {
+          throw new Error("invalid run registry schema");
+        }
+        this.runs = new Map(Object.entries(parsed.runs));
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+        await this.persist();
+      }
+    });
+  }
+
+  async create(record: Omit<RunRecord, "password_ref" | "prompt_ref" | "launch_config_ref">, prompt: string): Promise<RunRecord> {
+    return this.withLock(async () => {
+      if (this.runs.has(record.run_id)) throw new Error(`run ${record.run_id} already exists`);
+      const passwordRef = join(this.secretsDir, `${safeRunID(record.run_id)}.secret`);
+      const promptRef = prompt === "" ? undefined : join(this.promptsDir, `${safeRunID(record.run_id)}.prompt`);
+      const launchConfigRef = join(this.launchDir, `${safeRunID(record.run_id)}.json`);
+      await writePrivate(passwordRef, randomBytes(32).toString("base64url"));
+      if (promptRef) await writePrivate(promptRef, prompt);
+      const full: RunRecord = { ...record, password_ref: passwordRef, prompt_ref: promptRef, launch_config_ref: launchConfigRef };
+      this.runs.set(full.run_id, full);
+      await this.persist();
+      return structuredClone(full);
+    });
+  }
+
+  async get(runID: string): Promise<RunRecord | undefined> {
+    return this.withLock(() => {
+      const value = this.runs.get(runID);
+      return value ? structuredClone(value) : undefined;
+    });
+  }
+
+  async update(runID: string, changes: Partial<RunRecord>): Promise<RunRecord> {
+    return this.withLock(async () => {
+      const current = this.runs.get(runID);
+      if (!current) throw new Error(`run ${runID} is not registered`);
+      const next = { ...current, ...changes };
+      this.runs.set(runID, next);
+      await this.persist();
+      return structuredClone(next);
+    });
+  }
+
+  async reserveSequence(runID: string): Promise<number> {
+    return this.withLock(async () => {
+      const current = this.runs.get(runID);
+      if (!current) throw new Error(`run ${runID} is not registered`);
+      const sequence = current.next_seq;
+      current.next_seq += 1;
+      await this.persist();
+      return sequence;
+    });
+  }
+
+  async password(record: RunRecord): Promise<string> {
+    return readPrivate(record.password_ref);
+  }
+
+  async prompt(record: RunRecord): Promise<string> {
+    return record.prompt_ref ? readPrivate(record.prompt_ref) : "";
+  }
+
+  async writeLaunchConfig(record: RunRecord, config: LaunchConfig): Promise<void> {
+    await this.withLock(async () => {
+      if (this.runs.get(record.run_id)?.launch_config_ref !== record.launch_config_ref) {
+        throw new Error(`run ${record.run_id} launch config does not belong to this registry`);
+      }
+      await writePrivate(record.launch_config_ref, `${JSON.stringify(config)}\n`);
+    });
+  }
+
+  async readLaunchConfig(record: RunRecord): Promise<LaunchConfig> {
+    const parsed = JSON.parse(await readPrivate(record.launch_config_ref)) as LaunchConfig;
+    if (parsed.schema !== 1 || parsed.run_id !== record.run_id || !Number.isSafeInteger(parsed.port)) {
+      throw new Error(`invalid launch config for run ${record.run_id}`);
+    }
+    return parsed;
+  }
+
+  async cleanup(runID: string): Promise<void> {
+    await this.withLock(async () => {
+      const record = this.runs.get(runID);
+      if (!record) return;
+      this.runs.delete(runID);
+      await this.persist();
+      await Promise.all([
+        rm(record.password_ref, { force: true }),
+        record.prompt_ref ? rm(record.prompt_ref, { force: true }) : Promise.resolve(),
+        rm(record.launch_config_ref, { force: true }),
+      ]);
+    });
+  }
+
+  async pruneDead(healthProbe: (record: RunRecord) => Promise<boolean>): Promise<void> {
+    const candidates = await this.withLock(() => [...this.runs.values()].map((run) => structuredClone(run)));
+    for (const record of candidates) {
+      if (!(await healthProbe(record))) await this.cleanup(record.run_id);
+    }
+  }
+
+  private async persist(): Promise<void> {
+    const runs = Object.fromEntries(this.runs.entries());
+    await writePrivate(this.registryPath, `${JSON.stringify({ schema: 1, runs } satisfies RegistryContents)}\n`);
+  }
+
+  private async withLock<T>(operation: () => Promise<T> | T): Promise<T> {
+    const next = this.work.then(operation, operation);
+    this.work = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  }
+}
+
+export async function writePrivate(path: string, contents: string): Promise<void> {
+  await ensurePrivateDirectory(dirname(path));
+  const temp = join(dirname(path), `.${basename(path)}.${randomBytes(8).toString("hex")}.tmp`);
+  const file = await open(temp, "w", fileMode);
+  try {
+    await file.writeFile(contents, "utf8");
+    await file.sync();
+  } finally {
+    await file.close();
+  }
+  await chmod(temp, fileMode);
+  await rename(temp, path);
+  await chmod(path, fileMode);
+}
+
+export async function readPrivate(path: string): Promise<string> {
+  const info = await stat(path);
+  if ((info.mode & 0o077) !== 0) throw new Error(`private runtime file has unsafe permissions: ${path}`);
+  return readFile(path, "utf8");
+}
+
+async function ensurePrivateDirectory(path: string): Promise<void> {
+  await mkdir(path, { recursive: true, mode: directoryMode });
+  await chmod(path, directoryMode);
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function safeRunID(runID: string): string {
+  if (!/^[A-Za-z0-9_-]+$/.test(runID)) throw new Error("run_id contains unsafe path characters");
+  return runID;
+}

--- a/plugins/attn-opencode/src/types.ts
+++ b/plugins/attn-opencode/src/types.ts
@@ -1,0 +1,84 @@
+export const pluginAPIVersion = 2;
+
+export const supportedOpenCodeVersions = new Set(["1.17.16", "1.17.18"]);
+
+export type DriverCapabilities = Record<string, boolean>;
+
+export type DriverSpawnParams = {
+  session_id: string;
+  run_id: string;
+  cwd: string;
+  label?: string;
+  yolo?: boolean;
+  model?: string;
+  effort?: string;
+  initial_prompt?: string;
+  metadata?: unknown;
+};
+
+export type DriverSpawnResult = {
+  argv: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+};
+
+export type SessionClosedParams = {
+  session_id: string;
+  run_id: string;
+  reason: string;
+  exit_code?: number;
+  signal?: string;
+};
+
+export type OpenCodeModel = {
+  providerID: string;
+  id: string;
+  variant: string;
+};
+
+export type OpenCodeMetadata = {
+  schema: 1;
+  opencode_session_id: string;
+  opencode_version: string;
+  // Absent only for metadata produced before interactive-default launches.
+  // Those older records were all delegated, so resume treats absence as true.
+  pinned?: boolean;
+  model?: string;
+  variant?: string;
+};
+
+export type RunRecord = {
+  schema: 1;
+  attn_session_id: string;
+  run_id: string;
+  next_seq: number;
+  port: number;
+  password_ref: string;
+  prompt_ref?: string;
+  launch_config_ref: string;
+  opencode_session_id?: string;
+  opencode_version: string;
+  pinned: boolean;
+  model?: string;
+  variant?: string;
+  resume: boolean;
+  created_at: string;
+};
+
+export type LaunchConfig = {
+  schema: 1;
+  run_id: string;
+  executable: string;
+  cwd: string;
+  password_ref: string;
+  port: number;
+  yolo: boolean;
+  resume_session_id?: string;
+};
+
+export type ReportState = "working" | "idle" | "unknown";
+
+export type Report =
+  | { kind: "metadata"; metadata: OpenCodeMetadata }
+  | { kind: "state"; state: ReportState }
+  | { kind: "stop"; verdict: "idle" | "unknown" };

--- a/plugins/attn-opencode/test/driver.test.ts
+++ b/plugins/attn-opencode/test/driver.test.ts
@@ -1,0 +1,577 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { OpenCodeDriver } from "../src/driver";
+import { launch } from "../src/launcher";
+import { type EventSubscription, type ServerEvent, OpenCodeHTTP } from "../src/opencode-http";
+import { RunRegistry, writePrivate } from "../src/run-registry";
+import type { DriverSpawnParams } from "../src/types";
+import { FakeOpenCode, eventually } from "./fake-opencode";
+
+const servers: FakeOpenCode[] = [];
+afterEach(() => {
+  for (const server of servers.splice(0)) server.close();
+});
+
+class RecordingRPC {
+  readonly calls: Array<{ method: string; params: unknown }> = [];
+  async request(method: string, params?: unknown): Promise<unknown> {
+    this.calls.push({ method, params });
+    return { ok: true };
+  }
+}
+
+class ControlledEventClient extends OpenCodeHTTP {
+  readonly subscriptions: Array<{ reject: (error: Error) => void; resolve: () => void }> = [];
+
+  override subscribe(_onEvent: (event: ServerEvent) => Promise<void> | void, parentSignal?: AbortSignal): EventSubscription {
+    let resolve!: () => void;
+    let reject!: (error: Error) => void;
+    const done = new Promise<void>((nextResolve, nextReject) => {
+      resolve = nextResolve;
+      reject = nextReject;
+    });
+    const abort = () => resolve();
+    if (parentSignal?.aborted) {
+      abort();
+    } else {
+      parentSignal?.addEventListener("abort", abort, { once: true });
+    }
+    this.subscriptions.push({ reject, resolve });
+    return { ready: Promise.resolve(), done, abort };
+  }
+
+  failLatest(): void {
+    this.subscriptions.at(-1)?.reject(new Error("event stream dropped"));
+  }
+}
+
+function server(password: string, version?: string): FakeOpenCode {
+  const result = new FakeOpenCode(password, version);
+  servers.push(result);
+  return result;
+}
+
+function params(runID = "run-one"): DriverSpawnParams {
+  return {
+    session_id: `attn-${runID}`,
+    run_id: runID,
+    cwd: "/tmp",
+    model: "spotify-glm/zai-org/GLM-5.2-FP8",
+    effort: "max",
+    initial_prompt: "Say GLM_SPIKE_OK",
+  };
+}
+
+function driverFor(rpc: RecordingRPC, registry: RunRegistry, target: FakeOpenCode): OpenCodeDriver {
+  return new OpenCodeDriver({
+    rpc,
+    registry,
+    runCommand: async () => ({ exitCode: 0, stdout: "1.17.18\n", stderr: "" }),
+    allocatePort: async () => target.port,
+    http: (port, password) => new OpenCodeHTTP({ port, password }),
+    startupDeadline: 300,
+    reconnectDelay: 5,
+  });
+}
+
+describe("OpenCode server-backed driver", () => {
+  test("accepts both explicitly contract-tested OpenCode versions", async () => {
+    for (const version of ["1.17.16", "1.17.18"]) {
+      const rpc = new RecordingRPC();
+      const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+      const driver = new OpenCodeDriver({
+        rpc,
+        registry,
+        runCommand: async () => ({ exitCode: 0, stdout: `${version}\n`, stderr: "" }),
+      });
+      await driver.initialize();
+      expect(driver.health()).toEqual({ ok: true, message: `OpenCode ${version} is ready` });
+      expect(rpc.calls[0]?.method).toBe("driver.register");
+    }
+  });
+
+  test("uses per-run Basic authentication on every HTTP endpoint", async () => {
+    const target = server("correct-password");
+    await expect(new OpenCodeHTTP({ port: target.port, password: "wrong-password" }).health()).rejects.toThrow("HTTP 401");
+    const client = new OpenCodeHTTP({ port: target.port, password: "correct-password" });
+    await expect(client.health()).resolves.toEqual({ version: "1.17.18" });
+    expect(target.requests).toHaveLength(2);
+  });
+
+  test("creates a pinned native session after authenticated SSE subscription and does not infer idle from a missing status", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    expect(rpc.calls[0]?.method).toBe("driver.register");
+
+    await driver.spawn(params());
+    await eventually(
+      () => target.prompts.length === 1,
+      () => `staged prompt submission; health=${JSON.stringify(driver.health())}; requests=${JSON.stringify(target.requests)}; calls=${JSON.stringify(rpc.calls)}`,
+    );
+    expect(target.requests.some((request) => request.path === "/event")).toBe(true);
+    expect(target.requests.filter((request) => request.path === "/session/status")).toHaveLength(1);
+    expect(rpc.calls.map((call) => call.method)).toEqual(["driver.register", "session.report_metadata"]);
+
+    const created = target.sessions.get("native-1") as { model: { providerID: string; id: string; variant: string } };
+    expect(created.model).toEqual({ providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "max" });
+    expect(target.prompts[0]?.body).toEqual({
+      parts: [{ type: "text", text: "Say GLM_SPIKE_OK" }],
+      model: { providerID: "spotify-glm", modelID: "zai-org/GLM-5.2-FP8" },
+      variant: "max",
+    });
+
+    target.emit("session.status", { sessionID: "native-1", status: { type: "busy" } });
+    target.emit("session.status", { sessionID: "native-1", status: { type: "retry" } });
+    target.emit("session.status", { sessionID: "native-1", status: { type: "idle" } });
+    await eventually(() => rpc.calls.length === 5, "ordered lifecycle reports");
+    expect(rpc.calls.slice(1).map((call) => call.method)).toEqual([
+      "session.report_metadata",
+      "session.report_state",
+      "session.report_state",
+      "session.report_stop",
+    ]);
+    const sequences = rpc.calls.slice(1).map((call) => (call.params as { seq: number }).seq);
+    expect(sequences).toEqual([1, 2, 3, 4]);
+  });
+
+  test("lets an unpinned interactive launch use OpenCode defaults and records its first native session", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+
+    await driver.spawn({
+      session_id: "attn-interactive",
+      run_id: "run-interactive",
+      cwd: "/tmp",
+    });
+    await eventually(() => target.requests.some((request) => request.path === "/event"), "interactive SSE subscription");
+    expect(target.requests.some((request) => request.path === "/session" && request.method === "POST")).toBe(false);
+    expect(target.prompts).toHaveLength(0);
+
+    target.sessions.set("native-default", {
+      id: "native-default",
+      model: { providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "max" },
+    });
+    target.emit("session.created", { sessionID: "native-default" });
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_metadata"),
+      "interactive native session metadata",
+    );
+
+    const record = await registry.get("run-interactive");
+    expect(record).toEqual(expect.objectContaining({
+      opencode_session_id: "native-default",
+      pinned: false,
+      model: "spotify-glm/zai-org/GLM-5.2-FP8",
+      variant: "max",
+    }));
+    expect(rpc.calls.find((call) => call.method === "session.report_metadata")?.params).toEqual(expect.objectContaining({
+      metadata: {
+        schema: 1,
+        opencode_session_id: "native-default",
+        opencode_version: "1.17.18",
+        pinned: false,
+        model: "spotify-glm/zai-org/GLM-5.2-FP8",
+        variant: "max",
+      },
+    }));
+
+    target.emit("session.status", { sessionID: "native-default", status: { type: "busy" } });
+    target.emit("session.status", { sessionID: "native-default", status: { type: "idle" } });
+    await eventually(() => rpc.calls.filter((call) => call.method === "session.report_stop").length === 1, "interactive idle report");
+    expect(rpc.calls.slice(1).map((call) => call.method)).toEqual([
+      "session.report_metadata",
+      "session.report_state",
+      "session.report_stop",
+    ]);
+  });
+
+  test("keeps server-side pinning for staged prompts", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+
+    await expect(driver.spawn({
+      session_id: "attn-missing-pin",
+      run_id: "run-missing-pin",
+      cwd: "/tmp",
+      initial_prompt: "This must remain bound to a selected model",
+    })).rejects.toThrow("staged prompts require a delegated model pin");
+  });
+
+  test("resumes only the persisted native identity and metadata pins", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    target.sessions.set("native-resume", {
+      id: "native-resume",
+      model: { providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "low" },
+    });
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.resume({
+      ...params("run-resume"),
+      effort: "low",
+      initial_prompt: "",
+      metadata: {
+        schema: 1,
+        opencode_session_id: "native-resume",
+        opencode_version: "1.17.18",
+        model: "spotify-glm/zai-org/GLM-5.2-FP8",
+        variant: "low",
+      },
+    });
+    await eventually(() => target.requests.some((request) => request.path === "/tui/select-session"), "resume selection");
+    expect(target.prompts).toHaveLength(0);
+    expect(target.requests.some((request) => request.path === "/session/native-resume")).toBe(true);
+
+    await expect(driver.resume({
+      ...params("bad-resume"),
+      effort: "max",
+      metadata: {
+        schema: 1,
+        opencode_session_id: "native-resume",
+        opencode_version: "1.17.18",
+        model: "spotify-glm/zai-org/GLM-5.2-FP8",
+        variant: "low",
+      },
+    })).rejects.toThrow("effort pin does not match");
+  });
+
+  test("resumes an interactive OpenCode session without imposing pins", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    target.sessions.set("native-default", {
+      id: "native-default",
+      model: { providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "low" },
+    });
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+
+    await driver.resume({
+      session_id: "attn-interactive-resume",
+      run_id: "run-interactive-resume",
+      cwd: "/tmp",
+      metadata: {
+        schema: 1,
+        opencode_session_id: "native-default",
+        opencode_version: "1.17.18",
+        pinned: false,
+        // OpenCode owns model changes for this kind of session. These values
+        // are historical observation, not delegated constraints.
+        model: "spotify-glm/zai-org/GLM-5.2-FP8",
+        variant: "max",
+      },
+    });
+    await eventually(() => target.requests.some((request) => request.path === "/tui/select-session"), "interactive resume selection");
+    expect(target.requests.some((request) => request.path === "/session" && request.method === "POST")).toBe(false);
+    expect(await registry.get("run-interactive-resume")).toEqual(expect.objectContaining({
+      opencode_session_id: "native-default",
+      pinned: false,
+      model: "spotify-glm/zai-org/GLM-5.2-FP8",
+      variant: "max",
+      resume: true,
+    }));
+  });
+
+  test("relaunches an unbound interactive session instead of claiming it can resume", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+
+    await driver.resume({
+      session_id: "attn-unbound-recovery",
+      run_id: "run-unbound-recovery",
+      cwd: "/tmp",
+    });
+    await eventually(() => target.eventSubscriberCount === 1, "fresh interactive recovery SSE subscription");
+    expect(target.requests.some((request) => request.path === "/session" && request.method === "POST")).toBe(false);
+  });
+
+  test("keeps two concurrent ports, passwords, identities, and variants isolated", async () => {
+    const first = server("*");
+    const second = server("*");
+    const rpc = new RecordingRPC();
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    let nextPort = 0;
+    const driver = new OpenCodeDriver({
+      rpc,
+      registry,
+      runCommand: async () => ({ exitCode: 0, stdout: "1.17.18\n", stderr: "" }),
+      allocatePort: async () => [first.port, second.port][nextPort++]!,
+      http: (port, password) => new OpenCodeHTTP({ port, password }),
+      startupDeadline: 300,
+      reconnectDelay: 5,
+    });
+    await driver.initialize();
+    await Promise.all([
+      driver.spawn({ ...params("run-low"), effort: "low", initial_prompt: "first" }),
+      driver.spawn({ ...params("run-max"), effort: "max", initial_prompt: "second" }),
+    ]);
+    await eventually(() => first.prompts.length === 1 && second.prompts.length === 1, "both isolated prompt submissions");
+    const firstModel = (first.sessions.get("native-1") as { model: { variant: string } }).model;
+    const secondModel = (second.sessions.get("native-1") as { model: { variant: string } }).model;
+    expect([firstModel.variant, secondModel.variant].sort()).toEqual(["low", "max"]);
+    const low = await registry.get("run-low");
+    const max = await registry.get("run-max");
+    expect(low?.port).not.toBe(max?.port);
+    expect(low?.password_ref).not.toBe(max?.password_ref);
+    expect(await registry.password(low!)).not.toBe(await registry.password(max!));
+  });
+
+  test("reports degraded health and unknown when the authenticated server never becomes ready", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*", "1.17.17");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn(params("run-unhealthy"));
+    await eventually(() => rpc.calls.some((call) => call.method === "session.report_state"), "unknown failure report");
+    expect(driver.health()).toEqual(expect.objectContaining({ ok: false }));
+    expect(rpc.calls.at(-1)).toEqual(expect.objectContaining({ method: "session.report_state" }));
+    expect((rpc.calls.at(-1)?.params as { state: string }).state).toBe("unknown");
+  });
+
+  test("bounds a health request when a loopback server accepts but never responds", async () => {
+    const hanging = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => new Promise<Response>(() => {}),
+    });
+    try {
+      const rpc = new RecordingRPC();
+      const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+      const driver = new OpenCodeDriver({
+        rpc,
+        registry,
+        runCommand: async () => ({ exitCode: 0, stdout: "1.17.18\n", stderr: "" }),
+        allocatePort: async () => hanging.port,
+        http: (port, password) => new OpenCodeHTTP({ port, password }),
+        startupDeadline: 40,
+        reconnectDelay: 5,
+        healthRequestTimeout: 5,
+      });
+      await driver.initialize();
+      await driver.spawn(params("run-hung-health"));
+      await eventually(
+        () => rpc.calls.some((call) => call.method === "session.report_state"),
+        "bounded failed health report",
+      );
+      expect(driver.health()).toEqual(expect.objectContaining({ ok: false }));
+    } finally {
+      hanging.stop(true);
+    }
+  });
+
+  test("bounds event subscription readiness after health succeeds", async () => {
+    const hanging = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: (request) => {
+        const path = new URL(request.url).pathname;
+        if (path === "/global/health") return Response.json({ healthy: true, version: "1.17.18" });
+        if (path === "/event") return new Promise<Response>(() => {});
+        return new Response("not found", { status: 404 });
+      },
+    });
+    try {
+      const rpc = new RecordingRPC();
+      const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+      const driver = new OpenCodeDriver({
+        rpc,
+        registry,
+        runCommand: async () => ({ exitCode: 0, stdout: "1.17.18\n", stderr: "" }),
+        allocatePort: async () => hanging.port,
+        http: (port, password) => new OpenCodeHTTP({ port, password }),
+        startupDeadline: 100,
+        reconnectDelay: 5,
+        healthRequestTimeout: 5,
+      });
+      await driver.initialize();
+      await driver.spawn(params("run-hung-events"));
+      await eventually(
+        () => rpc.calls.some((call) => call.method === "session.report_state"),
+        "bounded event subscription failure report",
+      );
+      expect(driver.health()).toEqual(expect.objectContaining({ ok: false }));
+    } finally {
+      hanging.stop(true);
+    }
+  });
+
+  test("reconnects after an established SSE stream fails instead of degrading an idle interactive run", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn({
+      session_id: "attn-sse-reconnect",
+      run_id: "run-sse-reconnect",
+      cwd: "/tmp",
+    });
+    await eventually(() => target.eventSubscriberCount === 1, "initial SSE subscription");
+    target.closeEvents();
+    await eventually(
+      () => target.requests.filter((request) => request.path === "/event").length >= 2 && target.eventSubscriberCount === 1,
+      "reconnected SSE subscription",
+    );
+    expect(driver.health()).toEqual({ ok: true, message: "OpenCode 1.17.18 is ready" });
+    expect(rpc.calls.some((call) => (call.params as { state?: string }).state === "unknown")).toBe(false);
+  });
+
+  test("degrades after repeated established SSE stream failures", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    let client: ControlledEventClient | undefined;
+    const driver = new OpenCodeDriver({
+      rpc,
+      registry,
+      runCommand: async () => ({ exitCode: 0, stdout: "1.17.18\n", stderr: "" }),
+      allocatePort: async () => target.port,
+      http: (port, password) => {
+        client ??= new ControlledEventClient({ port, password });
+        return client;
+      },
+      startupDeadline: 300,
+      reconnectDelay: 5,
+    });
+    await driver.initialize();
+    await driver.spawn({
+      session_id: "attn-sse-repeated-failures",
+      run_id: "run-sse-repeated-failures",
+      cwd: "/tmp",
+    });
+    for (let expectedSubscriptions = 1; expectedSubscriptions <= 3; expectedSubscriptions += 1) {
+      await eventually(
+        () => client !== undefined && client.subscriptions.length === expectedSubscriptions,
+        `SSE subscription ${expectedSubscriptions}`,
+      );
+      client!.failLatest();
+    }
+    await eventually(
+      () => rpc.calls.some((call) => (call.params as { state?: string }).state === "unknown"),
+      "terminal SSE failure report",
+    );
+    expect(driver.health()).toEqual(expect.objectContaining({ ok: false }));
+  });
+
+  test("aborts an established SSE subscription when a later setup request times out", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    target.sessions.set("native-hung", {
+      id: "native-hung",
+      model: { providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "max" },
+    });
+    target.hangingSessionReads.add("native-hung");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = new OpenCodeDriver({
+      rpc,
+      registry,
+      runCommand: async () => ({ exitCode: 0, stdout: "1.17.18\n", stderr: "" }),
+      allocatePort: async () => target.port,
+      http: (port, password) => new OpenCodeHTTP({ port, password }),
+      startupDeadline: 100,
+      reconnectDelay: 5,
+      healthRequestTimeout: 5,
+    });
+    await driver.initialize();
+    await driver.resume({
+      session_id: "attn-hung-resume",
+      run_id: "run-hung-resume",
+      cwd: "/tmp",
+      metadata: {
+        schema: 1,
+        opencode_session_id: "native-hung",
+        opencode_version: "1.17.18",
+        pinned: false,
+      },
+    });
+
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_state"),
+      "degraded setup failure report",
+    );
+    await eventually(() => target.eventSubscriberCount === 0, "aborted established event subscription");
+    const reports = rpc.calls.length;
+    target.emit("session.status", { sessionID: "native-hung", status: { type: "busy" } });
+    await Bun.sleep(20);
+    expect(rpc.calls).toHaveLength(reports);
+  });
+});
+
+test("registry persists atomically with private files and cleans them after session close", async () => {
+  const rpc = new RecordingRPC();
+  const target = server("*");
+  const root = join(await tempRoot(), "runtime");
+  const registry = new RunRegistry(root);
+  const driver = driverFor(rpc, registry, target);
+  await driver.initialize();
+  await driver.spawn(params("run-cleanup"));
+  await eventually(() => target.prompts.length === 1, "run creation");
+  const record = await registry.get("run-cleanup");
+  expect(record).toBeDefined();
+  expect((await stat(record!.password_ref)).mode & 0o077).toBe(0);
+  expect((await stat(record!.prompt_ref!)).mode & 0o077).toBe(0);
+  expect(JSON.parse(await readFile(join(root, "runs.json"), "utf8")).runs["run-cleanup"].password_ref).toBe(record!.password_ref);
+  await driver.sessionClosed({ session_id: "attn-run-cleanup", run_id: "run-cleanup", reason: "exited" });
+  expect(await registry.get("run-cleanup")).toBeUndefined();
+  await expect(stat(record!.password_ref)).rejects.toThrow();
+});
+
+test("session close aborts the active SSE subscription", async () => {
+  const rpc = new RecordingRPC();
+  const target = server("*");
+  const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+  const driver = driverFor(rpc, registry, target);
+  await driver.initialize();
+  await driver.spawn(params("run-sse-close"));
+  await eventually(() => target.eventSubscriberCount === 1, "active SSE subscription");
+
+  await driver.sessionClosed({ session_id: "attn-run-sse-close", run_id: "run-sse-close", reason: "exited" });
+  await eventually(() => target.eventSubscriberCount === 0, "aborted SSE subscription");
+  const reports = rpc.calls.length;
+  target.emit("session.status", { sessionID: "native-1", status: { type: "busy" } });
+  await Bun.sleep(20);
+  expect(rpc.calls).toHaveLength(reports);
+});
+
+test("launcher retries an address-in-use failure with a fresh port", async () => {
+  const root = await tempRoot();
+  const marker = join(root, "attempted");
+  const executable = join(root, "fake-opencode");
+  await writeFile(executable, `#!/bin/sh\nif [ ! -f ${marker} ]; then touch ${marker}; echo EADDRINUSE >&2; exit 1; fi\nexit 0\n`, { mode: 0o755 });
+  const password = join(root, "password");
+  await writePrivate(password, "secret");
+  const config = join(root, "launch.json");
+  await writePrivate(config, JSON.stringify({
+    schema: 1,
+    run_id: "launch-retry",
+    executable,
+    cwd: root,
+    password_ref: password,
+    port: 12345,
+    yolo: false,
+  }));
+  expect(await launch(config)).toBe(0);
+  expect(JSON.parse(await readFile(config, "utf8")).port).not.toBe(12345);
+});
+
+async function tempRoot(): Promise<string> {
+  const root = join("/tmp", `attn-opencode-test-${randomUUID()}`);
+  await mkdir(root, { recursive: true, mode: 0o700 });
+  return root;
+}

--- a/plugins/attn-opencode/test/fake-opencode.ts
+++ b/plugins/attn-opencode/test/fake-opencode.ts
@@ -1,0 +1,121 @@
+type RequestRecord = {
+  method: string;
+  path: string;
+  body?: unknown;
+  authorization?: string | null;
+};
+
+export class FakeOpenCode {
+  readonly requests: RequestRecord[] = [];
+  readonly statuses = new Map<string, string>();
+  readonly sessions = new Map<string, unknown>();
+  readonly hangingSessionReads = new Set<string>();
+  readonly prompts: Array<{ sessionID: string; body: unknown }> = [];
+  private controllers = new Set<ReadableStreamDefaultController<Uint8Array>>();
+  private nextSession = 1;
+  readonly server: ReturnType<typeof Bun.serve>;
+
+  constructor(readonly password: string, readonly version = "1.17.18") {
+    this.server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: async (request) => this.handle(request),
+    });
+  }
+
+  get port(): number {
+    return this.server.port;
+  }
+
+  get eventSubscriberCount(): number {
+    return this.controllers.size;
+  }
+
+  close(): void {
+    for (const controller of this.controllers) controller.close();
+    this.controllers.clear();
+    this.server.stop(true);
+  }
+
+  emit(type: string, properties: Record<string, unknown>): void {
+    const frame = `event: ${type}\ndata: ${JSON.stringify({ type, properties })}\n\n`;
+    for (const controller of this.controllers) controller.enqueue(new TextEncoder().encode(frame));
+  }
+
+  closeEvents(): void {
+    for (const controller of this.controllers) controller.close();
+    this.controllers.clear();
+  }
+
+  private async handle(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const body = request.method === "GET" ? undefined : await request.json();
+    this.requests.push({
+      method: request.method,
+      path: url.pathname,
+      body,
+      authorization: request.headers.get("authorization"),
+    });
+    if (this.password !== "*" && request.headers.get("authorization") !== basic(this.password)) {
+      return new Response("unauthorized", { status: 401 });
+    }
+    if (url.pathname === "/global/health") return Response.json({ healthy: true, version: this.version });
+    if (url.pathname === "/event") {
+      let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+      const stream = new ReadableStream<Uint8Array>({
+        start: (nextController) => {
+          controller = nextController;
+          this.controllers.add(nextController);
+          nextController.enqueue(new TextEncoder().encode(": connected\n\n"));
+        },
+        cancel: () => {
+          if (controller) this.controllers.delete(controller);
+        },
+      });
+      return new Response(stream, { headers: { "content-type": "text/event-stream" } });
+    }
+    if (url.pathname === "/session" && request.method === "POST") {
+      const id = `native-${this.nextSession++}`;
+      this.sessions.set(id, { id, model: (body as { model: unknown }).model });
+      return Response.json({ id });
+    }
+    if (url.pathname === "/session/status") return Response.json(Object.fromEntries(this.statuses));
+    if (url.pathname.startsWith("/session/") && url.pathname.endsWith("/prompt_async")) {
+      const sessionID = decodeURIComponent(url.pathname.slice("/session/".length, -"/prompt_async".length));
+      const prompt = body as {
+        parts?: unknown;
+        model?: { providerID?: unknown; modelID?: unknown };
+        variant?: unknown;
+      };
+      if (!Array.isArray(prompt.parts) ||
+        typeof prompt.model?.providerID !== "string" ||
+        typeof prompt.model?.modelID !== "string" ||
+        typeof prompt.variant !== "string") {
+        return Response.json({ error: "invalid prompt_async body" }, { status: 400 });
+      }
+      this.prompts.push({ sessionID, body });
+      return new Response(null, { status: 204 });
+    }
+    if (url.pathname.startsWith("/session/") && request.method === "GET") {
+      const sessionID = decodeURIComponent(url.pathname.slice("/session/".length));
+      if (this.hangingSessionReads.has(sessionID)) return new Promise<Response>(() => {});
+      const session = this.sessions.get(sessionID);
+      return session ? Response.json(session) : new Response("missing", { status: 404 });
+    }
+    if (url.pathname === "/tui/select-session") return Response.json(true);
+    return new Response("not found", { status: 404 });
+  }
+}
+
+export function basic(password: string): string {
+  return `Basic ${Buffer.from(`opencode:${password}`).toString("base64")}`;
+}
+
+export async function eventually(predicate: () => boolean, message: string | (() => string)): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(`timed out: ${typeof message === "function" ? message() : message}`);
+}

--- a/scripts/wsctl/main.go
+++ b/scripts/wsctl/main.go
@@ -13,6 +13,7 @@
 //	go run ./scripts/wsctl rm-workspace --id I
 //	go run ./scripts/wsctl add-session --workspace W --cwd D [--agent claude] [--label L] [--initial-prompt-file P] [--yolo] [--id I] [--cols 80] [--rows 24]
 //	go run ./scripts/wsctl rm-session --id I
+//	go run ./scripts/wsctl kill-session --id I [--reload]
 //	go run ./scripts/wsctl screen --id I
 //	go run ./scripts/wsctl input --id I --text T [--enter]
 //	go run ./scripts/wsctl list
@@ -54,6 +55,8 @@ func main() {
 		err = addSession(args)
 	case "rm-session":
 		err = rmSession(args)
+	case "kill-session":
+		err = killSession(args)
 	case "screen":
 		err = screen(args)
 	case "input":
@@ -84,6 +87,7 @@ Commands:
   rm-workspace --id I
   add-session --workspace W --cwd D [--agent claude] [--label L] [--initial-prompt-file P] [--yolo] [--id I] [--cols 80] [--rows 24]
   rm-session --id I
+  kill-session --id I [--reload]
   screen --id I
   input --id I --text T [--enter]
   list
@@ -237,6 +241,28 @@ func rmSession(args []string) error {
 		return err
 	}
 	fmt.Printf("session removed: id=%s\n", *id)
+	return nil
+}
+
+func killSession(args []string) error {
+	fs := flag.NewFlagSet("kill-session", flag.ExitOnError)
+	id := fs.String("id", "", "session id (required)")
+	reload := fs.Bool("reload", false, "mark the kill as the first half of an in-place reload")
+	fs.Parse(args)
+	if *id == "" {
+		return errors.New("--id is required")
+	}
+	msg := map[string]any{
+		"cmd": "kill_session",
+		"id":  *id,
+	}
+	if *reload {
+		msg["reload"] = true
+	}
+	if err := send(msg); err != nil {
+		return err
+	}
+	fmt.Printf("session killed: id=%s reload=%t\n", *id, *reload)
 	return nil
 }
 

--- a/sdk/plugin/src/index.ts
+++ b/sdk/plugin/src/index.ts
@@ -119,7 +119,7 @@ type HealthResult = {
   ok: boolean;
 };
 
-const pluginAPIVersion = 1;
+const pluginAPIVersion = 2;
 
 export class AttnPluginClient {
   private socket?: Socket;


### PR DESCRIPTION
## Intent / why

Implements the first OpenCode integration slice for `opencode-design`: an
installable external driver that keeps attn in control of the PTY and lifecycle
while OpenCode supplies its native model/session behavior. Ordinary sessions
use OpenCode defaults; delegated prompts can pin a provider/model and the
verified `low` or `max` variant.

## Summary

- Adds external-driver API v2 model/effort capabilities and forwards resolved
  pins through spawn and resume.
- Adds the authenticated, per-run `attn-opencode` HTTP/SSE plugin with native
  session resume, private atomic storage, ordering, cleanup, and bounded
  failure handling.
- Keeps interactive OpenCode selections observational (`pinned: false`) so a
  later TUI model change does not become an accidental delegated constraint.
- Adds deterministic adapter and daemon coverage, plus a user-facing changelog
  entry.

## Verification

- [x] `bun test` in `plugins/attn-opencode` — 18 tests, 49 assertions.
- [x] `go test ./...`.
- [x] `make check-types`.
- [x] `make test-frontend` — 146 files, 1,431 tests.
- [x] Isolated `attn-dev` proof against OpenCode 1.17.18: plugin discovery,
  visible GLM 5.2/max TUI, delegated GLM `low`/`max` completion, steering,
  working-to-idle, close/resume, and concurrent isolation. No production app
  was used.
- [x] Two native adversarial reviews; all findings fixed and final passes clean.

## Out of scope

Generic installed-plugin supervision, semantic `waiting_input`, chief/workspace
context parity, additional effort mappings, and production installation.
