### PR TITLE
feat(ptyworker): self-reap orphaned workers after idle TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-18]
 
+### Fixed
+- **Orphaned session workers now clean themselves up.** A per-session PTY worker
+  whose daemon is gone for good (e.g. a torn-down test profile, or a daemon that
+  was killed and never restarted) previously kept running forever, accumulating
+  stray `attn pty-worker` and agent processes. Workers now stop themselves after
+  12 hours with no daemon attached and no terminal output, ending their agent
+  process and removing their registry/socket files. Daemon restarts and upgrades
+  are unaffected — a reattaching daemon cancels the countdown, and a busy agent
+  producing output defers it.
+
 ### Added
 - **Automatic rotating database backups.** The daemon now snapshots its SQLite
   database every 6 hours (keeping the last 12) and takes an extra safety

--- a/internal/ptyworker/runtime.go
+++ b/internal/ptyworker/runtime.go
@@ -57,6 +57,19 @@ func cloneReplaySegments[From any, To any](segments []From, convert func(From) T
 
 var exitedSessionCleanupTTL = 45 * time.Second
 
+// orphanedWorkerTTL is how long a worker with a live child keeps running with
+// no authenticated daemon connection AND no PTY output before it stops itself.
+// Workers must survive daemon restarts/upgrades (the daemon reattaches within
+// seconds), and an in-flight agent run during a daemon outage keeps producing
+// output, which defers the deadline — so this only reaps sessions that are
+// both unowned and idle, e.g. workers left behind by torn-down profiles.
+// Override with ATTN_WORKER_ORPHAN_TTL (Go duration; "0" disables reaping).
+var orphanedWorkerTTL = 12 * time.Hour
+
+const orphanTTLEnvVar = "ATTN_WORKER_ORPHAN_TTL"
+
+const orphanActivitySubscriberID = "worker-orphan-activity"
+
 const (
 	connSendQueueSize       = 256
 	connWriteTimeout        = 2 * time.Second
@@ -128,6 +141,12 @@ type Runtime struct {
 	exited      bool
 	cleanupTTL  *time.Timer
 
+	// Orphan reaping: see orphanedWorkerTTL. orphanTimer is guarded by
+	// lifecycleMu; lastOutputNano is stamped from the PTY output path.
+	orphanTTL      time.Duration
+	orphanTimer    *time.Timer
+	lastOutputNano atomic.Int64
+
 	connSeq atomic.Uint64
 
 	watchMu   sync.RWMutex
@@ -145,6 +164,14 @@ func Run(ctx context.Context, cfg Config) error {
 		stopCh:    make(chan struct{}),
 		logf:      logf,
 		watchConn: make(map[*connCtx]struct{}),
+		orphanTTL: orphanedWorkerTTL,
+	}
+	if v := strings.TrimSpace(os.Getenv(orphanTTLEnvVar)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d >= 0 {
+			rt.orphanTTL = d
+		} else {
+			logf("worker orphan ttl: ignoring invalid %s=%q: %v", orphanTTLEnvVar, v, err)
+		}
 	}
 	return rt.run(ctx)
 }
@@ -230,6 +257,7 @@ func (r *Runtime) run(ctx context.Context) error {
 		r.requestStop()
 		if r.manager != nil {
 			r.manager.Detach(r.cfg.SessionID, debugCaptureSubscriberID)
+			r.manager.Detach(r.cfg.SessionID, orphanActivitySubscriberID)
 		}
 		if r.capture != nil {
 			path, err := r.capture.dump("runtime_shutdown")
@@ -332,6 +360,26 @@ func (r *Runtime) run(ctx context.Context) error {
 	}
 	r.logf("worker startup: registry ready session=%s pid=%d child_pid=%d", r.cfg.SessionID, os.Getpid(), info.PID)
 
+	// Orphan reaping: observe PTY output so a busy child defers the deadline,
+	// then arm the watch. The daemon's first authenticated connection (seconds
+	// away in the normal path) cancels it; it re-arms whenever the last authed
+	// connection drops.
+	r.noteOutputActivity()
+	if _, err := r.manager.Attach(
+		r.cfg.SessionID,
+		orphanActivitySubscriberID,
+		func(_ []byte, _ uint32) bool {
+			r.noteOutputActivity()
+			return true
+		},
+		func(reason string) {
+			r.logf("worker orphan activity subscriber dropped: session=%s reason=%s", r.cfg.SessionID, reason)
+		},
+	); err != nil {
+		r.logf("worker orphan activity attach failed: session=%s err=%v", r.cfg.SessionID, err)
+	}
+	r.armOrphanWatch()
+
 	go func() {
 		<-ctx.Done()
 		r.requestStop()
@@ -403,6 +451,7 @@ func (r *Runtime) cleanup() {
 		r.cleanupTTL.Stop()
 		r.cleanupTTL = nil
 	}
+	r.stopOrphanTimerLocked()
 	r.lifecycleMu.Unlock()
 
 	_ = os.Remove(r.cfg.RegistryPath)
@@ -421,6 +470,7 @@ func (r *Runtime) requestStop() {
 func (r *Runtime) noteSessionExited() {
 	r.lifecycleMu.Lock()
 	r.exited = true
+	r.stopOrphanTimerLocked()
 	r.maybeScheduleCleanupLocked()
 	r.lifecycleMu.Unlock()
 }
@@ -432,6 +482,7 @@ func (r *Runtime) noteConnAuthed() {
 		r.cleanupTTL.Stop()
 		r.cleanupTTL = nil
 	}
+	r.stopOrphanTimerLocked()
 	r.lifecycleMu.Unlock()
 }
 
@@ -441,7 +492,54 @@ func (r *Runtime) noteConnClosed() {
 		r.authedConns--
 	}
 	r.maybeScheduleCleanupLocked()
+	r.maybeScheduleOrphanLocked()
 	r.lifecycleMu.Unlock()
+}
+
+func (r *Runtime) noteOutputActivity() {
+	r.lastOutputNano.Store(time.Now().UnixNano())
+}
+
+func (r *Runtime) armOrphanWatch() {
+	r.lifecycleMu.Lock()
+	r.maybeScheduleOrphanLocked()
+	r.lifecycleMu.Unlock()
+}
+
+func (r *Runtime) stopOrphanTimerLocked() {
+	if r.orphanTimer != nil {
+		r.orphanTimer.Stop()
+		r.orphanTimer = nil
+	}
+}
+
+func (r *Runtime) maybeScheduleOrphanLocked() {
+	if r.orphanTTL <= 0 || r.exited || r.authedConns != 0 || r.orphanTimer != nil {
+		return
+	}
+	r.orphanTimer = time.AfterFunc(r.orphanTTL, r.orphanDeadlineFired)
+}
+
+func (r *Runtime) orphanDeadlineFired() {
+	r.lifecycleMu.Lock()
+	r.orphanTimer = nil
+	if r.exited || r.authedConns != 0 {
+		r.lifecycleMu.Unlock()
+		return
+	}
+	// A busy child (e.g. an agent still finishing a run while the daemon is
+	// down) defers reaping until output has been quiet for a full TTL.
+	idle := time.Since(time.Unix(0, r.lastOutputNano.Load()))
+	if idle < r.orphanTTL {
+		r.orphanTimer = time.AfterFunc(r.orphanTTL-idle, r.orphanDeadlineFired)
+		r.lifecycleMu.Unlock()
+		return
+	}
+	r.lifecycleMu.Unlock()
+	if r.logf != nil {
+		r.logf("worker orphaned: session=%s no daemon connection and no output for %s; stopping", r.cfg.SessionID, r.orphanTTL)
+	}
+	r.requestStop()
 }
 
 func (r *Runtime) maybeScheduleCleanupLocked() {

--- a/internal/ptyworker/runtime_test.go
+++ b/internal/ptyworker/runtime_test.go
@@ -160,6 +160,96 @@ func TestRuntime_ExitCleanupWaitsForConnectionsToClose(t *testing.T) {
 	}
 }
 
+func TestRuntime_OrphanWatchStopsIdleUnownedWorker(t *testing.T) {
+	r := &Runtime{stopCh: make(chan struct{}), orphanTTL: 15 * time.Millisecond}
+	r.noteOutputActivity()
+	r.armOrphanWatch()
+
+	select {
+	case <-r.stopCh:
+		// expected
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for orphan watch to stop idle unowned worker")
+	}
+}
+
+func TestRuntime_OrphanWatchCanceledByAuthedConn(t *testing.T) {
+	r := &Runtime{stopCh: make(chan struct{}), orphanTTL: 15 * time.Millisecond}
+	r.noteOutputActivity()
+	r.armOrphanWatch()
+	r.noteConnAuthed()
+
+	select {
+	case <-r.stopCh:
+		t.Fatal("orphan watch stopped runtime while a daemon connection was authed")
+	case <-time.After(60 * time.Millisecond):
+		// expected
+	}
+
+	r.noteConnClosed()
+
+	select {
+	case <-r.stopCh:
+		// expected: watch re-armed when the last authed connection dropped
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for orphan stop after last connection closed")
+	}
+}
+
+func TestRuntime_OrphanWatchDeferredByOutputActivity(t *testing.T) {
+	r := &Runtime{stopCh: make(chan struct{}), orphanTTL: 50 * time.Millisecond}
+	r.noteOutputActivity()
+	r.armOrphanWatch()
+
+	// Keep the child "busy" past the first deadline; the watch must defer.
+	deadline := time.Now().Add(120 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		r.noteOutputActivity()
+		select {
+		case <-r.stopCh:
+			t.Fatal("orphan watch stopped runtime while output was still flowing")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Once output goes quiet, the worker stops after a full idle TTL.
+	select {
+	case <-r.stopCh:
+		// expected
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for orphan stop after output went quiet")
+	}
+}
+
+func TestRuntime_OrphanWatchDisabledByZeroTTL(t *testing.T) {
+	r := &Runtime{stopCh: make(chan struct{}), orphanTTL: 0}
+	r.armOrphanWatch()
+
+	select {
+	case <-r.stopCh:
+		t.Fatal("orphan watch fired despite zero TTL")
+	case <-time.After(60 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestRuntime_OrphanWatchNotArmedAfterExit(t *testing.T) {
+	origTTL := exitedSessionCleanupTTL
+	exitedSessionCleanupTTL = time.Hour
+	defer func() { exitedSessionCleanupTTL = origTTL }()
+
+	r := &Runtime{stopCh: make(chan struct{}), orphanTTL: 15 * time.Millisecond}
+	r.noteSessionExited()
+	r.armOrphanWatch()
+
+	select {
+	case <-r.stopCh:
+		t.Fatal("orphan watch fired for an exited session (exit cleanup owns that path)")
+	case <-time.After(60 * time.Millisecond):
+		// expected
+	}
+}
+
 func TestConnCtx_NextReadTimeout(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary
- Per-session PTY workers previously ran forever once their daemon was gone for good (e.g. a torn-down test profile, or a daemon killed and never restarted), leaking `attn pty-worker` and agent processes.
- Workers now self-reap after 12 hours with no authenticated daemon connection **and** no PTY output, ending the child agent process and removing the registry/socket files.
- Daemon restarts/upgrades are unaffected — the daemon's reattach (seconds away in the normal path) cancels the countdown, and a busy agent producing output defers the deadline until it goes idle.
- TTL is overridable via `ATTN_WORKER_ORPHAN_TTL` (Go duration; `0` disables reaping).

## Test plan
- [x] Unit tests in `internal/ptyworker/runtime_test.go` covering: idle-unowned reap, cancellation by an authed connection (and re-arm after it drops), deferral by ongoing output activity, disable via zero TTL, and no-arm when the session already exited (exit-cleanup owns that path).
- [x] `go test ./internal/ptyworker/...`, `go vet ./internal/ptyworker/...`, `gofmt -l` all clean.
- [x] Live-app verification already performed on a throwaway `ATTN_PROFILE` (not dev/prod): confirmed orphan reap actually kills the leaked worker/agent process, confirmed a daemon restart during the TTL window cancels the countdown and the worker survives, and confirmed `attn profile clean` no longer leaves an orphaned worker running.