### PR TITLE
feat(config): ATTN_DATA_DIR test scoping — tests can never touch the real data dir

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,17 @@ Tests must never resolve `config.DataDir()` (or anything derived from it —
 2026-07-18 daemon test did exactly that and destroyed the production
 database. Scoping goes through `ATTN_DATA_DIR`, never by redirecting `HOME`.
 Every package whose tests reach `config.DataDir()` sets a per-run temp dir as
-the default via `TestMain` (`os.Setenv("ATTN_DATA_DIR", <temp dir>)` before
-`m.Run()`); individual tests layer `t.Setenv("ATTN_DATA_DIR", t.TempDir())`
-on top for extra isolation. `config.DataDir()` panics under `go test` if
+the default via `TestMain`, calling `config.ScopeTestEnvironment(<temp dir>)`
+before `m.Run()` — not a raw `os.Setenv("ATTN_DATA_DIR", ...)`, because
+`DBPath`, `SocketPath`, `PluginDir`, and the config-file path each check
+their own env-var override (`ATTN_DB_PATH`, `ATTN_SOCKET_PATH`,
+`ATTN_CONFIG_PATH`, `ATTN_PLUGIN_DIR`) before ever reaching the
+`ATTN_DATA_DIR`-scoped chokepoint, so a stray inherited value from the
+calling shell (e.g. a leftover `ATTN_DB_PATH` pointed at the real
+`~/.attn/attn.db`) can bypass scoping entirely unless it's cleared.
+`ScopeTestEnvironment` sets `ATTN_DATA_DIR` and clears the four overrides in
+one call; individual tests layer `t.Setenv("ATTN_DATA_DIR", t.TempDir())` on
+top for extra isolation. `config.DataDir()` panics under `go test` if
 `ATTN_DATA_DIR` isn't set — a presence check, not a path comparison — so a
 package that forgets this fails loudly instead of writing to prod. See
 [docs/plans/2026-07-18-db-loss-mitigation.md](docs/plans/2026-07-18-db-loss-mitigation.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,20 @@ DEBUG=debug attn -s test
 - do not use `log.Printf()` for daemon logging because stderr is discarded in background mode
 - use prefixed `console.log/warn/error` in frontend code and inspect via Tauri DevTools
 
+### Test Data-Dir Scoping
+
+Tests must never resolve `config.DataDir()` (or anything derived from it —
+`DBPath`, `SocketPath`, `PluginDir`, `LogPath`, ...) to the real `~/.attn`: a
+2026-07-18 daemon test did exactly that and destroyed the production
+database. Scoping goes through `ATTN_DATA_DIR`, never by redirecting `HOME`.
+Every package whose tests reach `config.DataDir()` sets a per-run temp dir as
+the default via `TestMain` (`os.Setenv("ATTN_DATA_DIR", <temp dir>)` before
+`m.Run()`); individual tests layer `t.Setenv("ATTN_DATA_DIR", t.TempDir())`
+on top for extra isolation. `config.DataDir()` panics under `go test` if
+`ATTN_DATA_DIR` isn't set — a presence check, not a path comparison — so a
+package that forgets this fails loudly instead of writing to prod. See
+[docs/plans/2026-07-18-db-loss-mitigation.md](docs/plans/2026-07-18-db-loss-mitigation.md).
+
 ### Frontend Instrumentation (disk-based)
 
 For hard-to-reproduce UI bugs, prefer disk-based JSONL logs over `console.log` — agents can read files but not DevTools. Write to `$APPLOCALDATA/debug/<name>.jsonl` using Tauri's `writeTextFile`. See `app/src/utils/terminalDiagnosticsLog.ts` and `app/src/utils/terminalLinkHitTestLog.ts` for the pattern. Remove temporary instrumentation once the bug is resolved.

--- a/docs/plans/2026-07-18-db-loss-mitigation.md
+++ b/docs/plans/2026-07-18-db-loss-mitigation.md
@@ -1,0 +1,116 @@
+# Plan: attn.db Data-Loss Mitigation
+
+## Why
+
+On 2026-07-18 a `go test ./internal/daemon` run destroyed the production
+`~/.attn/attn.db`: daemon tests resolve `config.DataDir()` straight to the real
+`~/.attn`, and a test wrote a sentinel file there. Nothing was recoverable —
+no backups existed, no Time Machine / APFS snapshots. Workspaces and settings
+were salvaged from the live daemon's memory, but tickets, session registry,
+review comments, and recent locations (the connective core) were gone, so in
+practice the state was a total loss.
+
+Two mitigations, in order: make loss recoverable (backups), then make this
+class of loss impossible to cause from the test suite (tooling).
+
+## 1. Periodic Backups With Rotation
+
+**Status: core merged (#578, `a1860213`).** The daemon snapshots the DB via
+`VACUUM INTO` into `<data-dir>/backups/`:
+
+- at daemon startup and every 6h — `attn-<timestamp>.db`, **keep last 12**
+  (~3 days), oldest pruned
+- before any pending schema migration — `attn-premigration-<ver>-<ts>.db`
+- backups refuse the in-memory fallback store (would snapshot garbage and
+  rotate away real copies exactly when the durable DB is broken)
+- a failed backup logs and never blocks startup
+
+Reaches prod on the next prod install; until then the running daemon has no
+safety net.
+
+Follow-ups (rotation awareness — no infinite copies anywhere):
+
+- [ ] Cap pre-migration snapshots too. They are exempt from the keep-12 prune
+      today, which is unbounded over time. Prune to the last **5**
+      pre-migration snapshots (they only accrue one per migration, but
+      "exempt" must not mean "immortal").
+- [ ] Restore path: `attn db restore <backup|latest>` — stop-daemon-safe copy
+      of a snapshot back into place (refuses while a daemon holds the DB), so
+      recovery is one command instead of an incident script.
+- [ ] Surfacing: expose last-successful-backup age (settings/status payload).
+      A backup loop that silently fails for weeks is a safety net that isn't
+      there; the app can show a warning when the newest snapshot is stale
+      (> 24h).
+
+## 2. Tooling: Tests Can Never Touch The Real Data Dir
+
+Root cause: `config.DataDir()` is env-derived at call time (`$HOME/.attn`),
+and nothing in the test harness redirects it. Any test (or transitively, any
+helper) that writes under `DataDir()` writes to production. The current state
+— three individually-guarded tests with a `t.Setenv("HOME", ...)` prologue —
+is convention, not enforcement.
+
+We deliberately do NOT touch `HOME`: redirecting a global env var that every
+tool interprets is exactly the kind of blast-radius lever a mistaken agent or
+partially-applied redirect can turn into real damage. Instead, an explicit
+attn-only override:
+
+```text
+Layer 1 (explicit test scoping)       Layer 2 (global backstop)
+ATTN_DATA_DIR env var, highest         under `go test`, config.DataDir()
+  precedence in config resolution;     panics unless ATTN_DATA_DIR is set —
+  TestMain sets it to a per-run        no path heuristics, no HOME
+  temp dir                             inspection, just "tests must scope"
+```
+
+- [x] **`ATTN_DATA_DIR` override in `config`**: highest-precedence data-dir
+      source (above `ATTN_PROFILE` derivation). Nothing else in the
+      environment changes — HOME is never read differently, no other tool's
+      dotfiles are affected, and destructive test cleanup only ever sees the
+      explicit temp path.
+- [x] **TestMain scoping** in `internal/daemon` (and any other package whose
+      tests can reach `config.DataDir()` — audit `internal/store`,
+      `internal/hooks`, `cmd/attn`): `os.Setenv("ATTN_DATA_DIR", <temp dir>)`
+      in `TestMain` before `m.Run()`, so every test in the package is scoped
+      by default instead of opt-in. Empirically (added the backstop, ran
+      `go test ./...`, fixed every panic) this landed in `internal/daemon`
+      (extended the existing `TestMain`), `internal/daemonctl`, and
+      `internal/client`; `internal/store`, `internal/hooks`, and `cmd/attn`
+      never reach the guarded chokepoint in tests and needed no changes.
+- [x] **Backstop in `config`**: using `testing.Testing()` (Go ≥1.21),
+      `DataDir()` panics if called under `go test` without `ATTN_DATA_DIR`
+      set. A panic is correct here: it converts silent prod damage into an
+      immediate, attributable test failure, and it catches every future
+      package that forgets Layer 1 — including code that doesn't exist yet.
+      The rule is a simple presence check, not a path comparison, so it can't
+      be fooled by symlinks or unusual HOMEs. (Also had to make `config`'s
+      `init()`-time config-file load lazy — it ran before any package's
+      `TestMain` could set `ATTN_DATA_DIR`, so the backstop fired on package
+      load for every test binary that imports `config`, not just ones that
+      call `DataDir()`.)
+- [x] Regression proof: one test per layer — `TestAttnDir_DerivedPathsAllInheritDataDir`
+      proves `ATTN_DATA_DIR` wins even with `ATTN_PROFILE` set and that every
+      derived path (socket/DB/log) inherits it; `TestDataDir_PanicsWithoutATTNDataDirUnderTest`
+      proves the backstop panic fires, via a subprocess that re-execs the test
+      binary with `ATTN_DATA_DIR` unset (same pattern as os/exec crash tests).
+
+## Decisions
+
+- **No HOME manipulation, ever** (Victor, 2026-07-18): test scoping goes
+  through the attn-specific `ATTN_DATA_DIR` override, never by redirecting
+  `HOME`. A global env redirect is a blast-radius lever — a partially-applied
+  or mistaken redirect combined with destructive cleanup could hit the real
+  home directory.
+- Backstop lives in `config` (the single source of path truth), not in
+  `store.OpenDB` — the incident wrote a raw file without going through the
+  store, so guarding the store would not have caught it.
+- `testing.Testing()` over env-sniffing heuristics: it is the stdlib's
+  purpose-built signal and free of false positives in production binaries.
+- Pre-migration snapshot cap of 5 rather than folding them into the keep-12
+  pool: a bad migration may only be noticed days later; the newest rotating
+  snapshots would already be post-migration by then.
+
+## Follow-ups
+
+- Consider an opt-in `attn db backup now` CLI verb for manual pre-surgery
+  snapshots (cheap once BackupNow exists).

--- a/docs/plans/2026-07-18-db-loss-mitigation.md
+++ b/docs/plans/2026-07-18-db-loss-mitigation.md
@@ -70,13 +70,31 @@ ATTN_DATA_DIR env var, highest         under `go test`, config.DataDir()
       explicit temp path.
 - [x] **TestMain scoping** in `internal/daemon` (and any other package whose
       tests can reach `config.DataDir()` — audit `internal/store`,
-      `internal/hooks`, `cmd/attn`): `os.Setenv("ATTN_DATA_DIR", <temp dir>)`
-      in `TestMain` before `m.Run()`, so every test in the package is scoped
-      by default instead of opt-in. Empirically (added the backstop, ran
-      `go test ./...`, fixed every panic) this landed in `internal/daemon`
-      (extended the existing `TestMain`), `internal/daemonctl`, and
-      `internal/client`; `internal/store`, `internal/hooks`, and `cmd/attn`
-      never reach the guarded chokepoint in tests and needed no changes.
+      `internal/hooks`, `cmd/attn`): `config.ScopeTestEnvironment(<temp
+      dir>)` in `TestMain` before `m.Run()`, so every test in the package is
+      scoped by default instead of opt-in. Empirically (added the backstop,
+      ran `go test ./...`, fixed every panic) this landed in
+      `internal/daemon` (extended the existing `TestMain`),
+      `internal/daemonctl`, and `internal/client`; `internal/store`,
+      `internal/hooks`, and `cmd/attn` never reach the guarded chokepoint in
+      tests and needed no changes.
+- [x] **Closed the per-path override escape door** (figgyster review on
+      PR #584): `DBPath`, `SocketPath`, `PluginDir`, and the config-file path
+      each check their own env var (`ATTN_DB_PATH`, `ATTN_SOCKET_PATH`,
+      `ATTN_PLUGIN_DIR`, `ATTN_CONFIG_PATH`) before ever reaching the
+      `ATTN_DATA_DIR`-scoped `attnDir()` chokepoint, so setting
+      `ATTN_DATA_DIR` alone in `TestMain` did not bound them — a shell with
+      an inherited `ATTN_DB_PATH` pointed at the real database would still
+      leak into tests. `config.ScopeTestEnvironment(dataDir)` sets
+      `ATTN_DATA_DIR` and unconditionally clears all four overrides in one
+      call; every `TestMain` above uses it instead of a raw
+      `os.Setenv("ATTN_DATA_DIR", ...)`. Test-only: panics outside
+      `testing.Testing()`. Proven by a subprocess regression
+      (`TestScopeTestEnvironment_SanitizesInheritedOverrides`) that seeds
+      hostile `ATTN_DB_PATH`/`ATTN_SOCKET_PATH`/`ATTN_CONFIG_PATH` in the
+      child's inherited env and asserts the child's `TestMain`-scoped
+      `DBPath()`/`SocketPath()` still resolve inside the fresh
+      `ATTN_DATA_DIR`, not the hostile values.
 - [x] **Backstop in `config`**: using `testing.Testing()` (Go ≥1.21),
       `DataDir()` panics if called under `go test` without `ATTN_DATA_DIR`
       set. A panic is correct here: it converts silent prod damage into an

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -26,6 +26,16 @@ app path, and e2e ports, and whether the daemon socket / app are present. Any
 non-default `attn` command also prints a one-line `[attn profile=… socket=…
 port=…]` banner so you can never lose track of which world you are touching.
 
+`ATTN_DATA_DIR`, when set, overrides every profile-derived data dir outright
+(highest precedence, above `ATTN_PROFILE`) — the knob test suites and
+harnesses use to scope themselves to an explicit temp dir instead of ever
+touching a real profile's data. See
+[docs/plans/2026-07-18-db-loss-mitigation.md](plans/2026-07-18-db-loss-mitigation.md).
+It is a per-process scoping override, not a profile. `attn profile resolve`
+and `attn profile clean` deliberately keep reporting and operating on the
+profile's canonical directories and do not honor it, so under `ATTN_DATA_DIR`
+the live process's runtime paths differ from `resolve`'s output by design.
+
 ## The single authority: `attn profile resolve`
 
 Every resource a profile maps to is derived in exactly one place

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -534,15 +534,20 @@ func TestClient_SocketPath(t *testing.T) {
 	// Set binary name for test
 	config.SetBinaryName("attn")
 
-	// Test default socket path
-	t.Setenv("HOME", "/home/testuser")
+	// DefaultSocketPath() = config.SocketPath(), which composes off
+	// ATTN_DATA_DIR; assert that composition directly instead of redirecting
+	// HOME (config's own tests pin the HOME-derived default formula without
+	// touching the go-test data-dir backstop — see
+	// TestDefaultAttnDir_SplitsByProfile in internal/config).
+	dataDir := t.TempDir()
+	t.Setenv("ATTN_DATA_DIR", dataDir)
 	t.Setenv("ATTN_PROFILE", "")
 	t.Setenv("ATTN_SOCKET_PATH", "")
 	t.Setenv("ATTN_CONFIG_PATH", filepath.Join(t.TempDir(), "missing-config.json"))
 	config.ReloadForTesting()
 
 	path := DefaultSocketPath()
-	expected := "/home/testuser/.attn/attn.sock"
+	expected := filepath.Join(dataDir, "attn.sock")
 	if path != expected {
 		t.Errorf("DefaultSocketPath() = %q, want %q", path, expected)
 	}

--- a/internal/client/testmain_test.go
+++ b/internal/client/testmain_test.go
@@ -3,6 +3,8 @@ package client
 import (
 	"os"
 	"testing"
+
+	"github.com/victorarias/attn/internal/config"
 )
 
 // TestMain scopes every test in this package to an explicit temp data dir so
@@ -15,7 +17,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic("client: TestMain: MkdirTemp: " + err.Error())
 	}
-	os.Setenv("ATTN_DATA_DIR", dir)
+	config.ScopeTestEnvironment(dir)
 	code := m.Run()
 	os.RemoveAll(dir)
 	os.Exit(code)

--- a/internal/client/testmain_test.go
+++ b/internal/client/testmain_test.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain scopes every test in this package to an explicit temp data dir so
+// no test can resolve config.DataDir() to the real ~/.attn — see
+// docs/plans/2026-07-18-db-loss-mitigation.md. Individual tests that need
+// their own isolation (e.g. asserting the default HOME-derived path formula)
+// layer a t.Setenv("ATTN_DATA_DIR", ...) on top.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "attn-test-data-*")
+	if err != nil {
+		panic("client: TestMain: MkdirTemp: " + err.Error())
+	}
+	os.Setenv("ATTN_DATA_DIR", dir)
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/config/banner.go
+++ b/internal/config/banner.go
@@ -34,6 +34,14 @@ func CollapseHome(path string) string {
 	if err != nil || home == "" {
 		return path
 	}
+	return collapseHomeRelativeTo(path, home)
+}
+
+// collapseHomeRelativeTo is the pure formula behind CollapseHome, taking
+// home explicitly instead of reading it from the environment. Extracted so
+// tests can exercise the collapsing logic against an arbitrary home string
+// without redirecting the real HOME env var.
+func collapseHomeRelativeTo(path, home string) string {
 	home = filepath.Clean(home)
 	cleaned := filepath.Clean(path)
 	if cleaned == home {

--- a/internal/config/banner_test.go
+++ b/internal/config/banner_test.go
@@ -37,7 +37,9 @@ func TestPrintProfileBanner_MentionsProfileSocketAndPort(t *testing.T) {
 }
 
 func TestCollapseHome(t *testing.T) {
-	t.Setenv("HOME", "/Users/victor")
+	// Pure formula test: pass home explicitly instead of redirecting the
+	// real HOME env var (see collapseHomeRelativeTo).
+	home := "/Users/victor"
 	cases := map[string]string{
 		"/Users/victor":                     "~",
 		"/Users/victor/.attn-dev":           "~/.attn-dev",
@@ -46,8 +48,8 @@ func TestCollapseHome(t *testing.T) {
 		"/tmp/other":                        "/tmp/other",
 	}
 	for in, want := range cases {
-		if got := CollapseHome(in); got != want {
-			t.Errorf("CollapseHome(%q) = %q, want %q", in, got, want)
+		if got := collapseHomeRelativeTo(in, home); got != want {
+			t.Errorf("collapseHomeRelativeTo(%q, %q) = %q, want %q", in, home, got, want)
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -290,6 +290,41 @@ func requireExplicitDataDirUnderTest() {
 	}
 }
 
+// ScopeTestEnvironment sets ATTN_DATA_DIR to dataDir and clears
+// ATTN_DB_PATH, ATTN_SOCKET_PATH, ATTN_CONFIG_PATH, and ATTN_PLUGIN_DIR.
+// Call it from a package TestMain (or an individual test) instead of
+// setting ATTN_DATA_DIR directly.
+//
+// Why clear the other four: DBPath, SocketPath, PluginDir, and the
+// config-file path all check their own env-var override before ever
+// reaching the attnDir() chokepoint, so ATTN_DATA_DIR alone does not bound
+// them. A developer's shell can carry an inherited ATTN_DB_PATH pointing at
+// the real ~/.attn/attn.db (e.g. from a scoped profile) even while
+// ATTN_DATA_DIR is set to a temp dir for the current test run; without this
+// clearing, that inherited override would still route test I/O at the real
+// database. This is the same incident class documented in
+// docs/plans/2026-07-18-db-loss-mitigation.md, one step removed: the
+// backstop in requireExplicitDataDirUnderTest only guards attnDir() itself,
+// not these four overrides that sit above it in precedence.
+//
+// It does not touch HOME or ATTN_PROFILE: ATTN_DATA_DIR already outranks
+// profile derivation, and HOME is off-limits for test scoping (see the
+// Decisions section of the plan above).
+//
+// Test-only: panics if called outside testing.Testing(), since it mutates
+// process-global environment and must never be reachable from a production
+// binary.
+func ScopeTestEnvironment(dataDir string) {
+	if !testing.Testing() {
+		panic("config.ScopeTestEnvironment is test-only")
+	}
+	os.Setenv("ATTN_DATA_DIR", dataDir)
+	os.Unsetenv("ATTN_DB_PATH")
+	os.Unsetenv("ATTN_SOCKET_PATH")
+	os.Unsetenv("ATTN_CONFIG_PATH")
+	os.Unsetenv("ATTN_PLUGIN_DIR")
+}
+
 // defaultAttnDir computes the profile-aware default data dir from the real
 // $HOME, ignoring ATTN_DATA_DIR and the test backstop entirely. It is a pure
 // function of (HOME, profile) with no I/O, so it's safe to call directly

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,13 +10,20 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 )
 
 var binaryName string
 
 func init() {
 	binaryName = filepath.Base(os.Args[0])
-	loadConfig()
+	// Deliberately does NOT call loadConfig() here: package init() runs
+	// before any test's TestMain, so an eager load would hit attnDir()'s
+	// go-test backstop before a package ever gets a chance to set
+	// ATTN_DATA_DIR. Config loading is instead lazy — see
+	// ensureConfigLoaded — triggered by the first call to a function that
+	// actually needs it (DBPath, SocketPath), which by then runs inside a
+	// test body/TestMain, not package init.
 }
 
 // BinaryName returns the name of the running binary (e.g., "attn")
@@ -37,8 +44,26 @@ type configFile struct {
 
 var (
 	loadedConfig configFile
+	configLoaded bool
 	configMu     sync.RWMutex
 )
+
+// ensureConfigLoaded performs the first, lazy load of config.json, unless it
+// has already been loaded (by this or an explicit reloadConfig() call).
+// Callers that read loadedConfig (DBPath, SocketPath) must call this before
+// reading it. Lazy rather than init()-time so the first load happens inside
+// a test body/TestMain (after ATTN_DATA_DIR is set) rather than at package
+// init, which runs before any TestMain and would otherwise trip the
+// attnDir() test backstop unconditionally, in every package that merely
+// imports config.
+func ensureConfigLoaded() {
+	configMu.RLock()
+	loaded := configLoaded
+	configMu.RUnlock()
+	if !loaded {
+		loadConfig()
+	}
+}
 
 // loadConfig loads configuration from file
 func loadConfig() {
@@ -47,6 +72,7 @@ func loadConfig() {
 
 	// Reset to empty
 	loadedConfig = configFile{}
+	configLoaded = true
 
 	configPath := os.Getenv("ATTN_CONFIG_PATH")
 	if configPath == "" {
@@ -224,16 +250,59 @@ func NormalizeProfileName(name string) (string, error) {
 	return canonical, nil
 }
 
-// attnDir returns the base directory for attn files. Profile-aware:
-// default profile → ~/.attn, named profile → ~/.attn-<profile>.
+// attnDir returns the base directory for attn files. This is the single
+// chokepoint every derived path (socket, DB, plugins, logs, PID, workers,
+// ...) funnels through, so ATTN_DATA_DIR and the test backstop below only
+// need to live in one place.
+//
+// Precedence:
+//  1. ATTN_DATA_DIR env var, if set and non-empty — highest precedence,
+//     above ATTN_PROFILE derivation. Returned verbatim (filepath.Clean'd).
+//  2. Profile-aware default: ~/.attn, or ~/.attn-<profile> for a named
+//     profile.
 func attnDir() string {
+	if override := strings.TrimSpace(os.Getenv("ATTN_DATA_DIR")); override != "" {
+		return filepath.Clean(override)
+	}
+	requireExplicitDataDirUnderTest()
+	return defaultAttnDir(Profile())
+}
+
+// requireExplicitDataDirUnderTest panics if called from a test binary
+// (testing.Testing()) without ATTN_DATA_DIR set. This is the backstop for
+// the 2026-07-18 incident where a daemon test resolved config.DataDir()
+// straight to the real ~/.attn and destroyed the production database.
+//
+// It is a presence check only — no path comparison, no HOME inspection —
+// so it can't be fooled by symlinks or unusual HOMEs, and it catches every
+// package (including ones that don't exist yet) that forgets to scope its
+// data dir.
+//
+// If you hit this panic: set ATTN_DATA_DIR to a temp dir, either in a
+// package TestMain (os.Setenv, so it applies to the whole package) or in an
+// individual test via t.Setenv for extra per-test isolation. Never redirect
+// HOME to work around this — see docs/plans/2026-07-18-db-loss-mitigation.md.
+func requireExplicitDataDirUnderTest() {
+	if testing.Testing() && strings.TrimSpace(os.Getenv("ATTN_DATA_DIR")) == "" {
+		panic("config: ATTN_DATA_DIR is not set under go test — tests must never resolve the real data dir. " +
+			"Set ATTN_DATA_DIR to a temp dir (os.Setenv in a package TestMain, or t.Setenv per-test). " +
+			"Never redirect HOME to work around this: see docs/plans/2026-07-18-db-loss-mitigation.md")
+	}
+}
+
+// defaultAttnDir computes the profile-aware default data dir from the real
+// $HOME, ignoring ATTN_DATA_DIR and the test backstop entirely. It is a pure
+// function of (HOME, profile) with no I/O, so it's safe to call directly
+// from tests that want to assert the default-derivation formula without
+// tripping requireExplicitDataDirUnderTest.
+func defaultAttnDir(profile string) string {
 	home, err := os.UserHomeDir()
 	base := "/tmp/.attn"
 	if err == nil {
 		base = filepath.Join(home, ".attn")
 	}
-	if p := Profile(); p != "" {
-		return base + "-" + p
+	if profile != "" {
+		return base + "-" + profile
 	}
 	return base
 }
@@ -256,6 +325,12 @@ func PluginDir() string {
 // profile name (without reading ATTN_PROFILE). Pass "" for the default
 // profile. Callers use this to probe whether the *other* profile's
 // daemon is running, for friendlier error messages.
+//
+// This function deliberately bypasses the attnDir() chokepoint and therefore
+// does not honor ATTN_DATA_DIR overrides or the go-test backstop. The
+// *ForProfile helpers must probe other profiles' directories for cross-profile
+// error messages and must not honor the current process's ATTN_DATA_DIR override.
+// Tests must never write through this path.
 func DataDirForProfile(profile string) string {
 	home, err := os.UserHomeDir()
 	base := "/tmp/.attn"
@@ -276,6 +351,10 @@ func DataDirForProfile(profile string) string {
 // name, independent of the current process's ATTN_PROFILE. Used for
 // cross-profile probing in error messages; does not consult env overrides
 // or the config file.
+//
+// This function deliberately bypasses the attnDir() chokepoint and therefore
+// does not honor ATTN_DATA_DIR overrides or the go-test backstop. It must not
+// honor the current process's override. Tests must never write through this path.
 func SocketPathForProfile(profile string) string {
 	return filepath.Join(DataDirForProfile(profile), "attn.sock")
 }
@@ -289,6 +368,7 @@ func DBPath() string {
 	}
 
 	// 2. Config file
+	ensureConfigLoaded()
 	configMu.RLock()
 	configPath := loadedConfig.DBPath
 	configMu.RUnlock()
@@ -309,6 +389,7 @@ func SocketPath() string {
 	}
 
 	// 2. Config file
+	ensureConfigLoaded()
 	configMu.RLock()
 	configPath := loadedConfig.SocketPath
 	configMu.RUnlock()
@@ -371,7 +452,11 @@ func comparableDaemonIsolationPath(path string) (string, error) {
 	return filepath.Clean(absolute), nil
 }
 
-// StatePath returns the legacy state file path (for migration/cleanup)
+// StatePath returns the legacy state file path (for migration/cleanup).
+//
+// This function deliberately bypasses the attnDir() chokepoint and therefore
+// does not honor ATTN_DATA_DIR overrides or the go-test backstop. Tests must
+// never write through this path.
 func StatePath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,15 +9,20 @@ import (
 )
 
 func TestDBPath_DefaultsToAttnDir(t *testing.T) {
-	// Clear any env vars
+	// DBPath() = filepath.Join(attnDir(), "attn.db") when unoverridden; assert
+	// that composition against the ATTN_DATA_DIR-scoped data dir rather than
+	// the real $HOME (attnDir()'s HOME-derivation formula itself is covered
+	// by TestDefaultAttnDir_SplitsByProfile without touching go test's
+	// data-dir backstop).
+	dataDir := t.TempDir()
+	t.Setenv("ATTN_DATA_DIR", dataDir)
 	os.Unsetenv("ATTN_DB_PATH")
 	os.Unsetenv("ATTN_CONFIG_PATH")
 	os.Unsetenv("ATTN_PROFILE")
 
 	path := DBPath()
 
-	home, _ := os.UserHomeDir()
-	expected := filepath.Join(home, ".attn", "attn.db")
+	expected := filepath.Join(dataDir, "attn.db")
 	if path != expected {
 		t.Errorf("DBPath() = %q, want %q", path, expected)
 	}
@@ -35,14 +40,15 @@ func TestDBPath_EnvVarOverridesDefault(t *testing.T) {
 }
 
 func TestSocketPath_DefaultsToAttnDir(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ATTN_DATA_DIR", dataDir)
 	os.Unsetenv("ATTN_SOCKET_PATH")
 	os.Unsetenv("ATTN_CONFIG_PATH")
 	os.Unsetenv("ATTN_PROFILE")
 
 	path := SocketPath()
 
-	home, _ := os.UserHomeDir()
-	expected := filepath.Join(home, ".attn", "attn.sock")
+	expected := filepath.Join(dataDir, "attn.sock")
 	if path != expected {
 		t.Errorf("SocketPath() = %q, want %q", path, expected)
 	}
@@ -89,8 +95,7 @@ func TestValidateDaemonIsolation_AllowsForeignSocketRootWithIsolatedDB(t *testin
 }
 
 func TestValidateDaemonIsolation_RejectsRelativeDBPathInProfileDir(t *testing.T) {
-	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
+	t.Setenv("ATTN_DATA_DIR", t.TempDir())
 	t.Setenv("ATTN_PROFILE", "")
 	t.Setenv("ATTN_SOCKET_PATH", filepath.Join(t.TempDir(), "attn.sock"))
 	t.Setenv("ATTN_DB_PATH", "attn.db")
@@ -125,11 +130,12 @@ func TestValidateDaemonIsolation_AllowsSocketOverrideInsideProfileDataDir(t *tes
 }
 
 func TestPluginDir_DefaultsToAttnDir(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("ATTN_DATA_DIR", dataDir)
 	os.Unsetenv("ATTN_PLUGIN_DIR")
 	os.Unsetenv("ATTN_PROFILE")
 
-	home, _ := os.UserHomeDir()
-	want := filepath.Join(home, ".attn", "plugins")
+	want := filepath.Join(dataDir, "plugins")
 	if got := PluginDir(); got != want {
 		t.Errorf("PluginDir() = %q, want %q", got, want)
 	}
@@ -264,8 +270,28 @@ func TestValidateProfile_RejectsBadNames(t *testing.T) {
 	}
 }
 
-func TestAttnDir_SplitsByProfile(t *testing.T) {
+// TestDefaultAttnDir_SplitsByProfile pins the HOME-derivation formula
+// attnDir() falls back to when ATTN_DATA_DIR is unset. It calls the pure
+// defaultAttnDir helper directly (no env var, no I/O) instead of exercising
+// attnDir()/DataDir(), which the go-test backstop refuses to resolve without
+// an explicit ATTN_DATA_DIR override.
+func TestDefaultAttnDir_SplitsByProfile(t *testing.T) {
 	home, _ := os.UserHomeDir()
+
+	if got, want := defaultAttnDir(""), filepath.Join(home, ".attn"); got != want {
+		t.Errorf("defaultAttnDir(\"\") = %q, want %q", got, want)
+	}
+	if got, want := defaultAttnDir("dev"), filepath.Join(home, ".attn-dev"); got != want {
+		t.Errorf("defaultAttnDir(\"dev\") = %q, want %q", got, want)
+	}
+}
+
+// TestAttnDir_DerivedPathsAllInheritDataDir asserts every attnDir()-derived
+// path (socket, DB, log) composes off the same base, regardless of profile —
+// the property that lets ATTN_DATA_DIR override every derived path at once.
+func TestAttnDir_DerivedPathsAllInheritDataDir(t *testing.T) {
+	wantDir := t.TempDir()
+	t.Setenv("ATTN_DATA_DIR", wantDir)
 	os.Unsetenv("ATTN_SOCKET_PATH")
 	os.Unsetenv("ATTN_DB_PATH")
 	os.Unsetenv("ATTN_CONFIG_PATH")
@@ -273,7 +299,6 @@ func TestAttnDir_SplitsByProfile(t *testing.T) {
 	t.Setenv("ATTN_PROFILE", "dev")
 	reloadConfig()
 
-	wantDir := filepath.Join(home, ".attn-dev")
 	if got := DataDir(); got != wantDir {
 		t.Errorf("DataDir() = %q, want %q", got, wantDir)
 	}

--- a/internal/config/datadir_backstop_test.go
+++ b/internal/config/datadir_backstop_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestDataDir_PanicsWithoutATTNDataDirUnderTest proves the go-test backstop
+// actually fires. It cannot assert this in-process: this package's own
+// TestMain always sets ATTN_DATA_DIR, and unsetting it here would itself be
+// exactly the kind of "test resolves the real data dir" mistake the backstop
+// exists to catch. Instead it re-execs this same test binary as a
+// subprocess (the standard os/exec crash-test pattern) with ATTN_DATA_DIR
+// explicitly unset in the *child's* env, and asserts the child panics.
+//
+// The parent process's own ATTN_DATA_DIR is never touched.
+func TestDataDir_PanicsWithoutATTNDataDirUnderTest(t *testing.T) {
+	if os.Getenv("ATTN_TEST_DATADIR_BACKSTOP_HELPER") == "1" {
+		// Child process: deliberately call DataDir() without ATTN_DATA_DIR
+		// set, to prove it panics rather than silently resolving a real path.
+		_ = DataDir()
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestDataDir_PanicsWithoutATTNDataDirUnderTest$")
+	cmd.Env = childEnvWithout(os.Environ(), "ATTN_DATA_DIR")
+	cmd.Env = append(cmd.Env, "ATTN_TEST_DATADIR_BACKSTOP_HELPER=1")
+	out, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Fatalf("subprocess DataDir() call without ATTN_DATA_DIR did not fail; want a panic. output:\n%s", out)
+	}
+	if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.Success() {
+		t.Fatalf("subprocess exited with unexpected error %v (want a crash from panic); output:\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "ATTN_DATA_DIR is not set under go test") {
+		t.Fatalf("subprocess output missing backstop panic message; output:\n%s", out)
+	}
+}
+
+// childEnvWithout returns env with every entry for key removed.
+func childEnvWithout(env []string, key string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}

--- a/internal/config/scope_test_environment_test.go
+++ b/internal/config/scope_test_environment_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestScopeTestEnvironment_SanitizesInheritedOverrides proves that
+// ScopeTestEnvironment (as wired into this package's own TestMain) actually
+// strips hostile ATTN_DB_PATH / ATTN_SOCKET_PATH / ATTN_CONFIG_PATH values
+// inherited from the calling shell, rather than merely setting
+// ATTN_DATA_DIR on top of them. This is the scenario figgyster flagged on
+// PR #584: a developer's shell can carry ATTN_DB_PATH pointed at the real
+// ~/.attn/attn.db (e.g. left over from a scoped profile), and without this
+// sanitization DBPath()/SocketPath() would still resolve to that real path
+// even though ATTN_DATA_DIR is scoped to a temp dir for the test run.
+//
+// It cannot assert this in-process: this package's own TestMain has already
+// sanitized its environment by the time any in-process test body runs, so
+// there is nothing hostile left to observe. Instead it re-execs this test
+// binary as a subprocess (same pattern as
+// TestDataDir_PanicsWithoutATTNDataDirUnderTest) with the hostile overrides
+// seeded in the *child's* env, and asserts the child's TestMain-scoped
+// DBPath()/SocketPath() still resolve inside the freshly-scoped
+// ATTN_DATA_DIR rather than the hostile inherited values.
+//
+// The parent process's own environment is never touched.
+func TestScopeTestEnvironment_SanitizesInheritedOverrides(t *testing.T) {
+	const hostileDB = "/tmp/attn-hostile-inherited-test.db"
+	const hostileSocket = "/tmp/attn-hostile-inherited-test.sock"
+	const hostileConfig = "/tmp/attn-hostile-inherited-config.json"
+
+	if os.Getenv("ATTN_TEST_HOSTILE_OVERRIDE_HELPER") == "1" {
+		// Child process, past its own TestMain, which called
+		// ScopeTestEnvironment and should have cleared the hostile values
+		// seeded below before this test body ever runs.
+		dataDir := os.Getenv("ATTN_DATA_DIR")
+		if dataDir == "" {
+			panic("helper: ATTN_DATA_DIR unexpectedly empty inside TestMain-scoped subprocess")
+		}
+		if got := DBPath(); got == hostileDB || !strings.HasPrefix(got, dataDir) {
+			panic("helper: DBPath() escaped ATTN_DATA_DIR scope: got " + got + ", want prefix " + dataDir)
+		}
+		if got := SocketPath(); got == hostileSocket || !strings.HasPrefix(got, dataDir) {
+			panic("helper: SocketPath() escaped ATTN_DATA_DIR scope: got " + got + ", want prefix " + dataDir)
+		}
+		return
+	}
+
+	env := os.Environ()
+	for _, key := range []string{"ATTN_DB_PATH", "ATTN_SOCKET_PATH", "ATTN_CONFIG_PATH"} {
+		env = childEnvWithout(env, key)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestScopeTestEnvironment_SanitizesInheritedOverrides$")
+	cmd.Env = append(env,
+		"ATTN_TEST_HOSTILE_OVERRIDE_HELPER=1",
+		"ATTN_DB_PATH="+hostileDB,
+		"ATTN_SOCKET_PATH="+hostileSocket,
+		"ATTN_CONFIG_PATH="+hostileConfig,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("subprocess with inherited hostile overrides failed: %v\noutput:\n%s", err, out)
+	}
+}

--- a/internal/config/testmain_test.go
+++ b/internal/config/testmain_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain scopes every test in this package to an explicit temp data dir by
+// setting ATTN_DATA_DIR before any test runs. Without this, any test that
+// reaches attnDir() (directly or via DataDir/DBPath/SocketPath/PluginDir/...)
+// panics under the go-test backstop in config.go — see
+// requireExplicitDataDirUnderTest and docs/plans/2026-07-18-db-loss-mitigation.md.
+//
+// This is the package-default; individual tests that need their own
+// isolation (e.g. asserting override precedence) layer a t.Setenv on top.
+func TestMain(m *testing.M) {
+	// The backstop subprocess test deliberately re-execs this binary with
+	// ATTN_DATA_DIR unset to prove config.DataDir() panics; don't paper over
+	// that by setting it back here. See datadir_backstop_test.go.
+	if os.Getenv("ATTN_TEST_DATADIR_BACKSTOP_HELPER") == "1" {
+		os.Exit(m.Run())
+	}
+
+	dir, err := os.MkdirTemp("", "attn-test-data-*")
+	if err != nil {
+		panic("config: TestMain: MkdirTemp: " + err.Error())
+	}
+	os.Setenv("ATTN_DATA_DIR", dir)
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/config/testmain_test.go
+++ b/internal/config/testmain_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic("config: TestMain: MkdirTemp: " + err.Error())
 	}
-	os.Setenv("ATTN_DATA_DIR", dir)
+	ScopeTestEnvironment(dir)
 	code := m.Run()
 	os.RemoveAll(dir)
 	os.Exit(code)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -102,7 +102,20 @@ func TestMain(m *testing.M) {
 	// explicitly override these with t.Setenv.
 	_ = os.Setenv("ATTN_PTY_BACKEND", "embedded")
 	_ = os.Setenv("ATTN_PTY_SKIP_STARTUP_PROBE", "1")
-	os.Exit(m.Run())
+
+	// Scope every test in this package to an explicit temp data dir so no
+	// daemon test can resolve config.DataDir() to the real ~/.attn — see
+	// docs/plans/2026-07-18-db-loss-mitigation.md. Individual tests that need
+	// their own isolation layer a t.Setenv("ATTN_DATA_DIR", ...) on top.
+	dataDir, err := os.MkdirTemp("", "attn-test-data-*")
+	if err != nil {
+		panic("daemon: TestMain: MkdirTemp: " + err.Error())
+	}
+	_ = os.Setenv("ATTN_DATA_DIR", dataDir)
+
+	code := m.Run()
+	os.RemoveAll(dataDir)
+	os.Exit(code)
 }
 
 // waitForSocket waits for a unix socket to be ready for connections.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -103,6 +103,21 @@ func TestMain(m *testing.M) {
 	_ = os.Setenv("ATTN_PTY_BACKEND", "embedded")
 	_ = os.Setenv("ATTN_PTY_SKIP_STARTUP_PROBE", "1")
 
+	// Plugin-process helper subprocesses (TestDaemonPluginProcessHelper,
+	// TestPluginDriverFixtureProcess) re-exec this same test binary with a
+	// single -test.run and rely on ATTN_SOCKET_PATH being the exact value
+	// the parent test process injected via cmd.Env to wire the fixture back
+	// to its temp-scoped daemon socket — that's trusted IPC plumbing from an
+	// already-scoped parent test, not an inherited-from-the-shell override,
+	// and neither helper calls config.DataDir()/DBPath()/SocketPath(), so
+	// there is nothing here for ScopeTestEnvironment to protect. Skip
+	// scoping (and let them inherit whatever ATTN_DATA_DIR the parent test
+	// process already had) rather than clobber that wiring, same shape as
+	// config's own ATTN_TEST_DATADIR_BACKSTOP_HELPER skip.
+	if os.Getenv("ATTN_PLUGIN_HELPER") == "1" || os.Getenv("ATTN_PLUGIN_DRIVER_HELPER") == "1" {
+		os.Exit(m.Run())
+	}
+
 	// Scope every test in this package to an explicit temp data dir so no
 	// daemon test can resolve config.DataDir() to the real ~/.attn — see
 	// docs/plans/2026-07-18-db-loss-mitigation.md. Individual tests that need
@@ -111,7 +126,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic("daemon: TestMain: MkdirTemp: " + err.Error())
 	}
-	_ = os.Setenv("ATTN_DATA_DIR", dataDir)
+	config.ScopeTestEnvironment(dataDir)
 
 	code := m.Run()
 	os.RemoveAll(dataDir)

--- a/internal/daemon/fs_test.go
+++ b/internal/daemon/fs_test.go
@@ -641,11 +641,7 @@ func TestFsCommandsOmittedRootResolvesToNotebookRoot(t *testing.T) {
 // client so this exercises path validation specifically, not the separate
 // auth-gate tests below.
 func TestFsCommandsRejectInvalidRoots(t *testing.T) {
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
-	if !strings.HasPrefix(config.DataDir(), tmpHome+string(filepath.Separator)) {
-		t.Fatalf("test data dir %q escaped the temp HOME — refusing to touch a real data dir", config.DataDir())
-	}
+	t.Setenv("ATTN_DATA_DIR", t.TempDir())
 	if err := os.MkdirAll(config.DataDir(), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -678,11 +674,7 @@ func TestFsCommandsRejectInvalidRoots(t *testing.T) {
 // mutating path (fs_delete), and asserts the delete never touches the data
 // dir file.
 func TestFsCommandsRejectSymlinkedRootIntoDataDir(t *testing.T) {
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
-	if !strings.HasPrefix(config.DataDir(), tmpHome+string(filepath.Separator)) {
-		t.Fatalf("test data dir %q escaped the temp HOME — refusing to touch a real data dir", config.DataDir())
-	}
+	t.Setenv("ATTN_DATA_DIR", t.TempDir())
 	if err := os.MkdirAll(config.DataDir(), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -754,11 +746,7 @@ func TestFsCommandsRejectSymlinkedRootIntoDataDir(t *testing.T) {
 // via a /private symlink — so this exercises the exact canonicalize-both-sides
 // path the fix relies on, not just a synthetic case.
 func TestFsCommandsAcceptLegitimateSymlinkedRoot(t *testing.T) {
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
-	if !strings.HasPrefix(config.DataDir(), tmpHome+string(filepath.Separator)) {
-		t.Fatalf("test data dir %q escaped the temp HOME — refusing to touch a real data dir", config.DataDir())
-	}
+	t.Setenv("ATTN_DATA_DIR", t.TempDir())
 	if err := os.MkdirAll(config.DataDir(), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/daemonctl/testmain_test.go
+++ b/internal/daemonctl/testmain_test.go
@@ -1,0 +1,21 @@
+package daemonctl
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain scopes every test in this package to an explicit temp data dir so
+// no test can resolve config.DataDir() to the real ~/.attn — see
+// docs/plans/2026-07-18-db-loss-mitigation.md. Individual tests that need
+// their own isolation layer a t.Setenv("ATTN_DATA_DIR", ...) on top.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "attn-test-data-*")
+	if err != nil {
+		panic("daemonctl: TestMain: MkdirTemp: " + err.Error())
+	}
+	os.Setenv("ATTN_DATA_DIR", dir)
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/daemonctl/testmain_test.go
+++ b/internal/daemonctl/testmain_test.go
@@ -3,6 +3,8 @@ package daemonctl
 import (
 	"os"
 	"testing"
+
+	"github.com/victorarias/attn/internal/config"
 )
 
 // TestMain scopes every test in this package to an explicit temp data dir so
@@ -14,7 +16,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic("daemonctl: TestMain: MkdirTemp: " + err.Error())
 	}
-	os.Setenv("ATTN_DATA_DIR", dir)
+	config.ScopeTestEnvironment(dir)
 	code := m.Run()
 	os.RemoveAll(dir)
 	os.Exit(code)


### PR DESCRIPTION
## Summary
Implements §2 of docs/plans/2026-07-18-db-loss-mitigation.md (included in this PR).

- `ATTN_DATA_DIR` is now the highest-precedence data-dir source at the `attnDir()` chokepoint.
- Added a `testing.Testing()` presence-check backstop that panics when tests resolve the data dir unscoped — this is the failure class behind the 2026-07-18 incident where a daemon test overwrote the real `~/.attn` database.
- `TestMain` scoping added in `internal/daemon`, `internal/daemonctl`, `internal/client`, `internal/config`.
- `config.json` loading made lazy so the backstop doesn't fire at package init.
- The three PR#577 HOME-redirect tests migrated to `ATTN_DATA_DIR`.
- A subprocess regression test proves the panic actually fires when a test resolves the data dir unscoped.

Note: `DataDirForProfile`/`SocketPathForProfile`/`StatePath` deliberately bypass the chokepoint (documented in code and `docs/profiles.md`).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass, including internal/daemon, internal/daemonctl, internal/client, internal/config)

https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT