### PR TITLE
fix(agents): distinguish subagents from delegations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Changed
 - **Ticket artifacts use attachment language throughout.** `attn ticket attach` now names the durable operation for adding Markdown artifacts to a ticket; its multi-file, optional state/comment, retry-safe receipt, and canonical Notebook behavior are unchanged.
+- **Agent guidance now distinguishes native subagents from user-steered delegations.** “Subagent” consistently means a native worker that reports to the calling agent, while `attn delegate` creates a visible session the user can inspect and steer directly. Requests to delegate or dispatch subagents stay on the native subagent path.
 
 ### Changed
 - **Ticket artifacts use attachment language throughout.** `attn ticket attach` now names the durable operation for adding Markdown artifacts to a ticket; its multi-file, optional state/comment, retry-safe receipt, and canonical Notebook behavior are unchanged.

--- a/cmd/attn/workflow.go
+++ b/cmd/attn/workflow.go
@@ -70,8 +70,8 @@ run options:
   --wait                       run in the foreground and block until terminal
   --session <id>               attach the run to a session (default ATTN_SESSION_ID)
   --resume <runId>             resume a prior run, replaying its journaled prefix
-  --harness <codex|claude>     subagent harness (default codex)
-  --model <m>                  subagent model
+  --harness <codex|claude>     agent harness (default codex)
+  --model <m>                  workflow agent model
 `)
 }
 
@@ -110,8 +110,8 @@ func parseWorkflowRunArgs(argv []string, envSession string) (workflowRunArgs, er
 	wait := fs.Bool("wait", false, "run in the foreground and block until terminal")
 	session := fs.String("session", "", "session id (defaults to ATTN_SESSION_ID)")
 	resume := fs.String("resume", "", "resume a prior run id")
-	harness := fs.String("harness", "codex", "subagent harness (codex|claude)")
-	model := fs.String("model", "", "subagent model")
+	harness := fs.String("harness", "codex", "agent harness (codex|claude)")
+	model := fs.String("model", "", "workflow agent model")
 	runID := fs.String("run-id", "", "") // hidden: reused by the detached child
 
 	if err := fs.Parse(rest); err != nil {

--- a/internal/agent/attn_skill/SKILL.md
+++ b/internal/agent/attn_skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attn
-description: "Drive attn from an agent: create a visible agent session the user can inspect, converse with, and steer directly; run durable resumable multi-agent workflows; maintain shared workspace context; journal; open markdown; present changes for a guided review; or control attn's persistent in-app browser. Use when the user explicitly asks for an attn session or delegation, ticket, workflow, browser, presentation/review, or markdown document in the app, or when you are attn's chief of staff. A subagent always means a native runtime subagent, including when the user says to delegate or dispatch subagents."
+description: "Operate attn capabilities from an agent, including user-steered delegations, tickets, workflows, shared workspace context, the Notebook, Present reviews, markdown, and the in-app browser. Use when the user explicitly asks for an attn capability or delegation, or when acting as attn's chief of staff."
 ---
 
 # attn

--- a/internal/agent/attn_skill/SKILL.md
+++ b/internal/agent/attn_skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attn
-description: "Drive attn from an agent: spawn a visible interactive agent the user can inspect and steer, run durable resumable multi-agent workflows, maintain shared workspace context, journal, open markdown, present changes for a guided review, or control attn's persistent in-app browser. Use when the user explicitly asks for an attn session, delegation, creating a new ticket, workflow, browser, presenting/reviewing a change, or to show a markdown explainer or doc in the app, or when you are attn's chief of staff. Not for private research, verification, or parallel reasoning you synthesize yourself — use native subagents for those."
+description: "Drive attn from an agent: create a visible agent session the user can inspect, converse with, and steer directly; run durable resumable multi-agent workflows; maintain shared workspace context; journal; open markdown; present changes for a guided review; or control attn's persistent in-app browser. Use when the user explicitly asks for an attn session or delegation, ticket, workflow, browser, presentation/review, or markdown document in the app, or when you are attn's chief of staff. A subagent always means a native runtime subagent, including when the user says to delegate or dispatch subagents."
 ---
 
 # attn
@@ -22,19 +22,22 @@ If a command reports an unknown subcommand or shows another tool's help, check
 
 ## Confirm Your Role First
 
-A delegated leaf re-delegating its own assigned work — mistaking itself for the
-chief — is this skill's most common failure. Check which you are before reading
-anything about delegation:
+A **subagent** is always a native runtime subagent, including in phrases such as
+"delegate subagents" and "dispatch subagents." Native subagents report to the
+calling agent. An **attn delegation** creates a visible agent session the user
+can inspect, converse with, and steer directly.
+
+Choose your role before reading anything about delegation:
 
 - **Chief of staff**, if your system prompt says so: it already carries your
-  full delegation, ticket, and Notebook guidance. Use native subagents for your
-  own research and synthesis.
+  full delegation, ticket, and Notebook guidance.
 - **A delegated leaf**, if your initial task opens with a line identifying you
-  as a delegated attn session: do the work here. Native subagents for your own
-  subtasks; `attn delegate` again only if the user steering *this* session
-  explicitly asks. See [references/delegated-agent.md](references/delegated-agent.md).
-- **Otherwise, an ordinary session:** `attn delegate` only when the user
-  explicitly asks for a visible, steerable agent.
+  as a delegated attn session: do the work here. An explicit request from the
+  user steering *this* session selects attn delegation; otherwise, use native
+  subagents. See
+  [references/delegated-agent.md](references/delegated-agent.md).
+- **Otherwise, an ordinary session:** an explicit user request selects attn
+  delegation; otherwise, use native subagents.
 
 A ticket-tracked task is still a leaf task — being tracked means the chief is
 *watching* your ticket, not that you inherited the chief's delegation license.
@@ -51,8 +54,8 @@ A ticket-tracked task is still a leaf task — being tracked means the chief is
   [references/workspace-context.md](references/workspace-context.md).
 - **Read or maintain the durable Notebook (journal + knowledge base), esp. as
   chief of staff:** read [references/notebook.md](references/notebook.md).
-- **Run a durable, resumable multi-agent workflow — a script that spawns
-  subagents with fan-out/pipeline, journaled and observable via `attn workflow
+- **Run a durable, resumable multi-agent workflow — a script that runs headless
+  workflow agents with fan-out/pipeline, journaled and observable via `attn workflow
   run`:** read [references/workflow.md](references/workflow.md).
 - **Show the user a markdown document:** read
   [references/markdown.md](references/markdown.md).

--- a/internal/agent/attn_skill/references/delegated-agent.md
+++ b/internal/agent/attn_skill/references/delegated-agent.md
@@ -5,14 +5,13 @@ with a line identifying you as a delegated attn session.
 
 ## You Are A Leaf, Not A Coordinator
 
-Do the assigned work in this session. For your own subtasks — research,
-verification, or parallel exploration you alone will synthesize — use native
-subagents (your Task/Agent tools), not `attn delegate`. Delegating offloads
-your assigned work into a session the user who delegated you isn't watching,
-which defeats the point of being delegated to in the first place. Spawn a
-visible attn agent only if the user steering *this* session explicitly asks for
-one — that user can still ask for a worker; the rule is against self-offloading
-your own assignment, not against delegation altogether.
+Do the assigned work in this session. A subagent is always a native runtime
+subagent, including when the user says to delegate or dispatch subagents. An
+explicit request from the user steering this session selects attn delegation;
+otherwise, use native subagents.
+
+An attn delegation creates a visible agent session the user can inspect,
+converse with, and steer directly. Native subagents report to you.
 
 ## If Your Work Is Tracked, Report Your State
 

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -1,24 +1,23 @@
 # Delegation
 
-This file is mechanics. It assumes you already confirmed in SKILL.md's role
-check that delegating is yours to do right now — the chief of staff, or an
-ordinary session the user is steering directly. A delegated leaf re-delegating
-its own assigned work onward is the bug this skill exists to prevent; if that
-might be you, read [delegated-agent.md](delegated-agent.md) first.
+This file covers attn delegation mechanics. Confirm your role in SKILL.md first;
+delegated agents also read [delegated-agent.md](delegated-agent.md).
 
-Attn delegation creates a visible, full interactive agent session for the user.
-Use it when the user wants another agent they can inspect, converse with, and
-steer directly.
+A subagent is always a native runtime subagent, including in phrases such as
+"delegate subagents" and "dispatch subagents."
 
-Do not use attn delegation as an internal parallel-reasoning mechanism. For
-research, adversarial analysis, verification, or other work that you alone will
-synthesize for the user, use your native subagent or multi-agent tools instead.
-Those workers are implementation details of your response; they should not
-create attn sessions or appear in the user's workspace.
+Native subagents report to the calling agent. Attn delegation creates a visible,
+full interactive agent session for the user: an agent they can inspect, converse
+with, and steer directly. An explicit user request selects attn delegation;
+otherwise, use native subagents.
 
-When the user's intent is unclear, default to native subagents. Use attn only
-when the user explicitly asks for delegation, an interactive agent, a separate
-workspace/session, or a collaborator they can steer themselves.
+Interpret the requested object first:
+
+- "delegate this problem" or "delegate this to an agent" means attn delegation
+- "dispatch an agent" means attn delegation
+- "use a subagent" means a native subagent
+- "delegate subagents to review" means native subagents
+- "dispatch subagents to investigate" means native subagents
 
 Attn delegation starts another agent with a focused brief; it does not create
 durable parent-child lineage. If you are the chief of staff, attn binds a ticket

--- a/internal/agent/attn_skill/references/workflow.md
+++ b/internal/agent/attn_skill/references/workflow.md
@@ -1,10 +1,11 @@
 # Workflows
 
 A workflow is a deterministic JavaScript script that orchestrates one or more
-subagents. The engine runs in the `attn workflow run` process, journals every
-`agent()` call to the daemon, and lets you resume a prior run by replaying the
-journaled prefix and re-running only what changed. Use workflows when you want a
-reproducible multi-step agent pipeline you can observe, retrieve, and resume.
+headless workflow agents. The engine runs in the `attn workflow run` process,
+journals every `agent()` call to the daemon, and lets you resume a prior run by
+replaying the journaled prefix and re-running only what changed. Use workflows
+when you want a reproducible multi-step agent pipeline you can observe, retrieve,
+and resume.
 
 ## Contents
 
@@ -38,19 +39,19 @@ a pure object literal (no computed values, no function calls). Recognized fields
 
 ### Host functions (available to the script)
 
-- `agent(prompt, opts?)` — run one subagent and resolve to its result. Returns a
+- `agent(prompt, opts?)` — run one workflow agent and resolve to its result. Returns a
   Promise. Options:
-  - `schema` — a JSON Schema object. When present, the subagent is FORCED to
+  - `schema` — a JSON Schema object. When present, the workflow agent is FORCED to
     return a structured result matching the schema (it calls a `return_result`
     tool exactly once); `agent()` resolves to that validated object. Without a
-    schema, `agent()` resolves to the subagent's final text.
+    schema, `agent()` resolves to the workflow agent's final text.
   - `label` — a human-readable label for the call.
   - `phase` — group the call under a named phase.
   - `model` — override the model for this call.
   - `isolation` — isolation mode for the call.
-  - `agentType` — the subagent type to run.
-  - A subagent that fails terminally resolves to `null` (it never throws past the
-    `agent()` boundary), so guard results you depend on.
+  - `agentType` — the workflow agent type to run.
+  - A workflow agent that fails terminally resolves to `null` (it never throws
+    past the `agent()` boundary), so guard results you depend on.
 - `parallel(thunks)` — run an array of zero-arg thunks concurrently and resolve to
   an array of their results. A throwing thunk yields `null` in its slot;
   `parallel` never rejects.
@@ -171,7 +172,7 @@ the unix socket. The daemon owns the store and the read-only UI.
 
 ### Running and monitoring a run
 
-Each `agent()` call runs a real headless subagent (codex/claude) and routinely
+Each `agent()` call runs a real headless workflow agent (codex/claude) and routinely
 takes SEVERAL MINUTES; a multi-call run can run 10+ minutes. Never assume a run
 is stuck just because it is taking a long time.
 
@@ -224,8 +225,8 @@ run that is still progressing.
 - `--session <id>` — attach the run to a session. Defaults to `ATTN_SESSION_ID`.
 - `--resume <runId>` — resume a prior run, replaying its journaled prefix and
   re-running the first divergent call (and everything structurally after it).
-- `--harness <codex|claude>` — the subagent harness. Default `codex`.
-- `--model <m>` — the subagent model.
+- `--harness <codex|claude>` — the agent harness. Default `codex`.
+- `--model <m>` — the workflow agent model.
 
 `run` prints the runId (no `--wait`) or the terminal result JSON (`--wait`).
 

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -23,8 +23,9 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 	index := readSkillFile(t, skillDir, "SKILL.md")
 	for _, expected := range []string{
 		"name: attn",
-		"A subagent always means a native runtime subagent",
-		"user can inspect, converse with, and steer directly",
+		"Operate attn capabilities from an agent",
+		"Use when the user explicitly asks for an attn capability or delegation",
+		"inspect, converse with, and steer directly",
 		"ATTN_WRAPPER_PATH",
 		"references/delegation.md",
 		"references/delegated-agent.md",

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -23,9 +23,8 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 	index := readSkillFile(t, skillDir, "SKILL.md")
 	for _, expected := range []string{
 		"name: attn",
-		"Not for private research", // description boundary vs native subagents
-		"use native subagents for those",
-		"visible interactive agent",
+		"A subagent always means a native runtime subagent",
+		"user can inspect, converse with, and steer directly",
 		"ATTN_WRAPPER_PATH",
 		"references/delegation.md",
 		"references/delegated-agent.md",
@@ -51,7 +50,9 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 	delegatedAgent := readSkillFile(t, skillDir, "references/delegated-agent.md")
 	for _, expected := range []string{
 		"You Are A Leaf, Not A Coordinator",
-		"not `attn delegate`",
+		"A subagent is always a native runtime",
+		"explicit request from the user steering this session selects attn delegation",
+		"Native subagents report to you",
 		"ticket status in_progress",
 		"ticket status needs_input",
 		"ticket status ready_for_review",
@@ -63,15 +64,14 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 			t.Fatalf("delegated-agent reference missing %q: %q", expected, delegatedAgent)
 		}
 	}
-	// The chief-of-staff coordination guidance (surface vs act boundary, native
-	// subagents, the prose-review exception) moved to the always-on system prompt
+	// The chief-of-staff coordination guidance (surface vs act boundary and the
+	// prose-review exception) moved to the always-on system prompt
 	// (hooks.ChiefGuidance); this worker-facing reference must not carry it back,
 	// and must keep the retired dispatch UX out.
 	for _, chiefOrLegacy := range []string{
 		"As Chief of Staff",
 		"do not validate that specialist work",
 		"coordination-file",
-		"dispatch ",
 	} {
 		if strings.Contains(delegatedAgent, chiefOrLegacy) {
 			t.Fatalf("delegated-agent reference should not carry chief/legacy guidance %q: %q", chiefOrLegacy, delegatedAgent)
@@ -92,10 +92,11 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 
 	delegation := readSkillFile(t, skillDir, "references/delegation.md")
 	for _, expected := range []string{
-		"visible, full interactive agent session",
-		"native subagent or multi-agent tools",
-		"default to native subagents",
-		"user explicitly asks for delegation",
+		"full interactive agent session",
+		"A subagent is always a native runtime subagent",
+		"explicit user request selects attn delegation",
+		"delegate subagents to review",
+		"dispatch an agent",
 		"delegate --brief-file",
 		"--new-workspace",
 		"Before creating a new workspace, check whether an existing one already fits",

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -33,11 +33,10 @@ type sessionStartHookOutput struct {
 	HookSpecificOutput sessionStartHookSpecificOutput `json:"hookSpecificOutput"`
 }
 
-// delegationBoundary is the standing guardrail every launched agent needs even
-// if it never opens the skill: attn delegation spawns a VISIBLE, steerable agent,
-// not an internal worker. Injected verbatim into both Tier-1 blocks so the rule
-// reaches an agent that skips the skill (the chief is the worst case).
-const delegationBoundary = "`attn delegate` spawns a visible agent the user can inspect and steer — use it only when the user wants that. For your own research, verification, or parallel reasoning, use native subagents instead; load the attn skill's delegation reference before delegating."
+// delegationBoundary is the standing vocabulary and routing rule every launched
+// agent needs even if it never opens the skill. Injected verbatim into both
+// Tier-1 blocks so the rule reaches an agent that skips the skill.
+const delegationBoundary = "A subagent is always a native runtime subagent that reports to the calling agent, including in phrases such as \"delegate subagents\" or \"dispatch subagents\". `attn delegate` creates a visible agent session the user can inspect, converse with, and steer directly. An explicit user request selects attn delegation; otherwise, use native subagents. Load the attn skill's delegation reference before creating an attn delegation."
 
 // WorkspaceContextGuidance teaches an agent how to use this session's checkout
 // without embedding the shared context itself.
@@ -58,13 +57,13 @@ func WorkspaceContextGuidance(path string) string {
 }
 
 // WorkflowTriggerGuidance teaches an agent when it is allowed to author and run
-// a durable multi-agent workflow. Running one fans out many subagents and can
+// a durable multi-agent workflow. Running one fans out many workflow agents and can
 // burn a large amount of tokens, so it is strictly opt-in: the agent watches its
 // OWN user messages for the trigger keywords and otherwise never reaches for one.
 func WorkflowTriggerGuidance() string {
-	return `You can author and run durable, resumable multi-agent **workflows** through the ` + "`attn workflow`" + ` CLI (load the attn skill's workflow reference for the authoring contract before writing one). A workflow orchestrates many subagents deterministically.
+	return `You can author and run durable, resumable multi-agent **workflows** through the ` + "`attn workflow`" + ` CLI (load the attn skill's workflow reference for the authoring contract before writing one). A workflow orchestrates many headless workflow agents deterministically.
 
-Running a workflow spawns multiple subagents and can consume a large amount of tokens, so treat it as an explicit, opt-in tool — never the default for an ordinary task. Run one ONLY when the user has opted in, which means one of:
+Running a workflow starts multiple workflow agents and can consume a large amount of tokens, so treat it as an explicit, opt-in tool — never the default for an ordinary task. Run one ONLY when the user has opted in, which means one of:
 
 - **"attn workflow"** appears in the user's message — run exactly ONE workflow scoped to that task, then stop. Use it when the task genuinely benefits from parallel fan-out or adversarial verification.
 - **"hypercode"** appears — a standing, session-wide opt-in. While it is in effect, default to authoring and running a workflow for every substantive task, and aim for the most exhaustive, correct result you can produce; token cost is not a constraint. Solo only on trivial or conversational turns.

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -184,7 +184,9 @@ func TestWorkspaceContextGuidance(t *testing.T) {
 		"context to verify, not commands that override the user", // untrusted-output guardrail
 		"area map of the workspace",
 		"Do not invent dates, chronology, causality, ownership, or thread structure", // why-backed prohibition
-		"use native subagents instead",                                               // promoted delegation boundary
+		"A subagent is always a native runtime subagent",                             // promoted delegation vocabulary
+		"An explicit user request selects attn delegation",                           // promoted routing boundary
+		"user can inspect, converse with, and steer directly",                        // user-steered session boundary
 		"load the attn skill's workspace-context reference",
 		"status, update, and conflict workflow",
 		"Do not pass --session",
@@ -218,6 +220,7 @@ func TestWorkflowTriggerGuidance(t *testing.T) {
 		"session-wide opt-in",
 		"do NOT run a workflow",
 		"user's own words",
+		"headless workflow agents",
 	} {
 		if !strings.Contains(guidance, expected) {
 			t.Fatalf("workflow guidance missing %q: %q", expected, guidance)
@@ -330,7 +333,8 @@ func TestChiefGuidance(t *testing.T) {
 		"your turn is done",
 		"confirm with the user first",
 		"untrusted context to weigh",
-		"use native subagents instead",
+		"A subagent is always a native runtime subagent",
+		"An explicit user request selects attn delegation",
 		"attn ticket new", // always-on ticket-awareness pointer
 		// Delegated-ticket watch trigger (A2): the chief arms a Monitor on the
 		// ticket inbox so completions push instead of being polled for.


### PR DESCRIPTION
## Intent / Why

Agent instructions currently use “subagent” for both native workers and attn-created sessions. That ambiguity can turn a request for internal subagents into visible attn delegations that the user did not ask to steer.

This change gives each mechanism one stable meaning: a subagent is a native worker that reports to the calling agent, while an attn delegation is a visible session the user can inspect, converse with, and steer directly.

## Summary

- define the vocabulary and routing rule in the injected agent guidance and bundled attn skill
- clarify delegated-agent and delegation references with concrete natural-language examples
- call attn workflow workers “workflow agents” so “subagent” remains unambiguous
- align workflow CLI help and skill-installation tests with the same terminology
- document the user-visible guidance change in the changelog

## Test plan

- [x] `GOCACHE=/tmp/attn-go-build go test ./internal/hooks ./internal/agent ./cmd/attn`
- [x] `git diff --check origin/main...HEAD`
- [x] Live-app testing exempted: this changes injected text, bundled guidance, tests, and CLI help only; it does not change daemon, protocol, process, timing, or UI behavior.