### PR TITLE
feat(app): editor tile roots — workspace-dir default, root switcher, finder over fs_index

### DIFF
--- a/app/src/App.fsIndexToNotebookEntries.test.ts
+++ b/app/src/App.fsIndexToNotebookEntries.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fsIndexToNotebookEntries } from './App';
+import type { FsIndexResult } from './hooks/useDaemonSocket';
+
+// Pure-logic coverage for the fs_index -> NotebookEntry adapter that backs the
+// ⌘P finder (both notebook tiles and the fullscreen NotebookBrowser) since PR5
+// switched the finder off notebook_list onto the root-scoped fs_index command.
+// See makeNotebookSurfaceDaemon / notebookBrowserListFiles in App.tsx.
+
+describe('fsIndexToNotebookEntries', () => {
+  it('maps each fs_index path to a NotebookEntry with size 0', () => {
+    const result: FsIndexResult = {
+      root: '/Users/victor/code/attn',
+      files: ['README.md', 'docs/plan.md'],
+      truncated: false,
+    };
+
+    expect(fsIndexToNotebookEntries(result)).toEqual([
+      { path: 'README.md', size: 0 },
+      { path: 'docs/plan.md', size: 0 },
+    ]);
+  });
+
+  it('returns an empty list for an empty index', () => {
+    const result: FsIndexResult = { root: '/Users/victor/code/attn', files: [], truncated: false };
+    expect(fsIndexToNotebookEntries(result)).toEqual([]);
+  });
+
+  it('still returns entries for a truncated result (partial beats none) but warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result: FsIndexResult = {
+      root: '/Users/victor/code/attn',
+      files: ['README.md'],
+      truncated: true,
+    };
+
+    expect(fsIndexToNotebookEntries(result)).toEqual([{ path: 'README.md', size: 0 }]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('[App]');
+
+    warnSpy.mockRestore();
+  });
+
+  it('does not warn when the result is not truncated', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result: FsIndexResult = { root: '/Users/victor/code/attn', files: ['a.md'], truncated: false };
+
+    fsIndexToNotebookEntries(result);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -61,7 +61,7 @@ import {
 import { persistExcludedGridSessions, readExcludedGridSessions } from './components/grid/gridMembership';
 import type { HiddenGridSession } from './components/grid/GridHiddenSessions';
 import { normalizeSessionAgent, type SessionAgent } from './types/sessionAgent';
-import { hasPane, workspaceSnapshotFromDaemonWorkspace, resolveEditorTileRoot, serializeNotebookTileParams, type TerminalSplitDirection } from './types/workspace';
+import { hasPane, workspaceSnapshotFromDaemonWorkspace, resolveEditorTileRoot, localWorkspaceDirectory, serializeNotebookTileParams, type TerminalSplitDirection } from './types/workspace';
 import { useDaemonStore } from './store/daemonSessions';
 import { usePRsNeedingAttention } from './hooks/usePRsNeedingAttention';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -1973,20 +1973,28 @@ sendFetchPRDetails,
   // default actually needs.
   const daemonWorkspacesRef = useRef<DaemonWorkspace[]>([]);
 
+  // Same reasoning as daemonWorkspacesRef: lets handleOpenNotebookTile read the
+  // current session list (to gate a workspace's directory to local-only, see
+  // localWorkspaceDirectory) without rebinding the callback on every session
+  // change.
+  const daemonSessionsRef = useRef<DaemonSession[]>([]);
+
   // Dock a fresh Notebook tile into the active workspace. A unique tile id every
   // time: the daemon treats a duplicate id as a move, so a shared id would just
   // relocate the first tile instead of opening a second. Defaults the tile's root
   // to the active workspace's directory (⌘⌥N per the arbitrary-roots plan) so it
   // opens on the tree the user is working in; falls back to the notebook root
-  // (rootless tileParams) when the workspace has no directory or already matches
-  // the notebook root — see resolveEditorTileRoot.
+  // (rootless tileParams) when the workspace has no directory, the directory
+  // belongs to a remote endpoint (see localWorkspaceDirectory), or the directory
+  // already matches the notebook root — see resolveEditorTileRoot.
   const handleOpenNotebookTile = useCallback(() => {
     const workspaceId = activeWorkspaceIdRef.current;
     if (!workspaceId) return;
     const tileId = `notebook-tile-${crypto.randomUUID()}`;
     const workspace = daemonWorkspacesRef.current.find((w) => w.id === workspaceId);
+    const localDirectory = localWorkspaceDirectory(workspace?.directory, daemonSessionsRef.current, workspaceId);
     const effectiveNotebookRoot = settings['notebook.root.effective'] || '';
-    const root = resolveEditorTileRoot(workspace?.directory, effectiveNotebookRoot);
+    const root = resolveEditorTileRoot(localDirectory, effectiveNotebookRoot);
     void sendWorkspaceDockTile(workspaceId, tileId, 'notebook', {
       edge: 'right',
       ratio: 0.4,
@@ -2828,6 +2836,11 @@ sendFetchPRDetails,
   useEffect(() => {
     daemonWorkspacesRef.current = daemonWorkspaces;
   }, [daemonWorkspaces]);
+  // daemonSessionsRef mirrors daemonSessions for handleOpenNotebookTile — see
+  // its declaration for why a ref instead of a direct dependency.
+  useEffect(() => {
+    daemonSessionsRef.current = daemonSessions;
+  }, [daemonSessions]);
   useEffect(() => {
     if (view === 'session' && activeWorkspaceId) {
       sendWorkspaceSelected(activeWorkspaceId);
@@ -3633,7 +3646,7 @@ sendFetchPRDetails,
                   <SessionTerminalWorkspace
                     ref={setWorkspaceRef(workspace.id)}
                     workspaceId={workspace.id}
-                    workspaceDirectory={workspace.directory}
+                    workspaceDirectory={localWorkspaceDirectory(workspace.directory, daemonSessions, workspace.id)}
                     workspaceSessions={workspace.sessions.map((entry) => ({
                       id: entry.id,
                       label: entry.label,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -47,7 +47,7 @@ import {
   readWarmWorkspaceLimit,
   writeWarmWorkspaceLimit,
 } from './utils/terminalVirtualization';
-import { useDaemonSocket, DaemonWorktree, DaemonSession, DaemonWorkspace, DaemonPR, DaemonEndpoint, DaemonPlugin, DaemonPluginIssue, GitStatusUpdate, DaemonWarning, SessionExitInfo } from './hooks/useDaemonSocket';
+import { useDaemonSocket, DaemonWorktree, DaemonSession, DaemonWorkspace, DaemonPR, DaemonEndpoint, DaemonPlugin, DaemonPluginIssue, GitStatusUpdate, DaemonWarning, SessionExitInfo, type FsIndexResult, type NotebookEntry } from './hooks/useDaemonSocket';
 import type { Presentation } from './types/generated';
 import { useSessionWorkspaceController } from './hooks/useSessionWorkspaceController';
 import { isAttentionSessionState, normalizeSessionState } from './types/sessionState';
@@ -61,7 +61,7 @@ import {
 import { persistExcludedGridSessions, readExcludedGridSessions } from './components/grid/gridMembership';
 import type { HiddenGridSession } from './components/grid/GridHiddenSessions';
 import { normalizeSessionAgent, type SessionAgent } from './types/sessionAgent';
-import { hasPane, workspaceSnapshotFromDaemonWorkspace, type TerminalSplitDirection } from './types/workspace';
+import { hasPane, workspaceSnapshotFromDaemonWorkspace, resolveEditorTileRoot, serializeNotebookTileParams, type TerminalSplitDirection } from './types/workspace';
 import { useDaemonStore } from './store/daemonSessions';
 import { usePRsNeedingAttention } from './hooks/usePRsNeedingAttention';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -153,6 +153,19 @@ export function bumpFsChangeSignal(
 ): Record<string, number> {
   const key = fsChangeSignalKey(root, effectiveNotebookRoot);
   return { ...signals, [key]: (signals[key] || 0) + 1 };
+}
+
+// Adapts fs_index (a flat, root-scoped file listing) to the shape the ⌘P
+// finder and NotebookBrowser already expect from notebook_list. size is
+// always 0: fs_index deliberately omits stat() per entry to stay fast over
+// large repos, and nothing downstream of the finder reads it. A truncated
+// result still renders — an incomplete list beats none — but is flagged to
+// the console so a silently-cut-off finder doesn't look like a bug report.
+export function fsIndexToNotebookEntries(result: FsIndexResult): NotebookEntry[] {
+  if (result.truncated) {
+    console.warn('[App] fs_index truncated for', result.root, '— finder list is incomplete');
+  }
+  return result.files.map((path) => ({ path, size: 0 }));
 }
 
 const TERMINAL_AGENT: SessionAgent = 'shell';
@@ -594,13 +607,13 @@ function App() {
     sendFsReadAsset,
     sendFsWatch,
     sendFsUnwatch,
+    sendFsIndex,
     sendTaskList,
     sendTaskRetry,
     sendNotificationList,
     sendNotificationMarkRead,
     sendNotebookBacklinks,
     sendNotebookToChief,
-    sendNotebookList,
     sendGetRecentLocations,
     sendBrowseDirectory,
     sendInspectPath,
@@ -801,6 +814,7 @@ function App() {
         sendFsReadAsset={sendFsReadAsset}
         sendFsWatch={sendFsWatch}
         sendFsUnwatch={sendFsUnwatch}
+        sendFsIndex={sendFsIndex}
         sendTaskList={sendTaskList}
         sendTaskRetry={sendTaskRetry}
         sendNotificationList={sendNotificationList}
@@ -809,7 +823,6 @@ function App() {
         notificationsChangeSignal={notificationsChangeSignal}
         sendNotebookBacklinks={sendNotebookBacklinks}
         sendNotebookToChief={sendNotebookToChief}
-        sendNotebookList={sendNotebookList}
         fsChangeSignals={fsChangeSignals}
         notebookTaskChangeSignal={notebookTaskChangeSignal}
         sendGetRecentLocations={sendGetRecentLocations}
@@ -919,6 +932,7 @@ interface AppContentProps {
   sendFsReadAsset: ReturnType<typeof useDaemonSocket>['sendFsReadAsset'];
   sendFsWatch: ReturnType<typeof useDaemonSocket>['sendFsWatch'];
   sendFsUnwatch: ReturnType<typeof useDaemonSocket>['sendFsUnwatch'];
+  sendFsIndex: ReturnType<typeof useDaemonSocket>['sendFsIndex'];
   sendTaskList: ReturnType<typeof useDaemonSocket>['sendTaskList'];
   sendTaskRetry: ReturnType<typeof useDaemonSocket>['sendTaskRetry'];
   sendNotificationList: ReturnType<typeof useDaemonSocket>['sendNotificationList'];
@@ -927,7 +941,6 @@ interface AppContentProps {
   notificationsChangeSignal: number;
   sendNotebookBacklinks: ReturnType<typeof useDaemonSocket>['sendNotebookBacklinks'];
   sendNotebookToChief: ReturnType<typeof useDaemonSocket>['sendNotebookToChief'];
-  sendNotebookList: ReturnType<typeof useDaemonSocket>['sendNotebookList'];
   fsChangeSignals: Record<string, number>;
   notebookTaskChangeSignal: number;
   sendGetRecentLocations: ReturnType<typeof useDaemonSocket>['sendGetRecentLocations'];
@@ -1031,6 +1044,7 @@ function AppContent({
   sendFsReadAsset,
   sendFsWatch,
   sendFsUnwatch,
+  sendFsIndex,
   sendTaskList,
   sendTaskRetry,
   sendNotificationList,
@@ -1039,7 +1053,6 @@ function AppContent({
   notificationsChangeSignal,
   sendNotebookBacklinks,
   sendNotebookToChief,
-  sendNotebookList,
   fsChangeSignals,
   notebookTaskChangeSignal,
   sendGetRecentLocations,
@@ -1953,18 +1966,36 @@ sendFetchPRDetails,
   // and the ActionMenu items — both above that derivation — can use it.
   const activeWorkspaceIdRef = useRef<string | null>(null);
 
+  // Mirrors daemonWorkspaces for handleOpenNotebookTile below, same reasoning as
+  // activeWorkspaceIdRef: daemonWorkspaces updates on every workspace/session
+  // change, and depending on it directly would rebind the dock-tile callback (and
+  // any shortcut registered against it) far more often than the workspace-dir
+  // default actually needs.
+  const daemonWorkspacesRef = useRef<DaemonWorkspace[]>([]);
+
   // Dock a fresh Notebook tile into the active workspace. A unique tile id every
   // time: the daemon treats a duplicate id as a move, so a shared id would just
-  // relocate the first tile instead of opening a second.
+  // relocate the first tile instead of opening a second. Defaults the tile's root
+  // to the active workspace's directory (⌘⌥N per the arbitrary-roots plan) so it
+  // opens on the tree the user is working in; falls back to the notebook root
+  // (rootless tileParams) when the workspace has no directory or already matches
+  // the notebook root — see resolveEditorTileRoot.
   const handleOpenNotebookTile = useCallback(() => {
     const workspaceId = activeWorkspaceIdRef.current;
     if (!workspaceId) return;
     const tileId = `notebook-tile-${crypto.randomUUID()}`;
-    void sendWorkspaceDockTile(workspaceId, tileId, 'notebook', { edge: 'right', ratio: 0.4 })
+    const workspace = daemonWorkspacesRef.current.find((w) => w.id === workspaceId);
+    const effectiveNotebookRoot = settings['notebook.root.effective'] || '';
+    const root = resolveEditorTileRoot(workspace?.directory, effectiveNotebookRoot);
+    void sendWorkspaceDockTile(workspaceId, tileId, 'notebook', {
+      edge: 'right',
+      ratio: 0.4,
+      tileParams: root ? serializeNotebookTileParams({ root }) : undefined,
+    })
       .catch((error) => {
         console.warn('[App] Failed to dock notebook tile:', error);
       });
-  }, [sendWorkspaceDockTile]);
+  }, [sendWorkspaceDockTile, settings]);
 
   const actionMenuItems = useMemo<ActionMenuItem[]>(() => [
     {
@@ -2791,6 +2822,12 @@ sendFetchPRDetails,
   useEffect(() => {
     activeWorkspaceIdRef.current = activeWorkspaceId;
   }, [activeWorkspaceId]);
+
+  // daemonWorkspacesRef mirrors daemonWorkspaces for handleOpenNotebookTile — see
+  // its declaration for why a ref instead of a direct dependency.
+  useEffect(() => {
+    daemonWorkspacesRef.current = daemonWorkspaces;
+  }, [daemonWorkspaces]);
   useEffect(() => {
     if (view === 'session' && activeWorkspaceId) {
       sendWorkspaceSelected(activeWorkspaceId);
@@ -3391,18 +3428,22 @@ sendFetchPRDetails,
   // tile, bound to `root` (undefined = the notebook storage root, unchanged
   // behavior). Memoized so a tile's daemon instance is stable across renders
   // that don't touch its own root's change signal.
+  //
+  // listFiles is root-scoped (fs_index over `root`, or the notebook root when
+  // omitted) — the ⌘P finder browses whatever tree the tile is pinned to, per
+  // the arbitrary-roots plan. backlinksNotebook and sendToChief stay bound to
+  // the notebook storage root regardless of `root`: backlinks only exist
+  // between notebook notes, and "send to chief" appends to the notebook inbox,
+  // so both are meaningless (and left un-widened) off the notebook root.
   const makeNotebookSurfaceDaemon = useCallback((root?: string) => ({
     listDir: (path: string) => sendFsList(path, root),
     readFile: (path: string) => sendFsRead(path, root),
     writeFile: (path: string, content: string, baseHash?: string) => sendFsWrite(path, content, baseHash, root),
     existsFile: (path: string) => sendFsExists(path, root),
     readAsset: (path: string) => sendFsReadAsset(path, root),
-    // Notebook-storage-only commands (see NotebookSurfaceContext's boundary
-    // note): bound to the notebook root regardless of `root`.
     backlinksNotebook: sendNotebookBacklinks,
     sendToChief: sendNotebookToChief,
-    // Argless walk = empty prefix = the whole vault, for the in-tile finder index.
-    listFiles: sendNotebookList,
+    listFiles: () => sendFsIndex(root).then(fsIndexToNotebookEntries),
     changeSignal: fsChangeSignals[fsChangeSignalKey(root || '', effectiveNotebookRoot)] || 0,
   }), [
     sendFsList,
@@ -3412,7 +3453,7 @@ sendFetchPRDetails,
     sendFsReadAsset,
     sendNotebookBacklinks,
     sendNotebookToChief,
-    sendNotebookList,
+    sendFsIndex,
     fsChangeSignals,
     effectiveNotebookRoot,
   ]);
@@ -3428,6 +3469,13 @@ sendFetchPRDetails,
   // The fullscreen browser is always notebook-rooted — same signal a rootless
   // tile would resolve to via makeNotebookSurfaceDaemon(undefined).
   const notebookRootChangeSignal = fsChangeSignals[fsChangeSignalKey('', effectiveNotebookRoot)] || 0;
+
+  // The fullscreen browser's finder source: fs_index with root omitted, same
+  // notebook-rooted behavior as makeNotebookSurfaceDaemon's listFiles above.
+  const notebookBrowserListFiles = useCallback(
+    () => sendFsIndex().then(fsIndexToNotebookEntries),
+    [sendFsIndex],
+  );
 
   return (
     <DaemonProvider sendPRAction={sendPRAction} sendMutePR={sendMutePR} sendMuteRepo={sendMuteRepo} sendMuteAuthor={sendMuteAuthor} sendPRVisited={sendPRVisited}>
@@ -3585,6 +3633,7 @@ sendFetchPRDetails,
                   <SessionTerminalWorkspace
                     ref={setWorkspaceRef(workspace.id)}
                     workspaceId={workspace.id}
+                    workspaceDirectory={workspace.directory}
                     workspaceSessions={workspace.sessions.map((entry) => ({
                       id: entry.id,
                       label: entry.label,
@@ -3847,7 +3896,7 @@ sendFetchPRDetails,
         readAsset={sendFsReadAsset}
         backlinksNotebook={sendNotebookBacklinks}
         sendToChief={sendNotebookToChief}
-        listFiles={sendNotebookList}
+        listFiles={notebookBrowserListFiles}
         changeSignal={notebookRootChangeSignal}
         chiefActive={notebookChiefActive}
       />

--- a/app/src/components/SessionTerminalWorkspace.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace.test.tsx
@@ -1,9 +1,33 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { forwardRef, useEffect, useImperativeHandle } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, type ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SessionTerminalWorkspace } from './SessionTerminalWorkspace';
 import type { PaneRuntimeEventRouter } from './SessionTerminalWorkspace/paneRuntimeEventRouter';
 import { type TerminalWorkspaceState } from '../types/workspace';
+import { NotebookSurfaceProvider, type NotebookSurfaceContextValue } from '../contexts/NotebookSurfaceContext';
+
+// A docked tile (markdown, below) reads effectiveNotebookRoot unconditionally
+// via useNotebookSurfaceContext — real usage is always under App's provider.
+const testSurfaceValue: NotebookSurfaceContextValue = {
+  makeDaemon: () => ({
+    listDir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    existsFile: vi.fn(),
+    readAsset: vi.fn(),
+    backlinksNotebook: vi.fn(),
+    sendToChief: vi.fn(),
+    listFiles: vi.fn(),
+    changeSignal: 0,
+  }),
+  effectiveNotebookRoot: '',
+  sendFsWatch: vi.fn(),
+  sendFsUnwatch: vi.fn(),
+  connectionGeneration: 0,
+};
+function NotebookSurfaceTestWrapper({ children }: { children: ReactNode }) {
+  return <NotebookSurfaceProvider value={testSurfaceValue}>{children}</NotebookSurfaceProvider>;
+}
 const SESSION_PANE_ID = 'pane-session';
 function createSingleAgentWorkspace(): TerminalWorkspaceState {
   return {
@@ -695,7 +719,8 @@ describe('SessionTerminalWorkspace', () => {
         onClosePane={vi.fn()}
         onFocusPane={vi.fn()}
         onNavigateOutOfSession={vi.fn()}
-      />
+      />,
+      { wrapper: NotebookSurfaceTestWrapper },
     );
     const panes = container.querySelector('.session-terminal-panes') as HTMLElement;
     vi.spyOn(panes, 'getBoundingClientRect').mockReturnValue({
@@ -783,7 +808,8 @@ describe('SessionTerminalWorkspace', () => {
         onFocusPane={vi.fn()}
         onMoveLeaf={onMoveLeaf}
         onNavigateOutOfSession={vi.fn()}
-      />
+      />,
+      { wrapper: NotebookSurfaceTestWrapper },
     );
     const panes = container.querySelector('.session-terminal-panes') as HTMLElement;
     vi.spyOn(panes, 'getBoundingClientRect').mockReturnValue({

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.closeFocusedLeaf.test.tsx
@@ -1,8 +1,33 @@
+import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render } from '@testing-library/react';
 import { SessionTerminalWorkspace } from './index';
 import { createPaneRuntimeEventRouterController } from './paneRuntimeEventRouter';
 import { tileContentKey, type TerminalWorkspaceState } from '../../types/workspace';
+import { NotebookSurfaceProvider, type NotebookSurfaceContextValue } from '../../contexts/NotebookSurfaceContext';
+
+// The docked markdown tile below reads effectiveNotebookRoot unconditionally
+// via useNotebookSurfaceContext — real usage is always under App's provider.
+const testSurfaceValue: NotebookSurfaceContextValue = {
+  makeDaemon: () => ({
+    listDir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    existsFile: vi.fn(),
+    readAsset: vi.fn(),
+    backlinksNotebook: vi.fn(),
+    sendToChief: vi.fn(),
+    listFiles: vi.fn(),
+    changeSignal: 0,
+  }),
+  effectiveNotebookRoot: '',
+  sendFsWatch: vi.fn(),
+  sendFsUnwatch: vi.fn(),
+  connectionGeneration: 0,
+};
+function NotebookSurfaceTestWrapper({ children }: { children: ReactNode }) {
+  return <NotebookSurfaceProvider value={testSurfaceValue}>{children}</NotebookSurfaceProvider>;
+}
 
 // The terminal surface pulls in the Ghostty WASM model; stub it so the import
 // graph stays light in jsdom (this spec only cares about Cmd+W routing).
@@ -60,6 +85,7 @@ function renderSplit(overrides: { onClosePane?: () => void; onUndockTile?: (tile
       }}
       onRequestTileContent={vi.fn()}
     />,
+    { wrapper: NotebookSurfaceTestWrapper },
   );
   return { ...utils, onClosePane, onUndockTile };
 }

--- a/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.tileOnly.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/SessionTerminalWorkspace.tileOnly.test.tsx
@@ -1,8 +1,33 @@
+import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { SessionTerminalWorkspace } from './index';
 import { createPaneRuntimeEventRouterController } from './paneRuntimeEventRouter';
 import { tileContentKey, type TerminalWorkspaceState } from '../../types/workspace';
+import { NotebookSurfaceProvider, type NotebookSurfaceContextValue } from '../../contexts/NotebookSurfaceContext';
+
+// The docked markdown tile below reads effectiveNotebookRoot unconditionally
+// via useNotebookSurfaceContext — real usage is always under App's provider.
+const testSurfaceValue: NotebookSurfaceContextValue = {
+  makeDaemon: () => ({
+    listDir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    existsFile: vi.fn(),
+    readAsset: vi.fn(),
+    backlinksNotebook: vi.fn(),
+    sendToChief: vi.fn(),
+    listFiles: vi.fn(),
+    changeSignal: 0,
+  }),
+  effectiveNotebookRoot: '',
+  sendFsWatch: vi.fn(),
+  sendFsUnwatch: vi.fn(),
+  connectionGeneration: 0,
+};
+function NotebookSurfaceTestWrapper({ children }: { children: ReactNode }) {
+  return <NotebookSurfaceProvider value={testSurfaceValue}>{children}</NotebookSurfaceProvider>;
+}
 
 const browserTileProps = vi.hoisted(() => ({
   current: null as null | { visible: boolean },
@@ -60,6 +85,7 @@ function renderTileOnly() {
       }}
       onRequestTileContent={vi.fn()}
     />,
+    { wrapper: NotebookSurfaceTestWrapper },
   );
 }
 
@@ -125,6 +151,7 @@ describe('SessionTerminalWorkspace tile-only (sessionless) rendering', () => {
     };
     const { rerender } = render(
       <SessionTerminalWorkspace {...commonProps} enabled />,
+      { wrapper: NotebookSurfaceTestWrapper },
     );
 
     expect(browserTileProps.current?.visible).toBe(true);

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.css
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.css
@@ -112,6 +112,25 @@
   border-color: var(--color-border-focus);
 }
 
+.workspace-dock-tile-root-picker {
+  height: 24px;
+  max-width: 140px;
+  padding: 2px 4px;
+  border: 1px solid var(--color-border);
+  border-radius: 5px;
+  background: var(--color-bg-editor);
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  outline: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.workspace-dock-tile-root-picker:focus {
+  border-color: var(--color-border-focus);
+}
+
 .workspace-dock-tile-send-button {
   height: 24px;
   padding: 2px 10px;

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
@@ -1,16 +1,54 @@
+import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { invoke, isTauri } from '@tauri-apps/api/core';
+import { open } from '@tauri-apps/plugin-dialog';
 import { normalizeBrowserAddress, WorkspaceDockTile, resolveMarkdownTarget } from './WorkspaceDockTile';
 import type { WorkspaceTileSessionOption } from './WorkspaceDockTile';
 import { deriveTileTitle } from '../../utils/tilePresentation';
-import type { TileLeaf } from '../../types/workspace';
+import { serializeNotebookTileParams, type TileLeaf } from '../../types/workspace';
+import { NotebookSurfaceProvider, type NotebookSurfaceContextValue } from '../../contexts/NotebookSurfaceContext';
 import { setMarkdownAnnotationsTransport } from '../MarkdownReader/annotations/transport';
 import type {
   MarkdownAnnotationsSubmitResult,
   MarkdownAnnotationsTransport,
 } from '../MarkdownReader/annotations/transport';
 import type { WireAnnotation } from '../MarkdownReader/annotations/types';
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
+
+// The root picker's body (NotebookTile → NotebookSurface, CodeMirror-backed)
+// is exercised elsewhere (NotebookTile.test.tsx, NotebookBrowser.test.tsx);
+// stub it here so these tests exercise only the header switcher.
+vi.mock('../NotebookSurface', () => ({
+  NotebookSurface: () => <div data-testid="notebook-surface" />,
+}));
+
+// WorkspaceDockTile reads effectiveNotebookRoot for its (notebook-only) root
+// switcher unconditionally via useNotebookSurfaceContext — the real app always
+// renders it under NotebookSurfaceProvider, so every render here needs the same
+// wrapper even for the markdown/browser tiles this file mostly exercises.
+const testSurfaceValue: NotebookSurfaceContextValue = {
+  makeDaemon: () => ({
+    listDir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    existsFile: vi.fn(),
+    readAsset: vi.fn(),
+    backlinksNotebook: vi.fn(),
+    sendToChief: vi.fn(),
+    listFiles: vi.fn(),
+    changeSignal: 0,
+  }),
+  effectiveNotebookRoot: '/notebook-root',
+  sendFsWatch: vi.fn().mockResolvedValue({ root: '' }),
+  sendFsUnwatch: vi.fn().mockResolvedValue({ root: '' }),
+  connectionGeneration: 0,
+};
+
+function NotebookSurfaceTestWrapper({ children }: { children: ReactNode }) {
+  return <NotebookSurfaceProvider value={testSurfaceValue}>{children}</NotebookSurfaceProvider>;
+}
 
 const opener = vi.hoisted(() => ({
   openUrl: vi.fn(async () => {}),
@@ -46,6 +84,7 @@ function renderMarkdown(content: string, allowLocalTargets = true) {
       onHeaderPointerDown={vi.fn()}
       onRequestContent={vi.fn()}
     />,
+    { wrapper: NotebookSurfaceTestWrapper },
   );
 }
 
@@ -229,6 +268,7 @@ describe('WorkspaceDockTile browser integration', () => {
         onHeaderPointerDown={vi.fn()}
         onRequestContent={vi.fn()}
       />,
+      { wrapper: NotebookSurfaceTestWrapper },
     );
 
     await screen.findByText('Error: In-app browser hosting requires the Tauri app');
@@ -256,6 +296,7 @@ describe('WorkspaceDockTile browser integration', () => {
         onHeaderPointerDown={vi.fn()}
         onRequestContent={vi.fn()}
       />,
+      { wrapper: NotebookSurfaceTestWrapper },
     );
 
     await screen.findByText('Error: In-app browser hosting requires the Tauri app');
@@ -286,6 +327,7 @@ describe('WorkspaceDockTile browser integration', () => {
         onHeaderPointerDown={vi.fn()}
         onRequestContent={vi.fn()}
       />,
+      { wrapper: NotebookSurfaceTestWrapper },
     );
 
     fireEvent.pointerDown(screen.getByRole('textbox', { name: 'Browser address' }));
@@ -312,6 +354,7 @@ describe('WorkspaceDockTile browser integration', () => {
         onHeaderPointerDown={vi.fn()}
         onRequestContent={vi.fn()}
       />,
+      { wrapper: NotebookSurfaceTestWrapper },
     );
     const address = screen.getByRole('textbox', { name: 'Browser address' });
 
@@ -359,6 +402,113 @@ describe('WorkspaceDockTile browser integration', () => {
     expect(normalizeBrowserAddress('example.com:8080')).toBe('https://example.com:8080');
     expect(normalizeBrowserAddress('http://example.com:8080')).toBe('http://example.com:8080');
     expect(normalizeBrowserAddress('ftp://example.com')).toBe('ftp://example.com');
+  });
+});
+
+describe('WorkspaceDockTile notebook root switcher', () => {
+  beforeEach(() => {
+    vi.mocked(open).mockReset();
+  });
+
+  function renderNotebookTile(opts: {
+    tileParams?: string;
+    workspaceDirectory?: string;
+    onUpdateParams?: (tileParams: string) => Promise<unknown> | void;
+  } = {}) {
+    const onUpdateParams = opts.onUpdateParams ?? vi.fn(async () => {});
+    const utils = render(
+      <WorkspaceDockTile
+        tile={{ type: 'tile', tileId: 'tile-notebook', tileKind: 'notebook', tileParams: opts.tileParams }}
+        workspaceId="workspace-1"
+        workspaceDirectory={opts.workspaceDirectory}
+        dragging={false}
+        onClose={vi.fn()}
+        onUpdateParams={onUpdateParams}
+        onHeaderPointerDown={vi.fn()}
+        onRequestContent={vi.fn()}
+      />,
+      { wrapper: NotebookSurfaceTestWrapper },
+    );
+    return { ...utils, onUpdateParams };
+  }
+
+  function picker() {
+    return screen.getByRole('combobox', { name: 'Editor root' });
+  }
+
+  it('offers Notebook and Workspace options for a rootless tile with a distinct workspace directory', () => {
+    renderNotebookTile({ workspaceDirectory: '/Users/victor/code/attn' });
+
+    const options = Array.from(picker().querySelectorAll('option')).map((option) => option.textContent);
+    expect(options).toEqual(['Notebook', 'Workspace — attn', 'Browse…']);
+    expect(picker()).toHaveValue('');
+  });
+
+  it('adds the current root as its own option when it matches neither the notebook root nor the workspace directory', async () => {
+    renderNotebookTile({
+      tileParams: serializeNotebookTileParams({ root: '/tmp/some-other-root' }),
+      workspaceDirectory: '/Users/victor/code/attn',
+    });
+    // A root-bound tile's NotebookTile body opens its own fs_watch subscription
+    // (see NotebookTile.tsx); let that settle so the assertion isn't racing an
+    // unwrapped state update.
+    await act(async () => { await Promise.resolve(); });
+
+    const options = Array.from(picker().querySelectorAll('option')).map((option) => option.textContent);
+    expect(options).toEqual(['Notebook', 'Workspace — attn', 'some-other-root', 'Browse…']);
+    expect(picker()).toHaveValue('/tmp/some-other-root');
+  });
+
+  it('omits the Workspace option when no workspace directory is set', () => {
+    renderNotebookTile({});
+
+    const options = Array.from(picker().querySelectorAll('option')).map((option) => option.textContent);
+    expect(options).toEqual(['Notebook', 'Browse…']);
+  });
+
+  it('selecting Notebook writes rootless params without the open path', async () => {
+    const { onUpdateParams } = renderNotebookTile({
+      tileParams: serializeNotebookTileParams({ root: '/tmp/some-other-root', path: 'notes.md' }),
+      workspaceDirectory: '/Users/victor/code/attn',
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    fireEvent.change(picker(), { target: { value: '' } });
+
+    expect(onUpdateParams).toHaveBeenCalledWith(serializeNotebookTileParams({ root: undefined }));
+  });
+
+  it('selecting the workspace directory writes it as the root without the open path', () => {
+    const { onUpdateParams } = renderNotebookTile({
+      tileParams: serializeNotebookTileParams({ root: undefined, path: 'notes.md' }),
+      workspaceDirectory: '/Users/victor/code/attn',
+    });
+
+    fireEvent.change(picker(), { target: { value: '/Users/victor/code/attn' } });
+
+    expect(onUpdateParams).toHaveBeenCalledWith(serializeNotebookTileParams({ root: '/Users/victor/code/attn' }));
+  });
+
+  it('Browse… persists the chosen directory as the root', async () => {
+    vi.mocked(open).mockResolvedValue('/tmp/chosen-root');
+    const { onUpdateParams } = renderNotebookTile({ workspaceDirectory: '/Users/victor/code/attn' });
+
+    fireEvent.change(picker(), { target: { value: '__browse__' } });
+
+    await waitFor(() => {
+      expect(onUpdateParams).toHaveBeenCalledWith(serializeNotebookTileParams({ root: '/tmp/chosen-root' }));
+    });
+    expect(open).toHaveBeenCalledWith({ directory: true, multiple: false, title: 'Choose editor root' });
+  });
+
+  it('Browse… cancelled leaves the tile params untouched', async () => {
+    vi.mocked(open).mockResolvedValue(null);
+    const { onUpdateParams } = renderNotebookTile({ workspaceDirectory: '/Users/victor/code/attn' });
+
+    fireEvent.change(picker(), { target: { value: '__browse__' } });
+
+    await waitFor(() => expect(open).toHaveBeenCalled());
+    expect(onUpdateParams).not.toHaveBeenCalled();
   });
 });
 
@@ -423,7 +573,10 @@ function renderSendTile({
     onHeaderPointerDown: vi.fn(),
     onRequestContent: vi.fn(),
   };
-  const view = render(<WorkspaceDockTile tile={sendTile(tileSessionId)} {...props} />);
+  const view = render(
+    <WorkspaceDockTile tile={sendTile(tileSessionId)} {...props} />,
+    { wrapper: NotebookSurfaceTestWrapper },
+  );
   return {
     ...view,
     onRetargetTile,

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
@@ -1,19 +1,22 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type {
+  ChangeEvent,
   FocusEvent as ReactFocusEvent,
   FormEvent,
   PointerEvent as ReactPointerEvent,
   Ref,
   RefObject,
 } from 'react';
+import { open } from '@tauri-apps/plugin-dialog';
 import { browserHostLabel, claimBrowserHostFocus, controlBrowserHost } from '../../browser/host';
 import { parseNotebookTileParams, serializeNotebookTileParams, type TileContentState, type TileLeaf } from '../../types/workspace';
-import { deriveTileTitle } from '../../utils/tilePresentation';
+import { deriveTileTitle, tilePathBasename } from '../../utils/tilePresentation';
 import { BrowserTileBody } from './BrowserTileBody';
 import { MarkdownReader } from '../MarkdownReader';
 import type { MarkdownAnnotationsSendHandle } from '../MarkdownReader';
 import { getMarkdownAnnotationsTransport } from '../MarkdownReader/annotations/transport';
 import { useShortcut } from '../../shortcuts';
+import { useNotebookSurfaceContext } from '../../contexts/NotebookSurfaceContext';
 import { NotebookTile } from '../notebook/NotebookTile';
 import './WorkspaceDockTile.css';
 
@@ -54,6 +57,10 @@ interface WorkspaceDockTileProps {
   visible?: boolean;
   // The workspace's agent sessions — the markdown tile's retarget options.
   workspaceSessions?: WorkspaceTileSessionOption[];
+  // The owning workspace's directory (Workspace.directory), for the notebook
+  // tile's root switcher's "Workspace — <dir>" option. Absent for tile-only
+  // workspaces with no directory.
+  workspaceDirectory?: string;
   onClose: () => void;
   onUpdateParams?: (tileParams: string) => Promise<unknown> | void;
   // Rebind the tile's session binding (markdown Send target). Persisted by the
@@ -92,6 +99,7 @@ export function WorkspaceDockTile({
   dragging,
   visible = true,
   workspaceSessions = [],
+  workspaceDirectory,
   onClose,
   onUpdateParams,
   onRetargetTile,
@@ -299,6 +307,45 @@ export function WorkspaceDockTile({
     };
   }, [browserLabel, onUpdateParams, tile.tileKind, tile.tileParams]);
 
+  // Root switcher (notebook tiles only). Lives in the tile chrome rather than
+  // NotebookSurface because the dock tile already owns tileParams writes (see
+  // the notebook body's onOpenFile below) — the switcher just writes a
+  // different field of the same params.
+  const { effectiveNotebookRoot } = useNotebookSurfaceContext();
+  const isNotebook = tile.tileKind === 'notebook';
+  const currentRoot = isNotebook ? parseNotebookTileParams(tile.tileParams).root : undefined;
+  const ROOT_BROWSE_VALUE = '__browse__';
+  const workspaceDirIsRoot = !!workspaceDirectory && workspaceDirectory !== effectiveNotebookRoot;
+  // The current root shows as its own option only when it's neither of the two
+  // named shortcuts already covering it — otherwise it'd duplicate "Notebook"
+  // or "Workspace — <dir>".
+  const currentRootIsOther = !!currentRoot
+    && currentRoot !== effectiveNotebookRoot
+    && currentRoot !== workspaceDirectory;
+
+  const handleRootChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    if (value === ROOT_BROWSE_VALUE) {
+      void open({ directory: true, multiple: false, title: 'Choose editor root' }).then((selected) => {
+        if (!selected || typeof selected !== 'string') {
+          return; // cancelled — the select is controlled by parsed params, snaps back on re-render
+        }
+        void Promise.resolve(onUpdateParams?.(serializeNotebookTileParams({ root: selected }))).catch((error) => {
+          console.warn('[WorkspaceDockTile] Failed to persist browsed notebook root:', error);
+        });
+      }).catch((error) => {
+        console.warn('[WorkspaceDockTile] Failed to open root browse dialog:', error);
+      });
+      return;
+    }
+    // A chosen dir (or any non-browse option): path is deliberately omitted —
+    // the open file is meaningless under a different root, so the tile drops
+    // back to its tree view.
+    void Promise.resolve(onUpdateParams?.(serializeNotebookTileParams({ root: value || undefined }))).catch((error) => {
+      console.warn('[WorkspaceDockTile] Failed to persist notebook root:', error);
+    });
+  }, [onUpdateParams]);
+
   const reloadBrowser = () => {
     void controlBrowserHost(workspaceId, tile.tileId, 'reload').catch((error) => {
       console.warn('[WorkspaceDockTile] Failed to reload browser:', error);
@@ -354,6 +401,26 @@ export function WorkspaceDockTile({
         ) : (
           <span className="workspace-dock-tile-title">{title}</span>
         )}
+        {isNotebook ? (
+          <select
+            className="workspace-dock-tile-root-picker"
+            aria-label="Editor root"
+            value={currentRoot ?? ''}
+            // The header is the drag handle; interacting with the picker must
+            // not start a re-dock drag (mirrors the session-picker below).
+            onPointerDown={(event) => event.stopPropagation()}
+            onChange={handleRootChange}
+          >
+            <option value="">Notebook</option>
+            {workspaceDirIsRoot && (
+              <option value={workspaceDirectory}>Workspace — {tilePathBasename(workspaceDirectory as string)}</option>
+            )}
+            {currentRootIsOther && (
+              <option value={currentRoot}>{tilePathBasename(currentRoot as string)}</option>
+            )}
+            <option value={ROOT_BROWSE_VALUE}>Browse…</option>
+          </select>
+        ) : null}
         {isMarkdown ? (
           <div
             className="workspace-dock-tile-send"

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -104,6 +104,9 @@ export interface SessionTerminalWorkspaceHandle {
 
 interface SessionTerminalWorkspaceProps {
   workspaceId: string;
+  // The owning workspace's directory (Workspace.directory). Threaded down to
+  // WorkspaceDockTile's notebook root switcher's "Workspace — <dir>" option.
+  workspaceDirectory?: string;
   workspaceSessions?: Array<{
     id: string;
     label: string;
@@ -185,6 +188,7 @@ interface SessionTerminalWorkspaceProps {
 export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandle, SessionTerminalWorkspaceProps>(
   function SessionTerminalWorkspace({
     workspaceId,
+    workspaceDirectory,
     workspaceSessions = [],
     ticketActions,
     workspace,
@@ -985,6 +989,7 @@ export const SessionTerminalWorkspace = forwardRef<SessionTerminalWorkspaceHandl
                 && effectiveDraggingLeafId === null
               }
               workspaceSessions={tileSessionOptions}
+              workspaceDirectory={workspaceDirectory}
               onClose={() => onUndockTile?.(tileLeaf.tileId)}
               onUpdateParams={(tileParams) => onUpdateTile?.(tileLeaf.tileId, tileParams)}
               onRetargetTile={(sessionId) => (

--- a/app/src/contexts/NotebookSurfaceContext.tsx
+++ b/app/src/contexts/NotebookSurfaceContext.tsx
@@ -22,8 +22,10 @@ export interface NotebookSurfaceDaemon {
   readAsset: (path: string) => Promise<FsReadAssetResult>;
   backlinksNotebook: (path: string) => Promise<NotebookEntry[]>;
   sendToChief: (selection: string, sourcePath?: string) => Promise<NotebookSendToChiefResult>;
-  // Walk the whole vault (flat list of notes, with titles) for a tile's fuzzy finder.
-  // Notebook-storage only (see the boundary note below) — unaffected by `root`.
+  // Flat file list for a tile's ⌘P finder, root-scoped: fs_index over this
+  // daemon's `root` (or the notebook root when `root` is undefined). See the
+  // boundary note below — unlike backlinksNotebook/sendToChief, this one DOES
+  // follow `root`.
   listFiles: () => Promise<NotebookEntry[]>;
   // Bumps when an fs_changed broadcast arrives for this daemon's root, so an
   // open tile reloads its file. Scoped per-root: a root-bound tile only sees
@@ -36,13 +38,16 @@ export interface NotebookSurfaceDaemon {
 // call carries `root` down to the daemon; `changeSignal` is likewise sliced to
 // events for that root.
 //
-// CRITICAL BOUNDARY: backlinksNotebook, sendToChief, and listFiles are
-// Notebook-storage commands on the daemon side (notebook_backlinks,
-// notebook_send_to_chief, notebook_list) — they are bound to the notebook
-// root exactly as before regardless of the `root` argument here. Passing an
-// arbitrary filesystem root into those notebook_* commands is out of scope
-// and forbidden; UI for them on a non-notebook-rooted tile is gated off
-// separately (see the arbitrary-roots plan's authorization-boundary note).
+// CRITICAL BOUNDARY: backlinksNotebook and sendToChief are Notebook-storage
+// commands on the daemon side (notebook_backlinks, notebook_send_to_chief) —
+// they stay bound to the notebook root exactly as before regardless of the
+// `root` argument here. Backlinks only exist between notebook notes and "send
+// to chief" appends to the notebook inbox, so widening either to an arbitrary
+// filesystem root is out of scope and forbidden; UI for them on a
+// non-notebook-rooted tile is gated off separately (see the arbitrary-roots
+// plan's authorization-boundary note). listFiles is DIFFERENT: it now sources
+// fs_index, which the daemon resolves through the same root-scoped chokepoint
+// as every other fs_* command, so it follows `root` like listDir/readFile/etc.
 export type MakeNotebookSurfaceDaemon = (root?: string) => NotebookSurfaceDaemon;
 
 export interface NotebookSurfaceContextValue {

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -3275,7 +3275,7 @@ export function useDaemonSocket({
     workspaceId: string,
     tileId: string,
     tileKind: string,
-    options: { anchorPaneId?: string; edge?: TerminalDockEdge; ratio?: number } = {},
+    options: { anchorPaneId?: string; edge?: TerminalDockEdge; ratio?: number; tileParams?: string } = {},
   ) => {
     return sendWorkspaceCommand(
       'workspace_layout_dock_tile',
@@ -3288,6 +3288,7 @@ export function useDaemonSocket({
         tile_kind: tileKind,
         edge: options.edge ?? 'right',
         ...(options.ratio != null ? { ratio: options.ratio } : {}),
+        ...(options.tileParams != null ? { tile_params: options.tileParams } : {}),
       },
       tileId,
     );

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '169';
+export const PROTOCOL_VERSION = '170';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -4747,6 +4747,7 @@ export interface WorkspaceLayoutDockTileMessage {
     ratio?:         number;
     tile_id:        string;
     tile_kind:      string;
+    tile_params?:   string;
     workspace_id:   string;
     [property: string]: any;
 }
@@ -10538,6 +10539,7 @@ const typeMap: any = {
         { json: "ratio", js: "ratio", typ: u(undefined, 3.14) },
         { json: "tile_id", js: "tile_id", typ: "" },
         { json: "tile_kind", js: "tile_kind", typ: "" },
+        { json: "tile_params", js: "tile_params", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "WorkspaceLayoutFocusPaneMessage": o([

--- a/app/src/types/workspace.test.ts
+++ b/app/src/types/workspace.test.ts
@@ -9,6 +9,7 @@ import {
   getSplitDividers,
   hasPane,
   parseNotebookTileParams,
+  resolveEditorTileRoot,
   serializeNotebookTileParams,
   workspaceSnapshotFromDaemonWorkspace,
   type TerminalLayoutNode,
@@ -308,5 +309,22 @@ describe('notebook tile params (parse/serialize)', () => {
   it('ignores unknown fields in the JSON envelope', () => {
     const raw = JSON.stringify({ root: '/repo', path: 'a.md', bogus: 'nope' });
     expect(parseNotebookTileParams(raw)).toEqual({ root: '/repo', path: 'a.md' });
+  });
+});
+
+describe('resolveEditorTileRoot', () => {
+  it('returns undefined when the workspace has no directory', () => {
+    expect(resolveEditorTileRoot(undefined, '/Users/victor/notebook')).toBeUndefined();
+    expect(resolveEditorTileRoot('', '/Users/victor/notebook')).toBeUndefined();
+    expect(resolveEditorTileRoot('   ', '/Users/victor/notebook')).toBeUndefined();
+  });
+
+  it('returns undefined when the workspace directory is the notebook root', () => {
+    expect(resolveEditorTileRoot('/Users/victor/notebook', '/Users/victor/notebook')).toBeUndefined();
+  });
+
+  it('returns the trimmed workspace directory when it differs from the notebook root', () => {
+    expect(resolveEditorTileRoot('/Users/victor/code/attn', '/Users/victor/notebook')).toBe('/Users/victor/code/attn');
+    expect(resolveEditorTileRoot('  /Users/victor/code/attn  ', '/Users/victor/notebook')).toBe('/Users/victor/code/attn');
   });
 });

--- a/app/src/types/workspace.test.ts
+++ b/app/src/types/workspace.test.ts
@@ -331,22 +331,38 @@ describe('resolveEditorTileRoot', () => {
 });
 
 describe('localWorkspaceDirectory', () => {
-  it('returns undefined when a session on the workspace carries a non-empty endpoint_id', () => {
+  it('returns undefined for a sessionless workspace (absence of evidence is not evidence of locality)', () => {
+    expect(localWorkspaceDirectory('/Users/victor/code/attn', [], 'ws-1')).toBeUndefined();
+  });
+
+  it('returns undefined when the workspace has only a session with a non-empty endpoint_id', () => {
     const sessions = [{ workspace_id: 'ws-1', endpoint_id: 'remote-mac' }];
     expect(localWorkspaceDirectory('/home/victor/code/attn', sessions, 'ws-1')).toBeUndefined();
   });
 
-  it('passes the directory through when the remote session belongs to a different workspace', () => {
-    const sessions = [{ workspace_id: 'ws-2', endpoint_id: 'remote-mac' }];
+  it('returns undefined when the workspace has both a local and a remote session (duplicate-id corner)', () => {
+    const sessions = [
+      { workspace_id: 'ws-1', endpoint_id: '' },
+      { workspace_id: 'ws-1', endpoint_id: 'remote-mac' },
+    ];
+    expect(localWorkspaceDirectory('/Users/victor/code/attn', sessions, 'ws-1')).toBeUndefined();
+  });
+
+  it('returns the directory when a session on the workspace has an empty-string endpoint_id', () => {
+    const sessions = [{ workspace_id: 'ws-1', endpoint_id: '' }];
     expect(localWorkspaceDirectory('/Users/victor/code/attn', sessions, 'ws-1')).toBe('/Users/victor/code/attn');
   });
 
-  it('passes the directory through when there are no sessions', () => {
-    expect(localWorkspaceDirectory('/Users/victor/code/attn', [], 'ws-1')).toBe('/Users/victor/code/attn');
+  it('returns the directory when a session on the workspace has an absent endpoint_id', () => {
+    const sessions = [{ workspace_id: 'ws-1' }];
+    expect(localWorkspaceDirectory('/Users/victor/code/attn', sessions, 'ws-1')).toBe('/Users/victor/code/attn');
   });
 
-  it('treats an empty-string endpoint_id as local', () => {
-    const sessions = [{ workspace_id: 'ws-1', endpoint_id: '' }];
+  it('returns the directory when the only remote session belongs to a different workspace', () => {
+    const sessions = [
+      { workspace_id: 'ws-1' },
+      { workspace_id: 'ws-2', endpoint_id: 'remote-mac' },
+    ];
     expect(localWorkspaceDirectory('/Users/victor/code/attn', sessions, 'ws-1')).toBe('/Users/victor/code/attn');
   });
 });

--- a/app/src/types/workspace.test.ts
+++ b/app/src/types/workspace.test.ts
@@ -8,6 +8,7 @@ import {
   getNormalizedPaneBounds,
   getSplitDividers,
   hasPane,
+  localWorkspaceDirectory,
   parseNotebookTileParams,
   resolveEditorTileRoot,
   serializeNotebookTileParams,
@@ -326,5 +327,26 @@ describe('resolveEditorTileRoot', () => {
   it('returns the trimmed workspace directory when it differs from the notebook root', () => {
     expect(resolveEditorTileRoot('/Users/victor/code/attn', '/Users/victor/notebook')).toBe('/Users/victor/code/attn');
     expect(resolveEditorTileRoot('  /Users/victor/code/attn  ', '/Users/victor/notebook')).toBe('/Users/victor/code/attn');
+  });
+});
+
+describe('localWorkspaceDirectory', () => {
+  it('returns undefined when a session on the workspace carries a non-empty endpoint_id', () => {
+    const sessions = [{ workspace_id: 'ws-1', endpoint_id: 'remote-mac' }];
+    expect(localWorkspaceDirectory('/home/victor/code/attn', sessions, 'ws-1')).toBeUndefined();
+  });
+
+  it('passes the directory through when the remote session belongs to a different workspace', () => {
+    const sessions = [{ workspace_id: 'ws-2', endpoint_id: 'remote-mac' }];
+    expect(localWorkspaceDirectory('/Users/victor/code/attn', sessions, 'ws-1')).toBe('/Users/victor/code/attn');
+  });
+
+  it('passes the directory through when there are no sessions', () => {
+    expect(localWorkspaceDirectory('/Users/victor/code/attn', [], 'ws-1')).toBe('/Users/victor/code/attn');
+  });
+
+  it('treats an empty-string endpoint_id as local', () => {
+    const sessions = [{ workspace_id: 'ws-1', endpoint_id: '' }];
+    expect(localWorkspaceDirectory('/Users/victor/code/attn', sessions, 'ws-1')).toBe('/Users/victor/code/attn');
   });
 });

--- a/app/src/types/workspace.ts
+++ b/app/src/types/workspace.ts
@@ -498,19 +498,37 @@ export function resolveEditorTileRoot(
 }
 
 // localWorkspaceDirectory gates a workspace's directory to the local
-// filesystem: it returns undefined when any daemon session on this workspace
-// carries a non-empty endpoint_id, meaning the workspace lives on a remote
-// endpoint and its "directory" is a path on that remote machine, not one the
-// locally-connected daemon's fs pipeline (sendFsIndex, sendFsList, etc. — none
-// of which are endpoint-aware) can safely read. Otherwise it passes the
-// directory through unchanged.
+// filesystem, defaulting to locked (undefined) until locality is positively
+// proven — not the other way around. None of the sendFs* calls (sendFsIndex,
+// sendFsList, etc.) are endpoint-aware; they always execute against the
+// locally-connected daemon, so handing a remote directory to them can read or
+// write the wrong machine's files.
+//
+// A workspace's own record carries no endpoint marker: listWorkspaces appends
+// hubManager.RemoteWorkspaces() to the local workspace list independently of
+// sessions, and protocol.Workspace has no endpoint_id field at all. So the
+// only signal available here is the workspace's live sessions, and absence of
+// a session is absence of evidence, not evidence of locality — a retained
+// sessionless workspace (attn keeps pinned/tile-only workspaces after their
+// last session ends) must stay locked rather than default to passing its
+// directory through.
+//
+// Returns directory only when a session on this workspace positively proves
+// locality (an empty/absent endpoint_id) AND no session on this workspace
+// proves it remote. The second condition also covers the duplicate-id corner:
+// raw workspace ids can repeat across endpoints (disambiguated only by their
+// sessions), so if a remote twin's session shares this workspace_id, we can't
+// tell whose directory the caller's bare-id lookup actually grabbed — stay
+// locked rather than guess.
 export function localWorkspaceDirectory(
   directory: string | undefined,
   sessions: ReadonlyArray<{ workspace_id?: string | null; endpoint_id?: string | null }>,
   workspaceId: string,
 ): string | undefined {
-  const isRemote = sessions.some((session) => session.workspace_id === workspaceId && !!session.endpoint_id);
-  return isRemote ? undefined : directory;
+  const workspaceSessions = sessions.filter((session) => session.workspace_id === workspaceId);
+  const provenLocal = workspaceSessions.some((session) => !session.endpoint_id);
+  const provenRemote = workspaceSessions.some((session) => !!session.endpoint_id);
+  return provenLocal && !provenRemote ? directory : undefined;
 }
 
 function agentTerminalsFromPanes(panes: PaneElement[]): AgentTerminal[] {

--- a/app/src/types/workspace.ts
+++ b/app/src/types/workspace.ts
@@ -497,6 +497,22 @@ export function resolveEditorTileRoot(
   return trimmed;
 }
 
+// localWorkspaceDirectory gates a workspace's directory to the local
+// filesystem: it returns undefined when any daemon session on this workspace
+// carries a non-empty endpoint_id, meaning the workspace lives on a remote
+// endpoint and its "directory" is a path on that remote machine, not one the
+// locally-connected daemon's fs pipeline (sendFsIndex, sendFsList, etc. — none
+// of which are endpoint-aware) can safely read. Otherwise it passes the
+// directory through unchanged.
+export function localWorkspaceDirectory(
+  directory: string | undefined,
+  sessions: ReadonlyArray<{ workspace_id?: string | null; endpoint_id?: string | null }>,
+  workspaceId: string,
+): string | undefined {
+  const isRemote = sessions.some((session) => session.workspace_id === workspaceId && !!session.endpoint_id);
+  return isRemote ? undefined : directory;
+}
+
 function agentTerminalsFromPanes(panes: PaneElement[]): AgentTerminal[] {
   return panes
     .filter((pane) => pane.kind === 'agent' && typeof pane.runtime_id === 'string' && typeof pane.session_id === 'string')

--- a/app/src/types/workspace.ts
+++ b/app/src/types/workspace.ts
@@ -479,6 +479,24 @@ export function serializeNotebookTileParams(params: NotebookTileParams): string 
   return params.path || '';
 }
 
+// resolveEditorTileRoot picks the root a freshly-docked ⌘⌥N editor tile should
+// open at: the active workspace's directory, so the tile browses the tree the
+// user is actually working in rather than forcing a jump to notebook storage.
+// Returns undefined (rootless — notebook-rooted) when the directory is unset
+// or already equals the notebook root: those tiles keep the always-on
+// notebook watcher and notebook-only affordances (backlinks, etc.) instead of
+// being pinned to a redundant explicit root.
+export function resolveEditorTileRoot(
+  workspaceDirectory: string | undefined,
+  effectiveNotebookRoot: string,
+): string | undefined {
+  const trimmed = workspaceDirectory?.trim();
+  if (!trimmed || trimmed === effectiveNotebookRoot) {
+    return undefined;
+  }
+  return trimmed;
+}
+
 function agentTerminalsFromPanes(panes: PaneElement[]): AgentTerminal[] {
   return panes
     .filter((pane) => pane.kind === 'agent' && typeof pane.runtime_id === 'string' && typeof pane.session_id === 'string')

--- a/internal/daemon/workspace_session_protocol_test.go
+++ b/internal/daemon/workspace_session_protocol_test.go
@@ -814,6 +814,64 @@ func TestWorkspaceLayoutDockTilePersistsAndMoves(t *testing.T) {
 	expectWorkspaceLayoutActionResultIDs(t, client, protocol.CmdWorkspaceLayoutUndockTile, workspaceID, "", "", "tile-md", false)
 }
 
+// TestWorkspaceLayoutDockTileMessageParamsField exercises the tile_params
+// field on the dock_tile websocket message directly (as opposed to the
+// internal d.dockTile helper): a freshly docked tile takes the sent params,
+// and a later re-dock (move) with tile_params empty preserves what's already
+// persisted rather than clobbering it.
+func TestWorkspaceLayoutDockTileMessageParamsField(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	client := newWorkspaceProtocolTestClient()
+	workspaceID := "workspace-dock-tile-params-field"
+	cwd := t.TempDir()
+
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        workspaceID,
+		Title:     "Dock Tile Params Field",
+		Directory: cwd,
+	})
+	d.handleWorkspaceLayoutAddSessionPane(client, &protocol.WorkspaceLayoutAddSessionPaneMessage{
+		Cmd:         protocol.CmdWorkspaceLayoutAddSessionPane,
+		WorkspaceID: workspaceID,
+		PaneID:      protocol.Ptr("pane-1"),
+		SessionID:   "session-1",
+	})
+	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutAddSessionPane, workspaceID, "pane-1", true)
+
+	// (a) Docking a NEW tile with tile_params set persists the sent value.
+	d.handleWorkspaceLayoutDockTile(client, &protocol.WorkspaceLayoutDockTileMessage{
+		Cmd:          protocol.CmdWorkspaceLayoutDockTile,
+		WorkspaceID:  workspaceID,
+		AnchorPaneID: "pane-1",
+		Edge:         protocol.WorkspaceLayoutDockEdgeRight,
+		TileID:       "tile-notebook",
+		TileKind:     string(workspacelayout.TileKindNotebook),
+		TileParams:   protocol.Ptr("/notes/knowledge/decisions.md"),
+	})
+	expectWorkspaceLayoutActionResultIDs(t, client, protocol.CmdWorkspaceLayoutDockTile, workspaceID, "", "", "tile-notebook", true)
+	fresh := d.store.GetWorkspaceLayout(workspaceID)
+	if params, ok := workspacelayout.TileParamsByID(fresh.Layout, "tile-notebook"); !ok || params != "/notes/knowledge/decisions.md" {
+		t.Fatalf("fresh tile params = (%q, %v), want (%q, true)", params, ok, "/notes/knowledge/decisions.md")
+	}
+
+	// (b) Re-docking that same tile (a move) with tile_params empty must NOT
+	// clobber the params already persisted.
+	d.handleWorkspaceLayoutDockTile(client, &protocol.WorkspaceLayoutDockTileMessage{
+		Cmd:          protocol.CmdWorkspaceLayoutDockTile,
+		WorkspaceID:  workspaceID,
+		AnchorPaneID: "pane-1",
+		Edge:         protocol.WorkspaceLayoutDockEdgeBottom,
+		TileID:       "tile-notebook",
+		TileKind:     string(workspacelayout.TileKindNotebook),
+	})
+	expectWorkspaceLayoutActionResultIDs(t, client, protocol.CmdWorkspaceLayoutDockTile, workspaceID, "", "", "tile-notebook", true)
+	moved := d.store.GetWorkspaceLayout(workspaceID)
+	if params, ok := workspacelayout.TileParamsByID(moved.Layout, "tile-notebook"); !ok || params != "/notes/knowledge/decisions.md" {
+		t.Fatalf("moved tile params = (%q, %v), want unchanged (%q, true)", params, ok, "/notes/knowledge/decisions.md")
+	}
+}
+
 func firstSplitID(node workspacelayout.Node) string {
 	if node.Type == "split" {
 		return node.SplitID

--- a/internal/daemon/workspacelayout.go
+++ b/internal/daemon/workspacelayout.go
@@ -442,9 +442,11 @@ func dockEdgeToSplit(edge protocol.WorkspaceLayoutDockEdge) (workspacelayout.Dir
 }
 
 func (d *Daemon) handleWorkspaceLayoutDockTile(client *wsClient, msg *protocol.WorkspaceLayoutDockTileMessage) {
-	params := ""
-	if snapshot := d.store.GetWorkspaceLayout(msg.WorkspaceID); snapshot != nil {
-		params, _ = workspacelayout.TileParamsByID(snapshot.Layout, strings.TrimSpace(msg.TileID))
+	params := strings.TrimSpace(protocol.Deref(msg.TileParams))
+	if params == "" {
+		if snapshot := d.store.GetWorkspaceLayout(msg.WorkspaceID); snapshot != nil {
+			params, _ = workspacelayout.TileParamsByID(snapshot.Layout, strings.TrimSpace(msg.TileID))
+		}
 	}
 	err := d.dockTile(msg.WorkspaceID, msg.AnchorPaneID, msg.TileID, msg.TileKind, params, "", msg.Edge, msg.Ratio)
 	d.sendWorkspaceLayoutTileActionResult(client, protocol.CmdWorkspaceLayoutDockTile, msg.WorkspaceID, msg.TileID, err)

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "169"
+const ProtocolVersion = "170"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -5077,6 +5077,9 @@ type WorkspaceLayoutDockTileMessage struct {
 	// TileKind corresponds to the JSON schema field "tile_kind".
 	TileKind string `json:"tile_kind"`
 
+	// TileParams corresponds to the JSON schema field "tile_params".
+	TileParams *string `json:"tile_params,omitempty,omitzero"`
+
 	// WorkspaceID corresponds to the JSON schema field "workspace_id".
 	WorkspaceID string `json:"workspace_id"`
 }

--- a/internal/protocol/parse_test.go
+++ b/internal/protocol/parse_test.go
@@ -337,7 +337,7 @@ func TestParseWorkspaceLayoutMoveLeafToWorkspace(t *testing.T) {
 	}
 }
 
-func TestParseWorkspaceLayoutDockTileIgnoresInjectedParams(t *testing.T) {
+func TestParseWorkspaceLayoutDockTileParamsRoundTrip(t *testing.T) {
 	input := `{"cmd":"workspace_layout_dock_tile","workspace_id":"ws1","anchor_pane_id":"pane-a","edge":"right","tile_id":"tile-md","tile_kind":"markdown","tile_params":"/abs/file.md"}`
 	_, data, err := ParseMessage([]byte(input))
 	if err != nil {
@@ -346,6 +346,9 @@ func TestParseWorkspaceLayoutDockTileIgnoresInjectedParams(t *testing.T) {
 	msg := data.(*WorkspaceLayoutDockTileMessage)
 	if msg.WorkspaceID != "ws1" || msg.TileID != "tile-md" || msg.TileKind != "markdown" {
 		t.Errorf("fields = %q/%q/%q, want ws1/tile-md/markdown", msg.WorkspaceID, msg.TileID, msg.TileKind)
+	}
+	if Deref(msg.TileParams) != "/abs/file.md" {
+		t.Errorf("tile_params = %q, want /abs/file.md", Deref(msg.TileParams))
 	}
 }
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -1656,6 +1656,11 @@ model WorkspaceLayoutDockTileMessage {
   tile_id: string;
   tile_kind: string;
   ratio?: float64;
+
+  // Optional initial tile params for a freshly docked tile. When non-empty it
+  // becomes the tile's params; when omitted/empty, a re-dock (move) preserves
+  // the tile's existing params.
+  tile_params?: string;
 }
 
 model WorkspaceLayoutUndockTileMessage {


### PR DESCRIPTION
## Summary

PR5 of the editor-over-arbitrary-roots epic (`docs/plans/2026-07-18-editor-arbitrary-roots.md`; follows merged PR1 #577, PR2 #579, PR3 #580, PR4 #583).

- ⌘⌥N (`notebook.openTile`) in a workspace whose directory differs from the effective notebook root now docks the notebook tile root-bound to the workspace directory at dock time (`tile_params {"root":...}`) — no wrong-root flash.
- New protocol 170: `workspace_layout_dock_tile` gains optional `tile_params`; the dock handler prefers it when non-empty and preserves existing params on a paramless re-dock (move). This was needed because the daemon previously dropped the frontend's `tile_params` silently.
- Dock-tile header gains a root switcher (Notebook / Workspace / current-other-root / Browse…) for notebook tiles; switching rewrites the tile's params envelope (path deliberately dropped so the tile returns to the tree view).
- ⌘P finder and the tile file listing now go through `fs_index` scoped to the tile's root; fullscreen notebook browser keeps the rootless notebook listing.

## Testing

- Unit: `resolveEditorTileRoot`, `fsIndexToNotebookEntries`, 7 root-switcher component tests.
- Go: protocol parse round-trip + daemon dock-handler params tests.
- Local: `go build`/`vet`/`test` on protocol+daemon, full frontend vitest (172 files / 1821 tests), `tsc --noEmit`.
- Verified live in the packaged app on a throwaway profile: dock-time params persisted, finder listed the workspace root's files (including nested), file open persisted `{"root","path"}`, and a full app relaunch restored the root-bound tile with the file loaded.

## Note for reviewer

Changelog entry is deliberately deferred to PR6, which finishes the user-facing Editor rename and off-root gating.