### PR TITLE
feat(diagnostics): self-healing watchdog repairs persistently clipped terminal panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Fixed
 - **Terminal panes no longer get stuck at a stale size.** Some panes could stay rendered at a stale, historical size after a session reattach — bottom or right edges painted outside the pane — until the pane was reopened. They now recover on their own.
+- Terminals that still end up painted outside their pane now self-heal within seconds — the app detects the mismatch and refits the terminal automatically, and records what it repaired.
 - **Undo and redo now work in the Notebook editor.** ⌘Z and ⇧⌘Z were swallowed by the native Edit menu in the packaged app and never reached the editor; they now undo/redo your edits when the editor has focus. ⇧⌘Z still zooms the active pane when you're not in a text field.
 - **⌘⌥N and ⇧⌘⌥N open the Notebook again.** With Option held, macOS reports a dead-key character instead of the letter, so the notebook shortcuts never matched in the installed app and the keystroke fell through into the terminal. They now match on the physical key.
 

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -1881,6 +1881,12 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             canvasPixelWidth: activeCanvas?.width ?? null,
             canvasPixelHeight: activeCanvas?.height ?? null,
           };
+        }, () => {
+          // Watchdog repair: re-assert container-truth geometry. fit() self-bails
+          // (sameSize / inactiveSession) so a spurious call is harmless; a fresh
+          // queued replay defers it via the replayPending skip, and the staleness
+          // bound guarantees a lying queue cannot defer it forever.
+          fitRef.current();
         });
         inputRef.current = new InputHandler(
           ghostty,

--- a/app/src/utils/terminalDiagnosticsLog.test.ts
+++ b/app/src/utils/terminalDiagnosticsLog.test.ts
@@ -344,3 +344,176 @@ describe('bottom-clip detector', () => {
     expect(ringEventsFor(pane).filter((event) => event.kind === 'incident')).toHaveLength(0);
   });
 });
+
+describe('clip repair watchdog', () => {
+  beforeEach(() => {
+    window.localStorage.setItem('attn:terminal-diagnostics', '1');
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const probeWith = (over: Partial<RenderProbe>): RenderProbe => ({
+    cols: 80,
+    rows: 24,
+    modelPrintable: 100,
+    lastPaintAt: Date.now(),
+    lastPaintQuads: 100,
+    active: true,
+    ...over,
+  });
+
+  // A grid one row taller than its container — 26 rows at 21px, 540px client
+  // height, so floor(540/21)=25 rows fit and there is a persistent 6px spill.
+  const clippingGeometry: Partial<RenderProbe> = {
+    rows: 26, cellHeight: 21, clientHeight: 540, cellWidth: 9, clientWidth: 720,
+    session: 's-repair',
+  };
+  const fittingGeometry: Partial<RenderProbe> = {
+    rows: 25, cellHeight: 21, clientHeight: 525, cellWidth: 9, clientWidth: 720,
+    session: 's-repair',
+  };
+
+  it('waits for the 3rd consecutive clipping sweep before the first repair', () => {
+    const pane = 'pane-repair-persistent';
+    const repair = vi.fn();
+    const unregister = registerRenderProbe(pane, () => probeWith(clippingGeometry), repair);
+    try {
+      vi.advanceTimersByTime(1600);
+      vi.advanceTimersByTime(1600);
+      expect(repair).toHaveBeenCalledTimes(0);
+
+      vi.advanceTimersByTime(1600);
+      expect(repair).toHaveBeenCalledTimes(1);
+    } finally {
+      unregister();
+    }
+  });
+
+  it('never repairs a clip that clears on the 2nd sweep', () => {
+    const pane = 'pane-repair-transient';
+    const repair = vi.fn();
+    let clipping = true;
+    const unregister = registerRenderProbe(
+      pane,
+      () => probeWith(clipping ? clippingGeometry : fittingGeometry),
+      repair,
+    );
+    try {
+      vi.advanceTimersByTime(1600); // sweep 1: clipping
+      clipping = false;
+      vi.advanceTimersByTime(1600); // sweep 2: clear
+      vi.advanceTimersByTime(20000); // long tail, in case a stray timer fires late
+
+      expect(repair).toHaveBeenCalledTimes(0);
+    } finally {
+      unregister();
+    }
+  });
+
+  // Sweep ticks land on multiples of BOTTOM_CLIP_SWEEP_MS (1500ms). A repair
+  // only fires once Date.now() >= nextAttemptAtMs AT a sweep tick, so the
+  // observed delay is the backoff rounded UP to the next tick, never short of it.
+  it('backs off 3000ms before the 2nd repair and 10000ms before the 3rd, with the clip persisting', () => {
+    const pane = 'pane-repair-backoff';
+    const repair = vi.fn();
+    const unregister = registerRenderProbe(pane, () => probeWith(clippingGeometry), repair);
+    try {
+      vi.advanceTimersByTime(4500); // t=4500: 3rd sweep -> 1st repair fires
+      expect(repair).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(1500); // t=6000, only 1500ms after the 1st repair
+      expect(repair).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(1500); // t=7500, 3000ms after the 1st repair
+      expect(repair).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(9000); // t=16500, 9000ms after the 2nd repair (< 10000ms)
+      expect(repair).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(1500); // t=18000, first tick >= 10000ms after the 2nd repair
+      expect(repair).toHaveBeenCalledTimes(3);
+    } finally {
+      unregister();
+    }
+  });
+
+  it('gives up after 3 failed repairs and records exactly one give-up incident', () => {
+    const pane = 'pane-repair-give-up';
+    const repair = vi.fn();
+    const unregister = registerRenderProbe(pane, () => probeWith(clippingGeometry), repair);
+    try {
+      vi.advanceTimersByTime(4500); // t=4500: 1st repair
+      vi.advanceTimersByTime(3000); // t=7500: 2nd repair (3000ms backoff)
+      vi.advanceTimersByTime(10500); // t=18000: first tick >= 10000ms after the 2nd -> 3rd repair
+      expect(repair).toHaveBeenCalledTimes(3);
+
+      vi.advanceTimersByTime(60000); // clip persists well past the 3rd attempt's backoff
+      expect(repair).toHaveBeenCalledTimes(3); // no 4th attempt — the watchdog gave up
+
+      const giveUps = ringEventsFor(pane)
+        .filter((event) => event.kind === 'incident' && event.reason === 'bottom_clip_repair_gave_up');
+      expect(giveUps).toHaveLength(1);
+      expect(giveUps[0]?.attempts).toBe(3);
+    } finally {
+      unregister();
+    }
+  });
+
+  it('carries repairAttempts on the resolution incident after one repair fired', () => {
+    const pane = 'pane-repair-resolved';
+    const repair = vi.fn();
+    let clipping = true;
+    const unregister = registerRenderProbe(
+      pane,
+      () => probeWith(clipping ? clippingGeometry : fittingGeometry),
+      repair,
+    );
+    try {
+      vi.advanceTimersByTime(4500); // 3 sweeps: 1st repair fires
+      expect(repair).toHaveBeenCalledTimes(1);
+      clipping = false;
+      vi.advanceTimersByTime(1600); // clip clears
+
+      const resolved = ringEventsFor(pane)
+        .filter((event) => event.kind === 'incident' && event.reason === 'bottom_clip_resolved');
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0]?.repairAttempts).toBe(1);
+    } finally {
+      unregister();
+    }
+  });
+
+  it('never repairs an inactive pane even with overflowing geometry', () => {
+    const pane = 'pane-repair-inactive';
+    const repair = vi.fn();
+    const unregister = registerRenderProbe(
+      pane,
+      () => probeWith({ ...clippingGeometry, active: false }),
+      repair,
+    );
+    try {
+      vi.advanceTimersByTime(20000);
+      expect(repair).toHaveBeenCalledTimes(0);
+    } finally {
+      unregister();
+    }
+  });
+
+  it('still logs bottom_clip incidents (and does not throw) for a pane with no repair handler', () => {
+    const pane = 'pane-repair-none';
+    const unregister = registerRenderProbe(pane, () => probeWith(clippingGeometry));
+    try {
+      expect(() => {
+        vi.advanceTimersByTime(20000);
+      }).not.toThrow();
+
+      const incidents = ringEventsFor(pane).filter((event) => event.kind === 'incident' && event.reason === 'bottom_clip');
+      expect(incidents).toHaveLength(1);
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/app/src/utils/terminalDiagnosticsLog.ts
+++ b/app/src/utils/terminalDiagnosticsLog.ts
@@ -58,6 +58,16 @@ const BOTTOM_CLIP_SWEEP_MS = 1500;
 // Pixel slack mirroring geometryOverflowsContainer: ignore sub-pixel container
 // heights so we only act on a genuine extra row.
 const BOTTOM_CLIP_SLACK_PX = 1;
+// Wait this many consecutive clipping sweeps before the first repair
+// (3 sweeps ≈ 4.5s at the sweep cadence) — beyond the longest observed
+// legitimate attach-replay transient, so the watchdog never fights a
+// clip that heals on its own.
+const CLIP_REPAIR_AFTER_SWEEPS = 3;
+// Wall-clock delay before the 2nd and 3rd repair attempts.
+const CLIP_REPAIR_BACKOFF_MS = [3000, 10000];
+// After this many failed repairs, stop and record a give-up incident;
+// the pane is beyond a refit's reach (e.g. dead renderer).
+const CLIP_REPAIR_MAX_ATTEMPTS = 3;
 
 export type DiagKind =
   | 'pane_mount'
@@ -190,10 +200,19 @@ let ringNextIndex = 0;
 let ringWrapped = false;
 const paneHealth = new Map<string, PaneHealth>();
 const renderProbes = new Map<string, () => RenderProbe | null>();
+// Optional per-pane repair callback (a refit) for the bottom-clip watchdog.
+const repairHandlers = new Map<string, () => void>();
 const watchdogTimers = new Map<string, ReturnType<typeof setTimeout>[]>();
 // Per-pane "currently clipping at the bottom" flag so the detector reports the
 // clip's onset (and its resolution) once, not on every sweep tick.
 const clipState = new Map<string, boolean>();
+// Per-pane bottom-clip repair progress: consecutive clipping sweeps, repair
+// attempts made, the earliest wall-clock time the next attempt may fire, and
+// whether the watchdog has given up on this continuous clip.
+const clipRepairState = new Map<
+  string,
+  { clippingSweeps: number; attempts: number; nextAttemptAtMs: number; gaveUp: boolean }
+>();
 let clipSweepTimer: ReturnType<typeof setInterval> | null = null;
 
 let lifecycleBytes = 0;
@@ -438,12 +457,21 @@ export function recordPaint(sample: PaintSample): void {
   }
 }
 
-export function registerRenderProbe(pane: string, probe: () => RenderProbe | null): () => void {
+export function registerRenderProbe(
+  pane: string,
+  probe: () => RenderProbe | null,
+  repair?: () => void,
+): () => void {
   renderProbes.set(pane, probe);
+  if (repair) {
+    repairHandlers.set(pane, repair);
+  }
   ensureClipSweep();
   return () => {
     renderProbes.delete(pane);
+    repairHandlers.delete(pane);
     clipState.delete(pane);
+    clipRepairState.delete(pane);
     stopClipSweepIfIdle();
   };
 }
@@ -645,6 +673,28 @@ function recordBottomClipIncident(pane: string, detail: Record<string, unknown>)
   enqueueWrite('incident', `${JSON.stringify(record)}\n`);
 }
 
+function recordBottomClipRepairIncident(
+  pane: string,
+  reason: 'bottom_clip_repair' | 'bottom_clip_repair_gave_up',
+  detail: Record<string, unknown>,
+  session?: string,
+): void {
+  const now = Date.now();
+  const marker: DiagEvent = { at: now, kind: 'incident', pane, session, reason, ...detail };
+  pushRing(marker);
+  enqueueWrite('lifecycle', `${JSON.stringify(marker)}\n`);
+  const record = {
+    at: now,
+    kind: 'incident',
+    pane,
+    session,
+    reason,
+    detail,
+    context: ringSnapshot().slice(-INCIDENT_CONTEXT_EVENTS),
+  };
+  enqueueWrite('incident', `${JSON.stringify(record)}\n`);
+}
+
 function sweepBottomClip(): void {
   if (typeof window === 'undefined' || !isEnabled()) {
     return;
@@ -663,6 +713,7 @@ function sweepBottomClip(): void {
     // clips re-reports the onset.
     if (!probe || !probe.active) {
       if (wasClipping) clipState.set(pane, false);
+      clipRepairState.delete(pane);
       continue;
     }
     const overflowPx = bottomClipOverflowPx(probe);
@@ -674,6 +725,7 @@ function sweepBottomClip(): void {
       overflowPx == null && domOverflow == null && domOffset == null
       && domOverflowRight == null && domOffsetLeft == null
     ) {
+      clipRepairState.delete(pane);
       continue;
     }
     const trigger: string[] = [];
@@ -683,14 +735,46 @@ function sweepBottomClip(): void {
     if (domOverflowRight != null && domOverflowRight > BOTTOM_CLIP_SLACK_PX) trigger.push('dom_overflow_right');
     if (domOffsetLeft != null && domOffsetLeft > BOTTOM_CLIP_SLACK_PX) trigger.push('dom_offset_left');
     const clipping = trigger.length > 0;
-    if (clipping === wasClipping) {
-      continue;
-    }
-    clipState.set(pane, clipping);
     const cellHeight = probe.cellHeight ?? 0;
     const clientHeight = probe.clientHeight ?? 0;
     const flooredRows = cellHeight > 0 ? Math.floor(clientHeight / cellHeight) : 0;
-    if (clipping) {
+
+    if (!clipping) {
+      // Full reset: the clip is gone (or never started this sweep). Keep the
+      // existing edge-triggered incident/resolve logging as-is, but attach how
+      // many repairs were attempted during the episode that just ended.
+      const priorState = clipRepairState.get(pane);
+      clipRepairState.delete(pane);
+      if (clipping === wasClipping) {
+        continue;
+      }
+      clipState.set(pane, clipping);
+      recordDiag({
+        kind: 'incident',
+        pane,
+        session: probe.session,
+        reason: 'bottom_clip_resolved',
+        rows: probe.rows,
+        cols: probe.cols,
+        flooredRows,
+        overflowPx: overflowPx == null ? null : Math.round(overflowPx),
+        domOverflowPx: domOverflow == null ? null : Math.round(domOverflow),
+        domOffsetTopPx: domOffset == null ? null : Math.round(domOffset),
+        domOverflowRightPx: domOverflowRight == null ? null : Math.round(domOverflowRight),
+        domOffsetLeftPx: domOffsetLeft == null ? null : Math.round(domOffsetLeft),
+        cellHeight,
+        clientHeight,
+        repairAttempts: priorState?.attempts ?? 0,
+      });
+      continue;
+    }
+
+    // Clipping is true on this sweep. Edge-triggered incident logging fires
+    // only on the onset (matching the pre-watchdog behavior), but repair
+    // evaluation runs on EVERY clipping sweep so backoff/attempts advance
+    // while the clip persists.
+    clipState.set(pane, clipping);
+    if (clipping !== wasClipping) {
       recordBottomClipIncident(pane, {
         rows: probe.rows,
         cols: probe.cols,
@@ -716,25 +800,50 @@ function sweepBottomClip(): void {
         winInnerWidth: window.innerWidth,
         winInnerHeight: window.innerHeight,
       });
-    } else {
-      // The clip cleared (a remount, a window resize that re-fit, or an
-      // activation refit). Record what fixed it so the trail is self-describing.
-      recordDiag({
-        kind: 'incident',
-        pane,
-        session: probe.session,
-        reason: 'bottom_clip_resolved',
-        rows: probe.rows,
-        cols: probe.cols,
-        flooredRows,
-        overflowPx: overflowPx == null ? null : Math.round(overflowPx),
-        domOverflowPx: domOverflow == null ? null : Math.round(domOverflow),
-        domOffsetTopPx: domOffset == null ? null : Math.round(domOffset),
-        domOverflowRightPx: domOverflowRight == null ? null : Math.round(domOverflowRight),
-        domOffsetLeftPx: domOffsetLeft == null ? null : Math.round(domOffsetLeft),
-        cellHeight,
-        clientHeight,
-      });
+    }
+
+    const repair = repairHandlers.get(pane);
+    const state = clipRepairState.get(pane) ?? {
+      clippingSweeps: 0,
+      attempts: 0,
+      nextAttemptAtMs: 0,
+      gaveUp: false,
+    };
+    state.clippingSweeps += 1;
+    clipRepairState.set(pane, state);
+
+    if (
+      repair
+      && document.visibilityState === 'visible'
+      && state.clippingSweeps >= CLIP_REPAIR_AFTER_SWEEPS
+      && !state.gaveUp
+      && Date.now() >= state.nextAttemptAtMs
+    ) {
+      if (state.attempts >= CLIP_REPAIR_MAX_ATTEMPTS) {
+        state.gaveUp = true;
+        recordBottomClipRepairIncident(pane, 'bottom_clip_repair_gave_up', {
+          rows: probe.rows,
+          cols: probe.cols,
+          attempts: state.attempts,
+        }, probe.session);
+      } else {
+        state.attempts += 1;
+        const backoff = CLIP_REPAIR_BACKOFF_MS[state.attempts - 1] ?? CLIP_REPAIR_BACKOFF_MS[CLIP_REPAIR_BACKOFF_MS.length - 1];
+        state.nextAttemptAtMs = Date.now() + backoff;
+        recordBottomClipRepairIncident(pane, 'bottom_clip_repair', {
+          attempt: state.attempts,
+          rows: probe.rows,
+          cols: probe.cols,
+          overflowPx: overflowPx == null ? null : Math.round(overflowPx),
+          domOverflowPx: domOverflow == null ? null : Math.round(domOverflow),
+        }, probe.session);
+        try {
+          repair();
+        } catch {
+          // The next sweep re-evaluates; a repair handler throwing must not
+          // break the sweep loop for other panes.
+        }
+      }
     }
   }
 }
@@ -816,7 +925,9 @@ export function disposePaneDiagnostics(pane: string): void {
   clearWatchdog(pane);
   paneHealth.delete(pane);
   renderProbes.delete(pane);
+  repairHandlers.delete(pane);
   clipState.delete(pane);
+  clipRepairState.delete(pane);
   stopClipSweepIfIdle();
 }
 


### PR DESCRIPTION
## Summary

Layer 2 on top of #537 (just merged). #537 fixed the root cause found in prod telemetry (stale replay geometry suppressing the corrective fit). This PR adds a structural guarantee on top: the existing 1.5s DOM-truth bottom-clip sweep in `terminalDiagnosticsLog.ts` now actively **repairs** a persistently clipped pane instead of only detecting it.

- After 3 consecutive clipping sweeps (~4.5s — beyond the longest observed legitimate transient), the watchdog invokes the pane's registered repair handler (a refit).
- Backoff: 3s, then 10s between repair attempts, max 3 attempts, then a one-time `bottom_clip_repair_gave_up` incident.
- `bottom_clip_resolved` telemetry now carries `repairAttempts`.
- Repairs only run for visible, active panes.

Net effect: any future stale-geometry path (not just the one fixed in #537) converges within seconds instead of sticking until remount.

## Verification

Done by the lead prior to handoff:
- Full frontend unit suite green (146 files / 1443 tests) + `tsc --noEmit` clean, re-verified after rebase (42/42 targeted tests).
- Live packaged-app verification on a throwaway `offsetfix` profile built from this branch: `real-app:scenario-reveal-overflow` passed, and `real-app:scenario-offset-soak --seed 3 --iterations 120` passed (0 persistent violations, 3 transients). The profile's incident log showed 4 transient `bottom_clip` onsets and ZERO `bottom_clip_repair` events — the watchdog correctly stays quiet on clips that heal within its 3-sweep threshold; no repair loops or false positives.

Re-verified locally before opening this PR:
- `pnpm vitest run src/utils/terminalDiagnosticsLog.test.ts src/components/GhosttyTerminal.resizePolicy.test.ts` — 42/42 passed.
- `pnpm exec tsc --noEmit` — clean.