### PR TITLE
feat(notebook): add in-editor search to live markdown editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-12]
 
+### Added
+- **Find in a note.** ⌘F inside the Notebook editor opens an in-editor search panel (matches highlighted, Enter/⇧Enter to step). Esc closes the panel first; ⌘F still opens terminal search when you're not in a text field.
+
 ### Fixed
 - **Undo and redo now work in the Notebook editor.** ⌘Z and ⇧⌘Z were swallowed by the native Edit menu in the packaged app and never reached the editor; they now undo/redo your edits when the editor has focus. ⇧⌘Z still zooms the active pane when you're not in a text field.
 - **⌘⌥N and ⇧⌘⌥N open the Notebook again.** With Option held, macOS reports a dead-key character instead of the letter, so the notebook shortcuts never matched in the installed app and the keystroke fell through into the terminal. They now match on the physical key.

--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -201,6 +201,34 @@ test.describe('NotebookBrowser (fs surface)', () => {
     expect(await page.evaluate(() => window.__HARNESS__.getCalls('close').length)).toBeGreaterThan(0);
   });
 
+  test('Cmd+F opens the in-editor search panel; Esc closes it before the modal', async ({ page }) => {
+    // The search panel gets its own higher-priority escape-stack entry, pushed only
+    // while it's open — the first Esc must close just the panel, not the modal.
+    await page.goto('/test-harness/?component=NotebookBrowser');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.waitForSelector('.cm-content');
+
+    await page.locator('.cm-content').click();
+    await page.keyboard.press('Meta+f');
+    await expect(page.locator('.cm-panel.cm-search')).toBeVisible();
+    await expect(page.locator('.cm-search input[name="search"]')).toBeFocused();
+
+    // Search for a word that repeats throughout the fixture note; matches highlight.
+    await page.keyboard.type('distilled');
+    await expect(page.locator('.cm-searchMatch').first()).toBeVisible();
+    expect(await page.locator('.cm-searchMatch').count()).toBeGreaterThan(0);
+
+    // First Esc closes only the search panel — the modal stays open (no onClose).
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.cm-panel.cm-search')).toHaveCount(0);
+    await expect(page.locator('.notebook-browser')).toBeVisible();
+    expect(await page.evaluate(() => window.__HARNESS__.getCalls('close').length)).toBe(0);
+
+    // Second Esc (no panel open) closes the modal itself.
+    await page.keyboard.press('Escape');
+    expect(await page.evaluate(() => window.__HARNESS__.getCalls('close').length)).toBeGreaterThan(0);
+  });
+
   test('renders stage-5 chrome and folds the tree to zero width via the edge handle', async ({ page }) => {
     await page.goto('/test-harness/?component=NotebookBrowser');
     await page.waitForFunction(() => window.__HARNESS__?.ready === true);

--- a/app/package.json
+++ b/app/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.3",
+    "@codemirror/search": "^6.7.1",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.43.1",
     "@lezer/common": "^1.5.2",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@codemirror/language':
         specifier: ^6.12.3
         version: 6.12.3
+      '@codemirror/search':
+        specifier: ^6.7.1
+        version: 6.7.1
       '@codemirror/state':
         specifier: ^6.6.0
         version: 6.6.0

--- a/app/src/components/NotebookBrowser.test.tsx
+++ b/app/src/components/NotebookBrowser.test.tsx
@@ -40,7 +40,7 @@ vi.mock('./notebook/LiveMarkdownEditor', async () => {
         onSelectionChange?: (sel: { text: string; top: number; left: number } | null) => void;
         ariaLabel?: string;
       },
-      ref: React.Ref<{ scrollToPos: (pos: number) => void; applyExternalContent: (next: string) => void }>,
+      ref: React.Ref<{ scrollToPos: (pos: number) => void; applyExternalContent: (next: string) => void; closeSearchPanel: () => boolean }>,
     ) {
       editorMock.current = { onFollowLink, onSelectionChange };
       useImperativeHandle(ref, () => ({
@@ -51,6 +51,8 @@ vi.mock('./notebook/LiveMarkdownEditor', async () => {
           editorMock.externalApplies.push(next);
           onChange(next);
         },
+        // The mock never opens a search panel, so closing is always a no-op.
+        closeSearchPanel: () => false,
       }), [onChange]);
       return (
         <textarea

--- a/app/src/components/NotebookSurface.tsx
+++ b/app/src/components/NotebookSurface.tsx
@@ -142,6 +142,9 @@ export function NotebookSurface({
   // the outline and backlinks are visible without a click. Local UI state only.
   const [outlineOpen, setOutlineOpen] = useState(true);
   const [backlinksOpen, setBacklinksOpen] = useState(true);
+  // Whether the live editor's in-CodeMirror search panel (⌘F) is currently open.
+  // Drives a dedicated escape-stack entry so the first Esc closes just the panel.
+  const [searchOpen, setSearchOpen] = useState(false);
   // Whole-pane edge-rail folds (manual). Tri-state per side: null = follow the auto
   // default, true/false = an explicit user override. The auto default is a hardcoded
   // `false` here — stage 7 PR3 (tile auto-fold) swaps it for a width-driven value, so
@@ -240,6 +243,11 @@ export function NotebookSurface({
   // handled by the finder input's onKeyDown directly, no stack involved.)
   useEscapeStack(handleEscape, variant === 'modal' && active);
   useEscapeStack(() => setFinderOpen(false), variant === 'modal' && active && finderOpen);
+  // The in-editor search panel (⌘F) gets its own higher-priority Esc entry, pushed
+  // only while it's open — LIFO puts it above the modal-close entry, so the first
+  // Esc closes just the search panel. Not gated on variant: a tile's search panel
+  // also closes via the centralized stack (a tile has no modal-close entry to race).
+  useEscapeStack(() => { editorRef.current?.closeSearchPanel(); }, active && searchOpen);
 
   // Load `path` into the document pane. `prefetched` lets a caller that already read
   // the file (the on-open existence probe) seed the editor without a second read.
@@ -654,6 +662,13 @@ export function NotebookSurface({
     setJustSaved(false);
     setChiefSel(null);
     setChiefStatus(null);
+    // Navigating away can keep the same CodeMirror view alive (the editor is
+    // un-keyed), so an open search panel would survive the switch with no
+    // escape-stack entry. Close the panel itself; the open-change callback
+    // resets searchOpen when the view is still mounted, and the direct reset
+    // covers the unmounted case.
+    editorRef.current?.closeSearchPanel();
+    setSearchOpen(false);
   }, [selectedPath]);
 
   // Debounced autosave: once the buffer diverges from the synced file, persist it
@@ -851,6 +866,7 @@ export function NotebookSurface({
                     existsFile={existsFile}
                     revalidateSignal={changeSignal}
                     ariaLabel="Note"
+                    onSearchOpenChange={setSearchOpen}
                   />
                 ) : (
                   <textarea

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -7,7 +7,8 @@
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
-import { EditorView, type ViewUpdate } from '@codemirror/view';
+import { closeSearchPanel, search, searchKeymap, searchPanelOpen } from '@codemirror/search';
+import { EditorView, keymap, type ViewUpdate } from '@codemirror/view';
 import { brokenLinks, revalidateBrokenLinks, type ExistsCheck } from './brokenLinks';
 import { frontmatterCard } from './frontmatterCard';
 import { liveMarkdownPreview } from './liveMarkdownPreview';
@@ -35,6 +36,8 @@ export interface LiveMarkdownEditorHandle {
   // someone is reading. No-op until the view mounts, or when `next` is already current.
   // Does NOT focus or scroll into view (the reader may be elsewhere on the page).
   applyExternalContent: (next: string) => void;
+  // Close the in-editor search panel. Returns true if a panel was open.
+  closeSearchPanel: () => boolean;
 }
 
 interface LiveMarkdownEditorProps {
@@ -51,6 +54,9 @@ interface LiveMarkdownEditorProps {
   revalidateSignal?: number;
   ariaLabel?: string;
   autoFocus?: boolean;
+  // Called with the new open state whenever the in-editor search panel opens or
+  // closes, so the parent can register/unregister an escape-stack entry.
+  onSearchOpenChange?: (open: boolean) => void;
 }
 
 // Themed entirely through the app's CSS variables so it tracks the app's light/dark
@@ -92,6 +98,43 @@ const editorTheme = EditorView.theme({
   '.cm-selectionLayer .cm-selectionBackground': {
     backgroundColor: 'color-mix(in srgb, var(--accent, #ff6b35) 30%, transparent) !important',
   },
+  // Search panel (⌘F): themed to the app's tokens. CM's base theme paints its
+  // buttons with a background-image gradient, so that must be cleared explicitly.
+  '.cm-panels': {
+    color: 'var(--color-text-primary, inherit)',
+    backgroundColor: 'var(--color-bg-elevated, rgba(128, 128, 128, 0.08))',
+  },
+  '.cm-panels.cm-panels-top': {
+    borderBottom: '1px solid var(--color-border, rgba(128, 128, 128, 0.3))',
+  },
+  '.cm-panel.cm-search': {
+    padding: '4px 6px',
+    fontFamily: 'system-ui, -apple-system, sans-serif',
+    fontSize: '12px',
+  },
+  '.cm-panel.cm-search input, .cm-panel.cm-search button, .cm-panel.cm-search label': {
+    fontFamily: 'inherit',
+    fontSize: 'inherit',
+    color: 'var(--color-text-primary, inherit)',
+  },
+  '.cm-panel.cm-search input': {
+    backgroundColor: 'var(--color-bg-input, transparent)',
+    border: '1px solid var(--color-border, rgba(128, 128, 128, 0.3))',
+    borderRadius: '3px',
+    padding: '2px 4px',
+  },
+  '.cm-panel.cm-search button': {
+    backgroundImage: 'none',
+    backgroundColor: 'var(--color-bg-button, transparent)',
+    border: '1px solid var(--color-border, rgba(128, 128, 128, 0.3))',
+    borderRadius: '3px',
+  },
+  '.cm-searchMatch': {
+    backgroundColor: 'color-mix(in srgb, var(--accent, #ff6b35) 25%, transparent)',
+  },
+  '.cm-searchMatch-selected': {
+    backgroundColor: 'color-mix(in srgb, var(--accent, #ff6b35) 50%, transparent)',
+  },
 });
 
 export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkdownEditorProps>(function LiveMarkdownEditor({
@@ -103,8 +146,12 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
   revalidateSignal,
   ariaLabel,
   autoFocus,
+  onSearchOpenChange,
 }, ref) {
   const cmRef = useRef<ReactCodeMirrorRef>(null);
+  // Previous search-panel-open value, so handleUpdate only calls onSearchOpenChange
+  // on a genuine transition (not on every unrelated update while the panel is open).
+  const searchOpenRef = useRef(false);
 
   useImperativeHandle(ref, () => ({
     scrollToPos: (pos: number) => {
@@ -134,6 +181,12 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
         scrollIntoView: false,
       });
     },
+    closeSearchPanel: () => {
+      const view = cmRef.current?.view;
+      if (!view || !searchPanelOpen(view.state)) return false;
+      closeSearchPanel(view);
+      return true;
+    },
   }), []);
 
   const extensions = useMemo(
@@ -143,6 +196,8 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
       frontmatterCard(),
       liveMarkdownPreview({ onFollowLink }),
       brokenLinks({ existsFile }),
+      search({ top: true }),
+      keymap.of(searchKeymap),
       editorTheme,
     ],
     [onFollowLink, existsFile],
@@ -163,6 +218,13 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
   const handleUpdate = useMemo(
     () =>
       (update: ViewUpdate) => {
+        if (onSearchOpenChange) {
+          const isOpen = searchPanelOpen(update.state);
+          if (isOpen !== searchOpenRef.current) {
+            searchOpenRef.current = isOpen;
+            onSearchOpenChange(isOpen);
+          }
+        }
         if (!onSelectionChange) return;
         if (!update.selectionSet && !update.docChanged && !update.focusChanged) return;
         const range = update.state.selection.main;
@@ -182,7 +244,7 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
         }
         onSelectionChange({ text, top: coords.top, left: (coords.left + coords.right) / 2 });
       },
-    [onSelectionChange],
+    [onSelectionChange, onSearchOpenChange],
   );
 
   return (

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -8,11 +8,22 @@ import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'rea
 import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { closeSearchPanel, search, searchKeymap, searchPanelOpen } from '@codemirror/search';
-import { EditorView, keymap, type ViewUpdate } from '@codemirror/view';
+import { EditorView, keymap, type KeyBinding, type ViewUpdate } from '@codemirror/view';
 import { brokenLinks, revalidateBrokenLinks, type ExistsCheck } from './brokenLinks';
 import { frontmatterCard } from './frontmatterCard';
 import { liveMarkdownPreview } from './liveMarkdownPreview';
 import { computeMinimalEdit } from './minimalEdit';
+
+// searchKeymap binds its commands with CodeMirror's "Mod-" modifier, which CM
+// resolves to Meta only when it detects a Mac platform (navigator.platform) and
+// to Ctrl everywhere else. attn only ships on macOS (see AGENTS.md), so "Mod"
+// must always mean Cmd — but a Linux CI browser (e.g. headless Chromium on the
+// e2e runners) reports a non-Mac platform and silently rebinds Cmd+F to Ctrl+F,
+// leaving Cmd+F inert. Rewrite every "Mod-" prefix to an explicit "Cmd-" so the
+// binding is platform-independent instead of relying on CM's own detection.
+const macSearchKeymap: readonly KeyBinding[] = searchKeymap.map((binding) =>
+  binding.key?.startsWith('Mod-') ? { ...binding, key: `Cmd-${binding.key.slice(4)}` } : binding,
+);
 
 export interface LiveSelection {
   text: string;
@@ -197,7 +208,7 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
       liveMarkdownPreview({ onFollowLink }),
       brokenLinks({ existsFile }),
       search({ top: true }),
-      keymap.of(searchKeymap),
+      keymap.of(macSearchKeymap),
       editorTheme,
     ],
     [onFollowLink, existsFile],

--- a/app/src/shortcuts/registry.ts
+++ b/app/src/shortcuts/registry.ts
@@ -53,8 +53,10 @@ export const SHORTCUTS = {
   'terminal.focusUp': { key: 'ArrowUp', meta: true, alt: true },
   'terminal.focusDown': { key: 'ArrowDown', meta: true, alt: true },
 
-  // Find in terminal scrollback
-  'terminal.find': { key: 'f', meta: true },
+  // Find in terminal scrollback. In editable targets ⌘F belongs to the focused
+  // editor (the notebook editor's CodeMirror search); terminal find only makes
+  // sense when focus isn't in a text field.
+  'terminal.find': { key: 'f', meta: true, editableTarget: 'native' },
 
   // Session management
   'session.new': { key: 'n', meta: true },

--- a/app/src/shortcuts/useShortcut.test.tsx
+++ b/app/src/shortcuts/useShortcut.test.tsx
@@ -9,12 +9,14 @@ function ShortcutHarness(props: {
   onTerminalClose: () => void;
   onToggleZoom?: () => void;
   onSelectWorkspace?: () => void;
+  onTerminalFind?: () => void;
   terminalEnabled?: boolean;
 }) {
   useShortcut('session.close', props.onSessionClose, true);
   useShortcut('terminal.close', props.onTerminalClose, props.terminalEnabled ?? true);
   useShortcut('terminal.toggleZoom', props.onToggleZoom ?? (() => {}), props.onToggleZoom !== undefined);
   useShortcut('workspace.select1', props.onSelectWorkspace ?? (() => {}), props.onSelectWorkspace !== undefined);
+  useShortcut('terminal.find', props.onTerminalFind ?? (() => {}), props.onTerminalFind !== undefined);
 
   return (
     <div>
@@ -23,6 +25,7 @@ function ShortcutHarness(props: {
       <div className="session-terminal-workspace">
         <input aria-label="Browser address" />
       </div>
+      <div data-testid="editable-target" contentEditable={true} suppressContentEditableWarning />
     </div>
   );
 }
@@ -116,6 +119,30 @@ describe('useShortcut close priority', () => {
 
     expect(allowed).toBe(true);
     expect(onToggleZoom).not.toHaveBeenCalled();
+  });
+
+  it('leaves Cmd+F to the focused editor in editable targets, but fires terminal.find elsewhere', () => {
+    const onTerminalFind = vi.fn();
+
+    render(
+      <ShortcutHarness
+        onSessionClose={vi.fn()}
+        onTerminalClose={vi.fn()}
+        onTerminalFind={onTerminalFind}
+      />,
+    );
+
+    const allowed = fireEvent.keyDown(screen.getByTestId('editable-target'), {
+      key: 'f',
+      metaKey: true,
+    });
+
+    expect(allowed).toBe(true);
+    expect(onTerminalFind).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(screen.getByTestId('plain-target'), { key: 'f', metaKey: true });
+
+    expect(onTerminalFind).toHaveBeenCalledTimes(1);
   });
 
   it('keeps unrelated app shortcuts active in non-terminal editable controls', () => {


### PR DESCRIPTION
## Summary

PR2 of the notebook editor polish plan. Adds in-editor search to the Notebook's live markdown editor (CodeMirror-based).

- Wires `@codemirror/search` into `LiveMarkdownEditor` (`search({top: true})` + `keymap.of(searchKeymap)`), with the search panel themed to the app's CSS tokens (CodeMirror's default button gradient cleared explicitly).
- `terminal.find` gains `editableTarget: 'native'` so Cmd+F inside an editable field (the notebook editor) is handled by the focused editor's own search; terminal find (ghostty) still fires when focus isn't in a text field.
- `NotebookSurface` tracks search-panel-open state via a new `onSearchOpenChange` prop and registers a dedicated escape-stack entry, so Esc closes the search panel first, before the fullscreen modal or the note finder. Switching notes closes the panel defensively.

## Test plan

- [x] `vitest`: 1432 passed / 0 failed
- [x] `tsc --noEmit`: clean
- [x] e2e `notebook-browser.spec.ts`: 9/9 (includes a new Cmd+F / Esc-ordering test)
- [x] e2e `terminal-find.spec.ts`: 3/3
- [x] Live-verified in attn-dev: Cmd+F in the editor opens the search panel with highlighted matches, Esc closes the panel before the fullscreen modal, and Cmd+F in a terminal still opens ghostty find.
- [x] `go build ./...` and `tsc --noEmit` re-confirmed clean before opening this PR.

Heads-up: PR #535 (feat/nb-editor-pr1-undo) may also touch `CHANGELOG.md` under a `## [2026-07-12]` heading — if there's a conflict, combine sections under one dated heading rather than picking one side.