### PR TITLE
feat(notebook): render GFM tables as a widget in the live markdown editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Find in a note.** ⌘F inside the Notebook editor opens an in-editor search panel (matches highlighted, Enter/⇧Enter to step). Esc closes the panel first; ⌘F still opens terminal search when you're not in a text field.
 - **Richer live-preview rendering in the Notebook editor.** Code fences now get language syntax highlighting, and blockquotes and horizontal rules render styled instead of as raw markers.
+- **Markdown tables in the Notebook editor** now render as real tables, with raw source revealed for editing when the cursor is inside (click a row to edit it).
 
 ### Fixed
 - **Undo and redo now work in the Notebook editor.** ⌘Z and ⇧⌘Z were swallowed by the native Edit menu in the packaged app and never reached the editor; they now undo/redo your edits when the editor has focus. ⇧⌘Z still zooms the active pane when you're not in a text field.

--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -265,4 +265,23 @@ test.describe('NotebookBrowser (fs surface)', () => {
     await expect(page.locator('.cm-md-blockquote')).toHaveCount(1);
     await expect(page.locator('.cm-md-hr')).toHaveCount(1);
   });
+
+  test('renders a GFM table as a widget, revealing raw source when clicked', async ({ page }) => {
+    await page.goto('/test-harness/?component=NotebookBrowser');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.getByRole('heading', { level: 2, name: 'index' }).waitFor();
+
+    await page.getByRole('treeitem', { name: 'fences.md' }).click();
+    await expect(page.getByRole('heading', { level: 2, name: 'fences' })).toBeVisible();
+
+    const table = page.locator('.cm-md-table');
+    await expect(table).toBeVisible();
+    await expect(table.locator('th', { hasText: 'col a' })).toBeVisible();
+    await expect(table.locator('td', { hasText: 'two' })).toBeVisible();
+    await expect(page.getByText('| one', { exact: false })).not.toBeVisible();
+
+    await table.locator('tbody tr').first().click();
+    await expect(table).not.toBeVisible();
+    await expect(page.locator('.cm-content')).toContainText('| one');
+  });
 });

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -15,6 +15,7 @@ import { EditorView, keymap, type KeyBinding, type ViewUpdate } from '@codemirro
 import { brokenLinks, revalidateBrokenLinks, type ExistsCheck } from './brokenLinks';
 import { frontmatterCard } from './frontmatterCard';
 import { liveMarkdownPreview } from './liveMarkdownPreview';
+import { markdownTables } from './tableWidget';
 import { computeMinimalEdit } from './minimalEdit';
 
 // searchKeymap binds its commands with CodeMirror's "Mod-" modifier, which CM
@@ -213,6 +214,7 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
       syntaxHighlighting(classHighlighter),
       EditorView.lineWrapping,
       frontmatterCard(),
+      markdownTables(),
       liveMarkdownPreview({ onFollowLink }),
       brokenLinks({ existsFile }),
       search({ top: true }),

--- a/app/src/components/notebook/tableWidget.test.ts
+++ b/app/src/components/notebook/tableWidget.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { parseTableData, markdownTables } from './tableWidget';
+
+function stateFor(doc: string, selection: { anchor: number; head?: number }): EditorState {
+  return EditorState.create({
+    doc,
+    selection,
+    extensions: [markdown({ base: markdownLanguage }), markdownTables()],
+  });
+}
+
+// The table field is private (only parseTableData/markdownTables are exported), so
+// tests read its contribution to the standard decorations facet — resolvable from a
+// bare EditorState since markdownTables()'s only decoration source is a StateField
+// (Facet.from(field) needs no view). Counts block-replace ranges without depending on
+// widget internals.
+function replaceRangeCount(state: EditorState): number {
+  let count = 0;
+  for (const provider of state.facet(EditorView.decorations)) {
+    const set = typeof provider === 'function' ? provider(state as unknown as EditorView) : provider;
+    const iter = set.iter();
+    while (iter.value) {
+      count++;
+      iter.next();
+    }
+  }
+  return count;
+}
+
+describe('parseTableData', () => {
+  it('parses header, alignment, rows, and fromLine', () => {
+    const doc = '| a | b |\n| --- | :-: |\n| 1 | 2 |';
+    const state = stateFor(doc, { anchor: 0 });
+    const data = parseTableData(state, 0, doc.length);
+    expect(data).toEqual({
+      header: ['a', 'b'],
+      align: [null, 'center'],
+      rows: [['1', '2']],
+      fromLine: 1,
+    });
+  });
+
+  it('parses all four alignment forms', () => {
+    const doc = '| a | b | c | d |\n| --- | :-- | --: | :-: |\n| 1 | 2 | 3 | 4 |';
+    const state = stateFor(doc, { anchor: 0 });
+    const data = parseTableData(state, 0, doc.length);
+    expect(data?.align).toEqual([null, 'left', 'right', 'center']);
+  });
+
+  it('keeps inline markdown as raw cell text (v1 contract)', () => {
+    const doc = '| a |\n| --- |\n| **x** |';
+    const state = stateFor(doc, { anchor: 0 });
+    const data = parseTableData(state, 0, doc.length);
+    expect(data?.rows).toEqual([['**x**']]);
+  });
+
+  it('returns null for a range that is not a well-formed Table node', () => {
+    const doc = 'just a paragraph, no table here';
+    const state = stateFor(doc, { anchor: 0 });
+    expect(parseTableData(state, 0, doc.length)).toBeNull();
+  });
+});
+
+describe('markdownTables reveal gate', () => {
+  const doc = '| a | b |\n| --- | :-: |\n| 1 | 2 |';
+
+  it('renders one block-replace widget when the cursor is outside the table', () => {
+    const state = stateFor(`${doc}\n\nafter`, { anchor: doc.length + 3 });
+    expect(replaceRangeCount(state)).toBe(1);
+  });
+
+  it('reveals raw source (no decoration) when the cursor is on the header line', () => {
+    const state = stateFor(`${doc}\n\nafter`, { anchor: 2 });
+    expect(replaceRangeCount(state)).toBe(0);
+  });
+
+  it('reveals raw source when the cursor is on the delimiter line', () => {
+    const delimiterPos = doc.indexOf('\n', doc.indexOf('\n') + 1) - 1;
+    const state = stateFor(`${doc}\n\nafter`, { anchor: delimiterPos });
+    expect(replaceRangeCount(state)).toBe(0);
+  });
+
+  it('reveals raw source when the cursor is on a body row', () => {
+    const state = stateFor(`${doc}\n\nafter`, { anchor: doc.length - 2 });
+    expect(replaceRangeCount(state)).toBe(0);
+  });
+
+  it('reveals when a selection range overlaps the table edge (anchor before, head inside)', () => {
+    const state = stateFor(`${doc}\n\nafter`, { anchor: 0, head: 5 });
+    expect(replaceRangeCount(state)).toBe(0);
+  });
+
+  it('reveals only the table the cursor is inside, with a second table intact', () => {
+    const secondTable = '| c | d |\n| --- | --- |\n| 3 | 4 |';
+    const full = `${doc}\n\n${secondTable}`;
+    // Cursor on the first table's header line.
+    const state = stateFor(full, { anchor: 2 });
+    expect(replaceRangeCount(state)).toBe(1); // only the second table's widget remains
+  });
+});

--- a/app/src/components/notebook/tableWidget.ts
+++ b/app/src/components/notebook/tableWidget.ts
@@ -1,0 +1,232 @@
+// GFM tables in the Notebook's live markdown editor: a table renders as a real
+// `<table>` widget, and reveals raw pipe-row source when the cursor is inside it — the
+// same reveal-on-cursor model as frontmatterCard, for the same reason.
+//
+// CM constraint that shapes this file: decorations that affect vertical layout (block
+// widgets, replacements spanning line breaks) MUST come directly from a StateField via
+// `EditorView.decorations.from(...)` — the view plugin that powers the inline preview
+// is computed after layout and is forbidden from introducing them. So the table
+// extension lives here, in its own field, mirroring frontmatterCard.ts.
+
+import { ensureSyntaxTree } from '@codemirror/language';
+import { type EditorState, type Extension, type Range, StateField } from '@codemirror/state';
+import { Decoration, type DecorationSet, EditorView, WidgetType } from '@codemirror/view';
+import type { SyntaxNode } from '@lezer/common';
+
+export type CellAlign = 'left' | 'center' | 'right' | null;
+
+export interface TableData {
+  header: string[];
+  align: CellAlign[]; // one entry per column, from the delimiter row (:--- :--: ---:)
+  rows: string[][]; // body rows, raw cell text (inline markdown left as-is, v1)
+  fromLine: number; // 1-based doc line of the table's first (header) row
+}
+
+function cellAlign(spec: string): CellAlign {
+  const left = spec.startsWith(':');
+  const right = spec.endsWith(':');
+  if (left && right) return 'center';
+  if (right) return 'right';
+  if (left) return 'left';
+  return null;
+}
+
+function cellTexts(row: SyntaxNode, state: EditorState): string[] {
+  const cells: string[] = [];
+  for (let cell = row.firstChild; cell; cell = cell.nextSibling) {
+    if (cell.name === 'TableCell') cells.push(state.doc.sliceString(cell.from, cell.to).trim());
+  }
+  return cells;
+}
+
+// Locate the Table syntax node exactly spanning [from, to] within the already-parsed
+// tree, so parseTableData can walk its real children (TableHeader/TableDelimiter/
+// TableRow) rather than re-deriving structure from text.
+function findTableNode(state: EditorState, from: number, to: number): SyntaxNode | null {
+  const tree = ensureSyntaxTree(state, to, 50);
+  if (!tree) return null;
+  let found: SyntaxNode | null = null;
+  tree.iterate({
+    from,
+    to,
+    enter: (node) => {
+      if (found) return false;
+      if (node.name === 'Table' && node.from === from && node.to === to) {
+        found = node.node;
+        return false;
+      }
+      return undefined;
+    },
+  });
+  return found;
+}
+
+// Parse the Table syntax node at [from,to] into TableData; null if it isn't a
+// well-formed table (defensive — Lezer only emits Table for valid GFM tables).
+export function parseTableData(state: EditorState, from: number, to: number): TableData | null {
+  const table = findTableNode(state, from, to);
+  if (!table) return null;
+
+  let header: string[] | null = null;
+  let align: CellAlign[] | null = null;
+  const rows: string[][] = [];
+
+  for (let child = table.firstChild; child; child = child.nextSibling) {
+    if (child.name === 'TableHeader') {
+      header = cellTexts(child, state);
+    } else if (child.name === 'TableDelimiter') {
+      align = state.doc
+        .sliceString(child.from, child.to)
+        .split('|')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+        .map(cellAlign);
+    } else if (child.name === 'TableRow') {
+      rows.push(cellTexts(child, state));
+    }
+  }
+  if (!header || !align) return null;
+
+  return { header, align, rows, fromLine: state.doc.lineAt(from).number };
+}
+
+class TableWidget extends WidgetType {
+  constructor(readonly data: TableData) {
+    super();
+  }
+
+  eq(other: TableWidget) {
+    return JSON.stringify(this.data) === JSON.stringify(other.data);
+  }
+
+  // Reserve roughly the right height before the DOM is measured, so the first layout
+  // doesn't jump the scroll position. CM re-measures the real height after mount.
+  get estimatedHeight() {
+    return (1 + this.data.rows.length) * 26 + 8;
+  }
+
+  // Clicks must reach the editor so a row click can hand off to raw editing.
+  ignoreEvent() {
+    return false;
+  }
+
+  toDOM(view: EditorView) {
+    const { header, align, rows, fromLine } = this.data;
+    const lastLine = view.state.doc.lines;
+
+    const gotoLine = (line: number) => {
+      const clamped = Math.max(1, Math.min(line, lastLine));
+      const target = view.state.doc.line(clamped).from;
+      view.dispatch({ selection: { anchor: target } });
+      view.focus();
+    };
+
+    const table = document.createElement('table');
+    table.className = 'cm-md-table';
+
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    headRow.addEventListener('mousedown', (event) => event.preventDefault());
+    headRow.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      gotoLine(fromLine);
+    });
+    header.forEach((text, i) => {
+      const th = document.createElement('th');
+      th.textContent = text;
+      const a = align[i];
+      if (a) th.style.textAlign = a;
+      headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    rows.forEach((cells, rowIndex) => {
+      const tr = document.createElement('tr');
+      tr.addEventListener('mousedown', (event) => event.preventDefault());
+      tr.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        gotoLine(fromLine + 2 + rowIndex); // +1 header, +1 delimiter row
+      });
+      cells.forEach((text, i) => {
+        const td = document.createElement('td');
+        td.textContent = text;
+        const a = align[i];
+        if (a) td.style.textAlign = a;
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+
+    return table;
+  }
+}
+
+// Pure decoration builder (no view), so the reveal gate is unit-testable headlessly.
+// Every top-level Table node renders as a widget, except one the selection currently
+// intersects — that table stays raw so it can be edited.
+function tableDecorations(state: EditorState): DecorationSet {
+  const tree = ensureSyntaxTree(state, state.doc.length, 50);
+  if (!tree) return Decoration.none;
+
+  const ranges: Range<Decoration>[] = [];
+  tree.iterate({
+    enter: (node) => {
+      if (node.name !== 'Table') return undefined;
+      const { from, to } = node;
+      const revealed = state.selection.ranges.some(
+        (range) => range.from <= to && range.to >= from,
+      );
+      if (!revealed) {
+        const data = parseTableData(state, from, to);
+        if (data) {
+          ranges.push(Decoration.replace({ block: true, widget: new TableWidget(data) }).range(from, to));
+        }
+      }
+      return false; // tables don't nest
+    },
+  });
+  return Decoration.set(ranges);
+}
+
+const tableField = StateField.define<DecorationSet>({
+  create: (state) => tableDecorations(state),
+  update(value, tr) {
+    if (tr.docChanged || tr.selection) {
+      const tree = ensureSyntaxTree(tr.state, tr.state.doc.length, 50);
+      // Recompute create()-style from scratch (mirrors frontmatterCard), but if the
+      // tree isn't ready yet, keep the previous set rather than flashing empty.
+      if (!tree) return value.map(tr.changes);
+      return tableDecorations(tr.state);
+    }
+    return value.map(tr.changes);
+  },
+  provide: (field) => EditorView.decorations.from(field),
+});
+
+const tableTheme = EditorView.baseTheme({
+  '.cm-md-table': {
+    borderCollapse: 'collapse',
+    margin: '4px 0',
+    fontSize: '13px',
+  },
+  '.cm-md-table th, .cm-md-table td': {
+    border: '1px solid var(--color-border, rgba(127,127,127,0.35))',
+    padding: '3px 10px',
+  },
+  '.cm-md-table th': {
+    backgroundColor: 'var(--color-bg-elevated, rgba(128,128,128,0.08))',
+    fontWeight: '600',
+  },
+  '.cm-md-table tr': {
+    cursor: 'pointer',
+  },
+});
+
+export function markdownTables(): Extension {
+  return [tableField, tableTheme];
+}

--- a/app/test-harness/harnesses/NotebookBrowserHarness.tsx
+++ b/app/test-harness/harnesses/NotebookBrowserHarness.tsx
@@ -82,6 +82,10 @@ const x = 1; // note
 ---
 
 After the rule.
+
+| col a | col b |
+| ----- | ----: |
+| one   | two   |
 `,
 };
 


### PR DESCRIPTION
## Summary

PR4 of the notebook-editor-polish plan (`docs/plans/2026-07-11-notebook-editor-polish.md`).

Markdown tables now render as a styled `<table>` widget in the live editor, mirroring the frontmatter-card reveal model already used for other block types: the raw pipe-row source is revealed when the cursor (or selection) intersects the table's range, and clicking a rendered row places the cursor on its source line to hand off to raw editing.

## Test plan

- [x] `go build ./...`, `gofmt -l .`, `go vet ./...` all clean
- [x] `pnpm exec vitest run` — 147 files, 1447 tests passing
- [x] Live-verified in a packaged dev install (`attn-dev.app`): opened a note containing a GFM table via the notebook tile and confirmed it renders as a real table (Name/Role/Status columns)
- [x] New `tableWidget.test.ts` (103 lines) covers the widget's parsing/reveal logic; `app/e2e/notebook-browser.spec.ts` gained Playwright coverage for the feature

Claude-Session: https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT