### PR TITLE
feat(wsctl): profile-aware daemon targeting and app-visible sessions

### DIFF
--- a/internal/daemon/workspace_session_protocol_test.go
+++ b/internal/daemon/workspace_session_protocol_test.go
@@ -77,6 +77,140 @@ func TestWorkspaceSessionProtocolLifecycleMatchesAppOrder(t *testing.T) {
 	}
 }
 
+// Bare spawn_session (no pre-created pane — wsctl, scripts) must still yield a
+// rendered session: the daemon ensures a layout pane on the spawn success path.
+func TestWorkspaceSessionProtocolBareSpawnEnsuresLayoutPane(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &fakeSpawnBackend{}
+	client := newWorkspaceProtocolTestClient()
+	workspaceID := "workspace-bare-spawn"
+	sessionID := "session-bare-spawn"
+	cwd := t.TempDir()
+
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        workspaceID,
+		Title:     "Bare Spawn",
+		Directory: cwd,
+	})
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:         protocol.CmdSpawnSession,
+		ID:          sessionID,
+		Label:       protocol.Ptr("bare shell"),
+		Cwd:         cwd,
+		Agent:       protocol.AgentShellValue,
+		WorkspaceID: workspaceID,
+		Cols:        80,
+		Rows:        24,
+	})
+	expectSpawnResult(t, client, sessionID, true)
+
+	gotWorkspaceID, paneID, ok := d.store.FindWorkspaceLayoutPaneBySessionID(sessionID)
+	if !ok {
+		t.Fatalf("bare spawn did not create a workspace layout pane for %s", sessionID)
+	}
+	if gotWorkspaceID != workspaceID {
+		t.Fatalf("ensured pane workspace = %q, want %q", gotWorkspaceID, workspaceID)
+	}
+	expectPaneStatus(t, d, workspaceID, paneID, workspacelayout.PaneStatusReady, "")
+
+	snapshot := d.store.GetWorkspaceLayout(workspaceID)
+	if len(snapshot.Panes) != 1 {
+		t.Fatalf("panes = %+v, want exactly the ensured pane", snapshot.Panes)
+	}
+	if snapshot.Panes[0].Title != "bare shell" {
+		t.Fatalf("ensured pane title = %q, want the session label", snapshot.Panes[0].Title)
+	}
+}
+
+// A bare spawn (no pre-created pane) that fails must not leave a ghost pane
+// behind: ensureWorkspaceSessionPane only runs on the spawn success path, so a
+// rejected/timed-out spawn has nothing to roll back.
+func TestWorkspaceSessionProtocolBareSpawnFailureCreatesNoPane(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &failingSpawnBackend{err: errors.New("boom")}
+	client := newWorkspaceProtocolTestClient()
+	workspaceID := "workspace-bare-spawn-fails"
+	sessionID := "session-bare-spawn-fails"
+	cwd := t.TempDir()
+
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        workspaceID,
+		Title:     "Bare Spawn Fails",
+		Directory: cwd,
+	})
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:         protocol.CmdSpawnSession,
+		ID:          sessionID,
+		Label:       protocol.Ptr("bare shell"),
+		Cwd:         cwd,
+		Agent:       protocol.AgentShellValue,
+		WorkspaceID: workspaceID,
+		Cols:        80,
+		Rows:        24,
+	})
+	expectSpawnResult(t, client, sessionID, false)
+
+	if session := d.store.Get(sessionID); session != nil {
+		t.Fatalf("failed bare spawn registered session %s", sessionID)
+	}
+	if _, _, ok := d.store.FindWorkspaceLayoutPaneBySessionID(sessionID); ok {
+		t.Fatalf("failed bare spawn left a ghost pane for session %s", sessionID)
+	}
+	if snapshot := d.store.GetWorkspaceLayout(workspaceID); snapshot != nil && len(snapshot.Panes) != 0 {
+		t.Fatalf("workspace layout has panes after failed bare spawn: %+v", snapshot.Panes)
+	}
+}
+
+// The app pre-creates the pane before spawning; the spawn-time ensure must adopt
+// that pane instead of splitting a duplicate next to it.
+func TestWorkspaceSessionProtocolSpawnAdoptsPreCreatedPane(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.ptyBackend = &fakeSpawnBackend{}
+	client := newWorkspaceProtocolTestClient()
+	workspaceID := "workspace-adopt"
+	sessionID := "session-adopt"
+	paneID := "pane-session-adopt"
+	cwd := t.TempDir()
+
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        workspaceID,
+		Title:     "Adopt",
+		Directory: cwd,
+	})
+	d.handleWorkspaceLayoutAddSessionPane(client, &protocol.WorkspaceLayoutAddSessionPaneMessage{
+		Cmd:         protocol.CmdWorkspaceLayoutAddSessionPane,
+		WorkspaceID: workspaceID,
+		PaneID:      protocol.Ptr(paneID),
+		SessionID:   sessionID,
+		Title:       protocol.Ptr("custom title"),
+	})
+	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutAddSessionPane, workspaceID, paneID, true)
+
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:         protocol.CmdSpawnSession,
+		ID:          sessionID,
+		Label:       protocol.Ptr("different label"),
+		Cwd:         cwd,
+		Agent:       protocol.AgentShellValue,
+		WorkspaceID: workspaceID,
+		Cols:        80,
+		Rows:        24,
+	})
+	expectSpawnResult(t, client, sessionID, true)
+
+	snapshot := d.store.GetWorkspaceLayout(workspaceID)
+	if len(snapshot.Panes) != 1 {
+		t.Fatalf("panes = %+v, want the single pre-created pane adopted", snapshot.Panes)
+	}
+	if snapshot.Panes[0].PaneID != paneID || snapshot.Panes[0].Title != "custom title" {
+		t.Fatalf("adopted pane = %+v, want id %q with its original title", snapshot.Panes[0], paneID)
+	}
+	expectPaneStatus(t, d, workspaceID, paneID, workspacelayout.PaneStatusReady, "")
+}
+
 func TestWorkspaceLayoutAddSessionPaneCorrelatesSetupFailure(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	client := newWorkspaceProtocolTestClient()

--- a/internal/daemon/workspacelayout.go
+++ b/internal/daemon/workspacelayout.go
@@ -1037,21 +1037,29 @@ func (d *Daemon) recomputeAndBroadcastWorkspace(workspaceID string) {
 }
 
 func (d *Daemon) handleWorkspaceLayoutAddSessionPane(client *wsClient, msg *protocol.WorkspaceLayoutAddSessionPaneMessage) {
+	paneID, err := d.addWorkspaceSessionPane(msg)
+	d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, paneID, err)
+}
+
+// addWorkspaceSessionPane adds (or adopts) a layout pane for a session. It is the
+// single mechanism behind both the explicit workspace_layout_add_session_pane
+// command and the spawn-time pane guarantee (ensureWorkspaceSessionPane), so a
+// session can never exist in a workspace without a pane the app can render.
+// Idempotent per session: if the session already owns a pane, that pane is
+// returned unchanged.
+func (d *Daemon) addWorkspaceSessionPane(msg *protocol.WorkspaceLayoutAddSessionPaneMessage) (*string, error) {
 	snapshot, err := d.currentOrEmptyWorkspaceLayout(msg.WorkspaceID)
 	if err != nil {
-		d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, msg.PaneID, err)
-		return
+		return msg.PaneID, err
 	}
 
 	sessionID := strings.TrimSpace(msg.SessionID)
 	if sessionID == "" {
-		d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, nil, fmt.Errorf("session_id is required"))
-		return
+		return nil, fmt.Errorf("session_id is required")
 	}
 	for _, pane := range snapshot.Panes {
 		if pane.SessionID == sessionID {
-			d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, protocol.Ptr(pane.PaneID), nil)
-			return
+			return protocol.Ptr(pane.PaneID), nil
 		}
 	}
 
@@ -1061,17 +1069,14 @@ func (d *Daemon) handleWorkspaceLayoutAddSessionPane(client *wsClient, msg *prot
 	}
 	for _, pane := range snapshot.Panes {
 		if pane.PaneID == paneID {
-			d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, protocol.Ptr(paneID), fmt.Errorf("pane already exists: %s", paneID))
-			return
+			return protocol.Ptr(paneID), fmt.Errorf("pane already exists: %s", paneID)
 		}
 	}
 	if workspacelayout.HasPane(snapshot.Layout, paneID) {
-		d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, protocol.Ptr(paneID), fmt.Errorf("pane already exists: %s", paneID))
-		return
+		return protocol.Ptr(paneID), fmt.Errorf("pane already exists: %s", paneID)
 	}
 	if workspacelayout.HasTile(snapshot.Layout, paneID) {
-		d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, protocol.Ptr(paneID), fmt.Errorf("tile already exists: %s", paneID))
-		return
+		return protocol.Ptr(paneID), fmt.Errorf("tile already exists: %s", paneID)
 	}
 	title := strings.TrimSpace(protocol.Deref(msg.Title))
 	if title == "" {
@@ -1089,8 +1094,7 @@ func (d *Daemon) handleWorkspaceLayoutAddSessionPane(client *wsClient, msg *prot
 	targetPaneID := strings.TrimSpace(protocol.Deref(msg.TargetPaneID))
 	if len(snapshot.Panes) == 0 || snapshot.Layout.Type == "" {
 		if targetPaneID != "" {
-			d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, protocol.Ptr(targetPaneID), fmt.Errorf("cannot target pane in empty layout"))
-			return
+			return protocol.Ptr(targetPaneID), fmt.Errorf("cannot target pane in empty layout")
 		}
 		snapshot.Layout = workspacelayout.DefaultLayout(paneID)
 	} else {
@@ -1101,8 +1105,7 @@ func (d *Daemon) handleWorkspaceLayoutAddSessionPane(client *wsClient, msg *prot
 			targetPaneID = firstWorkspaceLayoutPaneID(*snapshot)
 		}
 		if targetPaneID == "" {
-			d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, nil, fmt.Errorf("workspace has no target pane"))
-			return
+			return nil, fmt.Errorf("workspace has no target pane")
 		}
 		layout, changed := workspacelayout.Split(
 			snapshot.Layout,
@@ -1113,8 +1116,7 @@ func (d *Daemon) handleWorkspaceLayoutAddSessionPane(client *wsClient, msg *prot
 			workspacelayout.DefaultSplitRatio,
 		)
 		if !changed {
-			d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, protocol.Ptr(targetPaneID), fmt.Errorf("pane not found: %s", targetPaneID))
-			return
+			return protocol.Ptr(targetPaneID), fmt.Errorf("pane not found: %s", targetPaneID)
 		}
 		snapshot.Layout = layout
 	}
@@ -1123,11 +1125,28 @@ func (d *Daemon) handleWorkspaceLayoutAddSessionPane(client *wsClient, msg *prot
 	snapshot.Panes = append(snapshot.Panes, nextPane)
 	normalized := workspacelayout.NormalizeWorkspaceLayout(*snapshot)
 	if err := d.store.SaveWorkspaceLayout(normalized); err != nil {
-		d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, protocol.Ptr(paneID), err)
-		return
+		return protocol.Ptr(paneID), err
 	}
 	d.broadcastWorkspaceLayoutUpdated(msg.WorkspaceID)
-	d.sendWorkspaceLayoutActionResult(client, protocol.CmdWorkspaceLayoutAddSessionPane, msg.WorkspaceID, protocol.Ptr(paneID), nil)
+	return protocol.Ptr(paneID), nil
+}
+
+// ensureWorkspaceSessionPane guarantees a workspace layout pane exists for a
+// freshly spawned session. Clients that pre-create a pane (the app's optimistic
+// UI, delegate, ticket resume) hit the adopt path; bare spawn_session callers
+// (wsctl, scripts) get a pane with default placement so the session always
+// renders in the app.
+func (d *Daemon) ensureWorkspaceSessionPane(workspaceID, sessionID, title string) (string, error) {
+	msg := &protocol.WorkspaceLayoutAddSessionPaneMessage{
+		Cmd:         protocol.CmdWorkspaceLayoutAddSessionPane,
+		WorkspaceID: workspaceID,
+		SessionID:   sessionID,
+	}
+	if strings.TrimSpace(title) != "" {
+		msg.Title = protocol.Ptr(title)
+	}
+	paneID, err := d.addWorkspaceSessionPane(msg)
+	return protocol.Deref(paneID), err
 }
 
 func (d *Daemon) handleWorkspaceLayoutClosePane(client *wsClient, msg *protocol.WorkspaceLayoutClosePaneMessage) {

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -763,6 +763,15 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		}
 		d.store.UpsertRecentLocation(cwd)
 		d.associateSessionWithWorkspace(session.ID, workspaceID)
+		// Single mechanism: spawn_session guarantees the session has a layout
+		// pane. Clients that pre-created one (app, delegate, ticket resume) hit
+		// the adopt path; bare spawns (wsctl, scripts) get default placement.
+		// A pane failure must not fail the spawn — the session is already live.
+		if workspaceID != "" {
+			if _, err := d.ensureWorkspaceSessionPane(workspaceID, session.ID, session.Label); err != nil {
+				d.logf("ensure workspace pane for session %s: %v", session.ID, err)
+			}
+		}
 		d.setWorkspacePaneStatusForSession(session.ID, workspacelayout.PaneStatusReady, "")
 		eventType := protocol.EventSessionRegistered
 		if existingSession != nil {

--- a/scripts/wsctl/main.go
+++ b/scripts/wsctl/main.go
@@ -18,7 +18,7 @@
 //
 //	go run ./scripts/wsctl add-workspace --title T --dir D [--id I]
 //	go run ./scripts/wsctl rm-workspace --id I
-//	go run ./scripts/wsctl add-session --workspace W --cwd D [--agent claude] [--label L] [--initial-prompt-file P] [--yolo] [--id I] [--cols 80] [--rows 24] [--no-pane]
+//	go run ./scripts/wsctl add-session --workspace W --cwd D [--agent claude] [--label L] [--initial-prompt-file P] [--yolo] [--id I] [--cols 80] [--rows 24]
 //	go run ./scripts/wsctl rm-session --id I
 //	go run ./scripts/wsctl kill-session --id I [--reload]
 //	go run ./scripts/wsctl screen --id I
@@ -95,7 +95,7 @@ URL: %s (ATTN_WS_URL > ATTN_PROFILE-derived port > dev; prod needs an explicit A
 Commands:
   add-workspace --title T --dir D [--id I]
   rm-workspace --id I
-  add-session --workspace W --cwd D [--agent claude] [--label L] [--initial-prompt-file P] [--yolo] [--id I] [--cols 80] [--rows 24] [--no-pane]
+  add-session --workspace W --cwd D [--agent claude] [--label L] [--initial-prompt-file P] [--yolo] [--id I] [--cols 80] [--rows 24]
   rm-session --id I
   kill-session --id I [--reload]
   screen --id I
@@ -185,7 +185,6 @@ func addSession(args []string) error {
 	id := fs.String("id", "", "session id (defaults to a generated one)")
 	cols := fs.Int("cols", 80, "initial PTY cols")
 	rows := fs.Int("rows", 24, "initial PTY rows")
-	noPane := fs.Bool("no-pane", false, "skip the workspace layout pane (session will not render in the app)")
 	fs.Parse(args)
 
 	if *workspace == "" || *cwd == "" {
@@ -203,31 +202,9 @@ func addSession(args []string) error {
 		sessID = newUUID()
 	}
 
-	// The app only renders sessions that own a workspace layout pane; the
-	// normal app flow persists the pane BEFORE spawn_session (which then
-	// flips it to ready). Mirror that order here, or the session exists in
-	// the daemon but the workspace shows a blank main area.
-	if !*noPane {
-		paneResp, err := sendAndWaitMatch(map[string]any{
-			"cmd":          "workspace_layout_add_session_pane",
-			"workspace_id": *workspace,
-			"session_id":   sessID,
-		}, "workspace_layout_action_result", func(ev map[string]any) bool {
-			action, _ := ev["action"].(string)
-			wsID, _ := ev["workspace_id"].(string)
-			return action == "workspace_layout_add_session_pane" && wsID == *workspace
-		}, 10*time.Second)
-		if err != nil {
-			return fmt.Errorf("add layout pane: %w", err)
-		}
-		if success, _ := paneResp["success"].(bool); !success {
-			errMsg, _ := paneResp["error"].(string)
-			return fmt.Errorf("daemon rejected layout pane: %s", errMsg)
-		}
-		paneID, _ := paneResp["pane_id"].(string)
-		fmt.Printf("layout pane created: pane_id=%s\n", paneID)
-	}
-
+	// The daemon guarantees a workspace layout pane for every spawned session
+	// (spawn_session ensures one, adopting a pre-created pane when present),
+	// so a bare spawn is all a script needs for the session to render.
 	msg := map[string]any{
 		"cmd":          "spawn_session",
 		"id":           sessID,
@@ -254,7 +231,9 @@ func addSession(args []string) error {
 	// Spawn replies with a SpawnResult — wait briefly for it so we
 	// can surface failures (bad cwd, unknown agent, etc.) instead of
 	// printing "ok" and leaving the user to wonder why nothing
-	// appeared.
+	// appeared. The pane only exists once spawn succeeds (the daemon
+	// ensures it on the success path), so a failure here leaves nothing
+	// to roll back.
 	resp, err := sendAndWait(msg, "spawn_result", sessID, 30*time.Second)
 	if err != nil {
 		return err

--- a/scripts/wsctl/main.go
+++ b/scripts/wsctl/main.go
@@ -4,14 +4,21 @@
 // canvas spike (attn-spike5) has no way to create the workspaces or
 // workspace-bound sessions it consumes. This script fills that gap.
 //
-// Defaults to the dev daemon (ws://localhost:29849/ws). Override with
-// ATTN_WS_URL.
+// Target daemon resolution, in priority order:
+//
+//  1. ATTN_WS_URL — explicit URL, used verbatim (the only way to reach prod).
+//  2. ATTN_PROFILE — the profile's derived WS port (same resolution as every
+//     other attn entrypoint).
+//  3. Fallback: the dev daemon (ws://localhost:29849/ws). wsctl never targets
+//     prod implicitly.
+//
+// The resolved target is printed to stderr on every invocation.
 //
 // Usage:
 //
 //	go run ./scripts/wsctl add-workspace --title T --dir D [--id I]
 //	go run ./scripts/wsctl rm-workspace --id I
-//	go run ./scripts/wsctl add-session --workspace W --cwd D [--agent claude] [--label L] [--initial-prompt-file P] [--yolo] [--id I] [--cols 80] [--rows 24]
+//	go run ./scripts/wsctl add-session --workspace W --cwd D [--agent claude] [--label L] [--initial-prompt-file P] [--yolo] [--id I] [--cols 80] [--rows 24] [--no-pane]
 //	go run ./scripts/wsctl rm-session --id I
 //	go run ./scripts/wsctl kill-session --id I [--reload]
 //	go run ./scripts/wsctl screen --id I
@@ -29,8 +36,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
 	"nhooyr.io/websocket"
 )
@@ -44,6 +53,7 @@ func main() {
 	}
 	cmd := os.Args[1]
 	args := os.Args[2:]
+	fmt.Fprintf(os.Stderr, "[wsctl → %s]\n", wsURL())
 
 	var err error
 	switch cmd {
@@ -80,12 +90,12 @@ func main() {
 func usage() {
 	fmt.Fprintf(os.Stderr, `wsctl — dev helper for driving the attn daemon over WebSocket.
 
-URL: %s (override with ATTN_WS_URL)
+URL: %s (ATTN_WS_URL > ATTN_PROFILE-derived port > dev; prod needs an explicit ATTN_WS_URL)
 
 Commands:
   add-workspace --title T --dir D [--id I]
   rm-workspace --id I
-  add-session --workspace W --cwd D [--agent claude] [--label L] [--initial-prompt-file P] [--yolo] [--id I] [--cols 80] [--rows 24]
+  add-session --workspace W --cwd D [--agent claude] [--label L] [--initial-prompt-file P] [--yolo] [--id I] [--cols 80] [--rows 24] [--no-pane]
   rm-session --id I
   kill-session --id I [--reload]
   screen --id I
@@ -95,8 +105,20 @@ Commands:
 }
 
 func wsURL() string {
-	if u := os.Getenv("ATTN_WS_URL"); u != "" {
+	return resolveWSURL(os.Getenv("ATTN_WS_URL"), os.Getenv("ATTN_PROFILE"))
+}
+
+// resolveWSURL picks the daemon to talk to. An explicit ATTN_WS_URL always
+// wins (and is the only way to target prod). Otherwise a named ATTN_PROFILE
+// resolves to that profile's derived WS port, and with no profile at all we
+// fall back to the dev daemon — never prod.
+func resolveWSURL(explicitURL, profile string) string {
+	if u := strings.TrimSpace(explicitURL); u != "" {
 		return u
+	}
+	p := strings.ToLower(strings.TrimSpace(profile))
+	if p != "" && p != "default" {
+		return "ws://localhost:" + config.WSPortForProfile(p) + "/ws"
 	}
 	return defaultWSURL
 }
@@ -163,6 +185,7 @@ func addSession(args []string) error {
 	id := fs.String("id", "", "session id (defaults to a generated one)")
 	cols := fs.Int("cols", 80, "initial PTY cols")
 	rows := fs.Int("rows", 24, "initial PTY rows")
+	noPane := fs.Bool("no-pane", false, "skip the workspace layout pane (session will not render in the app)")
 	fs.Parse(args)
 
 	if *workspace == "" || *cwd == "" {
@@ -178,6 +201,31 @@ func addSession(args []string) error {
 		// ids — the agent CLI uses them directly as its own session
 		// identifier, which must be UUID-shaped.
 		sessID = newUUID()
+	}
+
+	// The app only renders sessions that own a workspace layout pane; the
+	// normal app flow persists the pane BEFORE spawn_session (which then
+	// flips it to ready). Mirror that order here, or the session exists in
+	// the daemon but the workspace shows a blank main area.
+	if !*noPane {
+		paneResp, err := sendAndWaitMatch(map[string]any{
+			"cmd":          "workspace_layout_add_session_pane",
+			"workspace_id": *workspace,
+			"session_id":   sessID,
+		}, "workspace_layout_action_result", func(ev map[string]any) bool {
+			action, _ := ev["action"].(string)
+			wsID, _ := ev["workspace_id"].(string)
+			return action == "workspace_layout_add_session_pane" && wsID == *workspace
+		}, 10*time.Second)
+		if err != nil {
+			return fmt.Errorf("add layout pane: %w", err)
+		}
+		if success, _ := paneResp["success"].(bool); !success {
+			errMsg, _ := paneResp["error"].(string)
+			return fmt.Errorf("daemon rejected layout pane: %s", errMsg)
+		}
+		paneID, _ := paneResp["pane_id"].(string)
+		fmt.Printf("layout pane created: pane_id=%s\n", paneID)
 	}
 
 	msg := map[string]any{
@@ -398,6 +446,19 @@ func send(payload map[string]any) error {
 // event of the given type (filtered by id when provided) or the
 // timeout elapses. Other frames are silently dropped.
 func sendAndWait(payload map[string]any, expectedEvent, expectedID string, timeout time.Duration) (map[string]any, error) {
+	return sendAndWaitMatch(payload, expectedEvent, func(ev map[string]any) bool {
+		if expectedID == "" {
+			return true
+		}
+		id, _ := ev["id"].(string)
+		return id == expectedID
+	}, timeout)
+}
+
+// sendAndWaitMatch is sendAndWait with an arbitrary predicate over events of
+// the expected type, for results that carry no top-level "id" field (e.g.
+// workspace_layout_action_result).
+func sendAndWaitMatch(payload map[string]any, expectedEvent string, match func(map[string]any) bool, timeout time.Duration) (map[string]any, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+3*time.Second)
 	defer cancel()
 	conn, _, err := websocket.Dial(ctx, wsURL(), nil)
@@ -445,13 +506,8 @@ func sendAndWait(payload map[string]any, expectedEvent, expectedID string, timeo
 			}
 			fmt.Fprintf(os.Stderr, "<- %s\n", snippet)
 		}
-		if event["event"] == expectedEvent {
-			if expectedID == "" {
-				return event, nil
-			}
-			if id, _ := event["id"].(string); id == expectedID {
-				return event, nil
-			}
+		if event["event"] == expectedEvent && match(event) {
+			return event, nil
 		}
 	}
 }

--- a/scripts/wsctl/main_test.go
+++ b/scripts/wsctl/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/victorarias/attn/internal/config"
+)
+
+func TestResolveWSURL(t *testing.T) {
+	cases := []struct {
+		name        string
+		explicitURL string
+		profile     string
+		want        string
+	}{
+		{"explicit URL wins over profile", "ws://localhost:9849/ws", "mdclick1", "ws://localhost:9849/ws"},
+		{"no env falls back to dev", "", "", defaultWSURL},
+		{"blank profile falls back to dev", "", "   ", defaultWSURL},
+		{"default profile falls back to dev, never prod", "", "default", defaultWSURL},
+		{"dev profile resolves to dev port", "", "dev", "ws://localhost:29849/ws"},
+		{"named profile resolves to its derived port", "", "mdclick1", "ws://localhost:" + config.WSPortForProfile("mdclick1") + "/ws"},
+		{"profile name is case-insensitive", "", "MDCLICK1", "ws://localhost:" + config.WSPortForProfile("mdclick1") + "/ws"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveWSURL(tc.explicitURL, tc.profile); got != tc.want {
+				t.Fatalf("resolveWSURL(%q, %q) = %q, want %q", tc.explicitURL, tc.profile, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveWSURLNeverImplicitProd(t *testing.T) {
+	prod := "ws://localhost:" + config.WSPortForProfile("") + "/ws"
+	for _, profile := range []string{"", "default", "DEFAULT", " ", "dev", "mdclick1"} {
+		if got := resolveWSURL("", profile); got == prod {
+			t.Fatalf("resolveWSURL(\"\", %q) resolved to prod %q; prod must require an explicit ATTN_WS_URL", profile, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `scripts/wsctl` previously hardcoded the dev daemon `ws://localhost:29849/ws` unless `ATTN_WS_URL` was set, which silently sent commands to the wrong daemon when working on a named `ATTN_PROFILE`.
- It now resolves the target daemon in this order: `ATTN_WS_URL` explicit override > `ATTN_PROFILE`-derived port (`config.WSPortForProfile`) > dev fallback. The resolved target is printed to stderr on every invocation. wsctl never targets prod implicitly — prod requires an explicit `ATTN_WS_URL`.
- `add-session` previously created a workspace layout pane client-side before calling `spawn_session`, so wsctl-spawned sessions render in the app instead of leaving a blank main area. Per review feedback, that guarantee now lives in the daemon: `spawn_session` ensures a session's layout pane on its success path (adopting a pre-created pane when the app or another flow already made one, otherwise creating one with default placement). A failed or timed-out spawn therefore has nothing to roll back — there's no window where a pane can outlive a spawn that never succeeded. This is a single mechanism shared by the app's own pre-create flow and bare spawns (wsctl, scripts), and it made the `--no-pane` flag meaningless, so it was removed.
- Unit tests cover the URL resolution logic (including a "never implicit prod" guard) and the pane-guarantee behavior, including a regression test asserting a failed bare spawn leaves no ghost pane.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./scripts/wsctl`
- [x] `go test ./scripts/wsctl/... ./internal/daemon/...`
- [x] Live-verified against a throwaway profile (`mdclick1`): the profile-derived banner `[wsctl → ws://localhost:25696/ws]` printed correctly, and `add-workspace` + `add-session --agent shell` rendered a live shell pane in `attn-mdclick1.app` with streaming output.

https://claude.ai/code/session_01TkqDvJnLVPJCU5udzSdcdP