### PR TITLE
feat(protocol): endpoint_id on Workspace — hub stamps remote workspaces, frontend gate reads the record (protocol 171)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1973,12 +1973,6 @@ sendFetchPRDetails,
   // default actually needs.
   const daemonWorkspacesRef = useRef<DaemonWorkspace[]>([]);
 
-  // Same reasoning as daemonWorkspacesRef: lets handleOpenNotebookTile read the
-  // current session list (to gate a workspace's directory to local-only, see
-  // localWorkspaceDirectory) without rebinding the callback on every session
-  // change.
-  const daemonSessionsRef = useRef<DaemonSession[]>([]);
-
   // Dock a fresh Notebook tile into the active workspace. A unique tile id every
   // time: the daemon treats a duplicate id as a move, so a shared id would just
   // relocate the first tile instead of opening a second. Defaults the tile's root
@@ -1991,8 +1985,11 @@ sendFetchPRDetails,
     const workspaceId = activeWorkspaceIdRef.current;
     if (!workspaceId) return;
     const tileId = `notebook-tile-${crypto.randomUUID()}`;
-    const workspace = daemonWorkspacesRef.current.find((w) => w.id === workspaceId);
-    const localDirectory = localWorkspaceDirectory(workspace?.directory, daemonSessionsRef.current, workspaceId);
+    // endpoint-aware find: raw workspace ids can repeat across a remote twin
+    // mirrored by the hub, so filter to the local record before trusting its
+    // directory (see localWorkspaceDirectory).
+    const workspace = daemonWorkspacesRef.current.find((w) => w.id === workspaceId && !w.endpoint_id);
+    const localDirectory = localWorkspaceDirectory(workspace);
     const effectiveNotebookRoot = settings['notebook.root.effective'] || '';
     const root = resolveEditorTileRoot(localDirectory, effectiveNotebookRoot);
     void sendWorkspaceDockTile(workspaceId, tileId, 'notebook', {
@@ -2836,11 +2833,6 @@ sendFetchPRDetails,
   useEffect(() => {
     daemonWorkspacesRef.current = daemonWorkspaces;
   }, [daemonWorkspaces]);
-  // daemonSessionsRef mirrors daemonSessions for handleOpenNotebookTile — see
-  // its declaration for why a ref instead of a direct dependency.
-  useEffect(() => {
-    daemonSessionsRef.current = daemonSessions;
-  }, [daemonSessions]);
   useEffect(() => {
     if (view === 'session' && activeWorkspaceId) {
       sendWorkspaceSelected(activeWorkspaceId);
@@ -3646,7 +3638,7 @@ sendFetchPRDetails,
                   <SessionTerminalWorkspace
                     ref={setWorkspaceRef(workspace.id)}
                     workspaceId={workspace.id}
-                    workspaceDirectory={localWorkspaceDirectory(workspace.directory, daemonSessions, workspace.id)}
+                    workspaceDirectory={localWorkspaceDirectory({ directory: workspace.directory, endpoint_id: workspace.endpointId })}
                     workspaceSessions={workspace.sessions.map((entry) => ({
                       id: entry.id,
                       label: entry.label,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -61,7 +61,7 @@ import {
 import { persistExcludedGridSessions, readExcludedGridSessions } from './components/grid/gridMembership';
 import type { HiddenGridSession } from './components/grid/GridHiddenSessions';
 import { normalizeSessionAgent, type SessionAgent } from './types/sessionAgent';
-import { hasPane, workspaceSnapshotFromDaemonWorkspace, resolveEditorTileRoot, localWorkspaceDirectory, serializeNotebookTileParams, type TerminalSplitDirection } from './types/workspace';
+import { hasPane, workspaceSnapshotFromDaemonWorkspace, resolveEditorTileRoot, localWorkspaceDirectory, soleWorkspaceForId, serializeNotebookTileParams, type TerminalSplitDirection } from './types/workspace';
 import { useDaemonStore } from './store/daemonSessions';
 import { usePRsNeedingAttention } from './hooks/usePRsNeedingAttention';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -1985,10 +1985,13 @@ sendFetchPRDetails,
     const workspaceId = activeWorkspaceIdRef.current;
     if (!workspaceId) return;
     const tileId = `notebook-tile-${crypto.randomUUID()}`;
-    // endpoint-aware find: raw workspace ids can repeat across a remote twin
-    // mirrored by the hub, so filter to the local record before trusting its
-    // directory (see localWorkspaceDirectory).
-    const workspace = daemonWorkspacesRef.current.find((w) => w.id === workspaceId && !w.endpoint_id);
+    // Duplicate ids across endpoints are unresolvable from a bare active id
+    // (activeWorkspaceIdRef carries no endpoint identity), so any twin
+    // ambiguity forfeits the workspace-dir default — the tile falls back to
+    // the Notebook root instead of risking adopting a remote twin's
+    // directory. localWorkspaceDirectory still rejects a sole-but-remote
+    // record on top of this.
+    const workspace = soleWorkspaceForId(daemonWorkspacesRef.current, workspaceId);
     const localDirectory = localWorkspaceDirectory(workspace);
     const effectiveNotebookRoot = settings['notebook.root.effective'] || '';
     const root = resolveEditorTileRoot(localDirectory, effectiveNotebookRoot);

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '170';
+export const PROTOCOL_VERSION = '171';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1881,14 +1881,15 @@ export interface WarningElement {
 }
 
 export interface WorkspaceElement {
-    directory: string;
-    id:        string;
-    layout?:   Layout;
-    muted:     boolean;
-    pinned:    boolean;
-    rank:      string;
-    status:    WorkspaceStatus;
-    title:     string;
+    directory:    string;
+    endpoint_id?: string;
+    id:           string;
+    layout?:      Layout;
+    muted:        boolean;
+    pinned:       boolean;
+    rank:         string;
+    status:       WorkspaceStatus;
+    title:        string;
     [property: string]: any;
 }
 
@@ -4535,14 +4536,15 @@ export enum WorkflowRunUpsertMessageCmd {
 }
 
 export interface Workspace {
-    directory: string;
-    id:        string;
-    layout?:   Layout;
-    muted:     boolean;
-    pinned:    boolean;
-    rank:      string;
-    status:    WorkspaceStatus;
-    title:     string;
+    directory:    string;
+    endpoint_id?: string;
+    id:           string;
+    layout?:      Layout;
+    muted:        boolean;
+    pinned:       boolean;
+    rank:         string;
+    status:       WorkspaceStatus;
+    title:        string;
     [property: string]: any;
 }
 
@@ -8833,6 +8835,7 @@ const typeMap: any = {
     ], "any"),
     "WorkspaceElement": o([
         { json: "directory", js: "directory", typ: "" },
+        { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "id", js: "id", typ: "" },
         { json: "layout", js: "layout", typ: u(undefined, r("Layout")) },
         { json: "muted", js: "muted", typ: true },
@@ -10415,6 +10418,7 @@ const typeMap: any = {
     ], "any"),
     "Workspace": o([
         { json: "directory", js: "directory", typ: "" },
+        { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "id", js: "id", typ: "" },
         { json: "layout", js: "layout", typ: u(undefined, r("Layout")) },
         { json: "muted", js: "muted", typ: true },

--- a/app/src/types/workspace.test.ts
+++ b/app/src/types/workspace.test.ts
@@ -331,38 +331,31 @@ describe('resolveEditorTileRoot', () => {
 });
 
 describe('localWorkspaceDirectory', () => {
-  it('returns undefined for a sessionless workspace (absence of evidence is not evidence of locality)', () => {
-    expect(localWorkspaceDirectory('/Users/victor/code/attn', [], 'ws-1')).toBeUndefined();
+  it('returns undefined for a remote workspace (endpoint_id set)', () => {
+    const workspace = { directory: '/Users/victor/code/attn', endpoint_id: 'remote-mac' };
+    expect(localWorkspaceDirectory(workspace)).toBeUndefined();
   });
 
-  it('returns undefined when the workspace has only a session with a non-empty endpoint_id', () => {
-    const sessions = [{ workspace_id: 'ws-1', endpoint_id: 'remote-mac' }];
-    expect(localWorkspaceDirectory('/home/victor/code/attn', sessions, 'ws-1')).toBeUndefined();
+  it('returns the directory for a local workspace with an empty-string endpoint_id', () => {
+    const workspace = { directory: '/Users/victor/code/attn', endpoint_id: '' };
+    expect(localWorkspaceDirectory(workspace)).toBe('/Users/victor/code/attn');
   });
 
-  it('returns undefined when the workspace has both a local and a remote session (duplicate-id corner)', () => {
-    const sessions = [
-      { workspace_id: 'ws-1', endpoint_id: '' },
-      { workspace_id: 'ws-1', endpoint_id: 'remote-mac' },
+  it('returns the directory for a local workspace with an absent endpoint_id', () => {
+    const workspace = { directory: '/Users/victor/code/attn' };
+    expect(localWorkspaceDirectory(workspace)).toBe('/Users/victor/code/attn');
+  });
+
+  it('returns undefined for an undefined workspace', () => {
+    expect(localWorkspaceDirectory(undefined)).toBeUndefined();
+  });
+
+  it('endpoint-aware find picks the local twin\'s directory from a duplicate-id workspace list', () => {
+    const workspaces = [
+      { id: 'ws-1', directory: '/remote/code/attn', endpoint_id: 'remote-mac' },
+      { id: 'ws-1', directory: '/Users/victor/code/attn', endpoint_id: undefined as string | undefined },
     ];
-    expect(localWorkspaceDirectory('/Users/victor/code/attn', sessions, 'ws-1')).toBeUndefined();
-  });
-
-  it('returns the directory when a session on the workspace has an empty-string endpoint_id', () => {
-    const sessions = [{ workspace_id: 'ws-1', endpoint_id: '' }];
-    expect(localWorkspaceDirectory('/Users/victor/code/attn', sessions, 'ws-1')).toBe('/Users/victor/code/attn');
-  });
-
-  it('returns the directory when a session on the workspace has an absent endpoint_id', () => {
-    const sessions = [{ workspace_id: 'ws-1' }];
-    expect(localWorkspaceDirectory('/Users/victor/code/attn', sessions, 'ws-1')).toBe('/Users/victor/code/attn');
-  });
-
-  it('returns the directory when the only remote session belongs to a different workspace', () => {
-    const sessions = [
-      { workspace_id: 'ws-1' },
-      { workspace_id: 'ws-2', endpoint_id: 'remote-mac' },
-    ];
-    expect(localWorkspaceDirectory('/Users/victor/code/attn', sessions, 'ws-1')).toBe('/Users/victor/code/attn');
+    const local = workspaces.find((w) => w.id === 'ws-1' && !w.endpoint_id);
+    expect(localWorkspaceDirectory(local)).toBe('/Users/victor/code/attn');
   });
 });

--- a/app/src/types/workspace.test.ts
+++ b/app/src/types/workspace.test.ts
@@ -9,6 +9,7 @@ import {
   getSplitDividers,
   hasPane,
   localWorkspaceDirectory,
+  soleWorkspaceForId,
   parseNotebookTileParams,
   resolveEditorTileRoot,
   serializeNotebookTileParams,
@@ -350,12 +351,35 @@ describe('localWorkspaceDirectory', () => {
     expect(localWorkspaceDirectory(undefined)).toBeUndefined();
   });
 
-  it('endpoint-aware find picks the local twin\'s directory from a duplicate-id workspace list', () => {
+});
+
+describe('soleWorkspaceForId + localWorkspaceDirectory (active-id locality)', () => {
+  it('does not adopt the local twin\'s directory when a remote twin shares the active id', () => {
     const workspaces = [
-      { id: 'ws-1', directory: '/remote/code/attn', endpoint_id: 'remote-mac' },
-      { id: 'ws-1', directory: '/Users/victor/code/attn', endpoint_id: undefined as string | undefined },
+      { id: 'ws-1', directory: '/local/dir' },
+      { id: 'ws-1', directory: '/remote/dir', endpoint_id: 'remote-mac' },
     ];
-    const local = workspaces.find((w) => w.id === 'ws-1' && !w.endpoint_id);
-    expect(localWorkspaceDirectory(local)).toBe('/Users/victor/code/attn');
+    const resolved = soleWorkspaceForId(workspaces, 'ws-1');
+    expect(resolved).toBeUndefined();
+    expect(localWorkspaceDirectory(resolved)).toBeUndefined();
+  });
+
+  it('returns the directory for a sole local record', () => {
+    const workspaces = [{ id: 'ws-1', directory: '/Users/victor/code/attn' }];
+    const resolved = soleWorkspaceForId(workspaces, 'ws-1');
+    expect(localWorkspaceDirectory(resolved)).toBe('/Users/victor/code/attn');
+  });
+
+  it('returns undefined for a sole remote record', () => {
+    const workspaces = [{ id: 'ws-1', directory: '/remote/dir', endpoint_id: 'remote-mac' }];
+    const resolved = soleWorkspaceForId(workspaces, 'ws-1');
+    expect(localWorkspaceDirectory(resolved)).toBeUndefined();
+  });
+
+  it('returns undefined when the id is absent from the list', () => {
+    const workspaces = [{ id: 'ws-2', directory: '/Users/victor/code/attn' }];
+    const resolved = soleWorkspaceForId(workspaces, 'ws-1');
+    expect(resolved).toBeUndefined();
+    expect(localWorkspaceDirectory(resolved)).toBeUndefined();
   });
 });

--- a/app/src/types/workspace.ts
+++ b/app/src/types/workspace.ts
@@ -504,31 +504,27 @@ export function resolveEditorTileRoot(
 // locally-connected daemon, so handing a remote directory to them can read or
 // write the wrong machine's files.
 //
-// A workspace's own record carries no endpoint marker: listWorkspaces appends
-// hubManager.RemoteWorkspaces() to the local workspace list independently of
-// sessions, and protocol.Workspace has no endpoint_id field at all. So the
-// only signal available here is the workspace's live sessions, and absence of
-// a session is absence of evidence, not evidence of locality — a retained
-// sessionless workspace (attn keeps pinned/tile-only workspaces after their
-// last session ends) must stay locked rather than default to passing its
-// directory through.
+// The workspace record itself now carries the endpoint marker: a hub daemon
+// stamps EndpointID on every workspace it mirrors from a remote endpoint at
+// ingest (internal/hub/manager.go replaceRemoteWorkspaces/upsertRemoteWorkspace),
+// and never trusts a remote-supplied value when doing so. That makes locality
+// a property of the workspace record itself rather than something inferred
+// from live sessions, so a retained sessionless workspace (attn keeps
+// pinned/tile-only workspaces after their last session ends) gets its
+// directory back instead of staying locked for lack of session evidence.
 //
-// Returns directory only when a session on this workspace positively proves
-// locality (an empty/absent endpoint_id) AND no session on this workspace
-// proves it remote. The second condition also covers the duplicate-id corner:
-// raw workspace ids can repeat across endpoints (disambiguated only by their
-// sessions), so if a remote twin's session shares this workspace_id, we can't
-// tell whose directory the caller's bare-id lookup actually grabbed — stay
-// locked rather than guess.
+// Returns directory only when the workspace exists and its endpoint_id is
+// absent/empty (local). Callers doing an id-based lookup across a workspace
+// list that may contain duplicate-id remote twins should filter by
+// !endpoint_id themselves before calling this (see the duplicate-id find in
+// App.tsx) — this function trusts whatever workspace record it's handed.
 export function localWorkspaceDirectory(
-  directory: string | undefined,
-  sessions: ReadonlyArray<{ workspace_id?: string | null; endpoint_id?: string | null }>,
-  workspaceId: string,
+  workspace: { directory?: string | null; endpoint_id?: string | null } | undefined,
 ): string | undefined {
-  const workspaceSessions = sessions.filter((session) => session.workspace_id === workspaceId);
-  const provenLocal = workspaceSessions.some((session) => !session.endpoint_id);
-  const provenRemote = workspaceSessions.some((session) => !!session.endpoint_id);
-  return provenLocal && !provenRemote ? directory : undefined;
+  if (!workspace || workspace.endpoint_id) {
+    return undefined;
+  }
+  return workspace.directory ?? undefined;
 }
 
 function agentTerminalsFromPanes(panes: PaneElement[]): AgentTerminal[] {

--- a/app/src/types/workspace.ts
+++ b/app/src/types/workspace.ts
@@ -497,6 +497,20 @@ export function resolveEditorTileRoot(
   return trimmed;
 }
 
+// Resolve the workspace record for a bare active-workspace id, for callers
+// that need to trust the record's locality (localWorkspaceDirectory). The
+// active-workspace selection carries no endpoint identity, so when the same
+// id names both a local and a remote twin we cannot know which one is
+// actually active — fail closed (undefined) rather than adopt the local
+// twin's directory for a workspace that may be the remote one.
+export function soleWorkspaceForId<T extends { id: string }>(
+  workspaces: ReadonlyArray<T>,
+  workspaceId: string,
+): T | undefined {
+  const matches = workspaces.filter((w) => w.id === workspaceId);
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 // localWorkspaceDirectory gates a workspace's directory to the local
 // filesystem, defaulting to locked (undefined) until locality is positively
 // proven — not the other way around. None of the sendFs* calls (sendFsIndex,
@@ -515,9 +529,9 @@ export function resolveEditorTileRoot(
 //
 // Returns directory only when the workspace exists and its endpoint_id is
 // absent/empty (local). Callers doing an id-based lookup across a workspace
-// list that may contain duplicate-id remote twins should filter by
-// !endpoint_id themselves before calling this (see the duplicate-id find in
-// App.tsx) — this function trusts whatever workspace record it's handed.
+// list that may contain duplicate-id remote twins should resolve the record
+// with soleWorkspaceForId first (see App.tsx handleOpenNotebookTile) — this
+// function trusts whatever workspace record it's handed.
 export function localWorkspaceDirectory(
   workspace: { directory?: string | null; endpoint_id?: string | null } | undefined,
 ): string | undefined {

--- a/docs/plans/2026-07-18-editor-arbitrary-roots.md
+++ b/docs/plans/2026-07-18-editor-arbitrary-roots.md
@@ -73,13 +73,13 @@ directory. The storage concept (keeper, journal, knowledge base) stays bound to
       string back-compat), root-aware fs calls, `fs_changed` root filtering
 - [x] PR5 frontend (#585): workspace-directory default for ⌘⌥N, header root
       switcher, finder on `fs_index`
-- [ ] PR6 frontend: off-root affordance gating, Editor labels + settings copy,
+- [x] PR6 frontend (#588): off-root affordance gating, Editor labels + settings copy,
       changelog, packaged-app bridge-only scenario (editor over a workspace
       root)
 - [ ] PR7 daemon+frontend: endpoint_id on protocol.Workspace (populated for
       hub remote workspaces) so localWorkspaceDirectory can restore the
       workspace-dir default for sessionless local pinned workspaces
-      (fast-follow committed in PR #585 review)
+      (fast-follow committed in PR #585 review) (this PR)
 
 ## Open Questions
 

--- a/internal/daemon/workspace_session_protocol_test.go
+++ b/internal/daemon/workspace_session_protocol_test.go
@@ -1040,3 +1040,40 @@ func (b *failingSpawnBackend) Recover(context.Context) (ptybackend.RecoveryRepor
 	return ptybackend.RecoveryReport{}, nil
 }
 func (b *failingSpawnBackend) Shutdown(context.Context) error { return nil }
+
+// TestListWorkspacesLocalWorkspaceHasEmptyEndpointID guards the local half of
+// the endpoint_id contract (internal/protocol/schema/main.tsp Workspace):
+// only a hub stamps EndpointID on workspaces it mirrors from a remote
+// endpoint (internal/hub/manager.go replaceRemoteWorkspaces/
+// upsertRemoteWorkspace); a workspace registered directly on this daemon must
+// never carry one. The frontend's localWorkspaceDirectory gate
+// (app/src/types/workspace.ts) trusts this to decide whether a workspace's
+// directory is safe to hand to non-endpoint-aware fs calls.
+func TestListWorkspacesLocalWorkspaceHasEmptyEndpointID(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	client := newWorkspaceProtocolTestClient()
+	workspaceID := "workspace-local-endpoint-id"
+	cwd := t.TempDir()
+
+	d.handleRegisterWorkspace(client, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        workspaceID,
+		Title:     "Local Workspace",
+		Directory: cwd,
+	})
+
+	workspaces := d.listWorkspaces()
+	var found *protocol.Workspace
+	for i := range workspaces {
+		if workspaces[i].ID == workspaceID {
+			found = &workspaces[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("listWorkspaces() did not include %s: %+v", workspaceID, workspaces)
+	}
+	if found.EndpointID != nil && *found.EndpointID != "" {
+		t.Fatalf("local workspace EndpointID = %v, want nil/empty", found.EndpointID)
+	}
+}

--- a/internal/hub/manager.go
+++ b/internal/hub/manager.go
@@ -1208,6 +1208,7 @@ func (m *Manager) replaceRemoteWorkspaces(id string, workspaces []protocol.Works
 	}
 	next := make(map[string]protocol.Workspace, len(workspaces))
 	for _, workspace := range workspaces {
+		workspace.EndpointID = protocol.Ptr(id)
 		next[workspace.ID] = workspace
 	}
 	if workspaceLayoutsEqual(runtime.workspaces, next) {
@@ -1249,6 +1250,7 @@ func (m *Manager) upsertRemoteWorkspace(id string, workspace protocol.Workspace)
 	if runtime.workspaces == nil {
 		runtime.workspaces = make(map[string]protocol.Workspace)
 	}
+	workspace.EndpointID = protocol.Ptr(id)
 	runtime.workspaces[workspace.ID] = workspace
 	return true
 }

--- a/internal/hub/manager_test.go
+++ b/internal/hub/manager_test.go
@@ -190,6 +190,12 @@ func TestManagerRemoteWorkspacesTrackAndClear(t *testing.T) {
 	if got[0].ID != "ws-a" || got[1].ID != "ws-b" {
 		t.Fatalf("RemoteWorkspaces() ids = %q, %q, want ws-a, ws-b", got[0].ID, got[1].ID)
 	}
+	if got[0].EndpointID == nil || *got[0].EndpointID != first.ID {
+		t.Fatalf("RemoteWorkspaces()[0].EndpointID = %v, want %q", got[0].EndpointID, first.ID)
+	}
+	if got[1].EndpointID == nil || *got[1].EndpointID != second.ID {
+		t.Fatalf("RemoteWorkspaces()[1].EndpointID = %v, want %q", got[1].EndpointID, second.ID)
+	}
 
 	if endpointID, ok := manager.EndpointIDForSession("missing"); ok || endpointID != "" {
 		t.Fatalf("EndpointIDForSession(missing) = (%q, %v), want ('', false)", endpointID, ok)
@@ -220,6 +226,60 @@ func TestManagerRemoteWorkspacesTrackAndClear(t *testing.T) {
 	got = manager.RemoteWorkspaces()
 	if len(got) != 1 || got[0].ID != "ws-b" {
 		t.Fatalf("RemoteWorkspaces() after clear = %+v, want only ws-b", got)
+	}
+}
+
+// TestManagerStampsEndpointIDOnIngest verifies the hub always overwrites
+// EndpointID with the ingesting endpoint's own id — never trusting a
+// remote-supplied value — for both replaceRemoteWorkspaces and
+// upsertRemoteWorkspace, and that stamping does not defeat the
+// workspaceLayoutsEqual change-detection short-circuit (re-ingesting an
+// identical workspace still reports no change).
+func TestManagerStampsEndpointIDOnIngest(t *testing.T) {
+	endpointStore := store.New()
+	first, err := endpointStore.AddEndpoint("gpu-box", "gpu", "")
+	if err != nil {
+		t.Fatalf("AddEndpoint(first) error = %v", err)
+	}
+
+	manager := NewManager(endpointStore, nil, nil, nil, nil)
+
+	workspace := protocol.Workspace{
+		ID:         "ws-a",
+		Title:      "GPU review",
+		Directory:  "/srv/repo",
+		Status:     protocol.WorkspaceStatusWorking,
+		EndpointID: protocol.Ptr("bogus-spoofed-id"),
+	}
+
+	if changed := manager.replaceRemoteWorkspaces(first.ID, []protocol.Workspace{workspace}); !changed {
+		t.Fatal("replaceRemoteWorkspaces reported no change on first ingest")
+	}
+	got := manager.RemoteWorkspace("ws-a")
+	if got == nil || got.EndpointID == nil || *got.EndpointID != first.ID {
+		t.Fatalf("RemoteWorkspace(ws-a).EndpointID = %v, want %q (bogus pre-set value must be overwritten)", got, first.ID)
+	}
+
+	// Re-ingesting the identical (still bogus-tagged) workspace must not
+	// report a change: stamping happens before the equality comparison, so
+	// stamped-vs-stamped still compares equal.
+	if changed := manager.replaceRemoteWorkspaces(first.ID, []protocol.Workspace{workspace}); changed {
+		t.Fatal("replaceRemoteWorkspaces reported a change re-ingesting an identical workspace")
+	}
+
+	// upsertRemoteWorkspace must also overwrite a spoofed EndpointID.
+	if changed := manager.upsertRemoteWorkspace(first.ID, protocol.Workspace{
+		ID:         "ws-c",
+		Title:      "Upserted",
+		Directory:  "/srv/repo2",
+		Status:     protocol.WorkspaceStatusIdle,
+		EndpointID: protocol.Ptr("also-bogus"),
+	}); !changed {
+		t.Fatal("upsertRemoteWorkspace reported no change")
+	}
+	upserted := manager.RemoteWorkspace("ws-c")
+	if upserted == nil || upserted.EndpointID == nil || *upserted.EndpointID != first.ID {
+		t.Fatalf("RemoteWorkspace(ws-c).EndpointID = %v, want %q (bogus pre-set value must be overwritten)", upserted, first.ID)
 	}
 }
 

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "170"
+const ProtocolVersion = "171"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -4758,6 +4758,9 @@ type Workspace struct {
 	// Directory corresponds to the JSON schema field "directory".
 	Directory string `json:"directory"`
 
+	// EndpointID corresponds to the JSON schema field "endpoint_id".
+	EndpointID *string `json:"endpoint_id,omitempty,omitzero"`
+
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id"`
 

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -149,6 +149,7 @@ model Workspace {
   pinned: boolean;              // Pinned workspaces persist in the sidebar even when empty.
   rank: string;                 // Fractional-index sort key; default order is opening (creation) order.
   layout?: WorkspaceLayout;
+  endpoint_id?: string;         // Set by a hub daemon on workspaces mirrored from a remote endpoint; absent/empty means the workspace is local to this daemon. Remote daemons never set this themselves — the hub stamps it at ingest.
 }
 
 model WorkspaceContext {


### PR DESCRIPTION
## Summary

Final PR of the editor-arbitrary-roots epic (`docs/plans/2026-07-18-editor-arbitrary-roots.md`), the fast-follow committed in #585's review thread.

- Adds `endpoint_id?: string` to `protocol.Workspace` (protocol 170→171, bumped in both lockstep spots: `internal/protocol/constants.go` and `app/src/hooks/useDaemonSocket.ts`).
- Hub daemons stamp `EndpointID` on every workspace mirrored from a remote endpoint at ingest (`replaceRemoteWorkspaces`/`upsertRemoteWorkspace` in `internal/hub/manager.go`), **unconditionally overwriting** any remote-supplied value so a buggy or compromised remote can't spoof locality.
- `localWorkspaceDirectory` now reads the workspace record directly instead of cross-referencing sessions, restoring the workspace-directory ⌘⌥N default for sessionless local pinned workspaces.
- The workspace lookup in `handleOpenNotebookTile` is now endpoint-aware, to correctly disambiguate duplicate-id remote twins.
- `daemonSessionsRef` deleted (no longer needed once workspace lookups don't cross-reference sessions).

## Test plan

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/hub/... ./internal/daemon/... ./internal/protocol/...` — pass, including hub-stamping coverage (spoof-overwrite on both `replaceRemoteWorkspaces`/`upsertRemoteWorkspace`, and change-detection short-circuit preserved), and confirming the local (non-hub) daemon never stamps `EndpointID`.
- `pnpm test` — 173 files / 1843 tests pass, including frontend gate-semantics coverage for the new field.
- `pnpm exec tsc --noEmit` — clean.
- Live packaged-app verification on a throwaway profile: ⌘⌥N workspace-dir default → root-scoped editor tile + protocol-171 handshake (`scenario-editor-workspace-root`) — passed.
- **Not live-verified**: the hub-stamping half was not exercised against a real remote endpoint (no cheap rig available) — it is covered by unit tests only.

https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT