### PR TITLE
fix(tickets): submit Codex nudges atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-13]
+
+### Fixed
+- **Ticket nudges now submit in Codex instead of stopping in the composer.** The
+  bounded inbox prompt is explicitly framed before Enter, so the nudge starts a
+  turn while retaining the approval-prompt safety fence.
+
 ## [2026-07-12]
 
 ### Added

--- a/app/scripts/real-app-harness/scenario-nudge-trigger.mjs
+++ b/app/scripts/real-app-harness/scenario-nudge-trigger.mjs
@@ -12,9 +12,10 @@
  *      session B (a cheap shell) — A is selected, so the daemon arms the nudge
  *      PAUSED (no timer): nudge_fires_at is absent and the paused button renders,
  *   3. assert the doorbell has NOT been injected yet (the gate held), then
- *   4. click the real "deliver now" button and assert the verbatim doorbell prompt
- *      lands in A's pane — exercising the button onClick -> sendTriggerNudge -> WS
- *      -> handleTriggerNudge chain that no unit/tsc check covers.
+ *   4. click the real "deliver now" button and assert Codex starts a turn, consumes
+ *      the ticket inbox, and settles with no doorbell text stranded in its composer
+ *      — exercising the button onClick -> sendTriggerNudge -> WS ->
+ *      handleTriggerNudge chain that no unit/tsc check covers.
  *
  * Because A is selected the nudge is paused with no armed timer, so the single
  * click is structurally the only delivery path — that is the exactly-once
@@ -215,7 +216,8 @@ async function main() {
     note(`author shell ready`, { authorId });
 
     runAttn(['ticket', 'comment', ticketId, '-m', 'Please take a look when you can.', '--session', authorId]);
-    note(`author commented on the ticket -> should notify the target participant`);
+    runAttn(['ticket', 'comment', ticketId, '-m', 'One more related note.', '--session', authorId]);
+    note(`author posted overlapping ticket activity -> should produce one target doorbell`);
 
     // 3) The notify reaches A as unread. A is selected, so the daemon pauses the
     //    nudge: ticket_unread true, nudge_fires_at ABSENT (no armed timer). This
@@ -265,29 +267,101 @@ async function main() {
     assert(clickRes?.clicked === true, `the trigger button was found and clicked (got ${JSON.stringify(clickRes)})`);
     note(`clicked the deliver-now trigger`, { surface: clickRes.surface });
 
-    // 6) The verbatim doorbell prompt must now land in A's pane. A was PAUSED (no
-    //    armed timer), so this single click is structurally the only delivery path
-    //    — that is the exactly-once guarantee, without counting noisy rendered text.
-    let afterText = '';
-    const wantedCore = normalizeWs(DOORBELL_CORE);
-    const delivered = await pollFor(
-      async () => {
-        afterText = (await readPaneText(client, targetId)).text;
-        return normalizeWs(afterText).includes(wantedCore) ? afterText : null;
-      },
-      'the verbatim doorbell prompt to land in the target pane after the click',
-      20_000,
-      500,
+    // 6) Injection is not enough: the regression left the verbatim prompt in the
+    //    composer and the old assertion still passed. Require the real Codex state
+    //    transition into a turn, then wait for it to settle and consume the inbox.
+    const started = await pollFor(
+      () => (observer.getSession(targetId)?.state === 'working' ? true : null),
+      'Codex to start a turn from the delivered doorbell',
+      30_000,
+      100,
     ).catch(() => null);
+
+    let afterText = (await readPaneText(client, targetId)).text;
     fs.writeFileSync(path.join(runDir, 'pane-after-click.txt'), afterText, 'utf8');
     assert(
-      delivered !== null,
-      `the doorbell ("${DOORBELL_CORE}") landed in the target pane after clicking deliver-now (see pane-after-click.txt)`,
+      started === true,
+      'the delivered doorbell started a Codex turn instead of remaining in the composer (see pane-after-click.txt)',
     );
-    note(`doorbell delivered: verbatim prompt present in target pane after the click`);
+    note(`doorbell submitted: Codex entered working state`);
+
+    const settledState = await pollFor(
+      () => {
+        const state = observer.getSession(targetId)?.state;
+        return IDLE_STATES.has(state) ? state : null;
+      },
+      'Codex to finish the nudge turn',
+      90_000,
+      250,
+    );
+    await pollFor(
+      () => (observer.getSession(targetId)?.ticket_unread === true ? null : true),
+      'the submitted nudge turn to consume the ticket inbox',
+      30_000,
+      250,
+    );
+
+    afterText = (await readPaneText(client, targetId)).text;
+    fs.writeFileSync(path.join(runDir, 'pane-after-settle.txt'), afterText, 'utf8');
+    const wantedCore = normalizeWs(DOORBELL_CORE);
+    assert(
+      normalizeWs(afterText).includes(wantedCore),
+      `the submitted transcript contains the complete doorbell message (see pane-after-settle.txt)`,
+    );
+    note(`nudge turn settled with inbox consumed and no stranded composer text`, { state: settledState });
+
+    // 7) Busy delivery uses Codex's queue semantics. Keep a normal turn alive long
+    //    enough to click deliver-now while state is authoritatively `working`, then
+    //    require the queued nudge to run afterward and drain the new ticket event.
+    const busyPrompt = 'Run `sleep 8`, then reply with the exact words: foreground turn finished';
+    await client.request('write_pane', { sessionId: targetId, paneId: beforeClick.paneId, text: busyPrompt, submit: false });
+    await delay(1_200);
+    await client.request('write_pane', { sessionId: targetId, paneId: beforeClick.paneId, text: '\r', submit: false });
+    await pollFor(
+      () => (observer.getSession(targetId)?.state === 'working' ? true : null),
+      'Codex to start the foreground busy turn',
+      30_000,
+      100,
+    );
+
+    runAttn(['ticket', 'comment', ticketId, '-m', 'Busy-state follow-up.', '--session', authorId]);
+    await pollFor(
+      () => (observer.getSession(targetId)?.ticket_unread === true ? true : null),
+      'busy target to show unread ticket activity',
+      30_000,
+      100,
+    );
+    assert(observer.getSession(targetId)?.state === 'working', 'target is still working before busy nudge delivery');
+
+    const busyClick = await client.request('click_nudge_trigger', {});
+    assert(busyClick?.clicked === true, `busy-state trigger button was clicked (got ${JSON.stringify(busyClick)})`);
+    note(`delivered a second nudge while Codex was working`, { surface: busyClick.surface });
+
+    await pollFor(
+      () => (observer.getSession(targetId)?.ticket_unread === true ? null : true),
+      'the busy-state queued nudge to consume the ticket inbox',
+      120_000,
+      250,
+    );
+    const busySettledState = await pollFor(
+      () => {
+        const state = observer.getSession(targetId)?.state;
+        return IDLE_STATES.has(state) ? state : null;
+      },
+      'Codex to settle after the foreground and queued nudge turns',
+      120_000,
+      250,
+    );
+    const afterBusy = (await readPaneText(client, targetId)).text;
+    fs.writeFileSync(path.join(runDir, 'pane-after-busy-nudge.txt'), afterBusy, 'utf8');
+    assert(
+      normalizeWs(afterBusy).includes(normalizeWs('Busy-state follow-up.')),
+      'the queued nudge turn read the busy-state ticket event (see pane-after-busy-nudge.txt)',
+    );
+    note(`busy-state nudge processed through Codex queue semantics`, { state: busySettledState });
 
     saveEvidence('passed');
-    console.log('[nudge-trigger] Nudge trigger scenario passed: gate held, then the real button delivered the doorbell.');
+    console.log('[nudge-trigger] Nudge trigger scenario passed: idle and busy Codex nudges submitted and consumed ticket activity.');
     console.log(JSON.stringify(evidence, null, 2));
   } catch (error) {
     saveEvidence(`error: ${error instanceof Error ? error.message : String(error)}`);

--- a/docs/plans/2026-07-13-codex-nudge-submission.md
+++ b/docs/plans/2026-07-13-codex-nudge-submission.md
@@ -1,0 +1,64 @@
+# Plan: Codex nudge submission
+
+## Why / Alignment
+
+An attn nudge is a submitted doorbell message, not composer text. This chunk
+restores that contract for Codex while preserving the recently added approval
+fence, countdown deduplication, busy-session delivery policy, and user-input
+guards.
+
+In scope: the shared doorbell transport, focused daemon coverage, the packaged
+Codex nudge scenario, and a user-facing changelog entry. Deferred: redesigning
+nudge eligibility, countdown timing, composer introspection, or agent-specific
+plugin contracts.
+
+## Architecture Map
+
+```text
+Current:
+ticket event -> countdown / deliver-now -> typeDoorbell
+  -> one PTY write: prompt + CR
+    -> Codex treats the burst as composer input; no turn starts
+
+Target:
+ticket event -> countdown / deliver-now -> typeDoorbell (approval fence held)
+  -> one PTY write: bracketed-paste(prompt) + CR
+    -> explicit paste terminator separates prompt from Enter semantically
+    -> Codex submits one user message and starts a turn
+
+Tests:
+daemon fake backend -> assert atomic framed write + state fence
+packaged attn-dev.app -> real Codex -> assert working transition + settled prompt
+```
+
+## Boundaries
+
+- `typeDoorbell` owns one atomic prompt-and-submit write under `doorbellMu`.
+- `applyStateAndSyncNudge` remains the authority that prevents an approval state
+  from landing inside that transaction.
+- Countdown, unread, selection, and recent-keystroke policy remain unchanged.
+- The real-app scenario must distinguish “text appeared” from “Codex started a
+  turn.”
+
+## Implementation Steps
+
+- [x] Reproduce the stranded-composer regression on signed current `main` with a
+  real Codex session.
+- [x] Restore distinct prompt and Enter semantics inside one approval-fenced PTY
+  write.
+- [x] Update daemon tests to assert atomic framing, non-interleaving, and no
+  duplicate submission.
+- [x] Strengthen the packaged-app scenario to require a real Codex turn and an
+  empty composer after settling.
+- [x] Run focused/static/full relevant checks and live verification.
+- [x] Run the repository review workflow and prepare a review-ready handoff.
+
+## Decisions
+
+- Keep the fix in the existing shared doorbell primitive: the regression was
+  introduced there, and the previous separated-write behavior was shared across
+  runtimes.
+- Preserve the atomic state fence and use explicit bracketed-paste framing to
+  separate the composer text from Enter without a timing window.
+- Treat the current harness pass as a regression in the assertion: pane text alone
+  proves injection, not submission.

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -15,6 +15,11 @@ var errDoorbellBlockedByApproval = errors.New("doorbell blocked by pending appro
 
 const profileRoleChiefOfStaff = "chief_of_staff"
 
+const (
+	bracketedPasteStart = "\x1b[200~"
+	bracketedPasteEnd   = "\x1b[201~"
+)
+
 func (d *Daemon) chiefOfStaffSessionID() string {
 	if d.store == nil {
 		return ""
@@ -121,19 +126,22 @@ func (d *Daemon) nudgeChiefOfStaff(prompt string) bool {
 	return true
 }
 
-// typeDoorbell types a bounded prompt and its Enter as one PTY write. It serializes
-// that write against authoritative state commits, so a pending_approval report
-// cannot land between the prompt and Enter. It is the shared primitive behind the
-// chief-of-staff doorbells (notebook activation, inbox nudge): a fixed trigger,
-// never arbitrary streamed content.
+// typeDoorbell types a bounded prompt as an explicit bracketed-paste event and
+// follows it with Enter in the same PTY write. The paste terminator gives Codex a
+// semantic boundary before Enter (so the prompt submits instead of remaining in
+// the composer), while the single write keeps the approval-state fence atomic.
+// It is the shared primitive behind the chief-of-staff doorbells (notebook
+// activation, inbox nudge): a fixed trigger, never arbitrary streamed content.
 func (d *Daemon) typeDoorbell(sessionID, prompt string) error {
 	d.doorbellMu.Lock()
 	defer d.doorbellMu.Unlock()
 	if session := d.store.Get(sessionID); session == nil || !isNudgeDeliveryAllowed(string(session.State)) {
 		return errDoorbellBlockedByApproval
 	}
-	input := make([]byte, 0, len(prompt)+1)
+	input := make([]byte, 0, len(bracketedPasteStart)+len(prompt)+len(bracketedPasteEnd)+1)
+	input = append(input, bracketedPasteStart...)
 	input = append(input, prompt...)
+	input = append(input, bracketedPasteEnd...)
 	input = append(input, '\r')
 	return d.ptyBackend.Input(context.Background(), sessionID, input)
 }

--- a/internal/daemon/notebook_test.go
+++ b/internal/daemon/notebook_test.go
@@ -709,15 +709,16 @@ func TestNotebookSendToChiefAppendsAndNudges(t *testing.T) {
 		t.Fatalf("send-to-chief result = %+v, want success inbox.md nudged", res.Result)
 	}
 
-	// Only the bounded doorbell + Enter was typed into the chief PTY as one atomic
-	// write — never the selection content itself (that goes to the inbox note, not
-	// the terminal).
+	// Only the bounded doorbell and its submit input were typed into the chief PTY
+	// as one bracketed, atomic write — never the selection content itself (that
+	// goes to the inbox note, not the terminal).
 	mu.Lock()
 	got := append([]string(nil), inputs...)
 	mu.Unlock()
 	wantNudge := chiefInboxNudgePrompt(d.store.GetSetting(SettingNotebookRoot))
-	if len(got) != 1 || got[0] != wantNudge+"\r" {
-		t.Fatalf("PTY inputs = %q, want one nudge-prompt-plus-Enter write", got)
+	wantInput := bracketedPasteStart + wantNudge + bracketedPasteEnd + "\r"
+	if len(got) != 1 || got[0] != wantInput {
+		t.Fatalf("PTY inputs = %q, want one atomic bracketed nudge-prompt-plus-Enter write", got)
 	}
 
 	body := readInboxNote(t, d)
@@ -776,7 +777,7 @@ func TestNotebookSendToChiefNudgesWorkingChief(t *testing.T) {
 	n := len(inputs)
 	mu.Unlock()
 	if n != 1 {
-		t.Fatalf("PTY inputs = %d, want one prompt-plus-Enter write", n)
+		t.Fatalf("PTY inputs = %d, want one atomic bracketed prompt-plus-Enter write", n)
 	}
 }
 

--- a/internal/daemon/nudge_countdown_test.go
+++ b/internal/daemon/nudge_countdown_test.go
@@ -214,8 +214,9 @@ func TestDoorbellWriteDoesNotInterleaveWithPendingApproval(t *testing.T) {
 		t.Fatalf("typeDoorbell() error = %v", err)
 	}
 	<-stateDone
-	if got := <-inputs; got != ticketNudgePrompt+"\r" {
-		t.Fatalf("doorbell input = %q, want one atomic prompt+Enter write", got)
+	want := bracketedPasteStart + ticketNudgePrompt + bracketedPasteEnd + "\r"
+	if got := <-inputs; got != want {
+		t.Fatalf("doorbell input = %q, want atomic bracketed prompt+Enter %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Intent / Why

Ticket nudges could appear in Codex's composer without being submitted, leaving the agent idle and the inbox unread. The doorbell still needs to remain one approval-fenced PTY write so a nudge cannot race with a permission prompt.

## Summary

- frame the bounded doorbell prompt as an explicit bracketed-paste event, with Enter outside the paste terminator but inside the same atomic PTY write
- update daemon coverage to assert the exact framed input while preserving the pending-approval state fence
- strengthen the packaged-app scenario so text injection alone cannot pass: it now requires a real Codex turn, inbox consumption, overlapping-event deduplication, and busy-session queue behavior
- document the user-visible fix and the transport boundary

## Test plan

- [x] `go test ./internal/daemon -count=1`
- [x] focused nudge tests under `go test -race`
- [x] `pnpm --dir app exec vitest run scripts/real-app-harness` (142 tests)
- [x] `go vet ./internal/daemon ./internal/ticketnotify ./internal/ptybackend`
- [x] signed `attn-dev.app` live scenario with real Codex v0.144.3: idle nudge submits, overlapping activity produces one doorbell, busy nudge queues and drains the inbox, no composer text remains stranded

`go test ./...` passed every package except a load-sensitive timeout in `TestCodexResumeMappingEndToEnd`; that test passed immediately in isolation, and the full `internal/daemon` package passed independently.

## Out of scope

- nudge eligibility, countdown timing, selection behavior, and recent-user-input guards are unchanged
- no plugin or agent-driver contract changes
