### PR TITLE
feat(daemon): fs_index bounded recursive file index

### DIFF
--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '168';
+export const PROTOCOL_VERSION = '169';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -442,6 +442,16 @@ export interface FsExistsResult {
 // there is no other result payload).
 export interface FsWatchResult {
   root: string;
+}
+
+// Result of fs_index: a bounded recursive file index of root, for the ⌘P
+// finder. Mirrors the daemon's protocol.FsIndexResultMessage. files are
+// root-relative slash paths, files only, sorted lexicographically. truncated
+// is true when the walk hit the server-side entry cap before finishing.
+export interface FsIndexResult {
+  root: string;
+  files: string[];
+  truncated: boolean;
 }
 
 interface UseDaemonSocketOptions {
@@ -1713,6 +1723,29 @@ export function useDaemonSocket({
               pending.resolve({ root: data.root });
             } else {
               pending.reject(new Error(data.error || 'Filesystem watch action failed'));
+            }
+            break;
+          }
+
+          case 'fs_index_result': {
+            const requestId = data.request_id;
+            if (typeof requestId !== 'string') {
+              break;
+            }
+            const key = `fs_index:${requestId}`;
+            const pending = pendingActionsRef.current.get(key);
+            if (!pending) {
+              break;
+            }
+            pendingActionsRef.current.delete(key);
+            if (data.success) {
+              pending.resolve({
+                root: data.root,
+                files: data.files || [],
+                truncated: !!data.truncated,
+              });
+            } else {
+              pending.reject(new Error(data.error || 'Filesystem index failed'));
             }
             break;
           }
@@ -4824,6 +4857,29 @@ export function useDaemonSocket({
     });
   }, [nextRequestID]);
 
+  // Bounded recursive file index of root (undefined/empty = the notebook
+  // root), for the ⌘P finder. No client-controlled limit — the daemon caps
+  // entries server-side and reports truncated=true if the walk was cut short.
+  const sendFsIndex = useCallback((root?: string): Promise<FsIndexResult> => {
+    return new Promise((resolve, reject) => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        reject(new Error('WebSocket not connected'));
+        return;
+      }
+      const requestId = nextRequestID('fs_index');
+      const key = `fs_index:${requestId}`;
+      pendingActionsRef.current.set(key, { resolve, reject });
+      ws.send(JSON.stringify({ cmd: 'fs_index', request_id: requestId, ...(root ? { root } : {}) }));
+      setTimeout(() => {
+        if (pendingActionsRef.current.has(key)) {
+          pendingActionsRef.current.delete(key);
+          reject(new Error('Filesystem index timed out'));
+        }
+      }, 10000);
+    });
+  }, [nextRequestID]);
+
   // Get recent locations from daemon
   const sendGetRecentLocations = useCallback((endpointId?: string, limit?: number): Promise<RecentLocationsResult> => {
     return new Promise((resolve, reject) => {
@@ -5351,6 +5407,7 @@ export function useDaemonSocket({
     sendFsExists,
     sendFsWatch,
     sendFsUnwatch,
+    sendFsIndex,
     sendGetRecentLocations,
     sendBrowseDirectory,
     sendInspectPath,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -58,6 +58,8 @@
 //   const fSExistsMessage = Convert.toFSExistsMessage(json);
 //   const fSExistsResult = Convert.toFSExistsResult(json);
 //   const fSExistsResultMessage = Convert.toFSExistsResultMessage(json);
+//   const fSIndexMessage = Convert.toFSIndexMessage(json);
+//   const fSIndexResultMessage = Convert.toFSIndexResultMessage(json);
 //   const fSListMessage = Convert.toFSListMessage(json);
 //   const fSListResultMessage = Convert.toFSListResultMessage(json);
 //   const fSReadAssetMessage = Convert.toFSReadAssetMessage(json);
@@ -1155,6 +1157,32 @@ export interface FSExistsResultMessageResult {
     exists: boolean;
     path:   string;
     [property: string]: any;
+}
+
+export interface FSIndexMessage {
+    cmd:         FSIndexMessageCmd;
+    request_id?: string;
+    root?:       string;
+    [property: string]: any;
+}
+
+export enum FSIndexMessageCmd {
+    FSIndex = "fs_index",
+}
+
+export interface FSIndexResultMessage {
+    error?:     string;
+    event:      FSIndexResultMessageEvent;
+    files:      string[];
+    request_id: string;
+    root:       string;
+    success:    boolean;
+    truncated:  boolean;
+    [property: string]: any;
+}
+
+export enum FSIndexResultMessageEvent {
+    FSIndexResult = "fs_index_result",
 }
 
 export interface FSListMessage {
@@ -5435,6 +5463,22 @@ export class Convert {
         return JSON.stringify(uncast(value, r("FSExistsResultMessage")), null, 2);
     }
 
+    public static toFSIndexMessage(json: string): FSIndexMessage {
+        return cast(JSON.parse(json), r("FSIndexMessage"));
+    }
+
+    public static fSIndexMessageToJson(value: FSIndexMessage): string {
+        return JSON.stringify(uncast(value, r("FSIndexMessage")), null, 2);
+    }
+
+    public static toFSIndexResultMessage(json: string): FSIndexResultMessage {
+        return cast(JSON.parse(json), r("FSIndexResultMessage"));
+    }
+
+    public static fSIndexResultMessageToJson(value: FSIndexResultMessage): string {
+        return JSON.stringify(uncast(value, r("FSIndexResultMessage")), null, 2);
+    }
+
     public static toFSListMessage(json: string): FSListMessage {
         return cast(JSON.parse(json), r("FSListMessage"));
     }
@@ -8355,6 +8399,20 @@ const typeMap: any = {
         { json: "exists", js: "exists", typ: true },
         { json: "path", js: "path", typ: "" },
     ], "any"),
+    "FSIndexMessage": o([
+        { json: "cmd", js: "cmd", typ: r("FSIndexMessageCmd") },
+        { json: "request_id", js: "request_id", typ: u(undefined, "") },
+        { json: "root", js: "root", typ: u(undefined, "") },
+    ], "any"),
+    "FSIndexResultMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("FSIndexResultMessageEvent") },
+        { json: "files", js: "files", typ: a("") },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "root", js: "root", typ: "" },
+        { json: "success", js: "success", typ: true },
+        { json: "truncated", js: "truncated", typ: true },
+    ], "any"),
     "FSListMessage": o([
         { json: "cmd", js: "cmd", typ: r("FSListMessageCmd") },
         { json: "path", js: "path", typ: u(undefined, "") },
@@ -10765,6 +10823,12 @@ const typeMap: any = {
     ],
     "FSExistsResultMessageEvent": [
         "fs_exists_result",
+    ],
+    "FSIndexMessageCmd": [
+        "fs_index",
+    ],
+    "FSIndexResultMessageEvent": [
+        "fs_index_result",
     ],
     "FSListMessageCmd": [
         "fs_list",

--- a/internal/daemon/fs_index.go
+++ b/internal/daemon/fs_index.go
@@ -50,11 +50,14 @@ func (d *Daemon) handleFsIndex(client *wsClient, requestID, rawRoot string) {
 // root-relative slash path, sorted lexicographically, plus whether the walk
 // was truncated at cap entries. It skips any directory whose name starts with
 // "." or is named "node_modules" (not descended at all), dot-prefixed files,
-// and symlinks (files and dirs alike — a symlinked dir is never descended by
-// WalkDir, and a symlinked file is skipped rather than listed). A per-entry
-// walk error (e.g. permission denied) skips that entry/subtree without
-// failing the whole index. cap is injected so tests can exercise truncation
-// with a tiny value instead of the real maxFsIndexEntries.
+// and any non-regular-file entry — symlinks, FIFOs, sockets, device nodes —
+// via DirEntry.Type().IsRegular(), a no-syscall type-bits check (a symlinked
+// dir is also never descended by WalkDir). This matters beyond symlinks: a
+// FIFO or socket that slipped into the list would be advertised as an
+// openable file when fs_read rejects anything that isn't a regular file. A
+// per-entry walk error (e.g. permission denied) skips that entry/subtree
+// without failing the whole index. cap is injected so tests can exercise
+// truncation with a tiny value instead of the real maxFsIndexEntries.
 //
 // normalizeExternalRoot only canonicalizes the deepest EXISTING ancestor, so a
 // root that does not exist (or a root that is a file, not a directory) can
@@ -96,7 +99,7 @@ func indexRoot(root string, cap int) ([]string, bool, error) {
 		if strings.HasPrefix(name, ".") {
 			return nil
 		}
-		if d.Type()&fs.ModeSymlink != 0 {
+		if !d.Type().IsRegular() {
 			return nil
 		}
 		if len(files) >= cap {

--- a/internal/daemon/fs_index.go
+++ b/internal/daemon/fs_index.go
@@ -1,0 +1,118 @@
+package daemon
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// maxFsIndexEntries bounds a single fs_index walk. It is a server-side
+// constant, not a client-controlled limit — the ⌘P finder needs a bound that
+// cannot be widened by a request, so a walk that would exceed it stops early
+// and reports truncated=true instead of returning a partial-but-unbounded
+// list.
+const maxFsIndexEntries = 25000
+
+// handleFsIndex resolves rawRoot through resolveFsRoot — the same chokepoint
+// every other fs_* command uses, so fs_index inherits the auth gate (an
+// explicit root is honored only for the authenticated app client; an
+// omitted/empty root always resolves to the notebook root) with no separate
+// check here — then walks it bounded by maxFsIndexEntries. Replies with an
+// fs_index_result event correlated by requestID.
+func (d *Daemon) handleFsIndex(client *wsClient, requestID, rawRoot string) {
+	var files []string
+	var truncated bool
+	root, err := d.resolveFsRoot(client, rawRoot)
+	if err == nil {
+		files, truncated, err = indexRoot(root, maxFsIndexEntries)
+	}
+	msg := protocol.FsIndexResultMessage{
+		Event:     protocol.EventFsIndexResult,
+		RequestID: requestID,
+		Success:   err == nil,
+		Root:      root,
+		Files:     files,
+		Truncated: truncated,
+	}
+	if err != nil {
+		msg.Error = protocol.Ptr(err.Error())
+		msg.Files = []string{}
+	}
+	d.sendToClient(client, msg)
+}
+
+// indexRoot walks root recursively and returns every regular file's
+// root-relative slash path, sorted lexicographically, plus whether the walk
+// was truncated at cap entries. It skips any directory whose name starts with
+// "." or is named "node_modules" (not descended at all), dot-prefixed files,
+// and symlinks (files and dirs alike — a symlinked dir is never descended by
+// WalkDir, and a symlinked file is skipped rather than listed). A per-entry
+// walk error (e.g. permission denied) skips that entry/subtree without
+// failing the whole index. cap is injected so tests can exercise truncation
+// with a tiny value instead of the real maxFsIndexEntries.
+//
+// normalizeExternalRoot only canonicalizes the deepest EXISTING ancestor, so a
+// root that does not exist (or a root that is a file, not a directory) can
+// still pass resolveFsRoot. Without an explicit check here, WalkDir's first
+// callback invocation for such a root fires with a non-nil err and a nil
+// DirEntry, the generic "skip and continue" branch below treats that as
+// nothing-to-walk, and the whole call silently succeeds with zero files —
+// fs_index would report success+empty for a root fs_list correctly errors on.
+// Stat first and fail loudly instead.
+func indexRoot(root string, cap int) ([]string, bool, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, false, err
+	}
+	if !info.IsDir() {
+		return nil, false, fmt.Errorf("root %s is not a directory", root)
+	}
+	var files []string
+	truncated := false
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Skip the entry (and, for a directory, its subtree) rather than
+			// aborting the whole walk on one permission-denied or similar error.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if path == root {
+			return nil
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if strings.HasPrefix(name, ".") || name == "node_modules" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if strings.HasPrefix(name, ".") {
+			return nil
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+		if len(files) >= cap {
+			truncated = true
+			return fs.SkipAll
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	sort.Strings(files)
+	return files, truncated, nil
+}

--- a/internal/daemon/fs_index_test.go
+++ b/internal/daemon/fs_index_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/victorarias/attn/internal/protocol"
@@ -21,7 +22,9 @@ func fsIndex(t *testing.T, d *Daemon, client *wsClient, requestID, root string) 
 
 // fs_index over a real tree returns every regular file's root-relative slash
 // path, sorted, while excluding: a dot-dir's contents (not just the dir
-// itself), a node_modules dir's contents, dot-files, and symlinked files.
+// itself), a node_modules dir's contents, dot-files, symlinked files, and a
+// FIFO (a non-regular-file entry that would otherwise be advertised as an
+// openable file when fs_read rejects anything that isn't a regular file).
 // truncated must be false since nothing hits the cap.
 func TestFsIndexListsFilesExcludingDotDirsNodeModulesAndSymlinks(t *testing.T) {
 	d := newFsDaemon(t)
@@ -41,7 +44,7 @@ func TestFsIndexListsFilesExcludingDotDirsNodeModulesAndSymlinks(t *testing.T) {
 	mustWrite("top.md")
 	mustWrite("nested/dir/deep.md")
 	mustWrite("nested/dir/deep2.txt")
-	mustWrite(".hidden-dir/inside.md")  // whole dot-dir excluded
+	mustWrite(".hidden-dir/inside.md")     // whole dot-dir excluded
 	mustWrite("node_modules/pkg/index.js") // whole node_modules dir excluded
 	mustWrite(".dotfile")                  // dot-file excluded
 
@@ -52,6 +55,12 @@ func TestFsIndexListsFilesExcludingDotDirsNodeModulesAndSymlinks(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.Symlink(symlinkTarget, filepath.Join(root, "linked.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	// A FIFO must be excluded too — not a symlink, but still not a regular
+	// file, and fs_read can't open it either.
+	if err := syscall.Mkfifo(filepath.Join(root, "pipe.fifo"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/daemon/fs_index_test.go
+++ b/internal/daemon/fs_index_test.go
@@ -1,0 +1,175 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+// fsIndex drives handleFsIndex directly and returns the decoded result event.
+func fsIndex(t *testing.T, d *Daemon, client *wsClient, requestID, root string) protocol.FsIndexResultMessage {
+	t.Helper()
+	d.handleFsIndex(client, requestID, root)
+	var res protocol.FsIndexResultMessage
+	readNotebookWSEvent(t, client.send, &res)
+	return res
+}
+
+// fs_index over a real tree returns every regular file's root-relative slash
+// path, sorted, while excluding: a dot-dir's contents (not just the dir
+// itself), a node_modules dir's contents, dot-files, and symlinked files.
+// truncated must be false since nothing hits the cap.
+func TestFsIndexListsFilesExcludingDotDirsNodeModulesAndSymlinks(t *testing.T) {
+	d := newFsDaemon(t)
+	root := t.TempDir()
+
+	mustWrite := func(rel string) {
+		t.Helper()
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mustWrite("top.md")
+	mustWrite("nested/dir/deep.md")
+	mustWrite("nested/dir/deep2.txt")
+	mustWrite(".hidden-dir/inside.md")  // whole dot-dir excluded
+	mustWrite("node_modules/pkg/index.js") // whole node_modules dir excluded
+	mustWrite(".dotfile")                  // dot-file excluded
+
+	// A symlinked file must be excluded (listed as an entry but skipped, not
+	// followed).
+	symlinkTarget := filepath.Join(t.TempDir(), "target.md")
+	if err := os.WriteFile(symlinkTarget, []byte("target"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(symlinkTarget, filepath.Join(root, "linked.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	client := trustedFsClient(4)
+	res := fsIndex(t, d, client, "i1", root)
+	if !res.Success {
+		t.Fatalf("fs_index(root) failed: %v", res.Error)
+	}
+	if res.Root != root {
+		t.Fatalf("fs_index.root = %q, want %q", res.Root, root)
+	}
+	if res.Truncated {
+		t.Fatalf("fs_index.truncated = true, want false")
+	}
+	want := []string{"nested/dir/deep.md", "nested/dir/deep2.txt", "top.md"}
+	if !equalStrings(res.Files, want) {
+		t.Fatalf("fs_index.files = %v, want %v", res.Files, want)
+	}
+}
+
+// equalStrings reports whether a and b hold the same elements in the same
+// order.
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// indexRoot (the injectable-cap walk helper) truncates once the cap is hit
+// rather than returning an unbounded list: with more files than cap, it must
+// report truncated=true and return exactly cap entries.
+func TestIndexRootTruncatesAtInjectedCap(t *testing.T) {
+	root := t.TempDir()
+	const total = 12
+	const cap = 5
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("file%02d.txt", i)
+		if err := os.WriteFile(filepath.Join(root, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, truncated, err := indexRoot(root, cap)
+	if err != nil {
+		t.Fatalf("indexRoot: %v", err)
+	}
+	if !truncated {
+		t.Fatalf("truncated = false, want true (total=%d cap=%d)", total, cap)
+	}
+	if len(files) != cap {
+		t.Fatalf("len(files) = %d, want %d", len(files), cap)
+	}
+}
+
+// normalizeExternalRoot only requires the deepest EXISTING ancestor to
+// canonicalize, so a nonexistent explicit root (or one pointing at a regular
+// file rather than a directory) passes resolveFsRoot. Without an explicit
+// pre-walk check, WalkDir's error-recovery branch swallows the "root does not
+// exist" error and the walk silently "succeeds" with zero files — a
+// silently-empty finder instead of a visible error. Both cases must fail with
+// Success=false, not report an empty index.
+func TestFsIndexRejectsNonexistentAndNonDirectoryRoots(t *testing.T) {
+	d := newFsDaemon(t)
+	base := t.TempDir()
+
+	client := trustedFsClient(4)
+	missing := filepath.Join(base, "does-not-exist")
+	res := fsIndex(t, d, client, "i1", missing)
+	if res.Success || res.Error == nil {
+		t.Fatalf("fs_index(nonexistent root) = %+v, want failure", res)
+	}
+	if !strings.Contains(*res.Error, missing) {
+		t.Fatalf("fs_index(nonexistent root) error = %q, want it to mention the root %q", *res.Error, missing)
+	}
+
+	regularFile := filepath.Join(base, "not-a-dir.txt")
+	if err := os.WriteFile(regularFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fileClient := trustedFsClient(4)
+	fileRes := fsIndex(t, d, fileClient, "i2", regularFile)
+	if fileRes.Success {
+		t.Fatalf("fs_index(root = regular file) = %+v, want failure", fileRes)
+	}
+}
+
+// An ordinary (unauthenticated) client asking to index an explicit root must
+// be denied with no file listing — fs_index inherits the resolveFsRoot
+// chokepoint's auth gate just like fs_watch does. The same client succeeds
+// with root omitted (the notebook root), since the gate is scoped to the
+// explicit-root escape hatch.
+func TestFsIndexWithExplicitRootDeniedForUntrustedClient(t *testing.T) {
+	d := newFsDaemon(t)
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "secret.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	untrusted := &wsClient{send: make(chan outboundMessage, 8)}
+	res := fsIndex(t, d, untrusted, "i1", root)
+	if res.Success || res.Error == nil {
+		t.Fatalf("fs_index(explicit root, untrusted client) = %+v, want failure", res)
+	}
+	if !strings.Contains(*res.Error, "authenticated") {
+		t.Fatalf("fs_index(explicit root, untrusted client) error = %q, want it to mention the authenticated app", *res.Error)
+	}
+	if len(res.Files) != 0 {
+		t.Fatalf("fs_index(explicit root, untrusted client) files = %v, want empty", res.Files)
+	}
+
+	omittedRes := fsIndex(t, d, untrusted, "i2", "")
+	if !omittedRes.Success {
+		t.Fatalf("fs_index(omitted root, untrusted client) = %+v, want success", omittedRes)
+	}
+}

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -964,6 +964,9 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 	case protocol.CmdFsUnwatch:
 		fsUnwatch := msg.(*protocol.FsUnwatchMessage)
 		go d.handleFsUnwatch(client, protocol.Deref(fsUnwatch.RequestID), protocol.Deref(fsUnwatch.Root))
+	case protocol.CmdFsIndex:
+		fsIndex := msg.(*protocol.FsIndexMessage)
+		go d.handleFsIndex(client, protocol.Deref(fsIndex.RequestID), protocol.Deref(fsIndex.Root))
 	case protocol.CmdApprovePR:
 		d.handleApprovePRWS(client, msg.(*protocol.ApprovePRMessage))
 	case protocol.CmdMergePR:

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "168"
+const ProtocolVersion = "169"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -90,6 +90,7 @@ const (
 	CmdFsExists                              = "fs_exists"
 	CmdFsWatch                               = "fs_watch"
 	CmdFsUnwatch                             = "fs_unwatch"
+	CmdFsIndex                               = "fs_index"
 	CmdUnregister                            = "unregister"
 	CmdState                                 = "state"
 	CmdSetSessionResumeID                    = "set_session_resume_id"
@@ -239,6 +240,7 @@ const (
 	EventFsExistsResult                  = "fs_exists_result"
 	EventFsWatchResult                   = "fs_watch_result"
 	EventFsUnwatchResult                 = "fs_unwatch_result"
+	EventFsIndexResult                   = "fs_index_result"
 	EventFsChanged                       = "fs_changed"
 	EventPRsUpdated                      = "prs_updated"
 	EventReposUpdated                    = "repos_updated"
@@ -716,6 +718,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdFsUnwatch:
 		var msg FsUnwatchMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdFsIndex:
+		var msg FsIndexMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -868,6 +868,40 @@ type FsExistsResultMessage struct {
 	Success bool `json:"success"`
 }
 
+type FsIndexMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID *string `json:"request_id,omitempty,omitzero"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root *string `json:"root,omitempty,omitzero"`
+}
+
+type FsIndexResultMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Files corresponds to the JSON schema field "files".
+	Files []string `json:"files"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Root corresponds to the JSON schema field "root".
+	Root string `json:"root"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+
+	// Truncated corresponds to the JSON schema field "truncated".
+	Truncated bool `json:"truncated"`
+}
+
 type FsListMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1182,6 +1182,17 @@ model FsUnwatchMessage {
   request_id?: string; // set by the WS frontend to correlate the result event
 }
 
+// Bounded recursive file index of a root, for the ⌘P finder. No
+// client-controlled limit — the entry cap is a server-side constant
+// (maxFsIndexEntries). Root resolution goes through the same resolveFsRoot
+// chokepoint as every other fs_* command, so an explicit root is gated on the
+// authenticated app client.
+model FsIndexMessage {
+  cmd: "fs_index";
+  root?: string; // Absolute directory to operate under; omitted/empty = the notebook root.
+  request_id?: string; // set by the WS frontend to correlate the result event
+}
+
 model DelegateWorktreeRequest {
   repo?: string;
   branch: string;
@@ -3012,6 +3023,20 @@ model FsUnwatchResultMessage {
   root?: string;
 }
 
+// Result of fs_index. root is the resolved absolute root (echoed for
+// correlation with the request). files are root-relative slash paths, files
+// only (no directories), sorted lexicographically. truncated is true when the
+// walk hit the server-side entry cap before finishing.
+model FsIndexResultMessage {
+  event: "fs_index_result";
+  request_id: string;
+  success: boolean;
+  error?: string;
+  root: string;
+  files: string[];
+  truncated: boolean;
+}
+
 // Broadcast when files under the root change. origin is agent|ui|external, the
 // same vocabulary as notebook_changed. Fires for every changed path regardless of
 // file type: under the notebook root this rides the always-on notebook watcher;
@@ -3212,6 +3237,7 @@ alias DaemonEvent =
   | FsExistsResultMessage
   | FsWatchResultMessage
   | FsUnwatchResultMessage
+  | FsIndexResultMessage
   | FsChangedMessage
   | TaskListResultMessage
   | TaskRetryResultMessage


### PR DESCRIPTION
PR3 of the editor-over-arbitrary-roots plan (docs/plans/2026-07-18-editor-arbitrary-roots.md) — new `fs_index` command returning a bounded recursive index of a root for the ⌘P finder:

- server-side 25k entry cap with a truncated flag
- skips dot-dirs/dot-files/node_modules/symlinks
- rejects nonexistent or non-directory roots
- inherits the explicit-root auth gate via the `resolveFsRoot` chokepoint, with its own denial test
- protocol version 169
- `sendFsIndex` socket helper

https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT