### PR TITLE
fix(notebook): three editor interaction fixes

### DIFF
--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -385,4 +385,35 @@ test.describe('NotebookBrowser (fs surface)', () => {
     await expect(page.locator('.cm-md-code')).toHaveCount(0);
     await expect(content).toContainText('a horizontal rule');
   });
+
+  test('anchors the send-to-chief pill below the selection end, not over the line above it', async ({ page }) => {
+    await page.goto('/test-harness/?component=NotebookBrowser');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.getByRole('heading', { level: 2, name: 'index' }).waitFor();
+
+    await page.getByRole('treeitem', { name: 'fences.md' }).click();
+    await expect(page.getByRole('heading', { level: 2, name: 'fences' })).toBeVisible();
+
+    await dblclickWord(page, 'quoted');
+
+    const pill = page.getByRole('button', { name: 'Send to chief' });
+    await expect(pill).toBeVisible();
+
+    // The real DOM selection rect (the pill's anchor is computed from CM's own
+    // coordsAtPos, but this is the ground truth the pill must not cover).
+    const selectionBottom = await page.evaluate(() => {
+      const sel = window.getSelection();
+      const range = sel?.rangeCount ? sel.getRangeAt(0) : null;
+      return range ? range.getBoundingClientRect().bottom : null;
+    });
+    expect(selectionBottom).not.toBeNull();
+
+    const pillBox = await pill.boundingBox();
+    expect(pillBox).not.toBeNull();
+    // The pill hangs below the selection end, so its top edge must sit at or below
+    // the selection's bottom edge — never covering the selected text or the line
+    // above it (the old above-anchored transform put the pill's bottom well above
+    // this point, failing this assertion).
+    expect(pillBox!.y).toBeGreaterThanOrEqual(selectionBottom!);
+  });
 });

--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -7,6 +7,7 @@ declare global {
     __NB_HARNESS__?: {
       fsChanged: (path?: string, content?: string, hash?: string) => void;
       getContent: (path: string) => string;
+      forceConflict: (on: boolean) => void;
     };
   }
 }
@@ -415,5 +416,33 @@ test.describe('NotebookBrowser (fs surface)', () => {
     // above it (the old above-anchored transform put the pill's bottom well above
     // this point, failing this assertion).
     expect(pillBox!.y).toBeGreaterThanOrEqual(selectionBottom!);
+  });
+
+  test('restores editor focus after resolving a save conflict via "Reload from disk"', async ({ page }) => {
+    await page.goto('/test-harness/?component=NotebookBrowser');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.getByRole('heading', { level: 2, name: 'index' }).waitFor();
+    await page.waitForSelector('.cm-content');
+
+    // Force the next autosave to report a CAS conflict, then dirty the buffer so the
+    // debounced autosave fires and the banner appears.
+    await page.evaluate(() => window.__NB_HARNESS__!.forceConflict(true));
+    await page.locator('.cm-content').click();
+    await page.keyboard.press('Control+End');
+    await page.keyboard.type(' more', { delay: 8 });
+
+    const banner = page.locator('.notebook-browser-editor-conflict');
+    await expect(banner).toBeVisible({ timeout: 4000 });
+
+    // Stop forcing conflicts so the reload's own read succeeds normally, then reload —
+    // this is the button click that steals focus.
+    await page.evaluate(() => window.__NB_HARNESS__!.forceConflict(false));
+    await banner.getByRole('button', { name: 'Reload from disk' }).click();
+    await expect(banner).toHaveCount(0);
+
+    // Type WITHOUT clicking back into the editor. Without the focus() fix, focus is
+    // stuck on the (now-removed) button and this text never reaches the document.
+    await page.keyboard.type('typed after reload', { delay: 8 });
+    await expect(page.locator('.cm-content')).toContainText('typed after reload');
   });
 });

--- a/app/src/components/NotebookBrowser.css
+++ b/app/src/components/NotebookBrowser.css
@@ -524,11 +524,12 @@
   color: var(--color-danger, #e5534b);
 }
 
-/* Floating action over a rendered-markdown text selection. Fixed to the viewport
-   at the selection rect, centered above it, and above the modal chrome. */
+/* Floating action over a rendered-markdown text selection. Fixed to the viewport,
+   hanging below the selection end (centered on its last char), above the modal
+   chrome — never over the selection or the line above it. */
 .notebook-browser-send-chief {
   position: fixed;
-  transform: translate(-50%, calc(-100% - 8px));
+  transform: translate(-50%, 8px);
   z-index: 500;
   padding: 6px 12px;
   font-size: 12px;

--- a/app/src/components/NotebookBrowser.test.tsx
+++ b/app/src/components/NotebookBrowser.test.tsx
@@ -21,6 +21,9 @@ const editorMock = vi.hoisted(() => ({
   // can assert that a live refresh applies a genuine change via the minimal-edit path
   // (which keeps the reader anchored) rather than a full document swap.
   externalApplies: [] as string[],
+  // Count of imperative focus() calls, so a test can assert the conflict-banner
+  // actions restore editor focus.
+  focusCalls: 0,
 }));
 
 vi.mock('./notebook/LiveMarkdownEditor', async () => {
@@ -40,7 +43,7 @@ vi.mock('./notebook/LiveMarkdownEditor', async () => {
         onSelectionChange?: (sel: { text: string; top: number; left: number } | null) => void;
         ariaLabel?: string;
       },
-      ref: React.Ref<{ scrollToPos: (pos: number) => void; applyExternalContent: (next: string) => void; closeSearchPanel: () => boolean }>,
+      ref: React.Ref<{ scrollToPos: (pos: number) => void; applyExternalContent: (next: string) => void; closeSearchPanel: () => boolean; focus: () => void }>,
     ) {
       editorMock.current = { onFollowLink, onSelectionChange };
       useImperativeHandle(ref, () => ({
@@ -53,6 +56,7 @@ vi.mock('./notebook/LiveMarkdownEditor', async () => {
         },
         // The mock never opens a search panel, so closing is always a no-op.
         closeSearchPanel: () => false,
+        focus: () => { editorMock.focusCalls += 1; },
       }), [onChange]);
       return (
         <textarea
@@ -155,6 +159,7 @@ describe('NotebookBrowser', () => {
     editorMock.current = null;
     editorMock.scrollCalls.length = 0;
     editorMock.externalApplies.length = 0;
+    editorMock.focusCalls = 0;
     vi.restoreAllMocks();
   });
 
@@ -566,6 +571,8 @@ describe('NotebookBrowser', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Overwrite anyway' }));
     await waitFor(() => expect(writeFile).toHaveBeenLastCalledWith('knowledge/index.md', '# mine\n', 'hX'));
     await waitFor(() => expect(screen.queryByText(/changed on disk/i)).not.toBeInTheDocument());
+    // Focus returns to the editor so typing works immediately, with no extra click.
+    expect(editorMock.focusCalls).toBeGreaterThan(0);
   });
 
   it('flushes an unsaved buffer when navigating away before autosave fires', async () => {
@@ -810,6 +817,7 @@ describe('NotebookBrowser stage 5 chrome', () => {
     editorMock.current = null;
     editorMock.scrollCalls.length = 0;
     editorMock.externalApplies.length = 0;
+    editorMock.focusCalls = 0;
     vi.restoreAllMocks();
   });
 

--- a/app/src/components/NotebookSurface.tsx
+++ b/app/src/components/NotebookSurface.tsx
@@ -460,6 +460,9 @@ export function NotebookSurface({
       if (loadSeqRef.current !== seq || selectedPathRef.current !== path) return;
       setNote(fresh);
       setDraft(fresh.content);
+      // The banner's "Reload from disk" button still has focus at this point; pull it
+      // back to the editor so typing works immediately, with no extra click.
+      editorRef.current?.focus();
     } catch (err) {
       if (loadSeqRef.current !== seq || selectedPathRef.current !== path) return;
       setSaveError(err instanceof Error ? err.message : 'Could not reload this file');
@@ -867,7 +870,18 @@ export function NotebookSurface({
                     <button type="button" onClick={() => void reloadFromDisk()} disabled={saving}>
                       Reload from disk
                     </button>
-                    <button type="button" onClick={() => void writeBuffer(conflict.currentHash ?? '', draft)} disabled={saving}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void (async () => {
+                          await writeBuffer(conflict.currentHash ?? '', draft);
+                          // The button still has focus at this point; pull it back to the
+                          // editor so typing works immediately, with no extra click.
+                          editorRef.current?.focus();
+                        })();
+                      }}
+                      disabled={saving}
+                    >
                       Overwrite anyway
                     </button>
                   </div>

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -33,7 +33,9 @@ const macSearchKeymap: readonly KeyBinding[] = searchKeymap.map((binding) =>
 
 export interface LiveSelection {
   text: string;
-  // Viewport coordinates of the selection start, for floating UI.
+  // Viewport coordinates for floating UI: top is the bottom edge of the selection's
+  // last char, left is that char's horizontal midpoint — so a pill anchored here hangs
+  // below the selection end and never covers the selected text or the line above it.
   top: number;
   left: number;
 }
@@ -267,12 +269,15 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
           onSelectionChange(null);
           return;
         }
-        const coords = update.view.coordsAtPos(range.from);
+        // Anchor at the selection's END, not its start: a pill placed above the start
+        // covers the line before the selection, and one placed above the end covers the
+        // selection itself. Below the end is the only spot that covers neither.
+        const coords = update.view.coordsAtPos(range.to);
         if (!coords) {
           onSelectionChange(null);
           return;
         }
-        onSelectionChange({ text, top: coords.top, left: (coords.left + coords.right) / 2 });
+        onSelectionChange({ text, top: coords.bottom, left: (coords.left + coords.right) / 2 });
       },
     [onSelectionChange, onSearchOpenChange],
   );

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -57,6 +57,11 @@ export interface LiveMarkdownEditorHandle {
   applyExternalContent: (next: string) => void;
   // Close the in-editor search panel. Returns true if a panel was open.
   closeSearchPanel: () => boolean;
+  // Restore keyboard focus to the editor without moving the cursor or scrolling
+  // (unlike scrollToPos). Used after a chrome control outside the editor — e.g. a
+  // conflict-banner button — steals focus, so typing works immediately again with no
+  // extra click back into the document.
+  focus: () => void;
 }
 
 interface LiveMarkdownEditorProps {
@@ -210,6 +215,9 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
       if (!view || !searchPanelOpen(view.state)) return false;
       closeSearchPanel(view);
       return true;
+    },
+    focus: () => {
+      cmRef.current?.view?.focus();
     },
   }), []);
 

--- a/app/src/components/notebook/liveMarkdownPreview.test.ts
+++ b/app/src/components/notebook/liveMarkdownPreview.test.ts
@@ -226,4 +226,26 @@ describe('liveMarkdownPreview decorations', () => {
     const decos = decosFor(doc, doc.length); // cursor on "body"
     expect(hasWidget(decos, 'cm-md-hr')).toBe(false);
   });
+
+  it('does not decorate a YAML list inside frontmatter, but still decorates a body list', () => {
+    const doc = '---\ntags:\n  - one\n  - two\n---\n\n- item\n\nbody';
+    const fmEnd = doc.indexOf('---\n\n') + '---\n'.length; // end of the closing fence line
+    const decos = decosFor(doc, doc.length); // cursor on "body", away from both lists
+
+    // No bullet widget anywhere inside the frontmatter block.
+    expect(decos.some((d) => d.widget === 'cm-md-bullet' && d.from < fmEnd)).toBe(false);
+    // The body list still gets its bullet.
+    expect(decos.some((d) => d.widget === 'cm-md-bullet' && d.from >= fmEnd)).toBe(true);
+  });
+
+  it('treats an unclosed frontmatter fence as ordinary markdown, matching frontmatterCard', () => {
+    // Opened with "---" but never closed — parseFrontmatter (and frontmatterCard) treat
+    // this as NOT frontmatter at all, so the list lines are plain markdown and still get
+    // their bullet. A transient bullet while the fence is mid-typing beats suppressing
+    // every decoration in the note.
+    const doc = '---\ntags:\n  - one\n  - two\n- item';
+    expect(() => decosFor(doc, doc.length)).not.toThrow();
+    const decos = decosFor(doc, doc.length);
+    expect(hasWidget(decos, 'cm-md-bullet')).toBe(true);
+  });
 });

--- a/app/src/components/notebook/liveMarkdownPreview.ts
+++ b/app/src/components/notebook/liveMarkdownPreview.ts
@@ -19,6 +19,24 @@ import {
   WidgetType,
 } from '@codemirror/view';
 import type { Tree } from '@lezer/common';
+import { parseFrontmatter } from './frontmatter';
+
+// A note's leading frontmatter is YAML, not markdown — no inline-preview decoration
+// (bullets, bold, etc.) is ever correct there; it renders raw or as the frontmatterCard
+// widget (a separate extension). Returns 0 when the doc has no frontmatter, else the
+// region's end offset. Parses only a BOUNDED prefix (frontmatter is always small, and a
+// full doc.toString() per keystroke is wasted work on a large note).
+function frontmatterEnd(state: EditorState): number {
+  const prefix = state.doc.sliceString(0, Math.min(state.doc.length, 4096));
+  const fm = parseFrontmatter(prefix);
+  // Must agree with frontmatterCard's own notion of "is this frontmatter" — an opening
+  // `---` with no closing fence (still being typed, malformed, or truncated past the
+  // bounded prefix) is treated as NOT frontmatter by both extensions, matching
+  // parseFrontmatter's null return. The alternative — suppressing every decoration in
+  // the whole note while the user is mid-typing frontmatter — is worse than a
+  // transient bullet on a YAML list line.
+  return fm ? fm.to : 0;
+}
 
 export interface LiveMarkdownOptions {
   // Invoked when the user mod-clicks (⌘/Ctrl) a rendered link. Receives the raw href.
@@ -157,6 +175,7 @@ export function buildDecorations(
   // arbitrarily large note synchronously.
   const tree = parsedTree ?? ensureSyntaxTree(state, doc.length, 100) ?? syntaxTree(state);
   const scanRange = range ?? { from: 0, to: doc.length };
+  const fmEnd = frontmatterEnd(state);
 
   const onActiveLine = (pos: number) => active.has(doc.lineAt(pos).number);
 
@@ -164,6 +183,10 @@ export function buildDecorations(
     from: scanRange.from,
     to: scanRange.to,
     enter: (node) => {
+      // The frontmatter block is YAML, not markdown — no preview decoration there is
+      // ever right (it's either shown raw or replaced whole by frontmatterCard).
+      if (node.from < fmEnd) return;
+
       const name = node.name;
 
       // ---- block: ATX headings ----

--- a/app/test-harness/harnesses/NotebookBrowserHarness.tsx
+++ b/app/test-harness/harnesses/NotebookBrowserHarness.tsx
@@ -112,6 +112,10 @@ interface NotebookHarnessControls {
   // The bytes a path currently reads as, so the e2e can derive a minimally-edited
   // version (an agent appending a line) rather than guessing the fixture body.
   getContent: (path: string) => string;
+  // Force every writeFile call to report a CAS conflict (simulating an out-of-band
+  // disk change) until toggled off, so e2e can drive the conflict-banner flow
+  // without racing a real write.
+  forceConflict: (on: boolean) => void;
 }
 declare global {
   interface Window {
@@ -123,6 +127,8 @@ export function NotebookBrowserHarness({ onReady, setTriggerRerender }: HarnessP
   const [changeSignal, setChangeSignal] = useState(0);
   // Per-path byte/hash overrides the e2e stages to simulate an on-disk change.
   const overridesRef = useRef<Record<string, { content: string; hash: string }>>({});
+  // See NotebookHarnessControls.forceConflict.
+  const forceConflictRef = useRef(false);
 
   const listDir = useCallback(async (path: string): Promise<FsEntry[]> => TREE[path] ?? [], []);
   const readFile = useCallback(async (path: string): Promise<FsReadResult> => {
@@ -135,6 +141,9 @@ export function NotebookBrowserHarness({ onReady, setTriggerRerender }: HarnessP
   ], []);
   const writeFile = useCallback(async (path: string, content: string, baseHash?: string): Promise<FsWriteResult> => {
     window.__HARNESS__.recordCall('writeFile', [path, content, baseHash]);
+    if (forceConflictRef.current) {
+      return { path, hash: 'h1', conflict: true, currentHash: 'h-disk' };
+    }
     return { path, hash: 'h2', conflict: false };
   }, []);
   const existsFile = useCallback(async (path: string): Promise<FsExistsResult> => {
@@ -178,6 +187,9 @@ export function NotebookBrowserHarness({ onReady, setTriggerRerender }: HarnessP
       },
       getContent: (path: string) =>
         overridesRef.current[path]?.content ?? CONTENT[path] ?? `# ${path}\n\nSample body.`,
+      forceConflict: (on: boolean) => {
+        forceConflictRef.current = on;
+      },
     };
     onReady();
   }, [onReady, setTriggerRerender]);


### PR DESCRIPTION
## Summary
- The "Send to chief" pill now hangs below the current selection instead of covering the line above it.
- Typing works immediately after resolving a save conflict banner, with no extra click needed to regain editor focus.
- A note's YAML frontmatter no longer shows stray markdown list bullet decorations while editing it.

## Test plan
- `go build ./...`
- `go test ./internal/daemon ./internal/protocol`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run` (166 files / 1766 tests)
- Live-app verification pending in this PR flow (part of stacked notebook-editor-polish series; part of the larger epic already exercised live per prior PRs in the stack)