### PR TITLE
fix(delegate): make retries idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ---
 
+## [2026-07-19]
+
+### Fixed
+- **Retried delegations no longer create duplicate agents or tickets.** `attn
+  delegate` now prints a durable request and operation identity before slow
+  worktree preparation, shows concise progress while it waits, and lets callers
+  retry or inspect an unknown outcome by that identity. Concurrent retries
+  converge on the same session, interrupted preparation resumes after a daemon
+  restart, terminal failures stay terminal, and sharing an active worktree now
+  requires the explicit `--allow-worktree-reuse` override.
+
 ## [2026-07-18]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ Your agents can work as a team, not just side by side:
 
 - **Shared workspace context** — a living brief agents read and keep current, so a new session orients itself without you re-explaining the task.
 - **Delegation** — an agent can spin up a fresh, visible session with a focused brief (`attn delegate`) instead of cramming everything into one context.
+
+Delegation is retry-safe. The CLI generates and immediately prints a stable
+request ID before repository or worktree preparation; orchestration callers can
+provide their own with `--request-id <id>`. If the command is interrupted after
+acceptance, repeat the same command with that ID or inspect it with `attn delegate
+status <request-or-operation-id>`. Reusing an ID never creates a second ticket or
+session. Attn also refuses to place another active session in the same worktree
+unless `--allow-worktree-reuse` explicitly confirms that exceptional choice.
 - **[Chief of staff](#put-a-manager-in-charge-of-your-agents)** — a manager for your agents. It helps shape the plan and keeps one coherent picture; you choose the handoffs.
 - **In-app browser** — `attn browser open <url>` docks a real browser an agent can drive; log in once and it persists.
 

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '172';
+export const PROTOCOL_VERSION = '173';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import generated protocol types from "./file";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -32,7 +32,11 @@
 //   const delegateMessage = Convert.toDelegateMessage(json);
 //   const delegateResult = Convert.toDelegateResult(json);
 //   const delegateResultMessage = Convert.toDelegateResultMessage(json);
+//   const delegateStatusMessage = Convert.toDelegateStatusMessage(json);
 //   const delegateWorktreeRequest = Convert.toDelegateWorktreeRequest(json);
+//   const delegationOperation = Convert.toDelegationOperation(json);
+//   const delegationOperationMessage = Convert.toDelegationOperationMessage(json);
+//   const delegationOperationState = Convert.toDelegationOperationState(json);
 //   const deleteWorktreeMessage = Convert.toDeleteWorktreeMessage(json);
 //   const deleteWorktreeResultMessage = Convert.toDeleteWorktreeResultMessage(json);
 //   const detachSessionMessage = Convert.toDetachSessionMessage(json);
@@ -740,18 +744,20 @@ export interface DaemonWarning {
 }
 
 export interface DelegateMessage {
-    agent?:            string;
-    brief:             string;
-    cmd:               DelegateMessageCmd;
-    cwd?:              string;
-    effort?:           string;
-    label?:            string;
-    model?:            string;
-    placement?:        string;
-    source_session_id: string;
-    workspace_id?:     string;
-    worktree?:         DelegateMessageWorktree;
-    yolo_mode?:        boolean;
+    agent?:                string;
+    allow_worktree_reuse?: boolean;
+    brief:                 string;
+    cmd:                   DelegateMessageCmd;
+    cwd?:                  string;
+    effort?:               string;
+    label?:                string;
+    model?:                string;
+    placement?:            string;
+    request_id:            string;
+    source_session_id:     string;
+    workspace_id?:         string;
+    worktree?:             DelegateMessageWorktree;
+    yolo_mode?:            boolean;
     [property: string]: any;
 }
 
@@ -799,11 +805,72 @@ export interface DelegateResultObject {
     [property: string]: any;
 }
 
+export interface DelegateStatusMessage {
+    cmd: DelegateStatusMessageCmd;
+    id:  string;
+    [property: string]: any;
+}
+
+export enum DelegateStatusMessageCmd {
+    DelegateStatus = "delegate_status",
+}
+
 export interface DelegateWorktreeRequest {
     branch:         string;
     path?:          string;
     repo?:          string;
     starting_from?: string;
+    [property: string]: any;
+}
+
+export interface DelegationOperation {
+    created_at:     string;
+    error?:         string;
+    operation_id:   string;
+    progress:       string;
+    request_id:     string;
+    result?:        DelegateResultObject;
+    session_id:     string;
+    state:          DelegationOperationState;
+    ticket_id?:     string;
+    updated_at:     string;
+    workspace_id?:  string;
+    worktree_path?: string;
+    [property: string]: any;
+}
+
+export enum DelegationOperationState {
+    Accepted = "accepted",
+    Completed = "completed",
+    Failed = "failed",
+    Preparing = "preparing",
+}
+
+export interface DelegationOperationMessage {
+    error?:     string;
+    event:      DelegationOperationMessageEvent;
+    operation?: DelegationOperationObject;
+    success:    boolean;
+    [property: string]: any;
+}
+
+export enum DelegationOperationMessageEvent {
+    DelegationOperation = "delegation_operation",
+}
+
+export interface DelegationOperationObject {
+    created_at:     string;
+    error?:         string;
+    operation_id:   string;
+    progress:       string;
+    request_id:     string;
+    result?:        DelegateResultObject;
+    session_id:     string;
+    state:          DelegationOperationState;
+    ticket_id?:     string;
+    updated_at:     string;
+    workspace_id?:  string;
+    worktree_path?: string;
     [property: string]: any;
 }
 
@@ -1736,7 +1803,7 @@ export enum GitOperationStatus {
 
 export interface GitOperationFinishedMessage {
     event:     GitOperationFinishedMessageEvent;
-    operation: Operation;
+    operation: GitOperationFinishedMessageOperation;
     [property: string]: any;
 }
 
@@ -1744,7 +1811,7 @@ export enum GitOperationFinishedMessageEvent {
     GitOperationFinished = "git_operation_finished",
 }
 
-export interface Operation {
+export interface GitOperationFinishedMessageOperation {
     duration_ms?: number;
     endpoint_id?: string;
     error?:       string;
@@ -1759,7 +1826,7 @@ export interface Operation {
 
 export interface GitOperationStartedMessage {
     event:     GitOperationStartedMessageEvent;
-    operation: Operation;
+    operation: GitOperationFinishedMessageOperation;
     [property: string]: any;
 }
 
@@ -3295,6 +3362,7 @@ export interface Response {
     authors?:                              AuthorElement[];
     data?:                                 string;
     delegate_result?:                      DelegateResultObject;
+    delegation_operation?:                 DelegationOperationObject;
     error?:                                string;
     journal_append_result?:                JournalAppendResultObject;
     notebook_entries?:                     NotebookEntryElement[];
@@ -4387,7 +4455,7 @@ export interface WebSocketEvent {
     last_seq?:                 number;
     modified?:                 string;
     name?:                     string;
-    operation?:                Operation;
+    operation?:                GitOperationFinishedMessageOperation;
     original?:                 string;
     pane_id?:                  string;
     path?:                     string;
@@ -5335,12 +5403,44 @@ export class Convert {
         return JSON.stringify(uncast(value, r("DelegateResultMessage")), null, 2);
     }
 
+    public static toDelegateStatusMessage(json: string): DelegateStatusMessage {
+        return cast(JSON.parse(json), r("DelegateStatusMessage"));
+    }
+
+    public static delegateStatusMessageToJson(value: DelegateStatusMessage): string {
+        return JSON.stringify(uncast(value, r("DelegateStatusMessage")), null, 2);
+    }
+
     public static toDelegateWorktreeRequest(json: string): DelegateWorktreeRequest {
         return cast(JSON.parse(json), r("DelegateWorktreeRequest"));
     }
 
     public static delegateWorktreeRequestToJson(value: DelegateWorktreeRequest): string {
         return JSON.stringify(uncast(value, r("DelegateWorktreeRequest")), null, 2);
+    }
+
+    public static toDelegationOperation(json: string): DelegationOperation {
+        return cast(JSON.parse(json), r("DelegationOperation"));
+    }
+
+    public static delegationOperationToJson(value: DelegationOperation): string {
+        return JSON.stringify(uncast(value, r("DelegationOperation")), null, 2);
+    }
+
+    public static toDelegationOperationMessage(json: string): DelegationOperationMessage {
+        return cast(JSON.parse(json), r("DelegationOperationMessage"));
+    }
+
+    public static delegationOperationMessageToJson(value: DelegationOperationMessage): string {
+        return JSON.stringify(uncast(value, r("DelegationOperationMessage")), null, 2);
+    }
+
+    public static toDelegationOperationState(json: string): DelegationOperationState {
+        return cast(JSON.parse(json), r("DelegationOperationState"));
+    }
+
+    public static delegationOperationStateToJson(value: DelegationOperationState): string {
+        return JSON.stringify(uncast(value, r("DelegationOperationState")), null, 2);
     }
 
     public static toDeleteWorktreeMessage(json: string): DeleteWorktreeMessage {
@@ -8257,6 +8357,7 @@ const typeMap: any = {
     ], "any"),
     "DelegateMessage": o([
         { json: "agent", js: "agent", typ: u(undefined, "") },
+        { json: "allow_worktree_reuse", js: "allow_worktree_reuse", typ: u(undefined, true) },
         { json: "brief", js: "brief", typ: "" },
         { json: "cmd", js: "cmd", typ: r("DelegateMessageCmd") },
         { json: "cwd", js: "cwd", typ: u(undefined, "") },
@@ -8264,6 +8365,7 @@ const typeMap: any = {
         { json: "label", js: "label", typ: u(undefined, "") },
         { json: "model", js: "model", typ: u(undefined, "") },
         { json: "placement", js: "placement", typ: u(undefined, "") },
+        { json: "request_id", js: "request_id", typ: "" },
         { json: "source_session_id", js: "source_session_id", typ: "" },
         { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
         { json: "worktree", js: "worktree", typ: u(undefined, r("DelegateMessageWorktree")) },
@@ -8297,11 +8399,49 @@ const typeMap: any = {
         { json: "workspace_id", js: "workspace_id", typ: "" },
         { json: "worktree_created", js: "worktree_created", typ: u(undefined, true) },
     ], "any"),
+    "DelegateStatusMessage": o([
+        { json: "cmd", js: "cmd", typ: r("DelegateStatusMessageCmd") },
+        { json: "id", js: "id", typ: "" },
+    ], "any"),
     "DelegateWorktreeRequest": o([
         { json: "branch", js: "branch", typ: "" },
         { json: "path", js: "path", typ: u(undefined, "") },
         { json: "repo", js: "repo", typ: u(undefined, "") },
         { json: "starting_from", js: "starting_from", typ: u(undefined, "") },
+    ], "any"),
+    "DelegationOperation": o([
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "operation_id", js: "operation_id", typ: "" },
+        { json: "progress", js: "progress", typ: "" },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "result", js: "result", typ: u(undefined, r("DelegateResultObject")) },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "state", js: "state", typ: r("DelegationOperationState") },
+        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
+        { json: "updated_at", js: "updated_at", typ: "" },
+        { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
+        { json: "worktree_path", js: "worktree_path", typ: u(undefined, "") },
+    ], "any"),
+    "DelegationOperationMessage": o([
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "event", js: "event", typ: r("DelegationOperationMessageEvent") },
+        { json: "operation", js: "operation", typ: u(undefined, r("DelegationOperationObject")) },
+        { json: "success", js: "success", typ: true },
+    ], "any"),
+    "DelegationOperationObject": o([
+        { json: "created_at", js: "created_at", typ: "" },
+        { json: "error", js: "error", typ: u(undefined, "") },
+        { json: "operation_id", js: "operation_id", typ: "" },
+        { json: "progress", js: "progress", typ: "" },
+        { json: "request_id", js: "request_id", typ: "" },
+        { json: "result", js: "result", typ: u(undefined, r("DelegateResultObject")) },
+        { json: "session_id", js: "session_id", typ: "" },
+        { json: "state", js: "state", typ: r("DelegationOperationState") },
+        { json: "ticket_id", js: "ticket_id", typ: u(undefined, "") },
+        { json: "updated_at", js: "updated_at", typ: "" },
+        { json: "workspace_id", js: "workspace_id", typ: u(undefined, "") },
+        { json: "worktree_path", js: "worktree_path", typ: u(undefined, "") },
     ], "any"),
     "DeleteWorktreeMessage": o([
         { json: "cmd", js: "cmd", typ: r("GitOperationKind") },
@@ -8852,9 +8992,9 @@ const typeMap: any = {
     ], "any"),
     "GitOperationFinishedMessage": o([
         { json: "event", js: "event", typ: r("GitOperationFinishedMessageEvent") },
-        { json: "operation", js: "operation", typ: r("Operation") },
+        { json: "operation", js: "operation", typ: r("GitOperationFinishedMessageOperation") },
     ], "any"),
-    "Operation": o([
+    "GitOperationFinishedMessageOperation": o([
         { json: "duration_ms", js: "duration_ms", typ: u(undefined, 0) },
         { json: "endpoint_id", js: "endpoint_id", typ: u(undefined, "") },
         { json: "error", js: "error", typ: u(undefined, "") },
@@ -8867,7 +9007,7 @@ const typeMap: any = {
     ], "any"),
     "GitOperationStartedMessage": o([
         { json: "event", js: "event", typ: r("GitOperationStartedMessageEvent") },
-        { json: "operation", js: "operation", typ: r("Operation") },
+        { json: "operation", js: "operation", typ: r("GitOperationFinishedMessageOperation") },
     ], "any"),
     "GitStatusUpdateMessage": o([
         { json: "directory", js: "directory", typ: "" },
@@ -9767,6 +9907,7 @@ const typeMap: any = {
         { json: "authors", js: "authors", typ: u(undefined, a(r("AuthorElement"))) },
         { json: "data", js: "data", typ: u(undefined, "") },
         { json: "delegate_result", js: "delegate_result", typ: u(undefined, r("DelegateResultObject")) },
+        { json: "delegation_operation", js: "delegation_operation", typ: u(undefined, r("DelegationOperationObject")) },
         { json: "error", js: "error", typ: u(undefined, "") },
         { json: "journal_append_result", js: "journal_append_result", typ: u(undefined, r("JournalAppendResultObject")) },
         { json: "notebook_entries", js: "notebook_entries", typ: u(undefined, a(r("NotebookEntryElement"))) },
@@ -10420,7 +10561,7 @@ const typeMap: any = {
         { json: "last_seq", js: "last_seq", typ: u(undefined, 0) },
         { json: "modified", js: "modified", typ: u(undefined, "") },
         { json: "name", js: "name", typ: u(undefined, "") },
-        { json: "operation", js: "operation", typ: u(undefined, r("Operation")) },
+        { json: "operation", js: "operation", typ: u(undefined, r("GitOperationFinishedMessageOperation")) },
         { json: "original", js: "original", typ: u(undefined, "") },
         { json: "pane_id", js: "pane_id", typ: u(undefined, "") },
         { json: "path", js: "path", typ: u(undefined, "") },
@@ -10923,6 +11064,18 @@ const typeMap: any = {
     ],
     "DelegateResultMessageEvent": [
         "delegate_result",
+    ],
+    "DelegateStatusMessageCmd": [
+        "delegate_status",
+    ],
+    "DelegationOperationState": [
+        "accepted",
+        "completed",
+        "failed",
+        "preparing",
+    ],
+    "DelegationOperationMessageEvent": [
+        "delegation_operation",
     ],
     "GitOperationKind": [
         "delete_worktree",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
 	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/buildinfo"
 	"github.com/victorarias/attn/internal/client"
@@ -628,18 +629,59 @@ func runDelegate() {
 		writeDelegateHelp(os.Stdout)
 		return
 	}
+	if len(os.Args) >= 3 && os.Args[2] == "status" {
+		if len(os.Args) != 4 || strings.TrimSpace(os.Args[3]) == "" {
+			fmt.Fprintln(os.Stderr, "delegate status: usage: attn delegate status <request-or-operation-id>")
+			os.Exit(2)
+		}
+		result, err := client.New("").DelegationStatus(os.Args[3])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "delegate status: %v\n", err)
+			os.Exit(1)
+		}
+		printJSON(result)
+		return
+	}
 	warnIfDaemonVersionMismatch()
 	args, err := parseDelegateArgs(os.Args[2:])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "delegate: %v\n", err)
 		os.Exit(2)
 	}
-	result, err := client.New("").Delegate(args.sourceSessionID, args.brief, args.options)
+	c := client.New("")
+	// Print the caller-owned recovery key before crossing the transport. The
+	// daemon may durably accept the request even if this process never receives
+	// its response; this line is what makes that unknown outcome recoverable.
+	fmt.Fprintf(os.Stderr, "delegation request: request_id=%s\n", args.options.RequestID)
+	operation, err := c.StartDelegation(args.sourceSessionID, args.brief, args.options)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "delegate: %v\n", err)
 		os.Exit(1)
 	}
-	printJSON(result)
+	fmt.Fprintf(os.Stderr, "delegation accepted: request_id=%s operation_id=%s session_id=%s\n",
+		operation.RequestID, operation.OperationID, operation.SessionID)
+	lastProgress := ""
+	for operation.State == protocol.DelegationOperationStateAccepted || operation.State == protocol.DelegationOperationStatePreparing {
+		if operation.Progress != "" && operation.Progress != lastProgress {
+			fmt.Fprintf(os.Stderr, "delegation progress: %s\n", operation.Progress)
+			lastProgress = operation.Progress
+		}
+		time.Sleep(250 * time.Millisecond)
+		operation, err = c.DelegationStatus(operation.OperationID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "delegate: outcome unknown; inspect or retry with --request-id %s: %v\n", args.options.RequestID, err)
+			os.Exit(1)
+		}
+	}
+	if operation.State == protocol.DelegationOperationStateFailed {
+		fmt.Fprintf(os.Stderr, "delegate: %s (request_id=%s)\n", protocol.Deref(operation.Error), operation.RequestID)
+		os.Exit(1)
+	}
+	if operation.Result == nil {
+		fmt.Fprintln(os.Stderr, "delegate: completed operation has no result")
+		os.Exit(1)
+	}
+	printJSON(operation.Result)
 }
 
 func writeDelegateHelp(w io.Writer) {
@@ -660,6 +702,7 @@ worktree options:
   --worktree-path <path>     override the generated sibling path
 
 session options:
+	--request-id <id>          stable retry key (generated and printed when omitted; op- is reserved)
   --agent <name>             configured prompt-capable built-in or plugin agent
   --model <name>             pin the agent's model (alias or full id, e.g.
                              "opus" or "claude-opus-4-8"; defaults to the
@@ -672,6 +715,10 @@ session options:
                              unique; defaults to the directory name)
   --source-session <id>      source session (defaults to ATTN_SESSION_ID)
   --yolo                     bypass agent approval prompts
+	--allow-worktree-reuse     explicitly allow another active session to share the worktree
+
+inspection:
+  attn delegate status <request-or-operation-id>
 `)
 }
 
@@ -2259,6 +2306,8 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 	worktreeRepo := fs.String("repo", "", "main repository for --worktree (defaults to source repository)")
 	worktreeStart := fs.String("from", "", "starting ref for --worktree")
 	worktreePath := fs.String("worktree-path", "", "custom path for --worktree")
+	requestID := fs.String("request-id", "", "stable delegation request id")
+	allowWorktreeReuse := fs.Bool("allow-worktree-reuse", false, "allow active sessions to share a worktree")
 	if err := fs.Parse(args); err != nil {
 		return delegateCLIArgs{}, err
 	}
@@ -2293,6 +2342,10 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 	repo := strings.TrimSpace(*worktreeRepo)
 	startingFrom := strings.TrimSpace(*worktreeStart)
 	customWorktreePath := strings.TrimSpace(*worktreePath)
+	stableRequestID := strings.TrimSpace(*requestID)
+	if stableRequestID == "" {
+		stableRequestID = uuid.NewString()
+	}
 	if explicitWorkspace != "" && (*newWorkspace || customCWD != "") {
 		return delegateCLIArgs{}, errors.New("--workspace cannot be combined with --new-workspace or --cwd")
 	}
@@ -2311,18 +2364,20 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 		sourceSessionID: source,
 		brief:           brief,
 		options: client.DelegateOptions{
-			Agent:        strings.TrimSpace(*agentName),
-			Model:        strings.TrimSpace(*model),
-			Effort:       strings.TrimSpace(*effort),
-			Label:        strings.TrimSpace(*name),
-			Yolo:         *yolo,
-			Placement:    placement,
-			WorkspaceID:  explicitWorkspace,
-			CWD:          customCWD,
-			WorktreeRepo: repo,
-			Worktree:     branch,
-			WorktreePath: customWorktreePath,
-			StartingFrom: startingFrom,
+			RequestID:          stableRequestID,
+			Agent:              strings.TrimSpace(*agentName),
+			Model:              strings.TrimSpace(*model),
+			Effort:             strings.TrimSpace(*effort),
+			Label:              strings.TrimSpace(*name),
+			Yolo:               *yolo,
+			Placement:          placement,
+			WorkspaceID:        explicitWorkspace,
+			CWD:                customCWD,
+			WorktreeRepo:       repo,
+			Worktree:           branch,
+			WorktreePath:       customWorktreePath,
+			StartingFrom:       startingFrom,
+			AllowWorktreeReuse: *allowWorktreeReuse,
 		},
 	}, nil
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/victorarias/attn/internal/config"
 	"github.com/victorarias/attn/internal/protocol"
 )
@@ -162,24 +163,32 @@ func (c *Client) UpdateTodos(id string, todos []string) error {
 }
 
 type DelegateOptions struct {
-	Agent        string
-	Model        string
-	Effort       string
-	Label        string
-	Yolo         bool
-	Placement    string
-	WorkspaceID  string
-	CWD          string
-	WorktreeRepo string
-	Worktree     string
-	WorktreePath string
-	StartingFrom string
+	RequestID          string
+	Agent              string
+	Model              string
+	Effort             string
+	Label              string
+	Yolo               bool
+	Placement          string
+	WorkspaceID        string
+	CWD                string
+	WorktreeRepo       string
+	Worktree           string
+	WorktreePath       string
+	StartingFrom       string
+	AllowWorktreeReuse bool
 }
 
-// Delegate starts another agent with an initial brief and optional placement.
-func (c *Client) Delegate(sourceSessionID, brief string, opts DelegateOptions) (*protocol.DelegateResult, error) {
+// StartDelegation durably accepts a delegation and returns before slow worktree
+// preparation. The operation can be polled by either request or operation id.
+func (c *Client) StartDelegation(sourceSessionID, brief string, opts DelegateOptions) (*protocol.DelegationOperation, error) {
+	requestID := strings.TrimSpace(opts.RequestID)
+	if requestID == "" {
+		requestID = uuid.NewString()
+	}
 	msg := protocol.DelegateMessage{
 		Cmd:             protocol.CmdDelegate,
+		RequestID:       requestID,
 		SourceSessionID: sourceSessionID,
 		Brief:           brief,
 	}
@@ -197,6 +206,9 @@ func (c *Client) Delegate(sourceSessionID, brief string, opts DelegateOptions) (
 	}
 	if opts.Yolo {
 		msg.YoloMode = protocol.Ptr(true)
+	}
+	if opts.AllowWorktreeReuse {
+		msg.AllowWorktreeReuse = protocol.Ptr(true)
 	}
 	if value := strings.TrimSpace(opts.Placement); value != "" {
 		msg.Placement = protocol.Ptr(value)
@@ -225,10 +237,44 @@ func (c *Client) Delegate(sourceSessionID, brief string, opts DelegateOptions) (
 	if err != nil {
 		return nil, err
 	}
-	if resp.DelegateResult == nil {
-		return nil, errors.New("daemon returned no delegation result")
+	if resp.DelegationOperation == nil {
+		return nil, errors.New("daemon returned no delegation operation")
 	}
-	return resp.DelegateResult, nil
+	return resp.DelegationOperation, nil
+}
+
+func (c *Client) DelegationStatus(id string) (*protocol.DelegationOperation, error) {
+	resp, err := c.send(protocol.DelegateStatusMessage{Cmd: protocol.CmdDelegateStatus, ID: strings.TrimSpace(id)})
+	if err != nil {
+		return nil, err
+	}
+	if resp.DelegationOperation == nil {
+		return nil, errors.New("daemon returned no delegation operation")
+	}
+	return resp.DelegationOperation, nil
+}
+
+// Delegate preserves the original blocking API for in-process callers while
+// using the durable accepted operation underneath.
+func (c *Client) Delegate(sourceSessionID, brief string, opts DelegateOptions) (*protocol.DelegateResult, error) {
+	op, err := c.StartDelegation(sourceSessionID, brief, opts)
+	if err != nil {
+		return nil, err
+	}
+	for op.State == protocol.DelegationOperationStateAccepted || op.State == protocol.DelegationOperationStatePreparing {
+		time.Sleep(100 * time.Millisecond)
+		op, err = c.DelegationStatus(op.OperationID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if op.State == protocol.DelegationOperationStateFailed {
+		return nil, fmt.Errorf("delegation failed: %s", protocol.Deref(op.Error))
+	}
+	if op.Result == nil {
+		return nil, errors.New("completed delegation has no result")
+	}
+	return op.Result, nil
 }
 
 // SetTicketStatus reports a work state and moves a ticket to the matching

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -348,17 +348,20 @@ func TestClient_Delegate(t *testing.T) {
 
 		json.NewEncoder(conn).Encode(protocol.Response{
 			Ok: true,
-			DelegateResult: &protocol.DelegateResult{
-				SessionID:   "delegated-session",
-				WorkspaceID: "workspace-1",
-				Directory:   "/tmp/project",
-				Placement:   "new_workspace",
+			DelegationOperation: &protocol.DelegationOperation{
+				OperationID: "operation-1", RequestID: "request-1", SessionID: "delegated-session",
+				State: protocol.DelegationOperationStateCompleted,
+				Result: &protocol.DelegateResult{
+					SessionID: "delegated-session", WorkspaceID: "workspace-1",
+					Directory: "/tmp/project", Placement: "new_workspace",
+				},
 			},
 		})
 	}()
 
 	c := New(sockPath)
 	result, err := c.Delegate("source-session", "Investigate the parser", DelegateOptions{
+		RequestID:    "request-1",
 		Agent:        "codex",
 		Model:        "gpt-5.2-codex",
 		Effort:       "high",

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -154,7 +154,11 @@ type Daemon struct {
 	ticketReconcilePRFetch prStateFetcher
 	// ticketArtifactMu serializes attach installation with its durable ticket
 	// receipt so concurrent submissions cannot race on destination names.
-	ticketArtifactMu sync.Mutex
+	ticketArtifactMu  sync.Mutex
+	delegationMu      sync.Mutex
+	delegationRunning map[string]bool
+	// deterministic slow-preparation seam used by delegation idempotency tests.
+	delegationWorktreePrepareHook func(path string)
 	// reloadingSessions marks sessions whose agent is being re-spawned in place
 	// (chief-of-staff assign/demote reload). handlePTYExit consumes the flag to
 	// suppress the killed worker's session_exited so the reload reads as a runtime
@@ -860,6 +864,11 @@ func (d *Daemon) Start() error {
 	go func() {
 		d.performStartupPTYRecovery(recoveryStartedAt)
 		d.setRecovering(false)
+		// A pending delegation may have spawned its stable runtime ID just
+		// before the daemon stopped. Resume only after worker reconciliation has
+		// adopted any surviving runtime into the session store; absence is then
+		// authoritative enough to launch the reserved ID once.
+		d.resumePendingDelegations()
 	}()
 
 	// Note: No background persistence needed - SQLite persists immediately
@@ -2024,6 +2033,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleRegister(conn, msg.(*protocol.RegisterMessage))
 	case protocol.CmdDelegate:
 		d.handleDelegate(conn, msg.(*protocol.DelegateMessage))
+	case protocol.CmdDelegateStatus:
+		d.handleDelegateStatus(conn, msg.(*protocol.DelegateStatusMessage))
 	case protocol.CmdSetTicketStatus:
 		d.handleSetTicketStatus(conn, msg.(*protocol.SetTicketStatusMessage))
 	case protocol.CmdTicketInbox:

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/google/uuid"
 	agentdriver "github.com/victorarias/attn/internal/agent"
@@ -19,6 +20,7 @@ const (
 	delegationPlacementCurrent  = "current_workspace"
 	delegationPlacementExisting = "existing_workspace"
 	delegationPlacementNew      = "new_workspace"
+	delegationWorktreeOwnerFile = "attn-delegation-owner"
 )
 
 type internalActionResult struct {
@@ -187,6 +189,24 @@ func validateDelegationDirectory(path string) (string, error) {
 	return path, nil
 }
 
+func (d *Daemon) activeSessionInLinkedWorktree(directory string) (string, bool) {
+	worktreeRoot, err := git.GetRepoRoot(directory)
+	if err != nil || git.GetMainRepoFromWorktree(worktreeRoot) == "" {
+		return "", false
+	}
+	worktreeRoot = git.CanonicalizePath(worktreeRoot)
+	for _, session := range d.store.List("") {
+		if session.State == protocol.SessionStateIdle {
+			continue
+		}
+		sessionRoot, err := git.GetRepoRoot(session.Directory)
+		if err == nil && git.CanonicalizePath(sessionRoot) == worktreeRoot {
+			return worktreeRoot, true
+		}
+	}
+	return worktreeRoot, false
+}
+
 func (d *Daemon) rollbackDelegation(createdWorkspaceID, createdWorktreePath string, cause error) error {
 	if createdWorkspaceID != "" {
 		d.handleUnregisterWorkspace(nil, &protocol.UnregisterWorkspaceMessage{
@@ -203,18 +223,99 @@ func (d *Daemon) rollbackDelegation(createdWorkspaceID, createdWorktreePath stri
 	return cause
 }
 
-func (d *Daemon) createDelegationWorktree(baseDirectory string, request *protocol.DelegateWorktreeRequest) (string, error) {
+func delegationWorktreeOwnerPath(worktreePath string) (string, error) {
+	out, err := git.Output(git.OpMetadata, worktreePath, "rev-parse", "--git-path", delegationWorktreeOwnerFile)
+	if err != nil {
+		return "", fmt.Errorf("resolve delegation worktree owner marker: %w", err)
+	}
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		return "", fmt.Errorf("resolve delegation worktree owner marker: git returned an empty path")
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(worktreePath, path)
+	}
+	return filepath.Clean(path), nil
+}
+
+func writeDelegationWorktreeOwner(worktreePath, token string) error {
+	path, err := delegationWorktreeOwnerPath(worktreePath)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write delegation worktree owner marker: %w", err)
+	}
+	return nil
+}
+
+func verifyDelegationWorktreeOwner(worktreePath, token string) error {
+	path, err := delegationWorktreeOwnerPath(worktreePath)
+	if err != nil {
+		return err
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read delegation worktree owner marker: %w", err)
+	}
+	if token == "" || strings.TrimSpace(string(contents)) != token {
+		return fmt.Errorf("delegation worktree owner marker does not match")
+	}
+	return nil
+}
+
+func (d *Daemon) createDelegationWorktree(baseDirectory string, request *protocol.DelegateWorktreeRequest, operationID, ownedPath string, worktreeOwned bool, ownedToken string, allowReuse bool) (string, bool, error) {
 	branch := strings.TrimSpace(request.Branch)
 	if branch == "" {
-		return "", fmt.Errorf("worktree branch is required")
+		return "", false, fmt.Errorf("worktree branch is required")
 	}
 	repo := strings.TrimSpace(protocol.Deref(request.Repo))
 	if repo == "" {
 		repoRoot, err := git.GetRepoRoot(baseDirectory)
 		if err != nil {
-			return "", fmt.Errorf("workspace directory is not in a git repository; pass --repo")
+			return "", false, fmt.Errorf("workspace directory is not in a git repository; pass --repo")
 		}
 		repo = git.ResolveMainRepoPath(repoRoot)
+	}
+	expectedPath := strings.TrimSpace(protocol.Deref(request.Path))
+	if expectedPath == "" {
+		expectedPath = git.GenerateWorktreePath(repo, branch)
+	}
+	expectedPath = git.CanonicalizePath(expectedPath)
+	if _, statErr := os.Stat(expectedPath); statErr == nil {
+		wt := d.discoverWorktree(expectedPath)
+		if wt == nil || strings.TrimSpace(wt.Branch) != branch {
+			return "", false, fmt.Errorf("worktree path already exists and is not branch %q: %s", branch, expectedPath)
+		}
+		if allowReuse {
+			return expectedPath, false, nil
+		}
+		if worktreeOwned && git.CanonicalizePath(ownedPath) == expectedPath {
+			if err := verifyDelegationWorktreeOwner(expectedPath, ownedToken); err != nil {
+				return "", false, fmt.Errorf("worktree %s was created before delegation preparation was interrupted, but its current ownership cannot be proven (%v), so it was left untouched", expectedPath, err)
+			}
+			return expectedPath, true, nil
+		}
+		if operationID != "" && ownedPath != "" && git.CanonicalizePath(ownedPath) == expectedPath {
+			// Git creation and SQLite ownership cannot be one atomic transaction.
+			// A crash after `git worktree add` but before Mark...Owned leaves the
+			// path ambiguous: it may be ours, or another actor may have created it
+			// after the durable intent record. The product contract permits a
+			// terminal failure on restart; never adopt or delete without proof.
+			return "", false, fmt.Errorf("worktree %s appeared while delegation preparation was interrupted; ownership cannot be proven, so it was left untouched", expectedPath)
+		}
+		return "", false, fmt.Errorf("worktree %s already exists; pass --allow-worktree-reuse only when sharing it is intentional", expectedPath)
+	} else if !os.IsNotExist(statErr) {
+		return "", false, fmt.Errorf("inspect delegated worktree path: %w", statErr)
+	}
+	if operationID != "" {
+		if err := d.store.UpdateDelegationOperation(operationID, protocol.DelegationOperationStatePreparing,
+			"preparing worktree "+expectedPath, "", "", expectedPath, nil, nil, time.Now()); err != nil {
+			return "", false, fmt.Errorf("record delegated worktree preparation: %w", err)
+		}
+	}
+	if d.delegationWorktreePrepareHook != nil {
+		d.delegationWorktreePrepareHook(expectedPath)
 	}
 	startingFrom := request.StartingFrom
 	if strings.TrimSpace(protocol.Deref(startingFrom)) == "" {
@@ -237,14 +338,57 @@ func (d *Daemon) createDelegationWorktree(baseDirectory string, request *protoco
 	})
 	if err != nil {
 		if worktreePath != "" {
-			return "", d.rollbackDelegation("", worktreePath, fmt.Errorf("create delegated worktree: %w", err))
+			return "", false, d.rollbackDelegation("", worktreePath, fmt.Errorf("create delegated worktree: %w", err))
 		}
-		return "", fmt.Errorf("create delegated worktree: %w", err)
+		return "", false, fmt.Errorf("create delegated worktree: %w", err)
 	}
-	return worktreePath, nil
+	if operationID != "" {
+		ownerToken := uuid.NewString()
+		if err := writeDelegationWorktreeOwner(worktreePath, ownerToken); err != nil {
+			return "", false, d.rollbackDelegation("", worktreePath, err)
+		}
+		if err := d.store.MarkDelegationWorktreeOwned(operationID, worktreePath, ownerToken, time.Now()); err != nil {
+			return "", false, d.rollbackDelegation("", worktreePath, fmt.Errorf("record delegated worktree ownership: %w", err))
+		}
+	}
+	return worktreePath, true, nil
 }
 
 func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResult, error) {
+	return d.delegateOperation(msg, "", "", "", false, "", "")
+}
+
+func (d *Daemon) spawnDelegatedRuntime(msg *protocol.DelegateMessage, sessionID, workspaceID, directory, name, agent, model, effort, brief string, trackedByChief bool) error {
+	initialPrompt := brief
+	if trackedByChief {
+		initialPrompt = delegatedTicketPrompt(brief)
+	}
+	initialPrompt = withLeafIdentity(initialPrompt)
+	spawnMsg := &protocol.SpawnSessionMessage{
+		Cmd:           protocol.CmdSpawnSession,
+		ID:            sessionID,
+		Cwd:           directory,
+		WorkspaceID:   workspaceID,
+		Agent:         agent,
+		Cols:          80,
+		Rows:          24,
+		Label:         protocol.Ptr(name),
+		YoloMode:      msg.YoloMode,
+		InitialPrompt: protocol.Ptr(initialPrompt),
+	}
+	if model != "" {
+		spawnMsg.Model = protocol.Ptr(model)
+	}
+	if effort != "" {
+		spawnMsg.Effort = protocol.Ptr(effort)
+	}
+	spawnClient := newInternalWSClient()
+	d.handleSpawnSession(spawnClient, spawnMsg)
+	_, err := readInternalActionResult(spawnClient)
+	return err
+}
+
+func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, reservedSessionID, ownedWorktreePath string, worktreeOwned bool, worktreeToken, initiatingChiefSessionID string) (*protocol.DelegateResult, error) {
 	sourceSessionID := strings.TrimSpace(msg.SourceSessionID)
 	if sourceSessionID == "" {
 		return nil, fmt.Errorf("source_session_id is required")
@@ -272,15 +416,71 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 	// name is the explicit --name, or empty to default to the directory basename
 	// once the directory is finalized below.
 	name := strings.TrimSpace(protocol.Deref(msg.Label))
-	sessionID := uuid.NewString()
-	chiefSessionID := d.chiefOfStaffSessionID()
-	trackedByChief := chiefSessionID == sourceSessionID
+	sessionID := reservedSessionID
+	if sessionID == "" {
+		sessionID = uuid.NewString()
+	}
+	chiefSessionID := initiatingChiefSessionID
+	if operationID == "" && d.chiefOfStaffSessionID() == sourceSessionID {
+		chiefSessionID = sourceSessionID
+	}
+	trackedByChief := chiefSessionID != ""
 	paneID := "pane-" + sessionID
 	placement := delegationPlacement(msg)
 	workspaceID := ""
 	directory := ""
 	createdWorkspaceID := ""
 	createdWorktreePath := ""
+	operationWorktreePath := ""
+	if existing := d.store.Get(sessionID); existing != nil {
+		expectedWorkspaceID := ""
+		switch placement {
+		case delegationPlacementCurrent:
+			expectedWorkspaceID = source.WorkspaceID
+		case delegationPlacementExisting:
+			expectedWorkspaceID = strings.TrimSpace(protocol.Deref(msg.WorkspaceID))
+		case delegationPlacementNew:
+			expectedWorkspaceID = "workspace-" + sessionID
+		}
+		if existing.WorkspaceID == "" && expectedWorkspaceID != "" {
+			d.store.AssignSessionWorkspace(sessionID, expectedWorkspaceID)
+			existing.WorkspaceID = expectedWorkspaceID
+		}
+		if name != "" && existing.Label != name {
+			d.store.UpdateSessionLabel(sessionID, name)
+			existing.Label = name
+		}
+		if !d.sessionHasLiveWorker(sessionID) {
+			if operationID != "" {
+				_ = d.store.UpdateDelegationOperation(operationID, protocol.DelegationOperationStatePreparing,
+					"recovering delegated runtime", existing.WorkspaceID, "", existing.Directory, nil, nil, time.Now())
+			}
+			if err := d.spawnDelegatedRuntime(msg, sessionID, existing.WorkspaceID, existing.Directory, existing.Label, agent, model, effort, brief, trackedByChief); err != nil {
+				return nil, fmt.Errorf("recover delegated session runtime: %w", err)
+			}
+		}
+		if trackedByChief {
+			ticket, ticketErr := d.store.ActiveTicketForSession(sessionID)
+			if ticketErr != nil {
+				return nil, ticketErr
+			}
+			if ticket == nil {
+				ticketID, ticketErr := d.createDelegatedTicket(chiefSessionID, existing, brief, existing.Label, agent)
+				if ticketErr != nil {
+					return nil, ticketErr
+				}
+				if operationID != "" {
+					worktreePath := ""
+					if msg.Worktree != nil {
+						worktreePath = existing.Directory
+					}
+					_ = d.store.UpdateDelegationOperation(operationID, protocol.DelegationOperationStatePreparing,
+						"recovered delegated ticket", existing.WorkspaceID, ticketID, worktreePath, nil, nil, time.Now())
+				}
+			}
+		}
+		return d.completedDelegationResult(existing, placement, worktreeOwned), nil
+	}
 
 	switch placement {
 	case delegationPlacementCurrent:
@@ -340,18 +540,20 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 	}
 
 	if msg.Worktree != nil {
-		worktreePath, createErr := d.createDelegationWorktree(directory, msg.Worktree)
+		worktreePath, created, createErr := d.createDelegationWorktree(directory, msg.Worktree, operationID, ownedWorktreePath, worktreeOwned, worktreeToken, protocol.Deref(msg.AllowWorktreeReuse))
 		if createErr != nil {
 			return nil, createErr
 		}
-		createdWorktreePath = worktreePath
+		if created {
+			createdWorktreePath = worktreePath
+		}
 		validatedDirectory, directoryErr := validateDelegationDirectory(worktreePath)
 		if directoryErr != nil {
 			return nil, d.rollbackDelegation("", createdWorktreePath, directoryErr)
 		}
 		directory = validatedDirectory
+		operationWorktreePath = directory
 	}
-
 	// Finalize a new workspace's directory before resolving the name so a
 	// directory-basename default reflects the real directory.
 	if placement == delegationPlacementNew {
@@ -360,6 +562,11 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 			return nil, d.rollbackDelegation("", createdWorktreePath, directoryErr)
 		}
 		directory = validatedDirectory
+	}
+	if worktreeRoot, occupied := d.activeSessionInLinkedWorktree(directory); occupied && !protocol.Deref(msg.AllowWorktreeReuse) {
+		// Once another active session occupies the worktree, it is no longer safe
+		// to roll the directory back even if this operation originally created it.
+		return nil, fmt.Errorf("an active session already uses worktree %s; pass --allow-worktree-reuse only when sharing it is intentional", worktreeRoot)
 	}
 
 	// Default the name to the directory basename when --name was not given, then
@@ -385,45 +592,33 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 		}
 		createdWorkspaceID = workspaceID
 	}
-
-	paneClient := newInternalWSClient()
-	d.handleWorkspaceLayoutAddSessionPane(paneClient, &protocol.WorkspaceLayoutAddSessionPaneMessage{
-		Cmd:         protocol.CmdWorkspaceLayoutAddSessionPane,
-		WorkspaceID: workspaceID,
-		PaneID:      protocol.Ptr(paneID),
-		SessionID:   sessionID,
-		Title:       protocol.Ptr(name),
-	})
-	if _, err := readInternalActionResult(paneClient); err != nil {
-		return nil, d.rollbackDelegation(createdWorkspaceID, createdWorktreePath, fmt.Errorf("create delegated pane: %w", err))
+	if operationID != "" {
+		if err := d.store.UpdateDelegationOperation(operationID, protocol.DelegationOperationStatePreparing,
+			"assembling workspace and session", workspaceID, "", operationWorktreePath, nil, nil, time.Now()); err != nil {
+			return nil, d.rollbackDelegation(createdWorkspaceID, createdWorktreePath, err)
+		}
 	}
 
-	spawnClient := newInternalWSClient()
-	initialPrompt := brief
-	if trackedByChief {
-		initialPrompt = delegatedTicketPrompt(brief)
+	if existingWorkspaceID, _, found := d.store.FindWorkspaceLayoutPaneBySessionID(sessionID); found {
+		if existingWorkspaceID != workspaceID {
+			return nil, d.rollbackDelegation(createdWorkspaceID, createdWorktreePath,
+				fmt.Errorf("reserved delegated pane belongs to workspace %s, want %s", existingWorkspaceID, workspaceID))
+		}
+	} else {
+		paneClient := newInternalWSClient()
+		d.handleWorkspaceLayoutAddSessionPane(paneClient, &protocol.WorkspaceLayoutAddSessionPaneMessage{
+			Cmd:         protocol.CmdWorkspaceLayoutAddSessionPane,
+			WorkspaceID: workspaceID,
+			PaneID:      protocol.Ptr(paneID),
+			SessionID:   sessionID,
+			Title:       protocol.Ptr(name),
+		})
+		if _, err := readInternalActionResult(paneClient); err != nil {
+			return nil, d.rollbackDelegation(createdWorkspaceID, createdWorktreePath, fmt.Errorf("create delegated pane: %w", err))
+		}
 	}
-	initialPrompt = withLeafIdentity(initialPrompt)
-	spawnMsg := &protocol.SpawnSessionMessage{
-		Cmd:           protocol.CmdSpawnSession,
-		ID:            sessionID,
-		Cwd:           directory,
-		WorkspaceID:   workspaceID,
-		Agent:         agent,
-		Cols:          80,
-		Rows:          24,
-		Label:         protocol.Ptr(name),
-		YoloMode:      msg.YoloMode,
-		InitialPrompt: protocol.Ptr(initialPrompt),
-	}
-	if model != "" {
-		spawnMsg.Model = protocol.Ptr(model)
-	}
-	if effort != "" {
-		spawnMsg.Effort = protocol.Ptr(effort)
-	}
-	d.handleSpawnSession(spawnClient, spawnMsg)
-	if _, err := readInternalActionResult(spawnClient); err != nil {
+
+	if err := d.spawnDelegatedRuntime(msg, sessionID, workspaceID, directory, name, agent, model, effort, brief, trackedByChief); err != nil {
 		d.removeWorkspaceLayoutPaneForSession(sessionID)
 		return nil, d.rollbackDelegation(createdWorkspaceID, createdWorktreePath, fmt.Errorf("spawn delegated session: %w", err))
 	}
@@ -454,6 +649,10 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 			)
 		}
 		d.logf("delegate: bound ticket %q to session %s", ticketID, session.ID)
+		if operationID != "" {
+			_ = d.store.UpdateDelegationOperation(operationID, protocol.DelegationOperationStatePreparing,
+				"delegated session and ticket created", workspaceID, ticketID, operationWorktreePath, nil, nil, time.Now())
+		}
 		d.broadcastTicketsUpdated()
 	}
 	result := &protocol.DelegateResult{
@@ -469,6 +668,19 @@ func (d *Daemon) delegate(msg *protocol.DelegateMessage) (*protocol.DelegateResu
 		result.Branch = protocol.Ptr(strings.TrimSpace(*session.Branch))
 	}
 	return result, nil
+}
+
+func (d *Daemon) completedDelegationResult(session *protocol.Session, placement string, worktreeCreated bool) *protocol.DelegateResult {
+	result := &protocol.DelegateResult{
+		SessionID: session.ID, WorkspaceID: session.WorkspaceID, Directory: session.Directory, Placement: placement,
+	}
+	if worktreeCreated {
+		result.WorktreeCreated = protocol.Ptr(true)
+	}
+	if branch := strings.TrimSpace(protocol.Deref(session.Branch)); branch != "" {
+		result.Branch = protocol.Ptr(branch)
+	}
+	return result
 }
 
 // leafIdentityPreamble is prepended to every delegated agent's initial prompt.
@@ -536,19 +748,44 @@ the user.`
 }
 
 func (d *Daemon) handleDelegate(conn net.Conn, msg *protocol.DelegateMessage) {
-	result, err := d.delegate(msg)
+	operation, err := d.startDelegation(msg)
 	if err != nil {
 		d.sendError(conn, "delegate: "+err.Error())
 		return
 	}
 	_ = json.NewEncoder(conn).Encode(protocol.Response{
-		Ok:             true,
-		DelegateResult: result,
+		Ok:                  true,
+		DelegationOperation: operation,
 	})
 }
 
+func (d *Daemon) handleDelegateStatus(conn net.Conn, msg *protocol.DelegateStatusMessage) {
+	operation, err := d.delegationOperation(msg.ID)
+	if err != nil {
+		d.sendError(conn, "delegate status: "+err.Error())
+		return
+	}
+	_ = json.NewEncoder(conn).Encode(protocol.Response{Ok: true, DelegationOperation: operation})
+}
+
 func (d *Daemon) handleDelegateWS(client *wsClient, msg *protocol.DelegateMessage) {
-	result, err := d.delegate(msg)
+	operation, err := d.startDelegation(msg)
+	if err == nil {
+		for operation.State == protocol.DelegationOperationStateAccepted || operation.State == protocol.DelegationOperationStatePreparing {
+			time.Sleep(100 * time.Millisecond)
+			operation, err = d.delegationOperation(operation.OperationID)
+			if err != nil {
+				break
+			}
+		}
+	}
+	var result *protocol.DelegateResult
+	if operation != nil {
+		result = operation.Result
+		if operation.State == protocol.DelegationOperationStateFailed && operation.Error != nil {
+			err = fmt.Errorf("%s", protocol.Deref(operation.Error))
+		}
+	}
 	response := protocol.DelegateResultMessage{
 		Event:   protocol.EventDelegateResult,
 		Success: err == nil,

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -955,6 +955,84 @@ func TestDelegateTruncatesLongWorktreeDefaultName(t *testing.T) {
 	}
 }
 
+func TestDelegateRejectsActiveWorktreeCollisionWithoutExplicitReuse(t *testing.T) {
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitDaemon(t, mainRepo, "init")
+	runGitDaemon(t, mainRepo, "commit", "--allow-empty", "-m", "init")
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSourceAt(t, d, backend, mainRepo)
+	consumeDelegatedPrompt(t, backend)
+	worktreePath := filepath.Join(root, "repo--shared")
+	base := protocol.DelegateMessage{
+		Cmd: protocol.CmdDelegate, SourceSessionID: sourceSessionID, Brief: "First owner.",
+		Agent: protocol.Ptr("codex"), Label: protocol.Ptr("owner"), Placement: protocol.Ptr(delegationPlacementNew),
+		Worktree: &protocol.DelegateWorktreeRequest{Repo: protocol.Ptr(mainRepo), Branch: "feat/shared", Path: protocol.Ptr(worktreePath)},
+	}
+	if _, err := d.delegate(&base); err != nil {
+		t.Fatalf("first delegate: %v", err)
+	}
+
+	retry := base
+	retry.Brief = "Unintentional second owner."
+	retry.Label = protocol.Ptr("collision")
+	retry.Placement = protocol.Ptr(delegationPlacementCurrent)
+	if _, err := d.delegate(&retry); err == nil || !strings.Contains(err.Error(), "--allow-worktree-reuse") {
+		t.Fatalf("collision error=%v, want explicit reuse guidance", err)
+	}
+	retry.AllowWorktreeReuse = protocol.Ptr(true)
+	result, err := d.delegate(&retry)
+	if err != nil {
+		t.Fatalf("explicit reuse: %v", err)
+	}
+	if result.Directory != git.CanonicalizePath(worktreePath) {
+		t.Fatalf("directory=%q want %q", result.Directory, worktreePath)
+	}
+
+	byCWD := protocol.DelegateMessage{
+		Cmd: protocol.CmdDelegate, SourceSessionID: sourceSessionID, Brief: "CWD collision.",
+		Agent: protocol.Ptr("codex"), Label: protocol.Ptr("cwd-collision"),
+		Placement: protocol.Ptr(delegationPlacementNew), Cwd: protocol.Ptr(worktreePath),
+	}
+	if main := git.GetMainRepoFromWorktree(worktreePath); main == "" {
+		t.Fatal("test setup did not produce a linked worktree")
+	}
+	if !d.store.HasSessionInDirectory(git.CanonicalizePath(worktreePath)) {
+		t.Fatal("test setup has no active session in shared worktree")
+	}
+	if protocol.Deref(byCWD.AllowWorktreeReuse) {
+		t.Fatal("cwd collision unexpectedly opted into reuse")
+	}
+	if _, err := d.delegate(&byCWD); err == nil || !strings.Contains(err.Error(), "--allow-worktree-reuse") {
+		t.Fatalf("cwd collision error=%v, want explicit reuse guidance", err)
+	}
+	byCWD.AllowWorktreeReuse = protocol.Ptr(true)
+	if _, err := d.delegate(&byCWD); err != nil {
+		t.Fatalf("explicit cwd reuse: %v", err)
+	}
+
+	subdir := filepath.Join(worktreePath, "nested", "package")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bySubdir := protocol.DelegateMessage{
+		Cmd: protocol.CmdDelegate, SourceSessionID: sourceSessionID, Brief: "Nested CWD collision.",
+		Agent: protocol.Ptr("codex"), Label: protocol.Ptr("nested-collision"),
+		Placement: protocol.Ptr(delegationPlacementNew), Cwd: protocol.Ptr(subdir),
+	}
+	if _, err := d.delegate(&bySubdir); err == nil || !strings.Contains(err.Error(), git.CanonicalizePath(worktreePath)) {
+		t.Fatalf("nested cwd collision error=%v, want resolved worktree root", err)
+	}
+	bySubdir.AllowWorktreeReuse = protocol.Ptr(true)
+	if _, err := d.delegate(&bySubdir); err != nil {
+		t.Fatalf("explicit nested cwd reuse: %v", err)
+	}
+}
+
 func TestTruncateDelegationName(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/internal/daemon/delegation_operation.go
+++ b/internal/daemon/delegation_operation.go
@@ -1,0 +1,155 @@
+package daemon
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func (d *Daemon) startDelegation(msg *protocol.DelegateMessage) (*protocol.DelegationOperation, error) {
+	requestID := strings.TrimSpace(msg.RequestID)
+	if requestID == "" {
+		// Compatibility for older websocket clients. The CLI always supplies and
+		// prints a stable key, which is the recoverable retry contract.
+		requestID = uuid.NewString()
+	}
+	if strings.HasPrefix(requestID, "op-") {
+		return nil, fmt.Errorf("request_id uses reserved operation prefix op-")
+	}
+	msg.RequestID = requestID
+	msg.Cmd = protocol.CmdDelegate
+	encoded, err := json.Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("encode delegation request: %w", err)
+	}
+	chiefSessionID := ""
+	if currentChief := d.chiefOfStaffSessionID(); currentChief == strings.TrimSpace(msg.SourceSessionID) {
+		chiefSessionID = currentChief
+	}
+	record, claimed, err := d.store.ClaimDelegationOperation(requestID, "op-"+uuid.NewString(), uuid.NewString(), chiefSessionID, string(encoded), time.Now())
+	if err != nil {
+		return nil, err
+	}
+	if claimed || record.Operation.State == protocol.DelegationOperationStateAccepted || record.Operation.State == protocol.DelegationOperationStatePreparing {
+		go d.runDelegationOperation(record.Operation.OperationID)
+	}
+	return &record.Operation, nil
+}
+
+func (d *Daemon) runDelegationOperation(id string) {
+	if !d.beginDelegationRun(id) {
+		return
+	}
+	defer d.endDelegationRun(id)
+	record, err := d.store.GetDelegationOperation(id)
+	if err != nil {
+		d.logf("delegate operation %s disappeared: %v", id, err)
+		return
+	}
+	if record.Operation.State == protocol.DelegationOperationStateCompleted || record.Operation.State == protocol.DelegationOperationStateFailed {
+		return
+	}
+	_ = d.store.UpdateDelegationOperation(id, protocol.DelegationOperationStatePreparing,
+		"validating delegation request", "", "", "", nil, nil, time.Now())
+	var msg protocol.DelegateMessage
+	if err := json.Unmarshal([]byte(record.RequestJSON), &msg); err != nil {
+		d.finishDelegationFailure(id, fmt.Errorf("decode accepted delegation request: %w", err))
+		return
+	}
+	result, launchErr := d.delegateOperation(&msg, id, record.Operation.SessionID, protocol.Deref(record.Operation.WorktreePath), record.WorktreeOwned, record.WorktreeToken, record.ChiefSessionID)
+	if launchErr != nil {
+		d.finishDelegationFailure(id, launchErr)
+		return
+	}
+	d.persistDelegationTerminal(id, protocol.DelegationOperationStateCompleted,
+		"delegation ready", result.WorkspaceID, "", result, nil)
+}
+
+func (d *Daemon) finishDelegationFailure(id string, err error) {
+	d.persistDelegationTerminal(id, protocol.DelegationOperationStateFailed,
+		"delegation failed", "", "", nil, err)
+}
+
+// Terminal persistence is part of completing the launch operation, not
+// best-effort bookkeeping. If SQLite temporarily rejects the write after
+// externally visible side effects, keep one finisher alive so callers cannot be
+// stranded polling a permanently preparing record. Daemon restart is the other
+// recovery boundary: pending records are resumed from the durable journal.
+func (d *Daemon) persistDelegationTerminal(id string, state protocol.DelegationOperationState, progress, workspaceID, worktreePath string, result *protocol.DelegateResult, operationErr error) {
+	delay := 100 * time.Millisecond
+	for {
+		if err := d.store.UpdateDelegationOperation(id, state, progress, workspaceID, "", worktreePath, result, operationErr, time.Now()); err == nil {
+			return
+		} else {
+			d.logf("persist terminal delegation operation %s: %v", id, err)
+		}
+		select {
+		case <-d.done:
+			return
+		case <-time.After(delay):
+			if delay < 5*time.Second {
+				delay *= 2
+			}
+		}
+	}
+}
+
+func (d *Daemon) beginDelegationRun(id string) bool {
+	d.delegationMu.Lock()
+	defer d.delegationMu.Unlock()
+	if d.delegationRunning == nil {
+		d.delegationRunning = make(map[string]bool)
+	}
+	if d.delegationRunning[id] {
+		return false
+	}
+	d.delegationRunning[id] = true
+	return true
+}
+
+func (d *Daemon) endDelegationRun(id string) {
+	d.delegationMu.Lock()
+	delete(d.delegationRunning, id)
+	d.delegationMu.Unlock()
+}
+
+func (d *Daemon) delegationOperation(id string) (*protocol.DelegationOperation, error) {
+	record, err := d.store.GetDelegationOperation(strings.TrimSpace(id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("delegation operation not found: %s", id)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &record.Operation, nil
+}
+
+func (d *Daemon) resumePendingDelegations() {
+	records, err := d.store.PendingDelegationOperations()
+	if err != nil {
+		d.logf("load pending delegation operations: %v", err)
+		return
+	}
+	for i := range records {
+		go d.runDelegationOperation(records[i].Operation.OperationID)
+	}
+}
+
+func (d *Daemon) handleDelegateStatusWS(client *wsClient, msg *protocol.DelegateStatusMessage) {
+	operation, err := d.delegationOperation(msg.ID)
+	response := protocol.DelegationOperationMessage{
+		Event:     protocol.EventDelegationOperation,
+		Success:   err == nil,
+		Operation: operation,
+	}
+	if err != nil {
+		response.Error = protocol.Ptr(err.Error())
+	}
+	d.sendToClient(client, response)
+}

--- a/internal/daemon/delegation_operation_test.go
+++ b/internal/daemon/delegation_operation_test.go
@@ -1,0 +1,494 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/store"
+)
+
+func waitDelegationOperation(t *testing.T, d *Daemon, id string) *protocol.DelegationOperation {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		op, err := d.delegationOperation(id)
+		if err != nil {
+			t.Fatalf("delegationOperation(%s): %v", id, err)
+		}
+		if op.State == protocol.DelegationOperationStateCompleted || op.State == protocol.DelegationOperationStateFailed {
+			return op
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for delegation operation %s", id)
+	return nil
+}
+
+func TestDelegationOperationSequentialAndResponseLossRetryConverge(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceID, _ := setupDelegationSource(t, d, backend)
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, sourceID); err != nil {
+		t.Fatal(err)
+	}
+	consumeDelegatedPrompt(t, backend)
+	msg := &protocol.DelegateMessage{Cmd: protocol.CmdDelegate, RequestID: "stable-request", SourceSessionID: sourceID, Brief: "Do the work once.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("once")}
+
+	first, err := d.startDelegation(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate losing the first accepted/final response: the caller retains only
+	// its request key and invokes the same logical request again.
+	second, err := d.startDelegation(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.OperationID != second.OperationID || first.SessionID != second.SessionID {
+		t.Fatalf("retries diverged: first=%+v second=%+v", first, second)
+	}
+	done := waitDelegationOperation(t, d, first.OperationID)
+	if done.Result == nil {
+		t.Fatalf("completed operation has no result: %+v", done)
+	}
+	if done.WorktreePath != nil {
+		t.Fatalf("ordinary delegation reported worktree_path=%q", protocol.Deref(done.WorktreePath))
+	}
+	if got := len(d.store.List("")); got != 2 {
+		t.Fatalf("sessions=%d, want source + one delegate", got)
+	}
+	tickets, err := d.store.ListTickets(store.TicketListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tickets) != 1 || tickets[0].Assignee != done.SessionID {
+		t.Fatalf("tickets=%+v, want exactly one bound ticket", tickets)
+	}
+}
+
+func TestDelegationOperationReservesOperationIDNamespace(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceID, _ := setupDelegationSource(t, d, backend)
+	_, err := d.startDelegation(&protocol.DelegateMessage{Cmd: protocol.CmdDelegate, RequestID: "op-caller-value", SourceSessionID: sourceID, Brief: "Must reject.", Agent: protocol.Ptr("codex")})
+	if err == nil || !strings.Contains(err.Error(), "reserved operation prefix") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestRecoveredDelegationResultDistinguishesReusedWorktree(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	session := &protocol.Session{ID: "session", WorkspaceID: "workspace", Directory: "/tmp/shared", IsWorktree: protocol.Ptr(true)}
+	reused := d.completedDelegationResult(session, delegationPlacementNew, false)
+	if reused.WorktreeCreated != nil {
+		t.Fatalf("reused worktree reported created=%v", protocol.Deref(reused.WorktreeCreated))
+	}
+	created := d.completedDelegationResult(session, delegationPlacementNew, true)
+	if !protocol.Deref(created.WorktreeCreated) {
+		t.Fatal("owned worktree lost created receipt")
+	}
+}
+
+func TestDelegationOperationConcurrentRetriesConverge(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+	msg := protocol.DelegateMessage{Cmd: protocol.CmdDelegate, RequestID: "concurrent-request", SourceSessionID: sourceID, Brief: "Launch once concurrently.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("parallel")}
+	const callers = 12
+	results := make(chan *protocol.DelegationOperation, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			copy := msg
+			op, err := d.startDelegation(&copy)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- op
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	operationID := ""
+	for op := range results {
+		if operationID == "" {
+			operationID = op.OperationID
+		}
+		if op.OperationID != operationID {
+			t.Fatalf("operation ids diverged: %s != %s", op.OperationID, operationID)
+		}
+	}
+	done := waitDelegationOperation(t, d, operationID)
+	if done.Result == nil || len(d.store.List("")) != 2 {
+		t.Fatalf("operation=%+v sessions=%d", done, len(d.store.List("")))
+	}
+}
+
+func TestDelegationOperationAcceptedBeforeSlowPreparation(t *testing.T) {
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitDaemon(t, mainRepo, "init")
+	runGitDaemon(t, mainRepo, "commit", "--allow-empty", "-m", "init")
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceID, _ := setupDelegationSourceAt(t, d, backend, mainRepo)
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, sourceID); err != nil {
+		t.Fatal(err)
+	}
+	consumeDelegatedPrompt(t, backend)
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	d.delegationWorktreePrepareHook = func(string) {
+		entered <- struct{}{}
+		<-release
+	}
+	start := time.Now()
+	op, err := d.startDelegation(&protocol.DelegateMessage{
+		Cmd: protocol.CmdDelegate, RequestID: "slow-request", SourceSessionID: sourceID,
+		Brief: "Slow worktree launch.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("slow"),
+		Worktree: &protocol.DelegateWorktreeRequest{Repo: protocol.Ptr(mainRepo), Branch: "feat/slow", Path: protocol.Ptr(filepath.Join(root, "repo--slow"))},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Since(start) > 100*time.Millisecond {
+		t.Fatalf("durable acceptance was not prompt: %v", time.Since(start))
+	}
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("launch did not reach controlled slow seam")
+	}
+	inProgress, err := d.delegationOperation(op.RequestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inProgress.State != protocol.DelegationOperationStatePreparing {
+		t.Fatalf("state=%s, want preparing", inProgress.State)
+	}
+	if err := d.store.SetProfileRole(profileRoleChiefOfStaff, "replacement-chief"); err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+	done := waitDelegationOperation(t, d, op.OperationID)
+	if done.State != protocol.DelegationOperationStateCompleted {
+		t.Fatalf("done=%+v", done)
+	}
+	tickets, err := d.store.ListTickets(store.TicketListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tickets) != 1 || tickets[0].Assignee != done.SessionID {
+		t.Fatalf("tickets=%+v, want admission-time chief delegation ticket", tickets)
+	}
+}
+
+func TestDelegationOperationRestartResumesAcceptedRecord(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "attn.db")
+	persistent, err := store.NewWithDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d1 := NewForTesting(filepath.Join(t.TempDir(), "one.sock"))
+	_ = d1.store.Close()
+	d1.store = persistent
+	backend := &fakeSpawnBackend{}
+	_, sourceID, _ := setupDelegationSource(t, d1, backend)
+	msg := protocol.DelegateMessage{Cmd: protocol.CmdDelegate, RequestID: "restart-request", SourceSessionID: sourceID, Brief: "Resume after restart.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("restart")}
+	requestJSON, _ := json.Marshal(msg)
+	record, claimed, err := d1.store.ClaimDelegationOperation(msg.RequestID, "operation-restart", "session-restart", "", string(requestJSON), time.Now())
+	if err != nil || !claimed {
+		t.Fatalf("claim: claimed=%v err=%v", claimed, err)
+	}
+	if err := d1.store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := store.NewWithDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d2 := NewForTesting(filepath.Join(t.TempDir(), "two.sock"))
+	_ = d2.store.Close()
+	d2.store = reopened
+	d2.ptyBackend = &fakeSpawnBackend{}
+	consumeDelegatedPrompt(t, d2.ptyBackend.(*fakeSpawnBackend))
+	d2.loadWorkspacesFromStore()
+	d2.resumePendingDelegations()
+	done := waitDelegationOperation(t, d2, record.Operation.OperationID)
+	if done.State != protocol.DelegationOperationStateCompleted || done.SessionID != "session-restart" {
+		t.Fatalf("resumed operation=%+v", done)
+	}
+}
+
+func TestDelegationOperationAdoptsReconciledReservedRuntime(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	workspaceID, sourceID, cwd := setupDelegationSource(t, d, backend)
+	msg := protocol.DelegateMessage{Cmd: protocol.CmdDelegate, RequestID: "spawn-crash", SourceSessionID: sourceID, Brief: "Adopt the surviving runtime.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("adopted")}
+	encoded, _ := json.Marshal(msg)
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-spawn-crash", "session-spawn-crash", "", string(encoded), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Startup worker reconciliation found the stable runtime ID that was spawned
+	// before the old daemon could persist its full session association.
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{ID: record.Operation.SessionID, Label: filepath.Base(cwd), Agent: protocol.SessionAgentCodex, Directory: cwd, State: protocol.SessionStateLaunching, StateSince: now, StateUpdatedAt: now, LastSeen: now})
+	backend.sessionIDs = append(backend.sessionIDs, record.Operation.SessionID)
+	d.runDelegationOperation(record.Operation.OperationID)
+	done := waitDelegationOperation(t, d, record.Operation.OperationID)
+	if done.State != protocol.DelegationOperationStateCompleted || done.WorkspaceID == nil || protocol.Deref(done.WorkspaceID) != workspaceID {
+		t.Fatalf("operation=%+v", done)
+	}
+	adopted := d.store.Get(record.Operation.SessionID)
+	if adopted == nil || adopted.WorkspaceID != workspaceID || adopted.Label != "adopted" {
+		t.Fatalf("adopted session=%+v", adopted)
+	}
+	if got := len(backend.spawnOpts); got != 1 {
+		t.Fatalf("spawn count=%d, want only source runtime", got)
+	}
+}
+
+func TestDelegationOperationRespawnsPersistedSessionWithoutLiveRuntime(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	workspaceID, sourceID, cwd := setupDelegationSource(t, d, backend)
+	msg := protocol.DelegateMessage{Cmd: protocol.CmdDelegate, RequestID: "spawn-missing", SourceSessionID: sourceID, Brief: "Recover the missing runtime.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("respawned")}
+	encoded, _ := json.Marshal(msg)
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-spawn-missing", "session-spawn-missing", "", string(encoded), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{ID: record.Operation.SessionID, WorkspaceID: workspaceID, Label: "respawned", Agent: protocol.SessionAgentCodex, Directory: cwd, State: protocol.SessionStateIdle, StateSince: now, StateUpdatedAt: now, LastSeen: now, Recoverable: protocol.Ptr(true)})
+	d.runDelegationOperation(record.Operation.OperationID)
+	done := waitDelegationOperation(t, d, record.Operation.OperationID)
+	if done.State != protocol.DelegationOperationStateCompleted {
+		t.Fatalf("operation=%+v", done)
+	}
+	if got := len(backend.spawnOpts); got != 2 {
+		t.Fatalf("spawn count=%d, want source plus recovered delegation", got)
+	}
+	if backend.spawnOpts[1].ID != record.Operation.SessionID {
+		t.Fatalf("recovered spawn=%+v", backend.spawnOpts[1])
+	}
+}
+
+func TestDelegationOperationTerminalFailureRetryDoesNotRelaunch(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceID, _ := setupDelegationSource(t, d, backend)
+	msg := &protocol.DelegateMessage{Cmd: protocol.CmdDelegate, RequestID: "failed-request", SourceSessionID: sourceID, Brief: "Fail once.", Agent: protocol.Ptr("missing-agent")}
+	first, err := d.startDelegation(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed := waitDelegationOperation(t, d, first.OperationID)
+	if failed.State != protocol.DelegationOperationStateFailed {
+		t.Fatalf("operation=%+v", failed)
+	}
+	second, err := d.startDelegation(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.OperationID != first.OperationID || second.State != protocol.DelegationOperationStateFailed {
+		t.Fatalf("retry=%+v first=%+v", second, first)
+	}
+	if len(d.store.List("")) != 1 {
+		t.Fatalf("failure retry created a session")
+	}
+}
+
+func TestDelegationRestartDoesNotOwnWorktreeFromPathJournalAlone(t *testing.T) {
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitDaemon(t, mainRepo, "init")
+	runGitDaemon(t, mainRepo, "commit", "--allow-empty", "-m", "init")
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceID, _ := setupDelegationSourceAt(t, d, backend, mainRepo)
+	path := filepath.Join(root, "repo--external")
+	msg := protocol.DelegateMessage{
+		Cmd: protocol.CmdDelegate, RequestID: "path-only", SourceSessionID: sourceID,
+		Brief: "Do not adopt external work.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("path-only"),
+		Worktree: &protocol.DelegateWorktreeRequest{Repo: protocol.Ptr(mainRepo), Branch: "feat/external", Path: protocol.Ptr(path)},
+	}
+	encoded, _ := json.Marshal(msg)
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-path-only", "session-path-only", "", string(encoded), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.UpdateDelegationOperation(record.Operation.OperationID, protocol.DelegationOperationStatePreparing,
+		"preparing worktree "+path, "", "", path, nil, nil, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	// The daemon stopped after journaling intent but before creation. A different
+	// actor then created the same requested branch/path.
+	runGitDaemon(t, mainRepo, "worktree", "add", "-b", "feat/external", path)
+	d.runDelegationOperation(record.Operation.OperationID)
+	failed := waitDelegationOperation(t, d, record.Operation.OperationID)
+	if failed.State != protocol.DelegationOperationStateFailed {
+		t.Fatalf("operation=%+v", failed)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("external worktree was removed: %v", err)
+	}
+	stored, err := d.store.GetDelegationOperation(record.Operation.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.WorktreeOwned {
+		t.Fatal("path intent was incorrectly promoted to cleanup ownership")
+	}
+}
+
+func TestDelegationRestartDoesNotDeleteReplacementForPreviouslyOwnedWorktree(t *testing.T) {
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitDaemon(t, mainRepo, "init")
+	runGitDaemon(t, mainRepo, "commit", "--allow-empty", "-m", "init")
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceID, _ := setupDelegationSourceAt(t, d, backend, mainRepo)
+	path := filepath.Join(root, "repo--replacement")
+	msg := protocol.DelegateMessage{
+		Cmd: protocol.CmdDelegate, RequestID: "owned-replaced", SourceSessionID: sourceID,
+		Brief: "Do not delete replacement work.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("owned-replaced"),
+		Worktree: &protocol.DelegateWorktreeRequest{Repo: protocol.Ptr(mainRepo), Branch: "feat/replacement", Path: protocol.Ptr(path)},
+	}
+	encoded, _ := json.Marshal(msg)
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-owned-replaced", "session-owned-replaced", "", string(encoded), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runGitDaemon(t, mainRepo, "worktree", "add", "-b", "feat/replacement", path)
+	if err := d.store.MarkDelegationWorktreeOwned(record.Operation.OperationID, path, "original-owner-token", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	// The original daemon stopped after recording ownership. During the outage,
+	// another actor replaced the worktree with a new instance at the same path.
+	runGitDaemon(t, mainRepo, "worktree", "remove", path)
+	runGitDaemon(t, mainRepo, "branch", "-D", "feat/replacement")
+	runGitDaemon(t, mainRepo, "worktree", "add", "-b", "feat/replacement", path)
+
+	d.runDelegationOperation(record.Operation.OperationID)
+	failed := waitDelegationOperation(t, d, record.Operation.OperationID)
+	if failed.State != protocol.DelegationOperationStateFailed {
+		t.Fatalf("operation=%+v", failed)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("replacement worktree was removed: %v", err)
+	}
+}
+
+func TestDelegationRestartResumesPreviouslyOwnedWorktreeWithMatchingMarker(t *testing.T) {
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitDaemon(t, mainRepo, "init")
+	runGitDaemon(t, mainRepo, "commit", "--allow-empty", "-m", "init")
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceID, _ := setupDelegationSourceAt(t, d, backend, mainRepo)
+	path := filepath.Join(root, "repo--owned")
+	msg := protocol.DelegateMessage{
+		Cmd: protocol.CmdDelegate, RequestID: "owned-resume", SourceSessionID: sourceID,
+		Brief: "Resume original work.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("owned-resume"),
+		Worktree: &protocol.DelegateWorktreeRequest{Repo: protocol.Ptr(mainRepo), Branch: "feat/owned", Path: protocol.Ptr(path)},
+	}
+	encoded, _ := json.Marshal(msg)
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-owned-resume", "session-owned-resume", "", string(encoded), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runGitDaemon(t, mainRepo, "worktree", "add", "-b", "feat/owned", path)
+	const ownerToken = "matching-owner-token"
+	if err := writeDelegationWorktreeOwner(path, ownerToken); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.MarkDelegationWorktreeOwned(record.Operation.OperationID, path, ownerToken, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	d.runDelegationOperation(record.Operation.OperationID)
+	completed := waitDelegationOperation(t, d, record.Operation.OperationID)
+	if completed.State != protocol.DelegationOperationStateCompleted || completed.Result == nil {
+		t.Fatalf("operation=%+v", completed)
+	}
+	if completed.Result.SessionID != record.Operation.SessionID || !protocol.Deref(completed.Result.WorktreeCreated) {
+		t.Fatalf("result=%+v", completed.Result)
+	}
+}
+
+func TestDelegationRestartLeavesOwnedWorktreeWhenAnotherSessionOccupiesIt(t *testing.T) {
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitDaemon(t, mainRepo, "init")
+	runGitDaemon(t, mainRepo, "commit", "--allow-empty", "-m", "init")
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceID, _ := setupDelegationSourceAt(t, d, backend, mainRepo)
+	path := filepath.Join(root, "repo--occupied")
+	msg := protocol.DelegateMessage{
+		Cmd: protocol.CmdDelegate, RequestID: "owned-occupied", SourceSessionID: sourceID,
+		Brief: "Do not disturb the occupant.", Agent: protocol.Ptr("codex"), Label: protocol.Ptr("owned-occupied"),
+		Worktree: &protocol.DelegateWorktreeRequest{Repo: protocol.Ptr(mainRepo), Branch: "feat/occupied", Path: protocol.Ptr(path)},
+	}
+	encoded, _ := json.Marshal(msg)
+	record, _, err := d.store.ClaimDelegationOperation(msg.RequestID, "operation-owned-occupied", "session-owned-occupied", "", string(encoded), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runGitDaemon(t, mainRepo, "worktree", "add", "-b", "feat/occupied", path)
+	const ownerToken = "occupied-owner-token"
+	if err := writeDelegationWorktreeOwner(path, ownerToken); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.store.MarkDelegationWorktreeOwned(record.Operation.OperationID, path, ownerToken, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	now := string(protocol.TimestampNow())
+	d.store.Add(&protocol.Session{ID: "other-session", Label: "other", Agent: protocol.SessionAgentCodex, Directory: path, State: protocol.SessionStateWorking, StateSince: now, StateUpdatedAt: now, LastSeen: now})
+
+	d.runDelegationOperation(record.Operation.OperationID)
+	failed := waitDelegationOperation(t, d, record.Operation.OperationID)
+	if failed.State != protocol.DelegationOperationStateFailed {
+		t.Fatalf("operation=%+v", failed)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("occupied worktree was removed: %v", err)
+	}
+	if d.store.Get("other-session") == nil {
+		t.Fatal("occupying session was removed")
+	}
+}

--- a/internal/daemon/websocket.go
+++ b/internal/daemon/websocket.go
@@ -880,6 +880,8 @@ func (d *Daemon) handleClientMessage(client *wsClient, data []byte) {
 		d.handleClientHello(client, msg.(*protocol.ClientHelloMessage))
 	case protocol.CmdDelegate:
 		go d.handleDelegateWS(client, msg.(*protocol.DelegateMessage))
+	case protocol.CmdDelegateStatus:
+		go d.handleDelegateStatusWS(client, msg.(*protocol.DelegateStatusMessage))
 	case protocol.CmdWorkspaceContextCheckout:
 		go func() {
 			result, err := d.checkoutWorkspaceContext(msg.(*protocol.WorkspaceContextCheckoutMessage))

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "172"
+const ProtocolVersion = "173"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -43,6 +43,7 @@ const (
 	CmdClientHello                           = "client_hello"
 	CmdRegister                              = "register"
 	CmdDelegate                              = "delegate"
+	CmdDelegateStatus                        = "delegate_status"
 	CmdSetTicketStatus                       = "set_ticket_status"
 	CmdTicketInbox                           = "ticket_inbox"
 	CmdTicketList                            = "ticket_list"
@@ -219,6 +220,7 @@ const (
 	EventPresentationAdded               = "presentation_added"
 	EventPresentationUpdated             = "presentation_updated"
 	EventDelegateResult                  = "delegate_result"
+	EventDelegationOperation             = "delegation_operation"
 	EventWorkspaceContextResult          = "workspace_context_result"
 	EventWorkspaceContextListResult      = "workspace_context_list_result"
 	EventNotebookListResult              = "notebook_list_result"
@@ -390,6 +392,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdDelegate:
 		var msg DelegateMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdDelegateStatus:
+		var msg DelegateStatusMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -427,6 +427,9 @@ type DelegateMessage struct {
 	// Agent corresponds to the JSON schema field "agent".
 	Agent *string `json:"agent,omitempty,omitzero"`
 
+	// AllowWorktreeReuse corresponds to the JSON schema field "allow_worktree_reuse".
+	AllowWorktreeReuse *bool `json:"allow_worktree_reuse,omitempty,omitzero"`
+
 	// Brief corresponds to the JSON schema field "brief".
 	Brief string `json:"brief"`
 
@@ -447,6 +450,9 @@ type DelegateMessage struct {
 
 	// Placement corresponds to the JSON schema field "placement".
 	Placement *string `json:"placement,omitempty,omitzero"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
 
 	// SourceSessionID corresponds to the JSON schema field "source_session_id".
 	SourceSessionID string `json:"source_session_id"`
@@ -495,6 +501,14 @@ type DelegateResultMessage struct {
 	Success bool `json:"success"`
 }
 
+type DelegateStatusMessage struct {
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// ID corresponds to the JSON schema field "id".
+	ID string `json:"id"`
+}
+
 type DelegateWorktreeRequest struct {
 	// Branch corresponds to the JSON schema field "branch".
 	Branch string `json:"branch"`
@@ -508,6 +522,65 @@ type DelegateWorktreeRequest struct {
 	// StartingFrom corresponds to the JSON schema field "starting_from".
 	StartingFrom *string `json:"starting_from,omitempty,omitzero"`
 }
+
+type DelegationOperation struct {
+	// CreatedAt corresponds to the JSON schema field "created_at".
+	CreatedAt string `json:"created_at"`
+
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// OperationID corresponds to the JSON schema field "operation_id".
+	OperationID string `json:"operation_id"`
+
+	// Progress corresponds to the JSON schema field "progress".
+	Progress string `json:"progress"`
+
+	// RequestID corresponds to the JSON schema field "request_id".
+	RequestID string `json:"request_id"`
+
+	// Result corresponds to the JSON schema field "result".
+	Result *DelegateResult `json:"result,omitempty,omitzero"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
+
+	// State corresponds to the JSON schema field "state".
+	State DelegationOperationState `json:"state"`
+
+	// TicketID corresponds to the JSON schema field "ticket_id".
+	TicketID *string `json:"ticket_id,omitempty,omitzero"`
+
+	// UpdatedAt corresponds to the JSON schema field "updated_at".
+	UpdatedAt string `json:"updated_at"`
+
+	// WorkspaceID corresponds to the JSON schema field "workspace_id".
+	WorkspaceID *string `json:"workspace_id,omitempty,omitzero"`
+
+	// WorktreePath corresponds to the JSON schema field "worktree_path".
+	WorktreePath *string `json:"worktree_path,omitempty,omitzero"`
+}
+
+type DelegationOperationMessage struct {
+	// Error corresponds to the JSON schema field "error".
+	Error *string `json:"error,omitempty,omitzero"`
+
+	// Event corresponds to the JSON schema field "event".
+	Event string `json:"event"`
+
+	// Operation corresponds to the JSON schema field "operation".
+	Operation *DelegationOperation `json:"operation,omitempty,omitzero"`
+
+	// Success corresponds to the JSON schema field "success".
+	Success bool `json:"success"`
+}
+
+type DelegationOperationState string
+
+const DelegationOperationStateAccepted DelegationOperationState = "accepted"
+const DelegationOperationStateCompleted DelegationOperationState = "completed"
+const DelegationOperationStateFailed DelegationOperationState = "failed"
+const DelegationOperationStatePreparing DelegationOperationState = "preparing"
 
 type DeleteWorktreeMessage struct {
 	// Cmd corresponds to the JSON schema field "cmd".
@@ -3207,6 +3280,10 @@ type Response struct {
 
 	// DelegateResult corresponds to the JSON schema field "delegate_result".
 	DelegateResult *DelegateResult `json:"delegate_result,omitempty,omitzero"`
+
+	// DelegationOperation corresponds to the JSON schema field
+	// "delegation_operation".
+	DelegationOperation *DelegationOperation `json:"delegation_operation,omitempty,omitzero"`
 
 	// Error corresponds to the JSON schema field "error".
 	Error *string `json:"error,omitempty,omitzero"`

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -627,6 +627,7 @@ model TodosMessage {
 
 model DelegateMessage {
   cmd: "delegate";
+  request_id: string; // Stable caller-supplied idempotency key for one logical delegation
   source_session_id: string;
   brief: string;
   agent?: string;
@@ -638,6 +639,12 @@ model DelegateMessage {
   worktree?: DelegateWorktreeRequest;
   `model`?: string; // Pin the delegated agent's model (alias or full id); empty = agent default
   effort?: string; // Pin the delegated agent's reasoning effort; empty = agent default
+  allow_worktree_reuse?: boolean; // Exceptional opt-in to share an existing worktree
+}
+
+model DelegateStatusMessage {
+  cmd: "delegate_status";
+  id: string; // Request id or daemon-issued operation id
 }
 
 // SetTicketStatusMessage moves a ticket to the column for a reported work
@@ -2690,6 +2697,7 @@ model Response {
   error?: string;
   data?: string;
   delegate_result?: DelegateResult;
+  delegation_operation?: DelegationOperation;
   workspace_context_result?: WorkspaceContextResult;
   workspace_context_maintenance_result?: WorkspaceContextMaintenanceResult;
   workspace_contexts?: WorkspaceContext[];
@@ -2744,11 +2752,40 @@ model DelegateResult {
   worktree_created?: boolean;
 }
 
+enum DelegationOperationState {
+  accepted,
+  preparing,
+  completed,
+  failed,
+}
+
+model DelegationOperation {
+  operation_id: string;
+  request_id: string;
+  state: DelegationOperationState;
+  progress: string;
+  session_id: string;
+  workspace_id?: string;
+  ticket_id?: string;
+  worktree_path?: string;
+  result?: DelegateResult;
+  error?: string;
+  created_at: string;
+  updated_at: string;
+}
+
 model DelegateResultMessage {
   event: "delegate_result";
   success: boolean;
   error?: string;
   result?: DelegateResult;
+}
+
+model DelegationOperationMessage {
+  event: "delegation_operation";
+  success: boolean;
+  error?: string;
+  operation?: DelegationOperation;
 }
 
 model WorkspaceContextResult {

--- a/internal/store/delegation_operations.go
+++ b/internal/store/delegation_operations.go
@@ -1,0 +1,176 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+var ErrDelegationRequestConflict = errors.New("delegation request id already has different inputs")
+
+// DelegationOperationRecord is the durable launch journal. RequestJSON is kept
+// alongside the public operation shape so a daemon restart can resume the exact
+// accepted request and a reused key can be rejected when its inputs differ.
+type DelegationOperationRecord struct {
+	Operation      protocol.DelegationOperation
+	RequestJSON    string
+	WorktreeOwned  bool
+	WorktreeToken  string
+	ChiefSessionID string
+}
+
+func (s *Store) ClaimDelegationOperation(requestID, operationID, sessionID, chiefSessionID, requestJSON string, now time.Time) (*DelegationOperationRecord, bool, error) {
+	if strings.HasPrefix(requestID, "op-") {
+		return nil, false, fmt.Errorf("request id uses reserved operation prefix op-")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return nil, false, errors.New("delegation idempotency requires a database")
+	}
+	stamp := now.UTC().Format(time.RFC3339Nano)
+	result, err := s.db.Exec(`INSERT OR IGNORE INTO delegation_operations
+		(request_id, operation_id, request_json, state, progress, session_id, chief_session_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, requestID, operationID, requestJSON,
+		string(protocol.DelegationOperationStateAccepted), "accepted by daemon", sessionID, chiefSessionID, stamp, stamp)
+	if err != nil {
+		return nil, false, fmt.Errorf("claim delegation operation: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return nil, false, fmt.Errorf("claim delegation operation rows: %w", err)
+	}
+	record, err := getDelegationOperation(s.db, requestID)
+	if err != nil {
+		return nil, false, err
+	}
+	if record.RequestJSON != requestJSON {
+		return nil, false, ErrDelegationRequestConflict
+	}
+	return record, rows == 1, nil
+}
+
+func (s *Store) GetDelegationOperation(id string) (*DelegationOperationRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return nil, sql.ErrNoRows
+	}
+	return getDelegationOperation(s.db, id)
+}
+
+func getDelegationOperation(db *sql.DB, id string) (*DelegationOperationRecord, error) {
+	var rec DelegationOperationRecord
+	var state, workspaceID, ticketID, worktreePath, worktreeToken, chiefSessionID, resultJSON, errorText string
+	var worktreeOwned int
+	err := db.QueryRow(`SELECT request_id, operation_id, request_json, state, progress,
+		session_id, workspace_id, ticket_id, worktree_path, worktree_owned, worktree_token, chief_session_id, result_json, error, created_at, updated_at
+		FROM delegation_operations WHERE request_id = ? OR operation_id = ?`, id, id).Scan(
+		&rec.Operation.RequestID, &rec.Operation.OperationID, &rec.RequestJSON, &state,
+		&rec.Operation.Progress, &rec.Operation.SessionID, &workspaceID, &ticketID,
+		&worktreePath, &worktreeOwned, &worktreeToken, &chiefSessionID, &resultJSON, &errorText, &rec.Operation.CreatedAt, &rec.Operation.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	rec.Operation.State = protocol.DelegationOperationState(state)
+	rec.WorktreeOwned = worktreeOwned == 1
+	rec.WorktreeToken = worktreeToken
+	rec.ChiefSessionID = chiefSessionID
+	if workspaceID != "" {
+		rec.Operation.WorkspaceID = protocol.Ptr(workspaceID)
+	}
+	if ticketID != "" {
+		rec.Operation.TicketID = protocol.Ptr(ticketID)
+	}
+	if worktreePath != "" {
+		rec.Operation.WorktreePath = protocol.Ptr(worktreePath)
+	}
+	if errorText != "" {
+		rec.Operation.Error = protocol.Ptr(errorText)
+	}
+	if resultJSON != "" {
+		var result protocol.DelegateResult
+		if err := json.Unmarshal([]byte(resultJSON), &result); err != nil {
+			return nil, fmt.Errorf("decode delegation result: %w", err)
+		}
+		rec.Operation.Result = &result
+	}
+	return &rec, nil
+}
+
+func (s *Store) MarkDelegationWorktreeOwned(id, path, token string, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	stamp := now.UTC().Format(time.RFC3339Nano)
+	_, err := s.db.Exec(`UPDATE delegation_operations SET worktree_path = ?, worktree_owned = 1, worktree_token = ?, updated_at = ?
+		WHERE request_id = ? OR operation_id = ?`, path, token, stamp, id, id)
+	return err
+}
+
+func (s *Store) UpdateDelegationOperation(id string, state protocol.DelegationOperationState, progress, workspaceID, ticketID, worktreePath string, result *protocol.DelegateResult, operationErr error, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return errors.New("delegation idempotency requires a database")
+	}
+	resultJSON := ""
+	if result != nil {
+		encoded, err := json.Marshal(result)
+		if err != nil {
+			return fmt.Errorf("encode delegation result: %w", err)
+		}
+		resultJSON = string(encoded)
+	}
+	errorText := ""
+	if operationErr != nil {
+		errorText = operationErr.Error()
+	}
+	stamp := now.UTC().Format(time.RFC3339Nano)
+	_, err := s.db.Exec(`UPDATE delegation_operations SET state = ?, progress = ?,
+		workspace_id = CASE WHEN ? = '' THEN workspace_id ELSE ? END,
+		ticket_id = CASE WHEN ? = '' THEN ticket_id ELSE ? END,
+		worktree_path = CASE WHEN ? = '' THEN worktree_path ELSE ? END,
+		result_json = ?, error = ?, updated_at = ? WHERE request_id = ? OR operation_id = ?`,
+		string(state), progress, workspaceID, workspaceID, ticketID, ticketID,
+		worktreePath, worktreePath, resultJSON, errorText, stamp, id, id)
+	return err
+}
+
+func (s *Store) PendingDelegationOperations() ([]DelegationOperationRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	rows, err := s.db.Query(`SELECT request_id FROM delegation_operations WHERE state IN (?, ?) ORDER BY created_at`,
+		string(protocol.DelegationOperationStateAccepted), string(protocol.DelegationOperationStatePreparing))
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	var out []DelegationOperationRecord
+	for _, id := range ids {
+		rec, err := getDelegationOperation(s.db, id)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *rec)
+	}
+	return out, nil
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -659,6 +659,26 @@ CREATE TABLE IF NOT EXISTS ticket_event_cursors (
 		observer_key TEXT PRIMARY KEY,
 		last_attention_at TEXT NOT NULL
 	)`},
+	{70, "create delegation operations table", `CREATE TABLE IF NOT EXISTS delegation_operations (
+		request_id TEXT PRIMARY KEY,
+		operation_id TEXT NOT NULL UNIQUE,
+		request_json TEXT NOT NULL,
+		state TEXT NOT NULL,
+		progress TEXT NOT NULL,
+		session_id TEXT NOT NULL,
+		workspace_id TEXT NOT NULL DEFAULT '',
+		ticket_id TEXT NOT NULL DEFAULT '',
+		worktree_path TEXT NOT NULL DEFAULT '',
+		worktree_owned INTEGER NOT NULL DEFAULT 0,
+		result_json TEXT NOT NULL DEFAULT '',
+		error TEXT NOT NULL DEFAULT '',
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_delegation_operations_operation_id
+		ON delegation_operations(operation_id);`},
+	{71, "add delegation worktree ownership token", ""},
+	{72, "add delegation initiating chief identity", ""},
 }
 
 // OpenDB opens a SQLite database at the given path, creating it if necessary.
@@ -870,6 +890,16 @@ func migrateDB(db *sql.DB, dbPath string) error {
 			}
 		} else if m.version == 65 {
 			if err := applyMigration65(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 71 {
+			if err := applyMigration71(tx); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
+			}
+		} else if m.version == 72 {
+			if err := applyMigration72(tx); err != nil {
 				tx.Rollback()
 				return fmt.Errorf("migration %d (%s): %w", m.version, m.desc, err)
 			}
@@ -1179,6 +1209,44 @@ func applyMigration65(tx *sql.Tx) error {
 		return nil
 	}
 	_, err = tx.Exec(`ALTER TABLE presentation_rounds ADD COLUMN verdict TEXT`)
+	return err
+}
+
+func applyMigration71(tx *sql.Tx) error {
+	exists, err := tableExists(tx, "delegation_operations")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	hasColumn, err := columnExists(tx, "delegation_operations", "worktree_token")
+	if err != nil {
+		return err
+	}
+	if hasColumn {
+		return nil
+	}
+	_, err = tx.Exec(`ALTER TABLE delegation_operations ADD COLUMN worktree_token TEXT NOT NULL DEFAULT ''`)
+	return err
+}
+
+func applyMigration72(tx *sql.Tx) error {
+	exists, err := tableExists(tx, "delegation_operations")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	hasColumn, err := columnExists(tx, "delegation_operations", "chief_session_id")
+	if err != nil {
+		return err
+	}
+	if hasColumn {
+		return nil
+	}
+	_, err = tx.Exec(`ALTER TABLE delegation_operations ADD COLUMN chief_session_id TEXT NOT NULL DEFAULT ''`)
 	return err
 }
 

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -34,7 +34,7 @@ func TestOpenDB_CreatesSchema(t *testing.T) {
 	defer db.Close()
 
 	// Verify tables exist by querying them
-	tables := []string{"sessions", "prs", "repos", "workspace_contexts", "workspace_keeper_compact_backups", "profile_roles", "chief_of_staff_dispatches", "chief_of_staff_dispatch_messages"}
+	tables := []string{"sessions", "prs", "repos", "workspace_contexts", "workspace_keeper_compact_backups", "profile_roles", "chief_of_staff_dispatches", "chief_of_staff_dispatch_messages", "delegation_operations"}
 	for _, table := range tables {
 		var count int
 		err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&count)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -429,7 +429,7 @@ func (s *Store) HasSessionInDirectory(directory string) bool {
 
 	if s.db == nil {
 		for _, session := range s.sessions {
-			if session.Directory == directory {
+			if session.Directory == directory && session.State != protocol.SessionStateIdle {
 				return true
 			}
 		}
@@ -437,7 +437,7 @@ func (s *Store) HasSessionInDirectory(directory string) bool {
 	}
 
 	var count int
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM sessions WHERE directory = ?`, directory).Scan(&count)
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM sessions WHERE directory = ? AND state != ?`, directory, string(protocol.SessionStateIdle)).Scan(&count)
 	if err != nil {
 		return false
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -715,6 +715,34 @@ func TestStore_ListAuthorStates(t *testing.T) {
 	}
 }
 
+func TestHasSessionInDirectoryIgnoresIdleSessions(t *testing.T) {
+	for _, persistent := range []bool{false, true} {
+		name := "memory"
+		var s *Store
+		if persistent {
+			name = "sqlite"
+			var err error
+			s, err = NewWithDB(t.TempDir() + "/test.db")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer s.Close()
+		} else {
+			s = New()
+		}
+		t.Run(name, func(t *testing.T) {
+			s.Add(&protocol.Session{ID: "idle", Directory: "/tmp/worktree", State: protocol.SessionStateIdle})
+			if s.HasSessionInDirectory("/tmp/worktree") {
+				t.Fatal("idle session should not reserve the worktree")
+			}
+			s.Add(&protocol.Session{ID: "working", Directory: "/tmp/worktree", State: protocol.SessionStateWorking})
+			if !s.HasSessionInDirectory("/tmp/worktree") {
+				t.Fatal("working session should reserve the worktree")
+			}
+		})
+	}
+}
+
 // The intentional-close mark is the durable half of the close-vs-crash signal:
 // it must survive a store reopen (daemon restart) so the startup reap's ticket
 // seam can still tell a user close from a spontaneous death, and clearing it


### PR DESCRIPTION
## Intent / Why

A slow `attn delegate` can finish creating a worktree, ticket, and session after the caller has already concluded that the command timed out. Retrying then creates a second delegation for the same logical work. The caller's timeout is outside attn's control, so this change makes the launch outcome recoverable: attn exposes a stable identity before slow preparation, durably accepts it, and converges retries on the original operation.

## Summary

- add `--request-id`, early request/operation receipts, concise progress, and `attn delegate status <id>` so callers can recover an unknown outcome without creating new work
- atomically claim and persist delegation operations before worktree, workspace, session, or ticket side effects; resume accepted/preparing operations after daemon restart and preserve terminal failures
- preserve admission-time chief ownership, model/effort pins, brief contents, placement modes, and existing one-shot CLI behavior
- journal worktree intent and verify operation-specific ownership markers before restart recovery or cleanup
- reject a second active session anywhere in the same linked worktree unless `--allow-worktree-reuse` explicitly opts in
- update protocol version 173, generated Go/TypeScript types, CLI help, README guidance, and changelog

## Test plan

- [x] `gotestsum --format standard-quiet -- ./...` — 2,534 passed, 8 opt-in integration tests skipped
- [x] `pnpm --dir app test` — 1,848 passed
- [x] `make generate-types`
- [x] focused sequential retry, concurrent retry, response loss, slow preparation, restart recovery, missing-runtime recovery, terminal failure, worktree ownership/replacement/collision, admission-time chief, and one-shot delegation tests
- [x] signed `make dev` build/install in the isolated dev profile; production was not touched
- [x] live services-pilot worktree preparation with two overlapping invocations using one request ID: both returned operation `op-17a691e6-a8d8-4f25-99dd-616ace0ce022` and session `119e58be-57bd-4ddc-9e7d-39c8b9c07556`
- [x] inspected `~/.attn-dev/attn.db`: exactly one operation, one session, and one ticket; schema version 72; durable worktree ownership token and Git-private marker present

## Compatibility

Existing `attn delegate` calls remain valid. The CLI generates and prints a request ID when callers do not provide one. JSON result output remains the completed delegation result; progress and recovery receipts go to stderr.
