### PR TITLE
fix(terminal): bound stale replay-geometry suppression and verify fit after dropped replay resizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Find in a note.** ⌘F inside the Notebook editor opens an in-editor search panel (matches highlighted, Enter/⇧Enter to step). Esc closes the panel first; ⌘F still opens terminal search when you're not in a text field.
 
 ### Fixed
+- **Terminal panes no longer get stuck at a stale size.** Some panes could stay rendered at a stale, historical size after a session reattach — bottom or right edges painted outside the pane — until the pane was reopened. They now recover on their own.
 - **Undo and redo now work in the Notebook editor.** ⌘Z and ⇧⌘Z were swallowed by the native Edit menu in the packaged app and never reached the editor; they now undo/redo your edits when the editor has focus. ⇧⌘Z still zooms the active pane when you're not in a text field.
 - **⌘⌥N and ⇧⌘⌥N open the Notebook again.** With Option held, macOS reports a dead-key character instead of the letter, so the notebook shortcuts never matched in the installed app and the keystroke fell through into the terminal. They now match on the physical key.
 

--- a/app/src/components/GhosttyTerminal.resizePolicy.test.ts
+++ b/app/src/components/GhosttyTerminal.resizePolicy.test.ts
@@ -106,29 +106,70 @@ describe('fitShouldBailAsSuspicious', () => {
 });
 
 describe('liveResizeConflictsWithQueuedReplay', () => {
+  const NOW = 1_000_000;
+
   // The relaunch blank-pane regression: replay marches the model through a
   // historical 80x24 segment; a selection fit (and the pre-attach resize echo)
   // target the live 62x27 geometry the replay ends at. Cancelling the queued
   // history for those leaves the pane permanently empty.
   it('skips a live resize that targets the geometry the queued replay ends at', () => {
     expect(liveResizeConflictsWithQueuedReplay(
-      { cols: 62, rows: 27, resizes: 1 },
+      { cols: 62, rows: 27, resizes: 1, lastQueuedAt: NOW },
       { cols: 62, rows: 27 },
+      NOW,
     )).toBe('skip');
   });
 
   it('cancels the queued replay for a genuinely different live geometry', () => {
     expect(liveResizeConflictsWithQueuedReplay(
-      { cols: 62, rows: 27, resizes: 1 },
+      { cols: 62, rows: 27, resizes: 1, lastQueuedAt: NOW },
       { cols: 95, rows: 53 },
+      NOW,
     )).toBe('cancel');
   });
 
   it('does not interfere once all queued replay resizes have applied', () => {
     expect(liveResizeConflictsWithQueuedReplay(
-      { cols: 62, rows: 27, resizes: 0 },
+      { cols: 62, rows: 27, resizes: 0, lastQueuedAt: NOW },
       { cols: 95, rows: 53 },
+      NOW,
     )).toBe('none');
-    expect(liveResizeConflictsWithQueuedReplay(null, { cols: 62, rows: 27 })).toBe('none');
+    expect(liveResizeConflictsWithQueuedReplay(null, { cols: 62, rows: 27 }, NOW)).toBe('none');
+  });
+
+  // The dropped-replay-resize regression: a queued replay resize op can be
+  // silently discarded by a generation mismatch, breaking the "replay will
+  // land there" promise. A stale pending geometry must stop suppressing live
+  // corrections regardless of whether the live target happens to match it.
+  it('treats a stale pending geometry as no-longer-conflicting for a matching target', () => {
+    expect(liveResizeConflictsWithQueuedReplay(
+      { cols: 62, rows: 27, resizes: 1, lastQueuedAt: NOW },
+      { cols: 62, rows: 27 },
+      NOW + 3001,
+    )).toBe('stale');
+  });
+
+  it('treats a stale pending geometry as no-longer-conflicting for a different target', () => {
+    expect(liveResizeConflictsWithQueuedReplay(
+      { cols: 62, rows: 27, resizes: 1, lastQueuedAt: NOW },
+      { cols: 95, rows: 53 },
+      NOW + 3001,
+    )).toBe('stale');
+  });
+
+  it('does not treat exactly the staleness threshold as stale', () => {
+    expect(liveResizeConflictsWithQueuedReplay(
+      { cols: 62, rows: 27, resizes: 1, lastQueuedAt: NOW },
+      { cols: 62, rows: 27 },
+      NOW + 3000,
+    )).toBe('skip');
+  });
+
+  it('returns none for a resolved replay even when the timestamp is stale', () => {
+    expect(liveResizeConflictsWithQueuedReplay(
+      { cols: 62, rows: 27, resizes: 0, lastQueuedAt: NOW },
+      { cols: 95, rows: 53 },
+      NOW + 10_000,
+    )).toBe('none');
   });
 });

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -335,20 +335,33 @@ export function fitShouldBailAsSuspicious(
 // `resizes` counts replay resize operations still on the write chain.
 export interface PendingReplayGeometry extends TerminalDimensions {
   resizes: number;
+  lastQueuedAt: number;
 }
+
+// On a healthy write chain a queued replay resize applies within
+// milliseconds; if it still hasn't applied after this long, the "replay will
+// land there" promise is stale and must no longer suppress live geometry
+// corrections.
+export const REPLAY_GEOMETRY_STALE_MS = 3000;
 
 // Replay segments march the model through historical geometries before
 // landing on the live PTY size. A live fit or daemon resize echo arriving
 // mid-replay would see a transient mismatch and cancel the queued history —
 // but if it targets the geometry replay already ends at, it is not a
 // conflict: skip it and let the replay land there. Only a genuinely
-// different target cancels.
+// different target cancels. If the queued replay has gone stale (its resize
+// never applied — e.g. a generation-mismatch drop), the promise is broken
+// and suppression must not hold forever.
 export function liveResizeConflictsWithQueuedReplay(
   pendingReplay: PendingReplayGeometry | null,
   target: TerminalDimensions,
-): 'skip' | 'cancel' | 'none' {
+  nowMs: number,
+): 'skip' | 'cancel' | 'none' | 'stale' {
   if (!pendingReplay || pendingReplay.resizes <= 0) {
     return 'none';
+  }
+  if (nowMs - pendingReplay.lastQueuedAt > REPLAY_GEOMETRY_STALE_MS) {
+    return 'stale';
   }
   return fitRequiresTerminalResize(pendingReplay, target) ? 'cancel' : 'skip';
 }
@@ -529,6 +542,9 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
     // Queued historical-replay operations (writes + resizes) not yet applied.
     // Used to detect that a generation bump actually discarded history.
     const pendingReplayOpsRef = useRef(0);
+    // A queued replay resize op was dropped (generation mismatch) without a
+    // later fit to correct the model. Verify geometry once the queue drains.
+    const droppedReplayResizeRef = useRef(false);
     const fitResizeCoalescerRef = useRef<ResizeCoalescer | null>(null);
     // `fit` is defined far below; resizeLocal needs to re-assert local geometry
     // when the daemon's PTY size overflows this window, so reach it via a ref.
@@ -1188,6 +1204,19 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       return writeChainRef.current;
     }, []);
 
+    // Coalesce a verification fit into the next animation frame, replacing
+    // any frame already queued. Shared by the overflow-correction path and
+    // the dropped-replay-resize recovery paths below.
+    const scheduleCoalescedRefit = useCallback(() => {
+      if (overflowRefitRafRef.current !== null) {
+        cancelAnimationFrame(overflowRefitRafRef.current);
+      }
+      overflowRefitRafRef.current = requestAnimationFrame(() => {
+        overflowRefitRafRef.current = null;
+        fitRef.current();
+      });
+    }, []);
+
     const write = useCallback((
       data: string | Uint8Array,
       options?: {
@@ -1204,6 +1233,14 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       return enqueueOperation(async () => {
         if (options?.historicalReplay) {
           pendingReplayOpsRef.current = Math.max(0, pendingReplayOpsRef.current - 1);
+          if (pendingReplayOpsRef.current === 0 && droppedReplayResizeRef.current) {
+            // A dropped replay resize means the model may be stranded at a
+            // historical geometry with no later fit coming; verify once the
+            // replay queue drains (fit() no-ops via its sameSize bail when
+            // geometry is already correct).
+            droppedReplayResizeRef.current = false;
+            scheduleCoalescedRefit();
+          }
         }
         if (
           options?.historicalReplay
@@ -1351,7 +1388,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           scheduleSynchronizedOutputRenderFallback();
         }
       });
-    }, [enqueueOperation, flushSynchronizedOutputRender, lineAtVisibleRow, scheduleSynchronizedOutputRenderFallback, selectionLineAtBufferRow]);
+    }, [enqueueOperation, flushSynchronizedOutputRender, lineAtVisibleRow, scheduleCoalescedRefit, scheduleSynchronizedOutputRenderFallback, selectionLineAtBufferRow]);
 
     // Reconcile the block store with the model's new geometry after a resize.
     //
@@ -1391,6 +1428,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           cols,
           rows,
           resizes: (pendingReplayGeometryRef.current?.resizes ?? 0) + 1,
+          lastQueuedAt: Date.now(),
         };
         pendingReplayOpsRef.current += 1;
       }
@@ -1400,6 +1438,7 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
         const replayConflict = liveResizeConflictsWithQueuedReplay(
           pendingReplayGeometryRef.current,
           { cols, rows },
+          Date.now(),
         );
         if (replayConflict === 'skip') {
           // The daemon's resize echo targets the geometry the queued replay
@@ -1411,6 +1450,17 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             source: 'resizeLocal', bail: 'replayPending', toCols: cols, toRows: rows,
           });
           return Promise.resolve();
+        }
+        if (replayConflict === 'stale') {
+          // The queued replay's promise to land at pendingReplay's geometry
+          // is broken (its resize never applied). `bail: 'replayStale'` is
+          // logged for visibility only — despite the field name, this branch
+          // falls through to the normal resize below instead of bailing.
+          noteResize(diagKeyRef.current, {
+            session: runtimeMetaRef.current?.sessionId ?? undefined,
+            paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
+            source: 'resizeLocal', bail: 'replayStale', toCols: cols, toRows: rows,
+          });
         }
         if (fitRequiresTerminalResize(
           { cols: currentTerminal.cols, rows: currentTerminal.rows },
@@ -1435,10 +1485,32 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             );
           }
         }
+        // Record a drop before checking whether the queue has drained: if
+        // this dropped op is itself the last one queued, the drain check
+        // below must still see the flag it sets.
+        const dropped = Boolean(options?.historicalReplay)
+          && historicalReplayGeneration !== historicalReplayGenerationRef.current;
+        if (dropped) {
+          droppedReplayResizeRef.current = true;
+          noteResize(diagKeyRef.current, {
+            session: runtimeMetaRef.current?.sessionId ?? undefined,
+            paneKind: runtimeMetaRef.current?.paneKind ?? undefined,
+            source: 'resizeLocal', bail: 'staleGeneration', toCols: cols, toRows: rows,
+          });
+        }
         if (
           options?.historicalReplay
-          && historicalReplayGeneration !== historicalReplayGenerationRef.current
+          && pendingReplayOpsRef.current === 0
+          && droppedReplayResizeRef.current
         ) {
+          // A dropped replay resize means the model may be stranded at a
+          // historical geometry with no later fit coming; verify once the
+          // replay queue drains (fit() no-ops via its sameSize bail when
+          // geometry is already correct).
+          droppedReplayResizeRef.current = false;
+          scheduleCoalescedRefit();
+        }
+        if (dropped) {
           return;
         }
         const terminal = terminalRef.current;
@@ -1486,17 +1558,11 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             container
             && geometryOverflowsContainer(rows, renderer.cellHeight, container.clientHeight)
           ) {
-            if (overflowRefitRafRef.current !== null) {
-              cancelAnimationFrame(overflowRefitRafRef.current);
-            }
-            overflowRefitRafRef.current = requestAnimationFrame(() => {
-              overflowRefitRafRef.current = null;
-              fitRef.current();
-            });
+            scheduleCoalescedRefit();
           }
         }
       });
-    }, [enqueueOperation, reconcileBlocksAfterResize, renderSurface]);
+    }, [enqueueOperation, reconcileBlocksAfterResize, renderSurface, scheduleCoalescedRefit]);
 
     const applyFitDimensions = useCallback((dims: TerminalDimensions) => {
       const terminal = terminalRef.current;
@@ -1533,16 +1599,26 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
       // geometry. If it targets the geometry the queued replay ends at, it
       // is not a conflict — skip it and let the replay land there (the PTY
       // is already that size, so there is nothing to notify either).
-      if (liveResizeConflictsWithQueuedReplay(pendingReplayGeometryRef.current, dims) === 'skip') {
+      const replayConflict = liveResizeConflictsWithQueuedReplay(pendingReplayGeometryRef.current, dims, Date.now());
+      if (replayConflict === 'skip') {
         noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'replayPending', toCols: dims.cols, toRows: dims.rows, cw, ch, fromCols: terminal.cols, fromRows: terminal.rows });
         renderSurface(false);
         return;
+      }
+      if (replayConflict === 'stale') {
+        // The queued replay's promise to land at pendingReplay's geometry is
+        // broken (its resize never applied). `bail: 'replayStale'` is logged
+        // for visibility only — despite the field name, this falls through
+        // to the normal fit below instead of bailing.
+        noteResize(diagKeyRef.current, { session, paneKind, source: 'fit', bail: 'replayStale', toCols: dims.cols, toRows: dims.rows, cw, ch, fromCols: terminal.cols, fromRows: terminal.rows });
       }
       // Only a real geometry change conflicts with the queued history; a
       // no-op fit arriving while cooperative replay yields between chunks
       // bails above.
       historicalReplayGenerationRef.current += 1;
       pendingReplayGeometryRef.current = null;
+      // A real fit just ran; nothing owed for any earlier dropped replay resize.
+      droppedReplayResizeRef.current = false;
       if (pendingReplayOpsRef.current > 0) {
         // Queued history was discarded (e.g. a split landed mid-replay); the
         // owner re-requests the attach replay once geometry settles.


### PR DESCRIPTION
## Summary

Prod telemetry showed panes stuck at historical (offscreen) geometry after double attach-replay cycles. The corrective fit was being suppressed indefinitely: a pending replay-geometry promise could be broken by silently dropped replay resize ops, but the `replayPending` skip guard never expired and never retried the fit, leaving the pane wrong until remount.

## Fix

- Add a 3s staleness bound (`REPLAY_GEOMETRY_STALE_MS`) on the `replayPending` suppression so a broken/abandoned replay-geometry promise can no longer suppress fit forever.
- Emit `bail: 'staleGeneration'` diagnostics when a replay resize op is dropped, for observability.
- When a drop is detected, schedule a coalesced verification refit once the replay queue drains, so geometry self-corrects without waiting for the stale bound or a remount.

## Verification

- Full frontend unit suite (146 files / 1431 tests) passed; `tsc --noEmit` clean (re-verified locally as part of this ship).
- `pnpm vitest run src/components/GhosttyTerminal.resizePolicy.test.ts` — 18/18 passing (re-verified locally as part of this ship).
- Live packaged-app verification on a throwaway `offsetfix` profile:
  - `real-app:scenario-reveal-overflow` — passed (converged after 1 measurement).
  - `real-app:scenario-offset-soak --seed 2 --iterations 120` — passed (0 persistent violations, 2 self-healing transients).

Note: this is PR 1 of a stack. A follow-up branch (`fix/clip-watchdog`) builds on this one but is out of scope here.