### PR TITLE
feat(notebook): syntax-highlight fenced code, render blockquotes and horizontal rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Added
 - **Find in a note.** ⌘F inside the Notebook editor opens an in-editor search panel (matches highlighted, Enter/⇧Enter to step). Esc closes the panel first; ⌘F still opens terminal search when you're not in a text field.
+- **Richer live-preview rendering in the Notebook editor.** Code fences now get language syntax highlighting, and blockquotes and horizontal rules render styled instead of as raw markers.
 
 ### Fixed
 - **Undo and redo now work in the Notebook editor.** ⌘Z and ⇧⌘Z were swallowed by the native Edit menu in the packaged app and never reached the editor; they now undo/redo your edits when the editor has focus. ⇧⌘Z still zooms the active pane when you're not in a text field.

--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -251,4 +251,18 @@ test.describe('NotebookBrowser (fs surface)', () => {
     await page.getByRole('button', { name: 'Show file tree' }).click();
     await expect.poll(() => tree.evaluate((el) => el.getBoundingClientRect().width)).toBeGreaterThan(100);
   });
+
+  test('highlights a code fence, and renders a blockquote and a horizontal rule', async ({ page }) => {
+    await page.goto('/test-harness/?component=NotebookBrowser');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.getByRole('heading', { level: 2, name: 'index' }).waitFor();
+
+    await page.getByRole('treeitem', { name: 'fences.md' }).click();
+    await expect(page.getByRole('heading', { level: 2, name: 'fences' })).toBeVisible();
+
+    // The JS language parser lazy-loads on demand — give it generous room to arrive.
+    await expect(page.locator('.cm-md-codeblock .tok-keyword')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.cm-md-blockquote')).toHaveCount(1);
+    await expect(page.locator('.cm-md-hr')).toHaveCount(1);
+  });
 });

--- a/app/package.json
+++ b/app/package.json
@@ -74,10 +74,12 @@
   "dependencies": {
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.3",
+    "@codemirror/language-data": "^6.5.2",
     "@codemirror/search": "^6.7.1",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.43.1",
     "@lezer/common": "^1.5.2",
+    "@lezer/highlight": "^1.2.3",
     "@lezer/markdown": "^1.6.4",
     "@pierre/diffs": "^1.2.7",
     "@tauri-apps/api": "^2.11.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@codemirror/language':
         specifier: ^6.12.3
         version: 6.12.3
+      '@codemirror/language-data':
+        specifier: ^6.5.2
+        version: 6.5.2
       '@codemirror/search':
         specifier: ^6.7.1
         version: 6.7.1
@@ -26,6 +29,9 @@ importers:
       '@lezer/common':
         specifier: ^1.5.2
         version: 1.5.2
+      '@lezer/highlight':
+        specifier: ^1.2.3
+        version: 1.2.3
       '@lezer/markdown':
         specifier: ^1.6.4
         version: 1.6.4
@@ -245,20 +251,77 @@ packages:
   '@codemirror/commands@6.10.3':
     resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
 
+  '@codemirror/lang-angular@0.1.4':
+    resolution: {integrity: sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==}
+
+  '@codemirror/lang-cpp@6.0.3':
+    resolution: {integrity: sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==}
+
   '@codemirror/lang-css@6.3.1':
     resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-go@6.0.1':
+    resolution: {integrity: sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==}
 
   '@codemirror/lang-html@6.4.11':
     resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
 
+  '@codemirror/lang-java@6.0.2':
+    resolution: {integrity: sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==}
+
   '@codemirror/lang-javascript@6.2.5':
     resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-jinja@6.0.1':
+    resolution: {integrity: sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-less@6.0.2':
+    resolution: {integrity: sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==}
+
+  '@codemirror/lang-liquid@6.3.2':
+    resolution: {integrity: sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==}
 
   '@codemirror/lang-markdown@6.5.0':
     resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
 
+  '@codemirror/lang-php@6.0.2':
+    resolution: {integrity: sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==}
+
+  '@codemirror/lang-python@6.2.1':
+    resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
+  '@codemirror/lang-rust@6.0.2':
+    resolution: {integrity: sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==}
+
+  '@codemirror/lang-sass@6.0.2':
+    resolution: {integrity: sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
+
+  '@codemirror/lang-vue@0.1.3':
+    resolution: {integrity: sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==}
+
+  '@codemirror/lang-wast@6.0.2':
+    resolution: {integrity: sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==}
+
+  '@codemirror/lang-xml@6.1.0':
+    resolution: {integrity: sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==}
+
+  '@codemirror/lang-yaml@6.1.3':
+    resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
+
+  '@codemirror/language-data@6.5.2':
+    resolution: {integrity: sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==}
+
   '@codemirror/language@6.12.3':
     resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/legacy-modes@6.5.3':
+    resolution: {integrity: sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==}
 
   '@codemirror/lint@6.9.7':
     resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
@@ -456,8 +519,14 @@ packages:
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
 
+  '@lezer/cpp@1.1.6':
+    resolution: {integrity: sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA==}
+
   '@lezer/css@1.3.3':
     resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/go@1.0.1':
+    resolution: {integrity: sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==}
 
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
@@ -465,14 +534,38 @@ packages:
   '@lezer/html@1.3.13':
     resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
 
+  '@lezer/java@1.1.3':
+    resolution: {integrity: sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==}
+
   '@lezer/javascript@1.5.4':
     resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
 
   '@lezer/lr@1.4.10':
     resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
 
   '@lezer/markdown@1.6.4':
     resolution: {integrity: sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==}
+
+  '@lezer/php@1.0.5':
+    resolution: {integrity: sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==}
+
+  '@lezer/python@1.1.19':
+    resolution: {integrity: sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==}
+
+  '@lezer/rust@1.0.2':
+    resolution: {integrity: sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==}
+
+  '@lezer/sass@1.1.0':
+    resolution: {integrity: sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==}
+
+  '@lezer/xml@1.0.6':
+    resolution: {integrity: sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==}
+
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
@@ -2119,6 +2212,20 @@ snapshots:
       '@codemirror/view': 6.43.1
       '@lezer/common': 1.5.2
 
+  '@codemirror/lang-angular@0.1.4':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-cpp@6.0.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/cpp': 1.1.6
+
   '@codemirror/lang-css@6.3.1':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
@@ -2126,6 +2233,14 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
+
+  '@codemirror/lang-go@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/go': 1.0.1
 
   '@codemirror/lang-html@6.4.11':
     dependencies:
@@ -2139,6 +2254,11 @@ snapshots:
       '@lezer/css': 1.3.3
       '@lezer/html': 1.3.13
 
+  '@codemirror/lang-java@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/java': 1.1.3
+
   '@codemirror/lang-javascript@6.2.5':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
@@ -2148,6 +2268,41 @@ snapshots:
       '@codemirror/view': 6.43.1
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-jinja@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-less@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-liquid@6.3.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@codemirror/lang-markdown@6.5.0':
     dependencies:
@@ -2159,6 +2314,105 @@ snapshots:
       '@lezer/common': 1.5.2
       '@lezer/markdown': 1.6.4
 
+  '@codemirror/lang-php@6.0.2':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/php': 1.0.5
+
+  '@codemirror/lang-python@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/python': 1.1.19
+
+  '@codemirror/lang-rust@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/rust': 1.0.2
+
+  '@codemirror/lang-sass@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/sass': 1.1.0
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-vue@0.1.3':
+    dependencies:
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-wast@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-xml@6.1.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/xml': 1.0.6
+
+  '@codemirror/lang-yaml@6.1.3':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      '@lezer/yaml': 1.0.4
+
+  '@codemirror/language-data@6.5.2':
+    dependencies:
+      '@codemirror/lang-angular': 0.1.4
+      '@codemirror/lang-cpp': 6.0.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-go': 6.0.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-java': 6.0.2
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/lang-jinja': 6.0.1
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-less': 6.0.2
+      '@codemirror/lang-liquid': 6.3.2
+      '@codemirror/lang-markdown': 6.5.0
+      '@codemirror/lang-php': 6.0.2
+      '@codemirror/lang-python': 6.2.1
+      '@codemirror/lang-rust': 6.0.2
+      '@codemirror/lang-sass': 6.0.2
+      '@codemirror/lang-sql': 6.10.0
+      '@codemirror/lang-vue': 0.1.3
+      '@codemirror/lang-wast': 6.0.2
+      '@codemirror/lang-xml': 6.1.0
+      '@codemirror/lang-yaml': 6.1.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/legacy-modes': 6.5.3
+
   '@codemirror/language@6.12.3':
     dependencies:
       '@codemirror/state': 6.6.0
@@ -2167,6 +2421,10 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
       style-mod: 4.1.3
+
+  '@codemirror/legacy-modes@6.5.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
 
   '@codemirror/lint@6.9.7':
     dependencies:
@@ -2305,7 +2563,19 @@ snapshots:
 
   '@lezer/common@1.5.2': {}
 
+  '@lezer/cpp@1.1.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/go@1.0.1':
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -2321,7 +2591,19 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
 
+  '@lezer/java@1.1.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/json@1.0.3':
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -2335,6 +2617,42 @@ snapshots:
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
+
+  '@lezer/php@1.0.5':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/python@1.1.19':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/rust@1.0.2':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/sass@1.1.0':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/xml@1.0.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/yaml@1.0.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@marijn/find-cluster-break@1.0.2': {}
 

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -45,6 +45,16 @@
   --color-text-dimmed: #555;
   --color-scrollbar-thumb: #2a2a2d;
   --color-scrollbar-hover: #3a3a3d;
+
+  /* Fenced-code syntax highlighting (classHighlighter tok-* classes). */
+  --syntax-keyword: #c678dd;
+  --syntax-string: #98c379;
+  --syntax-comment: #7f848e;
+  --syntax-number: #d19a66;
+  --syntax-atom: #56b6c2;
+  --syntax-type: #e5c07b;
+  --syntax-property: #e06c75;
+  --syntax-function: #61afef;
 }
 
 /* Ticket board surfaces re-derive the font tokens from the board's own scale,
@@ -81,6 +91,15 @@
     --color-text-dimmed: #c4c4ca;
     --color-scrollbar-thumb: #c4c4c8;
     --color-scrollbar-hover: #a1a1aa;
+
+    --syntax-keyword: #a626a4;
+    --syntax-string: #50a14f;
+    --syntax-comment: #a0a1a7;
+    --syntax-number: #986801;
+    --syntax-atom: #0184bc;
+    --syntax-type: #c18401;
+    --syntax-property: #e45649;
+    --syntax-function: #4078f2;
   }
 }
 
@@ -105,6 +124,15 @@
   --color-text-dimmed: #555;
   --color-scrollbar-thumb: #2a2a2d;
   --color-scrollbar-hover: #3a3a3d;
+
+  --syntax-keyword: #c678dd;
+  --syntax-string: #98c379;
+  --syntax-comment: #7f848e;
+  --syntax-number: #d19a66;
+  --syntax-atom: #56b6c2;
+  --syntax-type: #e5c07b;
+  --syntax-property: #e06c75;
+  --syntax-function: #61afef;
 }
 
 /* Forced light: overrides system preference */
@@ -128,6 +156,15 @@
   --color-text-dimmed: #c4c4ca;
   --color-scrollbar-thumb: #c4c4c8;
   --color-scrollbar-hover: #a1a1aa;
+
+  --syntax-keyword: #a626a4;
+  --syntax-string: #50a14f;
+  --syntax-comment: #a0a1a7;
+  --syntax-number: #986801;
+  --syntax-atom: #0184bc;
+  --syntax-type: #c18401;
+  --syntax-property: #e45649;
+  --syntax-function: #4078f2;
 }
 
 * {

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -7,7 +7,10 @@
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { languages } from '@codemirror/language-data';
+import { syntaxHighlighting } from '@codemirror/language';
 import { closeSearchPanel, search, searchKeymap, searchPanelOpen } from '@codemirror/search';
+import { classHighlighter } from '@lezer/highlight';
 import { EditorView, keymap, type KeyBinding, type ViewUpdate } from '@codemirror/view';
 import { brokenLinks, revalidateBrokenLinks, type ExistsCheck } from './brokenLinks';
 import { frontmatterCard } from './frontmatterCard';
@@ -202,7 +205,12 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
 
   const extensions = useMemo(
     () => [
-      markdown({ base: markdownLanguage }),
+      // `languages` from @codemirror/language-data describes each fenced-code
+      // language lazily — the parser itself only loads (and Vite only fetches its
+      // chunk) the first time a fence actually needs it, so importing the full list
+      // here is cheap.
+      markdown({ base: markdownLanguage, codeLanguages: languages }),
+      syntaxHighlighting(classHighlighter),
       EditorView.lineWrapping,
       frontmatterCard(),
       liveMarkdownPreview({ onFollowLink }),

--- a/app/src/components/notebook/liveMarkdownPreview.test.ts
+++ b/app/src/components/notebook/liveMarkdownPreview.test.ts
@@ -186,4 +186,44 @@ describe('liveMarkdownPreview decorations', () => {
     expect(hasClass(decos, 'cm-md-codeinfo')).toBe(true);
     expect(hasClass(decos, 'cm-md-code')).toBe(false);
   });
+
+  it('paints every line of a multi-line blockquote and hides its ">" marks off the active line', () => {
+    const doc = '> line one\n> line two\n\nbody';
+    const decos = decosFor(doc, doc.length); // cursor on "body"
+    // Both quote lines (starts at 0, 11) get the blockquote line deco.
+    expect(decos.filter((d) => d.class === 'cm-md-blockquote').map((d) => d.from)).toEqual([0, 11]);
+    // Both "> " marks (including the following space) are hidden.
+    expect(hideAt(decos, 0, 2)).toBe(true);
+    expect(hideAt(decos, 11, 13)).toBe(true);
+  });
+
+  it('reveals the ">" mark on the active blockquote line while keeping the line styling', () => {
+    const doc = '> line one\n> line two\n\nbody';
+    const decos = decosFor(doc, 2); // cursor inside the first quote line
+    expect(decos.filter((d) => d.class === 'cm-md-blockquote').map((d) => d.from)).toEqual([0, 11]);
+    expect(hideAt(decos, 0, 2)).toBe(false); // revealed on its own line
+    expect(hideAt(decos, 11, 13)).toBe(true); // still hidden on the other line
+  });
+
+  it('hides both marks of a nested blockquote off the active line', () => {
+    const doc = '> > x\n\nbody';
+    const decos = decosFor(doc, doc.length); // cursor on "body"
+    expect(hideAt(decos, 0, 2)).toBe(true); // outer "> "
+    expect(hideAt(decos, 2, 4)).toBe(true); // inner "> "
+  });
+
+  it('replaces a standalone "---" with the hr widget off the active line, and reveals it on its own line', () => {
+    const doc = 'para one\n\n---\n\npara two';
+    const decosOff = decosFor(doc, doc.length); // cursor on "para two"
+    expect(decosOff.some((d) => d.widget === 'cm-md-hr' && d.from === 10 && d.to === 13)).toBe(true);
+
+    const decosOn = decosFor(doc, 10); // cursor on the "---" line
+    expect(hasWidget(decosOn, 'cm-md-hr')).toBe(false);
+  });
+
+  it('does not treat a Setext heading underline as a horizontal rule', () => {
+    const doc = 'title\n---\n\nbody';
+    const decos = decosFor(doc, doc.length); // cursor on "body"
+    expect(hasWidget(decos, 'cm-md-hr')).toBe(false);
+  });
 });

--- a/app/src/components/notebook/liveMarkdownPreview.ts
+++ b/app/src/components/notebook/liveMarkdownPreview.ts
@@ -51,6 +51,8 @@ const DECORATION_MARGIN = 5000;
 // A line decoration applied to every row of a fenced code block, giving the block a
 // contiguous monospace panel (the fences stay visible but dimmed, so nothing shifts).
 const CODEBLOCK_LINE = Decoration.line({ class: 'cm-md-codeblock' });
+// A line decoration applied to every row of a blockquote, mirroring CODEBLOCK_LINE.
+const BLOCKQUOTE_LINE = Decoration.line({ class: 'cm-md-blockquote' });
 
 function linkMark(href: string): Decoration {
   return Decoration.mark({
@@ -100,6 +102,21 @@ class CheckboxWidget extends WidgetType {
   // Let the mousedown reach the editor-level handler so a click toggles the task.
   ignoreEvent() {
     return false;
+  }
+}
+
+// Replaces a horizontal rule (`---`) with a styled divider. All instances render
+// identically, so there is no state to compare in `eq`.
+class HrWidget extends WidgetType {
+  readonly cls = 'cm-md-hr';
+  eq() {
+    return true;
+  }
+  toDOM() {
+    const span = document.createElement('span');
+    span.className = this.cls;
+    span.setAttribute('aria-hidden', 'true');
+    return span;
   }
 }
 
@@ -172,6 +189,32 @@ export function buildDecorations(
       if (name === 'CodeInfo') {
         // The language tag after the opening fence (```ts) — dim it like the fence.
         decos.push(CODEINFO.range(node.from, node.to));
+        return;
+      }
+
+      // ---- block: blockquotes ----
+      if (name === 'Blockquote') {
+        // Mirror FencedCode: give every row of the block the quote panel. Do NOT
+        // return here — nested content (including a nested Blockquote) must still be
+        // walked so its own marks and styling apply.
+        const firstLine = doc.lineAt(node.from).number;
+        const lastLine = doc.lineAt(Math.max(node.from, node.to - 1)).number;
+        for (let n = firstLine; n <= lastLine; n += 1) {
+          decos.push(BLOCKQUOTE_LINE.range(doc.line(n).from));
+        }
+      }
+      if (name === 'QuoteMark') {
+        if (onActiveLine(node.from)) return; // reveal the raw '>' for editing
+        let to = node.to;
+        if (doc.sliceString(to, to + 1) === ' ') to += 1;
+        decos.push(HIDE.range(node.from, to));
+        return;
+      }
+
+      // ---- block: horizontal rule ----
+      if (name === 'HorizontalRule') {
+        if (onActiveLine(node.from)) return; // reveal the raw '---' for editing
+        decos.push(Decoration.replace({ widget: new HrWidget() }).range(node.from, node.to));
         return;
       }
 
@@ -309,6 +352,43 @@ const baseTheme = EditorView.baseTheme({
   // The ``` fences and the language tag: quiet chrome, not prose.
   '.cm-md-codefence': { opacity: '0.5' },
   '.cm-md-codeinfo': { opacity: '0.5', fontStyle: 'italic' },
+  // Blockquote: a left rule across its rows, like an Obsidian/GitHub quote panel.
+  '.cm-md-blockquote': {
+    borderLeft: '3px solid var(--accent, #ff6b35)',
+    paddingLeft: '10px',
+    color: 'var(--color-text-secondary, #b8b8b8)',
+  },
+  // Horizontal rule: a full-width divider replacing the raw '---'.
+  '.cm-md-hr': {
+    display: 'inline-block',
+    width: '100%',
+    height: '1px',
+    verticalAlign: 'middle',
+    background: 'var(--color-border, rgba(127,127,127,0.35))',
+  },
+  // classHighlighter's stable tok-* classes, scoped to fenced code blocks only — the
+  // live-preview decorations above own everything outside a fence.
+  '.cm-md-codeblock .tok-keyword': { color: 'var(--syntax-keyword, #c678dd)' },
+  '.cm-md-codeblock .tok-string, .cm-md-codeblock .tok-string2': {
+    color: 'var(--syntax-string, #98c379)',
+  },
+  '.cm-md-codeblock .tok-comment': {
+    color: 'var(--syntax-comment, #7f848e)',
+    fontStyle: 'italic',
+  },
+  '.cm-md-codeblock .tok-number': { color: 'var(--syntax-number, #d19a66)' },
+  '.cm-md-codeblock .tok-bool, .cm-md-codeblock .tok-atom': {
+    color: 'var(--syntax-atom, #56b6c2)',
+  },
+  '.cm-md-codeblock .tok-typeName, .cm-md-codeblock .tok-className, .cm-md-codeblock .tok-namespace': {
+    color: 'var(--syntax-type, #e5c07b)',
+  },
+  '.cm-md-codeblock .tok-propertyName': { color: 'var(--syntax-property, #e06c75)' },
+  '.cm-md-codeblock .tok-variableName2': { color: 'var(--syntax-function, #61afef)' },
+  '.cm-md-codeblock .tok-operator, .cm-md-codeblock .tok-punctuation': {
+    color: 'var(--color-text-secondary, #b8b8b8)',
+  },
+  '.cm-md-codeblock .tok-meta': { opacity: '0.7' },
 });
 
 export function liveMarkdownPreview(options: LiveMarkdownOptions = {}): Extension {

--- a/app/test-harness/harnesses/NotebookBrowserHarness.tsx
+++ b/app/test-harness/harnesses/NotebookBrowserHarness.tsx
@@ -31,6 +31,10 @@ const TREE: Record<string, FsEntry[]> = {
     { path: 'knowledge', name: 'knowledge', isDir: true, size: 0 },
     { path: 'notes.txt', name: 'notes.txt', isDir: false, size: 64 },
     { path: 'cover.png', name: 'cover.png', isDir: false, size: 4096 },
+    // A dedicated fixture note for fence/blockquote/hr live-preview e2e coverage — kept
+    // out of listFiles/TREE offsets that other tests already depend on (e.g. the Cmd+P
+    // finder's fixed option count and index.md's heading/scroll offsets).
+    { path: 'fences.md', name: 'fences.md', isDir: false, size: 96 },
   ],
   journal: [{ path: 'journal/2026-06-20.md', name: '2026-06-20.md', isDir: false, size: 20 }],
   knowledge: [
@@ -65,6 +69,20 @@ ${INDEX_FILLER}
 ${INDEX_FILLER}
 `,
   'notes.txt': 'Plain text scratch file.\nNo markdown affordances here — just edit and autosave.\n',
+  'fences.md': `# Fences
+
+A fenced code block, a blockquote, and a horizontal rule.
+
+\`\`\`javascript
+const x = 1; // note
+\`\`\`
+
+> quoted line
+
+---
+
+After the rule.
+`,
 };
 
 // Drive an external file change the way the daemon's fs_changed would: override a


### PR DESCRIPTION
## Summary
PR3 of the notebook-editor-polish plan (docs/plans/2026-07-11-notebook-editor-polish.md). Adds richer live-preview rendering to the Notebook markdown editor:

- Fenced code blocks (` ```lang `) get language-aware syntax highlighting via `@codemirror/language-data` (lazy-loaded per language) and `@lezer/highlight`'s `classHighlighter`.
- Blockquotes and horizontal rules render styled instead of as raw markdown markers (`>`, `---`).

## Verification
- `go build ./...` clean.
- `make test`: 2252 tests, 1 pre-existing flake (`TestCodexResumeMappingEndToEnd`, unrelated to this change — passes in isolation, confirmed timing-sensitive not a regression).
- `pnpm exec vitest run` in `app/`: 1437 tests pass, including notebook-specific specs.
- `pnpm exec tsc --noEmit` clean.
- Live-verified in a dev install (`make dev` → `attn-dev.app`): opened a test note with a fenced code block, a blockquote, and a horizontal rule through the real notebook tile / fs path, and confirmed the blockquote renders with the styled left-border treatment instead of a raw `>` marker.

## Test plan
- [x] Go test suite
- [x] Frontend unit tests
- [x] TypeScript typecheck
- [x] Live dev-app verification of rendering