### PR TITLE
feat(plugins): add attn-pi driver plugin (rock 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Format: `[YYYY-MM-DD]` entries with categories: Added, Changed, Fixed, Removed.
 ## [2026-07-19]
 
 ### Added
+- **pi can run as an attn session.** The new bundled `attn-pi` plugin drives
+  the pi coding agent: create pi sessions with an optional initial prompt,
+  pin the model and thinking effort, and resume a past session with its pins
+  re-applied. Enable it with `attn plugin install-bundled attn-pi`. Requires
+  pi 0.80.10 or newer; resuming refuses to run on an older pi version than
+  the session last used.
 - **Waiting on a pull request returns as soon as something needs you.** `attn pr
   wait-ready` watches checks, reviews, and comments in one request and stops at
   the first actionable update: a failing check, a review requesting changes, a

--- a/docs/grounding/pi-plugins.md
+++ b/docs/grounding/pi-plugins.md
@@ -1,0 +1,108 @@
+# Grounding: pi plugins (driver + suite)
+
+2026-07-19, pi at v0.80.10, commit f1c587dd.
+
+## The question
+
+Three blindspots gated the first chunk of `docs/vision/pi-attn-plugins.md`:
+(1) pi's extension runtime under long-lived sessions, (2) pi's release
+cadence / pinnable API contract, (3) pi's TUI under attn's PTY geometry rules
+vs claude/codex. All three grounded 2026-07-19; none invalidates the vision.
+
+## Blindspot 1 — extension runtime
+
+- Extensions load per-session via factory `(pi: ExtensionAPI) => void|Promise<void>`;
+  discovery from `<cwd>/.pi/extensions/`, `<agentDir>/extensions/`, configured
+  paths (core/extensions/loader.ts:673-721). Module factory cached per
+  process+cwd (loader.ts:142-164); factory re-invoked with fresh
+  Extension/API on every transition (loader.ts:454-480).
+- Full teardown + re-instantiation on resume: switchSession emits
+  `session_before_switch` (cancellable) → `session_shutdown` → dispose →
+  fresh createRuntime → `session_start` reason "resume" with
+  `previousSessionFile` (agent-session-runtime.ts:193-221). Stale contexts
+  throw by design (runner.ts:539-552).
+- Persistence only via explicit session-JSONL entries: `appendEntry`
+  (LLM-invisible) / `sendMessage` (LLM-visible, `display:false` hides from
+  UI). Session file is append-only JSONL, tree-structured via `parentId`.
+- Steering is first-class: `sendUserMessage`/`sendMessage` with `deliverAs`
+  `steer`|`followUp`|`nextTurn` injects into a live streaming turn
+  (types.ts:1267-1280); `isIdle()` exists (types.ts:319); full event list
+  includes `agent_start`/`agent_end`/`turn_start`/`turn_end`/
+  `tool_execution_*`/`session_*`.
+- Extensions are full-trust in-process Node/Bun code — no sandbox,
+  unrestricted net/fs/exec. Dialing attn's unix socket is trivial.
+- Handler exceptions are contained (a throwing `tool_call` handler fails that
+  one tool call, not the session), though `tool_call`'s containment lives one
+  layer above the runner unlike other events.
+- Crash asymmetry: SIGTERM/SIGHUP/clean quit fire `session_shutdown` reason
+  "quit" before exit (interactive-mode.ts:3487-3594, pinned by regression
+  test 5080); uncaught exception exits with NO `session_shutdown`
+  (uncaughtCrash, interactive-mode.ts:3548); SIGKILL likewise. PTY exit is the
+  authoritative liveness signal.
+
+## Blindspot 2 — release cadence and pinning
+
+- 303 tags / ~247 GitHub releases since 2025-08; peak 86/month (Dec 2025), now
+  ~1-2/week; latest v0.80.10 (2026-07-16). Rolling release, 0.x, no LTS, no
+  1.0.
+- All 5 packages (`@earendil-works/pi-{agent-core,ai,coding-agent,
+  orchestrator,tui}`) version-locked; extension API types live in
+  pi-coding-agent (`src/core/extensions/types.ts`, ~1700 lines, 37 commits in
+  3 months).
+- Breaking changes every ~2-4 releases, maintainer-curated under "### Breaking
+  Changes" with migration prose (42 sections in coding-agent CHANGELOG). Ad
+  hoc compat shims soften some breaks (legacy npm-scope aliases, deprecated-
+  field projections) — best-effort, not a guarantee.
+- No extension compat mechanism whatsoever: no manifest version, no
+  load-time check. Pin exact version; gate upgrades on reading the
+  changelog; suite self-checks pi version at `session_start` and declares
+  degraded state to attn on mismatch.
+
+## Blindspot 3 — TUI under attn PTY
+
+- attn contract recap with citations: worker is the single terminal-query
+  responder (CPR from live vt10x cursor, DA1 static `ESC[?1;2c`, OSC
+  10/11/12 per-occurrence in ask order from daemon-pushed theme) —
+  internal/pty/session.go:730-935; `pty_resize` authoritative, replay
+  provisional; #537 replay-geometry race bound + #541 bottom-clip watchdog
+  are the invariants a hosted TUI must tolerate.
+- pi: custom TUI (packages/tui), no alt-screen anywhere (zero mode-1049
+  uses), differential renderer, every frame wrapped in DEC 2026 (tui.ts:
+  1286+), full clear+redraw on width/height change, self-fires SIGWINCH after
+  enabling raw mode (terminal.ts:153-156).
+- Queries: only OSC 11 once (tui.ts:1684) + kitty negotiation
+  `ESC[>7u ESC[?u ESC[c` (terminal.ts:17,225); attn's DA1 matcher
+  (session.go:872) answers the sentinel → pi falls back to modifyOtherKeys
+  deterministically. pi never sends CPR/OSC10/OSC12.
+- Open (needs the phase-2 live smoke run): resize races under a real attn
+  PTY; Kitty graphics images through vt10x snapshot/replay; behavior of the
+  unanswered `ESC[?u` in practice.
+
+## Driver pattern (opencode walkthrough)
+
+- `attn-plugin.toml` with `attn_api_version=4` hard gate
+  (internal/plugins/plugins.go:83); `driver.register` with fixed capability
+  vocabulary (internal/daemon/plugin_driver.go:165-186), response returns
+  `active_runs` for crash/restart reconciliation; `driver.spawn`/`resume`
+  return argv+env+cwd that the daemon launches in the attn-owned PTY
+  (plugin_driver.go:478-505); reports (state/stop/metadata) carry
+  `run_id`+`seq`, ownership-checked, flow through `applyState`; metadata is
+  the resume token; `driver.session_closed` on end.
+- pi simplifications vs opencode: no side-channel server/monitor/classifier
+  needed for rock 1; identity minted at spawn via `--session-id` (args.ts:108)
+  instead of opencode's SSE `session.created` dance; likely no launcher
+  script (no port/password bootstrap).
+
+## Decisions taken (Victor, 2026-07-19)
+
+- Rock 1 = pure driver, dumb state. No screen-scraping detector, no state
+  stub; declared state is rock 2.
+- Live pi-under-attn smoke run deferred to phase 2 as its opening spike.
+
+## Open questions
+
+- pi flag mapping for yolo / model+effort pins / initial prompt.
+- Exact on-disk layout `pi install local:` expects at extension-discovery
+  time (package-manager.ts resolve path not traced).
+- Daemon/UI behavior for a driver registered without `state_reporting` —
+  what the session shows day-to-day.

--- a/docs/plans/2026-07-19-pi-driver-plugin.md
+++ b/docs/plans/2026-07-19-pi-driver-plugin.md
@@ -105,25 +105,32 @@ Flag mapping (verified against pi v0.80.10 `args.ts`):
 
 ## Implementation Steps
 
-- [ ] Smoke spike (phase-2 opener): launch pi manually inside a
+- [x] Smoke spike (phase-2 opener): launch pi manually inside a
       throwaway-profile attn session; verify TUI render, OSC 11/kitty
       negotiation against the worker responder, resize behavior,
       `--session-id` create + resume round-trip, and the project-trust prompt
       flow. Capture evidence for the PR.
-- [ ] Plugin skeleton: `attn-plugin.toml`, `package.json`, `src/index.ts`
+      Done 2026-07-19 (headless, throwaway profile pismoke, shell session over daemon WS): TUI renders under the worker PTY; resize 90x24/140x40 re-flows; --session-id create + resume restores history; --model/--thinking pins apply; ctrl+d exits to shell.
+- [x] Plugin skeleton: `attn-plugin.toml`, `package.json`, `src/index.ts`
       rpc wiring (mirror attn-opencode).
-- [ ] `src/driver.ts`: availability + version floor, `driver.register`
+- [x] `src/driver.ts`: availability + version floor, `driver.register`
       (capabilities above), spawn/resume argv mapping, metadata report,
       `driver.session_closed` cleanup.
-- [ ] Unit tests: argv mapping (pins/prompt/resume), version gate incl.
+- [x] Unit tests: argv mapping (pins/prompt/resume), version gate incl.
       downgrade-on-resume refusal, malformed metadata rejection.
-- [ ] Bundling: add attn-pi to `scripts/build-bundled-plugins.sh` (bun
+      13 tests green (`bun test` in plugins/attn-pi).
+- [x] Bundling: add attn-pi to `scripts/build-bundled-plugins.sh` (bun
       compile + generated executable manifest) so
-      `attn plugin install-bundled attn-pi` works.
-- [ ] Live verification on a throwaway profile per AGENTS.md (preflight
-      first): spawn from the app UI, type a turn, quit, resume, confirm
-      session lifecycle + working/idle states.
-- [ ] CHANGELOG entry; PR includes plugins/attn-pi guidance docs and
+      `attn plugin install-bundled attn-pi` works. Also added attn-pi
+      sources to the `scripts/source-fingerprint.sh` includes.
+- [x] Live verification on a throwaway profile (pismoke, daemon built from
+      this branch): `attn plugin install-bundled attn-pi` -> driver
+      registered (agent=pi) -> spawn with effort pin -> state=working +
+      PiMetadata persisted -> real turn -> ctrl+d -> idle -> re-spawn same
+      session id -> driver.resume restored history with pins re-applied.
+      Headless over the daemon WS, not the app UI: the PR touches no
+      frontend code, and the picker is dynamic (see Open Questions).
+- [x] CHANGELOG entry; PR includes plugins/attn-pi guidance docs and
       docs/grounding/pi-plugins.md.
 
 ## Decisions
@@ -137,15 +144,18 @@ Flag mapping (verified against pi v0.80.10 `args.ts`):
   one-line change gated on reading pi's CHANGELOG.
 - Initial prompt travels as a positional argv (visible in `ps`) — same
   exposure class as existing agent launches; not worth staging machinery.
+- pi's --model flag is a fuzzy pattern, not an exact id: in the smoke run, "--model gpt-5.5" matched an azure-openai-responses provider rather than the default openai one. The driver passes the pin through verbatim; provider-qualified patterns are the user's tool if it matters.
 
 ## Open Questions
 
-- pi's project-trust prompt: does trust persist across launches per cwd, or
-  will every attn spawn re-prompt? Smoke spike answers; if it re-prompts,
-  consider `--approve` implications instead of accepting the friction.
-- Frontend: pi should appear in the agent picker automatically via
-  `broadcastSettings` on driver registration — verify in smoke; if not, a
-  small frontend follow-up is needed.
+- ~~pi's project-trust prompt~~ Resolved 2026-07-19: first launch in a fresh cwd with a fresh ~/.pi showed no trust prompt — pi went straight to the input UI.
+- ~~Frontend picker~~ Resolved 2026-07-19 in code: `driver.register`
+  broadcasts settings (`internal/daemon/plugin_driver.go:199`), the settings
+  payload publishes `pi_available=true` plus capability keys for registered
+  plugin drivers (`internal/daemon/ws_settings.go:238-243`), and the
+  frontend parses any `<agent>_available` key
+  (`app/src/utils/agentAvailability.ts`) — pi appears in the picker with no
+  frontend change.
 - `pi install local:` on-disk layout expectations (matters for rock 2's suite
   staging, not for this PR).
 

--- a/docs/plans/2026-07-19-pi-driver-plugin.md
+++ b/docs/plans/2026-07-19-pi-driver-plugin.md
@@ -1,0 +1,157 @@
+# Plan: attn-pi driver plugin (rock 1)
+
+## Why / Alignment
+
+Rock 1 of [docs/vision/pi-attn-plugins.md](../vision/pi-attn-plugins.md): pi
+launches, resumes, and lives as an attn session. Grounding evidence:
+[docs/grounding/pi-plugins.md](../grounding/pi-plugins.md).
+
+Aligned with Victor (2026-07-19):
+
+- **Pure driver, dumb state.** No `state_reporting`, no screen-scraping
+  detectors, no state stub. Sessions ride the daemon's existing
+  no-state_reporting path: created directly in `working`
+  (`internal/daemon/ws_pty.go:707,445-447`), stay `working` while pi runs,
+  close normally on exit. Declared state arrives with the pi-side suite
+  (rock 2).
+- **Capabilities:** `resume`, `initial_prompt`, `model_pin`, `effort_pin`.
+  No `yolo` (pi has no approval gate to bypass), no `launch_instructions`
+  (delegation-grade staging deferred).
+- **Version gate:** minimum supported pi version + refuse downgrade on
+  resume (opencode pattern). Exact-pin ceremony waits for rock 2, where the
+  unstable extension API actually bites; rock 1 touches only pi's stable CLI
+  surface.
+- **Single PR**, split only if it balloons past ~1k lines. The live smoke
+  spike opens implementation and its evidence rides in the PR.
+
+Deferred: state declaration, the pi-side attn suite, delegation targets,
+safety envelope, kitty-graphics replay fidelity.
+
+## Architecture Map
+
+```text
+Target (spawn):
+attn UI spawn (agent=pi)
+  -> daemon ws_pty spawn
+    -> pluginRegistry.driver("pi") -> callPlugin "driver.spawn"
+      -> attn-pi plugin (bun, plugins/attn-pi)
+        -> check pi availability + version floor (`pi --version`)
+        -> mint pi session id (uuid)
+        -> build argv: pi --session-id <id> [--model <pin>] [--thinking <effort>] [<initial prompt>]
+        -> report metadata {pi_session_id, pi_version} (daemon queues during launch)
+  -> daemon launches argv in the attn-owned PTY (worker)
+  -> session record created state=working (plugin has no state_reporting)
+
+Target (resume):
+daemon "driver.resume" with persisted metadata
+  -> validate installed pi version >= metadata.pi_version
+  -> argv: pi --session-id <same id> (+ re-applied pins)
+
+Close/exit:
+PTY child exit -> daemon close path -> "driver.session_closed" -> driver drops in-memory run tracking
+
+Tests:
+bun test (plugins/attn-pi/test)
+  -> driver with fake rpc + fake runCommand
+    -> argv mapping, version gate, resume metadata validation, session_closed
+```
+
+Plugin layout mirrors `plugins/attn-opencode`:
+
+```text
+plugins/attn-pi/
+  attn-plugin.toml        # attn_api_version = 4, bun entrypoint
+  package.json
+  AGENTS.md / CLAUDE.md   # already written (grounding capture)
+  src/index.ts            # rpc wiring: driver.spawn/resume/session_closed handlers
+  src/driver.ts           # PiDriver
+  src/attn-rpc.ts         # reuse opencode's rpc transport pattern
+  src/types.ts
+  test/
+```
+
+## Data Model / Interfaces
+
+```ts
+// resume token, persisted daemon-side via session.report_metadata,
+// handed back verbatim on driver.resume
+type PiMetadata = {
+  schema: 1;
+  pi_session_id: string;   // minted by the driver at spawn
+  pi_version: string;      // `pi --version` at spawn; resume refuses downgrade
+  model?: string;          // pinned model pattern, if any
+  thinking?: string;       // pinned thinking level, if any
+};
+```
+
+Flag mapping (verified against pi v0.80.10 `args.ts`):
+
+- attn model pin -> `--model <pattern>`
+- attn effort pin -> `--thinking <level>` (attn effort names are valid pi levels)
+- initial prompt -> positional argument (interactive mode accepts it)
+- resume -> `--session-id <id>` (creates if missing; same flag both ways)
+
+## Boundaries
+
+- The daemon owns the PTY, session records, and state; the plugin only decides
+  what argv to run.
+- The plugin must not report state, touch the PTY, or scrape screens.
+- pi owns its session files (default session dir); attn correlates via the
+  minted `--session-id`, never by reading pi's files.
+- No on-disk run registry (unlike opencode): pi needs no port/password/prompt
+  staging — everything travels as argv — and with no monitor there is nothing
+  to reattach on plugin restart. `driver.register`'s `active_runs` response is
+  acknowledged but requires no reconciliation work.
+
+## Implementation Steps
+
+- [ ] Smoke spike (phase-2 opener): launch pi manually inside a
+      throwaway-profile attn session; verify TUI render, OSC 11/kitty
+      negotiation against the worker responder, resize behavior,
+      `--session-id` create + resume round-trip, and the project-trust prompt
+      flow. Capture evidence for the PR.
+- [ ] Plugin skeleton: `attn-plugin.toml`, `package.json`, `src/index.ts`
+      rpc wiring (mirror attn-opencode).
+- [ ] `src/driver.ts`: availability + version floor, `driver.register`
+      (capabilities above), spawn/resume argv mapping, metadata report,
+      `driver.session_closed` cleanup.
+- [ ] Unit tests: argv mapping (pins/prompt/resume), version gate incl.
+      downgrade-on-resume refusal, malformed metadata rejection.
+- [ ] Bundling: add attn-pi to `scripts/build-bundled-plugins.sh` (bun
+      compile + generated executable manifest) so
+      `attn plugin install-bundled attn-pi` works.
+- [ ] Live verification on a throwaway profile per AGENTS.md (preflight
+      first): spawn from the app UI, type a turn, quit, resume, confirm
+      session lifecycle + working/idle states.
+- [ ] CHANGELOG entry; PR includes plugins/attn-pi guidance docs and
+      docs/grounding/pi-plugins.md.
+
+## Decisions
+
+- No on-disk run registry — opencode's existed for port/password/prompt
+  staging and monitor recovery; pi has none of those needs. Revisit only if
+  rock 2 requires driver-side persistence.
+- Dumb state deliberately shows `working` for the whole pi run. Accepted
+  trade-off: no attention states for pi until rock 2; no false ones either.
+- Version floor starts at the grounded version (0.80.10); raising it is a
+  one-line change gated on reading pi's CHANGELOG.
+- Initial prompt travels as a positional argv (visible in `ps`) — same
+  exposure class as existing agent launches; not worth staging machinery.
+
+## Open Questions
+
+- pi's project-trust prompt: does trust persist across launches per cwd, or
+  will every attn spawn re-prompt? Smoke spike answers; if it re-prompts,
+  consider `--approve` implications instead of accepting the friction.
+- Frontend: pi should appear in the agent picker automatically via
+  `broadcastSettings` on driver registration — verify in smoke; if not, a
+  small frontend follow-up is needed.
+- `pi install local:` on-disk layout expectations (matters for rock 2's suite
+  staging, not for this PR).
+
+## Follow-ups
+
+- Rock 2: attn citizenship — pi-side suite, session linking, declared state,
+  doorbell/nudge steering.
+- Delegation support (`launch_instructions` via `--append-system-prompt`).
+- Kitty graphics images through vt10x snapshot/replay (fidelity check).

--- a/plugins/attn-pi/AGENTS.md
+++ b/plugins/attn-pi/AGENTS.md
@@ -1,0 +1,66 @@
+# attn-pi plugin guide
+
+attn-side driver plugin for [pi](https://github.com/earendil-works/pi). Canonical
+vision: `docs/vision/pi-attn-plugins.md`. Full grounding evidence with citations:
+`docs/grounding/pi-plugins.md`. Reference implementation for the driver pattern:
+`plugins/attn-opencode`.
+
+## Pinning pi
+
+- pi is 0.x rolling-release (~1-2 releases/week), with real breaking changes
+  every few releases, documented only as prose in each package's
+  `CHANGELOG.md` under "### Breaking Changes".
+- pi has NO extension/version compat gate: an extension built against old
+  types loads silently and fails at the first missing call site. Pin the exact
+  pi version; treat upgrades as deliberate, changelog-gated events; the
+  pi-side suite must self-check the pi version at `session_start` rather than
+  assume compatibility.
+
+## pi lifecycle invariants (verified against pi source at v0.80.x)
+
+- One pi process = one live session; resume/fork/new replace the session
+  in-process, never re-exec.
+- Extension factories re-run on EVERY session transition (resume/fork/new/
+  reload); extension contexts from before a transition throw on any use. Only
+  module-scope variables survive transitions (and only until cwd changes or
+  process exit). A persistent socket must live at module scope; the factory
+  re-links, it does not re-dial.
+- `session_shutdown` fires on clean quit and SIGTERM/SIGHUP, but NOT on
+  uncaught exceptions or SIGKILL. Never treat a missing goodbye as
+  meaningful: the PTY child exit that the driver observes is the
+  authoritative liveness signal; declared state rides on top.
+- Session identity: resume keeps the same session id + JSONL file; fork mints
+  a new id with a `parentSession` header link; a plain `/new` has NO lineage
+  link. Correlation with the attn session must be re-declared on every
+  `session_start`, not inferred from files.
+- The driver mints native session identity at spawn with
+  `pi --session-id <id>` (creates if missing); resume uses the same flag.
+  Never parse pi's session picker.
+
+## pi TUI under attn's PTY (verified against pi source)
+
+- pi never uses the alternate screen, never sends CPR, and queries only OSC
+  11 (background color, once, for light/dark detection) — the worker answers
+  it from the daemon-pushed theme.
+- pi negotiates the Kitty keyboard protocol with `ESC[>7u ESC[?u ESC[c`;
+  attn's worker answers the trailing DA1, so pi deterministically falls back
+  to modifyOtherKeys. Degraded-but-correct; do not "fix" this by answering
+  kitty queries.
+- pi full-redraws on any resize under DEC 2026 synchronized output and
+  self-fires SIGWINCH at startup. Resize races are expected to self-heal;
+  live-verify before assuming otherwise.
+- Not yet live-verified: resize races under a real attn PTY, and Kitty
+  graphics images surviving vt10x snapshot/replay.
+
+## Driver pattern
+
+- Follow `plugins/attn-opencode`: `attn-plugin.toml` (`attn_api_version`
+  gate), `driver.register` with capability map, `driver.spawn`/`driver.resume`
+  returning argv+env+cwd that the daemon runs in the attn-owned PTY,
+  `session.report_metadata` as the resume token, `driver.session_closed`
+  cleanup.
+- Rock 1 is a pure driver with dumb state (no `state_reporting`); declared
+  state arrives with the pi-side attn suite (rock 2). Do not add
+  screen-scraping state detectors for pi.
+- Staging the pi-side suite uses `pi install <local-dir> -a` (non-interactive;
+  stores the absolute path, no copy).

--- a/plugins/attn-pi/CLAUDE.md
+++ b/plugins/attn-pi/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/plugins/attn-pi/README.md
+++ b/plugins/attn-pi/README.md
@@ -1,0 +1,8 @@
+# attn-pi
+
+attn driver plugin for [pi](https://github.com/earendil-works/pi): pi launches,
+resumes, and lives as an attn session. Pure driver with dumb state — the daemon
+owns the PTY and session records; this plugin only decides what argv to run.
+
+See `AGENTS.md` for the pi invariants this driver relies on and
+`docs/plans/2026-07-19-pi-driver-plugin.md` for the implementation plan.

--- a/plugins/attn-pi/attn-plugin.toml
+++ b/plugins/attn-pi/attn-plugin.toml
@@ -1,0 +1,7 @@
+name = "attn-pi"
+version = "0.1.0"
+attn_api_version = 4
+description = "pi driver for attn"
+
+[plugin]
+entrypoint = "src/index.ts"

--- a/plugins/attn-pi/package.json
+++ b/plugins/attn-pi/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "attn-pi",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "bun test"
+  }
+}

--- a/plugins/attn-pi/src/attn-rpc.ts
+++ b/plugins/attn-pi/src/attn-rpc.ts
@@ -1,0 +1,156 @@
+import { createConnection, type Socket } from "node:net";
+import { pluginAPIVersion } from "./types";
+
+type JSONRPCID = number | string;
+
+type JSONRPCRequest = {
+  jsonrpc: "2.0";
+  id: JSONRPCID;
+  method: string;
+  params?: unknown;
+};
+
+type JSONRPCResponse = {
+  jsonrpc: "2.0";
+  id: JSONRPCID;
+  result?: unknown;
+  error?: { code: number; message: string };
+};
+
+type Pending = {
+  resolve: (result: unknown) => void;
+  reject: (error: Error) => void;
+};
+
+export type RPCHandler = (params: unknown) => Promise<unknown> | unknown;
+
+export class AttnRPCClient {
+  private socket?: Socket;
+  private buffer = "";
+  private nextID = 1;
+  private readonly pending = new Map<string, Pending>();
+  private readonly handlers = new Map<string, RPCHandler>();
+
+  constructor(
+    private readonly options: {
+      socketPath: string;
+      name: string;
+      version: string;
+      generation: number;
+    },
+  ) {}
+
+  handle(method: string, handler: RPCHandler): void {
+    if (this.socket) {
+      throw new Error("register RPC handlers before connecting");
+    }
+    this.handlers.set(method, handler);
+  }
+
+  async connect(): Promise<void> {
+    if (this.socket) return;
+    const socket = await new Promise<Socket>((resolve, reject) => {
+      const candidate = createConnection({ path: this.options.socketPath });
+      candidate.once("error", reject);
+      candidate.once("connect", () => {
+        candidate.off("error", reject);
+        resolve(candidate);
+      });
+    });
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => this.consume(chunk));
+    socket.on("error", (error) => this.failPending(error));
+    socket.on("close", () => {
+      this.socket = undefined;
+      this.failPending(new Error("attn plugin socket closed"));
+    });
+    this.socket = socket;
+
+    try {
+      const result = await this.request<{ ok: boolean }>("hello", {
+        name: this.options.name,
+        version: this.options.version,
+        attn_api_version: pluginAPIVersion,
+        generation: this.options.generation,
+      });
+      if (!result.ok) throw new Error("attn rejected plugin hello");
+    } catch (error) {
+      this.close();
+      throw error;
+    }
+  }
+
+  close(): void {
+    this.socket?.destroy();
+    this.socket = undefined;
+    this.failPending(new Error("attn plugin client closed"));
+  }
+
+  request<TResult = unknown>(method: string, params?: unknown): Promise<TResult> {
+    const id = this.nextID++;
+    const result = new Promise<TResult>((resolve, reject) => {
+      this.pending.set(String(id), { resolve: (value) => resolve(value as TResult), reject });
+    });
+    try {
+      this.send({ jsonrpc: "2.0", id, method, params });
+    } catch (error) {
+      this.pending.delete(String(id));
+      throw error;
+    }
+    return result;
+  }
+
+  private consume(chunk: string): void {
+    this.buffer += chunk;
+    for (;;) {
+      const end = this.buffer.indexOf("\n");
+      if (end < 0) return;
+      const line = this.buffer.slice(0, end).trim();
+      this.buffer = this.buffer.slice(end + 1);
+      if (line === "") continue;
+      this.route(JSON.parse(line) as JSONRPCRequest | JSONRPCResponse);
+    }
+  }
+
+  private route(message: JSONRPCRequest | JSONRPCResponse): void {
+    if ("method" in message) {
+      void this.respond(message);
+      return;
+    }
+    const pending = this.pending.get(String(message.id));
+    if (!pending) return;
+    this.pending.delete(String(message.id));
+    if (message.error) {
+      pending.reject(new Error(message.error.message));
+      return;
+    }
+    pending.resolve(message.result);
+  }
+
+  private async respond(request: JSONRPCRequest): Promise<void> {
+    const handler = this.handlers.get(request.method);
+    if (!handler) {
+      this.sendError(request.id, -32601, `unknown method ${request.method}`);
+      return;
+    }
+    try {
+      this.send({ jsonrpc: "2.0", id: request.id, result: await handler(request.params) });
+    } catch (error) {
+      this.sendError(request.id, -32603, error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  private send(message: JSONRPCRequest | JSONRPCResponse): void {
+    if (!this.socket) throw new Error("attn plugin socket is not connected");
+    this.socket.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private sendError(id: JSONRPCID, code: number, message: string): void {
+    this.send({ jsonrpc: "2.0", id, error: { code, message } });
+  }
+
+  private failPending(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+}

--- a/plugins/attn-pi/src/driver.ts
+++ b/plugins/attn-pi/src/driver.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from "node:crypto";
+import type { AttnRPCClient } from "./attn-rpc";
+import {
+  compareVersion,
+  evaluatePiVersion,
+  parseStableVersion,
+  piThinkingLevels,
+  type DriverRegisterResult,
+  type DriverSpawnParams,
+  type DriverSpawnResult,
+  type PiMetadata,
+  type SessionClosedParams,
+} from "./types";
+
+export type CommandResult = { exitCode: number; stdout: string; stderr: string };
+export type RunCommand = (argv: string[]) => Promise<CommandResult>;
+
+type Availability =
+  | { ok: true; executable: string; version: string }
+  | { ok: false; message: string };
+
+const defaultRunCommand: RunCommand = async (argv) => {
+  const child = Bun.spawn(argv, { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+};
+
+export class PiDriver {
+  private readonly rpc: AttnRPCClient;
+  private readonly runCommand: RunCommand;
+  private readonly executable: string;
+  private availability: Availability = { ok: false, message: "pi availability has not been checked" };
+
+  constructor(options: { rpc: AttnRPCClient; runCommand?: RunCommand; executable?: string }) {
+    this.rpc = options.rpc;
+    this.runCommand = options.runCommand ?? defaultRunCommand;
+    this.executable = options.executable?.trim() || process.env.ATTN_PI_EXECUTABLE?.trim() || "pi";
+  }
+
+  async initialize(): Promise<void> {
+    await this.refreshAvailability();
+    if (!this.availability.ok) return;
+    const result = await this.rpc.request<DriverRegisterResult>("driver.register", {
+      agent: "pi",
+      capabilities: {
+        resume: true,
+        initial_prompt: true,
+        model_pin: true,
+        effort_pin: true,
+      },
+    });
+    if (!result.ok) throw new Error("attn rejected pi driver registration");
+    // No recovery work: this driver keeps no per-run state. Active runs keep
+    // living in their daemon-owned PTYs; resume metadata is persisted daemon-side.
+  }
+
+  health(): { ok: boolean; message: string } {
+    return this.availability.ok
+      ? { ok: true, message: `pi ${this.availability.version} is ready` }
+      : { ok: false, message: this.availability.message };
+  }
+
+  async spawn(params: DriverSpawnParams): Promise<DriverSpawnResult> {
+    const availability = await this.requireAvailability();
+    const metadata: PiMetadata = {
+      schema: 1,
+      pi_session_id: randomUUID(),
+      pi_version: availability.version,
+      model: cleanOptional(params.model),
+      thinking: thinkingFor(params.effort),
+    };
+    await this.reportMetadata(params, metadata);
+    return { argv: this.argvFor(availability.executable, metadata, params.initial_prompt), cwd: params.cwd };
+  }
+
+  async resume(params: DriverSpawnParams): Promise<DriverSpawnResult> {
+    const availability = await this.requireAvailability();
+    const previous = parsePiMetadata(params.metadata);
+    const installed = parseStableVersion(availability.version);
+    const recorded = parseStableVersion(previous.pi_version);
+    if (compareVersion(installed, recorded) < 0) {
+      throw new Error(
+        `installed pi ${installed.raw} is older than the ${recorded.raw} this session last ran on; upgrade pi or point ATTN_PI_EXECUTABLE at a matching build`,
+      );
+    }
+    const metadata: PiMetadata = {
+      schema: 1,
+      pi_session_id: previous.pi_session_id,
+      pi_version: availability.version,
+      model: cleanOptional(params.model) ?? previous.model,
+      thinking: thinkingFor(params.effort) ?? previous.thinking,
+    };
+    await this.reportMetadata(params, metadata);
+    return { argv: this.argvFor(availability.executable, metadata, undefined), cwd: params.cwd };
+  }
+
+  async sessionClosed(_params: SessionClosedParams): Promise<{ ok: true }> {
+    return { ok: true };
+  }
+
+  private argvFor(executable: string, metadata: PiMetadata, initialPrompt: string | undefined): string[] {
+    const argv = [executable, "--session-id", metadata.pi_session_id];
+    if (metadata.model) argv.push("--model", metadata.model);
+    if (metadata.thinking) argv.push("--thinking", metadata.thinking);
+    if (initialPrompt !== undefined && initialPrompt.trim() !== "") argv.push(initialPrompt);
+    return argv;
+  }
+
+  private async reportMetadata(params: DriverSpawnParams, metadata: PiMetadata): Promise<void> {
+    await this.rpc.request("session.report_metadata", {
+      session_id: requireText(params.session_id, "session_id"),
+      run_id: requireText(params.run_id, "run_id"),
+      seq: 1,
+      metadata,
+    });
+  }
+
+  private async refreshAvailability(): Promise<void> {
+    try {
+      const result = await this.runCommand([this.executable, "--version"]);
+      if (result.exitCode !== 0) throw new Error(result.stderr.trim() || `exit ${result.exitCode}`);
+      const evaluated = evaluatePiVersion(result.stdout.trim());
+      if (evaluated.kind === "invalid") throw new Error(`unrecognized pi version: ${evaluated.reason}`);
+      if (evaluated.kind === "too_old") {
+        throw new Error(`pi ${evaluated.installed.raw} is older than the minimum supported ${evaluated.minimum.raw}`);
+      }
+      this.availability = { ok: true, executable: this.executable, version: evaluated.installed.raw };
+    } catch (error) {
+      this.availability = { ok: false, message: `pi executable ${this.executable} is unavailable: ${safeError(error)}` };
+    }
+  }
+
+  private async requireAvailability(): Promise<Extract<Availability, { ok: true }>> {
+    await this.refreshAvailability();
+    if (!this.availability.ok) throw new Error(this.availability.message);
+    return this.availability;
+  }
+}
+
+export function parsePiMetadata(value: unknown): PiMetadata {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("pi session metadata must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  if (record.schema !== 1) throw new Error(`unsupported pi session metadata schema ${JSON.stringify(record.schema)}`);
+  const sessionID = record.pi_session_id;
+  if (typeof sessionID !== "string" || sessionID.trim() === "") throw new Error("pi session metadata is missing pi_session_id");
+  const version = record.pi_version;
+  if (typeof version !== "string" || version.trim() === "") throw new Error("pi session metadata is missing pi_version");
+  return {
+    schema: 1,
+    pi_session_id: sessionID.trim(),
+    pi_version: version.trim(),
+    model: cleanOptional(typeof record.model === "string" ? record.model : undefined),
+    thinking: cleanOptional(typeof record.thinking === "string" ? record.thinking : undefined),
+  };
+}
+
+function thinkingFor(effort: string | undefined): string | undefined {
+  const cleaned = cleanOptional(effort);
+  if (cleaned === undefined) return undefined;
+  if (!(piThinkingLevels as readonly string[]).includes(cleaned)) {
+    throw new Error(`unsupported pi thinking level ${JSON.stringify(cleaned)}; expected one of ${piThinkingLevels.join(", ")}`);
+  }
+  return cleaned;
+}
+
+function cleanOptional(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function requireText(value: string, field: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new Error(`${field} is required`);
+  return trimmed;
+}
+
+function safeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/plugins/attn-pi/src/index.ts
+++ b/plugins/attn-pi/src/index.ts
@@ -1,0 +1,35 @@
+import { AttnRPCClient } from "./attn-rpc";
+import { PiDriver } from "./driver";
+import type { DriverSpawnParams, SessionClosedParams } from "./types";
+
+const pluginVersion = "0.1.0";
+
+await runPlugin();
+
+async function runPlugin(): Promise<void> {
+  const socketPath = requiredEnvironment("ATTN_SOCKET_PATH");
+  const pluginName = requiredEnvironment("ATTN_PLUGIN_NAME");
+  const pluginGeneration = requiredGeneration();
+  const rpc = new AttnRPCClient({ socketPath, name: pluginName, version: pluginVersion, generation: pluginGeneration });
+  const driver = new PiDriver({ rpc });
+
+  rpc.handle("attn.health", () => driver.health());
+  rpc.handle("driver.spawn", (params) => driver.spawn(params as DriverSpawnParams));
+  rpc.handle("driver.resume", (params) => driver.resume(params as DriverSpawnParams));
+  rpc.handle("driver.session_closed", (params) => driver.sessionClosed(params as SessionClosedParams));
+
+  await rpc.connect();
+  await driver.initialize();
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function requiredGeneration(): number {
+  const value = Number(requiredEnvironment("ATTN_PLUGIN_GENERATION"));
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error("ATTN_PLUGIN_GENERATION must be a positive integer");
+  return value;
+}

--- a/plugins/attn-pi/src/types.ts
+++ b/plugins/attn-pi/src/types.ts
@@ -1,0 +1,102 @@
+export const pluginAPIVersion = 4;
+
+export type StableVersion = {
+  raw: string;
+  major: number;
+  minor: number;
+  patch: number;
+};
+
+export type VersionCompatibility =
+  | { kind: "supported"; installed: StableVersion; minimum: StableVersion }
+  | { kind: "too_old"; installed: StableVersion; minimum: StableVersion }
+  | { kind: "invalid"; raw: string; reason: string };
+
+export function parseStableVersion(value: string): StableVersion {
+  const candidate = value.trim();
+  const match = /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(candidate);
+  if (!match) {
+    throw new Error(`expected a stable MAJOR.MINOR.PATCH release, got ${candidate || "(empty)"}`);
+  }
+  const [major, minor, patch] = match.slice(1).map(Number);
+  if (![major, minor, patch].every(Number.isSafeInteger)) {
+    throw new Error(`version components must be safe integers, got ${candidate}`);
+  }
+  return { raw: `${major}.${minor}.${patch}`, major, minor, patch };
+}
+
+export function compareVersion(a: StableVersion, b: StableVersion): -1 | 0 | 1 {
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (a[key] < b[key]) return -1;
+    if (a[key] > b[key]) return 1;
+  }
+  return 0;
+}
+
+export const minimumPiVersion = parseStableVersion("0.80.10");
+
+export function evaluatePiVersion(value: string): VersionCompatibility {
+  let installed: StableVersion;
+  try {
+    installed = parseStableVersion(value);
+  } catch (error) {
+    return {
+      kind: "invalid",
+      raw: value,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+  return compareVersion(installed, minimumPiVersion) < 0
+    ? { kind: "too_old", installed, minimum: minimumPiVersion }
+    : { kind: "supported", installed, minimum: minimumPiVersion };
+}
+
+export type DriverCapabilities = Record<string, boolean>;
+
+export type ActivePluginRun = {
+  session_id: string;
+  run_id: string;
+  metadata?: unknown;
+};
+
+export type DriverRegisterResult = {
+  ok: boolean;
+  active_runs?: ActivePluginRun[];
+};
+
+export type DriverSpawnParams = {
+  session_id: string;
+  run_id: string;
+  cwd: string;
+  label?: string;
+  model?: string;
+  effort?: string;
+  initial_prompt?: string;
+  metadata?: unknown;
+};
+
+export type DriverSpawnResult = {
+  argv: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+};
+
+export type SessionClosedParams = {
+  session_id: string;
+  run_id: string;
+  reason: string;
+  exit_code?: number;
+  signal?: string;
+};
+
+// Resume token: persisted daemon-side via session.report_metadata and handed
+// back verbatim on driver.resume.
+export type PiMetadata = {
+  schema: 1;
+  pi_session_id: string;
+  pi_version: string;
+  model?: string;
+  thinking?: string;
+};
+
+export const piThinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;

--- a/plugins/attn-pi/test/driver.test.ts
+++ b/plugins/attn-pi/test/driver.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "bun:test";
+import { PiDriver, type CommandResult, type RunCommand } from "../src/driver";
+import type { DriverSpawnParams } from "../src/types";
+
+class FakeRPC {
+  readonly requests: Array<{ method: string; params: any }> = [];
+
+  async request(method: string, params: any): Promise<any> {
+    this.requests.push({ method, params });
+    if (method === "driver.register") return { ok: true, active_runs: [] };
+    return { ok: true };
+  }
+
+  handle(_method: string, _handler: unknown): void {
+    // no-op: this driver never dispatches through its own RPC handle table
+  }
+}
+
+function fakeRunCommand(overrides?: Partial<CommandResult>): RunCommand {
+  const result: CommandResult = { exitCode: 0, stdout: "0.80.10\n", stderr: "", ...overrides };
+  return async () => result;
+}
+
+function params(overrides?: Partial<DriverSpawnParams>): DriverSpawnParams {
+  return {
+    session_id: "session-1",
+    run_id: "run-1",
+    cwd: "/tmp/work",
+    ...overrides,
+  };
+}
+
+const uuidPattern = /^[0-9a-f-]{36}$/;
+
+describe("PiDriver", () => {
+  test("initialize registers the driver with agent pi and the expected capabilities", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({ rpc: rpc as any, runCommand: fakeRunCommand(), executable: "pi" });
+    await driver.initialize();
+
+    const register = rpc.requests.find((call) => call.method === "driver.register");
+    expect(register).toBeDefined();
+    expect(register?.params).toEqual({
+      agent: "pi",
+      capabilities: {
+        resume: true,
+        initial_prompt: true,
+        model_pin: true,
+        effort_pin: true,
+      },
+    });
+  });
+
+  test("initialize does not register when pi --version fails, and health reports not ok", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({
+      rpc: rpc as any,
+      runCommand: fakeRunCommand({ exitCode: 1, stdout: "", stderr: "command not found" }),
+      executable: "pi",
+    });
+    await driver.initialize();
+
+    expect(rpc.requests.find((call) => call.method === "driver.register")).toBeUndefined();
+    const health = driver.health();
+    expect(health.ok).toBe(false);
+  });
+
+  test("spawn returns a fresh session id, passes cwd through, and reports metadata", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({ rpc: rpc as any, runCommand: fakeRunCommand(), executable: "pi" });
+
+    const result = await driver.spawn(params());
+
+    expect(result.argv[0]).toBe("pi");
+    expect(result.argv[1]).toBe("--session-id");
+    const sessionID = result.argv[2];
+    expect(sessionID).toMatch(uuidPattern);
+    expect(result.argv).toEqual(["pi", "--session-id", sessionID]);
+    expect(result.cwd).toBe("/tmp/work");
+
+    const report = rpc.requests.find((call) => call.method === "session.report_metadata");
+    expect(report).toBeDefined();
+    expect(report?.params).toEqual({
+      session_id: "session-1",
+      run_id: "run-1",
+      seq: 1,
+      metadata: {
+        schema: 1,
+        pi_session_id: sessionID,
+        pi_version: "0.80.10",
+      },
+    });
+  });
+
+  test("two spawns mint distinct pi_session_ids", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({ rpc: rpc as any, runCommand: fakeRunCommand(), executable: "pi" });
+
+    const first = await driver.spawn(params({ session_id: "session-1", run_id: "run-1" }));
+    const second = await driver.spawn(params({ session_id: "session-2", run_id: "run-2" }));
+
+    expect(first.argv[2]).not.toBe(second.argv[2]);
+  });
+
+  test("spawn with model, effort, and initial_prompt composes argv and metadata", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({ rpc: rpc as any, runCommand: fakeRunCommand(), executable: "pi" });
+
+    const result = await driver.spawn(
+      params({ model: "gpt-5.5", effort: "high", initial_prompt: "do the thing" }),
+    );
+
+    const sessionID = result.argv[2];
+    expect(result.argv).toEqual(["pi", "--session-id", sessionID, "--model", "gpt-5.5", "--thinking", "high", "do the thing"]);
+
+    const report = rpc.requests.find((call) => call.method === "session.report_metadata");
+    expect(report?.params.metadata).toEqual({
+      schema: 1,
+      pi_session_id: sessionID,
+      pi_version: "0.80.10",
+      model: "gpt-5.5",
+      thinking: "high",
+    });
+  });
+
+  test("spawn with an unsupported thinking level throws, and empty effort is treated as absent", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({ rpc: rpc as any, runCommand: fakeRunCommand(), executable: "pi" });
+
+    await expect(driver.spawn(params({ effort: "sky-high" }))).rejects.toThrow(/unsupported pi thinking level/);
+
+    const result = await driver.spawn(params({ effort: "" }));
+    expect(result.argv).not.toContain("--thinking");
+  });
+
+  test("spawn refuses a pi version below the minimum supported", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({
+      rpc: rpc as any,
+      runCommand: fakeRunCommand({ stdout: "0.79.0\n" }),
+      executable: "pi",
+    });
+
+    await expect(driver.spawn(params())).rejects.toThrow(/minimum supported/);
+  });
+
+  test("resume with existing metadata and no pins reuses the pi_session_id and pins", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({ rpc: rpc as any, runCommand: fakeRunCommand(), executable: "pi" });
+
+    const result = await driver.resume(
+      params({
+        metadata: { schema: 1, pi_session_id: "abc-123", pi_version: "0.80.10", model: "m1", thinking: "low" },
+      }),
+    );
+
+    expect(result.argv).toEqual(["pi", "--session-id", "abc-123", "--model", "m1", "--thinking", "low"]);
+
+    const report = rpc.requests.find((call) => call.method === "session.report_metadata");
+    expect(report?.params.metadata).toEqual({
+      schema: 1,
+      pi_session_id: "abc-123",
+      pi_version: "0.80.10",
+      model: "m1",
+      thinking: "low",
+    });
+  });
+
+  test("resume params pins override metadata pins", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({ rpc: rpc as any, runCommand: fakeRunCommand(), executable: "pi" });
+
+    const result = await driver.resume(
+      params({
+        model: "m2",
+        effort: "max",
+        metadata: { schema: 1, pi_session_id: "abc-123", pi_version: "0.80.10", model: "m1", thinking: "low" },
+      }),
+    );
+
+    expect(result.argv).toEqual(["pi", "--session-id", "abc-123", "--model", "m2", "--thinking", "max"]);
+  });
+
+  test("resume refuses a downgrade from the recorded pi version", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({ rpc: rpc as any, runCommand: fakeRunCommand({ stdout: "0.80.10\n" }), executable: "pi" });
+
+    await expect(
+      driver.resume(
+        params({
+          metadata: { schema: 1, pi_session_id: "abc-123", pi_version: "0.81.0" },
+        }),
+      ),
+    ).rejects.toThrow(/older/);
+  });
+
+  test("resume rejects malformed metadata", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({ rpc: rpc as any, runCommand: fakeRunCommand(), executable: "pi" });
+
+    await expect(driver.resume(params({ metadata: "not-an-object" }))).rejects.toThrow();
+    await expect(driver.resume(params({ metadata: { schema: 2, pi_session_id: "abc", pi_version: "0.80.10" } }))).rejects.toThrow();
+    await expect(driver.resume(params({ metadata: { schema: 1, pi_version: "0.80.10" } }))).rejects.toThrow();
+  });
+
+  test("resume never includes an initial prompt in argv", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({ rpc: rpc as any, runCommand: fakeRunCommand(), executable: "pi" });
+
+    const result = await driver.resume(
+      params({
+        initial_prompt: "should be ignored",
+        metadata: { schema: 1, pi_session_id: "abc-123", pi_version: "0.80.10" },
+      }),
+    );
+
+    expect(result.argv).toEqual(["pi", "--session-id", "abc-123"]);
+  });
+
+  test("sessionClosed resolves ok", async () => {
+    const rpc = new FakeRPC();
+    const driver = new PiDriver({ rpc: rpc as any, runCommand: fakeRunCommand(), executable: "pi" });
+
+    await expect(driver.sessionClosed({ session_id: "session-1", run_id: "run-1", reason: "exit" })).resolves.toEqual({
+      ok: true,
+    });
+  });
+});

--- a/scripts/build-bundled-plugins.sh
+++ b/scripts/build-bundled-plugins.sh
@@ -2,33 +2,43 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-source_dir="${repo_root}/plugins/attn-opencode"
 stage_root="${1:-${repo_root}/app/src-tauri/bundled-plugins}"
-stage_dir="${stage_root}/attn-opencode"
 
-package_version="$(cd "${source_dir}" && bun -e 'console.log(require("./package.json").version)')"
-manifest_version="$(awk -F '"' '/^version = / { print $2; exit }' "${source_dir}/attn-plugin.toml")"
-runtime_version="$(awk -F '"' '/^const pluginVersion = / { print $2; exit }' "${source_dir}/src/index.ts")"
-if [[ -z "${package_version}" || "${package_version}" != "${manifest_version}" || "${package_version}" != "${runtime_version}" ]]; then
-  echo "attn-opencode version mismatch: package=${package_version:-missing} manifest=${manifest_version:-missing} runtime=${runtime_version:-missing}" >&2
-  exit 1
-fi
+stage_plugin() {
+  local name="$1" description="$2"
+  local source_dir="${repo_root}/plugins/${name}"
+  local stage_dir="${stage_root}/${name}"
 
-rm -rf "${stage_dir}"
-mkdir -p "${stage_dir}/bin"
-bun build "${source_dir}/src/index.ts" --compile --minify --outfile "${stage_dir}/bin/attn-opencode"
-chmod 0755 "${stage_dir}/bin/attn-opencode"
-bun build "${source_dir}/src/guidance-plugin.ts" --target=bun --format=esm --minify --outfile "${stage_dir}/guidance-plugin.js"
-cp "${source_dir}/README.md" "${stage_dir}/README.md"
-cat >"${stage_dir}/attn-plugin.toml" <<EOF
-name = "attn-opencode"
+  local package_version manifest_version runtime_version
+  package_version="$(cd "${source_dir}" && bun -e 'console.log(require("./package.json").version)')"
+  manifest_version="$(awk -F '"' '/^version = / { print $2; exit }' "${source_dir}/attn-plugin.toml")"
+  runtime_version="$(awk -F '"' '/^const pluginVersion = / { print $2; exit }' "${source_dir}/src/index.ts")"
+  if [[ -z "${package_version}" || "${package_version}" != "${manifest_version}" || "${package_version}" != "${runtime_version}" ]]; then
+    echo "${name} version mismatch: package=${package_version:-missing} manifest=${manifest_version:-missing} runtime=${runtime_version:-missing}" >&2
+    exit 1
+  fi
+
+  rm -rf "${stage_dir}"
+  mkdir -p "${stage_dir}/bin"
+  bun build "${source_dir}/src/index.ts" --compile --minify --outfile "${stage_dir}/bin/${name}"
+  chmod 0755 "${stage_dir}/bin/${name}"
+  if [[ "${name}" == "attn-opencode" ]]; then
+    bun build "${source_dir}/src/guidance-plugin.ts" --target=bun --format=esm --minify --outfile "${stage_dir}/guidance-plugin.js"
+  fi
+  cp "${source_dir}/README.md" "${stage_dir}/README.md"
+  cat >"${stage_dir}/attn-plugin.toml" <<EOF
+name = "${name}"
 version = "${package_version}"
 attn_api_version = 4
-description = "Server-backed OpenCode driver for attn"
+description = "${description}"
 
 [plugin]
 kind = "executable"
-path = "bin/attn-opencode"
+path = "bin/${name}"
 EOF
 
-echo "Staged bundled attn-opencode ${package_version} at ${stage_dir}"
+  echo "Staged bundled ${name} ${package_version} at ${stage_dir}"
+}
+
+stage_plugin attn-opencode "Server-backed OpenCode driver for attn"
+stage_plugin attn-pi "pi driver for attn"

--- a/scripts/source-fingerprint.sh
+++ b/scripts/source-fingerprint.sh
@@ -68,6 +68,8 @@ should_exclude_path() {
   case "${relative_path}" in
     plugins/attn-opencode/src/*) return 1 ;;
     plugins/attn-opencode/package.json|plugins/attn-opencode/bun.lock|plugins/attn-opencode/attn-plugin.toml|plugins/attn-opencode/README.md) return 1 ;;
+    plugins/attn-pi/src/*) return 1 ;;
+    plugins/attn-pi/package.json|plugins/attn-pi/bun.lock|plugins/attn-pi/attn-plugin.toml|plugins/attn-pi/README.md) return 1 ;;
     scripts/build-app-profile.sh|scripts/build-bundled-plugins.sh) return 1 ;;
     app/scripts/real-app-harness/*) return 0 ;;
     app/scripts/*)                  return 0 ;;


### PR DESCRIPTION
Rock 1 of `docs/vision/pi-attn-plugins.md`: pi launches, resumes, and lives as an attn session via a new bundled driver plugin, `plugins/attn-pi`.

## What

- **Pure driver, dumb state** (aligned with Victor): no `state_reporting`, no screen-scraping. Sessions ride the daemon's existing no-state path — created in `working`, `idle` on PTY child exit. Declared state arrives with the pi-side suite (rock 2).
- **Capabilities:** `resume`, `initial_prompt`, `model_pin` (`--model`, a fuzzy pattern per pi), `effort_pin` (`--thinking`, attn effort names are valid pi levels).
- **Version gate:** floor at pi 0.80.10 (the grounded version); resume refuses to run on an older pi than the session last used.
- **Resume token:** `PiMetadata {schema, pi_session_id, pi_version, model?, thinking?}` persisted daemon-side via `session.report_metadata`, handed back verbatim on `driver.resume`. The driver mints the pi session id at spawn (`--session-id` creates-if-missing).
- **Bundling:** `scripts/build-bundled-plugins.sh` refactored to a `stage_plugin` function staging both attn-opencode and attn-pi; attn-pi sources added to `scripts/source-fingerprint.sh` includes.
- No frontend changes needed: `driver.register` broadcasts settings, which publish `pi_available` + capability keys; the picker parses any `<agent>_available` key dynamically.

Also carries the phase-1 grounding docs (`docs/grounding/pi-plugins.md`, `plugins/attn-pi/AGENTS.md`) and the plan (`docs/plans/2026-07-19-pi-driver-plugin.md`).

## Testing

- `bun test` in `plugins/attn-pi`: 13/13 green (argv mapping, version floor, downgrade refusal, metadata validation, resume semantics).
- **Live verification** on throwaway profile `pismoke` (daemon built from this branch, headless over the daemon WS): smoke spike first (pi TUI under the worker PTY, resize re-flow, `--session-id` create+resume round-trip, pins, clean ctrl+d exit); then the full plugin path — `attn plugin install-bundled attn-pi` → driver registered (agent=pi) → spawn with effort pin → `working` + PiMetadata persisted → real turn → ctrl+d → `idle` → re-spawn same session id → `driver.resume` restored history with pins re-applied.

## Deferred (rock 2+)

State declaration, pi-side attn suite, delegation targets, safety envelope, kitty-graphics replay fidelity.