### PR TITLE
perf(test): speed up Go verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        run: go test ./...
+        run: ./scripts/test-go.sh
 
   frontend:
     name: Frontend

--- a/Makefile
+++ b/Makefile
@@ -47,16 +47,16 @@ GOTESTSUM=$(HOME)/go/bin/gotestsum
 $(GOTESTSUM):
 	go install gotest.tools/gotestsum@latest
 
-test: $(GOTESTSUM)
-	$(GOTESTSUM) --format testdox -- ./...
+test:
+	./scripts/test-go.sh
 
 # Verbose test output (shows all test names as they run)
-test-v: $(GOTESTSUM)
-	$(GOTESTSUM) --format standard-verbose -- ./...
+test-v:
+	./scripts/test-go.sh -v
 
-# Quick test (dots only, fastest)
-test-quick: $(GOTESTSUM)
-	$(GOTESTSUM) --format dots -- ./...
+# Quick test (compact package output)
+test-quick:
+	./scripts/test-go.sh
 
 # Watch mode - re-runs tests on file changes
 test-watch: $(GOTESTSUM)

--- a/docs/plans/2026-07-19-fast-go-tests.md
+++ b/docs/plans/2026-07-19-fast-go-tests.md
@@ -1,0 +1,93 @@
+# Plan: Faster Go tests
+
+## Goal
+
+Keep the ordinary Go verification contract intact while making a cache-controlled
+`go test` run fast and predictable enough for pre-commit use. Tests must remain
+isolated from production `~/.attn`.
+
+## Starting Measurements
+
+Measured on an Apple M5 Max with macOS 26.5.2 and Go 1.26.2. Full-test timings
+use a warm compiler cache and `-count=1` so Go's test-result cache cannot hide
+execution. These numbers describe this machine and cache state, not a universal
+budget.
+
+| Candidate | Starting result |
+| --- | ---: |
+| Full `go test -count=1 ./...`, inherited Spotify Git wrapper | 131.07s, pass |
+| `internal/daemon` within that run | 129.882s, pass |
+| `internal/git`, inherited Spotify Git wrapper | 14.97s, pass |
+| `internal/git`, direct Git | 5.93s, pass |
+| Full suite, direct Git diagnostic | 70.41s, one load-sensitive Codex-resume failure |
+| Four direct-Git daemon shards | 18.81s, one shared `/tmp/attn.pid` collision |
+| Compile only, fresh `GOCACHE` | 29.68s |
+| Compile only, warm `GOCACHE` | 0.29s |
+
+## Test Path
+
+```text
+Current:
+make / pre-commit
+  -> one `go test ./...`
+    -> packages run concurrently
+      -> 778 daemon tests run almost entirely serially
+      -> every `git` lookup inherits the developer PATH
+
+Target:
+make / pre-commit
+  -> one repository test runner
+    -> temp-scoped ATTN_DATA_DIR with inherited path overrides cleared
+    -> direct, uninstrumented Git for test subprocesses
+    -> bounded package and per-process Go parallelism
+    -> five deterministic daemon test shards
+      -> temp-scoped sockets, PID files, ports, and data
+    -> one reusable attn test binary for process E2E tests
+    -> 90-second per-job fail-fast budget
+```
+
+## Implementation Tasks
+
+- [x] Run tests with a direct Git executable rather than an inherited wrapper.
+- [x] Isolate daemon socket, PID-file, port, and other shared test resources.
+- [x] Shard `internal/daemon` deterministically across five test processes.
+- [x] Replace deliberate wall-clock sleeps with test-controlled thresholds.
+- [x] Reuse a prebuilt `attn` binary across process E2E tests.
+- [x] Add `t.Parallel()` only to audited tests without process-global state.
+- [x] Repeat cold and warm measurements and compare them with this baseline.
+
+## Results
+
+Ten consecutive five-shard `-count=1` runs passed. Their wall times were
+24.71–27.45s, with a 25.64s median and 27.45s observed p95. A fresh-`GOCACHE`
+run passed in 48.43s. The cache-controlled median is 80% lower than the 131.07s
+starting measurement; the observed p95 and cold run meet their budgets. The
+median missed the aspirational sub-25s target by 0.64s.
+
+The focused `internal/git` package improved from 14.97s through the inherited
+wrapper to 1.99s using direct Git plus audited parallel tests. The worker theme
+argument test improved from 6.3s and load-sensitive failure to 0.42s by testing
+argument construction without launching a process.
+
+## Success Criteria
+
+- [x] The same default Go test coverage passes ten consecutive cache-controlled runs.
+- [ ] Warm compiler cache with test-result caching disabled: p50 under 25s on
+  the baseline machine (observed 25.64s).
+- [x] Warm compiler cache with test-result caching disabled: p95 under 30s on
+  the baseline machine (observed 27.45s).
+- [x] Fresh `GOCACHE`: p95 under 60s on the baseline machine.
+- [x] No failures from fixed ports, shared PID files, sockets, inherited test paths,
+  or production attn state.
+
+## Decisions
+
+- Preserve the complete default suite before considering a separate integration
+  tier.
+- Prefer process sharding over broad in-process parallelism because daemon tests
+  mutate environment variables and package globals.
+- Keep Git selection test-scoped; do not change interactive Git or global Spotify
+  configuration.
+- Five daemon shards with `GOMAXPROCS=3` replaced the initial four-shard shape
+  after the measured concurrency sweep: 25.32s versus 30.75s for four/four and
+  41.85s for six/four.

--- a/docs/plans/2026-07-19-fast-go-tests.md
+++ b/docs/plans/2026-07-19-fast-go-tests.md
@@ -62,6 +62,11 @@ make / pre-commit
 - [x] Remeasure the focused tests and ten complete cache-controlled runs.
 - [x] Prototype compiling the daemon test binary once for all shards; reject it
   if the measured gain does not justify duplicating Go's flag rewriting.
+- [x] Stabilize only the runner's outer isolation paths so unchanged daemon
+  shards can use Go's result cache while executed tests keep fresh temp dirs.
+- [x] Prove cache invalidation when the E2E binary or direct Git executable
+  changes, plus concurrent-run isolation.
+- [x] Measure the unchanged-hook warm path and a cache-controlled changed path.
 
 ## Results
 
@@ -106,6 +111,24 @@ run-to-run variance and does not justify maintaining a partial reimplementation
 of Go's build/test flag rewriting, changing daemon test-cache behavior, or
 degrading package-aware output. The runner change was therefore removed.
 
+The hook-oriented cache pass instead kept Go in charge and stabilized only the
+runner's outer environment. `ATTN_DATA_DIR` now points at a non-production cache
+namespace while every executing package `TestMain` still replaces it with a
+fresh per-process temp directory. The direct Git path is keyed by both path and
+binary content, and the shared E2E executable is copied to a content-addressed
+path, so changing either external input invalidates the test results that read
+it. An explicitly supplied `ATTN_E2E_BIN` is normalized through the same path.
+
+After one population run, five unchanged full runs passed in 5.19–6.36s with a
+5.80s median and all 44 package results cached. The final runner revision took
+30.61s to populate its new namespace and 5.77s on the immediate 44/44 cached
+rerun. `-count=1` still forced all tests to run and passed in 33.11s. Two
+simultaneous cache-miss runners both passed, covering ten concurrent daemon
+shards without sharing runtime data. A cmd-only mutation invalidated only the
+two daemon shards that read the changed E2E binary; a semantics-preserving
+alternate Git executable invalidated all Git-reading shards. Both mutation
+probes passed and were removed.
+
 ## Success Criteria
 
 - [x] The same default Go test coverage passes ten consecutive cache-controlled runs.
@@ -130,3 +153,6 @@ degrading package-aware output. The runner change was therefore removed.
   41.85s for six/four.
 - Keep the Go driver responsible for compiling and invoking every test binary;
   compiling the daemon binary once did not produce a material wall-time gain.
+- Cache only stable outer inputs. Runtime data remains unique per executing test
+  process, while content-addressed external executables prevent cached results
+  from hiding changed Git or E2E behavior.

--- a/docs/plans/2026-07-19-fast-go-tests.md
+++ b/docs/plans/2026-07-19-fast-go-tests.md
@@ -60,6 +60,8 @@ make / pre-commit
 - [x] Test the daemon's no-new-turn handling through a fake extraction adapter instead of the real Claude retry loop.
 - [x] Move remote URL variants to the pure parser and retain one Git-backed origin integration test.
 - [x] Remeasure the focused tests and ten complete cache-controlled runs.
+- [x] Prototype compiling the daemon test binary once for all shards; reject it
+  if the measured gain does not justify duplicating Go's flag rewriting.
 
 ## Results
 
@@ -96,6 +98,14 @@ runs clustered at 27.95–32.81s; the 40.36s outlier coincided with that externa
 load. The focused timings establish the code-path savings; the full-run sample
 shows no correctness regression but cannot establish a new low-contention p50.
 
+A compiled-daemon-binary prototype also passed default, verbose, short, JSON
+fallback, and focused race-instrumented verification. Ten cache-controlled runs
+passed at 24.85–36.16s with a 29.60s median, compared with 29.87s immediately
+before the prototype. The roughly 0.27s median difference is within ordinary
+run-to-run variance and does not justify maintaining a partial reimplementation
+of Go's build/test flag rewriting, changing daemon test-cache behavior, or
+degrading package-aware output. The runner change was therefore removed.
+
 ## Success Criteria
 
 - [x] The same default Go test coverage passes ten consecutive cache-controlled runs.
@@ -118,3 +128,5 @@ shows no correctness regression but cannot establish a new low-contention p50.
 - Five daemon shards with `GOMAXPROCS=3` replaced the initial four-shard shape
   after the measured concurrency sweep: 25.32s versus 30.75s for four/four and
   41.85s for six/four.
+- Keep the Go driver responsible for compiling and invoking every test binary;
+  compiling the daemon binary once did not produce a material wall-time gain.

--- a/docs/plans/2026-07-19-fast-go-tests.md
+++ b/docs/plans/2026-07-19-fast-go-tests.md
@@ -67,9 +67,9 @@ make / pre-commit
 - [x] Prove cache invalidation when the E2E binary or direct Git executable
   changes, plus concurrent-run isolation.
 - [x] Measure the unchanged-hook warm path and a cache-controlled changed path.
-- [ ] Make pre-commit's temporary E2E build metadata deterministic.
-- [ ] Enable the tracked `.githooks/pre-commit` for every attn worktree.
-- [ ] Commit through the installed hook and measure its cache behavior.
+- [x] Make pre-commit's temporary E2E build metadata deterministic.
+- [x] Enable the tracked `.githooks/pre-commit` for every attn worktree.
+- [x] Commit through the installed hook and measure its cache behavior.
 
 ## Results
 
@@ -132,6 +132,23 @@ two daemon shards that read the changed E2E binary; a semantics-preserving
 alternate Git executable invalidated all Git-reading shards. Both mutation
 probes passed and were removed.
 
+The tracked `.githooks/pre-commit` is now enabled through the repository's
+shared `core.hooksPath=.githooks`, which resolves each worktree's own checked-out
+hook instead of a script from the main worktree. The hook already routes by
+staged path: Go-affecting changes run build plus the full Go suite, while
+unrelated commits skip that bucket. Enabling it exposed and fixed two dormant
+portability issues in `scripts/pre-commit.sh`: macOS Bash 3 lacks `mapfile`, and
+one exported command substitution masked its status under ShellCheck.
+
+Pre-commit E2E binaries now use fixed test-only build metadata and
+`-buildvcs=false`; two builds were byte-identical. Production and release
+metadata are unchanged. The first real commit through the installed hook passed
+in 28.97s. An exact retry of the same staged state passed in 4.97s, while a new
+staged hook change took 27–30s because it correctly produced a new test-input
+identity. The practical contract is therefore about 30s for newly changed
+daemon-bucket inputs, about 5s for an exact cached retry, and effectively no Go
+cost for staged paths outside the daemon bucket.
+
 ## Success Criteria
 
 - [x] The same default Go test coverage passes ten consecutive cache-controlled runs.
@@ -159,3 +176,6 @@ probes passed and were removed.
 - Cache only stable outer inputs. Runtime data remains unique per executing test
   process, while content-addressed external executables prevent cached results
   from hiding changed Git or E2E behavior.
+- Use Git's existing tracked `.githooks` seam rather than adding a hook manager.
+  The relative hooks path keeps hook code worktree-local while configuration is
+  shared by the repository.

--- a/docs/plans/2026-07-19-fast-go-tests.md
+++ b/docs/plans/2026-07-19-fast-go-tests.md
@@ -55,6 +55,11 @@ make / pre-commit
 - [x] Reuse a prebuilt `attn` binary across process E2E tests.
 - [x] Add `t.Parallel()` only to audited tests without process-global state.
 - [x] Repeat cold and warm measurements and compare them with this baseline.
+- [x] Replace the eight real SSH dial timeouts with one deterministic protocol failure while preserving the OS-level child-reaping assertion.
+- [x] Add a private Claude transcript-retry seam so duplicate-turn behavior is tested without the production two-second window.
+- [x] Test the daemon's no-new-turn handling through a fake extraction adapter instead of the real Claude retry loop.
+- [x] Move remote URL variants to the pure parser and retain one Git-backed origin integration test.
+- [x] Remeasure the focused tests and ten complete cache-controlled runs.
 
 ## Results
 
@@ -68,6 +73,28 @@ The focused `internal/git` package improved from 14.97s through the inherited
 wrapper to 1.99s using direct Git plus audited parallel tests. The worker theme
 argument test improved from 6.3s and load-sensitive failure to 0.42s by testing
 argument construction without launching a process.
+
+A second pass removed the remaining deliberate waits without deleting their
+regression contracts. Isolated `-count=1 -json` timings changed as follows:
+
+| Test contract | Before | After |
+| --- | ---: | ---: |
+| SSH child reaping after dial failure | 4.30s | 0.16s |
+| Claude duplicate-turn extraction | 2.02s | <0.01s |
+| Daemon no-new-turn handling | 2.03s | 0.01s |
+| Git-backed origin resolution | 0.50s | 0.10s |
+
+The faster SSH harness still failed in 0.21s and found one zombie when
+`cmd.Wait()` was temporarily mutation-removed, proving that it preserves the
+historical regression signal.
+
+Ten additional complete runs passed at 27.95–40.36s with a 29.45s median.
+This sample is not directly comparable to the earlier low-contention median:
+other attn worktrees ran `go test ./...` concurrently, and observed system CPU
+included `mediaanalysisd` above 75% and `JamfDaemon` above 50%. Eight of ten
+runs clustered at 27.95–32.81s; the 40.36s outlier coincided with that external
+load. The focused timings establish the code-path savings; the full-run sample
+shows no correctness regression but cannot establish a new low-contention p50.
 
 ## Success Criteria
 

--- a/docs/plans/2026-07-19-fast-go-tests.md
+++ b/docs/plans/2026-07-19-fast-go-tests.md
@@ -67,6 +67,9 @@ make / pre-commit
 - [x] Prove cache invalidation when the E2E binary or direct Git executable
   changes, plus concurrent-run isolation.
 - [x] Measure the unchanged-hook warm path and a cache-controlled changed path.
+- [ ] Make pre-commit's temporary E2E build metadata deterministic.
+- [ ] Enable the tracked `.githooks/pre-commit` for every attn worktree.
+- [ ] Commit through the installed hook and measure its cache behavior.
 
 ## Results
 

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -626,7 +626,25 @@ func (c *Claude) ExtractLastAssistantForClassification(
 	classificationStart time.Time,
 	lastClassifiedTurnID string,
 ) (content string, turnID string, err error) {
-	deadline := time.Now().Add(claudeTranscriptRetryWindow)
+	return c.extractLastAssistantForClassification(
+		transcriptPath,
+		maxChars,
+		classificationStart,
+		lastClassifiedTurnID,
+		claudeTranscriptRetryWindow,
+		claudeTranscriptRetryInterval,
+	)
+}
+
+func (c *Claude) extractLastAssistantForClassification(
+	transcriptPath string,
+	maxChars int,
+	classificationStart time.Time,
+	lastClassifiedTurnID string,
+	retryWindow time.Duration,
+	retryInterval time.Duration,
+) (content string, turnID string, err error) {
+	deadline := time.Now().Add(retryWindow)
 	minAssistantTimestamp := classificationStart.Add(-claudeTranscriptFreshnessSkew)
 	lastClassified := strings.TrimSpace(lastClassifiedTurnID)
 	for {
@@ -649,7 +667,7 @@ func (c *Claude) ExtractLastAssistantForClassification(
 			}
 			return "", "", turnErr
 		}
-		time.Sleep(claudeTranscriptRetryInterval)
+		time.Sleep(retryInterval)
 	}
 }
 

--- a/internal/agent/daemon_policy_test.go
+++ b/internal/agent/daemon_policy_test.go
@@ -205,12 +205,13 @@ func TestExtractLastAssistantForClassification_ClaudeNoNewTurn(t *testing.T) {
 		t.Fatalf("write transcript: %v", err)
 	}
 
-	_, _, err := ExtractLastAssistantForClassification(
-		Get("claude"),
+	_, _, err := (&Claude{}).extractLastAssistantForClassification(
 		path,
 		500,
 		time.Now(),
 		"turn-1",
+		0,
+		0,
 	)
 	if !errors.Is(err, ErrNoNewAssistantTurn) {
 		t.Fatalf("expected ErrNoNewAssistantTurn, got %v", err)

--- a/internal/daemon/codex_resume_e2e_test.go
+++ b/internal/daemon/codex_resume_e2e_test.go
@@ -24,13 +24,7 @@ func TestCodexResumeMappingEndToEnd(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
-	repoRoot := findRepoRootForTest(t)
-	attnBin := filepath.Join(tmpDir, "attn")
-	build := exec.Command("go", "build", "-o", attnBin, "./cmd/attn")
-	build.Dir = repoRoot
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build attn test binary: %v\n%s", err, string(output))
-	}
+	attnBin := attnBinaryForE2ETest(t, tmpDir)
 
 	fakeCodexLog := filepath.Join(tmpDir, "fake-codex.log")
 	fakeCodex := filepath.Join(tmpDir, "fake-codex")
@@ -201,4 +195,25 @@ func findRepoRootForTest(t *testing.T) string {
 		}
 		dir = parent
 	}
+}
+
+func attnBinaryForE2ETest(t *testing.T, tmpDir string) string {
+	t.Helper()
+	if binary := os.Getenv("ATTN_E2E_BIN"); binary != "" {
+		if info, err := os.Stat(binary); err != nil {
+			t.Fatalf("stat ATTN_E2E_BIN: %v", err)
+		} else if info.Mode()&0o111 == 0 {
+			t.Fatalf("ATTN_E2E_BIN is not executable: %s", binary)
+		}
+		return binary
+	}
+
+	repoRoot := findRepoRootForTest(t)
+	binary := filepath.Join(tmpDir, "attn")
+	build := exec.Command("go", "build", "-o", binary, "./cmd/attn")
+	build.Dir = repoRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build attn test binary: %v\n%s", err, string(output))
+	}
+	return binary
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -129,12 +129,16 @@ type Daemon struct {
 	classifiedMu     sync.Mutex
 	classifiedTurn   map[string]string
 	classifyingTurn  map[string]string
-	longRunMu        sync.Mutex
-	longRun          map[string]longRunSession
-	forcedStopMu     sync.Mutex
-	forcedStop       map[string]time.Time
-	pendingResumeMu  sync.Mutex
-	pendingResumeID  map[string]string
+	// classificationTranscriptExtractor is a private test seam for exercising
+	// classification outcomes without waiting on an agent driver's retry policy.
+	// Production leaves it nil and uses extractLastAssistantMessage below.
+	classificationTranscriptExtractor func(*protocol.Session, string, int, time.Time) (string, string, error)
+	longRunMu                         sync.Mutex
+	longRun                           map[string]longRunSession
+	forcedStopMu                      sync.Mutex
+	forcedStop                        map[string]time.Time
+	pendingResumeMu                   sync.Mutex
+	pendingResumeID                   map[string]string
 	// Orphaned-ticket reconciliation (docs/plans/2026-07-01-orphaned-ticket-
 	// reconciliation.md): when an owning session dies with a non-terminal ticket,
 	// a capped headless classifier judges the dead transcript against the brief.
@@ -2520,7 +2524,11 @@ func (d *Daemon) classifySessionState(sessionID, transcriptPath string) {
 
 	// Parse transcript for last assistant message
 	d.logf("classifySessionState: parsing transcript for session %s", sessionID)
-	lastMessage, assistantTurnID, err := d.extractLastAssistantMessage(session, resolvedTranscriptPath, 500, classificationStartTime)
+	extract := d.extractLastAssistantMessage
+	if d.classificationTranscriptExtractor != nil {
+		extract = d.classificationTranscriptExtractor
+	}
+	lastMessage, assistantTurnID, err := extract(session, resolvedTranscriptPath, 500, classificationStartTime)
 	if err != nil {
 		if errors.Is(err, agentdriver.ErrNoNewAssistantTurn) {
 			d.logf("classifySessionState: no new assistant turn for session %s, skipping classification", sessionID)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -231,6 +231,7 @@ type Daemon struct {
 	plugins             *pluginRegistry
 	pluginSupervisorMu  sync.Mutex
 	pluginSupervisor    *pluginSupervisor
+	pluginHealthEnabled bool
 	pluginDriverMu      sync.Mutex
 	pluginLaunching     map[string]pluginSessionLaunch
 	pluginReports       map[string][]pendingPluginReport
@@ -574,35 +575,36 @@ func New(socketPath string) *Daemon {
 	manager := pty.NewManager(pty.DefaultScrollbackSize, logger.Infof)
 
 	d := &Daemon{
-		socketPath:         socketPath,
-		pidPath:            pidPath,
-		dataRoot:           dataRoot,
-		store:              sessionStore,
-		wsHub:              newWSHub(),
-		done:               make(chan struct{}),
-		logger:             logger,
-		debugLogging:       logger != nil && logger.DebugEnabled(),
-		ghRegistry:         github.NewClientRegistry(),
-		hubManager:         nil,
-		repoCaches:         make(map[string]*repoCache),
-		gitCoord:           newGitCoordinator(),
-		warnings:           startupWarnings,
-		workflowDirty:      make(map[string]bool),
-		workflowEngineConn: make(map[string]workflowEngineSink),
-		ptyBackend:         ptybackend.NewEmbedded(manager),
-		transcriptWatch:    make(map[string]*transcriptWatcher),
-		pendingInitialWS:   make(map[*wsClient]struct{}),
-		startedCh:          make(chan struct{}),
-		classifiedTurn:     make(map[string]string),
-		classifyingTurn:    make(map[string]string),
-		longRun:            make(map[string]longRunSession),
-		forcedStop:         make(map[string]time.Time),
-		pendingResumeID:    make(map[string]string),
-		tailscale:          newTailscaleRuntime(),
-		plugins:            newPluginRegistry(),
-		pluginDir:          pluginDirForSocket(socketPath),
-		bundledPluginDir:   bundledPluginDirForExecutable(),
-		workspaces:         newWorkspaceRegistry(),
+		socketPath:          socketPath,
+		pidPath:             pidPath,
+		dataRoot:            dataRoot,
+		store:               sessionStore,
+		wsHub:               newWSHub(),
+		done:                make(chan struct{}),
+		logger:              logger,
+		debugLogging:        logger != nil && logger.DebugEnabled(),
+		ghRegistry:          github.NewClientRegistry(),
+		hubManager:          nil,
+		repoCaches:          make(map[string]*repoCache),
+		gitCoord:            newGitCoordinator(),
+		warnings:            startupWarnings,
+		workflowDirty:       make(map[string]bool),
+		workflowEngineConn:  make(map[string]workflowEngineSink),
+		ptyBackend:          ptybackend.NewEmbedded(manager),
+		transcriptWatch:     make(map[string]*transcriptWatcher),
+		pendingInitialWS:    make(map[*wsClient]struct{}),
+		startedCh:           make(chan struct{}),
+		classifiedTurn:      make(map[string]string),
+		classifyingTurn:     make(map[string]string),
+		longRun:             make(map[string]longRunSession),
+		forcedStop:          make(map[string]time.Time),
+		pendingResumeID:     make(map[string]string),
+		tailscale:           newTailscaleRuntime(),
+		plugins:             newPluginRegistry(),
+		pluginHealthEnabled: true,
+		pluginDir:           pluginDirForSocket(socketPath),
+		bundledPluginDir:    bundledPluginDirForExecutable(),
+		workspaces:          newWorkspaceRegistry(),
 	}
 	// Production wiring for the orphaned-ticket reconciliation classifier. Test
 	// constructors leave this nil so unit tests never shell out to a real CLI.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -178,7 +178,7 @@ func shortTempDir(t *testing.T) string {
 }
 
 func TestDaemon_RegisterAndQuery(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19900")
+	useFreeWSPort(t)
 
 	tmpDir := shortTempDir(t)
 	sockPath := filepath.Join(tmpDir, "test.sock")
@@ -218,7 +218,7 @@ func TestDaemon_RegisterAndQuery(t *testing.T) {
 }
 
 func TestDaemon_StateUpdate(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19901")
+	useFreeWSPort(t)
 
 	tmpDir := shortTempDir(t)
 	sockPath := filepath.Join(tmpDir, "test.sock")
@@ -262,7 +262,7 @@ func TestDaemon_StateUpdate(t *testing.T) {
 // "scheduled") over the real socket. It must land as scheduled (not idle, not
 // dropped) so the parked session reads correctly end to end.
 func TestDaemon_ScheduledStateUpdate(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19952")
+	useFreeWSPort(t)
 
 	tmpDir := shortTempDir(t)
 	sockPath := filepath.Join(tmpDir, "test.sock")
@@ -309,7 +309,7 @@ func TestDaemon_ScheduledStateUpdate(t *testing.T) {
 }
 
 func TestDaemon_Unregister(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19902")
+	useFreeWSPort(t)
 
 	tmpDir := shortTempDir(t)
 	sockPath := filepath.Join(tmpDir, "test.sock")
@@ -332,7 +332,7 @@ func TestDaemon_Unregister(t *testing.T) {
 }
 
 func TestDaemon_MultipleSessions(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19903")
+	useFreeWSPort(t)
 
 	tmpDir := shortTempDir(t)
 	sockPath := filepath.Join(tmpDir, "test.sock")
@@ -389,7 +389,7 @@ func TestDaemon_MultipleSessions(t *testing.T) {
 }
 
 func TestDaemon_SocketCleanup(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19904")
+	useFreeWSPort(t)
 
 	tmpDir := shortTempDir(t)
 	sockPath := filepath.Join(tmpDir, "test.sock")
@@ -413,9 +413,9 @@ func TestDaemon_SocketCleanup(t *testing.T) {
 }
 
 func TestDaemon_PrunesSessionsWithoutLivePTYOnStart(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19924")
+	useFreeWSPort(t)
 	t.Setenv("ATTN_PTY_BACKEND", "embedded")
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-prune-%d.sock", time.Now().UnixNano()))
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 
 	d := NewForTesting(sockPath)
 
@@ -520,7 +520,7 @@ func TestDaemon_ReseedWorkspaceStatusesAfterRecovery(t *testing.T) {
 func TestDaemon_Start_SelectsWorkerBackendWhenRequested(t *testing.T) {
 	t.Setenv("ATTN_PTY_BACKEND", "worker")
 	t.Setenv("ATTN_PTY_SKIP_STARTUP_PROBE", "1")
-	t.Setenv("ATTN_WS_PORT", "19926")
+	useFreeWSPort(t)
 
 	sockPath := filepath.Join(shortTempDir(t), "worker-select.sock")
 	d := NewForTesting(sockPath)
@@ -556,7 +556,7 @@ func TestDaemon_Start_WorkerProbeFailureFallsBackToEmbedded(t *testing.T) {
 	t.Setenv("ATTN_PTY_BACKEND", "worker")
 	t.Setenv("ATTN_PTY_SKIP_STARTUP_PROBE", "0")
 	t.Setenv("ATTN_PTY_WORKER_BINARY", filepath.Join(t.TempDir(), "missing-attn-binary"))
-	t.Setenv("ATTN_WS_PORT", "19936")
+	useFreeWSPort(t)
 
 	sockPath := filepath.Join(shortTempDir(t), "worker-probe-fallback.sock")
 	d := NewForTesting(sockPath)
@@ -595,7 +595,7 @@ func TestDaemon_Start_WorkerProbeFailureFallsBackToEmbedded(t *testing.T) {
 
 func TestDaemon_Start_SelectsEmbeddedBackendWhenRequested(t *testing.T) {
 	t.Setenv("ATTN_PTY_BACKEND", "embedded")
-	t.Setenv("ATTN_WS_PORT", "19927")
+	useFreeWSPort(t)
 
 	sockPath := filepath.Join(shortTempDir(t), "embedded-select.sock")
 	d := NewForTesting(sockPath)
@@ -3553,10 +3553,7 @@ func TestDaemon_HealthEndpoint(t *testing.T) {
 	tmpDir := shortTempDir(t)
 	sockPath := filepath.Join(tmpDir, "test.sock")
 
-	// Use unique port
-	wsPort := "19851"
-	os.Setenv("ATTN_WS_PORT", wsPort)
-	defer os.Unsetenv("ATTN_WS_PORT")
+	wsPort := useFreeWSPort(t)
 
 	d := NewForTesting(sockPath)
 	go d.Start()
@@ -3642,9 +3639,7 @@ func TestDaemon_WebRootServesEmbeddedClient(t *testing.T) {
 	tmpDir := shortTempDir(t)
 	sockPath := filepath.Join(tmpDir, "test.sock")
 
-	wsPort := "19852"
-	os.Setenv("ATTN_WS_PORT", wsPort)
-	defer os.Unsetenv("ATTN_WS_PORT")
+	wsPort := useFreeWSPort(t)
 
 	d := NewForTesting(sockPath)
 	go d.Start()
@@ -3813,9 +3808,7 @@ func TestDaemon_WebFaviconDoesNot404(t *testing.T) {
 	tmpDir := shortTempDir(t)
 	sockPath := filepath.Join(tmpDir, "test.sock")
 
-	wsPort := "19853"
-	os.Setenv("ATTN_WS_PORT", wsPort)
-	defer os.Unsetenv("ATTN_WS_PORT")
+	wsPort := useFreeWSPort(t)
 
 	d := NewForTesting(sockPath)
 	go d.Start()
@@ -3864,8 +3857,7 @@ func TestDaemon_WebInstrumentationLogsPayload(t *testing.T) {
 		t.Fatalf("freeTCPPort: %v", err)
 	}
 	wsPort := strconv.Itoa(port)
-	os.Setenv("ATTN_WS_PORT", wsPort)
-	defer os.Unsetenv("ATTN_WS_PORT")
+	t.Setenv("ATTN_WS_PORT", wsPort)
 
 	logger, err := logging.New(logPath)
 	if err != nil {
@@ -4629,10 +4621,7 @@ func TestDaemon_ApprovePR_ViaWebSocket(t *testing.T) {
 		Role:   "reviewer",
 	})
 
-	// Use unique port to avoid conflicts
-	wsPort := "19849"
-	os.Setenv("ATTN_WS_PORT", wsPort)
-	defer os.Unsetenv("ATTN_WS_PORT")
+	wsPort := useFreeWSPort(t)
 
 	// Create GitHub client pointing to mock server
 	ghClient, err := github.NewClient(mockGH.URL, "test-token")
@@ -4645,7 +4634,7 @@ func TestDaemon_ApprovePR_ViaWebSocket(t *testing.T) {
 
 	// Create daemon with GitHub client
 	// Use /tmp directly to avoid long socket paths, with unique suffix to prevent parallel test conflicts
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-test-ws-%d.sock", time.Now().UnixNano()))
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 	os.Remove(sockPath) // Clean up any existing socket
 	d := NewWithGitHubClient(sockPath, ghClient)
 
@@ -4744,7 +4733,7 @@ func TestDaemon_ApprovePR_ViaWebSocket(t *testing.T) {
 }
 
 func TestDaemon_InjectTestPR(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19905")
+	useFreeWSPort(t)
 
 	tmpDir := t.TempDir()
 	sockPath := filepath.Join(tmpDir, "test.sock")
@@ -4823,13 +4812,10 @@ func TestDaemon_InjectTestPR(t *testing.T) {
 }
 
 func TestDaemon_MutePR_ViaWebSocket(t *testing.T) {
-	// Use unique port to avoid conflicts
-	wsPort := "19850"
-	os.Setenv("ATTN_WS_PORT", wsPort)
-	defer os.Unsetenv("ATTN_WS_PORT")
+	wsPort := useFreeWSPort(t)
 
 	// Use /tmp directly to avoid long socket paths, with unique suffix to prevent parallel test conflicts
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-test-mute-pr-%d.sock", time.Now().UnixNano()))
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 	os.Remove(sockPath) // Clean up any existing socket
 
 	d := NewForTesting(sockPath)
@@ -4944,13 +4930,10 @@ func TestDaemon_MutePR_ViaWebSocket(t *testing.T) {
 }
 
 func TestDaemon_MuteRepo_ViaWebSocket(t *testing.T) {
-	// Use unique port to avoid conflicts
-	wsPort := "19851"
-	os.Setenv("ATTN_WS_PORT", wsPort)
-	defer os.Unsetenv("ATTN_WS_PORT")
+	wsPort := useFreeWSPort(t)
 
 	// Use /tmp directly to avoid long socket paths, with unique suffix to prevent parallel test conflicts
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-test-mute-repo-%d.sock", time.Now().UnixNano()))
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 	os.Remove(sockPath) // Clean up any existing socket
 
 	d := NewForTesting(sockPath)
@@ -5026,13 +5009,10 @@ func TestDaemon_MuteRepo_ViaWebSocket(t *testing.T) {
 }
 
 func TestDaemon_InitialState_IncludesRepoStates(t *testing.T) {
-	// Use unique port to avoid conflicts
-	wsPort := "19852"
-	os.Setenv("ATTN_WS_PORT", wsPort)
-	defer os.Unsetenv("ATTN_WS_PORT")
+	wsPort := useFreeWSPort(t)
 
 	// Use /tmp directly to avoid long socket paths, with unique suffix to prevent parallel test conflicts
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-test-initial-repos-%d.sock", time.Now().UnixNano()))
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 	os.Remove(sockPath) // Clean up any existing socket
 
 	d := NewForTesting(sockPath)
@@ -5099,12 +5079,9 @@ func TestDaemon_InitialState_IncludesRepoStates(t *testing.T) {
 // ============================================================================
 
 func TestDaemon_StateChange_BroadcastsToWebSocket(t *testing.T) {
-	// Use unique port to avoid conflicts
-	wsPort := "19853"
-	os.Setenv("ATTN_WS_PORT", wsPort)
-	defer os.Unsetenv("ATTN_WS_PORT")
+	wsPort := useFreeWSPort(t)
 
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-test-state-broadcast-%d.sock", time.Now().UnixNano()))
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 	os.Remove(sockPath)
 
 	d := NewForTesting(sockPath)
@@ -5168,12 +5145,9 @@ func TestDaemon_StateChange_BroadcastsToWebSocket(t *testing.T) {
 }
 
 func TestDaemon_StateTransitions_AllStates(t *testing.T) {
-	// Use unique port to avoid conflicts
-	wsPort := "19854"
-	os.Setenv("ATTN_WS_PORT", wsPort)
-	defer os.Unsetenv("ATTN_WS_PORT")
+	wsPort := useFreeWSPort(t)
 
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-test-state-transitions-%d.sock", time.Now().UnixNano()))
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 	os.Remove(sockPath)
 
 	d := NewForTesting(sockPath)
@@ -5253,12 +5227,9 @@ func TestDaemon_StateTransitions_AllStates(t *testing.T) {
 }
 
 func TestDaemon_InjectTestSession_BroadcastsToWebSocket(t *testing.T) {
-	// Use unique port to avoid conflicts
-	wsPort := "19855"
-	os.Setenv("ATTN_WS_PORT", wsPort)
-	defer os.Unsetenv("ATTN_WS_PORT")
+	wsPort := useFreeWSPort(t)
 
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-test-inject-session-%d.sock", time.Now().UnixNano()))
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 	os.Remove(sockPath)
 
 	d := NewForTesting(sockPath)
@@ -5345,10 +5316,10 @@ func TestDaemon_InjectTestSession_BroadcastsToWebSocket(t *testing.T) {
 }
 
 func TestDaemon_StopCommand_PendingTodos_SetsWaitingInput(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19906")
+	useFreeWSPort(t)
 
 	// Use /tmp directly to avoid long socket paths
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-test-stop-pending-%d.sock", time.Now().UnixNano()))
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 	os.Remove(sockPath) // Clean up any existing socket
 
 	d := NewForTesting(sockPath)
@@ -5422,7 +5393,7 @@ func TestDaemon_StopCommand_PendingTodos_SetsWaitingInput(t *testing.T) {
 }
 
 func TestDaemon_StopCommand_CompletedTodos_ProceedsToClassification(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19907")
+	useFreeWSPort(t)
 
 	// This test verifies that when all todos are completed, the daemon
 	// does NOT short-circuit to waiting_input based on todos alone.
@@ -5432,7 +5403,7 @@ func TestDaemon_StopCommand_CompletedTodos_ProceedsToClassification(t *testing.T
 	// but that's different from the todos short-circuit path.
 
 	// Use /tmp directly to avoid long socket paths
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-test-stop-completed-%d.sock", time.Now().UnixNano()))
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 	os.Remove(sockPath) // Clean up any existing socket
 
 	d := NewForTesting(sockPath)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5572,10 +5572,13 @@ func TestClassifySessionState_TranscriptDisabledWithPendingTodos_SetsWaitingInpu
 	}
 }
 
-func TestClassifySessionState_ClaudeSkipsDuplicateAssistantTurn(t *testing.T) {
+func TestClassifySessionState_SkipsNoNewAssistantTurn(t *testing.T) {
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	mockClassifier := &countingClassifier{state: protocol.StateWaitingInput}
 	d.classifier = mockClassifier
+	d.classificationTranscriptExtractor = func(*protocol.Session, string, int, time.Time) (string, string, error) {
+		return "", "", agentdriver.ErrNoNewAssistantTurn
+	}
 
 	now := time.Now()
 	nowStr := string(protocol.NewTimestamp(now))
@@ -5590,40 +5593,17 @@ func TestClassifySessionState_ClaudeSkipsDuplicateAssistantTurn(t *testing.T) {
 		LastSeen:       nowStr,
 	})
 
-	transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
-	content := fmt.Sprintf(
-		`{"type":"user","uuid":"u1","timestamp":"%s","message":{"role":"user","content":"hello"}}
-{"type":"assistant","uuid":"a1","timestamp":"%s","message":{"role":"assistant","content":[{"type":"text","text":"Hello! What can I help you with today?"}]}}
-`,
-		now.Add(-1*time.Second).UTC().Format(time.RFC3339Nano),
-		now.UTC().Format(time.RFC3339Nano),
-	)
-	if err := os.WriteFile(transcriptPath, []byte(content), 0644); err != nil {
-		t.Fatalf("write transcript: %v", err)
-	}
-
-	d.classifySessionState("sess-1", transcriptPath)
-	if got := mockClassifier.CallCount(); got != 1 {
-		t.Fatalf("first classify calls=%d, want 1", got)
+	d.classifySessionState("sess-1", filepath.Join(t.TempDir(), "transcript.jsonl"))
+	if got := mockClassifier.CallCount(); got != 0 {
+		t.Fatalf("classifier calls=%d, want 0", got)
 	}
 
 	sess := d.store.Get("sess-1")
 	if sess == nil {
-		t.Fatal("session missing after first classify")
+		t.Fatal("session missing after classification")
 	}
-	firstState := sess.State
-
-	d.classifySessionState("sess-1", transcriptPath)
-	if got := mockClassifier.CallCount(); got != 1 {
-		t.Fatalf("second classify calls=%d, want still 1", got)
-	}
-
-	sess = d.store.Get("sess-1")
-	if sess == nil {
-		t.Fatal("session missing after second classify")
-	}
-	if sess.State != firstState {
-		t.Fatalf("state changed on duplicate turn: got %q want %q", sess.State, firstState)
+	if sess.State != protocol.StateWorking {
+		t.Fatalf("state changed on no-new-turn result: got %q want %q", sess.State, protocol.StateWorking)
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -161,6 +161,17 @@ func waitForSocket(t *testing.T, sockPath string, timeout time.Duration) {
 	t.Fatalf("socket %s not ready after %v", sockPath, timeout)
 }
 
+func waitForRecovery(t *testing.T, d *Daemon) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for d.isRecovering() {
+		if time.Now().After(deadline) {
+			t.Fatal("daemon recovery did not finish before test setup")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func shortTempDir(t *testing.T) string {
 	t.Helper()
 	// Unix socket paths are length-limited (notably on macOS). The default
@@ -188,13 +199,7 @@ func TestDaemon_RegisterAndQuery(t *testing.T) {
 	defer d.Stop()
 
 	waitForSocket(t, sockPath, 5*time.Second)
-	deadline := time.Now().Add(2 * time.Second)
-	for d.isRecovering() {
-		if time.Now().After(deadline) {
-			t.Fatal("daemon recovery did not finish before test setup")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForRecovery(t, d)
 
 	c := client.New(sockPath)
 
@@ -228,13 +233,7 @@ func TestDaemon_StateUpdate(t *testing.T) {
 	defer d.Stop()
 
 	waitForSocket(t, sockPath, 5*time.Second)
-	deadline := time.Now().Add(2 * time.Second)
-	for d.isRecovering() {
-		if time.Now().After(deadline) {
-			t.Fatal("daemon recovery did not finish before test setup")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForRecovery(t, d)
 
 	c := client.New(sockPath)
 
@@ -272,13 +271,7 @@ func TestDaemon_ScheduledStateUpdate(t *testing.T) {
 	defer d.Stop()
 
 	waitForSocket(t, sockPath, 5*time.Second)
-	deadline := time.Now().Add(2 * time.Second)
-	for d.isRecovering() {
-		if time.Now().After(deadline) {
-			t.Fatal("daemon recovery did not finish before test setup")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForRecovery(t, d)
 
 	c := client.New(sockPath)
 	c.Register("sess-1", "loop-bot", "/tmp")
@@ -342,13 +335,7 @@ func TestDaemon_MultipleSessions(t *testing.T) {
 	defer d.Stop()
 
 	waitForSocket(t, sockPath, 5*time.Second)
-	deadline := time.Now().Add(2 * time.Second)
-	for d.isRecovering() {
-		if time.Now().After(deadline) {
-			t.Fatal("daemon recovery did not finish before test setup")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForRecovery(t, d)
 
 	c := client.New(sockPath)
 
@@ -368,7 +355,7 @@ func TestDaemon_MultipleSessions(t *testing.T) {
 		t.Fatalf("UpdateState(2, working) error: %v", err)
 	}
 
-	deadline = time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(2 * time.Second)
 	for {
 		launching, err := c.Query(protocol.StateLaunching)
 		if err != nil {

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -542,20 +542,27 @@ func TestDelegateThreadsModelAndEffortIntoPluginDriver(t *testing.T) {
 	requestDone := make(chan struct{})
 	go func() {
 		defer close(requestDone)
-		request := decodeJSONRPCMessage(t, client)
-		if request.Method != "driver.spawn" {
-			t.Errorf("method=%q, want driver.spawn", request.Method)
+		for {
+			request := decodeJSONRPCMessage(t, client)
+			if request.Method == pluginHealthMethod {
+				respondPluginRequest(t, client, request, pluginHealthResult{OK: true})
+				continue
+			}
+			if request.Method != "driver.spawn" {
+				t.Errorf("method=%q, want driver.spawn", request.Method)
+				return
+			}
+			var got pluginDriverSpawnParams
+			if err := json.Unmarshal(request.Params, &got); err != nil {
+				t.Errorf("decode plugin spawn params: %v", err)
+				return
+			}
+			if got.Model != "spotify-glm/zai-org/GLM-5.2-FP8" || got.Effort != "low" {
+				t.Errorf("plugin spawn pins=%q/%q, want selected model/low", got.Model, got.Effort)
+			}
+			respondPluginRequest(t, client, request, pluginDriverSpawnResult{Argv: []string{"fixture"}})
 			return
 		}
-		var got pluginDriverSpawnParams
-		if err := json.Unmarshal(request.Params, &got); err != nil {
-			t.Errorf("decode plugin spawn params: %v", err)
-			return
-		}
-		if got.Model != "spotify-glm/zai-org/GLM-5.2-FP8" || got.Effort != "low" {
-			t.Errorf("plugin spawn pins=%q/%q, want selected model/low", got.Model, got.Effort)
-		}
-		respondPluginRequest(t, client, request, pluginDriverSpawnResult{Argv: []string{"fixture"}})
 	}()
 
 	if _, err := d.delegate(&protocol.DelegateMessage{
@@ -679,7 +686,7 @@ func TestDelegateWebSocketCommandReturnsResult(t *testing.T) {
 		if result.Result.WorkspaceID != "workspace-source" {
 			t.Fatalf("workspace = %q, want workspace-source", result.Result.WorkspaceID)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for delegate_result")
 	}
 }

--- a/internal/daemon/plugin_driver_e2e_test.go
+++ b/internal/daemon/plugin_driver_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -33,13 +32,7 @@ func TestPluginDriverEndToEnd_InstalledProcessLaunchReportAndResumeThroughWorker
 	}
 
 	tmpDir := shortTempDir(t)
-	repoRoot := findRepoRootForTest(t)
-	attnBin := filepath.Join(tmpDir, "attn")
-	build := exec.Command("go", "build", "-o", attnBin, "./cmd/attn")
-	build.Dir = repoRoot
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build attn test binary: %v\n%s", err, string(output))
-	}
+	attnBin := attnBinaryForE2ETest(t, tmpDir)
 
 	port, err := freeTCPPort()
 	if err != nil {

--- a/internal/daemon/plugin_rpc.go
+++ b/internal/daemon/plugin_rpc.go
@@ -568,7 +568,9 @@ func (d *Daemon) handlePluginConnection(conn net.Conn, reader *bufio.Reader, hel
 		return
 	}
 	d.broadcastPluginsUpdated()
-	go d.monitorPluginHealth(plugin)
+	if d.pluginHealthEnabled {
+		go d.monitorPluginHealth(plugin)
+	}
 
 	for {
 		data, err := readSocketFrame(reader)

--- a/internal/daemon/plugin_runtime_test.go
+++ b/internal/daemon/plugin_runtime_test.go
@@ -120,7 +120,7 @@ entrypoint = "src/index.ts"
 }
 
 func TestDaemon_StartInstalledPlugins_SpawnsProviderPlugin(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19971")
+	useFreeWSPort(t)
 	t.Setenv("ATTN_PLUGIN_HELPER", "1")
 	t.Setenv("ATTN_TEST_HELPER_BINARY", os.Args[0])
 
@@ -154,7 +154,7 @@ func TestDaemon_StartInstalledPlugins_SpawnsProviderPlugin(t *testing.T) {
 }
 
 func TestDaemon_StartInstalledPlugins_RestartsCleanExitWithNewGeneration(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19972")
+	useFreeWSPort(t)
 	t.Setenv("ATTN_PLUGIN_HELPER", "1")
 	t.Setenv("ATTN_TEST_HELPER_BINARY", os.Args[0])
 

--- a/internal/daemon/real_agent_harness_test.go
+++ b/internal/daemon/real_agent_harness_test.go
@@ -313,6 +313,17 @@ func freeTCPPort() (int, error) {
 	return addr.Port, nil
 }
 
+func useFreeWSPort(t *testing.T) string {
+	t.Helper()
+	port, err := freeTCPPort()
+	if err != nil {
+		t.Fatalf("allocate WebSocket port: %v", err)
+	}
+	value := strconv.Itoa(port)
+	t.Setenv("ATTN_WS_PORT", value)
+	return value
+}
+
 func asString(v interface{}) string {
 	switch t := v.(type) {
 	case string:

--- a/internal/daemon/testharness_test.go
+++ b/internal/daemon/testharness_test.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"encoding/json"
-	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -14,8 +13,8 @@ import (
 )
 
 func TestHarness_FakeClassifier(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19908")
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-harness-classifier-%d.sock", time.Now().UnixNano()))
+	useFreeWSPort(t)
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 
 	harness := NewTestHarnessBuilder(sockPath).
 		WithDefaultClassifierState(protocol.StateIdle).
@@ -70,8 +69,8 @@ func TestHarness_FakeClassifier(t *testing.T) {
 }
 
 func TestHarness_ClaudeStop_RetriesTranscriptReadOnFirstTurn(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19912")
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-harness-claude-stop-retry-%d.sock", time.Now().UnixNano()))
+	useFreeWSPort(t)
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 
 	harness := NewTestHarnessBuilder(sockPath).
 		WithDefaultClassifierState(protocol.StateIdle).
@@ -135,8 +134,8 @@ func TestHarness_ClaudeStop_RetriesTranscriptReadOnFirstTurn(t *testing.T) {
 }
 
 func TestHarness_BroadcastRecorder(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19909")
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-harness-recorder-%d.sock", time.Now().UnixNano()))
+	useFreeWSPort(t)
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 
 	harness := NewTestHarnessBuilder(sockPath).Build()
 
@@ -188,8 +187,8 @@ func TestHarness_BroadcastRecorder(t *testing.T) {
 }
 
 func TestHarness_WaitForEvent(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19910")
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-harness-wait-%d.sock", time.Now().UnixNano()))
+	useFreeWSPort(t)
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 
 	harness := NewTestHarnessBuilder(sockPath).Build()
 
@@ -247,8 +246,8 @@ func TestHarness_ClassifierWithCustomResponses(t *testing.T) {
 }
 
 func TestHarness_ConcurrentOperations(t *testing.T) {
-	t.Setenv("ATTN_WS_PORT", "19911")
-	sockPath := filepath.Join("/tmp", fmt.Sprintf("attn-harness-concurrent-%d.sock", time.Now().UnixNano()))
+	useFreeWSPort(t)
+	sockPath := filepath.Join(shortTempDir(t), "attn.sock")
 
 	harness := NewTestHarnessBuilder(sockPath).Build()
 

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -16,6 +16,7 @@ func writeFile(t *testing.T, dir, name, content string) {
 }
 
 func TestListRemoteBranches(t *testing.T) {
+	t.Parallel()
 	// This test requires a repo with remotes, skip in CI
 	if os.Getenv("CI") != "" {
 		t.Skip("Skipping remote branch test in CI")
@@ -32,6 +33,7 @@ func TestListRemoteBranches(t *testing.T) {
 }
 
 func TestCheckoutRemoteBranch(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init")
 	runGit(t, dir, "config", "user.email", "test@test.com")
@@ -59,6 +61,7 @@ func TestCheckoutRemoteBranch(t *testing.T) {
 }
 
 func TestRefExists(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init", "-b", "main")
 	runGit(t, dir, "commit", "--allow-empty", "-m", "init")
@@ -80,6 +83,7 @@ func TestRefExists(t *testing.T) {
 }
 
 func TestGetCurrentBranchEmptyRepo(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init", "-b", "main")
 
@@ -93,6 +97,7 @@ func TestGetCurrentBranchEmptyRepo(t *testing.T) {
 }
 
 func TestListBranchesWithCommitsEmptyRepo(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init", "-b", "main")
 
@@ -106,6 +111,7 @@ func TestListBranchesWithCommitsEmptyRepo(t *testing.T) {
 }
 
 func TestListBranchesWithCommits(t *testing.T) {
+	t.Parallel()
 	// Create temp directory with subdirectories for main repo and worktree
 	tmpDir := t.TempDir()
 	mainDir := filepath.Join(tmpDir, "main")

--- a/internal/git/command.go
+++ b/internal/git/command.go
@@ -26,13 +26,12 @@ const (
 	OpClone    Operation = "clone"
 )
 
-const slowGitLogThreshold = 2 * time.Second
-
 var (
-	logMu       sync.RWMutex
-	logf        func(format string, args ...interface{})
-	timeoutMu   sync.RWMutex
-	timeoutByOp = map[Operation]time.Duration{}
+	logMu               sync.RWMutex
+	logf                func(format string, args ...interface{})
+	slowGitLogThreshold = 2 * time.Second
+	timeoutMu           sync.RWMutex
+	timeoutByOp         = map[Operation]time.Duration{}
 )
 
 // SetLogFunc wires git command duration logging into the daemon logger.
@@ -40,6 +39,19 @@ func SetLogFunc(fn func(format string, args ...interface{})) {
 	logMu.Lock()
 	defer logMu.Unlock()
 	logf = fn
+}
+
+func setSlowLogThresholdForTesting(threshold time.Duration) func() {
+	logMu.Lock()
+	previous := slowGitLogThreshold
+	slowGitLogThreshold = threshold
+	logMu.Unlock()
+
+	return func() {
+		logMu.Lock()
+		defer logMu.Unlock()
+		slowGitLogThreshold = previous
+	}
 }
 
 func defaultTimeout(op Operation) time.Duration {
@@ -198,11 +210,12 @@ func mergedCommandEnv(overrides map[string]string) []string {
 func logGitCommand(op Operation, dir string, args []string, duration time.Duration, ctxErr error) {
 	logMu.RLock()
 	fn := logf
+	threshold := slowGitLogThreshold
 	logMu.RUnlock()
 	if fn == nil {
 		return
 	}
-	if duration < slowGitLogThreshold && ctxErr == nil {
+	if duration < threshold && ctxErr == nil {
 		return
 	}
 	status := "slow"

--- a/internal/git/command_test.go
+++ b/internal/git/command_test.go
@@ -32,10 +32,12 @@ func TestRunGitOutputTimesOut(t *testing.T) {
 func TestRunGitOutputLogsSlowCommand(t *testing.T) {
 	fakeBin := t.TempDir()
 	fakeGit := filepath.Join(fakeBin, "git")
-	if err := os.WriteFile(fakeGit, []byte("#!/bin/sh\nsleep 3\nprintf ok\n"), 0755); err != nil {
+	if err := os.WriteFile(fakeGit, []byte("#!/bin/sh\nprintf ok\n"), 0755); err != nil {
 		t.Fatalf("write fake git: %v", err)
 	}
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	cleanupThreshold := setSlowLogThresholdForTesting(0)
+	defer cleanupThreshold()
 
 	var logs []string
 	SetLogFunc(func(format string, args ...interface{}) {

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -11,6 +11,7 @@ import (
 // Test helper functions (pure functions, no git needed)
 
 func TestParseGitStatus(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		code     string
 		expected string
@@ -38,6 +39,7 @@ func TestParseGitStatus(t *testing.T) {
 }
 
 func TestParseGitPorcelainStatus(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		xy       string
 		expected string
@@ -68,6 +70,7 @@ func TestParseGitPorcelainStatus(t *testing.T) {
 }
 
 func TestExtractRenamePath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    string
 		expected string
@@ -102,6 +105,7 @@ func TestExtractRenamePath(t *testing.T) {
 // Integration tests with actual git repos
 
 func TestGetBranchDiffFiles_CommittedChanges(t *testing.T) {
+	t.Parallel()
 	// Create temp git repo
 	dir := t.TempDir()
 	runGit(t, dir, "init")
@@ -137,6 +141,7 @@ func TestGetBranchDiffFiles_CommittedChanges(t *testing.T) {
 }
 
 func TestGetBranchDiffFiles_UncommittedChanges(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init")
 
@@ -169,6 +174,7 @@ func TestGetBranchDiffFiles_UncommittedChanges(t *testing.T) {
 }
 
 func TestGetBranchDiffFiles_MixedChanges(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init")
 
@@ -224,6 +230,7 @@ func TestGetBranchDiffFiles_MixedChanges(t *testing.T) {
 }
 
 func TestGetBranchDiffFiles_DeletedFile(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init")
 
@@ -258,6 +265,7 @@ func TestGetBranchDiffFiles_DeletedFile(t *testing.T) {
 }
 
 func TestGetBranchDiffFiles_UntrackedFile(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init")
 	runGit(t, dir, "commit", "--allow-empty", "-m", "init")
@@ -287,6 +295,7 @@ func TestGetBranchDiffFiles_UntrackedFile(t *testing.T) {
 }
 
 func TestGetBranchDiffFiles_NoChanges(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init")
 	runGit(t, dir, "commit", "--allow-empty", "-m", "init")
@@ -304,6 +313,7 @@ func TestGetBranchDiffFiles_NoChanges(t *testing.T) {
 }
 
 func TestGetBranchDiffFiles_InvalidBaseRef(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init")
 	runGit(t, dir, "commit", "--allow-empty", "-m", "init")
@@ -324,6 +334,7 @@ func TestGetBranchDiffFiles_InvalidBaseRef(t *testing.T) {
 }
 
 func TestGetBranchDiffFiles_LineStats(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init")
 	runGit(t, dir, "commit", "--allow-empty", "-m", "init")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestGetBranchInfo_MainRepo(t *testing.T) {
+	t.Parallel()
 	// Create temp git repo
 	dir := t.TempDir()
 	runGit(t, dir, "init")
@@ -30,6 +31,7 @@ func TestGetBranchInfo_MainRepo(t *testing.T) {
 }
 
 func TestGetBranchInfo_Worktree(t *testing.T) {
+	t.Parallel()
 	// Create temp git repo with worktree - use single tmpDir with subdirs
 	// to avoid flakiness when running tests in parallel
 	tmpDir := t.TempDir()
@@ -59,6 +61,7 @@ func TestGetBranchInfo_Worktree(t *testing.T) {
 }
 
 func TestGetBranchInfo_NotGitRepo(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	info, err := GetBranchInfo(dir)
 	if err != nil {
@@ -70,6 +73,7 @@ func TestGetBranchInfo_NotGitRepo(t *testing.T) {
 }
 
 func TestGetBranchInfo_DetachedHead(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init")
 	runGit(t, dir, "commit", "--allow-empty", "-m", "init")

--- a/internal/git/resolve_test.go
+++ b/internal/git/resolve_test.go
@@ -4,6 +4,22 @@ import "testing"
 
 func TestOriginHostOwnerRepo(t *testing.T) {
 	t.Parallel()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "remote", "add", "origin", "ssh://git@github.com:2222/owner/name.git")
+
+	host, slug := OriginHostOwnerRepo(dir)
+	if host != "github.com" || slug != "owner/name" {
+		t.Errorf("OriginHostOwnerRepo() = (%q, %q), want (%q, %q)",
+			host, slug, "github.com", "owner/name")
+	}
+	if got := OriginOwnerRepo(dir); got != "owner/name" {
+		t.Errorf("OriginOwnerRepo() = %q, want %q", got, "owner/name")
+	}
+}
+
+func TestHostOwnerRepoFromRemote(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name     string
 		remote   string
@@ -21,17 +37,10 @@ func TestOriginHostOwnerRepo(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			runGit(t, dir, "init")
-			runGit(t, dir, "remote", "add", "origin", tc.remote)
-
-			host, slug := OriginHostOwnerRepo(dir)
+			host, slug := hostOwnerRepoFromRemote(tc.remote)
 			if host != tc.wantHost || slug != tc.wantSlug {
-				t.Errorf("OriginHostOwnerRepo(%q) = (%q, %q), want (%q, %q)",
+				t.Errorf("hostOwnerRepoFromRemote(%q) = (%q, %q), want (%q, %q)",
 					tc.remote, host, slug, tc.wantHost, tc.wantSlug)
-			}
-			if got := OriginOwnerRepo(dir); got != tc.wantSlug {
-				t.Errorf("OriginOwnerRepo(%q) = %q, want %q", tc.remote, got, tc.wantSlug)
 			}
 		})
 	}

--- a/internal/git/resolve_test.go
+++ b/internal/git/resolve_test.go
@@ -3,6 +3,7 @@ package git
 import "testing"
 
 func TestOriginHostOwnerRepo(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name     string
 		remote   string
@@ -37,6 +38,7 @@ func TestOriginHostOwnerRepo(t *testing.T) {
 }
 
 func TestOriginHostOwnerRepo_NotGitRepo(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	if host, slug := OriginHostOwnerRepo(dir); host != "" || slug != "" {
 		t.Errorf("OriginHostOwnerRepo(non-repo) = (%q, %q), want empty", host, slug)
@@ -44,6 +46,7 @@ func TestOriginHostOwnerRepo_NotGitRepo(t *testing.T) {
 }
 
 func TestOriginHostOwnerRepo_NoOrigin(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	runGit(t, dir, "init")
 	if host, slug := OriginHostOwnerRepo(dir); host != "" || slug != "" {
@@ -52,6 +55,7 @@ func TestOriginHostOwnerRepo_NoOrigin(t *testing.T) {
 }
 
 func TestHostOwnerRepoFromRemoteUnparseable(t *testing.T) {
+	t.Parallel()
 	cases := []string{"", "just-a-name", "https://github.com/", "relative/path/only"}
 	for _, remote := range cases {
 		if host, slug := hostOwnerRepoFromRemote(remote); host != "" || slug != "" {

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -71,6 +71,7 @@ func TestEnsureDetachedWorktreeAtRevisionRecoversFreshStaleMetadata(t *testing.T
 }
 
 func TestListWorktrees(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	mainDir := filepath.Join(tmpDir, "main")
 	if err := os.MkdirAll(mainDir, 0755); err != nil {
@@ -107,6 +108,7 @@ func TestListWorktrees(t *testing.T) {
 }
 
 func TestCreateWorktree(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	mainDir := filepath.Join(tmpDir, "main")
 	if err := os.MkdirAll(mainDir, 0755); err != nil {
@@ -137,6 +139,7 @@ func TestCreateWorktree(t *testing.T) {
 }
 
 func TestDeleteWorktree(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	mainDir := filepath.Join(tmpDir, "main")
 	if err := os.MkdirAll(mainDir, 0755); err != nil {
@@ -163,6 +166,7 @@ func TestDeleteWorktree(t *testing.T) {
 }
 
 func TestDeleteWorktreeDirtyRequiresForce(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	mainDir := filepath.Join(tmpDir, "main")
 	if err := os.MkdirAll(mainDir, 0755); err != nil {
@@ -199,6 +203,7 @@ func TestDeleteWorktreeDirtyRequiresForce(t *testing.T) {
 }
 
 func TestGenerateWorktreePath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		mainRepo string
 		branch   string
@@ -217,6 +222,7 @@ func TestGenerateWorktreePath(t *testing.T) {
 }
 
 func TestResolveMainRepoPath_WithMainRepo(t *testing.T) {
+	t.Parallel()
 	mainDir := t.TempDir()
 	runGit(t, mainDir, "init")
 	runGit(t, mainDir, "commit", "--allow-empty", "-m", "init")
@@ -228,6 +234,7 @@ func TestResolveMainRepoPath_WithMainRepo(t *testing.T) {
 }
 
 func TestResolveMainRepoPath_WithWorktree(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	mainDir := filepath.Join(tmpDir, "hurdy-gurdy")
 	if err := os.MkdirAll(mainDir, 0755); err != nil {

--- a/internal/hub/transport_zombie_test.go
+++ b/internal/hub/transport_zombie_test.go
@@ -19,38 +19,32 @@ import (
 // without a matching cmd.Wait. On macOS these accumulate until the per-user
 // process limit is hit.
 func TestConnectViaSSHOnceReapsChildOnDialFailure(t *testing.T) {
-	// Shim "ssh" to a script that runs long enough for websocket.Dial to
-	// time out without producing a valid WebSocket upgrade response. The
-	// Dial error path is the one that leaked zombies in the bug.
+	// Shim "ssh" to return an invalid WebSocket upgrade immediately, then stay
+	// alive until connectViaSSHOnce kills it. The dial error path is the one that
+	// leaked zombies in the bug; a real timeout only made this regression slow.
 	shimDir := t.TempDir()
 	shim := filepath.Join(shimDir, "ssh")
-	script := "#!/bin/sh\nsleep 10\n"
+	script := "#!/bin/sh\nprintf 'HTTP/1.1 502 Bad Gateway\\r\\nContent-Length: 0\\r\\n\\r\\n'\nsleep 10\n"
 	if err := os.WriteFile(shim, []byte(script), 0o755); err != nil {
 		t.Fatalf("write shim: %v", err)
 	}
 	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	const iterations = 8
-	for i := 0; i < iterations; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-		ws, cmd, err := connectViaSSHOnce(ctx, "fake-target", "", "")
-		cancel()
-		if err == nil {
-			// Unexpected success — clean up and fail.
-			if ws != nil {
-				_ = ws.CloseNow()
-			}
-			killAndReap(cmd)
-			t.Fatalf("iteration %d: expected dial failure via shim, got success", i)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ws, cmd, err := connectViaSSHOnce(ctx, "fake-target", "", "")
+	cancel()
+	if err == nil {
+		// Unexpected success — clean up and fail.
+		if ws != nil {
+			_ = ws.CloseNow()
 		}
+		killAndReap(cmd)
+		t.Fatal("expected dial failure via shim, got success")
 	}
-
-	// Give the OS a moment to update process accounting.
-	time.Sleep(200 * time.Millisecond)
 
 	zombies := zombieChildrenOf(t, os.Getpid())
 	if zombies > 0 {
-		t.Fatalf("after %d failed dials: found %d zombie child ssh processes (expected 0)", iterations, zombies)
+		t.Fatalf("after failed dial: found %d zombie child ssh processes (expected 0)", zombies)
 	}
 }
 

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -354,54 +354,11 @@ func (b *WorkerBackend) Probe(ctx context.Context) error {
 	return nil
 }
 
-func (b *WorkerBackend) Spawn(ctx context.Context, opts SpawnOptions) error {
-	if err := validateSessionID(opts.ID); err != nil {
-		return err
-	}
-
-	token, err := randomToken(32)
-	if err != nil {
-		return err
-	}
-	sessionID := opts.ID
-	socketPath, err := b.expectedSocketPath(sessionID)
-	if err != nil {
-		return err
-	}
-	session := &workerSession{
-		SessionID:    sessionID,
-		SocketPath:   socketPath,
-		RegistryPath: filepath.Join(b.registryDir(), sessionID+".json"),
-		ControlToken: token,
-		LifecycleID:  opts.LifecycleID,
-	}
-
-	b.mu.Lock()
-	if _, exists := b.sessions[sessionID]; exists {
-		b.mu.Unlock()
-		return fmt.Errorf("session %s already exists", sessionID)
-	}
-	// Reserve the session ID early to avoid duplicate concurrent spawns.
-	b.sessions[sessionID] = session
-	b.mu.Unlock()
-	spawnReady := false
-	var workerProc *os.Process
-	defer func() {
-		if spawnReady {
-			return
-		}
-		if workerProc != nil {
-			b.stopSpawnedWorkerProcess(workerProc, sessionID)
-		}
-		b.mu.Lock()
-		delete(b.sessions, sessionID)
-		b.mu.Unlock()
-	}()
-
+func (b *WorkerBackend) spawnArgs(opts SpawnOptions, session *workerSession) ([]string, error) {
 	args := []string{
 		"pty-worker",
 		"--daemon-instance-id", b.cfg.DaemonInstanceID,
-		"--session-id", sessionID,
+		"--session-id", session.SessionID,
 		"--agent", opts.Agent,
 		"--cwd", opts.CWD,
 		"--cols", strconv.Itoa(int(opts.Cols)),
@@ -452,12 +409,63 @@ func (b *WorkerBackend) Spawn(ctx context.Context, opts SpawnOptions) error {
 	if len(opts.ExternalCommand) > 0 {
 		encoded, err := json.Marshal(opts.ExternalCommand)
 		if err != nil {
-			return fmt.Errorf("encode external command: %w", err)
+			return nil, fmt.Errorf("encode external command: %w", err)
 		}
 		args = append(args, "--external-command-json", string(encoded))
 	}
 	if opts.ExternalCWD != "" {
 		args = append(args, "--external-cwd", opts.ExternalCWD)
+	}
+	return args, nil
+}
+
+func (b *WorkerBackend) Spawn(ctx context.Context, opts SpawnOptions) error {
+	if err := validateSessionID(opts.ID); err != nil {
+		return err
+	}
+
+	token, err := randomToken(32)
+	if err != nil {
+		return err
+	}
+	sessionID := opts.ID
+	socketPath, err := b.expectedSocketPath(sessionID)
+	if err != nil {
+		return err
+	}
+	session := &workerSession{
+		SessionID:    sessionID,
+		SocketPath:   socketPath,
+		RegistryPath: filepath.Join(b.registryDir(), sessionID+".json"),
+		ControlToken: token,
+		LifecycleID:  opts.LifecycleID,
+	}
+
+	b.mu.Lock()
+	if _, exists := b.sessions[sessionID]; exists {
+		b.mu.Unlock()
+		return fmt.Errorf("session %s already exists", sessionID)
+	}
+	// Reserve the session ID early to avoid duplicate concurrent spawns.
+	b.sessions[sessionID] = session
+	b.mu.Unlock()
+	spawnReady := false
+	var workerProc *os.Process
+	defer func() {
+		if spawnReady {
+			return
+		}
+		if workerProc != nil {
+			b.stopSpawnedWorkerProcess(workerProc, sessionID)
+		}
+		b.mu.Lock()
+		delete(b.sessions, sessionID)
+		b.mu.Unlock()
+	}()
+
+	args, err := b.spawnArgs(opts, session)
+	if err != nil {
+		return err
 	}
 
 	binaryPath := b.resolveBinaryPath()

--- a/internal/ptybackend/worker_test.go
+++ b/internal/ptybackend/worker_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestWithoutEnvironmentKeysRemovesInheritedLaunchPins(t *testing.T) {
+	t.Parallel()
+
 	got := withoutEnvironmentKeys([]string{
 		"PATH=/bin",
 		"ATTN_MODEL=inherited",
@@ -1309,44 +1311,37 @@ func TestWorkerBackend_Spawn_CleansUpUnreadyWorkerProcess(t *testing.T) {
 }
 
 // TestWorkerBackend_Spawn_PassesThemeFlagsOnlyWhenSet covers the --theme-*
-// flag round-trip in Spawn(): a fake worker binary dumps its argv to a file
-// instead of running, so the assertion never depends on worker readiness.
+// flag round-trip in Spawn() without starting a worker process.
 func TestWorkerBackend_Spawn_PassesThemeFlagsOnlyWhenSet(t *testing.T) {
+	t.Parallel()
+
 	root := newWorkerBackendTestRoot(t)
-	argsFile := filepath.Join(root, "args.txt")
-	scriptPath := filepath.Join(root, "fake-worker.sh")
-	script := "#!/bin/sh\n" +
-		"printf '%s\\n' \"$@\" > \"$ATTN_TEST_ARGS_FILE\"\n" +
-		"exit 1\n"
-	if err := os.WriteFile(scriptPath, []byte(script), 0700); err != nil {
-		t.Fatalf("WriteFile(fake worker script) error: %v", err)
-	}
-	t.Setenv("ATTN_TEST_ARGS_FILE", argsFile)
 
 	backend, err := NewWorker(WorkerBackendConfig{
 		DataRoot:         root,
 		DaemonInstanceID: "d-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		BinaryPath:       scriptPath,
 	})
 	if err != nil {
 		t.Fatalf("NewWorker() error: %v", err)
 	}
+	session := &workerSession{
+		SessionID:    "sess-theme",
+		RegistryPath: filepath.Join(root, "registry.json"),
+		SocketPath:   filepath.Join(root, "worker.sock"),
+		ControlToken: "test-token",
+	}
 
-	prevSpawnReadyTimeout := spawnReadyTimeout
-	spawnReadyTimeout = 2 * time.Second
-	defer func() { spawnReadyTimeout = prevSpawnReadyTimeout }()
-
-	// The fake worker never writes a ready registry, so Spawn always errors —
-	// only the recorded argv (written before exit) matters here.
-	_ = backend.Spawn(context.Background(), SpawnOptions{
+	argv, err := backend.spawnArgs(SpawnOptions{
 		ID:    "sess-theme-set",
 		Agent: "shell",
 		CWD:   root,
 		Cols:  80,
 		Rows:  24,
 		Theme: pty.TerminalTheme{Foreground: "#aabbcc", Background: "#001122", Cursor: "#334455"},
-	})
-	argv := readSpawnArgsFile(t, argsFile)
+	}, session)
+	if err != nil {
+		t.Fatalf("spawnArgs(theme set) error: %v", err)
+	}
 	wantFlags := map[string]string{
 		"--theme-foreground": "#aabbcc",
 		"--theme-background": "#001122",
@@ -1358,15 +1353,16 @@ func TestWorkerBackend_Spawn_PassesThemeFlagsOnlyWhenSet(t *testing.T) {
 		}
 	}
 
-	_ = os.Remove(argsFile)
-	_ = backend.Spawn(context.Background(), SpawnOptions{
+	argv, err = backend.spawnArgs(SpawnOptions{
 		ID:    "sess-theme-unset",
 		Agent: "shell",
 		CWD:   root,
 		Cols:  80,
 		Rows:  24,
-	})
-	argv = readSpawnArgsFile(t, argsFile)
+	}, session)
+	if err != nil {
+		t.Fatalf("spawnArgs(theme unset) error: %v", err)
+	}
 	for _, flag := range []string{"--theme-foreground", "--theme-background", "--theme-cursor"} {
 		for _, arg := range argv {
 			if arg == flag {
@@ -1374,24 +1370,6 @@ func TestWorkerBackend_Spawn_PassesThemeFlagsOnlyWhenSet(t *testing.T) {
 			}
 		}
 	}
-}
-
-func readSpawnArgsFile(t *testing.T, path string) []string {
-	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	var data []byte
-	var err error
-	for time.Now().Before(deadline) {
-		data, err = os.ReadFile(path)
-		if err == nil {
-			break
-		}
-		time.Sleep(25 * time.Millisecond)
-	}
-	if err != nil {
-		t.Fatalf("timed out reading spawn args file %s: %v", path, err)
-	}
-	return strings.Split(strings.TrimRight(string(data), "\n"), "\n")
 }
 
 func argAfterFlag(argv []string, flag string) string {

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -35,7 +35,8 @@ changed_matching() {
 
 configure_pkg_config() {
   if ! command -v pkg-config >/dev/null 2>&1 && command -v pkgconf >/dev/null 2>&1; then
-    export PKG_CONFIG="$(command -v pkgconf)"
+    PKG_CONFIG="$(command -v pkgconf)"
+    export PKG_CONFIG
   fi
 
   if [ -z "${PKG_CONFIG_PATH:-}" ] && [ -d "$HOME/.nix-profile/lib/pkgconfig" ]; then
@@ -62,7 +63,9 @@ ensure_no_unstaged_changes() {
 
 format_go_files() {
   local go_files=()
-  mapfile -t go_files < <(changed_matching '\.go$')
+  while IFS= read -r file; do
+    go_files+=("$file")
+  done < <(changed_matching '\.go$')
   if [ "${#go_files[@]}" -eq 0 ]; then
     return
   fi
@@ -75,7 +78,9 @@ format_go_files() {
 format_rust_files() {
   local pattern="$1"
   local rust_files=()
-  mapfile -t rust_files < <(changed_matching "$pattern")
+  while IFS= read -r file; do
+    rust_files+=("$file")
+  done < <(changed_matching "$pattern")
   if [ "${#rust_files[@]}" -eq 0 ]; then
     return
   fi
@@ -86,6 +91,9 @@ format_rust_files() {
 }
 
 tmp_bin=""
+# This binary is a test artifact, not a release. Stable metadata lets Go reuse
+# daemon E2E results when the staged source and all other inputs are unchanged.
+test_build_time="1970-01-01T00:00:00Z"
 cleanup_tmp_bin() {
   if [ -n "$tmp_bin" ]; then
     rm -f "$tmp_bin"
@@ -100,7 +108,7 @@ ensure_e2e_binary() {
 
   header "Go build for E2E"
   tmp_bin="$(mktemp -t attn-precommit.XXXXXX)"
-  make -C "$root" build OUTPUT="$tmp_bin"
+  make -C "$root" build OUTPUT="$tmp_bin" BUILD_TIME="$test_build_time"
   export ATTN_E2E_BIN="$tmp_bin"
 }
 
@@ -144,7 +152,7 @@ if [ "$run_daemon_checks" = true ]; then
 
   header "Go build"
   tmp_bin="$(mktemp -t attn-precommit.XXXXXX)"
-  make -C "$root" build OUTPUT="$tmp_bin"
+  make -C "$root" build OUTPUT="$tmp_bin" BUILD_TIME="$test_build_time"
   if [ -z "${ATTN_E2E_BIN:-}" ]; then
     export ATTN_E2E_BIN="$tmp_bin"
   fi
@@ -165,7 +173,9 @@ fi
 if [ "$run_shell_checks" = true ]; then
   header "Shell syntax"
   shell_files=()
-  mapfile -t shell_files < <(changed_matching '(^|/)[^/]+\.sh$|^\.githooks/pre-commit$')
+  while IFS= read -r file; do
+    shell_files+=("$file")
+  done < <(changed_matching '(^|/)[^/]+\.sh$|^\.githooks/pre-commit$')
   if [ "${#shell_files[@]}" -gt 0 ]; then
     bash -n "${shell_files[@]}"
   fi

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -142,15 +142,15 @@ if [ "$run_daemon_checks" = true ]; then
   header "Go format"
   format_go_files
 
-  header "Go tests"
-  (cd "$root" && go test ./...)
-
   header "Go build"
   tmp_bin="$(mktemp -t attn-precommit.XXXXXX)"
   make -C "$root" build OUTPUT="$tmp_bin"
   if [ -z "${ATTN_E2E_BIN:-}" ]; then
     export ATTN_E2E_BIN="$tmp_bin"
   fi
+
+  header "Go tests"
+  (cd "$root" && ./scripts/test-go.sh)
 
   header "Tauri daemon binary"
   target_triple="$(rustc -vV | awk '/host:/ {print $2}')"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -169,7 +169,7 @@ if [ "$run_daemon_checks" = true ]; then
   fi
 
   header "Go tests"
-  (cd "$root" && GOFLAGS="$test_goflags" ./scripts/test-go.sh)
+  (cd "$root" && ./scripts/test-go.sh)
 
   header "Tauri daemon binary"
   target_triple="$(rustc -vV | awk '/host:/ {print $2}')"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -169,7 +169,7 @@ if [ "$run_daemon_checks" = true ]; then
   fi
 
   header "Go tests"
-  (cd "$root" && ./scripts/test-go.sh)
+  (cd "$root" && GOFLAGS="$test_goflags" ./scripts/test-go.sh)
 
   header "Tauri daemon binary"
   target_triple="$(rustc -vV | awk '/host:/ {print $2}')"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -94,6 +94,8 @@ tmp_bin=""
 # This binary is a test artifact, not a release. Stable metadata lets Go reuse
 # daemon E2E results when the staged source and all other inputs are unchanged.
 test_build_time="1970-01-01T00:00:00Z"
+test_source_fingerprint="pre-commit"
+test_git_commit="pre-commit"
 cleanup_tmp_bin() {
   if [ -n "$tmp_bin" ]; then
     rm -f "$tmp_bin"
@@ -108,7 +110,10 @@ ensure_e2e_binary() {
 
   header "Go build for E2E"
   tmp_bin="$(mktemp -t attn-precommit.XXXXXX)"
-  make -C "$root" build OUTPUT="$tmp_bin" BUILD_TIME="$test_build_time"
+  make -C "$root" build OUTPUT="$tmp_bin" \
+    BUILD_TIME="$test_build_time" \
+    SOURCE_FINGERPRINT="$test_source_fingerprint" \
+    GIT_COMMIT="$test_git_commit"
   export ATTN_E2E_BIN="$tmp_bin"
 }
 
@@ -152,7 +157,10 @@ if [ "$run_daemon_checks" = true ]; then
 
   header "Go build"
   tmp_bin="$(mktemp -t attn-precommit.XXXXXX)"
-  make -C "$root" build OUTPUT="$tmp_bin" BUILD_TIME="$test_build_time"
+  make -C "$root" build OUTPUT="$tmp_bin" \
+    BUILD_TIME="$test_build_time" \
+    SOURCE_FINGERPRINT="$test_source_fingerprint" \
+    GIT_COMMIT="$test_git_commit"
   if [ -z "${ATTN_E2E_BIN:-}" ]; then
     export ATTN_E2E_BIN="$tmp_bin"
   fi

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -96,6 +96,7 @@ tmp_bin=""
 test_build_time="1970-01-01T00:00:00Z"
 test_source_fingerprint="pre-commit"
 test_git_commit="pre-commit"
+test_goflags="${GOFLAGS:+$GOFLAGS }-buildvcs=false"
 cleanup_tmp_bin() {
   if [ -n "$tmp_bin" ]; then
     rm -f "$tmp_bin"
@@ -113,7 +114,8 @@ ensure_e2e_binary() {
   make -C "$root" build OUTPUT="$tmp_bin" \
     BUILD_TIME="$test_build_time" \
     SOURCE_FINGERPRINT="$test_source_fingerprint" \
-    GIT_COMMIT="$test_git_commit"
+    GIT_COMMIT="$test_git_commit" \
+    GOFLAGS="$test_goflags"
   export ATTN_E2E_BIN="$tmp_bin"
 }
 
@@ -160,7 +162,8 @@ if [ "$run_daemon_checks" = true ]; then
   make -C "$root" build OUTPUT="$tmp_bin" \
     BUILD_TIME="$test_build_time" \
     SOURCE_FINGERPRINT="$test_source_fingerprint" \
-    GIT_COMMIT="$test_git_commit"
+    GIT_COMMIT="$test_git_commit" \
+    GOFLAGS="$test_goflags"
   if [ -z "${ATTN_E2E_BIN:-}" ]; then
     export ATTN_E2E_BIN="$tmp_bin"
   fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -157,7 +157,7 @@ echo "Refreshing lockfiles..."
 
 if [[ "$SKIP_TESTS" -eq 0 ]]; then
   echo "Running validation..."
-  go test ./...
+  ./scripts/test-go.sh
   (cd app && pnpm run build)
   (cd app && pnpm test)
 fi

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+daemon_package="github.com/victorarias/attn/internal/daemon"
+shard_count="${ATTN_GO_TEST_SHARDS:-5}"
+package_parallelism="${ATTN_GO_TEST_PACKAGE_PARALLELISM:-4}"
+test_gomaxprocs="${ATTN_GO_TEST_GOMAXPROCS:-${GOMAXPROCS:-3}}"
+test_timeout="${ATTN_GO_TEST_TIMEOUT:-90s}"
+
+if ! [[ "$shard_count" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ATTN_GO_TEST_SHARDS must be a positive integer, got: $shard_count" >&2
+  exit 2
+fi
+if ! [[ "$package_parallelism" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ATTN_GO_TEST_PACKAGE_PARALLELISM must be a positive integer, got: $package_parallelism" >&2
+  exit 2
+fi
+if ! [[ "$test_gomaxprocs" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ATTN_GO_TEST_GOMAXPROCS must be a positive integer, got: $test_gomaxprocs" >&2
+  exit 2
+fi
+export GOMAXPROCS="$test_gomaxprocs"
+
+go_bin="$(command -v go)"
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/attn-go-test.XXXXXX")"
+cleanup() {
+  rm -rf "$test_root"
+}
+trap cleanup EXIT
+
+# Scope the entire test process tree away from production ~/.attn. Package
+# TestMain functions add their own isolation, but the runner must also protect
+# packages and subprocesses before any package-level setup executes.
+mkdir -p "$test_root/data"
+export ATTN_DATA_DIR="$test_root/data"
+unset ATTN_DB_PATH ATTN_SOCKET_PATH ATTN_CONFIG_PATH ATTN_PLUGIN_DIR
+
+# Tests should exercise Git itself, not an environment-specific command wrapper.
+# macOS is attn's supported platform, and /usr/bin/git provides a stable direct
+# executable. Other platforms keep their resolved Git unless explicitly pinned.
+test_git="${ATTN_TEST_GIT:-}"
+if [ -z "$test_git" ]; then
+  if [ "$(uname -s)" = "Darwin" ] && [ -x /usr/bin/git ]; then
+    test_git=/usr/bin/git
+  else
+    test_git="$(command -v git)"
+  fi
+fi
+if [ ! -x "$test_git" ]; then
+  echo "test Git is not executable: $test_git" >&2
+  exit 2
+fi
+mkdir -p "$test_root/bin"
+ln -s "$test_git" "$test_root/bin/git"
+export PATH="$test_root/bin:$PATH"
+
+short_mode=false
+for arg in "$@"; do
+  if [ "$arg" = "-short" ] || [ "$arg" = "-short=true" ]; then
+    short_mode=true
+  fi
+done
+
+# The daemon's process-level E2E tests need the real attn executable. Build it
+# once for all shards instead of independently inside each test.
+if [ "$short_mode" = false ] && [ -z "${ATTN_E2E_BIN:-}" ]; then
+  export ATTN_E2E_BIN="$test_root/attn"
+  "$go_bin" build -o "$ATTN_E2E_BIN" ./cmd/attn
+fi
+
+packages_file="$test_root/packages"
+"$go_bin" list ./... | awk -v daemon="$daemon_package" '$0 != daemon' >"$packages_file"
+
+tests_file="$test_root/daemon-tests"
+"$go_bin" test -list '^Test' ./internal/daemon | awk '/^Test/ { print }' >"$tests_file"
+if [ ! -s "$tests_file" ]; then
+  echo "no daemon tests discovered" >&2
+  exit 1
+fi
+
+pids=()
+names=()
+logs=()
+
+run_job() {
+  local name="$1"
+  shift
+  local log="$test_root/$name.log"
+  (cd "$root" && "$@") >"$log" 2>&1 &
+  pids+=("$!")
+  names+=("$name")
+  logs+=("$log")
+}
+
+packages=()
+while IFS= read -r package; do
+  packages+=("$package")
+done <"$packages_file"
+run_job packages "$go_bin" test -timeout "$test_timeout" -p "$package_parallelism" "$@" "${packages[@]}"
+
+shard=0
+while [ "$shard" -lt "$shard_count" ]; do
+  regex="$(awk -v count="$shard_count" -v target="$shard" '
+    (NR - 1) % count == target {
+      if (tests != "") tests = tests "|"
+      tests = tests $0
+    }
+    END { print "^(" tests ")$" }
+  ' "$tests_file")"
+  run_job "daemon-$((shard + 1))" "$go_bin" test -timeout "$test_timeout" "$@" -run "$regex" ./internal/daemon
+  shard=$((shard + 1))
+done
+
+failed=0
+index=0
+while [ "$index" -lt "${#pids[@]}" ]; do
+  if wait "${pids[$index]}"; then
+    cat "${logs[$index]}"
+  else
+    cat "${logs[$index]}" >&2
+    echo "Go test job failed: ${names[$index]}" >&2
+    failed=1
+  fi
+  index=$((index + 1))
+done
+
+exit "$failed"

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -25,6 +25,7 @@ export GOMAXPROCS="$test_gomaxprocs"
 
 go_bin="$(command -v go)"
 test_root="$(mktemp -d "${TMPDIR:-/tmp}/attn-go-test.XXXXXX")"
+# shellcheck disable=SC2329 # invoked indirectly by trap
 cleanup() {
   rm -rf "$test_root"
 }
@@ -32,9 +33,14 @@ trap cleanup EXIT
 
 # Scope the entire test process tree away from production ~/.attn. Package
 # TestMain functions add their own isolation, but the runner must also protect
-# packages and subprocesses before any package-level setup executes.
-mkdir -p "$test_root/data"
-export ATTN_DATA_DIR="$test_root/data"
+# packages and subprocesses before any package-level setup executes. Keep the
+# outer path stable so Go can reuse successful test results; TestMain still
+# replaces it with a fresh per-process directory whenever tests actually run.
+runner_hash="$(shasum -a 256 "$root/scripts/test-go.sh" | awk '{ print $1 }')"
+cache_namespace="$(printf '%s\n%s\n%s\n' "$root" "$($go_bin env GOVERSION)" "$runner_hash" | shasum -a 256 | awk '{ print $1 }')"
+test_cache_root="${TMPDIR:-/tmp}/attn-go-test-cache/$cache_namespace"
+mkdir -p "$test_cache_root/data"
+export ATTN_DATA_DIR="$test_cache_root/data"
 unset ATTN_DB_PATH ATTN_SOCKET_PATH ATTN_CONFIG_PATH ATTN_PLUGIN_DIR
 
 # Tests should exercise Git itself, not an environment-specific command wrapper.
@@ -52,9 +58,18 @@ if [ ! -x "$test_git" ]; then
   echo "test Git is not executable: $test_git" >&2
   exit 2
 fi
-mkdir -p "$test_root/bin"
-ln -s "$test_git" "$test_root/bin/git"
-export PATH="$test_root/bin:$PATH"
+test_git_hash="$(shasum -a 256 "$test_git" | awk '{ print $1 }')"
+test_git_key="$(printf '%s\n%s\n' "$test_git" "$test_git_hash" | shasum -a 256 | awk '{ print $1 }')"
+test_bin_dir="$test_cache_root/git/$test_git_key"
+mkdir -p "$test_bin_dir"
+if [ ! -e "$test_bin_dir/git" ]; then
+  ln -s "$test_git" "$test_bin_dir/git" 2>/dev/null || true
+fi
+if [ ! -L "$test_bin_dir/git" ] || [ "$(readlink "$test_bin_dir/git")" != "$test_git" ]; then
+  echo "cached test Git does not point to $test_git: $test_bin_dir/git" >&2
+  exit 2
+fi
+export PATH="$test_bin_dir:$PATH"
 
 short_mode=false
 for arg in "$@"; do
@@ -64,10 +79,32 @@ for arg in "$@"; do
 done
 
 # The daemon's process-level E2E tests need the real attn executable. Build it
-# once for all shards instead of independently inside each test.
-if [ "$short_mode" = false ] && [ -z "${ATTN_E2E_BIN:-}" ]; then
-  export ATTN_E2E_BIN="$test_root/attn"
-  "$go_bin" build -o "$ATTN_E2E_BIN" ./cmd/attn
+# once for all shards instead of independently inside each test. Normalize an
+# explicitly supplied binary the same way. The content-addressed path stays
+# stable for unchanged code and changes whenever the executable changes, so
+# daemon result-cache hits cannot hide a new binary at an unchanged source path.
+if [ "$short_mode" = false ]; then
+  source_e2e_bin="${ATTN_E2E_BIN:-}"
+  if [ -z "$source_e2e_bin" ]; then
+    source_e2e_bin="$test_root/attn"
+    "$go_bin" build -o "$source_e2e_bin" ./cmd/attn
+  elif [ ! -x "$source_e2e_bin" ]; then
+    echo "ATTN_E2E_BIN is not executable: $source_e2e_bin" >&2
+    exit 2
+  fi
+  e2e_hash="$(shasum -a 256 "$source_e2e_bin" | awk '{ print $1 }')"
+  e2e_cache_dir="$test_cache_root/e2e/$e2e_hash"
+  mkdir -p "$e2e_cache_dir"
+  cached_e2e_hash=""
+  if [ -f "$e2e_cache_dir/attn" ]; then
+    cached_e2e_hash="$(shasum -a 256 "$e2e_cache_dir/attn" | awk '{ print $1 }')"
+  fi
+  if [ "$cached_e2e_hash" != "$e2e_hash" ]; then
+    cp "$source_e2e_bin" "$e2e_cache_dir/attn.$$.tmp"
+    chmod +x "$e2e_cache_dir/attn.$$.tmp"
+    mv -f "$e2e_cache_dir/attn.$$.tmp" "$e2e_cache_dir/attn"
+  fi
+  export ATTN_E2E_BIN="$e2e_cache_dir/attn"
 fi
 
 packages_file="$test_root/packages"


### PR DESCRIPTION
## Why

Go verification was slow enough that a commit hook would be routinely bypassed. The largest costs were an environment-specific instrumented Git wrapper, mostly serial daemon tests, repeated wall-clock waits, and cache inputs that changed on every isolated run.

## What changed

- run Go tests through a production-safe repository runner using direct Git, bounded package parallelism, and five isolated daemon shards
- remove deliberate waits and redundant process/Git setup while preserving the regression contracts those tests protect
- keep outer test inputs cache-stable and content-address external Git and E2E binaries, while every executing test process still receives fresh temporary state
- make the staged-file-aware hook work with macOS Bash 3 and reproducible test build metadata
- route Make, CI, pre-commit, and release verification through the same Go runner

## Measured result

Measured on an Apple M5 Max running macOS 26.5.2 and Go 1.26.2; these numbers depend on machine load and cache state.

- inherited-wrapper baseline: 131.07s
- rebased full cache-populating run: 34.03s
- identical fully cached run: 6.86s
- installed hook: 29.30s for the final new daemon test input; 4.97s for an earlier exact staged retry; 0.13s for a docs-only change

The hook is intentionally narrow: staged Go/build inputs run the relevant Go verification bucket, while unrelated staged files do not turn pre-commit into a second CI pipeline.

## Test plan

- [x] Run ten consecutive cache-controlled full suites during optimization
- [x] Run the rebased suite with `-count=1` (42.85s)
- [x] Populate the rebased result cache with a full passing run (34.03s)
- [x] Verify an identical warm run returns all test results from cache (6.86s)
- [x] Run focused daemon recovery tests three times after the contention fix
- [x] Run focused race checks and `go vet` for changed packages
- [x] Run two simultaneous cache-miss runners without shared test state
- [x] Verify Git and E2E binary mutations invalidate affected cache entries
- [x] Commit through the installed hook and verify docs-only routing skips Go checks

Live-app testing is not applicable: this changes test and hook infrastructure, test seams, and test-only timing behavior; it does not change daemon protocol, lifecycle, or UI behavior.
