### PR TITLE
test(daemon): harden pid-lock and restore-lock coverage (PR #582/#586 follow-up)

### DIFF
--- a/cmd/attn/db.go
+++ b/cmd/attn/db.go
@@ -381,12 +381,19 @@ func stageBackupCopy(src, dstPath string) (stagedPath string, err error) {
 // The lock file is never unlinked here — only unlocked and closed — so a
 // second acquireDaemonLock always contends on the same inode rather than
 // racing a delete-then-recreate against a concurrent acquirer.
+//
+// flockFn is indirected to syscall.Flock so tests can inject a non-EWOULDBLOCK
+// failure (e.g. standing in for ENOLCK) without needing real OS-level
+// conditions to trigger it — EWOULDBLOCK is the only signal that means a live
+// daemon actually holds the lock.
+var flockFn = syscall.Flock
+
 func acquireDaemonLock(pidPath string) (release func(), err error) {
 	lockFile, err := os.OpenFile(pidPath, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("open pid file %s: %w", pidPath, err)
 	}
-	if flockErr := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); flockErr != nil {
+	if flockErr := flockFn(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); flockErr != nil {
 		lockFile.Close()
 		if errors.Is(flockErr, syscall.EWOULDBLOCK) {
 			return nil, fmt.Errorf("the attn daemon is running; stop it first (quit the app, or `attn daemon stop`) before restoring the database")

--- a/cmd/attn/db_test.go
+++ b/cmd/attn/db_test.go
@@ -410,6 +410,9 @@ func TestAcquireDaemonLock_HeldByAnotherProcess(t *testing.T) {
 	if !strings.Contains(err.Error(), "daemon is running") {
 		t.Fatalf("expected EWOULDBLOCK contention to be classified as \"daemon is running\", got: %v", err)
 	}
+	if strings.Contains(err.Error(), "cannot determine daemon state") {
+		t.Fatalf("expected EWOULDBLOCK contention not to use the indeterminate-state message, got: %v", err)
+	}
 
 	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil {
 		t.Fatalf("unlock pid file: %v", err)
@@ -420,6 +423,36 @@ func TestAcquireDaemonLock_HeldByAnotherProcess(t *testing.T) {
 		t.Fatalf("expected acquireDaemonLock to succeed after the lock was released, got: %v", err)
 	}
 	release()
+}
+
+// TestAcquireDaemonLock_NonContentionFlockErrorIsNotMisreportedAsRunning
+// proves acquireDaemonLock does not conflate every flock failure with "the
+// daemon is running": only EWOULDBLOCK (the actual contention signal) gets
+// that operator-facing message. Any other flock error must surface as
+// "cannot determine daemon state" instead, since telling the user to stop a
+// daemon that may not even exist would be misleading. Exercised by swapping
+// in a fake flock function that returns a non-EWOULDBLOCK error, mirroring
+// how an exotic failure (e.g. ENOLCK) would present.
+func TestAcquireDaemonLock_NonContentionFlockErrorIsNotMisreportedAsRunning(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "attn.pid")
+
+	restore := flockFn
+	flockFn = func(fd int, how int) error {
+		return syscall.ENOLCK
+	}
+	defer func() { flockFn = restore }()
+
+	_, err := acquireDaemonLock(pidPath)
+	if err == nil {
+		t.Fatal("expected acquireDaemonLock to refuse on a non-contention flock error")
+	}
+	if !strings.Contains(err.Error(), "cannot determine daemon state") {
+		t.Fatalf("acquireDaemonLock() error = %q, want the indeterminate-state message for a non-EWOULDBLOCK flock error", err)
+	}
+	if strings.Contains(err.Error(), "daemon is running") {
+		t.Fatalf("acquireDaemonLock() error = %q, should not claim daemon liveness on an indeterminate flock error", err)
+	}
 }
 
 // TestAcquireDaemonLock_ExcludesConcurrentRestore proves the lock is held —

--- a/internal/daemon/pidlock_test.go
+++ b/internal/daemon/pidlock_test.go
@@ -75,6 +75,11 @@ func TestDaemon_ReleasePIDLock_DoesNotOrphanAConcurrentHolder(t *testing.T) {
 	}
 	defer restoreHolder.Close()
 
+	restoreHolderInfo, err := restoreHolder.Stat()
+	if err != nil {
+		t.Fatalf("stat restore stand-in fd: %v", err)
+	}
+
 	// The daemon shuts down and releases.
 	d.releasePIDLock()
 
@@ -82,6 +87,15 @@ func TestDaemon_ReleasePIDLock_DoesNotOrphanAConcurrentHolder(t *testing.T) {
 	// merely blocked by the daemon's lock, not by a missing/replaced file.
 	if err := syscall.Flock(int(restoreHolder.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		t.Fatalf("restore stand-in flock after daemon release: %v", err)
+	}
+
+	// Belt-and-suspenders: confirm the pathname still resolves to the same
+	// inode the stand-in's fd is holding the lock on, rather than relying
+	// solely on the flock success above.
+	if pathInfo, err := os.Stat(pidPath); err != nil {
+		t.Fatalf("stat pid path after release: %v", err)
+	} else if !os.SameFile(restoreHolderInfo, pathInfo) {
+		t.Fatal("releasePIDLock changed the inode at pidPath; restore stand-in's held fd now refers to an orphaned inode")
 	}
 
 	// A new daemon startup attempting to acquire the lock at the same


### PR DESCRIPTION
## Summary

Purely additive hardening on top of #586's flock-error classification and resequenced orphan-holder test — no reverts of #586's structure or wording, just the untested branches/assertions layered on:

1. **`flockFn` injectable seam** in `cmd/attn/db.go` over `syscall.Flock`, so a non-EWOULDBLOCK flock failure (e.g. `ENOLCK`) can be exercised deterministically. #586 added the EWOULDBLOCK/other-error classification but left the "other error" branch untested.
2. **`TestAcquireDaemonLock_NonContentionFlockErrorIsNotMisreportedAsRunning`** (new) — covers that previously-untested branch via `flockFn`.
3. **Negative assertion** in `TestAcquireDaemonLock_HeldByAnotherProcess` — EWOULDBLOCK contention must not also match the indeterminate-state message.
4. **`os.SameFile` inode assertion** in `TestDaemon_ReleasePIDLock_DoesNotOrphanAConcurrentHolder` — on top of #586's existing flock-success check, explicitly proves the pathname still resolves to the daemon's original inode after release.

## Test plan

- [x] `gofmt -l` clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./internal/daemon ./cmd/...` — all green