### PR TITLE
perf(notebook): parse frontmatter from a bounded doc prefix

### DIFF
--- a/app/src/components/notebook/frontmatter.ts
+++ b/app/src/components/notebook/frontmatter.ts
@@ -1,12 +1,15 @@
 // Parse a note's leading YAML frontmatter block for the in-editor frontmatter card.
-// Pure (no DOM, no CodeMirror), so it runs in headless unit tests; the card widget
-// and its cursor/focus-gated reveal are layered on top in frontmatterCard.ts.
+// No DOM; only a type-only CodeMirror import for parseFrontmatterFromDoc's `Text`
+// parameter, so it still runs in headless unit tests. The card widget and its
+// cursor/focus-gated reveal are layered on top in frontmatterCard.ts.
 //
 // The notebook's frontmatter is keeper-written and structured, so we parse the small
 // YAML subset it actually uses — `key: value`, flow lists `[a, b]`, and block lists
 // (`key:` then indented `- item` lines) — rather than pulling in a full YAML parser.
 // Anything fancier (nested maps, block scalars) is out of scope; escalate to js-yaml
 // if notes ever need it.
+
+import type { Text } from '@codemirror/state';
 
 export type FrontmatterValue = string | string[];
 
@@ -87,4 +90,14 @@ export function parseFrontmatter(doc: string): Frontmatter | null {
   for (let i = 0; i <= close; i += 1) to += lines[i].length + 1;
   to = Math.min(to, doc.length); // no trailing newline after the close → clamp
   return { fields: parseFields(lines.slice(1, close)), from: 0, to };
+}
+
+// Frontmatter always lives in a small leading prefix; materializing the whole
+// document to parse it is wasted work on a large note. The bound is shared by
+// every editor extension so they all agree on what counts as frontmatter — a
+// fence that closes beyond it is treated as not-frontmatter everywhere.
+export const FRONTMATTER_SCAN_LIMIT = 4096;
+
+export function parseFrontmatterFromDoc(doc: Text): Frontmatter | null {
+  return parseFrontmatter(doc.sliceString(0, Math.min(doc.length, FRONTMATTER_SCAN_LIMIT)));
 }

--- a/app/src/components/notebook/frontmatterCard.test.ts
+++ b/app/src/components/notebook/frontmatterCard.test.ts
@@ -2,7 +2,7 @@ import { EditorSelection, EditorState } from '@codemirror/state';
 import { type DecorationSet } from '@codemirror/view';
 import { describe, expect, it } from 'vitest';
 import { frontmatterCardDecorations } from './frontmatterCard';
-import { parseFrontmatter } from './frontmatter';
+import { FRONTMATTER_SCAN_LIMIT, parseFrontmatter } from './frontmatter';
 
 // Pull the card's ranges out of the decoration set so the explicit-edit gate can be
 // asserted without mounting a view (the widget's toDOM never runs headlessly).
@@ -48,6 +48,21 @@ describe('frontmatterCardDecorations', () => {
 
   it('renders nothing for a frontmatter-only note (no body line to keep the cursor on)', () => {
     const got = ranges(frontmatterCardDecorations(stateAt('---\ntype: area\n---\n', 0), false));
+    expect(got).toHaveLength(0);
+  });
+
+  it('still renders the card when the body (not the frontmatter) exceeds the scan limit', () => {
+    const bigBody = '# Body\n' + 'x'.repeat(FRONTMATTER_SCAN_LIMIT * 2);
+    const note = ['---', 'type: area', '---', bigBody].join('\n');
+    const got = ranges(frontmatterCardDecorations(stateAt(note, 0), false));
+    const fm = parseFrontmatter(note.slice(0, FRONTMATTER_SCAN_LIMIT))!;
+    expect(got).toEqual([{ from: 0, to: fm.to, block: true }]);
+  });
+
+  it('treats an opening fence with no closing fence within the scan limit as no frontmatter', () => {
+    const note = '---\n' + 'padding line\n'.repeat(400) + '---\n# Body\n';
+    expect(note.indexOf('\n---\n', 4)).toBeGreaterThan(FRONTMATTER_SCAN_LIMIT);
+    const got = ranges(frontmatterCardDecorations(stateAt(note, 0), false));
     expect(got).toHaveLength(0);
   });
 });

--- a/app/src/components/notebook/frontmatterCard.ts
+++ b/app/src/components/notebook/frontmatterCard.ts
@@ -15,7 +15,7 @@
 
 import { type EditorState, type Extension, RangeSet, StateEffect, StateField } from '@codemirror/state';
 import { Decoration, type DecorationSet, EditorView, WidgetType } from '@codemirror/view';
-import { type Frontmatter, type FrontmatterValue, parseFrontmatter } from './frontmatter';
+import { type Frontmatter, type FrontmatterValue, parseFrontmatterFromDoc } from './frontmatter';
 
 // Raw frontmatter is an explicit editing mode, not a consequence of editor focus.
 // CodeMirror focuses before it places a pointer selection. Tying the card to focus
@@ -30,7 +30,7 @@ const editingFrontmatterField = StateField.define<boolean>({
       if (effect.is(setEditingFrontmatter)) value = effect.value;
     }
     if (value && tr.selection) {
-      const fm = parseFrontmatter(tr.state.doc.toString());
+      const fm = parseFrontmatterFromDoc(tr.state.doc);
       const remainsInside = fm && tr.state.selection.ranges.some(
         (range) => range.from < fm.to && range.to > fm.from,
       );
@@ -177,12 +177,11 @@ class FrontmatterCardWidget extends WidgetType {
 // buildDecorations. Returns the block-replace card, or an empty set when there's no
 // frontmatter or while explicit frontmatter editing is active.
 export function frontmatterCardDecorations(state: EditorState, editing: boolean): DecorationSet {
-  const doc = state.doc.toString();
-  const fm = parseFrontmatter(doc);
+  const fm = parseFrontmatterFromDoc(state.doc);
   if (!fm || fm.to <= fm.from) return Decoration.none;
   // Don't swallow the whole document: a note that is ONLY frontmatter has no body line
   // to keep the cursor on, so leave it as raw text.
-  if (fm.to >= doc.length) return Decoration.none;
+  if (fm.to >= state.doc.length) return Decoration.none;
   if (editing) {
     for (const range of state.selection.ranges) {
       if (range.from < fm.to && range.to > fm.from) return Decoration.none;
@@ -218,7 +217,7 @@ const cardField = StateField.define<DecorationSet>({
 // click cannot temporarily replace the card using CM's stale position-0 selection.
 const blurTracker = EditorView.domEventHandlers({
   blur: (_event, view) => {
-    const fm = parseFrontmatter(view.state.doc.toString());
+    const fm = parseFrontmatterFromDoc(view.state.doc);
     const selectionInside = fm && view.state.selection.ranges.some(
       (range) => range.from < fm.to && range.to > fm.from,
     );

--- a/app/src/components/notebook/liveMarkdownPreview.ts
+++ b/app/src/components/notebook/liveMarkdownPreview.ts
@@ -19,16 +19,14 @@ import {
   WidgetType,
 } from '@codemirror/view';
 import type { Tree } from '@lezer/common';
-import { parseFrontmatter } from './frontmatter';
+import { parseFrontmatterFromDoc } from './frontmatter';
 
 // A note's leading frontmatter is YAML, not markdown — no inline-preview decoration
 // (bullets, bold, etc.) is ever correct there; it renders raw or as the frontmatterCard
 // widget (a separate extension). Returns 0 when the doc has no frontmatter, else the
-// region's end offset. Parses only a BOUNDED prefix (frontmatter is always small, and a
-// full doc.toString() per keystroke is wasted work on a large note).
+// region's end offset.
 function frontmatterEnd(state: EditorState): number {
-  const prefix = state.doc.sliceString(0, Math.min(state.doc.length, 4096));
-  const fm = parseFrontmatter(prefix);
+  const fm = parseFrontmatterFromDoc(state.doc);
   // Must agree with frontmatterCard's own notion of "is this frontmatter" — an opening
   // `---` with no closing fence (still being typed, malformed, or truncated past the
   // bounded prefix) is treated as NOT frontmatter by both extensions, matching


### PR DESCRIPTION
## Summary
- Bounds frontmatter parsing to a fixed prefix of the document instead of scanning the whole document on every parse, avoiding wasted work on large notes where frontmatter only ever lives at the top.
- Touches `frontmatter.ts`, `frontmatterCard.ts`, and `liveMarkdownPreview.ts`; test coverage extended in `frontmatterCard.test.ts`.

This is PR9/9 (final) of the notebook editor polish stack (plan: `docs/plans/2026-07-11-notebook-editor-polish.md`; PRs 1-8 already merged).

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec vitest run frontmatter` — 23/23 passing across the touched files
- [x] Pure frontend perf refactor of frontmatter parsing, fully covered by the unit tests in this diff; the notebook editor surface it touches was live-verified extensively earlier in this stack (most recently PR8's packaged-app scenario run)

https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT