### PR TITLE
feat(cli): return pr wait-ready on first actionable update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,12 @@ Use the bundled CLI, not an unrelated `attn` on `PATH`. Preflight is diagnostic;
 fix reported tool/path/routing/daemon/protocol failures before treating scenario
 output as product evidence.
 
-For a GitHub merge gate, run `attn pr wait-ready <pr> --repo <owner/repo>
---reviewer <login>` once; do not poll checks and reviews separately.
+To wait on a GitHub PR, run `attn pr wait-ready <pr> --repo <owner/repo>
+--reviewer <login>` once; do not poll checks, reviews, and comments separately.
+It returns on the first actionable update and reports which one by exit code:
+`0` approved, `1` checks failed, `3` changes requested, `4` new human comment,
+`124` timeout. Bot comments are ignored; comments already present when the wait
+starts are the baseline.
 
 ### Packaged-app harness
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-19]
 
 ### Added
-- **PR readiness can be checked with one trustworthy gate.** `attn pr
-  wait-ready` reports check and review transitions, resets when the pull request
-  head changes, and succeeds only when one exact head is green and approved by
-  the required reviewer.
+- **Waiting on a pull request returns as soon as something needs you.** `attn pr
+  wait-ready` watches checks, reviews, and comments in one request and stops at
+  the first actionable update: a failing check, a review requesting changes, a
+  new comment from a person, or approval on a green exact head. Each outcome has
+  its own exit code, with `--json` for the full detail. Comments from bots are
+  ignored, as are comments already on the pull request when the wait begins.
 - **Live agent transcripts are inspectable from the CLI.** `attn session
   transcript <session-id>` prints timestamped conversation, tool, and error
   events across supported agents, with `--follow` for live updates and opaque

--- a/cmd/attn/pr.go
+++ b/cmd/attn/pr.go
@@ -170,6 +170,12 @@ func executePRCommand(args []string, stdout, stderr io.Writer) int {
 func reportPROutcome(result *prReadiness, outcome prOutcome, opts prWaitOptions, stdout io.Writer) int {
 	detail := describePROutcome(result, outcome, opts)
 	if opts.JSON {
+		// "comments" reports what arrived during the wait. On any other outcome
+		// the observation still carries the baseline, which is not news.
+		fresh := []prComment{}
+		if outcome == outcomeComment {
+			fresh = result.Comments
+		}
 		payload := map[string]any{
 			"outcome": string(outcome),
 			"pr":      result.Number,
@@ -185,7 +191,7 @@ func reportPROutcome(result *prReadiness, outcome prOutcome, opts prWaitOptions,
 				"state":    result.ReviewState,
 				"reviewer": result.Reviewer,
 			},
-			"comments": result.Comments,
+			"comments": fresh,
 		}
 		encoder := json.NewEncoder(stdout)
 		encoder.SetIndent("", "  ")
@@ -336,7 +342,7 @@ query($owner:String!,$name:String!,$number:Int!){
         pageInfo{hasNextPage}
         nodes{__typename ... on CheckRun{name status conclusion} ... on StatusContext{context state}}
       }}}}}
-      reviews(last:100){nodes{id state submittedAt author{__typename login} commit{oid}}}
+      reviews(last:100){nodes{id state bodyText submittedAt author{__typename login} commit{oid}}}
       comments(last:100){nodes{id createdAt author{__typename login}}}
       reviewThreads(last:100){nodes{comments(last:100){nodes{id createdAt author{__typename login}}}}}
     }}}`
@@ -406,6 +412,7 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 						Nodes []struct {
 							ID          string          `json:"id"`
 							State       string          `json:"state"`
+							BodyText    string          `json:"bodyText"`
 							SubmittedAt time.Time       `json:"submittedAt"`
 							Author      prGraphQLAuthor `json:"author"`
 							Commit      struct {
@@ -472,9 +479,15 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 	for _, review := range pr.Reviews.Nodes {
 		state := strings.ToUpper(review.State)
 		if state == "COMMENTED" {
-			result.Comments = appendPRComment(result.Comments, prGraphQLComment{
-				ID: review.ID, CreatedAt: review.SubmittedAt, Author: review.Author,
-			}, "review", opts)
+			// Posting a standalone inline comment makes GitHub wrap it in a
+			// bodyless COMMENTED review. Counting that wrapper would report one
+			// human remark twice, so only a review with its own text counts;
+			// the inline comments it holds arrive via reviewThreads.
+			if strings.TrimSpace(review.BodyText) != "" {
+				result.Comments = appendPRComment(result.Comments, prGraphQLComment{
+					ID: review.ID, CreatedAt: review.SubmittedAt, Author: review.Author,
+				}, "review", opts)
+			}
 			continue
 		}
 		if !strings.EqualFold(review.Author.Login, opts.Reviewer) || review.Commit.OID != result.HeadSHA ||

--- a/cmd/attn/pr.go
+++ b/cmd/attn/pr.go
@@ -18,9 +18,13 @@ import (
 )
 
 const (
-	prWaitExitFailed  = 1
-	prWaitExitUsage   = 2
-	prWaitExitTimeout = 124
+	prWaitExitApproved         = 0
+	prWaitExitChecksFailed     = 1
+	prWaitExitUsage            = 2
+	prWaitExitChangesRequested = 3
+	prWaitExitComment          = 4
+	prWaitExitError            = 5
+	prWaitExitTimeout          = 124
 
 	checksNone    = "none"
 	checksPending = "pending"
@@ -28,12 +32,56 @@ const (
 	checksFailed  = "failed"
 )
 
-type prCheck struct{ Name, State string }
+// prOutcome is the actionable update that ended the wait. The waiter exists to
+// return as soon as a human needs to do something, not only when the pull
+// request is mergeable.
+type prOutcome string
+
+const (
+	outcomeApproved         prOutcome = "approved"
+	outcomeChecksFailed     prOutcome = "checks_failed"
+	outcomeChangesRequested prOutcome = "changes_requested"
+	outcomeComment          prOutcome = "comment"
+	outcomeClosed           prOutcome = "closed"
+	outcomeTimeout          prOutcome = "timeout"
+)
+
+func (o prOutcome) exitCode() int {
+	switch o {
+	case outcomeApproved:
+		return prWaitExitApproved
+	case outcomeChecksFailed:
+		return prWaitExitChecksFailed
+	case outcomeChangesRequested:
+		return prWaitExitChangesRequested
+	case outcomeComment:
+		return prWaitExitComment
+	case outcomeTimeout:
+		return prWaitExitTimeout
+	default:
+		return prWaitExitError
+	}
+}
+
+type prCheck struct {
+	Name  string `json:"name"`
+	State string `json:"state"`
+}
+
+// prComment is any commentary surface: a standalone PR comment, an inline
+// review-thread comment, or a review submitted without a verdict.
+type prComment struct {
+	ID        string    `json:"-"`
+	Author    string    `json:"author"`
+	Kind      string    `json:"kind"`
+	CreatedAt time.Time `json:"created_at"`
+}
 
 type prReadiness struct {
 	Number, State, HeadSHA, CheckState, Reviewer, ReviewState string
 	Draft                                                     bool
 	Checks                                                    []prCheck
+	Comments                                                  []prComment
 }
 
 func (r *prReadiness) ready() bool {
@@ -45,13 +93,37 @@ type prReadinessSource interface {
 }
 
 type prWaitOptions struct {
-	Target, Repo, Reviewer string
-	Timeout, Interval      time.Duration
+	Host, Owner, Name string
+	Number            int
+	Reviewer          string
+	IgnoreAuthors     []string
+	Timeout, Interval time.Duration
+	JSON              bool
+}
+
+func (o prWaitOptions) ignored(author string) bool {
+	for _, ignored := range o.IgnoreAuthors {
+		if strings.EqualFold(ignored, author) {
+			return true
+		}
+	}
+	return false
 }
 
 type ghPRReadinessSource struct{}
 
-var errPRChecksFailed = errors.New("checks failed")
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string { return strings.Join(*s, ",") }
+
+func (s *stringSliceFlag) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("author must not be empty")
+	}
+	*s = append(*s, value)
+	return nil
+}
 
 func runPRCommand() {
 	code := executePRCommand(os.Args[2:], os.Stdout, os.Stderr)
@@ -79,23 +151,97 @@ func executePRCommand(args []string, stdout, stderr io.Writer) int {
 		return prWaitExitUsage
 	}
 
+	// Progress must never contaminate a JSON result on stdout.
+	progress := stdout
+	if opts.JSON {
+		progress = stderr
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
 	defer cancel()
-	result, err := waitForPRReady(ctx, ghPRReadinessSource{}, opts, stdout)
-	switch {
-	case err == nil:
-		fmt.Fprintf(stdout, "READY pr=#%s head=%s checks=%d approval=%s\n", result.Number, result.HeadSHA, len(result.Checks), result.Reviewer)
-		return 0
-	case errors.Is(err, context.DeadlineExceeded):
-		fmt.Fprintf(stderr, "pr wait-ready: timed out after %s\n", opts.Timeout)
-		return prWaitExitTimeout
-	case errors.Is(err, errPRChecksFailed):
-		fmt.Fprintf(stderr, "pr wait-ready: checks failed on current head %s\n", result.HeadSHA)
-		return prWaitExitFailed
-	default:
+	result, outcome, err := waitForPRActionable(ctx, ghPRReadinessSource{}, opts, progress)
+	if err != nil {
 		fmt.Fprintf(stderr, "pr wait-ready: %v\n", err)
-		return prWaitExitFailed
+		return prWaitExitError
 	}
+	return reportPROutcome(result, outcome, opts, stdout)
+}
+
+func reportPROutcome(result *prReadiness, outcome prOutcome, opts prWaitOptions, stdout io.Writer) int {
+	detail := describePROutcome(result, outcome, opts)
+	if opts.JSON {
+		payload := map[string]any{
+			"outcome": string(outcome),
+			"pr":      result.Number,
+			"head":    result.HeadSHA,
+			"state":   result.State,
+			"draft":   result.Draft,
+			"detail":  detail,
+			"checks": map[string]any{
+				"state": result.CheckState,
+				"items": result.Checks,
+			},
+			"review": map[string]any{
+				"state":    result.ReviewState,
+				"reviewer": result.Reviewer,
+			},
+			"comments": result.Comments,
+		}
+		encoder := json.NewEncoder(stdout)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(payload); err != nil {
+			return prWaitExitError
+		}
+		return outcome.exitCode()
+	}
+	fmt.Fprintf(stdout, "%s: %s\n", outcome, detail)
+	return outcome.exitCode()
+}
+
+func describePROutcome(result *prReadiness, outcome prOutcome, opts prWaitOptions) string {
+	head := shortSHA(result.HeadSHA)
+	switch outcome {
+	case outcomeApproved:
+		return fmt.Sprintf("%s approved %s; %d checks green", result.Reviewer, head, len(result.Checks))
+	case outcomeChangesRequested:
+		return fmt.Sprintf("%s requested changes on %s", result.Reviewer, head)
+	case outcomeChecksFailed:
+		return fmt.Sprintf("%s failed on %s", strings.Join(failedCheckNames(result.Checks), ", "), head)
+	case outcomeComment:
+		return describePRComments(result.Comments)
+	case outcomeClosed:
+		return fmt.Sprintf("pull request is %s", result.State)
+	case outcomeTimeout:
+		return fmt.Sprintf("no actionable update after %s (checks=%s review=%s)", opts.Timeout, result.CheckState, result.ReviewState)
+	default:
+		return string(outcome)
+	}
+}
+
+func describePRComments(comments []prComment) string {
+	authors := make([]string, 0, len(comments))
+	seen := map[string]bool{}
+	for _, comment := range comments {
+		if !seen[comment.Author] {
+			seen[comment.Author] = true
+			authors = append(authors, comment.Author)
+		}
+	}
+	noun := "comments"
+	if len(comments) == 1 {
+		noun = "comment"
+	}
+	return fmt.Sprintf("%d new %s from %s", len(comments), noun, strings.Join(authors, ", "))
+}
+
+func failedCheckNames(checks []prCheck) []string {
+	var names []string
+	for _, check := range checks {
+		if check.State == checksFailed {
+			names = append(names, check.Name)
+		}
+	}
+	return names
 }
 
 func isHelpArg(arg string) bool { return arg == "-h" || arg == "--help" }
@@ -107,6 +253,9 @@ func parsePRWaitArgs(args []string) (prWaitOptions, error) {
 	reviewer := fs.String("reviewer", "", "required reviewer login")
 	timeout := fs.Duration("timeout", 30*time.Minute, "maximum wait")
 	interval := fs.Duration("interval", 20*time.Second, "poll interval")
+	asJSON := fs.Bool("json", false, "emit the result as JSON")
+	var ignore stringSliceFlag
+	fs.Var(&ignore, "ignore-author", "comment author to ignore (repeatable)")
 
 	target := ""
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
@@ -127,92 +276,208 @@ func parsePRWaitArgs(args []string) (prWaitOptions, error) {
 		return prWaitOptions{}, errors.New("--timeout and --interval must be positive")
 	}
 
+	opts := prWaitOptions{
+		Reviewer:      strings.TrimSpace(*reviewer),
+		IgnoreAuthors: ignore,
+		Timeout:       *timeout,
+		Interval:      *interval,
+		JSON:          *asJSON,
+	}
 	if strings.HasPrefix(target, "https://") {
 		host, owner, repository, number, err := automation.ParsePullRequestURL(target)
 		if err != nil {
 			return prWaitOptions{}, err
 		}
-		target = fmt.Sprintf("https://%s/%s/%s/pull/%d", host, owner, repository, number)
-	} else {
-		number, err := strconv.Atoi(target)
-		if err != nil || number <= 0 {
-			return prWaitOptions{}, errors.New("pull request number must be positive")
-		}
-		if strings.TrimSpace(*repo) == "" {
-			return prWaitOptions{}, errors.New("--repo is required when the target is a number")
-		}
+		opts.Host, opts.Owner, opts.Name, opts.Number = host, owner, repository, number
+		return opts, nil
 	}
-	return prWaitOptions{Target: target, Repo: strings.TrimSpace(*repo), Reviewer: strings.TrimSpace(*reviewer), Timeout: *timeout, Interval: *interval}, nil
+	number, err := strconv.Atoi(target)
+	if err != nil || number <= 0 {
+		return prWaitOptions{}, errors.New("pull request number must be positive")
+	}
+	if strings.TrimSpace(*repo) == "" {
+		return prWaitOptions{}, errors.New("--repo is required when the target is a number")
+	}
+	host, owner, name, err := parseRepoFlag(*repo)
+	if err != nil {
+		return prWaitOptions{}, err
+	}
+	opts.Host, opts.Owner, opts.Name, opts.Number = host, owner, name, number
+	return opts, nil
 }
 
-func (ghPRReadinessSource) Fetch(ctx context.Context, opts prWaitOptions) (*prReadiness, error) {
-	args := []string{"pr", "view", opts.Target}
-	if opts.Repo != "" {
-		args = append(args, "--repo", opts.Repo)
+func parseRepoFlag(repo string) (host, owner, name string, err error) {
+	parts := strings.Split(strings.Trim(strings.TrimSpace(repo), "/"), "/")
+	switch len(parts) {
+	case 2:
+		host, owner, name = "", parts[0], parts[1]
+	case 3:
+		host, owner, name = parts[0], parts[1], parts[2]
+	default:
+		return "", "", "", errors.New("--repo must be [host/]owner/repository")
 	}
-	args = append(args, "--json", "number,state,isDraft,headRefOid,statusCheckRollup,reviews")
+	if owner == "" || name == "" {
+		return "", "", "", errors.New("--repo must be [host/]owner/repository")
+	}
+	return host, owner, name, nil
+}
+
+// prSnapshotQuery collects head, checks, reviews, and every comment surface in
+// one round trip so a poll cannot mix signals from different commits, and so
+// bot authorship is authoritative. `gh pr view --json comments` strips the
+// "[bot]" suffix and omits the author type, which makes bots indistinguishable
+// from humans; GraphQL's __typename does not.
+const prSnapshotQuery = `
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      number state isDraft headRefOid
+      commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){
+        pageInfo{hasNextPage}
+        nodes{__typename ... on CheckRun{name status conclusion} ... on StatusContext{context state}}
+      }}}}}
+      reviews(last:100){nodes{id state submittedAt author{__typename login} commit{oid}}}
+      comments(last:100){nodes{id createdAt author{__typename login}}}
+      reviewThreads(last:100){nodes{comments(last:100){nodes{id createdAt author{__typename login}}}}}
+    }}}`
+
+func (ghPRReadinessSource) Fetch(ctx context.Context, opts prWaitOptions) (*prReadiness, error) {
+	args := []string{"api", "graphql",
+		"-f", "query=" + prSnapshotQuery,
+		"-F", "owner=" + opts.Owner,
+		"-F", "name=" + opts.Name,
+		"-F", "number=" + strconv.Itoa(opts.Number),
+	}
+	if opts.Host != "" {
+		args = append(args, "--hostname", opts.Host)
+	}
 	output, err := exec.CommandContext(ctx, "gh", args...).CombinedOutput()
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		return nil, fmt.Errorf("gh pr view: %s", strings.TrimSpace(string(output)))
+		return nil, fmt.Errorf("gh api graphql: %s", strings.TrimSpace(string(output)))
 	}
-	return parseGHPRReadiness(output, opts.Reviewer)
+	return parsePRSnapshot(output, opts)
 }
 
-func parseGHPRReadiness(output []byte, reviewer string) (*prReadiness, error) {
+type prGraphQLAuthor struct {
+	TypeName string `json:"__typename"`
+	Login    string `json:"login"`
+}
+
+type prGraphQLComment struct {
+	ID        string          `json:"id"`
+	CreatedAt time.Time       `json:"createdAt"`
+	Author    prGraphQLAuthor `json:"author"`
+}
+
+func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 	var payload struct {
-		Number     json.Number `json:"number"`
-		State      string      `json:"state"`
-		IsDraft    bool        `json:"isDraft"`
-		HeadRefOID string      `json:"headRefOid"`
-		Checks     []struct {
-			TypeName   string `json:"__typename"`
-			Name       string
-			Context    string
-			Status     string
-			Conclusion string
-			State      string
-		} `json:"statusCheckRollup"`
-		Reviews []struct {
-			State       string
-			SubmittedAt time.Time
-			Author      struct{ Login string }
-			Commit      struct{ OID string }
-		}
+		Data struct {
+			Repository struct {
+				PullRequest *struct {
+					Number     json.Number `json:"number"`
+					State      string      `json:"state"`
+					IsDraft    bool        `json:"isDraft"`
+					HeadRefOID string      `json:"headRefOid"`
+					Commits    struct {
+						Nodes []struct {
+							Commit struct {
+								StatusCheckRollup *struct {
+									Contexts struct {
+										PageInfo struct {
+											HasNextPage bool `json:"hasNextPage"`
+										} `json:"pageInfo"`
+										Nodes []struct {
+											TypeName   string `json:"__typename"`
+											Name       string `json:"name"`
+											Context    string `json:"context"`
+											Status     string `json:"status"`
+											Conclusion string `json:"conclusion"`
+											State      string `json:"state"`
+										} `json:"nodes"`
+									} `json:"contexts"`
+								} `json:"statusCheckRollup"`
+							} `json:"commit"`
+						} `json:"nodes"`
+					} `json:"commits"`
+					Reviews struct {
+						Nodes []struct {
+							ID          string          `json:"id"`
+							State       string          `json:"state"`
+							SubmittedAt time.Time       `json:"submittedAt"`
+							Author      prGraphQLAuthor `json:"author"`
+							Commit      struct {
+								OID string `json:"oid"`
+							} `json:"commit"`
+						} `json:"nodes"`
+					} `json:"reviews"`
+					Comments struct {
+						Nodes []prGraphQLComment `json:"nodes"`
+					} `json:"comments"`
+					ReviewThreads struct {
+						Nodes []struct {
+							Comments struct {
+								Nodes []prGraphQLComment `json:"nodes"`
+							} `json:"comments"`
+						} `json:"nodes"`
+					} `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
 	}
 	if err := json.Unmarshal(output, &payload); err != nil {
-		return nil, fmt.Errorf("parse gh pr view: %w", err)
+		return nil, fmt.Errorf("parse gh api graphql: %w", err)
 	}
-	if payload.Number == "" || payload.HeadRefOID == "" {
-		return nil, errors.New("gh pr view returned no PR number or head SHA")
+	if len(payload.Errors) > 0 {
+		return nil, fmt.Errorf("gh api graphql: %s", payload.Errors[0].Message)
 	}
-	// gh requests the first 100 nodes for both connections but omits pageInfo
-	// from its JSON output. Refuse the boundary instead of silently accepting a
-	// snapshot that may have hidden checks or reviews.
-	if len(payload.Checks) >= 100 || len(payload.Reviews) >= 100 {
-		return nil, errors.New("PR has at least 100 checks or reviews; readiness cannot be verified without truncation")
+	pr := payload.Data.Repository.PullRequest
+	if pr == nil || pr.Number == "" || pr.HeadRefOID == "" {
+		return nil, errors.New("gh api graphql returned no PR number or head SHA")
 	}
 
 	result := &prReadiness{
-		Number: payload.Number.String(), State: strings.ToLower(payload.State), Draft: payload.IsDraft,
-		HeadSHA: payload.HeadRefOID, Reviewer: reviewer, ReviewState: "waiting",
+		Number: pr.Number.String(), State: strings.ToLower(pr.State), Draft: pr.IsDraft,
+		HeadSHA: pr.HeadRefOID, Reviewer: opts.Reviewer, ReviewState: "waiting",
 	}
-	for _, check := range payload.Checks {
-		name, state := "status:"+check.Context, statusState(check.State)
-		if check.TypeName == "CheckRun" {
-			name, state = "check:"+check.Name, checkRunState(check.Status, check.Conclusion)
+
+	if len(pr.Commits.Nodes) > 0 {
+		if rollup := pr.Commits.Nodes[0].Commit.StatusCheckRollup; rollup != nil {
+			// Checks are fetched first:100. Truncation here could hide a
+			// failing check, so refuse rather than report a false green.
+			if rollup.Contexts.PageInfo.HasNextPage {
+				return nil, errors.New("PR has more than 100 checks; readiness cannot be verified without truncation")
+			}
+			for _, check := range rollup.Contexts.Nodes {
+				name, state := "status:"+check.Context, statusState(check.State)
+				if check.TypeName == "CheckRun" {
+					name, state = "check:"+check.Name, checkRunState(check.Status, check.Conclusion)
+				}
+				result.Checks = append(result.Checks, prCheck{Name: name, State: state})
+			}
 		}
-		result.Checks = append(result.Checks, prCheck{Name: name, State: state})
 	}
 	sort.Slice(result.Checks, func(i, j int) bool { return result.Checks[i].Name < result.Checks[j].Name })
 	result.CheckState = summarizePRChecks(result.Checks)
 
+	// Reviews, comments, and threads use last:100, so truncation drops only the
+	// oldest entries. A superseded review or a long-read comment cannot be the
+	// actionable update, so that boundary is safe to accept.
 	var latest time.Time
-	for _, review := range payload.Reviews {
+	for _, review := range pr.Reviews.Nodes {
 		state := strings.ToUpper(review.State)
-		if !strings.EqualFold(review.Author.Login, reviewer) || review.Commit.OID != result.HeadSHA ||
+		if state == "COMMENTED" {
+			result.Comments = appendPRComment(result.Comments, prGraphQLComment{
+				ID: review.ID, CreatedAt: review.SubmittedAt, Author: review.Author,
+			}, "review", opts)
+			continue
+		}
+		if !strings.EqualFold(review.Author.Login, opts.Reviewer) || review.Commit.OID != result.HeadSHA ||
 			(state != "APPROVED" && state != "CHANGES_REQUESTED") || review.SubmittedAt.Before(latest) {
 			continue
 		}
@@ -223,7 +488,32 @@ func parseGHPRReadiness(output []byte, reviewer string) (*prReadiness, error) {
 			result.ReviewState = "changes_requested"
 		}
 	}
+	for _, comment := range pr.Comments.Nodes {
+		result.Comments = appendPRComment(result.Comments, comment, "issue", opts)
+	}
+	for _, thread := range pr.ReviewThreads.Nodes {
+		for _, comment := range thread.Comments.Nodes {
+			result.Comments = appendPRComment(result.Comments, comment, "inline", opts)
+		}
+	}
+	sort.Slice(result.Comments, func(i, j int) bool {
+		return result.Comments[i].CreatedAt.Before(result.Comments[j].CreatedAt)
+	})
 	return result, nil
+}
+
+// appendPRComment keeps only comments a human needs to answer. Bot authorship
+// comes from __typename; the token owner is deliberately NOT filtered, because
+// the operator and the agent share one token and the operator's own comment is
+// the most actionable event there is. Self-waking is prevented by the baseline
+// instead: anything present when the wait starts is never reported.
+func appendPRComment(comments []prComment, node prGraphQLComment, kind string, opts prWaitOptions) []prComment {
+	if node.ID == "" || node.Author.TypeName != "User" || opts.ignored(node.Author.Login) {
+		return comments
+	}
+	return append(comments, prComment{
+		ID: node.ID, Author: node.Author.Login, Kind: kind, CreatedAt: node.CreatedAt,
+	})
 }
 
 func checkRunState(status, conclusion string) string {
@@ -267,35 +557,71 @@ func summarizePRChecks(checks []prCheck) string {
 	return result
 }
 
-func waitForPRReady(ctx context.Context, source prReadinessSource, opts prWaitOptions, out io.Writer) (*prReadiness, error) {
+// waitForPRActionable returns on the first actionable update. The error return
+// is reserved for the waiter itself failing; every product outcome, including a
+// timeout, comes back as a prOutcome so the caller can report it uniformly.
+func waitForPRActionable(ctx context.Context, source prReadinessSource, opts prWaitOptions, progress io.Writer) (*prReadiness, prOutcome, error) {
 	var lastLine, lastHead string
+	var baseline map[string]bool
+	last := &prReadiness{Number: strconv.Itoa(opts.Number), Reviewer: opts.Reviewer, CheckState: checksNone, ReviewState: "waiting"}
+
 	for {
 		observation, err := source.Fetch(ctx, opts)
 		if err != nil {
-			return observation, err
+			if errors.Is(err, context.DeadlineExceeded) {
+				return last, outcomeTimeout, nil
+			}
+			return last, "", err
 		}
+		last = observation
+
 		if lastHead != "" && lastHead != observation.HeadSHA {
-			fmt.Fprintf(out, "head changed %s -> %s; reset\n", shortSHA(lastHead), shortSHA(observation.HeadSHA))
+			// A new head invalidates prior approval and check results, but not
+			// comments: a comment stays actionable regardless of what was pushed.
+			fmt.Fprintf(progress, "head changed %s -> %s; reset\n", shortSHA(lastHead), shortSHA(observation.HeadSHA))
 		}
 		lastHead = observation.HeadSHA
-		line := readinessLine(observation)
-		if line != lastLine {
-			fmt.Fprintln(out, line)
+
+		if line := readinessLine(observation); line != lastLine {
+			fmt.Fprintln(progress, line)
 			lastLine = line
 		}
-		if observation.State != "open" {
-			return observation, fmt.Errorf("pull request is %s", observation.State)
+
+		if baseline == nil {
+			baseline = make(map[string]bool, len(observation.Comments))
+			for _, comment := range observation.Comments {
+				baseline[comment.ID] = true
+			}
+		} else if fresh := unseenPRComments(observation.Comments, baseline); len(fresh) > 0 {
+			observation.Comments = fresh
+			return observation, outcomeComment, nil
 		}
-		if observation.CheckState == checksFailed {
-			return observation, errPRChecksFailed
+
+		switch {
+		case observation.State != "open":
+			return observation, outcomeClosed, nil
+		case observation.CheckState == checksFailed:
+			return observation, outcomeChecksFailed, nil
+		case observation.ReviewState == "changes_requested":
+			return observation, outcomeChangesRequested, nil
+		case observation.ready():
+			return observation, outcomeApproved, nil
 		}
-		if observation.ready() {
-			return observation, nil
-		}
+
 		if err := waitPRPoll(ctx, opts.Interval); err != nil {
-			return observation, err
+			return observation, outcomeTimeout, nil
 		}
 	}
+}
+
+func unseenPRComments(comments []prComment, baseline map[string]bool) []prComment {
+	var fresh []prComment
+	for _, comment := range comments {
+		if !baseline[comment.ID] {
+			fresh = append(fresh, comment)
+		}
+	}
+	return fresh
 }
 
 func waitPRPoll(ctx context.Context, interval time.Duration) error {
@@ -340,15 +666,21 @@ func shortSHA(sha string) string {
 func writePRHelp(w io.Writer) {
 	fmt.Fprint(w, `usage: attn pr wait-ready <number-or-url> --reviewer <login> [options]
 
-Wait until one pull request snapshot has green checks and an approval from the
-required reviewer on that exact head commit.
+Wait until a pull request has an actionable update: a failing check, a review
+requesting changes, a new human comment, or approval on a green exact head.
 
 options:
   --repo [host/]owner/repository  required with a pull request number
-  --reviewer login               required reviewer
-  --timeout duration             maximum wait (default 30m)
-  --interval duration            poll interval (default 20s)
+  --reviewer login                required reviewer
+  --timeout duration              maximum wait (default 30m)
+  --interval duration             poll interval (default 20s)
+  --ignore-author login           comment author to ignore (repeatable)
+  --json                          emit the result as JSON on stdout
 
-exit: 0 ready; 1 failed or closed; 2 usage; 124 timeout
+Bot comments are ignored. Comments already present when the wait starts are the
+baseline and never reported; only comments posted during the wait are.
+
+exit: 0 approved; 1 checks failed; 2 usage; 3 changes requested; 4 new comment;
+      5 error; 124 timeout
 `)
 }

--- a/cmd/attn/pr.go
+++ b/cmd/attn/pr.go
@@ -342,9 +342,9 @@ query($owner:String!,$name:String!,$number:Int!){
         pageInfo{hasNextPage}
         nodes{__typename ... on CheckRun{name status conclusion} ... on StatusContext{context state}}
       }}}}}
-      reviews(last:100){nodes{id state bodyText submittedAt author{__typename login} commit{oid}}}
+      reviews(last:100){nodes{id state bodyText submittedAt author{__typename login} commit{oid}
+        comments(first:100){pageInfo{hasNextPage} nodes{id createdAt author{__typename login}}}}}
       comments(last:100){nodes{id createdAt author{__typename login}}}
-      reviewThreads(last:100){nodes{comments(last:100){nodes{id createdAt author{__typename login}}}}}
     }}}`
 
 func (ghPRReadinessSource) Fetch(ctx context.Context, opts prWaitOptions) (*prReadiness, error) {
@@ -418,6 +418,12 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 							Commit      struct {
 								OID string `json:"oid"`
 							} `json:"commit"`
+							Comments struct {
+								PageInfo struct {
+									HasNextPage bool `json:"hasNextPage"`
+								} `json:"pageInfo"`
+								Nodes []prGraphQLComment `json:"nodes"`
+							} `json:"comments"`
 						} `json:"nodes"`
 					} `json:"reviews"`
 					Comments struct {
@@ -472,22 +478,34 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 	sort.Slice(result.Checks, func(i, j int) bool { return result.Checks[i].Name < result.Checks[j].Name })
 	result.CheckState = summarizePRChecks(result.Checks)
 
-	// Reviews, comments, and threads use last:100, so truncation drops only the
-	// oldest entries. A superseded review or a long-read comment cannot be the
-	// actionable update, so that boundary is safe to accept.
+	// Reviews and issue comments use last:100, so truncation drops only the
+	// oldest entries, which cannot be the actionable update.
+	//
+	// Inline comments deliberately come from the reviews that carry them rather
+	// than from reviewThreads. A thread's position is fixed when the thread
+	// starts but comments can be appended to it forever, so a reply to an old
+	// thread falls outside any newest-N slice of threads and would be missed.
+	// Every inline comment, including a reply to a long-dormant thread, arrives
+	// attached to a freshly submitted review, and reviews are submission
+	// ordered. Sourcing them here makes thread age irrelevant.
 	var latest time.Time
 	for _, review := range pr.Reviews.Nodes {
 		state := strings.ToUpper(review.State)
+		// A review with no text of its own is just the wrapper GitHub creates
+		// around an inline comment; its comments are reported below, so
+		// counting the wrapper too would report one remark twice.
+		if strings.TrimSpace(review.BodyText) != "" {
+			result.Comments = appendPRComment(result.Comments, prGraphQLComment{
+				ID: review.ID, CreatedAt: review.SubmittedAt, Author: review.Author,
+			}, "review", opts)
+		}
+		if review.Comments.PageInfo.HasNextPage {
+			return nil, errors.New("a review carries more than 100 comments; new comments cannot be detected without truncation")
+		}
+		for _, comment := range review.Comments.Nodes {
+			result.Comments = appendPRComment(result.Comments, comment, "inline", opts)
+		}
 		if state == "COMMENTED" {
-			// Posting a standalone inline comment makes GitHub wrap it in a
-			// bodyless COMMENTED review. Counting that wrapper would report one
-			// human remark twice, so only a review with its own text counts;
-			// the inline comments it holds arrive via reviewThreads.
-			if strings.TrimSpace(review.BodyText) != "" {
-				result.Comments = appendPRComment(result.Comments, prGraphQLComment{
-					ID: review.ID, CreatedAt: review.SubmittedAt, Author: review.Author,
-				}, "review", opts)
-			}
 			continue
 		}
 		if !strings.EqualFold(review.Author.Login, opts.Reviewer) || review.Commit.OID != result.HeadSHA ||
@@ -503,11 +521,6 @@ func parsePRSnapshot(output []byte, opts prWaitOptions) (*prReadiness, error) {
 	}
 	for _, comment := range pr.Comments.Nodes {
 		result.Comments = appendPRComment(result.Comments, comment, "issue", opts)
-	}
-	for _, thread := range pr.ReviewThreads.Nodes {
-		for _, comment := range thread.Comments.Nodes {
-			result.Comments = appendPRComment(result.Comments, comment, "inline", opts)
-		}
 	}
 	sort.Slice(result.Comments, func(i, j int) bool {
 		return result.Comments[i].CreatedAt.Before(result.Comments[j].CreatedAt)

--- a/cmd/attn/pr_test.go
+++ b/cmd/attn/pr_test.go
@@ -71,7 +71,7 @@ func TestParsePRSnapshotRequiresGreenChecksAndCurrentHeadApproval(t *testing.T) 
 
 func TestParsePRSnapshotCollectsHumanCommentsAndDropsBots(t *testing.T) {
 	head := strings.Repeat("a", 40)
-	reviews := `{"id":"r1","state":"COMMENTED","submittedAt":"2026-07-19T10:00:00Z","author":{"__typename":"User","login":"figgyster"},"commit":{"oid":"` + head + `"}}`
+	reviews := `{"id":"r1","state":"COMMENTED","bodyText":"a real review remark","submittedAt":"2026-07-19T10:00:00Z","author":{"__typename":"User","login":"figgyster"},"commit":{"oid":"` + head + `"}}`
 	comments := `{"id":"c1","createdAt":"2026-07-19T09:00:00Z","author":{"__typename":"User","login":"victorarias"}},
 	             {"id":"c2","createdAt":"2026-07-19T09:30:00Z","author":{"__typename":"Bot","login":"chatgpt-codex-connector"}},
 	             {"id":"c3","createdAt":"2026-07-19T09:45:00Z","author":{"__typename":"User","login":"noisy-human"}}`
@@ -95,6 +95,22 @@ func TestParsePRSnapshotCollectsHumanCommentsAndDropsBots(t *testing.T) {
 	// A COMMENTED review carries no verdict and must not move the review state.
 	if readiness.ReviewState != "waiting" {
 		t.Fatalf("COMMENTED review changed review state: %#v", readiness)
+	}
+}
+
+// GitHub wraps a standalone inline comment in a bodyless COMMENTED review.
+// Reporting both made one remark read as "2 new comments".
+func TestParsePRSnapshotDoesNotDoubleCountInlineCommentWrapper(t *testing.T) {
+	head := strings.Repeat("a", 40)
+	wrapper := `{"id":"r1","state":"COMMENTED","bodyText":"","submittedAt":"2026-07-19T19:33:19Z","author":{"__typename":"User","login":"victorarias"},"commit":{"oid":"` + head + `"}}`
+	threads := `{"comments":{"nodes":[{"id":"t1","createdAt":"2026-07-19T19:33:19Z","author":{"__typename":"User","login":"victorarias"}}]}}`
+
+	readiness, err := parsePRSnapshot(snapshotPayload(head, "", wrapper, "", threads), prWaitOptions{Reviewer: "figgyster"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(readiness.Comments) != 1 || readiness.Comments[0].ID != "t1" || readiness.Comments[0].Kind != "inline" {
+		t.Fatalf("comments = %#v, want the inline comment alone", readiness.Comments)
 	}
 }
 
@@ -242,16 +258,19 @@ func TestReportPROutcomeWritesPlainTextAndJSON(t *testing.T) {
 		t.Fatalf("plain output = %q", got)
 	}
 
+	// Baseline comments on the observation are not news on a non-comment outcome.
+	result.Comments = []prComment{{ID: "c1", Author: "victorarias", Kind: "issue"}}
 	var encoded bytes.Buffer
 	code := reportPROutcome(result, outcomeChangesRequested, prWaitOptions{JSON: true}, &encoded)
 	if code != prWaitExitChangesRequested {
 		t.Fatalf("exit code = %d", code)
 	}
 	var payload struct {
-		Outcome string `json:"outcome"`
-		Head    string `json:"head"`
-		Detail  string `json:"detail"`
-		Review  struct {
+		Outcome  string      `json:"outcome"`
+		Head     string      `json:"head"`
+		Detail   string      `json:"detail"`
+		Comments []prComment `json:"comments"`
+		Review   struct {
 			Reviewer string `json:"reviewer"`
 		} `json:"review"`
 	}
@@ -261,6 +280,9 @@ func TestReportPROutcomeWritesPlainTextAndJSON(t *testing.T) {
 	if payload.Outcome != "changes_requested" || payload.Head != head || payload.Review.Reviewer != "figgyster" ||
 		!strings.Contains(payload.Detail, "requested changes") {
 		t.Fatalf("payload = %#v", payload)
+	}
+	if len(payload.Comments) != 0 {
+		t.Fatalf("baseline comments reported as new: %#v", payload.Comments)
 	}
 }
 

--- a/cmd/attn/pr_test.go
+++ b/cmd/attn/pr_test.go
@@ -3,7 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
-	"errors"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -23,23 +24,33 @@ func (f *fakeReadinessSource) Fetch(context.Context, prWaitOptions) (*prReadines
 	return f.results[index], nil
 }
 
-func TestParseGHPRReadinessRequiresGreenChecksAndCurrentHeadApproval(t *testing.T) {
+// snapshotPayload wraps GraphQL fragments in the envelope gh api graphql emits.
+func snapshotPayload(head, checks, reviews, comments, threads string) []byte {
+	if checks == "" {
+		checks = `{"__typename":"CheckRun","name":"CI","status":"COMPLETED","conclusion":"SUCCESS"}`
+	}
+	return fmt.Appendf(nil, `{"data":{"repository":{"pullRequest":{
+      "number":404,"state":"OPEN","isDraft":false,"headRefOid":%q,
+      "commits":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{
+        "pageInfo":{"hasNextPage":false},"nodes":[%s]}}}}]},
+      "reviews":{"nodes":[%s]},
+      "comments":{"nodes":[%s]},
+      "reviewThreads":{"nodes":[%s]}
+    }}}}`, head, checks, reviews, comments, threads)
+}
+
+func TestParsePRSnapshotRequiresGreenChecksAndCurrentHeadApproval(t *testing.T) {
 	head := strings.Repeat("a", 40)
 	oldHead := strings.Repeat("b", 40)
-	output := `{
-      "number":404,"state":"OPEN","isDraft":false,"headRefOid":"` + head + `",
-      "statusCheckRollup":[
-        {"__typename":"CheckRun","name":"Daemon","status":"COMPLETED","conclusion":"SUCCESS"},
-        {"__typename":"CheckRun","name":"Frontend","status":"COMPLETED","conclusion":"SKIPPED"},
-        {"__typename":"StatusContext","context":"license","state":"SUCCESS"}
-      ],
-      "reviews":[
-        {"state":"APPROVED","submittedAt":"2026-07-19T10:00:00Z","author":{"login":"figgyster"},"commit":{"oid":"` + oldHead + `"}},
-        {"state":"CHANGES_REQUESTED","submittedAt":"2026-07-19T11:00:00Z","author":{"login":"figgyster"},"commit":{"oid":"` + head + `"}},
-        {"state":"APPROVED","submittedAt":"2026-07-19T12:00:00Z","author":{"login":"Figgyster"},"commit":{"oid":"` + head + `"}}
-      ]
-    }`
-	readiness, err := parseGHPRReadiness([]byte(output), "figgyster")
+	checks := `{"__typename":"CheckRun","name":"Daemon","status":"COMPLETED","conclusion":"SUCCESS"},
+	           {"__typename":"CheckRun","name":"Frontend","status":"COMPLETED","conclusion":"SKIPPED"},
+	           {"__typename":"StatusContext","context":"license","state":"SUCCESS"}`
+	reviews := `{"id":"r1","state":"APPROVED","submittedAt":"2026-07-19T10:00:00Z","author":{"__typename":"User","login":"figgyster"},"commit":{"oid":"` + oldHead + `"}},
+	            {"id":"r2","state":"CHANGES_REQUESTED","submittedAt":"2026-07-19T11:00:00Z","author":{"__typename":"User","login":"figgyster"},"commit":{"oid":"` + head + `"}},
+	            {"id":"r3","state":"APPROVED","submittedAt":"2026-07-19T12:00:00Z","author":{"__typename":"User","login":"Figgyster"},"commit":{"oid":"` + head + `"}}`
+
+	opts := prWaitOptions{Reviewer: "figgyster"}
+	readiness, err := parsePRSnapshot(snapshotPayload(head, checks, reviews, "", ""), opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,8 +58,9 @@ func TestParseGHPRReadinessRequiresGreenChecksAndCurrentHeadApproval(t *testing.
 		t.Fatalf("readiness = %#v", readiness)
 	}
 
-	oldOnly := strings.Replace(output, `,"commit":{"oid":"`+head+`"}`, `,"commit":{"oid":"`+oldHead+`"}`, 2)
-	readiness, err = parseGHPRReadiness([]byte(oldOnly), "figgyster")
+	// The same reviews bound to a superseded commit must not satisfy the gate.
+	staleReviews := strings.ReplaceAll(reviews, `"oid":"`+head+`"`, `"oid":"`+oldHead+`"`)
+	readiness, err = parsePRSnapshot(snapshotPayload(head, checks, staleReviews, "", ""), opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,9 +69,38 @@ func TestParseGHPRReadinessRequiresGreenChecksAndCurrentHeadApproval(t *testing.
 	}
 }
 
-func TestParseGHPRReadinessFailsClosedForUnknownCheckState(t *testing.T) {
-	output := `{"number":1,"state":"OPEN","headRefOid":"abc","statusCheckRollup":[{"__typename":"CheckRun","name":"CI","status":"COMPLETED","conclusion":"NEW_STATE"}],"reviews":[]}`
-	readiness, err := parseGHPRReadiness([]byte(output), "reviewer")
+func TestParsePRSnapshotCollectsHumanCommentsAndDropsBots(t *testing.T) {
+	head := strings.Repeat("a", 40)
+	reviews := `{"id":"r1","state":"COMMENTED","submittedAt":"2026-07-19T10:00:00Z","author":{"__typename":"User","login":"figgyster"},"commit":{"oid":"` + head + `"}}`
+	comments := `{"id":"c1","createdAt":"2026-07-19T09:00:00Z","author":{"__typename":"User","login":"victorarias"}},
+	             {"id":"c2","createdAt":"2026-07-19T09:30:00Z","author":{"__typename":"Bot","login":"chatgpt-codex-connector"}},
+	             {"id":"c3","createdAt":"2026-07-19T09:45:00Z","author":{"__typename":"User","login":"noisy-human"}}`
+	threads := `{"comments":{"nodes":[{"id":"t1","createdAt":"2026-07-19T11:00:00Z","author":{"__typename":"User","login":"figgyster"}}]}}`
+
+	opts := prWaitOptions{Reviewer: "figgyster", IgnoreAuthors: []string{"NOISY-HUMAN"}}
+	readiness, err := parsePRSnapshot(snapshotPayload(head, "", reviews, comments, threads), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got []string
+	for _, comment := range readiness.Comments {
+		got = append(got, comment.ID+":"+comment.Kind+":"+comment.Author)
+	}
+	// Sorted oldest-first; the bot and the ignored author are gone.
+	want := []string{"c1:issue:victorarias", "r1:review:figgyster", "t1:inline:figgyster"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("comments = %v, want %v", got, want)
+	}
+	// A COMMENTED review carries no verdict and must not move the review state.
+	if readiness.ReviewState != "waiting" {
+		t.Fatalf("COMMENTED review changed review state: %#v", readiness)
+	}
+}
+
+func TestParsePRSnapshotFailsClosedForUnknownCheckState(t *testing.T) {
+	checks := `{"__typename":"CheckRun","name":"CI","status":"COMPLETED","conclusion":"NEW_STATE"}`
+	readiness, err := parsePRSnapshot(snapshotPayload("abc", checks, "", "", ""), prWaitOptions{Reviewer: "r"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,17 +109,24 @@ func TestParseGHPRReadinessFailsClosedForUnknownCheckState(t *testing.T) {
 	}
 }
 
-func TestParseGHPRReadinessFailsClosedAtGHCollectionLimit(t *testing.T) {
-	check := `{"__typename":"CheckRun","name":"CI","status":"COMPLETED","conclusion":"SUCCESS"},`
-	checks := strings.TrimSuffix(strings.Repeat(check, 100), ",")
-	output := `{"number":1,"state":"OPEN","headRefOid":"abc","statusCheckRollup":[` + checks + `],"reviews":[]}`
-	_, err := parseGHPRReadiness([]byte(output), "reviewer")
-	if err == nil || !strings.Contains(err.Error(), "without truncation") {
+func TestParsePRSnapshotFailsClosedOnCheckTruncation(t *testing.T) {
+	payload := snapshotPayload("abc", "", "", "", "")
+	truncated := bytes.Replace(payload, []byte(`"hasNextPage":false`), []byte(`"hasNextPage":true`), 1)
+	if _, err := parsePRSnapshot(truncated, prWaitOptions{Reviewer: "r"}); err == nil ||
+		!strings.Contains(err.Error(), "without truncation") {
 		t.Fatalf("err = %v", err)
 	}
 }
 
-func TestWaitForPRReadyResetsAcrossHeadChangeAndSuppressesDuplicatePolls(t *testing.T) {
+func TestParsePRSnapshotSurfacesGraphQLErrors(t *testing.T) {
+	body := []byte(`{"data":{"repository":null},"errors":[{"message":"Could not resolve to a Repository"}]}`)
+	if _, err := parsePRSnapshot(body, prWaitOptions{Reviewer: "r"}); err == nil ||
+		!strings.Contains(err.Error(), "Could not resolve") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestWaitForPRActionableResetsAcrossHeadChangeAndSuppressesDuplicatePolls(t *testing.T) {
 	headA := strings.Repeat("a", 40)
 	headB := strings.Repeat("b", 40)
 	pendingA := readinessObservation("12", headA, checksPending, "waiting")
@@ -86,43 +134,133 @@ func TestWaitForPRReadyResetsAcrossHeadChangeAndSuppressesDuplicatePolls(t *test
 	waitingB := readinessObservation("12", headB, checksGreen, "waiting")
 	readyB := readinessObservation("12", headB, checksGreen, "approved")
 	source := &fakeReadinessSource{results: []*prReadiness{pendingA, pendingA, greenA, waitingB, readyB}}
-	opts := prWaitOptions{Target: "12", Repo: "owner/repo", Reviewer: "figgyster", Interval: 0}
+	opts := prWaitOptions{Number: 12, Owner: "owner", Name: "repo", Reviewer: "figgyster", Interval: 0}
+
 	var output bytes.Buffer
-	got, err := waitForPRReady(context.Background(), source, opts, &output)
+	got, outcome, err := waitForPRActionable(context.Background(), source, opts, &output)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.HeadSHA != headB || !got.ready() || source.calls != 5 {
-		t.Fatalf("got=%#v calls=%d", got, source.calls)
+	if outcome != outcomeApproved || got.HeadSHA != headB || source.calls != 5 {
+		t.Fatalf("got=%#v outcome=%s calls=%d", got, outcome, source.calls)
 	}
 	text := output.String()
 	if strings.Count(text, "head=aaaaaaaaaaaa state=open") != 2 {
 		t.Fatalf("duplicate polls were not suppressed:\n%s", text)
 	}
-	for _, want := range []string{"head changed aaaaaaaaaaaa -> bbbbbbbbbbbb; reset", "head=bbbbbbbbbbbb state=open", "review=approved reviewer=figgyster"} {
+	for _, want := range []string{"head changed aaaaaaaaaaaa -> bbbbbbbbbbbb; reset", "review=approved reviewer=figgyster"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("output missing %q:\n%s", want, text)
 		}
 	}
 }
 
-func TestWaitForPRReadyFailsOnCurrentHeadCheckFailure(t *testing.T) {
-	failed := readinessObservation("12", strings.Repeat("c", 40), checksFailed, "approved")
-	source := &fakeReadinessSource{results: []*prReadiness{failed}}
-	got, err := waitForPRReady(context.Background(), source, prWaitOptions{}, &bytes.Buffer{})
-	if !errors.Is(err, errPRChecksFailed) || got != failed {
-		t.Fatalf("got=%#v err=%v", got, err)
+// The motivating regression: a reviewer requesting changes used to fall through
+// to the poll loop and only surface when the whole timeout expired.
+func TestWaitForPRActionableReturnsPromptlyOnChangesRequested(t *testing.T) {
+	head := strings.Repeat("c", 40)
+	observation := readinessObservation("12", head, checksGreen, "changes_requested")
+	source := &fakeReadinessSource{results: []*prReadiness{observation}}
+
+	got, outcome, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster"}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != outcomeChangesRequested || outcome.exitCode() != prWaitExitChangesRequested || got != observation {
+		t.Fatalf("got=%#v outcome=%s", got, outcome)
+	}
+	if source.calls != 1 {
+		t.Fatalf("polled %d times; changes_requested must return on the first observation", source.calls)
 	}
 }
 
-func TestWaitForPRReadyReturnsTimeout(t *testing.T) {
+func TestWaitForPRActionableBaselinesExistingCommentsAndWakesOnNewOnes(t *testing.T) {
+	head := strings.Repeat("d", 40)
+	existing := prComment{ID: "c1", Author: "victorarias", Kind: "issue", CreatedAt: time.Unix(1, 0)}
+	fresh := prComment{ID: "c2", Author: "victorarias", Kind: "issue", CreatedAt: time.Unix(2, 0)}
+
+	first := readinessObservation("12", head, checksPending, "waiting")
+	first.Comments = []prComment{existing}
+	second := readinessObservation("12", head, checksPending, "waiting")
+	second.Comments = []prComment{existing}
+	third := readinessObservation("12", head, checksPending, "waiting")
+	third.Comments = []prComment{existing, fresh}
+	source := &fakeReadinessSource{results: []*prReadiness{first, second, third}}
+
+	got, outcome, err := waitForPRActionable(context.Background(), source, prWaitOptions{Reviewer: "figgyster"}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != outcomeComment || source.calls != 3 {
+		t.Fatalf("outcome=%s calls=%d", outcome, source.calls)
+	}
+	// Only the comment posted during the wait is reported, not the baseline.
+	if len(got.Comments) != 1 || got.Comments[0].ID != "c2" {
+		t.Fatalf("comments = %#v", got.Comments)
+	}
+}
+
+func TestWaitForPRActionableReportsCheckFailureAndClosure(t *testing.T) {
+	failed := readinessObservation("12", strings.Repeat("c", 40), checksFailed, "approved")
+	_, outcome, err := waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{failed}}, prWaitOptions{}, &bytes.Buffer{})
+	if err != nil || outcome != outcomeChecksFailed || outcome.exitCode() != prWaitExitChecksFailed {
+		t.Fatalf("outcome=%s err=%v", outcome, err)
+	}
+
+	closed := readinessObservation("12", strings.Repeat("c", 40), checksGreen, "waiting")
+	closed.State = "merged"
+	_, outcome, err = waitForPRActionable(context.Background(), &fakeReadinessSource{results: []*prReadiness{closed}}, prWaitOptions{}, &bytes.Buffer{})
+	if err != nil || outcome != outcomeClosed || outcome.exitCode() != prWaitExitError {
+		t.Fatalf("outcome=%s err=%v", outcome, err)
+	}
+}
+
+func TestWaitForPRActionableReturnsTimeoutOutcome(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	pending := readinessObservation("12", strings.Repeat("d", 40), checksPending, "waiting")
 	source := &fakeReadinessSource{results: []*prReadiness{pending}}
-	_, err := waitForPRReady(ctx, source, prWaitOptions{}, &bytes.Buffer{})
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("err = %v", err)
+
+	_, outcome, err := waitForPRActionable(ctx, source, prWaitOptions{Interval: time.Hour}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != outcomeTimeout || outcome.exitCode() != prWaitExitTimeout {
+		t.Fatalf("outcome = %s", outcome)
+	}
+}
+
+func TestReportPROutcomeWritesPlainTextAndJSON(t *testing.T) {
+	head := strings.Repeat("e", 40)
+	result := readinessObservation("12", head, checksGreen, "approved")
+
+	var plain bytes.Buffer
+	if code := reportPROutcome(result, outcomeApproved, prWaitOptions{}, &plain); code != prWaitExitApproved {
+		t.Fatalf("exit code = %d", code)
+	}
+	if got := plain.String(); !strings.HasPrefix(got, "approved: figgyster approved eeeeeeeeeeee") {
+		t.Fatalf("plain output = %q", got)
+	}
+
+	var encoded bytes.Buffer
+	code := reportPROutcome(result, outcomeChangesRequested, prWaitOptions{JSON: true}, &encoded)
+	if code != prWaitExitChangesRequested {
+		t.Fatalf("exit code = %d", code)
+	}
+	var payload struct {
+		Outcome string `json:"outcome"`
+		Head    string `json:"head"`
+		Detail  string `json:"detail"`
+		Review  struct {
+			Reviewer string `json:"reviewer"`
+		} `json:"review"`
+	}
+	if err := json.Unmarshal(encoded.Bytes(), &payload); err != nil {
+		t.Fatalf("json = %q err = %v", encoded.String(), err)
+	}
+	if payload.Outcome != "changes_requested" || payload.Head != head || payload.Review.Reviewer != "figgyster" ||
+		!strings.Contains(payload.Detail, "requested changes") {
+		t.Fatalf("payload = %#v", payload)
 	}
 }
 
@@ -131,14 +269,30 @@ func TestParsePRWaitArgs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if opts.Target != "https://github.com/victorarias/attn/pull/602" || opts.Reviewer != "figgyster" || opts.Interval != 5*time.Second {
+	if opts.Owner != "victorarias" || opts.Name != "attn" || opts.Number != 602 ||
+		opts.Reviewer != "figgyster" || opts.Interval != 5*time.Second {
 		t.Fatalf("opts = %#v", opts)
 	}
+
+	opts, err = parsePRWaitArgs([]string{"602", "--repo", "ghe.example.com/victorarias/attn", "--reviewer", "figgyster",
+		"--ignore-author", "bot-one", "--ignore-author", "bot-two", "--json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Host != "ghe.example.com" || opts.Owner != "victorarias" || opts.Name != "attn" || !opts.JSON ||
+		strings.Join(opts.IgnoreAuthors, ",") != "bot-one,bot-two" {
+		t.Fatalf("opts = %#v", opts)
+	}
+
 	if _, err := parsePRWaitArgs([]string{"602", "--reviewer", "figgyster"}); err == nil || !strings.Contains(err.Error(), "--repo is required") {
 		t.Fatalf("missing repo error = %v", err)
 	}
 	if _, err := parsePRWaitArgs([]string{"602", "--repo", "victorarias/attn"}); err == nil || !strings.Contains(err.Error(), "required") {
 		t.Fatalf("missing reviewer error = %v", err)
+	}
+	if _, err := parsePRWaitArgs([]string{"602", "--repo", "attn", "--reviewer", "figgyster"}); err == nil ||
+		!strings.Contains(err.Error(), "[host/]owner/repository") {
+		t.Fatalf("malformed repo error = %v", err)
 	}
 }
 
@@ -147,7 +301,7 @@ func TestExecutePRCommandShowsSubcommandHelp(t *testing.T) {
 	if code := executePRCommand([]string{"wait-ready", "--help"}, &stdout, &bytes.Buffer{}); code != 0 {
 		t.Fatalf("exit code = %d", code)
 	}
-	if !strings.Contains(stdout.String(), "exit: 0 ready") {
+	if !strings.Contains(stdout.String(), "exit: 0 approved") {
 		t.Fatalf("help = %q", stdout.String())
 	}
 }

--- a/cmd/attn/pr_test.go
+++ b/cmd/attn/pr_test.go
@@ -25,7 +25,7 @@ func (f *fakeReadinessSource) Fetch(context.Context, prWaitOptions) (*prReadines
 }
 
 // snapshotPayload wraps GraphQL fragments in the envelope gh api graphql emits.
-func snapshotPayload(head, checks, reviews, comments, threads string) []byte {
+func snapshotPayload(head, checks, reviews, comments string) []byte {
 	if checks == "" {
 		checks = `{"__typename":"CheckRun","name":"CI","status":"COMPLETED","conclusion":"SUCCESS"}`
 	}
@@ -34,9 +34,22 @@ func snapshotPayload(head, checks, reviews, comments, threads string) []byte {
       "commits":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{
         "pageInfo":{"hasNextPage":false},"nodes":[%s]}}}}]},
       "reviews":{"nodes":[%s]},
-      "comments":{"nodes":[%s]},
-      "reviewThreads":{"nodes":[%s]}
-    }}}}`, head, checks, reviews, comments, threads)
+      "comments":{"nodes":[%s]}
+    }}}}`, head, checks, reviews, comments)
+}
+
+// reviewNode builds one review. GitHub attaches every inline comment to a
+// freshly submitted review, including a reply to a long-dormant thread, and
+// wraps a standalone inline comment in a review with no body of its own.
+func reviewNode(id, state, body, at, author, oid, inline string) string {
+	return fmt.Sprintf(`{"id":%q,"state":%q,"bodyText":%q,"submittedAt":%q,
+	  "author":{"__typename":"User","login":%q},"commit":{"oid":%q},
+	  "comments":{"pageInfo":{"hasNextPage":false},"nodes":[%s]}}`,
+		id, state, body, at, author, oid, inline)
+}
+
+func inlineNode(id, at, author string) string {
+	return fmt.Sprintf(`{"id":%q,"createdAt":%q,"author":{"__typename":"User","login":%q}}`, id, at, author)
 }
 
 func TestParsePRSnapshotRequiresGreenChecksAndCurrentHeadApproval(t *testing.T) {
@@ -45,12 +58,14 @@ func TestParsePRSnapshotRequiresGreenChecksAndCurrentHeadApproval(t *testing.T) 
 	checks := `{"__typename":"CheckRun","name":"Daemon","status":"COMPLETED","conclusion":"SUCCESS"},
 	           {"__typename":"CheckRun","name":"Frontend","status":"COMPLETED","conclusion":"SKIPPED"},
 	           {"__typename":"StatusContext","context":"license","state":"SUCCESS"}`
-	reviews := `{"id":"r1","state":"APPROVED","submittedAt":"2026-07-19T10:00:00Z","author":{"__typename":"User","login":"figgyster"},"commit":{"oid":"` + oldHead + `"}},
-	            {"id":"r2","state":"CHANGES_REQUESTED","submittedAt":"2026-07-19T11:00:00Z","author":{"__typename":"User","login":"figgyster"},"commit":{"oid":"` + head + `"}},
-	            {"id":"r3","state":"APPROVED","submittedAt":"2026-07-19T12:00:00Z","author":{"__typename":"User","login":"Figgyster"},"commit":{"oid":"` + head + `"}}`
+	reviews := strings.Join([]string{
+		reviewNode("r1", "APPROVED", "", "2026-07-19T10:00:00Z", "figgyster", oldHead, ""),
+		reviewNode("r2", "CHANGES_REQUESTED", "", "2026-07-19T11:00:00Z", "figgyster", head, ""),
+		reviewNode("r3", "APPROVED", "", "2026-07-19T12:00:00Z", "Figgyster", head, ""),
+	}, ",")
 
 	opts := prWaitOptions{Reviewer: "figgyster"}
-	readiness, err := parsePRSnapshot(snapshotPayload(head, checks, reviews, "", ""), opts)
+	readiness, err := parsePRSnapshot(snapshotPayload(head, checks, reviews, ""), opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +75,7 @@ func TestParsePRSnapshotRequiresGreenChecksAndCurrentHeadApproval(t *testing.T) 
 
 	// The same reviews bound to a superseded commit must not satisfy the gate.
 	staleReviews := strings.ReplaceAll(reviews, `"oid":"`+head+`"`, `"oid":"`+oldHead+`"`)
-	readiness, err = parsePRSnapshot(snapshotPayload(head, checks, staleReviews, "", ""), opts)
+	readiness, err = parsePRSnapshot(snapshotPayload(head, checks, staleReviews, ""), opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,14 +86,14 @@ func TestParsePRSnapshotRequiresGreenChecksAndCurrentHeadApproval(t *testing.T) 
 
 func TestParsePRSnapshotCollectsHumanCommentsAndDropsBots(t *testing.T) {
 	head := strings.Repeat("a", 40)
-	reviews := `{"id":"r1","state":"COMMENTED","bodyText":"a real review remark","submittedAt":"2026-07-19T10:00:00Z","author":{"__typename":"User","login":"figgyster"},"commit":{"oid":"` + head + `"}}`
+	reviews := reviewNode("r1", "COMMENTED", "a real review remark", "2026-07-19T10:00:00Z", "figgyster", head,
+		inlineNode("t1", "2026-07-19T11:00:00Z", "figgyster"))
 	comments := `{"id":"c1","createdAt":"2026-07-19T09:00:00Z","author":{"__typename":"User","login":"victorarias"}},
 	             {"id":"c2","createdAt":"2026-07-19T09:30:00Z","author":{"__typename":"Bot","login":"chatgpt-codex-connector"}},
 	             {"id":"c3","createdAt":"2026-07-19T09:45:00Z","author":{"__typename":"User","login":"noisy-human"}}`
-	threads := `{"comments":{"nodes":[{"id":"t1","createdAt":"2026-07-19T11:00:00Z","author":{"__typename":"User","login":"figgyster"}}]}}`
 
 	opts := prWaitOptions{Reviewer: "figgyster", IgnoreAuthors: []string{"NOISY-HUMAN"}}
-	readiness, err := parsePRSnapshot(snapshotPayload(head, "", reviews, comments, threads), opts)
+	readiness, err := parsePRSnapshot(snapshotPayload(head, "", reviews, comments), opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,10 +117,10 @@ func TestParsePRSnapshotCollectsHumanCommentsAndDropsBots(t *testing.T) {
 // Reporting both made one remark read as "2 new comments".
 func TestParsePRSnapshotDoesNotDoubleCountInlineCommentWrapper(t *testing.T) {
 	head := strings.Repeat("a", 40)
-	wrapper := `{"id":"r1","state":"COMMENTED","bodyText":"","submittedAt":"2026-07-19T19:33:19Z","author":{"__typename":"User","login":"victorarias"},"commit":{"oid":"` + head + `"}}`
-	threads := `{"comments":{"nodes":[{"id":"t1","createdAt":"2026-07-19T19:33:19Z","author":{"__typename":"User","login":"victorarias"}}]}}`
+	wrapper := reviewNode("r1", "COMMENTED", "", "2026-07-19T19:33:19Z", "victorarias", head,
+		inlineNode("t1", "2026-07-19T19:33:19Z", "victorarias"))
 
-	readiness, err := parsePRSnapshot(snapshotPayload(head, "", wrapper, "", threads), prWaitOptions{Reviewer: "figgyster"})
+	readiness, err := parsePRSnapshot(snapshotPayload(head, "", wrapper, ""), prWaitOptions{Reviewer: "figgyster"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,9 +129,59 @@ func TestParsePRSnapshotDoesNotDoubleCountInlineCommentWrapper(t *testing.T) {
 	}
 }
 
+// A reply to a thread older than any newest-N slice of reviewThreads must still
+// be seen. GitHub attaches the reply to a freshly submitted review, so sourcing
+// inline comments from reviews rather than threads makes thread age irrelevant.
+func TestParsePRSnapshotSeesReplyOnLongDormantThread(t *testing.T) {
+	head := strings.Repeat("a", 40)
+	nodes := make([]string, 0, 130)
+	// 128 old reviews, each opening a thread, would push the first thread far
+	// outside a 100-thread window.
+	for i := range 128 {
+		nodes = append(nodes, reviewNode(
+			fmt.Sprintf("old-r%d", i), "COMMENTED", "", "2026-01-01T00:00:00Z", "victorarias", head,
+			inlineNode(fmt.Sprintf("old-t%d", i), "2026-01-01T00:00:00Z", "victorarias")))
+	}
+	// The reply lands on thread old-t0, but arrives as the newest review.
+	nodes = append(nodes, reviewNode("reply-r", "COMMENTED", "", "2026-07-19T20:00:00Z", "figgyster", head,
+		inlineNode("reply-t", "2026-07-19T20:00:00Z", "figgyster")))
+
+	readiness, err := parsePRSnapshot(snapshotPayload(head, "", strings.Join(nodes, ","), ""), prWaitOptions{Reviewer: "figgyster"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var baseline []prComment
+	for _, comment := range readiness.Comments {
+		if comment.ID != "reply-t" {
+			baseline = append(baseline, comment)
+		}
+	}
+	seen := map[string]bool{}
+	for _, comment := range baseline {
+		seen[comment.ID] = true
+	}
+	fresh := unseenPRComments(readiness.Comments, seen)
+	if len(fresh) != 1 || fresh[0].ID != "reply-t" {
+		t.Fatalf("reply on a dormant thread was missed: fresh = %#v", fresh)
+	}
+}
+
+func TestParsePRSnapshotFailsClosedOnReviewCommentTruncation(t *testing.T) {
+	head := strings.Repeat("a", 40)
+	review := reviewNode("r1", "COMMENTED", "", "2026-07-19T10:00:00Z", "victorarias", head,
+		inlineNode("t1", "2026-07-19T10:00:00Z", "victorarias"))
+	truncated := strings.Replace(review, `"pageInfo":{"hasNextPage":false}`, `"pageInfo":{"hasNextPage":true}`, 1)
+
+	if _, err := parsePRSnapshot(snapshotPayload(head, "", truncated, ""), prWaitOptions{Reviewer: "figgyster"}); err == nil ||
+		!strings.Contains(err.Error(), "without truncation") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
 func TestParsePRSnapshotFailsClosedForUnknownCheckState(t *testing.T) {
 	checks := `{"__typename":"CheckRun","name":"CI","status":"COMPLETED","conclusion":"NEW_STATE"}`
-	readiness, err := parsePRSnapshot(snapshotPayload("abc", checks, "", "", ""), prWaitOptions{Reviewer: "r"})
+	readiness, err := parsePRSnapshot(snapshotPayload("abc", checks, "", ""), prWaitOptions{Reviewer: "r"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +191,7 @@ func TestParsePRSnapshotFailsClosedForUnknownCheckState(t *testing.T) {
 }
 
 func TestParsePRSnapshotFailsClosedOnCheckTruncation(t *testing.T) {
-	payload := snapshotPayload("abc", "", "", "", "")
+	payload := snapshotPayload("abc", "", "", "")
 	truncated := bytes.Replace(payload, []byte(`"hasNextPage":false`), []byte(`"hasNextPage":true`), 1)
 	if _, err := parsePRSnapshot(truncated, prWaitOptions{Reviewer: "r"}); err == nil ||
 		!strings.Contains(err.Error(), "without truncation") {


### PR DESCRIPTION
## Intent

`attn pr wait-ready` was a binary merge gate: it returned only when the pull
request was mergeable, or when the whole timeout expired. That made a reviewer
requesting changes indistinguishable from slow CI — both surfaced as a 30-minute
`124`. The waiter should return as soon as something needs a human.

## Summary

- return on the first actionable update: failing check, changes requested, new
  human comment, or approval on a green exact head
- give each outcome its own exit code (`0` approved, `1` checks failed, `3`
  changes requested, `4` comment, `5` error, `124` timeout), print a plain-text
  result line by default, and add `--json` for detail
- collect checks, reviews, and every comment surface in one GraphQL snapshot,
  preserving #605's one-observation-per-poll invariant
- ignore bot comments using GraphQL `__typename`, and baseline comments already
  present when the wait starts so only new ones report
- add `--ignore-author` and accept `[host/]owner/repository` in `--repo`

`gh pr view --json comments` cannot support this: it strips the `[bot]` suffix
and omits the author type, so bots are indistinguishable from people. Getting
the same data over REST would cost four calls per poll; GraphQL costs one.

The token owner is deliberately **not** filtered. The operator and the agent
share one token, so filtering "self" would discard the operator's own comment —
the most actionable event there is. The baseline prevents self-waking instead.

## Test plan

- [x] `go test ./cmd/attn`, `go vet ./cmd/attn`, `go build ./...`
- [x] Live: `pending -> green` across a real CI run, duplicate polls suppressed
- [x] Live: comment posted mid-wait woke the waiter within one interval (exit 4)
- [x] Live: re-run on the same comment stayed quiet (exit 124) — baseline holds
- [x] Live: inline review-thread comment detected
- [x] Live: bot comment on #537 filtered out
- [x] Live: head change `c0bebb72 -> 39300b56` reset checks, comments unaffected
- [x] Live: `--json` keeps progress on stderr and stdout parseable

Live verification used a throwaway draft PR (#607), now closed and its branch
deleted. It caught two defects that the unit tests did not:

1. GitHub wraps a standalone inline comment in a bodyless `COMMENTED` review, so
   one remark was reported as two comments.
2. The JSON `comments` field carried the baseline on non-comment outcomes, so a
   timeout listed old comments where a consumer reads new ones.

Both now have regression tests built from the exact payloads GitHub returned.

## Not verified live

`approved` and `changes_requested` cannot be exercised on a synthetic PR:
GitHub blocks approving or requesting changes on your own pull request. They
rest on unit tests plus #605's live check against #404 at exact head. The
review-parsing logic is unchanged from that verified version, except that
`COMMENTED` reviews now divert to the comment path before the verdict branch.

## Out of scope

- resuming a wait from a prior baseline (`--since`), which needs a durable cursor
- daemon-side comment polling; this stays a standalone read-only CLI that runs
  without a daemon
