### PR TITLE
feat(plugin): report OpenCode native attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Added
 - **OpenCode can now run as an installable attn agent.** The server-backed `attn-opencode` plugin launches an interactive OpenCode TUI inside attn, using OpenCode's configured defaults for ordinary sessions and an authenticated local server for delegated prompts. It retains the native session for resume and keeps attn’s working/idle state in sync. Delegations can pin the OpenCode provider/model and the contract-tested `low` or `max` variant, including isolated concurrent runs.
+- **OpenCode sessions now surface native questions and permissions in attn.** Question-tool requests show as waiting for input, permission requests show as pending approval, and reconnecting recovers either state from OpenCode before declaring the session idle.
 
 ### Fixed
 - **Closed sessions no longer leave workspace tiles that reappear in the sidebar.** Closing now removes the pane before announcing the session's departure, stale agent panes cannot be moved into another workspace, and startup repairs any orphan panes left by older runs.

--- a/docs/plans/2026-07-11-opencode-native-waiting-state-evidence.md
+++ b/docs/plans/2026-07-11-opencode-native-waiting-state-evidence.md
@@ -1,0 +1,113 @@
+# Plan: OpenCode native waiting state
+
+## Why / Alignment
+
+OpenCode already exposes explicit question and permission lifecycle events, so
+attn should use those native facts before introducing an LLM classifier. This
+chunk is done when an OpenCode session with a pending question appears as
+`waiting_input`, a pending permission appears as `pending_approval`, answering
+either returns it to `working`, and reconnect reconciliation restores the same
+state without guessing from `session.idle`.
+
+We are aligned that native pending requests are authoritative. An idle event is
+only reported as `idle` when the linked session has no pending question or
+permission. Classifying an ordinary prose question, generic installed-plugin
+supervision, and chief/workspace-context parity remain deferred.
+
+## Architecture Map
+
+```text
+OpenCode 1.17.16 / 1.17.18 HTTP + SSE
+  -> OpenCodeHTTP normalizes question(.v2).* / permission(.v2).* events
+  -> OpenCodeDriver filters the linked native session
+     -> question asked       -> session.report_state(waiting_input)
+     -> permission asked     -> session.report_state(pending_approval)
+     -> replied / rejected   -> session.report_state(working)
+     -> idle                 -> reconcile pending requests
+        -> pending question  -> waiting_input
+        -> pending permission-> pending_approval
+        -> neither           -> session.report_stop(idle)
+
+Reconnect / initial binding
+  -> subscribe first
+  -> fetch status + pending questions + pending permissions
+  -> enqueue one ordered attn report for the linked session
+
+Tests
+  -> FakeOpenCode pending-request registries and SSE events
+  -> adapter tests for filtering, ordering, idle races, and reconnect recovery
+  -> isolated attn-dev live question + permission proof
+```
+
+## Data Model / Interfaces
+
+```ts
+type NativeAttention =
+  | "question"
+  | "permission"
+  | undefined
+
+type ServerEvent = {
+  type: string // normalized without optional `.v2`
+  sessionID?: string
+  status?: string
+}
+```
+
+Pending request IDs remain owned by OpenCode. The plugin reads only enough of
+`GET /question` and `GET /permission` to determine whether the linked native
+session has an outstanding request; attn stores only the resulting session
+state and the existing monotonic report cursor.
+
+## Implementation Steps
+
+- [x] Normalize legacy and v2 question/permission event names and add
+  authenticated pending-request queries.
+- [x] Map linked-session lifecycle events to ordered attn state reports.
+- [x] Reconcile pending attention before reporting idle on initial connection,
+  reconnect, and idle events.
+- [x] Add deterministic adapter tests for auth, filtering, ordering, idle races,
+  reconnect recovery, and no-pending idle behavior.
+- [x] Update user-facing plugin documentation and changelog.
+- [x] Run plugin, Go, frontend, and type-generation checks.
+- [x] Verify question and permission transitions in the isolated `attn-dev`
+  app; do not install or test production.
+
+## Decisions
+
+- Native pending requests outrank `session.idle`; idle describes the model loop,
+  not whether OpenCode is awaiting a human action.
+- Reconcile from OpenCode's list endpoints after subscribing so missed events do
+  not leave attn in a false resting state.
+- Support both legacy and v2 event discriminants because the verified OpenCode
+  compatibility interval exposes both wire families.
+- Keep `classifier: false`; this slice does not claim to recognize prose-only
+  questions.
+
+## Verification Evidence
+
+- `bun test` in `plugins/attn-opencode`: 22 passed, 59 assertions.
+- `go test ./... -count=1`: passed. An earlier run hit the existing flaky
+  `TestCodexResumeMappingEndToEnd`; its isolated rerun and the final full-tree
+  run both passed.
+- `make test-frontend`: passed.
+- `make check-types` found no schema change, but the current quicktype 23.3.1
+  reorders pre-existing ticket declarations in `app/src/types/generated.ts`
+  relative to `origin/main`. The generated output was restored because this
+  slice does not change the protocol wire shape.
+- Fresh `attn-dev` profile: a real OpenCode question rendered in the TUI and
+  moved attn to `waiting_input`, then returned through `working` to `idle` when
+  answered. A real shell permission rendered in the TUI and moved attn to
+  `pending_approval`, then returned through `working` to `idle` after approval
+  and completion. The test session/workspace was removed; production was not
+  installed, restarted, or tested.
+- External Codex autoreview was attempted with explicit diff-disclosure
+  authorization, but the execution approval layer rejected the disclosure.
+  Local diff review and `git diff --check` found no actionable defects.
+
+## Follow-ups
+
+- Evaluate a classifier only for idle responses that ask for input without
+  invoking OpenCode's question tool.
+- Add generic installed-plugin supervision separately.
+- Add chief/workspace-context parity separately.

--- a/docs/plans/2026-07-11-opencode-native-waiting-state-evidence.md
+++ b/docs/plans/2026-07-11-opencode-native-waiting-state-evidence.md
@@ -86,7 +86,8 @@ state and the existing monotonic report cursor.
 
 ## Verification Evidence
 
-- `bun test` in `plugins/attn-opencode`: 22 passed, 59 assertions.
+- `bun test` in `plugins/attn-opencode`: 23 passed, 59 assertions, including
+  overlapping question/permission arrival and resolution ordering.
 - `go test ./... -count=1`: passed. An earlier run hit the existing flaky
   `TestCodexResumeMappingEndToEnd`; its isolated rerun and the final full-tree
   run both passed.
@@ -101,9 +102,11 @@ state and the existing monotonic report cursor.
   `pending_approval`, then returned through `working` to `idle` after approval
   and completion. The test session/workspace was removed; production was not
   installed, restarted, or tested.
-- External Codex autoreview was attempted with explicit diff-disclosure
-  authorization, but the execution approval layer rejected the disclosure.
-  Local diff review and `git diff --check` found no actionable defects.
+- Codex autoreview accepted two P2 overlap findings: resolving one request could
+  hide another, and a later question could hide an existing permission. Both
+  were fixed by reconciling OpenCode's pending lists while preserving permission
+  priority. The final branch review returned no actionable findings and judged
+  the patch correct with 0.9 confidence.
 
 ## Follow-ups
 

--- a/plugins/attn-opencode/README.md
+++ b/plugins/attn-opencode/README.md
@@ -30,6 +30,10 @@ password and staged prompt live in private files under the active profile's
 attn data directory (`plugins/attn-opencode/`), are never included in metadata
 or argv, and are deleted when attn reports that the PTY run has closed.
 
-The first slice reports OpenCode `busy` and `retry` as `working`, and explicit
-`idle` as `idle`. It intentionally does not infer `waiting_input` from an idle
-event.
+The plugin reports OpenCode `busy` and `retry` as `working`. Native question
+requests become `waiting_input`, and native permission requests become
+`pending_approval`; answering either returns the session to `working`. On
+startup, reconnect, and explicit idle events, the plugin checks OpenCode's
+pending request lists before reporting `idle`, so a missed SSE event cannot hide
+a session that needs attention. It intentionally does not classify ordinary
+prose questions that did not use OpenCode's question tool.

--- a/plugins/attn-opencode/src/driver.ts
+++ b/plugins/attn-opencode/src/driver.ts
@@ -1,6 +1,6 @@
 import { createServer } from "node:net";
 import { join } from "node:path";
-import { type EventSubscription, OpenCodeHTTP, parseModelPin, sessionModel, sessionModelMatches, variantForEffort } from "./opencode-http";
+import { type EventSubscription, type ServerEvent, OpenCodeHTTP, parseModelPin, sessionModel, sessionModelMatches, variantForEffort } from "./opencode-http";
 import { RunRegistry } from "./run-registry";
 import {
   type DriverSpawnParams,
@@ -55,6 +55,11 @@ type NativeBinding = {
   mode: LaunchSelection["mode"];
 };
 
+type BufferedSubscription = {
+  subscription: EventSubscription;
+  release: () => Promise<void>;
+};
+
 export class OpenCodeDriver {
   private readonly executable: string;
   private readonly runCommand: (argv: string[]) => Promise<CommandResult>;
@@ -98,7 +103,9 @@ export class OpenCodeDriver {
           resume: true,
           yolo: true,
           initial_prompt: true,
+          classifier: false,
           state_reporting: true,
+          pending_approval: true,
           model_pin: true,
           effort_pin: true,
         },
@@ -238,7 +245,8 @@ export class OpenCodeDriver {
       const client = await this.waitForHealthyServer(binding.record, signal);
       if (signal.aborted) return;
 
-      subscription = client.subscribe((event) => this.handleEvent(client, binding, event, eventController.signal), eventController.signal);
+      let bufferedSubscription = this.subscribeBuffered(client, binding, eventController.signal);
+      subscription = bufferedSubscription.subscription;
       const setup = this.requestDeadline(signal);
       try {
         await this.awaitSubscriptionReady(subscription, setup.signal);
@@ -274,6 +282,7 @@ export class OpenCodeDriver {
           const prompt = await this.options.registry.prompt(binding.record);
           if (prompt !== "") await client.promptAsync(nativeID, prompt, model, setup.signal);
         }
+        await bufferedSubscription.release();
       } finally {
         setup.dispose();
       }
@@ -298,11 +307,13 @@ export class OpenCodeDriver {
         for (let attempt = 0; attempt < eventReconnectAttempts; attempt += 1) {
           await sleep(this.reconnectDelay, signal);
           if (signal.aborted) return;
-          subscription = client.subscribe((event) => this.handleEvent(client, binding, event, eventController.signal), eventController.signal);
+          bufferedSubscription = this.subscribeBuffered(client, binding, eventController.signal);
+          subscription = bufferedSubscription.subscription;
           const setup = this.requestDeadline(signal);
           try {
             await this.awaitSubscriptionReady(subscription, setup.signal);
             await this.reconcileStatus(binding.record, client, binding.nativeID, setup.signal);
+            await bufferedSubscription.release();
             reconnectError = undefined;
             break;
           } catch (error) {
@@ -359,8 +370,15 @@ export class OpenCodeDriver {
 
   private async reconcileStatus(record: RunRecord, client: OpenCodeHTTP, nativeID: string | undefined, signal?: AbortSignal): Promise<void> {
     if (!nativeID) return;
-    const status = await client.statusFor(nativeID, signal);
-    if (status === "busy" || status === "retry") {
+    const [status, attention] = await Promise.all([
+      client.statusFor(nativeID, signal),
+      client.pendingAttentionFor(nativeID, signal),
+    ]);
+    if (attention === "permission") {
+      await this.enqueueReport(record, { kind: "state", state: "pending_approval" });
+    } else if (attention === "question") {
+      await this.enqueueReport(record, { kind: "state", state: "waiting_input" });
+    } else if (status === "busy" || status === "retry") {
       await this.enqueueReport(record, { kind: "state", state: "working" });
     } else if (status === "idle") {
       await this.enqueueReport(record, { kind: "stop", verdict: "idle" });
@@ -409,12 +427,62 @@ export class OpenCodeDriver {
       if (event.status === "busy" || event.status === "retry") {
         await this.enqueueReport(record, { kind: "state", state: "working" });
       } else if (event.status === "idle") {
-        await this.enqueueReport(record, { kind: "stop", verdict: "idle" });
+        await this.reportIdleWithinDeadline(record, client, binding.nativeID, parentSignal);
       }
     } else if (event.type === "session.idle") {
-      await this.enqueueReport(record, { kind: "stop", verdict: "idle" });
+      await this.reportIdleWithinDeadline(record, client, binding.nativeID, parentSignal);
+    } else if (event.type === "question.asked") {
+      await this.enqueueReport(record, { kind: "state", state: "waiting_input" });
+    } else if (event.type === "question.replied" || event.type === "question.rejected") {
+      await this.enqueueReport(record, { kind: "state", state: "working" });
+    } else if (event.type === "permission.asked") {
+      await this.enqueueReport(record, { kind: "state", state: "pending_approval" });
+    } else if (event.type === "permission.replied") {
+      await this.enqueueReport(record, { kind: "state", state: "working" });
     } else if (event.type === "session.error") {
       await this.enqueueReport(record, { kind: "state", state: "unknown" });
+    }
+  }
+
+  private subscribeBuffered(client: OpenCodeHTTP, binding: NativeBinding, signal: AbortSignal): BufferedSubscription {
+    const events: ServerEvent[] = [];
+    let buffering = true;
+    const subscription = client.subscribe((event) => {
+      if (buffering) {
+        events.push(event);
+        return;
+      }
+      return this.handleEvent(client, binding, event, signal);
+    }, signal);
+    return {
+      subscription,
+      release: async () => {
+        while (events.length > 0) {
+          await this.handleEvent(client, binding, events.shift()!, signal);
+        }
+        buffering = false;
+      },
+    };
+  }
+
+  private async reportIdleWithinDeadline(
+    record: RunRecord,
+    client: OpenCodeHTTP,
+    nativeID: string,
+    parentSignal: AbortSignal,
+  ): Promise<void> {
+    const request = this.requestDeadline(parentSignal);
+    try {
+      const attention = await client.pendingAttentionFor(nativeID, request.signal);
+      if (attention === "permission") {
+        await this.enqueueReport(record, { kind: "state", state: "pending_approval" });
+      } else if (attention === "question") {
+        await this.enqueueReport(record, { kind: "state", state: "waiting_input" });
+      } else {
+        await this.enqueueReport(record, { kind: "stop", verdict: "idle" });
+      }
+    } finally {
+      request.dispose();
     }
   }
 

--- a/plugins/attn-opencode/src/driver.ts
+++ b/plugins/attn-opencode/src/driver.ts
@@ -434,11 +434,11 @@ export class OpenCodeDriver {
     } else if (event.type === "question.asked") {
       await this.enqueueReport(record, { kind: "state", state: "waiting_input" });
     } else if (event.type === "question.replied" || event.type === "question.rejected") {
-      await this.enqueueReport(record, { kind: "state", state: "working" });
+      await this.reportAttentionWithinDeadline(record, client, binding.nativeID, parentSignal, { kind: "state", state: "working" });
     } else if (event.type === "permission.asked") {
       await this.enqueueReport(record, { kind: "state", state: "pending_approval" });
     } else if (event.type === "permission.replied") {
-      await this.enqueueReport(record, { kind: "state", state: "working" });
+      await this.reportAttentionWithinDeadline(record, client, binding.nativeID, parentSignal, { kind: "state", state: "working" });
     } else if (event.type === "session.error") {
       await this.enqueueReport(record, { kind: "state", state: "unknown" });
     }
@@ -471,6 +471,16 @@ export class OpenCodeDriver {
     nativeID: string,
     parentSignal: AbortSignal,
   ): Promise<void> {
+    await this.reportAttentionWithinDeadline(record, client, nativeID, parentSignal, { kind: "stop", verdict: "idle" });
+  }
+
+  private async reportAttentionWithinDeadline(
+    record: RunRecord,
+    client: OpenCodeHTTP,
+    nativeID: string,
+    parentSignal: AbortSignal,
+    fallback: Report,
+  ): Promise<void> {
     const request = this.requestDeadline(parentSignal);
     try {
       const attention = await client.pendingAttentionFor(nativeID, request.signal);
@@ -479,7 +489,7 @@ export class OpenCodeDriver {
       } else if (attention === "question") {
         await this.enqueueReport(record, { kind: "state", state: "waiting_input" });
       } else {
-        await this.enqueueReport(record, { kind: "stop", verdict: "idle" });
+        await this.enqueueReport(record, fallback);
       }
     } finally {
       request.dispose();

--- a/plugins/attn-opencode/src/driver.ts
+++ b/plugins/attn-opencode/src/driver.ts
@@ -432,7 +432,7 @@ export class OpenCodeDriver {
     } else if (event.type === "session.idle") {
       await this.reportIdleWithinDeadline(record, client, binding.nativeID, parentSignal);
     } else if (event.type === "question.asked") {
-      await this.enqueueReport(record, { kind: "state", state: "waiting_input" });
+      await this.reportAttentionWithinDeadline(record, client, binding.nativeID, parentSignal, { kind: "state", state: "waiting_input" });
     } else if (event.type === "question.replied" || event.type === "question.rejected") {
       await this.reportAttentionWithinDeadline(record, client, binding.nativeID, parentSignal, { kind: "state", state: "working" });
     } else if (event.type === "permission.asked") {

--- a/plugins/attn-opencode/src/opencode-http.ts
+++ b/plugins/attn-opencode/src/opencode-http.ts
@@ -6,6 +6,8 @@ export type ServerEvent = {
   status?: string;
 };
 
+export type NativeAttention = "question" | "permission";
+
 export type EventSubscription = {
   ready: Promise<void>;
   done: Promise<void>;
@@ -71,6 +73,18 @@ export class OpenCodeHTTP {
   async statusFor(sessionID: string, signal?: AbortSignal): Promise<string | undefined> {
     const body = await this.request<unknown>("/session/status", { signal });
     return extractStatus(body, sessionID);
+  }
+
+  async pendingAttentionFor(sessionID: string, signal?: AbortSignal): Promise<NativeAttention | undefined> {
+    const [questions, permissions] = await Promise.all([
+      this.request<unknown>("/question", { signal }),
+      this.request<unknown>("/permission", { signal }),
+    ]);
+    // A permission requires a constrained approval response, so prefer that
+    // state if a buggy or transitioning server briefly returns both kinds.
+    if (hasPendingRequest(permissions, sessionID)) return "permission";
+    if (hasPendingRequest(questions, sessionID)) return "question";
+    return undefined;
   }
 
   subscribe(onEvent: (event: ServerEvent) => Promise<void> | void, parentSignal?: AbortSignal): EventSubscription {
@@ -223,11 +237,27 @@ function normalizeEvent(eventName: string, raw: string): ServerEvent | undefined
   }
   const root = asObject(data);
   const properties = asObject(root?.properties) ?? root;
-  const type = eventName || asString(root?.type) || asString(root?.event);
+  const type = normalizeEventType(eventName || asString(root?.type) || asString(root?.event));
   if (!type) return undefined;
   const statusValue = properties?.status;
   const status = typeof statusValue === "string" ? statusValue : asString(asObject(statusValue)?.type);
   return { type, sessionID: sessionIDFrom(properties) ?? sessionIDFrom(root), status };
+}
+
+function normalizeEventType(type: string | undefined): string | undefined {
+  return type?.replace(/^(question|permission)\.v2\./, "$1.");
+}
+
+function hasPendingRequest(body: unknown, sessionID: string): boolean {
+  const root = asObject(body);
+  const requests = Array.isArray(body)
+    ? body
+    : Array.isArray(root?.requests)
+      ? root.requests
+      : Array.isArray(root?.data)
+        ? root.data
+        : [];
+  return requests.some((request) => sessionIDFrom(asObject(request)) === sessionID);
 }
 
 function extractStatus(body: unknown, sessionID: string): string | undefined {

--- a/plugins/attn-opencode/src/types.ts
+++ b/plugins/attn-opencode/src/types.ts
@@ -76,9 +76,9 @@ export type LaunchConfig = {
   resume_session_id?: string;
 };
 
-export type ReportState = "working" | "idle" | "unknown";
+export type ReportState = "working" | "waiting_input" | "pending_approval" | "idle" | "unknown";
 
 export type Report =
   | { kind: "metadata"; metadata: OpenCodeMetadata }
   | { kind: "state"; state: ReportState }
-  | { kind: "stop"; verdict: "idle" | "unknown" };
+  | { kind: "stop"; verdict: "idle" | "waiting_input" | "unknown" };

--- a/plugins/attn-opencode/test/driver.test.ts
+++ b/plugins/attn-opencode/test/driver.test.ts
@@ -97,7 +97,10 @@ describe("OpenCode server-backed driver", () => {
     await expect(new OpenCodeHTTP({ port: target.port, password: "wrong-password" }).health()).rejects.toThrow("HTTP 401");
     const client = new OpenCodeHTTP({ port: target.port, password: "correct-password" });
     await expect(client.health()).resolves.toEqual({ version: "1.17.18" });
-    expect(target.requests).toHaveLength(2);
+    target.pendingQuestions.set("question-auth", "native-auth");
+    await expect(client.pendingAttentionFor("native-auth")).resolves.toBe("question");
+    expect(target.requests).toHaveLength(4);
+    expect(target.requests.slice(1).every((request) => request.authorization?.startsWith("Basic "))).toBe(true);
   });
 
   test("creates a pinned native session after authenticated SSE subscription and does not infer idle from a missing status", async () => {
@@ -137,6 +140,136 @@ describe("OpenCode server-backed driver", () => {
     ]);
     const sequences = rpc.calls.slice(1).map((call) => (call.params as { seq: number }).seq);
     expect(sequences).toEqual([1, 2, 3, 4]);
+  });
+
+  test("maps native question and permission events for only the linked session", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn(params("run-attention-events"));
+    await eventually(() => target.prompts.length === 1, "native prompt submission");
+
+    const reportsBeforeOtherSession = rpc.calls.length;
+    target.askQuestion("native-other", "question-other");
+    await Bun.sleep(20);
+    expect(rpc.calls).toHaveLength(reportsBeforeOtherSession);
+
+    target.askQuestion("native-1", "question-1", "question.v2.asked");
+    await eventually(
+      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "waiting_input",
+      "question waiting-input report",
+    );
+    target.replyQuestion("native-1", "question-1", "question.v2.replied");
+    await eventually(
+      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "working",
+      "question reply working report",
+    );
+    target.askPermission("native-1", "permission-1", "permission.v2.asked");
+    await eventually(
+      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "pending_approval",
+      "permission pending-approval report",
+    );
+    target.replyPermission("native-1", "permission-1", "permission.v2.replied");
+    await eventually(
+      () => rpc.calls.filter((call) => (call.params as { state?: string }).state === "working").length === 2,
+      "permission reply working report",
+    );
+
+    const attentionReports = rpc.calls.slice(reportsBeforeOtherSession);
+    expect(attentionReports.map((call) => (call.params as { state?: string }).state)).toEqual([
+      "waiting_input",
+      "working",
+      "pending_approval",
+      "working",
+    ]);
+    expect(attentionReports.map((call) => (call.params as { seq: number }).seq)).toEqual([2, 3, 4, 5]);
+  });
+
+  test("checks pending native attention before reporting an explicit idle event", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn(params("run-idle-attention"));
+    await eventually(() => target.prompts.length === 1, "native prompt submission");
+
+    target.pendingQuestions.set("question-idle", "native-1");
+    target.emit("session.idle", { sessionID: "native-1" });
+    await eventually(
+      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "waiting_input",
+      "idle with pending question",
+    );
+    expect(rpc.calls.some((call) => call.method === "session.report_stop")).toBe(false);
+
+    target.pendingQuestions.clear();
+    target.pendingPermissions.set("permission-idle", "native-1");
+    target.emit("session.status", { sessionID: "native-1", status: { type: "idle" } });
+    await eventually(
+      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "pending_approval",
+      "idle with pending permission",
+    );
+    expect(rpc.calls.some((call) => call.method === "session.report_stop")).toBe(false);
+
+    target.pendingPermissions.clear();
+    target.emit("session.idle", { sessionID: "native-1" });
+    await eventually(() => rpc.calls.at(-1)?.method === "session.report_stop", "idle without pending attention");
+    expect((rpc.calls.at(-1)?.params as { verdict: string }).verdict).toBe("idle");
+  });
+
+  test("reconciles a missed pending question after the SSE stream reconnects", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn(params("run-question-reconnect"));
+    await eventually(() => target.prompts.length === 1 && target.eventSubscriberCount === 1, "initial native run");
+
+    target.pendingQuestions.set("question-missed", "native-1");
+    target.closeEvents();
+    await eventually(
+      () => target.requests.filter((request) => request.path === "/event").length >= 2 &&
+        (rpc.calls.at(-1)?.params as { state?: string }).state === "waiting_input",
+      "reconnected pending-question reconciliation",
+    );
+    expect(driver.health()).toEqual({ ok: true, message: "OpenCode 1.17.18 is ready" });
+  });
+
+  test("applies events buffered during reconnect after the older pending-request snapshot", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn(params("run-question-reconnect-order"));
+    await eventually(() => target.prompts.length === 1 && target.eventSubscriberCount === 1, "initial native run");
+
+    target.pendingQuestions.set("question-race", "native-1");
+    let releaseSnapshot!: () => void;
+    target.pendingListBarrier = new Promise<void>((resolve) => {
+      releaseSnapshot = resolve;
+    });
+    target.closeEvents();
+    await eventually(
+      () => target.requests.filter((request) => request.path === "/question").length >= 2 &&
+        target.requests.filter((request) => request.path === "/permission").length >= 2 &&
+        target.eventSubscriberCount === 1,
+      "reconnect snapshot in flight",
+    );
+
+    target.replyQuestion("native-1", "question-race");
+    releaseSnapshot();
+    await eventually(
+      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "working",
+      "buffered question reply after stale snapshot",
+    );
+    const states = rpc.calls
+      .filter((call) => call.method === "session.report_state")
+      .map((call) => (call.params as { state: string }).state);
+    expect(states.slice(-2)).toEqual(["waiting_input", "working"]);
   });
 
   test("lets an unpinned interactive launch use OpenCode defaults and records its first native session", async () => {

--- a/plugins/attn-opencode/test/driver.test.ts
+++ b/plugins/attn-opencode/test/driver.test.ts
@@ -187,6 +187,50 @@ describe("OpenCode server-backed driver", () => {
     expect(attentionReports.map((call) => (call.params as { seq: number }).seq)).toEqual([2, 3, 4, 5]);
   });
 
+  test("keeps reporting attention when another native request remains after a resolution", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = driverFor(rpc, registry, target);
+    await driver.initialize();
+    await driver.spawn(params("run-overlapping-attention"));
+    await eventually(() => target.prompts.length === 1, "native prompt submission");
+
+    target.askQuestion("native-1", "question-overlap");
+    await eventually(
+      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "waiting_input",
+      "initial question report",
+    );
+    target.askPermission("native-1", "permission-overlap");
+    await eventually(
+      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "pending_approval",
+      "overlapping permission report",
+    );
+
+    target.replyPermission("native-1", "permission-overlap");
+    await eventually(
+      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "waiting_input",
+      "remaining question after permission reply",
+    );
+
+    target.askPermission("native-1", "permission-overlap-2");
+    await eventually(
+      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "pending_approval",
+      "second overlapping permission report",
+    );
+    target.replyQuestion("native-1", "question-overlap");
+    await eventually(
+      () => rpc.calls.filter((call) => (call.params as { state?: string }).state === "pending_approval").length === 3,
+      "remaining permission after question reply",
+    );
+
+    target.replyPermission("native-1", "permission-overlap-2");
+    await eventually(
+      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "working",
+      "working after all native attention resolves",
+    );
+  });
+
   test("checks pending native attention before reporting an explicit idle event", async () => {
     const rpc = new RecordingRPC();
     const target = server("*");

--- a/plugins/attn-opencode/test/driver.test.ts
+++ b/plugins/attn-opencode/test/driver.test.ts
@@ -196,15 +196,15 @@ describe("OpenCode server-backed driver", () => {
     await driver.spawn(params("run-overlapping-attention"));
     await eventually(() => target.prompts.length === 1, "native prompt submission");
 
-    target.askQuestion("native-1", "question-overlap");
-    await eventually(
-      () => (rpc.calls.at(-1)?.params as { state?: string }).state === "waiting_input",
-      "initial question report",
-    );
     target.askPermission("native-1", "permission-overlap");
     await eventually(
       () => (rpc.calls.at(-1)?.params as { state?: string }).state === "pending_approval",
-      "overlapping permission report",
+      "initial permission report",
+    );
+    target.askQuestion("native-1", "question-overlap");
+    await eventually(
+      () => rpc.calls.filter((call) => (call.params as { state?: string }).state === "pending_approval").length === 2,
+      "permission remains authoritative after overlapping question",
     );
 
     target.replyPermission("native-1", "permission-overlap");
@@ -220,7 +220,7 @@ describe("OpenCode server-backed driver", () => {
     );
     target.replyQuestion("native-1", "question-overlap");
     await eventually(
-      () => rpc.calls.filter((call) => (call.params as { state?: string }).state === "pending_approval").length === 3,
+      () => rpc.calls.filter((call) => (call.params as { state?: string }).state === "pending_approval").length === 4,
       "remaining permission after question reply",
     );
 

--- a/plugins/attn-opencode/test/fake-opencode.ts
+++ b/plugins/attn-opencode/test/fake-opencode.ts
@@ -9,6 +9,9 @@ export class FakeOpenCode {
   readonly requests: RequestRecord[] = [];
   readonly statuses = new Map<string, string>();
   readonly sessions = new Map<string, unknown>();
+  readonly pendingQuestions = new Map<string, string>();
+  readonly pendingPermissions = new Map<string, string>();
+  pendingListBarrier?: Promise<void>;
   readonly hangingSessionReads = new Set<string>();
   readonly prompts: Array<{ sessionID: string; body: unknown }> = [];
   private controllers = new Set<ReadableStreamDefaultController<Uint8Array>>();
@@ -40,6 +43,26 @@ export class FakeOpenCode {
   emit(type: string, properties: Record<string, unknown>): void {
     const frame = `event: ${type}\ndata: ${JSON.stringify({ type, properties })}\n\n`;
     for (const controller of this.controllers) controller.enqueue(new TextEncoder().encode(frame));
+  }
+
+  askQuestion(sessionID: string, requestID = "question-1", type = "question.asked"): void {
+    this.pendingQuestions.set(requestID, sessionID);
+    this.emit(type, { id: requestID, sessionID, questions: [] });
+  }
+
+  replyQuestion(sessionID: string, requestID = "question-1", type = "question.replied"): void {
+    this.pendingQuestions.delete(requestID);
+    this.emit(type, { sessionID, requestID, answers: [] });
+  }
+
+  askPermission(sessionID: string, requestID = "permission-1", type = "permission.asked"): void {
+    this.pendingPermissions.set(requestID, sessionID);
+    this.emit(type, { id: requestID, sessionID, permission: "bash", patterns: [], metadata: {}, always: [] });
+  }
+
+  replyPermission(sessionID: string, requestID = "permission-1", type = "permission.replied"): void {
+    this.pendingPermissions.delete(requestID);
+    this.emit(type, { sessionID, requestID, reply: "once" });
   }
 
   closeEvents(): void {
@@ -80,6 +103,23 @@ export class FakeOpenCode {
       return Response.json({ id });
     }
     if (url.pathname === "/session/status") return Response.json(Object.fromEntries(this.statuses));
+    if (url.pathname === "/question") {
+      const snapshot = [...this.pendingQuestions].map(([id, sessionID]) => ({ id, sessionID, questions: [] }));
+      await this.pendingListBarrier;
+      return Response.json(snapshot);
+    }
+    if (url.pathname === "/permission") {
+      const snapshot = [...this.pendingPermissions].map(([id, sessionID]) => ({
+        id,
+        sessionID,
+        permission: "bash",
+        patterns: [],
+        metadata: {},
+        always: [],
+      }));
+      await this.pendingListBarrier;
+      return Response.json(snapshot);
+    }
     if (url.pathname.startsWith("/session/") && url.pathname.endsWith("/prompt_async")) {
       const sessionID = decodeURIComponent(url.pathname.slice("/session/".length, -"/prompt_async".length));
       const prompt = body as {


### PR DESCRIPTION
## Intent

OpenCode already exposes explicit question and permission lifecycle signals. Use those native facts so delegated OpenCode sessions surface required human attention accurately without introducing prose classification.

## Summary

- map native OpenCode questions to `waiting_input` and permissions to `pending_approval`
- reconcile authenticated pending-request lists before idle, after request resolution, and across SSE reconnects
- preserve permission priority and ordered attn reports when questions and permissions overlap
- keep prose-only classification deferred and document the native behavior

## Test plan

- [x] `bun test` in `plugins/attn-opencode` — 23 passed
- [x] `go test ./... -count=1`
- [x] `make test-frontend`
- [x] Codex autoreview — final pass clean after fixing both overlapping-request orderings
- [x] Live `attn-dev` verification with a real OpenCode question and shell permission, including TUI rendering and `waiting_input` / `pending_approval` → `working` → `idle`

## Out of scope

- prose classification when OpenCode does not invoke its question tool
- generic installed-plugin supervision
- chief/workspace-context parity

Production was not installed, restarted, or tested.
