### PR TITLE
feat(plugins): supervise installed plugin processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-15]
 
 ### Added
+- **Installed plugins now recover automatically after crashes and lost connections.**
+  Attn restarts them with bounded backoff, shows their recovery state in
+  Settings, and lets OpenCode resume monitoring the same native sessions without
+  launching replacement TUIs.
 - **OpenCode prose questions now surface as waiting for input.** Native question
   and permission requests remain authoritative, while an explicit idle turn can
   also distinguish ordinary assistant questions from completed answers without

--- a/app/src/components/SettingsModal.css
+++ b/app/src/components/SettingsModal.css
@@ -326,7 +326,8 @@
 .settings-pill.warn,
 .endpoint-status-badge.status-connecting,
 .endpoint-status-badge.status-bootstrapping,
-.plugin-status-badge.starting {
+.plugin-status-badge.starting,
+.plugin-status-badge.backoff {
   color: #f59b4a;
   border-color: rgba(245, 155, 74, 0.42);
   background: rgba(245, 155, 74, 0.11);

--- a/app/src/components/SettingsModal.test.tsx
+++ b/app/src/components/SettingsModal.test.tsx
@@ -240,6 +240,7 @@ describe('SettingsModal', () => {
       priority: 0,
       connected: false,
       running: true,
+      runtime_phase: 'starting',
       health_status: 'unknown',
     };
 
@@ -256,7 +257,26 @@ describe('SettingsModal', () => {
     rerender(
       <SettingsModal
         {...baseProps}
-        plugins={[{ ...startingPlugin, connected: true, health_status: 'healthy' }]}
+        plugins={[{
+          ...startingPlugin,
+          running: false,
+          runtime_phase: 'backoff',
+          restart_attempt: 2,
+          next_restart_at: '2026-07-15T22:20:00Z',
+          last_exit: '2026-07-15T22:19:59Z: exit code 1',
+        }]}
+      />,
+    );
+
+    expect(await screen.findByText('backoff')).toBeInTheDocument();
+    expect(screen.getByText('Restart attempt')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText(/Last exit: 2026-07-15T22:19:59Z: exit code 1/)).toBeInTheDocument();
+
+    rerender(
+      <SettingsModal
+        {...baseProps}
+        plugins={[{ ...startingPlugin, connected: true, runtime_phase: 'connected', health_status: 'healthy' }]}
       />,
     );
 

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -1542,14 +1542,15 @@ export function SettingsModal({
               const busy = pluginActionName === plugin.name;
               const draftPriority = pluginPriorityDrafts[plugin.name] ?? String(plugin.priority);
               const healthStatus = plugin.health_status || 'unknown';
+              const runtimePhase = plugin.runtime_phase || (plugin.connected ? 'connected' : plugin.running ? 'starting' : 'stopped');
               return (
                 <div key={plugin.name} className="plugin-card">
                   <div className="plugin-card-header">
                     <div className="plugin-card-title">
                       <span className="endpoint-name">{plugin.name}</span>
                       <span className="settings-pill">v{plugin.version}</span>
-                      <span className={`plugin-status-badge ${plugin.connected ? 'connected' : plugin.running ? 'starting' : 'stopped'}`}>
-                        {plugin.connected ? 'connected' : plugin.running ? 'starting' : 'stopped'}
+                      <span className={`plugin-status-badge ${runtimePhase}`}>
+                        {runtimePhase}
                       </span>
                       <span className={`plugin-health-badge ${healthStatus}`}>
                         {healthStatus}
@@ -1565,11 +1566,28 @@ export function SettingsModal({
                       Healthcheck: {plugin.health_message}
                     </div>
                   )}
+                  {plugin.last_exit && (
+                    <div className="settings-warning">
+                      Last exit: {plugin.last_exit}
+                    </div>
+                  )}
                   <div className="plugin-meta-grid">
                     <div className="settings-meta-row">
                       <span className="settings-meta-label">Path</span>
                       <code>{plugin.dir}</code>
                     </div>
+                    {plugin.restart_attempt !== undefined && (
+                      <div className="settings-meta-row">
+                        <span className="settings-meta-label">Restart attempt</span>
+                        <code>{plugin.restart_attempt}</code>
+                      </div>
+                    )}
+                    {plugin.next_restart_at && (
+                      <div className="settings-meta-row">
+                        <span className="settings-meta-label">Next restart</span>
+                        <code>{plugin.next_restart_at}</code>
+                      </div>
+                    )}
                     <label className="plugin-priority-control">
                       <span className="settings-meta-label">Priority</span>
                       <input

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '164';
+export const PROTOCOL_VERSION = '165';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -2576,16 +2576,20 @@ export enum PluginActionResultMessageEvent {
 }
 
 export interface PluginInfo {
-    connected:       boolean;
-    description?:    string;
-    dir:             string;
-    health_message?: string;
-    health_status?:  string;
-    last_health_at?: string;
-    name:            string;
-    priority:        number;
-    running:         boolean;
-    version:         string;
+    connected:        boolean;
+    description?:     string;
+    dir:              string;
+    health_message?:  string;
+    health_status?:   string;
+    last_exit?:       string;
+    last_health_at?:  string;
+    name:             string;
+    next_restart_at?: string;
+    priority:         number;
+    restart_attempt?: number;
+    running:          boolean;
+    runtime_phase?:   string;
+    version:          string;
     [property: string]: any;
 }
 
@@ -9043,10 +9047,14 @@ const typeMap: any = {
         { json: "dir", js: "dir", typ: "" },
         { json: "health_message", js: "health_message", typ: u(undefined, "") },
         { json: "health_status", js: "health_status", typ: u(undefined, "") },
+        { json: "last_exit", js: "last_exit", typ: u(undefined, "") },
         { json: "last_health_at", js: "last_health_at", typ: u(undefined, "") },
         { json: "name", js: "name", typ: "" },
+        { json: "next_restart_at", js: "next_restart_at", typ: u(undefined, "") },
         { json: "priority", js: "priority", typ: 0 },
+        { json: "restart_attempt", js: "restart_attempt", typ: u(undefined, 0) },
         { json: "running", js: "running", typ: true },
+        { json: "runtime_phase", js: "runtime_phase", typ: u(undefined, "") },
         { json: "version", js: "version", typ: "" },
     ], "any"),
     "PluginIssue": o([

--- a/docs/plans/2026-04-16-plugin-system.md
+++ b/docs/plans/2026-04-16-plugin-system.md
@@ -61,12 +61,12 @@ These were proposed in conversation but not explicitly confirmed:
 
 1. **Bun-only vs Bun-preferred SDK.** Proposed: Bun-only. Simpler, cleaner, bets on Bun. Alternative: Bun-preferred with Node fallback.
 2. **Plugin distribution format.** Proposed: plugins ship TypeScript source + `package.json`, `attn plugin install` runs `bun install`, Bun is a prereq on the user's machine. Alternative: plugins ship `bun build --compile` binaries, no runtime dependency.
-3. **Plugin lifecycle.** Proposed: attn spawns installed plugins at daemon startup and reconciles on plugin-dir change. User-managed plugins (dev mode, ad-hoc scripts) spawn themselves and connect. One-per-plugin vs one-per-session not fully decided.
+3. **Plugin lifecycle.** Landed: attn owns one supervised process per installed plugin. Clean exits, crashes, and connection loss beyond a five-second grace period restart with bounded backoff; 60 seconds continuously connected resets the attempt count. User-managed plugins can still connect independently.
 4. **Remote daemons.** Proposed: plugins are daemon-local. Each daemon has its own plugin set. Install per host (SSH to remote, run `attn plugin install` there). Cross-daemon control plugins are deferred — likely exposing the same JSON-RPC over the hub's existing WebSocket later. User raised this as an open question worth capturing; design sketched but not confirmed.
 5. **SDK shape and timing.** User pushed back on designing SDK top-down. **Revised approach: the first real plugins are written against raw JSON-RPC first. After the provider path proved out, extract a small SDK from those patterns; let richer plugin surfaces wait until their concrete implementations exist.** The protocol must still stay ergonomic enough to consume without a wrapper.
 6. **Manifest format.** Probably TOML — minimal, human-readable, Bun ecosystem-neutral. Alternatives: JSON, YAML. Not confirmed.
 7. **Install sources.** Settings accepts a pasted Git repository URL or local directory. The CLI currently keeps `--path <dir>` for local development; a Git-source CLI form is deferred until it has a concrete use case.
-8. **API versioning discipline.** Installed plugin manifests and the socket hello use a strict, matching `attn_api_version`. Version 3 adds the optional attn-composed `instructions` bundle to driver launch requests (version 2 introduced delegated `model` and `effort`), so daemon and plugin agree on the expanded contract before launch. A wire-shape change must bump this version and update every bundled manifest/client; the daemon-client protocol version changes separately only when its own WebSocket schema changes.
+8. **API versioning discipline.** Installed plugin manifests and the socket hello use a strict, matching `attn_api_version`. Version 4 adds a daemon-issued process `generation` to hello and returns store-authoritative `active_runs` from `driver.register`, allowing stale processes to fail closed and restarted drivers to recover owned runs. Version 3 added the optional attn-composed `instructions` bundle to driver launch requests (version 2 introduced delegated `model` and `effort`). A wire-shape change must bump this version and update every bundled manifest/client; the daemon-client protocol version changes separately only when its own WebSocket schema changes.
 9. **Socket coexistence.** Existing one-message-per-connection hook protocol (claude hooks, whatever remains of the old pi plan's pattern) must keep working. Proposed: detect JSON-RPC handshake by first-message shape and switch the connection's mode. Not confirmed.
 10. **JSON-RPC framing.** Proposed: newline-delimited JSON. Alternative: LSP-style Content-Length headers. Unix socket + JSON makes newline-delimited the simpler choice.
 
@@ -91,15 +91,15 @@ These were proposed in conversation but not explicitly confirmed:
 
 ### Plugin lifecycle — driver flow
 
-1. attn spawns the plugin binary at daemon startup (or user runs it in dev mode).
-2. Plugin connects to `~/.attn/attn.sock`, sends `hello { name, version, attn_api_version, surfaces? }`.
-3. attn replies with accepted capabilities. An agent plugin then calls `driver.register { agent, capabilities }`; the base handshake does not carry a speculative role field.
+1. attn supervises the installed plugin binary from daemon startup, restarting it with bounded backoff after an exit or a connection loss longer than five seconds (or the user runs an unsupervised plugin in dev mode).
+2. Plugin connects to `~/.attn/attn.sock`, sends `hello { name, version, attn_api_version, generation, surfaces? }`. A supervised plugin must echo the exact generation injected into its environment; stale generations are rejected.
+3. attn replies with accepted capabilities. An agent plugin then calls `driver.register { agent, capabilities }`; the result includes the plugin's store-owned active runs so it can reconcile durable monitoring state after a restart. The base handshake does not carry a speculative role field.
 4. When a session starts with agent = the registered name, attn calls `driver.spawn { session_id, run_id, cwd, label, yolo }` on the plugin. On reload of that same session, it calls `driver.resume` with the stored opaque metadata. Capability inputs such as `yolo` express attn-level behavior, not required command-line flag names; each driver returns the agent-specific equivalent argv.
 5. Plugin responds `{ argv, env, cwd }`. attn spawns that command in a PTY under the session. **Attn owns the PTY. Plugin owns agent-specific semantics.**
 6. Plugin stages companion files (extensions, hooks) however it likes. Plugin monitors the agent however it likes.
 7. Plugin reports state via `session.report_state`, `session.report_stop`, `session.report_metadata`. The daemon supplies a fresh `run_id` per launched PTY and persists the spawning plugin as that run's owner; only that owner can report or receive close notification for the run. The plugin sequences reports within that run so asynchronous work cannot overwrite newer status or a replacement run.
 8. When an attn-owned plugin agent PTY exits or has been killed successfully, attn calls `driver.session_closed` on the recorded run owner so the plugin can dispose bridge tokens, watchers, classifiers, and staged launch resources for that run.
-9. Plugin exits when attn shuts down or its own lifecycle ends.
+9. Plugin exits intentionally when attn shuts down or removes it. Unexpected exits are supervised and do not terminate attn-owned agent PTYs.
 
 ### Provider and lifecycle surfaces
 

--- a/docs/plans/2026-07-15-installed-plugin-supervision.md
+++ b/docs/plans/2026-07-15-installed-plugin-supervision.md
@@ -1,0 +1,115 @@
+# Installed plugin supervision
+
+## Goal
+
+Keep installed plugins available across process exits and lost daemon
+connections, make recovery visible in Settings, and let a restarted OpenCode
+plugin resume monitoring attn-owned native sessions without relaunching their
+TUIs.
+
+## Architecture Map
+
+```text
+Current:
+daemon discovery / install
+  -> start bun once
+    -> Wait removes process record
+
+Target:
+daemon discovery / install
+  -> pluginSupervisor.Ensure(manifest)
+    -> generation-tagged process
+      -> hello(generation) -> connected + stability timer
+      -> exit / 5s disconnect grace
+        -> bounded backoff -> next generation
+
+driver.register
+  -> store.ListAgentDriverRuns(plugin)
+  -> active_runs response
+    -> OpenCode registry intersection
+      -> orphan/dead cleanup
+      -> surviving HTTP/SSE monitors restart in place
+
+Tests:
+fake clock + fake launcher/handles
+  -> deterministic lifecycle transitions
+fake daemon RPC + fake OpenCode server
+  -> ownership reconciliation + recovered reports
+```
+
+## Data Model / Interfaces
+
+```text
+ManagedPlugin (daemon-owned, in memory)
+  manifest, desired, phase, generation, process
+  restartAttempt, connectedAt, nextRestartAt
+  lastExit, restart/grace/stability cancellation
+
+PluginInfo (daemon -> Settings)
+  runtime_phase, restart_attempt, next_restart_at, last_exit
+
+plugin hello (plugin -> daemon)
+  name, version, attn_api_version, generation
+
+driver.register result (daemon -> plugin)
+  ok, active_runs[{session_id, run_id, metadata}]
+```
+
+## Boundaries
+
+- `pluginSupervisor` owns process desired state, generation checks, timers, and
+  exit diagnostics; it does not know about OpenCode or plugin drivers.
+- The daemon supplies process environment and translates connection lifecycle
+  into supervisor notifications.
+- The store is authoritative for active plugin-run ownership. OpenCode's private
+  registry contains the credentials and sequence needed to reconnect, but may
+  not resurrect a run absent from the store result.
+- OpenCode recovery reuses the existing monitor path and never spawns a TUI or
+  selects a different native conversation.
+
+## Execution
+
+- [x] Add the injectable supervisor with restart, backoff, stability, stop, and
+  disconnect-grace coverage.
+- [x] Route daemon discovery, install, remove, shutdown, and plugin connections
+  through desired-state and generation-aware supervision.
+- [x] Expose supervisor snapshots in the protocol and Settings; regenerate types
+  and increment the daemon protocol.
+- [x] Return authoritative active runs from `driver.register`; increment the
+  plugin API and update compatibility fixtures.
+- [x] Add OpenCode registry listing, ownership reconciliation, and monitor-only
+  recovery with focused adapter coverage.
+- [x] Update operational docs and changelog.
+- [x] Run full automated checks and the isolated packaged-app crash/recovery
+  scenario before opening the PR.
+- [ ] Open the PR, address Figgyster review, and merge only after approval.
+
+## Decisions
+
+- Put the supervisor behind launcher and clock interfaces so lifecycle tests do
+  not sleep or spawn real processes.
+- Include `generation` in plugin hello under the bumped API. Process identity
+  cannot be inferred safely from plugin name after a restart.
+- Reset restart attempts only after 60 seconds connected, not merely alive.
+- Treat OpenCode recovery as monitor reconstruction from surviving private
+  records; spawning or resuming a PTY remains daemon/worker-owned.
+
+## Verification
+
+- `go test ./...`
+- Focused supervisor tests under `go test -race`
+- OpenCode plugin: 63 tests, 175 assertions
+- Plugin SDK: 9 tests, 16 assertions
+- Settings: 44 tests
+- `make dev` packaged and installed the isolated `attn-dev` app.
+- Live `attn-dev`: OpenCode completed a turn, the confirmed dev plugin process
+  was terminated, the supervisor started a new process, and the plugin returned
+  healthy. A second turn completed in the same visible TUI with the same attn
+  run ID and native OpenCode session ID; its report sequence advanced from 8 to
+  13. The production plugin process was identified separately and left intact.
+
+## Follow-ups
+
+- Add a manual “restart now” control only if backoff diagnostics show a need.
+- Consider health-triggered restarts only after measuring hung-process false
+  positives.

--- a/examples/plugins/worktree-deps-hook/attn-plugin.toml
+++ b/examples/plugins/worktree-deps-hook/attn-plugin.toml
@@ -1,6 +1,6 @@
 name = "worktree-deps-hook"
 version = "0.1.0"
-attn_api_version = 3
+attn_api_version = 4
 description = "Example worktree after-create hook that installs JavaScript dependencies"
 
 [plugin]

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -213,6 +213,7 @@ type Daemon struct {
 	pluginReports      map[string][]pendingPluginReport
 	pluginExits        map[string]ptybackend.ExitInfo
 	pluginDir          string
+	removePlugin       func(pluginDir, name string) error
 
 	worktreePluginCallTimeout         time.Duration
 	worktreeCreateProviderCallTimeout time.Duration

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -199,19 +199,20 @@ type Daemon struct {
 	// fsStore is the generic filesystem view over the SAME root as the notebook
 	// (notebook.root). It is the raw layer beneath the curated notebook surface;
 	// both share the one root watcher started by ensureNotebookWatcher.
-	fsMu             sync.Mutex
-	fsStore          *fsdoc.Store
-	pendingInitialWS map[*wsClient]struct{}
-	startedOnce      sync.Once
-	startedCh        chan struct{}
-	tailscale        *tailscaleRuntime
-	plugins          *pluginRegistry
-	pluginProcesses  *pluginProcessRegistry
-	pluginDriverMu   sync.Mutex
-	pluginLaunching  map[string]pluginSessionLaunch
-	pluginReports    map[string][]pendingPluginReport
-	pluginExits      map[string]ptybackend.ExitInfo
-	pluginDir        string
+	fsMu               sync.Mutex
+	fsStore            *fsdoc.Store
+	pendingInitialWS   map[*wsClient]struct{}
+	startedOnce        sync.Once
+	startedCh          chan struct{}
+	tailscale          *tailscaleRuntime
+	plugins            *pluginRegistry
+	pluginSupervisorMu sync.Mutex
+	pluginSupervisor   *pluginSupervisor
+	pluginDriverMu     sync.Mutex
+	pluginLaunching    map[string]pluginSessionLaunch
+	pluginReports      map[string][]pendingPluginReport
+	pluginExits        map[string]ptybackend.ExitInfo
+	pluginDir          string
 
 	worktreePluginCallTimeout         time.Duration
 	worktreeCreateProviderCallTimeout time.Duration
@@ -563,7 +564,6 @@ func New(socketPath string) *Daemon {
 		pendingResumeID:    make(map[string]string),
 		tailscale:          newTailscaleRuntime(),
 		plugins:            newPluginRegistry(),
-		pluginProcesses:    newPluginProcessRegistry(),
 		pluginDir:          pluginDirForSocket(socketPath),
 		workspaces:         newWorkspaceRegistry(),
 	}
@@ -601,7 +601,6 @@ func NewForTesting(socketPath string) *Daemon {
 		pendingResumeID:    make(map[string]string),
 		tailscale:          newTailscaleRuntime(),
 		plugins:            newPluginRegistry(),
-		pluginProcesses:    newPluginProcessRegistry(),
 		pluginDir:          pluginDirForSocket(socketPath),
 		workspaces:         newWorkspaceRegistry(),
 		workflowDirty:      make(map[string]bool),
@@ -645,7 +644,6 @@ func NewWithGitHubClient(socketPath string, ghClient github.GitHubClient) *Daemo
 		pendingResumeID:    make(map[string]string),
 		tailscale:          newTailscaleRuntime(),
 		plugins:            newPluginRegistry(),
-		pluginProcesses:    newPluginProcessRegistry(),
 		pluginDir:          pluginDirForSocket(socketPath),
 		workspaces:         newWorkspaceRegistry(),
 		workflowDirty:      make(map[string]bool),
@@ -692,9 +690,7 @@ func (d *Daemon) Start() error {
 	if d.plugins == nil {
 		d.plugins = newPluginRegistry()
 	}
-	if d.pluginProcesses == nil {
-		d.pluginProcesses = newPluginProcessRegistry()
-	}
+	d.ensurePluginSupervisor()
 	// Push the headless context-window cap into the agent package's process-global
 	// before any headless run can start, so the default (or configured) cap
 	// applies from the first keeper/narration/reconcile run.

--- a/internal/daemon/plugin_driver.go
+++ b/internal/daemon/plugin_driver.go
@@ -28,7 +28,14 @@ type pluginDriverRegisterParams struct {
 }
 
 type pluginDriverRegisterResult struct {
-	OK bool `json:"ok"`
+	OK         bool              `json:"ok"`
+	ActiveRuns []activePluginRun `json:"active_runs,omitempty"`
+}
+
+type activePluginRun struct {
+	SessionID string          `json:"session_id"`
+	RunID     string          `json:"run_id"`
+	Metadata  json.RawMessage `json:"metadata,omitempty"`
 }
 
 type pluginDriverSpawnParams struct {
@@ -190,7 +197,16 @@ func (d *Daemon) handlePluginDriverMethod(plugin *pluginConnection, msg jsonRPCM
 		}
 		d.logf("plugin driver registered plugin=%s agent=%s", plugin.name, normalizePluginAgent(params.Agent))
 		d.broadcastSettings("")
-		return pluginDriverRegisterResult{OK: true}, true, nil
+		active := d.store.ListAgentDriverRuns(plugin.name)
+		runs := make([]activePluginRun, 0, len(active))
+		for _, run := range active {
+			item := activePluginRun{SessionID: run.SessionID, RunID: run.RunID}
+			if json.Valid([]byte(run.Metadata)) {
+				item.Metadata = json.RawMessage(run.Metadata)
+			}
+			runs = append(runs, item)
+		}
+		return pluginDriverRegisterResult{OK: true, ActiveRuns: runs}, true, nil
 	case "session.report_state":
 		var params pluginReportStateParams
 		if err := json.Unmarshal(msg.Params, &params); err != nil {

--- a/internal/daemon/plugin_driver_test.go
+++ b/internal/daemon/plugin_driver_test.go
@@ -49,6 +49,42 @@ func TestPluginDriverRegister_PublishesDynamicAgentSettings(t *testing.T) {
 	}
 }
 
+func TestPluginDriverRegister_ReturnsOnlyActiveRunsOwnedByPlugin(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	now := protocol.TimestampNow().String()
+	for _, sessionID := range []string{"owned", "other"} {
+		d.store.Add(&protocol.Session{ID: sessionID, Agent: "external", State: protocol.SessionStateWorking, StateSince: now, LastSeen: now})
+	}
+	if !d.store.BeginAgentDriverRun("owned", "snipe-plugin", "run-owned") ||
+		!d.store.BeginAgentDriverRun("other", "other-plugin", "run-other") {
+		t.Fatal("BeginAgentDriverRun failed")
+	}
+	if !d.store.ApplyAgentDriverMetadata("owned", "run-owned", 1, `{"native_id":"abc"}`) {
+		t.Fatal("ApplyAgentDriverMetadata failed")
+	}
+
+	client, done := startPluginPipe(t, d, "snipe-plugin", nil)
+	defer func() {
+		_ = client.Close()
+		<-done
+	}()
+	response := sendPluginMethodResponse(t, client, 2, "driver.register", pluginDriverRegisterParams{Agent: "snipe"})
+	if response.Error != nil {
+		t.Fatalf("driver.register error=%#v", response.Error)
+	}
+	var result pluginDriverRegisterResult
+	if err := json.Unmarshal(response.Result, &result); err != nil {
+		t.Fatalf("decode register result: %v", err)
+	}
+	if !result.OK || len(result.ActiveRuns) != 1 {
+		t.Fatalf("result=%+v, want one active run", result)
+	}
+	run := result.ActiveRuns[0]
+	if run.SessionID != "owned" || run.RunID != "run-owned" || string(run.Metadata) != `{"native_id":"abc"}` {
+		t.Fatalf("active run=%+v", run)
+	}
+}
+
 func TestHandleSpawnSession_PluginDriverLaunchesReturnedCommand(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}

--- a/internal/daemon/plugin_rpc.go
+++ b/internal/daemon/plugin_rpc.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-const pluginAPIVersion = 3
+const pluginAPIVersion = 4
 const pluginHealthMethod = "attn.health"
 const pluginHealthInterval = 15 * time.Second
 const pluginHealthTimeout = 2 * time.Second
@@ -32,6 +32,7 @@ type pluginHelloParams struct {
 	Name           string   `json:"name"`
 	Version        string   `json:"version"`
 	AttnAPIVersion int      `json:"attn_api_version"`
+	Generation     uint64   `json:"generation"`
 	Surfaces       []string `json:"surfaces,omitempty"`
 }
 
@@ -246,7 +247,8 @@ func validatePluginSurfaces(values []string) ([]string, error) {
 }
 
 type pluginConnection struct {
-	name string
+	name       string
+	generation uint64
 
 	conn   net.Conn
 	reader *bufio.Reader
@@ -267,6 +269,7 @@ type pluginConnection struct {
 func newPluginConnection(conn net.Conn, reader *bufio.Reader, params pluginHelloParams) *pluginConnection {
 	return &pluginConnection{
 		name:         strings.TrimSpace(params.Name),
+		generation:   params.Generation,
 		conn:         conn,
 		reader:       reader,
 		pending:      make(map[string]chan jsonRPCMessage),
@@ -494,6 +497,9 @@ func parsePluginHello(data []byte) (json.RawMessage, pluginHelloParams, bool, er
 	if params.AttnAPIVersion != pluginAPIVersion {
 		return msg.ID, pluginHelloParams{}, true, fmt.Errorf("unsupported attn_api_version %d", params.AttnAPIVersion)
 	}
+	if params.Generation == 0 {
+		return msg.ID, pluginHelloParams{}, true, errors.New("hello params.generation is required")
+	}
 	return msg.ID, params, true, nil
 }
 
@@ -541,7 +547,17 @@ func (d *Daemon) handlePluginConnection(conn net.Conn, reader *bufio.Reader, hel
 		_ = plugin.send(jsonRPCFailure(helloID, jsonRPCInvalidRequest, err.Error()))
 		return
 	}
+	if !d.ensurePluginSupervisor().NoteConnected(plugin.name, plugin.generation) {
+		registry.unregister(plugin)
+		_ = plugin.send(jsonRPCFailure(helloID, jsonRPCInvalidRequest, "plugin generation is no longer current"))
+		return
+	}
 	defer func() {
+		// Mark this connection gone before making the plugin name available to a
+		// replacement connection. That ordering lets the replacement's
+		// NoteConnected cancel the disconnect grace instead of an old defer
+		// arming the timer after the new connection is already healthy.
+		d.ensurePluginSupervisor().NoteDisconnected(plugin.name, plugin.generation)
 		registry.unregister(plugin)
 		plugin.closePending(io.EOF)
 		d.broadcastPluginsUpdated()

--- a/internal/daemon/plugin_rpc_test.go
+++ b/internal/daemon/plugin_rpc_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,6 +107,7 @@ func TestDaemon_HandleConnection_PluginHelloCanArriveAcrossWrites(t *testing.T) 
 			Name:           "split-provider",
 			Version:        "0.1.0",
 			AttnAPIVersion: pluginAPIVersion,
+			Generation:     1,
 		}),
 	})
 	if err != nil {
@@ -134,6 +136,99 @@ func TestDaemon_HandleConnection_PluginHelloCanArriveAcrossWrites(t *testing.T) 
 	case <-time.After(2 * time.Second):
 		t.Fatal("fragmented plugin connection did not close after client disconnect")
 	}
+}
+
+func TestParsePluginHelloRejectsOldAPIAndMissingGeneration(t *testing.T) {
+	tests := []struct {
+		name   string
+		params pluginHelloParams
+		want   string
+	}{
+		{
+			name: "old api",
+			params: pluginHelloParams{
+				Name:           "old-provider",
+				Version:        "0.1.0",
+				AttnAPIVersion: pluginAPIVersion - 1,
+				Generation:     1,
+			},
+			want: "unsupported attn_api_version",
+		},
+		{
+			name: "missing generation",
+			params: pluginHelloParams{
+				Name:           "missing-generation",
+				Version:        "0.1.0",
+				AttnAPIVersion: pluginAPIVersion,
+			},
+			want: "hello params.generation is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := json.Marshal(jsonRPCMessage{
+				JSONRPC: "2.0",
+				ID:      json.RawMessage("1"),
+				Method:  "hello",
+				Params:  mustMarshalPluginHelloParams(t, tt.params),
+			})
+			if err != nil {
+				t.Fatalf("marshal hello: %v", err)
+			}
+			_, _, matched, err := parsePluginHello(payload)
+			if !matched || err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("matched=%v error=%v, want %q", matched, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestDaemon_PluginConnectionGenerationDrivesDisconnectRecovery(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{}
+	d.pluginSupervisor = newTestPluginSupervisor(clock, launcher)
+	if err := d.pluginSupervisor.Ensure(pluginManifest{Name: "supervised"}); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	initial, _ := d.pluginSupervisor.Snapshot("supervised")
+	client, done := startPluginPipeGeneration(t, d, "supervised", nil, initial.Generation)
+	connected, _ := d.pluginSupervisor.Snapshot("supervised")
+	if connected.Phase != pluginPhaseConnected {
+		t.Fatalf("phase=%q after hello, want connected", connected.Phase)
+	}
+	_ = client.Close()
+	<-done
+
+	clock.Advance(pluginDisconnectGrace)
+	waitForSupervisor(t, func() bool {
+		snapshot, _ := d.pluginSupervisor.Snapshot("supervised")
+		return snapshot.Phase == pluginPhaseBackoff
+	})
+	clock.Advance(pluginRestartBackoff[0])
+	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
+	restarted, _ := d.pluginSupervisor.Snapshot("supervised")
+	if restarted.Generation == initial.Generation {
+		t.Fatal("restart did not advance generation")
+	}
+
+	serverConn, staleConn := net.Pipe()
+	staleDone := make(chan struct{})
+	go func() {
+		defer close(staleDone)
+		d.handleConnection(serverConn)
+	}()
+	sendPluginHelloWithGeneration(t, staleConn, "supervised", nil, initial.Generation)
+	if response := decodeJSONRPCMessage(t, staleConn); response.Error == nil {
+		t.Fatal("stale generation hello succeeded")
+	}
+	_ = staleConn.Close()
+	<-staleDone
+
+	current, currentDone := startPluginPipeGeneration(t, d, "supervised", nil, restarted.Generation)
+	d.pluginSupervisor.Stop("supervised", pluginStopRemove)
+	_ = current.Close()
+	<-currentDone
 }
 
 func TestDaemon_HandleConnection_PluginHelloRegistersSurfaces(t *testing.T) {
@@ -395,6 +490,10 @@ func TestDaemon_PluginHealthCheckRecordsStatus(t *testing.T) {
 }
 
 func startPluginPipe(t *testing.T, d *Daemon, name string, surfaces []string) (net.Conn, <-chan struct{}) {
+	return startPluginPipeGeneration(t, d, name, surfaces, 1)
+}
+
+func startPluginPipeGeneration(t *testing.T, d *Daemon, name string, surfaces []string, generation uint64) (net.Conn, <-chan struct{}) {
 	t.Helper()
 	serverConn, clientConn := net.Pipe()
 	done := make(chan struct{})
@@ -403,7 +502,7 @@ func startPluginPipe(t *testing.T, d *Daemon, name string, surfaces []string) (n
 		d.handleConnection(serverConn)
 	}()
 
-	sendPluginHelloWithSurfaces(t, clientConn, name, surfaces)
+	sendPluginHelloWithGeneration(t, clientConn, name, surfaces, generation)
 	helloResp := decodeJSONRPCMessage(t, clientConn)
 	if helloResp.Error != nil {
 		t.Fatalf("hello error = %#v, want nil", helloResp.Error)
@@ -416,11 +515,16 @@ func sendPluginHello(t *testing.T, conn net.Conn, name string) {
 }
 
 func sendPluginHelloWithSurfaces(t *testing.T, conn net.Conn, name string, surfaces []string) {
+	sendPluginHelloWithGeneration(t, conn, name, surfaces, 1)
+}
+
+func sendPluginHelloWithGeneration(t *testing.T, conn net.Conn, name string, surfaces []string, generation uint64) {
 	t.Helper()
 	params, err := json.Marshal(pluginHelloParams{
 		Name:           name,
 		Version:        "0.1.0",
 		AttnAPIVersion: pluginAPIVersion,
+		Generation:     generation,
 		Surfaces:       surfaces,
 	})
 	if err != nil {

--- a/internal/daemon/plugin_runtime.go
+++ b/internal/daemon/plugin_runtime.go
@@ -1,13 +1,10 @@
 package daemon
 
 import (
-	"errors"
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/victorarias/attn/internal/plugins"
 )
@@ -36,68 +33,24 @@ func loadPluginManifest(path string) (pluginManifest, error) {
 	return plugins.LoadManifest(path)
 }
 
-type pluginProcessRegistry struct {
-	mu        sync.Mutex
-	processes map[string]*pluginProcess
-}
-
-type pluginProcess struct {
-	manifest pluginManifest
-	cmd      *exec.Cmd
-}
-
-func newPluginProcessRegistry() *pluginProcessRegistry {
-	return &pluginProcessRegistry{processes: make(map[string]*pluginProcess)}
-}
-
-func (r *pluginProcessRegistry) add(process *pluginProcess) error {
-	if process == nil || process.manifest.Name == "" {
-		return errors.New("plugin process name is required")
+func (d *Daemon) ensurePluginSupervisor() *pluginSupervisor {
+	d.pluginSupervisorMu.Lock()
+	defer d.pluginSupervisorMu.Unlock()
+	if d.pluginSupervisor == nil {
+		d.pluginSupervisor = newPluginSupervisor(
+			execPluginProcessLauncher{},
+			realPluginSupervisorClock{},
+			func(manifest pluginManifest, generation uint64) []string {
+				return d.pluginCommandEnv(
+					"ATTN_SOCKET_PATH="+d.socketPath,
+					"ATTN_PLUGIN_NAME="+manifest.Name,
+					"ATTN_PLUGIN_GENERATION="+strconv.FormatUint(generation, 10),
+				)
+			},
+			d.broadcastPluginsUpdated,
+		)
 	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if _, exists := r.processes[process.manifest.Name]; exists {
-		return fmt.Errorf("plugin process %q is already running", process.manifest.Name)
-	}
-	r.processes[process.manifest.Name] = process
-	return nil
-}
-
-func (r *pluginProcessRegistry) remove(name string, process *pluginProcess) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.processes[name] == process {
-		delete(r.processes, name)
-	}
-}
-
-func (r *pluginProcessRegistry) get(name string) *pluginProcess {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.processes[name]
-}
-
-func (r *pluginProcessRegistry) isRunning(name string) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.processes[name] != nil
-}
-
-func (r *pluginProcessRegistry) list() []*pluginProcess {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	processes := make([]*pluginProcess, 0, len(r.processes))
-	for _, process := range r.processes {
-		processes = append(processes, process)
-	}
-	return processes
-}
-
-func (d *Daemon) ensurePluginProcessRegistry() *pluginProcessRegistry {
-	if d.pluginProcesses == nil {
-		d.pluginProcesses = newPluginProcessRegistry()
-	}
-	return d.pluginProcesses
+	return d.pluginSupervisor
 }
 
 func (d *Daemon) startInstalledPlugins() {
@@ -114,38 +67,7 @@ func (d *Daemon) startInstalledPlugins() {
 }
 
 func (d *Daemon) startInstalledPlugin(manifest pluginManifest) error {
-	cmd := exec.Command("/usr/bin/env", "bun", "run", manifest.Plugin.Entrypoint)
-	cmd.Dir = manifest.Dir
-	cmd.Env = d.pluginCommandEnv(
-		"ATTN_SOCKET_PATH="+d.socketPath,
-		"ATTN_PLUGIN_NAME="+manifest.Name,
-	)
-
-	process := &pluginProcess{manifest: manifest, cmd: cmd}
-	registry := d.ensurePluginProcessRegistry()
-	if err := registry.add(process); err != nil {
-		return err
-	}
-	if err := cmd.Start(); err != nil {
-		registry.remove(manifest.Name, process)
-		return fmt.Errorf("start bun process: %w", err)
-	}
-
-	go func() {
-		err := cmd.Wait()
-		registry.remove(manifest.Name, process)
-		select {
-		case <-d.done:
-			return
-		default:
-		}
-		if err != nil {
-			d.logf("plugin %s exited: %v", manifest.Name, err)
-			return
-		}
-		d.logf("plugin %s exited", manifest.Name)
-	}()
-	return nil
+	return d.ensurePluginSupervisor().Ensure(manifest)
 }
 
 func (d *Daemon) pluginCommandEnv(extra ...string) []string {
@@ -184,18 +106,9 @@ func mergePluginEnvironment(base, overlay []string) []string {
 }
 
 func (d *Daemon) stopInstalledPlugins() {
-	for _, process := range d.ensurePluginProcessRegistry().list() {
-		if process.cmd == nil || process.cmd.Process == nil {
-			continue
-		}
-		_ = process.cmd.Process.Kill()
-	}
+	d.ensurePluginSupervisor().Shutdown()
 }
 
 func (d *Daemon) stopInstalledPlugin(name string) {
-	process := d.ensurePluginProcessRegistry().get(name)
-	if process == nil || process.cmd == nil || process.cmd.Process == nil {
-		return
-	}
-	_ = process.cmd.Process.Kill()
+	d.ensurePluginSupervisor().Stop(name, pluginStopRemove)
 }

--- a/internal/daemon/plugin_runtime_test.go
+++ b/internal/daemon/plugin_runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -50,7 +51,7 @@ func TestDiscoverPluginManifests_ReportsInvalidManifest(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(badDir, pluginManifestName), []byte(`
 name = "bad-plugin"
 version = "0.1.0"
-attn_api_version = 3
+attn_api_version = 4
 `), 0o644); err != nil {
 		t.Fatalf("write bad manifest: %v", err)
 	}
@@ -77,7 +78,7 @@ func TestDiscoverPluginManifests_AllowsRuntimeOnlyManifestNames(t *testing.T) {
 	manifest := []byte(`
 name = "manual/provider"
 version = "0.1.0"
-attn_api_version = 3
+attn_api_version = 4
 
 [plugin]
 entrypoint = "src/index.ts"
@@ -132,6 +133,61 @@ func TestDaemon_StartInstalledPlugins_SpawnsProviderPlugin(t *testing.T) {
 	}
 }
 
+func TestDaemon_StartInstalledPlugins_RestartsCleanExitWithNewGeneration(t *testing.T) {
+	t.Setenv("ATTN_WS_PORT", "19972")
+	t.Setenv("ATTN_PLUGIN_HELPER", "1")
+	t.Setenv("ATTN_TEST_HELPER_BINARY", os.Args[0])
+
+	tmpDir := shortTempDir(t)
+	t.Setenv("ATTN_PLUGIN_EXIT_ONCE_MARKER", filepath.Join(tmpDir, "first-generation-exited"))
+	sockPath := filepath.Join(tmpDir, "plugin-runtime.sock")
+	pluginDir := filepath.Join(tmpDir, "plugins")
+	writeTestPluginManifest(t, pluginDir, "restarted-provider")
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir fake bun dir: %v", err)
+	}
+	bunPath := filepath.Join(binDir, "bun")
+	if err := os.WriteFile(bunPath, []byte("#!/bin/sh\nexec \"$ATTN_TEST_HELPER_BINARY\" -test.run '^TestDaemonPluginProcessHelper$'\n"), 0o755); err != nil {
+		t.Fatalf("write fake bun: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	d := NewForTesting(sockPath)
+	d.pluginDir = pluginDir
+	// Isolate process launching from the daemon's asynchronous login-shell env
+	// prewarm so every generation resolves the same fake bun fixture.
+	d.pluginSupervisor = newPluginSupervisor(
+		execPluginProcessLauncher{},
+		realPluginSupervisorClock{},
+		func(manifest pluginManifest, generation uint64) []string {
+			return mergePluginEnvironment(os.Environ(), []string{
+				"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+				"ATTN_SOCKET_PATH=" + sockPath,
+				"ATTN_PLUGIN_NAME=" + manifest.Name,
+				"ATTN_PLUGIN_GENERATION=" + strconv.FormatUint(generation, 10),
+			})
+		},
+		d.broadcastPluginsUpdated,
+	)
+	go d.Start()
+	defer d.Stop()
+	waitForSocket(t, sockPath, 5*time.Second)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot, ok := d.ensurePluginSupervisor().Snapshot("restarted-provider")
+		if ok && snapshot.Generation >= 2 && snapshot.Phase == pluginPhaseConnected {
+			if len(d.plugins.handlersForSurface("worktree.create")) != 1 {
+				t.Fatal("restarted plugin did not restore its surface")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	snapshot, _ := d.ensurePluginSupervisor().Snapshot("restarted-provider")
+	t.Fatalf("plugin did not reconnect after clean exit: %+v", snapshot)
+}
+
 func TestPluginCommandEnv_UsesLoginShellEnvironment(t *testing.T) {
 	t.Setenv("PATH", "/daemon/bin")
 
@@ -166,9 +222,23 @@ func TestDaemonPluginProcessHelper(t *testing.T) {
 	defer conn.Close()
 
 	name := os.Getenv("ATTN_PLUGIN_NAME")
-	sendPluginHelloWithSurfaces(t, conn, name, []string{"worktree.create", "worktree.delete"})
+	generation, err := strconv.ParseUint(os.Getenv("ATTN_PLUGIN_GENERATION"), 10, 64)
+	if err != nil || generation == 0 {
+		t.Fatalf("invalid plugin generation %q", os.Getenv("ATTN_PLUGIN_GENERATION"))
+	}
+	sendPluginHelloWithGeneration(t, conn, name, []string{"worktree.create", "worktree.delete"}, generation)
 	if resp := decodeJSONRPCMessage(t, conn); resp.Error != nil {
 		t.Fatalf("helper hello error=%#v", resp.Error)
+	}
+	if marker := os.Getenv("ATTN_PLUGIN_EXIT_ONCE_MARKER"); marker != "" {
+		file, err := os.OpenFile(marker, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			_ = file.Close()
+			return
+		}
+		if !os.IsExist(err) {
+			t.Fatalf("create one-shot exit marker: %v", err)
+		}
 	}
 
 	time.Sleep(30 * time.Second)
@@ -197,7 +267,7 @@ func writeTestPluginManifest(t *testing.T, pluginDir, name string) {
 	manifest := []byte(`
 name = "` + name + `"
 version = "0.1.0"
-attn_api_version = 3
+attn_api_version = 4
 
 [plugin]
 entrypoint = "src/index.ts"

--- a/internal/daemon/plugin_supervisor.go
+++ b/internal/daemon/plugin_supervisor.go
@@ -1,0 +1,467 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type pluginDesiredState string
+
+const (
+	pluginDesiredRunning pluginDesiredState = "running"
+	pluginDesiredStopped pluginDesiredState = "stopped"
+)
+
+type pluginRuntimePhase string
+
+const (
+	pluginPhaseStarting  pluginRuntimePhase = "starting"
+	pluginPhaseConnected pluginRuntimePhase = "connected"
+	pluginPhaseBackoff   pluginRuntimePhase = "backoff"
+	pluginPhaseStopped   pluginRuntimePhase = "stopped"
+)
+
+type pluginStopReason string
+
+const (
+	pluginStopRemove   pluginStopReason = "remove"
+	pluginStopShutdown pluginStopReason = "shutdown"
+)
+
+var pluginRestartBackoff = []time.Duration{
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+	16 * time.Second,
+	30 * time.Second,
+}
+
+const pluginDisconnectGrace = 5 * time.Second
+const pluginStableConnection = 60 * time.Second
+
+type pluginExit struct {
+	At       time.Time
+	ExitCode *int
+	Signal   string
+	Error    string
+}
+
+func (e pluginExit) String() string {
+	detail := strings.TrimSpace(e.Error)
+	if detail == "" && e.Signal != "" {
+		detail = "signal " + e.Signal
+	}
+	if detail == "" && e.ExitCode != nil {
+		detail = fmt.Sprintf("exit code %d", *e.ExitCode)
+	}
+	if detail == "" {
+		detail = "process exited"
+	}
+	if e.At.IsZero() {
+		return detail
+	}
+	return fmt.Sprintf("%s: %s", e.At.Format(time.RFC3339), detail)
+}
+
+type pluginRuntimeSnapshot struct {
+	Desired        pluginDesiredState
+	Phase          pluginRuntimePhase
+	Generation     uint64
+	Running        bool
+	Connected      bool
+	RestartAttempt int
+	StartedAt      time.Time
+	ConnectedAt    time.Time
+	NextRestartAt  time.Time
+	LastExit       *pluginExit
+}
+
+type pluginProcessHandle interface {
+	Wait() pluginExit
+	Kill() error
+}
+
+type pluginProcessLauncher interface {
+	Start(manifest pluginManifest, env []string) (pluginProcessHandle, error)
+}
+
+type pluginSupervisorTimer interface {
+	Stop() bool
+}
+
+type pluginSupervisorClock interface {
+	Now() time.Time
+	AfterFunc(time.Duration, func()) pluginSupervisorTimer
+}
+
+type realPluginSupervisorClock struct{}
+
+func (realPluginSupervisorClock) Now() time.Time { return time.Now() }
+func (realPluginSupervisorClock) AfterFunc(delay time.Duration, fn func()) pluginSupervisorTimer {
+	return time.AfterFunc(delay, fn)
+}
+
+type execPluginProcessLauncher struct{}
+
+func (execPluginProcessLauncher) Start(manifest pluginManifest, env []string) (pluginProcessHandle, error) {
+	cmd := exec.Command("/usr/bin/env", "bun", "run", manifest.Plugin.Entrypoint)
+	cmd.Dir = manifest.Dir
+	cmd.Env = env
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start bun process: %w", err)
+	}
+	return &execPluginProcess{cmd: cmd}, nil
+}
+
+type execPluginProcess struct {
+	cmd *exec.Cmd
+}
+
+func (p *execPluginProcess) Wait() pluginExit {
+	err := p.cmd.Wait()
+	exit := pluginExit{}
+	if err != nil {
+		exit.Error = err.Error()
+	}
+	if state := p.cmd.ProcessState; state != nil {
+		if code := state.ExitCode(); code >= 0 {
+			exit.ExitCode = intPtr(code)
+		}
+		if status, ok := state.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+			exit.Signal = status.Signal().String()
+		}
+	}
+	return exit
+}
+
+func (p *execPluginProcess) Kill() error {
+	if p.cmd == nil || p.cmd.Process == nil {
+		return nil
+	}
+	return p.cmd.Process.Kill()
+}
+
+type managedPlugin struct {
+	manifest pluginManifest
+	desired  pluginDesiredState
+	phase    pluginRuntimePhase
+
+	generation     uint64
+	process        pluginProcessHandle
+	restartAttempt int
+	startedAt      time.Time
+	connectedAt    time.Time
+	nextRestartAt  time.Time
+	lastExit       *pluginExit
+
+	restartTimer    pluginSupervisorTimer
+	disconnectTimer pluginSupervisorTimer
+	stabilityTimer  pluginSupervisorTimer
+}
+
+type pluginSupervisor struct {
+	mu       sync.Mutex
+	plugins  map[string]*managedPlugin
+	launcher pluginProcessLauncher
+	clock    pluginSupervisorClock
+	env      func(pluginManifest, uint64) []string
+	onChange func()
+	shutdown bool
+}
+
+func newPluginSupervisor(
+	launcher pluginProcessLauncher,
+	clock pluginSupervisorClock,
+	env func(pluginManifest, uint64) []string,
+	onChange func(),
+) *pluginSupervisor {
+	if launcher == nil {
+		launcher = execPluginProcessLauncher{}
+	}
+	if clock == nil {
+		clock = realPluginSupervisorClock{}
+	}
+	if env == nil {
+		env = func(pluginManifest, uint64) []string { return nil }
+	}
+	return &pluginSupervisor{
+		plugins:  make(map[string]*managedPlugin),
+		launcher: launcher,
+		clock:    clock,
+		env:      env,
+		onChange: onChange,
+	}
+}
+
+func (s *pluginSupervisor) Ensure(manifest pluginManifest) error {
+	if strings.TrimSpace(manifest.Name) == "" {
+		return errors.New("plugin process name is required")
+	}
+	s.mu.Lock()
+	if s.shutdown {
+		s.mu.Unlock()
+		return errors.New("plugin supervisor is shut down")
+	}
+	plugin := s.plugins[manifest.Name]
+	if plugin == nil {
+		plugin = &managedPlugin{manifest: manifest, desired: pluginDesiredRunning, phase: pluginPhaseStarting}
+		s.plugins[manifest.Name] = plugin
+	} else {
+		plugin.manifest = manifest
+		plugin.desired = pluginDesiredRunning
+		if plugin.process != nil || plugin.restartTimer != nil {
+			s.mu.Unlock()
+			return nil
+		}
+	}
+	err := s.spawnLocked(plugin)
+	s.mu.Unlock()
+	s.notify()
+	return err
+}
+
+func (s *pluginSupervisor) Stop(name string, _ pluginStopReason) {
+	s.mu.Lock()
+	plugin := s.plugins[name]
+	if plugin == nil {
+		s.mu.Unlock()
+		return
+	}
+	plugin.desired = pluginDesiredStopped
+	plugin.phase = pluginPhaseStopped
+	plugin.generation++
+	plugin.connectedAt = time.Time{}
+	plugin.nextRestartAt = time.Time{}
+	stopPluginTimer(&plugin.restartTimer)
+	stopPluginTimer(&plugin.disconnectTimer)
+	stopPluginTimer(&plugin.stabilityTimer)
+	process := plugin.process
+	plugin.process = nil
+	s.mu.Unlock()
+	if process != nil {
+		_ = process.Kill()
+	}
+	s.notify()
+}
+
+func (s *pluginSupervisor) Shutdown() {
+	s.mu.Lock()
+	if s.shutdown {
+		s.mu.Unlock()
+		return
+	}
+	s.shutdown = true
+	names := make([]string, 0, len(s.plugins))
+	for name := range s.plugins {
+		names = append(names, name)
+	}
+	s.mu.Unlock()
+	for _, name := range names {
+		s.Stop(name, pluginStopShutdown)
+	}
+}
+
+// NoteConnected accepts untracked test/manual connections, but a supervised
+// plugin must present the exact generation injected into its process.
+func (s *pluginSupervisor) NoteConnected(name string, generation uint64) bool {
+	s.mu.Lock()
+	plugin := s.plugins[name]
+	if plugin == nil {
+		s.mu.Unlock()
+		return true
+	}
+	if generation == 0 || generation != plugin.generation || plugin.desired != pluginDesiredRunning || plugin.process == nil {
+		s.mu.Unlock()
+		return false
+	}
+	plugin.phase = pluginPhaseConnected
+	plugin.connectedAt = s.clock.Now()
+	plugin.nextRestartAt = time.Time{}
+	stopPluginTimer(&plugin.disconnectTimer)
+	stopPluginTimer(&plugin.stabilityTimer)
+	capturedGeneration := plugin.generation
+	plugin.stabilityTimer = s.clock.AfterFunc(pluginStableConnection, func() {
+		s.markStable(name, capturedGeneration)
+	})
+	s.mu.Unlock()
+	s.notify()
+	return true
+}
+
+func (s *pluginSupervisor) NoteDisconnected(name string, generation uint64) {
+	s.mu.Lock()
+	plugin := s.plugins[name]
+	if plugin == nil || generation != plugin.generation || plugin.desired != pluginDesiredRunning || plugin.process == nil {
+		s.mu.Unlock()
+		return
+	}
+	plugin.phase = pluginPhaseStarting
+	plugin.connectedAt = time.Time{}
+	stopPluginTimer(&plugin.stabilityTimer)
+	stopPluginTimer(&plugin.disconnectTimer)
+	capturedProcess := plugin.process
+	capturedGeneration := plugin.generation
+	plugin.disconnectTimer = s.clock.AfterFunc(pluginDisconnectGrace, func() {
+		s.disconnectExpired(name, capturedGeneration, capturedProcess)
+	})
+	s.mu.Unlock()
+	s.notify()
+}
+
+func (s *pluginSupervisor) Snapshot(name string) (pluginRuntimeSnapshot, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	plugin := s.plugins[name]
+	if plugin == nil {
+		return pluginRuntimeSnapshot{}, false
+	}
+	snapshot := pluginRuntimeSnapshot{
+		Desired:        plugin.desired,
+		Phase:          plugin.phase,
+		Generation:     plugin.generation,
+		Running:        plugin.process != nil,
+		Connected:      plugin.phase == pluginPhaseConnected,
+		RestartAttempt: plugin.restartAttempt,
+		StartedAt:      plugin.startedAt,
+		ConnectedAt:    plugin.connectedAt,
+		NextRestartAt:  plugin.nextRestartAt,
+	}
+	if plugin.lastExit != nil {
+		exit := *plugin.lastExit
+		if plugin.lastExit.ExitCode != nil {
+			exit.ExitCode = intPtr(*plugin.lastExit.ExitCode)
+		}
+		snapshot.LastExit = &exit
+	}
+	return snapshot, true
+}
+
+func (s *pluginSupervisor) spawnLocked(plugin *managedPlugin) error {
+	plugin.generation++
+	plugin.phase = pluginPhaseStarting
+	plugin.nextRestartAt = time.Time{}
+	stopPluginTimer(&plugin.restartTimer)
+	generation := plugin.generation
+	process, err := s.launcher.Start(plugin.manifest, s.env(plugin.manifest, generation))
+	if err != nil {
+		exit := pluginExit{At: s.clock.Now(), Error: err.Error()}
+		plugin.lastExit = &exit
+		s.scheduleRestartLocked(plugin)
+		return err
+	}
+	plugin.process = process
+	plugin.startedAt = s.clock.Now()
+	stopPluginTimer(&plugin.disconnectTimer)
+	name := plugin.manifest.Name
+	capturedProcess := process
+	plugin.disconnectTimer = s.clock.AfterFunc(pluginDisconnectGrace, func() {
+		s.disconnectExpired(name, generation, capturedProcess)
+	})
+	go func(name string, generation uint64, process pluginProcessHandle) {
+		exit := process.Wait()
+		s.processExited(name, generation, process, exit)
+	}(name, generation, process)
+	return nil
+}
+
+func (s *pluginSupervisor) processExited(name string, generation uint64, process pluginProcessHandle, exit pluginExit) {
+	s.mu.Lock()
+	plugin := s.plugins[name]
+	if plugin == nil || generation != plugin.generation || plugin.process != process {
+		s.mu.Unlock()
+		return
+	}
+	plugin.process = nil
+	plugin.connectedAt = time.Time{}
+	stopPluginTimer(&plugin.disconnectTimer)
+	stopPluginTimer(&plugin.stabilityTimer)
+	exit.At = s.clock.Now()
+	plugin.lastExit = &exit
+	if plugin.desired == pluginDesiredRunning && !s.shutdown {
+		s.scheduleRestartLocked(plugin)
+	} else {
+		plugin.phase = pluginPhaseStopped
+		plugin.nextRestartAt = time.Time{}
+	}
+	s.mu.Unlock()
+	s.notify()
+}
+
+func (s *pluginSupervisor) scheduleRestartLocked(plugin *managedPlugin) {
+	stopPluginTimer(&plugin.restartTimer)
+	plugin.restartAttempt++
+	index := plugin.restartAttempt - 1
+	if index >= len(pluginRestartBackoff) {
+		index = len(pluginRestartBackoff) - 1
+	}
+	delay := pluginRestartBackoff[index]
+	plugin.phase = pluginPhaseBackoff
+	plugin.nextRestartAt = s.clock.Now().Add(delay)
+	capturedGeneration := plugin.generation
+	plugin.restartTimer = s.clock.AfterFunc(delay, func() {
+		s.restart(nameOf(plugin), capturedGeneration)
+	})
+}
+
+func (s *pluginSupervisor) restart(name string, generation uint64) {
+	s.mu.Lock()
+	plugin := s.plugins[name]
+	if plugin == nil || generation != plugin.generation || plugin.desired != pluginDesiredRunning || s.shutdown {
+		s.mu.Unlock()
+		return
+	}
+	plugin.restartTimer = nil
+	_ = s.spawnLocked(plugin)
+	s.mu.Unlock()
+	s.notify()
+}
+
+func (s *pluginSupervisor) markStable(name string, generation uint64) {
+	s.mu.Lock()
+	plugin := s.plugins[name]
+	if plugin == nil || generation != plugin.generation || plugin.phase != pluginPhaseConnected {
+		s.mu.Unlock()
+		return
+	}
+	plugin.restartAttempt = 0
+	plugin.stabilityTimer = nil
+	s.mu.Unlock()
+	s.notify()
+}
+
+func (s *pluginSupervisor) disconnectExpired(name string, generation uint64, process pluginProcessHandle) {
+	s.mu.Lock()
+	plugin := s.plugins[name]
+	if plugin == nil || generation != plugin.generation || plugin.process != process || plugin.phase == pluginPhaseConnected || plugin.desired != pluginDesiredRunning {
+		s.mu.Unlock()
+		return
+	}
+	plugin.disconnectTimer = nil
+	s.mu.Unlock()
+	_ = process.Kill()
+}
+
+func (s *pluginSupervisor) notify() {
+	if s.onChange != nil {
+		s.onChange()
+	}
+}
+
+func stopPluginTimer(timer *pluginSupervisorTimer) {
+	if *timer != nil {
+		(*timer).Stop()
+		*timer = nil
+	}
+}
+
+func nameOf(plugin *managedPlugin) string { return plugin.manifest.Name }
+
+func intPtr(value int) *int { return &value }

--- a/internal/daemon/plugin_supervisor_test.go
+++ b/internal/daemon/plugin_supervisor_test.go
@@ -1,0 +1,368 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPluginSupervisorRestartsExitsWithCappedBackoff(t *testing.T) {
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{}
+	supervisor := newTestPluginSupervisor(clock, launcher)
+	manifest := pluginManifest{Name: "fixture"}
+
+	if err := supervisor.Ensure(manifest); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	for attempt := 1; attempt <= len(pluginRestartBackoff)+2; attempt++ {
+		handle := launcher.handle(attempt - 1)
+		handle.exit(pluginExit{ExitCode: intPtr(0)})
+		waitForSupervisor(t, func() bool {
+			snapshot, _ := supervisor.Snapshot("fixture")
+			return snapshot.Phase == pluginPhaseBackoff && snapshot.RestartAttempt == attempt
+		})
+		snapshot, _ := supervisor.Snapshot("fixture")
+		index := attempt - 1
+		if index >= len(pluginRestartBackoff) {
+			index = len(pluginRestartBackoff) - 1
+		}
+		wantDelay := pluginRestartBackoff[index]
+		if got := snapshot.NextRestartAt.Sub(clock.Now()); got != wantDelay {
+			t.Fatalf("attempt %d delay=%s, want %s", attempt, got, wantDelay)
+		}
+		clock.Advance(wantDelay)
+		waitForSupervisor(t, func() bool { return launcher.count() == attempt+1 })
+	}
+}
+
+func TestPluginSupervisorRetriesStartFailure(t *testing.T) {
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{startErrors: []error{errors.New("bun missing")}}
+	supervisor := newTestPluginSupervisor(clock, launcher)
+
+	if err := supervisor.Ensure(pluginManifest{Name: "fixture"}); err == nil {
+		t.Fatal("Ensure error=nil, want start failure")
+	}
+	snapshot, _ := supervisor.Snapshot("fixture")
+	if snapshot.Phase != pluginPhaseBackoff || snapshot.RestartAttempt != 1 || snapshot.LastExit == nil {
+		t.Fatalf("snapshot=%+v, want first backoff with exit", snapshot)
+	}
+	clock.Advance(250 * time.Millisecond)
+	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
+	snapshot, _ = supervisor.Snapshot("fixture")
+	if snapshot.Phase != pluginPhaseStarting || !snapshot.Running {
+		t.Fatalf("snapshot=%+v, want restarted process", snapshot)
+	}
+}
+
+func TestPluginSupervisorResetsAttemptsOnlyAfterStableConnection(t *testing.T) {
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{}
+	supervisor := newTestPluginSupervisor(clock, launcher)
+	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
+	launcher.handle(0).exit(pluginExit{Error: "crash"})
+	waitForSupervisor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.RestartAttempt == 1
+	})
+	clock.Advance(250 * time.Millisecond)
+	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
+	snapshot, _ := supervisor.Snapshot("fixture")
+	if !supervisor.NoteConnected("fixture", snapshot.Generation) {
+		t.Fatal("NoteConnected rejected current generation")
+	}
+	clock.Advance(pluginStableConnection - time.Millisecond)
+	snapshot, _ = supervisor.Snapshot("fixture")
+	if snapshot.RestartAttempt != 1 {
+		t.Fatalf("attempt=%d before stability window, want 1", snapshot.RestartAttempt)
+	}
+	clock.Advance(time.Millisecond)
+	snapshot, _ = supervisor.Snapshot("fixture")
+	if snapshot.RestartAttempt != 0 || snapshot.Phase != pluginPhaseConnected {
+		t.Fatalf("snapshot=%+v after stability window, want connected attempt 0", snapshot)
+	}
+}
+
+func TestPluginSupervisorDisconnectGraceReconnectAndKill(t *testing.T) {
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{}
+	supervisor := newTestPluginSupervisor(clock, launcher)
+	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
+	snapshot, _ := supervisor.Snapshot("fixture")
+	generation := snapshot.Generation
+	if !supervisor.NoteConnected("fixture", generation) {
+		t.Fatal("NoteConnected rejected current generation")
+	}
+
+	supervisor.NoteDisconnected("fixture", generation)
+	clock.Advance(pluginDisconnectGrace - time.Millisecond)
+	if got := launcher.handle(0).killCount(); got != 0 {
+		t.Fatalf("kills before grace=%d, want 0", got)
+	}
+	if !supervisor.NoteConnected("fixture", generation) {
+		t.Fatal("same-generation reconnect was rejected")
+	}
+	clock.Advance(time.Millisecond)
+	if got := launcher.handle(0).killCount(); got != 0 {
+		t.Fatalf("kills after canceled grace=%d, want 0", got)
+	}
+
+	supervisor.NoteDisconnected("fixture", generation)
+	clock.Advance(pluginDisconnectGrace)
+	if got := launcher.handle(0).killCount(); got != 1 {
+		t.Fatalf("kills after expired grace=%d, want 1", got)
+	}
+	waitForSupervisor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == pluginPhaseBackoff
+	})
+}
+
+func TestPluginSupervisorRestartsProcessThatNeverConnects(t *testing.T) {
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{}
+	supervisor := newTestPluginSupervisor(clock, launcher)
+	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
+
+	clock.Advance(pluginDisconnectGrace)
+	if got := launcher.handle(0).killCount(); got != 1 {
+		t.Fatalf("kills after startup grace=%d, want 1", got)
+	}
+	waitForSupervisor(t, func() bool {
+		snapshot, _ := supervisor.Snapshot("fixture")
+		return snapshot.Phase == pluginPhaseBackoff && snapshot.RestartAttempt == 1
+	})
+	clock.Advance(pluginRestartBackoff[0])
+	waitForSupervisor(t, func() bool { return launcher.count() == 2 })
+}
+
+func TestPluginSupervisorIntentionalStopAndShutdownNeverRestart(t *testing.T) {
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{}
+	supervisor := newTestPluginSupervisor(clock, launcher)
+	_ = supervisor.Ensure(pluginManifest{Name: "one"})
+	_ = supervisor.Ensure(pluginManifest{Name: "two"})
+	one, _ := supervisor.Snapshot("one")
+	if !supervisor.NoteConnected("one", one.Generation) {
+		t.Fatal("connect one")
+	}
+	supervisor.NoteDisconnected("one", one.Generation)
+	supervisor.Stop("one", pluginStopRemove)
+
+	stopped, _ := supervisor.Snapshot("one")
+	if stopped.Phase != pluginPhaseStopped || stopped.Running || stopped.Desired != pluginDesiredStopped {
+		t.Fatalf("stopped snapshot=%+v", stopped)
+	}
+	if supervisor.NoteConnected("one", one.Generation) {
+		t.Fatal("stale generation reconnect accepted")
+	}
+	clock.Advance(time.Hour)
+	if got := launcher.count(); got != 2 {
+		t.Fatalf("starts after intentional stop=%d, want 2", got)
+	}
+
+	supervisor.Shutdown()
+	clock.Advance(time.Hour)
+	if got := launcher.count(); got != 2 {
+		t.Fatalf("starts after shutdown=%d, want 2", got)
+	}
+	for _, name := range []string{"one", "two"} {
+		snapshot, _ := supervisor.Snapshot(name)
+		if snapshot.Phase != pluginPhaseStopped || snapshot.Running {
+			t.Fatalf("%s snapshot=%+v after shutdown", name, snapshot)
+		}
+	}
+}
+
+func TestPluginSupervisorSnapshotsStartingConnectedBackoffAndStopped(t *testing.T) {
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{}
+	supervisor := newTestPluginSupervisor(clock, launcher)
+	_ = supervisor.Ensure(pluginManifest{Name: "fixture"})
+
+	snapshot, _ := supervisor.Snapshot("fixture")
+	if snapshot.Phase != pluginPhaseStarting || !snapshot.Running || snapshot.Connected {
+		t.Fatalf("starting snapshot=%+v", snapshot)
+	}
+	if !supervisor.NoteConnected("fixture", snapshot.Generation) {
+		t.Fatal("connect current generation")
+	}
+	snapshot, _ = supervisor.Snapshot("fixture")
+	if snapshot.Phase != pluginPhaseConnected || !snapshot.Connected {
+		t.Fatalf("connected snapshot=%+v", snapshot)
+	}
+	launcher.handle(0).exit(pluginExit{Error: "boom"})
+	waitForSupervisor(t, func() bool {
+		snapshot, _ = supervisor.Snapshot("fixture")
+		return snapshot.Phase == pluginPhaseBackoff
+	})
+	if snapshot.LastExit == nil || snapshot.NextRestartAt.IsZero() {
+		t.Fatalf("backoff snapshot=%+v", snapshot)
+	}
+	supervisor.Stop("fixture", pluginStopRemove)
+	snapshot, _ = supervisor.Snapshot("fixture")
+	if snapshot.Phase != pluginPhaseStopped {
+		t.Fatalf("stopped snapshot=%+v", snapshot)
+	}
+}
+
+func newTestPluginSupervisor(clock *fakePluginClock, launcher *fakePluginLauncher) *pluginSupervisor {
+	return newPluginSupervisor(launcher, clock, func(manifest pluginManifest, generation uint64) []string {
+		return []string{fmt.Sprintf("ATTN_PLUGIN_NAME=%s", manifest.Name), fmt.Sprintf("ATTN_PLUGIN_GENERATION=%d", generation)}
+	}, nil)
+}
+
+type fakePluginLauncher struct {
+	mu          sync.Mutex
+	handles     []*fakePluginProcess
+	startErrors []error
+	envs        [][]string
+}
+
+func (l *fakePluginLauncher) Start(_ pluginManifest, env []string) (pluginProcessHandle, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.envs = append(l.envs, append([]string(nil), env...))
+	index := len(l.envs) - 1
+	if index < len(l.startErrors) && l.startErrors[index] != nil {
+		return nil, l.startErrors[index]
+	}
+	handle := &fakePluginProcess{wait: make(chan pluginExit, 1)}
+	l.handles = append(l.handles, handle)
+	return handle, nil
+}
+
+func (l *fakePluginLauncher) count() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.envs)
+}
+
+func (l *fakePluginLauncher) handle(index int) *fakePluginProcess {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.handles[index]
+}
+
+type fakePluginProcess struct {
+	mu     sync.Mutex
+	wait   chan pluginExit
+	exited bool
+	kills  int
+}
+
+func (p *fakePluginProcess) Wait() pluginExit { return <-p.wait }
+
+func (p *fakePluginProcess) Kill() error {
+	p.mu.Lock()
+	p.kills++
+	alreadyExited := p.exited
+	if !alreadyExited {
+		p.exited = true
+	}
+	p.mu.Unlock()
+	if !alreadyExited {
+		p.wait <- pluginExit{Signal: "killed"}
+	}
+	return nil
+}
+
+func (p *fakePluginProcess) exit(exit pluginExit) {
+	p.mu.Lock()
+	if p.exited {
+		p.mu.Unlock()
+		return
+	}
+	p.exited = true
+	p.mu.Unlock()
+	p.wait <- exit
+}
+
+func (p *fakePluginProcess) killCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.kills
+}
+
+type fakePluginClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers []*fakePluginTimer
+}
+
+func newFakePluginClock() *fakePluginClock {
+	return &fakePluginClock{now: time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakePluginClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakePluginClock) AfterFunc(delay time.Duration, fn func()) pluginSupervisorTimer {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	timer := &fakePluginTimer{clock: c, at: c.now.Add(delay), fn: fn}
+	c.timers = append(c.timers, timer)
+	return timer
+}
+
+func (c *fakePluginClock) Advance(delay time.Duration) {
+	target := c.Now().Add(delay)
+	for {
+		c.mu.Lock()
+		var next *fakePluginTimer
+		for _, timer := range c.timers {
+			if timer.stopped || timer.fired || timer.at.After(target) {
+				continue
+			}
+			if next == nil || timer.at.Before(next.at) {
+				next = timer
+			}
+		}
+		if next == nil {
+			c.now = target
+			c.mu.Unlock()
+			return
+		}
+		c.now = next.at
+		next.fired = true
+		fn := next.fn
+		c.mu.Unlock()
+		fn()
+	}
+}
+
+type fakePluginTimer struct {
+	clock   *fakePluginClock
+	at      time.Time
+	fn      func()
+	stopped bool
+	fired   bool
+}
+
+func (t *fakePluginTimer) Stop() bool {
+	t.clock.mu.Lock()
+	defer t.clock.mu.Unlock()
+	if t.stopped || t.fired {
+		return false
+	}
+	t.stopped = true
+	return true
+}
+
+func waitForSupervisor(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("supervisor condition did not become true")
+}

--- a/internal/daemon/testharness.go
+++ b/internal/daemon/testharness.go
@@ -257,7 +257,6 @@ func (b *TestHarnessBuilder) Build() *TestHarness {
 		longRun:          make(map[string]longRunSession),
 		pendingResumeID:  make(map[string]string),
 		plugins:          newPluginRegistry(),
-		pluginProcesses:  newPluginProcessRegistry(),
 	}
 
 	return &TestHarness{

--- a/internal/daemon/ws_plugins.go
+++ b/internal/daemon/ws_plugins.go
@@ -45,12 +45,12 @@ func (d *Daemon) handleRemovePluginWS(client *wsClient, msg *protocol.RemovePlug
 		d.sendPluginActionResult(client, "remove", "", false, "plugin name is required")
 		return
 	}
+	d.stopInstalledPlugin(name)
 	if err := plugins.Remove(d.pluginDir, name); err != nil {
 		d.sendPluginActionResult(client, "remove", name, false, err.Error())
 		return
 	}
 
-	d.stopInstalledPlugin(name)
 	d.broadcastPluginsUpdated()
 	d.sendPluginActionResult(client, "remove", name, true, "")
 }
@@ -80,6 +80,7 @@ func (d *Daemon) pluginsUpdatedMessage() *protocol.PluginsUpdatedMessage {
 	pluginInfos := make([]protocol.PluginInfo, 0, len(manifests))
 	for _, manifest := range manifests {
 		connection := d.ensurePluginRegistry().get(manifest.Name)
+		runtime, supervised := d.ensurePluginSupervisor().Snapshot(manifest.Name)
 		healthStatus := "unknown"
 		var healthMessage string
 		var lastHealthAt string
@@ -97,8 +98,24 @@ func (d *Daemon) pluginsUpdatedMessage() *protocol.PluginsUpdatedMessage {
 			Dir:          manifest.Dir,
 			Priority:     priorities[manifest.Name],
 			Connected:    connection != nil,
-			Running:      d.ensurePluginProcessRegistry().isRunning(manifest.Name),
+			Running:      runtime.Running,
 			HealthStatus: protocol.Ptr(healthStatus),
+		}
+		runtimePhase := pluginPhaseStopped
+		if supervised {
+			runtimePhase = runtime.Phase
+		} else if connection != nil {
+			runtimePhase = pluginPhaseConnected
+		}
+		info.RuntimePhase = protocol.Ptr(string(runtimePhase))
+		if runtime.RestartAttempt > 0 {
+			info.RestartAttempt = protocol.Ptr(runtime.RestartAttempt)
+		}
+		if !runtime.NextRestartAt.IsZero() {
+			info.NextRestartAt = protocol.Ptr(runtime.NextRestartAt.Format(time.RFC3339Nano))
+		}
+		if runtime.LastExit != nil {
+			info.LastExit = protocol.Ptr(runtime.LastExit.String())
 		}
 		if manifest.Description != "" {
 			info.Description = protocol.Ptr(manifest.Description)

--- a/internal/daemon/ws_plugins.go
+++ b/internal/daemon/ws_plugins.go
@@ -45,11 +45,15 @@ func (d *Daemon) handleRemovePluginWS(client *wsClient, msg *protocol.RemovePlug
 		d.sendPluginActionResult(client, "remove", "", false, "plugin name is required")
 		return
 	}
-	d.stopInstalledPlugin(name)
-	if err := plugins.Remove(d.pluginDir, name); err != nil {
+	remove := d.removePlugin
+	if remove == nil {
+		remove = plugins.Remove
+	}
+	if err := remove(d.pluginDir, name); err != nil {
 		d.sendPluginActionResult(client, "remove", name, false, err.Error())
 		return
 	}
+	d.stopInstalledPlugin(name)
 
 	d.broadcastPluginsUpdated()
 	d.sendPluginActionResult(client, "remove", name, true, "")

--- a/internal/daemon/ws_plugins_test.go
+++ b/internal/daemon/ws_plugins_test.go
@@ -164,7 +164,7 @@ EOF
 	}
 }
 
-func TestDaemon_HandleRemovePluginWSStopsSupervisorBeforeDeletingFiles(t *testing.T) {
+func TestDaemon_HandleRemovePluginWSStopsSupervisorAfterDeletingFiles(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
 	d.pluginDir = filepath.Join(t.TempDir(), "plugins")
 	writeTestPluginManifest(t, d.pluginDir, "removable")
@@ -195,5 +195,41 @@ func TestDaemon_HandleRemovePluginWSStopsSupervisorBeforeDeletingFiles(t *testin
 	snapshot, _ := d.pluginSupervisor.Snapshot("removable")
 	if snapshot.Desired != pluginDesiredStopped || snapshot.Running {
 		t.Fatalf("snapshot after remove=%+v", snapshot)
+	}
+}
+
+func TestDaemon_HandleRemovePluginWSKeepsSupervisorRunningWhenDeletionFails(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	d.pluginDir = filepath.Join(t.TempDir(), "plugins")
+	writeTestPluginManifest(t, d.pluginDir, "removable")
+	manifest, err := loadPluginManifest(filepath.Join(d.pluginDir, "removable", pluginManifestName))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{}
+	d.pluginSupervisor = newTestPluginSupervisor(clock, launcher)
+	if err := d.pluginSupervisor.Ensure(manifest); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	d.removePlugin = func(pluginDir, name string) error {
+		return os.ErrPermission
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 1)}
+	d.handleRemovePluginWS(client, &protocol.RemovePluginMessage{Name: "removable"})
+	event := readOutboundEvent(t, client)
+	if event["success"] != false {
+		t.Fatalf("remove event=%v, want failure", event)
+	}
+	if _, err := os.Stat(manifest.Dir); err != nil {
+		t.Fatalf("installed plugin missing after failed remove: %v", err)
+	}
+	snapshot, _ := d.pluginSupervisor.Snapshot("removable")
+	if snapshot.Desired != pluginDesiredRunning || !snapshot.Running {
+		t.Fatalf("snapshot after failed remove=%+v", snapshot)
+	}
+	if got := launcher.count(); got != 1 {
+		t.Fatalf("start count after failed remove=%d, want 1", got)
 	}
 }

--- a/internal/daemon/ws_plugins_test.go
+++ b/internal/daemon/ws_plugins_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
 )
@@ -74,6 +76,46 @@ func TestDaemon_HandleListPluginsWS_ReturnsInstalledPlugins(t *testing.T) {
 	}
 }
 
+func TestDaemon_PluginsUpdatedMessageIncludesSupervisorBackoff(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	d.pluginDir = filepath.Join(t.TempDir(), "plugins")
+	writeTestPluginManifest(t, d.pluginDir, "recovering-provider")
+	manifest, err := loadPluginManifest(filepath.Join(d.pluginDir, "recovering-provider", pluginManifestName))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{}
+	d.pluginSupervisor = newTestPluginSupervisor(clock, launcher)
+	if err := d.pluginSupervisor.Ensure(manifest); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	launcher.handle(0).exit(pluginExit{ExitCode: intPtr(17)})
+	waitForSupervisor(t, func() bool {
+		snapshot, _ := d.pluginSupervisor.Snapshot(manifest.Name)
+		return snapshot.Phase == pluginPhaseBackoff
+	})
+
+	plugins := d.pluginsUpdatedMessage().Plugins
+	if len(plugins) != 1 {
+		t.Fatalf("plugin count=%d, want 1", len(plugins))
+	}
+	plugin := plugins[0]
+	if got := protocol.Deref(plugin.RuntimePhase); got != string(pluginPhaseBackoff) {
+		t.Fatalf("runtime phase=%q, want backoff", got)
+	}
+	if got := protocol.Deref(plugin.RestartAttempt); got != 1 {
+		t.Fatalf("restart attempt=%d, want 1", got)
+	}
+	if plugin.NextRestartAt == nil || *plugin.NextRestartAt != clock.Now().Add(pluginRestartBackoff[0]).Format(time.RFC3339Nano) {
+		t.Fatalf("next restart=%v, want first backoff deadline", plugin.NextRestartAt)
+	}
+	if plugin.LastExit == nil || !strings.Contains(*plugin.LastExit, "exit code 17") {
+		t.Fatalf("last exit=%v, want exit code 17", plugin.LastExit)
+	}
+}
+
 func TestDaemon_HandleInstallPluginWS_InstallsGitSource(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
 	d.pluginDir = filepath.Join(t.TempDir(), "plugins")
@@ -90,7 +132,7 @@ mkdir -p "$5/src"
 cat > "$5/attn-plugin.toml" <<'EOF'
 name = "attn-snipe"
 version = "0.1.0"
-attn_api_version = 3
+attn_api_version = 4
 
 [plugin]
 entrypoint = "src/index.ts"
@@ -119,5 +161,39 @@ EOF
 	}
 	if _, err := os.Stat(filepath.Join(d.pluginDir, "attn-snipe", "attn-plugin.toml")); err != nil {
 		t.Fatalf("installed plugin manifest missing: %v", err)
+	}
+}
+
+func TestDaemon_HandleRemovePluginWSStopsSupervisorBeforeDeletingFiles(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "daemon.sock"))
+	d.pluginDir = filepath.Join(t.TempDir(), "plugins")
+	writeTestPluginManifest(t, d.pluginDir, "removable")
+	manifest, err := loadPluginManifest(filepath.Join(d.pluginDir, "removable", pluginManifestName))
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	clock := newFakePluginClock()
+	launcher := &fakePluginLauncher{}
+	d.pluginSupervisor = newTestPluginSupervisor(clock, launcher)
+	if err := d.pluginSupervisor.Ensure(manifest); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 1)}
+	d.handleRemovePluginWS(client, &protocol.RemovePluginMessage{Name: "removable"})
+	event := readOutboundEvent(t, client)
+	if event["success"] != true {
+		t.Fatalf("remove event=%v", event)
+	}
+	if _, err := os.Stat(manifest.Dir); !os.IsNotExist(err) {
+		t.Fatalf("plugin dir still exists: %v", err)
+	}
+	clock.Advance(time.Hour)
+	if got := launcher.count(); got != 1 {
+		t.Fatalf("start count after remove=%d, want 1", got)
+	}
+	snapshot, _ := d.pluginSupervisor.Snapshot("removable")
+	if snapshot.Desired != pluginDesiredStopped || snapshot.Running {
+		t.Fatalf("snapshot after remove=%+v", snapshot)
 	}
 }

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	APIVersion   = 3
+	APIVersion   = 4
 	ManifestName = "attn-plugin.toml"
 )
 

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -87,7 +87,7 @@ mkdir -p "$5/src"
 cat > "$5/attn-plugin.toml" <<'EOF'
 name = "attn-snipe"
 version = "0.1.0"
-attn_api_version = 3
+attn_api_version = 4
 
 [plugin]
 entrypoint = "src/index.ts"
@@ -235,7 +235,7 @@ func TestLoadManifestRejectsEntrypointTraversal(t *testing.T) {
 	manifest := []byte(`
 name = "worktree-provider"
 version = "0.1.0"
-attn_api_version = 3
+attn_api_version = 4
 
 [plugin]
 entrypoint = "../outside.ts"
@@ -259,7 +259,7 @@ func writeTestPlugin(t *testing.T, root, name string) {
 	manifest := []byte(`
 name = "` + name + `"
 version = "0.1.0"
-attn_api_version = 3
+attn_api_version = 4
 
 [plugin]
 entrypoint = "src/index.ts"

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "164"
+const ProtocolVersion = "165"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -2403,17 +2403,29 @@ type PluginInfo struct {
 	// HealthStatus corresponds to the JSON schema field "health_status".
 	HealthStatus *string `json:"health_status,omitempty,omitzero"`
 
+	// LastExit corresponds to the JSON schema field "last_exit".
+	LastExit *string `json:"last_exit,omitempty,omitzero"`
+
 	// LastHealthAt corresponds to the JSON schema field "last_health_at".
 	LastHealthAt *string `json:"last_health_at,omitempty,omitzero"`
 
 	// Name corresponds to the JSON schema field "name".
 	Name string `json:"name"`
 
+	// NextRestartAt corresponds to the JSON schema field "next_restart_at".
+	NextRestartAt *string `json:"next_restart_at,omitempty,omitzero"`
+
 	// Priority corresponds to the JSON schema field "priority".
 	Priority int `json:"priority"`
 
+	// RestartAttempt corresponds to the JSON schema field "restart_attempt".
+	RestartAttempt *int `json:"restart_attempt,omitempty,omitzero"`
+
 	// Running corresponds to the JSON schema field "running".
 	Running bool `json:"running"`
+
+	// RuntimePhase corresponds to the JSON schema field "runtime_phase".
+	RuntimePhase *string `json:"runtime_phase,omitempty,omitzero"`
 
 	// Version corresponds to the JSON schema field "version".
 	Version string `json:"version"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -423,6 +423,12 @@ model PluginInfo {
   priority: int32;
   connected: boolean;
   running: boolean;
+  // "starting" | "connected" | "backoff" | "stopped". Plain string keeps
+  // generated Go/TypeScript consumers aligned with other runtime status fields.
+  runtime_phase?: string;
+  restart_attempt?: int32;
+  next_restart_at?: string;
+  last_exit?: string;
   health_status?: string;
   health_message?: string;
   last_health_at?: string;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -37,6 +37,12 @@ type AgentDriverReportCursor struct {
 	Seq        uint64
 }
 
+type ActiveAgentDriverRun struct {
+	SessionID string
+	RunID     string
+	Metadata  string
+}
+
 // New creates a new in-memory store (backed by SQLite :memory:)
 func New() *Store {
 	db, err := OpenDB(":memory:")
@@ -741,6 +747,55 @@ func (s *Store) GetAgentMetadata(id string) string {
 		return ""
 	}
 	return strings.TrimSpace(metadata)
+}
+
+// ListAgentDriverRuns returns the active external-driver runs owned by a
+// plugin. Session lifetime in this store is authoritative during plugin
+// recovery; private plugin state may only reconnect records returned here.
+func (s *Store) ListAgentDriverRuns(pluginName string) []ActiveAgentDriverRun {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	pluginName = strings.TrimSpace(pluginName)
+	if pluginName == "" {
+		return nil
+	}
+	if s.db == nil {
+		var runs []ActiveAgentDriverRun
+		for sessionID, cursor := range s.agentDriverRuns {
+			if cursor.PluginName != pluginName || strings.TrimSpace(cursor.RunID) == "" || s.sessions[sessionID] == nil {
+				continue
+			}
+			runs = append(runs, ActiveAgentDriverRun{
+				SessionID: sessionID,
+				RunID:     strings.TrimSpace(cursor.RunID),
+				Metadata:  strings.TrimSpace(s.agentMetadata[sessionID]),
+			})
+		}
+		sort.Slice(runs, func(i, j int) bool { return runs[i].SessionID < runs[j].SessionID })
+		return runs
+	}
+
+	rows, err := s.db.Query(`
+		SELECT id, agent_driver_run_id, agent_metadata
+		FROM sessions
+		WHERE agent_driver_plugin_name = ? AND agent_driver_run_id <> ''
+		ORDER BY id`, pluginName)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var runs []ActiveAgentDriverRun
+	for rows.Next() {
+		var run ActiveAgentDriverRun
+		if err := rows.Scan(&run.SessionID, &run.RunID, &run.Metadata); err != nil {
+			return nil
+		}
+		run.RunID = strings.TrimSpace(run.RunID)
+		run.Metadata = strings.TrimSpace(run.Metadata)
+		runs = append(runs, run)
+	}
+	return runs
 }
 
 // BeginAgentDriverRun records ownership and resets the cursor for a newly launched external agent run.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -170,6 +171,28 @@ func TestStore_AgentDriverRunRejectsWrongRunAndStaleSequence(t *testing.T) {
 	}
 	if s.ApplyAgentDriverState("plugin-run", "run-a", 3, protocol.StateIdle) {
 		t.Fatal("ApplyAgentDriverState() accepted report after run ended")
+	}
+}
+
+func TestStore_ListAgentDriverRunsFiltersByOwnerAndIncludesMetadata(t *testing.T) {
+	s := New()
+	for _, sessionID := range []string{"session-b", "session-a", "other"} {
+		s.Add(&protocol.Session{ID: sessionID, Agent: "external"})
+	}
+	if !s.BeginAgentDriverRun("session-b", "attn-opencode", "run-b") ||
+		!s.BeginAgentDriverRun("session-a", "attn-opencode", "run-a") ||
+		!s.BeginAgentDriverRun("other", "other-plugin", "run-other") {
+		t.Fatal("BeginAgentDriverRun failed")
+	}
+	if !s.ApplyAgentDriverMetadata("session-a", "run-a", 1, `{"native":"one"}`) {
+		t.Fatal("ApplyAgentDriverMetadata failed")
+	}
+
+	if got := s.ListAgentDriverRuns("attn-opencode"); !reflect.DeepEqual(got, []ActiveAgentDriverRun{
+		{SessionID: "session-a", RunID: "run-a", Metadata: `{"native":"one"}`},
+		{SessionID: "session-b", RunID: "run-b"},
+	}) {
+		t.Fatalf("ListAgentDriverRuns()=%+v", got)
 	}
 }
 

--- a/plugins/attn-opencode/README.md
+++ b/plugins/attn-opencode/README.md
@@ -36,6 +36,13 @@ OpenCode system hook rereads that file for every prompt, so resumed sessions
 receive role and context changes without modifying repository or global
 OpenCode configuration.
 
+If the plugin process exits or loses its daemon connection, attn restarts it
+with bounded backoff. On reconnect, the plugin intersects its private run
+records with the daemon's active-run ownership and rebuilds monitoring only for
+surviving runs. It reconnects to the same authenticated OpenCode server and
+native session; it does not launch another TUI. Orphaned or malformed private
+records are removed.
+
 Ordinary sessions receive the same workspace-context, workflow, and ticket
 guidance as built-in attn agents. Chiefs receive Notebook guidance instead.
 Resuming a session, including a chief promotion or demotion, recomposes the

--- a/plugins/attn-opencode/attn-plugin.toml
+++ b/plugins/attn-opencode/attn-plugin.toml
@@ -1,6 +1,6 @@
 name = "attn-opencode"
 version = "0.1.0"
-attn_api_version = 3
+attn_api_version = 4
 description = "Server-backed OpenCode driver for attn"
 
 [plugin]

--- a/plugins/attn-opencode/src/attn-rpc.ts
+++ b/plugins/attn-opencode/src/attn-rpc.ts
@@ -36,6 +36,7 @@ export class AttnRPCClient {
       socketPath: string;
       name: string;
       version: string;
+      generation: number;
     },
   ) {}
 
@@ -70,6 +71,7 @@ export class AttnRPCClient {
         name: this.options.name,
         version: this.options.version,
         attn_api_version: pluginAPIVersion,
+        generation: this.options.generation,
       });
       if (!result.ok) throw new Error("attn rejected plugin hello");
     } catch (error) {

--- a/plugins/attn-opencode/src/driver.ts
+++ b/plugins/attn-opencode/src/driver.ts
@@ -6,6 +6,8 @@ import { OpenCodeStopClassifier } from "./stop-classifier";
 import {
   type DriverSpawnParams,
   type DriverSpawnResult,
+  type ActivePluginRun,
+  type DriverRegisterResult,
   type LaunchConfig,
   type OpenCodeMetadata,
   type OpenCodeModel,
@@ -105,19 +107,9 @@ export class OpenCodeDriver {
 
   async initialize(): Promise<void> {
     await this.options.registry.initialize();
-    await this.options.registry.pruneDead(async (record) => {
-      try {
-        const config = await this.options.registry.readLaunchConfig(record);
-        const password = await this.options.registry.password(record);
-        await this.healthWithin(this.http(config.port, password));
-        return true;
-      } catch {
-        return false;
-      }
-    });
     await this.refreshAvailability();
     if (this.availability.ok) {
-      await this.options.rpc.request("driver.register", {
+      const result = await this.options.rpc.request<DriverRegisterResult>("driver.register", {
         agent: "opencode",
         capabilities: {
           resume: true,
@@ -131,6 +123,8 @@ export class OpenCodeDriver {
           launch_instructions: true,
         },
       });
+      if (!result.ok) throw new Error("attn rejected OpenCode driver registration");
+      await this.recover(result.active_runs ?? []);
     }
   }
 
@@ -194,9 +188,7 @@ export class OpenCodeDriver {
         instruction_ref: record.instruction_ref,
       };
       await this.options.registry.writeLaunchConfig(record, launchConfig);
-      const controller = new AbortController();
-      this.monitors.set(record.run_id, controller);
-      void this.monitor(record, selection, controller.signal);
+      this.startMonitor(record, selection);
       return {
         argv: [process.execPath, "run", join(import.meta.dir, "launcher.ts"), record.launch_config_ref],
         cwd: params.cwd,
@@ -205,6 +197,36 @@ export class OpenCodeDriver {
       if (record) await this.options.registry.cleanup(record.run_id);
       throw error;
     }
+  }
+
+  private async recover(activeRuns: ActivePluginRun[]): Promise<void> {
+    const owned = new Map(activeRuns.map((run) => [run.run_id, run]));
+    for (const record of await this.options.registry.list()) {
+      const active = owned.get(record.run_id);
+      if (!active || !activeRunMatchesRecord(active, record)) {
+        await this.options.registry.cleanup(record.run_id);
+        continue;
+      }
+      let selection: LaunchSelection;
+      try {
+        const config = await this.options.registry.readLaunchConfig(record);
+        const password = await this.options.registry.password(record);
+        const health = await this.healthWithin(this.http(config.port, password));
+        if (health.version !== record.opencode_version) throw new Error("OpenCode recovery server version changed");
+        selection = selectionFromRecord(record);
+      } catch {
+        await this.options.registry.cleanup(record.run_id);
+        continue;
+      }
+      this.startMonitor(record, selection);
+    }
+  }
+
+  private startMonitor(record: RunRecord, selection: LaunchSelection): void {
+    this.monitors.get(record.run_id)?.abort(new Error("OpenCode monitor was replaced"));
+    const controller = new AbortController();
+    this.monitors.set(record.run_id, controller);
+    void this.monitor(record, selection, controller.signal);
   }
 
   private freshSelection(params: DriverSpawnParams): LaunchSelection {
@@ -757,6 +779,31 @@ function cancelsClassification(event: { type: string; status?: string }): boolea
     event.type === "permission.replied" ||
     event.type === "session.error" ||
     event.type === "session.deleted";
+}
+
+function activeRunMatchesRecord(active: ActivePluginRun, record: RunRecord): boolean {
+  if (active.session_id !== record.attn_session_id || active.run_id !== record.run_id) return false;
+  if (active.metadata === undefined || active.metadata === null || active.metadata === "") return true;
+  try {
+    const metadata = parseMetadata(active.metadata);
+    return Boolean(record.opencode_session_id) && metadata.opencode_session_id === record.opencode_session_id;
+  } catch {
+    return false;
+  }
+}
+
+function selectionFromRecord(record: RunRecord): LaunchSelection {
+  if (!record.pinned) {
+    return { mode: "interactive", nativeSessionID: record.opencode_session_id };
+  }
+  if (!record.model || !record.variant) throw new Error("pinned OpenCode recovery record is missing model metadata");
+  return {
+    mode: "pinned",
+    modelText: record.model,
+    model: { ...parseModelPin(record.model), variant: record.variant },
+    variant: record.variant,
+    nativeSessionID: record.opencode_session_id,
+  };
 }
 
 async function runCommand(argv: string[]): Promise<CommandResult> {

--- a/plugins/attn-opencode/src/index.ts
+++ b/plugins/attn-opencode/src/index.ts
@@ -5,7 +5,8 @@ import type { DriverSpawnParams, SessionClosedParams } from "./types";
 
 const socketPath = requiredEnvironment("ATTN_SOCKET_PATH");
 const pluginName = requiredEnvironment("ATTN_PLUGIN_NAME");
-const rpc = new AttnRPCClient({ socketPath, name: pluginName, version: "0.1.0" });
+const pluginGeneration = requiredGeneration();
+const rpc = new AttnRPCClient({ socketPath, name: pluginName, version: "0.1.0", generation: pluginGeneration });
 const driver = new OpenCodeDriver({
   rpc,
   registry: new RunRegistry(runtimeRootFromSocket(socketPath)),
@@ -22,5 +23,11 @@ await driver.initialize();
 function requiredEnvironment(name: string): string {
   const value = process.env[name]?.trim();
   if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function requiredGeneration(): number {
+  const value = Number(requiredEnvironment("ATTN_PLUGIN_GENERATION"));
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error("ATTN_PLUGIN_GENERATION must be a positive integer");
   return value;
 }

--- a/plugins/attn-opencode/src/run-registry.ts
+++ b/plugins/attn-opencode/src/run-registry.ts
@@ -89,6 +89,10 @@ export class RunRegistry {
     });
   }
 
+  async list(): Promise<RunRecord[]> {
+    return this.withLock(() => [...this.runs.values()].map((run) => structuredClone(run)));
+  }
+
   async update(runID: string, changes: Partial<RunRecord>): Promise<RunRecord> {
     return this.withLock(async () => {
       const current = this.runs.get(runID);

--- a/plugins/attn-opencode/src/types.ts
+++ b/plugins/attn-opencode/src/types.ts
@@ -1,4 +1,4 @@
-export const pluginAPIVersion = 3;
+export const pluginAPIVersion = 4;
 
 export type StableVersion = {
   raw: string;
@@ -52,6 +52,17 @@ export function evaluateOpenCodeVersion(value: string): VersionCompatibility {
 }
 
 export type DriverCapabilities = Record<string, boolean>;
+
+export type ActivePluginRun = {
+  session_id: string;
+  run_id: string;
+  metadata?: unknown;
+};
+
+export type DriverRegisterResult = {
+  ok: boolean;
+  active_runs?: ActivePluginRun[];
+};
 
 export type PluginLaunchInstructions = {
   kind: "workspace" | "chief";

--- a/plugins/attn-opencode/test/driver.test.ts
+++ b/plugins/attn-opencode/test/driver.test.ts
@@ -17,9 +17,11 @@ afterEach(() => {
 
 class RecordingRPC {
   readonly calls: Array<{ method: string; params: unknown }> = [];
-  async request(method: string, params?: unknown): Promise<unknown> {
+  constructor(readonly activeRuns: Array<{ session_id: string; run_id: string; metadata?: unknown }> = []) {}
+
+  async request<T = unknown>(method: string, params?: unknown): Promise<T> {
     this.calls.push({ method, params });
-    return { ok: true };
+    return { ok: true, active_runs: method === "driver.register" ? this.activeRuns : undefined } as T;
   }
 }
 
@@ -810,6 +812,73 @@ describe("OpenCode server-backed driver", () => {
     expect(low?.port).not.toBe(max?.port);
     expect(low?.password_ref).not.toBe(max?.password_ref);
     expect(await registry.password(low!)).not.toBe(await registry.password(max!));
+  });
+
+  test("recovers only attn-owned runs and resumes monitoring without creating a native session", async () => {
+    const target = server("*");
+    target.sessions.set("native-recovery", {
+      id: "native-recovery",
+      model: { providerID: "spotify-glm", id: "zai-org/GLM-5.2-FP8", variant: "max" },
+    });
+    target.statuses.set("native-recovery", "busy");
+    const registry = new RunRegistry(join(await tempRoot(), "runtime"));
+    await registry.initialize();
+
+    const seed = async (runID: string, sessionID: string, nativeID: string) => {
+      const record = await registry.create({
+        schema: 1,
+        attn_session_id: sessionID,
+        run_id: runID,
+        next_seq: 7,
+        port: target.port,
+        opencode_session_id: nativeID,
+        opencode_version: "1.17.18",
+        pinned: true,
+        model: "spotify-glm/zai-org/GLM-5.2-FP8",
+        variant: "max",
+        resume: false,
+        created_at: new Date().toISOString(),
+      }, "");
+      await registry.writeLaunchConfig(record, {
+        schema: 1,
+        run_id: runID,
+        executable: "opencode",
+        cwd: "/tmp",
+        password_ref: record.password_ref,
+        port: target.port,
+        yolo: false,
+        resume_session_id: nativeID,
+      });
+    };
+    await seed("run-recovery", "attn-recovery", "native-recovery");
+    await seed("run-orphan", "attn-orphan", "native-orphan");
+
+    const rpc = new RecordingRPC([{
+      session_id: "attn-recovery",
+      run_id: "run-recovery",
+      metadata: { schema: 1, opencode_session_id: "native-recovery", opencode_version: "1.17.18", pinned: true },
+    }]);
+    const driver = new OpenCodeDriver({
+      rpc,
+      registry,
+      runCommand: async () => ({ exitCode: 0, stdout: "1.17.18\n", stderr: "" }),
+      http: (port, password) => new OpenCodeHTTP({ port, password }),
+      startupDeadline: 300,
+      reconnectDelay: 5,
+    });
+    await driver.initialize();
+
+    await eventually(
+      () => rpc.calls.some((call) => call.method === "session.report_state" && (call.params as { seq?: number }).seq === 7),
+      "recovered ordered state report",
+    );
+    expect(await registry.get("run-orphan")).toBeUndefined();
+    expect(await registry.get("run-recovery")).toBeDefined();
+    expect([...target.sessions.keys()]).toEqual(["native-recovery"]);
+    expect(target.requests.filter((request) => request.path === "/tui/select-session").map((request) => request.body)).toEqual([
+      { sessionID: "native-recovery" },
+    ]);
+    await driver.sessionClosed({ session_id: "attn-recovery", run_id: "run-recovery", reason: "test cleanup" });
   });
 
   test("keeps classifier sessions and equal-looking caches isolated across two runs", async () => {

--- a/sdk/plugin/README.md
+++ b/sdk/plugin/README.md
@@ -42,8 +42,14 @@ await client.connect();
 `client.handle(...)` is the declaration point. `connect()` includes every
 registered surface in the daemon handshake, so plugin code does not maintain a
 second registration list. Managed plugins get `ATTN_SOCKET_PATH` and
-`ATTN_PLUGIN_NAME` from attn; manually-launched plugins can still pass
-`socketPath` or `name` explicitly.
+`ATTN_PLUGIN_NAME` from attn, plus an `ATTN_PLUGIN_GENERATION` token that the SDK
+returns in the handshake. Manually launched plugins can still pass `socketPath`
+or `name` explicitly and use generation 1.
+
+Attn supervises installed plugin processes. A clean exit, crash, or connection
+loss longer than five seconds triggers a restart with bounded backoff. Plugin
+code should therefore rebuild registrations and in-memory state from durable
+sources each time `connect()` succeeds.
 
 The SDK handles `attn.health` internally and returns `{ ok: true }`. Plugin
 authors do not need to register a health handler for the daemon to distinguish a

--- a/sdk/plugin/src/index.ts
+++ b/sdk/plugin/src/index.ts
@@ -79,6 +79,7 @@ type ResolvedAttnPluginClientOptions = {
   socketPath: string;
   name: string;
   version: string;
+  generation: number;
 };
 
 export type PluginHandler<TParams = unknown, TResult = unknown> = (
@@ -119,7 +120,7 @@ type HealthResult = {
   ok: boolean;
 };
 
-const pluginAPIVersion = 3;
+const pluginAPIVersion = 4;
 
 export class AttnPluginClient {
   private socket?: Socket;
@@ -135,6 +136,7 @@ export class AttnPluginClient {
       socketPath: resolvePluginOption(options.socketPath, "ATTN_SOCKET_PATH", "socketPath"),
       name: resolvePluginOption(options.name, "ATTN_PLUGIN_NAME", "name"),
       version: options.version,
+      generation: resolvePluginGeneration(),
     };
   }
 
@@ -166,6 +168,7 @@ export class AttnPluginClient {
         name: this.options.name,
         version: this.options.version,
         attn_api_version: pluginAPIVersion,
+        generation: this.options.generation,
         surfaces: [...this.handlers.keys()].sort(),
       });
       if (!result.ok) {
@@ -337,4 +340,14 @@ function resolvePluginOption(
     throw new Error(`attn plugin ${optionName} is required; pass ${optionName} or set ${envName}`);
   }
   return value;
+}
+
+function resolvePluginGeneration(): number {
+  const raw = process.env.ATTN_PLUGIN_GENERATION?.trim();
+  if (!raw) return 1;
+  const generation = Number(raw);
+  if (!Number.isSafeInteger(generation) || generation <= 0) {
+    throw new Error("ATTN_PLUGIN_GENERATION must be a positive integer");
+  }
+  return generation;
 }

--- a/sdk/plugin/test/client.test.ts
+++ b/sdk/plugin/test/client.test.ts
@@ -59,6 +59,8 @@ describe("AttnPluginClient", () => {
 
     expect(server.requests.map((request) => request.method)).toEqual(["hello"]);
     expect(server.requests[0]?.params).toMatchObject({
+      attn_api_version: 4,
+      generation: 1,
       surfaces: ["worktree.after_create", "worktree.create"],
     });
 
@@ -74,8 +76,10 @@ describe("AttnPluginClient", () => {
     });
     const previousSocketPath = process.env.ATTN_SOCKET_PATH;
     const previousPluginName = process.env.ATTN_PLUGIN_NAME;
+    const previousGeneration = process.env.ATTN_PLUGIN_GENERATION;
     process.env.ATTN_SOCKET_PATH = server.socketPath;
     process.env.ATTN_PLUGIN_NAME = "sdk-env-provider";
+    process.env.ATTN_PLUGIN_GENERATION = "9";
 
     let client: AttnPluginClient | undefined;
     try {
@@ -87,12 +91,28 @@ describe("AttnPluginClient", () => {
 
       expect(server.requests[0]?.params).toMatchObject({
         name: "sdk-env-provider",
+        generation: 9,
       });
     } finally {
       client?.close();
       restoreEnv("ATTN_SOCKET_PATH", previousSocketPath);
       restoreEnv("ATTN_PLUGIN_NAME", previousPluginName);
+      restoreEnv("ATTN_PLUGIN_GENERATION", previousGeneration);
       await server.close();
+    }
+  });
+
+  test("rejects an invalid daemon-provided generation", () => {
+    const previousGeneration = process.env.ATTN_PLUGIN_GENERATION;
+    process.env.ATTN_PLUGIN_GENERATION = "stale";
+    try {
+      expect(() => new AttnPluginClient({
+        socketPath: "/tmp/unused.sock",
+        name: "sdk-provider",
+        version: "0.1.0",
+      })).toThrow("ATTN_PLUGIN_GENERATION must be a positive integer");
+    } finally {
+      restoreEnv("ATTN_PLUGIN_GENERATION", previousGeneration);
     }
   });
 


### PR DESCRIPTION
## Intent / Why

An installed plugin that exits or loses its daemon connection currently stays
offline until attn restarts. For OpenCode, that also stops state monitoring even
though the attn-owned TUI and native OpenCode session are still alive.

This change makes plugin availability a daemon-owned responsibility and lets a
restarted OpenCode plugin resume monitoring the exact run it previously owned.

## Summary

- Add a generic installed-plugin supervisor with a five-second connection
  grace, bounded 250 ms–30 s restart backoff, a 60-second stability reset, and
  generation guards that reject stale processes.
- Expose starting, connected, backoff, and stopped phases plus restart and exit
  diagnostics in Settings.
- Bump the plugin wire API to v4. `driver.register` now returns the registering
  plugin's store-authoritative active runs, and bundled manifests and the SDK
  carry the daemon-issued process generation.
- Reconcile OpenCode's private registry against those active runs after a plugin
  restart, remove orphaned records, and rebuild monitoring against the same
  authenticated server and native session without launching another TUI.

## Test plan

- [x] `go test ./...`
- [x] Race-enabled supervisor, generation, and real child-process tests
- [x] OpenCode plugin: 63 tests, 175 assertions
- [x] Plugin SDK: 9 tests, 16 assertions
- [x] Settings: 44 tests
- [x] Build, sign, and install the isolated app with `make dev`
- [x] In `attn-dev`, complete an OpenCode turn, terminate only the confirmed dev
      plugin process, observe a replacement process register healthy, and
      complete a second turn in the same visible TUI. The attn run ID and native
      OpenCode session ID remained unchanged, and ordered reporting advanced
      from sequence 8 to 13. The production plugin process was separately
      identified and left untouched.

## Out of scope

- Manual “restart now” controls
- Health-triggered restarts for a connected but unresponsive plugin
