### PR TITLE
Centralize daemon session state transitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,11 @@ Canonical example: `sendPRAction` in `app/src/hooks/useDaemonSocket.ts`.
 
 ### 3. Classifier Timestamp Protection
 
-Classifier work is asynchronous and can be slow. Capture the timestamp before classification starts and update state via `UpdateStateWithTimestamp()` so stale classifier results cannot overwrite fresher runtime state.
+Every persisted daemon session-state transition must go through `applyState` in
+`internal/daemon/session_state.go`; direct store state writes bypass required
+effects and are structurally forbidden. Classifier work is asynchronous and can
+be slow, so capture its observation timestamp before classification starts and
+pass it through `classifierObservation` so the door rejects stale results.
 
 ### 4. Review Comment Fan-Out
 

--- a/docs/plans/2026-07-02-session-state-door.md
+++ b/docs/plans/2026-07-02-session-state-door.md
@@ -1,185 +1,327 @@
-# Plan: One door for session state (`applyState`)
+# Plan: One daemon door for session state
 
-From the 2026-07-01 architecture review (top recommendation). Line references are
-as of commit `80c62f6b` — always re-anchor by symbol name, not line number.
+Re-anchored on 2026-07-13 at `7d3cb647`. The original 2026-07-02 diagnosis is
+still correct, but its proposed single timestamp-CAS store method predates the
+ticket-doorbell fence and sequenced plugin state reports.
 
-## Goal
+## Why / Alignment
 
-Session state writes are smeared across four copy-pasted choreographies plus five
-raw `store.UpdateState` calls, each applying a *different subset* of guards and
-side effects. The stale-classifier guard (`UpdateStateWithTimestamp`) is a
-convention with exactly one caller, documented as AGENTS.md Critical Pattern #3
-instead of being enforced by an interface.
+Session state is a daemon-level transition, not merely a store field update. A
+successful transition may update long-run tracking, refresh `last_seen`, fence
+ticket-doorbell delivery, broadcast the decorated session, and recompute its
+workspace. Those responsibilities are still spread across several callers, so
+new invariants have had to be patched into each choreography by convention.
 
-Deepen this into one module: every session state transition goes through a single
-`applyState` door that owns the guards, side effects, and broadcast. A bug fixed
-there is fixed for every writer. AGENTS.md #3 stops being tribal knowledge.
+We are aligned on preserving the original one-door goal with these corrections:
 
-**This is a behavior-preserving refactor.** No state transition, guard, or
-broadcast may change observably. The per-source differences below are the spec.
+- The door lives in `internal/daemon/session_state.go` and is the only daemon
+  module allowed to invoke a store session-state mutation.
+- Callers identify a closed semantic cause rather than assembling a bag of
+  boolean options. The cause selects one valid commit rule and effect profile.
+- The store keeps its distinct atomic primitives: unconditional state write,
+  classifier timestamp CAS, and plugin run/sequence CAS. They protect different
+  invariants and must not be collapsed into a timestamp fiction.
+- `applyStateAndSyncNudge` is absorbed into the door. For nudge-aware causes,
+  the state commit remains serialized with the complete doorbell write via
+  `doorbellMu`; nudge reconciliation still runs after releasing the lock.
+- Startup recovery remains silent and process exit preserves its pre-clobber
+  ticket reconciliation. Centralization must not homogenize intentionally
+  different lifecycle behavior.
+
+This chunk is a behavior-preserving daemon refactor. It does not change state
+semantics, nudge eligibility, plugin sequencing, recovery broadcasts, or exit
+classification. Typed store change events, the broader daemon broadcast pump,
+and extraction of classifier decision logic are deferred.
 
 ## Architecture Map
 
 ```text
-Current (4 choreographies + 5 raw writes, all converging on store.UpdateState):
+Current:
+hook / PTY
+  -> duplicated run tracking
+  -> applyStateAndSyncNudge(UpdateState + Touch)
+  -> duplicated session broadcast + workspace recompute
 
-hook/socket path      -> handleState (daemon.go ~2104)
-                           markRunStartedIfNeeded/clearLongRunTracking
-                           store.UpdateState + store.Touch
-                           cancelNudgeOnLeaveIdle, sendOK
-                           broadcast + recomputeAndBroadcastWorkspaceForSession
-PTY detector          -> handlePTYState (daemon.go ~1513)
-                           guard: GetAgentDriverRun + pluginDriverReportsState
-                           guard: agentdriver.ShouldApplyPTYState
-                           same as above + go notifyTicketSessionWentIdle (on idle)
-classifier            -> updateAndBroadcastStateWithTimestamp (daemon.go ~2775)
-                           store.UpdateStateWithTimestamp (CAS)  <- the ONLY guarded door
-transcript watcher    -> updateAndBroadcastState (daemon.go ~2750)
-                           same but NO store.Touch
-startup recovery      -> raw store.UpdateState (daemon.go ~844, ~1121, ~1132, ~1167)
-session exit          -> raw store.UpdateState (daemon.go ~1398) + Touch + broadcast
+transcript / long-run review
+  -> updateAndBroadcastState
+  -> duplicated run tracking
+  -> applyStateAndSyncNudge(UpdateState)
+  -> duplicated broadcast
+
+classifier
+  -> updateAndBroadcastStateWithTimestamp
+  -> applyStateAndSyncNudge(UpdateStateWithTimestamp)
+  -> duplicated accepted-only effects
+
+plugin report
+  -> applyStateAndSyncNudge(ApplyAgentDriverState)
+  -> duplicated accepted-only tracking + Touch + broadcast
+
+startup recovery -> five raw UpdateState calls -> later batch workspace reseed
+process exit      -> pre-clobber ticket reconcile -> raw UpdateState + broadcast
 
 Target:
+source-specific trust / lifecycle guard
+  -> d.applyState(sessionStateChange{cause: <closed cause>})
+       -> select the cause's atomic store commit
+       -> if nudge-aware: commit under doorbellMu
+       -> reject? stop; no side effects
+       -> accepted effect profile
+            Touch (where current source does)
+            long-run tracking (for live observations)
+            syncNudgeForState (for live/nudge-aware sources)
+            broadcastSessionStateChanged + workspace recompute (unless recovery)
 
-every writer
-  -> d.applyState(sessionID, state, stateChangeOpts{...})   // one module: session_state.go
-       -> guards (per opts)
-       -> run-tracking side effects
-       -> store write (always timestamp-CAS)
-       -> nudge cancel, ticket doorbell (per opts)
-       -> broadcast + workspace recompute (per opts)
-grep proof: store.UpdateState( appears ONLY inside session_state.go
+Tests:
+session_state_test.go
+  -> real in-memory SQLite store + daemon broadcast recorder
+  -> table of causes x accepted/rejected commit
+  -> existing concurrency, recovery, plugin, classifier, and lifecycle tests
 ```
 
-## Data Model / Interfaces
+## Transition Model
 
-New file `internal/daemon/session_state.go`:
+Use package-private cause variants so callers can express only meaningful
+combinations. Exact names may move slightly during implementation, but preserve
+this shape:
 
 ```go
-// stateChangeOpts encodes the (small, deliberate) differences between writers.
-// The defaults reproduce updateAndBroadcastState. Every field maps 1:1 to a
-// behavior in the Current tree above — do not invent new combinations.
-type stateChangeOpts struct {
-    observedAt   time.Time // zero => time.Now(); classifier passes its captured start time
-    touch        bool      // hook, PTY, session-exit paths set true
-    broadcast    bool      // default true; some recovery writes set false
-    ticketNudge  bool      // PTY path only: go notifyTicketSessionWentIdle on idle
+type sessionStateChange struct {
+    sessionID string
+    state     string
+    cause     sessionStateCause
 }
 
-// applyState is the ONLY place allowed to call store.UpdateState*.
-// Returns false when the CAS rejects a stale write.
-func (d *Daemon) applyState(sessionID, state string, opts stateChangeOpts) bool
+type sessionStateCause interface { isSessionStateCause() }
+
+type liveSignal struct{}                         // hook or trusted PTY signal
+type daemonObservation struct{}                  // transcript watcher / long-run handoff
+type classifierObservation struct{ observedAt time.Time }
+type pluginReport struct{ runID string; seq uint64 }
+type startupRecovery struct{}
+type processExit struct{}
+
+// applyState is the only daemon door for a persisted session-state transition.
+// It returns false when the session is missing or the cause-specific CAS rejects.
+func (d *Daemon) applyState(change sessionStateChange) bool
 ```
 
-Store side: `UpdateState(id, state)` becomes a thin wrapper over
-`UpdateStateWithTimestamp(id, state, time.Now())` (a fresh timestamp always wins,
-so current callers keep identical behavior), then delete the wrapper once the
-daemon only calls the timestamped method through `applyState`.
+The variants are a Go sum-type approximation. Do not replace them with exported
+flags such as `touch`, `broadcast`, or `ticketNudge`; allowing callers to invent
+new combinations recreates the problem this module is meant to solve.
 
-The PTY-specific guards (`GetAgentDriverRun`/`pluginDriverReportsState`,
-`ShouldApplyPTYState`) stay in `handlePTYState` *before* the `applyState` call —
-they are about whether the PTY observation is trustworthy, not about how a state
-write happens. `handlePTYState` shrinks to guards + one `applyState` call.
+### Cause policy
+
+| Cause | Current producers | Atomic store commit | Touch | Run tracking | Nudge fence + sync | State/workspace broadcast |
+| --- | --- | --- | --- | --- | --- | --- |
+| `liveSignal` | hook, trusted PTY | unconditional | yes | yes | yes | yes |
+| `daemonObservation` | transcript watcher, immediate long-run-review handoff | unconditional | no | yes | yes | yes |
+| `classifierObservation` | slow classifier result | timestamp CAS at `observedAt` | no | accepted only | accepted only | accepted only |
+| `pluginReport` | authorized plugin state/stop report | active-run + increasing-sequence CAS | yes | accepted only | accepted only | accepted only |
+| `startupRecovery` | prune and worker reconciliation | unconditional | no | no | no | no; batch reseed remains authoritative |
+| `processExit` | PTY exit idle-clobber | unconditional | yes | no; exit cleanup already owns it | no; do not re-arm a dead PTY | yes |
+
+`working` starts long-run tracking when needed. `idle` and `scheduled` clear it.
+Other states leave it unchanged, matching current behavior. Effects occur only
+after an accepted commit; a stale classifier result, stale plugin sequence, or
+missing session produces no touch, tracking, nudge, or broadcast effects.
+
+### Apply order and concurrency
+
+```text
+derive commit + effect profile from cause
+if cause is nudge-aware:
+    doorbellMu.Lock
+commit state using the cause-specific store primitive
+if cause is nudge-aware:
+    doorbellMu.Unlock
+if rejected: return false
+
+Touch if required
+update long-run tracking if required
+syncNudgeForState if required       # outside doorbellMu; may inspect tickets/arm timer
+broadcastSessionStateChanged if required
+return true
+```
+
+Only the state commit participates in the doorbell fence. Once
+`pending_approval` is committed, a competing `typeDoorbell` acquires the same
+lock, observes the new state, and refuses to type the prompt. Touch, tracking,
+ticket reads, timer work, and broadcasts stay outside the critical section.
+
+Change `store.UpdateState(id, state)` to return `bool`: true when a row was
+updated, false for a missing session or database error. Existing callers may
+ignore the result, while the state door can guarantee that rejected/missing
+writes have no follow-on effects. Keep `UpdateStateWithTimestamp` and
+`ApplyAgentDriverState` as separate bool-returning atomic primitives.
 
 ## Boundaries
 
-- `session_state.go` owns: run tracking (`markRunStartedIfNeeded`,
-  `clearLongRunTracking`), the store write, `cancelNudgeOnLeaveIdle`, the ticket
-  doorbell dispatch, the `EventSessionStateChanged` broadcast, and
-  `recomputeAndBroadcastWorkspaceForSession`.
-- Callers own: source-specific guards (PTY trust checks), transport replies
-  (`sendOK` stays in `handleState`), and *when* to capture `observedAt`
-  (classifier captures before slow work — keep `classificationStartTime` at the
-  top of `classifySessionState`).
-- Nothing outside `session_state.go` may call `d.store.UpdateState` or
-  `d.store.UpdateStateWithTimestamp`. Reads (`store.Get`) are unrestricted.
-- Hook-authoritative states must survive: do not weaken `ShouldApplyPTYState`
-  (see AGENTS.md; the per-agent policy seam in `internal/agent/daemon_policy.go`
-  is correct and stays).
+- `session_state.go` owns cause-to-policy mapping, store state mutation,
+  transition-derived long-run effects, nudge fencing/reconciliation, Touch, and
+  invocation of the normal state/workspace broadcast.
+- `handlePTYState` keeps `GetAgentDriverRun` / `pluginDriverReportsState` and
+  `agentdriver.ShouldApplyPTYState` guards. They decide whether a PTY observation
+  is trustworthy, before a transition exists.
+- Plugin handlers keep connection authorization, run ownership validation, and
+  payload validation. `pluginReport` carries the already-validated run/sequence
+  cursor into the atomic commit.
+- `classifySessionState` captures `classificationStartTime` before slow work and
+  passes it as `classifierObservation.observedAt`.
+- `handleState` keeps socket logging and `sendOK`; transport concerns do not
+  enter the state module.
+- `handlePTYExit` keeps teardown and `reconcileTicketsOnSessionEnd` before the
+  idle transition, because ticket outcome depends on the pre-clobber state. Its
+  unconditional lifecycle cleanup may clear long-run state independently of
+  whether a session row still exists.
+- Startup recovery still calls `reseedWorkspaceStatuses` after silent state
+  rewrites and before clients cross the recovery barrier. Per-session recovery
+  broadcasts remain forbidden.
+- `broadcastSessionStateChanged` remains reusable by nudge-indicator changes;
+  the state door owns calling it for accepted state transitions, not the helper
+  itself.
+- Tests may call store primitives directly to construct state. Non-test daemon
+  code outside `session_state.go` may not call `UpdateState`,
+  `UpdateStateWithTimestamp`, or `ApplyAgentDriverState`.
 
 ## Implementation Steps
 
-- [ ] PR 1 — the door. Add `session_state.go` with `applyState` + `stateChangeOpts`.
-      Rewrite the four choreographies as calls into it (`handleState`,
-      `handlePTYState`, `updateAndBroadcastState`,
-      `updateAndBroadcastStateWithTimestamp` — keep the last two as one-line
-      deprecated wrappers if that shrinks the diff, then inline them in PR 2).
-      Add table-driven tests for `applyState` itself: per-source option sets ×
-      (fresh timestamp, stale timestamp) asserting store state, broadcast
-      emission (use `BroadcastRecorder` from `testharness.go`), touch, and
-      nudge-cancel calls.
-- [ ] PR 2 — fold the stragglers. Convert the five raw sites (recovery writes at
-      daemon.go ~844/~1121/~1132/~1167 — keep `broadcast:false` to match today;
-      session-exit at ~1398 with `touch:true`) and the transcript-watcher calls.
-      Delete the wrapper methods. Add the structural guard: a test asserting
-      `store.UpdateState` has no non-test callers outside `session_state.go`.
-      While folding, grep the whole daemon package for other writers you may
-      have missed (`grep -rn 'store\.UpdateState' internal/daemon`) — fold every
-      hit, don't leave stragglers.
-- [ ] PR 3 — shrink AGENTS.md #3. Replace the "Classifier Timestamp Protection"
-      pattern text with two sentences pointing at `applyState` as the invariant
-      owner.
-- [ ] Optional PR 4 — `stopdecision`. Extract the non-LLM parts of
-      `classifySessionState` (pending-todo fast path, capability gates,
-      empty-message → idle, parse-error → unknown) into a pure
-      `Decide(session, transcriptText, classifier) (state, ok)` module so the
-      WAITING/DONE decision is unit-testable without driving the 110-line daemon
-      method.
+- [x] Before changing production code, add characterization tests through the
+      existing hook, PTY, long-run handoff, classifier, plugin, and exit entry
+      points. Assert the full stored/effect outcome and make this suite pass on
+      the pre-refactor implementation. During migration, do not weaken or
+      rewrite these expectations to fit `applyState`.
+- [x] Make `store.UpdateState` return whether it updated a session. Cover a
+      successful write and a missing-session rejection without changing its
+      unconditional timestamp semantics.
+- [x] Add `internal/daemon/session_state.go` with the cause variants, one
+      `applyState` entry point, cause-specific commits, accepted-only effects,
+      and concise source-aware logging for rejected guarded writes.
+- [x] Add `internal/daemon/session_state_test.go` with table-driven coverage for
+      every cause profile. Assert stored state, `LastSeen`, long-run tracking,
+      session/workspace broadcasts, and that rejected classifier/plugin writes
+      produce no effects.
+- [x] Fold the nudge-aware producers through the door:
+  - [x] `handleState` and `handlePTYState` use `liveSignal`; the PTY path keeps
+        only its trust guards before the call, while duplicated transition
+        effects move into the door.
+  - [x] Transcript-watcher line/tick results and the immediate long-run-review
+        handoff use `daemonObservation`.
+  - [x] Every classifier outcome uses `classifierObservation` with the captured
+        start time.
+  - [x] Plugin state and stop reports use `pluginReport`; preserve stale
+        sequence/run rejection and handler return behavior.
+- [x] Delete `updateAndBroadcastState`,
+      `updateAndBroadcastStateWithTimestamp`, and
+      `applyStateAndSyncNudge` once their last production callers are gone.
+      Keep `syncNudgeForState` as the ticket-policy seam called by the door.
+- [x] Fold lifecycle stragglers through explicit causes:
+  - [x] All prune/recovery writes use `startupRecovery` and remain silent.
+  - [x] The PTY-exit idle write uses `processExit` after pre-clobber ticket
+        reconciliation and backend teardown.
+- [x] Add a structural test using `go/parser`/`go/ast` that scans non-test Go
+      files in `internal/daemon` and rejects calls to the three store state
+      mutation methods outside `session_state.go`. This catches the plugin CAS
+      path that the original grep proof missed.
+- [x] Replace AGENTS.md "Classifier Timestamp Protection" with the stronger
+      invariant: all daemon state transitions use `applyState`; classifier
+      callers must still capture and pass the observation timestamp.
+- [x] Run automated verification and packaged-app process lifecycle verification.
+      The Codex nudge scenario reached `working` twice but could not complete
+      because Codex emitted `task_complete` with `last_agent_message: null`, so
+      no normal stop hook existed for attn to observe. No changelog entry is
+      expected because the refactor has no intended user-visible behavior change.
+
+Implement this as one PR with reviewable commits rather than landing a partial
+door across several PRs. The invariant is only real once every production writer
+and the structural guard land together.
 
 ## Decisions
 
-- Store keeps ONE write method (timestamped CAS); "un-guarded" callers pass a
-  fresh `time.Now()`, which is semantically identical to today's unguarded write.
-  Rejected: keeping two store methods — that is exactly the two-doors bug source.
-- The recovery-path writes keep their no-broadcast behavior (`broadcast:false`)
-  rather than being "fixed" to broadcast: startup reconcile runs before clients
-  attach and batch-reports via its own path. Do not change it in this refactor.
-- `sendOK`/transport replies stay out of `applyState` — the door is
-  transport-agnostic.
+- One daemon authority, multiple store commit primitives. Timestamp ordering and
+  plugin run/sequence ordering are different concurrency models; forcing both
+  through one store method would weaken correctness.
+- Closed causes over caller-supplied effect flags. The source semantics choose
+  the effect profile, so future writers must make an explicit architectural
+  choice instead of copying a nearby boolean combination.
+- Recovery and exit are first-class causes, not exceptions hidden in raw store
+  calls. Their intentionally reduced effects are documented policy.
+- The doorbell mutex protects only the state commit. A committed approval state
+  is sufficient to block a competing doorbell; holding the mutex during DB
+  Touch, ticket reads, timers, or broadcasts adds contention without safety.
+- Accepted-only effects are the module invariant. Guarded writes already behave
+  this way; making unconditional writes report missing-session failure prevents
+  ghost tracking or broadcasts for a transition that never existed.
 
 ## Verification
 
-Run after each PR:
-
 ```bash
 go build ./...
-go test ./internal/daemon -run 'TestSessionStateDoor|State|Classif|Nudge|Recover|Reconcile' -count=1
-go test ./internal/daemon -count=1          # full package; do NOT use -race on the
-                                            # whole package (known pre-existing race
-                                            # in TestGitStatusScheduler; scope -race
-                                            # with -run if you need it)
+go test ./internal/store -run 'UpdateState|ApplyAgentDriverState' -count=1
+go test ./internal/daemon -run 'SessionStateDoor|DoorbellWrite|NudgeCountdown|Plugin.*State|StateWithTimestamp|ScheduledClears|Recover|Reseed|PTYState' -count=1
+go test ./internal/daemon -count=1
 go test ./internal/store ./internal/classifier ./internal/transcript -count=1
+make test
 ```
 
-Structural asserts (all must hold when PR 2 lands):
+Structural proof after migration:
 
 ```bash
-# the door is the only writer:
-grep -rn 'store\.UpdateState' internal/daemon --include='*.go' | grep -v _test | grep -v session_state.go
-# -> no output
-# the old choreographies are gone:
-grep -rn 'updateAndBroadcastState' internal/daemon --include='*.go' | grep -v _test
+rg -n 'd\.store\.(UpdateState|UpdateStateWithTimestamp|ApplyAgentDriverState)\(' \
+  internal/daemon --glob '*.go' --glob '!*_test.go'
+# -> only internal/daemon/session_state.go
+
+rg -n 'updateAndBroadcastState|applyStateAndSyncNudge' \
+  internal/daemon --glob '*.go' --glob '!*_test.go'
 # -> no output
 ```
 
-Behaviors that must survive (spot-check via existing tests + manual `make dev`):
+Behaviors that must survive:
 
-1. Stale classifier result never overwrites a fresher state (existing
-   classifier tests must stay green unmodified — if one needs editing, the
-   refactor changed behavior).
-2. PTY detector still refuses to clobber hook-authoritative states
-   (`ShouldApplyPTYState` tests unmodified).
-3. Ticket doorbell still fires when a PTY-observed session goes idle, and only
-   on that path.
-4. Nudge countdown still cancels on leaving idle for hook AND PTY paths.
-5. Long-run tracking: `working` starts a run; `idle`/`scheduled` clears it, on
-   every path that did so before.
-6. Manual: `make dev`, run a Claude session, confirm the sidebar state flow
-   launching → working → waiting_input/idle behaves normally, and approval
-   (pending_approval) still clears.
+1. A stale classifier result cannot overwrite a newer hook, PTY, transcript, or
+   plugin state and cannot clear long-run-review tracking.
+2. A stale/wrong-run plugin report changes neither state nor sequence and emits
+   no transition effects.
+3. A `pending_approval` commit cannot interleave into the middle of a complete
+   bracketed-paste + Enter doorbell write; after commit, new doorbells are
+   blocked. Leaving approval rechecks unread activity.
+4. PTY detection still cannot clobber hook- or plugin-authoritative states.
+5. Hook/PTY/plugin signals still Touch; transcript/classifier/recovery do not.
+6. Recovery changes appear in the first corrected workspace snapshot without
+   per-session recovery broadcasts.
+7. PTY exit reconciles tickets from the pre-idle state, then broadcasts idle and
+   `session_exited` in the existing lifecycle.
+8. `working` starts long-run tracking; `idle`/`scheduled` clear it on the same
+   live paths as today.
+
+Live verification (non-prod profile):
+
+1. Run `make dev` outside the sandbox.
+2. Exercise a hook-backed Codex or Claude session through
+   `launching -> working -> waiting_input/idle`, including an approval prompt.
+3. Exercise an OpenCode/plugin-backed session and confirm sequenced native state
+   reports update the sidebar while PTY-derived noise remains ignored.
+4. Arm a ticket nudge, enter/leave approval, and confirm the countdown cancels
+   and re-arms without typing into the approval prompt.
+5. Restart the dev daemon and confirm recovery produces the correct initial
+   session/workspace state without transient per-session recovery churn.
+
+Recorded verification on 2026-07-13:
+
+- `go build ./...`, the targeted store/daemon suites, the full daemon/store/
+  classifier/transcript suites, repeated characterization/door tests, the
+  scoped race suite, and `make test` passed.
+- `make dev` built, signed, installed, and launched the isolated dev app.
+- `real-app:scenario-workspace-shell-lifecycle` passed against the packaged dev
+  app, covering live workspace panes and process-exit cleanup.
+- `real-app:scenario-nudge-trigger` reached the live `working` transition on two
+  runs. Both stopped before the nudge assertions because the spawned Codex CLI
+  recorded `task_complete` with no assistant message; this is retained as an
+  explicit live-verification gap rather than treated as passing evidence.
 
 ## Follow-ups
 
-- The store change-event candidate (see
-  `2026-07-02-store-single-implementation.md` follow-ups) generalizes this
-  one-door pattern to all entities; `applyState` becomes its first client.
+- Typed store change events plus a single daemon broadcast pump remain a separate
+  design problem after the store single-implementation cleanup.
+- Extracting the pure, non-LLM part of `classifySessionState` into a
+  `stopdecision` module remains independent of the state door.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -893,7 +893,11 @@ func (d *Daemon) pruneSessionsWithoutPTY() int {
 			continue
 		}
 		if d.recoverOnMissingPTY(session) {
-			d.store.UpdateState(session.ID, protocol.StateIdle)
+			d.applyState(sessionStateChange{
+				sessionID: session.ID,
+				state:     protocol.StateIdle,
+				cause:     startupRecovery{},
+			})
 			d.store.SetRecoverable(session.ID, true)
 			recoverable++
 			continue
@@ -1179,7 +1183,11 @@ func (d *Daemon) reconcileSessionsWithWorkerBackend(ctx context.Context, allowId
 			}
 			nextState := sessionStateFromRecoveredInfo(info)
 			if existing.State != nextState {
-				d.store.UpdateState(sessionID, string(nextState))
+				d.applyState(sessionStateChange{
+					sessionID: sessionID,
+					state:     string(nextState),
+					cause:     startupRecovery{},
+				})
 				report.StateUpdated++
 				report.Changed = true
 			}
@@ -1190,7 +1198,11 @@ func (d *Daemon) reconcileSessionsWithWorkerBackend(ctx context.Context, allowId
 			// Preserve interactive waiting/approval states during recovery.
 		default:
 			if existing.State != protocol.SessionStateLaunching {
-				d.store.UpdateState(sessionID, protocol.StateLaunching)
+				d.applyState(sessionStateChange{
+					sessionID: sessionID,
+					state:     protocol.StateLaunching,
+					cause:     startupRecovery{},
+				})
 				report.StateUpdated++
 				report.Changed = true
 			}
@@ -1225,7 +1237,11 @@ func (d *Daemon) reconcileSessionsWithWorkerBackend(ctx context.Context, allowId
 			continue
 		}
 		if d.recoverOnMissingPTY(session) {
-			d.store.UpdateState(session.ID, protocol.StateIdle)
+			d.applyState(sessionStateChange{
+				sessionID: session.ID,
+				state:     protocol.StateIdle,
+				cause:     startupRecovery{},
+			})
 			d.store.SetRecoverable(session.ID, true)
 			report.StateUpdated++
 			report.MarkedRecoverable++
@@ -1461,16 +1477,11 @@ func (d *Daemon) handlePTYExit(info ptybackend.ExitInfo) {
 		} else {
 			d.reconcileTicketsOnSessionEnd(info.ID, string(session.State))
 		}
-		d.store.Touch(info.ID)
-		d.store.UpdateState(info.ID, protocol.StateIdle)
-		updated := d.sessionForBroadcast(d.store.Get(info.ID))
-		if updated != nil {
-			d.wsHub.Broadcast(&protocol.WebSocketEvent{
-				Event:   protocol.EventSessionStateChanged,
-				Session: updated,
-			})
-			d.recomputeAndBroadcastWorkspaceForSession(info.ID)
-		}
+		d.applyState(sessionStateChange{
+			sessionID: info.ID,
+			state:     protocol.StateIdle,
+			cause:     processExit{},
+		})
 	}
 
 	event := &protocol.WebSocketEvent{
@@ -1602,26 +1613,11 @@ func (d *Daemon) handlePTYState(sessionID, state string) {
 	}
 
 	d.logf("pty state update: session=%s agent=%s state=%s", sessionID, agent, state)
-	switch state {
-	case protocol.StateWorking:
-		d.markRunStartedIfNeeded(sessionID)
-	case protocol.StateIdle, protocol.StateScheduled:
-		d.clearLongRunTracking(sessionID)
-	}
-	d.applyStateAndSyncNudge(sessionID, state, func() bool {
-		d.store.UpdateState(sessionID, state)
-		d.store.Touch(sessionID)
-		return true
+	d.applyState(sessionStateChange{
+		sessionID: sessionID,
+		state:     state,
+		cause:     liveSignal{},
 	})
-	updated := d.sessionForBroadcast(d.store.Get(sessionID))
-	if updated == nil {
-		return
-	}
-	d.wsHub.Broadcast(&protocol.WebSocketEvent{
-		Event:   protocol.EventSessionStateChanged,
-		Session: updated,
-	})
-	d.recomputeAndBroadcastWorkspaceForSession(sessionID)
 }
 
 // initHTTPServer creates the HTTP server synchronously to avoid race with Stop().
@@ -2184,37 +2180,12 @@ func (d *Daemon) handleUnregister(conn net.Conn, msg *protocol.UnregisterMessage
 
 func (d *Daemon) handleState(conn net.Conn, msg *protocol.StateMessage) {
 	d.logf("state update: id=%s state=%s", msg.ID, msg.State)
-	switch msg.State {
-	case protocol.StateWorking:
-		d.markRunStartedIfNeeded(msg.ID)
-	case protocol.StateIdle, protocol.StateScheduled:
-		// Both end the current run for long-run-review purposes: idle is
-		// terminal, and scheduled parks until a future cron fires (the resumed
-		// turn is a fresh run). Leaving stale tracking would mis-fire a long-run
-		// review on the next short resumed turn.
-		d.clearLongRunTracking(msg.ID)
-	}
-	d.applyStateAndSyncNudge(msg.ID, msg.State, func() bool {
-		d.store.UpdateState(msg.ID, msg.State)
-		d.store.Touch(msg.ID)
-		return true
+	d.applyState(sessionStateChange{
+		sessionID: msg.ID,
+		state:     msg.State,
+		cause:     liveSignal{},
 	})
-	// The hook is the authoritative state path for Codex and Claude; the shared
-	// state helper also reconciles a nudge deferred by an approval prompt.
 	d.sendOK(conn)
-
-	// Broadcast to WebSocket clients
-	session := d.sessionForBroadcast(d.store.Get(msg.ID))
-	if session != nil {
-		d.logf("broadcasting state change (from hook): session=%s state=%s clients=%d", msg.ID, msg.State, d.wsHub.ClientCount())
-		d.wsHub.Broadcast(&protocol.WebSocketEvent{
-			Event:   protocol.EventSessionStateChanged,
-			Session: session,
-		})
-		d.recomputeAndBroadcastWorkspaceForSession(msg.ID)
-	} else {
-		d.logf("handleState: session %s not found, no broadcast", msg.ID)
-	}
 }
 
 func (d *Daemon) handleSetSessionResumeID(conn net.Conn, msg *protocol.SetSessionResumeIDMessage) {
@@ -2340,7 +2311,11 @@ func (d *Daemon) classifyOrDeferAfterStop(sessionID, transcriptPath string) {
 		if session.State == protocol.SessionStatePendingApproval || session.State == protocol.SessionStateWaitingInput {
 			d.broadcastSessionStateChanged(sessionID)
 		} else {
-			d.updateAndBroadcastState(sessionID, protocol.StateWaitingInput)
+			d.applyState(sessionStateChange{
+				sessionID: sessionID,
+				state:     protocol.StateWaitingInput,
+				cause:     daemonObservation{},
+			})
 		}
 		return
 	}
@@ -2395,19 +2370,31 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 	d.logf("classifySessionState: session %s has %d total todos, %d pending", sessionID, len(session.Todos), pendingCount)
 	if pendingCount > 0 {
 		d.logf("classifySessionState: session %s has pending todos, setting waiting_input", sessionID)
-		d.updateAndBroadcastStateWithTimestamp(sessionID, protocol.StateWaitingInput, classificationStartTime)
+		d.applyState(sessionStateChange{
+			sessionID: sessionID,
+			state:     protocol.StateWaitingInput,
+			cause:     classifierObservation{observedAt: classificationStartTime},
+		})
 		return
 	}
 
 	if !transcriptEnabled {
 		d.logf("classifySessionState: transcript disabled for agent=%s session=%s, setting idle", session.Agent, sessionID)
-		d.updateAndBroadcastStateWithTimestamp(sessionID, protocol.StateIdle, classificationStartTime)
+		d.applyState(sessionStateChange{
+			sessionID: sessionID,
+			state:     protocol.StateIdle,
+			cause:     classifierObservation{observedAt: classificationStartTime},
+		})
 		return
 	}
 
 	if !classifierEnabled {
 		d.logf("classifySessionState: classifier disabled for agent=%s session=%s, setting idle", session.Agent, sessionID)
-		d.updateAndBroadcastStateWithTimestamp(sessionID, protocol.StateIdle, classificationStartTime)
+		d.applyState(sessionStateChange{
+			sessionID: sessionID,
+			state:     protocol.StateIdle,
+			cause:     classifierObservation{observedAt: classificationStartTime},
+		})
 		return
 	}
 
@@ -2431,7 +2418,11 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 		}
 		d.logf("classifySessionState: transcript parse error for %s: %v", sessionID, err)
 		d.logf("classifySessionState: unknown reason=transcript_parse_error session=%s transcript=%s", sessionID, resolvedTranscriptPath)
-		d.updateAndBroadcastStateWithTimestamp(sessionID, protocol.StateUnknown, classificationStartTime)
+		d.applyState(sessionStateChange{
+			sessionID: sessionID,
+			state:     protocol.StateUnknown,
+			cause:     classifierObservation{observedAt: classificationStartTime},
+		})
 		return
 	}
 	if strings.TrimSpace(assistantTurnID) != "" {
@@ -2441,7 +2432,11 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 	lastMessage = strings.TrimSpace(lastMessage)
 	if lastMessage == "" {
 		d.logf("classifySessionState: empty last message for session %s, setting idle", sessionID)
-		d.updateAndBroadcastStateWithTimestamp(sessionID, protocol.StateIdle, classificationStartTime)
+		d.applyState(sessionStateChange{
+			sessionID: sessionID,
+			state:     protocol.StateIdle,
+			cause:     classifierObservation{observedAt: classificationStartTime},
+		})
 		return
 	}
 
@@ -2468,7 +2463,11 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 	if strings.TrimSpace(assistantTurnID) != "" {
 		d.setClassifiedTurnID(sessionID, assistantTurnID)
 	}
-	d.updateAndBroadcastStateWithTimestamp(sessionID, state, classificationStartTime)
+	d.applyState(sessionStateChange{
+		sessionID: sessionID,
+		state:     state,
+		cause:     classifierObservation{observedAt: classificationStartTime},
+	})
 }
 
 func (d *Daemon) runClassifier(session *protocol.Session, text string, timeout time.Duration) (string, error) {
@@ -2828,59 +2827,6 @@ func (d *Daemon) broadcastSessionStateChanged(sessionID string) {
 		Session: decorated,
 	})
 	d.recomputeAndBroadcastWorkspaceForSession(sessionID)
-}
-
-func (d *Daemon) updateAndBroadcastState(sessionID, state string) {
-	switch state {
-	case protocol.StateWorking:
-		d.markRunStartedIfNeeded(sessionID)
-	case protocol.StateIdle, protocol.StateScheduled:
-		d.clearLongRunTracking(sessionID)
-	}
-	d.applyStateAndSyncNudge(sessionID, state, func() bool {
-		d.store.UpdateState(sessionID, state)
-		return true
-	})
-	// Broadcast to WebSocket clients
-	session := d.sessionForBroadcast(d.store.Get(sessionID))
-	if session != nil {
-		d.logf("broadcasting state change: session=%s state=%s clients=%d", sessionID, state, d.wsHub.ClientCount())
-		d.wsHub.Broadcast(&protocol.WebSocketEvent{
-			Event:   protocol.EventSessionStateChanged,
-			Session: session,
-		})
-		d.recomputeAndBroadcastWorkspaceForSession(sessionID)
-	}
-}
-
-// updateAndBroadcastStateWithTimestamp updates state only if the timestamp is newer
-// than the current state. Used by classifier to prevent stale results from overwriting
-// newer state updates that arrived during classification.
-func (d *Daemon) updateAndBroadcastStateWithTimestamp(sessionID, state string, updatedAt time.Time) bool {
-	if d.applyStateAndSyncNudge(sessionID, state, func() bool {
-		return d.store.UpdateStateWithTimestamp(sessionID, state, updatedAt)
-	}) {
-		switch state {
-		case protocol.StateWorking:
-			d.markRunStartedIfNeeded(sessionID)
-		case protocol.StateIdle, protocol.StateScheduled:
-			d.clearLongRunTracking(sessionID)
-		}
-		// Broadcast to WebSocket clients
-		session := d.sessionForBroadcast(d.store.Get(sessionID))
-		if session != nil {
-			d.logf("broadcasting state change (timestamped): session=%s state=%s clients=%d", sessionID, state, d.wsHub.ClientCount())
-			d.wsHub.Broadcast(&protocol.WebSocketEvent{
-				Event:   protocol.EventSessionStateChanged,
-				Session: session,
-			})
-			d.recomputeAndBroadcastWorkspaceForSession(sessionID)
-		}
-		return true
-	} else {
-		d.logf("state update discarded: session=%s state=%s (newer state exists)", sessionID, state)
-	}
-	return false
 }
 
 // broadcastRateLimited broadcasts a rate limit event to WebSocket clients

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5662,7 +5662,7 @@ func TestClassifySessionState_ClaudeConcurrentDuplicateTurnRunsOnce(t *testing.T
 	}
 }
 
-func TestUpdateAndBroadcastStateWithTimestamp_StaleIdleDoesNotClearLongRunTracking(t *testing.T) {
+func TestClassifierStateTransition_StaleIdleDoesNotClearLongRunTracking(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 
 	now := time.Now()
@@ -5683,7 +5683,11 @@ func TestUpdateAndBroadcastStateWithTimestamp_StaleIdleDoesNotClearLongRunTracki
 		needsReview:        true,
 	}
 
-	d.updateAndBroadcastStateWithTimestamp("sess-stale", protocol.StateIdle, now.Add(-1*time.Minute))
+	d.applyState(sessionStateChange{
+		sessionID: "sess-stale",
+		state:     protocol.StateIdle,
+		cause:     classifierObservation{observedAt: now.Add(-1 * time.Minute)},
+	})
 
 	session := d.store.Get("sess-stale")
 	if session == nil {
@@ -5719,7 +5723,11 @@ func TestScheduledClearsLongRunTracking(t *testing.T) {
 	// It has been working for 10 minutes, then parks on a cron.
 	d.longRun["sess-loop"] = longRunSession{workingSince: now.Add(-10 * time.Minute)}
 
-	d.updateAndBroadcastState("sess-loop", protocol.StateScheduled)
+	d.applyState(sessionStateChange{
+		sessionID: "sess-loop",
+		state:     protocol.StateScheduled,
+		cause:     daemonObservation{},
+	})
 
 	d.longRunMu.Lock()
 	_, tracked := d.longRun["sess-loop"]

--- a/internal/daemon/nudge_countdown_test.go
+++ b/internal/daemon/nudge_countdown_test.go
@@ -149,7 +149,11 @@ func TestNudgeCountdownSurvivesEligibleStateChange(t *testing.T) {
 		t.Fatal("precondition: no countdown armed")
 	}
 
-	d.updateAndBroadcastState(agentID, protocol.StateWorking)
+	d.applyState(sessionStateChange{
+		sessionID: agentID,
+		state:     protocol.StateWorking,
+		cause:     daemonObservation{},
+	})
 
 	if currentNudgeTimer(d, agentID) == nil {
 		t.Fatal("countdown was canceled when the agent became active")
@@ -162,7 +166,11 @@ func TestNudgeCountdownCancelsOnPendingApproval(t *testing.T) {
 	t.Cleanup(d.stopNudgeCountdowns)
 	agentID, _ := armForTest(t, d)
 
-	d.updateAndBroadcastState(agentID, protocol.StatePendingApproval)
+	d.applyState(sessionStateChange{
+		sessionID: agentID,
+		state:     protocol.StatePendingApproval,
+		cause:     daemonObservation{},
+	})
 
 	if currentNudgeTimer(d, agentID) != nil {
 		t.Fatal("countdown survived a pending approval prompt")
@@ -199,7 +207,11 @@ func TestDoorbellWriteDoesNotInterleaveWithPendingApproval(t *testing.T) {
 
 	stateDone := make(chan struct{})
 	go func() {
-		d.updateAndBroadcastState(sessionID, protocol.StatePendingApproval)
+		d.applyState(sessionStateChange{
+			sessionID: sessionID,
+			state:     protocol.StatePendingApproval,
+			cause:     daemonObservation{},
+		})
 		close(stateDone)
 	}()
 	select {

--- a/internal/daemon/plugin_driver.go
+++ b/internal/daemon/plugin_driver.go
@@ -276,26 +276,16 @@ func validatePluginReportCursor(runID string, seq uint64) error {
 
 func (d *Daemon) applyPluginReportedState(params pluginReportStateParams) bool {
 	state := strings.TrimSpace(params.State)
-	if !d.applyStateAndSyncNudge(params.SessionID, state, func() bool {
-		return d.store.ApplyAgentDriverState(params.SessionID, params.RunID, params.Seq, state)
+	if !d.applyState(sessionStateChange{
+		sessionID: params.SessionID,
+		state:     state,
+		cause: pluginReport{
+			runID: params.RunID,
+			seq:   params.Seq,
+		},
 	}) {
 		d.logf("plugin state report discarded: session=%s run=%s seq=%d state=%s", params.SessionID, params.RunID, params.Seq, state)
 		return false
-	}
-	switch state {
-	case protocol.StateWorking:
-		d.markRunStartedIfNeeded(params.SessionID)
-	case protocol.StateIdle:
-		d.clearLongRunTracking(params.SessionID)
-	}
-	d.store.Touch(params.SessionID)
-	session := d.sessionForBroadcast(d.store.Get(params.SessionID))
-	if session != nil {
-		d.wsHub.Broadcast(&protocol.WebSocketEvent{
-			Event:   protocol.EventSessionStateChanged,
-			Session: session,
-		})
-		d.recomputeAndBroadcastWorkspaceForSession(params.SessionID)
 	}
 	return true
 }

--- a/internal/daemon/session_state.go
+++ b/internal/daemon/session_state.go
@@ -1,0 +1,161 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// sessionStateCause is a package-private sum type. Each variant identifies one
+// valid store commit rule and one valid set of post-commit effects.
+type sessionStateCause interface {
+	isSessionStateCause()
+}
+
+// liveSignal is an authoritative hook or trusted PTY observation.
+type liveSignal struct{}
+
+// daemonObservation is a synchronous daemon-derived observation, such as the
+// transcript watcher or the immediate long-run-review handoff.
+type daemonObservation struct{}
+
+// classifierObservation is captured before slow classification work so its
+// eventual result cannot overwrite a newer state transition.
+type classifierObservation struct {
+	observedAt time.Time
+}
+
+// pluginReport carries the active driver run cursor used for ordered state CAS.
+type pluginReport struct {
+	runID string
+	seq   uint64
+}
+
+// startupRecovery rewrites persisted state before clients cross the recovery
+// barrier. It deliberately produces no per-session effects or broadcasts.
+type startupRecovery struct{}
+
+// processExit records the terminal idle state after exit-specific teardown and
+// pre-clobber ticket reconciliation have already run.
+type processExit struct{}
+
+func (liveSignal) isSessionStateCause()            {}
+func (daemonObservation) isSessionStateCause()     {}
+func (classifierObservation) isSessionStateCause() {}
+func (pluginReport) isSessionStateCause()          {}
+func (startupRecovery) isSessionStateCause()       {}
+func (processExit) isSessionStateCause()           {}
+
+type sessionStateChange struct {
+	sessionID string
+	state     string
+	cause     sessionStateCause
+}
+
+// stateEffectProfile is internal policy derived from a closed cause. Callers do
+// not assemble these flags themselves.
+type stateEffectProfile struct {
+	touch     bool
+	trackRun  bool
+	syncNudge bool
+	broadcast bool
+}
+
+func stateEffectProfileFor(cause sessionStateCause) (stateEffectProfile, bool) {
+	switch cause.(type) {
+	case liveSignal:
+		return stateEffectProfile{touch: true, trackRun: true, syncNudge: true, broadcast: true}, true
+	case daemonObservation, classifierObservation:
+		return stateEffectProfile{trackRun: true, syncNudge: true, broadcast: true}, true
+	case pluginReport:
+		return stateEffectProfile{touch: true, trackRun: true, syncNudge: true, broadcast: true}, true
+	case startupRecovery:
+		return stateEffectProfile{}, true
+	case processExit:
+		return stateEffectProfile{touch: true, broadcast: true}, true
+	default:
+		return stateEffectProfile{}, false
+	}
+}
+
+func sessionStateCauseName(cause sessionStateCause) string {
+	switch cause.(type) {
+	case liveSignal:
+		return "live_signal"
+	case daemonObservation:
+		return "daemon_observation"
+	case classifierObservation:
+		return "classifier_observation"
+	case pluginReport:
+		return "plugin_report"
+	case startupRecovery:
+		return "startup_recovery"
+	case processExit:
+		return "process_exit"
+	default:
+		return "unknown"
+	}
+}
+
+// applyState is the daemon's only persisted session-state transition door.
+// Cause-specific guards remain at the caller; once a transition reaches this
+// method, it owns the atomic store mutation and every accepted-state effect.
+func (d *Daemon) applyState(change sessionStateChange) bool {
+	if d.store == nil {
+		return false
+	}
+	profile, ok := stateEffectProfileFor(change.cause)
+	if !ok {
+		d.logf("state update discarded: session=%s state=%s cause=unknown", change.sessionID, change.state)
+		return false
+	}
+
+	if profile.syncNudge {
+		d.doorbellMu.Lock()
+	}
+	applied := d.commitSessionState(change)
+	if profile.syncNudge {
+		d.doorbellMu.Unlock()
+	}
+	if !applied {
+		d.logf(
+			"state update discarded: session=%s state=%s cause=%s",
+			change.sessionID,
+			change.state,
+			sessionStateCauseName(change.cause),
+		)
+		return false
+	}
+
+	if profile.touch {
+		d.store.Touch(change.sessionID)
+	}
+	if profile.trackRun {
+		switch change.state {
+		case protocol.StateWorking:
+			d.markRunStartedIfNeeded(change.sessionID)
+		case protocol.StateIdle, protocol.StateScheduled:
+			d.clearLongRunTracking(change.sessionID)
+		}
+	}
+	if profile.syncNudge {
+		d.syncNudgeForState(change.sessionID, change.state)
+	}
+	if profile.broadcast {
+		d.broadcastSessionStateChanged(change.sessionID)
+	}
+	return true
+}
+
+func (d *Daemon) commitSessionState(change sessionStateChange) bool {
+	switch cause := change.cause.(type) {
+	case liveSignal, daemonObservation, startupRecovery, processExit:
+		return d.store.UpdateState(change.sessionID, change.state)
+	case classifierObservation:
+		return d.store.UpdateStateWithTimestamp(change.sessionID, change.state, cause.observedAt)
+	case pluginReport:
+		return d.store.ApplyAgentDriverState(change.sessionID, cause.runID, cause.seq, change.state)
+	default:
+		return false
+	}
+}

--- a/internal/daemon/session_state_characterization_test.go
+++ b/internal/daemon/session_state_characterization_test.go
@@ -1,0 +1,290 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ptybackend"
+)
+
+const characterizationOldTimestamp = "2000-01-01T00:00:00Z"
+
+func addCharacterizationSession(
+	t *testing.T,
+	d *Daemon,
+	id string,
+	agent protocol.SessionAgent,
+	state protocol.SessionState,
+) string {
+	t.Helper()
+	directory := t.TempDir()
+	workspaceID := "workspace-" + id
+	addTestWorkspace(d, workspaceID, directory)
+	d.store.Add(&protocol.Session{
+		ID:             id,
+		Label:          id,
+		Agent:          agent,
+		Directory:      directory,
+		State:          state,
+		StateSince:     characterizationOldTimestamp,
+		StateUpdatedAt: characterizationOldTimestamp,
+		LastSeen:       characterizationOldTimestamp,
+	})
+	d.associateSessionWithWorkspace(id, workspaceID)
+	return workspaceID
+}
+
+func characterizationEventCount(events []protocol.WebSocketEvent, eventName, sessionID string) int {
+	count := 0
+	for _, event := range events {
+		if event.Event != eventName {
+			continue
+		}
+		if sessionID != "" && (event.Session == nil || event.Session.ID != sessionID) {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func assertCharacterizationLiveEffects(t *testing.T, d *Daemon, capture *broadcastCapture, sessionID string) {
+	t.Helper()
+	session := d.store.Get(sessionID)
+	if session == nil {
+		t.Fatal("session missing after state transition")
+	}
+	if session.State != protocol.SessionStateWorking {
+		t.Fatalf("state=%q, want working", session.State)
+	}
+	if session.StateUpdatedAt == characterizationOldTimestamp || session.StateSince == characterizationOldTimestamp {
+		t.Fatalf("state timestamps were not refreshed: since=%q updated=%q", session.StateSince, session.StateUpdatedAt)
+	}
+	if session.LastSeen == characterizationOldTimestamp {
+		t.Fatal("live state signal did not Touch the session")
+	}
+
+	d.longRunMu.Lock()
+	tracked := !d.longRun[sessionID].workingSince.IsZero()
+	d.longRunMu.Unlock()
+	if !tracked {
+		t.Fatal("working state did not start long-run tracking")
+	}
+
+	events := capture.snapshot()
+	if got := characterizationEventCount(events, protocol.EventSessionStateChanged, sessionID); got != 1 {
+		t.Fatalf("session_state_changed events=%d, want 1; events=%+v", got, events)
+	}
+	if got := characterizationEventCount(events, protocol.EventWorkspaceStateChanged, ""); got != 1 {
+		t.Fatalf("workspace_state_changed events=%d, want 1; events=%+v", got, events)
+	}
+}
+
+func TestSessionStateCharacterization_LiveSignalsShareEffects(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		agent        protocol.SessionAgent
+		initialState protocol.SessionState
+		apply        func(*Daemon, string)
+	}{
+		{
+			name:         "hook",
+			agent:        protocol.SessionAgentCodex,
+			initialState: protocol.SessionStateIdle,
+			apply: func(d *Daemon, id string) {
+				d.handleState(&syncConn{}, &protocol.StateMessage{ID: id, State: protocol.StateWorking})
+			},
+		},
+		{
+			name:         "trusted PTY",
+			agent:        protocol.SessionAgentClaude,
+			initialState: protocol.SessionStateWaitingInput,
+			apply: func(d *Daemon, id string) {
+				d.handlePTYState(id, protocol.StateWorking)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "state.sock"))
+			sessionID := "session-" + tc.name
+			addCharacterizationSession(t, d, sessionID, tc.agent, tc.initialState)
+			capture := captureBroadcasts(d)
+
+			tc.apply(d, sessionID)
+
+			assertCharacterizationLiveEffects(t, d, capture, sessionID)
+		})
+	}
+}
+
+func TestSessionStateCharacterization_DaemonObservationDoesNotTouch(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "state.sock"))
+	sessionID := "long-run-handoff"
+	addCharacterizationSession(t, d, sessionID, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+	d.longRun[sessionID] = longRunSession{workingSince: time.Now().Add(-longRunReviewThreshold - time.Minute)}
+	capture := captureBroadcasts(d)
+
+	d.classifyOrDeferAfterStop(sessionID, "/tmp/characterization-transcript.jsonl")
+
+	session := d.store.Get(sessionID)
+	if session == nil || session.State != protocol.SessionStateWaitingInput {
+		t.Fatalf("session=%+v, want waiting_input", session)
+	}
+	if session.LastSeen != characterizationOldTimestamp {
+		t.Fatalf("daemon observation touched LastSeen=%q, want %q", session.LastSeen, characterizationOldTimestamp)
+	}
+	if !d.sessionNeedsReviewAfterLongRun(sessionID) {
+		t.Fatal("long-run handoff did not preserve needs-review tracking")
+	}
+	events := capture.snapshot()
+	if got := characterizationEventCount(events, protocol.EventSessionStateChanged, sessionID); got != 1 {
+		t.Fatalf("session_state_changed events=%d, want 1; events=%+v", got, events)
+	}
+	if got := characterizationEventCount(events, protocol.EventWorkspaceStateChanged, ""); got != 1 {
+		t.Fatalf("workspace_state_changed events=%d, want 1; events=%+v", got, events)
+	}
+}
+
+func TestSessionStateCharacterization_StaleClassifierHasNoEffects(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "state.sock"))
+	sessionID := "stale-classifier"
+	addCharacterizationSession(t, d, sessionID, protocol.SessionAgentCodex, protocol.SessionStateWorking)
+	d.longRun[sessionID] = longRunSession{
+		workingSince:       time.Now().Add(-longRunReviewThreshold - time.Minute),
+		deferredTranscript: "/tmp/deferred.jsonl",
+		needsReview:        true,
+	}
+	classifier := newBlockingClassifier(protocol.StateIdle)
+	d.classifier = classifier
+
+	transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
+	content := `{"type":"assistant","message":{"role":"assistant","content":"Finished."}}` + "\n"
+	if err := os.WriteFile(transcriptPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	capture := captureBroadcasts(d)
+
+	classified := make(chan struct{})
+	go func() {
+		d.classifySessionState(sessionID, transcriptPath)
+		close(classified)
+	}()
+
+	select {
+	case <-classifier.started:
+	case <-time.After(2 * time.Second):
+		close(classifier.release)
+		t.Fatal("classifier did not start")
+	}
+
+	d.handleState(&syncConn{}, &protocol.StateMessage{ID: sessionID, State: protocol.StatePendingApproval})
+	fresh := d.store.Get(sessionID)
+	stateEventsBeforeRelease := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, sessionID)
+	close(classifier.release)
+	select {
+	case <-classified:
+	case <-time.After(2 * time.Second):
+		t.Fatal("classifier did not finish")
+	}
+
+	after := d.store.Get(sessionID)
+	if after == nil || after.State != protocol.SessionStatePendingApproval {
+		t.Fatalf("session=%+v, stale classifier overwrote pending_approval", after)
+	}
+	if after.StateUpdatedAt != fresh.StateUpdatedAt || after.LastSeen != fresh.LastSeen {
+		t.Fatalf("stale classifier changed timestamps: fresh=%+v after=%+v", fresh, after)
+	}
+	if !d.sessionNeedsReviewAfterLongRun(sessionID) {
+		t.Fatal("stale classifier cleared long-run review tracking")
+	}
+	if got := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, sessionID); got != stateEventsBeforeRelease {
+		t.Fatalf("stale classifier emitted state event: before=%d after=%d", stateEventsBeforeRelease, got)
+	}
+}
+
+func TestSessionStateCharacterization_PluginCASGatesEffects(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "state.sock"))
+	sessionID := "plugin-state"
+	addCharacterizationSession(t, d, sessionID, "snipe", protocol.SessionStateLaunching)
+	if !d.store.BeginAgentDriverRun(sessionID, "snipe-plugin", "run-current") {
+		t.Fatal("failed to begin plugin run")
+	}
+	capture := captureBroadcasts(d)
+
+	if !d.applyPluginReportedState(pluginReportStateParams{
+		SessionID: sessionID,
+		RunID:     "run-current",
+		Seq:       2,
+		State:     protocol.StateWorking,
+	}) {
+		t.Fatal("fresh plugin report was rejected")
+	}
+	accepted := d.store.Get(sessionID)
+	if accepted == nil || accepted.State != protocol.SessionStateWorking {
+		t.Fatalf("session=%+v, want working", accepted)
+	}
+	if accepted.LastSeen == characterizationOldTimestamp {
+		t.Fatal("accepted plugin report did not Touch the session")
+	}
+	d.longRunMu.Lock()
+	tracked := !d.longRun[sessionID].workingSince.IsZero()
+	d.longRunMu.Unlock()
+	if !tracked {
+		t.Fatal("accepted plugin working report did not start long-run tracking")
+	}
+	stateEventsAfterAccepted := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, sessionID)
+
+	if d.applyPluginReportedState(pluginReportStateParams{
+		SessionID: sessionID,
+		RunID:     "run-current",
+		Seq:       1,
+		State:     protocol.StateIdle,
+	}) {
+		t.Fatal("stale plugin report was accepted")
+	}
+	afterStale := d.store.Get(sessionID)
+	if afterStale == nil || afterStale.State != protocol.SessionStateWorking || afterStale.StateUpdatedAt != accepted.StateUpdatedAt || afterStale.LastSeen != accepted.LastSeen {
+		t.Fatalf("stale plugin report changed session: accepted=%+v after=%+v", accepted, afterStale)
+	}
+	if got := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, sessionID); got != stateEventsAfterAccepted {
+		t.Fatalf("stale plugin report emitted state event: before=%d after=%d", stateEventsAfterAccepted, got)
+	}
+}
+
+func TestSessionStateCharacterization_ProcessExitEffects(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "state.sock"))
+	d.ptyBackend = &fakeSpawnBackend{}
+	sessionID := "process-exit"
+	addCharacterizationSession(t, d, sessionID, protocol.SessionAgentClaude, protocol.SessionStateWorking)
+	d.longRun[sessionID] = longRunSession{workingSince: time.Now().Add(-time.Minute)}
+	capture := captureBroadcasts(d)
+
+	d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 0})
+
+	session := d.store.Get(sessionID)
+	if session == nil || session.State != protocol.SessionStateIdle {
+		t.Fatalf("session=%+v, want idle after exit", session)
+	}
+	if session.LastSeen == characterizationOldTimestamp {
+		t.Fatal("process exit did not Touch the session")
+	}
+	d.longRunMu.Lock()
+	_, tracked := d.longRun[sessionID]
+	d.longRunMu.Unlock()
+	if tracked {
+		t.Fatal("process exit did not clear long-run tracking")
+	}
+	events := capture.snapshot()
+	if got := characterizationEventCount(events, protocol.EventSessionStateChanged, sessionID); got != 1 {
+		t.Fatalf("session_state_changed events=%d, want 1; events=%+v", got, events)
+	}
+	if got := characterizationEventCount(events, protocol.EventWorkspaceStateChanged, ""); got != 1 {
+		t.Fatalf("workspace_state_changed events=%d, want 1; events=%+v", got, events)
+	}
+	if got := characterizationEventCount(events, protocol.EventSessionExited, ""); got != 1 {
+		t.Fatalf("session_exited events=%d, want 1; events=%+v", got, events)
+	}
+}

--- a/internal/daemon/session_state_test.go
+++ b/internal/daemon/session_state_test.go
@@ -1,0 +1,175 @@
+package daemon
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestSessionStateDoor_AcceptedCauseProfiles(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		state         string
+		cause         func(*testing.T, *Daemon, string) sessionStateCause
+		wantTouch     bool
+		wantTracking  bool
+		wantBroadcast bool
+	}{
+		{
+			name:          "live signal",
+			state:         protocol.StateWorking,
+			cause:         func(*testing.T, *Daemon, string) sessionStateCause { return liveSignal{} },
+			wantTouch:     true,
+			wantTracking:  true,
+			wantBroadcast: true,
+		},
+		{
+			name:          "daemon observation",
+			state:         protocol.StateWorking,
+			cause:         func(*testing.T, *Daemon, string) sessionStateCause { return daemonObservation{} },
+			wantTracking:  true,
+			wantBroadcast: true,
+		},
+		{
+			name:  "classifier observation",
+			state: protocol.StateWorking,
+			cause: func(*testing.T, *Daemon, string) sessionStateCause {
+				return classifierObservation{observedAt: time.Now()}
+			},
+			wantTracking:  true,
+			wantBroadcast: true,
+		},
+		{
+			name:  "plugin report",
+			state: protocol.StateWorking,
+			cause: func(t *testing.T, d *Daemon, id string) sessionStateCause {
+				if !d.store.BeginAgentDriverRun(id, "plugin", "run") {
+					t.Fatal("BeginAgentDriverRun() = false")
+				}
+				return pluginReport{runID: "run", seq: 1}
+			},
+			wantTouch:     true,
+			wantTracking:  true,
+			wantBroadcast: true,
+		},
+		{
+			name:  "startup recovery",
+			state: protocol.StateWorking,
+			cause: func(*testing.T, *Daemon, string) sessionStateCause { return startupRecovery{} },
+		},
+		{
+			name:          "process exit",
+			state:         protocol.StateIdle,
+			cause:         func(*testing.T, *Daemon, string) sessionStateCause { return processExit{} },
+			wantTouch:     true,
+			wantBroadcast: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewForTesting(filepath.Join(t.TempDir(), "state.sock"))
+			id := "session"
+			d.store.Add(&protocol.Session{
+				ID:             id,
+				Label:          id,
+				Agent:          protocol.SessionAgentCodex,
+				Directory:      t.TempDir(),
+				State:          protocol.SessionStateIdle,
+				StateSince:     characterizationOldTimestamp,
+				StateUpdatedAt: characterizationOldTimestamp,
+				LastSeen:       characterizationOldTimestamp,
+			})
+			capture := captureBroadcasts(d)
+
+			if !d.applyState(sessionStateChange{sessionID: id, state: tc.state, cause: tc.cause(t, d, id)}) {
+				t.Fatal("applyState() = false, want true")
+			}
+
+			session := d.store.Get(id)
+			if session == nil || string(session.State) != tc.state {
+				t.Fatalf("session=%+v, want state %q", session, tc.state)
+			}
+			if session.StateUpdatedAt == characterizationOldTimestamp {
+				t.Fatal("accepted transition did not update state timestamp")
+			}
+			if touched := session.LastSeen != characterizationOldTimestamp; touched != tc.wantTouch {
+				t.Fatalf("Touch=%v, want %v; LastSeen=%q", touched, tc.wantTouch, session.LastSeen)
+			}
+			d.longRunMu.Lock()
+			tracked := !d.longRun[id].workingSince.IsZero()
+			d.longRunMu.Unlock()
+			if tracked != tc.wantTracking {
+				t.Fatalf("long-run tracked=%v, want %v", tracked, tc.wantTracking)
+			}
+			broadcasts := characterizationEventCount(capture.snapshot(), protocol.EventSessionStateChanged, id)
+			if got := broadcasts > 0; got != tc.wantBroadcast {
+				t.Fatalf("state broadcast=%v (%d events), want %v", got, broadcasts, tc.wantBroadcast)
+			}
+		})
+	}
+}
+
+func TestSessionStateDoor_MissingSessionHasNoEffects(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "state.sock"))
+	capture := captureBroadcasts(d)
+
+	if d.applyState(sessionStateChange{
+		sessionID: "missing",
+		state:     protocol.StateWorking,
+		cause:     liveSignal{},
+	}) {
+		t.Fatal("applyState(missing) = true, want false")
+	}
+	d.longRunMu.Lock()
+	_, tracked := d.longRun["missing"]
+	d.longRunMu.Unlock()
+	if tracked {
+		t.Fatal("missing-session transition created long-run tracking")
+	}
+	if events := capture.snapshot(); len(events) != 0 {
+		t.Fatalf("missing-session transition broadcast events: %+v", events)
+	}
+}
+
+func TestSessionStateDoor_IsOnlyDaemonStoreStateWriter(t *testing.T) {
+	stateMethods := map[string]bool{
+		"UpdateState":              true,
+		"UpdateStateWithTimestamp": true,
+		"ApplyAgentDriverState":    true,
+	}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || name == "session_state.go" {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || !stateMethods[selector.Sel.Name] {
+				return true
+			}
+			position := fset.Position(call.Pos())
+			t.Errorf("session state store mutation %s is outside session_state.go at %s", selector.Sel.Name, position)
+			return true
+		})
+	}
+}

--- a/internal/daemon/ticket_notify.go
+++ b/internal/daemon/ticket_notify.go
@@ -84,19 +84,3 @@ func (d *Daemon) syncNudgeForState(sessionID, state string) {
 	}
 	go d.notifyTicketSession(sessionID, time.Now())
 }
-
-// applyStateAndSyncNudge serializes an authoritative session-state write with a
-// complete doorbell input. The lock establishes one order when a session reaches an
-// approval prompt at the same time a countdown wants to send Enter: either the
-// eligible doorbell is fully written first, or the approval state is committed first
-// and the doorbell is suppressed. The follow-up reconciliation runs outside the lock
-// because it may read tickets and arm timers.
-func (d *Daemon) applyStateAndSyncNudge(sessionID, state string, apply func() bool) bool {
-	d.doorbellMu.Lock()
-	applied := apply()
-	d.doorbellMu.Unlock()
-	if applied {
-		d.syncNudgeForState(sessionID, state)
-	}
-	return applied
-}

--- a/internal/daemon/ticket_notify_test.go
+++ b/internal/daemon/ticket_notify_test.go
@@ -209,7 +209,11 @@ func TestNotifyDefersPendingApprovalThenFlushesOnWorking(t *testing.T) {
 		t.Fatal("approval-waiting codex agent armed a countdown")
 	}
 
-	d.updateAndBroadcastState(agentID, protocol.StateWorking)
+	d.applyState(sessionStateChange{
+		sessionID: agentID,
+		state:     protocol.StateWorking,
+		cause:     daemonObservation{},
+	})
 	deadline := time.Now().Add(time.Second)
 	for currentNudgeTimer(d, agentID) == nil && time.Now().Before(deadline) {
 		time.Sleep(time.Millisecond)

--- a/internal/daemon/transcript_watcher.go
+++ b/internal/daemon/transcript_watcher.go
@@ -244,7 +244,11 @@ func (d *Daemon) runTranscriptWatcher(w *transcriptWatcher) {
 					d.logf("%s session=%s", lineResult.Log, w.sessionID)
 				}
 				if lineResult.State != "" && protocol.SessionState(lineResult.State) != sessionState {
-					d.updateAndBroadcastState(w.sessionID, lineResult.State)
+					d.applyState(sessionStateChange{
+						sessionID: w.sessionID,
+						state:     lineResult.State,
+						cause:     daemonObservation{},
+					})
 					sessionState = protocol.SessionState(lineResult.State)
 				}
 
@@ -282,7 +286,11 @@ func (d *Daemon) runTranscriptWatcher(w *transcriptWatcher) {
 			d.logf("%s session=%s", tickResult.Log, w.sessionID)
 		}
 		if tickResult.State != "" && protocol.SessionState(tickResult.State) != sessionState {
-			d.updateAndBroadcastState(w.sessionID, tickResult.State)
+			d.applyState(sessionStateChange{
+				sessionID: w.sessionID,
+				state:     tickResult.State,
+				cause:     daemonObservation{},
+			})
 			sessionState = protocol.SessionState(tickResult.State)
 		}
 		if tickResult.BlockClassification {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -447,29 +447,32 @@ func (s *Store) RemoveSessionsInDirectory(directory string) {
 	}
 }
 
-// UpdateState updates a session's state
-func (s *Store) UpdateState(id, state string) {
+// UpdateState updates a session's state and reports whether a session was updated.
+func (s *Store) UpdateState(id, state string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.db == nil {
 		session := s.sessions[id]
 		if session == nil {
-			return
+			return false
 		}
 		now := time.Now().Format(time.RFC3339Nano)
 		session.State = protocol.SessionState(state)
 		session.StateSince = now
 		session.StateUpdatedAt = now
-		return
+		return true
 	}
 
 	now := time.Now().Format(time.RFC3339Nano)
-	_, err := s.db.Exec(`UPDATE sessions SET state = ?, state_since = ?, state_updated_at = ? WHERE id = ?`,
+	result, err := s.db.Exec(`UPDATE sessions SET state = ?, state_since = ?, state_updated_at = ? WHERE id = ?`,
 		state, now, now, id)
 	if err != nil {
 		log.Printf("[store] UpdateState: failed for session %s: %v", id, err)
+		return false
 	}
+	updated, err := result.RowsAffected()
+	return err == nil && updated == 1
 }
 
 // UpdateStateWithTimestamp updates a session's state only if the provided timestamp

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -366,6 +366,28 @@ func TestStore_Touch(t *testing.T) {
 	}
 }
 
+func TestStore_UpdateStateReportsWhetherSessionWasUpdated(t *testing.T) {
+	s := New()
+	now := protocol.TimestampNow().String()
+	s.Add(&protocol.Session{
+		ID:             "state-result",
+		State:          protocol.SessionStateIdle,
+		StateSince:     now,
+		StateUpdatedAt: now,
+		LastSeen:       now,
+	})
+
+	if !s.UpdateState("state-result", protocol.StateWorking) {
+		t.Fatal("UpdateState(existing) = false, want true")
+	}
+	if got := s.Get("state-result"); got == nil || got.State != protocol.SessionStateWorking {
+		t.Fatalf("state after update = %+v, want working", got)
+	}
+	if s.UpdateState("missing", protocol.StateIdle) {
+		t.Fatal("UpdateState(missing) = true, want false")
+	}
+}
+
 func TestStore_UpdateStateWithTimestamp_SubSecondPrecision(t *testing.T) {
 	s := New()
 


### PR DESCRIPTION
## Summary

- centralize every persisted daemon session-state transition behind a typed applyState door
- preserve classifier timestamp ordering, plugin run/sequence CAS, doorbell fencing, lifecycle ordering, and source-specific side effects
- add pre-refactor characterization coverage plus an AST guard that prevents future production bypasses
- rewrite the session-state plan and strengthen the repository architecture guidance

## Verification

- go build ./...
- targeted store and daemon state-door suites
- full daemon, store, classifier, and transcript suites
- repeated characterization, state-door, and doorbell concurrency tests
- scoped go test -race suite
- make test
- make dev
- packaged real-app workspace shell lifecycle scenario

## Live-test note

The packaged Codex nudge scenario reached the real working transition on two runs, but the spawned Codex CLI then emitted task_complete with last_agent_message null and no normal stop hook. The scenario therefore could not reach its nudge assertions and is documented as an explicit live-verification gap, not passing evidence.

No user-visible behavior change is intended, so this PR has no changelog entry.
