### PR TITLE
fix(agents): instruct agents to call bare attn, not $ATTN_WRAPPER_PATH

### DIFF
--- a/internal/agent/attn_skill/references/browser.md
+++ b/internal/agent/attn_skill/references/browser.md
@@ -13,14 +13,14 @@ separate browser surface for an explicit attn-browser request.
 5. Collect the cheapest fresh evidence that proves the result.
 
 ```sh
-"$ATTN_WRAPPER_PATH" browser open http://localhost:3000
-"$ATTN_WRAPPER_PATH" browser snapshot
-"$ATTN_WRAPPER_PATH" browser find --using role --value textbox --name Search
-"$ATTN_WRAPPER_PATH" browser type --element attn-element-1 --text "query"
-"$ATTN_WRAPPER_PATH" browser click --element attn-element-2
-"$ATTN_WRAPPER_PATH" browser wait --using text --value Results --state visible
-"$ATTN_WRAPPER_PATH" browser reload
-"$ATTN_WRAPPER_PATH" browser screenshot ./attn-browser.png
+attn browser open http://localhost:3000
+attn browser snapshot
+attn browser find --using role --value textbox --name Search
+attn browser type --element attn-element-1 --text "query"
+attn browser click --element attn-element-2
+attn browser wait --using text --value Results --state visible
+attn browser reload
+attn browser screenshot ./attn-browser.png
 ```
 
 Use `browser snapshot` for state and locators. Use screenshots when visual
@@ -29,8 +29,8 @@ layout matters; do not request both by default.
 For lower-level WebDriver-shaped actions:
 
 ```sh
-"$ATTN_WRAPPER_PATH" browser command get_title
-"$ATTN_WRAPPER_PATH" browser command find_element \
+attn browser command get_title
+attn browser command find_element \
   --params '{"using":"label","value":"Email"}'
 ```
 

--- a/internal/agent/attn_skill/references/delegated-agent.md
+++ b/internal/agent/attn_skill/references/delegated-agent.md
@@ -25,22 +25,22 @@ the working column. Report when you:
 - need input or are blocked
 - finish the requested work
 
-    "$ATTN_WRAPPER_PATH" ticket status in_progress --comment \
+    attn ticket status in_progress --comment \
       "Implemented the parser and tests pass. Next: review the error wording."
 
 When work needs input, is ready for review, clearly completes, or fails, report
 the matching state:
 
-    "$ATTN_WRAPPER_PATH" ticket status needs_input \
+    attn ticket status needs_input \
       --comment "Core implementation is ready locally; which event contract should be used?"
 
-    "$ATTN_WRAPPER_PATH" ticket status ready_for_review \
+    attn ticket status ready_for_review \
       --comment "Parser implementation is ready for review"
 
-    "$ATTN_WRAPPER_PATH" ticket status completed \
+    attn ticket status completed \
       --comment "The requested PR merged and no follow-up remains"
 
-    "$ATTN_WRAPPER_PATH" ticket status failed \
+    attn ticket status failed \
       --comment "Implementation cannot continue because the required API was removed"
 
 Reporting moves your bound ticket to the matching column so the chief sees your
@@ -72,7 +72,7 @@ delegation.
 When tracked work produces a Markdown plan or design that must outlive this
 session, let attn choose its one canonical home:
 
-    "$ATTN_WRAPPER_PATH" ticket attach-plan \
+    attn ticket attach-plan \
       --file docs/plans/design.md \
       --state ready_for_review \
       --comment "The design is ready."

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -38,7 +38,7 @@ Prefer a brief file so the task can be drafted and revised before submission:
 
     brief_file="$(mktemp "${TMPDIR:-/tmp}/attn-delegate.XXXXXX")"
     # Write a concise task, relevant context, constraints, and expected output.
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file"
+    attn delegate --brief-file "$brief_file"
 
 The brief should let the delegated agent start immediately. Include:
 
@@ -60,8 +60,8 @@ Use `--brief <text>` only for short, simple tasks.
 
 The source agent is used by default. Select another supported agent with:
 
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" --agent claude
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" --agent codex
+    attn delegate --brief-file "$brief_file" --agent claude
+    attn delegate --brief-file "$brief_file" --agent codex
 
 Plugin agents work only when they declare delegated initial-prompt support.
 Copilot delegation is currently unsupported.
@@ -69,7 +69,7 @@ Copilot delegation is currently unsupported.
 `--model` and `--effort` pin the delegated agent's model and reasoning effort
 for that delegation only; omitted, the agent uses its own defaults:
 
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" \
+    attn delegate --brief-file "$brief_file" \
       --agent claude --model opus --effort high
 
 `--model` takes an alias or a full model id. `--effort` takes the agent's
@@ -85,7 +85,7 @@ labels, directories, and workspace IDs to identify domain workspaces the user
 already has (e.g. code reviews, goalie rotation, triage). When the delegated
 task matches an existing workspace's domain, place it there with `--workspace`:
 
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" --workspace <workspace-id>
+    attn delegate --brief-file "$brief_file" --workspace <workspace-id>
 
 When delegating multiple independent items in parallel, route each agent to the
 workspace that fits its domain rather than creating a new workspace per item.
@@ -94,15 +94,15 @@ If no existing workspace fits, use one of:
 
 No placement flag — adds the session to the current workspace:
 
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file"
+    attn delegate --brief-file "$brief_file"
 
 Create a separate workspace using the source directory:
 
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" --new-workspace
+    attn delegate --brief-file "$brief_file" --new-workspace
 
 Create a workspace at an existing directory:
 
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" --cwd /path/to/project
+    attn delegate --brief-file "$brief_file" --cwd /path/to/project
 
 `attn list` marks sessions in hidden workspaces with `workspace_muted: true`.
 When the source session is the chief of staff, delegating into a muted existing
@@ -113,19 +113,19 @@ Ordinary delegation preserves the workspace's current mute state.
 with any placement:
 
     # worktree in the current workspace
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" \
+    attn delegate --brief-file "$brief_file" \
       --worktree feat/delegated-task
 
     # worktree in an existing workspace
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" \
+    attn delegate --brief-file "$brief_file" \
       --workspace <workspace-id> --worktree feat/delegated-task
 
     # worktree in a new workspace
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" \
+    attn delegate --brief-file "$brief_file" \
       --new-workspace --worktree feat/delegated-task
 
     # worktree of the repo at an existing directory
-    "$ATTN_WRAPPER_PATH" delegate --brief-file "$brief_file" \
+    attn delegate --brief-file "$brief_file" \
       --cwd /path/to/project --worktree feat/delegated-task
 
 Worktree options:

--- a/internal/agent/attn_skill/references/markdown.md
+++ b/internal/agent/attn_skill/references/markdown.md
@@ -2,7 +2,7 @@
 
 Open a markdown document in a live-reloading tile next to the current session:
 
-    "$ATTN_WRAPPER_PATH" open <path/to/file.md>
+    attn open <path/to/file.md>
 
 The path may be relative or absolute. Use `--session <session-id>` to target a
 different session. Edits to the file appear in the tile automatically.

--- a/internal/agent/attn_skill/references/notebook.md
+++ b/internal/agent/attn_skill/references/notebook.md
@@ -98,6 +98,6 @@ record durable decisions in the knowledge base as you make them, and keep the
 day's journal current with your cross-workspace view. The keeper already narrates
 each workspace's own work into the journal, so write at a chief-of-staff
 altitude — what moved across workspaces, what you delegated and decided — not a
-per-workspace play-by-play. You remain profile-wide — you may `"$ATTN_WRAPPER_PATH"
+per-workspace play-by-play. You remain profile-wide — you may `attn
 workspace context show --session <id>` for a specific workspace you step into, but
 that is opt-in.

--- a/internal/agent/attn_skill/references/tickets.md
+++ b/internal/agent/attn_skill/references/tickets.md
@@ -47,7 +47,7 @@ artifact is itself the proof; unreviewed code normally lands in review.
 
 For a Markdown plan or design, use the canonical-source operation:
 
-    "$ATTN_WRAPPER_PATH" ticket attach-plan \
+    attn ticket attach-plan \
       --file docs/plans/design.md \
       --scope services/catalog \
       --ticket <ticket-id> \

--- a/internal/agent/attn_skill/references/workspace-context.md
+++ b/internal/agent/attn_skill/references/workspace-context.md
@@ -74,13 +74,13 @@ a session-local snapshot and may become stale when another session publishes.
 If the path is unavailable, recover it with:
 
 ```sh
-context_file="$("$ATTN_WRAPPER_PATH" workspace context show)"
+context_file="$(attn workspace context show)"
 ```
 
 After editing the file, inspect its state:
 
 ```sh
-"$ATTN_WRAPPER_PATH" workspace context status
+attn workspace context status
 ```
 
 Use the result as a decision:
@@ -91,8 +91,8 @@ Use the result as a decision:
 - `modified=true, stale=true`: use the conflict workflow below.
 
 ```sh
-"$ATTN_WRAPPER_PATH" workspace context update
-"$ATTN_WRAPPER_PATH" workspace context status
+attn workspace context update
+attn workspace context status
 ```
 
 The successful final state is `modified=false`, `stale=false`, with `revision`
@@ -104,10 +104,10 @@ Never run `show --force` on a modified checkout until its contents are saved;
 that command replaces the local file.
 
 ```sh
-context_file="$("$ATTN_WRAPPER_PATH" workspace context show)"
+context_file="$(attn workspace context show)"
 saved_context="$(mktemp "${TMPDIR:-/tmp}/attn-context.XXXXXX")"
 cp "$context_file" "$saved_context"
-"$ATTN_WRAPPER_PATH" workspace context show --force >/dev/null
+attn workspace context show --force >/dev/null
 ```
 
 Merge the durable changes from `"$saved_context"` into the refreshed
@@ -115,8 +115,8 @@ Merge the durable changes from `"$saved_context"` into the refreshed
 duplication, then publish and verify:
 
 ```sh
-"$ATTN_WRAPPER_PATH" workspace context update
-"$ATTN_WRAPPER_PATH" workspace context status
+attn workspace context update
+attn workspace context status
 rm -f "$saved_context"
 ```
 

--- a/internal/agent/attn_skill_test.go
+++ b/internal/agent/attn_skill_test.go
@@ -156,7 +156,7 @@ func assertAttnSkillTree(t *testing.T, skillDir string) {
 		}
 	}
 	saveCommand := `cp "$context_file" "$saved_context"`
-	refreshCommand := `"$ATTN_WRAPPER_PATH" workspace context show --force`
+	refreshCommand := `attn workspace context show --force`
 	if strings.Index(workspaceContext, saveCommand) >= strings.Index(workspaceContext, refreshCommand) {
 		t.Fatalf("workspace context reference must save local edits before force-refreshing: %q", workspaceContext)
 	}

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -717,17 +717,17 @@ func delegatedTicketPrompt(brief string) string {
 This task is tracked as a ticket in attn. Report your work state so the ticket
 moves across the board and the chief of staff can see your progress:
 
-    "$ATTN_WRAPPER_PATH" ticket status in_progress --comment "<progress and next action>"
+    attn ticket status in_progress --comment "<progress and next action>"
 
 Use the state that matches the outcome when work needs input, is ready, or ends:
 
-    "$ATTN_WRAPPER_PATH" ticket status needs_input --comment "<needed decision>"
-    "$ATTN_WRAPPER_PATH" ticket status ready_for_review --comment "<what is ready>"
-    "$ATTN_WRAPPER_PATH" ticket status completed --comment "<completed outcome>"
-    "$ATTN_WRAPPER_PATH" ticket status failed --comment "<terminal failure>"
+    attn ticket status needs_input --comment "<needed decision>"
+    attn ticket status ready_for_review --comment "<what is ready>"
+    attn ticket status completed --comment "<completed outcome>"
+    attn ticket status failed --comment "<terminal failure>"
 
 When the deliverable is a durable Markdown plan or design, hand it over with
-` + "`" + `"$ATTN_WRAPPER_PATH" ticket attach-plan --file <path>` + "`" + `. In a monorepo, add
+` + "`" + `attn ticket attach-plan --file <path>` + "`" + `. In a monorepo, add
 ` + "`" + `--scope <affected-component>` + "`" + `. The command follows the applicable repository
 convention: a committed repository plan stays canonical in Git and the ticket gets
 a Notebook reference; otherwise the plan is promoted to the Notebook and its


### PR DESCRIPTION
## Why

PR #572 made every attn-launched process put the active attn binary's directory first on `PATH`, so bare `attn` always resolves to the correct app/profile binary. But agents kept calling `"$ATTN_WRAPPER_PATH"` anyway — because every instruction surface they read still showed it as the canonical form: ~40 command examples across the embedded skill references, plus the delegated-ticket prompt composed in `delegate.go`.

## What

- All command examples in `internal/agent/attn_skill/references/*.md` now use bare `attn`.
- The ticket-reporting prompt in `internal/daemon/delegate.go` now says `attn ticket status ...` / `attn ticket attach-plan`.
- Updated the one test pinning the old form.

**Deliberately kept:** the wrapper env plumbing (`launchenv`, `pty/manager`, `ptybackend`, `codex.go`) — it powers the PATH prioritization — and the two stale-binary *recovery* mentions (SKILL.md bootstrap, `versioncheck.go`), which are its only intended agent-facing uses.

## Verification

- `go build ./...` clean; `internal/agent`, `internal/daemon`, `internal/hooks` tests pass.
- Fresh-built binary embeds zero wrapper ticket examples and the new bare-`attn` text (skill ships via `//go:embed`).
- Live check in an attn-managed shell: first `PATH` entry is the app bundle dir, ahead of `~/.local/bin`/homebrew, and `which attn` resolves to the active app binary.

Note: existing delegated sessions keep the old materialized skill; new delegations pick this up once a rebuilt daemon is installed.