### PR TITLE
feat(plugin): accept newer OpenCode releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   approval prompt, nothing is sent and your annotations are kept so you can retry.
 
 ### Changed
+- **OpenCode upgrades no longer require an attn plugin update.** The plugin now
+  accepts stable OpenCode releases at or above 1.17.16 and can resume existing
+  sessions after a forward upgrade. Older, preview, and downgrade versions are
+  still rejected, while a newer incompatible server reports the concrete API
+  failure through plugin health.
 - **Markdown tiles now render documents on a proper reading surface.** Files open on a centered card with book-quality typography, syntax-highlighted code blocks with a hover copy button, clickable heading anchors that scroll smoothly within the tile, and a metadata card for YAML frontmatter. Dangerous links (`javascript:`, `data:`) render as plain text instead of being clickable.
 - **Markdown tiles got the full GitHub-flavored polish.** `[!NOTE]`/`[!TIP]`/`[!IMPORTANT]`/`[!WARNING]`/`[!CAUTION]` callouts render as tinted alert blocks with icons, task lists show real checkboxes, wide tables scroll in place with header and hover tinting, and images referenced by relative paths load inline — click one for a full-screen lightbox (Escape or click-out to close). Prose gets smart quotes, dashes, and `:emoji:` shortcodes (command-line `--flags` are left alone), inline HTML like collapsible `<details>` blocks renders safely, and live reload no longer re-renders a document whose content hasn't changed.
 

--- a/docs/plans/2026-07-15-opencode-minimum-version.md
+++ b/docs/plans/2026-07-15-opencode-minimum-version.md
@@ -1,0 +1,48 @@
+# Plan: Use a minimum OpenCode version
+
+## Why / Alignment
+
+OpenCode upgrades should not require an attn release merely because a stable
+version is absent from an exact allowlist. This chunk replaces the allowlist
+with a stable `>= 1.17.16` policy while retaining exact server identity for each
+run and preventing resume downgrades.
+
+We are aligned on the existing canonical design: newer stable releases are
+attempted against the real server contract, prerelease and malformed versions
+remain unsupported, and concrete endpoint failures surface through degraded
+plugin health. The other OpenCode roadmap plans are deferred to their own PRs.
+
+## Runtime Map
+
+```text
+opencode --version
+  -> stable semver parser
+    -> older than 1.17.16 / invalid / prerelease: unhealthy, no driver
+    -> 1.17.16 or newer: register driver
+
+resume
+  -> current version must be at least the persisted version
+  -> launched server must exactly match this run's current version
+  -> verify native identity and persisted pins
+```
+
+## Implementation Steps
+
+- [x] Replace the exact allowlist with strict stable-version parsing and
+  comparison around a `1.17.16` minimum.
+- [x] Distinguish unsupported-old and invalid/prerelease availability failures.
+- [x] Preserve exact health-version equality for each launched run.
+- [x] Allow same-version and forward-version resume while rejecting downgrade.
+- [x] Persist the current version on a successfully upgraded run.
+- [x] Update compatibility documentation and the changelog.
+- [x] Complete automated and isolated live-app verification.
+- [ ] Open the PR, address Figgyster's review, and merge after approval.
+
+## Decisions
+
+- Stable releases have no maximum version; runtime APIs remain the contract
+  probe.
+- An optional leading `v` is normalized, but prerelease/build suffixes and
+  non-canonical numeric components are rejected.
+- Exact equality remains at the per-run server boundary because it proves the
+  adapter reached the process it launched.

--- a/plugins/attn-opencode/README.md
+++ b/plugins/attn-opencode/README.md
@@ -2,9 +2,11 @@
 
 This installable plugin runs an OpenCode TUI in an attn-owned PTY while the
 plugin uses OpenCode's loopback HTTP/SSE server to create and monitor the
-linked native session. It requires OpenCode `1.17.16` or `1.17.18`; versions
-outside that contract-tested set stay visible as an unhealthy plugin and do not
-register the `opencode` agent.
+linked native session. It requires a stable OpenCode release at or above
+`1.17.16`; older, malformed, and prerelease versions stay visible as an
+unhealthy plugin and do not register the `opencode` agent. Newer stable releases
+are attempted against the server contract and surface the specific failing API
+through degraded health if that contract has changed.
 
 Install it into a non-production attn profile while developing:
 

--- a/plugins/attn-opencode/src/driver.ts
+++ b/plugins/attn-opencode/src/driver.ts
@@ -11,7 +11,9 @@ import {
   type Report,
   type RunRecord,
   type SessionClosedParams,
-  supportedOpenCodeVersions,
+  compareVersion,
+  evaluateOpenCodeVersion,
+  minimumOpenCodeVersion,
 } from "./types";
 
 const startupDeadlineMs = 20_000;
@@ -206,8 +208,10 @@ export class OpenCodeDriver {
     }
     const metadata = parseMetadata(params.metadata);
     const pinned = metadata.pinned ?? Boolean(metadata.model && metadata.variant);
-    if (metadata.opencode_version !== version) {
-      throw new Error(`OpenCode resume requires version ${metadata.opencode_version}, found ${version}`);
+    const previousVersion = requireSupportedVersion(metadata.opencode_version, "persisted OpenCode version");
+    const installedVersion = requireSupportedVersion(version, "installed OpenCode version");
+    if (compareVersion(installedVersion, previousVersion) < 0) {
+      throw new Error(`OpenCode resume would downgrade ${previousVersion.raw} to ${installedVersion.raw}`);
     }
     if (params.model && (!pinned || !metadata.model || params.model !== metadata.model)) {
       throw new Error("OpenCode resume model pin does not match the persisted native session");
@@ -356,8 +360,8 @@ export class OpenCodeDriver {
         const password = await this.options.registry.password(record);
         const client = this.http(record.port, password);
         const health = await this.healthWithin(client, signal, deadline - Date.now());
-        if (health.version !== record.opencode_version || !supportedOpenCodeVersions.has(health.version)) {
-          throw new Error(`OpenCode server version ${health.version} is not the verified ${record.opencode_version}`);
+        if (health.version !== record.opencode_version) {
+          throw new Error(`OpenCode server version ${health.version} does not match this run's expected ${record.opencode_version}`);
         }
         return client;
       } catch (error) {
@@ -574,12 +578,9 @@ export class OpenCodeDriver {
   private async refreshAvailability(): Promise<void> {
     try {
       const result = await this.runCommand([this.executable, "--version"]);
-      const version = result.stdout.trim().replace(/^v/, "");
       if (result.exitCode !== 0) throw new Error(result.stderr.trim() || `exit ${result.exitCode}`);
-      if (!supportedOpenCodeVersions.has(version)) {
-        throw new Error(`version ${version || "(empty)"} is unsupported; verified versions: ${[...supportedOpenCodeVersions].join(", ")}`);
-      }
-      this.availability = { ok: true, executable: this.executable, version };
+      const version = requireSupportedVersion(result.stdout, "OpenCode executable version");
+      this.availability = { ok: true, executable: this.executable, version: version.raw };
     } catch (error) {
       this.availability = { ok: false, message: `OpenCode executable ${this.executable} is unavailable: ${safeError(error)}` };
     }
@@ -628,6 +629,17 @@ function parseMetadata(value: unknown): OpenCodeMetadata {
     throw new Error("OpenCode resume metadata is incomplete");
   }
   return result as OpenCodeMetadata;
+}
+
+function requireSupportedVersion(value: string, label: string) {
+  const compatibility = evaluateOpenCodeVersion(value);
+  if (compatibility.kind === "invalid") {
+    throw new Error(`${label} is invalid: ${compatibility.reason}`);
+  }
+  if (compatibility.kind === "too_old") {
+    throw new Error(`${label} ${compatibility.installed.raw} is unsupported; requires OpenCode >= ${minimumOpenCodeVersion.raw}`);
+  }
+  return compatibility.installed;
 }
 
 function requireText(value: string | undefined, label: string): string {

--- a/plugins/attn-opencode/src/types.ts
+++ b/plugins/attn-opencode/src/types.ts
@@ -1,6 +1,55 @@
 export const pluginAPIVersion = 2;
 
-export const supportedOpenCodeVersions = new Set(["1.17.16", "1.17.18"]);
+export type StableVersion = {
+  raw: string;
+  major: number;
+  minor: number;
+  patch: number;
+};
+
+export type VersionCompatibility =
+  | { kind: "supported"; installed: StableVersion; minimum: StableVersion }
+  | { kind: "too_old"; installed: StableVersion; minimum: StableVersion }
+  | { kind: "invalid"; raw: string; reason: string };
+
+export const minimumOpenCodeVersion = parseStableVersion("1.17.16");
+
+export function parseStableVersion(value: string): StableVersion {
+  const candidate = value.trim();
+  const match = /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(candidate);
+  if (!match) {
+    throw new Error(`expected a stable MAJOR.MINOR.PATCH release, got ${candidate || "(empty)"}`);
+  }
+  const [major, minor, patch] = match.slice(1).map(Number);
+  if (![major, minor, patch].every(Number.isSafeInteger)) {
+    throw new Error(`version components must be safe integers, got ${candidate}`);
+  }
+  return { raw: `${major}.${minor}.${patch}`, major, minor, patch };
+}
+
+export function compareVersion(a: StableVersion, b: StableVersion): -1 | 0 | 1 {
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (a[key] < b[key]) return -1;
+    if (a[key] > b[key]) return 1;
+  }
+  return 0;
+}
+
+export function evaluateOpenCodeVersion(value: string): VersionCompatibility {
+  let installed: StableVersion;
+  try {
+    installed = parseStableVersion(value);
+  } catch (error) {
+    return {
+      kind: "invalid",
+      raw: value,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+  return compareVersion(installed, minimumOpenCodeVersion) < 0
+    ? { kind: "too_old", installed, minimum: minimumOpenCodeVersion }
+    : { kind: "supported", installed, minimum: minimumOpenCodeVersion };
+}
 
 export type DriverCapabilities = Record<string, boolean>;
 

--- a/plugins/attn-opencode/test/driver.test.ts
+++ b/plugins/attn-opencode/test/driver.test.ts
@@ -77,8 +77,14 @@ function driverFor(rpc: RecordingRPC, registry: RunRegistry, target: FakeOpenCod
 }
 
 describe("OpenCode server-backed driver", () => {
-  test("accepts both explicitly contract-tested OpenCode versions", async () => {
-    for (const version of ["1.17.16", "1.17.18"]) {
+  test("accepts the minimum and newer stable OpenCode versions", async () => {
+    for (const [version, normalized] of [
+      ["1.17.16", "1.17.16"],
+      ["v1.17.16", "1.17.16"],
+      ["1.17.18", "1.17.18"],
+      ["1.18.0", "1.18.0"],
+      ["2.0.0", "2.0.0"],
+    ]) {
       const rpc = new RecordingRPC();
       const registry = new RunRegistry(join(await tempRoot(), "runtime"));
       const driver = new OpenCodeDriver({
@@ -87,8 +93,28 @@ describe("OpenCode server-backed driver", () => {
         runCommand: async () => ({ exitCode: 0, stdout: `${version}\n`, stderr: "" }),
       });
       await driver.initialize();
-      expect(driver.health()).toEqual({ ok: true, message: `OpenCode ${version} is ready` });
+      expect(driver.health()).toEqual({ ok: true, message: `OpenCode ${normalized} is ready` });
       expect(rpc.calls[0]?.method).toBe("driver.register");
+    }
+  });
+
+  test("rejects old, malformed, and prerelease OpenCode versions before registering", async () => {
+    for (const [version, message] of [
+      ["1.17.15", "requires OpenCode >= 1.17.16"],
+      ["1.17", "expected a stable MAJOR.MINOR.PATCH release"],
+      ["1.18.0-beta.1", "expected a stable MAJOR.MINOR.PATCH release"],
+    ]) {
+      const rpc = new RecordingRPC();
+      const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+      const driver = new OpenCodeDriver({
+        rpc,
+        registry,
+        runCommand: async () => ({ exitCode: 0, stdout: `${version}\n`, stderr: "" }),
+      });
+      await driver.initialize();
+      expect(driver.health()).toEqual(expect.objectContaining({ ok: false }));
+      expect(driver.health().message).toContain(message);
+      expect(rpc.calls).toHaveLength(0);
     }
   });
 
@@ -422,6 +448,89 @@ describe("OpenCode server-backed driver", () => {
         variant: "low",
       },
     })).rejects.toThrow("effort pin does not match");
+  });
+
+  test("resumes after a forward OpenCode upgrade and records the new run version", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*", "1.18.0");
+    target.sessions.set("native-upgrade", {
+      id: "native-upgrade",
+      model: { providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "low" },
+    });
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = new OpenCodeDriver({
+      rpc,
+      registry,
+      runCommand: async () => ({ exitCode: 0, stdout: "1.18.0\n", stderr: "" }),
+      allocatePort: async () => target.port,
+      http: (port, password) => new OpenCodeHTTP({ port, password }),
+      startupDeadline: 300,
+      reconnectDelay: 5,
+    });
+    await driver.initialize();
+    await driver.resume({
+      ...params("run-forward-upgrade"),
+      effort: "low",
+      initial_prompt: "",
+      metadata: {
+        schema: 1,
+        opencode_session_id: "native-upgrade",
+        opencode_version: "1.17.18",
+        model: "spotify-glm/zai-org/GLM-5.2-FP8",
+        variant: "low",
+      },
+    });
+    await eventually(() => target.requests.some((request) => request.path === "/tui/select-session"), "upgraded resume selection");
+    expect(await registry.get("run-forward-upgrade")).toEqual(expect.objectContaining({
+      opencode_session_id: "native-upgrade",
+      opencode_version: "1.18.0",
+      resume: true,
+    }));
+  });
+
+  test("rejects an OpenCode downgrade before creating a run", async () => {
+    const rpc = new RecordingRPC();
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = new OpenCodeDriver({
+      rpc,
+      registry,
+      runCommand: async () => ({ exitCode: 0, stdout: "1.17.18\n", stderr: "" }),
+    });
+    await driver.initialize();
+    await expect(driver.resume({
+      ...params("run-downgrade"),
+      initial_prompt: "",
+      metadata: {
+        schema: 1,
+        opencode_session_id: "native-newer",
+        opencode_version: "1.18.0",
+        model: "spotify-glm/zai-org/GLM-5.2-FP8",
+        variant: "max",
+      },
+    })).rejects.toThrow("OpenCode resume would downgrade 1.18.0 to 1.17.18");
+    expect(await registry.get("run-downgrade")).toBeUndefined();
+  });
+
+  test("keeps exact per-run server version identity on newer releases", async () => {
+    const rpc = new RecordingRPC();
+    const target = server("*", "1.18.1");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    const driver = new OpenCodeDriver({
+      rpc,
+      registry,
+      runCommand: async () => ({ exitCode: 0, stdout: "1.18.0\n", stderr: "" }),
+      allocatePort: async () => target.port,
+      http: (port, password) => new OpenCodeHTTP({ port, password }),
+      startupDeadline: 40,
+      reconnectDelay: 5,
+    });
+    await driver.initialize();
+    await driver.spawn({ session_id: "attn-version-mismatch", run_id: "run-version-mismatch", cwd: "/tmp" });
+    await eventually(
+      () => rpc.calls.some((call) => (call.params as { state?: string }).state === "unknown"),
+      "version identity failure report",
+    );
+    expect(driver.health().message).toContain("server version 1.18.1 does not match this run's expected 1.18.0");
   });
 
   test("resumes an interactive OpenCode session without imposing pins", async () => {

--- a/plugins/attn-opencode/test/types.test.ts
+++ b/plugins/attn-opencode/test/types.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import {
+  compareVersion,
+  evaluateOpenCodeVersion,
+  minimumOpenCodeVersion,
+  parseStableVersion,
+} from "../src/types";
+
+describe("OpenCode version policy", () => {
+  test.each([
+    ["", "invalid"],
+    ["garbage", "invalid"],
+    ["1.17", "invalid"],
+    ["1.17.15", "too_old"],
+    ["1.17.16", "supported"],
+    ["v1.17.16", "supported"],
+    ["1.17.17", "supported"],
+    ["1.18.0", "supported"],
+    ["2.0.0", "supported"],
+    ["1.18.0-beta.1", "invalid"],
+    ["1.18.0+build.1", "invalid"],
+  ] as const)("classifies %s as %s", (version, kind) => {
+    expect(evaluateOpenCodeVersion(version).kind).toBe(kind);
+  });
+
+  test("normalizes a leading v and surrounding whitespace", () => {
+    expect(parseStableVersion("  v1.17.16\n")).toEqual({
+      raw: "1.17.16",
+      major: 1,
+      minor: 17,
+      patch: 16,
+    });
+  });
+
+  test("compares major, minor, and patch components numerically", () => {
+    expect(compareVersion(parseStableVersion("1.17.16"), minimumOpenCodeVersion)).toBe(0);
+    expect(compareVersion(parseStableVersion("1.18.0"), minimumOpenCodeVersion)).toBe(1);
+    expect(compareVersion(parseStableVersion("1.17.15"), minimumOpenCodeVersion)).toBe(-1);
+  });
+});


### PR DESCRIPTION
## Intent / Why

The OpenCode plugin currently rejects every release except 1.17.16 and 1.17.18, forcing an attn update even when a newer stable OpenCode release preserves the server contract. This change makes compatibility forward-looking while retaining the strict checks that protect native-session resume and per-run server identity.

## Summary

- Replace the exact release allowlist with strict stable-version parsing and a minimum supported version of 1.17.16.
- Allow existing native sessions to resume after a forward OpenCode upgrade while rejecting downgrades.
- Keep each launched server pinned to the exact version recorded for that run, so wrong-process or wrong-port connections still fail closed.
- Document the compatibility policy and its user-visible behavior.

## Test plan

- [x] `bun test` in `plugins/attn-opencode` — 40 tests, 93 assertions.
- [x] `go test ./internal/daemon -run TestPluginDriver -count=1`.
- [x] `make dev` — full isolated app build, signing, installation, and launch.
- [x] Installed this branch plugin into the dev profile; daemon reported the driver registered and healthy.
- [x] Launched a real OpenCode 1.17.18 TUI in `attn-dev`, received `OPENCODE_VERSION_LIVE_OK`, and observed the attn session settle to `idle`.

## Out of scope

Launch-instruction parity, prose stop classification, plugin supervision, and bundled distribution remain separate PRs.