### PR TITLE
test(daemon): harden pid-lock orphan regression; classify restore lock errors

### DIFF
--- a/cmd/attn/db.go
+++ b/cmd/attn/db.go
@@ -388,7 +388,14 @@ func acquireDaemonLock(pidPath string) (release func(), err error) {
 	}
 	if flockErr := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); flockErr != nil {
 		lockFile.Close()
-		return nil, fmt.Errorf("the attn daemon is running; stop it first (quit the app, or `attn daemon stop`) before restoring the database")
+		if errors.Is(flockErr, syscall.EWOULDBLOCK) {
+			return nil, fmt.Errorf("the attn daemon is running; stop it first (quit the app, or `attn daemon stop`) before restoring the database")
+		}
+		// Any other flock failure means we cannot determine whether a
+		// daemon holds the lock. Fail closed rather than risk racing a
+		// live daemon: never proceed with the restore on an inconclusive
+		// lock result.
+		return nil, fmt.Errorf("cannot determine daemon state: %w", flockErr)
 	}
 	var once sync.Once
 	release = func() {

--- a/cmd/attn/db_test.go
+++ b/cmd/attn/db_test.go
@@ -403,8 +403,12 @@ func TestAcquireDaemonLock_HeldByAnotherProcess(t *testing.T) {
 		t.Fatalf("flock pid file: %v", err)
 	}
 
-	if _, err := acquireDaemonLock(pidPath); err == nil {
+	_, err = acquireDaemonLock(pidPath)
+	if err == nil {
 		t.Fatal("expected acquireDaemonLock to refuse while another fd holds the flock")
+	}
+	if !strings.Contains(err.Error(), "daemon is running") {
+		t.Fatalf("expected EWOULDBLOCK contention to be classified as \"daemon is running\", got: %v", err)
 	}
 
 	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil {

--- a/internal/daemon/pidlock_test.go
+++ b/internal/daemon/pidlock_test.go
@@ -44,6 +44,18 @@ func TestDaemon_ReleasePIDLock_LeavesFileInPlace(t *testing.T) {
 // a subsequent daemon-style acquire attempt on the same pathname is still
 // correctly excluded rather than silently succeeding against a
 // newly-created inode.
+//
+// The ordering here matters: the stand-in's fd is opened WHILE the daemon
+// still holds the lock (mirroring `attn db restore`'s real timing, where
+// acquireDaemonLock races to open and flock the daemon's live pid file
+// before/while it might be released) and deliberately WITHOUT O_CREATE, so
+// the open can only succeed against the daemon's already-created pathname
+// and the fd is proven to reference the daemon's original inode. If the fd
+// were instead opened after releasePIDLock (as a prior version of this test
+// did), an old buggy releasePIDLock that unlinks the pid file would still
+// let O_CREATE silently fabricate a fresh inode at that step, and the test
+// would pass for the wrong reason — it wouldn't be holding the daemon's
+// inode across the release at all, so it could never observe an orphan.
 func TestDaemon_ReleasePIDLock_DoesNotOrphanAConcurrentHolder(t *testing.T) {
 	dir := t.TempDir()
 	pidPath := filepath.Join(dir, "attn.pid")
@@ -53,22 +65,31 @@ func TestDaemon_ReleasePIDLock_DoesNotOrphanAConcurrentHolder(t *testing.T) {
 		t.Fatalf("acquirePIDLock error: %v", err)
 	}
 
-	// The daemon shuts down and releases.
-	d.releasePIDLock()
-
-	// A concurrent holder (the restore stand-in) acquires the still-present
-	// file immediately after release, before any new daemon starts.
-	restoreHolder, err := os.OpenFile(pidPath, os.O_RDWR|os.O_CREATE, 0644)
+	// The restore stand-in opens an fd on the pid file WHILE the daemon
+	// still holds the lock. No O_CREATE: the file must already exist
+	// because the daemon created it, proving this fd references the
+	// daemon's inode rather than one the stand-in fabricated itself.
+	restoreHolder, err := os.OpenFile(pidPath, os.O_RDWR, 0)
 	if err != nil {
 		t.Fatalf("open pid file as restore stand-in: %v", err)
 	}
 	defer restoreHolder.Close()
+
+	// The daemon shuts down and releases.
+	d.releasePIDLock()
+
+	// The stand-in can now acquire the flock on that same inode — it was
+	// merely blocked by the daemon's lock, not by a missing/replaced file.
 	if err := syscall.Flock(int(restoreHolder.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		t.Fatalf("restore stand-in flock: %v", err)
+		t.Fatalf("restore stand-in flock after daemon release: %v", err)
 	}
 
 	// A new daemon startup attempting to acquire the lock at the same
-	// pathname while the restore stand-in holds it must be excluded.
+	// pathname while the restore stand-in holds it must be excluded. Under
+	// the old unlink-on-release behavior, the pathname would have been
+	// unlinked back at releasePIDLock, so this acquire's O_CREATE would
+	// create a brand-new, different inode and wrongly succeed here — that
+	// is the regression this test exists to catch.
 	next := &Daemon{pidPath: pidPath}
 	if err := next.acquirePIDLock(); err == nil {
 		t.Fatal("expected daemon acquirePIDLock to be excluded while the restore stand-in holds the lock")


### PR DESCRIPTION
## Summary
Two review follow-ups from #582 (backup/restore pid-lock work, merged as ba613ae6):

- `internal/daemon/pidlock_test.go`: resequence `TestDaemon_ReleasePIDLock_DoesNotOrphanAConcurrentHolder` so the restore stand-in opens its fd (no `O_CREATE`) *while the daemon still holds the lock*, before `releasePIDLock` runs. The prior sequencing opened that fd after release, so the test would have passed even under the old unlink-on-release bug — it never actually held the daemon's original inode across the release. Verified by deliberately reintroducing `os.Remove` into `releasePIDLock`: the resequenced test fails at the exclusion assertion as expected; the old sequencing did not catch it.
- `cmd/attn/db.go`: `acquireDaemonLock` now classifies flock errors — `EWOULDBLOCK` keeps the existing "daemon is running" message (a live daemon holds the lock), any other error becomes "cannot determine daemon state: %w" instead of misattributing it. Both paths still fail closed and refuse the restore.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/daemon/... -run TestDaemon_ReleasePIDLock -v` — both pass
- [x] `go test ./cmd/attn/... -run TestAcquireDaemonLock -v` — all three pass
- [x] `go test ./...` — full suite green
- [x] `gofmt -l .` clean
- No live-app verification: this is a test-sequencing fix plus error-classification logic fully covered by unit tests, with no daemon-process, protocol, PTY, or UI surface touched.

https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT