### PR TITLE
fix(delegate): resolve worktree repo from workspace sessions, not the workspace record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   sessions move, so it could name a repository the workspace had nothing to do
   with. The repository now comes from the sessions already in that workspace,
   and a workspace whose sessions span several repositories asks for `--repo`
-  instead of silently picking one.
+  instead of silently picking one. Delegating into an existing workspace now
+  starts the branch from the repository's default branch: those sessions may sit
+  in several worktrees of one repository, and starting from whichever one the
+  daemon happened to list first was arbitrary. Pass `--from` to start elsewhere.
 - **Retried delegations no longer create duplicate agents or tickets.** `attn
   delegate` now prints a durable request and operation identity before slow
   worktree preparation, shows concise progress while it waits, and lets callers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,12 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   with. The repository now comes from the sessions already in that workspace,
   and a workspace whose sessions span several repositories asks for `--repo`
   instead of silently picking one. Delegating into an existing workspace now
-  starts the branch from the repository's default branch: those sessions may sit
-  in several worktrees of one repository, and starting from whichever one the
-  daemon happened to list first was arbitrary. Pass `--from` to start elsewhere.
+  starts the branch from the repository's default branch — `origin/<default>`
+  when it exists, so the work begins from what upstream has. Those sessions may
+  sit in several worktrees of one repository, so starting from whichever one the
+  daemon happened to list first was arbitrary, and starting from whatever the
+  main checkout had checked out was just as incidental. Pass `--from` to start
+  elsewhere.
 - **Retried delegations no longer create duplicate agents or tickets.** `attn
   delegate` now prints a durable request and operation identity before slow
   worktree preparation, shows concise progress while it waits, and lets callers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
   selected agent model and effort without changing the environment.
 
 ### Fixed
+- **Delegated worktrees no longer land in an unrelated repository.** When `attn
+  delegate --workspace <id> --worktree <branch>` ran without `--repo`, it chose
+  the repository from the workspace's recorded directory — a value that is
+  rewritten every time the workspace is registered and never updated when its
+  sessions move, so it could name a repository the workspace had nothing to do
+  with. The repository now comes from the sessions already in that workspace,
+  and a workspace whose sessions span several repositories asks for `--repo`
+  instead of silently picking one.
 - **Retried delegations no longer create duplicate agents or tickets.** `attn
   delegate` now prints a durable request and operation identity before slow
   worktree preparation, shows concise progress while it waits, and lets callers

--- a/cmd/attn/main.go
+++ b/cmd/attn/main.go
@@ -708,7 +708,8 @@ placement:
 worktree options:
   combine with any placement (current, --workspace, or --new-workspace);
   combining with --cwd creates a worktree of the repo at that directory
-  --repo <path>              main repository (defaults to the workspace repository)
+  --repo <path>              main repository (defaults to the repository the
+                             target workspace's sessions are in)
   --from <ref>               branch or ref to start from
   --worktree-path <path>     override the generated sibling path
 
@@ -2314,7 +2315,7 @@ func parseDelegateArgs(args []string) (delegateCLIArgs, error) {
 	workspaceID := fs.String("workspace", "", "place the delegated agent in an existing workspace")
 	cwd := fs.String("cwd", "", "use an existing directory in a new workspace")
 	worktreeBranch := fs.String("worktree", "", "create a worktree with this branch for the delegated session")
-	worktreeRepo := fs.String("repo", "", "main repository for --worktree (defaults to source repository)")
+	worktreeRepo := fs.String("repo", "", "main repository for --worktree (defaults to the target's session repository)")
 	worktreeStart := fs.String("from", "", "starting ref for --worktree")
 	worktreePath := fs.String("worktree-path", "", "custom path for --worktree")
 	requestID := fs.String("request-id", "", "stable delegation request id")

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -135,10 +135,12 @@ Worktree options:
   workspace's recorded directory. Delegation fails and asks for `--repo` when
   those sessions span more than one repository.
 - `--from <ref>` chooses the starting branch or ref. Delegating into an existing
-  workspace starts from the repository's default branch, because the workspace's
-  sessions may sit in several worktrees of that repository and none of their
-  branches is a better answer than the others. Pass `--from` to start somewhere
-  else. Other placements still start from the directory they are based on.
+  workspace starts from the repository's default branch — `origin/<default>` when
+  that exists, otherwise the local one — because the workspace's sessions may sit
+  in several worktrees of that repository and none of their branches is a better
+  answer than the others. It does not depend on what the main checkout currently
+  has checked out. Pass `--from` to start somewhere else. Other placements still
+  start from the directory they are based on.
 - `--worktree-path <path>` chooses an explicit worktree location.
 
 When running outside the source session, add `--source-session <session-id>`.

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -130,7 +130,10 @@ with any placement:
 
 Worktree options:
 
-- `--repo <path>` chooses the main repository (defaults to the workspace's repo).
+- `--repo <path>` chooses the main repository. It defaults to the repository the
+  target's existing sessions are in — the session you delegate alongside, not the
+  workspace's recorded directory. Delegation fails and asks for `--repo` when
+  those sessions span more than one repository.
 - `--from <ref>` chooses the starting branch or ref.
 - `--worktree-path <path>` chooses an explicit worktree location.
 

--- a/internal/agent/attn_skill/references/delegation.md
+++ b/internal/agent/attn_skill/references/delegation.md
@@ -134,7 +134,11 @@ Worktree options:
   target's existing sessions are in — the session you delegate alongside, not the
   workspace's recorded directory. Delegation fails and asks for `--repo` when
   those sessions span more than one repository.
-- `--from <ref>` chooses the starting branch or ref.
+- `--from <ref>` chooses the starting branch or ref. Delegating into an existing
+  workspace starts from the repository's default branch, because the workspace's
+  sessions may sit in several worktrees of that repository and none of their
+  branches is a better answer than the others. Pass `--from` to start somewhere
+  else. Other placements still start from the directory they are based on.
 - `--worktree-path <path>` chooses an explicit worktree location.
 
 When running outside the source session, add `--source-session <session-id>`.

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -324,6 +324,34 @@ func (d *Daemon) delegationWorktreeRepo(workspaceID string) (string, error) {
 	}
 }
 
+// delegationDefaultStartRef names the ref a delegated worktree starts from when
+// no working directory supplies a defensible starting point. It returns "" when
+// the repository's default branch cannot be resolved at all, leaving the caller
+// with git's own current-HEAD behaviour as a last resort.
+//
+// Prefers the remote-tracking ref, matching how the app's own new-worktree flow
+// defaults (RepoOptions.tsx), so a delegated branch starts from what upstream
+// has rather than from however stale the local checkout is; doCreateWorktree
+// fetches it before creating. Falls back to the local default branch for
+// repositories with no matching remote branch.
+func delegationDefaultStartRef(repo string) string {
+	branch, err := git.GetDefaultBranch(repo)
+	if err != nil {
+		return ""
+	}
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return ""
+	}
+	if remoteRef := "origin/" + branch; git.RefExists(repo, remoteRef) {
+		return remoteRef
+	}
+	if git.RefExists(repo, branch) {
+		return branch
+	}
+	return ""
+}
+
 // createDelegationWorktree creates the worktree. inferredRepo, when non-empty,
 // names the main repository already resolved by the caller; baseDirectory, when
 // non-empty, is a working directory the repository and the starting ref may be
@@ -386,6 +414,17 @@ func (d *Daemon) createDelegationWorktree(baseDirectory, inferredRepo string, re
 		d.delegationWorktreePrepareHook(expectedPath)
 	}
 	startingFrom := request.StartingFrom
+	if strings.TrimSpace(protocol.Deref(startingFrom)) == "" && baseDirectory == "" {
+		// No working directory whose branch could serve as a starting point, so
+		// name the repository's default branch explicitly. Leaving this empty
+		// would make `git worktree add -b` start from the main checkout's current
+		// HEAD (see starting_from in the protocol schema) — whatever that
+		// checkout happens to have checked out today, which is the same kind of
+		// ambient state this resolution exists to eliminate.
+		if ref := delegationDefaultStartRef(repo); ref != "" {
+			startingFrom = protocol.Ptr(ref)
+		}
+	}
 	if strings.TrimSpace(protocol.Deref(startingFrom)) == "" && baseDirectory != "" {
 		baseRoot, baseRootErr := git.GetRepoRoot(baseDirectory)
 		baseBranch, baseBranchErr := git.GetBranchInfo(baseDirectory)
@@ -617,9 +656,10 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 	// member sessions, which decouples the two inferences. Those sessions may sit
 	// in different worktrees of the one repository, each on its own branch, so
 	// there is no member branch that deserves to become the implicit --from.
-	// Leaving it empty falls through to the repository's own documented default
-	// (origin/main, with a local fallback) rather than a branch chosen by session
-	// ordering. An explicit --from still wins.
+	// Clearing it makes createDelegationWorktree resolve the repository's default
+	// branch explicitly (delegationDefaultStartRef) rather than a branch chosen
+	// by session ordering — and, just as importantly, rather than the main
+	// checkout's current HEAD. An explicit --from still wins.
 	worktreeStartRefBase := directory
 	inferredWorktreeRepo := ""
 	if msg.Worktree != nil && placement == delegationPlacementExisting &&

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -265,8 +265,9 @@ func verifyDelegationWorktreeOwner(worktreePath, token string) error {
 	return nil
 }
 
-// delegationWorktreeBase resolves the directory whose git repository a worktree
-// delegated into an existing workspace should branch from.
+// delegationWorktreeRepo resolves the main repository a worktree delegated into
+// an existing workspace belongs to, or "" when the workspace offers nothing to
+// infer from.
 //
 // A workspace's stored Directory is the location it was last registered at, not
 // a claim about the repositories its sessions occupy. It is overwritten on every
@@ -280,11 +281,16 @@ func verifyDelegationWorktreeOwner(worktreePath, token string) error {
 // re-derived from the real cwd on every register and spawn. When they disagree
 // on a main repository the choice is genuinely ambiguous, so fail and ask for
 // --repo rather than guess — a confusing error beats a silent misplacement.
-func (d *Daemon) delegationWorktreeBase(workspaceID, workspaceDirectory string) (string, error) {
-	firstDirectoryFor := map[string]string{}
+//
+// This deliberately answers only "which repository". Several member sessions can
+// sit in different worktrees of that one repository, each on its own branch, so
+// no member session's branch is a defensible starting point for the new one;
+// picking a representative session here would make the starting ref depend on
+// session ordering. Starting-ref selection is left to the caller (see the
+// worktreeStartRefBase comment in delegateOperation).
+func (d *Daemon) delegationWorktreeRepo(workspaceID string) (string, error) {
+	seen := map[string]struct{}{}
 	var repos []string
-	// SessionsInWorkspace orders by id, so the representative directory picked
-	// for a single-repo workspace is stable across runs.
 	for _, sessionID := range d.store.SessionsInWorkspace(workspaceID) {
 		session := d.store.Get(sessionID)
 		if session == nil || strings.TrimSpace(session.Directory) == "" {
@@ -294,21 +300,23 @@ func (d *Daemon) delegationWorktreeBase(workspaceID, workspaceDirectory string) 
 		if err != nil {
 			continue
 		}
+		// Distinct worktrees of one repository all resolve to the same main
+		// repository, so they are not an ambiguity.
 		repo := git.ResolveMainRepoPath(root)
-		if _, seen := firstDirectoryFor[repo]; seen {
+		if _, ok := seen[repo]; ok {
 			continue
 		}
-		firstDirectoryFor[repo] = session.Directory
+		seen[repo] = struct{}{}
 		repos = append(repos, repo)
 	}
 
 	switch len(repos) {
 	case 0:
-		// An empty or non-git workspace offers nothing better; fall back to the
-		// stored directory so the caller's own repo check reports it as before.
-		return workspaceDirectory, nil
+		// An empty or non-git workspace offers nothing to infer from; the caller
+		// falls back to the stored directory so its own repo check reports it.
+		return "", nil
 	case 1:
-		return firstDirectoryFor[repos[0]], nil
+		return repos[0], nil
 	default:
 		sort.Strings(repos)
 		return "", fmt.Errorf("workspace %s spans multiple repositories (%s); pass --repo to choose which one the worktree branches from",
@@ -316,12 +324,20 @@ func (d *Daemon) delegationWorktreeBase(workspaceID, workspaceDirectory string) 
 	}
 }
 
-func (d *Daemon) createDelegationWorktree(baseDirectory string, request *protocol.DelegateWorktreeRequest, operationID, ownedPath string, worktreeOwned bool, ownedToken string, allowReuse bool) (string, bool, error) {
+// createDelegationWorktree creates the worktree. inferredRepo, when non-empty,
+// names the main repository already resolved by the caller; baseDirectory, when
+// non-empty, is a working directory the repository and the starting ref may be
+// inferred from. A caller that knows the repository but has no defensible
+// starting point passes the repository alone and leaves baseDirectory empty.
+func (d *Daemon) createDelegationWorktree(baseDirectory, inferredRepo string, request *protocol.DelegateWorktreeRequest, operationID, ownedPath string, worktreeOwned bool, ownedToken string, allowReuse bool) (string, bool, error) {
 	branch := strings.TrimSpace(request.Branch)
 	if branch == "" {
 		return "", false, fmt.Errorf("worktree branch is required")
 	}
 	repo := strings.TrimSpace(protocol.Deref(request.Repo))
+	if repo == "" {
+		repo = strings.TrimSpace(inferredRepo)
+	}
 	if repo == "" {
 		repoRoot, err := git.GetRepoRoot(baseDirectory)
 		if err != nil {
@@ -370,7 +386,7 @@ func (d *Daemon) createDelegationWorktree(baseDirectory string, request *protoco
 		d.delegationWorktreePrepareHook(expectedPath)
 	}
 	startingFrom := request.StartingFrom
-	if strings.TrimSpace(protocol.Deref(startingFrom)) == "" {
+	if strings.TrimSpace(protocol.Deref(startingFrom)) == "" && baseDirectory != "" {
 		baseRoot, baseRootErr := git.GetRepoRoot(baseDirectory)
 		baseBranch, baseBranchErr := git.GetBranchInfo(baseDirectory)
 		if baseRootErr == nil &&
@@ -592,21 +608,34 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 	}
 
 	// The workspace record's directory is a registration artifact, not a repo
-	// authority (see delegationWorktreeBase). Only an existing-workspace
+	// authority (see delegationWorktreeRepo). Only an existing-workspace
 	// placement would otherwise infer a repo from it; current/new placements
-	// already base off a real session directory or an explicit --cwd.
-	worktreeBase := directory
+	// already base off a real session directory or an explicit --cwd, where that
+	// directory legitimately supplies both the repository and the starting ref.
+	//
+	// worktreeStartRefBase is cleared once the repository is known from the
+	// member sessions, which decouples the two inferences. Those sessions may sit
+	// in different worktrees of the one repository, each on its own branch, so
+	// there is no member branch that deserves to become the implicit --from.
+	// Leaving it empty falls through to the repository's own documented default
+	// (origin/main, with a local fallback) rather than a branch chosen by session
+	// ordering. An explicit --from still wins.
+	worktreeStartRefBase := directory
+	inferredWorktreeRepo := ""
 	if msg.Worktree != nil && placement == delegationPlacementExisting &&
 		strings.TrimSpace(protocol.Deref(msg.Worktree.Repo)) == "" {
-		resolvedBase, baseErr := d.delegationWorktreeBase(workspaceID, directory)
-		if baseErr != nil {
-			return nil, baseErr
+		resolvedRepo, repoErr := d.delegationWorktreeRepo(workspaceID)
+		if repoErr != nil {
+			return nil, repoErr
 		}
-		worktreeBase = resolvedBase
+		if resolvedRepo != "" {
+			inferredWorktreeRepo = resolvedRepo
+			worktreeStartRefBase = ""
+		}
 	}
 
 	if msg.Worktree != nil {
-		worktreePath, created, createErr := d.createDelegationWorktree(worktreeBase, msg.Worktree, operationID, ownedWorktreePath, worktreeOwned, worktreeToken, protocol.Deref(msg.AllowWorktreeReuse))
+		worktreePath, created, createErr := d.createDelegationWorktree(worktreeStartRefBase, inferredWorktreeRepo, msg.Worktree, operationID, ownedWorktreePath, worktreeOwned, worktreeToken, protocol.Deref(msg.AllowWorktreeReuse))
 		if createErr != nil {
 			return nil, createErr
 		}

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -367,6 +367,11 @@ func (d *Daemon) createDelegationWorktree(baseDirectory, inferredRepo string, re
 		repo = strings.TrimSpace(inferredRepo)
 	}
 	if repo == "" {
+		// Never call git with an empty directory: it would run in the daemon's own
+		// working directory and could resolve to an unrelated repository.
+		if baseDirectory == "" {
+			return "", false, fmt.Errorf("cannot determine which repository the worktree belongs to; pass --repo")
+		}
 		repoRoot, err := git.GetRepoRoot(baseDirectory)
 		if err != nil {
 			return "", false, fmt.Errorf("workspace directory is not in a git repository; pass --repo")
@@ -662,15 +667,25 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 	// checkout's current HEAD. An explicit --from still wins.
 	worktreeStartRefBase := directory
 	inferredWorktreeRepo := ""
-	if msg.Worktree != nil && placement == delegationPlacementExisting &&
-		strings.TrimSpace(protocol.Deref(msg.Worktree.Repo)) == "" {
-		resolvedRepo, repoErr := d.delegationWorktreeRepo(workspaceID)
-		if repoErr != nil {
-			return nil, repoErr
-		}
-		if resolvedRepo != "" {
+	if msg.Worktree != nil && placement == delegationPlacementExisting {
+		// Unconditionally, including when --repo is given: the workspace record's
+		// directory never supplies a starting ref for this placement. --repo
+		// selects the repository; only --from selects a non-default starting ref.
+		worktreeStartRefBase = ""
+		if strings.TrimSpace(protocol.Deref(msg.Worktree.Repo)) == "" {
+			resolvedRepo, repoErr := d.delegationWorktreeRepo(workspaceID)
+			if repoErr != nil {
+				return nil, repoErr
+			}
+			if resolvedRepo == "" {
+				// A workspace with no member sessions to learn from leaves the
+				// stored directory as the only remaining signal for *which*
+				// repository — still never for which ref.
+				if root, rootErr := git.GetRepoRoot(directory); rootErr == nil {
+					resolvedRepo = git.ResolveMainRepoPath(root)
+				}
+			}
 			inferredWorktreeRepo = resolvedRepo
-			worktreeStartRefBase = ""
 		}
 	}
 

--- a/internal/daemon/delegate.go
+++ b/internal/daemon/delegate.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -262,6 +263,57 @@ func verifyDelegationWorktreeOwner(worktreePath, token string) error {
 		return fmt.Errorf("delegation worktree owner marker does not match")
 	}
 	return nil
+}
+
+// delegationWorktreeBase resolves the directory whose git repository a worktree
+// delegated into an existing workspace should branch from.
+//
+// A workspace's stored Directory is the location it was last registered at, not
+// a claim about the repositories its sessions occupy. It is overwritten on every
+// re-registration (unlike title/rank/muted/pinned, which are deliberately
+// preserved), it is inherited wholesale when a pane is dragged out into a new
+// workspace, and it is never recomputed when a member session moves into a
+// worktree. It can therefore name a repository no member session has ever been
+// in, and trusting it here silently created worktrees in unrelated repositories.
+//
+// The member sessions are the authority instead: they carry a directory that is
+// re-derived from the real cwd on every register and spawn. When they disagree
+// on a main repository the choice is genuinely ambiguous, so fail and ask for
+// --repo rather than guess — a confusing error beats a silent misplacement.
+func (d *Daemon) delegationWorktreeBase(workspaceID, workspaceDirectory string) (string, error) {
+	firstDirectoryFor := map[string]string{}
+	var repos []string
+	// SessionsInWorkspace orders by id, so the representative directory picked
+	// for a single-repo workspace is stable across runs.
+	for _, sessionID := range d.store.SessionsInWorkspace(workspaceID) {
+		session := d.store.Get(sessionID)
+		if session == nil || strings.TrimSpace(session.Directory) == "" {
+			continue
+		}
+		root, err := git.GetRepoRoot(session.Directory)
+		if err != nil {
+			continue
+		}
+		repo := git.ResolveMainRepoPath(root)
+		if _, seen := firstDirectoryFor[repo]; seen {
+			continue
+		}
+		firstDirectoryFor[repo] = session.Directory
+		repos = append(repos, repo)
+	}
+
+	switch len(repos) {
+	case 0:
+		// An empty or non-git workspace offers nothing better; fall back to the
+		// stored directory so the caller's own repo check reports it as before.
+		return workspaceDirectory, nil
+	case 1:
+		return firstDirectoryFor[repos[0]], nil
+	default:
+		sort.Strings(repos)
+		return "", fmt.Errorf("workspace %s spans multiple repositories (%s); pass --repo to choose which one the worktree branches from",
+			workspaceID, strings.Join(repos, ", "))
+	}
 }
 
 func (d *Daemon) createDelegationWorktree(baseDirectory string, request *protocol.DelegateWorktreeRequest, operationID, ownedPath string, worktreeOwned bool, ownedToken string, allowReuse bool) (string, bool, error) {
@@ -539,8 +591,22 @@ func (d *Daemon) delegateOperation(msg *protocol.DelegateMessage, operationID, r
 		}
 	}
 
+	// The workspace record's directory is a registration artifact, not a repo
+	// authority (see delegationWorktreeBase). Only an existing-workspace
+	// placement would otherwise infer a repo from it; current/new placements
+	// already base off a real session directory or an explicit --cwd.
+	worktreeBase := directory
+	if msg.Worktree != nil && placement == delegationPlacementExisting &&
+		strings.TrimSpace(protocol.Deref(msg.Worktree.Repo)) == "" {
+		resolvedBase, baseErr := d.delegationWorktreeBase(workspaceID, directory)
+		if baseErr != nil {
+			return nil, baseErr
+		}
+		worktreeBase = resolvedBase
+	}
+
 	if msg.Worktree != nil {
-		worktreePath, created, createErr := d.createDelegationWorktree(directory, msg.Worktree, operationID, ownedWorktreePath, worktreeOwned, worktreeToken, protocol.Deref(msg.AllowWorktreeReuse))
+		worktreePath, created, createErr := d.createDelegationWorktree(worktreeBase, msg.Worktree, operationID, ownedWorktreePath, worktreeOwned, worktreeToken, protocol.Deref(msg.AllowWorktreeReuse))
 		if createErr != nil {
 			return nil, createErr
 		}

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -1829,3 +1829,120 @@ func TestDelegateWorktreeExplicitRepoOverridesWorkspaceSessions(t *testing.T) {
 		t.Fatalf("worktree directory = %q, want %q (off explicit --repo)", result.Directory, wantPath)
 	}
 }
+
+// TestDelegateWorktreeSameRepoDifferentBranchesUsesRepoDefault covers the case
+// where a workspace's member sessions sit in different worktrees of the SAME
+// main repository, each on its own branch. The repository is unambiguous, so
+// the delegation must succeed — but no member session's branch is a defensible
+// starting point, and picking a representative session would make the starting
+// ref depend on session-id ordering.
+//
+// The new branch must therefore start from the repository's default, matching
+// neither member branch, regardless of which session sorts first.
+func TestDelegateWorktreeSameRepoDifferentBranchesUsesRepoDefault(t *testing.T) {
+	root := t.TempDir()
+	repo := initDelegationRepo(t, root, "repo")
+	runGitDaemon(t, repo, "branch", "-M", "main")
+	mainHead := gitRevParseDaemon(t, repo, "HEAD")
+
+	// Two sibling worktrees of the same repo, each with its own extra commit so
+	// their heads differ from main and from each other.
+	worktreeA := filepath.Join(root, "repo--feat-a")
+	worktreeB := filepath.Join(root, "repo--feat-b")
+	runGitDaemon(t, repo, "worktree", "add", "-b", "feat/a", worktreeA)
+	runGitDaemon(t, worktreeA, "commit", "--allow-empty", "-m", "a")
+	runGitDaemon(t, repo, "worktree", "add", "-b", "feat/b", worktreeB)
+	runGitDaemon(t, worktreeB, "commit", "--allow-empty", "-m", "b")
+	headA := gitRevParseDaemon(t, worktreeA, "HEAD")
+	headB := gitRevParseDaemon(t, worktreeB, "HEAD")
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+
+	targetWorkspaceID := "workspace-target"
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        targetWorkspaceID,
+		Title:     "Target",
+		Directory: repo,
+	})
+	// "session-a" sorts before "session-b", so an ordering-dependent
+	// implementation starts the new branch from feat/a.
+	addWorkspaceSessionAt(t, d, targetWorkspaceID, "session-a", worktreeA)
+	addWorkspaceSessionAt(t, d, targetWorkspaceID, "session-b", worktreeB)
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Same repo, two branches.",
+		Placement:       protocol.Ptr(delegationPlacementExisting),
+		WorkspaceID:     protocol.Ptr(targetWorkspaceID),
+		Label:           protocol.Ptr("delegated"),
+		Worktree: &protocol.DelegateWorktreeRequest{
+			Branch: "feat/from-default",
+		},
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v, want success (repository is unambiguous)", err)
+	}
+	wantPath := git.CanonicalizePath(git.GenerateWorktreePath(repo, "feat/from-default"))
+	if result.Directory != wantPath {
+		t.Fatalf("worktree directory = %q, want %q", result.Directory, wantPath)
+	}
+
+	head := gitRevParseDaemon(t, result.Directory, "HEAD")
+	if head == headA || head == headB {
+		t.Fatalf("new branch started from a member session's branch (head %s; feat/a %s, feat/b %s); "+
+			"the starting ref must not depend on which session sorts first", head, headA, headB)
+	}
+	if head != mainHead {
+		t.Fatalf("new branch head = %s, want the repository default %s", head, mainHead)
+	}
+}
+
+// TestDelegateWorktreeExplicitFromStillWins confirms an explicit --from is
+// still honoured for an existing-workspace placement.
+func TestDelegateWorktreeExplicitFromStillWins(t *testing.T) {
+	root := t.TempDir()
+	repo := initDelegationRepo(t, root, "repo")
+	runGitDaemon(t, repo, "branch", "-M", "main")
+	worktreeA := filepath.Join(root, "repo--feat-a")
+	runGitDaemon(t, repo, "worktree", "add", "-b", "feat/a", worktreeA)
+	runGitDaemon(t, worktreeA, "commit", "--allow-empty", "-m", "a")
+	headA := gitRevParseDaemon(t, worktreeA, "HEAD")
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+
+	targetWorkspaceID := "workspace-target"
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        targetWorkspaceID,
+		Title:     "Target",
+		Directory: repo,
+	})
+	addWorkspaceSessionAt(t, d, targetWorkspaceID, "session-a", worktreeA)
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Explicit from.",
+		Placement:       protocol.Ptr(delegationPlacementExisting),
+		WorkspaceID:     protocol.Ptr(targetWorkspaceID),
+		Label:           protocol.Ptr("delegated"),
+		Worktree: &protocol.DelegateWorktreeRequest{
+			Branch:       "feat/explicit-from",
+			StartingFrom: protocol.Ptr("feat/a"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	if head := gitRevParseDaemon(t, result.Directory, "HEAD"); head != headA {
+		t.Fatalf("new branch head = %s, want feat/a head %s", head, headA)
+	}
+}

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -2027,3 +2027,81 @@ func TestDelegateWorktreePrefersRemoteDefaultBranch(t *testing.T) {
 		t.Fatalf("new branch head = %s, want origin/main %s", head, upstreamHead)
 	}
 }
+
+// TestDelegateWorktreeExplicitRepoStillUsesRepoDefault covers the same
+// contract as TestDelegateWorktreeSameRepoDifferentBranchesUsesRepoDefault,
+// but with an explicit --repo. --repo selects the repository; only --from may
+// select a non-default starting ref. The workspace's recorded directory is a
+// worktree of that same repository on a divergent branch, so an implementation
+// that keeps it as the start-ref base would inherit that branch instead.
+func TestDelegateWorktreeExplicitRepoStillUsesRepoDefault(t *testing.T) {
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	runGitDaemon(t, root, "init", "--bare", "-b", "main", origin)
+
+	repo := initDelegationRepo(t, root, "repo")
+	runGitDaemon(t, repo, "branch", "-M", "main")
+	runGitDaemon(t, repo, "remote", "add", "origin", origin)
+	runGitDaemon(t, repo, "push", "-q", "-u", "origin", "main")
+
+	// The workspace's recorded directory: a worktree of the same repository,
+	// parked on its own branch.
+	legacy := filepath.Join(root, "repo--legacy")
+	runGitDaemon(t, repo, "worktree", "add", "-b", "topic/legacy", legacy)
+	runGitDaemon(t, legacy, "commit", "--allow-empty", "-m", "legacy")
+	legacyHead := gitRevParseDaemon(t, legacy, "HEAD")
+
+	// The main checkout is parked elsewhere too, so falling through to
+	// `git worktree add -b`'s current-HEAD behaviour is also detectable.
+	runGitDaemon(t, repo, "checkout", "-q", "-b", "topic/ambient")
+	runGitDaemon(t, repo, "commit", "--allow-empty", "-m", "ambient")
+	ambientHead := gitRevParseDaemon(t, repo, "HEAD")
+
+	// Advance origin/main past the local default branch.
+	other := filepath.Join(root, "other")
+	runGitDaemon(t, root, "clone", "-q", origin, other)
+	runGitDaemon(t, other, "commit", "--allow-empty", "-m", "upstream advance")
+	runGitDaemon(t, other, "push", "-q", "origin", "main")
+	upstreamHead := gitRevParseDaemon(t, other, "HEAD")
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+
+	targetWorkspaceID := "workspace-target"
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        targetWorkspaceID,
+		Title:     "Target",
+		Directory: legacy,
+	})
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Explicit repo, default ref.",
+		Placement:       protocol.Ptr(delegationPlacementExisting),
+		WorkspaceID:     protocol.Ptr(targetWorkspaceID),
+		Label:           protocol.Ptr("delegated"),
+		Worktree: &protocol.DelegateWorktreeRequest{
+			Branch: "feat/explicit-repo-default",
+			Repo:   protocol.Ptr(repo),
+		},
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+
+	head := gitRevParseDaemon(t, result.Directory, "HEAD")
+	if head == legacyHead {
+		t.Fatalf("new branch started from the workspace directory's branch (%s); "+
+			"--repo selects the repository, not the starting ref", head)
+	}
+	if head == ambientHead {
+		t.Fatalf("new branch started from the main checkout's current HEAD (%s)", head)
+	}
+	if head != upstreamHead {
+		t.Fatalf("new branch head = %s, want origin/main %s", head, upstreamHead)
+	}
+}

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -1637,3 +1637,195 @@ func TestDelegateTruncatesLongDirectoryDefaultName(t *testing.T) {
 		t.Fatalf("delegated session = %+v, want label %q", session, wantName)
 	}
 }
+
+// initDelegationRepo creates a real git repository with one commit.
+func initDelegationRepo(t *testing.T, root, name string) string {
+	t.Helper()
+	repo := filepath.Join(root, name)
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", name, err)
+	}
+	runGitDaemon(t, repo, "init")
+	runGitDaemon(t, repo, "commit", "--allow-empty", "-m", "init")
+	return git.CanonicalizePath(repo)
+}
+
+// addWorkspaceSessionAt spawns an extra session into an existing workspace at
+// the given directory, the way a real pane in that workspace would exist.
+func addWorkspaceSessionAt(t *testing.T, d *Daemon, workspaceID, sessionID, cwd string) {
+	t.Helper()
+	client := newWorkspaceProtocolTestClient()
+	paneID := "pane-" + sessionID
+	d.handleWorkspaceLayoutAddSessionPane(client, &protocol.WorkspaceLayoutAddSessionPaneMessage{
+		Cmd:         protocol.CmdWorkspaceLayoutAddSessionPane,
+		WorkspaceID: workspaceID,
+		PaneID:      protocol.Ptr(paneID),
+		SessionID:   sessionID,
+		Title:       protocol.Ptr(sessionID),
+	})
+	expectWorkspaceLayoutActionResult(t, client, protocol.CmdWorkspaceLayoutAddSessionPane, workspaceID, paneID, true)
+	d.handleSpawnSession(client, &protocol.SpawnSessionMessage{
+		Cmd:         protocol.CmdSpawnSession,
+		ID:          sessionID,
+		Cwd:         cwd,
+		WorkspaceID: workspaceID,
+		Agent:       protocol.AgentShellValue,
+		Cols:        80,
+		Rows:        24,
+		Label:       protocol.Ptr(sessionID),
+	})
+	expectSpawnResult(t, client, sessionID, true)
+}
+
+// TestDelegateWorktreeIgnoresStaleWorkspaceDirectory is the regression test for
+// a worktree landing in the wrong repository. The target workspace holds a
+// session in repoA, but its stored directory has drifted to repoB — which is
+// what production does, since AddWorkspace overwrites directory on every
+// re-registration and never recomputes it from member sessions.
+//
+// The worktree must be created off repoA (where the workspace's session
+// actually lives), and nothing at all may appear beside repoB.
+func TestDelegateWorktreeIgnoresStaleWorkspaceDirectory(t *testing.T) {
+	root := t.TempDir()
+	repoA := initDelegationRepo(t, root, "repo-a")
+	repoB := initDelegationRepo(t, root, "repo-b")
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+
+	targetWorkspaceID := "workspace-target"
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        targetWorkspaceID,
+		Title:     "Target",
+		Directory: repoA,
+	})
+	addWorkspaceSessionAt(t, d, targetWorkspaceID, "session-target", repoA)
+	// Drift the stored directory to an unrelated repo, exactly as a
+	// re-registration does in production.
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        targetWorkspaceID,
+		Title:     "Target",
+		Directory: repoB,
+	})
+	if workspace := d.store.GetWorkspace(targetWorkspaceID); workspace == nil || workspace.Directory != repoB {
+		t.Fatalf("precondition: workspace directory = %+v, want %q", workspace, repoB)
+	}
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Work on the repo this workspace actually uses.",
+		Placement:       protocol.Ptr(delegationPlacementExisting),
+		WorkspaceID:     protocol.Ptr(targetWorkspaceID),
+		Label:           protocol.Ptr("delegated"),
+		Worktree: &protocol.DelegateWorktreeRequest{
+			Branch: "feat/right-repo",
+		},
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+
+	wantPath := git.CanonicalizePath(git.GenerateWorktreePath(repoA, "feat/right-repo"))
+	if result.Directory != wantPath {
+		t.Fatalf("worktree directory = %q, want %q (off repoA)", result.Directory, wantPath)
+	}
+	if main := git.GetMainRepoFromWorktree(result.Directory); git.CanonicalizePath(main) != repoA {
+		t.Fatalf("worktree main repo = %q, want %q", main, repoA)
+	}
+	// The decisive assertion: no worktree may exist anywhere beside repoB.
+	strayPath := git.CanonicalizePath(git.GenerateWorktreePath(repoB, "feat/right-repo"))
+	if _, statErr := os.Stat(strayPath); !os.IsNotExist(statErr) {
+		t.Fatalf("worktree created in the wrong repository at %s", strayPath)
+	}
+}
+
+// TestDelegateWorktreeAmbiguousWorkspaceRepoRequiresRepo covers the case the
+// member sessions cannot settle: they span two repositories, so there is no
+// defensible inference. Fail and name --repo rather than pick one silently.
+func TestDelegateWorktreeAmbiguousWorkspaceRepoRequiresRepo(t *testing.T) {
+	root := t.TempDir()
+	repoA := initDelegationRepo(t, root, "repo-a")
+	repoB := initDelegationRepo(t, root, "repo-b")
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+
+	targetWorkspaceID := "workspace-target"
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        targetWorkspaceID,
+		Title:     "Target",
+		Directory: repoA,
+	})
+	addWorkspaceSessionAt(t, d, targetWorkspaceID, "session-a", repoA)
+	addWorkspaceSessionAt(t, d, targetWorkspaceID, "session-b", repoB)
+
+	_, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Ambiguous repo.",
+		Placement:       protocol.Ptr(delegationPlacementExisting),
+		WorkspaceID:     protocol.Ptr(targetWorkspaceID),
+		Worktree: &protocol.DelegateWorktreeRequest{
+			Branch: "feat/ambiguous",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "pass --repo") {
+		t.Fatalf("delegate() error = %v, want an ambiguous-repository error naming --repo", err)
+	}
+	for _, repo := range []string{repoA, repoB} {
+		strayPath := git.CanonicalizePath(git.GenerateWorktreePath(repo, "feat/ambiguous"))
+		if _, statErr := os.Stat(strayPath); !os.IsNotExist(statErr) {
+			t.Fatalf("worktree created at %s despite ambiguous repository", strayPath)
+		}
+	}
+}
+
+// TestDelegateWorktreeExplicitRepoOverridesWorkspaceSessions confirms --repo
+// still wins over the inferred repository.
+func TestDelegateWorktreeExplicitRepoOverridesWorkspaceSessions(t *testing.T) {
+	root := t.TempDir()
+	repoA := initDelegationRepo(t, root, "repo-a")
+	repoB := initDelegationRepo(t, root, "repo-b")
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+
+	targetWorkspaceID := "workspace-target"
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        targetWorkspaceID,
+		Title:     "Target",
+		Directory: repoA,
+	})
+	addWorkspaceSessionAt(t, d, targetWorkspaceID, "session-target", repoA)
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Explicit repo wins.",
+		Placement:       protocol.Ptr(delegationPlacementExisting),
+		WorkspaceID:     protocol.Ptr(targetWorkspaceID),
+		Label:           protocol.Ptr("delegated"),
+		Worktree: &protocol.DelegateWorktreeRequest{
+			Repo:   protocol.Ptr(repoB),
+			Branch: "feat/explicit",
+		},
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	wantPath := git.CanonicalizePath(git.GenerateWorktreePath(repoB, "feat/explicit"))
+	if result.Directory != wantPath {
+		t.Fatalf("worktree directory = %q, want %q (off explicit --repo)", result.Directory, wantPath)
+	}
+}

--- a/internal/daemon/delegate_test.go
+++ b/internal/daemon/delegate_test.go
@@ -1837,8 +1837,12 @@ func TestDelegateWorktreeExplicitRepoOverridesWorkspaceSessions(t *testing.T) {
 // starting point, and picking a representative session would make the starting
 // ref depend on session-id ordering.
 //
-// The new branch must therefore start from the repository's default, matching
-// neither member branch, regardless of which session sorts first.
+// The new branch must therefore start from the repository's default branch,
+// matching neither member branch, regardless of which session sorts first.
+//
+// The main checkout is deliberately parked on a divergent topic branch: an
+// implementation that leaves StartingFrom empty gets `git worktree add -b`'s
+// current-HEAD behaviour, so its ambient checkout would steer the delegation.
 func TestDelegateWorktreeSameRepoDifferentBranchesUsesRepoDefault(t *testing.T) {
 	root := t.TempDir()
 	repo := initDelegationRepo(t, root, "repo")
@@ -1855,6 +1859,15 @@ func TestDelegateWorktreeSameRepoDifferentBranchesUsesRepoDefault(t *testing.T) 
 	runGitDaemon(t, worktreeB, "commit", "--allow-empty", "-m", "b")
 	headA := gitRevParseDaemon(t, worktreeA, "HEAD")
 	headB := gitRevParseDaemon(t, worktreeB, "HEAD")
+
+	// Park the main checkout somewhere other than the default branch. Nothing
+	// about the delegation may depend on this.
+	runGitDaemon(t, repo, "checkout", "-q", "-b", "topic/ambient")
+	runGitDaemon(t, repo, "commit", "--allow-empty", "-m", "ambient")
+	ambientHead := gitRevParseDaemon(t, repo, "HEAD")
+	if ambientHead == mainHead {
+		t.Fatal("precondition: main checkout HEAD must diverge from the default branch")
+	}
 
 	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
 	backend := &fakeSpawnBackend{}
@@ -1897,8 +1910,12 @@ func TestDelegateWorktreeSameRepoDifferentBranchesUsesRepoDefault(t *testing.T) 
 		t.Fatalf("new branch started from a member session's branch (head %s; feat/a %s, feat/b %s); "+
 			"the starting ref must not depend on which session sorts first", head, headA, headB)
 	}
+	if head == ambientHead {
+		t.Fatalf("new branch started from the main checkout's current HEAD (%s); "+
+			"the starting ref must not depend on what the main checkout happens to have checked out", head)
+	}
 	if head != mainHead {
-		t.Fatalf("new branch head = %s, want the repository default %s", head, mainHead)
+		t.Fatalf("new branch head = %s, want the repository default branch %s", head, mainHead)
 	}
 }
 
@@ -1944,5 +1961,69 @@ func TestDelegateWorktreeExplicitFromStillWins(t *testing.T) {
 	}
 	if head := gitRevParseDaemon(t, result.Directory, "HEAD"); head != headA {
 		t.Fatalf("new branch head = %s, want feat/a head %s", head, headA)
+	}
+}
+
+// TestDelegateWorktreePrefersRemoteDefaultBranch pins the documented preference
+// for the remote-tracking default branch: a delegated worktree should start from
+// what upstream has, not from a stale local default. The local default branch is
+// deliberately left behind origin's.
+func TestDelegateWorktreePrefersRemoteDefaultBranch(t *testing.T) {
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	runGitDaemon(t, root, "init", "--bare", "-b", "main", origin)
+
+	repo := initDelegationRepo(t, root, "repo")
+	runGitDaemon(t, repo, "branch", "-M", "main")
+	runGitDaemon(t, repo, "remote", "add", "origin", origin)
+	runGitDaemon(t, repo, "push", "-q", "-u", "origin", "main")
+	staleLocalHead := gitRevParseDaemon(t, repo, "main")
+
+	// Advance origin/main beyond the local default branch, then leave the local
+	// checkout behind. A clone elsewhere is the least contrived way to push a
+	// commit the local repo does not have.
+	other := filepath.Join(root, "other")
+	runGitDaemon(t, root, "clone", "-q", origin, other)
+	runGitDaemon(t, other, "commit", "--allow-empty", "-m", "upstream advance")
+	runGitDaemon(t, other, "push", "-q", "origin", "main")
+	upstreamHead := gitRevParseDaemon(t, other, "HEAD")
+	if upstreamHead == staleLocalHead {
+		t.Fatal("precondition: origin/main must be ahead of the local default branch")
+	}
+
+	d := NewForTesting(filepath.Join(t.TempDir(), "test.sock"))
+	backend := &fakeSpawnBackend{}
+	_, sourceSessionID, _ := setupDelegationSource(t, d, backend)
+	consumeDelegatedPrompt(t, backend)
+
+	targetWorkspaceID := "workspace-target"
+	d.handleRegisterWorkspace(nil, &protocol.RegisterWorkspaceMessage{
+		Cmd:       protocol.CmdRegisterWorkspace,
+		ID:        targetWorkspaceID,
+		Title:     "Target",
+		Directory: repo,
+	})
+	addWorkspaceSessionAt(t, d, targetWorkspaceID, "session-a", repo)
+
+	result, err := d.delegate(&protocol.DelegateMessage{
+		Cmd:             protocol.CmdDelegate,
+		SourceSessionID: sourceSessionID,
+		Brief:           "Start from upstream.",
+		Placement:       protocol.Ptr(delegationPlacementExisting),
+		WorkspaceID:     protocol.Ptr(targetWorkspaceID),
+		Label:           protocol.Ptr("delegated"),
+		Worktree: &protocol.DelegateWorktreeRequest{
+			Branch: "feat/from-upstream",
+		},
+	})
+	if err != nil {
+		t.Fatalf("delegate() error = %v", err)
+	}
+	head := gitRevParseDaemon(t, result.Directory, "HEAD")
+	if head == staleLocalHead {
+		t.Fatalf("new branch started from the stale local default branch (%s), want origin/main %s", head, upstreamHead)
+	}
+	if head != upstreamHead {
+		t.Fatalf("new branch head = %s, want origin/main %s", head, upstreamHead)
 	}
 }

--- a/internal/daemon/worktree_naming_test.go
+++ b/internal/daemon/worktree_naming_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -294,4 +295,16 @@ func canonicalPathDaemon(path string) string {
 		return filepath.Clean(resolved)
 	}
 	return filepath.Clean(path)
+}
+
+// gitRevParseDaemon resolves a revision to a full SHA in dir.
+func gitRevParseDaemon(t *testing.T, dir, rev string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", rev)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse %s in %s failed: %v", rev, dir, err)
+	}
+	return strings.TrimSpace(string(out))
 }


### PR DESCRIPTION
## Diagnosis

The framing offered three possibilities (metadata drift / wrong resolution / correct-by-design needing a loud failure). The answer is a **combination of the first two**, and it rules the third out.

**`workspaces.directory` is a registration artifact with no invariant tying it to reality.** There is exactly one SQL statement in the codebase that writes it — the `AddWorkspace` upsert in `internal/store/workspace.go:25` — and its conflict clause overwrites `directory` unconditionally:

```sql
ON CONFLICT(id) DO UPDATE SET
    title = excluded.title,
    directory = excluded.directory
```

`rank`, `muted`, and `pinned` are INSERT-only, and `title` is explicitly guarded against re-derivation (`daemon.go:2231-2241`) precisely so a rename sticks. `directory` has no such guard. On top of that:

- it is **inherited wholesale** when a pane is dragged out into a new workspace (`workspacelayout.go:719`) — from the *source workspace*, not the moved session's own directory;
- it is **never recomputed from member sessions**. The only rollup derived from members is `Status`. Creating a worktree for a session inside an existing workspace updates only the session's directory and leaves the workspace record pointing at the old path.

So it can name a repository no member session has ever been in. That is exactly the observed state — both the "exo" and "attn" workspaces stored `victor-cloud` while their sessions lived in `~/exo` and `~/projects/victor/attn` respectively.

**The resolution then trusted that field.** `delegate.go` picked the base directory per placement:

```go
case delegationPlacementCurrent:
    directory = source.Directory     // real session dir
case delegationPlacementExisting:
    directory = workspace.Directory  // <-- the drifting field
case delegationPlacementNew:
    directory = msg.Cwd; if empty -> source.Directory
```

and `createDelegationWorktree` turned that into a repo via `GetRepoRoot` + `ResolveMainRepoPath`. Only the `--workspace` path consulted the workspace record — which is why `--repo` "fixed" it and every other placement was fine.

Telling detail: the code **already knew these can diverge**. The `--from` default at `delegate.go:328` guards on `ResolveMainRepoPath(baseRoot) == ResolveMainRepoPath(repo)` before inheriting a starting branch. The repo resolution itself had no equivalent check.

Sessions, by contrast, carry a `directory` re-derived from the real cwd on every register and spawn, plus `branch`/`is_worktree`/`main_repo` from `git.GetBranchInfo`. They are the reliable authority.

## Fix

Resolve the worktree's repo from the target workspace's **member sessions**, not the workspace record. When those sessions span more than one repository the choice is genuinely ambiguous, so fail and name `--repo` rather than guess — a confusing error beats a silent misplacement.

Deliberately scoped: only the worktree repo inference under existing-workspace placement changes. Current/new placements already base off a real session directory or `--cwd`. The workspace's `directory` keeps its meaning as the workspace's home (it is the user-picked folder for app-created workspaces and feeds the recent-locations picker) — this PR just stops treating it as a claim about repositories. An empty workspace still falls back to it, since nothing better exists.

I did **not** rewrite the `directory` write path. That is a broader behavioral change across the app's workspace-creation flow, and once the sessions are authoritative for delegation the drift no longer misplaces work. Worth a separate ticket if the drift bothers us elsewhere.

## Regression coverage

`TestDelegateWorktreeIgnoresStaleWorkspaceDirectory` builds two real git repos, puts the workspace's session in repo-a, then drifts the stored directory to repo-b via a re-registration (what production actually does), and asserts the worktree is created off **repo-a** with nothing beside repo-b. It fails on `main`:

```
worktree directory = ".../repo-b--feat-right-repo", want ".../repo-a--feat-right-repo" (off repoA)
```

Plus `...AmbiguousWorkspaceRepoRequiresRepo` (multi-repo workspace errors, creates nothing) and `...ExplicitRepoOverridesWorkspaceSessions` (`--repo` still wins).

## Live verification

Throwaway `wtrepo` profile, real daemon, real WS protocol — the fixture drift was produced by an actual `register_workspace` re-registration, not a hand-written DB row:

```
workspaces:  ws-target | Target | .../live/repo-b
sessions:    s-a       | .../live/repo-a | ws-target
```

Delegating `--workspace ws-target --worktree feat/live-check` with no `--repo`:

```json
{ "directory": ".../live/repo-a--feat-live-check", "worktree_created": true }
```

`git -C repo-a worktree list` shows it registered; repo-b has only `main`. Adding a second session in repo-b and retrying gives the loud failure:

```
delegate: workspace ws-target spans multiple repositories (.../repo-a, .../repo-b);
pass --repo to choose which one the worktree branches from
```

with no directory created. Profile cleaned afterwards.

## Docs

`internal/agent/attn_skill/references/delegation.md` said `--repo` "defaults to the workspace's repo" — updated to the real contract. The two CLI help strings also disagreed with each other (`main.go:711` said "workspace repository", `main.go:2317` said "source repository"); both now match.