### PR TITLE
fix(terminal): keep canvas anchored in pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 - **Ticket nudges now submit in Codex instead of stopping in the composer.** The
   bounded inbox prompt is explicitly framed before Enter, so the nudge starts a
   turn while retaining the approval-prompt safety fence.
+- **Terminal content stays inside its pane even when the editable input host gains browser-managed content.** The rendered canvas is now anchored to the pane origin, preventing composition or editing layout from pushing its bottom rows offscreen.
 
 ## [2026-07-12]
 

--- a/app/e2e/terminal-interactions.spec.ts
+++ b/app/e2e/terminal-interactions.spec.ts
@@ -498,6 +498,32 @@ test.describe('Ghostty terminal interactions', () => {
     await expectOpenedUrl(page, url);
   });
 
+  test('keeps the canvas anchored when editable flow content appears before it', async ({ page, daemon }) => {
+    const terminal = await openTerminalSession(page, daemon, 's-editable-flow-offset');
+    await writeTerminalOutput(page, 's-editable-flow-offset', '\u001b[2J\u001b[Hanchored');
+
+    const geometry = await terminal.evaluate((element) => {
+      const canvas = element.querySelector('canvas');
+      if (!canvas) {
+        throw new Error('Terminal canvas not found');
+      }
+      const contaminant = document.createElement('div');
+      contaminant.dataset.testid = 'editable-flow-contaminant';
+      contaminant.style.height = '45px';
+      element.insertBefore(contaminant, canvas);
+
+      const terminalRect = element.getBoundingClientRect();
+      const canvasRect = canvas.getBoundingClientRect();
+      return {
+        offsetTop: canvasRect.top - terminalRect.top,
+        overflowBottom: canvasRect.bottom - terminalRect.bottom,
+      };
+    });
+
+    expect(geometry.offsetTop).toBeLessThanOrEqual(1);
+    expect(geometry.overflowBottom).toBeLessThanOrEqual(1);
+  });
+
   test('cmd+click opens a visible URL while terminal mouse tracking is active', async ({ page, daemon }) => {
     await installOpenerProbe(page);
     const terminal = await openTerminalSession(page, daemon, 's-link-tracked');

--- a/app/src/components/GhosttyTerminal.css
+++ b/app/src/components/GhosttyTerminal.css
@@ -143,7 +143,10 @@
   font: 12px var(--font-ui, sans-serif);
 }
 
-.ghostty-terminal canvas {
+.ghostty-terminal > canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
   display: block;
 }
 

--- a/app/src/components/GhosttyTerminal.tsx
+++ b/app/src/components/GhosttyTerminal.tsx
@@ -1844,9 +1844,6 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
           if (!model) return null;
           const activeRenderer = rendererRef.current;
           const activeContainer = containerRef.current;
-          const activeCanvas = canvasRef.current;
-          const containerRect = activeContainer?.getBoundingClientRect() ?? null;
-          const canvasRect = activeCanvas?.getBoundingClientRect() ?? null;
           return {
             cols: model.cols,
             rows: model.rows,
@@ -1856,12 +1853,9 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             // Mirrors renderSurface's inactive-session bail: a pane that is
             // not allowed to paint must not be judged blank by the watchdog.
             active: runtimeMetaRef.current ? runtimeMetaRef.current.isActiveSession : true,
-            // Geometry for the bottom-clip detector / on-demand dump. Reads the
-            // container/canvas live (forces a layout via getBoundingClientRect),
-            // so only the low-frequency sweep and the manual dump call this —
-            // never the per-frame paint path. The rects are DOM truth: they
-            // catch a canvas offset or mis-sized within its container even
-            // when the model's own row*cellHeight arithmetic looks clean.
+            // Geometry for the overflow detector / on-demand dump. Client
+            // dimensions are enough to identify stale PTY rows or columns;
+            // canvas placement is guaranteed structurally by CSS.
             session: runtimeMetaRef.current?.sessionId ?? undefined,
             isActivePane: runtimeMetaRef.current?.isActivePane ?? null,
             hasMeasuredSize: hasMeasuredSizeRef.current,
@@ -1869,23 +1863,10 @@ export const GhosttyTerminal = forwardRef<GhosttyTerminalHandle, GhosttyTerminal
             cellHeight: activeRenderer?.cellHeight ?? null,
             clientWidth: activeContainer?.clientWidth ?? null,
             clientHeight: activeContainer?.clientHeight ?? null,
-            containerTop: containerRect?.top ?? null,
-            containerBottom: containerRect?.bottom ?? null,
-            containerLeft: containerRect?.left ?? null,
-            containerRight: containerRect?.right ?? null,
-            canvasTop: canvasRect?.top ?? null,
-            canvasBottom: canvasRect?.bottom ?? null,
-            canvasLeft: canvasRect?.left ?? null,
-            canvasRight: canvasRect?.right ?? null,
-            canvasCssHeight: canvasRect?.height ?? null,
-            canvasPixelWidth: activeCanvas?.width ?? null,
-            canvasPixelHeight: activeCanvas?.height ?? null,
           };
         }, () => {
-          // Watchdog repair: re-assert container-truth geometry. fit() self-bails
-          // (sameSize / inactiveSession) so a spurious call is harmless; a fresh
-          // queued replay defers it via the replayPending skip, and the staleness
-          // bound guarantees a lying queue cannot defer it forever.
+          // Watchdog repair: re-assert container-owned geometry after the model
+          // remains larger than the visible pane across several sweeps.
           fitRef.current();
         });
         inputRef.current = new InputHandler(

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1772,7 +1772,7 @@ export function useUiAutomationBridge({
       }
       case 'dump_terminal_geometry': {
         // Same-moment app-side read of every mounted pane's model grid, cell
-        // metrics, clientWidth/Height, and DOM-truth canvas rects — avoids the
+        // metrics, and clientWidth/Height — avoids the
         // cross-clock ambiguity of comparing a harness screenshot's timestamp
         // against a separately-read disk dump.
         const snapshots = dumpTerminalGeometry();

--- a/app/src/utils/terminalDiagnosticsLog.test.ts
+++ b/app/src/utils/terminalDiagnosticsLog.test.ts
@@ -162,7 +162,7 @@ describe('blank-after-resize watchdog', () => {
   });
 });
 
-describe('bottom-clip detector', () => {
+describe('grid-overflow detector', () => {
   beforeEach(() => {
     window.localStorage.setItem('attn:terminal-diagnostics', '1');
     vi.useFakeTimers();
@@ -251,13 +251,12 @@ describe('bottom-clip detector', () => {
     });
   });
 
-  it('flags DOM-truth bottom overflow even when the model math is clean', () => {
-    const pane = 'pane-clip-dom-overflow';
-    // Model math is clean (rows*cellHeight == clientHeight), but the real
-    // canvas rect spills 5px past the container's bottom edge.
+  it('flags an active pane whose grid is one column wider than its container', () => {
+    const pane = 'pane-clip-right-overflow';
+    // floor(720/9)=80 columns fit, but the model still has 81 → 9px spill.
     const unregister = registerRenderProbe(pane, () => probeWith({
       rows: 25, cellHeight: 21, clientHeight: 525,
-      containerTop: 0, containerBottom: 525, canvasTop: 0, canvasBottom: 530,
+      cols: 81, cellWidth: 9, clientWidth: 720,
     }));
     vi.advanceTimersByTime(1600);
     unregister();
@@ -265,83 +264,32 @@ describe('bottom-clip detector', () => {
     const incidents = ringEventsFor(pane).filter((event) => event.kind === 'incident');
     expect(incidents).toHaveLength(1);
     expect(incidents[0]?.reason).toBe('bottom_clip');
-    expect(incidents[0]?.trigger).toEqual(['dom_overflow']);
-    expect(incidents[0]?.domOverflowPx).toBe(5);
-    expect(incidents[0]?.domOffsetTopPx).toBe(0);
+    expect(incidents[0]?.trigger).toEqual(['model_right']);
+    expect(incidents[0]?.rightOverflowPx).toBe(9);
+    expect(incidents[0]?.extraCols).toBe(1);
   });
 
-  it('flags a DOM-truth top offset even when the model math is clean', () => {
-    const pane = 'pane-clip-dom-offset';
-    const unregister = registerRenderProbe(pane, () => probeWith({
-      rows: 25, cellHeight: 21, clientHeight: 525,
-      containerTop: 0, containerBottom: 525, canvasTop: 4, canvasBottom: 525,
-    }));
-    vi.advanceTimersByTime(1600);
-    unregister();
-
-    const incidents = ringEventsFor(pane).filter((event) => event.kind === 'incident');
-    expect(incidents).toHaveLength(1);
-    expect(incidents[0]?.reason).toBe('bottom_clip');
-    expect(incidents[0]?.trigger).toEqual(['dom_offset']);
-    expect(incidents[0]?.domOffsetTopPx).toBe(4);
-    expect(incidents[0]?.domOverflowPx).toBe(0);
-  });
-
-  it('stays clean and resolves a previously-clipping pane when all three signals agree', () => {
+  it('resolves once both row and column geometry fit', () => {
     const pane = 'pane-clip-all-clean-then-resolve';
     let clipping = true;
     const unregister = registerRenderProbe(pane, () => (clipping
       ? probeWith({
         rows: 26, cellHeight: 21, clientHeight: 540,
-        containerTop: 0, containerBottom: 540, canvasTop: 0, canvasBottom: 546,
+        cols: 81, cellWidth: 9, clientWidth: 720,
       })
       : probeWith({
         rows: 25, cellHeight: 21, clientHeight: 525,
-        containerTop: 0, containerBottom: 525, canvasTop: 0, canvasBottom: 525,
+        cols: 80, cellWidth: 9, clientWidth: 720,
       })));
-    vi.advanceTimersByTime(1600); // onset (model + dom overflow agree)
+    vi.advanceTimersByTime(1600); // onset
     clipping = false;
-    vi.advanceTimersByTime(1600); // all three signals clean → resolution
+    vi.advanceTimersByTime(1600); // both model signals clean → resolution
     unregister();
 
     const reasons = ringEventsFor(pane)
       .filter((event) => event.kind === 'incident')
       .map((event) => event.reason);
     expect(reasons).toEqual(['bottom_clip', 'bottom_clip_resolved']);
-  });
-
-  it('flags a right-edge-only overflow that the bottom-only signals miss', () => {
-    const pane = 'pane-clip-right-overflow';
-    // Bottom is clean (even slightly under, i.e. negative overflow), but the
-    // canvas spills 7px past the container's right edge — the field repro
-    // this detector was blind to before the right/left signals were added.
-    const unregister = registerRenderProbe(pane, () => probeWith({
-      rows: 25, cellHeight: 21, clientHeight: 525,
-      containerTop: 0, containerBottom: 525, canvasTop: 0, canvasBottom: 525,
-      containerLeft: 0, containerRight: 720, canvasLeft: 0, canvasRight: 727,
-    }));
-    vi.advanceTimersByTime(1600);
-    unregister();
-
-    const incidents = ringEventsFor(pane).filter((event) => event.kind === 'incident');
-    expect(incidents).toHaveLength(1);
-    expect(incidents[0]?.reason).toBe('bottom_clip');
-    expect(incidents[0]?.trigger).toEqual(['dom_overflow_right']);
-    expect(incidents[0]?.domOverflowRightPx).toBe(7);
-    expect(incidents[0]?.domOffsetLeftPx).toBe(0);
-  });
-
-  it('stays clean when left/right rects agree with the container', () => {
-    const pane = 'pane-clip-lr-clean';
-    const unregister = registerRenderProbe(pane, () => probeWith({
-      rows: 25, cellHeight: 21, clientHeight: 525,
-      containerTop: 0, containerBottom: 525, canvasTop: 0, canvasBottom: 525,
-      containerLeft: 0, containerRight: 720, canvasLeft: 0, canvasRight: 720,
-    }));
-    vi.advanceTimersByTime(1600);
-    unregister();
-
-    expect(ringEventsFor(pane).filter((event) => event.kind === 'incident')).toHaveLength(0);
   });
 });
 

--- a/app/src/utils/terminalDiagnosticsLog.ts
+++ b/app/src/utils/terminalDiagnosticsLog.ts
@@ -13,17 +13,16 @@
 //     if the model holds content but the surface drew ~nothing, it writes an
 //     INCIDENT record (with ring context) to a separate file. That captures the
 //     blank automatically, so the user only has to keep using the app.
-//   - A second sweep (the bottom-clip detector) periodically checks each active
-//     pane for a grid that is taller than its container — the "last line cut off
-//     at the bottom of the window" bug. It records a `bottom_clip` incident (with
-//     ring context) when the clip appears and a `bottom_clip_resolved` marker
-//     when it clears, so the trigger sequence is captured in the wild.
+//   - A second sweep periodically checks each active pane for a grid that is
+//     larger than its container. It records a `bottom_clip` incident (the
+//     historical event name) when stale PTY geometry appears and a
+//     `bottom_clip_resolved` marker when it clears.
 //   - Disk writes are async/non-blocking and size-capped, so they never perturb
 //     the render timing we are trying to diagnose.
 //
 // Read the results from:
 //   $APPLOCALDATA/debug/terminal-diagnostics.jsonl   (lifecycle stream)
-//   $APPLOCALDATA/debug/terminal-incidents.jsonl      (auto-captured blanks + bottom clips)
+//   $APPLOCALDATA/debug/terminal-incidents.jsonl      (auto-captured blanks + grid overflow)
 //
 // Dump every mounted pane's live geometry on demand (DevTools console):
 //   window.__ATTN_TERMINAL_GEOMETRY()
@@ -50,10 +49,9 @@ const WATCHDOG_DELAYS_MS = [1200, 3500];
 // Do not emit more than one incident per pane within this window (avoids spam
 // while a pane stays blank across several repaint attempts).
 const INCIDENT_COOLDOWN_MS = 8000;
-// Bottom-clip detector: how often to sweep active panes for a rendered grid
-// taller than its container (the last row(s) clipped below the viewport). Low
-// frequency — the clip persists until a remount, so a slow sweep still catches
-// it, and the cost is one layout read per active pane per tick.
+// Geometry watchdog: how often to sweep active panes for a model grid larger
+// than its container. Low frequency because stale geometry persists until a
+// refit; the probe uses client dimensions and does not force layout.
 const BOTTOM_CLIP_SWEEP_MS = 1500;
 // Pixel slack mirroring geometryOverflowsContainer: ignore sub-pixel container
 // heights so we only act on a genuine extra row.
@@ -119,7 +117,7 @@ export interface RenderProbe {
   // "blank" is meaningless — it will paint on activation via the model's
   // accumulated dirty flag.
   active: boolean;
-  // Geometry for the bottom-clip detector / on-demand dump. Optional so other
+  // Geometry for the overflow detector / on-demand dump. Optional so other
   // probe producers and tests keep compiling; `null` means "not measured yet".
   session?: string;
   isActivePane?: boolean | null;
@@ -128,20 +126,6 @@ export interface RenderProbe {
   cellHeight?: number | null;
   clientWidth?: number | null;
   clientHeight?: number | null;
-  // DOM-truth rects, so the detector can also catch a canvas that disagrees
-  // with the model (offset within its container, or a size mismatch) rather
-  // than only judging the model's own arithmetic.
-  containerTop?: number | null;
-  containerBottom?: number | null;
-  containerLeft?: number | null;
-  containerRight?: number | null;
-  canvasTop?: number | null;
-  canvasBottom?: number | null;
-  canvasLeft?: number | null;
-  canvasRight?: number | null;
-  canvasCssHeight?: number | null;
-  canvasPixelWidth?: number | null;
-  canvasPixelHeight?: number | null;
 }
 
 export interface TerminalGeometrySnapshot {
@@ -159,13 +143,7 @@ export interface TerminalGeometrySnapshot {
   flooredCols: number | null;
   flooredRows: number | null;
   overflowPx: number | null;
-  domOverflowPx: number | null;
-  domOffsetTopPx: number | null;
-  domOverflowRightPx: number | null;
-  domOffsetLeftPx: number | null;
-  canvasCssHeight: number | null;
-  canvasPixelWidth: number | null;
-  canvasPixelHeight: number | null;
+  rightOverflowPx: number | null;
   clipping: boolean;
 }
 
@@ -200,13 +178,13 @@ let ringNextIndex = 0;
 let ringWrapped = false;
 const paneHealth = new Map<string, PaneHealth>();
 const renderProbes = new Map<string, () => RenderProbe | null>();
-// Optional per-pane repair callback (a refit) for the bottom-clip watchdog.
+// Optional per-pane repair callback (a refit) for the grid-overflow watchdog.
 const repairHandlers = new Map<string, () => void>();
 const watchdogTimers = new Map<string, ReturnType<typeof setTimeout>[]>();
-// Per-pane "currently clipping at the bottom" flag so the detector reports the
-// clip's onset (and its resolution) once, not on every sweep tick.
+// Per-pane overflow flag so the detector reports onset and resolution once,
+// not on every sweep tick.
 const clipState = new Map<string, boolean>();
-// Per-pane bottom-clip repair progress: consecutive clipping sweeps, repair
+// Per-pane grid-overflow repair progress: consecutive clipping sweeps, repair
 // attempts made, the earliest wall-clock time the next attempt may fire, and
 // whether the watchdog has given up on this continuous clip.
 const clipRepairState = new Map<
@@ -605,13 +583,12 @@ function maybeFlushIncident(pane: string, reason: string, detail: Record<string,
   enqueueWrite('incident', `${JSON.stringify(record)}\n`);
 }
 
-// --- Bottom-clip detector --------------------------------------------------
-// `fit()` floors rows so it can never overflow, but the daemon's authoritative
-// geometry is applied unfloored and the floor-correction (`fit()`) bails while
-// a pane is inactive — so a pane can end up one or two rows taller than its
-// container with no container resize to re-fire the ResizeObserver, clipping the
-// bottom line below the viewport. This sweep notices that state on any active
-// pane and captures it with full ring context (the resize trail that led there).
+// --- Grid-overflow detector ------------------------------------------------
+// The daemon's authoritative geometry can temporarily outlive the client
+// viewport that produced it, especially while panes are inactive. This sweep
+// notices persistent extra rows or columns after activation, captures the
+// resize trail, and asks `fit()` to reassert container-owned geometry. Event
+// names retain `bottom_clip` for compatibility with existing incident logs.
 
 function bottomClipOverflowPx(probe: RenderProbe): number | null {
   const cellHeight = probe.cellHeight ?? 0;
@@ -622,35 +599,13 @@ function bottomClipOverflowPx(probe: RenderProbe): number | null {
   return probe.rows * cellHeight - clientHeight;
 }
 
-// DOM-truth signals: computed straight from getBoundingClientRect(), so they
-// catch a canvas that is offset or mis-sized within its container even when
-// the model's own row*cellHeight arithmetic looks clean.
-function domOverflowPx(probe: RenderProbe): number | null {
-  if (probe.canvasBottom == null || probe.containerBottom == null) {
+function rightClipOverflowPx(probe: RenderProbe): number | null {
+  const cellWidth = probe.cellWidth ?? 0;
+  const clientWidth = probe.clientWidth ?? 0;
+  if (cellWidth <= 0 || clientWidth <= 0 || probe.cols <= 0) {
     return null;
   }
-  return probe.canvasBottom - probe.containerBottom;
-}
-
-function domOffsetTopPx(probe: RenderProbe): number | null {
-  if (probe.canvasTop == null || probe.containerTop == null) {
-    return null;
-  }
-  return probe.canvasTop - probe.containerTop;
-}
-
-function domOverflowRightPx(probe: RenderProbe): number | null {
-  if (probe.canvasRight == null || probe.containerRight == null) {
-    return null;
-  }
-  return probe.canvasRight - probe.containerRight;
-}
-
-function domOffsetLeftPx(probe: RenderProbe): number | null {
-  if (probe.canvasLeft == null || probe.containerLeft == null) {
-    return null;
-  }
-  return probe.canvasLeft - probe.containerLeft;
+  return probe.cols * cellWidth - clientWidth;
 }
 
 function recordBottomClipIncident(pane: string, detail: Record<string, unknown>): void {
@@ -717,27 +672,21 @@ function sweepBottomClip(): void {
       continue;
     }
     const overflowPx = bottomClipOverflowPx(probe);
-    const domOverflow = domOverflowPx(probe);
-    const domOffset = domOffsetTopPx(probe);
-    const domOverflowRight = domOverflowRightPx(probe);
-    const domOffsetLeft = domOffsetLeftPx(probe);
-    if (
-      overflowPx == null && domOverflow == null && domOffset == null
-      && domOverflowRight == null && domOffsetLeft == null
-    ) {
+    const rightOverflowPx = rightClipOverflowPx(probe);
+    if (overflowPx == null && rightOverflowPx == null) {
       clipRepairState.delete(pane);
       continue;
     }
     const trigger: string[] = [];
     if (overflowPx != null && overflowPx > BOTTOM_CLIP_SLACK_PX) trigger.push('model');
-    if (domOverflow != null && domOverflow > BOTTOM_CLIP_SLACK_PX) trigger.push('dom_overflow');
-    if (domOffset != null && domOffset > BOTTOM_CLIP_SLACK_PX) trigger.push('dom_offset');
-    if (domOverflowRight != null && domOverflowRight > BOTTOM_CLIP_SLACK_PX) trigger.push('dom_overflow_right');
-    if (domOffsetLeft != null && domOffsetLeft > BOTTOM_CLIP_SLACK_PX) trigger.push('dom_offset_left');
+    if (rightOverflowPx != null && rightOverflowPx > BOTTOM_CLIP_SLACK_PX) trigger.push('model_right');
     const clipping = trigger.length > 0;
     const cellHeight = probe.cellHeight ?? 0;
+    const cellWidth = probe.cellWidth ?? 0;
     const clientHeight = probe.clientHeight ?? 0;
+    const clientWidth = probe.clientWidth ?? 0;
     const flooredRows = cellHeight > 0 ? Math.floor(clientHeight / cellHeight) : 0;
+    const flooredCols = cellWidth > 0 ? Math.floor(clientWidth / cellWidth) : 0;
 
     if (!clipping) {
       // Full reset: the clip is gone (or never started this sweep). Keep the
@@ -757,13 +706,13 @@ function sweepBottomClip(): void {
         rows: probe.rows,
         cols: probe.cols,
         flooredRows,
+        flooredCols,
         overflowPx: overflowPx == null ? null : Math.round(overflowPx),
-        domOverflowPx: domOverflow == null ? null : Math.round(domOverflow),
-        domOffsetTopPx: domOffset == null ? null : Math.round(domOffset),
-        domOverflowRightPx: domOverflowRight == null ? null : Math.round(domOverflowRight),
-        domOffsetLeftPx: domOffsetLeft == null ? null : Math.round(domOffsetLeft),
+        rightOverflowPx: rightOverflowPx == null ? null : Math.round(rightOverflowPx),
         cellHeight,
+        cellWidth,
         clientHeight,
+        clientWidth,
         repairAttempts: priorState?.attempts ?? 0,
       });
       continue;
@@ -779,19 +728,15 @@ function sweepBottomClip(): void {
         rows: probe.rows,
         cols: probe.cols,
         flooredRows,
+        flooredCols,
         extraRows: probe.rows - flooredRows,
+        extraCols: probe.cols - flooredCols,
         overflowPx: overflowPx == null ? null : Math.round(overflowPx),
-        domOverflowPx: domOverflow == null ? null : Math.round(domOverflow),
-        domOffsetTopPx: domOffset == null ? null : Math.round(domOffset),
-        domOverflowRightPx: domOverflowRight == null ? null : Math.round(domOverflowRight),
-        domOffsetLeftPx: domOffsetLeft == null ? null : Math.round(domOffsetLeft),
+        rightOverflowPx: rightOverflowPx == null ? null : Math.round(rightOverflowPx),
         cellHeight,
-        cellWidth: probe.cellWidth ?? null,
+        cellWidth,
         clientHeight,
-        clientWidth: probe.clientWidth ?? null,
-        canvasCssHeight: probe.canvasCssHeight == null ? null : Math.round(probe.canvasCssHeight),
-        canvasPixelWidth: probe.canvasPixelWidth ?? null,
-        canvasPixelHeight: probe.canvasPixelHeight ?? null,
+        clientWidth,
         hasMeasuredSize: probe.hasMeasuredSize ?? null,
         isActivePane: probe.isActivePane ?? null,
         session: probe.session,
@@ -835,7 +780,7 @@ function sweepBottomClip(): void {
           rows: probe.rows,
           cols: probe.cols,
           overflowPx: overflowPx == null ? null : Math.round(overflowPx),
-          domOverflowPx: domOverflow == null ? null : Math.round(domOverflow),
+          rightOverflowPx: rightOverflowPx == null ? null : Math.round(rightOverflowPx),
         }, probe.session);
         try {
           repair();
@@ -881,10 +826,7 @@ export function dumpTerminalGeometry(): TerminalGeometrySnapshot[] {
     const clientHeight = probe.clientHeight ?? null;
     const clientWidth = probe.clientWidth ?? null;
     const overflowPx = cellHeight && clientHeight ? probe.rows * cellHeight - clientHeight : null;
-    const domOverflow = domOverflowPx(probe);
-    const domOffset = domOffsetTopPx(probe);
-    const domOverflowRight = domOverflowRightPx(probe);
-    const domOffsetLeft = domOffsetLeftPx(probe);
+    const rightOverflowPx = cellWidth && clientWidth ? probe.cols * cellWidth - clientWidth : null;
     snapshots.push({
       pane,
       session: probe.session,
@@ -900,18 +842,9 @@ export function dumpTerminalGeometry(): TerminalGeometrySnapshot[] {
       flooredCols: cellWidth && clientWidth ? Math.floor(clientWidth / cellWidth) : null,
       flooredRows: cellHeight && clientHeight ? Math.floor(clientHeight / cellHeight) : null,
       overflowPx: overflowPx == null ? null : Math.round(overflowPx),
-      domOverflowPx: domOverflow == null ? null : Math.round(domOverflow),
-      domOffsetTopPx: domOffset == null ? null : Math.round(domOffset),
-      domOverflowRightPx: domOverflowRight == null ? null : Math.round(domOverflowRight),
-      domOffsetLeftPx: domOffsetLeft == null ? null : Math.round(domOffsetLeft),
-      canvasCssHeight: probe.canvasCssHeight == null ? null : Math.round(probe.canvasCssHeight),
-      canvasPixelWidth: probe.canvasPixelWidth ?? null,
-      canvasPixelHeight: probe.canvasPixelHeight ?? null,
+      rightOverflowPx: rightOverflowPx == null ? null : Math.round(rightOverflowPx),
       clipping: (overflowPx != null && overflowPx > BOTTOM_CLIP_SLACK_PX)
-        || (domOverflow != null && domOverflow > BOTTOM_CLIP_SLACK_PX)
-        || (domOffset != null && domOffset > BOTTOM_CLIP_SLACK_PX)
-        || (domOverflowRight != null && domOverflowRight > BOTTOM_CLIP_SLACK_PX)
-        || (domOffsetLeft != null && domOffsetLeft > BOTTOM_CLIP_SLACK_PX),
+        || (rightOverflowPx != null && rightOverflowPx > BOTTOM_CLIP_SLACK_PX),
     });
   }
   enqueueWrite('incident', `${JSON.stringify({ at: Date.now(), kind: 'geometry_dump', snapshots })}\n`);

--- a/docs/alignment/terminal-canvas-origin.md
+++ b/docs/alignment/terminal-canvas-origin.md
@@ -1,0 +1,16 @@
+# Terminal canvas origin
+
+## Why
+
+The terminal model can have the correct row and column geometry while its canvas is displaced inside the editable terminal host, leaving the bottom rows rendered outside the visible pane. This chunk is done when editable-flow content cannot move the canvas away from the pane origin and the behavior is proven in a packaged non-production app.
+
+## Aligned on
+
+- Keep the terminal's editable host and existing keyboard, composition, and IME behavior.
+- Remove the canvas from editable document flow by anchoring it to the host's top-left corner; the renderer remains the authority for its explicit width and height.
+- Add a regression that contaminates the editable flow ahead of the canvas and proves the canvas stays anchored.
+- Verify the fix against the existing offset diagnostics and packaged-app scenario in a non-production profile.
+
+## In scope / deferred
+
+This chunk fixes and verifies the positional rendering bug and updates the user-facing changelog. Simplifying the detector, recovery behavior, and temporary terminal diagnostics is deferred until the fix is proven, so cleanup can be based on which safeguards still provide value.

--- a/docs/alignment/terminal-overflow-diagnostics-cleanup.md
+++ b/docs/alignment/terminal-overflow-diagnostics-cleanup.md
@@ -1,0 +1,16 @@
+# Terminal overflow diagnostics cleanup
+
+## Why
+
+The terminal diagnostics currently treat model-size overflow and DOM-position drift as the same incident even though only model-size overflow can be repaired by `fit()`. With the canvas structurally anchored, continuing to force container and canvas rectangle reads every sweep adds complexity and can still trigger futile repair attempts.
+
+## Aligned on
+
+- Remove DOM-position and DOM-rectangle signals from the production render probe and geometry snapshot.
+- Keep the low-frequency overflow watchdog for stale PTY geometry, covering both rows and columns from model dimensions and renderer cell metrics.
+- Only attempt `fit()` for overflow that a geometry change can actually repair.
+- Keep the packaged offset soak and the direct editable-flow regression as verification coverage.
+
+## In scope / deferred
+
+This chunk simplifies terminal overflow diagnostics, repair tests, and comments. The separate blank/underdraw detector, lifecycle ring buffer, and packaged terminal scenarios remain because they cover different failure modes.


### PR DESCRIPTION
## Intent / Why

Production diagnostics captured terminal panes whose model geometry fit the container while the rendered canvas was displaced downward inside the editable host. That left the bottom rows offscreen, and the existing watchdog repeatedly called `fit()` even though it correctly bailed with `sameSize`.

This change keeps the rendered terminal surface structurally contained and narrows automatic repair to geometry that a refit can actually change.

## Summary

- anchor the direct terminal canvas to the pane origin so browser-managed editable content cannot move rendered rows offscreen
- add an interaction regression that inserts editable-flow content before the canvas and verifies it remains contained
- remove DOM-rectangle polling and DOM-offset incident fields from terminal diagnostics
- retain delayed repair for actionable model overflow in both rows and columns, preserving existing incident event names
- document the user-visible fix in the changelog

## Test plan

- [x] `pnpm --dir app test` — 148 files, 1,463 tests
- [x] `pnpm --dir app run build`
- [x] terminal interaction Playwright spec — 19 tests
- [x] packaged dev app offset soak — 300 steps, no persistent violation
- [x] packaged dev app post-cleanup smoke — 60 steps, no persistent violation; one resize transient self-healed in 750 ms

## Out of scope

- Production was not rebuilt or restarted. All live verification used the isolated dev profile.
