### PR TITLE
fix(tickets): deliver completion handoffs immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   ritual.** Agents may complete work that Victor accepted, whose requested PR
   merged, or that has an equivalent objective terminal signal; finished work still
   awaiting review remains in review.
-- **Ticket notifications now protect attention without delaying the agent doing the work.** The current assignee keeps immediate delivery, while chiefs, subscribers, and other participants coalesce unread activity into one 30-minute observer-wide window. Explicit inbox reads remain immediate, and inbox watches share delivery with nudges without duplicate wake-ups.
+- **Ticket notifications now protect attention without delaying handoffs.** The current assignee and successful ticket completions keep immediate delivery, while chiefs, subscribers, and other participants coalesce ordinary unread activity into one 30-minute observer-wide window. Explicit inbox reads remain immediate, and inbox watches share delivery with nudges without duplicate wake-ups.
 - **Ticket updates now make agents read intervening activity before writing.** Status, comment, and attachment commands show unread updates and require a deliberate retry; app edits reject stale ticket details and refresh them before retry. Taking or subscribing to a ticket reports unread history without consuming it.
 
 ### Fixed

--- a/docs/alignment/ticket-completion-immediate.md
+++ b/docs/alignment/ticket-completion-immediate.md
@@ -1,0 +1,26 @@
+# Ticket completion immediate delivery
+
+## Why
+
+A ticket moving to `done` is a handoff boundary: the chief or another subscribed
+observer needs to know that the assigned work has finished so the next owner can be
+dispatched. This chunk is done when that event enters the existing immediate attention
+path without weakening PR 594's batching for ordinary activity.
+
+## Aligned on
+
+- A `status_changed` event whose destination is the canonical `done` status bypasses
+  the observer's 30-minute buffer. It still uses the normal short, visible nudge
+  countdown and the same watch/nudge delivery arbitration.
+- The immediate path consumes the observer's whole unread queue across tickets, so
+  every pending buffered update piggybacks with full ticket and event provenance.
+- `working`, `blocked`, `in_review`, comments, and attachments remain buffered for a
+  non-assignee observer. Other terminal outcomes retain their existing semantics.
+- Event rows and per-observer cursors remain the durable batch and acknowledgement;
+  no new delivery state or protocol shape is introduced.
+
+## In scope / deferred
+
+This chunk changes only ticket notification eligibility, focused tests, and the
+user-facing changelog wording. New urgency levels, settings, notification channels,
+or broader terminal-status policy are deferred.

--- a/internal/daemon/ticket_buffer_test.go
+++ b/internal/daemon/ticket_buffer_test.go
@@ -18,7 +18,8 @@ func TestTicketDeadlineBuffersObserverButNotAssignee(t *testing.T) {
 	ticketID := boundTicketID(t, d, assignee)
 	now := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
 
-	deadline, immediate, err := d.ticketDeadline(assignee, ticketID, now, now)
+	event := store.TicketEvent{TicketID: ticketID, Kind: store.TicketEventCommented, CreatedAt: now}
+	deadline, immediate, err := d.ticketDeadline(assignee, event, now)
 	if err != nil || !immediate || !deadline.Equal(now.Add(time.Second)) {
 		t.Fatalf("assignee deadline = %s immediate=%v err=%v", deadline, immediate, err)
 	}
@@ -27,7 +28,7 @@ func TestTicketDeadlineBuffersObserverButNotAssignee(t *testing.T) {
 	if err := d.store.SetTicketDeliveryAttention(observer, now.Add(-10*time.Minute)); err != nil {
 		t.Fatal(err)
 	}
-	deadline, immediate, err = d.ticketDeadline(observer, ticketID, now, now)
+	deadline, immediate, err = d.ticketDeadline(observer, event, now)
 	if err != nil || immediate || !deadline.Equal(now.Add(50*time.Minute)) {
 		t.Fatalf("observer deadline = %s immediate=%v err=%v", deadline, immediate, err)
 	}
@@ -44,9 +45,160 @@ func TestTicketDeadlineBuffersFirstObserverEventFromEventTime(t *testing.T) {
 	eventAt := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
 	now := eventAt.Add(5 * time.Minute)
 
-	deadline, immediate, err := d.ticketDeadline(observer, ticketID, eventAt, now)
+	event := store.TicketEvent{TicketID: ticketID, Kind: store.TicketEventCommented, CreatedAt: eventAt}
+	deadline, immediate, err := d.ticketDeadline(observer, event, now)
 	if err != nil || immediate || !deadline.Equal(eventAt.Add(time.Hour)) {
 		t.Fatalf("first observer deadline = %s immediate=%v err=%v", deadline, immediate, err)
+	}
+}
+
+func TestTicketDeadlineOnlyBypassesObserverBufferForDoneTransition(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Second
+	d.ticketBufferWindowOverride = time.Hour
+	_, assignee, _ := delegateForNotify(t, d, "codex")
+	ticketID := boundTicketID(t, d, assignee)
+	observer := "observer"
+	d.store.Add(&protocol.Session{ID: observer, Label: observer, Agent: protocol.SessionAgentCodex, Directory: t.TempDir(), State: protocol.StateIdle})
+	now := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
+	if err := d.store.SetTicketDeliveryAttention(observer, now); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		event     store.TicketEvent
+		immediate bool
+	}{
+		{name: "done", event: store.TicketEvent{Kind: store.TicketEventStatusChanged, ToStatus: store.TicketStatusDone}, immediate: true},
+		{name: "working", event: store.TicketEvent{Kind: store.TicketEventStatusChanged, ToStatus: store.TicketStatusWorking}},
+		{name: "blocked", event: store.TicketEvent{Kind: store.TicketEventStatusChanged, ToStatus: store.TicketStatusBlocked}},
+		{name: "in review", event: store.TicketEvent{Kind: store.TicketEventStatusChanged, ToStatus: store.TicketStatusInReview}},
+		{name: "failed", event: store.TicketEvent{Kind: store.TicketEventStatusChanged, ToStatus: store.TicketStatusFailed}},
+		{name: "comment", event: store.TicketEvent{Kind: store.TicketEventCommented}},
+		{name: "attachment", event: store.TicketEvent{Kind: store.TicketEventAttachSubmitted}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.event.TicketID = ticketID
+			tt.event.CreatedAt = now
+			deadline, immediate, err := d.ticketDeadline(observer, tt.event, now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if immediate != tt.immediate {
+				t.Fatalf("immediate = %v, want %v", immediate, tt.immediate)
+			}
+			want := now.Add(time.Hour)
+			if tt.immediate {
+				want = now.Add(time.Second)
+			}
+			if !deadline.Equal(want) {
+				t.Fatalf("deadline = %s, want %s", deadline, want)
+			}
+		})
+	}
+}
+
+func TestDoneTransitionPullsObserversForwardAndPiggybacksBufferedActivity(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	d.nudgeWindowOverride = time.Minute
+	d.ticketBufferWindowOverride = time.Hour
+	t.Cleanup(d.stopNudgeCountdowns)
+	chiefID, assignees, _ := delegateMany(t, d, "codex", "finish the design", "investigate the follow-up")
+	assignee, otherAssignee := assignees[0], assignees[1]
+	ticketID := boundTicketID(t, d, assignee)
+	otherTicketID := boundTicketID(t, d, otherAssignee)
+	d.setSelectedSession(assignee)
+
+	subscriberID := "subscriber"
+	d.store.Add(&protocol.Session{ID: subscriberID, Label: subscriberID, Agent: protocol.SessionAgentCodex, Directory: t.TempDir(), State: protocol.StateIdle})
+	for _, subscribedTicketID := range []string{ticketID, otherTicketID} {
+		if err := d.store.AddTicketSubscription(subscriberID, subscribedTicketID, time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, observer := range []string{chiefID, subscriberID} {
+		_ = callTicketInbox(t, d, observer)
+		if err := d.store.SetTicketDeliveryAttention(d.ticketAttentionKey(observer), time.Now()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := d.store.AddTicketComment(ticketID, assignee, "implementation finished", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	d.notifyTicketObservers(ticketID)
+	if _, err := d.store.AddTicketComment(otherTicketID, otherAssignee, "related investigation update", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	d.notifyTicketObservers(otherTicketID)
+	for _, observer := range []string{chiefID, subscriberID} {
+		deadline := waitForNudgeDeadline(t, d, observer)
+		if deadline.Before(time.Now().Add(59 * time.Minute)) {
+			t.Fatalf("%s comment deadline = %s, want buffered", observer, deadline)
+		}
+	}
+
+	callSetTicketStatus(t, d, assignee, string(protocol.DispatchWorkStateCompleted), "accepted plan attached")
+	for _, observer := range []string{chiefID, subscriberID} {
+		waitForNudgeDeadlineBefore(t, d, observer, time.Now().Add(61*time.Second))
+	}
+	// A daemon restart loses only the in-memory countdown. Rebuilding from the
+	// durable unread completion event must retain immediate eligibility.
+	d.cancelNudgeCountdown(chiefID, "simulate daemon restart")
+	d.notifyUnreadTicketSession(chiefID, time.Now())
+	waitForNudgeDeadlineBefore(t, d, chiefID, time.Now().Add(61*time.Second))
+
+	watch := protocol.TicketInboxModeWatch
+	chiefBundles := callTicketInboxMode(t, d, chiefID, &watch)
+	assertDoneFlushBundles(t, chiefBundles, ticketID, assignee, otherTicketID, otherAssignee)
+	subscriberBundles := callTicketInbox(t, d, subscriberID)
+	assertDoneFlushBundles(t, subscriberBundles, ticketID, assignee, otherTicketID, otherAssignee)
+	if again := callTicketInbox(t, d, chiefID); len(again) != 0 {
+		t.Fatalf("chief replayed completion = %+v", again)
+	}
+	if again := callTicketInbox(t, d, subscriberID); len(again) != 0 {
+		t.Fatalf("subscriber replayed completion = %+v", again)
+	}
+}
+
+func waitForNudgeDeadlineBefore(t *testing.T, d *Daemon, sessionID string, before time.Time) time.Time {
+	t.Helper()
+	limit := time.Now().Add(time.Second)
+	for time.Now().Before(limit) {
+		if deadline := currentNudgeDeadline(d, sessionID); !deadline.IsZero() && deadline.Before(before) {
+			return deadline
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("%s deadline = %s, want before %s", sessionID, currentNudgeDeadline(d, sessionID), before)
+	return time.Time{}
+}
+
+func assertDoneFlushBundles(t *testing.T, bundles []protocol.TicketEventBundle, ticketID, assignee, otherTicketID, otherAssignee string) {
+	t.Helper()
+	if len(bundles) != 2 {
+		t.Fatalf("bundles = %+v, want completed ticket plus other buffered ticket", bundles)
+	}
+	byTicket := make(map[string]protocol.TicketEventBundle, len(bundles))
+	for _, bundle := range bundles {
+		byTicket[bundle.TicketID] = bundle
+	}
+	completed := byTicket[ticketID]
+	if len(completed.Events) != 2 {
+		t.Fatalf("completed bundle = %+v, want buffered comment plus done event", completed)
+	}
+	comment, done := completed.Events[0], completed.Events[1]
+	if comment.Kind != protocol.TicketEventKindCommented || comment.Comment == nil || *comment.Comment != "implementation finished" {
+		t.Fatalf("piggybacked event = %+v, want original comment provenance", comment)
+	}
+	if done.Kind != protocol.TicketEventKindStatusChanged || done.Author != assignee || done.ToStatus == nil || *done.ToStatus != protocol.TicketStatusDone || done.Comment == nil || *done.Comment != "accepted plan attached" {
+		t.Fatalf("completion event = %+v, want full done provenance", done)
+	}
+	other := byTicket[otherTicketID]
+	if len(other.Events) != 1 || other.Events[0].Kind != protocol.TicketEventKindCommented || other.Events[0].Author != otherAssignee || other.Events[0].Comment == nil || *other.Events[0].Comment != "related investigation update" {
+		t.Fatalf("other buffered bundle = %+v, want cross-ticket update flushed intact", other)
 	}
 }
 

--- a/internal/daemon/ticket_notify.go
+++ b/internal/daemon/ticket_notify.go
@@ -58,12 +58,12 @@ func (d *Daemon) ticketAttentionKey(sessionID string) string {
 	return sessionID
 }
 
-func (d *Daemon) ticketDeadline(sessionID, ticketID string, unreadAt, now time.Time) (time.Time, bool, error) {
-	ticket, err := d.store.GetTicket(ticketID)
+func (d *Daemon) ticketDeadline(sessionID string, event store.TicketEvent, now time.Time) (time.Time, bool, error) {
+	ticket, err := d.store.GetTicket(event.TicketID)
 	if err != nil || ticket == nil {
 		return time.Time{}, false, err
 	}
-	if ticket.Assignee == sessionID {
+	if ticket.Assignee == sessionID || ticketEventNeedsImmediateAttention(event) {
 		return now.Add(d.nudgeWindow()), true, nil
 	}
 	attention, found, err := d.store.TicketDeliveryAttention(d.ticketAttentionKey(sessionID))
@@ -75,12 +75,20 @@ func (d *Daemon) ticketDeadline(sessionID, ticketID string, unreadAt, now time.T
 		if buffered := attention.LastAttentionAt.Add(d.ticketBufferWindow()); buffered.After(deadline) {
 			deadline = buffered
 		}
-	} else if !unreadAt.IsZero() {
-		if buffered := unreadAt.Add(d.ticketBufferWindow()); buffered.After(deadline) {
+	} else if !event.CreatedAt.IsZero() {
+		if buffered := event.CreatedAt.Add(d.ticketBufferWindow()); buffered.After(deadline) {
 			deadline = buffered
 		}
 	}
 	return deadline, false, nil
+}
+
+// ticketEventNeedsImmediateAttention identifies handoff boundaries that must not
+// wait behind an observer's ordinary interruption budget. Completion is the one
+// canonical successful terminal report; other statuses and activity retain PR
+// 594's buffering policy.
+func ticketEventNeedsImmediateAttention(event store.TicketEvent) bool {
+	return event.Kind == store.TicketEventStatusChanged && event.ToStatus == store.TicketStatusDone
 }
 
 // ticketNudger adapts the daemon's doorbell primitive to ticketnotify.Nudger.
@@ -184,12 +192,12 @@ func (d *Daemon) notifyUnreadTicketSessionLocked(sessionID string, now time.Time
 		}
 		for _, event := range events {
 			pending[event.Seq] = struct{}{}
-			candidate, assigned, err := d.ticketDeadline(sessionID, event.TicketID, event.CreatedAt, now)
+			candidate, eventImmediate, err := d.ticketDeadline(sessionID, event, now)
 			if err != nil {
 				continue
 			}
 			if deadline.IsZero() || candidate.Before(deadline) {
-				deadline, immediate = candidate, assigned
+				deadline, immediate = candidate, eventImmediate
 			}
 		}
 	}
@@ -198,7 +206,7 @@ func (d *Daemon) notifyUnreadTicketSessionLocked(sessionID string, now time.Time
 			d.ticketRebuildBeforeArmHook(sessionID, deadline)
 		}
 		if d.debugLogging {
-			d.logf("ticket delivery: observer=%s session=%s class=%s pending=%d deadline=%s channel=countdown outcome=armed", d.ticketAttentionKey(sessionID), sessionID, map[bool]string{true: "assignee", false: "buffered"}[immediate], len(pending), deadline.Format(time.RFC3339))
+			d.logf("ticket delivery: observer=%s session=%s class=%s pending=%d deadline=%s channel=countdown outcome=armed", d.ticketAttentionKey(sessionID), sessionID, map[bool]string{true: "immediate", false: "buffered"}[immediate], len(pending), deadline.Format(time.RFC3339))
 		}
 		d.armNudgeCountdownAt(sessionID, deadline)
 	}

--- a/internal/daemon/ticket_read.go
+++ b/internal/daemon/ticket_read.go
@@ -126,7 +126,7 @@ func (d *Daemon) ticketWatchEligible(sessionID string, now time.Time) (bool, err
 			return false, err
 		}
 		for _, event := range events {
-			deadline, immediate, err := d.ticketDeadline(sessionID, event.TicketID, event.CreatedAt, now)
+			deadline, immediate, err := d.ticketDeadline(sessionID, event, now)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
## Intent / Why

PR #594 intentionally coalesces ordinary non-assignee ticket activity into a 30-minute observer window. A successful completion is different: it is a handoff boundary, and delaying it can stall the chief from dispatching the next owner.

This follow-up keeps the buffering model while making the canonical `status_changed → done` event immediately eligible for the existing short attention countdown.

## Summary

- classify successful `done` transitions as immediate for chiefs, subscribers, and other relevant observers
- flush the observer full pending inbox across tickets when completion triggers delivery, preserving event provenance and durable unread cursors
- keep working, blocked, in-review, failed, comments, and attachments on their existing buffered policy
- apply the same event-aware eligibility to countdown reconstruction and inbox watches
- document the behavior contract and update the user-facing changelog

## Test plan

- [x] Focused deadline, completion-flush, explicit-inbox, watch-race, and overlapping-observer tests
- [x] `go test ./internal/daemon ./internal/store ./internal/ticketnotify -count=1`
- [x] `go test ./... -count=1`
- [x] Signed isolated `attn-dev` smoke: ordinary activity armed at ~29m59s, completion pulled delivery to ~29.9s, both events were consumed once
- [x] Structured Codex autoreview: no actionable findings

## Related

- Follow-up to #594