### PR TITLE
feat(cli): add environment preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,15 @@ A large automated suite — even a race-clean concurrency suite — is not by it
 
 Use a **non-prod** profile for this (the `dev` sibling or a throwaway `ATTN_PROFILE`) — that is pre-authorized; never smoke on prod. See [Iterating On Attn Itself](#iterating-on-attn-itself-attn-on-attn-testing) and [docs/profiles.md](docs/profiles.md).
 
+After installing and selecting the non-production profile, run that profile's newly bundled CLI preflight before starting live verification:
+
+```bash
+profile_app="$(./attn profile resolve --field appPath)"
+"$profile_app/Contents/MacOS/attn" preflight
+```
+
+When the scenario launches an agent with pinned settings, pass the same values to preflight, for example `--agent codex --model <model> --effort high`. Use `--json` when a script or agent needs a stable result. A failing preflight is an environment/setup failure: fix its reported tool, writable-path, routing, daemon, or protocol cause before treating later behavior as product evidence. Preflight is diagnostic only and never repairs or restarts the environment. Use the installed profile's bundled CLI as shown above, not an unrelated `attn` earlier on `PATH`.
+
 If a PR needs live-app verification and you **cannot** run it (no ability to build/install/run a non-prod profile in this environment), **stop and ask the user for guidance** — do not merge on automated tests alone. State plainly in the PR and to the user what was and was not verified live.
 
 ## Packaged-App Harness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   events across supported agents, with `--follow` for live updates and opaque
   cursors for safe resumption. Provider-specific records stay behind the daemon
   boundary, and secrets are redacted before output.
+- **Environment failures can be diagnosed before a run starts.** `attn
+  preflight` checks required tools and writable paths, verifies the active
+  profile's app, daemon, socket, routing, and protocol versions, and reports the
+  selected agent model and effort without changing the environment.
 
 ### Fixed
 - **Retried delegations no longer create duplicate agents or tickets.** `attn

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -242,6 +242,9 @@ func main() {
 	case "automation":
 		maybePrintProfileBanner()
 		runAutomationCommand()
+	case "preflight":
+		maybePrintProfileBanner()
+		runPreflight()
 	case "plugin":
 		maybePrintProfileBanner()
 		runPluginCommand()
@@ -615,6 +618,7 @@ commands:
   browser <command>                 open and control the in-app browser
   workflow <command>                run, inspect, and resume durable workflows
   automation <command>              manage and run durable automations
+  preflight                         diagnose tools, paths, routing, and launch settings
   list                              list sessions and workspaces
   present <command>                 open a review presentation and read feedback
   debug <command>                   probe debug artifacts (incidents, logs)

--- a/cmd/attn/preflight.go
+++ b/cmd/attn/preflight.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/victorarias/attn/internal/preflight"
+)
+
+func runPreflight() {
+	opts, jsonOutput, help, err := parsePreflightArgs(os.Args[2:], os.Getenv)
+	if help {
+		writePreflightHelp(os.Stdout)
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "preflight: %v\n", err)
+		writePreflightHelp(os.Stderr)
+		os.Exit(2)
+	}
+
+	report := preflight.Run(context.Background(), opts)
+	if jsonOutput {
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(report); err != nil {
+			fmt.Fprintf(os.Stderr, "preflight: encode result: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		writePreflightReport(os.Stdout, report)
+	}
+	if !report.OK() {
+		os.Exit(1)
+	}
+}
+
+func parsePreflightArgs(args []string, getenv func(string) string) (preflight.Options, bool, bool, error) {
+	fs := flag.NewFlagSet("preflight", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	agentDefault, agentSource := environmentDefault(getenv, "ATTN_AGENT", "codex")
+	modelDefault, modelSource := environmentDefault(getenv, "ATTN_MODEL", "")
+	effortDefault, effortSource := environmentDefault(getenv, "ATTN_EFFORT", "")
+	agent := fs.String("agent", agentDefault, "agent launch to check")
+	model := fs.String("model", modelDefault, "model pin to check")
+	effort := fs.String("effort", effortDefault, "reasoning effort pin to check")
+	jsonOutput := fs.Bool("json", false, "emit the stable JSON report")
+	help := fs.Bool("help", false, "show help")
+	fs.BoolVar(help, "h", false, "show help")
+	if err := fs.Parse(args); err != nil {
+		return preflight.Options{}, false, false, err
+	}
+	if fs.NArg() != 0 {
+		return preflight.Options{}, false, false, fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if flagWasSet(fs, "agent") {
+		agentSource = "explicit"
+	}
+	if flagWasSet(fs, "model") {
+		modelSource = "explicit"
+	}
+	if flagWasSet(fs, "effort") {
+		effortSource = "explicit"
+	}
+	return preflight.Options{
+		Agent: *agent, AgentSource: agentSource,
+		Model: *model, ModelSource: modelSource,
+		Effort: *effort, EffortSource: effortSource,
+	}, *jsonOutput, *help, nil
+}
+
+func environmentDefault(getenv func(string) string, key, fallback string) (string, string) {
+	if value := strings.TrimSpace(getenv(key)); value != "" {
+		return value, "environment"
+	}
+	if fallback != "" {
+		return fallback, "default"
+	}
+	return "", "agent_default"
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	found := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
+}
+
+func writePreflightReport(w io.Writer, report preflight.Report) {
+	failed, warned := 0, 0
+	for _, check := range report.Checks {
+		switch check.Status {
+		case preflight.StatusFail:
+			failed++
+		case preflight.StatusWarn:
+			warned++
+		}
+	}
+	fmt.Fprintf(w, "attn preflight: %s (%d failed, %d warnings)\n", strings.ToUpper(report.Status), failed, warned)
+	fmt.Fprintf(w, "profile: %s  socket=%s  port=%s\n", report.Routing.Label, report.Routing.Socket, report.Routing.WSPort)
+	fmt.Fprintf(w, "launch: agent=%s model=%s effort=%s\n\n",
+		resolvedDisplay(report.Launch.Agent), resolvedDisplay(report.Launch.Model), resolvedDisplay(report.Launch.Effort))
+	for _, check := range report.Checks {
+		fmt.Fprintf(w, "%-4s %-25s %s\n", strings.ToUpper(check.Status), check.Name, check.Summary)
+		if check.Action != "" {
+			fmt.Fprintf(w, "     action: %s\n", check.Action)
+		}
+	}
+}
+
+func resolvedDisplay(value preflight.ResolvedValue) string {
+	if value.Value == "" {
+		return "agent-default"
+	}
+	return value.Value + " (" + value.Source + ")"
+}
+
+func writePreflightHelp(w io.Writer) {
+	fmt.Fprint(w, `usage: attn preflight [options]
+
+Diagnose the active profile without changing it. The command exits non-zero
+when a required tool, writable path, route, daemon, or protocol check fails.
+
+options:
+  --agent <name>   agent launch to check (ATTN_AGENT, then codex)
+  --model <name>   model pin to check (ATTN_MODEL, then agent default)
+  --effort <level> effort pin to check (ATTN_EFFORT, then agent default)
+  --json           emit the stable machine-readable report
+`)
+}

--- a/cmd/attn/preflight_test.go
+++ b/cmd/attn/preflight_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+func TestParsePreflightArgsResolvesExplicitAndEnvironmentValues(t *testing.T) {
+	env := map[string]string{"ATTN_AGENT": "claude", "ATTN_MODEL": "env-model", "ATTN_EFFORT": "low"}
+	getenv := func(key string) string { return env[key] }
+	opts, jsonOutput, help, err := parsePreflightArgs([]string{"--model", "flag-model", "--json"}, getenv)
+	if err != nil || help || !jsonOutput {
+		t.Fatalf("parse result: json=%v help=%v err=%v", jsonOutput, help, err)
+	}
+	if opts.Agent != "claude" || opts.AgentSource != "environment" {
+		t.Fatalf("agent = %+v", opts)
+	}
+	if opts.Model != "flag-model" || opts.ModelSource != "explicit" {
+		t.Fatalf("model = %+v", opts)
+	}
+	if opts.Effort != "low" || opts.EffortSource != "environment" {
+		t.Fatalf("effort = %+v", opts)
+	}
+}
+
+func TestParsePreflightArgsUsesDocumentedDefaults(t *testing.T) {
+	opts, _, _, err := parsePreflightArgs(nil, func(string) string { return "" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Agent != "codex" || opts.AgentSource != "default" {
+		t.Fatalf("agent = %+v", opts)
+	}
+	if opts.Model != "" || opts.ModelSource != "agent_default" || opts.EffortSource != "agent_default" {
+		t.Fatalf("model/effort = %+v", opts)
+	}
+}

--- a/docs/alignment/environment-preflight.md
+++ b/docs/alignment/environment-preflight.md
@@ -1,0 +1,16 @@
+# Environment preflight alignment
+
+## Why
+
+`attn preflight` should separate environment failures from product failures before a build, live verification run, or automation launch starts. A successful run means the selected profile is routed consistently, the required local tools and writable paths are usable, the installed app and daemon speak the same protocol, and the intended agent model and effort are visible.
+
+## Aligned on
+
+- The command is diagnostic and read-only: it reports named `pass`, `warn`, and `fail` checks and never repairs the environment.
+- Human output is concise and actionable; `--json` exposes the same stable result for automation. Failures produce a non-zero exit status, while warnings do not.
+- Profile resolution remains owned by `internal/config`. The live daemon health response is the authority for actual profile, data-dir, socket, port, and protocol routing.
+- `--agent`, `--model`, and `--effort` describe the launch being checked. They fall back to active environment values and then the selected agent's native defaults, rather than guessing a model ID.
+
+## In scope / deferred
+
+This slice covers required source-build tools, writable working/cache/profile paths, active profile routing, installed-app/daemon protocol compatibility, and resolved launch model/effort. Autoreview-specific model, reasoning, and bundle reporting remains backlog item 4. The command will not install tools, create directories, restart daemons, or change settings.

--- a/internal/config/canonical_path_test.go
+++ b/internal/config/canonical_path_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCanonicalRuntimePathResolvesRelativePathAndSymlinkedAncestor(t *testing.T) {
+	realRoot := t.TempDir()
+	canonicalRoot, err := filepath.EvalSymlinks(realRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(t.TempDir(), "linked")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(filepath.Dir(linkRoot)); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+
+	got, err := CanonicalRuntimePath(filepath.Join(filepath.Base(linkRoot), "not-created", "attn.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(canonicalRoot, "not-created", "attn.sock")
+	if got != want {
+		t.Fatalf("canonical path = %q, want %q", got, want)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -476,6 +477,15 @@ func ValidateDaemonIsolation(socketPath string) error {
 }
 
 func comparableDaemonIsolationPath(path string) (string, error) {
+	return CanonicalRuntimePath(path)
+}
+
+// CanonicalRuntimePath returns one absolute representation of a runtime path.
+// It resolves symlinks through the deepest existing ancestor, so a not-yet-
+// created socket or database below a symlinked data directory still compares by
+// its real location. CLI/daemon routing checks must use this instead of comparing
+// raw environment or config strings, which may be relative to different CWDs.
+func CanonicalRuntimePath(path string) (string, error) {
 	trimmed := strings.TrimSpace(path)
 	if trimmed == "" {
 		return "", nil
@@ -484,7 +494,28 @@ func comparableDaemonIsolationPath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Clean(absolute), nil
+	absolute = filepath.Clean(absolute)
+
+	existing := absolute
+	var missing []string
+	for {
+		resolved, err := filepath.EvalSymlinks(existing)
+		if err == nil {
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return filepath.Clean(resolved), nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			return absolute, nil
+		}
+		missing = append(missing, filepath.Base(existing))
+		existing = parent
+	}
 }
 
 // StatePath returns the legacy state file path (for migration/cleanup).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3699,6 +3699,7 @@ func (d *Daemon) broadcastEndpointsUpdated() {
 func (d *Daemon) handleHealth(w http.ResponseWriter, r *http.Request) {
 	sessions := d.store.List("")
 	prs := d.store.ListPRs("")
+	dataDir, socketPath, routingPathError := healthRoutingPaths()
 
 	health := map[string]interface{}{
 		"status":             "ok",
@@ -3716,12 +3717,32 @@ func (d *Daemon) handleHealth(w http.ResponseWriter, r *http.Request) {
 		// they're connected to the daemon they expect and refuse to
 		// operate on a mismatch.
 		"profile":     config.ProfileLabel(),
-		"data_dir":    config.DataDir(),
-		"socket_path": config.SocketPath(),
+		"data_dir":    dataDir,
+		"socket_path": socketPath,
 		"port":        config.WSPort(),
+	}
+	if routingPathError != "" {
+		health["routing_path_error"] = routingPathError
 	}
 
 	setNoStoreHeaders(w.Header())
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(health)
+}
+
+func healthRoutingPaths() (dataDir, socketPath, routingPathError string) {
+	rawDataDir := config.DataDir()
+	rawSocketPath := config.SocketPath()
+	dataDir, dataErr := config.CanonicalRuntimePath(rawDataDir)
+	if dataErr != nil {
+		dataDir = rawDataDir
+	}
+	socketPath, socketErr := config.CanonicalRuntimePath(rawSocketPath)
+	if socketErr != nil {
+		socketPath = rawSocketPath
+	}
+	if dataErr != nil || socketErr != nil {
+		routingPathError = fmt.Sprintf("data_dir: %v; socket_path: %v", dataErr, socketErr)
+	}
+	return dataDir, socketPath, routingPathError
 }

--- a/internal/daemon/health_test.go
+++ b/internal/daemon/health_test.go
@@ -1,0 +1,44 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHealthRoutingPathsCanonicalizeRelativeOverridesAndSymlinkedAncestors(t *testing.T) {
+	realRoot := t.TempDir()
+	canonicalRoot, err := filepath.EvalSymlinks(realRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(realRoot, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workingDir := t.TempDir()
+	if err := os.Symlink(realRoot, filepath.Join(workingDir, "linked")); err != nil {
+		t.Fatal(err)
+	}
+
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(workingDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+	t.Setenv("ATTN_DATA_DIR", filepath.Join("linked", "data"))
+	t.Setenv("ATTN_SOCKET_PATH", filepath.Join("linked", "data", "attn.sock"))
+
+	dataDir, socketPath, routingErr := healthRoutingPaths()
+	if routingErr != "" {
+		t.Fatalf("health routing error = %q", routingErr)
+	}
+	if want := filepath.Join(canonicalRoot, "data"); dataDir != want {
+		t.Fatalf("data_dir = %q, want %q", dataDir, want)
+	}
+	if want := filepath.Join(canonicalRoot, "data", "attn.sock"); socketPath != want {
+		t.Fatalf("socket_path = %q, want %q", socketPath, want)
+	}
+}

--- a/internal/preflight/main_test.go
+++ b/internal/preflight/main_test.go
@@ -1,0 +1,19 @@
+package preflight
+
+import (
+	"os"
+	"testing"
+
+	"github.com/victorarias/attn/internal/config"
+)
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "attn-preflight-test-*")
+	if err != nil {
+		panic(err)
+	}
+	config.ScopeTestEnvironment(dir)
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -72,11 +72,12 @@ type Report struct {
 func (r Report) OK() bool { return r.Status != StatusFail }
 
 type daemonHealth struct {
-	Protocol   string `json:"protocol"`
-	Profile    string `json:"profile"`
-	DataDir    string `json:"data_dir"`
-	SocketPath string `json:"socket_path"`
-	Port       any    `json:"port"`
+	Protocol         string `json:"protocol"`
+	Profile          string `json:"profile"`
+	DataDir          string `json:"data_dir"`
+	SocketPath       string `json:"socket_path"`
+	RoutingPathError string `json:"routing_path_error"`
+	Port             any    `json:"port"`
 }
 
 type prober struct {
@@ -106,7 +107,7 @@ func Run(ctx context.Context, opts Options) Report {
 }
 
 func run(ctx context.Context, opts Options, p prober) Report {
-	routing := resolveRouting()
+	routing, routingErr := resolveRouting()
 	launch := resolveLaunch(opts)
 	report := Report{Status: StatusPass, Routing: routing, Launch: launch}
 	add := func(check Check) { report.Checks = append(report.Checks, check) }
@@ -177,7 +178,9 @@ func run(ctx context.Context, opts Options, p prober) Report {
 		}
 	}
 
-	if err := p.pathIsSocket(routing.Socket); err != nil {
+	if routingErr != nil {
+		add(fail("routing.socket", "could not canonicalize active routing paths: "+routingErr.Error(), "Use absolute paths for ATTN_DATA_DIR and ATTN_SOCKET_PATH, or fix inaccessible symlink ancestors."))
+	} else if err := p.pathIsSocket(routing.Socket); err != nil {
 		add(fail("routing.socket", fmt.Sprintf("expected daemon socket %s is unavailable: %v", routing.Socket, err), "Start the daemon for the active profile and verify ATTN_PROFILE/ATTN_SOCKET_PATH routing."))
 	} else {
 		add(pass("routing.socket", routing.Socket))
@@ -185,7 +188,7 @@ func run(ctx context.Context, opts Options, p prober) Report {
 
 	appProtocol, appErr := p.appProtocol(ctx, routing.AppPath)
 	if appErr != nil {
-		add(fail("protocol.app", fmt.Sprintf("could not read the installed app protocol: %v", appErr), "Build and install this profile's app, then rerun preflight."))
+		add(fail("protocol.cli_app", fmt.Sprintf("could not read the installed app protocol: %v", appErr), "Build and install this profile's app, then rerun preflight."))
 	} else if appProtocol != protocol.ProtocolVersion {
 		add(fail("protocol.cli_app", fmt.Sprintf("CLI protocol %s does not match installed app protocol %s", protocol.ProtocolVersion, appProtocol), "Rebuild and install the selected profile from this checkout."))
 	} else {
@@ -198,14 +201,18 @@ func run(ctx context.Context, opts Options, p prober) Report {
 		add(fail("protocol.app_daemon", "app/daemon protocol compatibility could not be verified", "Start the selected profile's daemon and rerun preflight."))
 	} else {
 		actualPort := fmt.Sprint(health.Port)
-		if health.Profile != routing.Label || health.DataDir != routing.DataDir || health.SocketPath != routing.Socket || actualPort != routing.WSPort {
+		if health.RoutingPathError != "" {
+			add(fail("routing.daemon", "daemon could not canonicalize its routing paths: "+health.RoutingPathError, "Use absolute daemon routing paths or fix inaccessible symlink ancestors, then restart this profile's daemon."))
+		} else if health.Profile != routing.Label || health.DataDir != routing.DataDir || health.SocketPath != routing.Socket || actualPort != routing.WSPort {
 			add(fail("routing.daemon", fmt.Sprintf("daemon routing mismatch: profile=%s data_dir=%s socket=%s port=%s", health.Profile, health.DataDir, health.SocketPath, actualPort), "Select the intended profile with `attn profile-env`, clear inherited routing overrides, and restart only that profile's daemon."))
 		} else {
 			add(pass("routing.daemon", fmt.Sprintf("profile=%s socket=%s port=%s", health.Profile, health.SocketPath, actualPort)))
 		}
-		if appErr == nil && appProtocol == health.Protocol {
+		if appErr != nil {
+			add(fail("protocol.app_daemon", "app/daemon protocol compatibility could not be verified because the app protocol is unavailable", "Build and install this profile's app, then rerun preflight."))
+		} else if appProtocol == health.Protocol {
 			add(pass("protocol.app_daemon", "installed app and daemon use protocol "+health.Protocol))
-		} else if appErr == nil {
+		} else {
 			add(fail("protocol.app_daemon", fmt.Sprintf("installed app protocol %s does not match daemon protocol %s", appProtocol, health.Protocol), "Restart the daemon from the selected profile's installed app."))
 		}
 	}
@@ -249,18 +256,40 @@ func resolvedLaunchValue(value, source string) ResolvedValue {
 	return ResolvedValue{Value: value, Source: source}
 }
 
-func resolveRouting() Routing {
+func resolveRouting() (Routing, error) {
 	profile := config.Profile()
 	label := profile
 	if label == "" {
 		label = "default"
 	}
-	return Routing{
+	rawDataDir := config.DataDir()
+	rawSocket := config.SocketPath()
+	dataDir, dataErr := config.CanonicalRuntimePath(rawDataDir)
+	if dataErr != nil {
+		dataDir = absoluteRoutingFallback(rawDataDir)
+	}
+	socket, socketErr := config.CanonicalRuntimePath(rawSocket)
+	if socketErr != nil {
+		socket = absoluteRoutingFallback(rawSocket)
+	}
+	routing := Routing{
 		Profile: profile, Label: label,
-		DataDir: config.DataDir(), Socket: config.SocketPath(),
+		DataDir: dataDir, Socket: socket,
 		WSPort: config.WSPort(), BundleID: config.BundleIdentifierForProfile(profile),
 		AppPath: config.AppPathForProfile(profile),
 	}
+	if dataErr != nil || socketErr != nil {
+		return routing, fmt.Errorf("data_dir: %v; socket: %v", dataErr, socketErr)
+	}
+	return routing, nil
+}
+
+func absoluteRoutingFallback(path string) string {
+	absolute, err := filepath.Abs(strings.TrimSpace(path))
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(absolute)
 }
 
 func probeWritableDirectory(path string) error {

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,0 +1,359 @@
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+const (
+	StatusPass = "pass"
+	StatusWarn = "warn"
+	StatusFail = "fail"
+)
+
+type Options struct {
+	Agent        string
+	AgentSource  string
+	Model        string
+	ModelSource  string
+	Effort       string
+	EffortSource string
+	WorkingDir   string
+}
+
+type ResolvedValue struct {
+	Value  string `json:"value,omitempty"`
+	Source string `json:"source"`
+}
+
+type Launch struct {
+	Agent  ResolvedValue `json:"agent"`
+	Model  ResolvedValue `json:"model"`
+	Effort ResolvedValue `json:"effort"`
+}
+
+type Routing struct {
+	Profile  string `json:"profile"`
+	Label    string `json:"label"`
+	DataDir  string `json:"data_dir"`
+	Socket   string `json:"socket"`
+	WSPort   string `json:"ws_port"`
+	BundleID string `json:"bundle_id"`
+	AppPath  string `json:"app_path"`
+}
+
+type Check struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Summary string `json:"summary"`
+	Action  string `json:"action,omitempty"`
+}
+
+type Report struct {
+	Status  string  `json:"status"`
+	Routing Routing `json:"routing"`
+	Launch  Launch  `json:"launch"`
+	Checks  []Check `json:"checks"`
+}
+
+func (r Report) OK() bool { return r.Status != StatusFail }
+
+type daemonHealth struct {
+	Protocol   string `json:"protocol"`
+	Profile    string `json:"profile"`
+	DataDir    string `json:"data_dir"`
+	SocketPath string `json:"socket_path"`
+	Port       any    `json:"port"`
+}
+
+type prober struct {
+	lookPath      func(string) (string, error)
+	writable      func(string) error
+	pathIsSocket  func(string) error
+	goCachePaths  func(context.Context) ([]string, error)
+	appProtocol   func(context.Context, string) (string, error)
+	daemonHealth  func(context.Context, string) (daemonHealth, error)
+	requiredTools []string
+}
+
+func defaultProber() prober {
+	return prober{
+		lookPath:      exec.LookPath,
+		writable:      probeWritableDirectory,
+		pathIsSocket:  requireSocket,
+		goCachePaths:  resolveGoCachePaths,
+		appProtocol:   readAppProtocol,
+		daemonHealth:  fetchDaemonHealth,
+		requiredTools: []string{"git", "gh", "go", "pnpm", "cargo", "make"},
+	}
+}
+
+func Run(ctx context.Context, opts Options) Report {
+	return run(ctx, opts, defaultProber())
+}
+
+func run(ctx context.Context, opts Options, p prober) Report {
+	routing := resolveRouting()
+	launch := resolveLaunch(opts)
+	report := Report{Status: StatusPass, Routing: routing, Launch: launch}
+	add := func(check Check) { report.Checks = append(report.Checks, check) }
+
+	driver := agentdriver.Get(launch.Agent.Value)
+	if driver == nil {
+		add(fail("launch.agent", fmt.Sprintf("agent %q is not registered", launch.Agent.Value), "Select a configured prompt-capable agent with --agent."))
+	} else {
+		caps := agentdriver.EffectiveCapabilities(driver)
+		if launch.Model.Value != "" && !caps.HasModelPin {
+			add(fail("launch.model", fmt.Sprintf("agent %q does not support model pins", launch.Agent.Value), "Remove --model or select an agent that supports model pins."))
+		}
+		if launch.Effort.Value != "" && !caps.HasEffortPin {
+			add(fail("launch.effort", fmt.Sprintf("agent %q does not support effort pins", launch.Agent.Value), "Remove --effort or select an agent that supports effort pins."))
+		}
+	}
+
+	tools := append([]string(nil), p.requiredTools...)
+	if driver != nil {
+		tools = append(tools, driver.ResolveExecutable(""))
+	}
+	sort.Strings(tools)
+	seen := map[string]bool{}
+	for _, tool := range tools {
+		if seen[tool] {
+			continue
+		}
+		seen[tool] = true
+		path, err := p.lookPath(tool)
+		if err != nil {
+			add(fail("tool."+filepath.Base(tool), fmt.Sprintf("required tool %q was not found on PATH", tool), fmt.Sprintf("Install %s or configure its executable path, then rerun preflight.", tool)))
+			continue
+		}
+		add(pass("tool."+filepath.Base(tool), path))
+	}
+
+	workingDir := strings.TrimSpace(opts.WorkingDir)
+	if workingDir == "" {
+		workingDir, _ = os.Getwd()
+	}
+	paths := []struct{ name, path, action string }{
+		{"path.working_directory", workingDir, "Choose a writable checkout or fix its permissions."},
+		{"path.profile_data", routing.DataDir, "Install or initialize the selected non-production profile, then fix the data directory permissions."},
+		{"path.applications", filepath.Dir(routing.AppPath), "Create a writable Applications directory for the selected profile."},
+	}
+	for _, item := range paths {
+		if err := p.writable(item.path); err != nil {
+			add(fail(item.name, fmt.Sprintf("%s is not writable: %v", item.path, err), item.action))
+		} else {
+			add(pass(item.name, item.path))
+		}
+	}
+
+	cachePaths, err := p.goCachePaths(ctx)
+	if err != nil {
+		add(fail("path.go_caches", fmt.Sprintf("could not resolve Go cache paths: %v", err), "Run `go env GOCACHE GOMODCACHE` and fix the reported tool or cache-path problem."))
+	} else {
+		for i, path := range cachePaths {
+			name := "path.go_build_cache"
+			if i == 1 {
+				name = "path.go_module_cache"
+			}
+			if err := p.writable(path); err != nil {
+				add(fail(name, fmt.Sprintf("%s is not writable: %v", path, err), "Point Go at a writable cache or fix this directory's permissions."))
+			} else {
+				add(pass(name, path))
+			}
+		}
+	}
+
+	if err := p.pathIsSocket(routing.Socket); err != nil {
+		add(fail("routing.socket", fmt.Sprintf("expected daemon socket %s is unavailable: %v", routing.Socket, err), "Start the daemon for the active profile and verify ATTN_PROFILE/ATTN_SOCKET_PATH routing."))
+	} else {
+		add(pass("routing.socket", routing.Socket))
+	}
+
+	appProtocol, appErr := p.appProtocol(ctx, routing.AppPath)
+	if appErr != nil {
+		add(fail("protocol.app", fmt.Sprintf("could not read the installed app protocol: %v", appErr), "Build and install this profile's app, then rerun preflight."))
+	} else if appProtocol != protocol.ProtocolVersion {
+		add(fail("protocol.cli_app", fmt.Sprintf("CLI protocol %s does not match installed app protocol %s", protocol.ProtocolVersion, appProtocol), "Rebuild and install the selected profile from this checkout."))
+	} else {
+		add(pass("protocol.cli_app", "CLI and installed app use protocol "+appProtocol))
+	}
+
+	health, healthErr := p.daemonHealth(ctx, routing.WSPort)
+	if healthErr != nil {
+		add(fail("routing.daemon", fmt.Sprintf("daemon health is unavailable on 127.0.0.1:%s: %v", routing.WSPort, healthErr), "Start the daemon for the active profile and verify the selected port is reachable."))
+		add(fail("protocol.app_daemon", "app/daemon protocol compatibility could not be verified", "Start the selected profile's daemon and rerun preflight."))
+	} else {
+		actualPort := fmt.Sprint(health.Port)
+		if health.Profile != routing.Label || health.DataDir != routing.DataDir || health.SocketPath != routing.Socket || actualPort != routing.WSPort {
+			add(fail("routing.daemon", fmt.Sprintf("daemon routing mismatch: profile=%s data_dir=%s socket=%s port=%s", health.Profile, health.DataDir, health.SocketPath, actualPort), "Select the intended profile with `attn profile-env`, clear inherited routing overrides, and restart only that profile's daemon."))
+		} else {
+			add(pass("routing.daemon", fmt.Sprintf("profile=%s socket=%s port=%s", health.Profile, health.SocketPath, actualPort)))
+		}
+		if appErr == nil && appProtocol == health.Protocol {
+			add(pass("protocol.app_daemon", "installed app and daemon use protocol "+health.Protocol))
+		} else if appErr == nil {
+			add(fail("protocol.app_daemon", fmt.Sprintf("installed app protocol %s does not match daemon protocol %s", appProtocol, health.Protocol), "Restart the daemon from the selected profile's installed app."))
+		}
+	}
+
+	for _, check := range report.Checks {
+		if check.Status == StatusFail {
+			report.Status = StatusFail
+			break
+		}
+		if check.Status == StatusWarn {
+			report.Status = StatusWarn
+		}
+	}
+	return report
+}
+
+func resolveLaunch(opts Options) Launch {
+	agentName := strings.ToLower(strings.TrimSpace(opts.Agent))
+	if agentName == "" {
+		agentName = "codex"
+	}
+	agentSource := opts.AgentSource
+	if agentSource == "" {
+		agentSource = "default"
+	}
+	return Launch{
+		Agent:  ResolvedValue{Value: agentName, Source: agentSource},
+		Model:  resolvedLaunchValue(opts.Model, opts.ModelSource),
+		Effort: resolvedLaunchValue(strings.ToLower(strings.TrimSpace(opts.Effort)), opts.EffortSource),
+	}
+}
+
+func resolvedLaunchValue(value, source string) ResolvedValue {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ResolvedValue{Source: "agent_default"}
+	}
+	if source == "" {
+		source = "explicit"
+	}
+	return ResolvedValue{Value: value, Source: source}
+}
+
+func resolveRouting() Routing {
+	profile := config.Profile()
+	label := profile
+	if label == "" {
+		label = "default"
+	}
+	return Routing{
+		Profile: profile, Label: label,
+		DataDir: config.DataDir(), Socket: config.SocketPath(),
+		WSPort: config.WSPort(), BundleID: config.BundleIdentifierForProfile(profile),
+		AppPath: config.AppPathForProfile(profile),
+	}
+}
+
+func probeWritableDirectory(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("not a directory")
+	}
+	file, err := os.CreateTemp(path, ".attn-preflight-*")
+	if err != nil {
+		return err
+	}
+	name := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(name)
+		return err
+	}
+	return os.Remove(name)
+}
+
+func requireSocket(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("path is not a Unix socket")
+	}
+	return nil
+}
+
+func resolveGoCachePaths(ctx context.Context) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "go", "env", "-json", "GOCACHE", "GOMODCACHE")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	var values struct {
+		Build  string `json:"GOCACHE"`
+		Module string `json:"GOMODCACHE"`
+	}
+	if err := json.Unmarshal(output, &values); err != nil {
+		return nil, err
+	}
+	if values.Build == "" || values.Module == "" {
+		return nil, fmt.Errorf("go returned an empty cache path")
+	}
+	return []string{values.Build, values.Module}, nil
+}
+
+func readAppProtocol(ctx context.Context, appPath string) (string, error) {
+	binary := filepath.Join(appPath, "Contents", "MacOS", "attn")
+	if _, err := os.Stat(binary); err != nil {
+		return "", fmt.Errorf("%s: %w", binary, err)
+	}
+	commandCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(commandCtx, binary, "--protocol-version").Output()
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(string(output))
+	if value == "" {
+		return "", fmt.Errorf("app returned an empty protocol version")
+	}
+	return value, nil
+}
+
+func fetchDaemonHealth(ctx context.Context, port string) (daemonHealth, error) {
+	requestCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, "http://"+net.JoinHostPort("127.0.0.1", port)+"/health", nil)
+	if err != nil {
+		return daemonHealth{}, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return daemonHealth{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemonHealth{}, fmt.Errorf("HTTP %s", resp.Status)
+	}
+	var health daemonHealth
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		return daemonHealth{}, err
+	}
+	return health, nil
+}
+
+func pass(name, summary string) Check { return Check{Name: name, Status: StatusPass, Summary: summary} }
+func fail(name, summary, action string) Check {
+	return Check{Name: name, Status: StatusFail, Summary: summary, Action: action}
+}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -1,0 +1,137 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/protocol"
+)
+
+func passingProber(t *testing.T) prober {
+	t.Helper()
+	return prober{
+		lookPath:     func(tool string) (string, error) { return "/tools/" + filepath.Base(tool), nil },
+		writable:     func(string) error { return nil },
+		pathIsSocket: func(string) error { return nil },
+		goCachePaths: func(context.Context) ([]string, error) { return []string{"/cache/build", "/cache/mod"}, nil },
+		appProtocol:  func(context.Context, string) (string, error) { return protocol.ProtocolVersion, nil },
+		daemonHealth: func(context.Context, string) (daemonHealth, error) {
+			return daemonHealth{
+				Protocol: protocol.ProtocolVersion, Profile: config.ProfileLabel(),
+				DataDir: config.DataDir(), SocketPath: config.SocketPath(), Port: config.WSPort(),
+			}, nil
+		},
+		requiredTools: []string{"git", "go"},
+	}
+}
+
+func TestRunPassesWithConsistentEnvironment(t *testing.T) {
+	report := run(context.Background(), Options{Agent: "codex", Model: "gpt-test", Effort: "high", WorkingDir: t.TempDir()}, passingProber(t))
+	if !report.OK() || report.Status != StatusPass {
+		t.Fatalf("report status = %q, checks=%+v", report.Status, report.Checks)
+	}
+	if report.Launch.Model.Value != "gpt-test" || report.Launch.Effort.Value != "high" {
+		t.Fatalf("launch = %+v", report.Launch)
+	}
+	assertCheck(t, report, "routing.daemon", StatusPass, "")
+	assertCheck(t, report, "protocol.app_daemon", StatusPass, "")
+}
+
+func TestRunReportsRootCausesAndActions(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*prober)
+		checkName string
+		contains  string
+	}{
+		{
+			name: "missing required tool",
+			mutate: func(p *prober) {
+				p.lookPath = func(tool string) (string, error) {
+					if tool == "go" {
+						return "", errors.New("missing")
+					}
+					return "/tools/" + tool, nil
+				}
+			},
+			checkName: "tool.go", contains: "not found on PATH",
+		},
+		{
+			name: "unwritable cache",
+			mutate: func(p *prober) {
+				p.writable = func(path string) error {
+					if path == "/cache/build" {
+						return errors.New("permission denied")
+					}
+					return nil
+				}
+			},
+			checkName: "path.go_build_cache", contains: "permission denied",
+		},
+		{
+			name: "profile routing mismatch",
+			mutate: func(p *prober) {
+				p.daemonHealth = func(context.Context, string) (daemonHealth, error) {
+					return daemonHealth{Protocol: protocol.ProtocolVersion, Profile: "other", DataDir: "/other", SocketPath: "/other.sock", Port: "1"}, nil
+				}
+			},
+			checkName: "routing.daemon", contains: "routing mismatch",
+		},
+		{
+			name: "app daemon protocol mismatch",
+			mutate: func(p *prober) {
+				p.daemonHealth = func(context.Context, string) (daemonHealth, error) {
+					return daemonHealth{Protocol: "older", Profile: config.ProfileLabel(), DataDir: config.DataDir(), SocketPath: config.SocketPath(), Port: config.WSPort()}, nil
+				}
+			},
+			checkName: "protocol.app_daemon", contains: "does not match",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := passingProber(t)
+			tt.mutate(&p)
+			report := run(context.Background(), Options{Agent: "codex", WorkingDir: t.TempDir()}, p)
+			if report.OK() || report.Status != StatusFail {
+				t.Fatalf("report status = %q, want fail", report.Status)
+			}
+			assertCheck(t, report, tt.checkName, StatusFail, tt.contains)
+		})
+	}
+}
+
+func TestProbeWritableDirectoryDoesNotLeaveArtifact(t *testing.T) {
+	dir := t.TempDir()
+	if err := probeWritableDirectory(dir); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("probe left artifacts: %+v", entries)
+	}
+}
+
+func assertCheck(t *testing.T, report Report, name, status, contains string) {
+	t.Helper()
+	for _, check := range report.Checks {
+		if check.Name != name {
+			continue
+		}
+		if check.Status != status || (contains != "" && !strings.Contains(check.Summary, contains)) {
+			t.Fatalf("check %s = %+v", name, check)
+		}
+		if status == StatusFail && check.Action == "" {
+			t.Fatalf("failing check %s has no action", name)
+		}
+		return
+	}
+	t.Fatalf("check %s not found in %+v", name, report.Checks)
+}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -14,6 +15,14 @@ import (
 
 func passingProber(t *testing.T) prober {
 	t.Helper()
+	dataDir, err := config.CanonicalRuntimePath(config.DataDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	socketPath, err := config.CanonicalRuntimePath(config.SocketPath())
+	if err != nil {
+		t.Fatal(err)
+	}
 	return prober{
 		lookPath:     func(tool string) (string, error) { return "/tools/" + filepath.Base(tool), nil },
 		writable:     func(string) error { return nil },
@@ -23,7 +32,7 @@ func passingProber(t *testing.T) prober {
 		daemonHealth: func(context.Context, string) (daemonHealth, error) {
 			return daemonHealth{
 				Protocol: protocol.ProtocolVersion, Profile: config.ProfileLabel(),
-				DataDir: config.DataDir(), SocketPath: config.SocketPath(), Port: config.WSPort(),
+				DataDir: dataDir, SocketPath: socketPath, Port: config.WSPort(),
 			}, nil
 		},
 		requiredTools: []string{"git", "go"},
@@ -83,10 +92,21 @@ func TestRunReportsRootCausesAndActions(t *testing.T) {
 			checkName: "routing.daemon", contains: "routing mismatch",
 		},
 		{
+			name: "unreadable app protocol with healthy daemon",
+			mutate: func(p *prober) {
+				p.appProtocol = func(context.Context, string) (string, error) {
+					return "", errors.New("app missing")
+				}
+			},
+			checkName: "protocol.app_daemon", contains: "app protocol is unavailable",
+		},
+		{
 			name: "app daemon protocol mismatch",
 			mutate: func(p *prober) {
+				dataDir, _ := config.CanonicalRuntimePath(config.DataDir())
+				socketPath, _ := config.CanonicalRuntimePath(config.SocketPath())
 				p.daemonHealth = func(context.Context, string) (daemonHealth, error) {
-					return daemonHealth{Protocol: "older", Profile: config.ProfileLabel(), DataDir: config.DataDir(), SocketPath: config.SocketPath(), Port: config.WSPort()}, nil
+					return daemonHealth{Protocol: "older", Profile: config.ProfileLabel(), DataDir: dataDir, SocketPath: socketPath, Port: config.WSPort()}, nil
 				}
 			},
 			checkName: "protocol.app_daemon", contains: "does not match",
@@ -102,6 +122,74 @@ func TestRunReportsRootCausesAndActions(t *testing.T) {
 			}
 			assertCheck(t, report, tt.checkName, StatusFail, tt.contains)
 		})
+	}
+}
+
+func TestRunRejectsSameRelativeRoutingOverridesFromDifferentWorkingDirectories(t *testing.T) {
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalDir) })
+
+	cliDir := t.TempDir()
+	daemonDir := t.TempDir()
+	for _, root := range []string{cliDir, daemonDir} {
+		if err := os.Mkdir(filepath.Join(root, ".attn-qa"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("ATTN_DATA_DIR", ".attn-qa")
+	t.Setenv("ATTN_SOCKET_PATH", filepath.Join(".attn-qa", "attn.sock"))
+
+	if err := os.Chdir(daemonDir); err != nil {
+		t.Fatal(err)
+	}
+	daemonDataDir, err := config.CanonicalRuntimePath(config.DataDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	daemonSocket, err := config.CanonicalRuntimePath(config.SocketPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(cliDir); err != nil {
+		t.Fatal(err)
+	}
+	p := passingProber(t)
+	p.daemonHealth = func(context.Context, string) (daemonHealth, error) {
+		return daemonHealth{
+			Protocol: protocol.ProtocolVersion, Profile: config.ProfileLabel(),
+			DataDir: daemonDataDir, SocketPath: daemonSocket, Port: config.WSPort(),
+		}, nil
+	}
+	report := run(context.Background(), Options{Agent: "codex", WorkingDir: cliDir}, p)
+	assertCheck(t, report, "routing.daemon", StatusFail, "routing mismatch")
+	if report.Routing.DataDir == daemonDataDir || report.Routing.Socket == daemonSocket {
+		t.Fatalf("relative overrides unexpectedly converged: cli=%+v daemon=%s/%s", report.Routing, daemonDataDir, daemonSocket)
+	}
+}
+
+func TestRunKeepsProtocolCheckNamesWhenAppProtocolIsUnavailable(t *testing.T) {
+	passing := run(context.Background(), Options{Agent: "codex", WorkingDir: t.TempDir()}, passingProber(t))
+	p := passingProber(t)
+	p.appProtocol = func(context.Context, string) (string, error) {
+		return "", errors.New("app missing")
+	}
+	failing := run(context.Background(), Options{Agent: "codex", WorkingDir: t.TempDir()}, p)
+
+	want := []string{"protocol.cli_app", "protocol.app_daemon"}
+	for _, report := range []Report{passing, failing} {
+		var got []string
+		for _, check := range report.Checks {
+			if strings.HasPrefix(check.Name, "protocol.") {
+				got = append(got, check.Name)
+			}
+		}
+		if !slices.Equal(got, want) {
+			t.Fatalf("protocol check names = %v, want %v", got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Intent

Environment failures during Automations work were initially indistinguishable from product failures. This adds one read-only preflight command that fails early with the actual missing tool, unwritable path, routing conflict, or protocol mismatch before a build or live run begins.

Related: #600

## Summary

- add `attn preflight [--json]` with stable named checks and actionable `pass`, `warn`, or `fail` results
- report required source-build tools, writable checkout/profile/cache paths, and the active profile's resolved app, socket, and port
- compare the current CLI and installed app protocol with the live daemon, including the daemon's actual profile routing
- report the selected agent, model, and effort from explicit flags, active environment values, or agent-native defaults
- keep every check diagnostic: the command does not install tools, create directories, restart daemons, or change settings

## Test plan

- [x] `go test ./...`
- [x] `go vet ./internal/preflight ./cmd/attn`
- [x] `git diff --check`
- [x] Install the isolated `preflightqa` profile and verify all 16 live checks pass against its packaged app and daemon at protocol 175
- [x] Inject the production socket into `preflightqa` and verify JSON output reports a routing mismatch and exits 1
- [x] Remove the temporary `preflightqa` profile after verification

## Out of scope

Autoreview-specific model, reasoning-level, and bundle output remains the next independent backlog item.
