### PR TITLE
feat(notebook): render whole-line images inline via daemon-resolved sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Richer live-preview rendering in the Notebook editor.** Code fences now get language syntax highlighting, and blockquotes and horizontal rules render styled instead of as raw markers.
 - **Markdown tables in the Notebook editor** now render as real tables, with raw source revealed for editing when the cursor is inside (click a row to edit it).
 - **⌘B/⌘I/⌘E toggle bold, italic, and inline code in the Notebook editor.** Wraps the selection or the word under the cursor; press again to remove.
+- **Images now render inline in the Notebook editor.** A `![alt](path)` on its own line shows the picture itself, with a "not found" placeholder if the file can't be located; click the image to see (and edit) its raw markdown.
 
 ### Fixed
 - **Terminal panes no longer get stuck at a stale size.** Some panes could stay rendered at a stale, historical size after a session reattach — bottom or right edges painted outside the pane — until the pane was reopened. They now recover on their own.

--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -313,6 +313,20 @@ test.describe('NotebookBrowser (fs surface)', () => {
     await page.locator('.cm-md-image').click();
     await expect(page.locator('.cm-md-image')).toHaveCount(0);
     await expect(page.locator('.cm-content')).toContainText('![tiny](assets/tiny.png)');
+
+    // Regression: the widget's eq() is deliberately position-blind (alt/src only) so
+    // an edit ABOVE it doesn't recreate its DOM (which would flicker/reload the image).
+    // But that means the click handler must read its position from the view at click
+    // time, not from a value captured when the DOM was built — otherwise editing above
+    // the image (shifting it down) leaves a click landing on the stale, pre-edit offset.
+    await page.locator('.cm-content').getByText('Images', { exact: true }).click();
+    await page.keyboard.press('Home');
+    await page.keyboard.type('\n\n');
+    await expect(page.locator('.cm-md-image')).toBeVisible();
+
+    await page.locator('.cm-md-image').click();
+    await expect(page.locator('.cm-md-image')).toHaveCount(0);
+    await expect(page.locator('.cm-content')).toContainText('![tiny](assets/tiny.png)');
   });
 
   // CodeMirror renders each line as one text node, so a text-content locator can't

--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -285,6 +285,36 @@ test.describe('NotebookBrowser (fs surface)', () => {
     await expect(page.locator('.cm-content')).toContainText('| one');
   });
 
+  test('renders an inline image as a widget wired to readAsset, shows a broken placeholder for a missing asset, and reveals raw source on click', async ({ page }) => {
+    await page.goto('/test-harness/?component=NotebookBrowser');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.getByRole('heading', { level: 2, name: 'index' }).waitFor();
+
+    await page.getByRole('treeitem', { name: 'images.md' }).click();
+    await expect(page.getByRole('heading', { level: 2, name: 'images' })).toBeVisible();
+
+    // The resolvable image renders as a real <img>, sourced from readAsset's bytes as
+    // a data: URI (never a bare notebook-relative path — the editor has no fs perms).
+    const img = page.locator('.cm-md-image img');
+    await expect(img).toBeVisible();
+    await expect(img).toHaveAttribute('src', /^data:image\/png;base64,/);
+    const checked = await page.evaluate(() => window.__HARNESS__.getCalls('readAsset').map((c) => c[0]));
+    expect(checked).toContain('assets/tiny.png');
+
+    // The missing asset shows the broken placeholder, not a blank/broken <img>.
+    const broken = page.locator('.cm-md-image-broken');
+    await expect(broken).toBeVisible();
+    await expect(broken).toContainText('gone');
+    await expect(broken).toContainText('image not found');
+
+    // Clicking the rendered widget's line reveals its raw markdown — the
+    // regression-prone part: if the selection-intersection reveal rule breaks, the
+    // widget never yields back to raw text.
+    await page.locator('.cm-md-image').click();
+    await expect(page.locator('.cm-md-image')).toHaveCount(0);
+    await expect(page.locator('.cm-content')).toContainText('![tiny](assets/tiny.png)');
+  });
+
   // CodeMirror renders each line as one text node, so a text-content locator can't
   // isolate a single word for dblclick; find the word's on-screen rect via a DOM
   // Range instead and double-click its center.

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -563,6 +563,7 @@ function App() {
     sendFsRename,
     sendFsDelete,
     sendFsExists,
+    sendFsReadAsset,
     sendTaskList,
     sendTaskRetry,
     sendNotificationList,
@@ -758,6 +759,7 @@ function App() {
         sendFsRename={sendFsRename}
         sendFsDelete={sendFsDelete}
         sendFsExists={sendFsExists}
+        sendFsReadAsset={sendFsReadAsset}
         sendTaskList={sendTaskList}
         sendTaskRetry={sendTaskRetry}
         sendNotificationList={sendNotificationList}
@@ -870,6 +872,7 @@ interface AppContentProps {
   sendFsRename: ReturnType<typeof useDaemonSocket>['sendFsRename'];
   sendFsDelete: ReturnType<typeof useDaemonSocket>['sendFsDelete'];
   sendFsExists: ReturnType<typeof useDaemonSocket>['sendFsExists'];
+  sendFsReadAsset: ReturnType<typeof useDaemonSocket>['sendFsReadAsset'];
   sendTaskList: ReturnType<typeof useDaemonSocket>['sendTaskList'];
   sendTaskRetry: ReturnType<typeof useDaemonSocket>['sendTaskRetry'];
   sendNotificationList: ReturnType<typeof useDaemonSocket>['sendNotificationList'];
@@ -976,6 +979,7 @@ function AppContent({
   sendFsRename,
   sendFsDelete,
   sendFsExists,
+  sendFsReadAsset,
   sendTaskList,
   sendTaskRetry,
   sendNotificationList,
@@ -3326,6 +3330,7 @@ sendFetchPRDetails,
     readFile: sendFsRead,
     writeFile: sendFsWrite,
     existsFile: sendFsExists,
+    readAsset: sendFsReadAsset,
     backlinksNotebook: sendNotebookBacklinks,
     sendToChief: sendNotebookToChief,
     // Argless walk = empty prefix = the whole vault, for the in-tile finder index.
@@ -3336,6 +3341,7 @@ sendFetchPRDetails,
     sendFsRead,
     sendFsWrite,
     sendFsExists,
+    sendFsReadAsset,
     sendNotebookBacklinks,
     sendNotebookToChief,
     sendNotebookList,
@@ -3757,6 +3763,7 @@ sendFetchPRDetails,
         readFile={sendFsRead}
         writeFile={sendFsWrite}
         existsFile={sendFsExists}
+        readAsset={sendFsReadAsset}
         backlinksNotebook={sendNotebookBacklinks}
         sendToChief={sendNotebookToChief}
         listFiles={sendNotebookList}

--- a/app/src/components/NotebookBrowser.test.tsx
+++ b/app/src/components/NotebookBrowser.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NotebookBrowser, parseNotebookHref } from './NotebookBrowser';
-import type { FsEntry, FsExistsResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../hooks/useDaemonSocket';
+import type { FsEntry, FsExistsResult, FsReadAssetResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../hooks/useDaemonSocket';
 
 // The live editor is CodeMirror-backed, which cannot mount under happy-dom (its
 // async measure pass throws). The real editing experience (live preview, typing,
@@ -99,6 +99,9 @@ function makeProps(overrides: Partial<React.ComponentProps<typeof NotebookBrowse
   const existsFile = vi
     .fn<(path: string) => Promise<FsExistsResult>>()
     .mockImplementation((path) => Promise.resolve({ path, exists: true }));
+  const readAsset = vi
+    .fn<(path: string) => Promise<FsReadAssetResult>>()
+    .mockImplementation((path) => Promise.resolve({ path, mimeType: 'image/png', dataBase64: '' }));
   const sendToChief = vi
     .fn<(selection: string, sourcePath?: string) => Promise<NotebookSendToChiefResult>>()
     .mockResolvedValue({ path: 'inbox.md', nudged: false });
@@ -112,6 +115,7 @@ function makeProps(overrides: Partial<React.ComponentProps<typeof NotebookBrowse
       backlinksNotebook,
       writeFile,
       existsFile,
+      readAsset,
       sendToChief,
       listFiles,
       changeSignal: 0,
@@ -122,6 +126,7 @@ function makeProps(overrides: Partial<React.ComponentProps<typeof NotebookBrowse
     backlinksNotebook,
     writeFile,
     existsFile,
+    readAsset,
     sendToChief,
   };
 }

--- a/app/src/components/NotebookBrowser.tsx
+++ b/app/src/components/NotebookBrowser.tsx
@@ -1,4 +1,4 @@
-import type { FsEntry, FsExistsResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../hooks/useDaemonSocket';
+import type { FsEntry, FsExistsResult, FsReadAssetResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../hooks/useDaemonSocket';
 import { NotebookSurface } from './NotebookSurface';
 
 // parseNotebookHref / NotebookHref moved to NotebookSurface with the rest of the
@@ -20,6 +20,8 @@ interface NotebookBrowserProps {
   // Check whether an in-notebook link target exists (no read), to flag broken links
   // in the editor. Only consulted for markdown notes.
   existsFile: (path: string) => Promise<FsExistsResult>;
+  // Read an image asset's bytes (base64) for the live editor's inline image widget.
+  readAsset: (path: string) => Promise<FsReadAssetResult>;
   // Backlinks ("Linked from") for a markdown note. Notebook-specific (walks .md link
   // graphs), so it is only consulted for .md files.
   backlinksNotebook: (path: string) => Promise<NotebookEntry[]>;

--- a/app/src/components/NotebookSurface.tsx
+++ b/app/src/components/NotebookSurface.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import FocusTrap from 'focus-trap-react';
-import type { FsEntry, FsExistsResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../hooks/useDaemonSocket';
+import type { FsEntry, FsExistsResult, FsReadAssetResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../hooks/useDaemonSocket';
 import { useEscapeStack } from '../hooks/useEscapeStack';
 import { useNotebookFileIndex } from '../hooks/useNotebookFileIndex';
 import { useTileAutoFold } from '../hooks/useTileAutoFold';
+import { notebookLinkPath } from './notebook/brokenLinks';
 import { FileTree } from './notebook/FileTree';
 import { fileKind, isBinaryPath, isMarkdownPath } from './notebook/fileKind';
 import { parseFrontmatter } from './notebook/frontmatter';
@@ -50,6 +51,9 @@ export interface NotebookSurfaceProps {
   // Check whether an in-notebook link target exists (no read), to flag broken links
   // in the editor. Only consulted for markdown notes.
   existsFile: (path: string) => Promise<FsExistsResult>;
+  // Read an image asset's bytes (base64) for the live editor's inline image widget.
+  // Only consulted for a non-direct src (not http(s)/data:/protocol-relative).
+  readAsset: (path: string) => Promise<FsReadAssetResult>;
   // Backlinks ("Linked from") for a markdown note. Notebook-specific (walks .md link
   // graphs), so it is only consulted for .md files.
   backlinksNotebook: (path: string) => Promise<NotebookEntry[]>;
@@ -97,6 +101,7 @@ export function NotebookSurface({
   readFile,
   writeFile,
   existsFile,
+  readAsset,
   backlinksNotebook,
   sendToChief,
   changeSignal = 0,
@@ -736,6 +741,22 @@ export function NotebookSurface({
     setChiefSel(selection);
   }, []);
 
+  // Resolve an inline image's src for the live editor's image widget: strip any
+  // #fragment/?query tail (notebookLinkPath — same rule brokenLinks uses), then read
+  // the asset's bytes and hand back a data: URI. A non-notebook path (already
+  // rejected by notebookLinkPath) or a failed read both resolve to null, which the
+  // widget renders as its broken placeholder.
+  const resolveImageSrc = useCallback(async (src: string) => {
+    const path = notebookLinkPath(src);
+    if (!path) return null;
+    try {
+      const asset = await readAsset(path);
+      return `data:${asset.mimeType};base64,${asset.dataBase64}`;
+    } catch {
+      return null;
+    }
+  }, [readAsset]);
+
   // The outline is a markdown affordance only, derived from the LIVE buffer so it
   // tracks edits as you type. Indexing into `draft` keeps heading positions aligned
   // with what the editor holds, so a jump lands on the right line. (Hook: must run
@@ -864,6 +885,7 @@ export function NotebookSurface({
                     onFollowLink={handleFollowLink}
                     onSelectionChange={handleSelectionChange}
                     existsFile={existsFile}
+                    resolveImageSrc={resolveImageSrc}
                     revalidateSignal={changeSignal}
                     ariaLabel="Note"
                     onSearchOpenChange={setSearchOpen}

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -15,6 +15,7 @@ import { EditorView, keymap, type KeyBinding, type ViewUpdate } from '@codemirro
 import { brokenLinks, revalidateBrokenLinks, type ExistsCheck } from './brokenLinks';
 import { formattingKeymap } from './formatting';
 import { frontmatterCard } from './frontmatterCard';
+import { imageWidget } from './imageWidget';
 import { liveMarkdownPreview } from './liveMarkdownPreview';
 import { markdownTables } from './tableWidget';
 import { computeMinimalEdit } from './minimalEdit';
@@ -64,6 +65,10 @@ interface LiveMarkdownEditorProps {
   // Check whether an in-notebook link target exists, to flag broken links. Omit to
   // disable the flagging (e.g. the test harness, which has no daemon).
   existsFile?: (path: string) => Promise<ExistsCheck>;
+  // Resolve an in-notebook image src to a displayable src (typically a data: URI) for
+  // the inline image widget. Omit to disable resolution — non-direct image srcs (not
+  // http(s)/data:/protocol-relative) then always render the broken placeholder.
+  resolveImageSrc?: (src: string) => Promise<string | null>;
   // Bumped whenever the notebook changed on disk; clears the broken-link cache's
   // "missing" verdicts so a link to a just-created note re-checks. (A change counter,
   // not data — only its identity change matters.)
@@ -159,6 +164,7 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
   onFollowLink,
   onSelectionChange,
   existsFile,
+  resolveImageSrc,
   revalidateSignal,
   ariaLabel,
   autoFocus,
@@ -216,6 +222,7 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
       EditorView.lineWrapping,
       frontmatterCard(),
       markdownTables(),
+      imageWidget({ resolveSrc: resolveImageSrc }),
       liveMarkdownPreview({ onFollowLink }),
       brokenLinks({ existsFile }),
       search({ top: true }),
@@ -223,7 +230,7 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
       formattingKeymap(),
       editorTheme,
     ],
-    [onFollowLink, existsFile],
+    [onFollowLink, existsFile, resolveImageSrc],
   );
 
   // When the notebook changed on disk, ask the broken-link checker to re-verify any

--- a/app/src/components/notebook/NotebookTile.tsx
+++ b/app/src/components/notebook/NotebookTile.tsx
@@ -23,6 +23,7 @@ export function NotebookTile({
       readFile={daemon.readFile}
       writeFile={daemon.writeFile}
       existsFile={daemon.existsFile}
+      readAsset={daemon.readAsset}
       backlinksNotebook={daemon.backlinksNotebook}
       sendToChief={daemon.sendToChief}
       changeSignal={daemon.changeSignal}

--- a/app/src/components/notebook/imageWidget.test.ts
+++ b/app/src/components/notebook/imageWidget.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { imageTargets, imageWidget } from './imageWidget';
+
+function stateFor(doc: string, selection?: { anchor: number; head?: number }): EditorState {
+  return EditorState.create({
+    doc,
+    selection: selection && EditorSelection.create([EditorSelection.range(selection.anchor, selection.head ?? selection.anchor)]),
+    extensions: [markdown({ base: markdownLanguage }), imageWidget()],
+  });
+}
+
+// The image field is private (only imageTargets/imageWidget are exported), so this
+// mirrors tableWidget.test.ts: read the field's contribution to the standard
+// decorations facet, resolvable from a bare EditorState since imageWidget()'s only
+// decoration source is a StateField.
+function replaceRangeCount(state: EditorState): number {
+  let count = 0;
+  for (const provider of state.facet(EditorView.decorations)) {
+    const set = typeof provider === 'function' ? provider(state as unknown as EditorView) : provider;
+    const iter = set.iter();
+    while (iter.value) {
+      count++;
+      iter.next();
+    }
+  }
+  return count;
+}
+
+describe('imageTargets', () => {
+  it('finds an own-line image with its alt and src', () => {
+    const doc = 'Some text.\n\n![a cat](assets/cat.png)\n\nMore text.';
+    const targets = imageTargets(stateFor(doc));
+    expect(targets).toHaveLength(1);
+    expect(targets[0].alt).toBe('a cat');
+    expect(targets[0].src).toBe('assets/cat.png');
+    const line = doc.split('\n')[2];
+    expect(targets[0].lineFrom).toBe(doc.indexOf(line));
+    expect(targets[0].lineTo).toBe(doc.indexOf(line) + line.length);
+  });
+
+  it('allows surrounding whitespace on the image line', () => {
+    const doc = '  ![a cat](assets/cat.png)  \n';
+    expect(imageTargets(stateFor(doc))).toHaveLength(1);
+  });
+
+  it('does not return an inline image mid-paragraph', () => {
+    const doc = 'Look at this ![a cat](assets/cat.png) right here.';
+    expect(imageTargets(stateFor(doc))).toHaveLength(0);
+  });
+
+  it('does not return a line with text after the image', () => {
+    const doc = '![a cat](assets/cat.png) — isn\'t she cute?';
+    expect(imageTargets(stateFor(doc))).toHaveLength(0);
+  });
+
+  it('does not return either image on a line with two images', () => {
+    const doc = '![one](a.png)![two](b.png)';
+    expect(imageTargets(stateFor(doc))).toHaveLength(0);
+  });
+});
+
+describe('imageWidget reveal gate', () => {
+  const doc = 'Before.\n\n![a cat](assets/cat.png)\n\nAfter.';
+  const imageLine = doc.split('\n')[2];
+  const imageLineFrom = doc.indexOf(imageLine);
+
+  it('renders one block-replace widget when the selection is elsewhere', () => {
+    const state = stateFor(doc, { anchor: 0 });
+    expect(replaceRangeCount(state)).toBe(1);
+  });
+
+  it('reveals raw source (no decoration) when the selection touches the image line', () => {
+    const state = stateFor(doc, { anchor: imageLineFrom + 2 });
+    expect(replaceRangeCount(state)).toBe(0);
+  });
+
+  it('reveals when a selection range overlaps the image line edge', () => {
+    const state = stateFor(doc, { anchor: 0, head: imageLineFrom + 2 });
+    expect(replaceRangeCount(state)).toBe(0);
+  });
+});

--- a/app/src/components/notebook/imageWidget.ts
+++ b/app/src/components/notebook/imageWidget.ts
@@ -1,0 +1,264 @@
+// Inline images (`![alt](src)`) that are the entire content of their own line render
+// as a block image widget, with the raw markdown revealed when a selection touches
+// the line — the same cursor-intersection reveal rule as tableWidget.ts (simpler than
+// frontmatterCard's explicit-edit-mode toggle: an image needs no dedicated editing
+// affordance beyond "click the line to see its source").
+//
+// CM constraint that shapes this file: decorations that affect vertical layout (block
+// widgets) MUST come directly from a StateField via `EditorView.decorations.from(...)`
+// — the view plugin that powers the inline preview runs after layout and is forbidden
+// from introducing them. So this extension lives here, in its own field, mirroring
+// tableWidget.ts and frontmatterCard.ts. (Inline, mid-paragraph images are left alone
+// by this module — liveMarkdownPreview's ViewPlugin already hides their LinkMark/URL
+// syntax the same way it does for a plain Link, so they read as bracket-free text.)
+
+import { ensureSyntaxTree } from '@codemirror/language';
+import { type EditorState, type Extension, type Range, StateField } from '@codemirror/state';
+import { Decoration, type DecorationSet, EditorView, WidgetType } from '@codemirror/view';
+import type { SyntaxNode } from '@lezer/common';
+import { notebookLinkPath } from './brokenLinks';
+
+export interface ImageTarget {
+  lineFrom: number;
+  lineTo: number;
+  alt: string;
+  src: string;
+}
+
+export interface ImageWidgetOptions {
+  // Resolve a notebook-relative src (already stripped of #fragment/?query) to a
+  // displayable src (typically a data: URI), or null when it can't be resolved.
+  // Absent, a null resolution, or a rejection all render the broken placeholder.
+  resolveSrc?: (src: string) => Promise<string | null>;
+}
+
+// Srcs the browser can load directly, with no daemon round-trip: an explicit URL
+// scheme (http:, data:, …) or a protocol-relative URL. Everything else is treated as
+// a notebook-relative path and goes through options.resolveSrc.
+const SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+
+function isDirectSrc(src: string): boolean {
+  return SCHEME.test(src) || src.startsWith('//');
+}
+
+// Pull { alt, src } out of an Image syntax node. Lezer's markdown grammar builds
+// Image with the same finishLink() shape as Link, except the opening LinkMark spans
+// the image's `![` (2 chars) instead of a link's `[` (1 char): children are
+// [LinkMark(open), ...alt content..., LinkMark(close ']'), LinkMark(open '('), URL,
+// Title?, LinkMark(close ')')]. There's no single "label" node, so alt is read as the
+// doc slice between the opening mark's end and the closing ']' mark's start — the
+// second-to-last LinkMark before the URL (the last is the '(' that precedes it).
+// Returns null for a node that doesn't parse as a complete inline image (e.g.
+// reference-style `![alt][ref]`, which has no URL child).
+function parseImageNode(node: SyntaxNode, state: EditorState): { alt: string; src: string } | null {
+  const url = node.getChild('URL');
+  if (!url) return null;
+  const marks: SyntaxNode[] = [];
+  for (let child = node.firstChild; child && child.from < url.from; child = child.nextSibling) {
+    if (child.name === 'LinkMark') marks.push(child);
+  }
+  if (marks.length < 3) return null; // need at least: opening ![, closing ], opening (
+  const open = marks[0];
+  const closeBracket = marks[marks.length - 2];
+  return {
+    alt: state.doc.sliceString(open.to, closeBracket.from),
+    src: state.doc.sliceString(url.from, url.to),
+  };
+}
+
+// The images that qualify for widget rendering: an Image node that is the ENTIRE
+// content of its line (surrounding whitespace allowed). Inline images mid-paragraph,
+// a line with trailing text after the image, and a line with more than one image
+// (each sees the other's raw markdown as non-whitespace "before"/"after" text) all
+// fail the check and stay raw. Pure over the parsed state, so it's unit-testable
+// headlessly like brokenLinks.notebookLinkPaths.
+export function imageTargets(state: EditorState): ImageTarget[] {
+  const tree = ensureSyntaxTree(state, state.doc.length, 50);
+  if (!tree) return [];
+  const targets: ImageTarget[] = [];
+  tree.iterate({
+    enter: (node) => {
+      if (node.name !== 'Image') return;
+      if (node.to > state.doc.lineAt(node.from).to) return; // spans a line break
+      const line = state.doc.lineAt(node.from);
+      const before = state.doc.sliceString(line.from, node.from).trim();
+      const after = state.doc.sliceString(node.to, line.to).trim();
+      if (before || after) return;
+      const parsed = parseImageNode(node.node, state);
+      if (!parsed) return;
+      targets.push({ lineFrom: line.from, lineTo: line.to, alt: parsed.alt, src: parsed.src });
+    },
+  });
+  return targets;
+}
+
+class ImageWidget extends WidgetType {
+  constructor(
+    readonly target: ImageTarget,
+    private readonly resolveSrc: ImageWidgetOptions['resolveSrc'],
+    // Shared with every widget instance from the same imageWidget() extension, so
+    // retyping or toggling the reveal doesn't re-fetch a src already resolved once.
+    private readonly cache: Map<string, Promise<string | null>>,
+  ) {
+    super();
+  }
+
+  eq(other: ImageWidget) {
+    return this.target.alt === other.target.alt && this.target.src === other.target.src;
+  }
+
+  // Rough space to reserve before the real image loads and CM re-measures, so the
+  // first layout doesn't jump the scroll position.
+  get estimatedHeight() {
+    return 220;
+  }
+
+  // Clicks must reach the editor so clicking the widget's line places the cursor
+  // there — which is what reveals the raw markdown (the same reveal rule tableWidget
+  // uses).
+  ignoreEvent() {
+    return false;
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    const { alt, src } = this.target;
+    const container = document.createElement('div');
+    container.className = 'cm-md-image';
+
+    // A click reveals the raw markdown: move the cursor onto the widget's line (the
+    // same gotoLine pattern tableWidget uses) rather than relying on CM's default
+    // click-to-cursor resolution over a replaced block range, which isn't guaranteed
+    // to land inside it.
+    container.addEventListener('mousedown', (event) => event.preventDefault());
+    container.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      view.dispatch({ selection: { anchor: this.target.lineFrom } });
+      view.focus();
+    });
+
+    const renderBroken = () => {
+      container.className = 'cm-md-image-broken';
+      container.replaceChildren();
+      const label = document.createElement('span');
+      label.className = 'cm-md-image-broken-label';
+      label.textContent = alt || src;
+      const hint = document.createElement('span');
+      hint.className = 'cm-md-image-broken-hint';
+      hint.textContent = 'image not found';
+      container.append(label, hint);
+    };
+
+    const renderImg = (resolvedSrc: string) => {
+      container.className = 'cm-md-image';
+      container.replaceChildren();
+      const img = document.createElement('img');
+      img.alt = alt;
+      img.src = resolvedSrc;
+      // A resolved src (e.g. a valid data: URI) can still fail to decode; fall back
+      // to the broken placeholder rather than leaving a blank box.
+      img.addEventListener('error', renderBroken);
+      container.appendChild(img);
+    };
+
+    if (isDirectSrc(src)) {
+      renderImg(src);
+      return container;
+    }
+
+    const path = notebookLinkPath(src);
+    if (!path || !this.resolveSrc) {
+      renderBroken();
+      return container;
+    }
+
+    let pending = this.cache.get(path);
+    if (!pending) {
+      pending = this.resolveSrc(path).catch(() => null);
+      this.cache.set(path, pending);
+    }
+    pending.then((resolved) => {
+      // The widget's DOM may already have been torn down (navigation, re-render, or
+      // the line's raw markdown got revealed) by the time this resolves.
+      if (!container.isConnected) return;
+      if (resolved) renderImg(resolved);
+      else renderBroken();
+    });
+
+    return container;
+  }
+}
+
+function imageDecorations(
+  state: EditorState,
+  resolveSrc: ImageWidgetOptions['resolveSrc'],
+  cache: Map<string, Promise<string | null>>,
+): DecorationSet {
+  const ranges: Range<Decoration>[] = [];
+  for (const target of imageTargets(state)) {
+    const revealed = state.selection.ranges.some(
+      (range) => range.from <= target.lineTo && range.to >= target.lineFrom,
+    );
+    if (revealed) continue;
+    ranges.push(
+      Decoration.replace({ block: true, widget: new ImageWidget(target, resolveSrc, cache) }).range(
+        target.lineFrom,
+        target.lineTo,
+      ),
+    );
+  }
+  return Decoration.set(ranges);
+}
+
+const imageTheme = EditorView.baseTheme({
+  '.cm-md-image': {
+    display: 'block',
+    margin: '4px 0',
+  },
+  '.cm-md-image img': {
+    display: 'block',
+    maxWidth: '100%',
+    maxHeight: '480px',
+    borderRadius: '6px',
+  },
+  '.cm-md-image-broken': {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+    margin: '4px 0',
+    padding: '10px 14px',
+    borderRadius: '8px',
+    border: '1px dashed var(--color-border, rgba(127,127,127,0.35))',
+    background: 'var(--color-bg-elevated, rgba(127,127,127,0.08))',
+    fontFamily: 'var(--font-sans, system-ui), sans-serif',
+  },
+  '.cm-md-image-broken-label': {
+    fontSize: '0.85em',
+    color: 'var(--color-text-secondary, #b8b8b8)',
+  },
+  '.cm-md-image-broken-hint': {
+    fontSize: '0.72em',
+    color: 'var(--color-text-dimmed, #666)',
+  },
+});
+
+export function imageWidget(options: ImageWidgetOptions = {}): Extension {
+  const cache = new Map<string, Promise<string | null>>();
+
+  const imageField = StateField.define<DecorationSet>({
+    create: (state) => imageDecorations(state, options.resolveSrc, cache),
+    update(value, tr) {
+      if (tr.docChanged || tr.selection) {
+        // Mirrors tableField: if the tree isn't ready yet, keep the previous set
+        // rather than flashing empty.
+        const tree = ensureSyntaxTree(tr.state, tr.state.doc.length, 50);
+        if (!tree) return value.map(tr.changes);
+        return imageDecorations(tr.state, options.resolveSrc, cache);
+      }
+      return value.map(tr.changes);
+    },
+    provide: (field) => EditorView.decorations.from(field),
+  });
+
+  return [imageField, imageTheme];
+}

--- a/app/src/components/notebook/imageWidget.ts
+++ b/app/src/components/notebook/imageWidget.ts
@@ -129,11 +129,18 @@ class ImageWidget extends WidgetType {
     // same gotoLine pattern tableWidget uses) rather than relying on CM's default
     // click-to-cursor resolution over a replaced block range, which isn't guaranteed
     // to land inside it.
+    //
+    // eq() is deliberately position-blind (alt/src only) so an edit above the image
+    // doesn't recreate this DOM and cause reload flicker — but that means this DOM can
+    // outlive the lineFrom it was built with. Read the position from the view at click
+    // time via posAtDOM, never from a captured this.target.lineFrom, or a stale click
+    // handler moves the cursor to wherever the image USED to be.
     container.addEventListener('mousedown', (event) => event.preventDefault());
     container.addEventListener('click', (event) => {
       event.preventDefault();
       event.stopPropagation();
-      view.dispatch({ selection: { anchor: this.target.lineFrom } });
+      const pos = view.posAtDOM(container);
+      if (pos >= 0) view.dispatch({ selection: { anchor: pos } });
       view.focus();
     });
 

--- a/app/src/contexts/NotebookSurfaceContext.tsx
+++ b/app/src/contexts/NotebookSurfaceContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, type ReactNode } from 'react';
 import type {
   FsEntry,
   FsExistsResult,
+  FsReadAssetResult,
   FsReadResult,
   FsWriteResult,
   NotebookEntry,
@@ -17,6 +18,7 @@ export interface NotebookSurfaceDaemon {
   readFile: (path: string) => Promise<FsReadResult>;
   writeFile: (path: string, content: string, baseHash?: string) => Promise<FsWriteResult>;
   existsFile: (path: string) => Promise<FsExistsResult>;
+  readAsset: (path: string) => Promise<FsReadAssetResult>;
   backlinksNotebook: (path: string) => Promise<NotebookEntry[]>;
   sendToChief: (selection: string, sourcePath?: string) => Promise<NotebookSendToChiefResult>;
   // Walk the whole vault (flat list of notes, with titles) for a tile's fuzzy finder.

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '163';
+export const PROTOCOL_VERSION = '164';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -399,6 +399,15 @@ export interface FsReadResult {
   path: string;
   content: string;
   hash: string;
+}
+
+// One image asset's bytes, base64-encoded, plus its mime type — for rendering
+// ![alt](path) images in the notebook editor without widening Tauri's fs
+// permissions. Mirrors the daemon's protocol.FsReadAssetResult.
+export interface FsReadAssetResult {
+  path: string;
+  mimeType: string;
+  dataBase64: string;
 }
 
 // The outcome of a filesystem hash-CAS save. conflict=true means the file changed
@@ -1587,6 +1596,29 @@ export function useDaemonSocket({
               pending.resolve(data.result);
             } else {
               pending.reject(new Error(data.error || 'Filesystem read failed'));
+            }
+            break;
+          }
+
+          case 'fs_read_asset_result': {
+            const requestId = data.request_id;
+            if (typeof requestId !== 'string') {
+              break;
+            }
+            const key = `fs_read_asset:${requestId}`;
+            const pending = pendingActionsRef.current.get(key);
+            if (!pending) {
+              break;
+            }
+            pendingActionsRef.current.delete(key);
+            if (data.success && data.result) {
+              pending.resolve({
+                path: data.result.path,
+                mimeType: data.result.mime_type,
+                dataBase64: data.result.data_base64,
+              });
+            } else {
+              pending.reject(new Error(data.error || 'Filesystem asset read failed'));
             }
             break;
           }
@@ -4574,6 +4606,28 @@ export function useDaemonSocket({
     });
   }, [nextRequestID]);
 
+  // Read one image asset's bytes as base64, for rendering ![alt](path) images in
+  // the notebook editor without widening Tauri's fs permissions.
+  const sendFsReadAsset = useCallback((path: string): Promise<FsReadAssetResult> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('fs_read_asset');
+      const key = `fs_read_asset:${requestId}`;
+      pendingActionsRef.current.set(key, { resolve, reject });
+      ws.send(JSON.stringify({ cmd: 'fs_read_asset', request_id: requestId, path }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Filesystem asset read timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
   // Save one file via the daemon (hash-CAS). Omit baseHash to create-only; pass the
   // file's loaded hash to edit. Resolves with the outcome — including a conflict
   // (resolve, not reject) the editor reconciles; rejects only on a transport error.
@@ -5174,6 +5228,7 @@ export function useDaemonSocket({
     sendNotebookToChief,
     sendFsList,
     sendFsRead,
+    sendFsReadAsset,
     sendFsWrite,
     sendFsRename,
     sendFsDelete,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -60,6 +60,9 @@
 //   const fSExistsResultMessage = Convert.toFSExistsResultMessage(json);
 //   const fSListMessage = Convert.toFSListMessage(json);
 //   const fSListResultMessage = Convert.toFSListResultMessage(json);
+//   const fSReadAssetMessage = Convert.toFSReadAssetMessage(json);
+//   const fSReadAssetResult = Convert.toFSReadAssetResult(json);
+//   const fSReadAssetResultMessage = Convert.toFSReadAssetResultMessage(json);
 //   const fSReadMessage = Convert.toFSReadMessage(json);
 //   const fSReadResult = Convert.toFSReadResult(json);
 //   const fSReadResultMessage = Convert.toFSReadResultMessage(json);
@@ -1176,6 +1179,44 @@ export interface EntryObject {
 
 export enum FSListResultMessageEvent {
     FSListResult = "fs_list_result",
+}
+
+export interface FSReadAssetMessage {
+    cmd:         FSReadAssetMessageCmd;
+    path:        string;
+    request_id?: string;
+    [property: string]: any;
+}
+
+export enum FSReadAssetMessageCmd {
+    FSReadAsset = "fs_read_asset",
+}
+
+export interface FSReadAssetResult {
+    data_base64: string;
+    mime_type:   string;
+    path:        string;
+    [property: string]: any;
+}
+
+export interface FSReadAssetResultMessage {
+    error?:     string;
+    event:      FSReadAssetResultMessageEvent;
+    request_id: string;
+    result?:    FSReadAssetResultMessageResult;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum FSReadAssetResultMessageEvent {
+    FSReadAssetResult = "fs_read_asset_result",
+}
+
+export interface FSReadAssetResultMessageResult {
+    data_base64: string;
+    mime_type:   string;
+    path:        string;
+    [property: string]: any;
 }
 
 export interface FSReadMessage {
@@ -5310,6 +5351,30 @@ export class Convert {
         return JSON.stringify(uncast(value, r("FSListResultMessage")), null, 2);
     }
 
+    public static toFSReadAssetMessage(json: string): FSReadAssetMessage {
+        return cast(JSON.parse(json), r("FSReadAssetMessage"));
+    }
+
+    public static fSReadAssetMessageToJson(value: FSReadAssetMessage): string {
+        return JSON.stringify(uncast(value, r("FSReadAssetMessage")), null, 2);
+    }
+
+    public static toFSReadAssetResult(json: string): FSReadAssetResult {
+        return cast(JSON.parse(json), r("FSReadAssetResult"));
+    }
+
+    public static fSReadAssetResultToJson(value: FSReadAssetResult): string {
+        return JSON.stringify(uncast(value, r("FSReadAssetResult")), null, 2);
+    }
+
+    public static toFSReadAssetResultMessage(json: string): FSReadAssetResultMessage {
+        return cast(JSON.parse(json), r("FSReadAssetResultMessage"));
+    }
+
+    public static fSReadAssetResultMessageToJson(value: FSReadAssetResultMessage): string {
+        return JSON.stringify(uncast(value, r("FSReadAssetResultMessage")), null, 2);
+    }
+
     public static toFSReadMessage(json: string): FSReadMessage {
         return cast(JSON.parse(json), r("FSReadMessage"));
     }
@@ -8158,6 +8223,28 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
         { json: "size", js: "size", typ: 0 },
     ], "any"),
+    "FSReadAssetMessage": o([
+        { json: "cmd", js: "cmd", typ: r("FSReadAssetMessageCmd") },
+        { json: "path", js: "path", typ: "" },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+    ], "any"),
+    "FSReadAssetResult": o([
+        { json: "data_base64", js: "data_base64", typ: "" },
+        { json: "mime_type", js: "mime_type", typ: "" },
+        { json: "path", js: "path", typ: "" },
+    ], "any"),
+    "FSReadAssetResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("FSReadAssetResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "result", js: "result", typ: u(undefined, r("FSReadAssetResultMessageResult")) },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "FSReadAssetResultMessageResult": o([
+        { json: "data_base64", js: "data_base64", typ: "" },
+        { json: "mime_type", js: "mime_type", typ: "" },
+        { json: "path", js: "path", typ: "" },
+    ], "any"),
     "FSReadMessage": o([
         { json: "cmd", js: "cmd", typ: r("FSReadMessageCmd") },
         { json: "path", js: "path", typ: "" },
@@ -10478,6 +10565,12 @@ const typeMap: any = {
     ],
     "FSListResultMessageEvent": [
         "fs_list_result",
+    ],
+    "FSReadAssetMessageCmd": [
+        "fs_read_asset",
+    ],
+    "FSReadAssetResultMessageEvent": [
+        "fs_read_asset_result",
     ],
     "FSReadMessageCmd": [
         "fs_read",

--- a/app/test-harness/harnesses/NotebookBrowserHarness.tsx
+++ b/app/test-harness/harnesses/NotebookBrowserHarness.tsx
@@ -15,12 +15,18 @@ import { NotebookBrowser } from '../../src/components/NotebookBrowser';
 import type {
   FsEntry,
   FsExistsResult,
+  FsReadAssetResult,
   FsReadResult,
   FsWriteResult,
   NotebookEntry,
   NotebookSendToChiefResult,
 } from '../../src/hooks/useDaemonSocket';
 import type { HarnessProps } from '../types';
+
+// A valid, minimal 1x1 transparent PNG — the "resolvable" asset the readAsset mock
+// returns for assets/tiny.png. Any other path is treated as missing.
+const TINY_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
 
 // A small fixture filesystem: a PARA-shaped notebook root with nested folders, a
 // markdown index, a plain text file, and a binary file (placeholder). listDir
@@ -35,6 +41,7 @@ const TREE: Record<string, FsEntry[]> = {
     // out of listFiles/TREE offsets that other tests already depend on (e.g. the Cmd+P
     // finder's fixed option count and index.md's heading/scroll offsets).
     { path: 'fences.md', name: 'fences.md', isDir: false, size: 96 },
+    { path: 'images.md', name: 'images.md', isDir: false, size: 64 },
   ],
   journal: [{ path: 'journal/2026-06-20.md', name: '2026-06-20.md', isDir: false, size: 20 }],
   knowledge: [
@@ -67,6 +74,12 @@ ${INDEX_FILLER}
 ### Subsection detail
 
 ${INDEX_FILLER}
+`,
+  'images.md': `# Images
+
+![tiny](assets/tiny.png)
+
+![gone](assets/missing.png)
 `,
   'notes.txt': 'Plain text scratch file.\nNo markdown affordances here — just edit and autosave.\n',
   'fences.md': `# Fences
@@ -129,6 +142,16 @@ export function NotebookBrowserHarness({ onReady, setTriggerRerender }: HarnessP
     // broken-link flag fires here (broken links have their own dedicated harness).
     return { path, exists: true };
   }, []);
+  // Serves the live editor's inline image widget: assets/tiny.png resolves to a real
+  // (tiny) PNG; anything else — e.g. assets/missing.png — rejects, so the widget
+  // renders its broken placeholder.
+  const readAsset = useCallback(async (path: string): Promise<FsReadAssetResult> => {
+    window.__HARNESS__.recordCall('readAsset', [path]);
+    if (path === 'assets/tiny.png') {
+      return { path, mimeType: 'image/png', dataBase64: TINY_PNG_BASE64 };
+    }
+    throw new Error(`asset not found: ${path}`);
+  }, []);
   const sendToChief = useCallback(async (selection: string, sourcePath?: string): Promise<NotebookSendToChiefResult> => {
     window.__HARNESS__.recordCall('sendToChief', [selection, sourcePath]);
     return { path: 'inbox.md', nudged: false };
@@ -168,6 +191,7 @@ export function NotebookBrowserHarness({ onReady, setTriggerRerender }: HarnessP
       backlinksNotebook={backlinksNotebook}
       writeFile={writeFile}
       existsFile={existsFile}
+      readAsset={readAsset}
       sendToChief={sendToChief}
       listFiles={listFiles}
       changeSignal={changeSignal}

--- a/internal/daemon/fs.go
+++ b/internal/daemon/fs.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -18,9 +19,10 @@ import (
 // on the wire is the contract and the file-size cap follows.
 const maxAssetMessageBytes = 8 << 20
 
-// assetEnvelopeSlack reserves room for everything in the message besides the
-// base64 payload: JSON structure, event/request_id fields, mime type, and the
-// asset path (paths are far shorter than this in practice).
+// assetEnvelopeSlack sizes the PREFLIGHT file-size cap only: a fast reject
+// before reading or encoding a file that's obviously too large. It is not the
+// wire bound — assetMessageFits below computes that exactly per request,
+// including arbitrarily long paths.
 const assetEnvelopeSlack = 4 << 10
 
 // maxAssetBytes bounds a single fs_read_asset read so base64(content) plus the
@@ -135,6 +137,10 @@ func (d *Daemon) sendFsReadAssetWSResult(client *wsClient, requestID, path strin
 			if content, _, err = store.Read(path); err == nil {
 				if len(content) > maxAssetBytes {
 					err = fmt.Errorf("asset exceeds the %d byte read cap", maxAssetBytes)
+				} else if fits, ferr := assetMessageFits(requestID, path, mimeType, len(content)); ferr != nil {
+					err = ferr
+				} else if !fits {
+					err = fmt.Errorf("asset response exceeds the %d byte message cap", maxAssetMessageBytes)
 				} else {
 					result = &protocol.FsReadAssetResult{
 						Path:       path,
@@ -166,6 +172,27 @@ func assetMimeTypeFor(path string) (string, error) {
 		return "", errors.New("not a supported image asset")
 	}
 	return mimeType, nil
+}
+
+// assetMessageFits reports whether the complete fs_read_asset_result message for
+// this request would marshal within maxAssetMessageBytes once rawLen content
+// bytes are base64-encoded into it. The size is exact, not an estimate: base64
+// output never needs JSON escaping, so the full message length is the marshaled
+// empty-payload envelope plus EncodedLen(rawLen). This — not the preflight file
+// cap — is the authoritative transport bound, and it accounts for the real
+// (arbitrarily long) path.
+func assetMessageFits(requestID, path, mimeType string, rawLen int) (bool, error) {
+	probe := protocol.FsReadAssetResultMessage{
+		Event:     protocol.EventFsReadAssetResult,
+		RequestID: requestID,
+		Success:   true,
+		Result:    &protocol.FsReadAssetResult{Path: path, MimeType: mimeType},
+	}
+	envelope, err := json.Marshal(probe)
+	if err != nil {
+		return false, err
+	}
+	return len(envelope)+base64.StdEncoding.EncodedLen(rawLen) <= maxAssetMessageBytes, nil
 }
 
 // sendFsWriteWSResult performs a hash-CAS write and replies with an

--- a/internal/daemon/fs.go
+++ b/internal/daemon/fs.go
@@ -1,12 +1,37 @@
 package daemon
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/victorarias/attn/internal/fsdoc"
 	"github.com/victorarias/attn/internal/notebook"
 	"github.com/victorarias/attn/internal/protocol"
 )
+
+// maxAssetBytes bounds a single fs_read_asset read so a huge binary file can't
+// balloon a WS frame (the whole file is base64-encoded into one JSON message).
+const maxAssetBytes = 10 << 20
+
+// assetMimeTypes is the explicit allowlist of image extensions fs_read_asset will
+// serve. This IS the contract, not a convenience lookup: unlike mime.TypeByExtension
+// it deliberately excludes everything non-image, since this surface exists only to
+// render ![alt](path) images in the notebook editor without widening Tauri's fs
+// permissions.
+var assetMimeTypes = map[string]string{
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif":  "image/gif",
+	".webp": "image/webp",
+	".svg":  "image/svg+xml",
+	".avif": "image/avif",
+	".bmp":  "image/bmp",
+	".ico":  "image/x-icon",
+}
 
 // fsStoreFor returns the daemon's single generic filesystem Store for the active
 // root. The root is the SAME one the notebook uses (notebook.root): fsdoc is the
@@ -84,6 +109,52 @@ func (d *Daemon) sendFsReadWSResult(client *wsClient, requestID, path string) {
 		msg.Error = protocol.Ptr(err.Error())
 	}
 	d.sendToClient(client, msg)
+}
+
+// sendFsReadAssetWSResult reads one image file's bytes as base64 and replies with
+// an fs_read_asset_result event correlated by requestID. Only extensions in
+// assetMimeTypes are served; the extension is rejected before the file is read.
+func (d *Daemon) sendFsReadAssetWSResult(client *wsClient, requestID, path string) {
+	var result *protocol.FsReadAssetResult
+	mimeType, err := assetMimeTypeFor(path)
+	if err == nil {
+		var store *fsdoc.Store
+		if store, err = d.fsStoreFor(); err == nil {
+			var content []byte
+			if content, _, err = store.Read(path); err == nil {
+				if len(content) > maxAssetBytes {
+					err = fmt.Errorf("asset exceeds the %d byte read cap", maxAssetBytes)
+				} else {
+					result = &protocol.FsReadAssetResult{
+						Path:       path,
+						MimeType:   mimeType,
+						DataBase64: base64.StdEncoding.EncodeToString(content),
+					}
+				}
+			}
+		}
+	}
+	msg := protocol.FsReadAssetResultMessage{
+		Event:     protocol.EventFsReadAssetResult,
+		RequestID: requestID,
+		Success:   err == nil,
+		Result:    result,
+	}
+	if err != nil {
+		msg.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, msg)
+}
+
+// assetMimeTypeFor returns the mime type for path's extension, or an error if the
+// extension is not in the image allowlist.
+func assetMimeTypeFor(path string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	mimeType, ok := assetMimeTypes[ext]
+	if !ok {
+		return "", errors.New("not a supported image asset")
+	}
+	return mimeType, nil
 }
 
 // sendFsWriteWSResult performs a hash-CAS write and replies with an

--- a/internal/daemon/fs.go
+++ b/internal/daemon/fs.go
@@ -12,9 +12,20 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 )
 
-// maxAssetBytes bounds a single fs_read_asset read so a huge binary file can't
-// balloon a WS frame (the whole file is base64-encoded into one JSON message).
-const maxAssetBytes = 10 << 20
+// maxAssetMessageBytes bounds the entire marshaled fs_read_asset_result JSON
+// message — the unit that actually hits the WebSocket transport, which has no
+// other outbound cap. The raw read cap below is DERIVED from it, so the bound
+// on the wire is the contract and the file-size cap follows.
+const maxAssetMessageBytes = 8 << 20
+
+// assetEnvelopeSlack reserves room for everything in the message besides the
+// base64 payload: JSON structure, event/request_id fields, mime type, and the
+// asset path (paths are far shorter than this in practice).
+const assetEnvelopeSlack = 4 << 10
+
+// maxAssetBytes bounds a single fs_read_asset read so base64(content) plus the
+// envelope always fits maxAssetMessageBytes (base64 of n bytes is 4*ceil(n/3)).
+const maxAssetBytes = (maxAssetMessageBytes - assetEnvelopeSlack) / 4 * 3
 
 // assetMimeTypes is the explicit allowlist of image extensions fs_read_asset will
 // serve. This IS the contract, not a convenience lookup: unlike mime.TypeByExtension

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -387,6 +387,36 @@ func TestFsReadAssetOversize(t *testing.T) {
 	}
 }
 
+// A file at exactly the per-asset byte cap is accepted, and the resulting
+// fs_read_asset_result message still fits maxAssetMessageBytes once marshaled.
+// This is the boundary the cap derivation exists to guarantee: it fails if
+// someone raises maxAssetBytes without re-deriving it, or if the base64
+// envelope math is wrong.
+func TestFsReadAssetMaxSizeFitsMessageCap(t *testing.T) {
+	d := newFsDaemon(t)
+	root := d.store.GetSetting(SettingNotebookRoot)
+	if err := os.MkdirAll(filepath.Join(root, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	max := bytes.Repeat([]byte{0xFF}, maxAssetBytes)
+	if err := os.WriteFile(filepath.Join(root, "assets", "max.png"), max, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := fsReadAsset(t, d, "a1", "assets/max.png")
+	if !got.Success || got.Result == nil {
+		t.Fatalf("read asset(max size) = %+v, want success", got)
+	}
+
+	marshaled, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	if len(marshaled) > maxAssetMessageBytes {
+		t.Fatalf("marshaled message = %d bytes, want <= %d (maxAssetMessageBytes)", len(marshaled), maxAssetMessageBytes)
+	}
+}
+
 // An extension outside the image allowlist is rejected before the file is even
 // read, regardless of the file's actual content.
 func TestFsReadAssetUnsupportedExtension(t *testing.T) {

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -1,10 +1,13 @@
 package daemon
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -302,5 +305,98 @@ func TestFsChangedExternalEditNotSelfWrite(t *testing.T) {
 	}
 	if slices.Contains(ext, "own.md") {
 		t.Fatalf("external fs_changed %v wrongly included attn's own write own.md", ext)
+	}
+}
+
+// pngHeaderBytes is a minimal valid PNG signature + IHDR-ish prefix. It does not
+// need to decode as a real image: fs_read_asset only serves bytes, it never
+// decodes them.
+var pngHeaderBytes = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D}
+
+// fsReadAsset reads one asset over the WS fs path and returns the decoded result
+// event.
+func fsReadAsset(t *testing.T, d *Daemon, requestID, path string) protocol.FsReadAssetResultMessage {
+	t.Helper()
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsReadAssetWSResult(client, requestID, path)
+	var res protocol.FsReadAssetResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	return res
+}
+
+// fs_read_asset serves an allowlisted image's bytes as base64 with its mime type,
+// round-tripping the exact bytes written to disk.
+func TestFsReadAssetWSResult(t *testing.T) {
+	d := newFsDaemon(t)
+	if res := fsWriteCAS(t, d, "assets/pic.png", string(pngHeaderBytes), ""); !res.Success || res.Result == nil {
+		t.Fatalf("seed write = %+v", res.Result)
+	}
+
+	got := fsReadAsset(t, d, "a1", "assets/pic.png")
+	if got.Event != protocol.EventFsReadAssetResult || got.RequestID != "a1" || !got.Success || got.Result == nil {
+		t.Fatalf("read asset = %+v", got)
+	}
+	if got.Result.MimeType != "image/png" {
+		t.Fatalf("mime type = %q, want image/png", got.Result.MimeType)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(got.Result.DataBase64)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	if !bytes.Equal(decoded, pngHeaderBytes) {
+		t.Fatalf("decoded bytes = %v, want %v", decoded, pngHeaderBytes)
+	}
+}
+
+// A path that escapes the notebook root is rejected by the same containment guard
+// fs_read uses (fsStoreFor/store.Read), not by any asset-specific path logic.
+func TestFsReadAssetPathEscape(t *testing.T) {
+	d := newFsDaemon(t)
+	got := fsReadAsset(t, d, "a1", "../outside.png")
+	if got.Success {
+		t.Fatalf("read asset(path escape) = %+v, want failure", got)
+	}
+}
+
+// A missing asset is a failed result with an error, not a panic or empty success.
+func TestFsReadAssetMissingFile(t *testing.T) {
+	d := newFsDaemon(t)
+	got := fsReadAsset(t, d, "a1", "assets/nope.png")
+	if got.Success || got.Error == nil {
+		t.Fatalf("read asset(missing) = %+v, want failure with error", got)
+	}
+}
+
+// A file over the per-asset byte cap is rejected with an error mentioning the cap,
+// even though it has a supported extension. Written directly to disk (bypassing
+// fs_write, which has its own smaller 2MiB cap) so the asset cap is what's tested.
+func TestFsReadAssetOversize(t *testing.T) {
+	d := newFsDaemon(t)
+	root := d.store.GetSetting(SettingNotebookRoot)
+	if err := os.MkdirAll(filepath.Join(root, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	big := bytes.Repeat([]byte{0xFF}, maxAssetBytes+1)
+	if err := os.WriteFile(filepath.Join(root, "assets", "huge.png"), big, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := fsReadAsset(t, d, "a1", "assets/huge.png")
+	if got.Success || got.Error == nil || !strings.Contains(*got.Error, "cap") {
+		t.Fatalf("read asset(oversize) = %+v, want failure mentioning the cap", got)
+	}
+}
+
+// An extension outside the image allowlist is rejected before the file is even
+// read, regardless of the file's actual content.
+func TestFsReadAssetUnsupportedExtension(t *testing.T) {
+	d := newFsDaemon(t)
+	if res := fsWriteCAS(t, d, "assets/doc.pdf", "not an image", ""); !res.Success || res.Result == nil {
+		t.Fatalf("seed write = %+v", res.Result)
+	}
+
+	got := fsReadAsset(t, d, "a1", "assets/doc.pdf")
+	if got.Success || got.Error == nil || *got.Error != "not a supported image asset" {
+		t.Fatalf("read asset(unsupported ext) = %+v, want \"not a supported image asset\"", got)
 	}
 }

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -417,6 +417,26 @@ func TestFsReadAssetMaxSizeFitsMessageCap(t *testing.T) {
 	}
 }
 
+// assetMessageFits is the exact per-request wire-size check that guards against
+// an arbitrarily long path pushing a max-size asset's message over the cap. It
+// is a pure function, tested directly here rather than through a real long path
+// on disk: macOS's PATH_MAX (1024) makes a real >4 KiB path uncreatable, but the
+// check itself must still hold for paths far longer than that.
+func TestAssetMessageFitsRejectsLongPath(t *testing.T) {
+	longPath := strings.Repeat("d/", 4096) + "x.png"
+	if fits, err := assetMessageFits("a1", longPath, "image/png", maxAssetBytes); err != nil {
+		t.Fatalf("assetMessageFits(long path): %v", err)
+	} else if fits {
+		t.Fatalf("assetMessageFits(long path) = true, want false")
+	}
+
+	if fits, err := assetMessageFits("a1", "assets/pic.png", "image/png", maxAssetBytes); err != nil {
+		t.Fatalf("assetMessageFits(short path): %v", err)
+	} else if !fits {
+		t.Fatalf("assetMessageFits(short path) = false, want true")
+	}
+}
+
 // An extension outside the image allowlist is rejected before the file is even
 // read, regardless of the file's actual content.
 func TestFsReadAssetUnsupportedExtension(t *testing.T) {

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -930,6 +930,9 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 	case protocol.CmdFsRead:
 		fsRead := msg.(*protocol.FsReadMessage)
 		go d.sendFsReadWSResult(client, protocol.Deref(fsRead.RequestID), fsRead.Path)
+	case protocol.CmdFsReadAsset:
+		fsReadAsset := msg.(*protocol.FsReadAssetMessage)
+		go d.sendFsReadAssetWSResult(client, protocol.Deref(fsReadAsset.RequestID), fsReadAsset.Path)
 	case protocol.CmdFsWrite:
 		fsWrite := msg.(*protocol.FsWriteMessage)
 		go d.sendFsWriteWSResult(client, protocol.Deref(fsWrite.RequestID), fsWrite.Path, fsWrite.Content, protocol.Deref(fsWrite.BaseHash))

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "163"
+const ProtocolVersion = "164"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -83,6 +83,7 @@ const (
 	CmdNotificationMarkRead                  = "notification_mark_read"
 	CmdFsList                                = "fs_list"
 	CmdFsRead                                = "fs_read"
+	CmdFsReadAsset                           = "fs_read_asset"
 	CmdFsWrite                               = "fs_write"
 	CmdFsRename                              = "fs_rename"
 	CmdFsDelete                              = "fs_delete"
@@ -227,6 +228,7 @@ const (
 	EventNotificationsUpdated            = "notifications_updated"
 	EventFsListResult                    = "fs_list_result"
 	EventFsReadResult                    = "fs_read_result"
+	EventFsReadAssetResult               = "fs_read_asset_result"
 	EventFsWriteResult                   = "fs_write_result"
 	EventFsRenameResult                  = "fs_rename_result"
 	EventFsDeleteResult                  = "fs_delete_result"
@@ -659,6 +661,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdFsRead:
 		var msg FsReadMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdFsReadAsset:
+		var msg FsReadAssetMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -887,6 +887,45 @@ type FsListResultMessage struct {
 	Success bool `json:"success"`
 }
 
+type FsReadAssetMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+}
+
+type FsReadAssetResult struct {
+	// DataBase64 corresponds to the JSON schema field "data_base64".
+	DataBase64 string `json:"data_base64"`
+
+	// MimeType corresponds to the JSON schema field "mime_type".
+	MimeType string `json:"mime_type"`
+
+	// Path corresponds to the JSON schema field "path".
+	Path string `json:"path"`
+}
+
+type FsReadAssetResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Result corresponds to the JSON schema field "result".
+	Result *FsReadAssetResult `json:"result,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type FsReadMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1106,6 +1106,15 @@ model FsReadMessage {
   request_id?: string; // set by the WS frontend to correlate the result event
 }
 
+// Read one image file's bytes as base64, for the notebook editor to render
+// ![alt](path) images without widening Tauri's fs permissions. Only a fixed
+// allowlist of image extensions is served; anything else is an error.
+model FsReadAssetMessage {
+  cmd: "fs_read_asset";
+  path: string;
+  request_id?: string; // set by the WS frontend to correlate the result event
+}
+
 model FsWriteMessage {
   cmd: "fs_write";
   path: string;
@@ -2847,6 +2856,12 @@ model FsReadResult {
   hash: string;
 }
 
+model FsReadAssetResult {
+  path: string;
+  mime_type: string;
+  data_base64: string;
+}
+
 // Result of fs_write. When conflict is true the write did not apply; current_hash
 // is the hash now on disk (empty if the target is gone). Same contract as
 // NotebookWriteResult.
@@ -2880,6 +2895,14 @@ model FsReadResultMessage {
   success: boolean;
   error?: string;
   result?: FsReadResult;
+}
+
+model FsReadAssetResultMessage {
+  event: "fs_read_asset_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  result?: FsReadAssetResult;
 }
 
 model FsRenameResultMessage {
@@ -3113,6 +3136,7 @@ alias DaemonEvent =
   | NotebookSendToChiefResultMessage
   | FsListResultMessage
   | FsReadResultMessage
+  | FsReadAssetResultMessage
   | FsWriteResultMessage
   | FsRenameResultMessage
   | FsDeleteResultMessage


### PR DESCRIPTION
PR6 of the notebook-editor-polish plan (docs/plans/2026-07-11-notebook-editor-polish.md).

Renders whole-line Markdown images (`![alt](src)`) inline in the live markdown editor, with image bytes resolved through a new daemon `fs_read_asset` command rather than direct filesystem access from the frontend.

- daemon: `fs_read_asset` command to read image bytes for a note-relative or absolute path
- editor: image widget renders resolved images in place of the raw markdown line
- editor: click handling reads the image widget's click position from the view

Bumps `ProtocolVersion` to 159 (new daemon command).

Verified locally: `go build ./...`, `go vet ./...`, `gofmt` clean, full `go test ./...`, `tsc --noEmit`, and `pnpm exec vitest run` (149 files / 1467 tests) all green after rebase onto main. This PR was live-verified in a dev install during development; the rebase onto main applied cleanly with no conflicts, so that verification stands per repo policy.