### PR TITLE
feat(app): editor tile — off-root gating, Editor labels, changelog, workspace-root scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   database file rather than deleting it. Settings now also surface the
   timestamp of the most recent successful backup.
 
+### Changed
+- **The Notebook tile is now an Editor that can open any folder.** ⌘⌥N opens
+  it on the active workspace's directory, the tile header shows the open root
+  with a switcher (workspace / Notebook / browse), and ⌘P fuzzy-finds across
+  the whole open root. Notebook-only affordances — backlinks and send-to-chief
+  — still appear only when you're browsing your actual Notebook.
+
 ## [2026-07-16]
 
 ### Added

--- a/app/package.json
+++ b/app/package.json
@@ -53,6 +53,7 @@
     "real-app:scenario-notebook-tile-close": "node scripts/real-app-harness/scenario-notebook-tile-close.mjs",
     "real-app:scenario-notebook-editor-undo": "node scripts/real-app-harness/scenario-notebook-editor-undo.mjs",
     "real-app:scenario-notebook-link-nav": "node scripts/real-app-harness/scenario-notebook-link-nav.mjs",
+    "real-app:scenario-editor-workspace-root": "node scripts/real-app-harness/scenario-editor-workspace-root.mjs",
     "real-app:scenario-autoclose-on-exit": "node scripts/real-app-harness/scenario-autoclose-on-exit.mjs",
     "real-app:scenario-present-flow": "node scripts/real-app-harness/scenario-present-flow.mjs",
     "real-app:scenario-ticket-lifecycle": "node scripts/real-app-harness/scenario-ticket-delegation-lifecycle.mjs",

--- a/app/scripts/real-app-harness/scenario-editor-workspace-root.mjs
+++ b/app/scripts/real-app-harness/scenario-editor-workspace-root.mjs
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+
+// Editor tile over an arbitrary workspace root, in the packaged app
+// (editor-arbitrary-roots epic, PR6). Docks a fresh editor tile with the REAL
+// native ⌘⌥N into a workspace whose directory is a throwaway temp folder (not
+// the Notebook root), opens a file in it via the tile's finder, and proves two
+// things at once:
+//   1. Root-scoped fs_read actually works for an arbitrary root — the tile
+//      renders the real file content (.cm-content), not an error state.
+//   2. Off-root gating (this PR) actually withholds Notebook-only chrome —
+//      the backlinks/outline rail never renders for a tile bound to a root
+//      other than the Notebook's.
+// A second tile, docked into a workspace whose directory IS the Notebook
+// root, is the positive control: the same rail CAN render there, proving step
+// 2 isolates the off-root case rather than the rail being broken generally.
+//
+// Modeled closely on scenario-notebook-tile-finder.mjs and
+// scenario-notebook-editor-undo.mjs (native ⌘⌥N dock, native finder typing).
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  createRunContext,
+  createSessionAndWaitForInitialPane,
+  launchFreshAppAndConnect,
+  parseCommonArgs,
+  printCommonHelp,
+} from './common.mjs';
+import { DaemonObserver } from './daemonObserver.mjs';
+import { currentHarnessProfile } from './harnessProfile.mjs';
+import { MacOSDriver } from './macosDriver.mjs';
+import { captureFrontWindowScreenshot } from './nativeWindowCapture.mjs';
+import {
+  waitForFirstWorkspacePane,
+  waitForPaneShellReady,
+  waitForPaneVisible,
+} from './scenarioAssertions.mjs';
+import { UiAutomationClient } from './uiAutomationClient.mjs';
+
+function parseArgs(argv) {
+  const args = [...argv];
+  if (args[0] === '--') {
+    args.shift();
+  }
+  return {
+    options: parseCommonArgs(args),
+    help: args.includes('--help') || args.includes('-h'),
+  };
+}
+
+// Scope every probe to the ACTIVE workspace: inactive workspaces stay mounted
+// but hidden (warm set), so an unscoped selector can match a stale tile left
+// open by a previous run's workspace and poison presence waits.
+const ACTIVE_TILE = '.terminal-wrapper.active .workspace-dock-tile';
+const FINDER_SELECTOR = `${ACTIVE_TILE} .notebook-finder`;
+const EDITOR_SELECTOR = `${ACTIVE_TILE} .cm-content`;
+const RAIL_SELECTOR = `${ACTIVE_TILE} .notebook-browser-rail`;
+
+// Mirrors internal/notebook/layout.go DefaultRoot: ~/attn-notebook, or
+// ~/attn-notebook-<profile> for any non-default profile. This is the notebook
+// root ONLY when the daemon's `notebook.root` setting is unset (the default
+// for every profile the harness creates fresh) — there is no UI-automation
+// surface that reports the resolved root without opening the Settings modal,
+// and adding one is out of scope here. If a profile has a custom
+// notebook.root configured, the "positive control" workspace below will not
+// actually land on the Notebook root and that half of the scenario will time
+// out with a clear cause. (Same convention as scenario-notebook-editor-undo.mjs
+// and scenario-notebook-link-nav.mjs.)
+function defaultNotebookRootForProfile(profile) {
+  const normalized = (profile || '').trim().toLowerCase();
+  const base = path.join(os.homedir(), 'attn-notebook');
+  return normalized === '' || normalized === 'default' ? base : `${base}-${normalized}`;
+}
+
+async function domSelectorPresent(client, selector) {
+  try {
+    await client.request('capture_screenshot_data', { selector });
+    return true;
+  } catch (error) {
+    if (String(error).includes('Screenshot selector not found in DOM')) {
+      return false;
+    }
+    // The selector resolved but the capture itself failed — html-to-image can
+    // throw on some subtrees (e.g. CodeMirror's .cm-content). We asked about
+    // presence, and the bridge only emits the "not found" error when the
+    // element is genuinely absent, so treat any other failure as present.
+    return true;
+  }
+}
+
+async function waitForDomSelector(client, selector, present, description, timeoutMs = 10_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if ((await domSelectorPresent(client, selector)) === present) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  throw new Error(`Timed out waiting for ${selector} to be ${present ? 'present' : 'absent'}: ${description}`);
+}
+
+// Absence-under-race check: an off-root tile withholds the rail because it
+// never asks the daemon for backlinks, not because a slow fetch hasn't landed
+// yet. Confirm the negative twice, a beat apart, so a race with a fetch that
+// SHOULD NOT exist can't slip a false pass through a single premature check.
+async function assertNeverAppears(client, selector, description, settleMs = 1_500) {
+  await waitForDomSelector(client, selector, false, `${description} (initial)`, 3_000);
+  await new Promise((resolve) => setTimeout(resolve, settleMs));
+  await waitForDomSelector(client, selector, false, `${description} (after settle)`, 3_000);
+}
+
+async function waitForWorkspaceUi(client, workspaceId, predicate, description, timeoutMs = 20_000) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await client.request('get_workspace_ui_state', { workspaceId }).catch((error) => ({ error: String(error) }));
+    if (predicate(last)) {
+      return last;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`Timed out waiting for ${description}. Last workspace UI state:\n${JSON.stringify(last, null, 2)}`);
+}
+
+// Dock a fresh editor tile via the REAL native ⌘⌥N (notebook.openTile) into
+// whichever workspace is currently frontmost/active — the macOS-menu →
+// WebView shortcut path browser e2e cannot reach. Waits for the tile to
+// appear titled "Editor" (the fresh-tile fallback title before anything is
+// opened — this PR's Editor-label rename).
+async function dockEditorTileNative(client, driver, workspaceId) {
+  await driver.activateApp();
+  await driver.pressKey('n', { command: true, option: true });
+  try {
+    return await waitForWorkspaceUi(
+      client,
+      workspaceId,
+      (state) => Array.isArray(state?.tileIds) && state.tileIds.length === 1
+        && Array.isArray(state?.tileTitles) && state.tileTitles.includes('Editor'),
+      'native Cmd+Opt+N to dock a fresh editor tile (titled "Editor")',
+      15_000,
+    );
+  } catch (dockError) {
+    const frontmost = await driver.frontmostBundleId().catch(() => '(unknown)');
+    throw new Error(
+      `${dockError.message}\n\nThe native Cmd+Opt+N did not reach the app. This scenario `
+      + `needs native keyboard input: grant Accessibility permission to the process running it `
+      + `and keep attn frontmost. Frontmost app was "${frontmost}" (expected "${driver.bundleId}").`,
+    );
+  }
+}
+
+// Open a note via the tile's auto-opened finder (a fresh tile with no
+// persisted path always opens straight into it): native-type the basename,
+// press Enter to pick the top ranked match — the same path a user takes.
+async function openNoteViaFinder(client, driver, basename) {
+  await waitForDomSelector(client, FINDER_SELECTOR, true, 'fresh editor tile auto-opens its finder');
+  await driver.activateApp();
+  await driver.typeText(basename);
+  await driver.pressEnter();
+  await waitForDomSelector(client, FINDER_SELECTOR, false, 'Enter picks the note and closes the finder');
+  await waitForDomSelector(client, EDITOR_SELECTOR, true, 'note opens into the live markdown editor');
+}
+
+async function closeWorkspacePanes(client, sessionId) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const workspace = await client.request('get_workspace', { sessionId }).catch(() => null);
+    const pane = workspace?.panes?.[0];
+    if (!pane) {
+      return;
+    }
+    await client.request('close_pane', { sessionId, paneId: pane.paneId }).catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+async function closeExistingSessions(client, sessionRootDir) {
+  const initial = await client.request('get_state');
+  const harnessSessions = (initial.sessions || []).filter((session) => session.cwd?.startsWith(sessionRootDir));
+  for (const session of harnessSessions) {
+    await closeWorkspacePanes(client, session.id).catch(() => {});
+  }
+}
+
+async function openWorkspaceForCwd(client, observer, cwd, label, sessionWaitMs = 30_000) {
+  const sessionId = await createSessionAndWaitForInitialPane({
+    client,
+    observer,
+    cwd,
+    label,
+    agent: 'shell',
+    waitForInitialPaneVisible: false,
+    sessionWaitMs,
+  });
+  const pane = await waitForFirstWorkspacePane(client, sessionId, 'initial workspace pane');
+  await client.request('select_session', { sessionId });
+  await waitForPaneVisible(client, sessionId, pane.paneId, 20_000);
+  await waitForPaneShellReady(client, sessionId, pane.paneId, {
+    timeoutMs: 20_000,
+    description: 'shell prompt ready',
+  });
+  const workspace = await client.request('get_workspace', { sessionId });
+  const workspaceId = workspace.workspaceId;
+  if (!workspaceId) {
+    throw new Error(`Could not resolve workspace id for session ${sessionId}: ${JSON.stringify(workspace)}`);
+  }
+  return { sessionId, workspaceId };
+}
+
+async function main() {
+  const { options, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printCommonHelp('scripts/real-app-harness/scenario-editor-workspace-root.mjs');
+    return;
+  }
+
+  const { runId, runDir, sessionDir } = createRunContext(options, 'editor-workspace-root');
+  const client = new UiAutomationClient({ appPath: options.appPath });
+  const observer = new DaemonObserver({ wsUrl: options.wsUrl });
+  const driver = new MacOSDriver({ appPath: options.appPath });
+  let tempSessionId = null;
+  let notebookSessionId = null;
+  let positiveControlPath = null;
+
+  console.log(`[RealAppHarness] runDir=${runDir}`);
+  console.log(`[RealAppHarness] sessionDir=${sessionDir}`);
+  console.log(`[RealAppHarness] wsUrl=${options.wsUrl}`);
+
+  try {
+    process.env.ATTN_HARNESS_PARK_VISIBLE_PX ??= '0';
+    await launchFreshAppAndConnect(client, observer);
+    await closeExistingSessions(client, options.sessionRootDir);
+
+    // 0. Seed the off-root fixture BEFORE launch/dock: a README.md at the root
+    //    plus a nested dir/note.md, so the tile's first fs_index already sees
+    //    both — no race against a fs_watch debounce.
+    const tempRoot = path.join(sessionDir, 'editor-root');
+    fs.mkdirSync(path.join(tempRoot, 'dir'), { recursive: true });
+    fs.writeFileSync(path.join(tempRoot, 'README.md'), '# Editor root fixture\n\nOff-root gating probe.\n', 'utf8');
+    fs.writeFileSync(path.join(tempRoot, 'dir', 'note.md'), '# Nested note\n\nUnder dir/.\n', 'utf8');
+    console.log(`[RealAppHarness] tempRoot=${tempRoot}`);
+
+    // Seed a positive-control note directly in the Notebook root (a real note
+    // among real notes — the same convention scenario-notebook-editor-undo.mjs
+    // and scenario-notebook-link-nav.mjs use for this uncontrolled-but-known
+    // location), unique to this run so it never collides across runs.
+    const notebookRoot = defaultNotebookRootForProfile(currentHarnessProfile());
+    fs.mkdirSync(notebookRoot, { recursive: true });
+    const positiveControlBasename = `editor-root-positive-control-${runId}`;
+    positiveControlPath = path.join(notebookRoot, `${positiveControlBasename}.md`);
+    fs.writeFileSync(positiveControlPath, '# Positive control\n\nOn-root rail probe.\n', 'utf8');
+    console.log(`[RealAppHarness] notebookRoot=${notebookRoot}`);
+    console.log(`[RealAppHarness] positiveControlPath=${positiveControlPath}`);
+
+    // 1. Off-root workspace: a normal shell session whose cwd is the temp root.
+    //    ⌘⌥N's default (resolveEditorTileRoot) pins a fresh editor tile to the
+    //    ACTIVE workspace's directory whenever it differs from the Notebook
+    //    root — so this docks a tile bound to tempRoot, not Notebook storage.
+    const off = await openWorkspaceForCwd(client, observer, tempRoot, `editor-root-off-${runId}`);
+    tempSessionId = off.sessionId;
+
+    const offRootDocked = await dockEditorTileNative(client, driver, off.workspaceId);
+    console.log(`[RealAppHarness] docked off-root editor tile=${offRootDocked.tileIds[0]}`);
+
+    // 2. Open README.md via the tile's auto-opened finder, then assert:
+    //    (a) tile title becomes the file basename.
+    await openNoteViaFinder(client, driver, 'README');
+    await waitForWorkspaceUi(
+      client,
+      off.workspaceId,
+      (state) => Array.isArray(state?.tileTitles) && state.tileTitles.includes('README.md'),
+      'tile title becomes the opened file\'s basename',
+      10_000,
+    );
+    await captureFrontWindowScreenshot(path.join(runDir, 'off-root-open.png'), { client }).catch((error) => {
+      console.warn(`[RealAppHarness] off-root-open screenshot failed: ${error}`);
+    });
+
+    // (b) .cm-content already asserted present by openNoteViaFinder — root-
+    //     scoped fs_read for an arbitrary root actually returned real bytes,
+    //     not an error state (which would never mount the editor at all).
+
+    // (c) THE off-root-gating assertion: no backlinks/outline rail. It must
+    //     never appear at all — this tile was never handed backlinksNotebook,
+    //     so there is no fetch in flight that could make it appear late.
+    await assertNeverAppears(client, RAIL_SELECTOR, 'off-root tile withholds the backlinks/outline rail');
+    console.log('[RealAppHarness] off-root tile: rail withheld as expected.');
+
+    // 3. Positive control: a second workspace whose directory IS the Notebook
+    //    root. resolveEditorTileRoot treats "directory === effective notebook
+    //    root" as the rootless case, so ⌘⌥N here docks a Notebook-rooted tile
+    //    (full capabilities) — the same rail should now render for a markdown
+    //    note, proving step (c) isolates off-root rather than the rail being
+    //    broken in general.
+    const on = await openWorkspaceForCwd(client, observer, notebookRoot, `editor-root-on-${runId}`);
+    notebookSessionId = on.sessionId;
+
+    const onRootDocked = await dockEditorTileNative(client, driver, on.workspaceId);
+    console.log(`[RealAppHarness] docked on-root (Notebook) editor tile=${onRootDocked.tileIds[0]}`);
+
+    await openNoteViaFinder(client, driver, positiveControlBasename);
+    await waitForDomSelector(client, RAIL_SELECTOR, true, 'on-root (Notebook) tile CAN render the backlinks/outline rail', 10_000);
+    console.log('[RealAppHarness] on-root (Notebook) tile: rail rendered (positive control).');
+    await captureFrontWindowScreenshot(path.join(runDir, 'on-root-rail.png'), { client }).catch((error) => {
+      console.warn(`[RealAppHarness] on-root-rail screenshot failed: ${error}`);
+    });
+
+    const summary = {
+      ok: true,
+      runId,
+      tempRoot,
+      notebookRoot,
+      offRoot: {
+        workspaceId: off.workspaceId,
+        tileId: offRootDocked.tileIds[0],
+        tileTitles: offRootDocked.tileTitles,
+      },
+      onRoot: {
+        workspaceId: on.workspaceId,
+        tileId: onRootDocked.tileIds[0],
+      },
+    };
+    fs.writeFileSync(path.join(runDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    console.log('[RealAppHarness] Editor tile over an arbitrary workspace root (off-root gating + positive control) passed.');
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    if (tempSessionId) {
+      await closeWorkspacePanes(client, tempSessionId).catch(() => {});
+    }
+    if (notebookSessionId) {
+      await closeWorkspacePanes(client, notebookSessionId).catch(() => {});
+    }
+    if (positiveControlPath) {
+      fs.rmSync(positiveControlPath, { force: true });
+    }
+    await client.quitApp().catch(() => {});
+    await observer.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/app/scripts/real-app-harness/scenario-notebook-tile-finder.mjs
+++ b/app/scripts/real-app-harness/scenario-notebook-tile-finder.mjs
@@ -173,8 +173,8 @@ async function main() {
         client,
         workspaceId,
         (state) => Array.isArray(state?.tileIds) && state.tileIds.length === 1
-          && Array.isArray(state?.tileTitles) && state.tileTitles.includes('Notebook'),
-        'native Cmd+Opt+N to dock a fresh notebook tile (titled "Notebook")',
+          && Array.isArray(state?.tileTitles) && state.tileTitles.includes('Editor'),
+        'native Cmd+Opt+N to dock a fresh notebook tile (titled "Editor")',
         15_000,
       );
     } catch (dockError) {

--- a/app/scripts/real-app-harness/scenarioCatalog.mjs
+++ b/app/scripts/real-app-harness/scenarioCatalog.mjs
@@ -48,6 +48,11 @@ export const scenarioCatalog = [
     command: ['pnpm', 'run', 'real-app:scenario-notebook-editor-undo'],
   },
   {
+    id: 'editor-workspace-root',
+    label: 'Editor tile over an arbitrary workspace root (off-root gating + positive control)',
+    command: ['pnpm', 'run', 'real-app:scenario-editor-workspace-root'],
+  },
+  {
     id: 'autoclose-on-exit',
     label: 'Auto-close on clean exit, keep failed exits',
     command: ['pnpm', 'run', 'real-app:scenario-autoclose-on-exit'],

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2008,9 +2008,9 @@ sendFetchPRDetails,
   const actionMenuItems = useMemo<ActionMenuItem[]>(() => [
     {
       id: 'notebook-tile',
-      title: 'Open Notebook tile',
-      description: 'Dock the notebook beside your terminals in this workspace',
-      keywords: ['notebook', 'tile', 'knowledge', 'journal', 'dock', 'split'],
+      title: 'Open Editor tile',
+      description: 'Dock an editor beside your terminals, opened on any folder',
+      keywords: ['notebook', 'editor', 'tile', 'knowledge', 'journal', 'dock', 'split'],
       icon: <ContextActionIcon />,
       shortcut: [shortcutTokens('notebook.openTile')],
       run: handleOpenNotebookTile,

--- a/app/src/components/NotebookSurface.test.tsx
+++ b/app/src/components/NotebookSurface.test.tsx
@@ -1,6 +1,7 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createRef } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { NotebookSurface } from './NotebookSurface';
+import { NotebookSurface, type NotebookSurfaceHandle } from './NotebookSurface';
 import type { FsEntry, FsExistsResult, FsReadAssetResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../hooks/useDaemonSocket';
 
 // Off-root gating (editor-arbitrary-roots PR6): backlinksNotebook and sendToChief
@@ -166,5 +167,79 @@ describe('NotebookSurface off-root gating (tile variant)', () => {
     act(() => editorMock.current!.onSelectionChange!({ text: 'a key decision', top: 40, left: 60 }));
 
     expect(await screen.findByRole('button', { name: 'Send to chief' })).toBeInTheDocument();
+  });
+});
+
+describe('NotebookSurface flushPendingSave handle (root-switch flush, PR #588 second review round)', () => {
+  // NotebookTile keys NotebookSurface on `root`, so a root switch remounts it —
+  // dropping any not-yet-autosaved edit (the autosave debounce is 700ms with no
+  // unmount flush). flushPendingSave is the imperative escape hatch the root
+  // switcher calls BEFORE swapping params, so the outgoing edit persists to the
+  // OLD root's file instead of vanishing.
+  beforeEach(() => {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    editorMock.current = null;
+    vi.restoreAllMocks();
+  });
+
+  it('flushPendingSave persists a dirty buffer immediately (ahead of the autosave debounce) and resolves "saved"', async () => {
+    const { props, writeFile } = makeProps();
+    const ref = createRef<NotebookSurfaceHandle>();
+    render(<NotebookSurface {...props} ref={ref} />);
+    await waitForNoteLoaded();
+
+    fireEvent.change(editor(), { target: { value: 'edited body' } });
+
+    // Called before the 700ms debounce would fire — writeFile must not have
+    // been called yet via the autosave path.
+    expect(writeFile).not.toHaveBeenCalled();
+
+    let outcome: string | undefined;
+    await act(async () => {
+      outcome = await ref.current!.flushPendingSave();
+    });
+
+    expect(writeFile).toHaveBeenCalledWith('note.md', 'edited body', 'h1');
+    expect(outcome).toBe('saved');
+  });
+
+  it('flushPendingSave resolves "conflict" and leaves the conflict banner showing when the write CAS-conflicts', async () => {
+    const { props, writeFile } = makeProps();
+    writeFile.mockResolvedValue({ path: 'note.md', conflict: true, currentHash: 'h-server' });
+    const ref = createRef<NotebookSurfaceHandle>();
+    render(<NotebookSurface {...props} ref={ref} />);
+    await waitForNoteLoaded();
+
+    fireEvent.change(editor(), { target: { value: 'edited body' } });
+
+    let outcome: string | undefined;
+    await act(async () => {
+      outcome = await ref.current!.flushPendingSave();
+    });
+
+    expect(outcome).toBe('conflict');
+    expect(document.querySelector('.notebook-browser-editor-conflict')).not.toBeNull();
+  });
+
+  it('flushPendingSave resolves "noop" when the buffer is already in sync', async () => {
+    const { props, writeFile } = makeProps();
+    const ref = createRef<NotebookSurfaceHandle>();
+    render(<NotebookSurface {...props} ref={ref} />);
+    await waitForNoteLoaded();
+
+    let outcome: string | undefined;
+    await act(async () => {
+      outcome = await ref.current!.flushPendingSave();
+    });
+
+    expect(outcome).toBe('noop');
+    expect(writeFile).not.toHaveBeenCalled();
   });
 });

--- a/app/src/components/NotebookSurface.test.tsx
+++ b/app/src/components/NotebookSurface.test.tsx
@@ -1,0 +1,170 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotebookSurface } from './NotebookSurface';
+import type { FsEntry, FsExistsResult, FsReadAssetResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../hooks/useDaemonSocket';
+
+// Off-root gating (editor-arbitrary-roots PR6): backlinksNotebook and sendToChief
+// are OPTIONAL on NotebookSurface. NotebookTile omits both when a tile is bound to
+// a filesystem root other than the Notebook's — this file proves the surface itself
+// (root-unaware; it just renders the affordances it's handed) actually withholds
+// the rail and the floating chief button when they're absent, and keeps rendering
+// them when they're provided. NotebookBrowser.test.tsx already covers the
+// always-both-provided modal path in depth; this file exercises the tile variant,
+// which is the one real caller that can omit them.
+
+const editorMock = vi.hoisted(() => ({
+  current: null as null | {
+    onSelectionChange?: (sel: { text: string; top: number; left: number } | null) => void;
+  },
+}));
+
+vi.mock('./notebook/LiveMarkdownEditor', async () => {
+  const { forwardRef, useImperativeHandle } = await import('react');
+  return {
+    LiveMarkdownEditor: forwardRef(function MockLiveMarkdownEditor(
+      {
+        value,
+        onChange,
+        onSelectionChange,
+        ariaLabel,
+      }: {
+        value: string;
+        onChange: (value: string) => void;
+        onSelectionChange?: (sel: { text: string; top: number; left: number } | null) => void;
+        ariaLabel?: string;
+      },
+      ref: React.Ref<{ scrollToPos: () => void; applyExternalContent: () => void; closeSearchPanel: () => boolean; focus: () => void }>,
+    ) {
+      editorMock.current = { onSelectionChange };
+      useImperativeHandle(ref, () => ({
+        scrollToPos: () => {},
+        applyExternalContent: () => {},
+        closeSearchPanel: () => false,
+        focus: () => {},
+      }), []);
+      return (
+        <textarea
+          aria-label={ariaLabel ?? 'Note'}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      );
+    }),
+  };
+});
+
+const TREE: Record<string, FsEntry[]> = {
+  '': [{ path: 'note.md', name: 'note.md', isDir: false, size: 32 }],
+};
+
+function makeProps(overrides: Partial<React.ComponentProps<typeof NotebookSurface>> = {}) {
+  const listDir = vi
+    .fn<(path: string) => Promise<FsEntry[]>>()
+    .mockImplementation((path) => Promise.resolve(TREE[path] ?? []));
+  const readFile = vi
+    .fn<(path: string) => Promise<FsReadResult>>()
+    .mockImplementation((path) => Promise.resolve({ path, content: `# ${path}\n\nBody text to select.`, hash: 'h1' }));
+  const writeFile = vi
+    .fn<(path: string, content: string, baseHash?: string) => Promise<FsWriteResult>>()
+    .mockImplementation((path) => Promise.resolve({ path, hash: 'h2', conflict: false }));
+  const existsFile = vi
+    .fn<(path: string) => Promise<FsExistsResult>>()
+    .mockImplementation((path) => Promise.resolve({ path, exists: true }));
+  const readAsset = vi
+    .fn<(path: string) => Promise<FsReadAssetResult>>()
+    .mockImplementation((path) => Promise.resolve({ path, mimeType: 'image/png', dataBase64: '' }));
+  const backlinksNotebook = vi
+    .fn<(path: string) => Promise<NotebookEntry[]>>()
+    .mockResolvedValue([{ path: 'other.md', type: 'note', title: 'Other', size: 10 }]);
+  const sendToChief = vi
+    .fn<(selection: string, sourcePath?: string) => Promise<NotebookSendToChiefResult>>()
+    .mockResolvedValue({ path: 'inbox.md', nudged: false });
+  return {
+    props: {
+      variant: 'tile' as const,
+      active: true,
+      initialPath: 'note.md',
+      listDir,
+      readFile,
+      writeFile,
+      existsFile,
+      readAsset,
+      changeSignal: 0,
+      ...overrides,
+    },
+    listDir,
+    readFile,
+    writeFile,
+    existsFile,
+    readAsset,
+    backlinksNotebook,
+    sendToChief,
+  };
+}
+
+function editor() {
+  return screen.getByRole('textbox', { name: 'Note' }) as HTMLTextAreaElement;
+}
+
+async function waitForNoteLoaded() {
+  await waitFor(() => expect(editor().value).toContain('# note.md'));
+}
+
+describe('NotebookSurface off-root gating (tile variant)', () => {
+  // The tile variant runs useTileAutoFold, which observes its body via a real
+  // ResizeObserver — not present under happy-dom. A no-op stub is enough; the
+  // fold ladder itself is unit-tested separately (useTileAutoFold.test.ts).
+  beforeEach(() => {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    editorMock.current = null;
+    vi.restoreAllMocks();
+  });
+
+  it('renders no backlinks/outline rail and never fetches backlinks when backlinksNotebook is absent', async () => {
+    const { props, backlinksNotebook } = makeProps({ backlinksNotebook: undefined });
+    render(<NotebookSurface {...props} />);
+    await waitForNoteLoaded();
+
+    // Give any (incorrect) fetch a chance to fire before asserting its absence.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(backlinksNotebook).not.toHaveBeenCalled();
+    expect(document.querySelector('.notebook-browser-rail')).toBeNull();
+  });
+
+  it('renders the backlinks/outline rail and fetches backlinks when backlinksNotebook is provided', async () => {
+    const { props, backlinksNotebook } = makeProps();
+    render(<NotebookSurface {...props} backlinksNotebook={backlinksNotebook} />);
+    await waitForNoteLoaded();
+
+    await waitFor(() => expect(backlinksNotebook).toHaveBeenCalledWith('note.md'));
+    expect(document.querySelector('.notebook-browser-rail')).not.toBeNull();
+  });
+
+  it('never renders the floating "Send to chief" button when sendToChief is absent, even with a selection', async () => {
+    const { props, sendToChief } = makeProps({ sendToChief: undefined });
+    render(<NotebookSurface {...props} />);
+    await waitForNoteLoaded();
+
+    act(() => editorMock.current!.onSelectionChange!({ text: 'a key decision', top: 40, left: 60 }));
+
+    expect(screen.queryByRole('button', { name: 'Send to chief' })).not.toBeInTheDocument();
+    expect(sendToChief).not.toHaveBeenCalled();
+  });
+
+  it('renders the floating "Send to chief" button on a selection when sendToChief is provided', async () => {
+    const { props, sendToChief } = makeProps();
+    render(<NotebookSurface {...props} sendToChief={sendToChief} />);
+    await waitForNoteLoaded();
+
+    act(() => editorMock.current!.onSelectionChange!({ text: 'a key decision', top: 40, left: 60 }));
+
+    expect(await screen.findByRole('button', { name: 'Send to chief' })).toBeInTheDocument();
+  });
+});

--- a/app/src/components/NotebookSurface.tsx
+++ b/app/src/components/NotebookSurface.tsx
@@ -56,12 +56,16 @@ export interface NotebookSurfaceProps {
   // Only consulted for a non-direct src (not http(s)/data:/protocol-relative).
   readAsset: (path: string) => Promise<FsReadAssetResult>;
   // Backlinks ("Linked from") for a markdown note. Notebook-specific (walks .md link
-  // graphs), so it is only consulted for .md files.
-  backlinksNotebook: (path: string) => Promise<NotebookEntry[]>;
+  // graphs), so it is only consulted for .md files. Optional: a caller that omits it
+  // (an off-root tile — see NotebookTile) gets no backlinks rail at all; the surface
+  // stays root-unaware and simply renders the affordances it's handed.
+  backlinksNotebook?: (path: string) => Promise<NotebookEntry[]>;
   // Hand a highlighted selection to the daemon to deliver to the chief of staff
   // (appends to the chief inbox note + best-effort live PTY nudge). The UI never
   // messages the chief directly. sourcePath is the note the selection came from.
-  sendToChief: (selection: string, sourcePath?: string) => Promise<NotebookSendToChiefResult>;
+  // Optional: a caller that omits it (an off-root tile) gets no floating "Send to
+  // chief" button at all.
+  sendToChief?: (selection: string, sourcePath?: string) => Promise<NotebookSendToChiefResult>;
   // Increments whenever an fs_changed event arrives, so an open browser re-lists the
   // tree (handled by FileTree) and reloads the open file (covering agent and external
   // writes).
@@ -326,7 +330,8 @@ export function NotebookSurface({
     }
     // Backlinks are a markdown-note concept; only walk the link graph for .md files.
     // A backlinks failure must not blank the file — it just yields no backlinks.
-    if (isMarkdownPath(path)) {
+    // Absent (an off-root tile) is a no-op: no fetch, backlinks stay empty.
+    if (isMarkdownPath(path) && backlinksNotebook) {
       setBacklinksLoading(true);
       void backlinksNotebook(path)
         .then((entries) => {
@@ -513,7 +518,8 @@ export function NotebookSurface({
     setDraft(fresh.content);
     setNoteError(null);
     // Content moved, so links may have too — re-walk backlinks for a markdown note.
-    if (isMarkdownPath(path)) {
+    // Absent (an off-root tile) is a no-op: no fetch, backlinks stay empty.
+    if (isMarkdownPath(path) && backlinksNotebook) {
       setBacklinksLoading(true);
       void backlinksNotebook(path)
         .then((entries) => {
@@ -533,7 +539,7 @@ export function NotebookSurface({
   // appends it to the chief inbox note and best-effort nudges a live chief; the
   // UI only surfaces the outcome and never messages the chief directly.
   const sendSelectionToChief = useCallback(async () => {
-    if (!chiefSel) return;
+    if (!chiefSel || !sendToChief) return;
     const path = selectedPathRef.current ?? undefined;
     // Freeze the load token (as writeBuffer does) so an outcome that resolves after
     // the user navigated away doesn't flash on the now-selected file.
@@ -761,10 +767,12 @@ export function NotebookSurface({
   }, [loadFile]);
 
   // The editor reports its current selection (or null when collapsed); float the
-  // "Send to chief" action over it.
+  // "Send to chief" action over it. Inert when sendToChief is absent (an off-root
+  // tile) — never tracks a selection, so the floating button can never render.
   const handleSelectionChange = useCallback((selection: LiveSelection | null) => {
+    if (!sendToChief) return;
     setChiefSel(selection);
-  }, []);
+  }, [sendToChief]);
 
   // Resolve an inline image's src for the live editor's image widget: strip any
   // #fragment/?query tail (notebookLinkPath — same rule brokenLinks uses), then read
@@ -799,7 +807,10 @@ export function NotebookSurface({
   const showBinaryPlaceholder = selectedPath !== null && selectedKind === 'binary';
   // The context rail (outline + backlinks) is a markdown-document affordance; a text
   // or binary file shows neither, so it keeps the two-pane layout (no empty rail).
-  const showRail = selectedKind === 'markdown' && !!note;
+  // Also gated on backlinksNotebook being provided: an off-root tile (NotebookTile)
+  // omits it, and the rail's Backlinks section has no other source, so the whole
+  // rail (Outline included) is withheld rather than showing a half-capable rail.
+  const showRail = selectedKind === 'markdown' && !!note && !!backlinksNotebook;
   // A single live save indicator (the error itself is surfaced by its own banner).
   const saveStatus = saveError
     ? null
@@ -1079,7 +1090,7 @@ export function NotebookSurface({
     </div>
   );
 
-  const floatingChief = chiefSel ? (
+  const floatingChief = chiefSel && sendToChief ? (
     <button
       type="button"
       className="notebook-browser-send-chief"

--- a/app/src/components/NotebookSurface.tsx
+++ b/app/src/components/NotebookSurface.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import FocusTrap from 'focus-trap-react';
 import type { FsEntry, FsExistsResult, FsReadAssetResult, FsReadResult, FsWriteResult, NotebookEntry, NotebookSendToChiefResult } from '../hooks/useDaemonSocket';
 import { useEscapeStack } from '../hooks/useEscapeStack';
@@ -94,9 +94,23 @@ const AUTOSAVE_DELAY_MS = 700;
 // Outcome of persisting the buffer. On-demand callers (navigate/close) MUST react
 // to 'conflict'/'error' — a CAS conflict cannot be silently dropped, or the user's
 // edits vanish behind a navigation/close without the banner ever showing.
-type PersistOutcome = 'saved' | 'conflict' | 'error' | 'noop';
+export type PersistOutcome = 'saved' | 'conflict' | 'error' | 'noop';
 
-export function NotebookSurface({
+// Imperative escape hatch for callers that need to flush the dirty buffer AHEAD
+// of a state transition they own (e.g. NotebookTile's root switcher, which must
+// persist the outgoing root's edit before swapping tileParams — see
+// WorkspaceDockTile.tsx). Everything else about persistence stays internal;
+// this is the one seam.
+export interface NotebookSurfaceHandle {
+  // Persists the dirty buffer (if any) against its synced base, via the same
+  // persist path the navigate/close flush already uses. Resolves 'noop' when
+  // there's nothing dirty (already in sync). On 'conflict' or 'error' the
+  // surface's own banner is already showing — the caller must abort whatever
+  // transition prompted the flush rather than proceeding past the failure.
+  flushPendingSave: () => Promise<PersistOutcome>;
+}
+
+export const NotebookSurface = forwardRef<NotebookSurfaceHandle, NotebookSurfaceProps>(function NotebookSurface({
   variant,
   active,
   initialPath,
@@ -112,7 +126,7 @@ export function NotebookSurface({
   changeSignal = 0,
   listFiles,
   chiefActive,
-}: NotebookSurfaceProps) {
+}: NotebookSurfaceProps, ref) {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [note, setNote] = useState<FsReadResult | null>(null);
   const [noteError, setNoteError] = useState<string | null>(null);
@@ -449,6 +463,10 @@ export function NotebookSurface({
   // Indirection so loadFile/requestClose (declared above the editing block) can invoke
   // the latest persist without a forward declaration.
   persistRef.current = persist;
+
+  useImperativeHandle(ref, () => ({
+    flushPendingSave: () => persistRef.current?.() ?? Promise.resolve('noop'),
+  }), []);
 
   // Discard the local buffer and reload the current on-disk version (the conflict
   // reconcile "reload from disk" path).
@@ -1170,7 +1188,7 @@ export function NotebookSurface({
       </FocusTrap>
     </div>
   );
-}
+});
 
 function basename(path: string): string {
   const name = path.slice(path.lastIndexOf('/') + 1);

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
@@ -231,6 +231,10 @@ describe('deriveTileTitle', () => {
     expect(deriveTileTitle({ type: 'tile', tileId: 'tile-x', tileKind: 'markdown' }, undefined)).toBe('markdown');
   });
 
+  it('falls back to "Editor" for a notebook tile with no open file yet', () => {
+    expect(deriveTileTitle({ type: 'tile', tileId: 'tile-notebook', tileKind: 'notebook' }, undefined)).toBe('Editor');
+  });
+
   it('uses the host as the title for a browser tile', () => {
     expect(deriveTileTitle({
       type: 'tile',

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.test.tsx
@@ -19,10 +19,24 @@ vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
 
 // The root picker's body (NotebookTile → NotebookSurface, CodeMirror-backed)
 // is exercised elsewhere (NotebookTile.test.tsx, NotebookBrowser.test.tsx);
-// stub it here so these tests exercise only the header switcher.
-vi.mock('../NotebookSurface', () => ({
-  NotebookSurface: () => <div data-testid="notebook-surface" />,
+// stub it here so these tests exercise only the header switcher. NotebookTile
+// forwards its ref straight through to NotebookSurface (see NotebookTile.tsx),
+// so this stub is also the fake ref handle the root-switcher flush-then-switch
+// tests below drive via notebookSurfaceStub.flushPendingSave.
+const notebookSurfaceStub = vi.hoisted(() => ({
+  flushPendingSave: vi.fn(async (): Promise<'saved' | 'conflict' | 'error' | 'noop'> => 'noop'),
 }));
+vi.mock('../NotebookSurface', async () => {
+  const { forwardRef, useImperativeHandle } = await import('react');
+  return {
+    NotebookSurface: forwardRef(function MockNotebookSurface(_props: unknown, ref: React.Ref<{ flushPendingSave: () => Promise<string> }>) {
+      useImperativeHandle(ref, () => ({
+        flushPendingSave: notebookSurfaceStub.flushPendingSave,
+      }), []);
+      return <div data-testid="notebook-surface" />;
+    }),
+  };
+});
 
 // WorkspaceDockTile reads effectiveNotebookRoot for its (notebook-only) root
 // switcher unconditionally via useNotebookSurfaceContext — the real app always
@@ -412,6 +426,8 @@ describe('WorkspaceDockTile browser integration', () => {
 describe('WorkspaceDockTile notebook root switcher', () => {
   beforeEach(() => {
     vi.mocked(open).mockReset();
+    notebookSurfaceStub.flushPendingSave.mockReset();
+    notebookSurfaceStub.flushPendingSave.mockResolvedValue('noop');
   });
 
   function renderNotebookTile(opts: {
@@ -479,10 +495,12 @@ describe('WorkspaceDockTile notebook root switcher', () => {
 
     fireEvent.change(picker(), { target: { value: '' } });
 
-    expect(onUpdateParams).toHaveBeenCalledWith(serializeNotebookTileParams({ root: undefined }));
+    // The handler now awaits flushPendingSave() (PR #588 second review round)
+    // before calling onUpdateParams, so the call lands after a microtask.
+    await waitFor(() => expect(onUpdateParams).toHaveBeenCalledWith(serializeNotebookTileParams({ root: undefined })));
   });
 
-  it('selecting the workspace directory writes it as the root without the open path', () => {
+  it('selecting the workspace directory writes it as the root without the open path', async () => {
     const { onUpdateParams } = renderNotebookTile({
       tileParams: serializeNotebookTileParams({ root: undefined, path: 'notes.md' }),
       workspaceDirectory: '/Users/victor/code/attn',
@@ -490,7 +508,9 @@ describe('WorkspaceDockTile notebook root switcher', () => {
 
     fireEvent.change(picker(), { target: { value: '/Users/victor/code/attn' } });
 
-    expect(onUpdateParams).toHaveBeenCalledWith(serializeNotebookTileParams({ root: '/Users/victor/code/attn' }));
+    // The handler now awaits flushPendingSave() (PR #588 second review round)
+    // before calling onUpdateParams, so the call lands after a microtask.
+    await waitFor(() => expect(onUpdateParams).toHaveBeenCalledWith(serializeNotebookTileParams({ root: '/Users/victor/code/attn' })));
   });
 
   it('Browse… persists the chosen directory as the root', async () => {
@@ -512,6 +532,56 @@ describe('WorkspaceDockTile notebook root switcher', () => {
     fireEvent.change(picker(), { target: { value: '__browse__' } });
 
     await waitFor(() => expect(open).toHaveBeenCalled());
+    expect(onUpdateParams).not.toHaveBeenCalled();
+  });
+
+  // PR #588 second review round: the header switcher must flush the outgoing
+  // root's dirty buffer (via NotebookTile's forwarded ref) BEFORE swapping
+  // tileParams, and abort the swap on a conflict/error rather than letting an
+  // edit vanish behind the root switch. NotebookSurface is stubbed above, and
+  // NotebookTile forwards its ref straight through to it, so
+  // notebookSurfaceStub.flushPendingSave is the fake ref handle here.
+  it('flushes the dirty buffer, then updates params, in that order, when flushPendingSave resolves "saved"', async () => {
+    const callOrder: string[] = [];
+    notebookSurfaceStub.flushPendingSave.mockImplementation(async () => {
+      callOrder.push('flush');
+      return 'saved';
+    });
+    const onUpdateParams = vi.fn(async (params: string) => {
+      callOrder.push(`params:${params}`);
+    });
+    renderNotebookTile({ workspaceDirectory: '/Users/victor/code/attn', onUpdateParams });
+
+    fireEvent.change(picker(), { target: { value: '/Users/victor/code/attn' } });
+
+    await waitFor(() => expect(onUpdateParams).toHaveBeenCalled());
+    expect(callOrder).toEqual([
+      'flush',
+      `params:${serializeNotebookTileParams({ root: '/Users/victor/code/attn' })}`,
+    ]);
+  });
+
+  it('never calls onUpdateParams when flushPendingSave resolves "conflict"', async () => {
+    notebookSurfaceStub.flushPendingSave.mockResolvedValue('conflict');
+    const { onUpdateParams } = renderNotebookTile({ workspaceDirectory: '/Users/victor/code/attn' });
+
+    fireEvent.change(picker(), { target: { value: '/Users/victor/code/attn' } });
+
+    await waitFor(() => expect(notebookSurfaceStub.flushPendingSave).toHaveBeenCalled());
+    // Give the (absent) params update a tick to fire before asserting it didn't.
+    await act(async () => { await Promise.resolve(); });
+    expect(onUpdateParams).not.toHaveBeenCalled();
+  });
+
+  it('never calls onUpdateParams via Browse… when flushPendingSave resolves "error"', async () => {
+    notebookSurfaceStub.flushPendingSave.mockResolvedValue('error');
+    vi.mocked(open).mockResolvedValue('/tmp/chosen-root');
+    const { onUpdateParams } = renderNotebookTile({ workspaceDirectory: '/Users/victor/code/attn' });
+
+    fireEvent.change(picker(), { target: { value: '__browse__' } });
+
+    await waitFor(() => expect(notebookSurfaceStub.flushPendingSave).toHaveBeenCalled());
+    await act(async () => { await Promise.resolve(); });
     expect(onUpdateParams).not.toHaveBeenCalled();
   });
 });

--- a/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
+++ b/app/src/components/SessionTerminalWorkspace/WorkspaceDockTile.tsx
@@ -18,6 +18,7 @@ import { getMarkdownAnnotationsTransport } from '../MarkdownReader/annotations/t
 import { useShortcut } from '../../shortcuts';
 import { useNotebookSurfaceContext } from '../../contexts/NotebookSurfaceContext';
 import { NotebookTile } from '../notebook/NotebookTile';
+import type { NotebookSurfaceHandle } from '../NotebookSurface';
 import './WorkspaceDockTile.css';
 
 // Link/image target resolution moved to the reader; re-exported here for
@@ -125,6 +126,11 @@ export function WorkspaceDockTile({
   const browserLabel = browserHostLabel(workspaceId, tile.tileId);
   const [browserAddress, setBrowserAddress] = useState(tile.tileParams || '');
   const pendingBrowserParamsRef = useRef<string | null>(null);
+  // Handle to the docked NotebookTile's NotebookSurface, so the root switcher
+  // (below) can flush a dirty buffer to the OLD root before swapping params —
+  // otherwise the 700ms autosave debounce can lose an in-flight edit across
+  // a root switch, or worse, persist it to the wrong root after remount.
+  const notebookSurfaceRef = useRef<NotebookSurfaceHandle | null>(null);
 
   // ---- markdown annotation send flow (PR6) ---------------------------------
   const isMarkdown = tile.tileKind === 'markdown';
@@ -326,9 +332,21 @@ export function WorkspaceDockTile({
   const handleRootChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
     const value = event.target.value;
     if (value === ROOT_BROWSE_VALUE) {
-      void open({ directory: true, multiple: false, title: 'Choose editor root' }).then((selected) => {
+      void open({ directory: true, multiple: false, title: 'Choose editor root' }).then(async (selected) => {
         if (!selected || typeof selected !== 'string') {
           return; // cancelled — the select is controlled by parsed params, snaps back on re-render
+        }
+        // Flush the outgoing root's dirty buffer BEFORE swapping params — the
+        // surface persists it to the OLD root via the same instance that has
+        // it open, since the param swap is what remounts NotebookSurface onto
+        // the new root (NotebookTile keys on `root`).
+        const outcome = notebookSurfaceRef.current ? await notebookSurfaceRef.current.flushPendingSave() : 'noop';
+        if (outcome === 'conflict' || outcome === 'error') {
+          // The surface's own conflict/save-error banner is already visible;
+          // the controlled select snaps back on re-render since params never
+          // changed. Aborting here is what keeps the edit from vanishing
+          // behind a root swap.
+          return;
         }
         void Promise.resolve(onUpdateParams?.(serializeNotebookTileParams({ root: selected }))).catch((error) => {
           console.warn('[WorkspaceDockTile] Failed to persist browsed notebook root:', error);
@@ -338,12 +356,19 @@ export function WorkspaceDockTile({
       });
       return;
     }
-    // A chosen dir (or any non-browse option): path is deliberately omitted —
-    // the open file is meaningless under a different root, so the tile drops
-    // back to its tree view.
-    void Promise.resolve(onUpdateParams?.(serializeNotebookTileParams({ root: value || undefined }))).catch((error) => {
-      console.warn('[WorkspaceDockTile] Failed to persist notebook root:', error);
-    });
+    void (async () => {
+      // Same flush-then-switch rule as the browse-dialog branch above.
+      const outcome = notebookSurfaceRef.current ? await notebookSurfaceRef.current.flushPendingSave() : 'noop';
+      if (outcome === 'conflict' || outcome === 'error') {
+        return;
+      }
+      // A chosen dir (or any non-browse option): path is deliberately omitted —
+      // the open file is meaningless under a different root, so the tile drops
+      // back to its tree view.
+      void Promise.resolve(onUpdateParams?.(serializeNotebookTileParams({ root: value || undefined }))).catch((error) => {
+        console.warn('[WorkspaceDockTile] Failed to persist notebook root:', error);
+      });
+    })();
   }, [onUpdateParams]);
 
   const reloadBrowser = () => {
@@ -554,6 +579,7 @@ export function WorkspaceDockTile({
             const { root, path: openPath } = parseNotebookTileParams(tile.tileParams);
             return (
               <NotebookTile
+                ref={notebookSurfaceRef}
                 initialPath={openPath || null}
                 root={root}
                 onOpenFile={(openedPath) => {

--- a/app/src/components/notebook/NotebookTile.test.tsx
+++ b/app/src/components/notebook/NotebookTile.test.tsx
@@ -11,9 +11,13 @@ import type { FsWatchResult } from '../../hooks/useDaemonSocket';
 // NotebookSurface itself (CodeMirror-backed tree/editor/finder) is covered by
 // NotebookBrowser.test.tsx; here we only need to observe what NotebookTile
 // hands it, so stub it to a thin recorder.
-const surfaceCalls = vi.hoisted(() => [] as Array<{ changeSignal?: number }>);
+const surfaceCalls = vi.hoisted(() => [] as Array<{
+  changeSignal?: number;
+  backlinksNotebook?: unknown;
+  sendToChief?: unknown;
+}>);
 vi.mock('../NotebookSurface', () => ({
-  NotebookSurface: (props: { changeSignal?: number }) => {
+  NotebookSurface: (props: { changeSignal?: number; backlinksNotebook?: unknown; sendToChief?: unknown }) => {
     surfaceCalls.push(props);
     return <div data-testid="notebook-surface" data-change-signal={props.changeSignal} />;
   },
@@ -244,5 +248,49 @@ describe('NotebookTile root-bound daemon + watch lifecycle', () => {
     await waitFor(() => expect(warnSpy).toHaveBeenCalled());
     expect(warnSpy.mock.calls[0][0]).toMatch(/^\[NotebookTile\]/);
     expect(surfaceCalls.length).toBeGreaterThan(0);
+  });
+});
+
+describe('NotebookTile off-root capability gating', () => {
+  it('omits backlinksNotebook and sendToChief for a tile bound to a root other than the effective notebook root', async () => {
+    const harness = makeHarness({ effectiveNotebookRoot: '/notebook-root' });
+    render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath="a.md" root="/repo" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+
+    await waitFor(() => expect(surfaceCalls.length).toBeGreaterThan(0));
+    const lastCall = surfaceCalls[surfaceCalls.length - 1];
+    expect(lastCall.backlinksNotebook).toBeUndefined();
+    expect(lastCall.sendToChief).toBeUndefined();
+  });
+
+  it('passes backlinksNotebook and sendToChief through for a rootless (notebook-rooted) tile', async () => {
+    const harness = makeHarness({ effectiveNotebookRoot: '/notebook-root' });
+    render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath="a.md" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+
+    await waitFor(() => expect(surfaceCalls.length).toBeGreaterThan(0));
+    const lastCall = surfaceCalls[surfaceCalls.length - 1];
+    expect(lastCall.backlinksNotebook).toBeDefined();
+    expect(lastCall.sendToChief).toBeDefined();
+  });
+
+  it('passes backlinksNotebook and sendToChief through for a tile explicitly bound to the effective notebook root', async () => {
+    const harness = makeHarness({ effectiveNotebookRoot: '/notebook-root' });
+    render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath="a.md" root="/notebook-root" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+
+    await waitFor(() => expect(surfaceCalls.length).toBeGreaterThan(0));
+    const lastCall = surfaceCalls[surfaceCalls.length - 1];
+    expect(lastCall.backlinksNotebook).toBeDefined();
+    expect(lastCall.sendToChief).toBeDefined();
   });
 });

--- a/app/src/components/notebook/NotebookTile.test.tsx
+++ b/app/src/components/notebook/NotebookTile.test.tsx
@@ -1,4 +1,5 @@
 import { render, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NotebookTile } from './NotebookTile';
 import {
@@ -16,9 +17,20 @@ const surfaceCalls = vi.hoisted(() => [] as Array<{
   backlinksNotebook?: unknown;
   sendToChief?: unknown;
 }>);
+// Records one entry per NotebookSurface mount (not per render): a plain push
+// in the render body would double-count every re-render caused by the
+// resolvedRoot/daemon state updates already exercised above, so remount
+// detection needs its own list driven by React's own mount lifecycle
+// (an empty-deps useEffect), which only re-fires when React tears the
+// element down and builds a fresh instance — exactly what `key={root}`
+// on NotebookSurface in NotebookTile.tsx is meant to force on root change.
+const surfaceMounts = vi.hoisted(() => [] as number[]);
 vi.mock('../NotebookSurface', () => ({
   NotebookSurface: (props: { changeSignal?: number; backlinksNotebook?: unknown; sendToChief?: unknown }) => {
     surfaceCalls.push(props);
+    useEffect(() => {
+      surfaceMounts.push(surfaceMounts.length);
+    }, []);
     return <div data-testid="notebook-surface" data-change-signal={props.changeSignal} />;
   },
 }));
@@ -77,6 +89,7 @@ function makeHarness(opts: {
 
 afterEach(() => {
   surfaceCalls.length = 0;
+  surfaceMounts.length = 0;
   vi.restoreAllMocks();
 });
 
@@ -292,5 +305,80 @@ describe('NotebookTile off-root capability gating', () => {
     const lastCall = surfaceCalls[surfaceCalls.length - 1];
     expect(lastCall.backlinksNotebook).toBeDefined();
     expect(lastCall.sendToChief).toBeDefined();
+  });
+});
+
+describe('NotebookTile remounts NotebookSurface on root change', () => {
+  // Regression coverage for a wrong-root-write risk flagged in PR #588 review:
+  // NotebookSurface's init effect deps are `[active]` only, so switching an
+  // already-mounted tile's root via the header switcher previously left
+  // selectedPath/note/draft state carrying over from the old root while the
+  // daemon rebinds underneath it — the next autosave could write the old
+  // document's buffer to the same relative path under the NEW root.
+  // NotebookTile.tsx now keys NotebookSurface on the raw `root` prop so a
+  // root change forces React to tear down and rebuild the surface instance
+  // (fresh selection/note/draft, fresh init effect). These tests assert the
+  // remount actually happens (and doesn't spuriously happen) rather than
+  // just asserting the key prop's value.
+
+  it('remounts NotebookSurface when root changes', async () => {
+    const harness = makeHarness({ effectiveNotebookRoot: '/notebook-root' });
+    const { rerender } = render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath="a.md" root="/a" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+    await waitFor(() => expect(surfaceMounts.length).toBe(1));
+
+    rerender(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath="a.md" root="/b" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+
+    await waitFor(() => expect(surfaceMounts.length).toBe(2));
+  });
+
+  it('does not remount NotebookSurface on a rerender with the same root', async () => {
+    const harness = makeHarness({ effectiveNotebookRoot: '/notebook-root' });
+    const { rerender } = render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath="a.md" root="/a" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+    await waitFor(() => expect(surfaceMounts.length).toBe(1));
+
+    // Rerender with an unrelated prop change (onOpenFile identity) but the
+    // same root: this must not remount, guarding against keying on
+    // something that isn't stable across ordinary re-renders.
+    rerender(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath="a.md" root="/a" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+
+    // Give any spurious effect a tick to fire before asserting it didn't.
+    await waitFor(() => expect(surfaceCalls.length).toBeGreaterThan(1));
+    expect(surfaceMounts.length).toBe(1);
+  });
+
+  it('does not remount when fs_watch resolves the root to a normalized form (e.g. /tmp -> /private/tmp)', async () => {
+    const harness = makeHarness({
+      effectiveNotebookRoot: '/notebook-root',
+      watchResolvesTo: (root) => root.replace(/^\/tmp\//, '/private/tmp/'),
+    });
+    render(
+      <NotebookSurfaceProvider value={harness.value}>
+        <NotebookTile initialPath="a.md" root="/tmp/x" onOpenFile={() => {}} />
+      </NotebookSurfaceProvider>,
+    );
+    await waitFor(() => expect(surfaceMounts.length).toBe(1));
+
+    // The daemon rebuild after resolution re-renders the (same-keyed)
+    // element with a new daemon instance — that's a normal re-render, not
+    // a remount, so surfaceMounts must stay at 1.
+    await waitFor(() => expect(harness.makeDaemon).toHaveBeenCalledWith('/private/tmp/x'));
+    await waitFor(() => expect(surfaceCalls.length).toBeGreaterThan(1));
+    expect(surfaceMounts.length).toBe(1);
   });
 });

--- a/app/src/components/notebook/NotebookTile.tsx
+++ b/app/src/components/notebook/NotebookTile.tsx
@@ -24,6 +24,12 @@ export function NotebookTile({
 }) {
   const { makeDaemon, effectiveNotebookRoot, sendFsWatch, sendFsUnwatch, connectionGeneration } = useNotebookSurfaceContext();
 
+  // Off-root: this tile is pinned to a filesystem root other than the notebook
+  // storage root. Notebook-only affordances (backlinks, send-to-chief) are
+  // gated off below — mirrors the same root-vs-notebook-root comparison the
+  // fs_watch effect uses (line ~46) so on-root/off-root agree everywhere.
+  const offRoot = !!root && root !== effectiveNotebookRoot;
+
   // fs_watch_result may normalize `root` (e.g. macOS resolving /tmp to
   // /private/tmp) — and fs_changed events for this subscription carry that
   // resolved form, not the raw prop. Once resolution lands, both the fs_*
@@ -97,8 +103,8 @@ export function NotebookTile({
       writeFile={daemon.writeFile}
       existsFile={daemon.existsFile}
       readAsset={daemon.readAsset}
-      backlinksNotebook={daemon.backlinksNotebook}
-      sendToChief={daemon.sendToChief}
+      backlinksNotebook={offRoot ? undefined : daemon.backlinksNotebook}
+      sendToChief={offRoot ? undefined : daemon.sendToChief}
       changeSignal={daemon.changeSignal}
       listFiles={daemon.listFiles}
     />

--- a/app/src/components/notebook/NotebookTile.tsx
+++ b/app/src/components/notebook/NotebookTile.tsx
@@ -94,6 +94,19 @@ export function NotebookTile({
 
   return (
     <NotebookSurface
+      // Remount on root change: NotebookSurface's init effect only depends on
+      // `active`, so without a key change, switching roots via the header
+      // switcher leaves selectedPath/note/draft carrying over from the old
+      // root while the daemon rebinds underneath — the next autosave can then
+      // write the old document's buffer to the same relative path under the
+      // NEW root. Keying on `root` forces a fresh mount (fresh state, fresh
+      // init effect) on every root change.
+      //
+      // This is the RAW `root` prop, not effectiveRoot/resolvedRoot above:
+      // fs_watch_result can normalize the path (e.g. /tmp -> /private/tmp
+      // on macOS), and that normalization must never itself trigger a
+      // remount — only a real root change (a new raw prop value) should.
+      key={root ?? ''}
       variant="tile"
       active
       initialPath={initialPath}

--- a/app/src/components/notebook/NotebookTile.tsx
+++ b/app/src/components/notebook/NotebookTile.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
 import { useNotebookSurfaceContext } from '../../contexts/NotebookSurfaceContext';
-import { NotebookSurface } from '../NotebookSurface';
+import { NotebookSurface, type NotebookSurfaceHandle } from '../NotebookSurface';
 
 // NotebookTile is the in-workspace shape of the Notebook: a `tile`-variant
 // NotebookSurface wired to the daemon via context. It reopens to `initialPath`
@@ -13,15 +13,15 @@ import { NotebookSurface } from '../NotebookSurface';
 // the daemon unconditionally, but nothing else is, so a tile is the one
 // deciding when it needs live updates for its root and dropping that
 // subscription when it stops needing them.
-export function NotebookTile({
-  initialPath,
-  root,
-  onOpenFile,
-}: {
+export const NotebookTile = forwardRef<NotebookSurfaceHandle, {
   initialPath: string | null;
   root?: string;
   onOpenFile: (path: string) => void;
-}) {
+}>(function NotebookTile({
+  initialPath,
+  root,
+  onOpenFile,
+}, ref) {
   const { makeDaemon, effectiveNotebookRoot, sendFsWatch, sendFsUnwatch, connectionGeneration } = useNotebookSurfaceContext();
 
   // Off-root: this tile is pinned to a filesystem root other than the notebook
@@ -106,7 +106,11 @@ export function NotebookTile({
       // fs_watch_result can normalize the path (e.g. /tmp -> /private/tmp
       // on macOS), and that normalization must never itself trigger a
       // remount — only a real root change (a new raw prop value) should.
+      // The root switcher (WorkspaceDockTile) awaits flushPendingSave()
+      // BEFORE updating params, so the old instance persists to the old
+      // root before this key ever changes.
       key={root ?? ''}
+      ref={ref}
       variant="tile"
       active
       initialPath={initialPath}
@@ -122,4 +126,4 @@ export function NotebookTile({
       listFiles={daemon.listFiles}
     />
   );
-}
+});

--- a/app/src/contexts/NotebookSurfaceContext.tsx
+++ b/app/src/contexts/NotebookSurfaceContext.tsx
@@ -43,9 +43,10 @@ export interface NotebookSurfaceDaemon {
 // they stay bound to the notebook root exactly as before regardless of the
 // `root` argument here. Backlinks only exist between notebook notes and "send
 // to chief" appends to the notebook inbox, so widening either to an arbitrary
-// filesystem root is out of scope and forbidden; UI for them on a
-// non-notebook-rooted tile is gated off separately (see the arbitrary-roots
-// plan's authorization-boundary note). listFiles is DIFFERENT: it now sources
+// filesystem root is out of scope and forbidden; NotebookTile omits both
+// capabilities (passes undefined) when its tile is bound to an off-root
+// (non-notebook) root, so NotebookSurface never renders their UI there (see
+// the arbitrary-roots plan's authorization-boundary note). listFiles is DIFFERENT: it now sources
 // fs_index, which the daemon resolves through the same root-scoped chokepoint
 // as every other fs_* command, so it follows `root` like listDir/readFile/etc.
 export type MakeNotebookSurfaceDaemon = (root?: string) => NotebookSurfaceDaemon;

--- a/app/src/shortcuts/metadata.ts
+++ b/app/src/shortcuts/metadata.ts
@@ -101,7 +101,7 @@ export const SHORTCUT_META: Record<ShortcutId, ShortcutMeta> = {
   'ui.increaseFontSize': { label: 'Increase font size', category: 'app' },
   'ui.decreaseFontSize': { label: 'Decrease font size', category: 'app' },
   'ui.resetFontSize': { label: 'Reset font size', category: 'app' },
-  'notebook.openTile': { label: 'Open Notebook tile', category: 'app' },
+  'notebook.openTile': { label: 'Open Editor tile', category: 'app' },
   'notebook.openFullscreen': { label: 'Open Notebook fullscreen', category: 'app' },
   'board.open': { label: 'Open Tickets board', category: 'app' },
   'app.quit': { label: 'Quit attn', category: 'app', protected: true },

--- a/app/src/utils/tilePresentation.ts
+++ b/app/src/utils/tilePresentation.ts
@@ -56,7 +56,7 @@ export function deriveTileTitle(tile: TileLeaf, content?: TileContentState): str
   // root-bound tile persists — parse either way to reach the open path.
   if (tile.tileKind === 'notebook') {
     const { path } = parseNotebookTileParams(tile.tileParams);
-    return path ? tilePathBasename(path) : 'Notebook';
+    return path ? tilePathBasename(path) : 'Editor';
   }
   const path = content?.path || tile.tileParams || '';
   return path ? tilePathBasename(path) : tile.tileKind;

--- a/docs/plans/2026-07-18-db-loss-mitigation.md
+++ b/docs/plans/2026-07-18-db-loss-mitigation.md
@@ -30,17 +30,20 @@ safety net.
 
 Follow-ups (rotation awareness — no infinite copies anywhere):
 
-- [ ] Cap pre-migration snapshots too. They are exempt from the keep-12 prune
-      today, which is unbounded over time. Prune to the last **5**
-      pre-migration snapshots (they only accrue one per migration, but
+- [x] Cap pre-migration snapshots too (#582). They are exempt from the
+      keep-12 prune today, which is unbounded over time. Prune to the last
+      **5** pre-migration snapshots (they only accrue one per migration, but
       "exempt" must not mean "immortal").
-- [ ] Restore path: `attn db restore <backup|latest>` — stop-daemon-safe copy
-      of a snapshot back into place (refuses while a daemon holds the DB), so
-      recovery is one command instead of an incident script.
-- [ ] Surfacing: expose last-successful-backup age (settings/status payload).
-      A backup loop that silently fails for weeks is a safety net that isn't
-      there; the app can show a warning when the newest snapshot is stale
-      (> 24h).
+- [x] Restore path (#582): `attn db restore <backup|latest>` — stop-daemon-safe
+      copy of a snapshot back into place (refuses while a daemon holds the
+      DB), so recovery is one command instead of an incident script.
+- [x] Surfacing (#582): expose last-successful-backup age (settings/status
+      payload). A backup loop that silently fails for weeks is a safety net
+      that isn't there; the app can show a warning when the newest snapshot
+      is stale (> 24h).
+
+pid-lock hardening follow-ups (orphan unlink-race regression, restore-lock
+error classification) landed via #586/#587.
 
 ## 2. Tooling: Tests Can Never Touch The Real Data Dir
 

--- a/docs/plans/2026-07-18-editor-arbitrary-roots.md
+++ b/docs/plans/2026-07-18-editor-arbitrary-roots.md
@@ -60,22 +60,26 @@ directory. The storage concept (keeper, journal, knowledge base) stays bound to
 
 ## PRs
 
-- [ ] PR1 daemon: `root` on fs_* + fs_read_asset + `fs_changed`, per-root store
-      cache, root validation, protocol bump + auth gate: explicit roots
-      require the authenticated app client (isTrustedAppClient), with
-      negative protocol tests
-- [ ] PR2 daemon: per-root watcher registry, generalized trackable,
+- [x] PR1 daemon (#577): `root` on fs_* + fs_read_asset + `fs_changed`,
+      per-root store cache, root validation, protocol bump + auth gate:
+      explicit roots require the authenticated app client
+      (isTrustedAppClient), with negative protocol tests
+- [x] PR2 daemon (#579): per-root watcher registry, generalized trackable,
       `fs_watch`/`fs_unwatch` (fs_watch inherits the root auth gate via
       resolveFsRoot + its own denial test)
-- [ ] PR3 daemon: `fs_index` bounded recursive file index (fs_index inherits
-      the root auth gate + denial test)
-- [ ] PR4 frontend: tile root plumbing (tileParams `{root, path}` + string
-      back-compat), root-aware fs calls, `fs_changed` root filtering
-- [ ] PR5 frontend: workspace-directory default for ⌘⌥N, header root switcher,
-      finder on `fs_index`
+- [x] PR3 daemon (#580): `fs_index` bounded recursive file index (fs_index
+      inherits the root auth gate + denial test)
+- [x] PR4 frontend (#583): tile root plumbing (tileParams `{root, path}` +
+      string back-compat), root-aware fs calls, `fs_changed` root filtering
+- [x] PR5 frontend (#585): workspace-directory default for ⌘⌥N, header root
+      switcher, finder on `fs_index`
 - [ ] PR6 frontend: off-root affordance gating, Editor labels + settings copy,
       changelog, packaged-app bridge-only scenario (editor over a workspace
       root)
+- [ ] PR7 daemon+frontend: endpoint_id on protocol.Workspace (populated for
+      hub remote workspaces) so localWorkspaceDirectory can restore the
+      workspace-dir default for sessionless local pinned workspaces
+      (fast-follow committed in PR #585 review)
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

PR6 of the editor-arbitrary-roots epic (`docs/plans/2026-07-18-editor-arbitrary-roots.md`). Frontend only.

- **Off-root affordance gating**: `NotebookSurface`'s `backlinksNotebook`/`sendToChief` props become optional. `NotebookTile` computes off-root the same way its `fs_watch` effect already does (`root !== effectiveNotebookRoot`) and omits both for off-root tiles, hiding the backlinks/outline rail and the "Send to chief" button off-root. Root-scoped `listFiles` (`fs_index`) is unaffected.
- **Editor labels on the tile surface only**: fallback tile title (`Notebook` → `Editor`), the `notebook.openTile` shortcut label, the App.tsx action-menu/palette entry, and the notebook-tile-finder scenario assertion. Fullscreen labels, storage/settings copy, Sidebar, and NotebookBrowser are unchanged.
- **CHANGELOG.md**: dated entry summarizing the epic's net user-visible outcome so far.
- **New packaged-app scenario**: `scenario-editor-workspace-root.mjs` (registered in `package.json` + `scenarioCatalog.mjs`), docking an off-root editor tile against a session whose cwd is a temp directory, asserting root-scoped `fs_read` works and the backlinks rail never renders, plus a positive-control tile pinned to the Notebook root where the rail does render.
- Plan-doc updates (PR1-5 marked done, PR7 fast-follow noted; unrelated db-loss-mitigation follow-ups marked done per coordinator note).

## Verification

- Live packaged-app verification on a throwaway profile: off-root rail withheld, Notebook-root positive control rendered the rail, root-scoped `fs_read` served real file content.
- `vitest`: 173 files, 1830 passed.
- `tsc`: clean.

This diff was already reviewed line-by-line and approved by the coordinating session prior to opening this PR.

https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT