### PR TITLE
feat(tickets): allow arbitrary file attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Added
 - **Tickets can now carry any regular file.** Attach HTML prototypes, images,
-  archives, and other artifacts alongside Markdown; text formats open as source
-  in the Notebook, while binary formats remain non-executing previews.
+  archives, and other artifacts alongside Markdown; recognized text formats open
+  as source in the Notebook, while opaque files remain non-executing previews.
 - **OpenCode is now an opt-in plugin included with the app.** Each profile can
   install it from Settings or the CLI without an attn checkout, Bun, or a daemon
   restart. Uninstalling preserves OpenCode run data and is blocked while the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-15]
 
 ### Added
+- **Tickets can now carry any regular file.** Attach HTML prototypes, images,
+  archives, and other artifacts alongside Markdown; text formats open as source
+  in the Notebook, while binary formats remain non-executing previews.
 - **OpenCode is now an opt-in plugin included with the app.** Each profile can
   install it from Settings or the CLI without an attn checkout, Bun, or a daemon
   restart. Uninstalling preserves OpenCode run data and is blocked while the

--- a/app/src/components/NotebookBrowser.test.tsx
+++ b/app/src/components/NotebookBrowser.test.tsx
@@ -78,6 +78,7 @@ const TREE: Record<string, FsEntry[]> = {
     { path: 'journal', name: 'journal', isDir: true, size: 0 },
     { path: 'notes.txt', name: 'notes.txt', isDir: false, size: 64 },
     { path: 'cover.png', name: 'cover.png', isDir: false, size: 4096 },
+    { path: 'prototype.docx', name: 'prototype.docx', isDir: false, size: 4096 },
   ],
   knowledge: [
     { path: 'knowledge/index.md', name: 'index.md', isDir: false, size: 128 },
@@ -256,6 +257,18 @@ describe('NotebookBrowser', () => {
     expect(screen.getByText("cover.png can't be opened here yet.")).toBeInTheDocument();
     // A binary file is never read (fs_read returns a string, meaningless for bytes).
     expect(readFile).not.toHaveBeenCalledWith('cover.png');
+  });
+
+  it('fails closed for an unknown opaque attachment without reading it', async () => {
+    const { props, readFile } = makeProps();
+    render(<NotebookBrowser {...props} />);
+    await screen.findByRole('treeitem', { name: 'prototype.docx' });
+
+    fireEvent.click(screen.getByRole('treeitem', { name: 'prototype.docx' }));
+
+    expect(await screen.findByText('Preview not available')).toBeInTheDocument();
+    expect(screen.getByText("prototype.docx can't be opened here yet.")).toBeInTheDocument();
+    expect(readFile).not.toHaveBeenCalledWith('prototype.docx');
   });
 
   it('does not read a binary file when the Notebook is reopened with one selected', async () => {

--- a/app/src/components/TicketDetailPanel.test.tsx
+++ b/app/src/components/TicketDetailPanel.test.tsx
@@ -417,8 +417,8 @@ describe('TicketDetailPanel', () => {
     expect(screen.queryByTestId('ticket-edit-description')).toBeNull();
   });
 
-  it('hands over selected Markdown files with optional state and comment', async () => {
-    vi.mocked(open).mockResolvedValue(['/tmp/design.md', '/tmp/rollout.md']);
+  it('hands over files of any type with optional state and comment', async () => {
+    vi.mocked(open).mockResolvedValue(['/tmp/design.md', '/tmp/prototype.html', '/tmp/results.zip']);
     const fetchTicket = vi.fn().mockResolvedValue(makeTicket());
     const onAttach = vi.fn().mockResolvedValue(undefined);
     render(
@@ -439,10 +439,11 @@ describe('TicketDetailPanel', () => {
     fireEvent.click(screen.getByTestId('ticket-submit-attach'));
     await waitFor(() => expect(onAttach).toHaveBeenCalledWith(
       'store-migration',
-      ['/tmp/design.md', '/tmp/rollout.md'],
+      ['/tmp/design.md', '/tmp/prototype.html', '/tmp/results.zip'],
       'ready_for_review',
       'Chosen approach',
     ));
+    expect(open).toHaveBeenCalledWith({ multiple: true });
   });
 
   it('opens, renames, and deletes a current artifact', async () => {
@@ -468,11 +469,11 @@ describe('TicketDetailPanel', () => {
     expect(onOpenArtifact).toHaveBeenCalledWith('tickets/store-migration/report.md');
 
     fireEvent.click(screen.getByText('Rename'));
-    fireEvent.change(screen.getByLabelText('Rename report.md'), { target: { value: 'implementation.md' } });
+    fireEvent.change(screen.getByLabelText('Rename report.md'), { target: { value: 'implementation.html' } });
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => expect(onRenameArtifact).toHaveBeenCalledWith(
       'tickets/store-migration/report.md',
-      'tickets/store-migration/implementation.md',
+      'tickets/store-migration/implementation.html',
     ));
 
     fireEvent.click(screen.getByText('Delete'));

--- a/app/src/components/TicketDetailPanel.tsx
+++ b/app/src/components/TicketDetailPanel.tsx
@@ -410,7 +410,7 @@ export function TicketDetailPanel({
                   data-testid="ticket-choose-attach"
                   disabled={busyAction !== null}
                   onClick={() => {
-                    void open({ multiple: true, filters: [{ name: 'Markdown', extensions: ['md'] }] })
+                    void open({ multiple: true })
                       .then((selected) => {
                         const paths = Array.isArray(selected) ? selected : selected ? [selected] : [];
                         if (paths.length > 0) setAttachFiles(paths);
@@ -485,7 +485,7 @@ export function TicketDetailPanel({
                           />
                           <button
                             type="button"
-                            disabled={busyAction !== null || !renameDraft.trim().endsWith('.md') || renameDraft.includes('/')}
+                            disabled={busyAction !== null || !renameDraft.trim() || renameDraft.includes('/')}
                             onClick={() => {
                               if (!onRenameArtifact) return;
                               runAction('rename-artifact', async () => {

--- a/app/src/components/notebook/fileKind.test.ts
+++ b/app/src/components/notebook/fileKind.test.ts
@@ -9,22 +9,27 @@ describe('fileKind', () => {
     expect(isMarkdownPath('a/b/c.txt')).toBe(false);
   });
 
-  it('classifies known-binary extensions as binary', () => {
+  it('classifies opaque and unknown extensions as binary', () => {
     expect(fileKind('assets/cover.png')).toBe('binary');
     expect(fileKind('a/b/clip.MP4')).toBe('binary');
     expect(fileKind('fonts/Inter.woff2')).toBe('binary');
     expect(isBinaryPath('x.pdf')).toBe(true);
+    expect(fileKind('attachments/prototype.docx')).toBe('binary');
+    expect(fileKind('attachments/installer.pkg')).toBe('binary');
     expect(isBinaryPath('x.md')).toBe(false);
   });
 
-  it('treats unknown and missing extensions as editable text', () => {
+  it('classifies known text source formats as editable text', () => {
     expect(fileKind('notes.txt')).toBe('text');
     expect(fileKind('config.json')).toBe('text');
     expect(fileKind('src/main.go')).toBe('text');
-    // No extension at all → text (e.g. a README or a LICENSE).
+    expect(fileKind('prototype.html')).toBe('text');
+    // Well-known extensionless source files remain editable.
     expect(fileKind('README')).toBe('text');
-    // A leading-dot dotfile with no further extension → text, not "" -> binary.
-    expect(fileKind('.gitignore')).toBe('text');
+    expect(fileKind('Makefile')).toBe('text');
+    // Ambiguous extensionless names and dotfiles fail closed.
+    expect(fileKind('attachment')).toBe('binary');
+    expect(fileKind('.gitignore')).toBe('binary');
   });
 
   it('extracts the lowercased extension of the basename only', () => {

--- a/app/src/components/notebook/fileKind.ts
+++ b/app/src/components/notebook/fileKind.ts
@@ -6,24 +6,21 @@
 //   binary   -> a read-only placeholder; we never even read it (fs_read returns a
 //               string, which is meaningless for binary bytes)
 //
-// The gate is an explicit binary-extension denylist: anything not known-binary is
-// treated as editable text. That errs toward editability (a stray unknown extension
-// opens as text) rather than hiding files behind a placeholder.
-
-const BINARY_EXTENSIONS = new Set([
-  // images
-  'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico', 'svgz', 'tif', 'tiff', 'heic', 'avif',
-  // documents / archives
-  'pdf', 'zip', 'gz', 'tgz', 'bz2', 'xz', '7z', 'rar', 'tar',
-  // audio / video
-  'mp4', 'mov', 'avi', 'mkv', 'webm', 'mp3', 'wav', 'flac', 'ogg', 'm4a',
-  // fonts
-  'woff', 'woff2', 'ttf', 'otf', 'eot',
-  // compiled / opaque binaries
-  'exe', 'dll', 'dylib', 'so', 'o', 'a', 'wasm', 'bin', 'dat', 'class', 'jar',
-  // databases / misc
-  'sqlite', 'db',
+// The gate is an explicit text-extension allowlist. Ticket attachments can carry
+// arbitrary files, so unknown formats must fail closed: opening an opaque file as
+// text could transform its bytes on a later autosave. Add an extension only when
+// the Notebook can safely edit it as UTF-8 source.
+const TEXT_EXTENSIONS = new Set([
+  'txt', 'text', 'html', 'htm', 'css', 'scss', 'sass', 'less',
+  'js', 'mjs', 'cjs', 'ts', 'tsx', 'jsx',
+  'json', 'jsonc', 'jsonl', 'yaml', 'yml', 'toml', 'xml', 'csv', 'tsv',
+  'ini', 'cfg', 'conf', 'env', 'log',
+  'sh', 'bash', 'zsh', 'fish', 'ps1',
+  'go', 'rs', 'py', 'rb', 'php', 'java', 'kt', 'kts', 'c', 'cc', 'cpp', 'cxx', 'h', 'hpp', 'cs', 'swift', 'scala', 'sql',
+  'md', 'markdown',
 ]);
+
+const TEXT_FILENAMES = new Set(['readme', 'license', 'makefile', 'dockerfile', 'brewfile']);
 
 export type FileKind = 'markdown' | 'text' | 'binary';
 
@@ -39,8 +36,8 @@ export function extensionOf(path: string): string {
 export function fileKind(path: string): FileKind {
   const ext = extensionOf(path);
   if (ext === 'md' || ext === 'markdown') return 'markdown';
-  if (BINARY_EXTENSIONS.has(ext)) return 'binary';
-  return 'text';
+  const name = path.slice(path.lastIndexOf('/') + 1).toLowerCase();
+  return TEXT_EXTENSIONS.has(ext) || TEXT_FILENAMES.has(name) ? 'text' : 'binary';
 }
 
 export function isMarkdownPath(path: string): boolean {

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -826,7 +826,7 @@ func parseTicketAttachArgs(args []string) (ticketAttachArgs, error) {
 	fs := flag.NewFlagSet("ticket attach", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	var files stringListFlag
-	fs.Var(&files, "file", "path to a Markdown artifact (repeatable)")
+	fs.Var(&files, "file", "path to an artifact file (repeatable)")
 	ticketID := fs.String("ticket", "", "attach to this ticket instead of the session's bound ticket")
 	state := fs.String("state", "", "optional resulting work state")
 	comment := fs.String("comment", "", "optional context recorded with the attachment")
@@ -880,8 +880,8 @@ func runTicketAttach(args []string) {
 			fmt.Fprintf(os.Stderr, "ticket attach: %v\n", statErr)
 			os.Exit(1)
 		}
-		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || filepath.Ext(absPath) != ".md" {
-			fmt.Fprintf(os.Stderr, "ticket attach: %q is not a regular Markdown file\n", absPath)
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			fmt.Fprintf(os.Stderr, "ticket attach: %q is not a regular file\n", absPath)
 			os.Exit(1)
 		}
 		files = append(files, protocol.TicketAttachFile{SourcePath: absPath, Filename: filepath.Base(absPath)})
@@ -1533,7 +1533,7 @@ commands:
         cursor
   attach --file <path> [--file <path> ...] [--ticket <id>]
         [--state <work-state>] [--comment <text>] [--session <id>] [--json]
-        copy Markdown artifacts into a ticket's canonical Notebook directory,
+		copy artifact files into a ticket's canonical Notebook directory,
         record one durable attachment, and optionally change ticket state
   new --title <t> [--description <d>] [--id <slug>] [--session <id>] [--json]
         create an unbound backlog ticket in todo (no agent, no session)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -144,7 +144,7 @@ The agent reports its own **work state** — in progress, needs input, ready for
 review, completed, or failed — which moves the ticket across the board
 (Todo · Working · Blocked · In Review · Done). Comments, status changes, and
 artifact attachments accumulate on the ticket's activity thread. Current artifacts
-are the Markdown files in the ticket's Notebook directory, and the chief watches
+are the files in the ticket's Notebook directory, and the chief watches
 progress from the ticket view and board rather than polling the agent.
 
 ## The raw tier

--- a/internal/agent/attn_skill/references/delegated-agent.md
+++ b/internal/agent/attn_skill/references/delegated-agent.md
@@ -63,7 +63,7 @@ delegation.
 
 ## Hand Over Durable Artifacts
 
-When tracked work produces a plan, design, or other Markdown artifact that must
+When tracked work produces a plan, design, or other artifact that must
 outlive this session, hand it over to the ticket:
 
     "$ATTN_WRAPPER_PATH" ticket attach \
@@ -78,7 +78,7 @@ attach event, and returns the canonical paths. A matching retry returns the same
 receipt; a same-name file with different bytes is preserved and must be renamed
 before retrying.
 
-After success, edit the returned files directly. They are ordinary Markdown files
+After success, edit the returned files directly. They are ordinary files
 and the filesystem is the current artifact index. When you make a meaningful edit,
 rename, or deletion, report it with `ticket status --comment` or `ticket comment`
 so the chief knows to re-read the ticket.

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -27,7 +27,7 @@ also arm a Monitor on `attn ticket inbox --watch` to consume updates sooner. Ord
 delegation needs none of that.
 
 For a chief-tracked delegation that returns a durable plan, read the ticket before
-continuing: `attn ticket show <ticket-id>` lists the Markdown files currently in
+continuing: `attn ticket show <ticket-id>` lists the files currently in
 the ticket's Notebook directory. Pass those canonical paths in follow-on briefs so
 the next agent updates the same plan instead of creating a conversational copy.
 

--- a/internal/agent/attn_skill/references/tickets.md
+++ b/internal/agent/attn_skill/references/tickets.md
@@ -40,7 +40,7 @@ Deliverable type also predicts the terminal status: research and prose often go 
 to **done** (the artifact is the proof); code lands in **in review** because someone else
 validates it.
 
-## Handing over Markdown artifacts
+## Handing over artifacts
 
 `attn ticket attach` is the durable producer-to-ticket operation:
 
@@ -53,7 +53,7 @@ validates it.
 
 - Omit `--ticket` to use your own bound ticket; include it to target any known
   ticket, matching `ticket status --ticket` and `ticket comment`.
-- Repeat `--file` to submit several Markdown files in one attachment.
+- Repeat `--file` to submit several files in one attachment.
 - `--state` uses the reporting vocabulary: `in_progress`, `needs_input`,
   `ready_for_review`, `completed`, or `failed`.
 - `--comment` is short decision context. Put the full reasoning in the Markdown.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -241,7 +241,7 @@ func (c *Client) SetTicketStatus(sourceSessionID, workState, comment, ticketID s
 	return resp.TicketStatusResult, nil
 }
 
-// AttachTicket copies one or more Markdown files into a ticket's canonical
+// AttachTicket copies one or more files into a ticket's canonical
 // Notebook directory and returns its durable receipt.
 func (c *Client) AttachTicket(sourceSessionID string, files []protocol.TicketAttachFile, ticketID, state, comment string) (*protocol.TicketAttachResult, error) {
 	msg := protocol.TicketAttachMessage{Cmd: protocol.CmdTicketAttach, SourceSessionID: sourceSessionID, Files: files}

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -514,7 +514,7 @@ Use the state that matches the outcome when work needs input, is ready, or ends:
     "$ATTN_WRAPPER_PATH" ticket status completed --comment "<completed outcome>"
     "$ATTN_WRAPPER_PATH" ticket status failed --comment "<terminal failure>"
 
-When the deliverable is a durable plan, design, or other Markdown artifact, hand
+When the deliverable is a durable plan, design, or other artifact, hand
 it over with ` + "`" + `"$ATTN_WRAPPER_PATH" ticket attach --file <path>` + "`" + `. Use repeatable
 ` + "`" + `--file` + "`" + ` flags for multiple artifacts and optionally include ` + "`" + `--state` + "`" + ` and
 ` + "`" + `--comment` + "`" + `. After success, the returned Notebook paths are canonical: keep

--- a/internal/daemon/fs.go
+++ b/internal/daemon/fs.go
@@ -134,7 +134,7 @@ func (d *Daemon) sendFsReadAssetWSResult(client *wsClient, requestID, path strin
 		var store *fsdoc.Store
 		if store, err = d.fsStoreFor(); err == nil {
 			var content []byte
-			if content, _, err = store.Read(path); err == nil {
+			if content, _, err = store.ReadWithLimit(path, maxAssetBytes); err == nil {
 				if len(content) > maxAssetBytes {
 					err = fmt.Errorf("asset exceeds the %d byte read cap", maxAssetBytes)
 				} else if fits, ferr := assetMessageFits(requestID, path, mimeType, len(content)); ferr != nil {

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/victorarias/attn/internal/fsdoc"
 	"github.com/victorarias/attn/internal/protocol"
 )
 
@@ -122,6 +123,29 @@ func TestFsWriteListReadWSResults(t *testing.T) {
 	readNotebookWSEvent(t, client.send, &missing)
 	if missing.RequestID != "r2" || missing.Success || missing.Error == nil {
 		t.Fatalf("missing read result = %+v, want failure with error", missing)
+	}
+}
+
+func TestFsReadWSRejectsOversizedFile(t *testing.T) {
+	d := newFsDaemon(t)
+	root, err := d.notebookRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "attachments", "too-large.txt")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, bytes.Repeat([]byte("x"), fsdoc.MaxFileSize+1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsReadWSResult(client, "oversized", "attachments/too-large.txt")
+	var read protocol.FsReadResultMessage
+	readNotebookWSEvent(t, client.send, &read)
+	if read.Success || read.Error == nil || !strings.Contains(*read.Error, "read cap") {
+		t.Fatalf("oversized read = %+v, want read-cap error", read)
 	}
 }
 

--- a/internal/daemon/ticket_artifacts.go
+++ b/internal/daemon/ticket_artifacts.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ticketArtifacts enumerates the filesystem-canonical artifact index for one
-// ticket. Only direct, regular, visible Markdown files are current artifacts.
+// ticket. Only direct, regular, visible files are current artifacts.
 func (d *Daemon) ticketArtifacts(ticketID string) ([]protocol.TicketArtifact, error) {
 	root, err := d.notebookRoot()
 	if err != nil {
@@ -32,7 +32,7 @@ func (d *Daemon) ticketArtifacts(ticketID string) ([]protocol.TicketArtifact, er
 	artifacts := make([]protocol.TicketArtifact, 0, len(entries))
 	for _, entry := range entries {
 		name := entry.Name()
-		if strings.HasPrefix(name, ".") || filepath.Ext(name) != ".md" || entry.Type()&os.ModeSymlink != 0 {
+		if strings.HasPrefix(name, ".") || entry.Type()&os.ModeSymlink != 0 {
 			continue
 		}
 		info, infoErr := entry.Info()

--- a/internal/daemon/ticket_attach.go
+++ b/internal/daemon/ticket_attach.go
@@ -173,9 +173,9 @@ func stageTicketAttachFiles(dir string, files []protocol.TicketAttachFile) ([]*s
 	staged := make([]*stagedAttachFile, 0, len(files))
 	for _, input := range files {
 		filename := filepath.Base(strings.TrimSpace(input.Filename))
-		if filename == "" || filename == "." || filename == ".." || strings.HasPrefix(filename, ".") || filepath.Ext(filename) != ".md" {
+		if filename == "" || filename == "." || filename == ".." || strings.HasPrefix(filename, ".") {
 			removeAttachStages(staged)
-			return nil, fmt.Errorf("%q is not a visible Markdown filename", input.Filename)
+			return nil, fmt.Errorf("%q is not a visible filename", input.Filename)
 		}
 		if _, exists := seen[filename]; exists {
 			removeAttachStages(staged)

--- a/internal/daemon/ticket_attach_test.go
+++ b/internal/daemon/ticket_attach_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -41,7 +42,7 @@ func attachSource(t *testing.T, dir, name, content string) protocol.TicketAttach
 	return protocol.TicketAttachFile{SourcePath: path, Filename: name}
 }
 
-func TestTicketAttachCopiesMultipleFilesAndChangesState(t *testing.T) {
+func TestTicketAttachCopiesFilesOfAnyTypeAndChangesState(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	notebookRoot := t.TempDir()
 	d.store.SetSetting(SettingNotebookRoot, notebookRoot)
@@ -56,7 +57,8 @@ func TestTicketAttachCopiesMultipleFilesAndChangesState(t *testing.T) {
 		SourceSessionID: agentID,
 		Files: []protocol.TicketAttachFile{
 			attachSource(t, sources, "design.md", "the design"),
-			attachSource(t, sources, "rollout.md", "the rollout"),
+			attachSource(t, sources, "prototype.html", "<!doctype html><title>prototype</title>"),
+			attachSource(t, sources, "results.json", `{"ok":true}`),
 		},
 		State:   &state,
 		Comment: &comment,
@@ -65,7 +67,7 @@ func TestTicketAttachCopiesMultipleFilesAndChangesState(t *testing.T) {
 		t.Fatalf("response = %+v, want attach receipt", resp)
 	}
 	result := resp.TicketAttachResult
-	if result.TicketID != ticketID || result.State != protocol.TicketStatusInReview || len(result.Artifacts) != 2 || result.EventSeq == 0 {
+	if result.TicketID != ticketID || result.State != protocol.TicketStatusInReview || len(result.Artifacts) != 3 || result.EventSeq == 0 {
 		t.Fatalf("receipt = %+v", result)
 	}
 	for _, artifact := range result.Artifacts {
@@ -75,6 +77,9 @@ func TestTicketAttachCopiesMultipleFilesAndChangesState(t *testing.T) {
 		if _, err := os.Stat(artifact.Path); err != nil {
 			t.Fatalf("artifact %q missing: %v", artifact.Path, err)
 		}
+	}
+	if got := artifactNames(result.Artifacts); !reflect.DeepEqual(got, []string{"design.md", "prototype.html", "results.json"}) {
+		t.Fatalf("receipt artifacts = %v", got)
 	}
 	ticket, err := d.store.GetTicket(ticketID)
 	if err != nil {
@@ -86,11 +91,38 @@ func TestTicketAttachCopiesMultipleFilesAndChangesState(t *testing.T) {
 	var sawAttach bool
 	for _, activity := range ticket.Activity {
 		if activity.Kind == store.TicketActivityAttach {
-			sawAttach = strings.Contains(activity.Comment, "design.md, rollout.md") && strings.Contains(activity.Comment, comment)
+			sawAttach = strings.Contains(activity.Comment, "design.md, prototype.html, results.json") && strings.Contains(activity.Comment, comment)
 		}
 	}
 	if !sawAttach {
 		t.Fatalf("attach history missing: %+v", ticket.Activity)
+	}
+}
+
+func TestTicketAttachUsesVisibleBasenamesAndRejectsNonRegularSources(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.store.SetSetting(SettingNotebookRoot, t.TempDir())
+	_, agentID, _ := delegateForNotify(t, d, "codex")
+
+	source := attachSource(t, t.TempDir(), "source.html", "<!doctype html>")
+	source.Filename = "nested/prototype.html"
+	resp := callTicketAttach(t, d, &protocol.TicketAttachMessage{Cmd: protocol.CmdTicketAttach, SourceSessionID: agentID, Files: []protocol.TicketAttachFile{source}})
+	if !resp.Ok || resp.TicketAttachResult == nil || len(resp.TicketAttachResult.Artifacts) != 1 || resp.TicketAttachResult.Artifacts[0].Filename != "prototype.html" {
+		t.Fatalf("basename attach response = %+v", resp)
+	}
+
+	target := attachSource(t, t.TempDir(), "target.txt", "target")
+	symlink := filepath.Join(t.TempDir(), "linked.txt")
+	if err := os.Symlink(target.SourcePath, symlink); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	resp = callTicketAttach(t, d, &protocol.TicketAttachMessage{
+		Cmd:             protocol.CmdTicketAttach,
+		SourceSessionID: agentID,
+		Files:           []protocol.TicketAttachFile{{SourcePath: symlink, Filename: "linked.txt"}},
+	})
+	if resp.Ok || resp.Error == nil || !strings.Contains(*resp.Error, "not a regular file") {
+		t.Fatalf("symlink response = %+v, want regular-file error", resp)
 	}
 }
 
@@ -121,11 +153,11 @@ func TestTicketAttachPreservesDifferentExistingArtifact(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	destination := filepath.Join(dir, "design.md")
+	destination := filepath.Join(dir, "prototype.html")
 	if err := os.WriteFile(destination, []byte("keep me"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	source := attachSource(t, t.TempDir(), "design.md", "replacement")
+	source := attachSource(t, t.TempDir(), "prototype.html", "replacement")
 	resp := callTicketAttach(t, d, &protocol.TicketAttachMessage{Cmd: protocol.CmdTicketAttach, SourceSessionID: agentID, Files: []protocol.TicketAttachFile{source}})
 	if resp.Ok || resp.Error == nil || !strings.Contains(*resp.Error, "different contents") {
 		t.Fatalf("response = %+v, want collision error", resp)

--- a/internal/daemon/ticket_board_test.go
+++ b/internal/daemon/ticket_board_test.go
@@ -150,7 +150,7 @@ func TestTicketArtifactsFollowFilesystemAtReadTime(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dir, "nested"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	for name, content := range map[string]string{"b.md": "b", "a.md": "a", ".hidden.md": "hidden", "notes.txt": "text"} {
+	for name, content := range map[string]string{"b.md": "b", "a.md": "a", ".hidden.md": "hidden", "notes.txt": "text", "prototype.html": "<h1>prototype</h1>"} {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -167,7 +167,7 @@ func TestTicketArtifactsFollowFilesystemAtReadTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if names := artifactNames(first.Artifacts); !reflect.DeepEqual(names, []string{"a.md", "b.md"}) {
+	if names := artifactNames(first.Artifacts); !reflect.DeepEqual(names, []string{"a.md", "b.md", "notes.txt", "prototype.html"}) {
 		t.Fatalf("artifact names = %v", names)
 	}
 	if err := os.Rename(filepath.Join(dir, "a.md"), filepath.Join(dir, "implementation.md")); err != nil {
@@ -180,7 +180,7 @@ func TestTicketArtifactsFollowFilesystemAtReadTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if names := artifactNames(second.Artifacts); !reflect.DeepEqual(names, []string{"implementation.md"}) {
+	if names := artifactNames(second.Artifacts); !reflect.DeepEqual(names, []string{"implementation.md", "notes.txt", "prototype.html"}) {
 		t.Fatalf("artifacts after rename/delete = %v", names)
 	}
 }

--- a/internal/fsdoc/store.go
+++ b/internal/fsdoc/store.go
@@ -146,9 +146,16 @@ func (s *Store) List(dir string) ([]Entry, error) {
 	return entries, nil
 }
 
-// Read returns the raw bytes of a file and their content hash. A missing file
-// yields a *NotFoundError.
+// Read returns the raw bytes of a file and their content hash, bounded by
+// MaxFileSize. A missing file yields a *NotFoundError.
 func (s *Store) Read(p string) (content []byte, hash string, err error) {
+	return s.ReadWithLimit(p, MaxFileSize)
+}
+
+// ReadWithLimit returns the raw bytes of a file and their content hash, bounded
+// by maxBytes before allocating file contents. Callers must supply the limit for
+// their transport or presentation surface; generic text reads use Read.
+func (s *Store) ReadWithLimit(p string, maxBytes int64) (content []byte, hash string, err error) {
 	rel, err := cleanRel(p, false)
 	if err != nil {
 		return nil, "", err
@@ -167,8 +174,8 @@ func (s *Store) Read(p string) (content []byte, hash string, err error) {
 	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
 		return nil, "", fmt.Errorf("fsdoc: %q is not a regular file", p)
 	}
-	if info.Size() > MaxFileSize {
-		return nil, "", fmt.Errorf("fsdoc: %q exceeds %d byte read cap", p, MaxFileSize)
+	if info.Size() > maxBytes {
+		return nil, "", fmt.Errorf("fsdoc: %q exceeds %d byte read cap", p, maxBytes)
 	}
 	content, err = os.ReadFile(abs)
 	if err != nil {

--- a/internal/fsdoc/store.go
+++ b/internal/fsdoc/store.go
@@ -24,7 +24,7 @@ import (
 
 // MaxFileSize bounds a single fs_write so a runaway write cannot balloon the
 // root. It mirrors notebook.MaxFileSize: the same root, the same sync-friendly
-// goal. (Reads are not yet size-capped — that lands with the non-text handling.)
+// goal. Reads use the same cap before allocating file contents for the WebSocket.
 const MaxFileSize = 2 << 20 // 2 MiB
 
 // Store is the generic filesystem store for one root directory. Writes serialize
@@ -156,6 +156,19 @@ func (s *Store) Read(p string) (content []byte, hash string, err error) {
 	abs, err := s.abs(rel)
 	if err != nil {
 		return nil, "", err
+	}
+	info, statErr := os.Lstat(abs)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return nil, "", &NotFoundError{Path: p}
+		}
+		return nil, "", statErr
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, "", fmt.Errorf("fsdoc: %q is not a regular file", p)
+	}
+	if info.Size() > MaxFileSize {
+		return nil, "", fmt.Errorf("fsdoc: %q exceeds %d byte read cap", p, MaxFileSize)
 	}
 	content, err = os.ReadFile(abs)
 	if err != nil {

--- a/internal/notebook/layout.go
+++ b/internal/notebook/layout.go
@@ -60,7 +60,7 @@ func TicketAttachmentsDir(root, ticketID string) string {
 }
 
 // TicketArtifactsDir returns the visible Notebook directory whose direct
-// Markdown children are the current artifacts for one ticket.
+// file children are the current artifacts for one ticket.
 func TicketArtifactsDir(root, ticketID string) string {
 	return filepath.Join(root, "tickets", ticketID)
 }

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -338,7 +338,7 @@ model TicketActivity {
   created_at: string;
 }
 
-// TicketArtifact is a current Markdown file in the ticket's visible Notebook
+// TicketArtifact is a current file in the ticket's visible Notebook
 // directory. The filesystem is authoritative, so the shape carries paths rather
 // than a database identity or lifecycle metadata.
 model TicketArtifact {
@@ -835,7 +835,7 @@ model TicketAttachFile {
   filename: string;
 }
 
-// TicketAttachMessage copies one or more Markdown artifacts into a ticket's
+// TicketAttachMessage copies one or more artifact files into a ticket's
 // visible Notebook directory and records one durable attach receipt. Without a
 // ticket_id the daemon resolves the caller's bound ticket; with one it follows the
 // same permissive by-id authorization as ticket status and comment.


### PR DESCRIPTION
## Intent

Agents need to hand over durable artifacts such as self-contained HTML prototypes directly through `attn ticket attach`, rather than creating a Markdown substitute and copying files outside the supported workflow.

## Summary

- Allow any regular, non-symlinked file through the CLI, daemon staging, and canonical ticket artifact listing.
- Remove Markdown-only file selection and rename constraints in the ticket detail panel, so attached files remain discoverable and manageable in-app.
- Keep opening safe: HTML is shown as Notebook source text rather than executed; known binary formats retain the existing non-executing preview placeholder.
- Update agent guidance, CLI help, protocol documentation, glossary, changelog, and focused regression coverage.

## Test plan

- [x] `go test ./...`
- [x] `pnpm --dir app test -- --run src/components/TicketDetailPanel.test.tsx`
- [x] `ATTN_HARNESS_PROFILE=htmlattach pnpm --dir app run real-app:scenario-ticket-lifecycle`
- [x] Built and ran the isolated `htmlattach` profile; attached a self-contained HTML fixture with the real CLI, verified `ticket show`, and byte-compared the canonical Notebook copy.
- [x] Repeated the real CLI flow with a Markdown fixture to confirm existing behavior.

## Why safe viewing matters

This change broadens transport and listing, not execution. The existing Notebook file-kind policy displays HTML as editable source and leaves known binary formats as a non-executing placeholder.