### PR TITLE
feat(tickets): buffer observer notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   ritual.** Agents may complete work that Victor accepted, whose requested PR
   merged, or that has an equivalent objective terminal signal; finished work still
   awaiting review remains in review.
+- **Ticket notifications now protect attention without delaying the agent doing the work.** The current assignee keeps immediate delivery, while chiefs, subscribers, and other participants coalesce unread activity into one 30-minute observer-wide window. Explicit inbox reads remain immediate, and inbox watches share delivery with nudges without duplicate wake-ups.
+- **Ticket updates now make agents read intervening activity before writing.** Status, comment, and attachment commands show unread updates and require a deliberate retry; app edits reject stale ticket details and refresh them before retry. Taking or subscribing to a ticket reports unread history without consuming it.
 
 ### Fixed
 - **Switching profiles from inside attn no longer keeps talking to the inherited
@@ -58,7 +60,6 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ### Added
 - **Black or stuck UI failures now leave useful evidence on disk.** Agent switches capture delayed app-shell health snapshots alongside the existing terminal renderer diagnostics, including frontend crashes, event-loop stalls, and native browser visibility. A React render failure now shows a persistent error screen instead of leaving an unexplained black window.
 - **Ask a bounded question about another Codex session.** `attn session instructions <session-id> --question "..."` reads that session's conversation and returns a concise Luna answer with exact supporting excerpts, transcript identity, and a fingerprint. It fails closed when the transcript, model response, or evidence cannot be verified.
-
 ## [2026-07-15]
 
 ### Added

--- a/app/src/components/SessionTerminalWorkspace/index.tsx
+++ b/app/src/components/SessionTerminalWorkspace/index.tsx
@@ -127,10 +127,10 @@ interface SessionTerminalWorkspaceProps {
   // renders; the chip's overlay only opens when these are present.
   ticketActions?: {
     fetchTicket: (ticketId: string) => Promise<Ticket>;
-    onChangeStatus: (ticketId: string, status: Ticket['status'], comment?: string) => Promise<void>;
-    onAddComment: (ticketId: string, comment: string) => Promise<void>;
-    onEditDescription: (ticketId: string, description: string) => Promise<void>;
-    onAttach?: (ticketId: string, paths: string[], state?: string, comment?: string) => Promise<unknown>;
+    onChangeStatus: (ticketId: string, status: Ticket['status'], expectedEventSeq: number, comment?: string) => Promise<void>;
+    onAddComment: (ticketId: string, comment: string, expectedEventSeq: number) => Promise<void>;
+    onEditDescription: (ticketId: string, description: string, expectedEventSeq: number) => Promise<void>;
+    onAttach?: (ticketId: string, paths: string[], state?: string, comment?: string, expectedEventSeq?: number) => Promise<unknown>;
     onRenameArtifact?: (path: string, newPath: string) => Promise<unknown>;
     onDeleteArtifact?: (path: string) => Promise<unknown>;
     onOpenArtifact?: (path: string) => void;

--- a/app/src/components/TicketDetailPanel.test.tsx
+++ b/app/src/components/TicketDetailPanel.test.tsx
@@ -19,6 +19,7 @@ function makeTicket(overrides: Partial<Ticket> = {}): Ticket {
     project_id: '',
     created_at: '2026-06-27T10:00:00Z',
     updated_at: '2026-06-27T10:05:00Z',
+    latest_event_seq: 7,
     activity: [
       {
         id: 1,
@@ -183,7 +184,7 @@ describe('TicketDetailPanel', () => {
 
     fireEvent.change(screen.getByTestId('ticket-status-select'), { target: { value: 'done' } });
     expect(onChangeStatus).toHaveBeenCalledTimes(1);
-    expect(onChangeStatus).toHaveBeenCalledWith('store-migration', 'done');
+    expect(onChangeStatus).toHaveBeenCalledWith('store-migration', 'done', 7);
   });
 
   it('adds a comment and clears the draft on success', async () => {
@@ -205,7 +206,7 @@ describe('TicketDetailPanel', () => {
     fireEvent.change(input, { target: { value: 'try the other approach' } });
     fireEvent.click(screen.getByTestId('ticket-add-comment'));
 
-    expect(onAddComment).toHaveBeenCalledWith('store-migration', 'try the other approach');
+    expect(onAddComment).toHaveBeenCalledWith('store-migration', 'try the other approach', 7);
     await waitFor(() => expect(input.value).toBe(''));
   });
 
@@ -229,7 +230,7 @@ describe('TicketDetailPanel', () => {
       fireEvent.change(input, { target: { value: 'ship it' } });
       fireEvent.keyDown(input, { key: 'Enter', [modifier]: true });
 
-      expect(onAddComment).toHaveBeenCalledWith('store-migration', 'ship it');
+      expect(onAddComment).toHaveBeenCalledWith('store-migration', 'ship it', 7);
       await waitFor(() => expect(input.value).toBe(''));
       unmount();
     }
@@ -337,9 +338,55 @@ describe('TicketDetailPanel', () => {
     fireEvent.change(input, { target: { value: 'Re-scoped: read path only' } });
     fireEvent.click(screen.getByTestId('ticket-save-description'));
 
-    expect(onEditDescription).toHaveBeenCalledWith('store-migration', 'Re-scoped: read path only');
+    expect(onEditDescription).toHaveBeenCalledWith('store-migration', 'Re-scoped: read path only', 7);
     // The editor closes on success.
     await waitFor(() => expect(screen.queryByTestId('ticket-description-input')).toBeNull());
+  });
+
+  it('keeps the description edit sequence stable across live refresh and adopts the new sequence only after a conflict', async () => {
+    const stale = makeTicket({ latest_event_seq: 7, description: 'Original description' });
+    const fresh = makeTicket({ latest_event_seq: 8, description: 'Someone else changed it' });
+    const fetchTicket = vi.fn().mockResolvedValueOnce(stale).mockResolvedValue(fresh);
+    const onEditDescription = vi.fn()
+      .mockRejectedValueOnce(new Error('ticket changed since it was opened: expected event 7, latest is 8'))
+      .mockResolvedValueOnce(undefined);
+    const row = makeTicket();
+    const { rerender } = render(
+      <TicketDetailPanel
+        isOpen
+        ticketId="store-migration"
+        ticketRow={row}
+        fetchTicket={fetchTicket}
+        onEditDescription={onEditDescription}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText('Original description'));
+    fireEvent.click(screen.getByTestId('ticket-edit-description'));
+    const input = screen.getByTestId('ticket-description-input') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'My draft' } });
+
+    rerender(
+      <TicketDetailPanel
+        isOpen
+        ticketId="store-migration"
+        ticketRow={{ ...row, updated_at: '2026-06-27T11:00:00Z' }}
+        fetchTicket={fetchTicket}
+        onEditDescription={onEditDescription}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => expect(fetchTicket).toHaveBeenCalledTimes(2));
+    expect(input.value).toBe('My draft');
+
+    fireEvent.click(screen.getByTestId('ticket-save-description'));
+    await waitFor(() => screen.getByRole('alert'));
+    expect(onEditDescription).toHaveBeenNthCalledWith(1, 'store-migration', 'My draft', 7);
+    expect(input.value).toBe('My draft');
+
+    fireEvent.click(screen.getByTestId('ticket-save-description'));
+    await waitFor(() => expect(onEditDescription).toHaveBeenCalledTimes(2));
+    expect(onEditDescription).toHaveBeenNthCalledWith(2, 'store-migration', 'My draft', 8);
   });
 
   it('surfaces an action error without claiming success', async () => {
@@ -360,6 +407,29 @@ describe('TicketDetailPanel', () => {
     fireEvent.change(screen.getByTestId('ticket-status-select'), { target: { value: 'failed' } });
     await waitFor(() => screen.getByRole('alert'));
     expect(screen.getByText('daemon refused the move')).toBeTruthy();
+  });
+
+  it('refreshes the detail after a stale action and requires retry', async () => {
+    const stale = makeTicket({ latest_event_seq: 7, description: 'old detail' });
+    const fresh = makeTicket({ latest_event_seq: 8, description: 'fresh detail' });
+    const fetchTicket = vi.fn().mockResolvedValueOnce(stale).mockResolvedValueOnce(fresh);
+    const onChangeStatus = vi.fn().mockRejectedValue(new Error('ticket changed since it was opened: expected event 7, latest is 8'));
+    render(
+      <TicketDetailPanel
+        isOpen
+        ticketId="store-migration"
+        ticketRow={makeTicket()}
+        fetchTicket={fetchTicket}
+        onChangeStatus={onChangeStatus}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText('old detail'));
+
+    fireEvent.change(screen.getByTestId('ticket-status-select'), { target: { value: 'failed' } });
+    await waitFor(() => screen.getByText('fresh detail'));
+    expect(fetchTicket).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('alert').textContent).toContain('ticket changed since it was opened');
   });
 
   it('shows Resume and calls onResume with the ticket id for a delegated ticket', async () => {
@@ -442,6 +512,7 @@ describe('TicketDetailPanel', () => {
       ['/tmp/design.md', '/tmp/prototype.html', '/tmp/results.zip'],
       'ready_for_review',
       'Chosen approach',
+      7,
     ));
     expect(open).toHaveBeenCalledWith({ multiple: true });
   });

--- a/app/src/components/TicketDetailPanel.tsx
+++ b/app/src/components/TicketDetailPanel.tsx
@@ -17,10 +17,10 @@ interface TicketDetailPanelProps {
   // Chief/user actions (slice 4c). Optional so the panel can render read-only
   // when an owner does not wire them. Each resolves once the daemon confirms;
   // the refreshed record arrives via the live re-fetch, not the resolve value.
-  onChangeStatus?: (ticketId: string, status: Ticket['status'], comment?: string) => Promise<void>;
-  onAddComment?: (ticketId: string, comment: string) => Promise<void>;
-  onEditDescription?: (ticketId: string, description: string) => Promise<void>;
-  onAttach?: (ticketId: string, paths: string[], state?: string, comment?: string) => Promise<unknown>;
+  onChangeStatus?: (ticketId: string, status: Ticket['status'], expectedEventSeq: number, comment?: string) => Promise<void>;
+  onAddComment?: (ticketId: string, comment: string, expectedEventSeq: number) => Promise<void>;
+  onEditDescription?: (ticketId: string, description: string, expectedEventSeq: number) => Promise<void>;
+  onAttach?: (ticketId: string, paths: string[], state?: string, comment?: string, expectedEventSeq?: number) => Promise<unknown>;
   onRenameArtifact?: (path: string, newPath: string) => Promise<unknown>;
   onDeleteArtifact?: (path: string) => Promise<unknown>;
   onOpenArtifact?: (path: string) => void;
@@ -114,6 +114,7 @@ export function TicketDetailPanel({
   const [commentDraft, setCommentDraft] = useState('');
   const [editingDescription, setEditingDescription] = useState(false);
   const [descriptionDraft, setDescriptionDraft] = useState('');
+  const [descriptionEditEventSeq, setDescriptionEditEventSeq] = useState(0);
   const [attachFiles, setAttachFiles] = useState<string[]>([]);
   const [attachState, setAttachState] = useState('');
   const [attachComment, setAttachComment] = useState('');
@@ -157,6 +158,7 @@ export function TicketDetailPanel({
     setCommentDraft('');
     setEditingDescription(false);
     setDescriptionDraft('');
+    setDescriptionEditEventSeq(0);
     setAttachFiles([]);
     setAttachState('');
     setAttachComment('');
@@ -171,8 +173,24 @@ export function TicketDetailPanel({
     setBusyAction(name);
     setActionError(null);
     return fn()
-      .catch((err) => {
-        setActionError(err instanceof Error ? err.message : 'Action failed');
+      .catch(async (err) => {
+        const message = err instanceof Error ? err.message : 'Action failed';
+        if (message.includes('ticket changed since it was opened') && ticketId) {
+          try {
+            const refreshed = await fetchTicket(ticketId);
+            setTicket(refreshed);
+            if (name === 'description') {
+              // Keep the user's draft, but require this failed save before adopting
+              // the refreshed sequence. A deliberate second click can then apply
+              // the draft after the user has seen the conflict and new history.
+              setDescriptionEditEventSeq(refreshed.latest_event_seq ?? 0);
+            }
+          } catch {
+            // Keep the mutation error as the useful action result. The normal
+            // board refresh path can retry the detail read.
+          }
+        }
+        setActionError(message);
         throw err;
       })
       .finally(() => setBusyAction(null));
@@ -204,7 +222,7 @@ export function TicketDetailPanel({
     if (!onAddComment || !fullTicket) return;
     const text = commentDraft.trim();
     if (!text || busyAction !== null) return;
-    runAction('comment', () => onAddComment(fullTicket.id, text))
+    runAction('comment', () => onAddComment(fullTicket.id, text, fullTicket.latest_event_seq ?? 0))
       .then(() => setCommentDraft(''))
       .catch(() => {});
   };
@@ -275,7 +293,7 @@ export function TicketDetailPanel({
                 onChange={(event) => {
                   const next = event.target.value as Ticket['status'];
                   if (next === fullTicket.status) return;
-                  runAction('status', () => onChangeStatus(fullTicket.id, next)).catch(() => {});
+                  runAction('status', () => onChangeStatus(fullTicket.id, next, fullTicket.latest_event_seq ?? 0)).catch(() => {});
                 }}
               >
                 {(SELECTABLE_STATUSES.includes(fullTicket.status)
@@ -306,6 +324,7 @@ export function TicketDetailPanel({
                   data-testid="ticket-edit-description"
                   onClick={() => {
                     setDescriptionDraft(fullTicket.description);
+                    setDescriptionEditEventSeq(fullTicket.latest_event_seq ?? 0);
                     setEditingDescription(true);
                   }}
                 >
@@ -330,7 +349,7 @@ export function TicketDetailPanel({
                     disabled={busyAction !== null}
                     onClick={() => {
                       if (!onEditDescription) return;
-                      runAction('description', () => onEditDescription(fullTicket.id, descriptionDraft))
+                      runAction('description', () => onEditDescription(fullTicket.id, descriptionDraft, descriptionEditEventSeq))
                         .then(() => setEditingDescription(false))
                         .catch(() => {});
                     }}
@@ -455,7 +474,7 @@ export function TicketDetailPanel({
                     disabled={busyAction !== null}
                     onClick={() => {
                       runAction('attach', async () => {
-                        await onAttach(fullTicket.id, attachFiles, attachState || undefined, attachComment.trim() || undefined);
+                        await onAttach(fullTicket.id, attachFiles, attachState || undefined, attachComment.trim() || undefined, fullTicket.latest_event_seq ?? 0);
                         setAttachFiles([]);
                         setAttachState('');
                         setAttachComment('');

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '171';
+export const PROTOCOL_VERSION = '172';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {
@@ -4418,24 +4418,33 @@ export function useDaemonSocket({
   }, [nextRequestID]);
 
   const sendTicketChangeStatus = useCallback(
-    (ticketId: string, status: Ticket['status'], comment?: string): Promise<void> =>
+    (ticketId: string, status: Ticket['status'], expectedEventSeq?: number, comment?: string): Promise<void> =>
       sendTicketAction('ticket_change_status', {
         ticket_id: ticketId,
         status,
+        ...(expectedEventSeq !== undefined ? { expected_event_seq: expectedEventSeq } : {}),
         ...(comment ? { comment } : {}),
       }),
     [sendTicketAction],
   );
 
   const sendTicketAddComment = useCallback(
-    (ticketId: string, comment: string): Promise<void> =>
-      sendTicketAction('ticket_add_comment', { ticket_id: ticketId, comment }),
+    (ticketId: string, comment: string, expectedEventSeq?: number): Promise<void> =>
+      sendTicketAction('ticket_add_comment', {
+        ticket_id: ticketId,
+        comment,
+        ...(expectedEventSeq !== undefined ? { expected_event_seq: expectedEventSeq } : {}),
+      }),
     [sendTicketAction],
   );
 
   const sendTicketEditDescription = useCallback(
-    (ticketId: string, description: string): Promise<void> =>
-      sendTicketAction('ticket_edit_description', { ticket_id: ticketId, description }),
+    (ticketId: string, description: string, expectedEventSeq?: number): Promise<void> =>
+      sendTicketAction('ticket_edit_description', {
+        ticket_id: ticketId,
+        description,
+        ...(expectedEventSeq !== undefined ? { expected_event_seq: expectedEventSeq } : {}),
+      }),
     [sendTicketAction],
   );
 
@@ -4444,6 +4453,7 @@ export function useDaemonSocket({
     paths: string[],
     state?: string,
     comment?: string,
+    expectedEventSeq?: number,
   ): Promise<unknown> => new Promise((resolve, reject) => {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -4458,6 +4468,7 @@ export function useDaemonSocket({
       request_id: requestId,
       source_session_id: 'you',
       ticket_id: ticketId,
+      ...(expectedEventSeq !== undefined ? { expected_event_seq: expectedEventSeq } : {}),
       files: paths.map((sourcePath) => ({
         source_path: sourcePath,
         filename: sourcePath.split(/[\\/]/).pop() || sourcePath,

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateWorktreeRequest, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import generated protocol types from "./file";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -268,6 +268,7 @@
 //   const ticketEventBundle = Convert.toTicketEventBundle(json);
 //   const ticketEventKind = Convert.toTicketEventKind(json);
 //   const ticketInboxMessage = Convert.toTicketInboxMessage(json);
+//   const ticketInboxMode = Convert.toTicketInboxMode(json);
 //   const ticketInboxResult = Convert.toTicketInboxResult(json);
 //   const ticketListMessage = Convert.toTicketListMessage(json);
 //   const ticketListResult = Convert.toTicketListResult(json);
@@ -1833,21 +1834,22 @@ export interface RepoElement {
 }
 
 export interface TicketElement {
-    activity:       ActivityElement[];
-    archived_at?:   string;
-    artifacts:      ArtifactElement[];
-    assignee:       string;
-    closed_at?:     string;
-    created_at:     string;
-    cwd:            string;
-    description:    string;
-    id:             string;
-    last_agent_id:  string;
-    project_id:     string;
-    reconciled_at?: string;
-    status:         TicketStatus;
-    title:          string;
-    updated_at:     string;
+    activity:          ActivityElement[];
+    archived_at?:      string;
+    artifacts:         ArtifactElement[];
+    assignee:          string;
+    closed_at?:        string;
+    created_at:        string;
+    cwd:               string;
+    description:       string;
+    id:                string;
+    last_agent_id:     string;
+    latest_event_seq?: number;
+    project_id:        string;
+    reconciled_at?:    string;
+    status:            TicketStatus;
+    title:             string;
+    updated_at:        string;
     [property: string]: any;
 }
 
@@ -3377,6 +3379,7 @@ export interface EvidenceElement {
 
 export interface TicketAttachResultObject {
     artifacts:    ArtifactElement[];
+    catch_up?:    CatchUp;
     deduplicated: boolean;
     event_seq:    number;
     fingerprint:  string;
@@ -3385,25 +3388,7 @@ export interface TicketAttachResultObject {
     [property: string]: any;
 }
 
-export interface TicketCommentResultObject {
-    ticket_id: string;
-    [property: string]: any;
-}
-
-export interface TicketCreateResultObject {
-    status:    TicketStatus;
-    ticket_id: string;
-    title:     string;
-    [property: string]: any;
-}
-
-export interface TicketInboxResultObject {
-    bundles:                BundleElement[];
-    last_user_activity_at?: string;
-    [property: string]: any;
-}
-
-export interface BundleElement {
+export interface CatchUp {
     events:    EventElement[];
     ticket_id: string;
     [property: string]: any;
@@ -3430,6 +3415,25 @@ export enum TicketEventKind {
     StatusChanged = "status_changed",
 }
 
+export interface TicketCommentResultObject {
+    catch_up?: CatchUp;
+    ticket_id: string;
+    [property: string]: any;
+}
+
+export interface TicketCreateResultObject {
+    status:    TicketStatus;
+    ticket_id: string;
+    title:     string;
+    [property: string]: any;
+}
+
+export interface TicketInboxResultObject {
+    bundles:                CatchUp[];
+    last_user_activity_at?: string;
+    [property: string]: any;
+}
+
 export interface TicketListResultObject {
     tickets: TicketElement[];
     [property: string]: any;
@@ -3441,19 +3445,22 @@ export interface TicketShowResultObject {
 }
 
 export interface TicketStatusResultObject {
+    catch_up?: CatchUp;
     status:    TicketStatus;
     ticket_id: string;
     [property: string]: any;
 }
 
 export interface TicketSubscribeResultObject {
-    ticket_id: string;
+    ticket_id:     string;
+    unread_count?: number;
     [property: string]: any;
 }
 
 export interface TicketTakeResultObject {
     previous_assignee: string;
     ticket_id:         string;
+    unread_count?:     number;
     [property: string]: any;
 }
 
@@ -3922,21 +3929,22 @@ export enum TasksChangedMessageEvent {
 }
 
 export interface Ticket {
-    activity:       ActivityElement[];
-    archived_at?:   string;
-    artifacts:      ArtifactElement[];
-    assignee:       string;
-    closed_at?:     string;
-    created_at:     string;
-    cwd:            string;
-    description:    string;
-    id:             string;
-    last_agent_id:  string;
-    project_id:     string;
-    reconciled_at?: string;
-    status:         TicketStatus;
-    title:          string;
-    updated_at:     string;
+    activity:          ActivityElement[];
+    archived_at?:      string;
+    artifacts:         ArtifactElement[];
+    assignee:          string;
+    closed_at?:        string;
+    created_at:        string;
+    cwd:               string;
+    description:       string;
+    id:                string;
+    last_agent_id:     string;
+    latest_event_seq?: number;
+    project_id:        string;
+    reconciled_at?:    string;
+    status:            TicketStatus;
+    title:             string;
+    updated_at:        string;
     [property: string]: any;
 }
 
@@ -3964,10 +3972,11 @@ export interface TicketActivity {
 }
 
 export interface TicketAddCommentMessage {
-    cmd:         TicketAddCommentMessageCmd;
-    comment:     string;
-    request_id?: string;
-    ticket_id:   string;
+    cmd:                 TicketAddCommentMessageCmd;
+    comment:             string;
+    expected_event_seq?: number;
+    request_id?:         string;
+    ticket_id:           string;
     [property: string]: any;
 }
 
@@ -3989,13 +3998,14 @@ export interface TicketAttachFile {
 }
 
 export interface TicketAttachMessage {
-    cmd:               TicketAttachMessageCmd;
-    comment?:          string;
-    files:             FileObject[];
-    request_id?:       string;
-    source_session_id: string;
-    state?:            DispatchWorkState;
-    ticket_id?:        string;
+    cmd:                 TicketAttachMessageCmd;
+    comment?:            string;
+    expected_event_seq?: number;
+    files:               FileObject[];
+    request_id?:         string;
+    source_session_id:   string;
+    state?:              DispatchWorkState;
+    ticket_id?:          string;
     [property: string]: any;
 }
 
@@ -4011,6 +4021,7 @@ export interface FileObject {
 
 export interface TicketAttachResult {
     artifacts:    ArtifactElement[];
+    catch_up?:    CatchUp;
     deduplicated: boolean;
     event_seq:    number;
     fingerprint:  string;
@@ -4033,11 +4044,12 @@ export enum TicketAttachResultMessageEvent {
 }
 
 export interface TicketChangeStatusMessage {
-    cmd:         TicketChangeStatusMessageCmd;
-    comment?:    string;
-    request_id?: string;
-    status:      TicketStatus;
-    ticket_id:   string;
+    cmd:                 TicketChangeStatusMessageCmd;
+    comment?:            string;
+    expected_event_seq?: number;
+    request_id?:         string;
+    status:              TicketStatus;
+    ticket_id:           string;
     [property: string]: any;
 }
 
@@ -4058,6 +4070,7 @@ export enum TicketCommentMessageCmd {
 }
 
 export interface TicketCommentResult {
+    catch_up?: CatchUp;
     ticket_id: string;
     [property: string]: any;
 }
@@ -4083,10 +4096,11 @@ export interface TicketCreateResult {
 }
 
 export interface TicketEditDescriptionMessage {
-    cmd:         TicketEditDescriptionMessageCmd;
-    description: string;
-    request_id?: string;
-    ticket_id:   string;
+    cmd:                 TicketEditDescriptionMessageCmd;
+    description:         string;
+    expected_event_seq?: number;
+    request_id?:         string;
+    ticket_id:           string;
     [property: string]: any;
 }
 
@@ -4113,8 +4127,10 @@ export interface TicketEventBundle {
 }
 
 export interface TicketInboxMessage {
-    cmd:               TicketInboxMessageCmd;
-    source_session_id: string;
+    cmd:                TicketInboxMessageCmd;
+    mode?:              TicketInboxMode;
+    source_session_id:  string;
+    watch_interval_ms?: string;
     [property: string]: any;
 }
 
@@ -4122,8 +4138,13 @@ export enum TicketInboxMessageCmd {
     TicketInbox = "ticket_inbox",
 }
 
+export enum TicketInboxMode {
+    Explicit = "explicit",
+    Watch = "watch",
+}
+
 export interface TicketInboxResult {
-    bundles:                BundleElement[];
+    bundles:                CatchUp[];
     last_user_activity_at?: string;
     [property: string]: any;
 }
@@ -4201,6 +4222,7 @@ export interface TicketShowResult {
 }
 
 export interface TicketStatusResult {
+    catch_up?: CatchUp;
     status:    TicketStatus;
     ticket_id: string;
     [property: string]: any;
@@ -4218,7 +4240,8 @@ export enum TicketSubscribeMessageCmd {
 }
 
 export interface TicketSubscribeResult {
-    ticket_id: string;
+    ticket_id:     string;
+    unread_count?: number;
     [property: string]: any;
 }
 
@@ -4237,6 +4260,7 @@ export enum TicketTakeMessageCmd {
 export interface TicketTakeResult {
     previous_assignee: string;
     ticket_id:         string;
+    unread_count?:     number;
     [property: string]: any;
 }
 
@@ -7199,6 +7223,14 @@ export class Convert {
         return JSON.stringify(uncast(value, r("TicketInboxMessage")), null, 2);
     }
 
+    public static toTicketInboxMode(json: string): TicketInboxMode {
+        return cast(JSON.parse(json), r("TicketInboxMode"));
+    }
+
+    public static ticketInboxModeToJson(value: TicketInboxMode): string {
+        return JSON.stringify(uncast(value, r("TicketInboxMode")), null, 2);
+    }
+
     public static toTicketInboxResult(json: string): TicketInboxResult {
         return cast(JSON.parse(json), r("TicketInboxResult"));
     }
@@ -8892,6 +8924,7 @@ const typeMap: any = {
         { json: "description", js: "description", typ: "" },
         { json: "id", js: "id", typ: "" },
         { json: "last_agent_id", js: "last_agent_id", typ: "" },
+        { json: "latest_event_seq", js: "latest_event_seq", typ: u(undefined, 0) },
         { json: "project_id", js: "project_id", typ: "" },
         { json: "reconciled_at", js: "reconciled_at", typ: u(undefined, "") },
         { json: "status", js: "status", typ: r("TicketStatus") },
@@ -9804,25 +9837,14 @@ const typeMap: any = {
     ], "any"),
     "TicketAttachResultObject": o([
         { json: "artifacts", js: "artifacts", typ: a(r("ArtifactElement")) },
+        { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
         { json: "deduplicated", js: "deduplicated", typ: true },
         { json: "event_seq", js: "event_seq", typ: 0 },
         { json: "fingerprint", js: "fingerprint", typ: "" },
         { json: "state", js: "state", typ: r("TicketStatus") },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
-    "TicketCommentResultObject": o([
-        { json: "ticket_id", js: "ticket_id", typ: "" },
-    ], "any"),
-    "TicketCreateResultObject": o([
-        { json: "status", js: "status", typ: r("TicketStatus") },
-        { json: "ticket_id", js: "ticket_id", typ: "" },
-        { json: "title", js: "title", typ: "" },
-    ], "any"),
-    "TicketInboxResultObject": o([
-        { json: "bundles", js: "bundles", typ: a(r("BundleElement")) },
-        { json: "last_user_activity_at", js: "last_user_activity_at", typ: u(undefined, "") },
-    ], "any"),
-    "BundleElement": o([
+    "CatchUp": o([
         { json: "events", js: "events", typ: a(r("EventElement")) },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
@@ -9836,6 +9858,19 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: "" },
         { json: "to_status", js: "to_status", typ: u(undefined, r("TicketStatus")) },
     ], "any"),
+    "TicketCommentResultObject": o([
+        { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
+        { json: "ticket_id", js: "ticket_id", typ: "" },
+    ], "any"),
+    "TicketCreateResultObject": o([
+        { json: "status", js: "status", typ: r("TicketStatus") },
+        { json: "ticket_id", js: "ticket_id", typ: "" },
+        { json: "title", js: "title", typ: "" },
+    ], "any"),
+    "TicketInboxResultObject": o([
+        { json: "bundles", js: "bundles", typ: a(r("CatchUp")) },
+        { json: "last_user_activity_at", js: "last_user_activity_at", typ: u(undefined, "") },
+    ], "any"),
     "TicketListResultObject": o([
         { json: "tickets", js: "tickets", typ: a(r("TicketElement")) },
     ], "any"),
@@ -9843,15 +9878,18 @@ const typeMap: any = {
         { json: "ticket", js: "ticket", typ: r("TicketElement") },
     ], "any"),
     "TicketStatusResultObject": o([
+        { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
         { json: "status", js: "status", typ: r("TicketStatus") },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
     "TicketSubscribeResultObject": o([
         { json: "ticket_id", js: "ticket_id", typ: "" },
+        { json: "unread_count", js: "unread_count", typ: u(undefined, 0) },
     ], "any"),
     "TicketTakeResultObject": o([
         { json: "previous_assignee", js: "previous_assignee", typ: "" },
         { json: "ticket_id", js: "ticket_id", typ: "" },
+        { json: "unread_count", js: "unread_count", typ: u(undefined, 0) },
     ], "any"),
     "TicketUnsubscribeResultObject": o([
         { json: "ticket_id", js: "ticket_id", typ: "" },
@@ -10123,6 +10161,7 @@ const typeMap: any = {
         { json: "description", js: "description", typ: "" },
         { json: "id", js: "id", typ: "" },
         { json: "last_agent_id", js: "last_agent_id", typ: "" },
+        { json: "latest_event_seq", js: "latest_event_seq", typ: u(undefined, 0) },
         { json: "project_id", js: "project_id", typ: "" },
         { json: "reconciled_at", js: "reconciled_at", typ: u(undefined, "") },
         { json: "status", js: "status", typ: r("TicketStatus") },
@@ -10147,6 +10186,7 @@ const typeMap: any = {
     "TicketAddCommentMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketAddCommentMessageCmd") },
         { json: "comment", js: "comment", typ: "" },
+        { json: "expected_event_seq", js: "expected_event_seq", typ: u(undefined, 0) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
@@ -10162,6 +10202,7 @@ const typeMap: any = {
     "TicketAttachMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketAttachMessageCmd") },
         { json: "comment", js: "comment", typ: u(undefined, "") },
+        { json: "expected_event_seq", js: "expected_event_seq", typ: u(undefined, 0) },
         { json: "files", js: "files", typ: a(r("FileObject")) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "source_session_id", js: "source_session_id", typ: "" },
@@ -10174,6 +10215,7 @@ const typeMap: any = {
     ], "any"),
     "TicketAttachResult": o([
         { json: "artifacts", js: "artifacts", typ: a(r("ArtifactElement")) },
+        { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
         { json: "deduplicated", js: "deduplicated", typ: true },
         { json: "event_seq", js: "event_seq", typ: 0 },
         { json: "fingerprint", js: "fingerprint", typ: "" },
@@ -10190,6 +10232,7 @@ const typeMap: any = {
     "TicketChangeStatusMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketChangeStatusMessageCmd") },
         { json: "comment", js: "comment", typ: u(undefined, "") },
+        { json: "expected_event_seq", js: "expected_event_seq", typ: u(undefined, 0) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "status", js: "status", typ: r("TicketStatus") },
         { json: "ticket_id", js: "ticket_id", typ: "" },
@@ -10201,6 +10244,7 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
     "TicketCommentResult": o([
+        { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
     "TicketCreateMessage": o([
@@ -10218,6 +10262,7 @@ const typeMap: any = {
     "TicketEditDescriptionMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketEditDescriptionMessageCmd") },
         { json: "description", js: "description", typ: "" },
+        { json: "expected_event_seq", js: "expected_event_seq", typ: u(undefined, 0) },
         { json: "request_id", js: "request_id", typ: u(undefined, "") },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
@@ -10237,10 +10282,12 @@ const typeMap: any = {
     ], "any"),
     "TicketInboxMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketInboxMessageCmd") },
+        { json: "mode", js: "mode", typ: u(undefined, r("TicketInboxMode")) },
         { json: "source_session_id", js: "source_session_id", typ: "" },
+        { json: "watch_interval_ms", js: "watch_interval_ms", typ: u(undefined, "") },
     ], "any"),
     "TicketInboxResult": o([
-        { json: "bundles", js: "bundles", typ: a(r("BundleElement")) },
+        { json: "bundles", js: "bundles", typ: a(r("CatchUp")) },
         { json: "last_user_activity_at", js: "last_user_activity_at", typ: u(undefined, "") },
     ], "any"),
     "TicketListMessage": o([
@@ -10282,6 +10329,7 @@ const typeMap: any = {
         { json: "ticket", js: "ticket", typ: r("TicketElement") },
     ], "any"),
     "TicketStatusResult": o([
+        { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
         { json: "status", js: "status", typ: r("TicketStatus") },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
@@ -10292,6 +10340,7 @@ const typeMap: any = {
     ], "any"),
     "TicketSubscribeResult": o([
         { json: "ticket_id", js: "ticket_id", typ: "" },
+        { json: "unread_count", js: "unread_count", typ: u(undefined, 0) },
     ], "any"),
     "TicketTakeMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketTakeMessageCmd") },
@@ -10302,6 +10351,7 @@ const typeMap: any = {
     "TicketTakeResult": o([
         { json: "previous_assignee", js: "previous_assignee", typ: "" },
         { json: "ticket_id", js: "ticket_id", typ: "" },
+        { json: "unread_count", js: "unread_count", typ: u(undefined, 0) },
     ], "any"),
     "TicketUnsubscribeMessage": o([
         { json: "cmd", js: "cmd", typ: r("TicketUnsubscribeMessageCmd") },
@@ -11456,6 +11506,10 @@ const typeMap: any = {
     ],
     "TicketInboxMessageCmd": [
         "ticket_inbox",
+    ],
+    "TicketInboxMode": [
+        "explicit",
+        "watch",
     ],
     "TicketListMessageCmd": [
         "ticket_list",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -811,6 +811,10 @@ func runTicketStatus(args []string) {
 		fmt.Fprintf(os.Stderr, "ticket status: %v\n", err)
 		os.Exit(1)
 	}
+	if result.CatchUp != nil {
+		printTicketMutationCatchUp("ticket status", result.CatchUp, parsed.JSON, result)
+		os.Exit(1)
+	}
 	if parsed.JSON {
 		printJSON(result)
 		return
@@ -903,6 +907,10 @@ func runTicketAttach(args []string) {
 	result, err := client.New("").AttachTicket(source, files, parsed.Ticket, parsed.State, parsed.Comment)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ticket attach: %v\n", err)
+		os.Exit(1)
+	}
+	if result.CatchUp != nil {
+		printTicketMutationCatchUp("ticket attach", result.CatchUp, parsed.JSON, result)
 		os.Exit(1)
 	}
 	if parsed.JSON {
@@ -1190,11 +1198,24 @@ func runTicketComment(args []string) {
 		fmt.Fprintf(os.Stderr, "ticket comment: %v\n", err)
 		os.Exit(1)
 	}
+	if result.CatchUp != nil {
+		printTicketMutationCatchUp("ticket comment", result.CatchUp, parsed.JSON, result)
+		os.Exit(1)
+	}
 	if parsed.JSON {
 		printJSON(result)
 		return
 	}
 	fmt.Printf("commented on ticket %s\n", result.TicketID)
+}
+
+func printTicketMutationCatchUp(command string, bundle *protocol.TicketEventBundle, jsonOutput bool, result any) {
+	if jsonOutput {
+		printJSON(result)
+	} else {
+		fprintTicketInbox(os.Stdout, &protocol.TicketInboxResult{Bundles: []protocol.TicketEventBundle{*bundle}})
+	}
+	fmt.Fprintf(os.Stderr, "%s: unread ticket activity was shown above; the requested update did not run — review it and retry\n", command)
 }
 
 // ticketIDArgs is a single ticket-id positional plus the common session/json flags —
@@ -1263,6 +1284,9 @@ func runTicketSubscribe(args []string) {
 		return
 	}
 	fmt.Printf("subscribed to ticket %s\n", result.TicketID)
+	if result.UnreadCount != nil && *result.UnreadCount > 0 {
+		fmt.Printf("%d ticket update(s) are unread — run `attn ticket inbox` before editing it\n", *result.UnreadCount)
+	}
 }
 
 // runTicketUnsubscribe opts the calling session back out. It is idempotent —
@@ -1361,9 +1385,12 @@ func runTicketTake(args []string) {
 	}
 	if result.PreviousAssignee != "" && result.PreviousAssignee != source {
 		fmt.Printf("took ticket %s (was assigned to %s)\n", result.TicketID, result.PreviousAssignee)
-		return
+	} else {
+		fmt.Printf("took ticket %s\n", result.TicketID)
 	}
-	fmt.Printf("took ticket %s\n", result.TicketID)
+	if result.UnreadCount != nil && *result.UnreadCount > 0 {
+		fmt.Printf("%d ticket update(s) are unread — run `attn ticket inbox` before editing it\n", *result.UnreadCount)
+	}
 }
 
 // runTicketInbox reads (and consumes) this session's unread ticket events — the
@@ -1429,7 +1456,7 @@ func runTicketInboxWatch(source string, interval time.Duration, jsonOutput bool)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	watchTicketInbox(ctx, ticker.C, func() (*protocol.TicketInboxResult, error) {
-		return c.TicketInbox(source)
+		return c.TicketInboxWatch(source, interval)
 	}, os.Stdout, os.Stderr, jsonOutput)
 }
 

--- a/docs/plans/2026-07-17-ticket-notification-buffering.md
+++ b/docs/plans/2026-07-17-ticket-notification-buffering.md
@@ -1,0 +1,320 @@
+# Plan: Ticket notification buffering and read-before-write
+
+## Goal
+
+Reduce ticket-notification interruptions while keeping updates immediate for the agent
+currently doing the work.
+
+- Current assignee: use the existing short safety countdown; never apply the 30-minute
+  buffer.
+- Every non-assignee observer—including the chief, subscribers, and former
+  participants—uses one fixed 30-minute interruption budget across all observed
+  tickets.
+- Immediate assignee delivery piggybacks that observer's buffered activity.
+- Explicit `ticket inbox` catches up immediately. Automated `ticket inbox --watch`
+  respects delivery eligibility.
+- A mutation attempted with unread target-ticket activity consumes and returns that
+  activity, rejects the write, and requires a deliberate retry.
+
+The first release has a fixed 30-minute window with test-only override. It does not
+change Automations, delay traffic to the current assignee, or add an urgency bypass for
+`needs_input`.
+
+## Simplified Architecture
+
+```text
+Current:
+ticket mutation
+  -> durable ticket event
+  -> participant identities
+  -> per-session in-memory countdown
+  -> fixed doorbell
+
+ticket inbox / --watch
+  -> ConsumeAll
+  -> advance durable per-ticket cursors
+  -> return ticket bundles
+
+Target:
+ticket mutation
+  -> durable ticket event
+  -> classify each live target against the ticket's current assignee
+       assignee     -> desired deadline = normal safety countdown
+       non-assignee -> desired deadline = max(normal countdown,
+                                               attention_anchor + 30m)
+                      where attention_anchor is last_attention_at when present,
+                      otherwise the oldest unread event time
+  -> existing countdown keeps the earliest requested deadline
+  -> fixed doorbell
+
+explicit inbox
+  -> existing ConsumeAll immediately
+  -> non-empty result updates last_attention_at
+
+watch poll
+  -> refresh short live-watch lease
+  -> if immediate activity or buffered deadline is due:
+       existing ConsumeAll (all unread activity piggybacks)
+  -> otherwise return empty
+
+guarded mutation
+  -> one store transaction:
+       target has updater-unread events -> consume target events; reject mutation
+       otherwise                         -> apply mutation
+```
+
+The event log remains the batch and the existing cursors remain acknowledgement. There
+is no materialized notification batch, batch identifier, prepare/ack protocol, or
+second scheduler.
+
+## Delivery Rules
+
+### One clock per observer
+
+Persist one value per delivery-budget identity:
+
+```go
+type TicketDeliveryAttention struct {
+    ObserverKey    string
+    LastAttentionAt time.Time
+}
+```
+
+- Active chief: use durable `role:chief_of_staff` so the clock survives chief-session
+  transfer, including activity from that chief session's personal subscriptions.
+- Every other observer: use its ordinary observer identity.
+- If the observer is the ticket's current assignee, immediate delivery wins regardless
+  of any subscription or role participation.
+
+`last_attention_at` moves forward after:
+
+- a successful ticket doorbell;
+- a non-empty explicit inbox consume;
+- a non-empty watch consume;
+- an immediate-assignee consume with piggybacked activity;
+- a mutation-conflict catch-up.
+
+An empty inbox read does not move it. Updating the clock never delays assignee traffic;
+it only affects the observer's future non-assignee delivery.
+
+Only `observer_key` and `last_attention_at` are durable. The daemon derives the next
+buffered deadline and counts from current unread events. On restart or session recovery,
+it recomputes the desired deadline and rearms the existing countdown.
+
+### Earliest-deadline countdown
+
+Extend `nudgeCountdown` to accept an absolute desired deadline:
+
+```text
+assignee deadline     = now + normalNudgeWindow
+buffered deadline     = max(now + normalNudgeWindow,
+                            attentionAnchor + 30m)
+armed deadline        = min(existingDeadline, desiredDeadline)
+```
+
+For a first delivery, `attentionAnchor` is the oldest unread event timestamp. After
+the observer has received or consumed activity, it is the durable
+`last_attention_at` value.
+
+This single rule supplies:
+
+- non-sliding burst coalescing;
+- one observer-wide timer across tickets;
+- immediate assignee precedence over an already-buffered timer;
+- piggybacking, because the resulting inbox consume already returns all unread events.
+
+Approval wait, active-session pause, and recent-user-input protection remain final PTY
+safety checks. They may postpone the doorbell without clearing unread state or moving
+the 30-minute clock.
+
+### Watch versus nudge
+
+`--watch` is an automated delivery channel, not an explicit catch-up. Add a watch mode
+to the existing inbox command rather than a separate batch interface.
+
+Each watch poll refreshes a short in-memory lease for that session. Watch eligibility
+and countdown firing share one daemon delivery lock:
+
+- a live watch consumes eligible activity and the countdown sees no unread events;
+- if the countdown reaches its deadline while the watch lease is live, it defers to the
+  next watch poll and keeps a short lease-expiry backstop;
+- if the watch disappears, the lease expires and the backstop doorbells the session;
+- an explicit inbox ignores both the lease and buffer deadline.
+
+The lease is intentionally ephemeral. After daemon restart, a real watch recreates it
+on its next poll; otherwise the durable unread state rearms the nudge path. A crash may
+repeat a fixed doorbell, but cannot lose ticket events.
+
+## Read-before-write
+
+### Agent commands
+
+For `ticket status`, `ticket comment`, and `ticket attach`, use one store-local
+transaction seam:
+
+```text
+attemptTicketMutation(updater identities, ticket, mutation):
+  pending = updater-unread events on this ticket only
+
+  if pending:
+    advance only this ticket's applicable cursors
+    commit
+    return pending without running mutation
+
+  run mutation in the same transaction
+  commit
+```
+
+The CLI renders returned events using the current inbox formatter, explains that the
+requested mutation did not run, and exits non-zero. The updater reviews the events and
+retries. A new event before the retry rejects it again. Unrelated ticket cursors never
+move.
+
+This deliberately keeps today's consume-before-render reliability model. If the CLI
+dies after the daemon response but before printing, the returned events are already
+read—the same crash window as `ticket inbox` today. Avoiding it would require the
+prepare/render/ack subsystem intentionally removed by this simplification.
+
+`ticket attach` may stage/install files before its store commit, as it does today; a
+catch-up conflict follows the existing rollback path and leaves no installed artifact.
+
+### App actions and exceptions
+
+The app already reads a ticket detail before status/comment/description/attach actions.
+Return `latest_event_seq` with that detail and send it back as `expected_event_seq`.
+The store rejects a stale value; the app refreshes the detail and requires retry.
+
+| Mutation | Behavior |
+|---|---|
+| CLI status, comment, attach | Atomic target-ticket consume-or-mutate |
+| App status, comment, description, attach | Optimistic `expected_event_seq` check |
+| Take/assign | Allow; report that ticket history is unread; next content mutation is guarded |
+| Subscribe | Allow; report newly visible unread history without consuming it |
+| Unsubscribe | Always allow |
+| New/delegated create | No prior activity to guard |
+| attn crash, revival, reconciliation | System mutation bypasses the updater guard |
+
+## Minimal Interfaces and State
+
+### Store
+
+Add:
+
+- one `ticket_delivery_attention(observer_key, last_attention_at)` table;
+- an unread summary that reports whether a session has assigned-ticket unread activity,
+  buffered unread activity, and counts needed for logs;
+- a target-ticket consume-or-mutate transaction helper;
+- `latest_event_seq` / expected-sequence checks for app mutations.
+
+Keep `ticket_events` and `ticket_event_cursors` unchanged.
+
+### Daemon
+
+Keep the existing `nudgeCountdowns` and `unreadCache`. Add only:
+
+```go
+deliveryMu     sync.Mutex
+watchLeaseUntil map[string]time.Time
+```
+
+`notifyTicketObservers` loads the ticket's current assignee once, maps role identities
+to live sessions as today, deduplicates delivery targets, and requests an immediate or
+buffered deadline. It does not need a general observer-relation type.
+
+### Protocol and CLI
+
+Change only the existing surfaces:
+
+- `TicketInboxMessage` gains `mode: explicit | watch`;
+- ticket mutation results may carry one catch-up `TicketEventBundle`;
+- ticket detail/actions carry `latest_event_seq` / `expected_event_seq`;
+- bump `ProtocolVersion` and regenerate Go/TypeScript types.
+
+Do not add batch IDs, cursor-advance messages, ack commands, delivery-reason enums, or a
+new notification result hierarchy.
+
+### Observability
+
+Reuse `ticket_unread` and `nudge_fires_at` for the existing unread marker/countdown.
+Add structured daemon logs containing observer key, immediate/buffered classification,
+pending counts, desired deadline, channel, and outcome. Do not log comment bodies.
+
+No new settings or notification UI are required in the first release.
+
+## Implementation Steps
+
+- [x] Store: add `last_attention_at` persistence, assignee-aware unread summary, atomic
+  target-ticket consume-or-mutate helpers, and optimistic app sequence checks.
+- [x] Daemon: make the existing countdown earliest-deadline-aware; classify targets by
+  current assignee; update/recover observer attention; preserve chief-role continuity.
+- [x] Inbox/watch: add watch mode, ephemeral watch leases, lease-expiry backstop, and
+  shared delivery serialization; keep explicit inbox immediate and consume all unread
+  for piggybacking.
+- [x] Mutations: guard CLI status/comment/attach, add app expected-sequence conflicts,
+  render caught-up events with the inbox formatter, and preserve mutation exceptions.
+- [x] Protocol/guidance/verification: regenerate types, bump `ProtocolVersion`, update
+  runtime guidance and `CHANGELOG.md`, then complete focused and packaged-app proof.
+
+## Verification
+
+### Core and store
+
+- Hundreds of events across several non-assigned tickets retain one deadline and one
+  observer interruption; provenance and ticket grouping survive.
+- Two observers have independent clocks/cursors.
+- Assignee plus subscriber/role overlap resolves to immediate.
+- An assigned-ticket event moves a long buffered countdown earlier and piggybacks all
+  unread activity.
+- Chief transfer retains the role clock/cursor and retargets only the session.
+- Restart before and after eligibility reconstructs the correct timer from unread
+  events plus `last_attention_at`.
+
+### Watch and nudge
+
+- A live watch consumes an eligible burst once and suppresses its nudge.
+- A dead watch's lease expires and the nudge backstop fires.
+- Watch polling and timer firing at the same boundary do not produce two wake-ups.
+- Explicit inbox consumes immediately during a buffer window.
+- Approval, selection pause, and recent-input rearm preserve unread state and deadlines.
+
+### Mutation guard
+
+- Target-ticket unread rejects status/comment/attach, returns and consumes only those
+  events, and writes no mutation.
+- Retry succeeds with no new event and rejects again if one arrived.
+- Concurrent event append cannot land between the unread check and mutation.
+- Attach conflict rolls staged files back.
+- App stale sequence refreshes without applying the action.
+- Take, subscribe, unsubscribe, create, and system mutations follow the exception table.
+
+### Live app
+
+Extend `scenario-chief-ticket-watch.mjs` or add one serial packaged-app scenario with
+short test overrides:
+
+1. a chief comment reaches the assigned worker through the normal short countdown;
+2. a worker burst remains buffered for the chief/subscriber and arrives once;
+3. immediate worker activity piggybacks that observer's buffered subscription activity;
+4. explicit inbox drains before the deadline;
+5. a stale mutation renders catch-up, rejects, and succeeds on retry;
+6. daemon restart preserves unread activity and reconstructs delivery.
+
+Run focused store, `ticketnotify`, daemon, CLI, and frontend tests; generated-type
+checks; and the signed non-production packaged-app scenario. Packaged scenarios remain
+strictly serial.
+
+## Decisions
+
+- Reuse the event log as the batch and current cursor consumption as acknowledgement.
+- Persist only `last_attention_at`; derive deadlines and counts from unread events.
+- Deepen the existing countdown rather than add a second delivery scheduler.
+- Prefer a live watch by lease; keep the nudge as its expiring backstop.
+- Accept today's consume-before-render CLI crash window to avoid a two-phase ack system.
+- Keep the 30-minute window fixed and preserve immediate current-assignee delivery.
+
+## Out of Scope
+
+- Automations.
+- Delaying activity to the current assignee.
+- Priority/urgent event semantics or a `needs_input` bypass.
+- New notification channels, settings, or first-release UI.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -376,10 +377,26 @@ func (c *Client) PresentFeedback(presentationID string, seq int) (*protocol.Pres
 // last_user_activity_at, the daemon's most recent observed user-presence
 // signal, so a watching agent can decide whether to push or hold.
 func (c *Client) TicketInbox(sourceSessionID string) (*protocol.TicketInboxResult, error) {
-	resp, err := c.send(protocol.TicketInboxMessage{
+	return c.ticketInbox(sourceSessionID, protocol.TicketInboxModeExplicit, 0)
+}
+
+// TicketInboxWatch is the polling form used by `ticket inbox --watch`. Unlike a
+// deliberate one-shot read, it only drains activity once the daemon says the
+// observer's immediate or buffered delivery deadline is eligible.
+func (c *Client) TicketInboxWatch(sourceSessionID string, interval time.Duration) (*protocol.TicketInboxResult, error) {
+	return c.ticketInbox(sourceSessionID, protocol.TicketInboxModeWatch, interval)
+}
+
+func (c *Client) ticketInbox(sourceSessionID string, mode protocol.TicketInboxMode, interval time.Duration) (*protocol.TicketInboxResult, error) {
+	message := protocol.TicketInboxMessage{
 		Cmd:             protocol.CmdTicketInbox,
 		SourceSessionID: sourceSessionID,
-	})
+		Mode:            protocol.Ptr(mode),
+	}
+	if mode == protocol.TicketInboxModeWatch && interval > 0 {
+		message.WatchIntervalMs = protocol.Ptr(strconv.FormatInt(interval.Milliseconds(), 10))
+	}
+	resp, err := c.send(message)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/chief_of_staff.go
+++ b/internal/daemon/chief_of_staff.go
@@ -313,7 +313,7 @@ func (d *Daemon) retargetChiefTicketDelivery(previousSessionID, newSessionID str
 		d.refreshTicketUnread(previousSessionID)
 	}
 	if newSessionID != "" {
-		d.notifyTicketSession(newSessionID, time.Now())
+		d.notifyUnreadTicketSession(newSessionID, time.Now())
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -186,13 +186,14 @@ type Daemon struct {
 	// between the prompt and its trailing Enter.
 	doorbellMu                 sync.Mutex
 	nudgeMu                    sync.Mutex
-	nudgeCountdowns            map[string]*nudgeCountdown     // presence == a running (unpaused) countdown
-	unreadCache                map[string]bool                // per-session unread ticket activity, for cheap broadcast decoration
-	deliveryMu                 sync.Mutex                     // serializes live watch consumes and nudge fire-time checks
-	watchLeaseUntil            map[string]time.Time           // ephemeral live-watch lease per session
-	nudgeWindowOverride        time.Duration                  // 0 => defaultNudgeCountdownWindow; a short test override otherwise
-	ticketBufferWindowOverride time.Duration                  // 0 => defaultTicketBufferWindow; test-only override
-	nudgeFireHook              func(sessionID, action string) // tests only: invoked at the end of a countdown fire
+	nudgeCountdowns            map[string]*nudgeCountdown                 // presence == a running (unpaused) countdown
+	unreadCache                map[string]bool                            // per-session unread ticket activity, for cheap broadcast decoration
+	deliveryMu                 sync.Mutex                                 // serializes consumes, catch-up, deadline rebuilds, and nudge fire-time checks
+	watchLeaseUntil            map[string]time.Time                       // ephemeral live-watch lease per session
+	nudgeWindowOverride        time.Duration                              // 0 => defaultNudgeCountdownWindow; a short test override otherwise
+	ticketBufferWindowOverride time.Duration                              // 0 => defaultTicketBufferWindow; test-only override
+	nudgeFireHook              func(sessionID, action string)             // tests only: invoked at the end of a countdown fire
+	ticketRebuildBeforeArmHook func(sessionID string, deadline time.Time) // tests only: invoked while deliveryMu is held
 	lastInputMu                sync.Mutex
 	lastUserInputAt            map[string]time.Time // per-session keystroke recency — the fire-time splice guard
 	recoveryMu                 sync.RWMutex

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -184,18 +184,21 @@ type Daemon struct {
 	// doorbellMu serializes authoritative session-state commits with a complete
 	// doorbell write. This keeps a pending_approval report from interleaving
 	// between the prompt and its trailing Enter.
-	doorbellMu          sync.Mutex
-	nudgeMu             sync.Mutex
-	nudgeCountdowns     map[string]*nudgeCountdown     // presence == a running (unpaused) countdown
-	unreadCache         map[string]bool                // per-session unread ticket activity, for cheap broadcast decoration
-	nudgeWindowOverride time.Duration                  // 0 => defaultNudgeCountdownWindow; a short test override otherwise
-	nudgeFireHook       func(sessionID, action string) // tests only: invoked at the end of a countdown fire
-	lastInputMu         sync.Mutex
-	lastUserInputAt     map[string]time.Time // per-session keystroke recency — the fire-time splice guard
-	recoveryMu          sync.RWMutex
-	recovering          bool
-	notebookMu          sync.Mutex
-	notebookStore       *notebook.Store
+	doorbellMu                 sync.Mutex
+	nudgeMu                    sync.Mutex
+	nudgeCountdowns            map[string]*nudgeCountdown     // presence == a running (unpaused) countdown
+	unreadCache                map[string]bool                // per-session unread ticket activity, for cheap broadcast decoration
+	deliveryMu                 sync.Mutex                     // serializes live watch consumes and nudge fire-time checks
+	watchLeaseUntil            map[string]time.Time           // ephemeral live-watch lease per session
+	nudgeWindowOverride        time.Duration                  // 0 => defaultNudgeCountdownWindow; a short test override otherwise
+	ticketBufferWindowOverride time.Duration                  // 0 => defaultTicketBufferWindow; test-only override
+	nudgeFireHook              func(sessionID, action string) // tests only: invoked at the end of a countdown fire
+	lastInputMu                sync.Mutex
+	lastUserInputAt            map[string]time.Time // per-session keystroke recency — the fire-time splice guard
+	recoveryMu                 sync.RWMutex
+	recovering                 bool
+	notebookMu                 sync.Mutex
+	notebookStore              *notebook.Store
 	// notebookWatcher observes notebook.root for external edits; guarded by its
 	// own mutex (distinct from notebookMu) so notebookStoreFor can start it
 	// without nesting locks. Lazily started on first notebook use.
@@ -994,6 +997,7 @@ func (d *Daemon) pluginDriverReportsState(agent protocol.SessionAgent) bool {
 }
 
 func (d *Daemon) performStartupPTYRecovery(recoveryStartedAt time.Time) {
+	defer d.rebuildTicketDeliverySchedules()
 	recoveryReport, recoverErr := d.recoverPTYBackend(10 * time.Second)
 	if recoverErr != nil {
 		d.logf("PTY backend recovery failed: %v", recoverErr)
@@ -1035,6 +1039,18 @@ func (d *Daemon) performStartupPTYRecovery(recoveryStartedAt time.Time) {
 	// Pruning flipped recovered sessions to idle in the store; refresh the
 	// cached workspace rollups so InitialState matches.
 	d.reseedWorkspaceStatuses()
+}
+
+func (d *Daemon) rebuildTicketDeliverySchedules() {
+	if d.store == nil {
+		return
+	}
+	now := time.Now()
+	for _, session := range d.store.List("") {
+		if session != nil {
+			d.notifyUnreadTicketSession(session.ID, now)
+		}
+	}
 }
 
 func (d *Daemon) recoverPTYBackend(timeout time.Duration) (ptybackend.RecoveryReport, error) {

--- a/internal/daemon/nudge_countdown.go
+++ b/internal/daemon/nudge_countdown.go
@@ -44,8 +44,19 @@ func (d *Daemon) nudgeWindow() time.Duration {
 // countdown is paused (no timer, no nudge_fires_at) and the UI offers click-to-
 // trigger; switching away resumes it via setSelectedSession.
 func (d *Daemon) armNudgeCountdown(sessionID string) {
+	d.armNudgeCountdownAt(sessionID, time.Now().Add(d.nudgeWindow()))
+}
+
+// armNudgeCountdownAt marks ticket activity unread and asks the existing
+// countdown to fire no later than deadline. A burst never pushes an already
+// armed countdown later; an immediate assignee update can pull a buffered
+// observer's deadline forward.
+func (d *Daemon) armNudgeCountdownAt(sessionID string, deadline time.Time) {
 	if sessionID == "" {
 		return
+	}
+	if deadline.Before(time.Now()) {
+		deadline = time.Now()
 	}
 	active := d.currentlySelectedSession() == sessionID
 
@@ -54,10 +65,10 @@ func (d *Daemon) armNudgeCountdown(sessionID string) {
 	if active {
 		// Paused while active: ensure no running timer and no deadline on the wire.
 		changed = d.stopCountdownLocked(sessionID) || changed
-	} else if _, running := d.nudgeCountdowns[sessionID]; !running {
-		// Debounce: an already-running countdown keeps its original deadline rather
-		// than resetting (a burst of ticket events must not sawtooth the bar).
-		d.startCountdownLocked(sessionID, d.nudgeWindow())
+	} else if existing, running := d.nudgeCountdowns[sessionID]; !running || deadline.Before(existing.firesAt) {
+		// Keep the earliest deadline. This is both the existing non-sliding burst
+		// debounce and the assignee-over-buffered precedence rule.
+		d.startCountdownAtLocked(sessionID, deadline)
 		changed = true
 	}
 	d.nudgeMu.Unlock()
@@ -73,6 +84,10 @@ func (d *Daemon) armNudgeCountdown(sessionID string) {
 // written value even if a tiny (test) window fires the timer immediately — the same
 // handshake scheduleTicketBackstop uses.
 func (d *Daemon) startCountdownLocked(sessionID string, window time.Duration) {
+	d.startCountdownAtLocked(sessionID, time.Now().Add(window))
+}
+
+func (d *Daemon) startCountdownAtLocked(sessionID string, firesAt time.Time) {
 	if d.nudgeCountdowns == nil {
 		d.nudgeCountdowns = make(map[string]*nudgeCountdown)
 	}
@@ -81,11 +96,15 @@ func (d *Daemon) startCountdownLocked(sessionID string, window time.Duration) {
 	}
 	ready := make(chan struct{})
 	var timer *time.Timer
-	timer = time.AfterFunc(window, func() {
+	delay := time.Until(firesAt)
+	if delay < 0 {
+		delay = 0
+	}
+	timer = time.AfterFunc(delay, func() {
 		<-ready
 		d.nudgeCountdownFire(sessionID, timer)
 	})
-	d.nudgeCountdowns[sessionID] = &nudgeCountdown{timer: timer, firesAt: time.Now().Add(window)}
+	d.nudgeCountdowns[sessionID] = &nudgeCountdown{timer: timer, firesAt: firesAt}
 	close(ready)
 }
 
@@ -159,6 +178,9 @@ func (d *Daemon) clearNudgeState(sessionID string) {
 	d.lastInputMu.Lock()
 	delete(d.lastUserInputAt, sessionID)
 	d.lastInputMu.Unlock()
+	d.deliveryMu.Lock()
+	delete(d.watchLeaseUntil, sessionID)
+	d.deliveryMu.Unlock()
 }
 
 // stopNudgeCountdowns cancels every armed countdown. Daemon.Stop() calls it so no
@@ -195,6 +217,9 @@ func (d *Daemon) nudgeCountdownFire(sessionID string, self *time.Timer) {
 // one was armed on re-arm).
 func (d *Daemon) deliverNudgeOrReArm(sessionID string) {
 	action := d.runNudgeDelivery(sessionID)
+	if d.debugLogging {
+		d.logf("ticket delivery: observer=%s session=%s channel=countdown outcome=%s", d.ticketAttentionKey(sessionID), sessionID, action)
+	}
 	if d.nudgeFireHook != nil {
 		d.nudgeFireHook(sessionID, action)
 	}
@@ -220,6 +245,16 @@ func (d *Daemon) runNudgeDelivery(sessionID string) string {
 		// Became the active session during the window; switching away re-arms it.
 		return "active"
 	}
+	d.deliveryMu.Lock()
+	defer d.deliveryMu.Unlock()
+	if until := d.watchLeaseUntil[sessionID]; until.After(time.Now()) {
+		// A live watch gets the next polling opportunity first. If it disappears,
+		// the short lease expires and this rearmed countdown becomes the backstop.
+		d.nudgeMu.Lock()
+		d.startCountdownAtLocked(sessionID, until)
+		d.nudgeMu.Unlock()
+		return "watch"
+	}
 	unread, err := d.ticketUnreadForSession(sessionID)
 	if err != nil {
 		d.logf("nudge countdown unread check %s: %v", sessionID, err)
@@ -238,6 +273,9 @@ func (d *Daemon) runNudgeDelivery(sessionID string) string {
 	if err := d.typeDoorbell(sessionID, ticketNudgePrompt); err != nil {
 		d.logf("nudge countdown doorbell %s: %v", sessionID, err)
 		return "doorbell-error"
+	}
+	if err := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(sessionID), time.Now()); err != nil {
+		d.logf("nudge attention update %s: %v", sessionID, err)
 	}
 	return "doorbell"
 }
@@ -259,16 +297,17 @@ func (d *Daemon) updateNudgeSelection(oldID, newID string) {
 	if newID != "" && d.stopCountdownLocked(newID) {
 		changed = append(changed, newID)
 	}
-	if resumeOld && d.unreadCache[oldID] {
-		if _, running := d.nudgeCountdowns[oldID]; !running {
-			d.startCountdownLocked(oldID, d.nudgeWindow())
-			changed = append(changed, oldID)
-		}
-	}
+	resumeUnread := resumeOld && d.unreadCache[oldID]
 	d.nudgeMu.Unlock()
 
 	for _, id := range changed {
 		d.broadcastSessionStateChanged(id)
+	}
+	if resumeUnread {
+		// The paused timer intentionally carries no deadline. Re-derive the
+		// assignee/buffered deadline from durable unread events and attention so
+		// switching away cannot collapse a long observer buffer to 30 seconds.
+		go d.notifyUnreadTicketSession(oldID, time.Now())
 	}
 }
 
@@ -314,6 +353,8 @@ func (d *Daemon) handleTriggerNudge(msg *protocol.TriggerNudgeMessage) {
 	if session == nil || !isNudgeDeliveryAllowed(string(session.State)) {
 		return
 	}
+	d.deliveryMu.Lock()
+	defer d.deliveryMu.Unlock()
 	unread, err := d.ticketUnreadForSession(sessionID)
 	if err != nil || unread == 0 {
 		// Nothing to deliver; clear a stale indicator rather than doorbell into nothing.
@@ -322,6 +363,8 @@ func (d *Daemon) handleTriggerNudge(msg *protocol.TriggerNudgeMessage) {
 	}
 	if err := d.typeDoorbell(sessionID, ticketNudgePrompt); err != nil {
 		d.logf("trigger_nudge doorbell %s: %v", sessionID, err)
+	} else if err := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(sessionID), time.Now()); err != nil {
+		d.logf("trigger_nudge attention update %s: %v", sessionID, err)
 	}
 	d.broadcastSessionStateChanged(sessionID)
 }

--- a/internal/daemon/nudge_countdown_test.go
+++ b/internal/daemon/nudge_countdown_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/ticketnotify"
 )
 
 // currentNudgeTimer returns the session's armed countdown timer, or nil when none is
@@ -17,6 +18,28 @@ func currentNudgeTimer(d *Daemon, sessionID string) *time.Timer {
 		return c.timer
 	}
 	return nil
+}
+
+func currentNudgeDeadline(d *Daemon, sessionID string) time.Time {
+	d.nudgeMu.Lock()
+	defer d.nudgeMu.Unlock()
+	if c, ok := d.nudgeCountdowns[sessionID]; ok {
+		return c.firesAt
+	}
+	return time.Time{}
+}
+
+func waitForNudgeDeadline(t *testing.T, d *Daemon, sessionID string) time.Time {
+	t.Helper()
+	limit := time.Now().Add(time.Second)
+	for time.Now().Before(limit) {
+		if deadline := currentNudgeDeadline(d, sessionID); !deadline.IsZero() {
+			return deadline
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("no nudge deadline armed for %s", sessionID)
+	return time.Time{}
 }
 
 // fireNudgeNow simulates the countdown timer firing immediately, by invoking the fire
@@ -115,9 +138,54 @@ func TestNudgeCountdownResumesOnSwitchAway(t *testing.T) {
 
 	d.setSelectedSession(chiefID) // switch away
 
-	if currentNudgeTimer(d, agentID) == nil {
-		t.Fatal("countdown did not resume after switching away from the session")
+	waitForNudgeDeadline(t, d, agentID)
+}
+
+func TestBufferedNudgePreservesDeadlineAcrossSelectionPause(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Second
+	d.ticketBufferWindowOverride = time.Hour
+	t.Cleanup(d.stopNudgeCountdowns)
+	chiefID, agentID, _ := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, agentID)
+	if _, err := ticketnotify.ConsumeAll(d.store, d.ticketObserversForSession(chiefID), time.Now()); err != nil {
+		t.Fatal(err)
 	}
+	attentionAt := time.Now().Add(-10 * time.Minute)
+	if err := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(chiefID), attentionAt); err != nil {
+		t.Fatal(err)
+	}
+	d.setSelectedSession(chiefID)
+	commentOnTicket(t, d, ticketID, "buffer this")
+	if deadline := currentNudgeDeadline(d, chiefID); !deadline.IsZero() {
+		t.Fatalf("selected chief armed deadline %s", deadline)
+	}
+
+	d.setSelectedSession(agentID)
+	deadline := waitForNudgeDeadline(t, d, chiefID)
+	want := attentionAt.Add(time.Hour)
+	// Store timestamps use RFC3339 second precision, so the durable round-trip
+	// may trim the sub-second component.
+	if delta := deadline.Sub(want); delta < -time.Second || delta > time.Second {
+		t.Fatalf("resumed deadline = %s, want %s", deadline, want)
+	}
+}
+
+func TestRebuildTicketDeliverySchedulesRearmsUnread(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Hour
+	t.Cleanup(d.stopNudgeCountdowns)
+	_, agentID, _ := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, agentID)
+	d.store.UpdateState(agentID, protocol.StateIdle)
+	commentOnTicket(t, d, ticketID, "survive restart")
+	d.cancelNudgeCountdown(agentID, "simulate daemon restart")
+	if currentNudgeTimer(d, agentID) != nil {
+		t.Fatal("countdown still armed before rebuild")
+	}
+
+	d.rebuildTicketDeliverySchedules()
+	waitForNudgeDeadline(t, d, agentID)
 }
 
 // Switching TO a session with a running countdown pauses it (no auto-fire while the
@@ -296,6 +364,9 @@ func TestTriggerNudgeFiresImmediately(t *testing.T) {
 	}
 	if currentNudgeTimer(d, agentID) != nil {
 		t.Fatal("trigger_nudge left a countdown running")
+	}
+	if _, found, err := d.store.TicketDeliveryAttention(d.ticketAttentionKey(agentID)); err != nil || !found {
+		t.Fatalf("trigger_nudge did not record attention: found=%v err=%v", found, err)
 	}
 }
 

--- a/internal/daemon/ticket_actions.go
+++ b/internal/daemon/ticket_actions.go
@@ -50,6 +50,10 @@ func (d *Daemon) handleTicketChangeStatus(client *wsClient, msg *protocol.Ticket
 		d.sendTicketActionResult(client, requestID, fmt.Errorf("ticket_id is required"))
 		return
 	}
+	if err := requireExpectedTicketEventSeq(msg.ExpectedEventSeq); err != nil {
+		d.sendTicketActionResult(client, requestID, err)
+		return
+	}
 	// crashed is the one status attn authors itself (a session that died without
 	// reporting); the board never offers it as a manual destination. The daemon is
 	// the authority, so it rejects it here rather than trusting the UI's
@@ -61,7 +65,10 @@ func (d *Daemon) handleTicketChangeStatus(client *wsClient, msg *protocol.Ticket
 		return
 	}
 	comment := strings.TrimSpace(protocol.Deref(msg.Comment))
-	_, err := d.store.SetTicketStatus(ticketID, status, store.TicketAuthorYou, comment, time.Now())
+	_, _, err := d.store.SetTicketStatusWithOptions(
+		ticketID, status, store.TicketAuthorYou, comment,
+		expectedTicketMutationOptions(msg.ExpectedEventSeq), time.Now(),
+	)
 	d.afterTicketMutation(ticketID, err)
 	d.sendTicketActionResult(client, requestID, err)
 }
@@ -74,7 +81,14 @@ func (d *Daemon) handleTicketAddComment(client *wsClient, msg *protocol.TicketAd
 		d.sendTicketActionResult(client, requestID, fmt.Errorf("ticket_id and comment are required"))
 		return
 	}
-	_, err := d.store.AddTicketComment(ticketID, store.TicketAuthorYou, comment, time.Now())
+	if err := requireExpectedTicketEventSeq(msg.ExpectedEventSeq); err != nil {
+		d.sendTicketActionResult(client, requestID, err)
+		return
+	}
+	_, _, err := d.store.AddTicketCommentWithOptions(
+		ticketID, store.TicketAuthorYou, comment,
+		expectedTicketMutationOptions(msg.ExpectedEventSeq), time.Now(),
+	)
 	d.afterTicketMutation(ticketID, err)
 	d.sendTicketActionResult(client, requestID, err)
 }
@@ -86,7 +100,14 @@ func (d *Daemon) handleTicketEditDescription(client *wsClient, msg *protocol.Tic
 		d.sendTicketActionResult(client, requestID, fmt.Errorf("ticket_id is required"))
 		return
 	}
-	err := d.store.EditTicketDescription(ticketID, msg.Description, store.TicketAuthorYou, time.Now())
+	if err := requireExpectedTicketEventSeq(msg.ExpectedEventSeq); err != nil {
+		d.sendTicketActionResult(client, requestID, err)
+		return
+	}
+	_, err := d.store.EditTicketDescriptionWithOptions(
+		ticketID, msg.Description, store.TicketAuthorYou,
+		expectedTicketMutationOptions(msg.ExpectedEventSeq), time.Now(),
+	)
 	d.afterTicketMutation(ticketID, err)
 	d.sendTicketActionResult(client, requestID, err)
 }

--- a/internal/daemon/ticket_actions_test.go
+++ b/internal/daemon/ticket_actions_test.go
@@ -2,12 +2,22 @@ package daemon
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/store"
 )
+
+func currentTicketEventSeq(t *testing.T, d *Daemon, ticketID string) *int {
+	t.Helper()
+	ticket, err := d.store.GetTicket(ticketID)
+	if err != nil || ticket == nil {
+		t.Fatalf("ticket %s: %v", ticketID, err)
+	}
+	return protocol.Ptr(int(ticket.LatestEventSeq))
+}
 
 // A human status change from the app moves the ticket, succeeds, and — because it
 // is authored as "you", not the agent — notifies the idle assigned agent.
@@ -21,11 +31,12 @@ func TestTicketChangeStatusMovesAndNotifies(t *testing.T) {
 
 	client := &wsClient{send: make(chan outboundMessage, 4)}
 	d.handleTicketChangeStatus(client, &protocol.TicketChangeStatusMessage{
-		Cmd:       protocol.CmdTicketChangeStatus,
-		RequestID: protocol.Ptr("req-1"),
-		TicketID:  ticketID,
-		Status:    protocol.TicketStatus(store.TicketStatusBlocked),
-		Comment:   protocol.Ptr("need a decision"),
+		Cmd:              protocol.CmdTicketChangeStatus,
+		RequestID:        protocol.Ptr("req-1"),
+		TicketID:         ticketID,
+		Status:           protocol.TicketStatus(store.TicketStatusBlocked),
+		Comment:          protocol.Ptr("need a decision"),
+		ExpectedEventSeq: currentTicketEventSeq(t, d, ticketID),
 	})
 
 	var res protocol.TicketActionResultMessage
@@ -55,10 +66,11 @@ func TestTicketAddCommentLandsAndNotifies(t *testing.T) {
 
 	client := &wsClient{send: make(chan outboundMessage, 4)}
 	d.handleTicketAddComment(client, &protocol.TicketAddCommentMessage{
-		Cmd:       protocol.CmdTicketAddComment,
-		RequestID: protocol.Ptr("req-2"),
-		TicketID:  ticketID,
-		Comment:   "try the other approach",
+		Cmd:              protocol.CmdTicketAddComment,
+		RequestID:        protocol.Ptr("req-2"),
+		TicketID:         ticketID,
+		Comment:          "try the other approach",
+		ExpectedEventSeq: currentTicketEventSeq(t, d, ticketID),
 	})
 
 	var res protocol.TicketActionResultMessage
@@ -90,10 +102,11 @@ func TestTicketEditDescriptionUpdates(t *testing.T) {
 
 	client := &wsClient{send: make(chan outboundMessage, 4)}
 	d.handleTicketEditDescription(client, &protocol.TicketEditDescriptionMessage{
-		Cmd:         protocol.CmdTicketEditDescription,
-		RequestID:   protocol.Ptr("req-3"),
-		TicketID:    ticketID,
-		Description: "Re-scoped: do only the read path",
+		Cmd:              protocol.CmdTicketEditDescription,
+		RequestID:        protocol.Ptr("req-3"),
+		TicketID:         ticketID,
+		Description:      "Re-scoped: do only the read path",
+		ExpectedEventSeq: currentTicketEventSeq(t, d, ticketID),
 	})
 
 	var res protocol.TicketActionResultMessage
@@ -104,6 +117,57 @@ func TestTicketEditDescriptionUpdates(t *testing.T) {
 	tk, _ := d.store.GetTicket(ticketID)
 	if tk == nil || tk.Description != "Re-scoped: do only the read path" {
 		t.Fatalf("description = %q, want re-scoped text", tk.Description)
+	}
+}
+
+func TestTicketActionRejectsStaleDetailSequence(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	_, agentID, _ := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, agentID)
+	detail, err := d.store.GetTicket(ticketID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.store.AddTicketComment(ticketID, agentID, "new since detail", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	expected := int(detail.LatestEventSeq)
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+	d.handleTicketChangeStatus(client, &protocol.TicketChangeStatusMessage{
+		Cmd: protocol.CmdTicketChangeStatus, RequestID: protocol.Ptr("stale"),
+		TicketID: ticketID, Status: protocol.TicketStatusDone, ExpectedEventSeq: &expected,
+	})
+	var res protocol.TicketActionResultMessage
+	readTicketResult(t, client.send, &res)
+	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "ticket changed since it was opened") {
+		t.Fatalf("stale result = %+v", res)
+	}
+	got, _ := d.store.GetTicket(ticketID)
+	if got.Status == store.TicketStatusDone {
+		t.Fatal("stale app action mutated the ticket")
+	}
+}
+
+func TestTicketActionRequiresDetailSequence(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	_, agentID, _ := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, agentID)
+	client := &wsClient{send: make(chan outboundMessage, 4)}
+
+	d.handleTicketAddComment(client, &protocol.TicketAddCommentMessage{
+		Cmd: protocol.CmdTicketAddComment, RequestID: protocol.Ptr("missing-seq"),
+		TicketID: ticketID, Comment: "must not land",
+	})
+	var res protocol.TicketActionResultMessage
+	readTicketResult(t, client.send, &res)
+	if res.Success || res.Error == nil || !strings.Contains(*res.Error, "expected_event_seq is required") {
+		t.Fatalf("missing sequence result = %+v", res)
+	}
+	ticket, _ := d.store.GetTicket(ticketID)
+	for _, activity := range ticket.Activity {
+		if activity.Comment == "must not land" {
+			t.Fatal("action without a detail sequence mutated the ticket")
+		}
 	}
 }
 
@@ -129,10 +193,11 @@ func TestTicketActionUnknownTicketFails(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	client := &wsClient{send: make(chan outboundMessage, 4)}
 	d.handleTicketChangeStatus(client, &protocol.TicketChangeStatusMessage{
-		Cmd:       protocol.CmdTicketChangeStatus,
-		RequestID: protocol.Ptr("req-5"),
-		TicketID:  "does-not-exist",
-		Status:    protocol.TicketStatus(store.TicketStatusDone),
+		Cmd:              protocol.CmdTicketChangeStatus,
+		RequestID:        protocol.Ptr("req-5"),
+		TicketID:         "does-not-exist",
+		Status:           protocol.TicketStatus(store.TicketStatusDone),
+		ExpectedEventSeq: protocol.Ptr(0),
 	})
 	var res protocol.TicketActionResultMessage
 	readTicketResult(t, client.send, &res)
@@ -151,10 +216,11 @@ func TestTicketChangeStatusBroadcastsBoard(t *testing.T) {
 
 	client := &wsClient{send: make(chan outboundMessage, 4)}
 	d.handleTicketChangeStatus(client, &protocol.TicketChangeStatusMessage{
-		Cmd:       protocol.CmdTicketChangeStatus,
-		RequestID: protocol.Ptr("req-b"),
-		TicketID:  ticketID,
-		Status:    protocol.TicketStatus(store.TicketStatusBlocked),
+		Cmd:              protocol.CmdTicketChangeStatus,
+		RequestID:        protocol.Ptr("req-b"),
+		TicketID:         ticketID,
+		Status:           protocol.TicketStatus(store.TicketStatusBlocked),
+		ExpectedEventSeq: currentTicketEventSeq(t, d, ticketID),
 	})
 
 	board := latestBroadcast()
@@ -186,10 +252,11 @@ func TestTicketActionFailureDoesNotNotify(t *testing.T) {
 
 	client := &wsClient{send: make(chan outboundMessage, 4)}
 	d.handleTicketChangeStatus(client, &protocol.TicketChangeStatusMessage{
-		Cmd:       protocol.CmdTicketChangeStatus,
-		RequestID: protocol.Ptr("req-f"),
-		TicketID:  ticketID,
-		Status:    protocol.TicketStatus("not-a-status"),
+		Cmd:              protocol.CmdTicketChangeStatus,
+		RequestID:        protocol.Ptr("req-f"),
+		TicketID:         ticketID,
+		Status:           protocol.TicketStatus("not-a-status"),
+		ExpectedEventSeq: currentTicketEventSeq(t, d, ticketID),
 	})
 
 	var res protocol.TicketActionResultMessage
@@ -213,10 +280,11 @@ func TestTicketChangeStatusRejectsCrashed(t *testing.T) {
 
 	client := &wsClient{send: make(chan outboundMessage, 4)}
 	d.handleTicketChangeStatus(client, &protocol.TicketChangeStatusMessage{
-		Cmd:       protocol.CmdTicketChangeStatus,
-		RequestID: protocol.Ptr("req-c"),
-		TicketID:  ticketID,
-		Status:    protocol.TicketStatus(store.TicketStatusCrashed),
+		Cmd:              protocol.CmdTicketChangeStatus,
+		RequestID:        protocol.Ptr("req-c"),
+		TicketID:         ticketID,
+		Status:           protocol.TicketStatus(store.TicketStatusCrashed),
+		ExpectedEventSeq: currentTicketEventSeq(t, d, ticketID),
 	})
 
 	var res protocol.TicketActionResultMessage

--- a/internal/daemon/ticket_attach.go
+++ b/internal/daemon/ticket_attach.go
@@ -161,7 +161,7 @@ func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author st
 	}
 	if len(outcome.ConflictEvents) > 0 {
 		rollbackInstalledAttachFiles(staged)
-		d.afterTicketMutationCatchUp(author, outcome.ConflictEvents)
+		d.afterTicketMutationCatchUpLocked(author, outcome.ConflictEvents)
 		d.deliveryMu.Unlock()
 		currentStatus := currentTicket.Status
 		if current, getErr := d.store.GetTicket(ticketID); getErr == nil && current != nil {

--- a/internal/daemon/ticket_attach.go
+++ b/internal/daemon/ticket_attach.go
@@ -53,6 +53,13 @@ func (d *Daemon) handleTicketAttach(conn net.Conn, msg *protocol.TicketAttachMes
 // must name the ticket explicitly.
 func (d *Daemon) handleTicketAttachWS(client *wsClient, msg *protocol.TicketAttachMessage) {
 	requestID := protocol.Deref(msg.RequestID)
+	if err := requireExpectedTicketEventSeq(msg.ExpectedEventSeq); err != nil {
+		d.sendToClient(client, protocol.TicketAttachResultMessage{
+			Event: protocol.EventTicketAttachResult, RequestID: requestID,
+			Success: false, Error: protocol.Ptr(err.Error()),
+		})
+		return
+	}
 	result, err := d.submitTicketAttach(msg, store.TicketAuthorYou, false)
 	reply := protocol.TicketAttachResultMessage{
 		Event:     protocol.EventTicketAttachResult,
@@ -84,9 +91,10 @@ func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author st
 	if ticketID == "" {
 		return nil, errors.New("ticket_id is required")
 	}
-	if ticket, err := d.store.GetTicket(ticketID); err != nil {
+	currentTicket, err := d.store.GetTicket(ticketID)
+	if err != nil {
 		return nil, err
-	} else if ticket == nil {
+	} else if currentTicket == nil {
 		return nil, fmt.Errorf("ticket not found: %s", ticketID)
 	}
 	if len(msg.Files) == 0 {
@@ -137,11 +145,37 @@ func (d *Daemon) submitTicketAttach(msg *protocol.TicketAttachMessage, author st
 		rollbackInstalledAttachFiles(staged)
 		return nil, err
 	}
-	record, err := d.store.SubmitTicketAttach(ticketID, author, fingerprint, detail, activityComment, status, time.Now())
+	options := expectedTicketMutationOptions(msg.ExpectedEventSeq)
+	if resolveBound {
+		options = d.ticketMutationOptions(author)
+	}
+	d.deliveryMu.Lock()
+	record, outcome, err := d.store.SubmitTicketAttachWithOptions(
+		ticketID, author, fingerprint, detail, activityComment, status,
+		options, time.Now(),
+	)
 	if err != nil {
+		d.deliveryMu.Unlock()
 		rollbackInstalledAttachFiles(staged)
 		return nil, err
 	}
+	if len(outcome.ConflictEvents) > 0 {
+		rollbackInstalledAttachFiles(staged)
+		d.afterTicketMutationCatchUp(author, outcome.ConflictEvents)
+		d.deliveryMu.Unlock()
+		currentStatus := currentTicket.Status
+		if current, getErr := d.store.GetTicket(ticketID); getErr == nil && current != nil {
+			currentStatus = current.Status
+		}
+		return &protocol.TicketAttachResult{
+			TicketID:    ticketID,
+			Artifacts:   []protocol.TicketArtifact{},
+			Fingerprint: fingerprint,
+			State:       protocol.TicketStatus(currentStatus),
+			CatchUp:     ticketMutationCatchUp(ticketID, outcome.ConflictEvents),
+		}, nil
+	}
+	d.deliveryMu.Unlock()
 
 	artifacts := make([]protocol.TicketArtifact, 0, len(staged))
 	changedPaths := make([]string, 0, len(staged))

--- a/internal/daemon/ticket_attach_test.go
+++ b/internal/daemon/ticket_attach_test.go
@@ -143,6 +143,36 @@ func TestTicketAttachRetryReturnsExistingReceipt(t *testing.T) {
 	}
 }
 
+func TestTicketAttachCatchUpRollsBackInstalledFile(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	root := t.TempDir()
+	d.store.SetSetting(SettingNotebookRoot, root)
+	_, agentID, _ := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, agentID)
+	if _, err := d.store.AddTicketComment(ticketID, "chief-peer", "new decision", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	source := attachSource(t, t.TempDir(), "design.md", "decision")
+	msg := &protocol.TicketAttachMessage{Cmd: protocol.CmdTicketAttach, SourceSessionID: agentID, Files: []protocol.TicketAttachFile{source}}
+
+	first := callTicketAttach(t, d, msg)
+	if !first.Ok || first.TicketAttachResult == nil || first.TicketAttachResult.CatchUp == nil {
+		t.Fatalf("first response = %+v, want catch-up", first)
+	}
+	destination := filepath.Join(root, "tickets", ticketID, "design.md")
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
+		t.Fatalf("conflicting attach left destination behind: %v", err)
+	}
+
+	retry := callTicketAttach(t, d, msg)
+	if !retry.Ok || retry.TicketAttachResult == nil || retry.TicketAttachResult.CatchUp != nil {
+		t.Fatalf("retry response = %+v", retry)
+	}
+	if _, err := os.Stat(destination); err != nil {
+		t.Fatalf("retry did not install destination: %v", err)
+	}
+}
+
 func TestTicketAttachPreservesDifferentExistingArtifact(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	root := t.TempDir()
@@ -193,6 +223,7 @@ func TestTicketAttachDispatchesFromWebSocketAsUser(t *testing.T) {
 	payload, _ := json.Marshal(protocol.TicketAttachMessage{
 		Cmd: protocol.CmdTicketAttach, SourceSessionID: store.TicketAuthorYou,
 		TicketID: protocol.Ptr("ui-ticket"), Files: []protocol.TicketAttachFile{source}, RequestID: protocol.Ptr("h1"),
+		ExpectedEventSeq: currentTicketEventSeq(t, d, "ui-ticket"),
 	})
 	d.handleClientMessage(client, payload)
 	var result protocol.TicketAttachResultMessage

--- a/internal/daemon/ticket_board.go
+++ b/internal/daemon/ticket_board.go
@@ -154,18 +154,19 @@ func (d *Daemon) sendGetTicketWSResult(client *wsClient, requestID, ticketID str
 // hydrated separately from the filesystem for full reads.
 func ticketToProtocol(t *store.Ticket) protocol.Ticket {
 	pt := protocol.Ticket{
-		ID:          t.ID,
-		Title:       t.Title,
-		Description: t.Description,
-		Status:      protocol.TicketStatus(t.Status),
-		Assignee:    t.Assignee,
-		Cwd:         t.Cwd,
-		LastAgentID: t.LastAgentID,
-		ProjectID:   t.ProjectID,
-		CreatedAt:   t.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:   t.UpdatedAt.Format(time.RFC3339),
-		Activity:    make([]protocol.TicketActivity, 0, len(t.Activity)),
-		Artifacts:   make([]protocol.TicketArtifact, 0),
+		ID:             t.ID,
+		Title:          t.Title,
+		Description:    t.Description,
+		Status:         protocol.TicketStatus(t.Status),
+		Assignee:       t.Assignee,
+		Cwd:            t.Cwd,
+		LastAgentID:    t.LastAgentID,
+		ProjectID:      t.ProjectID,
+		CreatedAt:      t.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:      t.UpdatedAt.Format(time.RFC3339),
+		LatestEventSeq: protocol.Ptr(int(t.LatestEventSeq)),
+		Activity:       make([]protocol.TicketActivity, 0, len(t.Activity)),
+		Artifacts:      make([]protocol.TicketArtifact, 0),
 	}
 	if t.ClosedAt != nil {
 		pt.ClosedAt = protocol.Ptr(t.ClosedAt.Format(time.RFC3339))

--- a/internal/daemon/ticket_buffer_test.go
+++ b/internal/daemon/ticket_buffer_test.go
@@ -1,0 +1,124 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+func TestTicketDeadlineBuffersObserverButNotAssignee(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Second
+	d.ticketBufferWindowOverride = time.Hour
+	_, assignee, _ := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, assignee)
+	now := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
+
+	deadline, immediate, err := d.ticketDeadline(assignee, ticketID, now, now)
+	if err != nil || !immediate || !deadline.Equal(now.Add(time.Second)) {
+		t.Fatalf("assignee deadline = %s immediate=%v err=%v", deadline, immediate, err)
+	}
+	observer := "observer"
+	d.store.Add(&protocol.Session{ID: observer, Label: observer, Agent: protocol.SessionAgentCodex, Directory: t.TempDir(), State: protocol.StateIdle})
+	if err := d.store.SetTicketDeliveryAttention(observer, now.Add(-10*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	deadline, immediate, err = d.ticketDeadline(observer, ticketID, now, now)
+	if err != nil || immediate || !deadline.Equal(now.Add(50*time.Minute)) {
+		t.Fatalf("observer deadline = %s immediate=%v err=%v", deadline, immediate, err)
+	}
+}
+
+func TestTicketDeadlineBuffersFirstObserverEventFromEventTime(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Second
+	d.ticketBufferWindowOverride = time.Hour
+	_, assignee, _ := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, assignee)
+	observer := "new-observer"
+	d.store.Add(&protocol.Session{ID: observer, Label: observer, Agent: protocol.SessionAgentCodex, Directory: t.TempDir(), State: protocol.StateIdle})
+	eventAt := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
+	now := eventAt.Add(5 * time.Minute)
+
+	deadline, immediate, err := d.ticketDeadline(observer, ticketID, eventAt, now)
+	if err != nil || immediate || !deadline.Equal(eventAt.Add(time.Hour)) {
+		t.Fatalf("first observer deadline = %s immediate=%v err=%v", deadline, immediate, err)
+	}
+}
+
+func TestMutationCatchUpRebuildsRemainingUnreadFromNewAttention(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Second
+	d.ticketBufferWindowOverride = time.Hour
+	t.Cleanup(d.stopNudgeCountdowns)
+	sessionID := "observer"
+	d.store.Add(&protocol.Session{ID: sessionID, Label: sessionID, Agent: protocol.SessionAgentCodex, Directory: t.TempDir(), State: protocol.StateIdle})
+	now := time.Now()
+	for _, ticketID := range []string{"first", "remaining"} {
+		if _, err := d.store.CreateTicket(store.Ticket{ID: ticketID, Title: ticketID, Status: store.TicketStatusWorking}, "creator", now.Add(-time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+		if err := d.store.AddTicketSubscription(sessionID, ticketID, now.Add(-time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := d.store.AddTicketComment(ticketID, "creator", "update", now.Add(-time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := d.store.SetTicketDeliveryAttention(sessionID, now.Add(-50*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	d.notifyUnreadTicketSession(sessionID, now)
+	oldDeadline := currentNudgeDeadline(d, sessionID)
+	if oldDeadline.IsZero() || oldDeadline.After(now.Add(11*time.Minute)) {
+		t.Fatalf("old deadline = %s, want about ten minutes", oldDeadline)
+	}
+
+	d.deliveryMu.Lock()
+	_, outcome, err := d.store.AddTicketCommentWithOptions(
+		"first", sessionID, "should not land", d.ticketMutationOptions(sessionID), now,
+	)
+	if err != nil || len(outcome.ConflictEvents) == 0 {
+		d.deliveryMu.Unlock()
+		t.Fatalf("mutation outcome = %+v err=%v, want catch-up", outcome, err)
+	}
+	d.afterTicketMutationCatchUp(sessionID, outcome.ConflictEvents)
+	d.deliveryMu.Unlock()
+
+	newDeadline := currentNudgeDeadline(d, sessionID)
+	if newDeadline.Before(now.Add(59 * time.Minute)) {
+		t.Fatalf("rebuilt deadline = %s, want fresh attention window", newDeadline)
+	}
+}
+
+func TestExplicitInboxConsumesDuringObserverBuffer(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Second
+	d.ticketBufferWindowOverride = time.Hour
+	t.Cleanup(d.stopNudgeCountdowns)
+	chiefID, agentID, _ := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, agentID)
+	if bundles := callTicketInbox(t, d, chiefID); len(bundles) != 0 {
+		t.Fatalf("initial chief inbox = %+v", bundles)
+	}
+	if err := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(chiefID), time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	d.setSelectedSession(agentID)
+	callSetTicketStatus(t, d, agentID, string(protocol.DispatchWorkStateNeedsInput), "need a decision")
+	deadline := waitForNudgeDeadline(t, d, chiefID)
+	if deadline.Before(time.Now().Add(59 * time.Minute)) {
+		t.Fatalf("needs-input observer deadline = %s, want buffered", deadline)
+	}
+
+	bundles := callTicketInbox(t, d, chiefID)
+	if len(bundles) != 1 || bundles[0].TicketID != ticketID {
+		t.Fatalf("explicit inbox = %+v, want immediate catch-up", bundles)
+	}
+	if currentNudgeTimer(d, chiefID) != nil {
+		t.Fatal("explicit inbox left the buffered countdown armed")
+	}
+}

--- a/internal/daemon/ticket_buffer_test.go
+++ b/internal/daemon/ticket_buffer_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -71,22 +72,58 @@ func TestMutationCatchUpRebuildsRemainingUnreadFromNewAttention(t *testing.T) {
 	if err := d.store.SetTicketDeliveryAttention(sessionID, now.Add(-50*time.Minute)); err != nil {
 		t.Fatal(err)
 	}
-	d.notifyUnreadTicketSession(sessionID, now)
-	oldDeadline := currentNudgeDeadline(d, sessionID)
+	staleDeadline := make(chan time.Time, 1)
+	resumeStaleRebuild := make(chan struct{})
+	var pauseOnce sync.Once
+	d.ticketRebuildBeforeArmHook = func(gotSessionID string, deadline time.Time) {
+		if gotSessionID != sessionID {
+			return
+		}
+		pauseOnce.Do(func() {
+			staleDeadline <- deadline
+			<-resumeStaleRebuild
+		})
+	}
+	rebuildDone := make(chan struct{})
+	go func() {
+		d.notifyUnreadTicketSession(sessionID, now)
+		close(rebuildDone)
+	}()
+	oldDeadline := <-staleDeadline
 	if oldDeadline.IsZero() || oldDeadline.After(now.Add(11*time.Minute)) {
 		t.Fatalf("old deadline = %s, want about ten minutes", oldDeadline)
 	}
 
-	d.deliveryMu.Lock()
-	_, outcome, err := d.store.AddTicketCommentWithOptions(
-		"first", sessionID, "should not land", d.ticketMutationOptions(sessionID), now,
-	)
-	if err != nil || len(outcome.ConflictEvents) == 0 {
-		d.deliveryMu.Unlock()
-		t.Fatalf("mutation outcome = %+v err=%v, want catch-up", outcome, err)
+	type catchUpResult struct {
+		outcome store.TicketMutationOutcome
+		err     error
 	}
-	d.afterTicketMutationCatchUp(sessionID, outcome.ConflictEvents)
-	d.deliveryMu.Unlock()
+	catchUpStarted := make(chan struct{})
+	catchUpDone := make(chan catchUpResult, 1)
+	go func() {
+		close(catchUpStarted)
+		d.deliveryMu.Lock()
+		_, outcome, err := d.store.AddTicketCommentWithOptions(
+			"first", sessionID, "should not land", d.ticketMutationOptions(sessionID), now,
+		)
+		if err == nil && len(outcome.ConflictEvents) > 0 {
+			d.afterTicketMutationCatchUpLocked(sessionID, outcome.ConflictEvents)
+		}
+		d.deliveryMu.Unlock()
+		catchUpDone <- catchUpResult{outcome: outcome, err: err}
+	}()
+	<-catchUpStarted
+	select {
+	case result := <-catchUpDone:
+		t.Fatalf("catch-up crossed paused reconstruction: outcome=%+v err=%v", result.outcome, result.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(resumeStaleRebuild)
+	<-rebuildDone
+	result := <-catchUpDone
+	if result.err != nil || len(result.outcome.ConflictEvents) == 0 {
+		t.Fatalf("mutation outcome = %+v err=%v, want catch-up", result.outcome, result.err)
+	}
 
 	newDeadline := currentNudgeDeadline(d, sessionID)
 	if newDeadline.Before(now.Add(59 * time.Minute)) {

--- a/internal/daemon/ticket_comment.go
+++ b/internal/daemon/ticket_comment.go
@@ -36,14 +36,28 @@ func (d *Daemon) handleTicketComment(conn net.Conn, msg *protocol.TicketCommentM
 	// AddTicketComment fails with ErrTicketNotFound when the id does not exist
 	// (touchTicketTx affects no rows), so an agent naming a bad ticket gets a clear
 	// error rather than a silently dropped comment.
-	if _, err := d.store.AddTicketComment(ticketID, sourceSessionID, comment, time.Now()); err != nil {
+	d.deliveryMu.Lock()
+	_, outcome, err := d.store.AddTicketCommentWithOptions(
+		ticketID, sourceSessionID, comment,
+		d.ticketMutationOptions(sourceSessionID), time.Now(),
+	)
+	if err != nil {
+		d.deliveryMu.Unlock()
 		d.sendError(conn, "ticket comment: "+err.Error())
 		return
 	}
-	_ = json.NewEncoder(conn).Encode(protocol.Response{
-		Ok:                  true,
-		TicketCommentResult: &protocol.TicketCommentResult{TicketID: ticketID},
-	})
+	result := &protocol.TicketCommentResult{
+		TicketID: ticketID,
+		CatchUp:  ticketMutationCatchUp(ticketID, outcome.ConflictEvents),
+	}
+	if len(outcome.ConflictEvents) > 0 {
+		d.afterTicketMutationCatchUp(sourceSessionID, outcome.ConflictEvents)
+		d.deliveryMu.Unlock()
+		_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, TicketCommentResult: result})
+		return
+	}
+	d.deliveryMu.Unlock()
+	_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, TicketCommentResult: result})
 	// The comment is an event the ticket's participants did not author, so notify
 	// them (the assignee, the chief). The commenter authored it, so Notify excludes
 	// it — no self-nudge — and comment authorship does not make the commenter a

--- a/internal/daemon/ticket_comment.go
+++ b/internal/daemon/ticket_comment.go
@@ -51,7 +51,7 @@ func (d *Daemon) handleTicketComment(conn net.Conn, msg *protocol.TicketCommentM
 		CatchUp:  ticketMutationCatchUp(ticketID, outcome.ConflictEvents),
 	}
 	if len(outcome.ConflictEvents) > 0 {
-		d.afterTicketMutationCatchUp(sourceSessionID, outcome.ConflictEvents)
+		d.afterTicketMutationCatchUpLocked(sourceSessionID, outcome.ConflictEvents)
 		d.deliveryMu.Unlock()
 		_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, TicketCommentResult: result})
 		return

--- a/internal/daemon/ticket_comment_test.go
+++ b/internal/daemon/ticket_comment_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
 )
 
 // syncConn is a net.Conn whose writes append to an in-memory buffer and never
@@ -113,5 +114,34 @@ func TestAgentCommentDoesNotSubscribeCommenter(t *testing.T) {
 		if b.TicketID == ticketY {
 			t.Fatalf("commenter's inbox carried events for a ticket it only commented on: %+v", b)
 		}
+	}
+}
+
+func TestStandaloneTicketCreatorGetsUnreadCommentIndicator(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Hour
+	t.Cleanup(d.stopNudgeCountdowns)
+	_, creatorID, _ := delegateForNotify(t, d, "codex")
+	d.store.UpdateState(creatorID, protocol.StateIdle)
+	d.setSelectedSession(creatorID)
+	ticket, err := d.store.CreateTicket(store.Ticket{
+		ID: "standalone", Title: "Standalone", Status: store.TicketStatusTodo,
+	}, creatorID, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	commenterID := "commenter"
+	d.store.Add(&protocol.Session{ID: commenterID, Label: commenterID, Agent: protocol.SessionAgentShell, Directory: t.TempDir(), State: protocol.StateWorking})
+
+	resp := callTicketComment(t, d, commenterID, ticket.ID, "please review")
+	if !resp.Ok {
+		t.Fatalf("comment response = %+v", resp)
+	}
+	decorated := d.sessionForBroadcast(d.store.Get(creatorID))
+	if decorated == nil || !protocol.Deref(decorated.TicketUnread) {
+		t.Fatalf("creator session = %+v, want unread ticket indicator", decorated)
+	}
+	if decorated.NudgeFiresAt != nil {
+		t.Fatalf("selected creator armed countdown at %s", *decorated.NudgeFiresAt)
 	}
 }

--- a/internal/daemon/ticket_mutation.go
+++ b/internal/daemon/ticket_mutation.go
@@ -1,0 +1,83 @@
+package daemon
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/ticketnotify"
+)
+
+func requireExpectedTicketEventSeq(expected *int) error {
+	if expected == nil {
+		return fmt.Errorf("expected_event_seq is required; refresh the ticket before editing it")
+	}
+	return nil
+}
+
+func (d *Daemon) ticketMutationOptions(sessionID string) store.TicketMutationOptions {
+	observers := d.ticketObserversForSession(sessionID)
+	options := store.TicketMutationOptions{
+		Observers:    make([]store.TicketMutationObserver, 0, len(observers)),
+		AttentionKey: d.ticketAttentionKey(sessionID),
+	}
+	for _, observer := range observers {
+		options.Observers = append(options.Observers, store.TicketMutationObserver{
+			CursorIdentity: observer.ID,
+			AuthorIdentity: observer.AuthorID,
+		})
+	}
+	return options
+}
+
+func expectedTicketMutationOptions(expected *int) store.TicketMutationOptions {
+	if expected == nil {
+		return store.TicketMutationOptions{}
+	}
+	value := int64(*expected)
+	return store.TicketMutationOptions{ExpectedEventSeq: &value}
+}
+
+func ticketMutationCatchUp(ticketID string, events []store.TicketEvent) *protocol.TicketEventBundle {
+	if len(events) == 0 {
+		return nil
+	}
+	bundles := ticketEventBundlesToProtocol([]ticketnotify.Bundle{{TicketID: ticketID, Events: events}})
+	if len(bundles) == 0 {
+		return nil
+	}
+	return &bundles[0]
+}
+
+func (d *Daemon) afterTicketMutationCatchUp(sessionID string, events []store.TicketEvent) {
+	if len(events) == 0 {
+		return
+	}
+	if d.debugLogging {
+		d.logf("ticket delivery: observer=%s session=%s channel=mutation outcome=catch-up pending=%d", d.ticketAttentionKey(sessionID), sessionID, len(events))
+	}
+	// Catch-up advances the interruption clock. Any timer derived from its old
+	// value is now stale and may be too early, so rebuild from the remaining
+	// durable unread events instead of retaining the earliest-deadline timer.
+	d.cancelNudgeCountdown(sessionID, "mutation catch-up")
+	d.refreshTicketUnread(sessionID)
+	d.notifyUnreadTicketSession(sessionID, time.Now())
+}
+
+func (d *Daemon) targetTicketUnreadCount(sessionID, ticketID string) int {
+	seen := make(map[int64]struct{})
+	for _, observer := range d.ticketObserversForSession(sessionID) {
+		events, err := d.store.UnreadTicketEventsFor(observer.ID, observer.AuthorID)
+		if err != nil {
+			d.logf("ticket unread count %s/%s: %v", sessionID, ticketID, err)
+			return 0
+		}
+		for _, event := range events {
+			if event.TicketID == ticketID {
+				seen[event.Seq] = struct{}{}
+			}
+		}
+	}
+	return len(seen)
+}

--- a/internal/daemon/ticket_mutation.go
+++ b/internal/daemon/ticket_mutation.go
@@ -50,7 +50,10 @@ func ticketMutationCatchUp(ticketID string, events []store.TicketEvent) *protoco
 	return &bundles[0]
 }
 
-func (d *Daemon) afterTicketMutationCatchUp(sessionID string, events []store.TicketEvent) {
+// afterTicketMutationCatchUpLocked repairs live delivery state after the store's
+// atomic read-before-write transaction advances cursors and attention. Caller holds
+// deliveryMu so no stale deadline reconstruction can cross the new attention clock.
+func (d *Daemon) afterTicketMutationCatchUpLocked(sessionID string, events []store.TicketEvent) {
 	if len(events) == 0 {
 		return
 	}
@@ -62,7 +65,7 @@ func (d *Daemon) afterTicketMutationCatchUp(sessionID string, events []store.Tic
 	// durable unread events instead of retaining the earliest-deadline timer.
 	d.cancelNudgeCountdown(sessionID, "mutation catch-up")
 	d.refreshTicketUnread(sessionID)
-	d.notifyUnreadTicketSession(sessionID, time.Now())
+	d.notifyUnreadTicketSessionLocked(sessionID, time.Now())
 }
 
 func (d *Daemon) targetTicketUnreadCount(sessionID, ticketID string) int {

--- a/internal/daemon/ticket_notify.go
+++ b/internal/daemon/ticket_notify.go
@@ -1,10 +1,10 @@
 package daemon
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/victorarias/attn/internal/store"
-	"github.com/victorarias/attn/internal/ticketnotify"
 )
 
 // ticketNudgePrompt is the fixed doorbell typed into a nudge-eligible agent: a
@@ -12,6 +12,76 @@ import (
 // queue with `attn ticket inbox`. This is the doorbell rule — the daemon signals,
 // it never streams the message into the PTY.
 const ticketNudgePrompt = "📋 New ticket activity — run `attn ticket inbox` to catch up."
+
+// defaultTicketBufferWindow is the interruption budget for every observer that
+// is not currently assigned to the ticket. The assignee keeps the short nudge
+// countdown because it is the agent actively doing the work.
+const defaultTicketBufferWindow = 30 * time.Minute
+const ticketWatchLeaseWindow = 5 * time.Second
+
+func ticketWatchLeaseWindowFor(intervalMS *string) time.Duration {
+	if intervalMS == nil {
+		return ticketWatchLeaseWindow
+	}
+	milliseconds, err := strconv.ParseInt(*intervalMS, 10, 64)
+	if err != nil || milliseconds <= 0 {
+		return ticketWatchLeaseWindow
+	}
+	const maxDuration = time.Duration(1<<63 - 1)
+	if milliseconds > int64(maxDuration/time.Millisecond) {
+		return maxDuration
+	}
+	interval := time.Duration(milliseconds) * time.Millisecond
+	grace := interval / 2
+	if grace < time.Second {
+		grace = time.Second
+	}
+	if interval > maxDuration-grace {
+		return maxDuration
+	}
+	return interval + grace
+}
+
+func (d *Daemon) ticketBufferWindow() time.Duration {
+	if d.ticketBufferWindowOverride > 0 {
+		return d.ticketBufferWindowOverride
+	}
+	return defaultTicketBufferWindow
+}
+
+// ticketAttentionKey intentionally follows the durable chief role across chief
+// session transfer. Other observers use their ordinary session identity.
+func (d *Daemon) ticketAttentionKey(sessionID string) string {
+	if d.isChiefOfStaffSession(sessionID) {
+		return store.TicketRoleIdentity(store.TicketRoleChiefOfStaff)
+	}
+	return sessionID
+}
+
+func (d *Daemon) ticketDeadline(sessionID, ticketID string, unreadAt, now time.Time) (time.Time, bool, error) {
+	ticket, err := d.store.GetTicket(ticketID)
+	if err != nil || ticket == nil {
+		return time.Time{}, false, err
+	}
+	if ticket.Assignee == sessionID {
+		return now.Add(d.nudgeWindow()), true, nil
+	}
+	attention, found, err := d.store.TicketDeliveryAttention(d.ticketAttentionKey(sessionID))
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	deadline := now.Add(d.nudgeWindow())
+	if found {
+		if buffered := attention.LastAttentionAt.Add(d.ticketBufferWindow()); buffered.After(deadline) {
+			deadline = buffered
+		}
+	} else if !unreadAt.IsZero() {
+		if buffered := unreadAt.Add(d.ticketBufferWindow()); buffered.After(deadline) {
+			deadline = buffered
+		}
+	}
+	return deadline, false, nil
+}
 
 // ticketNudger adapts the daemon's doorbell primitive to ticketnotify.Nudger.
 type ticketNudger struct{ d *Daemon }
@@ -67,11 +137,7 @@ func (d *Daemon) notifyTicketSession(sessionID string, now time.Time) {
 	// the delivery mechanism, so an active agent and an optional watcher both surface
 	// the unread marker.
 	d.refreshTicketUnread(sessionID)
-	observers := d.ticketObserversForSession(sessionID)
-	_, err := ticketnotify.NotifyAny(d.store, observers, observers[0], isNudgeDeliveryAllowed(string(session.State)), ticketNudger{d}, now)
-	if err != nil {
-		d.logf("ticket notify: %s: %v", sessionID, err)
-	}
+	d.notifyUnreadTicketSession(sessionID, now)
 }
 
 // syncNudgeForState cancels a queued doorbell only while a session is waiting for
@@ -82,5 +148,44 @@ func (d *Daemon) syncNudgeForState(sessionID, state string) {
 		d.cancelNudgeCountdown(sessionID, "waiting for approval")
 		return
 	}
-	go d.notifyTicketSession(sessionID, time.Now())
+	go d.notifyUnreadTicketSession(sessionID, time.Now())
+}
+
+// notifyUnreadTicketSession rebuilds a deadline after an approval wait or daemon
+// recovery, when there is no single triggering ticket. It derives the earliest
+// eligible deadline from durable unread events instead of persisting a scheduler.
+func (d *Daemon) notifyUnreadTicketSession(sessionID string, now time.Time) {
+	if d.store == nil {
+		return
+	}
+	session := d.store.Get(sessionID)
+	if session == nil || !isNudgeDeliveryAllowed(string(session.State)) {
+		return
+	}
+	var deadline time.Time
+	immediate := false
+	pending := make(map[int64]struct{})
+	for _, observer := range d.ticketObserversForSession(sessionID) {
+		events, err := d.store.UnreadTicketEventsFor(observer.ID, observer.AuthorID)
+		if err != nil {
+			d.logf("ticket notify rebuild: %s: %v", sessionID, err)
+			return
+		}
+		for _, event := range events {
+			pending[event.Seq] = struct{}{}
+			candidate, assigned, err := d.ticketDeadline(sessionID, event.TicketID, event.CreatedAt, now)
+			if err != nil {
+				continue
+			}
+			if deadline.IsZero() || candidate.Before(deadline) {
+				deadline, immediate = candidate, assigned
+			}
+		}
+	}
+	if !deadline.IsZero() {
+		if d.debugLogging {
+			d.logf("ticket delivery: observer=%s session=%s class=%s pending=%d deadline=%s channel=countdown outcome=armed", d.ticketAttentionKey(sessionID), sessionID, map[bool]string{true: "assignee", false: "buffered"}[immediate], len(pending), deadline.Format(time.RFC3339))
+		}
+		d.armNudgeCountdownAt(sessionID, deadline)
+	}
 }

--- a/internal/daemon/ticket_notify.go
+++ b/internal/daemon/ticket_notify.go
@@ -155,6 +155,17 @@ func (d *Daemon) syncNudgeForState(sessionID, state string) {
 // recovery, when there is no single triggering ticket. It derives the earliest
 // eligible deadline from durable unread events instead of persisting a scheduler.
 func (d *Daemon) notifyUnreadTicketSession(sessionID string, now time.Time) {
+	d.deliveryMu.Lock()
+	defer d.deliveryMu.Unlock()
+	d.notifyUnreadTicketSessionLocked(sessionID, now)
+}
+
+// notifyUnreadTicketSessionLocked is the serialized form used by catch-up paths
+// that already hold deliveryMu. Keeping the unread scan, attention read, deadline
+// calculation, and timer arm in one critical section prevents an old calculation
+// from re-arming an earlier countdown after a concurrent consume advances the
+// observer's attention clock.
+func (d *Daemon) notifyUnreadTicketSessionLocked(sessionID string, now time.Time) {
 	if d.store == nil {
 		return
 	}
@@ -183,6 +194,9 @@ func (d *Daemon) notifyUnreadTicketSession(sessionID string, now time.Time) {
 		}
 	}
 	if !deadline.IsZero() {
+		if d.ticketRebuildBeforeArmHook != nil {
+			d.ticketRebuildBeforeArmHook(sessionID, deadline)
+		}
 		if d.debugLogging {
 			d.logf("ticket delivery: observer=%s session=%s class=%s pending=%d deadline=%s channel=countdown outcome=armed", d.ticketAttentionKey(sessionID), sessionID, map[bool]string{true: "assignee", false: "buffered"}[immediate], len(pending), deadline.Format(time.RFC3339))
 		}

--- a/internal/daemon/ticket_notify_test.go
+++ b/internal/daemon/ticket_notify_test.go
@@ -158,9 +158,10 @@ func TestCodexNudgeRoundtrip(t *testing.T) {
 	// ticket, authored as "you" — an event the agent did not author, so it is unread.
 	client := &wsClient{send: make(chan outboundMessage, 8)}
 	d.handleTicketAddComment(client, &protocol.TicketAddCommentMessage{
-		Cmd:      protocol.CmdTicketAddComment,
-		TicketID: ticketID,
-		Comment:  "please take a look at the failing test",
+		Cmd:              protocol.CmdTicketAddComment,
+		TicketID:         ticketID,
+		Comment:          "please take a look at the failing test",
+		ExpectedEventSeq: currentTicketEventSeq(t, d, ticketID),
 	})
 
 	// 1) The idle codex agent was nudged by the chief's comment on its ticket (after
@@ -264,7 +265,7 @@ func TestDelegatedAgentNotNudgedByOwnDeliveredBrief(t *testing.T) {
 
 	// The agent settles after its initial run; the went-idle path re-runs the notify
 	// decision for it. With the brief consumed at delegation, there is nothing unread.
-	d.notifyTicketSession(a, time.Now())
+	d.notifyUnreadTicketSession(a, time.Now())
 
 	if wasNudged(inputs(a)) {
 		t.Fatal("delegated agent was doorbelled about its own already-delivered brief")
@@ -279,9 +280,10 @@ func commentOnTicket(t *testing.T, d *Daemon, ticketID, comment string) {
 	t.Helper()
 	client := &wsClient{send: make(chan outboundMessage, 8)}
 	d.handleTicketAddComment(client, &protocol.TicketAddCommentMessage{
-		Cmd:      protocol.CmdTicketAddComment,
-		TicketID: ticketID,
-		Comment:  comment,
+		Cmd:              protocol.CmdTicketAddComment,
+		TicketID:         ticketID,
+		Comment:          comment,
+		ExpectedEventSeq: currentTicketEventSeq(t, d, ticketID),
 	})
 }
 
@@ -412,12 +414,55 @@ func TestTicketWatchDrainClearsSharedCountdown(t *testing.T) {
 	if currentNudgeTimer(d, agentID) == nil {
 		t.Fatal("shared countdown was not armed for Claude")
 	}
-	callTicketInbox(t, d, agentID) // equivalent to the watch's consuming poll
+	watch := protocol.TicketInboxModeWatch
+	callTicketInboxMode(t, d, agentID, &watch)
 	if currentNudgeTimer(d, agentID) != nil {
 		t.Fatal("watch drain did not clear the shared countdown")
 	}
 	if wasNudged(inputs(agentID)) {
 		t.Fatal("watch-drained queue was still doorbelled")
+	}
+}
+
+func TestLiveWatchLeaseWinsCountdownRaceAndConsumesOnce(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Hour
+	t.Cleanup(d.stopNudgeCountdowns)
+	_, agentID, inputs := delegateForNotify(t, d, "claude")
+	ticketID := boundTicketID(t, d, agentID)
+	d.store.UpdateState(agentID, protocol.StateWorking)
+	watch := protocol.TicketInboxModeWatch
+	if bundles := callTicketInboxMode(t, d, agentID, &watch); len(bundles) != 0 {
+		t.Fatalf("initial watch = %+v, want empty lease refresh", bundles)
+	}
+
+	commentOnTicket(t, d, ticketID, "take a look")
+	fireNudgeNow(t, d, agentID)
+	if wasNudged(inputs(agentID)) {
+		t.Fatal("countdown doorbelled while the live watch lease owned delivery")
+	}
+	bundles := callTicketInboxMode(t, d, agentID, &watch)
+	if len(bundles) != 1 || bundles[0].TicketID != ticketID {
+		t.Fatalf("watch delivery = %+v, want one ticket bundle", bundles)
+	}
+	if again := callTicketInboxMode(t, d, agentID, &watch); len(again) != 0 {
+		t.Fatalf("second watch delivery = %+v, want acknowledged empty queue", again)
+	}
+}
+
+func TestWatchLeaseCoversReportedSlowPollingInterval(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	_, agentID, _ := delegateForNotify(t, d, "claude")
+	watch := protocol.TicketInboxModeWatch
+	interval := "30000"
+	started := time.Now()
+	callTicketInboxRequest(t, d, agentID, &watch, &interval)
+
+	d.deliveryMu.Lock()
+	leaseUntil := d.watchLeaseUntil[agentID]
+	d.deliveryMu.Unlock()
+	if leaseUntil.Before(started.Add(44 * time.Second)) {
+		t.Fatalf("slow-watch lease expires at %s, want interval plus jitter grace", leaseUntil)
 	}
 }
 

--- a/internal/daemon/ticket_read.go
+++ b/internal/daemon/ticket_read.go
@@ -54,7 +54,39 @@ func (d *Daemon) handleTicketInbox(conn net.Conn, msg *protocol.TicketInboxMessa
 		d.sendError(conn, "ticket inbox: source_session_id is required")
 		return
 	}
-	bundles, err := ticketnotify.ConsumeAll(d.store, d.ticketObserversForSession(sourceSessionID), time.Now())
+	now := time.Now()
+	watch := msg.Mode != nil && *msg.Mode == protocol.TicketInboxModeWatch
+	d.deliveryMu.Lock()
+	if watch {
+		if d.watchLeaseUntil == nil {
+			d.watchLeaseUntil = make(map[string]time.Time)
+		}
+		d.watchLeaseUntil[sourceSessionID] = now.Add(ticketWatchLeaseWindowFor(msg.WatchIntervalMs))
+		eligible, err := d.ticketWatchEligible(sourceSessionID, now)
+		if err != nil {
+			d.deliveryMu.Unlock()
+			d.sendError(conn, "ticket inbox: "+err.Error())
+			return
+		}
+		if !eligible {
+			if d.debugLogging {
+				d.logf("ticket delivery: observer=%s session=%s channel=watch outcome=buffered", d.ticketAttentionKey(sourceSessionID), sourceSessionID)
+			}
+			d.deliveryMu.Unlock()
+			_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, TicketInboxResult: &protocol.TicketInboxResult{Bundles: []protocol.TicketEventBundle{}}})
+			return
+		}
+	}
+	bundles, err := ticketnotify.ConsumeAll(d.store, d.ticketObserversForSession(sourceSessionID), now)
+	if err == nil && len(bundles) > 0 {
+		if attentionErr := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(sourceSessionID), now); attentionErr != nil {
+			// Cursors have already advanced, so returning only an error here would
+			// hide the consumed bundles. Preserve delivery and let the next
+			// successful attention write repair the interruption clock.
+			d.logf("ticket inbox attention update %s: %v", sourceSessionID, attentionErr)
+		}
+	}
+	d.deliveryMu.Unlock()
 	if err != nil {
 		d.sendError(conn, "ticket inbox: "+err.Error())
 		return
@@ -63,6 +95,17 @@ func (d *Daemon) handleTicketInbox(conn net.Conn, msg *protocol.TicketInboxMessa
 	// Refresh the indicator (and cancel any pending countdown if fully drained) — this
 	// is the chokepoint a runtime's optional watch drains through.
 	d.refreshTicketUnread(sourceSessionID)
+	if d.debugLogging && len(bundles) > 0 {
+		pending := 0
+		for _, bundle := range bundles {
+			pending += len(bundle.Events)
+		}
+		channel := "explicit"
+		if watch {
+			channel = "watch"
+		}
+		d.logf("ticket delivery: observer=%s session=%s channel=%s outcome=consumed pending=%d tickets=%d", d.ticketAttentionKey(sourceSessionID), sourceSessionID, channel, pending, len(bundles))
+	}
 	result := &protocol.TicketInboxResult{Bundles: ticketEventBundlesToProtocol(bundles)}
 	if lastActive := d.lastUserActivityAt(); !lastActive.IsZero() {
 		result.LastUserActivityAt = protocol.Ptr(lastActive.Format(time.RFC3339))
@@ -71,6 +114,28 @@ func (d *Daemon) handleTicketInbox(conn net.Conn, msg *protocol.TicketInboxMessa
 		Ok:                true,
 		TicketInboxResult: result,
 	})
+}
+
+// ticketWatchEligible keeps automated polling behind the same assignee/immediate
+// and observer/buffered boundary as a nudge. It peeks durable unread events only;
+// the eventual ConsumeAll remains the acknowledgement.
+func (d *Daemon) ticketWatchEligible(sessionID string, now time.Time) (bool, error) {
+	for _, observer := range d.ticketObserversForSession(sessionID) {
+		events, err := d.store.UnreadTicketEventsFor(observer.ID, observer.AuthorID)
+		if err != nil {
+			return false, err
+		}
+		for _, event := range events {
+			deadline, immediate, err := d.ticketDeadline(sessionID, event.TicketID, event.CreatedAt, now)
+			if err != nil {
+				return false, err
+			}
+			if immediate || !deadline.After(now) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func ticketEventBundlesToProtocol(bundles []ticketnotify.Bundle) []protocol.TicketEventBundle {

--- a/internal/daemon/ticket_read_test.go
+++ b/internal/daemon/ticket_read_test.go
@@ -11,12 +11,22 @@ import (
 )
 
 func callTicketInbox(t *testing.T, d *Daemon, sessionID string) []protocol.TicketEventBundle {
+	return callTicketInboxMode(t, d, sessionID, nil)
+}
+
+func callTicketInboxMode(t *testing.T, d *Daemon, sessionID string, mode *protocol.TicketInboxMode) []protocol.TicketEventBundle {
+	return callTicketInboxRequest(t, d, sessionID, mode, nil)
+}
+
+func callTicketInboxRequest(t *testing.T, d *Daemon, sessionID string, mode *protocol.TicketInboxMode, watchIntervalMS *string) []protocol.TicketEventBundle {
 	t.Helper()
 	server, clientConn := net.Pipe()
 	go func() {
 		d.handleTicketInbox(server, &protocol.TicketInboxMessage{
 			Cmd:             protocol.CmdTicketInbox,
 			SourceSessionID: sessionID,
+			Mode:            mode,
+			WatchIntervalMs: watchIntervalMS,
 		})
 		_ = server.Close()
 	}()

--- a/internal/daemon/ticket_status.go
+++ b/internal/daemon/ticket_status.go
@@ -90,7 +90,7 @@ func (d *Daemon) handleSetTicketStatus(conn net.Conn, msg *protocol.SetTicketSta
 		if current, getErr := d.store.GetTicket(ticketID); getErr == nil && current != nil {
 			result.Status = protocol.TicketStatus(current.Status)
 		}
-		d.afterTicketMutationCatchUp(sourceSessionID, outcome.ConflictEvents)
+		d.afterTicketMutationCatchUpLocked(sourceSessionID, outcome.ConflictEvents)
 		d.deliveryMu.Unlock()
 		_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, TicketStatusResult: result})
 		return

--- a/internal/daemon/ticket_status.go
+++ b/internal/daemon/ticket_status.go
@@ -71,17 +71,36 @@ func (d *Daemon) handleSetTicketStatus(conn net.Conn, msg *protocol.SetTicketSta
 	if msg.Comment != nil {
 		comment = strings.TrimSpace(*msg.Comment)
 	}
-	updated, err := d.store.SetTicketStatus(ticketID, status, sourceSessionID, comment, time.Now())
+	d.deliveryMu.Lock()
+	updated, outcome, err := d.store.SetTicketStatusWithOptions(
+		ticketID, status, sourceSessionID, comment,
+		d.ticketMutationOptions(sourceSessionID), time.Now(),
+	)
 	if err != nil {
+		d.deliveryMu.Unlock()
 		d.sendError(conn, "ticket status: "+err.Error())
 		return
 	}
+	result := &protocol.TicketStatusResult{
+		TicketID: ticketID,
+		Status:   protocol.TicketStatus(status),
+		CatchUp:  ticketMutationCatchUp(ticketID, outcome.ConflictEvents),
+	}
+	if len(outcome.ConflictEvents) > 0 {
+		if current, getErr := d.store.GetTicket(ticketID); getErr == nil && current != nil {
+			result.Status = protocol.TicketStatus(current.Status)
+		}
+		d.afterTicketMutationCatchUp(sourceSessionID, outcome.ConflictEvents)
+		d.deliveryMu.Unlock()
+		_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, TicketStatusResult: result})
+		return
+	}
+	result.TicketID = updated.ID
+	result.Status = protocol.TicketStatus(updated.Status)
+	d.deliveryMu.Unlock()
 	_ = json.NewEncoder(conn).Encode(protocol.Response{
-		Ok: true,
-		TicketStatusResult: &protocol.TicketStatusResult{
-			TicketID: updated.ID,
-			Status:   protocol.TicketStatus(updated.Status),
-		},
+		Ok:                 true,
+		TicketStatusResult: result,
 	})
 	// The agent moved its own ticket; notify the other observers (the chief) so the
 	// board→watcher direction reflects it. The agent itself authored the event, so

--- a/internal/daemon/ticket_status_test.go
+++ b/internal/daemon/ticket_status_test.go
@@ -115,6 +115,29 @@ func TestSetTicketStatusMovesBoundTicket(t *testing.T) {
 	}
 }
 
+func TestSetTicketStatusCatchesUpBeforeMutating(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	sessionID := delegateBoundSession(t, d)
+	ticketID := boundTicketID(t, d, sessionID)
+	if _, err := d.store.AddTicketComment(ticketID, "chief-peer", "read this first", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	first := callSetTicketStatus(t, d, sessionID, string(protocol.DispatchWorkStateReadyForReview), "should not land")
+	if !first.Ok || first.TicketStatusResult == nil || first.TicketStatusResult.CatchUp == nil {
+		t.Fatalf("first response = %+v, want catch-up", first)
+	}
+	ticket, _ := d.store.GetTicket(ticketID)
+	if ticket.Status != store.TicketStatusWorking {
+		t.Fatalf("conflicting status changed ticket to %s", ticket.Status)
+	}
+
+	retry := callSetTicketStatus(t, d, sessionID, string(protocol.DispatchWorkStateReadyForReview), "now reviewed")
+	if !retry.Ok || retry.TicketStatusResult == nil || retry.TicketStatusResult.CatchUp != nil || retry.TicketStatusResult.Status != protocol.TicketStatusInReview {
+		t.Fatalf("retry response = %+v", retry)
+	}
+}
+
 // A completed report closes the ticket (terminal Done), after which the session
 // has no active ticket and a further report is rejected.
 func TestSetTicketStatusCompletedClosesTicket(t *testing.T) {

--- a/internal/daemon/ticket_subscribe.go
+++ b/internal/daemon/ticket_subscribe.go
@@ -36,8 +36,11 @@ func (d *Daemon) handleTicketSubscribe(conn net.Conn, msg *protocol.TicketSubscr
 		return
 	}
 	_ = json.NewEncoder(conn).Encode(protocol.Response{
-		Ok:                    true,
-		TicketSubscribeResult: &protocol.TicketSubscribeResult{TicketID: ticketID},
+		Ok: true,
+		TicketSubscribeResult: &protocol.TicketSubscribeResult{
+			TicketID:    ticketID,
+			UnreadCount: protocol.Ptr(d.targetTicketUnreadCount(sourceSessionID, ticketID)),
+		},
 	})
 }
 

--- a/internal/daemon/ticket_take.go
+++ b/internal/daemon/ticket_take.go
@@ -53,8 +53,11 @@ func (d *Daemon) handleTicketTake(conn net.Conn, msg *protocol.TicketTakeMessage
 	// be noise. Report success so a redundant take is a harmless retry.
 	if previous == sourceSessionID {
 		_ = json.NewEncoder(conn).Encode(protocol.Response{
-			Ok:               true,
-			TicketTakeResult: &protocol.TicketTakeResult{TicketID: ticketID, PreviousAssignee: previous},
+			Ok: true,
+			TicketTakeResult: &protocol.TicketTakeResult{
+				TicketID: ticketID, PreviousAssignee: previous,
+				UnreadCount: protocol.Ptr(d.targetTicketUnreadCount(sourceSessionID, ticketID)),
+			},
 		})
 		return
 	}
@@ -68,8 +71,11 @@ func (d *Daemon) handleTicketTake(conn net.Conn, msg *protocol.TicketTakeMessage
 		return
 	}
 	_ = json.NewEncoder(conn).Encode(protocol.Response{
-		Ok:               true,
-		TicketTakeResult: &protocol.TicketTakeResult{TicketID: ticketID, PreviousAssignee: previous},
+		Ok: true,
+		TicketTakeResult: &protocol.TicketTakeResult{
+			TicketID: ticketID, PreviousAssignee: previous,
+			UnreadCount: protocol.Ptr(d.targetTicketUnreadCount(sourceSessionID, ticketID)),
+		},
 	})
 	// The assigned event was authored by the taker, so notifyTicketObservers
 	// excludes it (no self-nudge) and fans out to the ticket's other participants —

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "171"
+const ProtocolVersion = "172"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -3863,6 +3863,9 @@ type Ticket struct {
 	// LastAgentID corresponds to the JSON schema field "last_agent_id".
 	LastAgentID string `json:"last_agent_id"`
 
+	// LatestEventSeq corresponds to the JSON schema field "latest_event_seq".
+	LatestEventSeq *int `json:"latest_event_seq,omitempty,omitzero"`
+
 	// ProjectID corresponds to the JSON schema field "project_id".
 	ProjectID string `json:"project_id"`
 
@@ -3929,6 +3932,9 @@ type TicketAddCommentMessage struct {
 	// Comment corresponds to the JSON schema field "comment".
 	Comment string `json:"comment"`
 
+	// ExpectedEventSeq corresponds to the JSON schema field "expected_event_seq".
+	ExpectedEventSeq *int `json:"expected_event_seq,omitempty,omitzero"`
+
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
 
@@ -3962,6 +3968,9 @@ type TicketAttachMessage struct {
 	// Comment corresponds to the JSON schema field "comment".
 	Comment *string `json:"comment,omitempty,omitzero"`
 
+	// ExpectedEventSeq corresponds to the JSON schema field "expected_event_seq".
+	ExpectedEventSeq *int `json:"expected_event_seq,omitempty,omitzero"`
+
 	// Files corresponds to the JSON schema field "files".
 	Files []TicketAttachFile `json:"files"`
 
@@ -3981,6 +3990,9 @@ type TicketAttachMessage struct {
 type TicketAttachResult struct {
 	// Artifacts corresponds to the JSON schema field "artifacts".
 	Artifacts []TicketArtifact `json:"artifacts"`
+
+	// CatchUp corresponds to the JSON schema field "catch_up".
+	CatchUp *TicketEventBundle `json:"catch_up,omitempty,omitzero"`
 
 	// Deduplicated corresponds to the JSON schema field "deduplicated".
 	Deduplicated bool `json:"deduplicated"`
@@ -4022,6 +4034,9 @@ type TicketChangeStatusMessage struct {
 	// Comment corresponds to the JSON schema field "comment".
 	Comment *string `json:"comment,omitempty,omitzero"`
 
+	// ExpectedEventSeq corresponds to the JSON schema field "expected_event_seq".
+	ExpectedEventSeq *int `json:"expected_event_seq,omitempty,omitzero"`
+
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
 
@@ -4047,6 +4062,9 @@ type TicketCommentMessage struct {
 }
 
 type TicketCommentResult struct {
+	// CatchUp corresponds to the JSON schema field "catch_up".
+	CatchUp *TicketEventBundle `json:"catch_up,omitempty,omitzero"`
+
 	// TicketID corresponds to the JSON schema field "ticket_id".
 	TicketID string `json:"ticket_id"`
 }
@@ -4085,6 +4103,9 @@ type TicketEditDescriptionMessage struct {
 
 	// Description corresponds to the JSON schema field "description".
 	Description string `json:"description"`
+
+	// ExpectedEventSeq corresponds to the JSON schema field "expected_event_seq".
+	ExpectedEventSeq *int `json:"expected_event_seq,omitempty,omitzero"`
 
 	// RequestID corresponds to the JSON schema field "request_id".
 	RequestID *string `json:"request_id,omitempty,omitzero"`
@@ -4140,9 +4161,20 @@ type TicketInboxMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
 	Cmd string `json:"cmd"`
 
+	// Mode corresponds to the JSON schema field "mode".
+	Mode *TicketInboxMode `json:"mode,omitempty,omitzero"`
+
 	// SourceSessionID corresponds to the JSON schema field "source_session_id".
 	SourceSessionID string `json:"source_session_id"`
+
+	// WatchIntervalMs corresponds to the JSON schema field "watch_interval_ms".
+	WatchIntervalMs *string `json:"watch_interval_ms,omitempty,omitzero"`
 }
+
+type TicketInboxMode string
+
+const TicketInboxModeExplicit TicketInboxMode = "explicit"
+const TicketInboxModeWatch TicketInboxMode = "watch"
 
 type TicketInboxResult struct {
 	// Bundles corresponds to the JSON schema field "bundles".
@@ -4248,6 +4280,9 @@ const TicketStatusFailed TicketStatus = "failed"
 const TicketStatusInReview TicketStatus = "in_review"
 
 type TicketStatusResult struct {
+	// CatchUp corresponds to the JSON schema field "catch_up".
+	CatchUp *TicketEventBundle `json:"catch_up,omitempty,omitzero"`
+
 	// Status corresponds to the JSON schema field "status".
 	Status TicketStatus `json:"status"`
 
@@ -4272,6 +4307,9 @@ type TicketSubscribeMessage struct {
 type TicketSubscribeResult struct {
 	// TicketID corresponds to the JSON schema field "ticket_id".
 	TicketID string `json:"ticket_id"`
+
+	// UnreadCount corresponds to the JSON schema field "unread_count".
+	UnreadCount *int `json:"unread_count,omitempty,omitzero"`
 }
 
 type TicketTakeMessage struct {
@@ -4294,6 +4332,9 @@ type TicketTakeResult struct {
 
 	// TicketID corresponds to the JSON schema field "ticket_id".
 	TicketID string `json:"ticket_id"`
+
+	// UnreadCount corresponds to the JSON schema field "unread_count".
+	UnreadCount *int `json:"unread_count,omitempty,omitzero"`
 }
 
 type TicketUnsubscribeMessage struct {

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -317,6 +317,14 @@ model TicketInboxResult {
   last_user_activity_at?: string;
 }
 
+// TicketInboxMode distinguishes a deliberate catch-up from a long-lived polling
+// watch. Explicit reads drain immediately; watches share the buffered delivery
+// eligibility used by nudges.
+enum TicketInboxMode {
+  explicit,
+  watch,
+}
+
 // TicketActivityKind is the type of a human-facing history entry in a ticket's
 // detail view: a status change (column move, optional note) or a freeform comment.
 // It is the display subset of the richer event log (TicketEventKind).
@@ -368,6 +376,9 @@ model Ticket {
   // was judged by the reconciliation classifier (the verdict lands as an
   // attn-authored comment). Non-terminal + reconciled_at set = the orphan badge.
   reconciled_at?: string;
+  // Highest event sequence for this ticket at detail-read time. App mutations
+  // echo it as expected_event_seq and must refresh when it is stale.
+  latest_event_seq?: int32;
   activity: TicketActivity[];
   artifacts: TicketArtifact[];
 }
@@ -647,6 +658,7 @@ model SetTicketStatusMessage {
 model TicketStatusResult {
   ticket_id: string;
   status: TicketStatus;
+  catch_up?: TicketEventBundle;
 }
 
 // TicketCreateMessage mints a standalone backlog ticket — unbound (no assignee, no
@@ -688,6 +700,7 @@ model TicketCommentMessage {
 // confirm which ticket it posted to.
 model TicketCommentResult {
   ticket_id: string;
+  catch_up?: TicketEventBundle;
 }
 
 // PresentOpenMessage opens a new presentation (or a new round on an existing
@@ -744,6 +757,10 @@ model PresentFeedbackResult {
 model TicketInboxMessage {
   cmd: "ticket_inbox";
   source_session_id: string;
+  mode?: TicketInboxMode;
+  // Watch polls report their cadence so the daemon can distinguish a live slow
+  // watcher from an abandoned one without narrowing the CLI's interval support.
+  watch_interval_ms?: int64;
 }
 
 // TicketListMessage reads the board — every ticket, optionally filtered by status —
@@ -800,6 +817,7 @@ model TicketSubscribeMessage {
 // TicketSubscribeResult echoes the ticket the subscription landed on.
 model TicketSubscribeResult {
   ticket_id: string;
+  unread_count?: int32;
 }
 
 // TicketUnsubscribeMessage opts the calling session back out of a ticket's
@@ -835,6 +853,7 @@ model TicketTakeMessage {
 model TicketTakeResult {
   ticket_id: string;
   previous_assignee: string;
+  unread_count?: int32;
 }
 
 model TicketAttachFile {
@@ -854,6 +873,7 @@ model TicketAttachMessage {
   state?: DispatchWorkState;
   comment?: string;
   request_id?: string;
+  expected_event_seq?: int32;
 }
 
 // TicketAttachResult is the durable receipt returned for a new submission and
@@ -865,6 +885,7 @@ model TicketAttachResult {
   event_seq: int32;
   state: TicketStatus;
   deduplicated: boolean;
+  catch_up?: TicketEventBundle;
 }
 
 model TicketAttachResultMessage {
@@ -901,6 +922,7 @@ model TicketChangeStatusMessage {
   ticket_id: string;
   status: TicketStatus;
   comment?: string;
+  expected_event_seq?: int32;
 }
 
 // ticket_add_comment appends a freeform note to a ticket's thread — the chief's
@@ -910,6 +932,7 @@ model TicketAddCommentMessage {
   request_id?: string;
   ticket_id: string;
   comment: string;
+  expected_event_seq?: int32;
 }
 
 // ticket_edit_description replaces a ticket's brief (a re-brief / re-scope).
@@ -918,6 +941,7 @@ model TicketEditDescriptionMessage {
   request_id?: string;
   ticket_id: string;
   description: string;
+  expected_event_seq?: int32;
 }
 
 // TicketActionResultMessage is the shared reply to a chief ticket action,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -655,6 +655,10 @@ CREATE TABLE IF NOT EXISTS ticket_event_cursors (
 		tombstone_generation INTEGER NOT NULL DEFAULT 0,
 		updated_at TEXT NOT NULL
 	)`},
+	{69, "create ticket delivery attention table", `CREATE TABLE IF NOT EXISTS ticket_delivery_attention (
+		observer_key TEXT PRIMARY KEY,
+		last_attention_at TEXT NOT NULL
+	)`},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.

--- a/internal/store/ticket_delivery_attention.go
+++ b/internal/store/ticket_delivery_attention.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"database/sql"
+	"time"
+)
+
+// TicketDeliveryAttention is the one durable piece of notification scheduling
+// state. Event rows remain the batch and ticket_event_cursors remain the read
+// acknowledgement; this records only when an observer was last interrupted.
+type TicketDeliveryAttention struct {
+	ObserverKey     string
+	LastAttentionAt time.Time
+}
+
+// TicketDeliveryAttention returns the observer's most recent non-empty ticket
+// delivery. A missing row means the observer has no buffered-delivery history.
+func (s *Store) TicketDeliveryAttention(observerKey string) (TicketDeliveryAttention, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil || observerKey == "" {
+		return TicketDeliveryAttention{}, false, nil
+	}
+	var raw string
+	err := s.db.QueryRow(`SELECT last_attention_at FROM ticket_delivery_attention WHERE observer_key = ?`, observerKey).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return TicketDeliveryAttention{}, false, nil
+	}
+	if err != nil {
+		return TicketDeliveryAttention{}, false, err
+	}
+	return TicketDeliveryAttention{ObserverKey: observerKey, LastAttentionAt: parseTicketTime(raw)}, true, nil
+}
+
+// SetTicketDeliveryAttention advances the observer's interruption clock. The
+// value is monotonic so concurrent successful reads cannot move it backwards.
+func (s *Store) SetTicketDeliveryAttention(observerKey string, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil || observerKey == "" {
+		return nil
+	}
+	return setTicketDeliveryAttentionTx(s.db, observerKey, at)
+}
+
+func setTicketDeliveryAttentionTx(ex ticketExecer, observerKey string, at time.Time) error {
+	_, err := ex.Exec(`
+		INSERT INTO ticket_delivery_attention (observer_key, last_attention_at)
+		VALUES (?, ?)
+		ON CONFLICT(observer_key) DO UPDATE SET
+			last_attention_at = MAX(last_attention_at, excluded.last_attention_at)
+	`, observerKey, formatTicketTime(at))
+	return err
+}

--- a/internal/store/ticket_delivery_attention_test.go
+++ b/internal/store/ticket_delivery_attention_test.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTicketDeliveryAttentionIsDurableAndMonotonic(t *testing.T) {
+	dbPath := t.TempDir() + "/attn.db"
+	s, err := NewWithDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
+	if err := s.SetTicketDeliveryAttention("role:chief_of_staff", first); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTicketDeliveryAttention("role:chief_of_staff", first.Add(-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s, err = NewWithDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	got, ok, err := s.TicketDeliveryAttention("role:chief_of_staff")
+	if err != nil || !ok {
+		t.Fatalf("TicketDeliveryAttention = %+v, %v, %v", got, ok, err)
+	}
+	if !got.LastAttentionAt.Equal(first) {
+		t.Fatalf("last attention = %s, want %s", got.LastAttentionAt, first)
+	}
+}

--- a/internal/store/ticket_mutation.go
+++ b/internal/store/ticket_mutation.go
@@ -1,0 +1,183 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ErrStaleTicketEventSeq means an app action was based on a ticket detail that
+// no longer represents the latest event. The caller must refresh and retry.
+var ErrStaleTicketEventSeq = errors.New("ticket changed since it was opened")
+
+// TicketMutationObserver is one effective unread view for the updater. Ordinary
+// sessions use the same value for both fields; durable roles keep their cursor
+// while excluding events authored by the concrete session holding the role.
+type TicketMutationObserver struct {
+	CursorIdentity string
+	AuthorIdentity string
+}
+
+// TicketMutationOptions selects exactly one precondition for a content
+// mutation: CLI callers supply Observers for consume-or-mutate, while app callers
+// supply ExpectedEventSeq for optimistic concurrency.
+type TicketMutationOptions struct {
+	Observers        []TicketMutationObserver
+	AttentionKey     string
+	ExpectedEventSeq *int64
+}
+
+// TicketMutationOutcome reports a CLI catch-up conflict. A non-empty slice means
+// the transaction advanced only this ticket's applicable cursors and deliberately
+// did not execute the mutation callback.
+type TicketMutationOutcome struct {
+	ConflictEvents []TicketEvent
+}
+
+func (s *Store) withTicketMutation(
+	ticketID string,
+	options TicketMutationOptions,
+	now time.Time,
+	mutate func(*sql.Tx) error,
+) (TicketMutationOutcome, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return TicketMutationOutcome{}, nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return TicketMutationOutcome{}, err
+	}
+	defer tx.Rollback()
+
+	if options.ExpectedEventSeq != nil {
+		actual, err := latestTicketEventSeqTx(tx, ticketID)
+		if err != nil {
+			return TicketMutationOutcome{}, err
+		}
+		if actual != *options.ExpectedEventSeq {
+			return TicketMutationOutcome{}, fmt.Errorf("%w: expected event %d, latest is %d", ErrStaleTicketEventSeq, *options.ExpectedEventSeq, actual)
+		}
+	} else if len(options.Observers) > 0 {
+		conflicts, err := consumeTargetTicketEventsTx(tx, ticketID, options.Observers, now)
+		if err != nil {
+			return TicketMutationOutcome{}, err
+		}
+		if len(conflicts) > 0 {
+			if key := strings.TrimSpace(options.AttentionKey); key != "" {
+				if err := setTicketDeliveryAttentionTx(tx, key, now); err != nil {
+					return TicketMutationOutcome{}, err
+				}
+			}
+			if err := tx.Commit(); err != nil {
+				return TicketMutationOutcome{}, err
+			}
+			return TicketMutationOutcome{ConflictEvents: conflicts}, nil
+		}
+	}
+
+	if err := mutate(tx); err != nil {
+		return TicketMutationOutcome{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return TicketMutationOutcome{}, err
+	}
+	return TicketMutationOutcome{}, nil
+}
+
+func latestTicketEventSeqTx(tx *sql.Tx, ticketID string) (int64, error) {
+	var seq sql.NullInt64
+	if err := tx.QueryRow(`SELECT MAX(seq) FROM ticket_events WHERE ticket_id = ?`, ticketID).Scan(&seq); err != nil {
+		return 0, err
+	}
+	if !seq.Valid {
+		return 0, nil
+	}
+	return seq.Int64, nil
+}
+
+func consumeTargetTicketEventsTx(
+	tx *sql.Tx,
+	ticketID string,
+	observers []TicketMutationObserver,
+	now time.Time,
+) ([]TicketEvent, error) {
+	merged := make(map[int64]TicketEvent)
+	for _, observer := range observers {
+		cursorIdentity := strings.TrimSpace(observer.CursorIdentity)
+		if cursorIdentity == "" {
+			continue
+		}
+		authorIdentity := strings.TrimSpace(observer.AuthorIdentity)
+		if authorIdentity == "" {
+			authorIdentity = cursorIdentity
+		}
+		events, err := unreadTargetTicketEventsTx(tx, ticketID, cursorIdentity, authorIdentity)
+		if err != nil {
+			return nil, err
+		}
+		var cursor int64
+		for _, event := range events {
+			merged[event.Seq] = event
+			if event.Seq > cursor {
+				cursor = event.Seq
+			}
+		}
+		if cursor > 0 {
+			if err := setTicketCursorTx(tx, cursorIdentity, ticketID, cursor, now); err != nil {
+				return nil, err
+			}
+		}
+	}
+	conflicts := make([]TicketEvent, 0, len(merged))
+	for _, event := range merged {
+		conflicts = append(conflicts, event)
+	}
+	sort.Slice(conflicts, func(i, j int) bool { return conflicts[i].Seq < conflicts[j].Seq })
+	return conflicts, nil
+}
+
+func unreadTargetTicketEventsTx(
+	tx *sql.Tx,
+	ticketID, cursorIdentity, authorIdentity string,
+) ([]TicketEvent, error) {
+	rows, err := tx.Query(`
+		SELECT e.seq, e.ticket_id, e.kind, e.author, e.from_status, e.to_status, e.comment, e.detail, e.created_at
+		FROM ticket_events e
+		LEFT JOIN ticket_event_cursors c
+			ON c.identity = ? AND c.ticket_id = e.ticket_id
+		WHERE e.ticket_id = ?
+			AND e.author != ?
+			AND e.seq > COALESCE(c.cursor, 0)
+			AND (
+				EXISTS (SELECT 1 FROM tickets t WHERE t.id = e.ticket_id AND t.assignee = ?)
+				OR EXISTS (
+					SELECT 1 FROM ticket_events e2
+					WHERE e2.ticket_id = e.ticket_id AND e2.author = ? AND e2.kind != 'commented'
+						AND NOT (
+							e2.kind = 'created' AND EXISTS (
+								SELECT 1 FROM ticket_role_owners ro WHERE ro.ticket_id = e2.ticket_id
+							)
+						)
+				)
+				OR EXISTS (
+					SELECT 1 FROM ticket_subscriptions sub
+					WHERE sub.ticket_id = e.ticket_id AND sub.identity = ?
+				)
+				OR EXISTS (
+					SELECT 1 FROM ticket_role_owners ro
+					WHERE ro.ticket_id = e.ticket_id AND ? = ('role:' || ro.role)
+				)
+			)
+		ORDER BY e.seq ASC
+	`, cursorIdentity, ticketID, authorIdentity, cursorIdentity, cursorIdentity, cursorIdentity, cursorIdentity)
+	if err != nil {
+		return nil, err
+	}
+	return scanTicketEventRows(rows)
+}

--- a/internal/store/ticket_mutation_test.go
+++ b/internal/store/ticket_mutation_test.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestTicketMutationConsumesTargetUnreadBeforeMutating(t *testing.T) {
+	s := New()
+	defer s.Close()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	if _, err := s.CreateTicket(Ticket{ID: "target", Title: "Target", Assignee: "worker", Status: TicketStatusWorking}, "chief", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CreateTicket(Ticket{ID: "other", Title: "Other", Assignee: "worker", Status: TicketStatusWorking}, "chief", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AddTicketComment("target", "chief", "new target context", now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AddTicketComment("other", "chief", "unrelated context", now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	options := TicketMutationOptions{
+		Observers:    []TicketMutationObserver{{CursorIdentity: "worker", AuthorIdentity: "worker"}},
+		AttentionKey: "worker",
+	}
+
+	updated, outcome, err := s.SetTicketStatusWithOptions("target", TicketStatusDone, "worker", "done", options, now.Add(3*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != nil || len(outcome.ConflictEvents) != 1 || outcome.ConflictEvents[0].Comment != "new target context" {
+		t.Fatalf("first attempt updated=%+v outcome=%+v", updated, outcome)
+	}
+	target, _ := s.GetTicket("target")
+	if target.Status != TicketStatusWorking {
+		t.Fatalf("conflicting attempt changed status to %s", target.Status)
+	}
+	otherUnread, err := s.UnreadTicketEventsFor("worker", "worker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(otherUnread) != 1 || otherUnread[0].TicketID != "other" {
+		t.Fatalf("unrelated unread = %+v", otherUnread)
+	}
+	attention, found, err := s.TicketDeliveryAttention("worker")
+	if err != nil || !found || !attention.LastAttentionAt.Equal(now.Add(3*time.Second)) {
+		t.Fatalf("attention=%+v found=%v err=%v", attention, found, err)
+	}
+
+	updated, outcome, err = s.SetTicketStatusWithOptions("target", TicketStatusDone, "worker", "done", options, now.Add(4*time.Second))
+	if err != nil || updated == nil || len(outcome.ConflictEvents) != 0 || updated.Status != TicketStatusDone {
+		t.Fatalf("retry updated=%+v outcome=%+v err=%v", updated, outcome, err)
+	}
+}
+
+func TestTicketMutationRejectsStaleExpectedEventSeq(t *testing.T) {
+	s := New()
+	defer s.Close()
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	if _, err := s.CreateTicket(Ticket{ID: "target", Title: "Target", Status: TicketStatusWorking}, "chief", now); err != nil {
+		t.Fatal(err)
+	}
+	detail, err := s.GetTicket("target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AddTicketComment("target", "worker", "landed after detail", now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	expected := detail.LatestEventSeq
+	_, _, err = s.SetTicketStatusWithOptions(
+		"target", TicketStatusDone, TicketAuthorYou, "",
+		TicketMutationOptions{ExpectedEventSeq: &expected}, now.Add(2*time.Second),
+	)
+	if !errors.Is(err, ErrStaleTicketEventSeq) {
+		t.Fatalf("error = %v, want stale sequence", err)
+	}
+	got, _ := s.GetTicket("target")
+	if got.Status != TicketStatusWorking {
+		t.Fatalf("stale mutation changed status to %s", got.Status)
+	}
+}

--- a/internal/store/tickets.go
+++ b/internal/store/tickets.go
@@ -110,6 +110,9 @@ type Ticket struct {
 	// by the reconciliation classifier. Provenance + dedupe lock in one; cleared
 	// when the ticket is reassigned or its assignee session respawns (re-arm).
 	ReconciledAt *time.Time
+	// LatestEventSeq is populated by GetTicket for optimistic app mutations.
+	// Bare list rows leave it at zero.
+	LatestEventSeq int64
 
 	Activity    []TicketActivity   // populated by GetTicket
 	Attachments []TicketAttachment // populated by GetTicket
@@ -331,6 +334,9 @@ func (s *Store) GetTicket(id string) (*Ticket, error) {
 	if ticket.Attachments, err = s.ticketAttachments(id); err != nil {
 		return nil, err
 	}
+	if err := s.db.QueryRow(`SELECT COALESCE(MAX(seq), 0) FROM ticket_events WHERE ticket_id = ?`, id).Scan(&ticket.LatestEventSeq); err != nil {
+		return nil, err
+	}
 	return ticket, nil
 }
 
@@ -532,30 +538,27 @@ func (s *Store) ClearTicketReconciliationForAssignee(assignee string) error {
 // visible on the board again, never a hidden zombie immune to the TTL sweep.
 // Returns the updated ticket row.
 func (s *Store) SetTicketStatus(id string, to TicketStatus, author, comment string, now time.Time) (*Ticket, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	updated, _, err := s.SetTicketStatusWithOptions(id, to, author, comment, TicketMutationOptions{}, now)
+	return updated, err
+}
 
-	if s.db == nil {
-		return nil, nil
-	}
+func (s *Store) SetTicketStatusWithOptions(
+	id string,
+	to TicketStatus,
+	author, comment string,
+	options TicketMutationOptions,
+	now time.Time,
+) (*Ticket, TicketMutationOutcome, error) {
 	if !to.IsValid() {
-		return nil, fmt.Errorf("%w: %q", ErrInvalidTicketStatus, to)
+		return nil, TicketMutationOutcome{}, fmt.Errorf("%w: %q", ErrInvalidTicketStatus, to)
 	}
-
-	tx, err := s.db.Begin()
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	current, err := setTicketStatusTx(tx, id, to, author, comment, now)
-	if err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-	return current, nil
+	var updated *Ticket
+	outcome, err := s.withTicketMutation(id, options, now, func(tx *sql.Tx) error {
+		var mutationErr error
+		updated, mutationErr = setTicketStatusTx(tx, id, to, author, comment, now)
+		return mutationErr
+	})
+	return updated, outcome, err
 }
 
 func setTicketStatusTx(tx *sql.Tx, id string, to TicketStatus, author, comment string, now time.Time) (*Ticket, error) {
@@ -611,19 +614,11 @@ func setTicketStatusTx(tx *sql.Tx, id string, to TicketStatus, author, comment s
 // AddTicketComment appends a freeform comment to the activity thread and bumps
 // the ticket's updated_at. Returns the new activity entry.
 func (s *Store) AddTicketComment(id, author, comment string, now time.Time) (*TicketActivity, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	activity, _, err := s.AddTicketCommentWithOptions(id, author, comment, TicketMutationOptions{}, now)
+	return activity, err
+}
 
-	if s.db == nil {
-		return nil, nil
-	}
-
-	tx, err := s.db.Begin()
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
+func addTicketCommentTx(tx *sql.Tx, id, author, comment string, now time.Time) (*TicketActivity, error) {
 	if err := touchTicketTx(tx, id, now); err != nil {
 		return nil, err
 	}
@@ -646,9 +641,6 @@ func (s *Store) AddTicketComment(id, author, comment string, now time.Time) (*Ti
 	}, now); err != nil {
 		return nil, err
 	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
 	return &TicketActivity{
 		ID:        activityID,
 		TicketID:  id,
@@ -659,18 +651,44 @@ func (s *Store) AddTicketComment(id, author, comment string, now time.Time) (*Ti
 	}, nil
 }
 
+func (s *Store) AddTicketCommentWithOptions(
+	id, author, comment string,
+	options TicketMutationOptions,
+	now time.Time,
+) (*TicketActivity, TicketMutationOutcome, error) {
+	var activity *TicketActivity
+	outcome, err := s.withTicketMutation(id, options, now, func(tx *sql.Tx) error {
+		var mutationErr error
+		activity, mutationErr = addTicketCommentTx(tx, id, author, comment, now)
+		return mutationErr
+	})
+	return activity, outcome, err
+}
+
 // EditTicketDescription replaces the ticket's brief, bumps updated_at, and emits a
 // description_edited event authored by author. Detail carries the new brief so the
 // event is self-describing AND so the dedup signature distinguishes one re-brief
 // from another — without it, two consecutive edits would look identical and the
 // second (a real re-brief / steer) would be silently deduped away.
 func (s *Store) EditTicketDescription(id, description, author string, now time.Time) error {
-	return s.updateTicketFieldWithEvent(id, "description", description, TicketEvent{
+	_, err := s.EditTicketDescriptionWithOptions(id, description, author, TicketMutationOptions{}, now)
+	return err
+}
+
+func (s *Store) EditTicketDescriptionWithOptions(
+	id, description, author string,
+	options TicketMutationOptions,
+	now time.Time,
+) (TicketMutationOutcome, error) {
+	evt := TicketEvent{
 		TicketID: id,
 		Kind:     TicketEventDescriptionEdited,
 		Author:   author,
 		Detail:   description,
-	}, now)
+	}
+	return s.withTicketMutation(id, options, now, func(tx *sql.Tx) error {
+		return updateTicketFieldWithEventTx(tx, id, "description", description, evt, now)
+	})
 }
 
 // AssignTicket sets (or clears, with "") the assignee, bumps updated_at, and emits
@@ -840,28 +858,43 @@ func (s *Store) SubmitTicketAttach(
 	status *TicketStatus,
 	now time.Time,
 ) (*TicketAttachResult, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	result, _, err := s.SubmitTicketAttachWithOptions(
+		ticketID, author, fingerprint, detail, activityComment, status,
+		TicketMutationOptions{}, now,
+	)
+	return result, err
+}
 
-	if s.db == nil {
-		return nil, nil
-	}
+func (s *Store) SubmitTicketAttachWithOptions(
+	ticketID, author, fingerprint, detail, activityComment string,
+	status *TicketStatus,
+	options TicketMutationOptions,
+	now time.Time,
+) (*TicketAttachResult, TicketMutationOutcome, error) {
 	if strings.TrimSpace(fingerprint) == "" {
-		return nil, errors.New("attach fingerprint required")
+		return nil, TicketMutationOutcome{}, errors.New("attach fingerprint required")
 	}
 	if status != nil && !status.IsValid() {
-		return nil, fmt.Errorf("%w: %q", ErrInvalidTicketStatus, *status)
+		return nil, TicketMutationOutcome{}, fmt.Errorf("%w: %q", ErrInvalidTicketStatus, *status)
 	}
+	var result *TicketAttachResult
+	outcome, err := s.withTicketMutation(ticketID, options, now, func(tx *sql.Tx) error {
+		var mutationErr error
+		result, mutationErr = submitTicketAttachTx(tx, ticketID, author, fingerprint, detail, activityComment, status, now)
+		return mutationErr
+	})
+	return result, outcome, err
+}
 
-	tx, err := s.db.Begin()
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
+func submitTicketAttachTx(
+	tx *sql.Tx,
+	ticketID, author, fingerprint, detail, activityComment string,
+	status *TicketStatus,
+	now time.Time,
+) (*TicketAttachResult, error) {
 	var existingSeq int64
 	var existingStatus string
-	err = tx.QueryRow(`
+	err := tx.QueryRow(`
 		SELECT seq, to_status FROM ticket_events
 		WHERE ticket_id = ? AND kind = ? AND detail LIKE ?
 		ORDER BY seq DESC LIMIT 1
@@ -910,9 +943,6 @@ func (s *Store) SubmitTicketAttach(
 			return nil, updateErr
 		}
 		resultStatus = updated.Status
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
 	}
 	return &TicketAttachResult{EventSeq: eventSeq, Status: resultStatus}, nil
 }
@@ -1027,6 +1057,13 @@ func (s *Store) updateTicketFieldWithEvent(id, column, value string, evt TicketE
 	}
 	defer tx.Rollback()
 
+	if err := updateTicketFieldWithEventTx(tx, id, column, value, evt, now); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func updateTicketFieldWithEventTx(tx *sql.Tx, id, column, value string, evt TicketEvent, now time.Time) error {
 	res, err := tx.Exec(
 		`UPDATE tickets SET `+column+` = ?, updated_at = ? WHERE id = ?`,
 		value, formatTicketTime(now), id,
@@ -1040,7 +1077,7 @@ func (s *Store) updateTicketFieldWithEvent(id, column, value string, evt TicketE
 	if _, _, err := appendTicketEventTx(tx, evt, now); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return nil
 }
 
 // touchTicketTx bumps updated_at within a transaction, returning ErrTicketNotFound


### PR DESCRIPTION
## Intent / Why

Ticket bursts currently interrupt chiefs and subscribers repeatedly, while ticket mutations can overwrite intervening activity. This keeps updates immediate for the assignee doing the work, but gives every other observer one coherent interruption window and makes writers catch up before changing a stale ticket.

Related: attn ticket `chief-buffer`.

## Summary

- buffer non-assignee ticket delivery behind one durable 30-minute observer-wide attention window while preserving immediate assignee delivery and explicit inbox reads
- serialize nudge and watch consumption with polling-aware leases, durable restart recovery, provenance-preserving event bundles, and chief-role continuity
- make CLI status, comment, and attach mutations atomically consume target-ticket unread activity and reject the mutation until retry; report unread history on take and subscribe
- add app optimistic concurrency using `latest_event_seq` and `expected_event_seq`, including safe description-draft conflict behavior
- bump the protocol to 172, regenerate Go and TypeScript types, and document the contract

## Test plan

- [x] `go test ./...`
- [x] `pnpm --dir app test` (1,770 tests)
- [x] `pnpm --dir app exec tsc --noEmit`
- [x] structured autoreview clean
- [x] signed isolated `attn-dev.app` build and install
- [x] packaged nudge-trigger scenario: paused unread indicator, manual delivery, inbox consumption, and busy-agent queueing
- [x] isolated-dev live CLI proof: an unread update rejected the first mutation without changing state; retry applied it
- [x] post-rebase focused Go and ticket-panel regression tests

No production app was installed or restarted.
