### PR TITLE
feat(daemon): per-root fs watchers via fs_watch/fs_unwatch

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '167';
+export const PROTOCOL_VERSION = '168';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -435,6 +435,13 @@ export interface FsDeleteResult {
 export interface FsExistsResult {
   path: string;
   exists: boolean;
+}
+
+// The resolved absolute root an fs_watch/fs_unwatch applied to. Mirrors the
+// daemon's protocol.FsWatchResultMessage/FsUnwatchResultMessage (root only —
+// there is no other result payload).
+export interface FsWatchResult {
+  root: string;
 }
 
 interface UseDaemonSocketOptions {
@@ -1685,6 +1692,27 @@ export function useDaemonSocket({
               });
             } else {
               pending.reject(new Error(data.error || 'Filesystem exists check failed'));
+            }
+            break;
+          }
+
+          case 'fs_watch_result':
+          case 'fs_unwatch_result': {
+            const requestId = data.request_id;
+            if (typeof requestId !== 'string') {
+              break;
+            }
+            const prefix = data.event === 'fs_watch_result' ? 'fs_watch' : 'fs_unwatch';
+            const key = `${prefix}:${requestId}`;
+            const pending = pendingActionsRef.current.get(key);
+            if (!pending) {
+              break;
+            }
+            pendingActionsRef.current.delete(key);
+            if (data.success && data.root) {
+              pending.resolve({ root: data.root });
+            } else {
+              pending.reject(new Error(data.error || 'Filesystem watch action failed'));
             }
             break;
           }
@@ -4749,6 +4777,53 @@ export function useDaemonSocket({
     });
   }, [nextRequestID]);
 
+  // Subscribe this client to fs_changed broadcasts for root (undefined/empty =
+  // the notebook root, which is always watched already). Refcounted on the
+  // daemon side, so repeat calls and multiple subscribers share one watcher; pair
+  // with sendFsUnwatch when live updates are no longer needed.
+  const sendFsWatch = useCallback((root?: string): Promise<FsWatchResult> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('fs_watch');
+      const key = `fs_watch:${requestId}`;
+      pendingActionsRef.current.set(key, { resolve, reject });
+      ws.send(JSON.stringify({ cmd: 'fs_watch', request_id: requestId, ...(root ? { root } : {}) }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Filesystem watch timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
+  // Drop this client's subscription from sendFsWatch. A success no-op if this
+  // client never watched root, or root is the notebook root (always watched
+  // independent of subscriptions).
+  const sendFsUnwatch = useCallback((root?: string): Promise<FsWatchResult> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('fs_unwatch');
+      const key = `fs_unwatch:${requestId}`;
+      pendingActionsRef.current.set(key, { resolve, reject });
+      ws.send(JSON.stringify({ cmd: 'fs_unwatch', request_id: requestId, ...(root ? { root } : {}) }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Filesystem unwatch timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
   // Get recent locations from daemon
   const sendGetRecentLocations = useCallback((endpointId?: string, limit?: number): Promise<RecentLocationsResult> => {
     return new Promise((resolve, reject) => {
@@ -5274,6 +5349,8 @@ export function useDaemonSocket({
     sendFsRename,
     sendFsDelete,
     sendFsExists,
+    sendFsWatch,
+    sendFsUnwatch,
     sendGetRecentLocations,
     sendBrowseDirectory,
     sendInspectPath,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -69,6 +69,10 @@
 //   const fSRenameMessage = Convert.toFSRenameMessage(json);
 //   const fSRenameResult = Convert.toFSRenameResult(json);
 //   const fSRenameResultMessage = Convert.toFSRenameResultMessage(json);
+//   const fSUnwatchMessage = Convert.toFSUnwatchMessage(json);
+//   const fSUnwatchResultMessage = Convert.toFSUnwatchResultMessage(json);
+//   const fSWatchMessage = Convert.toFSWatchMessage(json);
+//   const fSWatchResultMessage = Convert.toFSWatchResultMessage(json);
 //   const fSWriteMessage = Convert.toFSWriteMessage(json);
 //   const fSWriteResult = Convert.toFSWriteResult(json);
 //   const fSWriteResultMessage = Convert.toFSWriteResultMessage(json);
@@ -1301,6 +1305,54 @@ export interface FSRenameResultMessageResult {
     new_path: string;
     path:     string;
     [property: string]: any;
+}
+
+export interface FSUnwatchMessage {
+    cmd:         FSUnwatchMessageCmd;
+    request_id?: string;
+    root?:       string;
+    [property: string]: any;
+}
+
+export enum FSUnwatchMessageCmd {
+    FSUnwatch = "fs_unwatch",
+}
+
+export interface FSUnwatchResultMessage {
+    error?:     string;
+    event:      FSUnwatchResultMessageEvent;
+    request_id: string;
+    root?:      string;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum FSUnwatchResultMessageEvent {
+    FSUnwatchResult = "fs_unwatch_result",
+}
+
+export interface FSWatchMessage {
+    cmd:         FSWatchMessageCmd;
+    request_id?: string;
+    root?:       string;
+    [property: string]: any;
+}
+
+export enum FSWatchMessageCmd {
+    FSWatch = "fs_watch",
+}
+
+export interface FSWatchResultMessage {
+    error?:     string;
+    event:      FSWatchResultMessageEvent;
+    request_id: string;
+    root?:      string;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum FSWatchResultMessageEvent {
+    FSWatchResult = "fs_watch_result",
 }
 
 export interface FSWriteMessage {
@@ -5471,6 +5523,38 @@ export class Convert {
         return JSON.stringify(uncast(value, r("FSRenameResultMessage")), null, 2);
     }
 
+    public static toFSUnwatchMessage(json: string): FSUnwatchMessage {
+        return cast(JSON.parse(json), r("FSUnwatchMessage"));
+    }
+
+    public static fSUnwatchMessageToJson(value: FSUnwatchMessage): string {
+        return JSON.stringify(uncast(value, r("FSUnwatchMessage")), null, 2);
+    }
+
+    public static toFSUnwatchResultMessage(json: string): FSUnwatchResultMessage {
+        return cast(JSON.parse(json), r("FSUnwatchResultMessage"));
+    }
+
+    public static fSUnwatchResultMessageToJson(value: FSUnwatchResultMessage): string {
+        return JSON.stringify(uncast(value, r("FSUnwatchResultMessage")), null, 2);
+    }
+
+    public static toFSWatchMessage(json: string): FSWatchMessage {
+        return cast(JSON.parse(json), r("FSWatchMessage"));
+    }
+
+    public static fSWatchMessageToJson(value: FSWatchMessage): string {
+        return JSON.stringify(uncast(value, r("FSWatchMessage")), null, 2);
+    }
+
+    public static toFSWatchResultMessage(json: string): FSWatchResultMessage {
+        return cast(JSON.parse(json), r("FSWatchResultMessage"));
+    }
+
+    public static fSWatchResultMessageToJson(value: FSWatchResultMessage): string {
+        return JSON.stringify(uncast(value, r("FSWatchResultMessage")), null, 2);
+    }
+
     public static toFSWriteMessage(json: string): FSWriteMessage {
         return cast(JSON.parse(json), r("FSWriteMessage"));
     }
@@ -8359,6 +8443,30 @@ const typeMap: any = {
         { json: "new_path", js: "new_path", typ: "" },
         { json: "path", js: "path", typ: "" },
     ], "any"),
+    "FSUnwatchMessage": o([
+        { json: "cmd", js: "cmd", typ: r("FSUnwatchMessageCmd") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "root", js: "root", typ: u(undefined, "") },
+    ], "any"),
+    "FSUnwatchResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("FSUnwatchResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "root", js: "root", typ: u(undefined, "") },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "FSWatchMessage": o([
+        { json: "cmd", js: "cmd", typ: r("FSWatchMessageCmd") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "root", js: "root", typ: u(undefined, "") },
+    ], "any"),
+    "FSWatchResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("FSWatchResultMessageEvent") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "root", js: "root", typ: u(undefined, "") },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
     "FSWriteMessage": o([
         { json: "base_hash", js: "base_hash", typ: u(undefined, "") },
         { json: "cmd", js: "cmd", typ: r("FSWriteMessageCmd") },
@@ -10681,6 +10789,18 @@ const typeMap: any = {
     ],
     "FSRenameResultMessageEvent": [
         "fs_rename_result",
+    ],
+    "FSUnwatchMessageCmd": [
+        "fs_unwatch",
+    ],
+    "FSUnwatchResultMessageEvent": [
+        "fs_unwatch_result",
+    ],
+    "FSWatchMessageCmd": [
+        "fs_watch",
+    ],
+    "FSWatchResultMessageEvent": [
+        "fs_watch_result",
     ],
     "FSWriteMessageCmd": [
         "fs_write",

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -202,6 +202,11 @@ type Daemon struct {
 	// other roots (arbitrary editor roots) get their own Store but no watcher yet.
 	fsMu                sync.Mutex
 	fsStores            map[string]*fsdoc.Store
+	// fsWatchMu guards fsWatchers, the per-root registry of client-refcounted
+	// watchers for fs_watch/fs_unwatch. Never holds an entry for the notebook
+	// root — that watcher is always-on via ensureNotebookWatcher instead.
+	fsWatchMu           sync.Mutex
+	fsWatchers          map[string]*fsRootWatch
 	pendingInitialWS    map[*wsClient]struct{}
 	startedOnce         sync.Once
 	startedCh           chan struct{}
@@ -1416,6 +1421,7 @@ func (d *Daemon) Stop() {
 	d.log("daemon stopping")
 	close(d.done)
 	d.stopNotebookWatcher()
+	d.stopFsWatchers()
 	if runner := d.compactRunnerRef(); runner != nil {
 		runner.Stop()
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -200,8 +200,8 @@ type Daemon struct {
 	// The notebook-root entry is the raw layer beneath the curated notebook
 	// surface and shares the one root watcher started by ensureNotebookWatcher;
 	// other roots (arbitrary editor roots) get their own Store but no watcher yet.
-	fsMu                sync.Mutex
-	fsStores            map[string]*fsdoc.Store
+	fsMu     sync.Mutex
+	fsStores map[string]*fsdoc.Store
 	// fsWatchMu guards fsWatchers, the per-root registry of client-refcounted
 	// watchers for fs_watch/fs_unwatch. Never holds an entry for the notebook
 	// root — that watcher is always-on via ensureNotebookWatcher instead.

--- a/internal/daemon/fs.go
+++ b/internal/daemon/fs.go
@@ -71,11 +71,12 @@ func (d *Daemon) resolveFsRoot(client *wsClient, raw string) (string, error) {
 
 // fsStoreFor returns the daemon's generic filesystem Store for rawRoot,
 // resolving it first (see resolveFsRoot). Stores are cached per resolved root
-// so writes to the same root serialize through one in-process writer. Only the
-// notebook root gets the shared external-edit watcher today (ensureNotebookWatcher);
-// other roots get a Store but no watcher — that lands with the non-text editor
-// work (PR2). Returns the resolved root alongside the store so callers can key
-// broadcasts and notebook-coupling decisions on it without re-resolving.
+// so writes to the same root serialize through one in-process writer. The
+// notebook root always gets the shared external-edit watcher
+// (ensureNotebookWatcher); other roots only get a live watcher once a client
+// holds them open via fs_watch (see fs_watch.go). Returns the resolved root
+// alongside the store so callers can key broadcasts and notebook-coupling
+// decisions on it without re-resolving.
 func (d *Daemon) fsStoreFor(client *wsClient, rawRoot string) (*fsdoc.Store, string, error) {
 	root, err := d.resolveFsRoot(client, rawRoot)
 	if err != nil {
@@ -258,11 +259,14 @@ func (d *Daemon) sendFsWriteWSResult(client *wsClient, requestID, path, content,
 				result.Hash = protocol.Ptr(hash)
 				if d.isNotebookRoot(root) {
 					// Content-aware self-write so the shared watcher does not surface this
-					// UI edit as an external one. NoteSelfWrite keys on the notebook's
-					// CleanPath, so it only registers a .md path — which is exactly the set
-					// the watcher can report today; a non-.md write fires no watcher event,
-					// so there is nothing to suppress for it either way.
+					// UI edit as an external one. The notebook watcher now runs a generic
+					// cleaner (fsdoc.CleanPath, see ensureNotebookWatcher), so this also
+					// suppresses a non-.md write from echoing back as external.
 					d.noteNotebookSelfWrite(notebook.SelfWrite{Rel: changed, Hash: hash})
+				} else if w := d.fsWatcherFor(root); w != nil {
+					// Same suppression for a generic editor root under an active fs_watch:
+					// without it, a UI fs_write would echo back as its own external edit.
+					w.NoteSelfWrite(notebook.SelfWrite{Rel: changed, Hash: hash})
 				}
 				d.broadcastFsChanged(root, originUI, changed)
 			}
@@ -300,6 +304,11 @@ func (d *Daemon) sendFsRenameWSResult(client *wsClient, requestID, oldPath, newP
 					notebook.SelfWrite{Rel: oldRel},
 					notebook.SelfWrite{Rel: newRel, Hash: hash},
 				)
+			} else if w := d.fsWatcherFor(root); w != nil {
+				w.NoteSelfWrite(
+					notebook.SelfWrite{Rel: oldRel},
+					notebook.SelfWrite{Rel: newRel, Hash: hash},
+				)
 			}
 			err = store.Rename(oldRel, newRel)
 			if err == nil {
@@ -329,6 +338,8 @@ func (d *Daemon) sendFsDeleteWSResult(client *wsClient, requestID, path, rawRoot
 		inNotebook := d.isNotebookRoot(root)
 		if inNotebook {
 			d.noteNotebookSelfWrite(notebook.SelfWrite{Rel: rel})
+		} else if w := d.fsWatcherFor(root); w != nil {
+			w.NoteSelfWrite(notebook.SelfWrite{Rel: rel})
 		}
 		err = store.Delete(rel)
 		if err == nil {

--- a/internal/daemon/fs.go
+++ b/internal/daemon/fs.go
@@ -98,16 +98,26 @@ func (d *Daemon) fsStoreFor(client *wsClient, rawRoot string) (*fsdoc.Store, str
 	return store, root, nil
 }
 
-// broadcastFsChanged announces a filesystem change to all websocket clients.
-// origin is agent|ui|external, the same vocabulary as notebook_changed. root is
-// the resolved absolute root the change happened under.
+// broadcastFsChanged announces a filesystem change under root. For the
+// notebook root this goes to every websocket client, matching legacy
+// notebook_changed fan-out. For any other root — reachable only through an
+// explicit fs_watch, which resolveFsRoot gates on the trusted app client —
+// the absolute root path and changed paths are sensitive, so the event is
+// sent only to clients currently holding an fs_watch ref on that root; a
+// connected client that never subscribed sees nothing. origin is
+// agent|ui|external, the same vocabulary as notebook_changed.
 func (d *Daemon) broadcastFsChanged(root, origin string, paths ...string) {
-	d.broadcastMessage(protocol.FsChangedMessage{
+	msg := protocol.FsChangedMessage{
 		Event:  protocol.EventFsChanged,
 		Paths:  paths,
 		Origin: origin,
 		Root:   root,
-	})
+	}
+	if d.isNotebookRoot(root) {
+		d.broadcastMessage(msg)
+		return
+	}
+	d.sendFsChangedToWatchers(root, msg)
 }
 
 // sendFsListWSResult lists one directory's immediate children and replies with an

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -517,9 +517,13 @@ func TestFsCommandsWithExplicitRootActOnThatDirectory(t *testing.T) {
 	}
 	externalRoot := t.TempDir()
 
-	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
-	d.wsHub.clients[hubClient] = true
-	go d.wsHub.run()
+	// A generic root's fs_changed audience is its fs_watch subscribers, not
+	// every connected client (see broadcastFsChanged), so watch externalRoot
+	// to observe the write's broadcast.
+	watchClient := trustedFsClient(4)
+	if res := fsWatch(t, d, watchClient, "w1", externalRoot); !res.Success {
+		t.Fatalf("fs_watch(externalRoot) = %+v", res)
+	}
 
 	write := fsWriteCASRoot(t, d, "notes/todo.txt", "buy milk", "", externalRoot)
 	if !write.Success || write.Result == nil || write.Result.Conflict || write.Result.Hash == nil {
@@ -550,7 +554,7 @@ func TestFsCommandsWithExplicitRootActOnThatDirectory(t *testing.T) {
 		t.Fatalf("read under explicit root = %+v", read.Result)
 	}
 
-	ev := waitForFsChangeWithRoot(t, hubClient.send, originUI)
+	ev := waitForFsChangeWithRoot(t, watchClient.send, originUI)
 	if !slices.Contains(ev.Paths, "notes/todo.txt") {
 		t.Fatalf("ui fs_changed paths = %v, want notes/todo.txt", ev.Paths)
 	}
@@ -586,14 +590,18 @@ func waitForFsChangeWithRoot(t *testing.T, ch chan outboundMessage, origin strin
 func TestFsWriteBroadcastsResolvedRoot(t *testing.T) {
 	d := newFsDaemon(t)
 	externalRoot := t.TempDir()
-	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
-	d.wsHub.clients[hubClient] = true
-	go d.wsHub.run()
+
+	// A generic root's fs_changed audience is its fs_watch subscribers, not
+	// every connected client (see broadcastFsChanged).
+	watchClient := trustedFsClient(4)
+	if res := fsWatch(t, d, watchClient, "w1", externalRoot); !res.Success {
+		t.Fatalf("fs_watch(externalRoot) = %+v", res)
+	}
 
 	if res := fsWriteCASRoot(t, d, "a.txt", "x", "", externalRoot); !res.Success || res.Result == nil {
 		t.Fatalf("write = %+v", res.Result)
 	}
-	ev := waitForFsChangeWithRoot(t, hubClient.send, originUI)
+	ev := waitForFsChangeWithRoot(t, watchClient.send, originUI)
 	if ev.Root != externalRoot {
 		t.Fatalf("fs_changed.root = %q, want %q", ev.Root, externalRoot)
 	}
@@ -887,13 +895,22 @@ func TestFsRenameDeleteNotebookCouplingIsRootConditional(t *testing.T) {
 	d.wsHub.clients[hubClient] = true
 	go d.wsHub.run()
 
+	// A generic root's fs_changed audience is its fs_watch subscribers, not
+	// every connected client (see broadcastFsChanged), so watch externalRoot
+	// to observe its write/rename/delete broadcasts below. notebook_changed
+	// stays global, so hubClient still covers the assertNoBroadcast checks.
+	watchClient := trustedFsClient(8)
+	if res := fsWatch(t, d, watchClient, "w1", externalRoot); !res.Success {
+		t.Fatalf("fs_watch(externalRoot) = %+v", res)
+	}
+
 	// --- foreign root: rename ---
 	if res := fsWriteCASRoot(t, d, "a.md", "x", "", externalRoot); !res.Success || res.Result == nil {
 		t.Fatalf("seed write (external) = %+v", res.Result)
 	}
 	// Drain the seed write's own fs_changed(a.md) so the rename's broadcast below
 	// is the one actually asserted on.
-	waitForFsChange(t, hubClient.send, originUI)
+	waitForFsChange(t, watchClient.send, originUI)
 	renameClient := trustedFsClient(4)
 	d.sendFsRenameWSResult(renameClient, "rn1", "a.md", "b.md", externalRoot)
 	var renameRes protocol.FsRenameResultMessage
@@ -902,7 +919,7 @@ func TestFsRenameDeleteNotebookCouplingIsRootConditional(t *testing.T) {
 		t.Fatalf("rename (external root) = %+v", renameRes)
 	}
 	assertNoBroadcast(t, hubClient.send, protocol.EventNotebookChanged, 300*time.Millisecond)
-	if got := waitForFsChange(t, hubClient.send, originUI); !slices.Contains(got, "b.md") {
+	if got := waitForFsChange(t, watchClient.send, originUI); !slices.Contains(got, "b.md") {
 		t.Fatalf("fs_changed after external rename = %v, want b.md", got)
 	}
 
@@ -915,7 +932,7 @@ func TestFsRenameDeleteNotebookCouplingIsRootConditional(t *testing.T) {
 		t.Fatalf("delete (external root) = %+v", deleteRes)
 	}
 	assertNoBroadcast(t, hubClient.send, protocol.EventNotebookChanged, 300*time.Millisecond)
-	if got := waitForFsChange(t, hubClient.send, originUI); !slices.Contains(got, "b.md") {
+	if got := waitForFsChange(t, watchClient.send, originUI); !slices.Contains(got, "b.md") {
 		t.Fatalf("fs_changed after external delete = %v, want b.md", got)
 	}
 

--- a/internal/daemon/fs_watch.go
+++ b/internal/daemon/fs_watch.go
@@ -1,0 +1,171 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/victorarias/attn/internal/fsdoc"
+	"github.com/victorarias/attn/internal/notebook"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// maxFsWatchers caps the number of live non-notebook watchers at once. Each is
+// a goroutine + an OS watch handle (kqueue fd), so this is a resource bound, not
+// a UI limit — a client that wants more must fs_unwatch something first.
+const maxFsWatchers = 16
+
+// fsRootWatch is one live generic-root watcher plus the clients holding it open.
+// Never created for the notebook root — that watcher is always-on via
+// ensureNotebookWatcher, independent of any client subscription.
+type fsRootWatch struct {
+	watcher *notebook.Watcher
+	refs    map[*wsClient]int // per-client refcount
+}
+
+// handleFsWatch subscribes client to fs_changed broadcasts for rawRoot: it
+// resolves the root through resolveFsRoot — the single chokepoint that gates
+// an explicit root on the authenticated app client, so fs_watch inherits that
+// gate with no separate check here — and for any root other than the notebook
+// root, starts a live watcher on first subscriber (refcounted so repeat calls
+// and multiple clients share one watcher). The notebook root is always watched
+// already, so fs_watch on it is a success no-op that does not touch the
+// registry. Replies with an fs_watch_result event correlated by requestID.
+func (d *Daemon) handleFsWatch(client *wsClient, requestID, rawRoot string) {
+	root, err := d.resolveFsRoot(client, rawRoot)
+	if err == nil && !d.isNotebookRoot(root) {
+		err = d.addFsWatchRef(client, root)
+	}
+	msg := protocol.FsWatchResultMessage{
+		Event:     protocol.EventFsWatchResult,
+		RequestID: requestID,
+		Success:   err == nil,
+	}
+	if err == nil {
+		msg.Root = protocol.Ptr(root)
+	} else {
+		msg.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, msg)
+}
+
+// handleFsUnwatch drops client's subscription to rawRoot, closing the watcher
+// once no client holds it open. The notebook root is a success no-op (nothing
+// to unwatch — it stays alive independent of subscriptions). Unwatching a root
+// this client never watched is also a success no-op. Replies with an
+// fs_unwatch_result event correlated by requestID.
+func (d *Daemon) handleFsUnwatch(client *wsClient, requestID, rawRoot string) {
+	root, err := d.resolveFsRoot(client, rawRoot)
+	if err == nil && !d.isNotebookRoot(root) {
+		d.dropFsWatchRef(client, root)
+	}
+	msg := protocol.FsUnwatchResultMessage{
+		Event:     protocol.EventFsUnwatchResult,
+		RequestID: requestID,
+		Success:   err == nil,
+	}
+	if err == nil {
+		msg.Root = protocol.Ptr(root)
+	} else {
+		msg.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, msg)
+}
+
+// addFsWatchRef increments client's ref on root's watcher, creating it (and the
+// registry entry) on the first subscriber. Returns an error if root cannot be
+// watched (e.g. it does not exist) or the live-watcher cap is exceeded.
+func (d *Daemon) addFsWatchRef(client *wsClient, root string) error {
+	d.fsWatchMu.Lock()
+	defer d.fsWatchMu.Unlock()
+	if d.fsWatchers == nil {
+		d.fsWatchers = make(map[string]*fsRootWatch)
+	}
+	entry, ok := d.fsWatchers[root]
+	if !ok {
+		if len(d.fsWatchers) >= maxFsWatchers {
+			return fmt.Errorf("too many watched roots")
+		}
+		w, err := notebook.NewWatcherWithCleaner(root, notebook.DefaultWatchDebounce, fsdoc.CleanPath, func(paths []string) {
+			d.broadcastFsChanged(root, originExternal, paths...)
+		})
+		if err != nil {
+			return err
+		}
+		entry = &fsRootWatch{watcher: w, refs: make(map[*wsClient]int)}
+		d.fsWatchers[root] = entry
+	}
+	entry.refs[client]++
+	return nil
+}
+
+// dropFsWatchRef decrements client's ref on root's watcher, deleting the ref (at
+// zero) and closing+deleting the watcher entry once no client holds it. A no-op
+// if root has no live registry entry or client never held a ref on it.
+func (d *Daemon) dropFsWatchRef(client *wsClient, root string) {
+	d.fsWatchMu.Lock()
+	entry, ok := d.fsWatchers[root]
+	if !ok {
+		d.fsWatchMu.Unlock()
+		return
+	}
+	if entry.refs[client] > 1 {
+		entry.refs[client]--
+		d.fsWatchMu.Unlock()
+		return
+	}
+	delete(entry.refs, client)
+	var toClose *notebook.Watcher
+	if len(entry.refs) == 0 {
+		delete(d.fsWatchers, root)
+		toClose = entry.watcher
+	}
+	d.fsWatchMu.Unlock()
+	// Close outside fsWatchMu: it joins the watcher's loop goroutine and can
+	// block briefly.
+	_ = toClose.Close()
+}
+
+// dropFsWatchClient removes client's refs from every fs_watch registry entry
+// (called on websocket client disconnect), closing and deleting any entry that
+// reaches zero clients as a result.
+func (d *Daemon) dropFsWatchClient(client *wsClient) {
+	d.fsWatchMu.Lock()
+	var toClose []*notebook.Watcher
+	for root, entry := range d.fsWatchers {
+		if _, held := entry.refs[client]; !held {
+			continue
+		}
+		delete(entry.refs, client)
+		if len(entry.refs) == 0 {
+			delete(d.fsWatchers, root)
+			toClose = append(toClose, entry.watcher)
+		}
+	}
+	d.fsWatchMu.Unlock()
+	for _, w := range toClose {
+		_ = w.Close()
+	}
+}
+
+// stopFsWatchers closes every live registry watcher (daemon shutdown).
+func (d *Daemon) stopFsWatchers() {
+	d.fsWatchMu.Lock()
+	watchers := d.fsWatchers
+	d.fsWatchers = nil
+	d.fsWatchMu.Unlock()
+	for _, entry := range watchers {
+		_ = entry.watcher.Close()
+	}
+}
+
+// fsWatcherFor returns the live registry watcher for root, or nil if none is
+// active (root is unwatched, or is the notebook root — which is never in this
+// registry).
+func (d *Daemon) fsWatcherFor(root string) *notebook.Watcher {
+	d.fsWatchMu.Lock()
+	defer d.fsWatchMu.Unlock()
+	entry, ok := d.fsWatchers[root]
+	if !ok {
+		return nil
+	}
+	return entry.watcher
+}

--- a/internal/daemon/fs_watch.go
+++ b/internal/daemon/fs_watch.go
@@ -169,3 +169,25 @@ func (d *Daemon) fsWatcherFor(root string) *notebook.Watcher {
 	}
 	return entry.watcher
 }
+
+// sendFsChangedToWatchers delivers msg only to the clients currently holding
+// an fs_watch ref on root — the audience restriction that keeps a generic
+// editor root's absolute path and changed paths from leaking to a connected
+// client that never subscribed to it. A no-op if root has no live registry
+// entry (e.g. the last subscriber unwatched between the change firing and
+// this call).
+func (d *Daemon) sendFsChangedToWatchers(root string, msg protocol.FsChangedMessage) {
+	d.fsWatchMu.Lock()
+	entry, ok := d.fsWatchers[root]
+	var clients []*wsClient
+	if ok {
+		clients = make([]*wsClient, 0, len(entry.refs))
+		for c := range entry.refs {
+			clients = append(clients, c)
+		}
+	}
+	d.fsWatchMu.Unlock()
+	for _, c := range clients {
+		d.sendToClient(c, msg)
+	}
+}

--- a/internal/daemon/fs_watch_test.go
+++ b/internal/daemon/fs_watch_test.go
@@ -1,0 +1,271 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// fsWatch drives handleFsWatch directly and returns the decoded result event.
+func fsWatch(t *testing.T, d *Daemon, client *wsClient, requestID, root string) protocol.FsWatchResultMessage {
+	t.Helper()
+	d.handleFsWatch(client, requestID, root)
+	var res protocol.FsWatchResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	return res
+}
+
+// fsUnwatch drives handleFsUnwatch directly and returns the decoded result event.
+func fsUnwatch(t *testing.T, d *Daemon, client *wsClient, requestID, root string) protocol.FsUnwatchResultMessage {
+	t.Helper()
+	d.handleFsUnwatch(client, requestID, root)
+	var res protocol.FsUnwatchResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	return res
+}
+
+// assertNoFsChangedForRoot fails the test if an fs_changed broadcast for the
+// given (root, origin) pair shows up on ch within the wait window. Any other
+// events (including fs_changed for a different root/origin) are drained and
+// re-queued so a later assertion in the same test still sees them.
+func assertNoFsChangedForRoot(t *testing.T, ch chan outboundMessage, root, origin string, wait time.Duration) {
+	t.Helper()
+	deadline := time.After(wait)
+	var drained []outboundMessage
+	for {
+		select {
+		case msg := <-ch:
+			var ev protocol.FsChangedMessage
+			if err := json.Unmarshal(msg.payload, &ev); err == nil &&
+				ev.Event == protocol.EventFsChanged && ev.Root == root && ev.Origin == origin {
+				t.Fatalf("unexpected fs_changed(root=%q origin=%q)", root, origin)
+			}
+			drained = append(drained, msg)
+		case <-deadline:
+			for _, m := range drained {
+				ch <- m
+			}
+			return
+		}
+	}
+}
+
+// fs_watch on a generic (non-notebook) root starts a live watcher whose external
+// edits surface as fs_changed(origin=external) for ANY file type — catching a
+// watcher that failed to start, or one still filtered to .md-only paths.
+func TestFsWatchExternalEditSurfacesForAnyFileType(t *testing.T) {
+	d := newFsDaemon(t)
+	root := t.TempDir()
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	watchClient := trustedFsClient(8)
+	res := fsWatch(t, d, watchClient, "w1", root)
+	if !res.Success || res.Root == nil || *res.Root != root {
+		t.Fatalf("fs_watch result = %+v", res)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "note.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ev := waitForFsChangeWithRoot(t, hubClient.send, originExternal)
+	if ev.Root != root || !slices.Contains(ev.Paths, "note.txt") {
+		t.Fatalf("external fs_changed = %+v, want root=%q paths containing note.txt", ev, root)
+	}
+}
+
+// Once fs_unwatch drops the last ref on a root, its watcher must actually stop:
+// a subsequent external write produces no fs_changed for that root. Catches a
+// leaked watcher that keeps running after the last subscriber leaves.
+func TestFsUnwatchStopsWatcherAtZeroRefs(t *testing.T) {
+	d := newFsDaemon(t)
+	root := t.TempDir()
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	client := trustedFsClient(8)
+	if res := fsWatch(t, d, client, "w1", root); !res.Success {
+		t.Fatalf("fs_watch = %+v", res)
+	}
+	if res := fsUnwatch(t, d, client, "u1", root); !res.Success {
+		t.Fatalf("fs_unwatch = %+v", res)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "after-unwatch.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assertNoFsChangedForRoot(t, hubClient.send, root, originExternal, 700*time.Millisecond)
+}
+
+// Two clients watching the same root: dropping one client's refs (as disconnect
+// does) must not close the watcher while the other client still holds it; only
+// once the last client unwatches does the watcher actually stop. Catches
+// disconnect cleanup closing too eagerly, or a refcount leak that never closes.
+func TestFsWatchRefcountedAcrossClients(t *testing.T) {
+	d := newFsDaemon(t)
+	root := t.TempDir()
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	clientA := trustedFsClient(8)
+	clientB := trustedFsClient(8)
+	if res := fsWatch(t, d, clientA, "wa", root); !res.Success {
+		t.Fatalf("fs_watch A = %+v", res)
+	}
+	if res := fsWatch(t, d, clientB, "wb", root); !res.Success {
+		t.Fatalf("fs_watch B = %+v", res)
+	}
+
+	d.dropFsWatchClient(clientA)
+
+	if err := os.WriteFile(filepath.Join(root, "still-watched.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ev := waitForFsChangeWithRoot(t, hubClient.send, originExternal)
+	if ev.Root != root || !slices.Contains(ev.Paths, "still-watched.txt") {
+		t.Fatalf("fs_changed after dropping one client = %+v", ev)
+	}
+
+	if res := fsUnwatch(t, d, clientB, "ub", root); !res.Success {
+		t.Fatalf("fs_unwatch B = %+v", res)
+	}
+	if err := os.WriteFile(filepath.Join(root, "no-longer-watched.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assertNoFsChangedForRoot(t, hubClient.send, root, originExternal, 700*time.Millisecond)
+}
+
+// A WS fs_write to a watched generic root must not echo back as its own
+// fs_changed(origin=external) — the self-write suppression must apply to
+// non-notebook watchers too, not just the notebook watcher. The origin=ui
+// broadcast from the write itself still fires as normal.
+func TestFsWatchSelfWriteNotEchoedAsExternal(t *testing.T) {
+	d := newFsDaemon(t)
+	root := t.TempDir()
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	watchClient := trustedFsClient(8)
+	if res := fsWatch(t, d, watchClient, "w1", root); !res.Success {
+		t.Fatalf("fs_watch = %+v", res)
+	}
+
+	if res := fsWriteCASRoot(t, d, "own.txt", "attn wrote this", "", root); !res.Success || res.Result == nil {
+		t.Fatalf("write = %+v", res.Result)
+	}
+
+	ev := waitForFsChangeWithRoot(t, hubClient.send, originUI)
+	if !slices.Contains(ev.Paths, "own.txt") {
+		t.Fatalf("ui fs_changed = %+v, want own.txt", ev)
+	}
+	assertNoFsChangedForRoot(t, hubClient.send, root, originExternal, 700*time.Millisecond)
+}
+
+// The notebook root's watcher is now generic: an external edit to a non-.md file
+// must surface as fs_changed but must NOT also fire notebook_changed (a .txt
+// file is not a note), while an external .md edit must fire BOTH. Catches a
+// broken split in the notebook watcher's onChange wiring.
+func TestNotebookRootWatcherSplitsFsAndNotebookBroadcasts(t *testing.T) {
+	d := newFsDaemon(t)
+	root := d.store.GetSetting(SettingNotebookRoot)
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	// Touch the notebook so the always-on watcher starts, then let it settle.
+	listFs(t, d, "")
+	time.Sleep(80 * time.Millisecond)
+
+	if err := os.WriteFile(filepath.Join(root, "plain.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ev := waitForFsChangeWithRoot(t, hubClient.send, originExternal)
+	if !slices.Contains(ev.Paths, "plain.txt") {
+		t.Fatalf("external fs_changed = %+v, want plain.txt", ev)
+	}
+	assertNoBroadcast(t, hubClient.send, protocol.EventNotebookChanged, 300*time.Millisecond)
+
+	if err := os.WriteFile(filepath.Join(root, "note.md"), []byte("---\ntype: note\n---\nhi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fsEv := waitForFsChangeWithRoot(t, hubClient.send, originExternal)
+	if !slices.Contains(fsEv.Paths, "note.md") {
+		t.Fatalf("external fs_changed = %+v, want note.md", fsEv)
+	}
+	nbPaths := waitForNotebookChangeEvent(t, hubClient.send)
+	if !slices.Contains(nbPaths, "note.md") {
+		t.Fatalf("notebook_changed = %v, want note.md", nbPaths)
+	}
+}
+
+// A 17th distinct watched root is rejected with a clear error, bounding the
+// number of live non-notebook watchers so a client cannot grow the daemon's
+// goroutine/fd count without limit.
+func TestFsWatchCapsLiveWatchers(t *testing.T) {
+	d := newFsDaemon(t)
+	client := trustedFsClient(32)
+	for i := 0; i < maxFsWatchers; i++ {
+		root := t.TempDir()
+		res := fsWatch(t, d, client, "w", root)
+		if !res.Success {
+			t.Fatalf("fs_watch #%d = %+v, want success", i, res)
+		}
+	}
+	overflowRoot := t.TempDir()
+	res := fsWatch(t, d, client, "overflow", overflowRoot)
+	if res.Success || res.Error == nil || *res.Error != "too many watched roots" {
+		t.Fatalf("fs_watch(17th root) = %+v, want failure with 'too many watched roots'", res)
+	}
+}
+
+// fs_watch inherits the fs surface's root-auth gate via resolveFsRoot: an
+// ordinary (unauthenticated) client asking to watch an explicit root must be
+// denied, and — the behavior that actually matters, not just the reported
+// error — no watcher must be registered for it, so a direct external write
+// under that root produces no fs_changed at all. Catches handleFsWatch
+// bypassing the resolveFsRoot chokepoint (e.g. calling addFsWatchRef before
+// checking the resolve error, or checking success but not identity).
+func TestFsWatchWithExplicitRootDeniedForUntrustedClient(t *testing.T) {
+	d := newFsDaemon(t)
+	root := t.TempDir()
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	untrusted := &wsClient{send: make(chan outboundMessage, 8)}
+	res := fsWatch(t, d, untrusted, "w1", root)
+	if res.Success || res.Error == nil {
+		t.Fatalf("fs_watch(explicit root, untrusted client) = %+v, want failure", res)
+	}
+	if !strings.Contains(*res.Error, "authenticated") {
+		t.Fatalf("fs_watch(explicit root, untrusted client) error = %q, want it to mention the authenticated app", *res.Error)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "unwatched.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assertNoFsChangedForRoot(t, hubClient.send, root, originExternal, 700*time.Millisecond)
+}
+
+// The same untrusted client must still succeed watching with root omitted (the
+// notebook root) — the gate is scoped to the explicit-root escape hatch, not
+// fs_watch as a whole.
+func TestFsWatchOmittedRootStillWorksForUntrustedClient(t *testing.T) {
+	d := newFsDaemon(t)
+	untrusted := &wsClient{send: make(chan outboundMessage, 8)}
+	res := fsWatch(t, d, untrusted, "w1", "")
+	if !res.Success {
+		t.Fatalf("fs_watch(omitted root, untrusted client) = %+v, want success", res)
+	}
+}

--- a/internal/daemon/fs_watch_test.go
+++ b/internal/daemon/fs_watch_test.go
@@ -58,13 +58,14 @@ func assertNoFsChangedForRoot(t *testing.T, ch chan outboundMessage, root, origi
 
 // fs_watch on a generic (non-notebook) root starts a live watcher whose external
 // edits surface as fs_changed(origin=external) for ANY file type — catching a
-// watcher that failed to start, or one still filtered to .md-only paths.
+// watcher that failed to start, or one still filtered to .md-only paths. The
+// event is delivered to the subscribed client directly, not via the hub
+// broadcast: a generic root's fs_changed audience is the watch's own
+// subscriber set (see TestFsWatchAudienceRestrictedToSubscribers), not every
+// connected client.
 func TestFsWatchExternalEditSurfacesForAnyFileType(t *testing.T) {
 	d := newFsDaemon(t)
 	root := t.TempDir()
-	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
-	d.wsHub.clients[hubClient] = true
-	go d.wsHub.run()
 
 	watchClient := trustedFsClient(8)
 	res := fsWatch(t, d, watchClient, "w1", root)
@@ -76,10 +77,40 @@ func TestFsWatchExternalEditSurfacesForAnyFileType(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ev := waitForFsChangeWithRoot(t, hubClient.send, originExternal)
+	ev := waitForFsChangeWithRoot(t, watchClient.send, originExternal)
 	if ev.Root != root || !slices.Contains(ev.Paths, "note.txt") {
 		t.Fatalf("external fs_changed = %+v, want root=%q paths containing note.txt", ev, root)
 	}
+}
+
+// The audience restriction that fixes the trust-boundary leak: a generic
+// root's fs_changed must reach only clients that hold an fs_watch ref on that
+// root. A second connected (and even trusted) client that never subscribed —
+// and the hub's broadcast path — must see nothing, even though the notebook
+// root's fs_changed still goes to everyone.
+func TestFsWatchAudienceRestrictedToSubscribers(t *testing.T) {
+	d := newFsDaemon(t)
+	root := t.TempDir()
+	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
+	d.wsHub.clients[hubClient] = true
+	go d.wsHub.run()
+
+	watchClient := trustedFsClient(8)
+	nonSubscriber := trustedFsClient(8)
+	if res := fsWatch(t, d, watchClient, "w1", root); !res.Success {
+		t.Fatalf("fs_watch = %+v", res)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "note.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ev := waitForFsChangeWithRoot(t, watchClient.send, originExternal)
+	if ev.Root != root || !slices.Contains(ev.Paths, "note.txt") {
+		t.Fatalf("subscriber fs_changed = %+v, want root=%q paths containing note.txt", ev, root)
+	}
+	assertNoFsChangedForRoot(t, hubClient.send, root, originExternal, 700*time.Millisecond)
+	assertNoFsChangedForRoot(t, nonSubscriber.send, root, originExternal, 700*time.Millisecond)
 }
 
 // Once fs_unwatch drops the last ref on a root, its watcher must actually stop:
@@ -88,9 +119,6 @@ func TestFsWatchExternalEditSurfacesForAnyFileType(t *testing.T) {
 func TestFsUnwatchStopsWatcherAtZeroRefs(t *testing.T) {
 	d := newFsDaemon(t)
 	root := t.TempDir()
-	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
-	d.wsHub.clients[hubClient] = true
-	go d.wsHub.run()
 
 	client := trustedFsClient(8)
 	if res := fsWatch(t, d, client, "w1", root); !res.Success {
@@ -103,7 +131,7 @@ func TestFsUnwatchStopsWatcherAtZeroRefs(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "after-unwatch.txt"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	assertNoFsChangedForRoot(t, hubClient.send, root, originExternal, 700*time.Millisecond)
+	assertNoFsChangedForRoot(t, client.send, root, originExternal, 700*time.Millisecond)
 }
 
 // Two clients watching the same root: dropping one client's refs (as disconnect
@@ -113,9 +141,6 @@ func TestFsUnwatchStopsWatcherAtZeroRefs(t *testing.T) {
 func TestFsWatchRefcountedAcrossClients(t *testing.T) {
 	d := newFsDaemon(t)
 	root := t.TempDir()
-	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
-	d.wsHub.clients[hubClient] = true
-	go d.wsHub.run()
 
 	clientA := trustedFsClient(8)
 	clientB := trustedFsClient(8)
@@ -131,7 +156,7 @@ func TestFsWatchRefcountedAcrossClients(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "still-watched.txt"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ev := waitForFsChangeWithRoot(t, hubClient.send, originExternal)
+	ev := waitForFsChangeWithRoot(t, clientB.send, originExternal)
 	if ev.Root != root || !slices.Contains(ev.Paths, "still-watched.txt") {
 		t.Fatalf("fs_changed after dropping one client = %+v", ev)
 	}
@@ -142,7 +167,7 @@ func TestFsWatchRefcountedAcrossClients(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "no-longer-watched.txt"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	assertNoFsChangedForRoot(t, hubClient.send, root, originExternal, 700*time.Millisecond)
+	assertNoFsChangedForRoot(t, clientB.send, root, originExternal, 700*time.Millisecond)
 }
 
 // A WS fs_write to a watched generic root must not echo back as its own
@@ -152,9 +177,6 @@ func TestFsWatchRefcountedAcrossClients(t *testing.T) {
 func TestFsWatchSelfWriteNotEchoedAsExternal(t *testing.T) {
 	d := newFsDaemon(t)
 	root := t.TempDir()
-	hubClient := &wsClient{send: make(chan outboundMessage, 64)}
-	d.wsHub.clients[hubClient] = true
-	go d.wsHub.run()
 
 	watchClient := trustedFsClient(8)
 	if res := fsWatch(t, d, watchClient, "w1", root); !res.Success {
@@ -165,11 +187,11 @@ func TestFsWatchSelfWriteNotEchoedAsExternal(t *testing.T) {
 		t.Fatalf("write = %+v", res.Result)
 	}
 
-	ev := waitForFsChangeWithRoot(t, hubClient.send, originUI)
+	ev := waitForFsChangeWithRoot(t, watchClient.send, originUI)
 	if !slices.Contains(ev.Paths, "own.txt") {
 		t.Fatalf("ui fs_changed = %+v, want own.txt", ev)
 	}
-	assertNoFsChangedForRoot(t, hubClient.send, root, originExternal, 700*time.Millisecond)
+	assertNoFsChangedForRoot(t, watchClient.send, root, originExternal, 700*time.Millisecond)
 }
 
 // The notebook root's watcher is now generic: an external edit to a non-.md file

--- a/internal/daemon/notebook.go
+++ b/internal/daemon/notebook.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/fsdoc"
 	"github.com/victorarias/attn/internal/hooks"
 	"github.com/victorarias/attn/internal/notebook"
 	"github.com/victorarias/attn/internal/protocol"
@@ -76,12 +77,22 @@ func (d *Daemon) ensureNotebookWatcher(root string) {
 		d.notebookWatcher = nil
 		d.notebookWatchedRoot = ""
 	}
-	w, err := notebook.NewWatcher(root, notebook.DefaultWatchDebounce, func(paths []string) {
-		// One filesystem, two surfaces over it: external edits feed both the curated
-		// notebook view and the raw fs view. (The watcher only surfaces .md paths
-		// today, so fs_changed inherits that limit until the watcher is generalized.)
-		d.broadcastNotebookChanged(originExternal, paths...)
+	w, err := notebook.NewWatcherWithCleaner(root, notebook.DefaultWatchDebounce, fsdoc.CleanPath, func(paths []string) {
+		// One filesystem, two surfaces over it: fs_changed always fires with every
+		// changed path (the raw fs view is not markdown-aware). notebook_changed is
+		// the curated markdown-only subset, so it only fires for the paths that are
+		// also valid notebook notes — and not at all when none are, since an empty
+		// notebook_changed would misreport "something in the notebook changed".
 		d.broadcastFsChanged(root, originExternal, paths...)
+		var mdPaths []string
+		for _, p := range paths {
+			if _, err := notebook.CleanPath(p); err == nil {
+				mdPaths = append(mdPaths, p)
+			}
+		}
+		if len(mdPaths) > 0 {
+			d.broadcastNotebookChanged(originExternal, mdPaths...)
+		}
 	})
 	if err != nil {
 		d.logf("notebook watcher: failed to watch %s: %v", root, err)

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -781,6 +781,7 @@ func (d *Daemon) wsReadPump(client *wsClient) {
 	defer func() {
 		d.dropPendingInitialState(client)
 		d.cleanupRemoteGitStatusSubscription(client)
+		d.dropFsWatchClient(client)
 		d.detachAllSessions(client)
 		close(client.recv) // signal wsMsgPump to exit
 		d.wsHub.unregister <- client
@@ -957,6 +958,12 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 	case protocol.CmdFsExists:
 		fsExists := msg.(*protocol.FsExistsMessage)
 		go d.sendFsExistsWSResult(client, protocol.Deref(fsExists.RequestID), fsExists.Path, protocol.Deref(fsExists.Root))
+	case protocol.CmdFsWatch:
+		fsWatch := msg.(*protocol.FsWatchMessage)
+		go d.handleFsWatch(client, protocol.Deref(fsWatch.RequestID), protocol.Deref(fsWatch.Root))
+	case protocol.CmdFsUnwatch:
+		fsUnwatch := msg.(*protocol.FsUnwatchMessage)
+		go d.handleFsUnwatch(client, protocol.Deref(fsUnwatch.RequestID), protocol.Deref(fsUnwatch.Root))
 	case protocol.CmdApprovePR:
 		d.handleApprovePRWS(client, msg.(*protocol.ApprovePRMessage))
 	case protocol.CmdMergePR:

--- a/internal/fsdoc/store.go
+++ b/internal/fsdoc/store.go
@@ -378,11 +378,14 @@ func (s *Store) abs(rel string) (string, error) {
 // directories, writes a uniquely-named temp file in the same directory, then
 // renames it into place. The temp file is removed on any error. (A focused copy
 // of the notebook's identical helper; both keep the same atomic-write semantics.)
+// The temp name is dot-prefixed so it falls outside CleanPath's trackable set:
+// fsdoc has no extension filter, so without this a watcher on the root would see
+// the transient swap file's own fsnotify events as a change to a real path.
 func writeAtomic(absPath string, content []byte) error {
 	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 		return err
 	}
-	tmp := fmt.Sprintf("%s.tmp.%d.%d", absPath, os.Getpid(), time.Now().UnixNano())
+	tmp := filepath.Join(filepath.Dir(absPath), fmt.Sprintf(".%s.tmp.%d.%d", filepath.Base(absPath), os.Getpid(), time.Now().UnixNano()))
 	if err := os.WriteFile(tmp, content, 0o644); err != nil {
 		_ = os.Remove(tmp)
 		return err

--- a/internal/notebook/store.go
+++ b/internal/notebook/store.go
@@ -488,12 +488,15 @@ func readPrefix(path string, limit int64) ([]byte, error) {
 
 // writeAtomic writes content to absPath atomically: it creates parent
 // directories, writes to a uniquely-named temp file in the same directory, then
-// renames it into place. The temp file is removed on any error.
+// renames it into place. The temp file is removed on any error. The temp name is
+// dot-prefixed so it lands outside CleanPath's trackable set: a watcher observing
+// this directory (self or otherwise) must not treat the transient swap file's own
+// fsnotify events as a change to a real, trackable path.
 func writeAtomic(absPath string, content []byte) error {
 	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 		return err
 	}
-	tmp := fmt.Sprintf("%s.tmp.%d.%d", absPath, os.Getpid(), time.Now().UnixNano())
+	tmp := filepath.Join(filepath.Dir(absPath), fmt.Sprintf(".%s.tmp.%d.%d", filepath.Base(absPath), os.Getpid(), time.Now().UnixNano()))
 	if err := os.WriteFile(tmp, content, 0o644); err != nil {
 		_ = os.Remove(tmp)
 		return err

--- a/internal/notebook/watcher.go
+++ b/internal/notebook/watcher.go
@@ -38,9 +38,10 @@ const selfWriteTTL = 3 * time.Second
 // onChange (which broadcasts notebook_changed) and drives NoteSelfWrite from its
 // write handlers.
 type Watcher struct {
-	root     string
-	debounce time.Duration
-	onChange func(paths []string)
+	root      string
+	debounce  time.Duration
+	cleanPath func(string) (string, error)
+	onChange  func(paths []string)
 
 	fsw *fsnotify.Watcher
 
@@ -73,8 +74,19 @@ type SelfWrite struct {
 // NewWatcher starts watching root (which must already exist) and every
 // non-dotdir subdirectory under it, coalescing events over debounce before
 // calling onChange. Close stops it. It errors if root does not exist or is not a
-// directory, rather than silently watching nothing.
+// directory, rather than silently watching nothing. Only .md files are
+// trackable (the notebook's rule); see NewWatcherWithCleaner for a generic root.
 func NewWatcher(root string, debounce time.Duration, onChange func(paths []string)) (*Watcher, error) {
+	return NewWatcherWithCleaner(root, debounce, CleanPath, onChange)
+}
+
+// NewWatcherWithCleaner is NewWatcher with an injectable path-cleaning rule.
+// cleanPath decides which filesystem paths are trackable: it is handed a
+// root-relative slash-path and either returns the canonical form to key events
+// on, or an error to skip the path entirely. Passing CleanPath (the .md rule)
+// reproduces NewWatcher's behavior; a permissive cleaner (e.g. fsdoc.CleanPath)
+// makes the watcher generic over every file under root.
+func NewWatcherWithCleaner(root string, debounce time.Duration, cleanPath func(string) (string, error), onChange func(paths []string)) (*Watcher, error) {
 	clean := filepath.Clean(root)
 	if info, err := os.Stat(clean); err != nil {
 		return nil, fmt.Errorf("notebook watcher: %w", err)
@@ -88,6 +100,7 @@ func NewWatcher(root string, debounce time.Duration, onChange func(paths []strin
 	w := &Watcher{
 		root:       clean,
 		debounce:   debounce,
+		cleanPath:  cleanPath,
 		onChange:   onChange,
 		fsw:        fsw,
 		selfWrites: make(map[string]selfWriteRecord),
@@ -114,7 +127,7 @@ func (w *Watcher) NoteSelfWrite(writes ...SelfWrite) {
 	defer w.mu.Unlock()
 	exp := w.now().Add(selfWriteTTL)
 	for _, sw := range writes {
-		clean, err := CleanPath(sw.Rel)
+		clean, err := w.cleanPath(sw.Rel)
 		if err != nil {
 			continue
 		}
@@ -173,11 +186,11 @@ func (w *Watcher) handleEvent(ev fsnotify.Event, pending map[string]struct{}) {
 				return // skip .attn/ and any dotdir subtree
 			}
 			// Surface whatever addTree discovered even if the walk aborted partway
-			// (e.g. a permission error on a sibling subdir): the .md files found
-			// before the failure are real notes whose parent dirs are already
+			// (e.g. a permission error on a sibling subdir): the files found before
+			// the failure are real trackable paths whose parent dirs are already
 			// watched, so dropping them would silently miss external edits.
-			mdFiles, _ := w.addTree(ev.Name)
-			for _, rel := range mdFiles {
+			files, _ := w.addTree(ev.Name)
+			for _, rel := range files {
 				pending[rel] = struct{}{}
 			}
 			return
@@ -259,10 +272,10 @@ func (w *Watcher) diskHash(rel string) string {
 }
 
 // addTree adds a watch for dir and every non-dotdir subdirectory, returning the
-// notebook-relative paths of the .md files it contains (so files that appear
+// root-relative paths of the trackable files it contains (so files that appear
 // alongside a freshly created directory are not missed).
 func (w *Watcher) addTree(dir string) ([]string, error) {
-	var mdFiles []string
+	var files []string
 	err := filepath.WalkDir(dir, func(p string, dirent fs.DirEntry, err error) error {
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -278,21 +291,23 @@ func (w *Watcher) addTree(dir string) ([]string, error) {
 			return nil
 		}
 		if rel, ok := w.trackable(p); ok {
-			mdFiles = append(mdFiles, rel)
+			files = append(files, rel)
 		}
 		return nil
 	})
-	return mdFiles, err
+	return files, err
 }
 
-// trackable reports whether an absolute path is a notebook note (a .md file with
-// no dotfile/dotdir segment under the root) and returns its clean relative path.
+// trackable reports whether an absolute path is trackable under this watcher's
+// cleanPath rule (no dotfile/dotdir segment under the root, plus whatever else
+// cleanPath enforces — e.g. .md-only for the notebook rule) and returns its
+// clean relative path.
 func (w *Watcher) trackable(absPath string) (string, bool) {
 	rel, err := filepath.Rel(w.root, absPath)
 	if err != nil {
 		return "", false
 	}
-	clean, err := CleanPath(filepath.ToSlash(rel))
+	clean, err := w.cleanPath(filepath.ToSlash(rel))
 	if err != nil {
 		return "", false
 	}

--- a/internal/notebook/watcher_test.go
+++ b/internal/notebook/watcher_test.go
@@ -272,7 +272,7 @@ func TestAddTreeReturnsPartialFilesOnWalkError(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = fsw.Close() })
-	w := &Watcher{root: filepath.Clean(root), fsw: fsw}
+	w := &Watcher{root: filepath.Clean(root), fsw: fsw, cleanPath: CleanPath}
 
 	mdFiles, walkErr := w.addTree(root)
 	if walkErr == nil {

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "167"
+const ProtocolVersion = "168"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -88,6 +88,8 @@ const (
 	CmdFsRename                              = "fs_rename"
 	CmdFsDelete                              = "fs_delete"
 	CmdFsExists                              = "fs_exists"
+	CmdFsWatch                               = "fs_watch"
+	CmdFsUnwatch                             = "fs_unwatch"
 	CmdUnregister                            = "unregister"
 	CmdState                                 = "state"
 	CmdSetSessionResumeID                    = "set_session_resume_id"
@@ -235,6 +237,8 @@ const (
 	EventFsRenameResult                  = "fs_rename_result"
 	EventFsDeleteResult                  = "fs_delete_result"
 	EventFsExistsResult                  = "fs_exists_result"
+	EventFsWatchResult                   = "fs_watch_result"
+	EventFsUnwatchResult                 = "fs_unwatch_result"
 	EventFsChanged                       = "fs_changed"
 	EventPRsUpdated                      = "prs_updated"
 	EventReposUpdated                    = "repos_updated"
@@ -698,6 +702,20 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdFsExists:
 		var msg FsExistsMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdFsWatch:
+		var msg FsWatchMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdFsUnwatch:
+		var msg FsUnwatchMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -1025,6 +1025,62 @@ type FsRenameResultMessage struct {
 	Success bool `json:"success"`
 }
 
+type FsUnwatchMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
+}
+
+type FsUnwatchResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
+type FsWatchMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
+}
+
+type FsWatchResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
 type FsWriteMessage struct {
 	// BaseHash corresponds to the JSON schema field "base_hash".
 	BaseHash *string `json:"base_hash,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1162,6 +1162,26 @@ model FsExistsMessage {
   request_id?: string; // set by the WS frontend to correlate the result event
 }
 
+// Subscribe this client to fs_changed broadcasts for a root: starts a live
+// watcher on first subscriber, refcounted per client so multiple subscribers (or
+// repeat calls) share one watcher. The notebook root is always watched already,
+// so fs_watch on it is a success no-op. Pair with fs_unwatch when the client no
+// longer needs live updates for that root.
+model FsWatchMessage {
+  cmd: "fs_watch";
+  root?: string; // Absolute directory to operate under; omitted/empty = the notebook root.
+  request_id?: string; // set by the WS frontend to correlate the result event
+}
+
+// Drop this client's subscription from fs_watch. The watcher for a root closes
+// once no client holds it open (including on client disconnect). Unwatching a
+// root this client never watched is a success no-op.
+model FsUnwatchMessage {
+  cmd: "fs_unwatch";
+  root?: string; // Absolute directory to operate under; omitted/empty = the notebook root.
+  request_id?: string; // set by the WS frontend to correlate the result event
+}
+
 model DelegateWorktreeRequest {
   repo?: string;
   branch: string;
@@ -2972,11 +2992,31 @@ model FsExistsResultMessage {
   result?: FsExistsResult;
 }
 
+// Result of fs_watch. root is the resolved absolute root on success, so the
+// frontend can key its subscription state on the same value fs_changed.root
+// carries.
+model FsWatchResultMessage {
+  event: "fs_watch_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  root?: string;
+}
+
+// Result of fs_unwatch.
+model FsUnwatchResultMessage {
+  event: "fs_unwatch_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  root?: string;
+}
+
 // Broadcast when files under the root change. origin is agent|ui|external, the
-// same vocabulary as notebook_changed. NOTE: today this rides the notebook
-// watcher, which only surfaces .md paths, so a non-.md external edit does not yet
-// emit fs_changed; generalizing the watcher to all files lands with the non-text
-// editor work.
+// same vocabulary as notebook_changed. Fires for every changed path regardless of
+// file type: under the notebook root this rides the always-on notebook watcher;
+// under any other root it fires only while at least one client holds that root
+// open via fs_watch.
 model FsChangedMessage {
   event: "fs_changed";
   paths: string[];
@@ -3170,6 +3210,8 @@ alias DaemonEvent =
   | FsRenameResultMessage
   | FsDeleteResultMessage
   | FsExistsResultMessage
+  | FsWatchResultMessage
+  | FsUnwatchResultMessage
   | FsChangedMessage
   | TaskListResultMessage
   | TaskRetryResultMessage


### PR DESCRIPTION
PR2 of the editor-over-arbitrary-roots plan (docs/plans/2026-07-18-editor-arbitrary-roots.md):

- Refcounted per-root watcher registry (cap 16)
- `fs_watch`/`fs_unwatch` commands gated through `resolveFsRoot` so explicit roots require the trusted app client
- Notebook root dual-broadcasts `fs_changed` + `notebook_changed`
- Dot-prefixed atomic-write temp files so generic watchers never see swap files
- Watcher cleanup on client disconnect
- Protocol version 168

## Test plan
- [x] go build/vet/test green locally
- [x] pnpm test green locally
- [x] protocol version 168 verified in lockstep (constants.go + useDaemonSocket.ts)

https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT