### PR TITLE
feat(notebook): ⌘B/⌘I/⌘E inline formatting in the live markdown editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Find in a note.** ⌘F inside the Notebook editor opens an in-editor search panel (matches highlighted, Enter/⇧Enter to step). Esc closes the panel first; ⌘F still opens terminal search when you're not in a text field.
 - **Richer live-preview rendering in the Notebook editor.** Code fences now get language syntax highlighting, and blockquotes and horizontal rules render styled instead of as raw markers.
 - **Markdown tables in the Notebook editor** now render as real tables, with raw source revealed for editing when the cursor is inside (click a row to edit it).
+- **⌘B/⌘I/⌘E toggle bold, italic, and inline code in the Notebook editor.** Wraps the selection or the word under the cursor; press again to remove.
 
 ### Fixed
 - **Undo and redo now work in the Notebook editor.** ⌘Z and ⇧⌘Z were swallowed by the native Edit menu in the packaged app and never reached the editor; they now undo/redo your edits when the editor has focus. ⇧⌘Z still zooms the active pane when you're not in a text field.

--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -284,4 +284,40 @@ test.describe('NotebookBrowser (fs surface)', () => {
     await expect(table).not.toBeVisible();
     await expect(page.locator('.cm-content')).toContainText('| one');
   });
+
+  test('Cmd+B toggles bold on the word under a double-clicked selection', async ({ page }) => {
+    await page.goto('/test-harness/?component=NotebookBrowser');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.getByRole('heading', { level: 2, name: 'index' }).waitFor();
+
+    await page.getByRole('treeitem', { name: 'fences.md' }).click();
+    await expect(page.getByRole('heading', { level: 2, name: 'fences' })).toBeVisible();
+
+    const content = page.locator('.cm-content');
+    // CodeMirror renders each line as one text node, so a text-content locator can't
+    // isolate a single word for dblclick; find the word's on-screen rect via a DOM
+    // Range instead and double-click its center.
+    const wordRect = await page.evaluate(() => {
+      const walker = document.createTreeWalker(document.querySelector('.cm-content')!, NodeFilter.SHOW_TEXT);
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        const idx = node.textContent?.indexOf('fenced') ?? -1;
+        if (idx === -1) continue;
+        const range = document.createRange();
+        range.setStart(node, idx);
+        range.setEnd(node, idx + 'fenced'.length);
+        const rect = range.getBoundingClientRect();
+        return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+      }
+      return null;
+    });
+    if (!wordRect) throw new Error('could not locate "fenced" in the editor');
+    await page.mouse.dblclick(wordRect.x, wordRect.y);
+
+    await page.keyboard.press('Meta+b');
+    await expect(content).toContainText('**fenced**');
+
+    await page.keyboard.press('Meta+b');
+    await expect(content).not.toContainText('**fenced**');
+    await expect(content).toContainText('A fenced code block');
+  });
 });

--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -285,7 +285,28 @@ test.describe('NotebookBrowser (fs surface)', () => {
     await expect(page.locator('.cm-content')).toContainText('| one');
   });
 
-  test('Cmd+B toggles bold on the word under a double-clicked selection', async ({ page }) => {
+  // CodeMirror renders each line as one text node, so a text-content locator can't
+  // isolate a single word for dblclick; find the word's on-screen rect via a DOM
+  // Range instead and double-click its center.
+  async function dblclickWord(page: import('@playwright/test').Page, word: string) {
+    const wordRect = await page.evaluate((needle) => {
+      const walker = document.createTreeWalker(document.querySelector('.cm-content')!, NodeFilter.SHOW_TEXT);
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        const idx = node.textContent?.indexOf(needle) ?? -1;
+        if (idx === -1) continue;
+        const range = document.createRange();
+        range.setStart(node, idx);
+        range.setEnd(node, idx + needle.length);
+        const rect = range.getBoundingClientRect();
+        return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+      }
+      return null;
+    }, word);
+    if (!wordRect) throw new Error(`could not locate "${word}" in the editor`);
+    await page.mouse.dblclick(wordRect.x, wordRect.y);
+  }
+
+  test('Cmd+B/I/E toggle bold, italic, and inline code on a double-clicked word', async ({ page }) => {
     await page.goto('/test-harness/?component=NotebookBrowser');
     await page.waitForFunction(() => window.__HARNESS__?.ready === true);
     await page.getByRole('heading', { level: 2, name: 'index' }).waitFor();
@@ -294,30 +315,30 @@ test.describe('NotebookBrowser (fs surface)', () => {
     await expect(page.getByRole('heading', { level: 2, name: 'fences' })).toBeVisible();
 
     const content = page.locator('.cm-content');
-    // CodeMirror renders each line as one text node, so a text-content locator can't
-    // isolate a single word for dblclick; find the word's on-screen rect via a DOM
-    // Range instead and double-click its center.
-    const wordRect = await page.evaluate(() => {
-      const walker = document.createTreeWalker(document.querySelector('.cm-content')!, NodeFilter.SHOW_TEXT);
-      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-        const idx = node.textContent?.indexOf('fenced') ?? -1;
-        if (idx === -1) continue;
-        const range = document.createRange();
-        range.setStart(node, idx);
-        range.setEnd(node, idx + 'fenced'.length);
-        const rect = range.getBoundingClientRect();
-        return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
-      }
-      return null;
-    });
-    if (!wordRect) throw new Error('could not locate "fenced" in the editor');
-    await page.mouse.dblclick(wordRect.x, wordRect.y);
 
+    await dblclickWord(page, 'fenced');
     await page.keyboard.press('Meta+b');
     await expect(content).toContainText('**fenced**');
-
     await page.keyboard.press('Meta+b');
     await expect(content).not.toContainText('**fenced**');
     await expect(content).toContainText('A fenced code block');
+
+    // Regression coverage for a real bug: basicSetup's defaultKeymap binds Mod-i to
+    // selectParentSyntax with preventDefault, which shadows Cmd-i at default keymap
+    // precedence unless formattingKeymap() is raised via Prec.high. Only a real keydown
+    // through the full extension stack (not a headless-state unit test) can catch this.
+    await dblclickWord(page, 'blockquote');
+    await page.keyboard.press('Meta+i');
+    await expect(page.locator('.cm-md-em')).toBeVisible();
+    await page.keyboard.press('Meta+i');
+    await expect(page.locator('.cm-md-em')).toHaveCount(0);
+    await expect(content).toContainText('a blockquote');
+
+    await dblclickWord(page, 'horizontal');
+    await page.keyboard.press('Meta+e');
+    await expect(page.locator('.cm-md-code')).toBeVisible();
+    await page.keyboard.press('Meta+e');
+    await expect(page.locator('.cm-md-code')).toHaveCount(0);
+    await expect(content).toContainText('a horizontal rule');
   });
 });

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -13,6 +13,7 @@ import { closeSearchPanel, search, searchKeymap, searchPanelOpen } from '@codemi
 import { classHighlighter } from '@lezer/highlight';
 import { EditorView, keymap, type KeyBinding, type ViewUpdate } from '@codemirror/view';
 import { brokenLinks, revalidateBrokenLinks, type ExistsCheck } from './brokenLinks';
+import { formattingKeymap } from './formatting';
 import { frontmatterCard } from './frontmatterCard';
 import { liveMarkdownPreview } from './liveMarkdownPreview';
 import { markdownTables } from './tableWidget';
@@ -219,6 +220,7 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
       brokenLinks({ existsFile }),
       search({ top: true }),
       keymap.of(macSearchKeymap),
+      formattingKeymap(),
       editorTheme,
     ],
     [onFollowLink, existsFile],

--- a/app/src/components/notebook/formatting.test.ts
+++ b/app/src/components/notebook/formatting.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { toggleInlineFormat, type InlineMarkType } from './formatting';
+
+function stateFor(doc: string, selection: { anchor: number; head?: number }): EditorState {
+  return EditorState.create({
+    doc,
+    selection,
+    extensions: [markdown({ base: markdownLanguage })],
+  });
+}
+
+describe('toggleInlineFormat', () => {
+  it('wraps a nonempty selection with strong markers, selecting the wrapped text', () => {
+    const doc = 'hello world';
+    const state = stateFor(doc, { anchor: 6, head: 11 }); // "world"
+    const next = state.update(toggleInlineFormat(state, 'strong')!);
+    expect(next.state.doc.toString()).toBe('hello **world**');
+    const range = next.state.selection.main;
+    expect(next.state.sliceDoc(range.from, range.to)).toBe('world');
+  });
+
+  it('unwraps when the cursor is inside a StrongEmphasis node', () => {
+    const doc = '**world**';
+    const state = stateFor(doc, { anchor: 4 }); // inside "world"
+    const next = state.update(toggleInlineFormat(state, 'strong')!);
+    expect(next.state.doc.toString()).toBe('world');
+  });
+
+  it('wraps the whole word under a bare cursor, keeping the cursor within it', () => {
+    const doc = 'hello world';
+    const state = stateFor(doc, { anchor: 8 }); // mid "world"
+    const next = state.update(toggleInlineFormat(state, 'strong')!);
+    expect(next.state.doc.toString()).toBe('hello **world**');
+    const pos = next.state.selection.main.head;
+    expect(pos).toBeGreaterThanOrEqual('hello **'.length);
+    expect(pos).toBeLessThanOrEqual('hello **world'.length);
+  });
+
+  it('inserts an empty marker pair with a centered cursor when there is no word', () => {
+    const doc = 'hello   world'; // cursor sits in the run of spaces (index 6)
+    const state = stateFor(doc, { anchor: 6 });
+    const next = state.update(toggleInlineFormat(state, 'strong')!);
+    expect(next.state.doc.toString()).toBe(doc.slice(0, 6) + '****' + doc.slice(6));
+    const head = next.state.selection.main.head;
+    expect(next.state.sliceDoc(head - 2, head)).toBe('**');
+    expect(next.state.sliceDoc(head, head + 2)).toBe('**');
+  });
+
+  it('emphasis inside bold wraps the word rather than stripping the bold', () => {
+    const doc = '**bold**';
+    const state = stateFor(doc, { anchor: 4 }); // inside "bold", within the StrongEmphasis
+    const next = state.update(toggleInlineFormat(state, 'emphasis')!);
+    expect(next.state.doc.toString()).toBe('***bold***');
+  });
+
+  it('unwraps inline code using the CodeMark node ranges, including double backticks', () => {
+    const doc = 'see ``x`` here';
+    const state = stateFor(doc, { anchor: 6 }); // inside the double-backtick span
+    const next = state.update(toggleInlineFormat(state, 'code')!);
+    expect(next.state.doc.toString()).toBe('see x here');
+  });
+
+  it('wraps two cursors on two different words independently', () => {
+    const doc = 'alpha beta';
+    const base = EditorState.create({
+      doc,
+      // Multi-range selections are collapsed to one by default; opt in explicitly.
+      extensions: [markdown({ base: markdownLanguage }), EditorState.allowMultipleSelections.of(true)],
+    });
+    const state = base.update({
+      selection: EditorSelection.create([EditorSelection.cursor(2), EditorSelection.cursor(8)]),
+    }).state;
+    const next = state.update(toggleInlineFormat(state, 'strong')!);
+    expect(next.state.doc.toString()).toBe('**alpha** **beta**');
+  });
+
+  it('round-trips wrap then unwrap back to the original doc (strong, emphasis, code)', () => {
+    const cases: Array<[InlineMarkType, string]> = [
+      ['strong', 'hello world'],
+      ['emphasis', 'hello world'],
+      ['code', 'hello world'],
+    ];
+    for (const [type, doc] of cases) {
+      const state = stateFor(doc, { anchor: 6, head: 11 });
+      const wrapped = state.update(toggleInlineFormat(state, type)!);
+      const unwrapped = wrapped.state.update(toggleInlineFormat(wrapped.state, type)!);
+      expect(unwrapped.state.doc.toString()).toBe(doc);
+    }
+  });
+});

--- a/app/src/components/notebook/formatting.ts
+++ b/app/src/components/notebook/formatting.ts
@@ -4,7 +4,7 @@
 // (adds `*…*`) rather than mistaking the enclosing StrongEmphasis for a match — Emphasis
 // and StrongEmphasis are distinct Lezer node types.
 
-import { EditorSelection, type EditorState, type Extension, type TransactionSpec } from '@codemirror/state';
+import { EditorSelection, Prec, type EditorState, type Extension, type TransactionSpec } from '@codemirror/state';
 import { EditorView, keymap, type KeyBinding } from '@codemirror/view';
 import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
 import type { SyntaxNode } from '@lezer/common';
@@ -133,5 +133,9 @@ export function formattingKeymap(): Extension {
     { key: 'Cmd-i', run: toggleCommand('emphasis') },
     { key: 'Cmd-e', run: toggleCommand('code') },
   ];
-  return keymap.of(bindings);
+  // Prec.high: basicSetup's defaultKeymap binds Mod-i to selectParentSyntax with
+  // preventDefault, which at equal precedence runs first (basicSetup is earlier in
+  // LiveMarkdownEditor's extension array) and swallows Cmd-i entirely — it expands the
+  // selection instead of toggling italics. Prec.high makes these bindings win.
+  return Prec.high(keymap.of(bindings));
 }

--- a/app/src/components/notebook/formatting.ts
+++ b/app/src/components/notebook/formatting.ts
@@ -1,0 +1,137 @@
+// ⌘B/⌘I/⌘E toggle bold/italic/inline-code marks in the Notebook's live markdown editor.
+// "Already formatted" is detected from the markdown parser's syntax tree, not by
+// scanning characters around the cursor, so toggling emphasis inside a bold run wraps
+// (adds `*…*`) rather than mistaking the enclosing StrongEmphasis for a match — Emphasis
+// and StrongEmphasis are distinct Lezer node types.
+
+import { EditorSelection, type EditorState, type Extension, type TransactionSpec } from '@codemirror/state';
+import { EditorView, keymap, type KeyBinding } from '@codemirror/view';
+import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
+import type { SyntaxNode } from '@lezer/common';
+
+export type InlineMarkType = 'strong' | 'emphasis' | 'code';
+
+interface MarkConfig {
+  nodeName: 'StrongEmphasis' | 'Emphasis' | 'InlineCode';
+  markNodeName: 'EmphasisMark' | 'CodeMark';
+  marker: string;
+}
+
+const CONFIGS: Record<InlineMarkType, MarkConfig> = {
+  strong: { nodeName: 'StrongEmphasis', markNodeName: 'EmphasisMark', marker: '**' },
+  emphasis: { nodeName: 'Emphasis', markNodeName: 'EmphasisMark', marker: '*' },
+  code: { nodeName: 'InlineCode', markNodeName: 'CodeMark', marker: '`' },
+};
+
+// Walk up from `node` looking for an ancestor named `nodeName` whose span fully
+// contains [from, to]. Because Emphasis and StrongEmphasis are separate node types,
+// a lookup for one never matches the other.
+function findEnclosing(node: SyntaxNode, nodeName: string, from: number, to: number): SyntaxNode | null {
+  let cur: SyntaxNode | null = node;
+  while (cur) {
+    if (cur.name === nodeName && cur.from <= from && cur.to >= to) return cur;
+    cur = cur.parent;
+  }
+  return null;
+}
+
+// Map a position through two deletions (the open/close mark ranges), both expressed
+// in the original document's coordinates and applied as one local change set.
+function afterDeletions(
+  pos: number,
+  openFrom: number,
+  openTo: number,
+  closeFrom: number,
+  closeTo: number,
+): number {
+  let result = pos;
+  if (pos >= openTo) result -= openTo - openFrom;
+  if (pos >= closeTo) result -= closeTo - closeFrom;
+  return result;
+}
+
+// Toggle `type` across every selection range via changeByRange, so multi-cursor
+// selections all flip together. Returns null when the selection is empty of ranges
+// (never happens in practice — EditorSelection always has at least one — but keeps
+// the contract honest for callers).
+export function toggleInlineFormat(state: EditorState, type: InlineMarkType): TransactionSpec | null {
+  const config = CONFIGS[type];
+  if (state.selection.ranges.length === 0) return null;
+
+  return state.changeByRange((range) => {
+    // The tree is available synchronously for the selection's vicinity; fall back to
+    // whatever's already parsed if the budget is exhausted rather than blocking.
+    const tree = ensureSyntaxTree(state, range.to, 50) ?? syntaxTree(state);
+    const resolved = tree.resolveInner(range.from, 1);
+    const enclosing = findEnclosing(resolved, config.nodeName, range.from, range.to);
+    const marks = enclosing?.getChildren(config.markNodeName) ?? [];
+
+    if (enclosing && marks.length >= 2) {
+      // Unwrap: delete the mark nodes using their actual ranges (inline code can be
+      // fenced with more than one backtick), keep the text between them.
+      const open = marks[0];
+      const close = marks[marks.length - 1];
+      const changes = [
+        { from: open.from, to: open.to, insert: '' },
+        { from: close.from, to: close.to, insert: '' },
+      ];
+      const map = (pos: number) => afterDeletions(pos, open.from, open.to, close.from, close.to);
+      return { changes, range: EditorSelection.range(map(range.from), map(range.to)) };
+    }
+
+    if (!range.empty) {
+      // Wrap a nonempty selection: markers land outside it, selection stays on the text.
+      const changes = [
+        { from: range.from, insert: config.marker },
+        { from: range.to, insert: config.marker },
+      ];
+      return {
+        changes,
+        range: EditorSelection.range(
+          range.from + config.marker.length,
+          range.to + config.marker.length,
+        ),
+      };
+    }
+
+    const word = state.wordAt(range.head);
+    if (word) {
+      // Empty selection on a word: wrap the whole word, keep the cursor at its
+      // original position (now shifted past the opening marker).
+      const changes = [
+        { from: word.from, insert: config.marker },
+        { from: word.to, insert: config.marker },
+      ];
+      return { changes, range: EditorSelection.cursor(range.head + config.marker.length) };
+    }
+
+    // Empty selection, no word under it (whitespace or an empty line): insert the
+    // marker pair and place the cursor between them.
+    const pair = config.marker + config.marker;
+    return {
+      changes: { from: range.head, insert: pair },
+      range: EditorSelection.cursor(range.head + config.marker.length),
+    };
+  });
+}
+
+function toggleCommand(type: InlineMarkType) {
+  return (view: EditorView): boolean => {
+    const spec = toggleInlineFormat(view.state, type);
+    if (!spec) return false;
+    view.dispatch(spec);
+    return true;
+  };
+}
+
+// Explicit Cmd- (not Mod-) bindings: CodeMirror resolves Mod- via navigator.platform
+// sniffing, which is wrong on non-macOS browsers (e.g. Linux CI). This app is
+// macOS-only, so Cmd is always the correct key.
+export function formattingKeymap(): Extension {
+  const bindings: KeyBinding[] = [
+    { key: 'Cmd-b', run: toggleCommand('strong') },
+    { key: 'Cmd-i', run: toggleCommand('emphasis') },
+    { key: 'Cmd-e', run: toggleCommand('code') },
+  ];
+  return keymap.of(bindings);
+}


### PR DESCRIPTION
## Summary
PR5 of the notebook-editor-polish plan (docs/plans/2026-07-11-notebook-editor-polish.md).

- Adds a CodeMirror formatting keymap: ⌘B/⌘I/⌘E toggle bold, italic, and inline code around the current selection or the word under the cursor; pressing again removes the markers.
- Raises the keymap's precedence (`Prec.high`) over basicSetup's `defaultKeymap`, which binds `Mod-i` to `selectParentSyntax` and would otherwise shadow ⌘I.

## Test plan
- [x] `go build ./...`
- [x] `pnpm exec vitest run` (app/) — 148 files / 1455 tests passed, including new `formatting.test.ts`
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec playwright test e2e/notebook-browser.spec.ts` — all 12 pass, including the new Cmd+B/I/E test that exercises a real DOM keydown through the full CodeMirror extension stack (this is what caught the Mod-i precedence bug in the first place)
- [x] Confirmed no native macOS Edit-menu accelerator claims Cmd+B/I/E (grepped `app/src-tauri/src/lib.rs`), so this doesn't need packaged-app harness verification per AGENTS.md's menu-intercept trap — the e2e keydown test is the right surface here
- [x] Live-built and installed the dev app (`make dev`) to confirm the branch builds and installs cleanly

Claude-Session: https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT