### PR TITLE
refactor(automation): unify unattended launch contract

### DIFF
--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -429,7 +429,9 @@ func runPTYWorker() {
 	fs.StringVar(&cfg.CodexExecutable, "codex-executable", "", "codex executable override")
 	fs.StringVar(&cfg.CopilotExecutable, "copilot-executable", "", "copilot executable override")
 	var externalCommandJSON string
+	var unattendedLaunchJSON string
 	fs.StringVar(&externalCommandJSON, "external-command-json", "", "external plugin driver argv as JSON")
+	fs.StringVar(&unattendedLaunchJSON, "unattended-launch-json", "", "immutable unattended launch contract as JSON")
 	fs.StringVar(&cfg.ExternalCWD, "external-cwd", "", "external plugin driver working directory")
 	fs.StringVar(&cfg.RegistryPath, "registry-path", "", "registry path")
 	fs.StringVar(&cfg.SocketPath, "socket-path", "", "socket path")
@@ -442,6 +444,16 @@ func runPTYWorker() {
 	if externalCommandJSON != "" {
 		if err := json.Unmarshal([]byte(externalCommandJSON), &cfg.ExternalCommand); err != nil {
 			fmt.Fprintf(os.Stderr, "pty-worker error: invalid --external-command-json: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	if unattendedLaunchJSON != "" {
+		if err := json.Unmarshal([]byte(unattendedLaunchJSON), &cfg.UnattendedLaunch); err != nil {
+			fmt.Fprintf(os.Stderr, "pty-worker error: invalid --unattended-launch-json: %v\n", err)
+			os.Exit(1)
+		}
+		if err := cfg.UnattendedLaunch.Validate(); err != nil {
+			fmt.Fprintf(os.Stderr, "pty-worker error: invalid --unattended-launch-json: %v\n", err)
 			os.Exit(1)
 		}
 	}

--- a/internal/automation/automation.go
+++ b/internal/automation/automation.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/victorarias/attn/internal/launchcontract"
 	"gopkg.in/yaml.v3"
 )
 
@@ -57,11 +58,7 @@ type PolicySpec struct {
 	CatchUp    string `yaml:"catch_up,omitempty" json:"catch_up,omitempty"`
 	Overlap    string `yaml:"overlap,omitempty" json:"overlap,omitempty"`
 }
-type EffectiveLaunch struct {
-	LaunchSpec
-	ApprovalProductMode string `json:"approval_product_mode"`
-	ApprovalDriverMode  string `json:"approval_driver_mode"`
-}
+type EffectiveLaunch = launchcontract.UnattendedLaunchSpec
 type Snapshot struct {
 	APIVersion         string          `json:"api_version"`
 	DefinitionRevision int             `json:"definition_revision,omitempty"`
@@ -106,7 +103,8 @@ func ValidateDefinition(s *DefinitionSpec) error {
 	if strings.TrimSpace(s.Prompt) == "" {
 		return errors.New("prompt is required")
 	}
-	if strings.TrimSpace(s.Launch.Driver) == "" {
+	s.Launch.Driver = strings.TrimSpace(strings.ToLower(s.Launch.Driver))
+	if s.Launch.Driver == "" {
 		return errors.New("launch.driver is required")
 	}
 	switch s.Location.Type {
@@ -291,16 +289,25 @@ func ParsePullRequestURL(raw string) (host, owner, repository string, number int
 }
 
 func Effective(spec DefinitionSpec, revision int) (Snapshot, error) {
-	mode := ""
+	mode := launchcontract.ApprovalAuto
 	switch strings.ToLower(spec.Launch.Driver) {
 	case "codex":
-		mode = "auto_review"
-	case "claude":
-		mode = "auto"
-	default:
-		mode = "auto"
+		mode = launchcontract.ApprovalAutoReview
 	}
-	return Snapshot{APIVersion: APIVersion, DefinitionRevision: revision, Prompt: spec.Prompt, Launch: EffectiveLaunch{LaunchSpec: spec.Launch, ApprovalProductMode: "auto", ApprovalDriverMode: mode}, Location: spec.Location, Policy: spec.Policy}, nil
+	launch := EffectiveLaunch{
+		Agent:               spec.Launch.Driver,
+		Model:               spec.Launch.Model,
+		Effort:              spec.Launch.Effort,
+		Executable:          spec.Launch.Executable,
+		ApprovalProductMode: launchcontract.ApprovalAuto,
+		ApprovalDriverMode:  mode,
+		DirectoryTrust:      launchcontract.TrustConfiguredDirectory,
+		Recovery:            launchcontract.RecoveryAdoptOrRestartFresh,
+	}
+	if err := launch.Validate(); err != nil {
+		return Snapshot{}, err
+	}
+	return Snapshot{APIVersion: APIVersion, DefinitionRevision: revision, Prompt: spec.Prompt, Launch: launch, Location: spec.Location, Policy: spec.Policy}, nil
 }
 
 type DeliveryIDs struct{ TicketID, SessionID, WorkspaceID, PaneID string }

--- a/internal/automation/automation_test.go
+++ b/internal/automation/automation_test.go
@@ -67,7 +67,31 @@ policy: {continuity: fresh}
 	if snapshot.Launch.ApprovalProductMode != "auto" || snapshot.Launch.ApprovalDriverMode != "auto_review" {
 		t.Fatalf("effective launch=%#v", snapshot.Launch)
 	}
+	if snapshot.Launch.Agent != "codex" || snapshot.Launch.DirectoryTrust != "configured_directory" || snapshot.Launch.Recovery != "adopt_or_restart_fresh" {
+		t.Fatalf("effective unattended contract=%#v", snapshot.Launch)
+	}
 	_ = os.RemoveAll(dir)
+}
+
+func TestDefinitionCanonicalizesLaunchDriver(t *testing.T) {
+	dir := t.TempDir()
+	raw := strings.ReplaceAll(`api_version: attn.dev/automations/v1alpha1
+id: canonical-driver
+name: Canonical driver
+enabled: true
+trigger: {type: manual}
+prompt: Inspect.
+launch: {driver: " CoDeX "}
+location: {type: directory, path: PATH}
+policy: {continuity: fresh}
+`, `PATH`, dir)
+	spec, canonical, err := ParseDefinitionYAML([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Launch.Driver != "codex" || strings.Contains(string(canonical), " CoDeX ") {
+		t.Fatalf("driver=%q canonical=%s", spec.Launch.Driver, canonical)
+	}
 }
 
 func TestDefinitionRejectsUnknownFields(t *testing.T) {

--- a/internal/daemon/automations.go
+++ b/internal/daemon/automations.go
@@ -225,6 +225,10 @@ func (d *Daemon) deliverAutomationRun(ctx context.Context, run *store.Automation
 	if err := json.Unmarshal([]byte(run.SnapshotJSON), &snapshot); err != nil {
 		return err
 	}
+	snapshot.Launch = snapshot.Launch.WithLegacyDefaults()
+	if err := snapshot.Launch.Validate(); err != nil {
+		return fmt.Errorf("invalid unattended launch contract: %w", err)
+	}
 	occurrence, err := d.store.GetAutomationOccurrence(run.OccurrenceID)
 	if err != nil {
 		return err
@@ -252,7 +256,7 @@ func (d *Daemon) EnsureTicket(_ context.Context, req automation.WorkRequest) err
 	if def == nil {
 		return fmt.Errorf("definition missing")
 	}
-	_, err = d.store.EnsureAutomationTicket(store.Ticket{ID: req.IDs.TicketID, Title: def.Name, Description: req.Prompt, Status: store.TicketStatusWorking, Assignee: req.IDs.SessionID, Cwd: req.Location.Path, LastAgentID: req.Launch.Driver, AutomationRunID: req.RunID}, "automation:"+req.DefinitionID, store.TicketRoleChiefOfStaff, time.Now())
+	_, err = d.store.EnsureAutomationTicket(store.Ticket{ID: req.IDs.TicketID, Title: def.Name, Description: req.Prompt, Status: store.TicketStatusWorking, Assignee: req.IDs.SessionID, Cwd: req.Location.Path, LastAgentID: req.Launch.Agent, AutomationRunID: req.RunID}, "automation:"+req.DefinitionID, store.TicketRoleChiefOfStaff, time.Now())
 	return err
 }
 func (d *Daemon) PrepareLocation(_ context.Context, req automation.WorkRequest) (automation.PreparedLocation, error) {
@@ -335,7 +339,7 @@ func (d *Daemon) PrepareLocation(_ context.Context, req automation.WorkRequest) 
 	sessionPersisted := false
 	if d.store != nil {
 		if existing := d.store.Get(req.IDs.SessionID); existing != nil {
-			if filepath.Clean(existing.Directory) != filepath.Clean(worktree) || existing.WorkspaceID != req.IDs.WorkspaceID || string(existing.Agent) != req.Launch.Driver {
+			if filepath.Clean(existing.Directory) != filepath.Clean(worktree) || existing.WorkspaceID != req.IDs.WorkspaceID || string(existing.Agent) != req.Launch.Agent {
 				return automation.PreparedLocation{}, fmt.Errorf("persisted session does not match automation snapshot")
 			}
 			sessionPersisted = true
@@ -353,7 +357,7 @@ func (d *Daemon) PrepareLocation(_ context.Context, req automation.WorkRequest) 
 }
 
 func (d *Daemon) BindTicketLocation(_ context.Context, req automation.WorkRequest, location automation.PreparedLocation) error {
-	return d.store.SetTicketSession(req.IDs.TicketID, location.Directory, req.Launch.Driver, time.Now())
+	return d.store.SetTicketSession(req.IDs.TicketID, location.Directory, req.Launch.Agent, time.Now())
 }
 func (d *Daemon) EnsureWorkspace(_ context.Context, req automation.WorkRequest, directory string) error {
 	if existing := d.store.GetWorkspace(req.IDs.WorkspaceID); existing != nil {
@@ -386,8 +390,11 @@ func (d *Daemon) EnsurePane(_ context.Context, req automation.WorkRequest) error
 	return nil
 }
 func (d *Daemon) EnsureSession(_ context.Context, req automation.WorkRequest, directory string) error {
+	if err := req.Launch.Validate(); err != nil {
+		return fmt.Errorf("invalid unattended launch contract: %w", err)
+	}
 	if existing := d.store.Get(req.IDs.SessionID); existing != nil {
-		if filepath.Clean(existing.Directory) != filepath.Clean(directory) || existing.WorkspaceID != req.IDs.WorkspaceID || string(existing.Agent) != req.Launch.Driver {
+		if filepath.Clean(existing.Directory) != filepath.Clean(directory) || existing.WorkspaceID != req.IDs.WorkspaceID || string(existing.Agent) != req.Launch.Agent {
 			return fmt.Errorf("persisted session does not match automation snapshot")
 		}
 		// Startup PTY recovery only adopts a still-live worker; it never respawns
@@ -408,7 +415,7 @@ func (d *Daemon) EnsureSession(_ context.Context, req automation.WorkRequest, di
 	}
 	prompt := automationSessionPrompt(req.Prompt, inputPath)
 	client := newInternalWSClient()
-	d.handleSpawnSessionWithPolicy(client, &protocol.SpawnSessionMessage{Cmd: protocol.CmdSpawnSession, ID: req.IDs.SessionID, Cwd: directory, WorkspaceID: req.IDs.WorkspaceID, Agent: req.Launch.Driver, Cols: 80, Rows: 24, Label: protocol.Ptr(filepath.Base(directory)), InitialPrompt: protocol.Ptr(prompt), Model: protocol.Ptr(req.Launch.Model), Effort: protocol.Ptr(req.Launch.Effort), Executable: protocol.Ptr(req.Launch.Executable)}, internalSpawnPolicy{autoApprove: true, trustWorkingDirectory: true})
+	d.handleSpawnSessionWithPolicy(client, &protocol.SpawnSessionMessage{Cmd: protocol.CmdSpawnSession, ID: req.IDs.SessionID, Cwd: directory, WorkspaceID: req.IDs.WorkspaceID, Agent: req.Launch.Agent, Cols: 80, Rows: 24, Label: protocol.Ptr(filepath.Base(directory)), InitialPrompt: protocol.Ptr(prompt), Model: protocol.Ptr(req.Launch.Model), Effort: protocol.Ptr(req.Launch.Effort), Executable: protocol.Ptr(req.Launch.Executable)}, internalSpawnPolicy{unattendedLaunch: req.Launch})
 	_, err = readInternalActionResult(client)
 	if err != nil {
 		return err
@@ -483,7 +490,7 @@ const codexDirectoryTrustPrompt = "Do you trust the contents of this directory?"
 // this choice. Exact screen matching keeps ordinary prompts and agent input out
 // of this path.
 func (d *Daemon) passUnattendedLaunchGate(req automation.WorkRequest) error {
-	if req.Launch.Driver != string(protocol.SessionAgentCodex) {
+	if req.Launch.Agent != string(protocol.SessionAgentCodex) {
 		return nil
 	}
 	snapshots, ok := d.ptyBackend.(interface {

--- a/internal/daemon/automations_test.go
+++ b/internal/daemon/automations_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/victorarias/attn/internal/automation"
 	attngit "github.com/victorarias/attn/internal/git"
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/store"
 )
 
@@ -188,6 +189,39 @@ func TestAutomationOccurrenceInputIsStructurallySeparateFromPrompt(t *testing.T)
 	}
 	if !strings.Contains(prompt, path) || !strings.Contains(prompt, "untrusted data") {
 		t.Fatalf("prompt does not carry the constrained data reference: %q", prompt)
+	}
+}
+
+func TestEnsureAutomationSessionPassesOneUnattendedContract(t *testing.T) {
+	directory := t.TempDir()
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	d.ptyBackend = backend
+	addTestWorkspace(d, "workspace-1", directory)
+	spec := launchcontract.UnattendedLaunchSpec{
+		Agent: "claude", Model: "sonnet", Effort: "high", Executable: "/opt/claude",
+		ApprovalProductMode: launchcontract.ApprovalAuto, ApprovalDriverMode: launchcontract.ApprovalAuto,
+		DirectoryTrust: launchcontract.TrustConfiguredDirectory, Recovery: launchcontract.RecoveryAdoptOrRestartFresh,
+	}
+	err := d.EnsureSession(context.Background(), automation.WorkRequest{
+		RunID: "run-1", Prompt: "Inspect the input.", Context: json.RawMessage(`{}`), Launch: spec,
+		IDs: automation.DeliveryIDs{SessionID: "session-1", WorkspaceID: "workspace-1"},
+	}, directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spawn, ok := backend.LastSpawn()
+	if !ok {
+		t.Fatal("automation did not spawn a session")
+	}
+	if spawn.UnattendedLaunch != spec {
+		t.Fatalf("spawn contract = %#v, want %#v", spawn.UnattendedLaunch, spec)
+	}
+	if spawn.AutoApprove || spawn.TrustWorkingDirectory || spawn.Model != "" || spawn.Effort != "" || spawn.Executable != "" {
+		t.Fatalf("parallel launch fields were populated: %#v", spawn)
+	}
+	if spawn.Agent != spec.Agent {
+		t.Fatalf("spawn agent = %q, want %q", spawn.Agent, spec.Agent)
 	}
 }
 

--- a/internal/daemon/reload.go
+++ b/internal/daemon/reload.go
@@ -294,7 +294,7 @@ func (d *Daemon) buildReloadSpawnOptions(session *protocol.Session) (ptybackend.
 		resumeSessionID = ""
 	}
 
-	return ptybackend.SpawnOptions{
+	opts := ptybackend.SpawnOptions{
 		ID:                      sessionID,
 		CWD:                     session.Directory,
 		Agent:                   agent,
@@ -320,7 +320,22 @@ func (d *Daemon) buildReloadSpawnOptions(session *protocol.Session) (ptybackend.
 		// role here to stay consistent with that RPC; non-chief sessions resolve
 		// to 0 (uncapped), matching delegated/ordinary reloads.
 		ChiefContextWindowCap: d.chiefContextWindowCap(d.isChiefOfStaffSession(sessionID)),
-	}, nil
+	}
+	if !params.UnattendedLaunch.IsZero() {
+		if err := params.UnattendedLaunch.Validate(); err != nil {
+			return ptybackend.SpawnOptions{}, fmt.Errorf("invalid recorded unattended launch contract: %w", err)
+		}
+		if !strings.EqualFold(agent, params.UnattendedLaunch.Agent) {
+			return ptybackend.SpawnOptions{}, fmt.Errorf("recorded unattended launch agent %q does not match session agent %q", params.UnattendedLaunch.Agent, agent)
+		}
+		opts.YoloMode = false
+		opts.Executable = ""
+		opts.Model = ""
+		opts.Effort = ""
+		opts.AutoApprove = false
+		opts.UnattendedLaunch = params.UnattendedLaunch
+	}
+	return opts, nil
 }
 
 type preparedPluginReload struct {

--- a/internal/daemon/reload_test.go
+++ b/internal/daemon/reload_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptybackend"
@@ -393,6 +394,31 @@ func TestBuildReloadSpawnOptionsCarriesChiefContextWindowCap(t *testing.T) {
 			t.Fatalf("ChiefContextWindowCap = %d, want 0 (non-chief reload must stay uncapped)", opts.ChiefContextWindowCap)
 		}
 	})
+}
+
+func TestBuildReloadSpawnOptionsPreservesUnattendedContractAsUnit(t *testing.T) {
+	spec := launchcontract.UnattendedLaunchSpec{
+		Agent: "codex", Model: "gpt-test", Effort: "high", Executable: "/opt/codex",
+		ApprovalProductMode: launchcontract.ApprovalAuto, ApprovalDriverMode: launchcontract.ApprovalAutoReview,
+		DirectoryTrust: launchcontract.TrustConfiguredDirectory, Recovery: launchcontract.RecoveryAdoptOrRestartFresh,
+	}
+	backend := &fakeReloadBackend{params: ptybackend.SessionLaunchParams{
+		Recorded: true, YoloMode: true, Model: "stale-model", Effort: "low", UnattendedLaunch: spec,
+	}}
+	d := newReloadTestDaemon(t, backend)
+	addReloadSession(d, "automation", protocol.SessionAgentCodex, protocol.SessionStateWorking)
+	d.store.SetSetting(SettingAutoApproveEnabled, "false")
+
+	opts, err := d.buildReloadSpawnOptions(d.store.Get("automation"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(opts.UnattendedLaunch, spec) {
+		t.Fatalf("reloaded contract = %#v, want %#v", opts.UnattendedLaunch, spec)
+	}
+	if opts.YoloMode || opts.AutoApprove || opts.Model != "" || opts.Effort != "" || opts.Executable != "" {
+		t.Fatalf("parallel launch fields survived reload: %#v", opts)
+	}
 }
 
 func TestReloadSessionAgentSkipsWhenNoLiveWorker(t *testing.T) {

--- a/internal/daemon/ws_pty.go
+++ b/internal/daemon/ws_pty.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	agentdriver "github.com/victorarias/attn/internal/agent"
 	"github.com/victorarias/attn/internal/git"
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/protocol"
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptybackend"
@@ -461,8 +462,7 @@ func buildSpawnSessionRecord(msg *protocol.SpawnSessionMessage, agent, cwd, labe
 }
 
 type internalSpawnPolicy struct {
-	autoApprove           bool
-	trustWorkingDirectory bool
+	unattendedLaunch launchcontract.UnattendedLaunchSpec
 }
 
 func (d *Daemon) handleSpawnSession(client *wsClient, msg *protocol.SpawnSessionMessage) {
@@ -598,8 +598,7 @@ func (d *Daemon) handleSpawnSessionWithPolicy(client *wsClient, msg *protocol.Sp
 		LoginShellEnv:     d.cachedLoginShellEnv(),
 
 		WorkflowGuidanceEnabled: parseBooleanSetting(d.store.GetSetting(SettingWorkflowsEnabled)),
-		AutoApprove:             parseBooleanSetting(d.store.GetSetting(SettingAutoApproveEnabled)) || policy.autoApprove,
-		TrustWorkingDirectory:   policy.trustWorkingDirectory,
+		AutoApprove:             parseBooleanSetting(d.store.GetSetting(SettingAutoApproveEnabled)),
 		Model:                   strings.TrimSpace(protocol.Deref(msg.Model)),
 		Effort:                  strings.TrimSpace(protocol.Deref(msg.Effort)),
 	}
@@ -632,6 +631,28 @@ func (d *Daemon) handleSpawnSessionWithPolicy(client *wsClient, msg *protocol.Sp
 		// No per-spawn pin (delegation); a chief launch falls back to the
 		// chief_effort_<agent> setting.
 		spawnOpts.Effort = d.chiefLaunchEffort(agent, isChief)
+	}
+	if launch := policy.unattendedLaunch; !launch.IsZero() {
+		if err := launch.Validate(); err != nil {
+			d.sendSpawnFailure(client, msg.ID, err)
+			return
+		}
+		if !strings.EqualFold(agent, launch.Agent) {
+			d.sendSpawnFailure(client, msg.ID, fmt.Errorf("unattended launch agent %q does not match spawn agent %q", launch.Agent, agent))
+			return
+		}
+		if strings.TrimSpace(protocol.Deref(msg.Model)) != strings.TrimSpace(launch.Model) ||
+			strings.TrimSpace(protocol.Deref(msg.Effort)) != strings.TrimSpace(launch.Effort) ||
+			strings.TrimSpace(configuredExecutable) != strings.TrimSpace(launch.Executable) {
+			d.sendSpawnFailure(client, msg.ID, errors.New("spawn message disagrees with unattended launch contract"))
+			return
+		}
+		spawnOpts.AutoApprove = false
+		spawnOpts.TrustWorkingDirectory = false
+		spawnOpts.Model = ""
+		spawnOpts.Effort = ""
+		spawnOpts.Executable = ""
+		spawnOpts.UnattendedLaunch = launch
 	}
 	// A chief launch caps its context window (chief_context_window_cap); non-chief
 	// launches stay uncapped so delegated interactive agents are never affected.

--- a/internal/launchcontract/unattended.go
+++ b/internal/launchcontract/unattended.go
@@ -1,0 +1,70 @@
+package launchcontract
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	ApprovalAuto       = "auto"
+	ApprovalAutoReview = "auto_review"
+
+	TrustConfiguredDirectory = "configured_directory"
+
+	RecoveryAdoptOrRestartFresh = "adopt_or_restart_fresh"
+)
+
+// UnattendedLaunchSpec is the complete, immutable launch policy for a
+// daemon-owned unattended agent. It is copied as a value through the daemon,
+// PTY backend, worker registry, and wrapper boundary.
+type UnattendedLaunchSpec struct {
+	Agent               string `json:"driver"`
+	Model               string `json:"model,omitempty"`
+	Effort              string `json:"effort,omitempty"`
+	Executable          string `json:"executable,omitempty"`
+	ApprovalProductMode string `json:"approval_product_mode"`
+	ApprovalDriverMode  string `json:"approval_driver_mode"`
+	DirectoryTrust      string `json:"directory_trust"`
+	Recovery            string `json:"recovery"`
+}
+
+func (s UnattendedLaunchSpec) IsZero() bool {
+	return s == (UnattendedLaunchSpec{})
+}
+
+// WithLegacyDefaults upgrades Slice 1 snapshots written before directory trust
+// and restart behavior were explicit parts of the contract.
+func (s UnattendedLaunchSpec) WithLegacyDefaults() UnattendedLaunchSpec {
+	if strings.TrimSpace(s.Agent) == "" {
+		return s
+	}
+	if s.DirectoryTrust == "" {
+		s.DirectoryTrust = TrustConfiguredDirectory
+	}
+	if s.Recovery == "" {
+		s.Recovery = RecoveryAdoptOrRestartFresh
+	}
+	return s
+}
+
+func (s UnattendedLaunchSpec) Validate() error {
+	if strings.TrimSpace(s.Agent) == "" {
+		return errors.New("unattended launch agent is required")
+	}
+	if s.ApprovalProductMode != ApprovalAuto {
+		return fmt.Errorf("unsupported unattended product approval mode %q", s.ApprovalProductMode)
+	}
+	switch s.ApprovalDriverMode {
+	case ApprovalAuto, ApprovalAutoReview:
+	default:
+		return fmt.Errorf("unsupported unattended driver approval mode %q", s.ApprovalDriverMode)
+	}
+	if s.DirectoryTrust != TrustConfiguredDirectory {
+		return fmt.Errorf("unsupported unattended directory trust %q", s.DirectoryTrust)
+	}
+	if s.Recovery != RecoveryAdoptOrRestartFresh {
+		return fmt.Errorf("unsupported unattended recovery policy %q", s.Recovery)
+	}
+	return nil
+}

--- a/internal/launchcontract/unattended_test.go
+++ b/internal/launchcontract/unattended_test.go
@@ -1,0 +1,23 @@
+package launchcontract
+
+import "testing"
+
+func TestUnattendedLaunchSpecLegacyDefaults(t *testing.T) {
+	spec := UnattendedLaunchSpec{
+		Agent:               "codex",
+		ApprovalProductMode: ApprovalAuto,
+		ApprovalDriverMode:  ApprovalAutoReview,
+	}.WithLegacyDefaults()
+	if spec.DirectoryTrust != TrustConfiguredDirectory || spec.Recovery != RecoveryAdoptOrRestartFresh {
+		t.Fatalf("legacy defaults = %#v", spec)
+	}
+	if err := spec.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestUnattendedLaunchSpecRejectsIncompletePolicy(t *testing.T) {
+	if err := (UnattendedLaunchSpec{Agent: "codex"}).Validate(); err == nil {
+		t.Fatal("Validate() accepted an incomplete unattended policy")
+	}
+}

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -18,6 +18,7 @@ import (
 
 	creackpty "github.com/creack/pty"
 	agentdriver "github.com/victorarias/attn/internal/agent"
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/launchenv"
 )
 
@@ -81,6 +82,7 @@ type SpawnOptions struct {
 	Model                   string
 	Effort                  string
 	ChiefContextWindowCap   int
+	UnattendedLaunch        launchcontract.UnattendedLaunchSpec
 
 	// Theme seeds the colors the session answers OSC 10/11/12 queries with,
 	// before the child's first query — set explicitly so a spawn under a
@@ -174,6 +176,18 @@ func (m *Manager) Spawn(opts SpawnOptions) error {
 	}
 	if opts.CWD == "" {
 		return errors.New("missing cwd")
+	}
+	if !opts.UnattendedLaunch.IsZero() {
+		if err := opts.UnattendedLaunch.Validate(); err != nil {
+			return err
+		}
+		if strings.TrimSpace(strings.ToLower(opts.Agent)) != strings.TrimSpace(strings.ToLower(opts.UnattendedLaunch.Agent)) {
+			return fmt.Errorf("unattended launch agent %q does not match spawn agent %q", opts.UnattendedLaunch.Agent, opts.Agent)
+		}
+		if opts.AutoApprove || opts.TrustWorkingDirectory || strings.TrimSpace(opts.Model) != "" ||
+			strings.TrimSpace(opts.Effort) != "" || strings.TrimSpace(opts.Executable) != "" {
+			return errors.New("unattended launch policy must not be duplicated in spawn options")
+		}
 	}
 	if opts.Cols == 0 {
 		opts.Cols = 80
@@ -566,7 +580,11 @@ func buildSpawnEnv(loginShell string, opts SpawnOptions, agent, wrapperPath stri
 		"ATTN_CHIEF_AUTO_COMPACT_WINDOW",
 	}
 	if os.Getenv("ATTN_PTY_WORKER") == "1" {
-		for _, key := range launchKeys {
+		inheritedKeys := launchKeys
+		if !opts.UnattendedLaunch.IsZero() {
+			inheritedKeys = []string{"ATTN_WORKFLOW_GUIDANCE_ENABLED", "ATTN_CHIEF_AUTO_COMPACT_WINDOW"}
+		}
+		for _, key := range inheritedKeys {
 			if value, ok := os.LookupEnv(key); ok {
 				launchEnv = append(launchEnv, key+"="+value)
 			}
@@ -589,6 +607,18 @@ func buildSpawnEnv(loginShell string, opts SpawnOptions, agent, wrapperPath stri
 	}
 	if opts.ChiefContextWindowCap > 0 {
 		launchEnv = append(launchEnv, "ATTN_CHIEF_AUTO_COMPACT_WINDOW="+strconv.Itoa(opts.ChiefContextWindowCap))
+	}
+	if launch := opts.UnattendedLaunch; !launch.IsZero() {
+		launchEnv = append(launchEnv,
+			"ATTN_AUTO_APPROVE=1",
+			"ATTN_TRUST_WORKING_DIRECTORY=1",
+		)
+		if model := strings.TrimSpace(launch.Model); model != "" {
+			launchEnv = append(launchEnv, "ATTN_MODEL="+model)
+		}
+		if effort := strings.TrimSpace(launch.Effort); effort != "" {
+			launchEnv = append(launchEnv, "ATTN_EFFORT="+effort)
+		}
 	}
 
 	shellEnv := opts.LoginShellEnv
@@ -670,6 +700,9 @@ func buildSpawnEnv(loginShell string, opts SpawnOptions, agent, wrapperPath stri
 }
 
 func configuredExecutableForAgent(opts SpawnOptions, agent string) string {
+	if !opts.UnattendedLaunch.IsZero() {
+		return strings.TrimSpace(opts.UnattendedLaunch.Executable)
+	}
 	if strings.TrimSpace(opts.Executable) != "" {
 		return strings.TrimSpace(opts.Executable)
 	}

--- a/internal/pty/manager_test.go
+++ b/internal/pty/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/victorarias/attn/internal/config"
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/launchenv"
 )
 
@@ -144,6 +145,35 @@ func TestBuildSpawnEnv_EmbeddedLaunchPinsOverrideInheritedEnvironment(t *testing
 	for key, want := range map[string]string{
 		"ATTN_AUTO_APPROVE": "1", "ATTN_TRUST_WORKING_DIRECTORY": "1",
 		"ATTN_MODEL": "automation-model", "ATTN_EFFORT": "low",
+	} {
+		if got, _ := lookupEnv(env, key); got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestBuildSpawnEnv_UnattendedContractOverridesInheritedWorkerAndLoginValues(t *testing.T) {
+	t.Setenv("ATTN_PTY_WORKER", "1")
+	for key, value := range map[string]string{
+		"ATTN_AUTO_APPROVE": "parent", "ATTN_TRUST_WORKING_DIRECTORY": "parent",
+		"ATTN_MODEL": "parent-model", "ATTN_EFFORT": "medium",
+		"ATTN_WORKFLOW_GUIDANCE_ENABLED": "1", "ATTN_CHIEF_AUTO_COMPACT_WINDOW": "12345",
+	} {
+		t.Setenv(key, value)
+	}
+	spec := launchcontract.UnattendedLaunchSpec{
+		Agent: "codex", Model: "exact-model", Effort: "high",
+		ApprovalProductMode: launchcontract.ApprovalAuto, ApprovalDriverMode: launchcontract.ApprovalAutoReview,
+		DirectoryTrust: launchcontract.TrustConfiguredDirectory, Recovery: launchcontract.RecoveryAdoptOrRestartFresh,
+	}
+	env := buildSpawnEnv("", SpawnOptions{
+		ID: "session-1", UnattendedLaunch: spec,
+		LoginShellEnv: []string{"ATTN_MODEL=login-model", "ATTN_EFFORT=low", "ATTN_AUTO_APPROVE=login"},
+	}, "codex", "/tmp/attn", nil)
+	for key, want := range map[string]string{
+		"ATTN_AUTO_APPROVE": "1", "ATTN_TRUST_WORKING_DIRECTORY": "1",
+		"ATTN_MODEL": "exact-model", "ATTN_EFFORT": "high",
+		"ATTN_WORKFLOW_GUIDANCE_ENABLED": "1", "ATTN_CHIEF_AUTO_COMPACT_WINDOW": "12345",
 	} {
 		if got, _ := lookupEnv(env, key); got != want {
 			t.Fatalf("%s = %q, want %q", key, got, want)

--- a/internal/ptybackend/backend.go
+++ b/internal/ptybackend/backend.go
@@ -2,8 +2,12 @@ package ptybackend
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"syscall"
 
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/pty"
 )
 
@@ -77,6 +81,29 @@ type SpawnOptions struct {
 	// Sourced from the chief_context_window_cap setting and set only for chief
 	// launches, so non-chief sessions stay uncapped.
 	ChiefContextWindowCap int
+
+	// UnattendedLaunch is the daemon-owned launch contract. When set, it is the
+	// sole source for agent, executable, approval, trust, model, effort, and
+	// recovery policy across embedded, worker, and reload paths.
+	UnattendedLaunch launchcontract.UnattendedLaunchSpec
+}
+
+func validateUnattendedSpawnOptions(opts SpawnOptions) error {
+	launch := opts.UnattendedLaunch
+	if launch.IsZero() {
+		return nil
+	}
+	if err := launch.Validate(); err != nil {
+		return err
+	}
+	if !strings.EqualFold(strings.TrimSpace(opts.Agent), strings.TrimSpace(launch.Agent)) {
+		return fmt.Errorf("unattended launch agent %q does not match spawn agent %q", launch.Agent, opts.Agent)
+	}
+	if opts.AutoApprove || opts.TrustWorkingDirectory || strings.TrimSpace(opts.Model) != "" ||
+		strings.TrimSpace(opts.Effort) != "" || strings.TrimSpace(opts.Executable) != "" {
+		return errors.New("unattended launch policy must not be duplicated in spawn options")
+	}
+	return nil
 }
 
 type AttachInfo struct {
@@ -191,6 +218,7 @@ type SessionLaunchParams struct {
 	CopilotExecutable string
 	Model             string
 	Effort            string
+	UnattendedLaunch  launchcontract.UnattendedLaunchSpec
 }
 
 // SessionLaunchParamsProvider is implemented by backends that can return the

--- a/internal/ptybackend/embedded.go
+++ b/internal/ptybackend/embedded.go
@@ -34,7 +34,14 @@ func (b *EmbeddedBackend) SetStateHandler(handler func(sessionID, state string))
 }
 
 func (b *EmbeddedBackend) Spawn(_ context.Context, opts SpawnOptions) error {
-	return b.manager.Spawn(pty.SpawnOptions{
+	if err := validateUnattendedSpawnOptions(opts); err != nil {
+		return err
+	}
+	return b.manager.Spawn(embeddedSpawnOptions(opts))
+}
+
+func embeddedSpawnOptions(opts SpawnOptions) pty.SpawnOptions {
+	return pty.SpawnOptions{
 		ID:                opts.ID,
 		CWD:               opts.CWD,
 		Agent:             opts.Agent,
@@ -62,7 +69,8 @@ func (b *EmbeddedBackend) Spawn(_ context.Context, opts SpawnOptions) error {
 		Model:                   opts.Model,
 		Effort:                  opts.Effort,
 		ChiefContextWindowCap:   opts.ChiefContextWindowCap,
-	})
+		UnattendedLaunch:        opts.UnattendedLaunch,
+	}
 }
 
 func (b *EmbeddedBackend) Attach(_ context.Context, sessionID, subscriberID string) (AttachInfo, Stream, error) {

--- a/internal/ptybackend/unattended_test.go
+++ b/internal/ptybackend/unattended_test.go
@@ -1,0 +1,73 @@
+package ptybackend
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/victorarias/attn/internal/launchcontract"
+)
+
+func TestUnattendedLaunchContractParityAcrossBackends(t *testing.T) {
+	tests := []struct {
+		name string
+		spec launchcontract.UnattendedLaunchSpec
+	}{
+		{
+			name: "codex auto review",
+			spec: launchcontract.UnattendedLaunchSpec{
+				Agent: "codex", Model: "gpt-test", Effort: "high", Executable: "/opt/codex",
+				ApprovalProductMode: launchcontract.ApprovalAuto, ApprovalDriverMode: launchcontract.ApprovalAutoReview,
+				DirectoryTrust: launchcontract.TrustConfiguredDirectory, Recovery: launchcontract.RecoveryAdoptOrRestartFresh,
+			},
+		},
+		{
+			name: "claude auto",
+			spec: launchcontract.UnattendedLaunchSpec{
+				Agent: "claude", Model: "sonnet", Effort: "low",
+				ApprovalProductMode: launchcontract.ApprovalAuto, ApprovalDriverMode: launchcontract.ApprovalAuto,
+				DirectoryTrust: launchcontract.TrustConfiguredDirectory, Recovery: launchcontract.RecoveryAdoptOrRestartFresh,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			embedded := embeddedSpawnOptions(SpawnOptions{Agent: tt.spec.Agent, UnattendedLaunch: tt.spec})
+			if !reflect.DeepEqual(embedded.UnattendedLaunch, tt.spec) {
+				t.Fatalf("embedded contract = %#v, want %#v", embedded.UnattendedLaunch, tt.spec)
+			}
+
+			args, err := appendUnattendedLaunchArgs(nil, tt.spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(args) != 2 || args[0] != "--unattended-launch-json" {
+				t.Fatalf("worker args = %#v", args)
+			}
+			var worker launchcontract.UnattendedLaunchSpec
+			if err := json.Unmarshal([]byte(args[1]), &worker); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(worker, tt.spec) {
+				t.Fatalf("worker contract = %#v, want %#v", worker, tt.spec)
+			}
+		})
+	}
+}
+
+func TestUnattendedLaunchContractRejectsParallelPolicyFields(t *testing.T) {
+	spec := launchcontract.UnattendedLaunchSpec{
+		Agent: "codex", Model: "exact",
+		ApprovalProductMode: launchcontract.ApprovalAuto, ApprovalDriverMode: launchcontract.ApprovalAutoReview,
+		DirectoryTrust: launchcontract.TrustConfiguredDirectory, Recovery: launchcontract.RecoveryAdoptOrRestartFresh,
+	}
+	for _, opts := range []SpawnOptions{
+		{Agent: "codex", UnattendedLaunch: spec, Model: "duplicate"},
+		{Agent: "codex", UnattendedLaunch: spec, AutoApprove: true},
+		{Agent: "codex", UnattendedLaunch: spec, TrustWorkingDirectory: true},
+	} {
+		if err := validateUnattendedSpawnOptions(opts); err == nil {
+			t.Fatalf("accepted parallel unattended policy fields: %#v", opts)
+		}
+	}
+}

--- a/internal/ptybackend/worker.go
+++ b/internal/ptybackend/worker.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/pty"
 	"github.com/victorarias/attn/internal/ptyworker"
 )
@@ -413,6 +414,10 @@ func (b *WorkerBackend) spawnArgs(opts SpawnOptions, session *workerSession) ([]
 		}
 		args = append(args, "--external-command-json", string(encoded))
 	}
+	args, err := appendUnattendedLaunchArgs(args, opts.UnattendedLaunch)
+	if err != nil {
+		return nil, err
+	}
 	if opts.ExternalCWD != "" {
 		args = append(args, "--external-cwd", opts.ExternalCWD)
 	}
@@ -420,6 +425,9 @@ func (b *WorkerBackend) spawnArgs(opts SpawnOptions, session *workerSession) ([]
 }
 
 func (b *WorkerBackend) Spawn(ctx context.Context, opts SpawnOptions) error {
+	if err := validateUnattendedSpawnOptions(opts); err != nil {
+		return err
+	}
 	if err := validateSessionID(opts.ID); err != nil {
 		return err
 	}
@@ -580,6 +588,20 @@ func (b *WorkerBackend) Spawn(ctx context.Context, opts SpawnOptions) error {
 		return errors.New("worker exited before ready")
 	}
 	return fmt.Errorf("worker did not become ready: %w", lastErr)
+}
+
+func appendUnattendedLaunchArgs(args []string, launch launchcontract.UnattendedLaunchSpec) ([]string, error) {
+	if launch.IsZero() {
+		return args, nil
+	}
+	if err := launch.Validate(); err != nil {
+		return nil, err
+	}
+	encoded, err := json.Marshal(launch)
+	if err != nil {
+		return nil, fmt.Errorf("encode unattended launch contract: %w", err)
+	}
+	return append(args, "--unattended-launch-json", string(encoded)), nil
 }
 
 func withoutEnvironmentKeys(env []string, keys ...string) []string {
@@ -1027,6 +1049,7 @@ func (b *WorkerBackend) SessionLaunchParams(ctx context.Context, sessionID strin
 		CopilotExecutable: entry.CopilotExecutable,
 		Model:             entry.Model,
 		Effort:            entry.Effort,
+		UnattendedLaunch:  entry.UnattendedLaunch,
 	}, nil
 }
 

--- a/internal/ptybackend/worker_test.go
+++ b/internal/ptybackend/worker_test.go
@@ -26,10 +26,12 @@ func TestWithoutEnvironmentKeysRemovesInheritedLaunchPins(t *testing.T) {
 
 	got := withoutEnvironmentKeys([]string{
 		"PATH=/bin",
+		"ATTN_AUTO_APPROVE=inherited",
+		"ATTN_TRUST_WORKING_DIRECTORY=inherited",
 		"ATTN_MODEL=inherited",
 		"ATTN_EFFORT=medium",
 		"ATTN_MODEL=duplicate",
-	}, "ATTN_MODEL", "ATTN_EFFORT")
+	}, "ATTN_AUTO_APPROVE", "ATTN_TRUST_WORKING_DIRECTORY", "ATTN_MODEL", "ATTN_EFFORT")
 	want := []string{"PATH=/bin"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("withoutEnvironmentKeys() = %#v, want %#v", got, want)

--- a/internal/ptyworker/registry.go
+++ b/internal/ptyworker/registry.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/victorarias/attn/internal/launchcontract"
 )
 
 type RegistryEntry struct {
@@ -31,14 +33,15 @@ type RegistryEntry struct {
 	// which hard-requires Version==1, keeps accepting the entry); when it is false
 	// the daemon must NOT trust yolo, executable, model, or effort and must abort
 	// the reload rather than respawn with defaulted launch flags.
-	LaunchParamsRecorded bool   `json:"launch_params_recorded,omitempty"`
-	YoloMode             bool   `json:"yolo_mode,omitempty"`
-	Executable           string `json:"executable,omitempty"`
-	ClaudeExecutable     string `json:"claude_executable,omitempty"`
-	CodexExecutable      string `json:"codex_executable,omitempty"`
-	CopilotExecutable    string `json:"copilot_executable,omitempty"`
-	Model                string `json:"model,omitempty"`
-	Effort               string `json:"effort,omitempty"`
+	LaunchParamsRecorded bool                                `json:"launch_params_recorded,omitempty"`
+	YoloMode             bool                                `json:"yolo_mode,omitempty"`
+	Executable           string                              `json:"executable,omitempty"`
+	ClaudeExecutable     string                              `json:"claude_executable,omitempty"`
+	CodexExecutable      string                              `json:"codex_executable,omitempty"`
+	CopilotExecutable    string                              `json:"copilot_executable,omitempty"`
+	Model                string                              `json:"model,omitempty"`
+	Effort               string                              `json:"effort,omitempty"`
+	UnattendedLaunch     launchcontract.UnattendedLaunchSpec `json:"unattended_launch,omitzero"`
 }
 
 func WriteRegistryAtomic(path string, entry RegistryEntry) error {

--- a/internal/ptyworker/registry_test.go
+++ b/internal/ptyworker/registry_test.go
@@ -2,7 +2,10 @@ package ptyworker
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
+
+	"github.com/victorarias/attn/internal/launchcontract"
 )
 
 func TestWriteAndReadRegistry(t *testing.T) {
@@ -11,6 +14,11 @@ func TestWriteAndReadRegistry(t *testing.T) {
 	entry.OwnerPID = 333
 	entry.OwnerStartedAt = "2026-02-11T00:00:00Z"
 	entry.OwnerNonce = "nonce-123"
+	entry.UnattendedLaunch = launchcontract.UnattendedLaunchSpec{
+		Agent: "codex", Model: "gpt-test", Effort: "high",
+		ApprovalProductMode: launchcontract.ApprovalAuto, ApprovalDriverMode: launchcontract.ApprovalAutoReview,
+		DirectoryTrust: launchcontract.TrustConfiguredDirectory, Recovery: launchcontract.RecoveryAdoptOrRestartFresh,
+	}
 	if err := WriteRegistryAtomic(path, entry); err != nil {
 		t.Fatalf("WriteRegistryAtomic() error: %v", err)
 	}
@@ -35,5 +43,8 @@ func TestWriteAndReadRegistry(t *testing.T) {
 	}
 	if got.OwnerNonce != entry.OwnerNonce {
 		t.Fatalf("owner_nonce = %q, want %q", got.OwnerNonce, entry.OwnerNonce)
+	}
+	if !reflect.DeepEqual(got.UnattendedLaunch, entry.UnattendedLaunch) {
+		t.Fatalf("unattended launch = %#v, want %#v", got.UnattendedLaunch, entry.UnattendedLaunch)
 	}
 }

--- a/internal/ptyworker/runtime.go
+++ b/internal/ptyworker/runtime.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/victorarias/attn/internal/launchcontract"
 	"github.com/victorarias/attn/internal/pty"
 )
 
@@ -104,6 +105,7 @@ type Config struct {
 	ExternalCommand   []string
 	ExternalEnv       []string
 	ExternalCWD       string
+	UnattendedLaunch  launchcontract.UnattendedLaunchSpec
 
 	RegistryPath   string
 	SocketPath     string
@@ -296,6 +298,7 @@ func (r *Runtime) run(ctx context.Context) error {
 		ExternalCommand:   r.cfg.ExternalCommand,
 		ExternalEnv:       r.cfg.ExternalEnv,
 		ExternalCWD:       r.cfg.ExternalCWD,
+		UnattendedLaunch:  r.cfg.UnattendedLaunch,
 	}); err != nil {
 		return fmt.Errorf("spawn PTY session: %w", err)
 	}
@@ -353,8 +356,12 @@ func (r *Runtime) run(ctx context.Context) error {
 	entry.ClaudeExecutable = r.cfg.ClaudeExecutable
 	entry.CodexExecutable = r.cfg.CodexExecutable
 	entry.CopilotExecutable = r.cfg.CopilotExecutable
-	entry.Model = strings.TrimSpace(os.Getenv("ATTN_MODEL"))
-	entry.Effort = strings.TrimSpace(os.Getenv("ATTN_EFFORT"))
+	if r.cfg.UnattendedLaunch.IsZero() {
+		entry.Model = strings.TrimSpace(os.Getenv("ATTN_MODEL"))
+		entry.Effort = strings.TrimSpace(os.Getenv("ATTN_EFFORT"))
+	} else {
+		entry.UnattendedLaunch = r.cfg.UnattendedLaunch
+	}
 	if err := WriteRegistryAtomic(r.cfg.RegistryPath, entry); err != nil {
 		return err
 	}
@@ -417,6 +424,14 @@ func (r *Runtime) validate() error {
 	}
 	if strings.TrimSpace(r.cfg.CWD) == "" {
 		return errors.New("missing --cwd")
+	}
+	if !r.cfg.UnattendedLaunch.IsZero() {
+		if err := r.cfg.UnattendedLaunch.Validate(); err != nil {
+			return err
+		}
+		if !strings.EqualFold(strings.TrimSpace(r.cfg.Agent), strings.TrimSpace(r.cfg.UnattendedLaunch.Agent)) {
+			return fmt.Errorf("unattended launch agent %q does not match worker agent %q", r.cfg.UnattendedLaunch.Agent, r.cfg.Agent)
+		}
 	}
 	if strings.TrimSpace(r.cfg.RegistryPath) == "" {
 		return errors.New("missing --registry-path")


### PR DESCRIPTION
## Intent

Automation launch intent currently crosses snapshots, daemon policy, PTY backends, worker processes, and child environments through several parallel fields. That makes model, effort, approval, trust, and recovery behavior vulnerable to drift—especially after daemon restart or when the worker inherits launch variables.

This change gives unattended launches one immutable internal contract that survives every handoff and remains the sole source for contract-owned policy.

## Summary

- add `UnattendedLaunchSpec` with explicit driver, model, effort, executable, approval, directory-trust, and recovery policy
- preserve the contract through automation snapshots, daemon spawning, embedded and worker backends, worker registry persistence, and reload recovery
- reject parallel generic launch fields when an unattended contract is present
- consume contract values only at the final wrapper boundary while preserving non-contract workflow guidance and chief context limits
- canonicalize configured driver names before snapshots are persisted
- add backend parity, registry round-trip, reload, environment-isolation, and validation regressions

## Test plan

- [x] `go test ./...`
- [x] `go vet ./cmd/attn ./internal/launchcontract ./internal/automation ./internal/daemon ./internal/pty ./internal/ptybackend ./internal/ptyworker`
- [x] repository pre-commit build and Go checks
- [x] structured Codex autoreview (`gpt-5.6-terra`, high) returned no actionable findings after fixes
- [x] isolated `launchcontractqa` app passed preflight at protocol 175
- [x] live automation canonicalized a spaced/case-varied Claude driver and delivered the exact model, effort, approval, trust, and recovery contract without leaking launch-only variables to the child
- [x] worker registry stored the complete contract without duplicate legacy model or effort fields
- [x] isolated profile and smoke-test data removed afterward

## Out of scope

Truthful durable automation-run lifecycle states remain the next backlog item.
