### PR TITLE
feat(daemon): backup restore CLI, pre-migration snapshot cap, last-backup surfacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   database every 6 hours (keeping the last 12) and takes an extra safety
   snapshot right before any database migration, so session, ticket, and
   workspace state can be recovered if the database is ever lost or corrupted.
+- **Restore the database from a backup.** `attn db restore [path|latest]`
+  restores `attn.db` from a rotating snapshot (the newest one by default),
+  refusing while the daemon is running and always preserving the previous
+  database file rather than deleting it. Settings now also surface the
+  timestamp of the most recent successful backup.
 
 ## [2026-07-16]
 

--- a/cmd/attn/db.go
+++ b/cmd/attn/db.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -193,28 +194,86 @@ func restoreDatabase(dbPath, backupsDir, source string, daemonRunning func() (bo
 // to preservedAs+suffix keeps the preserved copy openable and consistent.
 //
 // The timestamp alone is only second-resolution, so two restores within the
-// same second would otherwise collide and the second os.Rename would replace
-// the first preserved copy; the -N suffix loop makes the chosen name unique
-// regardless of how many restores land in the same second.
+// same second would otherwise collide; the -N suffix loop makes the chosen
+// name unique regardless of how many restores land in the same second. The
+// loop checks the main file AND both sidecar targets before accepting a
+// candidate — a candidate whose main-file path is free but whose -wal or
+// -shm path is already taken (e.g. from an earlier restore that had no
+// sidecars to preserve, leaving that name's main-file slot free) would
+// otherwise let a later rename silently replace that stray file.
+//
+// If the main-file rename succeeds but a sidecar rename then fails, every
+// earlier move in this call is rolled back (in reverse order) before
+// returning, so a sidecar-only filesystem error never strands dbPath
+// missing; a rollback failure is wrapped alongside the original error
+// instead of being discarded.
 func preserveExistingDB(dbPath string) (string, error) {
-	base := dbPath + ".pre-restore-" + time.Now().UTC().Format("20060102-150405")
-	preservedAs := base
+	return preserveExistingDBAt(dbPath, time.Now, os.Rename)
+}
+
+// preserveExistingDBAt is preserveExistingDB with the clock and the rename
+// operation injected, so tests can force a same-second collision
+// deterministically and force a specific rename in the sequence to fail
+// without relying on real filesystem-permission tricks.
+func preserveExistingDBAt(dbPath string, now func() time.Time, rename func(oldpath, newpath string) error) (preservedAs string, err error) {
+	base := dbPath + ".pre-restore-" + now().UTC().Format("20060102-150405")
+	preservedAs = base
 	for n := 2; ; n++ {
-		if _, err := os.Stat(preservedAs); os.IsNotExist(err) {
+		free, err := preserveTargetFree(preservedAs)
+		if err != nil {
+			return "", fmt.Errorf("check preserve target %s: %w", preservedAs, err)
+		}
+		if free {
 			break
 		}
 		preservedAs = fmt.Sprintf("%s-%d", base, n)
 	}
 
-	if err := os.Rename(dbPath, preservedAs); err != nil {
+	type move struct{ from, to string }
+	var moved []move
+	rollback := func() error {
+		var rbErr error
+		for i := len(moved) - 1; i >= 0; i-- {
+			if err := os.Rename(moved[i].to, moved[i].from); err != nil {
+				rbErr = errors.Join(rbErr, fmt.Errorf("restore %s: %w", moved[i].from, err))
+			}
+		}
+		return rbErr
+	}
+
+	if err := rename(dbPath, preservedAs); err != nil {
 		return "", fmt.Errorf("preserve existing db %s: %w", dbPath, err)
 	}
+	moved = append(moved, move{from: dbPath, to: preservedAs})
+
 	for _, suffix := range []string{"-wal", "-shm"} {
-		if err := os.Rename(dbPath+suffix, preservedAs+suffix); err != nil && !os.IsNotExist(err) {
-			return "", fmt.Errorf("preserve existing db sidecar %s: %w", dbPath+suffix, err)
+		from, to := dbPath+suffix, preservedAs+suffix
+		if err := rename(from, to); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			if rbErr := rollback(); rbErr != nil {
+				return "", fmt.Errorf("preserve existing db sidecar %s: %w (rollback also failed: %v)", from, err, rbErr)
+			}
+			return "", fmt.Errorf("preserve existing db sidecar %s: %w", from, err)
 		}
+		moved = append(moved, move{from: from, to: to})
 	}
 	return preservedAs, nil
+}
+
+// preserveTargetFree reports whether candidate is available to become a
+// preserve-rename destination: neither the main file nor either -wal/-shm
+// sidecar target may already exist there.
+func preserveTargetFree(candidate string) (bool, error) {
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if _, err := os.Stat(candidate + suffix); err == nil {
+			return false, nil
+		} else if !os.IsNotExist(err) {
+			return false, fmt.Errorf("stat %s: %w", candidate+suffix, err)
+		}
+	}
+	return true, nil
 }
 
 // latestRotatingBackup returns the newest canonical rotating backup

--- a/cmd/attn/db.go
+++ b/cmd/attn/db.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -62,8 +63,9 @@ func runDBRestore(args []string) {
 
 	dbPath := config.DBPath()
 	backupsDir := filepath.Join(config.DataDir(), "backups")
+	pidPath := filepath.Join(config.DataDir(), "attn.pid")
 
-	restoredFrom, preservedAs, err := restoreDatabase(dbPath, backupsDir, source, isDaemonRunningAt(config.DataDir))
+	restoredFrom, preservedAs, err := restoreDatabase(dbPath, backupsDir, source, pidPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "attn db restore: %v\n", err)
 		os.Exit(1)
@@ -78,9 +80,9 @@ func runDBRestore(args []string) {
 	fmt.Println("start the daemon when ready (e.g. `attn daemon ensure`, or reopen the app)")
 }
 
-// restoreDatabase implements `attn db restore` against explicit paths, with an
-// injected daemonRunning check so it is fully unit-testable against temp
-// dirs: it never resolves config's real data dir itself.
+// restoreDatabase implements `attn db restore` against explicit paths so it
+// is fully unit-testable against temp dirs: it never resolves config's real
+// data dir itself.
 //
 // source is either "" or "latest" (pick the newest rotating attn-<ts>.db
 // snapshot in backupsDir) or an explicit path to any snapshot file, including
@@ -93,11 +95,14 @@ func runDBRestore(args []string) {
 // Returns the resolved source path and the preserved-db path (empty if there
 // was nothing to preserve).
 //
-// daemonRunning reports whether a live daemon holds the pid-file lock. An
-// error from it (anything other than a clean "not running"/"running"
-// determination) must not be silently treated as "not running" — that would
-// let a destructive restore proceed while daemon liveness is actually
-// unknown — so restoreDatabase refuses and surfaces the error instead.
+// pidPath is the daemon's pid-file lock (see acquireDaemonLock). The lock is
+// acquired before anything else and held for the entire restore, including
+// staging, preserving, and the final swap — not just probed and released up
+// front. A point-in-time-only probe would leave a window in which a daemon
+// could start (or a second `attn db restore` could run) between the probe
+// and the file swap; holding the lock for the whole critical section closes
+// that window, mirroring how the daemon itself holds the same lock for its
+// entire lifetime (daemon.acquirePIDLock).
 //
 // The live dbPath is only ever mutated after the source has been fully and
 // successfully staged, so a bad source (a directory, an unreadable file, or
@@ -108,14 +113,12 @@ func runDBRestore(args []string) {
 // fully-old file or the fully-new one, never a partially-written one. If the
 // final swap still fails after a preserve-rename has already happened, the
 // preserved copy is rolled back into place so dbPath is never left missing.
-func restoreDatabase(dbPath, backupsDir, source string, daemonRunning func() (bool, error)) (restoredFrom, preservedAs string, err error) {
-	running, err := daemonRunning()
+func restoreDatabase(dbPath, backupsDir, source, pidPath string) (restoredFrom, preservedAs string, err error) {
+	release, err := acquireDaemonLock(pidPath)
 	if err != nil {
-		return "", "", fmt.Errorf("cannot determine daemon state: %w", err)
+		return "", "", err
 	}
-	if running {
-		return "", "", fmt.Errorf("the attn daemon is running; stop it first (quit the app, or `attn daemon stop`) before restoring the database")
-	}
+	defer release()
 
 	srcPath := strings.TrimSpace(source)
 	if srcPath == "" || srcPath == "latest" {
@@ -361,36 +364,38 @@ func stageBackupCopy(src, dstPath string) (stagedPath string, err error) {
 	return tmpPath, nil
 }
 
-// isDaemonRunningAt reports whether a live daemon holds the exclusive flock on
-// dataDir()'s pid file. dataDir is a func rather than a plain string so tests
-// can inject a throwaway temp dir without dbRestore ever touching config's
-// real resolution.
+// acquireDaemonLock acquires and holds the exclusive advisory flock on
+// pidPath, creating the file if it does not yet exist, and returns a release
+// func the caller must call exactly once (a second call is a no-op) when the
+// held section is over.
 //
-// This mirrors the liveness+ownership technique stopProfileDaemon (profile.go)
-// uses: the daemon holds an exclusive advisory lock on its pid file for its
-// whole lifetime (daemon.acquirePIDLock), so successfully acquiring the lock
-// ourselves proves no live daemon owns it — the pid on disk, if any, is stale.
+// This mirrors the liveness+ownership technique stopProfileDaemon
+// (profile.go) uses: the daemon holds this same exclusive lock on its pid
+// file for its whole lifetime (daemon.acquirePIDLock), so successfully
+// acquiring it ourselves proves no live daemon owns it — the pid on disk, if
+// any, is stale. Unlike a probe-then-release check, the caller keeps holding
+// the lock (via the returned release func) for as long as it needs mutual
+// exclusion, so a daemon cannot start, and a second caller of
+// acquireDaemonLock cannot proceed, until release is called.
 //
-// The returned func distinguishes a clean "not running" determination from an
-// error: no pid file (or a lock we can acquire) is (false, nil), a lock held
-// by another process is (true, nil), and any other OpenFile failure (e.g.
-// permission denied) is (false, err) — never silently "not running", which
-// would let a destructive restore proceed while liveness is actually unknown.
-func isDaemonRunningAt(dataDir func() string) func() (bool, error) {
-	return func() (bool, error) {
-		pidPath := filepath.Join(dataDir(), "attn.pid")
-		lockFile, err := os.OpenFile(pidPath, os.O_RDWR, 0)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return false, nil
-			}
-			return false, fmt.Errorf("open pid file %s: %w", pidPath, err)
-		}
-		defer lockFile.Close()
-		if flockErr := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); flockErr == nil {
-			_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
-			return false, nil
-		}
-		return true, nil
+// The lock file is never unlinked here — only unlocked and closed — so a
+// second acquireDaemonLock always contends on the same inode rather than
+// racing a delete-then-recreate against a concurrent acquirer.
+func acquireDaemonLock(pidPath string) (release func(), err error) {
+	lockFile, err := os.OpenFile(pidPath, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open pid file %s: %w", pidPath, err)
 	}
+	if flockErr := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); flockErr != nil {
+		lockFile.Close()
+		return nil, fmt.Errorf("the attn daemon is running; stop it first (quit the app, or `attn daemon stop`) before restoring the database")
+	}
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+			_ = lockFile.Close()
+		})
+	}
+	return release, nil
 }

--- a/cmd/attn/db.go
+++ b/cmd/attn/db.go
@@ -97,6 +97,16 @@ func runDBRestore(args []string) {
 // determination) must not be silently treated as "not running" — that would
 // let a destructive restore proceed while daemon liveness is actually
 // unknown — so restoreDatabase refuses and surfaces the error instead.
+//
+// The live dbPath is only ever mutated after the source has been fully and
+// successfully staged, so a bad source (a directory, an unreadable file, or
+// dbPath itself) is rejected before anything at dbPath is touched. Staging
+// happens into a uniquely-named temp file in dbPath's own directory, which
+// also makes the final swap a same-filesystem os.Rename instead of a
+// copy/truncate directly onto the live path — so the live path is either the
+// fully-old file or the fully-new one, never a partially-written one. If the
+// final swap still fails after a preserve-rename has already happened, the
+// preserved copy is rolled back into place so dbPath is never left missing.
 func restoreDatabase(dbPath, backupsDir, source string, daemonRunning func() (bool, error)) (restoredFrom, preservedAs string, err error) {
 	running, err := daemonRunning()
 	if err != nil {
@@ -112,27 +122,45 @@ func restoreDatabase(dbPath, backupsDir, source string, daemonRunning func() (bo
 		if err != nil {
 			return "", "", err
 		}
-	} else if _, statErr := os.Stat(srcPath); statErr != nil {
-		return "", "", fmt.Errorf("backup file %s: %w", srcPath, statErr)
 	}
 
-	if _, statErr := os.Stat(dbPath); statErr == nil {
-		preservedAs = dbPath + ".pre-restore-" + time.Now().UTC().Format("20060102-150405")
-		if err := os.Rename(dbPath, preservedAs); err != nil {
-			return "", "", fmt.Errorf("preserve existing db %s: %w", dbPath, err)
-		}
-		// Preserve the -wal/-shm sidecars alongside the renamed db, never
-		// delete them: they can hold uncheckpointed data that only exists
-		// there. SQLite derives sidecar names by appending to the main
-		// filename, so renaming both to preservedAs+suffix keeps the
-		// preserved copy openable and consistent.
-		for _, suffix := range []string{"-wal", "-shm"} {
-			if err := os.Rename(dbPath+suffix, preservedAs+suffix); err != nil && !os.IsNotExist(err) {
-				return "", "", fmt.Errorf("preserve existing db sidecar %s: %w", dbPath+suffix, err)
-			}
+	srcInfo, statErr := os.Stat(srcPath)
+	if statErr != nil {
+		return "", "", fmt.Errorf("backup file %s: %w", srcPath, statErr)
+	}
+	if !srcInfo.Mode().IsRegular() {
+		return "", "", fmt.Errorf("backup source %s is not a regular file", srcPath)
+	}
+
+	dstExists := false
+	if dstInfo, statErr := os.Stat(dbPath); statErr == nil {
+		dstExists = true
+		if os.SameFile(srcInfo, dstInfo) {
+			return "", "", fmt.Errorf("backup source %s is the live database at %s; choose a snapshot from the backups directory instead", srcPath, dbPath)
 		}
 	} else if !os.IsNotExist(statErr) {
 		return "", "", fmt.Errorf("stat existing db %s: %w", dbPath, statErr)
+	}
+
+	// Fully materialize the source before touching the live path at all:
+	// this is what turns a bad source (directory, unreadable file, disk
+	// full mid-copy) into a no-op failure instead of a stranded db.
+	stagedPath, err := stageBackupCopy(srcPath, dbPath)
+	if err != nil {
+		return "", "", fmt.Errorf("stage backup %s: %w", srcPath, err)
+	}
+	stagedNeedsCleanup := true
+	defer func() {
+		if stagedNeedsCleanup {
+			_ = os.Remove(stagedPath)
+		}
+	}()
+
+	if dstExists {
+		preservedAs, err = preserveExistingDB(dbPath)
+		if err != nil {
+			return "", "", err
+		}
 	} else {
 		// Nothing existed at dbPath to preserve; any stray sidecars are not
 		// tied to a preserved copy, so remove them as before.
@@ -141,11 +169,52 @@ func restoreDatabase(dbPath, backupsDir, source string, daemonRunning func() (bo
 		}
 	}
 
-	if err := copyFileContents(srcPath, dbPath); err != nil {
-		return "", "", fmt.Errorf("copy backup %s into place: %w", srcPath, err)
+	if err := os.Rename(stagedPath, dbPath); err != nil {
+		if preservedAs != "" {
+			// The live path is now missing because the preserve-rename
+			// already happened; put the preserved copy back rather than
+			// leaving dbPath gone.
+			_ = os.Rename(preservedAs, dbPath)
+			for _, suffix := range []string{"-wal", "-shm"} {
+				_ = os.Rename(preservedAs+suffix, dbPath+suffix)
+			}
+		}
+		return "", "", fmt.Errorf("move staged backup into place: %w", err)
 	}
+	stagedNeedsCleanup = false
 
 	return srcPath, preservedAs, nil
+}
+
+// preserveExistingDB renames dbPath (and its -wal/-shm sidecars, if any) to a
+// collision-proof dbPath+".pre-restore-<UTC ts>[-N]" path, never deleting
+// them: they can hold uncheckpointed data that only exists there. SQLite
+// derives sidecar names by appending to the main filename, so renaming both
+// to preservedAs+suffix keeps the preserved copy openable and consistent.
+//
+// The timestamp alone is only second-resolution, so two restores within the
+// same second would otherwise collide and the second os.Rename would replace
+// the first preserved copy; the -N suffix loop makes the chosen name unique
+// regardless of how many restores land in the same second.
+func preserveExistingDB(dbPath string) (string, error) {
+	base := dbPath + ".pre-restore-" + time.Now().UTC().Format("20060102-150405")
+	preservedAs := base
+	for n := 2; ; n++ {
+		if _, err := os.Stat(preservedAs); os.IsNotExist(err) {
+			break
+		}
+		preservedAs = fmt.Sprintf("%s-%d", base, n)
+	}
+
+	if err := os.Rename(dbPath, preservedAs); err != nil {
+		return "", fmt.Errorf("preserve existing db %s: %w", dbPath, err)
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if err := os.Rename(dbPath+suffix, preservedAs+suffix); err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("preserve existing db sidecar %s: %w", dbPath+suffix, err)
+		}
+	}
+	return preservedAs, nil
 }
 
 // latestRotatingBackup returns the newest canonical rotating backup
@@ -179,33 +248,58 @@ func latestRotatingBackup(dir string) (string, error) {
 	return filepath.Join(dir, names[len(names)-1]), nil
 }
 
-// copyFileContents copies src's bytes into dst (creating/truncating dst),
-// preserving src's file mode. It never removes src — the backup being
-// restored from is left in place.
-func copyFileContents(src, dst string) (err error) {
-	info, err := os.Stat(src)
-	if err != nil {
-		return err
-	}
-
+// stageBackupCopy copies src's bytes into a new, uniquely-named temp file in
+// dstPath's own directory (never dstPath itself), preserving src's file
+// mode, and fsyncs it before returning. It never removes src — the backup
+// being restored from is left in place. On any error the temp file is
+// removed and the caller gets no path to clean up.
+//
+// Staging in dstPath's directory (rather than copying straight onto dstPath)
+// is what makes the final move a same-filesystem os.Rename: atomic, and safe
+// to attempt even if the source turns out to be bad, because nothing at
+// dstPath has been touched yet.
+func stageBackupCopy(src, dstPath string) (stagedPath string, err error) {
 	in, err := os.Open(src)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer in.Close()
 
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	info, err := in.Stat()
 	if err != nil {
-		return err
+		return "", err
 	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(dstPath), filepath.Base(dstPath)+".restore-tmp-*")
+	if err != nil {
+		return "", err
+	}
+	tmpPath := tmp.Name()
+	succeeded := false
 	defer func() {
-		if closeErr := out.Close(); err == nil {
-			err = closeErr
+		if !succeeded {
+			_ = os.Remove(tmpPath)
 		}
 	}()
 
-	_, err = io.Copy(out, in)
-	return err
+	if err := tmp.Chmod(info.Mode().Perm()); err != nil {
+		tmp.Close()
+		return "", err
+	}
+	if _, err := io.Copy(tmp, in); err != nil {
+		tmp.Close()
+		return "", err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		return "", err
+	}
+
+	succeeded = true
+	return tmpPath, nil
 }
 
 // isDaemonRunningAt reports whether a live daemon holds the exclusive flock on

--- a/cmd/attn/db.go
+++ b/cmd/attn/db.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/store"
+)
+
+// runDB routes `attn db <command>`: operator-facing database maintenance that
+// sits alongside the daemon's own automatic rotating backups (BackupNow /
+// backupPreMigration in internal/store).
+func runDB() {
+	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
+		writeDBHelp(os.Stdout)
+		return
+	}
+	switch os.Args[2] {
+	case "restore":
+		if hasHelpFlag(os.Args[3:]) {
+			writeDBHelp(os.Stdout)
+			return
+		}
+		runDBRestore(os.Args[3:])
+	default:
+		fmt.Fprintf(os.Stderr, "db: unknown command %q\n", os.Args[2])
+		writeDBHelp(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func writeDBHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn db <command>
+
+commands:
+  restore [path|latest]
+        restore attn.db from a rotating backup (default: latest). The daemon
+        must be stopped first. The current attn.db is preserved (renamed, never
+        deleted) as attn.db.pre-restore-<UTC timestamp> before the backup is
+        copied into place.
+
+        path defaults to "latest": the newest rotating attn-<timestamp>.db
+        snapshot in the profile's backups directory. Pass an explicit path to
+        restore from any snapshot, including a pre-migration one
+        (attn-premigration-<version>-<timestamp>.db).
+`)
+}
+
+func runDBRestore(args []string) {
+	source := "latest"
+	if len(args) > 0 {
+		source = args[0]
+	}
+
+	dbPath := config.DBPath()
+	backupsDir := filepath.Join(config.DataDir(), "backups")
+
+	restoredFrom, preservedAs, err := restoreDatabase(dbPath, backupsDir, source, isDaemonRunningAt(config.DataDir))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "attn db restore: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("restored attn.db from: %s\n", restoredFrom)
+	if preservedAs != "" {
+		fmt.Printf("previous attn.db preserved as: %s\n", preservedAs)
+	} else {
+		fmt.Println("no previous attn.db existed to preserve")
+	}
+	fmt.Println("start the daemon when ready (e.g. `attn daemon ensure`, or reopen the app)")
+}
+
+// restoreDatabase implements `attn db restore` against explicit paths, with an
+// injected daemonRunning check so it is fully unit-testable against temp
+// dirs: it never resolves config's real data dir itself.
+//
+// source is either "" or "latest" (pick the newest rotating attn-<ts>.db
+// snapshot in backupsDir) or an explicit path to any snapshot file, including
+// a pre-migration one.
+//
+// On success it (a) preserves the existing dbPath by renaming it (and its
+// -wal/-shm sidecars, if any) to dbPath+".pre-restore-<UTC ts>" (a no-op, not
+// an error, if dbPath does not currently exist), then (b) copies (not moves
+// — the source backup remains) the resolved snapshot into place as dbPath.
+// Returns the resolved source path and the preserved-db path (empty if there
+// was nothing to preserve).
+//
+// daemonRunning reports whether a live daemon holds the pid-file lock. An
+// error from it (anything other than a clean "not running"/"running"
+// determination) must not be silently treated as "not running" — that would
+// let a destructive restore proceed while daemon liveness is actually
+// unknown — so restoreDatabase refuses and surfaces the error instead.
+func restoreDatabase(dbPath, backupsDir, source string, daemonRunning func() (bool, error)) (restoredFrom, preservedAs string, err error) {
+	running, err := daemonRunning()
+	if err != nil {
+		return "", "", fmt.Errorf("cannot determine daemon state: %w", err)
+	}
+	if running {
+		return "", "", fmt.Errorf("the attn daemon is running; stop it first (quit the app, or `attn daemon stop`) before restoring the database")
+	}
+
+	srcPath := strings.TrimSpace(source)
+	if srcPath == "" || srcPath == "latest" {
+		srcPath, err = latestRotatingBackup(backupsDir)
+		if err != nil {
+			return "", "", err
+		}
+	} else if _, statErr := os.Stat(srcPath); statErr != nil {
+		return "", "", fmt.Errorf("backup file %s: %w", srcPath, statErr)
+	}
+
+	if _, statErr := os.Stat(dbPath); statErr == nil {
+		preservedAs = dbPath + ".pre-restore-" + time.Now().UTC().Format("20060102-150405")
+		if err := os.Rename(dbPath, preservedAs); err != nil {
+			return "", "", fmt.Errorf("preserve existing db %s: %w", dbPath, err)
+		}
+		// Preserve the -wal/-shm sidecars alongside the renamed db, never
+		// delete them: they can hold uncheckpointed data that only exists
+		// there. SQLite derives sidecar names by appending to the main
+		// filename, so renaming both to preservedAs+suffix keeps the
+		// preserved copy openable and consistent.
+		for _, suffix := range []string{"-wal", "-shm"} {
+			if err := os.Rename(dbPath+suffix, preservedAs+suffix); err != nil && !os.IsNotExist(err) {
+				return "", "", fmt.Errorf("preserve existing db sidecar %s: %w", dbPath+suffix, err)
+			}
+		}
+	} else if !os.IsNotExist(statErr) {
+		return "", "", fmt.Errorf("stat existing db %s: %w", dbPath, statErr)
+	} else {
+		// Nothing existed at dbPath to preserve; any stray sidecars are not
+		// tied to a preserved copy, so remove them as before.
+		for _, suffix := range []string{"-wal", "-shm"} {
+			_ = os.Remove(dbPath + suffix)
+		}
+	}
+
+	if err := copyFileContents(srcPath, dbPath); err != nil {
+		return "", "", fmt.Errorf("copy backup %s into place: %w", srcPath, err)
+	}
+
+	return srcPath, preservedAs, nil
+}
+
+// latestRotatingBackup returns the newest canonical rotating backup
+// (attn-<timestamp>.db) in dir, by lexical (== chronological, fixed-width
+// timestamp) sort. It defers to store.IsRotatingBackupName for the canonical
+// filename check (validated timestamp suffix, not just a prefix/suffix
+// match), so a stray non-canonical attn-*.db file cannot be mistaken for the
+// latest backup. Pre-migration snapshots (attn-premigration-*.db) are
+// excluded — "latest" only ever means the newest routine rotation.
+func latestRotatingBackup(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("read backups dir %s: %w", dir, err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !store.IsRotatingBackupName(name) {
+			continue
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return "", fmt.Errorf("no rotating backups found in %s", dir)
+	}
+	sort.Strings(names)
+	return filepath.Join(dir, names[len(names)-1]), nil
+}
+
+// copyFileContents copies src's bytes into dst (creating/truncating dst),
+// preserving src's file mode. It never removes src — the backup being
+// restored from is left in place.
+func copyFileContents(src, dst string) (err error) {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := out.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
+// isDaemonRunningAt reports whether a live daemon holds the exclusive flock on
+// dataDir()'s pid file. dataDir is a func rather than a plain string so tests
+// can inject a throwaway temp dir without dbRestore ever touching config's
+// real resolution.
+//
+// This mirrors the liveness+ownership technique stopProfileDaemon (profile.go)
+// uses: the daemon holds an exclusive advisory lock on its pid file for its
+// whole lifetime (daemon.acquirePIDLock), so successfully acquiring the lock
+// ourselves proves no live daemon owns it — the pid on disk, if any, is stale.
+//
+// The returned func distinguishes a clean "not running" determination from an
+// error: no pid file (or a lock we can acquire) is (false, nil), a lock held
+// by another process is (true, nil), and any other OpenFile failure (e.g.
+// permission denied) is (false, err) — never silently "not running", which
+// would let a destructive restore proceed while liveness is actually unknown.
+func isDaemonRunningAt(dataDir func() string) func() (bool, error) {
+	return func() (bool, error) {
+		pidPath := filepath.Join(dataDir(), "attn.pid")
+		lockFile, err := os.OpenFile(pidPath, os.O_RDWR, 0)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("open pid file %s: %w", pidPath, err)
+		}
+		defer lockFile.Close()
+		if flockErr := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); flockErr == nil {
+			_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+			return false, nil
+		}
+		return true, nil
+	}
+}

--- a/cmd/attn/db_test.go
+++ b/cmd/attn/db_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func alwaysRunning() (bool, error) { return true, nil }
+func neverRunning() (bool, error)  { return false, nil }
+
+// TestRestoreDatabase_RefusesWhileRunning proves restoreDatabase refuses to
+// touch anything on disk when the injected daemon-running check reports the
+// daemon is live, and that its error tells the operator to stop the daemon.
+func TestRestoreDatabase_RefusesWhileRunning(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "attn.db")
+	backupsDir := filepath.Join(dir, "backups")
+	writeFile(t, dbPath, "current db")
+	mustMkdirAll(t, backupsDir)
+	writeFile(t, filepath.Join(backupsDir, "attn-20260101-000000.db"), "backup")
+
+	_, _, err := restoreDatabase(dbPath, backupsDir, "latest", alwaysRunning)
+	if err == nil {
+		t.Fatal("expected error while daemon is running, got nil")
+	}
+	if !strings.Contains(err.Error(), "stop it first") && !strings.Contains(strings.ToLower(err.Error()), "running") {
+		t.Fatalf("error should tell the operator to stop the daemon, got: %v", err)
+	}
+
+	if got := readFile(t, dbPath); got != "current db" {
+		t.Fatalf("db was modified despite refusal: %q", got)
+	}
+}
+
+// TestRestoreDatabase_LatestSelectionPicksNewest proves "latest" (and the
+// default empty string) resolve to the newest rotating attn-<ts>.db by
+// timestamp, ignoring pre-migration snapshots even if they sort later
+// lexically by chance.
+func TestRestoreDatabase_LatestSelectionPicksNewest(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "attn.db")
+	backupsDir := filepath.Join(dir, "backups")
+	writeFile(t, dbPath, "current db")
+	mustMkdirAll(t, backupsDir)
+	writeFile(t, filepath.Join(backupsDir, "attn-20260101-000000.db"), "oldest")
+	writeFile(t, filepath.Join(backupsDir, "attn-20260601-000000.db"), "newest rotating")
+	writeFile(t, filepath.Join(backupsDir, "attn-20260301-000000.db"), "middle")
+	// A pre-migration snapshot with a timestamp that would sort after every
+	// rotating backup above must still be excluded from "latest".
+	writeFile(t, filepath.Join(backupsDir, "attn-premigration-99-20261231-000000.db"), "premigration, must be ignored")
+
+	restoredFrom, _, err := restoreDatabase(dbPath, backupsDir, "latest", neverRunning)
+	if err != nil {
+		t.Fatalf("restoreDatabase error: %v", err)
+	}
+	if filepath.Base(restoredFrom) != "attn-20260601-000000.db" {
+		t.Fatalf("restoredFrom = %s, want the newest rotating backup", restoredFrom)
+	}
+	if got := readFile(t, dbPath); got != "newest rotating" {
+		t.Fatalf("restored db content = %q, want the newest rotating backup's content", got)
+	}
+
+	// Default (empty string) source must behave identically to "latest".
+	writeFile(t, dbPath, "current db again")
+	restoredFrom2, _, err := restoreDatabase(dbPath, backupsDir, "", neverRunning)
+	if err != nil {
+		t.Fatalf("restoreDatabase (default) error: %v", err)
+	}
+	if restoredFrom2 != restoredFrom {
+		t.Fatalf("default source resolved to %s, want same as explicit latest %s", restoredFrom2, restoredFrom)
+	}
+}
+
+// TestRestoreDatabase_PreservesOldDBAndLeavesBackupInPlace proves the restore
+// preserves (renames, never deletes) the pre-restore attn.db and its -wal/-shm
+// sidecars, copies (not moves) the backup into place, and that the backup
+// file itself survives at its original path afterward.
+func TestRestoreDatabase_PreservesOldDBAndLeavesBackupInPlace(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "attn.db")
+	backupsDir := filepath.Join(dir, "backups")
+	writeFile(t, dbPath, "old contents")
+	writeFile(t, dbPath+"-wal", "wal")
+	writeFile(t, dbPath+"-shm", "shm")
+	mustMkdirAll(t, backupsDir)
+	backupPath := filepath.Join(backupsDir, "attn-20260101-000000.db")
+	writeFile(t, backupPath, "backup contents")
+
+	restoredFrom, preservedAs, err := restoreDatabase(dbPath, backupsDir, "latest", neverRunning)
+	if err != nil {
+		t.Fatalf("restoreDatabase error: %v", err)
+	}
+	if restoredFrom != backupPath {
+		t.Fatalf("restoredFrom = %s, want %s", restoredFrom, backupPath)
+	}
+	if preservedAs == "" {
+		t.Fatal("expected a non-empty preservedAs path for an existing attn.db")
+	}
+	if got := readFile(t, preservedAs); got != "old contents" {
+		t.Fatalf("preserved db content = %q, want %q", got, "old contents")
+	}
+	if got := readFile(t, dbPath); got != "backup contents" {
+		t.Fatalf("restored db content = %q, want %q", got, "backup contents")
+	}
+	// The backup file itself must still exist, unmodified — restore copies.
+	if got := readFile(t, backupPath); got != "backup contents" {
+		t.Fatalf("backup file was mutated or removed: %q", got)
+	}
+	// The old db's -wal/-shm sidecars must be preserved alongside the
+	// renamed db, not deleted — they can hold uncheckpointed data.
+	if got := readFile(t, preservedAs+"-wal"); got != "wal" {
+		t.Fatalf("preserved -wal content = %q, want %q", got, "wal")
+	}
+	if got := readFile(t, preservedAs+"-shm"); got != "shm" {
+		t.Fatalf("preserved -shm content = %q, want %q", got, "shm")
+	}
+	// No stale sidecars should be left at the (now-restored) dbPath.
+	if _, err := os.Stat(dbPath + "-wal"); !os.IsNotExist(err) {
+		t.Fatalf("expected attn.db-wal to be gone from dbPath, stat err = %v", err)
+	}
+	if _, err := os.Stat(dbPath + "-shm"); !os.IsNotExist(err) {
+		t.Fatalf("expected attn.db-shm to be gone from dbPath, stat err = %v", err)
+	}
+}
+
+// TestRestoreDatabase_NoExistingDBRemovesStraySidecars proves that when there
+// is no existing dbPath to preserve, stray -wal/-shm sidecars (with nothing
+// to be preserved alongside) are still cleaned up as before.
+func TestRestoreDatabase_NoExistingDBRemovesStraySidecars(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "attn.db")
+	backupsDir := filepath.Join(dir, "backups")
+	writeFile(t, dbPath+"-wal", "stray wal")
+	writeFile(t, dbPath+"-shm", "stray shm")
+	mustMkdirAll(t, backupsDir)
+	backupPath := filepath.Join(backupsDir, "attn-20260101-000000.db")
+	writeFile(t, backupPath, "backup contents")
+
+	_, preservedAs, err := restoreDatabase(dbPath, backupsDir, "latest", neverRunning)
+	if err != nil {
+		t.Fatalf("restoreDatabase error: %v", err)
+	}
+	if preservedAs != "" {
+		t.Fatalf("expected no preservedAs when there was no existing db, got %q", preservedAs)
+	}
+	if _, err := os.Stat(dbPath + "-wal"); !os.IsNotExist(err) {
+		t.Fatalf("expected stray attn.db-wal to be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(dbPath + "-shm"); !os.IsNotExist(err) {
+		t.Fatalf("expected stray attn.db-shm to be removed, stat err = %v", err)
+	}
+}
+
+// TestRestoreDatabase_MissingBackupsDirErrors proves resolving "latest"
+// against a nonexistent backups dir fails loudly rather than silently no-op'ing.
+func TestRestoreDatabase_MissingBackupsDirErrors(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "attn.db")
+	backupsDir := filepath.Join(dir, "backups") // never created
+	writeFile(t, dbPath, "current db")
+
+	_, _, err := restoreDatabase(dbPath, backupsDir, "latest", neverRunning)
+	if err == nil {
+		t.Fatal("expected error for missing backups dir, got nil")
+	}
+	if got := readFile(t, dbPath); got != "current db" {
+		t.Fatalf("db was modified despite the error: %q", got)
+	}
+}
+
+// TestIsDaemonRunningAt_NoPidFile proves the liveness check reports "not
+// running" (with no error) when there is no pid file at all, without ever
+// touching real config resolution — dataDir is an injected temp dir.
+func TestIsDaemonRunningAt_NoPidFile(t *testing.T) {
+	dir := t.TempDir()
+	check := isDaemonRunningAt(func() string { return dir })
+	running, err := check()
+	if err != nil {
+		t.Fatalf("unexpected error with no pid file present: %v", err)
+	}
+	if running {
+		t.Fatal("expected not-running with no pid file present")
+	}
+}
+
+// TestIsDaemonRunningAt_FlockHeld proves the liveness check reports
+// "running" (true, nil) while another open file description holds the
+// exclusive flock on the pid file, and "not running" (false, nil) once that
+// lock is released. BSD flock is per-open-file-description, so holding the
+// lock on a separate fd from the one isDaemonRunningAt opens internally is a
+// faithful stand-in for a live daemon process holding the lock.
+func TestIsDaemonRunningAt_FlockHeld(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "attn.pid")
+	writeFile(t, pidPath, "12345")
+
+	lockFile, err := os.OpenFile(pidPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open pid file: %v", err)
+	}
+	defer lockFile.Close()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("flock pid file: %v", err)
+	}
+
+	check := isDaemonRunningAt(func() string { return dir })
+
+	running, err := check()
+	if err != nil {
+		t.Fatalf("unexpected error while lock held: %v", err)
+	}
+	if !running {
+		t.Fatal("expected running=true while another fd holds the flock")
+	}
+
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatalf("unlock pid file: %v", err)
+	}
+
+	running, err = check()
+	if err != nil {
+		t.Fatalf("unexpected error after unlock: %v", err)
+	}
+	if running {
+		t.Fatal("expected running=false after the lock was released")
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func mustMkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+}

--- a/cmd/attn/db_test.go
+++ b/cmd/attn/db_test.go
@@ -171,6 +171,101 @@ func TestRestoreDatabase_MissingBackupsDirErrors(t *testing.T) {
 	}
 }
 
+// TestRestoreDatabase_RejectsSourceEqualToDestination proves that passing
+// the live attn.db itself as the restore source is rejected before anything
+// is touched, rather than renaming the source out from under itself and
+// then failing with the live db already gone.
+func TestRestoreDatabase_RejectsSourceEqualToDestination(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "attn.db")
+	backupsDir := filepath.Join(dir, "backups")
+	writeFile(t, dbPath, "current db")
+	mustMkdirAll(t, backupsDir)
+
+	_, _, err := restoreDatabase(dbPath, backupsDir, dbPath, neverRunning)
+	if err == nil {
+		t.Fatal("expected error when source == destination, got nil")
+	}
+	if !strings.Contains(err.Error(), "live database") {
+		t.Fatalf("error should call out that the source is the live database, got: %v", err)
+	}
+	if got := readFile(t, dbPath); got != "current db" {
+		t.Fatalf("db was modified despite the rejection: %q", got)
+	}
+	matches, globErr := filepath.Glob(dbPath + ".pre-restore-*")
+	if globErr != nil {
+		t.Fatalf("glob for preserve-rename artifacts: %v", globErr)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("no preserve-rename should have happened, found: %v", matches)
+	}
+}
+
+// TestRestoreDatabase_RejectsNonRegularSource proves that a directory passed
+// as the restore source is rejected (os.Stat succeeds for directories, so
+// this must be an explicit check) before the live db is touched, rather than
+// failing partway through io.Copy after the live db has already been
+// renamed aside and truncated.
+func TestRestoreDatabase_RejectsNonRegularSource(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "attn.db")
+	backupsDir := filepath.Join(dir, "backups")
+	writeFile(t, dbPath, "current db")
+	mustMkdirAll(t, backupsDir)
+	notAFile := filepath.Join(dir, "not-a-backup-dir")
+	mustMkdirAll(t, notAFile)
+
+	_, _, err := restoreDatabase(dbPath, backupsDir, notAFile, neverRunning)
+	if err == nil {
+		t.Fatal("expected error for a directory source, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("error should call out the source is not a regular file, got: %v", err)
+	}
+	if got := readFile(t, dbPath); got != "current db" {
+		t.Fatalf("db was modified despite the rejection: %q", got)
+	}
+}
+
+// TestRestoreDatabase_PreserveNameCollisionIsResolved proves that two
+// restores landing in the same second (so their default UTC-timestamp
+// preserve names would collide) each get their own preserved copy instead of
+// the second restore's preserve-rename silently replacing the first.
+func TestRestoreDatabase_PreserveNameCollisionIsResolved(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "attn.db")
+	backupsDir := filepath.Join(dir, "backups")
+	mustMkdirAll(t, backupsDir)
+	backupPath := filepath.Join(backupsDir, "attn-20260101-000000.db")
+	writeFile(t, backupPath, "backup contents")
+
+	// Simulate the collision directly: preserveExistingDB is what
+	// restoreDatabase calls internally, and its collision-avoidance loop is
+	// exercised by calling it twice for the same second without relying on
+	// two restoreDatabase calls landing in the same wall-clock second.
+	writeFile(t, dbPath, "first generation")
+	firstPreserved, err := preserveExistingDB(dbPath)
+	if err != nil {
+		t.Fatalf("first preserveExistingDB error: %v", err)
+	}
+
+	writeFile(t, dbPath, "second generation")
+	secondPreserved, err := preserveExistingDB(dbPath)
+	if err != nil {
+		t.Fatalf("second preserveExistingDB error: %v", err)
+	}
+
+	if firstPreserved == secondPreserved {
+		t.Fatalf("expected distinct preserved paths, both were %q", firstPreserved)
+	}
+	if got := readFile(t, firstPreserved); got != "first generation" {
+		t.Fatalf("first preserved db content = %q, want %q (must not be clobbered by the second preserve)", got, "first generation")
+	}
+	if got := readFile(t, secondPreserved); got != "second generation" {
+		t.Fatalf("second preserved db content = %q, want %q", got, "second generation")
+	}
+}
+
 // TestIsDaemonRunningAt_NoPidFile proves the liveness check reports "not
 // running" (with no error) when there is no pid file at all, without ever
 // touching real config resolution — dataDir is an injected temp dir.

--- a/cmd/attn/db_test.go
+++ b/cmd/attn/db_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func alwaysRunning() (bool, error) { return true, nil }
@@ -227,6 +229,15 @@ func TestRestoreDatabase_RejectsNonRegularSource(t *testing.T) {
 	}
 }
 
+// fixedClock returns a now func pinned to the same instant every call, so
+// preserveExistingDBAt's collision-avoidance loop can be exercised
+// deterministically instead of depending on two calls landing in the same
+// real wall-clock second.
+func fixedClock() func() time.Time {
+	t := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	return func() time.Time { return t }
+}
+
 // TestRestoreDatabase_PreserveNameCollisionIsResolved proves that two
 // restores landing in the same second (so their default UTC-timestamp
 // preserve names would collide) each get their own preserved copy instead of
@@ -234,25 +245,18 @@ func TestRestoreDatabase_RejectsNonRegularSource(t *testing.T) {
 func TestRestoreDatabase_PreserveNameCollisionIsResolved(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "attn.db")
-	backupsDir := filepath.Join(dir, "backups")
-	mustMkdirAll(t, backupsDir)
-	backupPath := filepath.Join(backupsDir, "attn-20260101-000000.db")
-	writeFile(t, backupPath, "backup contents")
+	now := fixedClock()
 
-	// Simulate the collision directly: preserveExistingDB is what
-	// restoreDatabase calls internally, and its collision-avoidance loop is
-	// exercised by calling it twice for the same second without relying on
-	// two restoreDatabase calls landing in the same wall-clock second.
 	writeFile(t, dbPath, "first generation")
-	firstPreserved, err := preserveExistingDB(dbPath)
+	firstPreserved, err := preserveExistingDBAt(dbPath, now, os.Rename)
 	if err != nil {
-		t.Fatalf("first preserveExistingDB error: %v", err)
+		t.Fatalf("first preserveExistingDBAt error: %v", err)
 	}
 
 	writeFile(t, dbPath, "second generation")
-	secondPreserved, err := preserveExistingDB(dbPath)
+	secondPreserved, err := preserveExistingDBAt(dbPath, now, os.Rename)
 	if err != nil {
-		t.Fatalf("second preserveExistingDB error: %v", err)
+		t.Fatalf("second preserveExistingDBAt error: %v", err)
 	}
 
 	if firstPreserved == secondPreserved {
@@ -263,6 +267,79 @@ func TestRestoreDatabase_PreserveNameCollisionIsResolved(t *testing.T) {
 	}
 	if got := readFile(t, secondPreserved); got != "second generation" {
 		t.Fatalf("second preserved db content = %q, want %q", got, "second generation")
+	}
+}
+
+// TestPreserveExistingDB_CollisionCheckCoversSidecarTargets proves the
+// collision-avoidance loop rejects a candidate name whose main-file slot is
+// free but whose -wal sidecar slot is already taken by an unrelated file —
+// checking only the main file would let the sidecar rename silently replace
+// that stray file.
+func TestPreserveExistingDB_CollisionCheckCoversSidecarTargets(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "attn.db")
+	now := fixedClock()
+	writeFile(t, dbPath, "live db")
+	writeFile(t, dbPath+"-wal", "live wal")
+
+	base := dbPath + ".pre-restore-" + now().UTC().Format("20060102-150405")
+	writeFile(t, base+"-wal", "unrelated stray wal")
+
+	preservedAs, err := preserveExistingDBAt(dbPath, now, os.Rename)
+	if err != nil {
+		t.Fatalf("preserveExistingDBAt error: %v", err)
+	}
+	if preservedAs == base {
+		t.Fatalf("expected a name other than %q since its -wal target was already taken", base)
+	}
+	if got := readFile(t, base+"-wal"); got != "unrelated stray wal" {
+		t.Fatalf("stray -wal file was clobbered, content = %q", got)
+	}
+	if got := readFile(t, preservedAs); got != "live db" {
+		t.Fatalf("preserved db content = %q, want %q", got, "live db")
+	}
+	if got := readFile(t, preservedAs+"-wal"); got != "live wal" {
+		t.Fatalf("preserved -wal content = %q, want %q", got, "live wal")
+	}
+}
+
+// TestPreserveExistingDB_RollsBackIfSidecarRenameFails proves that when the
+// main-file rename succeeds but a sidecar rename then fails, the main-file
+// move is rolled back so dbPath is never left missing.
+func TestPreserveExistingDB_RollsBackIfSidecarRenameFails(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "attn.db")
+	writeFile(t, dbPath, "live db")
+	writeFile(t, dbPath+"-wal", "live wal")
+	writeFile(t, dbPath+"-shm", "live shm")
+
+	calls := 0
+	failOnSecondCall := func(oldpath, newpath string) error {
+		calls++
+		if calls == 2 { // the -wal sidecar rename
+			return fmt.Errorf("injected rename failure")
+		}
+		return os.Rename(oldpath, newpath)
+	}
+
+	_, err := preserveExistingDBAt(dbPath, fixedClock(), failOnSecondCall)
+	if err == nil {
+		t.Fatal("expected error when the sidecar rename fails")
+	}
+	if !strings.Contains(err.Error(), "injected rename failure") {
+		t.Fatalf("error should surface the underlying rename failure, got: %v", err)
+	}
+
+	if got := readFile(t, dbPath); got != "live db" {
+		t.Fatalf("dbPath was not restored by rollback, content = %q", got)
+	}
+	if got := readFile(t, dbPath+"-wal"); got != "live wal" {
+		t.Fatalf("-wal sidecar was not restored by rollback, content = %q", got)
+	}
+	// The -shm sidecar rename was never reached (the -wal one failed first)
+	// so it should be untouched.
+	if got := readFile(t, dbPath+"-shm"); got != "live shm" {
+		t.Fatalf("-shm sidecar unexpectedly modified, content = %q", got)
 	}
 }
 

--- a/cmd/attn/db_test.go
+++ b/cmd/attn/db_test.go
@@ -10,26 +10,44 @@ import (
 	"time"
 )
 
-func alwaysRunning() (bool, error) { return true, nil }
-func neverRunning() (bool, error)  { return false, nil }
+// testPidPath returns a not-yet-created pid-file path in dir: passing it to
+// restoreDatabase exercises the common case where no daemon has ever run
+// (acquireDaemonLock creates and locks it), without any test needing to
+// depend on a real daemon-liveness stand-in.
+func testPidPath(dir string) string {
+	return filepath.Join(dir, "attn.pid")
+}
 
 // TestRestoreDatabase_RefusesWhileRunning proves restoreDatabase refuses to
-// touch anything on disk when the injected daemon-running check reports the
-// daemon is live, and that its error tells the operator to stop the daemon.
+// touch anything on disk when another file description already holds the
+// exclusive flock on the pid file (a faithful stand-in for a live daemon
+// holding daemon.acquirePIDLock — flock is per-open-file-description), and
+// that its error tells the operator to stop the daemon.
 func TestRestoreDatabase_RefusesWhileRunning(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "attn.db")
 	backupsDir := filepath.Join(dir, "backups")
+	pidPath := testPidPath(dir)
 	writeFile(t, dbPath, "current db")
 	mustMkdirAll(t, backupsDir)
 	writeFile(t, filepath.Join(backupsDir, "attn-20260101-000000.db"), "backup")
+	writeFile(t, pidPath, "12345")
 
-	_, _, err := restoreDatabase(dbPath, backupsDir, "latest", alwaysRunning)
-	if err == nil {
+	lockFile, err := os.OpenFile(pidPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open pid file: %v", err)
+	}
+	defer lockFile.Close()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("flock pid file: %v", err)
+	}
+
+	_, _, restoreErr := restoreDatabase(dbPath, backupsDir, "latest", pidPath)
+	if restoreErr == nil {
 		t.Fatal("expected error while daemon is running, got nil")
 	}
-	if !strings.Contains(err.Error(), "stop it first") && !strings.Contains(strings.ToLower(err.Error()), "running") {
-		t.Fatalf("error should tell the operator to stop the daemon, got: %v", err)
+	if !strings.Contains(restoreErr.Error(), "stop it first") && !strings.Contains(strings.ToLower(restoreErr.Error()), "running") {
+		t.Fatalf("error should tell the operator to stop the daemon, got: %v", restoreErr)
 	}
 
 	if got := readFile(t, dbPath); got != "current db" {
@@ -45,6 +63,7 @@ func TestRestoreDatabase_LatestSelectionPicksNewest(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "attn.db")
 	backupsDir := filepath.Join(dir, "backups")
+	pidPath := testPidPath(dir)
 	writeFile(t, dbPath, "current db")
 	mustMkdirAll(t, backupsDir)
 	writeFile(t, filepath.Join(backupsDir, "attn-20260101-000000.db"), "oldest")
@@ -54,7 +73,7 @@ func TestRestoreDatabase_LatestSelectionPicksNewest(t *testing.T) {
 	// rotating backup above must still be excluded from "latest".
 	writeFile(t, filepath.Join(backupsDir, "attn-premigration-99-20261231-000000.db"), "premigration, must be ignored")
 
-	restoredFrom, _, err := restoreDatabase(dbPath, backupsDir, "latest", neverRunning)
+	restoredFrom, _, err := restoreDatabase(dbPath, backupsDir, "latest", pidPath)
 	if err != nil {
 		t.Fatalf("restoreDatabase error: %v", err)
 	}
@@ -67,7 +86,7 @@ func TestRestoreDatabase_LatestSelectionPicksNewest(t *testing.T) {
 
 	// Default (empty string) source must behave identically to "latest".
 	writeFile(t, dbPath, "current db again")
-	restoredFrom2, _, err := restoreDatabase(dbPath, backupsDir, "", neverRunning)
+	restoredFrom2, _, err := restoreDatabase(dbPath, backupsDir, "", pidPath)
 	if err != nil {
 		t.Fatalf("restoreDatabase (default) error: %v", err)
 	}
@@ -84,6 +103,7 @@ func TestRestoreDatabase_PreservesOldDBAndLeavesBackupInPlace(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "attn.db")
 	backupsDir := filepath.Join(dir, "backups")
+	pidPath := testPidPath(dir)
 	writeFile(t, dbPath, "old contents")
 	writeFile(t, dbPath+"-wal", "wal")
 	writeFile(t, dbPath+"-shm", "shm")
@@ -91,7 +111,7 @@ func TestRestoreDatabase_PreservesOldDBAndLeavesBackupInPlace(t *testing.T) {
 	backupPath := filepath.Join(backupsDir, "attn-20260101-000000.db")
 	writeFile(t, backupPath, "backup contents")
 
-	restoredFrom, preservedAs, err := restoreDatabase(dbPath, backupsDir, "latest", neverRunning)
+	restoredFrom, preservedAs, err := restoreDatabase(dbPath, backupsDir, "latest", pidPath)
 	if err != nil {
 		t.Fatalf("restoreDatabase error: %v", err)
 	}
@@ -135,13 +155,14 @@ func TestRestoreDatabase_NoExistingDBRemovesStraySidecars(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "attn.db")
 	backupsDir := filepath.Join(dir, "backups")
+	pidPath := testPidPath(dir)
 	writeFile(t, dbPath+"-wal", "stray wal")
 	writeFile(t, dbPath+"-shm", "stray shm")
 	mustMkdirAll(t, backupsDir)
 	backupPath := filepath.Join(backupsDir, "attn-20260101-000000.db")
 	writeFile(t, backupPath, "backup contents")
 
-	_, preservedAs, err := restoreDatabase(dbPath, backupsDir, "latest", neverRunning)
+	_, preservedAs, err := restoreDatabase(dbPath, backupsDir, "latest", pidPath)
 	if err != nil {
 		t.Fatalf("restoreDatabase error: %v", err)
 	}
@@ -162,9 +183,10 @@ func TestRestoreDatabase_MissingBackupsDirErrors(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "attn.db")
 	backupsDir := filepath.Join(dir, "backups") // never created
+	pidPath := testPidPath(dir)
 	writeFile(t, dbPath, "current db")
 
-	_, _, err := restoreDatabase(dbPath, backupsDir, "latest", neverRunning)
+	_, _, err := restoreDatabase(dbPath, backupsDir, "latest", pidPath)
 	if err == nil {
 		t.Fatal("expected error for missing backups dir, got nil")
 	}
@@ -181,10 +203,11 @@ func TestRestoreDatabase_RejectsSourceEqualToDestination(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "attn.db")
 	backupsDir := filepath.Join(dir, "backups")
+	pidPath := testPidPath(dir)
 	writeFile(t, dbPath, "current db")
 	mustMkdirAll(t, backupsDir)
 
-	_, _, err := restoreDatabase(dbPath, backupsDir, dbPath, neverRunning)
+	_, _, err := restoreDatabase(dbPath, backupsDir, dbPath, pidPath)
 	if err == nil {
 		t.Fatal("expected error when source == destination, got nil")
 	}
@@ -212,12 +235,13 @@ func TestRestoreDatabase_RejectsNonRegularSource(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "attn.db")
 	backupsDir := filepath.Join(dir, "backups")
+	pidPath := testPidPath(dir)
 	writeFile(t, dbPath, "current db")
 	mustMkdirAll(t, backupsDir)
 	notAFile := filepath.Join(dir, "not-a-backup-dir")
 	mustMkdirAll(t, notAFile)
 
-	_, _, err := restoreDatabase(dbPath, backupsDir, notAFile, neverRunning)
+	_, _, err := restoreDatabase(dbPath, backupsDir, notAFile, pidPath)
 	if err == nil {
 		t.Fatal("expected error for a directory source, got nil")
 	}
@@ -343,28 +367,29 @@ func TestPreserveExistingDB_RollsBackIfSidecarRenameFails(t *testing.T) {
 	}
 }
 
-// TestIsDaemonRunningAt_NoPidFile proves the liveness check reports "not
-// running" (with no error) when there is no pid file at all, without ever
-// touching real config resolution — dataDir is an injected temp dir.
-func TestIsDaemonRunningAt_NoPidFile(t *testing.T) {
+// TestAcquireDaemonLock_NoPidFile proves the lock can be acquired (with no
+// error) when there is no pid file at all yet — acquireDaemonLock creates it.
+func TestAcquireDaemonLock_NoPidFile(t *testing.T) {
 	dir := t.TempDir()
-	check := isDaemonRunningAt(func() string { return dir })
-	running, err := check()
+	pidPath := filepath.Join(dir, "attn.pid")
+
+	release, err := acquireDaemonLock(pidPath)
 	if err != nil {
 		t.Fatalf("unexpected error with no pid file present: %v", err)
 	}
-	if running {
-		t.Fatal("expected not-running with no pid file present")
+	defer release()
+
+	if _, statErr := os.Stat(pidPath); statErr != nil {
+		t.Fatalf("expected acquireDaemonLock to create the pid file, stat err = %v", statErr)
 	}
 }
 
-// TestIsDaemonRunningAt_FlockHeld proves the liveness check reports
-// "running" (true, nil) while another open file description holds the
-// exclusive flock on the pid file, and "not running" (false, nil) once that
-// lock is released. BSD flock is per-open-file-description, so holding the
-// lock on a separate fd from the one isDaemonRunningAt opens internally is a
-// faithful stand-in for a live daemon process holding the lock.
-func TestIsDaemonRunningAt_FlockHeld(t *testing.T) {
+// TestAcquireDaemonLock_HeldByAnotherProcess proves acquireDaemonLock refuses
+// (with an operator-facing error) while another open file description holds
+// the exclusive flock on the pid file — a faithful stand-in for a live
+// daemon process holding daemon.acquirePIDLock, since BSD flock is
+// per-open-file-description.
+func TestAcquireDaemonLock_HeldByAnotherProcess(t *testing.T) {
 	dir := t.TempDir()
 	pidPath := filepath.Join(dir, "attn.pid")
 	writeFile(t, pidPath, "12345")
@@ -378,27 +403,71 @@ func TestIsDaemonRunningAt_FlockHeld(t *testing.T) {
 		t.Fatalf("flock pid file: %v", err)
 	}
 
-	check := isDaemonRunningAt(func() string { return dir })
-
-	running, err := check()
-	if err != nil {
-		t.Fatalf("unexpected error while lock held: %v", err)
-	}
-	if !running {
-		t.Fatal("expected running=true while another fd holds the flock")
+	if _, err := acquireDaemonLock(pidPath); err == nil {
+		t.Fatal("expected acquireDaemonLock to refuse while another fd holds the flock")
 	}
 
 	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil {
 		t.Fatalf("unlock pid file: %v", err)
 	}
 
-	running, err = check()
+	release, err := acquireDaemonLock(pidPath)
 	if err != nil {
-		t.Fatalf("unexpected error after unlock: %v", err)
+		t.Fatalf("expected acquireDaemonLock to succeed after the lock was released, got: %v", err)
 	}
-	if running {
-		t.Fatal("expected running=false after the lock was released")
+	release()
+}
+
+// TestAcquireDaemonLock_ExcludesConcurrentRestore proves the lock is held —
+// not merely probed and released — for as long as the caller keeps it: a
+// daemon-style flock attempt on the same pid file, and a second
+// acquireDaemonLock call standing in for a concurrent `attn db restore`,
+// must both be refused while the first caller has not released, and both
+// must succeed once it has. This is the regression test for the TOCTOU gap
+// where a point-in-time-only probe left a window between the check and the
+// file swap for a daemon to start or a second restore to race in.
+func TestAcquireDaemonLock_ExcludesConcurrentRestore(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "attn.pid")
+
+	// Simulates restoreDatabase having acquired the lock and being paused
+	// mid-restore (staging/preserving/swapping) — release is deliberately
+	// not called yet.
+	release, err := acquireDaemonLock(pidPath)
+	if err != nil {
+		t.Fatalf("initial acquireDaemonLock error: %v", err)
 	}
+
+	// A daemon starting up (daemon.acquirePIDLock's exact mechanism: open
+	// with O_RDWR|O_CREATE, then LOCK_EX|LOCK_NB) must not be able to start
+	// while restore holds the lock.
+	daemonAttempt, err := os.OpenFile(pidPath, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		t.Fatalf("open pid file as a daemon-style attempt: %v", err)
+	}
+	if flockErr := syscall.Flock(int(daemonAttempt.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); flockErr == nil {
+		syscall.Flock(int(daemonAttempt.Fd()), syscall.LOCK_UN)
+		daemonAttempt.Close()
+		t.Fatal("expected a daemon-style flock attempt to be excluded while restore holds the lock")
+	}
+	daemonAttempt.Close()
+
+	// A second `attn db restore` (a second acquireDaemonLock call) must
+	// also be excluded.
+	if _, err := acquireDaemonLock(pidPath); err == nil {
+		t.Fatal("expected a concurrent acquireDaemonLock to be excluded while the first is still held")
+	}
+
+	release()
+
+	// Once released, both a daemon-style attempt and a fresh
+	// acquireDaemonLock must succeed — the exclusion must not outlive the
+	// held section.
+	afterRelease, err := acquireDaemonLock(pidPath)
+	if err != nil {
+		t.Fatalf("expected acquireDaemonLock to succeed after release, got: %v", err)
+	}
+	afterRelease()
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -255,6 +255,9 @@ func main() {
 	case "debug":
 		maybePrintProfileBanner()
 		runDebug()
+	case "db":
+		maybePrintProfileBanner()
+		runDB()
 	case "journal":
 		maybePrintProfileBanner()
 		runJournal()
@@ -581,6 +584,7 @@ commands:
   list                              list sessions and workspaces
   present <command>                 open a review presentation and read feedback
   debug <command>                   probe debug artifacts (incidents, logs)
+  db <command>                      database maintenance (restore from backup)
   vision-check <image> <question>   answer a question about an image (single LLM call)
   daemon <command>                  manage the daemon
   profile <status|resolve|list>     show / resolve the active profile's resources

--- a/internal/daemon/backup.go
+++ b/internal/daemon/backup.go
@@ -55,4 +55,13 @@ func (d *Daemon) performDatabaseBackup() {
 		return
 	}
 	d.logf("database backup written to %s", path)
+
+	d.lastBackupMu.Lock()
+	d.lastBackupAt = time.Now().UTC()
+	d.lastBackupMu.Unlock()
+
+	// Fan out via the same settings-updated broadcast the settings code uses
+	// elsewhere, so live clients see db.last_backup_at move without a
+	// dedicated protocol message.
+	d.broadcastSettings("")
 }

--- a/internal/daemon/backup_test.go
+++ b/internal/daemon/backup_test.go
@@ -1,0 +1,62 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/store"
+)
+
+// TestPerformDatabaseBackup_SurfacesLastBackupAt proves a successful
+// performDatabaseBackup call records lastBackupAt and surfaces it as a
+// parseable RFC3339 UTC db.last_backup_at settings key, so live clients (and
+// db restore's "did the backup succeed recently" sanity check) can see the
+// backup cadence move.
+func TestPerformDatabaseBackup_SurfacesLastBackupAt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	s, err := store.NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	d := &Daemon{store: s, dataRoot: t.TempDir()}
+
+	before := time.Now().UTC()
+	d.performDatabaseBackup()
+
+	settings := d.settingsWithAgentAvailability()
+	raw, ok := settings[SettingDBLastBackupAt]
+	if !ok {
+		t.Fatalf("settings missing %s after successful backup: %v", SettingDBLastBackupAt, settings)
+	}
+	str, ok := raw.(string)
+	if !ok {
+		t.Fatalf("%s is not a string: %v (%T)", SettingDBLastBackupAt, raw, raw)
+	}
+	parsed, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		t.Fatalf("%s = %q is not parseable RFC3339: %v", SettingDBLastBackupAt, str, err)
+	}
+	if parsed.Before(before.Add(-time.Second)) || parsed.After(time.Now().UTC().Add(time.Second)) {
+		t.Fatalf("%s = %v is outside the expected window around %v", SettingDBLastBackupAt, parsed, before)
+	}
+}
+
+// TestPerformDatabaseBackup_FailedBackupLeavesKeyAbsent proves a failed
+// backup (a non-durable in-memory fallback store, same guard BackupNow
+// enforces) never sets db.last_backup_at — a stale or fabricated success
+// timestamp would be worse than an absent one.
+func TestPerformDatabaseBackup_FailedBackupLeavesKeyAbsent(t *testing.T) {
+	s := store.New() // in-memory fallback: not durable, BackupNow refuses
+	defer s.Close()
+
+	d := &Daemon{store: s, dataRoot: t.TempDir()}
+	d.performDatabaseBackup()
+
+	settings := d.settingsWithAgentAvailability()
+	if raw, ok := settings[SettingDBLastBackupAt]; ok {
+		t.Fatalf("%s should be absent after a failed backup, got %v", SettingDBLastBackupAt, raw)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1953,15 +1953,22 @@ func (d *Daemon) acquirePIDLock() error {
 	return nil
 }
 
-// releasePIDLock unlocks and removes the PID file
+// releasePIDLock unlocks the PID file. It deliberately leaves the file in
+// place on disk rather than removing it: other flock holders of that exact
+// inode (notably `attn db restore`, which holds this same lock for the
+// duration of a restore — see cmd/attn/db.go's acquireDaemonLock) only
+// contend correctly with a future daemon startup if acquirePIDLock reopens
+// and relocks that same inode. Unlinking here would let a concurrent holder
+// keep flocking an orphaned inode while a subsequent os.OpenFile(O_CREATE)
+// elsewhere silently creates and locks a different one at the same
+// pathname, defeating mutual exclusion entirely. acquirePIDLock already
+// truncates and rewrites the file's contents on every acquire, so a stale
+// leftover file is harmless.
 func (d *Daemon) releasePIDLock() {
 	if d.pidFile != nil {
 		syscall.Flock(int(d.pidFile.Fd()), syscall.LOCK_UN)
 		d.pidFile.Close()
 		d.pidFile = nil
-	}
-	if err := os.Remove(d.pidPath); err != nil && !os.IsNotExist(err) {
-		d.logf("Failed to remove PID file: %v", err)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -279,6 +279,13 @@ type Daemon struct {
 	browserControlMu sync.Mutex
 	browserControl   map[string]browserControlPending
 
+	// lastBackupMu guards lastBackupAt, the UTC timestamp of the most recent
+	// successful performDatabaseBackup call. Zero value means no backup has
+	// succeeded yet this process lifetime. Surfaced read-only in the settings
+	// payload as SettingDBLastBackupAt (see ws_settings.go).
+	lastBackupMu sync.Mutex
+	lastBackupAt time.Time
+
 	// Durable workflow engine IPC state. The engine runs in a separate process
 	// (the `attn workflow run` CLI); the daemon persists, coalesced-broadcasts
 	// run updates to the read-only UI, and relays cancel to the engine sink.

--- a/internal/daemon/pidlock_test.go
+++ b/internal/daemon/pidlock_test.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestDaemon_ReleasePIDLock_LeavesFileInPlace proves releasePIDLock unlocks
+// the PID file without unlinking it. The flock, not the file's presence, is
+// the sole mutual-exclusion signal shared with `attn db restore`
+// (cmd/attn/db.go's acquireDaemonLock): if release unlinked the pathname, a
+// concurrent holder of the old inode's flock and a subsequent daemon
+// startup's O_CREATE-created new inode at the same pathname would never
+// contend with each other.
+func TestDaemon_ReleasePIDLock_LeavesFileInPlace(t *testing.T) {
+	dir := t.TempDir()
+	d := &Daemon{pidPath: filepath.Join(dir, "attn.pid")}
+
+	if err := d.acquirePIDLock(); err != nil {
+		t.Fatalf("acquirePIDLock error: %v", err)
+	}
+	d.releasePIDLock()
+
+	if _, err := os.Stat(d.pidPath); err != nil {
+		t.Fatalf("expected pid file to remain on disk after release, stat err = %v", err)
+	}
+
+	// A fresh acquire must succeed on the very same pathname/inode — proving
+	// the flock was actually released, not just abandoned.
+	second := &Daemon{pidPath: d.pidPath}
+	if err := second.acquirePIDLock(); err != nil {
+		t.Fatalf("second acquirePIDLock after release error: %v", err)
+	}
+	second.releasePIDLock()
+}
+
+// TestDaemon_ReleasePIDLock_DoesNotOrphanAConcurrentHolder proves the
+// specific race this fix closes: a third party that flocked the PID file
+// while the daemon held it (standing in for `attn db restore`'s
+// acquireDaemonLock, which holds the lock across an entire restore) keeps
+// exclusive custody of that same inode straight through releasePIDLock, so
+// a subsequent daemon-style acquire attempt on the same pathname is still
+// correctly excluded rather than silently succeeding against a
+// newly-created inode.
+func TestDaemon_ReleasePIDLock_DoesNotOrphanAConcurrentHolder(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "attn.pid")
+
+	d := &Daemon{pidPath: pidPath}
+	if err := d.acquirePIDLock(); err != nil {
+		t.Fatalf("acquirePIDLock error: %v", err)
+	}
+
+	// The daemon shuts down and releases.
+	d.releasePIDLock()
+
+	// A concurrent holder (the restore stand-in) acquires the still-present
+	// file immediately after release, before any new daemon starts.
+	restoreHolder, err := os.OpenFile(pidPath, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		t.Fatalf("open pid file as restore stand-in: %v", err)
+	}
+	defer restoreHolder.Close()
+	if err := syscall.Flock(int(restoreHolder.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("restore stand-in flock: %v", err)
+	}
+
+	// A new daemon startup attempting to acquire the lock at the same
+	// pathname while the restore stand-in holds it must be excluded.
+	next := &Daemon{pidPath: pidPath}
+	if err := next.acquirePIDLock(); err == nil {
+		t.Fatal("expected daemon acquirePIDLock to be excluded while the restore stand-in holds the lock")
+	}
+
+	// Once the restore stand-in releases, the daemon must be able to start.
+	syscall.Flock(int(restoreHolder.Fd()), syscall.LOCK_UN)
+	restoreHolder.Close()
+
+	if err := next.acquirePIDLock(); err != nil {
+		t.Fatalf("expected daemon acquirePIDLock to succeed after the restore stand-in released, got: %v", err)
+	}
+	next.releasePIDLock()
+}

--- a/internal/daemon/ws_settings.go
+++ b/internal/daemon/ws_settings.go
@@ -99,6 +99,12 @@ const (
 	// but produce no background work while off. See notebookTasksEnabled and the
 	// enqueue/executor gates that honor it.
 	SettingNotebookTasksEnabled = "notebook.tasks_enabled"
+	// SettingDBLastBackupAt is a READ-ONLY, daemon-computed key surfaced in the
+	// settings payload (never stored, never accepted by set_setting): the UTC
+	// RFC3339 timestamp of the most recently successful rotating database
+	// backup (see performDatabaseBackup). Absent/empty before the first
+	// successful backup this process lifetime.
+	SettingDBLastBackupAt = "db.last_backup_at"
 )
 
 func (d *Daemon) handleGetSettingsWS(client *wsClient) {
@@ -147,7 +153,7 @@ func (d *Daemon) broadcastCurrentSettings(changedKey string) {
 	if strings.TrimSpace(changedKey) != "" {
 		event.ChangedKey = protocol.Ptr(changedKey)
 	}
-	d.wsHub.BroadcastValue(event)
+	d.broadcastMessage(event)
 }
 
 func executableSettingKey(agent string) string {
@@ -248,6 +254,12 @@ func (d *Daemon) settingsWithAgentAvailability() map[string]interface{} {
 	settings[SettingPTYBackendMode] = d.ptyBackendMode()
 	if root, err := d.notebookRoot(); err == nil {
 		settings[SettingNotebookRootEffective] = root
+	}
+	d.lastBackupMu.Lock()
+	lastBackupAt := d.lastBackupAt
+	d.lastBackupMu.Unlock()
+	if !lastBackupAt.IsZero() {
+		settings[SettingDBLastBackupAt] = lastBackupAt.Format(time.RFC3339)
 	}
 	settings[SettingTailscaleEnabled] = strconv.FormatBool(parseBooleanSetting(stored[SettingTailscaleEnabled]))
 	settings[SettingWorkflowsEnabled] = strconv.FormatBool(parseBooleanSetting(stored[SettingWorkflowsEnabled]))

--- a/internal/daemonctl/ensure.go
+++ b/internal/daemonctl/ensure.go
@@ -145,14 +145,22 @@ func spawnDaemon(binaryPath string) error {
 	return nil
 }
 
+// removeStaleSocketFiles clears the way for a fresh daemon to bind a new
+// listening socket. It deliberately does NOT remove the PID file: the PID
+// file's exclusive flock (not its presence on disk) is the sole mutual-
+// exclusion mechanism a live daemon and `attn db restore` share (see
+// Daemon.acquirePIDLock / releasePIDLock and cmd/attn/db.go's
+// acquireDaemonLock). Unlinking it here — right before spawnDaemon calls
+// acquirePIDLock, which reopens the path with O_CREATE — would let a
+// concurrent flock holder (e.g. a restore in progress) keep its lock on an
+// orphaned inode while the new daemon creates and locks a different inode
+// at the same pathname, so the two would never actually contend. The
+// listening socket has no such lock-based protection, so it still needs
+// unlinking before a fresh bind.
 func removeStaleSocketFiles() error {
 	socketPath := config.SocketPath()
-	pidPath := config.PIDPath()
 	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove stale socket %s: %w", socketPath, err)
-	}
-	if err := os.Remove(pidPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove stale pid %s: %w", pidPath, err)
 	}
 	return nil
 }

--- a/internal/daemonctl/ensure_test.go
+++ b/internal/daemonctl/ensure_test.go
@@ -2,6 +2,7 @@ package daemonctl
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -50,6 +51,44 @@ func TestMismatchReason_ReportsMissingFingerprint(t *testing.T) {
 
 	if got := mismatchReason(nil, healthResponse{}); got != "source_fingerprint_missing" {
 		t.Fatalf("mismatchReason() = %q, want source_fingerprint_missing", got)
+	}
+}
+
+// TestRemoveStaleSocketFiles_LeavesPIDFileInPlace proves removeStaleSocketFiles
+// removes the stale listening socket but never unlinks the PID file. The PID
+// file's exclusive flock (held across acquirePIDLock/releasePIDLock in
+// internal/daemon, and across an entire restore by cmd/attn/db.go's
+// acquireDaemonLock) is the sole mutual-exclusion mechanism; unlinking it
+// here — right before spawnDaemon's acquirePIDLock reopens the path with
+// O_CREATE — would let a concurrent flock holder (e.g. a restore in
+// progress) keep its lock on an orphaned inode while a new daemon silently
+// creates and locks a different one at the same pathname.
+func TestRemoveStaleSocketFiles_LeavesPIDFileInPlace(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "attn.sock")
+	t.Setenv("ATTN_PROFILE", "")
+	t.Setenv("ATTN_SOCKET_PATH", socketPath)
+	t.Setenv("ATTN_DB_PATH", "")
+	t.Setenv("ATTN_CONFIG_PATH", "")
+	config.ReloadForTesting()
+
+	pidPath := config.PIDPath()
+	if err := os.WriteFile(socketPath, []byte("stale socket"), 0644); err != nil {
+		t.Fatalf("write stale socket file: %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte("12345"), 0644); err != nil {
+		t.Fatalf("write stale pid file: %v", err)
+	}
+
+	if err := removeStaleSocketFiles(); err != nil {
+		t.Fatalf("removeStaleSocketFiles error: %v", err)
+	}
+
+	if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+		t.Fatalf("expected stale socket to be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(pidPath); err != nil {
+		t.Fatalf("expected pid file to remain on disk, stat err = %v", err)
 	}
 }
 

--- a/internal/hub/bootstrap.go
+++ b/internal/hub/bootstrap.go
@@ -566,7 +566,7 @@ func (b *Bootstrapper) ensureRemoteDaemonRunning(ctx context.Context, sshTarget,
 	}
 
 	if state.Stale {
-		if _, err := runSSH(ctx, sshTarget, profile, remoteSocketConfigScript()+`rm -f "$socket_path" "$pid_path"`); err != nil {
+		if _, err := runSSH(ctx, sshTarget, profile, removeStaleRemoteSocketScript()); err != nil {
 			return err
 		}
 		state = remoteDaemonState{}
@@ -628,7 +628,9 @@ func (b *Bootstrapper) startRemoteDaemon(ctx context.Context, sshTarget, profile
 }
 
 // stopRemoteDaemonScript returns the shell script that stops the remote daemon
-// for a given profile.
+// for a given profile. It deliberately leaves the PID file in place after
+// stopping the daemon — see the comment on the stale-cleanup branch in
+// ensureRemoteDaemonRunning for why unlinking it would be unsafe.
 func stopRemoteDaemonScript(profile string) string {
 	port := config.WSPortForProfile(profile)
 	return remoteSocketConfigScript() + fmt.Sprintf(`
@@ -651,7 +653,7 @@ for pid in $seen_pids; do
   kill -0 "$pid" 2>/dev/null || continue
   kill -9 "$pid" 2>/dev/null || true
 done
-rm -f "$socket_path" "$pid_path"
+rm -f "$socket_path"
 `, port)
 }
 
@@ -669,8 +671,22 @@ func (b *Bootstrapper) restartRemoteDaemon(ctx context.Context, sshTarget, profi
 		time.Sleep(500 * time.Millisecond)
 		_, _ = runSSH(ctx, sshTarget, profile, fmt.Sprintf("kill -9 %s 2>/dev/null || true", shellQuote(pid)))
 	}
-	if _, err := runSSH(ctx, sshTarget, profile, remoteSocketConfigScript()+`rm -f "$socket_path" "$pid_path"`); err != nil {
+	if _, err := runSSH(ctx, sshTarget, profile, removeStaleRemoteSocketScript()); err != nil {
 		return err
 	}
 	return b.startRemoteDaemon(ctx, sshTarget, profile)
+}
+
+// removeStaleRemoteSocketScript returns the shell script fragment used to
+// clear the way for a fresh remote daemon start. It deliberately unlinks
+// only the socket, never the PID path: the PID file's flock (not its
+// presence on disk) is the sole mutual-exclusion mechanism a remote daemon
+// and a concurrent `attn db restore` on that same host share. Unlinking the
+// PID path here — right before a subsequent daemon start reopens the
+// pathname with O_CREATE — would let a restore holding the old inode's
+// flock go uncontended against a new daemon's freshly created inode at the
+// same pathname. See internal/daemonctl/ensure.go's removeStaleSocketFiles
+// for the identical local-daemon invariant.
+func removeStaleRemoteSocketScript() string {
+	return remoteSocketConfigScript() + `rm -f "$socket_path"`
 }

--- a/internal/hub/bootstrap_test.go
+++ b/internal/hub/bootstrap_test.go
@@ -134,6 +134,55 @@ func TestStopRemoteDaemonScript_PortByProfile(t *testing.T) {
 	}
 }
 
+// TestStopRemoteDaemonScript_LeavesPIDFileInPlace pins the invariant that
+// stopping a remote daemon never unlinks its PID file. The PID file's flock
+// (not its presence on disk), is the sole mutual-exclusion mechanism a
+// remote daemon and a concurrent `attn db restore` on that same host share
+// (see removeStaleRemoteSocketScript and internal/daemonctl/ensure.go's
+// removeStaleSocketFiles for the identical local-daemon invariant).
+// Unlinking the pathname here would let a restore holding the old inode's
+// flock go uncontended against whatever daemon later creates a fresh inode
+// at the same pathname.
+func TestStopRemoteDaemonScript_LeavesPIDFileInPlace(t *testing.T) {
+	script := stopRemoteDaemonScript("")
+	if !strings.Contains(script, `rm -f "$socket_path"`) {
+		t.Fatalf("stop script should remove the stale socket: %s", script)
+	}
+	for _, line := range extractRemovalLines(script) {
+		if strings.Contains(line, "pid_path") {
+			t.Fatalf("stop script unlinks the PID path, want it left in place: %s", line)
+		}
+	}
+}
+
+// TestRemoveStaleRemoteSocketScript_LeavesPIDFileInPlace pins the same
+// invariant for the stale-cleanup script shared by ensureRemoteDaemonRunning
+// (stale-socket recovery) and restartRemoteDaemon.
+func TestRemoveStaleRemoteSocketScript_LeavesPIDFileInPlace(t *testing.T) {
+	script := removeStaleRemoteSocketScript()
+	if !strings.Contains(script, `rm -f "$socket_path"`) {
+		t.Fatalf("stale-cleanup script should remove the stale socket: %s", script)
+	}
+	for _, line := range extractRemovalLines(script) {
+		if strings.Contains(line, "pid_path") {
+			t.Fatalf("stale-cleanup script unlinks the PID path, want it left in place: %s", line)
+		}
+	}
+}
+
+// extractRemovalLines returns the lines of a generated shell script that
+// invoke `rm`, so tests can assert on exactly what gets unlinked without
+// being fooled by pid_path appearing elsewhere (e.g. reads via `cat`).
+func extractRemovalLines(script string) []string {
+	var lines []string
+	for _, line := range strings.Split(script, "\n") {
+		if strings.Contains(line, "rm ") || strings.Contains(line, "rm\t") || strings.HasPrefix(strings.TrimSpace(line), "rm ") {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
 func TestRemoteSocketConfigScriptHonorsProfileEnv(t *testing.T) {
 	script := remoteSocketConfigScript()
 	if !strings.Contains(script, `attn_profile="${ATTN_PROFILE:-}"`) {

--- a/internal/store/backup.go
+++ b/internal/store/backup.go
@@ -20,6 +20,22 @@ const (
 	backupNameSuffix = ".db"
 )
 
+// backupPremigrationKeep caps how many pre-migration snapshots
+// (attn-premigration-<version>-<timestamp>.db) accumulate in the backups
+// dir. These fire rarely (once per schema migration), but a long-lived
+// install crossing many schema versions would otherwise never prune them.
+const backupPremigrationKeep = 5
+
+// premigrationNamePrefix and premigrationTimestampLen let
+// pruneBackupPremigration recognize pre-migration snapshot filenames and
+// pull out the trailing UTC timestamp for chronological sorting, since the
+// embedded schema version varies in digit count and the whole filename does
+// not sort chronologically.
+const premigrationNamePrefix = "attn-premigration-"
+
+// len("20060102-150405")
+const premigrationTimestampLen = len(backupNameLayout)
+
 // BackupNow writes a consistent online snapshot of the store's database to
 // dir/attn-<UTC timestamp YYYYMMDD-HHMMSS>.db using SQLite's VACUUM INTO,
 // then prunes the oldest files in dir so at most keep backups remain.
@@ -77,7 +93,7 @@ func pruneBackups(dir string, keep int) error {
 		if e.IsDir() {
 			continue
 		}
-		if isRotatingBackupName(e.Name()) {
+		if IsRotatingBackupName(e.Name()) {
 			names = append(names, e.Name())
 		}
 	}
@@ -101,7 +117,7 @@ func pruneBackups(dir string, keep int) error {
 // dir/attn-premigration-<version>-<timestamp>.db, where dir is the
 // "backups" directory alongside dbPath, before pending migrations run.
 // version identifies the schema version the database is migrating FROM.
-// This name is deliberately excluded from isRotatingBackupName's pattern so
+// This name is deliberately excluded from IsRotatingBackupName's pattern so
 // BackupNow's rotation prune never counts or removes it. Returns the path of
 // the snapshot on success.
 func backupPreMigration(db *sql.DB, dbPath string, version int) (string, error) {
@@ -122,13 +138,76 @@ func backupPreMigration(db *sql.DB, dbPath string, version int) (string, error) 
 	if _, err := db.Exec("VACUUM INTO ?", target); err != nil {
 		return "", fmt.Errorf("vacuum into %s: %w", target, err)
 	}
+
+	if err := pruneBackupPremigration(dir, backupPremigrationKeep); err != nil {
+		return target, fmt.Errorf("wrote %s but premigration prune failed: %w", target, err)
+	}
+
 	return target, nil
 }
 
-// isRotatingBackupName reports whether name is a canonical rotating backup
+// pruneBackupPremigration removes the oldest pre-migration snapshots in dir
+// beyond keep, leaving the rotating attn-<timestamp>.db backups (and
+// anything else) untouched. Snapshots are ordered by the trailing
+// YYYYMMDD-HHMMSS timestamp embedded before the .db suffix, not by the
+// filename as a whole (the embedded schema version varies in digit count,
+// so whole-filename sort does not sort chronologically) and not by mtime.
+func pruneBackupPremigration(dir string, keep int) error {
+	if keep < 0 {
+		keep = 0
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read dir %s: %w", dir, err)
+	}
+
+	type snapshot struct {
+		name string
+		ts   string
+	}
+	var snapshots []snapshot
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, premigrationNamePrefix) || !strings.HasSuffix(name, backupNameSuffix) {
+			continue
+		}
+		stem := strings.TrimSuffix(name, backupNameSuffix)
+		if len(stem) < premigrationTimestampLen {
+			continue
+		}
+		ts := stem[len(stem)-premigrationTimestampLen:]
+		if _, err := time.Parse(backupNameLayout, ts); err != nil {
+			continue
+		}
+		snapshots = append(snapshots, snapshot{name: name, ts: ts})
+	}
+
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].ts < snapshots[j].ts
+	})
+
+	if len(snapshots) <= keep {
+		return nil
+	}
+
+	toRemove := snapshots[:len(snapshots)-keep]
+	var firstErr error
+	for _, s := range toRemove {
+		if err := os.Remove(filepath.Join(dir, s.name)); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("remove %s: %w", s.name, err)
+		}
+	}
+	return firstErr
+}
+
+// IsRotatingBackupName reports whether name is a canonical rotating backup
 // (attn-<timestamp>.db), excluding pre-migration snapshots
 // (attn-premigration-<version>-<timestamp>.db) which are exempt from prune.
-func isRotatingBackupName(name string) bool {
+func IsRotatingBackupName(name string) bool {
 	if !strings.HasPrefix(name, backupNamePrefix) || !strings.HasSuffix(name, backupNameSuffix) {
 		return false
 	}

--- a/internal/store/backup_test.go
+++ b/internal/store/backup_test.go
@@ -173,7 +173,7 @@ func TestBackupNow_Rotation(t *testing.T) {
 		if e.Name() == filepath.Base(newPath) {
 			sawNew = true
 		}
-		if isRotatingBackupName(e.Name()) {
+		if IsRotatingBackupName(e.Name()) {
 			rotating = append(rotating, e.Name())
 		}
 	}
@@ -265,5 +265,98 @@ func TestMigrateDB_PreMigrationBackup(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("no pre-migration backup found in %s, entries: %v", backupDir, entries)
+	}
+}
+
+// TestBackupPreMigration_CapsSnapshots proves that after backupPreMigration
+// runs, older attn-premigration-*.db files in the same dir beyond the newest
+// backupPremigrationKeep are pruned by their trailing timestamp (not by
+// mtime or whole-filename sort, which would misorder across differing
+// version-number digit widths), while rotating attn-<timestamp>.db backups
+// are left untouched.
+func TestBackupPreMigration_CapsSnapshots(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatalf("NewWithDB error: %v", err)
+	}
+	defer s.Close()
+
+	backupDir := filepath.Join(filepath.Dir(dbPath), "backups")
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		t.Fatalf("mkdir backups dir: %v", err)
+	}
+
+	// Seed 7 fake pre-migration files with distinct timestamps, deliberately
+	// using version numbers of differing digit widths (9 vs 10 vs 100) so a
+	// whole-filename sort would misorder them relative to a timestamp sort.
+	versions := []int{9, 10, 100, 11, 12, 13, 14}
+	var seeded []string
+	for i, v := range versions {
+		ts := fmt.Sprintf("202601%02d-000000", i+1)
+		name := fmt.Sprintf("attn-premigration-%d-%s.db", v, ts)
+		if err := os.WriteFile(filepath.Join(backupDir, name), []byte("fake"), 0644); err != nil {
+			t.Fatalf("seed premigration file %s: %v", name, err)
+		}
+		seeded = append(seeded, name)
+	}
+	// oldest-first by index/timestamp: seeded[0]..seeded[6]
+
+	// A rotating backup must never be touched by the premigration prune.
+	rotatingName := backupNamePrefix + "20260101-000000" + backupNameSuffix
+	if err := os.WriteFile(filepath.Join(backupDir, rotatingName), []byte("fake"), 0644); err != nil {
+		t.Fatalf("seed rotating file: %v", err)
+	}
+
+	// Force migrateDB down its "pending migrations" path against a real
+	// file, same technique as TestMigrateDB_PreMigrationBackup.
+	latest := latestSchemaVersion()
+	if _, err := s.db.Exec(`DELETE FROM schema_migrations WHERE version = ?`, latest); err != nil {
+		t.Fatalf("unrecord latest migration: %v", err)
+	}
+	if err := migrateDB(s.db, dbPath); err != nil {
+		t.Fatalf("migrateDB error: %v", err)
+	}
+
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		t.Fatalf("read backups dir: %v", err)
+	}
+
+	var premigration []string
+	sawRotating := false
+	for _, e := range entries {
+		if e.Name() == rotatingName {
+			sawRotating = true
+			continue
+		}
+		if strings.HasPrefix(e.Name(), premigrationNamePrefix) {
+			premigration = append(premigration, e.Name())
+		}
+	}
+
+	if !sawRotating {
+		t.Fatal("rotating backup was removed by premigration prune; it must be untouched")
+	}
+
+	// One new premigration snapshot was written by migrateDB itself, so the
+	// total before prune is len(seeded)+1 = 8; after capping to
+	// backupPremigrationKeep = 5, exactly 5 must remain.
+	if len(premigration) != backupPremigrationKeep {
+		t.Fatalf("premigration snapshots after prune = %d, want %d (%v)", len(premigration), backupPremigrationKeep, premigration)
+	}
+
+	// The oldest 3 of the 7 seeded files must be gone (8 total - 5 kept = 3
+	// removed, and the new snapshot's timestamp sorts after all seeded ones).
+	for _, name := range seeded[:3] {
+		if _, err := os.Stat(filepath.Join(backupDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("expected oldest premigration file %s to be pruned, stat err = %v", name, err)
+		}
+	}
+	// The newest 4 of the 7 seeded files must survive.
+	for _, name := range seeded[3:] {
+		if _, err := os.Stat(filepath.Join(backupDir, name)); err != nil {
+			t.Fatalf("expected premigration file %s to survive prune: %v", name, err)
+		}
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -717,7 +717,15 @@ func migrateDB(db *sql.DB, dbPath string) error {
 		latest := migrations[len(migrations)-1].version
 		if currentVersion < latest {
 			if path, err := backupPreMigration(db, dbPath, currentVersion); err != nil {
-				log.Printf("[store] pre-migration backup failed (schema v%d -> v%d): %v; proceeding with migrations", currentVersion, latest, err)
+				if path != "" {
+					// The snapshot itself was written; only pruning old
+					// pre-migration snapshots afterward failed. Report it as
+					// such — the operator needs to know the protective
+					// snapshot exists, not that the backup failed outright.
+					log.Printf("[store] pre-migration backup written to %s (schema v%d -> v%d), but pruning old pre-migration snapshots failed: %v", path, currentVersion, latest, err)
+				} else {
+					log.Printf("[store] pre-migration backup failed (schema v%d -> v%d): %v; proceeding with migrations", currentVersion, latest, err)
+				}
 			} else {
 				log.Printf("[store] pre-migration backup written to %s (schema v%d -> v%d)", path, currentVersion, latest)
 			}


### PR DESCRIPTION
## Summary
Implements §1 follow-ups of `docs/plans/2026-07-18-db-loss-mitigation.md`:

- Pre-migration snapshots are now capped at 5 (pruned by trailing timestamp — being exempt from rotation no longer means immortal).
- `attn db restore [path|latest]` restores `attn.db` from a rotating or pre-migration snapshot. It refuses while a daemon holds the pid-file flock or when liveness is undeterminable, preserves the previous `attn.db` and its `-wal`/`-shm` sidecars as `attn.db.pre-restore-<ts>`, and copies (never moves) the snapshot into place.
- `db.last_backup_at` is a computed, read-only settings key broadcast after each successful backup.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./internal/store ./internal/daemon ./cmd/...`
- [x] Restore live-smoked end-to-end on a throwaway `ATTN_PROFILE`: normal restore, and refusal while a daemon is live
- [x] CHANGELOG.md updated

Known pre-existing flake unrelated to this change: `TestDaemon_PrunesSessionsWithoutLivePTYOnStart` can fail on machines with a live daemon (order-dependent).

https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT