### PR TITLE
feat(daemon): rotating SQLite backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-18]
+
+### Added
+- **Automatic rotating database backups.** The daemon now snapshots its SQLite
+  database every 6 hours (keeping the last 12) and takes an extra safety
+  snapshot right before any database migration, so session, ticket, and
+  workspace state can be recovered if the database is ever lost or corrupted.
+
 ## [2026-07-16]
 
 ### Added

--- a/internal/daemon/backup.go
+++ b/internal/daemon/backup.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"path/filepath"
+	"time"
+)
+
+// backupDir returns the directory rotating SQLite backups are written to:
+// a "backups" subdirectory of the daemon's runtime data root. In production
+// this is identical to config.DataDir() (ValidateDaemonIsolation enforces
+// that the socket, and therefore dataRoot, cannot be split away from the
+// active profile's data directory) — but reading it off the daemon instance
+// rather than the global config keeps this test-safe: daemon tests point
+// dataRoot at a throwaway temp dir instead of the real ~/.attn.
+func (d *Daemon) backupDir() string {
+	return filepath.Join(d.dataRoot, "backups")
+}
+
+// runDatabaseBackupLoop takes an immediate backup on daemon start, then one
+// every backupInterval until the daemon shuts down. A backup failure is
+// logged and never propagated — it must not crash or wedge the daemon.
+func (d *Daemon) runDatabaseBackupLoop() {
+	d.performDatabaseBackup()
+
+	ticker := time.NewTicker(backupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-d.done:
+			return
+		case <-ticker.C:
+			d.performDatabaseBackup()
+		}
+	}
+}
+
+// performDatabaseBackup runs a single BackupNow call and logs the outcome.
+// It recovers from a panic in the store's backup path so a corrupt or
+// wedged database can never take the daemon down with it.
+func (d *Daemon) performDatabaseBackup() {
+	defer func() {
+		if r := recover(); r != nil {
+			d.logf("database backup panicked: %v", r)
+		}
+	}()
+
+	if d.store == nil {
+		return
+	}
+
+	path, err := d.store.BackupNow(d.backupDir(), backupKeep)
+	if err != nil {
+		d.logf("database backup failed: %v", err)
+		return
+	}
+	d.logf("database backup written to %s", path)
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -72,6 +72,12 @@ const (
 	forcedStopSuppressTTL  = 30 * time.Second
 	branchMonitorInterval  = 15 * time.Second
 
+	// backupInterval is how often the daemon takes a rotating snapshot of the
+	// SQLite store in the background. backupKeep is how many rotating
+	// snapshots survive pruning (older ones are deleted). See backup.go.
+	backupInterval = 6 * time.Hour
+	backupKeep     = 12
+
 	startupRecoveryRetryMax       = 2
 	startupRecoveryRetryDelay     = 500 * time.Millisecond
 	deferredRecoveryMaxAttempts   = 3
@@ -854,6 +860,10 @@ func (d *Daemon) Start() error {
 
 	// Start branch monitoring
 	go d.monitorBranches()
+
+	// Rotating SQLite backups: one immediately at startup, then every
+	// backupInterval. A failure here must never crash or wedge the daemon.
+	go d.runDatabaseBackupLoop()
 
 	// Orphaned-ticket sweep backstop: catches non-terminal tickets whose owning
 	// session died where the session-end seam couldn't run (pre-feature orphans,

--- a/internal/store/backup.go
+++ b/internal/store/backup.go
@@ -30,6 +30,9 @@ func (s *Store) BackupNow(dir string, keep int) (string, error) {
 	if s == nil || s.db == nil {
 		return "", fmt.Errorf("backup: store has no open database")
 	}
+	if !s.durable {
+		return "", fmt.Errorf("backup: store is not durably backed (in-memory fallback), skipping backup")
+	}
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", fmt.Errorf("backup: create dir %s: %w", dir, err)
 	}

--- a/internal/store/backup.go
+++ b/internal/store/backup.go
@@ -1,0 +1,137 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// backupNamePrefix and backupNameLayout define the on-disk naming scheme for
+// rotating backups: attn-<UTC timestamp YYYYMMDD-HHMMSS>.db. Pre-migration
+// snapshots use a different prefix (see backupNow's premigration variant in
+// sqlite.go) so the rotation prune below never counts or removes them.
+const (
+	backupNamePrefix = "attn-"
+	backupNameLayout = "20060102-150405"
+	backupNameSuffix = ".db"
+)
+
+// BackupNow writes a consistent online snapshot of the store's database to
+// dir/attn-<UTC timestamp YYYYMMDD-HHMMSS>.db using SQLite's VACUUM INTO,
+// then prunes the oldest files in dir so at most keep backups remain.
+// It creates dir if needed. Returns the path of the new backup. It must be
+// safe to call while the daemon is serving traffic (VACUUM INTO reads
+// through a consistent snapshot without blocking writers).
+func (s *Store) BackupNow(dir string, keep int) (string, error) {
+	if s == nil || s.db == nil {
+		return "", fmt.Errorf("backup: store has no open database")
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("backup: create dir %s: %w", dir, err)
+	}
+
+	name := backupNamePrefix + time.Now().UTC().Format(backupNameLayout) + backupNameSuffix
+	target := filepath.Join(dir, name)
+
+	if _, err := os.Stat(target); err == nil {
+		return "", fmt.Errorf("backup: target %s already exists", target)
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("backup: stat target %s: %w", target, err)
+	}
+
+	if _, err := s.db.Exec("VACUUM INTO ?", target); err != nil {
+		return "", fmt.Errorf("backup: vacuum into %s: %w", target, err)
+	}
+
+	if err := pruneBackups(dir, keep); err != nil {
+		return target, fmt.Errorf("backup: wrote %s but prune failed: %w", target, err)
+	}
+
+	return target, nil
+}
+
+// pruneBackups removes the oldest rotating backups in dir beyond keep. It
+// only considers files matching the canonical attn-<timestamp>.db name — not
+// pre-migration snapshots (attn-premigration-*.db), which are exempt from
+// rotation. Lexical sort on the fixed-width timestamp format sorts
+// chronologically.
+func pruneBackups(dir string, keep int) error {
+	if keep < 0 {
+		keep = 0
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read dir %s: %w", dir, err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if isRotatingBackupName(e.Name()) {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+
+	if len(names) <= keep {
+		return nil
+	}
+
+	toRemove := names[:len(names)-keep]
+	var firstErr error
+	for _, name := range toRemove {
+		if err := os.Remove(filepath.Join(dir, name)); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("remove %s: %w", name, err)
+		}
+	}
+	return firstErr
+}
+
+// backupPreMigration writes a one-off snapshot of db to
+// dir/attn-premigration-<version>-<timestamp>.db, where dir is the
+// "backups" directory alongside dbPath, before pending migrations run.
+// version identifies the schema version the database is migrating FROM.
+// This name is deliberately excluded from isRotatingBackupName's pattern so
+// BackupNow's rotation prune never counts or removes it. Returns the path of
+// the snapshot on success.
+func backupPreMigration(db *sql.DB, dbPath string, version int) (string, error) {
+	dir := filepath.Join(filepath.Dir(dbPath), "backups")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("create dir %s: %w", dir, err)
+	}
+
+	name := fmt.Sprintf("attn-premigration-%d-%s%s", version, time.Now().UTC().Format(backupNameLayout), backupNameSuffix)
+	target := filepath.Join(dir, name)
+
+	if _, err := os.Stat(target); err == nil {
+		return "", fmt.Errorf("target %s already exists", target)
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat target %s: %w", target, err)
+	}
+
+	if _, err := db.Exec("VACUUM INTO ?", target); err != nil {
+		return "", fmt.Errorf("vacuum into %s: %w", target, err)
+	}
+	return target, nil
+}
+
+// isRotatingBackupName reports whether name is a canonical rotating backup
+// (attn-<timestamp>.db), excluding pre-migration snapshots
+// (attn-premigration-<version>-<timestamp>.db) which are exempt from prune.
+func isRotatingBackupName(name string) bool {
+	if !strings.HasPrefix(name, backupNamePrefix) || !strings.HasSuffix(name, backupNameSuffix) {
+		return false
+	}
+	stem := strings.TrimSuffix(strings.TrimPrefix(name, backupNamePrefix), backupNameSuffix)
+	if _, err := time.Parse(backupNameLayout, stem); err != nil {
+		return false
+	}
+	return true
+}

--- a/internal/store/backup_test.go
+++ b/internal/store/backup_test.go
@@ -1,0 +1,244 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// TestBackupNow_ProducesValidSnapshot proves BackupNow's VACUUM INTO output is
+// a fully independent, openable SQLite database carrying the same schema
+// version and row data as the live source at the moment of the call.
+func TestBackupNow_ProducesValidSnapshot(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	s.Add(&protocol.Session{
+		ID:         "session-1",
+		Label:      "one",
+		Directory:  "/tmp/one",
+		State:      protocol.SessionStateWorking,
+		StateSince: protocol.TimestampNow().String(),
+		LastSeen:   protocol.TimestampNow().String(),
+	})
+	s.Add(&protocol.Session{
+		ID:         "session-2",
+		Label:      "two",
+		Directory:  "/tmp/two",
+		State:      protocol.SessionStateIdle,
+		StateSince: protocol.TimestampNow().String(),
+		LastSeen:   protocol.TimestampNow().String(),
+	})
+
+	backupDir := filepath.Join(t.TempDir(), "backups")
+	backupPath, err := s.BackupNow(backupDir, 12)
+	if err != nil {
+		t.Fatalf("BackupNow error: %v", err)
+	}
+	if _, err := os.Stat(backupPath); err != nil {
+		t.Fatalf("backup file missing: %v", err)
+	}
+	if filepath.Dir(backupPath) != backupDir {
+		t.Fatalf("backup path %s not under %s", backupPath, backupDir)
+	}
+
+	wantVersion, err := GetSchemaVersion(s.db)
+	if err != nil {
+		t.Fatalf("GetSchemaVersion(source): %v", err)
+	}
+
+	backupDB, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?mode=ro", backupPath))
+	if err != nil {
+		t.Fatalf("open backup: %v", err)
+	}
+	defer backupDB.Close()
+
+	gotVersion, err := GetSchemaVersion(backupDB)
+	if err != nil {
+		t.Fatalf("GetSchemaVersion(backup): %v", err)
+	}
+	if gotVersion != wantVersion {
+		t.Fatalf("backup schema_version = %d, want %d", gotVersion, wantVersion)
+	}
+
+	var count int
+	if err := backupDB.QueryRow(`SELECT COUNT(*) FROM sessions`).Scan(&count); err != nil {
+		t.Fatalf("count sessions in backup: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("backup sessions count = %d, want 2", count)
+	}
+
+	var label string
+	if err := backupDB.QueryRow(`SELECT label FROM sessions WHERE id = ?`, "session-1").Scan(&label); err != nil {
+		t.Fatalf("read session-1 from backup: %v", err)
+	}
+	if label != "one" {
+		t.Fatalf("session-1 label in backup = %q, want %q", label, "one")
+	}
+}
+
+// TestBackupNow_TargetAlreadyExists proves a timestamp collision fails loudly
+// instead of silently overwriting or auto-suffixing — the pinned design calls
+// this a caller bug, not something to paper over. The exact target name is
+// deterministic (second-granularity UTC timestamp), so we pre-create it right
+// before calling BackupNow.
+func TestBackupNow_TargetAlreadyExists(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	backupDir := t.TempDir()
+	// Seed both the current-second and next-second target names: BackupNow
+	// computes its own time.Now() after this test does, so a wall-clock
+	// second boundary crossed between the two calls must not let it pick a
+	// name we didn't pre-create (which would make the test spuriously pass
+	// without ever exercising the collision path).
+	now := time.Now().UTC()
+	for _, ts := range []time.Time{now, now.Add(time.Second)} {
+		name := backupNamePrefix + ts.Format(backupNameLayout) + backupNameSuffix
+		if err := os.WriteFile(filepath.Join(backupDir, name), []byte("occupied"), 0644); err != nil {
+			t.Fatalf("seed colliding file: %v", err)
+		}
+	}
+
+	if _, err := s.BackupNow(backupDir, 12); err == nil {
+		t.Fatal("expected BackupNow to fail on an existing target, got nil error")
+	}
+}
+
+// TestBackupNow_Rotation proves rotation prunes only the oldest canonical
+// rotating backups beyond keep, and never touches pre-migration snapshots.
+func TestBackupNow_Rotation(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	backupDir := t.TempDir()
+	const keep = 3
+
+	// Pre-create keep+3 fake rotating backups with distinct, lexically ordered
+	// timestamps, oldest first.
+	var existing []string
+	for i := 0; i < keep+3; i++ {
+		name := fmt.Sprintf("%s202601%02d-000000%s", backupNamePrefix, i+1, backupNameSuffix)
+		path := filepath.Join(backupDir, name)
+		if err := os.WriteFile(path, []byte("fake"), 0644); err != nil {
+			t.Fatalf("seed fake backup %s: %v", name, err)
+		}
+		existing = append(existing, name)
+	}
+
+	// A pre-migration snapshot must never be counted or pruned.
+	premigrationName := "attn-premigration-42-20260101-000000.db"
+	if err := os.WriteFile(filepath.Join(backupDir, premigrationName), []byte("fake"), 0644); err != nil {
+		t.Fatalf("seed premigration file: %v", err)
+	}
+
+	// One real backup call, which itself adds a new rotating file, pushing the
+	// total canonical count to keep+4 before pruning.
+	newPath, err := s.BackupNow(backupDir, keep)
+	if err != nil {
+		t.Fatalf("BackupNow error: %v", err)
+	}
+
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		t.Fatalf("read backup dir: %v", err)
+	}
+	var rotating []string
+	sawPremigration := false
+	sawNew := false
+	for _, e := range entries {
+		if e.Name() == premigrationName {
+			sawPremigration = true
+			continue
+		}
+		if e.Name() == filepath.Base(newPath) {
+			sawNew = true
+		}
+		if isRotatingBackupName(e.Name()) {
+			rotating = append(rotating, e.Name())
+		}
+	}
+
+	if !sawPremigration {
+		t.Fatal("premigration snapshot was pruned; it must be exempt")
+	}
+	if !sawNew {
+		t.Fatal("newly-written backup missing after rotation")
+	}
+	if len(rotating) != keep {
+		t.Fatalf("rotating backups after prune = %d, want %d (%v)", len(rotating), keep, rotating)
+	}
+
+	// The oldest fakes (index 0, 1, 2 of the pre-seeded batch — 3 files, since
+	// keep+3 total minus keep+1 kept-from-existing... ) must be gone. More
+	// simply: the two oldest fakes are guaranteed pruned, since the newly
+	// written backup's timestamp sorts after all the pre-seeded fakes.
+	oldestTwo := existing[:2]
+	for _, name := range oldestTwo {
+		if _, err := os.Stat(filepath.Join(backupDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("expected oldest backup %s to be pruned, stat err = %v", name, err)
+		}
+	}
+	// The newest of the pre-seeded fakes must survive.
+	newest := existing[len(existing)-1]
+	if _, err := os.Stat(filepath.Join(backupDir, newest)); err != nil {
+		t.Fatalf("expected newest pre-seeded backup %s to survive prune: %v", newest, err)
+	}
+}
+
+// TestMigrateDB_PreMigrationBackup proves that migrating an existing,
+// non-empty database forward writes a pre-migration snapshot to backups/
+// alongside the DB file before mutating the schema, using the same
+// unrecord-a-migration technique as TestMigration53AddsClosedStateColumnIdempotently
+// to force migrateDB down its "pending migrations" path against a real file.
+func TestMigrateDB_PreMigrationBackup(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	latest := latestSchemaVersion()
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version = ?`, latest); err != nil {
+		t.Fatalf("unrecord latest migration: %v", err)
+	}
+
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("migrateDB error: %v", err)
+	}
+
+	backupDir := filepath.Join(filepath.Dir(dbPath), "backups")
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		t.Fatalf("read backups dir: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), "attn-premigration-") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no pre-migration backup found in %s, entries: %v", backupDir, entries)
+	}
+}

--- a/internal/store/backup_test.go
+++ b/internal/store/backup_test.go
@@ -205,6 +205,31 @@ func TestBackupNow_Rotation(t *testing.T) {
 	}
 }
 
+// TestBackupNow_RefusesNonDurableStore proves that a store falling back to
+// the in-memory (":memory:") database — what New() returns when the durable
+// DB fails to open — refuses to back up rather than silently writing an
+// empty snapshot. Without this guard, a degraded daemon would rotate real
+// recovery copies out of the backups directory over the twelve ticks it
+// takes to fill the keep window, destroying exactly the safety net needed
+// while the durable DB is unavailable.
+func TestBackupNow_RefusesNonDurableStore(t *testing.T) {
+	s := New()
+	defer s.Close()
+
+	backupDir := t.TempDir()
+	if _, err := s.BackupNow(backupDir, 12); err == nil {
+		t.Fatal("expected BackupNow to refuse a non-durable (in-memory fallback) store, got nil error")
+	}
+
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		t.Fatalf("read backup dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("BackupNow wrote to backups dir despite refusing: %v", entries)
+	}
+}
+
 // TestMigrateDB_PreMigrationBackup proves that migrating an existing,
 // non-empty database forward writes a pre-migration snapshot to backups/
 // alongside the DB file before mutating the schema, using the same

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -683,7 +684,7 @@ func OpenDB(dbPath string) (*sql.DB, error) {
 	}
 
 	// Run versioned migrations
-	if err := migrateDB(db); err != nil {
+	if err := migrateDB(db, dbPath); err != nil {
 		db.Close()
 		return nil, err
 	}
@@ -692,8 +693,10 @@ func OpenDB(dbPath string) (*sql.DB, error) {
 }
 
 // migrateDB runs all pending migrations in order.
-// It tracks applied migrations in the schema_migrations table.
-func migrateDB(db *sql.DB) error {
+// It tracks applied migrations in the schema_migrations table. dbPath is used
+// only to locate a pre-migration backup directory alongside the database
+// file; it is ignored (no backup attempted) for the in-memory database.
+func migrateDB(db *sql.DB, dbPath string) error {
 	// Detect and handle legacy databases (created before migration system existed)
 	if err := seedLegacyDB(db); err != nil {
 		return fmt.Errorf("seeding legacy db: %w", err)
@@ -703,6 +706,22 @@ func migrateDB(db *sql.DB) error {
 	currentVersion, err := getCurrentVersion(db)
 	if err != nil {
 		return fmt.Errorf("getting schema version: %w", err)
+	}
+
+	// Take a pre-migration snapshot before mutating an existing, non-empty
+	// database. A brand-new DB (currentVersion 0) has nothing to protect, and
+	// :memory: has no on-disk directory to snapshot into — both are skipped.
+	// A failed backup must never block startup: log and proceed with
+	// migrations regardless.
+	if currentVersion > 0 && dbPath != "" && dbPath != ":memory:" && len(migrations) > 0 {
+		latest := migrations[len(migrations)-1].version
+		if currentVersion < latest {
+			if path, err := backupPreMigration(db, dbPath, currentVersion); err != nil {
+				log.Printf("[store] pre-migration backup failed (schema v%d -> v%d): %v; proceeding with migrations", currentVersion, latest, err)
+			} else {
+				log.Printf("[store] pre-migration backup written to %s (schema v%d -> v%d)", path, currentVersion, latest)
+			}
+		}
 	}
 
 	// Run pending migrations

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -842,7 +842,7 @@ func TestMigration52RenamesKeeperBackupsAndRealignsSentinel(t *testing.T) {
 		t.Fatalf("unrecord migration 52: %v", err)
 	}
 
-	if err := migrateDB(s.db); err != nil {
+	if err := migrateDB(s.db, dbPath); err != nil {
 		t.Fatalf("migrateDB error: %v", err)
 	}
 
@@ -904,7 +904,7 @@ func TestMigration53AddsClosedStateColumnIdempotently(t *testing.T) {
 	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version >= 53`); err != nil {
 		t.Fatalf("unrecord migration 53: %v", err)
 	}
-	if err := migrateDB(s.db); err != nil {
+	if err := migrateDB(s.db, dbPath); err != nil {
 		t.Fatalf("re-run migrateDB after unrecording 53: %v", err)
 	}
 	if !hasClosedState() {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -24,6 +24,16 @@ type Store struct {
 	mu sync.RWMutex
 	db *sql.DB
 
+	// durable reports whether db is backed by a real on-disk file rather
+	// than the in-memory (":memory:") fallback New() uses when the durable
+	// database fails to open. BackupNow refuses to run against a
+	// non-durable store: VACUUM INTO an in-memory fallback would silently
+	// write empty/degraded snapshots into the real backups directory and,
+	// after enough rotation ticks, prune away the last genuine recovery
+	// copies precisely when the durable DB is corrupt or unavailable — the
+	// moment they're needed most.
+	durable bool
+
 	sessions        map[string]*protocol.Session
 	agentDriverRuns map[string]AgentDriverReportCursor
 	agentMetadata   map[string]string
@@ -94,7 +104,7 @@ func NewWithDB(dbPath string) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Store{db: db}, nil
+	return &Store{db: db, durable: true}, nil
 }
 
 // NewWithPersistence creates a store that persists to SQLite (replaces JSON persistence)


### PR DESCRIPTION
## Summary
Prod `attn.db` was destroyed today with zero backups. The daemon now takes a `VACUUM INTO` snapshot at startup and every 6h into `<data-dir>/backups`, keeping the last 12, plus an unpruned pre-migration snapshot before any schema migration. Backup failures never block daemon startup.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/daemon/...`
- [x] Diff reviewed line-by-line and approved by the tech lead
- [x] Local `go test` green (tests remain hermetic under `t.TempDir()` HOME, never touching real `~/.attn`)
- [ ] CI green
- [ ] figgyster review

https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT