### PR TITLE
feat(notebook): relative note links resolve, images fixed, heading jumps

### DIFF
--- a/app/e2e/broken-links.spec.ts
+++ b/app/e2e/broken-links.spec.ts
@@ -28,9 +28,11 @@ test.describe('LiveMarkdownEditor broken links', () => {
     expect(color).not.toBe(realColor);
 
     // The existence check ran for the in-notebook links but NEVER for the external one.
+    // notebookLinkPath now returns a normalized, no-leading-slash root-relative path
+    // (via resolveNotebookLink) rather than the href's raw leading-slash form.
     const checked = await page.evaluate(() => window.__HARNESS__.getCalls('existsFile').map((c) => c[0]));
-    expect(checked).toContain('/knowledge/areas/missing.md');
-    expect(checked).toContain('/knowledge/areas/real.md');
+    expect(checked).toContain('knowledge/areas/missing.md');
+    expect(checked).toContain('knowledge/areas/real.md');
     expect(checked.some((p: string) => p.includes('example.com'))).toBe(false);
 
     await page.screenshot({ path: 'test-results/broken-links.png' });
@@ -48,6 +50,6 @@ test.describe('LiveMarkdownEditor broken links', () => {
     await expect(page.locator('.cm-md-link-broken')).toHaveCount(2);
 
     const checked = await page.evaluate(() => window.__HARNESS__.getCalls('existsFile').map((c) => c[0]));
-    expect(checked).toContain('/knowledge/areas/missing-extra.md');
+    expect(checked).toContain('knowledge/areas/missing-extra.md');
   });
 });

--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -494,7 +494,8 @@ test.describe('NotebookBrowser (fs surface)', () => {
     await page.waitForSelector('.cm-content');
 
     const scrollTop = () => page.locator('.cm-scroller').evaluate((el) => (el as HTMLElement).scrollTop);
-    expect(await scrollTop()).toBeLessThan(40);
+    await page.locator('.cm-scroller').evaluate((el) => { (el as HTMLElement).scrollTop = 0; });
+    await expect.poll(scrollTop).toBeLessThan(40);
 
     const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
     await page.locator('.cm-md-link[data-href="#down-below"]').click({ modifiers: [modifier] });

--- a/app/e2e/notebook-browser.spec.ts
+++ b/app/e2e/notebook-browser.spec.ts
@@ -445,4 +445,60 @@ test.describe('NotebookBrowser (fs surface)', () => {
     await page.keyboard.type('typed after reload', { delay: 8 });
     await expect(page.locator('.cm-content')).toContainText('typed after reload');
   });
+
+  test('mod-click on a bare-relative link navigates to the sibling note (resolved against the linking note\'s directory)', async ({ page }) => {
+    // Regression: parseNotebookHref required a leading '/' + '.md' for in-notebook
+    // navigation, so a bare `sibling.md` link was classified external and handed to
+    // window.open instead of navigating. resolveNotebookLink resolves it against the
+    // linking note's own directory (knowledge/areas), landing on knowledge/areas/bar.md.
+    await page.addInitScript(() => {
+      (window as unknown as { __OPENED__: string[] }).__OPENED__ = [];
+      window.open = ((url?: string | URL) => {
+        (window as unknown as { __OPENED__: string[] }).__OPENED__.push(String(url));
+        return null;
+      }) as typeof window.open;
+    });
+    await page.goto('/test-harness/?component=NotebookBrowser');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.getByRole('heading', { level: 2, name: 'index' }).waitFor();
+
+    // Open the linking note (knowledge/areas/foo.md) via the Cmd+P finder.
+    await page.locator('.cm-content').click();
+    await page.keyboard.press('Meta+p');
+    await page.locator('.notebook-finder-input').fill('foo');
+    await expect(page.locator('.notebook-finder-option')).toHaveCount(1);
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('heading', { level: 2, name: 'foo' })).toBeVisible();
+    await page.waitForSelector('.cm-md-link[data-href="bar.md"]');
+
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.locator('.cm-md-link[data-href="bar.md"]').click({ modifiers: [modifier] });
+
+    await expect(page.getByRole('heading', { level: 2, name: 'bar' })).toBeVisible();
+    await expect(page.locator('.cm-content')).toContainText('Sibling of foo');
+    // Never fell through to opening it as an external URL.
+    expect(await page.evaluate(() => (window as unknown as { __OPENED__: string[] }).__OPENED__)).toEqual([]);
+  });
+
+  test('mod-click on a #heading link scrolls that heading into view', async ({ page }) => {
+    await page.goto('/test-harness/?component=NotebookBrowser');
+    await page.waitForFunction(() => window.__HARNESS__?.ready === true);
+    await page.getByRole('heading', { level: 2, name: 'index' }).waitFor();
+
+    await page.locator('.cm-content').click();
+    await page.keyboard.press('Meta+p');
+    await page.locator('.notebook-finder-input').fill('foo');
+    await expect(page.locator('.notebook-finder-option')).toHaveCount(1);
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('heading', { level: 2, name: 'foo' })).toBeVisible();
+    await page.waitForSelector('.cm-content');
+
+    const scrollTop = () => page.locator('.cm-scroller').evaluate((el) => (el as HTMLElement).scrollTop);
+    expect(await scrollTop()).toBeLessThan(40);
+
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.locator('.cm-md-link[data-href="#down-below"]').click({ modifiers: [modifier] });
+
+    await expect.poll(scrollTop, { timeout: 2000 }).toBeGreaterThan(150);
+  });
 });

--- a/app/package.json
+++ b/app/package.json
@@ -52,6 +52,7 @@
     "real-app:scenario-notebook-tile-finder": "node scripts/real-app-harness/scenario-notebook-tile-finder.mjs",
     "real-app:scenario-notebook-tile-close": "node scripts/real-app-harness/scenario-notebook-tile-close.mjs",
     "real-app:scenario-notebook-editor-undo": "node scripts/real-app-harness/scenario-notebook-editor-undo.mjs",
+    "real-app:scenario-notebook-link-nav": "node scripts/real-app-harness/scenario-notebook-link-nav.mjs",
     "real-app:scenario-autoclose-on-exit": "node scripts/real-app-harness/scenario-autoclose-on-exit.mjs",
     "real-app:scenario-present-flow": "node scripts/real-app-harness/scenario-present-flow.mjs",
     "real-app:scenario-ticket-lifecycle": "node scripts/real-app-harness/scenario-ticket-delegation-lifecycle.mjs",

--- a/app/scripts/real-app-harness/scenario-notebook-link-nav.mjs
+++ b/app/scripts/real-app-harness/scenario-notebook-link-nav.mjs
@@ -9,6 +9,12 @@
 //      of the doc is virtualized OUT of the CodeMirror DOM before the jump
 //      and IN after it (CM only mounts visible lines, so presence proves the
 //      scroll landed).
+//   3. A note in a nested directory that references an image via a
+//      `..`-relative path (climbing back out to a sibling assets/ dir)
+//      renders the resolved image, not the broken placeholder — proving
+//      resolveImageSrc's baseDir-relative + `..`-clamped resolution against
+//      the real packaged-app asset-read IPC round trip (not just the
+//      resolver's unit tests).
 // Modeled on scenario-notebook-editor-undo.mjs, swapping every native driver
 // step for a bridge verb.
 
@@ -36,6 +42,12 @@ const FINDER_INPUT_SELECTOR = '.terminal-wrapper.active .notebook-finder-input';
 const FINDER_OPTION_SELECTOR = '.terminal-wrapper.active .notebook-finder-option';
 const DOWN_LINK = '.terminal-wrapper.active .cm-md-link[data-href="#down-below"]';
 const TOP_LINK = '.terminal-wrapper.active .cm-md-link[data-href="#anchor-top"]';
+const IMAGE_IMG = '.terminal-wrapper.active .cm-md-image img';
+const IMAGE_BROKEN = '.terminal-wrapper.active .cm-md-image-broken';
+
+// 1x1 transparent PNG, embedded so the harness has no external fixture to keep in sync.
+const PIXEL_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
 
 function parseArgs(argv) {
   const args = [...argv];
@@ -164,6 +176,29 @@ async function main() {
     const filler = Array.from({ length: 80 }, (_, i) => `Filler line ${i + 1}.`).join('\n\n');
     fs.writeFileSync(navPath, `# nav probe\n\n[bar](${BAR}.md)\n`, 'utf8');
     fs.writeFileSync(barPath, `# bar\n\nSibling of nav probe.\n\n[anchor](${ANCHOR}.md)\n`, 'utf8');
+    // 0b. A note nested one directory deep, referencing an image via a
+    // `..`-relative path back out to a sibling assets/ directory:
+    //   <root>/<run>-imgdir/<run>qimg.md   -> ![pixel](../<run>-assets/pixel.png)
+    //   <root>/<run>-assets/pixel.png
+    // Linked from the anchor probe (relative-path-into-a-subdirectory link),
+    // so reaching it exercises the same mod-click navigation as steps 4-5
+    // above rather than needing to re-summon the finder mid-session (the
+    // finder's only reopen affordance is the "Find a note" empty-state
+    // button, which isn't shown while a note is already open).
+    const IMG = `${runId}qimg`;
+    const imgDirName = `${runId}-imgdir`;
+    const assetsDirName = `${runId}-assets`;
+    const imgDir = path.join(notebookRoot, imgDirName);
+    const assetsDir = path.join(notebookRoot, assetsDirName);
+    fs.mkdirSync(imgDir, { recursive: true });
+    fs.mkdirSync(assetsDir, { recursive: true });
+    const imgNotePath = path.join(imgDir, `${IMG}.md`);
+    const pixelPath = path.join(assetsDir, 'pixel.png');
+    const imgLinkHref = `${imgDirName}/${IMG}.md`;
+    fs.writeFileSync(imgNotePath, `# image probe\n\n![pixel](../${assetsDirName}/pixel.png)\n`, 'utf8');
+    fs.writeFileSync(pixelPath, Buffer.from(PIXEL_PNG_BASE64, 'base64'));
+    console.log(`[RealAppHarness] imgNote=${imgNotePath} pixel=${pixelPath}`);
+
     fs.writeFileSync(anchorPath, [
       '# anchor probe',
       '',
@@ -174,6 +209,8 @@ async function main() {
       '## down below',
       '',
       'You made it. [top](#anchor-top)',
+      '',
+      `[image probe](${imgLinkHref})`,
       '',
     ].join('\n'), 'utf8');
     console.log(`[RealAppHarness] notebookRoot=${notebookRoot} nav=${NAV}.md bar=${BAR}.md anchor=${ANCHOR}.md`);
@@ -260,6 +297,28 @@ async function main() {
     await waitForDomSelector(client, TOP_LINK, true, 'mod-click #down-below scrolls the note into view');
     console.log('[RealAppHarness] STEP 4 OK: mod-click on #down-below scrolled the note (bottom-of-doc link now in the CM DOM).');
 
+    // 8. ⌘-click the image-probe link -> navigates into the nested imgdir/
+    // note that references a `..`-relative image.
+    const IMAGE_LINK = `.terminal-wrapper.active .cm-md-link[data-href="${imgLinkHref}"]`;
+    await waitForDomSelector(client, IMAGE_LINK, true, 'image-probe link rendered');
+    await client.request('dom_click', { selector: IMAGE_LINK, modifiers: { meta: true } });
+    await waitForWorkspaceUi(
+      client,
+      workspaceId,
+      (state) => state?.tileTitles?.includes(`${IMG}.md`),
+      'mod-click relative link navigates anchor -> nested image probe',
+    );
+    console.log('[RealAppHarness] STEP 5 OK: mod-click on relative link navigated into the nested directory.');
+
+    // 9. The `..`-relative image must resolve and render (not the broken
+    // placeholder): proves resolveImageSrc's baseDir-relative + `..`-clamped
+    // path resolution against the real asset-read IPC round trip.
+    await waitForDomSelector(client, IMAGE_IMG, true, '`..`-relative image renders (not broken placeholder)');
+    if (await domSelectorPresent(client, IMAGE_BROKEN)) {
+      throw new Error('`..`-relative image rendered as broken placeholder instead of resolving');
+    }
+    console.log('[RealAppHarness] STEP 6 OK: `..`-relative image resolved and rendered.');
+
     const summary = {
       ok: true,
       runId,
@@ -268,9 +327,11 @@ async function main() {
       navPath,
       barPath,
       anchorPath,
+      imgNotePath,
+      pixelPath,
     };
     fs.writeFileSync(path.join(runDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
-    console.log('[RealAppHarness] PASSED: bridge-only mod-click link navigation + heading jump verified.');
+    console.log('[RealAppHarness] PASSED: bridge-only mod-click link navigation + heading jump + `..`-relative image resolution verified.');
     console.log(JSON.stringify(summary, null, 2));
   } catch (error) {
     console.error(`[RealAppHarness] FAILED: ${error?.stack || error}`);

--- a/app/scripts/real-app-harness/scenario-notebook-link-nav.mjs
+++ b/app/scripts/real-app-harness/scenario-notebook-link-nav.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+
+// Mod-click markdown link navigation inside a notebook tile, packaged app,
+// entirely through the synthetic-DOM bridge (dom_click / dom_type) — no
+// MacOSDriver, no native CGEvent input at all. Proves:
+//   1. ⌘-click on a bare relative link navigates to the sibling note (tile
+//      title flips nav-probe -> bar).
+//   2. ⌘-click on a #heading link scrolls the note: a link near the bottom
+//      of the doc is virtualized OUT of the CodeMirror DOM before the jump
+//      and IN after it (CM only mounts visible lines, so presence proves the
+//      scroll landed).
+// Modeled on scenario-notebook-editor-undo.mjs, swapping every native driver
+// step for a bridge verb.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  createRunContext,
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { currentHarnessProfile } from './harnessProfile.mjs';
+import {
+  waitForFirstWorkspacePane,
+  waitForPaneShellReady,
+  waitForPaneVisible,
+} from './scenarioAssertions.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+
+const FINDER_SELECTOR = '.terminal-wrapper.active .notebook-finder';
+const FINDER_INPUT_SELECTOR = '.terminal-wrapper.active .notebook-finder-input';
+const FINDER_OPTION_SELECTOR = '.terminal-wrapper.active .notebook-finder-option';
+const DOWN_LINK = '.terminal-wrapper.active .cm-md-link[data-href="#down-below"]';
+const TOP_LINK = '.terminal-wrapper.active .cm-md-link[data-href="#anchor-top"]';
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') {
+    args.shift();
+  }
+  return {
+    options: parseCommonArgs(args),
+    help: args.includes('--help') || args.includes('-h'),
+  };
+}
+
+// Mirrors internal/notebook/layout.go DefaultRoot: ~/attn-notebook, or
+// ~/attn-notebook-<profile> for any non-default profile.
+function defaultNotebookRootForProfile(profile) {
+  const normalized = (profile || '').trim().toLowerCase();
+  const base = path.join(os.homedir(), 'attn-notebook');
+  return normalized === '' || normalized === 'default' ? base : `${base}-${normalized}`;
+}
+
+// Selector presence via the screenshot bridge: "not found" error == absent;
+// success or any other error (html-to-image chokes inside CM subtrees, which
+// still proves presence) == present.
+async function domSelectorPresent(client, selector) {
+  try {
+    await client.request('capture_screenshot_data', { selector }, { timeoutMs: 8000 });
+    return true;
+  } catch (error) {
+    return !String(error).includes('Screenshot selector not found in DOM');
+  }
+}
+
+async function waitForDomSelector(client, selector, present, description, timeoutMs = 10_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if ((await domSelectorPresent(client, selector)) === present) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  throw new Error(`Timed out waiting for ${selector} to be ${present ? 'present' : 'absent'}: ${description}`);
+}
+
+async function waitForWorkspaceUi(client, workspaceId, predicate, description, timeoutMs = 20_000) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await client.request('get_workspace_ui_state', { workspaceId }).catch((error) => ({ error: String(error) }));
+    if (predicate(last)) {
+      return last;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`Timed out waiting for ${description}. Last workspace UI state:\n${JSON.stringify(last, null, 2)}`);
+}
+
+async function closeWorkspacePanes(client, sessionId) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const workspace = await client.request('get_workspace', { sessionId }).catch(() => null);
+    const pane = workspace?.panes?.[0];
+    if (!pane) {
+      return;
+    }
+    await client.request('close_pane', { sessionId, paneId: pane.paneId }).catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+async function closeExistingSessions(client, sessionRootDir) {
+  const initial = await client.request('get_state');
+  const harnessSessions = (initial.sessions || []).filter((session) => session.cwd?.startsWith(sessionRootDir));
+  for (const session of harnessSessions) {
+    await closeWorkspacePanes(client, session.id).catch(() => {});
+  }
+}
+
+// Open a note via the finder, entirely through the bridge: type the fuzzy
+// query, wait for exactly one result row, mousedown-pick it (the finder picks
+// on mousedown, not click — see NotebookFinder.tsx).
+async function openNoteViaFinderBridge(client, workspaceId, basename, query) {
+  await waitForDomSelector(client, FINDER_SELECTOR, true, `finder open for ${basename}`);
+  await client.request('dom_type', { selector: FINDER_INPUT_SELECTOR, text: query });
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  await waitForDomSelector(client, FINDER_OPTION_SELECTOR, true, `finder shows a result for "${query}"`);
+  await client.request('dom_click', { selector: FINDER_OPTION_SELECTOR });
+  await waitForWorkspaceUi(
+    client,
+    workspaceId,
+    (state) => state?.tileTitles?.includes(`${basename}.md`),
+    `finder opens ${basename}.md (tile title)`,
+    15_000,
+  );
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-notebook-link-nav.mjs');
+    return;
+  }
+
+  const { runId, runDir, sessionDir } = createRunContext(options, 'notebook-link-nav');
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  let sessionId = null;
+
+  console.log(`[RealAppHarness] runDir=${runDir}`);
+  console.log(`[RealAppHarness] sessionDir=${sessionDir}`);
+  console.log(`[RealAppHarness] wsUrl=${options.wsUrl}`);
+
+  try {
+    await launchFreshAppAndConnect(client, observer);
+    await closeExistingSessions(client, options.sessionRootDir);
+
+    // 0. Seed three probe notes on disk before anything mounts. Names are
+    // chosen so each finder query fuzzy-matches exactly one note: "qnav" is
+    // not a subsequence of qbar/qanchor's names and vice versa.
+    const notebookRoot = defaultNotebookRootForProfile(currentHarnessProfile());
+    fs.mkdirSync(notebookRoot, { recursive: true });
+    const NAV = `${runId}qnav`;
+    const BAR = `${runId}qbar`;
+    const ANCHOR = `${runId}qanchor`;
+    const navPath = path.join(notebookRoot, `${NAV}.md`);
+    const barPath = path.join(notebookRoot, `${BAR}.md`);
+    const anchorPath = path.join(notebookRoot, `${ANCHOR}.md`);
+    const filler = Array.from({ length: 80 }, (_, i) => `Filler line ${i + 1}.`).join('\n\n');
+    fs.writeFileSync(navPath, `# nav probe\n\n[bar](${BAR}.md)\n`, 'utf8');
+    fs.writeFileSync(barPath, `# bar\n\nSibling of nav probe.\n\n[anchor](${ANCHOR}.md)\n`, 'utf8');
+    fs.writeFileSync(anchorPath, [
+      '# anchor probe',
+      '',
+      '[down](#down-below)',
+      '',
+      filler,
+      '',
+      '## down below',
+      '',
+      'You made it. [top](#anchor-top)',
+      '',
+    ].join('\n'), 'utf8');
+    console.log(`[RealAppHarness] notebookRoot=${notebookRoot} nav=${NAV}.md bar=${BAR}.md anchor=${ANCHOR}.md`);
+
+    // 1. A normal shell workspace to dock the notebook tile into.
+    const cwd = path.join(sessionDir, 'linknav-ws');
+    fs.mkdirSync(cwd, { recursive: true });
+    sessionId = await createSessionAndWaitForInitialPane({
+      client,
+      observer,
+      cwd,
+      label: `notebook-link-nav-${runId}`,
+      agent: 'shell',
+      waitForInitialPaneVisible: false,
+      sessionWaitMs: 30_000,
+    });
+    const pane = await waitForFirstWorkspacePane(client, sessionId, 'initial workspace pane');
+    await client.request('select_session', { sessionId });
+    await waitForPaneVisible(client, sessionId, pane.paneId, 20_000);
+    await waitForPaneShellReady(client, sessionId, pane.paneId, {
+      timeoutMs: 20_000,
+      description: 'shell prompt ready',
+    });
+
+    const workspace = await client.request('get_workspace', { sessionId });
+    const workspaceId = workspace.workspaceId;
+    if (!workspaceId) {
+      throw new Error(`Could not resolve workspace id for session ${sessionId}: ${JSON.stringify(workspace)}`);
+    }
+
+    // 2. Dock a notebook tile via the bridge shortcut dispatcher (no native
+    // ⌘⌥N needed) — the fresh tile auto-opens its finder.
+    await client.request('dispatch_shortcut', { shortcutId: 'notebook.openTile' });
+    const docked = await waitForWorkspaceUi(
+      client,
+      workspaceId,
+      (state) => Array.isArray(state?.tileIds) && state.tileIds.length === 1
+        && Array.isArray(state?.tileTitles) && state.tileTitles.includes('Notebook'),
+      'notebook.openTile docks a fresh notebook tile (titled "Notebook")',
+      15_000,
+    );
+    console.log(`[RealAppHarness] docked notebook tile=${docked.tileIds[0]}`);
+
+    // 3. Open the nav probe via the finder, bridge-only.
+    await openNoteViaFinderBridge(client, workspaceId, NAV, 'qnav');
+    console.log('[RealAppHarness] STEP 1 OK: nav-probe note open in the notebook tile.');
+
+    // 4. ⌘-click the bare relative link -> navigates to the sibling note.
+    await client.request('dom_click', {
+      selector: `.terminal-wrapper.active .cm-md-link[data-href="${BAR}.md"]`,
+      modifiers: { meta: true },
+    });
+    await waitForWorkspaceUi(
+      client,
+      workspaceId,
+      (state) => state?.tileTitles?.includes(`${BAR}.md`),
+      'mod-click relative link navigates nav-probe -> bar',
+    );
+    console.log('[RealAppHarness] STEP 2 OK: mod-click on relative link navigated to the sibling note.');
+
+    // 5. ⌘-click the second relative link -> navigates to the anchor probe.
+    await client.request('dom_click', {
+      selector: `.terminal-wrapper.active .cm-md-link[data-href="${ANCHOR}.md"]`,
+      modifiers: { meta: true },
+    });
+    await waitForWorkspaceUi(
+      client,
+      workspaceId,
+      (state) => state?.tileTitles?.includes(`${ANCHOR}.md`),
+      'mod-click relative link navigates bar -> anchor',
+    );
+    console.log('[RealAppHarness] STEP 3 OK: mod-click on relative link navigated bar -> anchor.');
+
+    // 6. Precondition: the bottom-of-doc [top] link must not be mounted yet
+    // (CM virtualization), and the [down] link must be.
+    await waitForDomSelector(client, DOWN_LINK, true, 'down link rendered');
+    if (await domSelectorPresent(client, TOP_LINK)) {
+      throw new Error('precondition failed: bottom [top] link already in DOM before the anchor jump');
+    }
+
+    // 7. ⌘-click #down-below -> scrolls the note; the [top] link enters the
+    // virtualized CM DOM only once the jump lands.
+    await client.request('dom_click', { selector: DOWN_LINK, modifiers: { meta: true } });
+    await waitForDomSelector(client, TOP_LINK, true, 'mod-click #down-below scrolls the note into view');
+    console.log('[RealAppHarness] STEP 4 OK: mod-click on #down-below scrolled the note (bottom-of-doc link now in the CM DOM).');
+
+    const summary = {
+      ok: true,
+      runId,
+      workspaceId,
+      tileId: docked.tileIds[0],
+      navPath,
+      barPath,
+      anchorPath,
+    };
+    fs.writeFileSync(path.join(runDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    console.log('[RealAppHarness] PASSED: bridge-only mod-click link navigation + heading jump verified.');
+    console.log(JSON.stringify(summary, null, 2));
+  } catch (error) {
+    console.error(`[RealAppHarness] FAILED: ${error?.stack || error}`);
+    throw error;
+  } finally {
+    if (sessionId) {
+      await closeWorkspacePanes(client, sessionId).catch(() => {});
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/src/components/NotebookBrowser.test.tsx
+++ b/app/src/components/NotebookBrowser.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { NotebookBrowser, parseNotebookHref } from './NotebookBrowser';
+import { NotebookBrowser } from './NotebookBrowser';
 import type { FsEntry, FsExistsResult, FsReadAssetResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../hooks/useDaemonSocket';
 
 // The live editor is CodeMirror-backed, which cannot mount under happy-dom (its
@@ -786,26 +786,8 @@ describe('NotebookBrowser', () => {
 
 });
 
-describe('parseNotebookHref', () => {
-  it('classifies a root-absolute .md target as in-notebook navigation', () => {
-    expect(parseNotebookHref('/knowledge/areas/foo.md')).toEqual({ kind: 'note', path: 'knowledge/areas/foo.md', anchor: undefined });
-  });
-
-  it('strips an anchor from a note target', () => {
-    expect(parseNotebookHref('/knowledge/areas/foo.md#why')).toEqual({ kind: 'note', path: 'knowledge/areas/foo.md', anchor: 'why' });
-  });
-
-  it('treats a bare fragment as an in-page anchor', () => {
-    expect(parseNotebookHref('#section')).toEqual({ kind: 'fragment', anchor: 'section' });
-  });
-
-  it('treats http(s) and relative targets as external', () => {
-    expect(parseNotebookHref('https://example.com').kind).toBe('external');
-    expect(parseNotebookHref('./relative.md').kind).toBe('external');
-    // A root-absolute path that is not a .md file is not in-notebook navigation.
-    expect(parseNotebookHref('/etc/passwd').kind).toBe('external');
-  });
-});
+// Link-classification logic (parseNotebookHref) moved to the shared
+// resolveNotebookLink and is covered by linkResolver.test.ts.
 
 // Stage 5 chrome: the manual edge-rail folds, the header chief pulse, and the note
 // kind badge. The fold ANIMATION and grid collapse are a real-browser concern

--- a/app/src/components/NotebookBrowser.tsx
+++ b/app/src/components/NotebookBrowser.tsx
@@ -1,10 +1,6 @@
 import type { FsEntry, FsExistsResult, FsReadAssetResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../hooks/useDaemonSocket';
 import { NotebookSurface } from './NotebookSurface';
 
-// parseNotebookHref / NotebookHref moved to NotebookSurface with the rest of the
-// body; re-exported here so existing importers (and the unit test) are unaffected.
-export { parseNotebookHref, type NotebookHref } from './NotebookSurface';
-
 interface NotebookBrowserProps {
   isOpen: boolean;
   initialPath?: string | null;

--- a/app/src/components/NotebookSurface.tsx
+++ b/app/src/components/NotebookSurface.tsx
@@ -8,6 +8,7 @@ import { notebookLinkPath } from './notebook/brokenLinks';
 import { FileTree } from './notebook/FileTree';
 import { fileKind, isBinaryPath, isMarkdownPath } from './notebook/fileKind';
 import { parseFrontmatter } from './notebook/frontmatter';
+import { headingSlug, noteDir, resolveNotebookLink } from './notebook/linkResolver';
 import { LiveMarkdownEditor, type LiveMarkdownEditorHandle, type LiveSelection } from './notebook/LiveMarkdownEditor';
 import { NotebookFinder } from './notebook/NotebookFinder';
 import { parseOutline } from './notebook/outline';
@@ -727,14 +728,35 @@ export function NotebookSurface({
     return () => window.clearTimeout(timer);
   }, [justSaved]);
 
-  // Mod-click on a rendered link: in-notebook .md targets navigate; external
-  // targets open in the browser; fragments are ignored (no in-editor anchor jump).
+  // Scroll to the current note's heading whose GitHub-style slug matches `anchor`
+  // (also accepting an exact raw-text case-insensitive match, for a heading that
+  // pre-dates or otherwise doesn't slug-match its own link). No match is a no-op.
+  const scrollToAnchor = useCallback((anchor: string) => {
+    const wanted = headingSlug(anchor);
+    const heading = parseOutline(draftRef.current).find(
+      (h) => headingSlug(h.text) === wanted || h.text.toLowerCase() === anchor.toLowerCase(),
+    );
+    if (heading) editorRef.current?.scrollToPos(heading.pos);
+  }, []);
+
+  // Mod-click on a rendered link: an in-notebook target navigates (resolved against
+  // the current note's directory); a same-note anchor scrolls to the matching
+  // heading; an external target opens in the browser. Cross-note anchors (a link
+  // like `other.md#heading`) are not yet handled — loadFile is a fire-and-forget
+  // navigation with no way to learn when the new note's content has landed without
+  // reshaping it, so a jump there is deferred to a follow-up.
   const handleFollowLink = useCallback((href: string) => {
-    const target = parseNotebookHref(href);
-    if (target.kind === 'note' && target.path) {
-      void loadFile(target.path);
-    } else if (target.kind === 'external' && target.href) {
-      window.open(target.href, '_blank', 'noreferrer');
+    const resolved = resolveNotebookLink(href, noteDir(selectedPathRef.current ?? ''));
+    if (resolved.kind === 'note') {
+      if (resolved.path === selectedPathRef.current && resolved.anchor) {
+        scrollToAnchor(resolved.anchor);
+      } else {
+        void loadFile(resolved.path);
+      }
+    } else if (resolved.kind === 'fragment') {
+      scrollToAnchor(resolved.anchor);
+    } else if (resolved.href) {
+      window.open(resolved.href, '_blank', 'noreferrer');
     }
   }, [loadFile]);
 
@@ -750,7 +772,7 @@ export function NotebookSurface({
   // rejected by notebookLinkPath) or a failed read both resolve to null, which the
   // widget renders as its broken placeholder.
   const resolveImageSrc = useCallback(async (src: string) => {
-    const path = notebookLinkPath(src);
+    const path = notebookLinkPath(src, noteDir(selectedPathRef.current ?? ''));
     if (!path) return null;
     try {
       const asset = await readAsset(path);
@@ -901,6 +923,7 @@ export function NotebookSurface({
                     existsFile={existsFile}
                     resolveImageSrc={resolveImageSrc}
                     revalidateSignal={changeSignal}
+                    notePath={selectedPath ?? ''}
                     ariaLabel="Note"
                     onSearchOpenChange={setSearchOpen}
                   />
@@ -1136,35 +1159,6 @@ export function NotebookSurface({
       </FocusTrap>
     </div>
   );
-}
-
-export interface NotebookHref {
-  kind: 'note' | 'fragment' | 'external';
-  // For 'note': the notebook-relative path (no leading slash, e.g. "knowledge/areas/foo.md").
-  path?: string;
-  // For 'fragment': the bare anchor without '#'. For 'note': an optional anchor.
-  anchor?: string;
-  // For 'external': the original href.
-  href?: string;
-}
-
-// parseNotebookHref classifies a markdown link target. Root-absolute .md targets
-// are in-notebook navigation; '#...' is an in-page anchor; everything else
-// (http(s), mailto, relative) is external and opened in the browser.
-export function parseNotebookHref(href: string): NotebookHref {
-  const trimmed = href.trim();
-  if (trimmed.startsWith('#')) {
-    return { kind: 'fragment', anchor: trimmed.slice(1) };
-  }
-  if (trimmed.startsWith('/')) {
-    const hashIdx = trimmed.indexOf('#');
-    const pathPart = hashIdx === -1 ? trimmed : trimmed.slice(0, hashIdx);
-    const anchor = hashIdx === -1 ? undefined : trimmed.slice(hashIdx + 1);
-    if (pathPart.toLowerCase().endsWith('.md')) {
-      return { kind: 'note', path: pathPart.replace(/^\/+/, ''), anchor };
-    }
-  }
-  return { kind: 'external', href: trimmed };
 }
 
 function basename(path: string): string {

--- a/app/src/components/notebook/LiveMarkdownEditor.tsx
+++ b/app/src/components/notebook/LiveMarkdownEditor.tsx
@@ -17,6 +17,7 @@ import { formattingKeymap } from './formatting';
 import { frontmatterCard } from './frontmatterCard';
 import { imageWidget } from './imageWidget';
 import { liveMarkdownPreview } from './liveMarkdownPreview';
+import { noteDir } from './linkResolver';
 import { markdownTables } from './tableWidget';
 import { computeMinimalEdit } from './minimalEdit';
 
@@ -80,6 +81,9 @@ interface LiveMarkdownEditorProps {
   // "missing" verdicts so a link to a just-created note re-checks. (A change counter,
   // not data — only its identity change matters.)
   revalidateSignal?: number;
+  // Root-relative path of the note being edited, used to resolve bare-relative link
+  // targets against its directory. Defaults to '' (the notebook root).
+  notePath?: string;
   ariaLabel?: string;
   autoFocus?: boolean;
   // Called with the new open state whenever the in-editor search panel opens or
@@ -173,6 +177,7 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
   existsFile,
   resolveImageSrc,
   revalidateSignal,
+  notePath,
   ariaLabel,
   autoFocus,
   onSearchOpenChange,
@@ -234,13 +239,13 @@ export const LiveMarkdownEditor = forwardRef<LiveMarkdownEditorHandle, LiveMarkd
       markdownTables(),
       imageWidget({ resolveSrc: resolveImageSrc }),
       liveMarkdownPreview({ onFollowLink }),
-      brokenLinks({ existsFile }),
+      brokenLinks({ existsFile, baseDir: noteDir(notePath ?? '') }),
       search({ top: true }),
       keymap.of(macSearchKeymap),
       formattingKeymap(),
       editorTheme,
     ],
-    [onFollowLink, existsFile, resolveImageSrc],
+    [onFollowLink, existsFile, resolveImageSrc, notePath],
   );
 
   // When the notebook changed on disk, ask the broken-link checker to re-verify any

--- a/app/src/components/notebook/brokenLinks.test.ts
+++ b/app/src/components/notebook/brokenLinks.test.ts
@@ -16,9 +16,9 @@ interface Mark {
   class?: string;
 }
 
-function marksFor(doc: string, missing: (path: string) => boolean): Mark[] {
+function marksFor(doc: string, baseDir: string, missing: (path: string) => boolean): Mark[] {
   const out: Mark[] = [];
-  const iter = brokenLinkDecorations(stateOf(doc), missing).iter();
+  const iter = brokenLinkDecorations(stateOf(doc), baseDir, missing).iter();
   while (iter.value) {
     out.push({ from: iter.from, to: iter.to, class: (iter.value.spec as { class?: string }).class });
     iter.next();
@@ -27,31 +27,31 @@ function marksFor(doc: string, missing: (path: string) => boolean): Mark[] {
 }
 
 describe('notebookLinkPath', () => {
-  it('resolves a root-absolute note link to its path', () => {
-    expect(notebookLinkPath('/knowledge/areas/foo.md')).toBe('/knowledge/areas/foo.md');
+  it('resolves a root-absolute note link to its (no-leading-slash) path', () => {
+    expect(notebookLinkPath('/knowledge/areas/foo.md', '')).toBe('knowledge/areas/foo.md');
   });
 
-  it('resolves a bare (relative) note link unchanged', () => {
-    expect(notebookLinkPath('knowledge/areas/foo.md')).toBe('knowledge/areas/foo.md');
+  it('resolves a bare relative link inside a note in a subdirectory against that directory (behavior change: this used to require a leading slash and was otherwise treated as external)', () => {
+    expect(notebookLinkPath('sibling.md', 'knowledge/areas')).toBe('knowledge/areas/sibling.md');
   });
 
   it('drops the #fragment and ?query tail (they address within a note)', () => {
-    expect(notebookLinkPath('/knowledge/foo.md#section')).toBe('/knowledge/foo.md');
-    expect(notebookLinkPath('/knowledge/foo.md?v=2')).toBe('/knowledge/foo.md');
+    expect(notebookLinkPath('/knowledge/foo.md#section', '')).toBe('knowledge/foo.md');
+    expect(notebookLinkPath('/knowledge/foo.md?v=2', '')).toBe('knowledge/foo.md');
   });
 
   it('never flags an external URL', () => {
-    expect(notebookLinkPath('http://example.com')).toBeNull();
-    expect(notebookLinkPath('https://example.com/x')).toBeNull();
-    expect(notebookLinkPath('mailto:a@b.com')).toBeNull();
-    expect(notebookLinkPath('file:///etc/hosts')).toBeNull();
-    expect(notebookLinkPath('//cdn.example.com/x')).toBeNull();
+    expect(notebookLinkPath('http://example.com', '')).toBeNull();
+    expect(notebookLinkPath('https://example.com/x', '')).toBeNull();
+    expect(notebookLinkPath('mailto:a@b.com', '')).toBeNull();
+    expect(notebookLinkPath('file:///etc/hosts', '')).toBeNull();
+    expect(notebookLinkPath('//cdn.example.com/x', '')).toBeNull();
   });
 
   it('never flags a pure in-document anchor or an empty href', () => {
-    expect(notebookLinkPath('#section')).toBeNull();
-    expect(notebookLinkPath('')).toBeNull();
-    expect(notebookLinkPath('   ')).toBeNull();
+    expect(notebookLinkPath('#section', '')).toBeNull();
+    expect(notebookLinkPath('', '')).toBeNull();
+    expect(notebookLinkPath('   ', '')).toBeNull();
   });
 });
 
@@ -61,33 +61,44 @@ describe('notebookLinkPaths', () => {
       'See [a](/knowledge/a.md) and [b](https://x.com) and [c](/knowledge/c.md).',
       'Also [again](/knowledge/a.md) and the [top](#intro).',
     ].join('\n');
-    expect(notebookLinkPaths(stateOf(doc)).sort()).toEqual(['/knowledge/a.md', '/knowledge/c.md']);
+    expect(notebookLinkPaths(stateOf(doc), '').sort()).toEqual(['knowledge/a.md', 'knowledge/c.md']);
   });
 
   it('returns nothing for a document with no in-notebook links', () => {
-    expect(notebookLinkPaths(stateOf('Just [external](https://x.com) here.'))).toEqual([]);
+    expect(notebookLinkPaths(stateOf('Just [external](https://x.com) here.'), '')).toEqual([]);
   });
 });
 
 describe('brokenLinkDecorations', () => {
   it('flags exactly the links whose target is reported missing', () => {
     const doc = 'See [gone](/knowledge/gone.md) and [here](/knowledge/here.md).';
-    const missing = (p: string) => p === '/knowledge/gone.md';
-    const marks = marksFor(doc, missing);
+    const missing = (p: string) => p === 'knowledge/gone.md';
+    const marks = marksFor(doc, '', missing);
     expect(marks).toHaveLength(1);
     expect(marks[0].class).toBe('cm-md-link-broken');
     // The mark spans the whole [text](url) link, not just its text.
     expect(doc.slice(marks[0].from, marks[0].to)).toBe('[gone](/knowledge/gone.md)');
   });
 
+  it('existence-checks a bare-relative link against the linking note\'s own directory', () => {
+    // A note at knowledge/areas/note.md linking bare `sibling.md` must check
+    // knowledge/areas/sibling.md, not sibling.md at the root — this is the behavior
+    // change PR8 makes.
+    const doc = 'See [sib](sibling.md).';
+    const missingAtRoot = (p: string) => p === 'sibling.md';
+    expect(marksFor(doc, 'knowledge/areas', missingAtRoot)).toHaveLength(0);
+    const missingAtSiblingDir = (p: string) => p === 'knowledge/areas/sibling.md';
+    expect(marksFor(doc, 'knowledge/areas', missingAtSiblingDir)).toHaveLength(1);
+  });
+
   it('flags nothing when every target exists (the predicate reports none missing)', () => {
     const doc = 'See [a](/knowledge/a.md) and [b](/knowledge/b.md).';
-    expect(marksFor(doc, () => false)).toHaveLength(0);
+    expect(marksFor(doc, '', () => false)).toHaveLength(0);
   });
 
   it('never flags an external link even if the predicate would match its raw href', () => {
     const doc = 'Read [docs](https://example.com/x).';
     // notebookLinkPath returns null for the URL, so the predicate is never consulted.
-    expect(marksFor(doc, () => true)).toHaveLength(0);
+    expect(marksFor(doc, '', () => true)).toHaveLength(0);
   });
 });

--- a/app/src/components/notebook/brokenLinks.ts
+++ b/app/src/components/notebook/brokenLinks.ts
@@ -17,6 +17,7 @@ import {
   ViewPlugin,
   type ViewUpdate,
 } from '@codemirror/view';
+import { resolveNotebookLink } from './linkResolver';
 
 // The outcome of an existence check — the shape of the daemon's FsExistsResult,
 // declared structurally so this module does not depend on the socket hook.
@@ -31,6 +32,9 @@ export interface BrokenLinkOptions {
   // to resolve) leaves the link UNFLAGGED — a link is only ever flagged broken on a
   // conclusive "does not exist", never on an inconclusive check.
   existsFile?: (path: string) => Promise<ExistsCheck>;
+  // The editing note's directory, root-relative ('' at the root) — bare-relative
+  // link targets resolve against this before the existence check.
+  baseDir: string;
 }
 
 // Fired when an async existence check resolves: rebuild so a now-known result paints.
@@ -50,31 +54,28 @@ const BROKEN = Decoration.mark({
 // Resolve a link href to the notebook path whose existence decides whether it is
 // broken, or null when the href is not an in-notebook note reference (and so must
 // never be flagged): an external URL (has a scheme like http:/mailto:), a protocol-
-// relative URL, a pure in-document anchor (#section), or empty. The `#fragment` and
-// `?query` tails are dropped — they address a spot within a note, not a file. Both
-// root-absolute (`/knowledge/x.md`) and bare (`knowledge/x.md`) forms resolve the
-// same, mirroring the daemon's root-relative path handling.
-export function notebookLinkPath(href: string): string | null {
-  const trimmed = href.trim();
-  if (!trimmed) return null;
-  if (trimmed.startsWith('#')) return null; // in-document anchor
-  if (trimmed.startsWith('//')) return null; // protocol-relative URL
-  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null; // http:, mailto:, file:, …
-  const path = trimmed.split('#')[0].split('?')[0].trim();
-  return path || null;
+// relative URL, a pure in-document anchor (#section), or empty. A bare-relative
+// target (`sibling.md`) resolves against `baseDir` — the editing note's own
+// directory — before the check; a root-absolute target (`/knowledge/x.md`) ignores
+// it. Resolution (including `..` and the `#fragment`/`?query` tails) happens here,
+// frontend-side, via the shared resolver — the daemon itself still only ever sees
+// and interprets paths root-relative.
+export function notebookLinkPath(href: string, baseDir: string): string | null {
+  const resolved = resolveNotebookLink(href, baseDir);
+  return resolved.kind === 'note' ? resolved.path : null;
 }
 
 // The distinct in-notebook link paths in the document — the set whose existence
 // decides broken-ness. Pure over the parsed state (no view, no daemon) so the
 // plugin's "what do I need to check" logic is unit-testable headlessly.
-export function notebookLinkPaths(state: EditorState): string[] {
+export function notebookLinkPaths(state: EditorState, baseDir: string): string[] {
   const seen = new Set<string>();
   syntaxTree(state).iterate({
     enter: (node) => {
       if (node.name !== 'Link') return;
       const url = node.node.getChild('URL');
       const href = url ? state.doc.sliceString(url.from, url.to) : '';
-      const path = notebookLinkPath(href);
+      const path = notebookLinkPath(href, baseDir);
       if (path) seen.add(path);
     },
   });
@@ -87,6 +88,7 @@ export function notebookLinkPaths(state: EditorState): string[] {
 // shape of liveMarkdownPreview.buildDecorations and frontmatterCardDecorations.
 export function brokenLinkDecorations(
   state: EditorState,
+  baseDir: string,
   missing: (path: string) => boolean,
 ): DecorationSet {
   const decos: Range<Decoration>[] = [];
@@ -95,15 +97,15 @@ export function brokenLinkDecorations(
       if (node.name !== 'Link') return;
       const url = node.node.getChild('URL');
       const href = url ? state.doc.sliceString(url.from, url.to) : '';
-      const path = notebookLinkPath(href);
+      const path = notebookLinkPath(href, baseDir);
       if (path && missing(path)) decos.push(BROKEN.range(node.from, node.to));
     },
   });
   return Decoration.set(decos, true);
 }
 
-export function brokenLinks(options: BrokenLinkOptions = {}): Extension {
-  const { existsFile } = options;
+export function brokenLinks(options: BrokenLinkOptions): Extension {
+  const { existsFile, baseDir } = options;
 
   const plugin = ViewPlugin.fromClass(
     class {
@@ -138,10 +140,10 @@ export function brokenLinks(options: BrokenLinkOptions = {}): Extension {
 
       private build(view: EditorView): DecorationSet {
         if (!existsFile) return Decoration.none;
-        const paths = notebookLinkPaths(view.state);
+        const paths = notebookLinkPaths(view.state, baseDir);
         const toCheck = paths.filter((p) => !this.cache.has(p) && !this.pending.has(p));
         if (toCheck.length) this.scheduleChecks(view, toCheck);
-        return brokenLinkDecorations(view.state, (p) => this.cache.get(p) === false);
+        return brokenLinkDecorations(view.state, baseDir, (p) => this.cache.get(p) === false);
       }
 
       private scheduleChecks(view: EditorView, paths: string[]) {

--- a/app/src/components/notebook/imageWidget.ts
+++ b/app/src/components/notebook/imageWidget.ts
@@ -16,7 +16,6 @@ import { ensureSyntaxTree } from '@codemirror/language';
 import { type EditorState, type Extension, type Range, StateField } from '@codemirror/state';
 import { Decoration, type DecorationSet, EditorView, WidgetType } from '@codemirror/view';
 import type { SyntaxNode } from '@lezer/common';
-import { notebookLinkPath } from './brokenLinks';
 
 export interface ImageTarget {
   lineFrom: number;
@@ -26,9 +25,11 @@ export interface ImageTarget {
 }
 
 export interface ImageWidgetOptions {
-  // Resolve a notebook-relative src (already stripped of #fragment/?query) to a
-  // displayable src (typically a data: URI), or null when it can't be resolved.
-  // Absent, a null resolution, or a rejection all render the broken placeholder.
+  // Resolve a raw, not-yet-normalized notebook-relative src (still needs #fragment/
+  // ?query stripping and baseDir-relative resolution — the caller does both, via
+  // linkResolver) to a displayable src (typically a data: URI), or null when it
+  // can't be resolved. Absent, a null resolution, or a rejection all render the
+  // broken placeholder.
   resolveSrc?: (src: string) => Promise<string | null>;
 }
 
@@ -173,16 +174,19 @@ class ImageWidget extends WidgetType {
       return container;
     }
 
-    const path = notebookLinkPath(src);
-    if (!path || !this.resolveSrc) {
+    // Not a direct src: hand the raw (still baseDir-relative) src straight to
+    // resolveSrc, which is the ONE place that resolves it (against the note's
+    // directory) — resolving here too would double-apply and mis-clamp a `..`
+    // src before the real baseDir is known.
+    if (!this.resolveSrc) {
       renderBroken();
       return container;
     }
 
-    let pending = this.cache.get(path);
+    let pending = this.cache.get(src);
     if (!pending) {
-      pending = this.resolveSrc(path).catch(() => null);
-      this.cache.set(path, pending);
+      pending = this.resolveSrc(src).catch(() => null);
+      this.cache.set(src, pending);
     }
     pending.then((resolved) => {
       // The widget's DOM may already have been torn down (navigation, re-render, or

--- a/app/src/components/notebook/linkResolver.test.ts
+++ b/app/src/components/notebook/linkResolver.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { headingSlug, noteDir, resolveNotebookLink } from './linkResolver';
+
+describe('resolveNotebookLink', () => {
+  it('resolves a bare relative link against the linking note\'s directory', () => {
+    expect(resolveNotebookLink('foo.md', 'knowledge/areas')).toEqual({
+      kind: 'note',
+      path: 'knowledge/areas/foo.md',
+      anchor: undefined,
+    });
+  });
+
+  it('climbs a directory with ..', () => {
+    expect(resolveNotebookLink('../bar.md', 'knowledge/areas')).toEqual({
+      kind: 'note',
+      path: 'knowledge/bar.md',
+      anchor: undefined,
+    });
+  });
+
+  it('clamps at the notebook root when .. climbs past it', () => {
+    expect(resolveNotebookLink('../../../x.md', 'a')).toEqual({
+      kind: 'note',
+      path: 'x.md',
+      anchor: undefined,
+    });
+  });
+
+  it('treats a leading slash as root-relative, ignoring baseDir', () => {
+    expect(resolveNotebookLink('/abs.md', 'knowledge/areas')).toEqual({
+      kind: 'note',
+      path: 'abs.md',
+      anchor: undefined,
+    });
+  });
+
+  it('decodes a fragment-only href', () => {
+    expect(resolveNotebookLink('#Sec%20One', 'knowledge/areas')).toEqual({
+      kind: 'fragment',
+      anchor: 'Sec One',
+    });
+  });
+
+  it('classifies a scheme URL as external', () => {
+    expect(resolveNotebookLink('https://example.com', '').kind).toBe('external');
+  });
+
+  it('classifies a protocol-relative URL as external', () => {
+    expect(resolveNotebookLink('//example.com/x', '').kind).toBe('external');
+  });
+
+  it('classifies mailto as external', () => {
+    expect(resolveNotebookLink('mailto:someone@example.com', '').kind).toBe('external');
+  });
+
+  it('splits a query and anchor off a note link', () => {
+    expect(resolveNotebookLink('foo.md?x=1#sec', 'knowledge/areas')).toEqual({
+      kind: 'note',
+      path: 'knowledge/areas/foo.md',
+      anchor: 'sec',
+    });
+  });
+
+  it('treats an empty href as external empty', () => {
+    expect(resolveNotebookLink('', 'knowledge/areas')).toEqual({ kind: 'external', href: '' });
+    expect(resolveNotebookLink('   ', 'knowledge/areas')).toEqual({ kind: 'external', href: '' });
+  });
+});
+
+describe('noteDir', () => {
+  it('returns the directory of a nested note path', () => {
+    expect(noteDir('knowledge/areas/foo.md')).toBe('knowledge/areas');
+  });
+
+  it('returns empty for a root-level note path', () => {
+    expect(noteDir('foo.md')).toBe('');
+  });
+});
+
+describe('headingSlug', () => {
+  it('lowercases and strips punctuation', () => {
+    expect(headingSlug('My Heading!')).toBe('my-heading');
+  });
+
+  it('collapses multiple spaces into one hyphen', () => {
+    expect(headingSlug('A   B')).toBe('a-b');
+  });
+});

--- a/app/src/components/notebook/linkResolver.ts
+++ b/app/src/components/notebook/linkResolver.ts
@@ -1,0 +1,82 @@
+// Single resolver for markdown link hrefs inside the notebook editor and its broken-
+// link checker, replacing the two resolvers that used to disagree (one required a
+// leading '/' + '.md' for in-notebook links, the other accepted bare root-relative
+// paths — neither resolved against the linking note's own directory). The daemon
+// always interprets fs paths root-relative (fsdoc cleanRel), so directory-relative
+// resolution has to happen here, before a path ever reaches the daemon.
+
+export type ResolvedLink =
+  | { kind: 'note'; path: string; anchor?: string } // path root-relative, no leading slash, normalized
+  | { kind: 'fragment'; anchor: string } // same-note anchor, '#' stripped, URI-decoded
+  | { kind: 'external'; href: string };
+
+const SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+
+function decodeAnchor(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+// Split '#anchor' (kept, decoded) and '?query' (dropped) off a path, in that order —
+// an anchor always follows any query in a URL, so a literal '?' inside the anchor
+// text (rare, but possible after decoding) is preserved rather than mis-split.
+function stripAnchorAndQuery(href: string): { path: string; anchor?: string } {
+  const hashIdx = href.indexOf('#');
+  const path = hashIdx === -1 ? href : href.slice(0, hashIdx);
+  const anchor = hashIdx === -1 ? undefined : decodeAnchor(href.slice(hashIdx + 1));
+  const queryIdx = path.indexOf('?');
+  return { path: queryIdx === -1 ? path : path.slice(0, queryIdx), anchor };
+}
+
+// Join and normalize '.'/'..' segments against a base. A '..' that would climb above
+// the notebook root clamps there instead of escaping it or throwing — matching the
+// daemon's cleanRel, since the resolved path is always handed to the daemon next.
+function normalizeJoin(baseDir: string, path: string): string {
+  const parts: string[] = [];
+  for (const segment of `${baseDir}/${path}`.split('/')) {
+    if (segment === '' || segment === '.') continue;
+    if (segment === '..') parts.pop();
+    else parts.push(segment);
+  }
+  return parts.join('/');
+}
+
+// Directory of a root-relative note path; '' for a root-level path.
+export function noteDir(notePath: string): string {
+  const idx = notePath.lastIndexOf('/');
+  return idx === -1 ? '' : notePath.slice(0, idx);
+}
+
+// GitHub-style anchor slug of a heading's text: lowercase, punctuation stripped
+// (keep letters/digits/space/hyphen), spaces → '-'.
+export function headingSlug(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9 -]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}
+
+// baseDir: the current note's directory, root-relative, '' at the root
+// (e.g. 'knowledge/areas' for note 'knowledge/areas/foo.md').
+export function resolveNotebookLink(href: string, baseDir: string): ResolvedLink {
+  const trimmed = href.trim();
+  if (!trimmed) return { kind: 'external', href: '' };
+  if (trimmed.startsWith('#')) {
+    return { kind: 'fragment', anchor: decodeAnchor(trimmed.slice(1)) };
+  }
+  if (trimmed.startsWith('//') || SCHEME.test(trimmed)) {
+    return { kind: 'external', href: trimmed };
+  }
+
+  const { path, anchor } = stripAnchorAndQuery(trimmed);
+  const resolved = path.startsWith('/')
+    ? normalizeJoin('', path.replace(/^\/+/, ''))
+    : normalizeJoin(baseDir, path);
+
+  if (!resolved) return { kind: 'external', href: '' };
+  return { kind: 'note', path: resolved, anchor };
+}

--- a/app/src/hooks/useUiAutomationBridge.ts
+++ b/app/src/hooks/useUiAutomationBridge.ts
@@ -1130,21 +1130,36 @@ async function dragSplitDivider(
 }
 
 function clickElement(element: HTMLElement) {
-  element.dispatchEvent(new MouseEvent('mousedown', {
+  clickElementWithModifiers(element);
+}
+
+interface ClickModifiers {
+  meta?: boolean;
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+}
+
+// Like clickElement, but dispatches at the element's center with optional
+// modifier keys (for mod-click link navigation etc).
+function clickElementWithModifiers(element: HTMLElement, modifiers?: ClickModifiers) {
+  const rect = element.getBoundingClientRect();
+  const clientX = rect.x + rect.width / 2;
+  const clientY = rect.y + rect.height / 2;
+  const init: MouseEventInit = {
     bubbles: true,
     cancelable: true,
     view: window,
-  }));
-  element.dispatchEvent(new MouseEvent('mouseup', {
-    bubbles: true,
-    cancelable: true,
-    view: window,
-  }));
-  element.dispatchEvent(new MouseEvent('click', {
-    bubbles: true,
-    cancelable: true,
-    view: window,
-  }));
+    clientX,
+    clientY,
+    metaKey: modifiers?.meta ?? false,
+    ctrlKey: modifiers?.ctrl ?? false,
+    shiftKey: modifiers?.shift ?? false,
+    altKey: modifiers?.alt ?? false,
+  };
+  element.dispatchEvent(new MouseEvent('mousedown', init));
+  element.dispatchEvent(new MouseEvent('mouseup', init));
+  element.dispatchEvent(new MouseEvent('click', init));
 }
 
 function setInputValue(element: HTMLInputElement, value: string) {
@@ -1629,6 +1644,37 @@ export function useUiAutomationBridge({
         return captureDomScreenshotData(
           typeof payload.selector === 'string' ? payload.selector : undefined,
         );
+      case 'dom_click': {
+        const selector = typeof payload.selector === 'string' ? payload.selector : null;
+        if (!selector) throw new Error('dom_click requires selector');
+        const element = document.querySelector(selector);
+        if (!(element instanceof HTMLElement)) {
+          throw new Error(`dom_click selector not found in DOM: ${selector}`);
+        }
+        const modifiers = (payload.modifiers ?? {}) as ClickModifiers;
+        clickElementWithModifiers(element, modifiers);
+        await settleUi(2);
+        return { clicked: true, bounds: rectSnapshot(element) };
+      }
+      case 'dom_type': {
+        const selector = typeof payload.selector === 'string' ? payload.selector : null;
+        const text = typeof payload.text === 'string' ? payload.text : null;
+        if (!selector) throw new Error('dom_type requires selector');
+        if (text === null) throw new Error('dom_type requires text');
+        const element = document.querySelector(selector);
+        if (!element) {
+          throw new Error(`dom_type selector not found in DOM: ${selector}`);
+        }
+        if (element instanceof HTMLInputElement) {
+          setInputValue(element, text);
+        } else if (element instanceof HTMLTextAreaElement) {
+          setControlValue(element, text);
+        } else {
+          throw new Error(`dom_type target is not an input or textarea: ${selector}`);
+        }
+        await settleUi(2);
+        return { typed: text };
+      }
       case 'get_window_bounds': {
         if (!isTauri()) {
           return null;

--- a/app/test-harness/harnesses/NotebookBrowserHarness.tsx
+++ b/app/test-harness/harnesses/NotebookBrowserHarness.tsx
@@ -48,7 +48,10 @@ const TREE: Record<string, FsEntry[]> = {
     { path: 'knowledge/index.md', name: 'index.md', isDir: false, size: 128 },
     { path: 'knowledge/areas', name: 'areas', isDir: true, size: 0 },
   ],
-  'knowledge/areas': [{ path: 'knowledge/areas/foo.md', name: 'foo.md', isDir: false, size: 30 }],
+  'knowledge/areas': [
+    { path: 'knowledge/areas/foo.md', name: 'foo.md', isDir: false, size: 30 },
+    { path: 'knowledge/areas/bar.md', name: 'bar.md', isDir: false, size: 20 },
+  ],
 };
 
 // A deliberately long body so the second/third headings sit well below the fold —
@@ -82,6 +85,23 @@ ${INDEX_FILLER}
 ![gone](assets/missing.png)
 `,
   'notes.txt': 'Plain text scratch file.\nNo markdown affordances here — just edit and autosave.\n',
+  // Fixture for PR8's link-resolver e2e coverage: a bare-relative link to a sibling
+  // note (resolves against foo.md's own directory, knowledge/areas — not the root),
+  // and a same-note #heading link whose target sits well below the fold.
+  'knowledge/areas/foo.md': `# Foo area
+
+A [sibling link](bar.md) resolved bare-relative, and a jump to [Down Below](#down-below).
+
+${INDEX_FILLER}
+
+## Down Below
+
+${INDEX_FILLER}
+`,
+  'knowledge/areas/bar.md': `# Bar area
+
+Sibling of foo, reached via a bare-relative link.
+`,
   'fences.md': `# Fences
 
 A fenced code block, a blockquote, and a horizontal rule.


### PR DESCRIPTION
## Summary
- Relative links between notes now resolve against the linking note's own folder instead of being treated as external URLs, and `#heading` links jump the editor to that heading in the same note.
- Centralizes href classification (note/fragment/external) and directory-relative path resolution (with root-clamped `..` handling) into `resolveNotebookLink`, shared by broken-link detection and NotebookSurface's link-following.
- Fixes a double-resolution bug in `imageWidget` where an image's raw `src` was pre-resolved against an implicit empty baseDir before the real baseDir resolution ran downstream, mis-clamping `..`-relative image paths.

Out of scope: cross-note anchor scrolling (mod-click a link to another note's heading) — `loadFile` is fire-and-forget with no return value and no non-invasive way to know when the target note finishes loading, so scrolling to a heading in a *different* note is left for a follow-up.

Part of the notebook editor polish stack; based on origin/main (post PR7 #562).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/daemon ./internal/protocol`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec vitest run` (167 files / 1777 tests)
- [ ] figgyster review
- [ ] CI green