### PR TITLE
perf(present): open the tour instantly, stream file diffs in progressively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-13]
 
 ### Fixed
+- **The Present review window opens instantly on large changesets.** The tour used to show "Loading tour…" until every file's diff had been fetched and parsed, which took several seconds on big diffs. It now opens immediately — each file appears as a lightweight card that fills in with its diff as it loads, so you can start reading the first file right away.
 - **The Present review window no longer lags on large changesets.** Typing a comment re-parsed and re-rendered every file's diff on each keystroke, making characters take a second or more to appear and J/K navigation land on the wrong file. Each file now only re-renders when its own content or comments change, so typing echoes instantly and navigation tracks keypresses correctly.
 - **Ticket nudges now submit in Codex instead of stopping in the composer.** The
   bounded inbox prompt is explicitly framed before Enter, so the nudge starts a

--- a/app/e2e/present-tour.spec.ts
+++ b/app/e2e/present-tour.spec.ts
@@ -436,13 +436,19 @@ test.describe('PresentTour summary fold', () => {
 
 test.describe('PresentTour deferred-load scroll replay', () => {
   test('a scroll request issued while still loading is replayed once files settle', async ({ page }) => {
-    // `&deferred=1` starts every file `{loading: true}` (no `<diffs-container>`
-    // mounts at all yet) so this exercises the case the rail/j-k effect used
-    // to drop: a scroll request that arrives before CodeView exists.
+    // `&deferred=1` starts every file `{loading: true}`. CodeView now mounts
+    // immediately (see PresentTour's progressive-load module doc) with each
+    // file rendered as a zero-hunk placeholder `<diffs-container>` rather
+    // than waiting for every diff fetch to settle — so this exercises the
+    // case the rail/j-k effect used to drop: a scroll request that arrives
+    // before a file's real diff item has been admitted.
     await page.goto('/test-harness/?component=PresentTour&seed=0&deferred=1');
     await page.waitForFunction(() => window.__HARNESS__?.ready === true);
-    await expect(page.locator('.present-tour-loading')).toBeVisible();
-    expect(await fileContainers(page).count()).toBe(0);
+    await expect.poll(() => fileContainers(page).count()).toBe(3);
+
+    const gammaPlaceholder = await findContainerByTitle(page, 'src/gamma.ts');
+    expect(gammaPlaceholder).not.toBeNull();
+    await expect(gammaPlaceholder!).toHaveClass(/present-tour-card-pending/);
 
     await page.evaluate(() => window.__HARNESS__.scrollToFile('src/gamma.ts'));
 

--- a/app/src/components/PresentTour/PresentTour.css
+++ b/app/src/components/PresentTour/PresentTour.css
@@ -182,3 +182,28 @@
 .present-tour-card-skip:focus-within {
   opacity: 0.85;
 }
+
+/* Pending cards (see PresentTour's pendingPathsRef / readyPaths admission):
+ * a file whose diff hasn't been admitted for parsing yet renders as a
+ * zero-hunk placeholder card. A gentle opacity pulse reads as "in flight"
+ * rather than "broken", distinct from the static dimming skip cards get. */
+.present-tour-card-pending {
+  opacity: 0.55;
+  animation: present-tour-pending-pulse 1.6s ease-in-out infinite alternate;
+}
+
+@keyframes present-tour-pending-pulse {
+  from {
+    opacity: 0.4;
+  }
+  to {
+    opacity: 0.7;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .present-tour-card-pending {
+    animation: none;
+    opacity: 0.55;
+  }
+}

--- a/app/src/components/PresentTour/PresentTour.test.tsx
+++ b/app/src/components/PresentTour/PresentTour.test.tsx
@@ -144,6 +144,13 @@ function tinyFile(path: string): PresentTourFile {
   return { path, diff: { loading: false, original, modified } };
 }
 
+// Same path shape as tinyFile, but not yet settled — this is what a file
+// looks like before its diff fetch resolves (or after a round reload puts it
+// back in flight). Used to exercise the pending/admission machinery directly.
+function loadingFile(path: string): PresentTourFile {
+  return { path, diff: { loading: true } };
+}
+
 function annotationComment(overrides: Partial<ReviewComment>): ReviewComment {
   return {
     id: 'annot:x',
@@ -165,6 +172,27 @@ async function waitForSettled() {
   });
 }
 
+// CodeView now mounts as soon as there's at least one file (see
+// PresentTour's module doc) — a not-yet-admitted file's item is a zero-hunk
+// placeholder (see the items memo's pending branch), not the real diff. Tests
+// that need the REAL item (annotations, real hunks) must wait for admission;
+// this polls the latest captured `items` array (see codeViewRenders above)
+// until every requested path's item is no longer a placeholder. An error
+// item ('file' type) needs no admission, so it always counts as ready.
+async function awaitAllReady(paths: string[]) {
+  await waitFor(() => {
+    const latest = codeViewRenders.calls[codeViewRenders.calls.length - 1] ?? [];
+    for (const path of paths) {
+      const item = latest.find((i) => (i.id as string) === path) as
+        | { type?: string; fileDiff?: { hunks: unknown[] } }
+        | undefined;
+      expect(item).toBeDefined();
+      if (item!.type === 'file') continue; // error card — renders immediately, no admission
+      expect((item!.fileDiff?.hunks ?? []).length).toBeGreaterThan(0);
+    }
+  });
+}
+
 describe('PresentTour annotations', () => {
   it('renders an annotation as a read-only thread at its line, author shown as Claude', async () => {
     const comment = annotationComment({ id: 'annot:1', content: 'why this line?' });
@@ -179,6 +207,7 @@ describe('PresentTour annotations', () => {
       />
     );
     await waitForSettled();
+    await awaitAllReady(['src/foo.ts']);
 
     const thread = screen.getByTestId('diff-comment-thread');
     expect(thread.textContent).toContain('why this line?');
@@ -212,6 +241,7 @@ describe('PresentTour annotations', () => {
       />
     );
     await waitForSettled();
+    await awaitAllReady(['src/foo.ts']);
 
     const thread = screen.getByTestId('diff-comment-thread');
     const bodies = Array.from(thread.querySelectorAll('.diff-comment-content')).map((el) => el.textContent);
@@ -233,6 +263,7 @@ describe('PresentTour annotations', () => {
       />
     );
     await waitForSettled();
+    await awaitAllReady(['src/foo.ts']);
 
     const replyBtn = screen.getByRole('button', { name: 'Reply' });
     act(() => {
@@ -266,6 +297,7 @@ describe('PresentTour annotations', () => {
       />
     );
     await waitForSettled();
+    await awaitAllReady(['src/foo.ts']);
 
     const thread = screen.getByTestId('diff-comment-thread');
     expect(thread.textContent).toContain('off in the weeds');
@@ -295,6 +327,7 @@ describe('PresentTour annotations', () => {
       />
     );
     await waitForSettled();
+    await awaitAllReady(['src/foo.ts']);
 
     expect(screen.queryByTestId('diff-comment-thread')).toBeNull();
   });
@@ -321,6 +354,7 @@ describe('PresentTour annotations', () => {
       />
     );
     await waitForSettled();
+    await awaitAllReady(['src/foo.ts', 'src/b.ts']);
 
     await waitFor(() => {
       expect(onAnnotationAnchorsChange).toHaveBeenCalled();
@@ -347,6 +381,7 @@ describe('PresentTour annotations', () => {
       />
     );
     await waitForSettled();
+    await awaitAllReady(['src/foo.ts']);
 
     const latestItems = codeViewRenders.calls[codeViewRenders.calls.length - 1];
     const item = latestItems[0] as { annotations: Array<{ metadata: Record<string, unknown> }> };
@@ -374,6 +409,7 @@ describe('PresentTour annotations', () => {
       />
     );
     await waitForSettled();
+    await awaitAllReady(['src/foo.ts']);
 
     await waitFor(() => {
       expect(onAnnotationAnchorsChange).toHaveBeenCalled();
@@ -509,26 +545,24 @@ describe('PresentTour summary fold', () => {
 
 // Regression test for the root-cause bug: the takeover/cold-window-pin
 // listener effect used to have `[]` deps, so it ran once against
-// `containerRef.current === null` while the first render's `allSettled` was
-// still false (diffs load async over the daemon WS in the live app) and then
-// never ran again once CodeView actually mounted. Passive scroll tracking
-// never armed, `handleScroll` returned early forever, and neither the
-// summary fold nor the cold-window scroll pin ever worked outside tests
-// (which, unlike the live app, feed pre-loaded diffs so `allSettled` is true
-// on the very first render). This must fail on the pre-fix `[]` deps and
-// pass once the effect depends on `allSettled`.
+// `containerRef.current === null` while the first render had zero manifest
+// files (the "Loading tour…" branch renders instead of CodeView, and
+// `tourMounted` was still false) and then never ran again once CodeView
+// actually mounted. Passive scroll tracking never armed, `handleScroll`
+// returned early forever, and neither the summary fold nor the cold-window
+// scroll pin ever worked outside tests (which, unlike the live app, usually
+// render with files already present). This must fail on the pre-fix `[]`
+// deps and pass once the effect depends on `tourMounted`.
 describe('PresentTour listener re-attach on deferred load (regression)', () => {
-  it('arms passive scroll tracking once CodeView mounts after starting in the loading state', async () => {
+  it('arms passive scroll tracking once CodeView mounts after starting with zero manifest files', async () => {
     const onActivePathChange = vi.fn();
-    const loadingFile: PresentTourFile = { path: 'src/foo.ts', diff: { loading: true } };
-    const { rerender } = render(
-      <PresentTour {...baseProps({ files: [loadingFile], onActivePathChange })} />
-    );
+    const { rerender } = render(<PresentTour {...baseProps({ files: [], onActivePathChange })} />);
 
     expect(screen.getByText('Loading tour…')).toBeInTheDocument();
 
     rerender(<PresentTour {...baseProps({ files: [tinyFile('src/foo.ts')], onActivePathChange })} />);
     await waitForSettled();
+    await awaitAllReady(['src/foo.ts']);
 
     fireEvent.wheel(screen.getByTestId('mock-codeview'));
     act(() => {
@@ -673,6 +707,7 @@ describe('PresentTour per-file item caching', () => {
     const files = [tinyFile('src/a.ts'), tinyFile('src/b.ts'), tinyFile('src/c.ts')];
     render(<PresentTour {...baseProps({ files })} />);
     await waitForSettled();
+    await awaitAllReady(['src/a.ts', 'src/b.ts', 'src/c.ts']);
 
     openDraftOn('src/a.ts');
     const form = await screen.findByTestId('diff-comment-form');
@@ -698,6 +733,7 @@ describe('PresentTour per-file item caching', () => {
     const files = [tinyFile('src/a.ts'), tinyFile('src/b.ts'), tinyFile('src/c.ts')];
     const { rerender } = render(<PresentTour {...baseProps({ files })} />);
     await waitForSettled();
+    await awaitAllReady(['src/a.ts', 'src/b.ts', 'src/c.ts']);
 
     const parseCountBefore = parseDiffFromFileSpy.fn!.mock.calls.length;
     const itemsBefore = latestItemsByPath();
@@ -718,6 +754,7 @@ describe('PresentTour per-file item caching', () => {
     const files = [tinyFile('src/a.ts'), tinyFile('src/b.ts')];
     render(<PresentTour {...baseProps({ files })} />);
     await waitForSettled();
+    await awaitAllReady(['src/a.ts', 'src/b.ts']);
 
     const itemsBefore = latestItemsByPath();
     openDraftOn('src/a.ts');
@@ -741,6 +778,7 @@ describe('PresentTour per-file item caching', () => {
       />
     );
     await waitForSettled();
+    await awaitAllReady(['src/a.ts', 'src/b.ts']);
 
     const parseCountBefore = parseDiffFromFileSpy.fn!.mock.calls.length;
     const itemsBefore = latestItemsByPath();
@@ -776,6 +814,7 @@ describe('PresentTour per-file item caching', () => {
     const fileB = tinyFile('src/b.ts');
     const { rerender } = render(<PresentTour {...baseProps({ files: [fileA, fileB] })} />);
     await waitForSettled();
+    await awaitAllReady(['src/a.ts', 'src/b.ts']);
 
     openDraftOn('src/a.ts');
     const form = await screen.findByTestId('diff-comment-form');
@@ -794,6 +833,138 @@ describe('PresentTour per-file item caching', () => {
     rerender(<PresentTour {...baseProps({ files: [fileA, fileB] })} />);
     const remountedForm = await screen.findByTestId('diff-comment-form');
     expect(remountedForm.querySelector('textarea')).toHaveValue('typed text');
+  });
+});
+
+// Exercises the progressive-load design itself (see the module doc's
+// "CodeView mounts as soon as..." paragraph): CodeView mounting before every
+// diff settles, placeholder items for not-yet-admitted files, and the
+// frame-budgeted readyPaths admission that swaps them for real items.
+describe('PresentTour progressive load', () => {
+  function latestItemsByPath(): Map<string, Record<string, unknown>> {
+    const latest = codeViewRenders.calls[codeViewRenders.calls.length - 1] ?? [];
+    return new Map(latest.map((item) => [item.id as string, item]));
+  }
+
+  it('mounts CodeView with a zero-hunk placeholder per file before any diff settles', async () => {
+    const files = [loadingFile('src/a.ts'), loadingFile('src/b.ts'), loadingFile('src/c.ts')];
+    render(<PresentTour {...baseProps({ files })} />);
+    await waitForSettled();
+
+    const items = latestItemsByPath();
+    expect(items.size).toBe(3);
+    for (const path of ['src/a.ts', 'src/b.ts', 'src/c.ts']) {
+      const item = items.get(path) as { type: string; fileDiff: { hunks: unknown[] } };
+      expect(item.type).toBe('diff');
+      expect(item.fileDiff.hunks).toHaveLength(0);
+    }
+  });
+
+  it('swaps one file to its real item as it settles, leaving the others as untouched placeholders', async () => {
+    const { rerender } = render(
+      <PresentTour {...baseProps({ files: [loadingFile('src/a.ts'), loadingFile('src/b.ts'), loadingFile('src/c.ts')] })} />
+    );
+    await waitForSettled();
+    const before = latestItemsByPath();
+    const bBefore = before.get('src/b.ts');
+    const cBefore = before.get('src/c.ts');
+
+    rerender(
+      <PresentTour {...baseProps({ files: [tinyFile('src/a.ts'), loadingFile('src/b.ts'), loadingFile('src/c.ts')] })} />
+    );
+    await awaitAllReady(['src/a.ts']);
+
+    const after = latestItemsByPath();
+    const aAfter = after.get('src/a.ts') as { type: string; fileDiff: { hunks: unknown[] }; version: number };
+    expect(aAfter.fileDiff.hunks.length).toBeGreaterThan(0);
+    expect(aAfter.version).not.toBe((before.get('src/a.ts') as { version: number }).version);
+    // b and c never re-settled — their placeholder items must be the exact
+    // same objects, not just equivalent-looking ones (proves admission is
+    // per-file, not a blanket rebuild of every still-loading item).
+    expect(after.get('src/b.ts')).toBe(bBefore);
+    expect(after.get('src/c.ts')).toBe(cBefore);
+  });
+
+  it('parses each settled file exactly once as sliced admission converges on a large batch', async () => {
+    const paths = Array.from({ length: 12 }, (_, i) => `src/file${i}.ts`);
+    const { rerender } = render(<PresentTour {...baseProps({ files: paths.map(loadingFile) })} />);
+    await waitForSettled();
+
+    rerender(<PresentTour {...baseProps({ files: paths.map(tinyFile) })} />);
+    await awaitAllReady(paths);
+
+    const realParseCalls = parseDiffFromFileSpy.fn!.mock.calls.filter(
+      (call) => (call[0] as { contents: string }).contents.length > 0
+    );
+    expect(realParseCalls).toHaveLength(paths.length);
+    for (const path of paths) {
+      const callsForPath = realParseCalls.filter((call) => (call[0] as { name: string }).name === path);
+      expect(callsForPath).toHaveLength(1);
+    }
+  });
+
+  it('leaves a loading file’s placeholder identity and version untouched by an unrelated prop change', async () => {
+    const files = [tinyFile('src/a.ts'), loadingFile('src/b.ts')];
+    const { rerender } = render(<PresentTour {...baseProps({ files })} />);
+    await waitForSettled();
+    await awaitAllReady(['src/a.ts']);
+
+    const before = latestItemsByPath().get('src/b.ts');
+    rerender(<PresentTour {...baseProps({ files, reviewedPaths: new Set(['src/a.ts']) })} />);
+    const after = latestItemsByPath().get('src/b.ts');
+
+    expect(after).toBe(before); // same object — a's reviewed-toggle never touches b's pending item
+  });
+
+  it('renders an error card immediately, with no admission wait, alongside files still loading', async () => {
+    const files = [
+      loadingFile('src/a.ts'),
+      { path: 'src/broken.ts', diff: { loading: false, error: 'boom' } },
+      loadingFile('src/c.ts'),
+    ];
+    render(<PresentTour {...baseProps({ files })} />);
+    await waitForSettled();
+
+    const items = latestItemsByPath();
+    const errored = items.get('src/broken.ts') as { type: string; file: { contents: string } };
+    expect(errored.type).toBe('file');
+    expect(errored.file.contents).toBe('boom');
+    // its siblings are still bare placeholders — the error needed no wait for them.
+    expect((items.get('src/a.ts') as { fileDiff: { hunks: unknown[] } }).fileDiff.hunks).toHaveLength(0);
+  });
+
+  it('re-parsing on a round reload is skipped when the file re-settles with identical content', async () => {
+    const file = tinyFile('src/a.ts');
+    const { rerender } = render(<PresentTour {...baseProps({ files: [file] })} />);
+    await waitForSettled();
+    await awaitAllReady(['src/a.ts']);
+    const parseCountAfterFirstSettle = parseDiffFromFileSpy.fn!.mock.calls.length;
+
+    // Round reload: the file goes back to loading — its item reverts to a
+    // placeholder regardless of its stale readyPaths membership (see the
+    // admission effect's comment on why that membership is kept, not cleared).
+    rerender(<PresentTour {...baseProps({ files: [loadingFile('src/a.ts')] })} />);
+    await waitFor(() => {
+      const item = latestItemsByPath().get('src/a.ts') as { fileDiff: { hunks: unknown[] } };
+      expect(item.fileDiff.hunks).toHaveLength(0);
+    });
+
+    // Re-settles with the exact same (original, modified) pair.
+    rerender(<PresentTour {...baseProps({ files: [file] })} />);
+    await waitFor(() => {
+      const item = latestItemsByPath().get('src/a.ts') as { fileDiff: { hunks: unknown[] } };
+      expect(item.fileDiff.hunks.length).toBeGreaterThan(0);
+    });
+
+    const realParseCallsAfter = parseDiffFromFileSpy.fn!.mock.calls.filter(
+      (call) => (call[0] as { contents: string }).contents.length > 0
+    );
+    expect(realParseCallsAfter).toHaveLength(1); // still just the original settle — parse cache reused, not rebuilt
+    // The reload's placeholder step is a fresh zero-hunk parse (its own cache
+    // entry was evicted when the file left the 'pending' signature on first
+    // settle) — one more call than after the first settle, but no SECOND real
+    // parse of the actual content.
+    expect(parseDiffFromFileSpy.fn!.mock.calls.length).toBe(parseCountAfterFirstSettle + 1);
   });
 });
 

--- a/app/src/components/PresentTour/index.tsx
+++ b/app/src/components/PresentTour/index.tsx
@@ -10,19 +10,10 @@
  * comment/draft anchor is `${filepath}:${side}:${start}` instead of just
  * `${side}:${start}`.
  *
- * Two design points called out in the slice-1 brief as "investigate, fall
- * back if unworkable" were resolved toward the documented fallback rather
- * than the preferred option, given the size of this slice:
+ * One design point called out in the slice-1 brief as "investigate, fall
+ * back if unworkable" was resolved toward the documented fallback rather
+ * than the preferred option, given the size of that slice:
  *
- *   - Per-file loading/error state: CodeView's controlled `items` only
- *     accept a real `CodeViewDiffItem` (needs a parsed `FileDiffMetadata`)
- *     or a `CodeViewFileItem` (needs real file contents) — there is no
- *     skeleton/placeholder item type. Rather than synthesize placeholder
- *     diffs, this component renders a single "loading tour…" state until
- *     every file's diff fetch has settled, then builds the full item list
- *     once. A per-file error still gets its own card in-order (rendered as
- *     a plain `type: 'file'` item carrying the error text) rather than
- *     being dropped, but it will not stream in before its siblings.
  *   - Summary placement: CodeView's react wrapper renders its own internal
  *     scroll container (via `containerRef`), not a slot host that's known to
  *     tolerate injected sibling DOM. Rather than risk fighting the library's
@@ -31,6 +22,16 @@
  *     result. Instead it folds away via `summaryVisible` once the caller
  *     reports the user has scrolled past the pinned Summary stop, so it
  *     doesn't permanently steal space from the diff.
+ *
+ * CodeView mounts as soon as the manifest has at least one file — it does not
+ * wait for every diff fetch to settle. A file whose diff hasn't settled yet
+ * renders as a lightweight placeholder item (zero-hunk parse, header-only
+ * card, no annotations or note — see the items memo's pending branch); once
+ * its fetch settles, a frame-budgeted admission effect (see `readyPaths`)
+ * parses it and swaps the real item in, a handful of files per animation
+ * frame so no single pass stalls the main thread on a large changeset. A
+ * per-file error still gets its own card in-order immediately (rendered as a
+ * plain `type: 'file'` item carrying the error text) — it needs no admission.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -240,6 +241,33 @@ function getVisibleLineRangesFromDiff(diff: ReturnType<typeof parseDiffFromFile>
   );
 }
 
+// Shared parse-and-cache logic for one file's (original, modified) pair, used
+// by both the items memo (the rare content-changed-while-ready case) and the
+// admission effect (the primary parse site for newly-settled files) — kept in
+// one place so the cache-entry shape isn't duplicated between them. A hit
+// requires the cached entry's own (original, modified) to match; a miss
+// parses, stores, and returns the fresh entry.
+function ensureParsedFile(
+  cache: Map<string, ParsedFileCacheEntry>,
+  path: string,
+  original: string,
+  modified: string
+): ParsedFileCacheEntry {
+  const cached = cache.get(path);
+  if (cached && cached.original === original && cached.modified === modified) return cached;
+  const oldFile: FileContents = { name: path, contents: original };
+  const newFile: FileContents = { name: path, contents: modified };
+  const fileDiff = parseDiffFromFile(oldFile, newFile);
+  const visibleLineRanges = getVisibleLineRangesFromDiff(fileDiff);
+  const lineCounts = {
+    additions: modified.split('\n').length,
+    deletions: original.split('\n').length,
+  };
+  const entry: ParsedFileCacheEntry = { original, modified, fileDiff, visibleLineRanges, lineCounts };
+  cache.set(path, entry);
+  return entry;
+}
+
 export function PresentTour({
   summary,
   summaryVisible = true,
@@ -339,6 +367,17 @@ export function PresentTour({
   // `syncItemRecord` see a matching version and do nothing at all for that
   // file, not merely a cheap diff.
   const fileItemCacheRef = useRef<Map<string, FileItemCacheEntry>>(new Map());
+  // Paths whose item is currently the pending placeholder rather than the
+  // real diff — reset and repopulated each items-memo run (same lifecycle as
+  // notePlacedPathsRef above), consumed by syncCardClasses below to toggle
+  // `.present-tour-card-pending` on the rendered card.
+  const pendingPathsRef = useRef<Set<string>>(new Set());
+  // Paths whose diff has settled AND been admitted for parsing (see the
+  // admission effect below). A file's item stays the pending placeholder
+  // until its path lands here — admission is deliberately decoupled from
+  // "settled" so a burst of files settling in the same tick still gets
+  // parsed a few at a time per animation frame, not all at once.
+  const [readyPaths, setReadyPaths] = useState<ReadonlySet<string>>(() => new Set());
 
   // Mermaid diagrams (in file notes and annotation bodies) render
   // asynchronously: the item is first measured against a short "loading"
@@ -456,7 +495,54 @@ export function PresentTour({
     return map;
   }, [draftKeys, drafts]);
 
-  const allSettled = files.length > 0 && files.every((f) => !f.diff.loading);
+  // CodeView mounts as soon as there's at least one manifest file — it no
+  // longer waits for every diff to settle (see the module doc). Drives the
+  // effects below that used to gate on "every diff settled": they only need
+  // CodeView to actually be in the DOM, not for its content to be final.
+  const tourMounted = files.length > 0;
+
+  // Frame-budgeted parse admission: the primary site where a newly-settled
+  // file's diff actually gets parsed (the items memo's own parse fallback
+  // below only covers the rarer case of a ready file's content changing).
+  // Runs one rAF-scheduled slice at a time rather than parsing every
+  // just-settled file synchronously, so a changeset where many fetches
+  // resolve in the same tick doesn't stall the main thread in one pass.
+  useEffect(() => {
+    const admittable = files.filter(
+      (f) => !f.diff.loading && !f.diff.error && f.diff.original !== undefined && f.diff.modified !== undefined && !readyPaths.has(f.path)
+    );
+    // Paths readyPaths still holds for files no longer in the manifest at
+    // all — dropped so the set doesn't grow unbounded across rounds. A file
+    // that instead went back to `loading` (a round reload) deliberately
+    // KEEPS its stale readyPaths membership: the items memo already routes
+    // any `diff.loading` file to the pending branch regardless of
+    // readyPaths, and if it re-settles with the same content it's ready
+    // again immediately (no extra admission round-trip needed) — the memo's
+    // own parse-cache check is what keeps that case free of a re-parse.
+    const currentPaths = new Set(files.map((f) => f.path));
+    const stale = Array.from(readyPaths).filter((p) => !currentPaths.has(p));
+    if (admittable.length === 0 && stale.length === 0) return;
+
+    const raf = requestAnimationFrame(() => {
+      const sliceStart = performance.now();
+      const admitted: string[] = [];
+      const SLICE_BUDGET_MS = 8;
+      for (const file of admittable) {
+        ensureParsedFile(parseCacheRef.current, file.path, file.diff.original as string, file.diff.modified as string);
+        admitted.push(file.path);
+        if (performance.now() - sliceStart > SLICE_BUDGET_MS) break; // always admits at least one file per slice
+      }
+      setReadyPaths((current) => {
+        const next = new Set(current);
+        for (const path of admitted) next.add(path);
+        for (const path of stale) next.delete(path);
+        return next;
+      });
+    });
+    return () => cancelAnimationFrame(raf);
+    // Re-running when readyPaths changes is what schedules the NEXT slice —
+    // this effect is its own driver, not a one-shot kickoff.
+  }, [files, readyPaths]);
 
   const handleSaveDraft = useCallback(
     async (key: string, content: string) => {
@@ -544,35 +630,36 @@ export function PresentTour({
     ]
   );
 
-  // Build one CodeViewItem per manifest file, in reading order. Only runs
-  // once every file's diff fetch has settled (see the module doc for why).
-  // Per file, this first computes a cheap "signature" of everything that
-  // affects that file's rendered payload (see fileItemCacheRef above) and
-  // compares it — together with the shown (original, modified) strings — to
-  // what produced the file's last cached item. A match reuses that exact item
-  // object (no re-parse, no new version); a miss rebuilds it, using
-  // parseCacheRef to skip re-parsing if only comments/drafts/review-state
-  // changed rather than the file's own content.
+  // Build one CodeViewItem per manifest file, in reading order — CodeView
+  // mounts as soon as there's at least one file (see the module doc), so this
+  // runs well before every diff has settled. Per file, this first computes a
+  // cheap "signature" of everything that affects that file's rendered
+  // payload (see fileItemCacheRef above) and compares it — together with the
+  // shown (original, modified) strings — to what produced the file's last
+  // cached item. A match reuses that exact item object (no re-parse, no new
+  // version); a miss rebuilds it, using parseCacheRef to skip re-parsing if
+  // only comments/drafts/review-state changed rather than the file's own
+  // content.
   const items = useMemo<CodeViewItem<AnnotationMeta>[]>(() => {
     annotationAnchorsRef.current = [];
     notePlacedPathsRef.current = new Set();
-    if (!allSettled) {
-      // A fresh fetch pass (files went from settled back to loading, e.g. a
-      // round reload) invalidates every cached parse/item — the next settle
-      // starts clean, same lifecycle as the two refs reset just above.
-      parseCacheRef.current.clear();
-      fileItemCacheRef.current.clear();
-      return [];
-    }
+    pendingPathsRef.current = new Set();
 
     const result = files.map((file): CodeViewItem<AnnotationMeta> => {
       const { diff } = file;
       const cached = fileItemCacheRef.current.get(file.path);
 
-      if (diff.error || diff.original === undefined || diff.modified === undefined) {
-        // Discriminator ('error' vs 'diff' below) so a file that flips
-        // between an errored and a settled diff across renders can never
-        // signature-match its own stale cache entry from the other branch.
+      // A still-loading file legitimately has no original/modified yet (see
+      // PresentRoot's initial `{ loading: true }` diff state) — that's the
+      // pending case below, not an error. Only missing content on a file
+      // that ISN'T loading is the anomalous "settled with nothing to show"
+      // case this treats as an error.
+      if (diff.error || (!diff.loading && (diff.original === undefined || diff.modified === undefined))) {
+        // Discriminator ('error' vs 'diff'/'pending' below) so a file that
+        // flips between an errored and a settled diff across renders can
+        // never signature-match its own stale cache entry from the other
+        // branch. An error needs no admission — it renders as soon as this
+        // file settles, regardless of its siblings.
         const signature = JSON.stringify(['error', diff.error ?? 'Failed to load this file’s diff.']);
         if (cached && cached.signature === signature && cached.shownOriginal === undefined && cached.shownModified === undefined) {
           if (cached.notePlaced) notePlacedPathsRef.current.add(file.path);
@@ -589,11 +676,50 @@ export function PresentTour({
         return item;
       }
 
+      if (diff.loading || !readyPaths.has(file.path)) {
+        // Not yet admitted (see the admission effect above) — a cheap
+        // zero-hunk placeholder so the card renders as a header-only shell
+        // rather than blocking the whole tour. Deliberately carries no
+        // annotations: a note or thread here would render through the same
+        // header/annotation paths the real item uses once admitted, and
+        // CodeView would have to re-measure the card's height on the swap —
+        // notes/threads simply wait for the real item, same as the diff body.
+        pendingPathsRef.current.add(file.path);
+        const signature = JSON.stringify(['pending']);
+        if (cached && cached.signature === signature) return cached.item;
+        const emptyFile: FileContents = { name: file.path, contents: '' };
+        const item: CodeViewItem<AnnotationMeta> = {
+          id: file.path,
+          type: 'diff',
+          fileDiff: parseDiffFromFile(emptyFile, emptyFile),
+          annotations: [],
+          version: ++itemsVersionRef.current,
+        };
+        fileItemCacheRef.current.set(file.path, {
+          signature,
+          shownOriginal: undefined,
+          shownModified: undefined,
+          item,
+          anchors: [],
+          notePlaced: false,
+        });
+        return item;
+      }
+
+      // Both branches above already returned for every case where original/
+      // modified could be undefined (not-loading-with-no-content is the
+      // error branch; still-loading is the pending branch just above) — TS
+      // can't follow that across the two separate conditionals, so this
+      // narrows explicitly rather than threading `as string` through every
+      // use below.
+      const original = diff.original as string;
+      const modified = diff.modified as string;
+
       const frozen = frozenRef.current.get(file.path);
       if (formOpenByFile.has(file.path) && !frozen) {
-        frozenRef.current.set(file.path, { original: diff.original, modified: diff.modified });
+        frozenRef.current.set(file.path, { original, modified });
       }
-      const shown = frozenRef.current.get(file.path) ?? { original: diff.original, modified: diff.modified };
+      const shown = frozenRef.current.get(file.path) ?? { original, modified };
 
       const fileComments = commentsByFile.get(file.path) ?? [];
       const fileDraftKeys = draftsByFile.get(file.path) ?? [];
@@ -639,23 +765,10 @@ export function PresentTour({
         return cached.item;
       }
 
-      const parsedCached = parseCacheRef.current.get(file.path);
-      let fileDiff: ReturnType<typeof parseDiffFromFile>;
-      let visibleLineRanges: VisibleLineRanges;
-      let lineCounts: { additions: number; deletions: number };
-      if (parsedCached && parsedCached.original === shown.original && parsedCached.modified === shown.modified) {
-        ({ fileDiff, visibleLineRanges, lineCounts } = parsedCached);
-      } else {
-        const oldFile: FileContents = { name: file.path, contents: shown.original };
-        const newFile: FileContents = { name: file.path, contents: shown.modified };
-        fileDiff = parseDiffFromFile(oldFile, newFile);
-        visibleLineRanges = getVisibleLineRangesFromDiff(fileDiff);
-        lineCounts = {
-          additions: shown.modified.split('\n').length,
-          deletions: shown.original.split('\n').length,
-        };
-        parseCacheRef.current.set(file.path, { original: shown.original, modified: shown.modified, fileDiff, visibleLineRanges, lineCounts });
-      }
+      // Usually already parsed by the admission effect above (this is the
+      // rarer content-changed-while-ready case — e.g. a frozen file's form
+      // closes and its shown content moves back to the live diff).
+      const { fileDiff, visibleLineRanges, lineCounts } = ensureParsedFile(parseCacheRef.current, file.path, shown.original, shown.modified);
 
       const groups = new Map<string, AnnotationMeta>();
       for (const comment of fileComments) {
@@ -797,9 +910,22 @@ export function PresentTour({
     // per-file signature contribution. None of these bump every file's
     // version unconditionally anymore (see fileItemCacheRef's declaration);
     // an unrelated file's signature comes out identical and that file's cache
-    // entry is reused as-is.
+    // entry is reused as-is. readyPaths is included so a file's admission
+    // (see the effect above) re-runs this memo and swaps its placeholder for
+    // the real item.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allSettled, files, commentsByFile, draftsByFile, drafts, formOpenByFile, editingCommentId, reviewedPaths, annotationCommentIds, diagramLayoutTick]);
+  }, [
+    files,
+    commentsByFile,
+    draftsByFile,
+    drafts,
+    formOpenByFile,
+    editingCommentId,
+    reviewedPaths,
+    annotationCommentIds,
+    diagramLayoutTick,
+    readyPaths,
+  ]);
 
   // Notify the parent of the current annotation anchor list once items has
   // committed (annotationAnchorsRef was populated by the memo above). A plain
@@ -837,33 +963,41 @@ export function PresentTour({
   const groupByPath = useMemo(() => new Map(files.map((f) => [f.path, f.group ?? 'tour'])), [files]);
 
   // The library's items don't carry an arbitrary className slot, so the
-  // skip-card de-emphasis (see .present-tour-card-skip in PresentTour.css) is
-  // applied imperatively to each rendered card's root element — the same
-  // `getRenderedItems()` escape hatch handleScroll below already relies on.
-  // CodeView virtualizes: scrolling can mount new item elements without the
-  // `items` array changing, so this also has to re-run on every scroll (see
-  // handleScroll) — this effect alone only covers items already rendered
-  // when the item list settles.
-  const syncSkipClasses = useCallback(() => {
+  // skip-card de-emphasis (see .present-tour-card-skip in PresentTour.css)
+  // and the pending-card dimming (see .present-tour-card-pending, driven by
+  // pendingPathsRef from the items memo) are applied imperatively to each
+  // rendered card's root element — the same `getRenderedItems()` escape hatch
+  // handleScroll below already relies on. CodeView virtualizes: scrolling can
+  // mount new item elements without the `items` array changing, so this also
+  // has to re-run on every scroll (see handleScroll) — this effect alone only
+  // covers items already rendered when the item list settles.
+  const syncCardClasses = useCallback(() => {
     const instance = handleRef.current?.getInstance();
     if (!instance) return;
     for (const rendered of instance.getRenderedItems()) {
       const isSkip = groupByPath.get(rendered.id) === 'skip';
       rendered.element.classList.toggle('present-tour-card-skip', isSkip);
+      rendered.element.classList.toggle('present-tour-card-pending', pendingPathsRef.current.has(rendered.id));
     }
   }, [groupByPath]);
 
   useEffect(() => {
-    if (!allSettled) return;
-    syncSkipClasses();
-  }, [allSettled, items, groupByPath, syncSkipClasses]);
+    if (!tourMounted) return;
+    syncCardClasses();
+  }, [tourMounted, items, groupByPath, syncCardClasses]);
 
   const renderHeaderMetadata = useCallback(
     (item: CodeViewItem<AnnotationMeta>) => {
       // The note already rendered as an annotation for this file (see
       // notePlacedPathsRef) — this header path is only the fallback for
-      // files with no visible diff line to anchor a note annotation to.
-      if (notePlacedPathsRef.current.has(item.id)) return null;
+      // files with no visible diff line to anchor a note annotation to. A
+      // pending (not yet admitted) file is also excluded here even though
+      // it isn't in notePlacedPathsRef either — its placeholder item is
+      // deliberately note-less (see the items memo's pending branch), and
+      // rendering the note here in the meantime would mount its Markdown/
+      // MermaidDiagram early, then remount it again once the real
+      // annotation takes over on admission.
+      if (notePlacedPathsRef.current.has(item.id) || pendingPathsRef.current.has(item.id)) return null;
       const note = noteByPath.get(item.id);
       if (!note) return null;
       return (
@@ -923,11 +1057,11 @@ export function PresentTour({
   // as a ref (not a closure-local variable) because the rail/j-k scrollTo
   // effect below also needs to arm it — see that effect's comment for why.
   const userTookOverRef = useRef(false);
-  // Tracks allSettled as of the previous run of the scroll-replay effect
+  // Tracks tourMounted as of the previous run of the scroll-replay effect
   // below, to detect the specific false->true transition (CodeView just
   // mounted this commit) rather than "a scroll has ever fired". See that
   // effect's comment.
-  const wasSettledRef = useRef(false);
+  const wasMountedRef = useRef(false);
   // True while a programmatic smooth scroll (rail/j-k or N/P) is settling —
   // handleScroll swallows passive reports during this window so the
   // animation's own scroll events can't fight the explicit navigation that
@@ -943,16 +1077,17 @@ export function PresentTour({
   // programmatic scroll started.
   const suppressQuietTimerRef = useRef<number>(0);
   // Must attach once CodeView actually mounts, not just on this component's
-  // own mount: diffs load async over the daemon WS, so on first render
-  // `allSettled` is often still false, the "Loading tour…" branch renders
-  // instead of CodeView, and `containerRef.current` is null — an empty dep
-  // array would run this effect exactly once against that null ref and never
+  // own mount: on first render there may be no manifest files yet, so
+  // `tourMounted` is still false, the "Loading tour…" branch renders instead
+  // of CodeView, and `containerRef.current` is null — an empty dep array
+  // would run this effect exactly once against that null ref and never
   // again, permanently disarming the takeover/cold-window-pin listeners (the
   // summary card would then never fold, since passive scroll reports never
-  // arm `userTookOverRef`). `allSettled` in the deps re-runs the effect the
-  // moment CodeView mounts; the cleanup also re-runs if diffs ever reload
-  // (allSettled true -> false -> true), which is correct since the container
-  // itself may have been swapped out during the loading branch.
+  // arm `userTookOverRef`). `tourMounted` in the deps re-runs the effect the
+  // moment CodeView mounts; the cleanup also re-runs if the manifest ever
+  // drops to zero files and back (tourMounted true -> false -> true), which
+  // is correct since the container itself may have been swapped out during
+  // the loading branch.
   useEffect(() => {
     const scroller = containerRef.current;
     if (!scroller) return;
@@ -977,7 +1112,7 @@ export function PresentTour({
       scroller.removeEventListener('scroll', onNativeScroll);
       window.clearTimeout(suppressQuietTimerRef.current);
     };
-  }, [allSettled]);
+  }, [tourMounted]);
 
   // Rail-driven / j-k-driven scroll: nonce forces a re-scroll even to the
   // same path (e.g. re-pressing j at the last file). A null scrollToPath
@@ -1000,30 +1135,34 @@ export function PresentTour({
   // issued before the user's first raw wheel/touch was silently swallowed.
   // Arm the same flag the pin checks so the pin treats this as real input.
   //
-  // `allSettled` is in the deps so a request that arrives while CodeView isn't
-  // mounted yet (handleRef.current is null / rows aren't laid out) is not lost:
-  // this effect no-ops without touching userTookOverRef while loading, then
-  // re-runs and performs the still-pending scroll once allSettled flips true.
-  // The arming stays here (at actual scroll time), not in a separate
-  // loading-phase branch, so a request that never got to scroll never marks
-  // the pin as taken over.
+  // `tourMounted` is in the deps so a request that arrives while CodeView
+  // isn't mounted yet (handleRef.current is null / rows aren't laid out) is
+  // not lost: this effect no-ops without touching userTookOverRef while
+  // there are no files yet, then re-runs and performs the still-pending
+  // scroll once tourMounted flips true. The arming stays here (at actual
+  // scroll time), not in a separate loading-phase branch, so a request that
+  // never got to scroll never marks the pin as taken over.
   //
-  // wasSettledRef tracks whether the PREVIOUS run of this same effect already
-  // saw allSettled=true. It updates on every run (even the early-return ones,
-  // so a settle that happens with no scroll pending is still recorded) and is
-  // read before that update — so it's true exactly when CodeView had a prior
-  // commit to lay itself out in before this scroll, and false the one time
-  // allSettled just flipped true THIS render (CodeView mounts and this effect
-  // fires in the same commit, before the browser has laid out the fresh
-  // container). CodeView.scrollTo silently no-ops if it can't resolve a
+  // A rail/j-k scroll to a file whose diff hasn't settled yet lands on its
+  // placeholder card; the real content grows in place once admitted — no
+  // special handling needed, same as any other item height change.
+  //
+  // wasMountedRef tracks whether the PREVIOUS run of this same effect already
+  // saw tourMounted=true. It updates on every run (even the early-return
+  // ones, so a mount that happens with no scroll pending is still recorded)
+  // and is read before that update — so it's true exactly when CodeView had a
+  // prior commit to lay itself out in before this scroll, and false the one
+  // time tourMounted just flipped true THIS render (CodeView mounts and this
+  // effect fires in the same commit, before the browser has laid out the
+  // fresh container). CodeView.scrollTo silently no-ops if it can't resolve a
   // destination against an unmeasured layout, so that one case gets a rAF to
   // let layout settle first; every other scroll (rail/j-k on an
   // already-mounted tour) stays perfectly synchronous, unchanged from before.
   useEffect(() => {
-    const wasSettled = wasSettledRef.current;
-    wasSettledRef.current = allSettled;
+    const wasMounted = wasMountedRef.current;
+    wasMountedRef.current = tourMounted;
     const hasRequest = (scrollNonce ?? 0) > 0;
-    if (!hasRequest || !allSettled) return;
+    if (!hasRequest || !tourMounted) return;
     const handle = handleRef.current;
     if (!handle) return;
     userTookOverRef.current = true;
@@ -1036,7 +1175,7 @@ export function PresentTour({
         containerRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
       }
     };
-    if (!wasSettled) {
+    if (!wasMounted) {
       const raf = requestAnimationFrame(performScroll);
       return () => cancelAnimationFrame(raf);
     }
@@ -1044,7 +1183,7 @@ export function PresentTour({
     // scrollNonce intentionally included so repeat clicks on the same path (or
     // repeat clicks on Summary) re-fire.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scrollToPath, scrollNonce, allSettled]);
+  }, [scrollToPath, scrollNonce, tourMounted]);
 
   // N/P annotation hop: first get the target file into view via the same
   // item-scroll CodeView uses for the rail/j-k path above, then locate the
@@ -1059,7 +1198,7 @@ export function PresentTour({
   useEffect(() => {
     if (!scrollToAnnotation) return;
     const hasRequest = (annotationScrollNonce ?? 0) > 0;
-    if (!hasRequest || !allSettled) return;
+    if (!hasRequest || !tourMounted) return;
     const handle = handleRef.current;
     if (!handle) return;
     userTookOverRef.current = true;
@@ -1084,7 +1223,7 @@ export function PresentTour({
     // annotationScrollNonce intentionally included so re-hopping to the same
     // anchor (e.g. a round with a single annotation) still re-scrolls.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scrollToAnnotation, annotationScrollNonce, allSettled]);
+  }, [scrollToAnnotation, annotationScrollNonce, tourMounted]);
 
   // Track the file nearest the top of the viewport so the rail can highlight
   // it. There is no `data-*` attribute on CodeView's rendered item roots to
@@ -1094,7 +1233,7 @@ export function PresentTour({
   // guessed selector.
   const handleScroll = useCallback(
     (_scrollTop: number) => {
-      syncSkipClasses();
+      syncCardClasses();
       if (!onActivePathChange || !containerRef.current) return;
       // Mount/cold-window-pin scroll noise never reports — passive tracking
       // only starts once the user has taken over with a real gesture (see the
@@ -1140,7 +1279,7 @@ export function PresentTour({
       const path = bestPath ?? nearestPath;
       if (path) onActivePathChange(path);
     },
-    [onActivePathChange, syncSkipClasses]
+    [onActivePathChange, syncCardClasses]
   );
 
   return (
@@ -1178,10 +1317,8 @@ export function PresentTour({
         </div>
       )}
 
-      {!allSettled ? (
+      {!tourMounted ? (
         <div className="present-tour-loading">Loading tour…</div>
-      ) : items.length === 0 ? (
-        <div className="present-tour-loading">No files in this round.</div>
       ) : (
         <CodeView<AnnotationMeta>
           ref={handleRef}

--- a/app/src/components/PresentTour/index.tsx
+++ b/app/src/components/PresentTour/index.tsx
@@ -501,6 +501,32 @@ export function PresentTour({
   // CodeView to actually be in the DOM, not for its content to be final.
   const tourMounted = files.length > 0;
 
+  // Distinct from tourMounted: true once every file's item has actually been
+  // admitted into its final, real-content form — not merely once its diff
+  // fetch resolved (`!f.diff.loading`), since a settled-but-not-yet-admitted
+  // file still renders as the zero-hunk pending placeholder (see the items
+  // memo and the admission effect below). A rail/j-k scroll issued while
+  // files are still placeholders can land short or no-op entirely —
+  // placeholder cards are zero-hunk, so the manifest may not even overflow
+  // the viewport yet — and nothing re-scrolls as the real content grows in
+  // above the target. The scroll-replay effect below re-fires once this
+  // flips true so a pending request still resolves to the right place once
+  // the tour has its final layout, matching the pre-progressive-load
+  // behavior for this one case without holding CodeView's mount hostage to
+  // it. An errored file needs no admission (see the items memo's error
+  // branch), so it counts as settled as soon as it's no longer loading.
+  const allSettled =
+    files.length > 0 &&
+    files.every((f) => {
+      if (f.diff.loading) return false;
+      // Mirrors the items memo's error-branch predicate: a file with no
+      // error but also no content is the anomalous "settled with nothing to
+      // show" case, rendered the same way as a genuine error — settled
+      // immediately, no admission needed.
+      const isErrorCard = Boolean(f.diff.error) || f.diff.original === undefined || f.diff.modified === undefined;
+      return isErrorCard || readyPaths.has(f.path);
+    });
+
   // Frame-budgeted parse admission: the primary site where a newly-settled
   // file's diff actually gets parsed (the items memo's own parse fallback
   // below only covers the rarer case of a ready file's content changing).
@@ -1181,9 +1207,11 @@ export function PresentTour({
     }
     performScroll();
     // scrollNonce intentionally included so repeat clicks on the same path (or
-    // repeat clicks on Summary) re-fire.
+    // repeat clicks on Summary) re-fire. `allSettled` is intentionally
+    // included too: it's what re-fires the same still-pending request once
+    // the tour's final layout is in — see the comment above tourMounted.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scrollToPath, scrollNonce, tourMounted]);
+  }, [scrollToPath, scrollNonce, tourMounted, allSettled]);
 
   // N/P annotation hop: first get the target file into view via the same
   // item-scroll CodeView uses for the rail/j-k path above, then locate the


### PR DESCRIPTION
## Problem

On large changesets the Present window showed "Loading tour…" for several seconds before rendering anything. Two causes, both frontend:

1. **All-settled barrier** — the tour refused to build its CodeView items until *every* file's diff fetch had settled.
2. **Parse-all pass** — once settled, one synchronous memo pass ran `parseDiffFromFile` over every file, stalling the main thread.

The daemon side is fine (per-file fetches already run concurrently); the delay was purely render gating + a monolithic parse.

## Fix

- **CodeView mounts as soon as the manifest has files.** Each not-yet-ready file renders as a zero-hunk placeholder card (same item id and type, so the later swap is an in-place `version` bump — never a teardown/remount).
- **Frame-budgeted admission**: settled files are parsed ~8 ms per animation frame (always ≥1 per frame) and swapped in progressively, so the first files are readable immediately while the rest stream in.
- Error cards render immediately without waiting for admission. Pending cards get a subtle opacity pulse (reduced-motion respected). Pending files are excluded from header notes so CodeView's analytic header-height math stays correct.
- Effects that previously gated on "all diffs settled" (scroll pin, j/k scrollTo, annotation hop, card-class sync) now gate on the tour being mounted.
- Round reloads reuse the content-keyed parse cache — identical re-settled content is never re-parsed.

## Testing

- 6 new regression tests (placeholder-before-settle, single-file in-place swap with identity assertions on untouched placeholders, exactly-one-parse-per-file across a 12-file batch, placeholder identity stability under unrelated prop changes, immediate error cards, round-reload parse-cache reuse). PresentTour suite 33/33.
- Full frontend suite: 1477/1477 (148 files); `tsc --noEmit` clean.
- **Live-app verification** on a throwaway profile (`presprog`) against a 62k-line synthetic fixture (28-file diff, 2.5k-line modules): window content fully rendered at t0 (previously several seconds of blank "Loading tour…"), 14 rapid `j` presses from cold open all processed correctly, comment-form typing echoed a full sentence instantly. Profile cleaned up after.

## Future work (out of scope)

- @pierre/diffs ships a worker pool for off-main-thread Shiki highlighting, but nothing mounts its `WorkerPoolContextProvider` — a possible next lever if highlighting cost ever shows up.

https://claude.ai/code/session_01LrwfEhDc8tfoGykC6961gW