### PR TITLE
test: seam external tool-home resolution behind ATTN_TOOL_HOME

### DIFF
--- a/cmd/attn/main_test.go
+++ b/cmd/attn/main_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/victorarias/attn/internal/buildinfo"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/toolhome"
 	"github.com/victorarias/attn/internal/transcript"
 )
 
@@ -95,13 +96,7 @@ func writeCopilotSessionState(t *testing.T, homeDir, sessionID, cwd string, star
 
 func TestFindCopilotTranscript_PrefersClosestStartTime(t *testing.T) {
 	homeDir := t.TempDir()
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", homeDir); err != nil {
-		t.Fatalf("set HOME: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", oldHome)
-	})
+	t.Setenv(toolhome.EnvVar, homeDir)
 
 	cwd := "/repo/project"
 	startedAt := time.Date(2026, 2, 8, 15, 30, 0, 0, time.UTC)
@@ -135,13 +130,7 @@ func TestFindCopilotTranscript_PrefersClosestStartTime(t *testing.T) {
 
 func TestFindCopilotTranscript_FallsBackToNewestModTime(t *testing.T) {
 	homeDir := t.TempDir()
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", homeDir); err != nil {
-		t.Fatalf("set HOME: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", oldHome)
-	})
+	t.Setenv(toolhome.EnvVar, homeDir)
 
 	cwd := "/repo/project"
 	startedAt := time.Date(2026, 2, 8, 15, 30, 0, 0, time.UTC)
@@ -175,13 +164,7 @@ func TestFindCopilotTranscript_FallsBackToNewestModTime(t *testing.T) {
 
 func TestResolveCopilotTranscript_PrefersResumeSessionPath(t *testing.T) {
 	homeDir := t.TempDir()
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", homeDir); err != nil {
-		t.Fatalf("set HOME: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", oldHome)
-	})
+	t.Setenv(toolhome.EnvVar, homeDir)
 
 	startedAt := time.Date(2026, 2, 8, 15, 30, 0, 0, time.UTC)
 	resumeID := "resume-session-id"
@@ -207,13 +190,7 @@ func TestResolveCopilotTranscript_PrefersResumeSessionPath(t *testing.T) {
 
 func TestResolveCopilotTranscript_FallsBackWhenResumePathMissing(t *testing.T) {
 	homeDir := t.TempDir()
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", homeDir); err != nil {
-		t.Fatalf("set HOME: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", oldHome)
-	})
+	t.Setenv(toolhome.EnvVar, homeDir)
 
 	cwd := "/repo/project"
 	startedAt := time.Date(2026, 2, 8, 15, 30, 0, 0, time.UTC)

--- a/internal/agent/attn_skill.go
+++ b/internal/agent/attn_skill.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/victorarias/attn/internal/toolhome"
 )
 
 //go:embed attn_skill
@@ -82,7 +84,7 @@ func pruneOrphanedSkillFiles(skillDir string, expected map[string]bool) error {
 }
 
 func ensureAttnClaudeSkillInstalled() error {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := toolhome.Dir()
 	if err != nil {
 		return fmt.Errorf("resolve home directory for Claude skills: %w", err)
 	}
@@ -90,7 +92,7 @@ func ensureAttnClaudeSkillInstalled() error {
 }
 
 func ensureAttnCodexSkillInstalled() error {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := toolhome.Dir()
 	if err != nil {
 		return fmt.Errorf("resolve home directory for agent skills: %w", err)
 	}
@@ -98,7 +100,7 @@ func ensureAttnCodexSkillInstalled() error {
 }
 
 func ensureAttnCopilotSkillInstalled() error {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := toolhome.Dir()
 	if err != nil {
 		return fmt.Errorf("resolve home directory for Copilot skills: %w", err)
 	}

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/victorarias/attn/internal/toolhome"
 )
 
 func readSkillFile(t *testing.T, skillDir, relative string) string {
@@ -188,7 +190,7 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 
 func TestEnsureAttnClaudeSkillInstalled(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	t.Setenv(toolhome.EnvVar, home)
 
 	if err := ensureAttnClaudeSkillInstalled(); err != nil {
 		t.Fatalf("ensureAttnClaudeSkillInstalled() error = %v", err)
@@ -205,7 +207,7 @@ func TestEnsureAttnClaudeSkillInstalled(t *testing.T) {
 // directly contradict the current skill's guidance, so install must prune.
 func TestEnsureAttnClaudeSkillInstalledPrunesOrphanedFiles(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	t.Setenv(toolhome.EnvVar, home)
 
 	skillDir := filepath.Join(home, ".claude", "skills", "attn")
 	if err := os.MkdirAll(filepath.Join(skillDir, "references"), 0o755); err != nil {
@@ -235,7 +237,7 @@ func TestEnsureAttnClaudeSkillInstalledPrunesOrphanedFiles(t *testing.T) {
 
 func TestEnsureAttnCodexSkillInstalled(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	t.Setenv(toolhome.EnvVar, home)
 
 	if err := ensureAttnCodexSkillInstalled(); err != nil {
 		t.Fatalf("ensureAttnCodexSkillInstalled() error = %v", err)
@@ -246,7 +248,7 @@ func TestEnsureAttnCodexSkillInstalled(t *testing.T) {
 
 func TestEnsureAttnCopilotSkillInstalled(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	t.Setenv(toolhome.EnvVar, home)
 
 	if err := ensureAttnCopilotSkillInstalled(); err != nil {
 		t.Fatalf("ensureAttnCopilotSkillInstalled() error = %v", err)
@@ -261,7 +263,7 @@ func TestEnsureAttnCopilotSkillInstalled(t *testing.T) {
 // chief-of-staff.md telling a delegated leaf it can re-delegate).
 func TestEnsureAttnCopilotSkillInstalledPrunesOrphanedFiles(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	t.Setenv(toolhome.EnvVar, home)
 
 	skillDir := filepath.Join(home, ".copilot", "skills", "attn")
 	if err := os.MkdirAll(filepath.Join(skillDir, "references"), 0o755); err != nil {
@@ -284,7 +286,7 @@ func TestEnsureAttnCopilotSkillInstalledPrunesOrphanedFiles(t *testing.T) {
 
 func TestAttnSkillInstallsAreIdentical(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	t.Setenv(toolhome.EnvVar, home)
 
 	if err := ensureAttnClaudeSkillInstalled(); err != nil {
 		t.Fatalf("ensureAttnClaudeSkillInstalled() error = %v", err)

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -16,6 +16,7 @@ import (
 	"github.com/victorarias/attn/internal/classifier"
 	"github.com/victorarias/attn/internal/hooks"
 	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/toolhome"
 	"github.com/victorarias/attn/internal/transcript"
 )
 
@@ -696,7 +697,7 @@ func copyTranscriptForResume(resumeSessionID, cwd string) error {
 }
 
 func claudeProjectDir(cwd string) string {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := toolhome.Dir()
 	if err != nil {
 		return ""
 	}

--- a/internal/agent/headless.go
+++ b/internal/agent/headless.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 
 	"github.com/victorarias/attn/internal/launchenv"
+	"github.com/victorarias/attn/internal/toolhome"
 )
 
 // DefaultContextWindowCap is the auto-compaction token threshold attn applies to
@@ -210,7 +211,7 @@ func headlessEnvironment(provider string) []string {
 		}
 	}
 	if provider == "codex" && strings.TrimSpace(os.Getenv("CODEX_HOME")) == "" {
-		if homeDir, err := os.UserHomeDir(); err == nil && strings.TrimSpace(homeDir) != "" {
+		if homeDir, err := toolhome.Dir(); err == nil && strings.TrimSpace(homeDir) != "" {
 			env = append(env, "CODEX_HOME="+filepath.Join(homeDir, ".codex"))
 		}
 	}

--- a/internal/agent/headless_test.go
+++ b/internal/agent/headless_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/victorarias/attn/internal/toolhome"
 )
 
 func writeHeadlessArgsRecorder(t *testing.T) (string, string) {
@@ -81,10 +83,8 @@ func TestCodexRunHeadlessTaskScopesToolsAndConfiguration(t *testing.T) {
 
 func TestHeadlessEnvironment_CodexSetsDefaultHomeWhenUnset(t *testing.T) {
 	t.Setenv("CODEX_HOME", "")
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatal(err)
-	}
+	homeDir := t.TempDir()
+	t.Setenv(toolhome.EnvVar, homeDir)
 	if !environmentContains(headlessEnvironment("codex"), "CODEX_HOME") {
 		t.Fatal("Codex headless environment did not set CODEX_HOME")
 	}

--- a/internal/agent/main_test.go
+++ b/internal/agent/main_test.go
@@ -1,0 +1,26 @@
+package agent
+
+import (
+	"os"
+	"testing"
+
+	"github.com/victorarias/attn/internal/toolhome"
+)
+
+// TestMain scopes every test in this package to a throwaway ATTN_TOOL_HOME by
+// default, so no test here can resolve toolhome.Dir() (~/.claude, ~/.codex,
+// ~/.copilot, ~/.agents skill installs and transcript lookups) to the real
+// home directory — see docs/plans/2026-07-18-db-loss-mitigation.md. Tests
+// that need specific fixtures under a fake home override this with their own
+// t.Setenv(toolhome.EnvVar, ...).
+func TestMain(m *testing.M) {
+	toolHomeDir, err := os.MkdirTemp("", "attn-agent-test-toolhome-*")
+	if err != nil {
+		panic("agent: TestMain: MkdirTemp: " + err.Error())
+	}
+	_ = os.Setenv(toolhome.EnvVar, toolHomeDir)
+
+	code := m.Run()
+	os.RemoveAll(toolHomeDir)
+	os.Exit(code)
+}

--- a/internal/agent/resume_available_test.go
+++ b/internal/agent/resume_available_test.go
@@ -4,12 +4,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/victorarias/attn/internal/toolhome"
 )
 
 func writeClaudeTranscriptFixture(t *testing.T, sessionID string) {
 	t.Helper()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	t.Setenv(toolhome.EnvVar, home)
 	projDir := filepath.Join(home, ".claude", "projects", "proj")
 	if err := os.MkdirAll(projDir, 0o755); err != nil {
 		t.Fatalf("mkdir transcript dir: %v", err)
@@ -26,7 +28,7 @@ func TestClaudeResumeAvailable(t *testing.T) {
 	claude := &Claude{}
 
 	// Empty home: no transcript for this id -> not resumable.
-	t.Setenv("HOME", t.TempDir())
+	t.Setenv(toolhome.EnvVar, t.TempDir())
 	if ResumeAvailable(claude, "no-transcript-id") {
 		t.Fatal("ResumeAvailable should be false when no transcript exists")
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -494,6 +494,10 @@ func TestClient_ConnectError_HintsOtherProfileWhenLive(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(tmp) })
 
+	// Intentionally exempt from the toolhome seam: DataDirForProfile is
+	// deliberately HOME-based for cross-profile probing (read-only path
+	// construction, no writes through the tool-dotfile paths toolhome guards),
+	// so HOME is its only lever. See config.go's DataDirForProfile comments.
 	t.Setenv("HOME", tmp)            // so SocketPathForProfile("") → $tmp/.attn/attn.sock
 	t.Setenv("ATTN_PROFILE", "dev")  // current profile is dev
 	t.Setenv("ATTN_SOCKET_PATH", "") // don't let an env override mask the default resolution

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/toolhome"
 	"github.com/victorarias/attn/internal/workspacelayout"
 	"nhooyr.io/websocket"
 )
@@ -128,8 +129,19 @@ func TestMain(m *testing.M) {
 	}
 	config.ScopeTestEnvironment(dataDir)
 
+	// Same story for toolhome.Dir() (~/.claude, ~/.codex, ~/.copilot,
+	// ~/.agents skill installs, transcript lookups): default every daemon
+	// test to a throwaway tool-home dir. Tests exercising specific transcript
+	// fixtures override this with their own t.Setenv(toolhome.EnvVar, ...).
+	toolHomeDir, err := os.MkdirTemp("", "attn-test-toolhome-*")
+	if err != nil {
+		panic("daemon: TestMain: MkdirTemp: " + err.Error())
+	}
+	_ = os.Setenv(toolhome.EnvVar, toolHomeDir)
+
 	code := m.Run()
 	os.RemoveAll(dataDir)
+	os.RemoveAll(toolHomeDir)
 	os.Exit(code)
 }
 
@@ -4551,7 +4563,7 @@ func TestDaemon_SettingsIncludePTYBackendMode(t *testing.T) {
 
 func TestDaemon_SettingsWithClaudeAvailability_InstallsClaudeSkill(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	t.Setenv(toolhome.EnvVar, home)
 
 	binDir := t.TempDir()
 	claudePath := filepath.Join(binDir, "claude")
@@ -4578,7 +4590,7 @@ func TestDaemon_SettingsWithClaudeAvailability_InstallsClaudeSkill(t *testing.T)
 
 func TestDaemon_SettingsWithCodexAvailability_InstallsCodexSkill(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	t.Setenv(toolhome.EnvVar, home)
 
 	binDir := t.TempDir()
 	codexPath := filepath.Join(binDir, "codex")

--- a/internal/daemon/reload_test.go
+++ b/internal/daemon/reload_test.go
@@ -17,16 +17,18 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptybackend"
+	"github.com/victorarias/attn/internal/toolhome"
 )
 
-// writeClaudeTranscriptFixture points HOME at a temp dir and writes a Claude
-// transcript for sessionID so FindClaudeTranscript (which walks ~/.claude/projects)
-// treats the session as resumable. Without it a reload-resume id with no transcript
-// on disk is correctly downgraded to a fresh spawn.
+// writeClaudeTranscriptFixture points ATTN_TOOL_HOME at a temp dir and writes
+// a Claude transcript for sessionID so FindClaudeTranscript (which walks
+// ~/.claude/projects) treats the session as resumable. Without it a
+// reload-resume id with no transcript on disk is correctly downgraded to a
+// fresh spawn.
 func writeClaudeTranscriptFixture(t *testing.T, sessionID string) {
 	t.Helper()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	t.Setenv(toolhome.EnvVar, home)
 	projDir := filepath.Join(home, ".claude", "projects", "proj")
 	if err := os.MkdirAll(projDir, 0o755); err != nil {
 		t.Fatalf("mkdir transcript dir: %v", err)
@@ -288,10 +290,10 @@ func TestReloadSessionAgentFreshSpawnsWhenNotResumable(t *testing.T) {
 	}
 	d := newReloadTestDaemon(t, backend)
 	addReloadSession(d, "chief", protocol.SessionAgentClaude, protocol.SessionStateWorking)
-	// A resume id with NO transcript on disk: point HOME at an empty temp home so
-	// FindClaudeTranscript finds nothing for this id.
+	// A resume id with NO transcript on disk: point ATTN_TOOL_HOME at an empty
+	// temp home so FindClaudeTranscript finds nothing for this id.
 	d.persistResumeSessionID("chief", "chief")
-	t.Setenv("HOME", t.TempDir())
+	t.Setenv(toolhome.EnvVar, t.TempDir())
 
 	d.reloadSessionAgent("chief")
 
@@ -337,7 +339,7 @@ func TestReloadSessionAgentAbortsWhenLaunchParamsNotRecorded(t *testing.T) {
 func TestBuildReloadSpawnOptionsCarriesChiefContextWindowCap(t *testing.T) {
 	// No transcript on disk → deterministic resume resolution (fresh-spawn), which
 	// keeps buildReloadSpawnOptions from depending on a resumable transcript.
-	t.Setenv("HOME", t.TempDir())
+	t.Setenv(toolhome.EnvVar, t.TempDir())
 
 	newDaemonWithSession := func(t *testing.T, sessionID string) *Daemon {
 		t.Helper()

--- a/internal/daemon/ticket_resume_test.go
+++ b/internal/daemon/ticket_resume_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/ptybackend"
 	"github.com/victorarias/attn/internal/store"
+	"github.com/victorarias/attn/internal/toolhome"
 )
 
 // resumeSpawnForSession returns the spawn opts recorded for sessionID at or after
@@ -156,10 +157,10 @@ func TestTicketResumeFallsBackToPickerWhenTranscriptGone(t *testing.T) {
 
 	d.unregisterSession(leafID, syscall.SIGTERM)
 	d.persistResumeSessionID(leafID, leafID)
-	// Point HOME at an empty home so claude's transcript lookup finds nothing for
-	// the mirrored id: it is not resumable, so the spawn must fall back to the
-	// cwd-scoped picker instead of `claude -r <dead-id>`.
-	t.Setenv("HOME", t.TempDir())
+	// Point ATTN_TOOL_HOME at an empty home so claude's transcript lookup finds
+	// nothing for the mirrored id: it is not resumable, so the spawn must fall
+	// back to the cwd-scoped picker instead of `claude -r <dead-id>`.
+	t.Setenv(toolhome.EnvVar, t.TempDir())
 	since := spawnCount(backend)
 
 	outcome, err := d.resumeTicket(ticket.ID)

--- a/internal/toolhome/toolhome.go
+++ b/internal/toolhome/toolhome.go
@@ -1,0 +1,43 @@
+// Package toolhome resolves the base directory under which external agent
+// tools' dotfiles live (~/.claude, ~/.codex, ~/.copilot, ~/.agents).
+package toolhome
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// EnvVar overrides the resolved base directory when set. Production leaves
+// it unset (real home); tests MUST set it — Dir panics under go test
+// otherwise, mirroring config.requireExplicitDataDirUnderTest.
+const EnvVar = "ATTN_TOOL_HOME"
+
+// Dir returns EnvVar's value when set (filepath.Clean'd), else
+// os.UserHomeDir().
+//
+// Under testing.Testing() with EnvVar unset it panics: tests must never
+// resolve real HOME through tool-dotfile paths (~/.claude, ~/.codex,
+// ~/.copilot, ~/.agents). This is the same incident class documented in
+// docs/plans/2026-07-18-db-loss-mitigation.md, one step removed: attn's own
+// data dir is guarded by config.requireExplicitDataDirUnderTest, but tests
+// were still redirecting HOME itself to sandbox other tools' dotfiles.
+//
+// If you hit this panic: set ATTN_TOOL_HOME to a temp dir, either in a
+// package TestMain (os.Setenv, so it applies to the whole package) or in an
+// individual test via t.Setenv(toolhome.EnvVar, t.TempDir()) for extra
+// per-test isolation. Never redirect HOME to work around this — see
+// docs/plans/2026-07-18-db-loss-mitigation.md.
+func Dir() (string, error) {
+	if override := strings.TrimSpace(os.Getenv(EnvVar)); override != "" {
+		return filepath.Clean(override), nil
+	}
+	if testing.Testing() {
+		panic("toolhome: ATTN_TOOL_HOME is not set under go test — tests must never resolve real HOME " +
+			"through tool-dotfile paths (~/.claude, ~/.codex, ~/.copilot, ~/.agents). " +
+			"Set ATTN_TOOL_HOME to a temp dir (os.Setenv in a package TestMain, or t.Setenv(toolhome.EnvVar, t.TempDir()) per-test). " +
+			"Never redirect HOME to work around this: see docs/plans/2026-07-18-db-loss-mitigation.md")
+	}
+	return os.UserHomeDir()
+}

--- a/internal/toolhome/toolhome_test.go
+++ b/internal/toolhome/toolhome_test.go
@@ -1,0 +1,34 @@
+package toolhome
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDir_EnvVarSet_ReturnsCleaned(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(EnvVar, tmp+string(filepath.Separator)+".")
+
+	got, err := Dir()
+	if err != nil {
+		t.Fatalf("Dir() returned error: %v", err)
+	}
+	want := filepath.Clean(tmp)
+	if got != want {
+		t.Fatalf("Dir() = %q, want %q", got, want)
+	}
+}
+
+func TestDir_EnvVarUnset_PanicsUnderTest(t *testing.T) {
+	t.Setenv(EnvVar, "")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected Dir() to panic when ATTN_TOOL_HOME is unset under go test, but it did not")
+		}
+	}()
+
+	_, _ = Dir()
+	t.Fatal("unreachable: Dir() should have panicked before returning")
+}

--- a/internal/transcript/discovery.go
+++ b/internal/transcript/discovery.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/victorarias/attn/internal/toolhome"
 )
 
 // FindCodexTranscript searches Codex session logs for the most recent session
@@ -157,7 +159,7 @@ func codexSessionsDir() string {
 	if codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME")); codexHome != "" {
 		return filepath.Join(codexHome, "sessions")
 	}
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := toolhome.Dir()
 	if err != nil {
 		return ""
 	}
@@ -256,7 +258,7 @@ func absDuration(d time.Duration) time.Duration {
 // FindCopilotTranscript searches Copilot session-state for the most recently
 // active events stream matching cwd and launch timing.
 func FindCopilotTranscript(cwd string, startedAt time.Time) string {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := toolhome.Dir()
 	if err != nil {
 		return ""
 	}
@@ -362,7 +364,7 @@ func FindCopilotTranscriptForResume(resumeID string) string {
 		return ""
 	}
 
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := toolhome.Dir()
 	if err != nil {
 		return ""
 	}
@@ -380,7 +382,7 @@ func FindClaudeTranscript(sessionID string) string {
 		return ""
 	}
 
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := toolhome.Dir()
 	if err != nil {
 		return ""
 	}

--- a/internal/transcript/discovery_test.go
+++ b/internal/transcript/discovery_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/victorarias/attn/internal/toolhome"
 )
 
 func writeCopilotSessionState(
@@ -91,13 +93,7 @@ func writeCodexTranscript(
 func TestFindCodexTranscript_MatchesSymlinkEquivalentCWD(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("CODEX_HOME", "")
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", homeDir); err != nil {
-		t.Fatalf("set HOME: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", oldHome)
-	})
+	t.Setenv(toolhome.EnvVar, homeDir)
 
 	root := t.TempDir()
 	realCWD := filepath.Join(root, "real", "project")
@@ -129,11 +125,7 @@ func TestFindCodexTranscript_MatchesSymlinkEquivalentCWD(t *testing.T) {
 func TestFindCodexTranscriptForResume_SelectsExactNativeID(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("CODEX_HOME", "")
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", homeDir); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+	t.Setenv(toolhome.EnvVar, homeDir)
 	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
 	wrong := writeCodexTranscript(t, homeDir, "native-wrong", "/repo", now, now)
 	want := writeCodexTranscript(t, homeDir, "native-target", "/other", now.Add(time.Second), now.Add(time.Second))
@@ -145,7 +137,9 @@ func TestFindCodexTranscriptForResume_SelectsExactNativeID(t *testing.T) {
 func TestFindCodexTranscriptForResume_HonorsCodexHome(t *testing.T) {
 	codexHome := t.TempDir()
 	t.Setenv("CODEX_HOME", codexHome)
-	t.Setenv("HOME", t.TempDir())
+	// CODEX_HOME is set, so codexSessionsDir never reaches toolhome.Dir(); set
+	// it anyway (defensive, and consistent with every other test in this file).
+	t.Setenv(toolhome.EnvVar, t.TempDir())
 	start := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
 	sessionDir := filepath.Join(codexHome, "sessions", "2026", "07", "18")
 	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
@@ -166,13 +160,7 @@ func TestFindCodexTranscriptForResume_HonorsCodexHome(t *testing.T) {
 
 func TestFindCopilotTranscript_PrefersClosestStartTime(t *testing.T) {
 	homeDir := t.TempDir()
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", homeDir); err != nil {
-		t.Fatalf("set HOME: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", oldHome)
-	})
+	t.Setenv(toolhome.EnvVar, homeDir)
 
 	cwd := "/repo/project"
 	startedAt := time.Date(2026, 2, 8, 15, 30, 0, 0, time.UTC)
@@ -206,13 +194,7 @@ func TestFindCopilotTranscript_PrefersClosestStartTime(t *testing.T) {
 
 func TestFindCopilotTranscript_FallsBackToNewestModTime(t *testing.T) {
 	homeDir := t.TempDir()
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", homeDir); err != nil {
-		t.Fatalf("set HOME: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", oldHome)
-	})
+	t.Setenv(toolhome.EnvVar, homeDir)
 
 	cwd := "/repo/project"
 	startedAt := time.Date(2026, 2, 8, 15, 30, 0, 0, time.UTC)
@@ -246,13 +228,7 @@ func TestFindCopilotTranscript_FallsBackToNewestModTime(t *testing.T) {
 
 func TestFindClaudeTranscript_FindsSessionFile(t *testing.T) {
 	homeDir := t.TempDir()
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", homeDir); err != nil {
-		t.Fatalf("set HOME: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", oldHome)
-	})
+	t.Setenv(toolhome.EnvVar, homeDir)
 
 	sessionID := "claude-session-123"
 	projectDir := filepath.Join(homeDir, ".claude", "projects", "-Users-test-repo")
@@ -273,13 +249,7 @@ func TestFindClaudeTranscript_FindsSessionFile(t *testing.T) {
 
 func TestFindClaudeTranscript_ReturnsEmptyWhenMissing(t *testing.T) {
 	homeDir := t.TempDir()
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", homeDir); err != nil {
-		t.Fatalf("set HOME: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", oldHome)
-	})
+	t.Setenv(toolhome.EnvVar, homeDir)
 
 	projectDir := filepath.Join(homeDir, ".claude", "projects", "-Users-test-repo")
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -3,11 +3,12 @@
 package test
 
 import (
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/victorarias/attn/internal/config"
 )
 
 func TestIntegration_DaemonAndClient(t *testing.T) {
@@ -20,8 +21,17 @@ func TestIntegration_DaemonAndClient(t *testing.T) {
 		t.Fatalf("build failed: %v", err)
 	}
 
-	// Start daemon
-	os.Setenv("HOME", tmpDir) // Use temp socket
+	// Scope the daemon subprocess's data dir (socket, db, etc.) instead of
+	// redirecting HOME — see docs/plans/2026-07-18-db-loss-mitigation.md.
+	// ScopeTestEnvironment calls os.Setenv (not t.Setenv), so the ATTN_DATA_DIR
+	// it sets is inherited by the daemon subprocess spawned below via the
+	// default (nil) exec.Cmd.Env, which falls back to os.Environ().
+	//
+	// Use tmpDir directly (not a nested subdirectory) to keep the resulting
+	// unix socket path short — ATTN_DATA_DIR/attn.sock must stay under the
+	// ~104-char unix socket path limit, and t.TempDir() paths are already
+	// long enough that adding another path segment risks tripping it.
+	config.ScopeTestEnvironment(tmpDir)
 	daemon := exec.Command(binPath, "daemon")
 	if err := daemon.Start(); err != nil {
 		t.Fatalf("daemon start failed: %v", err)


### PR DESCRIPTION
## Why

HOME redirection in tests is the same footgun class as the 2026-07-18 db-loss
incident (a test overwrote the real `~/.attn` because HOME-based state
resolution wasn't seamed for tests), one step removed. This applies the same
mitigation pattern used there (`config.requireExplicitDataDirUnderTest`) to
tool-dotfile resolution: `internal/toolhome` adds an `ATTN_TOOL_HOME` env seam
plus a panic backstop that fires if `os.UserHomeDir()` is reached under
`go test` without the override set, making accidental real-HOME resolution in
tests structurally impossible for tool-dotfile paths.

## What changed

- New `internal/toolhome` package (`toolhome.Dir()` + go-test panic backstop,
  mirroring `config.requireExplicitDataDirUnderTest`)
- Converts every `os.UserHomeDir()` call in `internal/transcript` and
  `internal/agent` to `toolhome.Dir()`
- Migrates all ~19 HOME-redirecting test sites off `HOME`, including **two
  latent leaks the new backstop caught** (test sites that were silently
  reading the real HOME before this change)
- One deliberate exemption: `internal/client/client_test.go` keeps
  `t.Setenv("HOME")` because `DataDirForProfile` is HOME-based by design for
  cross-profile probing (documented inline)

No CHANGELOG entry — internal-only, no user-visible behavior change.

## Verification

- `go build ./...` and `go vet ./...` clean
- `go test -count=1 ./...` green (fresh run, no cache)
- Live daemon smoke on a throwaway profile with `ATTN_TOOL_HOME` unset,
  confirming the production fallback path never hits the backstop
- Test-only, internal seam change with no daemon-process, protocol, PTY, or
  UI surface — no additional live-app verification needed beyond the above

Known pre-existing flake unrelated to this change: `internal/daemon`
git-status scheduler race under bare `-race` (scope with `-run` if hit).

https://claude.ai/code/session_01EBBCMUdJjyeuibj1UfrAKT