### PR TITLE
feat(cli): add live session transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 
 ## [2026-07-19]
 
+### Added
+- **Live agent transcripts are inspectable from the CLI.** `attn session
+  transcript <session-id>` prints timestamped conversation, tool, and error
+  events across supported agents, with `--follow` for live updates and opaque
+  cursors for safe resumption. Provider-specific records stay behind the daemon
+  boundary, and secrets are redacted before output.
+
 ### Fixed
 - **Retried delegations no longer create duplicate agents or tickets.** `attn
   delegate` now prints a durable request and operation identity before slow

--- a/app/src/hooks/useDaemonSocket.ts
+++ b/app/src/hooks/useDaemonSocket.ts
@@ -170,7 +170,7 @@ export interface RateLimitState {
 
 // Protocol version - must match daemon's ProtocolVersion
 // Increment when making breaking changes to the protocol
-export const PROTOCOL_VERSION = '174';
+export const PROTOCOL_VERSION = '175';
 const MAX_PENDING_ATTACH_OUTPUTS = 512;
 
 interface PRActionResult {

--- a/app/src/types/generated.ts
+++ b/app/src/types/generated.ts
@@ -1,6 +1,6 @@
 // To parse this data:
 //
-//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationListMessage, AutomationRunListMessage, AutomationRunMessage, AutomationShowMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
+//   import { Convert, AddEndpointMessage, ApprovePRMessage, AttachPolicy, AttachResultMessage, AttachSessionMessage, AuthorState, AuthorsUpdatedMessage, AutomationApplyMessage, AutomationListMessage, AutomationRunListMessage, AutomationRunMessage, AutomationShowMessage, BootstrapEndpointMessage, Branch, BranchChangedMessage, BranchesResultMessage, BrowseDirectoryMessage, BrowseDirectoryResultMessage, BrowserControlMessage, BrowserControlRequestMessage, BrowserControlResponseMessage, BrowserControlResultMessage, ChiefOfStaffResultMessage, ClearSessionsMessage, ClearWarningsMessage, ClientHelloMessage, CollapseRepoMessage, CommandErrorMessage, CreateWorktreeFromBranchMessage, CreateWorktreeMessage, CreateWorktreeResultMessage, DaemonWarning, DelegateMessage, DelegateResult, DelegateResultMessage, DelegateStatusMessage, DelegateWorktreeRequest, DelegationOperation, DelegationOperationMessage, DelegationOperationState, DeleteWorktreeMessage, DeleteWorktreeResultMessage, DetachSessionMessage, DirectoryEntry, DispatchWorkState, EndpointActionResultMessage, EndpointCapabilities, EndpointInfo, EndpointStatusChangedMessage, EndpointsUpdatedMessage, EnsureRepoMessage, EnsureRepoResultMessage, EvidenceExcerpt, FetchPRDetailsMessage, FetchPRDetailsResultMessage, FetchRemotesMessage, FetchRemotesResultMessage, FileDiffResultMessage, FSChangedMessage, FSDeleteMessage, FSDeleteResult, FSDeleteResultMessage, FSEntry, FSExistsMessage, FSExistsResult, FSExistsResultMessage, FSIndexMessage, FSIndexResultMessage, FSListMessage, FSListResultMessage, FSReadAssetMessage, FSReadAssetResult, FSReadAssetResultMessage, FSReadMessage, FSReadResult, FSReadResultMessage, FSRenameMessage, FSRenameResult, FSRenameResultMessage, FSUnwatchMessage, FSUnwatchResultMessage, FSWatchMessage, FSWatchResultMessage, FSWriteMessage, FSWriteResult, FSWriteResultMessage, GetDefaultBranchMessage, GetDefaultBranchResultMessage, GetFileDiffMessage, GetPresentationRoundMessage, GetPresentationRoundResultMessage, GetPresentationsMessage, GetPresentationsResultMessage, GetRecentLocationsMessage, GetRepoInfoMessage, GetRepoInfoResultMessage, GetScreenSnapshotMessage, GetScreenSnapshotResultMessage, GetSettingsMessage, GetTicketMessage, GitFileChange, GitHubHostsUpdatedMessage, GitOperation, GitOperationFinishedMessage, GitOperationKind, GitOperationStartedMessage, GitOperationStatus, GitStatusUpdateMessage, HeartbeatMessage, HeatState, InitialStateMessage, InjectTestPRMessage, InjectTestSessionMessage, InspectPathMessage, InspectPathResultMessage, InstallBundledPluginMessage, InstallPluginMessage, JournalAppendMessage, JournalAppendResult, KillSessionMessage, ListBranchesMessage, ListEndpointsMessage, ListPluginsMessage, ListRemoteBranchesMessage, ListRemoteBranchesResultMessage, ListWorktreesMessage, MarkdownAnnotation, MarkdownAnnotationAnchor, MarkdownAnnotationsClearMessage, MarkdownAnnotationsClearResultMessage, MarkdownAnnotationsGetMessage, MarkdownAnnotationsGetResultMessage, MarkdownAnnotationsSaveMessage, MarkdownAnnotationsSaveResultMessage, MarkdownAnnotationsSubmitMessage, MarkdownAnnotationsSubmitResultMessage, MergePRMessage, MuteAuthorMessage, MutePRMessage, MuteRepoMessage, MuteWorkspaceMessage, NotebookBacklinksMessage, NotebookBacklinksResultMessage, NotebookChangedMessage, NotebookEntry, NotebookGuideMessage, NotebookGuideResult, NotebookListMessage, NotebookListResultMessage, NotebookReadMessage, NotebookReadResult, NotebookReadResultMessage, NotebookSendToChiefMessage, NotebookSendToChiefResult, NotebookSendToChiefResultMessage, NotebookWriteMessage, NotebookWriteResult, NotebookWriteResultMessage, Notification, NotificationListMessage, NotificationListResultMessage, NotificationMarkReadMessage, NotificationMarkReadResultMessage, NotificationsUpdatedMessage, OpenBrowserMessage, OpenMarkdownMessage, OpenMarkdownResultMessage, PR, PRActionResultMessage, PRRole, PRVisitedMessage, PRsUpdatedMessage, PathInspection, PinWorkspaceMessage, PluginActionResultMessage, PluginInfo, PluginIssue, PluginsUpdatedMessage, PresentAnnotation, PresentCloseMessage, PresentCloseResultMessage, PresentCommentInput, PresentFeedbackMessage, PresentFeedbackResult, PresentFile, PresentManifestView, PresentOpenMessage, PresentOpenResult, PresentSubmitRoundMessage, PresentSubmitRoundResultMessage, Presentation, PresentationAddedMessage, PresentationComment, PresentationRound, PresentationUpdatedMessage, PtyDesyncMessage, PtyInputMessage, PtyOutputMessage, PtyResizeMessage, PtyResizedMessage, QueryAuthorsMessage, QueryMessage, QueryPRsMessage, QueryReposMessage, RateLimitedMessage, RecentLocation, RecentLocationsResultMessage, RefreshPRsMessage, RefreshPRsResultMessage, RegisterMessage, RegisterWorkspaceMessage, RemoveEndpointMessage, RemovePluginMessage, RenameResultMessage, RenameSessionMessage, RenameWorkspaceMessage, ReplaySegment, RepoInfo, RepoState, ReposUpdatedMessage, Response, ReviewComment, RuntimeRespawnedMessage, Session, SessionExitedMessage, SessionInstructionsMessage, SessionInstructionsResult, SessionRegisteredMessage, SessionSelectedMessage, SessionState, SessionStateChangedMessage, SessionTodosUpdatedMessage, SessionTranscriptEvent, SessionTranscriptMessage, SessionTranscriptResult, SessionUnregisteredMessage, SessionVisualizedMessage, SessionsUpdatedMessage, SetChiefOfStaffMessage, SetEndpointRemoteWebMessage, SetPluginPriorityMessage, SetSessionResumeIDMessage, SetSettingMessage, SetTerminalThemeMessage, SetTicketStatusMessage, SetWorkspaceRankMessage, SettingsUpdatedMessage, SpawnResultMessage, SpawnSessionMessage, StateMessage, StopMessage, SubscribeGitStatusMessage, Task, TaskListMessage, TaskListResultMessage, TaskRetryMessage, TaskRetryResultMessage, TasksChangedMessage, Ticket, TicketActionResultMessage, TicketActivity, TicketActivityKind, TicketAddCommentMessage, TicketArtifact, TicketAttachFile, TicketAttachMessage, TicketAttachResult, TicketAttachResultMessage, TicketChangeStatusMessage, TicketCommentMessage, TicketCommentResult, TicketCreateMessage, TicketCreateResult, TicketEditDescriptionMessage, TicketEvent, TicketEventBundle, TicketEventKind, TicketInboxMessage, TicketInboxMode, TicketInboxResult, TicketListMessage, TicketListResult, TicketResultMessage, TicketResumeMessage, TicketResumeResultMessage, TicketShowMessage, TicketShowResult, TicketStatus, TicketStatusResult, TicketSubscribeMessage, TicketSubscribeResult, TicketTakeMessage, TicketTakeResult, TicketUnsubscribeMessage, TicketUnsubscribeResult, TicketsUpdatedMessage, TodosMessage, TriggerNudgeMessage, UninstallPluginMessage, UnregisterMessage, UnregisterWorkspaceMessage, UnsubscribeGitStatusMessage, UpdateEndpointMessage, WebSocketEvent, WorkflowActionResultMessage, WorkflowAgentCall, WorkflowAgentCallStatus, WorkflowCallUpsertMessage, WorkflowRun, WorkflowRunCancelMessage, WorkflowRunGetMessage, WorkflowRunListMessage, WorkflowRunStatus, WorkflowRunUpdatedMessage, WorkflowRunUpsertMessage, Workspace, WorkspaceContext, WorkspaceContextChangedMessage, WorkspaceContextCheckoutMessage, WorkspaceContextCompactMessage, WorkspaceContextListMessage, WorkspaceContextListResultMessage, WorkspaceContextMaintenanceAction, WorkspaceContextMaintenanceResult, WorkspaceContextResult, WorkspaceContextResultMessage, WorkspaceContextRollbackMessage, WorkspaceContextStatusMessage, WorkspaceContextUpdateMessage, WorkspaceLayout, WorkspaceLayoutActionResultMessage, WorkspaceLayoutAddSessionPaneMessage, WorkspaceLayoutClosePaneMessage, WorkspaceLayoutDockEdge, WorkspaceLayoutDockTileMessage, WorkspaceLayoutFocusPaneMessage, WorkspaceLayoutGetMessage, WorkspaceLayoutMessage, WorkspaceLayoutMoveLeafMessage, WorkspaceLayoutMoveLeafToNewWorkspaceMessage, WorkspaceLayoutMoveLeafToWorkspaceMessage, WorkspaceLayoutPane, WorkspaceLayoutPaneKind, WorkspaceLayoutPaneStatus, WorkspaceLayoutRenamePaneMessage, WorkspaceLayoutSetSplitRatioMessage, WorkspaceLayoutSplitDirection, WorkspaceLayoutUndockTileMessage, WorkspaceLayoutUpdateTileMessage, WorkspaceLayoutUpdatedMessage, WorkspaceRegisteredMessage, WorkspaceSelectedMessage, WorkspaceStateChangedMessage, WorkspaceStatus, WorkspaceTileContentGetMessage, WorkspaceTileContentMessage, WorkspaceUnregisteredMessage, Worktree, WorktreeCreatedEvent, WorktreeDeletedEvent, WorktreesUpdatedMessage } from "./file";
 //
 //   const addEndpointMessage = Convert.toAddEndpointMessage(json);
 //   const approvePRMessage = Convert.toApprovePRMessage(json);
@@ -234,6 +234,9 @@
 //   const sessionState = Convert.toSessionState(json);
 //   const sessionStateChangedMessage = Convert.toSessionStateChangedMessage(json);
 //   const sessionTodosUpdatedMessage = Convert.toSessionTodosUpdatedMessage(json);
+//   const sessionTranscriptEvent = Convert.toSessionTranscriptEvent(json);
+//   const sessionTranscriptMessage = Convert.toSessionTranscriptMessage(json);
+//   const sessionTranscriptResult = Convert.toSessionTranscriptResult(json);
 //   const sessionUnregisteredMessage = Convert.toSessionUnregisteredMessage(json);
 //   const sessionVisualizedMessage = Convert.toSessionVisualizedMessage(json);
 //   const sessionsUpdatedMessage = Convert.toSessionsUpdatedMessage(json);
@@ -3431,6 +3434,7 @@ export interface Response {
     prs?:                                  PRElement[];
     repos?:                                RepoElement[];
     session_instructions_result?:          SessionInstructionsResultObject;
+    session_transcript_result?:            SessionTranscriptResultObject;
     sessions?:                             SessionElement[];
     ticket_attach_result?:                 TicketAttachResultObject;
     ticket_comment_result?:                TicketCommentResultObject;
@@ -3501,6 +3505,26 @@ export interface EvidenceElement {
     [property: string]: any;
 }
 
+export interface SessionTranscriptResultObject {
+    at_end:      boolean;
+    events:      EventElement[];
+    next_cursor: string;
+    session_id:  string;
+    [property: string]: any;
+}
+
+export interface EventElement {
+    cursor:        string;
+    is_error?:     boolean;
+    kind:          string;
+    role?:         string;
+    text?:         string;
+    timestamp?:    string;
+    tool_call_id?: string;
+    tool_name?:    string;
+    [property: string]: any;
+}
+
 export interface TicketAttachResultObject {
     artifacts:    ArtifactElement[];
     catch_up?:    CatchUp;
@@ -3513,12 +3537,12 @@ export interface TicketAttachResultObject {
 }
 
 export interface CatchUp {
-    events:    EventElement[];
+    events:    EventObject[];
     ticket_id: string;
     [property: string]: any;
 }
 
-export interface EventElement {
+export interface EventObject {
     author:       string;
     comment?:     string;
     created_at:   string;
@@ -3753,6 +3777,37 @@ export interface SessionTodosUpdatedMessage {
 
 export enum SessionTodosUpdatedMessageEvent {
     SessionTodosUpdated = "session_todos_updated",
+}
+
+export interface SessionTranscriptEvent {
+    cursor:        string;
+    is_error?:     boolean;
+    kind:          string;
+    role?:         string;
+    text?:         string;
+    timestamp?:    string;
+    tool_call_id?: string;
+    tool_name?:    string;
+    [property: string]: any;
+}
+
+export interface SessionTranscriptMessage {
+    after_cursor?:     string;
+    cmd:               SessionTranscriptMessageCmd;
+    target_session_id: string;
+    [property: string]: any;
+}
+
+export enum SessionTranscriptMessageCmd {
+    SessionTranscript = "session_transcript",
+}
+
+export interface SessionTranscriptResult {
+    at_end:      boolean;
+    events:      EventElement[];
+    next_cursor: string;
+    session_id:  string;
+    [property: string]: any;
 }
 
 export interface SessionUnregisteredMessage {
@@ -4245,7 +4300,7 @@ export interface TicketEvent {
 }
 
 export interface TicketEventBundle {
-    events:    EventElement[];
+    events:    EventObject[];
     ticket_id: string;
     [property: string]: any;
 }
@@ -7073,6 +7128,30 @@ export class Convert {
 
     public static sessionTodosUpdatedMessageToJson(value: SessionTodosUpdatedMessage): string {
         return JSON.stringify(uncast(value, r("SessionTodosUpdatedMessage")), null, 2);
+    }
+
+    public static toSessionTranscriptEvent(json: string): SessionTranscriptEvent {
+        return cast(JSON.parse(json), r("SessionTranscriptEvent"));
+    }
+
+    public static sessionTranscriptEventToJson(value: SessionTranscriptEvent): string {
+        return JSON.stringify(uncast(value, r("SessionTranscriptEvent")), null, 2);
+    }
+
+    public static toSessionTranscriptMessage(json: string): SessionTranscriptMessage {
+        return cast(JSON.parse(json), r("SessionTranscriptMessage"));
+    }
+
+    public static sessionTranscriptMessageToJson(value: SessionTranscriptMessage): string {
+        return JSON.stringify(uncast(value, r("SessionTranscriptMessage")), null, 2);
+    }
+
+    public static toSessionTranscriptResult(json: string): SessionTranscriptResult {
+        return cast(JSON.parse(json), r("SessionTranscriptResult"));
+    }
+
+    public static sessionTranscriptResultToJson(value: SessionTranscriptResult): string {
+        return JSON.stringify(uncast(value, r("SessionTranscriptResult")), null, 2);
     }
 
     public static toSessionUnregisteredMessage(json: string): SessionUnregisteredMessage {
@@ -10037,6 +10116,7 @@ const typeMap: any = {
         { json: "prs", js: "prs", typ: u(undefined, a(r("PRElement"))) },
         { json: "repos", js: "repos", typ: u(undefined, a(r("RepoElement"))) },
         { json: "session_instructions_result", js: "session_instructions_result", typ: u(undefined, r("SessionInstructionsResultObject")) },
+        { json: "session_transcript_result", js: "session_transcript_result", typ: u(undefined, r("SessionTranscriptResultObject")) },
         { json: "sessions", js: "sessions", typ: u(undefined, a(r("SessionElement"))) },
         { json: "ticket_attach_result", js: "ticket_attach_result", typ: u(undefined, r("TicketAttachResultObject")) },
         { json: "ticket_comment_result", js: "ticket_comment_result", typ: u(undefined, r("TicketCommentResultObject")) },
@@ -10093,6 +10173,22 @@ const typeMap: any = {
         { json: "timestamp", js: "timestamp", typ: u(undefined, "") },
         { json: "turn_id", js: "turn_id", typ: "" },
     ], "any"),
+    "SessionTranscriptResultObject": o([
+        { json: "at_end", js: "at_end", typ: true },
+        { json: "events", js: "events", typ: a(r("EventElement")) },
+        { json: "next_cursor", js: "next_cursor", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
+    ], "any"),
+    "EventElement": o([
+        { json: "cursor", js: "cursor", typ: "" },
+        { json: "is_error", js: "is_error", typ: u(undefined, true) },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "role", js: "role", typ: u(undefined, "") },
+        { json: "text", js: "text", typ: u(undefined, "") },
+        { json: "timestamp", js: "timestamp", typ: u(undefined, "") },
+        { json: "tool_call_id", js: "tool_call_id", typ: u(undefined, "") },
+        { json: "tool_name", js: "tool_name", typ: u(undefined, "") },
+    ], "any"),
     "TicketAttachResultObject": o([
         { json: "artifacts", js: "artifacts", typ: a(r("ArtifactElement")) },
         { json: "catch_up", js: "catch_up", typ: u(undefined, r("CatchUp")) },
@@ -10103,10 +10199,10 @@ const typeMap: any = {
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
     "CatchUp": o([
-        { json: "events", js: "events", typ: a(r("EventElement")) },
+        { json: "events", js: "events", typ: a(r("EventObject")) },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
-    "EventElement": o([
+    "EventObject": o([
         { json: "author", js: "author", typ: "" },
         { json: "comment", js: "comment", typ: u(undefined, "") },
         { json: "created_at", js: "created_at", typ: "" },
@@ -10254,6 +10350,27 @@ const typeMap: any = {
     "SessionTodosUpdatedMessage": o([
         { json: "event", js: "event", typ: r("SessionTodosUpdatedMessageEvent") },
         { json: "session", js: "session", typ: r("SessionElement") },
+    ], "any"),
+    "SessionTranscriptEvent": o([
+        { json: "cursor", js: "cursor", typ: "" },
+        { json: "is_error", js: "is_error", typ: u(undefined, true) },
+        { json: "kind", js: "kind", typ: "" },
+        { json: "role", js: "role", typ: u(undefined, "") },
+        { json: "text", js: "text", typ: u(undefined, "") },
+        { json: "timestamp", js: "timestamp", typ: u(undefined, "") },
+        { json: "tool_call_id", js: "tool_call_id", typ: u(undefined, "") },
+        { json: "tool_name", js: "tool_name", typ: u(undefined, "") },
+    ], "any"),
+    "SessionTranscriptMessage": o([
+        { json: "after_cursor", js: "after_cursor", typ: u(undefined, "") },
+        { json: "cmd", js: "cmd", typ: r("SessionTranscriptMessageCmd") },
+        { json: "target_session_id", js: "target_session_id", typ: "" },
+    ], "any"),
+    "SessionTranscriptResult": o([
+        { json: "at_end", js: "at_end", typ: true },
+        { json: "events", js: "events", typ: a(r("EventElement")) },
+        { json: "next_cursor", js: "next_cursor", typ: "" },
+        { json: "session_id", js: "session_id", typ: "" },
     ], "any"),
     "SessionUnregisteredMessage": o([
         { json: "event", js: "event", typ: r("SessionUnregisteredMessageEvent") },
@@ -10535,7 +10652,7 @@ const typeMap: any = {
         { json: "to_status", js: "to_status", typ: u(undefined, r("TicketStatus")) },
     ], "any"),
     "TicketEventBundle": o([
-        { json: "events", js: "events", typ: a(r("EventElement")) },
+        { json: "events", js: "events", typ: a(r("EventObject")) },
         { json: "ticket_id", js: "ticket_id", typ: "" },
     ], "any"),
     "TicketInboxMessage": o([
@@ -11691,6 +11808,9 @@ const typeMap: any = {
     ],
     "SessionTodosUpdatedMessageEvent": [
         "session_todos_updated",
+    ],
+    "SessionTranscriptMessageCmd": [
+        "session_transcript",
     ],
     "SessionUnregisteredMessageEvent": [
         "session_unregistered",

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -607,7 +607,7 @@ func writeHelp(w io.Writer) {
 
 commands:
   presence                          check whether the current shell runs inside attn
-	  session instructions <id>        answer a question from a session's conversation
+	  session <command>                 inspect a session's conversation
   delegate --brief-file <path>      start another agent with a delegated brief
   journal append --entry <text>     serialized append to the daily notebook journal
   workspace context <command>       edit shared workspace context

--- a/cmd/attn/session_instructions.go
+++ b/cmd/attn/session_instructions.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/victorarias/attn/internal/client"
 	"github.com/victorarias/attn/internal/daemon"
@@ -18,6 +22,13 @@ type sessionInstructionsArgs struct {
 	target   string
 	question string
 	json     bool
+}
+
+type sessionTranscriptArgs struct {
+	target string
+	after  string
+	follow bool
+	json   bool
 }
 
 func runSession() {
@@ -32,11 +43,145 @@ func runSession() {
 			return
 		}
 		runSessionInstructions(os.Args[3:])
+	case "transcript":
+		if hasHelpFlag(os.Args[3:]) {
+			writeSessionHelp(os.Stdout)
+			return
+		}
+		runSessionTranscript(os.Args[3:])
 	default:
 		fmt.Fprintf(os.Stderr, "session: unknown command %q\n", os.Args[2])
 		writeSessionHelp(os.Stderr)
 		os.Exit(2)
 	}
+}
+
+func parseSessionTranscriptArgs(args []string) (sessionTranscriptArgs, error) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return sessionTranscriptArgs{}, errors.New("exactly one target session id is required")
+	}
+	target := strings.TrimSpace(args[0])
+	args = args[1:]
+	fs := flag.NewFlagSet("session transcript", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	after := fs.String("after", "", "resume strictly after an opaque transcript cursor")
+	follow := fs.Bool("follow", false, "keep polling for new transcript events until interrupted")
+	jsonOut := fs.Bool("json", false, "print one transcript event as JSON per line")
+	if err := fs.Parse(args); err != nil {
+		return sessionTranscriptArgs{}, err
+	}
+	if target == "" || fs.NArg() != 0 {
+		return sessionTranscriptArgs{}, errors.New("exactly one target session id is required")
+	}
+	return sessionTranscriptArgs{target: target, after: strings.TrimSpace(*after), follow: *follow, json: *jsonOut}, nil
+}
+
+func runSessionTranscript(args []string) {
+	parsed, err := parseSessionTranscriptArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "session transcript: %v\n", err)
+		writeSessionHelp(os.Stderr)
+		os.Exit(2)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	cursor, err := streamSessionTranscript(ctx, os.Stdout, parsed, client.New("").SessionTranscript)
+	if cursor != "" {
+		fmt.Fprintf(os.Stderr, "cursor: %s\n", cursor)
+	}
+	if err == nil || errors.Is(err, context.Canceled) {
+		return
+	}
+	code := sessionTranscriptErrorCode(err)
+	fmt.Fprintln(os.Stderr, daemon.SessionTranscriptErrorMessage(code))
+	os.Exit(1)
+}
+
+type sessionTranscriptFetcher func(string, string) (*protocol.SessionTranscriptResult, error)
+
+func streamSessionTranscript(ctx context.Context, w io.Writer, args sessionTranscriptArgs, fetch sessionTranscriptFetcher) (string, error) {
+	cursor := args.after
+	for {
+		result, err := fetch(args.target, cursor)
+		if err != nil {
+			if args.follow && sessionTranscriptErrorCode(err) == "transcript_unavailable" {
+				if err := waitForTranscriptPoll(ctx); err != nil {
+					return cursor, err
+				}
+				continue
+			}
+			return cursor, err
+		}
+		for _, event := range result.Events {
+			if args.json {
+				if err := json.NewEncoder(w).Encode(event); err != nil {
+					return cursor, err
+				}
+			} else {
+				printSessionTranscriptEvent(w, event)
+			}
+		}
+		cursor = result.NextCursor
+
+		if !result.AtEnd {
+			continue
+		}
+		if !args.follow {
+			return cursor, nil
+		}
+		if err := waitForTranscriptPoll(ctx); err != nil {
+			return cursor, err
+		}
+	}
+}
+
+func waitForTranscriptPoll(ctx context.Context) error {
+	timer := time.NewTimer(500 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func printSessionTranscriptEvent(w io.Writer, event protocol.SessionTranscriptEvent) {
+	timestamp := "-"
+	if event.Timestamp != nil && strings.TrimSpace(*event.Timestamp) != "" {
+		timestamp = strings.TrimSpace(*event.Timestamp)
+	}
+	label := strings.ToUpper(event.Kind)
+	if event.IsError != nil && *event.IsError && event.Kind != "error" {
+		label += " ERROR"
+	}
+	fmt.Fprintf(w, "%s  %-12s", timestamp, label)
+	if event.ToolName != nil && strings.TrimSpace(*event.ToolName) != "" {
+		fmt.Fprintf(w, " %s", strings.TrimSpace(*event.ToolName))
+	}
+	if event.ToolCallID != nil && strings.TrimSpace(*event.ToolCallID) != "" {
+		fmt.Fprintf(w, " (%s)", strings.TrimSpace(*event.ToolCallID))
+	}
+	fmt.Fprintln(w)
+	if event.Text != nil && strings.TrimSpace(*event.Text) != "" {
+		for _, line := range strings.Split(strings.TrimSpace(*event.Text), "\n") {
+			fmt.Fprintf(w, "  %s\n", line)
+		}
+	}
+}
+
+func sessionTranscriptErrorCode(err error) string {
+	const prefix = "daemon error: "
+	message := strings.TrimSpace(err.Error())
+	if strings.HasPrefix(message, prefix) {
+		code := strings.TrimSpace(strings.TrimPrefix(message, prefix))
+		switch code {
+		case "session_not_found", "transcript_unavailable", "invalid_cursor", "cursor_mismatch", "cursor_past_end":
+			return code
+		}
+	}
+	return "transcript_unavailable"
 }
 
 func parseSessionInstructionsArgs(args []string) (sessionInstructionsArgs, error) {
@@ -116,12 +261,16 @@ func printSessionInstructionsTo(w io.Writer, result *protocol.SessionInstruction
 }
 
 func writeSessionHelp(w io.Writer) {
-	fmt.Fprint(w, `usage: attn session instructions <target-session-id> --question <text> [--json]
+	fmt.Fprint(w, `usage: attn session <command>
 
 commands:
   instructions <id> --question <text> [--json]
         answer a free-form question from the target session's bounded Codex
         conversation, returning validated exact excerpts. --json changes only
         presentation. Unclear is a successful answer.
+  transcript <id> [--after <cursor>] [--follow] [--json]
+        read provider-neutral, timestamped, redacted conversation and tool
+        events. --after resumes strictly after a prior cursor; --follow polls
+        until interrupted; --json emits one event per line.
 `)
 }

--- a/cmd/attn/session_instructions_test.go
+++ b/cmd/attn/session_instructions_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -20,6 +21,67 @@ func TestParseSessionInstructionsArgs(t *testing.T) {
 	for _, args := range [][]string{nil, {"--question", "x"}, {"target"}, {"target", "--question", " "}, {"target", "extra", "--question", "x"}} {
 		if _, err := parseSessionInstructionsArgs(args); err == nil {
 			t.Fatalf("parseSessionInstructionsArgs(%v) succeeded", args)
+		}
+	}
+}
+
+func TestParseSessionTranscriptArgs(t *testing.T) {
+	got, err := parseSessionTranscriptArgs([]string{"target", "--after", "v1:abc:10:0", "--follow", "--json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.target != "target" || got.after != "v1:abc:10:0" || !got.follow || !got.json {
+		t.Fatalf("got %+v", got)
+	}
+	for _, args := range [][]string{nil, {"--follow"}, {"target", "extra"}} {
+		if _, err := parseSessionTranscriptArgs(args); err == nil {
+			t.Fatalf("parseSessionTranscriptArgs(%v) succeeded", args)
+		}
+	}
+}
+
+func TestStreamSessionTranscriptPaginatesWithoutDuplicates(t *testing.T) {
+	pages := []*protocol.SessionTranscriptResult{
+		{SessionID: "target", Events: []protocol.SessionTranscriptEvent{{Cursor: "cursor-1", Kind: "user", Text: protocol.Ptr("one")}}, NextCursor: "cursor-1", AtEnd: false},
+		{SessionID: "target", Events: []protocol.SessionTranscriptEvent{{Cursor: "cursor-2", Kind: "assistant", Text: protocol.Ptr("two")}}, NextCursor: "cursor-2", AtEnd: true},
+	}
+	var cursors []string
+	fetch := func(_ string, cursor string) (*protocol.SessionTranscriptResult, error) {
+		cursors = append(cursors, cursor)
+		page := pages[len(cursors)-1]
+		return page, nil
+	}
+	var output bytes.Buffer
+	cursor, err := streamSessionTranscript(context.Background(), &output, sessionTranscriptArgs{target: "target", json: true}, fetch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cursor != "cursor-2" || len(cursors) != 2 || cursors[0] != "" || cursors[1] != "cursor-1" {
+		t.Fatalf("cursor=%q calls=%v", cursor, cursors)
+	}
+	if strings.Count(output.String(), `"kind"`) != 2 || strings.Count(output.String(), `"one"`) != 1 || strings.Count(output.String(), `"two"`) != 1 {
+		t.Fatalf("output=%q", output.String())
+	}
+}
+
+func TestSessionTranscriptErrorCodeAndRendering(t *testing.T) {
+	if got := sessionTranscriptErrorCode(errors.New("daemon error: cursor_mismatch")); got != "cursor_mismatch" {
+		t.Fatalf("code=%q", got)
+	}
+	if got := sessionTranscriptErrorCode(errors.New("socket unavailable")); got != "transcript_unavailable" {
+		t.Fatalf("code=%q", got)
+	}
+	var output bytes.Buffer
+	printSessionTranscriptEvent(&output, protocol.SessionTranscriptEvent{
+		Timestamp:  protocol.Ptr("2026-07-19T10:00:00Z"),
+		Kind:       "tool_call",
+		ToolName:   protocol.Ptr("shell"),
+		ToolCallID: protocol.Ptr("call-1"),
+		Text:       protocol.Ptr(`{"cmd":"pwd"}`),
+	})
+	for _, want := range []string{"2026-07-19T10:00:00Z", "TOOL_CALL", "shell", "call-1", `{"cmd":"pwd"}`} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("output=%q missing %q", output.String(), want)
 		}
 	}
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -202,6 +202,27 @@ func (c *Client) SessionInstructions(targetSessionID, question string) (*protoco
 	return resp.SessionInstructionsResult, nil
 }
 
+// SessionTranscript reads one provider-neutral, redacted transcript page
+// strictly after the opaque cursor. Repeating with NextCursor is lossless and
+// idempotent across daemon restarts while the native transcript is unchanged.
+func (c *Client) SessionTranscript(targetSessionID, afterCursor string) (*protocol.SessionTranscriptResult, error) {
+	msg := protocol.SessionTranscriptMessage{
+		Cmd:             protocol.CmdSessionTranscript,
+		TargetSessionID: targetSessionID,
+	}
+	if strings.TrimSpace(afterCursor) != "" {
+		msg.AfterCursor = protocol.Ptr(strings.TrimSpace(afterCursor))
+	}
+	resp, err := c.send(msg)
+	if err != nil {
+		return nil, err
+	}
+	if resp.SessionTranscriptResult == nil {
+		return nil, errors.New("daemon returned no session transcript result")
+	}
+	return resp.SessionTranscriptResult, nil
+}
+
 // SendStop sends a stop signal with transcript path for classification
 func (c *Client) SendStop(id, transcriptPath string) error {
 	msg := protocol.StopMessage{

--- a/internal/daemon/command_meta.go
+++ b/internal/daemon/command_meta.go
@@ -37,6 +37,7 @@ var CommandMeta = map[string]CommandMetadata{
 	protocol.CmdState:                                 commandMetadata(ScopeSession, false, true),
 	protocol.CmdSetSessionResumeID:                    commandMetadata(ScopeSession, false, true),
 	protocol.CmdSessionInstructions:                   commandMetadata(ScopeSession, false, true),
+	protocol.CmdSessionTranscript:                     commandMetadata(ScopeSession, false, true),
 	protocol.CmdStop:                                  commandMetadata(ScopeSession, false, true),
 	protocol.CmdTodos:                                 commandMetadata(ScopeSession, false, true),
 	protocol.CmdQuery:                                 commandMetadata(ScopeHubMerge, false, true),

--- a/internal/daemon/command_meta_test.go
+++ b/internal/daemon/command_meta_test.go
@@ -12,6 +12,8 @@ func TestCommandMetaCoversAllCommands(t *testing.T) {
 		protocol.CmdUnregister,
 		protocol.CmdState,
 		protocol.CmdSetSessionResumeID,
+		protocol.CmdSessionInstructions,
+		protocol.CmdSessionTranscript,
 		protocol.CmdStop,
 		protocol.CmdTodos,
 		protocol.CmdQuery,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2096,6 +2096,8 @@ func (d *Daemon) handleConnection(conn net.Conn) {
 		d.handleSetSessionResumeID(conn, msg.(*protocol.SetSessionResumeIDMessage))
 	case protocol.CmdSessionInstructions:
 		d.handleSessionInstructions(conn, msg.(*protocol.SessionInstructionsMessage))
+	case protocol.CmdSessionTranscript:
+		d.handleSessionTranscript(conn, msg.(*protocol.SessionTranscriptMessage))
 	case protocol.CmdStop:
 		d.handleStop(conn, msg.(*protocol.StopMessage))
 	case protocol.CmdTodos:

--- a/internal/daemon/session_transcript.go
+++ b/internal/daemon/session_transcript.go
@@ -1,0 +1,129 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/protocol"
+	"github.com/victorarias/attn/internal/transcript"
+)
+
+const sessionTranscriptPageSize = 200
+
+func (d *Daemon) handleSessionTranscript(conn net.Conn, msg *protocol.SessionTranscriptMessage) {
+	session := d.store.Get(strings.TrimSpace(msg.TargetSessionID))
+	if session == nil {
+		d.sendError(conn, "session_not_found")
+		return
+	}
+
+	path := d.inspectableTranscriptPath(session)
+	if path == "" {
+		d.sendError(conn, "transcript_unavailable")
+		return
+	}
+
+	page, err := transcript.ReadEventPage(path, string(session.Agent), strings.TrimSpace(protocol.Deref(msg.AfterCursor)), sessionTranscriptPageSize)
+	if err != nil {
+		switch {
+		case errors.Is(err, transcript.ErrInvalidCursor):
+			d.sendError(conn, "invalid_cursor")
+		case errors.Is(err, transcript.ErrCursorMismatch):
+			d.sendError(conn, "cursor_mismatch")
+		case errors.Is(err, transcript.ErrCursorPastEnd):
+			d.sendError(conn, "cursor_past_end")
+		default:
+			d.logf("session transcript read failed: session=%s err=%v", session.ID, err)
+			d.sendError(conn, "transcript_unavailable")
+		}
+		return
+	}
+
+	events := make([]protocol.SessionTranscriptEvent, 0, len(page.Events))
+	for _, event := range page.Events {
+		item := protocol.SessionTranscriptEvent{
+			Cursor: event.Cursor,
+			Kind:   event.Kind,
+		}
+		if event.Timestamp != "" {
+			item.Timestamp = protocol.Ptr(event.Timestamp)
+		}
+		if event.Role != "" {
+			item.Role = protocol.Ptr(event.Role)
+		}
+		if event.Text != "" {
+			item.Text = protocol.Ptr(event.Text)
+		}
+		if event.ToolName != "" {
+			item.ToolName = protocol.Ptr(event.ToolName)
+		}
+		if event.ToolCallID != "" {
+			item.ToolCallID = protocol.Ptr(event.ToolCallID)
+		}
+		if event.IsError {
+			item.IsError = protocol.Ptr(true)
+		}
+		events = append(events, item)
+	}
+
+	_ = json.NewEncoder(conn).Encode(protocol.Response{
+		Ok: true,
+		SessionTranscriptResult: &protocol.SessionTranscriptResult{
+			SessionID:  session.ID,
+			Events:     events,
+			NextCursor: page.NextCursor,
+			AtEnd:      page.AtEnd,
+		},
+	})
+}
+
+// inspectableTranscriptPath resolves only exact transcript identities. The
+// agent-native resume id is durable; the live watcher carries the launch-time
+// identity needed by providers whose files cannot be found by id. We never do
+// a broad cwd/newest fallback here because returning a neighboring session's
+// conversation would violate the transcript command's identity contract.
+func (d *Daemon) inspectableTranscriptPath(session *protocol.Session) string {
+	if session == nil {
+		return ""
+	}
+	driver := agentdriver.Get(string(session.Agent))
+	finder, ok := agentdriver.GetTranscriptFinder(driver)
+	if !ok {
+		return ""
+	}
+
+	if resumeID := strings.TrimSpace(d.store.GetResumeSessionID(session.ID)); resumeID != "" {
+		if path := strings.TrimSpace(finder.FindTranscriptForResume(resumeID)); path != "" {
+			return path
+		}
+	}
+
+	d.watchersMu.Lock()
+	watcher := d.transcriptWatch[session.ID]
+	d.watchersMu.Unlock()
+	if watcher != nil && watcher.agent == session.Agent {
+		return d.findTranscriptPathForWatcher(watcher)
+	}
+	return ""
+}
+
+// SessionTranscriptErrorMessage is the stable, transcript-free CLI surface.
+func SessionTranscriptErrorMessage(code string) string {
+	switch strings.TrimSpace(code) {
+	case "session_not_found":
+		return "The target session was not found"
+	case "transcript_unavailable":
+		return "The target transcript is unavailable"
+	case "invalid_cursor":
+		return "The transcript cursor is invalid"
+	case "cursor_mismatch":
+		return "The transcript cursor belongs to a different transcript"
+	case "cursor_past_end":
+		return "The transcript cursor is past the end of the transcript"
+	default:
+		return "Session transcript failed"
+	}
+}

--- a/internal/daemon/session_transcript_test.go
+++ b/internal/daemon/session_transcript_test.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func callSessionTranscript(t *testing.T, d *Daemon, msg *protocol.SessionTranscriptMessage) protocol.Response {
+	t.Helper()
+	server, client := net.Pipe()
+	defer client.Close()
+	go func() {
+		d.handleSessionTranscript(server, msg)
+		_ = server.Close()
+	}()
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var response protocol.Response
+	if err := json.NewDecoder(client).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
+func TestHandleSessionTranscriptResolvesNativeIDAndReturnsRedactedEvents(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	transcriptDir := filepath.Join(codexHome, "sessions", "2026", "07", "19")
+	if err := os.MkdirAll(transcriptDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(transcriptDir, "rollout.jsonl")
+	content := strings.Join([]string{
+		`{"timestamp":"2026-07-19T10:00:00Z","type":"session_meta","payload":{"id":"native-session"}}`,
+		`{"timestamp":"2026-07-19T10:00:01Z","type":"event_msg","payload":{"type":"user_message","message":"token=do-not-leak"}}`,
+		`{"timestamp":"2026-07-19T10:00:02Z","type":"event_msg","payload":{"type":"agent_message","message":"done"}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "attn.sock"))
+	d.store.Add(&protocol.Session{
+		ID: "attn-session", Agent: protocol.SessionAgentCodex, Directory: t.TempDir(),
+		WorkspaceID: "workspace", State: protocol.SessionStateWorking,
+		StateSince: "2026-07-19T10:00:00Z", StateUpdatedAt: "2026-07-19T10:00:00Z", LastSeen: "2026-07-19T10:00:00Z",
+	})
+	d.store.SetResumeSessionID("attn-session", "native-session")
+
+	response := callSessionTranscript(t, d, &protocol.SessionTranscriptMessage{Cmd: protocol.CmdSessionTranscript, TargetSessionID: "attn-session"})
+	if !response.Ok || response.SessionTranscriptResult == nil {
+		t.Fatalf("response = %+v", response)
+	}
+	result := response.SessionTranscriptResult
+	if !result.AtEnd || result.NextCursor == "" || len(result.Events) != 2 {
+		t.Fatalf("result = %+v", result)
+	}
+	if text := protocol.Deref(result.Events[0].Text); strings.Contains(text, "do-not-leak") || !strings.Contains(text, "[REDACTED]") {
+		t.Fatalf("redacted event text = %q", text)
+	}
+
+	resumed := callSessionTranscript(t, d, &protocol.SessionTranscriptMessage{
+		Cmd: protocol.CmdSessionTranscript, TargetSessionID: "attn-session", AfterCursor: protocol.Ptr(result.NextCursor),
+	})
+	if !resumed.Ok || resumed.SessionTranscriptResult == nil || len(resumed.SessionTranscriptResult.Events) != 0 {
+		t.Fatalf("resumed response = %+v", resumed)
+	}
+}
+
+func TestHandleSessionTranscriptReturnsStableErrors(t *testing.T) {
+	d := NewForTesting(filepath.Join(t.TempDir(), "attn.sock"))
+	response := callSessionTranscript(t, d, &protocol.SessionTranscriptMessage{Cmd: protocol.CmdSessionTranscript, TargetSessionID: "missing"})
+	if response.Ok || protocol.Deref(response.Error) != "session_not_found" {
+		t.Fatalf("response = %+v", response)
+	}
+	if got := SessionTranscriptErrorMessage("cursor_mismatch"); got != "The transcript cursor belongs to a different transcript" {
+		t.Fatalf("message = %q", got)
+	}
+}

--- a/internal/protocol/constants.go
+++ b/internal/protocol/constants.go
@@ -10,7 +10,7 @@ import (
 // ProtocolVersion is the version of the daemon-client protocol.
 // Increment this when making breaking changes to the protocol.
 // Client and daemon must have matching versions.
-const ProtocolVersion = "174"
+const ProtocolVersion = "175"
 
 // CapabilityWorkspaceSessions is required for websocket clients that use the
 // interactive daemon API. Clients without it are not workspace-first clients.
@@ -96,6 +96,7 @@ const (
 	CmdState                                 = "state"
 	CmdSetSessionResumeID                    = "set_session_resume_id"
 	CmdSessionInstructions                   = "session_instructions"
+	CmdSessionTranscript                     = "session_transcript"
 	CmdStop                                  = "stop"
 	CmdTodos                                 = "todos"
 	CmdQuery                                 = "query"
@@ -801,6 +802,13 @@ func ParseMessage(data []byte) (string, interface{}, error) {
 
 	case CmdSessionInstructions:
 		var msg SessionInstructionsMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return "", nil, err
+		}
+		return peek.Cmd, &msg, nil
+
+	case CmdSessionTranscript:
+		var msg SessionTranscriptMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return "", nil, err
 		}

--- a/internal/protocol/generated.go
+++ b/internal/protocol/generated.go
@@ -3367,6 +3367,10 @@ type Response struct {
 	// "session_instructions_result".
 	SessionInstructionsResult *SessionInstructionsResult `json:"session_instructions_result,omitempty,omitzero"`
 
+	// SessionTranscriptResult corresponds to the JSON schema field
+	// "session_transcript_result".
+	SessionTranscriptResult *SessionTranscriptResult `json:"session_transcript_result,omitempty,omitzero"`
+
 	// Sessions corresponds to the JSON schema field "sessions".
 	Sessions []Session `json:"sessions,omitempty,omitzero"`
 
@@ -3616,6 +3620,57 @@ type SessionTodosUpdatedMessage struct {
 
 	// Session corresponds to the JSON schema field "session".
 	Session Session `json:"session"`
+}
+
+type SessionTranscriptEvent struct {
+	// Cursor corresponds to the JSON schema field "cursor".
+	Cursor string `json:"cursor"`
+
+	// IsError corresponds to the JSON schema field "is_error".
+	IsError *bool `json:"is_error,omitempty,omitzero"`
+
+	// Kind corresponds to the JSON schema field "kind".
+	Kind string `json:"kind"`
+
+	// Role corresponds to the JSON schema field "role".
+	Role *string `json:"role,omitempty,omitzero"`
+
+	// Text corresponds to the JSON schema field "text".
+	Text *string `json:"text,omitempty,omitzero"`
+
+	// Timestamp corresponds to the JSON schema field "timestamp".
+	Timestamp *string `json:"timestamp,omitempty,omitzero"`
+
+	// ToolCallID corresponds to the JSON schema field "tool_call_id".
+	ToolCallID *string `json:"tool_call_id,omitempty,omitzero"`
+
+	// ToolName corresponds to the JSON schema field "tool_name".
+	ToolName *string `json:"tool_name,omitempty,omitzero"`
+}
+
+type SessionTranscriptMessage struct {
+	// AfterCursor corresponds to the JSON schema field "after_cursor".
+	AfterCursor *string `json:"after_cursor,omitempty,omitzero"`
+
+	// Cmd corresponds to the JSON schema field "cmd".
+	Cmd string `json:"cmd"`
+
+	// TargetSessionID corresponds to the JSON schema field "target_session_id".
+	TargetSessionID string `json:"target_session_id"`
+}
+
+type SessionTranscriptResult struct {
+	// AtEnd corresponds to the JSON schema field "at_end".
+	AtEnd bool `json:"at_end"`
+
+	// Events corresponds to the JSON schema field "events".
+	Events []SessionTranscriptEvent `json:"events"`
+
+	// NextCursor corresponds to the JSON schema field "next_cursor".
+	NextCursor string `json:"next_cursor"`
+
+	// SessionID corresponds to the JSON schema field "session_id".
+	SessionID string `json:"session_id"`
 }
 
 type SessionUnregisteredMessage struct {

--- a/internal/protocol/parse_test.go
+++ b/internal/protocol/parse_test.go
@@ -165,6 +165,21 @@ func TestParseRegister(t *testing.T) {
 	}
 }
 
+func TestParseSessionTranscript(t *testing.T) {
+	input := `{"cmd":"session_transcript","target_session_id":"session-1","after_cursor":"v1:0123456789abcdef0123456789abcdef:42:0"}`
+	cmd, data, err := ParseMessage([]byte(input))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if cmd != CmdSessionTranscript {
+		t.Fatalf("cmd = %q, want %q", cmd, CmdSessionTranscript)
+	}
+	msg, ok := data.(*SessionTranscriptMessage)
+	if !ok || msg.TargetSessionID != "session-1" || Deref(msg.AfterCursor) != "v1:0123456789abcdef0123456789abcdef:42:0" {
+		t.Fatalf("message = %#v", data)
+	}
+}
+
 func TestParseDelegatePlacementAndWorktree(t *testing.T) {
 	input := `{"cmd":"delegate","source_session_id":"source-1","brief":"Investigate this","agent":"codex","placement":"new_workspace","worktree":{"repo":"/repo","branch":"feat/delegated","starting_from":"main"}}`
 	cmd, data, err := ParseMessage([]byte(input))

--- a/internal/protocol/schema/main.tsp
+++ b/internal/protocol/schema/main.tsp
@@ -613,6 +613,14 @@ model SessionInstructionsMessage {
   question: string;
 }
 
+// Reads provider-neutral, redacted transcript events strictly after the opaque
+// cursor. The daemon owns native transcript discovery and cursor validation.
+model SessionTranscriptMessage {
+  cmd: "session_transcript";
+  target_session_id: string;
+  after_cursor?: string;
+}
+
 model StopMessage {
   cmd: "stop";
   id: string;
@@ -2730,6 +2738,7 @@ model Response {
   present_open_result?: PresentOpenResult;
   present_feedback_result?: PresentFeedbackResult;
   session_instructions_result?: SessionInstructionsResult;
+  session_transcript_result?: SessionTranscriptResult;
 }
 
 model EvidenceExcerpt {
@@ -2747,6 +2756,26 @@ model SessionInstructionsResult {
   transcript_fingerprint: string;
   `model`: string;
   reasoning_effort: string;
+}
+
+// Stable transcript contract. Provider-specific JSONL records never cross the
+// daemon boundary; new runtimes normalize into these existing event kinds.
+model SessionTranscriptEvent {
+  cursor: string;
+  timestamp?: string;
+  kind: string; // "user" | "assistant" | "tool_call" | "tool_result" | "error"
+  role?: string;
+  text?: string;
+  tool_name?: string;
+  tool_call_id?: string;
+  is_error?: boolean;
+}
+
+model SessionTranscriptResult {
+  session_id: string;
+  events: SessionTranscriptEvent[];
+  next_cursor: string;
+  at_end: boolean;
 }
 
 model DelegateResult {

--- a/internal/transcript/events.go
+++ b/internal/transcript/events.go
@@ -1,0 +1,556 @@
+package transcript
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	EventKindUser       = "user"
+	EventKindAssistant  = "assistant"
+	EventKindToolCall   = "tool_call"
+	EventKindToolResult = "tool_result"
+	EventKindError      = "error"
+
+	defaultEventPageSize = 200
+	cursorVersion        = "v1"
+)
+
+var (
+	ErrInvalidCursor  = errors.New("invalid transcript cursor")
+	ErrCursorMismatch = errors.New("transcript cursor does not match this transcript")
+	ErrCursorPastEnd  = errors.New("transcript cursor is past the end of the transcript")
+
+	bearerSecretPattern     = regexp.MustCompile(`(?i)\b(bearer\s+)[A-Za-z0-9._~+/=-]+`)
+	assignmentSecretPattern = regexp.MustCompile(`(?i)(\b(?:api[_-]?key|access[_-]?token|auth[_-]?token|token|password|passwd|secret|authorization|cookie|private[_-]?key)\b\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;}]+)`)
+	knownTokenPattern       = regexp.MustCompile(`\b(?:github_pat_[A-Za-z0-9_]{12,}|gh[opusr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16})\b`)
+	urlCredentialPattern    = regexp.MustCompile(`(https?://[^\s:/@]+:)[^\s/@]+(@)`)
+	privateKeyPattern       = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
+	toolFailurePattern      = regexp.MustCompile(`(?i)(?:process|script|command) exited with (?:code )?[1-9][0-9]*|["']?exit_code["']?\s*[:=]\s*[1-9][0-9]*`)
+)
+
+// Event is attn's stable, provider-neutral transcript record. Cursor identifies
+// the event within its source record so a consumer can checkpoint after every
+// emitted event without skipping siblings decoded from the same JSONL line.
+type Event struct {
+	Cursor     string `json:"cursor"`
+	Timestamp  string `json:"timestamp,omitempty"`
+	Kind       string `json:"kind"`
+	Role       string `json:"role,omitempty"`
+	Text       string `json:"text,omitempty"`
+	ToolName   string `json:"tool_name,omitempty"`
+	ToolCallID string `json:"tool_call_id,omitempty"`
+	IsError    bool   `json:"is_error,omitempty"`
+}
+
+// EventPage is one bounded read of a transcript. NextCursor advances across
+// both emitted events and ignored provider noise so follow-mode polling never
+// repeatedly parses the same source records.
+type EventPage struct {
+	Events     []Event
+	NextCursor string
+	AtEnd      bool
+}
+
+// ReadEventPage reads complete JSONL records strictly after cursor. It never
+// consumes a partially written final record, so a later call can decode it
+// exactly once after the writer appends its newline.
+func ReadEventPage(path, agent, cursor string, maxEvents int) (EventPage, error) {
+	if maxEvents <= 0 {
+		maxEvents = defaultEventPageSize
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return EventPage{}, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return EventPage{}, err
+	}
+	fingerprint, hasCompleteRecord, err := transcriptFingerprint(f)
+	if err != nil {
+		return EventPage{}, err
+	}
+
+	offset := int64(0)
+	skipEvents := 0
+	if strings.TrimSpace(cursor) != "" {
+		cursorFingerprint, cursorOffset, cursorEventIndex, decodeErr := decodeEventCursor(cursor)
+		if decodeErr != nil {
+			return EventPage{}, decodeErr
+		}
+		if !hasCompleteRecord || cursorFingerprint != fingerprint {
+			return EventPage{}, ErrCursorMismatch
+		}
+		if cursorOffset > info.Size() {
+			return EventPage{}, ErrCursorPastEnd
+		}
+		if cursorOffset > 0 {
+			var previous [1]byte
+			if _, err := f.ReadAt(previous[:], cursorOffset-1); err != nil || previous[0] != '\n' {
+				return EventPage{}, ErrInvalidCursor
+			}
+		}
+		offset = cursorOffset
+		skipEvents = cursorEventIndex
+	}
+
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return EventPage{}, err
+	}
+
+	page := EventPage{Events: []Event{}, NextCursor: strings.TrimSpace(cursor)}
+	reader := bufio.NewReader(f)
+	for {
+		record, readErr := reader.ReadBytes('\n')
+		complete := len(record) > 0 && record[len(record)-1] == '\n'
+		if !complete {
+			if readErr != nil && !errors.Is(readErr, io.EOF) {
+				return EventPage{}, readErr
+			}
+			page.AtEnd = true
+			return page, nil
+		}
+
+		lineOffset := offset
+		nextOffset := offset + int64(len(record))
+		line := bytes.TrimSpace(record)
+		allEvents := parseEventLine(agent, line)
+		if skipEvents > len(allEvents) {
+			return EventPage{}, ErrInvalidCursor
+		}
+		events := allEvents[skipEvents:]
+
+		remaining := maxEvents - len(page.Events)
+		if len(events) > remaining {
+			events = events[:remaining]
+		}
+		for i := range events {
+			events[i].Cursor = encodeEventCursor(fingerprint, lineOffset, skipEvents+i+1)
+			redactEvent(&events[i])
+		}
+		page.Events = append(page.Events, events...)
+		if len(events) > 0 {
+			page.NextCursor = events[len(events)-1].Cursor
+		}
+
+		if len(page.Events) >= maxEvents {
+			return page, nil
+		}
+
+		offset = nextOffset
+		skipEvents = 0
+		if hasCompleteRecord {
+			page.NextCursor = encodeEventCursor(fingerprint, offset, 0)
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				page.AtEnd = true
+				return page, nil
+			}
+			return EventPage{}, readErr
+		}
+	}
+}
+
+func transcriptFingerprint(f *os.File) (string, bool, error) {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return "", false, err
+	}
+	record, err := bufio.NewReader(f).ReadBytes('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", false, err
+	}
+	if len(record) == 0 || record[len(record)-1] != '\n' {
+		return "", false, nil
+	}
+	sum := sha256.Sum256(bytes.TrimSpace(record))
+	return hex.EncodeToString(sum[:16]), true, nil
+}
+
+func encodeEventCursor(fingerprint string, offset int64, eventIndex int) string {
+	return fmt.Sprintf("%s:%s:%d:%d", cursorVersion, fingerprint, offset, eventIndex)
+}
+
+func decodeEventCursor(cursor string) (string, int64, int, error) {
+	parts := strings.Split(strings.TrimSpace(cursor), ":")
+	if len(parts) != 4 || parts[0] != cursorVersion || len(parts[1]) != 32 {
+		return "", 0, 0, ErrInvalidCursor
+	}
+	if _, err := hex.DecodeString(parts[1]); err != nil {
+		return "", 0, 0, ErrInvalidCursor
+	}
+	offset, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil || offset < 0 {
+		return "", 0, 0, ErrInvalidCursor
+	}
+	eventIndex, err := strconv.Atoi(parts[3])
+	if err != nil || eventIndex < 0 {
+		return "", 0, 0, ErrInvalidCursor
+	}
+	return parts[1], offset, eventIndex, nil
+}
+
+type eventEnvelope struct {
+	Type      string           `json:"type"`
+	Timestamp string           `json:"timestamp"`
+	Subtype   string           `json:"subtype"`
+	Error     string           `json:"error"`
+	Result    string           `json:"result"`
+	IsError   bool             `json:"is_error"`
+	Origin    *sliceLineOrigin `json:"origin"`
+	Message   json.RawMessage  `json:"message"`
+	Payload   json.RawMessage  `json:"payload"`
+	Data      json.RawMessage  `json:"data"`
+}
+
+type eventMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+type eventContentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Input     json.RawMessage `json:"input"`
+	ToolUseID string          `json:"tool_use_id"`
+	Content   json.RawMessage `json:"content"`
+	IsError   bool            `json:"is_error"`
+}
+
+func parseEventLine(agent string, line []byte) []Event {
+	if len(line) == 0 {
+		return nil
+	}
+	var envelope eventEnvelope
+	if err := json.Unmarshal(line, &envelope); err != nil {
+		return nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(agent)) {
+	case "claude":
+		return parseClaudeEvent(envelope)
+	case "copilot":
+		return parseCopilotEvent(envelope)
+	case "codex":
+		return parseCodexEvent(envelope)
+	default:
+		return nil
+	}
+}
+
+func parseCodexEvent(envelope eventEnvelope) []Event {
+	switch envelope.Type {
+	case "event_msg":
+		var payload struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+			Error   string `json:"error"`
+		}
+		if json.Unmarshal(envelope.Payload, &payload) != nil {
+			return nil
+		}
+		switch payload.Type {
+		case "user_message":
+			return textEvent(envelope.Timestamp, EventKindUser, "user", payload.Message)
+		case "agent_message":
+			return textEvent(envelope.Timestamp, EventKindAssistant, "assistant", payload.Message)
+		}
+		if strings.Contains(payload.Type, "error") || payload.Error != "" {
+			return textEvent(envelope.Timestamp, EventKindError, "", firstNonEmpty(payload.Error, payload.Message))
+		}
+	case "response_item":
+		var payload struct {
+			Type   string          `json:"type"`
+			Name   string          `json:"name"`
+			CallID string          `json:"call_id"`
+			Input  json.RawMessage `json:"input"`
+			Output json.RawMessage `json:"output"`
+			Status string          `json:"status"`
+			Error  string          `json:"error"`
+		}
+		if json.Unmarshal(envelope.Payload, &payload) != nil {
+			return nil
+		}
+		switch payload.Type {
+		case "custom_tool_call", "function_call":
+			return []Event{{
+				Timestamp:  envelope.Timestamp,
+				Kind:       EventKindToolCall,
+				ToolName:   payload.Name,
+				ToolCallID: payload.CallID,
+				Text:       renderJSONValue(payload.Input),
+				IsError:    strings.EqualFold(payload.Status, "failed"),
+			}}
+		case "custom_tool_call_output", "function_call_output":
+			text := renderJSONValue(payload.Output)
+			return []Event{{
+				Timestamp:  envelope.Timestamp,
+				Kind:       EventKindToolResult,
+				ToolCallID: payload.CallID,
+				Text:       text,
+				IsError:    strings.EqualFold(payload.Status, "failed") || payload.Error != "" || toolFailurePattern.MatchString(text),
+			}}
+		}
+		if strings.Contains(payload.Type, "error") || payload.Error != "" {
+			return textEvent(envelope.Timestamp, EventKindError, "", payload.Error)
+		}
+	case "error":
+		var payload struct {
+			Message string `json:"message"`
+			Error   string `json:"error"`
+		}
+		_ = json.Unmarshal(envelope.Payload, &payload)
+		return textEvent(envelope.Timestamp, EventKindError, "", firstNonEmpty(payload.Error, payload.Message))
+	}
+	return nil
+}
+
+func parseClaudeEvent(envelope eventEnvelope) []Event {
+	if envelope.Type != "user" && envelope.Type != "assistant" && envelope.Type != "system" && envelope.Type != "result" {
+		return nil
+	}
+
+	if envelope.Type == "system" || envelope.Type == "result" {
+		if envelope.IsError || strings.Contains(envelope.Subtype, "error") || envelope.Error != "" {
+			return textEvent(envelope.Timestamp, EventKindError, "", firstNonEmpty(envelope.Error, envelope.Result, extractEventMessageText(envelope.Message)))
+		}
+		return nil
+	}
+
+	var message eventMessage
+	if json.Unmarshal(envelope.Message, &message) != nil {
+		return nil
+	}
+	blocks := decodeEventContent(message.Content)
+	var events []Event
+	var textParts []string
+	for _, block := range blocks {
+		switch block.Type {
+		case "text", "input_text", "output_text":
+			if strings.TrimSpace(block.Text) != "" {
+				textParts = append(textParts, block.Text)
+			}
+		case "tool_use":
+			events = append(events, Event{
+				Timestamp:  envelope.Timestamp,
+				Kind:       EventKindToolCall,
+				ToolName:   block.Name,
+				ToolCallID: block.ID,
+				Text:       renderJSONValue(block.Input),
+			})
+		case "tool_result":
+			events = append(events, Event{
+				Timestamp:  envelope.Timestamp,
+				Kind:       EventKindToolResult,
+				ToolCallID: block.ToolUseID,
+				Text:       renderJSONValue(block.Content),
+				IsError:    block.IsError,
+			})
+		}
+	}
+
+	text := strings.Join(textParts, "\n")
+	if strings.TrimSpace(text) != "" {
+		if envelope.Type == "assistant" {
+			events = append([]Event{{Timestamp: envelope.Timestamp, Kind: EventKindAssistant, Role: "assistant", Text: text}}, events...)
+		} else if envelope.Origin == nil || envelope.Origin.Kind == "human" {
+			events = append([]Event{{Timestamp: envelope.Timestamp, Kind: EventKindUser, Role: "user", Text: text}}, events...)
+		}
+	}
+	return events
+}
+
+func parseCopilotEvent(envelope eventEnvelope) []Event {
+	var data struct {
+		Content    string          `json:"content"`
+		ToolCallID string          `json:"toolCallId"`
+		ToolName   string          `json:"toolName"`
+		Arguments  json.RawMessage `json:"arguments"`
+		Output     json.RawMessage `json:"output"`
+		Result     json.RawMessage `json:"result"`
+		Error      string          `json:"error"`
+		Message    string          `json:"message"`
+		Success    *bool           `json:"success"`
+		Timestamp  string          `json:"timestamp"`
+	}
+	if json.Unmarshal(envelope.Data, &data) != nil {
+		return nil
+	}
+	timestamp := firstNonEmpty(envelope.Timestamp, data.Timestamp)
+	switch envelope.Type {
+	case "user.message":
+		return textEvent(timestamp, EventKindUser, "user", data.Content)
+	case "assistant.message":
+		return textEvent(timestamp, EventKindAssistant, "assistant", data.Content)
+	case "tool.execution_start":
+		return []Event{{
+			Timestamp:  timestamp,
+			Kind:       EventKindToolCall,
+			ToolName:   data.ToolName,
+			ToolCallID: data.ToolCallID,
+			Text:       renderJSONValue(data.Arguments),
+		}}
+	case "tool.execution_complete":
+		isError := data.Error != "" || (data.Success != nil && !*data.Success)
+		return []Event{{
+			Timestamp:  timestamp,
+			Kind:       EventKindToolResult,
+			ToolCallID: data.ToolCallID,
+			Text:       firstNonEmpty(renderJSONValue(data.Output), renderJSONValue(data.Result), data.Error),
+			IsError:    isError,
+		}}
+	}
+	if strings.Contains(envelope.Type, "error") || data.Error != "" {
+		return textEvent(timestamp, EventKindError, "", firstNonEmpty(data.Error, data.Message, data.Content))
+	}
+	return nil
+}
+
+func decodeEventContent(raw json.RawMessage) []eventContentBlock {
+	if len(raw) == 0 {
+		return nil
+	}
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return []eventContentBlock{{Type: "text", Text: text}}
+	}
+	var blocks []eventContentBlock
+	if json.Unmarshal(raw, &blocks) == nil {
+		return blocks
+	}
+	return nil
+}
+
+func extractEventMessageText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return text
+	}
+	var message eventMessage
+	if json.Unmarshal(raw, &message) != nil {
+		return ""
+	}
+	var parts []string
+	for _, block := range decodeEventContent(message.Content) {
+		if strings.TrimSpace(block.Text) != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func textEvent(timestamp, kind, role, text string) []Event {
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	return []Event{{Timestamp: timestamp, Kind: kind, Role: role, Text: text}}
+}
+
+func renderJSONValue(raw json.RawMessage) string {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return ""
+	}
+	var value any
+	if json.Unmarshal(raw, &value) != nil {
+		return strings.TrimSpace(string(raw))
+	}
+	value = redactJSONValue(value, "")
+	if text, ok := value.(string); ok {
+		var nested any
+		if json.Unmarshal([]byte(text), &nested) == nil {
+			nested = redactJSONValue(nested, "")
+			if encoded, err := json.Marshal(nested); err == nil {
+				return string(encoded)
+			}
+		}
+		return RedactText(text)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func redactEvent(event *Event) {
+	event.Timestamp = strings.TrimSpace(event.Timestamp)
+	event.Role = strings.TrimSpace(event.Role)
+	event.ToolName = RedactText(strings.TrimSpace(event.ToolName))
+	event.ToolCallID = RedactText(strings.TrimSpace(event.ToolCallID))
+	event.Text = RedactText(strings.TrimSpace(event.Text))
+}
+
+// RedactText removes common credential forms from all human-readable event
+// fields. Structured tool payloads are additionally redacted by key before
+// rendering, while these patterns cover secrets embedded in plain output.
+func RedactText(text string) string {
+	if text == "" {
+		return ""
+	}
+	text = privateKeyPattern.ReplaceAllString(text, "[REDACTED PRIVATE KEY]")
+	text = bearerSecretPattern.ReplaceAllString(text, `${1}[REDACTED]`)
+	text = assignmentSecretPattern.ReplaceAllString(text, `${1}[REDACTED]`)
+	text = knownTokenPattern.ReplaceAllString(text, "[REDACTED]")
+	text = urlCredentialPattern.ReplaceAllString(text, `${1}[REDACTED]${2}`)
+	return text
+}
+
+func redactJSONValue(value any, key string) any {
+	if isSensitiveKey(key) {
+		return "[REDACTED]"
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		for childKey, child := range typed {
+			typed[childKey] = redactJSONValue(child, childKey)
+		}
+		return typed
+	case []any:
+		for i := range typed {
+			typed[i] = redactJSONValue(typed[i], "")
+		}
+		return typed
+	case string:
+		return RedactText(typed)
+	default:
+		return value
+	}
+}
+
+func isSensitiveKey(key string) bool {
+	normalized := strings.ToLower(strings.NewReplacer("-", "", "_", "", " ", "").Replace(key))
+	switch normalized {
+	case "apikey", "accesstoken", "authtoken", "token", "password", "passwd", "secret", "authorization", "cookie", "privatekey", "clientsecret":
+		return true
+	default:
+		return strings.HasSuffix(normalized, "token") || strings.HasSuffix(normalized, "secret") || strings.HasSuffix(normalized, "password")
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/transcript/events.go
+++ b/internal/transcript/events.go
@@ -111,6 +111,10 @@ func ReadEventPage(path, agent, cursor string, maxEvents int) (EventPage, error)
 	if _, err := f.Seek(offset, io.SeekStart); err != nil {
 		return EventPage{}, err
 	}
+	previousEvent, hasPreviousEvent, err := previousNormalizedEvent(f, agent, offset)
+	if err != nil {
+		return EventPage{}, err
+	}
 
 	page := EventPage{Events: []Event{}, NextCursor: strings.TrimSpace(cursor)}
 	reader := bufio.NewReader(f)
@@ -128,9 +132,18 @@ func ReadEventPage(path, agent, cursor string, maxEvents int) (EventPage, error)
 		lineOffset := offset
 		nextOffset := offset + int64(len(record))
 		line := bytes.TrimSpace(record)
-		allEvents := parseEventLine(agent, line)
+		parsed := parseEventLine(agent, line)
+		allEvents := parsed.events
+		if parsed.dedupeAssistantEcho && hasPreviousEvent &&
+			previousEvent.Kind == EventKindAssistant && previousEvent.Text == allEvents[0].Text {
+			allEvents = nil
+		}
 		if skipEvents > len(allEvents) {
 			return EventPage{}, ErrInvalidCursor
+		}
+		if skipEvents > 0 {
+			previousEvent = allEvents[skipEvents-1]
+			hasPreviousEvent = true
 		}
 		events := allEvents[skipEvents:]
 
@@ -145,6 +158,10 @@ func ReadEventPage(path, agent, cursor string, maxEvents int) (EventPage, error)
 		page.Events = append(page.Events, events...)
 		if len(events) > 0 {
 			page.NextCursor = events[len(events)-1].Cursor
+		}
+		if len(allEvents) > 0 {
+			previousEvent = allEvents[len(allEvents)-1]
+			hasPreviousEvent = true
 		}
 
 		if len(page.Events) >= maxEvents {
@@ -164,6 +181,62 @@ func ReadEventPage(path, agent, cursor string, maxEvents int) (EventPage, error)
 			return EventPage{}, readErr
 		}
 	}
+}
+
+func previousNormalizedEvent(f *os.File, agent string, before int64) (Event, bool, error) {
+	for before > 0 {
+		line, start, ok, err := previousCompleteLine(f, before)
+		if err != nil {
+			return Event{}, false, err
+		}
+		if !ok {
+			return Event{}, false, nil
+		}
+		parsed := parseEventLine(agent, bytes.TrimSpace(line))
+		if len(parsed.events) > 0 {
+			return parsed.events[len(parsed.events)-1], true, nil
+		}
+		before = start
+	}
+	return Event{}, false, nil
+}
+
+func previousCompleteLine(f *os.File, before int64) ([]byte, int64, bool, error) {
+	end := before
+	var last [1]byte
+	if _, err := f.ReadAt(last[:], end-1); err != nil {
+		return nil, 0, false, err
+	}
+	if last[0] == '\n' {
+		end--
+	}
+	if end <= 0 {
+		return nil, 0, false, nil
+	}
+
+	const chunkSize int64 = 4096
+	for searchEnd := end; searchEnd > 0; {
+		searchStart := max(int64(0), searchEnd-chunkSize)
+		chunk := make([]byte, searchEnd-searchStart)
+		if _, err := f.ReadAt(chunk, searchStart); err != nil {
+			return nil, 0, false, err
+		}
+		if newline := bytes.LastIndexByte(chunk, '\n'); newline >= 0 {
+			start := searchStart + int64(newline) + 1
+			line := make([]byte, end-start)
+			if _, err := f.ReadAt(line, start); err != nil {
+				return nil, 0, false, err
+			}
+			return line, start, true, nil
+		}
+		searchEnd = searchStart
+	}
+
+	line := make([]byte, end)
+	if _, err := f.ReadAt(line, 0); err != nil {
+		return nil, 0, false, err
+	}
+	return line, 0, true, nil
 }
 
 func transcriptFingerprint(f *os.File) (string, bool, error) {
@@ -233,24 +306,33 @@ type eventContentBlock struct {
 	IsError   bool            `json:"is_error"`
 }
 
-func parseEventLine(agent string, line []byte) []Event {
+type parsedEventLine struct {
+	events              []Event
+	dedupeAssistantEcho bool
+}
+
+func parseEventLine(agent string, line []byte) parsedEventLine {
 	if len(line) == 0 {
-		return nil
+		return parsedEventLine{}
 	}
 	var envelope eventEnvelope
 	if err := json.Unmarshal(line, &envelope); err != nil {
-		return nil
+		return parsedEventLine{}
 	}
 
 	switch strings.ToLower(strings.TrimSpace(agent)) {
 	case "claude":
-		return parseClaudeEvent(envelope)
+		return parsedEventLine{events: parseClaudeEvent(envelope)}
 	case "copilot":
-		return parseCopilotEvent(envelope)
+		return parsedEventLine{events: parseCopilotEvent(envelope)}
 	case "codex":
-		return parseCodexEvent(envelope)
+		events := parseCodexEvent(envelope)
+		return parsedEventLine{
+			events:              events,
+			dedupeAssistantEcho: envelope.Type == "response_item" && len(events) == 1 && events[0].Kind == EventKindAssistant,
+		}
 	default:
-		return nil
+		return parsedEventLine{}
 	}
 }
 
@@ -276,18 +358,24 @@ func parseCodexEvent(envelope eventEnvelope) []Event {
 		}
 	case "response_item":
 		var payload struct {
-			Type   string          `json:"type"`
-			Name   string          `json:"name"`
-			CallID string          `json:"call_id"`
-			Input  json.RawMessage `json:"input"`
-			Output json.RawMessage `json:"output"`
-			Status string          `json:"status"`
-			Error  string          `json:"error"`
+			Type    string          `json:"type"`
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+			Name    string          `json:"name"`
+			CallID  string          `json:"call_id"`
+			Input   json.RawMessage `json:"input"`
+			Output  json.RawMessage `json:"output"`
+			Status  string          `json:"status"`
+			Error   string          `json:"error"`
 		}
 		if json.Unmarshal(envelope.Payload, &payload) != nil {
 			return nil
 		}
 		switch payload.Type {
+		case "message":
+			if payload.Role == "assistant" {
+				return textEvent(envelope.Timestamp, EventKindAssistant, "assistant", extractEventContentText(payload.Content))
+			}
 		case "custom_tool_call", "function_call":
 			return []Event{{
 				Timestamp:  envelope.Timestamp,
@@ -449,8 +537,12 @@ func extractEventMessageText(raw json.RawMessage) string {
 	if json.Unmarshal(raw, &message) != nil {
 		return ""
 	}
+	return extractEventContentText(message.Content)
+}
+
+func extractEventContentText(raw json.RawMessage) string {
 	var parts []string
-	for _, block := range decodeEventContent(message.Content) {
+	for _, block := range decodeEventContent(raw) {
 		if strings.TrimSpace(block.Text) != "" {
 			parts = append(parts, block.Text)
 		}

--- a/internal/transcript/events.go
+++ b/internal/transcript/events.go
@@ -134,16 +134,11 @@ func ReadEventPage(path, agent, cursor string, maxEvents int) (EventPage, error)
 		line := bytes.TrimSpace(record)
 		parsed := parseEventLine(agent, line)
 		allEvents := parsed.events
-		if parsed.dedupeAssistantEcho && hasPreviousEvent &&
-			previousEvent.Kind == EventKindAssistant && previousEvent.Text == allEvents[0].Text {
+		if isDuplicateAssistantEcho(parsed, previousEvent, hasPreviousEvent) {
 			allEvents = nil
 		}
 		if skipEvents > len(allEvents) {
 			return EventPage{}, ErrInvalidCursor
-		}
-		if skipEvents > 0 {
-			previousEvent = allEvents[skipEvents-1]
-			hasPreviousEvent = true
 		}
 		events := allEvents[skipEvents:]
 
@@ -307,8 +302,8 @@ type eventContentBlock struct {
 }
 
 type parsedEventLine struct {
-	events              []Event
-	dedupeAssistantEcho bool
+	events                 []Event
+	assistantEchoCandidate bool
 }
 
 func parseEventLine(agent string, line []byte) parsedEventLine {
@@ -328,12 +323,21 @@ func parseEventLine(agent string, line []byte) parsedEventLine {
 	case "codex":
 		events := parseCodexEvent(envelope)
 		return parsedEventLine{
-			events:              events,
-			dedupeAssistantEcho: envelope.Type == "response_item" && len(events) == 1 && events[0].Kind == EventKindAssistant,
+			events:                 events,
+			assistantEchoCandidate: envelope.Type == "response_item",
 		}
 	default:
 		return parsedEventLine{}
 	}
+}
+
+func isDuplicateAssistantEcho(parsed parsedEventLine, previous Event, hasPrevious bool) bool {
+	return parsed.assistantEchoCandidate &&
+		len(parsed.events) == 1 &&
+		parsed.events[0].Kind == EventKindAssistant &&
+		hasPrevious &&
+		previous.Kind == EventKindAssistant &&
+		previous.Text == parsed.events[0].Text
 }
 
 func parseCodexEvent(envelope eventEnvelope) []Event {

--- a/internal/transcript/events_test.go
+++ b/internal/transcript/events_test.go
@@ -17,6 +17,21 @@ func writeEventTranscript(t *testing.T, lines ...string) string {
 	return path
 }
 
+func appendEventTranscript(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestReadEventPageCodexNormalizesAndRedacts(t *testing.T) {
 	path := writeEventTranscript(t,
 		`{"timestamp":"2026-07-19T10:00:00Z","type":"session_meta","payload":{"id":"native-id"}}`,
@@ -96,18 +111,9 @@ func TestReadEventPageCodexDeduplicatesPairedAssistantAcrossFollowPoll(t *testin
 		t.Fatalf("first poll = %#v", first)
 	}
 
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, writeErr := f.WriteString(`{"timestamp":"2026-07-19T10:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"checking now"}]}}` + "\n")
-	closeErr := f.Close()
-	if writeErr != nil {
-		t.Fatal(writeErr)
-	}
-	if closeErr != nil {
-		t.Fatal(closeErr)
-	}
+	appendEventTranscript(t, path,
+		`{"timestamp":"2026-07-19T10:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"checking now"}]}}`,
+	)
 
 	second, err := ReadEventPage(path, "codex", first.NextCursor, 10)
 	if err != nil {

--- a/internal/transcript/events_test.go
+++ b/internal/transcript/events_test.go
@@ -1,0 +1,221 @@
+package transcript
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeEventTranscript(t *testing.T, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestReadEventPageCodexNormalizesAndRedacts(t *testing.T) {
+	path := writeEventTranscript(t,
+		`{"timestamp":"2026-07-19T10:00:00Z","type":"session_meta","payload":{"id":"native-id"}}`,
+		`{"timestamp":"2026-07-19T10:00:01Z","type":"event_msg","payload":{"type":"user_message","message":"deploy with token=super-secret-value"}}`,
+		`{"timestamp":"2026-07-19T10:00:02Z","type":"event_msg","payload":{"type":"agent_message","message":"checking now"}}`,
+		`{"timestamp":"2026-07-19T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"checking now"}]}}`,
+		`{"timestamp":"2026-07-19T10:00:03Z","type":"response_item","payload":{"type":"custom_tool_call","name":"shell","call_id":"call-1","input":"{\"cmd\":\"curl\",\"api_key\":\"hidden-value\"}"}}`,
+		`{"timestamp":"2026-07-19T10:00:04Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call-1","output":[{"type":"input_text","text":"Authorization: Bearer abcdefghijklmnop"}]}}`,
+		`{"timestamp":"2026-07-19T10:00:05Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call-2","output":"Process exited with code 2"}}`,
+	)
+
+	page, err := ReadEventPage(path, "codex", "", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !page.AtEnd {
+		t.Fatal("expected complete page to be at end")
+	}
+	if len(page.Events) != 5 {
+		t.Fatalf("events = %#v, want 5 provider-neutral events", page.Events)
+	}
+	if page.Events[0].Kind != EventKindUser || page.Events[0].Timestamp != "2026-07-19T10:00:01Z" {
+		t.Fatalf("user event = %#v", page.Events[0])
+	}
+	if strings.Contains(page.Events[0].Text, "super-secret-value") || !strings.Contains(page.Events[0].Text, "[REDACTED]") {
+		t.Fatalf("user secret was not redacted: %q", page.Events[0].Text)
+	}
+	if page.Events[1].Kind != EventKindAssistant || page.Events[1].Text != "checking now" {
+		t.Fatalf("assistant event = %#v", page.Events[1])
+	}
+	if page.Events[2].Kind != EventKindToolCall || page.Events[2].ToolName != "shell" || strings.Contains(page.Events[2].Text, "hidden-value") {
+		t.Fatalf("tool call = %#v", page.Events[2])
+	}
+	if page.Events[3].Kind != EventKindToolResult || page.Events[3].ToolCallID != "call-1" || strings.Contains(page.Events[3].Text, "abcdefghijklmnop") {
+		t.Fatalf("tool result = %#v", page.Events[3])
+	}
+	if page.Events[4].Kind != EventKindToolResult || !page.Events[4].IsError {
+		t.Fatalf("failed tool result = %#v", page.Events[4])
+	}
+	for _, event := range page.Events {
+		if event.Cursor == "" {
+			t.Fatalf("event missing cursor: %#v", event)
+		}
+	}
+}
+
+func TestReadEventPageCursorResumesWithoutDuplicates(t *testing.T) {
+	path := writeEventTranscript(t,
+		`{"type":"session_meta","payload":{"id":"native-id"}}`,
+		`{"type":"event_msg","payload":{"type":"user_message","message":"one"}}`,
+		`{"type":"event_msg","payload":{"type":"token_count"}}`,
+		`{"type":"event_msg","payload":{"type":"agent_message","message":"two"}}`,
+	)
+
+	first, err := ReadEventPage(path, "codex", "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Events) != 1 || first.Events[0].Text != "one" || first.AtEnd {
+		t.Fatalf("first page = %#v", first)
+	}
+
+	second, err := ReadEventPage(path, "codex", first.NextCursor, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second.Events) != 1 || second.Events[0].Text != "two" || !second.AtEnd {
+		t.Fatalf("second page = %#v", second)
+	}
+	if first.Events[0].Cursor == second.Events[0].Cursor {
+		t.Fatal("resumed event reused the prior source cursor")
+	}
+}
+
+func TestReadEventPageCursorResumesWithinMultiEventRecord(t *testing.T) {
+	path := writeEventTranscript(t,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"working"},{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"/tmp/x"}}]}}`,
+	)
+	first, err := ReadEventPage(path, "claude", "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Events) != 1 || first.Events[0].Kind != EventKindAssistant {
+		t.Fatalf("first page = %#v", first)
+	}
+	second, err := ReadEventPage(path, "claude", first.NextCursor, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second.Events) != 1 || second.Events[0].Kind != EventKindToolCall {
+		t.Fatalf("second page = %#v", second)
+	}
+	third, err := ReadEventPage(path, "claude", second.NextCursor, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(third.Events) != 0 || !third.AtEnd {
+		t.Fatalf("third page = %#v", third)
+	}
+}
+
+func TestReadEventPageWaitsForCompleteFinalRecord(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	prefix := "{\"type\":\"session_meta\"}\n"
+	partial := `{"type":"event_msg","payload":{"type":"agent_message","message":"later"}}`
+	if err := os.WriteFile(path, []byte(prefix+partial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := ReadEventPage(path, "codex", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Events) != 0 {
+		t.Fatalf("partial record emitted events: %#v", first.Events)
+	}
+	if err := os.WriteFile(path, []byte(prefix+partial+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	second, err := ReadEventPage(path, "codex", first.NextCursor, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second.Events) != 1 || second.Events[0].Text != "later" {
+		t.Fatalf("completed record = %#v", second.Events)
+	}
+}
+
+func TestReadEventPageRejectsCursorFromAnotherTranscript(t *testing.T) {
+	firstPath := writeEventTranscript(t,
+		`{"type":"session_meta","payload":{"id":"one"}}`,
+		`{"type":"event_msg","payload":{"type":"user_message","message":"one"}}`,
+	)
+	secondPath := writeEventTranscript(t,
+		`{"type":"session_meta","payload":{"id":"two"}}`,
+		`{"type":"event_msg","payload":{"type":"user_message","message":"two"}}`,
+	)
+	first, err := ReadEventPage(firstPath, "codex", "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ReadEventPage(secondPath, "codex", first.NextCursor, 1)
+	if !errors.Is(err, ErrCursorMismatch) {
+		t.Fatalf("error = %v, want ErrCursorMismatch", err)
+	}
+}
+
+func TestReadEventPageClaudeAndCopilot(t *testing.T) {
+	t.Run("claude", func(t *testing.T) {
+		path := writeEventTranscript(t,
+			`{"timestamp":"2026-07-19T11:00:00Z","type":"user","origin":{"kind":"human"},"message":{"content":[{"type":"text","text":"please inspect"}]}}`,
+			`{"timestamp":"2026-07-19T11:00:01Z","type":"assistant","message":{"content":[{"type":"text","text":"on it"},{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"/tmp/x"}}]}}`,
+			`{"timestamp":"2026-07-19T11:00:02Z","type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"done","is_error":false}]}}`,
+			`{"timestamp":"2026-07-19T11:00:03Z","type":"result","is_error":true,"result":"runtime failed"}`,
+		)
+		page, err := ReadEventPage(path, "claude", "", 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantKinds := []string{EventKindUser, EventKindAssistant, EventKindToolCall, EventKindToolResult, EventKindError}
+		if len(page.Events) != len(wantKinds) {
+			t.Fatalf("events = %#v", page.Events)
+		}
+		for i, kind := range wantKinds {
+			if page.Events[i].Kind != kind {
+				t.Fatalf("event %d kind = %q, want %q", i, page.Events[i].Kind, kind)
+			}
+		}
+	})
+
+	t.Run("copilot", func(t *testing.T) {
+		path := writeEventTranscript(t,
+			`{"timestamp":"2026-07-19T12:00:00Z","type":"user.message","data":{"content":"please inspect"}}`,
+			`{"timestamp":"2026-07-19T12:00:01Z","type":"tool.execution_start","data":{"toolCallId":"tool-1","toolName":"bash","arguments":{"cmd":"pwd"}}}`,
+			`{"timestamp":"2026-07-19T12:00:02Z","type":"tool.execution_complete","data":{"toolCallId":"tool-1","success":false,"error":"exit 1"}}`,
+		)
+		page, err := ReadEventPage(path, "copilot", "", 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(page.Events) != 3 || page.Events[2].Kind != EventKindToolResult || !page.Events[2].IsError {
+			t.Fatalf("events = %#v", page.Events)
+		}
+	})
+}
+
+func TestRedactTextCoversCredentialForms(t *testing.T) {
+	input := strings.Join([]string{
+		"Authorization: Bearer abc.def.ghi",
+		"password=hunter2",
+		"github_pat_abcdefghijklmnopqrstuvwxyz",
+		"https://user:password@example.com/repo.git",
+		"-----BEGIN PRIVATE KEY-----\nprivate material\n-----END PRIVATE KEY-----",
+	}, "\n")
+	got := RedactText(input)
+	for _, secret := range []string{"abc.def.ghi", "hunter2", "github_pat_abcdefghijklmnopqrstuvwxyz", "password@example.com", "private material"} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("secret %q remains in %q", secret, got)
+		}
+	}
+}

--- a/internal/transcript/events_test.go
+++ b/internal/transcript/events_test.go
@@ -63,6 +63,61 @@ func TestReadEventPageCodexNormalizesAndRedacts(t *testing.T) {
 	}
 }
 
+func TestReadEventPageCodexResponseItemAssistantOnly(t *testing.T) {
+	path := writeEventTranscript(t,
+		`{"timestamp":"2026-07-19T10:00:00Z","type":"session_meta","payload":{"id":"native-id"}}`,
+		`{"timestamp":"2026-07-19T10:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"First output."},{"type":"output_text","text":"Second output."}]}}`,
+	)
+
+	page, err := ReadEventPage(path, "codex", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 1 {
+		t.Fatalf("events = %#v, want one assistant event", page.Events)
+	}
+	event := page.Events[0]
+	if event.Kind != EventKindAssistant || event.Role != "assistant" || event.Text != "First output.\nSecond output." {
+		t.Fatalf("assistant event = %#v", event)
+	}
+}
+
+func TestReadEventPageCodexDeduplicatesPairedAssistantAcrossFollowPoll(t *testing.T) {
+	path := writeEventTranscript(t,
+		`{"timestamp":"2026-07-19T10:00:00Z","type":"session_meta","payload":{"id":"native-id"}}`,
+		`{"timestamp":"2026-07-19T10:00:01Z","type":"event_msg","payload":{"type":"agent_message","message":"checking now"}}`,
+	)
+
+	first, err := ReadEventPage(path, "codex", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Events) != 1 || first.Events[0].Text != "checking now" || !first.AtEnd {
+		t.Fatalf("first poll = %#v", first)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, writeErr := f.WriteString(`{"timestamp":"2026-07-19T10:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"checking now"}]}}` + "\n")
+	closeErr := f.Close()
+	if writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	if closeErr != nil {
+		t.Fatal(closeErr)
+	}
+
+	second, err := ReadEventPage(path, "codex", first.NextCursor, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second.Events) != 0 || !second.AtEnd {
+		t.Fatalf("paired response_item was not suppressed: %#v", second)
+	}
+}
+
 func TestReadEventPageCursorResumesWithoutDuplicates(t *testing.T) {
 	path := writeEventTranscript(t,
 		`{"type":"session_meta","payload":{"id":"native-id"}}`,


### PR DESCRIPTION
## Intent

Automations need a provider-neutral way to read session progress without scraping native Codex, Claude, or Copilot transcript formats. This adds a daemon-owned transcript API and CLI with stable events, resumable cursors, and centralized secret redaction.

## Summary

- add `attn session transcript <id>` with JSON, cursor resume, and follow modes
- normalize Codex, Claude, and Copilot transcripts into stable user, assistant, tool-call, tool-result, and error events
- redact structured secrets and common plaintext credential formats before events leave the daemon
- use per-event opaque cursors so resuming cannot skip sibling events from one native record
- add the protocol command and response, regenerate Go and TypeScript types, and bump protocol version to 175
- document the user-visible command in the changelog

## Test plan

- [x] `go test ./internal/transcript ./internal/protocol ./internal/client`
- [x] `go test ./internal/daemon`
- [x] `go test ./cmd/attn`
- [x] `pnpm --dir app test`
- [x] build and install isolated `transcript-smoke` profile
- [x] verify normalized snapshot output, redaction, cursor-only incremental resume, follow delivery, and clean SIGINT exit against the named-profile daemon
- [x] remove the temporary profile after verification

## Out of scope

Transcript waiting/expect helpers and later automation backlog items remain separate reviewable changes.