### PR TITLE
feat(plugin): inject attn guidance into OpenCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-15]
 
 ### Added
+- **OpenCode sessions now receive attn's launch guidance.** Ordinary sessions
+  get their workspace context plus workflow and ticket instructions; OpenCode
+  chiefs get Notebook guidance. Promotion, demotion, and resume refresh that
+  guidance without changing the native OpenCode conversation or modifying the
+  user's repository and global OpenCode configuration.
 - Markdown tiles can now be annotated: select text to comment, redline, or apply
   quick-labels (with keyboard shortcuts), add document-wide comments, and review
   everything in a sidebar. Annotations survive file edits by re-anchoring to the

--- a/docs/plans/2026-04-16-plugin-system.md
+++ b/docs/plans/2026-04-16-plugin-system.md
@@ -66,7 +66,7 @@ These were proposed in conversation but not explicitly confirmed:
 5. **SDK shape and timing.** User pushed back on designing SDK top-down. **Revised approach: the first real plugins are written against raw JSON-RPC first. After the provider path proved out, extract a small SDK from those patterns; let richer plugin surfaces wait until their concrete implementations exist.** The protocol must still stay ergonomic enough to consume without a wrapper.
 6. **Manifest format.** Probably TOML — minimal, human-readable, Bun ecosystem-neutral. Alternatives: JSON, YAML. Not confirmed.
 7. **Install sources.** Settings accepts a pasted Git repository URL or local directory. The CLI currently keeps `--path <dir>` for local development; a Git-source CLI form is deferred until it has a concrete use case.
-8. **API versioning discipline.** Installed plugin manifests and the socket hello use a strict, matching `attn_api_version`. Version 2 introduced optional delegated `model` and `effort` fields on the driver launch request, so daemon and plugin agree on the expanded driver contract before launch. A wire-shape change must bump this version and update every bundled manifest/client; the daemon-client protocol version changes separately only when its own WebSocket schema changes.
+8. **API versioning discipline.** Installed plugin manifests and the socket hello use a strict, matching `attn_api_version`. Version 3 adds the optional attn-composed `instructions` bundle to driver launch requests (version 2 introduced delegated `model` and `effort`), so daemon and plugin agree on the expanded contract before launch. A wire-shape change must bump this version and update every bundled manifest/client; the daemon-client protocol version changes separately only when its own WebSocket schema changes.
 9. **Socket coexistence.** Existing one-message-per-connection hook protocol (claude hooks, whatever remains of the old pi plan's pattern) must keep working. Proposed: detect JSON-RPC handshake by first-message shape and switch the connection's mode. Not confirmed.
 10. **JSON-RPC framing.** Proposed: newline-delimited JSON. Alternative: LSP-style Content-Length headers. Unix socket + JSON makes newline-delimited the simpler choice.
 
@@ -185,7 +185,7 @@ Extend the daemon's existing unix socket handler to recognize a JSON-RPC 2.0 han
 ```json
 → {"jsonrpc":"2.0","id":1,"method":"hello","params":{
     "name":"example-driver","version":"0.1.0",
-    "attn_api_version":2}}
+   "attn_api_version":3}}
 ← {"jsonrpc":"2.0","id":1,"result":{"ok":true}}
 ```
 
@@ -194,8 +194,8 @@ Extend the daemon's existing unix socket handler to recognize a JSON-RPC 2.0 han
 | Method                        | Direction       | Purpose                                                                 |
 |-------------------------------|-----------------|-------------------------------------------------------------------------|
 | `driver.register`             | plugin → attn   | Declare `{ agent, capabilities }`                                       |
-| `driver.spawn`                | attn → plugin   | Request `{ session_id, run_id, ... }`, returning `{ argv, env, cwd }` for a new session |
-| `driver.resume`               | attn → plugin   | Same, for resume; receives a fresh `run_id` for the replacement PTY      |
+| `driver.spawn`                | attn → plugin   | Request `{ session_id, run_id, ..., instructions? }`, returning `{ argv, env, cwd }` for a new session |
+| `driver.resume`               | attn → plugin   | Same, for resume; receives a fresh `run_id` and freshly composed optional instructions for the replacement PTY |
 | `driver.session_closed`       | attn → plugin   | `{ session_id, run_id, reason, exit_code?, signal? }`; dispose resources for the ended PTY run |
 | `session.report_state`        | plugin → attn   | `{ session_id, run_id, seq, state }`; stale or ended-run status is discarded |
 | `session.report_stop`         | plugin → attn   | `{ session_id, run_id, seq, verdict }`; classification reuses the `seq` assigned when stop was observed |
@@ -238,7 +238,7 @@ Manifest (`attn-plugin.toml` at repo root):
 ```toml
 name = "example-driver"
 version = "0.1.0"
-attn_api_version = 2
+attn_api_version = 3
 description = "Example external coding agent driver for attn"
 
 [plugin]

--- a/docs/plans/2026-07-15-opencode-launch-instructions.md
+++ b/docs/plans/2026-07-15-opencode-launch-instructions.md
@@ -1,0 +1,36 @@
+# OpenCode launch instructions
+
+## Why
+
+OpenCode sessions launched through a plugin driver currently bypass attn's built-in
+workspace, workflow, ticket, and chief guidance. Transport one attn-owned bundle
+through the generic driver contract and let the OpenCode plugin install it as a
+private per-run instruction file.
+
+## Alignment
+
+- Core composes the exact existing `hooks.AgentInstructions` or
+  `hooks.ChiefGuidance` text; plugins do not reinterpret policy.
+- Ordinary sessions get an explicit pre-persistence workspace checkout. A failed
+  launch removes only a checkout created for that attempt.
+- OpenCode loads a private per-run system-transform plugin through
+  `OPENCODE_CONFIG_CONTENT`, preserving inherited config and rereading the
+  instruction file for every prompt, including resumed conversations.
+- Chief promotion and demotion reload only plugin drivers advertising both
+  `launch_instructions` and `resume`. The daemon reconstructs the plugin command
+  before killing the live worker.
+- Resume always recomposes current guidance, so neither workspace revisions nor
+  chief role are frozen in persisted metadata.
+- Live refresh during an already-running turn and a reusable SDK file helper are
+  deferred.
+
+## Execution
+
+- [x] Add the generic capability and instruction-bundle wire contract; bump plugin API.
+- [x] Prepare workspace/chief instructions before plugin spawn, with safe checkout rollback.
+- [x] Store private OpenCode instruction files and merge them into launch config.
+- [x] Support capability-driven plugin chief reload while preserving launch metadata and flags.
+- [x] Add focused daemon, registry, launcher, and compatibility tests.
+- [x] Update user-facing and plugin-driver documentation.
+- [x] Run automated checks and the required non-prod live-app scenarios.
+- [ ] Open the PR, address Figgyster review, and merge only after approval.

--- a/examples/plugins/worktree-deps-hook/attn-plugin.toml
+++ b/examples/plugins/worktree-deps-hook/attn-plugin.toml
@@ -1,6 +1,6 @@
 name = "worktree-deps-hook"
 version = "0.1.0"
-attn_api_version = 2
+attn_api_version = 3
 description = "Example worktree after-create hook that installs JavaScript dependencies"
 
 [plugin]

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -157,16 +157,15 @@ func (d *Daemon) typeDoorbell(sessionID, prompt string) error {
 // check and the notebook-root resolution are independent of the sessions table.
 //
 // It is intentionally conservative: it assigns only on a genuine first launch
-// (existingSession == nil, never a reload/respawn) of a guidance-capable agent
-// (claude/codex — shells and plugin agents have no guidance launch path) and only
-// when no chief exists yet. A create-as-chief request while a chief is already
+// (existingSession == nil, never a reload/respawn) of a guidance-capable built-in
+// or plugin agent and only when no chief exists yet. A create-as-chief request while a chief is already
 // live is logged and ignored, never a silent role transfer. Returns whether it
 // assigned the role so the caller can roll it back if the launch then fails.
 func (d *Daemon) maybeAssignChiefOnSpawn(sessionID, agent string, requested bool, existingSession *protocol.Session) bool {
 	if !requested || existingSession != nil || d.store == nil {
 		return false
 	}
-	if !agentSupportsChiefReload(agent) {
+	if !d.agentSupportsChiefGuidance(agent) {
 		d.logf("create-as-chief: agent %q for session %s has no chief-guidance launch path; ignoring", agent, sessionID)
 		return false
 	}
@@ -200,6 +199,18 @@ func (d *Daemon) handleSetChiefOfStaff(client *wsClient, msg *protocol.SetChiefO
 				fmt.Errorf("session not found: %s", sessionID),
 			)
 			return
+		}
+		if session := d.store.Get(sessionID); session != nil {
+			if driver, ok := d.ensurePluginRegistry().driver(string(session.Agent)); ok {
+				switch {
+				case !driver.Capabilities["launch_instructions"]:
+					d.sendChiefOfStaffResult(client, sessionID, true, previousSessionID, fmt.Errorf("agent %q cannot be chief of staff without launch_instructions capability", session.Agent))
+					return
+				case !driver.Capabilities["resume"]:
+					d.sendChiefOfStaffResult(client, sessionID, true, previousSessionID, fmt.Errorf("agent %q cannot apply chief guidance without resume capability", session.Agent))
+					return
+				}
+			}
 		}
 		if err := d.store.SetProfileRole(profileRoleChiefOfStaff, sessionID); err != nil {
 			d.sendChiefOfStaffResult(client, sessionID, true, previousSessionID, err)

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -189,6 +190,10 @@ func (d *Daemon) handleSetChiefOfStaff(client *wsClient, msg *protocol.SetChiefO
 	}
 
 	previousSessionID := d.chiefOfStaffSessionID()
+	roleChanged := previousSessionID != sessionID
+	if !msg.ChiefOfStaff {
+		roleChanged = previousSessionID == sessionID
+	}
 	if msg.ChiefOfStaff {
 		if !d.sessionExists(sessionID) {
 			d.sendChiefOfStaffResult(
@@ -212,6 +217,48 @@ func (d *Daemon) handleSetChiefOfStaff(client *wsClient, msg *protocol.SetChiefO
 				}
 			}
 		}
+	}
+
+	prepared := make([]*preparedPluginRoleReload, 0, 2)
+	preparedSessions := make(map[string]bool)
+	if roleChanged {
+		desiredRoles := map[string]bool{sessionID: msg.ChiefOfStaff}
+		if msg.ChiefOfStaff && previousSessionID != "" && previousSessionID != sessionID {
+			desiredRoles[previousSessionID] = false
+		}
+		ids := make([]string, 0, len(desiredRoles))
+		for id := range desiredRoles {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		for _, id := range ids {
+			reload, pluginSession, err := d.preparePluginRoleReload(id, desiredRoles[id])
+			if err != nil {
+				for i := len(prepared) - 1; i >= 0; i-- {
+					prepared[i].abort()
+				}
+				d.sendChiefOfStaffResult(client, sessionID, msg.ChiefOfStaff, previousSessionID, fmt.Errorf("prepare chief guidance reload for %s: %w", id, err))
+				return
+			}
+			if pluginSession {
+				preparedSessions[id] = true
+			}
+			if reload != nil {
+				prepared = append(prepared, reload)
+			}
+		}
+	}
+	abortPrepared := true
+	defer func() {
+		if !abortPrepared {
+			return
+		}
+		for i := len(prepared) - 1; i >= 0; i-- {
+			prepared[i].abort()
+		}
+	}()
+
+	if msg.ChiefOfStaff {
 		if err := d.store.SetProfileRole(profileRoleChiefOfStaff, sessionID); err != nil {
 			d.sendChiefOfStaffResult(client, sessionID, true, previousSessionID, err)
 			return
@@ -221,6 +268,14 @@ func (d *Daemon) handleSetChiefOfStaff(client *wsClient, msg *protocol.SetChiefO
 		return
 	}
 
+	var reloadErr error
+	for _, reload := range prepared {
+		if err := reload.execute(); err != nil && reloadErr == nil {
+			reloadErr = err
+		}
+	}
+	abortPrepared = false
+
 	d.broadcastSessionsUpdated()
 	// Reload the agent(s) whose chief status actually changed so the new status reaches
 	// the system prompt: ChiefGuidance is injected only at agent-launch, so a live
@@ -228,29 +283,27 @@ func (d *Daemon) handleSetChiefOfStaff(client *wsClient, msg *protocol.SetChiefO
 	// (kill + resume-respawn), so fire it ONLY on a real role change — a redundant
 	// toggle (re-assigning the current chief, or demoting a session that wasn't chief,
 	// which ClearProfileRole no-ops) must not kill+respawn an innocent agent.
-	// Resume-preserving, fire-and-forget; symmetric — assign injects the guidance,
-	// demote drops it.
-	roleChanged := previousSessionID != sessionID
-	if !msg.ChiefOfStaff {
-		// Demote: changed only if this session actually held the role.
-		roleChanged = previousSessionID == sessionID
-	}
+	// Plugin replacements are preflighted and completed before the success result;
+	// built-in replacements remain resume-preserving and asynchronous. The behavior
+	// is symmetric — assign injects the guidance, demote drops it.
 	if roleChanged {
 		newChiefSessionID := ""
 		if msg.ChiefOfStaff {
 			newChiefSessionID = sessionID
 		}
 		d.retargetChiefTicketDelivery(previousSessionID, newChiefSessionID)
-		go d.reloadSessionAgent(sessionID)
+		if !preparedSessions[sessionID] {
+			go d.reloadSessionAgent(sessionID)
+		}
 		// A role transfer (promote B while A still held it) demotes A via the
 		// single-holder upsert. Reload A too so the displaced chief drops the guidance
 		// now, not whenever it next restarts. Different id → different reload lock, so
 		// this runs concurrently with the promotion reload.
-		if msg.ChiefOfStaff && previousSessionID != "" {
+		if msg.ChiefOfStaff && previousSessionID != "" && !preparedSessions[previousSessionID] {
 			go d.reloadSessionAgent(previousSessionID)
 		}
 	}
-	d.sendChiefOfStaffResult(client, sessionID, msg.ChiefOfStaff, previousSessionID, nil)
+	d.sendChiefOfStaffResult(client, sessionID, msg.ChiefOfStaff, previousSessionID, reloadErr)
 }
 
 // retargetChiefTicketDelivery moves only the live delivery target. Durable role

--- a/internal/daemon/create_as_chief_test.go
+++ b/internal/daemon/create_as_chief_test.go
@@ -107,6 +107,25 @@ func TestCreateAsChiefIgnoredForShell(t *testing.T) {
 	}
 }
 
+func TestCreateAsChiefRejectsPluginWithoutLaunchInstructions(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(func() { _ = d.store.Close() })
+	d.ptyBackend = &fakeSpawnBackend{}
+	plugin, done := startPluginPipe(t, d, "fixture-plugin", nil)
+	defer func() {
+		_ = plugin.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, plugin, "fixture", map[string]bool{"resume": true})
+	client := newWorkspaceProtocolTestClient()
+
+	spawnForChiefTest(t, d, client, "ws-plugin", "sess-plugin", "fixture", true)
+	expectSpawnResult(t, client, "sess-plugin", false)
+	if got := d.chiefOfStaffSessionID(); got != "" {
+		t.Fatalf("chief role holder = %q, want empty", got)
+	}
+}
+
 // A spawn that fails after the role was assigned must roll the role back, so a
 // session that never launched never holds the chief role.
 func TestCreateAsChiefRolledBackOnSpawnFailure(t *testing.T) {

--- a/internal/daemon/plugin_driver.go
+++ b/internal/daemon/plugin_driver.go
@@ -32,15 +32,16 @@ type pluginDriverRegisterResult struct {
 }
 
 type pluginDriverSpawnParams struct {
-	SessionID     string          `json:"session_id"`
-	RunID         string          `json:"run_id"`
-	CWD           string          `json:"cwd"`
-	Label         string          `json:"label,omitempty"`
-	Yolo          bool            `json:"yolo,omitempty"`
-	Model         string          `json:"model,omitempty"`
-	Effort        string          `json:"effort,omitempty"`
-	InitialPrompt string          `json:"initial_prompt,omitempty"`
-	Metadata      json.RawMessage `json:"metadata,omitempty"`
+	SessionID     string                    `json:"session_id"`
+	RunID         string                    `json:"run_id"`
+	CWD           string                    `json:"cwd"`
+	Label         string                    `json:"label,omitempty"`
+	Yolo          bool                      `json:"yolo,omitempty"`
+	Model         string                    `json:"model,omitempty"`
+	Effort        string                    `json:"effort,omitempty"`
+	InitialPrompt string                    `json:"initial_prompt,omitempty"`
+	Metadata      json.RawMessage           `json:"metadata,omitempty"`
+	Instructions  *pluginLaunchInstructions `json:"instructions,omitempty"`
 }
 
 type pluginDriverSpawnResult struct {
@@ -156,14 +157,15 @@ func normalizePluginAgent(value string) string {
 
 func validatePluginDriverCapabilities(values map[string]bool) (map[string]bool, error) {
 	allowed := map[string]struct{}{
-		"resume":           {},
-		"yolo":             {},
-		"initial_prompt":   {},
-		"classifier":       {},
-		"state_reporting":  {},
-		"pending_approval": {},
-		"model_pin":        {},
-		"effort_pin":       {},
+		"resume":              {},
+		"yolo":                {},
+		"initial_prompt":      {},
+		"classifier":          {},
+		"state_reporting":     {},
+		"pending_approval":    {},
+		"model_pin":           {},
+		"effort_pin":          {},
+		"launch_instructions": {},
 	}
 	out := make(map[string]bool, len(values))
 	for name, enabled := range values {

--- a/internal/daemon/plugin_driver_test.go
+++ b/internal/daemon/plugin_driver_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -23,10 +24,11 @@ func TestPluginDriverRegister_PublishesDynamicAgentSettings(t *testing.T) {
 	}()
 
 	registerTestPluginDriver(t, client, "snipe", map[string]bool{
-		"resume":     true,
-		"yolo":       true,
-		"model_pin":  true,
-		"effort_pin": true,
+		"resume":              true,
+		"yolo":                true,
+		"model_pin":           true,
+		"effort_pin":          true,
+		"launch_instructions": true,
 	})
 
 	settings := d.settingsWithAgentAvailability()
@@ -38,6 +40,9 @@ func TestPluginDriverRegister_PublishesDynamicAgentSettings(t *testing.T) {
 	}
 	if got := settings["snipe_cap_model_pin"]; got != "true" {
 		t.Fatalf("snipe_cap_model_pin=%v, want true", got)
+	}
+	if got := settings["snipe_cap_launch_instructions"]; got != "true" {
+		t.Fatalf("snipe_cap_launch_instructions=%v, want true", got)
 	}
 	if err := d.validateNewSessionAgent("snipe"); err != nil {
 		t.Fatalf("validateNewSessionAgent(snipe) error=%v", err)
@@ -53,7 +58,7 @@ func TestHandleSpawnSession_PluginDriverLaunchesReturnedCommand(t *testing.T) {
 		_ = client.Close()
 		<-done
 	}()
-	registerTestPluginDriver(t, client, "snipe", map[string]bool{"yolo": true, "model_pin": true, "effort_pin": true})
+	registerTestPluginDriver(t, client, "snipe", map[string]bool{"yolo": true, "model_pin": true, "effort_pin": true, "launch_instructions": true})
 
 	requestDone := make(chan struct{})
 	go func() {
@@ -74,6 +79,14 @@ func TestHandleSpawnSession_PluginDriverLaunchesReturnedCommand(t *testing.T) {
 		}
 		if params.RunID == "" {
 			t.Error("spawn run_id is empty, want daemon-assigned run identity")
+			return
+		}
+		if params.Instructions == nil || params.Instructions.Kind != pluginInstructionKindWorkspace || !strings.Contains(params.Instructions.Content, "attn tracks work as tickets") {
+			t.Errorf("spawn instructions=%+v, want workspace guidance", params.Instructions)
+			return
+		}
+		if params.Instructions.ContextPath == "" || params.Instructions.WorkspaceID != "workspace-snipe" {
+			t.Errorf("spawn instruction provenance=%+v, want workspace checkout", params.Instructions)
 			return
 		}
 		respondPluginRequest(t, client, request, pluginDriverSpawnResult{
@@ -138,7 +151,7 @@ func TestHandleSpawnSession_PluginDriverClosesRunWhenPTYSpawnFails(t *testing.T)
 		_ = client.Close()
 		<-done
 	}()
-	registerTestPluginDriver(t, client, "snipe", map[string]bool{})
+	registerTestPluginDriver(t, client, "snipe", map[string]bool{"launch_instructions": true})
 
 	closed := make(chan pluginDriverSessionClosedParams, 1)
 	go func() {
@@ -172,6 +185,9 @@ func TestHandleSpawnSession_PluginDriverClosesRunWhenPTYSpawnFails(t *testing.T)
 		Cols:        80,
 		Rows:        24,
 	})
+	if _, err := os.Stat(workspaceContextCheckoutDir(d.dataRoot, "snipe-failed-spawn")); !os.IsNotExist(err) {
+		t.Fatalf("failed plugin spawn left workspace checkout behind: %v", err)
+	}
 
 	params := <-closed
 	if params.SessionID != "snipe-failed-spawn" || params.RunID == "" || params.Reason != "launch_failed" {

--- a/internal/daemon/plugin_launch_instructions.go
+++ b/internal/daemon/plugin_launch_instructions.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/victorarias/attn/internal/hooks"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+const (
+	pluginInstructionKindWorkspace = "workspace"
+	pluginInstructionKindChief     = "chief"
+)
+
+type pluginLaunchInstructions struct {
+	Kind            string `json:"kind"`
+	Content         string `json:"content"`
+	WorkspaceID     string `json:"workspace_id,omitempty"`
+	ContextPath     string `json:"context_path,omitempty"`
+	ContextRevision int    `json:"context_revision,omitempty"`
+	NotebookRoot    string `json:"notebook_root,omitempty"`
+}
+
+// preparePluginLaunchInstructions composes the same attn-owned launch guidance
+// used by built-in agents. The rollback removes only a checkout that this call
+// created; an existing or locally modified checkout is never removed.
+func (d *Daemon) preparePluginLaunchInstructions(sessionID, workspaceID string, isChief bool) (*pluginLaunchInstructions, func(), error) {
+	rollback := func() {}
+	if isChief {
+		root, _, err := d.ensureNotebookScaffold()
+		if err != nil {
+			return nil, rollback, fmt.Errorf("prepare chief notebook: %w", err)
+		}
+		content := hooks.ChiefGuidance(root, d.sessionHasSelfMonitor(sessionID))
+		if strings.TrimSpace(content) == "" {
+			return nil, rollback, fmt.Errorf("prepare chief guidance: notebook root is empty")
+		}
+		return &pluginLaunchInstructions{
+			Kind:         pluginInstructionKindChief,
+			Content:      content,
+			WorkspaceID:  workspaceID,
+			NotebookRoot: root,
+		}, rollback, nil
+	}
+
+	contextPath, metadataPath := workspaceContextCheckoutPaths(d.dataRoot, sessionID)
+	_, contextErr := os.Stat(contextPath)
+	_, metadataErr := os.Stat(metadataPath)
+	created := os.IsNotExist(contextErr) && os.IsNotExist(metadataErr)
+	session := &protocol.Session{ID: sessionID, WorkspaceID: workspaceID}
+	result, err := d.checkoutWorkspaceContextForSession(session, false)
+	if err != nil {
+		if created {
+			_ = os.RemoveAll(workspaceContextCheckoutDir(d.dataRoot, sessionID))
+		}
+		return nil, rollback, fmt.Errorf("prepare workspace context: %w", err)
+	}
+	if created {
+		rollback = func() { _ = os.RemoveAll(workspaceContextCheckoutDir(d.dataRoot, sessionID)) }
+	}
+	return &pluginLaunchInstructions{
+		Kind:            pluginInstructionKindWorkspace,
+		Content:         hooks.AgentInstructions(result.Path, parseBooleanSetting(d.store.GetSetting(SettingWorkflowsEnabled))),
+		WorkspaceID:     workspaceID,
+		ContextPath:     result.Path,
+		ContextRevision: result.CanonicalRevision,
+	}, rollback, nil
+}

--- a/internal/daemon/plugin_launch_instructions_test.go
+++ b/internal/daemon/plugin_launch_instructions_test.go
@@ -1,0 +1,106 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestPreparePluginLaunchInstructionsBeforeSessionPersistence(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(func() { _ = d.store.Close() })
+	addTestWorkspace(d, "workspace-a", t.TempDir())
+	if _, _, err := d.store.UpdateWorkspaceContext("workspace-a", "# Shared\ncurrent decision\n", "source", 0); err != nil {
+		t.Fatalf("seed workspace context: %v", err)
+	}
+
+	instructions, rollback, err := d.preparePluginLaunchInstructions("session-a", "workspace-a", false)
+	if err != nil {
+		t.Fatalf("preparePluginLaunchInstructions: %v", err)
+	}
+	if d.store.Get("session-a") != nil {
+		t.Fatal("instruction preparation persisted a provisional session")
+	}
+	if instructions.Kind != pluginInstructionKindWorkspace || instructions.ContextRevision != 1 {
+		t.Fatalf("instructions = %+v, want workspace revision 1", instructions)
+	}
+	if !strings.Contains(instructions.Content, instructions.ContextPath) || !strings.Contains(instructions.Content, "attn tracks work as tickets") {
+		t.Fatalf("instructions content did not compose existing guidance: %q", instructions.Content)
+	}
+	if got, err := os.ReadFile(instructions.ContextPath); err != nil || string(got) != "# Shared\ncurrent decision\n" {
+		t.Fatalf("checkout = %q, err=%v", got, err)
+	}
+	other, otherRollback, err := d.preparePluginLaunchInstructions("session-b", "workspace-a", false)
+	if err != nil {
+		t.Fatalf("prepare second session: %v", err)
+	}
+	if other.ContextPath == instructions.ContextPath {
+		t.Fatalf("two sessions shared checkout path %q", other.ContextPath)
+	}
+	otherRollback()
+	if _, _, err := d.store.UpdateWorkspaceContext("workspace-a", "# Shared\nnew decision\n", "source", 1); err != nil {
+		t.Fatalf("update workspace context: %v", err)
+	}
+	refreshed, _, err := d.preparePluginLaunchInstructions("session-a", "workspace-a", false)
+	if err != nil {
+		t.Fatalf("refresh launch instructions: %v", err)
+	}
+	if refreshed.ContextRevision != 2 {
+		t.Fatalf("refreshed revision=%d, want 2", refreshed.ContextRevision)
+	}
+	if got, err := os.ReadFile(refreshed.ContextPath); err != nil || string(got) != "# Shared\nnew decision\n" {
+		t.Fatalf("refreshed checkout = %q, err=%v", got, err)
+	}
+
+	rollback()
+	if _, err := os.Stat(workspaceContextCheckoutDir(d.dataRoot, "session-a")); !os.IsNotExist(err) {
+		t.Fatalf("rollback left newly-created checkout: %v", err)
+	}
+}
+
+func TestPreparePluginLaunchInstructionsPreservesExistingCheckout(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(func() { _ = d.store.Close() })
+	setupWorkspaceContextSession(t, d, "session-a", "workspace-a")
+	checkout, err := d.checkoutWorkspaceContext(&protocol.WorkspaceContextCheckoutMessage{SourceSessionID: "session-a"})
+	if err != nil {
+		t.Fatalf("checkoutWorkspaceContext: %v", err)
+	}
+	if err := os.WriteFile(checkout.Path, []byte("local edit\n"), 0o600); err != nil {
+		t.Fatalf("edit checkout: %v", err)
+	}
+
+	_, rollback, err := d.preparePluginLaunchInstructions("session-a", "workspace-a", false)
+	if err != nil {
+		t.Fatalf("preparePluginLaunchInstructions: %v", err)
+	}
+	rollback()
+	if got, err := os.ReadFile(checkout.Path); err != nil || string(got) != "local edit\n" {
+		t.Fatalf("rollback changed existing checkout = %q, err=%v", got, err)
+	}
+}
+
+func TestPreparePluginChiefInstructionsUsesNotebookNotWorkspace(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	t.Cleanup(func() { _ = d.store.Close() })
+	addTestWorkspace(d, "workspace-a", t.TempDir())
+	notebookRoot := t.TempDir()
+	d.store.SetSetting(SettingNotebookRoot, notebookRoot)
+
+	instructions, _, err := d.preparePluginLaunchInstructions("session-a", "workspace-a", true)
+	if err != nil {
+		t.Fatalf("preparePluginLaunchInstructions: %v", err)
+	}
+	if instructions.Kind != pluginInstructionKindChief || instructions.NotebookRoot != notebookRoot || instructions.ContextPath != "" {
+		t.Fatalf("chief instructions = %+v", instructions)
+	}
+	if !strings.Contains(instructions.Content, "You are the chief of staff") || !strings.Contains(instructions.Content, notebookRoot) {
+		t.Fatalf("chief guidance = %q", instructions.Content)
+	}
+	if _, err := os.Stat(workspaceContextCheckoutDir(d.dataRoot, "session-a")); !os.IsNotExist(err) {
+		t.Fatalf("chief preparation created workspace checkout: %v", err)
+	}
+}

--- a/internal/daemon/plugin_rpc.go
+++ b/internal/daemon/plugin_rpc.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-const pluginAPIVersion = 2
+const pluginAPIVersion = 3
 const pluginHealthMethod = "attn.health"
 const pluginHealthInterval = 15 * time.Second
 const pluginHealthTimeout = 2 * time.Second

--- a/internal/daemon/plugin_runtime_test.go
+++ b/internal/daemon/plugin_runtime_test.go
@@ -50,7 +50,7 @@ func TestDiscoverPluginManifests_ReportsInvalidManifest(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(badDir, pluginManifestName), []byte(`
 name = "bad-plugin"
 version = "0.1.0"
-attn_api_version = 2
+attn_api_version = 3
 `), 0o644); err != nil {
 		t.Fatalf("write bad manifest: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestDiscoverPluginManifests_AllowsRuntimeOnlyManifestNames(t *testing.T) {
 	manifest := []byte(`
 name = "manual/provider"
 version = "0.1.0"
-attn_api_version = 2
+attn_api_version = 3
 
 [plugin]
 entrypoint = "src/index.ts"
@@ -197,7 +197,7 @@ func writeTestPluginManifest(t *testing.T, pluginDir, name string) {
 	manifest := []byte(`
 name = "` + name + `"
 version = "0.1.0"
-attn_api_version = 2
+attn_api_version = 3
 
 [plugin]
 entrypoint = "src/index.ts"

--- a/internal/daemon/reload.go
+++ b/internal/daemon/reload.go
@@ -184,15 +184,20 @@ func (d *Daemon) reloadSessionAgent(sessionID string) {
 		d.logf("reload: cannot reconstruct launch params for %s: %v; aborting (live worker preserved)", sessionID, err)
 		return
 	}
-	pluginReload, err := d.preparePluginReload(session, &opts)
+	pluginReload, err := d.preparePluginReload(session, &opts, d.isChiefOfStaffSession(sessionID))
 	if err != nil {
 		d.logf("reload: cannot reconstruct plugin launch for %s: %v; aborting (live worker preserved)", sessionID, err)
 		return
 	}
+	if err := d.executePreparedSessionReload(sessionID, opts, pluginReload); err != nil {
+		d.logf("reload: %v", err)
+	}
+}
+
+func (d *Daemon) executePreparedSessionReload(sessionID string, opts ptybackend.SpawnOptions, pluginReload *preparedPluginReload) error {
 	if pluginReload != nil {
 		defer pluginReload.abort()
 	}
-
 	ctx := context.Background()
 	// Mark BEFORE kill so the killed worker's async exit is suppressed no matter how
 	// quickly it fires relative to the kill returning.
@@ -216,7 +221,7 @@ func (d *Daemon) reloadSessionAgent(sessionID string) {
 		d.logf("reload: respawn failed for %s: %v; finalizing as exited", sessionID, spawnErr)
 		d.clearReloading(sessionID)
 		d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 1})
-		return
+		return fmt.Errorf("respawn failed for %s: %w", sessionID, spawnErr)
 	}
 	if pluginReload != nil {
 		if commitErr := pluginReload.commit(); commitErr != nil {
@@ -226,9 +231,8 @@ func (d *Daemon) reloadSessionAgent(sessionID string) {
 			d.clearReloading(sessionID)
 			d.closePluginDriverSession(sessionID, "reload_failed", nil, "")
 			d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 1})
-			return
+			return fmt.Errorf("activate plugin run failed for %s: %w", sessionID, commitErr)
 		}
-		pluginReload = nil
 	}
 
 	// Success. Do NOT clear the flag here — the killed worker's exit consumes it.
@@ -239,6 +243,7 @@ func (d *Daemon) reloadSessionAgent(sessionID string) {
 		ID:    protocol.Ptr(sessionID),
 	})
 	d.logf("reload: respawned %s (agent=%s resume=%t yolo=%t)", sessionID, opts.Agent, opts.ResumeSessionID != "", opts.YoloMode)
+	return nil
 }
 
 // buildReloadSpawnOptions reconstructs the SpawnOptions for an in-place re-spawn of
@@ -358,7 +363,7 @@ func (p *preparedPluginReload) commit() error {
 // worker is killed. That preserves the reload path's fail-safe: an unavailable
 // plugin, invalid metadata, or instruction preparation error leaves the current
 // runtime untouched.
-func (d *Daemon) preparePluginReload(session *protocol.Session, opts *ptybackend.SpawnOptions) (*preparedPluginReload, error) {
+func (d *Daemon) preparePluginReload(session *protocol.Session, opts *ptybackend.SpawnOptions, isChief bool) (*preparedPluginReload, error) {
 	reg, ok := d.ensurePluginRegistry().driver(string(session.Agent))
 	if !ok {
 		return nil, nil
@@ -368,7 +373,7 @@ func (d *Daemon) preparePluginReload(session *protocol.Session, opts *ptybackend
 	}
 	runID := uuid.NewString()
 	d.beginPluginSessionLaunch(session.ID, reg.PluginName, runID)
-	instructions, rollback, err := d.preparePluginLaunchInstructions(session.ID, session.WorkspaceID, d.isChiefOfStaffSession(session.ID))
+	instructions, rollback, err := d.preparePluginLaunchInstructions(session.ID, session.WorkspaceID, isChief)
 	if err != nil {
 		d.finishPluginSessionLaunch(session.ID, false)
 		return nil, err
@@ -406,4 +411,85 @@ func (d *Daemon) preparePluginReload(session *protocol.Session, opts *ptybackend
 	opts.ExternalEnv = commandEnv
 	opts.ExternalCWD = strings.TrimSpace(result.CWD)
 	return prepared, nil
+}
+
+type preparedPluginRoleReload struct {
+	d         *Daemon
+	sessionID string
+	opts      ptybackend.SpawnOptions
+	plugin    *preparedPluginReload
+	lock      *sync.Mutex
+	completed bool
+}
+
+func (p *preparedPluginRoleReload) abort() {
+	if p == nil || p.completed {
+		return
+	}
+	p.completed = true
+	p.plugin.abort()
+	p.lock.Unlock()
+}
+
+func (p *preparedPluginRoleReload) execute() error {
+	if p == nil || p.completed {
+		return nil
+	}
+	p.completed = true
+	defer p.lock.Unlock()
+	return p.d.executePreparedSessionReload(p.sessionID, p.opts, p.plugin)
+}
+
+// preparePluginRoleReload runs driver.resume before a public chief-role change
+// is persisted. A failure leaves both the role and the live worker untouched.
+func (d *Daemon) preparePluginRoleReload(sessionID string, desiredChief bool) (*preparedPluginRoleReload, bool, error) {
+	session := d.store.Get(sessionID)
+	if session == nil {
+		return nil, false, nil
+	}
+	reg, registered := d.ensurePluginRegistry().driver(string(session.Agent))
+	activeRun := d.store.GetAgentDriverRun(sessionID)
+	pluginSession := registered || activeRun.RunID != ""
+	if !pluginSession {
+		return nil, false, nil
+	}
+	if !d.sessionHasLiveWorker(sessionID) {
+		return nil, true, nil
+	}
+	if !registered {
+		return nil, true, fmt.Errorf("agent %q plugin driver is unavailable", session.Agent)
+	}
+	if !reg.Capabilities["launch_instructions"] || !reg.Capabilities["resume"] {
+		return nil, true, fmt.Errorf("agent %q requires launch_instructions and resume capabilities", reg.Agent)
+	}
+
+	lock := d.reloadLockFor(sessionID)
+	lock.Lock()
+	if !d.sessionHasLiveWorker(sessionID) {
+		lock.Unlock()
+		return nil, true, nil
+	}
+	session = d.store.Get(sessionID)
+	if session == nil {
+		lock.Unlock()
+		return nil, true, nil
+	}
+	opts, err := d.buildReloadSpawnOptions(session)
+	if err != nil {
+		lock.Unlock()
+		return nil, true, err
+	}
+	opts.ChiefContextWindowCap = d.chiefContextWindowCap(desiredChief)
+	pluginReload, err := d.preparePluginReload(session, &opts, desiredChief)
+	if err != nil {
+		lock.Unlock()
+		return nil, true, err
+	}
+	if pluginReload == nil {
+		lock.Unlock()
+		return nil, true, fmt.Errorf("agent %q plugin driver became unavailable", session.Agent)
+	}
+	return &preparedPluginRoleReload{
+		d: d, sessionID: sessionID, opts: opts, plugin: pluginReload, lock: lock,
+	}, true, nil
 }

--- a/internal/daemon/reload.go
+++ b/internal/daemon/reload.go
@@ -2,11 +2,14 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/google/uuid"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/protocol"
@@ -116,16 +119,25 @@ func (d *Daemon) sessionHasLiveWorker(sessionID string) bool {
 }
 
 // agentSupportsChiefReload reports whether an agent's launch path injects chief
-// guidance (claude via --append-system-prompt, codex via developer_instructions).
-// Only those agents gain anything from a reload; plugin-driver agents (e.g.
-// copilot) and shells do not, so reloading them would be a pointless kill+resume.
-func agentSupportsChiefReload(agent string) bool {
+// guidance (claude via --append-system-prompt, codex via developer_instructions,
+// or a plugin driver that advertises launch_instructions).
+func (d *Daemon) agentSupportsChiefGuidance(agent string) bool {
 	switch strings.TrimSpace(strings.ToLower(agent)) {
 	case string(protocol.SessionAgentClaude), string(protocol.SessionAgentCodex):
 		return true
-	default:
+	}
+	driver, ok := d.ensurePluginRegistry().driver(agent)
+	return ok && driver.Capabilities["launch_instructions"]
+}
+
+func (d *Daemon) agentSupportsChiefReload(agent string) bool {
+	if !d.agentSupportsChiefGuidance(agent) {
 		return false
 	}
+	if driver, ok := d.ensurePluginRegistry().driver(agent); ok {
+		return driver.Capabilities["resume"]
+	}
+	return true
 }
 
 // reloadSessionAgent kills a live session's agent worker and re-spawns it in place
@@ -153,7 +165,7 @@ func (d *Daemon) reloadSessionAgent(sessionID string) {
 		return
 	}
 	agent := string(session.Agent)
-	if !agentSupportsChiefReload(agent) {
+	if !d.agentSupportsChiefReload(agent) {
 		d.logf("reload: agent %q for session %s has no chief-guidance launch path; skipping", agent, sessionID)
 		return
 	}
@@ -171,6 +183,14 @@ func (d *Daemon) reloadSessionAgent(sessionID string) {
 		// loses yolo/executable.
 		d.logf("reload: cannot reconstruct launch params for %s: %v; aborting (live worker preserved)", sessionID, err)
 		return
+	}
+	pluginReload, err := d.preparePluginReload(session, &opts)
+	if err != nil {
+		d.logf("reload: cannot reconstruct plugin launch for %s: %v; aborting (live worker preserved)", sessionID, err)
+		return
+	}
+	if pluginReload != nil {
+		defer pluginReload.abort()
 	}
 
 	ctx := context.Background()
@@ -197,6 +217,18 @@ func (d *Daemon) reloadSessionAgent(sessionID string) {
 		d.clearReloading(sessionID)
 		d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 1})
 		return
+	}
+	if pluginReload != nil {
+		if commitErr := pluginReload.commit(); commitErr != nil {
+			d.logf("reload: activate plugin run failed for %s: %v; finalizing as exited", sessionID, commitErr)
+			_ = d.ptyBackend.Kill(ctx, sessionID, syscall.SIGTERM)
+			_ = d.ptyBackend.Remove(ctx, sessionID)
+			d.clearReloading(sessionID)
+			d.closePluginDriverSession(sessionID, "reload_failed", nil, "")
+			d.handlePTYExit(ptybackend.ExitInfo{ID: sessionID, ExitCode: 1})
+			return
+		}
+		pluginReload = nil
 	}
 
 	// Success. Do NOT clear the flag here — the killed worker's exit consumes it.
@@ -241,6 +273,9 @@ func (d *Daemon) buildReloadSpawnOptions(session *protocol.Session) (ptybackend.
 	}
 
 	agent := normalizeSpawnAgent(string(session.Agent))
+	if pluginDriver, ok := d.ensurePluginRegistry().driver(string(session.Agent)); ok {
+		agent = pluginDriver.Agent
+	}
 	driver := agentdriver.Get(agent)
 	resumeSessionID := agentdriver.ResolveSpawnResumeSessionID(driver, sessionID, "", d.store.GetResumeSessionID(sessionID))
 	// Fresh-spawn when there is nothing to resume. A session is assigned its own
@@ -268,6 +303,8 @@ func (d *Daemon) buildReloadSpawnOptions(session *protocol.Session) (ptybackend.
 		ClaudeExecutable:        params.ClaudeExecutable,
 		CodexExecutable:         params.CodexExecutable,
 		CopilotExecutable:       params.CopilotExecutable,
+		Model:                   params.Model,
+		Effort:                  params.Effort,
 		LoginShellEnv:           d.cachedLoginShellEnv(),
 		WorkflowGuidanceEnabled: parseBooleanSetting(d.store.GetSetting(SettingWorkflowsEnabled)),
 		AutoApprove:             parseBooleanSetting(d.store.GetSetting(SettingAutoApproveEnabled)),
@@ -279,4 +316,94 @@ func (d *Daemon) buildReloadSpawnOptions(session *protocol.Session) (ptybackend.
 		// to 0 (uncapped), matching delegated/ordinary reloads.
 		ChiefContextWindowCap: d.chiefContextWindowCap(d.isChiefOfStaffSession(sessionID)),
 	}, nil
+}
+
+type preparedPluginReload struct {
+	d          *Daemon
+	sessionID  string
+	pluginName string
+	runID      string
+	rollback   func()
+	completed  bool
+}
+
+func (p *preparedPluginReload) abort() {
+	if p == nil || p.completed {
+		return
+	}
+	p.completed = true
+	p.rollback()
+	p.d.abortPluginSessionLaunch(p.sessionID, "launch_failed")
+}
+
+func (p *preparedPluginReload) commit() error {
+	if p == nil || p.completed {
+		return nil
+	}
+	oldRun := p.d.store.GetAgentDriverRun(p.sessionID)
+	if !p.d.store.BeginAgentDriverRun(p.sessionID, p.pluginName, p.runID) {
+		return fmt.Errorf("initialize plugin driver run cursor")
+	}
+	p.completed = true
+	if exit := p.d.finishPluginSessionLaunch(p.sessionID, true); exit != nil {
+		go p.d.handlePTYExit(*exit)
+	}
+	if oldRun.RunID != "" && oldRun.RunID != p.runID {
+		p.d.notifyPluginDriverSessionClosed(oldRun.PluginName, p.sessionID, oldRun.RunID, "reloaded", nil, "")
+	}
+	return nil
+}
+
+// preparePluginReload resolves the replacement plugin command before the live
+// worker is killed. That preserves the reload path's fail-safe: an unavailable
+// plugin, invalid metadata, or instruction preparation error leaves the current
+// runtime untouched.
+func (d *Daemon) preparePluginReload(session *protocol.Session, opts *ptybackend.SpawnOptions) (*preparedPluginReload, error) {
+	reg, ok := d.ensurePluginRegistry().driver(string(session.Agent))
+	if !ok {
+		return nil, nil
+	}
+	if !reg.Capabilities["launch_instructions"] || !reg.Capabilities["resume"] {
+		return nil, fmt.Errorf("agent %q requires launch_instructions and resume capabilities", reg.Agent)
+	}
+	runID := uuid.NewString()
+	d.beginPluginSessionLaunch(session.ID, reg.PluginName, runID)
+	instructions, rollback, err := d.preparePluginLaunchInstructions(session.ID, session.WorkspaceID, d.isChiefOfStaffSession(session.ID))
+	if err != nil {
+		d.finishPluginSessionLaunch(session.ID, false)
+		return nil, err
+	}
+	prepared := &preparedPluginReload{
+		d: d, sessionID: session.ID, pluginName: reg.PluginName, runID: runID, rollback: rollback,
+	}
+	params := pluginDriverSpawnParams{
+		SessionID:    session.ID,
+		RunID:        runID,
+		CWD:          session.Directory,
+		Label:        session.Label,
+		Yolo:         opts.YoloMode,
+		Model:        opts.Model,
+		Effort:       opts.Effort,
+		Instructions: instructions,
+	}
+	if metadata := strings.TrimSpace(d.store.GetAgentMetadata(session.ID)); metadata != "" && json.Valid([]byte(metadata)) {
+		params.Metadata = json.RawMessage(metadata)
+	}
+	result, err := d.resolvePluginDriverLaunch(reg, params, true)
+	if err != nil {
+		prepared.abort()
+		return nil, err
+	}
+	commandEnv, err := pluginCommandEnv(result.Env)
+	if err != nil {
+		prepared.abort()
+		return nil, err
+	}
+	opts.Agent = reg.Agent
+	opts.ResumeSessionID = ""
+	opts.LifecycleID = runID
+	opts.ExternalCommand = append([]string(nil), result.Argv...)
+	opts.ExternalEnv = commandEnv
+	opts.ExternalCWD = strings.TrimSpace(result.CWD)
+	return prepared, nil
 }

--- a/internal/daemon/reload_test.go
+++ b/internal/daemon/reload_test.go
@@ -545,6 +545,91 @@ func TestReloadSessionAgentLeavesPluginWorkerAliveWhenResumeCannotBePrepared(t *
 	}
 }
 
+func TestSetChiefOfStaffRejectsPluginRoleChangeWhenResumePreflightFails(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		promote      bool
+		initialChief string
+		wantChief    string
+		wantKind     string
+	}{
+		{name: "promotion", promote: true, wantKind: pluginInstructionKindChief},
+		{name: "demotion", promote: false, initialChief: "plugin-chief", wantChief: "plugin-chief", wantKind: pluginInstructionKindWorkspace},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			backend := &fakeReloadBackend{
+				liveIDs: []string{"plugin-chief"},
+				info:    ptybackend.SessionInfo{Cols: 100, Rows: 32},
+				params:  ptybackend.SessionLaunchParams{Recorded: true},
+			}
+			d := newReloadTestDaemon(t, backend)
+			addTestWorkspace(d, "ws-plugin-chief", t.TempDir())
+			addReloadSession(d, "plugin-chief", protocol.SessionAgent("opencode"), protocol.SessionStateIdle)
+			d.store.SetSetting(SettingNotebookRoot, t.TempDir())
+			if test.initialChief != "" {
+				if err := d.store.SetProfileRole(profileRoleChiefOfStaff, test.initialChief); err != nil {
+					t.Fatalf("seed chief role: %v", err)
+				}
+			}
+			if !d.store.BeginAgentDriverRun("plugin-chief", "opencode-plugin", "run-live") {
+				t.Fatal("begin live plugin run")
+			}
+
+			plugin, done := startPluginPipe(t, d, "opencode-plugin", nil)
+			defer func() {
+				_ = plugin.Close()
+				<-done
+			}()
+			registerTestPluginDriver(t, plugin, "opencode", map[string]bool{"resume": true, "launch_instructions": true})
+			closed := make(chan struct{})
+			go func() {
+				request := decodeJSONRPCMessage(t, plugin)
+				if request.Method != "driver.resume" {
+					t.Errorf("method=%q, want driver.resume", request.Method)
+					return
+				}
+				var params pluginDriverSpawnParams
+				if err := json.Unmarshal(request.Params, &params); err != nil {
+					t.Errorf("decode resume params: %v", err)
+					return
+				}
+				if params.Instructions == nil || params.Instructions.Kind != test.wantKind {
+					t.Errorf("instructions=%+v, want kind %q", params.Instructions, test.wantKind)
+					return
+				}
+				_ = json.NewEncoder(plugin).Encode(jsonRPCMessage{
+					JSONRPC: "2.0",
+					ID:      request.ID,
+					Error:   &jsonRPCError{Code: jsonRPCInternalError, Message: "native resume unavailable"},
+				})
+				request = decodeJSONRPCMessage(t, plugin)
+				respondPluginRequest(t, plugin, request, pluginDriverSessionClosedResult{OK: true})
+				close(closed)
+			}()
+
+			client := newRenameTestClient()
+			d.handleSetChiefOfStaff(client, &protocol.SetChiefOfStaffMessage{
+				Cmd: protocol.CmdSetChiefOfStaff, SessionID: "plugin-chief", ChiefOfStaff: test.promote,
+			})
+			result := readChiefOfStaffResult(t, client)
+			if result.Success || !strings.Contains(protocol.Deref(result.Error), "native resume unavailable") {
+				t.Fatalf("result=%+v, want resume preflight failure", result)
+			}
+			if got := d.chiefOfStaffSessionID(); got != test.wantChief {
+				t.Fatalf("persisted chief role=%q, want %q", got, test.wantChief)
+			}
+			if order := backend.callOrder(); len(order) != 0 {
+				t.Fatalf("failed preflight touched live worker: %v", order)
+			}
+			select {
+			case <-closed:
+			case <-time.After(time.Second):
+				t.Fatal("failed prepared run was not cleaned up")
+			}
+		})
+	}
+}
+
 // A respawn that fails after the kill must never leave a live-looking pane over a
 // dead session: emit the real session_exited so the UI degrades to a dead pane.
 func TestReloadSessionAgentRespawnFailureBroadcastsSessionExited(t *testing.T) {

--- a/internal/daemon/reload_test.go
+++ b/internal/daemon/reload_test.go
@@ -2,10 +2,12 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -412,6 +414,134 @@ func TestReloadSessionAgentSkipsUnsupportedAgent(t *testing.T) {
 
 	if order := backend.callOrder(); len(order) != 0 {
 		t.Fatalf("expected no reload for an agent without a chief-guidance launch path, got %v", order)
+	}
+}
+
+func TestReloadSessionAgentRecomposesPluginChiefInstructionsBeforeKill(t *testing.T) {
+	backend := &fakeReloadBackend{
+		liveIDs: []string{"plugin-chief"},
+		info:    ptybackend.SessionInfo{Cols: 100, Rows: 32},
+		params: ptybackend.SessionLaunchParams{
+			Recorded: true,
+			YoloMode: true,
+			Model:    "provider/model",
+			Effort:   "high",
+		},
+	}
+	d := newReloadTestDaemon(t, backend)
+	addTestWorkspace(d, "ws-plugin-chief", t.TempDir())
+	addReloadSession(d, "plugin-chief", protocol.SessionAgent("opencode"), protocol.SessionStateIdle)
+	d.store.SetSetting(SettingNotebookRoot, t.TempDir())
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, "plugin-chief"); err != nil {
+		t.Fatalf("assign chief role: %v", err)
+	}
+	if !d.store.BeginAgentDriverRun("plugin-chief", "opencode-plugin", "run-old") {
+		t.Fatal("begin old plugin run")
+	}
+	if !d.store.ApplyAgentDriverMetadata("plugin-chief", "run-old", 1, `{"native_id":"same-session"}`) {
+		t.Fatal("seed plugin metadata")
+	}
+	plugin, done := startPluginPipe(t, d, "opencode-plugin", nil)
+	defer func() {
+		_ = plugin.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, plugin, "opencode", map[string]bool{
+		"resume": true, "yolo": true, "model_pin": true, "effort_pin": true, "launch_instructions": true,
+	})
+	closed := make(chan pluginDriverSessionClosedParams, 1)
+	go func() {
+		request := decodeJSONRPCMessage(t, plugin)
+		if request.Method != "driver.resume" {
+			t.Errorf("method=%q, want driver.resume", request.Method)
+			return
+		}
+		var params pluginDriverSpawnParams
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			t.Errorf("decode resume params: %v", err)
+			return
+		}
+		if params.Instructions == nil || params.Instructions.Kind != pluginInstructionKindChief || !strings.Contains(params.Instructions.Content, "You are the chief of staff") {
+			t.Errorf("resume instructions=%+v, want current chief guidance", params.Instructions)
+			return
+		}
+		if params.Model != "provider/model" || params.Effort != "high" || !params.Yolo || string(params.Metadata) != `{"native_id":"same-session"}` {
+			t.Errorf("resume params=%+v, want preserved flags and metadata", params)
+			return
+		}
+		respondPluginRequest(t, plugin, request, pluginDriverSpawnResult{Argv: []string{"opencode-launcher"}})
+		request = decodeJSONRPCMessage(t, plugin)
+		var closeParams pluginDriverSessionClosedParams
+		if err := json.Unmarshal(request.Params, &closeParams); err != nil {
+			t.Errorf("decode session_closed params: %v", err)
+			return
+		}
+		respondPluginRequest(t, plugin, request, pluginDriverSessionClosedResult{OK: true})
+		closed <- closeParams
+	}()
+
+	d.reloadSessionAgent("plugin-chief")
+
+	if order := backend.callOrder(); !reflect.DeepEqual(order, []string{"kill:plugin-chief", "remove:plugin-chief", "spawn:plugin-chief"}) {
+		t.Fatalf("orchestration order=%v", order)
+	}
+	spawn, ok := backend.lastSpawn()
+	if !ok || !reflect.DeepEqual(spawn.ExternalCommand, []string{"opencode-launcher"}) || spawn.LifecycleID == "" {
+		t.Fatalf("plugin respawn=%+v", spawn)
+	}
+	if active := d.store.GetAgentDriverRun("plugin-chief"); active.RunID != spawn.LifecycleID || active.PluginName != "opencode-plugin" {
+		t.Fatalf("active plugin run=%+v, want replacement", active)
+	}
+	select {
+	case params := <-closed:
+		if params.RunID != "run-old" || params.Reason != "reloaded" {
+			t.Fatalf("closed old run=%+v", params)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("old plugin run was not closed after replacement")
+	}
+}
+
+func TestReloadSessionAgentLeavesPluginWorkerAliveWhenResumeCannotBePrepared(t *testing.T) {
+	backend := &fakeReloadBackend{
+		liveIDs: []string{"plugin-chief"},
+		params:  ptybackend.SessionLaunchParams{Recorded: true},
+	}
+	d := newReloadTestDaemon(t, backend)
+	addTestWorkspace(d, "ws-plugin-chief", t.TempDir())
+	addReloadSession(d, "plugin-chief", protocol.SessionAgent("opencode"), protocol.SessionStateIdle)
+	d.store.SetSetting(SettingNotebookRoot, t.TempDir())
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, "plugin-chief"); err != nil {
+		t.Fatalf("assign chief role: %v", err)
+	}
+	plugin, done := startPluginPipe(t, d, "opencode-plugin", nil)
+	defer func() {
+		_ = plugin.Close()
+		<-done
+	}()
+	registerTestPluginDriver(t, plugin, "opencode", map[string]bool{"resume": true, "launch_instructions": true})
+	closed := make(chan struct{})
+	go func() {
+		request := decodeJSONRPCMessage(t, plugin)
+		_ = json.NewEncoder(plugin).Encode(jsonRPCMessage{
+			JSONRPC: "2.0",
+			ID:      request.ID,
+			Error:   &jsonRPCError{Code: jsonRPCInternalError, Message: "native resume unavailable"},
+		})
+		request = decodeJSONRPCMessage(t, plugin)
+		respondPluginRequest(t, plugin, request, pluginDriverSessionClosedResult{OK: true})
+		close(closed)
+	}()
+
+	d.reloadSessionAgent("plugin-chief")
+
+	if order := backend.callOrder(); len(order) != 0 {
+		t.Fatalf("failed preflight touched live worker: %v", order)
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("failed replacement run was not cleaned up")
 	}
 }
 

--- a/internal/daemon/workspace_context.go
+++ b/internal/daemon/workspace_context.go
@@ -144,6 +144,20 @@ func (d *Daemon) checkoutWorkspaceContext(msg *protocol.WorkspaceContextCheckout
 	if err != nil {
 		return nil, err
 	}
+	return d.checkoutWorkspaceContextForSession(session, protocol.Deref(msg.Force))
+}
+
+// checkoutWorkspaceContextForSession performs the checkout for an explicit
+// session/workspace identity. Unlike checkoutWorkspaceContext it does not require
+// the session row to exist, which lets plugin launch preparation stage guidance
+// before a successful PTY spawn is persisted.
+func (d *Daemon) checkoutWorkspaceContextForSession(session *protocol.Session, force bool) (*protocol.WorkspaceContextResult, error) {
+	if session == nil || strings.TrimSpace(session.ID) == "" || strings.TrimSpace(session.WorkspaceID) == "" {
+		return nil, errors.New("workspace context checkout requires session and workspace ids")
+	}
+	if d.store.GetWorkspace(session.WorkspaceID) == nil {
+		return nil, errors.New("source session has no local workspace")
+	}
 	canonical, err := d.store.GetWorkspaceContext(session.WorkspaceID)
 	if err != nil {
 		return nil, err
@@ -156,20 +170,20 @@ func (d *Daemon) checkoutWorkspaceContext(msg *protocol.WorkspaceContextCheckout
 	if contentErr != nil && !os.IsNotExist(contentErr) {
 		return nil, fmt.Errorf("read workspace context checkout: %w", contentErr)
 	}
-	if metadataErr != nil && !os.IsNotExist(metadataErr) && !protocol.Deref(msg.Force) {
+	if metadataErr != nil && !os.IsNotExist(metadataErr) && !force {
 		return nil, fmt.Errorf("workspace context checkout metadata is invalid; local file preserved; use `show --force` to replace it: %w", metadataErr)
 	}
 	validCheckout := contentErr == nil &&
 		metadataErr == nil &&
 		metadata.SessionID == session.ID &&
 		metadata.WorkspaceID == session.WorkspaceID
-	if !protocol.Deref(msg.Force) &&
+	if !force &&
 		(contentErr == nil || metadataErr == nil) &&
 		!validCheckout {
 		return nil, errors.New("workspace context checkout is incomplete or belongs to another session; local files preserved; use `show --force` to replace them")
 	}
 
-	if validCheckout && !protocol.Deref(msg.Force) {
+	if validCheckout && !force {
 		modified := contextContentHash(localContent) != metadata.CanonicalHash
 		if modified {
 			return workspaceContextResult(session, canonical, contextPath, metadata, localContent), nil

--- a/internal/daemon/ws_plugins_test.go
+++ b/internal/daemon/ws_plugins_test.go
@@ -90,7 +90,7 @@ mkdir -p "$5/src"
 cat > "$5/attn-plugin.toml" <<'EOF'
 name = "attn-snipe"
 version = "0.1.0"
-attn_api_version = 2
+attn_api_version = 3
 
 [plugin]
 entrypoint = "src/index.ts"

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -559,7 +559,23 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 	// The frontend sets chief_of_staff only on initial creation, not on
 	// reconnect/resume spawns after a daemon restart. Fall back to the
 	// persisted profile-roles table so chief settings survive respawns.
-	isChief := protocol.Deref(msg.ChiefOfStaff) || d.isChiefOfStaffSession(msg.ID)
+	requestedChief := protocol.Deref(msg.ChiefOfStaff)
+	if hasPluginDriver && requestedChief && !pluginDriver.Capabilities["launch_instructions"] {
+		d.sendSpawnFailure(client, msg.ID, fmt.Errorf("agent %q cannot be chief of staff without launch_instructions capability", agent))
+		return
+	}
+	if hasPluginDriver && requestedChief && !pluginDriver.Capabilities["resume"] {
+		d.sendSpawnFailure(client, msg.ID, fmt.Errorf("agent %q cannot be chief of staff without resume capability", agent))
+		return
+	}
+	chiefAssigned := d.maybeAssignChiefOnSpawn(msg.ID, agent, requestedChief, existingSession)
+	chiefAssignmentCommitted := false
+	defer func() {
+		if chiefAssigned && !chiefAssignmentCommitted {
+			d.clearChiefOfStaffIfSession(msg.ID)
+		}
+	}()
+	isChief := d.isChiefOfStaffSession(msg.ID)
 	if spawnOpts.Model == "" {
 		// No per-spawn pin (delegation); a chief launch falls back to the
 		// chief_model_<agent> setting.
@@ -587,6 +603,13 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		}
 	}
 	pluginRunID := ""
+	instructionsRollback := func() {}
+	instructionsCommitted := false
+	defer func() {
+		if !instructionsCommitted {
+			instructionsRollback()
+		}
+	}()
 	if hasPluginDriver {
 		pluginRunID = uuid.NewString()
 		spawnOpts.LifecycleID = pluginRunID
@@ -604,6 +627,15 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		if metadata := strings.TrimSpace(d.store.GetAgentMetadata(msg.ID)); metadata != "" && json.Valid([]byte(metadata)) {
 			params.Metadata = json.RawMessage(metadata)
 		}
+		if pluginDriver.Capabilities["launch_instructions"] {
+			var instructionErr error
+			params.Instructions, instructionsRollback, instructionErr = d.preparePluginLaunchInstructions(msg.ID, workspaceID, isChief)
+			if instructionErr != nil {
+				d.finishPluginSessionLaunch(msg.ID, false)
+				d.sendSpawnFailure(client, msg.ID, instructionErr)
+				return
+			}
+		}
 		result, err := d.resolvePluginDriverLaunch(pluginDriver, params, existingSession != nil && pluginDriver.Capabilities["resume"])
 		if err != nil {
 			d.finishPluginSessionLaunch(msg.ID, false)
@@ -620,12 +652,6 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 		spawnOpts.ExternalEnv = commandEnv
 		spawnOpts.ExternalCWD = strings.TrimSpace(result.CWD)
 	}
-
-	// Assign the chief role BEFORE Spawn so the agent's launch path (and its async
-	// notebook-guide query) sees chief=true and injects the guidance on the first
-	// boot. Rolled back below if the launch fails, so a never-launched session
-	// never holds the role.
-	chiefAssigned := d.maybeAssignChiefOnSpawn(msg.ID, agent, protocol.Deref(msg.ChiefOfStaff), existingSession)
 
 	if err := d.ptyBackend.Spawn(context.Background(), spawnOpts); err != nil {
 		if hasPluginDriver {
@@ -788,6 +814,8 @@ func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSession
 			d.handlePTYExit(*exit)
 		}
 	}
+	chiefAssignmentCommitted = true
+	instructionsCommitted = true
 
 	d.sendToClient(client, protocol.SpawnResultMessage{
 		Event:   protocol.EventSpawnResult,

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	APIVersion   = 2
+	APIVersion   = 3
 	ManifestName = "attn-plugin.toml"
 )
 

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -87,7 +87,7 @@ mkdir -p "$5/src"
 cat > "$5/attn-plugin.toml" <<'EOF'
 name = "attn-snipe"
 version = "0.1.0"
-attn_api_version = 2
+attn_api_version = 3
 
 [plugin]
 entrypoint = "src/index.ts"
@@ -235,7 +235,7 @@ func TestLoadManifestRejectsEntrypointTraversal(t *testing.T) {
 	manifest := []byte(`
 name = "worktree-provider"
 version = "0.1.0"
-attn_api_version = 2
+attn_api_version = 3
 
 [plugin]
 entrypoint = "../outside.ts"
@@ -259,7 +259,7 @@ func writeTestPlugin(t *testing.T, root, name string) {
 	manifest := []byte(`
 name = "` + name + `"
 version = "0.1.0"
-attn_api_version = 2
+attn_api_version = 3
 
 [plugin]
 entrypoint = "src/index.ts"

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -187,6 +187,8 @@ type SessionLaunchParams struct {
 	ClaudeExecutable  string
 	CodexExecutable   string
 	CopilotExecutable string
+	Model             string
+	Effort            string
 }
 
 // SessionLaunchParamsProvider is implemented by backends that can return the

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -987,6 +987,8 @@ func (b *WorkerBackend) SessionLaunchParams(ctx context.Context, sessionID strin
 		ClaudeExecutable:  entry.ClaudeExecutable,
 		CodexExecutable:   entry.CodexExecutable,
 		CopilotExecutable: entry.CopilotExecutable,
+		Model:             entry.Model,
+		Effort:            entry.Effort,
 	}, nil
 }
 

--- a/internal/ptyworker/registry.go
+++ b/internal/ptyworker/registry.go
@@ -29,14 +29,16 @@ type RegistryEntry struct {
 	// re-spawns the agent in place. LaunchParamsRecorded distinguishes a worker that
 	// records them from an older one that does not (Version stays 1 so recovery,
 	// which hard-requires Version==1, keeps accepting the entry); when it is false
-	// the daemon must NOT trust YoloMode/Executable and must abort the reload rather
-	// than respawn with defaulted launch flags.
+	// the daemon must NOT trust yolo, executable, model, or effort and must abort
+	// the reload rather than respawn with defaulted launch flags.
 	LaunchParamsRecorded bool   `json:"launch_params_recorded,omitempty"`
 	YoloMode             bool   `json:"yolo_mode,omitempty"`
 	Executable           string `json:"executable,omitempty"`
 	ClaudeExecutable     string `json:"claude_executable,omitempty"`
 	CodexExecutable      string `json:"codex_executable,omitempty"`
 	CopilotExecutable    string `json:"copilot_executable,omitempty"`
+	Model                string `json:"model,omitempty"`
+	Effort               string `json:"effort,omitempty"`
 }
 
 func WriteRegistryAtomic(path string, entry RegistryEntry) error {

--- a/internal/ptyworker/runtime.go
+++ b/internal/ptyworker/runtime.go
@@ -325,6 +325,8 @@ func (r *Runtime) run(ctx context.Context) error {
 	entry.ClaudeExecutable = r.cfg.ClaudeExecutable
 	entry.CodexExecutable = r.cfg.CodexExecutable
 	entry.CopilotExecutable = r.cfg.CopilotExecutable
+	entry.Model = strings.TrimSpace(os.Getenv("ATTN_MODEL"))
+	entry.Effort = strings.TrimSpace(os.Getenv("ATTN_EFFORT"))
 	if err := WriteRegistryAtomic(r.cfg.RegistryPath, entry); err != nil {
 		return err
 	}

--- a/plugins/attn-opencode/README.md
+++ b/plugins/attn-opencode/README.md
@@ -28,9 +28,18 @@ bound to the selected native session. Other effort labels remain intentionally
 unsupported until they have the same adapter and live-app evidence.
 
 Each run gets a separate loopback port and random Basic-auth password. The
-password and staged prompt live in private files under the active profile's
-attn data directory (`plugins/attn-opencode/`), are never included in metadata
-or argv, and are deleted when attn reports that the PTY run has closed.
+password, staged prompt, and attn-composed launch instructions live in private
+files under the active profile's attn data directory
+(`plugins/attn-opencode/`), are never included in metadata or argv, and are
+deleted when attn reports that the PTY run has closed. A private per-process
+OpenCode system hook rereads that file for every prompt, so resumed sessions
+receive role and context changes without modifying repository or global
+OpenCode configuration.
+
+Ordinary sessions receive the same workspace-context, workflow, and ticket
+guidance as built-in attn agents. Chiefs receive Notebook guidance instead.
+Resuming a session, including a chief promotion or demotion, recomposes the
+current guidance while retaining the same native OpenCode session.
 
 The plugin reports OpenCode `busy` and `retry` as `working`. Native question
 requests become `waiting_input`, and native permission requests become

--- a/plugins/attn-opencode/attn-plugin.toml
+++ b/plugins/attn-opencode/attn-plugin.toml
@@ -1,6 +1,6 @@
 name = "attn-opencode"
 version = "0.1.0"
-attn_api_version = 2
+attn_api_version = 3
 description = "Server-backed OpenCode driver for attn"
 
 [plugin]

--- a/plugins/attn-opencode/src/driver.ts
+++ b/plugins/attn-opencode/src/driver.ts
@@ -110,6 +110,7 @@ export class OpenCodeDriver {
           pending_approval: true,
           model_pin: true,
           effort_pin: true,
+          launch_instructions: true,
         },
       });
     }
@@ -160,7 +161,7 @@ export class OpenCodeDriver {
         variant: selection.model?.variant ?? selection.variant,
         resume,
         created_at: new Date().toISOString(),
-      }, params.initial_prompt ?? "");
+      }, params.initial_prompt ?? "", params.instructions);
       const launchConfig: LaunchConfig = {
         schema: 1,
         run_id: record.run_id,
@@ -170,6 +171,7 @@ export class OpenCodeDriver {
         port,
         yolo: params.yolo === true,
         resume_session_id: selection.nativeSessionID,
+        instruction_ref: record.instruction_ref,
       };
       await this.options.registry.writeLaunchConfig(record, launchConfig);
       const controller = new AbortController();

--- a/plugins/attn-opencode/src/guidance-plugin.ts
+++ b/plugins/attn-opencode/src/guidance-plugin.ts
@@ -1,0 +1,17 @@
+import { readFile } from "node:fs/promises";
+
+const instructionRefEnv = "ATTN_OPENCODE_INSTRUCTION_REF";
+
+export async function server() {
+  return {
+    "experimental.chat.system.transform": async (_input: unknown, output: { system: string[] }) => {
+      const instructionRef = process.env[instructionRefEnv]?.trim();
+      if (!instructionRef) throw new Error(`${instructionRefEnv} is required`);
+      const content = await readFile(instructionRef, "utf8");
+      if (!content.trim()) throw new Error("attn launch instructions are empty");
+      output.system.push(`attn launch instructions:\n${content}`);
+    },
+  };
+}
+
+export default server;

--- a/plugins/attn-opencode/src/launcher.ts
+++ b/plugins/attn-opencode/src/launcher.ts
@@ -1,10 +1,12 @@
 import { createServer } from "node:net";
 import { chmod, open, readFile, rename, rm } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { randomBytes } from "node:crypto";
 import type { LaunchConfig } from "./types";
 
 const maxPortAttempts = 3;
+const guidancePluginRef = pathToFileURL(join(import.meta.dir, "guidance-plugin.ts")).href;
 
 if (import.meta.main) {
   const configPath = process.argv[2];
@@ -14,6 +16,7 @@ if (import.meta.main) {
 
 export async function launch(path: string): Promise<number> {
   let config = await readConfig(path);
+  const opencodeConfig = opencodeConfigForLaunch(process.env.OPENCODE_CONFIG_CONTENT, config.instruction_ref, guidancePluginRef);
   for (let attempt = 1; attempt <= maxPortAttempts; attempt += 1) {
     const password = (await readFile(config.password_ref, "utf8")).trim();
     const args = [config.executable, "--hostname", "127.0.0.1", "--port", String(config.port)];
@@ -21,7 +24,16 @@ export async function launch(path: string): Promise<number> {
     if (config.yolo) args.push("--yolo");
     const child = Bun.spawn(args, {
       cwd: config.cwd,
-      env: { ...process.env, OPENCODE_SERVER_PASSWORD: password },
+      env: {
+        ...process.env,
+        OPENCODE_SERVER_PASSWORD: password,
+        ...(config.instruction_ref
+          ? {
+              ATTN_OPENCODE_INSTRUCTION_REF: config.instruction_ref,
+              OPENCODE_CONFIG_CONTENT: JSON.stringify(opencodeConfig),
+            }
+          : {}),
+      },
       stdin: "inherit",
       stdout: "inherit",
       stderr: "pipe",
@@ -39,6 +51,41 @@ export async function launch(path: string): Promise<number> {
     await writeConfig(path, config);
   }
   return 1;
+}
+
+export function opencodeConfigForLaunch(
+  existingJSON: string | undefined,
+  instructionRef?: string,
+  pluginRef = guidancePluginRef,
+): Record<string, unknown> {
+  let parsed: unknown = {};
+  if (existingJSON !== undefined && existingJSON.trim() !== "") {
+    try {
+      parsed = JSON.parse(existingJSON);
+    } catch (error) {
+      throw new Error(`invalid inherited OPENCODE_CONFIG_CONTENT: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("invalid inherited OPENCODE_CONFIG_CONTENT: expected a JSON object");
+  }
+  const base = parsed as Record<string, unknown>;
+  if (!instructionRef) return base;
+  const inheritedInstructions = base.instructions ?? [];
+  if (!Array.isArray(inheritedInstructions) || !inheritedInstructions.every((value) => typeof value === "string")) {
+    throw new Error("invalid inherited OPENCODE_CONFIG_CONTENT.instructions: expected an array of strings");
+  }
+  const inheritedPlugins = base.plugin ?? [];
+  if (!Array.isArray(inheritedPlugins)) {
+    throw new Error("invalid inherited OPENCODE_CONFIG_CONTENT.plugin: expected an array");
+  }
+  const hasGuidancePlugin = inheritedPlugins.some((value) =>
+    value === pluginRef || (Array.isArray(value) && value[0] === pluginRef)
+  );
+  return {
+    ...base,
+    plugin: hasGuidancePlugin ? inheritedPlugins : [...inheritedPlugins, pluginRef],
+  };
 }
 
 async function readConfig(path: string): Promise<LaunchConfig> {

--- a/plugins/attn-opencode/src/run-registry.ts
+++ b/plugins/attn-opencode/src/run-registry.ts
@@ -1,15 +1,17 @@
 import { randomBytes } from "node:crypto";
 import { chmod, mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
-import type { LaunchConfig, RunRecord } from "./types";
+import type { LaunchConfig, PluginLaunchInstructions, RunRecord } from "./types";
 
 const directoryMode = 0o700;
 const fileMode = 0o600;
 
 type RegistryContents = {
-  schema: 1;
+  schema: 2;
   runs: Record<string, RunRecord>;
 };
+
+type PersistedRegistryContents = Omit<RegistryContents, "schema"> & { schema: 1 | 2 };
 
 export function runtimeRootFromSocket(socketPath: string): string {
   return join(dirname(socketPath), "plugins", "attn-opencode");
@@ -19,6 +21,7 @@ export class RunRegistry {
   private readonly registryPath: string;
   private readonly secretsDir: string;
   private readonly promptsDir: string;
+  private readonly instructionsDir: string;
   private readonly launchDir: string;
   private runs = new Map<string, RunRecord>();
   private work = Promise.resolve();
@@ -27,20 +30,22 @@ export class RunRegistry {
     this.registryPath = join(root, "runs.json");
     this.secretsDir = join(root, "secrets");
     this.promptsDir = join(root, "prompts");
+    this.instructionsDir = join(root, "instructions");
     this.launchDir = join(root, "launch");
   }
 
   async initialize(): Promise<void> {
     await this.withLock(async () => {
-      for (const path of [this.root, this.secretsDir, this.promptsDir, this.launchDir]) {
+      for (const path of [this.root, this.secretsDir, this.promptsDir, this.instructionsDir, this.launchDir]) {
         await ensurePrivateDirectory(path);
       }
       try {
-        const parsed = JSON.parse(await readFile(this.registryPath, "utf8")) as RegistryContents;
-        if (parsed.schema !== 1 || !parsed.runs || typeof parsed.runs !== "object") {
+        const parsed = JSON.parse(await readFile(this.registryPath, "utf8")) as PersistedRegistryContents;
+        if ((parsed.schema !== 1 && parsed.schema !== 2) || !parsed.runs || typeof parsed.runs !== "object") {
           throw new Error("invalid run registry schema");
         }
         this.runs = new Map(Object.entries(parsed.runs));
+        if (parsed.schema === 1) await this.persist();
       } catch (error) {
         if (!isNotFound(error)) throw error;
         await this.persist();
@@ -48,15 +53,29 @@ export class RunRegistry {
     });
   }
 
-  async create(record: Omit<RunRecord, "password_ref" | "prompt_ref" | "launch_config_ref">, prompt: string): Promise<RunRecord> {
+  async create(
+    record: Omit<RunRecord, "password_ref" | "prompt_ref" | "instruction_ref" | "instruction_kind" | "launch_config_ref">,
+    prompt: string,
+    instructions?: PluginLaunchInstructions,
+  ): Promise<RunRecord> {
     return this.withLock(async () => {
       if (this.runs.has(record.run_id)) throw new Error(`run ${record.run_id} already exists`);
       const passwordRef = join(this.secretsDir, `${safeRunID(record.run_id)}.secret`);
       const promptRef = prompt === "" ? undefined : join(this.promptsDir, `${safeRunID(record.run_id)}.prompt`);
+      const instructionRef = instructions ? join(this.instructionsDir, `${safeRunID(record.run_id)}.md`) : undefined;
+      const instructionContents = instructions ? requireInstructionContent(instructions) : undefined;
       const launchConfigRef = join(this.launchDir, `${safeRunID(record.run_id)}.json`);
       await writePrivate(passwordRef, randomBytes(32).toString("base64url"));
       if (promptRef) await writePrivate(promptRef, prompt);
-      const full: RunRecord = { ...record, password_ref: passwordRef, prompt_ref: promptRef, launch_config_ref: launchConfigRef };
+      if (instructionRef && instructionContents) await writePrivate(instructionRef, instructionContents);
+      const full: RunRecord = {
+        ...record,
+        password_ref: passwordRef,
+        prompt_ref: promptRef,
+        instruction_ref: instructionRef,
+        instruction_kind: instructions?.kind,
+        launch_config_ref: launchConfigRef,
+      };
       this.runs.set(full.run_id, full);
       await this.persist();
       return structuredClone(full);
@@ -126,6 +145,7 @@ export class RunRegistry {
       await Promise.all([
         rm(record.password_ref, { force: true }),
         record.prompt_ref ? rm(record.prompt_ref, { force: true }) : Promise.resolve(),
+        record.instruction_ref ? rm(record.instruction_ref, { force: true }) : Promise.resolve(),
         rm(record.launch_config_ref, { force: true }),
       ]);
     });
@@ -140,7 +160,7 @@ export class RunRegistry {
 
   private async persist(): Promise<void> {
     const runs = Object.fromEntries(this.runs.entries());
-    await writePrivate(this.registryPath, `${JSON.stringify({ schema: 1, runs } satisfies RegistryContents)}\n`);
+    await writePrivate(this.registryPath, `${JSON.stringify({ schema: 2, runs } satisfies RegistryContents)}\n`);
   }
 
   private async withLock<T>(operation: () => Promise<T> | T): Promise<T> {
@@ -151,6 +171,16 @@ export class RunRegistry {
     );
     return next;
   }
+}
+
+function requireInstructionContent(instructions: PluginLaunchInstructions | undefined): string {
+  if (!instructions || (instructions.kind !== "workspace" && instructions.kind !== "chief")) {
+    throw new Error("launch instructions require a supported kind");
+  }
+  if (typeof instructions.content !== "string" || instructions.content.trim() === "") {
+    throw new Error("launch instructions require non-empty content");
+  }
+  return instructions.content;
 }
 
 export async function writePrivate(path: string, contents: string): Promise<void> {

--- a/plugins/attn-opencode/src/types.ts
+++ b/plugins/attn-opencode/src/types.ts
@@ -1,4 +1,4 @@
-export const pluginAPIVersion = 2;
+export const pluginAPIVersion = 3;
 
 export type StableVersion = {
   raw: string;
@@ -53,6 +53,15 @@ export function evaluateOpenCodeVersion(value: string): VersionCompatibility {
 
 export type DriverCapabilities = Record<string, boolean>;
 
+export type PluginLaunchInstructions = {
+  kind: "workspace" | "chief";
+  content: string;
+  workspace_id?: string;
+  context_path?: string;
+  context_revision?: number;
+  notebook_root?: string;
+};
+
 export type DriverSpawnParams = {
   session_id: string;
   run_id: string;
@@ -63,6 +72,7 @@ export type DriverSpawnParams = {
   effort?: string;
   initial_prompt?: string;
   metadata?: unknown;
+  instructions?: PluginLaunchInstructions;
 };
 
 export type DriverSpawnResult = {
@@ -104,6 +114,8 @@ export type RunRecord = {
   port: number;
   password_ref: string;
   prompt_ref?: string;
+  instruction_ref?: string;
+  instruction_kind?: "workspace" | "chief";
   launch_config_ref: string;
   opencode_session_id?: string;
   opencode_version: string;
@@ -123,6 +135,7 @@ export type LaunchConfig = {
   port: number;
   yolo: boolean;
   resume_session_id?: string;
+  instruction_ref?: string;
 };
 
 export type ReportState = "working" | "waiting_input" | "pending_approval" | "idle" | "unknown";

--- a/plugins/attn-opencode/test/driver.test.ts
+++ b/plugins/attn-opencode/test/driver.test.ts
@@ -3,7 +3,8 @@ import { randomUUID } from "node:crypto";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { OpenCodeDriver } from "../src/driver";
-import { launch } from "../src/launcher";
+import attnGuidancePlugin from "../src/guidance-plugin";
+import { launch, opencodeConfigForLaunch } from "../src/launcher";
 import { type EventSubscription, type ServerEvent, OpenCodeHTTP } from "../src/opencode-http";
 import { RunRegistry, writePrivate } from "../src/run-registry";
 import type { DriverSpawnParams } from "../src/types";
@@ -806,16 +807,109 @@ test("registry persists atomically with private files and cleans them after sess
   const registry = new RunRegistry(root);
   const driver = driverFor(rpc, registry, target);
   await driver.initialize();
-  await driver.spawn(params("run-cleanup"));
+  await driver.spawn({
+    ...params("run-cleanup"),
+    instructions: {
+      kind: "workspace",
+      content: "Private attn workspace guidance",
+      workspace_id: "workspace-a",
+      context_revision: 3,
+    },
+  });
   await eventually(() => target.prompts.length === 1, "run creation");
   const record = await registry.get("run-cleanup");
   expect(record).toBeDefined();
   expect((await stat(record!.password_ref)).mode & 0o077).toBe(0);
   expect((await stat(record!.prompt_ref!)).mode & 0o077).toBe(0);
+  expect((await stat(record!.instruction_ref!)).mode & 0o077).toBe(0);
+  expect(await readFile(record!.instruction_ref!, "utf8")).toBe("Private attn workspace guidance");
+  expect(record!.instruction_kind).toBe("workspace");
+  expect((await registry.readLaunchConfig(record!)).instruction_ref).toBe(record!.instruction_ref);
   expect(JSON.parse(await readFile(join(root, "runs.json"), "utf8")).runs["run-cleanup"].password_ref).toBe(record!.password_ref);
   await driver.sessionClosed({ session_id: "attn-run-cleanup", run_id: "run-cleanup", reason: "exited" });
   expect(await registry.get("run-cleanup")).toBeUndefined();
   await expect(stat(record!.password_ref)).rejects.toThrow();
+  await expect(stat(record!.instruction_ref!)).rejects.toThrow();
+});
+
+test("registry migrates schema 1 without changing existing runs", async () => {
+  const root = join(await tempRoot(), "runtime");
+  await writePrivate(join(root, "runs.json"), `${JSON.stringify({ schema: 1, runs: {} })}\n`);
+  const registry = new RunRegistry(root);
+  await registry.initialize();
+  expect(JSON.parse(await readFile(join(root, "runs.json"), "utf8")).schema).toBe(2);
+});
+
+test("OpenCode config merge preserves keys and deduplicates the guidance plugin", () => {
+  const pluginRef = "file:///tmp/attn-guidance.ts";
+  expect(opencodeConfigForLaunch(JSON.stringify({
+    theme: "dark",
+    instructions: ["repo.md"],
+    plugin: ["user-plugin", pluginRef],
+  }), "/tmp/attn.md", pluginRef)).toEqual({
+    theme: "dark",
+    instructions: ["repo.md"],
+    plugin: ["user-plugin", pluginRef],
+  });
+  expect(opencodeConfigForLaunch(undefined, "/tmp/attn.md", pluginRef)).toEqual({ plugin: [pluginRef] });
+});
+
+test("OpenCode config merge rejects malformed inherited config", () => {
+  expect(() => opencodeConfigForLaunch("{", "/tmp/attn.md")).toThrow("invalid inherited OPENCODE_CONFIG_CONTENT");
+  expect(() => opencodeConfigForLaunch(JSON.stringify({ instructions: [1] }), "/tmp/attn.md")).toThrow("array of strings");
+  expect(() => opencodeConfigForLaunch(JSON.stringify({ plugin: "bad" }), "/tmp/attn.md")).toThrow("expected an array");
+});
+
+test("guidance plugin reads the current private instruction file for every prompt", async () => {
+  const root = await tempRoot();
+  const instructionRef = join(root, "instructions.md");
+  await writePrivate(instructionRef, "workspace guidance one");
+  const previous = process.env.ATTN_OPENCODE_INSTRUCTION_REF;
+  process.env.ATTN_OPENCODE_INSTRUCTION_REF = instructionRef;
+  try {
+    const hooks = await attnGuidancePlugin();
+    const transform = hooks["experimental.chat.system.transform"];
+    const first = { system: ["base"] };
+    await transform({}, first);
+    expect(first.system).toEqual(["base", "attn launch instructions:\nworkspace guidance one"]);
+
+    await writePrivate(instructionRef, "chief guidance two");
+    const second = { system: ["base"] };
+    await transform({}, second);
+    expect(second.system).toEqual(["base", "attn launch instructions:\nchief guidance two"]);
+  } finally {
+    if (previous === undefined) delete process.env.ATTN_OPENCODE_INSTRUCTION_REF;
+    else process.env.ATTN_OPENCODE_INSTRUCTION_REF = previous;
+  }
+});
+
+test("launcher rejects malformed inherited config before starting OpenCode", async () => {
+  const root = await tempRoot();
+  const marker = join(root, "started");
+  const executable = join(root, "fake-opencode");
+  await writeFile(executable, `#!/bin/sh\ntouch ${marker}\n`, { mode: 0o755 });
+  const password = join(root, "password");
+  await writePrivate(password, "secret");
+  const config = join(root, "launch.json");
+  await writePrivate(config, JSON.stringify({
+    schema: 1,
+    run_id: "launch-invalid-config",
+    executable,
+    cwd: root,
+    password_ref: password,
+    instruction_ref: join(root, "instructions.md"),
+    port: 12345,
+    yolo: false,
+  }));
+  const previous = process.env.OPENCODE_CONFIG_CONTENT;
+  process.env.OPENCODE_CONFIG_CONTENT = "{";
+  try {
+    await expect(launch(config)).rejects.toThrow("invalid inherited OPENCODE_CONFIG_CONTENT");
+  } finally {
+    if (previous === undefined) delete process.env.OPENCODE_CONFIG_CONTENT;
+    else process.env.OPENCODE_CONFIG_CONTENT = previous;
+  }
+  await expect(stat(marker)).rejects.toThrow();
 });
 
 test("session close aborts the active SSE subscription", async () => {

--- a/sdk/plugin/src/index.ts
+++ b/sdk/plugin/src/index.ts
@@ -119,7 +119,7 @@ type HealthResult = {
   ok: boolean;
 };
 
-const pluginAPIVersion = 2;
+const pluginAPIVersion = 3;
 
 export class AttnPluginClient {
   private socket?: Socket;


### PR DESCRIPTION
## Intent / Why

OpenCode sessions launched through attn's plugin driver did not receive the workspace, workflow, ticket, or chief guidance that built-in agents rely on. That left OpenCode outside attn's coordination model and made chief promotion unsafe because the running conversation could not adopt its new role.

## Summary

- extend plugin API v3 with an attn-composed launch-instructions bundle, including pre-persistence workspace-context checkout and safe rollback
- keep each OpenCode run's guidance in a private file and inject it through a per-process system hook that rereads the file on every prompt
- support fail-safe OpenCode chief promotion and demotion by preflighting resume before replacing the live worker, while preserving the native conversation, model, effort, and yolo settings
- document the plugin contract and user-visible OpenCode guidance behavior

## Test plan

- [x] `go test ./...`
- [x] `bun test` in `plugins/attn-opencode` (45 tests, 108 assertions)
- [x] Build, sign, install, and launch the isolated `attn-dev.app`
- [x] Verify a fresh real OpenCode session receives its private workspace-context guidance
- [x] Update workspace context through the real OpenCode session and verify the resumed native conversation receives the current checkout
- [x] Promote and demote the same native OpenCode conversation, verifying chief guidance and restored workspace guidance after each live reload

## Out of scope

- refreshing guidance in the middle of an already-running model turn
- a reusable SDK helper for plugin-owned private instruction files
