### PR TITLE
fix(notebook): native undo/redo in the editor + dead ⌘⌥N shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-12]
+
+### Fixed
+- **Undo and redo now work in the Notebook editor.** ⌘Z and ⇧⌘Z were swallowed by the native Edit menu in the packaged app and never reached the editor; they now undo/redo your edits when the editor has focus. ⇧⌘Z still zooms the active pane when you're not in a text field.
+- **⌘⌥N and ⇧⌘⌥N open the Notebook again.** With Option held, macOS reports a dead-key character instead of the letter, so the notebook shortcuts never matched in the installed app and the keystroke fell through into the terminal. They now match on the physical key.
+
 ## [2026-07-11]
 
 ### Fixed

--- a/app/package.json
+++ b/app/package.json
@@ -51,6 +51,7 @@
     "real-app:scenario-tile-only-workspace-select": "node scripts/real-app-harness/scenario-tile-only-workspace-select.mjs",
     "real-app:scenario-notebook-tile-finder": "node scripts/real-app-harness/scenario-notebook-tile-finder.mjs",
     "real-app:scenario-notebook-tile-close": "node scripts/real-app-harness/scenario-notebook-tile-close.mjs",
+    "real-app:scenario-notebook-editor-undo": "node scripts/real-app-harness/scenario-notebook-editor-undo.mjs",
     "real-app:scenario-autoclose-on-exit": "node scripts/real-app-harness/scenario-autoclose-on-exit.mjs",
     "real-app:scenario-present-flow": "node scripts/real-app-harness/scenario-present-flow.mjs",
     "real-app:scenario-ticket-lifecycle": "node scripts/real-app-harness/scenario-ticket-delegation-lifecycle.mjs",

--- a/app/scripts/real-app-harness/scenario-notebook-editor-undo.mjs
+++ b/app/scripts/real-app-harness/scenario-notebook-editor-undo.mjs
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+
+// Native ⌘Z/⇧⌘Z inside a notebook tile's editor, in the packaged app. AGENTS.md
+// "Critical Pattern 8": a macOS native menu accelerator claims a key equivalent
+// before it ever reaches the WebView. This PR removes the predefined Edit > Undo
+// item in app/src-tauri/src/lib.rs `app_menu()` (Redo was already removed) so ⌘Z
+// reaches CodeMirror's history keymap inside the notebook editor instead of being
+// swallowed. Browser e2e cannot cover this: Playwright delivers ⌘Z as a plain DOM
+// keydown, never through the native menu, so a regression here would pass e2e and
+// unit tests while being silently dead in the installed app (the exact failure
+// mode "toggleZoom was dead" hit for ⇧⌘Z before that fix).
+//
+// The assertion is disk-based, not DOM-based: type a probe string into a real note
+// via native keystrokes, poll the file on disk for the autosaved (debounced) probe
+// text, then native ⌘Z until the file is back to its original content, then native
+// ⇧⌘Z until the probe text reappears. That proves both keys actually reached
+// CodeMirror's undo/redo, not just that "something" happened in the DOM.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  createRunContext,
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { currentHarnessProfile } from './harnessProfile.mjs';
+import { MacOSDriver } from './macosDriver.mjs';
+import { captureFrontWindowScreenshot } from './nativeWindowCapture.mjs';
+import {
+  waitForFirstWorkspacePane,
+  waitForPaneShellReady,
+  waitForPaneVisible,
+} from './scenarioAssertions.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') {
+    args.shift();
+  }
+  return {
+    options: parseCommonArgs(args),
+    help: args.includes('--help') || args.includes('-h'),
+  };
+}
+
+// Scope probes to the ACTIVE workspace: inactive workspaces stay mounted but
+// hidden (warm set), so an unscoped selector can match a stale finder/editor
+// left open by a previous run's workspace and poison presence waits.
+const FINDER_SELECTOR = '.terminal-wrapper.active .notebook-finder';
+const EDITOR_SELECTOR = '.terminal-wrapper.active .cm-content';
+const ORIGINAL_CONTENT = '# Undo Probe\n\nThis paragraph exists before the probe types anything.\n';
+const PROBE_SUFFIX = ' UNDOPROBE';
+
+// Mirrors internal/notebook/layout.go DefaultRoot: ~/attn-notebook, or
+// ~/attn-notebook-<profile> for any non-default profile. This is the notebook
+// root ONLY when the daemon's `notebook.root` setting is unset (the default for
+// every profile the harness creates fresh) — there is no UI-automation surface
+// that reports the resolved root without opening the Settings modal, and adding
+// one is out of scope here (real-app parity: don't invent new app surface for a
+// harness convenience). If a profile has a custom notebook.root configured, this
+// scenario will write its probe note into the wrong directory and the finder
+// step below will time out with a clear "finder never showed the probe" failure.
+function defaultNotebookRootForProfile(profile) {
+  const normalized = (profile || '').trim().toLowerCase();
+  const base = path.join(os.homedir(), 'attn-notebook');
+  return normalized === '' || normalized === 'default' ? base : `${base}-${normalized}`;
+}
+
+async function domSelectorPresent(client, selector) {
+  try {
+    await client.request('capture_screenshot_data', { selector });
+    return true;
+  } catch (error) {
+    if (String(error).includes('Screenshot selector not found in DOM')) {
+      return false;
+    }
+    // The selector resolved but the capture itself failed — html-to-image can
+    // throw on some subtrees (e.g. CodeMirror's .cm-content). We asked about
+    // presence, and the bridge only emits the "not found" error when the
+    // element is genuinely absent, so treat any other failure as present.
+    return true;
+  }
+}
+
+async function waitForDomSelector(client, selector, present, description, timeoutMs = 10_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if ((await domSelectorPresent(client, selector)) === present) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  throw new Error(`Timed out waiting for ${selector} to be ${present ? 'present' : 'absent'}: ${description}`);
+}
+
+async function waitForWorkspaceUi(client, workspaceId, predicate, description, timeoutMs = 20_000) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await client.request('get_workspace_ui_state', { workspaceId }).catch((error) => ({ error: String(error) }));
+    if (predicate(last)) {
+      return last;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`Timed out waiting for ${description}. Last workspace UI state:\n${JSON.stringify(last, null, 2)}`);
+}
+
+// Autosave is debounced 700ms (NotebookSurface AUTOSAVE_DELAY_MS); poll the file
+// on disk rather than guessing a sleep duration.
+async function waitForFileContent(filePath, predicate, description, timeoutMs = 10_000) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      last = fs.readFileSync(filePath, 'utf8');
+    } catch (error) {
+      last = `<read error: ${error instanceof Error ? error.message : String(error)}>`;
+    }
+    if (typeof last === 'string' && predicate(last)) {
+      return last;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for ${description}. Last file content:\n${last}`);
+}
+
+// Press a key up to `maxPresses` times, polling disk after each press, and
+// return as soon as the file matches `predicate`. CodeMirror's history groups
+// adjacent fast typing into one undo step, so one press is the common case, but
+// press count is not guaranteed, so retry rather than asserting an exact count.
+async function pressUntilFileMatches(driver, filePath, key, modifiers, predicate, description, maxPresses = 5) {
+  for (let attempt = 1; attempt <= maxPresses; attempt += 1) {
+    await driver.activateApp();
+    await driver.pressKey(key, modifiers);
+    try {
+      return await waitForFileContent(filePath, predicate, `${description} (press ${attempt}/${maxPresses})`, 3_000);
+    } catch {
+      // Not there yet; try another press.
+    }
+  }
+  const finalContent = fs.readFileSync(filePath, 'utf8');
+  throw new Error(`${description}: still not satisfied after ${maxPresses} presses of ${key}. Final content:\n${finalContent}`);
+}
+
+async function closeWorkspacePanes(client, sessionId) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const workspace = await client.request('get_workspace', { sessionId }).catch(() => null);
+    const pane = workspace?.panes?.[0];
+    if (!pane) {
+      return;
+    }
+    await client.request('close_pane', { sessionId, paneId: pane.paneId }).catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+async function closeExistingSessions(client, sessionRootDir) {
+  const initial = await client.request('get_state');
+  const harnessSessions = (initial.sessions || []).filter((session) => session.cwd?.startsWith(sessionRootDir));
+  for (const session of harnessSessions) {
+    await closeWorkspacePanes(client, session.id).catch(() => {});
+  }
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-notebook-editor-undo.mjs');
+    return;
+  }
+
+  const { runId, runDir, sessionDir } = createRunContext(options, 'notebook-editor-undo');
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const driver = new MacOSDriver({ appPath: options.appPath });
+  let sessionId = null;
+  let probeFilePath = null;
+
+  console.log(`[RealAppHarness] runDir=${runDir}`);
+  console.log(`[RealAppHarness] sessionDir=${sessionDir}`);
+  console.log(`[RealAppHarness] wsUrl=${options.wsUrl}`);
+
+  try {
+    process.env.ATTN_HARNESS_PARK_VISIBLE_PX ??= '0';
+    await launchFreshAppAndConnect(client, observer);
+    await closeExistingSessions(client, options.sessionRootDir);
+
+    // 0. Seed a note on disk before anything else, so the notebook's first file
+    //    index (built when a tile mounts) already contains it — no race against
+    //    the fs watcher's debounce.
+    const notebookRoot = defaultNotebookRootForProfile(currentHarnessProfile());
+    fs.mkdirSync(notebookRoot, { recursive: true });
+    const probeBasename = `undo-probe-${runId}`;
+    probeFilePath = path.join(notebookRoot, `${probeBasename}.md`);
+    fs.writeFileSync(probeFilePath, ORIGINAL_CONTENT, 'utf8');
+    console.log(`[RealAppHarness] notebookRoot=${notebookRoot}`);
+    console.log(`[RealAppHarness] probeFilePath=${probeFilePath}`);
+
+    // 1. A normal shell workspace to dock the notebook tile into.
+    const cwd = path.join(sessionDir, 'undo-ws');
+    fs.mkdirSync(cwd, { recursive: true });
+    sessionId = await createSessionAndWaitForInitialPane({
+      client,
+      observer,
+      cwd,
+      label: `notebook-undo-${runId}`,
+      agent: 'shell',
+      waitForInitialPaneVisible: false,
+      sessionWaitMs: 30_000,
+    });
+    const pane = await waitForFirstWorkspacePane(client, sessionId, 'initial workspace pane');
+    await client.request('select_session', { sessionId });
+    await waitForPaneVisible(client, sessionId, pane.paneId, 20_000);
+    await waitForPaneShellReady(client, sessionId, pane.paneId, {
+      timeoutMs: 20_000,
+      description: 'shell prompt ready',
+    });
+
+    const workspace = await client.request('get_workspace', { sessionId });
+    const workspaceId = workspace.workspaceId;
+    if (!workspaceId) {
+      throw new Error(`Could not resolve workspace id for session ${sessionId}: ${JSON.stringify(workspace)}`);
+    }
+
+    // 2. Dock a notebook tile via the REAL native ⌘⌥N (notebook.openTile) — the
+    //    macOS-menu → WebView shortcut path browser e2e can't reach.
+    await driver.activateApp();
+    await driver.pressKey('n', { command: true, option: true });
+
+    let docked;
+    try {
+      docked = await waitForWorkspaceUi(
+        client,
+        workspaceId,
+        (state) => Array.isArray(state?.tileIds) && state.tileIds.length === 1
+          && Array.isArray(state?.tileTitles) && state.tileTitles.includes('Notebook'),
+        'native Cmd+Opt+N to dock a fresh notebook tile (titled "Notebook")',
+        15_000,
+      );
+    } catch (dockError) {
+      const frontmost = await driver.frontmostBundleId().catch(() => '(unknown)');
+      throw new Error(
+        `${dockError.message}\n\nThis scenario needs native keyboard input: grant Accessibility `
+        + `permission to the process running it and keep attn frontmost. Frontmost app was `
+        + `"${frontmost}" (expected "${driver.bundleId}").`,
+      );
+    }
+    console.log(`[RealAppHarness] docked notebook tile=${docked.tileIds[0]}`);
+
+    // 3. A fresh tile auto-opens its finder. Type the probe note's basename and
+    //    press Enter to open it — the same native path a user takes.
+    await waitForDomSelector(client, FINDER_SELECTOR, true, 'fresh notebook tile auto-opens its finder');
+    await driver.activateApp();
+    await driver.typeText(probeBasename);
+    await driver.pressEnter();
+    await waitForDomSelector(client, FINDER_SELECTOR, false, 'Enter picks the probe note and closes the finder');
+
+    // 4. Confirm the editor actually rendered before trying to type into it.
+    await waitForDomSelector(client, EDITOR_SELECTOR, true, 'note opens into the live markdown editor');
+    await captureFrontWindowScreenshot(path.join(runDir, 'editor-open.png'), { client }).catch((error) => {
+      console.warn(`[RealAppHarness] editor-open screenshot failed: ${error}`);
+    });
+
+    // 5. Opening a note via the finder does NOT focus the editor (NotebookSurface
+    //    restores focus to whatever had it before the finder opened) — a real user
+    //    clicks into the note body before typing, so do the same with a REAL native
+    //    click. The docked tile occupies roughly the right quarter of the window,
+    //    with the note header card in its upper part, so aim at the note body low
+    //    in the tile. CodeMirror adds `.cm-focused` to its root while focused —
+    //    verify that landed (retrying once) instead of typing blind into the PTY.
+    await driver.activateApp();
+    let editorFocused = false;
+    for (let attempt = 0; attempt < 2 && !editorFocused; attempt++) {
+      await driver.clickWindow(0.85, 0.85);
+      try {
+        await waitForDomSelector(client, '.terminal-wrapper.active .cm-editor.cm-focused', true, 'native click focuses the CodeMirror editor', 5_000);
+        editorFocused = true;
+      } catch (error) {
+        if (attempt === 1) throw error;
+      }
+    }
+
+    // 6. Native typing into the editor, then wait for the debounced (700ms)
+    //    autosave to land the probe text on disk. This is the proof typing
+    //    reached CodeMirror at all, before undo/redo are exercised.
+    await driver.activateApp();
+    await driver.typeText(PROBE_SUFFIX);
+    await waitForFileContent(
+      probeFilePath,
+      (content) => content.includes(PROBE_SUFFIX.trim()),
+      'autosave to persist the typed probe text',
+    );
+    console.log('[RealAppHarness] probe text landed on disk via native typing + autosave.');
+
+    // 7. THE assertion: native ⌘Z must reach CodeMirror's undo, not a swallowed
+    //    Edit > Undo menu item. Retry the press (grouped-typing undo is usually
+    //    one step, but is not guaranteed) until the file is back to original.
+    await pressUntilFileMatches(
+      driver,
+      probeFilePath,
+      'z',
+      { command: true },
+      (content) => content === ORIGINAL_CONTENT,
+      'native Cmd+Z to undo the probe text back to original content',
+    );
+    console.log('[RealAppHarness] native Cmd+Z undid the probe text (menu no longer swallows it).');
+    await captureFrontWindowScreenshot(path.join(runDir, 'after-undo.png'), { client }).catch((error) => {
+      console.warn(`[RealAppHarness] after-undo screenshot failed: ${error}`);
+    });
+
+    // 8. Native ⇧⌘Z must reach CodeMirror's redo, not terminal.toggleZoom (the
+    //    exact menu-trap bug pattern AGENTS.md documents for ⇧⌘Z elsewhere).
+    await pressUntilFileMatches(
+      driver,
+      probeFilePath,
+      'z',
+      { command: true, shift: true },
+      (content) => content.includes(PROBE_SUFFIX.trim()),
+      'native Shift+Cmd+Z to redo the probe text',
+    );
+    console.log('[RealAppHarness] native Shift+Cmd+Z redid the probe text (menu no longer swallows it).');
+    await captureFrontWindowScreenshot(path.join(runDir, 'after-redo.png'), { client }).catch((error) => {
+      console.warn(`[RealAppHarness] after-redo screenshot failed: ${error}`);
+    });
+
+    // 9. Confirm ⇧⌘Z landed in CodeMirror's redo and NOT terminal.toggleZoom —
+    //    the exact confusion this fix disambiguates (see AGENTS.md Critical
+    //    Pattern 8, the toggleZoom precedent). get_session_ui_state's
+    //    workspace.view.zoomedPaneId is the existing UI-state surface for this;
+    //    no new automation surface needed.
+    const sessionUiState = await client.request('get_session_ui_state', { sessionId });
+    const zoomedPaneId = sessionUiState?.workspace?.view?.zoomedPaneId ?? null;
+    if (zoomedPaneId) {
+      throw new Error(
+        `Shift+Cmd+Z zoomed pane ${zoomedPaneId} instead of (only) redoing in the editor — `
+        + `terminal.toggleZoom fired alongside/instead of CodeMirror redo.`,
+      );
+    }
+
+    const summary = {
+      ok: true,
+      runId,
+      workspaceId,
+      tileId: docked.tileIds[0],
+      probeFilePath,
+    };
+    fs.writeFileSync(path.join(runDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    console.log('[RealAppHarness] Notebook editor native Cmd+Z undo / Shift+Cmd+Z redo passed.');
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    if (sessionId) {
+      await closeWorkspacePanes(client, sessionId).catch(() => {});
+    }
+    if (probeFilePath) {
+      fs.rmSync(probeFilePath, { force: true });
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/scripts/real-app-harness/scenario-notebook-tile-close.mjs
+++ b/app/scripts/real-app-harness/scenario-notebook-tile-close.mjs
@@ -163,7 +163,7 @@ async function main() {
     //    the terminal on dock.
     await waitForFinder(client, true, 'fresh notebook tile auto-opens its finder');
     await driver.activateApp();
-    await driver.pressKey('Escape');
+    await driver.pressKeyCode(53); // Esc — InputDriver's --key map only covers printable keys
     await waitForFinder(client, false, 'Esc dismisses the finder, leaving focus in the tile');
 
     // 4. The REAL native ⌘W. In the packaged app this fires the native "Close Pane"

--- a/app/scripts/real-app-harness/scenario-notebook-tile-finder.mjs
+++ b/app/scripts/real-app-harness/scenario-notebook-tile-finder.mjs
@@ -42,16 +42,28 @@ function parseArgs(argv) {
   };
 }
 
-const FINDER_SELECTOR = '.notebook-finder';
+// Scope probes to the ACTIVE workspace: inactive workspaces stay mounted but
+// hidden (warm set), so an unscoped selector can match a stale finder/editor
+// left open by a previous run's workspace and poison presence waits.
+const FINDER_SELECTOR = '.terminal-wrapper.active .notebook-finder';
 
 // The finder overlay is tile-scoped DOM, so capture_screenshot_data(selector)
 // resolves when it is mounted and throws ("selector not found") when it is not —
 // a clean presence probe that doubles as a screenshot of the overlay subtree.
 async function finderPresent(client) {
-  return client
-    .request('capture_screenshot_data', { selector: FINDER_SELECTOR })
-    .then(() => true)
-    .catch(() => false);
+  try {
+    await client.request('capture_screenshot_data', { selector: FINDER_SELECTOR });
+    return true;
+  } catch (error) {
+    if (String(error).includes('Screenshot selector not found in DOM')) {
+      return false;
+    }
+    // The selector resolved but the capture itself failed — html-to-image can
+    // throw on some subtrees (e.g. CodeMirror's .cm-content). We asked about
+    // presence, and the bridge only emits the "not found" error when the
+    // element is genuinely absent, so treat any other failure as present.
+    return true;
+  }
 }
 
 async function waitForFinder(client, present, description, timeoutMs = 10_000) {
@@ -185,7 +197,7 @@ async function main() {
     // 4. Esc must CLOSE the finder. If it doesn't, focus was not inside the tile
     //    (e.g. the terminal stole it on dock) — a real bug, surfaced here.
     await driver.activateApp();
-    await driver.pressKey('Escape');
+    await driver.pressKeyCode(53); // Esc — InputDriver's --key map only covers printable keys
     await waitForFinder(client, false, 'Esc dismisses the finder');
 
     // 5. Native ⌘P must RE-SUMMON it. This proves both that ⌘P reaches the WebView

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -43,6 +43,11 @@ export const scenarioCatalog = [
     command: ['pnpm', 'run', 'real-app:scenario-notebook-tile-finder'],
   },
   {
+    id: 'notebook-editor-undo',
+    label: 'Notebook editor undo/redo (native Cmd+Z / Shift+Cmd+Z reach CodeMirror)',
+    command: ['pnpm', 'run', 'real-app:scenario-notebook-editor-undo'],
+  },
+  {
     id: 'autoclose-on-exit',
     label: 'Auto-close on clean exit, keep failed exits',
     command: ['pnpm', 'run', 'real-app:scenario-autoclose-on-exit'],

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -542,6 +542,7 @@ fn app_menu(app: &tauri::AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wr
 
             let is_close_window = text == "Close Window";
             let is_redo = text == "Redo";
+            let is_undo = text == "Undo";
 
             if is_close_window {
                 submenu.remove_at(position)?;
@@ -550,13 +551,16 @@ fn app_menu(app: &tauri::AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wr
                     submenu.insert(&close_active_pane, position)?;
                     inserted_close_active_pane = true;
                 }
-            } else if is_redo && is_edit_menu {
-                // Drop the predefined Redo item so it stops claiming the ⇧⌘Z key
-                // equivalent. With Redo gone the key reaches the WebView, where the
-                // shortcut resolver routes ⇧⌘Z to terminal.toggleZoom — honoring any
-                // user rebinding, exactly like every other DOM shortcut. The macOS
-                // menu would otherwise swallow ⇧⌘Z and "Zoom active pane" did nothing
-                // in packaged builds.
+            } else if (is_redo || is_undo) && is_edit_menu {
+                // Drop the predefined Undo/Redo items so they stop claiming the ⌘Z/⇧⌘Z
+                // key equivalents. With them gone both keys reach the WebView: inside the
+                // notebook editor CodeMirror's history keymap handles undo/redo (its
+                // contenteditable is an editable target, so the DOM shortcut resolver
+                // yields ⇧⌘Z to it instead of terminal.toggleZoom), WebKit still handles
+                // undo natively in plain inputs/textareas, and outside editable targets
+                // ⇧⌘Z keeps dispatching terminal.toggleZoom through the resolver —
+                // honoring user rebindings. The menu items would otherwise swallow both
+                // keys in packaged builds (editor undo was dead, zoom did nothing).
                 submenu.remove_at(position)?;
             }
         }

--- a/app/src/shortcuts/registry.ts
+++ b/app/src/shortcuts/registry.ts
@@ -99,8 +99,14 @@ export const SHORTCUTS = {
   'ui.resetFontSize': { key: '0', meta: true },
 
   // Notebook (meta+alt+N is free — the only meta+alt combos are the pane-focus arrows)
-  'notebook.openTile': { key: 'n', meta: true, alt: true },
-  'notebook.openFullscreen': { key: 'n', meta: true, alt: true, shift: true },
+  // Option-modified letters need a `code` fallback: with ⌥ held, macOS/WebKit
+  // reports the dead-key character ('˜'/'Dead') as e.key, never 'n', so a
+  // key-only match can never fire on a real (or CGEvent) keystroke — the key
+  // falls through into the terminal PTY. matchesShortcut's e.code branch
+  // matches the physical key regardless of that translation. Browser e2e
+  // can't catch the broken state: Playwright synthesizes key:'n' directly.
+  'notebook.openTile': { key: 'n', code: 'KeyN', meta: true, alt: true },
+  'notebook.openFullscreen': { key: 'n', code: 'KeyN', meta: true, alt: true, shift: true },
 
   // Tickets board (fullscreen surface). meta+shift+T parallels meta+T = new workspace.
   'board.open': { key: 't', meta: true, shift: true },

--- a/docs/plans/2026-07-11-notebook-editor-polish.md
+++ b/docs/plans/2026-07-11-notebook-editor-polish.md
@@ -1,0 +1,142 @@
+# Plan: Notebook editor polish
+
+## Goal
+
+Close the gap between the notebook's live markdown editor and a trustworthy daily-driver
+(Obsidian-style unified editor, no View/Edit toggle). Phase 1 (this doc) is an evidence-based
+gap catalog from driving the real dev app, plus a most-valuable-first PR sequence. Phase 2
+implements the approved subset as small PRs, each verified in the live app.
+
+Invariants that must survive every PR: debounce autosave + hash-CAS; conflict banner
+(Reload / Keep mine); flush awaits write and aborts navigation on conflict; reloadFromDisk
+stale-navigation guard; editor kind contract (.md → live editor, text → plain, binary →
+never read bytes, reopen probe kind-checks); CSS-variable CM theming.
+
+## What was verified working (live, attn-dev.app)
+
+Driven via the real-app harness (CGEvent input + `capture_screenshot_data`), screenshots
+01–33 in session scratchpad:
+
+- Autosave → disk + "Saved" indicator; hash-CAS conflict banner both paths (Reload from
+  disk restores disk content; Overwrite anyway writes buffer over disk).
+- External change while clean → minimal-edit apply, viewport pixel-stable (no scroll jump).
+- List continuation on Enter (lang-markdown's default keymap is active — bullets, ordered
+  lists continue; static analysis had wrongly suggested otherwise).
+- ⌘-click link navigation, backlinks rail, outline jump, broken-link ⚠ flagging.
+- Frontmatter card → click-to-edit raw YAML.
+- ⌘P finder open/filter/Enter; fresh files indexed within ~2s of creation.
+- Paste of multi-line markdown (⌘V through the native menu) → verbatim insert + autosave.
+- Checkbox click toggles `- [ ]` ↔ `- [x]` on disk.
+- 280KB / 2500-section note: opens fast, outline complete, end-jump instant, typing lag-free.
+- Plain-text editor for `.txt` (TEXT badge); binary placeholder for `.png` (no bytes read).
+
+## Gap catalog (all confirmed live unless noted)
+
+Ranked by user pain. "Menu trap" = AGENTS.md Critical Pattern 8 (native accelerator swallows
+the key before the WebView; invisible to Playwright/jsdom).
+
+| # | Gap | Evidence |
+|---|-----|----------|
+| G1 | **Undo/redo dead in packaged app.** Edit > Undo still owns ⌘Z (`app_menu()` never removes it), so CM history never sees it. Redo's menu item is already removed, but the DOM resolver routes ⇧⌘Z to `terminal.toggleZoom` — a real binding conflict, not just a menu removal. | Typed text, ⌘Z → nothing; `lib.rs` app_menu confirms Undo item present |
+| G2 | **No in-editor search.** ⌘F does nothing (searchKeymap disabled in basicSetup; no native Find either). Unusable for long notes. | Shot 24 |
+| G3 | **Tables render as raw pipe text.** No live-preview table rendering. | Shots 32 |
+| G4 | **No syntax highlighting in code fences** (and none for inline markdown syntax — `syntaxHighlighting` disabled wholesale). | Shots (code fence flat) |
+| G5 | **Images render as mangled text** — `![alt](path)` shows "image/knowledge/.../pic.png" instead of the image or a clean widget. | Shot 13 area |
+| G6 | **No formatting keybindings** — ⌘B/⌘I do nothing (no bindings; ⌘B also unclaimed by menu, safe to bind). | Live probe |
+| G7 | **Blockquotes and horizontal rules unstyled** — `>` quote renders as plain text with the marker visible, `---` as literal dashes. | Shot 32 |
+| G8 | **Send-to-chief selection pill occludes the line above the selection.** | Shot 07 |
+| G9 | **Conflict-banner buttons keep focus** — after clicking Reload/Overwrite, keyboard nav goes to the button, not the editor; typing does nothing until you click back in. | Live probe (Cmd+↓ no-op after banner click) |
+| G10 | **YAML list items inside the raw frontmatter edit region get markdown • bullets** — the live-preview decorator doesn't exempt the frontmatter block while it's being edited. | Shot 16 |
+| G11 | **`#fragment` links silently ignored**; bare relative links (`foo.md`) classified external while brokenLinks resolves them in-notebook — two resolvers disagree (`parseNotebookHref` vs `brokenLinks.ts`). | Code + live |
+| G12 | **frontmatterCard runs full-doc `toString()` per keystroke** — O(doc) work on every edit; invisible at 280KB today but pure waste. | Code read |
+| G13 | Finder index transient: right after bulk fixture creation, ⌘P missed a matching note once (opened a scattered-path match instead). Not reproducible — fresh files index in ~2s. Low confidence, watch only. | Shots 17–20 |
+| G14 | `AUTOSAVE_DELAY_MS = 700` vs contract doc's 500ms — doc drift, not a bug. | Code |
+
+Test-coverage gaps (from coverage map): conflict banner / flush-on-nav / binary reopen probe
+are unit-only — the e2e `writeFile` mock hardcodes `conflict:false`, so no e2e can exercise
+the banner; undo/redo, paste, tables have zero coverage anywhere; menu-trap class needs
+packaged-app scenarios by definition.
+
+## PR sequence (most valuable first, each its own small PR)
+
+Each PR ships with unit tests where the logic is pure, and is verified live in attn-dev
+(`make dev`, drive the real editor). Menu-trap PRs additionally get a packaged-app harness
+scenario where feasible.
+
+- [ ] **PR1 — Undo/redo (G1).** Remove Edit > Undo predefined item in `app_menu()`
+      (`app/src-tauri/src/lib.rs`) so ⌘Z reaches the WebView; CM history (already in
+      basicSetup) handles it when the editor has focus, and WebKit's native undo still covers
+      plain inputs/textareas. For redo: make the ⇧⌘Z resolution context-aware in
+      `useShortcut.ts` — when focus is inside a CM editor, deliver to the editor (CM redo);
+      otherwise keep `terminal.toggleZoom`. Verify live: type → ⌘Z → ⇧⌘Z in the editor;
+      zoom still works in a terminal pane; undo still works in the ticket comment box.
+      Packaged-app scenario for the editor path (this exact class of bug is invisible to e2e).
+- [ ] **PR2 — In-editor search (G2).** Enable `@codemirror/search` (searchKeymap + panel)
+      in `LiveMarkdownEditor.tsx`, themed via CSS variables; scope ⌘F so it only claims the
+      key when editor is focused. Esc closes the search panel *before* the surface's
+      Esc-to-close handler fires (stopPropagation when panel open — Esc currently closes the
+      whole fullscreen surface).
+- [ ] **PR3 — Fence highlighting + blockquote/HR styling (G4, G7).** Re-enable
+      `syntaxHighlighting` with a CSS-variable highlight style; add fence language support
+      (`@codemirror/language-data` lazy import) and blockquote/HR decorations in
+      `liveMarkdownPreview.ts`.
+- [ ] **PR4 — Tables (G3).** Live-preview table widget in `liveMarkdownPreview.ts`: render
+      GFM tables as a styled widget when the cursor is outside, reveal raw source on the
+      cursor's row (same reveal model the rest of the preview uses).
+- [ ] **PR5 — Formatting keybindings (G6).** ⌘B/⌘I (+ ⌘E inline code) toggle wrap/unwrap
+      around selection or word; pure command functions unit-tested, bound via the editor
+      keymap. Check combos against default-menu accelerators first (⌘B/⌘I/⌘E are free).
+- [ ] **PR6 — Image rendering (G5).** Render `![...]` as an image widget (asset path
+      resolved through the notebook fs surface via Tauri `convertFileSrc` or equivalent —
+      must not add fs permissions beyond the notebook root) with a clean broken-image
+      placeholder; raw source on cursor line.
+- [ ] **PR7 — Small interaction fixes (G8, G9, G10).** Selection pill repositioned to not
+      occlude the line above; conflict-banner actions restore editor focus; frontmatter
+      region exempted from markdown list decoration while in raw-edit mode. Could split if
+      any turns non-trivial.
+- [ ] **PR8 — Link resolver unification (G11).** Single resolution helper shared by
+      `parseNotebookHref` (NotebookSurface) and `brokenLinks.ts`: bare-relative resolves
+      against the current note's dir; `#fragment` scrolls to the matching heading in-note
+      (or at least on same-note links). Unit-test the resolver.
+- [ ] **PR9 — Cheap hygiene (G12, G14).** frontmatterCard reads only the frontmatter prefix
+      instead of full-doc `toString()` per keystroke; fix the 500ms→700ms doc drift.
+
+Not planned (watch only): G13 finder transient — no repro; re-open if seen again.
+
+## Boundaries
+
+- `LiveMarkdownEditor.tsx` owns CM extensions/keymaps; `NotebookSurface.tsx` owns
+  load/save/conflict/navigation state. New bindings must not leak save logic into the editor.
+- `app_menu()` in `lib.rs` owns which keys ever reach the WebView; `useShortcut.ts` owns
+  DOM-side dispatch. Every new editor shortcut gets checked against `Menu::default`
+  accelerators (Critical Pattern 8) before implementation.
+- The live-preview plugin (`liveMarkdownPreview.ts`) owns all decoration; new render features
+  (tables, images, quotes) extend it rather than adding parallel plugins.
+- Image rendering must not widen fs capability (the capability guard test bans fs
+  permissions) — serve through the existing notebook read surface only.
+
+## Decisions
+
+- Undo fix removes the native Edit > Undo item (menu-trap pattern, same as the ⇧⌘Z zoom
+  fix) rather than forwarding via `dispatch_native_shortcut` — keeps user rebinding working
+  through the DOM resolver. WebKit still handles ⌘Z for plain inputs without the menu item.
+- Redo requires focus-aware dispatch because ⇧⌘Z is already bound to `terminal.toggleZoom`;
+  we resolve by focus context instead of moving either binding.
+- Tables/images follow the existing cursor-reveal model (widget when outside, raw when on
+  the line) — no split View mode, per the unified-editor invariant.
+- Large-note perf work dropped from the plan: 280KB/2500 sections measured fine live; only
+  the free frontmatterCard fix (G12) stays.
+
+## Open Questions
+
+- PR4 tables: read-only widget first, or in-widget cell editing? Proposal: read-only widget
+  + raw-reveal editing first; cell editing only if it hurts in practice.
+- PR2: should ⌘F fall back to a whole-vault search later? Out of scope here; in-note only.
+
+## Follow-ups
+
+- E2e harness: teach the `writeFile` mock to return `conflict:true` on demand so the conflict
+  banner gets e2e coverage (currently unit-only).
+- Packaged-app scenario for notebook editor basics (type/undo/search) to catch future
+  menu-trap regressions.
+- Outline rail is unvirtualized (2500 rows fine today); revisit only if notes grow 10×.


### PR DESCRIPTION
## Summary

First PR of the notebook editor polish plan (`docs/plans/2026-07-11-notebook-editor-polish.md`, committed in this branch's first commit).

- Removes the native Edit > Undo menu item (Redo was already removed for ⇧⌘Z/`toggleZoom`) so ⌘Z/⇧⌘Z reach the WebView; CodeMirror's history handles undo/redo in the notebook editor; ⇧⌘Z still resolves to `terminal.toggleZoom` outside editable targets. Note: React-controlled inputs (e.g. the finder input) never had working native undo — controlled value updates break WebKit's undo stack — so removing the menu item is not a regression there.
- Fixes dead ⌘⌥N/⇧⌘⌥N notebook shortcuts in the packaged app: with ⌥ held, WebKit reports the dead-key character as `e.key`, so key-only matching never fired; added `code: 'KeyN'` fallbacks (same pattern as the Digit1..9 workspace shortcuts).
- New packaged-app scenario `real-app:scenario-notebook-editor-undo` (native typing + disk-based undo/redo assertions + no-zoom assertion). Harness robustness fixes: presence probes only treat the bridge's "selector not found" error as absence; probe selectors scoped to `.terminal-wrapper.active` (warm-set workspaces keep stale finders mounted); Esc posted as keycode 53 (InputDriver's `--key` map only covers printable keys — `pressKey('Escape')` never worked).

## Test plan

- [x] `pnpm run test` — 1431 tests green
- [x] `pnpm run build` — tsc + vite build clean
- [x] `cargo build` (src-tauri) — clean
- [x] Verified live in attn-dev: manual ⌘Z/⇧⌘Z in the editor, ⇧⌘Z zoom outside editors, plus both packaged scenarios (`notebook-editor-undo`, `notebook-tile-finder`) green

https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT