### PR TITLE
feat(session): answer questions from prior sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ### Added
 - **Black or stuck UI failures now leave useful evidence on disk.** Agent switches capture delayed app-shell health snapshots alongside the existing terminal renderer diagnostics, including frontend crashes, event-loop stalls, and native browser visibility. A React render failure now shows a persistent error screen instead of leaving an unexplained black window.
+- **Ask a bounded question about another Codex session.** `attn session instructions <session-id> --question "..."` reads that session's conversation and returns a concise Luna answer with exact supporting excerpts, transcript identity, and a fingerprint. It fails closed when the transcript, model response, or evidence cannot be verified.
 
 ## [2026-07-15]
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '170';
+export const PROTOCOL_VERSION = '171';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PR, PRActionResultMessage, PresentAnnotation, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, PRRole, PRsUpdatedMessage, PRVisitedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizedMessage, PtyResizeMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionsUpdatedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SettingsUpdatedMessage, SetWorkspaceRankMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketsUpdatedMessage, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -45,6 +45,7 @@
 //   const endpointsUpdatedMessage = Convert.toEndpointsUpdatedMessage(json);
 //   const ensureRepoMessage = Convert.toEnsureRepoMessage(json);
 //   const ensureRepoResultMessage = Convert.toEnsureRepoResultMessage(json);
+//   const evidenceExcerpt = Convert.toEvidenceExcerpt(json);
 //   const fetchPRDetailsMessage = Convert.toFetchPRDetailsMessage(json);
 //   const fetchPRDetailsResultMessage = Convert.toFetchPRDetailsResultMessage(json);
 //   const fetchRemotesMessage = Convert.toFetchRemotesMessage(json);
@@ -159,20 +160,18 @@
 //   const openBrowserMessage = Convert.toOpenBrowserMessage(json);
 //   const openMarkdownMessage = Convert.toOpenMarkdownMessage(json);
 //   const openMarkdownResultMessage = Convert.toOpenMarkdownResultMessage(json);
+//   const pR = Convert.toPR(json);
+//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
+//   const pRRole = Convert.toPRRole(json);
+//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
+//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
 //   const pathInspection = Convert.toPathInspection(json);
 //   const pinWorkspaceMessage = Convert.toPinWorkspaceMessage(json);
 //   const pluginActionResultMessage = Convert.toPluginActionResultMessage(json);
 //   const pluginInfo = Convert.toPluginInfo(json);
 //   const pluginIssue = Convert.toPluginIssue(json);
 //   const pluginsUpdatedMessage = Convert.toPluginsUpdatedMessage(json);
-//   const pR = Convert.toPR(json);
-//   const pRActionResultMessage = Convert.toPRActionResultMessage(json);
 //   const presentAnnotation = Convert.toPresentAnnotation(json);
-//   const presentation = Convert.toPresentation(json);
-//   const presentationAddedMessage = Convert.toPresentationAddedMessage(json);
-//   const presentationComment = Convert.toPresentationComment(json);
-//   const presentationRound = Convert.toPresentationRound(json);
-//   const presentationUpdatedMessage = Convert.toPresentationUpdatedMessage(json);
 //   const presentCloseMessage = Convert.toPresentCloseMessage(json);
 //   const presentCloseResultMessage = Convert.toPresentCloseResultMessage(json);
 //   const presentCommentInput = Convert.toPresentCommentInput(json);
@@ -184,14 +183,16 @@
 //   const presentOpenResult = Convert.toPresentOpenResult(json);
 //   const presentSubmitRoundMessage = Convert.toPresentSubmitRoundMessage(json);
 //   const presentSubmitRoundResultMessage = Convert.toPresentSubmitRoundResultMessage(json);
-//   const pRRole = Convert.toPRRole(json);
-//   const pRsUpdatedMessage = Convert.toPRsUpdatedMessage(json);
-//   const pRVisitedMessage = Convert.toPRVisitedMessage(json);
+//   const presentation = Convert.toPresentation(json);
+//   const presentationAddedMessage = Convert.toPresentationAddedMessage(json);
+//   const presentationComment = Convert.toPresentationComment(json);
+//   const presentationRound = Convert.toPresentationRound(json);
+//   const presentationUpdatedMessage = Convert.toPresentationUpdatedMessage(json);
 //   const ptyDesyncMessage = Convert.toPtyDesyncMessage(json);
 //   const ptyInputMessage = Convert.toPtyInputMessage(json);
 //   const ptyOutputMessage = Convert.toPtyOutputMessage(json);
-//   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
 //   const ptyResizeMessage = Convert.toPtyResizeMessage(json);
+//   const ptyResizedMessage = Convert.toPtyResizedMessage(json);
 //   const queryAuthorsMessage = Convert.toQueryAuthorsMessage(json);
 //   const queryMessage = Convert.toQueryMessage(json);
 //   const queryPRsMessage = Convert.toQueryPRsMessage(json);
@@ -217,14 +218,16 @@
 //   const runtimeRespawnedMessage = Convert.toRuntimeRespawnedMessage(json);
 //   const session = Convert.toSession(json);
 //   const sessionExitedMessage = Convert.toSessionExitedMessage(json);
+//   const sessionInstructionsMessage = Convert.toSessionInstructionsMessage(json);
+//   const sessionInstructionsResult = Convert.toSessionInstructionsResult(json);
 //   const sessionRegisteredMessage = Convert.toSessionRegisteredMessage(json);
 //   const sessionSelectedMessage = Convert.toSessionSelectedMessage(json);
 //   const sessionState = Convert.toSessionState(json);
 //   const sessionStateChangedMessage = Convert.toSessionStateChangedMessage(json);
-//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const sessionTodosUpdatedMessage = Convert.toSessionTodosUpdatedMessage(json);
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
 //   const sessionVisualizedMessage = Convert.toSessionVisualizedMessage(json);
+//   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
 //   const setChiefOfStaffMessage = Convert.toSetChiefOfStaffMessage(json);
 //   const setEndpointRemoteWebMessage = Convert.toSetEndpointRemoteWebMessage(json);
 //   const setPluginPriorityMessage = Convert.toSetPluginPriorityMessage(json);
@@ -232,8 +235,8 @@
 //   const setSettingMessage = Convert.toSetSettingMessage(json);
 //   const setTerminalThemeMessage = Convert.toSetTerminalThemeMessage(json);
 //   const setTicketStatusMessage = Convert.toSetTicketStatusMessage(json);
-//   const settingsUpdatedMessage = Convert.toSettingsUpdatedMessage(json);
 //   const setWorkspaceRankMessage = Convert.toSetWorkspaceRankMessage(json);
+//   const settingsUpdatedMessage = Convert.toSettingsUpdatedMessage(json);
 //   const spawnResultMessage = Convert.toSpawnResultMessage(json);
 //   const spawnSessionMessage = Convert.toSpawnSessionMessage(json);
 //   const stateMessage = Convert.toStateMessage(json);
@@ -277,11 +280,11 @@
 //   const ticketStatusResult = Convert.toTicketStatusResult(json);
 //   const ticketSubscribeMessage = Convert.toTicketSubscribeMessage(json);
 //   const ticketSubscribeResult = Convert.toTicketSubscribeResult(json);
-//   const ticketsUpdatedMessage = Convert.toTicketsUpdatedMessage(json);
 //   const ticketTakeMessage = Convert.toTicketTakeMessage(json);
 //   const ticketTakeResult = Convert.toTicketTakeResult(json);
 //   const ticketUnsubscribeMessage = Convert.toTicketUnsubscribeMessage(json);
 //   const ticketUnsubscribeResult = Convert.toTicketUnsubscribeResult(json);
+//   const ticketsUpdatedMessage = Convert.toTicketsUpdatedMessage(json);
 //   const todosMessage = Convert.toTodosMessage(json);
 //   const triggerNudgeMessage = Convert.toTriggerNudgeMessage(json);
 //   const uninstallPluginMessage = Convert.toUninstallPluginMessage(json);
@@ -334,8 +337,8 @@
 //   const workspaceLayoutSetSplitRatioMessage = Convert.toWorkspaceLayoutSetSplitRatioMessage(json);
 //   const workspaceLayoutSplitDirection = Convert.toWorkspaceLayoutSplitDirection(json);
 //   const workspaceLayoutUndockTileMessage = Convert.toWorkspaceLayoutUndockTileMessage(json);
-//   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
 //   const workspaceLayoutUpdateTileMessage = Convert.toWorkspaceLayoutUpdateTileMessage(json);
+//   const workspaceLayoutUpdatedMessage = Convert.toWorkspaceLayoutUpdatedMessage(json);
 //   const workspaceRegisteredMessage = Convert.toWorkspaceRegisteredMessage(json);
 //   const workspaceSelectedMessage = Convert.toWorkspaceSelectedMessage(json);
 //   const workspaceStateChangedMessage = Convert.toWorkspaceStateChangedMessage(json);
@@ -966,6 +969,14 @@ export enum EnsureRepoResultMessageEvent {
     EnsureRepoResult = "ensure_repo_result",
 }
 
+export interface EvidenceExcerpt {
+    author:     string;
+    quote:      string;
+    timestamp?: string;
+    turn_id:    string;
+    [property: string]: any;
+}
+
 export interface FetchPRDetailsMessage {
     cmd: FetchPRDetailsMessageCmd;
     id:  string;
@@ -1518,7 +1529,7 @@ export interface PresentationElement {
 
 export interface Round {
     base_sha:        string;
-    changed_files?:  ChangedFileElement[];
+    changed_files?:  FileElement[];
     created_at:      string;
     head_sha:        string;
     id:              string;
@@ -1530,7 +1541,7 @@ export interface Round {
     [property: string]: any;
 }
 
-export interface ChangedFileElement {
+export interface FileElement {
     additions?:   number;
     annotations?: AnnotationElement[];
     deletions?:   number;
@@ -1547,7 +1558,7 @@ export interface AnnotationElement {
 }
 
 export interface Manifest {
-    files:    ChangedFileElement[];
+    files:    FileElement[];
     skip:     string[];
     summary?: string;
     title:    string;
@@ -2641,6 +2652,69 @@ export enum OpenMarkdownResultMessageEvent {
     OpenMarkdownResult = "open_markdown_result",
 }
 
+export interface PR {
+    approved_by_me:         boolean;
+    author:                 string;
+    ci_status?:             string;
+    comment_count?:         number;
+    details_fetched:        boolean;
+    details_fetched_at?:    string;
+    has_new_changes:        boolean;
+    head_branch?:           string;
+    head_sha?:              string;
+    heat_state?:            HeatState;
+    host:                   string;
+    id:                     string;
+    last_heat_activity_at?: string;
+    last_polled:            string;
+    last_updated:           string;
+    mergeable?:             boolean;
+    mergeable_state?:       string;
+    muted:                  boolean;
+    number:                 number;
+    reason:                 string;
+    repo:                   string;
+    review_status?:         string;
+    role:                   PRRole;
+    state:                  string;
+    title:                  string;
+    url:                    string;
+    [property: string]: any;
+}
+
+export interface PRActionResultMessage {
+    action:  string;
+    error?:  string;
+    event:   PRActionResultMessageEvent;
+    id:      string;
+    success: boolean;
+    [property: string]: any;
+}
+
+export enum PRActionResultMessageEvent {
+    PRActionResult = "pr_action_result",
+}
+
+export interface PRVisitedMessage {
+    cmd: PRVisitedMessageCmd;
+    id:  string;
+    [property: string]: any;
+}
+
+export enum PRVisitedMessageCmd {
+    PRVisited = "pr_visited",
+}
+
+export interface PRsUpdatedMessage {
+    event: PRsUpdatedMessageEvent;
+    prs?:  PRElement[];
+    [property: string]: any;
+}
+
+export enum PRsUpdatedMessageEvent {
+    PrsUpdated = "prs_updated",
+}
+
 export interface PathInspection {
     exists:        boolean;
     home_path?:    string;
@@ -2744,115 +2818,11 @@ export interface PluginElement {
     [property: string]: any;
 }
 
-export interface PR {
-    approved_by_me:         boolean;
-    author:                 string;
-    ci_status?:             string;
-    comment_count?:         number;
-    details_fetched:        boolean;
-    details_fetched_at?:    string;
-    has_new_changes:        boolean;
-    head_branch?:           string;
-    head_sha?:              string;
-    heat_state?:            HeatState;
-    host:                   string;
-    id:                     string;
-    last_heat_activity_at?: string;
-    last_polled:            string;
-    last_updated:           string;
-    mergeable?:             boolean;
-    mergeable_state?:       string;
-    muted:                  boolean;
-    number:                 number;
-    reason:                 string;
-    repo:                   string;
-    review_status?:         string;
-    role:                   PRRole;
-    state:                  string;
-    title:                  string;
-    url:                    string;
-    [property: string]: any;
-}
-
-export interface PRActionResultMessage {
-    action:  string;
-    error?:  string;
-    event:   PRActionResultMessageEvent;
-    id:      string;
-    success: boolean;
-    [property: string]: any;
-}
-
-export enum PRActionResultMessageEvent {
-    PRActionResult = "pr_action_result",
-}
-
 export interface PresentAnnotation {
     comments:   string[];
     line_end:   number;
     line_start: number;
     [property: string]: any;
-}
-
-export interface Presentation {
-    created_at:             string;
-    id:                     string;
-    kind:                   string;
-    latest_round_seq:       number;
-    latest_round_submitted: boolean;
-    repo_path:              string;
-    session_id:             string;
-    status:                 string;
-    ticket_id?:             string;
-    title:                  string;
-    [property: string]: any;
-}
-
-export interface PresentationAddedMessage {
-    event:        PresentationAddedMessageEvent;
-    presentation: PresentationElement;
-    [property: string]: any;
-}
-
-export enum PresentationAddedMessageEvent {
-    PresentationAdded = "presentation_added",
-}
-
-export interface PresentationComment {
-    author:     string;
-    content:    string;
-    created_at: string;
-    filepath:   string;
-    id:         string;
-    line_end:   number;
-    line_start: number;
-    round_id:   string;
-    side:       string;
-    [property: string]: any;
-}
-
-export interface PresentationRound {
-    base_sha:        string;
-    changed_files?:  ChangedFileElement[];
-    created_at:      string;
-    head_sha:        string;
-    id:              string;
-    manifest:        Manifest;
-    presentation_id: string;
-    seq:             number;
-    submitted_at?:   string;
-    verdict?:        string;
-    [property: string]: any;
-}
-
-export interface PresentationUpdatedMessage {
-    event:        PresentationUpdatedMessageEvent;
-    presentation: PresentationElement;
-    [property: string]: any;
-}
-
-export enum PresentationUpdatedMessageEvent {
-    PresentationUpdated = "presentation_updated",
 }
 
 export interface PresentCloseMessage {
@@ -2916,7 +2886,7 @@ export interface PresentFile {
 }
 
 export interface PresentManifestView {
-    files:    ChangedFileElement[];
+    files:    FileElement[];
     skip:     string[];
     summary?: string;
     title:    string;
@@ -2981,24 +2951,65 @@ export enum PresentSubmitRoundResultMessageEvent {
     PresentSubmitRoundResult = "present_submit_round_result",
 }
 
-export interface PRsUpdatedMessage {
-    event: PRsUpdatedMessageEvent;
-    prs?:  PRElement[];
+export interface Presentation {
+    created_at:             string;
+    id:                     string;
+    kind:                   string;
+    latest_round_seq:       number;
+    latest_round_submitted: boolean;
+    repo_path:              string;
+    session_id:             string;
+    status:                 string;
+    ticket_id?:             string;
+    title:                  string;
     [property: string]: any;
 }
 
-export enum PRsUpdatedMessageEvent {
-    PrsUpdated = "prs_updated",
-}
-
-export interface PRVisitedMessage {
-    cmd: PRVisitedMessageCmd;
-    id:  string;
+export interface PresentationAddedMessage {
+    event:        PresentationAddedMessageEvent;
+    presentation: PresentationElement;
     [property: string]: any;
 }
 
-export enum PRVisitedMessageCmd {
-    PRVisited = "pr_visited",
+export enum PresentationAddedMessageEvent {
+    PresentationAdded = "presentation_added",
+}
+
+export interface PresentationComment {
+    author:     string;
+    content:    string;
+    created_at: string;
+    filepath:   string;
+    id:         string;
+    line_end:   number;
+    line_start: number;
+    round_id:   string;
+    side:       string;
+    [property: string]: any;
+}
+
+export interface PresentationRound {
+    base_sha:        string;
+    changed_files?:  FileElement[];
+    created_at:      string;
+    head_sha:        string;
+    id:              string;
+    manifest:        Manifest;
+    presentation_id: string;
+    seq:             number;
+    submitted_at?:   string;
+    verdict?:        string;
+    [property: string]: any;
+}
+
+export interface PresentationUpdatedMessage {
+    event:        PresentationUpdatedMessageEvent;
+    presentation: PresentationElement;
+    [property: string]: any;
+}
+
+export enum PresentationUpdatedMessageEvent {
+    PresentationUpdated = "presentation_updated",
 }
 
 export interface PtyDesyncMessage {
@@ -3036,18 +3047,6 @@ export enum PtyOutputMessageEvent {
     PtyOutput = "pty_output",
 }
 
-export interface PtyResizedMessage {
-    cols:  number;
-    event: PtyResizedMessageEvent;
-    id:    string;
-    rows:  number;
-    [property: string]: any;
-}
-
-export enum PtyResizedMessageEvent {
-    PtyResized = "pty_resized",
-}
-
 export interface PtyResizeMessage {
     cmd:  PtyResizeMessageCmd;
     cols: number;
@@ -3058,6 +3057,18 @@ export interface PtyResizeMessage {
 
 export enum PtyResizeMessageCmd {
     PtyResize = "pty_resize",
+}
+
+export interface PtyResizedMessage {
+    cols:  number;
+    event: PtyResizedMessageEvent;
+    id:    string;
+    rows:  number;
+    [property: string]: any;
+}
+
+export enum PtyResizedMessageEvent {
+    PtyResized = "pty_resized",
 }
 
 export interface QueryAuthorsMessage {
@@ -3292,6 +3303,7 @@ export interface Response {
     present_open_result?:                  PresentOpenResultObject;
     prs?:                                  PRElement[];
     repos?:                                RepoElement[];
+    session_instructions_result?:          SessionInstructionsResultObject;
     sessions?:                             SessionElement[];
     ticket_attach_result?:                 TicketAttachResultObject;
     ticket_comment_result?:                TicketCommentResultObject;
@@ -3340,6 +3352,25 @@ export interface PresentOpenResultObject {
     seq:             number;
     title:           string;
     warnings?:       string[];
+    [property: string]: any;
+}
+
+export interface SessionInstructionsResultObject {
+    answer:                 string;
+    evidence:               EvidenceElement[];
+    model:                  string;
+    reasoning_effort:       string;
+    session_id:             string;
+    transcript_fingerprint: string;
+    transcript_path:        string;
+    [property: string]: any;
+}
+
+export interface EvidenceElement {
+    author:     string;
+    quote:      string;
+    timestamp?: string;
+    turn_id:    string;
     [property: string]: any;
 }
 
@@ -3530,6 +3561,28 @@ export enum SessionExitedMessageEvent {
     SessionExited = "session_exited",
 }
 
+export interface SessionInstructionsMessage {
+    cmd:               SessionInstructionsMessageCmd;
+    question:          string;
+    target_session_id: string;
+    [property: string]: any;
+}
+
+export enum SessionInstructionsMessageCmd {
+    SessionInstructions = "session_instructions",
+}
+
+export interface SessionInstructionsResult {
+    answer:                 string;
+    evidence:               EvidenceElement[];
+    model:                  string;
+    reasoning_effort:       string;
+    session_id:             string;
+    transcript_fingerprint: string;
+    transcript_path:        string;
+    [property: string]: any;
+}
+
 export interface SessionRegisteredMessage {
     event:   SessionRegisteredMessageEvent;
     session: SessionElement;
@@ -3560,16 +3613,6 @@ export enum SessionStateChangedMessageEvent {
     SessionStateChanged = "session_state_changed",
 }
 
-export interface SessionsUpdatedMessage {
-    event:     SessionsUpdatedMessageEvent;
-    sessions?: SessionElement[];
-    [property: string]: any;
-}
-
-export enum SessionsUpdatedMessageEvent {
-    SessionsUpdated = "sessions_updated",
-}
-
 export interface SessionTodosUpdatedMessage {
     event:   SessionTodosUpdatedMessageEvent;
     session: SessionElement;
@@ -3598,6 +3641,16 @@ export interface SessionVisualizedMessage {
 
 export enum SessionVisualizedMessageCmd {
     SessionVisualized = "session_visualized",
+}
+
+export interface SessionsUpdatedMessage {
+    event:     SessionsUpdatedMessageEvent;
+    sessions?: SessionElement[];
+    [property: string]: any;
+}
+
+export enum SessionsUpdatedMessageEvent {
+    SessionsUpdated = "sessions_updated",
 }
 
 export interface SetChiefOfStaffMessage {
@@ -3688,6 +3741,18 @@ export enum DispatchWorkState {
     ReadyForReview = "ready_for_review",
 }
 
+export interface SetWorkspaceRankMessage {
+    cmd:                SetWorkspaceRankMessageCmd;
+    next_workspace_id?: string;
+    prev_workspace_id?: string;
+    workspace_id:       string;
+    [property: string]: any;
+}
+
+export enum SetWorkspaceRankMessageCmd {
+    SetWorkspaceRank = "set_workspace_rank",
+}
+
 export interface SettingsUpdatedMessage {
     changed_key?: string;
     error?:       string;
@@ -3699,18 +3764,6 @@ export interface SettingsUpdatedMessage {
 
 export enum SettingsUpdatedMessageEvent {
     SettingsUpdated = "settings_updated",
-}
-
-export interface SetWorkspaceRankMessage {
-    cmd:                SetWorkspaceRankMessageCmd;
-    next_workspace_id?: string;
-    prev_workspace_id?: string;
-    workspace_id:       string;
-    [property: string]: any;
-}
-
-export enum SetWorkspaceRankMessageCmd {
-    SetWorkspaceRank = "set_workspace_rank",
 }
 
 export interface SpawnResultMessage {
@@ -3937,7 +3990,7 @@ export interface TicketAttachFile {
 export interface TicketAttachMessage {
     cmd:               TicketAttachMessageCmd;
     comment?:          string;
-    files:             FileElement[];
+    files:             FileObject[];
     request_id?:       string;
     source_session_id: string;
     state?:            DispatchWorkState;
@@ -3949,7 +4002,7 @@ export enum TicketAttachMessageCmd {
     TicketAttach = "ticket_attach",
 }
 
-export interface FileElement {
+export interface FileObject {
     filename:    string;
     source_path: string;
     [property: string]: any;
@@ -4168,16 +4221,6 @@ export interface TicketSubscribeResult {
     [property: string]: any;
 }
 
-export interface TicketsUpdatedMessage {
-    event:   TicketsUpdatedMessageEvent;
-    tickets: TicketElement[];
-    [property: string]: any;
-}
-
-export enum TicketsUpdatedMessageEvent {
-    TicketsUpdated = "tickets_updated",
-}
-
 export interface TicketTakeMessage {
     cmd:               TicketTakeMessageCmd;
     confirm?:          boolean;
@@ -4210,6 +4253,16 @@ export enum TicketUnsubscribeMessageCmd {
 export interface TicketUnsubscribeResult {
     ticket_id: string;
     [property: string]: any;
+}
+
+export interface TicketsUpdatedMessage {
+    event:   TicketsUpdatedMessageEvent;
+    tickets: TicketElement[];
+    [property: string]: any;
+}
+
+export enum TicketsUpdatedMessageEvent {
+    TicketsUpdated = "tickets_updated",
 }
 
 export interface TodosMessage {
@@ -4885,16 +4938,6 @@ export enum WorkspaceLayoutUndockTileMessageCmd {
     WorkspaceLayoutUndockTile = "workspace_layout_undock_tile",
 }
 
-export interface WorkspaceLayoutUpdatedMessage {
-    event:            WorkspaceLayoutUpdatedMessageEvent;
-    workspace_layout: Layout;
-    [property: string]: any;
-}
-
-export enum WorkspaceLayoutUpdatedMessageEvent {
-    WorkspaceLayoutUpdated = "workspace_layout_updated",
-}
-
 export interface WorkspaceLayoutUpdateTileMessage {
     cmd:              WorkspaceLayoutUpdateTileMessageCmd;
     request_id:       string;
@@ -4907,6 +4950,16 @@ export interface WorkspaceLayoutUpdateTileMessage {
 
 export enum WorkspaceLayoutUpdateTileMessageCmd {
     WorkspaceLayoutUpdateTile = "workspace_layout_update_tile",
+}
+
+export interface WorkspaceLayoutUpdatedMessage {
+    event:            WorkspaceLayoutUpdatedMessageEvent;
+    workspace_layout: Layout;
+    [property: string]: any;
+}
+
+export enum WorkspaceLayoutUpdatedMessageEvent {
+    WorkspaceLayoutUpdated = "workspace_layout_updated",
 }
 
 export interface WorkspaceRegisteredMessage {
@@ -5358,6 +5411,14 @@ export class Convert {
 
     public static ensureRepoResultMessageToJson(value: EnsureRepoResultMessage): string {
         return JSON.stringify(uncast(value, r("EnsureRepoResultMessage")), null, 2);
+    }
+
+    public static toEvidenceExcerpt(json: string): EvidenceExcerpt {
+        return cast(JSON.parse(json), r("EvidenceExcerpt"));
+    }
+
+    public static evidenceExcerptToJson(value: EvidenceExcerpt): string {
+        return JSON.stringify(uncast(value, r("EvidenceExcerpt")), null, 2);
     }
 
     public static toFetchPRDetailsMessage(json: string): FetchPRDetailsMessage {
@@ -6272,6 +6333,46 @@ export class Convert {
         return JSON.stringify(uncast(value, r("OpenMarkdownResultMessage")), null, 2);
     }
 
+    public static toPR(json: string): PR {
+        return cast(JSON.parse(json), r("PR"));
+    }
+
+    public static pRToJson(value: PR): string {
+        return JSON.stringify(uncast(value, r("PR")), null, 2);
+    }
+
+    public static toPRActionResultMessage(json: string): PRActionResultMessage {
+        return cast(JSON.parse(json), r("PRActionResultMessage"));
+    }
+
+    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
+        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
+    }
+
+    public static toPRRole(json: string): PRRole {
+        return cast(JSON.parse(json), r("PRRole"));
+    }
+
+    public static pRRoleToJson(value: PRRole): string {
+        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
+    }
+
+    public static toPRVisitedMessage(json: string): PRVisitedMessage {
+        return cast(JSON.parse(json), r("PRVisitedMessage"));
+    }
+
+    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
+        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
+    }
+
+    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
+        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
+    }
+
+    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
+    }
+
     public static toPathInspection(json: string): PathInspection {
         return cast(JSON.parse(json), r("PathInspection"));
     }
@@ -6320,68 +6421,12 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PluginsUpdatedMessage")), null, 2);
     }
 
-    public static toPR(json: string): PR {
-        return cast(JSON.parse(json), r("PR"));
-    }
-
-    public static pRToJson(value: PR): string {
-        return JSON.stringify(uncast(value, r("PR")), null, 2);
-    }
-
-    public static toPRActionResultMessage(json: string): PRActionResultMessage {
-        return cast(JSON.parse(json), r("PRActionResultMessage"));
-    }
-
-    public static pRActionResultMessageToJson(value: PRActionResultMessage): string {
-        return JSON.stringify(uncast(value, r("PRActionResultMessage")), null, 2);
-    }
-
     public static toPresentAnnotation(json: string): PresentAnnotation {
         return cast(JSON.parse(json), r("PresentAnnotation"));
     }
 
     public static presentAnnotationToJson(value: PresentAnnotation): string {
         return JSON.stringify(uncast(value, r("PresentAnnotation")), null, 2);
-    }
-
-    public static toPresentation(json: string): Presentation {
-        return cast(JSON.parse(json), r("Presentation"));
-    }
-
-    public static presentationToJson(value: Presentation): string {
-        return JSON.stringify(uncast(value, r("Presentation")), null, 2);
-    }
-
-    public static toPresentationAddedMessage(json: string): PresentationAddedMessage {
-        return cast(JSON.parse(json), r("PresentationAddedMessage"));
-    }
-
-    public static presentationAddedMessageToJson(value: PresentationAddedMessage): string {
-        return JSON.stringify(uncast(value, r("PresentationAddedMessage")), null, 2);
-    }
-
-    public static toPresentationComment(json: string): PresentationComment {
-        return cast(JSON.parse(json), r("PresentationComment"));
-    }
-
-    public static presentationCommentToJson(value: PresentationComment): string {
-        return JSON.stringify(uncast(value, r("PresentationComment")), null, 2);
-    }
-
-    public static toPresentationRound(json: string): PresentationRound {
-        return cast(JSON.parse(json), r("PresentationRound"));
-    }
-
-    public static presentationRoundToJson(value: PresentationRound): string {
-        return JSON.stringify(uncast(value, r("PresentationRound")), null, 2);
-    }
-
-    public static toPresentationUpdatedMessage(json: string): PresentationUpdatedMessage {
-        return cast(JSON.parse(json), r("PresentationUpdatedMessage"));
-    }
-
-    public static presentationUpdatedMessageToJson(value: PresentationUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PresentationUpdatedMessage")), null, 2);
     }
 
     public static toPresentCloseMessage(json: string): PresentCloseMessage {
@@ -6472,28 +6517,44 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PresentSubmitRoundResultMessage")), null, 2);
     }
 
-    public static toPRRole(json: string): PRRole {
-        return cast(JSON.parse(json), r("PRRole"));
+    public static toPresentation(json: string): Presentation {
+        return cast(JSON.parse(json), r("Presentation"));
     }
 
-    public static pRRoleToJson(value: PRRole): string {
-        return JSON.stringify(uncast(value, r("PRRole")), null, 2);
+    public static presentationToJson(value: Presentation): string {
+        return JSON.stringify(uncast(value, r("Presentation")), null, 2);
     }
 
-    public static toPRsUpdatedMessage(json: string): PRsUpdatedMessage {
-        return cast(JSON.parse(json), r("PRsUpdatedMessage"));
+    public static toPresentationAddedMessage(json: string): PresentationAddedMessage {
+        return cast(JSON.parse(json), r("PresentationAddedMessage"));
     }
 
-    public static pRsUpdatedMessageToJson(value: PRsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("PRsUpdatedMessage")), null, 2);
+    public static presentationAddedMessageToJson(value: PresentationAddedMessage): string {
+        return JSON.stringify(uncast(value, r("PresentationAddedMessage")), null, 2);
     }
 
-    public static toPRVisitedMessage(json: string): PRVisitedMessage {
-        return cast(JSON.parse(json), r("PRVisitedMessage"));
+    public static toPresentationComment(json: string): PresentationComment {
+        return cast(JSON.parse(json), r("PresentationComment"));
     }
 
-    public static pRVisitedMessageToJson(value: PRVisitedMessage): string {
-        return JSON.stringify(uncast(value, r("PRVisitedMessage")), null, 2);
+    public static presentationCommentToJson(value: PresentationComment): string {
+        return JSON.stringify(uncast(value, r("PresentationComment")), null, 2);
+    }
+
+    public static toPresentationRound(json: string): PresentationRound {
+        return cast(JSON.parse(json), r("PresentationRound"));
+    }
+
+    public static presentationRoundToJson(value: PresentationRound): string {
+        return JSON.stringify(uncast(value, r("PresentationRound")), null, 2);
+    }
+
+    public static toPresentationUpdatedMessage(json: string): PresentationUpdatedMessage {
+        return cast(JSON.parse(json), r("PresentationUpdatedMessage"));
+    }
+
+    public static presentationUpdatedMessageToJson(value: PresentationUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("PresentationUpdatedMessage")), null, 2);
     }
 
     public static toPtyDesyncMessage(json: string): PtyDesyncMessage {
@@ -6520,20 +6581,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("PtyOutputMessage")), null, 2);
     }
 
-    public static toPtyResizedMessage(json: string): PtyResizedMessage {
-        return cast(JSON.parse(json), r("PtyResizedMessage"));
-    }
-
-    public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
-        return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
-    }
-
     public static toPtyResizeMessage(json: string): PtyResizeMessage {
         return cast(JSON.parse(json), r("PtyResizeMessage"));
     }
 
     public static ptyResizeMessageToJson(value: PtyResizeMessage): string {
         return JSON.stringify(uncast(value, r("PtyResizeMessage")), null, 2);
+    }
+
+    public static toPtyResizedMessage(json: string): PtyResizedMessage {
+        return cast(JSON.parse(json), r("PtyResizedMessage"));
+    }
+
+    public static ptyResizedMessageToJson(value: PtyResizedMessage): string {
+        return JSON.stringify(uncast(value, r("PtyResizedMessage")), null, 2);
     }
 
     public static toQueryAuthorsMessage(json: string): QueryAuthorsMessage {
@@ -6736,6 +6797,22 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionExitedMessage")), null, 2);
     }
 
+    public static toSessionInstructionsMessage(json: string): SessionInstructionsMessage {
+        return cast(JSON.parse(json), r("SessionInstructionsMessage"));
+    }
+
+    public static sessionInstructionsMessageToJson(value: SessionInstructionsMessage): string {
+        return JSON.stringify(uncast(value, r("SessionInstructionsMessage")), null, 2);
+    }
+
+    public static toSessionInstructionsResult(json: string): SessionInstructionsResult {
+        return cast(JSON.parse(json), r("SessionInstructionsResult"));
+    }
+
+    public static sessionInstructionsResultToJson(value: SessionInstructionsResult): string {
+        return JSON.stringify(uncast(value, r("SessionInstructionsResult")), null, 2);
+    }
+
     public static toSessionRegisteredMessage(json: string): SessionRegisteredMessage {
         return cast(JSON.parse(json), r("SessionRegisteredMessage"));
     }
@@ -6768,14 +6845,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SessionStateChangedMessage")), null, 2);
     }
 
-    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
-        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
-    }
-
-    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
-    }
-
     public static toSessionTodosUpdatedMessage(json: string): SessionTodosUpdatedMessage {
         return cast(JSON.parse(json), r("SessionTodosUpdatedMessage"));
     }
@@ -6798,6 +6867,14 @@ export class Convert {
 
     public static sessionVisualizedMessageToJson(value: SessionVisualizedMessage): string {
         return JSON.stringify(uncast(value, r("SessionVisualizedMessage")), null, 2);
+    }
+
+    public static toSessionsUpdatedMessage(json: string): SessionsUpdatedMessage {
+        return cast(JSON.parse(json), r("SessionsUpdatedMessage"));
+    }
+
+    public static sessionsUpdatedMessageToJson(value: SessionsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("SessionsUpdatedMessage")), null, 2);
     }
 
     public static toSetChiefOfStaffMessage(json: string): SetChiefOfStaffMessage {
@@ -6856,20 +6933,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("SetTicketStatusMessage")), null, 2);
     }
 
-    public static toSettingsUpdatedMessage(json: string): SettingsUpdatedMessage {
-        return cast(JSON.parse(json), r("SettingsUpdatedMessage"));
-    }
-
-    public static settingsUpdatedMessageToJson(value: SettingsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("SettingsUpdatedMessage")), null, 2);
-    }
-
     public static toSetWorkspaceRankMessage(json: string): SetWorkspaceRankMessage {
         return cast(JSON.parse(json), r("SetWorkspaceRankMessage"));
     }
 
     public static setWorkspaceRankMessageToJson(value: SetWorkspaceRankMessage): string {
         return JSON.stringify(uncast(value, r("SetWorkspaceRankMessage")), null, 2);
+    }
+
+    public static toSettingsUpdatedMessage(json: string): SettingsUpdatedMessage {
+        return cast(JSON.parse(json), r("SettingsUpdatedMessage"));
+    }
+
+    public static settingsUpdatedMessageToJson(value: SettingsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("SettingsUpdatedMessage")), null, 2);
     }
 
     public static toSpawnResultMessage(json: string): SpawnResultMessage {
@@ -7216,14 +7293,6 @@ export class Convert {
         return JSON.stringify(uncast(value, r("TicketSubscribeResult")), null, 2);
     }
 
-    public static toTicketsUpdatedMessage(json: string): TicketsUpdatedMessage {
-        return cast(JSON.parse(json), r("TicketsUpdatedMessage"));
-    }
-
-    public static ticketsUpdatedMessageToJson(value: TicketsUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("TicketsUpdatedMessage")), null, 2);
-    }
-
     public static toTicketTakeMessage(json: string): TicketTakeMessage {
         return cast(JSON.parse(json), r("TicketTakeMessage"));
     }
@@ -7254,6 +7323,14 @@ export class Convert {
 
     public static ticketUnsubscribeResultToJson(value: TicketUnsubscribeResult): string {
         return JSON.stringify(uncast(value, r("TicketUnsubscribeResult")), null, 2);
+    }
+
+    public static toTicketsUpdatedMessage(json: string): TicketsUpdatedMessage {
+        return cast(JSON.parse(json), r("TicketsUpdatedMessage"));
+    }
+
+    public static ticketsUpdatedMessageToJson(value: TicketsUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("TicketsUpdatedMessage")), null, 2);
     }
 
     public static toTodosMessage(json: string): TodosMessage {
@@ -7672,20 +7749,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUndockTileMessage")), null, 2);
     }
 
-    public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
-        return cast(JSON.parse(json), r("WorkspaceLayoutUpdatedMessage"));
-    }
-
-    public static workspaceLayoutUpdatedMessageToJson(value: WorkspaceLayoutUpdatedMessage): string {
-        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
-    }
-
     public static toWorkspaceLayoutUpdateTileMessage(json: string): WorkspaceLayoutUpdateTileMessage {
         return cast(JSON.parse(json), r("WorkspaceLayoutUpdateTileMessage"));
     }
 
     public static workspaceLayoutUpdateTileMessageToJson(value: WorkspaceLayoutUpdateTileMessage): string {
         return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdateTileMessage")), null, 2);
+    }
+
+    public static toWorkspaceLayoutUpdatedMessage(json: string): WorkspaceLayoutUpdatedMessage {
+        return cast(JSON.parse(json), r("WorkspaceLayoutUpdatedMessage"));
+    }
+
+    public static workspaceLayoutUpdatedMessageToJson(value: WorkspaceLayoutUpdatedMessage): string {
+        return JSON.stringify(uncast(value, r("WorkspaceLayoutUpdatedMessage")), null, 2);
     }
 
     public static toWorkspaceRegisteredMessage(json: string): WorkspaceRegisteredMessage {
@@ -8290,6 +8367,12 @@ const typeMap: any = {
         { json: "success", js: "success", typ: u(undefined, true) },
         { json: "target_path", js: "target_path", typ: u(undefined, "") },
     ], "any"),
+    "EvidenceExcerpt": o([
+        { json: "author", js: "author", typ: "" },
+        { json: "quote", js: "quote", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: u(undefined, "") },
+        { json: "turn_id", js: "turn_id", typ: "" },
+    ], "any"),
     "FetchPRDetailsMessage": o([
         { json: "cmd", js: "cmd", typ: r("FetchPRDetailsMessageCmd") },
         { json: "id", js: "id", typ: "" },
@@ -8611,7 +8694,7 @@ const typeMap: any = {
     ], "any"),
     "Round": o([
         { json: "base_sha", js: "base_sha", typ: "" },
-        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("ChangedFileElement"))) },
+        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("FileElement"))) },
         { json: "created_at", js: "created_at", typ: "" },
         { json: "head_sha", js: "head_sha", typ: "" },
         { json: "id", js: "id", typ: "" },
@@ -8621,7 +8704,7 @@ const typeMap: any = {
         { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
         { json: "verdict", js: "verdict", typ: u(undefined, "") },
     ], "any"),
-    "ChangedFileElement": o([
+    "FileElement": o([
         { json: "additions", js: "additions", typ: u(undefined, 0) },
         { json: "annotations", js: "annotations", typ: u(undefined, a(r("AnnotationElement"))) },
         { json: "deletions", js: "deletions", typ: u(undefined, 0) },
@@ -8634,7 +8717,7 @@ const typeMap: any = {
         { json: "line_start", js: "line_start", typ: 0 },
     ], "any"),
     "Manifest": o([
-        { json: "files", js: "files", typ: a(r("ChangedFileElement")) },
+        { json: "files", js: "files", typ: a(r("FileElement")) },
         { json: "skip", js: "skip", typ: a("") },
         { json: "summary", js: "summary", typ: u(undefined, "") },
         { json: "title", js: "title", typ: "" },
@@ -9260,6 +9343,49 @@ const typeMap: any = {
         { json: "tile_id", js: "tile_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
     ], "any"),
+    "PR": o([
+        { json: "approved_by_me", js: "approved_by_me", typ: true },
+        { json: "author", js: "author", typ: "" },
+        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
+        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
+        { json: "details_fetched", js: "details_fetched", typ: true },
+        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
+        { json: "has_new_changes", js: "has_new_changes", typ: true },
+        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
+        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
+        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
+        { json: "host", js: "host", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
+        { json: "last_polled", js: "last_polled", typ: "" },
+        { json: "last_updated", js: "last_updated", typ: "" },
+        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
+        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
+        { json: "muted", js: "muted", typ: true },
+        { json: "number", js: "number", typ: 0 },
+        { json: "reason", js: "reason", typ: "" },
+        { json: "repo", js: "repo", typ: "" },
+        { json: "review_status", js: "review_status", typ: u(undefined, "") },
+        { json: "role", js: "role", typ: r("PRRole") },
+        { json: "state", js: "state", typ: "" },
+        { json: "title", js: "title", typ: "" },
+        { json: "url", js: "url", typ: "" },
+    ], "any"),
+    "PRActionResultMessage": o([
+        { json: "action", js: "action", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
+        { json: "id", js: "id", typ: "" },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "PRVisitedMessage": o([
+        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
+        { json: "id", js: "id", typ: "" },
+    ], "any"),
+    "PRsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
+        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
+    ], "any"),
     "PathInspection": o([
         { json: "exists", js: "exists", typ: true },
         { json: "home_path", js: "home_path", typ: u(undefined, "") },
@@ -9335,88 +9461,10 @@ const typeMap: any = {
         { json: "runtime_state", js: "runtime_state", typ: "" },
         { json: "version", js: "version", typ: "" },
     ], "any"),
-    "PR": o([
-        { json: "approved_by_me", js: "approved_by_me", typ: true },
-        { json: "author", js: "author", typ: "" },
-        { json: "ci_status", js: "ci_status", typ: u(undefined, "") },
-        { json: "comment_count", js: "comment_count", typ: u(undefined, 0) },
-        { json: "details_fetched", js: "details_fetched", typ: true },
-        { json: "details_fetched_at", js: "details_fetched_at", typ: u(undefined, "") },
-        { json: "has_new_changes", js: "has_new_changes", typ: true },
-        { json: "head_branch", js: "head_branch", typ: u(undefined, "") },
-        { json: "head_sha", js: "head_sha", typ: u(undefined, "") },
-        { json: "heat_state", js: "heat_state", typ: u(undefined, r("HeatState")) },
-        { json: "host", js: "host", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "last_heat_activity_at", js: "last_heat_activity_at", typ: u(undefined, "") },
-        { json: "last_polled", js: "last_polled", typ: "" },
-        { json: "last_updated", js: "last_updated", typ: "" },
-        { json: "mergeable", js: "mergeable", typ: u(undefined, true) },
-        { json: "mergeable_state", js: "mergeable_state", typ: u(undefined, "") },
-        { json: "muted", js: "muted", typ: true },
-        { json: "number", js: "number", typ: 0 },
-        { json: "reason", js: "reason", typ: "" },
-        { json: "repo", js: "repo", typ: "" },
-        { json: "review_status", js: "review_status", typ: u(undefined, "") },
-        { json: "role", js: "role", typ: r("PRRole") },
-        { json: "state", js: "state", typ: "" },
-        { json: "title", js: "title", typ: "" },
-        { json: "url", js: "url", typ: "" },
-    ], "any"),
-    "PRActionResultMessage": o([
-        { json: "action", js: "action", typ: "" },
-        { json: "error", js: "error", typ: u(undefined, "") },
-        { json: "event", js: "event", typ: r("PRActionResultMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "success", js: "success", typ: true },
-    ], "any"),
     "PresentAnnotation": o([
         { json: "comments", js: "comments", typ: a("") },
         { json: "line_end", js: "line_end", typ: 0 },
         { json: "line_start", js: "line_start", typ: 0 },
-    ], "any"),
-    "Presentation": o([
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "kind", js: "kind", typ: "" },
-        { json: "latest_round_seq", js: "latest_round_seq", typ: 0 },
-        { json: "latest_round_submitted", js: "latest_round_submitted", typ: true },
-        { json: "repo_path", js: "repo_path", typ: "" },
-        { json: "session_id", js: "session_id", typ: "" },
-        { json: "status", js: "status", typ: "" },
-        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
-        { json: "title", js: "title", typ: "" },
-    ], "any"),
-    "PresentationAddedMessage": o([
-        { json: "event", js: "event", typ: r("PresentationAddedMessageEvent") },
-        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
-    ], "any"),
-    "PresentationComment": o([
-        { json: "author", js: "author", typ: "" },
-        { json: "content", js: "content", typ: "" },
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "filepath", js: "filepath", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "line_end", js: "line_end", typ: 0 },
-        { json: "line_start", js: "line_start", typ: 0 },
-        { json: "round_id", js: "round_id", typ: "" },
-        { json: "side", js: "side", typ: "" },
-    ], "any"),
-    "PresentationRound": o([
-        { json: "base_sha", js: "base_sha", typ: "" },
-        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("ChangedFileElement"))) },
-        { json: "created_at", js: "created_at", typ: "" },
-        { json: "head_sha", js: "head_sha", typ: "" },
-        { json: "id", js: "id", typ: "" },
-        { json: "manifest", js: "manifest", typ: r("Manifest") },
-        { json: "presentation_id", js: "presentation_id", typ: "" },
-        { json: "seq", js: "seq", typ: 0 },
-        { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
-        { json: "verdict", js: "verdict", typ: u(undefined, "") },
-    ], "any"),
-    "PresentationUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PresentationUpdatedMessageEvent") },
-        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
     ], "any"),
     "PresentCloseMessage": o([
         { json: "cmd", js: "cmd", typ: r("PresentCloseMessageCmd") },
@@ -9455,7 +9503,7 @@ const typeMap: any = {
         { json: "path", js: "path", typ: "" },
     ], "any"),
     "PresentManifestView": o([
-        { json: "files", js: "files", typ: a(r("ChangedFileElement")) },
+        { json: "files", js: "files", typ: a(r("FileElement")) },
         { json: "skip", js: "skip", typ: a("") },
         { json: "summary", js: "summary", typ: u(undefined, "") },
         { json: "title", js: "title", typ: "" },
@@ -9496,13 +9544,48 @@ const typeMap: any = {
         { json: "round_id", js: "round_id", typ: "" },
         { json: "success", js: "success", typ: true },
     ], "any"),
-    "PRsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("PRsUpdatedMessageEvent") },
-        { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
-    ], "any"),
-    "PRVisitedMessage": o([
-        { json: "cmd", js: "cmd", typ: r("PRVisitedMessageCmd") },
+    "Presentation": o([
+        { json: "created_at", js: "created_at", typ: "" },
         { json: "id", js: "id", typ: "" },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "latest_round_seq", js: "latest_round_seq", typ: 0 },
+        { json: "latest_round_submitted", js: "latest_round_submitted", typ: true },
+        { json: "repo_path", js: "repo_path", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "status", js: "status", typ: "" },
+        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
+        { json: "title", js: "title", typ: "" },
+    ], "any"),
+    "PresentationAddedMessage": o([
+        { json: "event", js: "event", typ: r("PresentationAddedMessageEvent") },
+        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
+    ], "any"),
+    "PresentationComment": o([
+        { json: "author", js: "author", typ: "" },
+        { json: "content", js: "content", typ: "" },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "filepath", js: "filepath", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "line_end", js: "line_end", typ: 0 },
+        { json: "line_start", js: "line_start", typ: 0 },
+        { json: "round_id", js: "round_id", typ: "" },
+        { json: "side", js: "side", typ: "" },
+    ], "any"),
+    "PresentationRound": o([
+        { json: "base_sha", js: "base_sha", typ: "" },
+        { json: "changed_files", js: "changed_files", typ: u(undefined, a(r("FileElement"))) },
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "head_sha", js: "head_sha", typ: "" },
+        { json: "id", js: "id", typ: "" },
+        { json: "manifest", js: "manifest", typ: r("Manifest") },
+        { json: "presentation_id", js: "presentation_id", typ: "" },
+        { json: "seq", js: "seq", typ: 0 },
+        { json: "submitted_at", js: "submitted_at", typ: u(undefined, "") },
+        { json: "verdict", js: "verdict", typ: u(undefined, "") },
+    ], "any"),
+    "PresentationUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("PresentationUpdatedMessageEvent") },
+        { json: "presentation", js: "presentation", typ: r("PresentationElement") },
     ], "any"),
     "PtyDesyncMessage": o([
         { json: "event", js: "event", typ: r("PtyDesyncMessageEvent") },
@@ -9521,15 +9604,15 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "seq", js: "seq", typ: 0 },
     ], "any"),
-    "PtyResizedMessage": o([
-        { json: "cols", js: "cols", typ: 0 },
-        { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
-        { json: "id", js: "id", typ: "" },
-        { json: "rows", js: "rows", typ: 0 },
-    ], "any"),
     "PtyResizeMessage": o([
         { json: "cmd", js: "cmd", typ: r("PtyResizeMessageCmd") },
         { json: "cols", js: "cols", typ: 0 },
+        { json: "id", js: "id", typ: "" },
+        { json: "rows", js: "rows", typ: 0 },
+    ], "any"),
+    "PtyResizedMessage": o([
+        { json: "cols", js: "cols", typ: 0 },
+        { json: "event", js: "event", typ: r("PtyResizedMessageEvent") },
         { json: "id", js: "id", typ: "" },
         { json: "rows", js: "rows", typ: 0 },
     ], "any"),
@@ -9659,6 +9742,7 @@ const typeMap: any = {
         { json: "present_open_result", js: "present_open_result", typ: u(undefined, r("PresentOpenResultObject")) },
         { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
         { json: "repos", js: "repos", typ: u(undefined, a(r("RepoElement"))) },
+        { json: "session_instructions_result", js: "session_instructions_result", typ: u(undefined, r("SessionInstructionsResultObject")) },
         { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
         { json: "ticket_attach_result", js: "ticket_attach_result", typ: u(undefined, r("TicketAttachResultObject")) },
         { json: "ticket_comment_result", js: "ticket_comment_result", typ: u(undefined, r("TicketCommentResultObject")) },
@@ -9699,6 +9783,21 @@ const typeMap: any = {
         { json: "seq", js: "seq", typ: 0 },
         { json: "title", js: "title", typ: "" },
         { json: "warnings", js: "warnings", typ: u(undefined, a("")) },
+    ], "any"),
+    "SessionInstructionsResultObject": o([
+        { json: "answer", js: "answer", typ: "" },
+        { json: "evidence", js: "evidence", typ: a(r("EvidenceElement")) },
+        { json: "model", js: "model", typ: "" },
+        { json: "reasoning_effort", js: "reasoning_effort", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "transcript_fingerprint", js: "transcript_fingerprint", typ: "" },
+        { json: "transcript_path", js: "transcript_path", typ: "" },
+    ], "any"),
+    "EvidenceElement": o([
+        { json: "author", js: "author", typ: "" },
+        { json: "quote", js: "quote", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: u(undefined, "") },
+        { json: "turn_id", js: "turn_id", typ: "" },
     ], "any"),
     "TicketAttachResultObject": o([
         { json: "artifacts", js: "artifacts", typ: a(r("ArtifactElement")) },
@@ -9827,6 +9926,20 @@ const typeMap: any = {
         { json: "id", js: "id", typ: "" },
         { json: "signal", js: "signal", typ: u(undefined, "") },
     ], "any"),
+    "SessionInstructionsMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SessionInstructionsMessageCmd") },
+        { json: "question", js: "question", typ: "" },
+        { json: "target_session_id", js: "target_session_id", typ: "" },
+    ], "any"),
+    "SessionInstructionsResult": o([
+        { json: "answer", js: "answer", typ: "" },
+        { json: "evidence", js: "evidence", typ: a(r("EvidenceElement")) },
+        { json: "model", js: "model", typ: "" },
+        { json: "reasoning_effort", js: "reasoning_effort", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "transcript_fingerprint", js: "transcript_fingerprint", typ: "" },
+        { json: "transcript_path", js: "transcript_path", typ: "" },
+    ], "any"),
     "SessionRegisteredMessage": o([
         { json: "event", js: "event", typ: r("SessionRegisteredMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
@@ -9839,10 +9952,6 @@ const typeMap: any = {
         { json: "event", js: "event", typ: r("SessionStateChangedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
     ], "any"),
-    "SessionsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
-        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
-    ], "any"),
     "SessionTodosUpdatedMessage": o([
         { json: "event", js: "event", typ: r("SessionTodosUpdatedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
@@ -9854,6 +9963,10 @@ const typeMap: any = {
     "SessionVisualizedMessage": o([
         { json: "cmd", js: "cmd", typ: r("SessionVisualizedMessageCmd") },
         { json: "id", js: "id", typ: "" },
+    ], "any"),
+    "SessionsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("SessionsUpdatedMessageEvent") },
+        { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
     ], "any"),
     "SetChiefOfStaffMessage": o([
         { json: "chief_of_staff", js: "chief_of_staff", typ: true },
@@ -9893,18 +10006,18 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
         { json: "work_state", js: "work_state", typ: r("DispatchWorkState") },
     ], "any"),
+    "SetWorkspaceRankMessage": o([
+        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
+        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
+        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
+        { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
     "SettingsUpdatedMessage": o([
         { json: "changed_key", js: "changed_key", typ: u(undefined, "") },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "event", js: "event", typ: r("SettingsUpdatedMessageEvent") },
         { json: "settings", js: "settings", typ: u(undefined, m("any")) },
         { json: "success", js: "success", typ: u(undefined, true) },
-    ], "any"),
-    "SetWorkspaceRankMessage": o([
-        { json: "cmd", js: "cmd", typ: r("SetWorkspaceRankMessageCmd") },
-        { json: "next_workspace_id", js: "next_workspace_id", typ: u(undefined, "") },
-        { json: "prev_workspace_id", js: "prev_workspace_id", typ: u(undefined, "") },
-        { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
     "SpawnResultMessage": o([
         { json: "error", js: "error", typ: u(undefined, "") },
@@ -10046,13 +10159,13 @@ const typeMap: any = {
     "TicketAttachMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketAttachMessageCmd") },
         { json: "comment", js: "comment", typ: u(undefined, "") },
-        { json: "files", js: "files", typ: a(r("FileElement")) },
+        { json: "files", js: "files", typ: a(r("FileObject")) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "state", js: "state", typ: u(undefined, r("DispatchWorkState")) },
         { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
     ], "any"),
-    "FileElement": o([
+    "FileObject": o([
         { json: "filename", js: "filename", typ: "" },
         { json: "source_path", js: "source_path", typ: "" },
     ], "any"),
@@ -10177,10 +10290,6 @@ const typeMap: any = {
     "TicketSubscribeResult": o([
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
-    "TicketsUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("TicketsUpdatedMessageEvent") },
-        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
-    ], "any"),
     "TicketTakeMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketTakeMessageCmd") },
         { json: "confirm", js: "confirm", typ: u(undefined, true) },
@@ -10198,6 +10307,10 @@ const typeMap: any = {
     ], "any"),
     "TicketUnsubscribeResult": o([
         { json: "ticket_id", js: "ticket_id", typ: "" },
+    ], "any"),
+    "TicketsUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("TicketsUpdatedMessageEvent") },
+        { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
     ], "any"),
     "TodosMessage": o([
         { json: "cmd", js: "cmd", typ: r("TodosMessageCmd") },
@@ -10608,10 +10721,6 @@ const typeMap: any = {
         { json: "tile_id", js: "tile_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: "" },
     ], "any"),
-    "WorkspaceLayoutUpdatedMessage": o([
-        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
-        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
-    ], "any"),
     "WorkspaceLayoutUpdateTileMessage": o([
         { json: "cmd", js: "cmd", typ: r("WorkspaceLayoutUpdateTileMessageCmd") },
         { json: "request_id", js: "request_id", typ: "" },
@@ -10619,6 +10728,10 @@ const typeMap: any = {
         { json: "tile_params", js: "tile_params", typ: "" },
         { json: "tile_session_id", js: "tile_session_id", typ: u(undefined, "") },
         { json: "workspace_id", js: "workspace_id", typ: "" },
+    ], "any"),
+    "WorkspaceLayoutUpdatedMessage": o([
+        { json: "event", js: "event", typ: r("WorkspaceLayoutUpdatedMessageEvent") },
+        { json: "workspace_layout", js: "workspace_layout", typ: r("Layout") },
     ], "any"),
     "WorkspaceRegisteredMessage": o([
         { json: "event", js: "event", typ: r("WorkspaceRegisteredMessageEvent") },
@@ -11102,6 +11215,15 @@ const typeMap: any = {
     "OpenMarkdownResultMessageEvent": [
         "open_markdown_result",
     ],
+    "PRActionResultMessageEvent": [
+        "pr_action_result",
+    ],
+    "PRVisitedMessageCmd": [
+        "pr_visited",
+    ],
+    "PRsUpdatedMessageEvent": [
+        "prs_updated",
+    ],
     "PinWorkspaceMessageCmd": [
         "pin_workspace",
     ],
@@ -11110,15 +11232,6 @@ const typeMap: any = {
     ],
     "PluginsUpdatedMessageEvent": [
         "plugins_updated",
-    ],
-    "PRActionResultMessageEvent": [
-        "pr_action_result",
-    ],
-    "PresentationAddedMessageEvent": [
-        "presentation_added",
-    ],
-    "PresentationUpdatedMessageEvent": [
-        "presentation_updated",
     ],
     "PresentCloseMessageCmd": [
         "present_close",
@@ -11138,11 +11251,11 @@ const typeMap: any = {
     "PresentSubmitRoundResultMessageEvent": [
         "present_submit_round_result",
     ],
-    "PRsUpdatedMessageEvent": [
-        "prs_updated",
+    "PresentationAddedMessageEvent": [
+        "presentation_added",
     ],
-    "PRVisitedMessageCmd": [
-        "pr_visited",
+    "PresentationUpdatedMessageEvent": [
+        "presentation_updated",
     ],
     "PtyDesyncMessageEvent": [
         "pty_desync",
@@ -11153,11 +11266,11 @@ const typeMap: any = {
     "PtyOutputMessageEvent": [
         "pty_output",
     ],
-    "PtyResizedMessageEvent": [
-        "pty_resized",
-    ],
     "PtyResizeMessageCmd": [
         "pty_resize",
+    ],
+    "PtyResizedMessageEvent": [
+        "pty_resized",
     ],
     "QueryAuthorsMessageCmd": [
         "query_authors",
@@ -11225,6 +11338,9 @@ const typeMap: any = {
     "SessionExitedMessageEvent": [
         "session_exited",
     ],
+    "SessionInstructionsMessageCmd": [
+        "session_instructions",
+    ],
     "SessionRegisteredMessageEvent": [
         "session_registered",
     ],
@@ -11234,9 +11350,6 @@ const typeMap: any = {
     "SessionStateChangedMessageEvent": [
         "session_state_changed",
     ],
-    "SessionsUpdatedMessageEvent": [
-        "sessions_updated",
-    ],
     "SessionTodosUpdatedMessageEvent": [
         "session_todos_updated",
     ],
@@ -11245,6 +11358,9 @@ const typeMap: any = {
     ],
     "SessionVisualizedMessageCmd": [
         "session_visualized",
+    ],
+    "SessionsUpdatedMessageEvent": [
+        "sessions_updated",
     ],
     "SetChiefOfStaffMessageCmd": [
         "set_chief_of_staff",
@@ -11274,11 +11390,11 @@ const typeMap: any = {
         "needs_input",
         "ready_for_review",
     ],
-    "SettingsUpdatedMessageEvent": [
-        "settings_updated",
-    ],
     "SetWorkspaceRankMessageCmd": [
         "set_workspace_rank",
+    ],
+    "SettingsUpdatedMessageEvent": [
+        "settings_updated",
     ],
     "SpawnResultMessageEvent": [
         "spawn_result",
@@ -11355,14 +11471,14 @@ const typeMap: any = {
     "TicketSubscribeMessageCmd": [
         "ticket_subscribe",
     ],
-    "TicketsUpdatedMessageEvent": [
-        "tickets_updated",
-    ],
     "TicketTakeMessageCmd": [
         "ticket_take",
     ],
     "TicketUnsubscribeMessageCmd": [
         "ticket_unsubscribe",
+    ],
+    "TicketsUpdatedMessageEvent": [
+        "tickets_updated",
     ],
     "TodosMessageCmd": [
         "todos",
@@ -11494,11 +11610,11 @@ const typeMap: any = {
     "WorkspaceLayoutUndockTileMessageCmd": [
         "workspace_layout_undock_tile",
     ],
-    "WorkspaceLayoutUpdatedMessageEvent": [
-        "workspace_layout_updated",
-    ],
     "WorkspaceLayoutUpdateTileMessageCmd": [
         "workspace_layout_update_tile",
+    ],
+    "WorkspaceLayoutUpdatedMessageEvent": [
+        "workspace_layout_updated",
     ],
     "WorkspaceRegisteredMessageEvent": [
         "workspace_registered",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -252,6 +252,9 @@ func main() {
 	case "ticket":
 		maybePrintProfileBanner()
 		runTicket()
+	case "session":
+		maybePrintProfileBanner()
+		runSession()
 	case "debug":
 		maybePrintProfileBanner()
 		runDebug()
@@ -575,6 +578,7 @@ func writeHelp(w io.Writer) {
 
 commands:
   presence                          check whether the current shell runs inside attn
+	  session instructions <id>        answer a question from a session's conversation
   delegate --brief-file <path>      start another agent with a delegated brief
   journal append --entry <text>     serialized append to the daily notebook journal
   workspace context <command>       edit shared workspace context

--- a/cmd/attn/session_instructions.go
+++ b/cmd/attn/session_instructions.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/victorarias/attn/internal/client"
+	"github.com/victorarias/attn/internal/daemon"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+type sessionInstructionsArgs struct {
+	target   string
+	question string
+	json     bool
+}
+
+func runSession() {
+	if len(os.Args) < 3 || os.Args[2] == "-h" || os.Args[2] == "--help" {
+		writeSessionHelp(os.Stdout)
+		return
+	}
+	switch os.Args[2] {
+	case "instructions":
+		if hasHelpFlag(os.Args[3:]) {
+			writeSessionHelp(os.Stdout)
+			return
+		}
+		runSessionInstructions(os.Args[3:])
+	default:
+		fmt.Fprintf(os.Stderr, "session: unknown command %q\n", os.Args[2])
+		writeSessionHelp(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func parseSessionInstructionsArgs(args []string) (sessionInstructionsArgs, error) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return sessionInstructionsArgs{}, errors.New("exactly one target session id is required")
+	}
+	target := strings.TrimSpace(args[0])
+	args = args[1:]
+	fs := flag.NewFlagSet("session instructions", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	question := fs.String("question", "", "question to answer from the target conversation")
+	jsonOut := fs.Bool("json", false, "print the machine result as JSON")
+	if err := fs.Parse(args); err != nil {
+		return sessionInstructionsArgs{}, err
+	}
+	if target == "" || fs.NArg() != 0 {
+		return sessionInstructionsArgs{}, errors.New("exactly one target session id is required")
+	}
+	if strings.TrimSpace(*question) == "" {
+		return sessionInstructionsArgs{}, errors.New("--question is required")
+	}
+	return sessionInstructionsArgs{target: target, question: strings.TrimSpace(*question), json: *jsonOut}, nil
+}
+
+func runSessionInstructions(args []string) {
+	parsed, err := parseSessionInstructionsArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "session instructions: %v\n", err)
+		writeSessionHelp(os.Stderr)
+		os.Exit(2)
+	}
+	result, err := client.New("").SessionInstructions(parsed.target, parsed.question)
+	if err != nil {
+		code := sessionInstructionsErrorCode(err)
+		message := daemon.SessionInstructionsErrorMessage(code)
+		if parsed.json {
+			_ = json.NewEncoder(os.Stdout).Encode(map[string]any{"error": map[string]string{"code": code, "message": message}})
+		} else {
+			fmt.Fprintln(os.Stderr, message)
+		}
+		os.Exit(1)
+	}
+	if parsed.json {
+		printJSON(result)
+		return
+	}
+	printSessionInstructions(result)
+}
+
+func sessionInstructionsErrorCode(err error) string {
+	const prefix = "daemon error: "
+	message := strings.TrimSpace(err.Error())
+	if strings.HasPrefix(message, prefix) {
+		code := strings.TrimSpace(strings.TrimPrefix(message, prefix))
+		switch code {
+		case "session_not_found", "transcript_unavailable", "conversation_too_large", "model_unavailable", "invalid_response", "invalid_evidence":
+			return code
+		}
+	}
+	return "model_unavailable"
+}
+
+func printSessionInstructions(result *protocol.SessionInstructionsResult) {
+	printSessionInstructionsTo(os.Stdout, result)
+}
+
+func printSessionInstructionsTo(w io.Writer, result *protocol.SessionInstructionsResult) {
+	fmt.Fprintln(w, result.Answer)
+	for _, evidence := range result.Evidence {
+		fmt.Fprintf(w, "\n%s", evidence.Author)
+		if evidence.Timestamp != nil && strings.TrimSpace(*evidence.Timestamp) != "" {
+			fmt.Fprintf(w, " — %s", *evidence.Timestamp)
+		}
+		fmt.Fprintf(w, "\n  %q\n", evidence.Quote)
+	}
+	fmt.Fprintf(w, "\nTranscript: %s\n", result.TranscriptPath)
+}
+
+func writeSessionHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn session instructions <target-session-id> --question <text> [--json]
+
+commands:
+  instructions <id> --question <text> [--json]
+        answer a free-form question from the target session's bounded Codex
+        conversation, returning validated exact excerpts. --json changes only
+        presentation. Unclear is a successful answer.
+`)
+}

--- a/cmd/attn/session_instructions_test.go
+++ b/cmd/attn/session_instructions_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func TestParseSessionInstructionsArgs(t *testing.T) {
+	got, err := parseSessionInstructionsArgs([]string{"target", "--question", "Was it authorized?", "--json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.target != "target" || got.question != "Was it authorized?" || !got.json {
+		t.Fatalf("got %+v", got)
+	}
+	for _, args := range [][]string{nil, {"--question", "x"}, {"target"}, {"target", "--question", " "}, {"target", "extra", "--question", "x"}} {
+		if _, err := parseSessionInstructionsArgs(args); err == nil {
+			t.Fatalf("parseSessionInstructionsArgs(%v) succeeded", args)
+		}
+	}
+}
+
+func TestSessionInstructionsErrorCodeAndRendering(t *testing.T) {
+	if got := sessionInstructionsErrorCode(errors.New("daemon error: invalid_evidence")); got != "invalid_evidence" {
+		t.Fatalf("code=%q", got)
+	}
+	if got := sessionInstructionsErrorCode(errors.New("network down")); got != "model_unavailable" {
+		t.Fatalf("code=%q", got)
+	}
+	var output bytes.Buffer
+	printSessionInstructionsTo(&output, &protocol.SessionInstructionsResult{Answer: "Unclear.", Evidence: []protocol.EvidenceExcerpt{{TurnID: "turn-1", Author: "user", Quote: "hello"}}, TranscriptPath: "/tmp/synthetic.jsonl"})
+	if text := output.String(); !strings.Contains(text, "Unclear.") || !strings.Contains(text, "Transcript: /tmp/synthetic.jsonl") {
+		t.Fatalf("output=%q", text)
+	}
+}

--- a/docs/alignment/session-instructions-first-slice.md
+++ b/docs/alignment/session-instructions-first-slice.md
@@ -1,0 +1,26 @@
+# Session instructions first slice
+
+## Why
+
+Allow an attn agent to ask one free-form question about a Codex session and
+receive a concise, evidence-backed answer without introducing an authorization
+ledger or workflow-specific policy.
+
+## Aligned on
+
+- The scoped implementation spec is the build contract. Native Codex
+  `user_message` and `agent_message` records are the v1 evidence corpus.
+- The daemon must resolve the stored native Codex resume ID to one transcript
+  snapshot, fingerprint it before parsing, and validate all displayed excerpts
+  against that snapshot.
+- `Unclear` is a successful answer; transcript, model, and validation failures
+  return no verdict and a stable non-zero failure.
+- Assistant turns may supply context but cannot independently support a claim
+  about the user's instructions.
+
+## In scope / deferred
+
+This slice adds the read-only CLI, Unix-socket command, Codex projection,
+Luna low/medium retry, exact evidence validation, and focused tests. Claude,
+settings, retrieval for long conversations, and any durable provenance or
+authorization model are deferred.

--- a/docs/plans/2026-07-17-session-instructions-implementation-spec.md
+++ b/docs/plans/2026-07-17-session-instructions-implementation-spec.md
@@ -1,0 +1,315 @@
+# Plan: session instructions
+
+## Goal
+
+Add a generic command that answers a question about another attn session from
+that session's conversation:
+
+```sh
+attn session instructions <target-session-id> \
+  --question "Was creating, updating, and merging PR #571 authorized?"
+```
+
+The command sends the session's user and assistant messages, plus the question,
+to a small model and returns a concise answer with a few exact excerpts. It does
+not understand pull requests, authorization types, or workflows. Those are only
+things callers may ask about.
+
+The first implementation supports Codex transcripts and `gpt-5.6-luna`.
+Claude transcripts, Haiku/Sonnet, and model selection in Settings follow
+immediately after the first slice.
+
+## Product contract
+
+### Command
+
+```text
+attn session instructions <target-session-id> --question <text> [--json]
+```
+
+- The target session ID and a non-blank question are required.
+- `--json` changes presentation only.
+- There are no action, resource, workflow, transcript-path, model, or reasoning
+  flags.
+- The command is read-only and does not create an authorization record.
+
+Example human output:
+
+```text
+Yes. Victor authorized merging PR #571 after the earlier prohibition.
+
+User — 16:41
+  "Yes, do it."
+
+Assistant — 16:40
+  "The PR is ready. Should I merge #571 now?"
+
+Transcript: /Users/victora/.codex/sessions/2026/07/17/example.jsonl
+```
+
+The assistant excerpt supplies context for the user's pronoun. It is never
+treated as authorization by itself.
+
+### Result
+
+Keep the machine result small and generic:
+
+```go
+type SessionInstructionsResult struct {
+    Answer         string            `json:"answer"`
+    Evidence       []EvidenceExcerpt `json:"evidence"`
+    SessionID      string            `json:"session_id"`
+    TranscriptPath string            `json:"transcript_path"`
+    Fingerprint    string            `json:"transcript_fingerprint"`
+    Model          string            `json:"model"`
+    Effort         string            `json:"reasoning_effort"`
+}
+
+type EvidenceExcerpt struct {
+    TurnID    string `json:"turn_id"`
+    Author    string `json:"author"` // "user" or "assistant"
+    Quote     string `json:"quote"`
+    Timestamp string `json:"timestamp,omitempty"`
+}
+```
+
+`Answer` is free text. For a yes/no question it should begin with `Yes.`, `No.`,
+or `Unclear.`. `Unclear` is a successful result: the model inspected the
+conversation but could not support a more definite answer.
+
+`TranscriptPath` is the absolute path of the native transcript that attn read.
+The fingerprint identifies the exact contents read from that path. `Model` and
+`Effort` describe the attempt whose answer was returned, including an escalated
+retry.
+
+### Failure contract
+
+The command has three outcomes:
+
+1. **Answered:** the model produced an answer backed by validated excerpts.
+   Exit zero.
+2. **Inconclusive:** the model successfully determined that the conversation
+   does not answer the question. Return `Unclear`; exit zero.
+3. **Failed:** attn could not perform a trustworthy lookup. Return no answer or
+   evidence; exit non-zero.
+
+Failure must never be converted into `No` or `Unclear`. Fail closed means that
+the caller receives no usable verdict, not that attn assumes the action was
+unauthorized.
+
+JSON errors use a stable code and short message:
+
+```json
+{
+  "error": {
+    "code": "invalid_evidence",
+    "message": "The model did not return verifiable evidence"
+  }
+}
+```
+
+The first slice needs these codes:
+
+| Code | Meaning |
+| --- | --- |
+| `session_not_found` | The target session does not exist. |
+| `transcript_unavailable` | Its exact native transcript cannot be read or parsed. |
+| `conversation_too_large` | The projected conversation exceeds the model input limit. |
+| `model_unavailable` | The model invocation failed or timed out. |
+| `invalid_response` | Both attempts returned malformed structured output. |
+| `invalid_evidence` | Both attempts returned evidence that could not be resolved. |
+
+Human mode prints the corresponding message to stderr without transcript or
+question content.
+
+## Runtime shape
+
+```text
+attn session instructions
+  -> daemon resolves the target session and its native resume ID
+  -> read one transcript snapshot
+  -> project user and assistant conversation messages
+  -> Luna low answers the question with cited turn IDs and quote hints
+  -> validate citations against the snapshot
+     -> valid: return the answer and exact source excerpts
+     -> invalid: retry the whole request with Luna medium
+        -> valid: return the replacement answer and exact source excerpts
+        -> invalid: return an error with no answer
+```
+
+The implementation may live in a small `internal/sessioninstructions` package,
+called from the daemon's Unix-socket command handler. It should have one main
+entry point:
+
+```go
+type Request struct {
+    TargetSessionID string
+    Question        string
+}
+
+type Service struct {
+    Store  *store.Store
+    Model  ModelRunner
+}
+
+func (s *Service) Ask(ctx context.Context, req Request) (SessionInstructionsResult, error)
+```
+
+Use the existing client, daemon command, and TypeSpec generation patterns for
+the CLI-to-daemon boundary. Do not introduce a provider framework, access-token
+scheme, origin database, or authorization domain model for this feature.
+
+## Conversation projection
+
+Resolve the target through the attn session store, then use its stored native
+resume ID with the agent driver's `TranscriptFinder`. Exact native-ID lookup is
+required: the prototype showed that cwd/time-based discovery can select a
+plausible but wrong transcript.
+
+Read a single bounded snapshot and compute its fingerprint before parsing. For
+v1, project only the native Codex records representing:
+
+- user input;
+- assistant output.
+
+Omit system instructions, developer instructions, reasoning, tool calls, tool
+results, hooks, shell output, and attn metadata. Preserve message order and
+assign stable turn IDs within the snapshot.
+
+```go
+type ConversationTurn struct {
+    ID        string
+    Author    string // "user" or "assistant"
+    Text      string
+    Timestamp string
+}
+```
+
+The entire projected conversation and the caller's question go to the model in
+one request. V1 does not add semantic retrieval or transcript compaction beyond
+removing non-conversation events. If the result is still too large, return
+`conversation_too_large`.
+
+## Model call and retry
+
+The model returns a complete candidate answer, not trusted evidence:
+
+```go
+type ModelAnswer struct {
+    Answer   string `json:"answer"`
+    Evidence []struct {
+        TurnID string `json:"turn_id"`
+        Quote  string `json:"quote"`
+    } `json:"evidence"`
+}
+```
+
+The first attempt uses `gpt-5.6-luna` with low reasoning. If its structured
+output is malformed, evidence is missing, or any required excerpt cannot be
+resolved, make one repair attempt with `gpt-5.6-luna` at medium reasoning.
+
+The repair attempt receives:
+
+- the same transcript snapshot and question;
+- the validation errors from the first attempt;
+- an instruction to produce a complete replacement answer with verifiable
+  excerpts.
+
+Validate the replacement from scratch. Never combine the first answer with the
+second attempt's evidence, or mix citations between attempts. If the retry also
+fails, return `invalid_response` or `invalid_evidence` with no answer.
+
+A timeout or provider failure returns `model_unavailable`; escalating reasoning
+does not repair unavailable infrastructure.
+
+When Claude support lands, use the same policy with Haiku as the primary model
+and Sonnet as the repair model. The subsequent Settings work should configure a
+primary/retry pair per provider rather than changing this command's API.
+
+## Evidence validation
+
+Model excerpts are locator hints. They are never displayed directly.
+
+For each cited item:
+
+1. Find the cited turn ID in the projected conversation.
+2. Locate the hint within that turn, first exactly and then with harmless
+   normalization for whitespace and typographic punctuation.
+3. Require one unique match.
+4. Copy the displayed quote from the original transcript text.
+
+An assistant turn may clarify a reference such as "yes, do it," but an answer
+about what the user allowed must include supporting user-authored evidence.
+Generated interpretation remains the answer; exact transcript text remains the
+evidence.
+
+If an item cannot be resolved, the entire candidate is invalid and triggers the
+single repair attempt. Returning only the remaining excerpts could leave a
+claim without evidence for one of its clauses.
+
+## Minimal code-reading path
+
+An implementer should read these locations in order:
+
+1. `cmd/attn/main.go` — command parsing and human/JSON rendering conventions.
+2. `internal/client/client.go` and the existing Unix-socket command handlers —
+   the shortest path from CLI to daemon.
+3. `internal/protocol/schema/main.tsp` and
+   `internal/protocol/constants.go` — wire shape and protocol versioning.
+4. `internal/store/store.go` — target session and stored native resume ID.
+5. `internal/agent/driver.go` and `internal/agent/codex.go` — exact transcript
+   discovery through `TranscriptFinder`.
+6. `internal/transcript` and `cmd/session-evidence-prototype/main.go` — existing
+   transcript parsing and the proven projection/model/quote flow.
+7. `internal/classifier/classifier.go` — existing headless Codex invocation and
+   reasoning-effort configuration conventions.
+
+This is enough to implement the feature. The broader design document is useful
+background but is not an implementation checklist.
+
+## Tests
+
+Keep the test suite focused on the boundaries that can make the result wrong:
+
+1. **CLI contract:** required arguments, human output, JSON output, exit zero for
+   `Unclear`, and non-zero for every execution error.
+2. **Projection fixtures:** real Codex JSONL containing user messages,
+   assistant messages, reasoning, tools, hooks, and system records. Assert that
+   only ordered user/assistant conversation reaches the model.
+3. **Exact transcript resolution:** a regression fixture with multiple plausible
+   transcripts proves that the stored native resume ID selects the right one
+   and returns its absolute path.
+4. **Evidence validation:** exact match, normalized whitespace/quotes, missing
+   turn, altered quote, ambiguous quote, and assistant-only support for a claim
+   about user instructions.
+5. **Retry behavior:** a fake model returns invalid evidence on attempt one and
+   valid evidence on attempt two. Assert low then medium effort, identical
+   snapshot/question, validation feedback, and that only attempt two is
+   returned. Also assert that two invalid attempts produce no answer.
+6. **Contextual references:** fixtures such as an assistant asking whether to
+   merge followed by the user saying "yes, do it," plus later revocation and
+   conflicting-instruction cases.
+7. **Failure behavior:** missing transcript, oversized projection, timeout,
+   malformed output, and invalid evidence remain distinguishable from a valid
+   `Unclear` answer.
+8. **Real transcript smoke test:** run the production path against the transcript
+   used by the prototype and confirm an answer with byte-for-byte source quotes.
+
+The model runner is fake in deterministic tests; the real-model smoke test is
+explicit because model behavior cannot be proven by unit tests.
+
+## Implementation order
+
+- [ ] Add the CLI and generated daemon command/result shapes.
+- [ ] Resolve the exact Codex transcript and project conversation turns.
+- [ ] Add the Luna low call and structured response parsing.
+- [ ] Validate hints and return exact transcript excerpts.
+- [ ] Add the Luna medium repair attempt and failure mapping.
+- [ ] Add focused unit, integration, and real-transcript smoke tests.
+- [ ] Exercise the command through a non-production attn profile.
+
+## Immediate follow-up
+
+Add Claude transcript projection, Haiku primary/Sonnet repair calls, and Settings
+for selecting the primary and repair model pair. The command and result shapes
+remain unchanged.

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -146,7 +146,11 @@ func (c *Codex) RunHeadlessTask(ctx context.Context, request HeadlessTaskRequest
 	// it once here and pass it into the pure arg builders as an explicit input.
 	window := HeadlessContextWindowCap()
 	if request.usesNativeToolsPath() {
-		result, stdout, err := runHeadlessCommand(ctx, request.Executable, codexHeadlessArgs(request, window), request.WorkDir, "codex")
+		args := codexHeadlessArgs(request, window)
+		if request.DisableTools {
+			args = codexToolFreeHeadlessArgs(request, window)
+		}
+		result, stdout, err := runHeadlessCommand(ctx, request.Executable, args, request.WorkDir, "codex")
 		if err != nil {
 			return result, err
 		}
@@ -233,6 +237,9 @@ func buildCodexHeadlessArgs(request HeadlessTaskRequest, lastMsgPath string, win
 	// for a workflow agent() with no per-call/run model override).
 	if model := strings.TrimSpace(request.Model); model != "" {
 		args = append(args, "-m", model)
+	}
+	if effort := strings.TrimSpace(request.ReasoningEffort); effort != "" {
+		args = append(args, "-c", `model_reasoning_effort="`+effort+`"`)
 	}
 	if lastMsgPath != "" {
 		args = append(args, "--output-last-message", lastMsgPath)
@@ -381,6 +388,9 @@ func codexHeadlessArgs(request HeadlessTaskRequest, window int) []string {
 		"-m", strings.TrimSpace(request.Model),
 		"-c", `approval_policy="never"`,
 	}
+	if effort := strings.TrimSpace(request.ReasoningEffort); effort != "" {
+		args = append(args, "-c", `model_reasoning_effort="`+effort+`"`)
+	}
 	// Widen the workspace-write sandbox's writable set beyond the scratch WorkDir
 	// for tasks that must write outside cwd (e.g. the notebook narrate pass writing the
 	// curated journal under the notebook root). `--add-dir` is the codex exec flag
@@ -394,6 +404,34 @@ func codexHeadlessArgs(request HeadlessTaskRequest, window int) []string {
 			continue
 		}
 		args = append(args, "--add-dir", root)
+	}
+	args = append(args, codexFeatureLocks()...)
+	args = append(args, codexContextWindowCapArgs(window)...)
+	args = append(args, request.Prompt)
+	return args
+}
+
+// codexToolFreeHeadlessArgs builds a pure completion invocation. The prompt is
+// the complete model-visible evidence boundary: Codex receives neither native
+// shell/file tools nor user-configured MCP, plugins, apps, or web search.
+func codexToolFreeHeadlessArgs(request HeadlessTaskRequest, window int) []string {
+	args := []string{
+		"exec",
+		"--json",
+		"--ephemeral",
+		"--ignore-user-config",
+		"--ignore-rules",
+		"--strict-config",
+		"--skip-git-repo-check",
+		"--sandbox", "read-only",
+		"-m", strings.TrimSpace(request.Model),
+		"-c", `approval_policy="never"`,
+		"-c", "features.shell_tool=false",
+		"-c", "features.unified_exec=false",
+		"-c", `web_search="disabled"`,
+	}
+	if effort := strings.TrimSpace(request.ReasoningEffort); effort != "" {
+		args = append(args, "-c", `model_reasoning_effort="`+effort+`"`)
 	}
 	args = append(args, codexFeatureLocks()...)
 	args = append(args, codexContextWindowCapArgs(window)...)
@@ -421,7 +459,7 @@ func (c *Codex) FindTranscript(sessionID, cwd string, startedAt time.Time) strin
 }
 
 func (c *Codex) FindTranscriptForResume(resumeID string) string {
-	return "" // Codex doesn't support resume-id transcript lookup.
+	return transcript.FindCodexTranscriptForResume(resumeID)
 }
 
 func (c *Codex) BootstrapBytes() int64 {

--- a/internal/agent/driver.go
+++ b/internal/agent/driver.go
@@ -332,8 +332,11 @@ type ConfigOverrideProvider interface {
 // daemon writes inputs into WorkDir and reads the agent's output file back;
 // validation + commit stay daemon-owned.
 type HeadlessTaskRequest struct {
-	Executable       string
-	Model            string
+	Executable string
+	Model      string
+	// ReasoningEffort selects the provider's reasoning setting for this one
+	// bounded headless request. Empty preserves the provider default.
+	ReasoningEffort  string
 	Prompt           string
 	WorkDir          string
 	MCPServerName    string

--- a/internal/agent/headless.go
+++ b/internal/agent/headless.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -208,6 +209,11 @@ func headlessEnvironment(provider string) []string {
 			env = append(env, entry)
 		}
 	}
+	if provider == "codex" && strings.TrimSpace(os.Getenv("CODEX_HOME")) == "" {
+		if homeDir, err := os.UserHomeDir(); err == nil && strings.TrimSpace(homeDir) != "" {
+			env = append(env, "CODEX_HOME="+filepath.Join(homeDir, ".codex"))
+		}
+	}
 	if provider == "claude" {
 		env = append(env, "CLAUDE_CODE_DISABLE_AUTO_MEMORY=1")
 		// Cap the effective context window so auto-compaction fires at the
@@ -219,6 +225,16 @@ func headlessEnvironment(provider string) []string {
 		}
 	}
 	return launchenv.WithActiveAttnFirst(env, launchenv.ActiveAttnExecutable())
+}
+
+func environmentContains(env []string, name string) bool {
+	prefix := name + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func classifyHeadlessFailure(output string) string {

--- a/internal/agent/headless_native_test.go
+++ b/internal/agent/headless_native_test.go
@@ -143,3 +143,45 @@ func TestCodexHeadlessArgsUsesWorkspaceWriteAndDropsMCPPin(t *testing.T) {
 		`mcp_servers.attn_context.default_tools_approval_mode="approve"`,
 	)
 }
+
+func TestCodexToolFreeHeadlessArgsExposeOnlyThePrompt(t *testing.T) {
+	args := codexToolFreeHeadlessArgs(HeadlessTaskRequest{
+		Model:           "gpt-test",
+		ReasoningEffort: "low",
+		Prompt:          "judge these supplied turns",
+		WorkDir:         "/tmp/scratch",
+		ExtraWritableRoots: []string{
+			"/must-not-be-writable",
+		},
+	}, 12345)
+
+	assertContainsAll(t, "Codex tool-free args", args,
+		"exec",
+		"--json",
+		"--ephemeral",
+		"--ignore-user-config",
+		"--ignore-rules",
+		"--strict-config",
+		"--skip-git-repo-check",
+		"--sandbox",
+		"read-only",
+		`approval_policy="never"`,
+		`model_reasoning_effort="low"`,
+		"features.shell_tool=false",
+		"features.unified_exec=false",
+		`web_search="disabled"`,
+		"features.apps=false",
+		"features.plugins=false",
+		"features.browser_use=false",
+		"features.standalone_web_search=false",
+		"model_auto_compact_token_limit=12345",
+		"gpt-test",
+		"judge these supplied turns",
+	)
+	assertContainsNone(t, "Codex tool-free args", args,
+		"workspace-write",
+		"--add-dir",
+		"/must-not-be-writable",
+		"mcp_servers.",
+	)
+}

--- a/internal/agent/headless_test.go
+++ b/internal/agent/headless_test.go
@@ -79,6 +79,21 @@ func TestCodexRunHeadlessTaskScopesToolsAndConfiguration(t *testing.T) {
 	}
 }
 
+func TestHeadlessEnvironment_CodexSetsDefaultHomeWhenUnset(t *testing.T) {
+	t.Setenv("CODEX_HOME", "")
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !environmentContains(headlessEnvironment("codex"), "CODEX_HOME") {
+		t.Fatal("Codex headless environment did not set CODEX_HOME")
+	}
+	want := "CODEX_HOME=" + filepath.Join(homeDir, ".codex")
+	if !strings.Contains(strings.Join(headlessEnvironment("codex"), "\n"), want) {
+		t.Fatalf("Codex headless environment missing %q", want)
+	}
+}
+
 func TestCodexRunHeadlessTaskScopesSingleToolNameAndCapturesLastMessage(t *testing.T) {
 	executable, logPath := writeHeadlessArgsRecorder(t)
 	_, err := (&Codex{}).RunHeadlessTask(context.Background(), HeadlessTaskRequest{

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -121,6 +121,23 @@ func (c *Client) SetSessionResumeID(id, resumeSessionID string) error {
 	return err
 }
 
+// SessionInstructions asks one bounded question of another session's native
+// conversation. The daemon owns transcript lookup and model execution.
+func (c *Client) SessionInstructions(targetSessionID, question string) (*protocol.SessionInstructionsResult, error) {
+	resp, err := c.send(protocol.SessionInstructionsMessage{
+		Cmd:             protocol.CmdSessionInstructions,
+		TargetSessionID: targetSessionID,
+		Question:        question,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.SessionInstructionsResult == nil {
+		return nil, errors.New("daemon returned no session instructions result")
+	}
+	return resp.SessionInstructionsResult, nil
+}
+
 // SendStop sends a stop signal with transcript path for classification
 func (c *Client) SendStop(id, transcriptPath string) error {
 	msg := protocol.StopMessage{

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -36,6 +36,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdUnregister:                            commandMetadata(ScopeSession, true, true),
 	protocol.CmdState:                                 commandMetadata(ScopeSession, false, true),
 	protocol.CmdSetSessionResumeID:                    commandMetadata(ScopeSession, false, true),
+	protocol.CmdSessionInstructions:                   commandMetadata(ScopeSession, false, true),
 	protocol.CmdStop:                                  commandMetadata(ScopeSession, false, true),
 	protocol.CmdTodos:                                 commandMetadata(ScopeSession, false, true),
 	protocol.CmdQuery:                                 commandMetadata(ScopeHubMerge, false, true),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2062,6 +2062,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleState(conn, msg.(*protocol.StateMessage))
 	case protocol.CmdSetSessionResumeID:
 		d.handleSetSessionResumeID(conn, msg.(*protocol.SetSessionResumeIDMessage))
+	case protocol.CmdSessionInstructions:
+		d.handleSessionInstructions(conn, msg.(*protocol.SessionInstructionsMessage))
 	case protocol.CmdStop:
 		d.handleStop(conn, msg.(*protocol.StopMessage))
 	case protocol.CmdTodos:

--- a/internal/daemon/session_instructions.go
+++ b/internal/daemon/session_instructions.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/sessioninstructions"
+)
+
+const sessionInstructionsTimeout = 45 * time.Second
+
+func (d *Daemon) handleSessionInstructions(conn net.Conn, msg *protocol.SessionInstructionsMessage) {
+	service := sessioninstructions.Service{
+		Store:  d.store,
+		Finder: agentdriver.Get("codex").(agentdriver.TranscriptFinder),
+		Model:  daemonSessionInstructionsModel{daemon: d},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sessionInstructionsTimeout)
+	defer cancel()
+	result, err := service.Ask(ctx, sessioninstructions.Request{TargetSessionID: msg.TargetSessionID, Question: msg.Question})
+	if err != nil {
+		var sessionErr *sessioninstructions.Error
+		if errors.As(err, &sessionErr) {
+			d.sendError(conn, sessionErr.Code)
+			return
+		}
+		d.sendError(conn, "model_unavailable")
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, SessionInstructionsResult: result})
+}
+
+type daemonSessionInstructionsModel struct{ daemon *Daemon }
+
+func (m daemonSessionInstructionsModel) Run(ctx context.Context, request sessioninstructions.ModelRequest) (sessioninstructions.ModelAnswer, error) {
+	driver := agentdriver.Get("codex")
+	provider, ok := driver.(agentdriver.HeadlessTaskProvider)
+	if !ok {
+		m.daemon.logf("session instructions model failed: Codex headless provider unavailable")
+		return sessioninstructions.ModelAnswer{}, errors.New("codex headless provider unavailable")
+	}
+	executable, err := exec.LookPath(driver.ResolveExecutable(m.daemon.store.GetSetting(canonicalExecutableSettingKey("codex"))))
+	if err != nil {
+		m.daemon.logf("session instructions model failed: Codex executable unavailable")
+		return sessioninstructions.ModelAnswer{}, fmt.Errorf("resolve luna executable: %w", err)
+	}
+	workDir, err := os.MkdirTemp("", "attn-session-instructions-*")
+	if err != nil {
+		m.daemon.logf("session instructions model failed: scratch directory unavailable")
+		return sessioninstructions.ModelAnswer{}, err
+	}
+	defer os.RemoveAll(workDir)
+	result, err := provider.RunHeadlessTask(ctx, agentdriver.HeadlessTaskRequest{
+		Executable:      executable,
+		Model:           sessioninstructions.ModelName,
+		ReasoningEffort: request.Effort,
+		Prompt:          sessioninstructions.Prompt(request),
+		WorkDir:         workDir,
+		DisableTools:    true,
+	})
+	if err != nil {
+		diagnostic := strings.TrimSpace(result.Diagnostics)
+		if diagnostic == "" {
+			diagnostic = "unknown headless failure"
+		}
+		m.daemon.logf("session instructions model failed: %s", diagnostic)
+		return sessioninstructions.ModelAnswer{}, err
+	}
+	return sessioninstructions.ParseModelAnswer(result.Text)
+}
+
+// SessionInstructionsErrorMessage is the stable, transcript-free CLI surface.
+func SessionInstructionsErrorMessage(code string) string {
+	switch strings.TrimSpace(code) {
+	case "session_not_found":
+		return "The target session was not found"
+	case "transcript_unavailable":
+		return "The target transcript is unavailable"
+	case "conversation_too_large":
+		return "The target conversation is too large to inspect"
+	case "model_unavailable":
+		return "The session-instructions model is unavailable"
+	case "invalid_response":
+		return "The model did not return valid structured output"
+	case "invalid_evidence":
+		return "The model did not return verifiable evidence"
+	default:
+		return "Session instructions failed"
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -94,6 +94,7 @@ const (
 	CmdUnregister                            = "unregister"
 	CmdState                                 = "state"
 	CmdSetSessionResumeID                    = "set_session_resume_id"
+	CmdSessionInstructions                   = "session_instructions"
 	CmdStop                                  = "stop"
 	CmdTodos                                 = "todos"
 	CmdQuery                                 = "query"
@@ -746,6 +747,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdSetSessionResumeID:
 		var msg SetSessionResumeIDMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdSessionInstructions:
+		var msg SessionInstructionsMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "170"
+const ProtocolVersion = "171"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -695,6 +695,20 @@ type EnsureRepoResultMessage struct {
 	TargetPath *string `json:"target_path,omitempty,omitzero"`
 }
 
+type EvidenceExcerpt struct {
+	// Author corresponds to the JSON schema field "author".
+	Author string `json:"author"`
+
+	// Quote corresponds to the JSON schema field "quote".
+	Quote string `json:"quote"`
+
+	// Timestamp corresponds to the JSON schema field "timestamp".
+	Timestamp *string `json:"timestamp,omitempty,omitzero"`
+
+	// TurnID corresponds to the JSON schema field "turn_id".
+	TurnID string `json:"turn_id"`
+}
+
 type FetchPRDetailsMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
@@ -3229,6 +3243,10 @@ type Response struct {
 	// Repos corresponds to the JSON schema field "repos".
 	Repos []RepoState `json:"repos,omitempty,omitzero"`
 
+	// SessionInstructionsResult corresponds to the JSON schema field
+	// "session_instructions_result".
+	SessionInstructionsResult *SessionInstructionsResult `json:"session_instructions_result,omitempty,omitzero"`
+
 	// Sessions corresponds to the JSON schema field "sessions".
 	Sessions []Session `json:"sessions,omitempty,omitzero"`
 
@@ -3401,6 +3419,41 @@ type SessionExitedMessage struct {
 
 	// Signal corresponds to the JSON schema field "signal".
 	Signal *string `json:"signal,omitempty,omitzero"`
+}
+
+type SessionInstructionsMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// Question corresponds to the JSON schema field "question".
+	Question string `json:"question"`
+
+	// TargetSessionID corresponds to the JSON schema field "target_session_id".
+	TargetSessionID string `json:"target_session_id"`
+}
+
+type SessionInstructionsResult struct {
+	// Answer corresponds to the JSON schema field "answer".
+	Answer string `json:"answer"`
+
+	// Evidence corresponds to the JSON schema field "evidence".
+	Evidence []EvidenceExcerpt `json:"evidence"`
+
+	// Model corresponds to the JSON schema field "model".
+	Model string `json:"model"`
+
+	// ReasoningEffort corresponds to the JSON schema field "reasoning_effort".
+	ReasoningEffort string `json:"reasoning_effort"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
+
+	// TranscriptFingerprint corresponds to the JSON schema field
+	// "transcript_fingerprint".
+	TranscriptFingerprint string `json:"transcript_fingerprint"`
+
+	// TranscriptPath corresponds to the JSON schema field "transcript_path".
+	TranscriptPath string `json:"transcript_path"`
 }
 
 type SessionRegisteredMessage struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -595,6 +595,12 @@ model SetSessionResumeIDMessage {
   resume_session_id: string;
 }
 
+model SessionInstructionsMessage {
+  cmd: "session_instructions";
+  target_session_id: string;
+  question: string;
+}
+
 model StopMessage {
   cmd: "stop";
   id: string;
@@ -2684,6 +2690,24 @@ model Response {
   ticket_take_result?: TicketTakeResult;
   present_open_result?: PresentOpenResult;
   present_feedback_result?: PresentFeedbackResult;
+  session_instructions_result?: SessionInstructionsResult;
+}
+
+model EvidenceExcerpt {
+  turn_id: string;
+  author: string;
+  quote: string;
+  timestamp?: string;
+}
+
+model SessionInstructionsResult {
+  answer: string;
+  evidence: EvidenceExcerpt[];
+  session_id: string;
+  transcript_path: string;
+  transcript_fingerprint: string;
+  `model`: string;
+  reasoning_effort: string;
 }
 
 model DelegateResult {

--- a/internal/sessioninstructions/service.go
+++ b/internal/sessioninstructions/service.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"unicode"
@@ -283,14 +284,19 @@ func requiresUserEvidence(question, answer string) bool {
 	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(answer)), "unclear.") {
 		return false
 	}
-	q := strings.ToLower(question)
-	// Questions explicitly about what the assistant said are allowed to rely on
-	// assistant evidence. Everything else is conservatively treated as a claim
-	// about user-side instructions unless it is inconclusive.
-	if strings.Contains(q, "agent") || strings.Contains(q, "assistant") {
-		return false
-	}
-	return true
+	return !isExplicitSpeechReportingQuestion(question)
+}
+
+var explicitSpeechReportingQuestion = regexp.MustCompile(
+	`^(?:(?:did|does|do|has|have)\s+(?:the\s+)?(?:agent|assistant|codex)|what\s+(?:did|does|has|have)\s+(?:the\s+)?(?:agent|assistant|codex))\s+(?:say|said|tell|told|write|wrote|state|stated|claim|claimed|report|reported)\b|^(?:is|was|were)\s+(?:the\s+)?(?:agent|assistant|codex)\s+(?:saying|writing|stating|claiming|reporting)\b`,
+)
+
+func isExplicitSpeechReportingQuestion(question string) bool {
+	q := strings.ToLower(strings.TrimSpace(question))
+	// Assistant evidence can establish only what the assistant said. Mentioning
+	// an agent is not enough: "Was the agent authorized?" remains a claim about
+	// Victor's authorization and needs a user-authored instruction.
+	return explicitSpeechReportingQuestion.MatchString(q)
 }
 
 func uniqueQuoteMatch(text, hint string) bool {

--- a/internal/sessioninstructions/service.go
+++ b/internal/sessioninstructions/service.go
@@ -1,0 +1,422 @@
+// Package sessioninstructions answers bounded questions from one native Codex
+// conversation. It deliberately contains no authorization, workflow, or
+// resource taxonomy: the model interprets the question and attn validates only
+// transcript identity and the excerpts it returns.
+package sessioninstructions
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+const (
+	ModelName              = "gpt-5.6-luna"
+	lowEffort              = "low"
+	mediumEffort           = "medium"
+	defaultSnapshotMax     = 8 << 20
+	defaultConversationMax = 120_000
+)
+
+// Error is a stable, safe-to-render command failure. Its Message never
+// includes transcript or question content.
+type Error struct {
+	Code    string
+	Message string
+}
+
+func (e *Error) Error() string { return e.Message }
+
+var ErrInvalidResponse = errors.New("invalid structured model response")
+
+type ConversationTurn struct {
+	ID        string
+	Author    string
+	Text      string
+	Timestamp string
+}
+
+type CandidateEvidence struct {
+	TurnID string `json:"turn_id"`
+	Quote  string `json:"quote"`
+}
+
+type ModelAnswer struct {
+	Answer   string              `json:"answer"`
+	Evidence []CandidateEvidence `json:"evidence"`
+}
+
+type ModelRequest struct {
+	Question                 string
+	Conversation             []ConversationTurn
+	Effort                   string
+	PreviousValidationErrors []string
+}
+
+// ModelRunner runs a no-tools model call. The runner receives only the bounded
+// projection and must return the complete candidate, never a partial repair.
+type ModelRunner interface {
+	Run(context.Context, ModelRequest) (ModelAnswer, error)
+}
+
+type SessionLookup interface {
+	Get(string) *protocol.Session
+	GetResumeSessionID(string) string
+}
+
+type TranscriptFinder interface {
+	FindTranscriptForResume(string) string
+}
+
+type Service struct {
+	Store                SessionLookup
+	Finder               TranscriptFinder
+	Model                ModelRunner
+	SnapshotMaxBytes     int
+	ConversationMaxChars int
+}
+
+type Request struct {
+	TargetSessionID string
+	Question        string
+}
+
+func (s Service) Ask(ctx context.Context, req Request) (*protocol.SessionInstructionsResult, error) {
+	if strings.TrimSpace(req.TargetSessionID) == "" {
+		return nil, &Error{Code: "session_not_found", Message: "The target session was not found"}
+	}
+	if strings.TrimSpace(req.Question) == "" {
+		return nil, &Error{Code: "invalid_response", Message: "A non-blank question is required"}
+	}
+	if s.Store == nil || s.Finder == nil || s.Model == nil {
+		return nil, &Error{Code: "model_unavailable", Message: "Session instructions are unavailable"}
+	}
+	session := s.Store.Get(req.TargetSessionID)
+	if session == nil {
+		return nil, &Error{Code: "session_not_found", Message: "The target session was not found"}
+	}
+	if string(session.Agent) != protocol.SessionAgentCodex {
+		return nil, &Error{Code: "transcript_unavailable", Message: "The target transcript is unavailable"}
+	}
+	resumeID := strings.TrimSpace(s.Store.GetResumeSessionID(req.TargetSessionID))
+	if resumeID == "" {
+		return nil, &Error{Code: "transcript_unavailable", Message: "The target transcript is unavailable"}
+	}
+	path := strings.TrimSpace(s.Finder.FindTranscriptForResume(resumeID))
+	if path == "" {
+		return nil, &Error{Code: "transcript_unavailable", Message: "The target transcript is unavailable"}
+	}
+	raw, err := readSnapshot(path, s.snapshotLimit())
+	if err != nil {
+		return nil, &Error{Code: "transcript_unavailable", Message: "The target transcript is unavailable"}
+	}
+	turns, err := projectCodexConversation(raw)
+	if err != nil || len(turns) == 0 {
+		return nil, &Error{Code: "transcript_unavailable", Message: "The target transcript is unavailable"}
+	}
+	if conversationChars(turns) > s.conversationLimit() {
+		return nil, &Error{Code: "conversation_too_large", Message: "The target conversation is too large to inspect"}
+	}
+	fingerprint := "sha256:" + hash(raw)
+
+	first, err := s.Model.Run(ctx, ModelRequest{Question: req.Question, Conversation: turns, Effort: lowEffort})
+	if err != nil && !errors.Is(err, ErrInvalidResponse) {
+		return nil, &Error{Code: "model_unavailable", Message: "The session-instructions model is unavailable"}
+	}
+	firstErrs, _ := validateCandidate(first, req.Question, turns)
+	if errors.Is(err, ErrInvalidResponse) {
+		firstErrs = []string{"the first response was not valid structured output"}
+	}
+	if len(firstErrs) == 0 {
+		return resultFromCandidate(first, req.TargetSessionID, path, fingerprint, lowEffort, turns), nil
+	}
+
+	retry, err := s.Model.Run(ctx, ModelRequest{
+		Question:                 req.Question,
+		Conversation:             turns,
+		Effort:                   mediumEffort,
+		PreviousValidationErrors: firstErrs,
+	})
+	if err != nil && !errors.Is(err, ErrInvalidResponse) {
+		return nil, &Error{Code: "model_unavailable", Message: "The session-instructions model is unavailable"}
+	}
+	retryErrs, retryMalformed := validateCandidate(retry, req.Question, turns)
+	if errors.Is(err, ErrInvalidResponse) {
+		return nil, &Error{Code: "invalid_response", Message: "The model did not return valid structured output"}
+	}
+	if len(retryErrs) > 0 {
+		if retryMalformed {
+			return nil, &Error{Code: "invalid_response", Message: "The model did not return valid structured output"}
+		}
+		return nil, &Error{Code: "invalid_evidence", Message: "The model did not return verifiable evidence"}
+	}
+	return resultFromCandidate(retry, req.TargetSessionID, path, fingerprint, mediumEffort, turns), nil
+}
+
+func (s Service) snapshotLimit() int {
+	if s.SnapshotMaxBytes > 0 {
+		return s.SnapshotMaxBytes
+	}
+	return defaultSnapshotMax
+}
+
+func (s Service) conversationLimit() int {
+	if s.ConversationMaxChars > 0 {
+		return s.ConversationMaxChars
+	}
+	return defaultConversationMax
+}
+
+func readSnapshot(path string, max int) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil || info.Size() < 1 || info.Size() > int64(max) {
+		return nil, errors.New("snapshot unavailable")
+	}
+	return os.ReadFile(path)
+}
+
+type codexRecord struct {
+	Timestamp string `json:"timestamp"`
+	Type      string `json:"type"`
+	Payload   struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"payload"`
+}
+
+func projectCodexConversation(raw []byte) ([]ConversationTurn, error) {
+	var turns []ConversationTurn
+	lines := bytes.Split(raw, []byte{'\n'})
+	valid := false
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var record codexRecord
+		if err := json.Unmarshal(line, &record); err != nil {
+			continue
+		}
+		valid = true
+		if record.Type != "event_msg" {
+			continue
+		}
+		author := ""
+		switch record.Payload.Type {
+		case "user_message":
+			author = "user"
+		case "agent_message":
+			author = "assistant"
+		default:
+			continue
+		}
+		text := strings.TrimSpace(record.Payload.Message)
+		if text == "" {
+			continue
+		}
+		turns = append(turns, ConversationTurn{ID: fmt.Sprintf("turn-%d", len(turns)+1), Author: author, Text: text, Timestamp: record.Timestamp})
+	}
+	if !valid {
+		return nil, errors.New("not JSONL")
+	}
+	return turns, nil
+}
+
+func conversationChars(turns []ConversationTurn) int {
+	n := 0
+	for _, turn := range turns {
+		n += len(turn.Text)
+	}
+	return n
+}
+
+func hash(raw []byte) string { sum := sha256.Sum256(raw); return hex.EncodeToString(sum[:]) }
+
+func validateCandidate(candidate ModelAnswer, question string, turns []ConversationTurn) ([]string, bool) {
+	answer := safeAnswer(candidate.Answer)
+	malformed := false
+	var errs []string
+	if answer == "" {
+		errs = append(errs, "answer was empty")
+		malformed = true
+	}
+	if len(candidate.Evidence) == 0 {
+		errs = append(errs, "evidence was missing")
+		malformed = true
+	}
+	byID := make(map[string]ConversationTurn, len(turns))
+	for _, turn := range turns {
+		byID[turn.ID] = turn
+	}
+	seenUser := false
+	for _, evidence := range candidate.Evidence {
+		turn, ok := byID[evidence.TurnID]
+		if !ok {
+			errs = append(errs, "an evidence turn id was not found")
+			continue
+		}
+		if !uniqueQuoteMatch(turn.Text, evidence.Quote) {
+			errs = append(errs, "an evidence quote was not uniquely found")
+			continue
+		}
+		if turn.Author == "user" {
+			seenUser = true
+		}
+	}
+	if requiresUserEvidence(question, answer) && !seenUser {
+		errs = append(errs, "a user-instructions question needs user evidence")
+	}
+	return errs, malformed
+}
+
+func requiresUserEvidence(question, answer string) bool {
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(answer)), "unclear.") {
+		return false
+	}
+	q := strings.ToLower(question)
+	// Questions explicitly about what the assistant said are allowed to rely on
+	// assistant evidence. Everything else is conservatively treated as a claim
+	// about user-side instructions unless it is inconclusive.
+	if strings.Contains(q, "agent") || strings.Contains(q, "assistant") {
+		return false
+	}
+	return true
+}
+
+func uniqueQuoteMatch(text, hint string) bool {
+	hint = strings.TrimSpace(hint)
+	if hint == "" {
+		return false
+	}
+	if strings.Count(text, hint) == 1 {
+		return true
+	}
+	normalizedText, normalizedHint := normalize(text), normalize(hint)
+	return normalizedHint != "" && strings.Count(normalizedText, normalizedHint) == 1
+}
+
+func normalize(value string) string {
+	var b strings.Builder
+	space := false
+	for _, r := range strings.ToLower(value) {
+		switch r {
+		case '“', '”', '„', '‟':
+			r = '"'
+		case '‘', '’', '‚', '‛':
+			r = '\''
+		}
+		if unicode.IsSpace(r) {
+			space = b.Len() > 0
+			continue
+		}
+		if space {
+			b.WriteByte(' ')
+			space = false
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func resultFromCandidate(candidate ModelAnswer, sessionID, path, fingerprint, effort string, turns []ConversationTurn) *protocol.SessionInstructionsResult {
+	byID := make(map[string]ConversationTurn, len(turns))
+	for _, turn := range turns {
+		byID[turn.ID] = turn
+	}
+	evidence := make([]protocol.EvidenceExcerpt, 0, len(candidate.Evidence))
+	for _, item := range candidate.Evidence {
+		turn := byID[item.TurnID]
+		quote := exactQuote(turn.Text, item.Quote)
+		evidence = append(evidence, protocol.EvidenceExcerpt{TurnID: turn.ID, Author: turn.Author, Quote: quote, Timestamp: optionalTimestamp(turn.Timestamp)})
+	}
+	sort.SliceStable(evidence, func(i, j int) bool { return turnPosition(evidence[i].TurnID) < turnPosition(evidence[j].TurnID) })
+	return &protocol.SessionInstructionsResult{Answer: safeAnswer(candidate.Answer), Evidence: evidence, SessionID: sessionID, TranscriptPath: path, TranscriptFingerprint: fingerprint, Model: ModelName, ReasoningEffort: effort}
+}
+
+func turnPosition(id string) int {
+	var position int
+	_, _ = fmt.Sscanf(id, "turn-%d", &position)
+	return position
+}
+
+func exactQuote(text, hint string) string {
+	if at := strings.Index(text, hint); at >= 0 {
+		return text[at : at+len(hint)]
+	}
+	// Normalized matching has no byte-stable offset. Returning the whole original
+	// turn still preserves source bytes and cannot fabricate a quoted fragment.
+	return text
+}
+
+func optionalTimestamp(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+// Prompt returns the fixed, tool-less instruction given to the configured model.
+func Prompt(request ModelRequest) string {
+	var b strings.Builder
+	b.WriteString("Answer the question only from the labeled conversation. Return JSON with answer and evidence; evidence entries need turn_id and a short exact quote hint. For a yes/no question, answer must begin exactly Yes., No., or Unclear. Do not infer external facts from silence. An assistant turn can provide context, but it cannot independently establish what the user authorized; include the preceding assistant question when it is needed to interpret a terse user reply.\n\nQuestion:\n")
+	b.WriteString(request.Question)
+	b.WriteString("\n\nConversation:\n")
+	for _, turn := range request.Conversation {
+		fmt.Fprintf(&b, "[%s %s] %s\n", turn.ID, turn.Author, turn.Text)
+	}
+	if len(request.PreviousValidationErrors) > 0 {
+		b.WriteString("\nThe prior response was rejected. Produce a complete replacement. Validation errors:\n- ")
+		b.WriteString(strings.Join(request.PreviousValidationErrors, "\n- "))
+	}
+	return b.String()
+}
+
+// ParseModelAnswer accepts the JSON-only final answer requested by Prompt.
+func ParseModelAnswer(text string) (ModelAnswer, error) {
+	text = strings.TrimSpace(text)
+	if strings.HasPrefix(text, "```") {
+		text = strings.TrimPrefix(text, "```json")
+		text = strings.TrimPrefix(text, "```")
+		text = strings.TrimSuffix(strings.TrimSpace(text), "```")
+	}
+	var answer ModelAnswer
+	if err := json.Unmarshal([]byte(text), &answer); err != nil {
+		return ModelAnswer{}, ErrInvalidResponse
+	}
+	return answer, nil
+}
+
+func safeAnswer(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			if r == '\n' || r == '\t' {
+				b.WriteByte(' ')
+			}
+			continue
+		}
+		b.WriteRune(r)
+	}
+	answer := strings.TrimSpace(b.String())
+	switch strings.ToLower(answer) {
+	case "yes":
+		return "Yes."
+	case "no":
+		return "No."
+	case "unclear":
+		return "Unclear."
+	default:
+		return answer
+	}
+}

--- a/internal/sessioninstructions/service_test.go
+++ b/internal/sessioninstructions/service_test.go
@@ -1,0 +1,189 @@
+package sessioninstructions
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+type fakeStore struct {
+	session *protocol.Session
+	resume  string
+}
+
+func (s fakeStore) Get(string) *protocol.Session     { return s.session }
+func (s fakeStore) GetResumeSessionID(string) string { return s.resume }
+
+type fakeFinder struct{ path string }
+
+func (f fakeFinder) FindTranscriptForResume(string) string { return f.path }
+
+type fakeModel struct {
+	answers  []ModelAnswer
+	errs     []error
+	requests []ModelRequest
+}
+
+func (m *fakeModel) Run(_ context.Context, request ModelRequest) (ModelAnswer, error) {
+	m.requests = append(m.requests, request)
+	i := len(m.requests) - 1
+	if i < len(m.errs) && m.errs[i] != nil {
+		return ModelAnswer{}, m.errs[i]
+	}
+	return m.answers[i], nil
+}
+
+func writeTranscript(t *testing.T, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "conversation.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func testService(path string, model *fakeModel) Service {
+	return Service{Store: fakeStore{session: &protocol.Session{ID: "target", Agent: protocol.SessionAgentCodex}, resume: "native-target"}, Finder: fakeFinder{path: path}, Model: model}
+}
+
+func TestAskProjectsOnlyConversationAndCopiesExactQuotes(t *testing.T) {
+	path := writeTranscript(t,
+		`{"type":"session_meta","payload":{"id":"native-target"}}`,
+		`{"timestamp":"2026-07-18T10:00:00Z","type":"event_msg","payload":{"type":"user_message","message":"Please create PR #571. Do not merge it."}}`,
+		`{"type":"response_item","payload":{"type":"function_call","name":"shell"}}`,
+		`{"timestamp":"2026-07-18T10:01:00Z","type":"event_msg","payload":{"type":"agent_message","message":"The PR is ready. Should I merge it?"}}`,
+		`{"timestamp":"2026-07-18T10:02:00Z","type":"event_msg","payload":{"type":"user_message","message":"Yes, do it."}}`,
+	)
+	model := &fakeModel{answers: []ModelAnswer{{Answer: "Yes. The user authorized the merge.", Evidence: []CandidateEvidence{{TurnID: "turn-3", Quote: "Yes, do it."}, {TurnID: "turn-2", Quote: "Should I merge it?"}}}}}
+	result, err := testService(path, model).Ask(context.Background(), Request{TargetSessionID: "target", Question: "Was merging PR #571 authorized?"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ReasoningEffort != lowEffort || result.Model != ModelName {
+		t.Fatalf("result model = %+v", result)
+	}
+	if len(model.requests) != 1 || len(model.requests[0].Conversation) != 3 {
+		t.Fatalf("projection = %+v", model.requests)
+	}
+	if result.Evidence[0].TurnID != "turn-2" || result.Evidence[1].TurnID != "turn-3" {
+		t.Fatalf("evidence order = %+v", result.Evidence)
+	}
+	if result.Evidence[1].Quote != "Yes, do it." || !strings.HasPrefix(result.TranscriptFingerprint, "sha256:") {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestAskRetriesInvalidEvidenceAtMedium(t *testing.T) {
+	path := writeTranscript(t, `{"type":"event_msg","payload":{"type":"user_message","message":"Yes, do it."}}`)
+	model := &fakeModel{answers: []ModelAnswer{
+		{Answer: "Yes.", Evidence: []CandidateEvidence{{TurnID: "turn-9", Quote: "Yes"}}},
+		{Answer: "Yes.", Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "Yes, do it."}}},
+	}}
+	result, err := testService(path, model).Ask(context.Background(), Request{TargetSessionID: "target", Question: "Was it authorized?"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ReasoningEffort != mediumEffort || len(model.requests) != 2 {
+		t.Fatalf("result=%+v calls=%d", result, len(model.requests))
+	}
+	if model.requests[0].Effort != lowEffort || model.requests[1].Effort != mediumEffort || len(model.requests[1].PreviousValidationErrors) == 0 {
+		t.Fatalf("requests=%+v", model.requests)
+	}
+}
+
+func TestAskUnclearIsSuccessful(t *testing.T) {
+	path := writeTranscript(t, `{"type":"event_msg","payload":{"type":"user_message","message":"We discussed deployment timing."}}`)
+	model := &fakeModel{answers: []ModelAnswer{{Answer: "Unclear. The conversation does not say whether deployment was approved.", Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "deployment timing"}}}}}
+	result, err := testService(path, model).Ask(context.Background(), Request{TargetSessionID: "target", Question: "Was deployment approved?"})
+	if err != nil || !strings.HasPrefix(result.Answer, "Unclear.") {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+}
+
+func TestAskReturnsNegativeAnswer(t *testing.T) {
+	path := writeTranscript(t, `{"type":"event_msg","payload":{"type":"user_message","message":"Do not merge the PR."}}`)
+	model := &fakeModel{answers: []ModelAnswer{{Answer: "No. The user prohibited merging.", Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "Do not merge"}}}}}
+	result, err := testService(path, model).Ask(context.Background(), Request{TargetSessionID: "target", Question: "Was merging PR #571 authorized?"})
+	if err != nil || !strings.HasPrefix(result.Answer, "No.") {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+}
+
+func TestAskNormalizesOneWordYesNoAndUnclear(t *testing.T) {
+	for _, answer := range []string{"Yes", "No", "Unclear"} {
+		t.Run(answer, func(t *testing.T) {
+			path := writeTranscript(t, `{"type":"event_msg","payload":{"type":"user_message","message":"hello"}}`)
+			model := &fakeModel{answers: []ModelAnswer{{Answer: answer, Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "hello"}}}}}
+			result, err := testService(path, model).Ask(context.Background(), Request{TargetSessionID: "target", Question: "What did the user say?"})
+			if err != nil || result.Answer != answer+"." {
+				t.Fatalf("result=%+v err=%v", result, err)
+			}
+		})
+	}
+}
+
+func TestAskRejectsAssistantOnlyAuthorization(t *testing.T) {
+	path := writeTranscript(t, `{"type":"event_msg","payload":{"type":"agent_message","message":"I merged PR #571."}}`)
+	model := &fakeModel{answers: []ModelAnswer{
+		{Answer: "Yes.", Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "merged PR #571"}}},
+		{Answer: "Yes.", Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "merged PR #571"}}},
+	}}
+	_, err := testService(path, model).Ask(context.Background(), Request{TargetSessionID: "target", Question: "Was merging PR #571 authorized?"})
+	var sessionErr *Error
+	if !errors.As(err, &sessionErr) || sessionErr.Code != "invalid_evidence" {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestAskAllowsAssistantEvidenceForAssistantStatementQuestion(t *testing.T) {
+	path := writeTranscript(t, `{"type":"event_msg","payload":{"type":"agent_message","message":"I merged PR #571."}}`)
+	model := &fakeModel{answers: []ModelAnswer{{Answer: "Yes. The agent said it merged PR #571.", Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "merged PR #571"}}}}}
+	result, err := testService(path, model).Ask(context.Background(), Request{TargetSessionID: "target", Question: "Did the agent say it merged PR #571?"})
+	if err != nil || !strings.HasPrefix(result.Answer, "Yes.") {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+}
+
+func TestAskFailsClosedForMalformedAmbiguousOversizedAndModelFailure(t *testing.T) {
+	t.Run("malformed", func(t *testing.T) {
+		model := &fakeModel{}
+		_, err := testService(writeTranscript(t, `not-json`), model).Ask(context.Background(), Request{TargetSessionID: "target", Question: "What happened?"})
+		assertCode(t, err, "transcript_unavailable")
+	})
+	t.Run("missing", func(t *testing.T) {
+		_, err := testService(filepath.Join(t.TempDir(), "missing.jsonl"), &fakeModel{}).Ask(context.Background(), Request{TargetSessionID: "target", Question: "What happened?"})
+		assertCode(t, err, "transcript_unavailable")
+	})
+	t.Run("ambiguous evidence", func(t *testing.T) {
+		path := writeTranscript(t, `{"type":"event_msg","payload":{"type":"user_message","message":"yes yes"}}`)
+		model := &fakeModel{answers: []ModelAnswer{{Answer: "Yes.", Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "yes"}}}, {Answer: "Yes.", Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "yes"}}}}}
+		_, err := testService(path, model).Ask(context.Background(), Request{TargetSessionID: "target", Question: "Was it authorized?"})
+		assertCode(t, err, "invalid_evidence")
+	})
+	t.Run("oversized", func(t *testing.T) {
+		path := writeTranscript(t, `{"type":"event_msg","payload":{"type":"user_message","message":"abcdefghij"}}`)
+		service := testService(path, &fakeModel{})
+		service.ConversationMaxChars = 2
+		_, err := service.Ask(context.Background(), Request{TargetSessionID: "target", Question: "What happened?"})
+		assertCode(t, err, "conversation_too_large")
+	})
+	t.Run("model failure", func(t *testing.T) {
+		path := writeTranscript(t, `{"type":"event_msg","payload":{"type":"user_message","message":"hello"}}`)
+		model := &fakeModel{errs: []error{errors.New("timeout")}}
+		_, err := testService(path, model).Ask(context.Background(), Request{TargetSessionID: "target", Question: "What happened?"})
+		assertCode(t, err, "model_unavailable")
+	})
+}
+
+func assertCode(t *testing.T, err error, code string) {
+	t.Helper()
+	var sessionErr *Error
+	if !errors.As(err, &sessionErr) || sessionErr.Code != code {
+		t.Fatalf("err=%v, want code %s", err, code)
+	}
+}

--- a/internal/sessioninstructions/service_test.go
+++ b/internal/sessioninstructions/service_test.go
@@ -140,6 +140,19 @@ func TestAskRejectsAssistantOnlyAuthorization(t *testing.T) {
 	}
 }
 
+func TestAskRejectsAssistantOnlyAuthorizationQuestionAboutAgent(t *testing.T) {
+	path := writeTranscript(t, `{"type":"event_msg","payload":{"type":"agent_message","message":"I was authorized to merge PR #571."}}`)
+	model := &fakeModel{answers: []ModelAnswer{
+		{Answer: "Yes.", Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "authorized to merge PR #571"}}},
+		{Answer: "Yes.", Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "authorized to merge PR #571"}}},
+	}}
+	_, err := testService(path, model).Ask(context.Background(), Request{TargetSessionID: "target", Question: "Was the agent authorized to merge PR #571?"})
+	var sessionErr *Error
+	if !errors.As(err, &sessionErr) || sessionErr.Code != "invalid_evidence" {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestAskAllowsAssistantEvidenceForAssistantStatementQuestion(t *testing.T) {
 	path := writeTranscript(t, `{"type":"event_msg","payload":{"type":"agent_message","message":"I merged PR #571."}}`)
 	model := &fakeModel{answers: []ModelAnswer{{Answer: "Yes. The agent said it merged PR #571.", Evidence: []CandidateEvidence{{TurnID: "turn-1", Quote: "merged PR #571"}}}}}

--- a/internal/transcript/discovery.go
+++ b/internal/transcript/discovery.go
@@ -13,11 +13,10 @@ import (
 // FindCodexTranscript searches Codex session logs for the most recent session
 // matching the given cwd and start time. Returns empty string if not found.
 func FindCodexTranscript(cwd string, startedAt time.Time) string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
+	sessionsDir := codexSessionsDir()
+	if sessionsDir == "" {
 		return ""
 	}
-	sessionsDir := filepath.Join(homeDir, ".codex", "sessions")
 
 	type codexLine struct {
 		Type      string `json:"type"`
@@ -109,6 +108,60 @@ func FindCodexTranscript(cwd string, startedAt time.Time) string {
 		return bestPath
 	}
 	return fallbackPath
+}
+
+// FindCodexTranscriptForResume resolves a transcript by the native Codex
+// session id recorded in its session_meta event. Unlike cwd/time discovery it
+// cannot select a plausible neighbouring session.
+func FindCodexTranscriptForResume(resumeID string) string {
+	resumeID = strings.TrimSpace(resumeID)
+	if resumeID == "" {
+		return ""
+	}
+	sessionsDir := codexSessionsDir()
+	if sessionsDir == "" {
+		return ""
+	}
+	var found string
+	_ = filepath.WalkDir(sessionsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".jsonl") || found != "" {
+			return nil
+		}
+		f, openErr := os.Open(path)
+		if openErr != nil {
+			return nil
+		}
+		defer f.Close()
+		line, readErr := bufio.NewReader(f).ReadBytes('\n')
+		if readErr != nil && len(line) == 0 {
+			return nil
+		}
+		var entry struct {
+			Type    string `json:"type"`
+			Payload struct {
+				ID string `json:"id"`
+			} `json:"payload"`
+		}
+		if json.Unmarshal(bytes.TrimSpace(line), &entry) == nil && entry.Type == "session_meta" && strings.TrimSpace(entry.Payload.ID) == resumeID {
+			found = path
+		}
+		return nil
+	})
+	return found
+}
+
+// codexSessionsDir follows Codex's CODEX_HOME override when present. This is
+// necessary for isolated profiles and test environments; the default remains
+// the native ~/.codex/sessions location.
+func codexSessionsDir() string {
+	if codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME")); codexHome != "" {
+		return filepath.Join(codexHome, "sessions")
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(homeDir, ".codex", "sessions")
 }
 
 func pathsEquivalent(a, b string) bool {

--- a/internal/transcript/discovery_test.go
+++ b/internal/transcript/discovery_test.go
@@ -90,6 +90,7 @@ func writeCodexTranscript(
 
 func TestFindCodexTranscript_MatchesSymlinkEquivalentCWD(t *testing.T) {
 	homeDir := t.TempDir()
+	t.Setenv("CODEX_HOME", "")
 	oldHome := os.Getenv("HOME")
 	if err := os.Setenv("HOME", homeDir); err != nil {
 		t.Fatalf("set HOME: %v", err)
@@ -122,6 +123,44 @@ func TestFindCodexTranscript_MatchesSymlinkEquivalentCWD(t *testing.T) {
 	got := FindCodexTranscript(linkCWD, startedAt)
 	if got != expected {
 		t.Fatalf("FindCodexTranscript() = %q, want %q", got, expected)
+	}
+}
+
+func TestFindCodexTranscriptForResume_SelectsExactNativeID(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("CODEX_HOME", "")
+	oldHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	wrong := writeCodexTranscript(t, homeDir, "native-wrong", "/repo", now, now)
+	want := writeCodexTranscript(t, homeDir, "native-target", "/other", now.Add(time.Second), now.Add(time.Second))
+	if got := FindCodexTranscriptForResume("native-target"); got != want {
+		t.Fatalf("FindCodexTranscriptForResume() = %q, want %q (wrong=%q)", got, want, wrong)
+	}
+}
+
+func TestFindCodexTranscriptForResume_HonorsCodexHome(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("HOME", t.TempDir())
+	start := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	sessionDir := filepath.Join(codexHome, "sessions", "2026", "07", "18")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(sessionDir, "rollout-native-target.jsonl")
+	line := fmt.Sprintf(`{"type":"session_meta","payload":{"id":"%s","cwd":"/synthetic"}}`+"\n", "native-target")
+	if err := os.WriteFile(want, []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(want, start, start); err != nil {
+		t.Fatal(err)
+	}
+	if got := FindCodexTranscriptForResume("native-target"); got != want {
+		t.Fatalf("FindCodexTranscriptForResume() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Intent

Let users ask a free-form, evidence-bounded question about a previous native Codex conversation, without creating an authorization ledger or workflow-specific policy model.

## Summary

- Adds attn session instructions <session-id> --question "..." with concise human and JSON output.
- Finds only the exact native session transcript, bounds and fingerprints it, and validates every quoted excerpt against the source. Assistant text may add context but cannot independently establish authorization.
- Runs Luna with no shell, unified execution, web, MCP, or workspace access; preserves the default CODEX_HOME for packaged-daemon Codex authentication.
- Includes malformed, missing, oversized, fabricated/ambiguous citation, assistant-only, model-failure, CLI, and transcript-discovery coverage.

## Test plan

- [x] go test ./...
- [x] git diff --check
- [x] Installed isolated non-production attn app smoke with a synthetic native transcript: returned Yes with validated excerpts, transcript path/fingerprint, and gpt-5.6-luna low effort.

## Out of scope

This reports what the recorded conversation supports. It does not establish external human identity, create an authorization ledger, or interpret PR/workflow-specific policy.