### PR TITLE
feat(app): notebook tile root plumbing — tileParams {root,path}, root-bound fs, per-root change signals

### DIFF
--- a/app/src/App.fsChangeSignals.test.ts
+++ b/app/src/App.fsChangeSignals.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { bumpFsChangeSignal, fsChangeSignalKey } from './App';
+
+// Pure-logic coverage for the per-root fs_changed routing that feeds every
+// notebook surface's changeSignal (see makeNotebookSurfaceDaemon in App.tsx).
+// App.tsx has no dedicated render-level test suite for this wiring (see
+// App.presentationNotices.test.ts for the same pattern applied to another
+// piece of App.tsx state), so this exercises the extracted key/reducer
+// functions directly rather than standing up a full App render + mocked
+// WebSocket.
+
+const NOTEBOOK_ROOT = '/Users/victor/attn-notebook';
+const ROOT_A = '/Users/victor/code/repo-a';
+const ROOT_B = '/Users/victor/code/repo-b';
+
+describe('fsChangeSignalKey', () => {
+  it('uses the event root verbatim when present', () => {
+    expect(fsChangeSignalKey(ROOT_A, NOTEBOOK_ROOT)).toBe(ROOT_A);
+  });
+
+  it('falls back to the effective notebook root for an empty/missing root', () => {
+    expect(fsChangeSignalKey('', NOTEBOOK_ROOT)).toBe(NOTEBOOK_ROOT);
+  });
+});
+
+describe('bumpFsChangeSignal (per-root fs_changed routing)', () => {
+  it('bumps only the signal for the event root, leaving other roots untouched', () => {
+    let signals: Record<string, number> = { [ROOT_A]: 1, [ROOT_B]: 5 };
+    signals = bumpFsChangeSignal(signals, ROOT_A, NOTEBOOK_ROOT);
+    expect(signals).toEqual({ [ROOT_A]: 2, [ROOT_B]: 5 });
+  });
+
+  it('an event for root A never bumps a tile keyed to root B', () => {
+    let signals: Record<string, number> = {};
+    signals = bumpFsChangeSignal(signals, ROOT_A, NOTEBOOK_ROOT);
+    // Root B's key was never touched — a tile bound to it reads the default (0).
+    expect(signals[ROOT_B]).toBeUndefined();
+    expect(signals[ROOT_A]).toBe(1);
+  });
+
+  it('an empty-root event reaches notebook-rooted tiles (keyed to the effective notebook root)', () => {
+    let signals: Record<string, number> = {};
+    signals = bumpFsChangeSignal(signals, '', NOTEBOOK_ROOT);
+    expect(signals[NOTEBOOK_ROOT]).toBe(1);
+    // It must not create a spurious '' key that no tile would ever look up.
+    expect(signals['']).toBeUndefined();
+  });
+
+  it('a notebook-root event and an empty-root event land on the same key (both mean notebook-rooted)', () => {
+    let signals: Record<string, number> = {};
+    signals = bumpFsChangeSignal(signals, NOTEBOOK_ROOT, NOTEBOOK_ROOT);
+    signals = bumpFsChangeSignal(signals, '', NOTEBOOK_ROOT);
+    expect(signals[NOTEBOOK_ROOT]).toBe(2);
+  });
+
+  it('accumulates independently across many roots', () => {
+    let signals: Record<string, number> = {};
+    signals = bumpFsChangeSignal(signals, ROOT_A, NOTEBOOK_ROOT);
+    signals = bumpFsChangeSignal(signals, ROOT_A, NOTEBOOK_ROOT);
+    signals = bumpFsChangeSignal(signals, ROOT_B, NOTEBOOK_ROOT);
+    signals = bumpFsChangeSignal(signals, '', NOTEBOOK_ROOT);
+    expect(signals).toEqual({ [ROOT_A]: 2, [ROOT_B]: 1, [NOTEBOOK_ROOT]: 1 });
+  });
+});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -640,6 +640,7 @@ function App() {
     sendTicketResume,
     getPresentations,
     connectionError,
+    connectionGeneration,
     hasReceivedInitialState,
     rateLimit,
     warnings,
@@ -749,6 +750,7 @@ function App() {
         daemonGitHubHosts={daemonGitHubHosts}
         settings={settings}
         connectionError={connectionError}
+        connectionGeneration={connectionGeneration}
         hasReceivedInitialState={hasReceivedInitialState}
         rateLimit={rateLimit}
         warnings={warnings}
@@ -866,6 +868,7 @@ interface AppContentProps {
   daemonGitHubHosts: string[];
   settings: Record<string, string>;
   connectionError: string | null;
+  connectionGeneration: number;
   hasReceivedInitialState: boolean;
   rateLimit: import('./hooks/useDaemonSocket').RateLimitState | null;
   warnings: DaemonWarning[];
@@ -978,6 +981,7 @@ function AppContent({
   daemonGitHubHosts,
   settings,
   connectionError,
+  connectionGeneration,
   hasReceivedInitialState,
   rateLimit,
   warnings,
@@ -3418,7 +3422,8 @@ sendFetchPRDetails,
     effectiveNotebookRoot,
     sendFsWatch,
     sendFsUnwatch,
-  }), [makeNotebookSurfaceDaemon, effectiveNotebookRoot, sendFsWatch, sendFsUnwatch]);
+    connectionGeneration,
+  }), [makeNotebookSurfaceDaemon, effectiveNotebookRoot, sendFsWatch, sendFsUnwatch, connectionGeneration]);
 
   // The fullscreen browser is always notebook-rooted — same signal a rootless
   // tile would resolve to via makeNotebookSurfaceDaemon(undefined).

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -133,6 +133,28 @@ export function latestPresentationBySessionId(notices: Presentation[]): Map<stri
   }
   return bySessionId;
 }
+// The per-root fs_changed signal key: the daemon-resolved root verbatim, or
+// `effectiveNotebookRoot` when the event carries no root (the daemon's
+// notebook-root events, and — as a safety fallback — any malformed event
+// missing the field). A rootless tile and the fullscreen browser look
+// themselves up with the same normalization (root='' → effectiveNotebookRoot),
+// so they land on this key too.
+export function fsChangeSignalKey(root: string, effectiveNotebookRoot: string): string {
+  return root || effectiveNotebookRoot;
+}
+
+// Pure reducer for the per-root fs_changed signal map: bumps only the key the
+// event resolves to, leaving every other root's counter untouched so a tile
+// bound to root A never re-renders for a change under root B.
+export function bumpFsChangeSignal(
+  signals: Record<string, number>,
+  root: string,
+  effectiveNotebookRoot: string,
+): Record<string, number> {
+  const key = fsChangeSignalKey(root, effectiveNotebookRoot);
+  return { ...signals, [key]: (signals[key] || 0) + 1 };
+}
+
 const TERMINAL_AGENT: SessionAgent = 'shell';
 
 type LocationPickerPurpose = 'workspace' | 'session';
@@ -510,11 +532,14 @@ function App() {
     sessionExitHandlerRef.current?.(info);
   }, []);
 
-  // Bumped on every fs_changed event so the Notebook browser's filesystem tree
-  // re-lists and the open file reloads (covers agent writes and external edits to
-  // any file under the root). The browser reads via the generic fs surface, so
-  // fs_changed — not notebook_changed — is its refresh signal.
-  const [fsChangeSignal, setFsChangeSignal] = useState(0);
+  // Bumped per-root on every fs_changed event so a Notebook surface (the
+  // fullscreen browser, or a tile bound to that same root) re-lists its
+  // filesystem tree and reloads its open file — without bumping surfaces bound
+  // to an unrelated root. Keyed by the daemon-resolved root string; an
+  // fs_changed with an empty/missing root is normalized to the effective
+  // notebook root (see bumpFsChangeSignal below), matching how a rootless
+  // tile/the fullscreen browser look themselves up.
+  const [fsChangeSignals, setFsChangeSignals] = useState<Record<string, number>>({});
   // Bumped on every tasks_changed broadcast so an open Tasks panel
   // re-fetches the durable runner's task list (covers any lifecycle transition).
   const [notebookTaskChangeSignal, setTaskChangeSignal] = useState(0);
@@ -567,6 +592,8 @@ function App() {
     sendFsDelete,
     sendFsExists,
     sendFsReadAsset,
+    sendFsWatch,
+    sendFsUnwatch,
     sendTaskList,
     sendTaskRetry,
     sendNotificationList,
@@ -622,9 +649,14 @@ function App() {
     onPresentationAdded: (p) => setPresentationNotices((prev) => upsertPresentationNotice(prev, p)),
     onPresentationUpdated: (p) => setPresentationNotices((prev) => upsertPresentationNotice(prev, p)),
     // The daemon tags each fs_changed with an origin ("ui"/"agent"/"external"), but
-    // every origin is treated the same here: bump a signal so an open browser
-    // re-lists its tree and reloads the open file. Covers any file under the root.
-    onFsChanged: () => setFsChangeSignal((n) => n + 1),
+    // every origin is treated the same here: bump the signal for whichever root
+    // changed, so only browsers/tiles bound to that root re-list and reload. An
+    // empty/missing root (treated as notebook-root for safety) is normalized to
+    // the effective notebook root, matching how a rootless tile/the fullscreen
+    // browser key their own lookups (see notebookSurfaceDaemon below).
+    onFsChanged: (_origin, _paths, root) => {
+      setFsChangeSignals((prev) => bumpFsChangeSignal(prev, root, settings['notebook.root.effective'] || ''));
+    },
     // A task lifecycle transition broadcast bumps the signal so an open Tasks panel
     // refetches the runner's list (the broadcast itself is payload-free).
     onTasksChanged: () => setTaskChangeSignal((n) => n + 1),
@@ -765,6 +797,8 @@ function App() {
         sendFsDelete={sendFsDelete}
         sendFsExists={sendFsExists}
         sendFsReadAsset={sendFsReadAsset}
+        sendFsWatch={sendFsWatch}
+        sendFsUnwatch={sendFsUnwatch}
         sendTaskList={sendTaskList}
         sendTaskRetry={sendTaskRetry}
         sendNotificationList={sendNotificationList}
@@ -774,7 +808,7 @@ function App() {
         sendNotebookBacklinks={sendNotebookBacklinks}
         sendNotebookToChief={sendNotebookToChief}
         sendNotebookList={sendNotebookList}
-        fsChangeSignal={fsChangeSignal}
+        fsChangeSignals={fsChangeSignals}
         notebookTaskChangeSignal={notebookTaskChangeSignal}
         sendGetRecentLocations={sendGetRecentLocations}
         sendBrowseDirectory={sendBrowseDirectory}
@@ -880,6 +914,8 @@ interface AppContentProps {
   sendFsDelete: ReturnType<typeof useDaemonSocket>['sendFsDelete'];
   sendFsExists: ReturnType<typeof useDaemonSocket>['sendFsExists'];
   sendFsReadAsset: ReturnType<typeof useDaemonSocket>['sendFsReadAsset'];
+  sendFsWatch: ReturnType<typeof useDaemonSocket>['sendFsWatch'];
+  sendFsUnwatch: ReturnType<typeof useDaemonSocket>['sendFsUnwatch'];
   sendTaskList: ReturnType<typeof useDaemonSocket>['sendTaskList'];
   sendTaskRetry: ReturnType<typeof useDaemonSocket>['sendTaskRetry'];
   sendNotificationList: ReturnType<typeof useDaemonSocket>['sendNotificationList'];
@@ -889,7 +925,7 @@ interface AppContentProps {
   sendNotebookBacklinks: ReturnType<typeof useDaemonSocket>['sendNotebookBacklinks'];
   sendNotebookToChief: ReturnType<typeof useDaemonSocket>['sendNotebookToChief'];
   sendNotebookList: ReturnType<typeof useDaemonSocket>['sendNotebookList'];
-  fsChangeSignal: number;
+  fsChangeSignals: Record<string, number>;
   notebookTaskChangeSignal: number;
   sendGetRecentLocations: ReturnType<typeof useDaemonSocket>['sendGetRecentLocations'];
   sendBrowseDirectory: ReturnType<typeof useDaemonSocket>['sendBrowseDirectory'];
@@ -989,6 +1025,8 @@ function AppContent({
   sendFsDelete,
   sendFsExists,
   sendFsReadAsset,
+  sendFsWatch,
+  sendFsUnwatch,
   sendTaskList,
   sendTaskRetry,
   sendNotificationList,
@@ -998,7 +1036,7 @@ function AppContent({
   sendNotebookBacklinks,
   sendNotebookToChief,
   sendNotebookList,
-  fsChangeSignal,
+  fsChangeSignals,
   notebookTaskChangeSignal,
   sendGetRecentLocations,
   sendBrowseDirectory,
@@ -3340,20 +3378,28 @@ sendFetchPRDetails,
       && !boardSurfaceOpen,
   });
 
-  // The daemon surface shared by the fullscreen Notebook and every notebook tile.
-  // Memoized so tiles re-render only when a callback identity or a change signal
-  // actually moves.
-  const notebookSurfaceDaemon = useMemo(() => ({
-    listDir: sendFsList,
-    readFile: sendFsRead,
-    writeFile: sendFsWrite,
-    existsFile: sendFsExists,
-    readAsset: sendFsReadAsset,
+  // The daemon's resolved notebook storage root (settings['notebook.root.effective']).
+  // An fs_changed with no root, and a tile with no explicit root, both key off this
+  // value — see setFsChangeSignals above and makeNotebookSurfaceDaemon below.
+  const effectiveNotebookRoot = settings['notebook.root.effective'] || '';
+
+  // Builds the daemon surface for the fullscreen Notebook and every notebook
+  // tile, bound to `root` (undefined = the notebook storage root, unchanged
+  // behavior). Memoized so a tile's daemon instance is stable across renders
+  // that don't touch its own root's change signal.
+  const makeNotebookSurfaceDaemon = useCallback((root?: string) => ({
+    listDir: (path: string) => sendFsList(path, root),
+    readFile: (path: string) => sendFsRead(path, root),
+    writeFile: (path: string, content: string, baseHash?: string) => sendFsWrite(path, content, baseHash, root),
+    existsFile: (path: string) => sendFsExists(path, root),
+    readAsset: (path: string) => sendFsReadAsset(path, root),
+    // Notebook-storage-only commands (see NotebookSurfaceContext's boundary
+    // note): bound to the notebook root regardless of `root`.
     backlinksNotebook: sendNotebookBacklinks,
     sendToChief: sendNotebookToChief,
     // Argless walk = empty prefix = the whole vault, for the in-tile finder index.
     listFiles: sendNotebookList,
-    changeSignal: fsChangeSignal,
+    changeSignal: fsChangeSignals[fsChangeSignalKey(root || '', effectiveNotebookRoot)] || 0,
   }), [
     sendFsList,
     sendFsRead,
@@ -3363,12 +3409,24 @@ sendFetchPRDetails,
     sendNotebookBacklinks,
     sendNotebookToChief,
     sendNotebookList,
-    fsChangeSignal,
+    fsChangeSignals,
+    effectiveNotebookRoot,
   ]);
+
+  const notebookSurfaceContextValue = useMemo(() => ({
+    makeDaemon: makeNotebookSurfaceDaemon,
+    effectiveNotebookRoot,
+    sendFsWatch,
+    sendFsUnwatch,
+  }), [makeNotebookSurfaceDaemon, effectiveNotebookRoot, sendFsWatch, sendFsUnwatch]);
+
+  // The fullscreen browser is always notebook-rooted — same signal a rootless
+  // tile would resolve to via makeNotebookSurfaceDaemon(undefined).
+  const notebookRootChangeSignal = fsChangeSignals[fsChangeSignalKey('', effectiveNotebookRoot)] || 0;
 
   return (
     <DaemonProvider sendPRAction={sendPRAction} sendMutePR={sendMutePR} sendMuteRepo={sendMuteRepo} sendMuteAuthor={sendMuteAuthor} sendPRVisited={sendPRVisited}>
-    <NotebookSurfaceProvider value={notebookSurfaceDaemon}>
+    <NotebookSurfaceProvider value={notebookSurfaceContextValue}>
     <div className="app" ref={appShellRef} tabIndex={-1} style={{ outline: 'none' }} onPointerDownCapture={handleAppPointerDownCapture}>
       {/* Error banner for version mismatch */}
       {connectionError && (
@@ -3785,7 +3843,7 @@ sendFetchPRDetails,
         backlinksNotebook={sendNotebookBacklinks}
         sendToChief={sendNotebookToChief}
         listFiles={sendNotebookList}
-        changeSignal={fsChangeSignal}
+        changeSignal={notebookRootChangeSignal}
         chiefActive={notebookChiefActive}
       />
       <TicketBoardSurface

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
@@ -7,7 +7,7 @@ import type {
   RefObject,
 } from 'react';
 import { browserHostLabel, claimBrowserHostFocus, controlBrowserHost } from '../../browser/host';
-import type { TileContentState, TileLeaf } from '../../types/workspace';
+import { parseNotebookTileParams, serializeNotebookTileParams, type TileContentState, type TileLeaf } from '../../types/workspace';
 import { deriveTileTitle } from '../../utils/tilePresentation';
 import { BrowserTileBody } from './BrowserTileBody';
 import { MarkdownReader } from '../MarkdownReader';
@@ -107,7 +107,12 @@ export function WorkspaceDockTile({
     }
   }, [workspaceId, tile.tileId, tile.tileKind, tile.tileParams, onRequestContent]);
 
-  const path = content?.path || tile.tileParams || '';
+  // Notebook tileParams may be the legacy bare-path string or the {root, path}
+  // JSON envelope a root-bound tile persists — parse either way so the header
+  // tooltip and annotation transport see the plain open path, not raw JSON.
+  const path = content?.path
+    || (tile.tileKind === 'notebook' ? parseNotebookTileParams(tile.tileParams).path : tile.tileParams)
+    || '';
   const title = deriveTileTitle(tile, content);
   const browserLabel = browserHostLabel(workspaceId, tile.tileId);
   const [browserAddress, setBrowserAddress] = useState(tile.tileParams || '');
@@ -476,14 +481,23 @@ export function WorkspaceDockTile({
         ) : tile.tileKind === 'notebook' ? (
           // The notebook tile self-serves its content over the fs surface (via
           // context); the only tile→params write is the opened file's path.
-          <NotebookTile
-            initialPath={tile.tileParams || null}
-            onOpenFile={(openedPath) => {
-              void Promise.resolve(onUpdateParams?.(openedPath)).catch((error) => {
-                console.warn('[WorkspaceDockTile] Failed to persist notebook path:', error);
-              });
-            }}
-          />
+          // tileParams may be the legacy bare-path string (rootless tile) or the
+          // {root, path} JSON envelope a root-bound tile persists.
+          (() => {
+            const { root, path: openPath } = parseNotebookTileParams(tile.tileParams);
+            return (
+              <NotebookTile
+                initialPath={openPath || null}
+                root={root}
+                onOpenFile={(openedPath) => {
+                  const nextParams = serializeNotebookTileParams({ root, path: openedPath });
+                  void Promise.resolve(onUpdateParams?.(nextParams)).catch((error) => {
+                    console.warn('[WorkspaceDockTile] Failed to persist notebook path:', error);
+                  });
+                }}
+              />
+            );
+          })()
         ) : (
           <div className="workspace-dock-tile-message">Unsupported tile: {tile.tileKind}</div>
         )}

--- a/app/src/components/notebook/NotebookTile.test.tsx
+++ b/app/src/components/notebook/NotebookTile.test.tsx
@@ -45,6 +45,7 @@ function makeHarness(opts: {
   effectiveNotebookRoot?: string;
   watchResolvesTo?: (root: string) => string;
   watchRejects?: boolean;
+  connectionGeneration?: number;
 } = {}): Harness {
   const callLog: string[] = [];
   const resolveRoot = opts.watchResolvesTo ?? ((root: string) => root);
@@ -65,6 +66,7 @@ function makeHarness(opts: {
     effectiveNotebookRoot: opts.effectiveNotebookRoot ?? '/notebook-root',
     sendFsWatch,
     sendFsUnwatch,
+    connectionGeneration: opts.connectionGeneration ?? 0,
   };
   return { value, makeDaemon, sendFsWatch, sendFsUnwatch, callLog };
 }
@@ -151,6 +153,7 @@ describe('NotebookTile root-bound daemon + watch lifecycle', () => {
       effectiveNotebookRoot: '/notebook-root',
       sendFsWatch,
       sendFsUnwatch,
+      connectionGeneration: 0,
     };
 
     const { unmount } = render(
@@ -193,6 +196,38 @@ describe('NotebookTile root-bound daemon + watch lifecycle', () => {
     await waitFor(() => expect(harness.sendFsUnwatch).toHaveBeenCalledWith('/repo-a-resolved'));
     await waitFor(() => expect(harness.sendFsWatch).toHaveBeenCalledWith('/repo-b'));
     expect(harness.callLog).toEqual(['watch:/repo-a', 'unwatch:/repo-a-resolved', 'watch:/repo-b']);
+  });
+
+  it('re-issues fs_watch after a reconnect (connectionGeneration bump), unwatching the pre-reconnect ref first', async () => {
+    // The daemon drops an explicit fs_watch ref whenever the owning client's
+    // socket disconnects, but a normal frontend reconnect leaves the tile
+    // mounted with the same root/callback identities — nothing else in the
+    // effect's deps would re-fire the subscription without connectionGeneration.
+    const harness = makeHarness({
+      effectiveNotebookRoot: '/notebook-root',
+      watchResolvesTo: () => '/repo-resolved',
+      connectionGeneration: 1,
+    });
+    const { rerender } = render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath={null} root="/repo" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+    await waitFor(() => expect(harness.sendFsWatch).toHaveBeenCalledWith('/repo'));
+    await waitFor(() => expect(harness.makeDaemon).toHaveBeenCalledWith('/repo-resolved'));
+
+    // Simulate a reconnect: same root, same context shape, only the
+    // generation counter bumps.
+    rerender(
+      <NotebookSurfaceProvider value={{ ...harness.value, connectionGeneration: 2 }}>
+        <NotebookTile initialPath={null} root="/repo" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+
+    await waitFor(() => expect(harness.sendFsUnwatch).toHaveBeenCalledWith('/repo-resolved'));
+    await waitFor(() => expect(harness.sendFsWatch).toHaveBeenCalledTimes(2));
+    expect(harness.sendFsWatch.mock.calls[1]).toEqual(['/repo']);
+    expect(harness.callLog).toEqual(['watch:/repo', 'unwatch:/repo-resolved', 'watch:/repo']);
   });
 
   it('survives a watch failure (e.g. the daemon watch cap) without throwing — the tile still renders', async () => {

--- a/app/src/components/notebook/NotebookTile.test.tsx
+++ b/app/src/components/notebook/NotebookTile.test.tsx
@@ -1,0 +1,164 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NotebookTile } from './NotebookTile';
+import {
+  NotebookSurfaceProvider,
+  type NotebookSurfaceContextValue,
+  type NotebookSurfaceDaemon,
+} from '../../contexts/NotebookSurfaceContext';
+import type { FsWatchResult } from '../../hooks/useDaemonSocket';
+
+// NotebookSurface itself (CodeMirror-backed tree/editor/finder) is covered by
+// NotebookBrowser.test.tsx; here we only need to observe what NotebookTile
+// hands it, so stub it to a thin recorder.
+const surfaceCalls = vi.hoisted(() => [] as Array<{ changeSignal?: number }>);
+vi.mock('../NotebookSurface', () => ({
+  NotebookSurface: (props: { changeSignal?: number }) => {
+    surfaceCalls.push(props);
+    return <div data-testid="notebook-surface" data-change-signal={props.changeSignal} />;
+  },
+}));
+
+function fakeDaemon(changeSignal = 0): NotebookSurfaceDaemon {
+  return {
+    listDir: vi.fn().mockResolvedValue([]),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    existsFile: vi.fn(),
+    readAsset: vi.fn(),
+    backlinksNotebook: vi.fn(),
+    sendToChief: vi.fn(),
+    listFiles: vi.fn(),
+    changeSignal,
+  };
+}
+
+interface Harness {
+  value: NotebookSurfaceContextValue;
+  makeDaemon: ReturnType<typeof vi.fn>;
+  sendFsWatch: ReturnType<typeof vi.fn>;
+  sendFsUnwatch: ReturnType<typeof vi.fn>;
+  callLog: string[];
+}
+
+function makeHarness(opts: {
+  effectiveNotebookRoot?: string;
+  watchResolvesTo?: (root: string) => string;
+  watchRejects?: boolean;
+} = {}): Harness {
+  const callLog: string[] = [];
+  const resolveRoot = opts.watchResolvesTo ?? ((root: string) => root);
+  const makeDaemon = vi.fn((_root?: string) => fakeDaemon());
+  const sendFsWatch = vi.fn((root?: string): Promise<FsWatchResult> => {
+    callLog.push(`watch:${root}`);
+    if (opts.watchRejects) {
+      return Promise.reject(new Error('watch cap reached'));
+    }
+    return Promise.resolve({ root: resolveRoot(root || '') });
+  });
+  const sendFsUnwatch = vi.fn((root?: string): Promise<FsWatchResult> => {
+    callLog.push(`unwatch:${root}`);
+    return Promise.resolve({ root: root || '' });
+  });
+  const value: NotebookSurfaceContextValue = {
+    makeDaemon,
+    effectiveNotebookRoot: opts.effectiveNotebookRoot ?? '/notebook-root',
+    sendFsWatch,
+    sendFsUnwatch,
+  };
+  return { value, makeDaemon, sendFsWatch, sendFsUnwatch, callLog };
+}
+
+afterEach(() => {
+  surfaceCalls.length = 0;
+  vi.restoreAllMocks();
+});
+
+describe('NotebookTile root-bound daemon + watch lifecycle', () => {
+  it('binds the daemon via makeDaemon(root) and never watches a rootless (notebook-rooted) tile', async () => {
+    const harness = makeHarness();
+    render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath="a.md" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+
+    await waitFor(() => expect(surfaceCalls.length).toBeGreaterThan(0));
+    expect(harness.makeDaemon).toHaveBeenCalledWith(undefined);
+    expect(harness.sendFsWatch).not.toHaveBeenCalled();
+    expect(harness.sendFsUnwatch).not.toHaveBeenCalled();
+  });
+
+  it('never watches a tile explicitly bound to the effective notebook root (server already watches it)', async () => {
+    const harness = makeHarness({ effectiveNotebookRoot: '/notebook-root' });
+    render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath="a.md" root="/notebook-root" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+
+    await waitFor(() => expect(surfaceCalls.length).toBeGreaterThan(0));
+    expect(harness.makeDaemon).toHaveBeenCalledWith('/notebook-root');
+    expect(harness.sendFsWatch).not.toHaveBeenCalled();
+  });
+
+  it('watches an arbitrary root on mount and unwatches the resolved root on unmount', async () => {
+    const harness = makeHarness({
+      effectiveNotebookRoot: '/notebook-root',
+      // fs_watch_result may normalize the path (e.g. resolve symlinks/trailing slash).
+      watchResolvesTo: () => '/repo-resolved',
+    });
+    const { unmount } = render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath={null} root="/repo" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+
+    await waitFor(() => expect(harness.sendFsWatch).toHaveBeenCalledWith('/repo'));
+
+    unmount();
+
+    await waitFor(() => expect(harness.sendFsUnwatch).toHaveBeenCalledWith('/repo-resolved'));
+    // Mount-then-unmount ordering: watch strictly precedes the matching unwatch.
+    expect(harness.callLog).toEqual(['watch:/repo', 'unwatch:/repo-resolved']);
+  });
+
+  it('unwatches the previously resolved root and re-watches the new one when root changes', async () => {
+    const harness = makeHarness({
+      effectiveNotebookRoot: '/notebook-root',
+      watchResolvesTo: (root) => `${root}-resolved`,
+    });
+    const { rerender } = render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath={null} root="/repo-a" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+    await waitFor(() => expect(harness.sendFsWatch).toHaveBeenCalledWith('/repo-a'));
+
+    rerender(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath={null} root="/repo-b" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+
+    await waitFor(() => expect(harness.sendFsUnwatch).toHaveBeenCalledWith('/repo-a-resolved'));
+    await waitFor(() => expect(harness.sendFsWatch).toHaveBeenCalledWith('/repo-b'));
+    expect(harness.callLog).toEqual(['watch:/repo-a', 'unwatch:/repo-a-resolved', 'watch:/repo-b']);
+  });
+
+  it('survives a watch failure (e.g. the daemon watch cap) without throwing — the tile still renders', async () => {
+    const harness = makeHarness({ effectiveNotebookRoot: '/notebook-root', watchRejects: true });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath={null} root="/repo" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+
+    await waitFor(() => expect(harness.sendFsWatch).toHaveBeenCalledWith('/repo'));
+    await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+    expect(warnSpy.mock.calls[0][0]).toMatch(/^\[NotebookTile\]/);
+    expect(surfaceCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/app/src/components/notebook/NotebookTile.test.tsx
+++ b/app/src/components/notebook/NotebookTile.test.tsx
@@ -102,10 +102,12 @@ describe('NotebookTile root-bound daemon + watch lifecycle', () => {
     expect(harness.sendFsWatch).not.toHaveBeenCalled();
   });
 
-  it('watches an arbitrary root on mount and unwatches the resolved root on unmount', async () => {
+  it('watches an arbitrary root on mount, adopts the resolved root for the daemon, and unwatches it on unmount', async () => {
     const harness = makeHarness({
       effectiveNotebookRoot: '/notebook-root',
-      // fs_watch_result may normalize the path (e.g. resolve symlinks/trailing slash).
+      // fs_watch_result may normalize the path (e.g. resolve symlinks/trailing slash) —
+      // fs_changed events for this subscription carry that resolved form, not the raw
+      // prop, so both the fs_* calls and the changeSignal lookup must key off it too.
       watchResolvesTo: () => '/repo-resolved',
     });
     const { unmount } = render(
@@ -114,13 +116,60 @@ describe('NotebookTile root-bound daemon + watch lifecycle', () => {
       </NotebookSurfaceProvider>,
     );
 
+    // Before resolution: bound to the raw root prop.
+    expect(harness.makeDaemon).toHaveBeenCalledWith('/repo');
+
     await waitFor(() => expect(harness.sendFsWatch).toHaveBeenCalledWith('/repo'));
+
+    // After fs_watch_result lands: the daemon is rebuilt against the resolved
+    // root, and the surface re-renders with that instance.
+    await waitFor(() => expect(harness.makeDaemon).toHaveBeenCalledWith('/repo-resolved'));
+    await waitFor(() => expect(surfaceCalls.length).toBeGreaterThan(1));
 
     unmount();
 
     await waitFor(() => expect(harness.sendFsUnwatch).toHaveBeenCalledWith('/repo-resolved'));
     // Mount-then-unmount ordering: watch strictly precedes the matching unwatch.
     expect(harness.callLog).toEqual(['watch:/repo', 'unwatch:/repo-resolved']);
+  });
+
+  it('unwatches a root whose fs_watch resolves only after the tile has already unmounted (no leaked watcher)', async () => {
+    const callLog: string[] = [];
+    let resolveWatch!: (result: FsWatchResult) => void;
+    const sendFsWatch = vi.fn((root?: string) => {
+      callLog.push(`watch:${root}`);
+      return new Promise<FsWatchResult>((resolve) => {
+        resolveWatch = resolve;
+      });
+    });
+    const sendFsUnwatch = vi.fn((root?: string): Promise<FsWatchResult> => {
+      callLog.push(`unwatch:${root}`);
+      return Promise.resolve({ root: root || '' });
+    });
+    const value: NotebookSurfaceContextValue = {
+      makeDaemon: vi.fn((_root?: string) => fakeDaemon()),
+      effectiveNotebookRoot: '/notebook-root',
+      sendFsWatch,
+      sendFsUnwatch,
+    };
+
+    const { unmount } = render(
+      <NotebookSurfaceProvider value={value}>
+        <NotebookTile initialPath={null} root="/repo" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+    await waitFor(() => expect(sendFsWatch).toHaveBeenCalledWith('/repo'));
+
+    // Unmount BEFORE fs_watch resolves: the effect's own cleanup runs with
+    // watchedRootRef still null, so it can't unwatch anything itself.
+    unmount();
+    expect(sendFsUnwatch).not.toHaveBeenCalled();
+
+    // The daemon-side watcher lands only now — it must still be dropped, or
+    // it leaks until app restart.
+    resolveWatch({ root: '/repo-resolved' });
+    await waitFor(() => expect(sendFsUnwatch).toHaveBeenCalledWith('/repo-resolved'));
+    expect(callLog).toEqual(['watch:/repo', 'unwatch:/repo-resolved']);
   });
 
   it('unwatches the previously resolved root and re-watches the new one when root changes', async () => {

--- a/app/src/components/notebook/NotebookTile.tsx
+++ b/app/src/components/notebook/NotebookTile.tsx
@@ -22,7 +22,7 @@ export function NotebookTile({
   root?: string;
   onOpenFile: (path: string) => void;
 }) {
-  const { makeDaemon, effectiveNotebookRoot, sendFsWatch, sendFsUnwatch } = useNotebookSurfaceContext();
+  const { makeDaemon, effectiveNotebookRoot, sendFsWatch, sendFsUnwatch, connectionGeneration } = useNotebookSurfaceContext();
 
   // fs_watch_result may normalize `root` (e.g. macOS resolving /tmp to
   // /private/tmp) — and fs_changed events for this subscription carry that
@@ -46,6 +46,11 @@ export function NotebookTile({
     if (!root || root === effectiveNotebookRoot) {
       return;
     }
+    // connectionGeneration is a dep (not read below) purely to force this
+    // effect to re-run on every fresh WebSocket connect: the daemon drops
+    // this tile's explicit fs_watch ref whenever the socket disconnects, but
+    // a normal frontend reconnect leaves the tile mounted and these callback
+    // identities intact, so nothing else here would re-fire the subscription.
     let cancelled = false;
     sendFsWatch(root)
       .then((result) => {
@@ -79,7 +84,7 @@ export function NotebookTile({
       });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- sendFsWatch/sendFsUnwatch are stable daemon callbacks
-  }, [root, effectiveNotebookRoot]);
+  }, [root, effectiveNotebookRoot, connectionGeneration]);
 
   return (
     <NotebookSurface

--- a/app/src/components/notebook/NotebookTile.tsx
+++ b/app/src/components/notebook/NotebookTile.tsx
@@ -1,18 +1,68 @@
-import { useNotebookSurfaceDaemon } from '../../contexts/NotebookSurfaceContext';
+import { useEffect, useMemo, useRef } from 'react';
+import { useNotebookSurfaceContext } from '../../contexts/NotebookSurfaceContext';
 import { NotebookSurface } from '../NotebookSurface';
 
 // NotebookTile is the in-workspace shape of the Notebook: a `tile`-variant
 // NotebookSurface wired to the daemon via context. It reopens to `initialPath`
 // (the tile's persisted file) and reports each opened file back so the tile's
 // params persist the new path. A tile is always active once mounted.
+//
+// `root`, when set, pins the tile to an arbitrary filesystem root instead of
+// the notebook storage root (editor-over-arbitrary-roots). A root-bound tile
+// also owns its own fs_watch subscription — the notebook root is watched by
+// the daemon unconditionally, but nothing else is, so a tile is the one
+// deciding when it needs live updates for its root and dropping that
+// subscription when it stops needing them.
 export function NotebookTile({
   initialPath,
+  root,
   onOpenFile,
 }: {
   initialPath: string | null;
+  root?: string;
   onOpenFile: (path: string) => void;
 }) {
-  const daemon = useNotebookSurfaceDaemon();
+  const { makeDaemon, effectiveNotebookRoot, sendFsWatch, sendFsUnwatch } = useNotebookSurfaceContext();
+  const daemon = useMemo(() => makeDaemon(root), [makeDaemon, root]);
+
+  // The root this tile is actually subscribed to via fs_watch, so the effect's
+  // cleanup unwatches the resolution the daemon echoed back — not necessarily
+  // the raw `root` prop, which fs_watch_result may have normalized.
+  const watchedRootRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    // The notebook root is watched by the daemon unconditionally; only an
+    // arbitrary, distinct root needs this tile to open its own subscription.
+    if (!root || root === effectiveNotebookRoot) {
+      return;
+    }
+    let cancelled = false;
+    sendFsWatch(root)
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        watchedRootRef.current = result.root;
+      })
+      .catch((error) => {
+        // The tile still works without live refresh (e.g. the daemon's watch
+        // cap is reached) — just no fs_changed-driven reload for this root.
+        console.warn('[NotebookTile] fs_watch failed for root', root, error);
+      });
+    return () => {
+      cancelled = true;
+      const watchedRoot = watchedRootRef.current;
+      watchedRootRef.current = null;
+      if (!watchedRoot) {
+        return;
+      }
+      sendFsUnwatch(watchedRoot).catch((error) => {
+        console.warn('[NotebookTile] fs_unwatch failed for root', watchedRoot, error);
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- sendFsWatch/sendFsUnwatch are stable daemon callbacks
+  }, [root, effectiveNotebookRoot]);
+
   return (
     <NotebookSurface
       variant="tile"

--- a/app/src/components/notebook/NotebookTile.tsx
+++ b/app/src/components/notebook/NotebookTile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNotebookSurfaceContext } from '../../contexts/NotebookSurfaceContext';
 import { NotebookSurface } from '../NotebookSurface';
 
@@ -23,7 +23,16 @@ export function NotebookTile({
   onOpenFile: (path: string) => void;
 }) {
   const { makeDaemon, effectiveNotebookRoot, sendFsWatch, sendFsUnwatch } = useNotebookSurfaceContext();
-  const daemon = useMemo(() => makeDaemon(root), [makeDaemon, root]);
+
+  // fs_watch_result may normalize `root` (e.g. macOS resolving /tmp to
+  // /private/tmp) — and fs_changed events for this subscription carry that
+  // resolved form, not the raw prop. Once resolution lands, both the fs_*
+  // calls and the changeSignal lookup must use it, or a root-bound tile's
+  // live refresh is silently dead. Reset on every root change so a stale
+  // resolution from a previous root never leaks into the new one.
+  const [resolvedRoot, setResolvedRoot] = useState<string | null>(null);
+  const effectiveRoot = root ? (resolvedRoot ?? root) : undefined;
+  const daemon = useMemo(() => makeDaemon(effectiveRoot), [makeDaemon, effectiveRoot]);
 
   // The root this tile is actually subscribed to via fs_watch, so the effect's
   // cleanup unwatches the resolution the daemon echoed back — not necessarily
@@ -31,6 +40,7 @@ export function NotebookTile({
   const watchedRootRef = useRef<string | null>(null);
 
   useEffect(() => {
+    setResolvedRoot(null);
     // The notebook root is watched by the daemon unconditionally; only an
     // arbitrary, distinct root needs this tile to open its own subscription.
     if (!root || root === effectiveNotebookRoot) {
@@ -40,9 +50,17 @@ export function NotebookTile({
     sendFsWatch(root)
       .then((result) => {
         if (cancelled) {
+          // The tile unmounted (or root changed) before this resolved: the
+          // daemon-side watcher was just established, so it must still be
+          // dropped here — the cleanup below already ran and saw no
+          // watchedRootRef to unwatch, so this is the only chance.
+          sendFsUnwatch(result.root).catch((error) => {
+            console.warn('[NotebookTile] fs_unwatch failed for root', result.root, error);
+          });
           return;
         }
         watchedRootRef.current = result.root;
+        setResolvedRoot(result.root);
       })
       .catch((error) => {
         // The tile still works without live refresh (e.g. the daemon's watch

--- a/app/src/contexts/NotebookSurfaceContext.tsx
+++ b/app/src/contexts/NotebookSurfaceContext.tsx
@@ -53,6 +53,11 @@ export interface NotebookSurfaceContextValue {
   effectiveNotebookRoot: string;
   sendFsWatch: (root?: string) => Promise<FsWatchResult>;
   sendFsUnwatch: (root?: string) => Promise<FsWatchResult>;
+  // Bumps on every fresh WebSocket connect (including reconnects). The daemon
+  // drops explicit fs_watch refs whenever a client's socket disconnects, so a
+  // root-bound tile must re-issue fs_watch after each new generation or it
+  // silently stops seeing external fs_changed events post-reconnect.
+  connectionGeneration: number;
 }
 
 const NotebookSurfaceContext = createContext<NotebookSurfaceContextValue | null>(null);

--- a/app/src/contexts/NotebookSurfaceContext.tsx
+++ b/app/src/contexts/NotebookSurfaceContext.tsx
@@ -4,6 +4,7 @@ import type {
   FsExistsResult,
   FsReadAssetResult,
   FsReadResult,
+  FsWatchResult,
   FsWriteResult,
   NotebookEntry,
   NotebookSendToChiefResult,
@@ -22,21 +23,48 @@ export interface NotebookSurfaceDaemon {
   backlinksNotebook: (path: string) => Promise<NotebookEntry[]>;
   sendToChief: (selection: string, sourcePath?: string) => Promise<NotebookSendToChiefResult>;
   // Walk the whole vault (flat list of notes, with titles) for a tile's fuzzy finder.
+  // Notebook-storage only (see the boundary note below) — unaffected by `root`.
   listFiles: () => Promise<NotebookEntry[]>;
-  // Bumps when an fs_changed broadcast arrives, so an open tile reloads its file.
+  // Bumps when an fs_changed broadcast arrives for this daemon's root, so an
+  // open tile reloads its file. Scoped per-root: a root-bound tile only sees
+  // this move for its own root, not for unrelated fs activity elsewhere.
   changeSignal: number;
 }
 
-const NotebookSurfaceContext = createContext<NotebookSurfaceDaemon | null>(null);
+// Builds a NotebookSurfaceDaemon bound to `root` (undefined = the notebook
+// storage root, same behavior as before per-root tiles existed). Each fs_*
+// call carries `root` down to the daemon; `changeSignal` is likewise sliced to
+// events for that root.
+//
+// CRITICAL BOUNDARY: backlinksNotebook, sendToChief, and listFiles are
+// Notebook-storage commands on the daemon side (notebook_backlinks,
+// notebook_send_to_chief, notebook_list) — they are bound to the notebook
+// root exactly as before regardless of the `root` argument here. Passing an
+// arbitrary filesystem root into those notebook_* commands is out of scope
+// and forbidden; UI for them on a non-notebook-rooted tile is gated off
+// separately (see the arbitrary-roots plan's authorization-boundary note).
+export type MakeNotebookSurfaceDaemon = (root?: string) => NotebookSurfaceDaemon;
 
-export function NotebookSurfaceProvider({ value, children }: { value: NotebookSurfaceDaemon; children: ReactNode }) {
+export interface NotebookSurfaceContextValue {
+  makeDaemon: MakeNotebookSurfaceDaemon;
+  // settings['notebook.root.effective'], threaded through so a tile can tell
+  // whether its own root differs from the (always-watched) notebook root and
+  // therefore needs its own fs_watch/fs_unwatch subscription.
+  effectiveNotebookRoot: string;
+  sendFsWatch: (root?: string) => Promise<FsWatchResult>;
+  sendFsUnwatch: (root?: string) => Promise<FsWatchResult>;
+}
+
+const NotebookSurfaceContext = createContext<NotebookSurfaceContextValue | null>(null);
+
+export function NotebookSurfaceProvider({ value, children }: { value: NotebookSurfaceContextValue; children: ReactNode }) {
   return <NotebookSurfaceContext.Provider value={value}>{children}</NotebookSurfaceContext.Provider>;
 }
 
-export function useNotebookSurfaceDaemon(): NotebookSurfaceDaemon {
+export function useNotebookSurfaceContext(): NotebookSurfaceContextValue {
   const ctx = useContext(NotebookSurfaceContext);
   if (!ctx) {
-    throw new Error('useNotebookSurfaceDaemon must be used within a NotebookSurfaceProvider');
+    throw new Error('useNotebookSurfaceContext must be used within a NotebookSurfaceProvider');
   }
   return ctx;
 }

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -859,6 +859,12 @@ export function useDaemonSocket({
   const profileMismatchRef = useRef<boolean>(false);
   const profileCheckedRef = useRef<boolean>(false);
   const [connectionError, setConnectionError] = useState<string | null>(null);
+  // Bumped on every successful WebSocket connect (including reconnects). The
+  // daemon deliberately drops explicit fs_watch refs when a client's socket
+  // disconnects, so any consumer that needs a durable server-side
+  // subscription across reconnects (e.g. NotebookTile's arbitrary-root
+  // fs_watch) must re-issue it whenever this generation changes.
+  const [connectionGeneration, setConnectionGeneration] = useState(0);
   const [hasReceivedInitialState, setHasReceivedInitialState] = useState(false);
   const [rateLimit, setRateLimit] = useState<RateLimitState | null>(null);
   const [warnings, setWarnings] = useState<DaemonWarning[]>([]);
@@ -1124,6 +1130,7 @@ export function useDaemonSocket({
       console.log('[Daemon] WebSocket connected');
       daemonRestartInProgressRef.current = false;
       setConnectionError(null);
+      setConnectionGeneration((prev) => prev + 1);
       reconnectDelayRef.current = 1000; // Reset to 1s on successful connect
       reconnectAttemptsRef.current = 0;
       circuitOpenRef.current = false;
@@ -5282,6 +5289,7 @@ export function useDaemonSocket({
   return {
     isConnected: wsRef.current?.readyState === WebSocket.OPEN,
     connectionError,
+    connectionGeneration,
     hasReceivedInitialState,
     settings: settingsRef.current,
     rateLimit,

--- a/app/src/types/workspace.test.ts
+++ b/app/src/types/workspace.test.ts
@@ -8,6 +8,8 @@ import {
   getNormalizedPaneBounds,
   getSplitDividers,
   hasPane,
+  parseNotebookTileParams,
+  serializeNotebookTileParams,
   workspaceSnapshotFromDaemonWorkspace,
   type TerminalLayoutNode,
 } from './workspace';
@@ -259,5 +261,52 @@ describe('docked tiles', () => {
     });
     // A split whose second child fails to parse yields no usable tree.
     expect(snapshot.workspace.layoutTree).toBeNull();
+  });
+});
+
+describe('notebook tile params (parse/serialize)', () => {
+  it('round-trips the legacy bare-path format for a rootless tile', () => {
+    const raw = 'knowledge/areas/foo.md';
+    const parsed = parseNotebookTileParams(raw);
+    expect(parsed).toEqual({ path: raw });
+    expect(serializeNotebookTileParams(parsed)).toBe(raw);
+  });
+
+  it('round-trips the {root, path} JSON envelope for a root-bound tile', () => {
+    const raw = serializeNotebookTileParams({ root: '/Users/victor/code/attn', path: 'README.md' });
+    expect(raw.startsWith('{')).toBe(true);
+    const parsed = parseNotebookTileParams(raw);
+    expect(parsed).toEqual({ root: '/Users/victor/code/attn', path: 'README.md' });
+    expect(serializeNotebookTileParams(parsed)).toBe(raw);
+  });
+
+  it('treats a malformed JSON-looking string as a legacy bare path', () => {
+    const raw = '{not valid json';
+    expect(parseNotebookTileParams(raw)).toEqual({ path: raw });
+  });
+
+  it('serializes a root with no open path as {root} only', () => {
+    const raw = serializeNotebookTileParams({ root: '/tmp/some-root' });
+    expect(JSON.parse(raw)).toEqual({ root: '/tmp/some-root' });
+    expect(parseNotebookTileParams(raw)).toEqual({ root: '/tmp/some-root' });
+  });
+
+  it('treats empty/null/undefined raw as no params', () => {
+    expect(parseNotebookTileParams(undefined)).toEqual({});
+    expect(parseNotebookTileParams(null)).toEqual({});
+    expect(parseNotebookTileParams('')).toEqual({});
+  });
+
+  it('preserves a tile\'s root across a path update (open-file round trip)', () => {
+    // Simulates WorkspaceDockTile's onOpenFile: parse the current params, keep
+    // `root`, and reserialize with the newly opened path.
+    const initial = parseNotebookTileParams(serializeNotebookTileParams({ root: '/repo', path: 'a.md' }));
+    const afterOpen = serializeNotebookTileParams({ root: initial.root, path: 'b.md' });
+    expect(parseNotebookTileParams(afterOpen)).toEqual({ root: '/repo', path: 'b.md' });
+  });
+
+  it('ignores unknown fields in the JSON envelope', () => {
+    const raw = JSON.stringify({ root: '/repo', path: 'a.md', bogus: 'nope' });
+    expect(parseNotebookTileParams(raw)).toEqual({ root: '/repo', path: 'a.md' });
   });
 });

--- a/app/src/types/workspace.ts
+++ b/app/src/types/workspace.ts
@@ -429,6 +429,56 @@ export function tileIdsFromLayoutJSON(layoutJSON: string, kind?: TileKind): stri
     .map((tile) => tile.tileId);
 }
 
+// A notebook tile's parsed tileParams: `root` is set only for a tile pinned to
+// an arbitrary filesystem root (editor-over-arbitrary-roots); its absence
+// means the tile renders the notebook-storage root, same as before this
+// shape existed. `path` is the tile's currently open file, relative to
+// whichever root applies.
+export interface NotebookTileParams {
+  root?: string;
+  path?: string;
+}
+
+// parseNotebookTileParams decodes a persisted notebook tile's tileParams.
+// Two encodings coexist on purpose: pre-arbitrary-roots tiles persisted a bare
+// path string (no JSON envelope), and every tile still round-trips through
+// that legacy shape when it has no root — see serializeNotebookTileParams.
+// A JSON-looking string that fails to parse is treated as a (verbatim, if
+// unusual) legacy path rather than dropped, so a malformed persisted value
+// degrades to "reopen this path" instead of "lose the tile's file".
+export function parseNotebookTileParams(raw: string | undefined | null): NotebookTileParams {
+  if (!raw) {
+    return {};
+  }
+  if (raw.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const result: NotebookTileParams = {};
+      if (typeof parsed.root === 'string' && parsed.root) {
+        result.root = parsed.root;
+      }
+      if (typeof parsed.path === 'string' && parsed.path) {
+        result.path = parsed.path;
+      }
+      return result;
+    } catch {
+      return { path: raw };
+    }
+  }
+  return { path: raw };
+}
+
+// serializeNotebookTileParams is the inverse of parseNotebookTileParams. A
+// rootless tile (the common case today) keeps persisting the legacy bare-path
+// format so its params stay readable by, and round-trip through, code that
+// still expects the pre-arbitrary-roots shape.
+export function serializeNotebookTileParams(params: NotebookTileParams): string {
+  if (params.root) {
+    return JSON.stringify(params.path ? { root: params.root, path: params.path } : { root: params.root });
+  }
+  return params.path || '';
+}
+
 function agentTerminalsFromPanes(panes: PaneElement[]): AgentTerminal[] {
   return panes
     .filter((pane) => pane.kind === 'agent' && typeof pane.runtime_id === 'string' && typeof pane.session_id === 'string')

--- a/app/src/utils/tilePresentation.ts
+++ b/app/src/utils/tilePresentation.ts
@@ -1,4 +1,4 @@
-import type { TileContentState, TileLeaf } from '../types/workspace';
+import { parseNotebookTileParams, type TileContentState, type TileLeaf } from '../types/workspace';
 
 export function tilePathBasename(path: string): string {
   const trimmed = path.replace(/\/+$/, '');
@@ -51,9 +51,12 @@ export function deriveTileTitle(tile: TileLeaf, content?: TileContentState): str
     if (fromContent) return fromContent;
   }
   // A notebook tile self-serves its content, so there's no `content` to title from:
-  // show the open file's name, or a plain label before anything is opened.
+  // show the open file's name, or a plain label before anything is opened. Params
+  // may be the legacy bare-path string or the {root, path} JSON envelope a
+  // root-bound tile persists — parse either way to reach the open path.
   if (tile.tileKind === 'notebook') {
-    return tile.tileParams ? tilePathBasename(tile.tileParams) : 'Notebook';
+    const { path } = parseNotebookTileParams(tile.tileParams);
+    return path ? tilePathBasename(path) : 'Notebook';
   }
   const path = content?.path || tile.tileParams || '';
   return path ? tilePathBasename(path) : tile.tileKind;

--- a/app/test-harness/harnesses/NotebookTileHarness.tsx
+++ b/app/test-harness/harnesses/NotebookTileHarness.tsx
@@ -9,9 +9,9 @@
 import { useCallback, useMemo, useState, useEffect } from 'react';
 // Pull in the app's design tokens so the surface renders with the real theme.
 import '../../src/App.css';
-import { NotebookSurfaceProvider, type NotebookSurfaceDaemon } from '../../src/contexts/NotebookSurfaceContext';
+import { NotebookSurfaceProvider, type NotebookSurfaceDaemon, type NotebookSurfaceContextValue } from '../../src/contexts/NotebookSurfaceContext';
 import { NotebookTile } from '../../src/components/notebook/NotebookTile';
-import type { FsEntry, FsExistsResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../../src/hooks/useDaemonSocket';
+import type { FsEntry, FsExistsResult, FsReadAssetResult, FsReadResult, FsWatchResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../../src/hooks/useDaemonSocket';
 import type { HarnessProps } from '../types';
 
 const TREE: Record<string, FsEntry[]> = {
@@ -66,6 +66,7 @@ export function NotebookTileHarness({ onReady, setTriggerRerender }: HarnessProp
     return { path, hash: 'h2', conflict: false };
   }, []);
   const existsFile = useCallback(async (path: string): Promise<FsExistsResult> => ({ path, exists: true }), []);
+  const readAsset = useCallback(async (path: string): Promise<FsReadAssetResult> => ({ path, mimeType: 'image/png', dataBase64: '' }), []);
   const backlinksNotebook = useCallback(async (): Promise<NotebookEntry[]> => [], []);
   const sendToChief = useCallback(async (selection: string, sourcePath?: string): Promise<NotebookSendToChiefResult> => {
     window.__HARNESS__.recordCall('sendToChief', [selection, sourcePath]);
@@ -78,11 +79,22 @@ export function NotebookTileHarness({ onReady, setTriggerRerender }: HarnessProp
     readFile,
     writeFile,
     existsFile,
+    readAsset,
     backlinksNotebook,
     sendToChief,
     listFiles,
     changeSignal: 0,
-  }), [listDir, readFile, writeFile, existsFile, backlinksNotebook, sendToChief, listFiles]);
+  }), [listDir, readFile, writeFile, existsFile, readAsset, backlinksNotebook, sendToChief, listFiles]);
+
+  const sendFsWatch = useCallback(async (root?: string): Promise<FsWatchResult> => ({ root: root ?? '' }), []);
+  const sendFsUnwatch = useCallback(async (root?: string): Promise<FsWatchResult> => ({ root: root ?? '' }), []);
+
+  const surfaceValue = useMemo<NotebookSurfaceContextValue>(() => ({
+    makeDaemon: () => daemon,
+    effectiveNotebookRoot: '',
+    sendFsWatch,
+    sendFsUnwatch,
+  }), [daemon, sendFsWatch, sendFsUnwatch]);
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', 'dark');
@@ -94,7 +106,7 @@ export function NotebookTileHarness({ onReady, setTriggerRerender }: HarnessProp
   return (
     <div style={{ position: 'fixed', inset: 0, display: 'flex', background: 'var(--color-bg-app)' }}>
       <div style={{ width, height: '100%', overflow: 'hidden' }} data-testid="notebook-tile-frame">
-        <NotebookSurfaceProvider value={daemon}>
+        <NotebookSurfaceProvider value={surfaceValue}>
           <NotebookTile
             initialPath={initialPath}
             onOpenFile={(path) => window.__HARNESS__.recordCall('openFile', [path])}

--- a/app/test-harness/harnesses/NotebookTileHarness.tsx
+++ b/app/test-harness/harnesses/NotebookTileHarness.tsx
@@ -94,6 +94,7 @@ export function NotebookTileHarness({ onReady, setTriggerRerender }: HarnessProp
     effectiveNotebookRoot: '',
     sendFsWatch,
     sendFsUnwatch,
+    connectionGeneration: 0,
   }), [daemon, sendFsWatch, sendFsUnwatch]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
PR4 of the editor-arbitrary-roots plan (`docs/plans/2026-07-18-editor-arbitrary-roots.md`).

Frontend-only, no protocol change:
- `tileParams` upgraded to `{root, path}` JSON with legacy bare-path back-compat
- `NotebookSurfaceDaemon` becomes a root-binding factory (notebook-storage commands deliberately stay notebook-rooted)
- Per-root `fs_changed` signals
- `fs_watch`/`fs_unwatch` lifecycle wired to root-bound tiles

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test -- --run` — 1806 tests passing
- [x] Live-smoked on a throwaway profile: created a file externally and confirmed it appeared in the open notebook's tree