### PR TITLE
feat(daemon): fs commands accept an explicit root

### DIFF
--- a/app/src/hooks/useDaemonSocket.test.tsx
+++ b/app/src/hooks/useDaemonSocket.test.tsx
@@ -2935,15 +2935,15 @@ describe('useDaemonSocket fs surface', () => {
     unmount();
   });
 
-  it('invokes onFsChanged with origin and paths', async () => {
+  it('invokes onFsChanged with origin, paths, and root', async () => {
     const onFsChanged = vi.fn();
     const { unmount } = renderFsHook({ onFsChanged });
     const ws = await waitForOpenSocket();
 
     act(() => {
-      ws.emit({ event: 'fs_changed', origin: 'ui', paths: ['notes/todo.txt'] });
+      ws.emit({ event: 'fs_changed', origin: 'ui', paths: ['notes/todo.txt'], root: '/Users/x/attn-notebook' });
     });
-    expect(onFsChanged).toHaveBeenCalledWith('ui', ['notes/todo.txt']);
+    expect(onFsChanged).toHaveBeenCalledWith('ui', ['notes/todo.txt'], '/Users/x/attn-notebook');
     unmount();
   });
 });

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '166';
+export const PROTOCOL_VERSION = '167';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -453,7 +453,7 @@ interface UseDaemonSocketOptions {
   // Fired when files under the root change (any client/agent/external write). paths
   // are root-relative; origin is agent|ui|external. Mirrors onNotebookChanged for
   // the generic filesystem surface (fs_changed).
-  onFsChanged?: (origin: string, paths: string[]) => void;
+  onFsChanged?: (origin: string, paths: string[], root: string) => void;
   // Fired with the non-archived ticket board (bare rows) on initial_state and on
   // every tickets_updated broadcast. The detail view fetches full records itself.
   onTicketsUpdate?: (tickets: Ticket[]) => void;
@@ -1524,6 +1524,7 @@ export function useDaemonSocket({
             callbacksRef.current.onFsChanged?.(
               typeof data.origin === 'string' ? data.origin : '',
               Array.isArray(data.paths) ? data.paths : [],
+              typeof data.root === 'string' ? data.root : '',
             );
             break;
 
@@ -4603,7 +4604,7 @@ export function useDaemonSocket({
   // List one directory's immediate children over the generic filesystem surface.
   // Omit/empty path = the root directory. Shallow: a tree expands lazily, one call
   // per node.
-  const sendFsList = useCallback((path?: string): Promise<FsEntry[]> => {
+  const sendFsList = useCallback((path?: string, root?: string): Promise<FsEntry[]> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -4613,7 +4614,7 @@ export function useDaemonSocket({
       const requestId = nextRequestID('fs_list');
       const key = `fs_list:${requestId}`;
       pendingActionsRef.current.set(key, { resolve, reject });
-      ws.send(JSON.stringify({ cmd: 'fs_list', request_id: requestId, ...(path ? { path } : {}) }));
+      ws.send(JSON.stringify({ cmd: 'fs_list', request_id: requestId, ...(path ? { path } : {}), ...(root ? { root } : {}) }));
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
@@ -4624,7 +4625,7 @@ export function useDaemonSocket({
   }, [nextRequestID]);
 
   // Read one file's full bytes + content hash.
-  const sendFsRead = useCallback((path: string): Promise<FsReadResult> => {
+  const sendFsRead = useCallback((path: string, root?: string): Promise<FsReadResult> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -4634,7 +4635,7 @@ export function useDaemonSocket({
       const requestId = nextRequestID('fs_read');
       const key = `fs_read:${requestId}`;
       pendingActionsRef.current.set(key, { resolve, reject });
-      ws.send(JSON.stringify({ cmd: 'fs_read', request_id: requestId, path }));
+      ws.send(JSON.stringify({ cmd: 'fs_read', request_id: requestId, path, ...(root ? { root } : {}) }));
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
@@ -4646,7 +4647,7 @@ export function useDaemonSocket({
 
   // Read one image asset's bytes as base64, for rendering ![alt](path) images in
   // the notebook editor without widening Tauri's fs permissions.
-  const sendFsReadAsset = useCallback((path: string): Promise<FsReadAssetResult> => {
+  const sendFsReadAsset = useCallback((path: string, root?: string): Promise<FsReadAssetResult> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -4656,7 +4657,7 @@ export function useDaemonSocket({
       const requestId = nextRequestID('fs_read_asset');
       const key = `fs_read_asset:${requestId}`;
       pendingActionsRef.current.set(key, { resolve, reject });
-      ws.send(JSON.stringify({ cmd: 'fs_read_asset', request_id: requestId, path }));
+      ws.send(JSON.stringify({ cmd: 'fs_read_asset', request_id: requestId, path, ...(root ? { root } : {}) }));
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
@@ -4669,7 +4670,7 @@ export function useDaemonSocket({
   // Save one file via the daemon (hash-CAS). Omit baseHash to create-only; pass the
   // file's loaded hash to edit. Resolves with the outcome — including a conflict
   // (resolve, not reject) the editor reconciles; rejects only on a transport error.
-  const sendFsWrite = useCallback((path: string, content: string, baseHash?: string): Promise<FsWriteResult> => {
+  const sendFsWrite = useCallback((path: string, content: string, baseHash?: string, root?: string): Promise<FsWriteResult> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -4679,7 +4680,7 @@ export function useDaemonSocket({
       const requestId = nextRequestID('fs_write');
       const key = `fs_write:${requestId}`;
       pendingActionsRef.current.set(key, { resolve, reject });
-      ws.send(JSON.stringify({ cmd: 'fs_write', request_id: requestId, path, content, ...(baseHash ? { base_hash: baseHash } : {}) }));
+      ws.send(JSON.stringify({ cmd: 'fs_write', request_id: requestId, path, content, ...(baseHash ? { base_hash: baseHash } : {}), ...(root ? { root } : {}) }));
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);
@@ -4689,7 +4690,7 @@ export function useDaemonSocket({
     });
   }, [nextRequestID]);
 
-  const sendFsRename = useCallback((path: string, newPath: string): Promise<FsRenameResult> => new Promise((resolve, reject) => {
+  const sendFsRename = useCallback((path: string, newPath: string, root?: string): Promise<FsRenameResult> => new Promise((resolve, reject) => {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) {
       reject(new Error('WebSocket not connected'));
@@ -4698,7 +4699,7 @@ export function useDaemonSocket({
     const requestId = nextRequestID('fs_rename');
     const key = `fs_rename:${requestId}`;
     pendingActionsRef.current.set(key, { resolve, reject });
-    ws.send(JSON.stringify({ cmd: 'fs_rename', request_id: requestId, path, new_path: newPath }));
+    ws.send(JSON.stringify({ cmd: 'fs_rename', request_id: requestId, path, new_path: newPath, ...(root ? { root } : {}) }));
     setTimeout(() => {
       if (pendingActionsRef.current.has(key)) {
         pendingActionsRef.current.delete(key);
@@ -4707,7 +4708,7 @@ export function useDaemonSocket({
     }, 10000);
   }), [nextRequestID]);
 
-  const sendFsDelete = useCallback((path: string): Promise<FsDeleteResult> => new Promise((resolve, reject) => {
+  const sendFsDelete = useCallback((path: string, root?: string): Promise<FsDeleteResult> => new Promise((resolve, reject) => {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) {
       reject(new Error('WebSocket not connected'));
@@ -4716,7 +4717,7 @@ export function useDaemonSocket({
     const requestId = nextRequestID('fs_delete');
     const key = `fs_delete:${requestId}`;
     pendingActionsRef.current.set(key, { resolve, reject });
-    ws.send(JSON.stringify({ cmd: 'fs_delete', request_id: requestId, path }));
+    ws.send(JSON.stringify({ cmd: 'fs_delete', request_id: requestId, path, ...(root ? { root } : {}) }));
     setTimeout(() => {
       if (pendingActionsRef.current.has(key)) {
         pendingActionsRef.current.delete(key);
@@ -4728,7 +4729,7 @@ export function useDaemonSocket({
   // Check whether a path exists under the notebook root, without reading it. Used
   // to flag in-notebook markdown links whose target note is missing. Rejects on a
   // transport/daemon error (the caller leaves the link unflagged in that case).
-  const sendFsExists = useCallback((path: string): Promise<FsExistsResult> => {
+  const sendFsExists = useCallback((path: string, root?: string): Promise<FsExistsResult> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -4738,7 +4739,7 @@ export function useDaemonSocket({
       const requestId = nextRequestID('fs_exists');
       const key = `fs_exists:${requestId}`;
       pendingActionsRef.current.set(key, { resolve, reject });
-      ws.send(JSON.stringify({ cmd: 'fs_exists', request_id: requestId, path }));
+      ws.send(JSON.stringify({ cmd: 'fs_exists', request_id: requestId, path, ...(root ? { root } : {}) }));
       setTimeout(() => {
         if (pendingActionsRef.current.has(key)) {
           pendingActionsRef.current.delete(key);

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -153,18 +153,20 @@
 //   const openBrowserMessage = Convert.toOpenBrowserMessage(json);
 //   const openMarkdownMessage = Convert.toOpenMarkdownMessage(json);
 //   const openMarkdownResultMessage = Convert.toOpenMarkdownResultMessage(json);
-//   const pR = Convert.toPR(json);
-//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
-//   const pRRole = Convert.toPRRole(json);
-//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
-//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
 //   const pathInspection = Convert.toPathInspection(json);
 //   const pinWorkspaceMessage = Convert.toPinWorkspaceMessage(json);
 //   const pluginActionResultMessage = Convert.toPluginActionResultMessage(json);
 //   const pluginInfo = Convert.toPluginInfo(json);
 //   const pluginIssue = Convert.toPluginIssue(json);
 //   const pluginsUpdatedMessage = Convert.toPluginsUpdatedMessage(json);
+//   const pR = Convert.toPR(json);
+//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
 //   const presentAnnotation = Convert.toPresentAnnotation(json);
+//   const presentation = Convert.toPresentation(json);
+//   const presentationAddedMessage = Convert.toPresentationAddedMessage(json);
+//   const presentationComment = Convert.toPresentationComment(json);
+//   const presentationRound = Convert.toPresentationRound(json);
+//   const presentationUpdatedMessage = Convert.toPresentationUpdatedMessage(json);
 //   const presentCloseMessage = Convert.toPresentCloseMessage(json);
 //   const presentCloseResultMessage = Convert.toPresentCloseResultMessage(json);
 //   const presentCommentInput = Convert.toPresentCommentInput(json);
@@ -176,16 +178,14 @@
 //   const presentOpenResult = Convert.toPresentOpenResult(json);
 //   const presentSubmitRoundMessage = Convert.toPresentSubmitRoundMessage(json);
 //   const presentSubmitRoundResultMessage = Convert.toPresentSubmitRoundResultMessage(json);
-//   const presentation = Convert.toPresentation(json);
-//   const presentationAddedMessage = Convert.toPresentationAddedMessage(json);
-//   const presentationComment = Convert.toPresentationComment(json);
-//   const presentationRound = Convert.toPresentationRound(json);
-//   const presentationUpdatedMessage = Convert.toPresentationUpdatedMessage(json);
+//   const pRRole = Convert.toPRRole(json);
+//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
+//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
 //   const ptyDesyncMessage = Convert.toPtyDesyncMessage(json);
 //   const ptyInputMessage = Convert.toPtyInputMessage(json);
 //   const ptyOutputMessage = Convert.toPtyOutputMessage(json);
-//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
+//   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
 //   const queryAuthorsMessage = Convert.toQueryAuthorsMessage(json);
 //   const queryMessage = Convert.toQueryMessage(json);
 //   const queryPRsMessage = Convert.toQueryPRsMessage(json);
@@ -215,10 +215,10 @@
 //   const sessionSelectedMessage = Convert.toSessionSelectedMessage(json);
 //   const sessionState = Convert.toSessionState(json);
 //   const sessionStateChangedMessage = Convert.toSessionStateChangedMessage(json);
+//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const sessionTodosUpdatedMessage = Convert.toSessionTodosUpdatedMessage(json);
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
 //   const sessionVisualizedMessage = Convert.toSessionVisualizedMessage(json);
-//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
 //   const setPluginPriorityMessage = Convert.toSetPluginPriorityMessage(json);
@@ -226,8 +226,8 @@
 //   const setSettingMessage = Convert.toSetSettingMessage(json);
 //   const setTerminalThemeMessage = Convert.toSetTerminalThemeMessage(json);
 //   const setTicketStatusMessage = Convert.toSetTicketStatusMessage(json);
-//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const settingsUpdatedMessage = Convert.toSettingsUpdatedMessage(json);
+//   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
 //   const spawnResultMessage = Convert.toSpawnResultMessage(json);
 //   const spawnSessionMessage = Convert.toSpawnSessionMessage(json);
 //   const stateMessage = Convert.toStateMessage(json);
@@ -271,11 +271,11 @@
 //   const ticketStatusResult = Convert.toTicketStatusResult(json);
 //   const ticketSubscribeMessage = Convert.toTicketSubscribeMessage(json);
 //   const ticketSubscribeResult = Convert.toTicketSubscribeResult(json);
+//   const ticketsUpdatedMessage = Convert.toTicketsUpdatedMessage(json);
 //   const ticketTakeMessage = Convert.toTicketTakeMessage(json);
 //   const ticketTakeResult = Convert.toTicketTakeResult(json);
 //   const ticketUnsubscribeMessage = Convert.toTicketUnsubscribeMessage(json);
 //   const ticketUnsubscribeResult = Convert.toTicketUnsubscribeResult(json);
-//   const ticketsUpdatedMessage = Convert.toTicketsUpdatedMessage(json);
 //   const todosMessage = Convert.toTodosMessage(json);
 //   const triggerNudgeMessage = Convert.toTriggerNudgeMessage(json);
 //   const uninstallPluginMessage = Convert.toUninstallPluginMessage(json);
@@ -328,8 +328,8 @@
 //   const workspaceLayoutSetSplitRatioMessage = Convert.toWorkspaceLayoutSetSplitRatioMessage(json);
 //   const workspaceLayoutSplitDirection = Convert.toWorkspaceLayoutSplitDirection(json);
 //   const workspaceLayoutUndockTileMessage = Convert.toWorkspaceLayoutUndockTileMessage(json);
-//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
+//   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
 //   const workspaceRegisteredMessage = Convert.toWorkspaceRegisteredMessage(json);
 //   const workspaceSelectedMessage = Convert.toWorkspaceSelectedMessage(json);
 //   const workspaceStateChangedMessage = Convert.toWorkspaceStateChangedMessage(json);
@@ -1064,6 +1064,7 @@ export interface FSChangedMessage {
     event:  FSChangedMessageEvent;
     origin: string;
     paths:  string[];
+    root:   string;
     [property: string]: any;
 }
 
@@ -1075,6 +1076,7 @@ export interface FSDeleteMessage {
     cmd:         FSDeleteMessageCmd;
     path:        string;
     request_id?: string;
+    root?:       string;
     [property: string]: any;
 }
 
@@ -1118,6 +1120,7 @@ export interface FSExistsMessage {
     cmd:         FSExistsMessageCmd;
     path:        string;
     request_id?: string;
+    root?:       string;
     [property: string]: any;
 }
 
@@ -1154,6 +1157,7 @@ export interface FSListMessage {
     cmd:         FSListMessageCmd;
     path?:       string;
     request_id?: string;
+    root?:       string;
     [property: string]: any;
 }
 
@@ -1187,6 +1191,7 @@ export interface FSReadAssetMessage {
     cmd:         FSReadAssetMessageCmd;
     path:        string;
     request_id?: string;
+    root?:       string;
     [property: string]: any;
 }
 
@@ -1225,6 +1230,7 @@ export interface FSReadMessage {
     cmd:         FSReadMessageCmd;
     path:        string;
     request_id?: string;
+    root?:       string;
     [property: string]: any;
 }
 
@@ -1264,6 +1270,7 @@ export interface FSRenameMessage {
     new_path:    string;
     path:        string;
     request_id?: string;
+    root?:       string;
     [property: string]: any;
 }
 
@@ -1302,6 +1309,7 @@ export interface FSWriteMessage {
     content:     string;
     path:        string;
     request_id?: string;
+    root?:       string;
     [property: string]: any;
 }
 
@@ -1430,7 +1438,7 @@ export interface PresentationElement {
 
 export interface Round {
     base_sha:        string;
-    changed_files?:  FileElement[];
+    changed_files?:  ChangedFileElement[];
     created_at:      string;
     head_sha:        string;
     id:              string;
@@ -1442,7 +1450,7 @@ export interface Round {
     [property: string]: any;
 }
 
-export interface FileElement {
+export interface ChangedFileElement {
     additions?:   number;
     annotations?: AnnotationElement[];
     deletions?:   number;
@@ -1459,7 +1467,7 @@ export interface AnnotationElement {
 }
 
 export interface Manifest {
-    files:    FileElement[];
+    files:    ChangedFileElement[];
     skip:     string[];
     summary?: string;
     title:    string;
@@ -2553,69 +2561,6 @@ export enum OpenMarkdownResultMessageEvent {
     OpenMarkdownResult = "open_markdown_result",
 }
 
-export interface PR {
-    approved_by_me:         boolean;
-    author:                 string;
-    ci_status?:             string;
-    comment_count?:         number;
-    details_fetched:        boolean;
-    details_fetched_at?:    string;
-    has_new_changes:        boolean;
-    head_branch?:           string;
-    head_sha?:              string;
-    heat_state?:            HeatState;
-    host:                   string;
-    id:                     string;
-    last_heat_activity_at?: string;
-    last_polled:            string;
-    last_updated:           string;
-    mergeable?:             boolean;
-    mergeable_state?:       string;
-    muted:                  boolean;
-    number:                 number;
-    reason:                 string;
-    repo:                   string;
-    review_status?:         string;
-    role:                   PRRole;
-    state:                  string;
-    title:                  string;
-    url:                    string;
-    [property: string]: any;
-}
-
-export interface PRActionResultMessage {
-    action:  string;
-    error?:  string;
-    event:   PRActionResultMessageEvent;
-    id:      string;
-    success: boolean;
-    [property: string]: any;
-}
-
-export enum PRActionResultMessageEvent {
-    PRActionResult = "pr_action_result",
-}
-
-export interface PRVisitedMessage {
-    cmd: PRVisitedMessageCmd;
-    id:  string;
-    [property: string]: any;
-}
-
-export enum PRVisitedMessageCmd {
-    PRVisited = "pr_visited",
-}
-
-export interface PRsUpdatedMessage {
-    event: PRsUpdatedMessageEvent;
-    prs?:  PRElement[];
-    [property: string]: any;
-}
-
-export enum PRsUpdatedMessageEvent {
-    PrsUpdated = "prs_updated",
-}
-
 export interface PathInspection {
     exists:        boolean;
     home_path?:    string;
@@ -2719,11 +2664,115 @@ export interface PluginElement {
     [property: string]: any;
 }
 
+export interface PR {
+    approved_by_me:         boolean;
+    author:                 string;
+    ci_status?:             string;
+    comment_count?:         number;
+    details_fetched:        boolean;
+    details_fetched_at?:    string;
+    has_new_changes:        boolean;
+    head_branch?:           string;
+    head_sha?:              string;
+    heat_state?:            HeatState;
+    host:                   string;
+    id:                     string;
+    last_heat_activity_at?: string;
+    last_polled:            string;
+    last_updated:           string;
+    mergeable?:             boolean;
+    mergeable_state?:       string;
+    muted:                  boolean;
+    number:                 number;
+    reason:                 string;
+    repo:                   string;
+    review_status?:         string;
+    role:                   PRRole;
+    state:                  string;
+    title:                  string;
+    url:                    string;
+    [property: string]: any;
+}
+
+export interface PRActionResultMessage {
+    action:  string;
+    error?:  string;
+    event:   PRActionResultMessageEvent;
+    id:      string;
+    success: boolean;
+    [property: string]: any;
+}
+
+export enum PRActionResultMessageEvent {
+    PRActionResult = "pr_action_result",
+}
+
 export interface PresentAnnotation {
     comments:   string[];
     line_end:   number;
     line_start: number;
     [property: string]: any;
+}
+
+export interface Presentation {
+    created_at:             string;
+    id:                     string;
+    kind:                   string;
+    latest_round_seq:       number;
+    latest_round_submitted: boolean;
+    repo_path:              string;
+    session_id:             string;
+    status:                 string;
+    ticket_id?:             string;
+    title:                  string;
+    [property: string]: any;
+}
+
+export interface PresentationAddedMessage {
+    event:        PresentationAddedMessageEvent;
+    presentation: PresentationElement;
+    [property: string]: any;
+}
+
+export enum PresentationAddedMessageEvent {
+    PresentationAdded = "presentation_added",
+}
+
+export interface PresentationComment {
+    author:     string;
+    content:    string;
+    created_at: string;
+    filepath:   string;
+    id:         string;
+    line_end:   number;
+    line_start: number;
+    round_id:   string;
+    side:       string;
+    [property: string]: any;
+}
+
+export interface PresentationRound {
+    base_sha:        string;
+    changed_files?:  ChangedFileElement[];
+    created_at:      string;
+    head_sha:        string;
+    id:              string;
+    manifest:        Manifest;
+    presentation_id: string;
+    seq:             number;
+    submitted_at?:   string;
+    verdict?:        string;
+    [property: string]: any;
+}
+
+export interface PresentationUpdatedMessage {
+    event:        PresentationUpdatedMessageEvent;
+    presentation: PresentationElement;
+    [property: string]: any;
+}
+
+export enum PresentationUpdatedMessageEvent {
+    PresentationUpdated = "presentation_updated",
 }
 
 export interface PresentCloseMessage {
@@ -2787,7 +2836,7 @@ export interface PresentFile {
 }
 
 export interface PresentManifestView {
-    files:    FileElement[];
+    files:    ChangedFileElement[];
     skip:     string[];
     summary?: string;
     title:    string;
@@ -2852,65 +2901,24 @@ export enum PresentSubmitRoundResultMessageEvent {
     PresentSubmitRoundResult = "present_submit_round_result",
 }
 
-export interface Presentation {
-    created_at:             string;
-    id:                     string;
-    kind:                   string;
-    latest_round_seq:       number;
-    latest_round_submitted: boolean;
-    repo_path:              string;
-    session_id:             string;
-    status:                 string;
-    ticket_id?:             string;
-    title:                  string;
+export interface PRsUpdatedMessage {
+    event: PRsUpdatedMessageEvent;
+    prs?:  PRElement[];
     [property: string]: any;
 }
 
-export interface PresentationAddedMessage {
-    event:        PresentationAddedMessageEvent;
-    presentation: PresentationElement;
+export enum PRsUpdatedMessageEvent {
+    PrsUpdated = "prs_updated",
+}
+
+export interface PRVisitedMessage {
+    cmd: PRVisitedMessageCmd;
+    id:  string;
     [property: string]: any;
 }
 
-export enum PresentationAddedMessageEvent {
-    PresentationAdded = "presentation_added",
-}
-
-export interface PresentationComment {
-    author:     string;
-    content:    string;
-    created_at: string;
-    filepath:   string;
-    id:         string;
-    line_end:   number;
-    line_start: number;
-    round_id:   string;
-    side:       string;
-    [property: string]: any;
-}
-
-export interface PresentationRound {
-    base_sha:        string;
-    changed_files?:  FileElement[];
-    created_at:      string;
-    head_sha:        string;
-    id:              string;
-    manifest:        Manifest;
-    presentation_id: string;
-    seq:             number;
-    submitted_at?:   string;
-    verdict?:        string;
-    [property: string]: any;
-}
-
-export interface PresentationUpdatedMessage {
-    event:        PresentationUpdatedMessageEvent;
-    presentation: PresentationElement;
-    [property: string]: any;
-}
-
-export enum PresentationUpdatedMessageEvent {
-    PresentationUpdated = "presentation_updated",
+export enum PRVisitedMessageCmd {
+    PRVisited = "pr_visited",
 }
 
 export interface PtyDesyncMessage {
@@ -2948,18 +2956,6 @@ export enum PtyOutputMessageEvent {
     PtyOutput = "pty_output",
 }
 
-export interface PtyResizeMessage {
-    cmd:  PtyResizeMessageCmd;
-    cols: number;
-    id:   string;
-    rows: number;
-    [property: string]: any;
-}
-
-export enum PtyResizeMessageCmd {
-    PtyResize = "pty_resize",
-}
-
 export interface PtyResizedMessage {
     cols:  number;
     event: PtyResizedMessageEvent;
@@ -2970,6 +2966,18 @@ export interface PtyResizedMessage {
 
 export enum PtyResizedMessageEvent {
     PtyResized = "pty_resized",
+}
+
+export interface PtyResizeMessage {
+    cmd:  PtyResizeMessageCmd;
+    cols: number;
+    id:   string;
+    rows: number;
+    [property: string]: any;
+}
+
+export enum PtyResizeMessageCmd {
+    PtyResize = "pty_resize",
 }
 
 export interface QueryAuthorsMessage {
@@ -3472,6 +3480,16 @@ export enum SessionStateChangedMessageEvent {
     SessionStateChanged = "session_state_changed",
 }
 
+export interface SessionsUpdatedMessage {
+    event:     SessionsUpdatedMessageEvent;
+    sessions?: SessionElement[];
+    [property: string]: any;
+}
+
+export enum SessionsUpdatedMessageEvent {
+    SessionsUpdated = "sessions_updated",
+}
+
 export interface SessionTodosUpdatedMessage {
     event:   SessionTodosUpdatedMessageEvent;
     session: SessionElement;
@@ -3500,16 +3518,6 @@ export interface SessionVisualizedMessage {
 
 export enum SessionVisualizedMessageCmd {
     SessionVisualized = "session_visualized",
-}
-
-export interface SessionsUpdatedMessage {
-    event:     SessionsUpdatedMessageEvent;
-    sessions?: SessionElement[];
-    [property: string]: any;
-}
-
-export enum SessionsUpdatedMessageEvent {
-    SessionsUpdated = "sessions_updated",
 }
 
 export interface SetChiefOfStaffMessage {
@@ -3600,18 +3608,6 @@ export enum DispatchWorkState {
     ReadyForReview = "ready_for_review",
 }
 
-export interface SetWorkspaceRankMessage {
-    cmd:                SetWorkspaceRankMessageCmd;
-    next_workspace_id?: string;
-    prev_workspace_id?: string;
-    workspace_id:       string;
-    [property: string]: any;
-}
-
-export enum SetWorkspaceRankMessageCmd {
-    SetWorkspaceRank = "set_workspace_rank",
-}
-
 export interface SettingsUpdatedMessage {
     changed_key?: string;
     error?:       string;
@@ -3623,6 +3619,18 @@ export interface SettingsUpdatedMessage {
 
 export enum SettingsUpdatedMessageEvent {
     SettingsUpdated = "settings_updated",
+}
+
+export interface SetWorkspaceRankMessage {
+    cmd:                SetWorkspaceRankMessageCmd;
+    next_workspace_id?: string;
+    prev_workspace_id?: string;
+    workspace_id:       string;
+    [property: string]: any;
+}
+
+export enum SetWorkspaceRankMessageCmd {
+    SetWorkspaceRank = "set_workspace_rank",
 }
 
 export interface SpawnResultMessage {
@@ -3849,7 +3857,7 @@ export interface TicketAttachFile {
 export interface TicketAttachMessage {
     cmd:               TicketAttachMessageCmd;
     comment?:          string;
-    files:             FileObject[];
+    files:             FileElement[];
     request_id?:       string;
     source_session_id: string;
     state?:            DispatchWorkState;
@@ -3861,7 +3869,7 @@ export enum TicketAttachMessageCmd {
     TicketAttach = "ticket_attach",
 }
 
-export interface FileObject {
+export interface FileElement {
     filename:    string;
     source_path: string;
     [property: string]: any;
@@ -4080,6 +4088,16 @@ export interface TicketSubscribeResult {
     [property: string]: any;
 }
 
+export interface TicketsUpdatedMessage {
+    event:   TicketsUpdatedMessageEvent;
+    tickets: TicketElement[];
+    [property: string]: any;
+}
+
+export enum TicketsUpdatedMessageEvent {
+    TicketsUpdated = "tickets_updated",
+}
+
 export interface TicketTakeMessage {
     cmd:               TicketTakeMessageCmd;
     confirm?:          boolean;
@@ -4112,16 +4130,6 @@ export enum TicketUnsubscribeMessageCmd {
 export interface TicketUnsubscribeResult {
     ticket_id: string;
     [property: string]: any;
-}
-
-export interface TicketsUpdatedMessage {
-    event:   TicketsUpdatedMessageEvent;
-    tickets: TicketElement[];
-    [property: string]: any;
-}
-
-export enum TicketsUpdatedMessageEvent {
-    TicketsUpdated = "tickets_updated",
 }
 
 export interface TodosMessage {
@@ -4796,6 +4804,16 @@ export enum WorkspaceLayoutUndockTileMessageCmd {
     WorkspaceLayoutUndockTile = "workspace_layout_undock_tile",
 }
 
+export interface WorkspaceLayoutUpdatedMessage {
+    event:            WorkspaceLayoutUpdatedMessageEvent;
+    workspace_layout: Layout;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutUpdatedMessageEvent {
+    WorkspaceLayoutUpdated = "workspace_layout_updated",
+}
+
 export interface WorkspaceLayoutUpdateTileMessage {
     cmd:              WorkspaceLayoutUpdateTileMessageCmd;
     request_id:       string;
@@ -4808,16 +4826,6 @@ export interface WorkspaceLayoutUpdateTileMessage {
 
 export enum WorkspaceLayoutUpdateTileMessageCmd {
     WorkspaceLayoutUpdateTile = "workspace_layout_update_tile",
-}
-
-export interface WorkspaceLayoutUpdatedMessage {
-    event:            WorkspaceLayoutUpdatedMessageEvent;
-    workspace_layout: Layout;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutUpdatedMessageEvent {
-    WorkspaceLayoutUpdated = "workspace_layout_updated",
 }
 
 export interface WorkspaceRegisteredMessage {
@@ -6135,46 +6143,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("OpenMarkdownResultMessage")), null, 2);
     }
 
-    public static toPR(json: string): PR {
-        return cast(JSON.parse(json), r("PR"));
-    }
-
-    public static pRToJson(value: PR): string {
-        return JSON.stringify(uncast(value, r("PR")), null, 2);
-    }
-
-    public static toPRActionResultMessage(json: string): PRActionResultMessage {
-        return cast(JSON.parse(json), r("PRActionResultMessage"));
-    }
-
-    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
-        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
-    }
-
-    public static toPRRole(json: string): PRRole {
-        return cast(JSON.parse(json), r("PRRole"));
-    }
-
-    public static pRRoleToJson(value: PRRole): string {
-        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
-    }
-
-    public static toPRVisitedMessage(json: string): PRVisitedMessage {
-        return cast(JSON.parse(json), r("PRVisitedMessage"));
-    }
-
-    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
-        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
-    }
-
-    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
-        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
-    }
-
-    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
-    }
-
     public static toPathInspection(json: string): PathInspection {
         return cast(JSON.parse(json), r("PathInspection"));
     }
@@ -6223,12 +6191,68 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PluginsUpdatedMessage")), null, 2);
     }
 
+    public static toPR(json: string): PR {
+        return cast(JSON.parse(json), r("PR"));
+    }
+
+    public static pRToJson(value: PR): string {
+        return JSON.stringify(uncast(value, r("PR")), null, 2);
+    }
+
+    public static toPRActionResultMessage(json: string): PRActionResultMessage {
+        return cast(JSON.parse(json), r("PRActionResultMessage"));
+    }
+
+    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
+        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
+    }
+
     public static toPresentAnnotation(json: string): PresentAnnotation {
         return cast(JSON.parse(json), r("PresentAnnotation"));
     }
 
     public static presentAnnotationToJson(value: PresentAnnotation): string {
         return JSON.stringify(uncast(value, r("PresentAnnotation")), null, 2);
+    }
+
+    public static toPresentation(json: string): Presentation {
+        return cast(JSON.parse(json), r("Presentation"));
+    }
+
+    public static presentationToJson(value: Presentation): string {
+        return JSON.stringify(uncast(value, r("Presentation")), null, 2);
+    }
+
+    public static toPresentationAddedMessage(json: string): PresentationAddedMessage {
+        return cast(JSON.parse(json), r("PresentationAddedMessage"));
+    }
+
+    public static presentationAddedMessageToJson(value: PresentationAddedMessage): string {
+        return JSON.stringify(uncast(value, r("PresentationAddedMessage")), null, 2);
+    }
+
+    public static toPresentationComment(json: string): PresentationComment {
+        return cast(JSON.parse(json), r("PresentationComment"));
+    }
+
+    public static presentationCommentToJson(value: PresentationComment): string {
+        return JSON.stringify(uncast(value, r("PresentationComment")), null, 2);
+    }
+
+    public static toPresentationRound(json: string): PresentationRound {
+        return cast(JSON.parse(json), r("PresentationRound"));
+    }
+
+    public static presentationRoundToJson(value: PresentationRound): string {
+        return JSON.stringify(uncast(value, r("PresentationRound")), null, 2);
+    }
+
+    public static toPresentationUpdatedMessage(json: string): PresentationUpdatedMessage {
+        return cast(JSON.parse(json), r("PresentationUpdatedMessage"));
+    }
+
+    public static presentationUpdatedMessageToJson(value: PresentationUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PresentationUpdatedMessage")), null, 2);
     }
 
     public static toPresentCloseMessage(json: string): PresentCloseMessage {
@@ -6319,44 +6343,28 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PresentSubmitRoundResultMessage")), null, 2);
     }
 
-    public static toPresentation(json: string): Presentation {
-        return cast(JSON.parse(json), r("Presentation"));
+    public static toPRRole(json: string): PRRole {
+        return cast(JSON.parse(json), r("PRRole"));
     }
 
-    public static presentationToJson(value: Presentation): string {
-        return JSON.stringify(uncast(value, r("Presentation")), null, 2);
+    public static pRRoleToJson(value: PRRole): string {
+        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
     }
 
-    public static toPresentationAddedMessage(json: string): PresentationAddedMessage {
-        return cast(JSON.parse(json), r("PresentationAddedMessage"));
+    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
+        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
     }
 
-    public static presentationAddedMessageToJson(value: PresentationAddedMessage): string {
-        return JSON.stringify(uncast(value, r("PresentationAddedMessage")), null, 2);
+    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
     }
 
-    public static toPresentationComment(json: string): PresentationComment {
-        return cast(JSON.parse(json), r("PresentationComment"));
+    public static toPRVisitedMessage(json: string): PRVisitedMessage {
+        return cast(JSON.parse(json), r("PRVisitedMessage"));
     }
 
-    public static presentationCommentToJson(value: PresentationComment): string {
-        return JSON.stringify(uncast(value, r("PresentationComment")), null, 2);
-    }
-
-    public static toPresentationRound(json: string): PresentationRound {
-        return cast(JSON.parse(json), r("PresentationRound"));
-    }
-
-    public static presentationRoundToJson(value: PresentationRound): string {
-        return JSON.stringify(uncast(value, r("PresentationRound")), null, 2);
-    }
-
-    public static toPresentationUpdatedMessage(json: string): PresentationUpdatedMessage {
-        return cast(JSON.parse(json), r("PresentationUpdatedMessage"));
-    }
-
-    public static presentationUpdatedMessageToJson(value: PresentationUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PresentationUpdatedMessage")), null, 2);
+    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
+        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
     }
 
     public static toPtyDesyncMessage(json: string): PtyDesyncMessage {
@@ -6383,20 +6391,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PtyOutputMessage")), null, 2);
     }
 
-    public static toPtyResizeMessage(json: string): PtyResizeMessage {
-        return cast(JSON.parse(json), r("PtyResizeMessage"));
-    }
-
-    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
-        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
-    }
-
     public static toPtyResizedMessage(json: string): PtyResizedMessage {
         return cast(JSON.parse(json), r("PtyResizedMessage"));
     }
 
     public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
         return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
+    }
+
+    public static toPtyResizeMessage(json: string): PtyResizeMessage {
+        return cast(JSON.parse(json), r("PtyResizeMessage"));
+    }
+
+    public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
+        return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
     }
 
     public static toQueryAuthorsMessage(json: string): QueryAuthorsMessage {
@@ -6631,6 +6639,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionStateChangedMessage")), null, 2);
     }
 
+    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
+        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
+    }
+
+    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
+    }
+
     public static toSessionTodosUpdatedMessage(json: string): SessionTodosUpdatedMessage {
         return cast(JSON.parse(json), r("SessionTodosUpdatedMessage"));
     }
@@ -6653,14 +6669,6 @@ export class Convert {
 
     public static sessionVisualizedMessageToJson(value: SessionVisualizedMessage): string {
         return JSON.stringify(uncast(value, r("SessionVisualizedMessage")), null, 2);
-    }
-
-    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
-        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
-    }
-
-    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
     }
 
     public static toSetChiefOfStaffMessage(json: string): SetChiefOfStaffMessage {
@@ -6719,20 +6727,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SetTicketStatusMessage")), null, 2);
     }
 
-    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
-        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
-    }
-
-    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
-        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
-    }
-
     public static toSettingsUpdatedMessage(json: string): SettingsUpdatedMessage {
         return cast(JSON.parse(json), r("SettingsUpdatedMessage"));
     }
 
     public static settingsUpdatedMessageToJson(value: SettingsUpdatedMessage): string {
         return JSON.stringify(uncast(value, r("SettingsUpdatedMessage")), null, 2);
+    }
+
+    public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
+        return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
+    }
+
+    public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
+        return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
     }
 
     public static toSpawnResultMessage(json: string): SpawnResultMessage {
@@ -7079,6 +7087,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("TicketSubscribeResult")), null, 2);
     }
 
+    public static toTicketsUpdatedMessage(json: string): TicketsUpdatedMessage {
+        return cast(JSON.parse(json), r("TicketsUpdatedMessage"));
+    }
+
+    public static ticketsUpdatedMessageToJson(value: TicketsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("TicketsUpdatedMessage")), null, 2);
+    }
+
     public static toTicketTakeMessage(json: string): TicketTakeMessage {
         return cast(JSON.parse(json), r("TicketTakeMessage"));
     }
@@ -7109,14 +7125,6 @@ export class Convert {
 
     public static ticketUnsubscribeResultToJson(value: TicketUnsubscribeResult): string {
         return JSON.stringify(uncast(value, r("TicketUnsubscribeResult")), null, 2);
-    }
-
-    public static toTicketsUpdatedMessage(json: string): TicketsUpdatedMessage {
-        return cast(JSON.parse(json), r("TicketsUpdatedMessage"));
-    }
-
-    public static ticketsUpdatedMessageToJson(value: TicketsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("TicketsUpdatedMessage")), null, 2);
     }
 
     public static toTodosMessage(json: string): TodosMessage {
@@ -7535,20 +7543,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockTileMessage")), null, 2);
     }
 
-    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
-    }
-
-    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
-    }
-
     public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutUpdatedMessage"));
     }
 
     public static workspaceLayoutUpdatedMessageToJson(value: WorkspaceLayoutUpdatedMessage): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
+    }
+
+    public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
+    }
+
+    public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
     }
 
     public static toWorkspaceRegisteredMessage(json: string): WorkspaceRegisteredMessage {
@@ -8214,11 +8222,13 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("FSChangedMessageEvent") },
         { json: "origin", js: "origin", typ: "" },
         { json: "paths", js: "paths", typ: a("") },
+        { json: "root", js: "root", typ: "" },
     ], "any"),
     "FSDeleteMessage": o([
         { json: "cmd", js: "cmd", typ: r("FSDeleteMessageCmd") },
         { json: "path", js: "path", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "root", js: "root", typ: u(undefined, "") },
     ], "any"),
     "FSDeleteResult": o([
         { json: "path", js: "path", typ: "" },
@@ -8244,6 +8254,7 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("FSExistsMessageCmd") },
         { json: "path", js: "path", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "root", js: "root", typ: u(undefined, "") },
     ], "any"),
     "FSExistsResult": o([
         { json: "exists", js: "exists", typ: true },
@@ -8264,6 +8275,7 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("FSListMessageCmd") },
         { json: "path", js: "path", typ: u(undefined, "") },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "root", js: "root", typ: u(undefined, "") },
     ], "any"),
     "FSListResultMessage": o([
         { json: "entries", js: "entries", typ: u(undefined, a(r("EntryObject"))) },
@@ -8283,6 +8295,7 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("FSReadAssetMessageCmd") },
         { json: "path", js: "path", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "root", js: "root", typ: u(undefined, "") },
     ], "any"),
     "FSReadAssetResult": o([
         { json: "data_base64", js: "data_base64", typ: "" },
@@ -8305,6 +8318,7 @@ const typeMap: any = {
         { json: "cmd", js: "cmd", typ: r("FSReadMessageCmd") },
         { json: "path", js: "path", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "root", js: "root", typ: u(undefined, "") },
     ], "any"),
     "FSReadResult": o([
         { json: "content", js: "content", typ: "" },
@@ -8328,6 +8342,7 @@ const typeMap: any = {
         { json: "new_path", js: "new_path", typ: "" },
         { json: "path", js: "path", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "root", js: "root", typ: u(undefined, "") },
     ], "any"),
     "FSRenameResult": o([
         { json: "new_path", js: "new_path", typ: "" },
@@ -8350,6 +8365,7 @@ const typeMap: any = {
         { json: "content", js: "content", typ: "" },
         { json: "path", js: "path", typ: "" },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "root", js: "root", typ: u(undefined, "") },
     ], "any"),
     "FSWriteResult": o([
         { json: "conflict", js: "conflict", typ: true },
@@ -8428,7 +8444,7 @@ const typeMap: any = {
     ], "any"),
     "Round": o([
         { json: "base_sha", js: "base_sha", typ: "" },
-        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("FileElement"))) },
+        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("ChangedFileElement"))) },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "head_sha", js: "head_sha", typ: "" },
         { json: "id", js: "id", typ: "" },
@@ -8438,7 +8454,7 @@ const typeMap: any = {
         { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
         { json: "verdict", js: "verdict", typ: u(undefined, "") },
     ], "any"),
-    "FileElement": o([
+    "ChangedFileElement": o([
         { json: "additions", js: "additions", typ: u(undefined, 0) },
         { json: "annotations", js: "annotations", typ: u(undefined, a(r("AnnotationElement"))) },
         { json: "deletions", js: "deletions", typ: u(undefined, 0) },
@@ -8451,7 +8467,7 @@ const typeMap: any = {
         { json: "line_start", js: "line_start", typ: 0 },
     ], "any"),
     "Manifest": o([
-        { json: "files", js: "files", typ: a(r("FileElement")) },
+        { json: "files", js: "files", typ: a(r("ChangedFileElement")) },
         { json: "skip", js: "skip", typ: a("") },
         { json: "summary", js: "summary", typ: u(undefined, "") },
         { json: "title", js: "title", typ: "" },
@@ -9077,49 +9093,6 @@ const typeMap: any = {
         { json: "tile_id", js: "tile_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
     ], "any"),
-    "PR": o([
-        { json: "approved_by_me", js: "approved_by_me", typ: true },
-        { json: "author", js: "author", typ: "" },
-        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
-        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
-        { json: "details_fetched", js: "details_fetched", typ: true },
-        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
-        { json: "has_new_changes", js: "has_new_changes", typ: true },
-        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
-        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
-        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
-        { json: "host", js: "host", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
-        { json: "last_polled", js: "last_polled", typ: "" },
-        { json: "last_updated", js: "last_updated", typ: "" },
-        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
-        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
-        { json: "muted", js: "muted", typ: true },
-        { json: "number", js: "number", typ: 0 },
-        { json: "reason", js: "reason", typ: "" },
-        { json: "repo", js: "repo", typ: "" },
-        { json: "review_status", js: "review_status", typ: u(undefined, "") },
-        { json: "role", js: "role", typ: r("PRRole") },
-        { json: "state", js: "state", typ: "" },
-        { json: "title", js: "title", typ: "" },
-        { json: "url", js: "url", typ: "" },
-    ], "any"),
-    "PRActionResultMessage": o([
-        { json: "action", js: "action", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "success", js: "success", typ: true },
-    ], "any"),
-    "PRVisitedMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
-        { json: "id", js: "id", typ: "" },
-    ], "any"),
-    "PRsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
-        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
-    ], "any"),
     "PathInspection": o([
         { json: "exists", js: "exists", typ: true },
         { json: "home_path", js: "home_path", typ: u(undefined, "") },
@@ -9195,10 +9168,88 @@ const typeMap: any = {
         { json: "runtime_state", js: "runtime_state", typ: "" },
         { json: "version", js: "version", typ: "" },
     ], "any"),
+    "PR": o([
+        { json: "approved_by_me", js: "approved_by_me", typ: true },
+        { json: "author", js: "author", typ: "" },
+        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
+        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
+        { json: "details_fetched", js: "details_fetched", typ: true },
+        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
+        { json: "has_new_changes", js: "has_new_changes", typ: true },
+        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
+        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
+        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
+        { json: "host", js: "host", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
+        { json: "last_polled", js: "last_polled", typ: "" },
+        { json: "last_updated", js: "last_updated", typ: "" },
+        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
+        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
+        { json: "muted", js: "muted", typ: true },
+        { json: "number", js: "number", typ: 0 },
+        { json: "reason", js: "reason", typ: "" },
+        { json: "repo", js: "repo", typ: "" },
+        { json: "review_status", js: "review_status", typ: u(undefined, "") },
+        { json: "role", js: "role", typ: r("PRRole") },
+        { json: "state", js: "state", typ: "" },
+        { json: "title", js: "title", typ: "" },
+        { json: "url", js: "url", typ: "" },
+    ], "any"),
+    "PRActionResultMessage": o([
+        { json: "action", js: "action", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
     "PresentAnnotation": o([
         { json: "comments", js: "comments", typ: a("") },
         { json: "line_end", js: "line_end", typ: 0 },
         { json: "line_start", js: "line_start", typ: 0 },
+    ], "any"),
+    "Presentation": o([
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "latest_round_seq", js: "latest_round_seq", typ: 0 },
+        { json: "latest_round_submitted", js: "latest_round_submitted", typ: true },
+        { json: "repo_path", js: "repo_path", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "status", js: "status", typ: "" },
+        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
+        { json: "title", js: "title", typ: "" },
+    ], "any"),
+    "PresentationAddedMessage": o([
+        { json: "event", js: "event", typ: r("PresentationAddedMessageEvent") },
+        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
+    ], "any"),
+    "PresentationComment": o([
+        { json: "author", js: "author", typ: "" },
+        { json: "content", js: "content", typ: "" },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "filepath", js: "filepath", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "line_end", js: "line_end", typ: 0 },
+        { json: "line_start", js: "line_start", typ: 0 },
+        { json: "round_id", js: "round_id", typ: "" },
+        { json: "side", js: "side", typ: "" },
+    ], "any"),
+    "PresentationRound": o([
+        { json: "base_sha", js: "base_sha", typ: "" },
+        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("ChangedFileElement"))) },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "head_sha", js: "head_sha", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "manifest", js: "manifest", typ: r("Manifest") },
+        { json: "presentation_id", js: "presentation_id", typ: "" },
+        { json: "seq", js: "seq", typ: 0 },
+        { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
+        { json: "verdict", js: "verdict", typ: u(undefined, "") },
+    ], "any"),
+    "PresentationUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PresentationUpdatedMessageEvent") },
+        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
     ], "any"),
     "PresentCloseMessage": o([
         { json: "cmd", js: "cmd", typ: r("PresentCloseMessageCmd") },
@@ -9237,7 +9288,7 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
     ], "any"),
     "PresentManifestView": o([
-        { json: "files", js: "files", typ: a(r("FileElement")) },
+        { json: "files", js: "files", typ: a(r("ChangedFileElement")) },
         { json: "skip", js: "skip", typ: a("") },
         { json: "summary", js: "summary", typ: u(undefined, "") },
         { json: "title", js: "title", typ: "" },
@@ -9278,48 +9329,13 @@ const typeMap: any = {
         { json: "round_id", js: "round_id", typ: "" },
         { json: "success", js: "success", typ: true },
     ], "any"),
-    "Presentation": o([
-        { json: "created_at", js: "created_at", typ: "" },
+    "PRsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
+        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
+    ], "any"),
+    "PRVisitedMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
         { json: "id", js: "id", typ: "" },
-        { json: "kind", js: "kind", typ: "" },
-        { json: "latest_round_seq", js: "latest_round_seq", typ: 0 },
-        { json: "latest_round_submitted", js: "latest_round_submitted", typ: true },
-        { json: "repo_path", js: "repo_path", typ: "" },
-        { json: "session_id", js: "session_id", typ: "" },
-        { json: "status", js: "status", typ: "" },
-        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
-        { json: "title", js: "title", typ: "" },
-    ], "any"),
-    "PresentationAddedMessage": o([
-        { json: "event", js: "event", typ: r("PresentationAddedMessageEvent") },
-        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
-    ], "any"),
-    "PresentationComment": o([
-        { json: "author", js: "author", typ: "" },
-        { json: "content", js: "content", typ: "" },
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "filepath", js: "filepath", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "line_end", js: "line_end", typ: 0 },
-        { json: "line_start", js: "line_start", typ: 0 },
-        { json: "round_id", js: "round_id", typ: "" },
-        { json: "side", js: "side", typ: "" },
-    ], "any"),
-    "PresentationRound": o([
-        { json: "base_sha", js: "base_sha", typ: "" },
-        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("FileElement"))) },
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "head_sha", js: "head_sha", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "manifest", js: "manifest", typ: r("Manifest") },
-        { json: "presentation_id", js: "presentation_id", typ: "" },
-        { json: "seq", js: "seq", typ: 0 },
-        { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
-        { json: "verdict", js: "verdict", typ: u(undefined, "") },
-    ], "any"),
-    "PresentationUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PresentationUpdatedMessageEvent") },
-        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
     ], "any"),
     "PtyDesyncMessage": o([
         { json: "event", js: "event", typ: r("PtyDesyncMessageEvent") },
@@ -9338,15 +9354,15 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "seq", js: "seq", typ: 0 },
     ], "any"),
-    "PtyResizeMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
-        { json: "cols", js: "cols", typ: 0 },
-        { json: "id", js: "id", typ: "" },
-        { json: "rows", js: "rows", typ: 0 },
-    ], "any"),
     "PtyResizedMessage": o([
         { json: "cols", js: "cols", typ: 0 },
         { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "rows", js: "rows", typ: 0 },
+    ], "any"),
+    "PtyResizeMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
+        { json: "cols", js: "cols", typ: 0 },
         { json: "id", js: "id", typ: "" },
         { json: "rows", js: "rows", typ: 0 },
     ], "any"),
@@ -9656,6 +9672,10 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("SessionStateChangedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
     ], "any"),
+    "SessionsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
+        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
+    ], "any"),
     "SessionTodosUpdatedMessage": o([
         { json: "event", js: "event", typ: r("SessionTodosUpdatedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
@@ -9667,10 +9687,6 @@ const typeMap: any = {
     "SessionVisualizedMessage": o([
         { json: "cmd", js: "cmd", typ: r("SessionVisualizedMessageCmd") },
         { json: "id", js: "id", typ: "" },
-    ], "any"),
-    "SessionsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
-        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
     ], "any"),
     "SetChiefOfStaffMessage": o([
         { json: "chief_of_staff", js: "chief_of_staff", typ: true },
@@ -9710,18 +9726,18 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
         { json: "work_state", js: "work_state", typ: r("DispatchWorkState") },
     ], "any"),
-    "SetWorkspaceRankMessage": o([
-        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
-        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
-        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
     "SettingsUpdatedMessage": o([
         { json: "changed_key", js: "changed_key", typ: u(undefined, "") },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("SettingsUpdatedMessageEvent") },
         { json: "settings", js: "settings", typ: u(undefined, m("any")) },
         { json: "success", js: "success", typ: u(undefined, true) },
+    ], "any"),
+    "SetWorkspaceRankMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
+        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
+        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "SpawnResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
@@ -9863,13 +9879,13 @@ const typeMap: any = {
     "TicketAttachMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketAttachMessageCmd") },
         { json: "comment", js: "comment", typ: u(undefined, "") },
-        { json: "files", js: "files", typ: a(r("FileObject")) },
+        { json: "files", js: "files", typ: a(r("FileElement")) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "state", js: "state", typ: u(undefined, r("DispatchWorkState")) },
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
     ], "any"),
-    "FileObject": o([
+    "FileElement": o([
         { json: "filename", js: "filename", typ: "" },
         { json: "source_path", js: "source_path", typ: "" },
     ], "any"),
@@ -9994,6 +10010,10 @@ const typeMap: any = {
     "TicketSubscribeResult": o([
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
+    "TicketsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("TicketsUpdatedMessageEvent") },
+        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
+    ], "any"),
     "TicketTakeMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketTakeMessageCmd") },
         { json: "confirm", js: "confirm", typ: u(undefined, true) },
@@ -10011,10 +10031,6 @@ const typeMap: any = {
     ], "any"),
     "TicketUnsubscribeResult": o([
         { json: "ticket_id", js: "ticket_id", typ: "" },
-    ], "any"),
-    "TicketsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("TicketsUpdatedMessageEvent") },
-        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
     ], "any"),
     "TodosMessage": o([
         { json: "cmd", js: "cmd", typ: r("TodosMessageCmd") },
@@ -10424,6 +10440,10 @@ const typeMap: any = {
         { json: "tile_id", js: "tile_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
+    "WorkspaceLayoutUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
+        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
+    ], "any"),
     "WorkspaceLayoutUpdateTileMessage": o([
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUpdateTileMessageCmd") },
         { json: "request_id", js: "request_id", typ: "" },
@@ -10431,10 +10451,6 @@ const typeMap: any = {
         { json: "tile_params", js: "tile_params", typ: "" },
         { json: "tile_session_id", js: "tile_session_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: "" },
-    ], "any"),
-    "WorkspaceLayoutUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
-        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
     ], "any"),
     "WorkspaceRegisteredMessage": o([
         { json: "event", js: "event", typ: r("WorkspaceRegisteredMessageEvent") },
@@ -10900,15 +10916,6 @@ const typeMap: any = {
     "OpenMarkdownResultMessageEvent": [
         "open_markdown_result",
     ],
-    "PRActionResultMessageEvent": [
-        "pr_action_result",
-    ],
-    "PRVisitedMessageCmd": [
-        "pr_visited",
-    ],
-    "PRsUpdatedMessageEvent": [
-        "prs_updated",
-    ],
     "PinWorkspaceMessageCmd": [
         "pin_workspace",
     ],
@@ -10917,6 +10924,15 @@ const typeMap: any = {
     ],
     "PluginsUpdatedMessageEvent": [
         "plugins_updated",
+    ],
+    "PRActionResultMessageEvent": [
+        "pr_action_result",
+    ],
+    "PresentationAddedMessageEvent": [
+        "presentation_added",
+    ],
+    "PresentationUpdatedMessageEvent": [
+        "presentation_updated",
     ],
     "PresentCloseMessageCmd": [
         "present_close",
@@ -10936,11 +10952,11 @@ const typeMap: any = {
     "PresentSubmitRoundResultMessageEvent": [
         "present_submit_round_result",
     ],
-    "PresentationAddedMessageEvent": [
-        "presentation_added",
+    "PRsUpdatedMessageEvent": [
+        "prs_updated",
     ],
-    "PresentationUpdatedMessageEvent": [
-        "presentation_updated",
+    "PRVisitedMessageCmd": [
+        "pr_visited",
     ],
     "PtyDesyncMessageEvent": [
         "pty_desync",
@@ -10951,11 +10967,11 @@ const typeMap: any = {
     "PtyOutputMessageEvent": [
         "pty_output",
     ],
-    "PtyResizeMessageCmd": [
-        "pty_resize",
-    ],
     "PtyResizedMessageEvent": [
         "pty_resized",
+    ],
+    "PtyResizeMessageCmd": [
+        "pty_resize",
     ],
     "QueryAuthorsMessageCmd": [
         "query_authors",
@@ -11032,6 +11048,9 @@ const typeMap: any = {
     "SessionStateChangedMessageEvent": [
         "session_state_changed",
     ],
+    "SessionsUpdatedMessageEvent": [
+        "sessions_updated",
+    ],
     "SessionTodosUpdatedMessageEvent": [
         "session_todos_updated",
     ],
@@ -11040,9 +11059,6 @@ const typeMap: any = {
     ],
     "SessionVisualizedMessageCmd": [
         "session_visualized",
-    ],
-    "SessionsUpdatedMessageEvent": [
-        "sessions_updated",
     ],
     "SetChiefOfStaffMessageCmd": [
         "set_chief_of_staff",
@@ -11072,11 +11088,11 @@ const typeMap: any = {
         "needs_input",
         "ready_for_review",
     ],
-    "SetWorkspaceRankMessageCmd": [
-        "set_workspace_rank",
-    ],
     "SettingsUpdatedMessageEvent": [
         "settings_updated",
+    ],
+    "SetWorkspaceRankMessageCmd": [
+        "set_workspace_rank",
     ],
     "SpawnResultMessageEvent": [
         "spawn_result",
@@ -11153,14 +11169,14 @@ const typeMap: any = {
     "TicketSubscribeMessageCmd": [
         "ticket_subscribe",
     ],
+    "TicketsUpdatedMessageEvent": [
+        "tickets_updated",
+    ],
     "TicketTakeMessageCmd": [
         "ticket_take",
     ],
     "TicketUnsubscribeMessageCmd": [
         "ticket_unsubscribe",
-    ],
-    "TicketsUpdatedMessageEvent": [
-        "tickets_updated",
     ],
     "TodosMessageCmd": [
         "todos",
@@ -11292,11 +11308,11 @@ const typeMap: any = {
     "WorkspaceLayoutUndockTileMessageCmd": [
         "workspace_layout_undock_tile",
     ],
-    "WorkspaceLayoutUpdateTileMessageCmd": [
-        "workspace_layout_update_tile",
-    ],
     "WorkspaceLayoutUpdatedMessageEvent": [
         "workspace_layout_updated",
+    ],
+    "WorkspaceLayoutUpdateTileMessageCmd": [
+        "workspace_layout_update_tile",
     ],
     "WorkspaceRegisteredMessageEvent": [
         "workspace_registered",

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -196,11 +196,12 @@ type Daemon struct {
 	notebookWatcherMu   sync.Mutex
 	notebookWatcher     *notebook.Watcher
 	notebookWatchedRoot string
-	// fsStore is the generic filesystem view over the SAME root as the notebook
-	// (notebook.root). It is the raw layer beneath the curated notebook surface;
-	// both share the one root watcher started by ensureNotebookWatcher.
+	// fsStores is the generic filesystem view, keyed by resolved absolute root.
+	// The notebook-root entry is the raw layer beneath the curated notebook
+	// surface and shares the one root watcher started by ensureNotebookWatcher;
+	// other roots (arbitrary editor roots) get their own Store but no watcher yet.
 	fsMu                sync.Mutex
-	fsStore             *fsdoc.Store
+	fsStores            map[string]*fsdoc.Store
 	pendingInitialWS    map[*wsClient]struct{}
 	startedOnce         sync.Once
 	startedCh           chan struct{}

--- a/internal/daemon/fs.go
+++ b/internal/daemon/fs.go
@@ -47,12 +47,20 @@ var assetMimeTypes = map[string]string{
 }
 
 // resolveFsRoot resolves the raw root a fs_* command asked to operate under:
-// empty/blank means "the notebook root" (today's behavior, unchanged); a
-// non-empty value must be a normalized-clean absolute path outside the attn
-// data dir, same rule as notebook.root, worded for the fs surface.
-func (d *Daemon) resolveFsRoot(raw string) (string, error) {
+// empty/blank means "the notebook root" (today's behavior, unchanged, and
+// available to ANY client). A non-empty value is an arbitrary filesystem root
+// request, so it is gated on client being the authenticated attn app itself
+// (see isTrustedAppClient) before it is even validated — without this, any
+// accepted local WebSocket client could use fs_* {root} to read or overwrite
+// files anywhere in the user's home. Once past that gate, the value must be a
+// normalized-clean absolute path outside the attn data dir, same rule as
+// notebook.root, worded for the fs surface.
+func (d *Daemon) resolveFsRoot(client *wsClient, raw string) (string, error) {
 	if strings.TrimSpace(raw) == "" {
 		return d.notebookRoot()
+	}
+	if !client.isTrustedAppClient() {
+		return "", fmt.Errorf("fs root requires the authenticated attn app client")
 	}
 	resolved, err := normalizeExternalRoot(raw)
 	if err != nil {
@@ -68,8 +76,8 @@ func (d *Daemon) resolveFsRoot(raw string) (string, error) {
 // other roots get a Store but no watcher — that lands with the non-text editor
 // work (PR2). Returns the resolved root alongside the store so callers can key
 // broadcasts and notebook-coupling decisions on it without re-resolving.
-func (d *Daemon) fsStoreFor(rawRoot string) (*fsdoc.Store, string, error) {
-	root, err := d.resolveFsRoot(rawRoot)
+func (d *Daemon) fsStoreFor(client *wsClient, rawRoot string) (*fsdoc.Store, string, error) {
+	root, err := d.resolveFsRoot(client, rawRoot)
 	if err != nil {
 		return nil, "", err
 	}
@@ -105,7 +113,7 @@ func (d *Daemon) broadcastFsChanged(root, origin string, paths ...string) {
 // fs_list_result event correlated by requestID.
 func (d *Daemon) sendFsListWSResult(client *wsClient, requestID, path, rawRoot string) {
 	var entries []protocol.FsEntry
-	store, _, err := d.fsStoreFor(rawRoot)
+	store, _, err := d.fsStoreFor(client, rawRoot)
 	if err == nil {
 		var list []fsdoc.Entry
 		if list, err = store.List(path); err == nil {
@@ -128,7 +136,7 @@ func (d *Daemon) sendFsListWSResult(client *wsClient, requestID, path, rawRoot s
 // correlated by requestID.
 func (d *Daemon) sendFsReadWSResult(client *wsClient, requestID, path, rawRoot string) {
 	var result *protocol.FsReadResult
-	store, _, err := d.fsStoreFor(rawRoot)
+	store, _, err := d.fsStoreFor(client, rawRoot)
 	if err == nil {
 		var content []byte
 		var hash string
@@ -156,7 +164,7 @@ func (d *Daemon) sendFsReadAssetWSResult(client *wsClient, requestID, path, rawR
 	mimeType, err := assetMimeTypeFor(path)
 	if err == nil {
 		var store *fsdoc.Store
-		if store, _, err = d.fsStoreFor(rawRoot); err == nil {
+		if store, _, err = d.fsStoreFor(client, rawRoot); err == nil {
 			var content []byte
 			if content, _, err = store.ReadWithLimit(path, maxAssetBytes); err == nil {
 				if len(content) > maxAssetBytes {
@@ -227,7 +235,7 @@ func assetMessageFits(requestID, path, mimeType string, rawLen int) (bool, error
 // broadcasts fs_changed(origin=ui).
 func (d *Daemon) sendFsWriteWSResult(client *wsClient, requestID, path, content, baseHash, rawRoot string) {
 	var result *protocol.FsWriteResult
-	store, root, err := d.fsStoreFor(rawRoot)
+	store, root, err := d.fsStoreFor(client, rawRoot)
 	if err == nil {
 		// Normalize the path to the canonical form fs_list/fs_changed key on, so the
 		// echoed result.path and the broadcast match it (not the raw leading-slash
@@ -277,7 +285,7 @@ func (d *Daemon) sendFsRenameWSResult(client *wsClient, requestID, oldPath, newP
 	newRel, newErr := fsdoc.CleanPath(newPath)
 	err := errors.Join(oldErr, newErr)
 	var result *protocol.FsRenameResult
-	store, root, storeErr := d.fsStoreFor(rawRoot)
+	store, root, storeErr := d.fsStoreFor(client, rawRoot)
 	if err == nil {
 		err = storeErr
 	}
@@ -313,7 +321,7 @@ func (d *Daemon) sendFsRenameWSResult(client *wsClient, requestID, oldPath, newP
 func (d *Daemon) sendFsDeleteWSResult(client *wsClient, requestID, path, rawRoot string) {
 	rel, err := fsdoc.CleanPath(path)
 	var result *protocol.FsDeleteResult
-	store, root, storeErr := d.fsStoreFor(rawRoot)
+	store, root, storeErr := d.fsStoreFor(client, rawRoot)
 	if err == nil {
 		err = storeErr
 	}
@@ -345,7 +353,7 @@ func (d *Daemon) sendFsDeleteWSResult(client *wsClient, requestID, path, rawRoot
 // the frontend treats as "unknown, leave the link unflagged", not as "missing".
 func (d *Daemon) sendFsExistsWSResult(client *wsClient, requestID, path, rawRoot string) {
 	var result *protocol.FsExistsResult
-	store, _, err := d.fsStoreFor(rawRoot)
+	store, _, err := d.fsStoreFor(client, rawRoot)
 	if err == nil {
 		var exists bool
 		if exists, err = store.Exists(path); err == nil {

--- a/internal/daemon/fs.go
+++ b/internal/daemon/fs.go
@@ -46,42 +46,66 @@ var assetMimeTypes = map[string]string{
 	".ico":  "image/x-icon",
 }
 
-// fsStoreFor returns the daemon's single generic filesystem Store for the active
-// root. The root is the SAME one the notebook uses (notebook.root): fsdoc is the
-// raw layer beneath the curated notebook surface. The Store is cached and reused
-// so writes serialize through one in-process writer, and rebuilt only when the
-// resolved root changes. As with the notebook, every fs operation lazily ensures
-// the one shared root watcher is running (so fs_changed fires for external edits).
-func (d *Daemon) fsStoreFor() (*fsdoc.Store, error) {
-	root, err := d.notebookRoot()
+// resolveFsRoot resolves the raw root a fs_* command asked to operate under:
+// empty/blank means "the notebook root" (today's behavior, unchanged); a
+// non-empty value must be a normalized-clean absolute path outside the attn
+// data dir, same rule as notebook.root, worded for the fs surface.
+func (d *Daemon) resolveFsRoot(raw string) (string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return d.notebookRoot()
+	}
+	resolved, err := normalizeExternalRoot(raw)
 	if err != nil {
-		return nil, err
+		return "", fmt.Errorf("fs root %w", err)
+	}
+	return resolved, nil
+}
+
+// fsStoreFor returns the daemon's generic filesystem Store for rawRoot,
+// resolving it first (see resolveFsRoot). Stores are cached per resolved root
+// so writes to the same root serialize through one in-process writer. Only the
+// notebook root gets the shared external-edit watcher today (ensureNotebookWatcher);
+// other roots get a Store but no watcher — that lands with the non-text editor
+// work (PR2). Returns the resolved root alongside the store so callers can key
+// broadcasts and notebook-coupling decisions on it without re-resolving.
+func (d *Daemon) fsStoreFor(rawRoot string) (*fsdoc.Store, string, error) {
+	root, err := d.resolveFsRoot(rawRoot)
+	if err != nil {
+		return nil, "", err
 	}
 	d.fsMu.Lock()
-	if d.fsStore == nil || d.fsStore.Root() != root {
-		d.fsStore = fsdoc.NewStore(root)
+	if d.fsStores == nil {
+		d.fsStores = make(map[string]*fsdoc.Store)
 	}
-	store := d.fsStore
+	store, ok := d.fsStores[root]
+	if !ok {
+		store = fsdoc.NewStore(root)
+		d.fsStores[root] = store
+	}
 	d.fsMu.Unlock()
-	d.ensureNotebookWatcher(root)
-	return store, nil
+	if notebookRoot, nerr := d.notebookRoot(); nerr == nil && root == notebookRoot {
+		d.ensureNotebookWatcher(root)
+	}
+	return store, root, nil
 }
 
 // broadcastFsChanged announces a filesystem change to all websocket clients.
-// origin is agent|ui|external, the same vocabulary as notebook_changed.
-func (d *Daemon) broadcastFsChanged(origin string, paths ...string) {
+// origin is agent|ui|external, the same vocabulary as notebook_changed. root is
+// the resolved absolute root the change happened under.
+func (d *Daemon) broadcastFsChanged(root, origin string, paths ...string) {
 	d.broadcastMessage(protocol.FsChangedMessage{
 		Event:  protocol.EventFsChanged,
 		Paths:  paths,
 		Origin: origin,
+		Root:   root,
 	})
 }
 
 // sendFsListWSResult lists one directory's immediate children and replies with an
 // fs_list_result event correlated by requestID.
-func (d *Daemon) sendFsListWSResult(client *wsClient, requestID, path string) {
+func (d *Daemon) sendFsListWSResult(client *wsClient, requestID, path, rawRoot string) {
 	var entries []protocol.FsEntry
-	store, err := d.fsStoreFor()
+	store, _, err := d.fsStoreFor(rawRoot)
 	if err == nil {
 		var list []fsdoc.Entry
 		if list, err = store.List(path); err == nil {
@@ -102,9 +126,9 @@ func (d *Daemon) sendFsListWSResult(client *wsClient, requestID, path string) {
 
 // sendFsReadWSResult reads one file and replies with an fs_read_result event
 // correlated by requestID.
-func (d *Daemon) sendFsReadWSResult(client *wsClient, requestID, path string) {
+func (d *Daemon) sendFsReadWSResult(client *wsClient, requestID, path, rawRoot string) {
 	var result *protocol.FsReadResult
-	store, err := d.fsStoreFor()
+	store, _, err := d.fsStoreFor(rawRoot)
 	if err == nil {
 		var content []byte
 		var hash string
@@ -127,12 +151,12 @@ func (d *Daemon) sendFsReadWSResult(client *wsClient, requestID, path string) {
 // sendFsReadAssetWSResult reads one image file's bytes as base64 and replies with
 // an fs_read_asset_result event correlated by requestID. Only extensions in
 // assetMimeTypes are served; the extension is rejected before the file is read.
-func (d *Daemon) sendFsReadAssetWSResult(client *wsClient, requestID, path string) {
+func (d *Daemon) sendFsReadAssetWSResult(client *wsClient, requestID, path, rawRoot string) {
 	var result *protocol.FsReadAssetResult
 	mimeType, err := assetMimeTypeFor(path)
 	if err == nil {
 		var store *fsdoc.Store
-		if store, err = d.fsStoreFor(); err == nil {
+		if store, _, err = d.fsStoreFor(rawRoot); err == nil {
 			var content []byte
 			if content, _, err = store.ReadWithLimit(path, maxAssetBytes); err == nil {
 				if len(content) > maxAssetBytes {
@@ -201,9 +225,9 @@ func assetMessageFits(requestID, path, mimeType string, rawLen int) (bool, error
 // for the UI to reconcile, not an error. On a successful write it records the
 // path as a self-write (so the shared watcher does not echo it as external) and
 // broadcasts fs_changed(origin=ui).
-func (d *Daemon) sendFsWriteWSResult(client *wsClient, requestID, path, content, baseHash string) {
+func (d *Daemon) sendFsWriteWSResult(client *wsClient, requestID, path, content, baseHash, rawRoot string) {
 	var result *protocol.FsWriteResult
-	store, err := d.fsStoreFor()
+	store, root, err := d.fsStoreFor(rawRoot)
 	if err == nil {
 		// Normalize the path to the canonical form fs_list/fs_changed key on, so the
 		// echoed result.path and the broadcast match it (not the raw leading-slash
@@ -224,13 +248,15 @@ func (d *Daemon) sendFsWriteWSResult(client *wsClient, requestID, path, content,
 				}
 			} else {
 				result.Hash = protocol.Ptr(hash)
-				// Content-aware self-write so the shared watcher does not surface this
-				// UI edit as an external one. NoteSelfWrite keys on the notebook's
-				// CleanPath, so it only registers a .md path — which is exactly the set
-				// the watcher can report today; a non-.md write fires no watcher event,
-				// so there is nothing to suppress for it either way.
-				d.noteNotebookSelfWrite(notebook.SelfWrite{Rel: changed, Hash: hash})
-				d.broadcastFsChanged(originUI, changed)
+				if d.isNotebookRoot(root) {
+					// Content-aware self-write so the shared watcher does not surface this
+					// UI edit as an external one. NoteSelfWrite keys on the notebook's
+					// CleanPath, so it only registers a .md path — which is exactly the set
+					// the watcher can report today; a non-.md write fires no watcher event,
+					// so there is nothing to suppress for it either way.
+					d.noteNotebookSelfWrite(notebook.SelfWrite{Rel: changed, Hash: hash})
+				}
+				d.broadcastFsChanged(root, originUI, changed)
 			}
 		}
 	}
@@ -246,12 +272,12 @@ func (d *Daemon) sendFsWriteWSResult(client *wsClient, requestID, path, content,
 	d.sendToClient(client, msg)
 }
 
-func (d *Daemon) sendFsRenameWSResult(client *wsClient, requestID, oldPath, newPath string) {
+func (d *Daemon) sendFsRenameWSResult(client *wsClient, requestID, oldPath, newPath, rawRoot string) {
 	oldRel, oldErr := fsdoc.CleanPath(oldPath)
 	newRel, newErr := fsdoc.CleanPath(newPath)
 	err := errors.Join(oldErr, newErr)
 	var result *protocol.FsRenameResult
-	store, storeErr := d.fsStoreFor()
+	store, root, storeErr := d.fsStoreFor(rawRoot)
 	if err == nil {
 		err = storeErr
 	}
@@ -260,15 +286,20 @@ func (d *Daemon) sendFsRenameWSResult(client *wsClient, requestID, oldPath, newP
 		if readErr != nil {
 			err = readErr
 		} else {
-			d.noteNotebookSelfWrite(
-				notebook.SelfWrite{Rel: oldRel},
-				notebook.SelfWrite{Rel: newRel, Hash: hash},
-			)
+			inNotebook := d.isNotebookRoot(root)
+			if inNotebook {
+				d.noteNotebookSelfWrite(
+					notebook.SelfWrite{Rel: oldRel},
+					notebook.SelfWrite{Rel: newRel, Hash: hash},
+				)
+			}
 			err = store.Rename(oldRel, newRel)
 			if err == nil {
 				result = &protocol.FsRenameResult{Path: oldRel, NewPath: newRel}
-				d.broadcastNotebookChanged(originUI, oldRel, newRel)
-				d.broadcastFsChanged(originUI, oldRel, newRel)
+				if inNotebook {
+					d.broadcastNotebookChanged(originUI, oldRel, newRel)
+				}
+				d.broadcastFsChanged(root, originUI, oldRel, newRel)
 			}
 		}
 	}
@@ -279,20 +310,25 @@ func (d *Daemon) sendFsRenameWSResult(client *wsClient, requestID, oldPath, newP
 	d.sendToClient(client, msg)
 }
 
-func (d *Daemon) sendFsDeleteWSResult(client *wsClient, requestID, path string) {
+func (d *Daemon) sendFsDeleteWSResult(client *wsClient, requestID, path, rawRoot string) {
 	rel, err := fsdoc.CleanPath(path)
 	var result *protocol.FsDeleteResult
-	store, storeErr := d.fsStoreFor()
+	store, root, storeErr := d.fsStoreFor(rawRoot)
 	if err == nil {
 		err = storeErr
 	}
 	if err == nil {
-		d.noteNotebookSelfWrite(notebook.SelfWrite{Rel: rel})
+		inNotebook := d.isNotebookRoot(root)
+		if inNotebook {
+			d.noteNotebookSelfWrite(notebook.SelfWrite{Rel: rel})
+		}
 		err = store.Delete(rel)
 		if err == nil {
 			result = &protocol.FsDeleteResult{Path: rel}
-			d.broadcastNotebookChanged(originUI, rel)
-			d.broadcastFsChanged(originUI, rel)
+			if inNotebook {
+				d.broadcastNotebookChanged(originUI, rel)
+			}
+			d.broadcastFsChanged(root, originUI, rel)
 		}
 	}
 	msg := protocol.FsDeleteResultMessage{Event: protocol.EventFsDeleteResult, RequestID: requestID, Success: err == nil, Result: result}
@@ -307,9 +343,9 @@ func (d *Daemon) sendFsDeleteWSResult(client *wsClient, requestID, path string) 
 // file — the frontend uses it to flag an in-notebook link whose target note is
 // missing. A path that fails to validate (escapes the root, dotfile) is an error
 // the frontend treats as "unknown, leave the link unflagged", not as "missing".
-func (d *Daemon) sendFsExistsWSResult(client *wsClient, requestID, path string) {
+func (d *Daemon) sendFsExistsWSResult(client *wsClient, requestID, path, rawRoot string) {
 	var result *protocol.FsExistsResult
-	store, err := d.fsStoreFor()
+	store, _, err := d.fsStoreFor(rawRoot)
 	if err == nil {
 		var exists bool
 		if exists, err = store.Exists(path); err == nil {
@@ -326,6 +362,14 @@ func (d *Daemon) sendFsExistsWSResult(client *wsClient, requestID, path string) 
 		msg.Error = protocol.Ptr(err.Error())
 	}
 	d.sendToClient(client, msg)
+}
+
+// isNotebookRoot reports whether root is the currently resolved notebook root
+// (best-effort: a notebookRoot() error is treated as "not the notebook root",
+// so a foreign fs root never accidentally couples to notebook broadcasts).
+func (d *Daemon) isNotebookRoot(root string) bool {
+	notebookRoot, err := d.notebookRoot()
+	return err == nil && root == notebookRoot
 }
 
 // fsEntriesToProtocol converts store entries to their protocol shape.

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -633,6 +633,15 @@ func TestFsCommandsOmittedRootResolvesToNotebookRoot(t *testing.T) {
 // client so this exercises path validation specifically, not the separate
 // auth-gate tests below.
 func TestFsCommandsRejectInvalidRoots(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if !strings.HasPrefix(config.DataDir(), tmpHome+string(filepath.Separator)) {
+		t.Fatalf("test data dir %q escaped the temp HOME — refusing to touch a real data dir", config.DataDir())
+	}
+	if err := os.MkdirAll(config.DataDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
 	d := newFsDaemon(t)
 
 	client := trustedFsClient(4)
@@ -661,6 +670,15 @@ func TestFsCommandsRejectInvalidRoots(t *testing.T) {
 // mutating path (fs_delete), and asserts the delete never touches the data
 // dir file.
 func TestFsCommandsRejectSymlinkedRootIntoDataDir(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if !strings.HasPrefix(config.DataDir(), tmpHome+string(filepath.Separator)) {
+		t.Fatalf("test data dir %q escaped the temp HOME — refusing to touch a real data dir", config.DataDir())
+	}
+	if err := os.MkdirAll(config.DataDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
 	d := newFsDaemon(t)
 
 	sentinel := filepath.Join(config.DataDir(), "attn.db")
@@ -728,6 +746,15 @@ func TestFsCommandsRejectSymlinkedRootIntoDataDir(t *testing.T) {
 // via a /private symlink — so this exercises the exact canonicalize-both-sides
 // path the fix relies on, not just a synthetic case.
 func TestFsCommandsAcceptLegitimateSymlinkedRoot(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if !strings.HasPrefix(config.DataDir(), tmpHome+string(filepath.Separator)) {
+		t.Fatalf("test data dir %q escaped the temp HOME — refusing to touch a real data dir", config.DataDir())
+	}
+	if err := os.MkdirAll(config.DataDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
 	d := newFsDaemon(t)
 
 	target := t.TempDir()

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -25,18 +25,32 @@ func newFsDaemon(t *testing.T) *Daemon {
 	return d
 }
 
+// trustedFsClient returns a wsClient identified — via the real identity
+// setters, not by poking identityMu-guarded fields directly — as the
+// authenticated attn app itself (isTrustedAppClient() == true). The fs
+// surface's explicit-root gate requires exactly this identity; ordinary
+// clients (browser tabs, other local processes) must not pass it.
+func trustedFsClient(bufSize int) *wsClient {
+	client := &wsClient{send: make(chan outboundMessage, bufSize), trustedTauriOrigin: true}
+	client.setBrowserHostAuthenticated(true)
+	client.setIdentity("tauri-app", "test", nil)
+	return client
+}
+
 // fsWriteCAS performs a hash-CAS fs_write over the WS path and returns the decoded
 // result event (a successful result may carry conflict=true). Uses a throwaway
-// client; the origin=ui broadcast goes to the hub, not this client.
+// trusted client; the origin=ui broadcast goes to the hub, not this client.
 func fsWriteCAS(t *testing.T, d *Daemon, path, content, baseHash string) protocol.FsWriteResultMessage {
 	t.Helper()
 	return fsWriteCASRoot(t, d, path, content, baseHash, "")
 }
 
 // fsWriteCASRoot is fsWriteCAS with an explicit root (empty = notebook root).
+// Uses a trusted app client so root tests exercise root resolution, not the
+// separate auth-gate tests below.
 func fsWriteCASRoot(t *testing.T, d *Daemon, path, content, baseHash, root string) protocol.FsWriteResultMessage {
 	t.Helper()
-	client := &wsClient{send: make(chan outboundMessage, 8)}
+	client := trustedFsClient(8)
 	d.sendFsWriteWSResult(client, "setup-fs-write", path, content, baseHash, root)
 	var res protocol.FsWriteResultMessage
 	readNotebookWSEvent(t, client.send, &res)
@@ -49,10 +63,11 @@ func listFs(t *testing.T, d *Daemon, dir string) []protocol.FsEntry {
 	return listFsRoot(t, d, dir, "")
 }
 
-// listFsRoot is listFs with an explicit root (empty = notebook root).
+// listFsRoot is listFs with an explicit root (empty = notebook root). Uses a
+// trusted app client; see fsWriteCASRoot.
 func listFsRoot(t *testing.T, d *Daemon, dir, root string) []protocol.FsEntry {
 	t.Helper()
-	client := &wsClient{send: make(chan outboundMessage, 8)}
+	client := trustedFsClient(8)
 	d.sendFsListWSResult(client, "setup-fs-list", dir, root)
 	var res protocol.FsListResultMessage
 	readNotebookWSEvent(t, client.send, &res)
@@ -527,7 +542,7 @@ func TestFsCommandsWithExplicitRootActOnThatDirectory(t *testing.T) {
 		t.Fatalf("list under explicit root = %+v", entries)
 	}
 
-	client := &wsClient{send: make(chan outboundMessage, 4)}
+	client := trustedFsClient(4)
 	d.sendFsReadWSResult(client, "r1", "notes/todo.txt", externalRoot)
 	var read protocol.FsReadResultMessage
 	readNotebookWSEvent(t, client.send, &read)
@@ -614,11 +629,13 @@ func TestFsCommandsOmittedRootResolvesToNotebookRoot(t *testing.T) {
 // A relative root, and a root inside config.DataDir(), must both be rejected —
 // the same validation notebook.root enforces. Without this, a client could point
 // the fs surface at attn's own data dir (defeating the "notebook must live
-// outside .attn" invariant) or at an ambiguous relative path.
+// outside .attn" invariant) or at an ambiguous relative path. Uses a trusted app
+// client so this exercises path validation specifically, not the separate
+// auth-gate tests below.
 func TestFsCommandsRejectInvalidRoots(t *testing.T) {
 	d := newFsDaemon(t)
 
-	client := &wsClient{send: make(chan outboundMessage, 4)}
+	client := trustedFsClient(4)
 	d.sendFsListWSResult(client, "rel", "", "relative/path")
 	var relRes protocol.FsListResultMessage
 	readNotebookWSEvent(t, client.send, &relRes)
@@ -627,12 +644,106 @@ func TestFsCommandsRejectInvalidRoots(t *testing.T) {
 	}
 
 	insideDataDir := filepath.Join(config.DataDir(), "notebook")
-	client2 := &wsClient{send: make(chan outboundMessage, 4)}
+	client2 := trustedFsClient(4)
 	d.sendFsListWSResult(client2, "indatadir", "", insideDataDir)
 	var dataDirRes protocol.FsListResultMessage
 	readNotebookWSEvent(t, client2.send, &dataDirRes)
 	if dataDirRes.Success || dataDirRes.Error == nil {
 		t.Fatalf("fs_list(root inside data dir) = %+v, want failure", dataDirRes)
+	}
+}
+
+// An explicit root turns the fs surface into an arbitrary-file API, so it must be
+// gated on the caller being the authenticated attn app itself — not just any
+// accepted local WebSocket client (a browser tab, or any other local process that
+// completes the handshake). Without this gate, fs_read/{root} would let such a
+// client read any file the OS lets the daemon process read.
+func TestFsReadWithExplicitRootDeniedForUntrustedClient(t *testing.T) {
+	d := newFsDaemon(t)
+	externalRoot := t.TempDir()
+	secretPath := filepath.Join(externalRoot, "secret.txt")
+	if err := os.WriteFile(secretPath, []byte("top secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsReadWSResult(client, "r1", "secret.txt", externalRoot)
+	var res protocol.FsReadResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil {
+		t.Fatalf("fs_read(explicit root, untrusted client) = %+v, want failure", res)
+	}
+	if !strings.Contains(*res.Error, "authenticated") {
+		t.Fatalf("fs_read(explicit root, untrusted client) error = %q, want it to mention the authenticated app", *res.Error)
+	}
+}
+
+// The write side of the same gate: an untrusted client must not be able to
+// CREATE a file anywhere on disk via an explicit root, and the attempted write
+// must never touch the filesystem (not merely reported as an error).
+func TestFsWriteWithExplicitRootDeniedForUntrustedClientAndFileNotCreated(t *testing.T) {
+	d := newFsDaemon(t)
+	externalRoot := t.TempDir()
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsWriteWSResult(client, "w1", "pwned.txt", "attacker-controlled content", "", externalRoot)
+	var res protocol.FsWriteResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil {
+		t.Fatalf("fs_write(explicit root, untrusted client) = %+v, want failure", res)
+	}
+	if !strings.Contains(*res.Error, "authenticated") {
+		t.Fatalf("fs_write(explicit root, untrusted client) error = %q, want it to mention the authenticated app", *res.Error)
+	}
+	if _, err := os.Stat(filepath.Join(externalRoot, "pwned.txt")); !os.IsNotExist(err) {
+		t.Fatalf("fs_write(explicit root, untrusted client) must not create the file, stat err = %v", err)
+	}
+}
+
+// The SAME untrusted client must still succeed with root omitted — the auth
+// gate is scoped to the explicit-root escape hatch, not the fs surface as a
+// whole. Regressing this would break every existing fs_* caller, none of which
+// authenticate as the app today.
+func TestFsCommandsOmittedRootStillWorksForUntrustedClient(t *testing.T) {
+	d := newFsDaemon(t)
+	notebookRoot, err := d.notebookRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsWriteWSResult(client, "w1", "notes/todo.txt", "buy milk", "", "")
+	var res protocol.FsWriteResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if !res.Success || res.Result == nil || res.Result.Conflict {
+		t.Fatalf("fs_write(omitted root, untrusted client) = %+v, want success", res)
+	}
+	if _, err := os.Stat(filepath.Join(notebookRoot, "notes", "todo.txt")); err != nil {
+		t.Fatalf("file did not land under the notebook root: %v", err)
+	}
+}
+
+// A client that has the browser-host secret and the right origin but declared a
+// non-tauri-app client kind (e.g. it spoofed/omitted client_hello's kind) must
+// still be denied. This catches the gate collapsing to token-only — checking just
+// trustedTauriOrigin+browserHostAuthenticated without clientKind would let any
+// client that merely obtained the secret claim arbitrary roots.
+func TestFsCommandsExplicitRootDeniedForNonTauriAppClientKind(t *testing.T) {
+	d := newFsDaemon(t)
+	externalRoot := t.TempDir()
+
+	client := &wsClient{send: make(chan outboundMessage, 4), trustedTauriOrigin: true}
+	client.setBrowserHostAuthenticated(true)
+	client.setIdentity("not-tauri-app", "test", nil)
+
+	d.sendFsListWSResult(client, "l1", "", externalRoot)
+	var res protocol.FsListResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if res.Success || res.Error == nil {
+		t.Fatalf("fs_list(explicit root, non-tauri-app clientKind) = %+v, want failure", res)
+	}
+	if !strings.Contains(*res.Error, "authenticated") {
+		t.Fatalf("fs_list(explicit root, non-tauri-app clientKind) error = %q, want it to mention the authenticated app", *res.Error)
 	}
 }
 
@@ -660,7 +771,7 @@ func TestFsRenameDeleteNotebookCouplingIsRootConditional(t *testing.T) {
 	// Drain the seed write's own fs_changed(a.md) so the rename's broadcast below
 	// is the one actually asserted on.
 	waitForFsChange(t, hubClient.send, originUI)
-	renameClient := &wsClient{send: make(chan outboundMessage, 4)}
+	renameClient := trustedFsClient(4)
 	d.sendFsRenameWSResult(renameClient, "rn1", "a.md", "b.md", externalRoot)
 	var renameRes protocol.FsRenameResultMessage
 	readNotebookWSEvent(t, renameClient.send, &renameRes)
@@ -673,7 +784,7 @@ func TestFsRenameDeleteNotebookCouplingIsRootConditional(t *testing.T) {
 	}
 
 	// --- foreign root: delete ---
-	deleteClient := &wsClient{send: make(chan outboundMessage, 4)}
+	deleteClient := trustedFsClient(4)
 	d.sendFsDeleteWSResult(deleteClient, "d1", "b.md", externalRoot)
 	var deleteRes protocol.FsDeleteResultMessage
 	readNotebookWSEvent(t, deleteClient.send, &deleteRes)

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -653,6 +653,102 @@ func TestFsCommandsRejectInvalidRoots(t *testing.T) {
 	}
 }
 
+// fsdoc.Store deliberately permits symlinked roots, so the data-dir exclusion
+// in normalizeExternalRoot cannot be a purely lexical comparison: a root that
+// LOOKS external but is actually a symlink into config.DataDir() (or a subdir
+// of it) must still be rejected — otherwise fs_delete could reach attn.db
+// through the alias. Covers both the read-only path (fs_list) and the
+// mutating path (fs_delete), and asserts the delete never touches the data
+// dir file.
+func TestFsCommandsRejectSymlinkedRootIntoDataDir(t *testing.T) {
+	d := newFsDaemon(t)
+
+	sentinel := filepath.Join(config.DataDir(), "attn.db")
+	if err := os.WriteFile(sentinel, []byte("sqlite-ish"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Symlink directly at the data dir.
+	linkDir := t.TempDir()
+	directLink := filepath.Join(linkDir, "editor-root")
+	if err := os.Symlink(config.DataDir(), directLink); err != nil {
+		t.Fatal(err)
+	}
+
+	client := trustedFsClient(4)
+	d.sendFsListWSResult(client, "l1", "", directLink)
+	var listRes protocol.FsListResultMessage
+	readNotebookWSEvent(t, client.send, &listRes)
+	if listRes.Success || listRes.Error == nil {
+		t.Fatalf("fs_list(symlink into data dir) = %+v, want failure", listRes)
+	}
+	if !strings.Contains(*listRes.Error, "outside the attn data dir") {
+		t.Fatalf("fs_list(symlink into data dir) error = %q, want it to mention the data dir exclusion", *listRes.Error)
+	}
+
+	deleteClient := trustedFsClient(4)
+	d.sendFsDeleteWSResult(deleteClient, "d1", "attn.db", directLink)
+	var deleteRes protocol.FsDeleteResultMessage
+	readNotebookWSEvent(t, deleteClient.send, &deleteRes)
+	if deleteRes.Success || deleteRes.Error == nil {
+		t.Fatalf("fs_delete(symlink into data dir) = %+v, want failure", deleteRes)
+	}
+	if !strings.Contains(*deleteRes.Error, "outside the attn data dir") {
+		t.Fatalf("fs_delete(symlink into data dir) error = %q, want it to mention the data dir exclusion", *deleteRes.Error)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("fs_delete(symlink into data dir) must not touch the data dir, stat err = %v", err)
+	}
+
+	// Symlink to a SUBDIR of the data dir (nested alias) must also be rejected.
+	subdir := filepath.Join(config.DataDir(), "workers")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nestedLink := filepath.Join(linkDir, "editor-root-nested")
+	if err := os.Symlink(subdir, nestedLink); err != nil {
+		t.Fatal(err)
+	}
+	nestedClient := trustedFsClient(4)
+	d.sendFsListWSResult(nestedClient, "l2", "", nestedLink)
+	var nestedRes protocol.FsListResultMessage
+	readNotebookWSEvent(t, nestedClient.send, &nestedRes)
+	if nestedRes.Success || nestedRes.Error == nil {
+		t.Fatalf("fs_list(symlink into data dir subdir) = %+v, want failure", nestedRes)
+	}
+	if !strings.Contains(*nestedRes.Error, "outside the attn data dir") {
+		t.Fatalf("fs_list(symlink into data dir subdir) error = %q, want it to mention the data dir exclusion", *nestedRes.Error)
+	}
+}
+
+// A symlink to a normal external directory (not aliasing the data dir) must
+// keep working: the canonicalization added for the data-dir exclusion check
+// must not become a general "no symlinked roots" ban. macOS matters here
+// specifically because t.TempDir() lives under /var/folders, itself reached
+// via a /private symlink — so this exercises the exact canonicalize-both-sides
+// path the fix relies on, not just a synthetic case.
+func TestFsCommandsAcceptLegitimateSymlinkedRoot(t *testing.T) {
+	d := newFsDaemon(t)
+
+	target := t.TempDir()
+	linkParent := t.TempDir()
+	link := filepath.Join(linkParent, "editor-root")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	client := trustedFsClient(4)
+	d.sendFsWriteWSResult(client, "w1", "note.md", "hello", "", link)
+	var res protocol.FsWriteResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	if !res.Success || res.Result == nil || res.Result.Conflict {
+		t.Fatalf("fs_write(legitimate symlinked root) = %+v, want success", res)
+	}
+	if _, err := os.Stat(filepath.Join(target, "note.md")); err != nil {
+		t.Fatalf("file did not land under the symlink target: %v", err)
+	}
+}
+
 // An explicit root turns the fs surface into an arbitrary-file API, so it must be
 // gated on the caller being the authenticated attn app itself — not just any
 // accepted local WebSocket client (a browser tab, or any other local process that

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/fsdoc"
 	"github.com/victorarias/attn/internal/protocol"
 )
@@ -29,8 +30,14 @@ func newFsDaemon(t *testing.T) *Daemon {
 // client; the origin=ui broadcast goes to the hub, not this client.
 func fsWriteCAS(t *testing.T, d *Daemon, path, content, baseHash string) protocol.FsWriteResultMessage {
 	t.Helper()
+	return fsWriteCASRoot(t, d, path, content, baseHash, "")
+}
+
+// fsWriteCASRoot is fsWriteCAS with an explicit root (empty = notebook root).
+func fsWriteCASRoot(t *testing.T, d *Daemon, path, content, baseHash, root string) protocol.FsWriteResultMessage {
+	t.Helper()
 	client := &wsClient{send: make(chan outboundMessage, 8)}
-	d.sendFsWriteWSResult(client, "setup-fs-write", path, content, baseHash)
+	d.sendFsWriteWSResult(client, "setup-fs-write", path, content, baseHash, root)
 	var res protocol.FsWriteResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	return res
@@ -39,8 +46,14 @@ func fsWriteCAS(t *testing.T, d *Daemon, path, content, baseHash string) protoco
 // listFs lists one directory over the WS fs path and returns the entries.
 func listFs(t *testing.T, d *Daemon, dir string) []protocol.FsEntry {
 	t.Helper()
+	return listFsRoot(t, d, dir, "")
+}
+
+// listFsRoot is listFs with an explicit root (empty = notebook root).
+func listFsRoot(t *testing.T, d *Daemon, dir, root string) []protocol.FsEntry {
+	t.Helper()
 	client := &wsClient{send: make(chan outboundMessage, 8)}
-	d.sendFsListWSResult(client, "setup-fs-list", dir)
+	d.sendFsListWSResult(client, "setup-fs-list", dir, root)
 	var res protocol.FsListResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	if !res.Success {
@@ -53,7 +66,7 @@ func listFs(t *testing.T, d *Daemon, dir string) []protocol.FsEntry {
 func fsExists(t *testing.T, d *Daemon, path string) protocol.FsExistsResultMessage {
 	t.Helper()
 	client := &wsClient{send: make(chan outboundMessage, 8)}
-	d.sendFsExistsWSResult(client, "setup-fs-exists", path)
+	d.sendFsExistsWSResult(client, "setup-fs-exists", path, "")
 	var res protocol.FsExistsResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	return res
@@ -109,7 +122,7 @@ func TestFsWriteListReadWSResults(t *testing.T) {
 
 	// Read the file: content + the same hash the write returned.
 	client := &wsClient{send: make(chan outboundMessage, 4)}
-	d.sendFsReadWSResult(client, "r1", "notes/todo.txt")
+	d.sendFsReadWSResult(client, "r1", "notes/todo.txt", "")
 	var read protocol.FsReadResultMessage
 	readNotebookWSEvent(t, client.send, &read)
 	if read.Event != protocol.EventFsReadResult || read.RequestID != "r1" || !read.Success ||
@@ -118,7 +131,7 @@ func TestFsWriteListReadWSResults(t *testing.T) {
 	}
 
 	// A missing file is a failed result, not a panic or empty success.
-	d.sendFsReadWSResult(client, "r2", "nope.txt")
+	d.sendFsReadWSResult(client, "r2", "nope.txt", "")
 	var missing protocol.FsReadResultMessage
 	readNotebookWSEvent(t, client.send, &missing)
 	if missing.RequestID != "r2" || missing.Success || missing.Error == nil {
@@ -141,7 +154,7 @@ func TestFsReadWSRejectsOversizedFile(t *testing.T) {
 	}
 
 	client := &wsClient{send: make(chan outboundMessage, 4)}
-	d.sendFsReadWSResult(client, "oversized", "attachments/too-large.txt")
+	d.sendFsReadWSResult(client, "oversized", "attachments/too-large.txt", "")
 	var read protocol.FsReadResultMessage
 	readNotebookWSEvent(t, client.send, &read)
 	if read.Success || read.Error == nil || !strings.Contains(*read.Error, "read cap") {
@@ -267,7 +280,7 @@ func TestFsWriteBroadcastsUiChange(t *testing.T) {
 	go d.wsHub.run()
 
 	writer := &wsClient{send: make(chan outboundMessage, 8)}
-	d.sendFsWriteWSResult(writer, "w1", "notes/todo.txt", "hello", "")
+	d.sendFsWriteWSResult(writer, "w1", "notes/todo.txt", "hello", "", "")
 	var res protocol.FsWriteResultMessage
 	readNotebookWSEvent(t, writer.send, &res)
 	if !res.Success || res.Result == nil || res.Result.Conflict {
@@ -342,7 +355,7 @@ var pngHeaderBytes = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0
 func fsReadAsset(t *testing.T, d *Daemon, requestID, path string) protocol.FsReadAssetResultMessage {
 	t.Helper()
 	client := &wsClient{send: make(chan outboundMessage, 4)}
-	d.sendFsReadAssetWSResult(client, requestID, path)
+	d.sendFsReadAssetWSResult(client, requestID, path, "")
 	var res protocol.FsReadAssetResultMessage
 	readNotebookWSEvent(t, client.send, &res)
 	return res
@@ -472,5 +485,274 @@ func TestFsReadAssetUnsupportedExtension(t *testing.T) {
 	got := fsReadAsset(t, d, "a1", "assets/doc.pdf")
 	if got.Success || got.Error == nil || *got.Error != "not a supported image asset" {
 		t.Fatalf("read asset(unsupported ext) = %+v, want \"not a supported image asset\"", got)
+	}
+}
+
+// An explicit root pointing outside the notebook root must make fs_write/fs_read/
+// fs_list operate on THAT directory: the file must physically land there (not
+// under the notebook root), results must be relative to it, and the fs_changed
+// broadcast must carry the resolved root. This is the core PR1 behavior — without
+// it, an explicit root would be silently ignored or resolved against the wrong
+// base.
+func TestFsCommandsWithExplicitRootActOnThatDirectory(t *testing.T) {
+	d := newFsDaemon(t)
+	notebookRoot, err := d.notebookRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	externalRoot := t.TempDir()
+
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	write := fsWriteCASRoot(t, d, "notes/todo.txt", "buy milk", "", externalRoot)
+	if !write.Success || write.Result == nil || write.Result.Conflict || write.Result.Hash == nil {
+		t.Fatalf("write under explicit root = %+v", write.Result)
+	}
+	if write.Result.Path != "notes/todo.txt" {
+		t.Fatalf("write result path = %q, want root-relative notes/todo.txt", write.Result.Path)
+	}
+
+	// The file must physically land under externalRoot, not the notebook root.
+	if _, err := os.Stat(filepath.Join(externalRoot, "notes", "todo.txt")); err != nil {
+		t.Fatalf("file did not land under explicit root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(notebookRoot, "notes", "todo.txt")); err == nil {
+		t.Fatalf("file wrongly landed under the notebook root")
+	}
+
+	entries := listFsRoot(t, d, "notes", externalRoot)
+	if len(entries) != 1 || entries[0].Path != "notes/todo.txt" {
+		t.Fatalf("list under explicit root = %+v", entries)
+	}
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsReadWSResult(client, "r1", "notes/todo.txt", externalRoot)
+	var read protocol.FsReadResultMessage
+	readNotebookWSEvent(t, client.send, &read)
+	if !read.Success || read.Result == nil || read.Result.Content != "buy milk" {
+		t.Fatalf("read under explicit root = %+v", read.Result)
+	}
+
+	ev := waitForFsChangeWithRoot(t, hubClient.send, originUI)
+	if !slices.Contains(ev.Paths, "notes/todo.txt") {
+		t.Fatalf("ui fs_changed paths = %v, want notes/todo.txt", ev.Paths)
+	}
+	if ev.Root != externalRoot {
+		t.Fatalf("ui fs_changed root = %q, want %q", ev.Root, externalRoot)
+	}
+}
+
+// waitForFsChangeWithRoot returns the full fs_changed event matching origin, so
+// callers can assert on Root in addition to Paths.
+func waitForFsChangeWithRoot(t *testing.T, ch chan outboundMessage, origin string) protocol.FsChangedMessage {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case msg := <-ch:
+			var ev protocol.FsChangedMessage
+			if err := json.Unmarshal(msg.payload, &ev); err != nil {
+				continue
+			}
+			if ev.Event == protocol.EventFsChanged && ev.Origin == origin {
+				return ev
+			}
+		case <-deadline:
+			t.Fatalf("no fs_changed with origin %q was broadcast", origin)
+			return protocol.FsChangedMessage{}
+		}
+	}
+}
+
+// fs_changed's root must be the resolved absolute root the write happened under,
+// so a UI subscribed to one root can ignore broadcasts for another.
+func TestFsWriteBroadcastsResolvedRoot(t *testing.T) {
+	d := newFsDaemon(t)
+	externalRoot := t.TempDir()
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	if res := fsWriteCASRoot(t, d, "a.txt", "x", "", externalRoot); !res.Success || res.Result == nil {
+		t.Fatalf("write = %+v", res.Result)
+	}
+	ev := waitForFsChangeWithRoot(t, hubClient.send, originUI)
+	if ev.Root != externalRoot {
+		t.Fatalf("fs_changed.root = %q, want %q", ev.Root, externalRoot)
+	}
+}
+
+// Omitting root must still resolve to the notebook root, and fs_changed.root must
+// equal it exactly — a back-compat regression would either break existing fs
+// clients (nothing sent a root before this PR) or silently resolve to some other
+// directory.
+func TestFsCommandsOmittedRootResolvesToNotebookRoot(t *testing.T) {
+	d := newFsDaemon(t)
+	notebookRoot, err := d.notebookRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	res := fsWriteCAS(t, d, "notes/todo.txt", "buy milk", "")
+	if !res.Success || res.Result == nil {
+		t.Fatalf("write = %+v", res.Result)
+	}
+	if _, err := os.Stat(filepath.Join(notebookRoot, "notes", "todo.txt")); err != nil {
+		t.Fatalf("file did not land under the notebook root: %v", err)
+	}
+	ev := waitForFsChangeWithRoot(t, hubClient.send, originUI)
+	if ev.Root != notebookRoot {
+		t.Fatalf("fs_changed.root = %q, want notebook root %q", ev.Root, notebookRoot)
+	}
+}
+
+// A relative root, and a root inside config.DataDir(), must both be rejected —
+// the same validation notebook.root enforces. Without this, a client could point
+// the fs surface at attn's own data dir (defeating the "notebook must live
+// outside .attn" invariant) or at an ambiguous relative path.
+func TestFsCommandsRejectInvalidRoots(t *testing.T) {
+	d := newFsDaemon(t)
+
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsListWSResult(client, "rel", "", "relative/path")
+	var relRes protocol.FsListResultMessage
+	readNotebookWSEvent(t, client.send, &relRes)
+	if relRes.Success || relRes.Error == nil {
+		t.Fatalf("fs_list(relative root) = %+v, want failure", relRes)
+	}
+
+	insideDataDir := filepath.Join(config.DataDir(), "notebook")
+	client2 := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsListWSResult(client2, "indatadir", "", insideDataDir)
+	var dataDirRes protocol.FsListResultMessage
+	readNotebookWSEvent(t, client2.send, &dataDirRes)
+	if dataDirRes.Success || dataDirRes.Error == nil {
+		t.Fatalf("fs_list(root inside data dir) = %+v, want failure", dataDirRes)
+	}
+}
+
+// fs_rename/fs_delete under a non-notebook root must broadcast fs_changed but NOT
+// notebook_changed (a foreign root has no notebook to couple to), while the same
+// operations under the notebook root must still broadcast both — regressing
+// either direction either leaks the notebook coupling to arbitrary roots or loses
+// it for the actual notebook.
+func TestFsRenameDeleteNotebookCouplingIsRootConditional(t *testing.T) {
+	d := newFsDaemon(t)
+	notebookRoot, err := d.notebookRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	externalRoot := t.TempDir()
+
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	// --- foreign root: rename ---
+	if res := fsWriteCASRoot(t, d, "a.md", "x", "", externalRoot); !res.Success || res.Result == nil {
+		t.Fatalf("seed write (external) = %+v", res.Result)
+	}
+	// Drain the seed write's own fs_changed(a.md) so the rename's broadcast below
+	// is the one actually asserted on.
+	waitForFsChange(t, hubClient.send, originUI)
+	renameClient := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsRenameWSResult(renameClient, "rn1", "a.md", "b.md", externalRoot)
+	var renameRes protocol.FsRenameResultMessage
+	readNotebookWSEvent(t, renameClient.send, &renameRes)
+	if !renameRes.Success || renameRes.Result == nil {
+		t.Fatalf("rename (external root) = %+v", renameRes)
+	}
+	assertNoBroadcast(t, hubClient.send, protocol.EventNotebookChanged, 300*time.Millisecond)
+	if got := waitForFsChange(t, hubClient.send, originUI); !slices.Contains(got, "b.md") {
+		t.Fatalf("fs_changed after external rename = %v, want b.md", got)
+	}
+
+	// --- foreign root: delete ---
+	deleteClient := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsDeleteWSResult(deleteClient, "d1", "b.md", externalRoot)
+	var deleteRes protocol.FsDeleteResultMessage
+	readNotebookWSEvent(t, deleteClient.send, &deleteRes)
+	if !deleteRes.Success || deleteRes.Result == nil {
+		t.Fatalf("delete (external root) = %+v", deleteRes)
+	}
+	assertNoBroadcast(t, hubClient.send, protocol.EventNotebookChanged, 300*time.Millisecond)
+	if got := waitForFsChange(t, hubClient.send, originUI); !slices.Contains(got, "b.md") {
+		t.Fatalf("fs_changed after external delete = %v, want b.md", got)
+	}
+
+	// --- notebook root: rename still broadcasts both ---
+	if res := fsWriteCAS(t, d, "c.md", "x", ""); !res.Success || res.Result == nil {
+		t.Fatalf("seed write (notebook) = %+v", res.Result)
+	}
+	// Drain the seed write's own fs_changed(c.md) broadcast.
+	waitForFsChange(t, hubClient.send, originUI)
+	renameClient2 := &wsClient{send: make(chan outboundMessage, 4)}
+	d.sendFsRenameWSResult(renameClient2, "rn2", "c.md", "d.md", "")
+	var renameRes2 protocol.FsRenameResultMessage
+	readNotebookWSEvent(t, renameClient2.send, &renameRes2)
+	if !renameRes2.Success || renameRes2.Result == nil {
+		t.Fatalf("rename (notebook root) = %+v", renameRes2)
+	}
+	notebookEv := waitForNotebookChangeEvent(t, hubClient.send)
+	if !slices.Contains(notebookEv, "d.md") {
+		t.Fatalf("notebook_changed after notebook rename = %v, want d.md", notebookEv)
+	}
+	if got := waitForFsChange(t, hubClient.send, originUI); !slices.Contains(got, "d.md") {
+		t.Fatalf("fs_changed after notebook rename = %v, want d.md", got)
+	}
+	_ = notebookRoot
+}
+
+// assertNoBroadcast fails the test if an event of the given type shows up on ch
+// within the wait window. Any other events (including fs_changed) are drained and
+// ignored so a later waitForFsChange in the same test still sees them — this
+// function only asserts absence of eventType.
+func assertNoBroadcast(t *testing.T, ch chan outboundMessage, eventType string, wait time.Duration) {
+	t.Helper()
+	deadline := time.After(wait)
+	var drained []outboundMessage
+	for {
+		select {
+		case msg := <-ch:
+			var ev struct {
+				Event string `json:"event"`
+			}
+			if err := json.Unmarshal(msg.payload, &ev); err == nil && ev.Event == eventType {
+				t.Fatalf("unexpected %s broadcast", eventType)
+			}
+			drained = append(drained, msg)
+		case <-deadline:
+			for _, m := range drained {
+				ch <- m
+			}
+			return
+		}
+	}
+}
+
+// waitForNotebookChangeEvent returns the paths of the first notebook_changed
+// broadcast on ch.
+func waitForNotebookChangeEvent(t *testing.T, ch chan outboundMessage) []string {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case msg := <-ch:
+			var ev protocol.NotebookChangedMessage
+			if err := json.Unmarshal(msg.payload, &ev); err != nil {
+				continue
+			}
+			if ev.Event == protocol.EventNotebookChanged {
+				return ev.Paths
+			}
+		case <-deadline:
+			t.Fatalf("no notebook_changed was broadcast")
+			return nil
+		}
 	}
 }

--- a/internal/daemon/notebook.go
+++ b/internal/daemon/notebook.go
@@ -81,7 +81,7 @@ func (d *Daemon) ensureNotebookWatcher(root string) {
 		// notebook view and the raw fs view. (The watcher only surfaces .md paths
 		// today, so fs_changed inherits that limit until the watcher is generalized.)
 		d.broadcastNotebookChanged(originExternal, paths...)
-		d.broadcastFsChanged(originExternal, paths...)
+		d.broadcastFsChanged(root, originExternal, paths...)
 	})
 	if err != nil {
 		d.logf("notebook watcher: failed to watch %s: %v", root, err)

--- a/internal/daemon/ticket_attach.go
+++ b/internal/daemon/ticket_attach.go
@@ -156,7 +156,9 @@ func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author st
 	d.notifyTicketObservers(ticketID)
 	d.broadcastTicketsUpdated()
 	d.broadcastNotebookChanged(originAgent, changedPaths...)
-	d.broadcastFsChanged(originAgent, changedPaths...)
+	if root, rootErr := d.notebookRoot(); rootErr == nil {
+		d.broadcastFsChanged(root, originAgent, changedPaths...)
+	}
 
 	return &protocol.TicketAttachResult{
 		TicketID:     ticketID,

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -926,25 +926,25 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		go d.handleTicketResume(client, msg.(*protocol.TicketResumeMessage))
 	case protocol.CmdFsList:
 		fsList := msg.(*protocol.FsListMessage)
-		go d.sendFsListWSResult(client, protocol.Deref(fsList.RequestID), protocol.Deref(fsList.Path))
+		go d.sendFsListWSResult(client, protocol.Deref(fsList.RequestID), protocol.Deref(fsList.Path), protocol.Deref(fsList.Root))
 	case protocol.CmdFsRead:
 		fsRead := msg.(*protocol.FsReadMessage)
-		go d.sendFsReadWSResult(client, protocol.Deref(fsRead.RequestID), fsRead.Path)
+		go d.sendFsReadWSResult(client, protocol.Deref(fsRead.RequestID), fsRead.Path, protocol.Deref(fsRead.Root))
 	case protocol.CmdFsReadAsset:
 		fsReadAsset := msg.(*protocol.FsReadAssetMessage)
-		go d.sendFsReadAssetWSResult(client, protocol.Deref(fsReadAsset.RequestID), fsReadAsset.Path)
+		go d.sendFsReadAssetWSResult(client, protocol.Deref(fsReadAsset.RequestID), fsReadAsset.Path, protocol.Deref(fsReadAsset.Root))
 	case protocol.CmdFsWrite:
 		fsWrite := msg.(*protocol.FsWriteMessage)
-		go d.sendFsWriteWSResult(client, protocol.Deref(fsWrite.RequestID), fsWrite.Path, fsWrite.Content, protocol.Deref(fsWrite.BaseHash))
+		go d.sendFsWriteWSResult(client, protocol.Deref(fsWrite.RequestID), fsWrite.Path, fsWrite.Content, protocol.Deref(fsWrite.BaseHash), protocol.Deref(fsWrite.Root))
 	case protocol.CmdFsRename:
 		fsRename := msg.(*protocol.FsRenameMessage)
-		go d.sendFsRenameWSResult(client, protocol.Deref(fsRename.RequestID), fsRename.Path, fsRename.NewPath)
+		go d.sendFsRenameWSResult(client, protocol.Deref(fsRename.RequestID), fsRename.Path, fsRename.NewPath, protocol.Deref(fsRename.Root))
 	case protocol.CmdFsDelete:
 		fsDelete := msg.(*protocol.FsDeleteMessage)
-		go d.sendFsDeleteWSResult(client, protocol.Deref(fsDelete.RequestID), fsDelete.Path)
+		go d.sendFsDeleteWSResult(client, protocol.Deref(fsDelete.RequestID), fsDelete.Path, protocol.Deref(fsDelete.Root))
 	case protocol.CmdFsExists:
 		fsExists := msg.(*protocol.FsExistsMessage)
-		go d.sendFsExistsWSResult(client, protocol.Deref(fsExists.RequestID), fsExists.Path)
+		go d.sendFsExistsWSResult(client, protocol.Deref(fsExists.RequestID), fsExists.Path, protocol.Deref(fsExists.Root))
 	case protocol.CmdApprovePR:
 		d.handleApprovePRWS(client, msg.(*protocol.ApprovePRMessage))
 	case protocol.CmdMergePR:

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -90,6 +90,18 @@ func (c *wsClient) setBrowserHostAuthenticated(authenticated bool) {
 	c.browserHostAuthenticated = authenticated
 }
 
+// isTrustedAppClient reports whether this connection is the authenticated attn
+// app itself: trusted Tauri origin, per-profile browser-host secret verified via
+// client_hello, and the tauri-app client kind. It is IsBrowserHost minus the
+// browser-host capability — identity, not feature opt-in. Arbitrary fs roots
+// are gated on it: without this, any accepted local WebSocket client could use
+// fs_* {root} to read or overwrite files anywhere in the user's home.
+func (c *wsClient) isTrustedAppClient() bool {
+	c.identityMu.RLock()
+	defer c.identityMu.RUnlock()
+	return c.trustedTauriOrigin && c.browserHostAuthenticated && c.clientKind == "tauri-app"
+}
+
 func websocketReadLimit(client *wsClient) int64 {
 	if client.IsBrowserHost() {
 		return maxBrowserHostWebSocketReadBytes

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -476,23 +476,44 @@ func validateNotebookRoot(value string) error {
 	if strings.TrimSpace(value) == "" {
 		return nil
 	}
-	path := value
+	_, err := normalizeExternalRoot(value)
+	if err != nil {
+		return fmt.Errorf("notebook.root %w", err)
+	}
+	return nil
+}
+
+// normalizeExternalRoot expands a leading "~/" against the user's home
+// directory, requires the result to be an absolute path, cleans it, and
+// rejects a path that is (or is inside) the attn data dir — an external root
+// must live OUTSIDE ~/.attn[-profile] so it stays a plain, externally-syncable
+// directory a dotfile-skipping scanner won't miss. Empty input is the
+// caller's concern: it returns ("", nil) unchanged.
+//
+// Errors are unprefixed (e.g. "must be an absolute path") so each caller can
+// prefix them with its own vocabulary (notebook.root vs fs root).
+func normalizeExternalRoot(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", nil
+	}
+	path := trimmed
 	if strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return fmt.Errorf("cannot determine home directory: %w", err)
+			return "", fmt.Errorf("cannot determine home directory: %w", err)
 		}
 		path = filepath.Join(home, path[2:])
 	}
 	if !filepath.IsAbs(path) {
-		return fmt.Errorf("notebook.root must be an absolute path")
+		return "", fmt.Errorf("must be an absolute path")
 	}
 	dataDir := config.DataDir()
 	clean := filepath.Clean(path)
 	if clean == dataDir || strings.HasPrefix(clean, dataDir+string(filepath.Separator)) {
-		return fmt.Errorf("notebook.root must be outside the attn data dir (%s)", dataDir)
+		return "", fmt.Errorf("must be outside the attn data dir (%s)", dataDir)
 	}
-	return nil
+	return clean, nil
 }
 
 // validateNotebookCronFrequency accepts an empty value (use the default) or a

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -513,7 +513,48 @@ func normalizeExternalRoot(value string) (string, error) {
 	if clean == dataDir || strings.HasPrefix(clean, dataDir+string(filepath.Separator)) {
 		return "", fmt.Errorf("must be outside the attn data dir (%s)", dataDir)
 	}
+	// fsdoc.Store deliberately permits symlinked roots, so a purely lexical
+	// comparison above can be defeated by a symlink into the data dir (e.g. a
+	// root under /tmp whose target is ~/.attn). Re-check on canonicalized
+	// forms; the canonical value is used ONLY for this comparison — we still
+	// return the original cleaned (non-canonical) path below so legitimate
+	// symlinked roots keep their own spelling.
+	canonRoot := canonicalizeForComparison(clean)
+	canonData := canonicalizeForComparison(dataDir)
+	if canonRoot == canonData || strings.HasPrefix(canonRoot, canonData+string(filepath.Separator)) {
+		return "", fmt.Errorf("must be outside the attn data dir (%s)", dataDir)
+	}
 	return clean, nil
+}
+
+// canonicalizeForComparison resolves path to its canonical form for
+// containment checks: symlinks in the deepest existing ancestor are resolved
+// and any not-yet-existing remainder is re-joined lexically. Used ONLY for
+// comparison against the (equally canonicalized) attn data dir — the returned
+// value is never handed to callers as the root, so legitimate symlinked roots
+// keep their original spelling.
+func canonicalizeForComparison(path string) string {
+	clean := filepath.Clean(path)
+	ancestor := clean
+	var remainder []string
+	for {
+		if _, err := os.Stat(ancestor); err == nil {
+			break
+		}
+		parent := filepath.Dir(ancestor)
+		if parent == ancestor {
+			// Reached the root without finding an existing ancestor; fall back
+			// to the lexically cleaned input.
+			return clean
+		}
+		remainder = append([]string{filepath.Base(ancestor)}, remainder...)
+		ancestor = parent
+	}
+	resolved, err := filepath.EvalSymlinks(ancestor)
+	if err != nil {
+		return clean
+	}
+	return filepath.Join(append([]string{resolved}, remainder...)...)
 }
 
 // validateNotebookCronFrequency accepts an empty value (use the default) or a

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "166"
+const ProtocolVersion = "167"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -771,6 +771,9 @@ type FsChangedMessage struct {
 
 	// Paths corresponds to the JSON schema field "paths".
 	Paths []string `json:"paths"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root string `json:"root"`
 }
 
 type FsDeleteMessage struct {
@@ -782,6 +785,9 @@ type FsDeleteMessage struct {
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
 }
 
 type FsDeleteResult struct {
@@ -832,6 +838,9 @@ type FsExistsMessage struct {
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
 }
 
 type FsExistsResult struct {
@@ -868,6 +877,9 @@ type FsListMessage struct {
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
 }
 
 type FsListResultMessage struct {
@@ -896,6 +908,9 @@ type FsReadAssetMessage struct {
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
 }
 
 type FsReadAssetResult struct {
@@ -935,6 +950,9 @@ type FsReadMessage struct {
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
 }
 
 type FsReadResult struct {
@@ -977,6 +995,9 @@ type FsRenameMessage struct {
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
 }
 
 type FsRenameResult struct {
@@ -1019,6 +1040,9 @@ type FsWriteMessage struct {
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
 }
 
 type FsWriteResult struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1108,12 +1108,14 @@ model NotificationMarkReadMessage {
 model FsListMessage {
   cmd: "fs_list";
   path?: string; // omitted/"" = the root directory itself
+  root?: string; // Absolute directory to operate under; omitted/empty = the notebook root.
   request_id?: string; // set by the WS frontend to correlate the result event
 }
 
 model FsReadMessage {
   cmd: "fs_read";
   path: string;
+  root?: string; // Absolute directory to operate under; omitted/empty = the notebook root.
   request_id?: string; // set by the WS frontend to correlate the result event
 }
 
@@ -1123,6 +1125,7 @@ model FsReadMessage {
 model FsReadAssetMessage {
   cmd: "fs_read_asset";
   path: string;
+  root?: string; // Absolute directory to operate under; omitted/empty = the notebook root.
   request_id?: string; // set by the WS frontend to correlate the result event
 }
 
@@ -1131,6 +1134,7 @@ model FsWriteMessage {
   path: string;
   content: string;
   base_hash?: string; // omitted = create-only; present = hash-CAS edit
+  root?: string; // Absolute directory to operate under; omitted/empty = the notebook root.
   request_id?: string; // set by the WS frontend to correlate the result event
 }
 
@@ -1138,12 +1142,14 @@ model FsRenameMessage {
   cmd: "fs_rename";
   path: string;
   new_path: string;
+  root?: string; // Absolute directory to operate under; omitted/empty = the notebook root.
   request_id?: string;
 }
 
 model FsDeleteMessage {
   cmd: "fs_delete";
   path: string;
+  root?: string; // Absolute directory to operate under; omitted/empty = the notebook root.
   request_id?: string;
 }
 
@@ -1152,6 +1158,7 @@ model FsDeleteMessage {
 model FsExistsMessage {
   cmd: "fs_exists";
   path: string;
+  root?: string; // Absolute directory to operate under; omitted/empty = the notebook root.
   request_id?: string; // set by the WS frontend to correlate the result event
 }
 
@@ -2974,6 +2981,7 @@ model FsChangedMessage {
   event: "fs_changed";
   paths: string[];
   origin: string;
+  root: string; // the resolved absolute root the change happened under
 }
 
 model WorkspaceContextResultMessage {


### PR DESCRIPTION
PR1 of the editor-over-arbitrary-roots epic (docs/plans/2026-07-18-editor-arbitrary-roots.md).

Every `fs_*` WS command (list/read/write/exists/rename/delete/read_asset) gains an optional absolute `root` field — omitted defaults to the notebook root, preserving full backward compatibility. `fs_changed` gains a matching `root` field. Root validation is shared with `notebook.root` (`normalizeExternalRoot`), with a per-root `fsdoc.Store` cache. Notebook coupling (self-write suppression + `notebook_changed`) is now root-conditional.

ProtocolVersion bumped 166 -> 167 (constants.go and useDaemonSocket.ts in lockstep).

No changelog entry — protocol-internal, no user-visible behavior change yet.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./internal/daemon -run 'TestFs|TestNotebook|TestWebsocket|TestSettings|TestTicketAttach'` — all pass
- [x] `tsc --noEmit`
- [x] `vitest run src/hooks/useDaemonSocket.test.tsx` — 58 passed