### PR TITLE
fix(app): capture black-screen diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-16]
+
+### Added
+- **Black or stuck UI failures now leave useful evidence on disk.** Agent switches capture delayed app-shell health snapshots alongside the existing terminal renderer diagnostics, including frontend crashes, event-loop stalls, and native browser visibility. A React render failure now shows a persistent error screen instead of leaving an unexplained black window.
+
 ## [2026-07-15]
 
 ### Added

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -190,6 +190,29 @@ html, body, #root {
   overflow: clip;
 }
 
+.app-fatal-error {
+  height: 100%;
+  width: 100%;
+  padding: 48px;
+  background: var(--color-bg-app, #17181c);
+  color: var(--color-text, #f3f3f4);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.app-fatal-error h1 {
+  margin-bottom: 12px;
+  font-size: 24px;
+}
+
+.app-fatal-error p {
+  margin-bottom: 16px;
+  color: var(--color-text-muted, #b6b8bf);
+}
+
+.app-fatal-error code {
+  white-space: pre-wrap;
+}
+
 /* Custom scrollbar styling */
 ::-webkit-scrollbar {
   width: 8px;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -75,6 +75,7 @@ import { useOpenPR, type OpenPRProgress } from './hooks/useOpenPR';
 import { useUiAutomationBridge } from './hooks/useUiAutomationBridge';
 import { ptySpawn } from './pty/bridge';
 import { clearBrowserHostFocus, controlBrowserHost, isBrowserHostOwnedTarget } from './browser/host';
+import { probeUiAfterSwitch } from './utils/uiDiagnosticsLog';
 import {
   agentLabel,
   getAgentAvailability,
@@ -2716,6 +2717,15 @@ sendFetchPRDetails,
     selectedSessionlessWorkspaceId,
   );
   const activeWorkspaceId = workspaceSelection.activeWorkspaceId;
+
+  useEffect(() => {
+    probeUiAfterSwitch({
+      sessionId: activeSessionId,
+      workspaceId: activeWorkspaceId,
+      view,
+    });
+  }, [activeSessionId, activeWorkspaceId, view]);
+
   // activeWorkspaceIdRef is declared earlier (near the ActionMenu items); keep it in
   // sync here, where activeWorkspaceId is derived.
   useEffect(() => {

--- a/app/src/browser/host.ts
+++ b/app/src/browser/host.ts
@@ -1,4 +1,5 @@
 import { invoke, isTauri } from '@tauri-apps/api/core';
+import { recordUiDiag } from '../utils/uiDiagnosticsLog';
 
 export const MAX_BROWSER_CONTROL_RESULT_BYTES = 24 * 1024 * 1024;
 
@@ -7,6 +8,20 @@ export interface BrowserHostRect {
   y: number;
   width: number;
   height: number;
+}
+
+const tracedBrowserHostState = new Map<string, { visible: boolean; suspicious: boolean }>();
+
+function shouldTraceBrowserUpdate(label: string, rect: BrowserHostRect, visible: boolean): boolean {
+  const suspicious = visible && (
+    rect.width >= window.innerWidth * 0.9
+    || rect.height >= window.innerHeight * 0.9
+    || rect.width <= 1
+    || rect.height <= 1
+  );
+  const previous = tracedBrowserHostState.get(label);
+  tracedBrowserHostState.set(label, { visible, suspicious });
+  return !previous || previous.visible !== visible || suspicious !== previous.suspicious;
 }
 
 export function serializeBrowserControlResultMessage(
@@ -46,17 +61,41 @@ export async function mountBrowserHost(
   if (!isTauri()) {
     throw new Error('In-app browser hosting requires the Tauri app');
   }
-  await invoke('browser_host_mount', { label, url, ...rect, visible });
+  recordUiDiag({ kind: 'browser_host_request', action: 'mount', label, rect, visible });
+  tracedBrowserHostState.set(label, { visible, suspicious: false });
+  try {
+    await invoke('browser_host_mount', { label, url, ...rect, visible });
+    recordUiDiag({ kind: 'browser_host_result', action: 'mount', label, rect, visible });
+  } catch (error) {
+    recordUiDiag({ kind: 'browser_host_error', action: 'mount', label, rect, visible, error: String(error) });
+    throw error;
+  }
 }
 
 export async function updateBrowserHost(label: string, rect: BrowserHostRect, visible: boolean): Promise<void> {
   if (!isTauri()) return;
-  await invoke('browser_host_update', { label, ...rect, visible });
+  const trace = shouldTraceBrowserUpdate(label, rect, visible);
+  if (trace) recordUiDiag({ kind: 'browser_host_request', action: 'update', label, rect, visible });
+  try {
+    await invoke('browser_host_update', { label, ...rect, visible });
+    if (trace) recordUiDiag({ kind: 'browser_host_result', action: 'update', label, rect, visible });
+  } catch (error) {
+    recordUiDiag({ kind: 'browser_host_error', action: 'update', label, rect, visible, error: String(error) });
+    throw error;
+  }
 }
 
 export async function unmountBrowserHost(label: string): Promise<void> {
   if (!isTauri()) return;
-  await invoke('browser_host_unmount', { label });
+  recordUiDiag({ kind: 'browser_host_request', action: 'unmount', label });
+  try {
+    await invoke('browser_host_unmount', { label });
+    tracedBrowserHostState.delete(label);
+    recordUiDiag({ kind: 'browser_host_result', action: 'unmount', label });
+  } catch (error) {
+    recordUiDiag({ kind: 'browser_host_error', action: 'unmount', label, error: String(error) });
+    throw error;
+  }
 }
 
 export function clearBrowserHostFocus(): void {

--- a/app/src/components/AppErrorBoundary.test.tsx
+++ b/app/src/components/AppErrorBoundary.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { AppErrorBoundary } from './AppErrorBoundary';
+
+function Broken(): ReactNode {
+  throw new Error('render exploded');
+}
+
+describe('AppErrorBoundary', () => {
+  it('keeps a visible diagnostic fallback when React rendering fails', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<AppErrorBoundary><Broken /></AppErrorBoundary>);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('attn hit a UI error');
+    expect(screen.getByRole('alert')).toHaveTextContent('render exploded');
+  });
+});

--- a/app/src/components/AppErrorBoundary.tsx
+++ b/app/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,28 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { recordReactError } from '../utils/uiDiagnosticsLog';
+
+export class AppErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    recordReactError(error, info.componentStack ?? undefined);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <main className="app-fatal-error" role="alert">
+          <h1>attn hit a UI error</h1>
+          <p>The error was saved to the UI diagnostics log. Restart attn to continue.</p>
+          <code>{this.state.error.message}</code>
+        </main>
+      );
+    }
+    return this.props.children;
+  }
+}
+

--- a/app/src/components/AppErrorBoundary.tsx
+++ b/app/src/components/AppErrorBoundary.tsx
@@ -25,4 +25,3 @@ export class AppErrorBoundary extends Component<{ children: ReactNode }, { error
     return this.props.children;
   }
 }
-

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,10 +1,13 @@
 import { installVerbatimTextEntryGuard } from './utils/verbatimTextEntry';
+import { AppErrorBoundary } from './components/AppErrorBoundary';
+import { installUiDiagnostics, recordUiDiag } from './utils/uiDiagnosticsLog';
 
 declare global { interface Window { __dbg?: (msg: string) => void } }
 const dbg = (msg: string) => window.__dbg?.(msg);
 
 dbg('main.tsx: imports resolved');
 installVerbatimTextEntryGuard(document);
+installUiDiagnostics();
 
 // The Present window is a separate Tauri window (opened via
 // open_presentation_window) that loads this same bundle with
@@ -31,8 +34,11 @@ async function boot() {
   dbg('boot: createRoot');
   // Note: StrictMode disabled because it causes double-mounting which breaks
   // the PTY connection (terminal gets disposed and recreated)
-  root.render(<App />);
+  root.render(<AppErrorBoundary><App /></AppErrorBoundary>);
   dbg('boot: render called');
 }
 
-boot().catch((err) => dbg('boot FAILED: ' + (err?.stack || err)));
+boot().catch((err) => {
+  recordUiDiag({ kind: 'boot_failed', message: String(err), stack: err instanceof Error ? err.stack : undefined });
+  dbg('boot FAILED: ' + (err?.stack || err));
+});

--- a/app/src/utils/uiDiagnosticsLog.test.ts
+++ b/app/src/utils/uiDiagnosticsLog.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { captureUiSnapshot, probeUiAfterSwitch } from './uiDiagnosticsLog';
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.innerHTML = '';
+});
+
+describe('UI diagnostics', () => {
+  it('captures the app shell and active terminal wrapper', () => {
+    document.body.innerHTML = `
+      <div id="root">
+        <div class="app">
+          <div class="terminal-wrapper active">terminal</div>
+        </div>
+      </div>
+    `;
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: () => document.querySelector('.terminal-wrapper'),
+    });
+
+    const snapshot = captureUiSnapshot();
+
+    expect(snapshot.rootChildren).toBe(1);
+    expect(snapshot.activeWrapperCount).toBe(1);
+    expect(snapshot.app).toMatchObject({ tag: 'div', classes: 'app' });
+    expect(snapshot.center).toMatchObject({ classes: 'terminal-wrapper active' });
+  });
+
+  it('records delayed probes for the latest agent switch', () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '<div id="root"><div class="app" /></div>';
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: () => document.querySelector('.app'),
+    });
+
+    probeUiAfterSwitch({ sessionId: 'chief-session', workspaceId: 'chief-workspace', view: 'session' });
+    vi.advanceTimersByTime(1500);
+
+    const events = (window.__ATTN_UI_DIAG_DUMP?.() ?? [])
+      .filter((event) => event.sessionId === 'chief-session');
+    expect(events.map((event) => event.kind)).toEqual([
+      'session_switch',
+      'switch_probe',
+      'switch_probe',
+      'switch_probe',
+    ]);
+    expect(events.slice(1).map((event) => event.delayMs)).toEqual([0, 250, 1500]);
+  });
+
+  it('cancels stale delayed probes when another agent is selected', () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '<div id="root"><div class="app" /></div>';
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: () => document.querySelector('.app'),
+    });
+
+    probeUiAfterSwitch({ sessionId: 'first', workspaceId: 'one', view: 'session' });
+    probeUiAfterSwitch({ sessionId: 'second', workspaceId: 'two', view: 'session' });
+    vi.advanceTimersByTime(1500);
+
+    const events = window.__ATTN_UI_DIAG_DUMP?.() ?? [];
+    expect(events.filter((event) => event.sessionId === 'first' && event.kind === 'switch_probe')).toHaveLength(0);
+    expect(events.filter((event) => event.sessionId === 'second' && event.kind === 'switch_probe')).toHaveLength(3);
+  });
+});
+

--- a/app/src/utils/uiDiagnosticsLog.test.ts
+++ b/app/src/utils/uiDiagnosticsLog.test.ts
@@ -67,4 +67,3 @@ describe('UI diagnostics', () => {
     expect(events.filter((event) => event.sessionId === 'second' && event.kind === 'switch_probe')).toHaveLength(3);
   });
 });
-

--- a/app/src/utils/uiDiagnosticsLog.ts
+++ b/app/src/utils/uiDiagnosticsLog.ts
@@ -1,0 +1,201 @@
+// Bounded, disk-backed diagnostics for failures that affect the whole app
+// shell. Terminal rendering has its own richer stream; this file answers the
+// layer above it: did React render, did the DOM stay visible, did the event loop
+// stall, or did a native browser child WebView remain over the app?
+import { isTauri } from '@tauri-apps/api/core';
+
+const DEBUG_DIR = 'debug';
+const FILE = `${DEBUG_DIR}/ui-diagnostics.jsonl`;
+const FILE_SIZE_CAP_BYTES = 4 * 1024 * 1024;
+const RING_LIMIT = 300;
+const SWITCH_PROBE_DELAYS_MS = [0, 250, 1500];
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const EVENT_LOOP_STALL_MS = 5_000;
+
+export interface UiDiagEvent {
+  at: number;
+  kind: string;
+  [key: string]: unknown;
+}
+
+declare global {
+  interface Window {
+    __ATTN_UI_DIAG?: UiDiagEvent[];
+    __ATTN_UI_DIAG_DUMP?: () => UiDiagEvent[];
+    __ATTN_UI_DIAG_FILE?: string;
+  }
+}
+
+const ring: UiDiagEvent[] = [];
+let writeChain: Promise<void> = Promise.resolve();
+let bytes = 0;
+let sizeSeeded = false;
+let installed = false;
+let switchGeneration = 0;
+
+function exposeGlobals(): void {
+  window.__ATTN_UI_DIAG = ring;
+  window.__ATTN_UI_DIAG_DUMP = () => [...ring];
+  window.__ATTN_UI_DIAG_FILE = `$APPLOCALDATA/${FILE}`;
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+async function append(line: string): Promise<void> {
+  if (!isTauri()) return;
+  // Some unit tests mock `isTauri()` so browser-host calls take their native
+  // branch without installing Tauri's real invoke bridge. Avoid noisy failed
+  // filesystem calls in that partial environment.
+  const tauriInternals = (window as unknown as { __TAURI_INTERNALS__?: { invoke?: unknown } }).__TAURI_INTERNALS__;
+  if (typeof tauriInternals?.invoke !== 'function') return;
+  try {
+    const { mkdir, stat, writeTextFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+    await mkdir(DEBUG_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
+    if (!sizeSeeded) {
+      try {
+        bytes = (await stat(FILE, { baseDir: BaseDirectory.AppLocalData })).size;
+      } catch {
+        bytes = 0;
+      }
+      sizeSeeded = true;
+    }
+    const reset = bytes > FILE_SIZE_CAP_BYTES;
+    const payload = reset
+      ? `${JSON.stringify({ at: Date.now(), kind: 'rotate' })}\n${line}`
+      : line;
+    await writeTextFile(FILE, payload, {
+      baseDir: BaseDirectory.AppLocalData,
+      append: !reset,
+      create: true,
+    });
+    bytes = reset ? byteLength(payload) : bytes + byteLength(payload);
+  } catch (error) {
+    console.warn('[UiDiag] write failed:', error);
+  }
+}
+
+export function recordUiDiag(event: Omit<UiDiagEvent, 'at'>): void {
+  if (typeof window === 'undefined') return;
+  exposeGlobals();
+  const entry = { ...event, at: Date.now() } as UiDiagEvent;
+  if (ring.length >= RING_LIMIT) ring.shift();
+  ring.push(entry);
+  const line = `${JSON.stringify(entry)}\n`;
+  writeChain = writeChain.catch(() => {}).then(() => append(line));
+}
+
+function errorDetail(value: unknown): { message: string; stack?: string } {
+  if (value instanceof Error) {
+    return { message: value.message, stack: value.stack };
+  }
+  if (typeof value === 'string') return { message: value };
+  try {
+    return { message: JSON.stringify(value) };
+  } catch {
+    return { message: String(value) };
+  }
+}
+
+function elementSummary(element: Element | null): Record<string, unknown> | null {
+  if (!element) return null;
+  const html = element as HTMLElement;
+  const rect = html.getBoundingClientRect();
+  const style = getComputedStyle(html);
+  return {
+    tag: element.tagName.toLowerCase(),
+    id: html.id || undefined,
+    classes: typeof html.className === 'string' ? html.className.slice(0, 240) : undefined,
+    rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+    display: style.display,
+    visibility: style.visibility,
+    opacity: style.opacity,
+    background: style.backgroundColor,
+  };
+}
+
+export function captureUiSnapshot(): Record<string, unknown> {
+  const root = document.getElementById('root');
+  const app = document.querySelector('.app');
+  const activeWrappers = [...document.querySelectorAll('.terminal-wrapper.active')];
+  const center = document.elementFromPoint(window.innerWidth / 2, window.innerHeight / 2);
+  return {
+    visibilityState: document.visibilityState,
+    window: { width: window.innerWidth, height: window.innerHeight, devicePixelRatio: window.devicePixelRatio },
+    root: elementSummary(root),
+    rootChildren: root?.childElementCount ?? 0,
+    app: elementSummary(app),
+    activeWrapperCount: activeWrappers.length,
+    activeWrappers: activeWrappers.slice(0, 4).map(elementSummary),
+    center: elementSummary(center),
+    activeElement: elementSummary(document.activeElement),
+    browserHostOwners: [...document.querySelectorAll('[data-browser-host-owner]')].slice(0, 8).map(elementSummary),
+  };
+}
+
+export function probeUiAfterSwitch(context: {
+  sessionId: string | null;
+  workspaceId: string | null;
+  view: string;
+}): void {
+  const generation = ++switchGeneration;
+  recordUiDiag({ kind: 'session_switch', generation, ...context });
+  for (const delayMs of SWITCH_PROBE_DELAYS_MS) {
+    window.setTimeout(() => {
+      if (generation !== switchGeneration) return;
+      recordUiDiag({
+        kind: 'switch_probe',
+        generation,
+        delayMs,
+        ...context,
+        snapshot: captureUiSnapshot(),
+      });
+    }, delayMs);
+  }
+}
+
+export function installUiDiagnostics(): void {
+  if (installed || typeof window === 'undefined') return;
+  installed = true;
+  exposeGlobals();
+  recordUiDiag({ kind: 'boot', href: window.location.pathname, visibilityState: document.visibilityState });
+
+  window.addEventListener('error', (event) => {
+    recordUiDiag({
+      kind: 'window_error',
+      ...errorDetail(event.error ?? event.message),
+      filename: event.filename,
+      line: event.lineno,
+      column: event.colno,
+      snapshot: captureUiSnapshot(),
+    });
+  });
+  window.addEventListener('unhandledrejection', (event) => {
+    recordUiDiag({ kind: 'unhandled_rejection', ...errorDetail(event.reason), snapshot: captureUiSnapshot() });
+  });
+  document.addEventListener('visibilitychange', () => {
+    recordUiDiag({ kind: 'visibility_change', visibilityState: document.visibilityState });
+  });
+
+  let expectedAt = Date.now() + HEARTBEAT_INTERVAL_MS;
+  window.setInterval(() => {
+    const now = Date.now();
+    const lateByMs = Math.max(0, now - expectedAt);
+    recordUiDiag({
+      kind: lateByMs >= EVENT_LOOP_STALL_MS ? 'event_loop_stall' : 'heartbeat',
+      lateByMs,
+      visibilityState: document.visibilityState,
+    });
+    expectedAt = now + HEARTBEAT_INTERVAL_MS;
+  }, HEARTBEAT_INTERVAL_MS);
+}
+
+export function recordReactError(error: unknown, componentStack?: string): void {
+  recordUiDiag({
+    kind: 'react_error',
+    ...errorDetail(error),
+    componentStack,
+    snapshot: captureUiSnapshot(),
+  });
+}

--- a/docs/alignment/ui-black-screen-diagnostics.md
+++ b/docs/alignment/ui-black-screen-diagnostics.md
@@ -1,0 +1,16 @@
+## Why
+
+Agent switches can leave the app visually black and unusable. The existing terminal diagnostics have captured a matching `blank_after_resize` incident for the chief session, but they cannot show whether the rest of the React shell remained healthy or whether a native browser WebView covered it. This chunk is done when a future occurrence leaves a bounded, disk-backed trail that distinguishes those failure families and preserves fatal frontend errors.
+
+## Aligned on
+
+- Keep the current terminal diagnostics and correlate them with a separate app-shell stream rather than widening the high-volume terminal log.
+- Record agent/workspace switches, delayed DOM health snapshots, JavaScript and React failures, event-loop stalls, visibility changes, and native browser-host geometry/lifecycle calls.
+- Keep diagnostics production-safe: asynchronous writes, bounded files, low-frequency heartbeats, and no terminal contents or user text.
+- Show a durable error fallback when React fails so a render exception is distinguishable from a compositor or terminal failure.
+
+## In scope / deferred
+
+In scope: app-wide disk diagnostics, switch probes, browser-host tracing, fatal error capture, focused tests, and live verification in a non-production profile.
+
+Deferred: automatic reloads or renderer recovery beyond the existing terminal recovery path, and a root-cause fix for the black screen until the new evidence distinguishes the failing layer.


### PR DESCRIPTION
## Intent / Why

Agent and workspace switches can occasionally leave the app window black and unresponsive. Existing terminal diagnostics captured a matching `blank_after_resize` incident for the long-lived chief session, but they cannot tell whether React, the app-shell DOM, a native browser WebView, or the terminal renderer failed.

This change preserves enough bounded, disk-backed evidence to identify the failing layer the next time the issue occurs. It deliberately does not add automatic recovery yet, because reloading could erase the state needed for diagnosis.

## Summary

- add a bounded `ui-diagnostics.jsonl` stream for frontend errors, event-loop stalls, visibility changes, and agent/workspace switch snapshots
- capture root/app geometry, active terminal wrappers, focus ownership, the element covering the window center, and native browser-host visibility or suspicious full-window geometry
- show a persistent error screen when React rendering fails instead of leaving an unexplained black window
- keep terminal contents and user text out of the new diagnostics

## Test plan

- [x] Run all frontend tests: 167 files, 1,759 tests
- [x] Run TypeScript compilation and the production frontend build
- [x] Build, sign, install, and launch the exact branch as the isolated `attn-dev` profile
- [x] Verify the packaged app writes boot and 0/250/1500 ms switch snapshots to `ui-diagnostics.jsonl`
- [x] Exercise multiple real workspace switches and inspect the captured app-shell geometry
- [ ] Grant Accessibility access to the real-app input driver and rerun the full workspace-switching scenario end to end

## Out of scope

Automatic reload or renderer recovery remains deferred until the next captured occurrence establishes which layer failed. The packaged switching scenario produced valid switch snapshots, then stopped when its native input driver lacked macOS Accessibility permission.